### PR TITLE
Add support for Flatpak

### DIFF
--- a/bin/omarchy-flatpak-pkg-install
+++ b/bin/omarchy-flatpak-pkg-install
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Check if flatpak is installed, install it with yay if not
+if ! command -v flatpak &>/dev/null; then
+  echo "Flatpak is not installed. Installing it with yay..."
+  yay -S flatpak
+  echo "Flatpak installed. A restart is required to continue. Please restart your system and run the script again."
+  exit 0
+fi
+
+fzf_args=(
+  --multi
+  --preview 'echo "alt-p: toggle description, alt-j/k: scroll, F11: maximize"; echo; flatpak remote-info flathub {2}'
+  --preview-window 'down:65%:wrap'
+  --bind 'alt-p:toggle-preview'
+  --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
+  --bind 'alt-k:preview-up,alt-j:preview-down'
+)
+
+installed_apps=$(flatpak list --columns=application)
+declare -A installed_map
+while IFS= read -r app; do
+  [[ -n "$app" ]] && installed_map["$app"]=1
+done <<<"$installed_apps"
+
+pkg_data=$(flatpak remote-ls flathub --columns=application,name)
+
+pkg_list=$(while IFS=$'\t' read -r app name; do
+  if [[ ${installed_map[$app]} ]]; then
+    printf "[Installed] %s\t%s\n" "$name" "$app"
+  else
+    printf "%s\t%s\n" "$name" "$app"
+  fi
+done <<<"$pkg_data")
+
+selected=$(echo "$pkg_list" | fzf "${fzf_args[@]}" --with-nth=1 --delimiter=$'\t')
+
+if [[ -n "$selected" ]]; then
+  pkg_name=$(echo "$selected" | cut -f2)
+
+  # Check if the selected app is installed
+  if [[ ${installed_map[$pkg_name]} ]]; then
+    echo "Uninstalling $pkg_name..."
+    flatpak uninstall -y "$pkg_name"
+  else
+    echo "Installing $pkg_name..."
+    flatpak install -y flathub "$pkg_name"
+  fi
+
+  sudo updatedb
+  omarchy-show-done
+fi

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -171,7 +171,7 @@ show_setup_config_menu() {
 }
 
 show_install_menu() {
-  case $(menu "Install" "󰣇  Package\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming") in
+  case $(menu "Install" "󰣇  Package\n  Web App\n  Service\n  Style\n󰵮  Development\n  Editor\n󱚤  AI\n  Gaming\n  Flatpak") in
   *Package*) terminal omarchy-pkg-install ;;
   *Web*) present_terminal omarchy-webapp-install ;;
   *Service*) show_install_service_menu ;;
@@ -180,6 +180,7 @@ show_install_menu() {
   *Editor*) show_install_editor_menu ;;
   *AI*) show_install_ai_menu ;;
   *Gaming*) show_install_gaming_menu ;;
+  *Flatpak*) terminal omarchy-flatpak-pkg-install ;;
   *) show_main_menu ;;
   esac
 }


### PR DESCRIPTION
Hi,

Similar to the yay install pkg script, this PR adds Flatpak installation. 

- Shows apps from Flathub with [Installed] markers and app names.
- Includes preview info via `flatpak remote-info` and supports multi-selection.

If the user selects an entry, it installs it; if the program is already installed, the script removes it.

<img width="914" height="764" alt="Capture d’écran 2025-08-17 à 14 04 12" src="https://github.com/user-attachments/assets/9819063e-f1fd-4c85-befa-958f522f2a97" />

Add a package :

https://youtu.be/y40xe7gV-QY

Remove a package : 

https://youtu.be/U5aEv2PXuTc
