### PR TITLE
Add auto-changing colors for Neovim

### DIFF
--- a/config/nvim/lua/plugins/all-themes.lua
+++ b/config/nvim/lua/plugins/all-themes.lua
@@ -1,0 +1,56 @@
+return {
+	-- Load all theme plugins but don't apply them
+	-- This ensures all colorschemes are available for hot-reloading
+	{
+		"ribru17/bamboo.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"catppuccin/nvim",
+		name = "catppuccin",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"sainnhe/everforest",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"ellisonleao/gruvbox.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"rebelot/kanagawa.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"tahayvr/matteblack.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"loctvl842/monokai-pro.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"shaunsingh/nord.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"rose-pine/neovim",
+		name = "rose-pine",
+		lazy = true,
+		priority = 1000,
+	},
+	{
+		"folke/tokyonight.nvim",
+		lazy = true,
+		priority = 1000,
+	},
+}

--- a/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
+++ b/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
@@ -5,24 +5,36 @@ return {
 		lazy = false,
 		priority = 1000,
 		config = function()
-			-- Listen to Lazy's reload event to apply the new colorscheme
-			vim.api.nvim_create_autocmd("User", {
-				pattern = "LazyReload",
-				callback = function()
-					package.loaded["plugins.theme"] = nil
+			local function reload_theme()
+				-- Clear the module cache
+				package.loaded["plugins.theme"] = nil
 
-					local ok, theme_spec = pcall(require, "plugins.theme")
-					if ok and theme_spec then
-						for _, spec in ipairs(theme_spec) do
-							if spec[1] == "LazyVim/LazyVim" and spec.opts and spec.opts.colorscheme then
-								vim.schedule(function()
-									require("lazy.core.loader").colorscheme(spec.opts.colorscheme)
-								end)
-								break
-							end
+				local ok, theme_spec = pcall(require, "plugins.theme")
+				if ok and theme_spec then
+					for _, spec in ipairs(theme_spec) do
+						if spec[1] == "LazyVim/LazyVim" and spec.opts and spec.opts.colorscheme then
+							local colorscheme = spec.opts.colorscheme
+
+							vim.schedule(function()
+								pcall(vim.cmd, "colorscheme " .. colorscheme)
+								vim.notify("Theme reloaded: " .. colorscheme, vim.log.levels.INFO)
+
+								-- Reapply transparency if it exists
+								local transparency_file = vim.fn.stdpath("config") .. "/plugin/after/transparency.lua"
+								if vim.fn.filereadable(transparency_file) == 1 then
+									vim.cmd("source " .. transparency_file)
+								end
+							end)
+							break
 						end
 					end
-				end,
+				end
+			end
+
+			-- Listen to Lazy's reload event
+			vim.api.nvim_create_autocmd("User", {
+				pattern = "LazyReload",
+				callback = reload_theme,
 			})
 		end,
 	},

--- a/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
+++ b/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
@@ -1,40 +1,38 @@
 return {
 	{
-		name = "omarchy-theme-hotreload",
+		name = "theme-hotreload",
 		dir = vim.fn.stdpath("config"),
 		lazy = false,
 		priority = 1000,
 		config = function()
-			local function reload_theme()
-				-- Clear the module cache
-				package.loaded["plugins.theme"] = nil
-
-				local ok, theme_spec = pcall(require, "plugins.theme")
-				if ok and theme_spec then
-					for _, spec in ipairs(theme_spec) do
-						if spec[1] == "LazyVim/LazyVim" and spec.opts and spec.opts.colorscheme then
-							local colorscheme = spec.opts.colorscheme
-
-							vim.schedule(function()
-								pcall(vim.cmd, "colorscheme " .. colorscheme)
-								vim.notify("Theme reloaded: " .. colorscheme, vim.log.levels.INFO)
-
-								-- Reapply transparency if it exists
-								local transparency_file = vim.fn.stdpath("config") .. "/plugin/after/transparency.lua"
-								if vim.fn.filereadable(transparency_file) == 1 then
-									vim.cmd("source " .. transparency_file)
-								end
-							end)
-							break
-						end
-					end
-				end
-			end
-
-			-- Listen to Lazy's reload event
 			vim.api.nvim_create_autocmd("User", {
 				pattern = "LazyReload",
-				callback = reload_theme,
+				callback = function()
+					-- Clear the theme module cache
+					package.loaded["plugins.theme"] = nil
+
+					local ok, theme_spec = pcall(require, "plugins.theme")
+					if ok and theme_spec then
+						for _, spec in ipairs(theme_spec) do
+							if spec[1] == "LazyVim/LazyVim" and spec.opts and spec.opts.colorscheme then
+								local colorscheme = spec.opts.colorscheme
+								-- Defer to next tick to escape the autocmd context
+								vim.defer_fn(function()
+									require("lazy.core.loader").colorscheme(colorscheme)
+
+									pcall(vim.cmd.colorscheme, colorscheme)
+
+									local transparency_file = vim.fn.stdpath("config")
+										.. "/plugin/after/transparency.lua"
+									if vim.fn.filereadable(transparency_file) == 1 then
+										vim.cmd.source(transparency_file)
+									end
+								end, 0)
+								break
+							end
+						end
+					end
+				end,
 			})
 		end,
 	},

--- a/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
+++ b/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
@@ -1,0 +1,29 @@
+return {
+	{
+		name = "omarchy-theme-hotreload",
+		dir = vim.fn.stdpath("config"),
+		lazy = false,
+		priority = 1000,
+		config = function()
+			-- Listen to Lazy's reload event to apply the new colorscheme
+			vim.api.nvim_create_autocmd("User", {
+				pattern = "LazyReload",
+				callback = function()
+					package.loaded["plugins.theme"] = nil
+
+					local ok, theme_spec = pcall(require, "plugins.theme")
+					if ok and theme_spec then
+						for _, spec in ipairs(theme_spec) do
+							if spec[1] == "LazyVim/LazyVim" and spec.opts and spec.opts.colorscheme then
+								vim.schedule(function()
+									require("lazy.core.loader").colorscheme(spec.opts.colorscheme)
+								end)
+								break
+							end
+						end
+					end
+				end,
+			})
+		end,
+	},
+}

--- a/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
+++ b/config/nvim/lua/plugins/omarchy-theme-hotreload.lua
@@ -5,44 +5,39 @@ return {
 		lazy = false,
 		priority = 1000,
 		config = function()
-			-- Cache the transparency file path
 			local transparency_file = vim.fn.stdpath("config") .. "/plugin/after/transparency.lua"
-			local has_transparency = vim.fn.filereadable(transparency_file) == 1
 
 			vim.api.nvim_create_autocmd("User", {
 				pattern = "LazyReload",
 				callback = function()
 					package.loaded["plugins.theme"] = nil
 
-					local ok, theme_spec = pcall(require, "plugins.theme")
-					if ok and theme_spec then
+					vim.schedule(function()
+						local ok, theme_spec = pcall(require, "plugins.theme")
+						if not ok then
+							return
+						end
+
 						for _, spec in ipairs(theme_spec) do
 							if spec[1] == "LazyVim/LazyVim" and spec.opts and spec.opts.colorscheme then
 								local colorscheme = spec.opts.colorscheme
 
+								require("lazy.core.loader").colorscheme(colorscheme)
+
 								vim.defer_fn(function()
-									local colorscheme_available =
-										vim.tbl_contains(vim.fn.getcompletion("", "color"), colorscheme)
+									pcall(vim.cmd.colorscheme, colorscheme)
 
-									if not colorscheme_available then
-										require("lazy.core.loader").colorscheme(colorscheme)
+									if vim.fn.filereadable(transparency_file) == 1 then
+										vim.defer_fn(function()
+											vim.cmd.source(transparency_file)
+										end, 5)
 									end
-
-									local success = pcall(vim.cmd.colorscheme, colorscheme)
-
-									if success then
-										if has_transparency then
-											vim.defer_fn(function()
-												vim.cmd.source(transparency_file)
-											end, 1)
-										end
-									end
-								end, 0)
+								end, 5)
 
 								break
 							end
 						end
-					end
+					end)
 				end,
 			})
 		end,

--- a/config/nvim/lua/plugins/theme.lua
+++ b/config/nvim/lua/plugins/theme.lua
@@ -1,8 +1,0 @@
-return {
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "tokyonight",
-		},
-	},
-}

--- a/migrations/1758081785.sh
+++ b/migrations/1758081785.sh
@@ -1,0 +1,4 @@
+echo "Add live themeing to neovim"
+
+cp -f $OMARCHY_PATH/config/nvim/lua/plugins/all-themes.lua ~/.config/nvim/lua/plugins/
+cp -f $OMARCHY_PATH/config/nvim/lua/plugins/omarchy-theme-hotreload.lua ~/.config/nvim/lua/plugins/

--- a/themes/catppuccin-latte/neovim.lua
+++ b/themes/catppuccin-latte/neovim.lua
@@ -3,12 +3,9 @@ return {
 		"catppuccin/nvim",
 		name = "catppuccin",
 		priority = 1000,
-		config = function()
-			require("catppuccin").setup({
-				flavour = "latte", -- other options: "mocha", "frappe", "macchiato"
-			})
-			vim.cmd.colorscheme("catppuccin-latte")
-		end,
+		opts = {
+			flavour = "latte",
+		},
 	},
 	{
 		"LazyVim/LazyVim",

--- a/themes/catppuccin/neovim.lua
+++ b/themes/catppuccin/neovim.lua
@@ -1,5 +1,10 @@
 return {
 	{
+		"catppuccin/nvim",
+		name = "catppuccin",
+		priority = 1000,
+	},
+	{
 		"LazyVim/LazyVim",
 		opts = {
 			colorscheme = "catppuccin",

--- a/themes/osaka-jade/neovim.lua
+++ b/themes/osaka-jade/neovim.lua
@@ -1,9 +1,13 @@
 return {
-	"ribru17/bamboo.nvim",
-	lazy = false,
-	priority = 1000,
-	config = function()
-		require("bamboo").setup({})
-		require("bamboo").load()
-	end,
+	{
+		"ribru17/bamboo.nvim",
+		priority = 1000,
+		opts = {},
+	},
+	{
+		"LazyVim/LazyVim",
+		opts = {
+			colorscheme = "bamboo",
+		},
+	},
 }

--- a/themes/ristretto/neovim.lua
+++ b/themes/ristretto/neovim.lua
@@ -1,31 +1,14 @@
 return {
-  {
-    "gthelding/monokai-pro.nvim",
-    config = function()
-      require("monokai-pro").setup({
-        filter = "ristretto",
-        override = function()
-          return {
-            NonText = { fg = "#948a8b" },
-            MiniIconsGrey = { fg = "#948a8b" },
-	    MiniIconsRed = { fg = "#fd6883" },
-	    MiniIconsBlue = { fg = "#85dacc" },
-	    MiniIconsGreen = { fg = "#adda78" },
-	    MiniIconsYellow = { fg = "#f9cc6c" },
-	    MiniIconsOrange = { fg = "#f38d70" },
-	    MiniIconsPurple = { fg = "#a8a9eb" },
-	    MiniIconsAzure = { fg = "#a8a9eb" },
-	    MiniIconsCyan = { fg = "#85dacc" }, -- same value as MiniIconsBlue for consistency
-          }
-        end,
-      })
-      vim.cmd([[colorscheme monokai-pro]])
-    end,
-  },
-  {
-    "LazyVim/LazyVim",
-    opts = {
-      colorscheme = "monokai-pro",
-    },
-  },
+	{
+		"loctvl842/monokai-pro.nvim",
+		opts = {
+			filter = "ristretto",
+		},
+	},
+	{
+		"LazyVim/LazyVim",
+		opts = {
+			colorscheme = "monokai-pro",
+		},
+	},
 }

--- a/themes/tokyo-night/neovim.lua
+++ b/themes/tokyo-night/neovim.lua
@@ -6,7 +6,7 @@ return {
 	{
 		"LazyVim/LazyVim",
 		opts = {
-			colorscheme = "tokyonight",
+			colorscheme = "tokyonight-night",
 		},
 	},
 }

--- a/themes/tokyo-night/neovim.lua
+++ b/themes/tokyo-night/neovim.lua
@@ -1,5 +1,9 @@
 return {
 	{
+		"folke/tokyonight.nvim",
+		priority = 1000,
+	},
+	{
 		"LazyVim/LazyVim",
 		opts = {
 			colorscheme = "tokyonight",


### PR DESCRIPTION
Very MVP oriented approach to changing colors in Neovim.

This taps into the auto-config reload capabilities of Lazy and just utilizes a simple `colorscheme` command to allow Lazy to do the work since it automatically lazy-loads colorschemes.

Because we're registering all of the themes in `all-themes.lua` so that they're installed, we technically could remove them from the individual theme files. I didn't in the event we decide to pivot this approach at all.

The other key thing is that this requires us to effectively prevent any themes that become a part of main line from using any config functions like Catppuccin and Ristretto were using before this change. If we all those to happen, this gets far more complex clearing out highlights and other remnants of shit. -- Not worth it.