### PR TITLE
Swiss keyboard layout patch

### DIFF
--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -2,6 +2,7 @@
 conf="/etc/vconsole.conf"
 hyprconf="$HOME/.config/hypr/input.conf"
 
+#TODO add check for underscores in the layout from arch and set the hypr configs accordingly
 if grep -q '^XKBLAYOUT=' "$conf"; then
   layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
   sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"

--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -17,10 +17,6 @@ if grep -q '^KEYMAP=' "$conf"; then
     layout="ch"
     variant="fr"
     ;;
-  it_CH*)
-    layout="ch"
-    variant="it"
-    ;;
   *)
     layout="$keymap"
     ;;

--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -2,13 +2,35 @@
 conf="/etc/vconsole.conf"
 hyprconf="$HOME/.config/hypr/input.conf"
 
-#TODO add check for underscores in the layout from arch and set the hypr configs accordingly
-if grep -q '^XKBLAYOUT=' "$conf"; then
-  layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"
-fi
+if grep -q '^KEYMAP=' "$conf"; then
+  keymap=$(grep '^KEYMAP=' "$conf" | cut -d= -f2 | tr -d '"')
 
-if grep -q '^XKBVARIANT=' "$conf"; then
-  variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\  kb_variant = $variant" "$hyprconf"
+  layout=""
+  variant=""
+
+  case "$keymap" in
+  de_CH*)
+    layout="ch"
+    variant="de"
+    ;;
+  fr_CH*)
+    layout="ch"
+    variant="fr"
+    ;;
+  it_CH*)
+    layout="ch"
+    variant="it"
+    ;;
+  *)
+    layout="$keymap"
+    ;;
+  esac
+
+  # Write to hypr config
+  if [[ -n "$layout" ]]; then
+    sed -i "/^[[:space:]]*kb_options *=/i\  kb_layout = $layout" "$hyprconf"
+  fi
+  if [[ -n "$variant" ]]; then
+    sed -i "/^[[:space:]]*kb_options *=/i\  kb_variant = $variant" "$hyprconf"
+  fi
 fi


### PR DESCRIPTION
Patch to support the Swiss keyboard layouts in hyprland config. Unfortunately the format of the layout coming from arch (linux in general) for Swiss keyboard is ugly.

I'm not the best with bash and I am absolutely not an expert with hypr so every suggestion is more than welcome.
