### PR TITLE
Change default shutdown timeout to 5sec

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -14,6 +14,7 @@ run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
+run_logged $OMARCHY_INSTALL/config/fast-shutdown.sh
 run_logged $OMARCHY_INSTALL/config/sudoless-asdcontrol.sh
 run_logged $OMARCHY_INSTALL/config/hardware/network.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh

--- a/install/config/fast-shutdown.sh
+++ b/install/config/fast-shutdown.sh
@@ -1,0 +1,7 @@
+sudo mkdir -p /etc/systemd/system.conf.d
+
+cat <<EOF | sudo tee /etc/systemd/system.conf.d/10-faster-shutdown.conf
+[Manager]
+DefaultTimeoutStopSec=10s
+EOF
+sudo systemctl daemon-reload

--- a/install/config/fast-shutdown.sh
+++ b/install/config/fast-shutdown.sh
@@ -2,6 +2,6 @@ sudo mkdir -p /etc/systemd/system.conf.d
 
 cat <<EOF | sudo tee /etc/systemd/system.conf.d/10-faster-shutdown.conf
 [Manager]
-DefaultTimeoutStopSec=10s
+DefaultTimeoutStopSec=5s
 EOF
 sudo systemctl daemon-reload

--- a/migrations/1758564460_enable_fast_shutdown.sh
+++ b/migrations/1758564460_enable_fast_shutdown.sh
@@ -1,0 +1,2 @@
+echo "Enable fast shutdown"
+source $OMARCHY_PATH/install/config/fast-shutdown.sh 


### PR DESCRIPTION
The default shutdown timeout is 90sec which occasionally results in hanging on the shutdown screen with "A stop job is running for session 1 {user}: (xx / 1min 30sec)"

This reduces the max timeout to 5s before hard shutdown happens and anything left open is killed.

From some digging, it seems that Steam tends to cause this hang but others certainly can as well which is why we don't see it consistently.