### PR TITLE
feat: add WirePlumber config for automatic Bluetooth audio switching

### DIFF
--- a/config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf
+++ b/config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf
@@ -1,0 +1,36 @@
+# Automatically switch to Bluetooth audio devices when connected
+# This configuration ensures Bluetooth audio devices become the default
+# audio sink/source when they connect
+
+monitor.bluez.rules = [
+  {
+    # Bluetooth output devices (headphones/speakers)
+    matches = [
+      {
+        device.api = "bluez5"
+        media.class = "Audio/Sink"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.session = 2000   # Higher priority than internal audio (1000)
+        priority.driver  = 2000
+      }
+    }
+  }
+  {
+    # Bluetooth input devices (microphones)
+    matches = [
+      {
+        device.api = "bluez5"
+        media.class = "Audio/Source"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.session = 2000   # Higher priority than internal mic
+        priority.driver  = 2000
+      }
+    }
+  }
+]

--- a/migrations/1759159162.sh
+++ b/migrations/1759159162.sh
@@ -3,17 +3,9 @@ echo "Enable automatic Bluetooth audio device switching"
 # Ensure WirePlumber is installed
 omarchy-pkg-add wireplumber
 
-# Create config directory if it doesn't exist
+# Copy over bluetooth switch config
 mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+cp $OMARCHY_PATH/config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf ~/.config/wireplumber/wireplumber.conf.d/
 
-# Only install if not already present (don't overwrite user modifications)
-if [[ ! -f ~/.config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf ]]; then
-  cp ~/.local/share/omarchy/config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf \
-     ~/.config/wireplumber/wireplumber.conf.d/
-
-  echo "  → Bluetooth auto-switch config installed"
-  echo "  → Restarting WirePlumber..."
-  systemctl --user restart wireplumber
-else
-  echo "  → Config already exists, skipping"
-fi
+# Restart to pickup new config
+systemctl --user restart wireplumber

--- a/migrations/1759159162.sh
+++ b/migrations/1759159162.sh
@@ -1,0 +1,19 @@
+echo "Enable automatic Bluetooth audio device switching"
+
+# Ensure WirePlumber is installed
+omarchy-pkg-add wireplumber
+
+# Create config directory if it doesn't exist
+mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+
+# Only install if not already present (don't overwrite user modifications)
+if [[ ! -f ~/.config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf ]]; then
+  cp ~/.local/share/omarchy/config/wireplumber/wireplumber.conf.d/51-bluetooth-autoswitch.conf \
+     ~/.config/wireplumber/wireplumber.conf.d/
+
+  echo "  → Bluetooth auto-switch config installed"
+  echo "  → Restarting WirePlumber..."
+  systemctl --user restart wireplumber
+else
+  echo "  → Config already exists, skipping"
+fi


### PR DESCRIPTION
**The problem:**

On a fresh Omarchy install, when a Bluetooth audio device connects, it does not automatically become the active audio sink. The user must manually open a tool like `wiremix` and select the device to route audio to it.

This behavior seems to be caused by WirePlumber storing user preferences (`~/.local/state/wireplumber/default-nodes`), which can override the default device priorities on reconnection.

**The solution:**

This PR makes the auto-switch behavior explicit and reliable by adding a WirePlumber configuration that gives newly connected Bluetooth devices a higher priority (2000) than the default for internal audio (1000).

**The result:**

With this change, any newly connected Bluetooth headset will immediately and automatically become the default input/output device. This provides a seamless "it just works" experience, consistent with the Omarchy philosophy, regardless of stored preferences or specific hardware.

---

(description edited for clarity - thx @iamobservable and @cluah)