### PR TITLE
Keyboard brightness multimedia keys support

### DIFF
--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -23,3 +23,8 @@ bindld = , XF86AudioPrev, Previous track, exec, $osdclient --playerctl previous
 
 # Switch audio output with Super + Mute
 bindld = SUPER, XF86AudioMute, Switch audio output, exec, omarchy-cmd-audio-switch
+
+#Laptop multimedia keys for keyboard brightness (with OSD)
+$keysswayosd = $osdclient --custom-progress=$(awk "BEGIN {print $(brightnessctl --device=apple::kbd_backlight get)/255}") --custom-icon=input-keyboard
+bindeld = ,XF86KbdBrightnessDown, Keyboard Brightness down, exec, brightnessctl --device=apple::kbd_backlight set 10%- && $keysswayosd
+bindeld = ,XF86KbdBrightnessUp, Keyboard Brightness up, exec, brightnessctl --device=apple::kbd_backlight set +10% && $keysswayosd

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -28,3 +28,7 @@ bindld = SUPER, XF86AudioMute, Switch audio output, exec, omarchy-cmd-audio-swit
 $keysswayosd = $osdclient --custom-progress=$(awk "BEGIN {print $(brightnessctl --device=apple::kbd_backlight get)/255}") --custom-icon=input-keyboard
 bindeld = ,XF86KbdBrightnessDown, Keyboard Brightness down, exec, brightnessctl --device=apple::kbd_backlight set 10%- && $keysswayosd
 bindeld = ,XF86KbdBrightnessUp, Keyboard Brightness up, exec, brightnessctl --device=apple::kbd_backlight set +10% && $keysswayosd
+
+# Precise 1% multimedia adjustments with Alt modifier
+bindeld = ALT, XF86KbdBrightnessDown, Keyboard Brightness down precise, exec, brightnessctl --device=apple::kbd_backlight set 1%- && $keysswayosd
+bindeld = ALT, XF86KbdBrightnessUp, Keyboard Brightness up precise, exec, brightnessctl --device=apple::kbd_backlight set +1% && $keysswayosd


### PR DESCRIPTION
I use a 2019 macbook air and the keyboard keys for backlight do not work out of the box. Made a issues post and a discussion on it and got some feedback.
Adding my commit to the default media.conf could help with the out of the box experience.

## Possible Issues:
my keyboard uses apple::kbd_backlight call. I have seen another person have a smc::kbd_backlight call. We could make the vendor into a variable and pass into it, but I do not know how to call it.

## References:
[#2291](https://github.com/basecamp/omarchy/issues/2291)
https://github.com/basecamp/omarchy/pull/1779
