### PR TITLE
Fix Omarchy Screenrecord

### DIFF
--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -69,16 +69,21 @@ start_screenrecording() {
 stop_screenrecording() {
   pkill -SIGINT -f "gpu-screen-recorder"  # SIGINT required to save video properly
 
+  # Wait a maximum of 5 seconds to finish before hard killing
   local count=0
   while pgrep -f "gpu-screen-recorder" >/dev/null && [ $count -lt 50 ]; do
     sleep 0.1
     count=$((count + 1))
   done
 
-  pgrep -f "gpu-screen-recorder" >/dev/null && pkill -9 -f "gpu-screen-recorder"
-  cleanup_webcam
-
-  notify-send "Screen recording saved to $OUTPUT_DIR" -t 2000
+  if pgrep -f "gpu-screen-recorder" >/dev/null; then
+    pkill -9 -f "gpu-screen-recorder"
+    cleanup_webcam
+    notify-send "Screen recording error" "Recording process had to be force-killed. Video may be corrupted." -u critical -t 5000
+  else
+    cleanup_webcam
+    notify-send "Screen recording saved to $OUTPUT_DIR" -t 2000
+  fi
   toggle_screenrecording_indicator
 }
 

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -8,31 +8,63 @@ if [[ ! -d "$OUTPUT_DIR" ]]; then
   exit 1
 fi
 
-# Selects region or output
-SCOPE="$1"
+SCOPE=""
+AUDIO="false"
+WEBCAM="false"
 
-# Selects audio inclusion or not
-AUDIO=$([[ $2 == "audio" ]] && echo "--audio")
+for arg in "$@"; do
+  case "$arg" in
+    --with-audio) AUDIO="true" ;;
+    --with-webcam) WEBCAM="true" ;;
+    output|region) SCOPE="$arg" ;;
+  esac
+done
+
+cleanup_webcam() {
+  pkill -f "WebcamOverlay" 2>/dev/null
+}
+
+start_webcam_overlay() {
+  cleanup_webcam
+
+  local scale=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .scale')
+  local width=$(awk "BEGIN {printf \"%.0f\", 360 * $scale}")
+  local height=$(awk "BEGIN {printf \"%.0f\", 203 * $scale}")
+
+  ffplay -f v4l2 -framerate 30 /dev/video0 \
+    -vf "scale=${width}:${height}" \
+    -window_title "WebcamOverlay" \
+    -noborder \
+    -fflags nobuffer -flags low_delay \
+    -probesize 32 -analyzeduration 0 \
+    -loglevel quiet &
+  sleep 1
+}
 
 start_screenrecording() {
   local filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
+  local audio_args=""
 
-  if lspci | grep -qi 'nvidia'; then
-    wf-recorder $AUDIO -f "$filename" -c libx264 -p crf=23 -p preset=medium -p movflags=+faststart "$@" &
-  else
-    wl-screenrec $AUDIO -f "$filename" --ffmpeg-encoder-options="-c:v libx264 -crf 23 -preset medium -movflags +faststart" "$@" &
-  fi
+  # Merge audio tracks into one - separate tracks only play one at a time in most players
+  [[ "$AUDIO" == "true" ]] && audio_args="-a default_output|default_input"
 
+  gpu-screen-recorder -w "$@" -f 60 -c mp4 -o "$filename" $audio_args &
   toggle_screenrecording_indicator
 }
 
 stop_screenrecording() {
-  pkill -x wl-screenrec
-  pkill -x wf-recorder
+  pkill -SIGINT -f "gpu-screen-recorder"  # SIGINT required to save video properly
+
+  local count=0
+  while pgrep -f "gpu-screen-recorder" >/dev/null && [ $count -lt 50 ]; do
+    sleep 0.1
+    count=$((count + 1))
+  done
+
+  pgrep -f "gpu-screen-recorder" >/dev/null && pkill -9 -f "gpu-screen-recorder"
+  cleanup_webcam
 
   notify-send "Screen recording saved to $OUTPUT_DIR" -t 2000
-
-  sleep 0.2 # ensures the process is actually dead before we check
   toggle_screenrecording_indicator
 }
 
@@ -41,15 +73,51 @@ toggle_screenrecording_indicator() {
 }
 
 screenrecording_active() {
-  pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null
+  pgrep -f "gpu-screen-recorder" >/dev/null || pgrep -x slurp >/dev/null || pgrep -f "WebcamOverlay" >/dev/null
 }
 
 if screenrecording_active; then
-  stop_screenrecording
+  if pgrep -x slurp >/dev/null; then
+    pkill -x slurp 2>/dev/null
+  elif pgrep -f "WebcamOverlay" >/dev/null && ! pgrep -f "gpu-screen-recorder" >/dev/null; then
+    cleanup_webcam
+  else
+    stop_screenrecording
+  fi
 elif [[ "$SCOPE" == "output" ]]; then
-  output=$(slurp -o) || exit 1
-  start_screenrecording -g "$output"
+  [[ "$WEBCAM" == "true" ]] && start_webcam_overlay
+
+  if ! output=$(slurp -o -f "%o"); then
+    [[ "$WEBCAM" == "true" ]] && cleanup_webcam
+    exit 1
+  fi
+
+  if [[ -z "$output" ]]; then
+    notify-send "Error" "Could not detect monitor" -u critical
+    [[ "$WEBCAM" == "true" ]] && cleanup_webcam
+    exit 1
+  fi
+
+  start_screenrecording "$output"
 else
-  region=$(slurp) || exit 1
-  start_screenrecording -g "$region"
+  [[ "$WEBCAM" == "true" ]] && start_webcam_overlay
+
+  scale=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .scale')
+
+  if ! region=$(slurp -f "%wx%h+%x+%y"); then
+    [[ "$WEBCAM" == "true" ]] && cleanup_webcam
+    exit 1
+  fi
+
+  if [[ "$region" =~ ^([0-9]+)x([0-9]+)\+([0-9]+)\+([0-9]+)$ ]]; then
+    w=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[1]} * $scale}")
+    h=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[2]} * $scale}")
+    x=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[3]} * $scale}")
+    y=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[4]} * $scale}")
+    scaled_region="${w}x${h}+${x}+${y}"
+  else
+    scaled_region="$region"
+  fi
+
+  start_screenrecording region -region "$scaled_region"
 fi

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -33,8 +33,19 @@ start_webcam_overlay() {
   # Target width (base 360px, scaled to monitor)
   local target_width=$(awk "BEGIN {printf \"%.0f\", 360 * $scale}")
 
-  # Scale maintaining aspect ratio (-1 means auto-calculate to maintain ratio)
-  ffplay -f v4l2 -framerate 30 /dev/video0 \
+  # Try preferred 16:9 resolutions in order, use first available
+  local preferred_resolutions=("640x360" "1280x720" "1920x1080")
+  local video_size_arg=""
+  local available_formats=$(v4l2-ctl --list-formats-ext -d /dev/video0 2>/dev/null)
+
+  for resolution in "${preferred_resolutions[@]}"; do
+    if echo "$available_formats" | grep -q "$resolution"; then
+      video_size_arg="-video_size $resolution"
+      break
+    fi
+  done
+
+  ffplay -f v4l2 $video_size_arg -framerate 30 /dev/video0 \
     -vf "scale=${target_width}:-1" \
     -window_title "WebcamOverlay" \
     -noborder \

--- a/bin/omarchy-cmd-screenrecord
+++ b/bin/omarchy-cmd-screenrecord
@@ -27,12 +27,15 @@ cleanup_webcam() {
 start_webcam_overlay() {
   cleanup_webcam
 
+  # Get monitor scale
   local scale=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .scale')
-  local width=$(awk "BEGIN {printf \"%.0f\", 360 * $scale}")
-  local height=$(awk "BEGIN {printf \"%.0f\", 203 * $scale}")
 
+  # Target width (base 360px, scaled to monitor)
+  local target_width=$(awk "BEGIN {printf \"%.0f\", 360 * $scale}")
+
+  # Scale maintaining aspect ratio (-1 means auto-calculate to maintain ratio)
   ffplay -f v4l2 -framerate 30 /dev/video0 \
-    -vf "scale=${width}:${height}" \
+    -vf "scale=${target_width}:-1" \
     -window_title "WebcamOverlay" \
     -noborder \
     -fflags nobuffer -flags low_delay \

--- a/default/hypr/apps.conf
+++ b/default/hypr/apps.conf
@@ -12,3 +12,4 @@ source = ~/.local/share/omarchy/default/hypr/apps/steam.conf
 source = ~/.local/share/omarchy/default/hypr/apps/system.conf
 source = ~/.local/share/omarchy/default/hypr/apps/terminals.conf
 source = ~/.local/share/omarchy/default/hypr/apps/walker.conf
+source = ~/.local/share/omarchy/default/hypr/apps/webcam-overlay.conf

--- a/default/hypr/apps/webcam-overlay.conf
+++ b/default/hypr/apps/webcam-overlay.conf
@@ -1,11 +1,6 @@
 # Webcam overlay for screen recording
 windowrule = float, title:WebcamOverlay
 windowrule = pin, title:WebcamOverlay
-# windowrule = size 480 360, title:WebcamOverlay
-windowrule = noshadow, title:WebcamOverlay
-windowrule = noblur, title:WebcamOverlay
 windowrule = noinitialfocus, title:WebcamOverlay
 windowrule = nodim, title:WebcamOverlay
-windowrule = opaque, title:WebcamOverlay
-windowrule = opacity 1 1, title:WebcamOverlay
-windowrule = move 100%-w-40 100%-w-40, title:WebcamOverlay
+windowrule = move 100%-w-40 100%-w-40, title:WebcamOverlay # There's a typo in the hyprland rule so 100%-w on the height param is actually correct here

--- a/default/hypr/apps/webcam-overlay.conf
+++ b/default/hypr/apps/webcam-overlay.conf
@@ -1,0 +1,11 @@
+# Webcam overlay for screen recording
+windowrule = float, title:WebcamOverlay
+windowrule = pin, title:WebcamOverlay
+# windowrule = size 480 360, title:WebcamOverlay
+windowrule = noshadow, title:WebcamOverlay
+windowrule = noblur, title:WebcamOverlay
+windowrule = noinitialfocus, title:WebcamOverlay
+windowrule = nodim, title:WebcamOverlay
+windowrule = opaque, title:WebcamOverlay
+windowrule = opacity 1 1, title:WebcamOverlay
+windowrule = move 100%-w-40 100%-w-40, title:WebcamOverlay

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -36,9 +36,9 @@ bindd = CTRL, PRINT, Screenshot of display, exec, omarchy-cmd-screenshot output
 
 # Screen recordings
 bindd = ALT, PRINT, Screen record a region, exec, omarchy-cmd-screenrecord region
-bindd = ALT SHIFT, PRINT, Screen record a region with audio, exec, omarchy-cmd-screenrecord region audio
+bindd = ALT SHIFT, PRINT, Screen record a region with audio, exec, omarchy-cmd-screenrecord region --with-audio
 bindd = CTRL ALT, PRINT, Screen record display, exec, omarchy-cmd-screenrecord output
-bindd = CTRL ALT SHIFT, PRINT, Screen record display with audio, exec, omarchy-cmd-screenrecord output audio
+bindd = CTRL ALT SHIFT, PRINT, Screen record display with audio, exec, omarchy-cmd-screenrecord output --with-audio
 
 # Color picker
 bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a

--- a/default/waybar/indicators/screen-recording.sh
+++ b/default/waybar/indicators/screen-recording.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if pgrep -x wl-screenrec >/dev/null || pgrep -x wf-recorder >/dev/null; then
+if pgrep -f "gpu-screen-recorder" >/dev/null; then
   echo '{"text": "󰻂", "tooltip": "Stop recording", "class": "active"}'
 else
   echo '{"text": ""}'

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -120,7 +120,6 @@ wiremix
 wireplumber
 wl-clip-persist
 wl-clipboard
-wl-screenrec
 woff2-font-awesome
 xdg-desktop-portal-gtk
 xdg-desktop-portal-hyprland

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -35,6 +35,7 @@ github-cli
 gnome-calculator
 gnome-keyring
 gnome-themes-extra
+gpu-screen-recorder
 gum
 gvfs-mtp
 gvfs-smb
@@ -113,7 +114,6 @@ unzip
 uwsm
 walker-bin
 waybar
-wf-recorder
 whois
 wireless-regdb
 wiremix

--- a/migrations/1760144906.sh
+++ b/migrations/1760144906.sh
@@ -1,0 +1,3 @@
+echo "Change omarchy-screenrecord to use gpu-screen-recorder"
+omarchy-pkg-drop wf-recorder wl-screenrec
+omarchy-pkg-add gpu-screen-recorder


### PR DESCRIPTION
Changes `omarchy-cmd-screenrecord` to use gpu-screen-recorder and adds a webcam option (not currently hotkeyed anywhere).