### PR TITLE
feat(clipboard.conf): add descriptions

### DIFF
--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -1,5 +1,5 @@
 # Copy / Paste
-bind = SUPER, C, sendshortcut, CTRL, Insert,
-bind = SUPER, V, sendshortcut, SHIFT, Insert,
-bind = SUPER, X, sendshortcut, CTRL, X,
+bindd = SUPER, C, Copy, sendshortcut, CTRL, Insert,
+bindd = SUPER, V, Paste, sendshortcut, SHIFT, Insert,
+bindd = SUPER, X, Cut, sendshortcut, CTRL, X,
 bindd = SUPER CTRL, V, Clipboard, exec, omarchy-launch-walker -m clipboard


### PR DESCRIPTION
Add descriptions to Copy / Paste shortcuts for consistent display them inside `omarchy-menu-keybindings`.