### PR TITLE
Adding title to TUI App

### DIFF
--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -38,12 +38,14 @@ else
   APP_CLASS="TUI.tile"
 fi
 
+APP_TITLE="TUI.$APP_NAME"
+
 cat >"$DESKTOP_FILE" <<EOF
 [Desktop Entry]
 Version=1.0
 Name=$APP_NAME
 Comment=$APP_NAME
-Exec=\$TERMINAL --class=$APP_CLASS -e $APP_EXEC
+Exec=\$TERMINAL --title=$APP_TITLE --class=$APP_CLASS -e $APP_EXEC
 Terminal=false
 Type=Application
 Icon=$ICON_PATH


### PR DESCRIPTION
Added a app title to a TUI App installer allowing better recognition of a installed app. This mainly comes from need to set specific hyprland windowrule to given App only.