### PR TITLE
Feat config docker with on demand startup

### DIFF
--- a/install/config/docker.sh
+++ b/install/config/docker.sh
@@ -16,8 +16,8 @@ sudo mkdir -p /etc/systemd/resolved.conf.d
 echo -e '[Resolve]\nDNSStubListenerExtra=172.17.0.1' | sudo tee /etc/systemd/resolved.conf.d/20-docker-dns.conf >/dev/null
 sudo systemctl restart systemd-resolved
 
-# Start Docker automatically
-sudo systemctl enable docker
+# Start Docker on-demand
+sudo systemctl enable docker.socket
 
 # Give this user privileged Docker access
 sudo usermod -aG docker ${USER}


### PR DESCRIPTION
Changed Docker configuration from `systemctl enable docker` to `systemctl enable docker.socket`. This prevents dockerd from starting automatically at boot, while still allowing it to start instantly when any Docker command is executed via socket activation.

Summary
• Saves Memory when Docker is not actively being used
• One less service starting during system boot
• Docker commands work identically - dockerd starts automatically on first use