### PR TITLE
Nvidia script refactoring

### DIFF
--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -8,73 +8,52 @@
 #
 # ==============================================================================
 
-# --- GPU Detection ---
-if [ -n "$(lspci | grep -i 'nvidia')" ]; then
-  # --- Driver Selection ---
-  # Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
-  if echo "$(lspci | grep -i 'nvidia')" | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
-    NVIDIA_DRIVER_PACKAGE="nvidia-open-dkms"
-  else
-    NVIDIA_DRIVER_PACKAGE="nvidia-dkms"
-  fi
+# Exit early if no nvidia devices found
+if lspci | grep -qvi 'nvidia'; then
+   exit 0
+fi
 
-  # Check which kernel is installed and set appropriate headers package
-  KERNEL_HEADERS="linux-headers" # Default
-  if pacman -Q linux-zen &>/dev/null; then
-    KERNEL_HEADERS="linux-zen-headers"
-  elif pacman -Q linux-lts &>/dev/null; then
-    KERNEL_HEADERS="linux-lts-headers"
-  elif pacman -Q linux-hardened &>/dev/null; then
-    KERNEL_HEADERS="linux-hardened-headers"
-  fi
+# Driver Selection
+NVIDIA_DRIVER_PACKAGE="nvidia-dkms"
 
-  # force package database refresh
-  sudo pacman -Syu --noconfirm
+# Turing (16xx, 20xx), Ampere (30xx), Ada (40xx), and newer recommend the open-source kernel modules
+if lspci | grep -i 'nvidia' | grep -q -E "RTX [2-9][0-9]|GTX 16"; then
+  NVIDIA_DRIVER_PACKAGE="nvidia-open-dkms"
+fi
 
-  # Install packages
-  PACKAGES_TO_INSTALL=(
-    "${KERNEL_HEADERS}"
-    "${NVIDIA_DRIVER_PACKAGE}"
-    "nvidia-utils"
-    "lib32-nvidia-utils"
-    "egl-wayland"
-    "libva-nvidia-driver" # For VA-API hardware acceleration
-    "qt5-wayland"
-    "qt6-wayland"
-  )
+# Add headers to all supported kernels
+KERNEL_HEADERS="$( pacman -Q | grep -E '^linux(-zen|-lts|-hardened)? ' |awk '{print $1 "-headers"}' )"
 
-  sudo pacman -S --needed --noconfirm "${PACKAGES_TO_INSTALL[@]}"
+# Install packages
+PACKAGES_TO_INSTALL=(
+  "${KERNEL_HEADERS}"
+  "${NVIDIA_DRIVER_PACKAGE}"
+  "nvidia-utils"
+  "lib32-nvidia-utils"
+  "egl-wayland"
+  "libva-nvidia-driver" # For VA-API hardware acceleration
+  "qt5-wayland"
+  "qt6-wayland"
+)
+sudo pacman -Syu --needed --noconfirm "${PACKAGES_TO_INSTALL[@]}"
 
-  # Configure modprobe for early KMS
-  echo "options nvidia_drm modeset=1" | sudo tee /etc/modprobe.d/nvidia.conf >/dev/null
+# Configure modprobe for early KMS and hibernation
+cat <<EOF | sudo tee /etc/modprobe.d/nvidia.conf >/dev/null
+options nvidia_drm modeset=1
+EOF
 
-  # Configure mkinitcpio for early loading
-  MKINITCPIO_CONF="/etc/mkinitcpio.conf"
+# Configure mkinitcpio for early loading
+echo 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee /etc/mkinitcpio.conf.d/nvidia.conf >/dev/null
 
-  # Define modules
-  NVIDIA_MODULES="nvidia nvidia_modeset nvidia_uvm nvidia_drm"
+# Regenerate initramfs with applied changes
+sudo limine-mkinitcpio
 
-  # Create backup
-  sudo cp "$MKINITCPIO_CONF" "${MKINITCPIO_CONF}.backup"
-
-  # Remove any old nvidia modules to prevent duplicates
-  sudo sed -i -E 's/ nvidia_drm//g; s/ nvidia_uvm//g; s/ nvidia_modeset//g; s/ nvidia//g;' "$MKINITCPIO_CONF"
-  # Add the new modules at the start of the MODULES array
-  sudo sed -i -E "s/^(MODULES=\\()/\\1${NVIDIA_MODULES} /" "$MKINITCPIO_CONF"
-  # Clean up potential double spaces
-  sudo sed -i -E 's/  +/ /g' "$MKINITCPIO_CONF"
-
-  sudo mkinitcpio -P
-
-  # Add NVIDIA environment variables to hyprland.conf
-  HYPRLAND_CONF="$HOME/.config/hypr/hyprland.conf"
-  if [ -f "$HYPRLAND_CONF" ]; then
-    cat >>"$HYPRLAND_CONF" <<'EOF'
+# Add NVIDIA environment variables to envs.conf
+HYPRLAND_CONF="$HOME/.config/hypr/envs.conf"
+cat >>"$HYPRLAND_CONF" <<'EOF'
 
 # NVIDIA environment variables
 env = NVD_BACKEND,direct
 env = LIBVA_DRIVER_NAME,nvidia
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
-  fi
-fi

--- a/install/config/hardware/nvidia.sh
+++ b/install/config/hardware/nvidia.sh
@@ -37,13 +37,8 @@ PACKAGES_TO_INSTALL=(
 )
 sudo pacman -Syu --needed --noconfirm "${PACKAGES_TO_INSTALL[@]}"
 
-# Configure modprobe for early KMS and hibernation
-cat <<EOF | sudo tee /etc/modprobe.d/nvidia.conf >/dev/null
-options nvidia_drm modeset=1
-EOF
-
 # Configure mkinitcpio for early loading
-echo 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee /etc/mkinitcpio.conf.d/nvidia.conf >/dev/null
+echo 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee /etc/mkinitcpio.conf.d/omarchy_nvidia.conf >/dev/null
 
 # Regenerate initramfs with applied changes
 sudo limine-mkinitcpio

--- a/migrations/1761664693.sh
+++ b/migrations/1761664693.sh
@@ -1,0 +1,28 @@
+if lspci | grep -qvi 'nvidia'; then
+   exit 0
+fi
+
+KERNEL_HEADERS="$( pacman -Q | grep -E '^linux(-zen|-lts|-hardened)? ' |awk '{print $1 "-headers"}' )"
+sudo pacman -Syu --needed --noconfirm "$KERNEL_HEADERS"
+
+sudo sed -i -E 's/ nvidia_drm//g; s/ nvidia_uvm//g; s/ nvidia_modeset//g; s/ nvidia//g;' /etc/mkinitcpio.conf
+
+echo 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee /etc/mkinitcpio.conf.d/nvidia.conf >/dev/null
+
+cat >>"$HOME/.config/hypr/envs.conf"<<'EOF'
+
+# NVIDIA environment variables
+env = NVD_BACKEND,direct
+env = LIBVA_DRIVER_NAME,nvidia
+env = __GLX_VENDOR_LIBRARY_NAME,nvidia
+EOF
+
+sed -i \
+  -e '/^# NVIDIA environment variables$/d' \
+  -e '/^env = NVD_BACKEND,direct$/d' \
+  -e '/^env = LIBVA_DRIVER_NAME,nvidia$/d' \
+  -e '/^env = __GLX_VENDOR_LIBRARY_NAME,nvidia$/d' \
+  "$HOME/.config/hypr/hyprland.conf"
+
+
+

--- a/migrations/1761664693.sh
+++ b/migrations/1761664693.sh
@@ -5,9 +5,10 @@ fi
 KERNEL_HEADERS="$( pacman -Q | grep -E '^linux(-zen|-lts|-hardened)? ' |awk '{print $1 "-headers"}' )"
 sudo pacman -Syu --needed --noconfirm "$KERNEL_HEADERS"
 
+sudo cp "/etc/mkinitcpio.conf" "/etc/mkinitcpio.conf.bak.$(date +%s)"
 sudo sed -i -E 's/ nvidia_drm//g; s/ nvidia_uvm//g; s/ nvidia_modeset//g; s/ nvidia//g;' /etc/mkinitcpio.conf
 
-echo 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee /etc/mkinitcpio.conf.d/nvidia.conf >/dev/null
+echo 'MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)' | sudo tee /etc/mkinitcpio.conf.d/omarchy_nvidia.conf >/dev/null
 
 cat >>"$HOME/.config/hypr/envs.conf"<<'EOF'
 
@@ -17,6 +18,8 @@ env = LIBVA_DRIVER_NAME,nvidia
 env = __GLX_VENDOR_LIBRARY_NAME,nvidia
 EOF
 
+
+sudo cp "$HOME/.config/hypr/hyprland.conf" "$HOME/.config/hypr/hyprland.conf.bak.$(date +%s)"
 sed -i \
   -e '/^# NVIDIA environment variables$/d' \
   -e '/^env = NVD_BACKEND,direct$/d' \


### PR DESCRIPTION
So, in #1417, I discovered that some shenanigans are needed to enable hibernation for Nvidia users.
Somehow I found myself refactoring this script :D

1. Installs headers to all installed kernels.
2. Adds modules to a separate file `/etc/mkinitcpio.conf.d/nvidia.conf` instead of using sed on `/etc/mkinitcpio.conf`.
3. Uses `limine-mkinitcpio` instead of `mkinitcpio -P` (this removes another interactive confirmation).
4. Creates `env =` for nvidia in `envs.conf` instead of `hyprland.conf`.
5. Exits early, so all the script not indented
6. Overall improvements

I also added migration to standardize the configurations for already existing users. 

@Kn0ax, as the author of the script, please let me know if you have any concerns.