### PR TITLE
Feature: Screen rotation

### DIFF
--- a/bin/omarchy-cmd-rotate-screen
+++ b/bin/omarchy-cmd-rotate-screen
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-# Exit if arguments are missing
 if [[ -z "$1" ]]; then
   echo "Usage: $0 ['▲' (UP) || '▶' (RIGHT) || '▼' (DOWN) || '◀' (LEFT)]"
   echo "Example: $0 ▲"
   exit 1
 fi
 
-rotate_command="$1" # ['▲' (UP) || '▶' (RIGHT) || '▼' (DOWN) || '◀' (LEFT)]
+rotate_command="$1"
 which_monitor=$(hyprctl activeworkspace | awk -F "on monitor" 'NR==1 {print substr($2, 2, length($2)-2)}')
 
 declare -A monitor_transforms
@@ -17,7 +16,6 @@ while IFS=':' read -r monitor transform; do
   [[ -n "$monitor" && -n "$transform" ]] && monitor_transforms["$monitor"]="$transform"
 done < <(awk -F '[= ,]' '
 /^monitor/ {
-  # Find name: first non-empty field after "monitor"
   for (i=2; i<=NF; i++) {
     if ($i != "" && $i != "=") {
       name = $i
@@ -25,7 +23,7 @@ done < <(awk -F '[= ,]' '
       break
     }
   }
-  # Find transform: last numeric field (0-3), or default 0 if none
+
   transform = 0
   for (j=NF; j>=1; j--) {
     if ($j ~ /^[0-3]$/) {  # Matches 0,1,2,3
@@ -33,12 +31,9 @@ done < <(awk -F '[= ,]' '
       break
     }
   }
-  if (name != "") print name ":" transform
 }' "$config_file")
 
 default_transform="${monitor_transforms[$which_monitor]}"
-
-echo "${default_transform}" > ~/Work/output.txt
 
 if [[ "$rotate_command" == "UP" ]]; then
   new_transform=$(( $default_transform % 4 ))

--- a/bin/omarchy-cmd-rotate-screen
+++ b/bin/omarchy-cmd-rotate-screen
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Exit if arguments are missing
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 ['▲' (UP) || '▶' (RIGHT) || '▼' (DOWN) || '◀' (LEFT)]"
+  echo "Example: $0 ▲"
+  exit 1
+fi
+
+rotate_command="$1" # ['▲' (UP) || '▶' (RIGHT) || '▼' (DOWN) || '◀' (LEFT)]
+which_monitor=$(hyprctl activeworkspace | awk -F "on monitor" 'NR==1 {print substr($2, 2, length($2)-2)}')
+
+declare -A monitor_transforms
+config_file="$HOME/.config/hypr/monitors.conf"
+
+while IFS=':' read -r monitor transform; do
+  [[ -n "$monitor" && -n "$transform" ]] && monitor_transforms["$monitor"]="$transform"
+done < <(awk -F '[= ,]' '
+/^monitor/ {
+  # Find name: first non-empty field after "monitor"
+  for (i=2; i<=NF; i++) {
+    if ($i != "" && $i != "=") {
+      name = $i
+      gsub(/^[ \t]+|[ \t]+$/, "", name)  # Trim any lingering spaces
+      break
+    }
+  }
+  # Find transform: last numeric field (0-3), or default 0 if none
+  transform = 0
+  for (j=NF; j>=1; j--) {
+    if ($j ~ /^[0-3]$/) {  # Matches 0,1,2,3
+      transform = $j
+      break
+    }
+  }
+  if (name != "") print name ":" transform
+}' "$config_file")
+
+default_transform="${monitor_transforms[$which_monitor]}"
+
+echo "${default_transform}" > ~/Work/output.txt
+
+if [[ "$rotate_command" == "UP" ]]; then
+  new_transform=$(( $default_transform % 4 ))
+fi
+if [[ "$rotate_command" == "LEFT" ]]; then
+  new_transform=$(( ($default_transform + 1) % 4 ))
+fi
+if [[ "$rotate_command" == "DOWN" ]]; then
+  new_transform=$(( ($default_transform + 2) % 4 ))
+fi
+if [[ "$rotate_command" == "RIGHT" ]]; then
+  new_transform=$(( ($default_transform + 3) % 4 ))
+fi
+
+hyprctl keyword monitor "${which_monitor},preferred,auto,auto,transform,${new_transform}"
+

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -97,3 +97,10 @@ bindd = SUPER ALT, 2, Switch to group window 2, changegroupactive, 2
 bindd = SUPER ALT, 3, Switch to group window 3, changegroupactive, 3
 bindd = SUPER ALT, 4, Switch to group window 4, changegroupactive, 4
 bindd = SUPER ALT, 5, Switch to group window 5, changegroupactive, 5
+
+# Rotate screen with SUPER + ALT + arrow keys
+bindd = SUPER CTRL, UP, , exec, omarchy-cmd-rotate-screen "UP"
+bindd = SUPER CTRL, DOWN, , exec, omarchy-cmd-rotate-screen "DOWN"
+bindd = SUPER CTRL, RIGHT, , exec, omarchy-cmd-rotate-screen "RIGHT"
+bindd = SUPER CTRL, LEFT, , exec, omarchy-cmd-rotate-screen "LEFT"
+


### PR DESCRIPTION
### Screen Rotation

**Overview**  
Effortlessly switch your display orientation on the fly—perfect for 2-in-1 laptops like Framework in tent, tablet, or portrait modes. Seamlessly integrates with Hyprland for instant, hardware-aware flips without disrupting your workflow.

**How It Works**  
- **Quick Access**: Press **Super + CTRL + arrow** to cycle through orientations: Normal (up), Right (90° CW), Down (180°), Left (270° CW).  
- **Smart Behavior**: Applies only to your active monitor and rotates touch input/tablet stylus to match—everything feels natural, no lag or redraw glitches.  

**Note**
> You need to set transform default in .config/hypr/monitors.conf