### PR TITLE
Ensure Linux kernel is running preempt=full to avoid audio/video jitter under load

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -33,7 +33,7 @@ TARGET_OS_NAME="Omarchy"
 ESP_PATH="/boot"
 
 KERNEL_CMDLINE[default]="$CMDLINE"
-KERNEL_CMDLINE[default]+="quiet splash"
+KERNEL_CMDLINE[default]+="quiet splash preempt=full"
 
 ENABLE_UKI=yes
 CUSTOM_UKI_NAME="omarchy"

--- a/migrations/1762684663.sh
+++ b/migrations/1762684663.sh
@@ -1,0 +1,7 @@
+echo "Ensure Linux is running fully preemptible to avoid video/audio issues"
+
+if ! grep -q "preempt=full" /etc/default/limine; then
+  sudo sed -i 's/^\(KERNEL_CMDLINE\[default\]+=\"[^"]*\)"/\1 preempt=full"/' /etc/default/limine
+  sudo limine-update
+  omarchy-state set reboot-required
+fi


### PR DESCRIPTION
We never want audio/video playback or recording to crackle under load.