### PR TITLE
fix: passing additional arguments to omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,4 +7,7 @@ google-chrome* | brave-browser* | microsoft-edge* | opera* | vivaldi* | helium*)
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+app=$1
+rest=${@:2}
+
+exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$app" "$rest"


### PR DESCRIPTION
before the change
`omarchy-launch-or-focus-webapp "chrome-outlook.office.com__mail_inbox-Profile_2" "https://outlook.office.com/mail/inbox" "--profile-directory=Profile 2"`
would still launch with the default profile,

with the change, it loads with the specified Profile 2.