### PR TITLE
Enhance window focus to seamlessly cycle between tiled and floating windows

### DIFF
--- a/bin/omarchy-hyprland-move-focus
+++ b/bin/omarchy-hyprland-move-focus
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+DIRECTION="$1"
+
+ACTIVE_WINDOW_BEFORE=$(hyprctl activewindow -j | jq .address)
+IS_FLOATING=$(hyprctl activewindow -j | jq .floating)
+
+if [ "$IS_FLOATING" = "true" ]; then
+    hyprctl dispatch cyclenext next
+else
+    hyprctl dispatch movefocus "$DIRECTION"
+
+    ACTIVE_WINDOW_AFTER=$(hyprctl activewindow -j | jq .address)
+
+    if [ "$ACTIVE_WINDOW_BEFORE" = "$ACTIVE_WINDOW_AFTER" ]; then
+        hyprctl dispatch cyclenext next floating
+    fi
+fi
+

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -11,10 +11,10 @@ bindd = SUPER CTRL, F, Tiled full screen, fullscreenstate, 0 2
 bindd = SUPER ALT, F, Full width, fullscreen, 1
 
 # Move focus with SUPER + arrow keys
-bindd = SUPER, LEFT, Move window focus left, movefocus, l
-bindd = SUPER, RIGHT, Move window focus right, movefocus, r
-bindd = SUPER, UP, Move window focus up, movefocus, u
-bindd = SUPER, DOWN, Move window focus down, movefocus, d
+bindd = SUPER, LEFT, Move window focus left, exec, omarchy-hyprland-move-focus, l
+bindd = SUPER, RIGHT, Move window focus right, exec, omarchy-hyprland-move-focus, r
+bindd = SUPER, UP, Move window focus up, exec, omarchy-hyprland-move-focus, u
+bindd = SUPER, DOWN, Move window focus down, exec, omarchy-hyprland-move-focus, d
 
 # Switch workspaces with SUPER + [1-9]
 bindd = SUPER, code:10, Switch to workspace 1, workspace, 1

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -21,6 +21,9 @@ general {
     # Please see https://wiki.hyprland.org/Configuring/Tearing/ before you turn this on
     allow_tearing = false
 
+    # Disble move focus cyling for tiled windows
+    no_focus_fallback = true
+
     layout = dwindle
 }
 


### PR DESCRIPTION
This PR introduces a new Hyprland focus helper script omarchy-hyprland-move-focus that improves window navigation by:
- Moving focus between tiled windows using directional keys (l, r, u, d).
- Seamlessly falling back to floating windows when no tiled window exists in the chosen direction.
- Cycling between all windows when the currently focused window is floating.

## Caveat:
- **no_focus_fallback** must be set to true in the Hyprland configuration for this logic to function as intended. This ensures that failing to focus a tiled window properly triggers the fallback path.
- floating window is always visually on top even if it is not the active focused window. I can't seem to find a way to override this behavior, maybe its hyperland's limitation?

## Demo

https://github.com/user-attachments/assets/15316d70-46c5-441f-9dce-6c50a1021dc0

