### PR TITLE
Use the running Emacs to open the editor.

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -9,6 +9,14 @@ case "$EDITOR" in
 nvim | vim | nano | micro | hx | helix | fresh)
   exec omarchy-launch-tui "$EDITOR" "$@"
   ;;
+emacs)
+  # If emacs.service is active open a new frame instead of a whole new emacs.
+  if systemctl --user is-active emacs.service >/dev/null 2>&1; then
+    exec setsid uwsm-app -- emacsclient -n -r "$@"
+  else
+    exec setsid uwsm-app -- emacs "$@"
+  fi
+  ;;
 *)
   exec setsid uwsm-app -- "$EDITOR" "$@"
   ;;


### PR DESCRIPTION
When we install Emacs, we also enable the emacs.service; to avoid having two competing Emacs instances, let's open a frame if the service is running.