### PR TITLE
Let the screensaver run in Wezterm

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -20,6 +20,11 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
   hyprctl dispatch focusmonitor $m
 
   case $terminal in
+  *wezterm*)
+    hyprctl dispatch exec -- \
+      wezterm start --class=org.omarchy.screensaver --no-auto-connect \
+        --always-new-process omarchy-cmd-screensaver
+    ;;
   *Alacritty*)
     hyprctl dispatch exec -- \
       alacritty --class=org.omarchy.screensaver \
@@ -41,7 +46,7 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
       -e omarchy-cmd-screensaver
     ;;
   *)
-    notify-send "✋  Screensaver only runs in Alacritty, Ghostty, or Kitty"
+    notify-send "✋  Screensaver only runs in Wezterm, Alacritty, Ghostty, or Kitty"
     ;;
   esac
 done


### PR DESCRIPTION
Because Wezterm is nice.

Alternatively, perhaps it would be better for the screensaver to always use a specific terminal emulator regardless of the user’s preference for interactive terminals.