### PR TITLE
Fix: Refactored the battery notification script with added feature and fix for inconsistent notifications

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -8,19 +8,11 @@ WARN_BATTERY_THRESHOLD=20
 CRIT_NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified_crit"
 WARN_NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified_warn"
 
-BATTERY_PATH=$(upower -e | grep 'BAT' | head -n 1)
+BATTERY_PATH=$(upower -e | grep 'DisplayDevice' | head -n 1)
 BATTERY_INFO=$(upower -i "$BATTERY_PATH")
 
 BATTERY_STATE=$(echo "$BATTERY_INFO" | grep "state" | awk '{print $2}')
 BATTERY_LEVEL=$(echo "$BATTERY_INFO" | grep "percentage" | awk '{print $2}' | tr -d '%')
-#BATTERY_LEVEL=$(echo "$BATTERY_INFO" | grep "percentage" \
-#  | awk -F: '/percentage/ {
-#    gsub(/[%[:space:]]/, "", $2);
-#    val=$2;
-#    printf("%d\n", (val+0.5))
-#    exit
-#    }'
-#  )
 
 send_notification() {
   local level=$1

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -2,22 +2,58 @@
 
 # Designed to be run by systemd timer every 30 seconds and alerts if battery is low
 
-BATTERY_THRESHOLD=10
-NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
-BATTERY_LEVEL=$(omarchy-battery-remaining)
-BATTERY_STATE=$(upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}')
+CRIT_BATTERY_THRESHOLD=10
+WARN_BATTERY_THRESHOLD=20
+
+CRIT_NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified_crit"
+WARN_NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified_warn"
+
+BATTERY_PATH=$(upower -e | grep 'BAT' | head -n 1)
+BATTERY_INFO=$(upower -i "$BATTERY_PATH")
+
+BATTERY_STATE=$(echo "$BATTERY_INFO" | grep "state" | awk '{print $2}')
+BATTERY_LEVEL=$(echo "$BATTERY_INFO" | grep "percentage" | awk '{print $2}' | tr -d '%')
+#BATTERY_LEVEL=$(echo "$BATTERY_INFO" | grep "percentage" \
+#  | awk -F: '/percentage/ {
+#    gsub(/[%[:space:]]/, "", $2);
+#    val=$2;
+#    printf("%d\n", (val+0.5))
+#    exit
+#    }'
+#  )
 
 send_notification() {
-  notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
+  local level=$1
+  local title=$2
+  local msg=$3
+  local urgency=$4
+
+  notify-send -u "$urgency" -a "System Power" "$title" "$msg" -i battery-caution -t 50000
 }
 
+
 if [[ -n "$BATTERY_LEVEL" && "$BATTERY_LEVEL" =~ ^[0-9]+$ ]]; then
-  if [[ $BATTERY_STATE == "discharging" && $BATTERY_LEVEL -le $BATTERY_THRESHOLD ]]; then
-    if [[ ! -f $NOTIFICATION_FLAG ]]; then
-      send_notification $BATTERY_LEVEL
-      touch $NOTIFICATION_FLAG
+
+  if [[ $BATTERY_STATE == "discharging" ]]; then
+
+    if [[ "$BATTERY_LEVEL" -le "$CRIT_BATTERY_THRESHOLD" ]]; then
+      if [[ ! -f "$CRIT_NOTIFICATION_FLAG" ]]; then
+        send_notification "$BATTERY_LEVEL" " 🔴 Critical Battery" "Battery is critical (${BATTERY_LEVEL}%)" "critical"
+        touch "$CRIT_NOTIFICATION_FLAG"
+        # Also creates WARN flag to prevent duplicate flags
+        touch "$WARN_NOTIFICATION_FLAG"
+      fi
+
+    elif [[ "$BATTERY_LEVEL" -le "$WARN_BATTERY_THRESHOLD" ]] then
+      if [[ ! -f "$WARN_NOTIFICATION_FLAG" ]]; then
+        send_notification "$BATTERY_LEVEL" " 🟠 Low Battery" "Battery is Low (${BATTERY_LEVEL}%)" "critical"
+        touch "$WARN_NOTIFICATION_FLAG"
+      fi
     fi
+  # Remove notified flags when plugged in
   else
-    rm -f $NOTIFICATION_FLAG
+    if [[ -f "$WARN_NOTIFICATION_FLAG" || -f "$CRIT_NOTIFICATION_FLAG" ]]; then
+      rm -f "$WARN_NOTIFICATION_FLAG" "$CRIT_NOTIFICATION_FLAG"
+    fi
   fi
 fi

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -12,25 +12,18 @@ BATTERY_PATH=$(upower -e | grep 'DisplayDevice' | head -n 1)
 BATTERY_INFO=$(upower -i "$BATTERY_PATH")
 
 BATTERY_STATE=$(echo "$BATTERY_INFO" | grep "state" | awk '{print $2}')
-BATTERY_LEVEL=$(echo "$BATTERY_INFO" | grep "percentage" | awk '{print $2}' | tr -d '%')
+BATTERY_LEVEL=$(omarchy-battery-remaining)
 
 send_notification() {
-  local level=$1
-  local title=$2
-  local msg=$3
-  local urgency=$4
-
-  notify-send -u "$urgency" -a "System Power" "$title" "$msg" -i battery-caution -t 50000
+  notify-send -u critical -a "System Power" "$1" "$2" -i battery-caution -t 50000
 }
 
-
 if [[ -n "$BATTERY_LEVEL" && "$BATTERY_LEVEL" =~ ^[0-9]+$ ]]; then
-
   if [[ $BATTERY_STATE == "discharging" ]]; then
 
     if [[ "$BATTERY_LEVEL" -le "$CRIT_BATTERY_THRESHOLD" ]]; then
       if [[ ! -f "$CRIT_NOTIFICATION_FLAG" ]]; then
-        send_notification "$BATTERY_LEVEL" " 🔴 Critical Battery" "Battery is critical (${BATTERY_LEVEL}%)" "critical"
+        send_notification " 🔴 Critical Battery" "Battery is critically low (${BATTERY_LEVEL}%)"
         touch "$CRIT_NOTIFICATION_FLAG"
         # Also creates WARN flag to prevent duplicate flags
         touch "$WARN_NOTIFICATION_FLAG"
@@ -38,14 +31,12 @@ if [[ -n "$BATTERY_LEVEL" && "$BATTERY_LEVEL" =~ ^[0-9]+$ ]]; then
 
     elif [[ "$BATTERY_LEVEL" -le "$WARN_BATTERY_THRESHOLD" ]] then
       if [[ ! -f "$WARN_NOTIFICATION_FLAG" ]]; then
-        send_notification "$BATTERY_LEVEL" " 🟠 Low Battery" "Battery is Low (${BATTERY_LEVEL}%)" "critical"
+        send_notification " 🟠 Low Battery" "Battery is low (${BATTERY_LEVEL}%)"
         touch "$WARN_NOTIFICATION_FLAG"
       fi
     fi
   # Remove notified flags when plugged in
   else
-    if [[ -f "$WARN_NOTIFICATION_FLAG" || -f "$CRIT_NOTIFICATION_FLAG" ]]; then
-      rm -f "$WARN_NOTIFICATION_FLAG" "$CRIT_NOTIFICATION_FLAG"
-    fi
+    rm -f "$WARN_NOTIFICATION_FLAG" "$CRIT_NOTIFICATION_FLAG"
   fi
 fi

--- a/bin/omarchy-battery-remaining
+++ b/bin/omarchy-battery-remaining
@@ -2,10 +2,5 @@
 
 # Returns the battery percentage remaining as an integer.
 
-upower -i $(upower -e | grep BAT) \
-| awk -F: '/percentage/ {
-    gsub(/[%[:space:]]/, "", $2);
-    val=$2;
-    printf("%d\n", (val+0.5))
-    exit
-  }'
+upower -i $(upower -e | grep 'DisplayDevice' | head -n 1 ) \
+  | grep "percentage" | awk '{print $2}' | tr -dc '0-9'


### PR DESCRIPTION
### Summary

Refactored the omarchy-battery-monitor script to improve reliability of battery notifications.

### Changes

Rewrote battery level fetching and parsing logic, removing dependency on _omarchy-battery-remaining_ call that may have caused inconsistent notifications mentioned in issue #3066 

Updated notification flow to use two levels:

A higher-threshold warning.

A lower-threshold critical alert.

### Outcome

Should ensure battery notifications trigger consistently and notify twice now.

P.S If omarchy-battery-remaining script is not used elsewhere it should be obselete and safe to remove.