### PR TITLE
fix: Robust cleanup for orphaned user-local desktop entries on packag…

### DIFF
--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -17,5 +17,27 @@ pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
 if [[ -n "$pkg_names" ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
-  omarchy-show-done
+
+  echo "Cleaning up user-local desktop entries..."
+  # Read Each Package Individually from the selection.
+  while read -r PKG_NAME; do
+    find "$HOME/.local/share/applications" \
+    -name "${PKG_NAME}.desktop" \
+    -o -name "${PKG_NAME,,}.desktop" \
+    -o -name "$(echo "$PKG_NAME" | sed 's/-//g').desktop" \
+    -o -name "$(echo "$PKG_NAME" | sed 's/\(.*\)/\L\1/; s/-//g').desktop" \
+    -o -name "$(echo "$PKG_NAME" | sed 's/\(.*\)/\U\1/; s/-//g').desktop" \
+    -exec echo "--> Deleting {}" \; \
+    -exec rm -f {} \; -quit 2>/dev/null
+  done <<< "$pkg_names"
+
+  # Refresh the application menu cache.
+  if command -v omarchy-refresh-applications &> /dev/null; then
+    omarchy-refresh-applications
+  fi
+
+  # Final Success Notification (Only once, after all operations)
+  if command -v omarchy-show-done &> /dev/null; then
+    omarchy-show-done
+  fi
 fi


### PR DESCRIPTION
## Fix: Robust Cleanup for Orphaned User-Local Desktop Files

Fixes #3574

This PR addresses the issue of application entries remaining in the user's application launcher after a package has been removed using `omarchy-pkg-remove`.

This bug resulted in "orphaned" desktop files (`~/.local/share/applications/*.desktop`) pointing to non-existent binaries.

### Key Changes in `omarchy-pkg-remove`
1.  **Robust Desktop Entry Deletion:**
    * The cleanup logic has been upgraded to a robust `find` command that iterates over the package selection.
    * It now searches for the `.desktop` file using multiple common name variations (original casing, lowercase, and variations without hyphens) to ensure the file is caught regardless of how it was created.

2.  **Application Menu Cache Refresh:**
    * The command `omarchy-refresh-applications` is now called after the deletion. This is vital, as it forces the desktop environment (like Wofi or Rofi) to rebuild its application cache, immediately eliminating the dead entry.

3.  **Correct Flow Control:**
    * The success notification (`omarchy-show-done`) is executed only once, after the package removal, file cleanup, and application refresh are all successfully completed.