### PR TITLE
allow user to extend or overwrite omarchy-menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -477,6 +477,13 @@ go_to_menu() {
   esac
 }
 
+# User's overrides
+EXTENSIONS="$HOME/.config/walker/omarchy/menu-extensions.sh"
+
+if [[ -f "$EXTENSIONS" ]]; then
+  source "$EXTENSIONS"
+fi
+
 if [[ -n "$1" ]]; then
   BACK_TO_EXIT=true
   go_to_menu "$1"


### PR DESCRIPTION
This PR introduces a supported extension point for Omarchy menus by sourcing
`menu-extensions.sh` after all core menu functions are defined.

By loading extensions last, users can override or extend menu behavior
(e.g. `show_system_menu`) without modifying the main script.

This enables customization while keeping upstream updates intact.

example:
user to create this file ` ~/.config/walker/omarchy/menu-extensions.sh` to override the system menu with their own like adding the suspend function back.
```bash
#!/bin/bash

show_system_menu() {
  case $(menu "System" "  Lock\n󱄄  Screensaver\n󰒲  Suspend\n󰜉  Restart\n󰐥  Shutdown") in
  *Lock*) omarchy-lock-screen ;;
  *Screensaver*) omarchy-launch-screensaver force ;;
  *Suspend*) systemctl suspend ;;
  *Restart*) omarchy-cmd-reboot ;;
  *Shutdown*) omarchy-cmd-shutdown ;;
  *) back_to show_main_menu ;;
  esac
}
```