### PR TITLE
Allow unsecure URLs to be copied

### DIFF
--- a/default/chromium/extensions/copy-url/background.js
+++ b/default/chromium/extensions/copy-url/background.js
@@ -1,21 +1,26 @@
-chrome.commands.onCommand.addListener((command) => {
-  if (command === 'copy-url') {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const currentTab = tabs[0];
+async function copyToClipboard(text) {
+  await chrome.offscreen.createDocument({
+    url: 'offscreen.html',
+    reasons: ['CLIPBOARD'],
+    justification: 'Copy URL to clipboard'
+  }).catch(() => {});
 
-      chrome.scripting.executeScript({
-        target: { tabId: currentTab.id },
-        func: () => {
-          navigator.clipboard.writeText(window.location.href);
-        }
-      }).then(() => {
-        chrome.notifications.create({
-          type: 'basic',
-          iconUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
-          title: '   URL copied to clipboard',
-          message: ''
-        });
-      });
+  await chrome.runtime.sendMessage({ type: 'copy', text });
+
+  await chrome.offscreen.closeDocument().catch(() => {});
+}
+
+chrome.commands.onCommand.addListener(async (command) => {
+  if (command === 'copy-url') {
+    const [currentTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+    await copyToClipboard(currentTab.url);
+
+    chrome.notifications.create({
+      type: 'basic',
+      iconUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+      title: '   URL copied to clipboard',
+      message: ''
     });
   }
 });

--- a/default/chromium/extensions/copy-url/manifest.json
+++ b/default/chromium/extensions/copy-url/manifest.json
@@ -3,7 +3,7 @@
   "name": "Copy URL",
   "version": "1.0",
   "description": "Copy current URL to clipboard, this extension is installed by Omarchy",
-  "permissions": ["activeTab", "scripting", "notifications"],
+  "permissions": ["activeTab", "scripting", "notifications", "offscreen", "clipboardWrite"],
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/default/chromium/extensions/copy-url/offscreen.html
+++ b/default/chromium/extensions/copy-url/offscreen.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<textarea id="text"></textarea>
+<script src="offscreen.js"></script>

--- a/default/chromium/extensions/copy-url/offscreen.js
+++ b/default/chromium/extensions/copy-url/offscreen.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'copy') {
+    const textArea = document.getElementById('text');
+    textArea.value = message.text;
+    textArea.select();
+    document.execCommand('copy');
+  }
+});


### PR DESCRIPTION
Current version only allows URLs in a secure context like HTTPS to be copied.

The new version allows unsecure URLs to be copied.

It's useful when you're using it for URLs during development without HTTPS (e.g. via SSH)

It is using [chrome.offscreen API](https://developer.chrome.com/docs/extensions/reference/api/offscreen)