### PR TITLE
fix(migrations-1767138576): split sed commands in scrolltouchpad migration

### DIFF
--- a/migrations/1767138576.sh
+++ b/migrations/1767138576.sh
@@ -1,8 +1,8 @@
 echo "Update terminal scrolltouchpad setting to Hyprland 0.53 style"
 
 if grep -q "scrolltouchpad" ~/.config/hypr/input.conf; then
-  sed -Ei 's/^windowrule = scrolltouchpad ([^,]+), class:\(([^)]+)\)$/windowrule = match:class (\2), scroll_touchpad \1/;
-  s/^windowrule = scrolltouchpad ([^,]+), class:([^ ]+)$/windowrule = match:class \2, scroll_touchpad \1/' ~/.config/hypr/input.conf
+  sed -Ei 's/^windowrule = scrolltouchpad ([^,]+), class:\(([^)]+)\)$/windowrule = match:class (\2), scroll_touchpad \1/' ~/.config/hypr/input.conf
+  sed -Ei 's/^windowrule = scrolltouchpad ([^,]+), class:([^ ]+)$/windowrule = match:class \2, scroll_touchpad \1/' ~/.config/hypr/input.conf
   sed -Ei 's/^windowrule = scrolltouchpad ([^,]+), tag:terminal$/windowrule = match:class (Alacritty|kitty), scroll_touchpad 1.5\nwindowrule = match:class com.mitchellh.ghostty, scroll_touchpad 0.2/' ~/.config/hypr/input.conf
 fi
 


### PR DESCRIPTION
The sed expression for converting scrolltouchpad syntax to Hyprland 0.53 format was broken across two lines, causing the second substitution pattern to fail silently. Split into separate sed commands to ensure both class:(pattern) and class:pattern formats are migrated correctly.