### PR TITLE
feat: implement interactive .NET version selection

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -133,8 +133,21 @@ ocaml)
   opam install ocaml-lsp-server odoc ocamlformat utop --yes
   ;;
 dotnet)
-  echo -e "Installing .NET...\n"
-  mise use --global dotnet@latest
+  
+  # List available stable .NET versions, filtering out RC and preview versions, and sort them in descending order
+  versions=$(mise ls-remote dotnet \
+  | grep -vE 'rc|preview' \
+  | sort -Vr \
+  | awk -F. '!seen[$1"."$2]++')
+
+  dotnet_version=$(echo "$versions" | gum choose --header "Select .NET version to install...")
+
+  if [[ -n "$dotnet_version" ]]; then
+    echo -e "\nInstalling .NET ${dotnet_version}...\n"
+
+    # Install the selected .NET version
+    mise use --global "dotnet@${dotnet_version}"
+  fi
   ;;
 clojure)
   echo -e "Installing Clojure...\n"


### PR DESCRIPTION
**Motivation:** Installing the latest version isn't always appropriate (compatibility, LTS, legacy projects). This change lets users pick the exact stable minor/patch they need rather than forcing latest.

**What I changed:**

- Behavior: Show interactive list of stable .NET versions and install the chosen one.
- Filtering: Exclude `rc` and `preview` releases.
- Deduplication: Keep one entry per minor version (latest patch).

**Artifacts** 
<img width="866" height="510" alt="image" src="https://github.com/user-attachments/assets/cdd5320d-51c9-4057-9eb0-77057d69b789" />

<img width="1346" height="382" alt="image" src="https://github.com/user-attachments/assets/2f740f8f-c4ea-4ae1-b637-6ecb0267777c" />

<img width="838" height="194" alt="image" src="https://github.com/user-attachments/assets/8da59d52-7b1a-4949-b2da-c80ca155f343" />

