### PR TITLE
Add 5G/LTE modem support in waybar

### DIFF
--- a/bin/omarchy-5g-status
+++ b/bin/omarchy-5g-status
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Waybar module for 5G/LTE modem status
+# Returns JSON for waybar custom module
+
+MODEM=$(mmcli -L 2>/dev/null | grep -oP '/Modem/\K\d+' | head -1)
+
+if [ -z "$MODEM" ]; then
+    echo '{"text": "", "tooltip": "No modem found", "class": "hidden"}'
+    exit 0
+fi
+
+# Strip ANSI color codes from output
+STATUS=$(mmcli -m "$MODEM" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
+STATE=$(echo "$STATUS" | grep -P '^\s+\|\s+state:' | grep -oP 'state:\s+\K\w+')
+SIGNAL=$(echo "$STATUS" | grep -oP 'signal quality:\s+\K\d+')
+OPERATOR=$(echo "$STATUS" | grep -oP 'operator name:\s+\K.+' | head -1)
+ACCESS=$(echo "$STATUS" | grep -oP 'access tech:\s+\K\w+')
+
+# Get bearer info if connected
+BEARER=$(echo "$STATUS" | grep -oP 'Bearer\s+\|.*paths:.*Bearer/\K\d+' | tail -1)
+if [ -n "$BEARER" ]; then
+    IP=$(mmcli -b "$BEARER" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -oP 'address:\s+\K[\d.]+')
+fi
+
+# Default signal if not available
+[ -z "$SIGNAL" ] && SIGNAL=0
+
+# Select icon based on signal strength and connection state
+if [ "$STATE" = "connected" ]; then
+    if [ "$SIGNAL" -ge 80 ]; then
+        ICON="󰀳"
+    elif [ "$SIGNAL" -ge 60 ]; then
+        ICON="󰀵"
+    elif [ "$SIGNAL" -ge 40 ]; then
+        ICON="󰀷"
+    elif [ "$SIGNAL" -ge 20 ]; then
+        ICON="󰀹"
+    else
+        ICON="󰀻"
+    fi
+    CLASS="connected"
+    TOOLTIP="$OPERATOR ($ACCESS)\nSignal: $SIGNAL%\nIP: $IP\nClick to manage"
+elif [ "$STATE" = "registered" ]; then
+    ICON="󰀽"
+    CLASS="registered"
+    TOOLTIP="$OPERATOR ($ACCESS)\nSignal: $SIGNAL%\nClick to connect"
+elif [ "$STATE" = "disabled" ]; then
+    ICON="󰀿"
+    CLASS="disabled"
+    TOOLTIP="5G Modem disabled\nClick to enable"
+else
+    ICON="󰀿"
+    CLASS="disconnected"
+    TOOLTIP="5G Modem: $STATE\nClick to manage"
+fi
+
+echo "{\"text\": \"$ICON\", \"tooltip\": \"$TOOLTIP\", \"class\": \"$CLASS\", \"percentage\": $SIGNAL}"

--- a/bin/omarchy-launch-5g
+++ b/bin/omarchy-launch-5g
@@ -1,0 +1,86 @@
+#!/bin/bash
+# 5G/LTE modem menu for connect/disconnect operations
+# Requires: modemmanager, fuzzel
+
+MODEM=$(mmcli -L 2>/dev/null | grep -oP '/Modem/\K\d+' | head -1)
+
+if [ -z "$MODEM" ]; then
+    notify-send "5G Modem" "No modem found" -i network-cellular-offline
+    exit 1
+fi
+
+STATUS=$(mmcli -m "$MODEM" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
+STATE=$(echo "$STATUS" | grep -P '^\s+\|\s+state:' | grep -oP 'state:\s+\K\w+')
+SIGNAL=$(echo "$STATUS" | grep -oP 'signal quality:\s+\K\d+')
+OPERATOR=$(echo "$STATUS" | grep -oP 'operator name:\s+\K.+' | head -1)
+ACCESS=$(echo "$STATUS" | grep -oP 'access tech:\s+\K\w+')
+
+# Build menu based on state
+case "$STATE" in
+    connected)
+        MENU="󰀂  Disconnect\n󰑓  Refresh Status"
+        PROMPT="5G Connected - $OPERATOR ($ACCESS) $SIGNAL%"
+        ;;
+    registered)
+        MENU="󰀂  Connect\n󰑓  Refresh Status"
+        PROMPT="5G Ready - $OPERATOR ($ACCESS) $SIGNAL%"
+        ;;
+    disabled)
+        MENU="󱐥  Enable Modem\n󰑓  Refresh Status"
+        PROMPT="5G Modem Disabled"
+        ;;
+    *)
+        MENU="󱐥  Enable Modem\n󰑓  Refresh Status"
+        PROMPT="5G: $STATE"
+        ;;
+esac
+
+# Show menu using fuzzel
+CHOICE=$(echo -e "$MENU" | fuzzel --dmenu --prompt "$PROMPT > " --width 40 --lines 3)
+
+case "$CHOICE" in
+    *"Disconnect"*)
+        notify-send "5G Modem" "Disconnecting..." -i network-cellular
+        sudo mmcli -m "$MODEM" --simple-disconnect
+        sudo ip addr flush dev wwan0 2>/dev/null
+        sudo ip route del default dev wwan0 2>/dev/null
+        notify-send "5G Modem" "Disconnected" -i network-cellular-offline
+        ;;
+    *"Connect"*)
+        notify-send "5G Modem" "Connecting to $OPERATOR..." -i network-cellular-acquiring
+
+        # Get APN from operator (default to common APNs)
+        APN="fast.t-mobile.com"  # Default for T-Mobile US
+
+        sudo mmcli -m "$MODEM" --simple-connect="apn=$APN"
+
+        sleep 2
+        BEARER=$(mmcli -m "$MODEM" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -oP 'Bearer\s+\|.*paths:.*Bearer/\K\d+' | tail -1)
+        if [ -n "$BEARER" ]; then
+            BEARER_INFO=$(mmcli -b "$BEARER" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
+            IP=$(echo "$BEARER_INFO" | grep -oP 'address:\s+\K[\d.]+')
+            PREFIX=$(echo "$BEARER_INFO" | grep -oP 'prefix:\s+\K\d+')
+            GW=$(echo "$BEARER_INFO" | grep -oP 'gateway:\s+\K[\d.]+')
+            MTU=$(echo "$BEARER_INFO" | grep -oP 'mtu:\s+\K\d+')
+
+            # Configure network interface
+            sudo ip addr flush dev wwan0 2>/dev/null
+            sudo ip addr add "$IP/$PREFIX" dev wwan0
+            sudo ip link set wwan0 mtu "$MTU"
+            sudo ip route add default via "$GW" dev wwan0 metric 700
+
+            notify-send "5G Modem" "Connected: $IP" -i network-cellular-connected
+        else
+            notify-send "5G Modem" "Connection failed" -i network-cellular-offline
+        fi
+        ;;
+    *"Enable"*)
+        notify-send "5G Modem" "Enabling modem..." -i network-cellular-acquiring
+        sudo mmcli -m "$MODEM" --enable
+        notify-send "5G Modem" "Modem enabled - click again to connect" -i network-cellular
+        ;;
+    *"Refresh"*)
+        # Trigger waybar refresh
+        pkill -RTMIN+10 waybar 2>/dev/null
+        ;;
+esac

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -9,6 +9,7 @@
   "modules-right": [
     "group/tray-expander",
     "bluetooth",
+    "custom/5g",
     "network",
     "pulseaudio",
     "cpu",
@@ -78,6 +79,13 @@
     "interval": 3,
     "spacing": 1,
     "on-click": "omarchy-launch-wifi"
+  },
+  "custom/5g": {
+    "exec": "omarchy-5g-status",
+    "return-type": "json",
+    "interval": 5,
+    "on-click": "omarchy-launch-5g",
+    "tooltip": true
   },
   "battery": {
     "format": "{capacity}% {icon}",

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -52,6 +52,17 @@
   margin-right: 13px;
 }
 
+#custom-5g {
+  min-width: 12px;
+  margin: 0 10px;
+}
+
+#custom-5g.hidden {
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
 #custom-expand-icon {
   margin-right: 18px;
 }


### PR DESCRIPTION
## Summary
Adds waybar integration for 5G/LTE cellular modems using ModemManager.

- **omarchy-5g-status**: Waybar module showing connection status and signal strength
- **omarchy-launch-5g**: Fuzzel-based menu for connect/disconnect
- Auto-hides when no modem is detected (safe for all systems)

## Screenshots
The module appears between Bluetooth and WiFi icons, showing signal strength with cellular icons.

## Test plan
- [x] Tested on Samsung Galaxy Book 935QDC with MediaTek T700 5G modem
- [x] Module hides correctly when no modem present
- [x] Connect/disconnect workflow works via fuzzel menu
- [x] Signal strength updates every 5 seconds

## Dependencies
- `modemmanager` - for modem control
- `fuzzel` - for the connect/disconnect menu