### PR TITLE
Ensure Walker can't just die and stay dead

### DIFF
--- a/bin/omarchy-refresh-walker
+++ b/bin/omarchy-refresh-walker
@@ -5,9 +5,17 @@
 # Ensure walker is set to autostart
 mkdir -p ~/.config/autostart/
 cp $OMARCHY_PATH/default/walker/walker.desktop ~/.config/autostart/
+
+# And restarts if it crashes or is killed
+mkdir -p ~/.config/systemd/user/app-walker@autostart.service.d/
+cp $OMARCHY_PATH/default/walker/restart.conf ~/.config/systemd/user/app-walker@autostart.service.d/restart.conf
+
 systemctl --user daemon-reload
 
+# Refresh configs
 omarchy-refresh-config walker/config.toml
 omarchy-refresh-config elephant/calc.toml
 omarchy-refresh-config elephant/desktopapplications.toml
+
+# Restart service
 omarchy-restart-walker

--- a/default/walker/restart.conf
+++ b/default/walker/restart.conf
@@ -1,0 +1,3 @@
+[Service]
+Restart=always
+RestartSec=2

--- a/install/config/walker-elephant.sh
+++ b/install/config/walker-elephant.sh
@@ -4,6 +4,10 @@
 mkdir -p ~/.config/autostart/
 cp $OMARCHY_PATH/default/walker/walker.desktop ~/.config/autostart/
 
+# And is restarted if it crashes or is killed
+mkdir -p ~/.config/systemd/user/app-walker@autostart.service.d/
+cp $OMARCHY_PATH/default/walker/restart.conf ~/.config/systemd/user/app-walker@autostart.service.d/restart.conf
+
 # Create pacman hook to restart walker after updates
 sudo mkdir -p /etc/pacman.d/hooks
 sudo tee /etc/pacman.d/hooks/walker-restart.hook > /dev/null << EOF

--- a/migrations/1770375817.sh
+++ b/migrations/1770375817.sh
@@ -1,0 +1,6 @@
+echo "Ensure walker service is restarted if it's killed or crashes"
+
+mkdir -p ~/.config/systemd/user/app-walker@autostart.service.d/
+cp $OMARCHY_PATH/default/walker/restart.conf ~/.config/systemd/user/app-walker@autostart.service.d/restart.conf
+systemctl --user daemon-reload
+


### PR DESCRIPTION
Before, Walker could crash, and the service wouldn't be restarted, so user would be stuck with cold-boot lag.