### PR TITLE
Fix mkinitcpio hook persistence and vfat initramfs coverage after 3.4 upgrade failures

### DIFF
--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -9,3 +9,12 @@ if grep -q "Updating linux initcpios" "$update_log"; then
     echo
   fi
 fi
+
+# Check for disabled mkinitcpio hooks (should never happen after an update)
+hooks_dir="/usr/share/libalpm/hooks"
+if [[ -f "$hooks_dir/90-mkinitcpio-install.hook.disabled" ]] || \
+   [[ -f "$hooks_dir/60-mkinitcpio-remove.hook.disabled" ]]; then
+  echo -e '\e[31mWarning: mkinitcpio pacman hooks are disabled. Kernel upgrades will not regenerate initramfs.\e[0m'
+  echo -e '\e[31mRun: omarchy-update to restore them.\e[0m'
+  echo
+fi

--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -8,7 +8,34 @@ hyprctl dispatch tagwindow +noidle &> /dev/null || true
 # Capture update logs
 exec > >(tee "/tmp/omarchy-update.log") 2>&1
 
+restore_disabled_mkinitcpio_hooks() {
+  local hooks_dir="/usr/share/libalpm/hooks"
+  local disabled enabled
+  local changed=false
+
+  for disabled in \
+    "$hooks_dir/90-mkinitcpio-install.hook.disabled" \
+    "$hooks_dir/60-mkinitcpio-remove.hook.disabled"; do
+    enabled="${disabled%.disabled}"
+
+    if [[ -f $disabled ]]; then
+      changed=true
+
+      if [[ -f $enabled ]]; then
+        sudo rm -f "$disabled"
+      else
+        sudo mv "$disabled" "$enabled"
+      fi
+    fi
+  done
+
+  if [[ $changed == "true" ]]; then
+    echo -e "\e[32m\nRestored mkinitcpio hooks before system upgrade\e[0m"
+  fi
+}
+
 # Perform all update steps
+restore_disabled_mkinitcpio_hooks
 omarchy-update-time
 omarchy-update-keyring
 omarchy-update-available-reset

--- a/migrations/1771711738.sh
+++ b/migrations/1771711738.sh
@@ -1,0 +1,54 @@
+echo "Protect /boot vfat mounts and restore mkinitcpio hooks"
+
+MKINITCPIO_DROPIN="/etc/mkinitcpio.conf.d/zz-omarchy-vfat.conf"
+HOOKS_DIR="/usr/share/libalpm/hooks"
+changed=false
+
+sudo mkdir -p /etc/mkinitcpio.conf.d || exit 1
+
+if [[ ! -f $MKINITCPIO_DROPIN ]] || ! grep -Eq 'MODULES\+=\([^)]*\bvfat\b[^)]*\)' "$MKINITCPIO_DROPIN"; then
+  sudo tee "$MKINITCPIO_DROPIN" <<EOF >/dev/null || exit 1
+MODULES+=(vfat)
+EOF
+  changed=true
+fi
+
+restore_hook() {
+  local disabled="$1"
+  local enabled="${disabled%.disabled}"
+
+  if [[ -f $disabled ]]; then
+    changed=true
+
+    if [[ -f $enabled ]]; then
+      sudo rm -f "$disabled" || exit 1
+    else
+      sudo mv "$disabled" "$enabled" || exit 1
+    fi
+  fi
+}
+
+restore_hook "$HOOKS_DIR/90-mkinitcpio-install.hook.disabled"
+restore_hook "$HOOKS_DIR/60-mkinitcpio-remove.hook.disabled"
+
+if [[ $changed == "true" ]]; then
+  if ! findmnt -n /boot >/dev/null; then
+    echo "Mounting /boot before rebuilding boot artifacts"
+    sudo mount /boot || exit 1
+  fi
+
+  if omarchy-cmd-present limine-mkinitcpio; then
+    sudo limine-mkinitcpio || exit 1
+  elif omarchy-cmd-present mkinitcpio; then
+    sudo mkinitcpio -P || exit 1
+  else
+    echo "Error: no initramfs rebuild command found"
+    exit 1
+  fi
+
+  if omarchy-cmd-present limine-update; then
+    sudo limine-update || exit 1
+  fi
+
+  omarchy-state set reboot-required
+fi


### PR DESCRIPTION
I hit this while switching channels and upgrading to Omarchy 3.4: after the upgrade, mkinitcpio pacman hooks were left in `*.hook.disabled`, and boot also failed mounting `/boot` with `unknown filesystem type 'vfat'`.

After tracing logs and the install/update flow, I found this can happen if install exits after hooks are disabled but before they are restored. In that state, later kernel upgrades can skip initramfs regeneration. On EFI systems, that gets worse because `vfat` for `/boot` is not guaranteed to be included in initramfs when relying on autodetect.

This change hardens that entire path instead of patching a single symptom. It restores disabled mkinitcpio hooks on installer exit/error paths, restores them again before system package upgrades, and backfills existing systems with a migration that adds `MODULES+=(vfat)`, repairs disabled hooks, rebuilds boot artifacts, and marks reboot-required when changes are applied. For fresh installs, `limine-snapper.sh` now always writes the vfat drop-in, and it now runs with `set -e` so failures stop immediately in its own shell context. There is also a post-update warning if mkinitcpio hooks are still disabled, since that should now be exceptional.

The goal is to close the exact failure class I saw during the 3.4 transition and cover fresh installs, upgrades, and already-affected systems.
