### PR TITLE
Fix custom theme overrides by centralizing colors and moving imports

### DIFF
--- a/config/swayosd/style.css
+++ b/config/swayosd/style.css
@@ -1,22 +1,22 @@
-@import "../omarchy/current/theme/swayosd.css";
+@import "../omarchy/current/theme/colors.css";
 
 window {
   border-radius: 0;
   opacity: 0.97;
-  border: 2px solid @border-color;
+  border: 2px solid @foreground;
 
-  background-color: @background-color;
+  background-color: @background;
 }
 
 label {
   font-family: 'JetBrainsMono Nerd Font';
   font-size: 11pt;
 
-  color: @label;
+  color: @foreground;
 }
 
 image {
-  color: @image;
+  color: @foreground;
 }
 
 progressbar {
@@ -24,5 +24,7 @@ progressbar {
 }
 
 progress {
-  background-color: @progress;
+  background-color: @accent;
 }
+
+@import "../omarchy/current/theme/swayosd.css";

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -1,4 +1,4 @@
-@import "../omarchy/current/theme/waybar.css";
+@import "../omarchy/current/theme/colors.css";
 
 * {
   background-color: @background;
@@ -7,7 +7,7 @@
   border: none;
   border-radius: 0;
   min-height: 0;
-  font-family: 'JetBrainsMono Nerd Font';
+  font-family: "JetBrainsMono Nerd Font";
   font-size: 12px;
 }
 
@@ -98,3 +98,5 @@ tooltip {
 #custom-voxtype.recording {
   color: #a55555;
 }
+
+@import "../omarchy/current/theme/waybar.css";

--- a/default/themed/colors.css.tpl
+++ b/default/themed/colors.css.tpl
@@ -1,0 +1,23 @@
+@define-color accent {{ accent }};
+@define-color foreground {{ foreground }};
+@define-color background {{ background }};
+@define-color cursor {{ cursor }};
+@define-color selection_foreground {{ selection_foreground }};
+@define-color selection_background {{ selection_background }};
+
+@define-color color0 {{ color0 }};
+@define-color color1 {{ color1 }};
+@define-color color2 {{ color2 }};
+@define-color color3 {{ color3 }};
+@define-color color4 {{ color4 }};
+@define-color color5 {{ color5 }};
+@define-color color6 {{ color6 }};
+@define-color color7 {{ color7 }};
+@define-color color8 {{ color8 }};
+@define-color color9 {{ color9 }};
+@define-color color10 {{ color10 }};
+@define-color color11 {{ color11 }};
+@define-color color12 {{ color12 }};
+@define-color color13 {{ color13 }};
+@define-color color14 {{ color14 }};
+@define-color color15 {{ color15 }};

--- a/default/themed/swayosd.css.tpl
+++ b/default/themed/swayosd.css.tpl
@@ -1,5 +1,0 @@
-@define-color background-color {{ background }};
-@define-color border-color {{ foreground }};
-@define-color label {{ foreground }};
-@define-color image {{ foreground }};
-@define-color progress {{ accent }};

--- a/default/themed/walker.css.tpl
+++ b/default/themed/walker.css.tpl
@@ -1,6 +1,0 @@
-@define-color selected-text {{ accent }};
-@define-color text {{ foreground }};
-@define-color base {{ background }};
-@define-color border {{ foreground }};
-@define-color foreground {{ foreground }};
-@define-color background {{ background }};

--- a/default/themed/waybar.css.tpl
+++ b/default/themed/waybar.css.tpl
@@ -1,2 +1,0 @@
-@define-color foreground {{ foreground }};
-@define-color background {{ background }};

--- a/default/walker/themes/omarchy-default/style.css
+++ b/default/walker/themes/omarchy-default/style.css
@@ -1,4 +1,4 @@
-@import "../../../../../../../.config/omarchy/current/theme/walker.css";
+@import "../../../../../../../.config/omarchy/current/theme/colors.css";
 
 * {
   all: unset;
@@ -7,7 +7,7 @@
 * {
   font-family: monospace;
   font-size: 18px;
-  color: @text;
+  color: @foreground;
 }
 
 scrollbar {
@@ -23,9 +23,9 @@ scrollbar {
 }
 
 .box-wrapper {
-  background: alpha(@base, 0.95);
+  background: alpha(@background, 0.95);
   padding: 20px;
-  border: 2px solid @border;
+  border: 2px solid @foreground;
 }
 
 .preview-box {
@@ -35,7 +35,7 @@ scrollbar {
 }
 
 .search-container {
-  background: @base;
+  background: @background;
   padding: 10px;
 }
 
@@ -75,7 +75,7 @@ child:selected .item-box {
 }
 
 child:selected .item-box * {
-  color: @selected-text;
+  color: @accent;
 }
 
 .item-box {
@@ -114,3 +114,5 @@ child:selected .item-box * {
 
 .preview {
 }
+
+@import "../../../../../../../.config/omarchy/current/theme/walker.css";


### PR DESCRIPTION
TLDR: Fixed custom themes sometimes being unable to override default styling due to import order.

Previously, each component (waybar, swayosd, walker) defined its own color variables in separate .tpl files and imported them at the top of config files, making it difficult for custom themes to override defaults. Centralized all color definitions into a single colors.css.tpl and standardized the import order across config files: colors.css at the top, default styling in the middle, theme overrides at the bottom. This lets custom themes loaded at the bottom cleanly override any default styling above them.

Remapped component specific variable names to the standard ones from colors.css (e.g. base to background, text to foreground) and emptied the now redundant waybar.css.tpl, swayosd.css.tpl, and walker.css.tpl.