### PR TITLE
Move active audio streams when switching output

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -58,6 +58,9 @@ next_sink_volume_icon="sink-volume-${icon_state}-symbolic"
 
 if [[ $next_sink_name != $current_sink_name ]]; then
   pactl set-default-sink "$next_sink_name"
+  pactl list sink-inputs short | awk '{print $1}' | while read -r input_id; do
+    pactl move-sink-input "$input_id" "$next_sink_name"
+  done
 fi
 
 swayosd-client \


### PR DESCRIPTION
When switching audio output with Super + Mute, I noticed that apps already playing audio (Zoom, Spotify etc) stayed routed to the old output. Only newly opened apps would use the new one.

I ran this before and after hitting the keybind (SUPER + Mute):

```bash
pactl get-default-sink && pactl list sink-inputs short
```

Before switching:
```
alsa_output.usb-Apple__Inc._EarPods    ← earphones were default
2246    2115    2245    PipeWire        ← Zoom/Spotify stream IDs
```

After switching:
```
alsa_output.pci-...Speaker             ← default changed to speakers ✓
2315    2115    2245    PipeWire        ← same stream IDs, still on earphones ✗
```

The stream IDs `2115` and `2245` were identical before and after — meaning Zoom and Spotify hadn't moved at all. The default changed but the already-running apps were never told about it.

## Root cause

The original script only runs `pactl set-default-sink` which updates the default output for new apps only. PipeWire does not automatically move already-running streams when the default changes.

## Fix

After setting the new default sink, I added a step that grabs every app currently playing audio and explicitly moves it to the new output:

```bash
pactl list sink-inputs short | awk '{print $1}' | while read -r input_id; do
  pactl move-sink-input "$input_id" "$next_sink_name"
done
```

`pactl list sink-inputs short` lists every app currently playing audio, `awk '{print $1}'` grabs just their ID numbers, and `pactl move-sink-input` moves each one to the new output one by one.
