### PR TITLE
Add --isolate option for webapps to run in separate browser process

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -1,7 +1,35 @@
 #!/bin/bash
 
 # omarchy:summary=Launch a URL as a web app in the default supported browser
-# omarchy:args=<url>
+# omarchy:args=<url> [--isolate|--isolate=<name>] [browser-flags...]
+# omarchy:examples=omarchy launch-webapp https://example.com | omarchy launch-webapp https://mail.example.com --isolate=mail
+
+# --isolate / --isolate=<name> starts a separate browser process via
+# --user-data-dir, so a crash in the webapp cannot take down the main browser.
+
+URL="$1"
+shift
+
+ISOLATE=false
+ISOLATE_NAME=""
+EXTRA_ARGS=()
+while (($# > 0)); do
+  case "$1" in
+  --isolate)
+    ISOLATE=true
+    shift
+    ;;
+  --isolate=*)
+    ISOLATE=true
+    ISOLATE_NAME="${1#--isolate=}"
+    shift
+    ;;
+  *)
+    EXTRA_ARGS+=("$1")
+    shift
+    ;;
+  esac
+done
 
 browser=$(xdg-settings get default-web-browser)
 
@@ -10,4 +38,16 @@ google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+browser_bin=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+
+isolation_args=()
+if [[ $ISOLATE == true ]]; then
+  if [[ -z $ISOLATE_NAME ]]; then
+    ISOLATE_NAME=$(sed -E 's|^https?://||; s|/.*||; s|^www\.||' <<<"$URL")
+  fi
+  data_dir="$HOME/.local/share/omarchy/webapps/$ISOLATE_NAME"
+  mkdir -p "$data_dir"
+  isolation_args=(--user-data-dir="$data_dir")
+fi
+
+exec setsid uwsm-app -- "$browser_bin" --app="$URL" "${isolation_args[@]}" "${EXTRA_ARGS[@]}"

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Create a desktop launcher for a web app
-# omarchy:args=[name url icon-url-or-name [custom-exec] [mime-types]]
+# omarchy:args=[--isolate] [name url icon-url-or-name [custom-exec] [mime-types]]
 
 set -e
 
@@ -65,6 +65,17 @@ fetch_site_icon() {
     download_icon "https://www.google.com/s2/favicons?domain=${site_url}&sz=256" "$dest"
 }
 
+ISOLATE=false
+ARGS=()
+for arg in "$@"; do
+  if [[ $arg == "--isolate" ]]; then
+    ISOLATE=true
+  else
+    ARGS+=("$arg")
+  fi
+done
+set -- "${ARGS[@]}"
+
 if (( $# < 3 )); then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
@@ -86,6 +97,12 @@ if (( $# < 3 )); then
   CUSTOM_EXEC=""
   MIME_TYPES=""
   INTERACTIVE_MODE=true
+
+  if [[ $ISOLATE != true ]]; then
+    if gum confirm "Isolate this webapp? (separate process, won't crash main browser, but requires separate login)"; then
+      ISOLATE=true
+    fi
+  fi
 else
   APP_NAME="$1"
   APP_URL="$2"
@@ -128,8 +145,17 @@ else
   ICON_VALUE=$(icon_name_from_ref "$ICON_REF")
 fi
 
+ISOLATE_FLAG=""
+if [[ $ISOLATE == true ]]; then
+  SANITIZED_NAME=$(safe_icon_name "$APP_NAME")
+  if [[ -z $SANITIZED_NAME ]]; then
+    SANITIZED_NAME="webapp"
+  fi
+  ISOLATE_FLAG=" --isolate=$SANITIZED_NAME"
+fi
+
 # Use custom exec if provided, otherwise default behavior
-EXEC_COMMAND="${CUSTOM_EXEC:-omarchy-launch-webapp $APP_URL}"
+EXEC_COMMAND="${CUSTOM_EXEC:-omarchy-launch-webapp $APP_URL$ISOLATE_FLAG}"
 
 # Create application .desktop file
 DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
@@ -155,5 +181,9 @@ fi
 chmod +x "$DESKTOP_FILE"
 
 if [[ $INTERACTIVE_MODE == "true" ]]; then
-  echo -e "You can now find $APP_NAME using the app launcher (SUPER + SPACE)\n"
+  if [[ $ISOLATE == true ]]; then
+    echo -e "You can now find $APP_NAME using the app launcher (SUPER + SPACE)\nThis webapp will run in an isolated process. You'll need to log in separately.\n"
+  else
+    echo -e "You can now find $APP_NAME using the app launcher (SUPER + SPACE)\n"
+  fi
 fi

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -8,6 +8,7 @@ set -e
 ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 OLD_ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
+WEBAPP_DATA_DIR="$HOME/.local/share/omarchy/webapps"
 
 if (( $# == 0 )); then
   # Find all web apps
@@ -34,7 +35,14 @@ if [[ -z $APP_NAME ]]; then
 fi
 
 icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
+DESKTOP_FILE="$DESKTOP_DIR/$APP_NAME.desktop"
+if [[ -f $DESKTOP_FILE ]]; then
+  isolate_name=$(sed -n 's/.*--isolate=\([^ ]*\).*/\1/p' "$DESKTOP_FILE")
+  if [[ -n $isolate_name && -d $WEBAPP_DATA_DIR/$isolate_name ]]; then
+    rm -rf "$WEBAPP_DATA_DIR/$isolate_name"
+  fi
+fi
+rm -f "$DESKTOP_FILE"
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then

--- a/bin/omarchy-webapp-remove-all
+++ b/bin/omarchy-webapp-remove-all
@@ -7,6 +7,7 @@ set -e
 APP_DIR="${1:-$HOME/.local/share/applications}"
 ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 OLD_ICON_DIR="$HOME/.local/share/applications/icons"
+WEBAPP_DATA_DIR="$HOME/.local/share/omarchy/webapps"
 
 echo "Scanning for web apps in $APP_DIR..."
 
@@ -26,6 +27,10 @@ for file in "${webapp_desktop_files[@]}"; do
   app_name=$(basename "$file" .desktop)
   icon_name=$(printf '%s\n' "$app_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
   echo "Removing web app: $app_name"
+  isolate_name=$(sed -n 's/.*--isolate=\([^ ]*\).*/\1/p' "$file")
+  if [[ -n $isolate_name && -d $WEBAPP_DATA_DIR/$isolate_name ]]; then
+    rm -rf "$WEBAPP_DATA_DIR/$isolate_name"
+  fi
   rm -f "$file"
   rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$app_name.png" "$OLD_ICON_DIR/$app_name.png"
 done

--- a/test/shell.d/webapp-isolation-test.sh
+++ b/test/shell.d/webapp-isolation-test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command sed
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+mock_bin="$test_tmp/bin"
+launch_log="$test_tmp/launch.log"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications"
+
+cat >"$test_home/.local/share/applications/chromium.desktop" <<'EOF'
+[Desktop Entry]
+Exec=chromium %U
+EOF
+
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+echo chromium.desktop
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH_LOG"
+SH
+
+cat >"$mock_bin/gtk-update-icon-cache" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/update-desktop-database" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$mock_bin"/*
+
+icon_file="$test_tmp/icon.png"
+printf 'fake-icon' >"$icon_file"
+
+export HOME="$test_home"
+export PATH="$mock_bin:$PATH"
+export OMARCHY_TEST_LAUNCH_LOG="$launch_log"
+export OMARCHY_REMOVE_NOTIFY=false
+
+bash "$ROOT/bin/omarchy-webapp-install" "Mail App" "https://mail.example.com" "$icon_file" --isolate
+
+desktop="$test_home/.local/share/applications/Mail App.desktop"
+[[ -f $desktop ]] || fail "isolated install writes a desktop file"
+grep -Fq 'Exec=omarchy-launch-webapp https://mail.example.com --isolate=mail-app' "$desktop" ||
+  fail "isolated install writes --isolate into Exec" "$(cat "$desktop")"
+pass "isolated install writes --isolate into Exec"
+
+bash "$ROOT/bin/omarchy-webapp-install" "Shared App" "https://shared.example.com" "$icon_file"
+shared_desktop="$test_home/.local/share/applications/Shared App.desktop"
+grep -Fq 'Exec=omarchy-launch-webapp https://shared.example.com' "$shared_desktop" ||
+  fail "non-isolated install writes a plain Exec" "$(cat "$shared_desktop")"
+if grep -q -- '--isolate' "$shared_desktop"; then
+  fail "non-isolated install does not pass --isolate" "$(cat "$shared_desktop")"
+fi
+pass "non-isolated install leaves Exec unisolated"
+
+: >"$launch_log"
+bash "$ROOT/bin/omarchy-launch-webapp" "https://mail.example.com" --isolate=mail-app
+grep -Fq -- '--app=https://mail.example.com' "$launch_log" ||
+  fail "isolated launch keeps --app" "$(cat "$launch_log")"
+grep -Fq -- "--user-data-dir=$test_home/.local/share/omarchy/webapps/mail-app" "$launch_log" ||
+  fail "isolated launch passes --user-data-dir" "$(cat "$launch_log")"
+[[ -d $test_home/.local/share/omarchy/webapps/mail-app ]] ||
+  fail "isolated launch creates the profile directory"
+pass "isolated launch uses a separate user-data-dir"
+
+: >"$launch_log"
+bash "$ROOT/bin/omarchy-launch-webapp" "https://shared.example.com"
+grep -Fq -- '--app=https://shared.example.com' "$launch_log" ||
+  fail "plain launch keeps --app" "$(cat "$launch_log")"
+if grep -q -- '--user-data-dir' "$launch_log"; then
+  fail "plain launch does not pass --user-data-dir" "$(cat "$launch_log")"
+fi
+pass "plain launch does not isolate the browser process"
+
+mkdir -p "$test_home/.local/share/omarchy/webapps/mail-app"
+printf 'profile' >"$test_home/.local/share/omarchy/webapps/mail-app/marker"
+bash "$ROOT/bin/omarchy-webapp-remove" "Mail App"
+[[ ! -e $desktop ]] || fail "remove deletes the desktop file"
+[[ ! -d $test_home/.local/share/omarchy/webapps/mail-app ]] ||
+  fail "remove deletes the isolated profile"
+pass "remove deletes the isolated profile"
+
+bash "$ROOT/bin/omarchy-webapp-install" "Another App" "https://other.example.com" "$icon_file" --isolate
+mkdir -p "$test_home/.local/share/omarchy/webapps/another-app"
+printf 'profile' >"$test_home/.local/share/omarchy/webapps/another-app/marker"
+bash "$ROOT/bin/omarchy-webapp-remove-all" "$test_home/.local/share/applications"
+[[ ! -d $test_home/.local/share/omarchy/webapps/another-app ]] ||
+  fail "remove-all deletes isolated profiles"
+pass "remove-all deletes isolated profiles"


### PR DESCRIPTION
## Summary

- Adds `--isolate` flag to `omarchy-launch-webapp` that launches webapps with `--user-data-dir=`, creating a fully separate browser process tree
- Adds interactive `gum confirm` prompt and `--isolate` flag to `omarchy-webapp-install`
- Cleans up isolated data directories in `omarchy-webapp-remove` and `omarchy-webapp-remove-all`

Browser-agnostic — works with all Chromium-based browsers supported by `omarchy-launch-webapp` (Chrome, Brave, Edge, Opera, Vivaldi, Helium). Isolated data stored at `~/.local/share/omarchy/webapps/<name>`.

Retargeted from `dev` to `quattro`. The original issue was converted to a suggestion: https://github.com/basecamp/omarchy/discussions/6250

## Test plan

- [x] Programmatic install with `--isolate` creates correct `.desktop` Exec line
- [x] Isolated webapp launches with separate `--user-data-dir` and its own process tree
- [x] Killing isolated webapp does not affect main browser
- [x] `omarchy-webapp-remove` and `omarchy-webapp-remove-all` clean up isolated data directories
- [x] Non-isolated webapps still work as before (no regression)
- [x] `test/shell.d/webapp-isolation-test.sh` and `./test/cli` pass