### PR TITLE
Add script to unlock screen after lockscreen app crash

### DIFF
--- a/bin/omarchy-unfuck-hyprland
+++ b/bin/omarchy-unfuck-hyprland
@@ -1,0 +1,3 @@
+#!/bin/bash
+hyprctl --instance 0 'keyword misc:allow_session_lock_restore 1'
+hyprctl --instance 0 'dispatch exec hyprlock'


### PR DESCRIPTION
## Problem
My lockscreen app frequently (multiple times per day) crashes and shows this error screen. This script performs the recovery steps suggested on the error screen.


<img width="1080" height="714" alt="xa876px6id7g1" src="https://github.com/user-attachments/assets/f7ee8339-4012-4962-a2b8-cfd81f3cf028" />


## Usage
Use the recovery script from a TTY to restore access.

```bash
Ctrl + Alt + F3
login
omarchy-unfuck-hyprland
Ctrl + Alt + F1
```
