### PR TITLE
Fix monitor scaling toggle for multi-monitor setups

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling-cycle
+++ b/bin/omarchy-hyprland-monitor-scaling-cycle
@@ -4,9 +4,10 @@
 MONITOR_INFO=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)')
 ACTIVE_MONITOR=$(echo "$MONITOR_INFO" | jq -r '.name')
 CURRENT_SCALE=$(echo "$MONITOR_INFO" | jq -r '.scale')
-WIDTH=$(echo "$MONITOR_INFO" | jq -r '.width')
-HEIGHT=$(echo "$MONITOR_INFO" | jq -r '.height')
-REFRESH_RATE=$(echo "$MONITOR_INFO" | jq -r '.refreshRate')
+ACTIVE_MODE=$(echo "$MONITOR_INFO" | jq -r '"\(.width)x\(.height)@\(.refreshRate | round)"')
+ACTIVE_X=$(echo "$MONITOR_INFO" | jq -r '.x')
+ACTIVE_Y=$(echo "$MONITOR_INFO" | jq -r '.y')
+ACTIVE_WIDTH=$(echo "$MONITOR_INFO" | jq -r '.width')
 
 # Cycle through scales: 1 → 1.6 → 2 → 3 → 1
 CURRENT_INT=$(awk -v s="$CURRENT_SCALE" 'BEGIN { printf "%.0f", s * 10 }')
@@ -18,5 +19,41 @@ case "$CURRENT_INT" in
 *) NEW_SCALE=1 ;;
 esac
 
-hyprctl keyword monitor "$ACTIVE_MONITOR,${WIDTH}x${HEIGHT}@${REFRESH_RATE},auto,$NEW_SCALE"
+OLD_LOGICAL_WIDTH=$(awk -v w="$ACTIVE_WIDTH" -v s="$CURRENT_SCALE" 'BEGIN { printf "%.0f", w / s }')
+NEW_LOGICAL_WIDTH=$(awk -v w="$ACTIVE_WIDTH" -v s="$NEW_SCALE" 'BEGIN { printf "%.0f", w / s }')
+DELTA=$((NEW_LOGICAL_WIDTH - OLD_LOGICAL_WIDTH))
+
+# Place adjacent monitors at exact absolute positions instead of relative delta
+# to avoid drift from Hyprland auto-adjusting positions between commands
+reposition_adjacent_monitors() {
+  local next_x=$((ACTIVE_X + NEW_LOGICAL_WIDTH))
+  while IFS= read -r other; do
+    OTHER_NAME=$(echo "$other" | jq -r '.name')
+    OTHER_MODE=$(echo "$other" | jq -r '"\(.width)x\(.height)@\(.refreshRate | round)"')
+    OTHER_SCALE=$(echo "$other" | jq -r '.scale')
+    OTHER_WIDTH=$(echo "$other" | jq -r '.width')
+    OTHER_Y=$(echo "$other" | jq -r '.y')
+    hyprctl keyword monitor "$OTHER_NAME,$OTHER_MODE,${next_x}x${OTHER_Y},$OTHER_SCALE"
+    local other_lw=$(awk -v w="$OTHER_WIDTH" -v s="$OTHER_SCALE" 'BEGIN { printf "%.0f", w / s }')
+    next_x=$((next_x + other_lw))
+  done < <(hyprctl monitors -j | jq -c --arg active "$ACTIVE_MONITOR" --argjson ax "$ACTIVE_X" \
+    '[.[] | select(.name != $active and .x > $ax)] | sort_by(.x) | .[]')
+}
+
+if [ "$DELTA" -gt 0 ]; then
+  # Monitor is getting wider — move adjacent monitors out of the way first to prevent overlap
+  reposition_adjacent_monitors
+  hyprctl keyword monitor "$ACTIVE_MONITOR,$ACTIVE_MODE,${ACTIVE_X}x${ACTIVE_Y},$NEW_SCALE"
+elif [ "$DELTA" -lt 0 ]; then
+  # Monitor is getting narrower — scale first, then close the gap
+  hyprctl keyword monitor "$ACTIVE_MONITOR,$ACTIVE_MODE,${ACTIVE_X}x${ACTIVE_Y},$NEW_SCALE"
+  reposition_adjacent_monitors
+else
+  hyprctl keyword monitor "$ACTIVE_MONITOR,$ACTIVE_MODE,${ACTIVE_X}x${ACTIVE_Y},$NEW_SCALE"
+fi
+
+# Restore layout settings that may have been reset by monitor reconfiguration
+hyprctl keyword source ~/.local/share/omarchy/default/hypr/looknfeel.conf
+hyprctl keyword source ~/.config/hypr/looknfeel.conf
+
 notify-send -u low "󰍹    Display scaling set to ${NEW_SCALE}x"


### PR DESCRIPTION
## Problem

On multi-monitor setups, using `Super+/` to cycle monitor scaling causes several issues:

1. **Monitor positions swap.** The script used `auto` for position, which at runtime places monitors by hardware detection order (internal display first) rather than config order — swapping left/right.

2. **Mouse can't cross between monitors.** Changing a monitor's scale changes its logical width (e.g. 2560px at 1x → 1600px at 1.6x), but adjacent monitors aren't repositioned — leaving a dead zone the mouse can't cross.

3. **Window gaps and layout settings are lost.** `hyprctl keyword monitor` resets layout properties like `gaps_in`, `gaps_out`, border size, and rounding.

4. **Position drift after full cycle.** Using relative deltas to reposition monitors causes cumulative drift (e.g. 53px after a 1x→1.6x→2x→3x→1x cycle) because Hyprland auto-adjusts positions between sequential commands.

## Fix

- **Preserve position:** use each monitor's current `x`/`y` instead of `auto`.
- **Reposition adjacent monitors with absolute positioning:** compute exact positions from scratch (`active_x + new_logical_width`, then stack each subsequent monitor) to avoid drift from Hyprland's inter-command adjustments.
- **Order operations to prevent overlap warnings:** when the monitor gets wider (scale decreasing), move adjacent monitors out of the way *first*; when it gets narrower (scale increasing), scale *first*, then close the gap.
- **Preserve current mode:** use each monitor's actual `width x height @ refreshRate` instead of `preferred`, which may select a lower refresh rate.
- **Restore layout settings:** re-source `looknfeel.conf` after reconfiguration to restore gaps, borders, rounding, and other layout properties.

## Note

Only repositions monitors to the right of the active one. This covers the common layout (laptop + external to the right). Monitors to the left are unaffected.

## Testing

Tested on a 2-monitor setup (external left at 2560x1440@360Hz + laptop right at 2560x1600@240Hz) through full scale cycles (1x → 1.6x → 2x → 3x → 1x) on both monitors. Positions return to exact original values after a full cycle, mouse movement works at every scale, no overlap warnings, and layout settings are preserved.
