### PR TITLE
Add Calibre theme integration

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -201,6 +201,7 @@ post_theme_commands=(
   omarchy-theme-set-browser
   omarchy-theme-set-vscode
   omarchy-theme-set-obsidian
+  omarchy-theme-set-calibre
   omarchy-theme-set-keyboard
 )
 

--- a/bin/omarchy-theme-set-calibre
+++ b/bin/omarchy-theme-set-calibre
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Sync Omarchy theme to Calibre
+
+omarchy-cmd-present calibre || exit 0
+
+CURRENT_THEME_DIR="$HOME/.config/omarchy/current/theme"
+COLORS_FILE="$CURRENT_THEME_DIR/colors.toml"
+
+[[ -f $COLORS_FILE ]] || exit 0
+
+# Parse colors from TOML
+declare -A colors
+while IFS='=' read -r key value; do
+  key="${key//[\"\' ]/}"
+  [[ $key && $key != \#* ]] || continue
+  value="${value#*[\"\']}"
+  value="${value%%[\"\']*}"
+  colors[$key]="$value"
+done <"$COLORS_FILE"
+
+bg="${colors[background]}"
+fg="${colors[foreground]}"
+accent="${colors[accent]}"
+sel_bg="${colors[selection_background]}"
+sel_fg="${colors[selection_foreground]}"
+
+# Blend a hex color toward black or white by a percentage (0-100)
+blend() {
+  local hex="${1#\#}"
+  local factor="$2"
+  local target="$3"
+  local r=$((16#${hex:0:2}))
+  local g=$((16#${hex:2:2}))
+  local b=$((16#${hex:4:2}))
+
+  if [[ $target == "black" ]]; then
+    r=$((r * (100 - factor) / 100))
+    g=$((g * (100 - factor) / 100))
+    b=$((b * (100 - factor) / 100))
+  else
+    r=$((r + (255 - r) * factor / 100))
+    g=$((g + (255 - g) * factor / 100))
+    b=$((b + (255 - b) * factor / 100))
+  fi
+
+  printf '#%02x%02x%02x' "$r" "$g" "$b"
+}
+
+# Derive shades for palette roles with no direct colors.toml mapping
+if [[ -f $CURRENT_THEME_DIR/light.mode ]]; then
+  palette_type="light"
+  alt_base=$(blend "$bg" 5 black)
+  placeholder=$(blend "$fg" 40 white)
+else
+  palette_type="dark"
+  alt_base=$(blend "$bg" 15 white)
+  placeholder=$(blend "$fg" 40 black)
+fi
+
+# Kill Calibre BEFORE writing so its shutdown doesn't overwrite our changes
+calibre_was_running=false
+if pgrep -x calibre >/dev/null 2>&1; then
+  calibre_was_running=true
+  pkill -x calibre 2>/dev/null
+  while pgrep -x calibre >/dev/null 2>&1; do sleep 0.2; done
+fi
+
+# Write palette into Calibre's gprefs via calibre-debug
+calibre-debug -c "
+from calibre.gui2 import gprefs
+
+palette = {
+    'Window': '$bg',
+    'WindowText': '$fg',
+    'Base': '$bg',
+    'Text': '$fg',
+    'Button': '$bg',
+    'ButtonText': '$fg',
+    'BrightText': '${colors[color1]}',
+    'Highlight': '$sel_bg',
+    'HighlightedText': '$sel_fg',
+    'Link': '$accent',
+    'LinkVisited': '${colors[color5]}',
+    'AlternateBase': '$alt_base',
+    'ToolTipBase': '$alt_base',
+    'ToolTipText': '$fg',
+    'PlaceholderText': '$placeholder',
+}
+
+palettes = gprefs['${palette_type}_palettes']
+palettes['Omarchy'] = palette
+gprefs['${palette_type}_palettes'] = palettes
+gprefs['${palette_type}_palette_name'] = 'Omarchy'
+gprefs['color_palette'] = '${palette_type}'
+" 2>/dev/null
+
+# Relaunch Calibre if it was running
+if $calibre_was_running; then
+  setsid uwsm-app -- calibre --detach >/dev/null 2>&1 &
+fi

--- a/bin/omarchy-theme-set-calibre
+++ b/bin/omarchy-theme-set-calibre
@@ -60,8 +60,16 @@ fi
 
 # Kill Calibre BEFORE writing so its shutdown doesn't overwrite our changes
 calibre_was_running=false
+calibre_workspace=""
 if pgrep -x calibre >/dev/null 2>&1; then
   calibre_was_running=true
+  calibre_workspace=$(hyprctl clients -j 2>/dev/null | python3 -c "
+import json, sys
+for c in json.load(sys.stdin):
+    if c.get('class') == 'calibre-gui':
+        print(c['workspace']['id'])
+        break
+" 2>/dev/null)
   pkill -x calibre 2>/dev/null
   while pgrep -x calibre >/dev/null 2>&1; do sleep 0.2; done
 fi
@@ -95,7 +103,16 @@ gprefs['${palette_type}_palette_name'] = 'Omarchy'
 gprefs['color_palette'] = '${palette_type}'
 " 2>/dev/null
 
-# Relaunch Calibre if it was running
+# Relaunch Calibre on its original workspace if it was running
 if $calibre_was_running; then
+  if [[ -n $calibre_workspace ]]; then
+    hyprctl keyword windowrule "match:class calibre-gui, workspace $calibre_workspace silent" >/dev/null 2>&1
+  fi
+
   setsid uwsm-app -- calibre --detach >/dev/null 2>&1 &
+
+  # Clean up the temporary window rule after Calibre has opened
+  if [[ -n $calibre_workspace ]]; then
+    (sleep 10 && hyprctl keyword windowrule "match:class calibre-gui, workspace unset" >/dev/null 2>&1) &
+  fi
 fi

--- a/bin/omarchy-theme-set-calibre
+++ b/bin/omarchy-theme-set-calibre
@@ -9,6 +9,13 @@
 # ANSI alias (color1..color15), and the light/dark mode resolve identically
 # to every other theme consumer. Calibre's Qt palette needs fifteen roles;
 # the roles with no direct colors.toml mapping are derived with blend().
+#
+# Calibre only reads its palette at startup, and its shutdown handler saves
+# gprefs from memory back to disk. So applying a theme requires killing a
+# running Calibre before writing, then relaunching it. To avoid bouncing
+# Calibre when nothing changed (e.g. re-selecting the current theme), the
+# resolved palette is compared against the stored one first; if identical
+# the script exits without touching Calibre.
 
 omarchy-cmd-present calibre || exit 0
 
@@ -61,6 +68,44 @@ else
   placeholder=$(blend "$fg" 40 black)
 fi
 
+# The palette dict, built once and reused by both the change check and the write.
+PALETTE_PY="
+palette = {
+    'Window': '$bg',
+    'WindowText': '$fg',
+    'Base': '$bg',
+    'Text': '$fg',
+    'Button': '$bg',
+    'ButtonText': '$fg',
+    'BrightText': '$bright_text',
+    'Highlight': '$sel_bg',
+    'HighlightedText': '$sel_fg',
+    'Link': '$accent',
+    'LinkVisited': '$link_visited',
+    'AlternateBase': '$alt_base',
+    'ToolTipBase': '$alt_base',
+    'ToolTipText': '$fg',
+    'PlaceholderText': '$placeholder',
+}
+"
+
+# Skip kill/write/restart entirely when the stored palette already matches.
+if [[ $(calibre-debug -c "
+from calibre.gui2 import gprefs
+
+$PALETTE_PY
+
+current = gprefs.get('${palette_type}_palettes', {}).get('Omarchy')
+if (current == palette
+        and gprefs.get('${palette_type}_palette_name') == 'Omarchy'
+        and gprefs.get('color_palette') == '${palette_type}'):
+    print('UNCHANGED')
+else:
+    print('CHANGED')
+" 2>/dev/null) == "UNCHANGED" ]]; then
+  exit 0
+fi
+
 # Kill Calibre BEFORE writing so its shutdown doesn't overwrite our changes
 calibre_was_running=false
 calibre_workspace=""
@@ -81,23 +126,7 @@ fi
 calibre-debug -c "
 from calibre.gui2 import gprefs
 
-palette = {
-    'Window': '$bg',
-    'WindowText': '$fg',
-    'Base': '$bg',
-    'Text': '$fg',
-    'Button': '$bg',
-    'ButtonText': '$fg',
-    'BrightText': '$bright_text',
-    'Highlight': '$sel_bg',
-    'HighlightedText': '$sel_fg',
-    'Link': '$accent',
-    'LinkVisited': '$link_visited',
-    'AlternateBase': '$alt_base',
-    'ToolTipBase': '$alt_base',
-    'ToolTipText': '$fg',
-    'PlaceholderText': '$placeholder',
-}
+$PALETTE_PY
 
 palettes = gprefs['${palette_type}_palettes']
 palettes['Omarchy'] = palette

--- a/bin/omarchy-theme-set-calibre
+++ b/bin/omarchy-theme-set-calibre
@@ -1,29 +1,34 @@
 #!/bin/bash
 
-# Sync Omarchy theme to Calibre
+# omarchy:summary=Apply the current theme to Calibre
+# omarchy:hidden=true
+
+# Sync the active Omarchy theme to Calibre's custom palette system.
+#
+# colors.toml is resolved through omarchy-theme-color so every semantic key,
+# ANSI alias (color1..color15), and the light/dark mode resolve identically
+# to every other theme consumer. Calibre's Qt palette needs fifteen roles;
+# the roles with no direct colors.toml mapping are derived with blend().
 
 omarchy-cmd-present calibre || exit 0
 
-CURRENT_THEME_DIR="$HOME/.config/omarchy/current/theme"
-COLORS_FILE="$CURRENT_THEME_DIR/colors.toml"
+THEME_DIR="$HOME/.local/state/omarchy/current/theme"
+COLORS_FILE="$THEME_DIR/colors.toml"
 
 [[ -f $COLORS_FILE ]] || exit 0
 
-# Parse colors from TOML
-declare -A colors
-while IFS='=' read -r key value; do
-  key="${key//[\"\' ]/}"
-  [[ $key && $key != \#* ]] || continue
-  value="${value#*[\"\']}"
-  value="${value%%[\"\']*}"
-  colors[$key]="$value"
-done <"$COLORS_FILE"
+color() {
+  omarchy-theme-color --file "$COLORS_FILE" "$1" "${2:-}" 2>/dev/null
+}
 
-bg="${colors[background]}"
-fg="${colors[foreground]}"
-accent="${colors[accent]}"
-sel_bg="${colors[selection_background]}"
-sel_fg="${colors[selection_foreground]}"
+bg=$(color background)
+fg=$(color foreground)
+accent=$(color accent)
+sel_bg=$(color selection_background selection)
+sel_fg=$(color selection_foreground foreground)
+bright_text=$(color color1 red)
+link_visited=$(color color5 magenta)
+palette_type=$(color mode)
 
 # Blend a hex color toward black or white by a percentage (0-100)
 blend() {
@@ -48,12 +53,10 @@ blend() {
 }
 
 # Derive shades for palette roles with no direct colors.toml mapping
-if [[ -f $CURRENT_THEME_DIR/light.mode ]]; then
-  palette_type="light"
+if [[ $palette_type == "light" ]]; then
   alt_base=$(blend "$bg" 5 black)
   placeholder=$(blend "$fg" 40 white)
 else
-  palette_type="dark"
   alt_base=$(blend "$bg" 15 white)
   placeholder=$(blend "$fg" 40 black)
 fi
@@ -85,11 +88,11 @@ palette = {
     'Text': '$fg',
     'Button': '$bg',
     'ButtonText': '$fg',
-    'BrightText': '${colors[color1]}',
+    'BrightText': '$bright_text',
     'Highlight': '$sel_bg',
     'HighlightedText': '$sel_fg',
     'Link': '$accent',
-    'LinkVisited': '${colors[color5]}',
+    'LinkVisited': '$link_visited',
     'AlternateBase': '$alt_base',
     'ToolTipBase': '$alt_base',
     'ToolTipText': '$fg',


### PR DESCRIPTION
## Problem Statement
Calibre doesn't natively update with Omarchy themes, so I added a new script and call in `bin/omarchy-theme-set` to trigger Calibre theme changes. Calibre is a little finicky with updating themes, so I added logic to make sure it closes and applies the theme whenever a user changes the Omarchy theme.

## Summary
Syncs the current Omarchy theme to Calibre's custom palette system when switching themes. Follows the same pattern as the existing Obsidian, VS Code, and browser integrations.
- Parses `colors.toml` and maps colors to Qt QPalette roles (deriving shades like `AlternateBase` and `PlaceholderText` via a `blend()` helper since `colors.toml` only has ~6 base colors but Calibre's palette needs 15)
- Detects light/dark mode via light.mode marker
- Writes the palette to Calibre's `gprefs` via `calibre-debug -c` (Calibre stores palettes in a Python-managed JSON config, not a plain file)
- Restarts Calibre if it was running -- kills it _before_ writing the palette because Calibre's shutdown handler saves its in-memory config to disk, which would overwrite our changes
- Reopens Calibre on its original workspace after restarting -- captures the workspace via `hyprctl` before killing, then sets a temporary `windowrule` so it opens silently in the right place
- Guarded by `omarchy-cmd-present calibre` -- no-op if Calibre isn't installed

## Files
- `bin/omarchy-theme-set-calibre` → new script
- `bin/omarchy-theme-set` → added `omarchy-theme-set-calibre` between obsidian and keyboard