### PR TITLE
feat: Timeout for encryption password input

### DIFF
--- a/config/mkinitcpio/luks-timeout.patch
+++ b/config/mkinitcpio/luks-timeout.patch
@@ -1,0 +1,41 @@
+--- encrypt	2026-02-28 18:02:14.718126028 +0500
++++ encrypt-upd	2026-03-01 14:00:47.917985370 +0500
+@@ -100,18 +100,38 @@
+                 fi
+             fi
+             # Ask for a passphrase
++            local IDLE_TIMEOUT=120
+             if [ "${dopassphrase}" -gt 0 ]; then
+                 if command -v plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null; then
++                    (
++                        sleep "$IDLE_TIMEOUT"
++                        if [ ! -e "/dev/mapper/${cryptname}" ]; then
++                            plymouth display-message --text="Idle timeout: Powering off..."
++                            sleep 3
++                            poweroff -f
++                        fi
++                    ) &
++                    WATCHDOG_PID=$!
++
+                     plymouth ask-for-password \
+                         --prompt="A password is required to access the ${cryptname} volume" \
+                         --command="cryptsetup open --type luks --key-file=- ${resolved} ${cryptname} ${cryptargs} ${CSQUIET}"
++
++                    kill $WATCHDOG_PID 2>/dev/null
+                 else
+                     echo ""
+                     echo "A password is required to access the ${cryptname} volume:"
+ 
++                    timer_elapsed=0
+                     #loop until we get a real password
+                     while ! eval cryptsetup open --type luks "${resolved}" "${cryptname}" "${cryptargs}" "${CSQUIET}"; do
+                         sleep 2;
++                        timer_elapsed=$((timer_elapsed + 2))
++
++                        if [ "$timer_elapsed" -ge "IDLE_TIMEOUT" ]; then
++                            echo "Idle timeout: Powering off..."
++                            poweroff -f
++                        fi
+                     done
+                 fi
+             fi

--- a/config/mkinitcpio/luks-timeout.patch
+++ b/config/mkinitcpio/luks-timeout.patch
@@ -32,7 +32,7 @@
                          sleep 2;
 +                        timer_elapsed=$((timer_elapsed + 2))
 +
-+                        if [ "$timer_elapsed" -ge "IDLE_TIMEOUT" ]; then
++                        if [ "$timer_elapsed" -ge "$IDLE_TIMEOUT" ]; then
 +                            echo "Idle timeout: Powering off..."
 +                            poweroff -f
 +                        fi

--- a/migrations/1772353103.sh
+++ b/migrations/1772353103.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Add 120s timeout to LUKS encryption password input screen
+
+PATCH_FILE="$OMARCHY_PATH"/config/mkinitcpio/luks-timeout.patch
+TARGET_HOOK="/usr/lib/initcpio/hooks/encrypt"
+
+if [ ! -f "$TARGET_HOOK" ]; then
+  echo "Error: Encryption hook not found"
+  exit 1
+fi
+
+if [ ! -f "$PATCH_FILE" ]; then
+  echo "Error: Patch file not found in repository"
+  exit 1
+fi
+
+if grep -q "WATCHDOG_PID" "$TARGET_HOOK"; then
+  echo "Hook already patched skipping"
+  exit 0
+fi
+
+echo "Applying Timeout patch..."
+if sudo patch "$TARGET_HOOK" "$PATCH_FILE"; then
+  echo "Patch has been applied, regenerating initramfs"
+  sudo limine-mkinitcpio
+else
+  echo "Failed to apply patch"
+  exit 1
+fi


### PR DESCRIPTION
Recently i had my laptop turned on by accident in my backpack and after 4-5 hours i noticed that my bag was warm after inspecting i found out that my laptop was on all this time in LUKS decryption password prompt screen stayed there for roughly 5 hours, laptop was hot but i was lucky that it did not inflict any damage to the hardware, i was sure i would have an omarchy logo burned in in on my OLED screen, luckily it is fine.
I modified encrypt hook to include 120 second timeout for both plymouth and fallback shell to power off after the timeout, this helps prevent cases such as above, where device is turned on by accident and display is left on, leading to overheating or display damages if left on for long periods of time.
Added changes as migration script should work fine to patch the encrypt hook and apply using limine-mkinitcpio.
Tested couple of times on my own hardware with no issues, might require some more testing.