### PR TITLE
Enable SSD TRIM on LUKS-encrypted drives

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -44,3 +44,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-asus-rog-mic.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/framework16-qmk-hid.sh
+run_logged $OMARCHY_INSTALL/config/hardware/luks-trim.sh

--- a/install/config/hardware/luks-trim.sh
+++ b/install/config/hardware/luks-trim.sh
@@ -1,0 +1,20 @@
+# Enable SSD TRIM on LUKS-encrypted drives
+# Without this, dm-crypt silently drops all TRIM/DEALLOCATE commands,
+# causing unnecessary write amplification and reduced SSD lifespan.
+# See: https://wiki.archlinux.org/title/Dm-crypt/Specialties#Discard/TRIM_support_for_solid_state_drives_(SSD)
+
+if lsblk --noheadings -o TYPE | grep -q "crypt"; then
+  echo "LUKS encryption detected. Enabling SSD TRIM support..."
+
+  # Set allow-discards persistently in the LUKS2 header so TRIM commands
+  # pass through dm-crypt to the underlying SSD controller.
+  for dev in $(lsblk --noheadings -o NAME,TYPE | awk '$2=="crypt" {print $1}'); do
+    if ! sudo cryptsetup luksDump /dev/mapper/$dev 2>/dev/null | grep -q "allow-discards"; then
+      echo "Enabling allow-discards on /dev/mapper/$dev"
+      sudo cryptsetup --allow-discards --persistent refresh $dev
+    fi
+  done
+
+  # Enable weekly TRIM via fstrim.timer
+  chrootable_systemctl_enable fstrim.timer
+fi

--- a/migrations/1772373643.sh
+++ b/migrations/1772373643.sh
@@ -1,0 +1,16 @@
+echo "Enable SSD TRIM on LUKS-encrypted drives"
+
+# Without allow-discards, dm-crypt silently drops all TRIM commands,
+# causing write amplification and reduced SSD lifespan.
+# See: https://wiki.archlinux.org/title/Dm-crypt/Specialties#Discard/TRIM_support_for_solid_state_drives_(SSD)
+
+if lsblk --noheadings -o TYPE | grep -q "crypt"; then
+  for dev in $(lsblk --noheadings -o NAME,TYPE | awk '$2=="crypt" {print $1}'); do
+    if ! sudo cryptsetup luksDump /dev/mapper/$dev 2>/dev/null | grep -q "allow-discards"; then
+      echo "Enabling allow-discards on /dev/mapper/$dev"
+      sudo cryptsetup --allow-discards --persistent refresh $dev
+    fi
+  done
+
+  chrootable_systemctl_enable fstrim.timer
+fi


### PR DESCRIPTION
## Summary
- Enables `allow-discards` on LUKS volumes via `cryptsetup --persistent refresh` so TRIM commands pass through dm-crypt to the SSD controller
- Enables `fstrim.timer` for weekly periodic TRIM
- Includes install-time hardware detection script and migration for existing users

Fixes #2229

## Context

Every Omarchy install uses LUKS encryption, and the `encrypt` mkinitcpio hook silently drops all TRIM/DEALLOCATE commands by default. On a 1 TB NVMe drive, this caused 400+ GiB of stale blocks the controller couldn't reclaim — unnecessary write amplification that degrades both performance and SSD lifespan.

The approach uses `cryptsetup --allow-discards --persistent refresh` rather than kernel parameter modification, writing the flag directly into the LUKS2 header. This is the method recommended by the [Arch Wiki](https://wiki.archlinux.org/title/Dm-crypt/Specialties#LUKS2) and works regardless of boot configuration.

**Security note:** `allow-discards` leaks block usage patterns to physical disk forensics. For most users, the performance/longevity benefits far outweigh this risk.

## Files changed
- `install/config/hardware/luks-trim.sh` — new install-time script (detects LUKS, enables discards + fstrim.timer)
- `install/config/all.sh` — registers the new hardware script
- `migrations/1772373643.sh` — applies the same fix to existing installations on update

## Test plan
- [ ] Fresh Omarchy install with LUKS: verify `lsblk --discard` shows non-zero DISC-GRAN on crypt device
- [ ] Fresh install: verify `systemctl is-enabled fstrim.timer` returns "enabled"
- [ ] Existing install: run `omarchy-migrate` and verify both changes apply
- [ ] Non-LUKS install (if any): verify script is a no-op (no errors, no changes)
- [ ] Verify `sudo fstrim -av` successfully trims the root partition after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)