### PR TITLE
Layout aware bindings

### DIFF
--- a/bin/omarchy-hyprland-window-fullscreen-toggle
+++ b/bin/omarchy-hyprland-window-fullscreen-toggle
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Layout-aware fullscreen/expand toggle.
+# Scrolling: toggle between colresize 1.0 and the configured column_width default.
+# Dwindle/master: toggle fullscreen (maximize).
+
+LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+
+if [[ $LAYOUT == "scrolling" ]]; then
+  size=$(hyprctl activewindow -j | jq -c '.size')
+  new_size=$(hyprctl --batch -j "dispatch layoutmsg colresize 1; activewindow" \
+    | tail -n +2 | jq -c '.size')
+
+  if [[ $size == "$new_size" ]]; then
+    default_width=$(hyprctl getoption scrolling:column_width -j | jq -r '.float')
+    hyprctl dispatch layoutmsg colresize "$default_width"
+  fi
+else
+  hyprctl dispatch fullscreen 1
+fi

--- a/bin/omarchy-hyprland-window-resize
+++ b/bin/omarchy-hyprland-window-resize
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Layout-aware window resize for both scrolling and dwindle/master layouts.
+# Usage: omarchy-hyprland-window-resize <direction> <axis>
+#   direction: grow | shrink
+#   axis: horizontal | vertical
+
+DIRECTION=$1
+AXIS=${2:-horizontal}
+LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+
+if [[ $LAYOUT == "scrolling" ]]; then
+  if [[ $AXIS == "horizontal" ]]; then
+    if [[ $DIRECTION == "grow" ]]; then
+      hyprctl dispatch layoutmsg colresize +0.1
+    else
+      hyprctl dispatch layoutmsg colresize -0.1
+    fi
+  else
+    if [[ $DIRECTION == "grow" ]]; then
+      hyprctl dispatch resizeactive 0 100
+    else
+      hyprctl dispatch resizeactive 0 -100
+    fi
+  fi
+else
+  if [[ $AXIS == "horizontal" ]]; then
+    if [[ $DIRECTION == "grow" ]]; then
+      hyprctl dispatch resizeactive 100 0
+    else
+      hyprctl dispatch resizeactive -100 0
+    fi
+  else
+    if [[ $DIRECTION == "grow" ]]; then
+      hyprctl dispatch resizeactive 0 100
+    else
+      hyprctl dispatch resizeactive 0 -100
+    fi
+  fi
+fi

--- a/bin/omarchy-hyprland-window-split-toggle
+++ b/bin/omarchy-hyprland-window-split-toggle
@@ -7,10 +7,13 @@
 LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
 
 if [[ $LAYOUT == "scrolling" ]]; then
-  ADDR=$(hyprctl activewindow -j | jq -r '.address')
-  WINDOW_X=$(hyprctl activewindow -j | jq -r '.at[0]')
-  SAME_COL=$(hyprctl clients -j | jq --arg x "$WINDOW_X" --arg addr "$ADDR" \
-    '[.[] | select(.at[0] == ($x | tonumber) and .floating == false and .mapped == true)] | length')
+  ACTIVE=$(hyprctl activewindow -j)
+  ADDR=$(echo "$ACTIVE" | jq -r '.address')
+  WINDOW_X=$(echo "$ACTIVE" | jq -r '.at[0]')
+  WORKSPACE=$(echo "$ACTIVE" | jq -r '.workspace.id')
+
+  SAME_COL=$(hyprctl clients -j | jq --arg x "$WINDOW_X" --argjson ws "$WORKSPACE" \
+    '[.[] | select(.at[0] == ($x | tonumber) and .workspace.id == $ws and .floating == false and .mapped == true)] | length')
 
   if (( SAME_COL > 1 )); then
     hyprctl dispatch layoutmsg promote

--- a/bin/omarchy-hyprland-window-split-toggle
+++ b/bin/omarchy-hyprland-window-split-toggle
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Layout-aware toggle split / merge columns.
+# Dwindle: togglesplit.
+# Scrolling: promote window to its own column, or merge it into the adjacent column.
+
+LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+
+if [[ $LAYOUT == "scrolling" ]]; then
+  ADDR=$(hyprctl activewindow -j | jq -r '.address')
+  WINDOW_X=$(hyprctl activewindow -j | jq -r '.at[0]')
+  SAME_COL=$(hyprctl clients -j | jq --arg x "$WINDOW_X" --arg addr "$ADDR" \
+    '[.[] | select(.at[0] == ($x | tonumber) and .floating == false and .mapped == true)] | length')
+
+  if (( SAME_COL > 1 )); then
+    hyprctl dispatch layoutmsg promote
+    ADDR=$(hyprctl activewindow -j | jq -r '.address')
+    hyprctl dispatch movefocus l
+    hyprctl dispatch focuswindow "address:$ADDR"
+  else
+    hyprctl dispatch movewindow l
+    ADDR=$(hyprctl activewindow -j | jq -r '.address')
+    hyprctl dispatch movefocus l
+    hyprctl dispatch focuswindow "address:$ADDR"
+  fi
+else
+  hyprctl dispatch layoutmsg togglesplit
+fi

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -82,8 +82,8 @@ bindd = ALT, TAB, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, TAB, Reveal active window on top, bringactivetotop
 
 # Resize active window
-bindd = SUPER, code:20, Expand window left, exec, omarchy-hyprland-window-resize shrink horizontal  # - key
-bindd = SUPER, code:21, Shrink window left, exec, omarchy-hyprland-window-resize grow horizontal       # = key
+bindd = SUPER, code:20, Shrink window horizontally, exec, omarchy-hyprland-window-resize shrink horizontal  # - key
+bindd = SUPER, code:21, Grow window horizontally, exec, omarchy-hyprland-window-resize grow horizontal       # = key
 bindd = SUPER SHIFT, code:20, Shrink window vertically, exec, omarchy-hyprland-window-resize shrink vertical
 bindd = SUPER SHIFT, code:21, Grow window vertically, exec, omarchy-hyprland-window-resize grow vertical
 

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -3,12 +3,12 @@ bindd = SUPER, W, Close window, killactive,
 bindd = CTRL ALT, DELETE, Close all windows, exec, omarchy-hyprland-window-close-all
 
 # Control tiling
-bindd = SUPER, J, Toggle window split, layoutmsg, togglesplit
+bindd = SUPER, J, Toggle window split, exec, omarchy-hyprland-window-split-toggle
 bindd = SUPER, P, Pseudo window, pseudo, # dwindle
 bindd = SUPER, T, Toggle window floating/tiling, togglefloating,
 bindd = SUPER, F, Full screen, fullscreen, 0
 bindd = SUPER CTRL, F, Tiled full screen, fullscreenstate, 0 2
-bindd = SUPER ALT, F, Full width, fullscreen, 1
+bindd = SUPER ALT, F, Full width, exec, omarchy-hyprland-window-fullscreen-toggle
 bindd = SUPER, O, Pop window out (float & pin), exec, omarchy-hyprland-window-pop
 bindd = SUPER, L, Toggle workspace layout, exec, omarchy-hyprland-workspace-layout-toggle
 
@@ -82,10 +82,10 @@ bindd = ALT, TAB, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, TAB, Reveal active window on top, bringactivetotop
 
 # Resize active window
-bindd = SUPER, code:20, Expand window left, resizeactive, -100 0    # - key
-bindd = SUPER, code:21, Shrink window left, resizeactive, 100 0     # = key
-bindd = SUPER SHIFT, code:20, Shrink window up, resizeactive, 0 -100
-bindd = SUPER SHIFT, code:21, Expand window down, resizeactive, 0 100
+bindd = SUPER, code:20, Shrink window horizontally, exec, omarchy-hyprland-window-resize shrink horizontal  # - key
+bindd = SUPER, code:21, Grow window horizontally, exec, omarchy-hyprland-window-resize grow horizontal       # = key
+bindd = SUPER SHIFT, code:20, Shrink window vertically, exec, omarchy-hyprland-window-resize shrink vertical
+bindd = SUPER SHIFT, code:21, Grow window vertically, exec, omarchy-hyprland-window-resize grow vertical
 
 # Scroll through existing workspaces with SUPER + scroll
 bindd = SUPER, mouse_down, Scroll active workspace forward, workspace, e+1

--- a/default/hypr/bindings/tiling-v2.conf
+++ b/default/hypr/bindings/tiling-v2.conf
@@ -82,8 +82,8 @@ bindd = ALT, TAB, Reveal active window on top, bringactivetotop
 bindd = ALT SHIFT, TAB, Reveal active window on top, bringactivetotop
 
 # Resize active window
-bindd = SUPER, code:20, Shrink window horizontally, exec, omarchy-hyprland-window-resize shrink horizontal  # - key
-bindd = SUPER, code:21, Grow window horizontally, exec, omarchy-hyprland-window-resize grow horizontal       # = key
+bindd = SUPER, code:20, Expand window left, exec, omarchy-hyprland-window-resize shrink horizontal  # - key
+bindd = SUPER, code:21, Shrink window left, exec, omarchy-hyprland-window-resize grow horizontal       # = key
 bindd = SUPER SHIFT, code:20, Shrink window vertically, exec, omarchy-hyprland-window-resize shrink vertical
 bindd = SUPER SHIFT, code:21, Grow window vertically, exec, omarchy-hyprland-window-resize grow vertical
 


### PR DESCRIPTION
## Summary

Keybindings for resize, fullscreen (`SUPER ALT F`), and split toggle (`SUPER J`) now detect the active workspace layout and dispatch the appropriate command for both **scrolling** and **dwindle** layouts.

Since Omarchy already ships `omarchy-hyprland-workspace-layout-toggle` to switch between layouts, the tiling bindings should adapt accordingly. Currently, resize/fullscreen/split only work correctly with dwindle.

## Changes

### Three new bin scripts

| Script | Scrolling behavior | Dwindle behavior |
|--------|-------------------|-----------------|
| `omarchy-hyprland-window-resize` | `layoutmsg colresize` for horizontal, `resizeactive` for vertical | `resizeactive` for both axes |
| `omarchy-hyprland-window-fullscreen-toggle` | Toggles between `colresize 1.0` and configured `column_width` default | `fullscreen 1` (maximize toggle) |
| `omarchy-hyprland-window-split-toggle` | `promote` (split out) or `movewindow` (merge into adjacent column) | `layoutmsg togglesplit` |

### Updated bindings in `tiling-v2.conf`

- `SUPER J` (toggle split) -> `omarchy-hyprland-window-split-toggle`
- `SUPER ALT F` (full width) -> `omarchy-hyprland-window-fullscreen-toggle`
- `SUPER +/-` and `SUPER SHIFT +/-` (resize) -> `omarchy-hyprland-window-resize`

### No migration needed

`tiling-v2.conf` lives in `default/` and is sourced directly from `~/.local/share/omarchy/`, so changes take effect automatically on update.

### Fullscreen toggle approach

The scrolling fullscreen toggle uses a size-comparison technique: it attempts `colresize 1` via `hyprctl --batch`, then checks if the window size actually changed. If not (already full width), it resets to the user's configured `scrolling:column_width` default. No temp files or state tracking needed.


https://github.com/user-attachments/assets/a1921c96-4d97-424c-838c-d39b59548458

