### PR TITLE
Prevent LM Studio install from downgrading to legacy package

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -353,7 +353,7 @@ show_install_ai_menu() {
   *Gemini*) install "Gemini CLI" "gemini-cli" ;;
   *Copilot*) install "Copilot CLI" "github-copilot-cli" ;;
   *Cursor*) install "Cursor CLI" "cursor-cli" ;;
-  *Studio*) install "LM Studio" "lmstudio" ;;
+  *Studio*) install "LM Studio" "lmstudio-bin" ;;
   *Ollama*) install "Ollama" $ollama_pkg ;;
   *Crush*) install "Crush" "crush-bin" ;;
   *) show_install_menu ;;


### PR DESCRIPTION
Use `lmstudio-bin` in the AI install menu so new installs and reinstalls stay on the current LM Studio package stream instead of reverting to legacy `lmstudio`.