### PR TITLE
feat: add ctrl n and ctrl p for walker

### DIFF
--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -9,6 +9,8 @@ hide_action_hints = true                                                    # gl
 
 [keybinds]
 quick_activate = []
+next = ["Down", "ctrl n"]
+previous = ["Up", "ctrl p"]
 
 [columns]
 symbols = 1 # providers to be queried by default


### PR DESCRIPTION
# Why?
To have the option to use ctrl + n for next and ctrl + p for previous, this is something common in other programs and it is useful for people that use small keyboards without arrow keys