### PR TITLE
Add Copy Path context menu action to Nautilus

### DIFF
--- a/config/nautilus/copy-path.py
+++ b/config/nautilus/copy-path.py
@@ -14,7 +14,7 @@ class CopyPath(GObject.GObject, Nautilus.MenuProvider):
             if path is not None:
                 path_list.append(path)
         paths = "\n".join(path_list)
-        subprocess.Popen(["wl-copy", paths])
+        subprocess.run(["wl-copy", paths], check=True)
 
     def get_file_items(self, files):
         if not files:

--- a/config/nautilus/copy-path.py
+++ b/config/nautilus/copy-path.py
@@ -3,7 +3,17 @@ from gi.repository import Nautilus, GObject
 
 class CopyPath(GObject.GObject, Nautilus.MenuProvider):
     def _copy_path(self, menu, files):
-        paths = "\n".join(f.get_location().get_path() for f in files)
+        path_list = []
+        for f in files:
+            location = f.get_location()
+            if location is None:
+                continue
+            path = location.get_path()
+            if path is None:
+                path = location.get_uri()
+            if path is not None:
+                path_list.append(path)
+        paths = "\n".join(path_list)
         subprocess.Popen(["wl-copy", paths])
 
     def get_file_items(self, files):

--- a/config/nautilus/copy-path.py
+++ b/config/nautilus/copy-path.py
@@ -1,0 +1,15 @@
+import subprocess
+from gi.repository import Nautilus, GObject
+
+class CopyPath(GObject.GObject, Nautilus.MenuProvider):
+    def _copy_path(self, menu, files):
+        paths = "\n".join(f.get_location().get_path() for f in files)
+        subprocess.Popen(["wl-copy", paths])
+
+    def get_file_items(self, files):
+        if not files:
+            return []
+
+        item = Nautilus.MenuItem(name="CopyPath::CopyPath", label="Copy Path")
+        item.connect("activate", self._copy_path, files)
+        return [item]

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -14,6 +14,7 @@ run_logged $OMARCHY_INSTALL/config/mise-work.sh
 run_logged $OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh
 run_logged $OMARCHY_INSTALL/config/docker.sh
 run_logged $OMARCHY_INSTALL/config/mimetypes.sh
+run_logged $OMARCHY_INSTALL/config/nautilus-copy-path.sh
 run_logged $OMARCHY_INSTALL/config/remove-fcitx5-autostart.sh
 run_logged $OMARCHY_INSTALL/config/localdb.sh
 run_logged $OMARCHY_INSTALL/config/walker-elephant.sh

--- a/install/config/nautilus-copy-path.sh
+++ b/install/config/nautilus-copy-path.sh
@@ -1,0 +1,2 @@
+mkdir -p ~/.local/share/nautilus-python/extensions
+cp ~/.local/share/omarchy/config/nautilus/copy-path.py ~/.local/share/nautilus-python/extensions/

--- a/migrations/1772966489.sh
+++ b/migrations/1772966489.sh
@@ -1,0 +1,3 @@
+echo "Add Copy Path context menu action to Nautilus"
+
+source $OMARCHY_PATH/install/config/nautilus-copy-path.sh


### PR DESCRIPTION
## Summary
- Adds a nautilus-python extension that provides a **Copy Path** right-click menu item in Nautilus
- Copies the full path of selected file(s) to clipboard via `wl-copy`
- No new package dependencies — `nautilus-python` and `wl-clipboard` are already in `omarchy-base.packages`

## Changes
- `config/nautilus/copy-path.py` — the nautilus-python MenuProvider extension
- `install/config/nautilus-copy-path.sh` — installs the extension to `~/.local/share/nautilus-python/extensions/`
- `install/config/all.sh` — registers the install script