### PR TITLE
Exit screensaver on mouse movement

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -28,9 +28,13 @@ while true; do
     --random-effect --exclude-effects dev_worm \
     --no-eol --no-restore-cursor &
 
+  last_pos=$(hyprctl cursorpos)
   while pgrep -t "${tty#/dev/}" -x tte >/dev/null; do
-    if read -n1 -t 1 || ! screensaver_in_focus; then
+    current_pos=$(hyprctl cursorpos)
+    if [[ "$current_pos" != "$last_pos" ]] || read -n1 -t 1 || ! screensaver_in_focus; then
       exit_screensaver
     fi
+
+    last_pos=$current_pos
   done
 done


### PR DESCRIPTION
I noticed a previous PR to get the screensaver to close on mouse movement that didn't work out because of issues with Bluetooth mice.

Here is a different approach that compares mouse position which I think should do the trick!