### PR TITLE
Move update log to persistent path so it survives reboot

### DIFF
--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-update_log="/tmp/omarchy-update.log"
+update_log="$HOME/.local/state/omarchy/update.log"
 
 # Check for initramfs generation failure
 if grep -q "Updating linux initcpios" "$update_log"; then

--- a/bin/omarchy-update-perform
+++ b/bin/omarchy-update-perform
@@ -7,7 +7,7 @@ hyprctl dispatch tagwindow +noidle &>/dev/null || true
 
 # Capture update logs (CLICOLOR_FORCE keeps gum styled when stdout is piped through tee)
 export CLICOLOR_FORCE=1
-exec > >(tee "/tmp/omarchy-update.log") 2>&1
+exec > >(tee "$HOME/.local/state/omarchy/update.log") 2>&1
 
 # Perform all update steps
 omarchy-update-keyring


### PR DESCRIPTION
## Summary

- Move update log from `/tmp/omarchy-update.log` to `~/.local/state/omarchy/update.log` so it persists across reboots
- Updated both `omarchy-update-perform` (writes the log) and `omarchy-update-analyze-logs` (reads the log)
- Follows existing convention — `~/.local/state/omarchy/` is already used for migrations, toggles, and other persistent state

## Test plan

- [ ] Run `omarchy-update-perform` and verify log is written to `~/.local/state/omarchy/update.log`
- [ ] Reboot and confirm the log file is still present
- [ ] Verify `omarchy-update-analyze-logs` reads from the correct path

Fixes #4965