### PR TITLE
waybar/workspaces: remove margin from button to fix cursor flicker

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -21,8 +21,7 @@
 
 #workspaces button {
   all: initial;
-  padding: 0 6px;
-  margin: 0 1.5px;
+  padding: 0 7px;
   min-width: 9px;
 }
 


### PR DESCRIPTION
The margin created gaps between workspace buttons where there was no clickable element, causing the cursor to revert to default when moving between workspaces. Increased padding from 6px to 7px to maintain visual spacing while fixing the issue.