### PR TITLE
Skip invalid scales in monitor scaling cycle

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling-cycle
+++ b/bin/omarchy-hyprland-monitor-scaling-cycle
@@ -8,15 +8,39 @@ WIDTH=$(echo "$MONITOR_INFO" | jq -r '.width')
 HEIGHT=$(echo "$MONITOR_INFO" | jq -r '.height')
 REFRESH_RATE=$(echo "$MONITOR_INFO" | jq -r '.refreshRate')
 
-# Cycle through scales: 1 → 1.6 → 2 → 3 → 1
-CURRENT_INT=$(awk -v s="$CURRENT_SCALE" 'BEGIN { printf "%.0f", s * 10 }')
+# All candidate scales in cycle order
+ALL_SCALES=(1 1.6 2 3)
 
-case "$CURRENT_INT" in
-10) NEW_SCALE=1.6 ;;
-16) NEW_SCALE=2 ;;
-20) NEW_SCALE=3 ;;
-*) NEW_SCALE=1 ;;
-esac
+# Filter to only scales that divide cleanly into this monitor's resolution
+VALID_SCALES=()
+for s in "${ALL_SCALES[@]}"; do
+  if awk -v w="$WIDTH" -v h="$HEIGHT" -v s="$s" 'BEGIN {
+    sw = w / s; sh = h / s
+    dw = sw - int(sw); if (dw < 0) dw = -dw
+    dh = sh - int(sh); if (dh < 0) dh = -dh
+    exit !(dw < 0.001 && dh < 0.001)
+  }'; then
+    VALID_SCALES+=("$s")
+  fi
+done
+
+# Need at least 2 valid scales to cycle
+if [ "${#VALID_SCALES[@]}" -lt 2 ]; then
+  notify-send "󰍹    Only one valid scale (1x) for this display"
+  exit 0
+fi
+
+# Find current scale in the valid list, pick the next one
+CURRENT_INT=$(awk -v s="$CURRENT_SCALE" 'BEGIN { printf "%.0f", s * 10 }')
+NEW_SCALE="${VALID_SCALES[0]}"
+for i in "${!VALID_SCALES[@]}"; do
+  s_int=$(awk -v s="${VALID_SCALES[$i]}" 'BEGIN { printf "%.0f", s * 10 }')
+  if [ "$s_int" = "$CURRENT_INT" ]; then
+    next=$(( (i + 1) % ${#VALID_SCALES[@]} ))
+    NEW_SCALE="${VALID_SCALES[$next]}"
+    break
+  fi
+done
 
 hyprctl keyword misc:disable_scale_notification true
 hyprctl keyword monitor "$ACTIVE_MONITOR,${WIDTH}x${HEIGHT}@${REFRESH_RATE},auto,$NEW_SCALE"


### PR DESCRIPTION
Fixes #5017

## Problem

`omarchy-hyprland-monitor-scaling-cycle` hardcodes the scale cycle `1 → 1.6 → 2 → 3 → 1`. On displays where these scales don't divide cleanly into the native resolution, Hyprland shows an error banner:

> Invalid scale passed to monitor eDP-1, failed to find a clean divisor
> Hyprland may not work correctly

Affected common resolutions:
- **1366x768** — scale 1.6 (853.75 width) and 3 (455.33 width) are invalid
- **2560x1440** — scale 3 (853.33 width) is invalid
- **6016x3384** — scale 3 (2005.33 width) is invalid

## Fix

Before applying a scale, validate that `width/scale` and `height/scale` both produce integer pixel values. Invalid scales are skipped and the cycle moves to the next valid one.

- **No behavior change** for displays that support all scales (1920x1080, 2880x1920, 3840x2160)
- On 1366x768, cycles `1 → 2 → 1` (skips 1.6 and 3)
- On 2560x1440, cycles `1 → 1.6 → 2 → 1` (skips 3)
- If only scale 1x is valid, shows a notification instead of erroring

| Resolution | Valid scales | Skipped |
|---|---|---|
| 1366x768 | 1, 2 | 1.6, 3 |
| 1920x1080 | 1, 1.6, 2, 3 | — |
| 2560x1440 | 1, 1.6, 2 | 3 |
| 2880x1920 | 1, 1.6, 2, 3 | — |
| 3840x2160 | 1, 1.6, 2, 3 | — |
| 6016x3384 | 1, 1.6, 2 | 3 |

Zero new dependencies — uses only awk/jq already required by the script.