### PR TITLE
fix: adds "Open Directory" to the xdg-desktop-portal-gtk floating-window tag windowrule

### DIFF
--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -4,7 +4,7 @@ windowrule = center on, match:tag floating-window
 windowrule = size 875 600, match:tag floating-window
 
 windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
-windowrule = tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)
+windowrule = tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Open [D|d]irectory.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)
 windowrule = float on, match:class org.gnome.Calculator
 
 # Fullscreen screensaver


### PR DESCRIPTION
Adds Open Directory dialogs to the floating-window Hyprland rule so those file chooser windows are treated the same as existing Open/Save dialogs. This fixes cases where xdg-desktop-portal-gtk and similar app dialogs would not open as centered floating windows.

example output from hyprctl clients

```json
{
    "address": "0x5566bc419320",
    "mapped": true,
    "hidden": false,
    "at": [1288, 36],
    "size": [1266, 1398],
    "workspace": {
        "id": 2,
        "name": "2"
    },
    "floating": false,
    "monitor": 1,
    "class": "xdg-desktop-portal-gtk",
    "title": "Open Directory",
    "initialClass": "xdg-desktop-portal-gtk",
    "initialTitle": "Open Directory",
    "pid": 2005,
    "xwayland": false,
    "pinned": false,
    "fullscreen": 0,
    "fullscreenClient": 0,
    "overFullscreen": false,
    "grouped": [],
    "tags": ["default-opacity*"],
    "swallowing": "0x0",
    "focusHistoryID": 2,
    "inhibitingIdle": false,
    "xdgTag": "",
    "xdgDescription": "",
    "contentType": "none",
    "stableId": "18000112"
}

```