### PR TITLE
Fix Hyprland freeze on suspend/resume with NVIDIA GPUs

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -34,6 +34,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/printer.sh
 run_logged $OMARCHY_INSTALL/config/hardware/usb-autosuspend.sh
 run_logged $OMARCHY_INSTALL/config/hardware/ignore-power-button.sh
 run_logged $OMARCHY_INSTALL/config/hardware/nvidia.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-nvidia-suspend.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel-thermald.sh
 run_logged $OMARCHY_INSTALL/config/hardware/vulkan.sh

--- a/install/config/hardware/fix-nvidia-suspend.sh
+++ b/install/config/hardware/fix-nvidia-suspend.sh
@@ -1,0 +1,50 @@
+# Fix Hyprland freeze on suspend/resume with NVIDIA GPUs
+# nvidia-utils disables session freezing during suspend, which causes Wayland
+# clients to keep running while the GPU suspends. This creates a race condition
+# that crashes hyprlock (SIGSEGV) and freezes the compositor.
+# Solution: Pause Hyprland with SIGSTOP before NVIDIA suspends, resume with SIGCONT after.
+# See: https://github.com/basecamp/omarchy/issues/4891
+# See: https://github.com/0xFMD/hyprland-suspend-fix
+
+NVIDIA="$(lspci | grep -i 'nvidia')"
+
+if [ -n "$NVIDIA" ]; then
+  echo "Installing NVIDIA suspend fix for Hyprland..."
+
+  cat <<EOF | sudo tee /etc/systemd/system/omarchy-hyprland-suspend.service >/dev/null
+[Unit]
+Description=Pause Hyprland before NVIDIA GPU suspend
+Before=systemd-suspend.service
+Before=systemd-hibernate.service
+Before=nvidia-suspend.service
+Before=nvidia-hibernate.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/killall -STOP Hyprland
+
+[Install]
+WantedBy=systemd-suspend.service
+WantedBy=systemd-hibernate.service
+EOF
+
+  cat <<EOF | sudo tee /etc/systemd/system/omarchy-hyprland-resume.service >/dev/null
+[Unit]
+Description=Resume Hyprland after NVIDIA GPU resume
+After=systemd-suspend.service
+After=systemd-hibernate.service
+After=nvidia-resume.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/killall -CONT Hyprland
+
+[Install]
+WantedBy=systemd-suspend.service
+WantedBy=systemd-hibernate.service
+EOF
+
+  sudo systemctl daemon-reload
+  chrootable_systemctl_enable omarchy-hyprland-suspend.service
+  chrootable_systemctl_enable omarchy-hyprland-resume.service
+fi

--- a/migrations/1773664282.sh
+++ b/migrations/1773664282.sh
@@ -1,0 +1,49 @@
+echo "Install NVIDIA suspend fix for Hyprland (prevents freeze on resume)"
+
+NVIDIA="$(lspci | grep -i 'nvidia')"
+
+if [ -z "$NVIDIA" ]; then
+  exit 0
+fi
+
+# Skip if already installed
+if systemctl is-enabled omarchy-hyprland-suspend.service &>/dev/null; then
+  exit 0
+fi
+
+cat <<EOF | sudo tee /etc/systemd/system/omarchy-hyprland-suspend.service >/dev/null
+[Unit]
+Description=Pause Hyprland before NVIDIA GPU suspend
+Before=systemd-suspend.service
+Before=systemd-hibernate.service
+Before=nvidia-suspend.service
+Before=nvidia-hibernate.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/killall -STOP Hyprland
+
+[Install]
+WantedBy=systemd-suspend.service
+WantedBy=systemd-hibernate.service
+EOF
+
+cat <<EOF | sudo tee /etc/systemd/system/omarchy-hyprland-resume.service >/dev/null
+[Unit]
+Description=Resume Hyprland after NVIDIA GPU resume
+After=systemd-suspend.service
+After=systemd-hibernate.service
+After=nvidia-resume.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/killall -CONT Hyprland
+
+[Install]
+WantedBy=systemd-suspend.service
+WantedBy=systemd-hibernate.service
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable omarchy-hyprland-suspend.service
+sudo systemctl enable omarchy-hyprland-resume.service


### PR DESCRIPTION
## Summary

- Adds systemd services that pause Hyprland (SIGSTOP) before NVIDIA GPU suspend and resume it (SIGCONT) after, preventing the race condition that causes compositor freeze and hyprlock SIGSEGV crashes
- Includes hardware install script (`fix-nvidia-suspend.sh`) for new installations and a migration for existing NVIDIA setups
- Services are only installed on systems with NVIDIA GPUs detected via `lspci`

## Root Cause

`nvidia-utils` installs a systemd drop-in (`10-nvidia-no-freeze-session.conf`) that sets `SYSTEMD_SLEEP_FREEZE_USER_SESSIONS=false`. This keeps Wayland clients (hyprlock, Hyprland, waybar) running while the GPU is being suspended by `nvidia-suspend.service`. When the GPU disappears mid-operation:

- hyprlock crashes with SIGSEGV in `std::thread::join()` during cleanup
- Hyprland freezes with a stale framebuffer, requiring a hard reboot
- Affects both hybrid GPU laptops and multi-GPU desktops

## Approach

Based on the community-proven pattern from [0xFMD/hyprland-suspend-fix](https://github.com/0xFMD/hyprland-suspend-fix), adapted to Omarchy conventions:

- `omarchy-hyprland-suspend.service` runs **before** `nvidia-suspend.service`, sending SIGSTOP to Hyprland
- `omarchy-hyprland-resume.service` runs **after** `nvidia-resume.service`, sending SIGCONT to Hyprland
- Follows the same systemd service pattern used by `omarchy-nvme-suspend-fix.service`

## Files Changed

- `install/config/hardware/fix-nvidia-suspend.sh` — new hardware script, auto-detects NVIDIA
- `install/config/all.sh` — registers the script after `nvidia.sh`
- `migrations/1773664282.sh` — applies the fix to existing installations

## Test Plan

- [ ] Verify services install only on NVIDIA systems (`lspci | grep -i nvidia`)
- [ ] Confirm `systemctl is-enabled omarchy-hyprland-suspend.service` after migration
- [ ] Suspend/resume cycle: lock screen renders, input works, no SIGSEGV in `coredumpctl`
- [ ] Non-NVIDIA systems: migration exits cleanly without creating services

Fixes #4891
Related: #3589, #2991, #2635