### PR TITLE
Add TUI calendar to waybar clock

### DIFF
--- a/bin/omarchy-launch-calendar
+++ b/bin/omarchy-launch-calendar
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.calendar -e omarchy-tui-calendar

--- a/bin/omarchy-tui-calendar
+++ b/bin/omarchy-tui-calendar
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+year=$(date +%Y)
+month=$(date +%-m)
+
+show_calendar() {
+  printf '\033[2J\033[H'
+  local cols
+  cols=$(tput cols)
+  local pad=$(( (cols - 20) / 2 ))
+  local indent
+  indent=$(printf "%${pad}s" "")
+  while IFS= read -r line; do
+    [[ -z "${line// }" ]] && continue
+    printf "%s%s\n" "$indent" "$line"
+  done < <(cal "$month" "$year")
+  printf "\n%sh← prev →l next q quit\n" "$indent"
+}
+
+sleep 0.1
+show_calendar
+
+while IFS= read -rsn1 key; do
+  case "$key" in
+    q|Q) break ;;
+    h)
+      (( month-- ))
+      (( month < 1 )) && { month=12; (( year-- )); }
+      show_calendar
+      ;;
+    l)
+      (( month++ ))
+      (( month > 12 )) && { month=1; (( year++ )); }
+      show_calendar
+      ;;
+    $'\x1b')
+      read -rsn2 -t 0.1 suffix
+      case "$suffix" in
+        '[D')
+          (( month-- ))
+          (( month < 1 )) && { month=12; (( year-- )); }
+          show_calendar
+          ;;
+        '[C')
+          (( month++ ))
+          (( month > 12 )) && { month=1; (( year++ )); }
+          show_calendar
+          ;;
+      esac
+      ;;
+  esac
+done

--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -64,7 +64,7 @@
     "format": "{:L%A %H:%M}",
     "format-alt": "{:L%d %B W%V %Y}",
     "tooltip": false,
-    "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
+    "on-click-right": "omarchy-launch-calendar"
   },
   "network": {
     "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -3,6 +3,10 @@ windowrule = float on, match:tag floating-window
 windowrule = center on, match:tag floating-window
 windowrule = size 875 600, match:tag floating-window
 
+windowrule = float on, match:class org.omarchy.calendar
+windowrule = center on, match:class org.omarchy.calendar
+windowrule = size 220 212, match:class org.omarchy.calendar
+
 windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
 windowrule = tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)
 windowrule = float on, match:class org.gnome.Calculator


### PR DESCRIPTION
## Summary

- Right-clicking the clock in waybar opens a minimal TUI calendar in a floating terminal
- Navigate months with `h`/`←` (previous) and `l`/`→` (next), quit with `q`
- No dependencies — uses the standard `cal` command

## Changes

- **`bin/omarchy-tui-calendar`** — shell script rendering a centered, navigable monthly calendar in the terminal
- **`bin/omarchy-launch-calendar`** — launcher using `setsid uwsm-app` + `xdg-terminal-exec` with app-id `org.omarchy.calendar`
- **`config/waybar/config.jsonc`** — `on-click-right` on the clock module set to `omarchy-launch-calendar`
- **`default/hypr/apps/system.conf`** — window rules for `org.omarchy.calendar`: float, center, fixed size 220×212 (kept separate from the `floating-window` tag to avoid inheriting the 875×600 size rule)