### PR TITLE
Set critical notification timeout to 30s instead of infinite

### DIFF
--- a/default/mako/core.ini
+++ b/default/mako/core.ini
@@ -17,7 +17,7 @@ invisible=true
 invisible=false
 
 [urgency=critical]
-default-timeout=0
+default-timeout=30000
 layer=overlay
 
 [summary~="Setup Wi-Fi"]


### PR DESCRIPTION
## Problem

The current `default-timeout=0` for `[urgency=critical]` in mako's core.ini means critical notifications never auto-dismiss. Combined with mako's known ghost surface bug ([emersion/mako#622](https://github.com/emersion/mako/issues/622)), this can leave phantom notifications permanently stuck on screen — surviving even `makoctl dismiss --all`.

Any script or application that sends `urgency=critical` (even with an explicit `-t 5000` timeout) gets overridden to infinite by this config, which is surprising behavior.

## Fix

Change `default-timeout=0` to `default-timeout=30000` (30 seconds). This is long enough to notice any critical alert while preventing notifications from becoming permanent screen fixtures.

## Context

- mako upstream bug: https://github.com/emersion/mako/issues/622
- The ghost surface persists in the Wayland layer-shell even after mako's internal dismiss, requiring a full `makoctl reload` or daemon restart to clear.