### PR TITLE
Replace Impala with nettui for network controls

### DIFF
--- a/bin/omarchy-launch-wifi
+++ b/bin/omarchy-launch-wifi
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-# Launch the Omarchy wifi controls (provided by the Impala TUI).
-# Attempts to unblock the wifi service first in case it should be been blocked.
+# Launch the Omarchy network controls through nettui.
+#
+# Omarchy exposes a single network entry point for both Wi-Fi and Ethernet.
+# Unblock Wi-Fi first in case the radio was soft-blocked.
+
+if ! command -v nettui >/dev/null 2>&1; then
+  notify-send "󰤮    nettui Not Installed" "Install the nettui package to open Omarchy network controls." -u critical -t 5000
+  exit 1
+fi
 
 rfkill unblock wifi
-omarchy-launch-or-focus-tui impala
+exec omarchy-launch-or-focus-tui nettui

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -219,7 +219,7 @@ show_font_menu() {
 }
 
 show_setup_menu() {
-  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
+  local options="  Audio\n󰤨  Network\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
   [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
   options="$options\n  Key Remapping"
   [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
@@ -227,7 +227,7 @@ show_setup_menu() {
 
   case $(menu "Setup" "$options") in
   *Audio*) omarchy-launch-audio ;;
-  *Wifi*) omarchy-launch-wifi ;;
+  *Network*) omarchy-launch-wifi ;;
   *Bluetooth*) omarchy-launch-bluetooth ;;
   *Power*) show_setup_power_menu ;;
   *System*) show_setup_system_menu ;;

--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -187,7 +187,7 @@ prioritize_entries() {
     if (match(line, /Clipboard/))  prio = 17
     if (match(line, /Audio controls/))  prio = 18
     if (match(line, /Bluetooth controls/))  prio = 19
-    if (match(line, /Wifi controls/))  prio = 20
+    if (match(line, /Network controls/))  prio = 20
     if (match(line, /Emoji picker/))  prio = 21
     if (match(line, /Color picker/))  prio = 22
     if (match(line, /Screenshot/))  prio = 23

--- a/default/hypr/apps/system.conf
+++ b/default/hypr/apps/system.conf
@@ -2,8 +2,9 @@
 windowrule = float on, match:tag floating-window
 windowrule = center on, match:tag floating-window
 windowrule = size 875 600, match:tag floating-window
+windowrule = size 1120 760, match:class org.omarchy.nettui
 
-windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
+windowrule = tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.nettui|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)
 windowrule = tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)
 windowrule = float on, match:class org.gnome.Calculator
 

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -48,7 +48,7 @@ bindd = SUPER CTRL ALT, B, Show battery remaining, exec, notify-send "$(omarchy-
 # Control panels
 bindd = SUPER CTRL, A, Audio controls, exec, omarchy-launch-audio
 bindd = SUPER CTRL, B, Bluetooth controls, exec, omarchy-launch-bluetooth
-bindd = SUPER CTRL, W, Wifi controls, exec, omarchy-launch-wifi
+bindd = SUPER CTRL, W, Network controls, exec, omarchy-launch-wifi
 bindd = SUPER CTRL, T, Activity, exec, omarchy-launch-tui btop
 
 # Dictation

--- a/docs/network-click-behavior.md
+++ b/docs/network-click-behavior.md
@@ -1,0 +1,20 @@
+# Network Click Behavior (Waybar)
+
+Omarchy uses Waybar's `network` module for both Wi-Fi and Ethernet.
+That module exposes a single click handler, so Omarchy routes the action to one unified network TUI.
+
+## Implementation
+
+Waybar calls `omarchy-launch-wifi`.
+
+That launcher opens `nettui`.
+
+`nettui` is responsible for:
+
+1. showing Wi-Fi and Ethernet in one TUI
+2. handling Wi-Fi-only systems
+3. handling Ethernet-only systems
+4. handling systems with both adapters present
+5. showing a clear state when no adapter is available
+
+If `nettui` is not installed, the launcher shows a notification instead of opening a partial fallback UI.

--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -1,5 +1,6 @@
 # Ensure iwd service will be started
 sudo systemctl enable iwd.service
+sudo systemctl enable systemd-networkd.service
 
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -55,7 +55,7 @@ hyprlock
 hyprpicker
 hyprsunset
 imagemagick
-impala
+nettui
 imv
 inetutils
 inxi

--- a/migrations/1773693740.sh
+++ b/migrations/1773693740.sh
@@ -1,0 +1,9 @@
+echo "Replace Impala with nettui for Omarchy network controls"
+
+if omarchy-cmd-missing nettui; then
+  omarchy-pkg-add nettui
+fi
+
+if omarchy-cmd-present impala; then
+  omarchy-pkg-drop impala
+fi

--- a/migrations/1773693740.sh
+++ b/migrations/1773693740.sh
@@ -4,6 +4,10 @@ if omarchy-cmd-missing nettui; then
   omarchy-pkg-add nettui
 fi
 
+sudo systemctl enable --now systemd-networkd.service
+sudo systemctl disable systemd-networkd-wait-online.service
+sudo systemctl mask systemd-networkd-wait-online.service
+
 if omarchy-cmd-present impala; then
   omarchy-pkg-drop impala
 fi

--- a/migrations/1773693740.sh
+++ b/migrations/1773693740.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Replace Impala with nettui for Omarchy network controls"
 
 if omarchy-cmd-missing nettui; then
@@ -8,6 +10,6 @@ sudo systemctl enable --now systemd-networkd.service
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service
 
-if omarchy-cmd-present impala; then
+if omarchy-cmd-present nettui && omarchy-cmd-present impala; then
   omarchy-pkg-drop impala
 fi


### PR DESCRIPTION
This PR replaces Impala with nettui as Omarchy's network TUI.

Why

Omarchy currently routes its top-bar network action to a Wi-Fi-only TUI.
`nettui` keeps the same iwd-first approach, but extends it into a single network TUI for both Wi-Fi and Ethernet.

This project is heavily inspired by Impala and intentionally stays close to Impala's interaction model and backend philosophy.
It is not meant to replace that model with something foreign. If anything, nettui is much closer to an Impala-derived network TUI than to a clean-sheet rewrite: the same general Wi-Fi workflow, extended with integrated Ethernet support and Omarchy-specific polish.

What changed

- replaced `impala` with `nettui` in `install/omarchy-base.packages`
- updated `omarchy-launch-wifi` to launch `nettui`
- renamed the Omarchy UI entry from `Wifi` to `Network`
- renamed the keybinding label from `Wifi controls` to `Network controls`
- added a dedicated Hyprland floating size for `org.omarchy.nettui`
- enabled `systemd-networkd.service` in the network setup path
- added a migration that installs `nettui` and removes `impala`
- documented the single network click path in `docs/network-click-behavior.md`

Why this is a better fit for Omarchy

- one TUI for Wi-Fi and Ethernet
- better match for Omarchy's single network entry point
- stays very close to the Impala-style iwd workflow
- avoids splitting network management across separate tools

Important note

This PR requires `nettui` to be published in `pkgs.omarchy.org` before merge.
Without that package source, replacing `impala` in the Omarchy installer would break the official install path.


Nettui is available at: https://github.com/skibidiandulka/nettui/
