### PR TITLE
fix: re-run depmod after DKMS to prevent stale modules.dep

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -52,3 +52,4 @@ run_logged $OMARCHY_INSTALL/config/hardware/fix-synaptic-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-tuxedo-backlight.sh
 run_logged $OMARCHY_INSTALL/config/hardware/framework16-qmk-hid.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel-ipu7-camera.sh
+run_logged $OMARCHY_INSTALL/config/depmod-after-dkms-hook.sh

--- a/install/config/depmod-after-dkms-hook.sh
+++ b/install/config/depmod-after-dkms-hook.sh
@@ -1,0 +1,13 @@
+sudo install -Dm644 /dev/stdin /etc/pacman.d/hooks/75-depmod-after-dkms.hook <<'EOF'
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Target = usr/lib/modules/*/updates/dkms/*.ko*
+Target = usr/lib/modules/*/extramodules/*.ko*
+
+[Action]
+Description = Rebuilding module dependecies after DKMS
+When = PostTransaction
+Exec = /bin/sh -c 'for d in /usr/lib/modules/*/; do [ -f "${d}modules.order" ] && depmod "$(basename "$d")"; done'
+EOF


### PR DESCRIPTION
## Problem

After `pacman -Syu` upgrades the kernel, systems using `nvidia-open-dkms`
(or any DKMS module) drop to emergency mode on next boot.

Pacman hook execution order is the root cause:

- `60-depmod` builds `modules.dep` before DKMS has run
- `70-dkms-install` builds `nvidia.ko` and other DKMS modules
- `90-mkinitcpio-install` tries to include them, but they're not in
  `modules.dep` yet — so the UKI is built without them (or not rebuilt at all)

On reboot, the old UKI references a kernel module directory that no longer
exists. Emergency mode.

## Fix

Adds `install/config/depmod-after-dkms-hook.sh` which installs a pacman
hook at priority 75 — after DKMS builds complete but before mkinitcpio runs.
It re-indexes `modules.dep` so the UKI is built with all DKMS modules present.

The hook only fires when `.ko` files are actually produced, so it is a
no-op on machines without DKMS modules.

Corrected execution order:
```
60-depmod             → initial modules.dep
70-dkms-install       → builds DKMS modules
75-depmod-after-dkms  → re-indexes modules.dep with DKMS output
90-mkinitcpio-install → builds UKI with all modules present
```

Closes #5026