### PR TITLE
Remove timeout for normal-level notifications

### DIFF
--- a/default/mako/core.ini
+++ b/default/mako/core.ini
@@ -1,5 +1,5 @@
 anchor=top-right
-default-timeout=5000
+default-timeout=0
 width=420
 outer-margin=20
 padding=10,15
@@ -17,8 +17,10 @@ invisible=true
 invisible=false
 
 [urgency=critical]
-default-timeout=0
 layer=overlay
+
+[urgency=low]
+default-timeout=5000
 
 [summary~="Setup Wi-Fi"]
 on-button-left=exec sh -c 'omarchy-notification-dismiss "Setup Wi-Fi"; omarchy-launch-wifi'


### PR DESCRIPTION
Depends on: https://github.com/basecamp/omarchy/pull/5056

DHH stated his philosophy for notifications as follows (https://github.com/basecamp/omarchy/issues/1560#issuecomment-3276209751):
> I looked into [having a notification center], but ultimately decided that I didn't think it was worth it. We stack notifications now, and you really should just be reading and dismissing them. I always found that other operating systems I had that used this ended up with a junk drawer (hello mac!)

I believe that having normal-level notifications persist until dismissed is more in line with this philosophy. This ensures they are actually read and dismissed. Collecting notifications into a notification center and never reading them is bad but so is not reading notifications because of looking away from the screen for 5 seconds.

Notifications that should truly be auto-dismissed can be labeled as low urgency as I've proposed in https://github.com/basecamp/omarchy/pull/5056.