### PR TITLE
feat: add voxtype daemon toggle with dictation warning

### DIFF
--- a/bin/omarchy-toggle-dictation
+++ b/bin/omarchy-toggle-dictation
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Toggle dictation recording, with warning if daemon is not running
+
+if ! systemctl --user is-active voxtype.service &>/dev/null; then
+  notify-send "󰔊    Voxtype daemon is not running" -t 3000
+  exit 1
+fi
+
+exec voxtype record toggle

--- a/bin/omarchy-toggle-voxtype
+++ b/bin/omarchy-toggle-voxtype
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Toggle voxtype daemon on/off to free/allocate VRAM/RAM
+
+if omarchy-cmd-missing voxtype; then
+  notify-send "󰔊    Voxtype is not installed"
+  exit 1
+fi
+
+if systemctl --user is-active voxtype.service &>/dev/null; then
+  systemctl --user stop voxtype.service &&
+    notify-send "󰔊    Voxtype daemon disabled"
+else
+  systemctl --user start voxtype.service &&
+    notify-send "󰔊    Voxtype daemon enabled"
+fi

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -52,7 +52,8 @@ bindd = SUPER CTRL, W, Wifi controls, exec, omarchy-launch-wifi
 bindd = SUPER CTRL, T, Activity, exec, omarchy-launch-tui btop
 
 # Dictation
-bindd = SUPER CTRL, X, Toggle dictation, exec, voxtype record toggle
+bindd = SUPER CTRL, X, Toggle dictation, exec, omarchy-toggle-dictation
+bindd = SUPER CTRL ALT, X, Toggle voxtype daemon, exec, omarchy-toggle-voxtype
 
 # Zoom
 bindd = SUPER CTRL, Z, Zoom in, exec, hyprctl keyword cursor:zoom_factor $(hyprctl getoption cursor:zoom_factor -j | jq '.float + 1')


### PR DESCRIPTION
## Summary

- Add `omarchy-toggle-voxtype` to start/stop voxtype daemon (frees VRAM when stopped)
- Add `omarchy-toggle-dictation` wrapper that warns if daemon is not running
- Update keybindings:
  - `Super+Ctrl+X` - Toggle dictation recording (warns if daemon stopped)
  - `Super+Ctrl+Alt+X` - Toggle voxtype daemon (free VRAM)

## Changes

| File | Description |
|------|-------------|
| `bin/omarchy-toggle-voxtype` | New command to toggle voxtype daemon via systemctl |
| `bin/omarchy-toggle-dictation` | New wrapper for `voxtype record toggle` with daemon check |
| `default/hypr/bindings/utilities.conf` | Updated keybindings for both toggles |