### PR TITLE
Fix Bluetooth audio: auto-switch sink, move streams, preserve volume

### DIFF
--- a/bin/omarchy-cmd-audio-switch
+++ b/bin/omarchy-cmd-audio-switch
@@ -58,6 +58,12 @@ next_sink_volume_icon="sink-volume-${icon_state}-symbolic"
 
 if [[ $next_sink_name != $current_sink_name ]]; then
   pactl set-default-sink "$next_sink_name"
+
+  # Move all existing audio streams (e.g. Spotify) to the new sink
+  next_sink_index_num=$(echo "$next_sink" | jq -r '.index')
+  pactl list short sink-inputs 2>/dev/null | while read -r stream_id _rest; do
+    pactl move-sink-input "$stream_id" "$next_sink_index_num" 2>/dev/null
+  done
 fi
 
 swayosd-client \

--- a/bin/omarchy-restart-pipewire
+++ b/bin/omarchy-restart-pipewire
@@ -3,4 +3,4 @@
 # Restart the PipeWire audio service to fix audio issues or apply new configuration.
 
 echo -e "Restarting pipewire audio service...\n"
-systemctl --user restart pipewire.service
+systemctl --user restart pipewire.service pipewire-pulse.service wireplumber.service

--- a/default/wireplumber/wireplumber.conf.d/bluetooth.conf
+++ b/default/wireplumber/wireplumber.conf.d/bluetooth.conf
@@ -1,0 +1,34 @@
+## Bluetooth audio configuration
+## Ensures Bluetooth devices become the default audio output when connected,
+## existing audio streams follow the new default, and volume is preserved
+## between tracks.
+
+# Move existing audio streams (e.g. Spotify) to the new default sink
+# when it changes, rather than leaving them on the old output.
+wireplumber.settings = {
+  default-policy.move = true
+}
+
+# Bluetooth output node rules
+monitor.bluez.rules = [
+  {
+    matches = [
+      {
+        node.name = "~bluez_output.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        # Higher priority than built-in speakers (~1000-2000) so Bluetooth
+        # automatically becomes the default sink when connected.
+        priority.session = 2500
+        priority.driver  = 2500
+
+        # Keep the Bluetooth transport alive between tracks to prevent
+        # volume from resetting when PipeWire suspends and re-establishes
+        # the A2DP connection.
+        session.suspend-timeout-seconds = 5
+      }
+    }
+  }
+]


### PR DESCRIPTION
Fixes three Bluetooth audio issues:

- Volume keys control PC speakers instead of the connected Bluetooth device
- Volume resets to max between Spotify tracks (A2DP transport getting suspended)
- Bluetooth speaker not always appearing without a full PipeWire stack restart

Adds a WirePlumber Bluetooth config to prioritize BT sinks and keep the transport alive between tracks, moves active streams when switching output, and restarts all three audio services in omarchy-restart-pipewire.