### PR TITLE
Add keyboard-only screenshot bindings for active window and full screen

### DIFF
--- a/bin/omarchy-cmd-screenshot
+++ b/bin/omarchy-cmd-screenshot
@@ -79,6 +79,9 @@ windows)
   SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
   kill $PID 2>/dev/null
   ;;
+activewindow)
+  SELECTION=$(hyprctl activewindow -j | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
+  ;;
 fullscreen)
   SELECTION=$(hyprctl monitors -j | jq -r "${JQ_MONITOR_GEO} .[] | select(.focused == true) | format_geo")
   ;;

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -35,6 +35,8 @@ bindd = SHIFT CTRL, F2, Apple Display full brightness, exec, omarchy-brightness-
 
 # Captures
 bindd = , PRINT, Screenshot, exec, omarchy-cmd-screenshot
+bindd = SUPER SHIFT CTRL, C, Screenshot active window, exec, omarchy-cmd-screenshot activewindow
+bindd = SUPER ALT, C, Screenshot full screen, exec, omarchy-cmd-screenshot fullscreen
 bindd = ALT, PRINT, Screenrecording, exec, omarchy-menu screenrecord
 bindd = SUPER, PRINT, Color picker, exec, pkill hyprpicker || hyprpicker -a
 


### PR DESCRIPTION
## Summary

The existing screenshot tool (`omarchy-cmd-screenshot`) supports `smart`, `region`, `windows`, and `fullscreen` modes, but there are no default keybindings for quickly capturing the active window or the full screen without mouse interaction.

This PR adds:

- **`activewindow` mode** to `omarchy-cmd-screenshot` — grabs the focused window's geometry via `hyprctl activewindow` and passes it directly to `grim`, requiring zero mouse interaction
- **Super + Shift + Ctrl + C** — screenshot the active window (no click needed)
- **Super + Alt + C** — screenshot the full screen (instant, no interaction)

These complement the existing **Super + Ctrl + C** (capture menu / smart mode) and follow the established modifier layering pattern (e.g. `Super + Ctrl + Z` = zoom in, `Super + Ctrl + Alt + Z` = reset zoom).

### Why?

The current `smart` mode is great for mouse-driven workflows, but keyboard-focused users (e.g. in tiling setups) have no way to screenshot without reaching for the mouse. The `windows` mode still requires a click to select, and `fullscreen` had no binding at all.

## Test plan

- [ ] Press **Super + Shift + Ctrl + C** — should instantly screenshot the focused window, copy to clipboard, and show the standard notification with edit action
- [ ] Press **Super + Alt + C** — should instantly screenshot the full screen with same behavior
- [ ] Press **Super + Ctrl + C** — existing capture menu should still work as before
- [ ] Run `omarchy-cmd-screenshot activewindow` from terminal — should work identically to the keybinding
- [ ] Verify neither **Super + Shift + Ctrl + C** nor **Super + Alt + C** conflict with existing bindings