### PR TITLE
Create user ~/.config/hypr/envs.conf by default and source from hyprland.conf

### DIFF
--- a/config/hypr/envs.conf
+++ b/config/hypr/envs.conf
@@ -1,0 +1,2 @@
+# Environment variables
+# env = XCURSOR_SIZE,24

--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -13,6 +13,7 @@ source = ~/.local/share/omarchy/default/hypr/windows.conf
 source = ~/.config/omarchy/current/theme/hyprland.conf
 
 # Change your own setup in these files (and overwrite any settings from defaults!)
+source = ~/.config/hypr/envs.conf
 source = ~/.config/hypr/monitors.conf
 source = ~/.config/hypr/input.conf
 source = ~/.config/hypr/bindings.conf


### PR DESCRIPTION
I noticed that the user's `~/.config/hypr/envs.conf` file was never created and sourced in the `~/.config/hypr/hyprland.conf` file. This is specifically important because `nvidia.sh` writes to `~/.config/hypr/envs.conf` for the Nvidia GPU env vars.

@Nickalus12 (#5123) we talked about automating the addition of the source to hyprland.conf, but I feel like that isn't the job of nvidia.sh and instead we should treat it exactly like `/config/hypr/autostart.conf` where the file is created with a brief comment on what the user can do with the file.

Would love some feedback on if this fix should be as simple as this?