### PR TITLE
Added theme agnostic background directory

### DIFF
--- a/default/elephant/omarchy_background_selector.lua
+++ b/default/elephant/omarchy_background_selector.lua
@@ -36,6 +36,7 @@ function GetEntries()
   -- Directories to search
   local dirs = {
     home .. "/.config/omarchy/current/theme/backgrounds",
+    home .. "/.config/omarchy/backgrounds",
   }
   if theme_name then
     table.insert(dirs, home .. "/.config/omarchy/backgrounds/" .. theme_name)


### PR DESCRIPTION
Made omarchy_background_selecor.lua also search for background images outside of the current theme directory.

This allows an easy way to add a background to all themes.