### PR TITLE
Support multiple post update hooks (example usage scripts)

### DIFF
--- a/config/omarchy/hooks/post-update.d/10-my-post-update-task-1.sample
+++ b/config/omarchy/hooks/post-update.d/10-my-post-update-task-1.sample
@@ -3,6 +3,6 @@
 # Example post-update.d hook. To use: drop the `.sample` suffix and chmod +x.
 # Runs after omarchy-update when ~/.config/omarchy/hooks/post-update is enabled.
 
-command -v notify-send >/dev/null 2>&1 || exit 0
+# command -v notify-send >/dev/null 2>&1 || exit 0
 
-notify-send -u low "First post-update task" "Example: first task completed."
+# notify-send -u low "First post-update task" "Example: first task completed."

--- a/config/omarchy/hooks/post-update.d/10-my-post-update-task-1.sample
+++ b/config/omarchy/hooks/post-update.d/10-my-post-update-task-1.sample
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Example post-update.d hook. To use: drop the `.sample` suffix and chmod +x.
+# Runs after omarchy-update when ~/.config/omarchy/hooks/post-update is enabled.
+
+command -v notify-send >/dev/null 2>&1 || exit 0
+
+notify-send -u low "First post-update task" "Example: first task completed."

--- a/config/omarchy/hooks/post-update.d/20-my-post-update-task-2.sample
+++ b/config/omarchy/hooks/post-update.d/20-my-post-update-task-2.sample
@@ -3,6 +3,6 @@
 # Example post-update.d hook. To use: drop the `.sample` suffix and chmod +x.
 # Runs after omarchy-update when ~/.config/omarchy/hooks/post-update is enabled.
 
-command -v notify-send >/dev/null 2>&1 || exit 0
+# command -v notify-send >/dev/null 2>&1 || exit 0
 
-notify-send -u low "Second post-update task" "Example: second task completed."
+# notify-send -u low "Second post-update task" "Example: second task completed."

--- a/config/omarchy/hooks/post-update.d/20-my-post-update-task-2.sample
+++ b/config/omarchy/hooks/post-update.d/20-my-post-update-task-2.sample
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Example post-update.d hook. To use: drop the `.sample` suffix and chmod +x.
+# Runs after omarchy-update when ~/.config/omarchy/hooks/post-update is enabled.
+
+command -v notify-send >/dev/null 2>&1 || exit 0
+
+notify-send -u low "Second post-update task" "Example: second task completed."

--- a/config/omarchy/hooks/post-update.sample
+++ b/config/omarchy/hooks/post-update.sample
@@ -7,7 +7,7 @@
 # notify-send -u low "Update Performed" "Your system is now up to date"
 
 
-# Optionally for multiple post-updatetasks: run every executable script in `post-update.d`, sorted by filename.
+# Optionally - for multiple post-update tasks: run every executable script in `post-update.d`, sorted by filename.
 # Drop-in hooks: create post-update.d if needed, add executable scripts, and they run
 # here in filename order (e.g. 10-my-post-update-task-1, 20-my-post-update-task-2). See post-update.d/ for examples.
 

--- a/config/omarchy/hooks/post-update.sample
+++ b/config/omarchy/hooks/post-update.sample
@@ -5,3 +5,21 @@
 
 # Example: Show notification after the system has been updated.
 # notify-send -u low "Update Performed" "Your system is now up to date"
+
+
+# Optionally for multiple post-updatetasks: run every executable script in `post-update.d`, sorted by filename.
+# Drop-in hooks: create post-update.d if needed, add executable scripts, and they run
+# here in filename order (e.g. 10-my-post-update-task-1, 20-my-post-update-task-2). See post-update.d/ for examples.
+
+# set -uo pipefail
+
+# HOOK_DIR="${HOME}/.config/omarchy/hooks/post-update.d"
+# [[ -d $HOOK_DIR ]] || exit 0
+
+# for hook in "$HOOK_DIR"/*; do
+#   [[ -f $hook && -x $hook ]] || continue
+#   echo "[omarchy post-update] running $(basename "$hook")"
+#   if ! "$hook"; then
+#     echo "[omarchy post-update] ERROR: $(basename "$hook") failed"
+#   fi
+# done

--- a/config/omarchy/hooks/post-update.sample
+++ b/config/omarchy/hooks/post-update.sample
@@ -21,7 +21,7 @@
 # shopt -u nullglob
 
 # for hook in "${hooks[@]}"; do
-#   [[ -f $hook && -x $hook ]] || continue
+#   [[ -f "$hook" && -x "$hook" ]] || continue
 #   echo "[omarchy post-update] running $(basename "$hook")"
 #   if ! "$hook"; then
 #     echo "[omarchy post-update] ERROR: $(basename "$hook") failed"

--- a/config/omarchy/hooks/post-update.sample
+++ b/config/omarchy/hooks/post-update.sample
@@ -7,16 +7,20 @@
 # notify-send -u low "Update Performed" "Your system is now up to date"
 
 
-# Optionally - for multiple post-update tasks: run every executable script in `post-update.d`, sorted by filename.
-# Drop-in hooks: create post-update.d if needed, add executable scripts, and they run
-# here in filename order (e.g. 10-my-post-update-task-1, 20-my-post-update-task-2). See post-update.d/ for examples.
+# Optionally, for multiple post-update tasks: run every executable script in `post-update.d`.
+# Paths are sorted explicitly (LC_ALL=C) so numeric prefixes like 10- and 20- run in order; plain
+# globs are not guaranteed sorted. Create post-update.d if needed. See post-update.d/ for examples.
 
 # set -uo pipefail
 
 # HOOK_DIR="${HOME}/.config/omarchy/hooks/post-update.d"
 # [[ -d $HOOK_DIR ]] || exit 0
 
-# for hook in "$HOOK_DIR"/*; do
+# shopt -s nullglob
+# mapfile -t hooks < <(printf '%s\n' "$HOOK_DIR"/* | LC_ALL=C sort)
+# shopt -u nullglob
+
+# for hook in "${hooks[@]}"; do
 #   [[ -f $hook && -x $hook ]] || continue
 #   echo "[omarchy post-update] running $(basename "$hook")"
 #   if ! "$hook"; then


### PR DESCRIPTION
## Summary

Documents an optional pattern for running several scripts after an Omarchy update by using a `post-update.d/` directory, and adds example drop-in hooks so users can copy and adapt them.

## Motivation

`omarchy-hook post-update` still runs a single executable at `~/.config/omarchy/hooks/post-update`. Users who want more than one post-update action (notifications, backups, package tweaks, etc.) benefit from a small, predictable convention: executable scripts in `post-update.d/`, run in **lexicographic order by path** using an explicit `LC_ALL=C sort` (not raw glob order, which is not guaranteed sorted), without changing `omarchy-hook` itself.

## What changed

- **`config/omarchy/hooks/post-update.sample`** — Comments describe optional use of `~/.config/omarchy/hooks/post-update.d/` and include a ready-to-uncomment loop that:
  - uses `nullglob` so an empty directory does not leave a stray `*` path;
  - builds a sorted list (`mapfile` + `printf` + `LC_ALL=C sort`) so numeric prefixes like `10-` and `20-` run in a stable order;
  - runs only regular executable files (`-f` and `-x`), logs each script, and reports failures without stopping the rest of the chain.

- **`config/omarchy/hooks/post-update.d/`** — Example scripts (`10-my-post-update-task-1.sample`, `20-my-post-update-task-2.sample`) demonstrate minimal valid bash hooks (e.g. desktop notifications), consistent with other `*.sample` hooks in this repo.

## How to use (for reviewers / release notes)

1. Copy defaults into `~/.config/omarchy/hooks/` as usual.
2. Rename `post-update.sample` → `post-update` and, if you want multiple hooks, uncomment the `post-update.d` block in that file.
3. Create `~/.config/omarchy/hooks/post-update.d/` if needed, copy examples, remove the `.sample` suffix, and `chmod +x` the scripts you want to run.

No changes to `bin/omarchy-hook` or `omarchy-update-perform` are required for this pattern.

## Checklist

- [ ] Sample comments match actual paths and behavior.
- [ ] Example scripts are valid bash and pass `shellcheck` (if you run it in CI).