### PR TITLE
Add style overrides for Mako and Walker

### DIFF
--- a/config/mako/config
+++ b/config/mako/config
@@ -1,0 +1,6 @@
+include=~/.config/omarchy/current/theme/mako.ini
+
+# Overwrite Mako configuration
+
+# border-size=4
+# border-radius=5

--- a/config/walker/style.css
+++ b/config/walker/style.css
@@ -1,9 +1,3 @@
 /**
- * Walker overrides go here.
+ * Override Walker styling CSS
  */
-
-/*
-.box-wrapper {
-  border: 1px solid @border;
-}
-*/

--- a/config/walker/style.css
+++ b/config/walker/style.css
@@ -1,0 +1,9 @@
+/**
+ * Walker overrides go here.
+ */
+
+/*
+.box-wrapper {
+  border: 1px solid @border;
+}
+*/

--- a/default/walker/themes/omarchy-default/style.css
+++ b/default/walker/themes/omarchy-default/style.css
@@ -114,3 +114,5 @@ child:selected .item-box * {
 
 .preview {
 }
+
+@import "../../../../../../../.config/walker/style.css";

--- a/install/config/theme.sh
+++ b/install/config/theme.sh
@@ -13,9 +13,6 @@ rm -rf ~/.config/chromium/SingletonLock # otherwise archiso will own the chromiu
 mkdir -p ~/.config/btop/themes
 ln -snf ~/.config/omarchy/current/theme/btop.theme ~/.config/btop/themes/current.theme
 
-mkdir -p ~/.config/mako
-ln -snf ~/.config/omarchy/current/theme/mako.ini ~/.config/mako/config
-
 # Add managed policy directories for Chromium and Brave for theme changes
 sudo mkdir -p /etc/chromium/policies/managed
 sudo chmod a+rw /etc/chromium/policies/managed

--- a/migrations/1775552171.sh
+++ b/migrations/1775552171.sh
@@ -1,0 +1,6 @@
+echo "Add CSS override for Walker"
+
+# If the existing CSS override file doesn't already exist, add it.
+if [[ ! -e ~/.config/walker/style.css ]]; then
+  cp $OMARCHY_PATH/config/walker/style.css ~/.config/walker/style.css
+fi

--- a/migrations/1775555289.sh
+++ b/migrations/1775555289.sh
@@ -1,0 +1,7 @@
+echo "Remove direct symlink to Mako config in theme, and copy over the new Mako config."
+
+# If there's a symlink, remove it and copy over the new config file.
+if [[ -L ~/.config/mako/config ]]; then
+  rm -f ~/.config/mako/config
+  cp $OMARCHY_PATH/config/mako/config ~/.config/mako/config
+fi


### PR DESCRIPTION
Building upon #3830, this PR additionally adds the ability to override Walker styling. This is done by adding a new `@import` statement at the end of the Omarchy-default Walker stylesheet that imports a user-editable stylesheet (which will be installed by default from now on, and that a migration script backfills for extant installations).

Again, I wanted to be able to reduce the border thickness and add a border radius to Walker and Mako windows, which we can already do with Hyprland windows and Sway popups, amongst other things. Here's how it looks:

Walker:
<img width="500" alt="screenshot-2026-04-07_17-56-01" src="https://github.com/user-attachments/assets/b25c723b-858b-4b48-8942-a6b9db9cb60f" />

Mako:
<img width="330" height="82" alt="screenshot-2026-04-07_17-58-06" src="https://github.com/user-attachments/assets/3edf656f-37bc-41c5-a4d0-66ca296666bc" />

