### PR TITLE
Add rotating backgrounds feature toggle

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -211,7 +211,7 @@ show_share_menu() {
 }
 
 show_toggle_menu() {
-  local options="󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰂛  Notifications\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n  Direct Boot\n󰟵  Passwordless Sudo"
+  local options="󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰂛  Notifications\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n󰑓  Cycle Backgrounds\n  Direct Boot\n󰟵  Passwordless Sudo"
 
   case $(menu "Toggle" "$options") in
   *Screensaver*) omarchy-toggle-screensaver ;;
@@ -223,6 +223,7 @@ show_toggle_menu() {
   *Ratio*) omarchy-hyprland-window-single-square-aspect-toggle ;;
   *Gaps*) omarchy-hyprland-window-gaps-toggle ;;
   *Scaling*) omarchy-hyprland-monitor-scaling-cycle ;;
+  *Cycle*) omarchy-toggle-bg-cycle ;;
   *"Direct Boot"*) present_terminal omarchy-config-direct-boot ;;
   *"Passwordless Sudo"*) present_terminal omarchy-sudo-passwordless ;;
   *) back_to show_trigger_menu ;;

--- a/bin/omarchy-toggle-bg-cycle
+++ b/bin/omarchy-toggle-bg-cycle
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if systemctl --user is-enabled --quiet omarchy-bg-cycle.timer; then
+  systemctl --user disable --now omarchy-bg-cycle.timer
+  notify-send -u low "󰑓  Background cycling disabled"
+else
+  systemctl --user daemon-reload
+  systemctl --user enable --now omarchy-bg-cycle.timer
+  notify-send -u low "󰑓  Background cycling enabled (hourly)"
+fi

--- a/bin/omarchy-toggle-bg-cycle
+++ b/bin/omarchy-toggle-bg-cycle
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 if systemctl --user is-enabled --quiet omarchy-bg-cycle.timer; then
-  systemctl --user disable --now omarchy-bg-cycle.timer
-  notify-send -u low "󰑓  Background cycling disabled"
+  if systemctl --user disable --now omarchy-bg-cycle.timer; then
+    notify-send -u low "󰑓  Background cycling disabled"
+  fi
 else
-  systemctl --user daemon-reload
-  systemctl --user enable --now omarchy-bg-cycle.timer
-  notify-send -u low "󰑓  Background cycling enabled (hourly)"
+  if systemctl --user enable --now omarchy-bg-cycle.timer; then
+    notify-send -u low "󰑓  Background cycling enabled (hourly)"
+  fi
 fi

--- a/config/systemd/user/omarchy-bg-cycle.service
+++ b/config/systemd/user/omarchy-bg-cycle.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Omarchy Background Cycle
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/share/omarchy/bin/omarchy-theme-bg-next
+KillMode=none

--- a/config/systemd/user/omarchy-bg-cycle.service
+++ b/config/systemd/user/omarchy-bg-cycle.service
@@ -5,4 +5,3 @@ After=graphical-session.target
 [Service]
 Type=oneshot
 ExecStart=%h/.local/share/omarchy/bin/omarchy-theme-bg-next
-KillMode=none

--- a/config/systemd/user/omarchy-bg-cycle.timer
+++ b/config/systemd/user/omarchy-bg-cycle.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Omarchy Background Cycle Timer
+Requires=omarchy-bg-cycle.service
+
+[Timer]
+OnCalendar=hourly
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/config/systemd/user/omarchy-bg-cycle.timer
+++ b/config/systemd/user/omarchy-bg-cycle.timer
@@ -4,6 +4,7 @@ Description=Omarchy Background Cycle Timer
 [Timer]
 OnCalendar=hourly
 AccuracySec=1min
+Persistent=true
 Unit=omarchy-bg-cycle.service
 
 [Install]

--- a/config/systemd/user/omarchy-bg-cycle.timer
+++ b/config/systemd/user/omarchy-bg-cycle.timer
@@ -1,10 +1,10 @@
 [Unit]
 Description=Omarchy Background Cycle Timer
-Requires=omarchy-bg-cycle.service
 
 [Timer]
 OnCalendar=hourly
 AccuracySec=1min
+Unit=omarchy-bg-cycle.service
 
 [Install]
 WantedBy=timers.target

--- a/migrations/1778860987.sh
+++ b/migrations/1778860987.sh
@@ -1,0 +1,7 @@
+echo "Install rotating backgrounds systemd timer"
+
+mkdir -p ~/.config/systemd/user
+cp "$OMARCHY_PATH/config/systemd/user/omarchy-bg-cycle.service" ~/.config/systemd/user/omarchy-bg-cycle.service
+cp "$OMARCHY_PATH/config/systemd/user/omarchy-bg-cycle.timer" ~/.config/systemd/user/omarchy-bg-cycle.timer
+
+systemctl --user daemon-reload


### PR DESCRIPTION
Some themes ship with multiple beautiful backgrounds and choosing just one means missing out on the rest. This PR adds background cycling as a first-class Omarchy feature so users can enjoy all of them automatically.

Accessible via the SUPER+CTRL+O trigger menu → Toggle → Cycle Backgrounds.

  When enabled, a systemd user timer fires `omarchy-theme-bg-next` hourly to
  automatically cycle through the active theme's backgrounds. The timer runs
  inside the user session, ensuring `WAYLAND_DISPLAY` and `DBUS_SESSION_BUS_ADDRESS`
  are available (unlike cron). `KillMode=none` is set on the service so systemd
  doesn't kill the newly launched `swaybg` process when cleaning up the cgroup.

  The feature is opt-in — nothing is auto-enabled on install.

  ## Changes

  - `bin/omarchy-toggle-bg-cycle` — enables/disables `omarchy-bg-cycle.timer` via `systemctl --user`, with notify-send feedback
  - `config/systemd/user/omarchy-bg-cycle.{service,timer}` — oneshot service + hourly timer unit files (deployed to `~/.config/systemd/user/` on install)
  - `bin/omarchy-menu` — adds Cycle Backgrounds entry to the Toggle submenu

<img width="600" height="1150" alt="image" src="https://github.com/user-attachments/assets/20353f72-51a7-4836-bac2-9cf90dfbc4a9" />
