### PR TITLE
fix: prevent DCS passthrough race in tdl causing nvim E349 on startup

### DIFF
--- a/default/bash/fns/tmux
+++ b/default/bash/fns/tmux
@@ -21,9 +21,14 @@ tdl() {
   # Split editor pane horizontally - AI on right 30% (capture new pane ID directly)
   ai_pane=$(tmux split-window -h -p 30 -t "$editor_pane" -c "$current_dir" -P -F '#{pane_id}')
 
+  # Block DCS passthrough on AI panes during init to prevent terminal capability
+  # responses from being misrouted to the editor pane during the focus transition
+  tmux set-option -p -t "$ai_pane" allow-passthrough off
+
   # If second AI provided, split the AI pane vertically
   if [[ -n $ai2 ]]; then
     ai2_pane=$(tmux split-window -v -t "$ai_pane" -c "$current_dir" -P -F '#{pane_id}')
+    tmux set-option -p -t "$ai2_pane" allow-passthrough off
     tmux send-keys -t "$ai2_pane" "$ai2" C-m
   fi
 
@@ -35,6 +40,13 @@ tdl() {
 
   # Select the nvim pane for focus
   tmux select-pane -t "$editor_pane"
+
+  # Restore passthrough after AI TUI init completes (DCS queries finish)
+  { sleep 1
+    tmux set-option -p -t "$ai_pane" allow-passthrough on 2>/dev/null
+    [[ -n $ai2_pane ]] && tmux set-option -p -t "$ai2_pane" allow-passthrough on 2>/dev/null
+  } &
+  disown
 }
 
 # Create multiple tdl windows with one per subdirectory in the current directory


### PR DESCRIPTION
## Summary

When `tdl` launches OpenCode (`alias c`) alongside nvim, OpenCode's TUI framework sends DCS passthrough terminal capability queries during initialization (wrapped as `\ePtmux;\e...\eST`). Because `tdl` creates the AI pane last, that pane has focus when `send-keys` fires. The queries are forwarded to the terminal emulator via `allow-passthrough=on` in `tmux.conf`.

The subsequent `select-pane` shifts focus to the editor pane before the terminal's responses arrive. Tmux delivers the incoming responses to the now-focused editor pane, where nvim misinterprets the leaked bytes as normal-mode commands, triggering **E349** ("No identifier under cursor") as a one-time flash on startup.

### Why this only affects OpenCode, not Claude Code

- **OpenCode** (`alias c` / `opencode`): Its TUI framework sends DCS passthrough terminal capability queries (DECRQM, XTVERSION, Kitty graphics queries, pixel resolution queries, etc.) immediately during startup. These are the sequences that get misrouted.
- **Claude Code** (`alias cx` / `claude`): Does not send DCS passthrough queries during TUI initialization. The `cx` alias also includes a `printf` screen-clear before launching, which produces only CSI sequences handled internally by tmux and generates no passthrough traffic.

### Fix

Temporarily disable `allow-passthrough` on AI panes at creation time using per-pane `tmux set-option -p`, blocking the DCS queries during the race window. After the focus transition completes, a background subshell restores passthrough after 1 second, once the AI tool's TUI init is finished. This preserves full passthrough capability for AI panes during normal use.

### Reproduction

1. tmux with `allow-passthrough=on` and `focus-events=on` (Omarchy defaults)
2. `tdl c` (OpenCode in AI pane, nvim in editor pane)
3. E349 flashes in nvim on startup

### Confirmed not affected

- `tdl cx` (Claude Code)
- `nvim` alone
- Any `tdl` invocation without OpenCode

## Test plan

- [ ] Run `tdl c` repeatedly; E349 should never appear
- [ ] Run `tdl cx`; confirm no regression
- [ ] Run `tdl c cx` (dual AI); confirm no regression
- [ ] Confirm passthrough still works on AI panes after the 1-second restore (e.g., any tool needing DCS passthrough)
- [ ] Test over SSH to confirm fix holds with network latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)