### PR TITLE
omarchy-reinstall-git: use existing remote instead of hardcoding

### DIFF
--- a/bin/omarchy-reinstall-git
+++ b/bin/omarchy-reinstall-git
@@ -2,7 +2,24 @@
 set -e
 
 # Reinstall the Omarchy configuration directory from the git source.
+#
+# URL and branch are derived from the existing $OMARCHY_PATH checkout so
+# any fork (arm ports, personal customizations, etc.) reinstalls from
+# the same remote it was running on. Falls back to upstream only if the
+# existing install has no usable git metadata.
 
-git clone --depth=1 "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new >/dev/null
+DEFAULT_URL="https://github.com/basecamp/omarchy.git"
+DEFAULT_BRANCH="master"
+
+REMOTE_URL=$(git -C "$OMARCHY_PATH" remote get-url origin 2>/dev/null || echo "$DEFAULT_URL")
+BRANCH=$(git -C "$OMARCHY_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "$DEFAULT_BRANCH")
+
+# Prefer HTTPS for cloning: avoids needing SSH keys configured, which
+# matters if reinstall is being run as a recovery action.
+case "$REMOTE_URL" in
+  git@github.com:*) REMOTE_URL="https://github.com/${REMOTE_URL#git@github.com:}" ;;
+esac
+
+git clone --depth=1 --branch "$BRANCH" "$REMOTE_URL" ~/.local/share/omarchy-new >/dev/null
 mv $OMARCHY_PATH ~/.local/share/omarchy-old
 mv ~/.local/share/omarchy-new $OMARCHY_PATH


### PR DESCRIPTION
## Problem

`omarchy-reinstall-git` hardcodes the clone URL:

```bash
git clone --depth=1 "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new
```

This means anyone running `omarchy-reinstall` on a fork (port for a different
arch, personal customizations, company-internal mirror, etc.) silently loses
their fork's customizations and ends up with upstream — without any warning.
It also implicitly clones the remote's default branch, so users on a non-default
branch lose that too.

## Fix

Read the clone URL from the existing `$OMARCHY_PATH` checkout's `origin` remote,
and the target branch from the current HEAD. Forks reinstall from themselves;
upstream users continue to reinstall from upstream (same behavior they get today).

Also converts SSH origin URLs to HTTPS for the clone step — reinstall is often a
recovery action and shouldn't depend on having an SSH agent/key configured.
Falls back to the upstream URL + `master` only if the existing install has no
usable git metadata.

## Testing

Verified on both an upstream `basecamp/omarchy` checkout and a fork
(`jondkinney/armarchy`, branch `amarchy-3-x`). Each now reinstalls from its
own origin and branch.