### PR TITLE
Add Logitech MX Keys key bindings

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -34,6 +34,6 @@ bindd = SUPER SHIFT ALT, X, X Post, exec, omarchy-launch-webapp "https://x.com/c
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu
 
 # Logitech MX Keys
-# bind = SUPER+SHIFT, S, exec, omarchy-cmd-screenshot          # Print Screen Button
+# bind = SUPER SHIFT, S, exec, omarchy-cmd-screenshot          # Print Screen Button
 # bind = SUPER, h, exec, voxtype record toggle                 # Dictation Button
 # bind = SUPER, period, exec, omarchy-launch-walker -m symbols # Emoji Button

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -32,3 +32,8 @@ bindd = SUPER SHIFT ALT, X, X Post, exec, omarchy-launch-webapp "https://x.com/c
 # Overwrite existing bindings, like putting Omarchy Menu on Super + Space
 # unbind = SUPER, SPACE
 # bindd = SUPER, SPACE, Omarchy menu, exec, omarchy-menu
+
+# Logitech MX Keys
+# bind = SUPER+SHIFT, S, exec, omarchy-cmd-screenshot          # Print Screen Button
+# bind = SUPER, h, exec, voxtype record toggle                 # Dictation Button
+# bind = SUPER, period, exec, omarchy-launch-walker -m symbols # Emoji Button

--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -35,5 +35,5 @@ bindd = SUPER SHIFT ALT, X, X Post, exec, omarchy-launch-webapp "https://x.com/c
 
 # Logitech MX Keys
 # bind = SUPER SHIFT, S, exec, omarchy-cmd-screenshot          # Print Screen Button
-# bind = SUPER, h, exec, voxtype record toggle                 # Dictation Button
-# bind = SUPER, period, exec, omarchy-launch-walker -m symbols # Emoji Button
+# bind = SUPER, H, exec, voxtype record toggle                 # Dictation Button
+# bind = SUPER, PERIOD, exec, omarchy-launch-walker -m symbols # Emoji Button


### PR DESCRIPTION
## Why
Instead of just reporting the XF86 convention Logitech had the great idea to report those keys as you can see in the binding.conf. I would prefer a firmware update to fix this but we will never have it.

I also don't want to install Solaar and don't think it should be installed by default just because a Logitech USB Receiver was detected during OS install.
The mute button is not there because it does not report anything at all that I could catch using wev.

Adding this commented so when Logitech MX Keys users went looking for why the PrintScn button is not working they will find this and then they can uncomment.