### PR TITLE
Install Emacs via omarchy-emacs AUR package

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -577,7 +577,7 @@ show_install_editor_menu() {
   *Sublime*) install_and_launch "Sublime Text" "sublime-text-4" "sublime_text" ;;
   *Helix*) present_terminal omarchy-install-helix ;;
   *Vim*) install "Vim" "vim" ;;
-  *Emacs*) install "Emacs" "emacs-wayland" && systemctl --user enable --now emacs.service ;;
+  *Emacs*) present_terminal "omarchy-pkg-aur-add omarchy-emacs && omarchy-install-emacs" ;;
   *) show_install_menu ;;
   esac
 }


### PR DESCRIPTION
## Summary

- Replaces the in-tree Emacs install with an install of the `omarchy-emacs` AUR package, mirroring the `omarchy-nvim` pattern.
- One-line change in `bin/omarchy-menu`; no new files, no new dependencies in the Omarchy tree.

## Context

This is a follow-up to #4807, where I originally proposed adding Emacs integration directly to Omarchy. @dhh, thank you for the feedback on that PR — your suggestion to package it as an AUR package (like `omarchy-nvim`) was exactly the right call, and working through it taught me a lot about Arch packaging conventions. Really appreciate it.

The integration now lives at:

- AUR: https://aur.archlinux.org/packages/omarchy-emacs
- Source: https://github.com/scottjones/omarchy-emacs

The AUR package ships `omarchy-install-emacs`, which is the single entry point for installing `emacs-wayland`, running setup (themes, font-sync hook, color template), and enabling the user `emacs.service` — equivalent to what the current menu line does today.

## Behavior

Before: `install "Emacs" "emacs-wayland" && systemctl --user enable --now emacs.service`
After:  `present_terminal "omarchy-pkg-aur-add omarchy-emacs && omarchy-install-emacs"`

End-user experience is unchanged — Emacs installs, configures, and starts the daemon. The config/theme code just lives in the AUR package instead of Omarchy itself.

## Test plan

- [x] Install via `omarchy-pkg-aur-add omarchy-emacs && omarchy-install-emacs` (the exact command the menu line invokes) succeeds
- [x] `emacs-wayland` is pulled in as a dependency of `omarchy-emacs`
- [x] `emacs.service` is enabled and running after install
- [x] Theme sync works (`omarchy-theme-set` → Emacs picks up new colors)
- [x] Font sync works (changing terminal font size updates Emacs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)