### PR TITLE
Enable SSD TRIM for LUKS-encrypted drives

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -29,6 +29,11 @@ EOF
 
   CMDLINE=$(grep "^[[:space:]]*cmdline:" "$limine_config" | head -1 | sed 's/^[[:space:]]*cmdline:[[:space:]]*//')
 
+  # Enable SSD TRIM passthrough for LUKS-encrypted drives
+  if [[ $CMDLINE == *"cryptdevice="* ]] && [[ $CMDLINE != *"allow-discards"* ]]; then
+    CMDLINE=$(echo "$CMDLINE" | sed 's/\(cryptdevice=[^ ]*\)/\1:allow-discards/')
+  fi
+
   sudo cp $OMARCHY_PATH/default/limine/default.conf /etc/default/limine
   sudo sed -i "s|@@CMDLINE@@|$CMDLINE|g" /etc/default/limine
 

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -31,7 +31,7 @@ EOF
 
   # Enable SSD TRIM passthrough for LUKS-encrypted drives
   if [[ $CMDLINE == *"cryptdevice="* ]] && [[ $CMDLINE != *"allow-discards"* ]]; then
-    CMDLINE=$(echo "$CMDLINE" | sed 's/\(cryptdevice=[^ ]*\)/\1:allow-discards/')
+    CMDLINE=$(printf '%s\n' "$CMDLINE" | sed 's/\(cryptdevice=[^ "]*\)/\1:allow-discards/')
   fi
 
   sudo cp $OMARCHY_PATH/default/limine/default.conf /etc/default/limine

--- a/migrations/1776500000.sh
+++ b/migrations/1776500000.sh
@@ -1,0 +1,26 @@
+echo "Enable SSD TRIM for LUKS-encrypted drives"
+
+# Only apply if the system uses LUKS encryption
+if ! grep -q "cryptdevice=" /etc/default/limine 2>/dev/null; then
+  exit 0
+fi
+
+# Skip if allow-discards is already configured
+if grep -q "allow-discards" /etc/default/limine 2>/dev/null; then
+  exit 0
+fi
+
+# Add :allow-discards to the cryptdevice= parameter in the boot config
+# Format: cryptdevice=device:dmname -> cryptdevice=device:dmname:allow-discards
+sudo sed -i 's/\(cryptdevice=[^ ]*\)/\1:allow-discards/' /etc/default/limine
+
+# Enable allow-discards on the running LUKS device so TRIM works immediately
+if [[ -b /dev/mapper/root ]]; then
+  sudo cryptsetup --allow-discards --persistent refresh root
+fi
+
+# Regenerate initramfs and boot entry
+sudo limine-mkinitcpio
+sudo limine-update
+
+echo "SSD TRIM enabled for LUKS encryption"

--- a/migrations/1776500000.sh
+++ b/migrations/1776500000.sh
@@ -12,11 +12,13 @@ fi
 
 # Add :allow-discards to the cryptdevice= parameter in the boot config
 # Format: cryptdevice=device:dmname -> cryptdevice=device:dmname:allow-discards
-sudo sed -i 's/\(cryptdevice=[^ ]*\)/\1:allow-discards/' /etc/default/limine
+sudo sed -i 's/\(cryptdevice=[^ "]*\)/\1:allow-discards/' /etc/default/limine
 
-# Enable allow-discards on the running LUKS device so TRIM works immediately
-if [[ -b /dev/mapper/root ]]; then
-  sudo cryptsetup --allow-discards --persistent refresh root
+# Extract the dmname from cryptdevice=device:dmname and enable allow-discards
+# on the running LUKS device so TRIM works immediately
+DMNAME=$(grep -oP 'cryptdevice=[^: "]+:\K[^: "]+' /etc/default/limine | head -1)
+if [[ -n $DMNAME ]] && [[ -b /dev/mapper/$DMNAME ]]; then
+  sudo cryptsetup --allow-discards --persistent refresh "$DMNAME"
 fi
 
 # Regenerate initramfs and boot entry


### PR DESCRIPTION
## Summary

- Add `:allow-discards` to the `cryptdevice=` kernel parameter so TRIM commands pass through the dm-crypt layer to the SSD
- Migration for existing installs applies immediately via `cryptsetup --persistent` (no reboot required)
- New installs get `:allow-discards` automatically during Limine setup

Closes #2229

## Details

Without `:allow-discards`, dm-crypt blocks all TRIM/DEALLOCATE commands from reaching the SSD — even on modern NVMe drives. The drive controller treats freed blocks as occupied data, increasing write amplification and reducing drive longevity.

Since kernel 6.2, btrfs automatically enables `discard=async`, so `fstrim.timer` is not needed. The only missing piece is allowing TRIM commands to pass through the LUKS encryption layer.

### Changes

**`migrations/1776500000.sh`** — Migration for existing installs:
- Detects LUKS encryption via `cryptdevice=` in `/etc/default/limine`
- Skips silently on unencrypted systems or if already configured
- Appends `:allow-discards` to the kernel parameter
- Applies immediately via `cryptsetup --allow-discards --persistent refresh root`
- Regenerates initramfs and boot entry

**`install/login/limine-snapper.sh`** — For new installs:
- Appends `:allow-discards` to the extracted `cryptdevice=` cmdline before writing to `/etc/default/limine`

## Test plan

- [ ] Verify on LUKS-encrypted system: `lsblk --discard` shows non-zero `DISC-GRAN` for root after migration
- [ ] Verify `sudo fstrim -av` trims the root partition
- [ ] Verify unencrypted systems are unaffected (migration exits cleanly)
- [ ] Verify fresh install on encrypted disk gets `:allow-discards` in `/etc/default/limine`
- [ ] Verify idempotent: running migration twice doesn't double-append