### PR TITLE
Add global ~/Wallpapers directory to background selector

### DIFF
--- a/default/elephant/omarchy_background_selector.lua
+++ b/default/elephant/omarchy_background_selector.lua
@@ -40,13 +40,14 @@ function GetEntries()
   if theme_name then
     table.insert(dirs, home .. "/.config/omarchy/backgrounds/" .. theme_name)
   end
+  table.insert(dirs, home .. "/Wallpapers")
 
   -- Track added files to avoid duplicates
   local seen = {}
 
   for _, wallpaper_dir in ipairs(dirs) do
     local handle = io.popen(
-      "find " .. ShellEscape(wallpaper_dir)
+      "find -L " .. ShellEscape(wallpaper_dir)
         .. " -maxdepth 1 -type f \\( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' -o -name '*.bmp' -o -name '*.webp' \\) 2>/dev/null | sort"
     )
     if handle then

--- a/migrations/1776587855.sh
+++ b/migrations/1776587855.sh
@@ -1,0 +1,5 @@
+echo "Create ~/Wallpapers directory for global wallpaper collection"
+
+if [[ ! -d "$HOME/Wallpapers" ]]; then
+  mkdir -p "$HOME/Wallpapers"
+fi

--- a/migrations/1776587855.sh
+++ b/migrations/1776587855.sh
@@ -1,5 +1,9 @@
 echo "Create ~/Wallpapers directory for global wallpaper collection"
 
-if [[ ! -d "$HOME/Wallpapers" ]]; then
+if [[ -d "$HOME/Wallpapers" ]]; then
+  :
+elif [[ -e "$HOME/Wallpapers" ]]; then
+  echo "Skipping ~/Wallpapers creation: $HOME/Wallpapers exists but is not a directory"
+else
   mkdir -p "$HOME/Wallpapers"
 fi


### PR DESCRIPTION
Addresses discussion #3164 and issue #5149. ~/Wallpapers is always included in the background selector regardless of the active theme, searched last so theme wallpapers take priority. find now uses -L to follow symlinks, so ~/Wallpapers can point to a mounted network share or similar. Migration 1776587855.sh creates the directory on first run.

If ~/Wallpapers is empty or doesn't exist, behaviour is unchanged.