### PR TITLE
Migrate existing waybar configs to pin battery to BAT0

### DIFF
--- a/migrations/1776674079.sh
+++ b/migrations/1776674079.sh
@@ -2,7 +2,9 @@ echo "Pin waybar battery module to BAT0 to prevent crash on HID battery disconne
 
 CONFIG_FILE=~/.config/waybar/config.jsonc
 
-if [[ -f "$CONFIG_FILE" ]] && ! grep -q '"bat":' "$CONFIG_FILE"; then
-  sed -i '/"battery": {/a\    "bat": "BAT0",' "$CONFIG_FILE"
+if [[ -f "$CONFIG_FILE" ]] \
+  && ! grep -Eq '"bat"[[:space:]]*:' "$CONFIG_FILE" \
+  && grep -Eq '"battery"[[:space:]]*:[[:space:]]*\{' "$CONFIG_FILE"; then
+  sed -i -E '/"battery"[[:space:]]*:[[:space:]]*\{/a\    "bat": "BAT0",' "$CONFIG_FILE"
   omarchy-restart-waybar
 fi

--- a/migrations/1776674079.sh
+++ b/migrations/1776674079.sh
@@ -1,0 +1,8 @@
+echo "Pin waybar battery module to BAT0 to prevent crash on HID battery disconnect"
+
+CONFIG_FILE=~/.config/waybar/config.jsonc
+
+if [[ -f "$CONFIG_FILE" ]] && ! grep -q '"bat":' "$CONFIG_FILE"; then
+  sed -i '/"battery": {/a\    "bat": "BAT0",' "$CONFIG_FILE"
+  omarchy-restart-waybar
+fi


### PR DESCRIPTION
Follow-up to #4918.

That PR pinned `"bat": "BAT0"` in the default waybar template, which fixes new installs.

This migration patches existing configs in place.

## Tested

- Running against the pre-#4918 template produces output byte-identical to the post-#4918 template (`diff` returns empty).
- Idempotent: second run skips.
- Missing file: skips cleanly (no error).
- Preserves users who've already set `"bat": "BAT1"` or another value — the `grep` guard short-circuits before `sed` runs.
- Locally applied and `omarchy-restart-waybar` succeeds.