### PR TITLE
Add k9s theme sync

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -55,6 +55,7 @@ omarchy-theme-set-browser
 omarchy-theme-set-vscode
 omarchy-theme-set-obsidian
 omarchy-theme-set-keyboard
+omarchy-theme-set-k9s
 
 # Call hook on theme set
 omarchy-hook theme-set "$THEME_NAME"

--- a/bin/omarchy-theme-set-k9s
+++ b/bin/omarchy-theme-set-k9s
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Sync Omarchy theme to k9s when the user already has a k9s config directory
+
+K9S_CONFIG_DIR="${K9S_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/k9s}"
+K9S_SKINS_DIR="$K9S_CONFIG_DIR/skins"
+OMARCHY_K9S_THEME="$HOME/.config/omarchy/current/theme/k9s.yaml"
+
+[[ -d $K9S_CONFIG_DIR ]] || exit 0
+[[ -f $OMARCHY_K9S_THEME ]] || exit 0
+
+mkdir -p "$K9S_SKINS_DIR"
+cp "$OMARCHY_K9S_THEME" "$K9S_SKINS_DIR/omarchy.yaml"

--- a/default/themed/k9s.yaml.tpl
+++ b/default/themed/k9s.yaml.tpl
@@ -1,0 +1,90 @@
+k9s:
+  body:
+    fgColor: '#{{ foreground_strip }}'
+    bgColor: '#{{ background_strip }}'
+    logoColor: '#{{ accent_strip }}'
+  prompt:
+    fgColor: '#{{ foreground_strip }}'
+    bgColor: '#{{ background_strip }}'
+    suggestColor: '#{{ color11_strip }}'
+  info:
+    fgColor: '#{{ accent_strip }}'
+    sectionColor: '#{{ foreground_strip }}'
+  dialog:
+    fgColor: '#{{ foreground_strip }}'
+    bgColor: '#{{ background_strip }}'
+    buttonFgColor: '#{{ foreground_strip }}'
+    buttonBgColor: '#{{ color13_strip }}'
+    buttonFocusFgColor: '#{{ color11_strip }}'
+    buttonFocusBgColor: '#{{ accent_strip }}'
+    labelFgColor: '#{{ color11_strip }}'
+    fieldFgColor: '#{{ foreground_strip }}'
+  frame:
+    border:
+      fgColor: '#{{ selection_foreground_strip }}'
+      focusColor: '#{{ selection_background_strip }}'
+    menu:
+      fgColor: '#{{ foreground_strip }}'
+      keyColor: '#{{ accent_strip }}'
+      numKeyColor: '#{{ accent_strip }}'
+    crumbs:
+      fgColor: '#{{ selection_foreground_strip }}'
+      bgColor: '#{{ selection_background_strip }}'
+      activeColor: '#{{ accent_strip }}'
+    status:
+      newColor: '#{{ color14_strip }}'
+      modifyColor: '#{{ color13_strip }}'
+      addColor: '#{{ color10_strip }}'
+      errorColor: '#{{ color9_strip }}'
+      highlightColor: '#{{ color11_strip }}'
+      killColor: '#{{ color8_strip }}'
+      completedColor: '#{{ color8_strip }}'
+    title:
+      fgColor: '#{{ foreground_strip }}'
+      bgColor: '#{{ background_strip }}'
+      highlightColor: '#{{ color11_strip }}'
+      counterColor: '#{{ color13_strip }}'
+      filterColor: '#{{ accent_strip }}'
+  views:
+    charts:
+      bgColor: '#{{ background_strip }}'
+      defaultDialColors:
+        - '#{{ color13_strip }}'
+        - '#{{ color9_strip }}'
+      defaultChartColors:
+        - '#{{ color13_strip }}'
+        - '#{{ color9_strip }}'
+    table:
+      fgColor: '#{{ foreground_strip }}'
+      bgColor: '#{{ background_strip }}'
+      cursorColor: '#{{ selection_background_strip }}'
+      header:
+        fgColor: '#{{ foreground_strip }}'
+        bgColor: '#{{ background_strip }}'
+        sorterColor: '#{{ color14_strip }}'
+    xray:
+      fgColor: '#{{ foreground_strip }}'
+      bgColor: '#{{ background_strip }}'
+      cursorColor: '#{{ selection_background_strip }}'
+      graphicColor: '#{{ color13_strip }}'
+      showIcons: false
+    yaml:
+      keyColor: '#{{ accent_strip }}'
+      colonColor: '#{{ color13_strip }}'
+      valueColor: '#{{ foreground_strip }}'
+    logs:
+      fgColor: '#{{ foreground_strip }}'
+      bgColor: '#{{ background_strip }}'
+      indicator:
+        fgColor: '#{{ foreground_strip }}'
+        bgColor: '#{{ color13_strip }}'
+        toggleOnColor: '#{{ color10_strip }}'
+        toggleOffColor: '#{{ color8_strip }}'
+    help:
+      fgColor: '#{{ foreground_strip }}'
+      bgColor: '#{{ background_strip }}'
+      keyColor: '#{{ accent_strip }}'
+      numKeyColor: '#{{ color13_strip }}'
+      sectionColor: '#{{ color8_strip }}'
+      indicator:
+        fgColor: '#{{ color9_strip }}'


### PR DESCRIPTION
Generate a k9s skin from the active Omarchy theme and sync it to ~/.config/k9s/skins/omarchy.yaml when a k9s config directory already exists.

Enable it in k9s with:

```
k9s:
  ui:
    skin: omarchy
```