### PR TITLE
Deprioritize iPhone USB tethering below Wi-Fi

### DIFF
--- a/default/systemd/network/15-ipheth.network
+++ b/default/systemd/network/15-ipheth.network
@@ -1,0 +1,27 @@
+# Deprioritize iPhone USB tethering below Wi-Fi so plugging in an iPhone
+# to charge does not hijack the default route.
+#
+# ipheth is the Linux kernel driver specific to iPhone USB Ethernet.
+# Without this drop-in, the iPhone matches /etc/systemd/network/20-ethernet.network
+# (which catches eth*/en*) and gets RouteMetric=100 — beating Wi-Fi (600) and
+# taking over the default route the moment the phone hands out a DHCP lease.
+#
+# This file sorts before 20-ethernet.network lexically, so systemd-networkd
+# matches it first for any interface whose driver is ipheth. Setting
+# RouteMetric=700 keeps Wi-Fi primary when both are up. If Wi-Fi drops, the
+# iPhone route automatically takes over.
+
+[Match]
+Driver=ipheth
+
+[Link]
+RequiredForOnline=no
+
+[Network]
+DHCP=yes
+
+[DHCPv4]
+RouteMetric=700
+
+[IPv6AcceptRA]
+RouteMetric=700

--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -7,4 +7,5 @@ sudo systemctl mask systemd-networkd-wait-online.service
 
 # Deprioritize iPhone USB tethering below Wi-Fi so plugging in an iPhone
 # to charge does not hijack the default route.
+sudo mkdir -p /etc/systemd/network
 sudo cp ~/.local/share/omarchy/default/systemd/network/15-ipheth.network /etc/systemd/network/

--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -4,3 +4,7 @@ sudo systemctl enable iwd.service
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service
+
+# Deprioritize iPhone USB tethering below Wi-Fi so plugging in an iPhone
+# to charge does not hijack the default route.
+sudo cp ~/.local/share/omarchy/default/systemd/network/15-ipheth.network /etc/systemd/network/

--- a/migrations/1777042493.sh
+++ b/migrations/1777042493.sh
@@ -1,0 +1,4 @@
+echo "Deprioritize iPhone USB tethering below Wi-Fi so plugging in an iPhone to charge does not hijack the default route"
+
+sudo cp $OMARCHY_PATH/default/systemd/network/15-ipheth.network /etc/systemd/network/
+sudo networkctl reload 2>/dev/null || sudo systemctl reload systemd-networkd 2>/dev/null || true

--- a/migrations/1777042493.sh
+++ b/migrations/1777042493.sh
@@ -1,4 +1,5 @@
 echo "Deprioritize iPhone USB tethering below Wi-Fi so plugging in an iPhone to charge does not hijack the default route"
 
+sudo mkdir -p /etc/systemd/network
 sudo cp $OMARCHY_PATH/default/systemd/network/15-ipheth.network /etc/systemd/network/
 sudo networkctl reload 2>/dev/null || sudo systemctl reload systemd-networkd 2>/dev/null || true


### PR DESCRIPTION
## Summary

Plugging an iPhone into USB (even just to charge) loads the `ipheth` kernel driver, which exposes the phone as a generic USB ethernet device. It then matches `/etc/systemd/network/20-ethernet.network` (which catches `eth*`/`en*`) and gets `RouteMetric=100` — beating Wi-Fi at 600 and taking over the default route the moment the phone hands out a DHCP lease. Users lose internet when simply charging their phone if the tether can't actually reach the internet (no data plan, poor signal, tethering disabled upstream).

This PR adds `/etc/systemd/network/15-ipheth.network` with `[Match] Driver=ipheth` and `RouteMetric=700`. systemd-networkd processes `.network` files in lexical order and uses the first match, so iPhone interfaces hit this file before the generic `20-ethernet.network`. Wi-Fi (600) now wins when both are up; if Wi-Fi drops, the tether still takes over automatically. Real USB ethernet dongles use different drivers (CDC-ECM/NCM/RNDIS) and are unaffected.

## Changes

- **`default/systemd/network/15-ipheth.network`** — the drop-in (`Driver=ipheth`, metric 700, `RequiredForOnline=no` so boot never waits on the phone).
- **`install/config/hardware/network.sh`** — installs the drop-in on fresh systems.
- **`migrations/1777042493.sh`** — installs the drop-in on existing systems and reloads systemd-networkd.

## Why driver-based matching

`ipheth` is a Linux kernel driver specific to Apple's iPhone USB tethering protocol (vendor `05ac`, iPhone product IDs). It doesn't bind to iPads, Android phones, or generic USB-ethernet adapters, so `Driver=ipheth` is a perfect filter for "this interface came from an iPhone."

## Test plan

- [ ] Reproduced the original issue: iPhone plugged in → `eth0` appears → default route moves to `172.20.10.1` at metric 100 → Wi-Fi deprioritized → internet breaks when tether has no upstream.
- [ ] Apply the drop-in, re-plug iPhone, verify `ip route` shows `default via 192.168.1.1 dev wlan0 ... metric 600` before the iPhone route at metric 700.
- [ ] Turn Wi-Fi off, verify traffic falls over to the iPhone tether automatically.
- [ ] Plug in a real USB-ethernet dongle (non-ipheth), verify it still takes priority as before at metric 100.
- [ ] Run the migration on an existing system, confirm `/etc/systemd/network/15-ipheth.network` is in place and `networkctl reload` succeeds.
