### PR TITLE
Add todo styles to Walker default theme

### DIFF
--- a/default/walker/themes/omarchy-default/style.css
+++ b/default/walker/themes/omarchy-default/style.css
@@ -119,3 +119,27 @@ child:selected {
 .preview {
 }
 
+.todo .item-subtext {
+  color: alpha(@text, 0.5);
+  font-size: 12px;
+}
+
+.todo.active .item-text,
+.todo.active .item-subtext {
+  font-style: italic;
+}
+
+.todo.critical .item-text,
+.todo.urgent .item-text {
+  text-decoration: underline;
+}
+
+.todo.done .item-text,
+.todo.done .item-subtext {
+  color: alpha(@text, 0.5);
+  text-decoration: line-through;
+}
+
+child:selected .todo * {
+  color: @selected-text;
+}


### PR DESCRIPTION
Adds default Walker theme styling for todo entries so subtext, active, urgent/critical, done, and selected states are displayed consistently in the launcher.

## Background

By accident, I discovered Walker's todo feature (`Cmd+Space`, then `!`, or `Cmd+Space`, then `/todo`), which seems to be shipped by default and also supports time-based notifications. Very nice feature.

I played around with it, but I could not find a visual indicator when the status changes. I then enabled the second line, which shows some status details, and added minimal visual CSS.

The idea behind the CSS is that `Active tasks` (`Return`) are _italicized_ to suggest movement. `Urgent/Critical` tasks are <ins>underlined</ins>, and `Done/finished` todos (`Ctrl+F`) are ~~struck through~~.

Examples:

- `in 10m > Check the oven` creates a time-based todo.
- `Review PR!` creates a critical todo.
- `in 10m > Check the oven!` creates a time-based critical todo.

Default keybindings: https://walkerlauncher.com/docs/keybindings#todo

Notice: When adding a new todo item (Ctrl+a), an icon is shown by default. This is untouched default behavior and does not match perfectly, so I focused only on the list item styles itself.