### PR TITLE
Add "Sleep Displays" to System menu

### DIFF
--- a/bin/omarchy-cmd-sleep-displays
+++ b/bin/omarchy-cmd-sleep-displays
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Power off all monitors via DPMS; any input wakes them.
+
+# Detach with a short delay so trailing input from the launcher (key release,
+# focus change) doesn't immediately wake the displays.
+(sleep 1 && hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })') &
+disown

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -28,6 +28,7 @@
   // System
   "system.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-launch-screensaver force"},
   "system.lock": {"icon":"","label":"Lock","keywords":"screen","action":"omarchy-system-lock"},
+  "system.sleep-displays": {"icon":"󰍹","label":"Sleep Displays","keywords":"monitor dpms screen off blank","action":"omarchy-cmd-sleep-displays"},
   "system.suspend": {"icon":"󰒲","label":"Suspend","keywords":"sleep","when":"! omarchy-toggle-enabled suspend-off","action":"systemctl suspend"},
   "system.hibernate": {"icon":"󰤁","label":"Hibernate","keywords":"sleep","when":"omarchy-hibernation-available","action":"systemctl hibernate"},
   "system.logout": {"icon":"󰍃","label":"Logout","keywords":"sign out","action":"omarchy-system-logout"},


### PR DESCRIPTION
## Summary
- Adds a **Sleep Displays** entry to the System menu (`default/omarchy/omarchy-menu.jsonc`), between Lock and Suspend
- New helper `bin/omarchy-cmd-sleep-displays` powers off all monitors via DPMS without locking or suspending the session — any input wakes them
- Helper detaches the DPMS dispatch with a 1s delay so trailing input from closing the launcher (key release, focus change) doesn't immediately wake the displays

## Motivation
There's no built-in way to manually sleep just the displays — equivalent to macOS's "sleep displays" / Ctrl+Shift+Power. `Lock` brings up the lock screen, `Suspend` puts the whole machine to sleep. This sits between them: blank the screens, keep everything else running, wake on any input.

## Notes
Rebased onto `omarchy-4` and reworked for the 4.x code path:
- Menu entry is now a row in the JSONC menu (`system.sleep-displays`) rather than a `show_system_menu` case in the old bash `omarchy-menu`.
- Uses the current Lua dispatch form `hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'`, matching `omarchy-brightness-display`.

## Test plan
- [x] Open the Omarchy menu → System → Sleep Displays — displays power off, wake on key/mouse input
- [x] Searchable via the menu (keywords: monitor / dpms / screen / off / blank)
- [x] Verify `omarchy-cmd-sleep-displays` works from a terminal too