### PR TITLE
Show app name for poorly-tagged GStreamer streams in wiremix

### DIFF
--- a/config/wiremix/wiremix.toml
+++ b/config/wiremix/wiremix.toml
@@ -15,6 +15,29 @@ types = [ "stream" ]
 matches = [ { "client:application.name" = "spotify" } ]
 templates = [ "Spotify" ]
 
+# Cliamp is an ALSA app routed through pipewire-alsa, which sets
+# application.name to "PipeWire ALSA [cliamp]". Match on the binary name
+# instead so the stream shows as "C L I A M P" (matching its own branding).
+[[names.overrides]]
+types = [ "stream" ]
+matches = [ { "client:application.process.binary" = "cliamp" } ]
+templates = [ "C L I A M P" ]
+
+# Chromium and Brave use node.name=<browser> and media.name="Playback", so
+# the default template renders the redundant "<browser>: Playback". Drop the
+# suffix since it carries no information (Chromium-based browsers don't
+# expose tab title or URL via PipeWire — that's MPRIS-only). Firefox is
+# fine as-is: it puts the page title in media.name.
+[[names.overrides]]
+types = [ "stream" ]
+matches = [ { "client:application.name" = "Chromium" } ]
+templates = [ "Chromium" ]
+
+[[names.overrides]]
+types = [ "stream" ]
+matches = [ { "client:application.name" = "Brave" } ]
+templates = [ "Brave" ]
+
 # Catch-all for any other GStreamer pipeline that ships with the same
 # untagged "audio-src" media name.
 [[names.overrides]]

--- a/migrations/1778213412.sh
+++ b/migrations/1778213412.sh
@@ -3,7 +3,10 @@ echo "Add wiremix name overrides for poorly-tagged GStreamer streams (e.g., Spot
 config=~/.config/wiremix/wiremix.toml
 [[ -f $config ]] || exit 0
 
-if ! grep -q '\[\[names.overrides\]\]' "$config"; then
+# Each rule is checked by its own unique match line so existing user overrides
+# (for unrelated apps) are preserved and don't suppress these additions.
+
+if ! grep -qF '"client:application.name" = "spotify"' "$config"; then
   cat <<'EOF' >>"$config"
 
 # Spotify on Linux uses GStreamer for playback and doesn't override the
@@ -16,6 +19,11 @@ if ! grep -q '\[\[names.overrides\]\]' "$config"; then
 types = [ "stream" ]
 matches = [ { "client:application.name" = "spotify" } ]
 templates = [ "Spotify" ]
+EOF
+fi
+
+if ! grep -qF '"node:media.name" = "audio-src"' "$config"; then
+  cat <<'EOF' >>"$config"
 
 # Catch-all for any other GStreamer pipeline that ships with the same
 # untagged "audio-src" media name.

--- a/migrations/1778213412.sh
+++ b/migrations/1778213412.sh
@@ -1,8 +1,10 @@
-# overwrites default wiremix configuration
-# defaults: https://github.com/tsowell/wiremix/blob/main/wiremix.toml
+echo "Add wiremix name overrides for poorly-tagged GStreamer streams (e.g., Spotify)"
 
-[char_sets.default]
-default_device = "⮞"
+config=~/.config/wiremix/wiremix.toml
+[[ -f $config ]] || exit 0
+
+if ! grep -q '\[\[names.overrides\]\]' "$config"; then
+  cat <<'EOF' >>"$config"
 
 # Spotify on Linux uses GStreamer for playback and doesn't override the
 # pulsesink stream-properties, so its PipeWire node inherits the default
@@ -21,3 +23,5 @@ templates = [ "Spotify" ]
 types = [ "stream" ]
 matches = [ { "node:media.name" = "audio-src" } ]
 templates = [ "{client:application.name}" ]
+EOF
+fi

--- a/migrations/1778213412.sh
+++ b/migrations/1778213412.sh
@@ -1,4 +1,4 @@
-echo "Add wiremix name overrides for poorly-tagged GStreamer streams (e.g., Spotify)"
+echo "Add wiremix name overrides for poorly-tagged streams (Spotify, cliamp, Chromium, Brave)"
 
 config=~/.config/wiremix/wiremix.toml
 [[ -f $config ]] || exit 0
@@ -19,6 +19,44 @@ if ! grep -qF '"client:application.name" = "spotify"' "$config"; then
 types = [ "stream" ]
 matches = [ { "client:application.name" = "spotify" } ]
 templates = [ "Spotify" ]
+EOF
+fi
+
+if ! grep -qF '"client:application.process.binary" = "cliamp"' "$config"; then
+  cat <<'EOF' >>"$config"
+
+# Cliamp is an ALSA app routed through pipewire-alsa, which sets
+# application.name to "PipeWire ALSA [cliamp]". Match on the binary name
+# instead so the stream shows as "C L I A M P" (matching its own branding).
+[[names.overrides]]
+types = [ "stream" ]
+matches = [ { "client:application.process.binary" = "cliamp" } ]
+templates = [ "C L I A M P" ]
+EOF
+fi
+
+if ! grep -qF '"client:application.name" = "Chromium"' "$config"; then
+  cat <<'EOF' >>"$config"
+
+# Chromium and Brave use node.name=<browser> and media.name="Playback", so
+# the default template renders the redundant "<browser>: Playback". Drop the
+# suffix since it carries no information (Chromium-based browsers don't
+# expose tab title or URL via PipeWire — that's MPRIS-only). Firefox is
+# fine as-is: it puts the page title in media.name.
+[[names.overrides]]
+types = [ "stream" ]
+matches = [ { "client:application.name" = "Chromium" } ]
+templates = [ "Chromium" ]
+EOF
+fi
+
+if ! grep -qF '"client:application.name" = "Brave"' "$config"; then
+  cat <<'EOF' >>"$config"
+
+[[names.overrides]]
+types = [ "stream" ]
+matches = [ { "client:application.name" = "Brave" } ]
+templates = [ "Brave" ]
 EOF
 fi
 


### PR DESCRIPTION
## Summary

Show real app names for audio streams whose default PipeWire tagging is unhelpful. Five `[[names.overrides]]` rules in `config/wiremix/wiremix.toml` cover the common offenders so wiremix's *Playback* tab is actually readable when you're routing per-app audio.

## What this PR changes

| Stream | Before | After | How it matches |
| --- | --- | --- | --- |
| Spotify | `audio-src: audio-src` | `Spotify` | `client:application.name = "spotify"` |
| Cliamp | `alsa_playback.cliamp: ALSA Playback` | `C L I A M P` | `client:application.process.binary = "cliamp"` |
| Chromium | `Chromium: Playback` | `Chromium` | `client:application.name = "Chromium"` |
| Brave | `Brave: Playback` | `Brave` | `client:application.name = "Brave"` |
| Other GStreamer-mistagged app | `audio-src: audio-src` | *(client app name)* | `node:media.name = "audio-src"` (catch-all) |
| Firefox, Zoom, mpv, VLC, … | unchanged | unchanged | — (already tag themselves correctly) |

## Why each app needs help

**Spotify** uses GStreamer for playback and doesn't override the `pulsesink` stream-properties, so its PipeWire **node** inherits the default `appsrc` element name `audio-src`. The default wiremix template (`{node:node.name}: {node:media.name}`) only reads node-level properties, so it has nothing better to render. The Spotify client *does* set `application.name = "spotify"` on its PipeWire **client** object — wiremix supports `{client:...}` placeholders that resolve through the linked client, which is where the fix comes from.

**Cliamp** is an ALSA app routed through `pipewire-alsa`, so its `application.name` shows up as `"PipeWire ALSA [cliamp]"`. Matching on `application.process.binary` skips the wrapper and renders the spaced-out brand `C L I A M P`.

**Chromium and Brave** both set `node.name=<browser>` and `media.name="Playback"`, which the default template joins as the redundant `<browser>: Playback`. Chromium-based browsers don't expose tab title or URL via PipeWire (that's MPRIS-only), so the suffix carries no information — drop it. Firefox is left alone because it already puts the page title in `media.name` (e.g. `Firefox: Fear and Excitement For My TED Talk | Flow State with Harry Mack #35 - YouTube`).

**Generic `audio-src` catch-all** picks up any other app that builds a stock GStreamer pipeline without setting sink properties.

## Override ordering

wiremix evaluates overrides first-match-wins (`src/config/names.rs::name_override` uses `find_map`), so specific rules must come before the generic catch-all. The new file orders them: Spotify, Cliamp, Chromium, Brave, then the `audio-src` catch-all.

## Migration

`migrations/1778213412.sh` applies the same rules idempotently to existing users' `~/.config/wiremix/wiremix.toml`. Each rule is checked by its own unique match line and appended independently, so users with their own unrelated overrides (Discord, OBS, etc.) keep them and still get all five additions. New installs pick up the same content through the existing config-copy path.

## Why ship this here, not upstream in wiremix

wiremix is a generic PipeWire mixer; baking app-specific defaults into it doesn't scale and runs against its design — the override system is the documented customization point. Distribution-layer config is the right home for "patch around noisy defaults from popular apps", and omarchy already personalizes `wiremix.toml` (the `default_device = "⮞"` glyph), so this fits the same scope.

## Screenshots

### Spotify before

<img width="1750" height="1200" alt="wiremix-spotify-before" src="https://github.com/user-attachments/assets/17e19202-c3f2-4bd8-8d6c-23dfe0fa4a4f" />

### Spotify after

<img width="1750" height="1200" alt="wiremix-spotify-after" src="https://github.com/user-attachments/assets/acd9edb5-50ea-4389-957f-10fc95ed4125" />

### CLIAMP & other browsers

<img width="1538" height="1216" alt="image" src="https://github.com/user-attachments/assets/9bfda91a-641e-435b-bfa2-68936c16113f" />

### So much going on at once!

<img width="3072" height="3456" alt="image" src="https://github.com/user-attachments/assets/3011ff78-1ff3-4cb6-84c4-7609afaebd82" />

## Test plan

- [ ] Play a track in Spotify → expect a `Spotify` row.
- [ ] Play a track in Cliamp → expect a `C L I A M P` row.
- [ ] Play audio in Chromium or Brave → expect a `Chromium` / `Brave` row (no `: Playback` suffix).
- [ ] Play a YouTube video in Firefox → expect the row to show the page title (unchanged from default behavior).
- [ ] On a system with an existing `~/.config/wiremix/wiremix.toml`, run the migration and verify all five rules end up appended to the file. Re-running the migration should be a no-op.
- [ ] On a system with pre-existing unrelated overrides (e.g. a custom Discord rule), verify those overrides are preserved after migration.
