### PR TITLE
Enable monthly btrfs scrub on root

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -29,6 +29,7 @@ run_logged $OMARCHY_INSTALL/config/kernel-modules-hook.sh
 run_logged $OMARCHY_INSTALL/config/powerprofilesctl-rules.sh
 run_logged $OMARCHY_INSTALL/config/wifi-powersave-rules.sh
 run_logged $OMARCHY_INSTALL/config/plocate-ac-only.sh
+run_logged $OMARCHY_INSTALL/config/btrfs-scrub.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/network.sh
 run_logged $OMARCHY_INSTALL/config/hardware/set-wireless-regdom.sh

--- a/install/config/btrfs-scrub.sh
+++ b/install/config/btrfs-scrub.sh
@@ -1,0 +1,12 @@
+# Enable monthly btrfs scrub on the root filesystem so silent bitrot is
+# detected (and corrected via the second copy / parity if redundancy exists).
+# btrfs-progs ships the btrfs-scrub@.timer template — we just enable the
+# instance for "/". The instance name "-" is systemd-escape for "/".
+#
+# No-op if root isn't btrfs (e.g. someone is using ext4).
+
+if [[ $(findmnt -no FSTYPE / 2>/dev/null) != "btrfs" ]]; then
+  exit 0
+fi
+
+chrootable_systemctl_enable btrfs-scrub@-.timer

--- a/migrations/1777962247.sh
+++ b/migrations/1777962247.sh
@@ -1,0 +1,7 @@
+echo "Enable monthly btrfs scrub on root (uses btrfs-progs's btrfs-scrub@.timer)"
+
+if [[ $(findmnt -no FSTYPE / 2>/dev/null) != "btrfs" ]]; then
+  exit 0
+fi
+
+sudo systemctl enable --now btrfs-scrub@-.timer

--- a/migrations/1777962247.sh
+++ b/migrations/1777962247.sh
@@ -4,4 +4,9 @@ if [[ $(findmnt -no FSTYPE / 2>/dev/null) != "btrfs" ]]; then
   exit 0
 fi
 
+if ! systemctl list-unit-files 'btrfs-scrub@-.timer' --no-legend 2>/dev/null | grep -q '^btrfs-scrub@-.timer'; then
+  echo "Skipping btrfs scrub timer: btrfs-scrub@-.timer is unavailable (btrfs-progs may not be installed)"
+  exit 0
+fi
+
 sudo systemctl enable --now btrfs-scrub@-.timer


### PR DESCRIPTION
## Summary

btrfs scrub is used to scrub a mounted btrfs filesystem, which will read all data and metadata blocks from all devices and verify checksums, and automatically repair corrupted blocks if there’s a correct copy available.

The recommended interval for a btrfs scrub is monthly, although more frequent scrubbing is OK. 

The / and /home btrfs volumes silently go unscrubbed by deafult in Omarchy out-of-the-box. `btrfs-progs` ships the `btrfs-scrub@.timer` template:  this PR enables it so that it runs on  `/` and by extention, on the subvolume `/home`' at the recommended interval.

## Why this matters

Scrub is btrfs's only way to detect and repair silent bitrot. Without periodic scrubs, data corruption can propagate into snapshots and backups before the user notices. This fix will cause omarchy to scan for filesystem data integrity problems. And in the case where auto-repair is not possible, it gives the user a chance to restore the file from a snapshot before they are pruned by snapper. 
 
On single disk systems, BTRFS by default stores 2 metadata copies: when file corruption is detected, it is sometimes possible to repair by the scrub. On dual-drive systems with a mirrored volume, the scrub operation will be able to recover corrupted data from the known-good copy.  

I kept 30 days for the scrub thinking that the 5th snapshot is likely to be more than 30 days old, so if a scrub fails and someone needs to recover a file from a snapshot, it's likely to be present. With the recent pace of releases, this might be too long an interval - but we can tune it if needed. 

## What this changes

These changes are limited to enabling what \`btrfs-progs\` already ships:

- **`install/config/btrfs-scrub.sh`** (new) — gates on `findmnt /` being btrfs, calls `chrootable_systemctl_enable btrfs-scrub@-.timer`. The `-` is systemd-escape for `/`.
- **`install/config/all.sh`** — one new \`run_logged\` line.
- **`migrations/1777962247.sh`** (new) — enables the timer on existing systems on the next \`omarchy-update\`. Idempotent.

## Test Evidence 

Migration will activate the timer: 

<img width="2456" height="1526" alt="screenshot-2026-05-08_00-31-21" src="https://github.com/user-attachments/assets/ee21a1b8-6630-44c2-a6dc-8fd0f2d956dc" />

Timer invokes the service unit, which kicks off a scrub: 

<img width="2452" height="1528" alt="screenshot-2026-05-08_00-33-52" src="https://github.com/user-attachments/assets/2537b090-569d-4f6e-8a52-31aad5bc15b8" />

Scrub completes pretty quickly on a 30GB partition. Low load background task. 

<img width="2456" height="1537" alt="screenshot-2026-05-08_00-35-17" src="https://github.com/user-attachments/assets/578eec26-0637-4aba-a1da-55201b70657c" />

