### PR TITLE
fix imv image navigation

### DIFF
--- a/applications/imv.desktop
+++ b/applications/imv.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Image Viewer
-Exec=imv %F
+Exec=imv-dir %F
 Icon=imv
 Type=Application
 MimeType=image/png;image/jpeg;image/jpg;image/gif;image/bmp;image/webp;image/tiff;image/x-xcf;image/x-portable-pixmap;image/x-xbitmap;

--- a/migrations/1778000380.sh
+++ b/migrations/1778000380.sh
@@ -1,0 +1,3 @@
+echo "Let Image Viewer navigate images in the same directory"
+
+cp -f "$OMARCHY_PATH/applications/imv.desktop" ~/.local/share/applications/imv.desktop


### PR DESCRIPTION
Opening one image from Files currently gives imv a one-image playlist, so
Left/Right cannot browse its folder. Use the packaged `imv-dir` helper to open
the containing folder at the clicked image. Selecting multiple images still
opens only that selection.

The launcher fix remains one line:

```diff
-Exec=imv %F
+Exec=imv-dir %F
```

The six-line migration changes only the exact stock command in an existing
user launcher. It preserves other fields, custom launch commands and symlinks,
and safely skips missing launchers. No new dependency or wrapper is needed.

Fixes #4050 and #11292 (reported again on September 11).
Also addresses the September 21 request in
https://github.com/omacom/omarchy/discussions/12830.

Related: #11294 proposes the same launcher change against `quattro`; its
migration copies the whole desktop file if present. This migration instead
preserves launcher customizations. Earlier directory-navigation attempts:
#1437, #1444, #2190 and #3758.

Validation on current `quattro`:

- `desktop-file-validate applications/imv.desktop` and Bash syntax checks pass.
- `./test/cli` passes.
- Existing `desktop-entry-launch` and `migrate-wrapper` shell tests pass.
- Checked the migration against temporary homes: repeat runs, absent launchers,
  custom commands, custom fields and symlink preservation.
- Verified in the running Hyprland UI using `gio launch` and the stock imv
  config: one selected image starts at 2/3 and Left/Right browses the folder;
  selecting two images cycles only those two. Paths with spaces and apostrophes
  work. Compared and inspected baseline/candidate screenshots.
