### PR TITLE
Additional "island" version to your waybar style collection

### DIFF
--- a/config/waybar/configs/island.jsonc
+++ b/config/waybar/configs/island.jsonc
@@ -1,0 +1,175 @@
+{
+  "reload_style_on_change": true,
+  "layer": "top",
+  "position": "top",
+  "spacing": 0,
+  "height": 26,
+  "modules-left": ["custom/omarchy", "hyprland/workspaces", "hyprland/window"],
+  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-right": [
+    "mpris",
+    "group/tray-expander",
+    "backlight",
+    "network",
+    "bluetooth",
+    "pulseaudio",
+    "cpu",
+    "battery"
+  ],
+  "hyprland/workspaces": {
+    "disable-scroll": true,
+    "all-outputs": true,
+    "cursor": true,
+    "format": "{icon}",
+      "persistent-workspaces": {
+      "*": 5
+    }
+  },
+  "custom/omarchy": {
+    "format": "<span font='omarchy'>\ue900</span>",
+    "on-click": "omarchy-menu",
+    "on-click-right": "xdg-terminal-exec",
+    "tooltip-format": "Omarchy Menu\n\nSuper + Alt + Space"
+  },
+  "custom/update": {
+    "format": "",
+    "exec": "omarchy-update-available",
+    "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update",
+    "tooltip-format": "Omarchy update available",
+    "signal": 7,
+    "interval": 21600
+  },
+  "cpu": {
+    "interval": 5,
+    "format": "󰍛",
+    "on-click": "omarchy-launch-or-focus-tui btop",
+    "on-click-right": "alacritty"
+  },
+  "clock": {
+    "format": "{:%I:%M %p}",
+    "format-alt": "{:%A %d/%m/%Y}",
+    "tooltip-format": "<span>{calendar}</span>",
+    "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
+  },
+  "network": {
+    "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],
+    "format": "{icon} {essid}",
+    "format-wifi": "{icon} {essid}",
+    "format-ethernet": "󰀂",
+    "format-disconnected": "󰤮",
+    "tooltip-format-wifi": "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-disconnected": "Disconnected",
+    "interval": 3,
+    "spacing": 1,
+    "on-click": "omarchy-launch-wifi"
+  },
+  "battery": {
+    "format": "{capacity}% {icon}",
+    "format-discharging": "{capacity}% {icon}",
+    "format-charging": "{capacity}% {icon}",
+    "format-plugged": "",
+    "format-icons": {
+      "charging": ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"],
+      "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+    },
+    "format-full": "󰂅",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "interval": 5,
+    "on-click": "omarchy-menu power",
+    "on-click-right": "notify-send -u low \"$(omarchy-battery-status)\"",
+    "states": {
+      "warning": 20,
+      "critical": 10
+    }
+  },
+  "bluetooth": {
+    "format": "",
+    "format-off": "󰂲",
+    "format-disabled": "󰂲",
+    "format-connected": "",
+    "format-no-controller": "",
+    "tooltip-format": "Devices connected: {num_connections}",
+    "on-click": "omarchy-launch-bluetooth"
+  },
+  "pulseaudio": {
+    "format": "{icon}",
+    "on-click": "omarchy-launch-audio",
+    "on-click-right": "pamixer -t",
+    "tooltip-format": "Playing at {volume}%",
+    "scroll-step": 5,
+    "format-muted": "",
+    "format-icons": {
+      "headphone": "",
+      "headset": "",
+      "default": ["", "", ""]
+    }
+  },
+  "group/tray-expander": {
+    "orientation": "inherit",
+    "drawer": {
+      "transition-duration": 600,
+      "children-class": "tray-group-item"
+    },
+    "modules": ["custom/expand-icon", "tray", "memory", "custom/weather"]
+  },
+  "custom/expand-icon": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/screenrecording-indicator": {
+    "on-click": "omarchy-capture-screenrecording",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/screen-recording.sh",
+    "signal": 8,
+    "return-type": "json"
+  },
+  "custom/idle-indicator": {
+    "on-click": "omarchy-toggle-idle",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/idle.sh",
+    "signal": 9,
+    "return-type": "json"
+  },
+  "custom/notification-silencing-indicator": {
+    "on-click": "omarchy-toggle-notification-silencing",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/notification-silencing.sh",
+    "signal": 10,
+    "return-type": "json"
+  },
+  "tray": {
+    "icon-size": 14,
+    "spacing": 6
+  },
+  "backlight": {
+    "format": "{percent}% {icon}",
+    "format-icons": ["🌑", "🌘", "🌗", "🌖", "🌕"]
+  },
+  "memory": {
+    "format": " {used:0.1f}gb",
+    "interval": 2,
+    "on-click": "omarchy-launch-or-focus-tui btop"
+  },
+  "custom/weather": {
+    "format": "{}°",
+    "tooltip": true,
+    "interval": 600,
+    "exec": "omarchy-cmd-present wttrbar && wttrbar || true",
+    "return-type": "json"
+  },
+  "mpris": {
+    "format": "{player_icon} {artist} - {title}",
+    "format-paused": "{status_icon} <i>{artist} - {title}</i>",
+    "ignored-players": ["chromium"],
+    "max-length": 35,
+    "player-icons": {
+      "default": "🎵",
+      "mpv": "🎵"
+    },
+    "status-icons": {
+      "paused": "⏸"
+    }
+  },
+  "hyprland/window": {
+    "format": "{}"
+  },
+}

--- a/config/waybar/configs/island.jsonc
+++ b/config/waybar/configs/island.jsonc
@@ -4,8 +4,19 @@
   "position": "top",
   "spacing": 0,
   "height": 26,
-  "modules-left": ["custom/omarchy", "hyprland/workspaces", "hyprland/window"],
-  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-left": [
+    "custom/omarchy",
+    "hyprland/workspaces",
+    "hyprland/window"
+  ],
+  "modules-center": [
+    "clock",
+    "custom/update",
+    "custom/voxtype",
+    "custom/screenrecording-indicator",
+    "custom/idle-indicator",
+    "custom/notification-silencing-indicator"
+  ],
   "modules-right": [
     "mpris",
     "group/tray-expander",
@@ -21,7 +32,7 @@
     "all-outputs": true,
     "cursor": true,
     "format": "{icon}",
-      "persistent-workspaces": {
+    "persistent-workspaces": {
       "*": 5
     }
   },
@@ -52,7 +63,13 @@
     "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
   },
   "network": {
-    "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],
+    "format-icons": [
+      "󰤯",
+      "󰤟",
+      "󰤢",
+      "󰤥",
+      "󰤨"
+    ],
     "format": "{icon} {essid}",
     "format-wifi": "{icon} {essid}",
     "format-ethernet": "󰀂",
@@ -70,8 +87,30 @@
     "format-charging": "{capacity}% {icon}",
     "format-plugged": "",
     "format-icons": {
-      "charging": ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"],
-      "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+      "charging": [
+        "󰢜",
+        "󰂆",
+        "󰂇",
+        "󰂈",
+        "󰢝",
+        "󰂉",
+        "󰢞",
+        "󰂊",
+        "󰂋",
+        "󰂅"
+      ],
+      "default": [
+        "󰁺",
+        "󰁻",
+        "󰁼",
+        "󰁽",
+        "󰁾",
+        "󰁿",
+        "󰂀",
+        "󰂁",
+        "󰂂",
+        "󰁹"
+      ]
     },
     "format-full": "󰂅",
     "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
@@ -103,7 +142,11 @@
     "format-icons": {
       "headphone": "",
       "headset": "",
-      "default": ["", "", ""]
+      "default": [
+        "",
+        "",
+        ""
+      ]
     }
   },
   "group/tray-expander": {
@@ -112,7 +155,12 @@
       "transition-duration": 600,
       "children-class": "tray-group-item"
     },
-    "modules": ["custom/expand-icon", "tray", "memory", "custom/weather"]
+    "modules": [
+      "custom/expand-icon",
+      "tray",
+      "memory",
+      "custom/weather"
+    ]
   },
   "custom/expand-icon": {
     "format": "",
@@ -140,9 +188,28 @@
     "icon-size": 14,
     "spacing": 6
   },
+   "custom/voxtype": {
+    "exec": "omarchy-voxtype-status",
+    "return-type": "json",
+    "format": "{icon}",
+    "format-icons": {
+      "idle": "",
+      "recording": "󰍬",
+      "transcribing": "󰔟"
+    },
+    "tooltip": true,
+    "on-click-right": "omarchy-voxtype-config",
+    "on-click": "omarchy-voxtype-model"
+  },
   "backlight": {
     "format": "{percent}% {icon}",
-    "format-icons": ["🌑", "🌘", "🌗", "🌖", "🌕"]
+    "format-icons": [
+      "🌑",
+      "🌘",
+      "🌗",
+      "🌖",
+      "🌕"
+    ]
   },
   "memory": {
     "format": " {used:0.1f}gb",
@@ -153,13 +220,15 @@
     "format": "{}°",
     "tooltip": true,
     "interval": 600,
-    "exec": "omarchy-cmd-present wttrbar && wttrbar || true",
+    "exec": "wttrbar --nerd --location Changchun",
     "return-type": "json"
   },
   "mpris": {
     "format": "{player_icon} {artist} - {title}",
     "format-paused": "{status_icon} <i>{artist} - {title}</i>",
-    "ignored-players": ["chromium"],
+    "ignored-players": [
+      "chromium"
+    ],
     "max-length": 35,
     "player-icons": {
       "default": "🎵",
@@ -170,6 +239,7 @@
     }
   },
   "hyprland/window": {
-    "format": "{}"
-  },
+    "format": "{}",
+    "max-length": 45
+  }
 }

--- a/config/waybar/configs/island2.jsonc
+++ b/config/waybar/configs/island2.jsonc
@@ -1,0 +1,206 @@
+{
+  "reload_style_on_change": true,
+  "layer": "top",
+  "position": "top",
+  "spacing": 0,
+  "height": 26,
+  "modules-left": ["group/left1", "group/left2"],
+  
+  "group/left1": {
+    "orientation": "inherit",
+    "modules": [
+    "custom/omarchy",
+    "hyprland/workspaces"
+  ]
+  },
+  "group/left2": {
+    "orientation": "inherit",
+    "modules": ["hyprland/window"]
+  },
+  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-right": [
+    "group/right1",
+    "group/right2",
+    "group/right3"
+  ],
+"group/right3": {
+    "orientation": "inherit",
+    "modules": [
+    "backlight",
+    "network",
+    "bluetooth",
+    "pulseaudio",
+    "cpu",
+    "battery"
+  ]
+  },
+  "group/right2": {
+    "orientation": "inherit",
+    "modules": [
+    "tray",
+    "memory",
+    "custom/weather"
+  ]
+  },
+    "group/right1": {
+    "orientation": "inherit",
+    "modules": ["mpris"]
+  },
+  "hyprland/workspaces": {
+    "disable-scroll": true,
+    "all-outputs": true,
+    "cursor": true,
+    "format": "{icon}",
+      "persistent-workspaces": {
+      "*": 5
+    }
+  },
+  "custom/omarchy": {
+    "format": "<span font='omarchy'>\ue900</span>",
+    "on-click": "omarchy-menu",
+    "on-click-right": "xdg-terminal-exec",
+    "tooltip-format": "Omarchy Menu\n\nSuper + Alt + Space"
+  },
+  "custom/update": {
+    "format": "",
+    "exec": "omarchy-update-available",
+    "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update",
+    "tooltip-format": "Omarchy update available",
+    "signal": 7,
+    "interval": 21600
+  },
+  "cpu": {
+    "interval": 5,
+    "format": "󰍛",
+    "on-click": "omarchy-launch-or-focus-tui btop",
+    "on-click-right": "alacritty"
+  },
+  "clock": {
+    "format": "{:%I:%M %p}",
+    "format-alt": "{:%A %d/%m/%Y}",
+    "tooltip-format": "<span>{calendar}</span>",
+    "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
+  },
+  "network": {
+    "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],
+    "format": "{icon} {essid}",
+    "format-wifi": "{icon} {essid}",
+    "format-ethernet": "󰀂",
+    "format-disconnected": "󰤮",
+    "tooltip-format-wifi": "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-disconnected": "Disconnected",
+    "interval": 3,
+    "spacing": 1,
+    "on-click": "omarchy-launch-wifi"
+  },
+  "battery": {
+    "format": "{capacity}% {icon}",
+    "format-discharging": "{capacity}% {icon}",
+    "format-charging": "{capacity}% {icon}",
+    "format-plugged": "",
+    "format-icons": {
+      "charging": ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"],
+      "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+    },
+    "format-full": "󰂅",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "interval": 5,
+    "on-click": "omarchy-menu power",
+    "on-click-right": "notify-send -u low \"$(omarchy-battery-status)\"",
+    "states": {
+      "warning": 20,
+      "critical": 10
+    }
+  },
+  "bluetooth": {
+    "format": "",
+    "format-off": "󰂲",
+    "format-disabled": "󰂲",
+    "format-connected": "",
+    "format-no-controller": "",
+    "tooltip-format": "Devices connected: {num_connections}",
+    "on-click": "omarchy-launch-bluetooth"
+  },
+  "pulseaudio": {
+    "format": "{icon}",
+    "on-click": "omarchy-launch-audio",
+    "on-click-right": "pamixer -t",
+    "tooltip-format": "Playing at {volume}%",
+    "scroll-step": 5,
+    "format-muted": "",
+    "format-icons": {
+      "headphone": "",
+      "headset": "",
+      "default": ["", "", ""]
+    }
+  },
+  "group/tray-expander": {
+    "orientation": "inherit",
+    "drawer": {
+      "transition-duration": 600,
+      "children-class": "tray-group-item"
+    },
+    "modules": ["custom/expand-icon", ]
+  },
+  "custom/expand-icon": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/screenrecording-indicator": {
+    "on-click": "omarchy-capture-screenrecording",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/screen-recording.sh",
+    "signal": 8,
+    "return-type": "json"
+  },
+  "custom/idle-indicator": {
+    "on-click": "omarchy-toggle-idle",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/idle.sh",
+    "signal": 9,
+    "return-type": "json"
+  },
+  "custom/notification-silencing-indicator": {
+    "on-click": "omarchy-toggle-notification-silencing",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/notification-silencing.sh",
+    "signal": 10,
+    "return-type": "json"
+  },
+  "tray": {
+    "icon-size": 14,
+    "spacing": 6
+  },
+  "backlight": {
+    "format": "{percent}% {icon}",
+    "format-icons": ["🌑", "🌘", "🌗", "🌖", "🌕"]
+  },
+  "memory": {
+    "format": " {used:0.1f}gb",
+    "interval": 2,
+    "on-click": "omarchy-launch-or-focus-tui btop"
+  },
+  "custom/weather": {
+    "format": "{}°",
+    "tooltip": true,
+    "interval": 600,
+    "exec": "omarchy-cmd-present wttrbar && wttrbar || true",
+    "return-type": "json"
+  },
+  "mpris": {
+    "format": "{player_icon} {artist} - {title}",
+    "format-paused": "{status_icon} <i>{artist} - {title}</i>",
+    "ignored-players": ["chromium"],
+    "max-length": 35,
+    "player-icons": {
+      "default": "🎵",
+      "mpv": "🎵"
+    },
+    "status-icons": {
+      "paused": "⏸"
+    }
+  },
+  "hyprland/window": {
+    "format": "{}",
+    "max-length": 45
+  },
+}

--- a/config/waybar/configs/island2.jsonc
+++ b/config/waybar/configs/island2.jsonc
@@ -4,54 +4,67 @@
   "position": "top",
   "spacing": 0,
   "height": 26,
-  "modules-left": ["group/left1", "group/left2"],
-  
+  "modules-left": [
+    "group/left1",
+    "group/left2"
+  ],
   "group/left1": {
     "orientation": "inherit",
     "modules": [
-    "custom/omarchy",
-    "hyprland/workspaces"
-  ]
+      "custom/omarchy",
+      "hyprland/workspaces"
+    ]
   },
   "group/left2": {
     "orientation": "inherit",
-    "modules": ["hyprland/window"]
+    "modules": [
+      "hyprland/window"
+    ]
   },
-  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-center": [
+    "clock",
+    "custom/update",
+    "custom/voxtype",
+    "custom/screenrecording-indicator",
+    "custom/idle-indicator",
+    "custom/notification-silencing-indicator"
+  ],
   "modules-right": [
     "group/right1",
     "group/right2",
     "group/right3"
   ],
-"group/right3": {
+  "group/right3": {
     "orientation": "inherit",
     "modules": [
-    "backlight",
-    "network",
-    "bluetooth",
-    "pulseaudio",
-    "cpu",
-    "battery"
-  ]
+      "backlight",
+      "network",
+      "bluetooth",
+      "pulseaudio",
+      "cpu",
+      "battery"
+    ]
   },
   "group/right2": {
     "orientation": "inherit",
     "modules": [
-    "tray",
-    "memory",
-    "custom/weather"
-  ]
+      "tray",
+      "memory",
+      "custom/weather"
+    ]
   },
-    "group/right1": {
+  "group/right1": {
     "orientation": "inherit",
-    "modules": ["mpris"]
+    "modules": [
+      "mpris"
+    ]
   },
   "hyprland/workspaces": {
     "disable-scroll": true,
     "all-outputs": true,
     "cursor": true,
     "format": "{icon}",
-      "persistent-workspaces": {
+    "persistent-workspaces": {
       "*": 5
     }
   },
@@ -82,7 +95,13 @@
     "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
   },
   "network": {
-    "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],
+    "format-icons": [
+      "󰤯",
+      "󰤟",
+      "󰤢",
+      "󰤥",
+      "󰤨"
+    ],
     "format": "{icon} {essid}",
     "format-wifi": "{icon} {essid}",
     "format-ethernet": "󰀂",
@@ -100,8 +119,30 @@
     "format-charging": "{capacity}% {icon}",
     "format-plugged": "",
     "format-icons": {
-      "charging": ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"],
-      "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+      "charging": [
+        "󰢜",
+        "󰂆",
+        "󰂇",
+        "󰂈",
+        "󰢝",
+        "󰂉",
+        "󰢞",
+        "󰂊",
+        "󰂋",
+        "󰂅"
+      ],
+      "default": [
+        "󰁺",
+        "󰁻",
+        "󰁼",
+        "󰁽",
+        "󰁾",
+        "󰁿",
+        "󰂀",
+        "󰂁",
+        "󰂂",
+        "󰁹"
+      ]
     },
     "format-full": "󰂅",
     "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
@@ -133,7 +174,11 @@
     "format-icons": {
       "headphone": "",
       "headset": "",
-      "default": ["", "", ""]
+      "default": [
+        "",
+        "",
+        ""
+      ]
     }
   },
   "group/tray-expander": {
@@ -142,7 +187,9 @@
       "transition-duration": 600,
       "children-class": "tray-group-item"
     },
-    "modules": ["custom/expand-icon", ]
+    "modules": [
+      "custom/expand-icon",
+    ]
   },
   "custom/expand-icon": {
     "format": "",
@@ -166,13 +213,32 @@
     "signal": 10,
     "return-type": "json"
   },
+  "custom/voxtype": {
+    "exec": "omarchy-voxtype-status",
+    "return-type": "json",
+    "format": "{icon}",
+    "format-icons": {
+      "idle": "",
+      "recording": "󰍬",
+      "transcribing": "󰔟"
+    },
+    "tooltip": true,
+    "on-click-right": "omarchy-voxtype-config",
+    "on-click": "omarchy-voxtype-model"
+  },
   "tray": {
     "icon-size": 14,
     "spacing": 6
   },
   "backlight": {
     "format": "{percent}% {icon}",
-    "format-icons": ["🌑", "🌘", "🌗", "🌖", "🌕"]
+    "format-icons": [
+      "🌑",
+      "🌘",
+      "🌗",
+      "🌖",
+      "🌕"
+    ]
   },
   "memory": {
     "format": " {used:0.1f}gb",
@@ -183,13 +249,15 @@
     "format": "{}°",
     "tooltip": true,
     "interval": 600,
-    "exec": "omarchy-cmd-present wttrbar && wttrbar || true",
+    "exec": "wttrbar --nerd --location Changchun",
     "return-type": "json"
   },
   "mpris": {
     "format": "{player_icon} {artist} - {title}",
     "format-paused": "{status_icon} <i>{artist} - {title}</i>",
-    "ignored-players": ["chromium"],
+    "ignored-players": [
+      "chromium"
+    ],
     "max-length": 35,
     "player-icons": {
       "default": "🎵",
@@ -202,5 +270,5 @@
   "hyprland/window": {
     "format": "{}",
     "max-length": 45
-  },
+  }
 }

--- a/config/waybar/configs/island3.jsonc
+++ b/config/waybar/configs/island3.jsonc
@@ -1,0 +1,178 @@
+{
+  "reload_style_on_change": true,
+  "layer": "top",
+  "position": "top",
+  "spacing": 0,
+  "height": 26,
+  "modules-left": ["custom/omarchy", "hyprland/workspaces", "hyprland/window"],
+  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-right": [
+    "tray",
+    "custom/weather",
+    "memory",
+    "backlight",
+    "network",
+    "bluetooth",
+    "pulseaudio",
+    "cpu",
+    "battery"
+  ],
+
+  "hyprland/workspaces": {
+    "disable-scroll": true,
+    "all-outputs": true,
+    "cursor": true,
+    "format": "{icon}",
+      "persistent-workspaces": {
+      "*": 5
+    }
+  },
+  "custom/omarchy": {
+    "format": "<span font='omarchy'>\ue900</span>",
+    "on-click": "omarchy-menu",
+    "on-click-right": "xdg-terminal-exec",
+    "tooltip-format": "Omarchy Menu\n\nSuper + Alt + Space"
+  },
+  "custom/update": {
+    "format": "",
+    "exec": "omarchy-update-available",
+    "on-click": "omarchy-launch-floating-terminal-with-presentation omarchy-update",
+    "tooltip-format": "Omarchy update available",
+    "signal": 7,
+    "interval": 21600
+  },
+  "cpu": {
+    "interval": 5,
+    "format": "󰍛",
+    "on-click": "omarchy-launch-or-focus-tui btop",
+    "on-click-right": "alacritty"
+  },
+  "clock": {
+    "format": "{:%I:%M %p}",
+    "format-alt": "{:%A %d/%m/%Y}",
+    "tooltip-format": "<span>{calendar}</span>",
+    "on-click-right": "omarchy-launch-floating-terminal-with-presentation omarchy-tz-select"
+  },
+  "network": {
+    "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],
+    "format": "{icon} {essid}",
+    "format-wifi": "{icon} {essid}",
+    "format-ethernet": "󰀂",
+    "format-disconnected": "󰤮",
+    "tooltip-format-wifi": "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-ethernet": "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}",
+    "tooltip-format-disconnected": "Disconnected",
+    "interval": 3,
+    "spacing": 1,
+    "on-click": "omarchy-launch-wifi"
+  },
+  "battery": {
+    "format": "{capacity}% {icon}",
+    "format-discharging": "{capacity}% {icon}",
+    "format-charging": "{capacity}% {icon}",
+    "format-plugged": "",
+    "format-icons": {
+      "charging": ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"],
+      "default": ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+    },
+    "format-full": "󰂅",
+    "tooltip-format-discharging": "{power:>1.0f}W↓ {capacity}%",
+    "tooltip-format-charging": "{power:>1.0f}W↑ {capacity}%",
+    "interval": 5,
+    "on-click": "omarchy-menu power",
+    "on-click-right": "notify-send -u low \"$(omarchy-battery-status)\"",
+    "states": {
+      "warning": 20,
+      "critical": 10
+    }
+  },
+  "bluetooth": {
+    "format": "",
+    "format-off": "󰂲",
+    "format-disabled": "󰂲",
+    "format-connected": "",
+    "format-no-controller": "",
+    "tooltip-format": "Devices connected: {num_connections}",
+    "on-click": "omarchy-launch-bluetooth"
+  },
+  "pulseaudio": {
+    "format": "{icon}",
+    "on-click": "omarchy-launch-audio",
+    "on-click-right": "pamixer -t",
+    "tooltip-format": "Playing at {volume}%",
+    "scroll-step": 5,
+    "format-muted": "",
+    "format-icons": {
+      "headphone": "",
+      "headset": "",
+      "default": ["", "", ""]
+    }
+  },
+  "group/tray-expander": {
+    "orientation": "inherit",
+    "drawer": {
+      "transition-duration": 600,
+      "children-class": "tray-group-item"
+    },
+    "modules": ["custom/expand-icon", ]
+  },
+  "custom/expand-icon": {
+    "format": "",
+    "tooltip": false
+  },
+  "custom/screenrecording-indicator": {
+    "on-click": "omarchy-capture-screenrecording",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/screen-recording.sh",
+    "signal": 8,
+    "return-type": "json"
+  },
+  "custom/idle-indicator": {
+    "on-click": "omarchy-toggle-idle",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/idle.sh",
+    "signal": 9,
+    "return-type": "json"
+  },
+  "custom/notification-silencing-indicator": {
+    "on-click": "omarchy-toggle-notification-silencing",
+    "exec": "$OMARCHY_PATH/default/waybar/indicators/notification-silencing.sh",
+    "signal": 10,
+    "return-type": "json"
+  },
+  "tray": {
+    "icon-size": 14,
+    "spacing": 6
+  },
+  "backlight": {
+    "format": "{percent}% {icon}",
+    "format-icons": ["🌑", "🌘", "🌗", "🌖", "🌕"]
+  },
+  "memory": {
+    "format": " {used:0.1f}gb",
+    "interval": 2,
+    "on-click": "omarchy-launch-or-focus-tui btop"
+  },
+  "custom/weather": {
+    "format": "{}°",
+    "tooltip": true,
+    "interval": 600,
+    "exec": "omarchy-cmd-present wttrbar && wttrbar || true",
+    "return-type": "json"
+  },
+  "mpris": {
+    "format": "{player_icon} {artist} - {title}",
+    "format-paused": "{status_icon} <i>{artist} - {title}</i>",
+    "ignored-players": ["chromium"],
+    "max-length": 35,
+    "player-icons": {
+      "default": "🎵",
+      "mpv": "🎵"
+    },
+    "status-icons": {
+      "paused": "⏸"
+    }
+  },
+  "hyprland/window": {
+    "format": "{}",
+    "max-length": 45
+  },
+}

--- a/config/waybar/configs/island3.jsonc
+++ b/config/waybar/configs/island3.jsonc
@@ -5,8 +5,9 @@
   "spacing": 0,
   "height": 26,
   "modules-left": ["custom/omarchy", "hyprland/workspaces", "hyprland/window"],
-  "modules-center": ["clock", "custom/update", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
+  "modules-center": ["clock", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
   "modules-right": [
+    "mpris",
     "tray",
     "custom/weather",
     "memory",
@@ -108,18 +109,6 @@
       "default": ["", "", ""]
     }
   },
-  "group/tray-expander": {
-    "orientation": "inherit",
-    "drawer": {
-      "transition-duration": 600,
-      "children-class": "tray-group-item"
-    },
-    "modules": ["custom/expand-icon", ]
-  },
-  "custom/expand-icon": {
-    "format": "",
-    "tooltip": false
-  },
   "custom/screenrecording-indicator": {
     "on-click": "omarchy-capture-screenrecording",
     "exec": "$OMARCHY_PATH/default/waybar/indicators/screen-recording.sh",
@@ -138,6 +127,19 @@
     "signal": 10,
     "return-type": "json"
   },
+  "custom/voxtype": {
+    "exec": "omarchy-voxtype-status",
+    "return-type": "json",
+    "format": "{icon}",
+    "format-icons": {
+      "idle": "",
+      "recording": "󰍬",
+      "transcribing": "󰔟"
+    },
+    "tooltip": true,
+    "on-click-right": "omarchy-voxtype-config",
+    "on-click": "omarchy-voxtype-model"
+  },
   "tray": {
     "icon-size": 14,
     "spacing": 6
@@ -155,7 +157,7 @@
     "format": "{}°",
     "tooltip": true,
     "interval": 600,
-    "exec": "omarchy-cmd-present wttrbar && wttrbar || true",
+    "exec": "wttrbar --nerd --location Changchun",
     "return-type": "json"
   },
   "mpris": {

--- a/config/waybar/styles/island.css
+++ b/config/waybar/styles/island.css
@@ -1,0 +1,227 @@
+@import "../omarchy/current/theme/waybar.css";
+
+* {
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font';
+  font-size: 14px;
+}
+
+
+.modules-left,
+.modules-center,
+.modules-right {
+  background-color: @background; 
+  border-radius: 20px;          
+  padding: 0px 5px;
+  margin: 10px 5px;
+  min-height: 30px;
+}
+
+.modules-left {
+  margin-left: 5px;
+}
+
+.modules-right {
+  margin-right: 5px;
+}
+
+window#waybar {
+  background: transparent;
+}
+
+window#waybar.empty #window {
+  background: transparent;
+  color: transparent;
+  padding: 0;
+  margin: 0;
+  transition: .5s;
+}
+
+mpris.empty {
+  background: transparent;
+  padding: 0;
+  margin: 0;
+}
+
+#workspaces {
+    background-color: alpha(@foreground, .05);
+    border: none;
+    padding: 0px;
+    margin: 5px 6px;
+    margin-right: 0px;
+    border-radius: 15px;
+}
+
+
+#workspaces button {
+    padding: 0px 8px;
+    margin: 0px 2px;
+    color: @background;
+    border-radius: 15px;
+    background-color: alpha(@foreground, .4);
+}
+
+#workspaces button.active {
+    padding: 0px 8px;
+    margin: 0px 2px;
+    background: @foreground;
+    color: @background;
+    border-radius: 15px;
+    opacity: 1; 
+}
+
+#workspaces button.empty {
+    opacity: 0.2; 
+}
+
+#workspaces button.empty.active {
+opacity: 0.75; 
+}
+
+#workspaces button.active:hover,
+#workspaces button:hover {
+    background-color: alpha(@foreground, .3);
+    color: @background;
+    opacity: 1; 
+    transition: .7s;
+}
+
+#custom-weather,
+#memory,
+#mpris,
+#window,
+#tray-expander,
+#clock,
+#cpu,
+#battery,
+#network,
+#bluetooth,
+#pulseaudio,
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator,
+#custom-update{
+  background-color: alpha(@foreground, 0.1);
+  padding: 5px 12px;
+  margin: 5px 0;
+  border-radius: 0;
+}
+
+#mpris:hover,
+#window:hover,
+#clock:hover,
+#backlight:hover,
+#cpu:hover,
+#network:hover,
+#bluetooth:hover,
+#pulseaudio:hover,
+#custom-screenrecording-indicator:hover,
+#custom-idle-indicator:hover,
+#custom-notification-silencing-indicator:hover,
+#custom-update:hover {
+  background-color: alpha(@foreground, .2);
+  transition: .7s;
+}
+
+#custom-expand-icon {
+  margin-right: 7px;
+  padding: 0px 10px;
+  border-radius: 15px;
+}
+
+#tray,
+#memory,
+#custom-weather {
+  background-color: transparent;
+  margin: 5px;
+  padding: 0 2px;
+}
+
+#custom-update,
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator {
+  font-size: 14px;
+  border-radius: 15px;
+  padding: 0 11px 0 10px;
+  margin-left: 2px;
+  margin-right: 0px;
+}
+
+#clock {
+  border-radius: 15px;
+  padding: 0 15px;
+  margin: 5px 0px;
+  background-color: transparent;
+}
+
+.hidden {
+  opacity: 0;
+}
+
+#custom-screenrecording-indicator.active,
+#custom-idle-indicator.active,
+#custom-notification-silencing-indicator.active {
+  color: #a55555;
+}
+
+#custom-omarchy,
+#battery {
+  background-color: @foreground;
+  color: @background;
+  min-width: 10px;
+  border-radius: 15px;
+  padding: 0 8px;
+  margin: 5px 0 5px 0px;
+}
+
+#battery {
+  margin-left: 5px;
+}
+
+#mpris,
+#window {
+  border-radius: 15px; 
+  padding: 5px 10px;   
+  margin-right: 0px;   
+}
+
+#window {
+  margin-left: 5px;   
+}
+
+#tray-expander {
+  padding: 0 0 0 1px;
+  margin-left: 0px;
+  border-radius: 15px;
+  background-color: transparent;
+}
+
+#backlight {
+  background-color: alpha(@foreground, .1);
+  border-radius: 15px;
+  padding: 5px 10px;
+  margin: 5px;
+}
+
+#network {
+  border-radius: 15px 0 0 15px;
+}
+
+#cpu {
+  padding: 0 15px 0 10px;
+  border-radius: 0 15px 15px 0;
+  margin-right: 0px;
+}
+
+#pulseaudio {
+  padding: 0 15px 0 10px;
+}
+
+tooltip {
+  border-radius: 15px;
+  background: @background;
+  border: 2px solid alpha(@foreground, .5);
+}

--- a/config/waybar/styles/island.css
+++ b/config/waybar/styles/island.css
@@ -102,6 +102,7 @@ opacity: 0.75;
 #custom-screenrecording-indicator,
 #custom-idle-indicator,
 #custom-notification-silencing-indicator,
+#custom-voxtype,
 #custom-update{
   background-color: alpha(@foreground, 0.1);
   padding: 5px 12px;
@@ -139,6 +140,7 @@ opacity: 0.75;
   padding: 0 2px;
 }
 
+#custom-voxtype,
 #custom-update,
 #custom-screenrecording-indicator,
 #custom-idle-indicator,
@@ -161,6 +163,7 @@ opacity: 0.75;
   opacity: 0;
 }
 
+#custom-voxtype.recording,
 #custom-screenrecording-indicator.active,
 #custom-idle-indicator.active,
 #custom-notification-silencing-indicator.active {
@@ -224,4 +227,25 @@ tooltip {
   border-radius: 15px;
   background: @background;
   border: 2px solid alpha(@foreground, .5);
+}
+
+#custom-screenrecording-indicator {
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  color: transparent;
+}
+
+#custom-screenrecording-indicator.active {
+  background-color: alpha(@foreground, .2);
+  padding: 0 13px 0 10px;
+  color: #eb7087;
+  animation-name: blink-recording;
+  animation-duration: 0.5s;
+}
+
+@keyframes blink-recording {
+    to {
+        color: @foreground;
+    }
 }

--- a/config/waybar/styles/island2.css
+++ b/config/waybar/styles/island2.css
@@ -1,0 +1,213 @@
+@import "../omarchy/current/theme/waybar.css";
+
+* {
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font';
+  font-size: 14px;
+  min-height: 0px;
+}
+
+
+#left1 {
+  background-color: @background; 
+  border-radius: 20px;          
+  padding: 0px 5px;
+  margin: 10px 5px;
+}
+
+.modules-center {
+  background-color: @background; 
+  border-radius: 20px;          
+  padding: 0px 5px;
+  margin: 10px 5px;
+}
+
+#right2,
+#right3 {
+  background-color: @background; 
+  border-radius: 20px;          
+  padding: 0px 5px;
+  margin: 10px 5px;
+}
+
+.modules-left {
+  margin-left: 5px;
+}
+
+.modules-right {
+  margin-right: 5px;
+}
+
+#waybar {
+  background: transparent;
+}
+
+window#waybar.empty #window {
+  background: transparent;
+  color: transparent;
+  padding: 0;
+  margin: 0;
+  transition: .5s;
+}
+
+mpris.empty {
+  background: transparent;
+  padding: 0;
+  margin: 0;
+}
+
+#workspaces {
+    background-color: alpha(@foreground, .05);
+    border: none;
+    padding: 0px;
+    margin: 5px 6px;
+    margin-right: 0px;
+    border-radius: 15px;
+}
+
+
+#workspaces button {
+    padding: 0px 8px;
+    margin: 0px 1px;
+    color: @background;
+    border-radius: 15px;
+    background-color: alpha(@foreground, .4);
+}
+
+#workspaces button.active {
+    padding: 0px 8px;
+    margin: 0px 1px;
+    background: @foreground;
+    color: @background;
+    border-radius: 15px;
+    opacity: 1; 
+}
+
+#workspaces button.empty {
+    opacity: 0.2; 
+}
+
+#workspaces button.empty.active {
+opacity: 0.75; 
+}
+
+#workspaces button.active:hover,
+#workspaces button:hover {
+    background-color: alpha(@foreground, .3);
+    color: @background;
+    opacity: 1; 
+    transition: .7s;
+}
+
+#tray,
+#custom-weather,
+#memory,
+#backlight,
+#clock,
+#cpu,
+#battery,
+#network,
+#bluetooth,
+#pulseaudio,
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator,
+#custom-update{
+  background-color: alpha(@foreground, .6);
+  color: @background;
+  padding: 5px 12px;
+  margin: 5px 2px;
+  border-radius: 15px;
+}
+
+#clock:hover,
+#backlight:hover,
+#cpu:hover,
+#network:hover,
+#bluetooth:hover,
+#pulseaudio:hover,
+#custom-screenrecording-indicator:hover,
+#custom-idle-indicator:hover,
+#custom-notification-silencing-indicator:hover,
+#custom-update:hover {
+  background-color: alpha(@foreground, .4);
+  transition: .7s;
+}
+
+#tray,
+#memory,
+#custom-weather {
+  padding: 5px 12px;
+  margin: 5px 2px;
+}
+
+#custom-update,
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator {
+  font-size: 14px;
+  border-radius: 15px;
+  padding: 0 11px 0 10px;
+  margin-left: 2px;
+  margin-right: 0px;
+}
+
+#clock {
+  border-radius: 15px;
+  padding: 0 15px;
+  margin: 5px 0px;
+}
+
+.hidden {
+  opacity: 0;
+}
+
+#custom-screenrecording-indicator.active,
+#custom-idle-indicator.active,
+#custom-notification-silencing-indicator.active {
+  color: #a55555;
+}
+
+#custom-omarchy,
+#battery {
+  background-color: @foreground;
+  color: @background;
+  min-width: 10px;
+  border-radius: 15px;
+  padding: 0 8px;
+  margin: 5px 0 5px 0px;
+}
+
+#battery {
+  margin-left: 2px;
+}
+
+#mpris {
+  background: @background;
+  border-radius: 20px;          
+  padding: 0px 10px;
+  margin: 10px 5px;
+}
+
+#window {
+  background: @background;
+  border-radius: 20px;          
+  padding: 0px 10px;
+  margin: 10px 5px;
+}
+
+#network {
+  padding: 0 15px 0 10px;
+}
+
+#pulseaudio {
+  padding: 0 15px 0 10px;
+}
+
+tooltip {
+  border-radius: 15px;
+  background: @background;
+  border: 2px solid alpha(@foreground, .5);
+}

--- a/config/waybar/styles/island2.css
+++ b/config/waybar/styles/island2.css
@@ -114,6 +114,7 @@ opacity: 0.75;
 #custom-screenrecording-indicator,
 #custom-idle-indicator,
 #custom-notification-silencing-indicator,
+#custom-voxtype,
 #custom-update{
   background-color: alpha(@foreground, .6);
   color: @background;
@@ -142,16 +143,18 @@ opacity: 0.75;
   padding: 5px 12px;
   margin: 5px 2px;
 }
-
+#custom-voxtype,
 #custom-update,
 #custom-screenrecording-indicator,
 #custom-idle-indicator,
 #custom-notification-silencing-indicator {
   font-size: 14px;
   border-radius: 15px;
-  padding: 0 11px 0 10px;
+  padding: 0 7px 0 5px;
   margin-left: 2px;
   margin-right: 0px;
+  color: @foreground;
+  background: transparent;
 }
 
 #clock {
@@ -164,10 +167,12 @@ opacity: 0.75;
   opacity: 0;
 }
 
+#custom-voxtype.recording,
 #custom-screenrecording-indicator.active,
 #custom-idle-indicator.active,
 #custom-notification-silencing-indicator.active {
-  color: #a55555;
+  color: #af4b4b;
+  background: transparent;
 }
 
 #custom-omarchy,
@@ -210,4 +215,26 @@ tooltip {
   border-radius: 15px;
   background: @background;
   border: 2px solid alpha(@foreground, .5);
+}
+
+
+#custom-screenrecording-indicator {
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  color: transparent;
+}
+
+#custom-screenrecording-indicator.active {
+  background-color: transparent;
+  padding: 0 13px 0 10px;
+  color: #eb7087;
+  animation-name: blink-recording;
+  animation-duration: 0.5s;
+}
+
+@keyframes blink-recording {
+    to {
+        color: @background;
+    }
 }

--- a/config/waybar/styles/island3.css
+++ b/config/waybar/styles/island3.css
@@ -1,0 +1,201 @@
+@import "../omarchy/current/theme/waybar.css";
+
+* {
+  border: 0;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font';
+  font-size: 14px;
+  min-height: 0px;
+}
+
+
+
+.modules-left {
+  margin-left: 5px;
+}
+
+.modules-right {
+  margin-right: 5px;
+}
+
+#waybar {
+  background: transparent;
+}
+
+window#waybar.empty #window {
+  background: transparent;
+  color: transparent;
+  padding: 0;
+  margin: 0;
+  transition: .5s;
+  border: none;
+}
+
+mpris.empty {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+#workspaces {
+    background: @background;
+    border: .5px solid alpha(@foreground, .4);
+    padding: 0px;
+    margin: 5px 6px;
+    border-radius: 4px;
+}
+
+
+#workspaces button {
+    all: initial;
+    padding: 0px 12px;
+    margin: 0px 0px;
+    color: @foreground;
+    border: .1px solid alpha(@foreground, .4);
+    background: transparent;
+    opacity: 1;
+}
+
+#workspaces button.active {
+    padding: 0px 12px;
+    margin: 0px 0px;
+    background: @foreground;
+    color: @background;
+    opacity: 1; 
+}
+
+#workspaces button.empty {
+  background: @background;  
+   color: alpha(@foreground, .3);
+}
+
+#workspaces button.empty.active {
+opacity: 0.75; 
+background: @foreground;
+color: @background;
+}
+#workspaces button:first-child {
+    border-radius: 4px 0px 0px 4px;
+}
+
+#workspaces button:last-child {
+    border-radius: 0px 4px 4px 0px;
+}
+
+#workspaces button:first-child:last-child {
+    border-radius: 4px;
+}
+
+#workspaces button.active:hover,
+#workspaces button:hover {
+    background: @foreground;
+    color: @background;
+    opacity: 1; 
+    transition: .7s;
+}
+
+#tray,
+#custom-weather,
+#memory,
+#backlight,
+#clock,
+#cpu,
+#battery,
+#network,
+#bluetooth,
+#pulseaudio,
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator,
+#custom-update{
+  background-color: @background;
+  color: @foreground;
+  border: .5px solid alpha(@foreground, .4);
+  padding: 5px 12px;
+  margin: 5px 2px;
+  border-radius: 4px;
+}
+
+#memory:hover,
+#clock:hover,
+#backlight:hover,
+#cpu:hover,
+#network:hover,
+#bluetooth:hover,
+#pulseaudio:hover,
+#custom-screenrecording-indicator:hover,
+#custom-idle-indicator:hover,
+#custom-notification-silencing-indicator:hover,
+#custom-update:hover {
+  background-color: alpha(@foreground, .9);
+  color: @background;
+  transition: .7s;
+}
+
+#custom-update,
+#custom-screenrecording-indicator,
+#custom-idle-indicator,
+#custom-notification-silencing-indicator {
+  font-size: 14px;
+  border-radius: 4px;
+  padding: 0 11px 0 10px;
+  margin-left: 2px;
+  margin-right: 0px;
+}
+
+#clock {
+  border-radius: 4px;
+  padding: 0 15px;
+  margin: 5px 0px;
+}
+
+.hidden {
+  opacity: 0;
+}
+
+#custom-screenrecording-indicator.active,
+#custom-idle-indicator.active,
+#custom-notification-silencing-indicator.active {
+  color: #a55555;
+}
+
+#custom-omarchy,
+#battery {
+  background-color: @foreground;
+  color: @background;
+  border: 1px solid @background;
+  min-width: 10px;
+  border-radius: 4px;
+  padding: 0 8px;
+  margin: 5px 0 5px 0px;
+}
+
+#battery {
+  margin-left: 2px;
+}
+
+#mpris,
+#window {
+  background-color: @background;
+  color: @foreground;
+  border: .5px solid alpha(@foreground, .4);
+  padding: 5px 12px;
+  margin: 5px 1px;
+  border-radius: 4px;
+}
+
+#network {
+  padding: 0 15px 0 10px;
+}
+
+#pulseaudio {
+  padding: 0 15px 0 10px;
+}
+
+tooltip {
+  border-radius: 5px;
+  background: @background;
+  border: 2px solid alpha(@foreground, .5);
+}

--- a/config/waybar/styles/island3.css
+++ b/config/waybar/styles/island3.css
@@ -43,7 +43,7 @@ mpris.empty {
     background: @background;
     border: .5px solid alpha(@foreground, .4);
     padding: 0px;
-    margin: 5px 6px;
+    margin: 5px 2px;
     border-radius: 4px;
 }
 
@@ -107,8 +107,10 @@ color: @background;
 #bluetooth,
 #pulseaudio,
 #custom-screenrecording-indicator,
+#custom-screenrecording-indicator.active,
 #custom-idle-indicator,
 #custom-notification-silencing-indicator,
+#custom-voxtype,
 #custom-update{
   background-color: @background;
   color: @foreground;
@@ -134,6 +136,7 @@ color: @background;
   transition: .7s;
 }
 
+#custom-voxtype,
 #custom-update,
 #custom-screenrecording-indicator,
 #custom-idle-indicator,
@@ -155,10 +158,12 @@ color: @background;
   opacity: 0;
 }
 
+#custom-voxtype.recording,
 #custom-screenrecording-indicator.active,
 #custom-idle-indicator.active,
 #custom-notification-silencing-indicator.active {
   color: #a55555;
+  background: @background;
 }
 
 #custom-omarchy,
@@ -169,7 +174,7 @@ color: @background;
   min-width: 10px;
   border-radius: 4px;
   padding: 0 8px;
-  margin: 5px 0 5px 0px;
+  margin: 5px 2px;
 }
 
 #battery {
@@ -182,7 +187,7 @@ color: @background;
   color: @foreground;
   border: .5px solid alpha(@foreground, .4);
   padding: 5px 12px;
-  margin: 5px 1px;
+  margin: 5px 2px;
   border-radius: 4px;
 }
 
@@ -198,4 +203,25 @@ tooltip {
   border-radius: 5px;
   background: @background;
   border: 2px solid alpha(@foreground, .5);
+}
+
+#custom-screenrecording-indicator {
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  color: transparent;
+}
+
+#custom-screenrecording-indicator.active {
+  background-color: @background;
+  padding: 0 13px 0 10px;
+  color: #eb7087;
+  animation-name: blink-recording;
+  animation-duration: 0.5s;
+}
+
+@keyframes blink-recording {
+    to {
+        color: @foreground;
+    }
 }


### PR DESCRIPTION
### Summary
I have developed an "island" version of the Waybar configuration based on the existing `pill style` at "waybar-styling" branch.

**Key Changes**

- Island Architecture: Grouped .modules-left, .modules-center, and .modules-right into distinct containers with a 20px border radius to create a cohesive, floating appearance.

- New workspace style: Removed extra icons while preserving the existing transition behavior.

- MPRIS Optimization: Configured Chromium as an ignored player in island.jsonc. This prevents the module from remaining active with an empty text field (ghost placeholders) when the browser is open but not playing media. If a browser plays audio or video, hyprland/window will still display it as expected.

I am happy to make further adjustments if needed and would love to contribute to the great work the team is doing here.

**_Island 1_** **On Desktop Screenshot (no Battery , no Backlight module loaded)**
<img width="2560" height="700" alt="screenshot-2026-05-06_00-35-07" src="https://github.com/user-attachments/assets/938bdc30-bf5c-44c2-97c5-6fda343685f3" />
<img width="2560" height="279" alt="screenshot-2026-05-06_00-35-25" src="https://github.com/user-attachments/assets/e7e92189-be42-4e29-bfc3-654ac8f4d34a" />

**_Island 1_** **On Laptop Screenshot (all module loaded)**
<img width="1920" height="371" alt="screenshot-2026-05-06_00-36-54" src="https://github.com/user-attachments/assets/7dd9b01d-55b1-49d6-806a-7fa293ca93bb" />
[island.css](https://github.com/user-attachments/files/28326549/island.css)
[island.jsonc](https://github.com/user-attachments/files/28326550/island.jsonc)




**_Island 2_** **On Desktop Screenshot (no Battery , no Backlight module loaded)**
<img width="2560" height="746" alt="screenshot-2026-05-06_19-07-11" src="https://github.com/user-attachments/assets/b9f96346-75ed-4eb9-af1d-523d58f599a1" />
**_Island 2_** **On Laptop Screenshot (all module loaded)**
<img width="1920" height="168" alt="screenshot-2026-05-06_19-02-12" src="https://github.com/user-attachments/assets/e4f09446-1f22-419a-973a-afc49090277a" />
[island2.css](https://github.com/user-attachments/files/28326554/island2.css)
[island2.jsonc](https://github.com/user-attachments/files/28326555/island2.jsonc)



**_Island 3_** **On Desktop Screenshot (no Battery , no Backlight module loaded)**
<img width="2560" height="754" alt="desktopisland3" src="https://github.com/user-attachments/assets/3c300158-7d64-4f7c-9b5d-4c21116765b2" />
**_Island 3_** **On Laptop Screenshot (all module loaded)**
<img width="1920" height="178" alt="laptopisland3" src="https://github.com/user-attachments/assets/c164988d-ea59-4260-bc70-a8f19d0ea5fb" />
[island3.css](https://github.com/user-attachments/files/28326560/island3.css)
[island3.jsonc](https://github.com/user-attachments/files/28326561/island3.jsonc)

