### PR TITLE
omarchy upgrade analysis

### DIFF
--- a/bin/omarchy-update-agent-fix
+++ b/bin/omarchy-update-agent-fix
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# omarchy:summary=Ask opencode to fix skipped update migrations and upgrade errors.
+# omarchy:aliases=omarchy update agent-fix
+
+set -e
+
+OMARCHY_PATH=${OMARCHY_PATH:-$HOME/.local/share/omarchy}
+skipped_dir="$HOME/.local/state/omarchy/migrations/skipped"
+update_log="/tmp/omarchy-update.log"
+pacman_log="/var/log/pacman.log"
+skill="$OMARCHY_PATH/default/omarchy-skill-agent-fix/SKILL.md"
+
+"$OMARCHY_PATH/bin/omarchy-cmd-present" opencode 2>/dev/null || {
+  echo "opencode is not installed." >&2
+  exit 1
+}
+
+[[ -f $skill ]] || {
+  echo "Missing skill: $skill" >&2
+  exit 1
+}
+
+mapfile -t skipped_migrations < <(
+  find "$skipped_dir" -maxdepth 1 -type f -name "*.sh" -printf "$OMARCHY_PATH/migrations/%f\n" 2>/dev/null | sort
+)
+
+if (( ${#skipped_migrations[@]} )); then
+  skipped_list=$(printf -- "- %s\n" "${skipped_migrations[@]}")
+else
+  skipped_list="- none"
+fi
+
+opencode_prompt=$(cat <<EOF
+Use /omarchy-update-agent-fix.
+
+Update log: $update_log
+Pacman log: $pacman_log
+Skipped migration scripts:
+$skipped_list
+
+Fix the skipped Omarchy migration.
+EOF
+)
+
+echo "Opening opencode for skipped migrations..."
+exec opencode "$OMARCHY_PATH" --agent plan --prompt "$opencode_prompt"

--- a/default/omarchy-skill-agent-fix/SKILL.md
+++ b/default/omarchy-skill-agent-fix/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: omarchy-update-agent-fix
+description: >-
+  Use to fix skipped Omarchy update migrations and similar update failures.
+---
+
+# Omarchy Update Agent Fix
+
+Fix skipped update migrations and similar update failures.
+
+## Read
+
+- update log listed below
+- pacman log listed below for package failures
+- skipped migration scripts listed below
+
+Skipped state files in `~/.local/state/omarchy/migrations/skipped/` are empty
+markers. Use their filenames to read the matching script in
+`$OMARCHY_PATH/migrations/`.
+
+## Rules
+
+- Fix the failing migration.
+- Keep the change small.
+- Run `omarchy migrate`.
+- Remove skipped markers after success.
+
+## Tools
+
+- use the /omarchy or $omarchy skill for a broader system understanding.
+- go to <https://github.com/basecamp/omarchy/releases> to get a better
+  understanding of what changed in the releases

--- a/install/config/omarchy-ai-skill.sh
+++ b/install/config/omarchy-ai-skill.sh
@@ -1,3 +1,4 @@
 # Place in ~/.claude/skills since all tools populate from there as well as their own sources
 mkdir -p ~/.claude/skills
 ln -s $OMARCHY_PATH/default/omarchy-skill ~/.claude/skills/omarchy
+ln -s $OMARCHY_PATH/default/omarchy-skill-agent-fix ~/.claude/skills/omarchy-update-agent-fix

--- a/migrations/1778037319.sh
+++ b/migrations/1778037319.sh
@@ -1,0 +1,3 @@
+echo "Add Omarchy update agent fix AI skill"
+
+source $OMARCHY_PATH/install/config/omarchy-ai-skill.sh


### PR DESCRIPTION
the idea is to play nicely with #5610 

so when omarchy updates, and the user choses to view the logs properly in nvim, its just a bit of typing :

fire up a terminal with `ctrl+/` , then type the command `omarchy update agent-fix` to "fix" erros/discuss with the agent a topic of concern

thats motivated by  #5594 and #5595  to catch errors earlier and fix

