### PR TITLE
Add a power-source-change hook

### DIFF
--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -38,3 +38,5 @@ case "$action" in
     powerprofilesctl set balanced
     ;;
 esac
+
+omarchy-hook power-source-change "$action"

--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -1,10 +1,12 @@
 if omarchy-battery-present; then
+  user_uid=$(id -u)
   omarchy_path="${OMARCHY_PATH:-$HOME/.local/share/omarchy}"
   run_path="$omarchy_path/bin:/usr/local/sbin:/usr/local/bin:/usr/bin"
+  run_command="/usr/bin/runuser -u $USER -- /usr/bin/env HOME=$HOME OMARCHY_PATH=$omarchy_path XDG_RUNTIME_DIR=/run/user/$user_uid DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$user_uid/bus PATH=$run_path /usr/bin/systemd-run --user --quiet --collect $omarchy_path/bin/omarchy-powerprofiles-set"
 
   cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --setenv=HOME=$HOME --setenv=OMARCHY_PATH=$omarchy_path --setenv=PATH=$run_path --property=After=power-profiles-daemon.service $omarchy_path/bin/omarchy-powerprofiles-set"
-SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --setenv=HOME=$HOME --setenv=OMARCHY_PATH=$omarchy_path --setenv=PATH=$run_path --property=After=power-profiles-daemon.service $omarchy_path/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="$run_command"
+SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="$run_command"
 EOF
 
   sudo systemctl enable power-profiles-daemon

--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -1,7 +1,10 @@
 if omarchy-battery-present; then
+  omarchy_path="${OMARCHY_PATH:-$HOME/.local/share/omarchy}"
+  run_path="$omarchy_path/bin:/usr/local/sbin:/usr/local/bin:/usr/bin"
+
   cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
-SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --setenv=HOME=$HOME --setenv=OMARCHY_PATH=$omarchy_path --setenv=PATH=$run_path --property=After=power-profiles-daemon.service $omarchy_path/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --setenv=HOME=$HOME --setenv=OMARCHY_PATH=$omarchy_path --setenv=PATH=$run_path --property=After=power-profiles-daemon.service $omarchy_path/bin/omarchy-powerprofiles-set"
 EOF
 
   sudo systemctl enable power-profiles-daemon

--- a/migrations/1778159545.sh
+++ b/migrations/1778159545.sh
@@ -1,0 +1,3 @@
+echo "Pass HOME, OMARCHY_PATH, and PATH to power profile udev hooks"
+
+source "$OMARCHY_PATH/install/config/powerprofilesctl-rules.sh"


### PR DESCRIPTION
It would be useful to have a hook that triggers on power source change. I personally have two use cases:

- Change the default power profiles on AC and battery
- Add automatic display brightness adjustments (I know you're not a fan!)

The main change besides adding the hook to `omarchy-powerprofile-set` is that we have to set the `HOME`, `PATH` and `OMARCHY_PATH` in the UDEV rule and run it as the user instead of root to avoid privileges escalation.

If you like the idea, I could also add [sample](https://github.com/pomartel/config-files/blob/master/.config/omarchy/hooks/power-source-change.d/display-brightness) [hooks](https://github.com/pomartel/config-files/blob/master/.config/omarchy/hooks/power-source-change.d/power-profiles).