### PR TITLE
Resolve OMARCHY_PATH in omarchy-battery-monitor

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -3,14 +3,16 @@
 # omarchy:summary=Designed to be run by systemd timer every 30 seconds and alerts if battery is low
 # omarchy:hidden=true
 
+OMARCHY_PATH=${OMARCHY_PATH:-$HOME/.local/share/omarchy}
+
 BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
-BATTERY_LEVEL=$(omarchy-battery-remaining)
+BATTERY_LEVEL=$("$OMARCHY_PATH/bin/omarchy-battery-remaining")
 BATTERY_STATE=$(upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}')
 
 send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
-  omarchy-hook battery-low "$1"
+  "$OMARCHY_PATH/bin/omarchy-hook" battery-low "$1"
 }
 
 if [[ -n $BATTERY_LEVEL && $BATTERY_LEVEL =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary

Fix `omarchy-battery-monitor` so it works on the first systemd-timer firings after boot, before Hyprland has propagated the user environment.

## Problem

`omarchy-battery-monitor.timer` fires every 30 seconds. On a fresh boot the systemd user manager has not yet imported `$OMARCHY_PATH` (or `~/.local/share/omarchy/bin` on `$PATH`) — that happens later via Hyprland's `exec-once` env import. Until then, the script's two unqualified calls — `omarchy-battery-remaining` and `omarchy-hook` — fail with "command not found", so early timer ticks log errors and the low-battery hook silently no-ops.

## Background

Closed PR #5662 attempted to fix this by adding `Environment=PATH=…` to the user-side service unit. That was rejected (correctly) — Omarchy is moving toward a real package install, and any filesystem path hardcoded into a unit file would become wrong. Per @dhh's feedback in #5662: "if you find another way, please open a PR!"

## Fix

Move the resolution into the script itself, mirroring the convention already established in `bin/omarchy-snapshot`:

```bash
OMARCHY_PATH=${OMARCHY_PATH:-$HOME/.local/share/omarchy}
```

Then qualify both internal calls as `"$OMARCHY_PATH/bin/…"`.

This works regardless of where Omarchy is installed — when the move to a packaged install happens, callers just need to export the new `OMARCHY_PATH` and this script (along with every other consumer of the same convention) keeps working without further edits.

## Diff

```diff
 # omarchy:summary=Designed to be run by systemd timer every 30 seconds and alerts if battery is low
 # omarchy:hidden=true

+OMARCHY_PATH=${OMARCHY_PATH:-$HOME/.local/share/omarchy}
+
 BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
-BATTERY_LEVEL=$(omarchy-battery-remaining)
+BATTERY_LEVEL=$("$OMARCHY_PATH/bin/omarchy-battery-remaining")
 BATTERY_STATE=$(upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}')

 send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
-  omarchy-hook battery-low "$1"
+  "$OMARCHY_PATH/bin/omarchy-hook" battery-low "$1"
 }
```

## Test plan

- [ ] `bash -n bin/omarchy-battery-monitor` — syntax check passes
- [ ] Run directly with `OMARCHY_PATH` unset: `env -u OMARCHY_PATH bin/omarchy-battery-monitor` — falls back correctly, no errors
- [ ] Run directly with the script's own systemd unit: `systemctl --user start omarchy-battery-monitor.service && journalctl --user -u omarchy-battery-monitor.service -n 20` — clean run, no "command not found"
- [ ] Reboot and watch `journalctl --user -u omarchy-battery-monitor.service -f` — first two timer firings (within ~60s of boot) succeed before Hyprland's env propagation
