### PR TITLE
installer: prevent first-boot snapper notification Btrfs

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -61,6 +61,19 @@ EOF
   fi
   sudo cp $OMARCHY_PATH/default/snapper/root /etc/snapper/configs/root
 
+  # Ensure SNAPPER_CONFIGS lists "root" and the /.snapshots subvolume exists
+  # before first boot. In chroot, `snapper create-config` doesn't always update
+  # /etc/conf.d/snapper or create the subvolume, leaving limine-snapper-sync's
+  # first-boot self-init path to do it — which trips an upstream race in
+  # ConfigReader.readSnapperConfig (DBus list call against a stale snapperd
+  # cache) and surfaces as a critical "Command failed: snapper ... list ..."
+  # toast on slower / offline-installed machines.
+  if ! grep -qE '^SNAPPER_CONFIGS=.*\broot\b' /etc/conf.d/snapper 2>/dev/null; then
+    sudo sed -i 's|^SNAPPER_CONFIGS=.*|SNAPPER_CONFIGS="root"|' /etc/conf.d/snapper
+  fi
+  sudo btrfs subvolume show /.snapshots >/dev/null 2>&1 || sudo btrfs subvolume create /.snapshots
+  sudo chmod 750 /.snapshots
+
   # Disable btrfs quotas — full qgroup accounting is a major performance drag
   sudo btrfs quota disable / 2>/dev/null || true
 


### PR DESCRIPTION
## Symptom

On a fresh Btrfs install, first boot shows a critical mako notification:

> Command failed: snapper --no-headers --utc --machine-readable csv -c root list --disable-used-space --columns number,date,type,description

Reproduces consistently on slower or offline-installed machines; faster online installs miss the timing window.

## Root cause (upstream)

In `limine-snapper-sync` (`ConfigReader.readSnapperConfig`), `disableDbus` is decided once at start (based on `Utility.areYouInChroot()`). When no snapper config is detected at first boot, the binary auto-creates one via `snapper --no-dbus create-config /` (CLI, bypassing snapperd) and then builds `SNAPPER_LIST_CMDLINE` *without* `--no-dbus`. The immediately-following `SnapperReader.readList()` runs through DBus and asks snapperd for a config it hasn't picked up yet → exit 1 → journald → `limine-snapper-notify` → critical notification.

Source: <https://gitlab.com/Zesko/limine-snapper-sync/-/blob/master/src/main/java/org/limine/snapper/processes/ConfigReader.java>

A separate fix is appropriate against `Zesko/limine-snapper-sync` and will be filed there too.

## Why Omarchy hits it

`install/login/limine-snapper.sh` runs in the archinstall chroot, where `snapper create-config` doesn't reliably update `/etc/conf.d/snapper`'s `SNAPPER_CONFIGS` or persist the `/.snapshots` subvolume across the chroot teardown. On first boot, `limine-snapper-watcher`'s gating check `if [ ! -d /.snapshots ]` is therefore true → it invokes the racy auto-init path.

## Fix

Make the install leave `/.snapshots` + `SNAPPER_CONFIGS="root"` in a fully-initialized state, so the watcher's gating check is false on first boot and the racy self-init never runs.

## Repro evidence (journal from an affected first boot)

```
limine-snapper-watcher: Directory /.snapshots does not exist. limine-snapper-sync is triggered to initialize a snapper config for /.snapshots.
limine-snapper-watcher: No Snapper config found for '/'. Creating a Snapper config named 'root' and single root snapshot.
limine-snapper-watcher: Succeeded: snapper --no-dbus -c root create-config /
limine-snapper-watcher: Succeeded: snapper --no-dbus -c root create --description 'limine-snapper-sync' --cleanup-algorithm number --read-only
limine-snapper-watcher: Command failed: snapper --no-headers --utc --machine-readable csv -c root list --disable-used-space --columns number,date,type,description
limine-snapper-watcher: Output: [The config 'root' does not exist. Likely snapper is not configured., See 'man snapper' for further instructions.]
limine-snapper-watcher: Exit code: 1
```

## Test plan

- [x] Repro confirmed: clean 3.8 USB install on an Acer Nitro (offline at install time) — notification appears on first boot, journal trace above captured.
- [x] After patch: rebuilt the ISO with the patched `install/login/limine-snapper.sh`, re-installed on the same Acer Nitro (offline again) — `/.snapshots` exists at first boot, watcher skips the racy branch, no notification.