### PR TITLE
Restrict first-run systemctl sudo access

### DIFF
--- a/install/first-run/cleanup-reboot-sudoers.sh
+++ b/install/first-run/cleanup-reboot-sudoers.sh
@@ -1,3 +1,1 @@
-if sudo test -f /etc/sudoers.d/99-omarchy-installer-reboot; then
-  sudo rm -f /etc/sudoers.d/99-omarchy-installer-reboot
-fi
+sudo rm -f /etc/sudoers.d/99-omarchy-installer-reboot

--- a/install/preflight/first-run-mode.sh
+++ b/install/preflight/first-run-mode.sh
@@ -5,12 +5,15 @@ touch ~/.local/state/omarchy/first-run.mode
 # Setup sudo-less access for first-run
 sudo tee /etc/sudoers.d/first-run >/dev/null <<EOF
 Cmnd_Alias FIRST_RUN_CLEANUP = /bin/rm -f /etc/sudoers.d/first-run
+Cmnd_Alias INSTALLER_REBOOT_CLEANUP = /bin/rm -f /etc/sudoers.d/99-omarchy-installer-reboot
 Cmnd_Alias SYMLINK_RESOLVED = /usr/bin/ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
-$USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl
+Cmnd_Alias UFW_SERVICE_ENABLE = /usr/bin/systemctl enable ufw
+$USER ALL=(ALL) NOPASSWD: UFW_SERVICE_ENABLE
 $USER ALL=(ALL) NOPASSWD: /usr/bin/ufw
 $USER ALL=(ALL) NOPASSWD: /usr/bin/ufw-docker
 $USER ALL=(ALL) NOPASSWD: /usr/bin/gtk-update-icon-cache
 $USER ALL=(ALL) NOPASSWD: SYMLINK_RESOLVED
 $USER ALL=(ALL) NOPASSWD: FIRST_RUN_CLEANUP
+$USER ALL=(ALL) NOPASSWD: INSTALLER_REBOOT_CLEANUP
 EOF
 sudo chmod 440 /etc/sudoers.d/first-run

--- a/migrations/1778347762.sh
+++ b/migrations/1778347762.sh
@@ -1,0 +1,29 @@
+echo "Restrict first-run systemctl sudo access"
+
+if ! sudo -v; then
+  echo "Failed to obtain sudo privileges for first-run sudoers migration" >&2
+  exit 1
+fi
+
+if sudo test -f /etc/sudoers.d/first-run && sudo grep -q 'NOPASSWD: /usr/bin/systemctl' /etc/sudoers.d/first-run; then
+  first_run_user="$(sudo awk '/NOPASSWD:/ { print $1; exit }' /etc/sudoers.d/first-run)"
+  if [[ -z $first_run_user ]]; then
+    echo "Failed to determine existing first-run sudoers user" >&2
+    exit 1
+  fi
+
+  sudo tee /etc/sudoers.d/first-run >/dev/null <<EOF
+Cmnd_Alias FIRST_RUN_CLEANUP = /bin/rm -f /etc/sudoers.d/first-run
+Cmnd_Alias INSTALLER_REBOOT_CLEANUP = /bin/rm -f /etc/sudoers.d/99-omarchy-installer-reboot
+Cmnd_Alias SYMLINK_RESOLVED = /usr/bin/ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+Cmnd_Alias UFW_SERVICE_ENABLE = /usr/bin/systemctl enable ufw
+$first_run_user ALL=(ALL) NOPASSWD: UFW_SERVICE_ENABLE
+$first_run_user ALL=(ALL) NOPASSWD: /usr/bin/ufw
+$first_run_user ALL=(ALL) NOPASSWD: /usr/bin/ufw-docker
+$first_run_user ALL=(ALL) NOPASSWD: /usr/bin/gtk-update-icon-cache
+$first_run_user ALL=(ALL) NOPASSWD: SYMLINK_RESOLVED
+$first_run_user ALL=(ALL) NOPASSWD: FIRST_RUN_CLEANUP
+$first_run_user ALL=(ALL) NOPASSWD: INSTALLER_REBOOT_CLEANUP
+EOF
+  sudo chmod 440 /etc/sudoers.d/first-run
+fi

--- a/test/first-run-sudoers-test.sh
+++ b/test/first-run-sudoers-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+FIRST_RUN_MODE="$ROOT/install/preflight/first-run-mode.sh"
+REBOOT_CLEANUP="$ROOT/install/first-run/cleanup-reboot-sudoers.sh"
+MIGRATION="$ROOT/migrations/1778347762.sh"
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+assert_readable_file() {
+  local description="$1"
+  local file="$2"
+
+  if [[ ! -r $file ]]; then
+    printf 'Expected readable file: %s\n' "$file" >&2
+    fail "$description"
+  fi
+}
+
+assert_contains() {
+  local description="$1"
+  local file="$2"
+  local expected="$3"
+
+  assert_readable_file "$description" "$file"
+
+  if ! grep -Fqx "$expected" "$file"; then
+    printf 'Expected line in %s:\n%s\n' "$file" "$expected" >&2
+    fail "$description"
+  fi
+
+  pass "$description"
+}
+
+assert_not_contains() {
+  local description="$1"
+  local file="$2"
+  local unexpected="$3"
+
+  assert_readable_file "$description" "$file"
+
+  if grep -Fqx "$unexpected" "$file"; then
+    printf 'Unexpected line in %s:\n%s\n' "$file" "$unexpected" >&2
+    fail "$description"
+  fi
+
+  pass "$description"
+}
+
+assert_contains "first-run permits only the needed root systemctl command" "$FIRST_RUN_MODE" \
+  "Cmnd_Alias UFW_SERVICE_ENABLE = /usr/bin/systemctl enable ufw"
+assert_contains "first-run uses the restricted systemctl alias" "$FIRST_RUN_MODE" \
+  '$USER ALL=(ALL) NOPASSWD: UFW_SERVICE_ENABLE'
+assert_not_contains "first-run does not permit unrestricted root systemctl" "$FIRST_RUN_MODE" \
+  '$USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl'
+
+assert_contains "first-run permits reboot sudoers cleanup directly" "$FIRST_RUN_MODE" \
+  "Cmnd_Alias INSTALLER_REBOOT_CLEANUP = /bin/rm -f /etc/sudoers.d/99-omarchy-installer-reboot"
+assert_contains "first-run uses the reboot sudoers cleanup alias" "$FIRST_RUN_MODE" \
+  '$USER ALL=(ALL) NOPASSWD: INSTALLER_REBOOT_CLEANUP'
+assert_contains "reboot cleanup uses the permitted rm command" "$REBOOT_CLEANUP" \
+  "sudo rm -f /etc/sudoers.d/99-omarchy-installer-reboot"
+assert_not_contains "reboot cleanup does not require unpermitted sudo test" "$REBOOT_CLEANUP" \
+  "if sudo test -f /etc/sudoers.d/99-omarchy-installer-reboot; then"
+
+assert_contains "migration repairs active first-run sudoers" "$MIGRATION" \
+  "echo \"Restrict first-run systemctl sudo access\""
+assert_contains "migration writes the restricted systemctl alias" "$MIGRATION" \
+  "Cmnd_Alias UFW_SERVICE_ENABLE = /usr/bin/systemctl enable ufw"
+assert_contains "migration preserves the existing first-run sudoers user" "$MIGRATION" \
+  '  first_run_user="$(sudo awk '\''/NOPASSWD:/ { print $1; exit }'\'' /etc/sudoers.d/first-run)"'
+assert_contains "migration validates the extracted first-run user" "$MIGRATION" \
+  '  if [[ -z $first_run_user ]]; then'
+assert_not_contains "migration does not write unrestricted root systemctl" "$MIGRATION" \
+  '$USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl'


### PR DESCRIPTION
## Summary

- replace the first-run passwordless `systemctl` sudoers rule with an exact `systemctl enable ufw` alias
- allow reboot sudoers cleanup through an explicit `rm -f` alias instead of relying on an unpermitted `sudo test` precheck
- add a migration for active installs that still have the broad first-run sudoers file
- add a static regression test for the first-run sudoers contract

Fixes #5708

## Validation

- `bash -n install/preflight/first-run-mode.sh install/first-run/cleanup-reboot-sudoers.sh migrations/1778347762.sh test/first-run-sudoers-test.sh`
- `bash test/first-run-sudoers-test.sh`
- `visudo -c -f` against the generated first-run sudoers body
- `git diff --check`

Note: `bash test/omarchy-cli-test.sh` could not run on this macOS checkout because only Bash 3.2 is installed locally, and `bin/omarchy` requires Bash 5 associative arrays.
