### PR TITLE
Add weather location setup option

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -312,7 +312,7 @@ show_font_menu() {
 }
 
 show_setup_menu() {
-  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
+  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󰖙  Weather\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
   [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
   [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
   options="$options\n  Defaults\n󰱔  DNS\n  Security\n  Config"
@@ -321,6 +321,7 @@ show_setup_menu() {
   *Audio*) omarchy-launch-audio ;;
   *Wifi*) omarchy-launch-wifi ;;
   *Bluetooth*) omarchy-launch-bluetooth ;;
+  *Weather*) show_setup_weather_menu ;;
   *Power*) show_setup_power_menu ;;
   *System*) show_setup_system_menu ;;
   *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;
@@ -331,6 +332,13 @@ show_setup_menu() {
   *Security*) show_setup_security_menu ;;
   *Config*) show_setup_config_menu ;;
   *) show_main_menu ;;
+  esac
+}
+
+show_setup_weather_menu() {
+  case $(menu "Weather" "󰖙  Location") in
+  *Location*) present_terminal omarchy-setup-weather-location ;;
+  *) show_setup_menu ;;
   esac
 }
 

--- a/bin/omarchy-setup-weather-location
+++ b/bin/omarchy-setup-weather-location
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# omarchy:summary=Set or clear the weather location override
+# omarchy:args=[location]
+# omarchy:examples=omarchy setup weather location|omarchy-setup-weather-location "Nairobi"|omarchy-setup-weather-location auto
+
+WEATHER_DIR="$HOME/.config/omarchy/weather"
+WEATHER_LOCATION_PATH="$WEATHER_DIR/location"
+
+location="${1:-}"
+
+if [[ -z $location ]]; then
+  location=$(omarchy-menu-input "Weather location (blank = auto)" --width 420) || exit 0
+fi
+
+location=${location%$'\n'}
+
+if [[ -n $location ]]; then
+  location="${location#"${location%%[![:space:]]*}"}"
+  location="${location%"${location##*[![:space:]]}"}"
+fi
+
+if [[ -z $location || ${location,,} == "auto" ]]; then
+  rm -f "$WEATHER_LOCATION_PATH"
+  notify-send -u low "Weather location" "Using auto-detected location"
+  exit 0
+fi
+
+mkdir -p "$WEATHER_DIR"
+printf '%s\n' "$location" > "$WEATHER_LOCATION_PATH"
+notify-send -u low "Weather location" "Set to $location"

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -2,16 +2,40 @@
 
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+WEATHER_LOCATION_PATH="$HOME/.config/omarchy/weather/location"
+LEGACY_WEATHER_LOCATION_PATH="$HOME/.config/omarchy/weather-location"
+
+if [[ -f $WEATHER_LOCATION_PATH ]]; then
+  location=$(tr -d '\n' < "$WEATHER_LOCATION_PATH")
+elif [[ -f $LEGACY_WEATHER_LOCATION_PATH ]]; then
+  location=$(tr -d '\n' < "$LEGACY_WEATHER_LOCATION_PATH")
+fi
+
+if [[ -n $location ]]; then
+  location="${location#"${location%%[![:space:]]*}"}"
+  location="${location%"${location##*[![:space:]]}"}"
+fi
+
+if [[ -n $location ]]; then
+  weather=$(curl -fsS --max-time 4 "https://wttr.in/${location}?format=%t|%w" 2>/dev/null | tr -d '\n')
+else
+  weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+fi
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"
   exit 1
 fi
 
-IFS='|' read -r place temperature wind <<< "$weather"
-place=${place%%,*}
-place=${place^}
+if [[ -n $location ]]; then
+  IFS='|' read -r temperature wind <<< "$weather"
+  place="$location"
+else
+  IFS='|' read -r place temperature wind <<< "$weather"
+  place=${place%%,*}
+  place=${place^}
+fi
+
 temperature=${temperature#+}
 
 echo "$(omarchy-weather-icon)    $place  ·  Temp $temperature  ·  Wind $wind"


### PR DESCRIPTION
## Summary
This PR shares a weather location setup configuration:  
https://github.com/basecamp/omarchy/discussions/5707

- add `Setup -> Weather -> Location`
- add `omarchy-setup-weather-location` to set/clear a user-defined location
- update `omarchy-weather-status` to use an override when configured, while keeping default auto-detection unchanged

## Files changed
- `bin/omarchy-menu` — add `Setup -> Weather -> Location` menu flow
- `bin/omarchy-setup-weather-location` — new command to set/clear weather location
- `bin/omarchy-weather-status` — read configured location override with fallback behavior

## Behavior and compatibility
- default behavior remains unchanged when no location is configured (`wttr.in` auto-detection)
- canonical path used in this PR: `~/.config/omarchy/weather/location`
- compatibility fallback read path: `~/.config/omarchy/weather-location`
- no migration included because this is additive and non-breaking

## Clarification needed
### Maintainer decision requested
I’ve used `~/.config/omarchy/weather/location` as the canonical path in this PR, and would appreciate maintainer confirmation on the preferred long-term convention.

## Why
`wttr.in` auto-location can sometimes resolve to coordinates or unstable location names depending on ISP/VPN/routing. This adds a deterministic user override without requiring edits in `~/.local/share/omarchy`.