### PR TITLE
Fix internal display toggle not re-applied after resume

### DIFF
--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Enable, disable, toggle, or recover the internal laptop display
-# omarchy:args=<on|off|toggle|recover>
+# omarchy:args=<on|off|toggle|recover|reapply>
 
 TOGGLE="internal-monitor-disable"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.conf"
@@ -31,9 +31,18 @@ off() {
 }
 
 recover() {
-  if ! omarchy-hw-external-monitors; then
-    omarchy-hyprland-toggle $TOGGLE off
+  if ! omarchy-hyprland-toggle-enabled "$TOGGLE"; then
+    return
   fi
+
+  for i in {1..6}; do
+    if omarchy-hw-external-monitors; then
+      return
+    fi
+    sleep 0.5
+  done
+
+  omarchy-hyprland-toggle "$TOGGLE"
 }
 
 toggle() {
@@ -44,13 +53,20 @@ toggle() {
   fi
 }
 
+reapply() {
+  if omarchy-hyprland-toggle-enabled "$TOGGLE"; then
+    hyprctl reload
+  fi
+}
+
 case "$1" in
   on) on ;;
   off) off ;;
   toggle) toggle ;;
   recover) recover ;;
+  reapply) reapply ;;
   *)
-    echo "Usage: $(basename "$0") {on|off|toggle|recover}" >&2
+    echo "Usage: $(basename "$0") {on|off|toggle|recover|reapply}" >&2
     exit 1
     ;;
 esac

--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -31,18 +31,16 @@ off() {
 }
 
 recover() {
-  if ! omarchy-hyprland-toggle-enabled "$TOGGLE"; then
-    return
+  if omarchy-hyprland-toggle-enabled $TOGGLE; then
+    for i in {1..6}; do
+      if omarchy-hw-external-monitors; then
+        return
+      fi
+      sleep 0.5
+    done
+
+    omarchy-hyprland-toggle $TOGGLE off
   fi
-
-  for i in {1..6}; do
-    if omarchy-hw-external-monitors; then
-      return
-    fi
-    sleep 0.5
-  done
-
-  omarchy-hyprland-toggle "$TOGGLE"
 }
 
 toggle() {
@@ -54,7 +52,7 @@ toggle() {
 }
 
 reapply() {
-  if omarchy-hyprland-toggle-enabled "$TOGGLE"; then
+  if omarchy-hyprland-toggle-enabled $TOGGLE; then
     hyprctl reload
   fi
 }

--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -32,6 +32,7 @@ off() {
 
 recover() {
   if omarchy-hyprland-toggle-enabled $TOGGLE; then
+    # External monitors can take a few seconds to become available after sleep, so wait up to 3s
     for i in {1..6}; do
       if omarchy-hw-external-monitors; then
         return

--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Enable, disable, toggle, or recover mirroring the internal display to an external monitor
-# omarchy:args=<on|off|toggle|recover>
+# omarchy:args=<on|off|toggle|recover|reapply>
 
 TOGGLE="internal-monitor-mirror"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.conf"
@@ -45,8 +45,23 @@ toggle() {
 }
 
 recover() {
-  if ! omarchy-hw-external-monitors; then
-    omarchy-hyprland-toggle $TOGGLE off
+  if ! omarchy-hyprland-toggle-enabled "$TOGGLE"; then
+    return
+  fi
+
+  for i in {1..6}; do
+    if omarchy-hw-external-monitors; then
+      return
+    fi
+    sleep 0.5
+  done
+
+  omarchy-hyprland-toggle "$TOGGLE"
+}
+
+reapply() {
+  if omarchy-hyprland-toggle-enabled "$TOGGLE"; then
+    hyprctl reload
   fi
 }
 
@@ -55,8 +70,9 @@ case "$1" in
   off) off ;;
   toggle) toggle ;;
   recover) recover ;;
+  reapply) reapply ;;
   *)
-    echo "Usage: $(basename "$0") {on|off|toggle|recover}" >&2
+    echo "Usage: $(basename "$0") {on|off|toggle|recover|reapply}" >&2
     exit 1
     ;;
 esac

--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -45,22 +45,20 @@ toggle() {
 }
 
 recover() {
-  if ! omarchy-hyprland-toggle-enabled "$TOGGLE"; then
-    return
+  if omarchy-hyprland-toggle-enabled $TOGGLE; then
+    for i in {1..6}; do
+      if omarchy-hw-external-monitors; then
+        return
+      fi
+      sleep 0.5
+    done
+
+    omarchy-hyprland-toggle $TOGGLE off
   fi
-
-  for i in {1..6}; do
-    if omarchy-hw-external-monitors; then
-      return
-    fi
-    sleep 0.5
-  done
-
-  omarchy-hyprland-toggle "$TOGGLE"
 }
 
 reapply() {
-  if omarchy-hyprland-toggle-enabled "$TOGGLE"; then
+  if omarchy-hyprland-toggle-enabled $TOGGLE; then
     hyprctl reload
   fi
 }

--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -46,6 +46,7 @@ toggle() {
 
 recover() {
   if omarchy-hyprland-toggle-enabled $TOGGLE; then
+    # External monitors can take a few seconds to become available after sleep, so wait up to 3s
     for i in {1..6}; do
       if omarchy-hw-external-monitors; then
         return

--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -6,9 +6,13 @@ SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
 
 socat -U - "UNIX-CONNECT:$SOCKET" | while read -r event; do
   case "$event" in
-    monitorremoved\>\>*|monitorremovedv2\>\>*)
-      omarchy-hyprland-monitor-internal recover
-      omarchy-hyprland-monitor-internal-mirror recover
-      ;;
+  monitorremoved\>* | monitorremovedv2\>*)
+    omarchy-hyprland-monitor-internal recover
+    omarchy-hyprland-monitor-internal-mirror recover
+    ;;
+  monitoradded\>* | monitoraddedv2\>*)
+    omarchy-hyprland-monitor-internal reapply
+    omarchy-hyprland-monitor-internal-mirror reapply
+    ;;
   esac
 done


### PR DESCRIPTION
## Problem
When you disable the internal laptop display while an external monitor is connected, then trigger display sleep (screen off) and wake the laptop, the internal display incorrectly turns back on - even though nothing changed with the external monitor connection.
The expected behavior: the internal display should stay disabled after wake, as long as the external monitor remains connected. This works correctly with `systemctl suspend`, but fails with display sleep.

## Root Cause
When the screen turns off (display sleep), the external monitor loses signal due to no input and Hyprland sends a `monitorremoved` event. Shortly after, when the laptop wakes, the external monitor takes a moment to be detected again. The monitor watcher would immediately try to "recover" the internal display without waiting for the external monitor to reappear on wake, causing a race condition where the internal display gets turned back on before the external monitor is detected.

## Solution
1. **`recover()` now waits up to 3 seconds** - before re-enabling the internal display, it polls for external monitors to give the system time to detect them on wake
2. **Added `reapply()` function** - to properly refresh the toggle state when monitors are reconnected
3. **Added `monitoradded` event handling** - ensures toggle state is maintained when monitors are added

Probably fixes #5481