### PR TITLE
Make weather widgets location- and units-aware

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -358,8 +358,9 @@ show_setup_menu() {
 }
 
 show_setup_weather_menu() {
-  case $(menu "Weather" "󰖙  Location") in
+  case $(menu "Weather" "󰖙  Location\n  Units") in
   *Location*) omarchy-menu-weather ;;
+  *Units*) omarchy-menu-weather-units ;;
   *) show_setup_menu ;;
   esac
 }

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -334,7 +334,7 @@ show_font_menu() {
 }
 
 show_setup_menu() {
-  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
+  local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󰖙  Weather\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
   [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
   [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
   options="$options\n  Defaults\n󰱔  DNS\n  Security\n  Config"
@@ -343,6 +343,7 @@ show_setup_menu() {
   *Audio*) omarchy-launch-audio ;;
   *Wifi*) omarchy-launch-wifi ;;
   *Bluetooth*) omarchy-launch-bluetooth ;;
+  *Weather*) show_setup_weather_menu ;;
   *Power*) show_setup_power_menu ;;
   *System*) show_setup_system_menu ;;
   *Monitors*) open_in_editor ~/.config/hypr/monitors.conf ;;
@@ -353,6 +354,13 @@ show_setup_menu() {
   *Security*) show_setup_security_menu ;;
   *Config*) show_setup_config_menu ;;
   *) show_main_menu ;;
+  esac
+}
+
+show_setup_weather_menu() {
+  case $(menu "Weather" "󰖙  Location") in
+  *Location*) omarchy-menu-weather ;;
+  *) show_setup_menu ;;
   esac
 }
 

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -899,6 +899,7 @@ go_to_menu() {
   *theme*) show_theme_menu ;;
   *screenrecord*) show_screenrecord_menu ;;
   *setup*) show_setup_menu ;;
+  *weather*) show_setup_weather_menu ;;
   *power*) show_setup_power_menu ;;
   *install*) show_install_menu ;;
   *remove*) show_remove_menu ;;

--- a/bin/omarchy-menu-weather
+++ b/bin/omarchy-menu-weather
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# omarchy:summary=Pick a weather location via walker prompt and persist it
+# omarchy:group=menu
+# omarchy:examples=omarchy menu weather
+
+set -eo pipefail
+
+input=$(omarchy-menu-input "Weather location (city or zip)" || true)
+
+[[ -z $input ]] && exit 0
+
+omarchy weather set-location "$input"

--- a/bin/omarchy-menu-weather-units
+++ b/bin/omarchy-menu-weather-units
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Pick weather units via walker prompt and persist them
+# omarchy:group=menu
+# omarchy:examples=omarchy menu weather-units
+
+set -eo pipefail
+
+choice=$(omarchy-menu-select "Weather units" "Metric" "Imperial" "Auto-detect" || true)
+
+[[ -z $choice ]] && exit 0
+
+case $choice in
+  Metric) omarchy weather set-units metric ;;
+  Imperial) omarchy weather set-units imperial ;;
+  Auto-detect) omarchy weather clear-units ;;
+esac

--- a/bin/omarchy-weather-clear-location
+++ b/bin/omarchy-weather-clear-location
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Clear the configured weather location and return to auto-detect
+# omarchy:examples=omarchy weather clear-location
+
+set -eo pipefail
+
+path="$HOME/.config/omarchy/current/weather.location"
+
+if [[ -f $path ]]; then
+  rm -f "$path"
+  echo "Weather location cleared (using auto-detect)"
+  echo "Restarting Waybar..."
+  omarchy-restart-waybar
+else
+  echo "No weather location was configured"
+fi

--- a/bin/omarchy-weather-clear-units
+++ b/bin/omarchy-weather-clear-units
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Clear the configured weather units and return to auto-detect
+# omarchy:examples=omarchy weather clear-units
+
+set -eo pipefail
+
+path="$HOME/.config/omarchy/current/weather.units"
+
+if [[ -f $path ]]; then
+  rm -f "$path"
+  echo "Weather units cleared (using auto-detect)"
+  echo "Restarting Waybar..."
+  omarchy-restart-waybar
+else
+  echo "No weather units were configured"
+fi

--- a/bin/omarchy-weather-icon
+++ b/bin/omarchy-weather-icon
@@ -5,7 +5,14 @@
 loc=$(cat "$HOME/.config/omarchy/current/weather.location" 2>/dev/null || true)
 loc_path="${loc:+/${loc// /+}}"
 
-weather_data=$(curl -fsS --max-time 3 "https://wttr.in${loc_path}?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
+units=$(cat "$HOME/.config/omarchy/current/weather.units" 2>/dev/null || true)
+case $units in
+  metric) units_param="&m" ;;
+  imperial) units_param="&u" ;;
+  *) units_param="" ;;
+esac
+
+weather_data=$(curl -fsS --max-time 3 "https://wttr.in${loc_path}?format=j1${units_param}" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
 
 IFS=$'\t' read -r weather_code sunrise sunset <<< "$weather_data"
 if [[ ! $weather_code =~ ^[0-9]+$ || ! $sunrise =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ || ! $sunset =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ ]]; then

--- a/bin/omarchy-weather-icon
+++ b/bin/omarchy-weather-icon
@@ -2,7 +2,10 @@
 
 # omarchy:summary=Returns a weather condition icon, adjusted for live sunrise and sunset.
 
-weather_data=$(curl -fsS --max-time 3 "https://wttr.in?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
+loc=$(cat "$HOME/.config/omarchy/current/weather.location" 2>/dev/null || true)
+loc_path="${loc:+/${loc// /+}}"
+
+weather_data=$(curl -fsS --max-time 3 "https://wttr.in${loc_path}?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
 
 IFS=$'\t' read -r weather_code sunrise sunset <<< "$weather_data"
 if [[ ! $weather_code =~ ^[0-9]+$ || ! $sunrise =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ || ! $sunset =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ ]]; then

--- a/bin/omarchy-weather-location
+++ b/bin/omarchy-weather-location
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Show currently configured weather location
+# omarchy:examples=omarchy weather location
+
+path="$HOME/.config/omarchy/current/weather.location"
+
+if [[ -f $path ]]; then
+  cat "$path"
+else
+  echo "Not configured"
+fi

--- a/bin/omarchy-weather-set-location
+++ b/bin/omarchy-weather-set-location
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Set the weather location used by waybar weather widgets
+# omarchy:args=<location>
+# omarchy:examples=omarchy weather set-location "New York, NY" | omarchy weather set-location London | omarchy weather set-location 10001
+
+set -eo pipefail
+
+location="$1"
+
+if [[ -z $location ]]; then
+  echo "Usage: omarchy weather set-location <location>" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/.config/omarchy/current"
+printf '%s\n' "$location" >"$HOME/.config/omarchy/current/weather.location"
+
+echo "Weather location set to $location"
+echo "Restarting Waybar..."
+omarchy-restart-waybar

--- a/bin/omarchy-weather-set-units
+++ b/bin/omarchy-weather-set-units
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Set the weather units used by waybar weather widgets
+# omarchy:args=<metric|imperial>
+# omarchy:examples=omarchy weather set-units metric | omarchy weather set-units imperial
+
+set -eo pipefail
+
+units="$1"
+
+if [[ -z $units ]]; then
+  echo "Usage: omarchy weather set-units <metric|imperial>" >&2
+  exit 1
+fi
+
+if [[ $units != "metric" && $units != "imperial" ]]; then
+  echo "Invalid units: $units (must be metric or imperial)" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/.config/omarchy/current"
+printf '%s\n' "$units" >"$HOME/.config/omarchy/current/weather.units"
+
+echo "Weather units set to $units"
+echo "Restarting Waybar..."
+omarchy-restart-waybar

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -5,7 +5,14 @@
 loc=$(cat "$HOME/.config/omarchy/current/weather.location" 2>/dev/null || true)
 loc_path="${loc:+/${loc// /+}}"
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in${loc_path}?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+units=$(cat "$HOME/.config/omarchy/current/weather.units" 2>/dev/null || true)
+case $units in
+  metric) units_param="&m" ;;
+  imperial) units_param="&u" ;;
+  *) units_param="" ;;
+esac
+
+weather=$(curl -fsS --max-time 4 "https://wttr.in${loc_path}?format=%l|%t|%w${units_param}" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -2,7 +2,10 @@
 
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+loc=$(cat "$HOME/.config/omarchy/current/weather.location" 2>/dev/null || true)
+loc_path="${loc:+/${loc// /+}}"
+
+weather=$(curl -fsS --max-time 4 "https://wttr.in${loc_path}?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"

--- a/bin/omarchy-weather-units
+++ b/bin/omarchy-weather-units
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Show currently configured weather units
+# omarchy:examples=omarchy weather units
+
+path="$HOME/.config/omarchy/current/weather.units"
+
+if [[ -f $path ]]; then
+  cat "$path"
+else
+  echo "Auto-detect"
+fi


### PR DESCRIPTION
The weather widgets currently auto-detect both location and units from geo-IP, which fails on VPNs and on US locations that prefer metric (or vice versa). This adds:

**Location**
- `omarchy weather location` / `set-location` / `clear-location`
- walker picker via `omarchy menu weather`

**Units**
- `omarchy weather units` / `set-units (metric|imperial)` / `clear-units`
- walker picker reachable from the Setup → Weather menu

The Weather setup submenu now also dispatches via `omarchy-menu weather`, so a waybar right-click can be bound straight to it.

When no value is configured, behavior is identical to today — wttr.in auto-detects from the request.