### PR TITLE
Added notification for hyprpicker

### DIFF
--- a/bin/omarchy-capture-color
+++ b/bin/omarchy-capture-color
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Use hyprpicker to get a color
+# omarchy:group=capture
+
+COLOR=$(pkill hyprpicker || hyprpicker -a)
+
+omarchy-notification-send "󰃉" "Hex code copied to clipboard" "$COLOR"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -144,7 +144,7 @@ show_capture_menu() {
   *Screenshot*) omarchy-capture-screenshot ;;
   *Screenrecord*) show_screenrecord_menu ;;
   *Text*) omarchy-capture-text-extraction ;;
-  *Color*) pkill hyprpicker || hyprpicker -a ;;
+  *Color*) omarchy-capture-color;;
   *) back_to show_trigger_menu ;;
   esac
 }


### PR DESCRIPTION
Just a small change, now when you pick a color through the capture menu, it shows you a little notification with the hex code + telling you. that it's been copied (I didn't know it did that and thought hyprpicker had crashed after I picked a color, also this makes it a bit more consistent with the other capture actions).