### PR TITLE
Let the weather widget show your city

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -315,7 +315,7 @@ show_setup_menu() {
   local options="  Audio\n  Wifi\n󰂯  Bluetooth\n󱐋  Power Profile\n  System Sleep\n󰍹  Monitors"
   [[ -f ~/.config/hypr/bindings.conf ]] && options="$options\n  Keybindings"
   [[ -f ~/.config/hypr/input.conf ]] && options="$options\n  Input"
-  options="$options\n  Defaults\n󰱔  DNS\n  Security\n  Config"
+  options="$options\n  Defaults\n󰱔  DNS\n󰖐  Weather\n  Security\n  Config"
 
   case $(menu "Setup" "$options") in
   *Audio*) omarchy-launch-audio ;;
@@ -328,6 +328,7 @@ show_setup_menu() {
   *Input*) open_in_editor ~/.config/hypr/input.conf ;;
   *Defaults*) show_setup_default_menu ;;
   *DNS*) present_terminal omarchy-setup-dns ;;
+  *Weather*) present_terminal omarchy-weather-set-location ;;
   *Security*) show_setup_security_menu ;;
   *Config*) show_setup_config_menu ;;
   *) show_main_menu ;;

--- a/bin/omarchy-weather-icon
+++ b/bin/omarchy-weather-icon
@@ -2,7 +2,14 @@
 
 # omarchy:summary=Returns a weather condition icon, adjusted for live sunrise and sunset.
 
-weather_data=$(curl -fsS --max-time 3 "https://wttr.in?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
+location_file="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/weather-location"
+location=""
+if [[ -s $location_file ]]; then
+  candidate=$(head -n1 "$location_file" 2>/dev/null | tr -d '\r')
+  [[ $candidate =~ ^[A-Za-z0-9~,+._-]{1,128}$ ]] && location=$candidate
+fi
+
+weather_data=$(curl -fsS --max-time 3 "https://wttr.in/${location}?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
 
 IFS=$'\t' read -r weather_code sunrise sunset <<< "$weather_data"
 if [[ ! $weather_code =~ ^[0-9]+$ || ! $sunrise =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ || ! $sunset =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ ]]; then

--- a/bin/omarchy-weather-set-location
+++ b/bin/omarchy-weather-set-location
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# omarchy:summary=Set your city for the live weather widget.
+
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy"
+override_file="$config_dir/weather-location"
+mkdir -p "$config_dir"
+
+allowlist_re='^[A-Za-z0-9~,+._-]{1,128}$'
+nominatim_ua="omarchy-weather (https://github.com/basecamp/omarchy)"
+
+current=""
+[[ -s $override_file ]] && current=$(head -n1 "$override_file" 2>/dev/null | tr -d '\r')
+
+if [[ -n $current ]]; then
+  prompt="Update weather location (currently: ${current//+/ })> "
+else
+  prompt="Set weather location> "
+fi
+
+input=$(gum input --prompt "$prompt" --placeholder "San Francisco / Berlin / sfo / ~52.5,13.4")
+input=${input//$'\r'/}
+input=$(printf '%s' "$input" | tr -s '[:space:]' ' ')
+input="${input# }"
+input="${input% }"
+input=${input// /+}
+
+restart_widget() {
+  command -v omarchy-restart-waybar >/dev/null 2>&1 && omarchy-restart-waybar >/dev/null 2>&1 || true
+}
+
+if [[ -z $input ]]; then
+  if [[ -n $current ]] && gum confirm "Clear current location (${current//+/ })?"; then
+    rm -f "$override_file"
+    restart_widget
+    gum style --foreground 42 "Cleared. Weather will use IP-based fallback."
+  else
+    echo "Unchanged."
+  fi
+  exit 0
+fi
+
+if [[ ! $input =~ $allowlist_re ]]; then
+  gum style --foreground 196 "Invalid: only letters, digits, and ~,+._- allowed (max 128 chars)."
+  exit 1
+fi
+
+# Resolve the input to a real city name: wttr.in for coords, Nominatim for the city.
+# Falls back to the raw input (with first letter capitalized) if either lookup fails.
+resolved=""
+coords=$(curl -fsS --max-time 4 "https://wttr.in/${input}?format=j1" 2>/dev/null \
+  | jq -er '.nearest_area[0] | "\(.latitude),\(.longitude)"' 2>/dev/null)
+if [[ -n $coords ]]; then
+  city=$(curl -fsS --max-time 4 -A "$nominatim_ua" \
+    "https://nominatim.openstreetmap.org/reverse?lat=${coords%,*}&lon=${coords#*,}&format=jsonv2&addressdetails=1&zoom=10&accept-language=en" 2>/dev/null \
+    | jq -er '.address | (.city // .town // .village // .municipality // .county // .state)' 2>/dev/null)
+  if [[ -n $city ]]; then
+    candidate=${city// /+}
+    [[ $candidate =~ $allowlist_re ]] && resolved=$candidate
+  fi
+fi
+
+final=${resolved:-${input^}}
+
+printf '%s\n' "$final" > "$override_file"
+restart_widget
+
+if [[ -n $resolved && $resolved != "$input" ]]; then
+  gum style --foreground 42 "Resolved '$input' → '${final//+/ }'."
+else
+  gum style --foreground 42 "Set: ${final//+/ }"
+fi

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -2,16 +2,33 @@
 
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+location_file="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/weather-location"
+location=""
+if [[ -s $location_file ]]; then
+  candidate=$(head -n1 "$location_file" 2>/dev/null | tr -d '\r')
+  [[ $candidate =~ ^[A-Za-z0-9~,+._-]{1,128}$ ]] && location=$candidate
+fi
+
+if [[ -n $location ]]; then
+  # Override is a resolved place name (with + for spaces) — display it directly,
+  # only ask wttr.in for the numbers.
+  weather=$(curl -fsS --max-time 4 "https://wttr.in/${location}?format=%t|%w" 2>/dev/null | tr -d '\n')
+  place=${location//+/ }
+else
+  # No override: fall back to wttr.in's own (often wrong, often lowercase) %l.
+  weather=$(curl -fsS --max-time 4 "https://wttr.in/?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+  IFS='|' read -r place temperature_wind_rest <<< "$weather"
+  place=${place%%,*}
+  place=${place^}
+  weather=${temperature_wind_rest}
+fi
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"
   exit 1
 fi
 
-IFS='|' read -r place temperature wind <<< "$weather"
-place=${place%%,*}
-place=${place^}
+IFS='|' read -r temperature wind <<< "$weather"
 temperature=${temperature#+}
 
 echo "$(omarchy-weather-icon)    $place  ·  Temp $temperature  ·  Wind $wind"

--- a/migrations/1778424449.sh
+++ b/migrations/1778424449.sh
@@ -1,5 +1,12 @@
 echo "Set your city for the live weather widget (so it works behind VPNs and on travel)"
 
-if [[ ! -s "${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/weather-location" ]]; then
-  omarchy-weather-set-location || true
+if [[ -s "${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/weather-location" ]]; then
+  exit 0
 fi
+
+if [[ ! -t 0 ]] || ! command -v gum >/dev/null 2>&1; then
+  echo "Skipping prompt (non-interactive). Set later via Setup → Weather."
+  exit 0
+fi
+
+omarchy-weather-set-location

--- a/migrations/1778424449.sh
+++ b/migrations/1778424449.sh
@@ -1,0 +1,5 @@
+echo "Set your city for the live weather widget (so it works behind VPNs and on travel)"
+
+if [[ ! -s "${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/weather-location" ]]; then
+  omarchy-weather-set-location || true
+fi


### PR DESCRIPTION
The widget added in #5633 calls `wttr.in` without a location, so wttr.in geocodes the request IP. On a VPN that's the exit node. On a travelling laptop it's wherever you connected from last. I've been staring at "Miami" all week from a Nashville chair behind a VPN.

Fix: ask once and remember the answer. The helper also turns whatever you type into a real city name before saving, so airport codes and coordinates get displayed properly.

## What's in the PR

A new `omarchy-weather-set-location` script. Whatever you type at it (city, airport code, lat/lon) goes through wttr.in to get coordinates, then through Nominatim's reverse geocode to get a city name. The city name is what lands in `~/.config/omarchy/weather-location`. Type "bna" and "Nashville" gets saved. Type `~36.16,-86.78`, also "Nashville". Type "Tokyo" and you get "Tokyo" rather than 東京都 (the English locale is forced). Spaces, multiple spaces, CRLF endings, and leading/trailing whitespace all get cleaned up so "San Francisco" works as well as "san+francisco". If either lookup fails (no internet, no useful Nominatim hit), it just saves what you typed.

The two existing weather scripts read that file, validate it against `[A-Za-z0-9~,+._-]{1,128}`, and put it in the wttr.in path. `omarchy-weather-status` also displays the saved name directly now. It used to trust wttr.in's `%l` echo, which is exactly why typing "bna" left "bna" in the widget. wttr.in echoes the path. If the override is missing or invalid, the URL collapses to bare `wttr.in/`, same as today.

I added a "Weather" entry to the Setup submenu so the helper sits next to DNS and Direct Boot. The migration runs the prompt on first `omarchy-migrate` if you don't already have an override.

About 100 new lines of bash plus 31 lines of edits. No new packages. The wttr.in and Nominatim calls only happen when you set a location; the regular weather poll is untouched.

## Why ask instead of autodetect

Tried three autodetect paths before giving up.

GeoClue2's WiFi positioning needs `wpa_supplicant`. Omarchy ships `iwd`. GeoClue silently falls back to IP, which is the VPN problem we started with.

Connected-BSSID lookups via `iw dev <iface> link` POSTed to BeaconDB seemed like the right answer for a while. They work without root, and BeaconDB matches on the BSSID rather than the request IP, so VPN routing doesn't poison the result. I built it. On my laptop BeaconDB returned `"fallback":"ipf"` because my home BSSID isn't in their database, so BeaconDB itself fell back to IP geolocation. Same wrong city. Single-BSSID coverage looks sparse outside dense urban EU/US. For most users this would be a phone-home that doesn't deliver an answer.

Timezone-to-city is too coarse to bother with. `America/Chicago` covers Nashville, Memphis, Dallas, Minneapolis, St. Louis, and Chicago. Pick one and you're wrong for everyone else.

A feature that can't tell you what city you're in is worse than no feature at all.

## What would change the approach

If autodetect is worth another try, the move is `iw` in base packages plus `setcap cap_net_admin+ep` so a non-root user can scan all visible BSSIDs at once and POST the batch to BeaconDB. Multi-BSSID hit rates are much better than single-BSSID. It would still miss in low-coverage regions and it would still be a phone-home, so I'd probably wire it as opt-in.

Adding `wpa_supplicant` alongside `iwd` to revive the GeoClue route is a bigger wifi-stack reshuffle than a weather widget justifies. Google or Apple geolocation APIs have the best accuracy and the worst trade-offs (money, closed source).

If someone wants to layer the multi-BSSID path on top of this PR as a fallback for users who haven't set an override, the override semantics here don't get in the way.

## Testing

Built and used it on a Nashville laptop on a VPN that geocodes to Miami.

With no override the widget still shows Miami. That's the existing bug; this PR doesn't fix it for users who never set a location, but nothing gets worse either.

With the helper:

- `bna` resolves to Nashville. Widget reads "Nashville".
- `San Francisco` resolves to San Francisco (spaces, CRLF endings, and stray whitespace are all cleaned up before the lookup).
- `sfo` resolves to "Millbrae" because that's the city the SFO airport physically sits in. The helper tells you what it resolved to; if you want "San Francisco" instead, re-run and type it.
- `Tokyo` resolves to Tokyo, not 東京都.
- `~36.16,-86.78` resolves to Nashville.

The override allowlist rejects URL injection (`Berlin?format=j2`, `Berlin&foo`); bad content is treated as no override and you get the IP fallback. The migration only prompts when no override exists, so a second `omarchy-migrate` is a no-op. The weather widget, the on-click notification, and the `SUPER+CTRL+ALT+W` keybind all pick up the change.