### PR TITLE
Show OSD when ACPI platform profile changes

### DIFF
--- a/bin/omarchy-first-run
+++ b/bin/omarchy-first-run
@@ -18,6 +18,7 @@ if [[ -f $FIRST_RUN_MODE ]]; then
   bash "$OMARCHY_PATH/install/first-run/gnome-theme.sh"
   bash "$OMARCHY_PATH/install/first-run/gdk-scale.sh"
   bash "$OMARCHY_PATH/install/first-run/swayosd.sh"
+  bash "$OMARCHY_PATH/install/first-run/powerprofiles-osd.sh"
   bash "$OMARCHY_PATH/install/first-run/gtk-primary-paste.sh"
   bash "$OMARCHY_PATH/install/first-run/elephant.sh"
   omarchy-hook-install post-update "$OMARCHY_PATH/install/first-run/install-voxtype.hook"

--- a/bin/omarchy-powerprofiles-osd-watch
+++ b/bin/omarchy-powerprofiles-osd-watch
@@ -1,0 +1,66 @@
+#!/bin/python3
+
+# omarchy:summary=Show a SwayOSD when the ACPI platform profile changes (e.g. the ThinkPad mode key).
+# omarchy:hidden=true
+
+# Watches /sys/firmware/acpi/platform_profile with POLLPRI, which the kernel
+# asserts as soon as the firmware (e.g. a hardware mode key) flips the profile.
+# Avoids power-profiles-daemon's ~2s changes-done-hint coalescing window so the
+# OSD appears immediately.
+
+import select
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SYSFS = Path("/sys/firmware/acpi/platform_profile")
+
+# Map raw ACPI platform_profile values to PPD-style labels + freedesktop icons.
+PROFILES = {
+    "performance": ("Performance", "power-profile-performance-symbolic"),
+    "balanced": ("Balanced", "power-profile-balanced-symbolic"),
+    "low-power": ("Power Saver", "power-profile-power-saver-symbolic"),
+    "power-saver": ("Power Saver", "power-profile-power-saver-symbolic"),
+    "quiet": ("Quiet", "power-profile-power-saver-symbolic"),
+}
+
+
+def log(msg):
+    now = time.time()
+    stamp = time.strftime("%H:%M:%S", time.localtime(now))
+    print(f"{stamp}.{int(now * 1000) % 1000:03d} {msg}", flush=True)
+
+
+def show_osd(profile):
+    label, icon = PROFILES.get(profile, (profile, "dialog-information-symbolic"))
+    subprocess.Popen(
+        ["swayosd-client", "--custom-message", label, "--custom-icon", icon],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def main():
+    if not SYSFS.exists():
+        log(f"{SYSFS} not present; exiting")
+        return 0
+
+    f = SYSFS.open("rb")
+    poller = select.poll()
+    poller.register(f, select.POLLPRI | select.POLLERR)
+    last = f.read().decode().strip()
+    log(f"watching {SYSFS} (current={last})")
+
+    while True:
+        poller.poll()
+        f.seek(0)
+        current = f.read().decode().strip()
+        if current and current != last:
+            log(f"profile changed: {last} -> {current}")
+            show_osd(current)
+            last = current
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/config/systemd/user/omarchy-powerprofiles-osd.service
+++ b/config/systemd/user/omarchy-powerprofiles-osd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Omarchy Power Profile OSD
+After=graphical-session.target swayosd-server.service
+Wants=swayosd-server.service
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/share/omarchy/bin/omarchy-powerprofiles-osd-watch
+Restart=on-failure
+RestartSec=3
+LogLevelMax=warning
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/first-run/powerprofiles-osd.sh
+++ b/install/first-run/powerprofiles-osd.sh
@@ -1,0 +1,1 @@
+systemctl --user enable --now omarchy-powerprofiles-osd.service

--- a/migrations/1778646038.sh
+++ b/migrations/1778646038.sh
@@ -1,0 +1,6 @@
+echo "Show OSD when the ACPI platform profile changes"
+
+mkdir -p ~/.config/systemd/user
+cp -f $OMARCHY_PATH/config/systemd/user/omarchy-powerprofiles-osd.service ~/.config/systemd/user/omarchy-powerprofiles-osd.service
+systemctl --user daemon-reload
+systemctl --user enable --now omarchy-powerprofiles-osd.service


### PR DESCRIPTION
## Summary

- Adds an OSD (via SwayOSD) when the ACPI platform profile changes — e.g. when the ThinkPad mode key cycles between *Power Saver / Balanced / Performance*. Today the profile changes silently and the user gets no feedback, unlike volume or brightness.
- Implemented as a small user-level service: `omarchy-powerprofiles-osd-watch` (Python, stdlib only) + `omarchy-powerprofiles-osd.service`, plus a first-run hook for new installs and a migration to enable it for existing users.

## Why POLLPRI instead of listening to `power-profiles-daemon`?

I initially listened to `net.hadess.PowerProfiles` `PropertiesChanged`. That works but the OSD consistently lagged ~2 seconds behind the actual hardware change. Diagnosing it with three parallel detectors:

```
+11.710s [POLLPRI ] sysfs=performance     ← kernel/firmware updated /sys
+11.712s [INOTIFY ] event=changed
+13.713s [INOTIFY ] event=changes-done-hint
+13.730s [DBUS    ] ActiveProfile=performance
```

`power-profiles-daemon` uses GLib's `GFileMonitor` on `/sys/firmware/acpi/platform_profile`, and GLib coalesces `changed` events with a fixed ~2s window before firing `changes-done-hint`. The daemon only emits the DBus signal at the *end* of that window. Watching the sysfs file directly with `POLLPRI` reacts to the kernel's notification immediately.

## Files

- `bin/omarchy-powerprofiles-osd-watch` — Python stdlib watcher (`select.poll()` + `POLLPRI` on the sysfs node).
- `config/systemd/user/omarchy-powerprofiles-osd.service` — `Type=simple`, ordered after `swayosd-server.service`.
- `install/first-run/powerprofiles-osd.sh` — enables the service on new installs.
- `migrations/1778646038.sh` — installs the unit file and enables the service for existing users.

## Notes

- Works on any laptop that exposes `/sys/firmware/acpi/platform_profile`. If the node is absent the watcher exits cleanly and the service goes inactive — no impact on unsupported hardware.
- Tested on a Lenovo ThinkPad Z13 G2 (AMD, `amd_pstate`); the visible OSD latency went from ~2 s to effectively instant on mode-key press.
- Icons used are the standard freedesktop `power-profile-*-symbolic` names that current icon themes already ship.

## Test plan

- [ ] Fresh install: `install/first-run/powerprofiles-osd.sh` enables the service, mode key shows the OSD.
- [ ] Existing user runs `omarchy update`: migration `1778646038.sh` enables the service.
- [ ] CLI `powerprofilesctl set performance|balanced|power-saver` also produces an OSD.
- [ ] On a machine without `/sys/firmware/acpi/platform_profile`, the service exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)