### PR TITLE
Pin omarchy-reinstall-git to master branch

### DIFF
--- a/bin/omarchy-reinstall-git
+++ b/bin/omarchy-reinstall-git
@@ -6,6 +6,6 @@ set -e
 
 # Reinstall the Omarchy configuration directory from the git source.
 
-git clone --depth=1 "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new >/dev/null
+git clone --depth=1 --branch master "https://github.com/basecamp/omarchy.git" ~/.local/share/omarchy-new >/dev/null
 mv $OMARCHY_PATH ~/.local/share/omarchy-old
 mv ~/.local/share/omarchy-new $OMARCHY_PATH


### PR DESCRIPTION
GitHub's default branch on `basecamp/omarchy` is no longer `master`, so `omarchy-reinstall-git` was cloning the development branch and reinstalling unstable code onto users' machines.

Pass `--branch master` to `git clone` so reinstalls always land on stable regardless of what the repo's default branch is set to.

`boot.sh` already pins via `OMARCHY_REF` (defaults to `master`), so it isn't affected by the same bug.