### PR TITLE
update clipboard.conf to fix universal copy/paste/cut

### DIFF
--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -1,5 +1,5 @@
 # Copy / Paste
-bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
-bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
-bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
+bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert, activewindow
+bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert, activewindow
+bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X, activewindow
 bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard


### PR DESCRIPTION
after updating to 3.8.1 universal copy and paste isn't working, 
this fixes it