### PR TITLE
Allow manual weather location configuration

### DIFF
--- a/bin/omarchy-weather-icon
+++ b/bin/omarchy-weather-icon
@@ -2,7 +2,9 @@
 
 # omarchy:summary=Returns a weather condition icon, adjusted for live sunrise and sunset.
 
-weather_data=$(curl -fsS --max-time 3 "https://wttr.in?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
+location=$(cat ~/.config/omarchy/weather-location 2>/dev/null | tr -d '\n')
+url_location=${location:-+}
+weather_data=$(curl -fsS --max-time 3 "https://wttr.in${url_location:+/$url_location}?format=j1" 2>/dev/null | jq -er '[.current_condition[0].weatherCode, .weather[0].astronomy[0].sunrise, .weather[0].astronomy[0].sunset] | select(all(. != null and . != "")) | @tsv' 2>/dev/null) || exit 1
 
 IFS=$'\t' read -r weather_code sunrise sunset <<< "$weather_data"
 if [[ ! $weather_code =~ ^[0-9]+$ || ! $sunrise =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ || ! $sunset =~ ^[0-9]{1,2}:[0-9]{2}\ [AP]M$ ]]; then

--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -2,7 +2,9 @@
 
 # omarchy:summary=Returns a formatted weather status string with temperature and wind speed.
 
-weather=$(curl -fsS --max-time 4 "https://wttr.in?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
+location=$(cat ~/.config/omarchy/weather-location 2>/dev/null | tr -d '\n')
+url_location=${location:-+}
+weather=$(curl -fsS --max-time 4 "https://wttr.in${url_location:+/$url_location}?format=%l|%t|%w" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"


### PR DESCRIPTION
## Summary
- Add support for setting a manual weather location via `~/.config/omarchy/weather-location`
- Useful when using a VPN or in environments where auto-detection returns incorrect location

## Usage
To set a manual location:

```bash
echo "CityName" > ~/.config/omarchy/weather-location
```

Leave the file empty to revert to auto-detection.