### PR TITLE
Browse wallhaven and generate themes via aether from the theme switcher

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Open a generic image selector menu
-# omarchy:args=[--selected <image>] [--colors-file <path>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--cache-only] <image-dir>...
+# omarchy:args=[--selected <image>] [--colors-file <path>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--cache-only] [--action-key <key>] [--action-label <label>] [--action-command <shell>] <image-dir>...
 
 OMARCHY_PATH=${OMARCHY_PATH:-$HOME/.local/share/omarchy}
 
@@ -13,10 +13,13 @@ filterable=false
 lazy_thumbnails=false
 prepare_only=false
 cache_only=false
+action_key=""
+action_label=""
+action_command=""
 image_dirs=()
 
 usage() {
-  echo "Usage: omarchy-menu-images [--selected <image>] [--colors-file <path>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--cache-only] <image-dir>..."
+  echo "Usage: omarchy-menu-images [--selected <image>] [--colors-file <path>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--cache-only] [--action-key <key>] [--action-label <label>] [--action-command <shell>] <image-dir>..."
 }
 
 while [[ $# -gt 0 ]]; do
@@ -62,6 +65,33 @@ while [[ $# -gt 0 ]]; do
     --cache-only)
       cache_only=true
       shift
+      ;;
+    --action-key)
+      if (( $# < 2 )); then
+        usage >&2
+        exit 1
+      fi
+
+      action_key="$2"
+      shift 2
+      ;;
+    --action-label)
+      if (( $# < 2 )); then
+        usage >&2
+        exit 1
+      fi
+
+      action_label="$2"
+      shift 2
+      ;;
+    --action-command)
+      if (( $# < 2 )); then
+        usage >&2
+        exit 1
+      fi
+
+      action_command="$2"
+      shift 2
       ;;
     --help|-h)
       usage
@@ -251,8 +281,11 @@ ensure_selector() {
   [[ -S $socket_path ]]
 }
 
+action_command_payload=${action_command//$'\t'/$'\f'}
+action_command_payload=${action_command_payload//$'\n'/$'\v'}
+
 send_request() {
-  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$rows_payload" "$selected_list_image" "$selection_file" "$done_file" "$colors_payload" "$show_labels" "$filterable" |
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$rows_payload" "$selected_list_image" "$selection_file" "$done_file" "$colors_payload" "$show_labels" "$filterable" "$action_key" "$action_label" "$action_command_payload" |
     socat -u - "UNIX-CONNECT:$socket_path"
 }
 

--- a/bin/omarchy-theme-from-wallhaven
+++ b/bin/omarchy-theme-from-wallhaven
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# omarchy:summary=Append wallhaven results to the running image carousel
+# omarchy:examples=omarchy theme from wallhaven|omarchy-theme-from-wallhaven
+#
+# This script is normally invoked as the action_command of an already-open
+# image-selector carousel (e.g. omarchy-theme-switcher with the wallhaven +
+# tile). It fetches popular wallhaven thumbs and sends an op=append socket
+# message so the new entries splice in after the existing rows. The selector
+# itself stays open; the caller (omarchy-theme-switcher) handles the URL the
+# user eventually picks.
+
+set -u
+
+for bin in curl jq socat quickshell; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "omarchy-theme-from-wallhaven: $bin is required" >&2
+    exit 1
+  fi
+done
+
+pages_to_fetch="${OMARCHY_WALLHAVEN_PAGES:-6}"
+sorting="${OMARCHY_WALLHAVEN_SORTING:-toplist}"
+# Time window for toplist sorting: 1d, 3d, 1w, 1M, 3M, 6M, 1y.
+top_range="${OMARCHY_WALLHAVEN_TOPRANGE:-1M}"
+purity="${OMARCHY_WALLHAVEN_PURITY:-100}"
+# Wallhaven category bitmask: <General><Anime><People>. 100 = General only,
+# 111 = all three. Drop anime/people by default since those rarely make great
+# desktop wallpapers for theme extraction.
+categories="${OMARCHY_WALLHAVEN_CATEGORIES:-100}"
+
+socket_path="${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy-image-selector.sock"
+# Persists the next wallhaven page number across script invocations within
+# one carousel session. omarchy-theme-switcher deletes this at session start
+# so each new switcher run begins at page 1.
+page_state="${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy-wallhaven-page"
+
+state_dir=$(mktemp -d -t omarchy-wallhaven.XXXXXX)
+trap 'rm -rf "$state_dir"' EXIT
+
+fetch_pages_json() {
+  local start_page="$1"
+  local pages_dir="$state_dir/pages"
+  mkdir -p "$pages_dir"
+
+  local pids=() p end=$((start_page + pages_to_fetch - 1))
+  for ((p = start_page; p <= end; p++)); do
+    curl -sS --max-time 15 \
+      "https://wallhaven.cc/api/v1/search?sorting=$sorting&topRange=$top_range&purity=$purity&categories=$categories&page=$p" \
+      >"$pages_dir/$p.json" 2>/dev/null &
+    pids+=("$!")
+  done
+
+  local ok=0 pid
+  for pid in "${pids[@]}"; do
+    wait "$pid" && ((ok++))
+  done
+
+  (( ok > 0 ))
+}
+
+# Build TSV rows: <wallpaper-url>\t<thumb-url>\t<color1,color2,...>
+# The full image URL is filePath so picking a row writes the URL into the
+# selection file directly. The 3rd column is wallhaven's pre-computed 5-color
+# palette which the carousel renders as swatches under each card.
+build_rows() {
+  local pages_dir="$state_dir/pages"
+  shopt -s nullglob
+  local files=("$pages_dir"/*.json)
+  shopt -u nullglob
+  (( ${#files[@]} == 0 )) && return
+
+  jq -r '
+    .data[]?
+    | select(.thumbs.large != null and .path != null)
+    | .path + "\t" + .thumbs.large + "\t" + ((.colors // []) | join(","))
+  ' "${files[@]}" 2>/dev/null
+}
+
+# Encode rows for the socket protocol: tabs -> \f, newlines -> \v.
+encode_payload() {
+  local s="$1"
+  s=${s//$'\t'/$'\f'}
+  printf '%s' "${s//$'\n'/$'\v'}"
+}
+
+send_append() {
+  local rows="$1"
+  local rows_payload
+  rows_payload=$(encode_payload "$rows")
+
+  # Socket fields, with field 11 = op = "append" so the QML splices rather
+  # than reopens. The other fields are unused for append but must be present
+  # so the tab-split alignment stays sane.
+  printf '%s\t\t\t\t\t\t\t\t\t\t\tappend\n' "$rows_payload" |
+    socat -u - "UNIX-CONNECT:$socket_path"
+}
+
+if [[ ! -S $socket_path ]]; then
+  # The caller is supposed to have opened the carousel first. If the socket
+  # is missing there is no carousel to append to - bail rather than starting
+  # a new one (the user expects this to append, not replace).
+  exit 1
+fi
+
+# Reserve the next page range atomically. Two racing invocations from a
+# single QML carousel are already prevented by the actionProc.running guard,
+# but holding flock means a second omarchy-theme-switcher session can't
+# clobber the cursor either.
+{
+  flock -x 9
+  start_page=1
+  if [[ -f $page_state ]]; then
+    read -r p <"$page_state" 2>/dev/null || true
+    [[ $p =~ ^[0-9]+$ ]] && start_page=$p
+  fi
+  printf '%d\n' "$((start_page + pages_to_fetch))" >"$page_state"
+} 9>"$page_state.lock"
+
+if ! fetch_pages_json "$start_page"; then
+  exit 1
+fi
+
+rows=$(build_rows)
+if [[ -z $rows ]]; then
+  exit 1
+fi
+
+send_append "$rows"

--- a/bin/omarchy-theme-switcher
+++ b/bin/omarchy-theme-switcher
@@ -89,10 +89,47 @@ for extension in png jpg jpeg webp gif bmp; do
     break
   fi
 done
-exec omarchy-menu-images \
-  --print-name \
+# Reset the wallhaven pagination cursor so each switcher session starts at
+# page 1 of the toplist instead of resuming from a stale high-water mark.
+rm -f "${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy-wallhaven-page"
+
+# Capture the carousel result (full file path or URL). Without --print-name
+# we get the raw value, which is what lets us tell wallhaven URLs apart from
+# local theme previews and dispatch each to the right handler.
+selection=$(omarchy-menu-images \
   --show-labels \
   --filterable \
   --lazy-thumbnails \
   --selected "$selected_preview" \
-  "$preview_dir"
+  --action-label "wallhaven" \
+  --action-command "omarchy-theme-from-wallhaven" \
+  "$preview_dir")
+
+if [[ -z $selection ]]; then
+  exit 0
+fi
+
+if [[ $selection == http://* || $selection == https://* ]]; then
+  # Wallhaven (or any other URL) flow: download into aether's wallpaper dir
+  # so it shows up in --list-wallpapers, then let aether build the palette
+  # and apply the theme. Caller (omarchy-menu) gets nothing on stdout.
+  download_dir="$HOME/.local/share/aether/wallpapers"
+  mkdir -p "$download_dir"
+  filename=$(basename "$selection")
+  local_path="$download_dir/$filename"
+
+  if [[ ! -f $local_path ]]; then
+    if ! curl -fsSL --max-time 60 -o "$local_path" "$selection"; then
+      rm -f "$local_path"
+      exit 1
+    fi
+  fi
+
+  aether --generate "$local_path"
+  exit $?
+fi
+
+# Local theme preview: strip dir + extension and print the bare theme name so
+# omarchy-menu can pipe it to omarchy-theme-set.
+name=${selection##*/}
+printf '%s\n' "${name%.*}"

--- a/default/quickshell/select-by-image.qml
+++ b/default/quickshell/select-by-image.qml
@@ -23,6 +23,11 @@ ShellRoot {
   property int applySerial: 0
   property string doneFile: ""
   property string filterText: ""
+  property string actionKey: ""
+  property string actionLabel: ""
+  property string actionCommand: ""
+  readonly property int defaultNearbyWindow: 16
+  property int nearbyWindow: defaultNearbyWindow
   property var doneFilesToRelease: []
   property string socketPath: (Quickshell.env("XDG_RUNTIME_DIR") || ("/run/user/" + Quickshell.env("UID"))) + "/omarchy-image-selector.sock"
   property color accent: "#798186"
@@ -34,9 +39,31 @@ ShellRoot {
   property int sliceHeight: 432
   property int sliceSpacing: -30
   property int skewOffset: 28
-  property int bottomChromeHeight: showLabels ? (filterable ? 104 : 74) : (filterable ? 60 : 30)
+  // hasAction renders the "+" tile and accepts clicks. hasActionKey is the
+  // stricter form that also fires on keypress, so callers can opt in to
+  // click-only or click+key. The action tile is a synthetic slot at
+  // index === imageArray.length when hasAction is true.
+  property bool hasAction: actionCommand !== ""
+  property bool hasActionKey: hasAction && actionKey !== ""
+  // When the selected card is within autoLoadThreshold of imageArray.length
+  // the action command auto-fires to fetch the next batch. ~24 = one page
+  // of wallhaven results so the fetch starts about a page before the user
+  // would actually run out, hiding the network roundtrip. Only kicks in
+  // after the first manual action click (the "+" tile), so the bare theme
+  // list never auto-grows.
+  property int autoLoadThreshold: 24
+  property bool autoLoadActive: false
+  readonly property int totalCount: imageArray.length + (hasAction ? 1 : 0)
+  property int bottomChromeHeight: (showLabels ? (filterable ? 104 : 74) : (filterable ? 60 : 30)) + (hasActionKey ? 22 : 0)
 
   function fileUrl(path) {
+    if (!path) return ""
+    // Pass remote URLs through unchanged so Qt can stream them via QNetwork.
+    // This lets the wallhaven flow drop the local-cache step entirely and
+    // load thumbs straight from wallhaven's CDN as cards enter the nearby
+    // window.
+    if (path.indexOf("http://") === 0 || path.indexOf("https://") === 0)
+      return path
     return "file://" + path.split("/").map(encodeURIComponent).join("/")
   }
 
@@ -52,8 +79,13 @@ ShellRoot {
     return Qt.rgba(color.r, color.g, color.b, alpha)
   }
 
+  function isActionIndex(index) {
+    return hasAction && index === imageArray.length
+  }
+
   function currentPath() {
-    if (imageArray.length === 0 || !itemMatches(selectedIndex)) return ""
+    if (totalCount === 0 || !itemMatches(selectedIndex)) return ""
+    if (isActionIndex(selectedIndex)) return ""
     return imageArray[selectedIndex].filePath
   }
 
@@ -73,7 +105,8 @@ ShellRoot {
   }
 
   function itemMatches(index) {
-    if (index < 0 || index >= imageArray.length) return false
+    if (index < 0 || index >= totalCount) return false
+    if (isActionIndex(index)) return true
     if (!filterText) return true
 
     var path = imageArray[index].filePath
@@ -82,10 +115,10 @@ ShellRoot {
   }
 
   function matchingCount() {
-    if (!filterText) return imageArray.length
+    if (!filterText) return totalCount
 
     var count = 0
-    for (var i = 0; i < imageArray.length; i++) {
+    for (var i = 0; i < totalCount; i++) {
       if (itemMatches(i)) count++
     }
 
@@ -93,7 +126,7 @@ ShellRoot {
   }
 
   function firstMatchingIndex() {
-    for (var i = 0; i < imageArray.length; i++) {
+    for (var i = 0; i < totalCount; i++) {
       if (itemMatches(i)) return i
     }
 
@@ -118,17 +151,18 @@ ShellRoot {
   }
 
   function select(index, immediate) {
-    if (imageArray.length === 0) return
+    if (totalCount === 0) return
     if (index < 0) index = 0
-    else if (index >= imageArray.length) index = imageArray.length - 1
+    else if (index >= totalCount) index = totalCount - 1
     if (!itemMatches(index)) return
     if (index === selectedIndex && immediate !== true) return
 
     selectedIndex = index
+    maybeAutoFetch()
   }
 
   function selectAdjacent(direction) {
-    var count = imageArray.length
+    var count = totalCount
     if (count === 0) return
 
     var index = selectedIndex
@@ -165,6 +199,11 @@ ShellRoot {
   }
 
   function applySelected() {
+    if (isActionIndex(selectedIndex)) {
+      triggerAction()
+      return
+    }
+
     var path = currentPath()
     if (!path || !selectionFile) {
       cancel()
@@ -208,9 +247,8 @@ ShellRoot {
     root.opened = false
   }
 
-  function loadRows(rows) {
+  function parseRows(rows, seen) {
     var newImages = []
-    var seen = {}
     var paths = rows.split("\n")
     for (var i = 0; i < paths.length; i++) {
       var row = paths[i]
@@ -219,24 +257,47 @@ ShellRoot {
       var columns = row.split("\t")
       var path = columns[0]
       if (!path) continue
+      if (seen[path]) continue
+      seen[path] = true
       var fileName = path.split("/").pop()
-      if (seen[fileName]) continue
-      seen[fileName] = true
+      var palette = columns[2] ? columns[2].split(",").filter(function(c) { return c }) : []
       newImages.push({
         filePath: path,
         fileName: fileName,
-        thumbnailPath: columns[1] || path
+        thumbnailPath: columns[1] || path,
+        palette: palette
       })
     }
+    return newImages
+  }
 
-    root.imageArray = newImages
+  function loadRows(rows) {
+    var seen = {}
+    root.imageArray = parseRows(rows, seen)
     root.select(root.selectedImageIndex(), true)
     root.imagesLoaded = true
     root.opened = true
     carousel.forceActiveFocus()
   }
 
-  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextColorsFile, nextColorsRaw, nextShowLabels, nextFilterable) {
+  // Append rows to the running carousel. Dedups by filePath so re-firing the
+  // action does not pile up duplicate entries. Used by the wallhaven flow to
+  // splice its results in after the theme thumbnails without closing.
+  function appendRows(rows) {
+    var seen = {}
+    for (var i = 0; i < imageArray.length; i++) {
+      seen[imageArray[i].filePath] = true
+    }
+    var added = parseRows(rows, seen)
+    if (added.length === 0) return
+    root.imageArray = imageArray.concat(added)
+    carousel.forceActiveFocus()
+    // The user may have scrolled past the threshold while the fetch was in
+    // flight; re-evaluate so the next batch starts immediately if needed.
+    maybeAutoFetch()
+  }
+
+  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextColorsFile, nextColorsRaw, nextShowLabels, nextFilterable, nextActionKey, nextActionLabel, nextActionCommand, nextNearbyWindow) {
     if (requestActive && doneFile && doneFile !== nextDoneFile)
       finishDoneFile(doneFile)
 
@@ -251,6 +312,12 @@ ShellRoot {
     showLabels = nextShowLabels === true || nextShowLabels === "true"
     filterable = nextFilterable === true || nextFilterable === "true"
     filterText = ""
+    actionKey = nextActionKey || ""
+    actionLabel = nextActionLabel || ""
+    actionCommand = nextActionCommand || ""
+    autoLoadActive = false
+    var parsedNearby = parseInt(nextNearbyWindow)
+    nearbyWindow = (parsedNearby > 0) ? parsedNearby : defaultNearbyWindow
     colorsFile = nextColorsFile || (Quickshell.env("HOME") + "/.config/omarchy/current/theme/quickshell.json")
     if (nextColorsRaw)
       loadColors(nextColorsRaw)
@@ -263,6 +330,26 @@ ShellRoot {
     } else {
       loadImagesProc.output = ""
       loadImagesProc.running = true
+    }
+  }
+
+  // Fires the configured action command and keeps the carousel open. The
+  // command is expected to send an op=append socket message that splices new
+  // rows into the running carousel. Debounced via actionProc.running so
+  // navigating near the end doesn't spam concurrent fetches.
+  function triggerAction() {
+    if (!hasAction || actionProc.running) return
+
+    autoLoadActive = true
+    actionProc.command = ["bash", "-lc", actionCommand]
+    actionProc.running = true
+  }
+
+  function maybeAutoFetch() {
+    if (!autoLoadActive || actionProc.running) return
+    if (imageArray.length === 0) return
+    if (selectedIndex >= imageArray.length - autoLoadThreshold) {
+      triggerAction()
     }
   }
 
@@ -293,14 +380,14 @@ ShellRoot {
 
   Component.onCompleted: {
     if (selectionFile)
-      openSelector(imageDirs, "", selectedImage, selectionFile, Quickshell.env("OMARCHY_IMAGE_SELECTOR_DONE_FILE"), colorsFile, "", false, false)
+      openSelector(imageDirs, "", selectedImage, selectionFile, Quickshell.env("OMARCHY_IMAGE_SELECTOR_DONE_FILE"), colorsFile, "", false, false, "", "", "", "")
   }
 
   IpcHandler {
     target: "image-selector"
 
     function open(imageDirs: string, imageRows: string, selectedImage: string, selectionFile: string, doneFile: string, colorsFile: string): void {
-      root.openSelector(imageDirs, imageRows, selectedImage, selectionFile, doneFile, colorsFile, "", false, false)
+      root.openSelector(imageDirs, imageRows, selectedImage, selectionFile, doneFile, colorsFile, "", false, false, "", "", "", "")
     }
   }
 
@@ -313,13 +400,21 @@ ShellRoot {
       parser: SplitParser {
         onRead: function(message) {
           var fields = message.split("\t")
+          var op = fields[11] || "open"
+
+          if (op === "append" && root.opened) {
+            root.appendRows(root.decodeField(fields[0]))
+            clientSocket.connected = false
+            return
+          }
+
           if (root.opened) {
             root.closeSelector(fields[3] || "")
             clientSocket.connected = false
             return
           }
 
-          root.openSelector("", root.decodeField(fields[0]), fields[1] || "", fields[2] || "", fields[3] || "", "", root.decodeField(fields[4]), fields[5] || "false", fields[6] || "false")
+          root.openSelector("", root.decodeField(fields[0]), fields[1] || "", fields[2] || "", fields[3] || "", "", root.decodeField(fields[4]), fields[5] || "false", fields[6] || "false", fields[7] || "", fields[8] || "", root.decodeField(fields[9]), fields[10] || "")
           clientSocket.connected = false
         }
       }
@@ -353,6 +448,16 @@ ShellRoot {
   Process {
     id: releaseProc
     onExited: root.releaseNextDoneFile()
+  }
+
+  Process {
+    id: actionProc
+    // Disarm auto-fetch on a failed action so we don't spin re-firing
+    // a broken command every arrow press. The user can still re-arm by
+    // clicking the "+" tile manually.
+    onExited: (code) => {
+      if (code !== 0) root.autoLoadActive = false
+    }
   }
 
   PanelWindow {
@@ -419,6 +524,12 @@ ShellRoot {
           } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab) {
             root.selectAdjacent(1)
             event.accepted = true
+          } else if (root.hasActionKey && event.text && event.text.toLowerCase() === root.actionKey.toLowerCase() && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
+            // Action key takes precedence over filter typing so the bound key
+            // can't be "captured" by an active filter session. Pressing it
+            // closes the selector and runs actionCommand in the background.
+            root.triggerAction()
+            event.accepted = true
           } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
             root.updateFilter(root.filterText + event.text)
             event.accepted = true
@@ -428,21 +539,24 @@ ShellRoot {
         Component.onCompleted: forceActiveFocus()
 
         Repeater {
-          model: root.imageArray.length
+          model: root.totalCount
 
           delegate: Item {
             id: item
             required property int index
 
-            readonly property var imageData: root.imageArray[index]
+            readonly property bool isAction: root.isActionIndex(index)
+            readonly property var imageData: isAction ? null : root.imageArray[index]
             readonly property string filePath: imageData ? imageData.filePath : ""
             readonly property string fileName: imageData ? imageData.fileName : ""
             readonly property string thumbnailPath: imageData ? imageData.thumbnailPath : ""
+            readonly property var palette: imageData && imageData.palette ? imageData.palette : []
+            readonly property real swatchAreaWidth: selected ? width - 24 : width
 
             readonly property bool matched: root.itemMatches(index)
             readonly property int relativeIndex: root.filteredPosition(index) - root.selectedFilteredPosition()
             readonly property bool selected: matched && index === root.selectedIndex
-            readonly property bool nearby: matched && Math.abs(relativeIndex) <= 16
+            readonly property bool nearby: matched && Math.abs(relativeIndex) <= root.nearbyWindow
 
             visible: nearby
             x: selected ? carousel.previewX : (relativeIndex < 0 ? carousel.previewX + relativeIndex * carousel.itemStep : carousel.previewX + root.expandedWidth + root.sliceSpacing + (relativeIndex - 1) * carousel.itemStep)
@@ -500,9 +614,89 @@ ShellRoot {
                 smooth: true
               }
 
+              // High-quality overlay. Loads for the 3 cards on either side of
+              // the active one so the full wallpaper is already decoded by
+              // the time the user lands on it. Visibility is gated to the
+              // active card only - the preloaded neighbours sit in Qt's
+              // pixmap cache invisible until they're scrolled to.
+              //
+              // For local-file callers filePath == thumbnailPath so source
+              // stays empty and this overlay never activates.
+              Image {
+                id: imageFull
+                anchors.fill: parent
+                source: (item.nearby && Math.abs(item.relativeIndex) <= 3
+                         && item.filePath && item.filePath !== item.thumbnailPath)
+                  ? root.fileUrl(item.filePath) : ""
+                fillMode: Image.PreserveAspectCrop
+                asynchronous: true
+                cache: true
+                smooth: true
+                // Cap decoded size so a 5120x1440 wallpaper doesn't pin
+                // 30MB of pixmap memory per visited card.
+                sourceSize.width: 1600
+                // Show the full overlay on every preloaded neighbour, not
+                // just the active card, so scrolling does not visibly swap
+                // thumb -> full when each new card becomes active.
+                opacity: status === Image.Ready ? 1 : 0
+                Behavior on opacity { NumberAnimation { duration: 220 } }
+              }
+
               Rectangle {
                 anchors.fill: parent
                 color: root.withAlpha(root.background, item.selected ? 0 : 0.42)
+              }
+
+              // Wallhaven palette strip. Taller on the active card, slim on
+              // neighbours. Model is empty for off-nearby cards so the
+              // Repeater doesn't instantiate Rectangles for cards the user
+              // can't see.
+              Row {
+                visible: item.palette.length > 0 && !item.isAction
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottomMargin: item.selected ? 8 : 0
+                anchors.leftMargin: item.selected ? 12 : 0
+                anchors.rightMargin: item.selected ? 12 : 0
+                height: item.selected ? 22 : 6
+                spacing: 0
+
+                Repeater {
+                  model: item.nearby ? item.palette : []
+                  delegate: Rectangle {
+                    required property string modelData
+                    width: item.swatchAreaWidth / item.palette.length
+                    height: parent.height
+                    color: modelData
+                  }
+                }
+              }
+
+              Rectangle {
+                anchors.fill: parent
+                visible: item.isAction
+                color: root.withAlpha(root.background, item.selected ? 0.55 : 0.78)
+
+                Text {
+                  anchors.centerIn: parent
+                  text: "+"
+                  color: item.selected ? root.accent : root.foreground
+                  font.pixelSize: item.selected ? 200 : 80
+                  font.weight: Font.Light
+                  Behavior on font.pixelSize { NumberAnimation { duration: 160 } }
+                }
+
+                Text {
+                  visible: item.selected && root.actionLabel
+                  anchors.horizontalCenter: parent.horizontalCenter
+                  anchors.bottom: parent.bottom
+                  anchors.bottomMargin: 32
+                  text: root.actionLabel
+                  color: root.withAlpha(root.foreground, 0.75)
+                  font.pixelSize: 16
+                  font.family: "monospace"
+                }
               }
             }
 
@@ -549,6 +743,7 @@ ShellRoot {
       }
 
       Text {
+        id: filterDisplay
         visible: root.filterable && root.filterText
         anchors.top: selectedLabel.bottom
         anchors.topMargin: 8
@@ -560,6 +755,22 @@ ShellRoot {
         style: Text.Outline
         styleColor: root.withAlpha(root.background, 0.7)
         font.pixelSize: 14
+        horizontalAlignment: Text.AlignHCenter
+        elide: Text.ElideRight
+      }
+
+      Text {
+        visible: root.hasActionKey
+        anchors.top: filterDisplay.visible ? filterDisplay.bottom : (selectedLabel.visible ? selectedLabel.bottom : carousel.bottom)
+        anchors.topMargin: 8
+        anchors.horizontalCenter: carousel.horizontalCenter
+        width: root.expandedWidth
+        text: "press " + root.actionKey + " " + (root.actionLabel || "for action")
+        color: root.foreground
+        opacity: 0.6
+        style: Text.Outline
+        styleColor: root.withAlpha(root.background, 0.7)
+        font.pixelSize: 12
         horizontalAlignment: Text.AlignHCenter
         elide: Text.ElideRight
       }

--- a/default/quickshell/select-by-image.qml
+++ b/default/quickshell/select-by-image.qml
@@ -297,30 +297,36 @@ ShellRoot {
     maybeAutoFetch()
   }
 
-  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextColorsFile, nextColorsRaw, nextShowLabels, nextFilterable, nextActionKey, nextActionLabel, nextActionCommand, nextNearbyWindow) {
+  // Open the carousel with the given options. opts is a plain JS object so
+  // call sites name what they pass instead of aligning a long positional
+  // list; everything is optional and falls back to sensible defaults.
+  function openSelector(opts) {
+    var o = opts || {}
+    var nextDoneFile = o.doneFile || ""
+
     if (requestActive && doneFile && doneFile !== nextDoneFile)
       finishDoneFile(doneFile)
 
     requestSerial += 1
 
-    imageDirs = nextImageDirs
-    imageRows = nextImageRows
-    selectedImage = nextSelectedImage
-    selectionFile = nextSelectionFile
+    imageDirs = o.imageDirs || ""
+    imageRows = o.imageRows || ""
+    selectedImage = o.selectedImage || ""
+    selectionFile = o.selectionFile || ""
     doneFile = nextDoneFile
     requestActive = !!doneFile
-    showLabels = nextShowLabels === true || nextShowLabels === "true"
-    filterable = nextFilterable === true || nextFilterable === "true"
+    showLabels = o.showLabels === true || o.showLabels === "true"
+    filterable = o.filterable === true || o.filterable === "true"
     filterText = ""
-    actionKey = nextActionKey || ""
-    actionLabel = nextActionLabel || ""
-    actionCommand = nextActionCommand || ""
+    actionKey = o.actionKey || ""
+    actionLabel = o.actionLabel || ""
+    actionCommand = o.actionCommand || ""
     autoLoadActive = false
-    var parsedNearby = parseInt(nextNearbyWindow)
+    var parsedNearby = parseInt(o.nearbyWindow)
     nearbyWindow = (parsedNearby > 0) ? parsedNearby : defaultNearbyWindow
-    colorsFile = nextColorsFile || (Quickshell.env("HOME") + "/.config/omarchy/current/theme/quickshell.json")
-    if (nextColorsRaw)
-      loadColors(nextColorsRaw)
+    colorsFile = o.colorsFile || (Quickshell.env("HOME") + "/.config/omarchy/current/theme/quickshell.json")
+    if (o.colorsRaw)
+      loadColors(o.colorsRaw)
     imageArray = []
     selectedIndex = 0
     imagesLoaded = false
@@ -337,11 +343,18 @@ ShellRoot {
   // command is expected to send an op=append socket message that splices new
   // rows into the running carousel. Debounced via actionProc.running so
   // navigating near the end doesn't spam concurrent fetches.
+  //
+  // actionCommand is split on whitespace and exec'd directly (no shell), so
+  // the IPC payload can't smuggle shell metacharacters through the bash -c
+  // surface that a previous version used.
   function triggerAction() {
     if (!hasAction || actionProc.running) return
 
+    var argv = actionCommand.split(/\s+/).filter(function(s) { return s.length > 0 })
+    if (argv.length === 0) return
+
     autoLoadActive = true
-    actionProc.command = ["bash", "-lc", actionCommand]
+    actionProc.command = argv
     actionProc.running = true
   }
 
@@ -380,14 +393,27 @@ ShellRoot {
 
   Component.onCompleted: {
     if (selectionFile)
-      openSelector(imageDirs, "", selectedImage, selectionFile, Quickshell.env("OMARCHY_IMAGE_SELECTOR_DONE_FILE"), colorsFile, "", false, false, "", "", "", "")
+      openSelector({
+        imageDirs: imageDirs,
+        selectedImage: selectedImage,
+        selectionFile: selectionFile,
+        doneFile: Quickshell.env("OMARCHY_IMAGE_SELECTOR_DONE_FILE"),
+        colorsFile: colorsFile
+      })
   }
 
   IpcHandler {
     target: "image-selector"
 
     function open(imageDirs: string, imageRows: string, selectedImage: string, selectionFile: string, doneFile: string, colorsFile: string): void {
-      root.openSelector(imageDirs, imageRows, selectedImage, selectionFile, doneFile, colorsFile, "", false, false, "", "", "", "")
+      root.openSelector({
+        imageDirs: imageDirs,
+        imageRows: imageRows,
+        selectedImage: selectedImage,
+        selectionFile: selectionFile,
+        doneFile: doneFile,
+        colorsFile: colorsFile
+      })
     }
   }
 
@@ -414,7 +440,19 @@ ShellRoot {
             return
           }
 
-          root.openSelector("", root.decodeField(fields[0]), fields[1] || "", fields[2] || "", fields[3] || "", "", root.decodeField(fields[4]), fields[5] || "false", fields[6] || "false", fields[7] || "", fields[8] || "", root.decodeField(fields[9]), fields[10] || "")
+          root.openSelector({
+            imageRows: root.decodeField(fields[0]),
+            selectedImage: fields[1] || "",
+            selectionFile: fields[2] || "",
+            doneFile: fields[3] || "",
+            colorsRaw: root.decodeField(fields[4]),
+            showLabels: fields[5] || "false",
+            filterable: fields[6] || "false",
+            actionKey: fields[7] || "",
+            actionLabel: fields[8] || "",
+            actionCommand: root.decodeField(fields[9]),
+            nearbyWindow: fields[10] || ""
+          })
           clientSocket.connected = false
         }
       }
@@ -526,8 +564,7 @@ ShellRoot {
             event.accepted = true
           } else if (root.hasActionKey && event.text && event.text.toLowerCase() === root.actionKey.toLowerCase() && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
             // Action key takes precedence over filter typing so the bound key
-            // can't be "captured" by an active filter session. Pressing it
-            // closes the selector and runs actionCommand in the background.
+            // can't be "captured" by an active filter session.
             root.triggerAction()
             event.accepted = true
           } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
@@ -615,10 +652,8 @@ ShellRoot {
               }
 
               // High-quality overlay. Loads for the 3 cards on either side of
-              // the active one so the full wallpaper is already decoded by
-              // the time the user lands on it. Visibility is gated to the
-              // active card only - the preloaded neighbours sit in Qt's
-              // pixmap cache invisible until they're scrolled to.
+              // the active one and stays painted on all of them so scrolling
+              // never visibly swaps thumb -> full as cards become active.
               //
               // For local-file callers filePath == thumbnailPath so source
               // stays empty and this overlay never activates.
@@ -635,9 +670,6 @@ ShellRoot {
                 // Cap decoded size so a 5120x1440 wallpaper doesn't pin
                 // 30MB of pixmap memory per visited card.
                 sourceSize.width: 1600
-                // Show the full overlay on every preloaded neighbour, not
-                // just the active card, so scrolling does not visibly swap
-                // thumb -> full when each new card becomes active.
                 opacity: status === Image.Ready ? 1 : 0
                 Behavior on opacity { NumberAnimation { duration: 220 } }
               }


### PR DESCRIPTION
The "+" tile at the end of the carousel loads wallhaven's monthly toplist inline. Scrolling near the end auto-fetches the next batch. Picking an image downloads it and runs aether --generate to build and apply the theme.

https://github.com/user-attachments/assets/ac0fef58-177c-4ea9-8877-31ab65fdec97

