### PR TITLE
Vim/TUI redesign of Omarchy Settings panel

### DIFF
--- a/default/quickshell/omarchy-shell/plugins/settings/SettingsPanel.qml
+++ b/default/quickshell/omarchy-shell/plugins/settings/SettingsPanel.qml
@@ -73,6 +73,32 @@ Item {
   // flips both surfaces together.
   property int cornerRadius: 0
 
+  // Active Omarchy theme name (read from current/theme.name) so the sidebar
+  // footer + modeline can surface it without re-parsing colors.toml.
+  property string themeName: ""
+
+  // Version label shown in the title bar.
+  property string omarchyVersion: ""
+
+  // ---------------- bar-section selection ----------------------------------
+  // Which widget row is "selected" in the Bar tab. Drives the modeline
+  // readout, the ▶ indicator, and the action keys (J/K reorder, 1-3 zone
+  // jump, dd remove). Updated whenever a WidgetRow takes activeFocus.
+  property string selectedSection: ""   // "left" | "center" | "right" | ""
+  property int selectedIndex: -1
+
+  // Vim-style editor mode. We only ship NORMAL — the property is here so
+  // the modeline label stays a single source of truth for future modes.
+  property string editorMode: "NORMAL"
+
+  // `dd` two-keystroke remove state. Pressing `d` once arms removal for a
+  // brief window; pressing `d` again within that window fires it. Any other
+  // key resets the timer. Modeled on vim's dd.
+  property bool dPending: false
+
+  // Help overlay toggle (`?` opens it).
+  property bool helpOpen: false
+
   // ---------------- navigation ---------------------------------------------
   readonly property var categoryIds: ["defaults", "style", "bar", "system", "plugins"]
   property string activeCategory: "defaults"
@@ -163,6 +189,45 @@ Item {
     if (next >= items.length) next = 0
     items[next].forceActiveFocus()
     ensureBodyItemVisible(items[next])
+  }
+
+  // Jump to the section whose header reads `[idx] ...` (BracketedFrame,
+  // SectionEditor, and RadioSelector all expose `sectionIndex`). Focuses
+  // the first focusable descendant if any; otherwise just scrolls the
+  // section into view. Returns true if a matching section was found.
+  function focusSectionByIndex(idx) {
+    if (idx <= 0) return false
+    var match = null
+    function findSection(item) {
+      if (match) return
+      if (!item || !item.visible || item.enabled === false) return
+      if (item.sectionIndex === idx) { match = item; return }
+      var ch = item.children
+      if (!ch) return
+      for (var i = 0; i < ch.length; i++) findSection(ch[i])
+    }
+    if (typeof bodyScroll !== "undefined" && bodyScroll && bodyScroll.contentItem) {
+      findSection(bodyScroll.contentItem)
+    }
+    if (!match) return false
+
+    var focusable = null
+    function findFocusable(item) {
+      if (focusable) return
+      if (!item || !item.visible || item.enabled === false) return
+      if (item.activeFocusOnTab === true) { focusable = item; return }
+      var ch = item.children
+      if (!ch) return
+      for (var i = 0; i < ch.length; i++) findFocusable(ch[i])
+    }
+    findFocusable(match)
+    if (focusable) {
+      focusable.forceActiveFocus()
+      ensureBodyItemVisible(focusable)
+    } else {
+      ensureBodyItemVisible(match)
+    }
+    return true
   }
 
   // Scroll the bodyScroll Flickable so `item` is fully on-screen, with a
@@ -364,6 +429,203 @@ Item {
     } catch (e) {
       cornerRadius = 0
     }
+  }
+
+  // ---------------- bar-section keyboard ops -------------------------------
+  // J/K reorder within the selected widget's section.
+  function moveSelectedWithin(delta) {
+    if (root.activeCategory !== "bar") return
+    if (!root.selectedSection || root.selectedIndex < 0) return
+    var arr = root.sectionArray(root.selectedSection)
+    var next = root.selectedIndex + delta
+    if (next < 0 || next >= arr.length) return
+    root.moveEntry(root.selectedSection, root.selectedIndex, next)
+    root.selectedIndex = next
+    Qt.callLater(refocusSelected)
+  }
+
+  // 1/2/3 zone-jump: move the selected widget to left/center/right.
+  // Silently refuses duplicates that can't go in two sections at once.
+  function moveSelectedToSection(targetSection) {
+    if (root.activeCategory !== "bar") return
+    if (!root.selectedSection || root.selectedIndex < 0) return
+    if (root.selectedSection === targetSection) return
+    var arr = root.sectionArray(root.selectedSection)
+    if (root.selectedIndex >= arr.length) return
+    var entry = arr[root.selectedIndex]
+    if (!entry || !entry.id) return
+
+    var allowsMultiple = root.widgetAllowsMultiple(entry.id)
+    if (!allowsMultiple) {
+      var target = root.sectionArray(targetSection)
+      for (var i = 0; i < target.length; i++) {
+        if (target[i].id === entry.id) return
+      }
+    }
+
+    var newDraft = root.cloneJson(root.draft)
+    newDraft.bar.layout[root.selectedSection].splice(root.selectedIndex, 1)
+    newDraft.bar.layout[targetSection].push(root.cloneJson(entry))
+    root.draft = newDraft
+    root.markDirty()
+
+    root.selectedSection = targetSection
+    root.selectedIndex = newDraft.bar.layout[targetSection].length - 1
+    Qt.callLater(refocusSelected)
+  }
+
+  // dd: remove the selected widget, then clear the pending flag.
+  function fireSelectedDelete() {
+    if (root.activeCategory !== "bar") return
+    if (!root.selectedSection || root.selectedIndex < 0) return
+    var arr = root.sectionArray(root.selectedSection)
+    if (root.selectedIndex >= arr.length) return
+    var wasAt = root.selectedIndex
+    root.removeEntry(root.selectedSection, root.selectedIndex)
+    var nextLen = root.sectionArray(root.selectedSection).length
+    root.selectedIndex = Math.min(wasAt, nextLen - 1)
+    Qt.callLater(refocusSelected)
+  }
+
+  // Mouse drag-and-drop: place the widget at `sourceSection[sourceIndex]` into
+  // `targetSection` at `targetIndex` (insertion index — 0 means "before first",
+  // length means "append"). Mirrors the within/cross-section rules used by
+  // J/K and 1-3 so the two input modes stay consistent.
+  function dropWidget(sourceSection, sourceIndex, targetSection, targetIndex) {
+    if (root.activeCategory !== "bar") return
+    if (!sourceSection || sourceIndex < 0 || !targetSection) return
+    var srcArr = root.sectionArray(sourceSection)
+    if (sourceIndex >= srcArr.length) return
+    var entry = srcArr[sourceIndex]
+    if (!entry || !entry.id) return
+
+    if (sourceSection === targetSection) {
+      // Within-section: removing the source first shifts later indices, so a
+      // drop targeted after the source needs to be decremented.
+      var adjusted = targetIndex > sourceIndex ? targetIndex - 1 : targetIndex
+      if (adjusted < 0) adjusted = 0
+      if (adjusted > srcArr.length - 1) adjusted = srcArr.length - 1
+      if (adjusted === sourceIndex) return
+      root.moveEntry(sourceSection, sourceIndex, adjusted)
+      root.selectedSection = sourceSection
+      root.selectedIndex = adjusted
+    } else {
+      // Cross-section: refuse duplicates the widget can't tolerate.
+      if (!root.widgetAllowsMultiple(entry.id)) {
+        var tgtArr = root.sectionArray(targetSection)
+        for (var i = 0; i < tgtArr.length; i++) {
+          if (tgtArr[i].id === entry.id) return
+        }
+      }
+      var newDraft = root.cloneJson(root.draft)
+      newDraft.bar.layout[sourceSection].splice(sourceIndex, 1)
+      var insertAt = Math.max(0, Math.min(targetIndex, newDraft.bar.layout[targetSection].length))
+      newDraft.bar.layout[targetSection].splice(insertAt, 0, root.cloneJson(entry))
+      root.draft = newDraft
+      root.markDirty()
+      root.selectedSection = targetSection
+      root.selectedIndex = insertAt
+    }
+    Qt.callLater(refocusSelected)
+  }
+
+  // Re-focus the WidgetRow that matches selectedSection/Index after a draft
+  // mutation rebuilds the delegates.
+  function refocusSelected() {
+    if (root.activeCategory !== "bar") return
+    var items = gatherBodyFocusables()
+    for (var i = 0; i < items.length; i++) {
+      var it = items[i]
+      if (it && it.barRowMarker === true
+          && it.sectionKey === root.selectedSection
+          && it.entryIndex === root.selectedIndex) {
+        it.forceActiveFocus()
+        ensureBodyItemVisible(it)
+        return
+      }
+    }
+  }
+
+  // "01", "02", ... — JS String.padStart isn't available on every Qt JS
+  // engine version, so do it by hand.
+  function padTwo(n) {
+    var s = String(n)
+    return s.length >= 2 ? s : ("0" + s)
+  }
+
+  // Modeline left-side readout. Mirrors :command NORMAL · context · selection
+  // so the bar reads like a vim status line.
+  function modelineLeft() {
+    var prefix = ":" + (root.activeCategory || "settings") + " " + root.editorMode
+    if (root.dPending) prefix += "  d_"
+    var pieces = [prefix]
+    switch (root.activeCategory) {
+    case "bar":
+      if (root.selectedSection) {
+        var arr = root.sectionArray(root.selectedSection)
+        pieces.push(arr.length + " " + root.selectedSection + (arr.length === 1 ? " widget" : " widgets"))
+        if (root.selectedIndex >= 0 && root.selectedIndex < arr.length) {
+          pieces.push(root.widgetName(arr[root.selectedIndex].id) + " selected")
+        }
+      }
+      break
+    case "defaults":
+      pieces.push("3 groups")
+      break
+    case "style":
+      pieces.push("4 sections")
+      pieces.push("auto-saves on")
+      break
+    case "system":
+      pieces.push("2 sections")
+      break
+    case "plugins":
+      pieces.push((root.pluginRegistry ? Object.keys(root.pluginRegistry.installedPlugins).length : 0) + " plugins")
+      break
+    }
+    return pieces.join("  ·  ")
+  }
+
+  function modelineRight() {
+    switch (root.activeCategory) {
+    case "bar":
+      return "j/k move    J/K reorder    N jump    ⇧1-3 zone    dd remove    ? help"
+    case "defaults":
+      return "j/k move    N jump    space select    h back    ? help"
+    case "style":
+      return "j/k move    N jump    space toggle    h back    ? help"
+    case "system":
+      return "j/k move    N jump    space toggle    h back    ? help"
+    case "plugins":
+      return "j/k move    space toggle    h back    ? help"
+    }
+    return "j/k move    h back    ? help"
+  }
+
+  // FileView for theme name. Watches current/theme.name (overwritten in place
+  // on theme swap) so the sidebar footer + modeline track live.
+  FileView {
+    path: root.home + "/.config/omarchy/current/theme.name"
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.themeName = String(text() || "").replace(/\s+$/g, "")
+    onFileChanged: reload()
+  }
+
+  // Version string for the title-bar suffix.
+  FileView {
+    path: root.omarchyPath + "/version"
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.omarchyVersion = String(text() || "").replace(/\s+$/g, "")
+    onFileChanged: reload()
+  }
+
+  // Cancels a pending `dd` if the second `d` doesn't arrive quickly.
+  Timer {
+    id: deleteTimer
+    interval: 700
+    onTriggered: root.dPending = false
   }
 
   // ---------------- widget catalog -----------------------------------------
@@ -614,6 +876,25 @@ Item {
           if (ctrl && event.key === Qt.Key_L) { root.enterBodyZone(); event.accepted = true; return }
         } else {
           // body
+          var shift = (event.modifiers & Qt.ShiftModifier) !== 0
+          var inBarRow = root.activeCategory === "bar"
+            && root.selectedSection !== ""
+            && root.selectedIndex >= 0
+
+          // Any non-d key cancels a pending `dd`.
+          if (root.dPending && event.key !== Qt.Key_D) {
+            root.dPending = false
+            deleteTimer.stop()
+          }
+
+          // Help overlay swallows everything except `?` and Esc.
+          if (root.helpOpen) {
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Question) {
+              root.helpOpen = false; event.accepted = true; return
+            }
+            event.accepted = true; return
+          }
+
           switch (event.key) {
           case Qt.Key_Escape:
           case Qt.Key_H:
@@ -621,18 +902,65 @@ Item {
           case Qt.Key_Backtab:
             root.exitBodyZone(); event.accepted = true; return
           case Qt.Key_J:
+            if (shift && inBarRow) { root.moveSelectedWithin(+1); event.accepted = true; return }
+            root.focusBodyDelta(+1); event.accepted = true; return
+          case Qt.Key_K:
+            if (shift && inBarRow) { root.moveSelectedWithin(-1); event.accepted = true; return }
+            root.focusBodyDelta(-1); event.accepted = true; return
           case Qt.Key_Down:
           case Qt.Key_Tab:
             root.focusBodyDelta(+1); event.accepted = true; return
-          case Qt.Key_K:
           case Qt.Key_Up:
             root.focusBodyDelta(-1); event.accepted = true; return
+          case Qt.Key_Exclam:
+          case Qt.Key_At:
+          case Qt.Key_NumberSign: {
+            // Shift+1/2/3 on a US layout arrives as !/@/# — Qt rewrites the
+            // keycode rather than just setting ShiftModifier, so we have to
+            // match the shifted variants explicitly.
+            if (!inBarRow) { break }
+            var shiftZones = ["left", "center", "right"]
+            var sz = event.key === Qt.Key_Exclam ? 0
+                   : event.key === Qt.Key_At     ? 1 : 2
+            root.moveSelectedToSection(shiftZones[sz])
+            event.accepted = true; return
+          }
+          case Qt.Key_1:
+          case Qt.Key_2:
+          case Qt.Key_3:
+          case Qt.Key_4:
+          case Qt.Key_5:
+          case Qt.Key_6:
+          case Qt.Key_7:
+          case Qt.Key_8:
+          case Qt.Key_9: {
+            if (shift) { break }
+            var n = event.key - Qt.Key_0
+            if (root.focusSectionByIndex(n)) { event.accepted = true; return }
+            break
+          }
+          case Qt.Key_D:
+            if (inBarRow) {
+              if (root.dPending) {
+                root.fireSelectedDelete()
+                root.dPending = false
+                deleteTimer.stop()
+              } else {
+                root.dPending = true
+                deleteTimer.restart()
+              }
+              event.accepted = true; return
+            }
+            break
+          case Qt.Key_Question:
+            root.helpOpen = true; event.accepted = true; return
           }
           if (ctrl && event.key === Qt.Key_H) { root.exitBodyZone(); event.accepted = true; return }
         }
       }
 
     Rectangle {
+      id: panelContent
       anchors.fill: parent
       color: root.background
       // No explicit border — the Hyprland window decoration already draws one.
@@ -641,37 +969,55 @@ Item {
         anchors.fill: parent
         spacing: 0
 
-        // Header
+        // Header — title text sits above a hairline divider that runs the
+        // full width of the window. No notching: the title is a row in its
+        // own right, and the line below it cleanly separates the chrome
+        // from the body + sidebar.
         Item {
           Layout.fillWidth: true
-          Layout.preferredHeight: 48
+          Layout.preferredHeight: 46
 
-          Text {
-            text: "Omarchy Settings"
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: 16
-            font.bold: true
+          Row {
+            id: titleRow
             anchors.left: parent.left
-            anchors.leftMargin: 18
+            anchors.leftMargin: 24
             anchors.verticalCenter: parent.verticalCenter
+            spacing: 10
+
+            Text {
+              text: "[ Omarchy Settings ]"
+              color: root.accent
+              font.family: root.fontFamily
+              font.pixelSize: 16
+              font.bold: true
+              anchors.verticalCenter: parent.verticalCenter
+            }
+            Text {
+              visible: root.omarchyVersion !== ""
+              text: "— v" + root.omarchyVersion
+              color: Qt.darker(root.foreground, 1.5)
+              font.family: root.fontFamily
+              font.pixelSize: 13
+              anchors.verticalCenter: parent.verticalCenter
+            }
           }
 
           Text {
-            text: "~/.config/omarchy/shell.json"
-            color: Qt.darker(root.foreground, 1.8)
-            font.family: root.fontFamily
-            font.pixelSize: 10
+            id: pathLabel
             anchors.right: parent.right
-            anchors.rightMargin: 18
+            anchors.rightMargin: 24
             anchors.verticalCenter: parent.verticalCenter
+            text: "~/.config/omarchy/shell.json"
+            color: Qt.darker(root.foreground, 1.5)
+            font.family: root.fontFamily
+            font.pixelSize: 13
           }
         }
 
         Rectangle {
           Layout.fillWidth: true
           Layout.preferredHeight: 1
-          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
         }
 
         // Sidebar + content
@@ -692,16 +1038,67 @@ Item {
 
             ColumnLayout {
               anchors.fill: parent
-              anchors.margins: 8
+              anchors.margins: 14
               spacing: 2
 
-              SidebarRow { categoryId: "defaults"; label: "Defaults"; glyph: "󰀻" }
-              SidebarRow { categoryId: "style";    label: "Style";    glyph: "󰏘" }
-              SidebarRow { categoryId: "bar";      label: "Bar";      glyph: "󰛼" }
-              SidebarRow { categoryId: "system";   label: "System";   glyph: "󰒓" }
-              SidebarRow { categoryId: "plugins";  label: "Plugins";  glyph: "󰐱" }
+              SidebarRow { categoryId: "defaults"; label: "Defaults" }
+              SidebarRow { categoryId: "style";    label: "Style" }
+              SidebarRow { categoryId: "bar";      label: "Bar" }
+              SidebarRow { categoryId: "system";   label: "System" }
+              SidebarRow { categoryId: "plugins";  label: "Plugins" }
 
               Item { Layout.fillHeight: true }
+
+              // Footer: current theme + status. Mirrors the modeline style.
+              Column {
+                Layout.fillWidth: true
+                spacing: 2
+
+                Text {
+                  text: "THEME"
+                  color: Qt.darker(root.foreground, 1.8)
+                  font.family: root.fontFamily
+                  font.pixelSize: 10
+                  font.bold: true
+                }
+                Text {
+                  text: root.themeName || "—"
+                  color: root.foreground
+                  font.family: root.fontFamily
+                  font.pixelSize: 12
+                }
+              }
+
+              Item { Layout.preferredHeight: 10 }
+
+              Column {
+                Layout.fillWidth: true
+                spacing: 2
+
+                Text {
+                  text: "STATUS"
+                  color: Qt.darker(root.foreground, 1.8)
+                  font.family: root.fontFamily
+                  font.pixelSize: 10
+                  font.bold: true
+                }
+                Row {
+                  spacing: 6
+
+                  Rectangle {
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 6; height: 6; radius: 3
+                    color: root.accent
+                  }
+                  Text {
+                    text: "Quickshell · running"
+                    color: Qt.darker(root.foreground, 1.3)
+                    font.family: root.fontFamily
+                    font.pixelSize: 12
+                    anchors.verticalCenter: parent.verticalCenter
+                  }
+                }
+              }
             }
           }
 
@@ -740,56 +1137,263 @@ Item {
             }
           }
         }
+
+        // ----- modeline ------------------------------------------------------
+        // Vim-style status line. Left side: command + mode + selection context.
+        // Right side: keybinding hints for the active tab.
+        Rectangle {
+          Layout.fillWidth: true
+          Layout.preferredHeight: 1
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+        }
+
+        Item {
+          Layout.fillWidth: true
+          Layout.preferredHeight: 24
+
+          Rectangle {
+            anchors.fill: parent
+            color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+          }
+
+          Text {
+            anchors.left: parent.left
+            anchors.leftMargin: 18
+            anchors.verticalCenter: parent.verticalCenter
+            // Inline reads ensure QML tracks every dependency that the
+            // modeline label depends on, so it re-evaluates correctly.
+            text: {
+              var _ = [root.activeCategory, root.editorMode,
+                       root.selectedSection, root.selectedIndex,
+                       root.draftRevision, root.dPending,
+                       root.pluginRegistry ? root.pluginRegistry.registryRevision : 0]
+              return root.modelineLeft()
+            }
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: 11
+          }
+
+          Text {
+            anchors.right: parent.right
+            anchors.rightMargin: 18
+            anchors.verticalCenter: parent.verticalCenter
+            text: {
+              var _ = root.activeCategory
+              return root.modelineRight()
+            }
+            color: Qt.darker(root.foreground, 1.5)
+            font.family: root.fontFamily
+            font.pixelSize: 11
+          }
+        }
+      }
+
+      // ----- drag ghost ------------------------------------------------------
+      // Floating preview chip used to drag a widget row between sections.
+      // Lives at the panel-content level (rather than inside the row that
+      // started the drag) for two reasons: (1) WidgetRows are pinned by a
+      // Column layout and can't move themselves, and DropArea only fires
+      // when the *dragged item's* scene position changes; (2) a panel-level
+      // owner lets us track the cursor freely across all three sections.
+      // The chip is moved imperatively by each row's MouseArea when a drag
+      // is in flight. `sourceSection`/`sourceIndex` snapshot which row is
+      // being dragged so DropAreas can read it off `drag.source`.
+      Item {
+        id: dragGhost
+        width: 240
+        height: 26
+        // Visibility follows Drag.active so the chip disappears as soon as
+        // the drop completes — drop handlers mutate the draft, which
+        // destroys the source row's MouseArea before its onReleased can
+        // finish cleaning up imperatively.
+        visible: Drag.active
+        z: 90
+        opacity: 0.92
+
+        property string sourceSection: ""
+        property int sourceIndex: -1
+        property string sourceName: ""
+
+        Drag.source: dragGhost
+        Drag.keys: ["omarchy-bar-widget"]
+        Drag.hotSpot.x: width / 2
+        Drag.hotSpot.y: height / 2
+
+        Rectangle {
+          anchors.fill: parent
+          color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.20)
+          border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.75)
+          border.width: 1
+          radius: root.cornerRadius
+        }
+
+        Text {
+          anchors.left: parent.left
+          anchors.leftMargin: 12
+          anchors.right: parent.right
+          anchors.rightMargin: 12
+          anchors.verticalCenter: parent.verticalCenter
+          text: dragGhost.sourceName
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: 12
+          elide: Text.ElideRight
+        }
+      }
+
+      // ----- help overlay ----------------------------------------------------
+      // Pressed `?` to toggle. Lists the bar-tab keybindings. Dismiss with
+      // `?`, Esc, or click outside.
+      Rectangle {
+        anchors.fill: parent
+        visible: root.helpOpen
+        color: Qt.rgba(0, 0, 0, 0.55)
+        z: 100
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: root.helpOpen = false
+        }
+
+        Rectangle {
+          anchors.centerIn: parent
+          width: 540
+          height: helpColumn.implicitHeight + 56
+          color: root.background
+          border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.7)
+          border.width: 1
+          radius: root.cornerRadius
+
+          // Notched title on the top border.
+          Rectangle {
+            anchors.left: parent.left
+            anchors.leftMargin: 22
+            anchors.top: parent.top
+            anchors.topMargin: -helpTitle.implicitHeight / 2 - 2
+            width: helpTitle.implicitWidth + 18
+            height: helpTitle.implicitHeight + 6
+            color: root.background
+
+            Text {
+              id: helpTitle
+              anchors.centerIn: parent
+              text: "[ Keybindings ]"
+              color: root.accent
+              font.family: root.fontFamily
+              font.pixelSize: 13
+              font.bold: true
+            }
+          }
+
+          ColumnLayout {
+            id: helpColumn
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.leftMargin: 28
+            anchors.rightMargin: 28
+            anchors.topMargin: 24
+            spacing: 8
+
+            Repeater {
+              model: [
+                { keys: "j   k",        action: "move focus down / up" },
+                { keys: "h   l",        action: "exit / enter body" },
+                { keys: "J   K",        action: "reorder widget within section" },
+                { keys: "1 … 9",        action: "jump to section [N]" },
+                { keys: "⇧1   ⇧2   ⇧3", action: "move widget to left / center / right (in bar row)" },
+                { keys: "d d",          action: "remove selected widget" },
+                { keys: "drag",         action: "drag a widget to reorder or move between sections" },
+                { keys: "Tab",          action: "next focusable control" },
+                { keys: "Esc",          action: "close panel (sidebar) / back to sidebar (body)" },
+                { keys: "?",            action: "toggle this overlay" }
+              ]
+              delegate: RowLayout {
+                required property var modelData
+                Layout.fillWidth: true
+                spacing: 18
+
+                Text {
+                  text: modelData.keys
+                  color: root.accent
+                  font.family: root.fontFamily
+                  font.pixelSize: 13
+                  font.bold: true
+                  Layout.preferredWidth: 100
+                }
+                Text {
+                  text: modelData.action
+                  color: Qt.darker(root.foreground, 1.2)
+                  font.family: root.fontFamily
+                  font.pixelSize: 12
+                  Layout.fillWidth: true
+                }
+              }
+            }
+
+            Item { Layout.preferredHeight: 8 }
+
+            Text {
+              text: "press ? or Esc to close"
+              color: Qt.darker(root.foreground, 1.7)
+              font.family: root.fontFamily
+              font.pixelSize: 11
+              Layout.alignment: Qt.AlignRight
+            }
+          }
+        }
       }
     }
     }
   }
 
   // ===================== sidebar row =======================================
+  // No icon glyph — categories are labeled by name, with a ▶ marker on the
+  // active row. Mirrors the vim/tui aesthetic of the rest of the panel.
   component SidebarRow: Rectangle {
     id: sb
     property string categoryId: ""
     property string label: ""
-    property string glyph: ""
     readonly property bool active: root.activeCategory === categoryId
     readonly property bool sidebarFocused: root.focusZone === "sidebar"
 
     Layout.fillWidth: true
-    Layout.preferredHeight: 30
+    Layout.preferredHeight: 28
     radius: root.cornerRadius
     color: sb.active
       ? (sb.sidebarFocused
-          ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.20)
-          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.14))
-      : (sbArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.07) : "transparent")
-    border.color: sb.active
-      ? (sb.sidebarFocused ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.25))
+          ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.18)
+          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10))
+      : (sbArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06) : "transparent")
+    border.color: sb.active && sb.sidebarFocused
+      ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.55)
       : "transparent"
-    border.width: sb.active && sb.sidebarFocused ? 2 : 1
+    border.width: sb.active && sb.sidebarFocused ? 1 : 0
 
     Behavior on color { ColorAnimation { duration: 100 } }
 
-    Row {
+    // Caret indicator. Always reserves space so labels never shift.
+    Text {
+      text: sb.active ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      width: 12
       anchors.left: parent.left
-      anchors.leftMargin: 10
+      anchors.leftMargin: 8
       anchors.verticalCenter: parent.verticalCenter
-      spacing: 10
+    }
 
-      Text {
-        text: sb.glyph
-        color: sb.active ? root.accent : Qt.darker(root.foreground, 1.4)
-        font.family: root.fontFamily
-        font.pixelSize: 13
-        anchors.verticalCenter: parent.verticalCenter
-      }
-      Text {
-        text: sb.label
-        color: sb.active ? root.foreground : Qt.darker(root.foreground, 1.2)
-        font.family: root.fontFamily
-        font.pixelSize: 12
-        font.bold: sb.active
-        anchors.verticalCenter: parent.verticalCenter
-      }
+    Text {
+      text: sb.label
+      color: sb.active ? root.foreground : Qt.darker(root.foreground, 1.25)
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: sb.active
+      anchors.left: parent.left
+      anchors.leftMargin: 26
+      anchors.verticalCenter: parent.verticalCenter
     }
 
     MouseArea {
@@ -807,81 +1411,59 @@ Item {
 
   // ===================== bar category ======================================
   component BarCategory: ColumnLayout {
-    spacing: 14
+    spacing: 16
 
-    Text {
-      text: "Bar"
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: 18
-      font.bold: true
-    }
+    // Widget sections come first so Shift+1/2/3 lines up with [1]/[2]/[3]
+    // when moving widgets between zones. Position/anchor follow as [4]/[5].
+    SectionEditor { sectionKey: "left";    sectionLabel: "Bar · Left";   sectionIndex: 1 }
+    SectionEditor { sectionKey: "center";  sectionLabel: "Bar · Center"; sectionIndex: 2 }
+    SectionEditor { sectionKey: "right";   sectionLabel: "Bar · Right";  sectionIndex: 3 }
 
-    Text {
-      text: "Drag widgets between the bar's three sections, drop in plugin widgets, and tweak per-widget options. Auto-saves to shell.json."
-      color: Qt.darker(root.foreground, 1.6)
-      font.family: root.fontFamily
-      font.pixelSize: 11
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-    }
-
-    Row {
-      Layout.fillWidth: true
-      spacing: 14
-
-      Cmp.NDropdown {
-        label: "Position"
-        value: root.draft.bar.position
-        options: ["top", "right", "bottom", "left"]
-        foreground: root.foreground
-        background: root.background
-        accent: root.accent
-        fontFamily: root.fontFamily
-        cornerRadius: root.cornerRadius
-        onChanged: function(v) {
-          var next = root.cloneJson(root.draft)
-          next.bar.position = v
-          root.draft = next
-          root.markDirty()
-        }
-      }
-
-      Cmp.NDropdown {
-        label: "Center anchor"
-        value: root.draft.bar.centerAnchor || "(none)"
-        options: {
-          var list = ["(none)"]
-          var entries = root.draft.bar.layout.center || []
-          for (var i = 0; i < entries.length; i++) list.push(entries[i].id)
-          return list
-        }
-        foreground: root.foreground
-        background: root.background
-        accent: root.accent
-        fontFamily: root.fontFamily
-        cornerRadius: root.cornerRadius
-        onChanged: function(v) {
-          var next = root.cloneJson(root.draft)
-          next.bar.centerAnchor = v === "(none)" ? "" : v
-          root.draft = next
-          root.markDirty()
-        }
+    RadioSelector {
+      sectionLabel: "Bar · Position"
+      sectionMeta: "where the bar lives on screen"
+      sectionIndex: 4
+      value: root.draft.bar.position
+      options: [
+        { value: "top",    label: "top",    description: "above the workspace" },
+        { value: "right",  label: "right",  description: "right edge, vertical" },
+        { value: "bottom", label: "bottom", description: "below the workspace" },
+        { value: "left",   label: "left",   description: "left edge, vertical" }
+      ]
+      onChanged: function(v) {
+        var next = root.cloneJson(root.draft)
+        next.bar.position = v
+        root.draft = next
+        root.markDirty()
       }
     }
 
-    SectionEditor { sectionKey: "left";    sectionLabel: "Bar · Left" }
-    SectionEditor { sectionKey: "center";  sectionLabel: "Bar · Center" }
-    SectionEditor { sectionKey: "right";   sectionLabel: "Bar · Right" }
-
-    Rectangle {
-      Layout.fillWidth: true
-      Layout.preferredHeight: 1
-      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+    RadioSelector {
+      sectionLabel: "Bar · Center anchor"
+      sectionMeta: "widget aligned to the bar's midpoint"
+      sectionIndex: 5
+      value: root.draft.bar.centerAnchor || "(none)"
+      options: {
+        var list = [{ value: "(none)", label: "(none)", description: "no center anchor" }]
+        var entries = root.draft.bar.layout.center || []
+        for (var i = 0; i < entries.length; i++) {
+          var id = entries[i].id
+          list.push({ value: id, label: root.widgetName(id), description: root.widgetDescription(id) })
+        }
+        return list
+      }
+      onChanged: function(v) {
+        var next = root.cloneJson(root.draft)
+        next.bar.centerAnchor = v === "(none)" ? "" : v
+        root.draft = next
+        root.markDirty()
+      }
     }
 
+    // Trailing reset action — kept subtle, right-aligned.
     Row {
       Layout.alignment: Qt.AlignRight
+      Layout.topMargin: 6
       ActionPill {
         text: "Reset to defaults"
         foreground: root.urgent
@@ -892,6 +1474,7 @@ Item {
 
   // ===================== defaults category =================================
   component DefaultsCategory: ColumnLayout {
+    id: dc
     spacing: 14
 
     property string terminalCurrent: ""
@@ -909,24 +1492,24 @@ Item {
     Process {
       id: readTerminalProc
       command: ["omarchy-default-terminal"]
-      stdout: SplitParser { onRead: function(line) { terminalCurrent = String(line).trim() } }
+      stdout: SplitParser { onRead: function(line) { dc.terminalCurrent = String(line).trim() } }
     }
     Process {
       id: readBrowserProc
       command: ["omarchy-default-browser"]
-      stdout: SplitParser { onRead: function(line) { browserCurrent = String(line).trim() } }
+      stdout: SplitParser { onRead: function(line) { dc.browserCurrent = String(line).trim() } }
     }
     Process {
       id: readEditorProc
       command: ["omarchy-default-editor"]
-      stdout: SplitParser { onRead: function(line) { editorCurrent = String(line).trim() } }
+      stdout: SplitParser { onRead: function(line) { dc.editorCurrent = String(line).trim() } }
     }
     // Refresh after the write has actually finished — kicking off a read
     // synchronously after .running = true races the bash apply and ends up
     // displaying the *previous* default.
     Process {
       id: applyDefaultsProc
-      onExited: refresh()
+      onExited: dc.refresh()
     }
 
     function applyDefault(group, value) {
@@ -942,151 +1525,103 @@ Item {
     Component.onCompleted: refresh()
     onVisibleChanged: if (visible) refresh()
 
-    Text {
-      text: "Defaults"
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: 18
-      font.bold: true
-    }
-
-    Text {
-      text: "Pick the terminal, browser, and editor Omarchy hands off to when launching apps."
-      color: Qt.darker(root.foreground, 1.6)
-      font.family: root.fontFamily
-      font.pixelSize: 11
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-    }
-
-    DefaultsGroup {
-      title: "Terminal"
-      description: "Used by Super+Return and xdg-terminal-exec."
-      options: [
-        { id: "alacritty", label: "Alacritty",   cmd: "alacritty" },
-        { id: "foot",      label: "Foot",        cmd: "foot" },
-        { id: "ghostty",   label: "Ghostty",     cmd: "ghostty" },
-        { id: "kitty",     label: "Kitty",       cmd: "kitty" }
-      ]
-      currentId: terminalCurrent
-      onPicked: function(id) { applyDefault("terminal", id) }
-    }
-
-    DefaultsGroup {
-      title: "Browser"
-      description: "Used for x-scheme-handler/http and HTML files."
-      options: [
-        { id: "chromium",     label: "Chromium",     cmd: "chromium" },
-        { id: "chrome",       label: "Chrome",       cmd: "google-chrome-stable" },
-        { id: "brave",        label: "Brave",        cmd: "brave" },
-        { id: "brave-origin", label: "Brave Origin", cmd: "brave-origin-beta" },
-        { id: "edge",         label: "Edge",         cmd: "microsoft-edge-stable" },
-        { id: "firefox",      label: "Firefox",      cmd: "firefox" },
-        { id: "zen",          label: "Zen",          cmd: "zen-browser" }
-      ]
-      currentId: browserCurrent
-      onPicked: function(id) { applyDefault("browser", id) }
-    }
-
-    DefaultsGroup {
-      title: "Editor"
-      description: "Sets $EDITOR. Takes effect after the next login."
-      options: [
-        { id: "nvim",         label: "Neovim",       cmd: "nvim" },
-        { id: "code",         label: "VSCode",       cmd: "code" },
-        { id: "cursor",       label: "Cursor",       cmd: "cursor" },
-        { id: "zeditor",      label: "Zed",          cmd: "zeditor" },
-        { id: "sublime_text", label: "Sublime Text", cmd: "sublime_text" },
-        { id: "helix",        label: "Helix",        cmd: "helix" },
-        { id: "vim",          label: "Vim",          cmd: "vim" },
-        { id: "emacs",        label: "Emacs",        cmd: "emacs" }
-      ]
-      currentId: editorCurrent
-      onPicked: function(id) { applyDefault("editor", id) }
-    }
-  }
-
-  component DefaultsGroup: Column {
-    id: dg
-    property string title: ""
-    property string description: ""
-    property var options: []
-    property string currentId: ""
-    signal picked(string id)
-
-    Layout.fillWidth: true
-    Layout.topMargin: 8
-    spacing: 6
-
-    Row {
-      width: dg.width
-      spacing: 8
-      Text {
-        text: dg.title
-        color: root.foreground
-        font.family: root.fontFamily
-        font.pixelSize: 13
-        font.bold: true
-        anchors.verticalCenter: parent.verticalCenter
-      }
-      Text {
-        text: "·  " + dg.description
-        color: Qt.darker(root.foreground, 1.5)
-        font.family: root.fontFamily
-        font.pixelSize: 10
-        anchors.verticalCenter: parent.verticalCenter
-      }
-    }
-
-    Column {
-      width: dg.width
-      spacing: 4
+    BracketedFrame {
+      sectionIndex: 1
+      sectionLabel: "TERMINAL"
+      sectionMeta: "Super+Return · xdg-terminal-exec"
 
       Repeater {
-        model: dg.options
+        model: [
+          { id: "alacritty", label: "Alacritty", cmd: "alacritty" },
+          { id: "foot",      label: "Foot",      cmd: "foot" },
+          { id: "ghostty",   label: "Ghostty",   cmd: "ghostty" },
+          { id: "kitty",     label: "Kitty",     cmd: "kitty" }
+        ]
         delegate: DefaultsRow {
           required property var modelData
-          width: dg.width
-          optionId: modelData.id
+          required property int index
+          width: parent.width
+          rowIndex: index
           optionLabel: modelData.label
           checkCmd: modelData.cmd
-          selected: dg.currentId === modelData.id
-          onClicked: dg.picked(optionId)
+          selected: dc.terminalCurrent === modelData.id
+          onChosen: dc.applyDefault("terminal", modelData.id)
+        }
+      }
+    }
+
+    BracketedFrame {
+      sectionIndex: 2
+      sectionLabel: "BROWSER"
+      sectionMeta: "x-scheme-handler/http · HTML files"
+
+      Repeater {
+        model: [
+          { id: "chromium",     label: "Chromium",     cmd: "chromium" },
+          { id: "chrome",       label: "Chrome",       cmd: "google-chrome-stable" },
+          { id: "brave",        label: "Brave",        cmd: "brave" },
+          { id: "brave-origin", label: "Brave Origin", cmd: "brave-origin-beta" },
+          { id: "edge",         label: "Edge",         cmd: "microsoft-edge-stable" },
+          { id: "firefox",      label: "Firefox",      cmd: "firefox" },
+          { id: "zen",          label: "Zen",          cmd: "zen-browser" }
+        ]
+        delegate: DefaultsRow {
+          required property var modelData
+          required property int index
+          width: parent.width
+          rowIndex: index
+          optionLabel: modelData.label
+          checkCmd: modelData.cmd
+          selected: dc.browserCurrent === modelData.id
+          onChosen: dc.applyDefault("browser", modelData.id)
+        }
+      }
+    }
+
+    BracketedFrame {
+      sectionIndex: 3
+      sectionLabel: "EDITOR"
+      sectionMeta: "$EDITOR · effective on next login"
+
+      Repeater {
+        model: [
+          { id: "nvim",         label: "Neovim",       cmd: "nvim" },
+          { id: "code",         label: "VSCode",       cmd: "code" },
+          { id: "cursor",       label: "Cursor",       cmd: "cursor" },
+          { id: "zeditor",      label: "Zed",          cmd: "zeditor" },
+          { id: "sublime_text", label: "Sublime Text", cmd: "sublime_text" },
+          { id: "helix",        label: "Helix",        cmd: "helix" },
+          { id: "vim",          label: "Vim",          cmd: "vim" },
+          { id: "emacs",        label: "Emacs",        cmd: "emacs" }
+        ]
+        delegate: DefaultsRow {
+          required property var modelData
+          required property int index
+          width: parent.width
+          rowIndex: index
+          optionLabel: modelData.label
+          checkCmd: modelData.cmd
+          selected: dc.editorCurrent === modelData.id
+          onChosen: dc.applyDefault("editor", modelData.id)
         }
       }
     }
   }
 
-  component DefaultsRow: Rectangle {
+  // One terminal/browser/editor option. Wraps NumberedRadioRow with a
+  // PATH probe so unavailable commands are dimmed and labeled.
+  component DefaultsRow: Item {
     id: dr
-    property string optionId: ""
+    property int rowIndex: 0
     property string optionLabel: ""
     property string checkCmd: ""
     property bool selected: false
     property bool available: false
-    signal clicked()
+    signal chosen()
 
-    activeFocusOnTab: dr.available
-    Keys.onReturnPressed: if (dr.available && !dr.selected) dr.clicked()
-    Keys.onEnterPressed: if (dr.available && !dr.selected) dr.clicked()
-    Keys.onSpacePressed: if (dr.available && !dr.selected) dr.clicked()
+    implicitHeight: nrr.implicitHeight
+    width: parent ? parent.width : implicitWidth
 
-    implicitHeight: 38
-    radius: root.cornerRadius
-    color: dr.activeFocus
-      ? root.focusFillColor
-      : (drArea.containsMouse
-          ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
-          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03))
-    border.color: dr.activeFocus
-      ? root.focusBorderColor
-      : (dr.selected ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12))
-    border.width: dr.activeFocus ? root.focusBorderWidth : 1
-    opacity: dr.available ? 1 : 0.45
-
-    Behavior on color { ColorAnimation { duration: 100 } }
-
-    // Probe availability via `command -v`. Cached for the lifetime of the row.
     Process {
       id: probeProc
       command: ["bash", "-lc", "command -v " + dr.checkCmd + " >/dev/null && echo yes || echo no"]
@@ -1094,72 +1629,30 @@ Item {
       Component.onCompleted: running = true
     }
 
-    Row {
+    NumberedRadioRow {
+      id: nrr
       anchors.left: parent.left
-      anchors.leftMargin: 12
-      anchors.right: trailRow.left
-      anchors.rightMargin: 8
-      anchors.verticalCenter: parent.verticalCenter
-      spacing: 10
-
-      Text {
-        text: dr.selected ? "●" : "○"
-        color: dr.selected ? root.accent : Qt.darker(root.foreground, 1.3)
-        font.family: root.fontFamily
-        font.pixelSize: 12
-        anchors.verticalCenter: parent.verticalCenter
-      }
-      Text {
-        text: dr.optionLabel
-        color: dr.selected ? root.foreground : Qt.darker(root.foreground, 1.05)
-        font.family: root.fontFamily
-        font.pixelSize: 12
-        font.bold: dr.selected
-        anchors.verticalCenter: parent.verticalCenter
-      }
-      Text {
-        text: dr.checkCmd
-        color: Qt.darker(root.foreground, 1.7)
-        font.family: root.fontFamily
-        font.pixelSize: 10
-        anchors.verticalCenter: parent.verticalCenter
-      }
-    }
-
-    Row {
-      id: trailRow
       anchors.right: parent.right
-      anchors.rightMargin: 10
-      anchors.verticalCenter: parent.verticalCenter
-      spacing: 6
-
-      Text {
-        visible: !dr.available
-        text: "not installed"
-        color: Qt.darker(root.foreground, 1.7)
-        font.family: root.fontFamily
-        font.pixelSize: 10
-      }
-      Text {
-        visible: dr.selected
-        text: "default"
-        color: root.accent
-        font.family: root.fontFamily
-        font.pixelSize: 10
-      }
-    }
-
-    MouseArea {
-      id: drArea
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: dr.available ? Qt.PointingHandCursor : Qt.ForbiddenCursor
-      onClicked: if (dr.available && !dr.selected) dr.clicked()
+      rowIndex: dr.rowIndex
+      label: dr.optionLabel
+      detail: dr.checkCmd
+      selected: dr.selected
+      available: dr.available
+      trailing: dr.selected
+        ? "default"
+        : (dr.available
+            ? (nrr.activeFocus ? "press space to set" : "")
+            : "not installed")
+      trailingColor: dr.selected
+        ? root.accent
+        : Qt.darker(root.foreground, 1.6)
+      onChosen: dr.chosen()
     }
   }
 
   // ===================== style category ====================================
   component StyleCategory: ColumnLayout {
+    id: sc
     spacing: 14
 
     property string currentCorners: root.cornerRadius > 0 ? "round" : "sharp"
@@ -1182,19 +1675,19 @@ Item {
       readFontsListProc.running = true
     }
 
-    Process { id: applyStyleProc; onExited: refresh() }
+    Process { id: applyStyleProc; onExited: sc.refresh() }
 
     Process {
       id: readFontProc
       command: ["omarchy-font-current"]
-      stdout: SplitParser { onRead: function(line) { fontName = String(line).trim() } }
+      stdout: SplitParser { onRead: function(line) { sc.fontName = String(line).trim() } }
     }
     Process {
       id: readFontsListProc
       command: ["omarchy-font-list"]
       stdout: StdioCollector {
         waitForEnd: true
-        onStreamFinished: fontsList = String(text || "").trim().split("\n").filter(function(x) { return x.length > 0 })
+        onStreamFinished: sc.fontsList = String(text || "").trim().split("\n").filter(function(x) { return x.length > 0 })
       }
     }
 
@@ -1204,14 +1697,14 @@ Item {
       path: root.home + "/.config/omarchy/current/theme.name"
       watchChanges: true
       printErrors: false
-      onFileChanged: refresh()
-      onLoaded: refresh()
+      onFileChanged: sc.refresh()
+      onLoaded: sc.refresh()
     }
     FileView {
       path: root.home + "/.config/alacritty/alacritty.toml"
       watchChanges: true
       printErrors: false
-      onFileChanged: refresh()
+      onFileChanged: sc.refresh()
     }
 
     // Re-read when any toggle flag changes on disk — covers CLI/menu paths
@@ -1220,29 +1713,29 @@ Item {
       path: root.home + "/.local/state/omarchy/toggles"
       watchChanges: true
       printErrors: false
-      onFileChanged: refresh()
+      onFileChanged: sc.refresh()
     }
     FileView {
       path: root.home + "/.local/state/omarchy/toggles/hypr"
       watchChanges: true
       printErrors: false
-      onFileChanged: refresh()
+      onFileChanged: sc.refresh()
     }
 
     Process {
       id: readBarProc
       command: ["bash", "-lc", "[[ -f $HOME/.local/state/omarchy/toggles/bar-off ]] && echo no || echo yes"]
-      stdout: SplitParser { onRead: function(line) { barOn = String(line).trim() === "yes" } }
+      stdout: SplitParser { onRead: function(line) { sc.barOn = String(line).trim() === "yes" } }
     }
     Process {
       id: readGapsProc
       command: ["bash", "-lc", "[[ -f $HOME/.local/state/omarchy/toggles/hypr/window-no-gaps.lua ]] && echo no || echo yes"]
-      stdout: SplitParser { onRead: function(line) { gapsOn = String(line).trim() === "yes" } }
+      stdout: SplitParser { onRead: function(line) { sc.gapsOn = String(line).trim() === "yes" } }
     }
     Process {
       id: readOneWinSqProc
       command: ["bash", "-lc", "[[ -f $HOME/.local/state/omarchy/toggles/hypr/single-window-aspect-ratio.lua ]] && echo yes || echo no"]
-      stdout: SplitParser { onRead: function(line) { oneWinSquare = String(line).trim() === "yes" } }
+      stdout: SplitParser { onRead: function(line) { sc.oneWinSquare = String(line).trim() === "yes" } }
     }
     // Snaps the scale Hyprland reports (which may be fractional / drifted) to
     // the nearest value in the canonical list. Used by the scale picker to
@@ -1265,8 +1758,8 @@ Item {
       stdout: SplitParser { onRead: function(line) {
         var parts = String(line).trim().split("\t")
         if (parts.length >= 2) {
-          monitorName = parts[0]
-          monitorScale = snapScale(parts[1])
+          sc.monitorName = parts[0]
+          sc.monitorScale = sc.snapScale(parts[1])
         }
       } }
     }
@@ -1276,171 +1769,122 @@ Item {
       applyStyleProc.running = true
     }
 
+    function shortFontName(name) {
+      // Strip a trailing " Nerd Font" so the flag stays one token.
+      return String(name || "").replace(/\s+Nerd Font(\s+Mono)?$/i, "$1").replace(/\s+/g, "")
+    }
+
     Component.onCompleted: refresh()
     onVisibleChanged: if (visible) refresh()
 
-    Text {
-      text: "Style"
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: 18
-      font.bold: true
+    BracketedFrame {
+      sectionIndex: 1
+      sectionLabel: "WINDOWS"
+      sectionMeta: "hyprland behavior toggles"
+
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 0
+        label: "Window gaps"
+        description: "Tile windows with the default gap between them."
+        isOn: sc.gapsOn
+        onToggle: sc.runStyle("omarchy-hyprland-window-gaps-toggle")
+      }
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 1
+        label: "1-window square ratio"
+        description: "Constrain a solo tiled window to a square aspect."
+        isOn: sc.oneWinSquare
+        onToggle: sc.runStyle("omarchy-hyprland-window-single-square-aspect-toggle")
+      }
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 2
+        label: "Bar"
+        description: "Show the omarchy bar."
+        isOn: sc.barOn
+        onToggle: sc.runStyle("omarchy-toggle-bar")
+      }
     }
 
-    Text {
-      text: "Look-and-feel of the shell, lock screen, and windows."
-      color: Qt.darker(root.foreground, 1.6)
-      font.family: root.fontFamily
-      font.pixelSize: 11
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-    }
-
-
-    StyleToggleRow {
-      label: "Window gaps"
-      description: "Tile windows with the default gap between them."
-      isOn: gapsOn
-      onToggle: runStyle("omarchy-hyprland-window-gaps-toggle")
-    }
-
-    StyleToggleRow {
-      label: "1-window square ratio"
-      description: "Constrain a solo tiled window to a square aspect."
-      isOn: oneWinSquare
-      onToggle: runStyle("omarchy-hyprland-window-single-square-aspect-toggle")
-    }
-
-    StyleToggleRow {
-      label: "Bar"
-      description: "Show the omarchy bar. The shell keeps running either way, so menus and this panel stay reachable."
-      isOn: barOn
-      onToggle: runStyle("omarchy-toggle-bar")
-    }
-
-    // Corner style — a real picker since this changes the whole shell's look.
-    ColumnLayout {
-      Layout.fillWidth: true
-      Layout.topMargin: 8
-      spacing: 6
+    BracketedFrame {
+      sectionIndex: 2
+      sectionLabel: "CORNERS"
+      sectionMeta: "Sharp matches the retro TUI look; round softens windows."
 
       Row {
-        spacing: 8
-        Text {
-          text: "Corners"
-          color: root.foreground
-          font.family: root.fontFamily
-          font.pixelSize: 13
-          font.bold: true
-          anchors.verticalCenter: parent.verticalCenter
+        spacing: 14
+
+        BracketChip {
+          label: "Sharp"
+          selected: sc.currentCorners === "sharp"
+          onClicked: sc.runStyle("omarchy-style-corners sharp")
         }
-        Text {
-          text: "·  Sharp matches the retro TUI look; round softens windows, menus, and notifications."
-          color: Qt.darker(root.foreground, 1.5)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-          anchors.verticalCenter: parent.verticalCenter
+        BracketChip {
+          label: "Round"
+          selected: sc.currentCorners === "round"
+          onClicked: sc.runStyle("omarchy-style-corners round")
         }
       }
 
+      Item { width: 1; height: 4 }
+
       Row {
         spacing: 8
 
-        StyleOptionTile {
-          tileLabel: "Sharp"
-          tileHint: "0px radius"
-          selected: currentCorners === "sharp"
-          onClicked: runStyle("omarchy-style-corners sharp")
+        Text {
+          text: sc.currentCorners === "sharp" ? "0px radius" : "6px radius"
+          color: Qt.darker(root.foreground, 1.4)
+          font.family: root.fontFamily
+          font.pixelSize: 12
+          anchors.verticalCenter: parent.verticalCenter
         }
-        StyleOptionTile {
-          tileLabel: "Round"
-          tileHint: "6px radius"
-          selected: currentCorners === "round"
-          onClicked: runStyle("omarchy-style-corners round")
+        Text {
+          text: "·  windows, menus, notifications"
+          color: Qt.darker(root.foreground, 1.7)
+          font.family: root.fontFamily
+          font.pixelSize: 12
+          anchors.verticalCenter: parent.verticalCenter
         }
       }
     }
 
-    // Monitor scaling — explicit picker. The Super+Plus/Minus shortcuts still
-    // call `omarchy-hyprland-monitor-scaling-cycle` for keyboard cycling.
-    ColumnLayout {
-      Layout.fillWidth: true
-      Layout.topMargin: 8
-      spacing: 6
+    BracketedFrame {
+      sectionIndex: 3
+      sectionLabel: "SCALING"
+      sectionMeta: (sc.monitorName || "monitor") + "  ·  Super+= cycles up, Super+- cycles down"
 
       Row {
-        spacing: 8
-        Text {
-          text: "Monitor scaling"
-          color: root.foreground
-          font.family: root.fontFamily
-          font.pixelSize: 13
-          font.bold: true
-          anchors.verticalCenter: parent.verticalCenter
-        }
-        Text {
-          text: "·  Pick a scale for " + (monitorName || "the focused monitor") + ". Keyboard shortcut still cycles."
-          color: Qt.darker(root.foreground, 1.5)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-          anchors.verticalCenter: parent.verticalCenter
-        }
-      }
-
-      Row {
-        spacing: 8
+        spacing: 14
 
         Repeater {
           model: ["1", "1.25", "1.6", "2", "3", "4"]
-          delegate: StyleChip {
+          delegate: BracketChip {
             required property var modelData
             label: modelData + "×"
-            selected: monitorScale === modelData
-            onClicked: runStyle("omarchy-hyprland-monitor-scaling-set " + modelData)
+            selected: sc.monitorScale === modelData
+            onClicked: sc.runStyle("omarchy-hyprland-monitor-scaling-set " + modelData)
           }
         }
       }
     }
 
-    // Font picker — each row rendered in its own typeface. Sits at the
-    // bottom because it's long; everything else above is one-line tall.
-    ColumnLayout {
-      Layout.fillWidth: true
-      Layout.topMargin: 8
-      spacing: 6
+    BracketedFrame {
+      sectionIndex: 4
+      sectionLabel: "FONT"
+      sectionMeta: (sc.fontName || "—") + "  ·  " + sc.fontsList.length + " installed Nerd Fonts"
 
-      Row {
-        spacing: 8
-        Text {
-          text: "Font"
-          color: root.foreground
-          font.family: root.fontFamily
-          font.pixelSize: 13
-          font.bold: true
-          anchors.verticalCenter: parent.verticalCenter
-        }
-        Text {
-          text: "·  " + (fontName || "—")
-          color: Qt.darker(root.foreground, 1.5)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-          anchors.verticalCenter: parent.verticalCenter
-        }
-      }
-
-      ColumnLayout {
-        Layout.fillWidth: true
-        spacing: 4
-
-        Repeater {
-          model: fontsList
-          delegate: FontRow {
-            required property var modelData
-            Layout.fillWidth: true
-            fontFamilyName: modelData
-            selected: modelData === fontName
-            onPicked: runStyle("omarchy-font-set \"" + modelData + "\"")
-          }
+      Repeater {
+        model: sc.fontsList
+        delegate: FontPickerRow {
+          required property var modelData
+          required property int index
+          width: parent.width
+          rowIndex: index
+          fontFamilyName: modelData
+          selected: modelData === sc.fontName
+          onChosen: sc.runStyle("omarchy-font-set \"" + modelData + "\"")
         }
       }
     }
@@ -1448,6 +1892,7 @@ Item {
 
   // ===================== system category ===================================
   component SystemCategory: ColumnLayout {
+    id: syc
     spacing: 14
 
     property string powerProfile: ""
@@ -1458,6 +1903,17 @@ Item {
     property bool screensaverOn: false
     property bool suspendAvailable: true
     property int refreshTick: 0
+
+    // Total + on-count for the BEHAVIOR section meta.
+    readonly property var behaviorFlags: [
+      syc.nightlightOn, !syc.dndOn, syc.idleOn, syc.screensaverOn, syc.suspendAvailable
+    ]
+    readonly property int behaviorOn: {
+      var n = 0
+      for (var i = 0; i < behaviorFlags.length; i++) if (behaviorFlags[i]) n++
+      return n
+    }
+    readonly property int behaviorTotal: behaviorFlags.length
 
     function refresh() {
       refreshTick++
@@ -1470,19 +1926,19 @@ Item {
       readSuspendProc.running = true
     }
 
-    Process { id: applySystemProc; onExited: refresh() }
+    Process { id: applySystemProc; onExited: syc.refresh() }
 
     Process {
       id: readPowerProc
       command: ["bash", "-lc", "powerprofilesctl get 2>/dev/null"]
-      stdout: SplitParser { onRead: function(line) { powerProfile = String(line).trim() } }
+      stdout: SplitParser { onRead: function(line) { syc.powerProfile = String(line).trim() } }
     }
     Process {
       id: readPowerListProc
       command: ["bash", "-lc", "omarchy-powerprofiles-list 2>/dev/null"]
       stdout: StdioCollector {
         waitForEnd: true
-        onStreamFinished: powerProfiles = String(text || "").trim().split("\n").filter(function(x) { return x.length > 0 })
+        onStreamFinished: syc.powerProfiles = String(text || "").trim().split("\n").filter(function(x) { return x.length > 0 })
       }
     }
     Process {
@@ -1490,28 +1946,28 @@ Item {
       command: ["bash", "-lc", "hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+' | head -n1 || echo 6000"]
       stdout: SplitParser { onRead: function(line) {
         var n = parseInt(String(line).trim(), 10)
-        nightlightOn = isFinite(n) && n < 5500
+        syc.nightlightOn = isFinite(n) && n < 5500
       } }
     }
     Process {
       id: readDndProc
       command: ["bash", "-lc", "omarchy-shell-ipc notifications isDnd 2>/dev/null || echo off"]
-      stdout: SplitParser { onRead: function(line) { dndOn = String(line).trim() === "on" } }
+      stdout: SplitParser { onRead: function(line) { syc.dndOn = String(line).trim() === "on" } }
     }
     Process {
       id: readIdleProc
       command: ["bash", "-lc", "pgrep -x hypridle >/dev/null && echo yes || echo no"]
-      stdout: SplitParser { onRead: function(line) { idleOn = String(line).trim() === "yes" } }
+      stdout: SplitParser { onRead: function(line) { syc.idleOn = String(line).trim() === "yes" } }
     }
     Process {
       id: readScreensaverProc
       command: ["bash", "-lc", "[[ -f $HOME/.local/state/omarchy/toggles/screensaver-off ]] && echo no || echo yes"]
-      stdout: SplitParser { onRead: function(line) { screensaverOn = String(line).trim() === "yes" } }
+      stdout: SplitParser { onRead: function(line) { syc.screensaverOn = String(line).trim() === "yes" } }
     }
     Process {
       id: readSuspendProc
       command: ["bash", "-lc", "[[ -f $HOME/.local/state/omarchy/toggles/suspend-off ]] && echo no || echo yes"]
-      stdout: SplitParser { onRead: function(line) { suspendAvailable = String(line).trim() === "yes" } }
+      stdout: SplitParser { onRead: function(line) { syc.suspendAvailable = String(line).trim() === "yes" } }
     }
 
     function runSystem(cmd) {
@@ -1524,356 +1980,88 @@ Item {
       path: root.home + "/.local/state/omarchy/toggles"
       watchChanges: true
       printErrors: false
-      onFileChanged: refresh()
+      onFileChanged: syc.refresh()
     }
 
     Component.onCompleted: refresh()
     onVisibleChanged: if (visible) refresh()
 
-    Text {
-      text: "System"
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: 18
-      font.bold: true
-    }
-
-    Text {
-      text: "System-level behavior — power, notifications, idle, screensaver, suspend."
-      color: Qt.darker(root.foreground, 1.6)
-      font.family: root.fontFamily
-      font.pixelSize: 11
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-    }
-
-    ColumnLayout {
-      Layout.fillWidth: true
-      Layout.topMargin: 8
-      spacing: 6
+    BracketedFrame {
+      sectionIndex: 1
+      sectionLabel: "POWER PROFILE"
+      sectionMeta: "power-profiles-daemon"
 
       Row {
-        spacing: 8
-        Text {
-          text: "Power profile"
-          color: root.foreground
-          font.family: root.fontFamily
-          font.pixelSize: 13
-          font.bold: true
-          anchors.verticalCenter: parent.verticalCenter
-        }
-        Text {
-          text: "·  Pick how aggressively the CPU clocks down. Reads via power-profiles-daemon."
-          color: Qt.darker(root.foreground, 1.5)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-          anchors.verticalCenter: parent.verticalCenter
-        }
-      }
-
-      Row {
-        spacing: 8
+        spacing: 14
 
         Repeater {
-          model: powerProfiles
-          delegate: StyleChip {
+          model: syc.powerProfiles
+          delegate: BracketChip {
             required property var modelData
             label: modelData.charAt(0).toUpperCase() + modelData.slice(1).replace("-", " ")
-            selected: powerProfile === modelData
-            onClicked: runSystem("powerprofilesctl set " + modelData)
+            selected: syc.powerProfile === modelData
+            onClicked: syc.runSystem("powerprofilesctl set " + modelData)
           }
         }
       }
-    }
 
-    StyleToggleRow {
-      label: "Nightlight"
-      description: "Lower screen colour temperature in the evening."
-      isOn: nightlightOn
-      onToggle: runSystem("omarchy-toggle-nightlight")
-    }
-
-    StyleToggleRow {
-      label: "Notifications"
-      description: dndOn ? "Do-not-disturb is on — notifications are silenced." : "Notifications post normally."
-      isOn: !dndOn
-      onToggle: runSystem("omarchy-toggle-notification-silencing")
-    }
-
-    StyleToggleRow {
-      label: "Idle locking"
-      description: "Lock the screen when idle (hypridle)."
-      isOn: idleOn
-      onToggle: runSystem("omarchy-toggle-idle")
-    }
-
-    StyleToggleRow {
-      label: "Screensaver"
-      description: "Allow the screensaver to engage during idle."
-      isOn: screensaverOn
-      onToggle: runSystem("omarchy-toggle-screensaver")
-    }
-
-    StyleToggleRow {
-      label: "Suspend in system menu"
-      description: "Show 'Suspend' in the system power menu."
-      isOn: suspendAvailable
-      onToggle: runSystem("omarchy-toggle-suspend")
-    }
-  }
-
-  component StyleOptionTile: Rectangle {
-    id: tile
-    property string tileLabel: ""
-    property string tileHint: ""
-    property bool selected: false
-    signal clicked()
-
-    activeFocusOnTab: true
-    Keys.onReturnPressed: tile.clicked()
-    Keys.onEnterPressed: tile.clicked()
-    Keys.onSpacePressed: tile.clicked()
-
-    implicitWidth: 140
-    implicitHeight: 52
-    radius: root.cornerRadius
-    color: tile.activeFocus
-      ? root.focusFillColor
-      : (tileArea.containsMouse
-          ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10)
-          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03))
-    border.color: tile.activeFocus
-      ? root.focusBorderColor
-      : (tile.selected ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18))
-    border.width: tile.activeFocus ? root.focusBorderWidth : (tile.selected ? 2 : 1)
-
-    Behavior on color { ColorAnimation { duration: 100 } }
-
-    Text {
-      id: tileTitle
-      text: tile.tileLabel
-      color: tile.selected ? root.foreground : Qt.darker(root.foreground, 1.1)
-      font.family: root.fontFamily
-      font.pixelSize: 13
-      font.bold: tile.selected
-      horizontalAlignment: Text.AlignHCenter
-      anchors.horizontalCenter: parent.horizontalCenter
-      anchors.top: parent.top
-      anchors.topMargin: 10
-    }
-    Text {
-      text: tile.tileHint
-      color: Qt.darker(root.foreground, 1.6)
-      font.family: root.fontFamily
-      font.pixelSize: 10
-      horizontalAlignment: Text.AlignHCenter
-      anchors.horizontalCenter: parent.horizontalCenter
-      anchors.top: tileTitle.bottom
-      anchors.topMargin: 2
-    }
-
-    MouseArea {
-      id: tileArea
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onClicked: tile.clicked()
-    }
-  }
-
-  // Compact, single-line variant of StyleOptionTile — used for the monitor
-  // scaling chip row where 6 options need to fit on one line.
-  component StyleChip: Rectangle {
-    id: chip
-    property string label: ""
-    property bool selected: false
-    signal clicked()
-
-    activeFocusOnTab: true
-    Keys.onReturnPressed: chip.clicked()
-    Keys.onEnterPressed: chip.clicked()
-    Keys.onSpacePressed: chip.clicked()
-
-    implicitWidth: chipText.implicitWidth + 22
-    implicitHeight: 30
-    radius: root.cornerRadius
-    color: chip.activeFocus
-      ? root.focusFillColor
-      : (chipArea.containsMouse
-          ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10)
-          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03))
-    border.color: chip.activeFocus
-      ? root.focusBorderColor
-      : (chip.selected ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18))
-    border.width: chip.activeFocus ? root.focusBorderWidth : (chip.selected ? 2 : 1)
-
-    Behavior on color { ColorAnimation { duration: 100 } }
-
-    Text {
-      id: chipText
-      anchors.centerIn: parent
-      text: chip.label
-      color: chip.selected ? root.foreground : Qt.darker(root.foreground, 1.1)
-      font.family: root.fontFamily
-      font.pixelSize: 12
-      font.bold: chip.selected
-    }
-
-    MouseArea {
-      id: chipArea
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onClicked: chip.clicked()
-    }
-  }
-
-  // Row showing a font name rendered in its own typeface, plus a short sample
-  // string in the same font. Selected = accent border + bold.
-  component FontRow: Rectangle {
-    id: fr
-    property string fontFamilyName: ""
-    property bool selected: false
-    signal picked()
-
-    activeFocusOnTab: true
-    Keys.onReturnPressed: if (!fr.selected) fr.picked()
-    Keys.onEnterPressed: if (!fr.selected) fr.picked()
-    Keys.onSpacePressed: if (!fr.selected) fr.picked()
-
-    implicitHeight: 44
-    radius: root.cornerRadius
-    color: fr.activeFocus
-      ? root.focusFillColor
-      : (frArea.containsMouse
-          ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
-          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03))
-    border.color: fr.activeFocus
-      ? root.focusBorderColor
-      : (fr.selected ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12))
-    border.width: fr.activeFocus ? root.focusBorderWidth : (fr.selected ? 2 : 1)
-
-    Behavior on color { ColorAnimation { duration: 100 } }
-
-    Row {
-      anchors.fill: parent
-      anchors.leftMargin: 14
-      anchors.rightMargin: 14
-      spacing: 14
+      Item { width: 1; height: 4 }
 
       Text {
-        text: fr.fontFamilyName
-        color: fr.selected ? root.accent : root.foreground
-        font.family: fr.fontFamilyName
-        font.pixelSize: 13
-        font.bold: fr.selected
-        anchors.verticalCenter: parent.verticalCenter
-        width: 220
-        elide: Text.ElideRight
-      }
-      Text {
-        text: "The quick brown fox jumps over the lazy dog 0123"
-        color: Qt.darker(root.foreground, 1.3)
-        font.family: fr.fontFamilyName
-        font.pixelSize: 12
-        anchors.verticalCenter: parent.verticalCenter
-        elide: Text.ElideRight
-        width: parent.width - 234
-      }
-    }
-
-    MouseArea {
-      id: frArea
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onClicked: if (!fr.selected) fr.picked()
-    }
-  }
-
-
-  component StyleToggleRow: Rectangle {
-    id: tr
-    property string label: ""
-    property string description: ""
-    property bool isOn: false
-    signal toggle()
-
-    activeFocusOnTab: true
-    Keys.onReturnPressed: tr.toggle()
-    Keys.onEnterPressed: tr.toggle()
-    Keys.onSpacePressed: tr.toggle()
-
-    Layout.fillWidth: true
-    implicitHeight: 46
-    radius: root.cornerRadius
-    color: tr.activeFocus
-      ? root.focusFillColor
-      : (trArea.containsMouse
-          ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
-          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03))
-    border.color: tr.activeFocus ? root.focusBorderColor : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
-    border.width: tr.activeFocus ? root.focusBorderWidth : 1
-
-    Behavior on color { ColorAnimation { duration: 100 } }
-
-    Column {
-      anchors.left: parent.left
-      anchors.leftMargin: 14
-      anchors.right: trSwitch.left
-      anchors.rightMargin: 14
-      anchors.verticalCenter: parent.verticalCenter
-      spacing: 2
-
-      Text {
-        text: tr.label
-        color: root.foreground
-        font.family: root.fontFamily
-        font.pixelSize: 12
-        font.bold: true
-      }
-      Text {
-        text: tr.description
+        text: "CPU clocks down aggressively on saver. Performance disables boost throttling."
         color: Qt.darker(root.foreground, 1.5)
         font.family: root.fontFamily
-        font.pixelSize: 10
-        elide: Text.ElideRight
+        font.pixelSize: 12
+        wrapMode: Text.WordWrap
         width: parent.width
       }
     }
 
-    Rectangle {
-      id: trSwitch
-      anchors.right: parent.right
-      anchors.rightMargin: 14
-      anchors.verticalCenter: parent.verticalCenter
-      width: 48
-      height: 22
-      radius: root.cornerRadius
-      color: tr.isOn
-        ? root.accent
-        : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10)
-      border.color: tr.isOn ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.4)
-      border.width: 1
+    BracketedFrame {
+      sectionIndex: 2
+      sectionLabel: "BEHAVIOR"
+      sectionMeta: syc.behaviorOn + "/" + syc.behaviorTotal + " enabled"
 
-      Rectangle {
-        width: 16
-        height: 16
-        radius: root.cornerRadius
-        color: tr.isOn ? root.background : root.foreground
-        anchors.verticalCenter: parent.verticalCenter
-        x: tr.isOn ? parent.width - width - 3 : 3
-
-        Behavior on x { NumberAnimation { duration: 120 } }
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 0
+        label: "Nightlight"
+        description: "Lower screen colour temperature in the evening."
+        isOn: syc.nightlightOn
+        onToggle: syc.runSystem("omarchy-toggle-nightlight")
       }
-    }
-
-    MouseArea {
-      id: trArea
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onClicked: tr.toggle()
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 1
+        label: "Notifications"
+        description: syc.dndOn ? "Do-not-disturb is on — notifications are silenced." : "Notifications post normally."
+        isOn: !syc.dndOn
+        onToggle: syc.runSystem("omarchy-toggle-notification-silencing")
+      }
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 2
+        label: "Idle locking"
+        description: "Lock the screen when idle (hypridle)."
+        isOn: syc.idleOn
+        onToggle: syc.runSystem("omarchy-toggle-idle")
+      }
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 3
+        label: "Screensaver"
+        description: "Allow the screensaver to engage during idle."
+        isOn: syc.screensaverOn
+        onToggle: syc.runSystem("omarchy-toggle-screensaver")
+      }
+      NumberedToggleRow {
+        width: parent.width
+        rowIndex: 4
+        label: "Suspend in menu"
+        description: "Show 'Suspend' in the system power menu."
+        isOn: syc.suspendAvailable
+        onToggle: syc.runSystem("omarchy-toggle-suspend")
+      }
     }
   }
 
@@ -1907,7 +2095,7 @@ Item {
       text: pill.text
       color: pill.foreground
       font.family: root.fontFamily
-      font.pixelSize: 11
+      font.pixelSize: 12
     }
 
     MouseArea {
@@ -1947,7 +2135,7 @@ Item {
       text: iconButton.glyph
       color: iconButton.foreground
       font.family: root.fontFamily
-      font.pixelSize: 13
+      font.pixelSize: 14
     }
 
     MouseArea {
@@ -1959,63 +2147,513 @@ Item {
     }
   }
 
+  // Bracketed frame with a notched `[N] LABEL · meta` title — identical
+  // chrome to SectionEditor / RadioSelector, factored out for the
+  // non-bar categories. Inner children go into the default `inner` slot.
+  component BracketedFrame: Item {
+    id: bf
+    property string sectionLabel: ""
+    property string sectionMeta: ""
+    property int sectionIndex: 0
+    default property alias inner: bfInner.data
+    readonly property int notchH: 16
+
+    Layout.fillWidth: true
+    implicitHeight: notchH / 2 + bfInner.implicitHeight + 28
+
+    Rectangle {
+      id: bfFrame
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.topMargin: bf.notchH / 2
+      anchors.bottom: parent.bottom
+      color: "transparent"
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+      border.width: 1
+      radius: root.cornerRadius
+    }
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.leftMargin: 18
+      anchors.top: parent.top
+      width: bfLabel.implicitWidth + 16
+      height: bf.notchH
+      color: root.background
+
+      Text {
+        id: bfLabel
+        anchors.centerIn: parent
+        text: "[" + bf.sectionIndex + "] " + bf.sectionLabel
+              + (bf.sectionMeta !== "" ? "  ·  " + bf.sectionMeta : "")
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: 12
+      }
+    }
+
+    Column {
+      id: bfInner
+      anchors.left: bfFrame.left
+      anchors.right: bfFrame.right
+      anchors.top: bfFrame.top
+      anchors.leftMargin: 14
+      anchors.rightMargin: 14
+      anchors.topMargin: 14
+      spacing: 2
+    }
+  }
+
+  // Numbered toggle row — `▶ NN  Label   Description       [x]` / `[ ]`.
+  // Focusable; Enter / Space / click flips the state.
+  component NumberedToggleRow: Item {
+    id: tog
+    property int rowIndex: 0
+    property string label: ""
+    property string description: ""
+    property bool isOn: false
+    signal toggle()
+
+    implicitHeight: 28
+    activeFocusOnTab: true
+
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = ""
+        root.selectedIndex = -1
+      }
+    }
+
+    Keys.onReturnPressed: tog.toggle()
+    Keys.onEnterPressed:  tog.toggle()
+    Keys.onSpacePressed:  tog.toggle()
+
+    Rectangle {
+      anchors.fill: parent
+      color: tog.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (togArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    Text {
+      text: tog.activeFocus ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      anchors.left: parent.left
+      anchors.leftMargin: 6
+      anchors.verticalCenter: parent.verticalCenter
+      width: 12
+    }
+
+    Text {
+      text: root.padTwo(tog.rowIndex + 1)
+      color: Qt.darker(root.foreground, 1.9)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 24
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: togLabel
+      text: tog.label
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: tog.activeFocus || tog.isOn
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      text: tog.description
+      color: Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: togLabel.right
+      anchors.leftMargin: 14
+      anchors.right: togState.left
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+      elide: Text.ElideRight
+    }
+
+    Text {
+      id: togState
+      text: tog.isOn ? "[x]" : "[ ]"
+      color: tog.isOn ? root.accent : Qt.darker(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: tog.isOn
+      anchors.right: parent.right
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    MouseArea {
+      id: togArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: { tog.forceActiveFocus(); tog.toggle() }
+    }
+  }
+
+  // Numbered radio row — `▶ NN  ( )  Label   detail        trailing`.
+  // `trailing` lets each call site stamp a status string ("default",
+  // "not installed", "loaded", etc.) in its own color.
+  component NumberedRadioRow: Item {
+    id: nr
+    property int rowIndex: 0
+    property string label: ""
+    property string detail: ""
+    property string description: ""
+    property string trailing: ""
+    property color trailingColor: root.accent
+    property bool selected: false
+    property bool available: true
+    property bool emphasizeDetail: false
+    signal chosen()
+
+    implicitHeight: 28
+    activeFocusOnTab: nr.available
+    opacity: nr.available ? 1 : 0.45
+
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = ""
+        root.selectedIndex = -1
+      }
+    }
+
+    Keys.onReturnPressed: if (nr.available && !nr.selected) nr.chosen()
+    Keys.onEnterPressed:  if (nr.available && !nr.selected) nr.chosen()
+    Keys.onSpacePressed:  if (nr.available && !nr.selected) nr.chosen()
+
+    Rectangle {
+      anchors.fill: parent
+      color: nr.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (nrArea.containsMouse && nr.available ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    Text {
+      text: nr.activeFocus ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      anchors.left: parent.left
+      anchors.leftMargin: 6
+      anchors.verticalCenter: parent.verticalCenter
+      width: 12
+    }
+
+    Text {
+      text: root.padTwo(nr.rowIndex + 1)
+      color: Qt.darker(root.foreground, 1.9)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 24
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: nrRadio
+      text: nr.selected ? "(●)" : "( )"
+      color: nr.selected ? root.accent : Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 52
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: nrLabel
+      text: nr.label
+      color: nr.selected ? root.foreground : Qt.darker(root.foreground, 1.15)
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: nr.selected || nr.activeFocus
+      anchors.left: nrRadio.right
+      anchors.leftMargin: 10
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: nrDetail
+      text: nr.detail
+      color: nr.emphasizeDetail
+        ? Qt.darker(root.foreground, 1.3)
+        : Qt.darker(root.foreground, 1.7)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      font.italic: nr.emphasizeDetail
+      anchors.left: nrLabel.right
+      anchors.leftMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      text: nr.description
+      color: Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: nrDetail.right
+      anchors.leftMargin: 14
+      anchors.right: nrTrail.left
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+      elide: Text.ElideRight
+    }
+
+    Text {
+      id: nrTrail
+      text: nr.trailing
+      color: nr.trailingColor
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      font.bold: nr.selected
+      anchors.right: parent.right
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    MouseArea {
+      id: nrArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: nr.available ? Qt.PointingHandCursor : Qt.ForbiddenCursor
+      onClicked: if (nr.available && !nr.selected) { nr.forceActiveFocus(); nr.chosen() }
+    }
+  }
+
+  // Numbered font picker row — like NumberedRadioRow but the label and a
+  // short sample render in the font itself so the user can preview each
+  // typeface. No trailing status; selection is implicit via accent color.
+  component FontPickerRow: Item {
+    id: fpr
+    property int rowIndex: 0
+    property string fontFamilyName: ""
+    property bool selected: false
+    signal chosen()
+
+    implicitHeight: 30
+    activeFocusOnTab: true
+
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = ""
+        root.selectedIndex = -1
+      }
+    }
+
+    Keys.onReturnPressed: if (!fpr.selected) fpr.chosen()
+    Keys.onEnterPressed:  if (!fpr.selected) fpr.chosen()
+    Keys.onSpacePressed:  if (!fpr.selected) fpr.chosen()
+
+    Rectangle {
+      anchors.fill: parent
+      color: fpr.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (fprArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    Text {
+      text: fpr.activeFocus ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      anchors.left: parent.left
+      anchors.leftMargin: 6
+      anchors.verticalCenter: parent.verticalCenter
+      width: 12
+    }
+
+    Text {
+      text: root.padTwo(fpr.rowIndex + 1)
+      color: Qt.darker(root.foreground, 1.9)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 24
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: fprRadio
+      text: fpr.selected ? "(●)" : "( )"
+      color: fpr.selected ? root.accent : Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 52
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: fprName
+      text: fpr.fontFamilyName
+      color: fpr.selected ? root.accent : root.foreground
+      font.family: fpr.fontFamilyName
+      font.pixelSize: 13
+      font.bold: fpr.selected
+      anchors.left: fprRadio.right
+      anchors.leftMargin: 10
+      anchors.verticalCenter: parent.verticalCenter
+      elide: Text.ElideRight
+      width: 230
+    }
+
+    Text {
+      text: "The quick brown fox 0123"
+      color: Qt.darker(root.foreground, 1.4)
+      font.family: fpr.fontFamilyName
+      font.pixelSize: 12
+      anchors.right: parent.right
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+      elide: Text.ElideRight
+    }
+
+    MouseArea {
+      id: fprArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: if (!fpr.selected) { fpr.forceActiveFocus(); fpr.chosen() }
+    }
+  }
+
+  // Inline chip — `[Label]` when selected, ` Label ` otherwise. Used for
+  // chip rows (corners / scaling / power profile).
+  component BracketChip: Item {
+    id: bc
+    property string label: ""
+    property bool selected: false
+    signal clicked()
+
+    activeFocusOnTab: true
+
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = ""
+        root.selectedIndex = -1
+      }
+    }
+
+    Keys.onReturnPressed: bc.clicked()
+    Keys.onEnterPressed:  bc.clicked()
+    Keys.onSpacePressed:  bc.clicked()
+
+    implicitWidth: bcLabel.implicitWidth + 14
+    implicitHeight: 24
+
+    Rectangle {
+      anchors.fill: parent
+      color: bc.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (bcArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    Text {
+      id: bcLabel
+      anchors.centerIn: parent
+      text: bc.selected ? "[" + bc.label + "]" : bc.label
+      color: bc.selected ? root.accent : Qt.darker(root.foreground, 1.1)
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: bc.selected
+    }
+
+    MouseArea {
+      id: bcArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: { bc.forceActiveFocus(); bc.clicked() }
+    }
+  }
+
   // ===================== bar layout pieces =================================
-  component SectionEditor: Column {
+  // Bracketed-frame section. The title and "+ Add" affordance are notched
+  // into the top border line; the inner column holds the widget rows.
+  component SectionEditor: Item {
     id: section
 
     property string sectionKey: ""
     property string sectionLabel: ""
+    property int sectionIndex: 0
     property var entries: root.sectionArray(section.sectionKey)
+    // Top inset: room for the notched label to sit half-above the frame.
+    readonly property int notchH: 16
+
     Layout.fillWidth: true
-    Layout.topMargin: 8
-    spacing: 8
+    implicitHeight: section.notchH / 2 + innerColumn.implicitHeight + 26
 
     Connections {
       target: root
       function onDraftRevisionChanged() { section.entries = root.sectionArray(section.sectionKey) }
     }
 
-    Row {
-      width: section.width
-      spacing: 8
+    // The frame itself. Starts below the notch line so the label can punch
+    // through the top border cleanly.
+    Rectangle {
+      id: sectionFrame
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.topMargin: section.notchH / 2
+      anchors.bottom: parent.bottom
+      color: "transparent"
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+      border.width: 1
+      radius: root.cornerRadius
+    }
+
+    // Left notch: "[N] Bar · Section · K widgets"
+    Rectangle {
+      anchors.left: parent.left
+      anchors.leftMargin: 18
+      anchors.top: parent.top
+      width: sectionLabel.implicitWidth + 16
+      height: section.notchH
+      color: root.background
 
       Text {
-        text: section.sectionLabel
+        id: sectionLabel
+        anchors.centerIn: parent
+        text: "[" + section.sectionIndex + "] " + section.sectionLabel
+              + "  ·  " + section.entries.length
+              + (section.entries.length === 1 ? " widget" : " widgets")
         color: root.foreground
         font.family: root.fontFamily
-        font.pixelSize: 13
-        font.bold: true
-        anchors.verticalCenter: parent.verticalCenter
-      }
-
-      Text {
-        text: "·  " + section.entries.length + (section.entries.length === 1 ? " widget" : " widgets")
-        color: Qt.darker(root.foreground, 1.5)
-        font.family: root.fontFamily
-        font.pixelSize: 11
-        anchors.verticalCenter: parent.verticalCenter
-      }
-
-      Item {
-        width: Math.max(0, section.width - 200 - 100)
-        height: 1
-      }
-
-      ActionPill {
-        id: addPill
-        text: "+ Add widget"
-        onClicked: addPopup.open()
+        font.pixelSize: 12
       }
     }
 
-    // Styled add-widget popup. Anchored under the "+ Add widget" pill,
-    // pulls fresh data from the host's availableToAdd() each open.
+    // Add-widget popup. Anchored under the "+ Add widget" placeholder row
+    // at the bottom of the section (see innerColumn below). Pulls fresh
+    // availability data each time it opens.
     Popup {
       id: addPopup
-      parent: addPill
-      x: addPill.width - width
-      y: addPill.height + 4
-      width: 280
+      parent: addRow
+      x: 0
+      y: addRow.height + 4
+      width: Math.max(300, section.width - 28)
       implicitHeight: Math.min(addList.contentHeight + 2, 340)
       padding: 1
       modal: false
@@ -2023,7 +2661,7 @@ Item {
 
       background: Rectangle {
         color: root.background
-        border.color: root.foreground
+        border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.7)
         border.width: 1
         radius: root.cornerRadius
       }
@@ -2037,16 +2675,16 @@ Item {
         delegate: Rectangle {
           required property var modelData
           width: addList.width
-          height: 36
+          height: 38
           color: addArea.containsMouse
-            ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.18)
             : "transparent"
 
           Column {
             anchors.left: parent.left
             anchors.right: parent.right
-            anchors.leftMargin: 10
-            anchors.rightMargin: 10
+            anchors.leftMargin: 12
+            anchors.rightMargin: 12
             anchors.verticalCenter: parent.verticalCenter
             spacing: 1
 
@@ -2056,7 +2694,7 @@ Item {
                 + (modelData.elsewhere ? "  (elsewhere)" : "")
               color: root.foreground
               font.family: root.fontFamily
-              font.pixelSize: 12
+              font.pixelSize: 13
               elide: Text.ElideRight
               width: parent.width
             }
@@ -2065,7 +2703,7 @@ Item {
               text: modelData.description || ""
               color: Qt.darker(root.foreground, 1.5)
               font.family: root.fontFamily
-              font.pixelSize: 10
+              font.pixelSize: 11
               elide: Text.ElideRight
               width: parent.width
             }
@@ -2085,45 +2723,357 @@ Item {
       }
     }
 
+    // Interior rows + the trailing "+ Add widget" placeholder.
     Column {
-      Layout.fillWidth: true
-      width: section.width
-      spacing: 4
+      id: innerColumn
+      anchors.left: sectionFrame.left
+      anchors.right: sectionFrame.right
+      anchors.top: sectionFrame.top
+      anchors.leftMargin: 14
+      anchors.rightMargin: 14
+      anchors.topMargin: 14
+      spacing: 2
 
       Repeater {
         model: section.entries
-        delegate: WidgetCard {
+        delegate: WidgetRow {
           required property var modelData
           required property int index
-          width: section.width
+          width: innerColumn.width
           sectionKey: section.sectionKey
           entryIndex: index
           entry: modelData
         }
       }
 
-      Rectangle {
-        visible: section.entries.length === 0
-        width: parent.width
-        height: 32
-        radius: root.cornerRadius
-        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
-        border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
-        border.width: 1
+      // Placeholder "+ Add widget" row. Looks like a widget row but dimmer.
+      // Number prefix continues the section's sequence so the eye reads it as
+      // "this is where the next widget would land". Also accepts mouse-drag
+      // drops as an "append to this section" target — important for empty
+      // sections where there's no row to drop on.
+      Item {
+        id: addRow
+        width: innerColumn.width
+        height: 26
+        activeFocusOnTab: true
+
+        // True while a foreign widget is being dragged over this row, so we
+        // can render the insertion-line cue.
+        property bool dropActive: false
+
+        // Clear bar-row selection when this placeholder takes focus, so that
+        // dd / J/K / 1-3 don't accidentally act on the previous widget.
+        onActiveFocusChanged: {
+          if (activeFocus) {
+            root.selectedSection = ""
+            root.selectedIndex = -1
+          }
+        }
+
+        Keys.onReturnPressed: addPopup.open()
+        Keys.onEnterPressed: addPopup.open()
+        Keys.onSpacePressed: addPopup.open()
+
+        Rectangle {
+          anchors.fill: parent
+          color: addRow.activeFocus
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.10)
+            : (addArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+          radius: root.cornerRadius
+          Behavior on color { ColorAnimation { duration: 80 } }
+        }
+
+        // Insertion-line cue while a widget is hovered over this row. Drawn
+        // at the top because the drop lands "above" the placeholder — i.e.
+        // appended to the section's last real widget.
+        Rectangle {
+          visible: addRow.dropActive
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.top: parent.top
+          height: 2
+          color: root.accent
+          z: 10
+        }
 
         Text {
-          anchors.centerIn: parent
-          text: "Empty — add a widget"
-          color: Qt.darker(root.foreground, 1.5)
+          text: addRow.activeFocus ? "▶" : ""
+          color: root.accent
           font.family: root.fontFamily
           font.pixelSize: 11
+          anchors.left: parent.left
+          anchors.leftMargin: 6
+          anchors.verticalCenter: parent.verticalCenter
+          width: 12
+        }
+
+        Text {
+          text: root.padTwo(section.entries.length + 1)
+          color: Qt.darker(root.foreground, 1.9)
+          font.family: root.fontFamily
+          font.pixelSize: 12
+          anchors.left: parent.left
+          anchors.leftMargin: 24
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+          text: "+ Add widget"
+          color: addArea.containsMouse || addRow.activeFocus
+            ? root.accent
+            : Qt.darker(root.foreground, 1.5)
+          font.family: root.fontFamily
+          font.pixelSize: 13
+          font.italic: true
+          anchors.left: parent.left
+          anchors.leftMargin: 56
+          anchors.verticalCenter: parent.verticalCenter
+          Behavior on color { ColorAnimation { duration: 80 } }
+        }
+
+        MouseArea {
+          id: addArea
+          anchors.fill: parent
+          hoverEnabled: true
+          cursorShape: Qt.PointingHandCursor
+          onClicked: { addRow.forceActiveFocus(); addPopup.open() }
+        }
+
+        DropArea {
+          anchors.fill: parent
+          keys: ["omarchy-bar-widget"]
+
+          onEntered: (drag) => {
+            if (!drag.source
+                || drag.source.sourceSection === undefined
+                || drag.source.sourceIndex === undefined) {
+              addRow.dropActive = false
+              return
+            }
+            addRow.dropActive = true
+          }
+          onExited: addRow.dropActive = false
+
+          onDropped: (drop) => {
+            addRow.dropActive = false
+            if (!drop.source
+                || drop.source.sourceSection === undefined
+                || drop.source.sourceIndex === undefined) {
+              drop.accepted = false
+              return
+            }
+            // Append to the end of this section.
+            root.dropWidget(drop.source.sourceSection, drop.source.sourceIndex,
+                            section.sectionKey, section.entries.length)
+            drop.accept(Qt.MoveAction)
+          }
         }
       }
     }
   }
 
-  component WidgetCard: Rectangle {
-    id: card
+  // Bracketed radio-selector — same frame chrome as SectionEditor, but the
+  // body is a list of `( ) / (●)` options instead of widget rows. Used for
+  // Position / Center anchor (and any future single-choice setting).
+  component RadioSelector: Item {
+    id: rs
+
+    property string sectionLabel: ""
+    property string sectionMeta: ""
+    property int sectionIndex: 0
+    property var options: []
+    property string value: ""
+    signal changed(string newValue)
+
+    readonly property int notchH: 16
+
+    Layout.fillWidth: true
+    implicitHeight: rs.notchH / 2 + rsInner.implicitHeight + 26
+
+    // Frame — identical to SectionEditor's so the two read as siblings.
+    Rectangle {
+      id: rsFrame
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.topMargin: rs.notchH / 2
+      anchors.bottom: parent.bottom
+      color: "transparent"
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+      border.width: 1
+      radius: root.cornerRadius
+    }
+
+    // Left notch label: "[N] LABEL · meta"
+    Rectangle {
+      anchors.left: parent.left
+      anchors.leftMargin: 18
+      anchors.top: parent.top
+      width: rsLabel.implicitWidth + 16
+      height: rs.notchH
+      color: root.background
+
+      Text {
+        id: rsLabel
+        anchors.centerIn: parent
+        text: "[" + rs.sectionIndex + "] " + rs.sectionLabel
+              + (rs.sectionMeta !== "" ? "  ·  " + rs.sectionMeta : "")
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: 12
+      }
+    }
+
+    Column {
+      id: rsInner
+      anchors.left: rsFrame.left
+      anchors.right: rsFrame.right
+      anchors.top: rsFrame.top
+      anchors.leftMargin: 14
+      anchors.rightMargin: 14
+      anchors.topMargin: 14
+      spacing: 2
+
+      Repeater {
+        model: rs.options
+        delegate: RadioOption {
+          required property var modelData
+          required property int index
+          width: rsInner.width
+          optionData: modelData
+          optionIndex: index
+          selected: rs.value === modelData.value
+          onChosen: rs.changed(modelData.value)
+        }
+      }
+    }
+  }
+
+  // One row inside a RadioSelector. `( )` for unselected, `(●)` for the
+  // currently-applied option. Focusable; Enter / Space / click commits.
+  component RadioOption: Item {
+    id: opt
+    property var optionData: ({})
+    property int optionIndex: 0
+    property bool selected: false
+    signal chosen()
+
+    implicitHeight: 26
+    activeFocusOnTab: true
+
+    // When focused, this isn't a "widget" the dd/J/K/1-3 bindings apply to,
+    // so clear the bar-row selection just like the Add-widget placeholder.
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = ""
+        root.selectedIndex = -1
+      }
+    }
+
+    Keys.onReturnPressed: opt.chosen()
+    Keys.onEnterPressed:  opt.chosen()
+    Keys.onSpacePressed:  opt.chosen()
+
+    Rectangle {
+      anchors.fill: parent
+      color: opt.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (optArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    Text {
+      text: opt.activeFocus ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      anchors.left: parent.left
+      anchors.leftMargin: 6
+      anchors.verticalCenter: parent.verticalCenter
+      width: 12
+    }
+
+    Text {
+      text: root.padTwo(opt.optionIndex + 1)
+      color: Qt.darker(root.foreground, 1.9)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 24
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Radio circle — accent-tinted when selected.
+    Text {
+      id: radio
+      text: opt.selected ? "(●)" : "( )"
+      color: opt.selected ? root.accent : Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 52
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Option label.
+    Text {
+      id: optLabel
+      text: opt.optionData.label || opt.optionData.value || ""
+      color: opt.selected ? root.foreground : Qt.darker(root.foreground, 1.15)
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: opt.selected || opt.activeFocus
+      anchors.left: radio.right
+      anchors.leftMargin: 10
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Inline description.
+    Text {
+      text: opt.optionData.description || ""
+      color: Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: optLabel.right
+      anchors.leftMargin: 14
+      anchors.right: appliedLabel.left
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+      elide: Text.ElideRight
+    }
+
+    // Trailing status — only the currently-selected option shows "applied".
+    Text {
+      id: appliedLabel
+      visible: opt.selected
+      text: "applied"
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.right: parent.right
+      anchors.rightMargin: 12
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    MouseArea {
+      id: optArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: { opt.forceActiveFocus(); opt.chosen() }
+    }
+  }
+
+  // A single widget row inside a section frame. Numbered prefix on the left,
+  // name + description in the middle, [↕] [⚙] [×] action chips on the right.
+  // Focusable: when focused, marks itself as the "selected" widget so the
+  // modeline + section header reflect it, and the J/K/1-3/dd shortcuts act
+  // on it. Also draggable: press-and-drag past a small threshold begins a
+  // mouse reorder; insertion is shown as a thin accent line on the target
+  // row (above/below cursor midpoint) or the "+ Add widget" placeholder.
+  component WidgetRow: Item {
+    id: row
     property string sectionKey: ""
     property int entryIndex: -1
     property var entry: ({})
@@ -2131,86 +3081,336 @@ Item {
     readonly property string displayName: root.widgetName(entryId)
     readonly property string description: root.widgetDescription(entryId)
     readonly property bool hasSettings: root.widgetHasSettings(entryId)
+    // Marker so refocusSelected() can pick rows out of the focusables list
+    // without false-matching unrelated controls.
+    readonly property bool barRowMarker: true
 
-    implicitHeight: 50
-    radius: root.cornerRadius
-    color: cardArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08) : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03)
-    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
-    border.width: 1
+    // Drag-hover state used to render the insertion line. -1 = above this
+    // row, 1 = below this row, 0 = no drop hover. Always 0 on the source row
+    // of an in-flight drag.
+    property int dropHoverSide: 0
 
-    Behavior on color { ColorAnimation { duration: 100 } }
+    // True when this row IS the one being dragged via the shared dragGhost.
+    // Used to dim the source slot so the floating chip is the visual anchor.
+    readonly property bool isDragSource: dragGhost.Drag.active
+                                         && dragGhost.sourceSection === row.sectionKey
+                                         && dragGhost.sourceIndex === row.entryIndex
 
-    Row {
-      id: actionRow
-      anchors.right: parent.right
-      anchors.rightMargin: 8
-      anchors.verticalCenter: parent.verticalCenter
-      spacing: 4
+    implicitHeight: 26
+    activeFocusOnTab: true
+    opacity: row.isDragSource ? 0.35 : 1.0
+    Behavior on opacity { NumberAnimation { duration: 90 } }
 
-      IconButton {
-        glyph: "↑"
-        tooltip: "Move up"
-        onClicked: root.moveEntry(card.sectionKey, card.entryIndex, card.entryIndex - 1)
-      }
-      IconButton {
-        glyph: "↓"
-        tooltip: "Move down"
-        onClicked: root.moveEntry(card.sectionKey, card.entryIndex, card.entryIndex + 1)
-      }
-      IconButton {
-        glyph: "⚙"
-        tooltip: "Settings"
-        visible: card.hasSettings
-        onClicked: settingsLoader.open(card.entry)
-      }
-      IconButton {
-        glyph: "✕"
-        tooltip: "Remove"
-        foreground: root.urgent
-        onClicked: root.removeEntry(card.sectionKey, card.entryIndex)
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = row.sectionKey
+        root.selectedIndex = row.entryIndex
       }
     }
 
-    Column {
-      anchors.left: parent.left
-      anchors.right: actionRow.left
-      anchors.leftMargin: 12
-      anchors.rightMargin: 12
-      anchors.verticalCenter: parent.verticalCenter
-      spacing: 2
+    Keys.onReturnPressed: if (row.hasSettings) settingsLoader.open(row.entry)
+    Keys.onEnterPressed:  if (row.hasSettings) settingsLoader.open(row.entry)
 
-      Text {
-        text: card.displayName
-        color: root.foreground
-        font.family: root.fontFamily
-        font.pixelSize: 12
-        font.bold: true
-        elide: Text.ElideRight
-        width: parent.width
+    // Selection background. Subtle accent tint when focused; light hover
+    // tint otherwise.
+    Rectangle {
+      anchors.fill: parent
+      color: row.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (rowArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    // Insertion-line indicators. Rendered on the row being hovered as a
+    // drop target — never on the row being dragged (dropHoverSide is gated
+    // against drag.source === row in the DropArea handlers below).
+    Rectangle {
+      visible: row.dropHoverSide === -1
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      height: 2
+      color: root.accent
+      z: 10
+    }
+    Rectangle {
+      visible: row.dropHoverSide === 1
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      height: 2
+      color: root.accent
+      z: 10
+    }
+
+    // ▶ selection caret. Always occupies the same column so labels don't
+    // shift between focused / unfocused.
+    Text {
+      text: row.activeFocus ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      anchors.left: parent.left
+      anchors.leftMargin: 6
+      anchors.verticalCenter: parent.verticalCenter
+      width: 12
+    }
+
+    // Numeric prefix (01, 02, ...) — vim-style line numbers.
+    Text {
+      id: numberLabel
+      text: root.padTwo(row.entryIndex + 1)
+      color: Qt.darker(root.foreground, 1.8)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 24
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Widget display name.
+    Text {
+      id: nameLabel
+      text: row.displayName
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: row.activeFocus
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    // Inline description.
+    Text {
+      text: row.description
+      color: Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: nameLabel.right
+      anchors.leftMargin: 14
+      anchors.right: actionRow.left
+      anchors.rightMargin: 14
+      anchors.verticalCenter: parent.verticalCenter
+      elide: Text.ElideRight
+    }
+
+    // Action chips: [ ↕ ] reorder · [ * ] settings · [ × ] remove. Bracket
+    // colors track each chip's glyph color so the whole chip reads as one
+    // semantic unit. Mouse users get a click affordance on each chip.
+    Row {
+      id: actionRow
+      anchors.right: parent.right
+      anchors.rightMargin: 6
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: 8
+
+      BracketIcon {
+        glyph: "↕"
+        tooltip: "Move down (or J/K to reorder)"
+        foreground: Qt.darker(root.foreground, 1.25)
+        onClicked: {
+          var arr = root.sectionArray(row.sectionKey)
+          var next = (row.entryIndex + 1) % arr.length
+          if (next !== row.entryIndex) {
+            root.selectedSection = row.sectionKey
+            root.selectedIndex = row.entryIndex
+            root.moveEntry(row.sectionKey, row.entryIndex, next)
+            root.selectedIndex = next
+            Qt.callLater(root.refocusSelected)
+          }
+        }
       }
-      Text {
-        visible: text !== ""
-        text: card.description
-        color: Qt.darker(root.foreground, 1.5)
-        font.family: root.fontFamily
-        font.pixelSize: 10
-        elide: Text.ElideRight
-        width: parent.width
+      BracketIcon {
+        glyph: "*"
+        tooltip: "Widget settings"
+        foreground: root.accent
+        visible: row.hasSettings
+        // Reserve space when invisible so the × column doesn't shift.
+        opacity: row.hasSettings ? 1 : 0
+        enabled: row.hasSettings
+        onClicked: settingsLoader.open(row.entry)
+      }
+      BracketIcon {
+        glyph: "×"
+        tooltip: "Remove (or dd)"
+        foreground: root.urgent
+        onClicked: root.removeEntry(row.sectionKey, row.entryIndex)
       }
     }
 
     MouseArea {
-      id: cardArea
+      id: rowArea
       anchors.fill: parent
       hoverEnabled: true
-      acceptedButtons: Qt.NoButton
+      acceptedButtons: Qt.LeftButton
+      cursorShape: rowArea.dragging ? Qt.ClosedHandCursor : Qt.PointingHandCursor
+
+      // Press position cached so we only flip into drag mode once the
+      // cursor has moved past a small threshold — keeps clicks distinct
+      // from drags so the row still focuses on a stationary press.
+      property real pressX: 0
+      property real pressY: 0
+      property bool dragging: false
+
+      // Reposition the shared ghost in panelContent-local coords so the
+      // chip tracks the cursor across every section (DropArea events fire
+      // off the dragged item's scene position, not the cursor's).
+      function moveGhostToMouse(mouse) {
+        var p = rowArea.mapToItem(panelContent, mouse.x, mouse.y)
+        dragGhost.x = p.x - dragGhost.width / 2
+        dragGhost.y = p.y - dragGhost.height / 2
+      }
+
+      onPressed: (mouse) => {
+        rowArea.pressX = mouse.x
+        rowArea.pressY = mouse.y
+        rowArea.dragging = false
+        row.forceActiveFocus()
+      }
+
+      onPositionChanged: (mouse) => {
+        if (!rowArea.pressed) return
+        if (!rowArea.dragging) {
+          if (Math.abs(mouse.x - rowArea.pressX) > 6
+              || Math.abs(mouse.y - rowArea.pressY) > 6) {
+            rowArea.dragging = true
+            dragGhost.sourceSection = row.sectionKey
+            dragGhost.sourceIndex = row.entryIndex
+            dragGhost.sourceName = row.displayName
+            rowArea.moveGhostToMouse(mouse)
+            dragGhost.Drag.start()
+          }
+        } else {
+          rowArea.moveGhostToMouse(mouse)
+        }
+      }
+
+      onReleased: {
+        if (!rowArea.dragging) return
+        // Commit to whichever DropArea is under the cursor; if none,
+        // Drag.drop() is a no-op and the layout is unchanged. The ghost's
+        // visibility unbinds from Drag.active so the chip clears itself.
+        dragGhost.Drag.drop()
+        rowArea.dragging = false
+      }
+
+      onCanceled: {
+        if (!rowArea.dragging) return
+        dragGhost.Drag.cancel()
+        rowArea.dragging = false
+      }
+
+      onClicked: if (!rowArea.dragging) row.forceActiveFocus()
+    }
+
+    // Accepts drops from the dragGhost chip. The insertion side is decided
+    // by cursor Y relative to the row's midpoint, surfaced as `dropHoverSide`
+    // so the insertion line renders above or below. Skipped when this row
+    // is the drag source (dropping onto yourself is a no-op).
+    DropArea {
+      anchors.fill: parent
+      keys: ["omarchy-bar-widget"]
+
+      function isOwnSource(drag) {
+        return drag && drag.source
+            && drag.source.sourceSection === row.sectionKey
+            && drag.source.sourceIndex === row.entryIndex
+      }
+
+      onEntered: (drag) => {
+        if (isOwnSource(drag)) { row.dropHoverSide = 0; return }
+        row.dropHoverSide = drag.y < row.height / 2 ? -1 : 1
+      }
+
+      onPositionChanged: (drag) => {
+        if (isOwnSource(drag)) { row.dropHoverSide = 0; return }
+        row.dropHoverSide = drag.y < row.height / 2 ? -1 : 1
+      }
+
+      onExited: row.dropHoverSide = 0
+
+      onDropped: (drop) => {
+        var side = row.dropHoverSide
+        row.dropHoverSide = 0
+        if (!drop.source
+            || drop.source.sourceSection === undefined
+            || drop.source.sourceIndex === undefined) {
+          drop.accepted = false
+          return
+        }
+        if (drop.source.sourceSection === row.sectionKey
+            && drop.source.sourceIndex === row.entryIndex) {
+          drop.accepted = false
+          return
+        }
+        var targetIdx = row.entryIndex + (side > 0 ? 1 : 0)
+        root.dropWidget(drop.source.sourceSection, drop.source.sourceIndex,
+                        row.sectionKey, targetIdx)
+        drop.accept(Qt.MoveAction)
+      }
     }
 
     SettingsDialog {
       id: settingsLoader
       anchorWindow: window
-      sectionKey: card.sectionKey
-      entryIndex: card.entryIndex
+      sectionKey: row.sectionKey
+      entryIndex: row.entryIndex
+    }
+  }
+
+  // [ X ] chip — bracketed glyph button. Sized for a comfortable row of three.
+  // Bracket color tracks the glyph color so the whole chip reads as a single
+  // semantic unit (urgent-red for remove, accent for settings, neutral for
+  // reorder). Internal padding gives `[ X ]` rather than `[X]`.
+  component BracketIcon: Item {
+    id: bi
+    property string glyph: ""
+    property string tooltip: ""
+    property color foreground: root.foreground
+    // Brackets dim toward the glyph color when not hovered, then brighten on
+    // hover to mirror the glyph itself.
+    readonly property color bracketColor: Qt.rgba(bi.foreground.r, bi.foreground.g, bi.foreground.b, 0.55)
+    signal clicked()
+
+    implicitWidth: chip.implicitWidth + 6
+    implicitHeight: 22
+
+    Row {
+      id: chip
+      anchors.centerIn: parent
+      spacing: 5
+
+      Text {
+        text: "["
+        color: biArea.containsMouse ? bi.foreground : bi.bracketColor
+        font.family: root.fontFamily
+        font.pixelSize: 13
+        Behavior on color { ColorAnimation { duration: 80 } }
+      }
+      Text {
+        text: bi.glyph
+        color: bi.foreground
+        font.family: root.fontFamily
+        font.pixelSize: 13
+        font.bold: biArea.containsMouse
+      }
+      Text {
+        text: "]"
+        color: biArea.containsMouse ? bi.foreground : bi.bracketColor
+        font.family: root.fontFamily
+        font.pixelSize: 13
+        Behavior on color { ColorAnimation { duration: 80 } }
+      }
+    }
+
+    MouseArea {
+      id: biArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: bi.clicked()
     }
   }
 
@@ -2264,7 +3464,7 @@ Item {
             text: root.widgetName(dialog.workingEntry.id || "")
             color: root.foreground
             font.family: root.fontFamily
-            font.pixelSize: 14
+            font.pixelSize: 15
             font.bold: true
           }
 
@@ -2272,7 +3472,7 @@ Item {
             text: root.widgetDescription(dialog.workingEntry.id || "")
             color: Qt.darker(root.foreground, 1.4)
             font.family: root.fontFamily
-            font.pixelSize: 11
+            font.pixelSize: 12
             wrapMode: Text.WordWrap
             Layout.fillWidth: true
           }
@@ -2390,7 +3590,7 @@ Item {
         text: "Size (pixels)"
         color: Qt.darker(root.foreground, 1.4)
         font.family: root.fontFamily
-        font.pixelSize: 11
+        font.pixelSize: 12
       }
 
       SpinBox {
@@ -2417,7 +3617,7 @@ Item {
         id: calField
         property string fieldKey: ""
         font.family: root.fontFamily
-        font.pixelSize: 12
+        font.pixelSize: 13
         width: parent.width
         color: root.foreground
         selectionColor: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.35)
@@ -2442,7 +3642,7 @@ Item {
         text: "Horizontal format"
         color: Qt.darker(root.foreground, 1.4)
         font.family: root.fontFamily
-        font.pixelSize: 11
+        font.pixelSize: 12
       }
       CalendarField {
         fieldKey: "format"
@@ -2453,7 +3653,7 @@ Item {
         text: "Alternate format (click to swap)"
         color: Qt.darker(root.foreground, 1.4)
         font.family: root.fontFamily
-        font.pixelSize: 11
+        font.pixelSize: 12
       }
       CalendarField {
         fieldKey: "formatAlt"
@@ -2464,7 +3664,7 @@ Item {
         text: "Vertical format (left/right bars)"
         color: Qt.darker(root.foreground, 1.4)
         font.family: root.fontFamily
-        font.pixelSize: 11
+        font.pixelSize: 12
       }
       CalendarField {
         fieldKey: "verticalFormat"
@@ -2488,7 +3688,7 @@ Item {
         text: "Auto-refresh interval (minutes)"
         color: Qt.darker(root.foreground, 1.4)
         font.family: root.fontFamily
-        font.pixelSize: 11
+        font.pixelSize: 12
       }
 
       SpinBox {
@@ -2501,7 +3701,7 @@ Item {
   }
 
   // ===================== plugins category ==================================
-  component PluginManager: Column {
+  component PluginManager: ColumnLayout {
     id: pm
 
     property int registryRevision: root.pluginRegistry ? root.pluginRegistry.registryRevision : 0
@@ -2533,204 +3733,293 @@ Item {
       return rows
     }
 
+    function firstPartyList() {
+      return pm.pluginList().filter(function(p) { return p.firstParty })
+    }
+    function thirdPartyList() {
+      return pm.pluginList().filter(function(p) { return !p.firstParty })
+    }
+    function loadedCount() {
+      var list = pm.pluginList()
+      var n = 0
+      for (var i = 0; i < list.length; i++) if (list[i].enabled) n++
+      return n
+    }
+
     spacing: 14
     Layout.fillWidth: true
-    width: parent ? parent.width : 0
-
-    Text {
-      text: "Plugins"
-      color: root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: 18
-      font.bold: true
-    }
-
-    Text {
-      text: "Drop plugins at ~/.config/omarchy/plugins/<plugin-id>/, then click Rescan. First-party plugins are always enabled."
-      color: Qt.darker(root.foreground, 1.6)
-      font.family: root.fontFamily
-      font.pixelSize: 11
-      wrapMode: Text.WordWrap
-      width: pm.width
-    }
 
     Row {
-      spacing: 8
-      width: pm.width
+      Layout.fillWidth: true
+      spacing: 12
 
       Text {
-        text: (root.pluginRegistry ? Object.keys(root.pluginRegistry.installedPlugins).length : 0) + " installed"
+        text: {
+          var total = pm.pluginList().length
+          var loaded = pm.loadedCount()
+          return total + " installed  ·  " + loaded + " loaded"
+        }
         color: Qt.darker(root.foreground, 1.3)
         font.family: root.fontFamily
-        font.pixelSize: 11
+        font.pixelSize: 12
         anchors.verticalCenter: parent.verticalCenter
       }
 
-      Item { width: Math.max(0, pm.width - 200); height: 1 }
+      Item {
+        height: 1
+        width: Math.max(0, pm.width - rescanPill.width - rescanCount.implicitWidth - 24)
+      }
+
+      Text {
+        id: rescanCount
+        visible: false
+        text: pm.pluginList().length + " installed"
+      }
 
       ActionPill {
-        text: "Rescan"
-        onClicked: root.pluginRegistry.rescan()
+        id: rescanPill
+        anchors.verticalCenter: parent.verticalCenter
+        text: "[r] Rescan"
+        onClicked: if (root.pluginRegistry) root.pluginRegistry.rescan()
       }
     }
 
-    Repeater {
-      model: pm.pluginList()
-      delegate: PluginRow {
-        required property var modelData
-        width: pm.width
-        manifest: modelData.manifest
-        pluginId: modelData.id
-        pluginEnabled: modelData.enabled
-        firstParty: modelData.firstParty
+    BracketedFrame {
+      sectionIndex: 1
+      sectionLabel: "FIRST-PARTY"
+      sectionMeta: pm.firstPartyList().length + " plugins  ·  always enabled"
+
+      Repeater {
+        model: pm.firstPartyList()
+        delegate: PluginInfoRow {
+          required property var modelData
+          required property int index
+          width: parent.width
+          rowIndex: index
+          manifest: modelData.manifest
+          pluginId: modelData.id
+          pluginEnabled: modelData.enabled
+          firstParty: modelData.firstParty
+          onToggleEnabled: if (!firstParty && root.pluginRegistry)
+            root.pluginRegistry.setEnabled(pluginId, !pluginEnabled)
+        }
+      }
+
+      Item {
+        visible: pm.firstPartyList().length === 0
+        width: parent.width
+        height: 24
+        Text {
+          anchors.centerIn: parent
+          text: "no first-party plugins"
+          color: Qt.darker(root.foreground, 1.6)
+          font.family: root.fontFamily
+          font.pixelSize: 12
+          font.italic: true
+        }
+      }
+    }
+
+    BracketedFrame {
+      sectionIndex: 2
+      sectionLabel: "THIRD-PARTY"
+      sectionMeta: pm.thirdPartyList().length + " plugins  ·  run at your own risk"
+
+      Repeater {
+        model: pm.thirdPartyList()
+        delegate: PluginInfoRow {
+          required property var modelData
+          required property int index
+          width: parent.width
+          rowIndex: index
+          manifest: modelData.manifest
+          pluginId: modelData.id
+          pluginEnabled: modelData.enabled
+          firstParty: modelData.firstParty
+          onToggleEnabled: if (!firstParty && root.pluginRegistry)
+            root.pluginRegistry.setEnabled(pluginId, !pluginEnabled)
+        }
+      }
+
+      Item {
+        visible: pm.thirdPartyList().length === 0
+        width: parent.width
+        height: 24
+        Text {
+          anchors.centerIn: parent
+          text: "no third-party plugins · drop folders into ~/.config/omarchy/plugins/"
+          color: Qt.darker(root.foreground, 1.6)
+          font.family: root.fontFamily
+          font.pixelSize: 12
+          font.italic: true
+        }
       }
     }
 
     Text {
-      visible: pm.pluginList().length === 0
-      text: "No plugins discovered yet."
-      color: Qt.darker(root.foreground, 1.5)
+      Layout.fillWidth: true
+      Layout.topMargin: 6
+      text: "# tip  ·  plugin source lives at ~/.config/omarchy/plugins/. Drop a folder there and run :scan (or press r)."
+      color: Qt.darker(root.foreground, 1.7)
       font.family: root.fontFamily
-      font.pixelSize: 11
+      font.pixelSize: 12
+      wrapMode: Text.WordWrap
     }
   }
 
-  component PluginRow: Rectangle {
-    id: row
+  // Numbered plugin row — two-line content. Line 1: name + version + author
+  // + trailing "loaded"/"disabled" + [x]/[ ]. Line 2: description (dim).
+  // First-party rows are non-interactive but still rendered (they're always
+  // on).
+  component PluginInfoRow: Item {
+    id: pir
+    property int rowIndex: 0
     property var manifest: ({})
     property string pluginId: ""
     property bool pluginEnabled: false
     property bool firstParty: false
-    property bool expanded: false
+    signal toggleEnabled()
 
-    activeFocusOnTab: !row.firstParty
-    Keys.onReturnPressed: if (!row.firstParty) root.pluginRegistry.setEnabled(row.pluginId, !row.pluginEnabled)
-    Keys.onEnterPressed: if (!row.firstParty) root.pluginRegistry.setEnabled(row.pluginId, !row.pluginEnabled)
-    Keys.onSpacePressed: if (!row.firstParty) root.pluginRegistry.setEnabled(row.pluginId, !row.pluginEnabled)
+    readonly property string displayName: (manifest && manifest.name) ? manifest.name : pluginId
+    readonly property string versionStr: (manifest && manifest.version) ? "v" + manifest.version : ""
+    readonly property string authorStr: (manifest && manifest.author)
+      ? manifest.author
+      : (firstParty ? "omarchy" : "third-party")
+    readonly property string descStr: (manifest && manifest.description) ? manifest.description : ""
 
-    radius: root.cornerRadius
-    color: row.activeFocus
-      ? root.focusFillColor
-      : (rowArea.containsMouse ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08) : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.03))
-    border.color: row.activeFocus ? root.focusBorderColor : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
-    border.width: row.activeFocus ? root.focusBorderWidth : 1
-    implicitHeight: rowContent.implicitHeight + 16
+    implicitHeight: descStr ? 42 : 26
+    activeFocusOnTab: !pir.firstParty
+    opacity: pir.firstParty ? 0.85 : 1
 
-    Behavior on color { ColorAnimation { duration: 100 } }
-
-    Column {
-      id: rowContent
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.top: parent.top
-      anchors.margins: 8
-      spacing: 4
-
-      Row {
-        spacing: 8
-        width: parent.width
-
-        Column {
-          spacing: 2
-          width: parent.width - 110
-
-          Text {
-            text: row.manifest && row.manifest.name ? row.manifest.name : row.pluginId
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: 12
-            font.bold: true
-            elide: Text.ElideRight
-            width: parent.width
-          }
-          Text {
-            text: {
-              var bits = []
-              if (row.manifest && row.manifest.version) bits.push("v" + row.manifest.version)
-              if (row.manifest && row.manifest.author) bits.push(row.manifest.author)
-              bits.push(row.firstParty ? "first-party" : "third-party")
-              return bits.join("  ·  ")
-            }
-            color: Qt.darker(root.foreground, 1.5)
-            font.family: root.fontFamily
-            font.pixelSize: 10
-          }
-          Text {
-            visible: !!(row.manifest && row.manifest.description)
-            text: row.manifest ? (row.manifest.description || "") : ""
-            color: Qt.darker(root.foreground, 1.3)
-            font.family: root.fontFamily
-            font.pixelSize: 10
-            wrapMode: Text.WordWrap
-            width: parent.width
-          }
-        }
-
-        Item { width: 8; height: 1 }
-
-        Item {
-          implicitWidth: enabledSwitch.implicitWidth
-          implicitHeight: enabledSwitch.implicitHeight
-          anchors.verticalCenter: parent.verticalCenter
-
-          Switch {
-            id: enabledSwitch
-            checked: row.pluginEnabled
-            enabled: !row.firstParty
-            opacity: row.firstParty ? 0.45 : 1
-            ToolTip.visible: row.firstParty && hoverArea.containsMouse
-            ToolTip.delay: 300
-            ToolTip.text: "First-party plugin — always enabled"
-            onToggled: root.pluginRegistry.setEnabled(row.pluginId, checked)
-          }
-
-          MouseArea {
-            id: hoverArea
-            anchors.fill: parent
-            hoverEnabled: true
-            acceptedButtons: Qt.NoButton
-            visible: row.firstParty
-            cursorShape: Qt.ForbiddenCursor
-          }
-        }
-      }
-
-      Row {
-        visible: !!(row.manifest && row.manifest.barWidget && Array.isArray(row.manifest.barWidget.schema) && row.manifest.barWidget.schema.length > 0)
-        spacing: 6
-
-        Text {
-          text: row.expanded ? "▾ Options" : "▸ Options"
-          color: Qt.darker(root.foreground, 1.4)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-
-          MouseArea {
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-            onClicked: row.expanded = !row.expanded
-          }
-        }
-      }
-
-      Repeater {
-        model: row.expanded && row.manifest && row.manifest.barWidget && Array.isArray(row.manifest.barWidget.schema) ? row.manifest.barWidget.schema : []
-        delegate: Text {
-          required property var modelData
-          text: "• " + (modelData.label || modelData.key) + " (" + (modelData.type || "string") + ")"
-          color: Qt.darker(root.foreground, 1.3)
-          font.family: root.fontFamily
-          font.pixelSize: 10
-          leftPadding: 12
-        }
+    onActiveFocusChanged: {
+      if (activeFocus) {
+        root.selectedSection = ""
+        root.selectedIndex = -1
       }
     }
 
+    Keys.onReturnPressed: if (!pir.firstParty) pir.toggleEnabled()
+    Keys.onEnterPressed:  if (!pir.firstParty) pir.toggleEnabled()
+    Keys.onSpacePressed:  if (!pir.firstParty) pir.toggleEnabled()
+
+    Rectangle {
+      anchors.fill: parent
+      color: pir.activeFocus
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+        : (pirArea.containsMouse && !pir.firstParty ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05) : "transparent")
+      radius: root.cornerRadius
+      Behavior on color { ColorAnimation { duration: 80 } }
+    }
+
+    Text {
+      text: pir.activeFocus ? "▶" : ""
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: 11
+      anchors.left: parent.left
+      anchors.leftMargin: 6
+      anchors.top: parent.top
+      anchors.topMargin: 6
+      width: 12
+    }
+
+    Text {
+      text: root.padTwo(pir.rowIndex + 1)
+      color: Qt.darker(root.foreground, 1.9)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 24
+      anchors.top: parent.top
+      anchors.topMargin: 6
+    }
+
+    Row {
+      id: titleRow
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.right: trailLabel.left
+      anchors.rightMargin: 12
+      anchors.top: parent.top
+      anchors.topMargin: 6
+      spacing: 8
+      clip: true
+
+      Text {
+        text: pir.displayName
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: 13
+        font.bold: true
+      }
+      Text {
+        visible: pir.versionStr !== ""
+        text: pir.versionStr
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: 12
+      }
+      Text {
+        text: "·"
+        color: Qt.darker(root.foreground, 1.7)
+        font.family: root.fontFamily
+        font.pixelSize: 12
+      }
+      Text {
+        text: pir.authorStr
+        color: Qt.darker(root.foreground, 1.5)
+        font.family: root.fontFamily
+        font.pixelSize: 12
+      }
+    }
+
+    Text {
+      visible: pir.descStr !== ""
+      text: pir.descStr
+      color: Qt.darker(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      anchors.left: parent.left
+      anchors.leftMargin: 56
+      anchors.right: parent.right
+      anchors.rightMargin: 12
+      anchors.top: titleRow.bottom
+      anchors.topMargin: 2
+      elide: Text.ElideRight
+    }
+
+    Text {
+      id: trailLabel
+      text: pir.pluginEnabled ? "loaded" : "disabled"
+      color: pir.pluginEnabled ? root.accent : Qt.darker(root.foreground, 1.6)
+      font.family: root.fontFamily
+      font.pixelSize: 12
+      font.bold: pir.pluginEnabled
+      anchors.right: trailSwitch.left
+      anchors.rightMargin: 8
+      anchors.top: parent.top
+      anchors.topMargin: 6
+    }
+
+    Text {
+      id: trailSwitch
+      text: pir.pluginEnabled ? "[x]" : "[ ]"
+      color: pir.pluginEnabled ? root.accent : Qt.darker(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: 13
+      font.bold: pir.pluginEnabled
+      anchors.right: parent.right
+      anchors.rightMargin: 12
+      anchors.top: parent.top
+      anchors.topMargin: 6
+    }
+
     MouseArea {
-      id: rowArea
+      id: pirArea
       anchors.fill: parent
       hoverEnabled: true
-      acceptedButtons: Qt.NoButton
+      cursorShape: pir.firstParty ? Qt.ForbiddenCursor : Qt.PointingHandCursor
+      onClicked: if (!pir.firstParty) { pir.forceActiveFocus(); pir.toggleEnabled() }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Redesigns the panel chrome to a TUI/vim aesthetic: `[ Omarchy Settings ] — v<ver>` title bar, sidebar without glyphs (just a `▶` marker on the active row, plus a footer showing current theme + status), `[N] LABEL · meta` notched-bracket section frames everywhere, and a vim-style modeline at the bottom that reads `:bar NORMAL  ·  3 left widgets  ·  Workspaces selected`.
- Adds full keyboard editing of the Bar tab: `J`/`K` reorder a focused widget within its section, `Shift+1/2/3` move it across left/center/right zones, `1`–`9` jump to the section with that bracket index, `dd` removes (vim-style with a ~700 ms timeout), and `?` opens a help overlay that lists every binding.
- Adds mouse drag-and-drop for bar widgets: press-and-drag past 6 px starts a floating "ghost" chip that follows the cursor; rows render an accent insertion line above/below the cursor midpoint, and the trailing `+ Add widget` placeholder accepts drops as "append to this section". Within-section drops reorder; cross-section drops respect the existing duplicate rules.
- Consolidates ad-hoc row components (`StyleToggleRow`, `StyleOptionTile`, `StyleChip`, `FontRow`, `DefaultsGroup`, `WidgetCard`, `PluginRow`) into a smaller, consistent set: `BracketedFrame`, `NumberedToggleRow`, `NumberedRadioRow`, `FontPickerRow`, `RadioSelector`/`RadioOption`, `BracketChip`, `BracketIcon`, `WidgetRow`, `PluginInfoRow`. Defaults / Style / System / Plugins all re-render through the new components — same data, same disk reads, same apply scripts.
- Plugins tab splits the list into `[1] FIRST-PARTY` and `[2] THIRD-PARTY` frames, inlines version + author, and replaces the `Switch` control with a TUI `[x]`/`[ ]` glyph + `loaded`/`disabled` label.
- `FileView`s watch `~/.config/omarchy/current/theme.name` and `<omarchyPath>/version` so the sidebar footer and title-bar version label stay live across theme/version changes.

### Defaults
<img width="1889" height="2080" alt="image" src="https://github.com/user-attachments/assets/5faa1bab-872f-46ae-abee-335678328156" />

### Style
<img width="1889" height="2080" alt="image" src="https://github.com/user-attachments/assets/fc326f7c-4795-44e2-bb6c-16c339444148" />

### Bar
<img width="1889" height="2080" alt="image" src="https://github.com/user-attachments/assets/8b2518f4-4d28-4091-b64d-51df29dbb742" />

### System
<img width="1889" height="2080" alt="image" src="https://github.com/user-attachments/assets/aaa7f3e0-bd6a-4d0a-8c98-701a1ae983f3" />

### Plugins
<img width="1889" height="2080" alt="image" src="https://github.com/user-attachments/assets/22b2363c-72ac-4dbe-abe3-d8001ac9cbe0" />


## Test plan
- [ ] Open `omarchy-shell-settings`: sidebar shows `▶ Defaults`, footer reads the live theme name and `Quickshell · running`, title bar shows `[ Omarchy Settings ] — v<version>`, modeline reads `:defaults NORMAL  ·  3 groups`
- [ ] Bar tab → Tab into a widget row → `J`/`K` reorder within the section; modeline count + selection text update
- [ ] Bar tab → focused widget → `Shift+1` / `Shift+2` / `Shift+3` move it across left/center/right; non-duplicating widget across a zone that already has it silently no-ops
- [ ] Bar tab → focused widget → `dd` removes; lone `d` shows `d_` in the modeline and clears after ~700 ms
- [ ] Bar tab → press-drag a widget row 10 px → ghost chip follows the cursor; release on another row inserts above/below depending on cursor Y; release on `+ Add widget` appends; release outside any DropArea is a no-op
- [ ] Press `?` from any tab → help overlay opens; Esc or `?` again dismisses
- [ ] `1`–`9` from the body jumps focus to the section with that bracket index (Defaults: 1 Terminal / 2 Browser / 3 Editor; Bar: 1/2/3 sections + 4 Position + 5 Center anchor; Style/System/Plugins likewise)
- [ ] Defaults / Style / System: rows pick up `[N]` numeric prefixes per-section starting at 01; Space on a focused row applies the toggle/selection as before
- [ ] Plugins tab: third-party row → Space toggles `[x]`/`[ ]` + `loaded`/`disabled`; first-party rows render enabled and refuse interaction