### PR TITLE
Control Spotify volume independently for Spotify Connect

### DIFF
--- a/bin/omarchy-spotify-volume
+++ b/bin/omarchy-spotify-volume
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# omarchy:summary=Control Spotify volume independently from system volume. Useful for Spotify Connect.
+# omarchy:args=raise|lower
+
+playerctl -p spotify status &>/dev/null || exit 0
+
+case "$1" in
+  raise) playerctl -p spotify volume 0.05+ ;;
+  lower) playerctl -p spotify volume 0.05- ;;
+  *) exit 1 ;;
+esac
+
+vol=$(playerctl -p spotify volume)
+pct=$(awk "BEGIN {printf \"%d\", $vol * 100}")
+omarchy-swayosd-client --custom-icon "spotify" --custom-progress "$vol" --custom-progress-text "${pct}%"

--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -26,5 +26,9 @@ bindld = , XF86AudioPause, Pause, exec, omarchy-swayosd-client --playerctl play-
 bindld = , XF86AudioPlay, Play, exec, omarchy-swayosd-client --playerctl play-pause
 bindld = , XF86AudioPrev, Previous track, exec, omarchy-swayosd-client --playerctl previous
 
+# Spotify Connect volume with Super + Volume
+bindeld = SUPER, XF86AudioRaiseVolume, Spotify volume up, exec, omarchy-spotify-volume raise
+bindeld = SUPER, XF86AudioLowerVolume, Spotify volume down, exec, omarchy-spotify-volume lower
+
 # Switch audio output with Super + Mute
 bindld = SUPER, XF86AudioMute, Switch audio output, exec, omarchy-audio-output-switch


### PR DESCRIPTION
Added keybindings to control volume of Spotify independently of system volume. This is particularly useful for Spotify Connect. 