### PR TITLE
Fix DaVinci Resolve focus lock

### DIFF
--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -1,2 +1,2 @@
--- Keep DaVinci Resolve floating without locking focus.
-o.window({ class = "^[Rr]esolve([.]bin)?$" }, { float = true })
+-- Float secondary DaVinci Resolve windows without locking focus.
+o.window({ class = "^[Rr]esolve([.]bin)?$", title = "^(?!DaVinci Resolve( Studio)? - )" }, { float = true, center = true })

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -1,2 +1,2 @@
 -- Float secondary DaVinci Resolve windows without locking focus.
-o.window({ class = "^[Rr]esolve([.]bin)?$", title = "^(?!DaVinci Resolve( Studio)? - )" }, { float = true, center = true })
+o.window({ class = "^[Rr]esolve([.]bin)?$", title = "negative:^DaVinci Resolve( Studio)? - " }, { float = true, center = true })

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -1,2 +1,2 @@
--- DaVinci Resolve dialog focus handling.
-o.window(".*[Rr]esolve.*", { float = true, stay_focused = true })
+-- Keep DaVinci Resolve floating without locking focus.
+o.window({ class = "^[Rr]esolve([.]bin)?$" }, { float = true })


### PR DESCRIPTION
Fixes #5887.

DaVinci Resolve should still float under XWayland, but applying `stay_focused` to every Resolve window prevents focusing other apps and monitors while Resolve is open.

This narrows the default rule to keep Resolve floating without globally locking focus.

Tested:
- `lua -e 'assert(loadfile("default/hypr/apps/davinci-resolve.lua"))'`
- `bash test/omarchy-cli-test.sh`
