### PR TITLE
Add optional Surge installer

### DIFF
--- a/bin/omarchy-install-surge
+++ b/bin/omarchy-install-surge
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# omarchy:summary=Install Surge Download Manager from the AUR.
+
+set -e
+
+echo "Installing Surge Download Manager..."
+omarchy-pkg-aur-add surge
+
+cat <<'MSG'
+
+Surge installed.
+
+To connect your browser downloads to Surge:
+1. Download extension-chrome.zip from https://github.com/SurgeDM/Surge/releases/latest
+2. Unzip it somewhere on disk.
+3. Open chrome://extensions in Chrome, Chromium, Brave, or Edge.
+4. Enable Developer mode.
+5. Click Load unpacked and select the unzipped extension-chrome folder.
+6. Start Surge and get an auth token from Settings > Extension, or run: surge token
+7. Paste that token into the extension settings.
+
+The extension talks to Surge on port 1700 by default.
+MSG


### PR DESCRIPTION
## Summary

Adds `omarchy install surge` for Surge Download Manager.

Surge is available in the AUR as `surge`, so this follows the same pattern as other optional installers: a small `bin/omarchy-install-*` command that installs the package and prints any follow-up steps.

## Details

The installer:

- installs Surge from the AUR
- points users to the latest `extension-chrome.zip` release
- explains the Chrome/Chromium/Brave/Edge unpacked extension flow
- mentions `surge token` for connecting the browser extension

## Test

- `omarchy commands --check`
- `omarchy install surge --help`
