### PR TITLE
Fix dual-battery handling in upower queries

### DIFF
--- a/bin/omarchy-battery-capacity
+++ b/bin/omarchy-battery-capacity
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Returns the battery full capacity in Wh (rounded to whole number).
 
-battery_info=$(upower -i $(upower -e | grep BAT))
+battery_info=$(upower -i /org/freedesktop/UPower/devices/DisplayDevice)
 
 echo "$battery_info" | awk '/energy-full:/ {
     printf "%d", $2

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -6,7 +6,7 @@
 BATTERY_THRESHOLD=10
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 BATTERY_LEVEL=$(omarchy-battery-remaining)
-BATTERY_STATE=$(upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}')
+BATTERY_STATE=$(upower -i /org/freedesktop/UPower/devices/DisplayDevice | grep -E "state" | awk '{print $2}')
 
 send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000

--- a/bin/omarchy-battery-remaining
+++ b/bin/omarchy-battery-remaining
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Returns the battery percentage remaining as an integer.
 
-upower -i $(upower -e | grep BAT) | awk '/percentage/ { 
+upower -i /org/freedesktop/UPower/devices/DisplayDevice | awk '/percentage/ {
     print int($2)
     exit
 }'

--- a/bin/omarchy-battery-remaining-time
+++ b/bin/omarchy-battery-remaining-time
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Returns the battery time remaining (to empty or full) in a compact format.
 
-battery_info=$(upower -i $(upower -e | grep BAT))
+battery_info=$(upower -i /org/freedesktop/UPower/devices/DisplayDevice)
 
 echo "$battery_info" | awk '/time to (empty|full)/ {
     value = $4

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Returns a formatted battery status string with percentage and power draw/charge.
 
-battery_info=$(upower -i $(upower -e | grep BAT))
+battery_info=$(upower -i /org/freedesktop/UPower/devices/DisplayDevice)
 
 percentage=$(echo "$battery_info" | awk '/percentage/ {
     print int($2)


### PR DESCRIPTION
## Summary

Fixes the dual-battery inconsistency reported by @Michael-Steshenko in #5780: the waybar percentage and the right-click notification disagree on multi-battery systems (e.g. ThinkPad T480 with internal + slice).

## Root cause

Five scripts share the same anti-pattern:

```bash
upower -i $(upower -e | grep BAT)
```

`upower -e` lists every device path. When two batteries exist, `grep BAT` returns two lines, and `upower -i` is invoked with multiple positional args — it only honors the first. So the scripts report BAT0 only, while waybar's native battery module shows the correct unified value.

## Fix

Switch every call to `upower -i /org/freedesktop/UPower/devices/DisplayDevice`. That's upower's composite virtual device aggregating all power sources — the same data waybar uses internally. Same fields are exposed (`percentage`, `energy-rate`, `state`, `time-to-empty/full`, `energy-full`), so no other code change is needed.

## Scope

All five scripts in the affected callgraph are fixed in a single commit because they all share the same bug from the same root cause:

| Script | Used by |
|---|---|
| `bin/omarchy-battery-status` | waybar right-click + `SUPER+CTRL+ALT+B` notification |
| `bin/omarchy-battery-remaining-time` | called by `battery-status` |
| `bin/omarchy-battery-capacity` | called by `battery-status` |
| `bin/omarchy-battery-remaining` | called by `battery-monitor` |
| `bin/omarchy-battery-monitor` | systemd timer, critical-low alert |

The last two aren't strictly required to fix the symptom in the issue, but the same anti-pattern was silently breaking the critical-low alert as well — on dual-battery systems it could misfire (trigger when only BAT0 hits 10% while BAT1 is full) or never trigger (BAT0 stays charged thanks to BAT1 draining first). Reviewers — happy to split if you prefer one PR per concern.

## Master backport

The same five scripts exist on `master` with identical content (verified: `git diff origin/master:bin/omarchy-battery-{status,remaining,remaining-time,capacity,monitor} origin/dev:...`). If you'd like me to open a parallel PR against `master`, just say so.

## Test plan

- [x] `bash -n` clean on all five scripts
- [x] Smoke-run on a single-battery (well, no-battery — DisplayDevice still exists and returns sensible empty values) system, scripts don't crash and produce parseable output
- [ ] Multi-battery verification — I don't own a ThinkPad T480-class machine; relying on @Michael-Steshenko's root-cause analysis (their issue includes a screen recording showing the exact mismatch). If a reviewer can confirm on real hardware, that would close the loop.

Reported and root-caused by @Michael-Steshenko in #5780 — credit where it's due.
