### PR TITLE
Allow toggling Caps Lock via both Shift keys

### DIFF
--- a/config/hypr/input.lua
+++ b/config/hypr/input.lua
@@ -8,7 +8,7 @@ hl.config({
     -- Use a specific keyboard variant if needed (e.g. intl for international keyboards).
     -- kb_variant = "intl",
 
-    kb_options = "compose:caps", -- ,grp:alts_toggle
+    kb_options = "compose:caps,shift:both_capslock", -- ,grp:alts_toggle
 
     -- Change speed of keyboard repeat.
     repeat_rate = 40,

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -4,7 +4,7 @@ hl.config({
     kb_layout = "us",
     kb_variant = "",
     kb_model = "",
-    kb_options = "compose:caps",
+    kb_options = "compose:caps,shift:both_capslock",
     kb_rules = "",
     follow_mouse = 1,
     sensitivity = 0,


### PR DESCRIPTION
Adds `shift:both_capslock` alongside the existing `compose:caps` in `default/hypr/input.lua` and `config/hypr/input.lua`. Pressing **both Shift keys simultaneously** now toggles real Caps Lock; single-Shift behavior is unchanged, and Caps Lock continues to act as the XCompose key.

## Why

The current default `compose:caps` makes Caps Lock the XCompose key — great for emoji, accented characters, and `~/.XCompose` shortcuts — but it removes any way to enable real Caps Lock, which is occasionally valuable. More importantly, fcitx5's Wayland input-method grab occasionally desyncs (notably after a Hyprland reload), and when it does, Caps Lock can get stuck "on" with **no easy way to toggle it back off** — the Compose key is the very thing that's broken. This recurring confusion shows up across closed issues #166, #953, #1792, #2241, #2545, #3238, and #5200.

`shift:both_capslock` is a stock libxkbcommon option that provides an escape hatch. It costs nothing for users who don't reach for it:

- Single Shift is untouched.
- Caps Lock alone remains the Compose key.
- The Compose-key default that DHH preserved in #2525 stays exactly as it is.

This is purely additive — it restores the missing Caps Lock capability via a discoverable two-Shift chord without changing any existing behavior.

## Note on syntax

The XKB option string is comma-separated and **must not contain spaces** between options. `"compose:caps,shift:both_capslock"` is correct; `"compose:caps, shift:both_capslock"` would cause libxkbcommon to silently drop the second option. The change uses the correct space-free form.

## Test plan

- [x] Press both Shifts simultaneously → Caps Lock LED toggles, alphabetic keys produce uppercase.
- [x] Single Shift still produces uppercase only while held.
- [x] Caps Lock alone still acts as Compose / Multi_key 
- [x] `~/.XCompose` shortcuts still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)