### PR TITLE
fix: prefer dedicated music players over browsers for media keys

### DIFF
--- a/bin/omarchy-swayosd-client
+++ b/bin/omarchy-swayosd-client
@@ -1,6 +1,37 @@
 #!/bin/bash
 
 # omarchy:summary=Wrapper for swayosd-client that targets the currently focused monitor.
+# omarchy:summary=When --playerctl is used without an explicit --player, automatically
+# omarchy:summary=prefers dedicated music players (e.g. cliamp, spotify) over browser
+# omarchy:summary=instances (chromium, firefox) that register as MPRIS players even when
+# omarchy:summary=no media is playing.
 # omarchy:args=<swayosd-client-args...>
+
+# If --playerctl is requested without an explicit --player, inject the best active player.
+has_playerctl=false
+has_player=false
+for arg in "$@"; do
+  [[ "$arg" == "--playerctl" ]] && has_playerctl=true
+  [[ "$arg" == "--player" ]]    && has_player=true
+done
+
+if $has_playerctl && ! $has_player; then
+  music_playing="" music_paused="" browser_playing="" browser_paused=""
+  while IFS= read -r p; do
+    status=$(playerctl --player="$p" status 2>/dev/null)
+    is_browser=false
+    [[ "$p" == chromium* || "$p" == firefox* ]] && is_browser=true
+    if [[ "$status" == "Playing" ]]; then
+      $is_browser && [[ -z "$browser_playing" ]] && browser_playing="$p" \
+                  || [[ -z "$music_playing"   ]] && music_playing="$p"
+    elif [[ "$status" == "Paused" ]]; then
+      $is_browser && [[ -z "$browser_paused" ]] && browser_paused="$p" \
+                  || [[ -z "$music_paused"   ]] && music_paused="$p"
+    fi
+  done < <(playerctl -l 2>/dev/null)
+  # Priority: dedicated music playing > browser playing > dedicated music paused > browser paused
+  best_player="${music_playing:-${browser_playing:-${music_paused:-$browser_paused}}}"
+  [[ -n "$best_player" ]] && set -- "--player" "$best_player" "$@"
+fi
 
 exec swayosd-client --monitor "$(omarchy-hyprland-monitor-focused)" "$@"

--- a/bin/omarchy-swayosd-client
+++ b/bin/omarchy-swayosd-client
@@ -16,22 +16,26 @@ for arg in "$@"; do
 done
 
 if $has_playerctl && ! $has_player; then
-  music_playing="" music_paused="" browser_playing="" browser_paused=""
+  music_playing="" music_paused="" browser_playing=""
   while IFS= read -r p; do
     status=$(playerctl --player="$p" status 2>/dev/null)
     is_browser=false
     [[ "$p" == chromium* || "$p" == firefox* ]] && is_browser=true
     if [[ "$status" == "Playing" ]]; then
-      $is_browser && [[ -z "$browser_playing" ]] && browser_playing="$p" \
-                  || [[ -z "$music_playing"   ]] && music_playing="$p"
+      $is_browser && : "${browser_playing:=$p}" || : "${music_playing:=$p}"
     elif [[ "$status" == "Paused" ]]; then
-      $is_browser && [[ -z "$browser_paused" ]] && browser_paused="$p" \
-                  || [[ -z "$music_paused"   ]] && music_paused="$p"
+      $is_browser || : "${music_paused:=$p}"
     fi
   done < <(playerctl -l 2>/dev/null)
-  # Priority: dedicated music playing > browser playing > dedicated music paused > browser paused
-  best_player="${music_playing:-${browser_playing:-${music_paused:-$browser_paused}}}"
-  [[ -n "$best_player" ]] && set -- "--player" "$best_player" "$@"
+  # Override playerctld only when a dedicated music player should take control:
+  # 1. A music player is Playing (wins over a browser, even if browser also plays)
+  # 2. No browser is Playing but a music player is Paused (resume it)
+  # Otherwise let playerctld decide naturally (e.g. YouTube actively playing).
+  if [[ -n "$music_playing" ]]; then
+    set -- "--player" "$music_playing" "$@"
+  elif [[ -z "$browser_playing" && -n "$music_paused" ]]; then
+    set -- "--player" "$music_paused" "$@"
+  fi
 fi
 
 exec swayosd-client --monitor "$(omarchy-hyprland-monitor-focused)" "$@"


### PR DESCRIPTION
## Problem

Browsers (Chromium, Firefox) register as MPRIS players as soon as they open, even when no media is playing. When `playerctld` is running, it can pick the browser as the active player — causing media keys (play/pause/next/prev) to silently target the browser instead of a running music app (cliamp, Spotify, etc.).

The result: play/pause only works intermittently, or not at all, depending on which player `playerctld` happens to have prioritized.

## Fix

Extend `omarchy-swayosd-client` to detect this situation when `--playerctl` is used without an explicit `--player`: it scans all MPRIS players and injects `--player <best>` with the following priority:

| Priority | Condition |
|----------|-----------|
| 1st | Dedicated music player that is **Playing** |
| 2nd | Browser that is **Playing** (e.g. YouTube actively running) |
| 3rd | Dedicated music player that is **Paused** |
| 4th | Browser that is **Paused** |

This means:
- cliamp/Spotify playing + Chrome open → **music player gets the command** ✓
- YouTube playing + cliamp paused → **YouTube gets the command** ✓
- Only Chrome open (stopped) → falls back to default playerctl behavior ✓

## Scope

- No changes to `media.lua` or any bindings
- Transparent when `--player` is already supplied explicitly
- Only activates for `--playerctl` calls, leaving all other swayosd behavior untouched