### PR TITLE
Add suspend/resume recovery for T2 Macs (using legacy apple_bce)

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -64,6 +64,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/framework/qmk-hid.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-nvme.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
+run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2-suspend.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
 

--- a/install/config/hardware/apple/fix-t2-suspend.sh
+++ b/install/config/hardware/apple/fix-t2-suspend.sh
@@ -1,0 +1,32 @@
+# Detect T2 MacBook models using PCI IDs
+# Vendor: 106b (Apple), Device IDs: 1801 or 1802 (T2 Security Chip)
+if lspci -nn 2>/dev/null | grep -q "106b:180[12]"; then
+  echo "Configuring T2 suspend/resume service..."
+
+  # Install the suspend helper from the Omarchy repo
+  sudo mkdir -p /usr/local/libexec/omarchy/apple
+  sudo cp "$OMARCHY_PATH/install/config/hardware/apple/t2-suspend" /usr/local/libexec/omarchy/apple/t2-suspend
+  sudo chmod +x /usr/local/libexec/omarchy/apple/t2-suspend
+
+  # Write the systemd service
+  sudo tee /etc/systemd/system/omarchy-apple-t2-suspend.service >/dev/null <<'UNIT_EOF'
+[Unit]
+Description=Apple T2 suspend/resume
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/libexec/omarchy/apple/t2-suspend pre
+ExecStop=/usr/local/libexec/omarchy/apple/t2-suspend post
+TimeoutStopSec=10
+
+[Install]
+WantedBy=sleep.target
+UNIT_EOF
+
+  sudo systemctl enable omarchy-apple-t2-suspend.service
+
+  echo "T2 suspend/resume service enabled."
+fi

--- a/install/config/hardware/apple/t2-suspend
+++ b/install/config/hardware/apple/t2-suspend
@@ -4,13 +4,14 @@
 # systemd service so the T2 coprocessor is fully active during pre.
 
 # Pre:
-#   - unbinds aaudio (releases ALSA FDs held by userspace)
+#   - with asynchronous device suspend, unbinds aaudio and cycles apple_bce
+#   - with synchronous device suspend, keeps aaudio and apple_bce bound
 #   - stops tiny-dfr (prevents spurious wake-ups)
 #   - unloads T2 modules (reverse dep order)
 #     * on BCM4377b brcmfmac removed before sleep to avoid D3 timeout
 #     * on BCM4364  brcmfmac stays bound; kernel PCI PM handles D3cold
 # Post:
-#   - reloads apple_bce, then sleeps to let T2 firmware init
+#   - reloads apple_bce when it was unloaded, then lets T2 firmware init
 #   - reloads T2 modules (forward dep order), restarts tiny-dfr
 
 set -euo pipefail
@@ -24,8 +25,12 @@ log()     { logger -t "$LOG_TAG" "$1"; }
 
 mod_ld()  { [[ -d /sys/module/$1 ]]; }
 
+sync_suspend() {
+  [[ -r /sys/power/pm_async ]] && [[ $(</sys/power/pm_async) == "0" ]]
+}
+
 require_legacy_driver() {
-  # apple_bce is intentionally unloaded during pre, so check the kernel's
+  # apple_bce may be unloaded during pre, so check the kernel's
   # module metadata rather than /sys/module for both pre and post.
   if ! modinfo apple_bce >/dev/null 2>&1; then
     log "Skipping: legacy apple_bce driver is unavailable"
@@ -52,16 +57,22 @@ case "${1:-}" in
   pre)
     require_legacy_driver
 
-    for d in /sys/bus/pci/drivers/aaudio/0000:*; do
-      [[ -e $d ]] || continue
-      echo "${d##*/}" > /sys/bus/pci/drivers/aaudio/unbind 2>/dev/null &&
-        log "${d##*/} Unbound" || true
-    done
+    if sync_suspend; then
+      cycle_legacy_driver=0
+      log "Synchronous device suspend active; keeping aaudio and apple_bce bound"
+    else
+      cycle_legacy_driver=1
+      for d in /sys/bus/pci/drivers/aaudio/0000:*; do
+        [[ -e $d ]] || continue
+        echo "${d##*/}" > /sys/bus/pci/drivers/aaudio/unbind 2>/dev/null &&
+          log "${d##*/} Unbound" || true
+      done
+    fi
 
     systemctl stop tiny-dfr 2>/dev/null || true
 
     for m in "${PRE_MODS[@]}"; do skip "$m" || unload "$m"; done
-    unload apple_bce
+    (( cycle_legacy_driver )) && unload apple_bce
 
     if ! udevadm settle --timeout=5; then
       log "Timed out waiting for udev queue to settle"
@@ -72,7 +83,10 @@ case "${1:-}" in
   post)
     require_legacy_driver
 
-    load apple_bce; sleep 2
+    if ! mod_ld apple_bce; then
+      load apple_bce
+      sleep 2
+    fi
 
     for m in "${POST_MODS[@]}"; do skip "$m" || load "$m"; done
 

--- a/install/config/hardware/apple/t2-suspend
+++ b/install/config/hardware/apple/t2-suspend
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Apple T2 suspend/resume helper. Runs as a Before=sleep.target
+# systemd service so the T2 coprocessor is fully active during pre.
+
+# Pre:
+#   - unbinds aaudio (releases ALSA FDs held by userspace)
+#   - stops tiny-dfr (prevents spurious wake-ups)
+#   - unloads T2 modules (reverse dep order; brcmfmac for D3)
+# Post:
+#   - reloads apple_bce, then sleeps to let T2 firmware init
+#   - reloads T2 modules (forward dep order), restarts tiny-dfr
+
+PRE_MODS=(appletbdrm hid_appletb_kbd hid_appletb_bl brcmfmac_wcc brcmfmac)
+POST_MODS=(brcmfmac brcmfmac_wcc hid_appletb_bl hid_appletb_kbd appletbdrm)
+
+set -euo pipefail
+
+LOG_TAG="t2-suspend"
+
+log()     { logger -t "$LOG_TAG" "$1"; }
+
+mod_ld()  { [[ -d /sys/module/$1 ]]; }
+
+unload()  {
+  mod_ld "$1" && modprobe -r "$1" 2>/dev/null &&
+    log "Unloaded $1" || true
+}
+
+load()    {
+  mod_ld "$1" || {
+    modprobe "$1" 2>/dev/null && log "Loaded $1" || true
+  }
+}
+
+case "${1:-}" in
+  pre)
+    for d in /sys/bus/pci/drivers/aaudio/0000:*; do
+      [[ -e $d ]] || continue
+      echo "${d##*/}" > /sys/bus/pci/drivers/aaudio/unbind 2>/dev/null &&
+        log "${d##*/} Unbound" || true
+    done
+
+    systemctl stop tiny-dfr 2>/dev/null || true
+
+    for m in "${PRE_MODS[@]}"; do unload "$m"; done
+    unload apple_bce
+
+    if ! udevadm settle --timeout=5; then
+      log "Timed out waiting for udev queue to settle"
+    fi
+
+    log "Ready to suspend"
+    ;;
+  post)
+    load apple_bce; sleep 2
+
+    for m in "${POST_MODS[@]}"; do load "$m"; done
+
+    systemctl start tiny-dfr 2>/dev/null || true
+
+    log "Resume complete"
+    ;;
+  *)
+    echo "Usage: $0 {pre|post}"; exit 1 ;;
+esac

--- a/install/config/hardware/apple/t2-suspend
+++ b/install/config/hardware/apple/t2-suspend
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Apple T2 suspend/resume helper. Runs as a Before=sleep.target
+# Legacy apple_bce suspend/resume helper. Runs as a Before=sleep.target
 # systemd service so the T2 coprocessor is fully active during pre.
 
 # Pre:
@@ -24,6 +24,15 @@ log()     { logger -t "$LOG_TAG" "$1"; }
 
 mod_ld()  { [[ -d /sys/module/$1 ]]; }
 
+require_legacy_driver() {
+  # apple_bce is intentionally unloaded during pre, so check the kernel's
+  # module metadata rather than /sys/module for both pre and post.
+  if ! modinfo apple_bce >/dev/null 2>&1; then
+    log "Skipping: legacy apple_bce driver is unavailable"
+    exit 0
+  fi
+}
+
 unload()  {
   mod_ld "$1" && modprobe -r "$1" 2>/dev/null &&
     log "Unloaded $1" || true
@@ -41,6 +50,8 @@ skip() { is_bcm4364 && [[ $1 == "brcmfmac" || $1 == "brcmfmac_wcc" ]]; }
 
 case "${1:-}" in
   pre)
+    require_legacy_driver
+
     for d in /sys/bus/pci/drivers/aaudio/0000:*; do
       [[ -e $d ]] || continue
       echo "${d##*/}" > /sys/bus/pci/drivers/aaudio/unbind 2>/dev/null &&
@@ -59,6 +70,8 @@ case "${1:-}" in
     log "Ready to suspend"
     ;;
   post)
+    require_legacy_driver
+
     load apple_bce; sleep 2
 
     for m in "${POST_MODS[@]}"; do skip "$m" || load "$m"; done

--- a/install/config/hardware/apple/t2-suspend
+++ b/install/config/hardware/apple/t2-suspend
@@ -6,17 +6,19 @@
 # Pre:
 #   - unbinds aaudio (releases ALSA FDs held by userspace)
 #   - stops tiny-dfr (prevents spurious wake-ups)
-#   - unloads T2 modules (reverse dep order; brcmfmac for D3)
+#   - unloads T2 modules (reverse dep order)
+#     * on BCM4377b brcmfmac removed before sleep to avoid D3 timeout
+#     * on BCM4364  brcmfmac stays bound; kernel PCI PM handles D3cold
 # Post:
 #   - reloads apple_bce, then sleeps to let T2 firmware init
 #   - reloads T2 modules (forward dep order), restarts tiny-dfr
 
-PRE_MODS=(appletbdrm hid_appletb_kbd hid_appletb_bl brcmfmac_wcc brcmfmac)
-POST_MODS=(brcmfmac brcmfmac_wcc hid_appletb_bl hid_appletb_kbd appletbdrm)
-
 set -euo pipefail
 
 LOG_TAG="t2-suspend"
+BRCMF_D3COLD_PCI_ID=14e4:4464
+PRE_MODS=(appletbdrm hid_appletb_kbd hid_appletb_bl brcmfmac_wcc brcmfmac hci_bcm4377)
+POST_MODS=(hci_bcm4377 brcmfmac brcmfmac_wcc hid_appletb_bl hid_appletb_kbd appletbdrm)
 
 log()     { logger -t "$LOG_TAG" "$1"; }
 
@@ -33,6 +35,10 @@ load()    {
   }
 }
 
+is_bcm4364() { lspci -nn | grep -q "$BRCMF_D3COLD_PCI_ID"; }
+
+skip() { is_bcm4364 && [[ $1 == "brcmfmac" || $1 == "brcmfmac_wcc" ]]; }
+
 case "${1:-}" in
   pre)
     for d in /sys/bus/pci/drivers/aaudio/0000:*; do
@@ -43,7 +49,7 @@ case "${1:-}" in
 
     systemctl stop tiny-dfr 2>/dev/null || true
 
-    for m in "${PRE_MODS[@]}"; do unload "$m"; done
+    for m in "${PRE_MODS[@]}"; do skip "$m" || unload "$m"; done
     unload apple_bce
 
     if ! udevadm settle --timeout=5; then
@@ -55,9 +61,10 @@ case "${1:-}" in
   post)
     load apple_bce; sleep 2
 
-    for m in "${POST_MODS[@]}"; do load "$m"; done
+    for m in "${POST_MODS[@]}"; do skip "$m" || load "$m"; done
 
-    systemctl start tiny-dfr 2>/dev/null || true
+    systemctl reset-failed tiny-dfr 2>/dev/null &&
+      systemctl restart tiny-dfr 2>/dev/null || true
 
     log "Resume complete"
     ;;

--- a/install/config/hardware/apple/t2-suspend
+++ b/install/config/hardware/apple/t2-suspend
@@ -4,14 +4,13 @@
 # systemd service so the T2 coprocessor is fully active during pre.
 
 # Pre:
-#   - with asynchronous device suspend, unbinds aaudio and cycles apple_bce
-#   - with synchronous device suspend, keeps aaudio and apple_bce bound
+#   - unbinds aaudio (releases ALSA FDs held by userspace)
 #   - stops tiny-dfr (prevents spurious wake-ups)
 #   - unloads T2 modules (reverse dep order)
 #     * on BCM4377b brcmfmac removed before sleep to avoid D3 timeout
 #     * on BCM4364  brcmfmac stays bound; kernel PCI PM handles D3cold
 # Post:
-#   - reloads apple_bce when it was unloaded, then lets T2 firmware init
+#   - reloads apple_bce, then sleeps to let T2 firmware init
 #   - reloads T2 modules (forward dep order), restarts tiny-dfr
 
 set -euo pipefail
@@ -25,12 +24,8 @@ log()     { logger -t "$LOG_TAG" "$1"; }
 
 mod_ld()  { [[ -d /sys/module/$1 ]]; }
 
-sync_suspend() {
-  [[ -r /sys/power/pm_async ]] && [[ $(</sys/power/pm_async) == "0" ]]
-}
-
 require_legacy_driver() {
-  # apple_bce may be unloaded during pre, so check the kernel's
+  # apple_bce is intentionally unloaded during pre, so check the kernel's
   # module metadata rather than /sys/module for both pre and post.
   if ! modinfo apple_bce >/dev/null 2>&1; then
     log "Skipping: legacy apple_bce driver is unavailable"
@@ -57,22 +52,16 @@ case "${1:-}" in
   pre)
     require_legacy_driver
 
-    if sync_suspend; then
-      cycle_legacy_driver=0
-      log "Synchronous device suspend active; keeping aaudio and apple_bce bound"
-    else
-      cycle_legacy_driver=1
-      for d in /sys/bus/pci/drivers/aaudio/0000:*; do
-        [[ -e $d ]] || continue
-        echo "${d##*/}" > /sys/bus/pci/drivers/aaudio/unbind 2>/dev/null &&
-          log "${d##*/} Unbound" || true
-      done
-    fi
+    for d in /sys/bus/pci/drivers/aaudio/0000:*; do
+      [[ -e $d ]] || continue
+      echo "${d##*/}" > /sys/bus/pci/drivers/aaudio/unbind 2>/dev/null &&
+        log "${d##*/} Unbound" || true
+    done
 
     systemctl stop tiny-dfr 2>/dev/null || true
 
     for m in "${PRE_MODS[@]}"; do skip "$m" || unload "$m"; done
-    (( cycle_legacy_driver )) && unload apple_bce
+    unload apple_bce
 
     if ! udevadm settle --timeout=5; then
       log "Timed out waiting for udev queue to settle"
@@ -83,10 +72,7 @@ case "${1:-}" in
   post)
     require_legacy_driver
 
-    if ! mod_ld apple_bce; then
-      load apple_bce
-      sleep 2
-    fi
+    load apple_bce; sleep 2
 
     for m in "${POST_MODS[@]}"; do skip "$m" || load "$m"; done
 

--- a/install/config/hardware/apple/t2-suspend
+++ b/install/config/hardware/apple/t2-suspend
@@ -9,14 +9,17 @@
 #   - unloads T2 modules (reverse dep order)
 #     * on BCM4377b brcmfmac removed before sleep to avoid D3 timeout
 #     * on BCM4364  brcmfmac stays bound; kernel PCI PM handles D3cold
+#   - suspends the keyboard backlight before unloading apple_bce
 # Post:
 #   - reloads apple_bce, then sleeps to let T2 firmware init
-#   - reloads T2 modules (forward dep order), restarts tiny-dfr
+#   - reloads T2 modules (forward dep order)
+#   - resumes the keyboard backlight, then restarts tiny-dfr
 
 set -euo pipefail
 
 LOG_TAG="t2-suspend"
 BRCMF_D3COLD_PCI_ID=14e4:4464
+KBD_BACKLIGHT_DEVICE="*kbd_backlight*"
 PRE_MODS=(appletbdrm hid_appletb_kbd hid_appletb_bl brcmfmac_wcc brcmfmac hci_bcm4377)
 POST_MODS=(hci_bcm4377 brcmfmac brcmfmac_wcc hid_appletb_bl hid_appletb_kbd appletbdrm)
 
@@ -48,6 +51,16 @@ is_bcm4364() { lspci -nn | grep -q "$BRCMF_D3COLD_PCI_ID"; }
 
 skip() { is_bcm4364 && [[ $1 == "brcmfmac" || $1 == "brcmfmac_wcc" ]]; }
 
+keyboard_backlight_suspend() {
+  brightnessctl -sd "$KBD_BACKLIGHT_DEVICE" set 0 >/dev/null 2>&1 &&
+    log "Suspended keyboard backlight" || true
+}
+
+keyboard_backlight_resume() {
+  brightnessctl -rd "$KBD_BACKLIGHT_DEVICE" >/dev/null 2>&1 &&
+    log "Resumed keyboard backlight" || true
+}
+
 case "${1:-}" in
   pre)
     require_legacy_driver
@@ -61,6 +74,7 @@ case "${1:-}" in
     systemctl stop tiny-dfr 2>/dev/null || true
 
     for m in "${PRE_MODS[@]}"; do skip "$m" || unload "$m"; done
+    keyboard_backlight_suspend
     unload apple_bce
 
     if ! udevadm settle --timeout=5; then
@@ -75,6 +89,7 @@ case "${1:-}" in
     load apple_bce; sleep 2
 
     for m in "${POST_MODS[@]}"; do skip "$m" || load "$m"; done
+    keyboard_backlight_resume
 
     systemctl reset-failed tiny-dfr 2>/dev/null &&
       systemctl restart tiny-dfr 2>/dev/null || true

--- a/migrations/1780075490.sh
+++ b/migrations/1780075490.sh
@@ -1,0 +1,28 @@
+echo "Install t2-suspend T2 suspend/resume service"
+
+if lspci -nn 2>/dev/null | grep -q "106b:180[12]"; then
+  sudo mkdir -p /usr/local/libexec/omarchy/apple
+  sudo cp "$OMARCHY_PATH/install/config/hardware/apple/t2-suspend" /usr/local/libexec/omarchy/apple/t2-suspend
+  sudo chmod +x /usr/local/libexec/omarchy/apple/t2-suspend
+
+  sudo tee /etc/systemd/system/omarchy-apple-t2-suspend.service >/dev/null <<'UNIT_EOF'
+[Unit]
+Description=Apple T2 suspend/resume
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/libexec/omarchy/apple/t2-suspend pre
+ExecStop=/usr/local/libexec/omarchy/apple/t2-suspend post
+TimeoutStopSec=10
+
+[Install]
+WantedBy=sleep.target
+UNIT_EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable omarchy-apple-t2-suspend.service
+  echo "T2 suspend/resume service installed and enabled."
+fi


### PR DESCRIPTION
## Summary

Adds suspend/resume recovery for Apple T2 Macs running the legacy apple_bce driver stack. The service unloads and restores the T2 peripheral modules that do not reliably recover through native power management, with chipset-specific handling for BCM4377b and BCM4364 Wi-Fi.

This implementation was developed and validated on apple_bce kernels. Upstream T2 Linux has since introduced the replacement t2bce driver stack, whose coordinated power-management support may make some or all of this recovery unnecessary. Compatibility with t2bce has not yet been tested, so this PR should not be considered support for that driver.

## Tested on

- **Model**: MacBookPro15,4 (MacBook Pro 13", 2019)
- **Kernel**: (T2 Arch Linux) `6.19.13-arch1-Watanare-T2-1-t2`, `7.0.11-arch1-Watanare-T2-1-t2`, `7.1.3-arch1-Watanare-T2-2-t2`
- **Userspace**: PipeWire + WirePlumber (no stop/restart needed across suspend)

## Test results (extended suspend/resume + overnight/multi-night)

| Condition | Result |
|-----------|--------|
| Clean suspend/resume (audio, Wi-Fi, Touch Bar, USB, keyboard) | Pass |
| External monitor (HDMI) across suspend | Pass |
| Overnight suspend cycle (8+ hours) | Pass |
| Multi-night suspend cycle (48+ hours) | Pass |
| Bluetooth audio (headset playback and mic) across suspend | Pass |
| Built-in webcam after resume | Pass |
| `invalid position` / `scheduling while atomic` kernel errors (with the timestamp fix below) | Gone |
| `appletbdrm *ERROR* Failed to send message` on module unload | Gone |
| `brcmfmac: brcmf_pcie_pm_enter_D3: Timeout` | Gone |
| Playback resume after suspend (Spotify, local audio) | Pass |
| Record after resume (microphone input) | Pass |
| Wi-Fi reconnect after resume | Pass |
| Bluetooth recovers/reconnects after resume | Pass |
| Screen capture (grim) after resume | Pass |
| Audio recording (arecord) after resume | Pass |

## For testers

The service installs and enables automatically via Omarchy on T2 Macs
(detected via PCI ID `106b:180[12]`). To test:

```bash
# After updating Omarchy, the migration runs automatically on next update,
# or run it local manually:
OMARCHY_PATH=~/Projects/omarchy bash ~/Projects/omarchy/migrations/1780075490.sh

# Check status:
systemctl status omarchy-apple-t2-suspend.service
journalctl -t t2-suspend

# Test a suspend cycle:
systemctl suspend
```

### Legacy apple_bce kernel requirement (for clean audio after reload)

This requirement applies to all systems using the legacy `apple_bce` driver,
regardless of the current `pm_async` setting. It does not apply to the new
`t2bce` stack.

The service unbinds aaudio and unloads/reloads apple_bce on every suspend/resume
cycle, regardless of the current pm_async setting. Clean audio after any `apple_bce`
reload requires the PLAYBACK timestamp fix from `t2linux/apple-bce-drv#30`. Without it,
`aaudio_pcm_pointer` can return an invalid position after module re-probe,
causing XRUNs and `"scheduling while atomic"` errors.

**The fix is included in `linux-lts-t2` 6.18.36-1 and newer. As of `linux-t2`
7.1.4-1, it has not yet been imported into the mainline `linux-t2` package.**

The patch is one line in `audio/pcm.c`: change `dev_timestamp` → `os_timestamp`
in the `aaudio_handle_stream_timestamp` call for the PLAYBACK substream.

Mainline linux-t2 testers running 7.1.4-1 or an older legacy apple_bce kernel can rebuild
and install the corrected upstream driver:

```bash
git clone https://github.com/t2linux/apple-bce-drv && cd apple-bce-drv
make -C /lib/modules/$(uname -r)/build M=$PWD
# Backup original compressed module, then install the patched one
sudo mv /lib/modules/$(uname -r)/kernel/drivers/staging/apple-bce/apple-bce.ko.zst \
       /lib/modules/$(uname -r)/kernel/drivers/staging/apple-bce/apple-bce.ko.zst.bak
sudo cp apple-bce.ko /lib/modules/$(uname -r)/kernel/drivers/staging/apple-bce/
sudo depmod -a
```

### Model compatibility

Installation is gated by the presence of an Apple T2 PCI device
(`106b:1801` or `106b:1802`), not by a fixed list of Mac model identifiers.
At runtime, the helper exits without making changes unless the legacy
`apple_bce` driver is available. The common module list accommodates differences
between models by handling unloaded or unavailable modules silently.

Wi-Fi recovery is selected by chipset:

- On BCM4364 (`14e4:4464`), `brcmfmac` remains bound so the kernel can manage
  its PCI power transition. This path has been validated on a MacBookPro16,1:
  Wi-Fi returns immediately and Bluetooth and the Touch Bar recover correctly.
- Other T2 configurations use the module-cycling path validated with BCM4377b
  on the MacBookPro15,4. Additional Wi-Fi chipsets have not been specifically
  validated.

The recovery sequence has been validated on MacBookPro15,4 and MacBookPro16,1,
with additional successful testing reported on MacBookAir8,1 and the 2018 Mac
mini.

On the MacBookPro16,1, extended testing exposed a separate kernel device-suspend
failure involving asynchronous `amdgpu` and `brcmfmac` callbacks. Sixteen
consecutive cycles completed successfully when combined with `pm_async=0` from
#6149. That issue occurs outside this helper and does not require additional
dGPU module handling here.

## Debugging

If suspend/resume doesn't work on your model, collect the debug info:

```bash
collect-t2-debug() {
  echo "=== Service log ===" ; journalctl -t t2-suspend
  echo "=== Kernel errors ===" ; sudo dmesg | grep -iE "XRUN|appletbdrm|brcmfmac|apple_bce"
  echo "=== Modules ===" ; lsmod | grep -E "apple|brcmfmac"
  echo "=== Suspend method ===" ; cat /sys/power/mem_sleep
  echo "=== Model ===" ; cat /sys/class/dmi/id/product_name ; cat /sys/class/dmi/id/product_version
  echo "=== Kernel ===" ; uname -r
  echo "=== Cmdline ===" ; cat /proc/cmdline
  echo "=== PCI devices ===" ; lspci -nn | grep -iE "106b|vga|3d|display"
  echo "=== Async device suspend ===" ; cat /sys/power/pm_async
}
collect-t2-debug > ~/t2-debug.txt
```
Then attach `~/t2-debug.txt` to your comment.