### PR TITLE
Gate sudo fingerprint behind lid state (clamshell)

### DIFF
--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -18,6 +18,13 @@ remove_pam_config() {
     echo "Removing fingerprint authentication from polkit..."
     sudo sed -i '/pam_fprintd\.so/d' /etc/pam.d/polkit-1
   fi
+
+  # Remove the sudo lid guard + helper (added when fingerprint was set up on a laptop)
+  if grep -q omarchy-lid-open /etc/pam.d/sudo 2>/dev/null; then
+    echo "Removing lid guard from sudo..."
+    sudo sed -i '/omarchy-lid-open/d' /etc/pam.d/sudo
+  fi
+  sudo rm -f /usr/local/bin/omarchy-lid-open
 }
 
 remove_hyprlock_fingerprint_icon() {

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -37,7 +37,7 @@ install_lid_helper() {
 # omarchy:summary=Exit 0 if the laptop lid is open (used by PAM to gate fingerprint auth)
 for f in /proc/acpi/button/lid/*/state; do
   [[ -r "$f" ]] || continue
-  grep -q open "$f" && exit 0 || exit 1
+  if grep -q open "$f"; then exit 0; else exit 1; fi
 done
 exit 0
 EOF

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -18,14 +18,50 @@ check_fingerprint_hardware() {
   return 0
 }
 
+# True only on machines with an ACPI lid button (i.e. laptops). Desktops fall
+# through and keep the plain "fingerprint first" behavior, untouched.
+has_lid() {
+  local f
+  for f in /proc/acpi/button/lid/*/state; do
+    [[ -e "$f" ]] && return 0
+  done
+  return 1
+}
+
+# Install the lid-state helper that pam_exec consults before pam_fprintd.
+# Lives in /usr/local/bin so PAM (root) has a stable path independent of $PATH.
+install_lid_helper() {
+  echo "Installing lid-state helper for fingerprint gating..."
+  sudo tee /usr/local/bin/omarchy-lid-open >/dev/null <<'EOF'
+#!/bin/bash
+# omarchy:summary=Exit 0 if the laptop lid is open (used by PAM to gate fingerprint auth)
+for f in /proc/acpi/button/lid/*/state; do
+  [[ -r "$f" ]] || continue
+  grep -q open "$f" && exit 0 || exit 1
+done
+exit 0
+EOF
+  sudo chmod 755 /usr/local/bin/omarchy-lid-open
+}
+
 setup_pam_config() {
-  # Configure sudo
+  # Configure sudo. On laptops, gate pam_fprintd behind the lid state so a
+  # closed-lid / clamshell session falls straight through to the password
+  # prompt instead of blocking on an unreachable reader.
   if ! grep -q pam_fprintd.so /etc/pam.d/sudo; then
     echo "Configuring sudo for fingerprint authentication..."
     sudo sed -i '1i auth    sufficient pam_fprintd.so' /etc/pam.d/sudo
   fi
 
-  # Configure polkit
+  if has_lid && ! grep -q omarchy-lid-open /etc/pam.d/sudo; then
+    echo "Gating sudo fingerprint behind lid state..."
+    install_lid_helper
+    sudo sed -i '/pam_fprintd\.so/i auth    [success=ignore default=1] pam_exec.so quiet /usr/local/bin/omarchy-lid-open' /etc/pam.d/sudo
+  fi
+
+  # Configure polkit (unchanged). The polkit agent shows a password field in
+  # parallel with fingerprint, so it never blocks the way terminal sudo does
+  # and needs no lid guard.
   if [[ -f /etc/pam.d/polkit-1 ]] && ! grep -q 'pam_fprintd.so' /etc/pam.d/polkit-1; then
     echo "Configuring polkit for fingerprint authentication..."
     sudo sed -i '1i auth      sufficient pam_fprintd.so' /etc/pam.d/polkit-1

--- a/migrations/1780152390.sh
+++ b/migrations/1780152390.sh
@@ -15,7 +15,7 @@ if grep -q pam_fprintd.so /etc/pam.d/sudo && ! grep -q omarchy-lid-open /etc/pam
 # omarchy:summary=Exit 0 if the laptop lid is open (used by PAM to gate fingerprint auth)
 for f in /proc/acpi/button/lid/*/state; do
   [[ -r "$f" ]] || continue
-  grep -q open "$f" && exit 0 || exit 1
+  if grep -q open "$f"; then exit 0; else exit 1; fi
 done
 exit 0
 EOF

--- a/migrations/1780152390.sh
+++ b/migrations/1780152390.sh
@@ -1,0 +1,26 @@
+echo "Gate sudo fingerprint behind lid state (skip fingerprint when the laptop lid is closed)"
+
+# Desktops / machines without an ACPI lid button are left completely untouched.
+lid_present=false
+for f in /proc/acpi/button/lid/*/state; do
+  [[ -e "$f" ]] && lid_present=true
+done
+$lid_present || exit 0
+
+# Only relevant if sudo actually uses fingerprint and isn't already guarded.
+if grep -q pam_fprintd.so /etc/pam.d/sudo && ! grep -q omarchy-lid-open /etc/pam.d/sudo; then
+  # Install / refresh the lid-state helper used by pam_exec.
+  sudo tee /usr/local/bin/omarchy-lid-open >/dev/null <<'EOF'
+#!/bin/bash
+# omarchy:summary=Exit 0 if the laptop lid is open (used by PAM to gate fingerprint auth)
+for f in /proc/acpi/button/lid/*/state; do
+  [[ -r "$f" ]] || continue
+  grep -q open "$f" && exit 0 || exit 1
+done
+exit 0
+EOF
+  sudo chmod 755 /usr/local/bin/omarchy-lid-open
+
+  # Insert the guard immediately above the existing pam_fprintd line.
+  sudo sed -i '/pam_fprintd\.so/i auth    [success=ignore default=1] pam_exec.so quiet /usr/local/bin/omarchy-lid-open' /etc/pam.d/sudo
+fi


### PR DESCRIPTION
## Problem

When fingerprint auth is set up, `omarchy-setup-security-fingerprint` inserts `auth sufficient pam_fprintd.so` at the **top** of `/etc/pam.d/sudo`. Because it is first and `sufficient`, `pam_fprintd` grabs stdin with "Place your finger…" and **blocks the password prompt** until it times out.

In clamshell mode (laptop lid closed, docked to an external display) the reader is physically unreachable, so every `sudo` forces an awkward wait before you can type your password.

## Fix (sudo only)

Run `pam_fprintd` **only when the lid is open**. PAM can't read lid state, so a tiny `pam_exec` helper (`/usr/local/bin/omarchy-lid-open`) gates it:

```
auth    [success=ignore default=1] pam_exec.so quiet /usr/local/bin/omarchy-lid-open
auth    sufficient                 pam_fprintd.so
auth    include                    system-auth        # (unchanged)
```

- **Lid open** → helper exits 0 → `success=ignore` → falls through to `pam_fprintd` → fingerprint as before.
- **Lid closed** → helper exits 1 → `default=1` → jumps over the fprintd line → straight to the password stack.
- **Helper missing / errors / lid state unknown** → non-success → `default=1` → password. **Fail-safe: never a lockout.**

## Scope & safety

- **sudo only.** `/etc/pam.d/polkit-1` is intentionally left as-is — the polkit agent shows a password field *in parallel* with fingerprint, so it never blocks the way terminal `sudo` does.
- **Desktops / non-laptops untouched.** `has_lid()` is false when there is no `/proc/acpi/button/lid/*/state`, so setup inserts only the plain `pam_fprintd` line (today's behavior), no helper is installed, and the migration no-ops. A laptop with no ACPI lid button is treated like a desktop (fix simply doesn't engage).
- `pam_exec` ships with the base `pam` package — no new dependency.
- The helper lives in `/usr/local/bin` (not repo `bin/`, which is only on the user's `$PATH`) so PAM as root has a stable absolute path. Installed via `sudo tee`, mirroring the existing polkit-1 heredoc.

## Changes

- `bin/omarchy-setup-security-fingerprint`: `has_lid()`, `install_lid_helper()`; on laptops insert the lid guard above the sudo `pam_fprintd` line. polkit untouched.
- `bin/omarchy-remove-security-fingerprint`: strip the guard from sudo and remove the helper.
- `migrations/1780152390.sh`: upgrade existing laptop installs idempotently; no-op on desktops.

## Testing

Verified locally on a ThinkPad X1 Carbon gen 14 (Omarchy 3.8.2):

- `bash -n` clean on all three scripts.
- Helper tested against real `/proc` (lid open → exit 0), simulated closed lid (exit 1), and no-lid/desktop (exit 0).
- Applied the migration on a live `/etc/pam.d/sudo` (with backup) and exercised `sudo -k; sudo true` in both lid states: lid open prompts for fingerprint as before; lid closed (clamshell on external monitor) goes straight to the password prompt with no fingerprint wait. Toggled back and forth repeatedly with consistent results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
