### PR TITLE
Support local favicon discovery for webapp install

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -1,26 +1,120 @@
 #!/bin/bash
 
 # omarchy:summary=Create a desktop launcher for a web app
-# omarchy:args=[name url icon [custom-exec] [mime-types]]
+# omarchy:args=[name url [icon [custom-exec] [mime-types]]]
 
 set -e
 
 ICON_DIR="$HOME/.local/share/applications/icons"
 
-if (( $# < 3 )); then
+normalize_url() {
+  local url="$1"
+
+  if [[ -z $url ]]; then
+    return
+  fi
+
+  if [[ ! $url =~ ^[a-zA-Z][a-zA-Z0-9+.-]*: ]]; then
+    url="https://$url"
+  fi
+
+  printf '%s\n' "$url"
+}
+
+url_origin() {
+  local url="$1"
+  local scheme="${url%%://*}"
+  local rest="${url#*://}"
+  local host="${rest%%/*}"
+
+  printf '%s://%s\n' "$scheme" "$host"
+}
+
+url_directory() {
+  local url="$1"
+  local origin rest path
+
+  origin=$(url_origin "$url")
+  rest="${url#*://}"
+  path="${rest#*/}"
+
+  if [[ $path == "$rest" ]]; then
+    printf '%s/\n' "$origin"
+    return
+  fi
+
+  path="/${path%%[?#]*}"
+  if [[ $path == */ ]]; then
+    printf '%s%s\n' "$origin" "$path"
+  else
+    printf '%s%s/\n' "$origin" "${path%/*}"
+  fi
+}
+
+absolute_icon_url() {
+  local icon_ref="$1"
+  local app_url="$2"
+
+  if [[ $icon_ref =~ ^https?:// ]]; then
+    printf '%s\n' "$icon_ref"
+  elif [[ $icon_ref == //* ]]; then
+    printf '%s:%s\n' "${app_url%%://*}" "$icon_ref"
+  elif [[ $icon_ref == /* ]]; then
+    printf '%s%s\n' "$(url_origin "$app_url")" "$icon_ref"
+  else
+    printf '%s%s\n' "$(url_directory "$app_url")" "$icon_ref"
+  fi
+}
+
+discover_icon_url() {
+  local app_url="$1"
+  local icon_ref
+
+  icon_ref=$(curl -fsSL "$app_url" |
+    tr '\n' ' ' |
+    grep -Eio '<link[^>]+>' |
+    grep -Eim1 'rel=["'\''"][^"'\'']*(apple-touch-icon|icon)[^"'\'']*["'\''"]' |
+    grep -Eio 'href=["'\''"][^"'\'']+["'\''"]' |
+    head -n1 |
+    sed -E 's/^href=["'\''"]([^"'\'']+)["'\''"]$/\1/')
+
+  [[ -n $icon_ref ]] && absolute_icon_url "$icon_ref" "$app_url"
+}
+
+download_icon() {
+  local icon_url="$1"
+  local icon_path="$ICON_DIR/$APP_NAME.png"
+
+  curl -fsSL -o "$icon_path" "$icon_url" && [[ -s $icon_path ]]
+}
+
+use_default_icon() {
+  local icon_url
+
+  mkdir -p "$ICON_DIR"
+
+  if icon_url=$(discover_icon_url "$APP_URL") && [[ -n $icon_url ]] && download_icon "$icon_url"; then
+    ICON_REF="$APP_NAME.png"
+    return 0
+  fi
+
+  icon_url="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
+  if download_icon "$icon_url"; then
+    ICON_REF="$APP_NAME.png"
+    return 0
+  fi
+
+  return 1
+}
+
+if (( $# == 0 )); then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
   APP_URL=$(gum input --prompt "URL> " --placeholder "https://example.com")
-  if [[ ! $APP_URL =~ ^[a-zA-Z][a-zA-Z0-9+.-]*: ]]; then
-    APP_URL="https://$APP_URL"
-  fi
+  APP_URL=$(normalize_url "$APP_URL")
 
   # Try to fetch favicon automatically first.
-  FAVICON_URL="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
-  mkdir -p "$ICON_DIR"
-  if curl -fsSL -o "$ICON_DIR/$APP_NAME.png" "$FAVICON_URL" && [[ -s $ICON_DIR/$APP_NAME.png ]]; then
-    ICON_REF="$APP_NAME.png"
-  else
+  if ! use_default_icon; then
     ICON_REF=$(gum input --prompt "Icon URL> " --placeholder "Could not fetch favicon automatically. Enter PNG icon URL (see https://dashboardicons.com)")
   fi
 
@@ -30,9 +124,7 @@ if (( $# < 3 )); then
 else
   APP_NAME="$1"
   APP_URL="$2"
-  if [[ ! $APP_URL =~ ^[a-zA-Z][a-zA-Z0-9+.-]*: ]]; then
-    APP_URL="https://$APP_URL"
-  fi
+  APP_URL=$(normalize_url "$APP_URL")
   ICON_REF="$3"
   CUSTOM_EXEC="$4" # Optional custom exec command
   MIME_TYPES="$5"  # Optional mime types
@@ -48,8 +140,9 @@ fi
 # Resolve icon from URL or from a local icon name.
 mkdir -p "$ICON_DIR"
 
-if [[ -z $ICON_REF ]]; then
-  ICON_REF="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
+if [[ -z $ICON_REF ]] && ! use_default_icon; then
+  echo "Error: Failed to discover or download icon. Pass an icon URL or local icon name."
+  exit 1
 fi
 
 if [[ $ICON_REF =~ ^https?:// ]]; then

--- a/test/omarchy-webapp-install-test.sh
+++ b/test/omarchy-webapp-install-test.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT/bin/omarchy-webapp-install"
+TMPDIR=""
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local description="$1"
+  local file="$2"
+  local expected="$3"
+
+  if ! grep -Fq "$expected" "$file"; then
+    printf 'Expected %s to contain: %s\n' "$file" "$expected" >&2
+    printf 'Actual file:\n' >&2
+    cat "$file" >&2
+    fail "$description"
+  fi
+
+  pass "$description"
+}
+
+assert_file_equals() {
+  local description="$1"
+  local file="$2"
+  local expected="$3"
+  local actual
+
+  actual=$(cat "$file")
+  if [[ $actual != "$expected" ]]; then
+    printf 'Expected %s to equal: %s\n' "$file" "$expected" >&2
+    printf 'Actual: %s\n' "$actual" >&2
+    fail "$description"
+  fi
+
+  pass "$description"
+}
+
+cleanup() {
+  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+TMPDIR=$(mktemp -d)
+mkdir -p "$TMPDIR/bin"
+
+cat >"$TMPDIR/bin/curl" <<'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+output=""
+url=""
+
+while (($#)); do
+  case "$1" in
+  -o)
+    output="$2"
+    shift 2
+    ;;
+  -*)
+    shift
+    ;;
+  *)
+    url="$1"
+    shift
+    ;;
+  esac
+done
+
+printf '%s\n' "$url" >>"$CURL_LOG"
+
+write_output() {
+  local body="$1"
+
+  if [[ -n $output ]]; then
+    mkdir -p "$(dirname -- "$output")"
+    printf '%s' "$body" >"$output"
+  else
+    printf '%s' "$body"
+  fi
+}
+
+if [[ $url == "http://localhost:9001" ]]; then
+  write_output '<html><head><link rel="icon" href="images/favicon.png?version=1"></head></html>'
+elif [[ $url == "http://localhost:9001/images/favicon.png?version=1" ]]; then
+  write_output 'local-icon'
+elif [[ $url == "http://no-icon.local" ]]; then
+  write_output '<html><head><title>No icon</title></head></html>'
+elif [[ $url == "https://www.google.com/s2/favicons?domain=http://no-icon.local&sz=128" ]]; then
+  write_output 'google-icon'
+else
+  printf 'Unexpected curl URL: %s\n' "$url" >&2
+  exit 22
+fi
+EOF
+chmod +x "$TMPDIR/bin/curl"
+
+export PATH="$TMPDIR/bin:$ROOT/bin:$PATH"
+
+reset_home() {
+  local name="$1"
+
+  export HOME="$TMPDIR/home-$name"
+  export CURL_LOG="$TMPDIR/$name-curl.log"
+  mkdir -p "$HOME"
+  : >"$CURL_LOG"
+}
+
+reset_home local
+"$SCRIPT" Penpot http://localhost:9001
+
+desktop_file="$HOME/.local/share/applications/Penpot.desktop"
+icon_file="$HOME/.local/share/applications/icons/Penpot.png"
+[[ -f $desktop_file ]] || fail "two-argument install creates desktop file"
+[[ -f $icon_file ]] || fail "two-argument install creates icon file"
+pass "two-argument install creates files"
+assert_file_contains "two-argument install writes app exec" "$desktop_file" "Exec=omarchy-launch-webapp http://localhost:9001"
+assert_file_contains "two-argument install writes icon path" "$desktop_file" "Icon=$icon_file"
+assert_file_equals "two-argument install uses local favicon" "$icon_file" "local-icon"
+if grep -Fq 'google.com/s2/favicons' "$CURL_LOG"; then
+  fail "local favicon avoids Google fallback"
+fi
+pass "local favicon avoids Google fallback"
+
+reset_home google
+"$SCRIPT" NoIcon http://no-icon.local
+
+icon_file="$HOME/.local/share/applications/icons/NoIcon.png"
+assert_file_equals "missing local favicon falls back to Google favicon" "$icon_file" "google-icon"
+
+reset_home saved
+mkdir -p "$HOME/.local/share/applications/icons"
+printf 'saved-icon' >"$HOME/.local/share/applications/icons/Saved.png"
+"$SCRIPT" SavedApp http://saved.local Saved.png
+
+desktop_file="$HOME/.local/share/applications/SavedApp.desktop"
+assert_file_contains "saved local icon name is resolved from icon directory" "$desktop_file" "Icon=$HOME/.local/share/applications/icons/Saved.png"
+if [[ -s $CURL_LOG ]]; then
+  fail "saved local icon name does not call curl"
+fi
+pass "saved local icon name does not call curl"
+
+reset_home invalid
+if "$SCRIPT" OnlyName >"$TMPDIR/invalid.out" 2>"$TMPDIR/invalid.err"; then
+  fail "single-argument install fails"
+fi
+assert_file_contains "single-argument install explains missing URL" "$TMPDIR/invalid.out" "You must set app name and app URL!"


### PR DESCRIPTION
## Summary
- Allow `omarchy webapp install <name> <url>` to run non-interactively without an icon argument.
- Try the web app's advertised favicon first, including relative icon paths, before falling back to Google's favicon service.
- Keep explicit icon URLs and saved local icon names working as before.

## Tests
- `bash test/omarchy-webapp-install-test.sh`
- `bash test/omarchy-cli-test.sh`
- `git diff --check upstream/dev...HEAD`