### PR TITLE
Preserve waybar tray icons on theme changes

### DIFF
--- a/bin/omarchy-refresh-waybar
+++ b/bin/omarchy-refresh-waybar
@@ -5,4 +5,4 @@
 
 omarchy-refresh-config waybar/config.jsonc
 omarchy-refresh-config waybar/style.css
-omarchy-restart-waybar
+OMARCHY_WAYBAR_FULL_RESTART=1 omarchy-restart-waybar

--- a/bin/omarchy-refresh-waybar
+++ b/bin/omarchy-refresh-waybar
@@ -5,4 +5,4 @@
 
 omarchy-refresh-config waybar/config.jsonc
 omarchy-refresh-config waybar/style.css
-OMARCHY_WAYBAR_FULL_RESTART=1 omarchy-restart-waybar
+omarchy-restart-waybar

--- a/bin/omarchy-restart-waybar
+++ b/bin/omarchy-restart-waybar
@@ -3,5 +3,22 @@
 # omarchy:summary=Restart Waybar
 # omarchy:examples=omarchy restart waybar
 
-pkill -9 -x waybar
-setsid uwsm-app -- waybar >/dev/null 2>&1 &
+# By default, hot-reload waybar's CSS to preserve tray icons.
+# Set OMARCHY_WAYBAR_FULL_RESTART=1 to force a full restart (e.g. for config changes).
+if [[ ${OMARCHY_WAYBAR_FULL_RESTART:-0} == 1 ]]; then
+  pkill -x waybar
+  sleep 0.5
+  setsid uwsm-app -- waybar >/dev/null 2>&1 &
+else
+  style_css=~/.config/waybar/style.css
+  if [[ -f $style_css ]] && head -1 "$style_css" | grep -qE "^\s*@import"; then
+    # Add a timestamp comment to the first @import to trigger the file monitor.
+    # Waybar's reload_style_on_change watches style.css and re-applies on change.
+    sed -i "1s|\(@import[^;]*\);|\1; /* reloaded: $(date +%s) */|" "$style_css"
+  else
+    # Fall back to full restart if style.css is missing or doesn't start with @import
+    pkill -x waybar
+    sleep 0.5
+    setsid uwsm-app -- waybar >/dev/null 2>&1 &
+  fi
+fi

--- a/bin/omarchy-restart-waybar
+++ b/bin/omarchy-restart-waybar
@@ -3,21 +3,25 @@
 # omarchy:summary=Restart Waybar
 # omarchy:examples=omarchy restart waybar
 
-# By default, hot-reload waybar's CSS to preserve tray icons.
-# Set OMARCHY_WAYBAR_FULL_RESTART=1 to force a full restart (e.g. for config changes).
 if [[ -z ${DBUS_SESSION_BUS_ADDRESS:-} && -z ${XDG_RUNTIME_DIR:-} ]]; then
   echo "omarchy-restart-waybar: no D-Bus session; skipping waybar restart" >&2
   exit 0
 fi
 
-if [[ ${OMARCHY_WAYBAR_FULL_RESTART:-0} == 1 ]]; then
+if [[ ${OMARCHY_WAYBAR_HOT_RELOAD:-0} == 1 ]]; then
+  style_css=~/.config/waybar/style.css
+  if [[ -f $style_css ]] && head -1 "$style_css" | grep -qE "^\s*@import"; then
+    sed -i "1s|\(@import[^;]*\);.*|\1; /* reloaded: $(date +%s) */|" "$style_css"
+  else
+    pkill -x waybar
+    sleep 0.5
+    setsid uwsm-app -- waybar >/dev/null 2>&1 &
+  fi
+else
   pkill -x waybar
   sleep 0.5
   setsid uwsm-app -- waybar >/dev/null 2>&1 &
 
-  # Wait for the new watcher to come up, then re-register SNI items.
-  # Some SNI clients (e.g. ProtonVPN) do not watch for the watcher name
-  # and re-register automatically when it re-appears.
   for i in 1 2 3 4 5 6 7 8 9 10; do
     if busctl --user list 2>/dev/null | grep -q "^org.kde.StatusNotifierWatcher"; then
       break
@@ -28,16 +32,4 @@ if [[ ${OMARCHY_WAYBAR_FULL_RESTART:-0} == 1 ]]; then
     busctl call --user org.kde.StatusNotifierWatcher /StatusNotifierWatcher \
       org.kde.StatusNotifierWatcher RegisterStatusNotifierItem s "$item" 2>/dev/null
   done
-else
-  style_css=~/.config/waybar/style.css
-  if [[ -f $style_css ]] && head -1 "$style_css" | grep -qE "^\s*@import"; then
-    # Add a timestamp comment to the first @import to trigger the file monitor.
-    # Waybar's reload_style_on_change watches style.css and re-applies on change.
-    sed -i "1s|\(@import[^;]*\);.*|\1; /* reloaded: $(date +%s) */|" "$style_css"
-  else
-    # Fall back to full restart if style.css is missing or doesn't start with @import
-    pkill -x waybar
-    sleep 0.5
-    setsid uwsm-app -- waybar >/dev/null 2>&1 &
-  fi
 fi

--- a/bin/omarchy-restart-waybar
+++ b/bin/omarchy-restart-waybar
@@ -5,6 +5,11 @@
 
 # By default, hot-reload waybar's CSS to preserve tray icons.
 # Set OMARCHY_WAYBAR_FULL_RESTART=1 to force a full restart (e.g. for config changes).
+if [[ -z ${DBUS_SESSION_BUS_ADDRESS:-} && -z ${XDG_RUNTIME_DIR:-} ]]; then
+  echo "omarchy-restart-waybar: no D-Bus session; skipping waybar restart" >&2
+  exit 0
+fi
+
 if [[ ${OMARCHY_WAYBAR_FULL_RESTART:-0} == 1 ]]; then
   pkill -x waybar
   sleep 0.5

--- a/bin/omarchy-restart-waybar
+++ b/bin/omarchy-restart-waybar
@@ -9,12 +9,26 @@ if [[ ${OMARCHY_WAYBAR_FULL_RESTART:-0} == 1 ]]; then
   pkill -x waybar
   sleep 0.5
   setsid uwsm-app -- waybar >/dev/null 2>&1 &
+
+  # Wait for the new watcher to come up, then re-register SNI items.
+  # Some SNI clients (e.g. ProtonVPN) do not watch for the watcher name
+  # and re-register automatically when it re-appears.
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if busctl --user list 2>/dev/null | grep -q "^org.kde.StatusNotifierWatcher"; then
+      break
+    fi
+    sleep 0.2
+  done
+  for item in $(busctl --user list 2>/dev/null | awk '/^org\.kde\.StatusNotifierItem-/ {print $1}'); do
+    busctl call --user org.kde.StatusNotifierWatcher /StatusNotifierWatcher \
+      org.kde.StatusNotifierWatcher RegisterStatusNotifierItem s "$item" 2>/dev/null
+  done
 else
   style_css=~/.config/waybar/style.css
   if [[ -f $style_css ]] && head -1 "$style_css" | grep -qE "^\s*@import"; then
     # Add a timestamp comment to the first @import to trigger the file monitor.
     # Waybar's reload_style_on_change watches style.css and re-applies on change.
-    sed -i "1s|\(@import[^;]*\);|\1; /* reloaded: $(date +%s) */|" "$style_css"
+    sed -i "1s|\(@import[^;]*\);.*|\1; /* reloaded: $(date +%s) */|" "$style_css"
   else
     # Fall back to full restart if style.css is missing or doesn't start with @import
     pkill -x waybar

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -51,7 +51,7 @@ fi
 
 # Restart components to apply new theme
 if pgrep -x waybar >/dev/null; then
-  omarchy-restart-waybar
+  OMARCHY_WAYBAR_HOT_RELOAD=1 omarchy-restart-waybar
 fi
 omarchy-restart-swayosd
 omarchy-restart-terminal


### PR DESCRIPTION
## Problem

`omarchy-restart-waybar` kills waybar with `pkill -9`, which briefly releases waybar's `org.kde.StatusNotifierWatcher` D-Bus role. When waybar restarts and re-acquires the role, some apps don't re-register their tray icons, leaving the user without tray access for those apps until they're manually restarted.

This is most visible when running `omarchy theme set`, which calls `omarchy-restart-waybar` for every theme change.

When called from a shell environment without `DBUS_SESSION_BUS_ADDRESS` or `XDG_RUNTIME_DIR` (a TTY, an SSH session, a service with no graphical context), `pkill -x waybar` still kills the running waybar, but `setsid uwsm-app -- waybar` then fails to start a replacement, leaving the user with no bar at all.

## Fix

Make the in-place CSS hot-reload the opt-in (for theme-set, which wants to avoid the tray flicker), and a full restart with SNI re-registration the default (so picking "Restart Waybar" from the menu actually applies any pending config.jsonc change).

- **`bin/omarchy-restart-waybar`**:
  - Aborts with `exit 0` and a stderr note if no D-Bus session is available. File-system side effects of `omarchy-theme-set` still apply; only the in-place restart is skipped.
  - Default behaviour: kill waybar, start a fresh one, then wait for the new watcher to acquire its bus name and call `RegisterStatusNotifierItem` on every `org.kde.StatusNotifierItem-*` name on the session bus. This restores tray icons from SNI clients that don't watch the watcher name and re-register themselves (notably ProtonVPN, which is non-compliant with the SNI spec in this respect).
  - With `OMARCHY_WAYBAR_HOT_RELOAD=1`: re-trigger the file monitor by adding a fresh `/* reloaded: ... */` comment to the first `@import` in `style.css`. Falls back to a full restart if the file is missing or doesn't start with `@import`.
  - Drops the `-9` from `pkill` so waybar can release the watcher name cleanly.

- **`bin/omarchy-theme-set`**: Now sets `OMARCHY_WAYBAR_HOT_RELOAD=1` so theme changes stay flicker-free.

## Why it works

For theme changes, hot-reloading `style.css` is enough — `reload_style_on_change: true` is on by default in the omarchy waybar config, so waybar re-parses the CSS (including its `@import` of the current theme file) without destroying any modules. The D-Bus watcher role is never released, so apps don't need to re-register.

For config changes (the menu's "Restart Waybar" item, or after editing `config.jsonc` in the editor), a full restart is needed. The post-restart re-registration step uses `busctl` to find every SNI item already on the session bus and tell the new watcher about it. Compliant clients ignore duplicate registrations.

## Related

- Alexays/Waybar#3468 — Tray module not visible after some time. No such object path '/StatusNotifierWatcher'

## Testing

1. Start waybar with the default config and a tray app.
2. Run `omarchy theme set <any-theme>` — tray icons should stay visible (no flicker).
3. Edit `~/.config/waybar/config.jsonc` (e.g. change `height`), save, then pick `Update → Process → Waybar` from the omarchy menu — the bar should restart with the new config applied and all tray icons reappear within ~2s.
4. From a TTY (`Ctrl+Alt+F2`) or a stripped shell (`env -i HOME=$HOME PATH=/usr/bin bash -c omarchy-restart-waybar`): the script should print `omarchy-restart-waybar: no D-Bus session; skipping waybar restart` and leave the running waybar alone.