### PR TITLE
feat: preview and override the icon when installing a web app

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -15,18 +15,33 @@ if (( $# < 3 )); then
     APP_URL="https://$APP_URL"
   fi
 
-  # Fetch the favicon to offer as the default icon, and preview it so you can
-  # decide whether to keep it or supply your own.
+  # Fetch the favicon to offer as the default icon. Terminals with a real
+  # graphics protocol (kitty/ghostty via the kitty protocol, foot via sixel)
+  # get an inline preview; on every terminal we also print the favicon as a
+  # clickable link, so even Alacritty (the default, which has no inline-image
+  # support and would only get unreliable ASCII art from chafa) can preview it.
   FAVICON_URL="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
   mkdir -p "$ICON_DIR"
   DEFAULT_ICON="$(mktemp --suffix=.png)"
   if curl -fsSL -o "$DEFAULT_ICON" "$FAVICON_URL" && [[ -s $DEFAULT_ICON ]]; then
-    if command -v chafa &>/dev/null; then
+    # Pick the graphics protocol for the running terminal, if any.
+    PREVIEW_FORMAT=""
+    if [[ -n $KITTY_WINDOW_ID || $TERM == xterm-kitty || -n $GHOSTTY_BIN_DIR || -n $GHOSTTY_RESOURCES_DIR || $TERM == xterm-ghostty ]]; then
+      PREVIEW_FORMAT="kitty" # kitty graphics protocol (kitty, ghostty)
+    elif [[ $TERM == foot* ]]; then
+      PREVIEW_FORMAT="sixel"
+    fi
+
+    if [[ -n $PREVIEW_FORMAT ]] && omarchy-cmd-present chafa; then
       echo -e "Default icon preview:\n"
-      chafa --size=16x16 "$DEFAULT_ICON" || true
+      chafa -f "$PREVIEW_FORMAT" --size=16x16 "$DEFAULT_ICON" || true
       echo
     fi
-    ICON_PLACEHOLDER="Press Enter to use the favicon above, or paste a PNG icon URL (see https://dashboardicons.com)"
+
+    # Emit the favicon URL as an OSC 8 hyperlink: clickable where supported
+    # (all four terminals we ship), and still visible/copyable everywhere else.
+    printf 'Default icon: \e]8;;%s\e\\%s\e]8;;\e\\\n\n' "$FAVICON_URL" "$FAVICON_URL"
+    ICON_PLACEHOLDER="Press Enter to use this favicon, or paste a PNG icon URL (see https://dashboardicons.com)"
   else
     rm -f "$DEFAULT_ICON"
     DEFAULT_ICON=""

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -15,13 +15,36 @@ if (( $# < 3 )); then
     APP_URL="https://$APP_URL"
   fi
 
-  # Try to fetch favicon automatically first.
+  # Fetch the favicon to offer as the default icon, and preview it so you can
+  # decide whether to keep it or supply your own.
   FAVICON_URL="https://www.google.com/s2/favicons?domain=${APP_URL}&sz=128"
   mkdir -p "$ICON_DIR"
-  if curl -fsSL -o "$ICON_DIR/$APP_NAME.png" "$FAVICON_URL" && [[ -s $ICON_DIR/$APP_NAME.png ]]; then
+  DEFAULT_ICON="$(mktemp --suffix=.png)"
+  if curl -fsSL -o "$DEFAULT_ICON" "$FAVICON_URL" && [[ -s $DEFAULT_ICON ]]; then
+    if command -v chafa &>/dev/null; then
+      echo -e "Default icon preview:\n"
+      chafa --size=16x16 "$DEFAULT_ICON" || true
+      echo
+    fi
+    ICON_PLACEHOLDER="Press Enter to use the favicon above, or paste a PNG icon URL (see https://dashboardicons.com)"
+  else
+    rm -f "$DEFAULT_ICON"
+    DEFAULT_ICON=""
+    ICON_PLACEHOLDER="Could not fetch favicon automatically. Enter PNG icon URL (see https://dashboardicons.com)"
+  fi
+
+  ICON_INPUT=$(gum input --prompt "Icon URL> " --placeholder "$ICON_PLACEHOLDER")
+
+  if [[ -n $ICON_INPUT ]]; then
+    # A custom icon URL was given; use it instead of the previewed favicon.
+    ICON_REF="$ICON_INPUT"
+    [[ -n $DEFAULT_ICON ]] && rm -f "$DEFAULT_ICON"
+  elif [[ -n $DEFAULT_ICON ]]; then
+    # Keep the previewed favicon as the icon.
+    mv "$DEFAULT_ICON" "$ICON_DIR/$APP_NAME.png"
     ICON_REF="$APP_NAME.png"
   else
-    ICON_REF=$(gum input --prompt "Icon URL> " --placeholder "Could not fetch favicon automatically. Enter PNG icon URL (see https://dashboardicons.com)")
+    ICON_REF=""
   fi
 
   CUSTOM_EXEC=""

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -13,6 +13,7 @@ bluetui
 bolt
 brightnessctl
 btop
+chafa
 chromium
 clang
 claude-code


### PR DESCRIPTION
When adding a web app, you previously only got to choose an icon if the automatic favicon lookup *failed* and you never saw what icon you'd end up with.

Now, after entering the URL, the installer fetches the favicon, shows a preview of it in the terminal, and prompts for an icon:

- Press **Enter** to accept the previewed favicon.
- Paste a **PNG URL** (e.g. from dashboardicons.com) to use a custom icon instead.

If the favicon can't be fetched, it falls back to the previous behavior (prompt for a PNG URL).

The preview uses `chafa` (added to the base package list); when it isn't available the flow still works, just without the preview.

<img width="779" height="298" alt="image" src="https://github.com/user-attachments/assets/3dd8cefe-d3b0-42e5-86a4-e1c205a1364a" />

If the terminal does not support showing images via chafa it will default to showing just the clickable link

<img width="828" height="156" alt="image" src="https://github.com/user-attachments/assets/36761c33-156b-4ab0-9e94-a350031e3a8f" />

