### PR TITLE
Enable IPv6 privacy extensions by default

### DIFF
--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -1,6 +1,13 @@
 # Ensure iwd service will be started
 sudo systemctl enable iwd.service
 
+# Enable IPv6 privacy addresses by default
+sudo mkdir -p /etc/systemd/networkd.conf.d
+sudo tee /etc/systemd/networkd.conf.d/10-omarchy-ipv6-privacy.conf >/dev/null <<'EOF'
+[Network]
+IPv6PrivacyExtensions=yes
+EOF
+
 # Prevent systemd-networkd-wait-online timeout on boot
 sudo systemctl disable systemd-networkd-wait-online.service
 sudo systemctl mask systemd-networkd-wait-online.service

--- a/migrations/1779745014.sh
+++ b/migrations/1779745014.sh
@@ -1,0 +1,9 @@
+echo "Enable IPv6 privacy extensions for systemd-networkd"
+
+if ! grep -Rqs '^[[:space:]]*IPv6PrivacyExtensions[[:space:]]*=' /etc/systemd/networkd.conf /etc/systemd/networkd.conf.d /etc/systemd/network; then
+  sudo mkdir -p /etc/systemd/networkd.conf.d
+  sudo tee /etc/systemd/networkd.conf.d/10-omarchy-ipv6-privacy.conf >/dev/null <<'EOF'
+[Network]
+IPv6PrivacyExtensions=yes
+EOF
+fi


### PR DESCRIPTION
Enable IPv6 privacy extensions by default and add a migration for existing users. The migration does deliberately not restart `systemd-networkd` afterwards to avoid network issues during the following system upgrade; changes will be applied after reboot.

Without PE, clients use a static IPv6 suffix derived from their MAC address, which allows every web service (including any website visited in private mode) to identify and track users just by their IP. PE mitigate this by using temporary randomized addresses, and is therefore the default behavior of essentially all client operating systems like macOS, Windows, and most non-server Linux distros.