### PR TITLE
Make power profile defaults configurable

### DIFF
--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -4,6 +4,21 @@
 # omarchy:args=[autodetect|ac|battery]
 
 action="${1-}"
+config_dir="${OMARCHY_CONFIG_HOME:-}"
+
+if [[ -z $config_dir ]]; then
+  # udev runs this through systemd outside the user session, so $HOME
+  # may be /root. Derive the user config path from the install path.
+  executable=$(readlink -f "$0")
+
+  if [[ $executable == */.local/share/omarchy/bin/omarchy-powerprofiles-set ]]; then
+    config_dir="${executable%/.local/share/omarchy/bin/omarchy-powerprofiles-set}/.config/omarchy"
+  else
+    config_dir="$HOME/.config/omarchy"
+  fi
+fi
+
+config_path="$config_dir/powerprofiles.conf"
 
 # Auto-detect when called with no argument: treat any Mains or USB
 # power-supply device reporting online=1 as "on AC". This handles
@@ -30,16 +45,32 @@ fi
 
 mapfile -t profiles < <(powerprofilesctl list | awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }')
 
+configured_profile() {
+  local profile
+
+  profile=$(awk -F= -v source="$1" '$1 == source { print $2; exit }' "$config_path" 2>/dev/null)
+  [[ -n $profile && " ${profiles[*]} " == *" $profile "* ]] && echo "$profile"
+}
+
 case "$action" in
   ac)
-    # Prefer performance, fall back to balanced
-    if [[ " ${profiles[*]} " == *" performance "* ]]; then
+    profile=$(configured_profile ac)
+
+    if [[ -n $profile ]]; then
+      powerprofilesctl set "$profile"
+    elif [[ " ${profiles[*]} " == *" performance "* ]]; then
       powerprofilesctl set performance
     else
       powerprofilesctl set balanced
     fi
     ;;
   battery)
-    powerprofilesctl set balanced
+    profile=$(configured_profile battery)
+
+    if [[ -n $profile ]]; then
+      powerprofilesctl set "$profile"
+    else
+      powerprofilesctl set balanced
+    fi
     ;;
 esac

--- a/config/omarchy/powerprofiles.conf
+++ b/config/omarchy/powerprofiles.conf
@@ -1,0 +1,4 @@
+# Persistent power profile defaults used by omarchy-powerprofiles-set.
+# Values must match profiles listed by powerprofilesctl.
+ac=performance
+battery=balanced

--- a/migrations/1780735021.sh
+++ b/migrations/1780735021.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "Add configurable power profile defaults"
+
+config_dir="${OMARCHY_CONFIG_HOME:-$HOME/.config/omarchy}"
+
+mkdir -p "$config_dir"
+
+if [ ! -f "$config_dir/powerprofiles.conf" ]; then
+  if [ -z "${OMARCHY_PATH:-}" ]; then
+    echo "OMARCHY_PATH is required to seed power profile defaults" >&2
+    exit 1
+  fi
+
+  template="$OMARCHY_PATH/config/omarchy/powerprofiles.conf"
+
+  if [ ! -f "$template" ]; then
+    echo "Missing power profile defaults: $template" >&2
+    exit 1
+  fi
+
+  cp "$template" "$config_dir/powerprofiles.conf"
+fi


### PR DESCRIPTION
## Summary

This is a smaller version of #5621: no menu, just a persistent config file.

`omarchy-powerprofiles-set` now reads:

```ini
# ~/.config/omarchy/powerprofiles.conf
ac=performance
battery=balanced
```

Those are today's defaults, so behavior is unchanged unless the user edits the file. If the file is missing or contains an unavailable profile, the helper falls back to the existing defaults.

The existing udev rule is unchanged. This makes the Omarchy helper configurable and seeds the default config file.

One important detail: udev launches the helper through the system manager, so `$HOME` is not guaranteed to be the desktop user's home. The helper therefore still honors `OMARCHY_CONFIG_HOME` first, but otherwise derives the user config path from its installed executable path under `~/.local/share/omarchy/bin`. That lets the same config file work from boot, Hyprland autostart, and udev AC/USB events without changing the udev rule.

## Why

Editing the udev rule directly does not hold up as a persistent user preference:

- boot applies the profile outside udev via `omarchy-powerprofiles-init`
- Omarchy regenerates/replaces the power-profile udev rule during migrations/updates
- udev/systemd runs the helper outside the user session, so relying on `$HOME` alone can miss `~/.config/omarchy/powerprofiles.conf`

This gives users an Omarchy-supported override without changing defaults for everyone.

## Testing

- `bash -n bin/omarchy-powerprofiles-set migrations/1780735021.sh`
- `git diff --check`
- `bin/omarchy-powerprofiles-set ac` with local `ac=balanced`
- smoke-tested an installed-path helper with `HOME=/root` and `ac=balanced`, verifying it still reads the user config from the executable path
- smoke-tested `OMARCHY_CONFIG_HOME` override precedence
- `OMARCHY_CONFIG_HOME=/tmp/omarchy-powerprofiles-migration-test/.config/omarchy OMARCHY_PATH=/home/carmine/Code/omarchy bash migrations/1780735021.sh`
