### PR TITLE
Stop forcing Qt style override

### DIFF
--- a/default/hypr/envs.lua
+++ b/default/hypr/envs.lua
@@ -18,7 +18,6 @@ hl.env("HYPRCURSOR_SIZE", "24")
 -- Force all apps to use Wayland.
 hl.env("GDK_BACKEND", "wayland,x11,*")
 hl.env("QT_QPA_PLATFORM", "wayland;xcb")
-hl.env("QT_STYLE_OVERRIDE", "kvantum")
 hl.env("MOZ_ENABLE_WAYLAND", "1")
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "wayland")
 hl.env("OZONE_PLATFORM", "wayland")


### PR DESCRIPTION
## Summary

Remove the global `QT_STYLE_OVERRIDE=kvantum` export from the default Hyprland environment.

`QT_QPA_PLATFORM` still defaults Qt apps to Wayland/XCB; this only stops forcing the Qt style for every Qt app.

## Why

Forcing `QT_STYLE_OVERRIDE` globally prevents Qt settings tools and individual Qt apps from applying their configured style. Omarchy can set the platform default without making the visual Qt style a session-wide override.

## Testing

- `lua -e 'assert(loadfile("default/hypr/envs.lua"))'`
- `git diff --check origin/dev..cp/drop-qt-style-override`
