### PR TITLE
Show hostname in Starship over SSH

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -1,6 +1,6 @@
 add_newline = true
 command_timeout = 200
-format = "[$directory$git_branch$git_status]($style)$character"
+format = "[$hostname$directory$git_branch$git_status]($style)$character"
 
 [character]
 error_symbol = "[✗](bold cyan)"
@@ -30,3 +30,7 @@ stashed    = ""
 staged     = ""
 renamed    = ""
 deleted    = ""
+
+[hostname]
+ssh_only = true
+format = '[$hostname]($style) '

--- a/migrations/1780739892.sh
+++ b/migrations/1780739892.sh
@@ -1,0 +1,23 @@
+echo "Show hostname in Starship over SSH"
+
+starship_config="$HOME/.config/starship.toml"
+old_format_pattern='^[[:space:]]*format = "\[\$directory\$git_branch\$git_status\]\(\$style\)\$character"$'
+
+if [[ -f "$starship_config" ]] && grep -Eq "$old_format_pattern" "$starship_config" && ! grep -q '^\[hostname\]' "$starship_config"; then
+  tmp=$(mktemp)
+  awk '
+    /^[[:space:]]*format = "\[\$directory\$git_branch\$git_status\]\(\$style\)\$character"$/ && !updated {
+      print "format = \"[$hostname$directory$git_branch$git_status]($style)$character\""
+      updated = 1
+      next
+    }
+    { print }
+  ' "$starship_config" >"$tmp" && mv "$tmp" "$starship_config"
+
+  cat >>"$starship_config" <<'EOF'
+
+[hostname]
+ssh_only = true
+format = '[$hostname]($style) '
+EOF
+fi


### PR DESCRIPTION
## Summary

Add Starship's `hostname` module to the prompt with `ssh_only = true`.

Local prompts remain unchanged, but SSH sessions show the hostname before the directory/git segments.

## Why

When working across remote shells, the current prompt makes it too easy to lose track of which machine a terminal is connected to. Starship already supports this exact use case with `ssh_only`, so this keeps the normal local prompt clean while making remote sessions clearer.

## Testing

- `STARSHIP_CONFIG=$PWD/config/starship.toml starship explain`
- `bash -n migrations/1780739892.sh`
- smoke-tested the migration against the previous default Starship format
- `git diff --check origin/dev..cp/starship-ssh-hostname-clean`
