### PR TITLE
Use Inter as the default UI font

### DIFF
--- a/config/fontconfig/fonts.conf
+++ b/config/fontconfig/fonts.conf
@@ -6,6 +6,7 @@
       <string>sans-serif</string>
     </test>
     <edit name="family" mode="assign" binding="strong">
+      <string>Inter</string>
       <string>Liberation Sans</string>
     </edit>
   </match>
@@ -31,6 +32,7 @@
   <alias>
     <family>system-ui</family>
     <prefer>
+      <family>Inter</family>
       <family>Liberation Sans</family>
     </prefer>
   </alias>
@@ -45,6 +47,7 @@
   <alias>
     <family>-apple-system</family>
     <prefer>
+      <family>Inter</family>
       <family>Liberation Sans</family>
     </prefer>
   </alias>
@@ -52,6 +55,7 @@
   <alias>
     <family>BlinkMacSystemFont</family>
     <prefer>
+      <family>Inter</family>
       <family>Liberation Sans</family>
     </prefer>
   </alias>

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -61,6 +61,7 @@ imagemagick
 impala
 imv
 inetutils
+inter-font
 inxi
 iwd
 jq

--- a/migrations/1780739891.sh
+++ b/migrations/1780739891.sh
@@ -1,0 +1,12 @@
+echo "Use Inter as default UI font"
+
+omarchy-pkg-add inter-font
+
+fontconfig="$HOME/.config/fontconfig/fonts.conf"
+
+if [ -f "$fontconfig" ] && ! grep -q '>Inter<' "$fontconfig"; then
+  sed -i \
+    -e '/<string>Liberation Sans<\/string>/i\      <string>Inter</string>' \
+    -e '/<family>Liberation Sans<\/family>/i\      <family>Inter</family>' \
+    "$fontconfig"
+fi


### PR DESCRIPTION
## Summary

Install `inter-font` and prefer Inter for Omarchy's sans/system UI fontconfig defaults, keeping Liberation Sans as the fallback.

This updates `sans-serif`, `system-ui`, `-apple-system`, and `BlinkMacSystemFont` to prefer Inter first.

## Why

Inter is designed for user interfaces and is a better default UI font for the desktop. This only changes proportional UI/sans defaults; terminal monospace fonts remain unchanged.

The migration installs `inter-font` and inserts Inter before existing `Liberation Sans` entries in the user's fontconfig file, leaving the fallback intact.

## Testing

- `xmlstarlet val config/fontconfig/fonts.conf`
- smoke-tested the migration in a temporary HOME
- `bash -n migrations/1780739891.sh`
- `git diff --check`
