### PR TITLE
Surface xdg-open errors from open helper

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -34,7 +34,7 @@ if command -v zoxide &> /dev/null; then
 fi
 
 open() (
-  xdg-open "$@" >/dev/null 2>&1 &
+  xdg-open "$@" >/dev/null &
 )
 
 # Directories


### PR DESCRIPTION
## Summary

- let the `open` shell helper surface `xdg-open` stderr in the terminal
- keep stdout redirected to `/dev/null` so command output stays quiet
- keep `xdg-open` backgrounded in the subshell to preserve the non-blocking behavior and avoid job-control noise

Closes #6056

## Testing

- `bash -n default/bash/aliases`
- `git diff --check`
- focused shell test with a stubbed `xdg-open` confirmed stderr is visible while stdout stays out of pipelines