### PR TITLE
Pin browser password store to gnome-libsecret

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -1,4 +1,5 @@
 --ozone-platform=wayland
 --ozone-platform-hint=wayland
+--password-store=gnome-libsecret
 --enable-features=TouchpadOverscrollHistoryNavigation
 --load-extension=~/.local/share/omarchy/default/chromium/extensions/copy-url

--- a/migrations/1781079205.sh
+++ b/migrations/1781079205.sh
@@ -1,0 +1,12 @@
+echo "Pin browser password store to gnome-libsecret (prevents cookie/login loss on Hyprland)"
+
+# Chromium and Brave auto-detect their os_crypt backend; on Hyprland the xdg-desktop-portal Secret
+# backend has no provider and fails, so they can fall back to the 'basic' (v10) store. A swap from
+# the gnome-libsecret (v11) key to the basic key makes existing cookies and saved passwords
+# undecryptable, so the browser silently drops them and the user is logged out of everything.
+# Pin gnome-libsecret so the backend is deterministic across reboots and updates.
+for conf in ~/.config/chromium-flags.conf ~/.config/brave-flags.conf; do
+    if [[ -f $conf ]] && ! grep -q -- '--password-store=' "$conf"; then
+        echo '--password-store=gnome-libsecret' >> "$conf"
+    fi
+done


### PR DESCRIPTION
Chromium and Brave auto-detect their `os_crypt` backend at launch. On Hyprland the xdg-desktop-portal **Secret** backend has no provider (`gnome-keyring.portal` is `UseIn=gnome`; the portal preference is `hyprland;gtk`), so it fails — observable in `~/.config/chromium/Local State` as `os_crypt: {"portal":{"prev_desktop":"Hyprland","prev_init_success":false}}`. Per the [official Chromium docs](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md), it then "will fall back to `basic` if a requested or autodetected store is not available."

`basic` uses a hardcoded key (v10). When a launch lands on `basic` instead of `gnome-libsecret` (v11), previously encrypted cookies and saved passwords become undecryptable and are silently dropped — the user is logged out of everything, sometimes with a "create new keyring" prompt. This recurs across reboots/updates whenever the fallback target changes.

### Fix
Pin `--password-store=gnome-libsecret` so the backend is deterministic and the flaky portal autodetect is skipped. Omarchy already pins this exact value for VSCode (`bin/omarchy-install-vscode` writes `"password-store":"gnome-libsecret"` to argv.json), so this just aligns the browser defaults with existing intent. The Arch `chromium`/`brave` launcher reads `*-flags.conf`, so it also covers web-apps launched via `omarchy-launch-webapp`.

### Changes
- Add the flag to the shipped default `config/chromium-flags.conf`.
- `migrations/1781079205.sh`: idempotently add the flag to existing `chromium-flags.conf` and `brave-flags.conf`, mirroring the precedent in `migrations/1771188969.sh`.

### Notes
- Electron apps that bundle their own Electron (Slack, Signal, etc.) do not read a `*-flags.conf` and can still hit a backend swap; out of scope here.
- gnome-libsecret is correct for the stock omarchy secret service (gnome-keyring).

### Refs
- Chromium password storage (official): https://chromium.googlesource.com/chromium/src/+/master/docs/linux/password_storage.md
- Arch Wiki — Chromium: https://wiki.archlinux.org/title/Chromium