### PR TITLE
Docker: sudo support in cross-arch image builds

### DIFF
--- a/install/config/docker.sh
+++ b/install/config/docker.sh
@@ -1,1 +1,8 @@
 usermod -aG docker "$OMARCHY_INSTALL_USER"
+
+# Ensure sudo works in cross-platform Docker image builds
+for src in /usr/lib/binfmt.d/qemu-*-static.conf; do
+  dst="/etc/binfmt.d/$(basename "$src")"
+  install -Dm644 "$src" "$dst"
+  sed -i 's/:FP$/:OCF/' "$dst"
+done


### PR DESCRIPTION
## Setup

Run a cross-arch Docker image build with a `Dockerfile` containing a `USER` directive and `sudo`:

```Dockerfile
FROM alpine:latest

RUN apk add --no-cache sudo && \
    adduser -D appuser && \
    echo "appuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

USER appuser

CMD ["sudo", "whoami"]
```

using the following command:

```bash
docker build --platform linux/arm64 -t sudo-test . && docker run --platform linux/arm64 --rm sudo-test
```

## Before

It fails with:

```
sudo: effective uid is not 0, is /usr/bin/sudo on a file system with the 'nosuid' option set or an NFS file system without root privileges?
```

## After

It succeeds as expected and prints:

```
root
```

## Notes

No migration needed as `qemu-user-static-binfmt` was only added in quattro.