### PR TITLE
fix: apply the GSK_RENDERER fix to the autostarted Walker service

### DIFF
--- a/default/walker/walker.desktop
+++ b/default/walker/walker.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Walker
 Comment=Walker Service
-Exec=walker --gapplication-service
+Exec=env GSK_RENDERER=cairo walker --gapplication-service
 StartupNotify=false
 Terminal=false
 Type=Application

--- a/migrations/1781295157.sh
+++ b/migrations/1781295157.sh
@@ -1,0 +1,6 @@
+echo "Apply the GSK_RENDERER fix to the autostarted Walker service"
+
+mkdir -p ~/.config/autostart/
+cp $OMARCHY_PATH/default/walker/walker.desktop ~/.config/autostart/
+systemctl --user daemon-reload
+omarchy-restart-walker


### PR DESCRIPTION
The menu takes several seconds to show up the first time after a boot, then every open after that is instant. Same thing reported in #2723.

I dug into it on my machine (Raptor Lake iGPU + RTX 4060 laptop) and it turns out the GSK_RENDERER fix from 30ddfeda doesn't actually apply anymore. That commit moved `GSK_RENDERER=cairo` out of the Hyprland envs and into the line of `omarchy-launch-walker` that spawns the service:

But since Walker became a systemd autostart (c17bd85c), the service is already running by the time you press the keybind, started from `walker.desktop`, without the variable. The pgrep guard always passes, so on a normal boot the cairo env never gets applied to anything.

So the fix is to set it in `walker.desktop` itself, plus a migration that re-copies the desktop file, reloads the user daemon so the generated unit picks up the new Exec, and restarts Walker.

Fixes #2723