### PR TITLE
Add migration to backfill Mesa Vulkan driver for pre-vulkan.sh installs

### DIFF
--- a/migrations/1780929365.sh
+++ b/migrations/1780929365.sh
@@ -1,0 +1,25 @@
+echo "Install missing Mesa Vulkan driver for Intel/AMD/Apple GPUs"
+
+# Backfill for systems installed before install/config/hardware/vulkan.sh existed.
+# install/ scripts only run at initial setup, so machines set up earlier never
+# received a Mesa Vulkan ICD for their iGPU (leaving e.g. NVIDIA as the only Vulkan
+# device on hybrid laptops). omarchy-pkg-add is idempotent, so this is a no-op when
+# the driver is already present.
+
+declare -A VULKAN_DRIVERS=(
+  [Intel]=vulkan-intel
+  [AMD]=vulkan-radeon
+  [Apple]=vulkan-asahi
+)
+
+PACKAGES=()
+
+for vendor in "${!VULKAN_DRIVERS[@]}"; do
+  if lspci | grep -iE "(VGA|Display).*$vendor" >/dev/null; then
+    PACKAGES+=("${VULKAN_DRIVERS[$vendor]}")
+  fi
+done
+
+if (( ${#PACKAGES[@]} > 0 )); then
+  omarchy-pkg-add "${PACKAGES[@]}"
+fi

--- a/migrations/1780929365.sh
+++ b/migrations/1780929365.sh
@@ -1,4 +1,4 @@
-echo "Install missing Mesa Vulkan driver for Intel/AMD/Apple GPUs"
+echo "Install missing Mesa Vulkan driver for Intel/AMD GPUs"
 
 # Backfill for systems installed before install/config/hardware/vulkan.sh existed.
 # install/ scripts only run at initial setup, so machines set up earlier never
@@ -9,7 +9,6 @@ echo "Install missing Mesa Vulkan driver for Intel/AMD/Apple GPUs"
 declare -A VULKAN_DRIVERS=(
   [Intel]=vulkan-intel
   [AMD]=vulkan-radeon
-  [Apple]=vulkan-asahi
 )
 
 PACKAGES=()


### PR DESCRIPTION
## What

Adds a migration that installs the Mesa Vulkan driver (`vulkan-intel` / `vulkan-radeon` / `vulkan-asahi`) on systems that were set up **before** `install/config/hardware/vulkan.sh` was added (commit 694eb8c6, 2026-02-20).

Fixes #6089.

## Why

`install/` scripts only run once, at initial setup. `vulkan.sh` was introduced as an install-time step but no migration was shipped, so it never reaches pre-existing machines. Intel/AMD systems installed before that date have no Mesa Vulkan ICD to this day.

On hybrid (Optimus) laptops the impact is user-visible: NVIDIA Vulkan ships via `nvidia-utils`, so the discrete GPU becomes the *only* Vulkan device. `mpv` (default `vo=gpu-next`/Vulkan) then renders on the dGPU and cross-presents to the iGPU-driven compositor, which stalls ("Application Not Responding"). Installing `vulkan-intel` restored the iGPU as a Vulkan device and fixed it.

## How

The migration mirrors the detection in `vulkan.sh` and relies on `omarchy-pkg-add`, which is idempotent (`pacman -S --needed`) — so it is a **no-op** on systems that already have the driver (e.g. fresh installs). The migration timestamp (`1780929365`) is derived from the current `dev` HEAD commit, per `omarchy-dev-add-migration` convention, and sorts after the latest existing migration.

## Testing

Verified on an affected machine (Omarchy 3.8.2, Intel UHD 630 + NVIDIA GTX 1650, installed 2026-02-18): `vulkan-intel` was absent, the dGPU was the only Vulkan device, and mpv froze. After installing `vulkan-intel`, both GPUs appear as Vulkan devices and mpv renders on Intel without stalling.
