### PR TITLE
fix: drop fixed unit name from power-profile udev rule to prevent wakeup failures

### DIFF
--- a/install/config/powerprofilesctl-rules.sh
+++ b/install/config/powerprofilesctl-rules.sh
@@ -1,7 +1,7 @@
 if omarchy-battery-present; then
   cat <<EOF | sudo tee "/etc/udev/rules.d/99-power-profile.rules"
-SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
-SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
+SUBSYSTEM=="power_supply", ATTR{type}=="USB", RUN+="/usr/bin/systemd-run --no-block --collect --property=After=power-profiles-daemon.service $HOME/.local/share/omarchy/bin/omarchy-powerprofiles-set"
 EOF
 
   sudo systemctl enable power-profiles-daemon


### PR DESCRIPTION
## Problem

On laptops with USB-C only charging (e.g. ASUS Zenbook with Intel Meteor Lake), multiple `power_supply` udev events fire simultaneously on resume from sleep. Each event calls:

```
systemd-run --no-block --collect --unit=omarchy-power-profile ...
```

Because all events try to create a transient unit with the same fixed name, the second (and any subsequent) invocation fails with:

```
Failed to start transient service unit: Unit omarchy-power-profile.service was already loaded or has a fragment file.
exit: 1
```

This shows up in the journal on every wakeup as:

```
(udev-worker): ucsi-source-psy-USBC000:002: Process '/usr/bin/systemd-run ... --unit=omarchy-power-profile ...' failed with exit code 1.
```

## Fix

Remove the `--unit=omarchy-power-profile` argument so each event gets a unique auto-generated transient unit name. `powerprofilesctl set` is idempotent, so concurrent runs are harmless — the last one to execute simply wins.

## Test

Verified by triggering two rapid back-to-back `systemd-run` calls with the same unit name (reproduces the error), then without the fixed name (both succeed with exit 0). Also confirmed via `sudo udevadm trigger --subsystem-match=power_supply --attr-match=type=USB` that no failures appear in the journal after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)