### PR TITLE
make youtube and zoom webapps opaque on any browser and profile

### DIFF
--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -5,8 +5,8 @@ windowrule = tag -default-opacity, match:tag chromium-based-browser
 windowrule = tag -default-opacity, match:tag firefox-based-browser
 
 # Video apps: remove chromium browser tag so they don't get opacity applied
-windowrule = tag -chromium-based-browser, match:class (.*-youtube.com__.*|.*-app.zoom.us__wc_home.*)
-windowrule = tag -default-opacity, match:class (.*-youtube.com__.*|.*-app.zoom.us__wc_home.*)
+windowrule = tag -chromium-based-browser, match:class (^.+-youtube\.com__.*$|^.+-app\.zoom\.us__wc_home.*$)
+windowrule = tag -default-opacity, match:class (^.+-youtube\.com__.*$|^.+-app\.zoom\.us__wc_home.*$)
 
 # Force chromium-based browsers into a tile to deal with --app bug
 windowrule = tile on, match:tag chromium-based-browser

--- a/default/hypr/apps/browser.conf
+++ b/default/hypr/apps/browser.conf
@@ -5,8 +5,8 @@ windowrule = tag -default-opacity, match:tag chromium-based-browser
 windowrule = tag -default-opacity, match:tag firefox-based-browser
 
 # Video apps: remove chromium browser tag so they don't get opacity applied
-windowrule = tag -chromium-based-browser, match:class (chrome-youtube.com__-Default|chrome-app.zoom.us__wc_home-Default)
-windowrule = tag -default-opacity, match:class (chrome-youtube.com__-Default|chrome-app.zoom.us__wc_home-Default)
+windowrule = tag -chromium-based-browser, match:class (.*-youtube.com__.*|.*-app.zoom.us__wc_home.*)
+windowrule = tag -default-opacity, match:class (.*-youtube.com__.*|.*-app.zoom.us__wc_home.*)
 
 # Force chromium-based browsers into a tile to deal with --app bug
 windowrule = tile on, match:tag chromium-based-browser


### PR DESCRIPTION
the video opacity opt out in browser.conf only matches chrome on the default profile, so brave, chromium, edge and anyone on a non default profile still get the default 0.97/0.9 transparency on their youtube and zoom webapp windows. annoying when watching video.

this widens the class match to any browser prefix and any profile. same mechanism and same two tags as before, just a broader regex.

tested live on brave (class brave-youtube.com__-Profile_2): the default-opacity tag now gets removed and the window stays fully opaque. a normal browser tab on youtube keeps its plain browser class, so regular browsing is unaffected.
