### PR TITLE
Fix ASUS ExpertBook B9406 touchpad quirk never being applied

### DIFF
--- a/install/config/hardware/asus/fix-asus-ptl-b9406-touchpad.sh
+++ b/install/config/hardware/asus/fix-asus-ptl-b9406-touchpad.sh
@@ -8,16 +8,32 @@
 #
 # Mask the pressure axes with a quirks override, same pattern as the
 # Asus UX302LA entry in libinput's shipped 50-system-asus.quirks.
+#
+# Two things matter for the override to take effect:
+#   1. libinput reads only ONE override file, /etc/libinput/local-overrides.quirks.
+#      Custom-named files in /etc/libinput/ are never loaded.
+#   2. udev tags this pad as ID_INPUT_MOUSE, not ID_INPUT_TOUCHPAD, so a
+#      MatchUdevType=touchpad section is skipped. The bus/vendor/product/DMI
+#      keys already pin the device exactly, so we omit the type constraint.
 
 if omarchy-hw-asus-expertbook-b9406; then
-  sudo mkdir -p /etc/libinput
-  sudo tee /etc/libinput/asus-expertbook-b9406.quirks >/dev/null <<EOF
-[ASUS ExpertBook B9406 Touchpad]
+  QUIRKS_FILE="/etc/libinput/local-overrides.quirks"
+  QUIRKS_SECTION="[ASUS ExpertBook B9406 Touchpad]"
+
+  # Remove the stale, never-read file written by earlier Omarchy versions.
+  sudo rm -f /etc/libinput/asus-expertbook-b9406.quirks
+
+  # Append our section to the shared override file, but only once.
+  if ! sudo grep -qF "$QUIRKS_SECTION" "$QUIRKS_FILE" 2>/dev/null; then
+    sudo mkdir -p /etc/libinput
+    sudo tee -a "$QUIRKS_FILE" >/dev/null <<EOF
+
+$QUIRKS_SECTION
 MatchBus=i2c
-MatchUdevType=touchpad
 MatchVendor=0x093A
 MatchProduct=0x4F05
 MatchDMIModalias=dmi:*svnASUS*:pn*B9406*
 AttrEventCode=-ABS_MT_PRESSURE;-ABS_PRESSURE;
 EOF
+  fi
 fi

--- a/migrations/1781432360.sh
+++ b/migrations/1781432360.sh
@@ -1,0 +1,5 @@
+echo "Fix touchpad quirk on ASUS ExpertBook B9406 (was written to a path libinput never reads)"
+
+if omarchy-hw-asus-expertbook-b9406; then
+  source "$OMARCHY_PATH/install/config/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"
+fi


### PR DESCRIPTION
Follow-up to #5435. On a fresh 3.8.2 install of an ASUS ExpertBook B9406 the touchpad is still dead: clicks register but the cursor never moves. The quirk from #5435 never took effect, for two reasons:

1. It was written to `/etc/libinput/asus-expertbook-b9406.quirks`. libinput reads only `/etc/libinput/local-overrides.quirks` and does not scan the directory, so the file was ignored.

2. The section required `MatchUdevType=touchpad`, but udev tags this pad as `ID_INPUT_MOUSE`. The bus/vendor/product/DMI keys already pin the device, so the type constraint is dropped.

How this slipped through: the original fix was verified as a manual local edit, but the packaged install path was not tested end to end, so neither defect was caught. I have since corrected that in my workflow. Both changes here were confirmed working by the reporter. Adds a migration so existing B9406 installs pick up the corrected quirk.

This restores cursor motion. A wider correction (proper touchpad classification for full gestures) will follow once I have access to a working ExpertBook again. Mine is currently physically broken (cracked screen).

AI disclaimer: diagnosed and fixed with help from Claude Code (Opus 4.8).