### PR TITLE
Fix silently-lost reboot in omarchy-system-reboot

### DIFF
--- a/bin/omarchy-system-reboot
+++ b/bin/omarchy-system-reboot
@@ -6,8 +6,14 @@
 
 omarchy-state clear re*-required
 
-# Schedule the reboot to happen after closing windows (detached from terminal)
-nohup bash -c "sleep 2 && systemctl reboot --no-wall" >/dev/null 2>&1 &
+# Schedule the reboot to happen after closing windows.
+# Run it as a transient user unit rather than a backgrounded child of this
+# script. A `nohup &` child stays inside the terminal's transient systemd scope
+# (app-*.scope, created with --collect); closing that terminal below tears the
+# scope down and SIGTERMs the still-sleeping child before it can issue the
+# reboot, so the reboot is silently lost. A systemd-run unit lives in its own
+# cgroup under the user manager and survives the scope teardown.
+systemd-run --user --collect --quiet bash -c "sleep 2 && systemctl reboot --no-wall"
 
 # Now close all windows
 omarchy-hyprland-window-close-all


### PR DESCRIPTION
## Problem

`omarchy reboot` (and the reboot prompt after `omarchy update` when the kernel was upgraded) sometimes does nothing — it closes all your windows and then just sits there, no reboot, no error.

The cause is a race in `omarchy-system-reboot`:

```bash
nohup bash -c "sleep 2 && systemctl reboot --no-wall" >/dev/null 2>&1 &
omarchy-hyprland-window-close-all
```

The reboot is a backgrounded child, so it inherits the cgroup of the terminal's transient systemd scope (`app-*.scope`, created by `xdg-terminal-exec` with `--collect`). The very next line closes all windows — including the terminal running this script. When that terminal exits, systemd stops and **collects** the scope, sending `SIGTERM` to every process still in the cgroup, including the still-sleeping reboot child. `nohup` only blocks `SIGHUP`, not the scope's `SIGTERM`.

So it's a 2-second race between the `sleep 2` and the scope teardown. When the teardown wins, `systemctl reboot` is never reached and the reboot is lost silently — nothing reaches logind at all.

I hit this in the wild: an `omarchy update` upgraded the kernel, prompted to reboot, I confirmed, and nothing happened (no logind/polkit entry whatsoever). Re-running `omarchy update` — a no-op package-wise — re-prompted (because the trigger is running-kernel ≠ installed-kernel, still true) and that time the race went the other way and it rebooted.

## Fix

Launch the delayed reboot as a transient **user unit** via `systemd-run --user` instead of a backgrounded child. The unit lives in its own cgroup under the user manager, independent of the terminal's scope, so it survives `omarchy-hyprland-window-close-all` and reliably issues the reboot.

```bash
systemd-run --user --collect --quiet bash -c "sleep 2 && systemctl reboot --no-wall"
```

## Verification

Confirmed the logind reboot is still permitted without a polkit prompt from inside a `systemd-run --user` unit:

```
$ systemd-run --user --quiet --pipe --wait bash -c \
    'busctl call org.freedesktop.login1 /org/freedesktop/login1 \
     org.freedesktop.login1.Manager CanReboot; echo XDG_SESSION_ID=$XDG_SESSION_ID'
s "yes"
XDG_SESSION_ID=2
```

`CanReboot` returns `"yes"` and the unit retains its XDG session, so behavior is identical to the old path minus the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)