### PR TITLE
Fix fip function on zsh

### DIFF
--- a/default/bash/fns/ssh-port-forwarding
+++ b/default/bash/fns/ssh-port-forwarding
@@ -1,17 +1,17 @@
 # SSH Port Forwarding Functions
 fip() {
   (( $# < 2 )) && echo "Usage: fip <host> <port1> [port2] ..." && return 1
-  local host="${1}"
+  local host="$1"
   shift
   for port in "$@"; do
-    ssh -f -N -L "${port}:localhost:${port}" "${host}" && echo "Forwarding localhost:${port} -> ${host}:${port}"
+    ssh -f -N -L "${port}:localhost:${port}" "$host" && echo "Forwarding localhost:$port -> $host:$port"
   done
 }
 
 dip() {
   (( $# == 0 )) && echo "Usage: dip <port1> [port2] ..." && return 1
   for port in "$@"; do
-    pkill -f "ssh.*-L ${port}:localhost:${port}" && echo "Stopped forwarding port ${port}" || echo "No forwarding on port ${port}"
+    pkill -f "ssh.*-L ${port}:localhost:${port}" && echo "Stopped forwarding port $port" || echo "No forwarding on port $port"
   done
 }
 

--- a/default/bash/fns/ssh-port-forwarding
+++ b/default/bash/fns/ssh-port-forwarding
@@ -1,17 +1,17 @@
 # SSH Port Forwarding Functions
 fip() {
   (( $# < 2 )) && echo "Usage: fip <host> <port1> [port2] ..." && return 1
-  local host="$1"
+  local host="${1}"
   shift
   for port in "$@"; do
-    ssh -f -N -L "$port:localhost:$port" "$host" && echo "Forwarding localhost:$port -> $host:$port"
+    ssh -f -N -L "${port}:localhost:${port}" "${host}" && echo "Forwarding localhost:${port} -> ${host}:${port}"
   done
 }
 
 dip() {
   (( $# == 0 )) && echo "Usage: dip <port1> [port2] ..." && return 1
   for port in "$@"; do
-    pkill -f "ssh.*-L $port:localhost:$port" && echo "Stopped forwarding port $port" || echo "No forwarding on port $port"
+    pkill -f "ssh.*-L ${port}:localhost:${port}" && echo "Stopped forwarding port ${port}" || echo "No forwarding on port ${port}"
   done
 }
 


### PR DESCRIPTION
The original `fip` shell function works fine on bash, but not on zsh:

```
❯ fip remote_host 8081    
Bad local forwarding specification '8081ocalhost:8081'
```

The reason for this is that zsh interprets the `:l` part of `ssh -f -N -L "$port:localhost` as modifier (lowercase), resulting in `ssh -f -N -L "${port}ocalhost`.

This PR resolves this by using proper `${}` template variables, which work on both bash and zsh.