### PR TITLE
feat: add special handling for Outlook Web URLs

### DIFF
--- a/default/chromium/extensions/copy-url/background.js
+++ b/default/chromium/extensions/copy-url/background.js
@@ -6,7 +6,14 @@ chrome.commands.onCommand.addListener((command) => {
       chrome.scripting.executeScript({
         target: { tabId: currentTab.id },
         func: () => {
-          navigator.clipboard.writeText(window.location.href);
+          const url = new URL(window.location.href);
+          const outlookMailMatch = url.pathname.match(/^\/mail\/inbox\/id\/(.+)$/);
+
+          if (url.origin === 'https://outlook.office.com' && outlookMailMatch) {
+            navigator.clipboard.writeText(`https://outlook.office365.com/owa/?ItemID=${outlookMailMatch[1]}`);
+          } else {
+            navigator.clipboard.writeText(window.location.href);
+          }
         }
       }).then(() => {
         chrome.notifications.create({

--- a/default/chromium/extensions/copy-url/background.js
+++ b/default/chromium/extensions/copy-url/background.js
@@ -10,7 +10,7 @@ chrome.commands.onCommand.addListener((command) => {
           const outlookMailMatch = url.pathname.match(/^\/mail\/inbox\/id\/(.+)$/);
 
           if (url.origin === 'https://outlook.office.com' && outlookMailMatch) {
-            navigator.clipboard.writeText(`https://outlook.office365.com/owa/?ItemID=${outlookMailMatch[1]}`);
+            navigator.clipboard.writeText(`https://outlook.office365.com/owa/?exvsurl=1&viewmodel=ReadMessageItem&ItemID=${outlookMailMatch[1]}`);
           } else {
             navigator.clipboard.writeText(window.location.href);
           }

--- a/default/chromium/extensions/copy-url/manifest.json
+++ b/default/chromium/extensions/copy-url/manifest.json
@@ -1,9 +1,13 @@
 {
   "manifest_version": 3,
   "name": "Copy URL",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Copy current URL to clipboard, this extension is installed by Omarchy",
-  "permissions": ["activeTab", "scripting", "notifications"],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "notifications"
+  ],
   "icons": {
     "16": "icon.png",
     "48": "icon.png",
@@ -11,9 +15,13 @@
   },
   "commands": {
     "copy-url": {
-      "suggested_key": {"default": "Alt+Shift+L"},
+      "suggested_key": {
+        "default": "Alt+Shift+L"
+      },
       "description": "Copy URL"
     }
   },
-  "background": {"service_worker": "background.js"}
+  "background": {
+    "service_worker": "background.js"
+  }
 }


### PR DESCRIPTION
When using Outlook Web (OWA) as Web App and you're reading a specific mail, the current URL in the browser is not what you can use to navigate to that mail later (thanks Microsoft ...)  This uses the solution found in https://www.reddit.com/r/Outlook/comments/dqcewq/outlook_link_to_specific_email/ to use the mail `ItemId` to construct a proper URL and use that instead of the original one.