### PR TITLE
Fix fingerprint setup crash when libfprint-git is installed

### DIFF
--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -5,7 +5,6 @@
 
 set -e
 
-
 check_fingerprint_hardware() {
   # Get fingerprint devices for the user
   devices=$(fprintd-list "$USER" 2>/dev/null)
@@ -58,7 +57,7 @@ echo "Installing required packages..."
 # with -Rdd so the install goes silent. -Rdd (not omarchy-pkg-drop's
 # -Rns) is required because fprintd requires libfprint; the dep is
 # re-satisfied immediately by libfprint-git's provides=libfprint.
-if omarchy-pkg-present libfprint; then
+if pacman -Qq | grep -Fxq "libfprint"; then
   sudo pacman -Rdd --noconfirm libfprint
 fi
 


### PR DESCRIPTION
## Issue
The `omarchy-pkg-present libfprint` check returns `true` if `libfprint-git` is installed because it "provides" `libfprint`. 

The script then tries to remove the literal `libfprint` package with `pacman -Rdd`. This triggers a `sudo` prompt for existing fingerprint users, fails with a `target not found` error, and abruptly crashes the script due to `set -e`.

---

## Fix
Replaced the check with `pacman -Qq | grep -Fxq "libfprint"` to ensure it only attempts removal if the exact, literal `libfprint` package is installed.