### PR TITLE
Unconditionally turn off internal display when lid is closed

### DIFF
--- a/bin/omarchy-hw-lid-closed
+++ b/bin/omarchy-hw-lid-closed
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when the laptop lid is closed
+# omarchy:hidden=true
+
+for state in /proc/acpi/button/lid/*/state; do
+  [[ -r $state ]] || continue
+  [[ $(< "$state") == *"closed"* ]] && exit 0
+done
+
+exit 1

--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -18,7 +18,7 @@ on() {
 }
 
 off() {
-  if ! omarchy-hw-external-monitors; then
+  if ! omarchy-hw-external-monitors && ! omarchy-hw-lid-closed; then
     omarchy-notification-send -g 󰍹 "Can't disable the only active display"
     exit 1
   fi
@@ -31,7 +31,7 @@ off() {
 }
 
 recover() {
-  if ! omarchy-hw-external-monitors && omarchy-hyprland-toggle-enabled $TOGGLE; then
+  if ! omarchy-hw-external-monitors && ! omarchy-hw-lid-closed && omarchy-hyprland-toggle-enabled $TOGGLE; then
     omarchy-hyprland-toggle $TOGGLE off
   fi
 }

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -32,7 +32,7 @@ o.bind_toggle("SUPER + CTRL + I", "Toggle locking on idle", "idle")
 o.bind_toggle("SUPER + CTRL + N", "Toggle nightlight", "nightlight")
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
-o.bind("switch:on:Lid Switch", nil, "omarchy-hw-external-monitors && omarchy-hyprland-monitor-internal off", { locked = true })
+o.bind("switch:on:Lid Switch", nil, "omarchy-hyprland-monitor-internal off", { locked = true })
 o.bind("switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-internal on", { locked = true })
 
 o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")


### PR DESCRIPTION
## Summary

Right now we only turn off the internal display when an external display is connected. I currently use my FW laptop as a server (lid closed) without any connected display. I noticed the wattage on my laptop was higher than expected and realized that the lid display was still on.

I believe we should unconditionally turn off the internal display when the lid is closed.

The existing "only active display" guard is preserved for the lid-open case (where blanking would orphan the user). Desktops without `/proc/acpi/button/lid/*/state` are treated as lid-open, so their behavior is unchanged.
