### PR TITLE
Enable hyprlock input animations

### DIFF
--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -12,7 +12,7 @@ background {
 }
 
 animations {
-    enabled = false
+    enabled = true
 }
 
 input-field {


### PR DESCRIPTION
Adds animation so that long passwords still gives visual feedback on inputs. This is intentionally a small commit to be as little of disruption as possible. Just adding animation to password input so that you can visually see your key strokes.

I'd be happy to give the orb-animation a try as described in https://github.com/basecamp/omarchy/discussions/6130 but I'm not sure that is something most users want.

Before and after videos below of this PR.

https://github.com/user-attachments/assets/f1d49682-1df5-402d-b771-9b72c684b9f0

https://github.com/user-attachments/assets/876bbffe-dcf3-4e55-aca3-23f13dd3964d

