### PR TITLE
Fix inherited text shadows in Waybar tooltips

### DIFF
--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -9,6 +9,7 @@
   min-height: 0;
   font-family: 'JetBrainsMono Nerd Font';
   font-size: 12px;
+  /* omarchy:disable-text-shadow */
   text-shadow: none;
 }
 

--- a/config/waybar/style.css
+++ b/config/waybar/style.css
@@ -9,6 +9,7 @@
   min-height: 0;
   font-family: 'JetBrainsMono Nerd Font';
   font-size: 12px;
+  text-shadow: none;
 }
 
 .modules-left {
@@ -57,6 +58,11 @@
 
 tooltip {
   padding: 2px;
+  text-shadow: none;
+}
+
+tooltip * {
+  text-shadow: none;
 }
 
 #custom-update {

--- a/migrations/1779713467.sh
+++ b/migrations/1779713467.sh
@@ -1,14 +1,17 @@
 echo "Disable inherited text shadows in Waybar"
 
 waybar_style="$HOME/.config/waybar/style.css"
+marker="omarchy:disable-text-shadow"
 
-if [[ -f $waybar_style ]] && ! grep -q "text-shadow: none" "$waybar_style"; then
-  sed -i '/font-size: 12px;/a\  text-shadow: none;' "$waybar_style"
-  sed -i '/tooltip {/,/^}/ s/padding: 2px;/padding: 2px;\n  text-shadow: none;/' "$waybar_style"
+if [[ -f $waybar_style ]] && ! grep -qF "$marker" "$waybar_style"; then
+  cat >>"$waybar_style" <<'EOF'
 
-  cat >> "$waybar_style" << 'EOF'
+/* omarchy:disable-text-shadow */
+* {
+  text-shadow: none;
+}
 
-tooltip * {
+tooltip, tooltip * {
   text-shadow: none;
 }
 EOF

--- a/migrations/1779713467.sh
+++ b/migrations/1779713467.sh
@@ -1,0 +1,17 @@
+echo "Disable inherited text shadows in Waybar"
+
+waybar_style="$HOME/.config/waybar/style.css"
+
+if [[ -f $waybar_style ]] && ! grep -q "text-shadow: none" "$waybar_style"; then
+  sed -i '/font-size: 12px;/a\  text-shadow: none;' "$waybar_style"
+  sed -i '/tooltip {/,/^}/ s/padding: 2px;/padding: 2px;\n  text-shadow: none;/' "$waybar_style"
+
+  cat >> "$waybar_style" << 'EOF'
+
+tooltip * {
+  text-shadow: none;
+}
+EOF
+
+  omarchy-restart-waybar
+fi


### PR DESCRIPTION
## Summary

- disable inherited text shadows in the base Waybar CSS
- add a guarded migration for existing copied Waybar configs

## Why

On some themes, GTK text-shadow styling can leak into Waybar tooltips and make dropdown text look doubled. Omarchy Waybar themes only define colors, so the base Waybar CSS should explicitly opt out of text shadows.

## Validation

- `git diff --check`
- `bash -n migrations/1779713467.sh`
- tested the migration against a temporary HOME with a copied Waybar config

## Screenshots

### Before
<img width="382" height="706" alt="image" src="https://github.com/user-attachments/assets/4a984dbe-1d6e-4d70-8770-58ef720dcd8e" />

### After
<img width="356" height="706" alt="image" src="https://github.com/user-attachments/assets/7499c403-d1d6-4912-a90e-01590436178d" />
