### PR TITLE
Add Waybar workspace module with per-workspace window count

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -4,7 +4,7 @@
   "position": "top",
   "spacing": 0,
   "height": 26,
-  "modules-left": ["custom/omarchy", "hyprland/workspaces"],
+  "modules-left": ["custom/omarchy", "custom/workspace-windows"],
   "modules-center": ["clock", "custom/weather", "custom/update", "custom/voxtype", "custom/screenrecording-indicator", "custom/idle-indicator", "custom/notification-silencing-indicator"],
   "modules-right": [
     "group/tray-expander",
@@ -14,30 +14,13 @@
     "cpu",
     "battery"
   ],
-  "hyprland/workspaces": {
-    "on-click": "activate",
-    "format": "{icon}",
-    "format-icons": {
-      "default": "",
-      "1": "1",
-      "2": "2",
-      "3": "3",
-      "4": "4",
-      "5": "5",
-      "6": "6",
-      "7": "7",
-      "8": "8",
-      "9": "9",
-      "10": "0",
-      "active": "󱓻"
-    },
-    "persistent-workspaces": {
-      "1": [],
-      "2": [],
-      "3": [],
-      "4": [],
-      "5": []
-    }
+  "custom/workspace-windows": {
+    "format": "{}",
+    "exec": "$OMARCHY_PATH/default/waybar/workspace-windows.sh",
+    "tooltip": false,
+    "escape": false,
+    "on-scroll-up": "hyprctl dispatch workspace e-1",
+    "on-scroll-down": "hyprctl dispatch workspace e+1"
   },
   "custom/omarchy": {
     "format": "<span font='omarchy'>\ue900</span>",

--- a/default/waybar/workspace-windows.sh
+++ b/default/waybar/workspace-windows.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Waybar custom module: workspaces with a per-workspace window count badge.
+# Renders each workspace number followed by a superscript count of its windows,
+# highlights the active workspace, and updates instantly via the Hyprland IPC socket.
+
+# Minimum number of (persistent) workspaces always shown.
+MIN_WS=5
+
+# Superscript digits 0-9 for the count badge.
+SUP=("⁰" "¹" "²" "³" "⁴" "⁵" "⁶" "⁷" "⁸" "⁹")
+
+to_super() {
+  local n="$1" out="" i
+  for ((i = 0; i < ${#n}; i++)); do
+    out+="${SUP[${n:$i:1}]}"
+  done
+  printf '%s' "$out"
+}
+
+render() {
+  local active counts max=$MIN_WS ws c label out=""
+  active=$(hyprctl activeworkspace -j | jq -r '.id')
+
+  # Map "id -> window count" for normal (id >= 1) workspaces.
+  declare -A counts=()
+  while read -r id win; do
+    [[ "$id" =~ ^[0-9]+$ ]] && (( id >= 1 )) && counts[$id]=$win
+  done < <(hyprctl workspaces -j | jq -r '.[] | "\(.id) \(.windows)"')
+
+  # Show up to the highest populated/active workspace, but at least MIN_WS.
+  for id in "${!counts[@]}"; do (( id > max )) && max=$id; done
+  [[ "$active" =~ ^[0-9]+$ ]] && (( active > max )) && max=$active
+
+  for ((ws = 1; ws <= max; ws++)); do
+    c=${counts[$ws]:-0}
+    label="$ws"
+    (( c > 0 )) && label+="$(to_super "$c")"
+    if [[ "$ws" == "$active" ]]; then
+      out+="<span color='#ff3b30'><b>$label</b></span> "
+    else
+      out+="$label "
+    fi
+  done
+
+  printf '%s\n' "$out"
+}
+
+# Initial paint.
+render
+
+# Stream Hyprland events and repaint on anything that changes counts/active ws.
+SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
+socat -U - "UNIX-CONNECT:$SOCKET" 2>/dev/null | while read -r line; do
+  case "$line" in
+    workspace\>*|createworkspace\>*|destroyworkspace\>*|moveworkspace\>*|\
+openwindow\>*|closewindow\>*|movewindow\>*|focusedmon\>*|activespecial\>*)
+      render
+      ;;
+  esac
+done


### PR DESCRIPTION
## What

Replaces the default `hyprland/workspaces` module with a custom Waybar module
that shows each workspace number followed by a **superscript badge of its window
count**, highlights the active workspace, and updates instantly via the Hyprland
IPC socket.

```
▸ 1²   2¹   3   4   5
```

- Workspaces with no windows render as a plain number (no badge).
- At least `MIN_WS=5` workspaces are always shown, matching the current
  `persistent-workspaces` default.
- Live updates are driven by `.socket2.sock` events (workspace/window/monitor
  changes) — no polling.

## Why

The number badge gives an at-a-glance sense of where your windows are without
opening each workspace, while keeping the bar compact.

## Dependencies

None added. Both `jq` and `socat` are already declared in
`install/omarchy-base.packages`, and streaming `.socket2.sock` through `socat`
mirrors the existing pattern in `bin/omarchy-hyprland-monitor-watch`.

## Trade-offs / open questions (happy to adjust)

- **Navigation:** a Waybar `custom` module renders a single label, so
  individual workspace numbers are not clickable. Mouse-wheel scroll over the
  module switches workspaces (`workspace e-1` / `e+1`); the native module's
  click-to-activate-a-specific-workspace is not preserved. If keeping per-WS
  click is a requirement, the alternative is the native module with
  `window-rewrite` (shows per-window app icons instead of a count).
- **Active highlight color** is currently hard-coded (`#ff3b30`). Since a custom
  module can't reference theme CSS colors per-segment via Pango, I kept it
  inline — open to a better theme-aware approach if you have a preferred one.

## Testing

Tested on Hyprland (Waybar v0.15.0): badge counts track window open/close/move
across workspaces, the active workspace highlight follows focus, and scroll
switches workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
