### PR TITLE
Use Xe-capable btop on Intel xe GPU systems

### DIFF
--- a/bin/omarchy-hw-intel-xe
+++ b/bin/omarchy-hw-intel-xe
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Detect Intel GPUs using the Linux xe driver.
+
+for uevent in /sys/class/drm/card[0-9]*/device/uevent; do
+  [[ -r "$uevent" ]] || continue
+  grep -q '^DRIVER=xe$' "$uevent" || continue
+  grep -q '^PCI_ID=8086:' "$uevent" || continue
+  compgen -G '/sys/bus/event_source/devices/xe_*' >/dev/null && exit 0
+done
+
+exit 1

--- a/config/btop/btop.conf
+++ b/config/btop/btop.conf
@@ -107,7 +107,7 @@ cpu_graph_upper = "Auto"
 cpu_graph_lower = "Auto"
 
 #* If gpu info should be shown in the cpu box. Available values = "Auto", "On" and "Off".
-show_gpu_info = "Auto"
+show_gpu_info = "On"
 
 #* Toggles if the lower CPU graph should be inverted.
 cpu_invert_lower = true

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -43,6 +43,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/nvidia.sh
 run_logged $OMARCHY_INSTALL/config/hardware/vulkan.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/intel/video-acceleration.sh
+run_logged $OMARCHY_INSTALL/config/hardware/intel/btop-xe.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/lpmd.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/thermald.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/ipu7-camera.sh

--- a/install/config/hardware/intel/btop-xe.sh
+++ b/install/config/hardware/intel/btop-xe.sh
@@ -1,0 +1,5 @@
+# Temporary until upstream/Arch btop includes Intel xe GPU support.
+
+if omarchy-hw-intel-xe && pacman -Si btop-xe &>/dev/null; then
+  yes | sudo pacman -S --needed btop-xe
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -6,6 +6,7 @@ asusctl
 base
 base-devel
 broadcom-wl
+btop-xe
 btrfs-progs
 dkms
 egl-wayland

--- a/migrations/1782416832.sh
+++ b/migrations/1782416832.sh
@@ -1,0 +1,10 @@
+echo "Install btop with Intel Xe GPU support"
+
+if omarchy-hw-intel-xe; then
+  bash "$OMARCHY_PATH/install/config/hardware/intel/btop-xe.sh"
+
+  if [[ -f ~/.config/btop/btop.conf ]]; then
+    sed -i 's/^show_gpu_info = "Auto"/show_gpu_info = "On"/' ~/.config/btop/btop.conf
+    sed -i 's/^shown_boxes = "cpu mem net proc gpu0"/shown_boxes = "cpu mem net proc"/' ~/.config/btop/btop.conf
+  fi
+fi


### PR DESCRIPTION
## Summary

Detect Intel GPUs using the Linux `xe` driver and install the temporary `btop-xe` package from OPR so btop can show GPU usage/frequency on Lunar Lake, Panther Lake, Battlemage, and future Xe-driver systems.

Also turns on btop GPU info inside the CPU panel by default, while keeping the separate GPU box disabled.

Depends on: https://github.com/omacom-io/omarchy-pkgs/pull/114

## Why

Omarchy already installs `btop`, but current Arch `extra/btop` does not detect Intel GPUs using the `xe` kernel driver. On Panther Lake, btop shows CPU/memory/process stats but no Intel GPU usage/frequency even though the kernel exposes Xe telemetry.

This is not Panther Lake-only. The detector checks for Intel PCI GPU devices using `DRIVER=xe` and an exposed `xe_*` PMU source.

Upstream context:

- https://github.com/aristocratos/btop/issues/1407
- https://github.com/aristocratos/btop/pull/1457

## What changes

- Add `omarchy-hw-intel-xe`
- Add `install/config/hardware/intel/btop-xe.sh`
- Run that install hook from `install/config/all.sh`
- Include `btop-xe` in `install/omarchy-other.packages` for ISO/package availability
- Update default btop config:
  - `show_gpu_info = "On"`
  - keep `shown_boxes = "cpu mem net proc"`
  - keep `shown_gpus = "nvidia amd intel"`
- Add a migration for existing Intel Xe installs

## Compatibility

This does not disable or hide other GPU vendors.

`shown_gpus` remains:

```ini
shown_gpus = "nvidia amd intel"
```

The package still builds btop with normal GPU support. NVIDIA and AMD users are not routed through this hook because it only runs when an Intel GPU is using the `xe` driver.

## Screenshot

Intended layout: no separate GPU box, with Intel Xe GPU usage shown inside the CPU panel.

![btop showing Intel Xe GPU usage inside the CPU panel](https://raw.githubusercontent.com/stappmus/omarchy/btop-intel-xe-assets/pr-assets/btop-intel-xe-cpu-panel.png)

## Tested

On Intel Panther Lake / Arc B390:

```text
00:02.0 VGA compatible controller: Intel Corporation Panther Lake [Arc B390]
Kernel driver in use: xe
/sys/bus/event_source/devices/xe_0000_00_02.0 exists
```

The new detector exits successfully on that hardware:

```text
bin/omarchy-hw-intel-xe
# exit 0
```

After the package/config change:

```text
btop version: 1.4.7+76530c8
/usr/bin/btop cap_dac_read_search,cap_perfmon=ep
```

`btop -d` reports:

```text
Xe: Using fdinfo for GPU utilization (PCI: 0000:00:02.0)
```

GPU usage and frequency appear inside the CPU panel.

Additional checks:

```text
bash -n bin/omarchy-hw-intel-xe install/config/hardware/intel/btop-xe.sh migrations/1782416832.sh
git diff --check
```

## Notes

Temporary until upstream btop and Arch `extra/btop` ship Intel `xe` support.

AI disclosure: this PR was prepared with AI assistance and manually tested on real Panther Lake hardware.
