### PR TITLE
Fix intermittent suspend hang on T2 MacBooks (force synchronous device suspend)

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -63,6 +63,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/framework/qmk-hid.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-spi-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-nvme.sh
+run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-async.sh
 run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh

--- a/install/config/hardware/apple/fix-suspend-async.sh
+++ b/install/config/hardware/apple/fix-suspend-async.sh
@@ -16,6 +16,7 @@ if lspci -nn | grep -q "106b:180[12]"; then
   cat <<EOF | sudo tee /etc/systemd/system/omarchy-pm-async-suspend-fix.service >/dev/null
 [Unit]
 Description=Omarchy synchronous device-suspend fix for T2 MacBook
+ConditionPathExists=/sys/power/pm_async
 
 [Service]
 Type=oneshot

--- a/install/config/hardware/apple/fix-suspend-async.sh
+++ b/install/config/hardware/apple/fix-suspend-async.sh
@@ -1,0 +1,30 @@
+# Fix intermittent suspend hang on T2 MacBooks caused by async device suspend.
+#
+# On T2 Macs the kernel default of asynchronous (parallel) device suspend
+# (/sys/power/pm_async=1) intermittently HARD-HANGS the machine the instant it
+# enters suspend: black screen, dead keyboard/trackpad/Touch Bar, no wake, only
+# a forced power-off recovers. pm_trace fingerprints the hang in the async
+# device-suspend core (drivers/base/power/main.c), not in any single driver.
+# Forcing synchronous device suspend serialises it and resolves the hang.
+#
+# Confirmed on MacBookPro16,2 (5/5 clean suspend cycles with the fix vs 5/5
+# hangs without). Independent of suspend mode (deep or s2idle). See
+# basecamp/omarchy#1840 for the broader set of affected T2 models.
+if lspci -nn | grep -q "106b:180[12]"; then
+  echo "Detected MacBook with T2 chip. Applying synchronous device-suspend fix..."
+
+  cat <<EOF | sudo tee /etc/systemd/system/omarchy-pm-async-suspend-fix.service >/dev/null
+[Unit]
+Description=Omarchy synchronous device-suspend fix for T2 MacBook
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'echo 0 > /sys/power/pm_async'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  chrootable_systemctl_enable omarchy-pm-async-suspend-fix.service
+  sudo systemctl daemon-reload
+fi

--- a/install/config/hardware/apple/fix-suspend-async.sh
+++ b/install/config/hardware/apple/fix-suspend-async.sh
@@ -26,6 +26,16 @@ ExecStart=/bin/bash -c 'echo 0 > /sys/power/pm_async'
 WantedBy=multi-user.target
 EOF
 
-  chrootable_systemctl_enable omarchy-pm-async-suspend-fix.service
+  # The installer defines this helper via install/helpers/all.sh, but migrations
+  # run in a fresh shell, so pull it in directly when it isn't already defined.
+  # (OMARCHY_INSTALL is installer-only; OMARCHY_PATH is in the user environment.)
+  declare -F chrootable_systemctl_enable >/dev/null ||
+    source "$OMARCHY_PATH/install/helpers/chroot.sh"
+
+  if ! chrootable_systemctl_enable omarchy-pm-async-suspend-fix.service; then
+    echo "Failed to enable omarchy-pm-async-suspend-fix.service" >&2
+    exit 1
+  fi
+
   sudo systemctl daemon-reload
 fi

--- a/migrations/1782742549.sh
+++ b/migrations/1782742549.sh
@@ -1,11 +1,3 @@
-# Omarchy migration — apply the T2 synchronous device-suspend fix to existing
-# installs. At submission time, RENAME this file to a fresh unix timestamp that
-# is greater than the newest existing migration, e.g.:
-#
-#     mv migration.sh "migrations/$(date +%s).sh"
-#
-# (Verify it sorts after the current latest in migrations/.)
-
 echo "Fix intermittent suspend hang on T2 MacBooks (force synchronous device suspend)"
 
 source $OMARCHY_PATH/install/config/hardware/apple/fix-suspend-async.sh

--- a/migrations/1782742549.sh
+++ b/migrations/1782742549.sh
@@ -1,0 +1,11 @@
+# Omarchy migration — apply the T2 synchronous device-suspend fix to existing
+# installs. At submission time, RENAME this file to a fresh unix timestamp that
+# is greater than the newest existing migration, e.g.:
+#
+#     mv migration.sh "migrations/$(date +%s).sh"
+#
+# (Verify it sorts after the current latest in migrations/.)
+
+echo "Fix intermittent suspend hang on T2 MacBooks (force synchronous device suspend)"
+
+source $OMARCHY_PATH/install/config/hardware/apple/fix-suspend-async.sh


### PR DESCRIPTION
Refs: #1840

## Problem

On T2 MacBooks, `systemctl suspend` / lid-close intermittently **hard-hangs** the
machine the instant it enters suspend — black screen, dead keyboard/trackpad/
Touch Bar, no wake; only a forced power-off recovers. This is the core of the
widely-reported #1840 across many T2 models (13"/15"/16", 2018–2020).

## Root cause

An **asynchronous device-suspend race**. The kernel default
(`/sys/power/pm_async=1`) suspends devices in parallel; on T2 hardware this
races and deadlocks. `pm_trace` localises the hang to the async suspend core
(`drivers/base/power/main.c`), **not** to any single driver — which is why
unloading individual drivers (brcmfmac, apple-bce) and PCI D3cold tweaks don't
help. Forcing synchronous device suspend (`pm_async=0`) eliminates the race.

The existing `install/config/hardware/apple/fix-suspend-nvme.sh` does not cover
these machines: it excludes 16,x/15,x models and targets a discrete NVMe at PCI
`0000:01:00.0`, whereas 16,2-class storage is the T2-bridged ANS2 controller at
`e6:00.0`. This fix is independent of that one.

## Fix

Add `install/config/hardware/apple/fix-suspend-async.sh`: on T2 Macs
(`lspci 106b:180[12]`), install + enable a oneshot service that writes
`0` to `/sys/power/pm_async` at boot. Mirrors the structure of the existing
`fix-suspend-nvme.sh`. No change to mem_sleep / logind.conf / sleep.conf /
bootloader cmdline is required.

## Testing

- MacBookPro16,2, Omarchy 3.8.2, `linux-t2` 7.0.12: **5/5 clean** suspend/resume
  cycles with the fix vs **5/5 hard hangs** without (same `deep` mode). Lid
  close/reopen confirmed. Persists across reboot.
- Low risk: serial device suspend is marginally slower (sub-second) and is a
  no-op on hardware that wasn't racing.

## Changes

1. `install/config/hardware/apple/fix-suspend-async.sh` (new)
2. `install/config/all.sh` — add one line after the `fix-suspend-nvme.sh` entry:
   `run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-suspend-async.sh`
3. `migrations/<unix-timestamp>.sh` (new) — sources the script so existing
   installs get it on `omarchy update`.

## Note for reviewers

Gated to T2 Macs (where it's proven). `pm_async=0` is harmless on non-racing
hardware, so the gate could be widened to all Apple MacBooks (`#1840` includes a
couple of non-T2 reports) if preferred. Co-testers from #1840 on 13"/15" models
would help confirm breadth.