### PR TITLE
feat: add hyprmod to preinstalled packages and style menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -271,7 +271,7 @@ show_hardware_touchpad_haptics_menu() {
 }
 
 show_style_menu() {
-  case $(menu "Style" "󰸌  Theme\n󰟵  Unlock\n  Font\n  Background\n󰍜  Waybar\n󰘇  Corners\n  Hyprland\n󱄄  Screensaver\n  About") in
+  case $(menu "Style" "󰸌  Theme\n󰟵  Unlock\n  Font\n  Background\n󰍜  Waybar\n󰘇  Corners\n  Hyprland\n  HyprMod\n󱄄  Screensaver\n  About") in
 
   *Theme*) show_theme_menu ;;
   *Unlock*) omarchy-launch-walker -m menus:omarchyunlocks --width 800 --minheight 400 ;;
@@ -279,6 +279,7 @@ show_style_menu() {
   *Background*) show_background_menu ;;
   *Corners*) show_style_corners_menu ;;
   *Hyprland*) open_in_editor "$(hypr_config_file looknfeel)" ;;
+  *HyprMod*) setsid hyprmod ;;
   *Waybar*) show_waybar_position_menu ;;
   *Screensaver*) show_screensaver_menu ;;
   *About*) show_about_menu ;;

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -55,6 +55,7 @@ hyprland
 hyprland-guiutils
 hyprland-preview-share-picker
 hyprlock
+hyprmod
 hyprpicker
 hyprsunset
 imagemagick


### PR DESCRIPTION
## Summary
- Added HyprMod to the preinstalled package list
- Integrated HyprMod into the Style submenu (Super+Alt+Space)
cj
This provides a GUI to tinker with hyprland setup in omarchy in  a safe env. It does not touch the original config files.

## Changes
- **install/omarchy-base.packages**: Added `hyprmod` to the package list
- **bin/omarchy-menu**: Added HyprMod option to the Style submenu that launches `hyprmod`