### PR TITLE
Support per-power-source profile overrides in omarchy-powerprofiles-set

### DIFF
--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -30,16 +30,41 @@ fi
 
 mapfile -t profiles < <(powerprofilesctl list | awk '/^\s*[* ]\s*[a-zA-Z0-9\-]+:$/ { gsub(/^[*[:space:]]+|:$/,""); print }')
 
-case "$action" in
-  ac)
-    # Prefer performance, fall back to balanced
-    if [[ " ${profiles[*]} " == *" performance "* ]]; then
-      powerprofilesctl set performance
-    else
+profile_available() { [[ " ${profiles[*]} " == *" $1 "* ]]; }
+
+# Optional user overrides in ~/.config/omarchy/power-profile, e.g.:
+#   battery=power-saver
+#   ac=performance
+# The user's home is derived from the script path because udev invokes us as
+# root via systemd-run, so $HOME is not the desktop user's home.
+script_path="$(readlink -f "$0")"
+user_home="${script_path%/.local/share/omarchy/bin/omarchy-powerprofiles-set}"
+config_file="${user_home}/.config/omarchy/power-profile"
+
+configured_profile=""
+if [[ -r $config_file ]]; then
+  while IFS='=' read -r key value; do
+    key="${key//[[:space:]]/}"
+    value="${value//[[:space:]]/}"
+    [[ $key == "$action" ]] && configured_profile="$value"
+  done <"$config_file"
+fi
+
+# Honor a valid user override; otherwise use the built-in defaults.
+if [[ -n $configured_profile ]] && profile_available "$configured_profile"; then
+  powerprofilesctl set "$configured_profile"
+else
+  case "$action" in
+    ac)
+      # Prefer performance, fall back to balanced
+      if profile_available performance; then
+        powerprofilesctl set performance
+      else
+        powerprofilesctl set balanced
+      fi
+      ;;
+    battery)
       powerprofilesctl set balanced
-    fi
-    ;;
-  battery)
-    powerprofilesctl set balanced
-    ;;
-esac
+      ;;
+  esac
+fi


### PR DESCRIPTION
## What

Adds an optional user config file at `~/.config/omarchy/power-profile` that lets
you choose which power profile is applied on battery vs. on AC:

```
battery=power-saver
ac=balanced
```

Each key is looked up against the profiles reported by `powerprofilesctl list`,
so any valid profile name works.

## Why

The udev rule installed by `powerprofilesctl-rules.sh` runs
`omarchy-powerprofiles-set` on every AC/USB power event, and the script
unconditionally forces `performance` whenever the machine is on AC.

On my laptop that's a problem: `performance` makes the chassis run hot enough
that the built-in keyboard becomes uncomfortable to type on. I want to stay on
`power-saver` (or `balanced`) even while plugged in, but there was no way to do
that short of editing the script directly — which `git pull` reverts on the next
update.

This makes the AC/battery profile targets configurable, so the tradeoff between
performance and heat/noise/battery can be set to preference instead of being
hardcoded.

## Behavior

- **Fully backward compatible.** With no config file present, behavior is
  identical to today: `performance` on AC (falling back to `balanced` if
  unavailable), `balanced` on battery.
- Unknown keys or invalid/unavailable profile values fall back to the built-in
  defaults, so a typo can never leave the machine in a broken state.
- The user's home is derived from the script's own path rather than `$HOME`,
  because udev invokes the script as root via `systemd-run`.

## Example

~/.config/omarchy/power-profile
```
battery=power-saver
ac=power-saver
```

Keeps the laptop cool and quiet regardless of whether it's plugged in.
