### PR TITLE
Force software cursors on nouveau to fix invisible mouse pointer

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -40,6 +40,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/printer.sh
 run_logged $OMARCHY_INSTALL/config/hardware/usb-autosuspend.sh
 run_logged $OMARCHY_INSTALL/config/hardware/ignore-power-button.sh
 run_logged $OMARCHY_INSTALL/config/hardware/nvidia.sh
+run_logged $OMARCHY_INSTALL/config/hardware/fix-nouveau-cursor.sh
 run_logged $OMARCHY_INSTALL/config/hardware/vulkan.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/intel/video-acceleration.sh

--- a/install/config/hardware/fix-nouveau-cursor.sh
+++ b/install/config/hardware/fix-nouveau-cursor.sh
@@ -1,0 +1,35 @@
+# Disable hardware cursors when the nouveau driver is in use.
+#
+# The nouveau DRM driver does not display the hardware cursor plane on many
+# older NVIDIA GPUs (e.g. Apple's GeForce 320M / MCP89 in the 2010 Mac mini),
+# leaving the mouse pointer invisible on the physical display under Hyprland.
+# Forcing software cursors makes the pointer render correctly.
+#
+# The fix appends a Lua `hl.config({ cursor = { no_hardware_cursors = true } })`
+# block to the user's ~/.config/hypr/looknfeel.lua.
+#
+# nouveau only ever binds NVIDIA GPUs, so matching the driver line directly is
+# enough to mean "a GPU on this machine is driven by nouveau". Skip the fix when
+# nvidia.sh has just configured the proprietary driver (/etc/modprobe.d/nvidia.conf):
+# those systems are still on nouveau until the first reboot, but will switch to
+# the proprietary driver, which renders hardware cursors correctly.
+if [[ ! -f /etc/modprobe.d/nvidia.conf ]] &&
+  command -v lspci &>/dev/null &&
+  LC_ALL=C lspci -k | grep -qi 'Kernel driver in use: nouveau'; then
+  HYPR_LOOKNFEEL="$HOME/.config/hypr/looknfeel.lua"
+
+  if [[ -f $HYPR_LOOKNFEEL ]] && ! grep -q 'no_hardware_cursors' "$HYPR_LOOKNFEEL"; then
+    echo "Detected nouveau driver. Forcing software cursors so the mouse pointer stays visible."
+
+    cat >>"$HYPR_LOOKNFEEL" <<'EOF'
+
+-- nouveau does not display the hardware cursor plane on many older NVIDIA GPUs,
+-- leaving the pointer invisible on the physical display. Render it in software.
+hl.config({
+  cursor = {
+    no_hardware_cursors = true,
+  },
+})
+EOF
+  fi
+fi


### PR DESCRIPTION
## Problem

On systems using the **nouveau** driver, the mouse cursor is invisible on the physical display under Hyprland. The compositor tracks the pointer correctly (hover, clicks, and `hyprctl cursorpos` all work) — it simply is never painted, so local users see no cursor.

## Root cause

nouveau does not display the DRM hardware-cursor plane on many older NVIDIA GPUs. Hyprland's `cursor:no_hardware_cursors` defaults to `auto`, which keeps the hardware cursor plane in use, so the pointer never renders.

This turned up on a 2010 Mac mini (Apple **GeForce 320M / MCP89**) — a GPU too old for even the legacy `nvidia-580xx` branch in `nvidia.sh`, so Omarchy correctly leaves it on nouveau. But nothing then addresses the cursor, so the install boots to an invisible pointer.

## Fix

Add `install/config/hardware/fix-nouveau-cursor.sh`, which detects nouveau as the active DRM driver and appends a software-cursor override to the user's Hyprland config:

```lua
hl.config({
  cursor = {
    no_hardware_cursors = true,
  },
})
```

It writes to `~/.config/hypr/looknfeel.lua` — the user override file where Omarchy already keeps `cursor` settings (see `default/hypr/looknfeel.lua`) — and is registered in `install/config/all.sh` right after `nvidia.sh`.

- **Keyed on the active driver, not a GPU-model regex** — covers every affected machine rather than just one card. nouveau only ever binds NVIDIA GPUs, so `lspci -k | grep -qi 'Kernel driver in use: nouveau'` has no false positives.
- **Idempotent** — guarded on an existing `no_hardware_cursors` setting, so re-running the installer never duplicates the block.
- `lspci` is guarded with `command -v`, and `LC_ALL=C` keeps the match locale-stable.

## Testing

- Detection verified on the affected hardware (Mac mini, GeForce 320M / MCP89): `lspci -k` reports `Kernel driver in use: nouveau` and the script fires.
- Against the current `looknfeel.lua` template, the appended block parses cleanly under `luac -p`.
- Re-running does not add a second block (idempotency guard).
- `bash -n` passes.

The underlying one-line setting (`no_hardware_cursors = true`) was first applied by hand on the affected machine and confirmed to make the cursor visible.
