### PR TITLE
Add horizontal wheel workspace bindings

### DIFF
--- a/default/hypr/bindings/tiling-v2.lua
+++ b/default/hypr/bindings/tiling-v2.lua
@@ -64,6 +64,8 @@ o.bind("SUPER + CTRL + SHIFT + code:21", "Expand window down a lot", hl.dsp.wind
 
 o.bind("SUPER + mouse_down", "Scroll active workspace forward", hl.dsp.focus({ workspace = "e+1" }))
 o.bind("SUPER + mouse_up", "Scroll active workspace backward", hl.dsp.focus({ workspace = "e-1" }))
+o.bind("SUPER + mouse_right", "Scroll active workspace forward", hl.dsp.focus({ workspace = "e+1" }))
+o.bind("SUPER + mouse_left", "Scroll active workspace backward", hl.dsp.focus({ workspace = "e-1" }))
 
 o.bind("SUPER + mouse:272", "Move window", hl.dsp.window.drag(), { mouse = true })
 o.bind("SUPER + mouse:273", "Resize window", hl.dsp.window.resize(), { mouse = true })


### PR DESCRIPTION
## Summary

Adds default Hyprland bindings for horizontal mouse wheel events so mice with a horizontal scroll wheel can switch workspaces with the same modifier pattern Omarchy already uses for vertical wheel workspace navigation.

## What changed

Omarchy already binds:

- `Super + mouse_down` to move to the next workspace
- `Super + mouse_up` to move to the previous workspace

This PR adds the matching horizontal wheel bindings:

- `Super + mouse_right` moves to the next workspace
- `Super + mouse_left` moves to the previous workspace

## How to use it

On a mouse that emits horizontal wheel events, hold `Super` and use the horizontal scroll wheel:

- scroll right to move forward through workspaces
- scroll left to move backward through workspaces

This keeps plain horizontal scrolling available inside applications because the workspace action only triggers while `Super` is held.

## Why

Some mice, such as Logitech MX Master-style devices, include a dedicated horizontal wheel. Hyprland supports these events as `mouse_left` and `mouse_right`, so this makes workspace navigation feel consistent across vertical and horizontal wheel input without adding any device-specific configuration.

## Validation

- Tested locally by adding the equivalent bindings to `~/.config/hypr/bindings.conf`
- Ran `hyprctl reload` and `hyprctl configerrors` with no config errors
- Verified `Super` + horizontal wheel left/right switches workspaces on a Logitech MX Master 3S-style mouse
