### PR TITLE
Remove stale 99-omarchy-nofile.conf drop-ins via migration

### DIFF
--- a/migrations/1783292001.sh
+++ b/migrations/1783292001.sh
@@ -1,0 +1,32 @@
+echo "Remove stale 99-omarchy-nofile.conf systemd drop-ins"
+
+# Earlier Omarchy shipped 99-omarchy-nofile.conf using the key
+# 'DefaultLimitNOFILESoft', which is not a valid systemd manager setting.
+# systemd rejects it at manager load on every boot:
+#   /etc/systemd/system.conf.d/99-omarchy-nofile.conf: Unknown key
+#   'DefaultLimitNOFILESoft' in section [Manager], ignoring.
+# It was replaced by 20-omarchy-nofile.conf (DefaultLimitNOFILE=soft:hard),
+# but the orphaned 99- files are unowned by any package and linger on
+# upgraded systems, spamming the journal on every boot. Remove them; the
+# 20-omarchy-nofile.conf drop-in already sets the limit correctly.
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+removed=0
+for f in \
+  /etc/systemd/system.conf.d/99-omarchy-nofile.conf \
+  /etc/systemd/user.conf.d/99-omarchy-nofile.conf; do
+  if [[ -f $f ]]; then
+    as_root rm -f "$f" && removed=1
+  fi
+done
+
+if (( removed )); then
+  as_root systemctl daemon-reload >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
On upgraded systems, `/etc/systemd/{system,user}.conf.d/99-omarchy-nofile.conf` remains behind and uses the key `DefaultLimitNOFILESoft`, which is **not** a valid systemd `[Manager]` setting. systemd rejects it at manager load on **every boot**:

```
/etc/systemd/system.conf.d/99-omarchy-nofile.conf: Unknown key 'DefaultLimitNOFILESoft' in section [Manager], ignoring.
/etc/systemd/user.conf.d/99-omarchy-nofile.conf: Unknown key 'DefaultLimitNOFILESoft' in section [Manager], ignoring.
```

These were superseded by `20-omarchy-nofile.conf` (which correctly uses `DefaultLimitNOFILE=65536:524288`), but the `99-` files are **unowned by any package** (`pacman -Qo` reports no owner), so upgrades never remove them and they keep spamming the journal.

### Fix
Adds a migration that removes the orphaned `99-` drop-ins from both `system.conf.d` and `user.conf.d`, then reloads the manager. The `20-` drop-in already sets the limit, so no functional change to the NOFILE limits.

### Testing
Observed on a 4.0-alpha (`quattro`) system upgraded from an earlier build (14 such errors per boot). After running the migration the errors are gone and `20-omarchy-nofile.conf` continues to provide the limit.