### PR TITLE
Prevent migration notifier from rate-limiting itself off

### DIFF
--- a/default/systemd/user/omarchy-update-user-notify.service
+++ b/default/systemd/user/omarchy-update-user-notify.service
@@ -1,6 +1,13 @@
 [Unit]
 Description=Notify about pending Omarchy migrations
 ConditionPathIsDirectory=/usr/share/omarchy/migrations
+# A single update can drop several migration files at once, so the .path
+# unit re-triggers this oneshot in a burst. Without this, the default
+# start-rate limit (5 starts / 10s) trips and the watching .path unit
+# itself dies with 'unit-start-limit-hit', silently stopping migration
+# notifications for the rest of the session. The notifier is idempotent,
+# so disable the start-rate limit.
+StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
`omarchy-update-user-notify.path` watches `/usr/share/omarchy/migrations` with `PathModified`. A single update commonly drops **several** migration files at once, so the oneshot service is re-triggered in a burst and exceeds the default start-rate limit (`StartLimitBurst=5` / `10s`):

```
omarchy-update-user-notify.service: Start request repeated too quickly.
omarchy-update-user-notify.service: Failed with result 'start-limit-hit'.
omarchy-update-user-notify.path: Failed with result 'unit-start-limit-hit'.
```

When the limit trips, the watching **`.path` unit itself fails and stops watching**. Migrations that land later in the session are then never surfaced until the next login — defeating the purpose of the live watcher.

### Fix
Set `StartLimitIntervalSec=0` on the service. `omarchy-migrate-notify` is idempotent, so there is no downside to letting it run on every trigger.

### Testing
Reproduced on a 4.0-alpha (`quattro`) system: after an update wrote multiple migration files, `omarchy-update-user-notify.path` was left `inactive` (start-limit-hit) for the rest of the session. With `StartLimitIntervalSec=0` the burst no longer trips the limit and the `.path` unit stays active.