### PR TITLE
Align MAX_SNAPSHOT_ENTRIES with Snapper retention (off-by-one)

### DIFF
--- a/etc/limine-entry-tool.d/omarchy-defaults.conf
+++ b/etc/limine-entry-tool.d/omarchy-defaults.conf
@@ -10,6 +10,12 @@ FIND_BOOTLOADERS=yes
 
 BOOT_ORDER="*, *fallback, Snapshots"
 
-MAX_SNAPSHOT_ENTRIES=5
+# Snapper is configured with NUMBER_LIMIT="5" (see default/snapper/root).
+# limine-snapper-sync also counts the freshly-created / currently-booted
+# snapshot, so a steady state of 5 retained snapshots is seen as 6 entries.
+# Keep this one above the Snapper limit so the counts do not mismatch:
+#   Snapshot limit mismatch: 6 Snapper snapshots exceed configured
+#   MAX_SNAPSHOT_ENTRIES=5
+MAX_SNAPSHOT_ENTRIES=6
 
 SNAPSHOT_FORMAT_CHOICE=5

--- a/etc/limine-entry-tool.d/omarchy-defaults.conf
+++ b/etc/limine-entry-tool.d/omarchy-defaults.conf
@@ -10,10 +10,9 @@ FIND_BOOTLOADERS=yes
 
 BOOT_ORDER="*, *fallback, Snapshots"
 
-# Snapper is configured with NUMBER_LIMIT="5" (see default/snapper/root).
-# limine-snapper-sync also counts the freshly-created / currently-booted
-# snapshot, so a steady state of 5 retained snapshots is seen as 6 entries.
-# Keep this one above the Snapper limit so the counts do not mismatch:
+# Snapper is configured with NUMBER_LIMIT="5" (see default/snapper/root), but
+# limine-snapper-sync can see the newly created sixth snapshot before cleanup
+# restores the retained snapshot count to 5. Allow for that creation window:
 #   Snapshot limit mismatch: 6 Snapper snapshots exceed configured
 #   MAX_SNAPSHOT_ENTRIES=5
 MAX_SNAPSHOT_ENTRIES=6

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -5,13 +5,15 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 template="$ROOT/default/snapper/root"
+limine_defaults="$ROOT/etc/limine-entry-tool.d/omarchy-defaults.conf"
 limine_notify_autostart="$ROOT/config/autostart/limine-snapper-notify.desktop"
 
 grep -Fx 'NUMBER_CLEANUP="yes"' "$template" >/dev/null
 grep -Fx 'NUMBER_LIMIT="5"' "$template" >/dev/null
 grep -Fx 'TIMELINE_CREATE="no"' "$template" >/dev/null
 ! grep -Eq '^TIMELINE_(CLEANUP|LIMIT_)' "$template" || fail "Snapper template keeps timeline cleanup details out of the default config"
-pass "Snapper template keeps update snapshots and disables timeline snapshots"
+grep -Fx 'MAX_SNAPSHOT_ENTRIES=6' "$limine_defaults" >/dev/null || fail "Limine allows for a snapshot created before Snapper cleanup"
+pass "Snapper and Limine retain update snapshots without a transient limit mismatch"
 
 grep -Fx '[Desktop Entry]' "$limine_notify_autostart" >/dev/null
 grep -Fx 'Hidden=true' "$limine_notify_autostart" >/dev/null


### PR DESCRIPTION
Snapper is configured with `NUMBER_LIMIT="5"` (`default/snapper/root`), but `limine-snapper-sync` also counts the freshly-created / currently-booted snapshot, so five retained snapshots are reported as **six** entries. It warns on every snapshot and every update:

```
limine-snapper-sync: Snapshot limit mismatch: 6 Snapper snapshots exceed configured MAX_SNAPSHOT_ENTRIES=5
```

(There is already migration `1782049344.sh` that hides the desktop *notification* for this, but the underlying count mismatch and the journal warning remain.)

### Fix
Raise `MAX_SNAPSHOT_ENTRIES` to `6` (`NUMBER_LIMIT + 1`) so the boot-menu cap and Snapper retention agree.

**Alternative:** `MAX_SNAPSHOT_ENTRIES=auto` derives the cap from Snapper directly and can never mismatch — happy to switch to that if you prefer it over an explicit value. I kept an explicit number here to preserve the existing boot-menu limit. Note `NUMBER_LIMIT_IMPORTANT="5"` is separate, so heavy use of important snapshots could still exceed the cap; `auto` would also cover that case.

### Testing
Observed the warning on every `limine-snapper-sync`/`limine-snapper-watcher` run on a 4.0-alpha (`quattro`) system with 6 snapshots present.