### PR TITLE
[codex] Add left-arrow menu back navigation

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -841,6 +841,9 @@ Item {
             if (root.filterText.length > 0) root.setFilter(root.filterText.slice(0, -1))
             else root.goBack()
             event.accepted = true
+          } else if (!root.dmenuActive && event.key === Qt.Key_Left) {
+            root.goBack()
+            event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)
             event.accepted = true

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -119,6 +119,10 @@ assert(
   'menu route changes disarm pointer selection'
 )
 assert(
+  /Qt\.Key_Left\)[\s\S]*root\.goBack\(\)/.test(menuQml),
+  'menu supports left-arrow back navigation'
+)
+assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),
   'menu uses shared pointer movement gate in card coordinates'
 )


### PR DESCRIPTION
## Summary

Adds Left-arrow as a spatial back navigation shortcut in the Omarchy menu. Right/Enter already enter the selected submenu or action, so Left now returns to the previous menu when the menu is active.

Related to the Omarchy 4 alpha menu improvements.

## Validation

- `bash test/shell.d/menu-test.sh`
