### PR TITLE
[codex] Show breadcrumbs in the menu header

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -335,6 +335,17 @@ Item {
     return MenuModel.pathFor(root.items, id)
   }
 
+  function headerText() {
+    if (root.filterText) return root.filterText
+    if (root.dmenuActive) return root.dmenuPrompt + "…"
+
+    var entry = root.item(root.activeMenu)
+    if (!entry) return "Go…"
+
+    var path = root.pathFor(root.activeMenu)
+    return (path || entry.label) + "…"
+  }
+
   function parentPathFor(id) {
     return MenuModel.parentPathFor(root.items, id)
   }
@@ -885,7 +896,7 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || (root.dmenuActive ? (root.dmenuPrompt + "…") : ((root.item(root.activeMenu) ? root.item(root.activeMenu).label : "Go") + "…"))
+            text: root.headerText()
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -119,6 +119,10 @@ assert(
   'menu route changes disarm pointer selection'
 )
 assert(
+  /function headerText\(\)[\s\S]*var path = root\.pathFor\(root\.activeMenu\)[\s\S]*return \(path \|\| entry\.label\) \+ "…"/.test(menuQml),
+  'menu header shows the active breadcrumb path'
+)
+assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),
   'menu uses shared pointer movement gate in card coordinates'
 )


### PR DESCRIPTION
## Summary

Shows the full active menu path in the Omarchy menu header instead of only the current submenu label. Deep routes now retain context such as `Setup › Defaults › Browser` while preserving the existing type-to-filter placeholder behavior.

Related to the Omarchy 4 alpha menu improvements.

## Validation

- `bash test/shell.d/menu-test.sh`
