### PR TITLE
[codex] Clarify menu root category labels

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -16,12 +16,12 @@
   // Root Menu
   "apps": {"icon":"󰀻","label":"Apps","aliases":["app","applications"],"keywords":"","action":"omarchy-shell shell summon omarchy.launcher"},
   "learn": {"icon":"󰧑","label":"Learn","keywords":"manual docs help"},
-  "trigger": {"icon":"󱓞","label":"Trigger","keywords":""},
+  "trigger": {"icon":"󱓞","label":"Actions","aliases":["actions","tools"],"keywords":"trigger command run"},
   "style": {"icon":"","label":"Style","keywords":""},
-  "setup": {"icon":"","label":"Setup","aliases":["settings"],"keywords":""},
+  "setup": {"icon":"","label":"Settings","aliases":["settings","preferences"],"keywords":"setup config"},
   "install": {"icon":"󰉉","label":"Install","keywords":""},
   "remove": {"icon":"󰭌","label":"Remove","aliases":["uninstall"],"keywords":""},
-  "update": {"icon":"","label":"Update","aliases":["restart","refresh"],"keywords":"upgrade channel firmware timezone"},
+  "update": {"icon":"","label":"Maintenance","aliases":["update","restart","refresh"],"keywords":"upgrade channel firmware timezone"},
   "about": {"icon":"","label":"About","keywords":"omarchy system information","action":"omarchy-launch-about"},
   "system": {"icon":"","label":"System","aliases":["power-menu"],"keywords":"lock logout restart shutdown suspend hibernate"},
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -97,6 +97,12 @@ assert(
   defaultById['update.omarchy'].icon === '\ue900',
   'menu update Omarchy entry uses the Omarchy glyph'
 )
+assertEqual(defaultById['trigger'].label, 'Actions', 'menu uses a clearer root label for actions')
+assert(defaultById['trigger'].aliases.includes('actions'), 'menu can route directly to actions')
+assertEqual(defaultById['setup'].label, 'Settings', 'menu uses a clearer root label for settings')
+assert(defaultById['setup'].aliases.includes('settings'), 'menu preserves the settings route alias')
+assertEqual(defaultById['update'].label, 'Maintenance', 'menu uses a clearer root label for maintenance')
+assert(defaultById['update'].aliases.includes('update'), 'menu preserves the update route alias')
 assert(
   defaultById['update.omarchy'].iconFont === 'omarchy',
   'menu update Omarchy entry renders the private glyph with the Omarchy font'


### PR DESCRIPTION
## Summary

Renames a few broad top-level Omarchy menu categories to more direct user-facing labels while keeping the underlying IDs and routes stable:

- `Trigger` -> `Actions`
- `Setup` -> `Settings`
- `Update` -> `Maintenance`

Existing IDs remain unchanged, and aliases preserve common routes such as `settings` and `update`.

Related to the Omarchy 4 alpha menu improvements.

## Validation

- `bash test/shell.d/menu-test.sh`
