### PR TITLE
[codex] Show child counts for menu submenus

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1010,14 +1010,14 @@ Item {
 
               Row {
                 id: trail
-                width: Style.space(14)
+                width: row.childCount > 0 ? Style.space(44) : Style.space(14)
                 anchors.right: parent.right
                 anchors.rightMargin: root.rowReservedBorderRight + Style.space(8)
                 y: contentColumn.y + labelText.y + (labelText.height - height) / 2
-                spacing: 0
+                spacing: Style.space(4)
 
                 Text {
-                  visible: false
+                  visible: row.childCount > 0 && (row.kind === "menu" || row.kind === "link")
                   text: row.childCount
                   color: root.foreground
                   opacity: 0.45

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -90,6 +90,11 @@ assertDeepEqual(
   },
   'menu builds display rows'
 )
+assertEqual(
+  menu.displayRow(merged.items, merged.itemOrder, {}, merged.items.style, '', 0, '').childCount,
+  1,
+  'menu display rows expose submenu child counts'
+)
 
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))
@@ -104,6 +109,10 @@ assert(
 assert(
   /font\.family: row\.iconFont\.length > 0 \? row\.iconFont : root\.fontFamily/.test(menuQml),
   'menu rows support per-icon font families'
+)
+assert(
+  /visible: row\.childCount > 0 && \(row\.kind === "menu" \|\| row\.kind === "link"\)/.test(menuQml),
+  'menu rows show submenu child counts'
 )
 
 assert(


### PR DESCRIPTION
## Summary

Makes the Omarchy menu’s existing submenu child-count data visible in the trailing affordance for submenu and link rows. This gives dense menus a clearer signal that a row opens additional choices, and how many direct children it contains.

Related to the Omarchy 4 alpha menu improvements.

## Validation

- `bash test/shell.d/menu-test.sh`
