### PR TITLE
Fix wrong keyboard layout at the LUKS prompt on Plymouth 26

### DIFF
--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -1,6 +1,7 @@
 if command -v limine &>/dev/null; then
   sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
+FILES=(/etc/vconsole.conf)
 EOF
   sudo tee /etc/mkinitcpio.conf.d/thunderbolt_module.conf <<EOF >/dev/null
 MODULES+=(thunderbolt)

--- a/install/login/limine-snapper.sh
+++ b/install/login/limine-snapper.sh
@@ -1,7 +1,7 @@
 if command -v limine &>/dev/null; then
   sudo tee /etc/mkinitcpio.conf.d/omarchy_hooks.conf <<EOF >/dev/null
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
-FILES=(/etc/vconsole.conf)
+FILES+=(/etc/vconsole.conf)
 EOF
   sudo tee /etc/mkinitcpio.conf.d/thunderbolt_module.conf <<EOF >/dev/null
 MODULES+=(thunderbolt)

--- a/migrations/1783355853.sh
+++ b/migrations/1783355853.sh
@@ -1,0 +1,11 @@
+echo "Bundle the console keymap into the initramfs so Plymouth uses the right keyboard layout at the LUKS prompt"
+
+HOOKS_CONF="/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+
+if [[ -f $HOOKS_CONF ]] && ! grep -q '^FILES=' "$HOOKS_CONF"; then
+  echo "FILES=(/etc/vconsole.conf)" | sudo tee -a "$HOOKS_CONF" >/dev/null
+
+  if omarchy-cmd-present limine-mkinitcpio; then
+    sudo limine-mkinitcpio
+  fi
+fi

--- a/migrations/1783355853.sh
+++ b/migrations/1783355853.sh
@@ -2,8 +2,8 @@ echo "Bundle the console keymap into the initramfs so Plymouth uses the right ke
 
 HOOKS_CONF="/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
 
-if [[ -f $HOOKS_CONF ]] && ! grep -q '^FILES=' "$HOOKS_CONF"; then
-  echo "FILES=(/etc/vconsole.conf)" | sudo tee -a "$HOOKS_CONF" >/dev/null
+if [[ -f $HOOKS_CONF ]] && ! grep -q '/etc/vconsole.conf' "$HOOKS_CONF"; then
+  echo "FILES+=(/etc/vconsole.conf)" | sudo tee -a "$HOOKS_CONF" >/dev/null
 
   if omarchy-cmd-present limine-mkinitcpio; then
     sudo limine-mkinitcpio


### PR DESCRIPTION
After updating to the Plymouth 26 series my disk unlock prompt started falling back to US QWERTY instead of my actual keyboard layout. Once the system boots the layout is correct, it's only the LUKS prompt that's wrong.

The cause is that Plymouth 26 reads the keyboard layout from /etc/vconsole.conf, but that file never lands in the initramfs. The keymap hook only bakes in the compiled keymap.bin, not the config file, so Plymouth can't find the layout and defaults to US. Plymouth 24 didn't need the file, which is why this only shows up after the bump.

Reordering the hooks doesn't help (people tried keymap before plymouth and it made no difference). What actually fixes it is bundling the file. This adds FILES=(/etc/vconsole.conf) to omarchy_hooks.conf so the initramfs carries it. New installs pick it up through limine-snapper.sh, and existing installs get it through a migration that rebuilds the UKI.

It's additive, keymap.bin stays exactly as before, so there's no extra lockout risk. Confirmed on my own machine: after the rebuild the LUKS prompt uses my layout again.

Related to #6151 and #6072.
