### PR TITLE
fix: rename opencode alias from c to oc to avoid accidental triggers

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -43,7 +43,7 @@ alias ...='cd ../..'
 alias ....='cd ../../..'
 
 # Tools
-alias c='opencode'
+alias oc='opencode'
 alias cx='printf "\033[2J\033[3J\033[H" && claude --permission-mode bypassPermissions'
 alias d='docker'
 alias r='rails'


### PR DESCRIPTION
The single-letter alias `c='opencode'` is a footgun — any typo like `c;ear` (for `clear`) silently triggers a 54MB remote binary download via the opencode launcher. Renaming it to `oc` makes accidental invocation far less likely while keeping the alias short and memorable.

Closes #6119