### PR TITLE
fix: correct file extension and syntax in rounded-corners toggle

### DIFF
--- a/default/hypr/toggles/rounded-corners.conf
+++ b/default/hypr/toggles/rounded-corners.conf
@@ -1,4 +1,0 @@
-decoration {
-    rounding = 6
-    rounding_power = 3
-}

--- a/default/hypr/toggles/rounded-corners.lua
+++ b/default/hypr/toggles/rounded-corners.lua
@@ -1,0 +1,7 @@
+-- Apply rounded corners to windows.
+hl.config({
+  decoration = {
+    rounding = 6,
+    rounding_power = 3,
+  },
+})


### PR DESCRIPTION
The rounded-corners toggle file was named `rounded-corners.conf` but `omarchy-hyprland-toggle` looks for `rounded-corners.lua`, causing "Flag not found" and a silent no-op. Additionally the file used plain Hyprland syntax instead of the Lua `hl.config()` format required by the toggles system.

This renames `rounded-corners.conf` to `rounded-corners.lua` and converts its content to the correct Lua module format matching other toggles like `window-no-gaps.lua`.

Closes #6156