### PR TITLE
fix: add delay between selection and capture to avoid cursor in screenshot

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -123,6 +123,9 @@ esac
 
 [[ -z $SELECTION ]] && exit 0
 
+# Give the selection overlay time to disappear before capturing.
+sleep 0.1
+
 FILENAME="screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png"
 FILEPATH="$OUTPUT_DIR/$FILENAME"
 


### PR DESCRIPTION
After `slurp` completes its selection, `grim` was called immediately, capturing the selection crosshair overlay before it had time to disappear. Adding a 100ms delay lets the slurp UI clear before the screenshot is taken.

Closes #6142