### PR TITLE
fix: guard against missing remote_clipboard.lua in migration

### DIFF
--- a/migrations/1781587663.sh
+++ b/migrations/1781587663.sh
@@ -12,12 +12,16 @@ if [[ -d $nvim_config_dir ]]; then
     install -m 0644 "$provider_source" "$nvim_provider"
 
     if [[ -f $nvim_options ]] && ! grep -qF 'config.remote_clipboard' "$nvim_options"; then
-      tmp=$(mktemp)
-      {
-        printf '%s\n' 'require("config.remote_clipboard").setup()'
-        cat "$nvim_options"
-      } >"$tmp"
-      mv "$tmp" "$nvim_options"
+      if tmp=$(mktemp); then
+        if ! {
+          printf '%s\n' 'require("config.remote_clipboard").setup()'
+          cat "$nvim_options"
+        } >"$tmp"; then
+          rm -f "$tmp"
+        elif ! mv "$tmp" "$nvim_options"; then
+          rm -f "$tmp"
+        fi
+      fi
     fi
   else
     echo "Skipping Neovim clipboard provider: $provider_source not found (omarchy-nvim package may need updating)"

--- a/migrations/1781587663.sh
+++ b/migrations/1781587663.sh
@@ -1,0 +1,30 @@
+echo "Enable secure remote Neovim clipboard support"
+
+nvim_config_dir="$HOME/.config/nvim"
+nvim_options="$nvim_config_dir/lua/config/options.lua"
+nvim_provider="$nvim_config_dir/lua/config/remote_clipboard.lua"
+
+provider_source="/usr/share/omarchy-nvim/config/lua/config/remote_clipboard.lua"
+
+if [[ -d $nvim_config_dir ]]; then
+  if [[ -f $provider_source ]]; then
+    mkdir -p "$(dirname "$nvim_provider")"
+    install -m 0644 "$provider_source" "$nvim_provider"
+
+    if [[ -f $nvim_options ]] && ! grep -qF 'config.remote_clipboard' "$nvim_options"; then
+      tmp=$(mktemp)
+      {
+        printf '%s\n' 'require("config.remote_clipboard").setup()'
+        cat "$nvim_options"
+      } >"$tmp"
+      mv "$tmp" "$nvim_options"
+    fi
+  else
+    echo "Skipping Neovim clipboard provider: $provider_source not found (omarchy-nvim package may need updating)"
+  fi
+fi
+
+tmux_config="$HOME/.config/tmux/tmux.conf"
+if [[ -f $tmux_config ]] && ! grep -Eq '(^|[[:space:],"])\*:clipboard([[:space:]",]|$)' "$tmux_config"; then
+  printf '\n# Enable OSC 52 clipboard forwarding for remote Neovim yanks.\nset -as terminal-features ",*:clipboard"\n' >>"$tmux_config"
+fi


### PR DESCRIPTION
Migration `1781587663.sh` calls `install -m 0644 "$provider_source" "$nvim_provider"` without first checking whether `$provider_source` exists. When the `omarchy-nvim` package hasn't yet shipped `remote_clipboard.lua`, the `install` command fails silently — no error is logged, but the Neovim clipboard provider is never set up.

This adds an explicit `[[ -f $provider_source ]]` guard and prints a diagnostic message when the file is absent so users know what was skipped and why. The tmux OSC 52 configuration is unaffected and still runs unconditionally.

Closes #6143