### PR TITLE
Fix omarchy-hook double-running .d/ scripts when a parent hook exists

### DIFF
--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -17,9 +17,7 @@ shift
 
 if [[ -f $HOOK_PATH ]]; then
   bash "$HOOK_PATH" "$@" || echo "Hook failed: $HOOK_PATH"
-fi
-
-if [[ -d $HOOK_DIR ]]; then
+elif [[ -d $HOOK_DIR ]]; then
   for hook in "$HOOK_DIR"/*; do
     [[ -f $hook ]] || continue
     [[ $hook == *.sample ]] && continue


### PR DESCRIPTION
## Problem

When a parent hook (e.g. `theme-set`) iterates its own `.d/` scripts internally—passing exported colour variables to each child—`omarchy-hook` still runs those same `.d/` scripts a second time in fresh bash processes, but without the exports. The result is that the good output (correct CSS variables) is overwritten by a second run that sees only empty variables.

Reported in #6053. Reproduction:

1. `omarchy theme set <any theme>`
2. Check `~/.local/share/steam-adwaita/adwaita/colorthemes/omarchy/omarchy.css` — all `--adw-*-rgb:` values are empty.

## Fix

Change the second `if [[ -d $HOOK_DIR ]]` to `elif`, so the `.d/` loop only fires when **no parent hook file exists**. A parent hook that owns a `.d/` directory is responsible for running those scripts itself (which lets it pass down any env it needs). When there is no parent hook, the `.d/` loop runs as before.

```diff
 if [[ -f $HOOK_PATH ]]; then
   bash "$HOOK_PATH" "$@" || echo "Hook failed: $HOOK_PATH"
-fi
-
-if [[ -d $HOOK_DIR ]]; then
+elif [[ -d $HOOK_DIR ]]; then
```

One line change, no new dependencies.