### PR TITLE
Surface xdg-open errors from the open shell helper

### DIFF
--- a/default/bash/aliases
+++ b/default/bash/aliases
@@ -34,7 +34,7 @@ if command -v zoxide &> /dev/null; then
 fi
 
 open() (
-  xdg-open "$@" >/dev/null 2>&1 &
+  xdg-open "$@" >/dev/null &
 )
 
 # Directories


### PR DESCRIPTION
## Problem

The `open()` shell function silences both stdout *and* stderr from `xdg-open`:

```bash
open() (
  xdg-open "$@" >/dev/null 2>&1 &
)
```

When `xdg-open` fails (unknown MIME type, missing handler, bad path), the user
gets no output at all—the command just silently does nothing.

Reported in #6056.

## Fix

Drop only the stderr redirection. The function remains non-blocking and keeps
stdout suppressed (avoids noise from handlers that write to it), but
`xdg-open` errors now reach the terminal:

```diff
 open() (
-  xdg-open "$@" >/dev/null 2>&1 &
+  xdg-open "$@" >/dev/null &
 )
```

One character change. The non-blocking / no-job-control-noise behavior from
#4366 is fully preserved.