### PR TITLE
Add migration to backfill Mesa Vulkan drivers for pre-vulkan.sh installs

### DIFF
--- a/migrations/1783625095.sh
+++ b/migrations/1783625095.sh
@@ -1,0 +1,19 @@
+echo "Backfill Mesa Vulkan drivers for systems installed before vulkan.sh was added"
+
+declare -A VULKAN_DRIVERS=(
+  [Intel]=vulkan-intel
+  [AMD]=vulkan-radeon
+  [Apple]=vulkan-asahi
+)
+
+PACKAGES=()
+
+for vendor in "${!VULKAN_DRIVERS[@]}"; do
+  if lspci | grep -iE "(VGA|Display).*$vendor" > /dev/null; then
+    PACKAGES+=("${VULKAN_DRIVERS[$vendor]}")
+  fi
+done
+
+if (( ${#PACKAGES[@]} > 0 )); then
+  omarchy-pkg-add "${PACKAGES[@]}"
+fi


### PR DESCRIPTION
## Problem

`install/config/hardware/vulkan.sh` was added on 2026-02-20 but ships no
corresponding migration. Systems installed before that date never received
their Mesa Vulkan ICD. On Intel+NVIDIA Optimus laptops the effect is
concrete: only the NVIDIA Vulkan device is present, causing cross-presentation
stalls in mpv (Vulkan path) and similar GPU-selection bugs.

Reported in #6089.

## Fix

Add a migration that replays the same GPU vendor detection and
`omarchy-pkg-add` calls as `vulkan.sh`. `omarchy-pkg-add` is idempotent,
so systems that already received the driver (installed after 2026-02-20, or
on NVIDIA-only machines) are unaffected.

```bash
# migrations/1783625095.sh
declare -A VULKAN_DRIVERS=(
  [Intel]=vulkan-intel
  [AMD]=vulkan-radeon
  [Apple]=vulkan-asahi
)
...
```

No changes to install scripts or existing behaviour.