### PR TITLE
Extend sof-firmware install to all Intel SOF platforms (Arrow Lake, Meteor Lake, etc.)

### DIFF
--- a/bin/omarchy-hw-intel-sof
+++ b/bin/omarchy-hw-intel-sof
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer has an Intel SOF-capable audio DSP.
+# Matches Intel audio controllers (PCI class Multimedia audio or Audio device)
+# present on Skylake-and-later platforms that use sof-audio-pci-intel-* drivers.
+
+lspci | grep -iE '(Multimedia audio controller|Audio device).*Intel'

--- a/install/config/hardware/intel/sof-firmware.sh
+++ b/install/config/hardware/intel/sof-firmware.sh
@@ -1,8 +1,13 @@
-# Install Sound Open Firmware for the audio DSP on non-XPS Intel Panther
-# Lake systems. XPS PTL stays on linux-ptl, which hard-deps sof-firmware.
-# Mainline `linux` only optdeps it, so without this the DSP fails to boot
-# and only auto_null shows up in PipeWire.
+# Install Sound Open Firmware for the audio DSP on Intel systems that need it.
+# The sof-audio-pci-intel-* driver family requires sof-firmware to initialise
+# the DSP; without it the DSP fails to boot and PipeWire exposes only a
+# Dummy Output sink. This affects Arrow Lake, Meteor Lake, Tiger Lake,
+# Alder Lake, and similar platforms — not just Panther Lake.
+#
+# Panther Lake XPS systems are excluded because their linux-ptl kernel
+# already hard-depends sof-firmware, so the package is always present.
+# All other Intel SOF platforms on mainline linux need it installed explicitly.
 
-if omarchy-hw-intel-ptl && ! omarchy-hw-match "XPS"; then
+if omarchy-hw-intel-sof && ! (omarchy-hw-intel-ptl && omarchy-hw-match "XPS"); then
   omarchy-pkg-add sof-firmware
 fi

--- a/migrations/1783625096.sh
+++ b/migrations/1783625096.sh
@@ -1,0 +1,13 @@
+echo "Install sof-firmware for Intel SOF audio DSP platforms (Arrow Lake, Meteor Lake, etc.)"
+
+# Intel SOF platforms beyond Panther Lake (Arrow Lake, Meteor Lake, Tiger Lake,
+# Alder Lake) were not covered by the original sof-firmware install guard.
+# Without sof-firmware the DSP fails to boot and PipeWire exposes only a
+# Dummy Output. Install it now for all qualifying Intel systems.
+#
+# omarchy-pkg-add is idempotent — systems that already have the package
+# (Panther Lake XPS or any system that installed it manually) are unaffected.
+
+if omarchy-hw-intel-sof && ! (omarchy-hw-intel-ptl && omarchy-hw-match "XPS"); then
+  omarchy-pkg-add sof-firmware
+fi


### PR DESCRIPTION
## Problem

`install/config/hardware/intel/sof-firmware.sh` only installs `sof-firmware`
on Panther Lake systems. Arrow Lake (and Meteor Lake, Tiger Lake, Alder Lake,
etc.) all use the `sof-audio-pci-intel-*` driver family, which needs
`sof-firmware` to boot the DSP. On mainline `linux` the package is only an
`optdep`, so nothing pulls it in automatically. Result: fresh installs on
Arrow Lake laptops boot with no audio — PipeWire exposes only a Dummy Output
sink.

Reported in #6110 (Lenovo Yoga Pro 7 14IAH10, Intel Core Ultra 9 285H).

## Fix

**New detection script** `bin/omarchy-hw-intel-sof`: checks for any Intel
PCI audio controller (class Multimedia audio or Audio device). This reliably
identifies the Skylake-and-later platforms that load `sof-audio-pci-intel-*`
drivers.

**Updated `sof-firmware.sh`**: Replace `omarchy-hw-intel-ptl` with
`omarchy-hw-intel-sof`. The Panther Lake XPS exclusion is preserved — those
systems use `linux-ptl`, which already hard-depends `sof-firmware`.

**Migration** `migrations/1783625096.sh`: Backfills `sof-firmware` on
existing installs that were set up before this fix. `omarchy-pkg-add` is
idempotent so systems that already have the package are unaffected.