### PR TITLE
Move toggle config source before user overrides in hyprland.conf

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -12,15 +12,16 @@ source = ~/.local/share/omarchy/default/hypr/input.conf
 source = ~/.local/share/omarchy/default/hypr/windows.conf
 source = ~/.config/omarchy/current/theme/hyprland.conf
 
+# Toggle config flags dynamically (loaded before user overrides so that
+# ~/.config/hypr/looknfeel.conf and friends can still take precedence)
+source = ~/.local/state/omarchy/toggles/hypr/*.conf
+
 # Change your own setup in these files (and overwrite any settings from defaults!)
 source = ~/.config/hypr/monitors.conf
 source = ~/.config/hypr/input.conf
 source = ~/.config/hypr/bindings.conf
 source = ~/.config/hypr/looknfeel.conf
 source = ~/.config/hypr/autostart.conf
-
-# Toggle config flags dynamically
-source = ~/.local/state/omarchy/toggles/hypr/*.conf
 
 # Add any other personal Hyprland configuration below
 # windowrule = workspace 5, match:class qemu


### PR DESCRIPTION
## Problem

Toggle conf files (`~/.local/state/omarchy/toggles/hypr/*.conf`) are loaded **after** the user's custom files (`looknfeel.conf`, etc.), so any Hyprland variable set by a toggle — like `single_window_aspect_ratio` from the tiling toggle — silently overrides whatever the user put in their own `looknfeel.conf`. The only workaround today is to source `looknfeel.conf` again at the very bottom of `hyprland.conf`.

Reported in #6068.

## Fix

Move the toggle `source` glob to be between the Omarchy defaults and the user's custom files:

```
Omarchy defaults → current theme → toggle flags → user overrides
```

User overrides always win, which is the expected mental model: toggles express Omarchy feature flags, not unoverrideable system policy.