### PR TITLE
Add upstream Arch fallback mirrors to boot.sh

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -25,13 +25,25 @@ OMARCHY_REF="${OMARCHY_REF:-master}"
 # Set mirror based on branch
 if [[ $OMARCHY_REF == "dev" ]]; then
   export OMARCHY_MIRROR=edge
-  echo 'Server = https://mirror.omarchy.org/$repo/os/$arch' | sudo tee /etc/pacman.d/mirrorlist >/dev/null
+  {
+    echo 'Server = https://mirror.omarchy.org/$repo/os/$arch'
+    echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch'
+    echo 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch'
+  } | sudo tee /etc/pacman.d/mirrorlist >/dev/null
 elif [[ $OMARCHY_REF == "rc" ]]; then
   export OMARCHY_MIRROR=rc
-  echo 'Server = https://rc-mirror.omarchy.org/$repo/os/$arch' | sudo tee /etc/pacman.d/mirrorlist >/dev/null
+  {
+    echo 'Server = https://rc-mirror.omarchy.org/$repo/os/$arch'
+    echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch'
+    echo 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch'
+  } | sudo tee /etc/pacman.d/mirrorlist >/dev/null
 else
   export OMARCHY_MIRROR=stable
-  echo 'Server = https://stable-mirror.omarchy.org/$repo/os/$arch' | sudo tee /etc/pacman.d/mirrorlist >/dev/null
+  {
+    echo 'Server = https://stable-mirror.omarchy.org/$repo/os/$arch'
+    echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch'
+    echo 'Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch'
+  } | sudo tee /etc/pacman.d/mirrorlist >/dev/null
 fi
 
 sudo pacman -Syu --noconfirm --needed git


### PR DESCRIPTION
Fixes #6158

## Problem

`boot.sh` overwrites `/etc/pacman.d/mirrorlist` with a single omarchy mirror line. If that mirror is temporarily behind and a package version (e.g. `git-2.55.0-1`) returns HTTP 404, `pacman -Syu --needed git` fails with no fallback and the entire bootstrap is aborted.

## Fix

Add two well-known upstream Arch Linux mirrors (`geo.mirror.pkgbuild.com` and `mirror.rackspace.com`) after the primary omarchy mirror in each branch of the `if` block. Pacman tries mirrors in order, so the omarchy mirror is still preferred; the upstream mirrors serve as a safety net when it's temporarily stale.

The approach matches how robust `mirrorlist` configurations are typically set up and does not risk pulling in packages from an incompatible state — `pacman -Syu` still updates the database from whichever mirror responds, and only `git` is installed at this stage.