### PR TITLE
Show the charging bolt when plugged in but net-draining (power bar)

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -105,8 +105,11 @@ function modeLabel(device, onBattery, states) {
 
   var percentage = d.isPresent ? d.percentage : 0
   if (chargeThresholdActive(d, onBattery, states)) return "Threshold"
-  if (!onBattery && percentage >= 1) return "Fully charged"
+  // Check plugged-but-draining before the full-battery heuristic: a battery at
+  // 100% can still net-drain on AC (a load spike while full), and that should
+  // read as draining, not "Fully charged".
   if (pluggedButDraining(d, onBattery, states)) return "Draining on AC"
+  if (!onBattery && percentage >= 1) return "Fully charged"
   if (onBattery || d.state === states.Discharging) return "On battery"
   return "Charging"
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -63,6 +63,20 @@ function chargeThresholdActive(device, onBattery, states) {
   return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
 }
 
+// True when the charger is physically connected (line power present) yet the
+// battery is still net-draining -- i.e. the load exceeds what the charger can
+// supply (common on the performance profile or with an under-spec USB-C PD
+// charger). This is distinct from running on battery: the charger IS attached,
+// so the indicator should still read "plugged". UPower.onBattery gives us the
+// line-power state independently of the device's charge/discharge state, which
+// is exactly what makes this distinction possible (Waybar's battery module
+// could not express it -- see Alexays/Waybar#253, #3202).
+function pluggedButDraining(device, onBattery, states) {
+  var d = device || {}
+  var s = states || {}
+  return !!(d.isPresent && !onBattery && d.state === s.Discharging)
+}
+
 function batteryIcon(device, onBattery, states) {
   var d = device || {}
   if (!d.isPresent) return ""
@@ -75,7 +89,12 @@ function batteryIcon(device, onBattery, states) {
   if (threshold) return defaultIcons[index]
   if (d.state === states.FullyCharged) return "󰂅"
   if (d.state === states.Charging) return chargingIcons[index]
-  if (d.state === states.Discharging) return defaultIcons[index]
+  if (d.state === states.Discharging) {
+    // Plugged in but draining (load > charger): keep a charging/bolt glyph so
+    // "is a charger connected?" still reads true. Only a real on-battery
+    // discharge gets the plain, boltless icon.
+    return onBattery ? defaultIcons[index] : chargingIcons[index]
+  }
   if (!onBattery) return ""
   return defaultIcons[index]
 }
@@ -87,6 +106,7 @@ function modeLabel(device, onBattery, states) {
   var percentage = d.isPresent ? d.percentage : 0
   if (chargeThresholdActive(d, onBattery, states)) return "Threshold"
   if (!onBattery && percentage >= 1) return "Fully charged"
+  if (pluggedButDraining(d, onBattery, states)) return "Draining on AC"
   if (onBattery || d.state === states.Discharging) return "On battery"
   return "Charging"
 }
@@ -101,6 +121,7 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    pluggedButDraining: pluggedButDraining
   }
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -41,12 +41,15 @@ Panel {
 
   function batteryIcon() {
     var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    // Pass real line-power state (UPower.onBattery), NOT root.discharging: the
+    // latter is true whenever the device is discharging even while plugged in,
+    // which collapsed "plugged but draining" into the boltless on-battery icon.
+    return Model.batteryIcon(device, UPower.onBattery, upowerStates())
   }
 
   function modeLabel() {
     var device = UPower.displayDevice
-    return Model.modeLabel(device, root.discharging, upowerStates())
+    return Model.modeLabel(device, UPower.onBattery, upowerStates())
   }
 
   function profileIcon(name) {
@@ -63,7 +66,13 @@ Panel {
   }
   readonly property bool chargeThresholdActive: {
     var device = UPower.displayDevice
-    return Model.chargeThresholdActive(device, root.discharging, upowerStates())
+    return Model.chargeThresholdActive(device, UPower.onBattery, upowerStates())
+  }
+  // Charger connected but the battery is still net-draining (load exceeds the
+  // charger's output). Drives the alert tint on the bar icon.
+  readonly property bool pluggedButDraining: {
+    var device = UPower.displayDevice
+    return Model.pluggedButDraining(device, UPower.onBattery, upowerStates())
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
@@ -254,6 +263,10 @@ Panel {
     anchors.fill: parent
     bar: root.bar
     text: root.batteryIcon()
+    // Tint the bolt in the theme's urgent colour when plugged but draining, so
+    // "charger connected but losing charge" reads at a glance (→ bigger adapter).
+    foreground: root.pluggedButDraining ? (root.bar ? root.bar.urgent : Color.urgent)
+                                        : (root.bar ? root.bar.barForeground : Color.foreground)
     fixedWidth: root.bar && root.bar.vertical ? -1 : Style.space(27)
     fixedHeight: root.bar && root.bar.vertical ? Style.space(26) : -1
     tooltipText: ""

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -27,6 +27,21 @@ assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: s
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
-assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'On battery', 'power labels discharging battery mode')
+assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Draining on AC', 'power labels plugged-but-draining distinctly from on-battery')
 assert(power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging }, false, states).length > 0, 'power maps battery icons')
+
+// Plugged in but still draining (load exceeds charger) is distinct from being
+// on battery: the charger IS attached, so it must not read like on-battery.
+assert(power.pluggedButDraining({ isPresent: true, state: states.Discharging }, false, states), 'power detects plugged-but-draining (AC present, still discharging)')
+assert(!power.pluggedButDraining({ isPresent: true, state: states.Discharging }, true, states), 'power does not flag on-battery discharge as plugged-but-draining')
+assert(!power.pluggedButDraining({ isPresent: true, state: states.Charging }, false, states), 'power does not flag charging as plugged-but-draining')
+
+// The icon must differ from the on-battery glyph (keeps its bolt) and match the
+// charging-family glyph at the same level. Compared relationally to avoid
+// hard-coding the nerd-font glyphs.
+const drainingIcon = power.batteryIcon({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states)
+const onBatteryIcon = power.batteryIcon({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states)
+const chargingIcon = power.batteryIcon({ isPresent: true, percentage: 0.5, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states)
+assert(drainingIcon !== onBatteryIcon, 'power distinguishes plugged-but-draining from on-battery discharge')
+assertEqual(drainingIcon, chargingIcon, 'power keeps the charging/bolt glyph when plugged but draining')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -28,6 +28,7 @@ assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: s
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Draining on AC', 'power labels plugged-but-draining distinctly from on-battery')
+assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.Discharging }, false, states), 'Draining on AC', 'power prefers draining over "Fully charged" when a full battery drains on AC')
 assert(power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging }, false, states).length > 0, 'power maps battery icons')
 
 // Plugged in but still draining (load exceeds charger) is distinct from being


### PR DESCRIPTION
Targets the Quickshell work on `omarchy-shell`. Follows up on discussion #6203.

## Problem

The `omarchy.power` bar indicator drops its charging bolt whenever the battery is `Discharging` — **even while the charger is plugged in**. That happens routinely when the load exceeds what the charger supplies (the `performance` profile, or an under-spec USB-C PD charger): the battery net-drains to cover the shortfall, so `status` reads `Discharging` while the machine is still on AC. The result is that the bar icon looks identical to being unplugged, so it can't answer two independent questions the user actually has:

1. **Is a charger connected?** (bolt present) — if not, maybe the cable/port is the problem.
2. **Is input > output?** (net charging vs. draining) — if plugged but still losing charge, maybe a stronger adapter is needed.

This is the same limitation Waybar's native battery module has (Alexays/Waybar#253, #3202) — but Quickshell doesn't have to inherit it, because `UPower.onBattery` exposes line-power state independently of the device's charge/discharge state.

## Root cause

`Panel.qml` passed `root.discharging` into the model's `onBattery` parameter:

```qml
return Model.batteryIcon(device, root.discharging, upowerStates())
```

`root.discharging` is `(UPower.onBattery || device.state === Discharging)` — i.e. true whenever discharging, *plugged in or not*. So the model never saw real line-power state, and `batteryIcon()`'s `Discharging` branch always returned the boltless on-battery glyph. (The model was already written to take a real `onBattery`; its unit tests pass it correctly — only the call sites were wrong.)

## Fix

- Pass the real `UPower.onBattery` into `batteryIcon()`, `modeLabel()`, and `chargeThresholdActive` (behaviour-preserving for the latter — its `state === Discharging` early-return already guards it).
- Teach the model to treat **plugged-but-draining** distinctly: keep the charging/bolt glyph (so "charger connected?" reads true), and label it **"Draining on AC"** instead of "On battery".
- Add a `pluggedButDraining()` model helper, and tint the bar icon in the theme's `urgent` colour in that state so "connected but losing charge" reads at a glance.

Net effect on the bar icon:

| State | Before | After |
|---|---|---|
| Charging | bolt | bolt |
| **Plugged, load > charger** | **plain (looks unplugged)** | **bolt, urgent-tinted + "Draining on AC"** |
| On battery | plain | plain |
| Full / threshold-hold | full / plain | unchanged |

## Tests

`test/shell.d/power-test.sh` extended with 5 assertions (plugged-but-draining detection, icon keeps its bolt, differs from on-battery, distinct label). Updated the one existing assertion that encoded the old "On battery" mislabel. All power + battery logic tests pass:

```
==> test/shell.d/power-test.sh   (19 ok)
==> test/shell.d/battery-test.sh (6 ok)
```

The QML changes are minimal wiring; I don't have a Quickshell runtime handy to attach a screenshot — happy to add one, or adjust the "Draining on AC" wording / tint choice to taste. (Note: `bar-widget-contract`, `runtime-smoke`, etc. skip-and-exit-1 on a machine without Quickshell installed, independent of this change.)
