### PR TITLE
fix: prevent crosshair cursor from appearing in screenshots

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -69,6 +69,7 @@ get_rectangles() {
 # frozen overlay rather than live content shifting during teardown.
 cleanup_freeze() {
   [[ -n $PID ]] && kill $PID 2>/dev/null
+  hyprctl keyword cursor:no_hardware_cursors 2 2>/dev/null
 }
 trap cleanup_freeze EXIT
 
@@ -78,11 +79,15 @@ region)
   hyprpicker -r -z >/dev/null 2>&1 &
   PID=$!
   sleep .1
+  hyprctl keyword cursor:no_hardware_cursors 0 2>/dev/null
+  sleep .1
   SELECTION=$(slurp 2>/dev/null)
   ;;
 windows)
   hyprpicker -r -z >/dev/null 2>&1 &
   PID=$!
+  sleep .1
+  hyprctl keyword cursor:no_hardware_cursors 0 2>/dev/null
   sleep .1
   SELECTION=$(get_rectangles | slurp -r 2>/dev/null)
   ;;
@@ -93,6 +98,8 @@ smart | *)
   RECTS=$(get_rectangles)
   hyprpicker -r -z >/dev/null 2>&1 &
   PID=$!
+  sleep .1
+  hyprctl keyword cursor:no_hardware_cursors 0 2>/dev/null
   sleep .1
   SELECTION=$(echo "$RECTS" | slurp 2>/dev/null)
 


### PR DESCRIPTION
Closes #6142

When taking a region, window, or smart screenshot, the slurp crosshair cursor was captured in the image (visible in the bottom-right corner). This is a known wlroots issue where grim captures the software-composited cursor when cursor:no_hardware_cursors is enabled.

Temporarily enable hardware cursors before slurp starts so the cursor is rendered in a GPU plane invisible to grim. The setting is restored on exit via the cleanup trap.