### PR TITLE
Fix foot text-bindings migration writing a literal \n line into foot.ini

### DIFF
--- a/migrations/1783833508.sh
+++ b/migrations/1783833508.sh
@@ -40,7 +40,7 @@ fi
 foot_config="$HOME/.config/foot/foot.ini"
 if [[ -f $foot_config ]]; then
   if ! grep -q '^\[text-bindings\]$' "$foot_config"; then
-    sed -i '$a\\\n[text-bindings]' "$foot_config"
+    sed -i '$a\\n[text-bindings]' "$foot_config"
   fi
 
   if ! grep -Fq '\x1b[13;4u=Mod1+Shift+Return' "$foot_config"; then

--- a/migrations/1783983371.sh
+++ b/migrations/1783983371.sh
@@ -1,0 +1,23 @@
+echo "Repair foot text-bindings broken by an earlier migration"
+
+# The 1783833508 migration meant to append a blank line and a [text-bindings]
+# section header to foot.ini, but an extra backslash made sed append the
+# literal line '\n[text-bindings]' instead. foot then reports a syntax error
+# on every startup, and the follow-up inserts anchored on '[text-bindings]'
+# never matched, so the CSI-u bindings were never added.
+foot_config="$HOME/.config/foot/foot.ini"
+if [[ -f $foot_config ]]; then
+  sed -i '/^\\n\[text-bindings\]$/d' "$foot_config"
+
+  if ! grep -q '^\[text-bindings\]$' "$foot_config"; then
+    sed -i '$a\\n[text-bindings]' "$foot_config"
+  fi
+
+  if ! grep -Fq '\x1b[13;4u=Mod1+Shift+Return' "$foot_config"; then
+    sed -i '/^\[text-bindings\]$/a\# Send Alt+Shift+Return as CSI-u so tmux can match M-S-Enter.\n\\x1b[13;4u=Mod1+Shift+Return' "$foot_config"
+  fi
+
+  if ! grep -Fq '\x1b[13;2u=Shift+Return' "$foot_config"; then
+    sed -i '/^\[text-bindings\]$/a\# Send Shift+Return as CSI-u so TUIs can distinguish it from Return.\n\\x1b[13;2u=Shift+Return' "$foot_config"
+  fi
+fi


### PR DESCRIPTION
## Problem

Migration `1783833508.sh` (shipped in 3.8.3) breaks `~/.config/foot/foot.ini` for every foot user who runs it. After updating, every new foot terminal prints:

```
error: foot: /home/user/.config/foot/foot.ini:20: [key-bindings].\n[text-bindings]: syntax error: key/value pair has no value
```

## Root cause

The migration means to append a blank line plus a `[text-bindings]` section header:

```sh
sed -i '$a\\\n[text-bindings]' "$foot_config"
```

There is one backslash too many: sed consumes the first backslash as part of `a\`, and the remaining `\\n` is an escaped (literal) backslash followed by a plain `n`. So instead of a section header, the literal line `\n[text-bindings]` gets appended. Minimal repro on GNU sed 4.10:

```
$ printf '[key-bindings]\nclipboard-paste=Shift+Insert\n' > foot.ini
$ sed -i '$a\\\n[text-bindings]' foot.ini
$ tail -1 foot.ini
\n[text-bindings]
```

As a knock-on effect, the two follow-up inserts anchored on `/^\[text-bindings\]$/` never match anything, so the Shift+Return / Alt+Shift+Return CSI-u bindings are silently never added — the foot half of this migration's feature never reaches users, while tmux gets the `M-S-Enter` binding it can now never receive from foot.

## Fix

1. **`migrations/1783833508.sh`** — drop the extra backslash (`'$a\\n[text-bindings]'`), so anyone who hasn't run the migration yet gets the intended result.
2. **`migrations/1783983371.sh` (new)** — repairs already-affected configs: deletes the literal `\n[text-bindings]` line, then (re)adds the section and both bindings with the same guards as the original migration. It is a no-op for configs that are already correct (fresh installs, hand-fixed files).

## Verification

Tested on a real Omarchy 3.8.3 machine (GNU sed 4.10, foot 1.27.0):

- fixed original migration on a pre-3.8.3 config → byte-identical to the shipped `config/foot/foot.ini`
- repair migration on a broken config → same correct result
- repair migration on an already-correct config → unchanged
- repair migration run twice → idempotent
- fixed original + repair chained (fresh-updater path) → still correct
- `foot --check-config` accepts the repaired config

Targeting `master` since the affected migration only exists on `master`/`rc`.

Found and fixed with AI assistance (Claude Code); root cause and all of the above verified on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)