### PR TITLE
Remove bsnes2014 & mame2016 from RetroArch setup

### DIFF
--- a/bin/omarchy-install-gaming-retroarch
+++ b/bin/omarchy-install-gaming-retroarch
@@ -10,12 +10,12 @@ omarchy-pkg-add \
   retroarch-assets-glui retroarch-assets-ozone retroarch-assets-xmb \
   libretro-beetle-pce libretro-beetle-pce-fast libretro-beetle-psx libretro-beetle-psx-hw libretro-beetle-supergrafx \
   libretro-blastem \
-  libretro-bsnes libretro-bsnes-hd libretro-bsnes2014 \
+  libretro-bsnes libretro-bsnes-hd \
   libretro-core-info \
   libretro-desmume libretro-dolphin libretro-flycast \
   libretro-gambatte libretro-genesis-plus-gx \
   libretro-kronos \
-  libretro-mame libretro-mame2016 libretro-melonds libretro-mesen libretro-mesen-s libretro-mgba libretro-mupen64plus-next \
+  libretro-mame libretro-melonds libretro-mesen libretro-mesen-s libretro-mgba libretro-mupen64plus-next \
   libretro-nestopia \
   libretro-overlays \
   libretro-parallel-n64 libretro-picodrive libretro-play libretro-ppsspp \

--- a/bin/omarchy-remove-gaming-retroarch
+++ b/bin/omarchy-remove-gaming-retroarch
@@ -10,12 +10,12 @@ omarchy-pkg-drop \
   retroarch-assets-glui retroarch-assets-ozone retroarch-assets-xmb \
   libretro-beetle-pce libretro-beetle-pce-fast libretro-beetle-psx libretro-beetle-psx-hw libretro-beetle-supergrafx \
   libretro-blastem \
-  libretro-bsnes libretro-bsnes-hd libretro-bsnes2014 \
+  libretro-bsnes libretro-bsnes-hd \
   libretro-core-info \
   libretro-desmume libretro-dolphin libretro-flycast \
   libretro-gambatte libretro-genesis-plus-gx \
   libretro-kronos \
-  libretro-mame libretro-mame2016 libretro-melonds libretro-mesen libretro-mesen-s libretro-mgba libretro-mupen64plus-next \
+  libretro-mame libretro-melonds libretro-mesen libretro-mesen-s libretro-mgba libretro-mupen64plus-next \
   libretro-nestopia \
   libretro-overlays \
   libretro-parallel-n64 libretro-picodrive libretro-play libretro-ppsspp \


### PR DESCRIPTION
Both cores cause install to fail because they no longer exist in the repos.