### PR TITLE
Prevent using an opaque surface for bar

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -819,6 +819,7 @@ Item {
     implicitWidth: root.vertical ? root.barSize : 0
     implicitHeight: root.vertical ? 0 : root.barSize
     color: root.transparent ? "transparent" : root.background
+    surfaceFormat.opaque: false
     WlrLayershell.namespace: "omarchy-bar"
     WlrLayershell.layer: WlrLayer.Top
 


### PR DESCRIPTION
The bar supports switching between transparent and opaque. That means we can't use an opaque surface for it; if we did, it would be unable to reliably render as transparent when needed.

This fixes a visual glitch where the background of a transparent bar would flicker, particularly during mouse hover.