### PR TITLE
Add us fallback layout for non-Latin keyboards

### DIFF
--- a/install/config/detect-keyboard-layout.sh
+++ b/install/config/detect-keyboard-layout.sh
@@ -2,12 +2,21 @@
 conf="/etc/vconsole.conf"
 hyprlua="$HOME/.config/hypr/input.lua"
 
-if [[ -f $conf && -f $hyprlua ]] && grep -q '^XKBLAYOUT=' "$conf"; then
+if [[ -f $conf && -f $hyprlua ]]; then
   layout=$(grep '^XKBLAYOUT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\    kb_layout = \"$layout\"," "$hyprlua"
-fi
-
-if [[ -f $conf && -f $hyprlua ]] && grep -q '^XKBVARIANT=' "$conf"; then
   variant=$(grep '^XKBVARIANT=' "$conf" | cut -d= -f2 | tr -d '"')
-  sed -i "/^[[:space:]]*kb_options *=/i\    kb_variant = \"$variant\"," "$hyprlua"
+
+  # Layouts that can't type Latin characters get us first, so passwords and commands can always be typed
+  if [[ $layout =~ ^(af|am|ara|bd|bg|by|et|ge|gr|il|in|iq|ir|kg|kh|kz|la|lk|mk|mm|mn|mv|np|rs|ru|sy|th|tj|ua)$ ]]; then
+    layout="us,$layout"
+    [[ -n $variant ]] && variant=",$variant"
+  fi
+
+  [[ -n $layout ]] && sed -i "/^[[:space:]]*kb_options *=/i\    kb_layout = \"$layout\"," "$hyprlua"
+  [[ -n $variant ]] && sed -i "/^[[:space:]]*kb_options *=/i\    kb_variant = \"$variant\"," "$hyprlua"
+
+  # Enable switching between layouts with Left Alt + Right Alt when there's more than one
+  if [[ $layout == *,* ]]; then
+    sed -i '/^[[:space:]]*kb_options/s/",[[:space:]]*--[[:space:]]*,grp:alts_toggle/,grp:alts_toggle",/' "$hyprlua"
+  fi
 fi


### PR DESCRIPTION
Fixes #2054

## Problem

Installing Omarchy with a non-Latin keyboard layout (e.g. Russian) locks the user out: `detect-keyboard-layout.sh` copies the single layout from `/etc/vconsole.conf` into `input.lua`, and the `grp:alts_toggle` switch is commented out. The user can't type Latin characters at all — no wifi password, no terminal commands, and no way to edit the very config that would fix it (see #2054 for several people (including me) hitting this on first boot).

## Fix

In `install/config/detect-keyboard-layout.sh`:

- If the detected layout is one that can't produce Latin characters (ru, ua, gr, il, ara, th, ...), prepend `us` so `kb_layout = us,ru`. Latin-capable layouts (de, fr, ...) are untouched — the layout the user picked stays primary.
- Shift `kb_variant` accordingly when `us` is prepended (`,phonetic`).
- Uncomment `grp:alts_toggle` whenever multiple layouts end up configured (including a manual `us,ru` from the installer), enabling Left Alt + Right Alt switching as already hinted in `input.conf`.