### PR TITLE
Fix bar plugin array guards

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -18,8 +18,8 @@ BarWidget {
   property var activeTrayAnchor: null
   readonly property color foreground: bar ? bar.foreground : Color.foreground
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
-  readonly property var pinnedIds: Array.isArray(settings.pinned) ? settings.pinned : []
-  readonly property var hiddenIds: Array.isArray(settings.hidden) ? settings.hidden : []
+  readonly property var pinnedIds: settings.pinned instanceof Array ? settings.pinned : []
+  readonly property var hiddenIds: settings.hidden instanceof Array ? settings.hidden : []
   readonly property var pinnedItems: bucket("pinned")
   readonly property var drawerItems: bucket("drawer")
   readonly property var allItems: bucket("all")

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -44,7 +44,7 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
   readonly property bool showPeers: tailscale.running && tailscale.peers.length > 0
-  readonly property var recentMullvadRegions: Array.isArray(settings.recentMullvadRegions) ? settings.recentMullvadRegions : (Array.isArray(settings.recentMullvadCountries) ? settings.recentMullvadCountries : [])
+  readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
   readonly property var exitNodes: displayExitNodes()
   readonly property bool showExitNodes: tailscale.running && (exitNodes.length > 0 || tailscale.mullvadRegions.length > 0)


### PR DESCRIPTION
The `Bar` uses a `Repeater` when building out the models. This has the effect of marshalling the configuration, and causing JSON arrays to become sequence wrappers.

A couple of the plugins had been checking for the existence of array values with `Array.isArray`, which fails for the sequence wrappers, causing the values to be ignored. This breaks associated functionality (the "hide" and "pin" actions in the systray had stopped working, as had exit node selection in Tailscale).

Switching the guards to use `instanceof Array` works correctly for sequence values (as well as arrays).