### PR TITLE
Wake internal display only when leaving clamshell

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -115,7 +115,13 @@ enable_internal() {
 
   [[ -f $MANUAL_DISABLE_FLAG ]] && omarchy-hyprland-monitor-external-active && return 0
   sync_internal_scale
-  dpms_internal enable
+
+  # Only wake the panel when actually leaving clamshell. This also runs from
+  # the periodic clamshell poll, where an unconditional wake re-lights the
+  # internal display seconds after the lock screen blanks it.
+  if (( changed )); then
+    dpms_internal enable
+  fi
 }
 
 disable_internal() {


### PR DESCRIPTION
## Problem

On a laptop with an external monitor, locking the system blanks all displays (`omarchy-brightness-display off`), but the internal panel comes back on within ~2 seconds and stays lit showing the lock screen, while the external monitor correctly stays dark.

## Cause

`omarchy-hyprland-monitor-watch` polls `omarchy-hyprland-monitor-clamshell` every 2 seconds (`poll_clamshell_state`). With the lid open, every poll takes the `enable_internal` path, which unconditionally ended with `dpms_internal enable` — re-lighting the internal panel even though nothing changed. Observed live: after DPMS-off, both monitors report `dpmsStatus: false`, then eDP-1 flips back to `true` on the next poll while the external stays off.

## Fix

Only issue the DPMS wake when the clamshell flag was actually consumed — i.e. on the lid-open transition the wake was meant for. Idle polls no longer touch DPMS.

Verified with a stubbed `hyprctl`:
- plain poll (no clamshell flag): zero `dpms` dispatches
- leaving clamshell (flag present): flag consumed, `hl.dsp.dpms({ action = "enable", monitor = "eDP-1" })` dispatched as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)