### PR TITLE
Fix internal laptop screen re-lighting itself 2sec after locking

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -115,7 +115,10 @@ enable_internal() {
 
   [[ -f $MANUAL_DISABLE_FLAG ]] && omarchy-hyprland-monitor-external-active && return 0
   sync_internal_scale
-  dpms_internal enable
+
+  if (( changed )); then
+    dpms_internal enable
+  fi
 }
 
 disable_internal() {


### PR DESCRIPTION
Wake internal display only when leaving clamshell

The clamshell watcher polls omarchy-hyprland-monitor-clamshell every two seconds and calls enable_internal unconditionally which re-enabled DPMS on the internal panel each time. When the lock screen blanks the displays, the next poll of  omarchy-hyprland-monitor-clamshell re-lights the laptop screen, leaving it showing the lock screen indefinitely while external monitors stayed off.

Only issue the DPMS wake when the clamshell flag was actually consumed, i.e. on the lid-open transition the wake was meant for.

If the lid-open even fails to turn on the screen for whatever reason, then pressing a key or moving the mouse will re-light the screen. This is configured in `input.lua` via `key_press_enables_dpms = true` and `mouse_move_enables_dpms = true`

Tested this with my Framework 13 and everything works as expected.
Closing and opening the laptop turns the screen off and then back on, and when I lock the computer all screen stay off