### PR TITLE
reduce number of required args to 2 

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -7,7 +7,7 @@ set -e
 
 ICON_DIR="$HOME/.local/share/applications/icons"
 
-if (( $# < 3 )); then
+if (( $# < 2 )); then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
   APP_URL=$(gum input --prompt "URL> " --placeholder "https://example.com")


### PR DESCRIPTION
Since the webapp script now automatically tries to fetch the webapp icon, the number of required args should be 2, for the name and the url