### PR TITLE
Use hyprsunset-tui for Super + Ctrl + N nightlight binding

### DIFF
--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -29,7 +29,7 @@ o.bind("SUPER + ALT + COMMA", "Invoke last notification", "makoctl invoke")
 o.bind("SUPER + SHIFT + ALT + COMMA", "Restore last notification", "makoctl restore")
 
 o.bind_toggle("SUPER + CTRL + I", "Toggle locking on idle", "idle")
-o.bind_toggle("SUPER + CTRL + N", "Toggle nightlight", "nightlight")
+o.bind("SUPER + CTRL + N", "Nightlight controls", { tui = "hyprsunset-tui", focus = true })
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
 o.bind("switch:on:Lid Switch", nil, "omarchy-hw-external-monitors && omarchy-hyprland-monitor-internal off", { locked = true })

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -29,7 +29,7 @@ o.bind("SUPER + ALT + COMMA", "Invoke last notification", "makoctl invoke")
 o.bind("SUPER + SHIFT + ALT + COMMA", "Restore last notification", "makoctl restore")
 
 o.bind_toggle("SUPER + CTRL + I", "Toggle locking on idle", "idle")
-o.bind("SUPER + CTRL + N", "Nightlight controls", { tui = "hyprsunset-tui", focus = true })
+o.bind("SUPER + CTRL + N", "Nightlight controls", "sh -c 'omarchy-cmd-present hyprsunset-tui && omarchy-launch-or-focus-tui hyprsunset-tui || omarchy-toggle-nightlight'")
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
 o.bind("switch:on:Lid Switch", nil, "omarchy-hw-external-monitors && omarchy-hyprland-monitor-internal off", { locked = true })

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -57,7 +57,6 @@ hyprland-preview-share-picker
 hyprlock
 hyprpicker
 hyprsunset
-hyprsunset-tui
 imagemagick
 impala
 imv

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -57,6 +57,7 @@ hyprland-preview-share-picker
 hyprlock
 hyprpicker
 hyprsunset
+hyprsunset-tui
 imagemagick
 impala
 imv

--- a/migrations/1784412283.sh
+++ b/migrations/1784412283.sh
@@ -1,0 +1,3 @@
+echo "Bind Super + Ctrl + N to hyprsunset-tui"
+
+omarchy-pkg-add hyprsunset-tui

--- a/migrations/1784412283.sh
+++ b/migrations/1784412283.sh
@@ -1,3 +1,3 @@
 echo "Bind Super + Ctrl + N to hyprsunset-tui"
 
-omarchy-pkg-add hyprsunset-tui
+omarchy-pkg-aur-add hyprsunset-tui

--- a/migrations/1784412283.sh
+++ b/migrations/1784412283.sh
@@ -1,3 +1,3 @@
 echo "Bind Super + Ctrl + N to hyprsunset-tui"
 
-omarchy-pkg-aur-add hyprsunset-tui
+omarchy-pkg-aur-add hyprsunset-tui || echo "Skipping hyprsunset-tui (AUR unavailable), keybinding falls back to nightlight toggle"


### PR DESCRIPTION
## What

Rebinds `Super + Ctrl + N` to launch [hyprsunset-tui](https://aur.archlinux.org/packages/hyprsunset-tui) (interactive temperature/gamma control) when installed, falling back to the existing `omarchy-toggle-nightlight` when it isn't — so the binding never breaks.

Related discussion: #6257 (Configurable automatic nightlight schedule) — an interactive hyprsunset frontend on the existing nightlight binding covers much of what's being asked for there without Omarchy growing its own scheduling config.

- `default/hypr/bindings/utilities.lua`: bind checks `omarchy-cmd-present hyprsunset-tui` at keypress, launches the TUI or falls back to the toggle
- `migrations/1784412283.sh`: installs `hyprsunset-tui` via `omarchy-pkg-aur-add`, skipping gracefully if the AUR is unreachable (fallback keeps the binding working)

## Notes

- `hyprsunset-tui` is AUR-only today, so it's not in `omarchy-base.packages` — fresh installs keep the plain nightlight toggle until the package is mirrored into the `[omarchy]` repo (like `walker`/`voxtype-bin`), at which point it can be added to the base list and the fallback becomes a safety net.
- `omarchy toggle nightlight` also remains available from the Toggle menu (`Super + Ctrl + O`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)