### PR TITLE
Add unified password update for user and encrypted drives

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -851,7 +851,8 @@ show_update_hardware_menu() {
 }
 
 show_update_password_menu() {
-  case $(menu "Update Password" "  Drive Encryption\n  User") in
+  case $(menu "Update Password" "  All\n  Drive Encryption\n  User") in
+  *All*) present_terminal omarchy-update-password ;;
   *Drive*) present_terminal omarchy-drive-password ;;
   *User*) present_terminal passwd ;;
   *) show_update_menu ;;

--- a/bin/omarchy-update-password
+++ b/bin/omarchy-update-password
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# omarchy:summary=Change the user password and all drive encryption passwords together.
+# omarchy:requires-sudo=true
+
+new_password=$(gum input --password --header="New password")
+[[ -z $new_password ]] && exit 1
+
+if [[ $new_password != $(gum input --password --header="Confirm new password") ]]; then
+  echo "Passwords do not match."
+  exit 1
+fi
+
+encrypted_drives=$(blkid -t TYPE=crypto_LUKS -o device)
+
+if [[ -n $encrypted_drives ]]; then
+  current_password=$(gum input --password --header="Current drive encryption password")
+  [[ -z $current_password ]] && exit 1
+
+  while read -r drive; do
+    echo "Changing full-disk encryption password for $drive"
+    if ! sudo cryptsetup luksChangeKey --pbkdf argon2id --iter-time 2000 \
+      --key-file <(printf '%s' "$current_password") \
+      "$drive" <(printf '%s' "$new_password"); then
+      echo "Failed to change encryption password for $drive. User password left unchanged."
+      exit 1
+    fi
+  done <<<"$encrypted_drives"
+fi
+
+echo "Changing user password for $USER"
+echo "$USER:$new_password" | sudo chpasswd


### PR DESCRIPTION
## Problem

Update > Password makes it easy to change only the user password and forget the drive encryption passphrase (or vice versa). Since Omarchy sets both to the same password at install time, most users updating their password want both changed together — but the menu only offers them separately.

## Solution

Adds an "All" option to the Update Password menu, backed by a new `omarchy-update-password` script that:

1. Prompts once for the new password (with confirmation)
2. Changes the LUKS passphrase on every encrypted drive (`cryptsetup luksChangeKey`, same argon2id parameters as `omarchy-drive-password`)
3. Changes the user password via `chpasswd`

Drives are changed first: if the current encryption passphrase is wrong, the script exits before touching the user password, so the two never drift apart. Passphrases are passed to cryptsetup via process substitution, so they never appear in argv or on disk.

The existing "Drive Encryption" and "User" options are unchanged for anyone whose passwords intentionally differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)