### PR TITLE
shell: handle CTRL+BACKSPACE to clear filter

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -79,6 +79,25 @@ QtObject {
     }
   }
 
+  // Standard Qt text-editing keys shared by every searchable panel's filter:
+  //   Backspace       delete previous character
+  //   Ctrl+Backspace  delete previous word (Qt DeleteStartOfWord)
+  //   Ctrl+U          clear the whole field
+  // Panels decide how to apply the result (setFilter/updateFilter) and keep
+  // their own empty-field fallbacks (e.g. menu back-navigation).
+  function isFilterEditKey(event) {
+    return event.key === Qt.Key_Backspace
+        || (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier))
+  }
+
+  // New filter text after applying an edit key. Assumes isFilterEditKey(event).
+  function editedFilter(event, text) {
+    if (event.key === Qt.Key_U) return ""                        // Ctrl+U: clear
+    if (event.modifiers & Qt.ControlModifier)                    // Ctrl+Backspace: word
+      return text.replace(/\s+$/, "").replace(/\S+$/, "")
+    return text.slice(0, -1)                                     // Backspace: char
+  }
+
   // Layout normalization shared by bar config consumers
   // so the two never drift. Entries are deep-cloned to decouple from the
   // input config; consumers can mutate without leaking back to shell.json.

--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -86,8 +86,11 @@ QtObject {
   // Panels decide how to apply the result (setFilter/updateFilter) and keep
   // their own empty-field fallbacks (e.g. menu back-navigation).
   function isFilterEditKey(event) {
-    return event.key === Qt.Key_Backspace
-        || (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier))
+    // Alt/Meta-modified sequences belong to other shortcuts — never edit here.
+    if (event.modifiers & (Qt.AltModifier | Qt.MetaModifier)) return false
+    if (event.key === Qt.Key_U)                     // Ctrl+U only (not Ctrl+Shift+U → Unicode input)
+      return event.modifiers === Qt.ControlModifier
+    return event.key === Qt.Key_Backspace           // plain, Shift, or Ctrl Backspace
   }
 
   // New filter text after applying an edit key. Assumes isFilterEditKey(event).

--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -83,9 +83,11 @@ QtObject {
   //   Backspace       delete previous character
   //   Ctrl+Backspace  delete previous word (Qt DeleteStartOfWord)
   //   Ctrl+U          clear the whole field
-  // Panels decide how to apply the result (setFilter/updateFilter) and keep
-  // their own empty-field fallbacks (e.g. menu back-navigation).
-  function isFilterEditKey(event) {
+  // True only when the event would actually change the text, so an empty
+  // filter never swallows the key — panels keep their own empty-filter
+  // fallbacks (e.g. menu back-navigation) in later branches.
+  function editsFilter(event, text) {
+    if (!text) return false
     // Alt/Meta-modified sequences belong to other shortcuts — never edit here.
     if (event.modifiers & (Qt.AltModifier | Qt.MetaModifier)) return false
     if (event.key === Qt.Key_U)                     // Ctrl+U only (not Ctrl+Shift+U → Unicode input)
@@ -93,7 +95,7 @@ QtObject {
     return event.key === Qt.Key_Backspace           // plain, Shift, or Ctrl Backspace
   }
 
-  // New filter text after applying an edit key. Assumes isFilterEditKey(event).
+  // New filter text after applying an edit key. Assumes editsFilter(event, text).
   function editedFilter(event, text) {
     if (event.key === Qt.Key_U) return ""                        // Ctrl+U: clear
     if (event.modifiers & Qt.ControlModifier)                    // Ctrl+Backspace: word

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -346,7 +346,13 @@ Item {
             else root.close()
             event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if (root.filterText.length > 0) root.setFilter(root.filterText.slice(0, -1))
+            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+              // CTRL+BACKSPACE: clear entire filter
+              root.setFilter("")
+            } else if (root.filterText.length > 0) {
+              // BACKSPACE: remove one character
+              root.setFilter(root.filterText.slice(0, -1))
+            }
             event.accepted = true
           } else if (event.key === Qt.Key_Delete) {
             if (event.modifiers & Qt.ShiftModifier) root.requestClearHistory()

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -345,12 +345,16 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.close()
             event.accepted = true
+          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+            // CTRL+U: clear the entire filter
+            root.setFilter("")
+            event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-              // CTRL+BACKSPACE: clear entire filter
-              root.setFilter("")
+            if (event.modifiers & Qt.ControlModifier) {
+              // CTRL+BACKSPACE: remove the previous word
+              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
             } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove one character
+              // BACKSPACE: remove the previous character
               root.setFilter(root.filterText.slice(0, -1))
             }
             event.accepted = true

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -345,18 +345,8 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.close()
             event.accepted = true
-          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-            // CTRL+U: clear the entire filter
-            root.setFilter("")
-            event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (event.modifiers & Qt.ControlModifier) {
-              // CTRL+BACKSPACE: remove the previous word
-              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
-            } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove the previous character
-              root.setFilter(root.filterText.slice(0, -1))
-            }
+          } else if (Util.isFilterEditKey(event)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Delete) {
             if (event.modifiers & Qt.ShiftModifier) root.requestClearHistory()

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -345,7 +345,7 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.close()
             event.accepted = true
-          } else if (Util.isFilterEditKey(event)) {
+          } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Delete) {

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -200,10 +200,16 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (root.filterText.length > 0) root.setFilter(root.filterText.slice(0, -1))
-            event.accepted = true
-          } else if (event.key === Qt.Key_Left) {
+} else if (event.key === Qt.Key_Backspace) {
+  if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+    // CTRL+BACKSPACE: clear entire filter
+    root.setFilter("")
+  } else if (root.filterText.length > 0) {
+    // BACKSPACE: remove one character
+    root.setFilter(root.filterText.slice(0, -1))
+  }
+  event.accepted = true
+    } else if (event.key === Qt.Key_Left) {
             root.select(-1)
             event.accepted = true
           } else if (event.key === Qt.Key_Right) {

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -200,16 +200,20 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
+          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+            // CTRL+U: clear the entire filter
+            root.setFilter("")
+            event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-              // CTRL+BACKSPACE: clear entire filter
-              root.setFilter("")
+            if (event.modifiers & Qt.ControlModifier) {
+              // CTRL+BACKSPACE: remove the previous word
+              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
             } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove one character
+              // BACKSPACE: remove the previous character
               root.setFilter(root.filterText.slice(0, -1))
             }
             event.accepted = true
-              } else if (event.key === Qt.Key_Left) {
+          } else if (event.key === Qt.Key_Left) {
             root.select(-1)
             event.accepted = true
           } else if (event.key === Qt.Key_Right) {

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -200,18 +200,8 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-            // CTRL+U: clear the entire filter
-            root.setFilter("")
-            event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (event.modifiers & Qt.ControlModifier) {
-              // CTRL+BACKSPACE: remove the previous word
-              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
-            } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove the previous character
-              root.setFilter(root.filterText.slice(0, -1))
-            }
+          } else if (Util.isFilterEditKey(event)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Left) {
             root.select(-1)

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -200,7 +200,7 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (Util.isFilterEditKey(event)) {
+          } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Left) {

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -200,16 +200,16 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-} else if (event.key === Qt.Key_Backspace) {
-  if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-    // CTRL+BACKSPACE: clear entire filter
-    root.setFilter("")
-  } else if (root.filterText.length > 0) {
-    // BACKSPACE: remove one character
-    root.setFilter(root.filterText.slice(0, -1))
-  }
-  event.accepted = true
-    } else if (event.key === Qt.Key_Left) {
+          } else if (event.key === Qt.Key_Backspace) {
+            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+              // CTRL+BACKSPACE: clear entire filter
+              root.setFilter("")
+            } else if (root.filterText.length > 0) {
+              // BACKSPACE: remove one character
+              root.setFilter(root.filterText.slice(0, -1))
+            }
+            event.accepted = true
+              } else if (event.key === Qt.Key_Left) {
             root.select(-1)
             event.accepted = true
           } else if (event.key === Qt.Key_Right) {

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -417,18 +417,8 @@ Item {
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
               root.applySelected()
               event.accepted = true
-            } else if (event.key === Qt.Key_U && root.filterable && (event.modifiers & Qt.ControlModifier)) {
-              // CTRL+U: clear the entire filter
-              root.updateFilter("")
-              event.accepted = true
-            } else if (event.key === Qt.Key_Backspace && root.filterable) {
-              if (event.modifiers & Qt.ControlModifier) {
-                // CTRL+BACKSPACE: remove the previous word
-                root.updateFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
-              } else if (root.filterText.length > 0) {
-                // BACKSPACE: remove the previous character
-                root.updateFilter(root.filterText.slice(0, -1))
-              }
+            } else if (root.filterable && Util.isFilterEditKey(event)) {
+              root.updateFilter(Util.editedFilter(event, root.filterText))
               event.accepted = true
             } else if (event.key === Qt.Key_Left || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab) {
               root.selectAdjacent(-1)

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -417,7 +417,7 @@ Item {
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
               root.applySelected()
               event.accepted = true
-            } else if (root.filterable && Util.isFilterEditKey(event)) {
+            } else if (root.filterable && Util.editsFilter(event, root.filterText)) {
               root.updateFilter(Util.editedFilter(event, root.filterText))
               event.accepted = true
             } else if (event.key === Qt.Key_Left || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab) {

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -417,9 +417,14 @@ Item {
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
               root.applySelected()
               event.accepted = true
-            } else if (event.key === Qt.Key_Backspace && root.filterable) {
-              if (root.filterText.length > 0)
+           } else if (event.key === Qt.Key_Backspace && root.filterable) {
+              if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+                // CTRL+BACKSPACE: clear entire filter
+                root.updateFilter("")
+              } else if (root.filterText.length > 0) {
+                // BACKSPACE: remove one character
                 root.updateFilter(root.filterText.slice(0, -1))
+              }
               event.accepted = true
             } else if (event.key === Qt.Key_Left || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab) {
               root.selectAdjacent(-1)

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -417,12 +417,16 @@ Item {
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
               root.applySelected()
               event.accepted = true
-           } else if (event.key === Qt.Key_Backspace && root.filterable) {
-              if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-                // CTRL+BACKSPACE: clear entire filter
-                root.updateFilter("")
+            } else if (event.key === Qt.Key_U && root.filterable && (event.modifiers & Qt.ControlModifier)) {
+              // CTRL+U: clear the entire filter
+              root.updateFilter("")
+              event.accepted = true
+            } else if (event.key === Qt.Key_Backspace && root.filterable) {
+              if (event.modifiers & Qt.ControlModifier) {
+                // CTRL+BACKSPACE: remove the previous word
+                root.updateFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
               } else if (root.filterText.length > 0) {
-                // BACKSPACE: remove one character
+                // BACKSPACE: remove the previous character
                 root.updateFilter(root.filterText.slice(0, -1))
               }
               event.accepted = true

--- a/shell/plugins/launcher/Launcher.qml
+++ b/shell/plugins/launcher/Launcher.qml
@@ -464,12 +464,16 @@ Item {
             if (root.filterText.length > 0) root.setFilter("")
             else root.dismiss()
             event.accepted = true
+          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+            // CTRL+U: clear the entire filter
+            root.setFilter("")
+            event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-              // CTRL+BACKSPACE: clear entire filter
-              root.setFilter("")
+            if (event.modifiers & Qt.ControlModifier) {
+              // CTRL+BACKSPACE: remove the previous word
+              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
             } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove one character
+              // BACKSPACE: remove the previous character
               root.setFilter(root.filterText.slice(0, -1))
             }
             event.accepted = true

--- a/shell/plugins/launcher/Launcher.qml
+++ b/shell/plugins/launcher/Launcher.qml
@@ -464,18 +464,8 @@ Item {
             if (root.filterText.length > 0) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-            // CTRL+U: clear the entire filter
-            root.setFilter("")
-            event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (event.modifiers & Qt.ControlModifier) {
-              // CTRL+BACKSPACE: remove the previous word
-              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
-            } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove the previous character
-              root.setFilter(root.filterText.slice(0, -1))
-            }
+          } else if (Util.isFilterEditKey(event)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)

--- a/shell/plugins/launcher/Launcher.qml
+++ b/shell/plugins/launcher/Launcher.qml
@@ -465,7 +465,13 @@ Item {
             else root.dismiss()
             event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if (root.filterText.length > 0) root.setFilter(root.filterText.slice(0, -1))
+            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+              // CTRL+BACKSPACE: clear entire filter
+              root.setFilter("")
+            } else if (root.filterText.length > 0) {
+              // BACKSPACE: remove one character
+              root.setFilter(root.filterText.slice(0, -1))
+            }
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)

--- a/shell/plugins/launcher/Launcher.qml
+++ b/shell/plugins/launcher/Launcher.qml
@@ -464,7 +464,7 @@ Item {
             if (root.filterText.length > 0) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (Util.isFilterEditKey(event)) {
+          } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -837,12 +837,11 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
-          } else if (event.key === Qt.Key_Backspace && event.modifiers === Qt.NoModifier && root.filterText.length === 0) {
-            // BACKSPACE on an empty filter steps back a menu level
-            root.goBack()
-            event.accepted = true
-          } else if (Util.isFilterEditKey(event)) {
+          } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
+            event.accepted = true
+          } else if (event.key === Qt.Key_Backspace && !root.filterText) {
+            root.goBack()
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -837,7 +837,7 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
-          } else if (event.key === Qt.Key_Backspace && !(event.modifiers & Qt.ControlModifier) && root.filterText.length === 0) {
+          } else if (event.key === Qt.Key_Backspace && event.modifiers === Qt.NoModifier && root.filterText.length === 0) {
             // BACKSPACE on an empty filter steps back a menu level
             root.goBack()
             event.accepted = true

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -837,9 +837,14 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (root.filterText.length > 0) root.setFilter(root.filterText.slice(0, -1))
-            else root.goBack()
+          }else if (event.key === Qt.Key_Backspace) {
+           if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+            // CTRL+BACKSPACE: clear entire filter
+            root.setFilter("")
+          } else if (root.filterText.length > 0) {
+            // BACKSPACE: remove one character
+            root.setFilter(root.filterText.slice(0, -1))
+          }
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -837,14 +837,16 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
-          }else if (event.key === Qt.Key_Backspace) {
-           if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-            // CTRL+BACKSPACE: clear entire filter
-            root.setFilter("")
-          } else if (root.filterText.length > 0) {
-            // BACKSPACE: remove one character
-            root.setFilter(root.filterText.slice(0, -1))
-          }
+          } else if (event.key === Qt.Key_Backspace) {
+            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+              // CTRL+BACKSPACE: clear entire filter
+              root.setFilter("")
+            } else if (root.filterText.length > 0) {
+              // BACKSPACE: remove one character
+              root.setFilter(root.filterText.slice(0, -1))
+            } else {
+              root.goBack()
+            }
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -837,20 +837,12 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
-          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-            // CTRL+U: clear the entire filter
-            root.setFilter("")
+          } else if (event.key === Qt.Key_Backspace && !(event.modifiers & Qt.ControlModifier) && root.filterText.length === 0) {
+            // BACKSPACE on an empty filter steps back a menu level
+            root.goBack()
             event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (event.modifiers & Qt.ControlModifier) {
-              // CTRL+BACKSPACE: remove the previous word
-              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
-            } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove the previous character
-              root.setFilter(root.filterText.slice(0, -1))
-            } else {
-              root.goBack()
-            }
+          } else if (Util.isFilterEditKey(event)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
             root.select(-1)

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -837,12 +837,16 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
+          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+            // CTRL+U: clear the entire filter
+            root.setFilter("")
+            event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-              // CTRL+BACKSPACE: clear entire filter
-              root.setFilter("")
+            if (event.modifiers & Qt.ControlModifier) {
+              // CTRL+BACKSPACE: remove the previous word
+              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
             } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove one character
+              // BACKSPACE: remove the previous character
               root.setFilter(root.filterText.slice(0, -1))
             } else {
               root.goBack()

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -136,7 +136,13 @@ Item {
             else root.dismiss()
             event.accepted = true
           } else if (event.key === Qt.Key_Backspace) {
-            if (root.filterText.length > 0) root.setFilter(root.filterText.slice(0, -1))
+            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
+            // CTRL+BACKSPACE: clear entire filter
+            root.setFilter("")
+          } else if (root.filterText.length > 0) {
+            // BACKSPACE: remove one character
+            root.setFilter(root.filterText.slice(0, -1))
+          }
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             root.submit()

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -135,18 +135,8 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
-            // CTRL+U: clear the entire filter
-            root.setFilter("")
-            event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if (event.modifiers & Qt.ControlModifier) {
-              // CTRL+BACKSPACE: remove the previous word
-              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
-            } else if (root.filterText.length > 0) {
-              // BACKSPACE: remove the previous character
-              root.setFilter(root.filterText.slice(0, -1))
-            }
+          } else if (Util.isFilterEditKey(event)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             root.submit()

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -135,7 +135,7 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (Util.isFilterEditKey(event)) {
+          } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -135,14 +135,18 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true
-          } else if (event.key === Qt.Key_Backspace) {
-            if ((event.modifiers & Qt.ControlModifier) === Qt.ControlModifier) {
-            // CTRL+BACKSPACE: clear entire filter
+          } else if (event.key === Qt.Key_U && (event.modifiers & Qt.ControlModifier)) {
+            // CTRL+U: clear the entire filter
             root.setFilter("")
-          } else if (root.filterText.length > 0) {
-            // BACKSPACE: remove one character
-            root.setFilter(root.filterText.slice(0, -1))
-          }
+            event.accepted = true
+          } else if (event.key === Qt.Key_Backspace) {
+            if (event.modifiers & Qt.ControlModifier) {
+              // CTRL+BACKSPACE: remove the previous word
+              root.setFilter(root.filterText.replace(/\s+$/, "").replace(/\S+$/, ""))
+            } else if (root.filterText.length > 0) {
+              // BACKSPACE: remove the previous character
+              root.setFilter(root.filterText.slice(0, -1))
+            }
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             root.submit()


### PR DESCRIPTION
Align filter-field editing with Qt's standard keyboard shortcuts across all menu panels (clipboard, emojis, image-picker, launcher, menu, reminders):

- Backspace: delete previous character
- Ctrl+Backspace: delete previous word (Qt DeleteStartOfWord)
- Ctrl+U: clear entire filter

Previously Ctrl+Backspace cleared the whole field, diverging from Qt on KDE/GNOME. Preserves per-panel behavior (menu goBack, image-picker filterable gating) and fixes an indentation regression in the emoji handler.