### PR TITLE
Add omarchy calendar panel, opend by clicking the bar clock

### DIFF
--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -13,7 +13,7 @@ BarWidget {
 
   readonly property string activeFormat: alt
     ? setting("formatAlt", "d MMMM 'W'ww yyyy")
-    : (bar && bar.vertical ? setting("verticalFormat", "HH\n—\nmm") : setting("format", "dddd HH:mm"))
+    : (root.vertical ? setting("verticalFormat", "HH\n—\nmm") : setting("format", "dddd HH:mm"))
   readonly property string displayText: formatted(displayDate)
   readonly property var verticalLines: displayText.split("\n")
 
@@ -65,7 +65,8 @@ BarWidget {
     onPressed: function(button) {
       if (!root.bar) return
       if (button === Qt.RightButton) root.bar.run("omarchy-menu-timezone")
-      else root.alt = !root.alt
+      else if (button === Qt.MiddleButton) root.alt = !root.alt
+      else root.bar.run("omarchy-shell omarchy.calendar toggle")
     }
 
     Column {

--- a/shell/plugins/panels/calendar/BarWidget.qml
+++ b/shell/plugins/panels/calendar/BarWidget.qml
@@ -1,0 +1,55 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+// Deliberately invisible on the bar. This still has to be a "bar-widget"
+// plugin instance (kept in bar.layout) because that's what keeps Panel.qml
+// loaded and its `omarchy.calendar` IPC target registered — Clock.qml's
+// click handler is the only way to open the calendar, so this component's
+// only job is to host that Loader without taking up any bar space.
+BarWidget {
+  id: root
+  moduleName: "omarchy.calendar"
+
+  function injectPanel() {
+    var target = panelLoader.item
+    if (!target) return
+    if ("bar" in target) target.bar = root.bar
+    if ("settings" in target) target.settings = root.settings
+    if ("anchorItem" in target) target.anchorItem = root
+  }
+
+  function togglePanel() {
+    if (panelLoader.item && panelLoader.item.toggle) panelLoader.item.toggle()
+  }
+
+  // Shape contract for shell.summon/hide/toggle routing (Bar.findPanelWidget
+  // requires open/close/opened on the bar-widget root) — mirrors Weather,
+  // even though nothing on the bar itself triggers these anymore.
+  readonly property bool opened: panelLoader.item ? panelLoader.item.opened === true : false
+
+  function open() {
+    if (panelLoader.item && panelLoader.item.openFromHotkey) panelLoader.item.openFromHotkey()
+  }
+
+  function close() {
+    if (panelLoader.item && panelLoader.item.close) panelLoader.item.close()
+  }
+
+  implicitWidth: 0
+  implicitHeight: 0
+
+  onBarChanged: injectPanel()
+  onSettingsChanged: injectPanel()
+
+  Loader {
+    id: panelLoader
+    active: true
+    source: Qt.resolvedUrl("Panel.qml")
+    visible: false
+    onLoaded: {
+      root.injectPanel()
+      Qt.callLater(root.injectPanel)
+    }
+  }
+}

--- a/shell/plugins/panels/calendar/Model.js
+++ b/shell/plugins/panels/calendar/Model.js
@@ -1,0 +1,180 @@
+// Pure date-math + notes-persistence helpers for the calendar panel.
+// No QML/Qt globals here on purpose (matches Weather's Model.js /
+// Clipboard's ClipboardHistory.js convention) so this file stays testable
+// in plain Node and locale-agnostic: callers pass in a `formatter`
+// callback built from Qt.locale() when they want localized names,
+// otherwise the English fallback below is used.
+
+var MONTH_NAMES = ["January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"]
+var DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+var DAY_SHORT = ["S", "M", "T", "W", "T", "F", "S"]
+
+function pad2(n) { return (n < 10 ? "0" : "") + n }
+
+function daysInMonth(year, month) {
+  // month is 0-based; day 0 of the *next* month rolls back to the last
+  // day of `month`.
+  return new Date(year, month + 1, 0).getDate()
+}
+
+function isoDate(year, month, day) {
+  return year + "-" + pad2(month + 1) + "-" + pad2(day)
+}
+
+function isoFromDate(date) {
+  return isoDate(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function isSameDate(a, b) {
+  return !!a && !!b
+    && a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+}
+
+function isSameMonth(a, b) {
+  return !!a && !!b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
+}
+
+// Normalizes JS's Sunday-first getDay() (0-6) to a week-start-aware index.
+function weekdayIndex(date, weekStartsMonday) {
+  var day = date.getDay() // 0=Sun..6=Sat
+  return weekStartsMonday ? (day + 6) % 7 : day
+}
+
+function addMonths(year, month, delta) {
+  var total = month + delta
+  var y = year + Math.floor(total / 12)
+  var m = ((total % 12) + 12) % 12
+  return { year: y, month: m }
+}
+
+// Builds a fixed 6x7 grid (42 cells) so the panel height never jumps
+// between months. Cells outside the target month are flagged `inMonth:
+// false` but still carry a real Date so "prev/next month" click-throughs
+// and the notes lookup both work uniformly.
+function buildMonthGrid(year, month, weekStartsMonday, today) {
+  var firstOfMonth = new Date(year, month, 1)
+  var leadingBlanks = weekdayIndex(firstOfMonth, weekStartsMonday)
+  var totalDays = daysInMonth(year, month)
+
+  var cells = []
+  for (var i = 0; i < 42; i++) {
+    var dayOffset = i - leadingBlanks + 1
+    var date = new Date(year, month, dayOffset)
+    cells.push({
+      date: date,
+      iso: isoFromDate(date),
+      day: date.getDate(),
+      inMonth: dayOffset >= 1 && dayOffset <= totalDays,
+      isToday: today ? isSameDate(date, today) : false,
+      isWeekend: weekStartsMonday
+        ? (date.getDay() === 0 || date.getDay() === 6)
+        : (date.getDay() === 0 || date.getDay() === 6)
+    })
+  }
+  return cells
+}
+
+function weekdayLabels(weekStartsMonday, formatter) {
+  var order = []
+  for (var i = 0; i < 7; i++) order.push(weekStartsMonday ? (i + 1) % 7 : i)
+  return order.map(function(dayIndex) {
+    if (formatter) return formatter(dayIndex)
+    return DAY_SHORT[dayIndex]
+  })
+}
+
+function monthTitle(year, month, formatter) {
+  if (formatter) return formatter(year, month)
+  return MONTH_NAMES[month] + " " + year
+}
+
+// Same algorithm as the bar Clock widget's isoWeek(), duplicated here
+// rather than imported so this file stays a dependency-free module.
+function isoWeek(date) {
+  var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+  var day = d.getUTCDay() || 7
+  d.setUTCDate(d.getUTCDate() + 4 - day)
+  var yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+  return Math.ceil(((d - yearStart) / 86400000 + 1) / 7)
+}
+
+function fullDayLabel(date, formatter) {
+  if (!date) return ""
+  if (formatter) return formatter(date)
+  return DAY_NAMES[date.getDay()] + ", " + MONTH_NAMES[date.getMonth()] + " " + date.getDate()
+}
+
+// ---- Notes persistence -----------------------------------------------
+// Stored as { "2026-07-19": ["text", "text"], ... } — flat map keeps the
+// file trivially mergeable and the lookup O(1) per rendered cell.
+
+function parseNotes(raw) {
+  try {
+    var parsed = JSON.parse(String(raw || "{}"))
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+    var clean = {}
+    for (var key in parsed) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) continue
+      var list = parsed[key]
+      if (!Array.isArray(list)) continue
+      var texts = list.map(function(v) { return String(v || "").trim() }).filter(function(v) { return v.length > 0 })
+      if (texts.length > 0) clean[key] = texts
+    }
+    return clean
+  } catch (e) {
+    return {}
+  }
+}
+
+function notesFor(notesMap, iso) {
+  return (notesMap && Array.isArray(notesMap[iso])) ? notesMap[iso] : []
+}
+
+function addNote(notesMap, iso, text) {
+  var trimmed = String(text || "").trim()
+  var next = Object.assign({}, notesMap || {})
+  if (!trimmed) return next
+  var existing = Array.isArray(next[iso]) ? next[iso].slice() : []
+  existing.push(trimmed)
+  next[iso] = existing
+  return next
+}
+
+function removeNote(notesMap, iso, index) {
+  var next = Object.assign({}, notesMap || {})
+  var existing = Array.isArray(next[iso]) ? next[iso].slice() : []
+  if (index < 0 || index >= existing.length) return next
+  existing.splice(index, 1)
+  if (existing.length > 0) next[iso] = existing
+  else delete next[iso]
+  return next
+}
+
+function serializeNotes(notesMap) {
+  return JSON.stringify(notesMap || {}, null, 2) + "\n"
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    daysInMonth: daysInMonth,
+    isoDate: isoDate,
+    isoFromDate: isoFromDate,
+    isSameDate: isSameDate,
+    isSameMonth: isSameMonth,
+    weekdayIndex: weekdayIndex,
+    isoWeek: isoWeek,
+    addMonths: addMonths,
+    buildMonthGrid: buildMonthGrid,
+    weekdayLabels: weekdayLabels,
+    monthTitle: monthTitle,
+    fullDayLabel: fullDayLabel,
+    parseNotes: parseNotes,
+    notesFor: notesFor,
+    addNote: addNote,
+    removeNote: removeNote,
+    serializeNotes: serializeNotes
+  }
+}

--- a/shell/plugins/panels/calendar/Panel.qml
+++ b/shell/plugins/panels/calendar/Panel.qml
@@ -1,0 +1,537 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+import "Model.js" as Model
+
+Panel {
+  id: root
+  moduleName: "omarchy.calendar"
+  ipcTarget: "omarchy.calendar"
+  manageIpc: false
+
+  property var anchorItem: null
+  property bool openedFromHotkey: false
+
+  function open() {
+    openedFromHotkey = false
+    setCenterHoverRevealSuppressed(false)
+    root.controller.show()
+  }
+
+  function openFromHotkey() {
+    openedFromHotkey = true
+    setCenterHoverRevealSuppressed(true)
+    root.controller.show()
+    root.goToToday()
+  }
+
+  function close() {
+    setCenterHoverRevealSuppressed(false)
+    root.controller.hide()
+  }
+
+  function toggle() {
+    if (root.opened) root.close()
+    else root.openFromHotkey()
+  }
+
+  function setCenterHoverRevealSuppressed(value) {
+    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+      root.bar.centerHoverRevealSuppressed = value
+  }
+
+  // ---- Calendar state -----------------------------------------------------
+
+  property date today: new Date()
+  property int viewYear: today.getFullYear()
+  property int viewMonth: today.getMonth()
+  property date selectedDate: today
+
+  readonly property bool weekStartsMonday: setting("weekStart", "monday") !== "sunday"
+  readonly property string selectedIso: Model.isoFromDate(selectedDate)
+
+  readonly property var monthGrid: Model.buildMonthGrid(root.viewYear, root.viewMonth, root.weekStartsMonday, root.today)
+  readonly property var weekdayHeader: Model.weekdayLabels(root.weekStartsMonday, function(dayIndex) {
+    // 2023-01-01 was a Sunday; offsetting from it gives every weekday a
+    // stable reference date to hand to Qt's locale-aware formatter.
+    return Qt.formatDate(new Date(2023, 0, 1 + dayIndex), "ddd")
+  })
+  readonly property string monthLabel: Model.monthTitle(root.viewYear, root.viewMonth, function(y, m) {
+    return Qt.formatDate(new Date(y, m, 1), "MMMM yyyy")
+  })
+
+  // Keeps "today" correct across midnight while the panel is left open.
+  Timer {
+    interval: 60000
+    running: true
+    repeat: true
+    onTriggered: root.today = new Date()
+  }
+
+  function goToMonth(delta) {
+    var next = Model.addMonths(root.viewYear, root.viewMonth, delta)
+    root.viewYear = next.year
+    root.viewMonth = next.month
+  }
+
+  function goToToday() {
+    root.viewYear = root.today.getFullYear()
+    root.viewMonth = root.today.getMonth()
+    root.selectedDate = root.today
+  }
+
+  function selectDate(date) {
+    root.selectedDate = date
+    if (!Model.isSameMonth(date, new Date(root.viewYear, root.viewMonth, 1))) {
+      root.viewYear = date.getFullYear()
+      root.viewMonth = date.getMonth()
+    }
+  }
+
+  // dx moves by a day, dy by a week — matches PanelKeyCatcher's grid
+  // vocabulary (h/j/k/l and arrow keys) onto actual calendar geometry.
+  function moveSelection(dx, dy) {
+    var next = new Date(root.selectedDate)
+    next.setDate(next.getDate() + dx + dy * 7)
+    root.selectDate(next)
+  }
+
+  // ---- Notes ----------------------------------------------------------
+
+  property var notesMap: ({})
+  readonly property var selectedNotes: Model.notesFor(root.notesMap, root.selectedIso)
+  readonly property int monthNotesCount: {
+    var prefix = root.viewYear + "-" + (root.viewMonth < 9 ? "0" : "") + (root.viewMonth + 1) + "-"
+    var count = 0
+    for (var key in root.notesMap) {
+      if (key.indexOf(prefix) === 0) count += root.notesMap[key].length
+    }
+    return count
+  }
+
+  function saveNotes() {
+    notesFile.setText(Model.serializeNotes(root.notesMap))
+  }
+
+  function addNoteText(text) {
+    if (String(text || "").trim() === "") return
+    root.notesMap = Model.addNote(root.notesMap, root.selectedIso, text)
+    root.saveNotes()
+  }
+
+  function removeNoteAt(index) {
+    root.notesMap = Model.removeNote(root.notesMap, root.selectedIso, index)
+    root.saveNotes()
+  }
+
+  function removeLastNote() {
+    if (root.selectedNotes.length === 0) return
+    root.removeNoteAt(root.selectedNotes.length - 1)
+  }
+
+  property FileView notesFile: FileView {
+    id: notesFile
+    path: Quickshell.env("HOME") + "/.local/state/omarchy/settings/calendar-notes.json"
+    watchChanges: true
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root.notesMap = Model.parseNotes(text())
+    onLoadFailed: root.notesMap = Model.parseNotes("")
+    onFileChanged: reload()
+  }
+
+  IpcHandler {
+    target: root.ipcTarget
+    function open(): void { root.openFromHotkey() }
+    function close(): void { root.close() }
+    function show(): void { root.openFromHotkey() }
+    function hide(): void { root.close() }
+    function toggle(): void { root.toggle() }
+    function jumpToToday(): void { root.openFromHotkey() }
+  }
+
+  // ---- Presentation -----------------------------------------------------
+
+  readonly property int cellSize: Style.space(32)
+  readonly property int cellGap: Style.space(4)
+  // Single source of truth for horizontal breathing room. Every row below
+  // (hero, separator, notes list, input) anchors off this instead of its
+  // own hardcoded margin, so all their left/right edges line up instead
+  // of drifting between 0, 12 and "whatever centers this row" like before.
+  readonly property int hPad: Style.space(14)
+
+  KeyboardPanel {
+    id: panel
+    anchorItem: root.anchorItem
+    owner: root
+    bar: root.bar
+    open: root.opened
+    centerOnBar: true
+    focusTarget: keyCatcher
+    contentWidth: panel.fittedContentWidth(Style.space(280))
+    contentHeight: panel.fittedContentHeight(calendarColumn.implicitHeight)
+
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+      blocked: noteField.activeFocus
+
+      onCloseRequested: root.close()
+      onTabRequested: function(direction) { root.switchPanel(direction) }
+      onMoveRequested: function(dx, dy) { root.moveSelection(dx, dy) }
+      onActivateRequested: Qt.callLater(function() { noteField.forceActiveFocus() })
+      onDeleteRequested: root.removeLastNote()
+      onTextKey: function(t) {
+        if (t === "t") root.goToToday()
+        else if (t === "[") root.goToMonth(-1)
+        else if (t === "]") root.goToMonth(1)
+      }
+
+      Flickable {
+        id: calendarScroll
+        anchors.fill: parent
+        contentWidth: width
+        contentHeight: calendarColumn.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
+
+        Column {
+          id: calendarColumn
+          width: calendarScroll.width
+          spacing: Style.space(8)
+
+          // ---- Hero: big glyph + big selected-day number, with the
+          //      month/year label anchored top-right on the SAME row.
+          //      calMonthLabel's left edge is pinned to calHeroTop's right
+          //      edge (with a minimum gap), so its available width shrinks
+          //      automatically for long names — combined with elide, this
+          //      guarantees the two can never visually collide, regardless
+          //      of month name length ("September", "November"...) or font.
+          Item {
+            width: parent.width
+            height: calHeroTop.implicitHeight
+
+            Row {
+              id: calHeroTop
+              anchors.left: parent.left
+              anchors.leftMargin: root.hPad
+              anchors.verticalCenter: parent.verticalCenter
+              spacing: Style.space(8)
+
+              Text {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.verticalCenterOffset: -5
+                text: "\uf133" // nf-fa-calendar (outline)
+                color: Qt.darker(root.bar.foreground, 1.2)
+                font.family: root.bar.fontFamily
+                // A calendar glyph is decorative, not informational (unlike
+                // Weather's condition icon), so it stays modest next to the
+                // big number instead of matching Weather's 64px hero size.
+                font.pixelSize: 18
+              }
+
+              Row {
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Style.space(2)
+
+                Text {
+                  id: calDayBig
+                  text: String(root.selectedDate.getDate())
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  // Hero day-of-month read-out; deliberately oversized,
+                  // outside the Style.font.* scale (matches Weather's temp).
+                  font.pixelSize: 32
+                  font.bold: true
+                }
+                Text {
+                  text: Qt.formatDate(root.selectedDate, "ddd").toUpperCase()
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  anchors.top: calDayBig.top
+                  anchors.topMargin: Style.space(5)
+                }
+              }
+            }
+
+            Text {
+              id: calMonthLabel
+              anchors.left: calHeroTop.right
+              anchors.leftMargin: Style.space(8)
+              anchors.right: parent.right
+              anchors.rightMargin: root.hPad
+              anchors.verticalCenter: calHeroTop.verticalCenter
+              horizontalAlignment: Text.AlignRight
+              elide: Text.ElideRight
+              text: root.monthLabel.toUpperCase()
+              color: Qt.darker(root.bar.foreground, 1.4)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              font.letterSpacing: 1
+            }
+          }
+
+          // ---- WEEK / NOTES: two equal-width stat columns, evenly spread
+          //      across the panel and center-aligned so each label sits
+          //      directly above its value. (A third "TODAY" column used to
+          //      live here showing today's weekday — dropped because it
+          //      just duplicated the "SUN" already shown next to the big
+          //      day number above whenever the selected day was today.)
+          Row {
+            id: calHeroStats
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width - root.hPad * 2
+
+            Repeater {
+              model: [
+                { label: "WEEK", value: String(Model.isoWeek(root.selectedDate)) },
+                { label: "NOTES", value: String(root.monthNotesCount) }
+              ]
+
+              Column {
+                required property var modelData
+                width: calHeroStats.width / 2
+                spacing: Style.space(2)
+
+                Text {
+                  width: parent.width
+                  horizontalAlignment: Text.AlignHCenter
+                  text: modelData.label
+                  color: Qt.darker(root.bar.foreground, 1.5)
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.letterSpacing: 0.5
+                }
+                Text {
+                  width: parent.width
+                  horizontalAlignment: Text.AlignHCenter
+                  text: modelData.value
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.subtitle
+                  font.bold: true
+                }
+              }
+            }
+          }
+
+          // ---- Month navigation.
+          Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: Style.space(6)
+
+            Button {
+              iconText: "‹"
+              tooltipText: "Previous month"
+              foreground: root.bar.foreground
+              onClicked: root.goToMonth(-1)
+            }
+
+            Button {
+              text: "Today"
+              foreground: root.bar.foreground
+              onClicked: root.goToToday()
+            }
+
+            Button {
+              iconText: "›"
+              tooltipText: "Next month"
+              foreground: root.bar.foreground
+              onClicked: root.goToMonth(1)
+            }
+          }
+
+          // ---- Weekday header row.
+          Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: root.cellGap
+
+            Repeater {
+              model: root.weekdayHeader
+
+              Text {
+                required property string modelData
+                width: root.cellSize
+                horizontalAlignment: Text.AlignHCenter
+                text: modelData.toUpperCase()
+                color: Qt.darker(root.bar.foreground, 1.5)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+                font.letterSpacing: 0.5
+              }
+            }
+          }
+
+          // ---- Month grid: fixed 6 weeks x 7 days so the popup never
+          //      resizes when flipping between short and long months.
+          Column {
+            anchors.horizontalCenter: parent.horizontalCenter
+            spacing: root.cellGap
+
+            Repeater {
+              model: 6
+
+              Row {
+                required property int index
+                spacing: root.cellGap
+
+                Repeater {
+                  model: root.monthGrid.slice(index * 7, index * 7 + 7)
+
+                  Rectangle {
+                    id: dayCell
+                    required property var modelData
+                    readonly property bool isSelected: Model.isSameDate(modelData.date, root.selectedDate)
+                    readonly property bool hasNotes: Model.notesFor(root.notesMap, modelData.iso).length > 0
+
+                    width: root.cellSize
+                    height: root.cellSize
+                    radius: Style.cornerRadius
+                    color: isSelected
+                      ? Style.selectedFillFor(root.bar.foreground, Color.accent)
+                      : (cellMouse.containsMouse ? Style.hoverFillFor(root.bar.foreground, Color.accent) : "transparent")
+                    border.width: modelData.isToday ? Math.max(1, Style.space(1)) : 0
+                    border.color: Color.accent
+
+                    Text {
+                      anchors.centerIn: parent
+                      anchors.verticalCenterOffset: dayCell.hasNotes ? -Style.space(3) : 0
+                      text: String(dayCell.modelData.day)
+                      color: !dayCell.modelData.inMonth
+                        ? Qt.darker(root.bar.foreground, 2.2)
+                        : (dayCell.isSelected ? Style.selectedStateColor(root.bar.foreground, Color.accent) : root.bar.foreground)
+                      font.family: root.bar.fontFamily
+                      font.pixelSize: Style.font.bodySmall
+                      font.bold: dayCell.modelData.isToday || dayCell.isSelected
+                    }
+
+                    Rectangle {
+                      visible: dayCell.hasNotes
+                      anchors.horizontalCenter: parent.horizontalCenter
+                      anchors.bottom: parent.bottom
+                      anchors.bottomMargin: Style.space(5)
+                      width: Style.space(4)
+                      height: Style.space(4)
+                      radius: width / 2
+                      color: dayCell.isSelected ? Style.selectedStateColor(root.bar.foreground, Color.accent) : Color.accent
+                    }
+
+                    MouseArea {
+                      id: cellMouse
+                      anchors.fill: parent
+                      hoverEnabled: true
+                      cursorShape: Qt.PointingHandCursor
+                      onClicked: root.selectDate(dayCell.modelData.date)
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          PanelSeparator {
+            x: root.hPad
+            width: parent.width - root.hPad * 2
+            foreground: root.bar.foreground
+          }
+
+          // ---- Notes for the selected day. (No date subtitle here — the
+          //      hero row above already shows day number, weekday and
+          //      month/year, so repeating "Sunday, July 19" here was just
+          //      restating what's already on screen.)
+          PanelSectionHeader {
+            x: root.hPad
+            text: "Notes"
+            foreground: root.bar.foreground
+          }
+
+          Column {
+            x: root.hPad
+            width: parent.width - root.hPad * 2
+            spacing: Style.space(4)
+            visible: root.selectedNotes.length > 0
+
+            Repeater {
+              model: root.selectedNotes
+
+              Row {
+                required property string modelData
+                required property int index
+                width: parent.width
+                spacing: Style.space(8)
+
+                Text {
+                  width: Style.space(12)
+                  horizontalAlignment: Text.AlignHCenter
+                  text: "•"
+                  color: Color.accent
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.body
+                }
+
+                Text {
+                  // Budget the remaining width exactly: bullet + close
+                  // button + the two Row spacings between all three
+                  // children, so the "x" never overflows past the edge
+                  // and gets clipped by the Flickable above.
+                  width: parent.width - Style.space(12) - Style.space(24) - Style.space(16)
+                  text: modelData
+                  wrapMode: Text.Wrap
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                }
+
+                Item {
+                  width: Style.space(24)
+                  height: Style.space(24)
+
+                  Text {
+                    anchors.centerIn: parent
+                    text: "×"
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.body
+                  }
+
+                  MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.removeNoteAt(index)
+                  }
+                }
+              }
+            }
+          }
+
+          Text {
+            x: root.hPad
+            visible: root.selectedNotes.length === 0
+            text: "No notes for this day"
+            color: Qt.darker(root.bar.foreground, 1.5)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.italic: true
+          }
+
+          TextField {
+            id: noteField
+            x: root.hPad
+            width: parent.width - root.hPad * 2
+            placeholderText: "Add a note for this day…"
+            foreground: root.bar.foreground
+            onAccepted: {
+              root.addNoteText(text)
+              text = ""
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/panels/calendar/manifest.json
+++ b/shell/plugins/panels/calendar/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.calendar",
+  "name": "Calendar",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Month calendar with a day-notes popup",
+  "kinds": [
+    "bar-widget"
+  ],
+  "keepLoaded": true,
+  "entryPoints": {
+    "barWidget": "BarWidget.qml"
+  },
+  "barWidget": {
+    "displayName": "Calendar",
+    "description": "Month calendar with a day-notes popup",
+    "category": "Info",
+    "allowMultiple": false
+  }
+}


### PR DESCRIPTION
<p class="isSelectedEnd"><span>Adds a full month-view calendar with per-day notes, integrated directly into the existing </span><strong><span>Clock</span></strong><span> widget.</span></p><h2><span>Features</span></h2><ul data-spread="false"><li><span> Month-view calendar.</span></li><li><span> Per-day notes.</span></li><li><span> Opens by clicking the existing Clock widget instead of adding a separate bar icon.</span></li><li><span> Existing timezone menu remains unchanged.</span></li></ul><h2><span>User Interaction</span></h2>
Mouse Button | Action
-- | --
Left Click | Open/close the calendar
Middle Click | Toggle alternative time format (previous left-click behavior)
Right Click | Open the timezone menu

<p class="isSelectedEnd"><span>The calendar is opened through:</span></p><pre dir="ltr"><code dir="ltr"><span>omarchy-shell omarchy.calendar toggle</span></code></pre><h2><span>Implementation</span></h2><p class="isSelectedEnd"><span>A new plugin has been added under:</span></p><pre dir="ltr"><code dir="ltr"><span>shell/plugins/panels/calendar/
├── BarWidget.qml
├── Model.js
├── Panel.qml
└── manifest.json</span></code></pre><p class="isSelectedEnd"><span>The implementation follows the same </span><strong><span>bar-widget → Loader → Panel</span></strong><span> architecture used by the existing Weather, Dropbox, and Tailscale plugins.</span></p><h3><span>BarWidget</span></h3><p class="isSelectedEnd"><code dir="ltr"><span>BarWidget.qml</span></code><span> is intentionally invisible (</span><code dir="ltr"><span>0×0</span></code><span>).</span></p><p class="isSelectedEnd"><span>It exists only to:</span></p><ul data-spread="false"><li><span>Keep </span><code dir="ltr"><span>Panel.qml</span></code><span> loaded.</span></li><li><span>Register the </span><code dir="ltr"><span>omarchy.calendar</span></code><span> IPC target.</span></li></ul><p class="isSelectedEnd"><span>Since the calendar is opened from the Clock widget, no visible bar icon is required.</span></p><h2><span>Clock Integration</span></h2><p class="isSelectedEnd"><code dir="ltr"><span>shell/plugins/bar/widgets/Clock.qml</span></code><span> has been updated.</span></p><p class="isSelectedEnd"><span>Changes:</span></p><ul data-spread="false"><li><strong><span>Left Click:</span></strong><span> Open/close the calendar.</span></li><li><strong><span>Middle Click:</span></strong><span> Toggle alternative time format.</span></li><li><strong><span>Right Click:</span></strong><span> Timezone menu (unchanged).</span></li></ul><h2><span>Loading the Plugin</span></h2><p class="isSelectedEnd"><span>Although the calendar does not display its own bar icon, the plugin still needs to be loaded so its IPC target is registered.</span></p><p class="isSelectedEnd"><span>Either:</span></p><pre dir="ltr"><code dir="ltr"><span>omarchy bar plugin add omarchy.calendar</span></code></pre><p class="isSelectedEnd"><span>or include it in your </span><code dir="ltr"><span>bar.layout</span></code><span>.</span></p><h2><span>Testing</span></h2><p class="isSelectedEnd"><span>Tested locally using:</span></p><pre dir="ltr"><code dir="ltr"><span>omarchy-restart-shell</span></code></pre><p><span>The calendar opens correctly from the Clock widget, notes persist as expected, and existing Clock functionality continues to work.</span></p>


https://github.com/user-attachments/assets/0fbc84ad-80ee-4fe2-9999-e213cf9a0784

