### PR TITLE
looknfeel: open new windows on the active workspace (fix portal file dialogs)

### DIFF
--- a/default/hypr/looknfeel.lua
+++ b/default/hypr/looknfeel.lua
@@ -109,6 +109,11 @@ hl.config({
     focus_on_activate = true,
     anr_missed_pings = 3,
     on_focus_under_fullscreen = 1,
+    -- Open new windows on the active workspace, not the one their process was
+    -- launched on. Otherwise xdg-desktop-portal-gtk file dialogs (browser
+    -- Open/Save, etc.) always appear on the workspace where the portal first
+    -- started at login, instead of following the app that requested them.
+    initial_workspace_tracking = 0,
   },
 
   cursor = {


### PR DESCRIPTION
## What
Set `misc:initial_workspace_tracking = 0` in `default/hypr/looknfeel.lua`.

## Why
File-picker dialogs drawn by `xdg-desktop-portal-gtk` (browser Open/Save, GTK app choosers, etc.) open on the workspace where the **portal process** started at login — typically workspace 1 — instead of following the app that requested them.

**Repro:** put a browser on workspace 2, trigger a Save/Open dialog → it pops up on workspace 1, out of view.

With tracking off, new windows map on the currently active workspace, so the dialog follows the app.

## Trade-off
An app launched on one workspace that you switch away from before its window maps will now open on the new active workspace. In practice the dialog-follows-app behavior is the more intuitive default, and this fixes a confusing, easy-to-hit bug.

## Testing
Hyprland on Omarchy 4 (quattro): browser Save/Open dialogs now appear on the active workspace; `hyprctl getoption misc:initial_workspace_tracking` → `0` after reload.