### PR TITLE
voxtype: reload Hyprland after enabling the dictation toggle

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -21,6 +21,10 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   voxtype setup systemd
 
   omarchy-hyprland-toggle voxtype on
+  # Reload Hyprland so the dictation binds (F9 / Super+Ctrl+X) added by the
+  # toggle take effect immediately; otherwise they stay inactive until the next
+  # login. Tolerate running outside a live Hyprland session.
+  hyprctl reload >/dev/null 2>&1 || true
   omarchy-restart-shell
   omarchy-notification-send -g  "Voxtype Dictation Ready" "Hold F9 to dictate (or toggle with Super + Ctrl + X)." -t 10000
 fi


### PR DESCRIPTION
## What
Reload Hyprland after `omarchy-hyprland-toggle voxtype on` in `omarchy-voxtype-install`.

## Why
Enabling the voxtype toggle writes the dictation binds (F9 push-to-talk, Super+Ctrl+X toggle) into the state toggles dir, but nothing reloads Hyprland afterward — the installer restarts the *shell*, not Hyprland. So the binds stay inactive until the next login: a fresh install "succeeds" but hold-F9 does nothing until you reboot/reload.

Reloading Hyprland right after enabling the toggle makes dictation work immediately. `>/dev/null 2>&1 || true` keeps it safe if run outside a live Hyprland session.

## Testing
Fresh voxtype install on Hyprland (Omarchy 4): before, F9 was unbound until a reload/login; after, `hyprctl binds` shows the F9 binds immediately and dictation works right after install.