### PR TITLE
Prefer Noto Naskh Arabic over Nastaliq Urdu for Arabic text

### DIFF
--- a/default/fontconfig/conf.avail/50-omarchy.conf
+++ b/default/fontconfig/conf.avail/50-omarchy.conf
@@ -28,6 +28,16 @@
     </edit>
   </match>
 
+  <!-- Arabic: prefer Naskh (standard Arabic) over Nastaliq (Urdu style) -->
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ar</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Naskh Arabic</string>
+    </edit>
+  </match>
+
   <alias>
     <family>system-ui</family>
     <prefer>


### PR DESCRIPTION
## Summary

Adds a fontconfig rule that prepends `Noto Naskh Arabic` to the family list whenever the requested text is tagged with `lang=ar`. Without this rule, fontconfig's default scoring picks `Noto Nastaliq Urdu` as the fallback for Arabic text — the Nastaliq calligraphic style is standard for Urdu/Persian but is unfamiliar and hard to read for Arabic speakers, who expect Naskh (the standard newspaper/UI script across the Arab world).

Both fonts ship via the `noto-fonts` package and both declare `lang=ar` coverage, so they tie on fontconfig's language score. The tiebreak lands on Nastaliq for reasons internal to fontconfig's charset scoring, which is why the fix has to be an explicit `prepend` with `binding="strong"` — it wins before the scoring stage runs.

Fixes #5375
Fixes #5396

Credit to @ferass04 who diagnosed and proposed this exact rule in #5375.

## Scope

Only affects native apps that go through fontconfig (GTK, Qt, terminals, etc.). Electron/Chromium apps (Discord, Vesktop, VSCode) do their own glyph-level fallback that bypasses fontconfig's `lang=ar` rules — that's a separate problem and out of scope here.

## Test plan

- [x] Before the change: `fc-match -s :lang=ar | head -3` shows `NotoNastaliqUrdu-Regular.ttf` before `NotoNaskhArabic-Regular.ttf`
- [x] After the change + `fc-cache -f`: `NotoNaskhArabic-Regular.ttf` is first
- [x] Open any GTK app rendering Arabic (Nautilus, gedit, a browser on an Arabic site): text renders in horizontal Naskh style, not diagonal Nastaliq
- [x] Non-Arabic text (English, code, emoji) is unaffected