### PR TITLE
Install Emacs via the omarchy-emacs AUR package

### DIFF
--- a/bin/omarchy-install-editor-emacs
+++ b/bin/omarchy-install-editor-emacs
@@ -4,3 +4,6 @@
 
 echo "Installing Emacs..."
 omarchy-pkg-aur-add omarchy-emacs && omarchy-install-emacs
+
+# emacsclient opens a frame on the running daemon, not a second Emacs
+setsid gtk-launch emacsclient

--- a/bin/omarchy-install-editor-emacs
+++ b/bin/omarchy-install-editor-emacs
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# omarchy:summary=Install Emacs with Omarchy theme and font integration via the omarchy-emacs AUR package
+
+echo "Installing Emacs..."
+omarchy-pkg-aur-add omarchy-emacs && omarchy-install-emacs

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -186,7 +186,7 @@
   "install.editor.sublime": {"icon":"","label":"Sublime Text","action":"omarchy-install-and-launch 'Sublime Text' sublime-text-4 sublime_text"},
   "install.editor.helix": {"icon":"","label":"Helix","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-helix"},
   "install.editor.vim": {"icon":"","label":"Vim","action":"omarchy-install-app Vim vim"},
-  "install.editor.emacs": {"icon":"","label":"Emacs","action":"omarchy-install-app Emacs emacs-wayland && systemctl --user enable --now emacs.service"},
+  "install.editor.emacs": {"icon":"","label":"Emacs","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-emacs"},
   "install.terminal.alacritty": {"icon":"","label":"Alacritty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal alacritty'"},
   "install.terminal.foot": {"icon":"","label":"Foot","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal foot'"},
   "install.terminal.ghostty": {"icon":"","label":"Ghostty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal ghostty'"},


### PR DESCRIPTION
## Summary

- Points the **Emacs** entry in the install-editor menu at a dedicated `omarchy-install-editor-emacs` script, matching the pattern already used for Helix, VSCode, and Zed.
- The script installs the `omarchy-emacs` AUR package and runs its installer, which pulls in `emacs-wayland`, applies the theme/font integration, and enables the user `emacs.service`.
- One new script + one changed menu line. No new dependencies in the Omarchy tree.

## Context

This is the AUR-packaged follow-up to #4807, where @dhh suggested packaging the Emacs integration as an AUR package (like `omarchy-nvim`) rather than shipping it in-tree — thank you for that steer. The package now exists and is maintained:

- AUR: https://aur.archlinux.org/packages/omarchy-emacs
- Source: https://github.com/scottjones/omarchy-emacs

It supersedes #5329, which made the same change against `dev` before the quattro menu refactor landed. I'll close that one in favor of this.

## Behavior

**Before:** `omarchy-install-app Emacs emacs-wayland && systemctl --user enable --now emacs.service` — installs a bare Emacs with no theming.

**After:** installs an Emacs that automatically tracks the active Omarchy theme and font, with the daemon enabled. The AUR package encapsulates setup, so the menu line stays a one-liner consistent with the other setup-based editors (Helix/Zed/VSCode).

## Test plan

- [x] `omarchy-install-editor-emacs` runs cleanly — installs the package, runs setup, enables and starts `emacs.service`
- [x] The daemon comes up with the `omarchy` theme applied, tracking the current theme at `~/.local/state/omarchy/current/`
- [x] `omarchy-menu.jsonc` still parses; the entry launches via `omarchy-launch-floating-terminal-with-presentation` like the other setup-based editors
- [x] Verified on Omarchy 4 (quattro)
