### PR TITLE
Prevent Chromium Vulkan crashes on Wayland

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -1,5 +1,6 @@
 --ozone-platform=wayland
 --ozone-platform-hint=wayland
 --password-store=gnome-libsecret
+--use-webgpu-adapter=opengles
 --enable-features=TouchpadOverscrollHistoryNavigation
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp

--- a/migrations/1784607542.sh
+++ b/migrations/1784607542.sh
@@ -4,6 +4,7 @@ add_webgpu_adapter_flag() {
   local file=$1
   [[ -f $file ]] || return 0
   grep -Fxq -- "--use-webgpu-adapter=opengles" "$file" && return 0
+  [[ -n $(tail -c1 "$file") ]] && echo >>"$file"
   echo "--use-webgpu-adapter=opengles" >>"$file"
 }
 

--- a/migrations/1784607542.sh
+++ b/migrations/1784607542.sh
@@ -1,0 +1,20 @@
+echo "Disable Chromium's Wayland Vulkan WebGPU interop to prevent browser crashes"
+
+add_webgpu_adapter_flag() {
+  local file=$1
+  [[ -f $file ]] || return 0
+  grep -Fxq -- "--use-webgpu-adapter=opengles" "$file" && return 0
+  echo "--use-webgpu-adapter=opengles" >>"$file"
+}
+
+for flags_file in "$HOME"/.config/{chromium,chrome,google-chrome,google-chrome-beta,google-chrome-unstable,microsoft-edge-stable,microsoft-edge-beta,microsoft-edge-dev,vivaldi-stable,vivaldi-snapshot,opera,opera-beta,opera-developer}-flags.conf; do
+  add_webgpu_adapter_flag "$flags_file"
+done
+
+brave_flags="$HOME/.config/brave-flags.conf"
+brave_origin_flags="$HOME/.config/brave-origin-beta-flags.conf"
+if [[ -f $brave_flags && -L $brave_origin_flags ]] && [[ $(readlink -f "$brave_flags") == $(readlink -f "$brave_origin_flags") ]]; then
+  echo "Skip Brave flags shared with Brave Origin until its wrapper supports multiple flags"
+else
+  add_webgpu_adapter_flag "$brave_flags"
+fi

--- a/migrations/1784607542.sh
+++ b/migrations/1784607542.sh
@@ -2,7 +2,7 @@ echo "Disable Chromium's Wayland Vulkan WebGPU interop to prevent browser crashe
 
 add_webgpu_adapter_flag() {
   local file=$1
-  [[ -f $file ]] || return 0
+  [[ -f $file && -r $file && -w $file ]] || return 0
   grep -Fxq -- "--use-webgpu-adapter=opengles" "$file" && return 0
   [[ -n $(tail -c1 "$file") ]] && echo >>"$file"
   echo "--use-webgpu-adapter=opengles" >>"$file"

--- a/migrations/1784607542.sh
+++ b/migrations/1784607542.sh
@@ -12,9 +12,16 @@ for flags_file in "$HOME"/.config/{chromium,chrome,google-chrome,google-chrome-b
 done
 
 brave_flags="$HOME/.config/brave-flags.conf"
-brave_origin_flags="$HOME/.config/brave-origin-beta-flags.conf"
-if [[ -f $brave_flags && -L $brave_origin_flags ]] && [[ $(readlink -f "$brave_flags") == $(readlink -f "$brave_origin_flags") ]]; then
+brave_origin_flags="$HOME/.config/brave-origin-flags.conf"
+brave_origin_beta_flags="$HOME/.config/brave-origin-beta-flags.conf"
+
+if [[ -f $brave_flags ]] && {
+  [[ -L $brave_origin_flags && $(readlink -f "$brave_flags") == $(readlink -f "$brave_origin_flags") ]] ||
+  [[ -L $brave_origin_beta_flags && $(readlink -f "$brave_flags") == $(readlink -f "$brave_origin_beta_flags") ]]
+}; then
   echo "Skip Brave flags shared with Brave Origin until its wrapper supports multiple flags"
 else
   add_webgpu_adapter_flag "$brave_flags"
+  add_webgpu_adapter_flag "$brave_origin_flags"
+  add_webgpu_adapter_flag "$brave_origin_beta_flags"
 fi


### PR DESCRIPTION
## Summary
- select the OpenGL ES WebGPU adapter to avoid Chromium's Wayland Vulkan interop path
- migrate existing Chromium-based browser flag files idempotently
- preserve Brave Origin stability by skipping `brave-flags.conf` when it is shared with its known broken multi-line flags wrapper

## Why
Chromium can initialize Vulkan for WebGPU-on-Vulkan-via-GL interop even when the browser compositor uses OpenGL. On Wayland this triggers the `--ozone-platform=wayland is not compatible with Vulkan` error and can crash or freeze the browser. `--use-webgpu-adapter=opengles` disables that interop path while retaining hardware compositing and rasterization.

Refs: brave/brave-browser#55805, basecamp/omarchy#5372

## Testing
- `./test/all`
- exercised the migration against normal Chromium/Brave configurations and a Brave configuration shared with Brave Origin
- verified Brave reports hardware compositing and rasterization enabled, Vulkan disabled, and WebGPU-on-Vulkan interop disabled with this flag