### PR TITLE
fix(clock): display date, week, and year vertically in vertical bar.

### DIFF
--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -77,7 +77,6 @@ BarWidget {
 
         OpticalGlyph {
           required property string modelData
-          required property int index
           width: button.width
           height: Style.bar.iconSlot
           text: modelData

--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -12,7 +12,7 @@ BarWidget {
   property date displayDate: clock.date
 
   readonly property string activeFormat: alt
-    ? setting("formatAlt", "d MMMM 'W'ww yyyy")
+    ? (bar && bar.vertical ? setting("verticalFormatAlt", "dd\nMMM\n'W'ww\nyyyy") : setting("formatAlt", "d MMMM 'W'ww yyyy"))
     : (bar && bar.vertical ? setting("verticalFormat", "HH\n—\nmm") : setting("format", "dddd HH:mm"))
   readonly property string displayText: formatted(displayDate)
   readonly property var verticalLines: displayText.split("\n")
@@ -71,17 +71,21 @@ BarWidget {
     Column {
       visible: root.vertical
       anchors.fill: parent
+      spacing: 1
 
       Repeater {
         model: root.verticalLines
 
         OpticalGlyph {
           required property string modelData
+          required property int index
           width: button.width
           height: Style.bar.iconSlot
           text: modelData
           fontFamily: button.fontFamily
-          fontSize: button.fontSize
+          fontSize: root.alt && index === root.verticalLines.length - 1
+                ? button.fontSize * 0.8
+                : button.fontSize
           color: button.foreground
         }
       }

--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -12,8 +12,8 @@ BarWidget {
   property date displayDate: clock.date
 
   readonly property string activeFormat: alt
-    ? (bar && bar.vertical ? setting("verticalFormatAlt", "dd\nMMM\n'W'ww\nyyyy") : setting("formatAlt", "d MMMM 'W'ww yyyy"))
-    : (bar && bar.vertical ? setting("verticalFormat", "HH\n—\nmm") : setting("format", "dddd HH:mm"))
+    ? (vertical ? setting("verticalFormatAlt", "dd\nMMM\n'W'ww\nyyyy") : setting("formatAlt", "d MMMM 'W'ww yyyy"))
+    : (vertical ? setting("verticalFormat", "HH\n—\nmm") : setting("format", "dddd HH:mm"))
   readonly property string displayText: formatted(displayDate)
   readonly property var verticalLines: displayText.split("\n")
 
@@ -71,7 +71,7 @@ BarWidget {
     Column {
       visible: root.vertical
       anchors.fill: parent
- 
+
       Repeater {
         model: root.verticalLines
 
@@ -82,7 +82,7 @@ BarWidget {
           text: modelData
           fontFamily: button.fontFamily
           fontSize: modelData.length > 3
-      	    ? button.fontSize * 0.9
+            ? button.fontSize * 0.9
             : button.fontSize
           color: button.foreground
         }

--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -71,8 +71,7 @@ BarWidget {
     Column {
       visible: root.vertical
       anchors.fill: parent
-      spacing: 1
-
+ 
       Repeater {
         model: root.verticalLines
 
@@ -83,9 +82,9 @@ BarWidget {
           height: Style.bar.iconSlot
           text: modelData
           fontFamily: button.fontFamily
-          fontSize: root.alt && index === root.verticalLines.length - 1
-                ? button.fontSize * 0.8
-                : button.fontSize
+          fontSize: modelData.length > 3
+      	      ? button.fontSize * 0.9
+            : button.fontSize
           color: button.foreground
         }
       }

--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -83,7 +83,7 @@ BarWidget {
           text: modelData
           fontFamily: button.fontFamily
           fontSize: modelData.length > 3
-      	      ? button.fontSize * 0.9
+      	    ? button.fontSize * 0.9
             : button.fontSize
           color: button.foreground
         }


### PR DESCRIPTION
## What
Fixes the clock widget's alt-format (triggered by clicking the clock) 
when the bar is positioned vertically.

## Why
Previously, `activeFormat` used the same single-line `formatAlt` string 
regardless of bar orientation. On a horizontal bar this worked fine, 
but on a vertical bar the text got cut off since there was no `\n` 
to break it into lines that fit the narrow bar width.

## Changes
- Added a `verticalFormatAlt` setting so the alt view has its own 
  multi-line format when the bar is vertical, instead of reusing 
  the horizontal one.
- Updated the format to include the year (`yyyy`), which was missing.
- Minor spacing tweak in the vertical `Column` layout for readability.

## Testing
Tested by dragging the bar to a vertical position (left side of screen), 
clicking the clock to toggle alt view, and confirming the date, week 
number, and year all display fully without being cut off.

Before
<img width="66" height="320" alt="screenshot-2026-07-21_18-34-51" src="https://github.com/user-attachments/assets/27ca0e40-6bc5-46d5-af1f-83bf69a8721b" />

After
<img width="60" height="348" alt="screenshot-2026-07-21_19-04-23" src="https://github.com/user-attachments/assets/388c6b3d-163d-4bdd-8fde-ea37030f2c8a" />
