### PR TITLE
Fix headless bar widget test skip

### DIFF
--- a/test/shell.d/bar-widget-contract-test.sh
+++ b/test/shell.d/bar-widget-contract-test.sh
@@ -12,7 +12,9 @@ cleanup() {
     kill "$QS_PID" 2>/dev/null || true
     wait "$QS_PID" 2>/dev/null || true
   fi
-  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

- make optional temporary-directory cleanup a successful no-op when the directory was never created
- preserve successful exit status for the headless bar widget contract skip
- allow the aggregate shell suite to continue past that skip

Fixes #6337.

## Root cause

The EXIT trap returned the status of a final `[[ ... ]] && rm ...` expression. On the early headless skip path, `TMPDIR` is unset, so cleanup returned 1 and overrode the explicit `exit 0`.

## Validation

Passed:

- `env -u WAYLAND_DISPLAY bash test/shell.d/bar-widget-contract-test.sh`
- `bash -n test/shell.d/bar-widget-contract-test.sh`
- `git diff --check`
- `./test/cli` (as part of `./test/all`)

Aggregate limitation:

- `./test/shell` and `./test/all` both continue beyond the repaired test, then stop at the unrelated existing `bin-style-test.sh` check because `bin/omarchy-display-text-size` uses raw `command -v` calls. This file is unchanged by the PR.

🤖 Implemented with Codex. I reviewed the change and ran the checks listed above.