### PR TITLE
fix(power-widget): Power widget charging icon/label stuck after unplugging AC

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -39,15 +39,8 @@ Panel {
     setProfile(profiles[profileIndex])
   }
 
-  function batteryIcon() {
-    var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
-  }
-
-  function modeLabel() {
-    var device = UPower.displayDevice
-    return Model.modeLabel(device, root.discharging, upowerStates())
-  }
+  readonly property string batteryIconText: Model.batteryIcon(UPower.displayDevice, root.discharging, upowerStates())
+  readonly property string modeLabelText: Model.modeLabel(UPower.displayDevice, root.discharging, upowerStates())
 
   function profileIcon(name) {
     return Model.profileIcon(name)
@@ -59,7 +52,7 @@ Panel {
   }
   readonly property bool discharging: {
     var device = UPower.displayDevice
-    return !!(device && device.isPresent && UPower.onBattery)
+    return !!(device && device.isPresent && device.state === UPowerDeviceState.Discharging)
   }
   readonly property bool chargeThresholdActive: {
     var device = UPower.displayDevice
@@ -76,7 +69,7 @@ Panel {
 
   readonly property bool charging: {
     var d = UPower.displayDevice
-    return d && d.isPresent && !UPower.onBattery && !root.batteryFlowIdle
+    return d && d.isPresent && !root.discharging && !root.batteryFlowIdle
   }
 
   readonly property color batteryFillColor: {
@@ -121,7 +114,7 @@ Panel {
   readonly property string heroStatusText: {
     if (fullyCharged) return "Fully charged"
     if (rotatingPhrases) return activePhrases[phraseIndex % activePhrases.length]
-    return modeLabel()
+    return modeLabelText
   }
 
   function refresh() {
@@ -253,7 +246,7 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.batteryIcon()
+    text: root.batteryIconText
     tooltipText: ""
     onPressed: function(b) { if (root.batteryPresent) root.toggle() }
   }
@@ -294,7 +287,7 @@ Panel {
 
           Text {
             id: heroIcon
-            text: root.batteryIcon()
+            text: root.batteryIconText
             color: root.bar.foreground
             font.family: root.bar.fontFamily
             font.pixelSize: Style.font.display


### PR DESCRIPTION
# Fix: Power widget charging icon/label stuck after unplugging AC

## Problem

In the Power bar-widget, when the charger cable was unplugged, the
battery icon and the status label (`Charging`) would not update —
they stayed stuck in the charging state indefinitely, even though the
system itself (`upower --monitor`) correctly reported the AC-unplug
event instantly.

## Root cause

Two separate issues, found and fixed in sequence:

1. **Unreliable reactivity source.** The icon/label were originally
   read via plain JS functions (`batteryIcon()`, `modeLabel()`) called
   directly inside QML `Text` bindings. This made their re-evaluation
   depend on QML's automatic dependency tracking working transitively
   across function calls into an imported `.js` module — a pattern
   that isn't guaranteed to be as reliable as a plain `readonly
   property` binding.

2. **Wrong UPower source property (the real cause).** Charging state
   was derived from `UPower.onBattery` — a global, aggregate property
   on the UPower daemon. This property is known to lag or fail to
   notify promptly on some hardware. This is a well-documented pitfall
   in other UPower consumers (e.g. an equivalent bug was reported and
   fixed in `cosmic-applets`, where the fix was to switch from the
   global `on_battery` flag to the per-device `state` property).

   The correct, reliable source is the **per-device state**
   (`UPowerDevice.state`, e.g. `UPowerDeviceState.Discharging` /
   `Charging` / `FullyCharged` / `PendingCharge`), which is what
   `upower --monitor` itself reads and reports instantly.

## Fix

- Replaced the two JS functions with `readonly property` bindings
  (`batteryIconText`, `modeLabelText`) so the icon/label are
  guaranteed to re-evaluate on every relevant property change.
- Changed `discharging` (and by extension `charging`) to be computed
  from `UPowerDevice.state === UPowerDeviceState.Discharging` instead
  of the global `UPower.onBattery` flag.

## Known remaining behavior (not a bug)

There can still be a short delay (typically a couple of seconds)
between the physical plug/unplug event and the widget updating. This
comes from the underlying kernel → upowerd → DBus signal chain
(embedded-controller/ACPI reporting latency), which is outside the
widget's control and is consistent with the delay seen in
`upower --monitor` itself and in other desktop environments (GNOME,
KDE, etc.).

## Testing

- Verified with `udevadm monitor --udev --subsystem-match=power_supply`
  and `upower -i <device> --monitor` that the underlying system
  reports the state change, and confirmed the widget now reflects it
  (icon + label) without requiring the panel to be open.