### PR TITLE
Expose Dell firmware power profiles

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -365,12 +365,41 @@ show_setup_menu() {
 }
 
 show_setup_power_menu() {
-  profile=$(menu "Power Profile" "$(omarchy-powerprofiles-list)" "" "$(powerprofilesctl get)")
+  local dell_device=""
+  local dell_current=""
+  local device name current
+  while IFS=$'\t' read -r device name current; do
+    if [[ $name == "dell-pc" ]]; then
+      dell_device="$device"
+      dell_current="$current"
+      break
+    fi
+  done < <(omarchy-powerprofiles-platform list)
+
+  local profile
+  if [[ -n $dell_device ]]; then
+    local dell_profiles
+    dell_profiles=$(omarchy-powerprofiles-platform choices "$dell_device")
+    dell_profiles=$(printf '%s\n' quiet cool balanced performance | grep -Fx -f <(printf '%s\n' "$dell_profiles"))
+    profile=$(menu "Dell Power Profile" "$dell_profiles" "" "$dell_current")
+  else
+    profile=$(menu "Power Profile" "$(omarchy-powerprofiles-list)" "" "$(powerprofilesctl get)")
+  fi
 
   if [[ $profile == "CNCLD" || -z $profile ]]; then
     back_to show_setup_menu
-  else
+    return
+  fi
+
+  if [[ -z $dell_device ]]; then
     powerprofilesctl set "$profile"
+  elif omarchy-powerprofiles-list | grep -Fxq "$profile"; then
+    powerprofilesctl set "$profile"
+    [[ $(omarchy-powerprofiles-platform get "$dell_device") == $profile ]] ||
+      omarchy-powerprofiles-platform set "$dell_device" "$profile"
+  else
+    powerprofilesctl set power-saver
+    omarchy-powerprofiles-platform set "$dell_device" "$profile"
   fi
 }
 

--- a/bin/omarchy-powerprofiles-platform
+++ b/bin/omarchy-powerprofiles-platform
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# omarchy:summary=Inspect or set firmware platform profiles exposed by the kernel
+# omarchy:args=<list|choices|get|set> [device] [profile]
+# omarchy:examples=omarchy powerprofiles platform list | omarchy powerprofiles platform choices platform-profile-0
+
+set -euo pipefail
+
+profile_root="${OMARCHY_PLATFORM_PROFILE_ROOT:-/sys/class/platform-profile}"
+
+usage() {
+  echo "Usage: omarchy-powerprofiles-platform <list|choices|get|set> [device] [profile]" >&2
+  exit 1
+}
+
+find_profile_dir() {
+  local requested_device="$1"
+  local candidate
+
+  [[ -d $profile_root ]] || return 1
+
+  for candidate in "$profile_root"/*; do
+    [[ -e $candidate ]] || continue
+    if [[ ${candidate##*/} == $requested_device && -r $candidate/name && -r $candidate/choices && -r $candidate/profile ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+list_profiles() {
+  local candidate device name profile
+
+  [[ -d $profile_root ]] || return 0
+
+  for candidate in "$profile_root"/*; do
+    [[ -r $candidate/name && -r $candidate/choices && -r $candidate/profile ]] || continue
+    device="${candidate##*/}"
+    name=$(<"$candidate/name")
+    profile=$(<"$candidate/profile")
+    name="${name//$'\t'/ }"
+    name="${name//$'\n'/ }"
+    printf '%s\t%s\t%s\n' "$device" "$name" "$profile"
+  done
+}
+
+action="${1:-}"
+
+case "$action" in
+  list)
+    (( $# == 1 )) || usage
+    list_profiles
+    ;;
+  choices | get)
+    (( $# == 2 )) || usage
+    profile_dir=$(find_profile_dir "$2") || {
+      echo "Platform profile device not found: $2" >&2
+      exit 1
+    }
+
+    if [[ $action == "choices" ]]; then
+      tr -s '[:space:]' '\n' <"$profile_dir/choices"
+    else
+      cat "$profile_dir/profile"
+    fi
+    ;;
+  set)
+    (( $# == 3 )) || usage
+    profile_dir=$(find_profile_dir "$2") || {
+      echo "Platform profile device not found: $2" >&2
+      exit 1
+    }
+
+    requested_profile="$3"
+    read -r -a available_profiles <"$profile_dir/choices"
+    profile_available=false
+    for profile in "${available_profiles[@]}"; do
+      if [[ $profile == $requested_profile ]]; then
+        profile_available=true
+        break
+      fi
+    done
+
+    if [[ $profile_available != "true" ]]; then
+      echo "Platform profile is not available on $2: $requested_profile" >&2
+      exit 1
+    fi
+
+    if [[ -w $profile_dir/profile ]]; then
+      printf '%s\n' "$requested_profile" >"$profile_dir/profile"
+    else
+      echo "Platform profile is not writable: $profile_dir/profile" >&2
+      exit 1
+    fi
+    ;;
+  *) usage ;;
+esac

--- a/default/udev/99-omarchy-platform-profile.rules
+++ b/default/udev/99-omarchy-platform-profile.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="platform-profile", ATTR{name}=="dell-pc", RUN+="/bin/chgrp wheel /sys/class/platform-profile/%k/profile"
+ACTION=="add", SUBSYSTEM=="platform-profile", ATTR{name}=="dell-pc", RUN+="/bin/chmod g+w /sys/class/platform-profile/%k/profile"

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -29,6 +29,7 @@ run_logged $OMARCHY_INSTALL/config/pi.sh
 run_logged $OMARCHY_INSTALL/config/omarchy-toggles.sh
 run_logged $OMARCHY_INSTALL/config/kernel-modules-hook.sh
 run_logged $OMARCHY_INSTALL/config/powerprofilesctl-rules.sh
+run_logged $OMARCHY_INSTALL/config/platform-profile-rules.sh
 run_logged $OMARCHY_INSTALL/config/wifi-powersave-rules.sh
 run_logged $OMARCHY_INSTALL/config/plocate-ac-only.sh
 

--- a/install/config/platform-profile-rules.sh
+++ b/install/config/platform-profile-rules.sh
@@ -1,0 +1,4 @@
+sudo cp "$OMARCHY_PATH/default/udev/99-omarchy-platform-profile.rules" /etc/udev/rules.d/
+
+sudo udevadm control --reload-rules
+sudo udevadm trigger --action=add --subsystem-match=platform-profile

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -1,0 +1,3 @@
+echo "Allow Dell power profile changes without repeated authentication"
+
+source "$OMARCHY_PATH/install/config/platform-profile-rules.sh"

--- a/test/omarchy-cli-test.sh
+++ b/test/omarchy-cli-test.sh
@@ -217,6 +217,37 @@ pass "all executable bins have slim self-documenting metadata"
 TMPDIR=$(mktemp -d)
 ln -s "$CLI" "$TMPDIR/omarchy"
 
+platform_profile_root="$TMPDIR/platform-profile"
+mkdir -p "$platform_profile_root/platform-profile-0" "$platform_profile_root/platform-profile-1"
+printf '%s\n' "SoC Power Slider" >"$platform_profile_root/platform-profile-0/name"
+printf '%s\n' "low-power balanced performance" >"$platform_profile_root/platform-profile-0/choices"
+printf '%s\n' "balanced" >"$platform_profile_root/platform-profile-0/profile"
+printf '%s\n' "dell-pc" >"$platform_profile_root/platform-profile-1/name"
+printf '%s\n' "cool quiet balanced performance" >"$platform_profile_root/platform-profile-1/choices"
+printf '%s\n' "quiet" >"$platform_profile_root/platform-profile-1/profile"
+
+output=$(OMARCHY_PLATFORM_PROFILE_ROOT="$TMPDIR/no-platform-profile" "$CLI" powerprofiles platform list)
+[[ -z $output ]] || fail "systems without platform profile devices return an empty list"
+pass "systems without platform profile devices return an empty list"
+
+output=$(OMARCHY_PLATFORM_PROFILE_ROOT="$platform_profile_root" "$CLI" powerprofiles platform list)
+assert_output_contains "platform profile devices are listed" "$output" $'platform-profile-1\tdell-pc\tquiet'
+
+output=$(OMARCHY_PLATFORM_PROFILE_ROOT="$platform_profile_root" "$CLI" powerprofiles platform choices platform-profile-1)
+assert_output_contains "platform profile choices are listed" "$output" "performance"
+
+output=$(OMARCHY_PLATFORM_PROFILE_ROOT="$platform_profile_root" "$CLI" powerprofiles platform get platform-profile-1)
+assert_output_contains "current platform profile is returned" "$output" "quiet"
+
+OMARCHY_PLATFORM_PROFILE_ROOT="$platform_profile_root" "$CLI" powerprofiles platform set platform-profile-1 cool
+[[ $(<"$platform_profile_root/platform-profile-1/profile") == "cool" ]] || fail "platform profile can be set"
+pass "platform profile can be set"
+
+if OMARCHY_PLATFORM_PROFILE_ROOT="$platform_profile_root" "$CLI" powerprofiles platform set platform-profile-1 low-power 2>/dev/null; then
+  fail "unavailable platform profile is rejected"
+fi
+pass "unavailable platform profile is rejected"
+
 {
   printf '#!/bin/bash\n\n'
   printf '# ordinary comments are fine\n'


### PR DESCRIPTION
## Summary

Expose Dell firmware power profiles in Setup > Power Profile when the kernel provides a `dell-pc` platform-profile controller.

Non-Dell systems continue using the existing power-profiles-daemon menu.

## Details

- Shows supported Dell modes in lower-to-higher power order: `quiet`, `cool`, `balanced`, `performance`
- Maps `quiet` and `cool` to OS `power-saver`, `balanced` to OS `balanced`, and `performance` to OS `performance`
- Adds `omarchy powerprofiles platform` for safely inspecting and changing kernel platform-profile controllers
- Validates the device and requested profile before writing to sysfs
- Adds a udev rule scoped to `dell-pc`, allowing members of `wheel` to change the profile without repeated authentication

## Migration

Installs the platform-profile udev rule, reloads udev, and applies it to existing platform-profile devices. The same setup is included for fresh installations.

## Testing

- `bash test/omarchy-cli-test.sh`
- `bin/omarchy commands --check`
- Bash syntax and diff checks
- `udevadm verify`
- Confirmed the udev rule matches `dell-pc` but not the separate SoC Power Slider controller

## Hardware test

Tested on a Dell XPS 16 DA16260:

- `quiet` -> OS `power-saver` / Dell `quiet`
- `cool` -> OS `power-saver` / Dell `cool`
- `balanced` -> OS `balanced` / Dell `balanced`
- `performance` -> OS `performance` / Dell `performance`
- Profile changes work without repeated authentication
- Original profile state restored after testing
