### PR TITLE
Fix slow pointer navigation with flat acceleration in Quattro

### DIFF
--- a/shell/Ui/PointerMoveGate.qml
+++ b/shell/Ui/PointerMoveGate.qml
@@ -2,20 +2,29 @@ import QtQuick
 
 // Filters synthetic hover churn from moving delegates under a stationary
 // pointer. Call reset() after keyboard/list mutations, then moved() from a
-// row MouseArea's onPositionChanged before changing cursor selection.
+// row MouseArea's onPositionChanged before changing cursor selection. A
+// transition known to originate from the pointer can call allowInitialSample()
+// so the item under the stationary pointer remains selected.
 QtObject {
   id: root
 
   property Item referenceItem: null
   property real threshold: 1
   property bool primed: false
+  property bool initialSampleAllowed: false
   property real lastX: 0
   property real lastY: 0
 
   function reset() {
     root.primed = false
+    root.initialSampleAllowed = false
     root.lastX = 0
     root.lastY = 0
+  }
+
+  function allowInitialSample() {
+    root.reset()
+    root.initialSampleAllowed = true
   }
 
   function moved(item, mouse) {
@@ -26,12 +35,19 @@ QtObject {
 
     var target = root.referenceItem || item
     var point = item.mapToItem(target, mouse.x, mouse.y)
-    var didMove = root.primed
-      && (Math.abs(point.x - root.lastX) > root.threshold || Math.abs(point.y - root.lastY) > root.threshold)
+    var firstSample = !root.primed
+    var didMove = !firstSample
+      ? Math.abs(point.x - root.lastX) > root.threshold || Math.abs(point.y - root.lastY) > root.threshold
+      : root.initialSampleAllowed
 
-    root.lastX = point.x
-    root.lastY = point.y
+    // Keep the previous accepted position while filtering jitter so slow,
+    // sub-threshold steps accumulate into deliberate pointer movement.
+    if (firstSample || didMove) {
+      root.lastX = point.x
+      root.lastY = point.y
+    }
     root.primed = true
+    root.initialSampleAllowed = false
 
     return didMove
   }

--- a/shell/plugins/launcher/Launcher.qml
+++ b/shell/plugins/launcher/Launcher.qml
@@ -74,11 +74,11 @@ Item {
       ? root.contentMargin * 2 + root.searchHeight + root.contentSpacing + requestedListHeight
       : 400
 
-    root.opened = true
     root.filterText = payload.query || ""
     root.selectedIndex = 0
     root.cursorActive = true
     root.disarmHover()
+    root.opened = true
     root.rebuildDisplay()
     // The shell may start before first-install packages have finished placing
     // their icons. Refresh here even when the desktop entry list did not change.
@@ -626,9 +626,14 @@ Item {
               }
 
               MouseArea {
+                id: mouseArea
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
+                onEntered: root.selectFromPointer(row.index, row, {
+                  x: mouseArea.mouseX,
+                  y: mouseArea.mouseY
+                })
                 onPositionChanged: function(mouse) {
                   root.selectFromPointer(row.index, row, mouse)
                 }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -519,14 +519,15 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory) {
+  function setActiveMenu(id, pushHistory, fromPointer) {
     if (!root.item(id)) id = "root"
     if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
     root.activeMenu = id
     root.filterText = ""
     root.selectedIndex = 0
     root.cursorActive = true
-    root.disarmPointer()
+    if (fromPointer) pointerGate.allowInitialSample()
+    else root.disarmPointer()
     root.rebuildDisplay()
     root.loadProviderForMenu(id)
   }
@@ -546,7 +547,7 @@ Item {
     return true
   }
 
-  function activateIndex(index) {
+  function activateIndex(index, fromPointer) {
     if (root.dmenuActive) {
       if (root.mode === "input") {
         root.applyDmenuSelection(root.filterText)
@@ -561,7 +562,7 @@ Item {
 
     var row = displayModel.get(index)
     if (row.kind === "menu" || row.kind === "link") {
-      root.setActiveMenu(row.target || row.itemId, true)
+      root.setActiveMenu(row.target || row.itemId, true, fromPointer)
     } else {
       root.applySelected(row.itemId, row.action)
     }
@@ -1042,13 +1043,17 @@ Item {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
+                onEntered: root.selectFromPointer(row.index, row, {
+                  x: mouseArea.mouseX,
+                  y: mouseArea.mouseY
+                })
                 onPositionChanged: function(mouse) {
                   root.selectFromPointer(row.index, row, mouse)
                 }
                 onClicked: {
                   root.cursorActive = true
                   root.selectedIndex = row.index
-                  root.activateIndex(row.index)
+                  root.activateIndex(row.index, true)
                 }
               }
             }

--- a/test/shell.d/fixtures/pointer-move-gate/shell.qml
+++ b/test/shell.d/fixtures/pointer-move-gate/shell.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import Quickshell
+import qs.Ui
+
+ShellRoot {
+  id: root
+
+  function fail(message) {
+    console.log("RESULT fail " + message)
+    Qt.quit()
+  }
+
+  function runChecks() {
+    if (gate.moved(row, { x: 2, y: 3 })) {
+      fail("the default initial sample was accepted")
+      return
+    }
+    if (gate.moved(row, { x: 3, y: 4 })) {
+      fail("threshold-sized jitter was accepted")
+      return
+    }
+    if (!gate.moved(row, { x: 5, y: 4 })) {
+      fail("real pointer movement was ignored")
+      return
+    }
+
+    gate.reset()
+    if (gate.moved(row, { x: 7, y: 8 })) {
+      fail("reset accepted its initial sample")
+      return
+    }
+    if (gate.moved(row, { x: 7.6, y: 8 })) {
+      fail("sub-threshold movement was accepted too early")
+      return
+    }
+    if (!gate.moved(row, { x: 8.2, y: 8 })) {
+      fail("slow cumulative movement was ignored")
+      return
+    }
+
+    gate.allowInitialSample()
+    if (!gate.moved(row, { x: 9, y: 10 })) {
+      fail("the explicitly allowed initial sample was ignored")
+      return
+    }
+    if (gate.moved(row, { x: 9, y: 10 })) {
+      fail("the initial sample exception was not consumed")
+      return
+    }
+
+    console.log("RESULT pass")
+    Qt.quit()
+  }
+
+  Component.onCompleted: Qt.callLater(runChecks)
+
+  Item {
+    id: card
+    width: 200
+    height: 200
+
+    Item {
+      id: row
+      x: 20
+      y: 30
+      width: 100
+      height: 40
+    }
+  }
+
+  PointerMoveGate {
+    id: gate
+    referenceItem: card
+  }
+}

--- a/test/shell.d/launcher-search-test.sh
+++ b/test/shell.d/launcher-search-test.sh
@@ -80,6 +80,13 @@ assert(
   /function disarmHover\(\)[\s\S]*pointerGate\.reset\(\)/.test(launcherQml),
   'launcher resets pointer movement gate when hover is disarmed'
 )
+const openMatch = launcherQml.match(/function open\(payloadJson\) \{([\s\S]*?)\n  \}/)
+assert(openMatch, 'launcher open function exists')
+assert(
+  openMatch[1].indexOf('root.disarmHover()') < openMatch[1].indexOf('root.opened = true')
+    && !openMatch[1].includes('pointerGate.allowInitialSample()'),
+  'launcher ignores a stale hidden-pointer position when becoming visible'
+)
 assert(
   /function selectFromPointer\(index, item, mouse\)[\s\S]*pointerGate\.moved\(item, mouse\)[\s\S]*root\.selectedIndex = index/.test(launcherQml),
   'launcher only selects from pointer after real movement'
@@ -87,6 +94,10 @@ assert(
 assert(
   /onPositionChanged: function\(mouse\) \{\s*root\.selectFromPointer\(row\.index, row, mouse\)\s*\}/.test(launcherQml),
   'launcher row hover routes through pointer movement gate'
+)
+assert(
+  /onEntered: root\.selectFromPointer\(row\.index, row, \{\s*x: mouseArea\.mouseX,\s*y: mouseArea\.mouseY\s*\}\)/.test(launcherQml),
+  'launcher samples pointer movement immediately when entering a row'
 )
 assert(
   !/onContainsMouseChanged:[\s\S]*root\.selectedIndex/.test(launcherQml),
@@ -127,8 +138,6 @@ assert(
   'launcher prefers indexed app icons over ambiguous themed icons'
 )
 
-const openMatch = launcherQml.match(/function open\(payloadJson\) \{([\s\S]*?)\n  \}/)
-assert(openMatch, 'launcher open function exists')
 assert(
   openMatch[1].includes('if (!iconIndexScan.running) iconIndexScan.running = true'),
   'launcher refreshes its icon index when opened'

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -173,8 +173,8 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory\)[\s\S]*root\.disarmPointer\(\)/.test(menuQml),
-  'menu route changes disarm pointer selection'
+  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
@@ -188,6 +188,15 @@ assert(
   /function disarmPointer\(\)[\s\S]*pointerGate\.reset\(\)/.test(menuQml),
   'menu resets pointer movement gate when pointer selection is disarmed'
 )
+for (const functionName of ['openExistingMenu', 'openDmenu']) {
+  const openMatch = menuQml.match(new RegExp(`function ${functionName}\\([^)]*\\) \\{([\\s\\S]*?)\\n  \\}`))
+  assert(openMatch, `menu ${functionName} function exists`)
+  assert(
+    openMatch[1].indexOf('root.disarmPointer()') < openMatch[1].indexOf('opened = true')
+      && !openMatch[1].includes('pointerGate.allowInitialSample()'),
+    `menu ${functionName} ignores a stale hidden-pointer position when becoming visible`
+  )
+}
 assert(
   /function selectFromPointer\(index, item, mouse\)[\s\S]*pointerGate\.moved\(item, mouse\)[\s\S]*root\.selectedIndex = index/.test(menuQml),
   'menu only selects from pointer after real movement'
@@ -195,5 +204,14 @@ assert(
 assert(
   /onPositionChanged: function\(mouse\) \{\s*root\.selectFromPointer\(row\.index, row, mouse\)\s*\}/.test(menuQml),
   'menu row hover routes through pointer movement gate'
+)
+assert(
+  /onEntered: root\.selectFromPointer\(row\.index, row, \{\s*x: mouseArea\.mouseX,\s*y: mouseArea\.mouseY\s*\}\)/.test(menuQml),
+  'menu samples pointer movement immediately when entering a row'
+)
+assert(
+  /function activateIndex\(index, fromPointer\)[\s\S]*root\.setActiveMenu\(row\.target \|\| row\.itemId, true, fromPointer\)/.test(menuQml)
+    && /onClicked:[\s\S]*root\.activateIndex\(row\.index, true\)/.test(menuQml),
+  'mouse activation carries pointer intent into subordinate menus'
 )
 JS

--- a/test/shell.d/pointer-move-gate-test.sh
+++ b/test/shell.d/pointer-move-gate-test.sh
@@ -26,11 +26,50 @@ assert(
   'pointer movement gate can be disarmed after keyboard or list changes'
 )
 assert(
+  /function reset\(\)[\s\S]*root\.initialSampleAllowed = false/.test(gateQml),
+  'reset keeps the initial pointer sample ignored by default'
+)
+assert(
+  /function allowInitialSample\(\)[\s\S]*root\.reset\(\)[\s\S]*root\.initialSampleAllowed = true/.test(gateQml),
+  'pointer-initiated transitions can opt in to the initial pointer sample'
+)
+assert(
   /item\.mapToItem\(target, mouse\.x, mouse\.y\)/.test(gateQml),
   'pointer movement gate compares movement in stable target coordinates'
 )
 assert(
-  /var didMove = root\.primed[\s\S]*Math\.abs\(point\.x - root\.lastX\) > root\.threshold[\s\S]*Math\.abs\(point\.y - root\.lastY\) > root\.threshold/.test(gateQml),
-  'pointer movement gate only reports real movement after an initial sample'
+  /var didMove = !firstSample[\s\S]*Math\.abs\(point\.x - root\.lastX\) > root\.threshold[\s\S]*Math\.abs\(point\.y - root\.lastY\) > root\.threshold[\s\S]*root\.initialSampleAllowed/.test(gateQml),
+  'pointer movement gate reports real movement or an explicitly allowed initial sample'
+)
+assert(
+  /if \(firstSample \|\| didMove\) \{\s*root\.lastX = point\.x\s*root\.lastY = point\.y\s*\}/.test(gateQml),
+  'sub-threshold pointer movement accumulates from the last accepted sample'
+)
+assert(
+  /root\.primed = true\s*root\.initialSampleAllowed = false/.test(gateQml),
+  'the initial pointer sample exception is consumed once'
 )
 JS
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping pointer movement gate runtime test"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+cp "$SHELL_TEST_DIR/fixtures/pointer-move-gate/shell.qml" "$test_tmp/shell.qml"
+ln -s "$ROOT/shell/Ui" "$test_tmp/Ui"
+
+output=$(timeout 15 quickshell -p "$test_tmp" --no-color 2>&1) || {
+  printf '%s\n' "$output" >&2
+  fail "pointer movement gate runtime fixture exits cleanly"
+}
+
+if ! grep -q "RESULT pass" <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail "pointer movement gate runtime behavior is correct"
+fi
+
+pass "pointer movement gate runtime behavior is correct"


### PR DESCRIPTION
# Fix slow pointer navigation with flat acceleration in Quattro

## Summary

With Hyprland's `input.accel_profile` set to `flat`, slow pointer movement in Quattro's native launcher and Omarchy menu could leave the highlight behind the cursor. On the tested hardware, Omarchy's default `adaptive` profile produced large enough event deltas to mask the problem.

The pointer gate compared each event with the immediately preceding event, so every sub-threshold event replaced the movement reference point. As a result, a stream of small movements could be ignored indefinitely. Testing the affected paths also exposed two related pointer-selection inconsistencies:

- Entering a contiguous launcher row could wait for another position event before updating the highlight.
- Clicking into a subordinate menu discarded the fact that navigation came from the pointer and always highlighted its first row.

This change makes pointer selection responsive while keeping keyboard behavior predictable:

- Accumulate small movements from the last accepted pointer sample, so slow motion crosses the jitter threshold normally.
- Sample pointer coordinates on row entry as well as position changes, while still using stable card coordinates to reject stationary delegate churn.
- Carry pointer intent through mouse-opened subordinate menus, without changing keyboard-opened route behavior.
- Keep newly opened launcher/menu surfaces on the first row until genuine pointer movement occurs, avoiding selection from a stale hidden cursor position.

## Before

https://github.com/user-attachments/assets/d10ff284-7aed-4174-bf2e-5804b7f83881

## After

https://github.com/user-attachments/assets/61bd9740-5f6a-441c-8cfb-895d7108c790

## Testing

- `qmllint shell/Ui/PointerMoveGate.qml shell/plugins/launcher/Launcher.qml shell/plugins/menu/Menu.qml test/shell.d/fixtures/pointer-move-gate/shell.qml`
- `bash test/shell.d/pointer-move-gate-test.sh`
- `bash test/shell.d/launcher-search-test.sh`
- `bash test/shell.d/menu-test.sh`
- `bash test/shell.d/clipboard-test.sh`
- `bash test/shell.d/manifest-entrypoints-test.sh`
- Manually verified slow pointer movement and row-boundary transitions in `SUPER+SPACE`.
- Manually verified mouse- and keyboard-opened subordinate menus in `SUPER+ALT+SPACE`.
- Manually verified that a keyboard-opened launcher ignores the stale position of a hidden cursor.

### Acceleration profile comparison

| Version | `flat` | `adaptive`, sensitivity `0` |
| --- | --- | --- |
| Before this change | Reproduced | Not reproduced |
| With this change | Not reproduced | Not reproduced |
