### PR TITLE
Expose Dell firmware profiles in Quickshell power menus

### DIFF
--- a/bin/omarchy-powerprofiles-list
+++ b/bin/omarchy-powerprofiles-list
@@ -3,13 +3,58 @@
 # omarchy:summary=Returns a list of all the available power profiles on the system.
 # omarchy:args=[--active-state]
 
-if [[ ${1:-} != "" && ${1:-} != "--active-state" ]]; then
+option="${1:-}"
+
+if [[ $option != "" && $option != "--active-state" ]]; then
   echo "Usage: omarchy-powerprofiles-list [--active-state]" >&2
   exit 1
 fi
 
-powerprofilesctl list 2>/dev/null |
-  awk -v with_state="${1:+1}" '/^\s*[* ]\s*[a-zA-Z0-9-]+:$/ {
+os_profile_output=$(powerprofilesctl list 2>/dev/null)
+
+os_profile_available() {
+  grep -Eq "^[*[:space:]]+$1:$" <<<"$os_profile_output"
+}
+
+dell_profile_dir=""
+profile_root="${OMARCHY_PLATFORM_PROFILE_ROOT:-/sys/class/platform-profile}"
+for profile_dir in "$profile_root"/*; do
+  [[ -r $profile_dir/name && -r $profile_dir/choices && -r $profile_dir/profile && -w $profile_dir/profile ]] || continue
+  if [[ $(<"$profile_dir/name") == "dell-pc" ]]; then
+    dell_profile_dir="$profile_dir"
+    break
+  fi
+done
+
+if [[ -n $dell_profile_dir ]]; then
+  current=$(<"$dell_profile_dir/profile")
+  current_os=""
+  if [[ $option == "--active-state" ]]; then
+    current_os=$(powerprofilesctl get 2>/dev/null)
+  fi
+  read -r -a available_profiles <"$dell_profile_dir/choices"
+
+  for profile in quiet cool balanced performance; do
+    [[ " ${available_profiles[*]} " == *" $profile "* ]] || continue
+    case "$profile" in
+      quiet | cool) os_profile=power-saver ;;
+      *) os_profile="$profile" ;;
+    esac
+    os_profile_available "$os_profile" || continue
+
+    if [[ $option == "--active-state" ]]; then
+      active=0
+      [[ $profile == $current && $os_profile == $current_os ]] && active=1
+      printf '%s\t%s\n' "$profile" "$active"
+    else
+      printf '%s\n' "$profile"
+    fi
+  done
+  exit 0
+fi
+
+printf '%s\n' "$os_profile_output" |
+  awk -v with_state="${option:+1}" '/^\s*[* ]\s*[a-zA-Z0-9-]+:$/ {
     active = ($1 == "*") ? 1 : 0
     gsub(/^[*[:space:]]+|:$/, "")
     print $0 (with_state ? "\t" active : "")

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # omarchy:summary=Set and remember the power profile for AC or battery use
-# omarchy:args=[autodetect|ac|battery] [power-saver|balanced|performance]
+# omarchy:args=[autodetect|ac|battery] [quiet|cool|power-saver|balanced|performance]
 
 action="${1:-autodetect}"
 requested_profile="${2:-}"
 
 usage() {
-  echo "Usage: omarchy-powerprofiles-set [autodetect|ac|battery] [power-saver|balanced|performance]" >&2
+  echo "Usage: omarchy-powerprofiles-set [autodetect|ac|battery] [quiet|cool|power-saver|balanced|performance]" >&2
   exit 1
 }
 
@@ -45,6 +45,9 @@ if [[ -n $requested_profile ]]; then
   profile="$requested_profile"
 elif [[ -r $state_file ]]; then
   profile=$(<"$state_file")
+  if [[ $profile == "power-saver" ]] && profile_available quiet; then
+    profile=quiet
+  fi
 fi
 
 if [[ -z ${profile:-} ]] || ! profile_available "$profile"; then
@@ -55,7 +58,60 @@ if [[ -z ${profile:-} ]] || ! profile_available "$profile"; then
   fi
 fi
 
-powerprofilesctl set "$profile" || exit
+dell_profile_dir=""
+profile_root="${OMARCHY_PLATFORM_PROFILE_ROOT:-/sys/class/platform-profile}"
+for profile_dir in "$profile_root"/*; do
+  [[ -r $profile_dir/name && -r $profile_dir/choices && -r $profile_dir/profile && -w $profile_dir/profile ]] || continue
+  if [[ $(<"$profile_dir/name") == "dell-pc" ]]; then
+    dell_profile_dir="$profile_dir"
+    break
+  fi
+done
+
+os_profile="$profile"
+if [[ -n $dell_profile_dir ]]; then
+  case "$profile" in
+    quiet | cool) os_profile=power-saver ;;
+    balanced | performance) ;;
+    *) os_profile=balanced ;;
+  esac
+fi
+
+set_os_profile() {
+  local target="$1"
+  local attempt
+
+  # Multiple platform-profile controllers can make PPD settle one profile
+  # level per request, such as performance -> balanced -> power-saver.
+  for (( attempt = 0; attempt < 3; attempt++ )); do
+    powerprofilesctl set "$target" || return 1
+    [[ $(powerprofilesctl get 2>/dev/null) == "$target" ]] && return 0
+  done
+
+  echo "OS power profile did not settle: $target" >&2
+  return 1
+}
+
+previous_os_profile=""
+if [[ -n $dell_profile_dir ]]; then
+  previous_os_profile=$(powerprofilesctl get 2>/dev/null)
+  [[ -n $previous_os_profile ]] || { echo "Unable to read the current OS power profile" >&2; exit 1; }
+  if ! set_os_profile "$os_profile"; then
+    set_os_profile "$previous_os_profile" >/dev/null 2>&1 || true
+    exit 1
+  fi
+else
+  powerprofilesctl set "$os_profile" || exit
+fi
+
+if [[ -n $dell_profile_dir && $(<"$dell_profile_dir/profile") != $profile ]]; then
+  if ! printf '%s\n' "$profile" >"$dell_profile_dir/profile"; then
+    if [[ -n $previous_os_profile ]]; then
+      set_os_profile "$previous_os_profile" >/dev/null 2>&1 || true
+    fi
+    exit 1
+  fi
+fi
 
 if [[ -n $requested_profile ]]; then
   mkdir -p "$state_dir"

--- a/etc/udev/rules.d/99-omarchy-dell-platform-profile.rules
+++ b/etc/udev/rules.d/99-omarchy-dell-platform-profile.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="platform-profile", ATTR{name}=="dell-pc", RUN+="/usr/bin/chgrp wheel /sys/class/platform-profile/%k/profile"
+ACTION=="add", SUBSYSTEM=="platform-profile", ATTR{name}=="dell-pc", RUN+="/usr/bin/chmod g+w /sys/class/platform-profile/%k/profile"

--- a/install/post-install/udev.sh
+++ b/install/post-install/udev.sh
@@ -1,3 +1,4 @@
 # Apply package-owned udev rules for the live install session when possible.
 udevadm control --reload 2>/dev/null || true
 udevadm trigger --subsystem-match=power_supply 2>/dev/null || true
+udevadm trigger --action=add --subsystem-match=platform-profile 2>/dev/null || true

--- a/migrations/1784755941.sh
+++ b/migrations/1784755941.sh
@@ -1,0 +1,12 @@
+echo "Enable Dell firmware power profiles without a reboot"
+
+for profile_dir in /sys/class/platform-profile/*; do
+  [[ -r $profile_dir/name && -r $profile_dir/profile ]] || continue
+  [[ $(<"$profile_dir/name") == "dell-pc" ]] || continue
+  if [[ ! -w $profile_dir/profile ]]; then
+    pkexec /bin/bash -c \
+      '/usr/bin/udevadm control --reload && /usr/bin/udevadm trigger --settle --action=add --subsystem-match=platform-profile'
+    [[ -w $profile_dir/profile ]] || { echo "Dell power profile is still not writable" >&2; exit 1; }
+  fi
+  break
+done

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -226,7 +226,7 @@ Item {
       keywordsFor: function(value) { return value + " typeface" }
     },
     "power-profiles": {
-      script: "current=$(powerprofilesctl get 2>/dev/null); omarchy-powerprofiles-list 2>/dev/null | while read -r p; do [[ -z $p ]] && continue; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
+      script: "omarchy-powerprofiles-list --active-state 2>/dev/null | while read -r p active; do [[ -z $p ]] && continue; current=; if [[ $active == 1 ]]; then current=$p; fi; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
       icon: "\udb81\udc0b",
       actionFor: function(value) { return "omarchy-powerprofiles-set autodetect '" + value.replace(/'/g, "'\\''") + "'" },
       keywordsFor: function(value) { return value + " power profile" }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -3,12 +3,6 @@ function clampIndex(index, length) {
   return Math.max(0, Math.min(length - 1, index))
 }
 
-function selectProfileIndex(index, delta, profiles) {
-  var values = Array.isArray(profiles) ? profiles : []
-  if (values.length === 0) return 0
-  return clampIndex(index + delta, values.length)
-}
-
 function parseKeyValue(raw) {
   var next = {}
   var lines = String(raw || "").split("\n")
@@ -92,7 +86,6 @@ function modeLabel(device, onBattery, states) {
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
-    selectProfileIndex: selectProfileIndex,
     parseKeyValue: parseKeyValue,
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -16,6 +16,7 @@ Panel {
   property string activeProfile: ""
   property int profileIndex: 0
   property bool cursorActive: false
+  readonly property int profileColumns: profiles.length > 3 ? 2 : Math.max(1, profiles.length)
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -30,8 +31,11 @@ Panel {
     }
   }
 
-  function selectProfileByDelta(delta) {
-    profileIndex = Model.selectProfileIndex(profileIndex, delta, profiles)
+  function selectProfileByDirection(dx, dy) {
+    var next = profileIndex + (dx !== 0 ? dx : dy * profileColumns)
+    if (next < 0 || next >= profiles.length) return
+    if (dx !== 0 && Math.floor(next / profileColumns) !== Math.floor(profileIndex / profileColumns)) return
+    profileIndex = next
   }
 
   function activateSelectedProfile() {
@@ -273,8 +277,7 @@ Panel {
       anchors.fill: parent
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) { root.cursorActive = true; return }
-        if (dx !== 0) root.selectProfileByDelta(dx)
-        else if (dy !== 0) root.selectProfileByDelta(dy)
+        root.selectProfileByDirection(dx, dy)
       }
       onActivateRequested: if (root.cursorActive) root.activateSelectedProfile()
       onCloseRequested: root.close()
@@ -432,13 +435,15 @@ Panel {
             fontFamily: root.bar.fontFamily
           }
 
-          Row {
-            id: profileRow
+          Grid {
+            id: profileGrid
             width: parent.width
-            spacing: Style.space(6)
+            columns: root.profileColumns
+            columnSpacing: Style.space(6)
+            rowSpacing: Style.space(6)
 
             readonly property real cellWidth: root.profiles.length > 0
-              ? (width - spacing * (root.profiles.length - 1)) / root.profiles.length
+              ? (width - columnSpacing * (columns - 1)) / columns
               : 0
 
             Repeater {
@@ -446,7 +451,7 @@ Panel {
               Button {
                 required property var modelData
                 required property int index
-                width: profileRow.cellWidth
+                width: profileGrid.cellWidth
                 iconText: root.profileIcon(String(modelData))
                 iconSize: Style.font.title
                 text: String(modelData).charAt(0).toUpperCase() + String(modelData).slice(1)

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -8,9 +8,6 @@ run_node_test <<'JS'
 const power = requireFromRoot('shell/plugins/panels/power/Model.js')
 const states = { Charging: 1, Discharging: 2, FullyCharged: 3, PendingCharge: 4 }
 
-assertEqual(power.selectProfileIndex(0, 1, ['balanced', 'performance']), 1, 'power advances profile selection')
-assertEqual(power.selectProfileIndex(1, 1, ['balanced', 'performance']), 1, 'power clamps profile selection')
-
 assertDeepEqual(power.parseKeyValue('time\t2:00\nenergy\t42\n'), { time: '2:00', energy: '42' }, 'power parses key-value output')
 assertDeepEqual(
   power.parseProfiles('power-saver\t0\nbalanced\t1\nperformance\t0\n', 5),

--- a/test/shell.d/powerprofiles-dell-test.sh
+++ b/test/shell.d/powerprofiles-dell-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+profile_root="$tmp_dir/platform-profile"
+mkdir -p "$tmp_dir/bin" "$tmp_dir/state" "$profile_root/platform-profile-0" "$profile_root/platform-profile-1"
+
+printf '%s\n' "SoC Power Slider" >"$profile_root/platform-profile-0/name"
+printf '%s\n' "low-power balanced performance" >"$profile_root/platform-profile-0/choices"
+printf '%s\n' "balanced" >"$profile_root/platform-profile-0/profile"
+printf '%s\n' "dell-pc" >"$profile_root/platform-profile-1/name"
+printf '%s\n' "cool quiet balanced performance" >"$profile_root/platform-profile-1/choices"
+printf '%s\n' "quiet" >"$profile_root/platform-profile-1/profile"
+
+cat >"$tmp_dir/bin/powerprofilesctl" <<'EOF'
+#!/bin/bash
+
+if [[ $1 == "list" ]]; then
+  for profile in performance balanced power-saver; do
+    [[ $profile != "performance" || ${NO_PERFORMANCE:-0} == "0" ]] || continue
+    if [[ $(<"$POWERPROFILES_OS_STATE") == "$profile" ]]; then
+      printf '* %s:\n' "$profile"
+    else
+      printf '  %s:\n' "$profile"
+    fi
+  done
+elif [[ $1 == "get" ]]; then
+  cat "$POWERPROFILES_OS_STATE"
+elif [[ $1 == "set" ]]; then
+  printf '%s\n' "$2" >>"$POWERPROFILES_LOG"
+  if [[ ${POWERPROFILES_NEVER_SETTLE:-0} == "1" && $2 == "power-saver" ]]; then
+    printf '%s\n' "balanced" >"$POWERPROFILES_OS_STATE"
+  elif [[ ${POWERPROFILES_STEP_DOWN:-0} == "1" && $(<"$POWERPROFILES_OS_STATE") == "performance" && $2 == "power-saver" ]]; then
+    printf '%s\n' "balanced" >"$POWERPROFILES_OS_STATE"
+  else
+    printf '%s\n' "$2" >"$POWERPROFILES_OS_STATE"
+  fi
+fi
+EOF
+chmod +x "$tmp_dir/bin/powerprofilesctl"
+
+export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
+export POWERPROFILES_LOG="$tmp_dir/calls"
+export POWERPROFILES_OS_STATE="$tmp_dir/os-profile"
+export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
+export OMARCHY_PLATFORM_PROFILE_ROOT="$profile_root"
+printf '%s\n' "power-saver" >"$POWERPROFILES_OS_STATE"
+
+output=$("$ROOT/bin/omarchy-powerprofiles-list")
+[[ $output == $'quiet\ncool\nbalanced\nperformance' ]] || fail "Dell power profiles use the intended order"
+pass "Dell power profiles use the intended order"
+
+output=$("$ROOT/bin/omarchy-powerprofiles-list" --active-state)
+[[ $output == $'quiet\t1\ncool\t0\nbalanced\t0\nperformance\t0' ]] || fail "Dell power profiles report firmware state"
+pass "Dell power profiles report combined firmware and OS state"
+
+printf '%s\n' "balanced" >"$POWERPROFILES_OS_STATE"
+output=$("$ROOT/bin/omarchy-powerprofiles-list" --active-state)
+[[ $output == $'quiet\t0\ncool\t0\nbalanced\t0\nperformance\t0' ]] || fail "mismatched OS and firmware profiles are not reported as active"
+pass "Dell power profiles require matching firmware and OS state"
+printf '%s\n' "power-saver" >"$POWERPROFILES_OS_STATE"
+
+output=$(NO_PERFORMANCE=1 "$ROOT/bin/omarchy-powerprofiles-list")
+[[ $output == $'quiet\ncool\nbalanced' ]] || fail "Dell modes require their mapped OS profile"
+pass "Dell modes are limited to available OS profiles"
+
+printf '%s\n' "power-saver" >"$tmp_dir/state/battery"
+"$ROOT/bin/omarchy-powerprofiles-set" battery
+[[ $(<"$POWERPROFILES_OS_STATE") == "power-saver" ]] || fail "saved OS power-saver keeps its OS profile"
+[[ $(<"$profile_root/platform-profile-1/profile") == "quiet" ]] || fail "saved OS power-saver becomes Dell quiet"
+pass "existing power-saver preferences map to Dell quiet"
+
+for mapping in "quiet power-saver" "cool power-saver" "balanced balanced" "performance performance"; do
+  read -r dell_profile os_profile <<<"$mapping"
+  "$ROOT/bin/omarchy-powerprofiles-set" ac "$dell_profile"
+  [[ $(tail -n 1 "$POWERPROFILES_LOG") == $os_profile ]] || fail "$dell_profile selects OS $os_profile"
+  [[ $(<"$POWERPROFILES_OS_STATE") == $os_profile ]] || fail "$dell_profile updates the OS profile"
+  [[ $(<"$profile_root/platform-profile-1/profile") == $dell_profile ]] || fail "$dell_profile selects the Dell firmware profile"
+  [[ $(<"$tmp_dir/state/ac") == $dell_profile ]] || fail "$dell_profile is remembered"
+  active_profile=$("$ROOT/bin/omarchy-powerprofiles-list" --active-state | awk '$2 == 1 { print $1 }')
+  [[ $active_profile == $dell_profile ]] || fail "$dell_profile reports the combined mode as active"
+  pass "$dell_profile maps and persists correctly"
+done
+
+if "$ROOT/bin/omarchy-powerprofiles-set" ac power-saver 2>/dev/null; then
+  fail "Dell profile selection rejects hidden OS profiles"
+fi
+pass "Dell profile selection rejects hidden OS profiles"
+
+if POWERPROFILES_NEVER_SETTLE=1 "$ROOT/bin/omarchy-powerprofiles-set" ac quiet 2>/dev/null; then
+  fail "Dell profile selection reports an OS profile that does not settle"
+fi
+[[ $(<"$POWERPROFILES_OS_STATE") == "performance" ]] || fail "failed OS profile selection restores the previous OS profile"
+[[ $(<"$profile_root/platform-profile-1/profile") == "performance" ]] || fail "failed OS profile selection preserves Dell firmware"
+[[ $(<"$tmp_dir/state/ac") == "performance" ]] || fail "failed OS profile selection preserves the preference"
+pass "Dell profile selection rolls back an OS profile that does not settle"
+
+call_count=$(wc -l <"$POWERPROFILES_LOG")
+POWERPROFILES_STEP_DOWN=1 "$ROOT/bin/omarchy-powerprofiles-set" ac quiet
+[[ $(wc -l <"$POWERPROFILES_LOG") == $(( call_count + 2 )) ]] || fail "Dell profile selection waits for the OS profile to settle"
+[[ $(<"$POWERPROFILES_OS_STATE") == "power-saver" ]] || fail "stepped OS profile reaches power-saver"
+[[ $(<"$profile_root/platform-profile-1/profile") == "quiet" ]] || fail "stepped OS profile reaches Dell quiet"
+pass "Dell profile selection converges stepped OS profile changes"
+
+chmod 444 "$profile_root/platform-profile-1/profile"
+output=$("$ROOT/bin/omarchy-powerprofiles-list")
+[[ $output == $'power-saver\nbalanced\nperformance' ]] || fail "unwritable Dell profiles fall back to OS profiles"
+"$ROOT/bin/omarchy-powerprofiles-set" ac power-saver
+[[ $(<"$POWERPROFILES_OS_STATE") == "power-saver" ]] || fail "OS profiles remain selectable when Dell firmware is not writable"
+[[ $(<"$profile_root/platform-profile-1/profile") == "quiet" ]] || fail "OS fallback does not change Dell firmware"
+pass "unwritable Dell profiles preserve the standard OS controls"

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -7,7 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 
-mkdir -p "$tmp_dir/bin" "$tmp_dir/state"
+mkdir -p "$tmp_dir/bin" "$tmp_dir/state" "$tmp_dir/platform-profile"
 
 cat >"$tmp_dir/bin/powerprofilesctl" <<'EOF'
 #!/bin/bash
@@ -35,6 +35,7 @@ chmod +x "$tmp_dir/bin/busctl"
 export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
 export POWERPROFILES_LOG="$tmp_dir/calls"
 export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
+export OMARCHY_PLATFORM_PROFILE_ROOT="$tmp_dir/platform-profile"
 
 "$ROOT/bin/omarchy-powerprofiles-set" ac balanced
 [[ $(<"$tmp_dir/state/ac") == "balanced" ]] || fail "power profile stores AC preference"
@@ -80,3 +81,7 @@ pass "battery service applies profiles through Omarchy command"
 rg -F 'omarchy-powerprofiles-set autodetect' "$ROOT/shell/plugins/menu/Menu.qml" >/dev/null ||
   fail "power profile menu persists selections through Omarchy command"
 pass "power profile menu persists selections through Omarchy command"
+
+rg -F 'omarchy-powerprofiles-list --active-state' "$ROOT/shell/plugins/menu/Menu.qml" >/dev/null ||
+  fail "power profile menu reads active state through Omarchy command"
+pass "power profile menu reads active state through Omarchy command"


### PR DESCRIPTION
## Summary

- expose supported `dell-pc` firmware modes as `quiet`, `cool`, `balanced`, and `performance` in the Quickshell power panel and menu provider
- pair `quiet` and `cool` with OS `power-saver`, while `balanced` and `performance` use their matching OS profiles
- preserve the existing power-profiles-daemon controls when no writable Dell controller is available
- add a Dell-scoped udev rule so `wheel` users can switch modes without repeated authentication
- use a 2x2 picker when four modes are present, while retaining the existing single-row layout for three modes

This reworks #6341 for the `quattro` branch without adding another public helper command.

## Why

Dell's firmware thermal modes are separate from the OS power profile. `quiet` materially reduces fan noise, while `cool` uses a more aggressive fan policy to keep the chassis cooler. Pairing both layers gives every menu choice a predictable result.

## Profiles

| Menu choice | OS profile | Dell firmware profile |
| --- | --- | --- |
| `quiet` | `power-saver` | `quiet` |
| `cool` | `power-saver` | `cool` |
| `balanced` | `balanced` | `balanced` |
| `performance` | `performance` | `performance` |

The active marker requires both layers to match. Existing saved `power-saver` preferences become `quiet` when Dell modes activate.

On the test machine, power-profiles-daemon can step from `performance` through `balanced` before reaching `power-saver` because two platform-profile controllers are present. The setter verifies convergence with a bounded retry and restores the previous OS profile if convergence or the firmware write fails.

## Testing

- `./test/cli`
- `bash test/shell.d/powerprofiles-dell-test.sh`
- `bash test/shell.d/powerprofiles-set-test.sh`
- `bash test/shell.d/power-test.sh`
- Bash syntax and `git diff --check`
- `udevadm verify --no-style etc/udev/rules.d/99-omarchy-dell-platform-profile.rules`
- verified the rule matches `dell-pc`, not the separate SoC Power Slider controller
- verified all four mappings without authentication prompts on a Dell XPS 16 DA16260
- verified keyboard selection and the running 2x2 Quickshell layout; restored `quiet` afterward

`./test/shell` reaches the existing `bin-style-test.sh` failure for unchanged `bin/omarchy-display-text-size`; the focused shell tests above pass.
