### PR TITLE
Fix infinite loop in omarchy-mise-install wrappers

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -17,7 +17,7 @@ mkdir -p "$HOME/.local/bin"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 mise use -g "$package"
-exec "$bin" "\$@"
+exec mise exec "$package" -- "$bin" "\$@"
 EOF
 
 chmod +x "$HOME/.local/bin/$command"

--- a/migrations/1784909971.sh
+++ b/migrations/1784909971.sh
@@ -1,0 +1,12 @@
+echo "Regenerate mise wrappers to stop them recursing through PATH"
+
+for wrapper in "$HOME/.local/bin"/*; do
+  [[ -f $wrapper && -x $wrapper ]] || continue
+
+  package=$(sed -n 's/^mise use -g "\(.*\)"$/\1/p' "$wrapper")
+  bin=$(sed -n 's/^exec "\(.*\)" "\$@"$/\1/p' "$wrapper")
+
+  if [[ -n $package && -n $bin ]]; then
+    omarchy-mise-install "$package" "$(basename "$wrapper")" "$bin"
+  fi
+done


### PR DESCRIPTION
Fixes #6349.

The wrapper generated by `omarchy-mise-install` ended with `exec "$bin" "$@"`, which resolves `$bin` by name through PATH. When `~/.local/bin` precedes mise's `installs/<tool>/latest` — e.g. when starship/zoxide clobber mise's `PROMPT_COMMAND` hook (#3685), or transiently at fresh-shell startup — `exec "$bin"` re-finds the wrapper itself and recurses forever, spamming the `mise use` line and never launching the tool.

This execs through `mise exec "$package"` instead, so the tool resolves from mise's install dir rather than by name. Scoping to `$package` keeps lazy install working and avoids leaking other runtimes into the tool's PATH.

```diff
-exec "$bin" "$@"
+exec mise exec "$package" -- "$bin" "$@"
```

Verified the regenerated wrappers launch correctly (both plain tools and backend-prefixed packages like `npm:@kitlangton/ghui`) under the recursion-triggering PATH.

