### PR TITLE
Respect internal monitor config in clamshell recovery

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -30,11 +30,22 @@ configured_monitor_scale() {
   local monitor_lua="$HOME/.config/hypr/monitors.lua"
   [[ -f $monitor_lua ]] || return 0
   local scale
-  scale=$(sed -n 's/^local omarchy_monitor_scale = //p' "$monitor_lua" | head -1)
+  scale=$(configured_internal_monitor_value scale)
+  if [[ -z $scale ]]; then
+    scale=$(sed -n 's/^local omarchy_monitor_scale = //p' "$monitor_lua" | head -1)
+  fi
   if [[ -z $scale ]]; then
     scale=$(sed -nE 's/^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ([^ ]+) \}\)/\1/p' "$monitor_lua" | head -1)
   fi
   echo "$scale"
+}
+
+configured_internal_monitor_value() {
+  local key="$1"
+  local monitor_lua="$HOME/.config/hypr/monitors.lua"
+  [[ -n $INTERNAL && -f $monitor_lua ]] || return 0
+
+  sed -nE '/^hl\.monitor\(\{.*output = "'"$INTERNAL"'".*\}\)/s/.*'"$key"' = "?([^", }]+)"?.*/\1/p' "$monitor_lua" | head -1
 }
 
 current_internal_scale() {
@@ -75,11 +86,24 @@ read_monitor_scale() {
   echo 2
 }
 
+read_monitor_position() {
+  local position
+  position=$(configured_internal_monitor_value position)
+  if [[ $position =~ ^[-[:alnum:]_.+]+$ ]]; then
+    echo "$position"
+    return
+  fi
+
+  echo auto
+}
+
 enable_internal_output() {
   [[ -n $INTERNAL ]] || return 0
   local scale="${1:-}"
+  local position
   [[ -n $scale ]] || scale=$(read_monitor_scale)
-  hyprctl eval "hl.monitor({ output = \"$INTERNAL\", mode = \"preferred\", position = \"auto\", scale = $scale })" >/dev/null 2>&1 || true
+  position=$(read_monitor_position)
+  hyprctl eval "hl.monitor({ output = \"$INTERNAL\", mode = \"preferred\", position = \"$position\", scale = $scale })" >/dev/null 2>&1 || true
 }
 
 sync_internal_scale() {

--- a/test/shell.d/monitor-clamshell-scale-test.sh
+++ b/test/shell.d/monitor-clamshell-scale-test.sh
@@ -65,6 +65,13 @@ local omarchy_monitor_scale = "auto"
 LUA
 }
 
+write_internal_monitor_config() {
+  cat >"$monitor_lua" <<'LUA'
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "0x0", scale = 1.25 })
+hl.monitor({ output = "", mode = "preferred", position = "auto-right", scale = 1 })
+LUA
+}
+
 run_clamshell() {
   HOME="$home_dir" \
     PATH="$stub_bin:$PATH" \
@@ -102,3 +109,10 @@ OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
 grep -F 'scale = 1.6' "$eval_log" >/dev/null || fail "clamshell recovery uses remembered internal scale"
 ! grep -F 'scale = "auto"' "$eval_log" >/dev/null || fail "clamshell recovery avoids auto after disabled internal display"
 pass "clamshell recovery uses remembered internal scale"
+
+write_internal_monitor_config
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
+grep -F 'position = "0x0"' "$eval_log" >/dev/null || fail "clamshell recovery uses configured internal position"
+grep -F 'scale = 1.25' "$eval_log" >/dev/null || fail "clamshell recovery uses configured internal scale"
+pass "clamshell recovery uses configured internal monitor rule"


### PR DESCRIPTION
## Summary
- parse explicit internal monitor rules from ~/.config/hypr/monitors.lua before falling back to omarchy_monitor_scale
- preserve the configured internal monitor position when re-enabling the panel after clamshell recovery
- add regression coverage for configured internal scale and position

## Tests
- bash test/shell.d/monitor-clamshell-scale-test.sh
- bash -n bin/omarchy-hyprland-monitor-clamshell test/shell.d/monitor-clamshell-scale-test.sh