### PR TITLE
Treat gamepad input as Quickshell idle activity

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -127,6 +127,9 @@ Rules:
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
 8. `version: 1` is required.
 
+The built-in idle service treats gamepad button presses and meaningful axis
+movement as user activity. Small analog-axis drift is ignored.
+
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user
 customizes, `shell.json` is canonical — there is no deep-merge.

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -101,6 +101,7 @@ plocate
 plymouth
 postgresql-libs
 power-profiles-daemon
+python-evdev
 python-gobject
 python-poetry-core
 python-terminaltexteffects

--- a/migrations/1784797312.sh
+++ b/migrations/1784797312.sh
@@ -1,0 +1,3 @@
+echo "Install gamepad activity support"
+
+omarchy-pkg-add python-evdev

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -10,6 +10,7 @@ Item {
 
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
 
   readonly property string home: Quickshell.env("HOME")
   readonly property string stayAwakeStateDir: home + "/.local/state/omarchy/indicators"
@@ -31,6 +32,7 @@ Item {
   property bool pendingStayAwakePersist: false
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
+  property bool idleResetPending: false
   property string lastEvent: "starting"
   property string lastEventAt: ""
   property var screensaverWindows: ({})
@@ -177,6 +179,17 @@ Item {
     else handleActiveSignal()
   }
 
+  function registerActivity(source) {
+    if (!root.idleEnabled) return false
+
+    if (root.idledThisCycle) root.cancelIdleCycle((source || "external") + "-activity")
+
+    // Recreating the ext-idle-notify subscription starts a fresh countdown.
+    root.idleResetPending = true
+    idleResetTimer.restart()
+    return true
+  }
+
   function statusJson() {
     return JSON.stringify({
       enabled: root.idleEnabled,
@@ -192,11 +205,14 @@ Item {
       lockDelay: root.lockDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
+        idleReset: idleResetTimer.running,
         screensaver: screensaverTimer.running,
         lock: lockTimer.running,
-        screensaverLaunchGrace: screensaverLaunchGraceTimer.running
+        screensaverLaunchGrace: screensaverLaunchGraceTimer.running,
+        gamepadActivityRestart: gamepadActivityRestartTimer.running
       },
       processes: {
+        gamepadActivity: gamepadActivityProcess.running,
         screensaver: screensaverProcess.running,
         lock: lockProcess.running,
         wake: wakeProcess.running
@@ -249,10 +265,17 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.idleEnabled
+    enabled: root.idleEnabled && !root.idleResetPending
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
+  }
+
+  Timer {
+    id: idleResetTimer
+    interval: 50
+    repeat: false
+    onTriggered: root.idleResetPending = false
   }
 
   Timer {
@@ -280,6 +303,13 @@ Item {
     }
   }
 
+  Timer {
+    id: gamepadActivityRestartTimer
+    interval: 30000
+    repeat: false
+    onTriggered: if (!gamepadActivityProcess.running) gamepadActivityProcess.running = true
+  }
+
   Connections {
     target: Hyprland
     function onRawEvent(event) { root.handleHyprlandEvent(event) }
@@ -296,6 +326,19 @@ Item {
   Process {
     id: wakeProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+  Process {
+    id: gamepadActivityProcess
+    command: ["python3", root.omarchyPath + "/shell/plugins/services/idle/scripts/gamepad_activity.py"]
+    stdout: SplitParser {
+      onRead: function(line) {
+        if (String(line).trim() === "activity") root.registerActivity("gamepad")
+      }
+    }
+    onExited: function(exitCode, exitStatus) {
+      root.logEvent("process-exit", "gamepad-activity exitCode=" + exitCode + " status=" + exitStatus)
+      gamepadActivityRestartTimer.restart()
+    }
   }
 
   Process {
@@ -332,6 +375,7 @@ Item {
   Component.onCompleted: {
     logEvent("service-ready")
     refreshStayAwakeState()
+    gamepadActivityProcess.running = true
   }
 
   IpcHandler {
@@ -355,6 +399,10 @@ Item {
 
     function toggle(): string {
       return root.setIdleEnabled(!root.idleEnabled)
+    }
+
+    function activity(): string {
+      return root.registerActivity("ipc") ? "reset" : "disabled"
     }
   }
 }

--- a/shell/plugins/services/idle/scripts/gamepad_activity.py
+++ b/shell/plugins/services/idle/scripts/gamepad_activity.py
@@ -1,0 +1,195 @@
+"""Emit activity when an attached Linux gamepad receives meaningful input."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import time
+
+
+EV_KEY = 0x01
+EV_REL = 0x02
+EV_ABS = 0x03
+BTN_JOYSTICK = 0x120
+BTN_DIGI = 0x140
+
+SCAN_INTERVAL_SECONDS = 2
+REPORT_INTERVAL_SECONDS = 1
+AXIS_THRESHOLD_RATIO = 0.02
+
+
+def capability_code(entry):
+  if isinstance(entry, (tuple, list)):
+    return int(entry[0])
+  return int(entry)
+
+
+def has_gamepad_buttons(capabilities):
+  return any(
+    BTN_JOYSTICK <= capability_code(entry) < BTN_DIGI
+    for entry in capabilities.get(EV_KEY, [])
+  )
+
+
+def axis_info_from_capabilities(capabilities):
+  result = {}
+  for entry in capabilities.get(EV_ABS, []):
+    if isinstance(entry, (tuple, list)) and len(entry) >= 2:
+      result[capability_code(entry)] = entry[1]
+  return result
+
+
+class ActivityFilter:
+  def __init__(self, axis_info=None):
+    self.axes = {}
+    for code, info in (axis_info or {}).items():
+      minimum = int(getattr(info, "min", 0))
+      maximum = int(getattr(info, "max", minimum))
+      flat = max(0, int(getattr(info, "flat", 0)))
+      span = max(0, maximum - minimum)
+      threshold = max(1, flat, round(span * AXIS_THRESHOLD_RATIO))
+      value = int(getattr(info, "value", 0))
+      self.axes[int(code)] = [value, threshold]
+
+  def accepts(self, event_type, code, value):
+    if event_type == EV_KEY:
+      return value > 0
+
+    if event_type == EV_REL:
+      return value != 0
+
+    if event_type != EV_ABS:
+      return False
+
+    code = int(code)
+    value = int(value)
+    axis = self.axes.get(code)
+    if axis is None:
+      self.axes[code] = [value, 1]
+      return value != 0
+
+    if abs(value - axis[0]) < axis[1]:
+      return False
+
+    axis[0] = value
+    return True
+
+
+class ActivityReporter:
+  def __init__(self, minimum_interval=REPORT_INTERVAL_SECONDS, clock=None, stream=None):
+    self.minimum_interval = minimum_interval
+    self.clock = clock or time.monotonic
+    self.stream = stream or sys.stdout
+    self.last_reported_at = None
+
+  def report(self):
+    now = self.clock()
+    if self.last_reported_at is not None and now - self.last_reported_at < self.minimum_interval:
+      return False
+
+    print("activity", file=self.stream, flush=True)
+    self.last_reported_at = now
+    return True
+
+
+async def watch_device(device, activity_filter, reporter):
+  try:
+    async for event in device.async_read_loop():
+      if activity_filter.accepts(event.type, event.code, event.value):
+        reporter.report()
+  except asyncio.CancelledError:
+    raise
+  except OSError:
+    pass
+  finally:
+    device.close()
+
+
+async def monitor_devices(evdev):
+  reporter = ActivityReporter()
+  watched = {}
+  ignored = set()
+  reported_errors = {}
+
+  try:
+    while True:
+      current = set(evdev.list_devices())
+      ignored.intersection_update(current)
+      reported_errors = {
+        path: message
+        for path, message in reported_errors.items()
+        if path in current
+      }
+
+      retired = []
+      for path, task in list(watched.items()):
+        if path in current and not task.done():
+          continue
+        watched.pop(path)
+        if not task.done():
+          task.cancel()
+        retired.append(task)
+
+      if retired:
+        await asyncio.gather(*retired, return_exceptions=True)
+
+      pending = current.difference(set(watched), ignored)
+      for path in sorted(pending):
+        device = None
+        try:
+          device = evdev.InputDevice(path)
+          capabilities = device.capabilities(absinfo=True)
+        except OSError as error:
+          if device is not None:
+            device.close()
+          message = str(error)
+          if reported_errors.get(path) != message:
+            print(f"Unable to inspect {path}: {message}", file=sys.stderr)
+            reported_errors[path] = message
+          continue
+
+        reported_errors.pop(path, None)
+        if not has_gamepad_buttons(capabilities):
+          ignored.add(path)
+          device.close()
+          continue
+
+        name = device.name or path
+        print(f"Watching gamepad: {name} ({path})", file=sys.stderr)
+        activity_filter = ActivityFilter(axis_info_from_capabilities(capabilities))
+        watched[path] = asyncio.create_task(watch_device(device, activity_filter, reporter))
+
+      await asyncio.sleep(SCAN_INTERVAL_SECONDS)
+  finally:
+    for task in watched.values():
+      task.cancel()
+    await asyncio.gather(*watched.values(), return_exceptions=True)
+
+
+def wait_for_evdev():
+  warned = False
+  while True:
+    try:
+      return importlib.import_module("evdev")
+    except ModuleNotFoundError as error:
+      if error.name != "evdev":
+        raise
+      if not warned:
+        print("Waiting for the python-evdev package", file=sys.stderr)
+        warned = True
+      time.sleep(30)
+      importlib.invalidate_caches()
+
+
+def main():
+  evdev = wait_for_evdev()
+  try:
+    asyncio.run(monitor_devices(evdev))
+  except KeyboardInterrupt:
+    pass
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -35,6 +35,77 @@ assertDeepEqual(
 )
 JS
 
+require_command python3
+
+ROOT="$ROOT" python3 <<'PY'
+import importlib.util
+import io
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+helper_path = Path(os.environ["ROOT"]) / "shell/plugins/services/idle/scripts/gamepad_activity.py"
+spec = importlib.util.spec_from_file_location("gamepad_activity", helper_path)
+gamepad = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gamepad)
+
+
+def check(condition, description):
+  if not condition:
+    raise AssertionError(description)
+  print(f"ok - {description}")
+
+
+check(
+  gamepad.has_gamepad_buttons({gamepad.EV_KEY: [30, gamepad.BTN_JOYSTICK]}),
+  "idle recognizes gamepad button capabilities",
+)
+check(
+  not gamepad.has_gamepad_buttons({gamepad.EV_KEY: [1, 30, 57]}),
+  "idle does not classify a keyboard as a gamepad",
+)
+
+axis = SimpleNamespace(value=0, min=-32768, max=32767, flat=500)
+activity_filter = gamepad.ActivityFilter({0: axis})
+check(
+  not activity_filter.accepts(gamepad.EV_ABS, 0, 800),
+  "idle filters analog stick drift",
+)
+check(
+  activity_filter.accepts(gamepad.EV_ABS, 0, 1400),
+  "idle accepts cumulative intentional axis movement",
+)
+check(activity_filter.accepts(gamepad.EV_KEY, 304, 1), "idle accepts gamepad button presses")
+check(not activity_filter.accepts(gamepad.EV_KEY, 304, 0), "idle ignores gamepad button releases")
+check(activity_filter.accepts(gamepad.EV_REL, 0, 1), "idle accepts relative gamepad input")
+
+timestamps = iter([10.0, 10.5, 11.1])
+output = io.StringIO()
+reporter = gamepad.ActivityReporter(clock=lambda: next(timestamps), stream=output)
+check(reporter.report(), "idle reports initial gamepad activity")
+check(not reporter.report(), "idle throttles repeated gamepad activity")
+check(reporter.report(), "idle resumes gamepad activity reports after throttle")
+check(output.getvalue() == "activity\nactivity\n", "idle emits the shell activity protocol")
+PY
+
+if ! rg -qx 'python-evdev' "$ROOT/install/omarchy-base.packages"; then
+  fail "Gamepad activity dependency is in the base package list"
+fi
+
+if ! rg -q 'enabled: root.idleEnabled && !root.idleResetPending' "$ROOT/shell/plugins/services/idle/Service.qml"; then
+  fail "Gamepad activity resets the idle monitor"
+fi
+
+if ! rg -q 'idle/scripts/gamepad_activity.py' "$ROOT/shell/plugins/services/idle/Service.qml"; then
+  fail "Gamepad activity helper is started by the idle service"
+fi
+
+if ! rg -q 'function activity\(\): string' "$ROOT/shell/plugins/services/idle/Service.qml"; then
+  fail "Idle activity is available over shell IPC"
+fi
+
+pass "Gamepad activity is wired into the idle service"
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 


### PR DESCRIPTION
## Summary

- watch Linux gamepad devices from Omarchy's built-in Quickshell idle service
- restart the idle countdown for button presses, relative input, and meaningful analog-axis movement
- ignore button releases and small analog drift, throttle activity reports, and handle hot-plug/disconnect
- add `python-evdev` to the base install plus a migration for existing Quattro users
- expose `omarchy-shell idle activity` as a generic idle-reset entry point

## Why

Follow-up to #1269 and #1303. Fullscreen rules help known applications, but controller-only play can still trigger the screensaver in emulators and games that do not match an app-specific rule. Treating actual controller input as activity works independently of the active application and window mode.

This supersedes #6342. It is rebuilt on the current `quattro` head and addresses both review threads from that PR by making watched-device set conversion explicit and ignoring `EV_KEY` release events.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 bash test/shell.d/idle-test.sh`
- `PYTHONDONTWRITEBYTECODE=1 ./test/cli`
- `PYTHONDONTWRITEBYTECODE=1 ./test/shell` (passes through `snapper-test.sh`; that existing test stops because the sibling `omarchy-iso` checkout is unavailable)
- all 16 shell test files after `snapper-test.sh` run individually: pass
- `qmllint shell/plugins/services/idle/Service.qml`
- Python syntax compile, migration `bash -n`, and `git diff --check`
- evdev/UInput integration: controller hot-plugged after watcher startup, release ignored, button press reported
