### PR TITLE
Fix XDG browser defaults when BROWSER is set

### DIFF
--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -32,9 +32,6 @@ zen) desktop_id="zen.desktop"; name="Zen"; glyph=󰖟 ;;
   ;;
 esac
 
-xdg-settings set default-web-browser "$desktop_id"
-xdg-mime default "$desktop_id" x-scheme-handler/http
-xdg-mime default "$desktop_id" x-scheme-handler/https
-xdg-mime default "$desktop_id" text/html
+env -u BROWSER xdg-settings set default-web-browser "$desktop_id" || exit 1
 
 omarchy-notification-send -g $glyph "$name is now the default browser"

--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -5,7 +5,7 @@
 # omarchy:examples=omarchy default browser firefox | omarchy default browser brave
 
 if (($# == 0)); then
-  case "$(xdg-settings get default-web-browser)" in
+  case "$(env -u BROWSER xdg-settings get default-web-browser)" in
   chromium.desktop) echo "chromium" ;;
   google-chrome.desktop) echo "chrome" ;;
   brave-browser.desktop) echo "brave" ;;
@@ -13,7 +13,7 @@ if (($# == 0)); then
   microsoft-edge.desktop) echo "edge" ;;
   firefox.desktop) echo "firefox" ;;
   zen.desktop) echo "zen" ;;
-  *) xdg-settings get default-web-browser ;;
+  *) env -u BROWSER xdg-settings get default-web-browser ;;
   esac
   exit 0
 fi

--- a/bin/omarchy-finalize-user
+++ b/bin/omarchy-finalize-user
@@ -102,7 +102,7 @@ done
 source "$OMARCHY_INSTALL/user/all.sh"
 
 omarchy-refresh-applications
-xdg-settings set default-web-browser chromium.desktop
+env -u BROWSER xdg-settings set default-web-browser chromium.desktop
 xdg-mime default HEY.desktop x-scheme-handler/mailto
 
 if (( first_install )); then

--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -3,7 +3,7 @@
 # omarchy:summary=Launch the default browser as determined by xdg-settings.
 # omarchy:args=[url]
 
-default_browser=$(xdg-settings get default-web-browser)
+default_browser=$(env -u BROWSER xdg-settings get default-web-browser)
 browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
 if $browser_exec --help 2>/dev/null | grep -q MOZ_LOG; then

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -14,10 +14,7 @@ set_fallback_default_browser() {
   fi
 
   if omarchy-cmd-present chromium; then
-    xdg-settings set default-web-browser chromium.desktop
-    xdg-mime default chromium.desktop x-scheme-handler/http
-    xdg-mime default chromium.desktop x-scheme-handler/https
-    xdg-mime default chromium.desktop text/html
+    env -u BROWSER xdg-settings set default-web-browser chromium.desktop || exit 1
   fi
 }
 

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -7,14 +7,14 @@
 
 set_fallback_default_browser() {
   local current_browser
-  current_browser=$(xdg-settings get default-web-browser)
+  current_browser=$(env -u BROWSER xdg-settings get default-web-browser)
 
   if [[ $current_browser != $1 ]]; then
     return
   fi
 
   if omarchy-cmd-present chromium; then
-    env -u BROWSER xdg-settings set default-web-browser chromium.desktop || exit 1
+    env -u BROWSER xdg-settings set default-web-browser chromium.desktop || true
   fi
 }
 

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -2128,7 +2128,7 @@ if command -v update-desktop-database >/dev/null 2>&1; then
   update-desktop-database "$HOME/.local/share/applications" >/dev/null 2>&1 || true
 fi
 if command -v xdg-settings >/dev/null 2>&1; then
-  xdg-settings set default-web-browser chromium.desktop || true
+  env -u BROWSER xdg-settings set default-web-browser chromium.desktop || true
 fi
 if command -v xdg-mime >/dev/null 2>&1; then
   xdg-mime default HEY.desktop x-scheme-handler/mailto || true


### PR DESCRIPTION
Omarchy exports `BROWSER=omarchy-launch-browser`, which causes `xdg-settings` to reject default-browser changes.

Unset `BROWSER` for all XDG browser mutations and remove redundant `xdg-mime` calls, since `xdg-settings` already updates all relevant MIME and URL handlers.