### PR TITLE
Never enable Wi-Fi power save on Intel BE200/BE211

### DIFF
--- a/bin/omarchy-wifi-powersave
+++ b/bin/omarchy-wifi-powersave
@@ -3,6 +3,14 @@
 # omarchy:summary=Set Wi-Fi power save mode on wireless interfaces
 # omarchy:args=<on|off>
 
+# Never enable power save on Intel BE200/BE211 (iwlmld): the firmware misses
+# beacons in power save and drops the link in constant reconnect loops.
+# Same detection as fix-wifi7-eht.sh.
+# Remove when the BE-series power-save path is fixed in linux-firmware.
+if [[ "$1" == "on" ]] && lspci -nn 2>/dev/null | grep -qE '\[8086:(e440|272b)\]'; then
+  exit 0
+fi
+
 shopt -s nullglob
 for iface in /sys/class/net/*/wireless; do
   iface="$(basename "$(dirname "$iface")")"


### PR DESCRIPTION
The BE-series (`iwlmld`) firmware chronically misses beacons when power save is enabled — `missed beacons exceeds threshold` followed by deauth/reconnect loops. Since `99-wifi-powersave.rules` enables power save on every unplug, laptops with these cards (including the XPS 14/16 Panther Lake) drop Wi-Fi constantly on battery.

Measured on an X1 Carbon Gen 14 (BE211) across two days and two mesh setups: 6–52 disconnects/hour with power save on depending on signal, ~zero with it off — and no measurable battery-draw difference, since the reconnect churn eats the savings.

Fix: guard the `on` path by PCI ID, same detection as `fix-wifi7-eht.sh`. Remove when the BE-series power-save path is fixed in linux-firmware.