### PR TITLE
Fix notification popups stretching/squishing when the count changes

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -787,26 +787,27 @@ Item {
       readonly property var popupPlacement: NotificationLogic.popupPlacement(
         service.barPosition, service.barClearance, Style.gapsOut)
 
-      anchors {
-        top: popupWindow.popupPlacement.anchors.top
-        bottom: popupWindow.popupPlacement.anchors.bottom
-        left: popupWindow.popupPlacement.anchors.left
-        right: popupWindow.popupPlacement.anchors.right
-      }
-      margins {
-        top: popupWindow.popupPlacement.margins.top
-        bottom: popupWindow.popupPlacement.margins.bottom
-        left: popupWindow.popupPlacement.margins.left
-        right: popupWindow.popupPlacement.margins.right
-      }
+      // Full-screen, fixed-size surface (like the OSD overlay). Adding or
+      // removing a toast changes only the content inside; the Wayland surface
+      // never resizes, so the compositor can't briefly scale a stale buffer --
+      // which is what stretched/squished the cards during count changes.
+      anchors { top: true; bottom: true; left: true; right: true }
 
-      implicitWidth: popupColumn.implicitWidth
-      implicitHeight: popupColumn.implicitHeight
+      // Keep the surface click-through except over the toast column, so the
+      // rest of the (invisible) full-screen overlay never eats input.
+      mask: Region {
+        x: popupColumn.x
+        y: popupColumn.y
+        width: popupColumn.width
+        height: popupColumn.height
+      }
 
       ColumnLayout {
         id: popupColumn
         anchors.right: parent.right
         anchors.top: parent.top
+        anchors.topMargin: popupWindow.popupPlacement.margins.top
+        anchors.rightMargin: popupWindow.popupPlacement.margins.right
         spacing: Style.space(8)
 
         Repeater {

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -795,12 +795,7 @@ Item {
 
       // Keep the surface click-through except over the toast column, so the
       // rest of the (invisible) full-screen overlay never eats input.
-      mask: Region {
-        x: popupColumn.x
-        y: popupColumn.y
-        width: popupColumn.width
-        height: popupColumn.height
-      }
+      mask: Region { item: popupColumn }
 
       ColumnLayout {
         id: popupColumn


### PR DESCRIPTION
Notification toasts visibly stretch or squish for a moment whenever one appears or disappears — worst when only one or two are showing.

The popup uses one Wayland layer surface per output, sized to its content (`implicitWidth`/`implicitHeight` bound to the toast column). So every time a toast is added or removed, the surface resizes — and during that resize the compositor briefly scales the previous buffer to the new geometry, stretching/squishing the cards until quickshell commits a correctly-sized frame. Fewer toasts make it worse because each resize is a larger relative change. The cards themselves are fine; they render correctly whenever the stack is static.

This gives the popup surface a fixed, full-screen size (the same approach the OSD overlay already uses), so adding or removing a toast changes only the content inside it and the surface never resizes. The input region is masked to just the toast column so the otherwise-invisible full-screen overlay stays click-through.

Verified on a dual-monitor setup at 1.0× and 1.6×: clean at every count (1→4), transitions no longer distort, and clicks pass through everywhere except the toasts.

Sample shots from before:
<img width="715" height="245" alt="image" src="https://github.com/user-attachments/assets/12068725-35b2-444d-a15e-1f2772c78f04" />
<img width="694" height="87" alt="image" src="https://github.com/user-attachments/assets/8cfdbf91-b679-4ded-8c62-6a9553765c79" />

Samples from after:
<img width="705" height="597" alt="image" src="https://github.com/user-attachments/assets/9df7707d-8c58-42c4-bcab-f2fae5ade6d2" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)