### PR TITLE
Fix bar plugin JSON value validation

### DIFF
--- a/bin/omarchy-bar-plugin
+++ b/bin/omarchy-bar-plugin
@@ -420,7 +420,7 @@ cmd_set() {
   parse_placement "$@"
 
   if [[ $value_is_json == "true" ]]; then
-    jq -e . <<<"$value" >/dev/null 2>&1 || fail "invalid JSON value: $value"
+    jq -n --argjson value "$value" empty >/dev/null 2>&1 || fail "invalid JSON value: $value"
   fi
 
   local value_arg

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -289,6 +289,28 @@ jq -e '
 ' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
 pass "shell config removes widgets with remove alias"
 
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar-plugin set omarchy.bluetooth enabled false --json
+jq -e '
+  any(.bar.layout.right[]; .id == "omarchy.bluetooth" and .enabled == false)
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+pass "bar plugin set accepts false JSON values"
+
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar-plugin set omarchy.bluetooth optional null --json
+jq -e '
+  any(.bar.layout.right[]; .id == "omarchy.bluetooth" and has("optional") and .optional == null)
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+pass "bar plugin set accepts null JSON values"
+
+if HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar-plugin set omarchy.bluetooth broken '{' --json 2>/dev/null; then
+  fail "bar plugin set accepted malformed JSON"
+fi
+pass "bar plugin set rejects malformed JSON"
+
+if HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar-plugin set omarchy.bluetooth broken 'false null' --json 2>/dev/null; then
+  fail "bar plugin set accepted multiple JSON values"
+fi
+pass "bar plugin set rejects multiple JSON values"
+
 mock_bin="$TMPDIR/mock-bin"
 mkdir -p "$mock_bin"
 


### PR DESCRIPTION
- Validate `omarchy bar plugin set --json` values using jq's `--argjson` parser.
- Accept valid `false` and `null` settings without weakening JSON validation.
- Add regression coverage for malformed and multiple JSON values.

Previously, `jq -e .` treated valid `false` and `null` values as validation failures because `-e` returns a non-zero status for false and null results.