### PR TITLE
Stop install invitations from re-showing after they run

### DIFF
--- a/install/user/first-run/install-voxtype.hook
+++ b/install/user/first-run/install-voxtype.hook
@@ -4,7 +4,13 @@ set -e
 
 show_invitation() {
   if [[ -n $(omarchy-notification-send -u critical -g  "Install Dictation with Voxtype" "Click to install voice dictation for Omarchy." -a) ]]; then
-    omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install
+    # Launch the installer in its own transient unit so this invitation service
+    # can exit right after the click. If it stayed alive for the life of the
+    # install terminal, the installer's omarchy-restart-shell would re-trigger
+    # this still-running *-invitation unit and pop the toast a second time.
+    systemd-run --user --collect --quiet \
+      --unit=omarchy-voxtype-install \
+      omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install
   fi
 }
 

--- a/install/user/first-run/setup-fingerprint.hook
+++ b/install/user/first-run/setup-fingerprint.hook
@@ -4,7 +4,13 @@ set -e
 
 show_invitation() {
   if [[ -n $(omarchy-notification-send -u critical -g 󰈷 "Setup Fingerprint Reader" "Enable sudo and unlocking with your fingerprint." -a) ]]; then
-    omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint
+    # Launch the setup in its own transient unit so this invitation service can
+    # exit right after the click. If it stayed alive for the life of the setup
+    # terminal, the setup's omarchy-restart-shell would re-trigger this
+    # still-running *-invitation unit and pop the toast a second time.
+    systemd-run --user --collect --quiet \
+      --unit=omarchy-setup-security-fingerprint \
+      omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint
   fi
 }
 


### PR DESCRIPTION
## Problem

After accepting the Voxtype dictation invitation, it installs correctly — but the moment the install finishes, the **"Install Dictation with Voxtype"** toast pops up again. The fingerprint setup invitation has the same flaw.

## Cause

The invitation runs as a transient `omarchy-*-invitation.service` that shows a critical toast and blocks in `notify-send -A`. On click, `show_invitation` calls `omarchy-launch-floating-terminal-with-presentation`, which `exec`s the install terminal — so the invitation service stays `active running` for the entire life of that terminal (it owns the terminal's cgroup, `KillMode=control-group`).

The installer ends with `omarchy-restart-shell`, which does:

```sh
systemctl --user try-restart 'omarchy-*-invitation.service'
```

That re-show is deliberate: a shell restart wipes any still-waiting invitation toast without emitting `NotificationClosed`, hanging its `notify-send` waiter, so a *still-running* invitation unit is treated as an unanswered toast worth re-showing. But an **answered** invitation is still running only because it is the ancestor of the very install terminal that triggered the restart. The heuristic misfires and the toast re-appears.

Confirmed live: after answering, `omarchy-voxtype-install-invitation.service` was still `active running` when the install's shell restart re-triggered it.

## Fix

Launch the installer in its own transient unit so the invitation service exits immediately after the click:

```sh
systemd-run --user --collect --quiet \
  --unit=omarchy-voxtype-install \
  omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install
```

- **Answered** invitations now exit right away → no longer match the `omarchy-*-invitation.service` re-show glob → no duplicate toast.
- **Unanswered** invitations still block in `notify-send` and are still recovered by `omarchy-restart-shell` exactly as before.

Applied symmetrically to both `install-voxtype.hook` and `setup-fingerprint.hook`. Both pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHPDqx5hwLTwq27f7KpM9d