### PR TITLE
Way Better Preinstalls (BASE)

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -13,9 +13,8 @@ bluez-utils
 bolt
 brightnessctl
 btop
-chromium
+brave-origin-bin
 clang
-cliamp
 cups
 cups-browsed
 cups-filters
@@ -38,7 +37,7 @@ fcitx5-qt
 fd
 ffmpegthumbnailer
 fontconfig
-foot
+kitty-git
 fzf
 git
 gnome-calculator
@@ -141,7 +140,6 @@ woff2-font-awesome
 xdg-desktop-portal-gtk
 xdg-desktop-portal-hyprland
 xdg-terminal-exec
-xournalpp
 yaru-icon-theme
 yay
 yt-dlp

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -69,7 +69,7 @@ lazygit
 less
 libsecret
 libyaml
-libreoffice-fresh
+onlyoffice-bin
 llvm
 localsend
 lua51
@@ -118,6 +118,7 @@ sushi
 system-config-printer
 tesseract
 tesseract-data-eng
+obfuscate
 tldr
 tree-sitter-cli
 tmux
@@ -142,5 +143,6 @@ xdg-desktop-portal-hyprland
 xdg-terminal-exec
 yaru-icon-theme
 yay
+yazi-git
 yt-dlp
 zoxide


### PR DESCRIPTION
# Changes

ADDED:

+ Brave Origin: Minimalist browser with core privacy shields, stripped of AI, crypto, and telemetry features. 
+ Kitty: GPU-accelerated terminal for high-performance, low-latency rendering without unnecessary bloat. 
+ OnlyOffice: Secure office suite with superior MS Office compatibility and optional end-to-end encryption for collaboration. 
+ GNOME Obfuscate: Essential utility for securely redacting sensitive information from images (blackout mode) before sharing. 
+ Yazi: Blazing-fast, async file manager written in Rust with native image previews and zero telemetry. 

REMOVED:

- Chromium: Replaced by Brave Origin to eliminate Google sync and tracking services. 
- Foot: Replaced by Kitty for superior GPU acceleration and feature set.
- Cliamp: Removed the terminal-based music player.
- LibreOffice: Replaced by OnlyOffice for better format fidelity and enterprise-grade privacy features. 
- Xournalpp: Replaced by Omawrite already present in OMARCHY QUATTRO.

IMPACT:

Privacy: Eliminated major telemetry sources (Google, generic analytics). 
Performance: Upgraded terminal and file manager to GPU-accelerated and async Rust-based tools. 
Security: Added dedicated tooling for data redaction (Obfuscate) and encrypted collaboration (OnlyOffice).