### PR TITLE
Render clock weekday and month names in the system locale

### DIFF
--- a/shell/plugins/bar/widgets/Clock.qml
+++ b/shell/plugins/bar/widgets/Clock.qml
@@ -35,7 +35,7 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, isoWeekLiteral(date)))
+    return Qt.locale().toString(date, activeFormat.replace(/ww/g, isoWeekLiteral(date)))
   }
 
   implicitWidth: button.implicitWidth


### PR DESCRIPTION
Fixes #6360.

`omarchy.clock` renders `dddd` and `MMMM` in English however the session locale is set. `Clock.qml` formats through `Qt.formatDateTime(date, format)`, and given a *format string* Qt formats names in the C locale by contract — [`QDate::toString()`](https://doc.qt.io/qt-6/qdate.html) documents "Day and month names are given in English (C locale)" and points at `QLocale` for localized ones. No `LANG` or `LC_TIME` value can reach it.

`Qt.locale()` is the system locale and accepts the same format expressions:

```diff
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, isoWeekLiteral(date)))
+    return Qt.locale().toString(date, activeFormat.replace(/ww/g, isoWeekLiteral(date)))
```

The no-argument form is deliberate: it resolves `LC_TIME` independently of `LANG`, which `Qt.locale(Qt.locale().name)` would drop — under `LANG=en_US.UTF-8 LC_TIME=es_MX.UTF-8` the named form still renders `Saturday` where the bare form renders `sábado`. `Qt.formatDateTime` has no locale-taking overload.

With the shipped defaults, `es_MX` goes from `Saturday 16:42` / `25 July W30 2026` to `sábado 16:42` / `25 julio W30 2026`.

Verified in a live bar under `es_MX` and `ar_EG`.

- Locales with their own numerals now render digits natively, so `ar_EG` reads `٢٥ يوليو W30 ٢٠٢٦`. The ISO week is substituted into the format string as a literal before formatting, so it stays Latin while everything around it localizes. Qt offers no way to keep Latin digits throughout — it ignores both `ar-EG-u-nu-latn` and `ar_EG@numbers=latn` — so the choice is native digits as here, or localizing the week literal too so at least it is internally consistent. Happy to add the latter.