### PR TITLE
Fix Arabic falling back to Nastaliq in Chromium and Electron apps

### DIFF
--- a/default/fontconfig/conf.avail/50-omarchy.conf
+++ b/default/fontconfig/conf.avail/50-omarchy.conf
@@ -38,14 +38,30 @@
     </edit>
   </match>
 
-  <!-- Chromium and Electron resolve missing glyphs one character at a time
-       without lang=ar on the pattern, so the rule above never fires for them
-       and fontconfig falls through to a raw charset scan that lands on
-       Nastaliq. Naming Naskh as a weak last-resort family covers that path.
-       Weak binding means it only applies when nothing earlier already covers
-       the codepoint, so Latin and monospace resolution are unaffected. -->
+  <!-- Urdu is conventionally set in Nastaliq, so keep it there. Without this
+       the untargeted Naskh rule below would capture Urdu too. Appended rather
+       than prepended so it only wins the last-resort race against that rule
+       and never displaces the family the app actually asked for. -->
   <match target="pattern">
-    <edit name="family" mode="append" binding="weak">
+    <test name="lang" compare="contains">
+      <string>ur</string>
+    </test>
+    <edit name="family" mode="append" binding="strong">
+      <string>Noto Nastaliq Urdu</string>
+    </edit>
+  </match>
+
+  <!-- Chromium and Electron resolve missing glyphs one character at a time
+       without lang on the pattern, so the rules above never fire for them and
+       fontconfig falls through to a raw charset scan that lands on Nastaliq
+       (or on Kufi, once the latin alias chains have widened the pattern).
+       Naming Naskh as a last-resort family covers that path. Appending keeps
+       it behind every family the app actually asked for, and charset matching
+       outranks family matching, so a font that does not cover the codepoint
+       can never be pulled in: Latin, monospace, emoji, Nerd Font glyphs and
+       CJK all resolve exactly as before. -->
+  <match target="pattern">
+    <edit name="family" mode="append" binding="strong">
       <string>Noto Naskh Arabic</string>
     </edit>
   </match>

--- a/default/fontconfig/conf.avail/50-omarchy.conf
+++ b/default/fontconfig/conf.avail/50-omarchy.conf
@@ -38,6 +38,18 @@
     </edit>
   </match>
 
+  <!-- Chromium and Electron resolve missing glyphs one character at a time
+       without lang=ar on the pattern, so the rule above never fires for them
+       and fontconfig falls through to a raw charset scan that lands on
+       Nastaliq. Naming Naskh as a weak last-resort family covers that path.
+       Weak binding means it only applies when nothing earlier already covers
+       the codepoint, so Latin and monospace resolution are unaffected. -->
+  <match target="pattern">
+    <edit name="family" mode="append" binding="weak">
+      <string>Noto Naskh Arabic</string>
+    </edit>
+  </match>
+
   <alias>
     <family>system-ui</family>
     <prefer>


### PR DESCRIPTION
## Summary

#6322 made Arabic render in Naskh instead of Nastaliq, but only for apps that go through fontconfig's `lang=ar` matching. It called the rest out as unfinished:

> Only affects native apps that go through fontconfig (GTK, Qt, terminals, etc.). Electron/Chromium apps (Discord, Vesktop, VSCode) do their own glyph-level fallback that bypasses fontconfig's `lang=ar` rules — that's a separate problem and out of scope here.

This is that separate problem.

Chromium resolves missing glyphs one character at a time and does not put `lang` on the fontconfig pattern. Every `lang`-gated rule is skipped, including the one from #6322, and fontconfig falls through to a raw charset scan that lands on Nastaliq. The whole bug is visible in two queries:

```
$ fc-match "Roboto:charset=644:lang=ar"    # what GTK/Qt ask
NotoNaskhArabic-Regular.ttf: "Noto Naskh Arabic"

$ fc-match "Roboto:charset=644"            # what Chromium asks
NotoNastaliqUrdu-Regular.ttf: "Noto Nastaliq Urdu"
```

Naming Naskh as a weak, appended last-resort family covers the ungated path. Weak binding means it only applies when nothing earlier already covers the codepoint, so Latin and monospace resolution are untouched. Both fonts ship with `noto-fonts`, already in `omarchy-base.packages` — no new dependency.

## Test plan

Verified by placing the patched file into a replica of the real `/etc/fonts/conf.d/` chain, so its ordering against `65-nonlatin.conf` is faithful.

- [x] Before: `fc-match "Roboto:charset=644"` → `NotoNastaliqUrdu-Regular.ttf`
- [x] After: `fc-match "Roboto:charset=644"` → `NotoNaskhArabic-Regular.ttf`
- [x] The `lang=ar` path from #6322 still resolves to Naskh — no regression
- [x] Latin unchanged: `sans-serif` → Liberation Sans, `serif` → Liberation Serif, `monospace` → JetBrainsMono Nerd Font
- [x] Headless Chromium render of Arabic in `Roboto`, `Inter` and `sans-serif`: Nastaliq before, Naskh after
- [x] Reproduced on a stock config in Chromium, Discord, Obsidian, Claude Desktop and Stremio — all five render Nastaliq before, Naskh after
- [x] GTK/Pango apps were already correct and stay correct
