### PR TITLE
Let a transparent bar sit flush over the windows below it

### DIFF
--- a/config/omarchy/hooks/bar-changed.d/gaps.sh
+++ b/config/omarchy/hooks/bar-changed.d/gaps.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# omarchy-hook bar-changed <position> <transparent> [previous]
+#   position    : top | bottom | left | right  (the edge the bar occupies)
+#   transparent : true | false
+#   previous    : the edge the bar just moved off of, if it moved (optional)
+#
+# Keep the window gap on the bar's edge in step with the bar: 0 when the bar is
+# transparent (windows sit flush under it) or the same as the other edges when
+# opaque. Reads the current gaps_out and only touches two edges: the bar's own
+# edge, and the edge the bar just left (restored to the window gap, so a bar that
+# moves away from an edge it had flushed doesn't strand it at 0). Every other edge
+# is left untouched, so custom gaps, a hand-set zero, and toggles like
+# window-no-gaps are all preserved.
+
+position="${1:-top}"
+transparent="${2:-false}"
+previous="${3:-$position}"
+
+# Allow running from outside the session (the shell normally passes this in) by
+# deriving the Hyprland instance signature from the newest instance runtime dir,
+# the same way bin/omarchy-restart-shell does.
+if [[ -z ${HYPRLAND_INSTANCE_SIGNATURE:-} ]]; then
+  hypr_dir=$(find "${XDG_RUNTIME_DIR:-/run/user/$UID}/hypr" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -n 1 | cut -d' ' -f2-)
+  [[ -n $hypr_dir ]] && export HYPRLAND_INSTANCE_SIGNATURE=${hypr_dir##*/}
+fi
+
+# current gaps_out, in CSS order: top right bottom left
+read -r top right bottom left < <(hyprctl getoption general:gaps_out -j 2>/dev/null \
+  | python3 -c "import sys,json; c=(json.load(sys.stdin).get('css','').split()+['10']*4)[:4]; print(*c)" 2>/dev/null)
+for e in top right bottom left; do [[ ${!e} =~ ^[0-9]+$ ]] || printf -v "$e" 10; done
+
+# the window gap = the largest current gap, so an edge left flush doesn't skew it
+gap=$top; for v in $right $bottom $left; do (( v > gap )) && gap=$v; done
+
+# restore the edge the bar just moved off of (0 -> the window gap); it's the only
+# edge we ever assume was ours to flush, so a hand-set zero elsewhere is left alone
+if [[ $previous != "$position" ]]; then
+  case "$previous" in
+    top)    top=$gap ;;
+    bottom) bottom=$gap ;;
+    left)   left=$gap ;;
+    right)  right=$gap ;;
+  esac
+fi
+
+# the bar's own edge: 0 when transparent (flush), else the window gap
+edge=$gap; [[ $transparent == true ]] && edge=0
+case "$position" in
+  top)    top=$edge ;;
+  bottom) bottom=$edge ;;
+  left)   left=$edge ;;
+  right)  right=$edge ;;
+esac
+
+# omarchy drives Hyprland with the Lua config parser, where `hyprctl keyword` can
+# be rejected ("Use eval."); set the gap through the same hl.config() API instead.
+hyprctl eval "hl.config({ general = { gaps_out = { top = $top, right = $right, bottom = $bottom, left = $left } } })" >/dev/null 2>&1 || true

--- a/migrations/1785088068.sh
+++ b/migrations/1785088068.sh
@@ -1,0 +1,3 @@
+echo "Install the bar-changed hook so a transparent bar sits flush over the windows below it"
+
+omarchy-refresh-config omarchy/hooks/bar-changed.d/gaps.sh

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1,4 +1,5 @@
 import Quickshell
+import Quickshell.Hyprland
 import Quickshell.Io
 import Quickshell.Wayland
 import QtQuick
@@ -291,6 +292,8 @@ Item {
 
   readonly property bool vertical: position === "left" || position === "right"
   readonly property int barSize: vertical ? Style.bar.sizeVertical : Style.bar.sizeHorizontal
+  // Guards the one-time bar-changed emit on first applyBarConfig (startup).
+  property bool barChangeNotified: false
 
   function normalizePosition(value) {
     return BarModel.normalizePosition(value)
@@ -318,14 +321,44 @@ Item {
   function applyBarConfig() {
     var config = Util.isPlainObject(barConfig) ? barConfig : fallbackBarConfig
 
+    var previousPosition = position
+    var previousTransparent = requestedTransparent
     position = normalizePosition(config.position)
     setRequestedTransparency(config.transparent === true)
     centerAnchor = Util.canonicalWidgetId(config.centerAnchor || "")
     layoutConfig = normalizeLayout(config.layout)
     barConfigSerial++
+
+    // Keep the window gap under the bar in step with its edge and transparency;
+    // also fire once on first apply so gaps_out is corrected at startup.
+    if (!barChangeNotified || position !== previousPosition || requestedTransparent !== previousTransparent) {
+      barChangeNotified = true
+      notifyBarChanged(previousPosition)
+    }
+  }
+
+  // Hand the bar's edge and transparency to the bar-changed hook, which sets
+  // Hyprland's gaps_out: 0 under a transparent bar (windows flush) or the window
+  // gap when opaque. Passing the edge the bar just moved off of lets the hook
+  // restore exactly that edge (rather than guess which zero was a stale flush),
+  // so a hand-set zero elsewhere survives. Same hook contract theme changes use;
+  // fired on change, once at startup, and on a Hyprland config reload (see the
+  // Hyprland Connections below).
+  function notifyBarChanged(previousPosition) {
+    var movedFrom = previousPosition === undefined ? position : previousPosition
+    Quickshell.execDetached(["omarchy-hook", "bar-changed", position, requestedTransparent ? "true" : "false", movedFrom])
   }
 
   onBarConfigChanged: applyBarConfig()
+
+  // Hyprland resets gaps_out to its config default on reload, so re-assert the
+  // bar's gap whenever that happens.
+  Connections {
+    target: Hyprland
+    function onRawEvent(event) {
+      if (event && event.name === "configreloaded") root.notifyBarChanged()
+    }
+  }
 
   function layoutEntries(region) {
     var serial = barConfigSerial
@@ -514,6 +547,7 @@ Item {
       })
     } else {
       root.setRequestedTransparency(nextTransparent)
+      root.notifyBarChanged()
     }
   }
 

--- a/test/shell.d/bar-changed-hook-test.sh
+++ b/test/shell.d/bar-changed-hook-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+HOOK="$ROOT/config/omarchy/hooks/bar-changed.d/gaps.sh"
+[[ -f $HOOK ]] || fail "bar-changed hook exists: $HOOK"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Mock hyprctl: report a canned gaps_out (MOCK_GAPS) and capture the eval the
+# hook issues, so we can assert the resulting gaps_out without a live compositor.
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/hyprctl" <<'MOCK'
+#!/bin/bash
+case "$*" in
+  "getoption general:gaps_out -j") printf '{"css": "%s"}\n' "$MOCK_GAPS" ;;
+  eval*) printf '%s\n' "$*" >>"$EVAL_LOG" ;;
+esac
+MOCK
+chmod +x "$TMPDIR/bin/hyprctl"
+export PATH="$TMPDIR/bin:$PATH"
+export EVAL_LOG="$TMPDIR/eval.log"
+export HYPRLAND_INSTANCE_SIGNATURE=test   # skip the runtime-dir lookup in the hook
+
+# Run the hook and return the gaps_out it applied, as "top right bottom left".
+# previous is the edge the bar moved off of (defaults to position: no move).
+applied_gaps() {
+  local position="$1" transparent="$2" start="$3" previous="${4:-$1}"
+  : >"$EVAL_LOG"
+  MOCK_GAPS="$start" bash "$HOOK" "$position" "$transparent" "$previous"
+  grep -oE 'top = [0-9]+, right = [0-9]+, bottom = [0-9]+, left = [0-9]+' "$EVAL_LOG" \
+    | tail -1 | grep -oE '[0-9]+' | paste -sd' '
+}
+
+check() {
+  local position="$1" transparent="$2" start="$3" expected="$4" previous="${5:-$1}"
+  local got
+  got=$(applied_gaps "$position" "$transparent" "$start" "$previous")
+  [[ $got == "$expected" ]] \
+    || fail "bar-changed $position $transparent (from $previous) on [$start]" \
+            "  got [$got], want [$expected]"
+  pass "bar-changed $position $transparent (from $previous) on [$start] -> [$expected]"
+}
+
+# gaps_out order is top right bottom left.
+
+# A transparent bar flushes its own edge to 0.
+check top    true  "10 10 10 10" "0 10 10 10"
+check bottom true  "10 10 10 10" "10 10 0 10"
+check left   true  "10 10 10 10" "10 10 10 0"
+check right  true  "10 10 10 10" "10 0 10 10"
+
+# An opaque bar keeps the window gap on its edge (restoring an edge it had flushed).
+check top    false "0 10 10 10"  "10 10 10 10"
+
+# Only the bar's edge is touched: custom gaps on the other edges are preserved.
+check top    true  "5 10 15 20"  "0 10 15 20"
+
+# The no-gaps case (all zero) is preserved, not forced back to a default.
+check top    true  "0 0 0 0"     "0 0 0 0"
+
+# Moving the bar restores the edge it moved off of: from top to bottom, the top
+# edge it had flushed is set back to the window gap.
+check bottom true  "0 10 10 10"  "10 10 0 10"  top
+
+# The same starting gaps without a move: the bar is on bottom and stayed there, so
+# a hand-set top=0 is left exactly as the user configured it (not "restored").
+check bottom true  "0 10 10 10"  "0 10 0 10"
+
+pass "bar-changed hook keeps the window gap in step with the bar's edge and only restores the edge it moved off of"


### PR DESCRIPTION
## What

A transparent bar sits **flush** over windows — no widget overlap, no new setting, and **no change to any default**. Works on any edge, live, and multi-monitor.  This lets the text of the workspaces and icons be centered in the "empty" space above your windows rather than offet by the gap.

https://github.com/user-attachments/assets/cc5cfdce-5751-4e31-9c35-2130c1e5b00a

_Demo of the feature, note I have my date on the right of the quickshell bar because I have a notch on my MBP (that is not part of this PR)._

## How

The bar reserves only its own thickness (its layer-shell exclusive zone), so it never overlaps a window. A shipped hook keeps the window gap on the bar's edge in step with the bar: the shell fires `omarchy-hook bar-changed <edge> <transparent> <previous>` — the same hook contract theme changes use — and the hook reads the current `gaps_out` and sets the bar's edge to `0` when the bar is transparent (windows flush) or the same as the other edges when opaque. It only ever touches the bar's own edge and the edge the bar just moved off of (`<previous>`, restored to the window gap so a moved-away edge isn't stranded at `0`); every other edge is left exactly as configured.

It fires on any change to the bar's edge or transparency, **once at startup**, and on **Hyprland config reload**, so `gaps_out` always matches the bar (and self-heals after a reload).

## Notes

- **No new setting, no default look change**: an opaque bar keeps the standard window gap (the hook re-asserts it); `looknfeel.lua` and `shell.json` are untouched.
- The gap tracks your `gaps_out` — nothing separate to keep in sync. The hook only rewrites the bar's own edge (and restores the one it moved away from), so per-edge custom gaps, a hand-set zero, and toggles like `window-no-gaps` are preserved.
- Bar position is global across monitors, so one `gaps_out` covers all outputs.
- **Delivery**: fresh installs pick the hook up from the shipped `config/` skeleton; existing installs get it via a migration (`omarchy-refresh-config omarchy/hooks/bar-changed.d/gaps.sh`), so an update wires the behavior up rather than emitting an event nothing handles.

## Testing

- **Startup**: hook fires on first apply → the bar's edge is flush at boot (no toggle needed).
- **Transparency toggle**: gap collapses (flush) ↔ appears; reserved zone stays at `barSize` (no overlap).
- **All four edges**: the hook zeros the bar's edge, keeps the window gap on the others.
- **Moving the bar**: the edge it moved off of is restored to the window gap; a hand-set zero on any other edge is left as-is (covered by a unit test).
- **Hyprland reload**: `gaps_out` resets, then self-heals via the `configreloaded` listener.


