### PR TITLE
Exempt DaVinci Resolve from default window opacity

### DIFF
--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -1,2 +1,8 @@
--- DaVinci Resolve dialog focus handling.
-o.window(".*[Rr]esolve.*", { float = true, stay_focused = true })
+-- DaVinci Resolve dialog focus handling. Kept fully opaque: the default
+-- translucency distorts colour-critical grading work.
+o.window(".*[Rr]esolve.*", {
+  float = true,
+  stay_focused = true,
+  tag = "-default-opacity",
+  opacity = "1 1",
+})

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -1,4 +1,4 @@
--- DaVinci Resolve dialog focus handling. Kept fully opaque: the default
+-- DaVinci Resolve window focus handling. Kept fully opaque: the default
 -- translucency distorts colour-critical grading work.
 o.window(".*[Rr]esolve.*", {
   float = true,


### PR DESCRIPTION
The default-opacity tag (0.985 focused / 0.96 unfocused) currently applies to DaVinci Resolve, so the viewer and scopes render slightly translucent over the wallpaper. For a colour-grading app that visibly shifts what you're looking at, in the same way it would for video playback — which is why the browser video/PiP, qemu, and RetroArch rules already opt out.

This adds the same opt-out to the existing Resolve rule (`tag = "-default-opacity", opacity = "1 1"`), mirroring `retroarch.lua`.

Running 4.0.0.alpha (r1373) with Resolve 21 under XWayland here; verified locally with an equivalent user-level opacity override (loads clean, no interaction with the float/stay_focused handling).