### PR TITLE
Rank installed apps above equally matching menu entries

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -309,6 +309,12 @@ function searchScore(items, entry, query) {
   else if (descriptionTextMatches(needle, descriptionText)) score = 60
 
   if (entry.kind === "menu" || entry.kind === "link") score -= 2
+  // mergeAppRows appends app rows after every menu item, so an app always
+  // loses the order tiebreak below to a menu entry that matches just as well.
+  // Searching an installed app's name should launch it, not offer to install
+  // or remove it. The bias stays under the 10-point gap between match tiers,
+  // so a menu entry that matches better still sorts first.
+  if (entry.kind === "app") score -= 5
 
   return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
 }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -309,11 +309,8 @@ function searchScore(items, entry, query) {
   else if (descriptionTextMatches(needle, descriptionText)) score = 60
 
   if (entry.kind === "menu" || entry.kind === "link") score -= 2
-  // mergeAppRows appends app rows after every menu item, so an app always
-  // loses the order tiebreak below to a menu entry that matches just as well.
-  // Searching an installed app's name should launch it, not offer to install
-  // or remove it. The bias stays under the 10-point gap between match tiers,
-  // so a menu entry that matches better still sorts first.
+  // App rows sort after all menu items, so they lose the tiebreak below to an
+  // equal match. Outrank those, but stay inside the tier so better ones win.
   if (entry.kind === "app") score -= 5
 
   return score * 1000 + depthFor(items, entry.id) * 25 + entry.order

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -110,9 +110,8 @@ assertDeepEqual(
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))
 
-// App rows land after every static item, so ranking has to survive the real
-// menu's item count: with hundreds of entries ahead of them, the order
-// tiebreak alone buries an installed app under Install and Remove.
+// Needs the real menu: app rows sort after all menu items, and only at that
+// item count does the order tiebreak alone bury an installed app.
 const rankBase = menu.mergeMenuSources(defaultItems, [])
 const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
   { id: 'apps.brave', parent: 'apps', kind: 'app', label: 'Brave', description: '', aliases: [] },

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -109,6 +109,26 @@ assertDeepEqual(
 
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))
+
+// App rows land after every static item, so ranking has to survive the real
+// menu's item count: with hundreds of entries ahead of them, the order
+// tiebreak alone buries an installed app under Install and Remove.
+const rankBase = menu.mergeMenuSources(defaultItems, [])
+const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
+  { id: 'apps.brave', parent: 'apps', kind: 'app', label: 'Brave', description: '', aliases: [] },
+  { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] }
+])
+const rankScore = (id, query) => menu.searchScore(ranked.items, ranked.items[id], query)
+assert(
+  ['install.browser.brave', 'remove.browser.brave', 'setup.default.browser.brave'].every(
+    id => rankScore('apps.brave', 'brave') < rankScore(id, 'brave')
+  ),
+  'menu ranks an installed app above menu entries matching the query equally well'
+)
+assert(
+  rankScore('style.font', 'font') < rankScore('apps.fontforge', 'font'),
+  'menu keeps a better-matching menu entry above a weaker app match'
+)
 const triggerItems = defaultItems.filter(item => item.parent === 'trigger')
 assertEqual(
   triggerItems[0].id,


### PR DESCRIPTION
Searching the menu for an app I have installed buries it. Typing "brave" lists Setup > Defaults > Browser, Install > Browser and Remove > Browser above the Brave app itself, so launching an installed app takes four keystrokes past three entries that install, remove or reconfigure it.

All four rows are exact label matches and score 0, which drops the decision to the `depthFor * 25 + order` tiebreak. Since `mergeAppRows` appends app rows after every static item, an app can never win that tiebreak.

This biases app rows ahead of menu entries that match the query equally well. The bias is smaller than the gap between match tiers, so a menu entry that matches better still sorts first — searching "font" still gives you Style > Font rather than FontForge.

Covered by two assertions in `test/shell.d/menu-test.sh`, built on the real `omarchy-menu.jsonc` since the bug only shows up at the full menu's item count.

Before:
<img width="354" height="419" alt="image" src="https://github.com/user-attachments/assets/2877ebe4-7018-4a2b-808d-1c3b270759e7" />
After:
<img width="352" height="431" alt="image" src="https://github.com/user-attachments/assets/f24d817e-98fa-4b7d-afb0-731761171810" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)