### PR TITLE
Search apps only when the menu query starts with a capital letter

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -277,9 +277,20 @@ function descriptionTextMatches(query, text) {
   return true
 }
 
+// A query whose first character is uppercase ("Steam") searches apps only;
+// lowercase ("steam") searches everything. Non-letter leading characters
+// behave like lowercase.
+function queryWantsAppsOnly(query) {
+  var q = String(query || "").trim()
+  if (!q) return false
+  var first = q.charAt(0)
+  return first !== first.toLowerCase()
+}
+
 function matchesQuery(entry, query, visible) {
   if (!entry || entry.id === "root") return false
   if (!visible) return false
+  if (queryWantsAppsOnly(query) && entry.kind !== "app") return false
 
   var nameText = nameSearchText(entry)
   var descriptionText = String(entry.description || "").toLowerCase()
@@ -357,6 +368,7 @@ if (typeof module !== "undefined") {
     nameSearchText: nameSearchText,
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
+    queryWantsAppsOnly: queryWantsAppsOnly,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
     displayRow: displayRow

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -278,8 +278,8 @@ function descriptionTextMatches(query, text) {
 }
 
 // A query whose first character is uppercase ("Steam") searches apps only;
-// lowercase ("steam") searches everything. Non-letter leading characters
-// behave like lowercase.
+// lowercase ("steam") searches everything. Leading characters with no
+// distinct uppercase form (digits, symbols) count as lowercase.
 function queryWantsAppsOnly(query) {
   var q = String(query || "").trim()
   if (!q) return false

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -94,7 +94,11 @@ assert(menu.matchesQuery(appEntry, 'Steam', true), 'menu capitalized query match
 assert(!menu.matchesQuery(entry, 'Theme', true), 'menu capitalized query excludes non-app rows')
 assert(menu.matchesQuery(entry, 'theme', true), 'menu lowercase query still matches everything')
 assert(menu.matchesQuery(entry, 'tHEME', true), 'menu mid-word capitals do not trigger apps-only')
-assert(!menu.queryWantsAppsOnly('1Password'), 'menu uncased leading characters stay a normal query')
+assert(!menu.queryWantsAppsOnly('1Password'), 'menu digit-leading queries stay a normal query')
+assert(!menu.queryWantsAppsOnly('@Steam'), 'menu symbol-leading queries stay a normal query')
+assert(menu.matchesQuery(entry, 'theme colors', true), 'menu lowercase multi-term queries match as before')
+assert(!menu.matchesQuery(entry, 'Theme colors', true), 'menu capitalized multi-term queries are apps-only too')
+assert(menu.matchesQuery(appEntry, 'Steam steam', true), 'menu apps-only multi-term queries still require every term')
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
 
 assertDeepEqual(

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -98,7 +98,7 @@ assert(!menu.queryWantsAppsOnly('1Password'), 'menu digit-leading queries stay a
 assert(!menu.queryWantsAppsOnly('@Steam'), 'menu symbol-leading queries stay a normal query')
 assert(menu.matchesQuery(entry, 'theme colors', true), 'menu lowercase multi-term queries match as before')
 assert(!menu.matchesQuery(entry, 'Theme colors', true), 'menu capitalized multi-term queries are apps-only too')
-assert(menu.matchesQuery(appEntry, 'Steam steam', true), 'menu apps-only multi-term queries still require every term')
+assert(!menu.matchesQuery(appEntry, 'Steam missing', true), 'menu apps-only multi-term queries still require every term')
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
 
 assertDeepEqual(

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -83,6 +83,18 @@ assert(menu.matchesQuery(entry, 'theme', true), 'menu matches labels and aliases
 assert(menu.matchesQuery(entry, 'colors', true), 'menu matches aliases')
 assert(!menu.matchesQuery(entry, 'missing', true), 'menu rejects missing terms')
 assert(!menu.matchesQuery(entry, 'theme', false), 'menu hides invisible matches')
+
+// App rows are built by Menu.qml's mergeAppRows, not normalizeItem.
+const appEntry = {
+  id: 'apps.steam', parent: 'apps', kind: 'app', icon: '', appIcon: '', appId: 'steam',
+  label: 'Steam', title: '', target: '', description: '', action: '', provider: '',
+  aliases: [], when: '', checked: '', order: 0
+}
+assert(menu.matchesQuery(appEntry, 'Steam', true), 'menu capitalized query matches app rows')
+assert(!menu.matchesQuery(entry, 'Theme', true), 'menu capitalized query excludes non-app rows')
+assert(menu.matchesQuery(entry, 'theme', true), 'menu lowercase query still matches everything')
+assert(menu.matchesQuery(entry, 'tHEME', true), 'menu mid-word capitals do not trigger apps-only')
+assert(!menu.queryWantsAppsOnly('1Password'), 'menu uncased leading characters stay a normal query')
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
 
 assertDeepEqual(


### PR DESCRIPTION
Typing an app name in the menu currently mixes the app in with same-label system rows — `steam` surfaces **Install > Steam** and **Remove > Steam** alongside (and, due to the depth/order tie-break, above) the Steam app itself.

This adds a small, discoverable convention borrowed from case-sensitive smartcase searching: **a query whose first letter is capitalized searches apps only.**

- `Steam` → just the app, like a launcher
- `steam` → everything, exactly as today (matching and ranking untouched)
- Queries starting with a digit or symbol behave like lowercase
- Composes with multi-term queries; only the first character of the trimmed query is inspected

The diff is one helper plus a single guard line in `matchesQuery` (and its test export). Verified live on omarchy 4.0.0.r1373 by running a side-by-side clone of the menu plugin, plus node tests against the CommonJS export covering the cases above and regressions that lowercase behaviour is unchanged.