### PR TITLE
Fix ASUS ExpertBook B9406 touchpad quirk never being applied

### DIFF
--- a/install/hardware/asus/fix-asus-ptl-b9406-touchpad.sh
+++ b/install/hardware/asus/fix-asus-ptl-b9406-touchpad.sh
@@ -8,13 +8,21 @@
 #
 # Mask the pressure axes with a quirks override, same pattern as the
 # Asus UX302LA entry in libinput's shipped 50-system-asus.quirks.
+#
+# libinput scans /usr/share/libinput for *.quirks and additionally reads the
+# single file /etc/libinput/local-overrides.quirks. It never scans /etc, so a
+# drop-in is the only way to ship a quirk without editing the one override
+# file users hand-edit themselves.
+#
+# The pad's event node is tagged ID_INPUT_MOUSE rather than ID_INPUT_TOUCHPAD,
+# so a MatchUdevType=touchpad constraint would skip the section. Bus, vendor,
+# product and DMI already pin the device exactly.
 
 if omarchy-hw-asus-expertbook-b9406; then
-  mkdir -p /etc/libinput
-  cat > /etc/libinput/asus-expertbook-b9406.quirks <<'EOF'
+  mkdir -p /usr/share/libinput
+  cat > /usr/share/libinput/99-omarchy-asus-b9406-touchpad.quirks <<'EOF'
 [ASUS ExpertBook B9406 Touchpad]
 MatchBus=i2c
-MatchUdevType=touchpad
 MatchVendor=0x093A
 MatchProduct=0x4F05
 MatchDMIModalias=dmi:*svnASUS*:pn*B9406*

--- a/migrations/1785114924.sh
+++ b/migrations/1785114924.sh
@@ -1,0 +1,7 @@
+echo "Fix ASUS ExpertBook B9406 touchpad quirk (takes effect at next login)"
+
+omarchy-hw-asus-expertbook-b9406 || exit 0
+
+sudo rm -f /etc/libinput/asus-expertbook-b9406.quirks
+sudo env OMARCHY_PATH="$OMARCHY_PATH" PATH="$PATH" \
+  bash -euo pipefail "$OMARCHY_PATH/install/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"


### PR DESCRIPTION
Ports #6093 to `quattro`, with the fix mechanism changed. Original diagnosis and hardware verification by @mijuny.

On a fresh install of an ASUS ExpertBook B9406 the touchpad is dead: clicks register but the cursor never moves. The quirk from #5435 that masks the pad's bogus pressure axes never took effect.

## Why it never applied

libinput `scandir`s `/usr/share/libinput` for `*.quirks` and *additionally* reads the single file `/etc/libinput/local-overrides.quirks`. It never scans `/etc`. The quirk was written to `/etc/libinput/asus-expertbook-b9406.quirks`, so it was silently ignored.

Verified against the installed libinput rather than taken from docs: built a probe against `libinput.so`, pointed `LIBINPUT_QUIRKS_DIR` at a copy of the data dir, and dropped in a deliberately malformed file under a name libinput does not ship. libinput failed quirks loading — proving it reads any `*.quirks` in that directory, not a fixed list.

## Drop-in rather than appending to local-overrides

#6093 appends to `local-overrides.quirks`. That works, but it is the one file users edit by hand, and a shared file can only be updated idempotently by grepping for a section we already wrote — which silently pins the first version we ever shipped. If the quirk ever needs correcting, the grep matches the stale section and the fix never lands.

A drop-in at `/usr/share/libinput/99-omarchy-asus-b9406-touchpad.quirks` is a file we own outright, rewritten wholesale on every run. Consistent with how `fix-z13-touchpad.sh` owns its udev rule, and with the `/usr/share/fontconfig/conf.avail`, `/usr/share/xdg-terminal-exec` and `/usr/lib/chromium` drop-ins already shipped elsewhere.

## MatchUdevType

Dropped, as in #6093: the pad's event node is tagged `ID_INPUT_MOUSE`, so a `touchpad` constraint skips the section. Bus, vendor, product and DMI already pin the device exactly, so the widened match is inert on any other hardware.

Worth flagging honestly: this claim sits uneasily with the original diagnosis, since the `"Touch jump detected and discarded"` message comes from libinput's touchpad backend, which only runs on devices tagged as touchpads. Most likely the pad exposes several event nodes. The reporter's confirmation also bundled both changes, so the evidence clearly supports the path fix and is only suggestive on this one. Kept because it costs nothing if unnecessary. Full touchpad classification (gestures, two-finger scroll) remains follow-up work.

## Quattro porting

Three things in #6093 would not have worked here:

- `sudo` throughout — `install/hardware/*` runs as root (`omarchy-setup-hardware` hard-fails if `EUID != 0`).
- the migration `source`d the leaf — migrations run as the user, so it now escalates explicitly.
- migration timestamp `1781432360` predates quattro's newest (`1785095882`) — renumbered.

Stale-file cleanup moved out of the install leaf into the migration; fresh installs never had that file.

## Verification

- Quirks syntax parses cleanly under real libinput with `MatchUdevType` removed.
- Install leaf is idempotent — byte-identical file on rerun.
- Migration end to end with stubbed `sudo`: removes the stale file, writes the drop-in, exits 0.
- Migration on non-matching hardware exits 0 and writes nothing.
- `test/shell.d/migrate-scope-test.sh` passes; `bash -n` clean.

Not verified on the hardware itself — @mijuny's B9406 is currently broken. The path fix is mechanically proven; a confirmation on a live B9406 before merge would be ideal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)