### PR TITLE
Prefer app id matches in menu search

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -253,7 +253,7 @@ Item {
       var appId = String(entry.id || "")
       if (!appId) continue
       var subtext = root.appLibrary.entrySubtext(entry)
-      var aliases = subtext ? [subtext] : []
+      var aliases = subtext ? [subtext, appId] : [appId]
       try {
         if (entry.keywords && typeof entry.keywords.join === "function") aliases = aliases.concat(entry.keywords)
       } catch (e) { }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -277,6 +277,14 @@ function descriptionTextMatches(query, text) {
   return true
 }
 
+var appTokenStopWords = ({ app: true, com: true, dev: true, io: true, net: true, org: true })
+
+function isMeaningfulAppToken(token) {
+  var value = String(token || "").toLowerCase()
+  if (value.length < 3) return false
+  return appTokenStopWords[value] !== true
+}
+
 function matchesQuery(entry, query, visible) {
   if (!entry || entry.id === "root") return false
   if (!visible) return false
@@ -303,6 +311,7 @@ function searchScore(items, entry, query) {
   var score = 80
 
   if (label === needle) score = entry.parent === "root" ? 2 : 0
+  else if (entry.kind === "app" && isMeaningfulAppToken(needle) && termInSearchWords(needle, nameText)) score = 0
   else if (label.indexOf(needle) === 0) score = 10
   else if (label.indexOf(needle) >= 0) score = 30
   else if (nameText.indexOf(needle) >= 0) score = 40
@@ -360,6 +369,7 @@ if (typeof module !== "undefined") {
     nameSearchText: nameSearchText,
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
+    isMeaningfulAppToken: isMeaningfulAppToken,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
     displayRow: displayRow

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -115,9 +115,14 @@ const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item])
 const rankBase = menu.mergeMenuSources(defaultItems, [])
 const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
   { id: 'apps.brave', parent: 'apps', kind: 'app', label: 'Brave', description: '', aliases: [] },
-  { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] }
+  { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] },
+  { id: 'apps.spotify', parent: 'apps', kind: 'app', label: 'Spotify', description: 'Music Player', aliases: ['Music Player', 'spotify'] },
+  { id: 'apps.com.libretro.RetroArch', parent: 'apps', kind: 'app', label: 'RetroArch', description: 'Game emulator frontend', aliases: ['Game emulator frontend', 'com.libretro.RetroArch'] },
+  { id: 'apps.example-control', parent: 'apps', kind: 'app', label: 'Example', description: '', aliases: [] },
+  { id: 'apps.com.example.Player', parent: 'apps', kind: 'app', label: 'Music Player', description: '', aliases: ['com.example.Player'] }
 ])
 const rankScore = (id, query) => menu.searchScore(ranked.items, ranked.items[id], query)
+const rankTier = (id, query) => Math.floor(rankScore(id, query) / 1000)
 assert(
   ['install.browser.brave', 'remove.browser.brave', 'setup.default.browser.brave'].every(
     id => rankScore('apps.brave', 'brave') < rankScore(id, 'brave')
@@ -127,6 +132,22 @@ assert(
 assert(
   rankScore('style.font', 'font') < rankScore('apps.fontforge', 'font'),
   'menu keeps a better-matching menu entry above a weaker app match'
+)
+assert(
+  rankScore('apps.spotify', 'spotify') < rankScore('install.service.spotify', 'spotify'),
+  'menu ranks installed Spotify above the install-service entry'
+)
+assert(
+  rankScore('apps.com.libretro.RetroArch', 'retroarch') < rankScore('install.gaming.retroarch', 'retroarch'),
+  'menu ranks installed RetroArch above the install-gaming entry'
+)
+assert(
+  rankTier('apps.com.example.Player', 'example') === rankTier('apps.example-control', 'example'),
+  'menu ranks meaningful app id token matches like exact app matches'
+)
+assert(
+  rankScore('apps.com.example.Player', 'com') > rankScore('apps.com.example.Player', 'example'),
+  'menu does not boost generic reverse-DNS namespace tokens'
 )
 const triggerItems = defaultItems.filter(item => item.parent === 'trigger')
 assertEqual(


### PR DESCRIPTION
## Summary
- include each desktop app id in the Omarchy menu app row search aliases
- rank exact app token matches, such as `spotify` from `com.spotify.Client`, like exact app label matches
- keep stronger menu matches above weaker app prefix matches

## Tests
- bash test/shell.d/menu-test.sh
- node -c shell/plugins/menu/MenuModel.js