### PR TITLE
Enable cd/dvd ejection by default - and use Omarchy glyph for "Done" messages in the terminal instead of spinning globe

### DIFF
--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -3,4 +3,5 @@
 # omarchy:summary=Display a "Done!" message with a spinner and wait for user to press any key.
 
 echo
-gum spin --spinner "globe" --title "Done! Press any key to close..." -- bash -c 'read -n 1 -s'
+printf '\ue900  Done! Press any key to close...'
+read -n 1 -s

--- a/default/hypr/bindings/media.lua
+++ b/default/hypr/bindings/media.lua
@@ -27,6 +27,7 @@ o.bind("XF86AudioPause", "Pause", "omarchy-shell media playPause", { locked = tr
 o.bind("XF86AudioPlay", "Play", "omarchy-shell media playPause", { locked = true })
 o.bind("XF86AudioPrev", "Previous track", "omarchy-shell media previous", { locked = true })
 o.bind("ALT + SHIFT + XF86AudioPlay", "Previous track", "omarchy-shell media previous", { locked = true })
+o.bind("XF86Eject", "Eject media", "eject", { locked = true })
 
 o.bind("SHIFT + XF86AudioMute", "Switch audio output", "omarchy-audio-output-switch", { locked = true })
 o.bind("SHIFT + XF86AudioPause", "Switch media source", "omarchy-audio-source-switch", { locked = true })


### PR DESCRIPTION
A two-in-one-PR. Take what you want :)

**Change 1**
Enable cd/dvd ejection by default for all systems with a key mapped to "XF86Eject".
This e.g. activates the eject button on vintage macbook Pro laptops with superdrives.

**Change 2**
Update Omarchy-show-done to use the Omarchy glyph in "Done" messages in the terminal. This gives a subtle hint that the Done message comes from the Omarchy system. Substitutes the spinning globe. 

Current:
<img width="259" height="45" alt="image" src="https://github.com/user-attachments/assets/95d3f068-79ad-41b4-b46c-78d1924227b9" />

Proposed:
<img width="276" height="35" alt="image" src="https://github.com/user-attachments/assets/54396664-5a7b-4a58-bb02-d8e70ffeb704" />
