### PR TITLE
Enable cd/dvd ejection by default

### DIFF
--- a/default/hypr/bindings/media.lua
+++ b/default/hypr/bindings/media.lua
@@ -27,6 +27,7 @@ o.bind("XF86AudioPause", "Pause", "omarchy-shell media playPause", { locked = tr
 o.bind("XF86AudioPlay", "Play", "omarchy-shell media playPause", { locked = true })
 o.bind("XF86AudioPrev", "Previous track", "omarchy-shell media previous", { locked = true })
 o.bind("ALT + SHIFT + XF86AudioPlay", "Previous track", "omarchy-shell media previous", { locked = true })
+o.bind("XF86Eject", "Eject media", "eject", { locked = true })
 
 o.bind("SHIFT + XF86AudioMute", "Switch audio output", "omarchy-audio-output-switch", { locked = true })
 o.bind("SHIFT + XF86AudioPause", "Switch media source", "omarchy-audio-source-switch", { locked = true })


### PR DESCRIPTION
Enable cd/dvd ejection by default for all systems with a key mapped to "XF86Eject".  This e.g. activates the eject button on vintage Macbook Pro laptops with optical drives.