### PR TITLE
feat(notifications): add right-click to dismiss popup

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -77,7 +77,14 @@ BorderSurface {
   MouseArea {
     anchors.fill: parent
     cursorShape: Qt.PointingHandCursor
-    onClicked: root.cardClicked()
+    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    onClicked: function(mouse) {
+      if (mouse.button === Qt.RightButton) {
+        root.closeRequested()
+      } else {
+        root.cardClicked()
+      }
+    }
   }
 
   ColumnLayout {


### PR DESCRIPTION
Add right-click handling to the notification card MouseArea so users can manually dismiss notifications by right-clicking on them.

Previously, only left-click was handled (which triggered the default action). Now right-click emits closeRequested() to dismiss the popup.