### PR TITLE
Defer plocate updatedb to an idle first-boot oneshot

### DIFF
--- a/etc/systemd/system/omarchy-updatedb-first-boot.service
+++ b/etc/systemd/system/omarchy-updatedb-first-boot.service
@@ -1,15 +1,16 @@
 [Unit]
 Description=Seed plocate database after Omarchy install
 Documentation=man:updatedb(8)
-ConditionPathExists=!/var/lib/plocate/plocate.db
+# plocate's package may leave a zero-byte placeholder DB; treat empty the same
+# as missing so the first-boot seed still runs.
+ConditionFileNotEmpty=!/var/lib/plocate/plocate.db
 After=local-fs.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/updatedb
-# Once plocate.db exists, ConditionPathExists skips this unit on later boots.
-# Leave the timer enabled; evaluating the condition is cheaper than unpacking
-# sandbox privileges enough to systemctl disable from ExecStartPost.
+# Once plocate.db is non-empty, ConditionFileNotEmpty skips later boots.
+# Leave the timer enabled; evaluating the condition is cheap.
 LimitNOFILE=131072
 IOSchedulingClass=idle
 Nice=19

--- a/etc/systemd/system/omarchy-updatedb-first-boot.service
+++ b/etc/systemd/system/omarchy-updatedb-first-boot.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Seed plocate database after Omarchy install
+Documentation=man:updatedb(8)
+ConditionPathExists=!/var/lib/plocate/plocate.db
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/updatedb
+# Once plocate.db exists, ConditionPathExists skips this unit on later boots.
+# Leave the timer enabled; evaluating the condition is cheaper than unpacking
+# sandbox privileges enough to systemctl disable from ExecStartPost.
+LimitNOFILE=131072
+IOSchedulingClass=idle
+Nice=19
+
+CapabilityBoundingSet=CAP_DAC_READ_SEARCH CAP_CHOWN
+IPAddressDeny=any
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service @chown

--- a/etc/systemd/system/omarchy-updatedb-first-boot.timer
+++ b/etc/systemd/system/omarchy-updatedb-first-boot.timer
@@ -4,7 +4,9 @@ Documentation=man:updatedb(8)
 # Fresh ISO installs skip updatedb in the chroot so install stays under a
 # minute. Fire once the desktop is already coming up; do not pull this into
 # the multi-user/graphical startup transaction (a WantedBy oneshot would).
-ConditionPathExists=!/var/lib/plocate/plocate.db
+# plocate's package may leave a zero-byte placeholder DB; treat empty the same
+# as missing so the first-boot seed still runs.
+ConditionFileNotEmpty=!/var/lib/plocate/plocate.db
 
 [Timer]
 OnBootSec=15s

--- a/etc/systemd/system/omarchy-updatedb-first-boot.timer
+++ b/etc/systemd/system/omarchy-updatedb-first-boot.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Seed plocate database shortly after first boot
+Documentation=man:updatedb(8)
+# Fresh ISO installs skip updatedb in the chroot so install stays under a
+# minute. Fire once the desktop is already coming up; do not pull this into
+# the multi-user/graphical startup transaction (a WantedBy oneshot would).
+ConditionPathExists=!/var/lib/plocate/plocate.db
+
+[Timer]
+OnBootSec=15s
+AccuracySec=1s
+Persistent=false
+Unit=omarchy-updatedb-first-boot.service
+
+[Install]
+WantedBy=timers.target

--- a/install/post-install/localdb.sh
+++ b/install/post-install/localdb.sh
@@ -1,2 +1,8 @@
-# Update localdb so locate can find the installed system files immediately.
-updatedb
+# Defer plocate indexing out of the ISO install critical path. A synchronous
+# updatedb here can cost several seconds on a fresh tree — enough to miss a
+# sub-minute install — and locate is not needed before the first reboot.
+#
+# Enable an idle first-boot oneshot (via a short OnBootSec timer) instead so
+# the desktop is not blocked; daily plocate-updatedb.timer keeps the index
+# fresh afterwards.
+systemctl enable omarchy-updatedb-first-boot.timer

--- a/install/post-install/localdb.sh
+++ b/install/post-install/localdb.sh
@@ -3,6 +3,6 @@
 # sub-minute install — and locate is not needed before the first reboot.
 #
 # Enable an idle first-boot oneshot (via a short OnBootSec timer) instead so
-# the desktop is not blocked; daily plocate-updatedb.timer keeps the index
-# fresh afterwards.
+# the desktop is not blocked; plocate-updatedb.timer (when enabled) keeps the
+# index fresh afterwards.
 systemctl enable omarchy-updatedb-first-boot.timer


### PR DESCRIPTION
## Summary
Defer `updatedb` from install into a first-boot idle oneshot so the installer does not block on a full plocate index.

- `install/post-install/localdb.sh` enables a timer instead of running `updatedb` synchronously
- `omarchy-updatedb-first-boot.timer` fires ~15s after boot (`OnBootSec=15s`)
- oneshot runs `updatedb` at `Nice=19` / `IOSchedulingClass=idle`, matching plocate hardening
- uses `ConditionFileNotEmpty=!/var/lib/plocate/plocate.db` so a zero-byte package placeholder still counts as unseeded

## Test results
Verified locally against `quattro` with a local-source ISO (`omarchy-iso-make --local-source`) and `omarchy-iso-test --install-only`:

- Install completed successfully (~63.6s total phases); configure phase no longer runs a sync `updatedb`
- Timer enabled on the installed system; units present under `/etc/systemd/system/`
- First build used `ConditionPathExists=!…`, which skipped the oneshot when plocate left a **0-byte** `plocate.db` — fixed to `ConditionFileNotEmpty=!…`
- After the fix: oneshot ran successfully (**~1.05s wall / 572ms CPU**, ~185M peak); `plocate.db` grew to ~5.1M and `locate` worked

## Test plan
- [x] Local ISO build with `--local-source` against this branch
- [x] `omarchy-iso-test --install-only` succeeded
- [x] Confirm no sync `updatedb` during post-install configure
- [x] Confirm empty placeholder DB still triggers first-boot seed
- [x] Confirm non-empty DB + working `locate` after oneshot