### PR TITLE
Add Dropbox pause toggle to panel header

### DIFF
--- a/shell/Ui/PanelHero.qml
+++ b/shell/Ui/PanelHero.qml
@@ -15,6 +15,7 @@ Item {
   property alias metaOpacity: metaText.opacity
 
   readonly property color dim: Qt.darker(foreground, 1.4)
+  readonly property real titleCenterY: heroLabels.y + titleRow.y + titleRow.height / 2
 
   width: parent ? parent.width : implicitWidth
   implicitHeight: Math.max(iconLoader.implicitHeight, heroLabels.implicitHeight)

--- a/shell/Ui/PanelHero.qml
+++ b/shell/Ui/PanelHero.qml
@@ -12,6 +12,7 @@ Item {
   property string fontFamily: Style.font.family
   property real iconSize: Style.font.display
   property real iconOpacity: 1.0
+  property real rightInset: 0
   property alias metaOpacity: metaText.opacity
 
   readonly property color dim: Qt.darker(foreground, 1.4)
@@ -33,6 +34,7 @@ Item {
     anchors.left: iconLoader.right
     anchors.leftMargin: Style.space(14)
     anchors.right: parent.right
+    anchors.rightMargin: root.rightInset
     anchors.verticalCenter: parent.verticalCenter
     spacing: Style.space(2)
 

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -244,6 +244,7 @@ Panel {
               x: root.heroRingPad
               y: root.heroRingPad
               width: parent.width - root.heroRingPad
+              rightInset: powerSwitch.visible ? powerSwitch.width + Style.space(20) : 0
               title: "Dropbox"
               meta: dropbox.active ? root.heroPhraseText : "Syncing paused"
               foreground: root.foreground
@@ -323,6 +324,7 @@ Panel {
                 enabled: !dropbox.busy
                 hoverEnabled: true
                 cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onContainsMouseChanged: if (containsMouse) header.focusHero()
                 onClicked: dropbox.toggleRunning()
               }
 

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -291,6 +291,47 @@ Panel {
                 }
               }
             }
+
+            BorderSurface {
+              id: powerSwitch
+              visible: dropbox.installed
+              z: 10
+              anchors.right: parent.right
+              anchors.rightMargin: Style.space(10)
+              y: hero.y + hero.titleCenterY - height / 2
+              width: Style.space(52)
+              height: Style.space(28)
+              radius: height / 2
+              color: dropbox.active
+                ? Style.selectedFillFor(root.foreground, Color.accent)
+                : Style.normalFillFor(root.foreground, Color.accent)
+              borderSpec: Border.controlSpec(dropbox.active ? "selected" : "normal", root.foreground, Color.accent)
+
+              Rectangle {
+                width: Style.space(20)
+                height: width
+                radius: height / 2
+                anchors.verticalCenter: parent.verticalCenter
+                x: dropbox.active ? parent.width - width - Style.space(4) : Style.space(4)
+                color: dropbox.active ? Style.selectedStateColor(root.foreground, Color.accent) : root.dim
+                Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+              }
+
+              MouseArea {
+                id: powerSwitchMouse
+                anchors.fill: parent
+                enabled: !dropbox.busy
+                hoverEnabled: true
+                cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: dropbox.toggleRunning()
+              }
+
+              PanelToolTip {
+                visible: powerSwitchMouse.containsMouse
+                text: dropbox.active ? "Pause syncing" : "Resume syncing"
+                fontFamily: root.fontFamily
+              }
+            }
           }
 
           Text {


### PR DESCRIPTION
## Summary

- add a compact pause/resume switch to the Dropbox panel title row
- reflect the optimistic active state immediately while Dropbox settles
- disable the switch and its tooltip while a Dropbox operation is busy
- retain the existing hero-icon and keyboard controls

## Related header-toggle PRs

- Tailscale: #6408
- Bluetooth: #6410

This includes the same `PanelHero.titleCenterY` helper as #6408 so the PR remains independently mergeable. If #6408 lands first, that shared one-line change drops out of this diff.

## Validation

- `bash test/shell.d/dropbox-test.sh`
- `git diff --check`