### PR TITLE
Add Bluetooth power toggle to panel header

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -586,6 +586,7 @@ Panel {
             anchors.left: heroIcon.right
             anchors.leftMargin: Style.space(14)
             anchors.right: parent.right
+            anchors.rightMargin: powerSwitch.visible ? powerSwitch.width + Style.space(20) : 0
             anchors.verticalCenter: parent.verticalCenter
             spacing: Style.space(2)
 
@@ -646,6 +647,7 @@ Panel {
               enabled: !!root.adapter
               hoverEnabled: true
               cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+              onContainsMouseChanged: if (containsMouse) root.setHeaderCursor()
               onClicked: root.toggleBluetooth()
             }
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -590,6 +590,7 @@ Panel {
             spacing: Style.space(2)
 
             Text {
+              id: heroTitle
               text: "Bluetooth"
               color: root.bar.foreground
               font.family: root.bar.fontFamily
@@ -609,6 +610,49 @@ Panel {
               font.letterSpacing: 1.2
               elide: Text.ElideRight
               width: parent.width
+            }
+          }
+
+          BorderSurface {
+            id: powerSwitch
+            visible: !!root.adapter
+            z: 10
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(10)
+            y: heroLabels.y + heroTitle.y + heroTitle.height / 2 - height / 2
+            width: Style.space(52)
+            height: Style.space(28)
+            radius: height / 2
+            color: root.adapter && root.adapter.enabled
+              ? Style.selectedFillFor(root.bar.foreground, Color.accent)
+              : Style.normalFillFor(root.bar.foreground, Color.accent)
+            borderSpec: Border.controlSpec(root.adapter && root.adapter.enabled ? "selected" : "normal", root.bar.foreground, Color.accent)
+
+            Rectangle {
+              width: Style.space(20)
+              height: width
+              radius: height / 2
+              anchors.verticalCenter: parent.verticalCenter
+              x: root.adapter && root.adapter.enabled ? parent.width - width - Style.space(4) : Style.space(4)
+              color: root.adapter && root.adapter.enabled
+                ? Style.selectedStateColor(root.bar.foreground, Color.accent)
+                : Qt.darker(root.bar.foreground, 1.55)
+              Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+            }
+
+            MouseArea {
+              id: powerSwitchMouse
+              anchors.fill: parent
+              enabled: !!root.adapter
+              hoverEnabled: true
+              cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+              onClicked: root.toggleBluetooth()
+            }
+
+            PanelToolTip {
+              visible: powerSwitchMouse.containsMouse
+              text: root.adapter && root.adapter.enabled ? "Turn Bluetooth off" : "Turn Bluetooth on"
+              fontFamily: root.bar.fontFamily
             }
           }
         }


### PR DESCRIPTION
## Summary

- add a compact Bluetooth power switch to the panel title row
- align it directly with the title using the existing hero-label geometry
- share the adapter's live enabled state and preserve the existing icon, right-click, and keyboard controls
- keep the tooltip tied to the enabled MouseArea

## Related header-toggle PRs

- Tailscale: #6408
- Dropbox: #6409

Each PR is independent and can be reviewed or merged separately.

## Validation

- `bash test/shell.d/bluetooth-test.sh`
- `git diff --check`