### PR TITLE
fix(omarchy-menu): Escape steps back one menu level before closing

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -975,8 +975,12 @@ Item {
             root.requestDeleteSelected()
             event.accepted = true
           } else if (event.key === Qt.Key_Escape) {
+            // Clear an active search first, then step back one menu level
+            // (same as Backspace/Left) before falling back to a full close --
+            // otherwise Esc inside any submenu (e.g. style -> style.theme)
+            // skipped goBack() entirely and closed the whole menu in one press.
             if (root.filterText) root.setFilter("")
-            else root.cancel()
+            else if (!root.goBack()) root.cancel()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -976,8 +976,7 @@ Item {
             event.accepted = true
           } else if (event.key === Qt.Key_Escape) {
             // Clear an active search first, then step back one menu level
-            // (same as Backspace/Left) before falling back to a full close --
-            // otherwise Esc inside any submenu (e.g. style -> style.theme)
+            // (same as Backspace/Left) before falling back to a full close
             // skipped goBack() entirely and closed the whole menu in one press.
             if (root.filterText) root.setFilter("")
             else if (!root.goBack()) root.cancel()


### PR DESCRIPTION
# Menu — Escape Back-Navigation Fix

**File:** `Menu.qml`

**Bug:** Pressing `Esc` inside any submenu closed the entire menu immediately
instead of stepping back one level, forcing you to reopen the menu and
re-navigate every time.

**Fix:** `Esc` now calls `goBack()` first (same as `Backspace`/`Left`), and
only falls back to a full close once already at the root menu.

Before:

https://github.com/user-attachments/assets/db30f5fd-2bf5-44c5-bac9-a89d6f0dad15

After:

https://github.com/user-attachments/assets/e7bc4b74-8a01-47cf-b8dd-81714cf16e7b

