### PR TITLE
Stop stranding the Launching… OSD when a second app is launched

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -150,11 +150,15 @@ Item {
     try { return ToplevelManager.toplevels.values.length } catch (e) { return 0 }
   }
 
+  // launchOsdOpen tracks whether the OSD is on screen, not which launch put it
+  // there, so a new launch must not clear it: the OSD is shown with duration 0,
+  // and only closeLaunchFeedback() takes it down. Dropping the flag here would
+  // orphan an OSD left over from the previous launch, and the timer restarts
+  // below discard the timeout that was its last chance to close.
   function beginLaunchFeedback(name) {
     root.launchSerial++
     root.launchToplevelCount = root.toplevelCount()
     root.launchActiveToplevel = ToplevelManager.activeToplevel
-    root.launchOsdOpen = false
     root.launchOsdMessage = "Launching " + String(name || "application") + "…"
     launchDelay.restart()
     launchTimeout.restart()

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -26,6 +26,9 @@ Item {
   property int launchSerial: 0
   property int launchToplevelCount: 0
   property var launchActiveToplevel: null
+  // True while the launch OSD is on screen. It outlives the launch that opened
+  // it: the OSD shows with duration 0, so only closeLaunchFeedback() takes it
+  // down.
   property bool launchOsdOpen: false
   property string launchOsdMessage: ""
 
@@ -150,11 +153,6 @@ Item {
     try { return ToplevelManager.toplevels.values.length } catch (e) { return 0 }
   }
 
-  // launchOsdOpen tracks whether the OSD is on screen, not which launch put it
-  // there, so a new launch must not clear it: the OSD is shown with duration 0,
-  // and only closeLaunchFeedback() takes it down. Dropping the flag here would
-  // orphan an OSD left over from the previous launch, and the timer restarts
-  // below discard the timeout that was its last chance to close.
   function beginLaunchFeedback(name) {
     root.launchSerial++
     root.launchToplevelCount = root.toplevelCount()

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -121,6 +121,13 @@ assert(
   'app library prefers indexed app icons over ambiguous themed icons'
 )
 
+const beginLaunchMatch = appLibraryQml.match(/function beginLaunchFeedback\(name\) \{([\s\S]*?)\n  \}/)
+assert(beginLaunchMatch, 'app library beginLaunchFeedback function exists')
+assert(
+  !beginLaunchMatch[1].includes('root.launchOsdOpen = false'),
+  'app library keeps owning an OSD a previous launch left on screen'
+)
+
 const openMatch = menuQml.match(/function openExistingMenu\(initialMenu\) \{([\s\S]*?)\n  \}/)
 assert(openMatch, 'menu openExistingMenu function exists')
 assert(


### PR DESCRIPTION
### Description

`beginLaunchFeedback()` reset `launchOsdOpen` to `false` on every launch. That flag records whether the "Launching …" OSD is currently on screen, not which launch put it there, so clearing it on a new launch makes the shell forget an OSD that is still visible.

`closeLaunchFeedback()` only sends `osd close` when the flag is set, and the OSD is shown with `duration: 0`, so nothing else takes it down. The same function also restarts `launchTimeout`, discarding the 15s backstop that would otherwise have caught it. The result is an OSD that stays on screen for the rest of the session.

Dropping the reset is enough: the flag stays truthful, so the next `closeLaunchFeedback()` closes the OSD, and the 15s timeout works again for apps that never open a window.

To reproduce, both launches must go through the launcher:

1. Launch a slow app (one that takes more than ~2s to map a window). "Launching …" appears.
2. While it is still showing, launch a fast app from the launcher.
3. The fast app opens, but the OSD stays — past the slow app's own window, past the 15s timeout, indefinitely.

Launching the second app from a keybinding instead does not strand it, since keybindings never call `beginLaunchFeedback()`.

### Motivation

A stuck "Launching …" OSD sits over the desktop until the shell is restarted, and `omarchy-shell osd close` is the only way to clear it. Launching a second app from the launcher while a slow one is still starting is ordinary use, and it is enough to trigger this.
