### PR TITLE
fix: use device state as source of truth for battery charge status

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -59,7 +59,12 @@ Panel {
   }
   readonly property bool discharging: {
     var device = UPower.displayDevice
-    return !!(device && device.isPresent && UPower.onBattery)
+    if (!(device && device.isPresent)) return false
+    // Trust the battery's own reported state in addition to the global
+    // UPower.onBattery flag. The two can disagree (AC-detection can lag or
+    // get stuck), and when they do, the per-device state is the one that
+    // matches physical reality — it's what /sys/class/power_supply reports.
+    return !!(UPower.onBattery || device.state === UPowerDeviceState.Discharging)
   }
   readonly property bool chargeThresholdActive: {
     var device = UPower.displayDevice
@@ -76,7 +81,7 @@ Panel {
 
   readonly property bool charging: {
     var d = UPower.displayDevice
-    return d && d.isPresent && !UPower.onBattery && !root.batteryFlowIdle
+    return d && d.isPresent && !root.discharging && !root.batteryFlowIdle
   }
 
   readonly property color batteryFillColor: {


### PR DESCRIPTION
# Power Panel
 
## Known bug (fixed): battery icon stuck on "charging" after unplugging AC
 
<img width="400" height="600" alt="screenshot-2026-07-28_18-19-56" src="https://github.com/user-attachments/assets/a2269a8c-a803-4e02-b79d-6ea5236a5af0" />


### Symptom
Sometimes, right after unplugging the charger from the laptop, the battery icon in the top bar (and the status text in the panel) kept showing the "charging" state (AC/bolt icon), even though the battery itself was actually discharging. This was confirmed by checking the battery status directly from the system (`/sys/class/power_supply/BATx/status`), which correctly reported `Discharging` — yet the UI still displayed the charging state.
 
### Root cause
All of the battery-status display logic (the icon, the status label, the progress-bar pulse animation, and even the command run when switching power profiles) relied solely on a single global system flag, `UPower.onBattery`. This flag reflects whether the system is connected to wall power, but it doesn't always update instantly in lockstep with the battery's own reported state — particularly right around the moment the charger is plugged or unplugged, when AC detection can lag one step behind the state actually reported by the battery itself (`device.state`).
 
As a result, whenever these two sources of truth (the global AC flag and the battery's own state) fell out of sync, the UI trusted only the AC flag and mistakenly displayed the battery as "charging."
 
### What changed
The logic for determining "discharging" was rewritten to also check the battery's own reported state (`Discharging`) directly, in addition to the global AC flag. This means that as soon as the battery itself reports that it's discharging, the UI corrects itself immediately — even if the global AC flag hasn't updated yet or is temporarily out of sync.
 
An additional internal inconsistency was also fixed: the progress-bar pulse animation (the subtle pulsing effect shown while the battery is charging) was previously reading the global AC flag directly, independent of the corrected logic above. It now draws from the same single, corrected source of truth for battery state, so the whole UI (icon, text, and animation) always tells one consistent story instead of each piece potentially deciding — and disagreeing — on its own.
 
Practical result: as soon as the charger is unplugged, the icon and status text switch to the correct "discharging" state immediately, without lagging or getting stuck.
 
