### PR TITLE
Fix silent launch failure for apps whose desktop id ends in .desktop (Telegram)

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -78,7 +78,10 @@ Item {
     var id = String(desktopId || "")
     if (!id) return
     root.beginLaunchFeedback(name)
-    Util.execDetached("gtk-launch " + Util.shellQuote(id))
+    // Pass the full file name: gtk-launch only appends ".desktop" when the
+    // argument doesn't already end with it, so ids that themselves end in
+    // ".desktop" (e.g. org.telegram.desktop) would otherwise never resolve.
+    Util.execDetached("gtk-launch " + Util.shellQuote(id + ".desktop"))
   }
 
   function remove(desktopId, name) {

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -78,9 +78,9 @@ Item {
     var id = String(desktopId || "")
     if (!id) return
     root.beginLaunchFeedback(name)
-    // Pass the full file name: gtk-launch only appends ".desktop" when the
-    // argument doesn't already end with it, so ids that themselves end in
-    // ".desktop" (e.g. org.telegram.desktop) would otherwise never resolve.
+    // Pass the file name with its extension: gtk-launch only appends ".desktop"
+    // when the argument doesn't already end with it, so ids that themselves end
+    // in ".desktop" (e.g. org.telegram.desktop) would otherwise never resolve.
     Util.execDetached("gtk-launch " + Util.shellQuote(id + ".desktop"))
   }
 

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -105,6 +105,11 @@ assert(
 )
 
 assert(
+  appLibraryQml.includes('Util.shellQuote(id + ".desktop")'),
+  'app library launches by full file name so ids ending in .desktop (org.telegram.desktop) resolve'
+)
+
+assert(
   /function iconIndexScanCommand\(\)[\s\S]*-path "\*\/apps\/\*" -o -path "\*\/devices\/\*"/.test(appLibraryQml),
   'app library fallback icon index includes device icons'
 )


### PR DESCRIPTION
# Fix silent launch failure for apps whose desktop id ends in ".desktop" (Telegram)

## Problem

Since the quattro shell, Telegram cannot be launched from the app menu at all: selecting it shows the "Launching Telegram…" OSD, then nothing happens. No process is spawned and nothing is logged. Launching `/usr/bin/Telegram` from a terminal works fine, and reinstalling the package doesn't help (see #6312, closed for lack of detail — this is that bug).

## Root cause

`AppLibrary.launch()` runs `gtk-launch <entry.id>`. Quickshell's `DesktopEntry.id` is the desktop file basename with the final `.desktop` extension stripped, so for Telegram's `org.telegram.desktop.desktop` the id is `org.telegram.desktop`.

`gtk-launch` (both GTK3 and GTK4) only appends the `.desktop` suffix when the argument doesn't already end with it. Since Telegram's id itself ends in `.desktop`, gtk-launch treats it as a complete file name and looks for a file literally named `org.telegram.desktop`, which doesn't exist:

```
$ gtk-launch org.telegram.desktop
gtk-launch: no such application org.telegram.desktop

$ gtk-launch org.telegram.desktop.desktop   # works
```

The error is discarded by `execDetached`, so the failure is completely silent. Telegram is typically the only installed app with a reverse-DNS id ending in `.desktop`, which is why everything else launches normally.

## Fix

Pass the full file name to gtk-launch by appending `.desktop` to the id. This is unambiguous for both naming styles:

- `bitwarden` → `bitwarden.desktop` ✅ (same result as before)
- `org.telegram.desktop` → `org.telegram.desktop.desktop` ✅ (previously broken)

Also adds a regression assertion to `test/shell.d/app-search-test.sh`.

## Testing

- `bash test/shell.d/app-search-test.sh` — all 21 assertions pass, including the new one.
- Verified on an affected machine (Arch, omarchy quattro, telegram-desktop 7.0.6): `gtk-launch org.telegram.desktop` reproducibly fails, `gtk-launch org.telegram.desktop.desktop` launches Telegram; with the patched shell the menu launches Telegram again.
