### PR TITLE
Fix universal clipboard shortcuts under non-Latin keyboard layouts

### DIFF
--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -42,7 +42,10 @@ local function universal_clipboard_shortcut(default_mods, default_key, terminal_
   end
 end
 
-o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
-o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
+-- Letters are sent by physical keycode: send_key_state resolves key names in
+-- the active keymap, so "V" is "key not found" while a non-Latin layout
+-- (ru, ua, gr, ...) is active. Keycodes are layout-independent.
+o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "code:54", "CTRL", "Insert"))
+o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "code:55", "SHIFT", "Insert"))
+o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "code:53"))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")


### PR DESCRIPTION
## Problem

With a non-Latin keyboard layout active (Russian, Ukrainian, Greek, …), Super+V / Super+C / Super+X do nothing except pop a notification:

```
Runtime error in lua:
=[C]:-1: send_key_state: key not found
```

## Root cause

`send_key_state` resolves key *names* against the currently active keymap. While e.g. the Russian layout is active, the name `V` has no keysym in the keymap (that physical key produces Cyrillic М), so the lookup fails and the shortcut aborts. `Insert` still resolves — special keys exist in every layout — which is why the terminal branch of universal paste keeps working while the Ctrl+V branch errors out.

Reproducible directly:

```
$ hyprctl dispatch "hl.dsp.send_key_state({ mods = 'CTRL', key = 'V', state = 'up' })"
error: =[C]:-1: send_key_state: key not found        # Russian layout active
ok                                                   # US layout active
```

## Fix

Send the letter keys by physical keycode (`code:54`/`code:55`/`code:53` for C/V/X), which resolves regardless of the active layout:

```
$ hyprctl dispatch "hl.dsp.send_key_state({ mods = 'CTRL', key = 'code:55', state = 'up' })"
ok                                                   # Russian layout active
```

`Insert` is left as a name since it is layout-independent already.

## Testing

Verified on an affected machine (Arch, omarchy quattro, `us,ru` layouts): with the patched bindings, universal copy/paste/cut work in both layouts, in terminals and regular windows; no more runtime error notifications. `test/shell` passes (except the pre-existing `omarchy-pkgs checkout` environment check, which is unrelated).
