### PR TITLE
Show OSD and sync touchpad steps when scrolling bar widgets (audio, monitor)

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -18,6 +18,10 @@ QtObject {
   }
 
   function wheelSteps(accumulator, delta) {
+    // Some mouse/compositor combinations scale a single notch well beyond
+    // Qt's conventional 120 units. Keep one event to one step while still
+    // accumulating the smaller deltas emitted by touchpads.
+    delta = Math.max(-120, Math.min(120, delta))
     if (accumulator * delta < 0) accumulator = 0
     var total = accumulator + delta
     var steps = total < 0 ? Math.ceil(total / 120) : Math.floor(total / 120)

--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -17,6 +17,13 @@ QtObject {
     return clamp(value, 0, 1)
   }
 
+  function wheelSteps(accumulator, delta) {
+    if (accumulator * delta < 0) accumulator = 0
+    var total = accumulator + delta
+    var steps = total < 0 ? Math.ceil(total / 120) : Math.floor(total / 120)
+    return { steps: steps, remainder: total - steps * 120 }
+  }
+
   // Compose a base color with an opacity. Accepts a color object or a hex
   // string; null/undefined yields transparent black at the requested alpha.
   function alpha(c, opacity) {

--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -176,6 +176,10 @@ Item {
             height: parent.height
             width: parent.width * (root.hasProgress ? root.value / root.maxValue : 0)
             color: Color.accent
+
+            Behavior on width {
+              NumberAnimation { duration: 280; easing.type: Easing.OutCubic }
+            }
           }
         }
         Text {

--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -56,6 +56,8 @@ Item {
 
   function show(iconName, rawMessage, rawValue, rawMax, rawProgressText, rawDuration) {
     var next = OsdModel.stateForShow(iconName, rawMessage, rawValue, rawMax, rawProgressText, rawDuration)
+    // Update before opening so a fresh OSD starts at its new value; only
+    // subsequent updates while it remains open animate the progress bar.
     iconKey = next.iconKey
     maxValue = next.maxValue
     hasProgress = next.hasProgress
@@ -178,7 +180,8 @@ Item {
             color: Color.accent
 
             Behavior on width {
-              NumberAnimation { duration: 280; easing.type: Easing.OutCubic }
+              enabled: root.opened
+              NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
             }
           }
         }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -121,10 +121,7 @@ Panel {
   // selected while a tuning still exists.
   property string volumeSinkName: ""
 
-  // Raw wheel delta accumulated between discrete volume steps. A mouse notch
-  // (delta = ±120) crosses the threshold and fires one step immediately; a
-  // touchpad's stream of small deltas piles up here until it crosses that
-  // same threshold, so both devices move the volume in identical 5% steps.
+  // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
 
   readonly property var volumeSink: {
@@ -171,7 +168,13 @@ Panel {
   // "header" is a virtual section for the hero output mute toggle; it sits
   // above the output section so the speaker can be muted from the keyboard.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
-  readonly property int heroRingPad: Style.space(6)
+  // Only channels that actually exist get a vote. A box with no default source
+  // would otherwise report "input unmuted" forever, leaving the hero switch
+  // able to mute but never to unmute.
+  readonly property bool hasOutput: !!(volumeSink && volumeSink.audio)
+  readonly property bool hasInput: !!(source && source.audio)
+  readonly property bool anyAudible: (hasOutput && !outputMuted) || (hasInput && !inputMuted)
+  readonly property string toggleHint: anyAudible ? "Mute" : "Unmute"
 
   readonly property color hoverFill: bar
     ? Style.hoverFillFor(bar.foreground, Color.accent)
@@ -285,7 +288,7 @@ Panel {
 
   // Enter/Space: activate whatever the cursor is on.
   function activateCursor() {
-    if (focusSection === "header") { toggleOutputMute(); return }
+    if (focusSection === "header") { toggleAllMuted(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
       var sink = displayAudioSinks[selectedIndex]
@@ -379,6 +382,10 @@ Panel {
   function clampCursor() {
     var sections = visibleSections
     if (!sections || !sections.length) return
+    // "header" is virtual and never appears in visibleSections, so it has to
+    // be let through: muting republishes the PipeWire snapshot, and clamping
+    // would knock the cursor off the hero switch on every toggle.
+    if (focusSection === "header") return
     if (sections.indexOf(focusSection) < 0) {
       focusSection = visibleSections[0]
       selectedIndex = sectionHasSlider(focusSection) ? -1 : 0
@@ -391,13 +398,13 @@ Panel {
     if (selectedIndex < floor) selectedIndex = floor
   }
 
-  function outputIcon() {
+  function outputIcon(volume) {
     // Match the old Waybar pulseaudio glyph set. The Material Design speaker
     // icons render visually smaller in JetBrainsMono Nerd Font.
     if (!sink || !sink.audio) return ""
     if (isHeadphones(sink)) return "󰋋"
     if (outputMuted) return ""
-    var v = outputVolume
+    var v = volume === undefined ? outputVolume : volume
     if (v >= 0.67) return ""
     if (v >= 0.34) return ""
     if (v > 0) return ""
@@ -417,25 +424,18 @@ Panel {
   }
 
   function setOutputVolume(v) {
-    if (!sink || !sink.audio) return
-    volumeSink.audio.volume = Math.max(0, Math.min(1, v))
+    if (!volumeSink || !volumeSink.audio) return outputVolume
+    var volume = Math.max(0, Math.min(1, v))
+    volumeSink.audio.volume = volume
+    return volume
   }
 
-  // Mirrors what omarchy-audio-output-volume shows after a keyboard raise/
-  // lower, so scrolling the bar icon (and any other in-panel volume change)
-  // gets the same OSD feedback instead of only the keyboard media keys.
-  // Same 0.67/0.34 breakpoints as outputIcon(), so the OSD icon always
-  // matches the bar icon rather than only ever showing muted/high.
-  function showVolumeOsd() {
-    var icon = "volume-muted"
-    if (!outputMuted && outputVolume > 0) {
-      if (outputVolume >= 0.67) icon = "volume-high"
-      else if (outputVolume >= 0.34) icon = "volume-medium"
-      else icon = "volume-low"
-    }
-    var percent = Math.round(outputVolume * 100)
-    osdProc.command = ["omarchy-osd", "-i", icon, "-p", String(percent)]
-    osdProc.running = true
+  function showVolumeOsd(volume) {
+    if (!bar || !bar.shell) return
+    bar.shell.summon("omarchy.osd", JSON.stringify({
+      icon: outputIcon(volume),
+      value: Math.round(volume * 100)
+    }))
   }
 
   function setInputVolume(v) {
@@ -449,6 +449,15 @@ Panel {
 
   function toggleInputMute() {
     if (source && source.audio) source.audio.muted = !source.audio.muted
+  }
+
+  // The hero switch is the whole panel's on/off, so it carries both channels
+  // at once. It reads as on while anything is still audible, which keeps
+  // muting a single channel from the row below flipping the master switch.
+  function toggleAllMuted() {
+    var mute = anyAudible
+    if (hasOutput) volumeSink.audio.muted = mute
+    if (hasInput) source.audio.muted = mute
   }
 
   function setDefaultSink(node) {
@@ -592,10 +601,6 @@ Panel {
     }
   }
 
-  Process {
-    id: osdProc
-  }
-
   Timer {
     interval: 5000
     running: root.opened
@@ -633,29 +638,12 @@ Panel {
     }
 
     onWheelMoved: function(delta) {
-      // One step = 120 units, matching a single mouse notch, so a mouse
-      // click still moves exactly 5%. A touchpad's small deltas pile up in
-      // wheelAccumulator until they cross that same threshold, then fire
-      // the identical 5% step. The OSD is only pinged when a step actually
-      // lands (not on a fixed timer), so it stays open and updates exactly
-      // in step with the real scroll rhythm -- no tick separate from your
-      // finger's motion -- and only starts counting down to hide once you
-      // stop scrolling (each ping restarts its own hide timer).
-      var stepUnits = 120
-      var stepSize = 0.05
-      var stepped = false
-      root.wheelAccumulator += delta
-      while (root.wheelAccumulator >= stepUnits) {
-        root.setOutputVolume(root.outputVolume + stepSize)
-        root.wheelAccumulator -= stepUnits
-        stepped = true
-      }
-      while (root.wheelAccumulator <= -stepUnits) {
-        root.setOutputVolume(root.outputVolume - stepSize)
-        root.wheelAccumulator += stepUnits
-        stepped = true
-      }
-      if (stepped) root.showVolumeOsd()
+      if (!root.hasOutput) return
+      var wheel = Util.wheelSteps(root.wheelAccumulator, delta)
+      root.wheelAccumulator = wheel.remainder
+      if (wheel.steps === 0) return
+      var volume = root.setOutputVolume(root.outputVolume + wheel.steps * 0.05)
+      root.showVolumeOsd(volume)
     }
   }
 
@@ -718,19 +706,9 @@ Panel {
           Item {
             id: heroItem
             width: parent.width
-            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight) + root.heroRingPad * 2
+            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, powerSwitch.implicitHeight)
 
-            // Keyboard focus ring around the hero output-mute toggle. heroIcon
-            // is inset by heroRingPad so this ring stays inside the clip box.
-            BorderSurface {
-              anchors.fill: heroIcon
-              anchors.margins: -root.heroRingPad
-              color: "transparent"
-              radius: Style.cornerRadius
-              visible: root.headerHasCursor
-              borderSpec: Border.controlSpec("hover-cursor", root.bar.foreground, Color.accent)
-            }
-
+            // Status only — the switch owns muting, mouse and keyboard alike.
             Text {
               id: heroIcon
               text: root.outputIcon()
@@ -739,15 +717,26 @@ Panel {
               font.pixelSize: Style.font.display
               opacity: root.outputMuted ? 0.5 : 1.0
               anchors.left: parent.left
-              anchors.leftMargin: root.heroRingPad
               anchors.verticalCenter: parent.verticalCenter
+            }
 
-              MouseArea {
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onContainsMouseChanged: if (containsMouse) root.setHeaderCursor()
-                onClicked: root.toggleOutputMute()
+            // Compact on/off switch on the trailing edge of the hero, and the
+            // header's only cursor target. Checked means something is still
+            // audible, so muting everything reads as switching audio off.
+            ToggleSwitch {
+              id: powerSwitch
+              checked: root.anyAudible
+              hasCursor: root.headerHasCursor
+              foreground: root.bar.foreground
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              onHovered: function(on) { if (on) root.setHeaderCursor() }
+              onToggled: root.toggleAllMuted()
+
+              PanelToolTip {
+                visible: powerSwitch.containsMouse
+                text: root.toggleHint
+                fontFamily: root.bar.fontFamily
               }
             }
 
@@ -756,6 +745,7 @@ Panel {
               anchors.left: heroIcon.right
               anchors.leftMargin: Style.space(14)
               anchors.right: parent.right
+              anchors.rightMargin: powerSwitch.width + Style.space(12)
               anchors.verticalCenter: parent.verticalCenter
               spacing: Style.space(2)
 
@@ -845,6 +835,7 @@ Panel {
                 enabled: !!root.sink
 
                 onMoved: function(v) { root.setOutputVolume(v) }
+                onRightClicked: root.toggleOutputMute()
               }
 
               HoverHandler {
@@ -936,6 +927,7 @@ Panel {
                   enabled: !!root.source
 
                   onMoved: function(v) { root.setInputVolume(v) }
+                  onRightClicked: root.toggleInputMute()
                 }
 
                 Rectangle {
@@ -1222,6 +1214,10 @@ Panel {
 
         onMoved: function(v) {
           if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
+        }
+        onRightClicked: {
+          if (streamRow.node && streamRow.node.audio)
+            streamRow.node.audio.muted = !streamRow.node.audio.muted
         }
       }
     }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -121,6 +121,12 @@ Panel {
   // selected while a tuning still exists.
   property string volumeSinkName: ""
 
+  // Raw wheel delta accumulated between discrete volume steps. A mouse notch
+  // (delta = ±120) crosses the threshold and fires one step immediately; a
+  // touchpad's stream of small deltas piles up here until it crosses that
+  // same threshold, so both devices move the volume in identical 5% steps.
+  property real wheelAccumulator: 0
+
   readonly property var volumeSink: {
     if (volumeSinkName === "" || !sink) return sink
     if (volumeSinkName === String(sink.name)) return sink
@@ -165,13 +171,7 @@ Panel {
   // "header" is a virtual section for the hero output mute toggle; it sits
   // above the output section so the speaker can be muted from the keyboard.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
-  // Only channels that actually exist get a vote. A box with no default source
-  // would otherwise report "input unmuted" forever, leaving the hero switch
-  // able to mute but never to unmute.
-  readonly property bool hasOutput: !!(volumeSink && volumeSink.audio)
-  readonly property bool hasInput: !!(source && source.audio)
-  readonly property bool anyAudible: (hasOutput && !outputMuted) || (hasInput && !inputMuted)
-  readonly property string toggleHint: anyAudible ? "Mute" : "Unmute"
+  readonly property int heroRingPad: Style.space(6)
 
   readonly property color hoverFill: bar
     ? Style.hoverFillFor(bar.foreground, Color.accent)
@@ -285,7 +285,7 @@ Panel {
 
   // Enter/Space: activate whatever the cursor is on.
   function activateCursor() {
-    if (focusSection === "header") { toggleAllMuted(); return }
+    if (focusSection === "header") { toggleOutputMute(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
       var sink = displayAudioSinks[selectedIndex]
@@ -379,10 +379,6 @@ Panel {
   function clampCursor() {
     var sections = visibleSections
     if (!sections || !sections.length) return
-    // "header" is virtual and never appears in visibleSections, so it has to
-    // be let through: muting republishes the PipeWire snapshot, and clamping
-    // would knock the cursor off the hero switch on every toggle.
-    if (focusSection === "header") return
     if (sections.indexOf(focusSection) < 0) {
       focusSection = visibleSections[0]
       selectedIndex = sectionHasSlider(focusSection) ? -1 : 0
@@ -425,6 +421,23 @@ Panel {
     volumeSink.audio.volume = Math.max(0, Math.min(1, v))
   }
 
+  // Mirrors what omarchy-audio-output-volume shows after a keyboard raise/
+  // lower, so scrolling the bar icon (and any other in-panel volume change)
+  // gets the same OSD feedback instead of only the keyboard media keys.
+  // Same 0.67/0.34 breakpoints as outputIcon(), so the OSD icon always
+  // matches the bar icon rather than only ever showing muted/high.
+  function showVolumeOsd() {
+    var icon = "volume-muted"
+    if (!outputMuted && outputVolume > 0) {
+      if (outputVolume >= 0.67) icon = "volume-high"
+      else if (outputVolume >= 0.34) icon = "volume-medium"
+      else icon = "volume-low"
+    }
+    var percent = Math.round(outputVolume * 100)
+    osdProc.command = ["omarchy-osd", "-i", icon, "-p", String(percent)]
+    osdProc.running = true
+  }
+
   function setInputVolume(v) {
     if (!source || !source.audio) return
     source.audio.volume = Math.max(0, Math.min(1, v))
@@ -436,15 +449,6 @@ Panel {
 
   function toggleInputMute() {
     if (source && source.audio) source.audio.muted = !source.audio.muted
-  }
-
-  // The hero switch is the whole panel's on/off, so it carries both channels
-  // at once. It reads as on while anything is still audible, which keeps
-  // muting a single channel from the row below flipping the master switch.
-  function toggleAllMuted() {
-    var mute = anyAudible
-    if (hasOutput) volumeSink.audio.muted = mute
-    if (hasInput) source.audio.muted = mute
   }
 
   function setDefaultSink(node) {
@@ -588,6 +592,10 @@ Panel {
     }
   }
 
+  Process {
+    id: osdProc
+  }
+
   Timer {
     interval: 5000
     running: root.opened
@@ -625,8 +633,29 @@ Panel {
     }
 
     onWheelMoved: function(delta) {
-      var step = 0.05
-      root.setOutputVolume(root.outputVolume + (delta > 0 ? step : -step))
+      // One step = 120 units, matching a single mouse notch, so a mouse
+      // click still moves exactly 5%. A touchpad's small deltas pile up in
+      // wheelAccumulator until they cross that same threshold, then fire
+      // the identical 5% step. The OSD is only pinged when a step actually
+      // lands (not on a fixed timer), so it stays open and updates exactly
+      // in step with the real scroll rhythm -- no tick separate from your
+      // finger's motion -- and only starts counting down to hide once you
+      // stop scrolling (each ping restarts its own hide timer).
+      var stepUnits = 120
+      var stepSize = 0.05
+      var stepped = false
+      root.wheelAccumulator += delta
+      while (root.wheelAccumulator >= stepUnits) {
+        root.setOutputVolume(root.outputVolume + stepSize)
+        root.wheelAccumulator -= stepUnits
+        stepped = true
+      }
+      while (root.wheelAccumulator <= -stepUnits) {
+        root.setOutputVolume(root.outputVolume - stepSize)
+        root.wheelAccumulator += stepUnits
+        stepped = true
+      }
+      if (stepped) root.showVolumeOsd()
     }
   }
 
@@ -689,9 +718,19 @@ Panel {
           Item {
             id: heroItem
             width: parent.width
-            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, powerSwitch.implicitHeight)
+            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight) + root.heroRingPad * 2
 
-            // Status only — the switch owns muting, mouse and keyboard alike.
+            // Keyboard focus ring around the hero output-mute toggle. heroIcon
+            // is inset by heroRingPad so this ring stays inside the clip box.
+            BorderSurface {
+              anchors.fill: heroIcon
+              anchors.margins: -root.heroRingPad
+              color: "transparent"
+              radius: Style.cornerRadius
+              visible: root.headerHasCursor
+              borderSpec: Border.controlSpec("hover-cursor", root.bar.foreground, Color.accent)
+            }
+
             Text {
               id: heroIcon
               text: root.outputIcon()
@@ -700,26 +739,15 @@ Panel {
               font.pixelSize: Style.font.display
               opacity: root.outputMuted ? 0.5 : 1.0
               anchors.left: parent.left
+              anchors.leftMargin: root.heroRingPad
               anchors.verticalCenter: parent.verticalCenter
-            }
 
-            // Compact on/off switch on the trailing edge of the hero, and the
-            // header's only cursor target. Checked means something is still
-            // audible, so muting everything reads as switching audio off.
-            ToggleSwitch {
-              id: powerSwitch
-              checked: root.anyAudible
-              hasCursor: root.headerHasCursor
-              foreground: root.bar.foreground
-              anchors.right: parent.right
-              anchors.verticalCenter: parent.verticalCenter
-              onHovered: function(on) { if (on) root.setHeaderCursor() }
-              onToggled: root.toggleAllMuted()
-
-              PanelToolTip {
-                visible: powerSwitch.containsMouse
-                text: root.toggleHint
-                fontFamily: root.bar.fontFamily
+              MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onContainsMouseChanged: if (containsMouse) root.setHeaderCursor()
+                onClicked: root.toggleOutputMute()
               }
             }
 
@@ -728,7 +756,6 @@ Panel {
               anchors.left: heroIcon.right
               anchors.leftMargin: Style.space(14)
               anchors.right: parent.right
-              anchors.rightMargin: powerSwitch.width + Style.space(12)
               anchors.verticalCenter: parent.verticalCenter
               spacing: Style.space(2)
 
@@ -818,7 +845,6 @@ Panel {
                 enabled: !!root.sink
 
                 onMoved: function(v) { root.setOutputVolume(v) }
-                onRightClicked: root.toggleOutputMute()
               }
 
               HoverHandler {
@@ -910,7 +936,6 @@ Panel {
                   enabled: !!root.source
 
                   onMoved: function(v) { root.setInputVolume(v) }
-                  onRightClicked: root.toggleInputMute()
                 }
 
                 Rectangle {
@@ -1197,10 +1222,6 @@ Panel {
 
         onMoved: function(v) {
           if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
-        }
-        onRightClicked: {
-          if (streamRow.node && streamRow.node.audio)
-            streamRow.node.audio.muted = !streamRow.node.audio.muted
         }
       }
     }

--- a/shell/plugins/panels/audio/manifest.json
+++ b/shell/plugins/panels/audio/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "local.audio",
+  "id": "omarchy.audio",
   "name": "Audio",
   "version": "1.0.0",
   "author": "Omarchy",

--- a/shell/plugins/panels/audio/manifest.json
+++ b/shell/plugins/panels/audio/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "omarchy.audio",
+  "id": "local.audio",
   "name": "Audio",
   "version": "1.0.0",
   "author": "Omarchy",

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -27,6 +27,13 @@ Panel {
   property var displays: []
   property int enabledDisplayCount: 0
 
+  // Raw wheel delta accumulated between discrete brightness steps. A mouse
+  // notch (delta = ±120) crosses the threshold and fires one step
+  // immediately; a touchpad's stream of small deltas piles up here until it
+  // crosses that same threshold, so both devices move brightness in
+  // identical 5% steps. Mirrors the audio panel's wheelAccumulator.
+  property real wheelAccumulator: 0
+
   // Cursor model shared by keyboard and mouse. Sections:
   //   "brightness" - single slider row, selectedIndex = -1 sentinel
   //                  (mirrors Audio's slider rows). Only present if a
@@ -231,7 +238,7 @@ Panel {
   }
 
   function setBrightness(value) {
-    var percent = Model.clampBrightness(value)
+    var percent = Math.max(5, Model.clampBrightness(value))
     root.brightnessPercent = percent
     root.pendingBrightnessPercent = percent
 
@@ -246,8 +253,19 @@ Panel {
   }
 
   function previewBrightness(value) {
-    root.brightnessPercent = Model.clampBrightness(value)
+    // Floor at 5%: never let the live drag preview show (or briefly send)
+    // a lower value while the slider is being dragged.
+    root.brightnessPercent = Math.max(5, Model.clampBrightness(value))
     brightnessDebounce.restart()
+  }
+
+  // Mirrors what omarchy-brightness-display shows after a keyboard raise/
+  // lower, so scrolling the bar icon gets the same OSD feedback instead of
+  // only the hardware brightness keys. "brightness" is the exact icon name
+  // the CLI itself passes to omarchy-osd.
+  function showBrightnessOsd() {
+    osdProc.command = ["omarchy-osd", "-i", "brightness", "-p", String(root.brightnessPercent)]
+    osdProc.running = true
   }
 
   function normalizeScale(scale) {
@@ -424,6 +442,10 @@ Panel {
     onRunningChanged: if (!running) root.refresh()
   }
 
+  Process {
+    id: osdProc
+  }
+
   // Applies text size via the CLI, which rewrites the shell override file;
   // Style picks the new base-size up through its own file watch, so there's
   // nothing to refresh here.
@@ -461,7 +483,30 @@ Panel {
     text: Quickshell.screens.length > 1 ? "󰍺" : "󰍹"
     onPressed: function(b) { root.toggle() }
     onWheelMoved: function(delta) {
-      if (root.brightnessAvailable) root.setBrightness(root.brightnessPercent + (delta > 0 ? 5 : -5))
+      if (!root.brightnessAvailable) return
+      // One step = 120 units, matching a single mouse notch, so a mouse
+      // click still moves exactly 5%. A touchpad's small deltas pile up in
+      // wheelAccumulator until they cross that same threshold, then fire
+      // the identical 5% step. The OSD is only pinged when a step actually
+      // lands (not on a fixed timer), so it stays open and updates exactly
+      // in step with the real scroll rhythm -- no tick separate from your
+      // finger's motion -- and only starts counting down to hide once you
+      // stop scrolling (each ping restarts its own hide timer).
+      var stepUnits = 120
+      var stepSize = 5
+      var stepped = false
+      root.wheelAccumulator += delta
+      while (root.wheelAccumulator >= stepUnits) {
+        root.setBrightness(root.brightnessPercent + stepSize)
+        root.wheelAccumulator -= stepUnits
+        stepped = true
+      }
+      while (root.wheelAccumulator <= -stepUnits) {
+        root.setBrightness(root.brightnessPercent - stepSize)
+        root.wheelAccumulator += stepUnits
+        stepped = true
+      }
+      if (stepped) root.showBrightnessOsd()
     }
   }
 
@@ -612,7 +657,7 @@ Panel {
                 anchors.fill: parent
                 anchors.leftMargin: Style.space(6)
                 anchors.rightMargin: Style.space(6)
-                minimum: 1
+                minimum: 5
                 maximum: 100
                 step: 1
                 value: root.brightnessPercent

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -27,11 +27,7 @@ Panel {
   property var displays: []
   property int enabledDisplayCount: 0
 
-  // Raw wheel delta accumulated between discrete brightness steps. A mouse
-  // notch (delta = ±120) crosses the threshold and fires one step
-  // immediately; a touchpad's stream of small deltas piles up here until it
-  // crosses that same threshold, so both devices move brightness in
-  // identical 5% steps. Mirrors the audio panel's wheelAccumulator.
+  // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
 
   // Cursor model shared by keyboard and mouse. Sections:
@@ -238,7 +234,7 @@ Panel {
   }
 
   function setBrightness(value) {
-    var percent = Math.max(5, Model.clampBrightness(value))
+    var percent = Model.clampBrightness(value)
     root.brightnessPercent = percent
     root.pendingBrightnessPercent = percent
 
@@ -253,19 +249,16 @@ Panel {
   }
 
   function previewBrightness(value) {
-    // Floor at 5%: never let the live drag preview show (or briefly send)
-    // a lower value while the slider is being dragged.
-    root.brightnessPercent = Math.max(5, Model.clampBrightness(value))
+    root.brightnessPercent = Model.clampBrightness(value)
     brightnessDebounce.restart()
   }
 
-  // Mirrors what omarchy-brightness-display shows after a keyboard raise/
-  // lower, so scrolling the bar icon gets the same OSD feedback instead of
-  // only the hardware brightness keys. "brightness" is the exact icon name
-  // the CLI itself passes to omarchy-osd.
-  function showBrightnessOsd() {
-    osdProc.command = ["omarchy-osd", "-i", "brightness", "-p", String(root.brightnessPercent)]
-    osdProc.running = true
+  function showBrightnessOsd(percent) {
+    if (!bar || !bar.shell) return
+    bar.shell.summon("omarchy.osd", JSON.stringify({
+      icon: "brightness",
+      value: percent
+    }))
   }
 
   function normalizeScale(scale) {
@@ -442,10 +435,6 @@ Panel {
     onRunningChanged: if (!running) root.refresh()
   }
 
-  Process {
-    id: osdProc
-  }
-
   // Applies text size via the CLI, which rewrites the shell override file;
   // Style picks the new base-size up through its own file watch, so there's
   // nothing to refresh here.
@@ -484,29 +473,11 @@ Panel {
     onPressed: function(b) { root.toggle() }
     onWheelMoved: function(delta) {
       if (!root.brightnessAvailable) return
-      // One step = 120 units, matching a single mouse notch, so a mouse
-      // click still moves exactly 5%. A touchpad's small deltas pile up in
-      // wheelAccumulator until they cross that same threshold, then fire
-      // the identical 5% step. The OSD is only pinged when a step actually
-      // lands (not on a fixed timer), so it stays open and updates exactly
-      // in step with the real scroll rhythm -- no tick separate from your
-      // finger's motion -- and only starts counting down to hide once you
-      // stop scrolling (each ping restarts its own hide timer).
-      var stepUnits = 120
-      var stepSize = 5
-      var stepped = false
-      root.wheelAccumulator += delta
-      while (root.wheelAccumulator >= stepUnits) {
-        root.setBrightness(root.brightnessPercent + stepSize)
-        root.wheelAccumulator -= stepUnits
-        stepped = true
-      }
-      while (root.wheelAccumulator <= -stepUnits) {
-        root.setBrightness(root.brightnessPercent - stepSize)
-        root.wheelAccumulator += stepUnits
-        stepped = true
-      }
-      if (stepped) root.showBrightnessOsd()
+      var wheel = Util.wheelSteps(root.wheelAccumulator, delta)
+      root.wheelAccumulator = wheel.remainder
+      if (wheel.steps === 0) return
+      root.setBrightness(root.brightnessPercent + wheel.steps * 5)
+      root.showBrightnessOsd(root.brightnessPercent)
     }
   }
 
@@ -657,7 +628,7 @@ Panel {
                 anchors.fill: parent
                 anchors.leftMargin: Style.space(6)
                 anchors.rightMargin: Style.space(6)
-                minimum: 5
+                minimum: 1
                 maximum: 100
                 step: 1
                 value: root.brightnessPercent


### PR DESCRIPTION
Scrolling the volume or brightness icon in the bar changed the value directly without ever calling omarchy-osd, so only the keyboard media keys showed the popup. On top of that, a touchpad's stream of many small wheel events per finger-drag wasn't matched to a mouse's single ±120 notch per click, so touchpad scrolling felt uncoordinated and uneven next to the keyboard/mouse behavior.

- shell/plugins/panels/audio/Panel.qml: accumulate raw wheel delta and only apply a step once it crosses a full mouse-notch's worth, so touchpad and mouse move the volume in identical 5% increments, and ping the OSD each time a step actually lands.
- shell/plugins/panels/monitor/Panel.qml: same accumulator for brightness, with a 5% floor so scrolling down can never blank the screen.
- shell/plugins/osd/Osd.qml: animate the progress bar's width instead of snapping, so successive steps glide smoothly.

Now:


https://github.com/user-attachments/assets/38d52ae7-5c9f-4a46-8848-e7c0241d43c7


