### PR TITLE
Fix browser launch when xdg-settings is empty

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -4,6 +4,9 @@
 # omarchy:args=[url]
 
 default_browser=$(env -u BROWSER xdg-settings get default-web-browser)
+if [[ -z $default_browser ]]; then
+  default_browser=$(xdg-mime query default x-scheme-handler/https)
+fi
 browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
 if $browser_exec --help 2>/dev/null | grep -q MOZ_LOG; then

--- a/test/shell.d/launch-browser-test.sh
+++ b/test/shell.d/launch-browser-test.sh
@@ -18,7 +18,14 @@ EOF
 
 cat >"$mock_bin/xdg-settings" <<'SH'
 #!/bin/bash
-echo chromium.desktop
+[[ -z ${BROWSER:-} ]] || printf '%s\n' "$BROWSER" >"$OMARCHY_TEST_XDG_SETTINGS_BROWSER"
+[[ ${OMARCHY_TEST_XDG_SETTINGS_EMPTY:-0} == "1" ]] || echo chromium.desktop
+SH
+cat >"$mock_bin/xdg-mime" <<'SH'
+#!/bin/bash
+if [[ $* == "query default x-scheme-handler/https" ]]; then
+  echo chromium.desktop
+fi
 SH
 cat >"$mock_bin/chromium" <<'SH'
 #!/bin/bash
@@ -36,6 +43,7 @@ chmod +x "$mock_bin"/*
 
 launch_log="$test_tmp/launch"
 focus_log="$test_tmp/focus"
+xdg_settings_browser="$test_tmp/xdg-settings-browser"
 HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
   OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
   bash "$ROOT/bin/omarchy-launch-browser"
@@ -54,5 +62,20 @@ HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
 
 grep -F 'https://example.test/authorize' "$launch_log" >/dev/null || fail "browser launcher passes through the URL"
 grep -Fx '^chromium.*$' "$focus_log" >/dev/null || fail "browser launcher focuses the default browser window"
+
+rm -f "$focus_log" "$xdg_settings_browser"
+
+HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+  BROWSER=omarchy-launch-browser OMARCHY_TEST_XDG_SETTINGS_EMPTY=1 \
+  OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
+  OMARCHY_TEST_XDG_SETTINGS_BROWSER="$xdg_settings_browser" \
+  bash "$ROOT/bin/omarchy-launch-browser" "https://example.test/fallback"
+
+grep -F 'https://example.test/fallback' "$launch_log" >/dev/null ||
+  fail "browser launcher falls back to the HTTPS handler when xdg-settings is empty"
+[[ ! -e $xdg_settings_browser ]] ||
+  fail "browser launcher unsets BROWSER before reading xdg-settings"
+grep -Fx '^chromium.*$' "$focus_log" >/dev/null ||
+  fail "browser launcher focuses the browser resolved from the HTTPS handler"
 
 pass "browser launcher follows opened links to the browser workspace"


### PR DESCRIPTION
Fixes #6416.

When xdg-settings has no browser desktop entry after removing BROWSER to avoid wrapper recursion, fall back to the XDG HTTPS handler.

Adds regression coverage for the empty xdg-settings response, recursion guard, URL forwarding, and focus behavior.

Checks:
- syntax validation
- focused browser launcher shell test
