### PR TITLE
Skip Bluetooth startup delay when already powered

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -19,6 +19,7 @@ address=${2:-}
 [[ $address =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]] || usage
 
 power_on() {
+  bluetoothctl show | grep -Fq "Powered: yes" && return
   bluetoothctl power on >/dev/null 2>&1 || true
   sleep 0.5
 }


### PR DESCRIPTION
## What changed

Skip the Bluetooth power-on sequence when the adapter already reports `Powered: yes`.

## Why

`power_on` always ran `bluetoothctl power on` and slept for 500 ms, even when the adapter was already enabled. Pairing from the Omarchy 4 Bluetooth panel normally happens while the adapter is powered and scanning, so every pairing paid that fixed delay unnecessarily.

When the adapter is off, the existing power-on command and stabilization delay remain unchanged.

## Validation

- `bash -n bin/omarchy-bluetooth-device`
- `git diff --check`