### PR TITLE
Skip Bluetooth startup delay when already powered

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -19,7 +19,7 @@ address=${2:-}
 [[ $address =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]] || usage
 
 power_on() {
-  bluetoothctl show | grep -Fq "Powered: yes" && return
+  [[ $(timeout 2s bluetoothctl show 2>/dev/null) == *"Powered: yes"* ]] && return
   bluetoothctl power on >/dev/null 2>&1 || true
   sleep 0.5
 }

--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -19,6 +19,7 @@ address=${2:-}
 [[ $address =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]] || usage
 
 power_on() {
+  bluetoothctl show | grep -Fq "Powered: yes" && return
   bluetoothctl power on >/dev/null 2>&1 || true
   sleep 0.5
 }

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -91,3 +91,45 @@ assert(
   'bluetooth ignores non-sink nodes when matching audio outputs'
 )
 JS
+
+# The power-on shortcut is the whole point of skipping the stabilization sleep:
+# pair/connect from the panel run against an adapter that is already powered.
+device_tmp=$(mktemp -d)
+trap 'rm -rf "$device_tmp"' EXIT
+
+mock_bin="$device_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/bluetoothctl" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$BLUETOOTHCTL_LOG"
+[[ $1 == "show" ]] && printf '\tPowered: %s\n' "$BLUETOOTHCTL_POWERED"
+exit 0
+SH
+chmod +x "$mock_bin/bluetoothctl"
+
+bluetooth_device_log() {
+  local powered="$1"
+  local log="$device_tmp/$powered.log"
+
+  : >"$log"
+  PATH="$mock_bin:$PATH" BLUETOOTHCTL_LOG="$log" BLUETOOTHCTL_POWERED="$powered" \
+    "$ROOT/bin/omarchy-bluetooth-device" connect AA:BB:CC:DD:EE:FF ||
+    fail "omarchy-bluetooth-device exits cleanly with Powered: $powered"
+  printf '%s' "$log"
+}
+
+powered_log=$(bluetooth_device_log yes)
+grep -qx "power on" "$powered_log" &&
+  fail "bluetooth skips the power-on delay when the adapter is already powered"
+pass "bluetooth skips the power-on delay when the adapter is already powered"
+
+grep -qx "connect AA:BB:CC:DD:EE:FF" "$powered_log" ||
+  fail "bluetooth still connects when the adapter is already powered"
+pass "bluetooth still connects when the adapter is already powered"
+
+unpowered_log=$(bluetooth_device_log no)
+grep -qx "power on" "$unpowered_log" ||
+  fail "bluetooth powers the adapter on when it is off"
+pass "bluetooth powers the adapter on when it is off"


### PR DESCRIPTION
## The symptom that started this

Bluetooth devices (keyboard + mouse) took a bit longer to pair on Omarchy 4. Not by a lot, but enough to be noticeable.

## The bug

`power_on` always ran `bluetoothctl power on` and slept for 500 ms, even when the adapter was already enabled. Pairing from the Omarchy 4 Bluetooth panel normally happens while the adapter is powered and scanning, so every pairing paid that fixed delay unnecessarily.

## What this PR does

Skip the Bluetooth power-on sequence when the adapter already reports `Powered: yes`.
When the adapter is off, the existing power-on command and stabilization delay remain unchanged.