### PR TITLE
hypr/apps: open DaVinci Resolve's main window fullscreen so it isn't covered by the bar

### DIFF
--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -6,3 +6,8 @@ o.window(".*[Rr]esolve.*", {
   tag = "-default-opacity",
   opacity = "1 1",
 })
+
+-- Resolve's floating main window ignores the bar's reserved zone, so the bar
+-- covers its menu bar; fullscreen renders above top-layer surfaces. Scoped by
+-- title so the splash and Project Manager keep their natural size.
+o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve - .+$" }, { fullscreen = true })


### PR DESCRIPTION
## Symptom

On Omarchy 4.x, launching DaVinci Resolve leaves Resolve's **own** menu bar (File / Edit / Trim / Timeline / Clip / …) hidden underneath the Omarchy status bar, so those menus cannot be clicked.

## Root cause

`omarchy-bar` is a layer-shell surface on Hyprland's `top` layer with a 26px exclusive zone:

```
$ hyprctl layers
Layer level 2 (top):
    Layer ...: xywh: 0 0 2560 26, a: 1, namespace: omarchy-bar, pid: 1582
```

That reserved zone only constrains **tiled** windows, and it is being honoured correctly — `hyprctl monitors` reports `reserved: [0, 26, 0, 0]`, and tiled windows start at y=38 as expected.

The problem is that Resolve is not tiled. `default/hypr/apps/davinci-resolve.lua` floats every Resolve window, which is the right call — Resolve's many child windows tile badly. But floating windows are positioned by the client, and Resolve's XWayland main window places itself at **0,0 at the full monitor size**, ignoring the reserved zone entirely:

```
class='resolve' title='DaVinci Resolve - New Project 2' at=[0, 0] size=[2560, 1440] float=True fs=0
```

So the bar, being on the `top` layer, draws over it.

## Fix

Hyprland renders a fullscreen window **above** `top`-layer layer-shell surfaces. Opening Resolve's main window fullscreen therefore puts Resolve over the bar instead of under it. The bar is not modified, hidden, or killed — it behaves normally again as soon as you leave fullscreen or focus another window.

### Why the title match must be narrow

Every Resolve window shares the same class, and only the main one may be fullscreened. Windows observed during a cold start:

| window          | title                              | size      | fullscreened |
| --------------- | ---------------------------------- | --------- | ------------ |
| splash screen   | `resolve`                          | 740×326   | no           |
| project chooser | `Project Manager`                  | 900×512   | no           |
| modal dialogs   | e.g. `Preferences`                 | 630×534   | no           |
| main window     | `DaVinci Resolve - <project name>` | 2560×1440 | **yes**      |

Requiring the `" - <project>"` suffix leaves the splash, the Project Manager and Resolve's modal dialogs floating at their natural size. A class-only rule would fullscreen all of them, which is why the rule is title-scoped.

The class pattern `.*[Rr]esolve.*` is kept byte-identical to the existing rule in this file for consistency; the title is what does the scoping.

## Verification

Tested on Hyprland 0.56.1 / Omarchy 4.0.0.r1440, NVIDIA, 2560×1440 logical (3840×2160 physical, scale 1.5), DaVinci Resolve 21.0.3.

Method: sample the top 26px strip with `grim`. Bar colour is `(26,27,38)`; Resolve's UI chrome is `(23,24,26)`.

**Before** — bar covers Resolve:

```
 y=  5 [(26, 27, 38), (26, 27, 38), (26, 27, 38)]   <- bar
 y= 20 [(26, 27, 38), (26, 27, 38), (26, 27, 38)]   <- bar
 y= 35 [(26, 27, 38), (26, 27, 38), (26, 27, 38)]   <- bar
 y= 45 [(23, 24, 26), (23, 24, 26), (23, 24, 26)]   <- Resolve only starts here
```

**After** — Resolve renders over the bar, its menu text now visible at y=35:

```
 y=  5 [(23, 24, 26), (23, 24, 26), (23, 24, 26)]
 y= 20 [(23, 24, 26), (23, 24, 26), (23, 24, 26)]
 y= 35 [(179, 180, 180), (23, 24, 26), (23, 24, 26)]  <- menu text
 y= 45 [(23, 24, 26), (23, 24, 26), (23, 24, 26)]
```

With the exact rule string in this PR installed, a cold start produces precisely the intended scoping — only the main window is fullscreened, and a modal dialog that happened to open during the run was correctly left alone:

```
title='resolve'                          size=[740, 326]   FULLSCREEN=0
title='Project Manager'                  size=[900, 512]   FULLSCREEN=0
title='DaVinci Resolve - New Project 2'  size=[2560, 1440] FULLSCREEN=2
title='Preferences'                      size=[630, 534]   FULLSCREEN=0
```

That `Preferences` line is the important one: it is the failure mode a class-only rule would produce (a 630×534 dialog blown up to fill the screen), and it demonstrably does not happen.

## Notes for review

- Only the **main** window is fullscreened; splash, Project Manager and modal dialogs are untouched.
- If a user leaves fullscreen manually, the bar covers Resolve again — inherent to the approach, recoverable with `SUPER + F`.
- The title is matched at window-open time. If a future Resolve release changes its main-window title format, the rule silently stops matching and the old behaviour returns. It fails safe: no window gets wrongly fullscreened.
- Alternative considered and rejected: having Resolve's launcher run `omarchy toggle bar off` and restore it on exit. It needs no window titles, but hides the bar system-wide across all workspaces for as long as Resolve is open, and leaves the bar hidden if the process is killed uncleanly.
