### PR TITLE
Drop the Qt5 stack

### DIFF
--- a/default/sddm/omarchy/metadata.desktop
+++ b/default/sddm/omarchy/metadata.desktop
@@ -4,3 +4,4 @@ Description=Minimal terminal-style login theme matching the Limine bootloader ae
 Author=Omarchy
 Type=sddm-theme
 Version=1.0
+QtVersion=6

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -64,7 +64,7 @@ networkmanager
 jq
 kdenlive
 kernel-modules-hook
-kvantum-qt5
+kvantum
 lazydocker
 lazygit
 less
@@ -105,7 +105,6 @@ python-gobject
 python-poetry-core
 python-terminaltexteffects
 qemu-user-static-binfmt
-qt5-wayland
 quickshell-git
 ripgrep
 ruby


### PR DESCRIPTION
No application we ship runs on Qt5 any more, so the stack goes from fresh installs: **~110 MiB** across `kvantum-qt5`, `qt5-wayland`, `qt5-declarative`, `qt5-base`, `qt5-svg`, `qt5-x11extras` and `qt5-translations`.

`kvantum-qt5` only ever existed to dark-mode VLC (`fde252d9 "Need kvantum to dark mode vlc"`), and VLC is retired. `qt5-wayland` was the Qt5 Wayland platform plugin, but it also quietly dragged in `qt5-declarative` — which turned out to be load-bearing for something else entirely.

## The login screen is a Qt5 app

`sddm` picks its greeter from the theme's `SddmGreeterTheme/QtVersion`, and `ThemeMetadata.cpp` defaults that key to **5**:

```cpp
"SddmGreeterTheme/QtVersion", 5
```

Our theme didn't set it, so sddm execs `/usr/bin/sddm-greeter` — which links `libQt5Core/Gui/Network/Qml/QmlModels/Quick`. And sddm's tie to Qt5 is only an **optdepend**:

```
Optional Deps : qt5-declarative: for using Qt5 themes [installed]
```

So pacman would cheerfully remove Qt5 and leave a greeter that can't start. Unencrypted installs would land on a dead login screen; encrypted ones autologin and would mask it entirely.

The theme declares `QtVersion=6` now. The Qt6 greeter renders it unchanged — `Main.qml`'s `import QtQuick 2.0` / `import SddmComponents 2.0` resolve fine under `/usr/lib/qt6/qml/SddmComponents`, verified with an offscreen `--test-mode` run producing no QML errors.

## kvantum survives the cascade

`kvantum` — the Qt6 style engine providing `/usr/lib/qt6/plugins/styles/libkvantum.so`, which backs `QT_STYLE_OVERRIDE=kvantum` in `default/hypr/envs.lua:14` — was only present as a *dependency* of `kvantum-qt5`:

```
$ pacman -Rs --print kvantum-qt5 qt5-wayland
qt5-wayland, qt5-declarative, kvantum-qt5, qt5-x11extras,
qt5-svg, qt5-base, qt5-translations, kvantum      ← would have gone too
```

So the package list swaps to `kvantum` rather than dropping the line. `obs`, `kdenlive` and the Hyprland share picker — the only QWidget apps we ship, and therefore the only ones Kvantum can style — keep exactly the styling they have today.

## Fresh installs only, deliberately

Machines already installed keep their Qt5 stack.

Shedding it there means deciding which greeter sddm will actually launch, and that turns out to mean reimplementing its config loader. sddm reads **every file** in `sddm.conf.d` regardless of extension (`entryInfoList(QDir::Files | QDir::NoDotAndDotDot)`, no name filter) — so a `.pacnew`, `.bak` or editor leftover with a `[Theme]` section is live config. On top of that, QSettings trims keys and lets the last duplicate win, section headers only count when the trimmed line also *ends* in `]`, `#` is the only comment character, and `ThemeDir` can relocate the themes entirely.

A first attempt at a migration got each of those subtly wrong, in ways that would have certified "Qt6" and then removed the Qt5 the greeter still needed. Not worth risking a login screen for 110 MiB that a reinstall reclaims anyway.

`bin/omarchy-upgrade-to-quattro`'s `retired_packages` is deliberately untouched for the same reason: it runs at `:2264`, before migrations at `:2265`, so anything listed there is removed with no greeter check at all.

## Testing

Dependency and optdepend sweeps for anything still needing Qt5 turned up only `sddm` (fixed here) and `kvantum :: kvantum-qt5` (optional). `fcitx5-qt` keeps a handful of Qt5 ELF objects it builds regardless of what's installed; they go unused. Removal cascade dry-run and the Qt6 greeter against this theme are both verified.

**Still needs a boot test on an unencrypted install** — the only thing that proves the chain end to end. Confirm the login screen renders, then `pgrep -a sddm-greeter` shows `sddm-greeter-qt6` and `pacman -Qq | grep '^qt5'` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b73joG5wcVDZRMX9CtTzY