### PR TITLE
Warn when disk space is low before updating in Quattro

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -102,7 +102,7 @@ run_update_pipeline() {
 
 acquire_update_lock
 
-omarchy-update-requires-free-space || true
+omarchy-update-requires-free-space
 
 trap restore_update_inhibitors EXIT
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -34,32 +34,6 @@ acquire_update_lock() {
   export OMARCHY_UPDATE_LOCK_FD
 }
 
-check_free_disk_space() {
-  local default_minimum_gb=10
-  local minimum_gb=${OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB:-$default_minimum_gb}
-  local available_bytes
-  local available_gb
-
-  if [[ ! $minimum_gb =~ ^[0-9]+$ ]]; then
-    echo "OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB must be a whole number."
-    exit 1
-  fi
-
-  available_bytes=$(df --output=avail --block-size=1 / | tail -n 1)
-  if (( available_bytes >= minimum_gb * 1024 * 1024 * 1024 )); then
-    return 0
-  fi
-
-  available_gb=$(df --output=avail --human-readable / | tail -n 1 | xargs)
-  echo "Warning: Only $available_gb of disk space is available on /."
-  echo "Omarchy update expects at least ${minimum_gb} GB free (default: $default_minimum_gb GB)."
-  echo "Override this threshold with OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB."
-
-  if [[ ${1:-} != "-y" ]] && ! gum confirm --default=false "Continue with the update despite low disk space?"; then
-    exit 0
-  fi
-}
-
 update_disabled_idle=0
 sleep_inhibit_pid=""
 
@@ -127,7 +101,8 @@ run_update_pipeline() {
 }
 
 acquire_update_lock
-check_free_disk_space "${1:-}"
+
+omarchy-update-requires-free-space || true
 
 trap restore_update_inhibitors EXIT
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -34,6 +34,32 @@ acquire_update_lock() {
   export OMARCHY_UPDATE_LOCK_FD
 }
 
+check_free_disk_space() {
+  local default_minimum_gb=10
+  local minimum_gb=${OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB:-$default_minimum_gb}
+  local available_bytes
+  local available_gb
+
+  if [[ ! $minimum_gb =~ ^[0-9]+$ ]]; then
+    echo "OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB must be a whole number."
+    exit 1
+  fi
+
+  available_bytes=$(df --output=avail --block-size=1 / | tail -n 1)
+  if (( available_bytes >= minimum_gb * 1024 * 1024 * 1024 )); then
+    return 0
+  fi
+
+  available_gb=$(df --output=avail --human-readable / | tail -n 1 | xargs)
+  echo "Warning: Only $available_gb of disk space is available on /."
+  echo "Omarchy update expects at least ${minimum_gb} GB free (default: $default_minimum_gb GB)."
+  echo "Override this threshold with OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB."
+
+  if [[ ${1:-} != "-y" ]] && ! gum confirm --default=false "Continue with the update despite low disk space?"; then
+    exit 0
+  fi
+}
+
 update_disabled_idle=0
 sleep_inhibit_pid=""
 
@@ -101,6 +127,7 @@ run_update_pipeline() {
 }
 
 acquire_update_lock
+check_free_disk_space "${1:-}"
 
 trap restore_update_inhibitors EXIT
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR

--- a/bin/omarchy-update-requires-free-space
+++ b/bin/omarchy-update-requires-free-space
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# omarchy:summary=Check free disk space required for an update
+# omarchy:hidden=true
+
+set -e
+
+available_bytes=$(df --output=avail --block-size=1 / 2>/dev/null | tail -n 1)
+available_bytes=${available_bytes//[[:space:]]/}
+
+if [[ $available_bytes =~ ^[0-9]+$ ]] && (( available_bytes < 10 * 1024 * 1024 * 1024 )); then
+  echo "You need at least 10 GiB free to safely update Omarchy."
+  exit 1
+else
+  exit 0
+fi

--- a/bin/omarchy-update-requires-free-space
+++ b/bin/omarchy-update-requires-free-space
@@ -5,10 +5,11 @@
 
 set -e
 
-available_bytes=$(df --output=avail --block-size=1 / 2>/dev/null | tail -n 1)
-available_bytes=${available_bytes//[[:space:]]/}
-
-if [[ $available_bytes =~ ^[0-9]+$ ]] && (( available_bytes < 10 * 1024 * 1024 * 1024 )); then
+if [[ ${OMARCHY_UPDATE_FORCE:-0} == "1" ]]; then
+  exit 0
+elif read -r available_bytes < <(df --output=avail --block-size=1 / 2>/dev/null | tail -n 1) &&
+  [[ $available_bytes =~ ^[0-9]+$ ]] &&
+  (( available_bytes < 10 * 1024 * 1024 * 1024 )); then
   echo "You need at least 10 GiB free to safely update Omarchy."
   exit 1
 else

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -114,6 +114,8 @@ High-level flow:
 omarchy-update
   ├─ ensure transcript logging through script(1) → /tmp/omarchy-update.log
   ├─ acquire update lock
+  ├─ omarchy-update-requires-free-space
+  │    └─ check free space on / and warn below the configured threshold
   ├─ confirm unless -y
   ├─ create snapper snapshot, if snapper is installed
   └─ run update pipeline
@@ -136,6 +138,9 @@ Important behavior:
 
 - In dev-link mode, `omarchy update` fast-forwards the active checkout from its
   configured upstream before changing system packages or running migrations.
+- The free-space warning uses a 10 GiB threshold. Low space is called out before
+  the normal interactive confirmation; `-y` updates warn and continue. If free
+  space cannot be determined, the check is silently skipped.
 - `omarchy update` checks/runs migrations in the same visible terminal via
   `omarchy-migrate` after pacman finishes.
 - A failure should leave enough output in `/tmp/omarchy-update.log` and the

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -138,9 +138,9 @@ Important behavior:
 
 - In dev-link mode, `omarchy update` fast-forwards the active checkout from its
   configured upstream before changing system packages or running migrations.
-- The free-space warning uses a 10 GiB threshold. Low space is called out before
-  the normal interactive confirmation; `-y` updates warn and continue. If free
-  space cannot be determined, the check is silently skipped.
+- The free-space requirement uses a 10 GiB threshold and stops the update before
+  confirmation when it is not met. If free space cannot be determined, the
+  check is silently skipped.
 - `omarchy update` checks/runs migrations in the same visible terminal via
   `omarchy-migrate` after pacman finishes.
 - A failure should leave enough output in `/tmp/omarchy-update.log` and the

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -140,7 +140,7 @@ Important behavior:
   configured upstream before changing system packages or running migrations.
 - The free-space requirement uses a 10 GiB threshold and stops the update before
   confirmation when it is not met. If free space cannot be determined, the
-  check is silently skipped.
+  check is silently skipped. Set `OMARCHY_UPDATE_FORCE=1` to bypass the check.
 - `omarchy update` checks/runs migrations in the same visible terminal via
   `omarchy-migrate` after pacman finishes.
 - A failure should leave enough output in `/tmp/omarchy-update.log` and the

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -89,26 +89,26 @@ set -e
 (( status == 1 )) || fail "free-space helper exits non-zero when disk space is low"
 pass "free-space helper reports low disk space through its exit status"
 
+set +e
 output=$(run_update -y)
+status=$?
+set -e
+(( status == 1 )) || fail "non-interactive update exits non-zero with low disk space"
 [[ $output == *"You need at least 10 GiB free to safely update Omarchy."* ]] || fail "low disk space emits a warning"
 [[ ! -f $gum_marker ]] || fail "non-interactive update does not prompt for low disk space"
-[[ -f $snapshot_marker ]] || fail "non-interactive update continues after warning about low disk space"
-pass "non-interactive update warns and continues with low disk space"
+[[ ! -f $snapshot_marker ]] || fail "non-interactive update stops before snapshotting with low disk space"
+pass "non-interactive update stops with low disk space"
 
 rm -f "$snapshot_marker" "$gum_marker"
-run_update >/dev/null
-grep -q "confirm Continue with update?" "$gum_marker" ||
-  fail "interactive update prompts before continuing with low disk space"
-[[ ! -f $snapshot_marker ]] || fail "declining the low-space prompt skips the update"
-pass "interactive update can be cancelled when disk space is low"
-
-rm -f "$snapshot_marker" "$gum_marker"
-GUM_STATUS=0 run_update >/dev/null
-grep -q "confirm Continue with update?" "$gum_marker" ||
-  fail "interactive update prompts before accepting low disk space"
-(( $(grep -c "^confirm " "$gum_marker") == 1 )) || fail "interactive low-space update only prompts once"
-[[ -f $snapshot_marker ]] || fail "accepting the low-space prompt starts the update"
-pass "interactive update can continue with low disk space"
+set +e
+output=$(run_update)
+status=$?
+set -e
+(( status == 1 )) || fail "interactive update exits non-zero with low disk space"
+[[ $output == *"You need at least 10 GiB free to safely update Omarchy."* ]] || fail "interactive low-space update explains the requirement"
+[[ ! -f $gum_marker ]] || fail "interactive update stops before confirmation with low disk space"
+[[ ! -f $snapshot_marker ]] || fail "interactive update stops before snapshotting with low disk space"
+pass "interactive update stops before confirmation with low disk space"
 
 rm -f "$snapshot_marker" "$gum_marker"
 output=$(TEST_AVAILABLE_BYTES=$((10 * 1024 * 1024 * 1024)) run_update -y)

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "$(dirname "$0")/base-test.sh"
 
 unset GUM_STATUS
+unset OMARCHY_UPDATE_FORCE
 unset TEST_AVAILABLE_BYTES
 unset TEST_DF_INVALID
 
@@ -109,6 +110,13 @@ set -e
 [[ ! -f $gum_marker ]] || fail "interactive update stops before confirmation with low disk space"
 [[ ! -f $snapshot_marker ]] || fail "interactive update stops before snapshotting with low disk space"
 pass "interactive update stops before confirmation with low disk space"
+
+rm -f "$snapshot_marker" "$gum_marker"
+output=$(OMARCHY_UPDATE_FORCE=1 run_update -y)
+[[ -z $output ]] || fail "forced update does not emit the free-space warning"
+[[ ! -f $gum_marker ]] || fail "forced non-interactive update does not prompt"
+[[ -f $snapshot_marker ]] || fail "forced update continues with low disk space"
+pass "forced update skips the free-space requirement"
 
 rm -f "$snapshot_marker" "$gum_marker"
 output=$(TEST_AVAILABLE_BYTES=$((10 * 1024 * 1024 * 1024)) run_update -y)

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+unset GUM_STATUS
+unset TEST_AVAILABLE_BYTES
+unset TEST_DF_INVALID
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+runtime_dir="$test_tmp/runtime"
+snapshot_marker="$test_tmp/snapshot"
+gum_marker="$test_tmp/gum"
+mkdir -p "$stub_bin" "$test_home" "$runtime_dir"
+
+run_update() {
+  HOME="$test_home" \
+  XDG_RUNTIME_DIR="$runtime_dir" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  LC_ALL=C \
+  OMARCHY_UPDATE_LOGGED=1 \
+  TEST_AVAILABLE_BYTES=${TEST_AVAILABLE_BYTES:-$((9 * 1024 * 1024 * 1024))} \
+  TEST_DF_INVALID=${TEST_DF_INVALID:-0} \
+  SNAPSHOT_MARKER="$snapshot_marker" \
+  GUM_MARKER="$gum_marker" \
+  GUM_STATUS=${GUM_STATUS:-1} \
+    "$ROOT/bin/omarchy-update" "$@"
+}
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+write_stub df '
+if (( TEST_DF_INVALID )); then
+  printf "Avail\nunknown\n"
+else
+  printf "Avail\n%s\n" "$TEST_AVAILABLE_BYTES"
+fi'
+
+write_stub gum '
+printf "%s\n" "$*" >>"$GUM_MARKER"
+if [[ ${1:-} == "confirm" ]]; then
+  exit "$GUM_STATUS"
+fi
+exit 0'
+
+write_stub omarchy-snapshot '
+touch "$SNAPSHOT_MARKER"
+exit 0'
+
+for command in \
+  omarchy-cmd-present \
+  omarchy-toggle-idle \
+  systemd-inhibit \
+  omarchy-update-dev \
+  omarchy-update-keyring \
+  omarchy-update-system-pkgs \
+  omarchy-migrate \
+  omarchy-update-aur-pkgs \
+  omarchy-update-mise \
+  omarchy-update-orphan-pkgs \
+  omarchy-hook \
+  omarchy-update-analyze-logs \
+  omarchy-shell \
+  omarchy-update-restart; do
+  write_stub "$command" 'exit 0'
+done
+write_stub omarchy-update-available 'exit 1'
+
+set +e
+TEST_AVAILABLE_BYTES=$((9 * 1024 * 1024 * 1024)) \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-update-requires-free-space" >/dev/null
+status=$?
+set -e
+(( status == 1 )) || fail "free-space helper exits non-zero when disk space is low"
+pass "free-space helper reports low disk space through its exit status"
+
+output=$(run_update -y)
+[[ $output == *"You need at least 10 GiB free to safely update Omarchy."* ]] || fail "low disk space emits a warning"
+[[ ! -f $gum_marker ]] || fail "non-interactive update does not prompt for low disk space"
+[[ -f $snapshot_marker ]] || fail "non-interactive update continues after warning about low disk space"
+pass "non-interactive update warns and continues with low disk space"
+
+rm -f "$snapshot_marker" "$gum_marker"
+run_update >/dev/null
+grep -q "confirm Continue with update?" "$gum_marker" ||
+  fail "interactive update prompts before continuing with low disk space"
+[[ ! -f $snapshot_marker ]] || fail "declining the low-space prompt skips the update"
+pass "interactive update can be cancelled when disk space is low"
+
+rm -f "$snapshot_marker" "$gum_marker"
+GUM_STATUS=0 run_update >/dev/null
+grep -q "confirm Continue with update?" "$gum_marker" ||
+  fail "interactive update prompts before accepting low disk space"
+(( $(grep -c "^confirm " "$gum_marker") == 1 )) || fail "interactive low-space update only prompts once"
+[[ -f $snapshot_marker ]] || fail "accepting the low-space prompt starts the update"
+pass "interactive update can continue with low disk space"
+
+rm -f "$snapshot_marker" "$gum_marker"
+output=$(TEST_AVAILABLE_BYTES=$((10 * 1024 * 1024 * 1024)) run_update -y)
+[[ $output != *"You need at least 10 GiB free"* ]] || fail "space equal to the threshold does not produce a warning"
+[[ -f $snapshot_marker ]] || fail "space equal to the threshold allows the update"
+pass "disk-space threshold includes the exact boundary"
+
+rm -f "$snapshot_marker" "$gum_marker"
+GUM_STATUS=0 TEST_AVAILABLE_BYTES=$((10 * 1024 * 1024 * 1024)) run_update >/dev/null
+grep -q "confirm Continue with update?" "$gum_marker" ||
+  fail "interactive update with enough space uses the normal confirmation prompt"
+[[ -f $snapshot_marker ]] || fail "accepting the normal confirmation starts the update"
+pass "interactive update keeps the normal confirmation prompt when space is sufficient"
+
+rm -f "$snapshot_marker"
+output=$(TEST_DF_INVALID=1 run_update -y)
+[[ -z $output ]] || fail "failed disk-space detection remains silent"
+[[ -f $snapshot_marker ]] || fail "failed disk-space detection does not block the update"
+pass "failed disk-space detection silently continues"


### PR DESCRIPTION
## Summary

- Check available disk space on `/` once at update startup.
- Use a 10 GB minimum by default, configurable with `OMARCHY_UPDATE_MINIMUM_FREE_DISK_SPACE_GB`.
- Prompt interactive updates before continuing when space is low.
- Warn and continue without prompting when `-y` is supplied.
- Reject invalid threshold values with a clear error.

## Motivation

This improves update stability by warning before an update starts when limited disk space could cause it to fail partway through. It is especially useful for older, limited-resource hardware and systems with smaller drives.

The check could be extended to run before each step of the update process. This initial pull request deliberately keeps the implementation basic by checking once at startup, while still preventing a common class of avoidable update failures.

Because the CLI, menu, menubar, and compatibility update entry points converge on `omarchy-update`, the startup check covers each of them without changes elsewhere.

## Testing

- `bash -n bin/omarchy-update`
- `git diff --check`
- Forced the low-space path with an artificially high threshold.
- Verified interactive decline, `-y`, and invalid override behavior with command stubs so no update ran.
- `./test/cli` currently stops on an unrelated existing missing metadata summary for `omarchy-update-system-pkgs-when-conflicted`.

## Attribution

This is the author's first Omarchy pull request. It was created in OpenCode using the GPT-5.6 Sol LLM.