### PR TITLE
Apply the GSK_RENDERER fix to walker's autostart entry

### DIFF
--- a/default/walker/walker.desktop
+++ b/default/walker/walker.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Walker
 Comment=Walker Service
-Exec=walker --gapplication-service
+Exec=env GSK_RENDERER=cairo walker --gapplication-service
 StartupNotify=false
 Terminal=false
 Type=Application

--- a/migrations/1785381882.sh
+++ b/migrations/1785381882.sh
@@ -3,11 +3,12 @@ echo "Run walker's autostart service with the cairo GTK renderer"
 # omarchy-launch-walker starts walker with GSK_RENDERER=cairo, but the resident
 # service is normally already running from the XDG autostart entry, which had no
 # environment override. That left walker rendering through GTK4's Vulkan backend,
-# which can hard-freeze the session on amdgpu (#6443). Leave customized entries alone.
+# which can hard-freeze the session on amdgpu (#6443). Only the stock Exec line is
+# rewritten, so any other keys the user set in the entry are preserved.
 walker_autostart="$HOME/.config/autostart/walker.desktop"
 
 if [[ -f $walker_autostart ]] && grep -q "^Exec=walker --gapplication-service$" "$walker_autostart"; then
-  cp "$OMARCHY_PATH/default/walker/walker.desktop" "$walker_autostart"
+  sed -i "s|^Exec=walker --gapplication-service$|Exec=env GSK_RENDERER=cairo walker --gapplication-service|" "$walker_autostart"
 
   # The autostart generator only re-reads the entry on reload, so apply it now
   # instead of waiting for the next login.

--- a/migrations/1785381882.sh
+++ b/migrations/1785381882.sh
@@ -1,0 +1,16 @@
+echo "Run walker's autostart service with the cairo GTK renderer"
+
+# omarchy-launch-walker starts walker with GSK_RENDERER=cairo, but the resident
+# service is normally already running from the XDG autostart entry, which had no
+# environment override. That left walker rendering through GTK4's Vulkan backend,
+# which can hard-freeze the session on amdgpu (#6443). Leave customized entries alone.
+walker_autostart="$HOME/.config/autostart/walker.desktop"
+
+if [[ -f $walker_autostart ]] && grep -q "^Exec=walker --gapplication-service$" "$walker_autostart"; then
+  cp "$OMARCHY_PATH/default/walker/walker.desktop" "$walker_autostart"
+
+  # The autostart generator only re-reads the entry on reload, so apply it now
+  # instead of waiting for the next login.
+  systemctl --user daemon-reload
+  systemctl --user try-restart app-walker@autostart.service
+fi


### PR DESCRIPTION
Fixes #6443.

## Problem

`bin/omarchy-launch-walker` starts the walker service with `GSK_RENDERER=cairo`, but only behind this guard:

```bash
if ! pgrep -f "walker --gapplication-service" > /dev/null; then
  setsid uwsm-app -- env GSK_RENDERER=cairo walker --gapplication-service &
fi
```

On a normal login the service is already running, started by `default/walker/walker.desktop` via systemd's XDG autostart generator — which carries no environment override. The guard never fires, so the env var is effectively dead code and walker renders through GTK4's default Vulkan backend.

Verified on a stock 3.8.4 install:

```
$ pgrep -a walker
1796 /usr/bin/walker --gapplication-service
$ tr '\0' '\n' < /proc/1796/environ | grep GSK_RENDERER
(no output)
```

This regressed in 30ddfeda, which removed the session-wide `env = GSK_RENDERER,cairo` from `default/hypr/envs.conf` and narrowed it to the launcher. The global env had been inherited by the autostart service; the narrowed one is not.

On amdgpu the consequence is severe — walker page-faults on a GEM buffer, the kernel takes a NULL deref inside TTM while holding the LRU spinlock, and every subsequent display atomic commit deadlocks on it. The whole session hard-freezes (display and input dead, audio still playing). Three occurrences in three days here, always `Comm: walker`. Full kernel traces are in #6443.

## Change

Put the override where the long-lived process is actually started, keeping parity with `omarchy-launch-walker`:

```diff
-Exec=walker --gapplication-service
+Exec=env GSK_RENDERER=cairo walker --gapplication-service
```

Plus a migration, since `~/.config/autostart/walker.desktop` is user-owned and not refreshed automatically. It only rewrites the entry if the `Exec` line is still the stock one, so customized entries are left alone, and it reloads the generator instead of waiting for the next login.

## Alternative

Reverting to the session-wide `env = GSK_RENDERER,cairo` in `default/hypr/envs.conf` would also fix it and is closer to pre-30ddfeda behaviour, but it re-imposes the cairo renderer on every GTK4 app, which is what that commit set out to avoid. Happy to switch if you'd rather go that way.

## Scope

Targets `master`, since walker was dropped from `quattro` in abf0a68b — this only affects the 3.x stable line.

## Testing

- `test/omarchy-cli-test.sh` passes
- Migration is a no-op on a customized entry and idempotent once applied
- Applied the equivalent override locally via a systemd drop-in and confirmed the walker process then has `GSK_RENDERER=cairo`

One caveat, stated plainly: the underlying defect is a kernel-side TTM/amdgpu bug that fires unpredictably, roughly once every day or two, so I can't prove absence of the freeze from a short observation window. What this PR verifiably fixes is that the workaround reaches the process that needs it — which it currently does not.
