### PR TITLE
Fix non-ASCII SSID characters displayed as \xNN hex in network panel

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -120,7 +120,7 @@ print_verbose() {
       link=$(iw dev "$iface" link 2>/dev/null)
 
       if [[ -n $link ]]; then
-        printf 'ssid\t%s\n' "$(printf '%b' "$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")")"
+        printf 'ssid\t%s\n' "$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")"
         printf 'signal_dbm\t%s\n' "$(awk '/signal:/ { print $2; exit }' <<<"$link")"
         printf 'freq\t%s\n' "$(awk '/freq:/ { print $2; exit }' <<<"$link")"
         printf 'bitrate\t%s %s\n' "$(awk '/tx bitrate:/ { print $3; exit }' <<<"$link")" "$(awk '/tx bitrate:/ { print $4; exit }' <<<"$link")"

--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -120,7 +120,7 @@ print_verbose() {
       link=$(iw dev "$iface" link 2>/dev/null)
 
       if [[ -n $link ]]; then
-        printf 'ssid\t%s\n' "$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")"
+        printf 'ssid\t%s\n' "$(printf '%b' "$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")")"
         printf 'signal_dbm\t%s\n' "$(awk '/signal:/ { print $2; exit }' <<<"$link")"
         printf 'freq\t%s\n' "$(awk '/freq:/ { print $2; exit }' <<<"$link")"
         printf 'bitrate\t%s %s\n' "$(awk '/tx bitrate:/ { print $3; exit }' <<<"$link")" "$(awk '/tx bitrate:/ { print $4; exit }' <<<"$link")"

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -92,18 +92,21 @@ function parseBandStatus(raw) {
 
 function decodeIwSsid(value) {
   var raw = String(value || "")
-  var encoded = ""
-
-  for (var i = 0; i < raw.length; i++) {
-    if (raw[i] === "\\" && raw[i + 1] === "x" && /^[0-9a-f]{2}$/i.test(raw.substring(i + 2, i + 4))) {
-      encoded += "%" + raw.substring(i + 2, i + 4)
-      i += 3
-    } else {
-      encoded += encodeURIComponent(raw[i])
-    }
-  }
 
   try {
+    var encoded = ""
+
+    for (var i = 0; i < raw.length; i++) {
+      if (raw[i] === "\\" && raw[i + 1] === "x" && /^[0-9a-f]{2}$/i.test(raw.substring(i + 2, i + 4))) {
+        var hex = raw.substring(i + 2, i + 4)
+        var byte = parseInt(hex, 16)
+        encoded += byte < 32 || byte === 127 ? encodeURIComponent(raw.substring(i, i + 4)) : "%" + hex
+        i += 3
+      } else {
+        encoded += encodeURIComponent(raw[i])
+      }
+    }
+
     return decodeURIComponent(encoded)
   } catch (error) {
     return raw

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -90,7 +90,25 @@ function parseBandStatus(raw) {
   }
 }
 
+function decodeIwSsid(value) {
+  var raw = String(value || "")
+  var encoded = ""
 
+  for (var i = 0; i < raw.length; i++) {
+    if (raw[i] === "\\" && raw[i + 1] === "x" && /^[0-9a-f]{2}$/i.test(raw.substring(i + 2, i + 4))) {
+      encoded += "%" + raw.substring(i + 2, i + 4)
+      i += 3
+    } else {
+      encoded += encodeURIComponent(raw[i])
+    }
+  }
+
+  try {
+    return decodeURIComponent(encoded)
+  } catch (error) {
+    return raw
+  }
+}
 
 function parseKeyValue(raw) {
   var next = {}
@@ -100,7 +118,9 @@ function parseKeyValue(raw) {
     if (!line) continue
     var idx = line.indexOf("\t")
     if (idx === -1) continue
-    next[line.substring(0, idx)] = line.substring(idx + 1).trim()
+    var key = line.substring(0, idx)
+    var value = line.substring(idx + 1)
+    next[key] = key === "ssid" ? decodeIwSsid(value) : value.trim()
   }
   return next
 }
@@ -319,6 +339,7 @@ if (typeof module !== "undefined") {
     bandSectionTitle: bandSectionTitle,
     bandTooltip: bandTooltip,
     parseBandStatus: parseBandStatus,
+    decodeIwSsid: decodeIwSsid,
     parseKeyValue: parseKeyValue,
     throughputState: throughputState,
     pingLatencyState: pingLatencyState,

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -26,6 +26,15 @@ assertDeepEqual(
   { iface: 'wlan0', rx_bytes: '100', tx_bytes: '50' },
   'network parses detail key values'
 )
+assertEqual(network.decodeIwSsid('Cafe\\xe2\\x80\\x99'), 'Cafe’', 'network decodes UTF-8 SSID bytes')
+assertEqual(network.decodeIwSsid('\\x20Cafe\\x20'), ' Cafe ', 'network preserves edge spaces in SSIDs')
+assertEqual(network.decodeIwSsid('slash\\x5cname'), 'slash\\name', 'network decodes SSID backslashes once')
+assertEqual(network.decodeIwSsid('invalid\\xff'), 'invalid\\xff', 'network preserves invalid UTF-8 escapes')
+assertDeepEqual(
+  network.parseKeyValue('ssid\tline\\x0abreak\\x09tab\\x00nul\nsignal_dbm\t-40\n'),
+  { ssid: 'line\nbreak\ttab\0nul', signal_dbm: '-40' },
+  'network decodes control bytes after parsing detail records'
+)
 assertDeepEqual(
   network.throughputState({ prevIface: '', prevSampleTime: 0 }, { iface: 'wlan0', rx_bytes: '100', tx_bytes: '50' }, 10),
   { prevIface: 'wlan0', prevRxBytes: 100, prevTxBytes: 50, prevSampleTime: 10, downloadRate: 0, uploadRate: 0 },

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -27,13 +27,15 @@ assertDeepEqual(
   'network parses detail key values'
 )
 assertEqual(network.decodeIwSsid('Cafe\\xe2\\x80\\x99'), 'Cafe’', 'network decodes UTF-8 SSID bytes')
+assertEqual(network.decodeIwSsid('Smile \\xf0\\x9f\\x98\\x80'), 'Smile 😀', 'network decodes emoji SSID bytes')
 assertEqual(network.decodeIwSsid('\\x20Cafe\\x20'), ' Cafe ', 'network preserves edge spaces in SSIDs')
 assertEqual(network.decodeIwSsid('slash\\x5cname'), 'slash\\name', 'network decodes SSID backslashes once')
 assertEqual(network.decodeIwSsid('invalid\\xff'), 'invalid\\xff', 'network preserves invalid UTF-8 escapes')
+assertEqual(network.decodeIwSsid('already 😀'), 'already 😀', 'network safely preserves unexpected non-BMP input')
 assertDeepEqual(
   network.parseKeyValue('ssid\tline\\x0abreak\\x09tab\\x00nul\nsignal_dbm\t-40\n'),
-  { ssid: 'line\nbreak\ttab\0nul', signal_dbm: '-40' },
-  'network decodes control bytes after parsing detail records'
+  { ssid: 'line\\x0abreak\\x09tab\\x00nul', signal_dbm: '-40' },
+  'network leaves control-byte escapes safe for single-line display'
 )
 assertDeepEqual(
   network.throughputState({ prevIface: '', prevSampleTime: 0 }, { iface: 'wlan0', rx_bytes: '100', tx_bytes: '50' }, 10),


### PR DESCRIPTION
**Problem** 
The connected SSID in the network panel hero area shows `\xNN` hex escapes (e.g. `\xe2\x80\x99`) instead of the actual character (`'`) for any byte outside printable ASCII — smart quotes, emoji, accented letters, backslash, and leading/trailing spaces. The available networks list renders these correctly.

**Root cause** 
`bin/omarchy-network-status` reads the SSID from `iw dev <iface> link`, which escapes non-printable and non-ASCII bytes via `print_ssid_escaped()`. The available networks list reads via NetworkManager D-Bus with proper UTF-8 decoding, so it's unaffected.

**Fix** 
Wrap the awk output in `printf '%b'`, a bash builtin that decodes `\xNN` sequences back to literal bytes. `iw` already escapes backslashes and edge spaces as `\xNN` first, so the round-trip is safe — plain ASCII SSIDs pass through unchanged.

<img width="601" height="835" alt="image" src="https://github.com/user-attachments/assets/cdd05a5d-d97b-48a3-b7c7-13e2f7efde69" />
