### PR TITLE
Fix Bitwarden floating window rendering issues

### DIFF
--- a/default/hypr/apps/bitwarden.lua
+++ b/default/hypr/apps/bitwarden.lua
@@ -2,5 +2,7 @@ o.window("^(Bitwarden)$", { no_screen_share = true, tag = "+floating-window" })
 
 o.window("chrome-nngceckbapebfimnlniiiahkandclblb-Default", {
   no_screen_share = true,
-  tag = "+floating-window",
+  float = true,
+  no_blur = true,
+  max_size = "480 650",
 })


### PR DESCRIPTION
Windows tagged with +floating-window have a size of "875 600" by default.
This is larger than what the Bitwarden extension requests and causes the popup window to not refresh properly.
The window can be forced to resize by switching windows; however, forcing the max_size and removing the standard +floating-window tag allows the window to render properly.

Fixes #6075 