### PR TITLE
Enable be211 wifi7

### DIFF
--- a/install/config/hardware/intel/fix-wifi7-eht.sh
+++ b/install/config/hardware/intel/fix-wifi7-eht.sh
@@ -1,15 +1,12 @@
-# Temporary fix for Dell XPS 14/16 on Panther Lake
-# Disable WiFi 7 (EHT/802.11be) on Intel BE200/BE211 cards
-# The iwlwifi driver has a broken EHT RX data path — APs drop to MCS 0 NSS 1
-# when EHT is negotiated, making WiFi unusable. Disabling EHT falls
-# back to WiFi 6 (HE/802.11ax) which works at full speed.
-# This should be removed when Intel fixes the firmware/driver.
+# Temporarily disable WiFi 7 (EHT/802.11be) on Intel BE200 cards.
+# Linux kernel bug 221675 tracks a firmware assertion after warm reconnects
+# at 6 GHz/320 MHz. Disabling EHT avoids the failing channel context.
+# https://bugzilla.kernel.org/show_bug.cgi?id=221675
 
-if lspci -nn | grep -qE '\[8086:(e440|272b)\]'; then
+if lspci -nn | grep -q '\[8086:272b\]'; then
   sudo tee /etc/modprobe.d/iwlwifi-disable-eht.conf <<'EOF'
-# Temporary fix Dell XPS 14/16 on Panther lake
-# Disable WiFi 7 (EHT) on Intel BE200/BE211 — broken RX rate adaptation
-# Remove this file when fixes land in the iwlwifi EHT data path
+# Temporary workaround for Intel BE200 320 MHz firmware assertions
+# Remove this file when Linux kernel bug 221675 is fixed
 options iwlwifi disable_11be=Y
 EOF
 fi

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -135,11 +135,11 @@ enable_be211_wifi7() {
     return 1
   fi
 
-  sudo rm -f "$wifi7_backup" ||
-    echo "WARNING: Failed to remove $wifi7_backup; delete it manually"
-
   omarchy-state set reboot-required ||
     echo "WARNING: Failed to mark reboot-required; reboot to apply the WiFi 7 change"
+
+  sudo rm -f "$wifi7_backup" ||
+    echo "WARNING: Failed to remove $wifi7_backup; delete it manually"
 
   return 0
 }

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -14,6 +14,7 @@ enable_be211_wifi7() {
   local package_query
   local pkgbase_file
   local package
+  local pci_devices
   local queried_package
   local version
 
@@ -48,7 +49,17 @@ enable_be211_wifi7() {
     fi
   fi
 
-  lspci -nn | grep -q '\[8086:e440\]' || return 0
+  if ! pci_devices=$(lspci -nn); then
+    echo "Skipped $wifi7_config because PCI devices could not be inspected"
+    return 0
+  fi
+
+  [[ $pci_devices == *"[8086:e440]"* ]] || return 0
+
+  if [[ $pci_devices == *"[8086:272b]"* ]]; then
+    echo "Skipped $wifi7_config because Intel BE200 is also present"
+    return 0
+  fi
 
   for pkgbase_file in "$kernel_modules_dir"/*/pkgbase; do
     [[ -f $pkgbase_file ]] || continue

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -8,10 +8,13 @@ enable_be211_wifi7() {
   local actual_config
   local kernel_found=false
   local kernel_blocked=false
-  local migration_failed=false
   local -a rebuild_command
+  local comparison
+  local extra
+  local package_query
   local pkgbase_file
   local package
+  local queried_package
   local version
 
   expected_config=$(printf '%s\n' \
@@ -37,6 +40,8 @@ enable_be211_wifi7() {
         echo "ERROR: Failed to rebuild boot images after interrupted migration"
         return 1
       fi
+      omarchy-state set reboot-required ||
+        echo "WARNING: Failed to mark reboot-required after restoring $wifi7_config"
     else
       echo "Unable to restore unexpected backup $wifi7_backup"
       return 1
@@ -49,13 +54,24 @@ enable_be211_wifi7() {
     [[ -f $pkgbase_file ]] || continue
 
     package=$(<"$pkgbase_file")
-    if version=$(pacman -Q "$package" 2>/dev/null | awk '{ print $2 }'); then
-      kernel_found=true
-      if (( $(vercmp "$version" 7.1) < 0 )); then
-        kernel_blocked=true
-        break
-      fi
-    else
+    if ! package_query=$(pacman -Q "$package" 2>/dev/null); then
+      kernel_blocked=true
+      break
+    fi
+
+    read -r queried_package version extra <<<"$package_query"
+    if [[ $package_query == *$'\n'* || $queried_package != "$package" || -z $version || -n $extra ]]; then
+      kernel_blocked=true
+      break
+    fi
+
+    if ! comparison=$(vercmp "$version" 7.1 2>/dev/null) || [[ ! $comparison =~ ^-?[0-9]+$ ]]; then
+      kernel_blocked=true
+      break
+    fi
+
+    kernel_found=true
+    if (( comparison < 0 )); then
       kernel_blocked=true
       break
     fi
@@ -82,12 +98,6 @@ enable_be211_wifi7() {
   sudo mv "$wifi7_config" "$wifi7_backup" || return 1
 
   if ! "${rebuild_command[@]}"; then
-    migration_failed=true
-  elif ! omarchy-state set reboot-required; then
-    migration_failed=true
-  fi
-
-  if $migration_failed; then
     if ! sudo mv "$wifi7_backup" "$wifi7_config"; then
       echo "ERROR: Failed to restore $wifi7_config after migration failure"
       return 1
@@ -99,7 +109,13 @@ enable_be211_wifi7() {
     return 1
   fi
 
-  sudo rm -f "$wifi7_backup"
+  sudo rm -f "$wifi7_backup" ||
+    echo "WARNING: Failed to remove $wifi7_backup; delete it manually"
+
+  omarchy-state set reboot-required ||
+    echo "WARNING: Failed to mark reboot-required; reboot to apply the WiFi 7 change"
+
+  return 0
 }
 
 enable_be211_wifi7

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -88,7 +88,9 @@ enable_be211_wifi7() {
     fi
 
     read -r queried_package version extra <<<"$package_query"
-    if [[ $package_query == *$'\n'* || $queried_package != "$package" || -z $version || -n $extra ]]; then
+    # Arch package names cannot contain shell glob characters.
+    # shellcheck disable=SC2053
+    if [[ $package_query == *$'\n'* || $queried_package != $package || -z $version || -n $extra ]]; then
       kernel_blocked=true
       break
     fi
@@ -104,7 +106,7 @@ enable_be211_wifi7() {
     fi
   done
 
-  if ! $kernel_found || $kernel_blocked; then
+  if [[ $kernel_found == "false" || $kernel_blocked == "true" ]]; then
     echo "Skipped $wifi7_config because not all installed kernels are Linux 7.1 or newer"
     return 0
   fi

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -1,28 +1,32 @@
 echo "Enable WiFi 7 on Intel BE211 with Linux 7.1 or newer"
 
+wifi7_config_matches_omarchy_1784508420() {
+  local config_file=$1
+
+  printf '%s\n' \
+    '# Temporary fix Dell XPS 14/16 on Panther lake' \
+    '# Disable WiFi 7 (EHT) on Intel BE200/BE211 — broken RX rate adaptation' \
+    '# Remove this file when fixes land in the iwlwifi EHT data path' \
+    'options iwlwifi disable_11be=Y' |
+    sudo cmp -s "$config_file" -
+}
+
 enable_be211_wifi7() {
   local wifi7_config="/etc/modprobe.d/iwlwifi-disable-eht.conf"
   local wifi7_backup="${wifi7_config}.omarchy-1784508420-backup"
   local kernel_modules_dir="/usr/lib/modules"
-  local expected_config
-  local actual_config
   local kernel_found=false
   local kernel_blocked=false
   local -a rebuild_command
   local comparison
   local extra
+  local kernel_dir
   local package_query
   local pkgbase_file
   local package
   local pci_devices
   local queried_package
   local version
-
-  expected_config=$(printf '%s\n' \
-    '# Temporary fix Dell XPS 14/16 on Panther lake' \
-    '# Disable WiFi 7 (EHT) on Intel BE200/BE211 — broken RX rate adaptation' \
-    '# Remove this file when fixes land in the iwlwifi EHT data path' \
-    'options iwlwifi disable_11be=Y')
 
   if omarchy-cmd-present limine-mkinitcpio; then
     rebuild_command=(sudo limine-mkinitcpio)
@@ -31,8 +35,7 @@ enable_be211_wifi7() {
   fi
 
   if [[ ! -f $wifi7_config && -f $wifi7_backup ]]; then
-    actual_config=$(sudo cat "$wifi7_backup")
-    if [[ $actual_config == "$expected_config" ]]; then
+    if wifi7_config_matches_omarchy_1784508420 "$wifi7_backup"; then
       if ! sudo mv "$wifi7_backup" "$wifi7_config"; then
         echo "ERROR: Failed to restore $wifi7_config from interrupted migration"
         return 1
@@ -61,8 +64,22 @@ enable_be211_wifi7() {
     return 0
   fi
 
-  for pkgbase_file in "$kernel_modules_dir"/*/pkgbase; do
-    [[ -f $pkgbase_file ]] || continue
+  for kernel_dir in "$kernel_modules_dir"/*; do
+    [[ -d $kernel_dir ]] || continue
+
+    if [[ ! -d $kernel_dir/kernel &&
+      ! -f $kernel_dir/modules.builtin &&
+      ! -f $kernel_dir/modules.dep &&
+      ! -f $kernel_dir/vmlinuz ]]; then
+      continue
+    fi
+
+    kernel_found=true
+    pkgbase_file="$kernel_dir/pkgbase"
+    if [[ ! -f $pkgbase_file ]]; then
+      kernel_blocked=true
+      break
+    fi
 
     package=$(<"$pkgbase_file")
     if ! package_query=$(pacman -Q "$package" 2>/dev/null); then
@@ -81,7 +98,6 @@ enable_be211_wifi7() {
       break
     fi
 
-    kernel_found=true
     if (( comparison < 0 )); then
       kernel_blocked=true
       break
@@ -95,8 +111,7 @@ enable_be211_wifi7() {
 
   [[ -f $wifi7_config ]] || return 0
 
-  actual_config=$(sudo cat "$wifi7_config")
-  if [[ $actual_config != "$expected_config" ]]; then
+  if ! wifi7_config_matches_omarchy_1784508420 "$wifi7_config"; then
     echo "Skipped $wifi7_config because it is not the Omarchy-managed workaround"
     return 0
   fi

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -1,0 +1,105 @@
+echo "Enable WiFi 7 on Intel BE211 with Linux 7.1 or newer"
+
+enable_be211_wifi7() {
+  local wifi7_config="/etc/modprobe.d/iwlwifi-disable-eht.conf"
+  local wifi7_backup="${wifi7_config}.omarchy-1784508420-backup"
+  local kernel_modules_dir="/usr/lib/modules"
+  local expected_config
+  local actual_config
+  local kernel_found=false
+  local kernel_blocked=false
+  local migration_failed=false
+  local -a rebuild_command
+  local pkgbase_file
+  local package
+  local version
+
+  expected_config=$(printf '%s\n' \
+    '# Temporary fix Dell XPS 14/16 on Panther lake' \
+    '# Disable WiFi 7 (EHT) on Intel BE200/BE211 — broken RX rate adaptation' \
+    '# Remove this file when fixes land in the iwlwifi EHT data path' \
+    'options iwlwifi disable_11be=Y')
+
+  if omarchy-cmd-present limine-mkinitcpio; then
+    rebuild_command=(sudo limine-mkinitcpio)
+  else
+    rebuild_command=(sudo mkinitcpio -P)
+  fi
+
+  if [[ ! -f $wifi7_config && -f $wifi7_backup ]]; then
+    actual_config=$(sudo cat "$wifi7_backup")
+    if [[ $actual_config == "$expected_config" ]]; then
+      if ! sudo mv "$wifi7_backup" "$wifi7_config"; then
+        echo "ERROR: Failed to restore $wifi7_config from interrupted migration"
+        return 1
+      fi
+      if ! "${rebuild_command[@]}"; then
+        echo "ERROR: Failed to rebuild boot images after interrupted migration"
+        return 1
+      fi
+    else
+      echo "Unable to restore unexpected backup $wifi7_backup"
+      return 1
+    fi
+  fi
+
+  lspci -nn | grep -q '\[8086:e440\]' || return 0
+
+  for pkgbase_file in "$kernel_modules_dir"/*/pkgbase; do
+    [[ -f $pkgbase_file ]] || continue
+
+    package=$(<"$pkgbase_file")
+    if version=$(pacman -Q "$package" 2>/dev/null | awk '{ print $2 }'); then
+      kernel_found=true
+      if (( $(vercmp "$version" 7.1) < 0 )); then
+        kernel_blocked=true
+        break
+      fi
+    else
+      kernel_blocked=true
+      break
+    fi
+  done
+
+  if ! $kernel_found || $kernel_blocked; then
+    echo "Skipped $wifi7_config because not all installed kernels are Linux 7.1 or newer"
+    return 0
+  fi
+
+  [[ -f $wifi7_config ]] || return 0
+
+  actual_config=$(sudo cat "$wifi7_config")
+  if [[ $actual_config != "$expected_config" ]]; then
+    echo "Skipped $wifi7_config because it is not the Omarchy-managed workaround"
+    return 0
+  fi
+
+  if [[ -e $wifi7_backup ]]; then
+    echo "Unable to migrate while backup already exists at $wifi7_backup"
+    return 1
+  fi
+
+  sudo mv "$wifi7_config" "$wifi7_backup" || return 1
+
+  if ! "${rebuild_command[@]}"; then
+    migration_failed=true
+  elif ! omarchy-state set reboot-required; then
+    migration_failed=true
+  fi
+
+  if $migration_failed; then
+    if ! sudo mv "$wifi7_backup" "$wifi7_config"; then
+      echo "ERROR: Failed to restore $wifi7_config after migration failure"
+      return 1
+    fi
+
+    if ! "${rebuild_command[@]}"; then
+      echo "ERROR: Failed to rebuild boot images with the restored WiFi workaround"
+    fi
+    return 1
+  fi
+
+  sudo rm -f "$wifi7_backup"
+}
+
+enable_be211_wifi7


### PR DESCRIPTION
## Summary

- Stop disabling WiFi 7 on Intel BE211 (`8086:e440`) systems.
- Keep the EHT workaround for Intel BE200 (`8086:272b`), where Linux kernel bug 221675 still tracks a warm-reconnect failure at 6 GHz/320 MHz.
- Add a guarded migration that removes the historical Omarchy workaround from existing BE211 installations only when every discovered installed kernel is Linux 7.1 or newer.

## Why

Omarchy added the workaround in [basecamp/omarchy#5106](https://github.com/basecamp/omarchy/pull/5106) while the new `iwlmld` path made EHT connections unusable on Panther Lake hardware. Linux 7.1 includes relevant `iwlmld` TSO fixes, including [torvalds/linux@92cee08](https://github.com/torvalds/linux/commit/92cee08dc4f00e77fd1317e4343c5d458b0abab7).

The original BE211 system was retested on Linux `7.1.5-arch1-1-ptl` with firmware `102.07fca168.0`:

- Negotiated EHT on 6 GHz channel 37 at 320 MHz.
- Reached 3.46 Gbps RX / 3.84 Gbps TX PHY rates.
- Completed five controlled disconnect/reconnect cycles, returning to EHT/320 MHz every time.
- Transferred approximately 1.95 GB under bidirectional load.
- Measured approximately 718 Mbps download and 622 Mbps upload during the warm-state test.
- Recorded zero TX failures, TX retries, beacon losses, firmware crashes, or `iwlmld` errors.

The BE200 workaround remains because [kernel bug 221675](https://bugzilla.kernel.org/show_bug.cgi?id=221675) is still open and describes a distinct 320 MHz firmware assertion after warm reconnects.

## Migration safety

The migration:

- Matches the complete historical Omarchy-generated config before removing it.
- Preserves user-authored or modified files.
- Requires every discovered installed kernel package to be version 7.1 or newer.
- Conservatively skips unknown and older kernels.
- Moves the config to a transaction backup while rebuilding boot images.
- Treats a successful desired-state boot-image rebuild as the transaction boundary.
- Restores both the config and boot images if that rebuild fails.
- Warns without undoing the rebuilt image if backup cleanup or reboot-state recording fails.
- Recovers and rebuilds safely after an interrupted previous attempt.
- Marks a reboot as required after successful migration and after interrupted-recovery rebuilds.

## Validation

- `bash -n` on both changed scripts.
- ShellCheck 0.11.0 on both changed scripts.
- `git diff --check`.
- Full `test/omarchy-cli-test.sh` suite: 60 checks passed.
- Hardware-policy matrix covering BE211 and BE200 installer behavior.
- Migration matrix covering:
  - current, older, mixed, and unknown kernels
  - exact Omarchy and user-owned config files
  - initial rebuild failure
  - backup-cleanup and reboot-state warning failures
  - rollback rebuild failure
  - interrupted migration recovery
  - recovery with an older kernel or hardware mismatch
  - orphaned backup restore and rebuild failures
- Independent read-only review completed with no remaining substantive findings.

## Remaining risk

The live A/B validation covers one BE211, firmware, and access-point combination. Suspend/resume and other BE211/AP combinations still need broader real-world coverage. The BE200 exclusion should remain until its upstream 320 MHz issue is resolved.