### PR TITLE
fix add built in transparency theme options

### DIFF
--- a/themes/catppuccin-latte/neovim.lua
+++ b/themes/catppuccin-latte/neovim.lua
@@ -1,16 +1,21 @@
 return {
-	{
-		"catppuccin/nvim",
-		name = "catppuccin",
-		priority = 1000,
-		opts = {
-			flavour = "latte",
-		},
-	},
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "catppuccin-latte",
-		},
-	},
+  {
+    "catppuccin/nvim",
+    name = "catppuccin",
+    lazy = true,
+    priority = 1000,
+    opts = {
+      flavor = "latte",
+      transparent_background = true,
+      float = {
+        transparent = true,
+      },
+    },
+  },
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "catppuccin-latte",
+    },
+  },
 }

--- a/themes/catppuccin-latte/neovim.lua
+++ b/themes/catppuccin-latte/neovim.lua
@@ -5,7 +5,7 @@ return {
     lazy = true,
     priority = 1000,
     opts = {
-      flavor = "latte",
+      flavour = "latte",
       transparent_background = true,
       float = {
         transparent = true,

--- a/themes/catppuccin-latte/neovim.lua
+++ b/themes/catppuccin-latte/neovim.lua
@@ -2,7 +2,6 @@ return {
   {
     "catppuccin/nvim",
     name = "catppuccin",
-    lazy = true,
     priority = 1000,
     opts = {
       flavour = "latte",

--- a/themes/catppuccin/neovim.lua
+++ b/themes/catppuccin/neovim.lua
@@ -2,7 +2,14 @@ return {
   {
     "catppuccin/nvim",
     name = "catppuccin",
+    lazy = true,
     priority = 1000,
+    opts = {
+      transparent_background = true,
+      float = {
+        transparent = true,
+      },
+    },
   },
   {
     "LazyVim/LazyVim",

--- a/themes/catppuccin/neovim.lua
+++ b/themes/catppuccin/neovim.lua
@@ -2,7 +2,6 @@ return {
   {
     "catppuccin/nvim",
     name = "catppuccin",
-    lazy = true,
     priority = 1000,
     opts = {
       transparent_background = true,

--- a/themes/everforest/neovim.lua
+++ b/themes/everforest/neovim.lua
@@ -1,10 +1,18 @@
 return {
-	{ "neanias/everforest-nvim" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "everforest",
-			background = "soft",
-		},
-	},
+  {
+    "neanias/everforest-nvim",
+    config = function()
+      require("everforest").setup({
+        transparent_background_level = 2,
+        background = "soft",
+      })
+    end,
+  },
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "everforest",
+      background = "soft",
+    },
+  },
 }

--- a/themes/retro-82/neovim.lua
+++ b/themes/retro-82/neovim.lua
@@ -3,7 +3,7 @@ return {
     "OldJobobo/retro-82.nvim",
     priority = 1000,
     opts = {
-      transparency = true,
+      transparent = true,
     },
   },
   {

--- a/themes/retro-82/neovim.lua
+++ b/themes/retro-82/neovim.lua
@@ -2,6 +2,9 @@ return {
   {
     "OldJobobo/retro-82.nvim",
     priority = 1000,
+    opts = {
+      transparency = true,
+    },
   },
   {
     "LazyVim/LazyVim",

--- a/themes/rose-pine/neovim.lua
+++ b/themes/rose-pine/neovim.lua
@@ -1,7 +1,6 @@
 return {
   {
     "rose-pine/neovim",
-    lazy = true,
     priority = 1000,
     opts = {
       styles = {

--- a/themes/rose-pine/neovim.lua
+++ b/themes/rose-pine/neovim.lua
@@ -1,9 +1,18 @@
 return {
-	{ "rose-pine/neovim", name = "rose-pine" },
-	{
-		"LazyVim/LazyVim",
-		opts = {
-			colorscheme = "rose-pine-dawn",
-		},
-	},
+  {
+    "rose-pine/neovim",
+    lazy = true,
+    priority = 1000,
+    opts = {
+      styles = {
+        transparency = true,
+      },
+    },
+  },
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "rose-pine-dawn",
+    },
+  },
 }


### PR DESCRIPTION
### Summary of Changes

Some themes natively offer transparency settings, but reliance on Omarchy's global Lua file alone leaves certain UI elements unrendered/opaque in specific themes, notably **lualine**, **bufferline**, and **floating windows**.

This change enables built-in theme transparency options where available, ensuring a consistent transparent aesthetic across all UI elements without missing spots.

### Problem

* Omarchy uses a global Lua configuration to manage transparency across themes universally.
* However, for specific themes, certain UI components (e.g., status line via `lualine`, tab bar via `bufferline`, and floating window backgrounds) ignore or bypass this global override, resulting in opaque patches or visual inconsistencies.

### Solution

* Explicitly enabled theme-native transparency settings for affected themes.
* Fixes visual glitches and ensures statuslines, bufferlines, and float backgrounds blend seamlessly when transparency is turned on.

### Themes changed:

- Catppuccin
- Catppuccin Latte
- Everforest
- Retro82
- Rosè Pine