### PR TITLE
Drop auto scale from default monitor config

### DIFF
--- a/config/hypr/monitors.lua
+++ b/config/hypr/monitors.lua
@@ -1,8 +1,8 @@
 -- See https://wiki.hypr.land/Configuring/Basics/Monitors/
 -- List current monitors and supported resolutions with: hyprctl monitors all
 
-local omarchy_gdk_scale = 2
-local omarchy_monitor_scale = "auto"
+local omarchy_gdk_scale = 1
+local omarchy_monitor_scale = 1
 
 hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
 hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })


### PR DESCRIPTION
The stock `monitors.lua` set `GDK_SCALE=2` and `scale="auto"`. On ~120 DPI displays (e.g. 1366x768 laptops) the `"auto"` heuristic resolves to `2.00`, making everything 2x oversized.

Hyprland's auto-scale uses PPI thresholds that treat ~120 DPI panels as HiDPI and assigns 2x scale incorrectly.

**Fix:** Replace the two-variable pattern with a single `monitor_scale = 1` that both `GDK_SCALE` and `hl.monitor` scale use. This gives correct 1x rendering on standard-DPI panels out of the box. HiDPI users can override the value.
