### PR TITLE
Add selective sync to the Dropbox panel

### DIFF
--- a/shell/plugins/panels/dropbox/Model.js
+++ b/shell/plugins/panels/dropbox/Model.js
@@ -47,6 +47,41 @@ function defaultStatus() {
   }
 }
 
+function parseFolders(raw) {
+  var text = String(raw || "").trim()
+  if (text === "") return defaultFolders()
+  try {
+    var parsed = JSON.parse(text)
+    if (!parsed || typeof parsed !== "object") return defaultFolders()
+    parsed.folders = Array.isArray(parsed.folders) ? parsed.folders : []
+    return parsed
+  } catch (e) {
+    var failed = defaultFolders()
+    failed.error = "Failed to parse Dropbox folders"
+    return failed
+  }
+}
+
+function defaultFolders() {
+  return {
+    ok: false,
+    error: "",
+    accountPath: "",
+    path: "",
+    parentPath: "",
+    atRoot: true,
+    folders: []
+  }
+}
+
+function folderMeta(folder) {
+  if (!folder) return ""
+  if (folder.excluded === true) return "Not synced"
+  var count = Number(folder.childCount || 0)
+  if (count <= 0) return "Synced"
+  return "Synced · " + count + (count === 1 ? " folder" : " folders")
+}
+
 function fileExtension(name) {
   var value = String(name || "").toLowerCase()
   var index = value.lastIndexOf(".")
@@ -125,6 +160,9 @@ if (typeof module !== "undefined") {
   module.exports = {
     parseStatus: parseStatus,
     defaultStatus: defaultStatus,
+    parseFolders: parseFolders,
+    defaultFolders: defaultFolders,
+    folderMeta: folderMeta,
     fileExtension: fileExtension,
     fileKind: fileKind,
     fileGlyph: fileGlyph,

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -211,13 +211,14 @@ Panel {
       if (onUpRow()) goUpFolder()
       else {
         var folder = selectedFolder()
-        // Enter drills into a browsable folder; for a leaf there is nothing to
-        // open, so it flips syncing instead of doing nothing.
+        // Enter only ever navigates. A folder with no subfolders is not
+        // browsable, and rows give no hint of that, so falling back to a
+        // toggle here would silently unsync — and delete the local copy of —
+        // whatever the cursor happened to be on. `s` and the switch own
+        // toggling.
         if (folder && folder.browsable === true) {
           dropbox.enterFolder(folder)
           folderIndex = 0
-        } else {
-          toggleSelectedFolder()
         }
       }
     }

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -16,8 +16,25 @@ Panel {
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   property string focusSection: "login"
   property int fileIndex: 0
+  property int folderIndex: 0
   property bool cursorActive: false
   property int phraseIndex: 0
+
+  readonly property bool showFolders: settings && settings.showSyncedFolders !== undefined
+    ? settings.showSyncedFolders !== false
+    : true
+  // The ".." row is a cursor stop too, so folder navigation indexes over
+  // [up?, ...folders]. `folderRowCount` is that combined length.
+  readonly property bool hasUpRow: !dropbox.folderAtRoot && dropbox.folderParentPath !== ""
+  readonly property int folderRowCount: (hasUpRow ? 1 : 0) + dropbox.folders.length
+  readonly property bool foldersVisible: showFolders && dropbox.authenticated
+  readonly property string browseCrumb: {
+    var root_ = String(dropbox.accountPath || "")
+    var here = String(dropbox.browsePath || "")
+    if (root_ === "" || here === "" || here === root_) return "Dropbox"
+    if (here.indexOf(root_ + "/") !== 0) return here
+    return "Dropbox/" + here.substring(root_.length + 1)
+  }
 
   readonly property var activePhrases: [
     "Filing files",
@@ -47,33 +64,97 @@ Panel {
     if (!dropbox.authenticated) {
       focusSection = "login"
       fileIndex = 0
+      folderIndex = 0
       return
     }
-    if (dropbox.files.length === 0) {
-      focusSection = "header"
-      fileIndex = 0
-      return
+    if (folderRowCount === 0 && focusSection === "folders") focusSection = "header"
+    if (dropbox.files.length === 0 && focusSection === "files") focusSection = "header"
+    if (focusSection !== "files" && focusSection !== "folders" && focusSection !== "header") {
+      focusSection = folderRowCount > 0 && foldersVisible ? "folders" : "header"
     }
-    if (focusSection !== "files" && focusSection !== "header") focusSection = "files"
-    if (fileIndex >= dropbox.files.length) fileIndex = Math.max(0, dropbox.files.length - 1)
-    if (fileIndex < 0) fileIndex = 0
+    folderIndex = Math.max(0, Math.min(folderIndex, Math.max(0, folderRowCount - 1)))
+    fileIndex = Math.max(0, Math.min(fileIndex, Math.max(0, dropbox.files.length - 1)))
+  }
+
+  // Vertical order through the panel: header -> folders -> files. Each helper
+  // returns "" when its section has nothing to land on, so an empty section is
+  // skipped rather than trapping the cursor.
+  function sectionBelow(name) {
+    if (name === "header") {
+      if (foldersVisible && folderRowCount > 0) return "folders"
+      if (dropbox.files.length > 0) return "files"
+      return ""
+    }
+    if (name === "folders" && dropbox.files.length > 0) return "files"
+    return ""
+  }
+
+  function sectionAbove(name) {
+    if (name === "files") {
+      if (foldersVisible && folderRowCount > 0) return "folders"
+      return "header"
+    }
+    if (name === "folders") return "header"
+    return ""
   }
 
   function moveCursor(dx, dy) {
     cursorActive = true
     ensureCursor()
-    if (dy === 0) return
+    if (dy === 0) {
+      // Left/right (and h/l) browse the folder tree, the way a file manager
+      // does. PanelKeyCatcher swallows h/l as movement, so this is the only
+      // place folder navigation can hang off those keys.
+      if (dx !== 0 && focusSection === "folders") {
+        if (dx < 0) goUpFolder()
+        else if (!onUpRow()) {
+          var folder = selectedFolder()
+          if (folder && folder.browsable === true) {
+            dropbox.enterFolder(folder)
+            folderIndex = 0
+          }
+        }
+      }
+      return
+    }
     if (focusSection === "header") {
-      if (dy > 0 && dropbox.files.length > 0) {
-        focusSection = "files"
+      var below = sectionBelow("header")
+      if (dy > 0 && below !== "") {
+        focusSection = below
+        folderIndex = 0
         fileIndex = 0
         scrollCursorIntoView()
       }
       return
     }
+    if (focusSection === "folders") {
+      if (dy < 0 && folderIndex === 0) {
+        setHeaderCursor()
+        return
+      }
+      if (dy > 0 && folderIndex === folderRowCount - 1) {
+        var next = sectionBelow("folders")
+        if (next !== "") {
+          focusSection = next
+          fileIndex = 0
+          scrollCursorIntoView()
+          return
+        }
+      }
+      folderIndex = Math.max(0, Math.min(folderRowCount - 1, folderIndex + dy))
+      scrollCursorIntoView()
+      return
+    }
     if (focusSection === "files") {
       if (dy < 0 && fileIndex === 0) {
-        setHeaderCursor()
+        var previous = sectionAbove("files")
+        if (previous === "folders") {
+          focusSection = "folders"
+          folderIndex = Math.max(0, folderRowCount - 1)
+          scrollCursorIntoView()
+        } else {
+          setHeaderCursor()
+        }
         return
       }
       fileIndex = Math.max(0, Math.min(dropbox.files.length - 1, fileIndex + dy))
@@ -87,6 +168,36 @@ Panel {
     if (panelFlick) panelFlick.contentY = 0
   }
 
+  function setFolderCursor(index) {
+    cursorActive = true
+    focusSection = "folders"
+    folderIndex = index
+    scrollCursorIntoView()
+  }
+
+  // Row 0 is the ".." row when it is present, so folder N sits at N + 1.
+  function selectedFolder() {
+    var index = hasUpRow ? folderIndex - 1 : folderIndex
+    if (index < 0 || index >= dropbox.folders.length) return null
+    return dropbox.folders[index]
+  }
+
+  function onUpRow() {
+    return hasUpRow && folderIndex === 0
+  }
+
+  function toggleSelectedFolder() {
+    if (focusSection !== "folders") return
+    var folder = selectedFolder()
+    if (folder && !dropbox.syncBusy) dropbox.toggleFolderSynced(folder)
+  }
+
+  function goUpFolder() {
+    if (!hasUpRow) return
+    dropbox.goUpFolder()
+    folderIndex = 0
+  }
+
   function toggleRunning() {
     if (dropbox.installed && !dropbox.busy) dropbox.toggleRunning()
   }
@@ -96,6 +207,20 @@ Panel {
     if (focusSection === "login") dropbox.login()
     else if (focusSection === "header") toggleRunning()
     else if (focusSection === "files") dropbox.openFile(selectedFile())
+    else if (focusSection === "folders") {
+      if (onUpRow()) goUpFolder()
+      else {
+        var folder = selectedFolder()
+        // Enter drills into a browsable folder; for a leaf there is nothing to
+        // open, so it flips syncing instead of doing nothing.
+        if (folder && folder.browsable === true) {
+          dropbox.enterFolder(folder)
+          folderIndex = 0
+        } else {
+          toggleSelectedFolder()
+        }
+      }
+    }
   }
 
   function selectedFile() {
@@ -129,6 +254,8 @@ Panel {
   function scrollCursorIntoView() {
     if (focusSection === "files" && fileColumn && fileIndex >= 0 && fileIndex < fileColumn.children.length) {
       scrollItemIntoView(fileColumn.children[fileIndex])
+    } else if (focusSection === "folders" && folderColumn && folderIndex >= 0 && folderIndex < folderColumn.children.length) {
+      scrollItemIntoView(folderColumn.children[folderIndex])
     }
   }
 
@@ -137,11 +264,21 @@ Panel {
 
   onOpenedChanged: if (opened) {
     cursorActive = false
+    // The panel item outlives a close, so the cursor has to be sent back to the
+    // top explicitly. Without this it resumes wherever it was last left, which
+    // silently skips whichever sections sit above that point.
+    focusSection = dropbox.authenticated ? "header" : "login"
+    folderIndex = 0
+    fileIndex = 0
     if (panelFlick) panelFlick.contentY = 0
     dropbox.refresh()
+    // Reopen at the Dropbox root rather than wherever the last visit left off,
+    // so the view always matches the cursor being reset to the top.
+    if (showFolders) dropbox.resetBrowse()
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
   onFileIndexChanged: scrollCursorIntoView()
+  onFolderIndexChanged: scrollCursorIntoView()
 
   Service {
     id: dropbox
@@ -153,6 +290,7 @@ Panel {
     target: dropbox
     function onAuthenticatedChanged() { root.ensureCursor() }
     function onFilesChanged() { root.ensureCursor() }
+    function onFoldersChanged() { root.ensureCursor() }
   }
 
   IpcHandler {
@@ -209,9 +347,10 @@ Panel {
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
-        if (t === "r" || t === "R") dropbox.refresh()
+        if (t === "r" || t === "R") { dropbox.refresh(); if (root.showFolders) dropbox.loadFolders() }
         else if (t === "l" || t === "L") dropbox.login()
         else if (t === "p" || t === "P") root.toggleRunning()
+        else if (t === "s" || t === "S") root.toggleSelectedFolder()
       }
 
       Flickable {
@@ -304,6 +443,100 @@ Panel {
               width: parent.width
               spacing: Style.spacing.labelGap
               InfoPair { label: "Stored"; value: Model.usageText(dropbox.usedBytes, dropbox.quotaBytes, dropbox.quotaKnown) }
+            }
+          }
+
+          PanelSeparator {
+            visible: root.foldersVisible
+            foreground: root.foreground
+          }
+
+          Column {
+            id: folderSection
+            visible: root.foldersVisible
+            width: parent.width
+            spacing: Style.space(10)
+
+            Item {
+              width: parent.width
+              implicitHeight: foldersHeader.implicitHeight
+
+              PanelSectionHeader {
+                id: foldersHeader
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                text: "SYNCED FOLDERS"
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+              }
+
+              PanelActionButton {
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                iconText: "󰑐"
+                tooltipText: "Refresh folders"
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                enabled: !dropbox.foldersBusy
+                onClicked: dropbox.loadFolders()
+              }
+            }
+
+            // Where we are in the tree, shown only once you have drilled in.
+            Text {
+              visible: root.hasUpRow
+              width: parent.width
+              text: root.browseCrumb
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideLeft
+            }
+
+            Text {
+              visible: dropbox.foldersError !== ""
+              width: parent.width
+              text: dropbox.foldersError
+              color: root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              wrapMode: Text.WordWrap
+            }
+
+            Text {
+              visible: dropbox.foldersError === "" && dropbox.foldersLoaded && root.folderRowCount === 0
+              width: parent.width
+              text: "No folders here."
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+              horizontalAlignment: Text.AlignHCenter
+            }
+
+            Column {
+              id: folderColumn
+              visible: root.folderRowCount > 0
+              width: parent.width
+              spacing: Style.space(6)
+
+              // A Repeater rather than a `visible` binding so the row is truly
+              // absent when at the root — `scrollCursorIntoView` indexes into
+              // `folderColumn.children`, which must line up with `folderIndex`.
+              Repeater {
+                model: root.hasUpRow ? 1 : 0
+                UpRow { width: folderColumn.width }
+              }
+
+              Repeater {
+                model: dropbox.folders
+                FolderRow {
+                  required property var modelData
+                  required property int index
+                  width: folderColumn.width
+                  folder: modelData
+                  rowIndex: root.hasUpRow ? index + 1 : index
+                }
+              }
             }
           }
 
@@ -446,6 +679,162 @@ Panel {
         enabled: dropbox.installed && !dropbox.busy
         Layout.alignment: Qt.AlignVCenter
         onClicked: dropbox.login()
+      }
+    }
+  }
+
+  // Always cursor row 0 when present. Clicking anywhere walks one level up.
+  component UpRow: CursorSurface {
+    id: upRow
+
+    hasCursor: root.cursorActive && root.focusSection === "folders" && root.folderIndex === 0
+    foreground: root.foreground
+
+    implicitHeight: upContent.implicitHeight + Style.spacing.rowPaddingX
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onEntered: root.setFolderCursor(0)
+      onClicked: root.goUpFolder()
+    }
+
+    RowLayout {
+      id: upContent
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      spacing: Style.space(8)
+
+      Text {
+        text: "󰁍"
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.icon
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      Text {
+        Layout.fillWidth: true
+        text: "Back"
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        elide: Text.ElideRight
+      }
+    }
+  }
+
+  // One folder in the current directory: name, sync state, and a switch that
+  // drives `dropbox-cli exclude add/remove`. The row body drills in when the
+  // folder is browsable; the switch always owns toggling, mouse and keyboard
+  // alike, exactly as the hero's power switch does.
+  component FolderRow: CursorSurface {
+    id: folderRow
+    property var folder: null
+    property int rowIndex: 0
+
+    readonly property string folderName: folder ? String(folder.name || "Untitled") : "Untitled"
+    readonly property bool synced: dropbox.folderSynced(folder)
+    readonly property bool pending: dropbox.folderPending(folder)
+    readonly property bool browsable: folder ? folder.browsable === true : false
+    readonly property bool rowSelected: root.cursorActive && root.focusSection === "folders" && root.folderIndex === rowIndex
+
+    hasCursor: rowSelected
+    foreground: root.foreground
+
+    implicitHeight: folderContent.implicitHeight + Style.spacing.rowPaddingX
+
+    MouseArea {
+      id: folderMouse
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: folderRow.browsable ? Qt.PointingHandCursor : Qt.ArrowCursor
+      onEntered: root.setFolderCursor(folderRow.rowIndex)
+      onClicked: if (folderRow.browsable) {
+        dropbox.enterFolder(folderRow.folder)
+        root.folderIndex = 0
+      }
+    }
+
+    PanelToolTip {
+      visible: folderMouse.containsMouse && folderRow.browsable
+      text: "Open folder"
+      fontFamily: root.fontFamily
+    }
+
+    RowLayout {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      spacing: Style.space(8)
+
+      Text {
+        text: folderRow.synced ? "󰉋" : "󰉖"
+        color: folderRow.synced ? root.foreground : root.dim
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.icon
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      ColumnLayout {
+        id: folderContent
+        Layout.fillWidth: true
+        spacing: Style.space(1)
+
+        Text {
+          Layout.fillWidth: true
+          text: folderRow.folderName
+          color: folderRow.synced ? root.foreground : root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+        }
+
+        Text {
+          Layout.fillWidth: true
+          text: folderRow.pending
+            ? (folderRow.synced ? "Syncing…" : "Removing…")
+            : Model.folderMeta(folderRow.folder)
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+      }
+
+      Text {
+        visible: folderRow.browsable
+        text: "󰅂"
+        color: root.dim
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      ToggleSwitch {
+        id: folderSwitch
+        Layout.alignment: Qt.AlignVCenter
+        checked: folderRow.synced
+        busy: dropbox.syncBusy
+        // The surrounding row owns drill-in, so the switch keeps its own
+        // cursor ring rather than borrowing the row's highlight.
+        hasCursor: false
+        foreground: root.foreground
+        trackHeight: Math.max(18, Math.round(Style.spacing.controlHeight * 0.42))
+        onHovered: function(on) { if (on) root.setFolderCursor(folderRow.rowIndex) }
+        onToggled: dropbox.setFolderSynced(folderRow.folder, !folderRow.synced)
+
+        PanelToolTip {
+          visible: folderSwitch.containsMouse
+          text: folderRow.synced ? "Stop syncing this folder" : "Sync this folder"
+          fontFamily: root.fontFamily
+        }
       }
     }
   }

--- a/shell/plugins/panels/dropbox/README.md
+++ b/shell/plugins/panels/dropbox/README.md
@@ -1,0 +1,85 @@
+# Dropbox
+
+Dropbox status, storage usage, login, **selective sync**, and recent synced
+files in the Omarchy bar.
+
+Installed and enabled by `omarchy-install-service-dropbox`, which also adds the
+`dropbox`, `dropbox-cli`, and `nautilus-dropbox` packages.
+
+| File | Role |
+|---|---|
+| `Panel.qml` | Bar button, popup layout, keyboard cursor |
+| `Service.qml` | State and every `dropbox-cli` invocation |
+| `Model.js` | Pure formatting/parsing helpers |
+| `status.py` | Account, storage, and recent-files probe |
+| `folders.py` | Folder tree + selective-sync state |
+| `DropboxIcon.qml` | The glyph |
+
+Both helpers print a single JSON object on stdout and never raise; the QML side
+treats a non-zero exit or unparseable output as an error state.
+
+## Selective sync
+
+The **Synced folders** section lists the folders inside your Dropbox with a
+switch each. Switching one off runs `dropbox-cli exclude add` (Dropbox deletes
+the local copy but keeps the cloud copy); switching it back on runs
+`dropbox-cli exclude remove` and the folder is downloaded again.
+
+This replaces the selective-sync dialog that used to live behind the Dropbox
+tray icon's right-click menu, which no longer exists now that the bar plugin has
+taken the tray's place.
+
+### Keys
+
+| Key | Action |
+|---|---|
+| `j` / `k` / `↓` / `↑` | Move the cursor (header → folders → recent files) |
+| `l` / `→` / `Enter` | Open the highlighted folder |
+| `h` / `←` | Go up one folder |
+| `s` | Sync or unsync the highlighted folder |
+| `r` | Refresh status and folders |
+| `p` | Pause or resume syncing |
+| `Esc` | Close |
+
+`Enter` on a folder with no subfolders toggles it instead of opening it, since
+there is nothing to open.
+
+### Settings
+
+| Key | Default | Meaning |
+|---|---|---|
+| `refreshIntervalSec` | `60` | Status poll interval |
+| `showSyncedFolders` | `true` | Show the Synced folders section |
+| `maxFolderRows` | `50` | Cap on folders listed per directory |
+
+### Limitation: excluded folders are leaves
+
+The Dropbox CLI has no remote directory listing. An excluded folder is deleted
+locally, so its children cannot be enumerated and it is shown as a toggle-only
+row with no `›`. Sync it back on and it becomes browsable once the download
+lands. Folders that *are* synced can be browsed to any depth.
+
+### Implementation notes
+
+Two details of `dropbox-cli` that `folders.py` depends on:
+
+1. `exclude list` prints each path through `relpath()`, so its output is
+   relative to the process cwd. It is therefore invoked with `cwd="/"`, which
+   makes every line root-relative and absolute with a single `/` prefix — no
+   guessing at where the Dropbox folder is or what it is named.
+2. `exclude add`/`remove` take absolute paths and block until the daemon
+   accepts the change, so they always run through QML's async `Process`.
+
+Folder names routinely contain spaces and other shell metacharacters, so
+`exclude list` output is only ever stripped of whitespace, never split.
+
+A folder's children are the union of the subdirectories present on disk and the
+ignore-set entries parented there. A path can appear in both for a moment while
+the daemon is deleting it; excluded wins, because that is the state the user
+just asked for.
+
+Toggles are optimistic — the switch flips immediately and `folders.py` is
+re-polled a few times until reality agrees, the same trick `Service.qml` already
+uses for pause/resume. Only an in-flight `exclude add`/`remove` (`syncBusy`)
+blocks another toggle; a background folder listing (`foldersBusy`) does not, so
+an undo right after a toggle is never swallowed.

--- a/shell/plugins/panels/dropbox/README.md
+++ b/shell/plugins/panels/dropbox/README.md
@@ -41,8 +41,9 @@ taken the tray's place.
 | `p` | Pause or resume syncing |
 | `Esc` | Close |
 
-`Enter` on a folder with no subfolders toggles it instead of opening it, since
-there is nothing to open.
+`Enter` only ever navigates. A folder with no subfolders is not browsable and
+`Enter` does nothing on it, rather than falling back to a toggle that would
+unsync whatever the cursor happened to be on. `s` and the switch own toggling.
 
 ### Settings
 

--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -31,9 +31,128 @@ Item {
   property string actionStatus: ""
   property string lastError: ""
 
+  // --- Selective sync ---------------------------------------------------
+  // `browsePath` is the folder currently on screen; "" means "follow the
+  // account root", which is what we want before the first status lands.
+  property string browsePath: ""
+  property string folderParentPath: ""
+  property bool folderAtRoot: true
+  property var folders: []
+  property string foldersError: ""
+  property bool foldersLoaded: false
+
+  // Optimistic desired state per folder, abs-path -> synced bool, in the same
+  // spirit as `_desired` above: the switch throws the instant you click while
+  // dropboxd spends its own sweet time resyncing. Entries are dropped once the
+  // helper reports reality has caught up. QML does not signal on in-place
+  // mutation, so every write reassigns the whole object.
+  property var pendingFolders: ({})
+
+  readonly property string effectiveBrowsePath: browsePath !== "" ? browsePath : accountPath
+
+  function folderSynced(folder) {
+    if (!folder) return false
+    var pending = pendingFolders[String(folder.path || "")]
+    if (pending !== undefined) return pending === true
+    return folder.excluded !== true
+  }
+
+  function folderPending(folder) {
+    if (!folder) return false
+    return pendingFolders[String(folder.path || "")] !== undefined
+  }
+
+  function setPending(path, value) {
+    var next = {}
+    for (var key in pendingFolders) next[key] = pendingFolders[key]
+    if (value === undefined) delete next[path]
+    else next[path] = value
+    pendingFolders = next
+  }
+
+  function loadFolders(path) {
+    if (foldersProcess.running || omarchyPath === "" || !authenticated) return
+    var target = String(path || effectiveBrowsePath || accountPath || "")
+    if (target === "") return
+    _foldersOutput = ""
+    _foldersError = ""
+    foldersProcess.command = ["python3", foldersHelperPath, "list", target]
+    foldersProcess.running = true
+  }
+
+  function applyFolders(raw) {
+    var parsed = Model.parseFolders(raw)
+    if (parsed.ok !== true) {
+      foldersError = elideStatus(parsed.error || "Could not read Dropbox folders")
+      folders = []
+      foldersLoaded = true
+      return
+    }
+    foldersError = ""
+    browsePath = String(parsed.path || "")
+    folderParentPath = String(parsed.parentPath || "")
+    folderAtRoot = parsed.atRoot === true
+    var rows = parsed.folders || []
+    folders = rows.length > maxFolderRows ? rows.slice(0, maxFolderRows) : rows
+
+    // Reality caught up for any folder whose real state now matches what was
+    // asked for — stop overriding it.
+    var next = {}
+    var settled = {}
+    for (var i = 0; i < folders.length; i++) settled[folders[i].path] = folders[i].excluded !== true
+    for (var key in pendingFolders) {
+      if (settled[key] === undefined || settled[key] !== pendingFolders[key]) next[key] = pendingFolders[key]
+    }
+    pendingFolders = next
+    foldersLoaded = true
+  }
+
+  function resetBrowse() {
+    browsePath = ""
+    loadFolders(accountPath)
+  }
+
+  function enterFolder(folder) {
+    if (!folder || folder.browsable !== true) return
+    loadFolders(String(folder.path || ""))
+  }
+
+  function goUpFolder() {
+    if (folderAtRoot || folderParentPath === "") return
+    loadFolders(folderParentPath)
+  }
+
+  function setFolderSynced(folder, on) {
+    if (!folder || !installed || excludeProcess.running) return
+    var path = String(folder.path || "")
+    if (path === "") return
+    setPending(path, on === true)
+    _excludePath = path
+    _excludeOutput = ""
+    _excludeError = ""
+    excludeProcess.command = ["dropbox-cli", "exclude", on ? "remove" : "add", path]
+    excludeProcess.running = true
+  }
+
+  function toggleFolderSynced(folder) {
+    if (!folder) return
+    setFolderSynced(folder, !folderSynced(folder))
+  }
+
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 60, 10, 3600)
+  readonly property int maxFolderRows: intSetting("maxFolderRows", 50, 10, 500)
   readonly property bool busy: statusProcess.running || loginProcess.running || controlProcess.running
-  readonly property string helperPath: (omarchyPath || "") + "/shell/plugins/panels/dropbox/status.py"
+  // Two different kinds of busy. `foldersBusy` covers the read-only listing and
+  // only gates the refresh button. `syncBusy` is an actual exclude add/remove in
+  // flight — the one thing that genuinely cannot overlap. Gating toggles on the
+  // listing instead would silently swallow clicks for the ~10s the settle timer
+  // spends re-polling, which is exactly when someone wants to undo.
+  readonly property bool foldersBusy: foldersProcess.running || excludeProcess.running
+  readonly property bool syncBusy: excludeProcess.running
+
+  readonly property string pluginPath: (omarchyPath || "") + "/shell/plugins/panels/dropbox"
+  readonly property string helperPath: pluginPath + "/status.py"
+  readonly property string foldersHelperPath: pluginPath + "/folders.py"
 
   property string _statusOutput: ""
   property string _statusError: ""
@@ -42,6 +161,23 @@ Item {
   property bool _loginUrlOpened: false
   property string _controlOutput: ""
   property string _controlError: ""
+  property string _foldersOutput: ""
+  property string _foldersError: ""
+  property string _excludeOutput: ""
+  property string _excludeError: ""
+  property string _excludePath: ""
+
+  onAuthenticatedChanged: {
+    if (authenticated) {
+      loadFolders()
+    } else {
+      browsePath = ""
+      folders = []
+      foldersError = ""
+      foldersLoaded = false
+      pendingFolders = ({})
+    }
+  }
 
   function setting(name, fallback) {
     var value = settings ? settings[name] : undefined
@@ -57,7 +193,7 @@ Item {
   }
 
   function refresh() {
-    if (statusProcess.running || helperPath === "/shell/plugins/panels/dropbox/status.py") return
+    if (statusProcess.running || omarchyPath === "") return
     _statusOutput = ""
     _statusError = ""
     refreshing = true
@@ -248,6 +384,74 @@ Item {
         root.actionStatus = ""
         root.lastError = ""
       }
+      delayedRefresh.restart()
+    }
+  }
+
+  Timer {
+    // An exclude add/remove returns as soon as the daemon accepts it, but the
+    // folder does not appear or vanish on disk until the resync lands. Re-poll
+    // a handful of times so the row settles without waiting on the periodic
+    // refresh; anything still pending after that keeps its optimistic value
+    // until the next successful load.
+    id: folderSettleTimer
+    property int ticks: 0
+    interval: 2000
+    repeat: true
+    running: false
+    onTriggered: {
+      folderSettleTimer.ticks += 1
+      root.loadFolders()
+      if (folderSettleTimer.ticks >= 5) {
+        folderSettleTimer.ticks = 0
+        folderSettleTimer.running = false
+      }
+    }
+  }
+
+  Process {
+    id: foldersProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: foldersStdout; waitForEnd: true; onStreamFinished: root._foldersOutput = text }
+    stderr: StdioCollector { id: foldersStderr; waitForEnd: true; onStreamFinished: root._foldersError = text }
+    onExited: function(exitCode) {
+      var stdout = String(foldersStdout.text || root._foldersOutput || "")
+      var stderr = String(foldersStderr.text || root._foldersError || "")
+      if (exitCode === 0 && stdout !== "") root.applyFolders(stdout)
+      else {
+        root.foldersError = root.elideStatus(stderr || stdout || "Could not read Dropbox folders")
+        root.foldersLoaded = true
+      }
+    }
+  }
+
+  Process {
+    id: excludeProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: excludeStdout; waitForEnd: true; onStreamFinished: root._excludeOutput = text }
+    stderr: StdioCollector { id: excludeStderr; waitForEnd: true; onStreamFinished: root._excludeError = text }
+    onExited: function(exitCode) {
+      var stdout = String(excludeStdout.text || root._excludeOutput || "")
+      var stderr = String(excludeStderr.text || root._excludeError || "")
+      // The CLI reports "Dropbox isn't running!" on stdout with exit 0, so the
+      // exit code alone is not enough to call this a success.
+      var combined = stdout + " " + stderr
+      var failed = exitCode !== 0 || /isn't running|isn't responding|Couldn't |daemon stopped/i.test(combined)
+      if (failed) {
+        // Drop only this folder's optimistic value; other folders may still
+        // have legitimate pending state from earlier toggles.
+        root.setPending(root._excludePath, undefined)
+        root.lastError = root.elideStatus(stderr || stdout || "Could not change folder syncing")
+        root.actionStatus = root.lastError
+        actionStatusTimer.restart()
+      } else {
+        root.lastError = ""
+      }
+      folderSettleTimer.ticks = 0
+      folderSettleTimer.restart()
+      root.loadFolders()
       delayedRefresh.restart()
     }
   }

--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -71,9 +71,17 @@ Item {
   }
 
   function loadFolders(path) {
-    if (foldersProcess.running || omarchyPath === "" || !authenticated) return
+    if (omarchyPath === "" || !authenticated) return
     var target = String(path || effectiveBrowsePath || accountPath || "")
     if (target === "") return
+    // Only one listing runs at a time, but a request that arrives mid-flight
+    // must not be dropped: the in-flight result would then apply its own (now
+    // stale) path over the one just asked for. Remember it and run it on exit.
+    if (foldersProcess.running) {
+      _queuedFolderPath = target
+      return
+    }
+    _queuedFolderPath = ""
     _foldersOutput = ""
     _foldersError = ""
     foldersProcess.command = ["python3", foldersHelperPath, "list", target]
@@ -166,6 +174,7 @@ Item {
   property string _excludeOutput: ""
   property string _excludeError: ""
   property string _excludePath: ""
+  property string _queuedFolderPath: ""
 
   onAuthenticatedChanged: {
     if (authenticated) {
@@ -176,6 +185,7 @@ Item {
       foldersError = ""
       foldersLoaded = false
       pendingFolders = ({})
+      _queuedFolderPath = ""
     }
   }
 
@@ -209,11 +219,14 @@ Item {
     }
     installed = parsed.installed === true
     running = parsed.running === true
+    // Before `authenticated`, whose change handler loads the folder list and
+    // needs somewhere to load it from. Assigning it after left that first load
+    // with an empty account path, so it silently did nothing.
+    accountPath = String(parsed.accountPath || "")
     authenticated = parsed.authenticated === true
     // Reality caught up to the pending pause/resume — stop overriding.
     if (_desired !== -1 && running === (_desired === 1)) _desired = -1
     statusText = String(parsed.statusText || (installed ? "Stopped" : "Not installed"))
-    accountPath = String(parsed.accountPath || "")
     plan = String(parsed.plan || "")
     usedBytes = Number(parsed.usedBytes || 0)
     quotaBytes = Number(parsed.quotaBytes || 0)
@@ -418,6 +431,15 @@ Item {
     onExited: function(exitCode) {
       var stdout = String(foldersStdout.text || root._foldersOutput || "")
       var stderr = String(foldersStderr.text || root._foldersError || "")
+      // A newer request came in while this one was running, so this result is
+      // already stale — drop it rather than let it apply its path, and serve
+      // the request that superseded it.
+      if (root._queuedFolderPath !== "") {
+        var queued = root._queuedFolderPath
+        root._queuedFolderPath = ""
+        root.loadFolders(queued)
+        return
+      }
       if (exitCode === 0 && stdout !== "") root.applyFolders(stdout)
       else {
         root.foldersError = root.elideStatus(stderr || stdout || "Could not read Dropbox folders")

--- a/shell/plugins/panels/dropbox/folders.py
+++ b/shell/plugins/panels/dropbox/folders.py
@@ -1,0 +1,194 @@
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+# `dropbox-cli exclude list` prints each path through `relpath()`, so its output
+# is relative to our cwd. Running from "/" makes every line a root-relative path
+# that becomes absolute with a single "/" prefix — no guessing at where the
+# Dropbox folder lives or what it is called.
+IGNORE_LIST_CWD = "/"
+
+IGNORE_HEADER = "excluded:"
+IGNORE_EMPTY = "no directories are being ignored."
+
+
+def read_info():
+  info_path = Path.home() / ".dropbox" / "info.json"
+  if not info_path.exists():
+    return {}
+  try:
+    with info_path.open("r", encoding="utf-8") as handle:
+      return json.load(handle)
+  except (OSError, json.JSONDecodeError):
+    return {}
+
+
+def dropbox_account(info):
+  for key in ("personal", "business"):
+    account = info.get(key)
+    if isinstance(account, dict):
+      return account
+  return {}
+
+
+def account_path():
+  account = dropbox_account(read_info())
+  path = account.get("path")
+  return path if isinstance(path, str) else ""
+
+
+def ignore_set(dropbox_cli):
+  """Absolute paths currently excluded from syncing, or None if unreadable."""
+  if not dropbox_cli:
+    return None
+  try:
+    completed = subprocess.run(
+      [dropbox_cli, "exclude", "list"],
+      check=False, capture_output=True, text=True, timeout=10, cwd=IGNORE_LIST_CWD)
+  except (OSError, subprocess.TimeoutExpired):
+    return None
+  if completed.returncode != 0:
+    return None
+
+  paths = set()
+  for raw in completed.stdout.splitlines():
+    # Folder names may contain spaces and pipes, so only ever strip whitespace —
+    # never split the line.
+    line = raw.strip()
+    lowered = line.lower()
+    if line == "" or lowered == IGNORE_HEADER or lowered == IGNORE_EMPTY:
+      continue
+    if lowered.startswith("dropbox isn't") or lowered.startswith("couldn't "):
+      return None
+    paths.add(os.path.join("/", line))
+  return paths
+
+
+def subdirectory_count(path):
+  count = 0
+  try:
+    with os.scandir(path) as entries:
+      for entry in entries:
+        if entry.name.startswith("."):
+          continue
+        try:
+          if entry.is_dir(follow_symlinks=False):
+            count += 1
+        except OSError:
+          continue
+  except OSError:
+    return 0
+  return count
+
+
+def local_subdirectories(path):
+  names = []
+  try:
+    with os.scandir(path) as entries:
+      for entry in entries:
+        if entry.name.startswith("."):
+          continue
+        try:
+          if entry.is_dir(follow_symlinks=False):
+            names.append(entry.name)
+        except OSError:
+          continue
+  except OSError:
+    return None
+  return names
+
+
+def within(root, path):
+  try:
+    return os.path.commonpath([root, path]) == root
+  except ValueError:
+    return False
+
+
+def fail(message, root=""):
+  print(json.dumps({
+    "ok": False,
+    "error": message,
+    "accountPath": root,
+    "path": "",
+    "parentPath": "",
+    "atRoot": True,
+    "folders": [],
+  }))
+  return 0
+
+
+def list_folders(target):
+  root = account_path()
+  if root == "" or not os.path.isdir(root):
+    return fail("Dropbox folder not found", root)
+
+  target = os.path.abspath(os.path.expanduser(target or root))
+  # Never let a bad argument walk outside the Dropbox folder.
+  if not within(root, target):
+    return fail("Path is outside the Dropbox folder", root)
+  if not os.path.isdir(target):
+    return fail("Folder is no longer available", root)
+
+  dropbox_cli = shutil.which("dropbox-cli")
+  if dropbox_cli is None:
+    return fail("Dropbox CLI is not installed", root)
+
+  excluded = ignore_set(dropbox_cli)
+  if excluded is None:
+    return fail("Dropbox isn't running", root)
+
+  local = local_subdirectories(target)
+  if local is None:
+    return fail("Could not read folder contents", root)
+
+  # Children of `target` come from two places: directories that exist on disk
+  # (synced) and ignore-set entries parented here (excluded, so absent locally).
+  # A path can briefly appear in both while the daemon is deleting it — excluded
+  # wins, since that is the state the user just asked for.
+  excluded_here = {path for path in excluded if os.path.dirname(path) == target}
+  names = {name: os.path.join(target, name) for name in local}
+  for path in excluded_here:
+    names[os.path.basename(path)] = path
+
+  folders = []
+  for name in sorted(names, key=lambda value: (value.lower(), value)):
+    path = names[name]
+    is_excluded = path in excluded_here
+    # The CLI has no remote listing, so an excluded folder's children are
+    # unknowable — it stays a toggle-only leaf until it is synced again.
+    children = 0 if is_excluded else subdirectory_count(path)
+    folders.append({
+      "name": name,
+      "path": path,
+      "excluded": is_excluded,
+      "browsable": not is_excluded and children > 0,
+      "childCount": children,
+    })
+
+  print(json.dumps({
+    "ok": True,
+    "error": "",
+    "accountPath": root,
+    "path": target,
+    "parentPath": "" if target == root else os.path.dirname(target),
+    "atRoot": target == root,
+    "folders": folders,
+  }))
+  return 0
+
+
+def main():
+  args = sys.argv[1:]
+  command = args[0] if args else "list"
+  if command != "list":
+    return fail("Unknown command: " + command)
+  return list_folders(args[1] if len(args) > 1 else "")
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/shell/plugins/panels/dropbox/folders.py
+++ b/shell/plugins/panels/dropbox/folders.py
@@ -28,6 +28,10 @@ def read_info():
 
 
 def dropbox_account(info):
+  # info.json is whatever is on disk, so it can decode to a list or a string
+  # just as easily as an object. Check before treating it as a mapping.
+  if not isinstance(info, dict):
+    return {}
   for key in ("personal", "business"):
     account = info.get(key)
     if isinstance(account, dict):
@@ -103,9 +107,13 @@ def local_subdirectories(path):
 
 
 def within(root, path):
+  # Compare resolved paths: abspath alone is lexical, so a symlink parked
+  # inside Dropbox and pointing elsewhere would pass the check and then be
+  # walked. Listings never offer symlinks as children, but this is the stated
+  # boundary and it should hold for any argument.
   try:
-    return os.path.commonpath([root, path]) == root
-  except ValueError:
+    return os.path.commonpath([os.path.realpath(root), os.path.realpath(path)]) == os.path.realpath(root)
+  except (ValueError, OSError):
     return False
 
 

--- a/shell/plugins/panels/dropbox/manifest.json
+++ b/shell/plugins/panels/dropbox/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Dropbox status, storage usage, login, and recent synced files in the Omarchy bar.",
+  "description": "Dropbox status, storage usage, login, selective sync, and recent synced files in the Omarchy bar.",
   "kinds": [
     "bar-widget"
   ],
@@ -14,12 +14,14 @@
   },
   "barWidget": {
     "displayName": "Dropbox",
-    "description": "Log in to Dropbox, view storage usage, and open recent synced files.",
+    "description": "Log in to Dropbox, view storage usage, choose which folders sync, and open recent synced files.",
     "category": "Files",
     "allowMultiple": false,
     "defaultSection": "right",
     "defaults": {
-      "refreshIntervalSec": 60
+      "refreshIntervalSec": 60,
+      "showSyncedFolders": true,
+      "maxFolderRows": 50
     },
     "schema": [
       {
@@ -30,6 +32,22 @@
         "max": 3600,
         "step": 5,
         "defaultValue": 60
+      },
+      {
+        "key": "showSyncedFolders",
+        "type": "boolean",
+        "label": "Show synced folders",
+        "description": "Choose which Dropbox folders sync to this machine.",
+        "defaultValue": true
+      },
+      {
+        "key": "maxFolderRows",
+        "type": "integer",
+        "label": "Maximum folders listed",
+        "min": 10,
+        "max": 500,
+        "step": 10,
+        "defaultValue": 50
       }
     ]
   }

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -31,4 +31,25 @@ assertEqual(
   '1h ago · Docs',
   'dropbox file metadata includes relative time and folder'
 )
+
+const folders = dropbox.parseFolders(JSON.stringify({
+  ok: true,
+  accountPath: '/home/user/Dropbox',
+  path: '/home/user/Dropbox/Photos',
+  parentPath: '/home/user/Dropbox',
+  atRoot: false,
+  folders: [{ name: 'Trips', path: '/home/user/Dropbox/Photos/Trips', excluded: false, browsable: true, childCount: 2 }]
+}))
+assert(folders.ok === true && folders.atRoot === false, 'dropbox parses folder listing flags')
+assertEqual(folders.folders.length, 1, 'dropbox preserves folder rows')
+assertEqual(folders.parentPath, '/home/user/Dropbox', 'dropbox parses the parent path')
+
+assertEqual(dropbox.parseFolders('not json').ok, false, 'dropbox rejects malformed folder payloads')
+assertEqual(dropbox.parseFolders('').folders.length, 0, 'dropbox defaults an empty folder payload')
+assert(dropbox.parseFolders(JSON.stringify({ ok: true })).folders.length === 0, 'dropbox defaults a missing folder array')
+
+assertEqual(dropbox.folderMeta({ excluded: true }), 'Not synced', 'dropbox labels excluded folders')
+assertEqual(dropbox.folderMeta({ excluded: false, childCount: 0 }), 'Synced', 'dropbox labels a synced leaf folder')
+assertEqual(dropbox.folderMeta({ excluded: false, childCount: 1 }), 'Synced · 1 folder', 'dropbox labels a single child folder')
+assertEqual(dropbox.folderMeta({ excluded: false, childCount: 3 }), 'Synced · 3 folders', 'dropbox labels multiple child folders')
 JS


### PR DESCRIPTION
## Why

Omarchy 4 replaced the Dropbox system-tray icon with the `omarchy.dropbox` bar plugin. The tray's right-click → **Preferences → Selective Sync** dialog went with it, so the panel can start and stop syncing but not choose *what* syncs. Today the only way to pick folders is `dropbox-cli exclude` in a terminal.

## What

A **Synced folders** section between *Stored* and *Recent files*: every folder in the current directory with a switch, browsable into any folder that is currently synced. Off runs `dropbox-cli exclude add`, on runs `exclude remove`.

Built with the existing kit — `CursorSurface` rows with a trailing `ToggleSwitch`, the same shape as the Bluetooth panel's device rows. Nothing about the bar icon, hero, pause/resume, or recent files changes.

| Key | Action |
|---|---|
| `j` / `k` | Move the cursor (header → folders → recent files) |
| `l` / `→` / `Enter` | Open the highlighted folder |
| `h` / `←` | Go up one folder |
| `s` | Sync or unsync the highlighted folder |

`Enter` only ever navigates. It does nothing on a folder with no subfolders rather than falling back to a toggle, because unsyncing deletes the local copy and no row affordance marks which folders would have taken that path. `s` and the switch are the only ways to toggle.

Two new settings, both defaulted so existing configs are unaffected: `showSyncedFolders` (default `true`) and `maxFolderRows` (default `50`).

New `folders.py` alongside `status.py`, following the same conventions — stdlib only, one JSON object on stdout, never raises. It refuses any path that does not resolve inside the Dropbox folder.

## Two CLI details that shape the implementation

1. `exclude list` prints paths through `relpath()`, so its output is relative to the process cwd. It is invoked with `cwd="/"`, which makes every line absolute with a single `/` prefix — no guessing at where the Dropbox folder is or what it is named.
2. `exclude add`/`remove` take absolute paths and block until the daemon accepts the change, so they always run through async `Process`.

Folder names routinely contain spaces and other metacharacters, so `exclude list` output is only ever stripped of whitespace, never split.

## Known limitation

The Dropbox CLI has no remote directory listing. An excluded folder is deleted locally, so its children cannot be enumerated — it is shown as a toggle-only leaf with no `›` until it is synced back on. Synced folders browse to any depth. This is documented in the new `README.md`.

## Screenshots
<img width="414" height="592" alt="screenshot-2026-07-30_21-04-28" src="https://github.com/user-attachments/assets/422a72a7-f8c5-4931-b1ce-2096b2f21dd8" />
<img width="408" height="591" alt="screenshot-2026-07-30_21-04-49" src="https://github.com/user-attachments/assets/c735dd59-fbe7-4624-bda2-cb89dbf061bc" />


## Commits

The branch is three commits; the second and third are fixes to this PR's own code, found while reviewing it (the first two issues were independently flagged by the Copilot reviewer on the opening commit).

**1. `Add selective sync to the Dropbox panel`** — the feature.

**2. `Fix two folder-listing races in the Dropbox panel`**
- `applyStatus` assigned `authenticated` before `accountPath`, and the folder list loads from `onAuthenticatedChanged`. That first load therefore ran with an empty account path and silently did nothing. Opening the panel loads again, so it only showed up when authenticating with the panel already open, which left the section empty until a manual refresh. `accountPath` is now assigned first.
- `loadFolders` bailed out whenever a listing was already running, which dropped the reset-to-root that `resetBrowse` issues on open. The in-flight result then applied its own now-stale path over the root just requested, so reopening could land back in a subfolder. The newer request is now queued and served when the running one exits, and the superseded result is discarded.

**3. `Keep Enter navigational and harden the folder helper`**
- `Enter` fell back to toggling when the highlighted folder had no subfolders, so it unsynced — and deleted the local copy of — a folder the user was only trying to open. On the account this was developed against, one of nine synced folders was in that state.
- The containment check compared paths that had only been through `abspath`, so a symlink parked inside Dropbox and pointing elsewhere passed it and was then walked. Listings never offer symlinks as children, so this was not reachable through the UI, but the helper documents a boundary and it now holds for any argument.
- An `info.json` that is valid JSON but decodes to something other than an object raised `AttributeError`, breaking the contract of always printing one JSON object.
- Added coverage for the new `Model.js` helpers to `test/shell.d/dropbox-test.sh`.

## Verification

On a real account (44 top-level folders, names containing spaces and `|`):

- Folder listing cross-checked against `dropbox-cli exclude list` and the filesystem
- Full round-trip on a scratch folder: **off** → appears in the exclude list and is deleted locally; **on** → re-downloaded from the cloud, both files restored
- Optimistic switch flips within ~0.4s and is reconciled against `folders.py` once the daemon settles
- Keyboard navigation, drill-in, and go-up exercised in the running shell; no QML warnings from the plugin
- The listing queue was checked by widening the race with a deliberately slowed helper and counting invocations: one before the fix (the request was dropped), two after, the second starting as the first exited
- The path guard and the malformed-`info.json` path were each reproduced against a throwaway `HOME` and confirmed fixed; the guard now rejects a symlink that previously enumerated `/etc`
- `test/shell.d/dropbox-test.sh` passes, including 10 new assertions for `parseFolders` and `folderMeta`. `./test/shell` and `./test/all` each report one unrelated failure, `omarchy-pkgs checkout found for PKGBUILD coverage`, which is a missing sibling checkout — verified identical on a clean `quattro` worktree

## Notes for reviewers

`Service.qml` gains `pluginPath` so `status.py` and `folders.py` derive from one `$OMARCHY_PATH` expression instead of two. This also drops a dead sentinel check in `refresh()` that compared `helperPath` against a path that could never match once `OMARCHY_PATH` was set. Happy to split that out if you would rather keep the diff to the feature.

`folders.py` skips dot-prefixed directories, which keeps `.dropbox` and `.dropbox.cache` out of the list but also hides genuinely synced content like `.obsidian`, so those cannot be toggled from the panel. Hiding dotfiles matches what a file picker normally does, so it is left as-is, but it is a judgment call and easy to narrow to just the Dropbox-internal names if you would prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
