### PR TITLE
Re-add wl-clip-persist: the paste-hang that got it removed was fixed upstream in 0.5.0

### DIFF
--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -9,6 +9,10 @@ hl.on("hyprland.start", function()
   hl.exec_cmd(o.launch("omarchy-hyprland-monitor-watch"))
   hl.exec_cmd(o.launch("udiskie --automount --no-notify --no-tray"))
 
+  -- Keep the clipboard alive after the app it was copied from closes,
+  -- without persisting password manager entries.
+  hl.exec_cmd(o.launch("wl-clip-persist --clipboard regular --all-mime-type-regex '^(?!x-kde-passwordManagerHint).+'"))
+
   -- Run post-boot hooks after startup config has loaded.
   hl.exec_cmd("sleep 2 && omarchy-hook post-boot")
 end)

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -133,6 +133,7 @@ uwsm
 whois
 wireless-regdb
 wireplumber
+wl-clip-persist
 wl-clipboard
 wtype
 woff2-font-awesome

--- a/migrations/1785476902.sh
+++ b/migrations/1785476902.sh
@@ -1,0 +1,12 @@
+echo "Install wl-clip-persist so the clipboard survives closing the app it was copied from"
+
+# On Wayland the copying app owns the clipboard, so closing it (browser,
+# password manager popup, etc.) silently empties the clipboard even though
+# the entry still shows in the clipboard history. wl-clip-persist takes
+# ownership of every selection so pasting keeps working.
+omarchy-pkg-add wl-clip-persist
+
+# Start it in the running session too; autostart.lua covers future logins.
+if ! pgrep -x wl-clip-persist >/dev/null; then
+  uwsm-app -- wl-clip-persist --clipboard regular --all-mime-type-regex '^(?!x-kde-passwordManagerHint).+' &>/dev/null &
+fi


### PR DESCRIPTION
# Re-add wl-clip-persist: the "cure worse than the disease" was cured upstream

## Problem

There's a recurring class of bug reports with the same confusing shape: you copy something, pasting silently does nothing — yet the text **is** visible in the clipboard manager (Super+Ctrl+V), and selecting it there makes paste work again.

- #4397 — copy in one window, paste in another fails, "I have to manually go to clipboard history and select it then i can paste" (closed stale, locked)
- #2684 — Proton Pass click-to-copy stopped pasting (the popup closes right after copying)
- #3183 / #2795 — "copy only works the second time" reports, plausibly the same cause

## Root cause

This is Wayland working as designed: **the app you copy from owns the clipboard**, and data only transfers at paste time. If the source app exits before you paste — closing the browser after copying, a password-manager popup dismissing itself — the selection is destroyed and the compositor reports "Nothing is copied".

Hyprland explicitly declines to persist selections (hyprwm/Hyprland#9638, closed as intended behavior), and the [Hyprland wiki](https://wiki.hyprland.org/Useful-Utilities/Clipboard-Managers/) names `wl-clip-persist` as the fix for exactly this.

Walker's history makes the failure extra confusing: elephant snapshots content *at copy time* (`wl-paste --watch`) but doesn't take ownership, so the history entry survives while plain paste dies. Selecting the entry works because elephant then becomes the new — always-alive — owner. That's why every reporter converges on the same "click it in the history" workaround.

## The elephant in the room: Omarchy already removed this once

wl-clip-persist was added in 7b0da0f and removed in 2d788dec (2025-10-15, "wl-clip-hist is buggy and feels like its a cure worse than the disease"). That removal was the right call at the time — but the disease it caused has since been cured upstream:

- The paste-hang in Chromium/Brave/Electron (#1885) was a **wl-clip-persist 0.4.3 bug, worked around upstream in v0.5.0** ([Linus789/wl-clip-persist#22](https://github.com/Linus789/wl-clip-persist/issues/22) — "paste-receiving applications hang indefinitely"); the reporter verified the fix in #1885, and v0.5.0 has been Arch `extra`'s package since 2025-09-26. Reports trailing into October came from systems still on 0.4.x. v0.5.0 also fixed "copy fails every second time" ([#17](https://github.com/Linus789/wl-clip-persist/issues/17)).
- The "wonky clipboard" conflict (#1062) was against the pre-elephant walker Omarchy shipped at the time; the walker author suggested elephant might persist the clipboard itself someday — as of elephant 2.21 it still doesn't (verified: after the source app closes, history has the entry while `wl-paste` reports "Nothing is copied").

Meanwhile the underlying paste breakage keeps generating issues (#4397, #2684, ...), each closed without a fix because there's nothing to fix in Omarchy's own config — the fix is this package.

## Change

- `install/omarchy-base.packages` — add `wl-clip-persist`
- `default/hypr/autostart.lua` — launch it on session start, with the same `--all-mime-type-regex '^(?!x-kde-passwordManagerHint).+'` exclusion the original autostart line used, so password-manager copies are never persisted
- migration — installs it on existing systems and starts it in the running session

## Tested

On Arch with wl-clip-persist 0.5.0-2, walker/elephant active: copied text, killed the owning process, pasted — clipboard intact with all text MIME types (previously "Nothing is copied"). Reads from the persisted selection are instant (no #1885-style hang), and elephant's history dedupes the re-own event, so no duplicate entries.

`--clipboard regular` only: the primary selection is untouched, middle-click paste semantics don't change.
