### PR TITLE
Correct three AGENTS.md claims against the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,8 +262,8 @@ omarchy-refresh-config hypr/hyprland.lua
 ```
 
 This copies `$OMARCHY_PATH/config/hypr/hyprland.lua` to `~/.config/hypr/hyprland.lua`. The argument
-must name a file that exists under `$OMARCHY_PATH/config/`; anything else exits with "Not a shipped
-user config".
+is interpolated into both paths and only checked with `[[ -e ]]`, so pass a plain relative path: a
+name containing `..` resolves and copies, landing outside `~/.config` rather than being rejected.
 
 # Migrations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,9 @@ Example:
 
 # Privileged Commands
 
-- Whenever you need to trigger a sudo command, use `pkexec` so it results in a user prompt they can approve.
+- Follow the "Privilege Escalation" section of `default/omarchy-skill/SKILL.md`. It draws the
+  `sudo`/`pkexec` line by whether the caller has a terminal to enter a password in, and the repo's
+  own scripts follow it.
 
 # Git
 
@@ -237,9 +239,12 @@ IPC:
   direct Quickshell socket calls in every CLI.
 - The `shell` IPC target exposes lifecycle and configuration methods including
   `ping`, `summon`, `hide`, `toggle`, `call`, `rescanPlugins`, `reloadConfig`,
-  `setPluginEnabled`, and `listPlugins`. Individual plugins can register
-  additional IPC targets (the bar registers `bar`, the background switcher
-  registers `image-selector`).
+  `setPluginEnabled`, and `listPlugins`. `shell.qml` also registers
+  `image-selector`, which drives the `omarchy.image-picker` panel.
+- Individual plugins register their own IPC targets, named for the plugin rather
+  than for where they appear: the background switcher registers `background`, and
+  bar widgets register one target each — `omarchy.indicators`,
+  `omarchy.system-update`, `omarchy.clock`. There is no `bar` target.
 
 Widget files in `shell/plugins/bar/widgets/` contain Nerd Font glyphs as raw
 unicode characters. The `Write` and `Edit` tools strip multi-byte
@@ -253,10 +258,12 @@ the surrounding context, or a Python script that inserts codepoints via
 To copy a default config to user config with automatic backup:
 
 ```bash
-omarchy-refresh-config hypr/hyprlock.conf
+omarchy-refresh-config hypr/hyprland.lua
 ```
 
-This copies `$OMARCHY_PATH/config/hypr/hyprlock.conf` to `~/.config/hypr/hyprlock.conf`.
+This copies `$OMARCHY_PATH/config/hypr/hyprland.lua` to `~/.config/hypr/hyprland.lua`. The argument
+must name a file that exists under `$OMARCHY_PATH/config/`; anything else exits with "Not a shipped
+user config".
 
 # Migrations
 


### PR DESCRIPTION
Second pass of the AGENTS.md work: the bridge PR made this file load at the start of every agent
session, and this checks that what loads is true. Six of these went out together; whether this one
merges is your call.

All three were re-run against `quattro` at `283276bec09a2bc17d8941071037e971c7423fd5`.

**`:70` — `pkexec` for all privileged work.** This repo ships a skill that says the opposite, with
reasoning: `default/omarchy-skill/SKILL.md:76-84` uses `sudo` for anything in a visible terminal and
reserves `pkexec` for callers that can't take a password there. The code follows the skill —
`sudo` appears on 448 lines across 143 files, `pkexec` on 14 lines across 8, two of which are these
docs. Rather than restate the rule in a second place where it can drift again, AGENTS.md now defers
to the skill.

**`:259` — `config/hypr/hyprlock.conf`.** Not in the repo; `config/hypr/` holds `hyprland.lua`,
`bindings.lua`, `hyprsunset.conf` and friends. `omarchy-refresh-config` exits with "Not a shipped
user config" for anything absent from `$OMARCHY_PATH/config/`, so the example as written fails.
Switched to `hypr/hyprland.lua`, which is the example the script prints in its own usage text.

**`:241-242` — two IPC targets that aren't registered there.** Scanning every
`IpcHandler { target: "…" }` in `shell/`:

- There is no `bar` target at all. Bar widgets each register their own —
  `omarchy.indicators` (`shell/plugins/bar/widgets/Indicators.qml`), `omarchy.system-update`,
  `omarchy.clock`.
- `image-selector` exists, but it's registered by `shell/shell.qml` and drives the
  `omarchy.image-picker` panel. The background switcher registers `background`
  (`shell/plugins/background/Background.qml`).

Docs only. Nothing in `shell/` or `bin/` changes.
