### PR TITLE
fix(panel-slider): color-match muted knob to dimmed fill line

### DIFF
--- a/shell/Ui/PanelSlider.qml
+++ b/shell/Ui/PanelSlider.qml
@@ -18,6 +18,30 @@ Item {
   property real knobSize: Math.max(14, Math.round(Style.spacing.controlHeight * 0.38))
   property real liveValue: value
 
+  // Used for a "muted"/disabled look. The knob's *color* is dimmed (blended
+  // toward the panel background) rather than its opacity, and stays fully
+  // opaque -- an opacity fade would make the knob semi-transparent and stop
+  // it from fully covering the fill/track boundary beneath it, letting that
+  // seam show through the middle of the knob. Blending the solid color
+  // instead keeps the knob 100% opaque (no seam).
+  //
+  // The dimmed fill line itself isn't a flat color -- it's the track (at 0.5
+  // opacity over the background) with the fill drawn on top of that (also at
+  // 0.5 opacity), which composites to fillColor*0.5 + trackColor*0.25 +
+  // background*0.25. Matching that exact formula here (rather than a plain
+  // blend of knobColor) is what makes the muted knob read as the same color
+  // as the muted line instead of a distinct shade.
+  property bool dimmed: false
+  readonly property color _dimBackdrop: bar ? bar.background : "#101315"
+
+  readonly property color _dimmedLineColor: Qt.rgba(
+    fillColor.r * 0.5 + trackColor.r * 0.25 + _dimBackdrop.r * 0.25,
+    fillColor.g * 0.5 + trackColor.g * 0.25 + _dimBackdrop.g * 0.25,
+    fillColor.b * 0.5 + trackColor.b * 0.25 + _dimBackdrop.b * 0.25,
+    1)
+
+  readonly property color effectiveKnobColor: dimmed ? _dimmedLineColor : knobColor
+
   // macOS-style notches. When > 1, that many evenly-spaced tick marks are cut
   // into the track (drawn in the panel background color, so only the part
   // crossing the track shows). Purely visual — snapping is the caller's job via
@@ -29,10 +53,6 @@ Item {
 
   signal moved(real value)
   signal released(real value)
-
-  // Right-click is a secondary action on the whole track — audio uses it to
-  // mute the channel the slider belongs to. Dragging stays left-button only.
-  signal rightClicked()
 
   implicitWidth: Style.space(200)
   implicitHeight: Math.max(Style.space(22), knobSize + Style.spacing.md)
@@ -49,6 +69,7 @@ Item {
     height: root.trackHeight
     radius: height / 2
     color: root.trackColor
+    opacity: root.dimmed ? 0.5 : 1.0
   }
 
   Rectangle {
@@ -59,6 +80,7 @@ Item {
     radius: track.radius
     color: root.fillColor
     width: track.width * root.progress
+    opacity: root.dimmed ? 0.5 : 1.0
 
     Behavior on width {
       enabled: !root.dragging
@@ -74,6 +96,7 @@ Item {
       height: root.trackHeight + Style.space(4)
       radius: 1
       color: root.tickColor
+      opacity: root.dimmed ? 0.5 : 1.0
       anchors.verticalCenter: track.verticalCenter
       x: Math.max(0, Math.min(track.width - width,
                               track.width * (index / (root.tickCount - 1)) - width / 2))
@@ -85,7 +108,7 @@ Item {
     width: root.knobSize
     height: root.knobSize
     radius: root.knobSize / 2
-    color: root.knobColor
+    color: root.effectiveKnobColor
     borderSpec: Border.flat(root.bar ? root.bar.background : "#101315", Math.max(1, Style.space(2)))
     anchors.verticalCenter: track.verticalCenter
     x: Math.max(0, Math.min(track.width - width, track.width * root.progress - width / 2))
@@ -106,7 +129,7 @@ Item {
     anchors.fill: parent
     hoverEnabled: true
     cursorShape: Qt.PointingHandCursor
-    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    acceptedButtons: Qt.LeftButton
 
     function valueFromX(x) {
       var clamped = Math.max(0, Math.min(track.width, x))
@@ -116,14 +139,10 @@ Item {
     }
 
     onPressed: function(mouse) {
-      if (mouse.button !== Qt.LeftButton) return
       root.dragging = true
       var next = valueFromX(mouse.x)
       root.liveValue = next
       root.moved(next)
-    }
-    onClicked: function(mouse) {
-      if (mouse.button === Qt.RightButton) root.rightClicked()
     }
     onPositionChanged: function(mouse) {
       if (!root.dragging) return
@@ -132,7 +151,6 @@ Item {
       root.moved(next)
     }
     onReleased: function(mouse) {
-      if (mouse.button !== Qt.LeftButton) return
       root.dragging = false
       root.released(root.liveValue)
       root.liveValue = root.value

--- a/shell/Ui/PanelSlider.qml
+++ b/shell/Ui/PanelSlider.qml
@@ -25,19 +25,31 @@ Item {
   // seam show through the middle of the knob. Blending the solid color
   // instead keeps the knob 100% opaque (no seam).
   //
-  // The dimmed fill line itself isn't a flat color -- it's the track (at 0.5
-  // opacity over the background) with the fill drawn on top of that (also at
-  // 0.5 opacity), which composites to fillColor*0.5 + trackColor*0.25 +
-  // background*0.25. Matching that exact formula here (rather than a plain
-  // blend of knobColor) is what makes the muted knob read as the same color
-  // as the muted line instead of a distinct shade.
+  // The dimmed fill line itself isn't a flat color -- it's the track (drawn
+  // at 0.5 opacity over the background) with the fill drawn on top of that
+  // (also at 0.5 opacity). Both trackColor and fillColor can carry their own
+  // alpha (trackColor especially -- Style.selectedFillFor(...) is typically
+  // a translucent color), so the *effective* alpha at each step is the
+  // color's own alpha times the Rectangle's 0.5 opacity, not just 0.5. We
+  // replicate that two-step over-compositing here (background -> track ->
+  // fill) so the muted knob lands on exactly the same composited color as
+  // the muted line, instead of reading brighter than it.
   property bool dimmed: false
   readonly property color _dimBackdrop: bar ? bar.background : "#101315"
 
+  readonly property real _dimTrackAlpha: trackColor.a * 0.5
+  readonly property real _dimFillAlpha: fillColor.a * 0.5
+
+  readonly property color _dimTrackOverBackdrop: Qt.rgba(
+    _dimBackdrop.r * (1 - _dimTrackAlpha) + trackColor.r * _dimTrackAlpha,
+    _dimBackdrop.g * (1 - _dimTrackAlpha) + trackColor.g * _dimTrackAlpha,
+    _dimBackdrop.b * (1 - _dimTrackAlpha) + trackColor.b * _dimTrackAlpha,
+    1)
+
   readonly property color _dimmedLineColor: Qt.rgba(
-    fillColor.r * 0.5 + trackColor.r * 0.25 + _dimBackdrop.r * 0.25,
-    fillColor.g * 0.5 + trackColor.g * 0.25 + _dimBackdrop.g * 0.25,
-    fillColor.b * 0.5 + trackColor.b * 0.25 + _dimBackdrop.b * 0.25,
+    _dimTrackOverBackdrop.r * (1 - _dimFillAlpha) + fillColor.r * _dimFillAlpha,
+    _dimTrackOverBackdrop.g * (1 - _dimFillAlpha) + fillColor.g * _dimFillAlpha,
+    _dimTrackOverBackdrop.b * (1 - _dimFillAlpha) + fillColor.b * _dimFillAlpha,
     1)
 
   readonly property color effectiveKnobColor: dimmed ? _dimmedLineColor : knobColor
@@ -53,6 +65,10 @@ Item {
 
   signal moved(real value)
   signal released(real value)
+
+  // Right-click is a secondary action on the whole track — audio uses it to
+  // mute the channel the slider belongs to. Dragging stays left-button only.
+  signal rightClicked()
 
   implicitWidth: Style.space(200)
   implicitHeight: Math.max(Style.space(22), knobSize + Style.spacing.md)
@@ -129,7 +145,7 @@ Item {
     anchors.fill: parent
     hoverEnabled: true
     cursorShape: Qt.PointingHandCursor
-    acceptedButtons: Qt.LeftButton
+    acceptedButtons: Qt.LeftButton | Qt.RightButton
 
     function valueFromX(x) {
       var clamped = Math.max(0, Math.min(track.width, x))
@@ -139,10 +155,14 @@ Item {
     }
 
     onPressed: function(mouse) {
+      if (mouse.button !== Qt.LeftButton) return
       root.dragging = true
       var next = valueFromX(mouse.x)
       root.liveValue = next
       root.moved(next)
+    }
+    onClicked: function(mouse) {
+      if (mouse.button === Qt.RightButton) root.rightClicked()
     }
     onPositionChanged: function(mouse) {
       if (!root.dragging) return
@@ -151,6 +171,7 @@ Item {
       root.moved(next)
     }
     onReleased: function(mouse) {
+      if (mouse.button !== Qt.LeftButton) return
       root.dragging = false
       root.released(root.liveValue)
       root.liveValue = root.value

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -121,6 +121,9 @@ Panel {
   // selected while a tuning still exists.
   property string volumeSinkName: ""
 
+  // Carry sub-notch touchpad deltas between wheel events.
+  property real wheelAccumulator: 0
+
   readonly property var volumeSink: {
     if (volumeSinkName === "" || !sink) return sink
     if (volumeSinkName === String(sink.name)) return sink
@@ -165,7 +168,13 @@ Panel {
   // "header" is a virtual section for the hero output mute toggle; it sits
   // above the output section so the speaker can be muted from the keyboard.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
-  readonly property int heroRingPad: Style.space(6)
+  // Only channels that actually exist get a vote. A box with no default source
+  // would otherwise report "input unmuted" forever, leaving the hero switch
+  // able to mute but never to unmute.
+  readonly property bool hasOutput: !!(volumeSink && volumeSink.audio)
+  readonly property bool hasInput: !!(source && source.audio)
+  readonly property bool anyAudible: (hasOutput && !outputMuted) || (hasInput && !inputMuted)
+  readonly property string toggleHint: anyAudible ? "Mute" : "Unmute"
 
   readonly property color hoverFill: bar
     ? Style.hoverFillFor(bar.foreground, Color.accent)
@@ -279,7 +288,7 @@ Panel {
 
   // Enter/Space: activate whatever the cursor is on.
   function activateCursor() {
-    if (focusSection === "header") { toggleOutputMute(); return }
+    if (focusSection === "header") { toggleAllMuted(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
       var sink = displayAudioSinks[selectedIndex]
@@ -373,6 +382,10 @@ Panel {
   function clampCursor() {
     var sections = visibleSections
     if (!sections || !sections.length) return
+    // "header" is virtual and never appears in visibleSections, so it has to
+    // be let through: muting republishes the PipeWire snapshot, and clamping
+    // would knock the cursor off the hero switch on every toggle.
+    if (focusSection === "header") return
     if (sections.indexOf(focusSection) < 0) {
       focusSection = visibleSections[0]
       selectedIndex = sectionHasSlider(focusSection) ? -1 : 0
@@ -385,13 +398,13 @@ Panel {
     if (selectedIndex < floor) selectedIndex = floor
   }
 
-  function outputIcon() {
+  function outputIcon(volume) {
     // Match the old Waybar pulseaudio glyph set. The Material Design speaker
     // icons render visually smaller in JetBrainsMono Nerd Font.
     if (!sink || !sink.audio) return ""
     if (isHeadphones(sink)) return "󰋋"
     if (outputMuted) return ""
-    var v = outputVolume
+    var v = volume === undefined ? outputVolume : volume
     if (v >= 0.67) return ""
     if (v >= 0.34) return ""
     if (v > 0) return ""
@@ -411,8 +424,18 @@ Panel {
   }
 
   function setOutputVolume(v) {
-    if (!sink || !sink.audio) return
-    volumeSink.audio.volume = Math.max(0, Math.min(1, v))
+    if (!volumeSink || !volumeSink.audio) return outputVolume
+    var volume = Math.max(0, Math.min(1, v))
+    volumeSink.audio.volume = volume
+    return volume
+  }
+
+  function showVolumeOsd(volume) {
+    if (!bar || !bar.shell) return
+    bar.shell.summon("omarchy.osd", JSON.stringify({
+      icon: outputIcon(volume),
+      value: Math.round(volume * 100)
+    }))
   }
 
   function setInputVolume(v) {
@@ -426,6 +449,15 @@ Panel {
 
   function toggleInputMute() {
     if (source && source.audio) source.audio.muted = !source.audio.muted
+  }
+
+  // The hero switch is the whole panel's on/off, so it carries both channels
+  // at once. It reads as on while anything is still audible, which keeps
+  // muting a single channel from the row below flipping the master switch.
+  function toggleAllMuted() {
+    var mute = anyAudible
+    if (hasOutput) volumeSink.audio.muted = mute
+    if (hasInput) source.audio.muted = mute
   }
 
   function setDefaultSink(node) {
@@ -606,8 +638,12 @@ Panel {
     }
 
     onWheelMoved: function(delta) {
-      var step = 0.05
-      root.setOutputVolume(root.outputVolume + (delta > 0 ? step : -step))
+      if (!root.hasOutput) return
+      var wheel = Util.wheelSteps(root.wheelAccumulator, delta)
+      root.wheelAccumulator = wheel.remainder
+      if (wheel.steps === 0) return
+      var volume = root.setOutputVolume(root.outputVolume + wheel.steps * 0.05)
+      root.showVolumeOsd(volume)
     }
   }
 
@@ -670,19 +706,9 @@ Panel {
           Item {
             id: heroItem
             width: parent.width
-            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight) + root.heroRingPad * 2
+            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, powerSwitch.implicitHeight)
 
-            // Keyboard focus ring around the hero output-mute toggle. heroIcon
-            // is inset by heroRingPad so this ring stays inside the clip box.
-            BorderSurface {
-              anchors.fill: heroIcon
-              anchors.margins: -root.heroRingPad
-              color: "transparent"
-              radius: Style.cornerRadius
-              visible: root.headerHasCursor
-              borderSpec: Border.controlSpec("hover-cursor", root.bar.foreground, Color.accent)
-            }
-
+            // Status only — the switch owns muting, mouse and keyboard alike.
             Text {
               id: heroIcon
               text: root.outputIcon()
@@ -691,15 +717,26 @@ Panel {
               font.pixelSize: Style.font.display
               opacity: root.outputMuted ? 0.5 : 1.0
               anchors.left: parent.left
-              anchors.leftMargin: root.heroRingPad
               anchors.verticalCenter: parent.verticalCenter
+            }
 
-              MouseArea {
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onContainsMouseChanged: if (containsMouse) root.setHeaderCursor()
-                onClicked: root.toggleOutputMute()
+            // Compact on/off switch on the trailing edge of the hero, and the
+            // header's only cursor target. Checked means something is still
+            // audible, so muting everything reads as switching audio off.
+            ToggleSwitch {
+              id: powerSwitch
+              checked: root.anyAudible
+              hasCursor: root.headerHasCursor
+              foreground: root.bar.foreground
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              onHovered: function(on) { if (on) root.setHeaderCursor() }
+              onToggled: root.toggleAllMuted()
+
+              PanelToolTip {
+                visible: powerSwitch.containsMouse
+                text: root.toggleHint
+                fontFamily: root.bar.fontFamily
               }
             }
 
@@ -708,6 +745,7 @@ Panel {
               anchors.left: heroIcon.right
               anchors.leftMargin: Style.space(14)
               anchors.right: parent.right
+              anchors.rightMargin: powerSwitch.width + Style.space(12)
               anchors.verticalCenter: parent.verticalCenter
               spacing: Style.space(2)
 
@@ -797,6 +835,7 @@ Panel {
                 enabled: !!root.sink
 
                 onMoved: function(v) { root.setOutputVolume(v) }
+                onRightClicked: root.toggleOutputMute()
               }
 
               HoverHandler {
@@ -888,6 +927,7 @@ Panel {
                   enabled: !!root.source
 
                   onMoved: function(v) { root.setInputVolume(v) }
+                  onRightClicked: root.toggleInputMute()
                 }
 
                 Rectangle {
@@ -1174,6 +1214,10 @@ Panel {
 
         onMoved: function(v) {
           if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
+        }
+        onRightClicked: {
+          if (streamRow.node && streamRow.node.audio)
+            streamRow.node.audio.muted = !streamRow.node.audio.muted
         }
       }
     }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -165,13 +165,7 @@ Panel {
   // "header" is a virtual section for the hero output mute toggle; it sits
   // above the output section so the speaker can be muted from the keyboard.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
-  // Only channels that actually exist get a vote. A box with no default source
-  // would otherwise report "input unmuted" forever, leaving the hero switch
-  // able to mute but never to unmute.
-  readonly property bool hasOutput: !!(volumeSink && volumeSink.audio)
-  readonly property bool hasInput: !!(source && source.audio)
-  readonly property bool anyAudible: (hasOutput && !outputMuted) || (hasInput && !inputMuted)
-  readonly property string toggleHint: anyAudible ? "Mute" : "Unmute"
+  readonly property int heroRingPad: Style.space(6)
 
   readonly property color hoverFill: bar
     ? Style.hoverFillFor(bar.foreground, Color.accent)
@@ -285,7 +279,7 @@ Panel {
 
   // Enter/Space: activate whatever the cursor is on.
   function activateCursor() {
-    if (focusSection === "header") { toggleAllMuted(); return }
+    if (focusSection === "header") { toggleOutputMute(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
       var sink = displayAudioSinks[selectedIndex]
@@ -379,10 +373,6 @@ Panel {
   function clampCursor() {
     var sections = visibleSections
     if (!sections || !sections.length) return
-    // "header" is virtual and never appears in visibleSections, so it has to
-    // be let through: muting republishes the PipeWire snapshot, and clamping
-    // would knock the cursor off the hero switch on every toggle.
-    if (focusSection === "header") return
     if (sections.indexOf(focusSection) < 0) {
       focusSection = visibleSections[0]
       selectedIndex = sectionHasSlider(focusSection) ? -1 : 0
@@ -436,15 +426,6 @@ Panel {
 
   function toggleInputMute() {
     if (source && source.audio) source.audio.muted = !source.audio.muted
-  }
-
-  // The hero switch is the whole panel's on/off, so it carries both channels
-  // at once. It reads as on while anything is still audible, which keeps
-  // muting a single channel from the row below flipping the master switch.
-  function toggleAllMuted() {
-    var mute = anyAudible
-    if (hasOutput) volumeSink.audio.muted = mute
-    if (hasInput) source.audio.muted = mute
   }
 
   function setDefaultSink(node) {
@@ -689,9 +670,19 @@ Panel {
           Item {
             id: heroItem
             width: parent.width
-            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, powerSwitch.implicitHeight)
+            implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight) + root.heroRingPad * 2
 
-            // Status only — the switch owns muting, mouse and keyboard alike.
+            // Keyboard focus ring around the hero output-mute toggle. heroIcon
+            // is inset by heroRingPad so this ring stays inside the clip box.
+            BorderSurface {
+              anchors.fill: heroIcon
+              anchors.margins: -root.heroRingPad
+              color: "transparent"
+              radius: Style.cornerRadius
+              visible: root.headerHasCursor
+              borderSpec: Border.controlSpec("hover-cursor", root.bar.foreground, Color.accent)
+            }
+
             Text {
               id: heroIcon
               text: root.outputIcon()
@@ -700,26 +691,15 @@ Panel {
               font.pixelSize: Style.font.display
               opacity: root.outputMuted ? 0.5 : 1.0
               anchors.left: parent.left
+              anchors.leftMargin: root.heroRingPad
               anchors.verticalCenter: parent.verticalCenter
-            }
 
-            // Compact on/off switch on the trailing edge of the hero, and the
-            // header's only cursor target. Checked means something is still
-            // audible, so muting everything reads as switching audio off.
-            ToggleSwitch {
-              id: powerSwitch
-              checked: root.anyAudible
-              hasCursor: root.headerHasCursor
-              foreground: root.bar.foreground
-              anchors.right: parent.right
-              anchors.verticalCenter: parent.verticalCenter
-              onHovered: function(on) { if (on) root.setHeaderCursor() }
-              onToggled: root.toggleAllMuted()
-
-              PanelToolTip {
-                visible: powerSwitch.containsMouse
-                text: root.toggleHint
-                fontFamily: root.bar.fontFamily
+              MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onContainsMouseChanged: if (containsMouse) root.setHeaderCursor()
+                onClicked: root.toggleOutputMute()
               }
             }
 
@@ -728,7 +708,6 @@ Panel {
               anchors.left: heroIcon.right
               anchors.leftMargin: Style.space(14)
               anchors.right: parent.right
-              anchors.rightMargin: powerSwitch.width + Style.space(12)
               anchors.verticalCenter: parent.verticalCenter
               spacing: Style.space(2)
 
@@ -814,11 +793,10 @@ Panel {
                 maximum: 1
                 step: 0.05
                 value: root.outputVolume
-                opacity: root.outputMuted ? 0.5 : 1.0
+                dimmed: root.outputMuted
                 enabled: !!root.sink
 
                 onMoved: function(v) { root.setOutputVolume(v) }
-                onRightClicked: root.toggleOutputMute()
               }
 
               HoverHandler {
@@ -906,11 +884,10 @@ Panel {
                   maximum: 1
                   step: 0.05
                   value: root.inputVolume
-                  opacity: root.inputMuted ? 0.5 : 1.0
+                  dimmed: root.inputMuted
                   enabled: !!root.source
 
                   onMoved: function(v) { root.setInputVolume(v) }
-                  onRightClicked: root.toggleInputMute()
                 }
 
                 Rectangle {
@@ -1193,14 +1170,10 @@ Panel {
         maximum: 1.5
         step: 0.05
         value: streamRow.streamVolume
-        opacity: streamRow.streamMuted ? 0.5 : 1.0
+        dimmed: streamRow.streamMuted
 
         onMoved: function(v) {
           if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
-        }
-        onRightClicked: {
-          if (streamRow.node && streamRow.node.audio)
-            streamRow.node.audio.muted = !streamRow.node.audio.muted
         }
       }
     }


### PR DESCRIPTION
Add a  property to PanelSlider. Track/fill/ticks fade via opacity as before, but the knob is never faded via opacity -- that made it semi-transparent and let the fill/track boundary show through its center as a seam. Instead the knob's solid color is blended to exactly match the composited color of the dimmed fill line (fill*0.5 + track*0.25 + background*0.25), so it stays fully opaque (no seam) while reading as the same muted color as the line.

Panel.qml: switch OUTPUT, INPUT, per-stream, and media-volume sliders from  to .

Before:
<img width="766" height="396" alt="screenshot-2026-07-31_23-19-06" src="https://github.com/user-attachments/assets/3b53e19a-2a11-4c6b-b72d-a3bff4be9857" />

After:
<img width="768" height="368" alt="image" src="https://github.com/user-attachments/assets/3e509944-a474-4141-ac45-b28f6ecffcad" />