### PR TITLE
Add pause/resume support to screen recording

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -44,6 +44,7 @@ RESUME_RECORDING="false"
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
 PAUSED_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-paused"
+PAUSE_LOCK_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-pause.lock"
 LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
 
 for arg in "$@"; do
@@ -101,10 +102,9 @@ start_webcam_overlay() {
     --no-border --no-audio --no-osc --osd-level=0 \
     --really-quiet &>/dev/null &
 
-  # The move has to settle before gpu-screen-recorder starts, or the camera is
-  # recorded sliding into its corner. Waiting for the map is what the blind
-  # second was partly guessing at, so the remainder is trimmed to hold the
-  # pre-capture delay where it was: starting later costs the first words spoken.
+  # The overlay must have settled into its final position before
+  # gpu-screen-recorder starts, or the move itself gets captured in the
+  # recording. Poll for the window to appear instead of a fixed sleep.
   local waited=0
   while ((waited < 40)) && ! hyprctl clients -j | jq -e 'any(.[]; .title == "WebcamOverlay")' >/dev/null 2>&1; do
     sleep 0.05
@@ -263,7 +263,22 @@ recording_paused() {
 # available in streaming/replay mode, but this script only ever runs it in
 # plain recording mode). The process keeps running while paused - nothing is
 # stopped or finalized - so resuming continues into the same output file.
+#
+# SIGUSR2 is a toggle, not two separate pause/unpause signals - so
+# pause_screenrecording and resume_screenrecording both depend entirely on
+# $PAUSED_FILE to know which direction to go. If two invocations ever ran
+# at once (e.g. a hotkey firing twice in quick succession), both could read
+# the same "not paused yet" state, both send SIGUSR2, and the two toggles
+# would cancel out - leaving the recording actually unpaused while
+# $PAUSED_FILE still says it's paused. flock serializes them so the second
+# invocation always sees the first one's result before acting.
 pause_screenrecording() {
+  exec {lock_fd}>"$PAUSE_LOCK_FILE"
+  if ! flock -x -w 2 "$lock_fd"; then
+    omarchy-notification-send -u critical -t 3000 "Screen recording is busy, try again"
+    return 1
+  fi
+
   if ! screenrecording_active; then
     omarchy-notification-send -u critical -t 3000 "No active screen recording to pause"
     return 1
@@ -280,7 +295,14 @@ pause_screenrecording() {
 }
 
 resume_screenrecording() {
+  exec {lock_fd}>"$PAUSE_LOCK_FILE"
+  if ! flock -x -w 2 "$lock_fd"; then
+    omarchy-notification-send -u critical -t 3000 "Screen recording is busy, try again"
+    return 1
+  fi
+
   if ! screenrecording_active || ! recording_paused; then
+    omarchy-notification-send -u critical -t 3000 "No paused screen recording to resume"
     return 1
   fi
 
@@ -318,6 +340,17 @@ finalize_recording() {
     rm -f "$processed"
   fi
 }
+
+# A stale pause marker can be left behind if a previous recording process was
+# killed or crashed outside of this script (stop_screenrecording, the only
+# other place this file is removed, never got to run). With no active
+# recording, that marker can't describe a real state, so drop it before
+# deciding what to do next - otherwise a fresh recording could be born
+# "already paused", and a --resume-recording call against it would send
+# SIGUSR2 into a live, unpaused process and actually pause it.
+if ! screenrecording_active; then
+  rm -f "$PAUSED_FILE"
+fi
 
 if [[ $PAUSE_RECORDING == "true" ]]; then
   pause_screenrecording

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Start or stop screen recording
 # omarchy:group=capture
-# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording]
+# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording] [--pause-recording] [--resume-recording]
 # omarchy:examples=omarchy screenrecord | omarchy capture screenrecording --with-desktop-audio
 # omarchy:aliases=omarchy screenrecord
 #
@@ -17,6 +17,11 @@
 # Env: OMARCHY_SCREENRECORD_DEBUG=true appends gpu-screen-recorder's stderr (and
 # the picker target it was launched with) to /tmp/omarchy-screenrecord.log so
 # users can attach a log when reporting capture failures.
+#
+# --pause-recording / --resume-recording pause and unpause the running
+# recording in place via gpu-screen-recorder's own SIGUSR2 handling: the
+# process keeps running and the output file is untouched, so resuming just
+# continues writing the same file instead of starting a new one.
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
@@ -34,8 +39,11 @@ WEBCAM_SIZE="medium"
 RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
+PAUSE_RECORDING="false"
+RESUME_RECORDING="false"
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
+PAUSED_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-paused"
 LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
 
 for arg in "$@"; do
@@ -48,6 +56,8 @@ for arg in "$@"; do
   --resolution=*) RESOLUTION="${arg#*=}" ;;
   --fullscreen) FULLSCREEN="true" ;;
   --stop-recording) STOP_RECORDING="true" ;;
+  --pause-recording) PAUSE_RECORDING="true" ;;
+  --resume-recording) RESUME_RECORDING="true" ;;
   esac
 done
 
@@ -234,7 +244,7 @@ stop_screenrecording() {
     ) &
   fi
 
-  rm -f "$RECORDING_FILE"
+  rm -f "$RECORDING_FILE" "$PAUSED_FILE"
 }
 
 toggle_screenrecording_indicator() {
@@ -243,6 +253,41 @@ toggle_screenrecording_indicator() {
 
 screenrecording_active() {
   pgrep -f "^gpu-screen-recorder" >/dev/null
+}
+
+recording_paused() {
+  [[ -f $PAUSED_FILE ]]
+}
+
+# gpu-screen-recorder has native pause/unpause support via SIGUSR2 (not
+# available in streaming/replay mode, but this script only ever runs it in
+# plain recording mode). The process keeps running while paused - nothing is
+# stopped or finalized - so resuming continues into the same output file.
+pause_screenrecording() {
+  if ! screenrecording_active; then
+    omarchy-notification-send -u critical -t 3000 "No active screen recording to pause"
+    return 1
+  fi
+
+  if recording_paused; then
+    return 0
+  fi
+
+  pkill -SIGUSR2 -f "^gpu-screen-recorder"
+  touch "$PAUSED_FILE"
+  toggle_screenrecording_indicator
+  omarchy-notification-send -t 2000 "Screen recording paused"
+}
+
+resume_screenrecording() {
+  if ! screenrecording_active || ! recording_paused; then
+    return 1
+  fi
+
+  pkill -SIGUSR2 -f "^gpu-screen-recorder"
+  rm -f "$PAUSED_FILE"
+  toggle_screenrecording_indicator
+  omarchy-notification-send -t 2000 "Screen recording resumed"
 }
 
 finalize_recording() {
@@ -274,7 +319,11 @@ finalize_recording() {
   fi
 }
 
-if screenrecording_active; then
+if [[ $PAUSE_RECORDING == "true" ]]; then
+  pause_screenrecording
+elif [[ $RESUME_RECORDING == "true" ]]; then
+  resume_screenrecording
+elif screenrecording_active; then
   stop_screenrecording
 elif [[ $STOP_RECORDING == "true" ]]; then
   exit 1

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -35,6 +35,8 @@ o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")
 o.bind("ALT + PRINT", "Screenrecording", "omarchy-capture-screenrecording --stop-recording || omarchy-menu toggle trigger.capture.screenrecord")
 o.bind("SUPER + ALT + code:34", "Make webcam overlay smaller", "omarchy-capture-webcam-resize smaller")
 o.bind("SUPER + ALT + code:35", "Make webcam overlay larger", "omarchy-capture-webcam-resize larger")
+o.bind("SUPER + ALT + P", "Pause screen recording", "omarchy-capture-screenrecording --pause-recording")
+o.bind("SUPER + ALT + R", "Resume screen recording", "omarchy-capture-screenrecording --resume-recording")
 o.bind("SUPER + PRINT", "Color picker", "pkill hyprpicker || hyprpicker -a")
 o.bind("SUPER + CTRL + PRINT", "Extract text (OCR) from screenshot", "omarchy-capture-text")
 


### PR DESCRIPTION
gpu-screen-recorder natively supports pausing via SIGUSR2 (only in plain recording mode, not stream/replay). This wires that up as --pause-recording / --resume-recording, so recording can be paused in place and resumed into the same output file instead of always having to stop and start a new recording.

Bound to `SUPER+ALT+P` (Pause) / `SUPER+ALT+R` (Resume)

**Tested manually:** start recording, pause, wait, resume, stop — output is a single file with no gap segment, timestamp jumps cleanly across the paused interval."


https://github.com/user-attachments/assets/f39ba437-e8d6-4e06-a971-487306e507c1

