### PR TITLE
Hide sharee nodes from the Tailscale machines list

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -47,6 +47,12 @@ function isMullvadPeer(peer) {
   return isMullvadHost(dnsName) || isMullvadHost(hostName)
 }
 
+// Funnel relays and machines of users we've shared with sit in the netmap only
+// so they can reach us — tailscale status hides them, so the panel does too.
+function isShareeNode(peer) {
+  return peer && peer.ShareeNode === true
+}
+
 function osIcon(os) {
   var value = String(os || "").toLowerCase()
   if (value === "linux") return "󰌽"
@@ -235,6 +241,7 @@ function parseStatus(raw) {
 
     for (var id in rawPeers) {
       var peer = rawPeers[id] || {}
+      if (isShareeNode(peer)) continue
       var normalized = peerFromStatus(id, peer)
       if (normalized.Mullvad) continue
       if (normalized.Online) {
@@ -315,6 +322,7 @@ if (typeof module !== "undefined") {
     hasFileSharing: hasFileSharing,
     isTaildropTarget: isTaildropTarget,
     isMullvadPeer: isMullvadPeer,
+    isShareeNode: isShareeNode,
     peerFromStatus: peerFromStatus,
     parseExitNodeList: parseExitNodeList,
     mullvadRegionOptions: mullvadRegionOptions,

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -69,6 +69,14 @@ const status = tailscale.parseStatus(JSON.stringify({
       UserID: 1001,
       TaildropTarget: 1
     },
+    funnelIngress: {
+      HostName: 'funnel-ingress-node',
+      DNSName: '',
+      TailscaleIPs: ['fd7a:115c:a1e0::3901:8ebc'],
+      Online: true,
+      OS: '',
+      ShareeNode: true
+    },
     mullvadExit: {
       HostName: 'al-tia-wg-003',
       DNSName: 'al-tia-wg-003.mullvad.ts.net.',
@@ -83,11 +91,12 @@ const status = tailscale.parseStatus(JSON.stringify({
 
 assert(status.ok && status.running, 'tailscale parses running status')
 assertEqual(status.selfIp, '100.74.97.73', 'tailscale parses self IP')
-assertDeepEqual(status.peers.map(peer => peer.HostName), ['alpha', 'zed'], 'tailscale filters offline and Mullvad peers and sorts online peers')
+assertDeepEqual(status.peers.map(peer => peer.HostName), ['alpha', 'zed'], 'tailscale filters offline, Mullvad, and sharee peers and sorts online peers')
 assertDeepEqual(status.peers[0].TailscaleIPv6, ['fd7a:115c:a1e0::1901:334b'], 'tailscale preserves peer IPv6 addresses for copy menu')
 assert(status.peers[1].ExitNodeOption && status.peers[1].ExitNode, 'tailscale preserves exit node flags')
 assertDeepEqual(status.exitNodes.map(peer => peer.HostName), ['zed'], 'tailscale lists only online tailnet exit nodes')
 assert(tailscale.isMullvadPeer({ HostName: 'al-tia-wg-003', DNSName: 'al-tia-wg-003.mullvad.ts.net.' }), 'tailscale detects Mullvad status peers')
+assert(tailscale.isShareeNode({ HostName: 'funnel-ingress-node', ShareeNode: true }), 'tailscale detects sharee nodes')
 
 assert(status.fileSharing, 'tailscale reads Taildrop capability from the status capability map')
 assertEqual(status.selfUserId, '1001', 'tailscale records the owning user of this machine')


### PR DESCRIPTION
Tailscale Funnel routes external internet traffic to a local service. It puts Tailscale's own `funnel-ingress-node` relays in your netmap, flagged `ShareeNode: true`. `tailscale status` hides them, but the panel doesn't. The result is many unusable nodes in the list, sorted ahead of actual devices.

Building off the Mullvad pattern, skip them in `parseStatus`. This also hides unreachable machines owned by users you've shared a device with. It will not hide devices shared *to* you.

Before:

<img width="652" height="960" alt="tailscale-before" src="https://github.com/user-attachments/assets/c90c8efd-f63f-489d-8f00-d347c784c937" />


After:

<img width="652" height="370" alt="tailscale-after" src="https://github.com/user-attachments/assets/5bf61fef-ed63-4ab7-b624-c6041db32bfc" />
