### PR TITLE
Add omarchy-capture-code for themed code screenshots

### DIFF
--- a/bin/omarchy-capture-code
+++ b/bin/omarchy-capture-code
@@ -1,0 +1,342 @@
+#!/bin/bash
+
+# omarchy:summary=Turn code on the clipboard into a themed image
+# omarchy:group=capture
+# omarchy:args=[copy|save]
+# omarchy:examples=omarchy capture code | omarchy capture code copy
+
+[[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
+OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/omarchy"
+CACHED_THEME="$CACHE_DIR/silicon.tmTheme"
+CURRENT_THEME_DIR="$HOME/.local/state/omarchy/current/theme"
+COLORS_FILE="$CURRENT_THEME_DIR/colors.toml"
+THEME_TEMPLATE="$OMARCHY_PATH/default/silicon/omarchy.tmTheme.tpl"
+
+MODE="${1:-both}"
+
+SCREENSHOT_EDITOR="${OMARCHY_SCREENSHOT_EDITOR:-tensaku-edit}"
+
+# silicon has its own config file, but the flags below are passed explicitly and
+# would override it, so the knobs worth changing are exposed here instead.
+#
+# The family follows the system monospace font, so `omarchy font set` changes
+# these screenshots the same way `omarchy theme set` does. Only the size is a
+# separate knob; CODE_FONT overrides the whole thing and takes silicon's
+# fallback-list syntax, e.g. "JetBrains Mono; Noto Sans CJK SC=32".
+CODE_FONT_SIZE="${OMARCHY_CODE_FONT_SIZE:-32}"
+code_font_family=$(omarchy-font-current 2>/dev/null)
+CODE_FONT="${OMARCHY_CODE_FONT:-${code_font_family:-monospace}=$CODE_FONT_SIZE}"
+CODE_PADDING="${OMARCHY_CODE_PADDING:-24}"
+CODE_CORNER_RADIUS="${OMARCHY_CODE_CORNER_RADIUS:-16}"
+
+open_editor() {
+  local filepath="$1"
+  "$SCREENSHOT_EDITOR" "$filepath"
+}
+
+# Extensions we accept from a window title, and the menu offered by the
+# interactive picker when neither the title nor the clipboard content decide.
+# Titles are full of dots that are not filenames — domains, version numbers,
+# sentence ends — so an allowlist beats a bare regex.
+KNOWN_EXTENSIONS="c cc cpp cs css dart ex exs fish go h hpp hs html java jl js json jsx kt lua md ml nim php pl proto py r rb rs rst scala scss sh sql svelte swift tf toml ts tsx vim vue xml yaml yml zig zsh"
+
+extension_is_known() {
+  local candidate="$1"
+  local known
+
+  for known in $KNOWN_EXTENSIONS; do
+    [[ $candidate == "$known" ]] && return 0
+  done
+
+  return 1
+}
+
+language_from_window_title() {
+  local title candidate
+
+  title=$(hyprctl activewindow -j 2>/dev/null | sed -n 's/.*"title": *"\([^"]*\)".*/\1/p')
+  [[ -z $title ]] && return 1
+
+  # Walk every dot-suffix in the title left to right; the first allowlisted
+  # one wins.
+  for candidate in $(grep -oE '\.[A-Za-z0-9]+' <<<"$title" | tr -d '.'); do
+    candidate=$(tr '[:upper:]' '[:lower:]' <<<"$candidate")
+    if extension_is_known "$candidate"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Only markers that are proof, never inference. A miss costs one keypress in
+# the picker; a wrong guess silently renders the snippet highlighted as the
+# wrong language, which the user has no reason to question. Inferential rules
+# for TS/JS/JSON/YAML/SQL/CSS were tried and dropped: across 15 sample files
+# they mislabelled C++ as TypeScript (`std::string` matching a type-annotation
+# pattern) and Ruby as Python (both spell it `def`).
+language_from_content() {
+  local first_line
+  first_line=$(head -1 <<<"$CODE")
+
+  case "$first_line" in
+  '#!'*bash | '#!'*sh | '#!'*zsh) printf 'sh' && return 0 ;;
+  '#!'*python*) printf 'py' && return 0 ;;
+  '#!'*node*) printf 'js' && return 0 ;;
+  '#!'*ruby*) printf 'rb' && return 0 ;;
+  '<?php'*) printf 'php' && return 0 ;;
+  esac
+
+  if grep -qE '^\s*package\s+\w+' <<<"$CODE" && grep -qE '^\s*func\s' <<<"$CODE"; then
+    printf 'go'
+    return 0
+  fi
+
+  if grep -qE '^\s*(pub\s+)?fn\s+\w+' <<<"$CODE"; then
+    printf 'rs'
+    return 0
+  fi
+
+  if grep -qiE '^\s*(<!DOCTYPE\s+html|<html\b)' <<<"$CODE"; then
+    printf 'html'
+    return 0
+  fi
+
+  return 1
+}
+
+language_from_picker() {
+  local picked
+
+  picked=$(tr ' ' '\n' <<<"$KNOWN_EXTENSIONS" | gum filter --placeholder "Language") || return 1
+  [[ -z $picked ]] && return 1
+
+  printf '%s' "$picked"
+}
+
+# Render the active theme into a silicon theme, reusing the cache until
+# colors.toml changes. A theme may ship its own file to override the template.
+silicon_theme_file() {
+  local override="$CURRENT_THEME_DIR/silicon.tmTheme"
+  local sed_script tmp_theme
+
+  if [[ -f $override ]]; then
+    printf '%s' "$override"
+    return 0
+  fi
+
+  [[ -f $COLORS_FILE && -f $THEME_TEMPLATE ]] || return 1
+
+  if [[ ! -f $CACHED_THEME || $COLORS_FILE -nt $CACHED_THEME ]]; then
+    sed_script=$(mktemp)
+    while IFS=$'\t' read -r key value; do
+      printf 's|{{ %s }}|%s|g\n' "$key" "$value" >>"$sed_script"
+    done < <(omarchy-theme-color --file "$COLORS_FILE" --all)
+
+    mkdir -p "$CACHE_DIR"
+    # Render to a temp file in the same directory and rename it into place:
+    # a `mv` within one filesystem is atomic, so a render killed mid-write
+    # (SIGKILL, OOM, session teardown) never leaves a truncated file at
+    # $CACHED_THEME. Without this, a partial file picks up a fresh mtime and
+    # the -nt check below would treat it as valid forever.
+    tmp_theme=$(mktemp "$CACHE_DIR/silicon.tmTheme.XXXXXX")
+    if sed -f "$sed_script" "$THEME_TEMPLATE" >"$tmp_theme"; then
+      mv "$tmp_theme" "$CACHED_THEME"
+    else
+      rm -f "$tmp_theme"
+    fi
+    rm -f "$sed_script"
+  fi
+
+  [[ -f $CACHED_THEME ]] || return 1
+  printf '%s' "$CACHED_THEME"
+}
+
+# wl-paste hands back whatever type the clipboard currently prefers. After a
+# copy-mode run the clipboard holds image/png, so without --type text a
+# second run in a row would feed those PNG bytes back in as "code".
+CODE=$(wl-paste --type text 2>/dev/null)
+
+if [[ -z $CODE ]]; then
+  omarchy-notification-send "Nothing to capture" "Copy some code first"
+  exit 0
+fi
+
+if LANGUAGE=$(language_from_window_title); then
+  :
+elif LANGUAGE=$(language_from_content); then
+  :
+elif [[ -t 0 ]]; then
+  # A real controlling terminal: prompt right here. A cancelled prompt is a
+  # deliberate no-op, not an error, so exit silently.
+  LANGUAGE=$(language_from_picker) || exit 0
+else
+  # No controlling terminal (Hyprland keybinding, menu action): gum has
+  # nothing to prompt in. Hand off to a floating terminal that re-runs this
+  # same command, where a real tty lets the picker run; this invocation's job
+  # ends at a successful handoff. Not `exec`: a failed handoff (no terminal
+  # emulator, no compositor) must still fall through to notify below, and
+  # `exec` would abort the script on failure instead of returning to it.
+  # Relaunch by absolute path, not by name: the terminal gets a fresh PATH, and
+  # a bare name leaves the user staring at an empty terminal reporting that the
+  # executable was not found, with no notification and a zero exit here.
+  #
+  # Carry the resolved appearance settings across explicitly. uwsm-app writes
+  # only the argv to the app daemon's fifo, so the relaunched process starts
+  # from the systemd user manager's environment, not this one: without this,
+  # every OMARCHY_CODE_* the user set is silently dropped the moment the
+  # picker is needed, and the image comes back with default styling.
+  if setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal -e \
+    /usr/bin/env \
+    "OMARCHY_CODE_FONT=$CODE_FONT" \
+    "OMARCHY_CODE_PADDING=$CODE_PADDING" \
+    "OMARCHY_CODE_CORNER_RADIUS=$CODE_CORNER_RADIUS" \
+    "OMARCHY_SCREENSHOT_DIR=$OUTPUT_DIR" \
+    "$(readlink -f "$0")" "$MODE"; then
+    exit 0
+  fi
+  omarchy-notification-send "Couldn't prompt for a language" "No terminal is available to pick one" -u critical
+  exit 1
+fi
+
+if [[ ! -d $OUTPUT_DIR ]]; then
+  mkdir -p "$OUTPUT_DIR"
+fi
+
+FILENAME="code-$(date +'%Y-%m-%d_%H-%M-%S').png"
+
+if [[ $MODE == "copy" ]]; then
+  # Left in /tmp on purpose rather than trapped away: the notification shows the
+  # image as a preview and needs the file to outlive this process. The system
+  # cleans /tmp, and omarchy-capture-screenshot's clipboard path is equally
+  # transient.
+  FILEPATH="$(mktemp -d)/$FILENAME"
+else
+  FILEPATH="$OUTPUT_DIR/$FILENAME"
+fi
+
+silicon_args=(-l "$LANGUAGE" -o "$FILEPATH" --no-window-controls
+  --pad-horiz "$CODE_PADDING" --pad-vert "$CODE_PADDING" -f "$CODE_FONT")
+if theme_file=$(silicon_theme_file); then
+  silicon_args+=(--theme "$theme_file")
+fi
+
+# Guarded the same way --theme is: fall back to silicon's own defaults when
+# no Omarchy theme is resolvable, rather than inventing a colour. Using the
+# plain `background` (not a darker shade) makes the padding blend into the
+# card instead of reading as a frame. The corner arcs below are the only
+# accent the image carries.
+ACCENT=""
+if omarchy-theme-color background >/dev/null 2>&1; then
+  silicon_args+=(--background "$(omarchy-theme-color background 2>/dev/null)")
+  ACCENT=$(omarchy-theme-color accent 2>/dev/null)
+  # silicon has no border flag, so round corners ourselves with ImageMagick
+  # below and ask silicon for a plain rectangle rather than double-rounding.
+  [[ -n $ACCENT ]] && silicon_args+=(--no-round-corner)
+fi
+
+# silicon exits 0 even when it fails (unsupported language, a broken theme
+# file, a permission error saving the image) and simply leaves no file
+# behind. Treat a missing/empty artifact as the real failure signal instead
+# of trusting the exit code.
+silicon_stderr=$(printf '%s' "$CODE" | silicon "${silicon_args[@]}" 2>&1 1>/dev/null)
+
+if [[ ! -s $FILEPATH ]]; then
+  omarchy-notification-send "Code screenshot failed" "${silicon_stderr:-silicon produced no image}" -u critical
+  exit 1
+fi
+
+# Round the corners and stroke only the four corner arcs in the theme's accent
+# colour, matching Hyprland's active window border. A full outline read as a
+# generic wrapped frame; the arcs carry the theme colour without boxing the
+# code in. silicon itself has no border flag. This is
+# purely cosmetic: if magick is missing, the image is malformed, or any step
+# fails, keep silicon's plain-rectangle image rather than losing the capture
+# over a post-processing failure. Rendered to a temp file and moved into
+# place only on success, mirroring the theme cache's atomic write, so a
+# failed post-process can never leave a truncated image at $FILEPATH.
+if [[ -n $ACCENT ]]; then
+  corner_radius=$CODE_CORNER_RADIUS
+  border_width=2
+  # Everything is drawn at this multiple and scaled back down. Drawing at final
+  # size leaves visibly stepped corners: ImageMagick antialiases a stroke, but
+  # the alpha edge of a shape drawn straight onto a transparent canvas is hard.
+  # 4 rather than 8: on a 1450x800 capture, 8 costs ~1.1s per draw against
+  # ~0.35s, for a difference invisible at 1:1 and at 9x magnification.
+  # The arcs are inset by a full stroke width rather than half, so their outer
+  # edge sits inside the mask instead of exactly on it -- on the boundary the
+  # mask clips the arc's own antialiasing and the curve reads as stepped.
+  supersample=4
+  img_width=$(identify -format '%w' "$FILEPATH" 2>/dev/null)
+  img_height=$(identify -format '%h' "$FILEPATH" 2>/dev/null)
+
+  if [[ -n $img_width && -n $img_height ]]; then
+    big_width=$((img_width * supersample))
+    big_height=$((img_height * supersample))
+    # The mask rounds at radius R centred on (R,R), so the arcs have to be
+    # concentric with it and inset by half the stroke, or the outer half of the
+    # stroke falls outside the mask and the arc ends up visibly clipped flat.
+    arc_near=$((border_width * supersample))
+    arc_far=$(((corner_radius * 2 - border_width) * supersample))
+    right_near=$((big_width - supersample - arc_far))
+    right_far=$((big_width - supersample - arc_near))
+    bottom_near=$((big_height - supersample - arc_far))
+    bottom_far=$((big_height - supersample - arc_near))
+
+    tmp_dir=$(mktemp -d "$(dirname "$FILEPATH")/.omarchy-capture-code.XXXXXX")
+    tmp_mask="$tmp_dir/mask.png"
+    tmp_arcs="$tmp_dir/arcs.png"
+    tmp_out="$tmp_dir/out.png"
+
+    # Drawn white-on-black and applied with CopyOpacity rather than drawn onto
+    # a transparent canvas: an opaque canvas gives the downscale clean values to
+    # average, which is what makes the rounded edge smooth.
+    if magick -size "${big_width}x${big_height}" xc:black -fill white -stroke none \
+      -draw "roundrectangle 0,0 $((big_width - 1)),$((big_height - 1)) $((corner_radius * supersample)),$((corner_radius * supersample))" \
+      -resize "${img_width}x${img_height}" -alpha off "png:$tmp_mask" 2>/dev/null &&
+      magick -size "${big_width}x${big_height}" xc:none \
+        -stroke "$ACCENT" -strokewidth "$((border_width * supersample))" -fill none \
+        -draw "arc $arc_near,$arc_near $arc_far,$arc_far 180,270" \
+        -draw "arc $right_near,$arc_near $right_far,$arc_far 270,360" \
+        -draw "arc $right_near,$bottom_near $right_far,$bottom_far 0,90" \
+        -draw "arc $arc_near,$bottom_near $arc_far,$bottom_far 90,180" \
+        -resize "${img_width}x${img_height}" "png:$tmp_arcs" 2>/dev/null &&
+      magick "$FILEPATH" "$tmp_arcs" -compose over -composite \
+        "$tmp_mask" -compose CopyOpacity -composite "png:$tmp_out" 2>/dev/null &&
+      [[ -s $tmp_out ]]; then
+      mv "$tmp_out" "$FILEPATH"
+    fi
+    rm -rf "$tmp_dir"
+  fi
+fi
+
+case "$MODE" in
+copy)
+  wl-copy --type image/png <"$FILEPATH"
+  (
+    if [[ -n $(omarchy-notification-send "Code image copied to clipboard" "Edit with Super + Alt + , (or click this)" --image "$FILEPATH" -a) ]]; then
+      open_editor "$FILEPATH"
+    fi
+  ) >/dev/null 2>&1 &
+  ;;
+save)
+  echo "$FILEPATH"
+  (
+    if [[ -n $(omarchy-notification-send "Code image saved" "Edit with Super + Alt + , (or click this)" --image "$FILEPATH" -a) ]]; then
+      open_editor "$FILEPATH"
+    fi
+  ) >/dev/null 2>&1 &
+  ;;
+*)
+  echo "$FILEPATH"
+  wl-copy --type image/png <"$FILEPATH"
+  (
+    if [[ -n $(omarchy-notification-send "Code image copied to clipboard and saved" "Edit with Super + Alt + , (or click this)" --image "$FILEPATH" -a) ]]; then
+      open_editor "$FILEPATH"
+    fi
+  ) >/dev/null 2>&1 &
+  ;;
+esac

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -37,6 +37,7 @@ o.bind("SUPER + ALT + code:34", "Make webcam overlay smaller", "omarchy-capture-
 o.bind("SUPER + ALT + code:35", "Make webcam overlay larger", "omarchy-capture-webcam-resize larger")
 o.bind("SUPER + PRINT", "Color picker", "pkill hyprpicker || hyprpicker -a")
 o.bind("SUPER + CTRL + PRINT", "Extract text (OCR) from screenshot", "omarchy-capture-text")
+o.bind("SUPER + SHIFT + PRINT", "Capture copied code as an image", "omarchy-capture-code")
 
 -- While the slurp region picker is open, Return captures the entire focused
 -- monitor. The bind lives exactly as long as a selection layer is on screen

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -51,6 +51,7 @@
   "trigger.capture.screenrecord.stop": {"icon":"","label":"Stop Screenrecording","when":"pgrep -f '^gpu-screen-recorder'","action":"omarchy-capture-screenrecording --stop-recording"},
   "trigger.capture.screenrecord": {"icon":"","label":"Screenrecord"},
   "trigger.capture.text": {"icon":"󰴑","label":"Text","action":"omarchy-capture-text"},
+  "trigger.capture.code": {"icon":"","label":"Code","action":"omarchy-capture-code"},
   "trigger.capture.color": {"icon":"󰃉","label":"Color","action":"pkill hyprpicker || hyprpicker -a"},
   "trigger.capture.screenrecord.no-audio": {"icon":"","label":"With no audio","action":"omarchy-capture-screenrecording"},
   "trigger.capture.screenrecord.desktop-audio": {"icon":"","label":"With desktop audio","action":"omarchy-capture-screenrecording --with-desktop-audio"},

--- a/default/silicon/omarchy.tmTheme.tpl
+++ b/default/silicon/omarchy.tmTheme.tpl
@@ -1,0 +1,949 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Omarchy</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>{{ background }}</string>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+        <key>caret</key>
+        <string>{{ bright_foreground }}</string>
+        <key>selection</key>
+        <string>{{ selection }}</string>
+        <key>lineHighlight</key>
+        <string>{{ lighter_background }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Comment</string>
+      <key>scope</key>
+      <string>comment, punctuation.definition.comment</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ muted }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Variable</string>
+      <key>scope</key>
+      <string>variable, string constant.other.placeholder</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Variable Parameter</string>
+      <key>scope</key>
+      <string>variable.parameter, entity.name.variable.parameter, meta.function.parameter</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Variable Property</string>
+      <key>scope</key>
+      <string>variable.other.property, variable.other.object.property, variable.other.member</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Variable Constant</string>
+      <key>scope</key>
+      <string>variable.other.constant, constant.other</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Enum Member</string>
+      <key>scope</key>
+      <string>variable.other.enummember</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ orange }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Invalid</string>
+      <key>scope</key>
+      <string>invalid, invalid.illegal</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ red }}</string>
+        <key>fontStyle</key>
+        <string>strikethrough</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Invalid Deprecated</string>
+      <key>scope</key>
+      <string>invalid.deprecated</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+        <key>fontStyle</key>
+        <string>strikethrough</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keyword</string>
+      <key>scope</key>
+      <string>keyword, storage.type.class, storage.type.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_magenta }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Storage Modifier</string>
+      <key>scope</key>
+      <string>storage.modifier</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keyword Control</string>
+      <key>scope</key>
+      <string>keyword.control, keyword.control.flow</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_magenta }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keyword Import</string>
+      <key>scope</key>
+      <string>keyword.control.import, keyword.control.export, keyword.control.from, keyword.control.as</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keyword Operator</string>
+      <key>scope</key>
+      <string>keyword.operator, keyword.operator.new, keyword.operator.expression, keyword.operator.logical, keyword.operator.comparison</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Operator</string>
+      <key>scope</key>
+      <string>punctuation.accessor, punctuation.separator.key-value</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Type</string>
+      <key>scope</key>
+      <string>storage.type, entity.name.type</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Type Builtin</string>
+      <key>scope</key>
+      <string>storage.type.primitive, support.type</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Type Class</string>
+      <key>scope</key>
+      <string>entity.name.type.class, entity.name.class, support.class, entity.other.inherited-class</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Type Interface</string>
+      <key>scope</key>
+      <string>entity.name.type.interface</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Type Enum</string>
+      <key>scope</key>
+      <string>entity.name.type.enum</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Type Parameter</string>
+      <key>scope</key>
+      <string>entity.name.type.parameter</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Namespace</string>
+      <key>scope</key>
+      <string>entity.name.namespace, entity.name.type.module</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Function</string>
+      <key>scope</key>
+      <string>entity.name.function, meta.function-call.generic, meta.function-call, variable.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Function Builtin</string>
+      <key>scope</key>
+      <string>support.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Function Method</string>
+      <key>scope</key>
+      <string>entity.name.function.method, meta.method.declaration</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Function Decorator</string>
+      <key>scope</key>
+      <string>entity.name.function.decorator, meta.decorator, punctuation.decorator, meta.annotation</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation</string>
+      <key>scope</key>
+      <string>punctuation, meta.brace, meta.bracket</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ dark_foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constant Numeric</string>
+      <key>scope</key>
+      <string>constant.numeric, constant.numeric.integer, constant.numeric.float, constant.numeric.hex, constant.numeric.octal, constant.numeric.binary</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ orange }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constant Boolean</string>
+      <key>scope</key>
+      <string>constant.language.boolean</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ orange }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constant Builtin</string>
+      <key>scope</key>
+      <string>constant.language, constant.language.null, constant.language.undefined</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constant Character</string>
+      <key>scope</key>
+      <string>constant.character</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ green }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constant Character Escape</string>
+      <key>scope</key>
+      <string>constant.character.escape</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_magenta }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>String</string>
+      <key>scope</key>
+      <string>string, string.quoted, string.template</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ green }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>String Interpolation</string>
+      <key>scope</key>
+      <string>punctuation.definition.template-expression, punctuation.section.embedded, meta.embedded.line</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>String Regexp</string>
+      <key>scope</key>
+      <string>string.regexp, constant.other.character-class.regexp, constant.character.escape.regexp</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Support</string>
+      <key>scope</key>
+      <string>support.type.property-name, support.constant, support.other</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Tag</string>
+      <key>scope</key>
+      <string>entity.name.tag, meta.tag</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Tag Attribute</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Property</string>
+      <key>scope</key>
+      <string>support.type.property-name.css, support.type.vendored.property-name.css, meta.property-name.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Value</string>
+      <key>scope</key>
+      <string>support.constant.property-value.css, meta.property-value.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Selector</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name.class.css, entity.other.attribute-name.id.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Pseudo</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name.pseudo-class.css, entity.other.attribute-name.pseudo-element.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>CSS Units</string>
+      <key>scope</key>
+      <string>keyword.other.unit.css</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ orange }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>JSON Key Level 0</string>
+      <key>scope</key>
+      <string>source.json meta.structure.dictionary.json support.type.property-name.json</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ orange }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>JSON Key Level 1</string>
+      <key>scope</key>
+      <string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>JSON Key Level 2</string>
+      <key>scope</key>
+      <string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>JSON Key Level 3</string>
+      <key>scope</key>
+      <string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_magenta }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>JSON Key Level 4</string>
+      <key>scope</key>
+      <string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>JSON Key Level 5+</string>
+      <key>scope</key>
+      <string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ green }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown Heading</string>
+      <key>scope</key>
+      <string>markup.heading, entity.name.section.markdown, punctuation.definition.heading.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown Bold</string>
+      <key>scope</key>
+      <string>markup.bold, punctuation.definition.bold.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown Italic</string>
+      <key>scope</key>
+      <string>markup.italic, punctuation.definition.italic.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown Link</string>
+      <key>scope</key>
+      <string>markup.underline.link, string.other.link.title.markdown, string.other.link.description.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown Code</string>
+      <key>scope</key>
+      <string>markup.inline.raw, markup.fenced_code.block, markup.raw.block</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ green }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown Quote</string>
+      <key>scope</key>
+      <string>markup.quote, punctuation.definition.quote.begin.markdown</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ muted }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Markdown List</string>
+      <key>scope</key>
+      <string>punctuation.definition.list.begin.markdown, markup.list.numbered, markup.list.unnumbered</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Diff Inserted</string>
+      <key>scope</key>
+      <string>markup.inserted, punctuation.definition.inserted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ green }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Diff Deleted</string>
+      <key>scope</key>
+      <string>markup.deleted, punctuation.definition.deleted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ red }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Diff Changed</string>
+      <key>scope</key>
+      <string>markup.changed, punctuation.definition.changed</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ orange }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>This/Self</string>
+      <key>scope</key>
+      <string>variable.language.this, variable.language.self, variable.language.special.self</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Object Keys</string>
+      <key>scope</key>
+      <string>meta.object-literal.key, string.unquoted.label.js</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Rust Lifetime</string>
+      <key>scope</key>
+      <string>entity.name.type.lifetime.rust, punctuation.definition.lifetime.rust</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Rust Macro</string>
+      <key>scope</key>
+      <string>entity.name.function.macro.rust, support.function.macro.rust</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Shell Variable</string>
+      <key>scope</key>
+      <string>variable.other.normal.shell, variable.other.positional.shell, variable.other.bracket.shell</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Shell Command</string>
+      <key>scope</key>
+      <string>entity.name.command.shell</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Shell Builtin</string>
+      <key>scope</key>
+      <string>support.function.builtin.shell</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>YAML Key</string>
+      <key>scope</key>
+      <string>entity.name.tag.yaml</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>TOML Key</string>
+      <key>scope</key>
+      <string>keyword.key.toml, support.type.property-name.toml</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>TOML Table</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name.table.toml, support.type.property-name.table.toml</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>INI Section</string>
+      <key>scope</key>
+      <string>entity.name.section.group-title.ini, punctuation.definition.entity.ini</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>INI Key</string>
+      <key>scope</key>
+      <string>keyword.other.definition.ini</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Make Target</string>
+      <key>scope</key>
+      <string>entity.name.function.target.makefile</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Make Variable</string>
+      <key>scope</key>
+      <string>variable.other.makefile</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Go Package</string>
+      <key>scope</key>
+      <string>entity.name.package.go</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ blue }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Python Self</string>
+      <key>scope</key>
+      <string>variable.parameter.function.language.special.self.python</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Python Magic</string>
+      <key>scope</key>
+      <string>support.function.magic.python, support.variable.magic.python</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>PHP Variable</string>
+      <key>scope</key>
+      <string>variable.other.php, punctuation.definition.variable.php</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>C Preprocessor</string>
+      <key>scope</key>
+      <string>meta.preprocessor.c, meta.preprocessor.include.c, keyword.control.directive.include.c</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>C# Attribute</string>
+      <key>scope</key>
+      <string>meta.attribute.csharp, entity.name.type.attribute.csharp</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ cyan }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>SQL Keyword</string>
+      <key>scope</key>
+      <string>keyword.other.DML.sql, keyword.other.DDL.sql</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ bright_magenta }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>GraphQL Type</string>
+      <key>scope</key>
+      <string>support.type.graphql, entity.name.type.graphql</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ yellow }}</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>GraphQL Field</string>
+      <key>scope</key>
+      <string>variable.graphql, variable.other.graphql</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>{{ foreground }}</string>
+      </dict>
+    </dict>
+  </array>
+  <key>uuid</key>
+  <string>4c0b0b8f-2f6a-4a3e-9c1a-omarchy000001</string>
+</dict>
+</plist>

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -111,6 +111,7 @@ ruby
 rust
 tensaku
 sddm
+silicon
 slurp
 socat
 starship

--- a/migrations/1785578538.sh
+++ b/migrations/1785578538.sh
@@ -1,0 +1,3 @@
+echo "Install silicon for code screenshots"
+
+omarchy-pkg-add silicon

--- a/test/shell.d/capture-code-test.sh
+++ b/test/shell.d/capture-code-test.sh
@@ -1,0 +1,708 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+log_file="$test_tmp/capture.log"
+out_dir="$test_tmp/pictures"
+mkdir -p "$stub_bin" "$out_dir"
+
+export OMARCHY_CAPTURE_TEST_LOG="$log_file"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<<"$body"
+  chmod +x "$stub_bin/$name"
+}
+
+log_call() {
+  cat <<'STUB'
+log() {
+  printf "%s" "$1" >>"$OMARCHY_CAPTURE_TEST_LOG"
+  shift
+  for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CAPTURE_TEST_LOG"; done
+  printf "\n" >>"$OMARCHY_CAPTURE_TEST_LOG"
+}
+STUB
+}
+
+write_stub hyprctl "#!/bin/bash
+printf '{\"title\": \"%s\"}' \"\${OMARCHY_TEST_TITLE:-}\"
+"
+
+write_stub wl-paste "#!/bin/bash
+$(log_call)
+log wl-paste \"\$@\"
+printf '%s' \"\${OMARCHY_TEST_CLIPBOARD:-}\"
+"
+
+write_stub wl-copy "#!/bin/bash
+$(log_call)
+log wl-copy \"\$@\"
+cat >/dev/null
+"
+
+# Writes a real file so the caller's -f checks behave like the real thing,
+# unless OMARCHY_TEST_SILICON_FAIL is set: real silicon exits 0 and leaves no
+# file behind on failures such as an unsupported language or a broken theme,
+# after printing a diagnostic to stderr.
+write_stub silicon "#!/bin/bash
+$(log_call)
+log silicon \"\$@\"
+if [[ -n \${OMARCHY_TEST_SILICON_FAIL:-} ]]; then
+  echo \"\$OMARCHY_TEST_SILICON_FAIL\" >&2
+  exit 0
+fi
+while [[ \$# -gt 0 ]]; do
+  if [[ \$1 == \"-o\" ]]; then printf 'PNG' >\"\$2\"; fi
+  shift
+done
+"
+
+write_stub gum "#!/bin/bash
+$(log_call)
+log gum \"\$@\"
+printf '%s' \"\${OMARCHY_TEST_GUM_PICK:-}\"
+exit \${OMARCHY_TEST_GUM_EXIT:-0}
+"
+
+write_stub omarchy-notification-send "#!/bin/bash
+$(log_call)
+log notify \"\$@\"
+"
+
+# Stands in for the real uwsm-app during the no-tty handoff: setsid is left
+# real (it just execs the next argument), so this is the first stubbed
+# command in that chain. Logs the xdg-terminal-exec invocation it was asked
+# to run and lets a scenario control whether the handoff itself succeeds.
+write_stub uwsm-app "#!/bin/bash
+$(log_call)
+log uwsm-app \"\$@\"
+exit \${OMARCHY_TEST_UWSM_EXIT:-0}
+"
+
+write_stub identify "#!/bin/bash
+$(log_call)
+log identify \"\$@\"
+printf '100'
+"
+
+# The real omarchy-font-current shells out to fc-match, so the developer's own
+# font would otherwise decide what these assertions see. Stubbed so the family
+# is a fixture, and so a scenario can make it come back empty.
+write_stub omarchy-font-current "#!/bin/bash
+printf '%s' \"\${OMARCHY_TEST_FONT-Test Mono}\"
+"
+
+# Writes a distinguishable marker to the destination (the last argument,
+# stripping a possible png: prefix) so a test can tell the bordered image
+# apart from silicon's plain one, unless OMARCHY_TEST_MAGICK_FAIL is set: a
+# failed (or missing) magick must degrade to the unbordered image, not fail
+# the capture.
+write_stub magick "#!/bin/bash
+$(log_call)
+log magick \"\$@\"
+if [[ -n \${OMARCHY_TEST_MAGICK_FAIL:-} ]]; then
+  echo 'magick: test failure' >&2
+  exit 1
+fi
+dest=\"\${@: -1}\"
+dest=\"\${dest#png:}\"
+printf 'BORDERED-PNG' >\"\$dest\"
+"
+
+# A throwaway HOME and XDG_CACHE_HOME keep the run hermetic: Task 5 reads the
+# active theme under $HOME and caches under $XDG_CACHE_HOME, and the result must
+# not depend on the developer's real theme state. $ROOT/bin is on PATH so the
+# real omarchy-theme-color is used rather than an installed copy.
+fake_home="$test_tmp/home"
+theme_dir="$fake_home/.local/state/omarchy/current/theme"
+mkdir -p "$theme_dir"
+
+# CAPTURE_EXIT holds the wrapped command's real exit status. Scenarios that
+# legitimately fail must read it explicitly instead of letting it propagate:
+# under `set -e`, a bare call to either runner below would otherwise abort
+# this whole test file the first time the wrapped command exits non-zero.
+CAPTURE_EXIT=0
+
+# The default runner: a plain bash invocation with stdin from /dev/null, no
+# controlling terminal at all. This matches the real Hyprland keybinding and
+# menu action (both invoke the command with no tty), and it is also what lets
+# the success notification's backgrounded editor-click subshell survive long
+# enough to write to the log: a pty session (see run_capture_tty below) sends
+# SIGHUP to anything still attached to it once the wrapped command exits,
+# killing an unrelated background job before it can run.
+run_capture() {
+  : >"$log_file"
+  set +e
+  PATH="$stub_bin:$ROOT/bin:$PATH" OMARCHY_SCREENSHOT_DIR="$out_dir" \
+    HOME="$fake_home" XDG_CACHE_HOME="$test_tmp/cache" OMARCHY_PATH="$ROOT" \
+    bash "$ROOT/bin/omarchy-capture-code" "$@" </dev/null >"$test_tmp/out" 2>&1
+  CAPTURE_EXIT=$?
+  set -e
+  # Let a success notification's backgrounded editor-click subshell settle
+  # before returning: otherwise it could still be writing to the log by the
+  # time the *next* scenario truncates it, bleeding a stray "notify" line
+  # into that scenario's assertions.
+  sleep 0.2
+}
+
+# Only for scenarios that must exercise the interactive gum picker directly:
+# gum's own `[[ -t 0 ]]` check needs a real controlling terminal, which
+# `script` provides by allocating a pty.
+run_capture_tty() {
+  : >"$log_file"
+  set +e
+  PATH="$stub_bin:$ROOT/bin:$PATH" OMARCHY_SCREENSHOT_DIR="$out_dir" \
+    HOME="$fake_home" XDG_CACHE_HOME="$test_tmp/cache" OMARCHY_PATH="$ROOT" \
+    script -qec "bash '$ROOT/bin/omarchy-capture-code' $*" /dev/null >"$test_tmp/out" 2>&1
+  CAPTURE_EXIT=$?
+  set -e
+}
+
+# Patterns starting with a dash are escaped by the caller (\-\-theme), not passed
+# as a bare `--` argument: the helpers already pass `--` to grep, so an extra one
+# would shift the pattern into $2 and leave an assertion that always passes.
+#
+# Success notifications now fire from a backgrounded subshell (matching
+# omarchy-capture-screenshot's clickable pattern), so the log line can land a
+# moment after the wrapped command already returned. Poll briefly rather than
+# failing on the first miss.
+assert_logged() {
+  local pattern="$1"
+  local description="$2"
+  local attempt
+
+  [[ -n $description ]] || fail "assert_logged called without a description" "pattern: $pattern"
+
+  for attempt in {1..20}; do
+    grep -q -- "$pattern" "$log_file" && { pass "$description"; return; }
+    sleep 0.05
+  done
+
+  fail "$description" "$(cat "$log_file")"
+}
+
+refute_logged() {
+  local pattern="$1"
+  local description="$2"
+
+  [[ -n $description ]] || fail "refute_logged called without a description" "pattern: $pattern"
+  if grep -q -- "$pattern" "$log_file"; then
+    fail "$description" "$(cat "$log_file")"
+  fi
+  pass "$description"
+}
+
+# --- Language comes from the focused window title ------------------------------
+
+OMARCHY_TEST_TITLE="config.rs — omarchy" \
+  OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+
+assert_logged $'silicon\t.*-l\trs' "passes the extension from the window title to silicon"
+refute_logged '^gum' "does not prompt when the title identifies the language"
+refute_logged '\-\-window-title' "never renders the filename into the image"
+assert_logged '\-\-no-window-controls' "never shows silicon's macOS-style window controls"
+assert_logged $'wl-paste\t--type\ttext' "reads only the text clipboard, never an image"
+assert_logged $'wl-copy\t--type\timage/png' "copies the rendered image to the clipboard"
+assert_logged '^notify' "notifies when the image is ready"
+
+if ! ls "$out_dir"/code-*.png >/dev/null 2>&1; then
+  fail "saves the image into the screenshot directory" "$(ls -la "$out_dir")"
+fi
+pass "saves the image into the screenshot directory"
+
+# --- A title dot that is not a filename must not be treated as a language ------
+
+# A domain in a browser tab title, and a version number: both end in a dotted
+# token that is not a file extension, and both must fall through to the picker
+# rather than being handed to silicon as a language.
+OMARCHY_TEST_TITLE="example.io — Search" \
+  OMARCHY_TEST_CLIPBOARD="plain words here" OMARCHY_TEST_GUM_PICK="txt" run_capture_tty
+refute_logged $'silicon\t.*-l\tio' "rejects a domain suffix from a window title"
+
+OMARCHY_TEST_TITLE="Release notes v1.2.3" \
+  OMARCHY_TEST_CLIPBOARD="plain words here" OMARCHY_TEST_GUM_PICK="txt" run_capture_tty
+refute_logged $'silicon\t.*-l\t3' "rejects a version-number suffix from a window title"
+
+# --- Empty clipboard is not an error -------------------------------------------
+
+OMARCHY_TEST_TITLE="config.rs — omarchy" OMARCHY_TEST_CLIPBOARD="" run_capture
+refute_logged '^silicon' "does not render when the clipboard is empty"
+
+# --- Content heuristics when the title has no usable extension -----------------
+
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD='#!/bin/bash
+echo hi' run_capture
+assert_logged $'silicon\t.*-l\tsh' "reads a bash shebang when the title says nothing"
+refute_logged '^gum' "does not prompt once the content identifies the language"
+
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD='#!/usr/bin/env python3
+print(1)' run_capture
+assert_logged $'silicon\t.*-l\tpy' "reads a python shebang"
+
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD='<?php echo 1;' run_capture
+assert_logged $'silicon\t.*-l\tphp' "recognises a php open tag"
+
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD='package main
+
+func main() {}' run_capture
+assert_logged $'silicon\t.*-l\tgo' "recognises a go package clause"
+
+# --- Picker fallback -----------------------------------------------------------
+
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD="SELECT 1;" OMARCHY_TEST_GUM_PICK="sql" run_capture_tty
+assert_logged '^gum' "prompts when neither the title nor the content decides"
+assert_logged $'silicon\t.*-l\tsql' "renders with the language picked in the prompt"
+
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD="SELECT 1;" OMARCHY_TEST_GUM_PICK="" OMARCHY_TEST_GUM_EXIT=1 run_capture_tty
+refute_logged '^silicon' "treats a dismissed prompt as a cancel, not an error"
+
+# gum can also exit 0 with an empty selection (filter cleared, enter pressed
+# on no match); that must be treated the same as a dismissed prompt.
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" \
+  OMARCHY_TEST_CLIPBOARD="SELECT 1;" OMARCHY_TEST_GUM_PICK="" run_capture_tty
+refute_logged '^silicon' "treats an empty picker selection as a cancel, not an error"
+
+# --- Output modes --------------------------------------------------------------
+
+rm -f "$out_dir"/code-*.png
+OMARCHY_TEST_TITLE="config.rs — omarchy" \
+  OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture copy
+assert_logged $'wl-copy\t--type\timage/png' "copy mode still reaches the clipboard"
+if ls "$out_dir"/code-*.png >/dev/null 2>&1; then
+  fail "copy mode leaves no file behind" "$(ls -la "$out_dir")"
+fi
+pass "copy mode leaves no file behind"
+
+OMARCHY_TEST_TITLE="config.rs — omarchy" \
+  OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture save
+refute_logged '^wl-copy' "save mode does not touch the clipboard"
+if ! ls "$out_dir"/code-*.png >/dev/null 2>&1; then
+  fail "save mode writes the file" "$(ls -la "$out_dir")"
+fi
+pass "save mode writes the file"
+
+# --- silicon can fail while still exiting 0 ------------------------------------
+
+# Real silicon exits 0 and writes no file for an unsupported language, a
+# broken theme, or a permission error saving the image, after printing a
+# diagnostic to stderr. The artifact itself, not the exit code, must decide.
+rm -f "$out_dir"/code-*.png
+OMARCHY_TEST_TITLE="config.rs — omarchy" OMARCHY_TEST_CLIPBOARD="let x = 1;" \
+  OMARCHY_TEST_SILICON_FAIL="Error: Cannot load the theme" run_capture
+capture_rc=$CAPTURE_EXIT
+
+if ls "$out_dir"/code-*.png >/dev/null 2>&1; then
+  fail "leaves no image behind when silicon silently fails" "$(ls -la "$out_dir")"
+fi
+pass "leaves no image behind when silicon silently fails"
+
+refute_logged 'Code image' "sends no success notification when silicon produced no file"
+assert_logged "Cannot load the theme" "surfaces silicon's stderr in the failure notification"
+assert_logged $'\-u\tcritical' "notifies at critical urgency on a silent silicon failure"
+
+if (( capture_rc == 0 )); then
+  fail "exits non-zero when silicon silently fails" "exit code was 0"
+fi
+pass "exits non-zero when silicon silently fails"
+
+# --- No controlling terminal (Hyprland keybinding, menu action) ----------------
+
+# Neither the title nor the content route below decide the language, so the
+# real flow would need to prompt with gum — but there is no tty to prompt in.
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" OMARCHY_TEST_CLIPBOARD="SELECT 1;" \
+  OMARCHY_CODE_FONT_SIZE=41 OMARCHY_CODE_PADDING=37 OMARCHY_CODE_CORNER_RADIUS=9 run_capture
+capture_rc=$CAPTURE_EXIT
+
+# The handoff must name an absolute path, not the bare command. The spawned
+# terminal gets a fresh PATH, and a bare name leaves the user staring at an
+# empty terminal reporting the executable was not found — with no notification,
+# because xdg-terminal-exec itself succeeded.
+assert_logged $'uwsm-app\t--\txdg-terminal-exec\t--app-id=org.omarchy.terminal\t-e\t/usr/bin/env\t.*'"$ROOT"$'/bin/omarchy-capture-code\tboth' \
+  "hands off to a floating terminal by absolute path when no tty is available"
+
+# uwsm-app passes only argv over the app daemon's fifo, so the relaunched
+# process starts from the systemd user manager's environment. Every setting
+# has to ride along as an explicit assignment or it is silently lost, and the
+# picker — now the common path, since content is never guessed — would hand
+# back a default-styled image no matter what the user configured.
+assert_logged $'uwsm-app\t.*\tOMARCHY_CODE_FONT=Test Mono=41\t' \
+  "carries the resolved font across the handoff"
+assert_logged $'uwsm-app\t.*\tOMARCHY_CODE_PADDING=37\t' \
+  "carries the padding across the handoff"
+assert_logged $'uwsm-app\t.*\tOMARCHY_CODE_CORNER_RADIUS=9\t' \
+  "carries the corner radius across the handoff"
+assert_logged $'uwsm-app\t.*\tOMARCHY_SCREENSHOT_DIR='"$out_dir"$'\t' \
+  "carries the output directory across the handoff"
+refute_logged '^gum' "never tries to prompt gum directly without a controlling terminal"
+refute_logged '^notify' "a successful handoff is silent"
+
+if (( capture_rc != 0 )); then
+  fail "exits cleanly after a successful handoff" "exit code was $capture_rc"
+fi
+pass "exits cleanly after a successful handoff"
+
+# The handoff itself can fail (no terminal emulator, no compositor); that must
+# still surface, rather than exiting silently like a cancelled picker would.
+OMARCHY_TEST_TITLE="ryu@omarchy: ~" OMARCHY_TEST_CLIPBOARD="SELECT 1;" \
+  OMARCHY_TEST_UWSM_EXIT=1 run_capture
+capture_rc=$CAPTURE_EXIT
+
+assert_logged '^notify' "notifies when the picker cannot be reached at all"
+assert_logged $'\-u\tcritical' "the no-terminal failure is a critical notification"
+
+if (( capture_rc == 0 )); then
+  fail "exits non-zero when the handoff itself fails" "exit code was 0"
+fi
+pass "exits non-zero when the handoff itself fails"
+
+# --- Theming -------------------------------------------------------------------
+
+colors_file="$theme_dir/colors.toml"
+cached_theme="$test_tmp/cache/omarchy/silicon.tmTheme"
+
+cp "$ROOT/themes/nord/colors.toml" "$colors_file"
+rm -f "$cached_theme"
+
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+assert_logged "\-\-theme" "renders with a theme derived from the active Omarchy theme"
+assert_logged "\-\-background" "renders with a background derived from the active theme, not silicon's lavender default"
+
+[[ -f $cached_theme ]] || fail "caches the rendered theme" "$(ls -la "$test_tmp/cache/omarchy" 2>&1)"
+pass "caches the rendered theme"
+
+if grep -q '{{' "$cached_theme"; then
+  fail "every placeholder resolves against a shipped theme" "$(grep -n '{{' "$cached_theme" | head)"
+fi
+pass "every placeholder resolves against a shipped theme"
+
+# plistlib, not a generic XML parser: a .tmTheme declares Apple's DTD by URL, and
+# a generic parser may try to fetch it, making the test depend on the network.
+python3 -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    theme = plistlib.load(f)
+assert 'settings' in theme, 'plist has no settings array'
+" "$cached_theme" 2>"$test_tmp/plist.err" ||
+  fail "rendered theme parses as a plist" "$(cat "$test_tmp/plist.err")"
+pass "rendered theme parses as a plist"
+
+# The keyword entry's scope is now a comma-separated list (storage.type.function
+# and storage.type.class join it), so match it as a list member rather than
+# requiring an exact "<string>keyword</string>" line.
+for scope in comment keyword string; do
+  grep -qE "<string>$scope(,|</string>)" "$cached_theme" ||
+    fail "rendered theme styles the $scope scope" "$(head -40 "$cached_theme")"
+  pass "rendered theme styles the $scope scope"
+done
+
+# Corrected scopes must use the colours already chosen in vscode-theme.json.tpl,
+# not the ones transcribed from the original (buggy) brief, so a screenshot
+# matches what the user sees in their editor. These pin fix-round colour
+# corrections against a regression, using nord's known hex values.
+python3 -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    theme = plistlib.load(f)
+by_scope = {s['scope']: s['settings'] for s in theme['settings'] if 'scope' in s}
+modifier = by_scope.get('storage.modifier', {})
+assert modifier.get('foreground') == '#ebcb8b', \
+    f\"expected nord's yellow, got {modifier.get('foreground')}\"
+plain_type = by_scope.get('storage.type, entity.name.type', {})
+assert plain_type.get('foreground') == '#ebcb8b', \
+    f\"expected nord's yellow, got {plain_type.get('foreground')}\"
+" "$cached_theme" 2>"$test_tmp/scope-color.err" ||
+  fail "storage keywords no longer share keyword's colour" "$(cat "$test_tmp/scope-color.err")"
+pass "storage keywords no longer share keyword's colour"
+
+python3 -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    theme = plistlib.load(f)
+by_scope = {s['scope']: s['settings'] for s in theme['settings'] if 'scope' in s}
+param = by_scope.get('variable.parameter, entity.name.variable.parameter, meta.function.parameter', {})
+assert param.get('foreground') == '#88c0d0', \
+    f\"expected nord's cyan, got {param.get('foreground')}\"
+assert param.get('fontStyle') == 'italic', \
+    f\"expected vscode's italic fontStyle, got {param.get('fontStyle')}\"
+" "$cached_theme" 2>"$test_tmp/scope-color.err" ||
+  fail "function parameters match vscode's italic cyan" "$(cat "$test_tmp/scope-color.err")"
+pass "function parameters match vscode's italic cyan"
+
+# storage.type.class/storage.type.function must join Keyword's bright_magenta
+# (vscode-theme.json.tpl groups them with "keyword"), not stay grouped with
+# plain storage.type's yellow: TextMate's longest-match means `fn`/`func`/
+# `function`/`class` would otherwise render differently than the user's editor.
+python3 -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    theme = plistlib.load(f)
+by_scope = {s['scope']: s['settings'] for s in theme['settings'] if 'scope' in s}
+keyword = by_scope.get('keyword, storage.type.class, storage.type.function', {})
+assert keyword.get('foreground') == '#b48ead', \
+    f\"expected nord's bright_magenta, got {keyword.get('foreground')}\"
+" "$cached_theme" 2>"$test_tmp/scope-color.err" ||
+  fail "storage.type.class and storage.type.function join Keyword's colour" "$(cat "$test_tmp/scope-color.err")"
+pass "storage.type.class and storage.type.function join Keyword's colour"
+
+# Invalid must strike through, matching vscode-theme.json.tpl's rule.
+python3 -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    theme = plistlib.load(f)
+by_scope = {s['scope']: s['settings'] for s in theme['settings'] if 'scope' in s}
+invalid = by_scope.get('invalid, invalid.illegal', {})
+assert invalid.get('fontStyle') == 'strikethrough', \
+    f\"expected strikethrough, got {invalid.get('fontStyle')}\"
+" "$cached_theme" 2>"$test_tmp/scope-color.err" ||
+  fail "invalid text is struck through" "$(cat "$test_tmp/scope-color.err")"
+pass "invalid text is struck through"
+
+# The full carry-over from vscode-theme.json.tpl's tokenColors, so this can't
+# silently regress back down to a hand-picked subset: exact scope count, a
+# few of the specific scopes called out as "doing the visual work" (method
+# calls, property access, operators, punctuation, JSON keys, escapes), and
+# the fontStyle counts (bold/italic/strikethrough) all pinned to vscode's
+# actual numbers.
+python3 -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as f:
+    theme = plistlib.load(f)
+scoped = [s for s in theme['settings'] if 'scope' in s]
+assert len(scoped) == 81, f'expected 81 scoped entries, got {len(scoped)}'
+
+joined_scopes = ' | '.join(s['scope'] for s in scoped)
+for needle in [
+    'entity.name.function.method',
+    'meta.function-call',
+    'variable.other.property',
+    'variable.other.object.property',
+    'keyword.operator',
+    'punctuation.accessor',
+    'constant.language.boolean',
+    'variable.other.constant',
+    'variable.other.enummember',
+    'entity.other.attribute-name',
+    'meta.decorator',
+    'support.type.property-name',
+    'constant.character.escape',
+    'markup.heading',
+]:
+    assert needle in joined_scopes, f'missing scope: {needle}'
+
+font_styles = [s['settings'].get('fontStyle') for s in scoped if 'fontStyle' in s['settings']]
+assert font_styles.count('bold') == 2, f\"expected 2 bold entries, got {font_styles.count('bold')}\"
+assert font_styles.count('italic') == 11, f\"expected 11 italic entries, got {font_styles.count('italic')}\"
+assert font_styles.count('strikethrough') == 2, f\"expected 2 strikethrough entries, got {font_styles.count('strikethrough')}\"
+" "$cached_theme" 2>"$test_tmp/scope-color.err" ||
+  fail "carries the full tokenColors set across, not a subset" "$(cat "$test_tmp/scope-color.err")"
+pass "carries the full tokenColors set across, not a subset"
+
+# --- Rounded corners with a border in the theme's accent colour ----------------
+#
+# Still examining the log from the "renders with a theme..." run_capture
+# above: nothing has truncated $log_file since.
+
+assert_logged $'silicon\t.*--background\t#2e3440' \
+  "backgrounds with the plain card colour, not a darker shade, so the padding is invisible"
+assert_logged $'silicon\t.*--pad-horiz\t24' "tightens horizontal padding to 24"
+assert_logged $'silicon\t.*--pad-vert\t24' "tightens vertical padding to 24"
+assert_logged $'silicon\t.*-f\tTest Mono=32' \
+  "renders in the system monospace font at the default size"
+assert_logged '\-\-no-round-corner' "asks silicon for a plain rectangle so ImageMagick can round it instead"
+assert_logged $'magick\t.*-stroke\t#81a1c1' "strokes the corners in the theme's accent colour"
+
+# Only the four corner arcs are stroked. A full outline reads as a generic
+# wrapped frame, which is what this replaced — so assert both that the arcs are
+# drawn and that no stroked roundrectangle sneaks back in. The mask that rounds
+# the image is a separate, unstroked draw and is matched separately below.
+for angles in "180,270" "270,360" "0,90" "90,180"; do
+  assert_logged $'magick\t.*arc .* '"$angles" "draws the ${angles} corner arc"
+done
+# The rounding mask legitimately draws a roundrectangle, but with `-stroke none`
+# — it is a shape to fill, not an outline. Only a roundrectangle drawn with a
+# real stroke colour would put a frame back around the card.
+if grep $'^magick' "$log_file" | grep -F 'roundrectangle' |
+  grep -qvF $'-stroke\tnone'; then
+  fail "does not stroke a full outline around the card" "$(cat "$log_file")"
+fi
+pass "does not stroke a full outline around the card"
+
+# The mask must be drawn unstroked, or its edge picks up a hard line that the
+# downscale cannot smooth away.
+assert_logged $'magick\t.*-stroke\tnone\t.*roundrectangle' \
+  "draws the rounding mask as an unstroked shape"
+
+if ! grep -q BORDERED "$out_dir"/code-*.png 2>/dev/null; then
+  fail "the bordered image replaces silicon's plain rectangle" "$(ls -la "$out_dir")"
+fi
+pass "the bordered image replaces silicon's plain rectangle"
+
+# magick failing (or being unavailable) must not fail the capture: silicon's
+# unbordered image is still perfectly usable, and losing the capture over a
+# cosmetic post-processing step would be worse.
+rm -f "$out_dir"/code-*.png
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" \
+  OMARCHY_TEST_MAGICK_FAIL=1 run_capture
+capture_rc=$CAPTURE_EXIT
+
+if grep -q BORDERED "$out_dir"/code-*.png 2>/dev/null; then
+  fail "a failed border pass leaves silicon's plain image untouched" "$(ls -la "$out_dir")"
+fi
+pass "a failed border pass leaves silicon's plain image untouched"
+
+if ! ls "$out_dir"/code-*.png >/dev/null 2>&1; then
+  fail "the capture itself still succeeds when the border pass fails" "$(ls -la "$out_dir")"
+fi
+pass "the capture itself still succeeds when the border pass fails"
+
+assert_logged '^notify' "still sends the normal success notification when the border pass fails"
+refute_logged $'\-u\tcritical' "a failed border pass is not treated as a capture failure"
+
+if (( capture_rc != 0 )); then
+  fail "exits cleanly when only the cosmetic border pass fails" "exit code was $capture_rc"
+fi
+pass "exits cleanly when only the cosmetic border pass fails"
+
+# An unchanged colors.toml must not trigger a re-render.
+before=$(stat -c %Y "$cached_theme")
+sleep 1
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+if (( before != $(stat -c %Y "$cached_theme") )); then
+  fail "reuses the cache while the theme is unchanged" "the cache was rewritten"
+fi
+pass "reuses the cache while the theme is unchanged"
+
+# Switching themes rewrites colors.toml, which must invalidate the cache.
+touch "$colors_file"
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+if (( before == $(stat -c %Y "$cached_theme") )); then
+  fail "re-renders after the active theme changes" "the cache was not refreshed"
+fi
+pass "re-renders after the active theme changes"
+
+# A theme may ship its own file and win over the generated one.
+printf 'override' >"$theme_dir/silicon.tmTheme"
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+assert_logged "\-\-theme.*current/theme/silicon.tmTheme" "prefers a theme-provided silicon.tmTheme"
+rm -f "$theme_dir/silicon.tmTheme"
+
+# No active theme at all: still produce an image, with silicon's own default.
+rm -f "$colors_file" "$cached_theme"
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+refute_logged "\-\-theme" "falls back to silicon's built-in theme when no theme is available"
+refute_logged "\-\-background" "omits a background flag entirely when no theme is available"
+refute_logged '\-\-no-round-corner' "skips the border rather than inventing an accent colour when no theme is available"
+refute_logged '^magick' "never invokes magick when no theme is available"
+assert_logged '^silicon' "still produces an image without an Omarchy theme"
+
+cp "$ROOT/themes/nord/colors.toml" "$colors_file"
+
+# --- Cache writes are atomic ----------------------------------------------------
+
+# Simulate a render killed mid-write (SIGKILL, OOM, session teardown): the `sed
+# -f` call that fills the cache writes partial output, then dies before
+# finishing. A correct implementation renders to a temp file and only renames
+# it into place on success, so the kill leaves no trace at the cache path
+# (rather than a truncated file with a fresh mtime that the -nt check would
+# then treat as valid forever).
+rm -f "$cached_theme"
+
+write_stub sed "#!/bin/bash
+if [[ \"\$1\" == \"-f\" ]]; then
+  printf 'CORRUPT'
+  kill -KILL \$\$
+fi
+exec /usr/bin/sed \"\$@\"
+"
+
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+rm -f "$stub_bin/sed"
+
+if [[ -f $cached_theme ]] && grep -q CORRUPT "$cached_theme"; then
+  fail "a killed render never leaves a corrupt file at the cache path" "$(cat "$cached_theme")"
+fi
+pass "a killed render never leaves a corrupt file at the cache path"
+
+# The next run (real sed restored) must recover with a full, valid render
+# rather than being stuck reusing a corrupt cache.
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+if [[ ! -f $cached_theme ]] || grep -q '{{' "$cached_theme" || grep -q CORRUPT "$cached_theme"; then
+  fail "recovers with a full render after a killed attempt" "$(cat "$cached_theme" 2>&1)"
+fi
+pass "recovers with a full render after a killed attempt"
+
+# --- Configurable font, padding and corner radius -----------------------------
+
+# silicon has its own config file, but these flags are passed explicitly and
+# would override it, so the env vars are the only way a user can change them.
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" \
+  OMARCHY_CODE_FONT="JetBrains Mono=34" OMARCHY_CODE_PADDING=40 \
+  OMARCHY_CODE_CORNER_RADIUS=8 run_capture
+
+assert_logged $'silicon\t.*-f\tJetBrains Mono=34' "honours OMARCHY_CODE_FONT"
+assert_logged $'silicon\t.*--pad-horiz\t40' "honours OMARCHY_CODE_PADDING horizontally"
+assert_logged $'silicon\t.*--pad-vert\t40' "honours OMARCHY_CODE_PADDING vertically"
+assert_logged $'magick\t.*roundrectangle 0,0 [0-9]*,[0-9]* 32,32' \
+  "honours OMARCHY_CODE_CORNER_RADIUS (8 x 4 supersample)"
+
+# Defaults still apply when nothing is set.
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" run_capture
+assert_logged $'silicon\t.*-f\tTest Mono=32' "defaults to the system font at size 32"
+assert_logged $'silicon\t.*--pad-horiz\t24' "defaults to 24px padding"
+
+# The font follows `omarchy font set` the same way the colours follow
+# `omarchy theme set` — that is the whole point of not hardcoding a family.
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" \
+  OMARCHY_TEST_FONT="CaskaydiaCove Nerd Font" run_capture
+assert_logged $'silicon\t.*-f\tCaskaydiaCove Nerd Font=32' \
+  "follows the system font when it changes"
+
+# Size is its own knob so changing it does not mean pinning a family and
+# losing that tracking.
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" \
+  OMARCHY_CODE_FONT_SIZE=18 run_capture
+assert_logged $'silicon\t.*-f\tTest Mono=18' \
+  "OMARCHY_CODE_FONT_SIZE resizes without pinning the family"
+
+# silicon panics and writes nothing when handed an empty family, so a broken
+# fontconfig must not reach it: fall back to the generic family, which
+# fontconfig always resolves.
+OMARCHY_TEST_TITLE="config.rs" OMARCHY_TEST_CLIPBOARD="let x = 1;" \
+  OMARCHY_TEST_FONT="" run_capture
+assert_logged $'silicon\t.*-f\tmonospace=32' \
+  "falls back to the generic family when the system font is unknown"
+
+# --- Content detection must not guess ------------------------------------------
+
+# A miss costs one keypress; a wrong guess silently renders the snippet as the
+# wrong language. These two both used to be mislabelled by inferential rules
+# that have since been removed, so they are pinned here: C++ was read as
+# TypeScript (`std::string` matched a type-annotation pattern) and Ruby as
+# Python (both spell it `def`). Reaching the picker is the correct outcome.
+for guessy in \
+  'template <typename T>
+std::optional<T> resolve(const std::map<std::string, T> &m) { return std::nullopt; }' \
+  'class Palette
+  def initialize(colors = {})
+    @colors = colors
+  end
+end'; do
+  OMARCHY_TEST_TITLE="ryu@omarchy: ~" OMARCHY_TEST_CLIPBOARD="$guessy" \
+    OMARCHY_TEST_GUM_PICK="cpp" run_capture_tty
+  assert_logged '^gum' "asks rather than guessing a language from ambiguous content"
+done


### PR DESCRIPTION
Adds `omarchy-capture-code`, which turns code on the clipboard into a PNG matching the active Omarchy theme — saved to the screenshot directory and copied to the clipboard, ready to paste into a chat or a post.

Bound to `SUPER + SHIFT + PRINT`, and added to `Trigger → Capture` alongside Screenshot / Screenrecord / Text / Color.

`silicon` is added to `install/omarchy-base.packages` for fresh installs, and a migration installs it for existing users — the update path is `pacman -Syu` plus migrations, and does not read that manifest.

Rendering is done by `silicon`, which is in the official repos, works offline, and depends only on `fontconfig freetype2 harfbuzz oniguruma` — so it brings no browser or network round-trip into the capture path, and harfbuzz already handles ligatures, CJK mixing and monospace alignment.

## Theming

The theme is rendered on demand from `default/silicon/omarchy.tmTheme.tpl` and cached at `~/.cache/omarchy/silicon.tmTheme`, invalidated by an mtime comparison against the active theme's `colors.toml`. A theme may ship its own `silicon.tmTheme` to override it entirely.

It is deliberately **not** in the `default/themed/` pipeline. Everything there is config for an application the user lives in, regenerated on every theme switch. `silicon` is a one-shot renderer that exists for a few hundred milliseconds; putting it there would make every user pay a render on every theme switch for a feature most never invoke.

The template carries the full `tokenColors` set from the existing `default/themed/vscode-theme.json.tpl` — same TextMate scope vocabulary, including `fontStyle` — so a capture matches the highlighting the user already sees in their editor rather than a reduced subset.

`silicon --theme` accepts a filesystem path, so no syntect cache build is involved.

The font family follows `fc-match monospace` rather than being hardcoded, so `omarchy font set` changes captures the same way `omarchy theme set` does. `OMARCHY_CODE_FONT`, `OMARCHY_CODE_FONT_SIZE`, `OMARCHY_CODE_PADDING` and `OMARCHY_CODE_CORNER_RADIUS` override the defaults.

## Language detection

`silicon` needs `--language` for clipboard input, and its own fallback only matches shebang-style first lines — with no default, so detection failure is a hard error. That is the common case for a mid-file snippet, so detection runs first, in three stages:

1. **Focused window title** via `hyprctl activewindow`. Editors put the filename there, and so does GitHub in a browser.
2. **Content markers** — shebangs, `<?php`, `package` + `func`, `<!DOCTYPE html`.
3. **`gum filter`** picker.

Stage 2 only accepts markers that are *proof*, never inference. Rules keyed on type annotations, `def`, or `::` were written and then removed: across 15 sample files they read C++ as TypeScript and Ruby as Python. A miss costs one keypress in the picker; a wrong guess silently renders the snippet highlighted as the wrong language, and nothing in the result tells the user it happened. The two snippets that were mislabelled are pinned as test cases.

Two details worth calling out:

The value passed to `-l` is a **file extension**, not a language name, because syntect's `find_syntax_by_token` matches extensions first. `bat --list-languages` is tempting as a name source but ships syntaxes absent from syntect's default set, which would produce `Unsupported language`.

An extension taken from a window title is accepted only if it is in a known list. Window titles are full of dots that are not filenames — domains, version numbers, sentence ends — and without the list a browser tab yields a nonsense language.

The picker needs a terminal, and **neither the keybinding nor the menu entry has one**, so the command hands itself off to a floating terminal when it needs to prompt — by resolved absolute path, not by name. Naming it bare leaves the user looking at an empty terminal reporting the executable as missing, with no notification, because the terminal spawn itself succeeded.

That handoff also carries the resolved appearance settings across as explicit assignments. `uwsm-app` writes only argv to the app daemon's fifo, so the relaunched process starts from the systemd user manager's environment; without this every `OMARCHY_CODE_*` the user set is silently dropped the moment the picker is needed.

## Error handling

`silicon` **exits 0 even when it fails** — unsupported language, unloadable theme, unwritable output — and simply writes no file. The artifact is checked rather than the exit code; otherwise the user gets a success notification while the clipboard still holds the old contents.

ImageMagick post-processing rounds the corners and strokes only the four corner arcs in the theme's `accent`, the same value Hyprland uses for the active window border. A full outline read as a generic wrapped frame. Post-processing is cosmetic, so if `magick` fails the unbordered image is kept rather than losing the capture; the result is written to a temp file and moved into place only on success.

## Scope coverage

Transliterating vscode's `tokenColors` turned out not to be enough. That vocabulary and syntect's Sublime grammars disagree, and TextMate matching is prefix-based — a rule for `meta.function-call.generic` never matches a scope of `meta.function-call`. Method calls stayed unstyled in every language as a result.

Probing each candidate scope with a unique colour showed what the grammars actually emit, which added `variable.function`, `meta.function-call`, `variable.other.member`, `entity.name.class`, `constant.other`, `meta.annotation` and `support.other`.

Verified across 15 languages — TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, Ruby, PHP, shell, JSON, YAML, SQL, Lua — every scope the grammars emit is now styled, bar the outermost `source`, which every token carries and which would flatten the whole image to one colour.

## Tests

`test/shell.d/capture-code-test.sh` — 92 assertions, using the PATH-stub and command-log pattern from `channel-test.sh`. No network, no clipboard, no compositor: `silicon`, `magick`, `hyprctl`, `wl-paste`, `wl-copy`, `gum` and `omarchy-font-current` are stubbed against a throwaway `HOME` and `XDG_CACHE_HOME`, so the run never depends on the developer's real theme or font state.

Coverage includes the three-stage cascade and its cancel paths, the no-tty handoff and the settings it carries, `copy`/`save`/default output modes, theme cache generation and invalidation, the theme-provided override, the font/padding/corner-radius knobs and their defaults, silicon's exit-0-on-failure path, and the magick degrade path.

Every assertion was mutation-tested — the behaviour was deliberately broken and the matching assertion confirmed to fail — before this was considered done.
