### PR TITLE
Fix WhatsApp Slim migration targeting brave-origin-beta instead of brave-origin

### DIFF
--- a/migrations/1785543725.sh
+++ b/migrations/1785543725.sh
@@ -15,6 +15,6 @@ add_whatsapp_slim_extension() {
   fi
 }
 
-for conf in chromium chrome google-chrome brave brave-beta brave-nightly brave-origin-beta microsoft-edge-stable; do
+for conf in chromium chrome google-chrome brave brave-beta brave-nightly brave-origin microsoft-edge-stable; do
   add_whatsapp_slim_extension "$HOME/.config/$conf-flags.conf"
 done

--- a/migrations/1785543725.sh
+++ b/migrations/1785543725.sh
@@ -11,6 +11,7 @@ add_whatsapp_slim_extension() {
   if grep -q "^--load-extension=" "$file"; then
     sed -i --follow-symlinks "s|^--load-extension=\(.*\)$|--load-extension=\1,$WHATSAPP_SLIM_EXT|" "$file"
   else
+    [[ -n $(tail -c1 "$file") ]] && echo >>"$file"
     echo "--load-extension=$WHATSAPP_SLIM_EXT" >>"$file"
   fi
 }

--- a/migrations/1785591762.sh
+++ b/migrations/1785591762.sh
@@ -11,6 +11,7 @@ add_whatsapp_slim_extension() {
   if grep -q "^--load-extension=" "$file"; then
     sed -i --follow-symlinks "s|^--load-extension=\(.*\)$|--load-extension=\1,$WHATSAPP_SLIM_EXT|" "$file"
   else
+    [[ -n $(tail -c1 "$file") ]] && echo >>"$file"
     echo "--load-extension=$WHATSAPP_SLIM_EXT" >>"$file"
   fi
 }

--- a/migrations/1785591762.sh
+++ b/migrations/1785591762.sh
@@ -1,0 +1,18 @@
+echo "Add WhatsApp Slim extension to Brave Origin flags for existing installs"
+
+WHATSAPP_SLIM_EXT="$OMARCHY_PATH/default/chromium/extensions/whatsapp-slim"
+
+add_whatsapp_slim_extension() {
+  local file=$1
+
+  [[ -f $file ]] || return 0
+  grep -q "extensions/whatsapp-slim" "$file" && return 0
+
+  if grep -q "^--load-extension=" "$file"; then
+    sed -i --follow-symlinks "s|^--load-extension=\(.*\)$|--load-extension=\1,$WHATSAPP_SLIM_EXT|" "$file"
+  else
+    echo "--load-extension=$WHATSAPP_SLIM_EXT" >>"$file"
+  fi
+}
+
+add_whatsapp_slim_extension "$HOME/.config/brave-origin-flags.conf"


### PR DESCRIPTION
## Summary

Fixes #6476. Migration `1785543725.sh` (from #6473, "Collapse WhatsApp Web to a Signal-style avatar rail in slim windows") appends the `whatsapp-slim` extension to browser flags files, but the browser list contains `brave-origin-beta` instead of `brave-origin`.

Omarchy migrated from Brave Origin Beta to Brave Origin stable in migration `1784510887.sh`, which renames `~/.config/brave-origin-beta-flags.conf` → `~/.config/brave-origin-flags.conf`. The WhatsApp Slim migration kept the stale `brave-origin-beta` entry, so it targets a config file that no longer exists and `whatsapp-slim` never loads in Brave Origin (it works in Chromium).

## Changes

1. Replace `brave-origin-beta` with `brave-origin` in `migrations/1785543725.sh` so new installs append the extension to `~/.config/brave-origin-flags.conf`.
2. Add `migrations/1785591762.sh` — an idempotent follow-up migration for existing installs that already ran `1785543725.sh`, appending `whatsapp-slim` to `~/.config/brave-origin-flags.conf` if it is missing. It mirrors the original helper logic (existence + grep guard, `--load-extension` append or new line), so it no-ops when already applied.