### PR TITLE
Dismiss bar panels when clicking on another monitor

### DIFF
--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -53,10 +53,10 @@ PanelWindow {
   property bool focusPrimed: false
 
   // Item that should take keyboard focus once the panel maps. Typically a
-  // PanelKeyCatcher inside the panel content. Layer-shell grants focus to
-  // the surface at map time, but Qt still needs an active-focus target
-  // inside the surface for Keys.onPressed handlers to fire. Schedule the
-  // focus through Qt.callLater so it runs after the surface is fully
+  // PanelKeyCatcher inside the panel content. Layer-shell grants focus to the
+  // surface during the Exclusive prime, but Qt still needs an active-focus
+  // target inside the surface for Keys.onPressed handlers to fire. Schedule
+  // the focus through Qt.callLater so it runs after the surface is fully
   // mapped and child items have completed layout.
   property Item focusTarget: null
 
@@ -69,6 +69,10 @@ PanelWindow {
   function close() {
     if (owner && "close" in owner) owner.close()
     else root.open = false
+  }
+
+  function beginFocusPrime() {
+    if (open && backingWindowVisible) focusPrimeTimer.restart()
   }
 
   // --- screen + lifetime ---------------------------------------------------
@@ -94,6 +98,8 @@ PanelWindow {
   WlrLayershell.keyboardFocus: open
     ? (focusPrimed ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.Exclusive)
     : WlrKeyboardFocus.None
+
+  onBackingWindowVisibleChanged: beginFocusPrime()
 
   // Full-screen layer-shell. The visible card is positioned inside via
   // `cardOrigin`. The `mask` below makes the bar area click-through (so
@@ -220,7 +226,7 @@ PanelWindow {
   onOpenChanged: {
     if (open) {
       focusPrimed = false
-      focusPrimeTimer.restart()
+      beginFocusPrime()
       if (focusTarget) Qt.callLater(function() {
         if (root.open && root.focusTarget) root.focusTarget.forceActiveFocus()
       })
@@ -244,9 +250,10 @@ PanelWindow {
 
   Timer {
     id: focusPrimeTimer
-    // Leave enough time for multiple Qt/Wayland commit cycles while keeping
-    // the compositor-wide Exclusive phase imperceptibly short. This interval
-    // is covered by the immediate hide/re-summon acceptance case.
+    // Leave enough time for multiple Qt/Wayland commit cycles after the
+    // backing window becomes visible while keeping the compositor-wide
+    // Exclusive phase imperceptibly short. This interval is covered by the
+    // immediate hide/re-summon acceptance case.
     interval: 75
     onTriggered: if (root.open) root.focusPrimed = true
   }
@@ -307,6 +314,7 @@ PanelWindow {
     }
 
     function forwardBarClick(px, py, button) {
+      if (button !== Qt.LeftButton && button !== Qt.RightButton && button !== Qt.MiddleButton) return false
       var target = pressTargetAt(px, py)
       if (!target) return false
       target.triggerPress(button)
@@ -387,7 +395,10 @@ PanelWindow {
 
     // Swallow clicks on the card so they don't bubble to the dismissal
     // MouseArea behind us.
-    MouseArea { anchors.fill: parent }
+    MouseArea {
+      anchors.fill: parent
+      acceptedButtons: Qt.AllButtons
+    }
 
     Item {
       id: contentHolder

--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -6,13 +6,12 @@ import qs.Commons
 // Layer-shell popup attached to a bar widget icon, designed for
 // click-driven AND keyboard-driven panels (e.g. SUPER+CTRL+W summon).
 //
-// Built on PanelWindow with WlrKeyboardFocus.OnDemand rather than
-// PopupWindow (xdg-popup). Layer-shell surfaces that declare any keyboard
-// interactivity get keyboard focus from Hyprland *at map time*, which is
-// the protocol-level equivalent of focus-on-launch for xdg-toplevels.
-// xdg-popups don't get that — they only receive keys after a click/hover
-// routes focus through their parent surface — so keyboard-summoned popups
-// fell flat without it.
+// Built on PanelWindow with a brief WlrKeyboardFocus.Exclusive prime followed
+// by OnDemand rather than PopupWindow (xdg-popup). The prime acquires focus
+// both when the surface maps and when it reopens while still mapped for its
+// fade-out. xdg-popups don't get that — they only receive keys after a
+// click/hover routes focus through their parent surface — so keyboard-summoned
+// popups fell flat without it.
 //
 // Exclusive would also grant map-time focus, but it makes Hyprland route
 // *every* pointer event to the exclusive surface no matter which output
@@ -245,6 +244,9 @@ PanelWindow {
 
   Timer {
     id: focusPrimeTimer
+    // Leave enough time for multiple Qt/Wayland commit cycles while keeping
+    // the compositor-wide Exclusive phase imperceptibly short. This interval
+    // is covered by the immediate hide/re-summon acceptance case.
     interval: 75
     onTriggered: if (root.open) root.focusPrimed = true
   }
@@ -272,6 +274,7 @@ PanelWindow {
     id: dismissArea
     anchors.fill: parent
     enabled: root.open
+    acceptedButtons: Qt.AllButtons
     hoverEnabled: true
     property bool hoveringBar: false
     cursorShape: hoveringBar ? Qt.PointingHandCursor : Qt.ArrowCursor
@@ -313,7 +316,10 @@ PanelWindow {
     onPositionChanged: function(mouse) { hoveringBar = inBarRegion(mouse.x, mouse.y) }
     onExited: hoveringBar = false
     onClicked: function(mouse) {
-      if (inBarRegion(mouse.x, mouse.y) && forwardBarClick(mouse.x, mouse.y, mouse.button)) return
+      // While Exclusive is priming, Hyprland may route a click from another
+      // output here with translated coordinates. Never interpret that as a
+      // click on this output's bar.
+      if (root.focusPrimed && inBarRegion(mouse.x, mouse.y) && forwardBarClick(mouse.x, mouse.y, mouse.button)) return
       root.close()
     }
   }
@@ -353,7 +359,8 @@ PanelWindow {
 
         MouseArea {
           anchors.fill: parent
-          onClicked: root.close()
+          acceptedButtons: Qt.AllButtons
+          onPressed: root.close()
         }
       }
     }

--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -51,6 +51,7 @@ PanelWindow {
   property int gap: Style.gapsOut  // distance between bar edge and panel
   property bool popoutSwitching: false
   property bool popoutSwitchClosing: false
+  property bool focusPrimed: false
 
   // Item that should take keyboard focus once the panel maps. Typically a
   // PanelKeyCatcher inside the panel content. Layer-shell grants focus to
@@ -85,12 +86,15 @@ PanelWindow {
   // animate, but keyboard/click ownership must release the moment the
   // logical close fires — otherwise the user is locked out for 140ms.
   //
-  // OnDemand, not Exclusive: an exclusive layer surface takes over pointer
-  // hit-testing compositor-wide, so clicks on other outputs get forced onto
-  // this surface instead of reaching the dismissal windows below. OnDemand
-  // still grabs focus when the surface maps, and follow-mouse can't steal it
-  // back because this surface plus the dismissal windows cover every output.
-  WlrLayershell.keyboardFocus: open ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
+  // Prime with Exclusive on every open, then settle on OnDemand. Hyprland
+  // focuses OnDemand when a surface first maps, but not when an already-mapped
+  // fade-out surface changes from None back to OnDemand. Exclusive also takes
+  // focus when the previously focused application has constrained the pointer.
+  // The brief prime covers both cases; OnDemand then releases compositor-wide
+  // pointer hit-testing so clicks can reach the dismissal windows below.
+  WlrLayershell.keyboardFocus: open
+    ? (focusPrimed ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.Exclusive)
+    : WlrKeyboardFocus.None
 
   // Full-screen layer-shell. The visible card is positioned inside via
   // `cardOrigin`. The `mask` below makes the bar area click-through (so
@@ -215,9 +219,16 @@ PanelWindow {
   // Coordinate on `open`, not `visible`. `visible` lags into the fade-out
   // animation, which made ownership transfer to a sibling popup race.
   onOpenChanged: {
-    if (open && focusTarget) Qt.callLater(function() {
-      if (root.open && root.focusTarget) root.focusTarget.forceActiveFocus()
-    })
+    if (open) {
+      focusPrimed = false
+      focusPrimeTimer.restart()
+      if (focusTarget) Qt.callLater(function() {
+        if (root.open && root.focusTarget) root.focusTarget.forceActiveFocus()
+      })
+    } else {
+      focusPrimeTimer.stop()
+      focusPrimed = false
+    }
     if (!bar) return
     if (open) {
       popoutSwitchClosing = false
@@ -230,6 +241,12 @@ PanelWindow {
       if (bar.activePopout === coordinatorKey) bar.releasePopout(coordinatorKey)
       if (popoutSwitchClosing) closeSwitchTimer.restart()
     }
+  }
+
+  Timer {
+    id: focusPrimeTimer
+    interval: 75
+    onTriggered: if (root.open) root.focusPrimed = true
   }
 
   Timer {

--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -6,12 +6,18 @@ import qs.Commons
 // Layer-shell popup attached to a bar widget icon, designed for
 // click-driven AND keyboard-driven panels (e.g. SUPER+CTRL+W summon).
 //
-// Built on PanelWindow with WlrKeyboardFocus.Exclusive rather than
-// PopupWindow (xdg-popup). Layer-shell surfaces declared Exclusive get
-// keyboard focus from Hyprland *at map time*, which is the protocol-level
-// equivalent of focus-on-launch for xdg-toplevels. xdg-popups don't get
-// that — they only receive keys after a click/hover routes focus through
-// their parent surface — so keyboard-summoned popups fell flat without it.
+// Built on PanelWindow with WlrKeyboardFocus.OnDemand rather than
+// PopupWindow (xdg-popup). Layer-shell surfaces that declare any keyboard
+// interactivity get keyboard focus from Hyprland *at map time*, which is
+// the protocol-level equivalent of focus-on-launch for xdg-toplevels.
+// xdg-popups don't get that — they only receive keys after a click/hover
+// routes focus through their parent surface — so keyboard-summoned popups
+// fell flat without it.
+//
+// Exclusive would also grant map-time focus, but it makes Hyprland route
+// *every* pointer event to the exclusive surface no matter which output
+// the cursor is over, which leaves clicks on any other monitor unable to
+// reach the dismissal surfaces below.
 //
 // API is a subset of Common.PopupCard: anchorItem, owner, bar, open,
 // padding, margin, contentWidth/Height, centerOnBar, default contentItem.
@@ -78,7 +84,13 @@ PanelWindow {
   // mapped during the fade-out so the opacity animation has something to
   // animate, but keyboard/click ownership must release the moment the
   // logical close fires — otherwise the user is locked out for 140ms.
-  WlrLayershell.keyboardFocus: open ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+  //
+  // OnDemand, not Exclusive: an exclusive layer surface takes over pointer
+  // hit-testing compositor-wide, so clicks on other outputs get forced onto
+  // this surface instead of reaching the dismissal windows below. OnDemand
+  // still grabs focus when the surface maps, and follow-mouse can't steal it
+  // back because this surface plus the dismissal windows cover every output.
+  WlrLayershell.keyboardFocus: open ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
 
   // Full-screen layer-shell. The visible card is positioned inside via
   // `cardOrigin`. The `mask` below makes the bar area click-through (so
@@ -286,6 +298,47 @@ PanelWindow {
     onClicked: function(mouse) {
       if (inBarRegion(mouse.x, mouse.y) && forwardBarClick(mouse.x, mouse.y, mouse.button)) return
       root.close()
+    }
+  }
+
+  // The panel surface only spans the anchor's screen, and the compositor
+  // hit-tests pointer input per output, so `dismissArea` above can never see
+  // a click on another monitor. Give every other output a transparent twin
+  // whose only job is to catch that click. They exist only while the panel is
+  // logically open (not during the fade-out, matching `dismissArea.enabled`).
+  //
+  // Keyboard focus is None: these must catch the pointer without taking focus
+  // from the panel when the cursor merely crosses onto their output.
+  Variants {
+    model: root.open ? Quickshell.screens : []
+
+    delegate: Component {
+      PanelWindow {
+        required property var modelData
+
+        screen: modelData
+        // Compare by output name: the anchor screen must be known before any
+        // twin maps, or a twin would cover the panel's own output.
+        visible: root.open && !!root.screen && modelData.name !== root.screen.name
+        color: "transparent"
+        exclusionMode: ExclusionMode.Ignore
+
+        WlrLayershell.namespace: "omarchy-keyboard-panel-dismiss"
+        WlrLayershell.layer: WlrLayer.Overlay
+        WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+
+        anchors {
+          top: true
+          bottom: true
+          left: true
+          right: true
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: root.close()
+        }
+      }
     }
   }
 

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -351,9 +351,9 @@ Panel {
 
   Component.onCompleted: refresh()
 
-  // KeyboardPanel takes Exclusive focus at map-time, so SUPER-bound IPC
-  // summons land with j/k ready to navigate. Keep a default landing point,
-  // but don't paint the cursor until hover or the first navigation key.
+  // KeyboardPanel primes focus at open-time, so SUPER-bound IPC summons land
+  // with j/k ready to navigate. Keep a default landing point, but don't paint
+  // the cursor until hover or the first navigation key.
   onOpenedChanged: {
     if (opened) {
       refresh()

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -283,10 +283,8 @@ Panel {
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
 
-  // The panel below is its own layer-shell with Exclusive keyboard focus,
-  // so Hyprland grants focus when the surface is mapped (opened flips
-  // to true). That's what makes the SUPER+CTRL+W keybind actually work
-  // — OnDemand only grants focus on click/hover.
+  // KeyboardPanel primes layer-shell focus whenever the panel opens. That's
+  // what makes the SUPER+CTRL+W keybind land here with navigation ready.
   onOpenedChanged: {
     if (opened) {
       refresh(true)

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1054,7 +1054,7 @@ Panel {
 
   // Keyboard-driven popup anchored to the bar widget icon. The shared
   // KeyboardPanel handles the layer-shell PanelWindow scaffolding
-  // (Exclusive focus on map, screen binding, anchored-to-icon positioning,
+  // (focus priming on open, screen binding, anchored-to-icon positioning,
   // outside-click via an overlay MouseArea + Region mask that lets the bar
   // remain clickable, fade animation, popout coordination). What stays
   // here is the wifi-specific UI inside.

--- a/test/acceptance.d/panels-test.sh
+++ b/test/acceptance.d/panels-test.sh
@@ -98,6 +98,18 @@ screenshot "success-panel-navigation-02-next"
 hide_panels
 wait_until "keyboard-navigated panel closes" 15 layer_absent "omarchy-keyboard-panel"
 
+# Reopening during the fade keeps the layer surface mapped. Verify the focus
+# prime reacquires compositor keyboard focus instead of relying on map-time
+# OnDemand behavior, which would leave Escape in the previously focused app.
+omarchy-shell shell summon omarchy.bluetooth >/dev/null
+wait_until "focus-prime panel opens" 15 layer_present "omarchy-keyboard-panel"
+omarchy-shell shell hide omarchy.bluetooth >/dev/null
+omarchy-shell shell summon omarchy.bluetooth >/dev/null
+sleep 1
+screenshot "success-panel-focus-prime-reopened"
+wtype -k Escape
+wait_until "Escape closes a panel reopened during fade" 15 layer_absent "omarchy-keyboard-panel"
+
 trap - EXIT
 restore_weather
 exit $status

--- a/test/acceptance.d/panels-test.sh
+++ b/test/acceptance.d/panels-test.sh
@@ -103,8 +103,13 @@ wait_until "keyboard-navigated panel closes" 15 layer_absent "omarchy-keyboard-p
 # OnDemand behavior, which would leave Escape in the previously focused app.
 omarchy-shell shell summon omarchy.bluetooth >/dev/null
 wait_until "focus-prime panel opens" 15 layer_present "omarchy-keyboard-panel"
+if (( $(hyprctl -j monitors | jq length) == 1 )); then
+  layer_absent "omarchy-keyboard-panel-dismiss" || fail "single-monitor panel has no dismissal twin"
+  pass "single-monitor panel has no dismissal twin"
+fi
 omarchy-shell shell hide omarchy.bluetooth >/dev/null
 omarchy-shell shell summon omarchy.bluetooth >/dev/null
+wait_until "focus-prime panel reopens" 15 layer_present "omarchy-keyboard-panel"
 sleep 1
 screenshot "success-panel-focus-prime-reopened"
 wtype -k Escape


### PR DESCRIPTION
## Description

`KeyboardPanel` creates its dismissal surface only on the anchor widget's screen, so an outside click on any other monitor never reaches it and the panel stays open.

Two changes, both required:

- Use `WlrKeyboardFocus.OnDemand` instead of `Exclusive`. An exclusive layer surface takes over pointer hit-testing compositor-wide, so clicks on other outputs are forced onto the panel surface with translated coordinates rather than reaching anything else. `OnDemand` still grants keyboard focus when the surface maps, so keyboard-summoned panels keep working.
- Give every other output a transparent, keyboard-inert dismissal surface while the panel is open.

`OnDemand` alone leaves nothing to catch the click; the dismissal surfaces alone are never hit-tested while the panel holds an exclusive grab.

## Motivation

Opening Audio, Network, Bluetooth, Display or Power on one monitor and clicking anywhere on another leaves the panel open. Outside-click dismissal works only on the monitor the panel was opened from.

The non-obvious half is why adding surfaces on the remaining outputs is not sufficient on its own. In `CInputManager::mouseMoveUnified`, Hyprland restricts pointer hit-testing to the exclusive layer surfaces whenever any exist, and falls back to the first one by identity when the cursor is not over it. While the panel holds `Exclusive`, it therefore receives clicks from every output and nothing else can be hit. `CLayerSurface` grants map-time keyboard focus for any interactivity other than `none`, so `OnDemand` preserves the focus-on-summon behaviour the exclusive grab was there for.

Reported and diagnosed by @Xclipsen in #6462, including the finding that the exclusive grab, not the full-screen input mask, is the blocking factor.

Fixes #6462
