### PR TITLE
Stop long fastfetch values from wrapping over the About logo

### DIFF
--- a/etc/fastfetch/config.jsonc
+++ b/etc/fastfetch/config.jsonc
@@ -10,6 +10,9 @@
       "left": 2
     }
   },
+  "display": {
+    "disableLinewrap": true
+  },
   "modules": [
     "break",
     {


### PR DESCRIPTION
## Problem

`omarchy about` runs `fastfetch` against `etc/fastfetch/config.jsonc`, which pairs a logo with a right-hand info column. The config never disables terminal line wrap, so any value longer than the remaining width wraps back to **column 0** — directly on top of the logo. The layout collapses and content scrolls off the top.

The packages line triggers this on most systems once a few Flatpaks are installed:

```
│ ├󰏖: 13 (flatpak-system), 12 (flatpak-user), 1625 (
pacman)          <- overwrites the logo column
```

`fastfetch --help disable-linewrap` reports `Default: true`, but fastfetch 2.66.0 does not emit the escape unless it is set explicitly:

```
[no flag]                  -> 0 occurrences of \e[?7l
[--disable-linewrap true]  -> 1
[--disable-linewrap false] -> 0
```

## Fix

Set `display.disableLinewrap` in the shipped config. Overlong values now clip at the right edge instead of reflowing onto the logo.

This is generic — it also covers long GPU names, disk mount labels and long theme names, not just the packages line.

## Verification

Captured from the real `omarchy-launch-about` float (875x600) on Omarchy `4.0.0.r1485.gfa95901-1`, fastfetch 2.66.0, kitty 0.48.1.

**Before:** `pacman)` wraps into the logo, `Hardware` header pushed off the top.
**After:** logo intact, `Hardware` header visible, packages line clips at the edge.

Also verified at 80 columns via `tmux capture-pane`, which reproduces the same before/after.

## Trade-off

Clipping loses the tail of an overlong line, and with wrap disabled the string's final character lands in the last column. That is a per-line cosmetic cost in exchange for the layout surviving, and it only affects lines that were already unreadable.

## Related

- Closes #4981
- Same root cause as #4013 and #5455 (both closed unfixed)
- #5030 attempted this by shelling out to `hyprctl` + `jq` to drop the logo on low-resolution displays, and was closed. This needs no scripting and no resolution detection.
