### PR TITLE
Bridge D-Bus screensaver inhibits to the idle service (#6475)

### DIFF
--- a/bin/omarchy-system-idle-inhibit-bridge
+++ b/bin/omarchy-system-idle-inhibit-bridge
@@ -1,0 +1,199 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Bridge D-Bus screensaver inhibit requests to the idle service
+# omarchy:group=system
+# omarchy:hidden=true
+
+# Quickshell's IdleMonitor (respectInhibitors: true) only understands the
+# Wayland zwp_idle_inhibit_manager_v1 protocol. It replaced hypridle, which
+# also registered org.freedesktop.ScreenSaver on the session bus and honored
+# the older D-Bus Inhibit()/UnInhibit() API that browsers and video players
+# still call instead. With nothing owning that name in Quattro, those calls go
+# nowhere and the screensaver/lock fire mid-playback (#6475).
+#
+# This process owns org.freedesktop.ScreenSaver and forwards inhibit state to
+# the idle service's own IPC target rather than reimplementing idle handling
+# here. Every count sent to it is the *absolute* number of inhibits currently
+# held, never a delta, so a crash-and-restart of this bridge (or a call missed
+# while the shell was reloading) self-heals on the next Inhibit/UnInhibit
+# instead of leaving idling stuck disabled.
+#
+# Python rather than bash, alone among the commands here, for the same reason
+# as omarchy-file-select: serving method calls means holding a single live
+# D-Bus connection for the life of the process, and no shell-callable client
+# (busctl, gdbus, dbus-send) can do that.
+
+import subprocess
+import sys
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+BUS_NAME = "org.freedesktop.ScreenSaver"
+INTERFACE = "org.freedesktop.ScreenSaver"
+
+# Some clients (older KDE tooling in particular) still call the pre-object-path
+# convention object path. Registering both means neither is left unserved.
+OBJECT_PATHS = ("/org/freedesktop/ScreenSaver", "/ScreenSaver")
+
+INTROSPECTION_XML = """
+<node>
+  <interface name="org.freedesktop.ScreenSaver">
+    <method name="Inhibit">
+      <arg type="s" name="application_name" direction="in"/>
+      <arg type="s" name="reason_for_inhibit" direction="in"/>
+      <arg type="u" name="cookie" direction="out"/>
+    </method>
+    <method name="UnInhibit">
+      <arg type="u" name="cookie" direction="in"/>
+    </method>
+    <method name="GetActive">
+      <arg type="b" name="active" direction="out"/>
+    </method>
+  </interface>
+</node>
+"""
+
+# Exit 0 when another owner already holds the bus name (a user-installed tool,
+# or the losing side of a restart race): that owner is presumably working, and
+# Restart=on-failure should not turn this into a restart loop. Any other exit
+# reaching main() is a real fault and should restart.
+EXIT_NAME_TAKEN = 0
+EXIT_ERROR = 1
+
+
+def sync_idle_service(count):
+    # Best-effort. omarchy-shell already degrades to a no-op when the shell
+    # isn't running or reloading, which is exactly the behavior wanted here:
+    # a missed update self-heals on the next call since we always send the
+    # absolute count.
+    try:
+        subprocess.run(
+            ["omarchy-shell", "-q", "idle", "setDbusInhibitors", str(count)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+class Bridge:
+    def __init__(self):
+        self.next_cookie = 1
+        self.cookies = {}  # cookie (uint32) -> holder's unique bus name
+        self.watches = {}  # unique bus name -> NameOwnerChanged subscription id
+        self.connection = None
+
+    def handle_method_call(self, connection, sender, path, interface, method, params, invocation):
+        if method == "Inhibit":
+            self._inhibit(sender, invocation)
+        elif method == "UnInhibit":
+            (cookie,) = params.unpack()
+            self._uninhibit(cookie, invocation)
+        elif method == "GetActive":
+            # Nothing here tracks whether the screensaver is actually showing;
+            # only the inhibit half of this interface is in scope for #6475.
+            invocation.return_value(GLib.Variant("(b)", (False,)))
+        else:
+            invocation.return_dbus_error(
+                "org.freedesktop.DBus.Error.UnknownMethod", "No such method"
+            )
+
+    def _inhibit(self, sender, invocation):
+        cookie = self.next_cookie
+        self.next_cookie += 1
+        self.cookies[cookie] = sender
+        self._watch_sender(sender)
+        sync_idle_service(len(self.cookies))
+        invocation.return_value(GLib.Variant("(u)", (cookie,)))
+
+    def _uninhibit(self, cookie, invocation):
+        self.cookies.pop(cookie, None)
+        sync_idle_service(len(self.cookies))
+        invocation.return_value(None)
+
+    def _watch_sender(self, sender):
+        if sender in self.watches:
+            return
+        self.watches[sender] = self.connection.signal_subscribe(
+            "org.freedesktop.DBus",
+            "org.freedesktop.DBus",
+            "NameOwnerChanged",
+            "/org/freedesktop/DBus",
+            sender,
+            Gio.DBusSignalFlags.NONE,
+            self._on_name_owner_changed,
+        )
+
+    def _on_name_owner_changed(self, connection, sender, path, interface, signal, params):
+        name, old_owner, new_owner = params.unpack()
+        if new_owner:
+            return
+
+        # The connection holding one or more cookies dropped off the bus
+        # (crash, kill, normal exit) without calling UnInhibit. The spec's
+        # "until UnInhibit is called or the calling process exits" is what
+        # keeps a crashed video player from leaving idling suppressed for the
+        # rest of the session.
+        stale = [cookie for cookie, holder in self.cookies.items() if holder == name]
+        for cookie in stale:
+            self.cookies.pop(cookie, None)
+
+        subscription = self.watches.pop(name, None)
+        if subscription is not None:
+            connection.signal_unsubscribe(subscription)
+
+        if stale:
+            sync_idle_service(len(self.cookies))
+
+
+bridge = Bridge()
+
+
+def on_bus_acquired(connection, name):
+    bridge.connection = connection
+    node_info = Gio.DBusNodeInfo.new_for_xml(INTROSPECTION_XML)
+    interface_info = node_info.interfaces[0]
+
+    for object_path in OBJECT_PATHS:
+        connection.register_object(
+            object_path,
+            interface_info,
+            bridge.handle_method_call,
+            None,
+            None,
+        )
+
+    # Reset on every (re)start, including after a crash: a bridge that died
+    # while holding inhibits must not leave the idle service believing it
+    # still does, with no further Inhibit/UnInhibit call ever coming to
+    # correct it.
+    sync_idle_service(0)
+
+
+def on_name_lost(connection, name):
+    sys.exit(EXIT_NAME_TAKEN)
+
+
+def main():
+    loop = GLib.MainLoop()
+    Gio.bus_own_name(
+        Gio.BusType.SESSION,
+        BUS_NAME,
+        Gio.BusNameOwnerFlags.NONE,
+        None,
+        on_bus_acquired,
+        on_name_lost,
+    )
+    loop.run()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except GLib.Error as error:
+        print("omarchy-system-idle-inhibit-bridge: %s" % error.message, file=sys.stderr)
+        sys.exit(EXIT_ERROR)

--- a/default/systemd/user/omarchy-idle-inhibit-bridge.service
+++ b/default/systemd/user/omarchy-idle-inhibit-bridge.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Bridge D-Bus screensaver inhibit requests (org.freedesktop.ScreenSaver) to the Omarchy idle service
+Documentation=https://github.com/basecamp/omarchy/issues/6475
+# Needs a live session bus, and needs WAYLAND_DISPLAY (via uwsm) to reach
+# omarchy-shell, so follow the same gating as omarchy-fcitx5.service.
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-system-idle-inhibit-bridge
+# on-failure, not always: a clean exit means org.freedesktop.ScreenSaver is
+# already owned by something else (a user-installed tool, or the losing side
+# of a restart race), and that other owner is presumably working fine.
+# Restarting into the same losing race forever would just be noise.
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -17,4 +17,5 @@ systemctl --user enable --now \
   omarchy-recover-internal-monitor.service \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
-  omarchy-fcitx5.service
+  omarchy-fcitx5.service \
+  omarchy-idle-inhibit-bridge.service

--- a/migrations/1785608166.sh
+++ b/migrations/1785608166.sh
@@ -1,0 +1,34 @@
+echo "Fix D-Bus idle inhibits (org.freedesktop.ScreenSaver) being silently dropped during video playback"
+
+# Quattro's Quickshell idle service only understands the Wayland
+# idle-inhibit protocol (IdleMonitor { respectInhibitors: true }). Nothing
+# replaced hypridle's ownership of org.freedesktop.ScreenSaver on the session
+# bus, so every D-Bus Inhibit() call from browsers and video players was
+# silently dropped and the screensaver/lock fired mid-playback (#6475).
+#
+# omarchy-system-idle-inhibit-bridge now owns that bus name and forwards
+# inhibit state to the idle service's IPC target.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# Enable without --now, and start by hand further down only when there is a
+# session to start into, matching the fcitx5 migration: `systemctl enable`
+# needs a live user manager, which an `omarchy update` from a TTY does not
+# have, so fall back to writing exactly the symlink it would have written
+# rather than silently leaving this unenabled.
+if ! systemctl --user enable omarchy-idle-inhibit-bridge.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-idle-inhibit-bridge.service \
+    "$wants_dir/omarchy-idle-inhibit-bridge.service"
+fi
+
+# Outside a graphical session (an update over SSH) there is nothing to start
+# into: the unit's own ConditionEnvironment would skip the start anyway, and
+# the next graphical login starts it. The enablement above is the whole job.
+if systemctl --user is-active --quiet graphical-session.target; then
+  if ! error=$(systemctl --user start omarchy-idle-inhibit-bridge.service 2>&1); then
+    echo "Could not start omarchy-idle-inhibit-bridge.service: $error"
+    echo "D-Bus idle inhibits (video players, browsers) will not be honored until the next login."
+  fi
+fi

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -4,6 +4,16 @@ function secondsFromConfig(value, fallback) {
   return Math.floor(n)
 }
 
+// The D-Bus inhibit bridge always reports the absolute number of inhibits it
+// currently holds rather than a delta (so a crash-and-restart of that process
+// self-heals instead of drifting). Anything unparsable or negative floors to
+// zero -- a bridge that fails to report is not grounds to block idling.
+function inhibitorCountFromValue(value) {
+  var n = Number(value)
+  if (!isFinite(n) || n < 0) return 0
+  return Math.floor(n)
+}
+
 function eventParts(event, count) {
   try {
     if (event && event.parse) return event.parse(count)
@@ -46,6 +56,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
+    inhibitorCountFromValue: inhibitorCountFromValue,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -22,10 +22,16 @@ Item {
   readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
-  readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
+  // dbusInhibitors mirrors the count last reported by the D-Bus idle inhibit
+  // bridge (org.freedesktop.ScreenSaver). Quickshell's IdleMonitor only honors
+  // the Wayland idle-inhibit protocol, so without that bridge owning the bus
+  // name, Inhibit() calls from browsers and video players go nowhere and the
+  // screensaver/lock fire mid-playback (#6475).
+  readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake && root.dbusInhibitors === 0
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
   property bool stayAwake: false
+  property int dbusInhibitors: 0
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
   property bool pendingStayAwakePersist: false
@@ -183,6 +189,7 @@ Item {
       stayAwake: root.stayAwake,
       stayAwakeStateLoaded: root.stayAwakeStateLoaded,
       stayAwakeStatePath: root.stayAwakeStatePath,
+      dbusInhibitors: root.dbusInhibitors,
       idle: idleMonitor.isIdle,
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
@@ -245,6 +252,24 @@ Item {
 
   function setIdleEnabled(value) {
     return applyStayAwake(!value, true, "ipc")
+  }
+
+  function applyDbusInhibitors(value) {
+    var next = IdleModel.inhibitorCountFromValue(value)
+    if (next === root.dbusInhibitors) return root.dbusInhibitors
+
+    var wasInhibited = root.dbusInhibitors > 0
+    root.dbusInhibitors = next
+    var isInhibited = next > 0
+
+    logEvent("dbus-inhibit", "count=" + next)
+
+    if (wasInhibited !== isInhibited) {
+      if (isInhibited) cancelIdleCycle("dbus-inhibit")
+      else Qt.callLater(root.handleIdleChanged)
+    }
+
+    return root.dbusInhibitors
   }
 
   IdleMonitor {
@@ -355,6 +380,16 @@ Item {
 
     function toggle(): string {
       return root.setIdleEnabled(!root.idleEnabled)
+    }
+
+    // Called by omarchy-system-idle-inhibit-bridge, which owns
+    // org.freedesktop.ScreenSaver on the session bus. count is always the
+    // absolute number of inhibits the bridge currently holds, not a delta, so
+    // a bridge restart (or a call missed while the shell was reloading)
+    // self-heals on the next Inhibit/UnInhibit instead of leaving idling
+    // stuck disabled or wrongly re-enabled.
+    function setDbusInhibitors(count: string): string {
+      return String(root.applyDbusInhibitors(count))
     }
   }
 }

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,12 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assertEqual(idle.inhibitorCountFromValue('2'), 2, 'idle parses the D-Bus inhibitor count')
+assertEqual(idle.inhibitorCountFromValue('1.9'), 1, 'idle floors a fractional inhibitor count')
+assertEqual(idle.inhibitorCountFromValue('-1'), 0, 'idle floors a negative inhibitor count to zero')
+assertEqual(idle.inhibitorCountFromValue('nope'), 0, 'idle floors an unparsable inhibitor count to zero')
+assertEqual(idle.inhibitorCountFromValue(undefined), 0, 'idle floors a missing inhibitor count to zero')
 JS
 
 test_tmp=$(mktemp -d)
@@ -52,3 +58,28 @@ if rg -q 'omarchy-shell' "$ROOT/bin/omarchy-toggle-idle"; then
 fi
 
 pass "Stay Awake toggle persists state without reentrant shell IPC"
+
+idle_service="$ROOT/shell/plugins/services/idle/Service.qml"
+
+grep -Fq 'root.dbusInhibitors === 0' "$idle_service" ||
+  fail "idleEnabled no longer requires D-Bus inhibitors to be clear (#6475 regression)"
+grep -Fq 'function setDbusInhibitors(count: string): string' "$idle_service" ||
+  fail "idle service dropped the setDbusInhibitors IPC method the bridge depends on"
+grep -Fq 'function applyDbusInhibitors(value)' "$idle_service" ||
+  fail "idle service dropped applyDbusInhibitors"
+pass "idle service tracks D-Bus inhibitors and exposes them over IPC"
+
+bridge_bin="$ROOT/bin/omarchy-system-idle-inhibit-bridge"
+[[ -x $bridge_bin ]] || fail "omarchy-system-idle-inhibit-bridge must be executable"
+
+require_command python3
+python3 -m py_compile "$bridge_bin" ||
+  fail "omarchy-system-idle-inhibit-bridge has a syntax error"
+
+grep -Fq 'BUS_NAME = "org.freedesktop.ScreenSaver"' "$bridge_bin" ||
+  fail "idle inhibit bridge must own org.freedesktop.ScreenSaver"
+grep -Fq 'setDbusInhibitors' "$bridge_bin" ||
+  fail "idle inhibit bridge no longer reports state to the idle service"
+grep -Fq 'sync_idle_service(0)' "$bridge_bin" ||
+  fail "idle inhibit bridge must reset the idle service to zero on (re)start, or a crash while inhibited leaves idling stuck disabled"
+pass "D-Bus idle inhibit bridge owns org.freedesktop.ScreenSaver and reports to the idle service"

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -77,6 +77,34 @@ grep -F 'fcitx5' "$ROOT/default/hypr/autostart.lua" >/dev/null &&
   fail "fcitx5 is autostarted from Hyprland; an unsupervised launch dies silently and takes every compose sequence with it"
 pass "fcitx5 runs supervised, so a lost input method comes back instead of killing XCompose until logout"
 
+bridge_service="$ROOT/default/systemd/user/omarchy-idle-inhibit-bridge.service"
+grep -Fx 'ExecStart=/usr/bin/omarchy-system-idle-inhibit-bridge' "$bridge_service" >/dev/null ||
+  fail "idle inhibit bridge service uses the wrong ExecStart path"
+grep -Fx 'Restart=on-failure' "$bridge_service" >/dev/null ||
+  fail "idle inhibit bridge exits 0 when another owner already holds org.freedesktop.ScreenSaver; Restart=always would fight that owner forever"
+grep -Fx 'After=graphical-session.target' "$bridge_service" >/dev/null ||
+  fail "idle inhibit bridge needs WAYLAND_DISPLAY, which uwsm imports before it reaches graphical-session.target"
+grep -Fx 'PartOf=graphical-session.target' "$bridge_service" >/dev/null ||
+  fail "idle inhibit bridge must stop with the compositor instead of lingering against a dead session"
+grep -Fx 'WantedBy=graphical-session.target' "$bridge_service" >/dev/null ||
+  fail "idle inhibit bridge is never pulled in at login without a WantedBy"
+grep -Fx 'ConditionEnvironment=WAYLAND_DISPLAY' "$bridge_service" >/dev/null ||
+  fail "an update over SSH has a live user manager and no display; starting the bridge there wedges the unit active-but-blind"
+
+grep -F 'omarchy-idle-inhibit-bridge.service' "$first_run_units" >/dev/null ||
+  fail "first-run does not enable the D-Bus idle inhibit bridge"
+pass "D-Bus idle inhibit bridge runs supervised and is enabled at first run"
+
+bridge_migration="$ROOT/migrations/1785608166.sh"
+[[ -f $bridge_migration ]] || fail "missing migration enabling the idle inhibit bridge for existing installs"
+grep -F 'systemctl --user enable omarchy-idle-inhibit-bridge.service' "$bridge_migration" >/dev/null ||
+  fail "migration must enable without --now; --now starts the unit before the session-gate check"
+grep -F 'is-active --quiet graphical-session.target' "$bridge_migration" >/dev/null ||
+  fail "migration starts the bridge outside a graphical session"
+grep -F 'Could not start omarchy-idle-inhibit-bridge.service' "$bridge_migration" >/dev/null ||
+  fail "migration must report a failed start instead of marking itself complete silently"
+pass "existing installs get the idle inhibit bridge without a fresh install"
+
 oomd_slice="$ROOT/default/systemd/user/app.slice.d/10-oomd.conf"
 grep -Fx 'ManagedOOMMemoryPressure=kill' "$oomd_slice" >/dev/null ||
   fail "nothing is a kill candidate, so systemd-oomd watches the machine thrash and never acts"


### PR DESCRIPTION
Quattro's Quickshell idle service only honors the Wayland idle-inhibit protocol (IdleMonitor { respectInhibitors: true }). Nothing replaced hypridle's ownership of org.freedesktop.ScreenSaver on the session bus, so every D-Bus Inhibit() call from browsers and video players was silently dropped and the screensaver/lock fired mid-playback.

- Add omarchy-system-idle-inhibit-bridge, a small PyGObject daemon that owns org.freedesktop.ScreenSaver, implements Inhibit/UnInhibit/ GetActive, and auto-releases inhibits when the holding connection drops off the bus.
- Wire a setDbusInhibitors IPC method into the idle Service.qml; idleEnabled now also requires dbusInhibitors === 0. The bridge always reports the absolute inhibitor count (not a delta), so a bridge crash/restart self-heals instead of leaving idling stuck.
- Ship omarchy-idle-inhibit-bridge.service (systemd user unit), enable it on first run, and add a migration for existing installs.
- Extend test/shell.d/idle-test.sh and systemd-test.sh accordingly.