### PR TITLE
Cycle backgrounds whose filename holds glob characters

### DIFF
--- a/bin/omarchy-theme-bg-next
+++ b/bin/omarchy-theme-bg-next
@@ -29,7 +29,9 @@ else
   # Find current background index
   INDEX=-1
   for i in "${!BACKGROUNDS[@]}"; do
-    if [[ ${BACKGROUNDS[$i]} == $CURRENT_BACKGROUND ]]; then
+    # Quoted so a filename holding glob characters compares literally rather
+    # than as a pattern, which never matches itself and restarts the cycle.
+    if [[ ${BACKGROUNDS[$i]} == "$CURRENT_BACKGROUND" ]]; then
       INDEX=$i
       break
     fi

--- a/test/shell.d/theme-bg-next-test.sh
+++ b/test/shell.d/theme-bg-next-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+backgrounds_dir="$home_dir/.local/state/omarchy/current/theme/backgrounds"
+current_link="$home_dir/.local/state/omarchy/current/background"
+set_log="$test_tmp/bg-set.log"
+
+mkdir -p "$stub_bin" "$backgrounds_dir"
+printf 'ristretto\n' >"$home_dir/.local/state/omarchy/current/theme.name"
+
+# A glob character in the name is what breaks a pattern comparison, so one of
+# the backgrounds carries brackets the way downloaded wallpapers often do.
+bracketed="$backgrounds_dir/aaa [4k].jpg"
+plain="$backgrounds_dir/bbb.jpg"
+touch "$bracketed" "$plain"
+
+cat >"$stub_bin/omarchy-theme-bg-set" <<'SH'
+#!/bin/bash
+printf '%s\n' "$1" >"$OMARCHY_TEST_BG_SET_LOG"
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+run_bg_next() {
+  ln -sfn "$1" "$current_link"
+  : >"$set_log"
+
+  HOME="$home_dir" \
+    PATH="$stub_bin:$PATH" \
+    OMARCHY_TEST_BG_SET_LOG="$set_log" \
+    "$ROOT/bin/omarchy-theme-bg-next"
+}
+
+run_bg_next "$bracketed"
+selected=$(<"$set_log")
+[[ $selected == "$plain" ]] ||
+  fail "background cycling advances past a name with glob characters" "expected: $plain
+actual:   $selected"
+pass "background cycling advances past a name with glob characters"
+
+run_bg_next "$plain"
+selected=$(<"$set_log")
+[[ $selected == "$bracketed" ]] ||
+  fail "background cycling wraps back to the first background" "expected: $bracketed
+actual:   $selected"
+pass "background cycling wraps back to the first background"


### PR DESCRIPTION
### Why

`omarchy theme bg next` gets stuck on the first wallpaper as soon as any background in the theme has a glob character in its name — `[`, `]`, `*` or `?`. Downloaded wallpapers carry these often enough (`wallhaven-abc [4k].jpg`).

`bin/omarchy-theme-bg-next` looked the current background up with an unquoted right-hand side:

```bash
if [[ ${BACKGROUNDS[$i]} == $CURRENT_BACKGROUND ]]; then
```

In `[[ ]]`, an unquoted right-hand side of `==` is a **pattern**, not a literal. `aaa [4k].jpg` as a pattern matches `aaa 4.jpg` or `aaa k.jpg`, but never itself. The loop finds nothing, `INDEX` stays `-1`, and the `INDEX == -1` branch selects `BACKGROUNDS[0]` — so every "next background" jumps back to the first image instead of advancing.

### What

Quote the right-hand side so the comparison is literal.

### Repro

Two backgrounds in the current theme, `aaa [4k].jpg` and `bbb.jpg`, with `aaa [4k].jpg` active:

```
before:  omarchy theme bg next  ->  aaa [4k].jpg   # same image, cycle stuck
after:   omarchy theme bg next  ->  bbb.jpg
```

### Test plan

- Added `test/shell.d/theme-bg-next-test.sh`, which builds a throwaway `$HOME` with those two backgrounds, stubs `omarchy-theme-bg-set`, and asserts both that the cycle advances past the bracketed name and that it wraps back around.
- Verified the new test fails on `quattro` without the one-character change and passes with it.
- `./test/shell` is otherwise unchanged by this branch.