### PR TITLE
Disable the laptop display while mirroring is on

### DIFF
--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -33,7 +33,12 @@ off() {
     exit 1
   fi
 
-  if omarchy-hyprland-toggle-disabled $TOGGLE && omarchy-hyprland-toggle-disabled $MIRROR_TOGGLE; then
+  # Mirroring drives the internal output too, so it has to go before the
+  # disable rule lands or the two toggles fight and nothing appears to happen.
+  # The mirror command clears this toggle the same way when it turns on.
+  omarchy-hyprland-toggle $MIRROR_TOGGLE off
+
+  if omarchy-hyprland-toggle-disabled $TOGGLE; then
     printf 'hl.monitor({ output = "%s", disabled = true })\n' "$INTERNAL" >"$TOGGLE_FLAG"
     omarchy-notification-send -g 󰍹 "Laptop display disabled"
     hyprctl reload

--- a/test/shell.d/monitor-internal-toggle-test.sh
+++ b/test/shell.d/monitor-internal-toggle-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+toggles_dir="$home_dir/.local/state/omarchy/toggles/hypr"
+disable_flag="$toggles_dir/internal-monitor-disable.lua"
+mirror_flag="$toggles_dir/internal-monitor-mirror.lua"
+hyprctl_log="$test_tmp/hyprctl.log"
+notification_log="$test_tmp/notification.log"
+
+mkdir -p "$stub_bin" "$toggles_dir"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_HYPRCTL_LOG"
+SH
+
+cat >"$stub_bin/omarchy-hyprland-monitor-laptop" <<'SH'
+#!/bin/bash
+printf 'eDP-1\n'
+SH
+
+cat >"$stub_bin/omarchy-hyprland-monitor-external-active" <<'SH'
+#!/bin/bash
+[[ ${OMARCHY_TEST_EXTERNAL_ACTIVE:-true} == "true" ]]
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_NOTIFICATION_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_internal() {
+  : >"$hyprctl_log"
+  : >"$notification_log"
+
+  HOME="$home_dir" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
+    OMARCHY_TEST_HYPRCTL_LOG="$hyprctl_log" \
+    OMARCHY_TEST_NOTIFICATION_LOG="$notification_log" \
+    OMARCHY_TEST_EXTERNAL_ACTIVE="${OMARCHY_TEST_EXTERNAL_ACTIVE:-true}" \
+    "$ROOT/bin/omarchy-hyprland-monitor-internal" "$1"
+}
+
+rm -f "$disable_flag" "$mirror_flag"
+run_internal off
+grep -F 'disabled = true' "$disable_flag" >/dev/null ||
+  fail "internal monitor disable writes the Hyprland rule" "$(cat "$disable_flag" 2>&1)"
+grep -F 'reload' "$hyprctl_log" >/dev/null || fail "internal monitor disable reloads Hyprland"
+pass "internal monitor disable writes the Hyprland rule"
+
+# Mirroring drives the internal output as well. Before, the disable path bailed
+# out silently whenever the mirror toggle was up, so Super + Ctrl + Delete did
+# nothing at all until the user left mirrored mode first.
+rm -f "$disable_flag"
+printf 'hl.monitor({ output = "DP-1", mirror = "eDP-1" })\n' >"$mirror_flag"
+run_internal off
+[[ ! -f $mirror_flag ]] || fail "internal monitor disable clears mirroring first"
+grep -F 'disabled = true' "$disable_flag" >/dev/null ||
+  fail "internal monitor disable works while mirroring is on" "$(cat "$disable_flag" 2>&1)"
+grep -F 'Laptop display disabled' "$notification_log" >/dev/null ||
+  fail "internal monitor disable reports back while mirroring is on" "$(cat "$notification_log")"
+pass "internal monitor disable clears mirroring first"
+pass "internal monitor disable works while mirroring is on"
+
+run_internal on
+[[ ! -f $disable_flag ]] || fail "internal monitor enable clears the disable rule"
+pass "internal monitor enable clears the disable rule"
+
+rm -f "$disable_flag" "$mirror_flag"
+OMARCHY_TEST_EXTERNAL_ACTIVE=false run_internal off && status=0 || status=$?
+(( status == 1 )) || fail "internal monitor disable refuses to kill the only display" "exit: $status"
+[[ ! -f $disable_flag ]] || fail "internal monitor disable writes no rule without an external display"
+pass "internal monitor disable refuses to kill the only display"


### PR DESCRIPTION
Fixes #6207.

### Why

With the laptop and an external monitor in mirrored mode (`SUPER + CTRL + ALT + Delete`), disabling the laptop display (`SUPER + CTRL + Delete`) does nothing at all — no rule written, no notification, no feedback. The user has to know to leave mirrored mode first.

`bin/omarchy-hyprland-monitor-internal` required both toggles to be down before it would act:

```bash
if omarchy-hyprland-toggle-disabled $TOGGLE && omarchy-hyprland-toggle-disabled $MIRROR_TOGGLE; then
```

With mirroring up, the condition is false and `off()` falls straight through — a silent no-op.

### What

Clear the mirror toggle first, then apply the disable rule. This is the same handshake the mirror command already performs in the other direction: `bin/omarchy-hyprland-monitor-internal-mirror` runs `omarchy-hyprland-toggle $DISABLE_TOGGLE off` before it turns mirroring on. This change just makes the pair symmetric.

`omarchy-hyprland-toggle` reloads Hyprland itself, so both toggles land in one config reload cycle.

### Test plan

- Added `test/shell.d/monitor-internal-toggle-test.sh`, a stubbed-`hyprctl` behavioural test covering: the plain disable path, disabling while mirroring is on (the regression), re-enabling, and the existing refusal to disable the only active display.
- Verified the new test fails on `quattro` without the change and passes with it.
- `test/shell.d/monitor-recovery-test.sh` still passes; `recover()` is untouched.

### Not verified

I could not exercise this on real hardware — it needs a laptop docked to an external monitor, and this was developed on a desktop. The logic and toggle state are covered by the test above, but a confirmation from the reporter or a run through the `omarchy-iso` VM harness would be worth having before merge.