### PR TITLE
Treat Omarchy TUIs as terminals for universal copy and paste

### DIFF
--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -19,6 +19,7 @@ local terminal_classes = {
   alacritty = true,
   ["com.mitchellh.ghostty"] = true,
   foot = true,
+  ["org.codeberg.dnkl.foot"] = true,
   kitty = true,
   wezterm = true,
 }
@@ -29,7 +30,13 @@ local function active_window_is_terminal()
     return false
   end
 
-  return terminal_classes[window.class:lower()] == true
+  local class = window.class:lower()
+
+  -- Omarchy's own TUIs are terminals wearing an "org.omarchy.<command>" app-id
+  -- (omarchy-launch-tui, omarchy-launch-floating-terminal-with-presentation).
+  -- Without this they take the GUI chord, and CTRL+C reads as SIGINT: the
+  -- window closes instead of copying.
+  return terminal_classes[class] == true or class:find("^org%.omarchy%.") ~= nil
 end
 
 local function universal_clipboard_shortcut(default_mods, default_key, terminal_mods, terminal_key)

--- a/test/shell.d/clipboard-bindings-test.sh
+++ b/test/shell.d/clipboard-bindings-test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+# Loads the real binding file against a stub Hyprland API, invokes the captured
+# callback, and prints the chord it dispatched for the given focused window.
+chord_for() {
+  local keys="$1" class="${2:-}"
+
+  OMARCHY_PATH="$ROOT" OMARCHY_TEST_KEYS="$keys" OMARCHY_TEST_CLASS="$class" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local bindings = {}
+local sent = {}
+
+hl = {
+  dsp = {
+    send_key_state = function(spec)
+      return spec
+    end,
+    exec_cmd = function(command)
+      return { kind = "exec", arg = command }
+    end,
+  },
+  bind = function(keys, dispatcher)
+    bindings[keys] = dispatcher
+  end,
+  dispatch = function(spec)
+    -- The binding splits every chord into a down and an up event; the down
+    -- event alone identifies which chord was chosen.
+    if type(spec) == "table" and spec.state == "down" then
+      sent[#sent + 1] = spec.mods .. " " .. spec.key
+    end
+  end,
+  timer = function() end,
+  get_active_window = function()
+    local class = os.getenv("OMARCHY_TEST_CLASS")
+    if class == nil or class == "" then
+      return nil
+    end
+
+    return { class = class }
+  end,
+}
+
+require("default.hypr.helpers")
+require("default.hypr.bindings.clipboard")
+
+local keys = os.getenv("OMARCHY_TEST_KEYS")
+local dispatcher = bindings[keys]
+assert(type(dispatcher) == "function", "no callback bound to " .. keys)
+dispatcher()
+
+print(sent[1] or "")
+LUA
+}
+
+assert_chord() {
+  local keys="$1" class="$2" expected="$3" description="$4"
+  local actual
+
+  actual=$(chord_for "$keys" "$class")
+  [[ $actual == "$expected" ]] || fail "$description" "expected: $expected
+actual:   $actual"
+  pass "$description"
+}
+
+assert_chord "SUPER + C" "foot" "CTRL Insert" "universal copy uses the terminal chord in a terminal"
+assert_chord "SUPER + C" "google-chrome" "CTRL C" "universal copy uses the GUI chord in an app"
+assert_chord "SUPER + C" "" "CTRL C" "universal copy falls back to the GUI chord with no focused window"
+
+# Omarchy's TUIs are terminals carrying an "org.omarchy.<command>" app-id, so
+# the GUI chord reaches them as SIGINT and closes the window instead of copying.
+assert_chord "SUPER + C" "org.omarchy.btop" "CTRL Insert" "universal copy treats an Omarchy TUI as a terminal"
+assert_chord "SUPER + C" "org.omarchy.terminal" "CTRL Insert" "universal copy treats the presentation terminal as a terminal"
+assert_chord "SUPER + V" "org.omarchy.btop" "SHIFT Insert" "universal paste treats an Omarchy TUI as a terminal"
+
+# system.lua tags this app-id as a floating window, so it reaches the bindings.
+assert_chord "SUPER + C" "org.codeberg.dnkl.foot" "CTRL Insert" "universal copy recognises foot's reverse-DNS app-id"


### PR DESCRIPTION
Fixes #6379.

### Why

`SUPER + C` closes floating TUI windows instead of copying from them. Open btop with `CTRL + SHIFT + ESCAPE`, About, or anything behind the presentation wrapper, press `SUPER + C`, and the window vanishes with nothing on the clipboard.

`default/hypr/bindings/clipboard.lua` picks between the terminal chord (`CTRL + Insert`) and the GUI chord (`CTRL + C`) from a fixed class list. Omarchy's own TUIs never carry one of those classes — `bin/omarchy-launch-tui` and `bin/omarchy-launch-floating-terminal-with-presentation` both pass `--app-id=org.omarchy.<command>`, which is exactly what `default/hypr/apps/system.lua` matches to tag them `+floating-window`.

So `active_window_is_terminal()` returns false, the binding sends a literal `CTRL + C`, the TUI takes it as SIGINT, and the window closes. `SUPER + V` shares the cause and sends `CTRL + V` where `SHIFT + Insert` was meant; it is just less visible because most TUIs ignore it.

### What

Treat any `org.omarchy.*` app-id as a terminal, since every one of them is a terminal emulator hosting a TUI.

Also add `org.codeberg.dnkl.foot` to the class list. `default/hypr/apps/system.lua` already matches that app-id in its window rules, but the clipboard class list only had bare `foot`.

### Confirmation

Reproduced the premise on Hyprland 0.56.0:

```
$ omarchy-launch-tui btop
$ hyprctl activewindow -j | jq -r '"class=\(.class) floating=\(.floating) pid=\(.pid)"'
class=org.omarchy.btop floating=true pid=65251

$ cat /proc/65251/comm
alacritty
```

A terminal process wearing an app-id the class list did not cover.

### Test plan

- Added `test/shell.d/clipboard-bindings-test.sh`. It loads the real binding file under `lua` against a stub Hyprland API, invokes the captured `SUPER + C` / `SUPER + V` callbacks with a chosen focused-window class, and asserts which chord gets dispatched.
- Covers the regression (`org.omarchy.btop`, `org.omarchy.terminal`, `org.codeberg.dnkl.foot` → terminal chord) alongside the pre-existing behaviour that must not shift (`foot` → terminal chord, `google-chrome` and no focused window → GUI chord).
- Verified the new test fails on `quattro` without this change and passes with it. The baseline cases pass either way, so the test is not merely asserting the new branch.
- `test/shell.d/hyprland-default-config-test.sh`, which also asserts against this file, still passes.

### Not verified

I confirmed the app-id and the underlying terminal process on a live session, but did not exercise a real `SUPER + C` keypress against a patched config — that means installing over a running Omarchy tree, which I did not want to do on someone's desktop session. The chord selection itself is covered by the test above.