### PR TITLE
feat(bar): add bar.screens to restrict the bar to specific monitors

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -7,6 +7,7 @@
   "bar": {
     "position": "top",
     "transparent": false,
+    "screens": [],
     "centerAnchor": "omarchy.clock",
     "layout": {
       "left": [

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -122,6 +122,7 @@ individual plugins (`bar`, `image-selector`, …).
     "id": "omarchy.bar",
     "position": "top",
     "transparent": false,
+    "screens": [],
     "centerAnchor": "calendar",
     "fontFamily": "JetBrainsMono Nerd Font",
     "layout": {
@@ -152,6 +153,9 @@ Rules:
 6. `allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
 8. `version: 1` is required.
+9. `bar.screens` is an optional list of Wayland output names that limits
+   which monitors get a bar (e.g. `["DP-1"]`). Empty or omitted means every
+   screen gets a bar.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -155,7 +155,9 @@ Rules:
 8. `version: 1` is required.
 9. `bar.screens` is an optional list of Wayland output names that limits
    which monitors get a bar (e.g. `["DP-1"]`). Empty or omitted means every
-   screen gets a bar.
+   screen gets a bar. It is implemented by the built-in bar (`omarchy.bar`);
+   replacement bar plugins receive `barConfig` but must implement the
+   filtering themselves.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -48,19 +48,12 @@ Item {
   property bool centerHoverRevealSuppressed: false
   property int barConfigSerial: 0
   property string position: "top"
-  // Optional list of output names (e.g. ["DP-1"]) to restrict the bar to.
+  // The screens that get a bar, honoring barConfig.screens: an optional
+  // list of output names (e.g. ["DP-1"], matching `hyprctl monitors`).
   // Empty or unset means every screen gets a bar, which is the default
-  // behavior. Values are Wayland output names as reported by Quickshell
-  // (ShellScreen.name), the same names `hyprctl monitors` prints.
-  readonly property var screenFilter: {
-    var cfg = barConfig && barConfig.screens
-    return Array.isArray(cfg) ? cfg : []
-  }
-  // The screens that actually get a bar, honoring barConfig.screens.
-  // Stays reactive: re-evaluates when screens hotplug or config reloads.
-  readonly property var barScreens: root.screenFilter.length > 0
-    ? Quickshell.screens.filter(s => root.screenFilter.indexOf(s.name) !== -1)
-    : Quickshell.screens
+  // behavior. The binding references Quickshell.screens and barConfig, so
+  // it re-evaluates on screen hotplug and on shell.json reloads.
+  readonly property var barScreens: BarModel.screensFor(barConfig, Quickshell.screens)
   // Resolves through fontconfig at paint time (Style.font.family defaults
   // to "monospace"), so changing the system font (via `omarchy-font-set`)
   // updates the bar without a reload.

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -48,6 +48,19 @@ Item {
   property bool centerHoverRevealSuppressed: false
   property int barConfigSerial: 0
   property string position: "top"
+  // Optional list of output names (e.g. ["DP-1"]) to restrict the bar to.
+  // Empty or unset means every screen gets a bar, which is the default
+  // behavior. Values are Wayland output names as reported by Quickshell
+  // (ShellScreen.name), the same names `hyprctl monitors` prints.
+  readonly property var screenFilter: {
+    var cfg = barConfig && barConfig.screens
+    return Array.isArray(cfg) ? cfg : []
+  }
+  // The screens that actually get a bar, honoring barConfig.screens.
+  // Stays reactive: re-evaluates when screens hotplug or config reloads.
+  readonly property var barScreens: root.screenFilter.length > 0
+    ? Quickshell.screens.filter(s => root.screenFilter.indexOf(s.name) !== -1)
+    : Quickshell.screens
   // Resolves through fontconfig at paint time (Style.font.family defaults
   // to "monospace"), so changing the system font (via `omarchy-font-set`)
   // updates the bar without a reload.
@@ -898,7 +911,7 @@ Item {
   }
 
   Variants {
-    model: Quickshell.screens
+    model: root.barScreens
 
     delegate: Component {
       BarPanel {
@@ -910,7 +923,7 @@ Item {
   }
 
   Variants {
-    model: Quickshell.screens
+    model: root.barScreens
 
     delegate: Component {
       DragGhostPanel {
@@ -923,7 +936,7 @@ Item {
   }
 
   Variants {
-    model: Quickshell.screens
+    model: root.barScreens
 
     delegate: Component {
       BarMoveGhostPanel {

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -7,6 +7,17 @@ function normalizePosition(value) {
   return /^(top|bottom|left|right)$/.test(next) ? next : "top"
 }
 
+function screenNames(config) {
+  var cfg = config && config.screens
+  return Array.isArray(cfg) ? cfg : []
+}
+
+function screensFor(config, allScreens) {
+  var names = screenNames(config)
+  if (names.length === 0) return allScreens
+  return allScreens.filter(function(s) { return names.indexOf(s.name) !== -1 })
+}
+
 function entrySettings(entry) {
   if (!isPlainObject(entry)) return {}
   var copy = {}
@@ -202,6 +213,8 @@ if (typeof module !== "undefined") {
     expandPath: expandPath,
     customModuleSafeName: customModuleSafeName,
     customModuleType: customModuleType,
-    customModulePath: customModulePath
+    customModulePath: customModulePath,
+    screenNames: screenNames,
+    screensFor: screensFor
   }
 }

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -26,6 +26,7 @@ Example `shell.json` (bar subtree only shown):
   "bar": {
     "position": "top",
     "transparent": false,
+    "screens": [],
     "centerAnchor": "omarchy.clock",
     "layout": {
       "left": [
@@ -47,6 +48,8 @@ Example `shell.json` (bar subtree only shown):
 ```
 
 `centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. Set to an empty string to disable anchoring (the center list is centered as a group).
+
+`screens` restricts which monitors get a bar. It is a list of Wayland output names (the same names `hyprctl monitors` prints, e.g. `["DP-1"]`). Leave it empty (`[]`) or omit it for the default behavior of one bar per screen. The bar re-evaluates the filter live, so editing the value in `shell.json` moves the bar immediately without a shell restart.
 
 ## Module catalogue
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -42,6 +42,7 @@ ShellRoot {
     bar: {
       position: "top",
       transparent: false,
+      screens: [],
       centerAnchor: "omarchy.clock",
       layout: {
         left: [{ id: "omarchy.menu" }, { id: "omarchy.workspaces" }],

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -14,6 +14,14 @@ if rg -q 'barMoveSettling|barMoveSettleTimer' "$ROOT/shell/plugins/bar/Bar.qml";
 fi
 pass "bar move outline has no post-release settling state"
 
+# Screen filtering: every per-screen panel must bind the configured filter,
+# never a raw Quickshell.screens model, or bars silently return to every
+# monitor on the next rewrite.
+if ! perl -0ne 'exit((() = /Variants \{\s*\n\s*model: root\.barScreens/g) == 3 ? 0 : 1)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar must bind exactly three per-screen panels to the configured screen filter"
+fi
+pass "bar binds every per-screen panel to the configured screen filter"
+
 run_node_test <<'JS'
 const fs = require('fs')
 const bar = requireFromRoot('shell/plugins/bar/BarModel.js')
@@ -124,6 +132,23 @@ assertEqual(bar.entryId('omarchy.clock'), 'omarchy.clock', 'bar extracts string 
 const entries = [{ id: 'a' }, { id: 'omarchy.tray' }, { id: 'b' }]
 assertDeepEqual(bar.pinTrayToInner(entries, 'left').map(bar.entryId), ['a', 'b', 'omarchy.tray'], 'bar pins tray to left inner edge')
 assertDeepEqual(bar.pinTrayToInner(entries, 'right').map(bar.entryId), ['omarchy.tray', 'a', 'b'], 'bar pins tray to right inner edge')
+
+// Screen filtering must default to every screen and only drop non-matching
+// outputs, so a regression cannot silently restore bars on every monitor.
+const screens = [{ name: 'DP-1' }, { name: 'HDMI-A-1' }, { name: 'eDP-1' }]
+assertDeepEqual(bar.screenNames(undefined), [], 'bar defaults the screen filter to empty')
+assertDeepEqual(bar.screenNames({}), [], 'bar tolerates a bar config without screens')
+assertDeepEqual(bar.screenNames({ screens: ['DP-1'] }), ['DP-1'], 'bar reads configured screen names')
+assertEqual(bar.screensFor(undefined, screens), screens, 'bar keeps every screen when the filter is unset')
+assertEqual(bar.screensFor({ screens: [] }, screens), screens, 'bar keeps every screen when the filter is empty')
+assertEqual(bar.screensFor({ screens: 'DP-1' }, screens), screens, 'bar ignores non-array screen filters')
+assertDeepEqual(bar.screensFor({ screens: ['DP-1'] }, screens).map(s => s.name), ['DP-1'], 'bar keeps only matching screens')
+assertDeepEqual(bar.screensFor({ screens: ['eDP-1', 'DP-1'] }, screens).map(s => s.name), ['DP-1', 'eDP-1'], 'bar keeps matching screens in screen order')
+assertDeepEqual(bar.screensFor({ screens: ['VGA-9'] }, screens), [], 'bar drops unmatched screen names')
+assert(
+  /BarModel\.screensFor\(barConfig, Quickshell\.screens\)/.test(barSource),
+  'bar derives filtered screens from the live config and screen list'
+)
 
 // A settings-only shell.json write must patch the live bar, not rebuild it:
 // the module Repeaters recreate every widget when their array model changes.


### PR DESCRIPTION
## Summary

The bar currently creates a panel on every connected screen (`Variants { model: Quickshell.screens }`). On multi-monitor setups there's no way to keep the bar on just one monitor — the only workaround is editing Bar.qml directly, which gets clobbered on every omarchy update. Waybar solved this years ago with a per-output config; this brings the same idea to shell.json.

Adds an optional `bar.screens` key: a list of Wayland output names the bar should be created on. Empty or omitted keeps the current behavior (bar on every screen).

```json
{
  "bar": {
    "position": "top",
    "screens": ["DP-1"]
  }
}
```

## Changes

- shell/plugins/bar/Bar.qml: new screenFilter/barScreens properties; all three per-screen Variants (BarPanel, DragGhostPanel, BarMoveGhostPanel) now bind to barScreens instead of Quickshell.screens directly
- shell/shell.qml: `screens: []` in the builtin fallback config
- config/omarchy/shell.json: `"screens": []` in the default config
- Docs updated in docs/omarchy-shell.md and shell/plugins/bar/README.md

## Behavior

- Default: unchanged, one bar per screen
- `"screens": ["DP-1"]`: only DP-1 gets a bar; names match `hyprctl monitors` output
- Reactive: re-evaluates when screens hotplug or shell.json reloads, so changing the value moves the bar live without a shell restart

## Testing

- qmllint passes on both modified QML files
- The filter expression is the same one I've been running on a dual-monitor setup (bar on DP-1 only, drag/move ghosts filtered too), verified working across shell restarts
