### PR TITLE
fix(menu): prevent guardProc buffer wipe race & eliminate login-shell overhead

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -948,8 +948,15 @@ Item {
 
   property var whenResults: ({})       // id → true|false (allow visibility)
   property var checkedResults: ({})    // id → true|false (show ✓)
+  property bool guardEvaluationPending: false
 
   function evaluateGuards() {
+    if (guardProc.running) {
+      root.guardEvaluationPending = true
+      return
+    }
+    root.guardEvaluationPending = false
+
     var script = ""
     var ids = Object.keys(root.items)
     for (var i = 0; i < ids.length; i++) {
@@ -964,7 +971,7 @@ Item {
       return
     }
     guardProc.collected = ""
-    guardProc.command = ["bash", "-lc", script]
+    guardProc.command = ["bash", "-c", script]
     guardProc.running = true
   }
 
@@ -977,6 +984,9 @@ Item {
     onExited: {
       var nextWhen = ({})
       var nextChecked = ({})
+      for (var k in root.whenResults) nextWhen[k] = root.whenResults[k]
+      for (var k2 in root.checkedResults) nextChecked[k2] = root.checkedResults[k2]
+
       var lines = guardProc.collected.split("\n")
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i].trim()
@@ -995,6 +1005,10 @@ Item {
       root.whenResults = nextWhen
       root.checkedResults = nextChecked
       if (root.opened) root.rebuildDisplay()
+
+      if (root.guardEvaluationPending) {
+        Qt.callLater(root.evaluateGuards)
+      }
     }
   }
   PanelWindow {


### PR DESCRIPTION
### Summary

When opening or toggling the Omarchy menu (such as via the physical keyboard power button `omarchy-menu toggle system`), the menu intermittently opens completely empty ("Nothing here yet") or fails to display submenus/items.

### Root Cause Analysis

1. **Buffer Wipe Race**: `evaluateGuards()` clears `guardProc.collected = ""` and attempts to start `guardProc` (`bash -lc script`). If `evaluateGuards()` is invoked while `guardProc` is already running in background, `guardProc.collected` is wiped mid-flight. When `guardProc.onExited` eventually runs, it parses a truncated stdout buffer.
2. **Destructive `whenResults` Overwrite**: `guardProc.onExited` overwrites `root.whenResults` and `root.checkedResults` with the partial/empty output, causing `isVisible()` checks to return `false` for valid items/submenus and rendering an empty state ("Nothing here yet").
3. **Login Shell Overhead**: Running `bash -lc` loads startup profile scripts (`~/.bashrc`, `~/.bash_profile`, etc.) on every guard pass, adding unnecessary latency to evaluation.

### Fix

- **Queue Concurrent Guard Runs**: If `guardProc.running` is true when `evaluateGuards()` is called, mark `guardEvaluationPending = true` and return without touching `guardProc.collected`. Re-run `evaluateGuards()` when `guardProc` exits if pending.
- **Preserve Existing Results**: Merge new `whenResults` and `checkedResults` into existing result maps in `onExited` so partial output never wipes known valid item visibility states.
- **Non-login Shell**: Use `bash -c` instead of `bash -lc` to avoid startup profile overhead.