### PR TITLE
fix(model-usage): suppress log spam when optional Claude files are missing

### DIFF
--- a/shell/plugins/model-usage/providers/Claude.qml
+++ b/shell/plugins/model-usage/providers/Claude.qml
@@ -87,11 +87,12 @@ Item {
         id: historyFile
         path: root.resolvePath("~/.claude/history.jsonl")
         watchChanges: true
+        printErrors: false
         onFileChanged: reload()
         onLoaded: root.parseHistory(text())
         onLoadFailed: error => {
-            if (error === FileViewError.FileNotFound)
-                console.error("model-usage/claude", "history.jsonl not found");
+            if (error !== FileViewError.FileNotFound)
+                console.error("model-usage/claude", "history.jsonl error:", error);
         }
     }
 
@@ -99,11 +100,12 @@ Item {
         id: credentialsFile
         path: root.resolvePath(root.providerSettings?.credentialsPath ?? "~/.claude/.credentials.json")
         watchChanges: true
+        printErrors: false
         onFileChanged: reload()
         onLoaded: root.parseCredentials(text())
         onLoadFailed: error => {
-            if (error === FileViewError.FileNotFound)
-                console.error("model-usage/claude", "credentials.json not found at", credentialsFile.path);
+            if (error !== FileViewError.FileNotFound)
+                console.error("model-usage/claude", "credentials.json error:", error);
         }
     }
 


### PR DESCRIPTION
### Summary
When using the `model-usage` plugin without optional Claude credentials or history files, `Claude.qml` logs `console.error("model-usage/claude", "credentials.json not found at...")` and Qt logs `WARN scene: QML FileView ... File does not exist` every 15 minutes continuously.

### Fix
Set `printErrors: false` on the `FileView` components and avoid logging `console.error` for expected `FileViewError.FileNotFound` errors when optional credentials or history files are missing.