### PR TITLE
fix(shell): remove login-shell overhead & queue in-flight icon index scans in AppLibrary

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -71,7 +71,11 @@ Item {
   // The shell may start before first-install packages have finished placing
   // their icons; consumers call this when they open so icons appear live.
   function refreshIcons() {
-    if (!iconIndexScan.running) iconIndexScan.running = true
+    if (iconIndexScan.running) {
+      root.pendingIconIndexRescan = true
+      return
+    }
+    iconIndexScan.running = true
   }
 
   function launch(desktopId, name) {
@@ -125,7 +129,7 @@ Item {
     // so the parser, which keeps the first hit per name, prefers scalable icons.
     return [
       'dirs="$HOME/.icons $HOME/.local/share/icons";',
-      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
+      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
       'for ext in svg png; do',
       '  for base in $dirs; do',
       '    [[ -d $base ]] && find "$base" \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" 2>/dev/null;',
@@ -188,20 +192,28 @@ Item {
 
   Process {
     id: hiddenEntryScan
-    command: ["bash", "-lc", root.hiddenEntryScanCommand()]
+    command: ["bash", "-c", root.hiddenEntryScanCommand()]
     stdout: SplitParser { onRead: function(line) { hiddenEntryOutput.text += line + "\n" } }
     onStarted: hiddenEntryOutput.text = ""
     onExited: root.loadDesktopHiddenEntries(hiddenEntryOutput.text)
   }
 
+  property bool pendingIconIndexRescan: false
+
   Process {
     id: iconIndexScan
-    command: ["bash", "-lc", root.iconIndexScanCommand()]
+    command: ["bash", "-c", root.iconIndexScanCommand()]
     stdout: SplitParser { onRead: function(line) { root.indexIconLine(line) } }
     onStarted: root.pendingIconIndex = ({})
     // Swapping the property re-evaluates every iconSource() binding, so
     // newly found icons appear without rebuilding the list.
-    onExited: root.iconIndex = root.pendingIconIndex
+    onExited: {
+      root.iconIndex = root.pendingIconIndex
+      if (root.pendingIconIndexRescan) {
+        root.pendingIconIndexRescan = false
+        iconIndexDebounce.restart()
+      }
+    }
   }
 
   // Coalesces bursts of app-list changes (a package install touches many
@@ -209,7 +221,13 @@ Item {
   Timer {
     id: iconIndexDebounce
     interval: 750
-    onTriggered: if (!iconIndexScan.running) iconIndexScan.running = true
+    onTriggered: {
+      if (iconIndexScan.running) {
+        root.pendingIconIndexRescan = true
+      } else {
+        iconIndexScan.running = true
+      }
+    }
   }
 
   FileView {

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -129,7 +129,7 @@ Item {
     // so the parser, which keeps the first hit per name, prefers scalable icons.
     return [
       'dirs="$HOME/.icons $HOME/.local/share/icons";',
-      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
+      'IFS=":"; for d in ${XDG_DATA_DIRS:-$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
       'for ext in svg png; do',
       '  for base in $dirs; do',
       '    [[ -d $base ]] && find "$base" \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" 2>/dev/null;',

--- a/shell/services/hidden-entries.sh
+++ b/shell/services/hidden-entries.sh
@@ -94,7 +94,7 @@ scan_dir() {
 
 scan_dir "$HOME/.local/share/applications"
 
-IFS=":" read -ra data_dirs <<< "${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+IFS=":" read -ra data_dirs <<< "${XDG_DATA_DIRS:-/usr/local/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share}"
 for data_dir in "${data_dirs[@]}"; do
   scan_dir "$data_dir/applications"
 done

--- a/shell/services/hidden-entries.sh
+++ b/shell/services/hidden-entries.sh
@@ -94,7 +94,7 @@ scan_dir() {
 
 scan_dir "$HOME/.local/share/applications"
 
-IFS=":" read -ra data_dirs <<< "${XDG_DATA_DIRS:-/usr/local/share:/usr/share:/var/lib/flatpak/exports/share:$HOME/.local/share/flatpak/exports/share}"
+IFS=":" read -ra data_dirs <<< "${XDG_DATA_DIRS:-$HOME/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share}"
 for data_dir in "${data_dirs[@]}"; do
   scan_dir "$data_dir/applications"
 done

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -139,4 +139,26 @@ assert(
   openMatch[1].includes('root.appLibrary.refreshIcons()'),
   'menu refreshes the shared icon index when opened'
 )
+
+assert(
+  /function refreshIcons\(\) \{[\s\S]*?if \(iconIndexScan\.running\) \{[\s\S]*?root\.pendingIconIndexRescan = true[\s\S]*?\} else \{[\s\S]*?iconIndexScan\.running = true/.test(appLibraryQml),
+  'app library queues an icon rescan when a scan is already running, instead of dropping the request'
+)
+assert(
+  /onExited: \{[\s\S]*?root\.iconIndex = root\.pendingIconIndex[\s\S]*?if \(root\.pendingIconIndexRescan\) \{[\s\S]*?root\.pendingIconIndexRescan = false[\s\S]*?iconIndexDebounce\.restart\(\)/.test(appLibraryQml),
+  'app library runs exactly one follow-up scan after the in-flight scan exits when a rescan was queued'
+)
+
+const flatpakFallback = appLibraryQml.match(/XDG_DATA_DIRS:-([^};]+)/)
+assert(flatpakFallback, 'app library declares a flatpak-aware XDG_DATA_DIRS fallback')
+const fallbackDirs = (flatpakFallback && flatpakFallback[1]) ? flatpakFallback[1].split(':').filter(Boolean) : []
+assert(
+  fallbackDirs.join('').indexOf('$HOME/.local/share/flatpak/exports/share') < fallbackDirs.join('').indexOf('/var/lib/flatpak/exports/share') &&
+    fallbackDirs.join('').indexOf('$HOME/.local/share/flatpak/exports/share') < fallbackDirs.join('').indexOf('local/share'),
+  'app library keeps user flatpak exports before system flatpak and standard dirs so a user install wins over a duplicate system id'
+)
+assert(
+  fallbackDirs.some(d => d.indexOf('flatpak/exports/share') !== -1),
+  'app library fallback restores user and system flatpak icon dirs that the login shell used to populate'
+)
 JS

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -152,9 +152,14 @@ assert(
 const flatpakFallback = appLibraryQml.match(/XDG_DATA_DIRS:-([^};]+)/)
 assert(flatpakFallback, 'app library declares a flatpak-aware XDG_DATA_DIRS fallback')
 const fallbackDirs = (flatpakFallback && flatpakFallback[1]) ? flatpakFallback[1].split(':').filter(Boolean) : []
+const userFlatpakDirIndex = fallbackDirs.indexOf('$HOME/.local/share/flatpak/exports/share')
+const systemFlatpakDirIndex = fallbackDirs.indexOf('/var/lib/flatpak/exports/share')
+const standardDirOffset = fallbackDirs.findIndex(d => d.endsWith('/usr/local/share') || d.endsWith('/usr/share'))
 assert(
-  fallbackDirs.join('').indexOf('$HOME/.local/share/flatpak/exports/share') < fallbackDirs.join('').indexOf('/var/lib/flatpak/exports/share') &&
-    fallbackDirs.join('').indexOf('$HOME/.local/share/flatpak/exports/share') < fallbackDirs.join('').indexOf('local/share'),
+  userFlatpakDirIndex > -1 &&
+    systemFlatpakDirIndex > -1 &&
+    userFlatpakDirIndex < systemFlatpakDirIndex &&
+    userFlatpakDirIndex < standardDirOffset,
   'app library keeps user flatpak exports before system flatpak and standard dirs so a user install wins over a duplicate system id'
 )
 assert(


### PR DESCRIPTION
### Summary
1. `hiddenEntryScan` and `iconIndexScan` in `AppLibrary.qml` ran `bash -lc` login shells, incurring unnecessary startup profile overhead per desktop file scan.
2. `iconIndexDebounce` dropped rescan requests if `iconIndexScan.running` was `true` (`if (!iconIndexScan.running) iconIndexScan.running = true`), causing desktop entry or package changes occurring mid-scan to be lost.

### Fix
- Use `bash -c` instead of `bash -lc`.
- Queue in-flight rescan requests in `pendingIconIndexRescan` and restart the debounce timer on `iconIndexScan.onExited`.

## Review follow-up

Initial Copilot review flagged the Flatpak side effects of dropping the login shell. Updated branch:

- The `XDG_DATA_DIRS` fallback in both `AppLibrary.qml` and `hidden-entries.sh` now lists **user flatpak exports before system flatpak and standard dirs**, so a user install still wins over a duplicate system id (`seen_ids` keeps the first hit).
- **Per-user icons are indexed** even when `XDG_DATA_DIRS` is unset (`$HOME/.local/share/flatpak/exports/share` included).
- Scope note: restoring these dirs is required — `/etc/profile.d/flatpak.sh` populated them previously, and UWSM does not source `/etc/profile.d`.
- Added regression coverage to `test/shell.d/app-search-test.sh`: in-flight icon rescan queues exactly one follow-up scan after exit, and the flatpak fallback ordering holds.

### Round 2 (post-re-review)

- The flatpak precedence assertion previously searched a concatenated string for `local/share`, which the user dir itself contains — it could never fail. It now asserts **array positions** of the parsed fallback dirs, so user-flatpak must actually come before system-flatpak and the standard dirs.

**Testing:** app-search-test.sh green · full `./test/shell` green against the same single pre-existing baseline failure.
