### PR TITLE
fix(notifications): check file icon existence via Quickshell.iconPath before setting Image source

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -36,7 +36,10 @@ BorderSurface {
   signal cardClicked()
   // Prefer per-notification media/avatar data, then fall back to the app icon.
   // The `check` flag avoids Qt's missing-texture placeholder for unknown names.
-  readonly property string smallIconSource: image.length > 0 ? image : iconSource(appIcon)
+  readonly property string smallIconSource: {
+    var img = iconSource(image)
+    return img.length > 0 ? img : iconSource(appIcon)
+  }
   readonly property bool hasGlyph: glyph.length > 0
   readonly property bool compactGlyph: NotificationLogic.shouldRenderCompactGlyph(glyph, smallIconSource, singleLineToast)
   readonly property bool hasSmallIcon: smallIconSource.length > 0
@@ -58,8 +61,14 @@ BorderSurface {
   function iconSource(icon) {
     var value = String(icon || "")
     if (value.length === 0) return ""
-    if (value.indexOf("file://") === 0 || value.indexOf("image://") === 0) return value
-    if (value.charAt(0) === "/") return Util.fileUrl(value)
+    if (value.indexOf("image://") === 0) return value
+    // Only percent-decode explicit file:// URIs; raw absolute paths are
+    // already literal filesystem paths where %20 is a real filename char.
+    if (value.indexOf("file://") === 0) {
+      var pathStr = value.substring(7)
+      try { pathStr = decodeURIComponent(pathStr) } catch (e) {}
+      return Quickshell.iconPath(pathStr, true)
+    }
     return Quickshell.iconPath(value, true)
   }
 


### PR DESCRIPTION
### Summary
When desktop notifications carry `file://` or absolute path icons pointing to non-existent files (e.g. uninstalled apps or missing cached assets), Qt QML logs `WARN scene: QML QQuickImage ... Cannot open: file://...`.

### Fix
Pass `file://` and absolute file paths through `Quickshell.iconPath(filePath, true)` in `iconSource()`. `Quickshell.iconPath` returns `""` if the file doesn't exist on disk, preventing Qt from attempting to open missing paths and eliminating console warning noise.