### PR TITLE
Keep a panel plugin enabled when its bar icon is removed

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -203,6 +203,19 @@ QtObject {
     return clone ? findBarLocation(config, clone, section) : { found: false }
   }
 
+  function findPluginLocation(config, id) {
+    if (!Util.isPlainObject(config) || !Array.isArray(config.plugins)) return { found: false }
+    var key = Util.canonicalWidgetId(String(id))
+    for (var j = 0; j < config.plugins.length; j++) {
+      if (config.plugins[j] && Util.canonicalWidgetId(config.plugins[j].id) === key)
+        return { found: true, kind: "plugin", index: j }
+    }
+    return { found: false }
+  }
+
+  // A plugin can be referenced in both places at once, so this reports the
+  // first reference found, in the order the shell cares about. Callers that
+  // must see every reference use findBarLocation and findPluginLocation.
   function findEntryLocation(config, id) {
     if (!Util.isPlainObject(config)) return { found: false }
     var key = Util.canonicalWidgetId(String(id))
@@ -214,12 +227,7 @@ QtObject {
       var barLocation = findBarLocation(config, key, "")
       if (barLocation.found) return barLocation
     }
-    if (Array.isArray(config.plugins)) {
-      for (var j = 0; j < config.plugins.length; j++) {
-        if (config.plugins[j] && Util.canonicalWidgetId(config.plugins[j].id) === key) return { found: true, kind: "plugin", index: j }
-      }
-    }
-    return { found: false }
+    return findPluginLocation(config, key)
   }
 
   function barTarget(config, placement, fallbackSection) {
@@ -437,9 +445,12 @@ QtObject {
           restoredEntry.id = sourceId
           config.bar.layout[cloneLocation.section][cloneLocation.index] = restoredEntry
         }
-      } else if (cloneLocation.kind === "plugin") {
-        config.plugins.splice(cloneLocation.index, 1)
       }
+      // A clone that is more than a widget also holds a plugins[] entry, so
+      // clear that whichever way it was referenced. Leaving it behind would
+      // keep the clone enabled after its source was restored.
+      var clonePluginLocation = findPluginLocation(config, cloneId)
+      if (clonePluginLocation.found) config.plugins.splice(clonePluginLocation.index, 1)
     }
 
     if (cloneShouldRestoreSource(config, cloneId)) removeDisabled(config, sourceId)
@@ -494,28 +505,32 @@ QtObject {
       }
 
       var isFirstParty = manifest && manifest.__isFirstParty
-      var location = findEntryLocation(config, key)
 
       if (value) {
         removeDisabled(config, key)
-        var entry = { id: key }
         var insertedWithPlacement = false
-        if (!location.found && isBarWidget) {
+
+        // A widget is enabled by its place in the bar. Anything with another
+        // kind is enabled by a plugins[] entry, and a plugin that is both
+        // needs both: the panel behind a bar icon must not be unloaded just
+        // because the icon was taken out of the bar.
+        if (isBarWidget && !findBarLocation(config, key, "").found) {
           var sourceLocation = clonedFrom ? findEntryLocation(config, clonedFrom) : { found: false }
           if (sourceLocation.kind === "bar") {
             var sourceEntry = config.bar.layout[sourceLocation.section][sourceLocation.index]
-            var replacement = Util.isPlainObject(sourceEntry) ? Util.cloneJson(sourceEntry) : entry
+            var replacement = Util.isPlainObject(sourceEntry) ? Util.cloneJson(sourceEntry) : { id: key }
             replacement.id = key
             config.bar.layout[sourceLocation.section][sourceLocation.index] = replacement
           } else {
             var section = defaultBarWidgetSection(manifest)
             var target = barTarget(config, placement || {}, section)
-            config.bar.layout[target.section].splice(target.index, 0, entry)
+            config.bar.layout[target.section].splice(target.index, 0, { id: key })
             insertedWithPlacement = true
           }
-        } else if (!location.found && !isFirstParty) {
-          config.plugins.push(entry)
         }
+
+        if (hasNonWidgetKind && !isFirstParty && !findPluginLocation(config, key).found)
+          config.plugins.push({ id: key })
 
         if (isBarWidget && !insertedWithPlacement && placement && Object.keys(placement).length)
           moveBarEntry(config, key, placement)
@@ -527,9 +542,17 @@ QtObject {
         return
       }
 
-      if (clonedFrom) restoreCloneSource(config, key, clonedFrom)
-      else if (location.kind === "bar") config.bar.layout[location.section].splice(location.index, 1)
-      else if (location.kind === "plugin") config.plugins.splice(location.index, 1)
+      // Off means off: clear every reference, not just the first one found.
+      // Enabling a plugin that is both a widget and a panel writes two, and
+      // leaving one behind would report it as still enabled.
+      if (clonedFrom) {
+        restoreCloneSource(config, key, clonedFrom)
+      } else {
+        var barEntry = findBarLocation(config, key, "")
+        if (barEntry.found) config.bar.layout[barEntry.section].splice(barEntry.index, 1)
+        var pluginEntry = findPluginLocation(config, key)
+        if (pluginEntry.found) config.plugins.splice(pluginEntry.index, 1)
+      }
 
       // Dropping the layout entry is the whole story for a widget. Anything
       // else built-in loads by default, so switching it off has to be stated.

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -956,6 +956,8 @@ ShellRoot {
         var kinds = plugins[id].kinds || []
         var isBarOption = Array.isArray(kinds) && kinds.indexOf("bar") !== -1
         var isBarWidget = Array.isArray(kinds) && kinds.indexOf("bar-widget") !== -1
+        var isWidgetOnly = isBarWidget && Array.isArray(kinds)
+          && !kinds.some(function(kind) { return kind !== "bar-widget" })
         var active = isBarOption && shell.isActiveBarOption(id)
         var metadata = plugins[id].omarchy
         var clonedFrom = Util.isPlainObject(metadata) ? String(metadata.clonedFrom || "") : ""
@@ -963,10 +965,12 @@ ShellRoot {
           id: id,
           name: plugins[id].name,
           kinds: kinds,
-          // What `omarchy plugin enable/disable` toggles: for a widget that is
-          // its place in the bar, not whether its component is loadable.
+          // What `omarchy plugin enable/disable` toggles: for a plugin that is
+          // only a widget that is its place in the bar, not whether its
+          // component is loadable. A plugin that also has a panel/overlay/menu
+          // kind outlives its bar icon, so ask whether it is enabled at all.
           enabled: isBarOption ? active
-            : (isBarWidget ? shell.pluginRegistry.inBar(id) : shell.pluginRegistry.isEnabled(id)),
+            : (isWidgetOnly ? shell.pluginRegistry.inBar(id) : shell.pluginRegistry.isEnabled(id)),
           active: active,
           // A bar has no off, only a successor: you leave one by enabling
           // another, so there is nothing for disable to do to it. Said here so

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -84,6 +84,7 @@ ShellRoot {
     scan += block("firstparty", "/first/panels/grouped", manifest("omarchy.grouped-panel", ["panel"], { panel: "Panel.qml" }))
     scan += block("firstparty", "/first/hybrid", manifest("omarchy.hybrid", ["menu", "bar-widget"], { menu: "Menu.qml", barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/panel", manifest("third.panel", ["panel"], { panel: "Panel.qml" }))
+    scan += block("thirdparty", "/third/hybrid", manifest("third.hybrid", ["panel", "bar-widget"], { panel: "Panel.qml", barWidget: "Widget.qml" }, { defaultSection: "right" }))
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
     scan += block("thirdparty", "/third/center-widget", manifest("third.center-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/right-widget", manifest("third.right-widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "right" }))
@@ -125,6 +126,7 @@ ShellRoot {
       "omarchy.hybrid",
       "third.bar",
       "third.center-widget",
+      "third.hybrid",
       "third.panel",
       "third.right-widget",
       "third.widget"
@@ -165,8 +167,35 @@ ShellRoot {
     registry.setEnabled("third.widget", true)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "third.widget" }], "enabling bar widgets uses their default section")
     root.assertTrue(registry.isEnabled("third.widget"), "enabled bar widgets are found")
+    root.assertDeepEqual(root.config.plugins, [], "enabling a widget-only plugin adds no plugins entry")
     registry.setEnabled("third.widget", false)
     root.assertDeepEqual(root.config.bar.layout.left, [], "disabling bar widgets removes layout entry")
+
+    // A plugin that is both a panel and a widget is reachable two ways: its bar
+    // icon and `shell toggle`. Enabling it has to write both references, or
+    // taking the icon out of the bar would unload the panel behind it and the
+    // keybinding would silently do nothing.
+    root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
+    registry.setEnabled("third.hybrid", true)
+    root.assertDeepEqual(root.config.bar.layout.right, [{ id: "third.hybrid" }], "enabling a panel widget places its icon")
+    root.assertDeepEqual(root.config.plugins, [{ id: "third.hybrid" }], "enabling a panel widget also writes a plugins entry")
+    root.assertTrue(registry.isEnabled("third.hybrid"), "an enabled panel widget is enabled")
+
+    root.config.bar.layout.right = []
+    root.assertTrue(registry.isEnabled("third.hybrid"), "a panel widget survives losing its bar icon")
+
+    root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
+    registry.setEnabled("third.hybrid", true)
+    registry.setEnabled("third.hybrid", false)
+    root.assertDeepEqual(root.config.bar.layout.right, [], "disabling a panel widget removes its icon")
+    root.assertDeepEqual(root.config.plugins, [], "disabling a panel widget clears every reference in one call")
+    root.assertTrue(!registry.isEnabled("third.hybrid"), "a disabled panel widget is disabled")
+
+    registry.setEnabled("third.hybrid", true)
+    registry.setEnabled("third.hybrid", true)
+    root.assertDeepEqual(root.config.bar.layout.right, [{ id: "third.hybrid" }], "enabling a panel widget twice adds one icon")
+    root.assertDeepEqual(root.config.plugins, [{ id: "third.hybrid" }], "enabling a panel widget twice adds one plugins entry")
+    registry.setEnabled("third.hybrid", false)
 
     root.config = {
       version: 1,
@@ -358,6 +387,7 @@ ShellRoot {
     registry.setEnabled("local.hybrid", false)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "omarchy.hybrid" }], "disabling a multi-kind clone restores its widget")
     root.assertTrue(root.config.disabledPlugins === undefined, "disabling a multi-kind clone enables the source")
+    root.assertDeepEqual(root.config.plugins, [], "restoring a clone's source leaves no orphan plugins entry")
 
     root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
     registry.setEnabled("local.grouped-panel", true)


### PR DESCRIPTION
A plugin whose `kinds` include both `bar-widget` and a `panel`, `overlay` or `menu` kind is enabled by its bar entry alone. `setEnabled` picks the bar branch of an if/else chain, so the `config.plugins.push(entry)` below it is unreachable for that shape:

```js
if (!location.found && isBarWidget) {
  ...                                    // bar entry written here
} else if (!location.found && !isFirstParty) {
  config.plugins.push(entry)             // never reached for a panel widget
}
```

`isEnabled()` then falls through to `findEntryLocation()`, which only finds the bar entry. Take such a plugin's icon out of the bar and it counts as disabled: the panel delegate is never instantiated and `omarchy-shell shell toggle <id>` becomes a silent no-op — exit 0, nothing on screen, and the reason only in `/run/user/$UID/quickshell/by-pid/*/log.log`:

```
WARN qml: summon: plugin not enabled, not summoning: <id>
```

Users hit this by binding a key to a panel plugin and then not wanting a second icon in their bar, or by running with the bar hidden. It reads as a broken keybinding, which is a long way from where the cause is.

## Changes

- `setEnabled` writes both references on enable: the bar entry for the widget, and a `plugins[]` entry for the kind that outlives it. Widget-only plugins are unaffected — they still get the bar entry alone, and first-party plugins still get neither.
- Disable clears *every* reference in one call rather than the first one found, so off still means off. This also means `omarchy plugin remove`'s single `setPluginEnabled <id> false` can no longer leave an orphan entry pointing at a directory that has been deleted.
- `restoreCloneSource` drops a clone's `plugins[]` entry whichever way it was referenced — without this the enable change would orphan one on every hybrid clone.
- `listPlugins` reports a widget-only plugin by its place in the bar as before; anything with another kind reports whether it is actually enabled.
- New `findPluginLocation`, plus a note on `findEntryLocation` that it returns the *first* reference now that two can coexist.

## Testing

`plugin-registry-contract-test.sh` runs real headless quickshell against the registry, so these are behavioural checks rather than source assertions. Added a `third.hybrid` `["panel","bar-widget"]` fixture covering:

- both references written on enable
- still enabled after the bar entry is removed
- one-call disable clearing both
- re-enabling twice adding one of each
- no orphan left behind when a clone's source is restored

Reverting only `PluginRegistry.qml` fails on exactly the new assertions (`expected=[{"id":"third.hybrid"}] actual=[]`), so the test pins the fix rather than merely passing alongside it. `./test/shell` is otherwise green — 603 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
