### PR TITLE
Reject theme names that could escape THEMES_DIR in theme remove

### DIFF
--- a/bin/omarchy-theme-remove
+++ b/bin/omarchy-theme-remove
@@ -26,6 +26,14 @@ if [[ -z $THEME_NAME ]]; then
   exit 1
 fi
 
+# Reject names that could escape THEMES_DIR (e.g. "../../.ssh") before we
+# ever build a path out of them, so a crafted name can't reach rm -rf outside
+# the themes directory.
+if [[ $THEME_NAME == */* || $THEME_NAME == *..* ]]; then
+  echo "Error: Invalid theme name '$THEME_NAME'." >&2
+  exit 1
+fi
+
 # Check if theme exists before attempting removal
 if [[ ! -d $THEME_PATH ]]; then
   echo "Error: Theme '$THEME_NAME' not found."


### PR DESCRIPTION
# Fix: `omarchy theme remove` Didn't Validate the Theme Name Before Deleting

## Summary

The `omarchy-theme-remove` script takes a theme name, builds a path to that theme's folder, and deletes it. It never checked whether the name it was given could actually point somewhere outside the themes folder. A crafted name could make it delete a directory that has nothing to do with themes at all.

## What Could Go Wrong

The script simply glued the themes directory and the given name together to build the path it would delete. It never asked whether that name contained something like "go up two directories" — the kind of relative-path trick that lets a name resolve to a completely different location on disk, such as a user's SSH key folder. Nothing forced the final path to actually stay inside the themes directory.

## Important Context: How Serious Is This, Really

This is worth being precise about. This isn't something an attacker could trigger remotely, and it isn't a privilege-escalation issue — the theme name always comes from the same user typing the command in their own terminal. In isolation, it's closer to "a user could type a command that hurts themselves" than a real attack surface.

What makes it worth fixing is consistency and defense-in-depth. A sibling command that removes installed plugins already validates its equivalent argument and explicitly rejects this exact kind of relative-path trick. Another sibling command that installs themes sidesteps the problem entirely by stripping away any directory components from the name before using it. This theme-removal script was the one command in that family with no equivalent safeguard — an inconsistency that turns into a real problem the moment this function is ever called from anywhere other than a human typing at a prompt: a plugin, a menu action, a future script.

## The Fix

Before the name is ever used to build a path, it's now checked for the telltale signs of an attempt to escape the intended directory, and rejected outright if found — with a clear error message instead of silently proceeding.

## Why It Was Worth Fixing

Not because it's an exploitable vulnerability today, but because it closes a gap that every neighboring command already closes, and because "the script that deletes things should never trust its input" is a baseline worth holding consistently across a codebase — especially in one still under heavy, active development where this function's callers are likely to grow.

## Conclusion

A real gap, correctly scoped as a hardening improvement rather than a security emergency. The fix is small, brings this command in line with its siblings, and costs nothing in terms of normal usage — legitimate theme names are entirely unaffected.