### PR TITLE
Enable DNS-over-TLS for custom DNS providers

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -281,6 +281,7 @@ Custom)
 [Resolve]
 DNS=${dns_servers//,/ }
 FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+DNSOverTLS=opportunistic
 EOF
   ;;
 esac


### PR DESCRIPTION
`omarchy dns Custom` silently disables DNS-over-TLS.

The `Cloudflare` and `Google` branches both write `DNSOverTLS=opportunistic`, and `DHCP` deliberately writes `DNSOverTLS=no`. The `Custom` branch writes neither, so `systemd-resolved` falls back to its built-in default of `no` and every lookup goes out in plaintext.

The result is a silent downgrade: a user who picks `Custom` specifically to point at a privacy-focused resolver gets the opposite of what they selected, with nothing in the output to indicate it. Quad9 is a good example, since it supports DoT and is already hardcoded as `FallbackDNS` in every other branch.

Reproduce on an affected machine:

```
$ omarchy dns Custom
Enter your DNS servers (space-separated, e.g. '192.168.1.1 1.1.1.1'):
9.9.9.9

$ grep -c DNSOverTLS /etc/systemd/resolved.conf
0

$ resolvectl status | grep DNSOverTLS
     +DNSOverTLS=no
```

`opportunistic` rather than `yes` keeps the documented `192.168.1.1` example working: a LAN resolver that does not speak DoT still resolves, and anything that does speak it gets upgraded. That also keeps `Custom` consistent with the two other provider branches rather than introducing a third behaviour.

`./test/cli` passes (100 assertions, 0 failures).
