### PR TITLE
Enable DNS-over-TLS for custom DNS providers

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -281,6 +281,7 @@ Custom)
 [Resolve]
 DNS=${dns_servers//,/ }
 FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+DNSOverTLS=opportunistic
 EOF
   ;;
 esac


### PR DESCRIPTION
`omarchy dns Custom` silently disables DNS-over-TLS.

Each provider branch overwrites `/etc/systemd/resolved.conf` wholesale. `Cloudflare` and `Google` write `DNSOverTLS=opportunistic`, `DHCP` writes `DNSOverTLS=no` deliberately, and `Custom` writes neither, so resolved falls back to its documented default of `no`.

Because it is an overwrite rather than an edit, selecting `Custom` after `Cloudflare` or `Google` also drops an already-encrypted resolver back to plaintext, with nothing in the output to say so.

Observed on a machine configured with `omarchy dns Custom` pointing at Quad9:

    $ head -3 /etc/systemd/resolved.conf
    [Resolve]
    DNS=9.9.9.9
    FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net ...

    $ grep -c DNSOverTLS /etc/systemd/resolved.conf
    0

    $ resolvectl status | grep -o '[+-]DNSOverTLS'
    -DNSOverTLS

Quad9 does support DoT, so this is a silent downgrade rather than an unavoidable fallback:

    $ openssl s_client -connect 9.9.9.9:853 -servername dns.quad9.net </dev/null
    subject=C=CH, ST=Zurich, L=Zürich, O=Quad9, CN=dns.quad9.net
    Verify return code: 0 (ok)

`opportunistic` rather than `yes` keeps the command's own `192.168.1.1` example working: a LAN resolver that does not speak DoT still resolves, one that does gets upgraded, and `Custom` stays consistent with the other branches instead of introducing a third behaviour.

The omission dates to 27497b19, which added all four branches and gave three of them the line. `bin/omarchy-dns` is the only file in the repo that writes DNS resolution settings, and the shipped `resolved.conf.d` drop-ins do not touch DoT.

Verified: `bash -n bin/omarchy-dns` clean, `./test/cli` passes, and the patched heredoc renders the expected `[Resolve]` block for both single and comma-separated server input. The privileged end-to-end run (`omarchy dns Custom` as root, then `resolvectl status`) has not been executed on this machine.
