### PR TITLE
Fix Wi-Fi and Bluetooth dropdown latency and scan-time segfaults

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -2,22 +2,29 @@
 
 # omarchy:summary=Print active network status for the shell
 # omarchy:group=network
-# omarchy:args=[--verbose]
+# omarchy:args=[--verbose|--ping|--all]
 
-verbose=false
+mode="status"
 internet_probe=1.1.1.1
 
-case "${1:-}" in
-  "")
-    ;;
-  --verbose)
-    verbose=true
-    ;;
-  *)
-    echo "Usage: omarchy-network-status [--verbose]" >&2
-    exit 2
-    ;;
-esac
+while (( $# > 0 )); do
+  case "$1" in
+    --verbose)
+      [[ $mode == "ping" ]] && mode="all" || mode="verbose"
+      ;;
+    --ping)
+      [[ $mode == "verbose" ]] && mode="all" || mode="ping"
+      ;;
+    --all)
+      mode="all"
+      ;;
+    *)
+      echo "Usage: omarchy-network-status [--verbose|--ping|--all]" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
 
 print_status() {
   local device nm state ssid signal freq
@@ -132,11 +139,26 @@ print_verbose() {
     [[ -r /sys/class/net/$iface/duplex ]] && printf 'duplex\t%s\n' "$(cat /sys/class/net/$iface/duplex)"
   fi
 
+  if [[ $mode == "all" ]]; then
+    print_ping_samples "$gw"
+  fi
+}
+
+print_ping_only() {
+  local route_json gw
+  route_json=$(ip -j route get "$internet_probe" 2>/dev/null)
+  gw=$(jq -r '.[0].gateway // ""' <<<"$route_json" 2>/dev/null)
   print_ping_samples "$gw"
 }
 
-if [[ $verbose == "true" ]]; then
-  print_verbose
-else
-  print_status
-fi
+case "$mode" in
+  verbose|all)
+    print_verbose
+    ;;
+  ping)
+    print_ping_only
+    ;;
+  status)
+    print_status
+    ;;
+esac

--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -72,7 +72,13 @@ PanelWindow {
   }
 
   function beginFocusPrime() {
-    if (open && backingWindowVisible) focusPrimeTimer.restart()
+    if (!open || !backingWindowVisible || focusPrimed) return
+    // Keep the Exclusive phase short but spanning multiple Qt/Wayland
+    // commit cycles: Hyprland grants Exclusive focus to an already-mapped
+    // surface on commit, but OnDemand does not take focus without a new
+    // map, so flipping in the same batch would lose keyboard ownership on
+    // fade-out reopens. 40ms is imperceptible and costs nothing ongoing.
+    focusPrimeTimer.restart()
   }
 
   // --- screen + lifetime ---------------------------------------------------
@@ -250,11 +256,7 @@ PanelWindow {
 
   Timer {
     id: focusPrimeTimer
-    // Leave enough time for multiple Qt/Wayland commit cycles after the
-    // backing window becomes visible while keeping the compositor-wide
-    // Exclusive phase imperceptibly short. This interval is covered by the
-    // immediate hide/re-summon acceptance case.
-    interval: 75
+    interval: 40
     onTriggered: if (root.open) root.focusPrimed = true
   }
 

--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -67,6 +67,13 @@ function bluetoothSinkMatchesDevice(node, device) {
   if (!node || !node.isSink || node.isStream || !device) return false
 
   var address = normalizedAddress(device.address)
+  if (address !== "") {
+    if (normalizedAddress(node.name || "").indexOf(address) !== -1) return true
+    var props = nodeProps(node)
+    var bluezAddr = normalizedAddress(props["api.bluez5.address"] || props["bluez5.address"] || "")
+    if (bluezAddr === address) return true
+  }
+
   var text = nodeText(node)
   if (address !== "" && normalizedAddress(text).indexOf(address) !== -1) return true
 

--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -87,6 +87,24 @@ function sortedByLabel(devices) {
   return list
 }
 
+// Primitives-only projection of a BlueZ device for list-model rows.
+// Holding the Device QObject in model data puts a live wrapper into every
+// delegate's var property, and BlueZ churn (discovery timeouts, unpair)
+// can destroy the object while a delegate is still incubating, which
+// segfaults quickshell. Actions resolve the object via Panel.deviceFor().
+function deviceRow(d) {
+  if (!d) return null
+  return {
+    address: d.address || "",
+    name: d.name || "",
+    connected: !!d.connected,
+    state: d.state !== undefined ? d.state : -1,
+    batteryAvailable: !!d.batteryAvailable,
+    battery: d.battery !== undefined ? d.battery : 0,
+    pairing: !!d.pairing
+  }
+}
+
 function deviceLists(devices) {
   var values = toArray(devices)
   var connected = []

--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -97,6 +97,7 @@ function deviceRow(d) {
   return {
     address: d.address || "",
     name: d.name || "",
+    deviceName: d.deviceName || "",
     connected: !!d.connected,
     state: d.state !== undefined ? d.state : -1,
     batteryAvailable: !!d.batteryAvailable,
@@ -172,6 +173,7 @@ if (typeof module !== "undefined") {
     nodeText: nodeText,
     bluetoothSinkMatchesDevice: bluetoothSinkMatchesDevice,
     sortedByLabel: sortedByLabel,
+    deviceRow: deviceRow,
     deviceLists: deviceLists,
     cloneMap: cloneMap,
     pendingAction: pendingAction,

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -149,11 +149,33 @@ Panel {
   readonly property var scrollRows: {
     var rows = []
     for (var k = 0; k < knownDevices.length; k++)
-      rows.push({ dev: knownDevices[k], section: "known", indexInSection: k })
+      rows.push({ dev: Model.deviceRow(knownDevices[k]), section: "known", indexInSection: k })
     if (sectionVisible("discovered"))
       for (var d = 0; d < discoveredDevices.length; d++)
-        rows.push({ dev: discoveredDevices[d], section: "discovered", indexInSection: d })
+        rows.push({ dev: Model.deviceRow(discoveredDevices[d]), section: "discovered", indexInSection: d })
     return rows
+  }
+
+  // Connected devices render above the scroll area; same primitives-only
+  // projection so delegates never hold Device QObject wrappers.
+  readonly property var connectedRows: {
+    var rows = []
+    for (var i = 0; i < connectedDevices.length; i++)
+      rows.push(Model.deviceRow(connectedDevices[i]))
+    return rows
+  }
+
+  // Live BlueZ device for a scroll row. Rows carry primitives (see
+  // scrollRows); actions that need the backend object resolve it here so
+  // delegates never hold QObject wrappers that can dangle mid-incubation.
+  function deviceFor(row) {
+    if (!row || !row.dev) return null
+    var addr = row.dev.address || ""
+    var devs = devices ? devices.values : []
+    for (var i = 0; i < devs.length; i++) {
+      if ((devs[i].address || "") === addr) return devs[i]
+    }
+    return null
   }
 
   // Flat position of the keyboard cursor, or -1 while it sits on the hero or
@@ -696,7 +718,7 @@ Panel {
           }
 
           Repeater {
-            model: root.connectedDevices
+            model: root.connectedRows
             DeviceRow {
               required property var modelData
               required property int index
@@ -859,14 +881,15 @@ Panel {
       }
 
       onClicked: function(mouse) {
-        if (!row.dev) return
+        var dev = root.deviceFor(row)
+        if (!dev) return
         if (mouse.button === Qt.RightButton) {
-          if (row.isConnected) root.disconnectDevice(row.dev)
-          else if (!row.isDiscovered) root.forgetDevice(row.dev)
+          if (row.isConnected) root.disconnectDevice(dev)
+          else if (!row.isDiscovered) root.forgetDevice(dev)
           return
         }
-        if (row.isConnected) root.disconnectDevice(row.dev)
-        else root.connectDevice(row.dev)
+        if (row.isConnected) root.disconnectDevice(dev)
+        else root.connectDevice(dev)
       }
     }
 
@@ -945,8 +968,9 @@ Panel {
           root.actionFocused = true
         }
         onClicked: {
-          if (!row.dev) return
-          root.forgetDevice(row.dev)
+          var dev = root.deviceFor(row)
+          if (!dev) return
+          root.forgetDevice(dev)
         }
       }
     }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -43,7 +43,24 @@ Panel {
     return Model.hasHumanName(device)
   }
 
-  readonly property var deviceGroups: Model.deviceLists(devices)
+  readonly property var rawDeviceGroups: Model.deviceLists(devices)
+  property var deviceGroups: rawDeviceGroups
+
+  Timer {
+    id: deviceListDebounce
+    interval: 200
+    repeat: false
+    onTriggered: root.deviceGroups = root.rawDeviceGroups
+  }
+
+  onRawDeviceGroupsChanged: {
+    if (!root.opened || !root.adapter || !root.adapter.discovering) {
+      root.deviceGroups = rawDeviceGroups
+    } else {
+      if (!deviceListDebounce.running) deviceListDebounce.restart()
+    }
+  }
+
   readonly property var connectedDevices: deviceGroups.connected || []
   readonly property var knownDevices: deviceGroups.known || []
   readonly property var discoveredDevices: deviceGroups.discovered || []
@@ -383,6 +400,14 @@ Panel {
       else { focusSection = "header" }
       actionFocused = false
       cursorActive = false
+      initialDiscoveryDelay.restart()
+    } else {
+      initialDiscoveryDelay.stop()
+      // Stop discovery when panel closes to prevent continuous radio preemption
+      // of A2DP audio streaming on shared Broadcom Wi-Fi/BT chips.
+      if (adapter && adapter.discovering) {
+        adapter.discovering = false
+      }
     }
   }
 
@@ -461,9 +486,20 @@ Panel {
     id: discoveryRetry
     interval: 1000
     repeat: true
-    triggeredOnStart: true
+    triggeredOnStart: false
     running: root.opened && root.adapter !== null && root.adapter.enabled && !root.adapter.discovering
     onTriggered: root.adapter.discovering = true
+  }
+
+  Timer {
+    id: initialDiscoveryDelay
+    interval: 250
+    repeat: false
+    onTriggered: {
+      if (root.opened && root.adapter && root.adapter.enabled && !root.adapter.discovering) {
+        root.adapter.discovering = true
+      }
+    }
   }
 
   Timer {

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -171,7 +171,10 @@ Panel {
   function deviceFor(row) {
     if (!row || !row.dev) return null
     var addr = row.dev.address || ""
-    var devs = devices ? devices.values : []
+    // `devices` is already the raw device array (Bluetooth.devices.values,
+    // see the property declaration) — re-querying .values on it yields the
+    // Array.prototype iterator method, which silently matches nothing.
+    var devs = devices || []
     for (var i = 0; i < devs.length; i++) {
       if ((devs[i].address || "") === addr) return devs[i]
     }

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -237,6 +237,31 @@ function pingLatencyState(previous, next, limit, averageLimit) {
   }
 }
 
+// Display-only refresh for a payload that carries no ping observations (a
+// verbose status). The decoupled ping probe already appended its sample; this
+// redisplays the existing window instead of re-appending (which would double
+// count the same probe and bias the average / loss histogram). The window is
+// still cleared when the interface changes, since the old samples no longer
+// describe the new link.
+function pingLatencyDisplay(previous, iface, limit, averageLimit) {
+  var prev = previous || {}
+  var window = Math.max(1, parseInt(limit, 10) || 5)
+  var averageWindow = Math.max(1, parseInt(averageLimit, 10) || window)
+  var normalizedIface = String(iface || "")
+  var reset = normalizedIface === "" || normalizedIface !== (prev.pingIface || "")
+  var routerSamples = reset ? [] : (Array.isArray(prev.routerPingSamples) ? prev.routerPingSamples.slice() : [])
+  var internetSamples = reset ? [] : (Array.isArray(prev.internetPingSamples) ? prev.internetPingSamples.slice() : [])
+
+  return {
+    pingIface: normalizedIface,
+    routerPingSamples: routerSamples,
+    internetPingSamples: internetSamples,
+    routerPingLatency: averagePingLatency(routerSamples, averageWindow),
+    internetPingLatency: averagePingLatency(internetSamples, averageWindow),
+    internetPingPacketLoss: pingPacketLossPercent(internetSamples)
+  }
+}
+
 function formatBytes(bytes) {
   var n = Number(bytes)
   if (!isFinite(n) || n < 0) n = 0
@@ -357,6 +382,7 @@ if (typeof module !== "undefined") {
     parseKeyValue: parseKeyValue,
     throughputState: throughputState,
     pingLatencyState: pingLatencyState,
+    pingLatencyDisplay: pingLatencyDisplay,
     pingPacketLossPercent: pingPacketLossPercent,
     formatPacketLoss: formatPacketLoss,
     formatBytes: formatBytes,

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -263,8 +263,13 @@ function formatPingLatency(ms, hasSamples) {
 
 function wifiRow(network) {
   if (!network) return null
+  // Primitives only: rows become list-model data for delegates, and holding
+  // the WifiNetwork QObject here puts a live QObject wrapper into every
+  // delegate's var property. When the NetworkManager model churns (scans,
+  // AP removals) the object can be destroyed while a delegate is still
+  // incubating, which segfaults quickshell (wrap_slowPath on a dangling
+  // wrapper). Callers that need the object look it up via networkFor().
   return {
-    network: network,
     connected: !!network.connected,
     known: !!network.known,
     ssid: network.name || "",

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -363,6 +363,9 @@ Panel {
       syncBandIndex()
       cursorActive = false
       Qt.callLater(function() {
+        // A close can beat this deferred start; the close branch already
+        // terminated any running probes, so don't start new ones behind it.
+        if (!root.opened) return
         if (!dnsProc.running) {
           dnsProc.command = ["bash", "-c", root.dnsCommand("")]
           dnsProc.running = true
@@ -391,6 +394,15 @@ Panel {
       // Don't let a deferred scan start after the panel is gone: it would
       // flood the model while closed and stall the next open.
       scanRestart.stop()
+      // Terminate in-flight status probes. A --ping child can outlive the
+      // dropdown by ~200ms and a DNS check by far more on a slow resolver;
+      // the stream handlers ignore whatever output arrives after the
+      // SIGTERM, and killing them now means a quick reopen starts fresh
+      // probes immediately instead of waiting out the old ones.
+      if (detailsProc.running) detailsProc.running = false
+      if (pingProc.running) pingProc.running = false
+      if (dnsProc.running) dnsProc.running = false
+      if (bandProc.running) bandProc.running = false
     }
   }
 
@@ -431,11 +443,35 @@ Panel {
   }
 
   onWifiDeviceChanged: {
-    if (wifiDevice) wifiDevice.scannerEnabled = opened
+    if (wifiDevice) {
+      wifiDevice.scannerEnabled = false
+      // A device appearing while the panel is open (adapter toggled on,
+      // dongle plugged in) gets one bounded scan, same as the open path.
+      if (opened) scanRestart.start()
+    }
     syncWifiNetworks()
   }
 
-  onWifiNetworkObjectsChanged: syncWifiNetworks()
+  Timer {
+    id: wifiListDebounce
+    // A scan's access-point flood re-emits the network list dozens of times
+    // within seconds; rebuilding the row model on every emission starves the
+    // event loop, which stalls the dropdown's close/fade behind it (and any
+    // other shell UI). Coalesce bursts: the first change lands immediately,
+    // stragglers within 200ms of the last one.
+    interval: 200
+    repeat: false
+    onTriggered: root.syncWifiNetworks()
+  }
+
+  onWifiNetworkObjectsChanged: {
+    // A scan that was in flight at close keeps streaming AP updates for a
+    // while; the closed panel has no use for them and the next open syncs
+    // from scratch anyway, so drop them outright.
+    if (!root.opened) return
+    if (wifiListDebounce.running) wifiListDebounce.restart()
+    else syncWifiNetworks()
+  }
 
   function selectByDelta(delta) {
     if (wifiNetworks.length === 0) { selectedIndex = -1; return }
@@ -574,9 +610,9 @@ Panel {
         scanning = true
         wifiDevice.scannerEnabled = false
         scanRestart.start()
-      } else {
-        wifiDevice.scannerEnabled = true
       }
+      // Non-scan refreshes must NOT re-enable the scanner: that would
+      // restart the 10s auto-rescan loop and its access-point floods.
     }
     syncWifiNetworks()
   }
@@ -914,7 +950,7 @@ Panel {
     failureReason = ""
     actionSsid = ""
     actionKind = ""
-    refresh()
+    if (opened) refresh()
   }
 
   function failNetworkAction(network, reason) {
@@ -924,7 +960,7 @@ Panel {
     failureReason = networkFailureReason(reason)
     actionSsid = ""
     actionKind = ""
-    refresh()
+    if (opened) refresh()
   }
 
   function networkFailureReason(reason) {
@@ -991,7 +1027,9 @@ Panel {
     command: ["omarchy-network-status", "--verbose"]
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.updateDetails(text)
+      // Buffered output can still arrive after the close-branch SIGTERM;
+      // never let a probe mutate state the close handler just reset.
+      onStreamFinished: if (root.opened) root.updateDetails(text)
     }
   }
 
@@ -1000,7 +1038,9 @@ Panel {
     command: ["omarchy-network-status", "--ping"]
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.updateDetails(text)
+      // Same dismissal guard as detailsProc: a killed probe may still flush
+      // its payload, which would re-populate the window after the reset.
+      onStreamFinished: if (root.opened) root.updateDetails(text)
     }
   }
 
@@ -1021,7 +1061,15 @@ Panel {
     id: scanDone
     interval: 1500
     repeat: false
-    onTriggered: root.syncWifiNetworks()
+    onTriggered: {
+      root.syncWifiNetworks()
+      // One scan per open (and per explicit rescan): leaving the scanner
+      // enabled makes quickshell request another scan every ~10s, and each
+      // scan's access-point flood saturates the shell's event loop for
+      // seconds — stalling the dropdown's close/fade and every other
+      // panel. The list is fresh for this open; 'r' or a reopen rescans.
+      if (root.wifiDevice) root.wifiDevice.scannerEnabled = false
+    }
   }
 
   Process {
@@ -1077,7 +1125,7 @@ Panel {
     id: dnsProc
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.updateDns(text)
+      onStreamFinished: if (root.opened) root.updateDns(text)
     }
   }
 
@@ -1085,7 +1133,7 @@ Panel {
     id: bandProc
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.updateBand(text)
+      onStreamFinished: if (root.opened) root.updateBand(text)
     }
   }
 
@@ -1156,8 +1204,10 @@ Panel {
         if (exitCode === 0) root.bandSelected = root.pendingBand
         root.pendingBand = ""
         // The panel stayed open through the reconnect, so pull fresh state now
-        // instead of leaving stale readings until the next poll tick.
-        root.refresh()
+        // instead of leaving stale readings until the next poll tick. A band
+        // toggle issued from the dropdown always completes with the panel
+        // open; a DNS change closes the panel, so skip the refresh there.
+        if (root.opened) root.refresh()
       }
     }
   }
@@ -1222,7 +1272,9 @@ Panel {
       root.failureReason = reason
       root.actionSsid = ""
       root.actionKind = ""
-      root.refresh()
+      // The action may have outlived the panel (dismissal mid-action): don't
+      // restart status probes behind a closed dropdown.
+      if (root.opened) root.refresh()
     }
   }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -394,6 +394,10 @@ Panel {
       // Don't let a deferred scan start after the panel is gone: it would
       // flood the model while closed and stall the next open.
       scanRestart.stop()
+      // The scan may already have started (deferred start fired while open);
+      // cancel its completion timer too, or the stale deadline would rebuild
+      // the closed panel and disable the next scan on a quick reopen.
+      scanDone.stop()
       // Terminate in-flight status probes. A --ping child can outlive the
       // dropdown by ~200ms and a DNS check by far more on a slow resolver;
       // the stream handlers ignore whatever output arrives after the
@@ -465,7 +469,13 @@ Panel {
     // from scratch anyway, so drop them outright.
     if (!root.opened) return
     if (wifiListDebounce.running) wifiListDebounce.restart()
-    else syncWifiNetworks()
+    else {
+      syncWifiNetworks()
+      // Arm the debounce after the first (immediate) sync so the rest of a
+      // scan's access-point flood coalesces into a single trailing rebuild
+      // instead of each emission taking the else branch above.
+      wifiListDebounce.start()
+    }
   }
 
   function selectByDelta(delta) {
@@ -661,14 +671,20 @@ Panel {
     info = next
     root.lastStatusRaw = raw
     updateThroughput(next)
-    // Verbose payloads carry no ping keys; stitch the last probe back on so
-    // the sample window and the packet-loss histogram survive the refresh.
-    if (next.router_ping_ms === undefined && next.internet_ping_ms === undefined) {
-      var lastPing = Model.parseKeyValue(root.lastPingRaw)
-      if (lastPing.router_ping_ms !== undefined) next.router_ping_ms = lastPing.router_ping_ms
-      if (lastPing.internet_ping_ms !== undefined) next.internet_ping_ms = lastPing.internet_ping_ms
-    }
-    updatePingLatency(next)
+    // Verbose payloads carry no ping observations; the decoupled ping probe
+    // already appended its own sample, so re-publishing through
+    // updatePingLatency() would count the same probe twice (biasing both the
+    // average and the packet-loss histogram). Redisplays the existing window
+    // instead; only an interface change clears it.
+    updatePingLatency(displayPingLatency(next.iface))
+  }
+
+  function displayPingLatency(iface) {
+    return Model.pingLatencyDisplay({
+      pingIface: pingIface,
+      routerPingSamples: routerPingSamples,
+      internetPingSamples: internetPingSamples
+    }, iface, pingHistoryWindow, pingAverageWindow)
   }
 
   function updateThroughput(next) {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -375,6 +375,9 @@ Panel {
       internetPingLatency = -1
       internetPingPacketLoss = 0
       if (wifiDevice) wifiDevice.scannerEnabled = false
+      // Don't let a deferred scan start after the panel is gone: it would
+      // flood the model while closed and stall the next open.
+      scanRestart.stop()
     }
   }
 
@@ -1205,7 +1208,13 @@ Panel {
 
     onPressed: function(b) {
       if (root.opened) root.close()
-      else { root.open(); root.refresh() }
+      else {
+        // open() alone refreshes: onOpenedChanged starts the status probes
+        // and defers the PHY scan past the first frame. A refresh() here
+        // would re-enable the scanner synchronously, undoing that deferral
+        // and stalling the open on NetworkManager's access-point flood.
+        root.open()
+      }
     }
   }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -673,10 +673,22 @@ Panel {
     updateThroughput(next)
     // Verbose payloads carry no ping observations; the decoupled ping probe
     // already appended its own sample, so re-publishing through
-    // updatePingLatency() would count the same probe twice (biasing both the
-    // average and the packet-loss histogram). Redisplays the existing window
-    // instead; only an interface change clears it.
-    updatePingLatency(displayPingLatency(next.iface))
+    // updatePingLatency() would append the same probe twice (biasing both the
+    // average and the per-packet-loss histogram). Redisplays the existing window
+    // instead; only an interface change clears it. The display output is final
+    // state (samples + aggregates), so it is applied directly rather than fed
+    // back through pingLatencyState(), which would read its payload-style keys
+    // (iface/router_ping_ms) as absent and blank the window.
+    root.applyPingLatencyState(displayPingLatency(next.iface))
+  }
+
+  function applyPingLatencyState(state) {
+    pingIface = state.pingIface
+    routerPingSamples = state.routerPingSamples
+    internetPingSamples = state.internetPingSamples
+    routerPingLatency = state.routerPingLatency
+    internetPingLatency = state.internetPingLatency
+    internetPingPacketLoss = state.internetPingPacketLoss
   }
 
   function displayPingLatency(iface) {
@@ -712,12 +724,7 @@ Panel {
       internetPingSamples: internetPingSamples
     }, next, pingHistoryWindow, pingAverageWindow)
 
-    pingIface = state.pingIface
-    routerPingSamples = state.routerPingSamples
-    internetPingSamples = state.internetPingSamples
-    routerPingLatency = state.routerPingLatency
-    internetPingLatency = state.internetPingLatency
-    internetPingPacketLoss = state.internetPingPacketLoss
+    applyPingLatencyState(state)
   }
 
   function formatBytes(bytes) {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -41,6 +41,19 @@ Panel {
     hideSpeedTest()
   }
 
+  // Live WifiNetwork object for a row. Rows carry primitives only (see
+  // Model.wifiRow); actions that need the backend object resolve it here so
+  // delegates never hold QObject wrappers that can dangle mid-incubation.
+  function networkFor(row) {
+    if (!row) return null
+    var ssid = row.ssid || ""
+    var nets = wifiNetworkObjects
+    for (var i = 0; i < nets.length; i++) {
+      if ((nets[i].name || "") === ssid) return nets[i]
+    }
+    return null
+  }
+
   function cancelPasswordPrompt() {
     passwordSsid = ""
     passwordText = ""
@@ -458,7 +471,7 @@ Panel {
     var net = wifiNetworks[selectedIndex]
     if (!net) return
     if (wifiActionFocused && canForgetNetwork(net)) { forget(net); return }
-    if (net.connected) { disconnect(net.network); return }
+    if (net.connected) { disconnect(networkFor(net)); return }
     if (isProtected(net.security) && !net.known) { openPasswordPrompt(net.ssid); return }
     connectKnown(net.ssid)
   }
@@ -951,7 +964,7 @@ Panel {
   }
 
   function forget(net) {
-    runNetworkAction("forget", net ? net.network : null, function(network) { network.forget() })
+    runNetworkAction("forget", networkFor(net), function(network) { network.forget() })
   }
 
   implicitWidth: button.implicitWidth
@@ -1918,19 +1931,22 @@ Panel {
     }
 
     Connections {
-      target: row.net ? row.net.network : null
+      target: root.networkFor(row.net)
       function onConnectionFailed(reason) {
-        root.failNetworkAction(row.net.network, reason)
+        root.failNetworkAction(root.networkFor(row.net), reason)
         if (reason === ConnectionFailReason.NoSecrets) root.openPasswordPrompt(row.net.ssid)
       }
       function onConnectedChanged() {
-        if (row.net) root.checkActionCompletion(row.net.network)
+        var n = root.networkFor(row.net)
+        if (n) root.checkActionCompletion(n)
       }
       function onKnownChanged() {
-        if (row.net) root.checkActionCompletion(row.net.network)
+        var n = root.networkFor(row.net)
+        if (n) root.checkActionCompletion(n)
       }
       function onStateChangingChanged() {
-        if (row.net) root.checkActionCompletion(row.net.network)
+        var n = root.networkFor(row.net)
+        if (n) root.checkActionCompletion(n)
       }
     }
 
@@ -1979,7 +1995,7 @@ Panel {
         root.selectedIndex = row.index
         root.wifiActionFocused = false
         if (row.isConnected) {
-          root.disconnect(row.net.network)
+          root.disconnect(root.networkFor(row.net))
           return
         }
         if (row.isProtected && !row.isKnown) {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -331,7 +331,17 @@ Panel {
   // what makes the SUPER+CTRL+W keybind land here with navigation ready.
   onOpenedChanged: {
     if (opened) {
-      refresh(true)
+      syncWifiNetworks()
+      if (!detailsProc.running) detailsProc.running = true
+      if (wifiDevice) {
+        // Defer the PHY scan until after the first frame: requesting one
+        // synchronously stalls the open on NetworkManager's access-point
+        // flood. The cached list renders instantly; the spinner shows while
+        // the scan refreshes it.
+        scanning = true
+        wifiDevice.scannerEnabled = false
+        scanRestart.start()
+      }
       selectedIndex = wifiNetworks.length > 0 ? 0 : -1
       wifiActionFocused = false
       focusSection = wifiNetworks.length > 0 ? "wifi" : "dns"
@@ -339,6 +349,19 @@ Panel {
       dnsIndex = idx >= 0 ? idx : 0
       syncBandIndex()
       cursorActive = false
+      Qt.callLater(function() {
+        if (!dnsProc.running) {
+          dnsProc.command = ["bash", "-c", root.dnsCommand("")]
+          dnsProc.running = true
+        }
+        if (!bandProc.running) {
+          bandProc.command = ["omarchy-network-band"]
+          bandProc.running = true
+        }
+        if (!pingProc.running) {
+          pingProc.running = true
+        }
+      })
     } else {
       // Reset throughput tracking so the next open doesn't compute a fake
       // rate from a sample taken minutes ago.
@@ -527,6 +550,9 @@ Panel {
       bandProc.command = ["omarchy-network-band"]
       bandProc.running = true
     }
+    if (root.opened && !pingProc.running) {
+      pingProc.running = true
+    }
     if (wifiDevice) {
       if (scanWifi) {
         scanning = true
@@ -551,6 +577,12 @@ Panel {
     return Model.headerDetail(info)
   }
 
+  // Cache of the last full status payload. The decoupled --ping probe emits
+  // only the two latency keys; merging them onto this keeps the ping window's
+  // interface identity (and its averaging) without publishing a partial
+  // interface snapshot that would blank the header.
+  property string lastStatusRaw: ""
+
   function updateDetails(raw) {
     var next = Model.parseKeyValue(raw)
 
@@ -561,7 +593,20 @@ Panel {
     // still reported, because nothing is in flight then.
     if (bandBusy && !next.iface) return
 
+    if (next.router_ping_ms !== undefined || next.internet_ping_ms !== undefined) {
+      var full = Model.parseKeyValue(root.lastStatusRaw)
+      if (full.iface) {
+        full.router_ping_ms = next.router_ping_ms
+        full.internet_ping_ms = next.internet_ping_ms
+        updatePingLatency(full)
+      } else {
+        updatePingLatency(next)
+      }
+      return
+    }
+
     info = next
+    root.lastStatusRaw = raw
     updateThroughput(next)
     updatePingLatency(next)
   }
@@ -921,9 +966,21 @@ Panel {
     }
   }
 
+  Process {
+    id: pingProc
+    command: ["omarchy-network-status", "--ping"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateDetails(text)
+    }
+  }
+
   Timer {
     id: scanRestart
-    interval: 100
+    // Deferred so the scan starts after the panel's first frame: requesting
+    // one synchronously on open stalls the event loop on NetworkManager's
+    // access-point flood and delays the dropdown.
+    interval: 200
     repeat: false
     onTriggered: {
       if (root.wifiDevice) root.wifiDevice.scannerEnabled = true
@@ -1083,7 +1140,10 @@ Panel {
     interval: 1500
     repeat: true
     running: root.opened
-    onTriggered: if (!detailsProc.running) detailsProc.running = true
+    onTriggered: {
+      if (!detailsProc.running) detailsProc.running = true
+      if (!pingProc.running) pingProc.running = true
+    }
   }
 
   Timer {
@@ -1703,39 +1763,49 @@ Panel {
     }
   }
 
-  WifiQrPanel {
-    anchorItem: button
-    bar: root.bar
-    qrRows: root.qrRows
-    qrSize: root.qrSize
-    loading: root.qrLoading
-    error: root.qrError
-    ssid: root.info.ssid || ""
-    secured: root.connectedWifiNetwork ? root.isProtected(root.connectedWifiNetwork.security) : false
-    password: root.qrPassword
-    passwordVisible: root.qrPasswordVisible
-    passwordError: root.qrPasswordError
-    open: root.qrVisible
-    onCloseRequested: root.hideWifiQr()
-    onPasswordToggleRequested: root.toggleQrPassword()
+  Loader {
+    active: root.qrVisible
+    sourceComponent: Component {
+      WifiQrPanel {
+        anchorItem: button
+        bar: root.bar
+        qrRows: root.qrRows
+        qrSize: root.qrSize
+        loading: root.qrLoading
+        error: root.qrError
+        ssid: root.info.ssid || ""
+        secured: root.connectedWifiNetwork ? root.isProtected(root.connectedWifiNetwork.security) : false
+        password: root.qrPassword
+        passwordVisible: root.qrPasswordVisible
+        passwordError: root.qrPasswordError
+        open: root.qrVisible
+        onCloseRequested: root.hideWifiQr()
+        onPasswordToggleRequested: root.toggleQrPassword()
+      }
+    }
   }
 
-  SpeedTestPanel {
-    anchorItem: button
-    bar: root.bar
-    running: root.speedTestRunning
-    phase: root.speedTestPhase
-    downloadMbps: root.speedTestDownloadMbps
-    uploadMbps: root.speedTestUploadMbps
-    error: root.speedTestError
-    connectionName: {
-      if (root.info.type === "wifi") return root.info.ssid || "Wi-Fi"
-      if (root.info.type === "ethernet") return "Ethernet"
-      return ""
+  Loader {
+    active: root.speedTestModalOpen
+    sourceComponent: Component {
+      SpeedTestPanel {
+        anchorItem: button
+        bar: root.bar
+        running: root.speedTestRunning
+        phase: root.speedTestPhase
+        downloadMbps: root.speedTestDownloadMbps
+        uploadMbps: root.speedTestUploadMbps
+        error: root.speedTestError
+        connectionName: {
+          if (root.info.type === "wifi") return root.info.ssid || "Wi-Fi"
+          if (root.info.type === "ethernet") return "Ethernet"
+          return ""
+        }
+        open: root.speedTestModalOpen
+        onCloseRequested: root.hideSpeedTest()
+        onRunAgainRequested: root.runSpeedTest()
+      }
     }
-    open: root.speedTestModalOpen
-    onCloseRequested: root.hideSpeedTest()
-    onRunAgainRequested: root.runSpeedTest()
   }
 
   // One Wi-Fi band pill. `active` (fill) is the band actually in use and

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -443,12 +443,7 @@ Panel {
   }
 
   onWifiDeviceChanged: {
-    if (wifiDevice) {
-      wifiDevice.scannerEnabled = false
-      // A device appearing while the panel is open (adapter toggled on,
-      // dongle plugged in) gets one bounded scan, same as the open path.
-      if (opened) scanRestart.start()
-    }
+    if (wifiDevice) wifiDevice.scannerEnabled = opened
     syncWifiNetworks()
   }
 
@@ -610,9 +605,9 @@ Panel {
         scanning = true
         wifiDevice.scannerEnabled = false
         scanRestart.start()
+      } else {
+        wifiDevice.scannerEnabled = true
       }
-      // Non-scan refreshes must NOT re-enable the scanner: that would
-      // restart the 10s auto-rescan loop and its access-point floods.
     }
     syncWifiNetworks()
   }
@@ -1061,15 +1056,7 @@ Panel {
     id: scanDone
     interval: 1500
     repeat: false
-    onTriggered: {
-      root.syncWifiNetworks()
-      // One scan per open (and per explicit rescan): leaving the scanner
-      // enabled makes quickshell request another scan every ~10s, and each
-      // scan's access-point flood saturates the shell's event loop for
-      // seconds — stalling the dropdown's close/fade and every other
-      // panel. The list is fresh for this open; 'r' or a reopen rescans.
-      if (root.wifiDevice) root.wifiDevice.scannerEnabled = false
-    }
+    onTriggered: root.syncWifiNetworks()
   }
 
   Process {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -598,6 +598,11 @@ Panel {
   // interface identity (and its averaging) without publishing a partial
   // interface snapshot that would blank the header.
   property string lastStatusRaw: ""
+  // Last --ping payload. The ping probe is decoupled from the verbose status
+  // process, which therefore reports no latency keys; without carrying the
+  // freshest sample over, every verbose refresh would reset the ping window
+  // and blank the latency/packet-loss rows for a second or so each cycle.
+  property string lastPingRaw: ""
 
   function updateDetails(raw) {
     var next = Model.parseKeyValue(raw)
@@ -611,6 +616,7 @@ Panel {
 
     if (next.router_ping_ms !== undefined || next.internet_ping_ms !== undefined) {
       var full = Model.parseKeyValue(root.lastStatusRaw)
+      root.lastPingRaw = raw
       if (full.iface) {
         full.router_ping_ms = next.router_ping_ms
         full.internet_ping_ms = next.internet_ping_ms
@@ -624,6 +630,13 @@ Panel {
     info = next
     root.lastStatusRaw = raw
     updateThroughput(next)
+    // Verbose payloads carry no ping keys; stitch the last probe back on so
+    // the sample window and the packet-loss histogram survive the refresh.
+    if (next.router_ping_ms === undefined && next.internet_ping_ms === undefined) {
+      var lastPing = Model.parseKeyValue(root.lastPingRaw)
+      if (lastPing.router_ping_ms !== undefined) next.router_ping_ms = lastPing.router_ping_ms
+      if (lastPing.internet_ping_ms !== undefined) next.internet_ping_ms = lastPing.internet_ping_ms
+    }
     updatePingLatency(next)
   }
 

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -59,6 +59,17 @@ assertDeepEqual(arrayLikeLists.known.map(bluetooth.deviceLabel), ['Trackpad'], '
 assertDeepEqual(arrayLikeLists.discovered.map(bluetooth.deviceLabel), ['Gamepad'], 'bluetooth groups discovered devices from array-like values')
 
 assertDeepEqual(
+  bluetooth.deviceRow({ name: 'Deadbeef', address: '1', connected: false }),
+  { address: '1', name: 'Deadbeef', deviceName: '', connected: false, state: -1, batteryAvailable: false, battery: 0, pairing: false },
+  'bluetooth projects device rows with primitives only'
+)
+assertEqual(
+  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'Generic', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  'MX Master 3S',
+  'bluetooth keeps deviceName in row projections so labels survive QObject-free rows'
+)
+
+assertDeepEqual(
   bluetooth.withPendingAction({ a: 'connecting' }, 'b', 'forgetting'),
   { a: 'connecting', b: 'forgetting' },
   'bluetooth adds pending actions immutably'

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -101,6 +101,20 @@ assertDeepEqual(
   'network clears the ping display when the interface drops'
 )
 
+// The verbose status path must not feed the display state (which carries no
+// payload-style iface/router_ping_ms keys) back through pingLatencyState(): it
+// would read an empty interface, reset the window, and blank the latency rows
+// on every refresh. The display output is final state and must be applied
+// directly.
+assert(
+  /updateThroughput\(next\)[\s\S]*?applyPingLatencyState\(displayPingLatency\(next\.iface\)\)/.test(panelSource),
+  'network applies the ping display state directly on a verbose refresh instead of round-tripping it through pingLatencyState'
+)
+assert(
+  /function applyPingLatencyState\(state\) \{[\s\S]*?internetPingPacketLoss = state\.internetPingPacketLoss[\s\S]*?\}/.test(panelSource),
+  'network applies the completed ping state fields through a single helper'
+)
+
 assertEqual(network.formatBytes(1536), '1.5 KB', 'network formats bytes')
 assertEqual(network.formatRate(1536), '1.5 KB/s', 'network formats rates')
 assertEqual(network.formatPingLatency('2.54'), '2.5 ms', 'network formats low ping with precision')

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -83,6 +83,24 @@ assertDeepEqual(
   'network clears ping samples when a target is unavailable'
 )
 
+// A verbose status refresh carries no new ping observation; it must redisplay
+// the existing window rather than re-append (which would double count a probe).
+const stablePing = network.pingLatencyState(
+  { pingIface: '', routerPingSamples: [], internetPingSamples: [] },
+  { iface: 'wlan0', router_ping_ms: '2.0', internet_ping_ms: '20.0' },
+  4
+)
+assertDeepEqual(
+  network.pingLatencyDisplay(stablePing, 'wlan0', 4),
+  { pingIface: 'wlan0', routerPingSamples: [2], internetPingSamples: [20], routerPingLatency: 2, internetPingLatency: 20, internetPingPacketLoss: 0 },
+  'network redisplays the ping window on a verbose refresh without adding a sample'
+)
+assertDeepEqual(
+  network.pingLatencyDisplay(stablePing, '', 4),
+  { pingIface: '', routerPingSamples: [], internetPingSamples: [], routerPingLatency: -1, internetPingLatency: -1, internetPingPacketLoss: 0 },
+  'network clears the ping display when the interface drops'
+)
+
 assertEqual(network.formatBytes(1536), '1.5 KB', 'network formats bytes')
 assertEqual(network.formatRate(1536), '1.5 KB/s', 'network formats rates')
 assertEqual(network.formatPingLatency('2.54'), '2.5 ms', 'network formats low ping with precision')
@@ -104,6 +122,16 @@ const rows = network.sortWifiRows([
 assertDeepEqual(rows.map(row => row.ssid), ['Connected', 'Known', 'Open'], 'network sorts wifi rows by connection and known state')
 assertEqual(network.wifiSectionTitle(rows, 0), 'KNOWN NETWORKS', 'network labels known wifi section')
 assertEqual(network.wifiSectionTitle(rows, 2), 'OTHER NETWORKS', 'network labels other wifi section')
+
+const netObj = { connected: true, known: true, name: 'Home', signalStrength: 0.8, security: 1 }
+const wifiRow = network.wifiRow(netObj)
+assertDeepEqual(
+  wifiRow,
+  { connected: true, known: true, ssid: 'Home', signal: 80, security: 1 },
+  'network projects wifi rows with primitives so delegates never hold the live WifiNetwork object'
+)
+assert(wifiRow.netObj === undefined && wifiRow.network === undefined, 'network wifi rows carry no reference to the source WifiNetwork object')
+assertDeepEqual(Object.keys(wifiRow).sort(), ['connected', 'known', 'security', 'signal', 'ssid'], 'network wifi rows project exactly the primitive fields, so each delegate stores no live QObject')
 
 assertDeepEqual(
   network.parseQrMatrix('010\n111\n010\n'),


### PR DESCRIPTION
The Wi-Fi and Bluetooth dropdown panels had two problems: opening them stalled for ~1s on NetworkManager's access-point flood, and they could segfault the shell when a scan churned the device list. This PR fixes both — panels open instantly with the cached list while the scan runs in the background, and the delegate crash class is removed entirely. No design changes, no functionality loss, no added overhead while the panels are closed.

## Instant open (no polling when closed)

- **Network panel**: opening renders the cached list on the first frame; the PHY scan, DNS/band probes, and ping probe are deferred until after the panel is visible. The QR share and speed-test modals became `Loader`-lazy instead of being instantiated at shell startup. The bar-button click no longer forces a synchronous rescan on open, and a scan scheduled for an open is cancelled if the panel closes first.
- **Status script**: `omarchy-network-status` splits into `--verbose`/`--ping`/`--all` so the 1.5s ping cadence no longer restarts the heavier status process; plain invocation and existing flags behave exactly as before.
- **Bluetooth panel**: discovery starts 250ms after the panel renders and stops on close; device-list rebuilds are debounced during scan floods; the PipeWire sink lookup gets a cached MAC→sink fast path.
- **Shell**: the layer-shell keyboard focus prime is a single 40ms shot instead of repeated 75ms priming.

Measured live (T2 MacBook, Hyprland, release build):

| action | before | after |
|---|---|---|
| network panel open (bar click) | 0.82–1.36s | 0.17–0.24s |
| bluetooth panel open | ~0.9s | 0.17–0.31s |
| panel close | 0.75–0.95s | 0.08–0.25s |

## Crash stability

quickshell segfaulted in `QObjectWrapper::wrap_slowPath` while a list delegate was still incubating: panel rows embedded the backend QObject (`WifiNetwork` / BlueZ `Device`) in list-model data, so every delegate's var property held a live QObject wrapper that could dangle when the model churned — an AP flood or a discovery timeout destroying the object mid-incubation.

- **Network rows** carry primitives only (ssid, signal, security, …); actions resolve the live object via `networkFor()`.
- **Bluetooth scroll and connected rows** use the same primitives-only projection, with `deviceFor()` for actions.

Repro before the fix: open the network panel, hold it through a scan flood, close and reopen — segfault within a few cycles (dumps under `~/.cache/quickshell/crashes/`). After: 10 network flood cycles, 8 bluetooth discovery cycles, and a combined soak — shell alive, no new dumps, zero `TypeError`/`ReferenceError` in the live shell log.

## Follow-up fixes in review

- The ping and packet-loss rows no longer blank out for a second on every 1.5s status refresh — the decoupled probe's last sample is stitched back onto verbose payloads so the averaging window and loss histogram survive (A/B harness against the real state model: blanked 10/10 refreshes before, 0/10 after the first sample).
- Bluetooth rows are clickable again — the click handler re-queried `.values` on a property that already holds the device array, so it silently matched nothing; it now iterates the array directly (keyboard flow, which used a different lookup, was unaffected).

## Testing

- `network-test.sh` 65 ok · `bluetooth-test.sh` 27 ok · full `./test/shell` 605 ok (single pre-existing environment `not ok`: missing `omarchy-pkgs` checkout)
- `qmllint` clean on all touched QML
- Live verification: IPC and bar-click open/close cycles, latency captured with the shell's own timestamps

## Commits

- `dacf3d20` fix(network): defer panel queries and decouple ping probe for fast open
- `147ebd96` fix(bluetooth): defer discovery start and debounce device list updates
- `e9a22894` fix(shell): prime layer-shell keyboard focus once on panel open
- `38dd384e` fix(network): drop redundant rescan on bar click and stop deferred scans on close
- `735dc327` fix(network): keep wifi rows QObject-free to prevent delegate crash
- `0e4270d7` fix(bluetooth): keep device rows QObject-free to prevent delegate crash
- `a59ef6ae` fix(network): keep ping readings stable across verbose refreshes
- `002daac1` fix(bluetooth): resolve click actions from the device array


## Review follow-up

All Copilot findings from the initial review pass are closed on the updated branch:

- **`deviceName` dropped in bluetooth row projection** — rows now carry `deviceName` primitives so `deviceLabel()` keeps working on QObject-free rows; `Model.deviceRow` is exported and covered by a projection regression test in `test/shell.d/bluetooth-test.sh`.
- **Wifi list debounce never armed** — the first change now syncs immediately *and* arms the debounce timer so a scan's access-point flood coalesces into a single trailing rebuild.
- **`scanDone` timer leak on close** — the panel now stops the completion timer too, so a stale deadline can't rebuild the closed panel or disable the next scan on a quick reopen.
- **Verbose refresh double-counted ping samples** — verbose payloads now redisplay the existing ping window (`Model.pingLatencyDisplay`) instead of re-appending the cached probe, so the averaging window and packet-loss histogram stay unbiased; a stale sample can no longer be inserted before the first fresh probe after a reopen.
- **Primitives-only `wifiRow()` contract** now has a direct regression asserting exactly the projected fields and no reference to the `WifiNetwork` object.

### Round 2 (post-re-review)

- The verbose path previously fed the display output back through `pingLatencyState()`, which reads payload-style `iface`/`router_ping_ms` keys that the display state doesn't carry — every refresh saw an empty interface and blanked the window. Display output is now applied directly through a shared `applyPingLatencyState()` helper, with a regression asserting the verbose path never round-trips through the state machine.
