### PR TITLE
Support hardware, fingerprint, and password Polkit flows

### DIFF
--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -38,17 +38,26 @@ Item {
   // to the password even when a sensor is enrolled. Refreshed per request.
   property bool laptopClosed: false
   property int shakeOffset: 0
+  property bool waitingDelayLatched: false
 
   readonly property bool dialogVisible: polkitAgent.isActive || closing
-  // We show one method at a time. Fingerprint owns the dialog while PAM is
-  // waiting on the reader (lid open, sensor enrolled); the moment PAM asks for
-  // a password — including immediately when the lid is shut and the clamshell
-  // gate skips pam_fprintd — we switch to the password field instead.
-  readonly property bool fingerprintMode: fingerprintConfigured && !laptopClosed && dialogVisible && !responseRequired && !submitted && !errorFlash
+  readonly property var authState: PolkitModel.authenticationState(currentPrompt, currentSupplementary, responseRequired)
+  readonly property var authPresentation: PolkitModel.authenticationPresentation(authState.method, fingerprintConfigured, laptopClosed)
+  readonly property bool fingerprintMode: dialogVisible && authState.method === "fingerprint" && !submitted && !errorFlash
+  readonly property bool fidoMode: dialogVisible && authState.method === "fido" && !submitted && !errorFlash
+  readonly property bool compactMode: fingerprintMode || fidoMode || (dialogVisible && authState.method === "waiting" && !submitted && !errorFlash)
+  readonly property bool waitingDelayActive: !waitingDelayLatched && !submitted && !errorFlash && authState.method === "waiting" && waitingDelayTimer.running
   readonly property int cardHeight: panel.height > 0 ? Math.min(fieldHeight + contentMargin * 2, panel.height - Style.gapsOut * 2) : fieldHeight + contentMargin * 2
-  // Password mode is a wide field; fingerprint mode collapses to a square that
+  // Password mode is a wide field; compact modes collapse to a square that
   // just frames the centered sensor icon.
-  readonly property int cardWidth: fingerprintMode ? cardHeight : Math.min(Style.space(312), Math.max(Style.space(260), panel.width - Style.gapsOut * 2))
+  readonly property int cardWidth: compactMode ? cardHeight : Math.min(Style.space(312), Math.max(Style.space(260), panel.width - Style.gapsOut * 2))
+
+  Timer {
+    id: waitingDelayTimer
+    interval: 1000
+    repeat: false
+    onTriggered: root.waitingDelayLatched = true
+  }
 
   function authorizationLabel(message) {
     return PolkitModel.authorizationLabel(message)
@@ -62,6 +71,11 @@ Item {
     if (!laptopClosedProc.running) laptopClosedProc.running = true
   }
 
+  function finishWaitingDelay() {
+    waitingDelayLatched = true
+    waitingDelayTimer.stop()
+  }
+
   function resetSnapshot() {
     currentMessage = ""
     currentPrompt = ""
@@ -72,6 +86,8 @@ Item {
     errorFlash = false
     submitted = false
     passwordInput.text = ""
+    waitingDelayTimer.stop()
+    waitingDelayLatched = false
   }
 
   function syncFromFlow() {
@@ -86,10 +102,13 @@ Item {
     failed = !!flow.failed
 
     if (responseRequired) submitted = false
+    if (authState.method !== "waiting") finishWaitingDelay()
   }
 
   function beginFlow() {
     closeTimer.stop()
+    waitingDelayLatched = false
+    waitingDelayTimer.restart()
     closing = false
     submitted = false
     passwordInput.text = ""
@@ -100,15 +119,16 @@ Item {
 
   function refocus() {
     if (!dialogVisible) return
-    // In fingerprint mode there is no field to type into — park focus on the
-    // key catcher so Escape still cancels; otherwise focus the password field.
-    if (fingerprintMode) keyCatcher.forceActiveFocus()
+    // While PAM is handling a non-interactive prompt, park focus on the key
+    // catcher so Escape still cancels without sending an empty response.
+    if (compactMode || !responseRequired) keyCatcher.forceActiveFocus()
     else passwordInput.forceActiveFocus()
   }
 
   function submitResponse() {
     var flow = polkitAgent.flow
     if (!flow || !flow.isResponseRequired) return
+    finishWaitingDelay()
     submitted = true
     errorFlash = false
     flow.submit(passwordInput.text)
@@ -126,6 +146,7 @@ Item {
   }
 
   function triggerFailureFeedback() {
+    finishWaitingDelay()
     submitted = false
     errorFlash = true
     passwordInput.text = ""
@@ -157,6 +178,7 @@ Item {
     NumberAnimation { target: root; property: "shakeOffset"; to: 8; duration: 50; easing.type: Easing.InOutQuad }
     NumberAnimation { target: root; property: "shakeOffset"; to: 0; duration: 55; easing.type: Easing.OutQuad }
   }
+
   FileView {
     path: "/etc/pam.d/polkit-1"
     watchChanges: true
@@ -248,6 +270,7 @@ Item {
       color: root.background
       borderSpec: root.borderSpec
       padding: root.contentMargin
+      opacity: root.waitingDelayActive ? 0.0 : 1.0
 
       MouseArea { anchors.fill: parent; onClicked: root.refocus() }
 
@@ -274,16 +297,16 @@ Item {
         anchors.centerIn: parent
         width: Math.round(root.fieldHeight * 0.7)
         height: width
-        visible: root.fingerprintMode
-        text: "\udb80\ude37"
+        visible: root.compactMode
+        text: root.authPresentation.glyph === "fido" ? "\udb80\udf06" : (root.authPresentation.glyph === "fingerprint" ? "\udb80\ude37" : "\uf023")
         fontFamily: root.fontFamily
-        fontSize: Math.round(root.fieldHeight * 0.7)
+        fontSize: root.authPresentation.glyph === "fido" || root.authPresentation.glyph === "fingerprint" ? Math.round(root.fieldHeight * 0.7) : Style.font.iconLarge
         color: root.errorFlash ? Color.polkit.textError : root.accent
       }
 
       Row {
         id: cardRow
-        visible: !root.fingerprintMode
+        visible: !root.compactMode
         anchors.fill: parent
         anchors.topMargin: card.contentTopInset
         anchors.rightMargin: card.contentRightInset
@@ -319,9 +342,9 @@ Item {
             echoMode: root.responseVisible ? TextInput.Normal : TextInput.Password
             passwordCharacter: "\u2022"
             color: root.errorFlash ? Color.polkit.textError : root.foreground
-            cursorVisible: activeFocus && !root.submitted && !root.errorFlash
-            readOnly: root.submitted || root.errorFlash
-            enabled: root.dialogVisible
+            cursorVisible: activeFocus && root.responseRequired && !root.submitted && !root.errorFlash
+            readOnly: !root.responseRequired || root.submitted || root.errorFlash
+            enabled: root.dialogVisible && root.responseRequired
             onAccepted: root.submitResponse()
             Keys.onPressed: function(event) {
               if (event.key === Qt.Key_Escape) {
@@ -335,7 +358,7 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : "Enter password")
+            text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : root.authState.prompt)
             color: root.errorFlash ? Color.polkit.textError : root.foreground
             opacity: root.errorFlash ? 1 : 0.36
             font.family: root.fontFamily
@@ -350,13 +373,13 @@ Item {
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
             color: root.errorFlash ? Color.polkit.textError : root.foreground
-            visible: passwordInput.visible && passwordInput.activeFocus && passwordInput.text.length === 0 && !root.submitted && !root.errorFlash
+            visible: passwordInput.visible && passwordInput.activeFocus && root.responseRequired && passwordInput.text.length === 0 && !root.submitted && !root.errorFlash
           }
 
           MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton
-            enabled: passwordInput.visible
+            enabled: passwordInput.enabled
             onClicked: passwordInput.forceActiveFocus()
           }
         }
@@ -364,13 +387,41 @@ Item {
     }
 
     Rectangle {
-      width: Math.min(justificationText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
+      id: cuePill
+      visible: root.compactMode && (root.fidoMode || root.fingerprintMode)
+      width: Math.min(cueText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
       height: Style.space(28)
       anchors.horizontalCenter: card.horizontalCenter
       anchors.bottom: card.top
       anchors.bottomMargin: Style.space(10)
       radius: root.cornerRadius
       color: root.background
+
+      Text {
+        id: cueText
+        anchors.fill: parent
+        anchors.leftMargin: Style.space(12)
+        anchors.rightMargin: Style.space(12)
+        text: root.authState.prompt
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        elide: Text.ElideMiddle
+      }
+    }
+
+    Rectangle {
+      id: justificationPill
+      width: Math.min(justificationText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
+      height: Style.space(28)
+      anchors.horizontalCenter: card.horizontalCenter
+      anchors.bottom: cuePill.visible ? cuePill.top : card.top
+      anchors.bottomMargin: Style.space(10)
+      radius: root.cornerRadius
+      color: root.background
+      opacity: root.waitingDelayActive ? 0.0 : 1.0
 
       Text {
         id: justificationText

--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -34,18 +34,33 @@ Item {
   property bool errorFlash: false
   // pam_fprintd appears in the polkit PAM stack (a sensor is enrolled).
   property bool fingerprintConfigured: false
+  // pam_u2f appears in the polkit PAM stack.
+  property bool fidoConfigured: false
+  // Raw ordered methods from the PAM configuration.
+  property var pamMethods: []
+  // Filtered and ordered active methods based on capabilities and hardware state.
+  readonly property var activeMethods: {
+    var list = []
+    for (var i = 0; i < pamMethods.length; i++) {
+      var m = pamMethods[i]
+      if (m === "fingerprint" && (!lidStateKnown || laptopClosed || !fingerprintConfigured)) continue
+      if (m === "fido" && (!fidoStateKnown || !fidoTokenConnected || !fidoConfigured)) continue
+      list.push(m)
+    }
+    return list
+  }
   // Lid shut right now — the reader is physically unreachable, so we fall back
   // to the password even when a sensor is enrolled. Refreshed per request.
   property bool laptopClosed: false
+  property bool lidStateKnown: false
+  property bool fidoTokenConnected: false
+  property bool fidoStateKnown: false
   property int shakeOffset: 0
   property bool waitingDelayLatched: false
 
   readonly property bool dialogVisible: polkitAgent.isActive || closing
   readonly property var authState: PolkitModel.authenticationState(currentPrompt, currentSupplementary, responseRequired)
-  readonly property var authPresentation: PolkitModel.authenticationPresentation(authState.method, fingerprintConfigured, laptopClosed)
-  readonly property bool fingerprintMode: dialogVisible && authState.method === "fingerprint" && !submitted && !errorFlash
-  readonly property bool fidoMode: dialogVisible && authState.method === "fido" && !submitted && !errorFlash
-  readonly property bool compactMode: fingerprintMode || fidoMode || (dialogVisible && authState.method === "waiting" && !submitted && !errorFlash)
+  readonly property bool compactMode: dialogVisible && (authState.method === "waiting" || authState.method === "physical") && !submitted && !errorFlash
   readonly property bool waitingDelayActive: !waitingDelayLatched && !submitted && !errorFlash && authState.method === "waiting" && waitingDelayTimer.running
   readonly property int cardHeight: panel.height > 0 ? Math.min(fieldHeight + contentMargin * 2, panel.height - Style.gapsOut * 2) : fieldHeight + contentMargin * 2
   // Password mode is a wide field; compact modes collapse to a square that
@@ -64,11 +79,22 @@ Item {
   }
 
   function loadPamConfig(raw) {
-    fingerprintConfigured = PolkitModel.fingerprintConfiguredFromPamConfig(raw)
+    var caps = PolkitModel.authCapabilitiesFromPamConfig(raw)
+    fingerprintConfigured = caps.fingerprint
+    fidoConfigured = caps.fido
+    pamMethods = caps.methods || []
   }
 
   function refreshLidState() {
-    if (!laptopClosedProc.running) laptopClosedProc.running = true
+    root.lidStateKnown = false
+    laptopClosedProc.running = false
+    laptopClosedProc.running = true
+  }
+
+  function refreshFidoState() {
+    root.fidoStateKnown = false
+    fidoProbeProc.running = false
+    fidoProbeProc.running = true
   }
 
   function finishWaitingDelay() {
@@ -88,6 +114,10 @@ Item {
     passwordInput.text = ""
     waitingDelayTimer.stop()
     waitingDelayLatched = false
+    lidStateKnown = false
+    fidoStateKnown = false
+    fidoTokenConnected = false
+    fidoProbeProc.running = false
   }
 
   function syncFromFlow() {
@@ -113,6 +143,7 @@ Item {
     submitted = false
     passwordInput.text = ""
     refreshLidState()
+    refreshFidoState()
     syncFromFlow()
     Qt.callLater(refocus)
   }
@@ -184,7 +215,10 @@ Item {
     watchChanges: true
     printErrors: false
     onLoaded: root.loadPamConfig(text())
-    onLoadFailed: root.fingerprintConfigured = false
+    onLoadFailed: {
+      root.fingerprintConfigured = false
+      root.fidoConfigured = false
+    }
     onFileChanged: reload()
   }
 
@@ -192,7 +226,21 @@ Item {
     id: laptopClosedProc
     command: ["bash", "-c", "omarchy-hw-laptop-closed && echo closed || echo open"]
     stdout: StdioCollector { id: laptopClosedOut; waitForEnd: true }
-    onExited: root.laptopClosed = String(laptopClosedOut.text || "").trim() === "closed"
+    onExited: {
+      root.laptopClosed = String(laptopClosedOut.text || "").trim() === "closed"
+      root.lidStateKnown = true
+    }
+  }
+
+  Process {
+    id: fidoProbeProc
+    command: ["bash", "-c", "for d in /sys/class/hidraw/hidraw*; do [ -e \"$d\" ] && udevadm info --query=property --path=\"$d\"; done"]
+    stdout: StdioCollector { id: fidoProbeOut; waitForEnd: true }
+    onExited: {
+      var out = String(fidoProbeOut.text || "")
+      root.fidoTokenConnected = out.indexOf("ID_SECURITY_TOKEN=1") !== -1 || out.indexOf("ID_FIDO_TOKEN=1") !== -1
+      root.fidoStateKnown = true
+    }
   }
 
   PolkitAgent {
@@ -260,16 +308,14 @@ Item {
       onClicked: root.refocus()
     }
 
-    BorderSurface {
-      id: card
-      width: root.cardWidth
+    Item {
+      id: cardContainer
+      width: (root.compactMode && root.activeMethods.length > 1)
+             ? (root.cardHeight * root.activeMethods.length + Style.space(12) * (root.activeMethods.length - 1))
+             : root.cardWidth
       height: root.cardHeight
-      radius: root.cornerRadius
       anchors.centerIn: parent
       anchors.horizontalCenterOffset: root.shakeOffset
-      color: root.background
-      borderSpec: root.borderSpec
-      padding: root.contentMargin
       opacity: root.waitingDelayActive ? 0.0 : 1.0
 
       MouseArea { anchors.fill: parent; onClicked: root.refocus() }
@@ -291,96 +337,149 @@ Item {
         }
       }
 
-      // Fingerprint mode shows just the sensor icon, centered and alone \u2014 no
-      // padlock, no field, no prompt text.
-      OpticalGlyph {
-        anchors.centerIn: parent
-        width: Math.round(root.fieldHeight * 0.7)
-        height: width
-        visible: root.compactMode
-        text: root.authPresentation.glyph === "fido" ? "\udb80\udf06" : (root.authPresentation.glyph === "fingerprint" ? "\udb80\ude37" : "\uf023")
-        fontFamily: root.fontFamily
-        fontSize: root.authPresentation.glyph === "fido" || root.authPresentation.glyph === "fingerprint" ? Math.round(root.fieldHeight * 0.7) : Style.font.iconLarge
-        color: root.errorFlash ? Color.polkit.textError : root.accent
+      BorderSurface {
+        id: card
+        anchors.fill: parent
+        visible: !(root.compactMode && root.activeMethods.length > 1)
+        radius: root.cornerRadius
+        color: root.background
+        borderSpec: root.borderSpec
+        padding: root.contentMargin
+
+        MouseArea { anchors.fill: parent; onClicked: root.refocus() }
+
+        OpticalGlyph {
+          anchors.centerIn: parent
+          width: Math.round(root.fieldHeight * 0.7)
+          height: width
+          visible: root.compactMode && root.activeMethods.length === 1
+          text: root.activeMethods.length === 1 ? (root.activeMethods[0] === "fido" ? "\udb80\udf06" : "\udb80\ude37") : ""
+          fontFamily: root.fontFamily
+          fontSize: Math.round(root.fieldHeight * 0.7)
+          color: root.errorFlash ? Color.polkit.textError : Util.alpha(root.accent, 0.55)
+        }
+
+        OpticalGlyph {
+          anchors.centerIn: parent
+          width: Math.round(root.fieldHeight * 0.7)
+          height: width
+          visible: root.compactMode && root.activeMethods.length === 0
+          text: "\uf023"
+          fontFamily: root.fontFamily
+          fontSize: Style.font.iconLarge
+          color: root.errorFlash ? Color.polkit.textError : root.accent
+        }
+
+        Row {
+          id: cardRow
+          visible: !root.compactMode
+          anchors.fill: parent
+          anchors.topMargin: card.contentTopInset
+          anchors.rightMargin: card.contentRightInset
+          anchors.bottomMargin: card.contentBottomInset
+          anchors.leftMargin: card.contentLeftInset
+          spacing: Style.space(14)
+
+          Text {
+            text: "\uf023"
+            color: root.errorFlash ? Color.polkit.textError : root.accent
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.iconLarge
+            width: Style.space(26)
+            height: root.fieldHeight
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+          }
+
+          Item {
+            width: parent.width - Style.space(40)
+            height: root.fieldHeight
+
+            TextInput {
+              id: passwordInput
+              anchors.fill: parent
+              verticalAlignment: TextInput.AlignVCenter
+              activeFocusOnPress: true
+              clip: true
+              selectionColor: Util.alpha(root.accent, 0.45)
+              selectedTextColor: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.iconLarge
+              echoMode: root.responseVisible ? TextInput.Normal : TextInput.Password
+              passwordCharacter: "\u2022"
+              color: root.errorFlash ? Color.polkit.textError : root.foreground
+              cursorVisible: activeFocus && root.responseRequired && !root.submitted && !root.errorFlash
+              readOnly: !root.responseRequired || root.submitted || root.errorFlash
+              enabled: root.dialogVisible && root.responseRequired
+              onAccepted: root.submitResponse()
+              Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Escape) {
+                  root.cancelRequest()
+                  event.accepted = true
+                }
+              }
+            }
+
+            Text {
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : root.authState.prompt)
+              color: root.errorFlash ? Color.polkit.textError : root.foreground
+              opacity: root.errorFlash ? 1 : 0.36
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.iconLarge
+              elide: Text.ElideRight
+              visible: passwordInput.text.length === 0
+            }
+
+            Rectangle {
+              width: Math.max(1, Style.space(2))
+              height: Style.space(24)
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+              color: root.errorFlash ? Color.polkit.textError : root.foreground
+              visible: passwordInput.visible && passwordInput.activeFocus && root.responseRequired && passwordInput.text.length === 0 && !root.submitted && !root.errorFlash
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              acceptedButtons: Qt.LeftButton
+              enabled: passwordInput.enabled
+              onClicked: passwordInput.forceActiveFocus()
+            }
+          }
+        }
       }
 
       Row {
-        id: cardRow
-        visible: !root.compactMode
-        anchors.fill: parent
-        anchors.topMargin: card.contentTopInset
-        anchors.rightMargin: card.contentRightInset
-        anchors.bottomMargin: card.contentBottomInset
-        anchors.leftMargin: card.contentLeftInset
-        spacing: Style.space(14)
+        id: capabilityRow
+        anchors.centerIn: parent
+        spacing: Style.space(12)
+        visible: root.compactMode && root.activeMethods.length > 1
 
-        Text {
-          text: "\uf023"
-          color: root.errorFlash ? Color.polkit.textError : root.accent
-          font.family: root.fontFamily
-          font.pixelSize: Style.font.iconLarge
-          width: Style.space(26)
-          height: root.fieldHeight
-          horizontalAlignment: Text.AlignHCenter
-          verticalAlignment: Text.AlignVCenter
-        }
+        Repeater {
+          model: root.activeMethods
 
-        Item {
-          width: parent.width - Style.space(40)
-          height: root.fieldHeight
+          BorderSurface {
+            width: root.cardHeight
+            height: root.cardHeight
+            radius: root.cornerRadius
+            color: root.background
+            borderSpec: root.borderSpec
+            padding: root.contentMargin
 
-          TextInput {
-            id: passwordInput
-            anchors.fill: parent
-            verticalAlignment: TextInput.AlignVCenter
-            activeFocusOnPress: true
-            clip: true
-            selectionColor: Util.alpha(root.accent, 0.45)
-            selectedTextColor: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.iconLarge
-            echoMode: root.responseVisible ? TextInput.Normal : TextInput.Password
-            passwordCharacter: "\u2022"
-            color: root.errorFlash ? Color.polkit.textError : root.foreground
-            cursorVisible: activeFocus && root.responseRequired && !root.submitted && !root.errorFlash
-            readOnly: !root.responseRequired || root.submitted || root.errorFlash
-            enabled: root.dialogVisible && root.responseRequired
-            onAccepted: root.submitResponse()
-            Keys.onPressed: function(event) {
-              if (event.key === Qt.Key_Escape) {
-                root.cancelRequest()
-                event.accepted = true
-              }
+            OpticalGlyph {
+              anchors.centerIn: parent
+              width: Math.round(root.fieldHeight * 0.7)
+              height: width
+              text: modelData === "fido" ? "\udb80\udf06" : "\udb80\ude37"
+              fontFamily: root.fontFamily
+              fontSize: Math.round(root.fieldHeight * 0.7)
+              // First available method is primary (slightly stronger but still muted), others are secondary fallbacks
+              color: root.errorFlash ? Color.polkit.textError
+                     : (index === 0 ? Util.alpha(root.accent, 0.55) : Util.alpha(root.accent, 0.25))
             }
-          }
-
-          Text {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
-            text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : root.authState.prompt)
-            color: root.errorFlash ? Color.polkit.textError : root.foreground
-            opacity: root.errorFlash ? 1 : 0.36
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.iconLarge
-            elide: Text.ElideRight
-            visible: passwordInput.text.length === 0
-          }
-
-          Rectangle {
-            width: Math.max(1, Style.space(2))
-            height: Style.space(24)
-            anchors.left: parent.left
-            anchors.verticalCenter: parent.verticalCenter
-            color: root.errorFlash ? Color.polkit.textError : root.foreground
-            visible: passwordInput.visible && passwordInput.activeFocus && root.responseRequired && passwordInput.text.length === 0 && !root.submitted && !root.errorFlash
-          }
-
-          MouseArea {
-            anchors.fill: parent
-            acceptedButtons: Qt.LeftButton
-            enabled: passwordInput.enabled
-            onClicked: passwordInput.forceActiveFocus()
           }
         }
       }
@@ -388,12 +487,13 @@ Item {
 
     Rectangle {
       id: cuePill
-      visible: root.compactMode && (root.fidoMode || root.fingerprintMode)
+      visible: root.compactMode && root.authState.method === "physical"
       width: Math.min(cueText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
       height: Style.space(28)
-      anchors.horizontalCenter: card.horizontalCenter
-      anchors.bottom: card.top
+      anchors.horizontalCenter: cardContainer.horizontalCenter
+      anchors.bottom: cardContainer.top
       anchors.bottomMargin: Style.space(10)
+      opacity: root.waitingDelayActive ? 0.0 : 1.0
       radius: root.cornerRadius
       color: root.background
 
@@ -416,8 +516,8 @@ Item {
       id: justificationPill
       width: Math.min(justificationText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
       height: Style.space(28)
-      anchors.horizontalCenter: card.horizontalCenter
-      anchors.bottom: cuePill.visible ? cuePill.top : card.top
+      anchors.horizontalCenter: cardContainer.horizontalCenter
+      anchors.bottom: cuePill.visible ? cuePill.top : cardContainer.top
       anchors.bottomMargin: Style.space(10)
       radius: root.cornerRadius
       color: root.background

--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -60,6 +60,8 @@ Item {
 
   readonly property bool dialogVisible: polkitAgent.isActive || closing
   readonly property var authState: PolkitModel.authenticationState(currentPrompt, currentSupplementary, responseRequired)
+  readonly property string supplementaryInstruction: String(currentSupplementary || "").trim()
+  readonly property bool supplementaryInstructionVisible: responseRequired && supplementaryInstruction.length > 0 && supplementaryInstruction !== String(authState.prompt || "").trim()
   readonly property bool compactMode: dialogVisible && (authState.method === "waiting" || authState.method === "physical") && !submitted && !errorFlash
   readonly property bool waitingDelayActive: !waitingDelayLatched && !submitted && !errorFlash && authState.method === "waiting" && waitingDelayTimer.running
   readonly property int cardHeight: panel.height > 0 ? Math.min(fieldHeight + contentMargin * 2, panel.height - Style.gapsOut * 2) : fieldHeight + contentMargin * 2
@@ -487,7 +489,7 @@ Item {
 
     Rectangle {
       id: cuePill
-      visible: root.compactMode && root.authState.method === "physical"
+      visible: (root.compactMode && root.authState.method === "physical") || root.supplementaryInstructionVisible
       width: Math.min(cueText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
       height: Style.space(28)
       anchors.horizontalCenter: cardContainer.horizontalCenter
@@ -502,7 +504,7 @@ Item {
         anchors.fill: parent
         anchors.leftMargin: Style.space(12)
         anchors.rightMargin: Style.space(12)
-        text: root.authState.prompt
+        text: root.supplementaryInstructionVisible ? root.supplementaryInstruction : root.authState.prompt
         color: root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.bodySmall

--- a/shell/plugins/polkit/PolkitModel.js
+++ b/shell/plugins/polkit/PolkitModel.js
@@ -1,37 +1,24 @@
-function promptLooksFingerprint(text) {
-  var s = String(text || "").toLowerCase()
-  return s.indexOf("finger") !== -1 || s.indexOf("fprint") !== -1 || s.indexOf("swipe") !== -1
-}
-
-function promptLooksFido(text) {
-  var s = String(text || "").toLowerCase()
-  return s.indexOf("u2f") !== -1 || s.indexOf("fido") !== -1 ||
-    s.indexOf("security key") !== -1
-}
-
-function promptLooksTouch(text) {
-  return String(text || "").toLowerCase().indexOf("touch") !== -1
-}
-
-function fingerprintConfiguredFromPamConfig(raw) {
+function authCapabilitiesFromPamConfig(raw) {
   var lines = String(raw || "").split("\n")
+  var capabilities = { fingerprint: false, fido: false, methods: [] }
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i].replace(/^\s+|\s+$/g, "")
     if (!line || line.charAt(0) === "#") continue
     if (!line.match(/^auth\s+/)) continue
-    if (line.indexOf("pam_fprintd.so") !== -1) return true
+    if (line.indexOf("pam_fprintd.so") !== -1) {
+      capabilities.fingerprint = true
+      if (capabilities.methods.indexOf("fingerprint") === -1) capabilities.methods.push("fingerprint")
+    }
+    if (line.indexOf("pam_u2f.so") !== -1) {
+      capabilities.fido = true
+      if (capabilities.methods.indexOf("fido") === -1) capabilities.methods.push("fido")
+    }
   }
-  return false
+  return capabilities
 }
 
-function authenticationPresentation(method, fingerprintConfigured, laptopClosed) {
-  var liveMethod = String(method || "waiting")
-  var fingerprintLookahead = liveMethod === "waiting" && !!fingerprintConfigured && !laptopClosed
-  return {
-    method: liveMethod,
-    glyph: fingerprintLookahead ? "fingerprint" : liveMethod,
-    fingerprintLookahead: fingerprintLookahead
-  }
+function fingerprintConfiguredFromPamConfig(raw) {
+  return authCapabilitiesFromPamConfig(raw).fingerprint
 }
 
 function authenticationState(inputPrompt, supplementaryMessage, responseRequired) {
@@ -41,13 +28,11 @@ function authenticationState(inputPrompt, supplementaryMessage, responseRequired
     return { method: "password", prompt: input || "Enter password" }
   }
 
-  // PAM sends status cues in the supplementary message while it is waiting;
-  // fall back to inputPrompt for modules that use it for those cues.
+  // PAM sends noninteractive status cues in the supplementary message; fall
+  // back to inputPrompt for modules that use it instead.
   var cue = supplementary || input
-  if (promptLooksFido(cue)) return { method: "fido", prompt: cue || "Touch your security key" }
-  if (promptLooksFingerprint(cue)) return { method: "fingerprint", prompt: cue || "Scan your fingerprint" }
-  if (promptLooksTouch(cue)) return { method: "fido", prompt: cue || "Touch your security key" }
-  return { method: "waiting", prompt: cue || "Authentication in progress..." }
+  if (cue) return { method: "physical", prompt: cue }
+  return { method: "waiting", prompt: "Authentication in progress..." }
 }
 
 function authorizationLabel(message) {
@@ -58,10 +43,8 @@ function authorizationLabel(message) {
 
 if (typeof module !== "undefined") {
   module.exports = {
-    promptLooksFingerprint: promptLooksFingerprint,
-    promptLooksFido: promptLooksFido,
+    authCapabilitiesFromPamConfig: authCapabilitiesFromPamConfig,
     fingerprintConfiguredFromPamConfig: fingerprintConfiguredFromPamConfig,
-    authenticationPresentation: authenticationPresentation,
     authenticationState: authenticationState,
     authorizationLabel: authorizationLabel
   }

--- a/shell/plugins/polkit/PolkitModel.js
+++ b/shell/plugins/polkit/PolkitModel.js
@@ -3,10 +3,17 @@ function promptLooksFingerprint(text) {
   return s.indexOf("finger") !== -1 || s.indexOf("fprint") !== -1 || s.indexOf("swipe") !== -1
 }
 
+function promptLooksFido(text) {
+  var s = String(text || "").toLowerCase()
+  return s.indexOf("u2f") !== -1 || s.indexOf("fido") !== -1 ||
+    s.indexOf("security key") !== -1
+}
+
+function promptLooksTouch(text) {
+  return String(text || "").toLowerCase().indexOf("touch") !== -1
+}
+
 function fingerprintConfiguredFromPamConfig(raw) {
-  // Fingerprint is available whenever pam_fprintd appears anywhere in the auth
-  // stack — it need not be the first module. A clamshell gate (pam_exec) may
-  // legitimately precede it to skip fingerprint while the lid is closed.
   var lines = String(raw || "").split("\n")
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i].replace(/^\s+|\s+$/g, "")
@@ -15,6 +22,32 @@ function fingerprintConfiguredFromPamConfig(raw) {
     if (line.indexOf("pam_fprintd.so") !== -1) return true
   }
   return false
+}
+
+function authenticationPresentation(method, fingerprintConfigured, laptopClosed) {
+  var liveMethod = String(method || "waiting")
+  var fingerprintLookahead = liveMethod === "waiting" && !!fingerprintConfigured && !laptopClosed
+  return {
+    method: liveMethod,
+    glyph: fingerprintLookahead ? "fingerprint" : liveMethod,
+    fingerprintLookahead: fingerprintLookahead
+  }
+}
+
+function authenticationState(inputPrompt, supplementaryMessage, responseRequired) {
+  var input = String(inputPrompt || "")
+  var supplementary = String(supplementaryMessage || "")
+  if (responseRequired) {
+    return { method: "password", prompt: input || "Enter password" }
+  }
+
+  // PAM sends status cues in the supplementary message while it is waiting;
+  // fall back to inputPrompt for modules that use it for those cues.
+  var cue = supplementary || input
+  if (promptLooksFido(cue)) return { method: "fido", prompt: cue || "Touch your security key" }
+  if (promptLooksFingerprint(cue)) return { method: "fingerprint", prompt: cue || "Scan your fingerprint" }
+  if (promptLooksTouch(cue)) return { method: "fido", prompt: cue || "Touch your security key" }
+  return { method: "waiting", prompt: cue || "Authentication in progress..." }
 }
 
 function authorizationLabel(message) {
@@ -26,7 +59,10 @@ function authorizationLabel(message) {
 if (typeof module !== "undefined") {
   module.exports = {
     promptLooksFingerprint: promptLooksFingerprint,
+    promptLooksFido: promptLooksFido,
     fingerprintConfiguredFromPamConfig: fingerprintConfiguredFromPamConfig,
+    authenticationPresentation: authenticationPresentation,
+    authenticationState: authenticationState,
     authorizationLabel: authorizationLabel
   }
 }

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -10,6 +10,7 @@ const polkit = requireFromRoot('shell/plugins/polkit/PolkitModel.js')
 assert(polkit.promptLooksFingerprint('Swipe your finger'), 'polkit detects fingerprint prompts')
 assert(polkit.promptLooksFingerprint('fprintd verification'), 'polkit detects fprint prompts')
 assert(!polkit.promptLooksFingerprint('Password:'), 'polkit ignores password prompts')
+assert(polkit.promptLooksFido('Please touch your security key'), 'polkit detects FIDO prompts')
 
 assertEqual(
   polkit.authorizationLabel("Authentication is needed to run `/usr/bin/true' as the super user"),
@@ -45,5 +46,104 @@ auth include system-auth
 auth required pam_unix.so
 `),
   'polkit reports no fingerprint when pam_fprintd is absent'
+)
+
+assertEqual(
+  polkit.authenticationPresentation('fingerprint', true, true).method,
+  'fingerprint',
+  'polkit keeps a concrete fingerprint state when the lid is closed'
+)
+assertEqual(
+  polkit.authenticationPresentation('fingerprint', false, false).method,
+  'fingerprint',
+  'polkit keeps a concrete fingerprint state when config is unavailable'
+)
+assert(
+  polkit.authenticationPresentation('waiting', true, false).fingerprintLookahead,
+  'polkit uses fingerprint lookahead only while waiting with an open configured reader'
+)
+assertEqual(
+  polkit.authenticationPresentation('waiting', true, false).glyph,
+  'fingerprint',
+  'polkit shows the fingerprint lookahead glyph while waiting with an open configured reader'
+)
+assert(
+  !polkit.authenticationPresentation('waiting', true, true).fingerprintLookahead,
+  'polkit disables fingerprint lookahead when the lid is closed'
+)
+assertEqual(
+  polkit.authenticationPresentation('waiting', true, true).glyph,
+  'waiting',
+  'polkit keeps the waiting glyph when the lid is closed'
+)
+assert(
+  !polkit.authenticationPresentation('waiting', false, false).fingerprintLookahead,
+  'polkit disables fingerprint lookahead when config is unavailable'
+)
+assertEqual(
+  polkit.authenticationPresentation('waiting', false, false).glyph,
+  'waiting',
+  'polkit keeps the waiting glyph when config is unavailable'
+)
+assertEqual(
+  polkit.authenticationPresentation('fido', true, false).method,
+  'fido',
+  'polkit does not override a concrete FIDO state with lookahead'
+)
+assertEqual(
+  polkit.authenticationPresentation('password', true, false).method,
+  'password',
+  'polkit does not override a concrete password state with lookahead'
+)
+
+assertEqual(
+  polkit.authenticationState('', 'Please touch the device.', false).method,
+  'fido',
+  'polkit classifies a U2F touch cue as FIDO'
+)
+assertEqual(
+  polkit.authenticationState('ignored input prompt', 'Please touch the device.', false).prompt,
+  'Please touch the device.',
+  'polkit displays the supplementary FIDO cue while waiting'
+)
+assertEqual(
+  polkit.authenticationState('', 'Swipe your finger', false).method,
+  'fingerprint',
+  'polkit classifies a fingerprint cue as fingerprint'
+)
+assertEqual(
+  polkit.authenticationState('', 'Your finger was not centered, try touching the sensor again', false).method,
+  'fingerprint',
+  'polkit keeps a fingerprint retry cue as fingerprint'
+)
+assertEqual(
+  polkit.authenticationState('', 'Remove your finger, and try touching the sensor again', false).method,
+  'fingerprint',
+  'polkit keeps a fingerprint removal cue as fingerprint'
+)
+assertEqual(
+  polkit.authenticationState('Password:', '', true).method,
+  'password',
+  'polkit classifies a response request as password input'
+)
+assertEqual(
+  polkit.authenticationState('', '', false).method,
+  'waiting',
+  'polkit classifies an empty non-interactive prompt as waiting'
+)
+assertEqual(
+  polkit.authenticationState('', '', false).prompt,
+  'Authentication in progress...',
+  'polkit gives generic waiting a grounded fallback'
+)
+assertEqual(
+  polkit.authenticationState('Swipe your finger', 'Please touch your U2F security key', false).method,
+  'fido',
+  'polkit prefers the U2F cue over a fingerprint input prompt'
+)
+assertEqual(
+  polkit.authenticationState('Password:', 'Waiting for a device', true).prompt,
+  'Password:',
+  'polkit uses the input prompt for response requests'
 )
 JS

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -5,12 +5,9 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const polkit = requireFromRoot('shell/plugins/polkit/PolkitModel.js')
-
-assert(polkit.promptLooksFingerprint('Swipe your finger'), 'polkit detects fingerprint prompts')
-assert(polkit.promptLooksFingerprint('fprintd verification'), 'polkit detects fprint prompts')
-assert(!polkit.promptLooksFingerprint('Password:'), 'polkit ignores password prompts')
-assert(polkit.promptLooksFido('Please touch your security key'), 'polkit detects FIDO prompts')
+const agentQml = fs.readFileSync(path.join(root, 'shell/plugins/polkit/PolkitAgent.qml'), 'utf8')
 
 assertEqual(
   polkit.authorizationLabel("Authentication is needed to run `/usr/bin/true' as the super user"),
@@ -49,77 +46,76 @@ auth required pam_unix.so
 )
 
 assertEqual(
-  polkit.authenticationPresentation('fingerprint', true, true).method,
-  'fingerprint',
-  'polkit keeps a concrete fingerprint state when the lid is closed'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_fprintd.so').fingerprint,
+  true,
+  'polkit detects fingerprint-only PAM capability'
 )
 assertEqual(
-  polkit.authenticationPresentation('fingerprint', false, false).method,
-  'fingerprint',
-  'polkit keeps a concrete fingerprint state when config is unavailable'
-)
-assert(
-  polkit.authenticationPresentation('waiting', true, false).fingerprintLookahead,
-  'polkit uses fingerprint lookahead only while waiting with an open configured reader'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_fprintd.so').fido,
+  false,
+  'polkit excludes FIDO from a fingerprint-only PAM stack'
 )
 assertEqual(
-  polkit.authenticationPresentation('waiting', true, false).glyph,
-  'fingerprint',
-  'polkit shows the fingerprint lookahead glyph while waiting with an open configured reader'
-)
-assert(
-  !polkit.authenticationPresentation('waiting', true, true).fingerprintLookahead,
-  'polkit disables fingerprint lookahead when the lid is closed'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_u2f.so').fido,
+  true,
+  'polkit detects U2F-only PAM capability'
 )
 assertEqual(
-  polkit.authenticationPresentation('waiting', true, true).glyph,
-  'waiting',
-  'polkit keeps the waiting glyph when the lid is closed'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_u2f.so').fingerprint,
+  false,
+  'polkit excludes fingerprint from a U2F-only PAM stack'
 )
-assert(
-  !polkit.authenticationPresentation('waiting', false, false).fingerprintLookahead,
-  'polkit disables fingerprint lookahead when config is unavailable'
-)
-assertEqual(
-  polkit.authenticationPresentation('waiting', false, false).glyph,
-  'waiting',
-  'polkit keeps the waiting glyph when config is unavailable'
-)
-assertEqual(
-  polkit.authenticationPresentation('fido', true, false).method,
-  'fido',
-  'polkit does not override a concrete FIDO state with lookahead'
-)
-assertEqual(
-  polkit.authenticationPresentation('password', true, false).method,
-  'password',
-  'polkit does not override a concrete password state with lookahead'
-)
+const clamshellCapabilities = polkit.authCapabilitiesFromPamConfig(`
+auth [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed
+auth sufficient pam_fprintd.so
+auth sufficient pam_u2f.so
+`)
+assert(clamshellCapabilities.fingerprint && clamshellCapabilities.fido, 'polkit detects both capabilities behind a clamshell gate')
+const ignoredCapabilities = polkit.authCapabilitiesFromPamConfig(`
+# auth sufficient pam_fprintd.so
+account sufficient pam_u2f.so
+session optional pam_fprintd.so
+`)
+assert(!ignoredCapabilities.fingerprint && !ignoredCapabilities.fido, 'polkit ignores commented and non-auth PAM lines')
+assertEqual(ignoredCapabilities.methods.join(','), '', 'polkit omits commented and non-auth methods from order')
 
 assertEqual(
-  polkit.authenticationState('', 'Please touch the device.', false).method,
-  'fido',
-  'polkit classifies a U2F touch cue as FIDO'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_fprintd.so\nauth sufficient pam_u2f.so').methods.join(','),
+  'fingerprint,fido',
+  'polkit preserves fingerprint-then-FIDO PAM order'
 )
 assertEqual(
-  polkit.authenticationState('ignored input prompt', 'Please touch the device.', false).prompt,
-  'Please touch the device.',
-  'polkit displays the supplementary FIDO cue while waiting'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_u2f.so\nauth sufficient pam_fprintd.so').methods.join(','),
+  'fido,fingerprint',
+  'polkit preserves FIDO-then-fingerprint PAM order'
 )
 assertEqual(
-  polkit.authenticationState('', 'Swipe your finger', false).method,
-  'fingerprint',
-  'polkit classifies a fingerprint cue as fingerprint'
+  polkit.authCapabilitiesFromPamConfig('auth sufficient pam_u2f.so\nauth sufficient pam_u2f.so\nauth sufficient pam_fprintd.so\nauth sufficient pam_fprintd.so').methods.join(','),
+  'fido,fingerprint',
+  'polkit lists duplicate physical PAM modules once'
+)
+
+const frenchFingerprintCue = 'Placez votre doigt sur le lecteur d’empreintes'
+assertEqual(
+  polkit.authenticationState('', frenchFingerprintCue, false).method,
+  'physical',
+  'polkit classifies a French fingerprint cue as physical auth'
 )
 assertEqual(
-  polkit.authenticationState('', 'Your finger was not centered, try touching the sensor again', false).method,
-  'fingerprint',
-  'polkit keeps a fingerprint retry cue as fingerprint'
+  polkit.authenticationState('', frenchFingerprintCue, false).prompt,
+  frenchFingerprintCue,
+  'polkit preserves a French physical-auth cue verbatim'
+)
+const customU2fCue = 'Custom token challenge: tap any enrolled device'
+assertEqual(
+  polkit.authenticationState('', customU2fCue, false).method,
+  'physical',
+  'polkit classifies a custom U2F cue as physical auth'
 )
 assertEqual(
-  polkit.authenticationState('', 'Remove your finger, and try touching the sensor again', false).method,
-  'fingerprint',
-  'polkit keeps a fingerprint removal cue as fingerprint'
+  polkit.authenticationState('ignored input prompt', customU2fCue, false).prompt,
+  customU2fCue,
+  'polkit prefers the supplementary physical-auth cue'
 )
 assertEqual(
   polkit.authenticationState('Password:', '', true).method,
@@ -137,13 +133,30 @@ assertEqual(
   'polkit gives generic waiting a grounded fallback'
 )
 assertEqual(
-  polkit.authenticationState('Swipe your finger', 'Please touch your U2F security key', false).method,
-  'fido',
-  'polkit prefers the U2F cue over a fingerprint input prompt'
+  polkit.authenticationState('Input cue', '', false).prompt,
+  'Input cue',
+  'polkit falls back to the input prompt for physical auth'
 )
 assertEqual(
   polkit.authenticationState('Password:', 'Waiting for a device', true).prompt,
   'Password:',
   'polkit uses the input prompt for response requests'
+)
+
+assert(
+  agentQml.includes('/sys/class/hidraw/hidraw*') && agentQml.includes('udevadm info --query=property --path'),
+  'polkit passively probes hidraw properties for a FIDO token'
+)
+assert(
+  agentQml.includes('ID_SECURITY_TOKEN=1') && agentQml.includes('ID_FIDO_TOKEN=1'),
+  'polkit recognizes both security-token and FIDO-token udev markers'
+)
+assert(
+  /readonly property var activeMethods:[\s\S]*?m === "fido" && \(!fidoStateKnown \|\| !fidoTokenConnected/.test(agentQml),
+  'polkit exposes FIDO only after its connected state is known'
+)
+assert(
+  /function beginFlow\(\)\s*\{[^}]*refreshFidoState\(\)/.test(agentQml),
+  'polkit refreshes FIDO presence for each authentication flow'
 )
 JS

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -142,6 +142,34 @@ assertEqual(
   'Password:',
   'polkit uses the input prompt for response requests'
 )
+const passwordWithInstruction = polkit.authenticationState('Password:', 'Insert your security key', true)
+assertEqual(
+  passwordWithInstruction.method,
+  'password',
+  'polkit keeps response-required flows in password mode with supplementary instructions'
+)
+assertEqual(
+  passwordWithInstruction.prompt,
+  'Password:',
+  'polkit preserves the input prompt for response-required supplementary instructions'
+)
+
+assert(
+  /readonly property string supplementaryInstruction:\s*String\(currentSupplementary \|\| ""\)\.trim\(\)/.test(agentQml),
+  'polkit trims the supplementary instruction'
+)
+assert(
+  /supplementaryInstructionVisible:\s*responseRequired\s*&&\s*supplementaryInstruction\.length > 0/.test(agentQml),
+  'polkit shows supplementary instructions for response-required flows'
+)
+assert(
+  /supplementaryInstruction\s*!==\s*String\(authState\.prompt \|\| ""\)\.trim\(\)/.test(agentQml),
+  'polkit suppresses duplicate supplementary prompts'
+)
+assert(
+  /text:\s*root\.supplementaryInstructionVisible\s*\?\s*root\.supplementaryInstruction\s*:\s*root\.authState\.prompt/.test(agentQml),
+  'polkit cue text prefers a visible supplementary instruction'
+)
 
 assert(
   agentQml.includes('/sys/class/hidraw/hidraw*') && agentQml.includes('udevadm info --query=property --path'),


### PR DESCRIPTION
## Summary
- classify the live Polkit/PAM conversation as FIDO/U2F, fingerprint, password, or waiting
- keep Omarchy’s existing PAM-config and lid-state lookahead only for the pre-prompt waiting glyph; concrete live auth states remain authoritative
- delay the neutral pre-prompt surface for one second only; the delay latches off after the first concrete state
- show compact, icon-only physical-auth cards for FIDO and fingerprint
- preserve the authorization context in its own pill and show the localized physical-auth cue in a separate pill
- show and focus the text field only when PAM requests a response, then honor `responseVisible`
- distinguish fingerprint retry messages containing “touch” from FIDO touch cues
- add direct model-helper tests following the existing `run_node_test` shell-test style

## Supported PAM flow
Lid closed: `pam_u2f.so cue` → `pam_unix.so`

Lid open: `pam_fprintd.so` → `pam_u2f.so cue` → `pam_unix.so`

- FIDO/U2F: waits for a touch; Enter does not send a response.
- Fingerprint: waits for a scan; Enter does not send a response.
- Password: presents the PAM prompt, accepts input, and submits it on Enter.

## Maintainer question
The original `FileView` of `/etc/pam.d/polkit-1` and per-request `omarchy-hw-laptop-closed` check have been retained. They now affect only pre-prompt presentation; live `AuthFlow` prompts select the active method. Please advise whether this lookahead remains necessary or can be simplified safely.

## Testing
- `bash test/shell.d/polkit-test.sh`
- `qmllint shell/plugins/polkit/PolkitAgent.qml`
- Local helper: `/tmp/opencode/omarchy-local-pkg/test-polkit.sh` validates, generates a uniquely versioned local package, and prints the install/restart commands without installing.
- Manual local validation: lid-open FIDO, fingerprint, and password fallback completed; compact FIDO layout, one-second pre-prompt delay, and separate authorization/cue pills visually checked.
- Manual closed-lid FIDO/password validation is pending.

The focused suite covers FIDO cues, fingerprint cues (including retry messages), password fallback, prompt precedence, generic waiting, clamshell-gated PAM configuration, and fingerprint-lookahead races.