### PR TITLE
Track usage limits for several Claude and Codex accounts

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # omarchy:summary=Print the Claude Code usage record as JSON
-# omarchy:args=[--force] [--limits-only]
+# omarchy:args=[--force] [--limits-only] [--id <id>] [--name <name>] [--shared-sessions <auto|on|off>]
 # omarchy:hidden=true
 """Collect Claude Code usage into one display-ready JSON record.
 
@@ -43,6 +43,33 @@ def config_dir() -> Path:
 
 def expand_path(value: str) -> Path:
   return Path(os.path.expandvars(os.path.expanduser(value))).resolve()
+
+
+def normalized_dir(value: object) -> str:
+  # Spelling, not identity on disk: collapse "~", "..", and trailing slashes
+  # but leave symlinks alone, so a symlinked alias of the stock directory
+  # reads as its own account rather than inheriting the stock one's claims.
+  return os.path.normpath(os.path.abspath(os.path.expanduser(str(value))))
+
+
+def on_stock_dir() -> bool:
+  return normalized_dir(os.environ.get("CLAUDE_CONFIG_DIR") or "~/.claude") == normalized_dir("~/.claude")
+
+
+# pi, omp, and opencode keep one transcript tree apiece, shared by every
+# Claude account on the machine — nothing in them says which CLAUDE_CONFIG_DIR
+# their tokens were burned against. Exactly one account may count them, or the
+# same tokens appear once per account. omarchy-agent-usage-update resolves the
+# owner across every enabled account (reading each one's preference through
+# --print-identity) and runs each collector with an explicit on or off; auto
+# is the answer for a collector run by hand, where the stock ~/.claude
+# account counts them.
+def include_shared_sessions(mode: str) -> bool:
+  if mode == "on":
+    return True
+  if mode == "off":
+    return False
+  return on_stock_dir()
 
 
 def cache_root() -> Path:
@@ -700,7 +727,7 @@ def probe_limits(access_token: str) -> dict[str, Any]:
   return {"ok": True, "limits": limits}
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+def collect_limits(access_token: str, expires_at_ms: int, force: bool, claude_dir: Path) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   if access_token == "":
@@ -711,8 +738,11 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
 
   # A panel that is opened and shut repeatedly must not turn into a request
   # per flick, so recent probe results are reused for a short window — and
-  # kept as the answer of record when a later probe fails.
-  probe_cache = cache_root() / "claude-limits.json"
+  # kept as the answer of record when a later probe fails. Keyed by the
+  # account's directory: limits are per-subscription, and a second account
+  # reusing the first one's cached limits would display the wrong numbers.
+  digest = hashlib.sha1(str(claude_dir).encode("utf-8")).hexdigest()[:16]
+  probe_cache = cache_root() / f"claude-limits-{digest}.json"
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fetched_at = number(cached.get("fetchedAtMs")) / 1000
   min_interval = 0 if force else PROBE_MIN_INTERVAL_SECONDS
@@ -746,7 +776,24 @@ def main() -> int:
   parser.add_argument("--force", action="store_true", help="rescan transcripts and re-probe limits, ignoring caches")
   parser.add_argument("--limits-only", action="store_true", help="reuse any recent transcript scan; only the limits probe must be fresh")
   parser.add_argument("--cache-seconds", type=float, default=20)
+  # A second account is this same collector run with CLAUDE_CONFIG_DIR
+  # pointing at its directory and an id of its own; see collectors.d in the
+  # agents README. The mark keeps every account of this tool on the Claude
+  # icon, whatever its id.
+  parser.add_argument("--id", dest="agent_id", default=AGENT_ID, help="record id, for accounts beyond the stock one")
+  parser.add_argument("--name", dest="agent_name", default="", help="display name for the account's tab")
+  parser.add_argument("--shared-sessions", choices=["auto", "on", "off"], default="auto",
+                      help="whether this account counts the shared pi/omp/opencode trees (auto: only the stock ~/.claude account does)")
+  parser.add_argument("--print-identity", action="store_true",
+                      help="print this account's tool, stock-directory status, and shared-sessions preference, then exit")
   args = parser.parse_args()
+
+  # The identity is what lets the update command resolve shared-tree
+  # ownership across accounts before any of them runs: which tool this is,
+  # whether it sits on the stock directory, and what its wrapper asked for.
+  if args.print_identity:
+    print(json.dumps({"tool": AGENT_ID, "stock": on_stock_dir(), "sharedSessions": args.shared_sessions}, separators=(",", ":")))
+    return 0
 
   claude_dir = config_dir()
   scan_age = 0 if args.force else (900 if args.limits_only else args.cache_seconds)
@@ -763,21 +810,26 @@ def main() -> int:
       if today_prompts or today_sessions:
         stats = dict(stats, todayPrompts=today_prompts, todaySessions=today_sessions)
 
-  pi_usage = scan_pi_usage(scan_age)
-  if pi_usage is not None:
-    stats = merge_stats(stats, pi_usage)
+  if include_shared_sessions(args.shared_sessions):
+    pi_usage = scan_pi_usage(scan_age)
+    if pi_usage is not None:
+      stats = merge_stats(stats, pi_usage)
 
-  opencode = scan_opencode_usage(scan_age)
-  if opencode is not None:
-    stats = merge_stats(stats, opencode)
+    opencode = scan_opencode_usage(scan_age)
+    if opencode is not None:
+      stats = merge_stats(stats, opencode)
 
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
-  limits = collect_limits(access_token, expires_at_ms, args.force)
+  limits = collect_limits(access_token, expires_at_ms, args.force, claude_dir)
 
   record = {
     "schemaVersion": 1,
-    "id": AGENT_ID,
-    "name": AGENT_NAME,
+    "id": args.agent_id,
+    "name": args.agent_name or (AGENT_NAME if args.agent_id == AGENT_ID else args.agent_id),
+    # Which tool this account runs, whatever id it goes by — the panel picks
+    # the Claude mark by it, and synced machines refuse to pool accounts
+    # whose marks disagree.
+    "mark": AGENT_ID,
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
     "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0,
     "hasLocalStats": True,

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # omarchy:summary=Print the Codex usage record as JSON
-# omarchy:args=[--force] [--limits-only]
+# omarchy:args=[--force] [--limits-only] [--id <id>] [--name <name>] [--shared-sessions <auto|on|off>]
 # omarchy:hidden=true
 """Collect Codex usage into one display-ready JSON record.
 
@@ -77,6 +77,33 @@ ENV = runtime_env()
 
 def find_command(name):
   return shutil.which(name, path=ENV.get("PATH"))
+
+
+def normalized_dir(value):
+  # Spelling, not identity on disk: collapse "~", "..", and trailing slashes
+  # but leave symlinks alone, so a symlinked alias of the stock directory
+  # reads as its own account rather than inheriting the stock one's claims.
+  return os.path.normpath(os.path.abspath(os.path.expanduser(str(value))))
+
+
+def on_stock_dir():
+  return normalized_dir(os.environ.get("CODEX_HOME") or "~/.codex") == normalized_dir("~/.codex")
+
+
+# pi, omp, and opencode keep one transcript tree apiece, shared by every
+# Codex account on the machine — nothing in them says which CODEX_HOME their
+# tokens were burned against. Exactly one account may count them, or the same
+# tokens appear once per account. omarchy-agent-usage-update resolves the
+# owner across every enabled account (reading each one's preference through
+# --print-identity) and runs each collector with an explicit on or off; auto
+# is the answer for a collector run by hand, where the stock ~/.codex account
+# counts them.
+def include_shared_sessions(mode):
+  if mode == "on":
+    return True
+  if mode == "off":
+    return False
+  return on_stock_dir()
 
 
 now = datetime.now()
@@ -395,17 +422,36 @@ def main():
   # every collector accepts the same invocation.
   parser.add_argument("--force", action="store_true")
   parser.add_argument("--limits-only", action="store_true")
-  parser.parse_args()
+  # A second account is this same collector run with CODEX_HOME pointing at
+  # its directory and an id of its own; see collectors.d in the agents
+  # README. The mark keeps every account of this tool on the Codex icon,
+  # whatever its id.
+  parser.add_argument("--id", dest="agent_id", default=AGENT_ID)
+  parser.add_argument("--name", dest="agent_name", default="")
+  parser.add_argument("--shared-sessions", choices=["auto", "on", "off"], default="auto")
+  parser.add_argument("--print-identity", action="store_true")
+  args = parser.parse_args()
 
-  scan_pi_sessions()
+  # The identity is what lets the update command resolve shared-tree
+  # ownership across accounts before any of them runs.
+  if args.print_identity:
+    print(json.dumps({"tool": AGENT_ID, "stock": on_stock_dir(), "sharedSessions": args.shared_sessions}, separators=(",", ":")))
+    return
+
+  if include_shared_sessions(args.shared_sessions):
+    scan_pi_sessions()
+    scan_opencode_sessions()
   scan_native_codex_sessions()
-  scan_opencode_sessions()
   rpc = fetch_codex_rpc()
 
   record = {
     "schemaVersion": 1,
-    "id": AGENT_ID,
-    "name": AGENT_NAME,
+    "id": args.agent_id,
+    "name": args.agent_name or (AGENT_NAME if args.agent_id == AGENT_ID else args.agent_id),
+    # Which tool this account runs, whatever id it goes by — the panel picks
+    # the Codex mark by it, and synced machines refuse to pool accounts
+    # whose marks disagree.
+    "mark": AGENT_ID,
     "updatedAt": datetime.now(timezone.utc).isoformat(),
     "ready": True,
     "hasLocalStats": True,

--- a/bin/omarchy-agent-usage-fireworks
+++ b/bin/omarchy-agent-usage-fireworks
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # omarchy:summary=Print the Fireworks usage record as JSON
-# omarchy:args=[--force] [--limits-only]
+# omarchy:args=[--force] [--limits-only] [--id <id>] [--name <name>]
 # omarchy:hidden=true
 """Collect Fireworks serverless usage into one display-ready JSON record.
 
@@ -29,6 +29,9 @@ from typing import Any
 
 AGENT_ID = "fireworks"
 AGENT_NAME = "Fireworks"
+# The stock id doubles as the mark, and survives --id rebinding AGENT_ID so
+# every Fireworks account keeps the Fireworks icon.
+AGENT_MARK = AGENT_ID
 AUTH_HELP = "Set FIREWORKS_API_KEY, run `firectl set-api-key`, or sign in to Fireworks in opencode."
 API_BASE_URL = "https://api.fireworks.ai"
 
@@ -108,6 +111,7 @@ def base_record(**overrides: Any) -> dict[str, Any]:
     "schemaVersion": 1,
     "id": AGENT_ID,
     "name": AGENT_NAME,
+    "mark": AGENT_MARK,
     "updatedAt": datetime.now(timezone.utc).isoformat(),
     "ready": False,
     "hasLocalStats": False,
@@ -486,6 +490,10 @@ def scan(api_base_url: str, auth_path: Path) -> dict[str, Any]:
 
 
 def main() -> int:
+  # Every record leaves through base_record, so a renamed account rebinds the
+  # module identity rather than threading the id through each call.
+  global AGENT_ID, AGENT_NAME
+
   parser = argparse.ArgumentParser(description="Print the Fireworks usage record as JSON")
   # Stats and balance come from the same few API calls, so there is no cache
   # to force past and no faster limits-only path. The flags exist so every
@@ -494,7 +502,14 @@ def main() -> int:
   parser.add_argument("--limits-only", action="store_true")
   parser.add_argument("--auth-path", default=os.environ.get("FIREWORKS_AUTH_PATH", "~/.fireworks/auth.ini"))
   parser.add_argument("--api-base-url", default=os.environ.get("FIREWORKS_API_BASE_URL", API_BASE_URL))
+  # A second account is this same collector run from a collectors.d wrapper
+  # with its own credentials in the environment and an id of its own.
+  parser.add_argument("--id", dest="agent_id", default=AGENT_ID)
+  parser.add_argument("--name", dest="agent_name", default="")
   args = parser.parse_args()
+
+  AGENT_ID = args.agent_id
+  AGENT_NAME = args.agent_name or (AGENT_NAME if args.agent_id == AGENT_MARK else args.agent_id)
 
   try:
     record = scan(args.api_base_url, Path(args.auth_path).expanduser())

--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -8,8 +8,15 @@
 # record; this writes them to ~/.local/state/omarchy/agents/usage/ where the
 # agents panel watches them. Adding an agent is adding a collector — the
 # panel picks up any record that appears here.
+#
+# Collectors also come from ~/.config/omarchy/agents/collectors.d/, one
+# executable per agent named for the agent id its record carries. That is how
+# a second account of a shipped agent exists: a wrapper that sets the
+# account's config directory and execs the shipped collector with --id. A
+# user collector with a shipped collector's name replaces it.
 
 USAGE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
+USER_COLLECTORS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/agents/collectors.d"
 mkdir -p "$USAGE_DIR"
 
 flags=()
@@ -42,7 +49,17 @@ wanted() {
 collect() {
   local collector="$1" agent="$2"
   local record tmp
-  if ! record=$("$collector" "${flags[@]}") || [[ -z $record ]] || ! jq -e . >/dev/null 2>&1 <<<"$record"; then
+  local extra=()
+  # The wrapper's own --shared-sessions is a preference, not the final word:
+  # this appended flag lands after it, and the collectors take the last one.
+  if [[ -n ${identity_tool[$agent]:-} ]]; then
+    if [[ ${shared_owner[${identity_tool[$agent]}]:-} == "$agent" ]]; then
+      extra=(--shared-sessions on)
+    else
+      extra=(--shared-sessions off)
+    fi
+  fi
+  if ! record=$("$collector" "${flags[@]}" "${extra[@]}") || [[ -z $record ]] || ! jq -e . >/dev/null 2>&1 <<<"$record"; then
     echo "omarchy-agent-usage-update: $agent collector failed" >&2
     return 1
   fi
@@ -51,13 +68,63 @@ collect() {
   mv "$tmp" "$USAGE_DIR/$agent.json"
 }
 
-pids=()
+declare -A collectors
 for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
   [[ -x $collector ]] || continue
   agent="${collector##*/omarchy-agent-usage-}"
   [[ $agent == "update" ]] && continue
+  collectors[$agent]=$collector
+done
+if [[ -d $USER_COLLECTORS_DIR ]]; then
+  for collector in "$USER_COLLECTORS_DIR"/*; do
+    [[ -f $collector && -x $collector ]] || continue
+    collectors[${collector##*/}]=$collector
+  done
+fi
+
+# pi, omp, and opencode keep one transcript tree per tool, shared by every
+# account of that tool, so exactly one account may count them — and only this
+# command sees all the accounts at once, so the choice is made here rather
+# than inside any collector. Each collector answers --print-identity with its
+# tool, whether it sits on the stock directory, and what its wrapper asked
+# for; an explicit claim wins (first in name order, loudly, if two claim),
+# otherwise the stock account counts them, and with neither present they stay
+# uncounted rather than landing under a subscription they may not belong to.
+# Collectors that do not answer are left to their own defaults. Identity spans
+# every enabled account, not just the agents this run regenerates, so a
+# partial run decides ownership the same way a full one does.
+declare -A identity_tool identity_stock identity_pref
+declare -A shared_owner
+while IFS= read -r agent; do
+  [[ -n ${excluded[$agent]} ]] && continue
+  identity=$("${collectors[$agent]}" --print-identity 2>/dev/null) || continue
+  tool=$(jq -er '.tool // empty' 2>/dev/null <<<"$identity") || continue
+  [[ -n $tool ]] || continue
+  identity_tool[$agent]=$tool
+  identity_stock[$agent]=$(jq -r '.stock == true' <<<"$identity")
+  identity_pref[$agent]=$(jq -r '.sharedSessions // "auto"' <<<"$identity")
+done < <(printf '%s\n' "${!collectors[@]}" | sort)
+
+while IFS= read -r agent; do
+  [[ ${identity_pref[$agent]:-} == "on" ]] || continue
+  tool=${identity_tool[$agent]}
+  if [[ -n ${shared_owner[$tool]:-} ]]; then
+    echo "omarchy-agent-usage-update: both ${shared_owner[$tool]} and $agent claim the shared $tool sessions — keeping ${shared_owner[$tool]}" >&2
+  else
+    shared_owner[$tool]=$agent
+  fi
+done < <(printf '%s\n' "${!identity_tool[@]}" | sort)
+
+while IFS= read -r agent; do
+  [[ ${identity_pref[$agent]:-} == "auto" && ${identity_stock[$agent]:-} == "true" ]] || continue
+  tool=${identity_tool[$agent]}
+  [[ -z ${shared_owner[$tool]:-} ]] && shared_owner[$tool]=$agent
+done < <(printf '%s\n' "${!identity_tool[@]}" | sort)
+
+pids=()
+for agent in "${!collectors[@]}"; do
   wanted "$agent" || continue
-  collect "$collector" "$agent" &
+  collect "${collectors[$agent]}" "$agent" &
   pids+=($!)
 done
 

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -203,7 +203,7 @@ Item {
     for (var syncedId in syncedProviders) {
       if (localIds[syncedId] || !providerEnabled(syncedId)) continue
       var stats = syncedProviders[syncedId] || {}
-      var syncedDisplay = displayProvider({ id: syncedId, name: stats.providerName || syncedId })
+      var syncedDisplay = displayProvider({ id: syncedId, name: stats.providerName || syncedId, mark: stats.providerMark || "" })
       if (providerHasData(syncedDisplay)) result.push(syncedDisplay)
     }
     return result
@@ -240,13 +240,16 @@ Item {
   }
 
   function displayProvider(record) {
-    var stats = syncedStatsFor(String(record.id))
+    var stats = syncedStatsFor(String(record.id), String(record.mark || ""))
     var synced = !!stats
     var deviceCount = synced ? Number(stats.deviceCount || aggregateData.deviceCount || 0) : 0
 
     return {
       providerId: String(record.id),
       providerName: String(record.name || record.id),
+      // The tool behind the account, for the panel's icon lookup. Absent on
+      // records from before it existed, whose id names the tool anyway.
+      mark: String(record.mark || ""),
       ready: record.ready === true || synced,
       usageStatusText: String(record.usageStatusText || ""),
       authHelpText: String(record.authHelpText || ""),
@@ -559,6 +562,7 @@ Item {
       providers[id] = {
         providerId: id,
         providerName: "",
+        providerMark: "",
         ready: false,
         hasLocalStats: false,
         hasPromptStats: false,
@@ -585,6 +589,17 @@ Item {
       for (var providerId in snapshotProviders) {
         var stats = snapshotProviders[providerId] || {}
         var acc = providerAcc(String(providerId))
+        // Ids name accounts, and machines may disagree about which tool an
+        // id names — pooling a Claude account with a Codex one that happens
+        // to share its name would charge one subscription with the other's
+        // tokens. Snapshots from before marks travelled carry none and merge
+        // as they always did.
+        var snapshotMark = String(stats.providerMark || "")
+        if (snapshotMark !== "" && acc.providerMark !== "" && snapshotMark !== acc.providerMark) {
+          console.warn("agents/sync", "account", providerId, "is", acc.providerMark, "here and", snapshotMark, "on", device, "— ignoring the mismatched snapshot")
+          continue
+        }
+        if (snapshotMark !== "" && acc.providerMark === "") acc.providerMark = snapshotMark
         acc.devices[device] = true
         if (stats.providerName && acc.providerName === "") acc.providerName = String(stats.providerName)
         acc.ready = acc.ready || stats.ready === true
@@ -632,6 +647,7 @@ Item {
       outProviders[id] = {
         providerId: acc.providerId,
         providerName: acc.providerName,
+        providerMark: acc.providerMark,
         ready: acc.ready || providerDevices.length > 0,
         hasLocalStats: acc.hasLocalStats,
         hasPromptStats: acc.hasPromptStats,
@@ -665,6 +681,7 @@ Item {
     return {
       providerId: String(record.id),
       providerName: String(record.name || record.id),
+      providerMark: String(record.mark || ""),
       ready: record.ready === true,
       hasLocalStats: record.hasLocalStats !== false,
       hasPromptStats: record.hasPromptStats !== false,
@@ -698,10 +715,18 @@ Item {
     }
   }
 
-  function syncedStatsFor(providerId) {
+  // The mark is part of the match, not just the id: an aggregate whose mark
+  // names the other tool belongs to a different subscription that happens to
+  // share the name. Aggregates and records from before marks travelled carry
+  // none and still match.
+  function syncedStatsFor(providerId, mark) {
     var rev = syncRevision
     if (!syncConfigured() || !aggregateData || !aggregateData.providers) return null
-    return aggregateData.providers[providerId] || null
+    var stats = aggregateData.providers[providerId] || null
+    if (!stats) return null
+    var statsMark = String(stats.providerMark || "")
+    if (statsMark !== "" && mark && statsMark !== String(mark)) return null
+    return stats
   }
 
   // ---------------------------------------------------------------- format

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -278,10 +278,14 @@ Panel {
   // if it doesn't.
   function iconCandidatesForProvider(p, surfaceColor) {
     if (!p) return []
+    // The mark names the tool an account runs, so a second account of one
+    // tool keeps that tool's icon instead of falling back to the bar glyph.
+    // Records without a mark are their own tool, as before.
+    var base = String(p.mark || p.providerId)
     var candidates = []
     if (colorLuminance(surfaceColor || Color.background) >= 0.5)
-      candidates.push(Qt.resolvedUrl("assets/" + p.providerId + "-light.svg"))
-    candidates.push(Qt.resolvedUrl("assets/" + p.providerId + ".svg"))
+      candidates.push(Qt.resolvedUrl("assets/" + base + "-light.svg"))
+    candidates.push(Qt.resolvedUrl("assets/" + base + ".svg"))
     return candidates
   }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -48,7 +48,9 @@ Adding an agent therefore never touches this plugin: ship a collector that
 prints the record contract (see the `claude` and `codex` collectors in
 `bin/`), and the panel gains a tab. An `assets/<id>.svg` mark is optional —
 with an `assets/<id>-light.svg` twin if the mark needs a dark variant for
-light surfaces — and the bar glyph stands in when there is none.
+light surfaces — and the bar glyph stands in when there is none. A record may
+instead name the tool it runs with `"mark"`, and the panel uses that mark's
+assets — how a second account of a shipped agent keeps its tool's icon.
 
 | Collector | Limits | Local stats |
 |---|---|---|
@@ -91,6 +93,59 @@ period. `accountId` only matters when one API key can access several
 accounts. Without a configured `fundedAmount` the tab still shows token
 usage, just no balance. With a live ledger, `fundedAmount` is optional and
 only adds the meter and the spent-of-funded line under the real figure.
+
+## Accounts
+
+An account is one subscription: a work Claude and a personal one are two
+accounts, each with its own config directory — `CLAUDE_CONFIG_DIR` for
+Claude, `CODEX_HOME` for Codex, the only mechanisms that keep two logins'
+credentials *and* transcripts apart — and each with its own tab, limits, and
+totals.
+
+The shipped collectors cover the stock directories. Every further account is
+a collector of its own in `~/.config/omarchy/agents/collectors.d/`: an
+executable named for the account's id that points a shipped collector at the
+account's directory.
+
+```bash
+# ~/.config/omarchy/agents/collectors.d/claude-work   (chmod +x)
+#!/bin/bash
+export CLAUDE_CONFIG_DIR="$HOME/.claude-work"
+exec omarchy-agent-usage-claude --id claude-work --name "Work" "$@"
+```
+
+The file name, the `--id`, and the record's id are one string — the update
+command names the record file after the collector, and per-agent `enabled`
+matches on it. `"$@"` keeps `--force` and `--limits-only` flowing. The
+account appears in the panel on the next refresh wearing the Claude mark:
+the record carries which tool it runs, so it never falls back to the bar
+glyph. A user collector with a shipped collector's name replaces the shipped
+one. Codex accounts work the same way with `CODEX_HOME` and
+`omarchy-agent-usage-codex`; Fireworks with its credential environment
+variables and `omarchy-agent-usage-fireworks`.
+
+pi, omp, and opencode keep one transcript tree apiece with nothing tying
+them to an account, so exactly one account may count them. The update
+command resolves whose they are across every enabled account — it reads each
+collector's tool and preference through `--print-identity`, then runs each
+one with an explicit `--shared-sessions on` or `off`. A wrapper claiming
+them with `--shared-sessions on` wins, and the stock account is switched off
+for that run without any paired override; with no claim the stock account
+counts them; with neither enabled they stay uncounted rather than landing
+under a subscription they may not belong to. Two claims keep the first, with
+a warning. A collector run by hand outside the update command falls back to
+its own `auto`: the stock directory counts the trees.
+
+Synced snapshots carry each account's tool, and machines refuse to pool a
+name that runs Claude here with one that runs Codex elsewhere — the
+mismatched snapshot is ignored with a warning rather than summed.
+
+Removing an account is removing its collector and the record it left:
+
+```bash
+rm ~/.config/omarchy/agents/collectors.d/claude-work
+rm ~/.local/state/omarchy/agents/usage/claude-work.json
+```
 
 ## Interactions
 

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -18,7 +18,7 @@ cat >"$projects/session.jsonl" <<EOF
 {"timestamp":"$timestamp","type":"assistant","sessionId":"session-1","uuid":"event-3","message":{"id":"message-2","role":"assistant","model":"claude-test","usage":{"input_tokens":2,"cache_creation_input_tokens":454,"cache_read_input_tokens":28857,"output_tokens":390}}}
 EOF
 
-result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+result=$(HOME="$TEST_HOME" CLAUDE_CONFIG_DIR="" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "58793" ]] ||
@@ -46,7 +46,7 @@ cat >"$HISTORY_HOME/.claude/history.jsonl" <<EOF
 {"timestamp":$now_ms,"sessionId":"s2","display":"two"}
 EOF
 
-result=$(HOME="$HISTORY_HOME" XDG_CACHE_HOME="$HISTORY_HOME/.cache" XDG_DATA_HOME="$HISTORY_HOME/.local/share" \
+result=$(HOME="$HISTORY_HOME" CLAUDE_CONFIG_DIR="" XDG_CACHE_HOME="$HISTORY_HOME/.cache" XDG_DATA_HOME="$HISTORY_HOME/.local/share" \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '(.todayPrompts|tostring) + "/" + (.todaySessions|tostring)' <<<"$result") == "2/2" ]] ||
@@ -92,7 +92,7 @@ conn.commit()
 conn.close()
 PY
 
-result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+result=$(HOME="$OPENCODE_HOME" CLAUDE_CONFIG_DIR="" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '(.ready|tostring) + "/" + (.todayTotalTokens|tostring)' <<<"$result") == "true/192" ]] ||
@@ -118,7 +118,7 @@ cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
 { "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "anthropic", "model": "claude-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }
 EOF
 
-result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+result=$(HOME="$PI_HOME" CLAUDE_CONFIG_DIR="" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "49" ]] ||
@@ -178,3 +178,84 @@ PY
 [[ $(jq -r '.mode' <<<"$race_output") == "0o644" ]] ||
   fail "Claude collector keeps cache files readable" "$race_output"
 pass "Claude collector survives concurrent writes to one cache file"
+
+[[ $(jq -r '.mark' <<<"$result") == "claude" ]] ||
+  fail "Claude collector records which tool the account runs" "$result"
+pass "Claude collector records which tool the account runs"
+
+# A second account is the same collector pointed at another CLAUDE_CONFIG_DIR
+# with an id of its own. It reports under that id wearing the Claude mark,
+# reads its own transcripts, and leaves the shared pi/omp/opencode trees to
+# the stock account — they carry no account, so counting them for both would
+# count them twice.
+work_projects="$PI_HOME/.claude-work/projects/example"
+mkdir -p "$work_projects"
+cat >"$work_projects/session.jsonl" <<EOF
+{"timestamp":"$timestamp","type":"assistant","sessionId":"work-1","uuid":"w-1","message":{"id":"wm-1","role":"assistant","model":"claude-test","usage":{"input_tokens":5,"output_tokens":7}}}
+EOF
+
+result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR="$PI_HOME/.claude-work" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force --id claude-work --name "Work")
+
+[[ $(jq -r '.id + "/" + .name + "/" + .mark' <<<"$result") == "claude-work/Work/claude" ]] ||
+  fail "a second Claude account reports its own id and name under the Claude mark" "$result"
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "12" ]] ||
+  fail "a second Claude account reads its own directory and leaves the shared trees to the stock account" "$result"
+pass "a second Claude account keeps its own identity and leaves shared trees alone"
+
+result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR="$PI_HOME/.claude-work" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force --id claude-work --shared-sessions on)
+
+[[ $(jq -r '.name + "/" + (.todayTotalTokens|tostring)' <<<"$result") == "claude-work/61" ]] ||
+  fail "--shared-sessions on claims the shared trees for a chosen account, which defaults its name to its id" "$result"
+pass "--shared-sessions on claims the shared trees for a chosen account"
+
+result=$(HOME="$PI_HOME" CLAUDE_CONFIG_DIR="" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force --shared-sessions off)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "0" ]] ||
+  fail "--shared-sessions off keeps the shared trees out of the stock account" "$result"
+pass "--shared-sessions off keeps the shared trees out of the stock account"
+
+# Rate limits are per-subscription, so each account keeps its own probe
+# cache — a second account answering with the first one's cached limits would
+# display the wrong subscription's numbers. Fresh per-directory caches are
+# seeded the way collect_limits writes them, so no probe leaves the machine.
+LIMITS_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$HISTORY_HOME" "$OPENCODE_HOME" "$PI_HOME" "$LIMITS_HOME"' EXIT
+future_ms=$(( ($(date +%s) + 3600) * 1000 ))
+for dir in .claude .claude-work; do
+  mkdir -p "$LIMITS_HOME/$dir"
+  cat >"$LIMITS_HOME/$dir/.credentials.json" <<EOF
+{"claudeAiOauth":{"accessToken":"token-$dir","expiresAt":$future_ms,"subscriptionType":"max"}}
+EOF
+done
+
+python3 - "$LIMITS_HOME" <<'PY'
+import hashlib, json, sys, time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+cache = home / ".cache" / "omarchy" / "agent-usage"
+cache.mkdir(parents=True, exist_ok=True)
+for dirname, label in ((".claude", "Stock window"), (".claude-work", "Work window")):
+  digest = hashlib.sha1(str((home / dirname).resolve()).encode("utf-8")).hexdigest()[:16]
+  (cache / f"claude-limits-{digest}.json").write_text(json.dumps({
+    "fetchedAtMs": round(time.time() * 1000),
+    "limits": [{"label": label, "percent": 0.5, "resetsAt": ""}],
+  }))
+PY
+
+result=$(HOME="$LIMITS_HOME" CLAUDE_CONFIG_DIR="" XDG_CACHE_HOME="$LIMITS_HOME/.cache" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude")
+[[ $(jq -r '.limits[0].label' <<<"$result") == "Stock window" ]] ||
+  fail "the stock account answers with its own cached limits" "$result"
+
+result=$(HOME="$LIMITS_HOME" XDG_CACHE_HOME="$LIMITS_HOME/.cache" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR="$LIMITS_HOME/.claude-work" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --id claude-work)
+[[ $(jq -r '.limits[0].label' <<<"$result") == "Work window" ]] ||
+  fail "a second account keeps a limits cache of its own" "$result"
+pass "each account keeps a limits cache of its own"

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -55,6 +55,10 @@ pass "Codex collector does not double-count cache or reasoning tokens"
   fail "Codex collector identifies itself with an empty limits list" "$result"
 pass "Codex collector identifies itself with an empty limits list"
 
+[[ $(jq -r '.mark' <<<"$result") == "codex" ]] ||
+  fail "Codex collector records which tool the account runs" "$result"
+pass "Codex collector records which tool the account runs"
+
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.
 PI_HOME=$(mktemp -d)
@@ -77,6 +81,33 @@ result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex" XDG_DATA_HOME="$PI_HOME/.l
 [[ $(jq -c '.modelUsage' <<<"$result") == '{"gpt-pi":{"inputTokens":10,"outputTokens":4,"cacheReadInputTokens":3,"cacheCreationInputTokens":2},"gpt-omp":{"inputTokens":20,"outputTokens":5,"cacheReadInputTokens":4,"cacheCreationInputTokens":1}}' ]] ||
   fail "Codex collector filters pi and omp sessions to Codex providers" "$result"
 pass "Codex collector counts pi and omp subscription usage"
+
+# A second account is the same collector pointed at another CODEX_HOME with an
+# id of its own. It reports under that id wearing the Codex mark, and leaves
+# the shared pi/omp trees to the stock account — they carry no account, so
+# counting them for both would count them twice.
+result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex-work" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  PATH="$PI_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --id codex-work --name "Work")
+
+[[ $(jq -r '.id + "/" + .name + "/" + .mark' <<<"$result") == "codex-work/Work/codex" ]] ||
+  fail "a second Codex account reports its own id and name under the Codex mark" "$result"
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "0" ]] ||
+  fail "a second Codex account leaves the shared pi and omp trees to the stock account" "$result"
+pass "a second Codex account keeps its own identity and leaves shared trees alone"
+
+result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex-work" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  PATH="$PI_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --id codex-work --shared-sessions on)
+
+[[ $(jq -r '.name + "/" + (.todayTotalTokens|tostring)' <<<"$result") == "codex-work/49" ]] ||
+  fail "--shared-sessions on claims the shared trees for a chosen account, which defaults its name to its id" "$result"
+pass "--shared-sessions on claims the shared trees for a chosen account"
+
+result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  PATH="$PI_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --shared-sessions off)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "0" ]] ||
+  fail "--shared-sessions off keeps the shared trees out of the stock account" "$result"
+pass "--shared-sessions off keeps the shared trees out of the stock account"
 
 # A subscription burned entirely through opencode has no native session files;
 # usage must come from opencode's message database, filtered to OpenAI.

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -35,7 +35,9 @@ chmod +x "$FAKE_OMARCHY/bin/"omarchy-agent-usage-*
 
 usage_dir="$TEST_HOME/.local/state/omarchy/agents/usage"
 
-HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
+# XDG_CONFIG_HOME is pinned so a collectors.d on the developer's own machine
+# cannot leak into the run.
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" XDG_CONFIG_HOME="" \
   "$ROOT/bin/omarchy-agent-usage-update" --except skipped 2>/dev/null && fail "update reports a failing collector"
 pass "update reports a failing collector"
 
@@ -55,7 +57,7 @@ pass "update skips agents excluded with --except"
   fail "update does not treat itself as a collector"
 pass "update does not treat itself as a collector"
 
-HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" XDG_CONFIG_HOME="" \
   "$ROOT/bin/omarchy-agent-usage-update" skipped 2>/dev/null ||
   fail "update succeeds when the requested collectors all pass"
 pass "update succeeds when the requested collectors all pass"
@@ -63,3 +65,110 @@ pass "update succeeds when the requested collectors all pass"
 [[ -e $usage_dir/skipped.json && ! -e $usage_dir/noisy.json ]] ||
   fail "update with agent arguments only runs the named collectors"
 pass "update with agent arguments only runs the named collectors"
+
+# User collectors in ~/.config/omarchy/agents/collectors.d/ join the shipped
+# ones — that is how a second account of a shipped agent exists. One with a
+# shipped collector's name replaces it, and everything else (--except, the
+# record naming) treats them alike.
+user_dir="$TEST_HOME/.config/omarchy/agents/collectors.d"
+mkdir -p "$user_dir"
+
+cat >"$user_dir/extra" <<'EOF'
+#!/bin/bash
+echo '{"schemaVersion":1,"id":"extra","name":"Extra Account","mark":"good","totalPrompts":2}'
+EOF
+
+cat >"$user_dir/good" <<'EOF'
+#!/bin/bash
+echo '{"schemaVersion":1,"id":"good","name":"User Good","totalPrompts":5}'
+EOF
+
+cat >"$user_dir/passive" <<'EOF'
+#!/bin/bash
+echo '{"id":"passive"}'
+EOF
+
+chmod +x "$user_dir/extra" "$user_dir/good"
+
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" XDG_CONFIG_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" --except noisy 2>/dev/null ||
+  fail "update succeeds with user collectors present"
+pass "update succeeds with user collectors present"
+
+[[ $(jq -r '.name' "$usage_dir/extra.json") == "Extra Account" ]] ||
+  fail "update runs user collectors from collectors.d"
+pass "update runs user collectors from collectors.d"
+
+[[ $(jq -r '.name' "$usage_dir/good.json") == "User Good" ]] ||
+  fail "a user collector with a shipped collector's name replaces it"
+pass "a user collector with a shipped collector's name replaces it"
+
+[[ ! -e $usage_dir/passive.json ]] ||
+  fail "update ignores non-executable files in collectors.d"
+pass "update ignores non-executable files in collectors.d"
+
+rm -f "$usage_dir/extra.json"
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" XDG_CONFIG_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" --except noisy --except extra 2>/dev/null ||
+  fail "update succeeds while excluding a user collector"
+
+[[ ! -e $usage_dir/extra.json ]] ||
+  fail "update skips user collectors excluded with --except"
+pass "update skips user collectors excluded with --except"
+
+# Shared-tree ownership is resolved here, across every enabled account of a
+# tool, so wrappers need no manually paired overrides: an explicit claim wins
+# and switches the stock account off; without one the stock account counts
+# the trees; with neither enabled they stay uncounted. Each fake answers
+# --print-identity and otherwise echoes its argv into its record, so the
+# assertions read exactly what this command decided.
+for spec in "shared-stock:true:auto" "shared-claimer:false:on" "shared-follower:false:auto"; do
+  IFS=: read -r name stock pref <<<"$spec"
+  cat >"$user_dir/$name" <<EOF
+#!/bin/bash
+for arg; do
+  [[ \$arg == --print-identity ]] && { echo '{"tool":"sharedtool","stock":$stock,"sharedSessions":"$pref"}'; exit 0; }
+done
+echo "{\"schemaVersion\":1,\"id\":\"$name\",\"args\":\"\$*\"}"
+EOF
+  chmod +x "$user_dir/$name"
+done
+
+run_update() {
+  HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" XDG_CONFIG_HOME="" \
+    "$ROOT/bin/omarchy-agent-usage-update" --except noisy "$@" 2>/dev/null
+}
+
+shared_args() {
+  jq -r '.args' "$usage_dir/$1.json"
+}
+
+run_update || fail "update succeeds while resolving shared-tree ownership"
+[[ $(shared_args shared-claimer) == *"--shared-sessions on"* ]] ||
+  fail "an explicit claim owns the shared trees" "$(shared_args shared-claimer)"
+[[ $(shared_args shared-stock) == *"--shared-sessions off"* ]] ||
+  fail "an explicit claim switches the stock account off without a manual override" "$(shared_args shared-stock)"
+[[ $(shared_args shared-follower) == *"--shared-sessions off"* ]] ||
+  fail "accounts without a claim are switched off" "$(shared_args shared-follower)"
+pass "an explicit claim owns the shared trees and switches the stock account off"
+
+run_update --except shared-claimer || fail "update succeeds without the claimant"
+[[ $(shared_args shared-stock) == *"--shared-sessions on"* ]] ||
+  fail "without an explicit claim the stock account counts the shared trees" "$(shared_args shared-stock)"
+[[ $(shared_args shared-follower) == *"--shared-sessions off"* ]] ||
+  fail "a non-stock account stays off when the stock account owns the trees" "$(shared_args shared-follower)"
+pass "without an explicit claim the stock account counts the shared trees"
+
+run_update --except shared-claimer --except shared-stock || fail "update succeeds without any claimant"
+[[ $(shared_args shared-follower) == *"--shared-sessions off"* ]] ||
+  fail "with no claimant and no stock account the shared trees stay uncounted" "$(shared_args shared-follower)"
+pass "with no claimant and no stock account the shared trees stay uncounted"
+
+# A partial run must decide ownership over the enabled population, not over
+# the agents it happens to regenerate — the claimant owns the trees even
+# when only another account refreshes.
+rm -f "$usage_dir/shared-follower.json"
+run_update shared-follower || fail "update succeeds for a partial run"
+[[ $(shared_args shared-follower) == *"--shared-sessions off"* && ! -e $usage_dir/shared-stock.json.tmp ]] ||
+  fail "a partial run decides ownership the same way a full one does" "$(shared_args shared-follower)"
+pass "a partial run decides ownership the same way a full one does"

--- a/test/shell.d/agents-accounts-test.sh
+++ b/test/shell.d/agents-accounts-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping agents accounts test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/agents-accounts"
+usage_dir="$TMPDIR/state/omarchy/agents/usage"
+mkdir -p "$config_dir" "$TMPDIR/home" "$TMPDIR/bin" "$usage_dir"
+cp "$SHELL_TEST_DIR/fixtures/agents-accounts/shell.qml" "$config_dir/shell.qml"
+
+# Two accounts of one tool, the way collectors.d wrappers would write them.
+cat >"$usage_dir/claude.json" <<'EOF'
+{"schemaVersion":1,"id":"claude","name":"Claude Code","mark":"claude","ready":true,"totalPrompts":3}
+EOF
+cat >"$usage_dir/claude-work.json" <<'EOF'
+{"schemaVersion":1,"id":"claude-work","name":"Work","mark":"claude","ready":true,"totalPrompts":5}
+EOF
+
+# Main.qml runs the updater once at startup; a stub keeps that run away from
+# the real collectors and the fixture records they would overwrite.
+cat >"$TMPDIR/bin/omarchy-agent-usage-update" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$TMPDIR/bin/omarchy-agent-usage-update"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_STATE_HOME="$TMPDIR/state" \
+PATH="$TMPDIR/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..100}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,120p' "$log" >&2
+    fail "agents accounts quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,120p' "$log" >&2
+  fail "agents accounts test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Agents accounts result:\n' >&2
+  jq . "$result" >&2
+  printf 'Agents accounts log:\n' >&2
+  sed -n '1,120p' "$log" >&2
+  fail "agents accounts identity checks pass"
+fi
+
+pass "agents accounts identity checks pass"

--- a/test/shell.d/fixtures/agents-accounts/shell.qml
+++ b/test/shell.d/fixtures/agents-accounts/shell.qml
@@ -1,0 +1,118 @@
+import QtQuick
+import Quickshell
+
+// Drives the agents Main.qml through the account-identity paths: records that
+// carry a mark, snapshots that carry it across machines, and the refusal to
+// pool two tools that happen to share an account name.
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  property var failures: []
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({ ok: failures.length === 0, failures: failures })
+    if (resultPath)
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+  }
+
+  // An explicit file:// url, not a bare path: a path goes through Quickshell's
+  // own vfs, where Main.qml's sibling Agent.qml no longer resolves.
+  Loader {
+    id: usage
+    source: "file://" + Quickshell.env("OMARCHY_PATH") + "/shell/plugins/agents/Main.qml"
+  }
+
+  function recordsLoaded() {
+    var agents = usage.item ? usage.item.agents : []
+    if (agents.length !== 2) return false
+    for (var i = 0; i < agents.length; i++)
+      if (!agents[i] || !agents[i].record) return false
+    return true
+  }
+
+  function recordById(id) {
+    var agents = usage.item.agents
+    for (var i = 0; i < agents.length; i++)
+      if (agents[i].record && String(agents[i].record.id) === id) return agents[i].record
+    return null
+  }
+
+  Timer {
+    interval: 120
+    repeat: true
+    running: true
+    property int ticks: 0
+
+    onTriggered: {
+      ticks++
+      if (!usage.item || !root.recordsLoaded()) {
+        if (ticks > 60) {
+          root.fail("usage records for both accounts load")
+          running = false
+          root.writeResult()
+        }
+        return
+      }
+      running = false
+
+      var item = usage.item
+
+      // The mark travels from the record into the display object the panel
+      // reads, so a second account of one tool wears that tool's icon.
+      var work = root.recordById("claude-work")
+      root.assertTrue(!!work && item.displayProvider(work).mark === "claude",
+        "displayProvider carries the record's mark")
+
+      // Machines may disagree about which tool an account name runs; pooling
+      // them would charge one subscription with the other's tokens. The first
+      // mark seen wins, the conflicting snapshot is ignored, and snapshots
+      // from before marks travelled still merge.
+      var aggregate = item.aggregateSnapshots([
+        JSON.parse('{"deviceId":"one","providers":{"work":{"providerName":"Work","providerMark":"claude","totalPrompts":100,"ready":true}}}'),
+        JSON.parse('{"deviceId":"two","providers":{"work":{"providerName":"Work","providerMark":"codex","totalPrompts":40,"ready":true}}}'),
+        JSON.parse('{"deviceId":"three","providers":{"legacy":{"providerName":"Old","totalPrompts":7,"ready":true}}}')
+      ])
+      root.assertTrue(aggregate.providers["work"].totalPrompts === 100,
+        "a snapshot whose mark names the other tool is not summed into the account")
+      root.assertTrue(aggregate.providers["work"].providerMark === "claude",
+        "the aggregate carries the account's mark")
+      root.assertTrue(aggregate.providers["legacy"].totalPrompts === 7,
+        "a snapshot written before marks travelled still merges")
+
+      // The lookup matches on the mark too, so a local account never reads an
+      // aggregate that belongs to the other tool. Sync is switched on for the
+      // assertions and off again before its debounce can run anything.
+      item.settings = ({ syncMode: "On", syncDir: "/tmp/agents-accounts-fixture-sync" })
+      item.aggregateData = aggregate
+      root.assertTrue(item.syncedStatsFor("work", "codex") === null,
+        "an account does not read an aggregate marked as the other tool")
+      root.assertTrue(!!item.syncedStatsFor("work", "claude") && item.syncedStatsFor("work", "claude").totalPrompts === 100,
+        "an account reads the aggregate marked as its own tool")
+      root.assertTrue(!!item.syncedStatsFor("legacy", "claude") && item.syncedStatsFor("legacy", "claude").totalPrompts === 7,
+        "an unmarked legacy aggregate still matches")
+      item.settings = ({})
+
+      // The local snapshot records each account's mark for the machines that
+      // will read it.
+      var snapshot = item.localSnapshot()
+      root.assertTrue(String(snapshot.providers["claude"].providerMark) === "claude"
+        && String(snapshot.providers["claude-work"].providerMark) === "claude",
+        "the local snapshot records each account's mark")
+
+      root.writeResult()
+    }
+  }
+}

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -100,6 +100,10 @@ ShellRoot {
       var lightIcons = item.iconCandidatesForProvider({ providerId: "codex" }, Qt.color("#ffffff")).join(" ")
       root.assertTrue(darkIcons.indexOf("codex.svg") >= 0 && darkIcons.indexOf("codex-light.svg") < 0, entry.id + " uses the dark-theme Codex icon on dark surfaces")
       root.assertTrue(lightIcons.indexOf("codex-light.svg") >= 0, entry.id + " prefers the light-theme Codex icon on light surfaces")
+      // The mark names the tool an account runs, so a second account keeps
+      // that tool's icon instead of falling back to the bar glyph.
+      var accountIcons = item.iconCandidatesForProvider({ providerId: "claude-work", mark: "claude" }, Qt.color("#1a1b26")).join(" ")
+      root.assertTrue(accountIcons.indexOf("/claude.svg") >= 0, entry.id + " marks a second account with its tool's icon")
     }
 
     safeCall(item, "refresh", entry)


### PR DESCRIPTION
## Why

I run more than one AI subscription on the same machine: a work Claude account, a second work account, and a personal one. Each lives in its own config directory -  that is what `CLAUDE_CONFIG_DIR` is for, and `CODEX_HOME` is its Codex counterpart. It is also the only mechanism that keeps two logins' credentials *and* transcripts apart.

The agents panel only ever shows the stock directories, so whichever account lives there is the only one with numbers in the bar. The others are invisible, and the subscription switch has nothing extra to switch between.

*Reworked after #6603 onto the collector/record split - this now touches no panel machinery beyond a one-line icon lookup, which is a good sign for that design.*

## What this adds

An account is one more collector. `omarchy-agent-usage-update` now also runs executables from `~/.config/omarchy/agents/collectors.d/`, and the shipped collectors take `--id` / `--name`, so a second account is a three-line wrapper named for the id its record carries:

```bash
# ~/.config/omarchy/agents/collectors.d/claude-work   (chmod +x)
#!/bin/bash
export CLAUDE_CONFIG_DIR="$HOME/.claude-work"
exec omarchy-agent-usage-claude --id claude-work --name "Work" "$@"
```

That's the whole feature: the record lands in the usage directory under its own id, and the panel — which already keys tabs on `record.id` - gains a tab with its own limits, plan line, and totals. Nothing is pooled across accounts. A user collector with a shipped collector's name replaces it, which is also how the stock account's flags can be overridden. `--except` and per-agent `enabled` keep working, since the collector name and the record id are the same string.

## The parts that needed more than plumbing

- **Icons.** Marks resolve as `assets/<id>.svg`, so `claude-work` would fall back to the bar glyph. Records now carry `"mark"` - the tool behind the account - and `iconCandidatesForProvider` prefers it over the id. One line in the panel; every account of a tool wears that tool's mark.
- **The shared trees.** pi, omp, and opencode keep one transcript tree apiece, with nothing tying them to an account - counting them for every account would count them once per account. Ownership is resolved centrally in `omarchy-agent-usage-update`, the one place that sees every account:= collectors answer `--print-identity` with their tool, stock-directory status (compared by path spelling, not symlink target), and their wrapper's preference, and the update run hands each one an explicit `--shared-sessions on`/`off` — appended after the wrapper's own flags, so the central decision takes precedence. An explicit claim wins and switches the stock account off with no paired override; with no claim the stock account counts the trees; with neither enabled they stay uncounted rather than landing under a subscription they may not belong to. Collectors that do not answer the identity probe are left to their own defaults, and a collector run by hand falls back to `auto`.
- **The limits cache.** The Claude collector kept one probe cache for the machine; a second account would have answered with the first one's cached limits. It is now keyed by the account's directory.
- **Sync.** Snapshots carry each account's mark, and machines refuse to pool a name that runs Claude here with one that runs Codex elsewhere - the mismatched snapshot is ignored with a warning, and the per-record lookup matches on the mark too. Snapshots from before marks travelled carry none and merge as they always did.

`omarchy-agent-usage-fireworks` takes `--id` / `--name` as well, for a second prepaid account fed by its own credential environment.

## Tests

- `agent-usage-update-test.sh`: collectors.d discovery, shipped-collector override, non-executables ignored, `--except` on a user collector, and the shared-tree resolution - an explicit claim switching the stock account off, the stock account owning the trees without one, nobody counting them with neither enabled, and a partial run deciding ownership over the enabled population rather than the agents it regenerates. The pre-existing invocations also pin `XDG_CONFIG_HOME`, so a collectors.d on the developer's machine cannot leak into the run.
- `agent-usage-claude-scanner-test.sh`: `--id`/`--name`/`mark`; a second account reading its own directory while leaving the shared trees to the stock account; `--shared-sessions` both ways; per-directory limits caches answering with their own numbers (seeded caches, no network). Invocations pin `CLAUDE_CONFIG_DIR`, which the developer's own session may export - found the hard way, on a machine where it is.
- `agent-usage-codex-scanner-test.sh`: the same identity and shared-tree cases for `CODEX_HOME`.
- New `agents-accounts-test.sh` drives `Main.qml` headless: the mark flowing into the display object, aggregation refusing a mark conflict while legacy snapshots still merge, the mark-aware synced lookup, and the local snapshot recording marks. Fails without each guard.
- The bar-widget contract fixture asserts a `claude-work` record with `mark: "claude"` resolves the Claude icon.

Verified on a running desktop with three real accounts: personal (Max 5x, live limits), a second Claude account, and Codex - three chips, each with its own plan line and totals, both Claude accounts wearing the Claude mark.

## Notes

Removing an account is removing its wrapper and the record it left in the usage directory; the README's new Accounts section documents the recipe, the shared-tree ownership, and that removal. Records written by older versions (no `mark`) display and sync exactly as before.