### PR TITLE
Add a keyboard layout switch command with an OSD readout

### DIFF
--- a/bin/omarchy-hyprland-keyboard-layout
+++ b/bin/omarchy-hyprland-keyboard-layout
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# omarchy:summary=Switch the keyboard layout and show it on the OSD
+# omarchy:args=[next|prev|status]
+# omarchy:examples=omarchy hyprland keyboard-layout | omarchy hyprland keyboard-layout prev | omarchy hyprland keyboard-layout status
+
+action="${1:-next}"
+
+case $action in
+  next | prev)
+    hyprctl switchxkblayout all "$action" >/dev/null
+    ;;
+  status) ;;
+  *)
+    echo "Usage: omarchy-hyprland-keyboard-layout [next|prev|status]" >&2
+    exit 1
+    ;;
+esac
+
+# hyprctl answers the dispatch only after the switch lands, so the read below
+# already sees the new keymap. The main keyboard speaks for the lot: `all`
+# switches every keyboard, and singling one out keeps power buttons and other
+# keymap-less "keyboards" from answering instead.
+layout=$(hyprctl -j devices | jq -r '.keyboards | (map(select(.main)) + .)[0].active_keymap // empty')
+[[ -n $layout ]] || exit 1
+
+if [[ $action == "status" ]]; then
+  echo "$layout"
+else
+  omarchy-osd -i keyboard -m "$layout"
+fi

--- a/test/shell.d/keyboard-layout-test.sh
+++ b/test/shell.d/keyboard-layout-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+export CALLS="$tmp_dir/calls"
+: >"$CALLS"
+
+# The power button and other keymap-less inputs also sit in `keyboards`, so the
+# fixture keeps a non-main entry first: the command must answer with the main
+# keyboard, not whichever happens to lead the list. The main keymap carries a
+# space and parentheses on purpose — xkb names them like that, and they must
+# survive the trip to the OSD intact.
+cat >"$tmp_dir/bin/hyprctl" <<'STUB'
+#!/bin/bash
+printf 'hyprctl %s\n' "$*" >>"$CALLS"
+if [[ $1 == "-j" && $2 == "devices" ]]; then
+  cat <<'JSON'
+{
+  "keyboards": [
+    { "name": "power-button", "main": false, "active_keymap": "English (US)" },
+    { "name": "real-keyboard", "main": true, "active_keymap": "Portuguese (Brazil)" }
+  ]
+}
+JSON
+fi
+exit 0
+STUB
+
+cat >"$tmp_dir/bin/omarchy-osd" <<'STUB'
+#!/bin/bash
+printf 'omarchy-osd %s\n' "$*" >>"$CALLS"
+STUB
+
+chmod +x "$tmp_dir/bin/hyprctl" "$tmp_dir/bin/omarchy-osd"
+
+run() {
+  : >"$CALLS"
+  PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-hyprland-keyboard-layout" "$@"
+}
+
+run
+grep -Fx 'hyprctl switchxkblayout all next' "$CALLS" >/dev/null || fail "default action dispatches switchxkblayout all next"
+grep -Fx 'omarchy-osd -i keyboard -m Portuguese (Brazil)' "$CALLS" >/dev/null || fail "switch shows the main keyboard layout on the OSD"
+pass "switch dispatches and shows the main keyboard layout on the OSD"
+
+run prev
+grep -Fx 'hyprctl switchxkblayout all prev' "$CALLS" >/dev/null || fail "prev dispatches switchxkblayout all prev"
+pass "prev dispatches switchxkblayout all prev"
+
+status_output=$(run status)
+[[ $status_output == "Portuguese (Brazil)" ]] || fail "status prints the main keyboard layout" "$status_output"
+if grep -q 'switchxkblayout' "$CALLS"; then
+  fail "status does not switch the layout"
+fi
+if grep -q 'omarchy-osd' "$CALLS"; then
+  fail "status does not open the OSD"
+fi
+pass "status reports without switching or opening the OSD"
+
+if run bogus 2>/dev/null; then
+  fail "unknown action exits non-zero"
+fi
+pass "unknown action exits non-zero"


### PR DESCRIPTION
## Why

Volume, brightness, and media keys all answer through the OSD, but switching the keyboard layout answers with nothing: bind `hyprctl switchxkblayout` and the only way to find out which layout you landed on is to type something and see what comes out. With two layouts that means guessing wrong half the time; with more, worse.

## What this adds

`omarchy-hyprland-keyboard-layout [next|prev|status]` — the same shape as `omarchy-audio-output-volume`: perform the change, then show the result on the OSD.

- `next` / `prev` dispatch `switchxkblayout all` and pop the OSD with the keyboard glyph and the new layout's name as xkb reports it — "English (US)", "Portuguese (Brazil)", "German (dead acute)", whatever is configured.
- `status` prints the active layout to stdout without switching or opening the OSD.

No default binding is added; users point whichever combo they already switch
with at it:

```lua
o.bind("SUPER + U", "Switch keyboard layout", "omarchy-hyprland-keyboard-layout", { locked = true })
```

`locked = true` is worth having here: the layout you type your lock-screen password in is the one place where being on the wrong one hurts most.

## Notes

- The layout is read back from the `main` keyboard rather than the first entry in `hyprctl devices` — power buttons and other keymap-less inputs also sit in `keyboards`, and `all` switches every real keyboard anyway, so the main one speaks for the lot.
- `hyprctl` answers the dispatch only after the switch lands, so the read that follows already sees the new keymap; no polling or delay is needed.
- The OSD already had a `keyboard` icon; no shell changes.

## Tests

`test/shell.d/keyboard-layout-test.sh` stubs `hyprctl` and `omarchy-osd` and covers: the default action dispatching `switchxkblayout all next` and showing the main keyboard's layout, `prev`, `status` printing without switching or opening the OSD, and an unknown action exiting non-zero. The fixture puts a keymap-less non-main "keyboard" first to pin the main-keyboard selection, and its keymap name carries a space and parentheses — the shape xkb names come in — to prove the name reaches the OSD intact.

Verified on a running desktop: switching layouts shows the OSD with the layout name in the same spot the volume OSD uses.