### PR TITLE
Fix: Target brave-origin instead of brave-origin-beta for whatsapp-slim

### DIFF
--- a/migrations/1785702266.sh
+++ b/migrations/1785702266.sh
@@ -1,4 +1,4 @@
-echo "Add WhatsApp Slim extension to Chromium-based browsers"
+echo "Add WhatsApp Slim extension to existing Brave Origin installations"
 
 WHATSAPP_SLIM_EXT="$OMARCHY_PATH/default/chromium/extensions/whatsapp-slim"
 
@@ -15,6 +15,6 @@ add_whatsapp_slim_extension() {
   fi
 }
 
-for conf in chromium chrome google-chrome brave brave-beta brave-nightly brave-origin microsoft-edge-stable; do
-  add_whatsapp_slim_extension "$HOME/.config/$conf-flags.conf"
-done
+# The previous migration (1785543725) mistakenly targeted brave-origin-beta instead of brave-origin.
+# This follow-up migration ensures brave-origin is updated for users who already ran the faulty migration.
+add_whatsapp_slim_extension "$HOME/.config/brave-origin-flags.conf"


### PR DESCRIPTION
Fixes #6476 by changing `brave-origin-beta` to `brave-origin` in the browser iteration loop, and adding a follow-up migration script to retroactively apply the extension for users who already ran the faulty migration.