### PR TITLE
Map Omarchy light/dark to Grok built-in themes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -198,6 +198,7 @@ post_theme_commands=(
   omarchy-theme-set-gnome
   omarchy-theme-set-pi
   omarchy-theme-set-claude
+  omarchy-theme-set-grok
   omarchy-theme-set-browser
   omarchy-theme-set-vscode
   omarchy-theme-set-obsidian

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+# omarchy:summary=Map the active Omarchy theme to a built-in Grok TUI theme
+# omarchy:args=[--activate]
+# omarchy:hidden=true
+
+# Stock Grok has no custom theme files — only five built-ins. This picks the
+# closest match and writes [ui] keys in $GROK_HOME/config.toml.
+#
+# Live light/dark: we set theme = "auto" so Grok's system-appearance watcher
+# retints when Omarchy flips the desktop color scheme (via theme-set-gnome).
+# Explicit theme= names are only read at Grok startup — external edits do NOT
+# retint a running session.
+#
+# Opt-in: without --activate (or a prior activate), this is a no-op.
+
+set -euo pipefail
+
+GROK_HOME="${GROK_HOME:-$HOME/.grok}"
+GROK_CONFIG_PATH="$GROK_HOME/config.toml"
+GROK_FOLLOW_FLAG="$HOME/.local/state/omarchy/grok-theme-follow"
+CURRENT_THEME_PATH="$HOME/.local/state/omarchy/current/theme"
+GROK_ACTIVATE=0
+
+usage() {
+  echo "Usage: omarchy-theme-set-grok [--activate]"
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --activate)
+      GROK_ACTIVATE=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if (( GROK_ACTIVATE == 0 )) && [[ ! -d $GROK_HOME ]]; then
+  exit 0
+fi
+
+if (( GROK_ACTIVATE == 0 )) && [[ ! -f $GROK_FOLLOW_FLAG ]]; then
+  exit 0
+fi
+
+omarchy_theme_slug() {
+  local path
+
+  if [[ -f $HOME/.local/state/omarchy/current/theme.name ]]; then
+    tr -d '[:space:]' <"$HOME/.local/state/omarchy/current/theme.name"
+    return
+  fi
+
+  path=$(readlink -f "$CURRENT_THEME_PATH" 2>/dev/null || true)
+  if [[ -n $path ]]; then
+    basename "$path"
+    return
+  fi
+
+  printf '%s' ""
+}
+
+omarchy_theme_mode() {
+  local mode=""
+
+  if omarchy-cmd-present omarchy-theme-color; then
+    mode=$(omarchy-theme-color mode 2>/dev/null || true)
+  fi
+  if [[ -z $mode && -f $CURRENT_THEME_PATH/colors.toml ]]; then
+    mode=$(sed -nE 's/^[[:space:]]*mode[[:space:]]*=[[:space:]]*"?([^"]+)"?.*/\1/p' \
+      "$CURRENT_THEME_PATH/colors.toml" | head -1)
+  fi
+
+  printf '%s' "$mode"
+}
+
+# Closest dark built-in for the current Omarchy slug (never "auto" / "grokday").
+map_grok_dark_theme() {
+  local slug
+
+  slug=$(omarchy_theme_slug)
+
+  case "$slug" in
+    tokyo-night | tokyonight | tokyo)
+      printf '%s' "tokyonight"
+      ;;
+    rose-pine | rosepine | rose-pine-moon | rosepine-moon)
+      printf '%s' "rosepine-moon"
+      ;;
+    matte-black | vantablack | hackerman)
+      printf '%s' "oscura-midnight"
+      ;;
+    *)
+      printf '%s' "groknight"
+      ;;
+  esac
+}
+
+# Write [ui] theme + auto_* keys, preserving the rest of config.toml.
+write_grok_ui_keys() {
+  local config="$GROK_CONFIG_PATH"
+  local theme="$1"
+  local auto_dark="$2"
+  local auto_light="$3"
+
+  mkdir -p "$(dirname "$config")"
+
+  python3 - "$config" "$theme" "$auto_dark" "$auto_light" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+wanted = {
+    "theme": sys.argv[2],
+    "auto_dark_theme": sys.argv[3],
+    "auto_light_theme": sys.argv[4],
+}
+
+text = path.read_text() if path.exists() else ""
+lines = text.splitlines(keepends=True)
+out = []
+section = None
+ui_seen = False
+written = {k: False for k in wanted}
+
+def emit_missing_ui_keys():
+    for key, value in wanted.items():
+        if not written[key]:
+            out.append(f'{key} = "{value}"\n')
+            written[key] = True
+
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        if section == "ui":
+            emit_missing_ui_keys()
+        name = stripped[1:-1].strip()
+        section = name
+        if name == "ui":
+            ui_seen = True
+        out.append(line)
+        continue
+
+    m = re.match(r"^([A-Za-z0-9_]+)\s*=", stripped)
+    if m and section == "ui" and m.group(1) in wanted:
+        key = m.group(1)
+        out.append(f'{key} = "{wanted[key]}"\n')
+        written[key] = True
+        continue
+
+    if m and section is None and m.group(1) == "theme":
+        # Legacy top-level theme — drop; live under [ui].
+        continue
+
+    out.append(line)
+
+if section == "ui":
+    emit_missing_ui_keys()
+
+if not ui_seen:
+    body = "".join(out)
+    if body and not body.endswith("\n"):
+        out.append("\n")
+    if out and out[-1].strip() != "":
+        out.append("\n")
+    out.append("[ui]\n")
+    for key, value in wanted.items():
+        out.append(f'{key} = "{value}"\n')
+
+tmp = path.with_suffix(path.suffix + ".tmp")
+tmp.write_text("".join(out))
+tmp.replace(path)
+PY
+}
+
+dark_theme=$(map_grok_dark_theme)
+light_theme="grokday"
+mode=$(omarchy_theme_mode)
+
+# theme=auto so running sessions follow OS light/dark (Omarchy sets that via GNOME).
+# auto_dark_theme carries the closest dark built-in for the current Omarchy slug.
+write_grok_ui_keys "auto" "$dark_theme" "$light_theme"
+
+effective="$dark_theme"
+if [[ $mode == "light" ]]; then
+  effective="$light_theme"
+fi
+
+mkdir -p "$(dirname "$GROK_FOLLOW_FLAG")"
+printf '%s\n' "$effective" >"$GROK_FOLLOW_FLAG"
+
+if (( GROK_ACTIVATE == 1 )); then
+  echo "Grok will follow Omarchy light/dark (auto mode)."
+  echo "  auto_dark_theme  = $dark_theme"
+  echo "  auto_light_theme = $light_theme"
+  echo "  config: $GROK_CONFIG_PATH"
+  echo
+  echo "Restart Grok once so it enters theme=auto. After that, light↔dark"
+  echo "desktop switches retint live. Same-polarity maps (e.g. tokyo-night"
+  echo "vs groknight) still need a restart or /theme to apply."
+fi

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -63,32 +63,24 @@ current_ui_theme() {
 
   python3 - "$config" <<'PY'
 import pathlib
-import re
 import sys
+import tomllib
 
 path = pathlib.Path(sys.argv[1])
-text = path.read_text()
-section = None
-top_level = None
-ui_theme = None
+try:
+    data = tomllib.loads(path.read_text())
+except tomllib.TOMLDecodeError:
+    print("")
+    raise SystemExit(0)
 
-for line in text.splitlines():
-    stripped = line.strip()
-    if stripped.startswith("[") and stripped.endswith("]"):
-        section = stripped[1:-1].strip()
-        continue
-    m = re.match(r'^theme\s*=\s*"([^"]*)"\s*$', stripped)
-    if not m:
-        m = re.match(r"^theme\s*=\s*'([^']*)'\s*$", stripped)
-    if not m:
-        continue
-    value = m.group(1)
-    if section == "ui":
-        ui_theme = value
-    elif section is None:
-        top_level = value
-
-print(ui_theme if ui_theme is not None else (top_level or ""))
+ui = data.get("ui")
+if isinstance(ui, dict) and "theme" in ui:
+    print(ui["theme"] if ui["theme"] is not None else "")
+elif "theme" in data:
+    # Legacy top-level theme key
+    print(data["theme"] if data["theme"] is not None else "")
+else:
+    print("")
 PY
 }
 
@@ -138,13 +130,13 @@ map_grok_dark_theme() {
   slug=$(omarchy_theme_slug)
 
   case "$slug" in
-    tokyo-night | tokyonight | tokyo)
+    tokyo-night | tokyonight | tokyo | nord | catppuccin | kanagawa | everforest | ethereal)
       printf '%s' "tokyonight"
       ;;
     rose-pine | rosepine | rose-pine-moon | rosepine-moon)
       printf '%s' "rosepine-moon"
       ;;
-    matte-black | vantablack | hackerman)
+    matte-black | vantablack | hackerman | osaka-jade | ristretto | solitude)
       printf '%s' "oscura-midnight"
       ;;
     *)

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -22,7 +22,6 @@ GROK_HOME="${GROK_HOME:-$HOME/.grok}"
 GROK_CONFIG_PATH="$GROK_HOME/config.toml"
 GROK_FOLLOW_FLAG="$HOME/.local/state/omarchy/grok-theme-follow"
 CURRENT_THEME_PATH="$HOME/.local/state/omarchy/current/theme"
-COLORS_FILE="$CURRENT_THEME_PATH/colors.toml"
 GROK_ACTIVATE=0
 
 usage() {
@@ -45,11 +44,13 @@ for arg in "$@"; do
   esac
 done
 
+# No-op when Grok is not installed. Finalize runs --activate unconditionally
+# under set -e, so this must not exit 1 (otherwise btop theme linking is skipped).
+# Interactive hand-runs still get a stderr note when stdout is a TTY.
 if [[ ! -d $GROK_HOME ]]; then
-  if (( GROK_ACTIVATE == 1 )); then
+  if (( GROK_ACTIVATE == 1 )) && [[ -t 1 ]]; then
     echo "Grok config directory missing: $GROK_HOME" >&2
     echo "Install Grok first, then re-run omarchy-theme-set-grok --activate." >&2
-    exit 1
   fi
   exit 0
 fi
@@ -232,8 +233,6 @@ PY
 
 dark_theme=$(map_grok_dark_theme)
 light_theme="grokday"
-# Same idiom as omarchy-theme-set-gnome: theme-color is a default Omarchy command.
-mode=$(omarchy-theme-color --file "$COLORS_FILE" mode)
 
 # theme=auto so running sessions follow OS light/dark (Omarchy sets that via GNOME).
 # auto_dark_theme carries the closest dark built-in for the current Omarchy slug.

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -6,17 +6,21 @@
 
 # Grok's only live external retint path is theme=auto + OS light/dark (the
 # system-appearance watcher). Writing an explicit [ui].theme only applies on
-# the next Grok start. So when ~/.grok exists we set theme=auto, pick the
-# closest built-in for auto_dark_theme / auto_light_theme, and rely on
-# theme-set-gnome flipping the desktop color-scheme for live light↔dark.
+# the next Grok start. So when following, we set theme=auto, pick the closest
+# built-in for auto_dark_theme / auto_light_theme, and rely on theme-set-gnome
+# flipping the desktop color-scheme for live light↔dark.
 #
-# No-op when Grok is not installed (no $GROK_HOME directory). --activate is
-# kept for install/user/theme.sh and prints a one-time restart note.
+# Follow mode is sticky until the user leaves auto:
+#   - omarchy-theme-set-grok --activate (or install/user/theme.sh) starts it
+#   - each Omarchy theme switch updates mappings while [ui].theme is "auto"
+#   - if they pick a fixed Grok theme, we stop and leave them alone
+#   - --activate again opts back in
 
 set -euo pipefail
 
 GROK_HOME="${GROK_HOME:-$HOME/.grok}"
 GROK_CONFIG_PATH="$GROK_HOME/config.toml"
+GROK_FOLLOW_FLAG="$HOME/.local/state/omarchy/grok-theme-follow"
 CURRENT_THEME_PATH="$HOME/.local/state/omarchy/current/theme"
 COLORS_FILE="$CURRENT_THEME_PATH/colors.toml"
 GROK_ACTIVATE=0
@@ -41,8 +45,6 @@ for arg in "$@"; do
   esac
 done
 
-# Match Pi: only touch Grok when it is already present (unless forcing activate
-# so first-run setup can create config under an existing install path).
 if [[ ! -d $GROK_HOME ]]; then
   if (( GROK_ACTIVATE == 1 )); then
     echo "Grok config directory missing: $GROK_HOME" >&2
@@ -50,6 +52,65 @@ if [[ ! -d $GROK_HOME ]]; then
     exit 1
   fi
   exit 0
+fi
+
+# Read [ui].theme (or legacy top-level theme) from config.toml.
+current_ui_theme() {
+  local config="$GROK_CONFIG_PATH"
+
+  [[ -f $config ]] || return 0
+
+  python3 - "$config" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+section = None
+top_level = None
+ui_theme = None
+
+for line in text.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        section = stripped[1:-1].strip()
+        continue
+    m = re.match(r'^theme\s*=\s*"([^"]*)"\s*$', stripped)
+    if not m:
+        m = re.match(r"^theme\s*=\s*'([^']*)'\s*$", stripped)
+    if not m:
+        continue
+    value = m.group(1)
+    if section == "ui":
+        ui_theme = value
+    elif section is None:
+        top_level = value
+
+print(ui_theme if ui_theme is not None else (top_level or ""))
+PY
+}
+
+stop_following() {
+  rm -f "$GROK_FOLLOW_FLAG"
+}
+
+start_following() {
+  mkdir -p "$(dirname "$GROK_FOLLOW_FLAG")"
+  : >"$GROK_FOLLOW_FLAG"
+}
+
+if (( GROK_ACTIVATE == 1 )); then
+  start_following
+elif [[ ! -f $GROK_FOLLOW_FLAG ]]; then
+  exit 0
+else
+  # Still following only while Grok remains on auto (or theme unset).
+  theme_now=$(current_ui_theme)
+  if [[ -n $theme_now && $theme_now != "auto" && $theme_now != "system" ]]; then
+    stop_following
+    exit 0
+  fi
 fi
 
 omarchy_theme_slug() {
@@ -187,4 +248,7 @@ if (( GROK_ACTIVATE == 1 )); then
   echo "Restart Grok once so it enters theme=auto. After that, light↔dark"
   echo "desktop switches retint live. Same-polarity maps (e.g. tokyo-night"
   echo "vs groknight) still need a restart or /theme to apply."
+  echo
+  echo "If you pick a fixed Grok theme later, Omarchy stops updating Grok until"
+  echo "you run: omarchy-theme-set-grok --activate"
 fi

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -4,13 +4,11 @@
 # omarchy:args=[--activate]
 # omarchy:hidden=true
 
-# Stock Grok has no custom theme files — only five built-ins. This picks the
-# closest match and writes [ui] keys in $GROK_HOME/config.toml.
-#
-# Live light/dark: we set theme = "auto" so Grok's system-appearance watcher
-# retints when Omarchy flips the desktop color scheme (via theme-set-gnome).
-# Explicit theme= names are only read at Grok startup — external edits do NOT
-# retint a running session.
+# Grok's only live external retint path is theme=auto + OS light/dark (the
+# system-appearance watcher). Writing an explicit [ui].theme only applies on
+# the next Grok start. So we set theme=auto, pick the closest built-in for
+# auto_dark_theme / auto_light_theme, and rely on theme-set-gnome flipping the
+# desktop color-scheme for live light↔dark.
 #
 # Opt-in: without --activate (or a prior activate), this is a no-op.
 
@@ -20,6 +18,7 @@ GROK_HOME="${GROK_HOME:-$HOME/.grok}"
 GROK_CONFIG_PATH="$GROK_HOME/config.toml"
 GROK_FOLLOW_FLAG="$HOME/.local/state/omarchy/grok-theme-follow"
 CURRENT_THEME_PATH="$HOME/.local/state/omarchy/current/theme"
+COLORS_FILE="$CURRENT_THEME_PATH/colors.toml"
 GROK_ACTIVATE=0
 
 usage() {
@@ -65,20 +64,6 @@ omarchy_theme_slug() {
   fi
 
   printf '%s' ""
-}
-
-omarchy_theme_mode() {
-  local mode=""
-
-  if omarchy-cmd-present omarchy-theme-color; then
-    mode=$(omarchy-theme-color mode 2>/dev/null || true)
-  fi
-  if [[ -z $mode && -f $CURRENT_THEME_PATH/colors.toml ]]; then
-    mode=$(sed -nE 's/^[[:space:]]*mode[[:space:]]*=[[:space:]]*"?([^"]+)"?.*/\1/p' \
-      "$CURRENT_THEME_PATH/colors.toml" | head -1)
-  fi
-
-  printf '%s' "$mode"
 }
 
 # Closest dark built-in for the current Omarchy slug (never "auto" / "grokday").
@@ -183,7 +168,8 @@ PY
 
 dark_theme=$(map_grok_dark_theme)
 light_theme="grokday"
-mode=$(omarchy_theme_mode)
+# Same idiom as omarchy-theme-set-gnome: theme-color is a default Omarchy command.
+mode=$(omarchy-theme-color --file "$COLORS_FILE" mode)
 
 # theme=auto so running sessions follow OS light/dark (Omarchy sets that via GNOME).
 # auto_dark_theme carries the closest dark built-in for the current Omarchy slug.

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -239,7 +239,9 @@ mode=$(omarchy-theme-color --file "$COLORS_FILE" mode)
 # auto_dark_theme carries the closest dark built-in for the current Omarchy slug.
 write_grok_ui_keys "auto" "$dark_theme" "$light_theme"
 
-if (( GROK_ACTIVATE == 1 )); then
+# Interactive only — finalize/install redirect stdout and should stay quiet
+# (same as pi's silent activate). Config + follow flag are still written above.
+if (( GROK_ACTIVATE == 1 )) && [[ -t 1 ]]; then
   echo "Grok will follow Omarchy light/dark (auto mode)."
   echo "  auto_dark_theme  = $dark_theme"
   echo "  auto_light_theme = $light_theme"

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -6,17 +6,17 @@
 
 # Grok's only live external retint path is theme=auto + OS light/dark (the
 # system-appearance watcher). Writing an explicit [ui].theme only applies on
-# the next Grok start. So we set theme=auto, pick the closest built-in for
-# auto_dark_theme / auto_light_theme, and rely on theme-set-gnome flipping the
-# desktop color-scheme for live light↔dark.
+# the next Grok start. So when ~/.grok exists we set theme=auto, pick the
+# closest built-in for auto_dark_theme / auto_light_theme, and rely on
+# theme-set-gnome flipping the desktop color-scheme for live light↔dark.
 #
-# Opt-in: without --activate (or a prior activate), this is a no-op.
+# No-op when Grok is not installed (no $GROK_HOME directory). --activate is
+# kept for install/user/theme.sh and prints a one-time restart note.
 
 set -euo pipefail
 
 GROK_HOME="${GROK_HOME:-$HOME/.grok}"
 GROK_CONFIG_PATH="$GROK_HOME/config.toml"
-GROK_FOLLOW_FLAG="$HOME/.local/state/omarchy/grok-theme-follow"
 CURRENT_THEME_PATH="$HOME/.local/state/omarchy/current/theme"
 COLORS_FILE="$CURRENT_THEME_PATH/colors.toml"
 GROK_ACTIVATE=0
@@ -41,11 +41,14 @@ for arg in "$@"; do
   esac
 done
 
-if (( GROK_ACTIVATE == 0 )) && [[ ! -d $GROK_HOME ]]; then
-  exit 0
-fi
-
-if (( GROK_ACTIVATE == 0 )) && [[ ! -f $GROK_FOLLOW_FLAG ]]; then
+# Match Pi: only touch Grok when it is already present (unless forcing activate
+# so first-run setup can create config under an existing install path).
+if [[ ! -d $GROK_HOME ]]; then
+  if (( GROK_ACTIVATE == 1 )); then
+    echo "Grok config directory missing: $GROK_HOME" >&2
+    echo "Install Grok first, then re-run omarchy-theme-set-grok --activate." >&2
+    exit 1
+  fi
   exit 0
 fi
 
@@ -174,14 +177,6 @@ mode=$(omarchy-theme-color --file "$COLORS_FILE" mode)
 # theme=auto so running sessions follow OS light/dark (Omarchy sets that via GNOME).
 # auto_dark_theme carries the closest dark built-in for the current Omarchy slug.
 write_grok_ui_keys "auto" "$dark_theme" "$light_theme"
-
-effective="$dark_theme"
-if [[ $mode == "light" ]]; then
-  effective="$light_theme"
-fi
-
-mkdir -p "$(dirname "$GROK_FOLLOW_FLAG")"
-printf '%s\n' "$effective" >"$GROK_FOLLOW_FLAG"
 
 if (( GROK_ACTIVATE == 1 )); then
   echo "Grok will follow Omarchy light/dark (auto mode)."

--- a/install/user/theme.sh
+++ b/install/user/theme.sh
@@ -10,6 +10,7 @@ if [[ ! -s $HOME/.local/state/omarchy/current/theme.name ]]; then
   fi
 fi
 omarchy-theme-set-pi --activate
+omarchy-theme-set-grok --activate
 
 mkdir -p ~/.config/btop/themes
 ln -snf "$HOME/.local/state/omarchy/current/theme/btop.theme" ~/.config/btop/themes/current.theme

--- a/test/cli
+++ b/test/cli
@@ -385,20 +385,17 @@ pass "claude theme activation preserves configured settings"
 
 GROK_TMPDIR=$(mktemp -d)
 GROK_HOME_DIR="$GROK_TMPDIR/grok"
-mkdir -p \
-  "$GROK_TMPDIR/.local/state/omarchy/current/theme" \
-  "$GROK_HOME_DIR"
+mkdir -p "$GROK_TMPDIR/.local/state/omarchy/current/theme"
 printf 'lumon\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
 printf 'mode = "dark"\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme/colors.toml"
 
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
-[[ ! -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync is a no-op before activate"
-[[ ! -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok follow flag is not created before activate"
-pass "grok theme sync is a no-op before activate"
+[[ ! -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync is a no-op without Grok home"
+pass "grok theme sync is a no-op without Grok home"
 
-HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok" --activate
-[[ -f $GROK_HOME_DIR/config.toml ]] || fail "grok activate writes config.toml"
-[[ -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok activate creates follow flag"
+mkdir -p "$GROK_HOME_DIR"
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+[[ -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync writes config when Grok home exists"
 awk '
   /^\[ui\]$/ { in_ui = 1; next }
   /^\[/ { in_ui = 0 }
@@ -406,8 +403,8 @@ awk '
   in_ui && $0 == "auto_dark_theme = \"groknight\"" { dark = 1 }
   in_ui && $0 == "auto_light_theme = \"grokday\"" { light = 1 }
   END { exit(theme && dark && light ? 0 : 1) }
-' "$GROK_HOME_DIR/config.toml" || fail "grok activate enables auto mode with mapped dark/light themes"
-pass "grok activate enables auto mode with mapped dark/light themes"
+' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync enables auto mode with mapped dark/light themes"
+pass "grok theme sync enables auto mode with mapped dark/light themes"
 
 cat >"$GROK_HOME_DIR/config.toml" <<'EOF'
 [cli]
@@ -446,9 +443,14 @@ pass "grok theme sync maps tokyo-night to tokyonight"
 printf 'flexoki-light\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
 printf 'mode = "light"\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme/colors.toml"
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
-[[ $(tr -d '[:space:]' <"$GROK_TMPDIR/.local/state/omarchy/grok-theme-follow") == "grokday" ]] || \
-  fail "grok follow flag records light theme as grokday"
-pass "grok follow flag records light theme as grokday"
+awk '
+  /^\[ui\]$/ { in_ui = 1; next }
+  /^\[/ { in_ui = 0 }
+  in_ui && $0 == "theme = \"auto\"" { theme = 1 }
+  in_ui && $0 == "auto_light_theme = \"grokday\"" { light = 1 }
+  END { exit(theme && light ? 0 : 1) }
+' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync keeps auto light theme as grokday"
+pass "grok theme sync keeps auto light theme as grokday"
 
 THEME_TMPDIR=$(mktemp -d)
 OMARCHY_PATH="$ROOT" HOME="$THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"

--- a/test/cli
+++ b/test/cli
@@ -418,26 +418,42 @@ awk '
 ' "$GROK_HOME_DIR/config.toml" || fail "grok activate enables auto mode with mapped dark/light themes"
 pass "grok activate enables auto mode with mapped dark/light themes"
 
+# Fixture mirrors a real Grok config: marketplace array-of-tables + [ui] siblings.
 cat >"$GROK_HOME_DIR/config.toml" <<'EOF'
 [cli]
 installer = "internal"
 
+[marketplace]
+default_skills_installs_purged = true
+official_marketplace_auto_installed = true
+
+[[marketplace.sources]]
+name = "xAI Official"
+git = "https://github.com/xai-org/plugin-marketplace.git"
+
 [ui]
 max_thoughts_width = 120
 theme = "auto"
+fork_secondary_model = "grok-4.5"
 yolo = false
 EOF
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
 awk '
-  /^\[cli\]$/ { in_cli = 1; in_ui = 0; next }
-  /^\[ui\]$/ { in_ui = 1; in_cli = 0; next }
-  /^\[/ { in_ui = 0; in_cli = 0 }
+  /^\[cli\]$/ { in_cli = 1; in_ui = 0; in_src = 0; next }
+  /^\[marketplace\]$/ { in_mkt = 1; in_cli = 0; in_ui = 0; in_src = 0; next }
+  /^\[\[marketplace\.sources\]\]$/ { in_src = 1; in_mkt = 0; in_cli = 0; in_ui = 0; next }
+  /^\[ui\]$/ { in_ui = 1; in_cli = 0; in_mkt = 0; in_src = 0; next }
+  /^\[/ { in_ui = 0; in_cli = 0; in_mkt = 0; in_src = 0 }
   in_cli && $0 == "installer = \"internal\"" { cli = 1 }
+  in_mkt && $0 == "official_marketplace_auto_installed = true" { mkt = 1 }
+  in_src && $0 == "name = \"xAI Official\"" { src_name = 1 }
+  in_src && index($0, "plugin-marketplace") { src_git = 1 }
   in_ui && $0 == "max_thoughts_width = 120" { width = 1 }
   in_ui && $0 == "theme = \"auto\"" { theme = 1 }
   in_ui && $0 == "auto_dark_theme = \"groknight\"" { dark = 1 }
+  in_ui && $0 == "fork_secondary_model = \"grok-4.5\"" { fork = 1 }
   in_ui && $0 == "yolo = false" { yolo = 1 }
-  END { exit(cli && width && theme && dark && yolo ? 0 : 1) }
+  END { exit(cli && mkt && src_name && src_git && width && theme && dark && fork && yolo ? 0 : 1) }
 ' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync preserves unrelated config keys while following"
 pass "grok theme sync preserves unrelated config keys while following"
 
@@ -452,10 +468,17 @@ awk '
 ' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync maps tokyo-night to tokyonight"
 pass "grok theme sync maps tokyo-night to tokyonight"
 
+printf 'nord\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+grep -Fx 'auto_dark_theme = "tokyonight"' "$GROK_HOME_DIR/config.toml" >/dev/null || \
+  fail "grok theme sync maps nord to tokyonight"
+pass "grok theme sync maps nord to tokyonight"
+
 # User picks a fixed Grok theme — stop following and leave it alone.
+# Trailing comment exercises tomllib read (must not treat as unset/auto).
 cat >"$GROK_HOME_DIR/config.toml" <<'EOF'
 [ui]
-theme = "oscura-midnight"
+theme = "oscura-midnight"  # manual pick
 auto_dark_theme = "tokyonight"
 auto_light_theme = "grokday"
 EOF
@@ -464,7 +487,7 @@ HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok
 awk '
   /^\[ui\]$/ { in_ui = 1; next }
   /^\[/ { in_ui = 0 }
-  in_ui && $0 == "theme = \"oscura-midnight\"" { theme = 1 }
+  in_ui && $0 ~ /^theme = "oscura-midnight"/ { theme = 1 }
   in_ui && $0 == "auto_dark_theme = \"tokyonight\"" { dark = 1 }
   END { exit(theme && dark ? 0 : 1) }
 ' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync leaves a manual theme untouched"

--- a/test/cli
+++ b/test/cli
@@ -7,6 +7,7 @@ CLI="$ROOT/bin/omarchy"
 TMPDIR=""
 PI_TMPDIR=""
 THEME_TMPDIR=""
+GROK_TMPDIR=""
 
 export PATH="$ROOT/bin:$PATH"
 
@@ -37,6 +38,7 @@ cleanup() {
   [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
   [[ -n $PI_TMPDIR && -d $PI_TMPDIR ]] && rm -rf "$PI_TMPDIR"
   [[ -n $THEME_TMPDIR && -d $THEME_TMPDIR ]] && rm -rf "$THEME_TMPDIR"
+  [[ -n $GROK_TMPDIR && -d $GROK_TMPDIR ]] && rm -rf "$GROK_TMPDIR"
 }
 trap cleanup EXIT
 
@@ -380,6 +382,73 @@ echo '{"model":"keep-me"}' >"$CLAUDE_TEST_CONFIG/settings.json"
 HOME="$PI_TMPDIR" CLAUDE_CONFIG_DIR="$CLAUDE_TEST_CONFIG" "$ROOT/bin/omarchy-theme-set-claude" --activate
 jq -e '.theme == "custom:omarchy" and .model == "keep-me"' "$CLAUDE_TEST_CONFIG/settings.json" >/dev/null
 pass "claude theme activation preserves configured settings"
+
+GROK_TMPDIR=$(mktemp -d)
+GROK_HOME_DIR="$GROK_TMPDIR/grok"
+mkdir -p \
+  "$GROK_TMPDIR/.local/state/omarchy/current/theme" \
+  "$GROK_HOME_DIR"
+printf 'lumon\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
+printf 'mode = "dark"\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme/colors.toml"
+
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+[[ ! -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync is a no-op before activate"
+[[ ! -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok follow flag is not created before activate"
+pass "grok theme sync is a no-op before activate"
+
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok" --activate
+[[ -f $GROK_HOME_DIR/config.toml ]] || fail "grok activate writes config.toml"
+[[ -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok activate creates follow flag"
+awk '
+  /^\[ui\]$/ { in_ui = 1; next }
+  /^\[/ { in_ui = 0 }
+  in_ui && $0 == "theme = \"auto\"" { theme = 1 }
+  in_ui && $0 == "auto_dark_theme = \"groknight\"" { dark = 1 }
+  in_ui && $0 == "auto_light_theme = \"grokday\"" { light = 1 }
+  END { exit(theme && dark && light ? 0 : 1) }
+' "$GROK_HOME_DIR/config.toml" || fail "grok activate enables auto mode with mapped dark/light themes"
+pass "grok activate enables auto mode with mapped dark/light themes"
+
+cat >"$GROK_HOME_DIR/config.toml" <<'EOF'
+[cli]
+installer = "internal"
+
+[ui]
+max_thoughts_width = 120
+theme = "oscura-midnight"
+yolo = false
+EOF
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+awk '
+  /^\[cli\]$/ { in_cli = 1; in_ui = 0; next }
+  /^\[ui\]$/ { in_ui = 1; in_cli = 0; next }
+  /^\[/ { in_ui = 0; in_cli = 0 }
+  in_cli && $0 == "installer = \"internal\"" { cli = 1 }
+  in_ui && $0 == "max_thoughts_width = 120" { width = 1 }
+  in_ui && $0 == "theme = \"auto\"" { theme = 1 }
+  in_ui && $0 == "auto_dark_theme = \"groknight\"" { dark = 1 }
+  in_ui && $0 == "yolo = false" { yolo = 1 }
+  END { exit(cli && width && theme && dark && yolo ? 0 : 1) }
+' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync preserves unrelated config keys"
+pass "grok theme sync preserves unrelated config keys"
+
+printf 'tokyo-night\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+awk '
+  /^\[ui\]$/ { in_ui = 1; next }
+  /^\[/ { in_ui = 0 }
+  in_ui && $0 == "auto_dark_theme = \"tokyonight\"" { dark = 1 }
+  in_ui && $0 == "theme = \"auto\"" { theme = 1 }
+  END { exit(dark && theme ? 0 : 1) }
+' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync maps tokyo-night to tokyonight"
+pass "grok theme sync maps tokyo-night to tokyonight"
+
+printf 'flexoki-light\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
+printf 'mode = "light"\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme/colors.toml"
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+[[ $(tr -d '[:space:]' <"$GROK_TMPDIR/.local/state/omarchy/grok-theme-follow") == "grokday" ]] || \
+  fail "grok follow flag records light theme as grokday"
+pass "grok follow flag records light theme as grokday"
 
 THEME_TMPDIR=$(mktemp -d)
 OMARCHY_PATH="$ROOT" HOME="$THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"

--- a/test/cli
+++ b/test/cli
@@ -385,17 +385,20 @@ pass "claude theme activation preserves configured settings"
 
 GROK_TMPDIR=$(mktemp -d)
 GROK_HOME_DIR="$GROK_TMPDIR/grok"
-mkdir -p "$GROK_TMPDIR/.local/state/omarchy/current/theme"
+mkdir -p \
+  "$GROK_TMPDIR/.local/state/omarchy/current/theme" \
+  "$GROK_HOME_DIR"
 printf 'lumon\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
 printf 'mode = "dark"\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme/colors.toml"
 
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
-[[ ! -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync is a no-op without Grok home"
-pass "grok theme sync is a no-op without Grok home"
+[[ ! -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync is a no-op before activate"
+[[ ! -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok follow flag is not created before activate"
+pass "grok theme sync is a no-op before activate"
 
-mkdir -p "$GROK_HOME_DIR"
-HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
-[[ -f $GROK_HOME_DIR/config.toml ]] || fail "grok theme sync writes config when Grok home exists"
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok" --activate
+[[ -f $GROK_HOME_DIR/config.toml ]] || fail "grok activate writes config.toml"
+[[ -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok activate creates follow flag"
 awk '
   /^\[ui\]$/ { in_ui = 1; next }
   /^\[/ { in_ui = 0 }
@@ -403,8 +406,8 @@ awk '
   in_ui && $0 == "auto_dark_theme = \"groknight\"" { dark = 1 }
   in_ui && $0 == "auto_light_theme = \"grokday\"" { light = 1 }
   END { exit(theme && dark && light ? 0 : 1) }
-' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync enables auto mode with mapped dark/light themes"
-pass "grok theme sync enables auto mode with mapped dark/light themes"
+' "$GROK_HOME_DIR/config.toml" || fail "grok activate enables auto mode with mapped dark/light themes"
+pass "grok activate enables auto mode with mapped dark/light themes"
 
 cat >"$GROK_HOME_DIR/config.toml" <<'EOF'
 [cli]
@@ -412,7 +415,7 @@ installer = "internal"
 
 [ui]
 max_thoughts_width = 120
-theme = "oscura-midnight"
+theme = "auto"
 yolo = false
 EOF
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
@@ -426,8 +429,8 @@ awk '
   in_ui && $0 == "auto_dark_theme = \"groknight\"" { dark = 1 }
   in_ui && $0 == "yolo = false" { yolo = 1 }
   END { exit(cli && width && theme && dark && yolo ? 0 : 1) }
-' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync preserves unrelated config keys"
-pass "grok theme sync preserves unrelated config keys"
+' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync preserves unrelated config keys while following"
+pass "grok theme sync preserves unrelated config keys while following"
 
 printf 'tokyo-night\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
@@ -440,17 +443,34 @@ awk '
 ' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync maps tokyo-night to tokyonight"
 pass "grok theme sync maps tokyo-night to tokyonight"
 
-printf 'flexoki-light\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme.name"
-printf 'mode = "light"\n' >"$GROK_TMPDIR/.local/state/omarchy/current/theme/colors.toml"
+# User picks a fixed Grok theme — stop following and leave it alone.
+cat >"$GROK_HOME_DIR/config.toml" <<'EOF'
+[ui]
+theme = "oscura-midnight"
+auto_dark_theme = "tokyonight"
+auto_light_theme = "grokday"
+EOF
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok"
+[[ ! -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok follow stops when theme is not auto"
+awk '
+  /^\[ui\]$/ { in_ui = 1; next }
+  /^\[/ { in_ui = 0 }
+  in_ui && $0 == "theme = \"oscura-midnight\"" { theme = 1 }
+  in_ui && $0 == "auto_dark_theme = \"tokyonight\"" { dark = 1 }
+  END { exit(theme && dark ? 0 : 1) }
+' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync leaves a manual theme untouched"
+pass "grok theme sync leaves a manual theme untouched"
+
+# Re-activate resumes following.
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok" --activate >/dev/null
+[[ -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok activate resumes follow"
 awk '
   /^\[ui\]$/ { in_ui = 1; next }
   /^\[/ { in_ui = 0 }
   in_ui && $0 == "theme = \"auto\"" { theme = 1 }
-  in_ui && $0 == "auto_light_theme = \"grokday\"" { light = 1 }
-  END { exit(theme && light ? 0 : 1) }
-' "$GROK_HOME_DIR/config.toml" || fail "grok theme sync keeps auto light theme as grokday"
-pass "grok theme sync keeps auto light theme as grokday"
+  END { exit(theme ? 0 : 1) }
+' "$GROK_HOME_DIR/config.toml" || fail "grok re-activate restores theme=auto"
+pass "grok re-activate restores theme=auto"
 
 THEME_TMPDIR=$(mktemp -d)
 OMARCHY_PATH="$ROOT" HOME="$THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"

--- a/test/cli
+++ b/test/cli
@@ -396,6 +396,15 @@ HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok
 [[ ! -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok follow flag is not created before activate"
 pass "grok theme sync is a no-op before activate"
 
+# Missing Grok home must not abort finalize (bash -e + theme.sh --activate).
+set +e
+HOME="$GROK_TMPDIR" GROK_HOME="$GROK_TMPDIR/no-such-grok" "$ROOT/bin/omarchy-theme-set-grok" --activate
+activate_missing_status=$?
+set -e
+(( activate_missing_status == 0 )) || fail "grok activate is a no-op when Grok home is missing"
+[[ ! -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok activate without home leaves no follow flag"
+pass "grok activate is a no-op when Grok home is missing"
+
 HOME="$GROK_TMPDIR" GROK_HOME="$GROK_HOME_DIR" "$ROOT/bin/omarchy-theme-set-grok" --activate
 [[ -f $GROK_HOME_DIR/config.toml ]] || fail "grok activate writes config.toml"
 [[ -f $GROK_TMPDIR/.local/state/omarchy/grok-theme-follow ]] || fail "grok activate creates follow flag"

--- a/test/shell.d/user-theme-test.sh
+++ b/test/shell.d/user-theme-test.sh
@@ -14,25 +14,39 @@ printf '%s\n' "$*" >>"$OMARCHY_TEST_THEME_CALLS"
 SH
 chmod +x "$mock_bin/omarchy-theme-set"
 
+# Record name + args so we assert finalize always activates pi/grok follow mode.
 for command in omarchy-theme-set-pi omarchy-theme-set-grok; do
-  cat >"$mock_bin/$command" <<'SH'
+  cat >"$mock_bin/$command" <<SH
 #!/bin/bash
-exit 0
+printf '%s %s\n' "$command" "\$*" >>"\$OMARCHY_TEST_ACTIVATE_CALLS"
 SH
   chmod +x "$mock_bin/$command"
 done
 
 calls="$test_tmp/theme-calls"
+activate_calls="$test_tmp/activate-calls"
 touch "$test_tmp/home/.config/chromium/SingletonLock"
-HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEME_CALLS="$calls" \
+: >"$activate_calls"
+HOME="$test_tmp/home" PATH="$mock_bin:$PATH" \
+  OMARCHY_TEST_THEME_CALLS="$calls" OMARCHY_TEST_ACTIVATE_CALLS="$activate_calls" \
   bash "$ROOT/install/user/theme.sh"
 grep -Fx 'Tokyo Night' "$calls" >/dev/null || fail "user theme setup seeds Tokyo Night when no theme exists"
 [[ -f $test_tmp/home/.config/chromium/SingletonLock ]] || fail "runtime user theme setup preserves Chromium's singleton lock"
+grep -Fx 'omarchy-theme-set-pi --activate' "$activate_calls" >/dev/null || \
+  fail "user theme setup activates pi theme follow"
+grep -Fx 'omarchy-theme-set-grok --activate' "$activate_calls" >/dev/null || \
+  fail "user theme setup activates grok theme follow"
 
 : >"$calls"
+: >"$activate_calls"
 printf 'Solitude\n' >"$test_tmp/home/.local/state/omarchy/current/theme.name"
-HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEME_CALLS="$calls" \
+HOME="$test_tmp/home" PATH="$mock_bin:$PATH" \
+  OMARCHY_TEST_THEME_CALLS="$calls" OMARCHY_TEST_ACTIVATE_CALLS="$activate_calls" \
   bash "$ROOT/install/user/theme.sh"
 [[ ! -s $calls ]] || fail "user theme setup preserves an existing theme"
+grep -Fx 'omarchy-theme-set-pi --activate' "$activate_calls" >/dev/null || \
+  fail "user theme setup re-activates pi when a theme already exists"
+grep -Fx 'omarchy-theme-set-grok --activate' "$activate_calls" >/dev/null || \
+  fail "user theme setup re-activates grok when a theme already exists"
 
 pass "user theme setup only seeds the default theme once"

--- a/test/shell.d/user-theme-test.sh
+++ b/test/shell.d/user-theme-test.sh
@@ -14,7 +14,7 @@ printf '%s\n' "$*" >>"$OMARCHY_TEST_THEME_CALLS"
 SH
 chmod +x "$mock_bin/omarchy-theme-set"
 
-for command in omarchy-theme-set-pi; do
+for command in omarchy-theme-set-pi omarchy-theme-set-grok; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 exit 0


### PR DESCRIPTION
## Summary

Grok's live external retint path is `theme = "auto"` plus OS light/dark. This maps Omarchy onto Grok's built-ins through that path, without fighting a manual theme choice forever.

- New `omarchy-theme-set-grok` (hidden), wired into `omarchy-theme-set` and `install/user/theme.sh`
- **`--activate` once** (install does this): set `theme=auto`, seed `auto_dark_theme` / `auto_light_theme`, leave a follow flag
- **While following:** each Omarchy theme switch refreshes the auto_* maps (and keeps `theme=auto`)
- **If the user picks a fixed Grok theme:** stop following and leave config alone until they run `--activate` again
- **No-op when Grok is not installed** (`$GROK_HOME` missing), including on `--activate` so finalize never aborts under `set -e`

After one Grok restart into auto mode, Omarchy light↔dark switches retint live. Same-polarity maps (e.g. tokyo-night → tokyonight) update for the next start.

## Test plan

- [ ] `./test/cli` (no-op before activate, activate without home, activate, preserve marketplace AOT + keys, tokyo-night/nord maps, stop on manual theme with comment, re-activate)
- [ ] `./test/shell` (user-theme-test mocks grok activate)
- [ ] Fresh: activate + restart Grok, light↔dark Omarchy themes retint live
- [ ] In Grok, `/theme oscura-midnight`, change Omarchy theme → Grok config stays oscura, follow stops
- [ ] `omarchy-theme-set-grok --activate` resumes follow
- [ ] Without `~/.grok`, `theme.sh --activate` does not fail finalize