### PR TITLE
Allow auto-opening the screenshot editor via OMARCHY_SCREENSHOT_AUTO_EDIT

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -72,6 +72,7 @@ case "$PROCESSING" in
     wl-copy --type image/png <"$FILEPATH"
 
     (
+      [[ ${OMARCHY_SCREENSHOT_AUTO_EDIT:-false} == "true" ]] && open_editor "$FILEPATH" && exit 0
       if [[ -n $(omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" --image "$FILEPATH" -a) ]]; then
         open_editor "$FILEPATH"
       fi


### PR DESCRIPTION
# Allow auto-opening the screenshot editor via OMARCHY_SCREENSHOT_AUTO_EDIT

## What

`bin/omarchy-capture-screenshot` saves the capture and copies it to the clipboard, then shows a notification with an "edit" action. Users can click that notification or press Super + Alt + , to open the editor.

Some users want the editor to open immediately — the same flow Omarchy used before the notification-based edit step was added.

## Diff

```diff
     (
+      [[ ${OMARCHY_SCREENSHOT_AUTO_EDIT:-false} == "true" ]] && open_editor "$FILEPATH" && exit 0
       if [[ -n $(omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" --image "$FILEPATH" -a) ]]; then
         open_editor "$FILEPATH"
       fi
     ) &
```

Adds an opt-in guard above the existing notification block. The notification `if` is unchanged.

## Usage

Set in `~/.config/uwsm/default` or `~/.config/hypr/envs.conf`:

```bash
export OMARCHY_SCREENSHOT_AUTO_EDIT=true
```

## Backward compatibility

`${OMARCHY_SCREENSHOT_AUTO_EDIT:-false}` falls back to the current behavior when the env is unset or empty. Existing installs see no behavior change.

## Related

- Guard-line pattern matches `pkill slurp && exit 0` in the same script and #5321 (guard before existing logic).
- Notification block unchanged — same shape as `omarchy-capture-screenrecording` and `omarchy-chromium-ytdlp-host`.
- Opt-in env var follows `OMARCHY_SCREENRECORD_USE_PORTAL` / `OMARCHY_OCR_LANGS` (#5623).
