### PR TITLE
Fix menu JSONC parsing silently dropping trailing-line comments

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -1,7 +1,36 @@
+// Strip // comments and trailing commas from a JSONC document. Comments are
+// recognized anywhere on a line, not just ones that occupy the whole line —
+// "value", // note   must work the same as a standalone comment line. The
+// scan tracks whether it is inside a JSON string (honoring \" escapes) so a
+// "//" that's part of a string value, e.g. a "https://..." action URL, is
+// never mistaken for a comment.
 function stripJsonc(raw) {
-  return String(raw || "")
-    .replace(/^\s*\/\/[^\n]*(\n|$)/gm, "")
-    .replace(/,(\s*[}\]])/g, "$1")
+  var text = String(raw || "")
+  var out = ""
+  var inString = false
+
+  for (var i = 0; i < text.length; i++) {
+    var ch = text[i]
+
+    if (inString) {
+      out += ch
+      if (ch === "\\" && i + 1 < text.length) { out += text[i + 1]; i += 1; continue }
+      if (ch === "\"") inString = false
+      continue
+    }
+
+    if (ch === "\"") { inString = true; out += ch; continue }
+
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1
+      i -= 1 // let the loop's i++ land back on the newline (or end of text)
+      continue
+    }
+
+    out += ch
+  }
+
+  return out.replace(/,(\s*[}\]])/g, "$1")
 }
 
 function normalizeAliases(value) {
@@ -46,6 +75,8 @@ function parseMenuJsonc(raw) {
   try {
     parsed = JSON.parse(stripped)
   } catch (e) {
+    if (typeof console !== "undefined" && console.warn)
+      console.warn("MenuModel: failed to parse menu JSONC: " + e)
     return []
   }
   if (typeof parsed !== "object" || parsed === null) return []


### PR DESCRIPTION
# inline JSONC comments silently wipe the custom menu

**File:** `shell/plugins/menu/MenuModel.js` → `stripJsonc`

## Problem

`stripJsonc` only removes comments that take up an entire line by
themselves. A comment written after real content on the same line — the
most natural way to annotate a config — is never recognized and stays in
the text.

That leftover comment breaks JSON parsing. The parsing function catches
that error and quietly returns an empty result, with no log or warning
anywhere. The empty result then replaces the user's entire custom menu
during the merge step — every custom entry disappears, with nothing in the
logs pointing back to the cause.

## Repro

Take any working menu entry and add a short trailing comment after it on
the same line, instead of putting the comment on its own line above it. The
whole file then fails to parse, and the custom menu section goes back to
showing nothing but the built-in defaults.

## Fix

Replaced the two-regex approach with a single-pass scanner that walks the
text character by character and keeps track of whether it is currently
inside a quoted string (correctly handling escaped quotes). Only when it is
outside of a string does it treat `//` as the start of a comment and skip to
the end of that line. This means:

- A comment can now appear anywhere on a line, not just as the whole line.
- A `//` that's part of a string value (like a URL in an action command) is
  never mistaken for a comment, since the scanner knows it's inside a string.
- A comment with no newline after it, right at the end of the file, is
  handled correctly too.

Block comments (the `/* ... */` style) are still not supported, but that was
never part of the format this config file documents, so it's considered out
of scope for this fix.