### PR TITLE
Add OpenCode Zen/Go local usage to usage panel

### DIFF
--- a/SPEC-opencode-collector.md
+++ b/SPEC-opencode-collector.md
@@ -1,0 +1,189 @@
+# Spec: OpenCode Agent Usage Collector
+
+## Overview
+
+Add an `omarchy-agent-usage-opencode` collector (Python) to `bin/` that
+prints a display-ready JSON record for the `omarchy.agents` panel. No plugin
+QML files need changing — the panel discovers agents from JSON records in
+`~/.local/state/omarchy/agents/usage/`.
+
+The collector replaces the old PR's
+`shell/plugins/model-usage/scripts/opencode_usage_scanner.py` and
+`shell/plugins/model-usage/providers/OpenCode.qml`.
+
+## Reference
+
+- **Codex collector** (`bin/omarchy-agent-usage-codex`) — closest analogue:
+  scans Pi sessions, native session files, and opencode sessions for tokens
+  on the Codex subscription. The OpenCode collector follows the same pattern
+  for its own provider tags.
+- **Claude collector** (`bin/omarchy-agent-usage-claude`) — also a good
+  reference for Anthropic OAuth limits, though OpenCode has no equivalent.
+- **`bin/omarchy-agent-usage-update`** — the orchestrator that runs every
+  `bin/omarchy-agent-usage-*` it finds. No changes needed here.
+- **`shell/plugins/agents/README.md`** — full panel contract.
+
+## Data Sources
+
+1. **Pi session transcripts** (`~/.pi/agent/sessions/`)
+   - Uses `rg` to find assistant messages tagged with an OpenCode provider
+     (`opencode`, `opencode-go`, `opencode-zen-openai`)
+   - Extracts per-message: input/output/cache tokens, model, timestamp
+   - Every message becomes one "prompt"
+
+2. **OpenCode CLI SQLite database** (`~/.local/share/opencode/opencode.db`)
+   - Queries assistant messages where `providerID` matches OpenCode routes
+   - Extracts per-day aggregated: input/output/reasoning/cache tokens, model,
+     session ids
+   - CLI sessions contribute to day totals and session counts but are not
+     counted as prompts (same as Codex collector)
+
+3. **No rate limits / tier RPC**
+   - OpenCode has no public API for usage limits, plan tier, or balance
+   - The record will have `limits: []` and `tierLabel: ""`
+   - `hasLocalStats: true`, `hasPromptStats: true`
+
+## Route Routing (Zen / Go)
+
+Messages are tagged by provider in both data sources:
+
+| Provider ID / tag | Route | Notes |
+|---|---|---|
+| `opencode` | `zen` | Zen subscription (API key) |
+| `opencode-zen-openai` | `zen` | Zen subscription via OpenAI compatible |
+| `opencode-go` | `go` | Go subscription |
+| anything else | — | BYOK / direct — excluded from OpenCode |
+
+Messages with a non-matching or absent provider tag are skipped.
+
+## Record Contract
+
+Each collector prints one JSON record to stdout. Both records follow the
+same schema as Codex/Claude records (the standard omarchy.agents contract):
+
+| Field | Type | Notes |
+|---|---|---|
+| `schemaVersion` | int | `1` |
+| `id` | string | `"opencode-zen"` or `"opencode-go"` |
+| `name` | string | `"OpenCode Zen"` or `"OpenCode Go"` |
+| `updatedAt` | ISO 8601 | UTC timestamp |
+| `ready` | bool | `true` |
+| `hasLocalStats` | bool | `true` |
+| `hasPromptStats` | bool | `true` — Pi messages are prompt-scoped |
+| `todayPrompts` | int | Pi assistant messages today for this route |
+| `todaySessions` | int | Unique session keys today for this route |
+| `todayTotalTokens` | int | Sum of all tokens today for this route |
+| `todayTokensByModel` | dict | `{ "model-id": count }` today for this route |
+| `recentDays` | array | Last 7 days, `{ date, messageCount }` |
+| `totalPrompts` | int | All-time Pi assistant messages for this route |
+| `totalSessions` | int | Unique session keys all-time for this route |
+| `activeDays` | int | Days with any usage for this route |
+| `activeDates` | array | Sorted date strings — enables cross-device merge |
+| `modelUsage` | dict | `{ "model": { inputTokens, outputTokens, cacheReadInputTokens, cacheCreationInputTokens } }` |
+| `retryAdvised` | bool | Not set — no limits endpoint to retry |
+| `limits` | array | `[]` — no API for rate limits |
+| `tierLabel` | string | `""` — no tier info |
+| `usageStatusText` | string | Empty — no auth needed |
+| `authHelpText` | string | Empty — no auth needed |
+
+## Design Decision: Two Records, Shared Base
+
+**Chosen approach: Option B — two separate records, one shared Python base.**
+
+Rationale: Zen (API-key, pay-per-token) and Go (subscription, rate-limited)
+are fundamentally different billing models. The panel treats each JSON
+record as a separate tab, so two records gives each its own space with
+independent enable/disable, future limits, and auto-hide when unused.
+
+A record with all-zero stats is still written to disk, but the panel's
+`providerHasData()` filter drops it — so only the route(s) with actual
+usage appear as tabs.
+
+Implementation structure:
+
+```
+bin/opencode-usage-base.py              ← shared scanning logic, --route flag
+bin/omarchy-agent-usage-opencode-zen    ← thin shell wrapper → base --route zen
+bin/omarchy-agent-usage-opencode-go     ← thin shell wrapper → base --route go
+```
+
+The orchestrator (`omarchy-agent-usage-update`) discovers the two wrapper
+scripts by glob pattern, runs each independently, and writes
+`opencode-zen.json` and `opencode-go.json` to the usage directory. The
+shared base is not matched by the glob (no `omarchy-agent-usage-` prefix),
+so it is never invoked directly.
+
+## Assets
+
+The old PR already has SVG icons at:
+- `shell/plugins/model-usage/assets/opencode.svg` (dark variant)
+- `shell/plugins/model-usage/assets/opencode-light.svg` (light variant)
+
+The agents panel resolves marks by provider id (`assets/<id>.svg` plus an
+optional `assets/<id>-light.svg` twin for light surfaces), so the mark must
+be shipped under each route's id:
+
+- `shell/plugins/agents/assets/opencode-zen.svg` + `opencode-zen-light.svg`
+- `shell/plugins/agents/assets/opencode-go.svg` + `opencode-go-light.svg`
+
+The plain `opencode.svg` / `opencode-light.svg` copies are left in place as
+the shared source of the mark.
+
+## Graceful Degradation
+
+- **Without `rg`** — Pi session scanning falls back gracefully (no match,
+  no results)
+- **Without the `opencode` CLI** — the SQLite database scan is skipped; Pi
+  session scanning continues (same degrade pattern as Codex)
+- **Without Pi sessions** — `~/.pi/agent/sessions/` missing: Pi scan is
+  silent; OpenCode CLI scan still runs
+- **Without either** — record prints `todayPrompts: 0, totalSessions: 0`
+  etc., which `providerHasData()` evaluates as false, so the panel hides
+  the tab automatically
+
+## Testing
+
+Create `test/shell.d/agent-usage-opencode-test.sh` with:
+
+1. Same fixture structure as the old scanner test: fake `opencode` CLI,
+   fake Pi sessions with per-route transcripts
+2. Run the base Python script with `--route zen` and `--route go`
+3. Assertions for each route: totals, session counts, prompt counts,
+   BYOK exclusion, route isolation, graceful degrade without CLI
+4. Standard contract assertions: valid JSON, schemaVersion, id, name,
+   ready, hasLocalStats, hasPromptStats, no routeData, empty limits
+
+## Open Questions
+
+1. **Zen/Go split approach** — which option (A/B/C) to implement?
+2. **Record `id`** — if not option A, what `id` values for route-specific
+   records?
+3. **Too-few records edge case** — a Pi user with no opencode sessions
+   would have `todayPrompts: 0` before the first scan picks up data; the
+   panel hides it. Is that acceptable for the first day?
+4. **Kol / light assets** — the old PR's SVGs have simple geometric shapes;
+   might want a more distinct mark than `opencode.svg` and
+   `opencode-light.svg` to differentiate from existing assets
+5. **Existing Pi scan filter** — should Pi messages from the opencode
+   `provider` tag also contribute toward the Codex collector? They
+   currently contribute to OpenCode via this collector AND to the general Pi
+   message scan in the Codex collector if the provider is `opencode-codex`.
+   The old scanner used `rg` with exact provider matches so there's no
+   overlap, but worth verifying.
+
+## Implementation Plan
+
+1. Create `bin/omarchy-agent-usage-opencode` (Python, ~200-250 lines)
+   - Adapt old scanner, strip QML-aware `routeData`
+   - Use `local_day`, `number`, `model_name`, `runtime_env` helpers from old
+     scanner (same pattern as Codex collector)
+   - Scan Pi sessions for OpenCode provider tags
+   - Query opencode CLI DB for session-level usage
+   - Print standard record contract JSON
+2. Copy SVG assets to `shell/plugins/agents/assets/`
+3. Create test file `test/shell.d/agent-usage-opencode-test.sh`
+4. Run tests with `./test/shell`
+5. Verify the panel picks up the record:
+   - `omarchy agent usage-update`
+   - Check `~/.local/state/omarchy/agents/usage/opencode.json` exists
+   - Open the agents panel and confirm the tab appears

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -1,0 +1,4 @@
+#!/bin/bash
+# omarchy:summary=Collect OpenCode Go (subscription) usage
+# omarchy:hidden=true
+exec "$(dirname "$0")/opencode-usage-base.py" --route go "$@"

--- a/bin/omarchy-agent-usage-opencode-zen
+++ b/bin/omarchy-agent-usage-opencode-zen
@@ -1,0 +1,4 @@
+#!/bin/bash
+# omarchy:summary=Collect OpenCode Zen (API key) usage
+# omarchy:hidden=true
+exec "$(dirname "$0")/opencode-usage-base.py" --route zen "$@"

--- a/bin/opencode-usage-base.py
+++ b/bin/opencode-usage-base.py
@@ -1,0 +1,353 @@
+#!/usr/bin/python3
+# omarchy:summary=Print an OpenCode usage record for one route as JSON
+# omarchy:args=--route <zen|go>
+# omarchy:hidden=true
+"""Collect OpenCode usage for one route (zen or go) into a display-ready
+JSON record.
+
+Usage: opencode-usage-base.py --route zen
+       opencode-usage-base.py --route go
+
+Local stats come from Pi session transcripts and the opencode CLI database.
+There is no limits/tier RPC (OpenCode has no public API for rate limits), so
+the record carries empty limits and no tier label.
+
+This script is invoked by the omarchy-agent-usage-opencode-{zen,go} wrapper
+scripts. The agents panel only ever reads the JSON this prints.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROUTE_PROVIDERS = {
+  "zen": {"opencode", "opencode-zen-openai"},
+  "go": {"opencode-go"},
+}
+
+
+def local_day(value):
+  if value is None:
+    return datetime.now().strftime("%Y-%m-%d")
+  if isinstance(value, (int, float)):
+    if value > 10_000_000_000:
+      value = value / 1000
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d")
+  text = str(value)
+  try:
+    if text.endswith("Z"):
+      dt = datetime.fromisoformat(text[:-1] + "+00:00")
+    else:
+      dt = datetime.fromisoformat(text)
+    if dt.tzinfo is not None:
+      dt = dt.astimezone()
+    return dt.strftime("%Y-%m-%d")
+  except Exception:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def number(value):
+  try:
+    return int(value or 0)
+  except Exception:
+    return 0
+
+
+def model_name(raw):
+  value = str(raw or "opencode")
+  return value if value else "opencode"
+
+
+def runtime_env():
+  home = str(Path.home())
+  path_parts = [
+    os.environ.get("PATH", ""),
+    f"{home}/.local/bin",
+    f"{home}/.npm-global/bin",
+    f"{home}/.local/share/mise/shims",
+  ]
+  env = os.environ.copy()
+  env["PATH"] = os.pathsep.join(part for part in path_parts if part)
+  return env
+
+
+ENV = runtime_env()
+
+
+def find_command(name):
+  return shutil.which(name, path=ENV.get("PATH"))
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--route", required=True, choices=("zen", "go"))
+  args = parser.parse_args()
+  route = args.route
+
+  AGENT_ID = f"opencode-{route}"
+  AGENT_NAME = {"zen": "OpenCode Zen", "go": "OpenCode Go"}[route]
+  AGENT_TIER = {"zen": "API", "go": "Subscription"}[route]
+  ROUTE_PROVIDERS_SET = ROUTE_PROVIDERS[route]
+
+  now = datetime.now()
+  today = now.strftime("%Y-%m-%d")
+  recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+
+  recent_by_day = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+  today_tokens_by_model = {}
+  model_usage = {}
+  today_sessions = set()
+  active_dates = set()
+  total_sessions = set()
+  total_prompts = 0
+  today_prompts = 0
+  today_total_tokens = 0
+  seen_pi_messages = set()
+
+
+  def add_usage(day, session_key, model, input_tokens, output_tokens, cache_read, cache_write, is_prompt=True):
+    nonlocal today_prompts, today_total_tokens, total_prompts
+    total = input_tokens + output_tokens + cache_read + cache_write
+    if is_prompt:
+      total_prompts += 1
+      if day == today:
+        today_prompts += 1
+    total_sessions.add(session_key)
+    active_dates.add(day)
+
+    bucket = model_usage.setdefault(model, {
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "cacheReadInputTokens": 0,
+      "cacheCreationInputTokens": 0,
+    })
+    bucket["inputTokens"] += input_tokens
+    bucket["outputTokens"] += output_tokens
+    bucket["cacheReadInputTokens"] += cache_read
+    bucket["cacheCreationInputTokens"] += cache_write
+
+    if day in recent_by_day:
+      recent_by_day[day]["messageCount"] += total
+
+    if day == today:
+      today_sessions.add(session_key)
+      today_total_tokens += total
+      today_tokens_by_model[model] = today_tokens_by_model.get(model, 0) + total
+
+
+  def add_cli_day(day, session_keys, model, input_tokens, output_tokens, reasoning_tokens, cache_read, cache_write):
+    nonlocal today_total_tokens, today_prompts, total_prompts
+    total = input_tokens + output_tokens + reasoning_tokens + cache_read + cache_write
+
+    if model:
+      bucket = model_usage.setdefault(model, {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "cacheReadInputTokens": 0,
+        "cacheCreationInputTokens": 0,
+      })
+      bucket["inputTokens"] += input_tokens
+      bucket["outputTokens"] += output_tokens + reasoning_tokens
+      bucket["cacheReadInputTokens"] += cache_read
+      bucket["cacheCreationInputTokens"] += cache_write
+
+    if day in recent_by_day:
+      recent_by_day[day]["messageCount"] += total
+      for key in session_keys:
+        total_sessions.add(key)
+        if day == today:
+          today_sessions.add(key)
+
+    else:
+      # Outside the 7-day window — still count sessions and active days.
+      for key in session_keys:
+        total_sessions.add(key)
+
+    if day == today:
+      today_total_tokens += total
+      if model:
+        today_tokens_by_model[model] = today_tokens_by_model.get(model, 0) + total
+
+    active_dates.add(day)
+
+
+  # -------------------------------------------------------------- Pi sessions
+
+  def scan_pi_sessions():
+    root = Path.home() / ".pi" / "agent" / "sessions"
+    if not root.exists():
+      return
+    try:
+      rg = find_command("rg") or "rg"
+      proc = subprocess.Popen(
+        [rg, "--json", "-e", '"provider":"opencode"',
+         "-e", '"provider":"opencode-go"',
+         "-e", '"provider":"opencode-zen-openai"',
+         str(root)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        errors="replace",
+        env=ENV,
+      )
+    except FileNotFoundError:
+      return
+
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+      try:
+        event = json.loads(raw)
+        if event.get("type") != "match":
+          continue
+        line = event.get("data", {}).get("lines", {}).get("text", "")
+        path = event.get("data", {}).get("path", {}).get("text", "pi-session")
+        entry = json.loads(line)
+      except Exception:
+        continue
+
+      if entry.get("type") != "message":
+        continue
+      message = entry.get("message") or {}
+      if message.get("role") != "assistant":
+        continue
+      provider = str(message.get("provider") or "")
+      if provider not in ROUTE_PROVIDERS_SET:
+        continue
+
+      message_key = path + ":" + str(entry.get("id") or "")
+      if message_key in seen_pi_messages:
+        continue
+      seen_pi_messages.add(message_key)
+
+      usage = message.get("usage") or {}
+      if not usage:
+        continue
+      total = number(usage.get("totalTokens"))
+      input_tokens = number(usage.get("input"))
+      output_tokens = number(usage.get("output"))
+      cache_read = number(usage.get("cacheRead"))
+      cache_write = number(usage.get("cacheWrite"))
+      if total and not (input_tokens or output_tokens or cache_read or cache_write):
+        input_tokens = total
+      if not (input_tokens or output_tokens or cache_read or cache_write):
+        continue
+
+      day = local_day(entry.get("timestamp") or message.get("timestamp"))
+      session_key = path
+      add_usage(day, session_key, model_name(message.get("model")),
+                input_tokens, output_tokens, cache_read, cache_write)
+
+    try:
+      proc.wait(timeout=1)
+    except Exception:
+      proc.kill()
+
+
+  # ---------------------------------------------------------- opencode CLI DB
+
+  def db_rows():
+    opencode = find_command("opencode")
+    if not opencode:
+      return None
+    query = (
+      "SELECT date(m.time_created/1000,'unixepoch','localtime') AS day, "
+      "CASE json_extract(m.data,'$.providerID') "
+      "  WHEN 'opencode' THEN 'zen' "
+      "  WHEN 'opencode-zen-openai' THEN 'zen' "
+      "  WHEN 'opencode-go' THEN 'go' "
+      "END AS route, "
+      "json_extract(m.data,'$.modelID') AS model, "
+      "group_concat(DISTINCT m.session_id) AS session_ids, "
+      "sum(json_extract(m.data,'$.tokens.input')) AS input, "
+      "sum(json_extract(m.data,'$.tokens.output')) AS output, "
+      "sum(json_extract(m.data,'$.tokens.reasoning')) AS reasoning, "
+      "sum(json_extract(m.data,'$.tokens.cache.read')) AS cache_read, "
+      "sum(json_extract(m.data,'$.tokens.cache.write')) AS cache_write "
+      "FROM message m "
+      "WHERE json_extract(m.data,'$.role') = 'assistant' "
+      "GROUP BY day, route, model ORDER BY day"
+    )
+    try:
+      proc = subprocess.Popen(
+        [opencode, "db", query, "--format", "json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        errors="replace",
+        env=ENV,
+      )
+      output, _ = proc.communicate(timeout=30)
+      if proc.returncode != 0:
+        return None
+      rows = json.loads(output or "[]")
+      return rows if isinstance(rows, list) else None
+    except subprocess.TimeoutExpired:
+      try:
+        proc.kill()
+        proc.wait()
+      except Exception:
+        pass
+      return None
+    except Exception:
+      return None
+
+  def scan_opencode_cli_db():
+    rows = db_rows()
+    if not rows:
+      return
+    for row in rows:
+      route_val = str(row.get("route") or "")
+      if route_val != route:
+        continue
+      day = str(row.get("day") or "")
+      if not day:
+        continue
+      session_keys = ["cli:" + sid for sid in str(row.get("session_ids") or "").split(",") if sid]
+      model = str(row.get("model") or "")
+      input_tokens = number(row.get("input"))
+      output_tokens = number(row.get("output"))
+      reasoning_tokens = number(row.get("reasoning"))
+      cache_read = number(row.get("cache_read"))
+      cache_write = number(row.get("cache_write"))
+      add_cli_day(day, session_keys, model, input_tokens, output_tokens, reasoning_tokens, cache_read, cache_write)
+
+
+  # ---------------------------------------------------------------- run
+
+  scan_pi_sessions()
+  scan_opencode_cli_db()
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": True,
+    "hasLocalStats": True,
+    "hasPromptStats": True,
+    "todayPrompts": today_prompts,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": today_total_tokens,
+    "todayTokensByModel": today_tokens_by_model,
+    "recentDays": [recent_by_day[day] for day in recent_dates],
+    "totalPrompts": total_prompts,
+    "totalSessions": len(total_sessions),
+    "activeDays": len(active_dates),
+    "activeDates": sorted(active_dates),
+    "modelUsage": model_usage,
+    "retryAdvised": False,
+    "limits": [],
+    "tierLabel": AGENT_TIER,
+    "usageStatusText": "",
+    "authHelpText": "",
+  }
+  print(json.dumps(record, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/shell/plugins/agents/assets/opencode-go-light.svg
+++ b/shell/plugins/agents/assets/opencode-go-light.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>OpenCode</title>
+  <path fill="#111" fill-rule="evenodd" clip-rule="evenodd" d="M18 19.5H6v-15h12v15zM15 7.5H9v9h6v-9z"/>
+  <path fill="#8a8a8a" d="M15 10.5v6H9v-6h6z"/>
+</svg>

--- a/shell/plugins/agents/assets/opencode-go.svg
+++ b/shell/plugins/agents/assets/opencode-go.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>OpenCode</title>
+  <path fill="#fff" fill-rule="evenodd" clip-rule="evenodd" d="M18 19.5H6v-15h12v15zM15 7.5H9v9h6v-9z"/>
+  <path fill="#9a9999" d="M15 10.5v6H9v-6h6z"/>
+</svg>

--- a/shell/plugins/agents/assets/opencode-light.svg
+++ b/shell/plugins/agents/assets/opencode-light.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>OpenCode</title>
+  <path fill="#111" fill-rule="evenodd" clip-rule="evenodd" d="M18 19.5H6v-15h12v15zM15 7.5H9v9h6v-9z"/>
+  <path fill="#8a8a8a" d="M15 10.5v6H9v-6h6z"/>
+</svg>

--- a/shell/plugins/agents/assets/opencode-zen-light.svg
+++ b/shell/plugins/agents/assets/opencode-zen-light.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>OpenCode</title>
+  <path fill="#111" fill-rule="evenodd" clip-rule="evenodd" d="M18 19.5H6v-15h12v15zM15 7.5H9v9h6v-9z"/>
+  <path fill="#8a8a8a" d="M15 10.5v6H9v-6h6z"/>
+</svg>

--- a/shell/plugins/agents/assets/opencode-zen.svg
+++ b/shell/plugins/agents/assets/opencode-zen.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>OpenCode</title>
+  <path fill="#fff" fill-rule="evenodd" clip-rule="evenodd" d="M18 19.5H6v-15h12v15zM15 7.5H9v9h6v-9z"/>
+  <path fill="#9a9999" d="M15 10.5v6H9v-6h6z"/>
+</svg>

--- a/shell/plugins/agents/assets/opencode.svg
+++ b/shell/plugins/agents/assets/opencode.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <title>OpenCode</title>
+  <path fill="#fff" fill-rule="evenodd" clip-rule="evenodd" d="M18 19.5H6v-15h12v15zM15 7.5H9v9h6v-9z"/>
+  <path fill="#9a9999" d="M15 10.5v6H9v-6h6z"/>
+</svg>

--- a/test/shell.d/agent-usage-opencode-test.sh
+++ b/test/shell.d/agent-usage-opencode-test.sh
@@ -278,3 +278,30 @@ no_cli_today=$(jq -r --arg d "$DAY" '.recentDays[] | select(.date == $d) | .mess
 [[ $no_cli_today == "550" ]] ||
   fail "Zen record falls back to Pi-only tokens without CLI" "$result_no_cli"
 pass "Zen record falls back to Pi-only tokens without CLI"
+
+# ---------------------------------------------------------------------------
+# Panel marks resolve by provider id (assets/<id>.svg, plus a -light twin for
+# light surfaces), so each route must ship the mark under its own id even
+# though zen and go share one OpenCode brand mark.
+
+require_command test
+
+mark() {
+  [[ -f "$ROOT/shell/plugins/agents/assets/$1" ]]
+}
+
+mark opencode-zen.svg ||
+  fail "Zen panel mark exists at assets/opencode-zen.svg"
+pass "Zen panel mark exists at assets/opencode-zen.svg"
+
+mark opencode-zen-light.svg ||
+  fail "Zen panel mark light twin exists at assets/opencode-zen-light.svg"
+pass "Zen panel mark light twin exists at assets/opencode-zen-light.svg"
+
+mark opencode-go.svg ||
+  fail "Go panel mark exists at assets/opencode-go.svg"
+pass "Go panel mark exists at assets/opencode-go.svg"
+
+mark opencode-go-light.svg ||
+  fail "Go panel mark light twin exists at assets/opencode-go-light.svg"
+pass "Go panel mark light twin exists at assets/opencode-go-light.svg"

--- a/test/shell.d/agent-usage-opencode-test.sh
+++ b/test/shell.d/agent-usage-opencode-test.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# The scanner only buckets the trailing 7 days, so the fixture day must be
+# today for the day-row assertions to hold.
+DAY=$(date +%Y-%m-%d)
+YDAY=$(date -d "1 day ago" +%Y-%m-%d)
+
+# Fake opencode CLI: answers the `db` query the collector makes with CLI-only
+# session usage. Rows carry a route (from providerID), a model, and session
+# ids, exactly like the real query returns.
+#
+#   - ses-cli-1 today: Zen row (route "zen")
+#   - ses-cli-2 today: Go row (route "go")
+#   - ses-cli-3 today: BYOK/unattributed (route ""), merged-only
+#   - ses-cli-1 yesterday: legacy/unattributed (route ""), merged-only
+#     ses-cli-1 appears on two days but must still count as one session
+mkdir -p "$TEST_HOME/bin"
+cat >"$TEST_HOME/bin/opencode" <<SCRIPT
+#!/bin/bash
+if [[ \$1 == "db" ]]; then
+  cat <<'JSON'
+[
+  {
+    "day": "$DAY",
+    "route": "zen",
+    "model": "claude-sonnet-4.2-lite",
+    "session_ids": "ses-cli-1",
+    "input": 2000,
+    "output": 500,
+    "reasoning": 250,
+    "cache_read": 1000,
+    "cache_write": 0
+  },
+  {
+    "day": "$DAY",
+    "route": "go",
+    "model": "kimi-k2.6",
+    "session_ids": "ses-cli-2",
+    "input": 100,
+    "output": 50,
+    "reasoning": 0,
+    "cache_read": 0,
+    "cache_write": 0
+  },
+  {
+    "day": "$DAY",
+    "route": "",
+    "model": "gpt-direct",
+    "session_ids": "ses-cli-3",
+    "input": 400,
+    "output": 0,
+    "reasoning": 0,
+    "cache_read": 0,
+    "cache_write": 0
+  },
+  {
+    "day": "$YDAY",
+    "route": "",
+    "model": "",
+    "session_ids": "ses-cli-1",
+    "input": 100,
+    "output": 0,
+    "reasoning": 0,
+    "cache_read": 0,
+    "cache_write": 0
+  }
+]
+JSON
+  exit 0
+fi
+exit 1
+SCRIPT
+chmod +x "$TEST_HOME/bin/opencode"
+
+# Pi transcripts: a Zen session and a Go session, each with one assistant
+# message carrying per-route usage. Timestamps must be local so they stay on
+# DAY in any timezone.
+ZEN_T0=$(date +%Y-%m-%dT10:00:00%:z)
+ZEN_T1=$(date +%Y-%m-%dT10:00:01%:z)
+GO_T0=$(date +%Y-%m-%dT11:00:00%:z)
+GO_T1=$(date +%Y-%m-%dT11:00:01%:z)
+mkdir -p "$TEST_HOME/.pi/agent/sessions/Projects-demo"
+cat >"$TEST_HOME/.pi/agent/sessions/Projects-demo/zen.jsonl" <<EOF
+{"type":"session","version":3,"id":"zen-ses","timestamp":"$ZEN_T0","cwd":"/demo"}
+{"type":"message","id":"m1","timestamp":"$ZEN_T1","message":{"role":"assistant","provider":"opencode","model":"gpt-5.6-luna","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":400,"totalTokens":550,"cost":{"total":0.001}}}}
+EOF
+cat >"$TEST_HOME/.pi/agent/sessions/Projects-demo/go.jsonl" <<EOF
+{"type":"session","version":3,"id":"go-ses","timestamp":"$GO_T0","cwd":"/demo"}
+{"type":"message","id":"m2","timestamp":"$GO_T1","message":{"role":"assistant","provider":"opencode-go","model":"kimi-k2.7-code","usage":{"input":300,"output":100,"cacheRead":0,"cacheWrite":0,"totalTokens":400,"cost":{"total":0.002}}}}
+EOF
+
+BASE="$ROOT/bin/opencode-usage-base.py"
+
+# ---------------------------------------------------------------------------
+# Standard contract fields
+
+run_zen() {
+  HOME="$TEST_HOME" PATH="$TEST_HOME/bin:$PATH" python3 "$BASE" --route zen
+}
+
+run_go() {
+  HOME="$TEST_HOME" PATH="$TEST_HOME/bin:$PATH" python3 "$BASE" --route go
+}
+
+result_zen=$(run_zen)
+result_go=$(run_go)
+
+# Both records must be valid JSON with the standard contract fields.
+jq -e . >/dev/null 2>&1 <<<"$result_zen" ||
+  fail "Zen record is valid JSON" "$result_zen"
+pass "Zen record is valid JSON"
+
+jq -e . >/dev/null 2>&1 <<<"$result_go" ||
+  fail "Go record is valid JSON" "$result_go"
+pass "Go record is valid JSON"
+
+[[ $(jq -r '.schemaVersion' <<<"$result_zen") == "1" ]] ||
+  fail "Zen record has schemaVersion" "$result_zen"
+pass "Zen record has schemaVersion"
+
+[[ $(jq -r '.id' <<<"$result_zen") == "opencode-zen" ]] ||
+  fail "Zen record has correct id" "$result_zen"
+pass "Zen record has correct id"
+
+[[ $(jq -r '.id' <<<"$result_go") == "opencode-go" ]] ||
+  fail "Go record has correct id" "$result_go"
+pass "Go record has correct id"
+
+[[ $(jq -r '.name' <<<"$result_zen") == "OpenCode Zen" ]] ||
+  fail "Zen record has correct name" "$result_zen"
+pass "Zen record has correct name"
+
+[[ $(jq -r '.name' <<<"$result_go") == "OpenCode Go" ]] ||
+  fail "Go record has correct name" "$result_go"
+pass "Go record has correct name"
+
+[[ $(jq -r '.tierLabel' <<<"$result_zen") == "API" ]] ||
+  fail "Zen record has API tier label" "$result_zen"
+pass "Zen record has API tier label"
+
+[[ $(jq -r '.tierLabel' <<<"$result_go") == "Subscription" ]] ||
+  fail "Go record has Subscription tier label" "$result_go"
+pass "Go record has Subscription tier label"
+
+[[ $(jq -r '.ready' <<<"$result_zen") == "true" ]] ||
+  fail "Zen record reports ready" "$result_zen"
+pass "Zen record reports ready"
+
+[[ $(jq -r '.hasLocalStats' <<<"$result_zen") == "true" ]] ||
+  fail "Zen record has local stats" "$result_zen"
+pass "Zen record has local stats"
+
+[[ $(jq -r '.hasPromptStats' <<<"$result_zen") == "true" ]] ||
+  fail "Zen record has prompt stats" "$result_zen"
+pass "Zen record has prompt stats"
+
+# No routeData field — the old scanner's extension is not present.
+[[ $(jq 'has("routeData")' <<<"$result_zen") == "false" ]] ||
+  fail "Zen record has no routeData field" "$result_zen"
+pass "Zen record has no routeData field"
+
+# Limits are empty (no OpenCode API for rate limits).
+[[ $(jq '.limits | length' <<<"$result_zen") == "0" ]] ||
+  fail "Zen record has empty limits" "$result_zen"
+pass "Zen record has empty limits"
+
+# retryAdvised is false (no limits endpoint to retry).
+[[ $(jq -r '.retryAdvised' <<<"$result_zen") == "false" ]] ||
+  fail "Zen record has retryAdvised false" "$result_zen"
+pass "Zen record has retryAdvised false"
+
+# ---------------------------------------------------------------------------
+# Zen route totals
+
+# Zen today: Pi zen (550) + CLI zen (2000+500+250+1000 = 3750) = 4300
+zen_today=$(jq -r --arg d "$DAY" '.recentDays[] | select(.date == $d) | .messageCount' <<<"$result_zen")
+[[ $zen_today == "4300" ]] ||
+  fail "Zen record totals Pi + CLI tokens by day" "$result_zen"
+pass "Zen record totals Pi + CLI tokens by day"
+
+# Sessions: 1 Pi session (zen-ses) + 1 CLI session (ses-cli-1) = 2
+[[ $(jq -r '.totalSessions' <<<"$result_zen") == "2" ]] ||
+  fail "Zen record counts Pi + CLI sessions" "$result_zen"
+pass "Zen record counts Pi + CLI sessions"
+
+# Prompts: Pi assistant messages only (CLI sessions are not prompts)
+[[ $(jq -r '.totalPrompts' <<<"$result_zen") == "1" ]] ||
+  fail "Zen record counts Pi messages as prompts" "$result_zen"
+pass "Zen record counts Pi messages as prompts"
+
+# activeDates: only today (BYOK-only yesterday is excluded)
+[[ $(jq -r '.activeDays' <<<"$result_zen") == "1" ]] ||
+  fail "Zen record has 1 active day" "$result_zen"
+pass "Zen record has 1 active day"
+
+# Zen model: Pi gpt-5.6-luna (100 input + 50 output + 400 cache = 550 total)
+[[ $(jq -r '.modelUsage["gpt-5.6-luna"].inputTokens' <<<"$result_zen") == "100" ]] ||
+  fail "Zen model tracks Pi input tokens" "$result_zen"
+pass "Zen model tracks Pi input tokens"
+
+# Reasoning folds into model output: CLI 500 + 250 reasoning = 750 output
+[[ $(jq -r '.modelUsage["claude-sonnet-4.2-lite"].outputTokens' <<<"$result_zen") == "750" ]] ||
+  fail "Zen model folds CLI reasoning into output" "$result_zen"
+pass "Zen model folds CLI reasoning into output"
+
+# BYOK (gpt-direct) must never appear in Zen route.
+[[ $(jq -r '.modelUsage["gpt-direct"]' <<<"$result_zen") == "null" ]] ||
+  fail "Zen record excludes BYOK tokens" "$result_zen"
+pass "Zen record excludes BYOK tokens"
+
+# Go route (kimi-k2.6 CLI, kimi-k2.7-code Pi) must never appear in Zen.
+[[ $(jq -r '.modelUsage["kimi-k2.6"]' <<<"$result_zen") == "null" ]] ||
+  fail "Zen record excludes Go CLI tokens" "$result_zen"
+pass "Zen record excludes Go CLI tokens"
+
+[[ $(jq -r '.modelUsage["kimi-k2.7-code"]' <<<"$result_zen") == "null" ]] ||
+  fail "Zen record excludes Go Pi tokens" "$result_zen"
+pass "Zen record excludes Go Pi tokens"
+
+# ---------------------------------------------------------------------------
+# Go route totals
+
+# Go today: Pi go (400) + CLI go (100+50 = 150) = 550
+go_today=$(jq -r --arg d "$DAY" '.recentDays[] | select(.date == $d) | .messageCount' <<<"$result_go")
+[[ $go_today == "550" ]] ||
+  fail "Go record totals Pi + CLI tokens by day" "$result_go"
+pass "Go record totals Pi + CLI tokens by day"
+
+# Sessions: 1 Pi session (go-ses) + 1 CLI session (ses-cli-2) = 2
+[[ $(jq -r '.totalSessions' <<<"$result_go") == "2" ]] ||
+  fail "Go record counts Pi + CLI sessions" "$result_go"
+pass "Go record counts Pi + CLI sessions"
+
+# Prompts: Pi assistant messages only
+[[ $(jq -r '.totalPrompts' <<<"$result_go") == "1" ]] ||
+  fail "Go record counts Pi messages as prompts" "$result_go"
+pass "Go record counts Pi messages as prompts"
+
+# Go model: Pi kimi-k2.7-code (300 input + 100 output = 400 total)
+[[ $(jq -r '.modelUsage["kimi-k2.7-code"].outputTokens' <<<"$result_go") == "100" ]] ||
+  fail "Go model tracks Pi output tokens" "$result_go"
+pass "Go model tracks Pi output tokens"
+
+# BYOK (gpt-direct) must never appear in Go route.
+[[ $(jq -r '.modelUsage["gpt-direct"]' <<<"$result_go") == "null" ]] ||
+  fail "Go record excludes BYOK tokens" "$result_go"
+pass "Go record excludes BYOK tokens"
+
+# Zen models must never appear in Go route.
+[[ $(jq -r '.modelUsage["gpt-5.6-luna"]' <<<"$result_go") == "null" ]] ||
+  fail "Go record excludes Zen Pi tokens" "$result_go"
+pass "Go record excludes Zen Pi tokens"
+
+[[ $(jq -r '.modelUsage["claude-sonnet-4.2-lite"]' <<<"$result_go") == "null" ]] ||
+  fail "Go record excludes Zen CLI tokens" "$result_go"
+pass "Go record excludes Zen CLI tokens"
+
+# ---------------------------------------------------------------------------
+# Graceful degrade without the opencode CLI
+
+result_no_cli=$(HOME="$TEST_HOME" PATH="/usr/bin:/bin:/usr/local/bin" \
+  python3 "$BASE" --route zen)
+
+[[ $(jq -r '.ready' <<<"$result_no_cli") == "true" ]] ||
+  fail "Zen record works without opencode CLI" "$result_no_cli"
+pass "Zen record works without opencode CLI"
+
+# Without CLI, only Pi Zen tokens remain: 550 today.
+no_cli_today=$(jq -r --arg d "$DAY" '.recentDays[] | select(.date == $d) | .messageCount' <<<"$result_no_cli")
+[[ $no_cli_today == "550" ]] ||
+  fail "Zen record falls back to Pi-only tokens without CLI" "$result_no_cli"
+pass "Zen record falls back to Pi-only tokens without CLI"


### PR DESCRIPTION
## Summary

- add OpenCode as another model-usage provider in the agent menu bar modal, with a Zen API / Go subscription usage split
- scan `~/.pi/agent/sessions` transcripts (zen/go split by provider tag) and the opencode CLI session database for per-route tokens
- within the OpenCode view, add ability to shift between Zen / Go / Both to see token usage across each (defaulting to Zen)
- The included usage from Pi will only be from OpenCode Zen/Go; Pi messages tagged with any other provider (fireworks, anthropic, openai-codex, ...) are excluded

## Testing

- bash test/shell.d/model-usage-opencode-scanner-test.sh
- bash test/shell.d/model-usage-codex-scanner-test.sh
- live scan against real Pi sessions + panel refresh via `omarchy-shell omarchy.model-usage refresh`

## Notes

OpenCode Go usage isn't available via API, so this is just showing OpenCode and Pi sessions: the panel reads only transcripts and sessions recorded on this machine, never the live Zen/Go balance from the web console (due to lack of public API availability).
