### PR TITLE
Abort passwordless sudo toggle after failed authentication

### DIFF
--- a/bin/omarchy-sudo-passwordless
+++ b/bin/omarchy-sudo-passwordless
@@ -14,6 +14,7 @@ if [[ $1 && ! $1 =~ ^[0-9]+$ ]]; then
 fi
 
 echo "Toggle passwordless sudo..."
+sudo -v || exit $?
 
 # Safety: if the file exists but the timer doesn't (e.g. after reboot), clean up
 if sudo test -f "$NOPASSWD_FILE" && ! systemctl is-active "${TIMER_NAME}.timer" &>/dev/null; then


### PR DESCRIPTION
## Problem

When `omarchy sudo passwordless` authentication fails or is interrupted, the privileged file checks return nonzero inside shell conditionals. That result is interpreted as “passwordless sudo is disabled,” so the script continues to the security warning and confirmation prompt.

## Fix

Validate sudo credentials with `sudo -v` before inspecting the passwordless sudo state. If validation fails, exit immediately with sudo's status.

## Verification

- `bash -n bin/omarchy-sudo-passwordless`
- `bash test/shell.d/bin-style-test.sh`
- `./test/cli`
- `git diff --check`