### PR TITLE
fix(network-panel): speed test contrast

### DIFF
--- a/shell/plugins/panels/network/SpeedTestPanel.qml
+++ b/shell/plugins/panels/network/SpeedTestPanel.qml
@@ -33,6 +33,16 @@ PanelWindow {
   readonly property bool failed: error !== ""
   readonly property bool finished: !running && !failed && (downloadValue > 0 || uploadValue > 0)
 
+  // The scrim below is a fixed near-black regardless of wallpaper or theme,
+  // so everything drawn on it needs a fixed light-on-dark palette too.
+  // `bar.foreground` is themed to contrast against the *bar's* own
+  // background, which flips dark/light independently of this scrim -- on
+  // light-foreground themes that made every label, tick, and digit here
+  // disappear against the black backdrop, leaving only the accent arc
+  // and needle (which already use Color.accent, not bar.foreground) visible.
+  readonly property color onScrim: "white"
+  readonly property color onScrimDim: Qt.rgba(1, 1, 1, 0.55)
+
   function toMbps(raw) {
     var value = parseFloat(raw)
     return isFinite(value) && value > 0 ? value : 0
@@ -101,7 +111,7 @@ PanelWindow {
         Text {
           visible: root.connectionName !== ""
           text: root.connectionName.toUpperCase()
-          color: Qt.darker(root.bar.foreground, 1.4)
+          color: root.onScrimDim
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.caption
           font.bold: true
@@ -137,7 +147,7 @@ PanelWindow {
           bordered: true
           enabled: !root.running
           opacity: root.running ? 0 : 1
-          foreground: root.bar.foreground
+          foreground: root.onScrim
           fontFamily: root.bar.fontFamily
           fontSize: Style.font.bodySmall
           horizontalPadding: Style.space(14)
@@ -184,9 +194,9 @@ PanelWindow {
     readonly property int tickCount: 46
     readonly property real arcWidth: Style.space(4)
     readonly property real arcRadius: diameter / 2 - arcWidth
-    readonly property color trackColor: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.14)
-    readonly property color minorTickColor: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
-    readonly property color majorTickColor: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.3)
+    readonly property color trackColor: Qt.rgba(1, 1, 1, 0.14)
+    readonly property color minorTickColor: Qt.rgba(1, 1, 1, 0.12)
+    readonly property color majorTickColor: Qt.rgba(1, 1, 1, 0.3)
     // The dial that isn't measuring yet sits dimmed until it gets a figure.
     readonly property bool engaged: live || value > 0
 
@@ -361,7 +371,7 @@ PanelWindow {
       Text {
         anchors.horizontalCenter: parent.horizontalCenter
         text: dial.reading < 10 ? dial.reading.toFixed(1) : Math.round(dial.reading).toString()
-        color: root.bar.foreground
+        color: root.onScrim
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.display
         font.bold: true
@@ -370,7 +380,7 @@ PanelWindow {
       Text {
         anchors.horizontalCenter: parent.horizontalCenter
         text: "Mbps"
-        color: Qt.darker(root.bar.foreground, 1.4)
+        color: root.onScrimDim
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.caption
       }
@@ -382,7 +392,7 @@ PanelWindow {
       anchors.horizontalCenter: parent.horizontalCenter
       anchors.bottom: parent.bottom
       text: dial.label
-      color: Qt.darker(root.bar.foreground, 1.3)
+      color: root.onScrimDim
       font.family: root.bar.fontFamily
       font.pixelSize: Style.font.caption
       font.bold: true

--- a/shell/plugins/panels/network/SpeedTestPanel.qml
+++ b/shell/plugins/panels/network/SpeedTestPanel.qml
@@ -37,6 +37,7 @@ PanelWindow {
   // ticks on it need a fixed light palette, not the themed bar.foreground.
   readonly property color onScrim: "white"
   readonly property color onScrimDim: Qt.rgba(1, 1, 1, 0.55)
+  readonly property color onScrimUrgent: "#ff6b6b"
 
   function toMbps(raw) {
     var value = parseFloat(raw)
@@ -158,7 +159,7 @@ PanelWindow {
         Text {
           visible: root.failed
           text: root.error
-          color: root.bar.urgent
+          color: root.onScrimUrgent
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall
           wrapMode: Text.Wrap

--- a/shell/plugins/panels/network/SpeedTestPanel.qml
+++ b/shell/plugins/panels/network/SpeedTestPanel.qml
@@ -33,13 +33,8 @@ PanelWindow {
   readonly property bool failed: error !== ""
   readonly property bool finished: !running && !failed && (downloadValue > 0 || uploadValue > 0)
 
-  // The scrim below is a fixed near-black regardless of wallpaper or theme,
-  // so everything drawn on it needs a fixed light-on-dark palette too.
-  // `bar.foreground` is themed to contrast against the *bar's* own
-  // background, which flips dark/light independently of this scrim -- on
-  // light-foreground themes that made every label, tick, and digit here
-  // disappear against the black backdrop, leaving only the accent arc
-  // and needle (which already use Color.accent, not bar.foreground) visible.
+  // The scrim below is a fixed near-black regardless of theme, so text and
+  // ticks on it need a fixed light palette, not the themed bar.foreground.
   readonly property color onScrim: "white"
   readonly property color onScrimDim: Qt.rgba(1, 1, 1, 0.55)
 

--- a/shell/plugins/panels/network/WifiQrPanel.qml
+++ b/shell/plugins/panels/network/WifiQrPanel.qml
@@ -25,10 +25,8 @@ PanelWindow {
 
   readonly property bool showingQr: qrSize > 0 && !loading && error === ""
 
-  // Same fix as SpeedTestPanel: the scrim below is fixed near-black
-  // regardless of theme, so text on it needs a fixed light palette instead
-  // of `bar.foreground` (which flips dark/light with the bar's own theme
-  // and was going near-invisible on light-foreground themes).
+  // The scrim below is a fixed near-black regardless of theme, so text on
+  // it needs a fixed light palette, not the themed bar.foreground.
   readonly property color onScrim: "white"
   readonly property color onScrimDim: Qt.rgba(1, 1, 1, 0.55)
 

--- a/shell/plugins/panels/network/WifiQrPanel.qml
+++ b/shell/plugins/panels/network/WifiQrPanel.qml
@@ -25,6 +25,13 @@ PanelWindow {
 
   readonly property bool showingQr: qrSize > 0 && !loading && error === ""
 
+  // Same fix as SpeedTestPanel: the scrim below is fixed near-black
+  // regardless of theme, so text on it needs a fixed light palette instead
+  // of `bar.foreground` (which flips dark/light with the bar's own theme
+  // and was going near-invisible on light-foreground themes).
+  readonly property color onScrim: "white"
+  readonly property color onScrimDim: Qt.rgba(1, 1, 1, 0.55)
+
   signal closeRequested()
   signal passwordToggleRequested()
 
@@ -84,7 +91,7 @@ PanelWindow {
 
         Text {
           text: (root.ssid || "Wi-Fi").toUpperCase()
-          color: Qt.darker(root.bar.foreground, 1.4)
+          color: root.onScrimDim
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.caption
           font.bold: true
@@ -136,7 +143,7 @@ PanelWindow {
         Text {
           visible: root.loading
           text: "Generating QR code…"
-          color: Qt.darker(root.bar.foreground, 1.3)
+          color: root.onScrimDim
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall
           Layout.fillWidth: true
@@ -158,7 +165,7 @@ PanelWindow {
         Text {
           visible: root.showingQr
           text: "Scan to join this network"
-          color: Qt.darker(root.bar.foreground, 1.3)
+          color: root.onScrimDim
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall
           Layout.fillWidth: true
@@ -170,7 +177,7 @@ PanelWindow {
           text: root.passwordError !== "" ? root.passwordError
             : root.passwordVisible ? root.password
             : "Show password"
-          color: root.passwordError !== "" ? root.bar.urgent : root.bar.foreground
+          color: root.passwordError !== "" ? root.bar.urgent : root.onScrim
           opacity: root.passwordVisible || root.passwordError !== "" ? 1 : 0.6
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall

--- a/shell/plugins/panels/network/WifiQrPanel.qml
+++ b/shell/plugins/panels/network/WifiQrPanel.qml
@@ -29,6 +29,7 @@ PanelWindow {
   // it needs a fixed light palette, not the themed bar.foreground.
   readonly property color onScrim: "white"
   readonly property color onScrimDim: Qt.rgba(1, 1, 1, 0.55)
+  readonly property color onScrimUrgent: "#ff6b6b"
 
   signal closeRequested()
   signal passwordToggleRequested()
@@ -151,7 +152,7 @@ PanelWindow {
         Text {
           visible: root.error !== ""
           text: root.error
-          color: root.bar.urgent
+          color: root.onScrimUrgent
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall
           wrapMode: Text.Wrap
@@ -175,7 +176,7 @@ PanelWindow {
           text: root.passwordError !== "" ? root.passwordError
             : root.passwordVisible ? root.password
             : "Show password"
-          color: root.passwordError !== "" ? root.bar.urgent : root.onScrim
+          color: root.passwordError !== "" ? root.onScrimUrgent : root.onScrim
           opacity: root.passwordVisible || root.passwordError !== "" ? 1 : 0.6
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall


### PR DESCRIPTION
# Network Panel — Speed Test Contrast Fix

## The Problem

Opening the speed test from the Network panel, the floating dial cluster showed almost nothing on some themes: no digits, no "DOWNLOAD"/"UPLOAD" labels, no tick marks around the dials — only the glowing blue arc and needle were visible. Switching to Tokyo Night, the exact same overlay looked correct, with every label and digit clearly legible.

## Root Cause

The speed test overlay is designed with no card and no border — just the two dials floating on a deep, near-black scrim laid over the whole screen. That scrim is fixed and doesn't change with the theme, on purpose: it's meant to guarantee readable contrast no matter what wallpaper is behind it.

The text and tick colors inside the overlay, though, weren't fixed — they followed the bar's own theme color, the same color used to keep text legible against the bar itself. That color is designed to flip between light and dark depending on the theme, since the bar's background does too. On themes where that color comes out dark, it was being drawn on top of the equally dark scrim, and the two nearly disappeared into each other. Only the accent-colored arc and needle stayed visible, since those were never tied to that color in the first place.

## The Fix

The speed test overlay now uses its own fixed, theme-independent color for everything drawn on the scrim — a light color for the main text and a softer, dimmed version of it for secondary labels and tick marks. Since the scrim itself never changes, this pairing is guaranteed to stay legible on every theme, including the one that was previously broken. The one exception left alone is the error-state color, which is a deliberate warning color already designed to read clearly against a dark background regardless of theme.

## Test
before:
<img width="1702" height="1030" alt="screenshot-2026-08-03_12-43-59" src="https://github.com/user-attachments/assets/00e0f1f5-0573-4540-9d96-a0b058c2f417" />

After:
<img width="1924" height="1546" alt="image" src="https://github.com/user-attachments/assets/54e4b8fa-c737-4038-b298-ba506b3ae208" />

## Result

The speed test dials now display all their text, numbers, and tick marks clearly on every theme — not just Tokyo Night.