### PR TITLE
Stop making browser managed-policy directories world-writable

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -6,7 +6,17 @@
 
 setup_policy_directory() {
   sudo mkdir -p "$1"
-  sudo chmod a+rw "$1"
+}
+
+setup_chromium_policy_directory() {
+  setup_policy_directory "$1"
+  # Pre-create a user-owned color.json so omarchy-theme-set-browser can update
+  # the theme color without write access to the root-owned policy directory.
+  if [[ ! -f $1/color.json ]]; then
+    printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' |
+      sudo tee "$1/color.json" >/dev/null
+    sudo chown "$USER:" "$1/color.json"
+  fi
 }
 
 announce_browser_installed() {
@@ -38,7 +48,7 @@ chrome)
   echo "Installing Chrome..."
   omarchy-pkg-aur-add google-chrome || exit 1
 
-  setup_policy_directory /etc/opt/chrome/policies/managed
+  setup_chromium_policy_directory /etc/opt/chrome/policies/managed
   copy_chromium_flags ~/.config/chrome-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Chrome"
@@ -47,7 +57,7 @@ edge)
   echo "Installing Edge..."
   omarchy-pkg-aur-add microsoft-edge-stable-bin || exit 1
 
-  setup_policy_directory /etc/opt/edge/policies/managed
+  setup_chromium_policy_directory /etc/opt/edge/policies/managed
   copy_chromium_flags ~/.config/microsoft-edge-stable-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Edge"
@@ -56,7 +66,7 @@ brave)
   echo "Installing Brave..."
   omarchy-pkg-aur-add brave-bin || exit 1
 
-  setup_policy_directory /etc/brave/policies/managed
+  setup_chromium_policy_directory /etc/brave/policies/managed
   copy_chromium_flags ~/.config/brave-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Brave"
@@ -65,7 +75,7 @@ brave-origin)
   echo "Installing Brave Origin..."
   omarchy-pkg-aur-add brave-origin-bin || exit 1
 
-  setup_policy_directory /etc/brave/policies/managed
+  setup_chromium_policy_directory /etc/brave/policies/managed
   copy_chromium_flags ~/.config/brave-origin-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Brave Origin"

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -5,17 +5,23 @@
 # omarchy:examples=omarchy install browser firefox | omarchy install browser brave
 
 setup_policy_directory() {
-  sudo mkdir -p "$1"
+  # Explicit mode so a permissive umask cannot recreate a world-writable dir.
+  sudo install -d -m 0755 "$1"
 }
 
 setup_chromium_policy_directory() {
   setup_policy_directory "$1"
   # Pre-create a user-owned color.json so omarchy-theme-set-browser can update
   # the theme color without write access to the root-owned policy directory.
-  if [[ ! -f $1/color.json ]]; then
+  local color_json="$1/color.json"
+  if [[ -L $color_json || ! -f $color_json ]]; then
+    if [[ -e $color_json || -L $color_json ]]; then
+      sudo rm -rf -- "$color_json"
+    fi
     printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' |
-      sudo tee "$1/color.json" >/dev/null
-    sudo chown "$USER:" "$1/color.json"
+      sudo tee "$color_json" >/dev/null
+    sudo chmod 0644 "$color_json"
+    sudo chown "$USER:" "$color_json"
   fi
 }
 

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1174,7 +1174,14 @@ apply_system_transition() {
     /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
   as_root gtk-update-icon-cache /usr/share/icons/Yaru >/dev/null 2>&1 || true
 
-  as_root install -d -m 0777 /etc/chromium/policies/managed
+  as_root install -d -m 0755 /etc/chromium/policies/managed
+  # Pre-create a user-owned color.json so omarchy-theme-set-browser can update
+  # the theme color without write access to the root-owned policy directory.
+  if [[ ! -f /etc/chromium/policies/managed/color.json ]]; then
+    printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' | \
+      as_root tee /etc/chromium/policies/managed/color.json >/dev/null
+    as_root chown "$target_user:" /etc/chromium/policies/managed/color.json
+  fi
   as_root install -d -m 0755 /usr/lib/chromium
   printf '%s\n' '{"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}' | \
     as_root tee /usr/lib/chromium/initial_preferences >/dev/null

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1177,9 +1177,15 @@ apply_system_transition() {
   as_root install -d -m 0755 /etc/chromium/policies/managed
   # Pre-create a user-owned color.json so omarchy-theme-set-browser can update
   # the theme color without write access to the root-owned policy directory.
-  if [[ ! -f /etc/chromium/policies/managed/color.json ]]; then
+  # The directory used to be world-writable, so replace anything that is not a
+  # plain regular file rather than following it.
+  if [[ -L /etc/chromium/policies/managed/color.json || ! -f /etc/chromium/policies/managed/color.json ]]; then
+    if [[ -e /etc/chromium/policies/managed/color.json || -L /etc/chromium/policies/managed/color.json ]]; then
+      as_root rm -rf -- /etc/chromium/policies/managed/color.json
+    fi
     printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' | \
       as_root tee /etc/chromium/policies/managed/color.json >/dev/null
+    as_root chmod 0644 /etc/chromium/policies/managed/color.json
     as_root chown "$target_user:" /etc/chromium/policies/managed/color.json
   fi
   as_root install -d -m 0755 /usr/lib/chromium

--- a/install/config/theme-system.sh
+++ b/install/config/theme-system.sh
@@ -8,7 +8,11 @@ gtk-update-icon-cache /usr/share/icons/Yaru &>/dev/null || true
 
 # Chromium policy directory for theme
 mkdir -p /etc/chromium/policies/managed
-chmod a+rw /etc/chromium/policies/managed
+# Pre-create a user-owned color.json so omarchy-theme-set-browser can update
+# the theme color without write access to the root-owned policy directory.
+printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' > \
+  /etc/chromium/policies/managed/color.json
+chown "$OMARCHY_INSTALL_USER:" /etc/chromium/policies/managed/color.json
 
 # Default Chromium to follow system appearance ("device") instead of dark
 mkdir -p /usr/lib/chromium

--- a/install/config/theme-system.sh
+++ b/install/config/theme-system.sh
@@ -6,12 +6,14 @@ ln -snf /usr/share/icons/Adwaita/symbolic/actions/go-next-symbolic.svg \
           /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
 gtk-update-icon-cache /usr/share/icons/Yaru &>/dev/null || true
 
-# Chromium policy directory for theme
-mkdir -p /etc/chromium/policies/managed
+# Chromium policy directory for theme. Create it with an explicit mode so a
+# permissive umask cannot reproduce the world-writable directory this replaces.
+install -d -m 0755 /etc/chromium/policies/managed
 # Pre-create a user-owned color.json so omarchy-theme-set-browser can update
 # the theme color without write access to the root-owned policy directory.
 printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' > \
   /etc/chromium/policies/managed/color.json
+chmod 0644 /etc/chromium/policies/managed/color.json
 chown "$OMARCHY_INSTALL_USER:" /etc/chromium/policies/managed/color.json
 
 # Default Chromium to follow system appearance ("device") instead of dark

--- a/migrations/1785760301.sh
+++ b/migrations/1785760301.sh
@@ -13,21 +13,30 @@ policy_dirs="${OMARCHY_BROWSER_POLICY_DIRS:-/etc/chromium/policies/managed
 while IFS= read -r policy_dir; do
   [[ -d $policy_dir ]] || continue
 
+  # Restore the default 0755 first; once the directory is no longer
+  # world-writable nothing can plant new entries while it is being repaired.
   if [[ $(stat -c %a "$policy_dir") != "755" ]]; then
     sudo chmod 755 "$policy_dir"
   fi
 
-  if [[ -f $policy_dir/color.json ]]; then
-    # Only repair files still owned by root; another user may have already
-    # claimed ownership, and that is the intended end state.
-    if [[ $(stat -c %U "$policy_dir/color.json") == "root" ]]; then
-      sudo chown "$USER:" "$policy_dir/color.json"
+  color_json="$policy_dir/color.json"
+
+  # While the directory was world-writable an attacker could have planted a
+  # symlink or FIFO here, and stat, chown, and tee would all follow it.
+  # Replace anything that is not a plain regular file.
+  if [[ -L $color_json || ! -f $color_json ]]; then
+    if [[ -e $color_json || -L $color_json ]]; then
+      sudo rm -rf -- "$color_json"
     fi
-  else
     # Without write access to the directory, omarchy-theme-set-browser can only
     # update an existing color.json, so make sure the file is present.
     printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' |
-      sudo tee "$policy_dir/color.json" >/dev/null
-    sudo chown "$USER:" "$policy_dir/color.json"
+      sudo tee "$color_json" >/dev/null
+    sudo chmod 0644 "$color_json"
+    sudo chown "$USER:" "$color_json"
+  elif [[ $(stat -c %U "$color_json") == "root" ]]; then
+    # Only repair files still owned by root; another user may have already
+    # claimed ownership, and that is the intended end state.
+    sudo chown "$USER:" "$color_json"
   fi
 done <<<"$policy_dirs"

--- a/migrations/1785760301.sh
+++ b/migrations/1785760301.sh
@@ -19,6 +19,20 @@ while IFS= read -r policy_dir; do
     sudo chmod 755 "$policy_dir"
   fi
 
+  # While the directory was world-writable, arbitrary policy files could have
+  # been planted, and fixing the mode only stops future additions. Root-owned
+  # entries are trusted administrator or package policies and stay; any other
+  # entry that is not the theme's color.json is untrusted and is removed.
+  while IFS= read -r -d '' entry; do
+    if [[ ${entry##*/} == "color.json" ]]; then
+      continue
+    fi
+    if [[ -L $entry || ! -f $entry || $(stat -c %U "$entry") != "root" ]]; then
+      echo "Removing untrusted browser policy entry: $entry"
+      sudo rm -rf -- "$entry"
+    fi
+  done < <(find "$policy_dir" -mindepth 1 -maxdepth 1 -print0)
+
   color_json="$policy_dir/color.json"
 
   # While the directory was world-writable an attacker could have planted a

--- a/migrations/1785760301.sh
+++ b/migrations/1785760301.sh
@@ -1,0 +1,33 @@
+echo "Tighten browser managed-policy directory permissions"
+
+# The policy directories used to be world-writable so omarchy-theme-set-browser
+# could write color.json as the user. That let any local user or process drop
+# arbitrary managed policies into a root-owned browser directory. Restore the
+# default 0755 and hand the user ownership of the single file they need to
+# update instead.
+policy_dirs="${OMARCHY_BROWSER_POLICY_DIRS:-/etc/chromium/policies/managed
+/etc/opt/chrome/policies/managed
+/etc/opt/edge/policies/managed
+/etc/brave/policies/managed}"
+
+while IFS= read -r policy_dir; do
+  [[ -d $policy_dir ]] || continue
+
+  if [[ $(stat -c %a "$policy_dir") != "755" ]]; then
+    sudo chmod 755 "$policy_dir"
+  fi
+
+  if [[ -f $policy_dir/color.json ]]; then
+    # Only repair files still owned by root; another user may have already
+    # claimed ownership, and that is the intended end state.
+    if [[ $(stat -c %U "$policy_dir/color.json") == "root" ]]; then
+      sudo chown "$USER:" "$policy_dir/color.json"
+    fi
+  else
+    # Without write access to the directory, omarchy-theme-set-browser can only
+    # update an existing color.json, so make sure the file is present.
+    printf '%s\n' '{"BrowserThemeColor": "#1c2027", "BrowserColorScheme": "device"}' |
+      sudo tee "$policy_dir/color.json" >/dev/null
+    sudo chown "$USER:" "$policy_dir/color.json"
+  fi
+done <<<"$policy_dirs"

--- a/test/shell.d/browser-policy-perms-test.sh
+++ b/test/shell.d/browser-policy-perms-test.sh
@@ -11,13 +11,19 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 stub_bin="$TMPDIR/bin"
+sudo_log="$TMPDIR/sudo.log"
 mkdir -p "$stub_bin"
 
-# The migration shells out to sudo for chmod/chown/tee. Execute the command
-# directly so the fixture tree shows what the real system would see.
-cat >"$stub_bin/sudo" <<'STUB'
+# chmod, tee, and rm act on the fixture tree so the results can be inspected.
+# chown is recorded but not executed: changing ownership depends on the
+# runner's user and privileges, which the test must not rely on.
+cat >"$stub_bin/sudo" <<STUB
 #!/bin/bash
-exec "$@"
+if [[ \$1 == chown ]]; then
+  echo "\$*" >>"$sudo_log"
+  exit 0
+fi
+exec "\$@"
 STUB
 chmod +x "$stub_bin/sudo"
 
@@ -37,27 +43,48 @@ policy_dirs="$world_writable"
 run_migration
 [[ $(stat -c %a "$world_writable") == "755" ]] || fail "migration restores 0755 on world-writable policy directory"
 pass "migration restores 0755 on world-writable policy directory"
-[[ -f $world_writable/color.json ]] || fail "migration creates missing color.json"
+[[ -f $world_writable/color.json && ! -L $world_writable/color.json ]] || fail "migration creates missing color.json"
 pass "migration creates missing color.json"
 grep -q 'BrowserThemeColor' "$world_writable/color.json" || fail "migration seeds color.json with theme policy"
 pass "migration seeds color.json with theme policy"
+[[ $(stat -c %a "$world_writable/color.json") == "644" ]] || fail "migration creates color.json with 0644"
+pass "migration creates color.json with 0644"
+grep -q "chown tester: $world_writable/color.json" "$sudo_log" || fail "migration hands the user ownership of color.json"
+pass "migration hands the user ownership of color.json"
 
 # A directory that is already 0755 with a user-owned color.json stays untouched.
 already_fixed="$TMPDIR/already-fixed"
 mkdir -p "$already_fixed"
 chmod 755 "$already_fixed"
 echo '{"BrowserThemeColor": "#ff0000", "BrowserColorScheme": "device"}' >"$already_fixed/color.json"
+: >"$sudo_log"
 policy_dirs="$already_fixed"
 run_migration
 [[ $(stat -c %a "$already_fixed") == "755" ]] || fail "migration keeps 0755 directory unchanged"
 pass "migration keeps 0755 directory unchanged"
 grep -q '#ff0000' "$already_fixed/color.json" || fail "migration keeps an existing user-owned color.json"
 pass "migration keeps an existing user-owned color.json"
+[[ ! -s $sudo_log ]] || fail "migration makes no privileged calls for an already-fixed directory"
+pass "migration makes no privileged calls for an already-fixed directory"
 
 # Missing directories (browser never installed) are skipped without error.
 policy_dirs="$TMPDIR/does-not-exist"
 run_migration
 pass "migration skips missing policy directories"
+
+# While the directory was world-writable an attacker could plant a symlink
+# named color.json; the migration must replace it instead of following it.
+symlinked="$TMPDIR/symlinked"
+mkdir -p "$symlinked"
+chmod 755 "$symlinked"
+ln -s /etc/passwd "$symlinked/color.json"
+: >"$sudo_log"
+policy_dirs="$symlinked"
+run_migration
+[[ -f $symlinked/color.json && ! -L $symlinked/color.json ]] || fail "migration replaces a symlinked color.json with a regular file"
+pass "migration replaces a symlinked color.json with a regular file"
+grep -q 'BrowserThemeColor' "$symlinked/color.json" || fail "migration reseeds a replaced color.json"
+pass "migration reseeds a replaced color.json"
 
 # The root-owned repair branch: report the fixture color.json as root-owned and
 # expect a chown to the current user.
@@ -74,14 +101,8 @@ fi
 exec /usr/bin/stat "$@"
 STUB
 chmod +x "$stub_bin/stat"
-chown_log="$TMPDIR/chown.log"
-cat >"$stub_bin/sudo" <<STUB
-#!/bin/bash
-if [[ \$1 == chown ]]; then echo "\$*" >>"$chown_log"; fi
-exec "\$@"
-STUB
-chmod +x "$stub_bin/sudo"
+: >"$sudo_log"
 policy_dirs="$root_owned"
 STAT_ROOT_OWNER_FOR="$root_owned/color.json" run_migration
-grep -q "chown tester:" "$chown_log" || fail "migration reclaims root-owned color.json for the user"
+grep -q "chown tester: $root_owned/color.json" "$sudo_log" || fail "migration reclaims root-owned color.json for the user"
 pass "migration reclaims root-owned color.json for the user"

--- a/test/shell.d/browser-policy-perms-test.sh
+++ b/test/shell.d/browser-policy-perms-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration=$(grep -rl 'Tighten browser managed-policy directory permissions' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "browser policy permissions migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+
+# The migration shells out to sudo for chmod/chown/tee. Execute the command
+# directly so the fixture tree shows what the real system would see.
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+# Runs the migration the same way omarchy-migrate does, against fixture dirs.
+run_migration() {
+  USER=tester PATH="$stub_bin:$PATH" OMARCHY_BROWSER_POLICY_DIRS="$policy_dirs" \
+    bash -euo pipefail "$migration" >/dev/null ||
+    fail "migration exits clean"
+}
+
+# A world-writable policy directory is restored to 0755 and gains a user-owned
+# color.json so theme updates keep working.
+world_writable="$TMPDIR/world-writable"
+mkdir -p "$world_writable"
+chmod 777 "$world_writable"
+policy_dirs="$world_writable"
+run_migration
+[[ $(stat -c %a "$world_writable") == "755" ]] || fail "migration restores 0755 on world-writable policy directory"
+pass "migration restores 0755 on world-writable policy directory"
+[[ -f $world_writable/color.json ]] || fail "migration creates missing color.json"
+pass "migration creates missing color.json"
+grep -q 'BrowserThemeColor' "$world_writable/color.json" || fail "migration seeds color.json with theme policy"
+pass "migration seeds color.json with theme policy"
+
+# A directory that is already 0755 with a user-owned color.json stays untouched.
+already_fixed="$TMPDIR/already-fixed"
+mkdir -p "$already_fixed"
+chmod 755 "$already_fixed"
+echo '{"BrowserThemeColor": "#ff0000", "BrowserColorScheme": "device"}' >"$already_fixed/color.json"
+policy_dirs="$already_fixed"
+run_migration
+[[ $(stat -c %a "$already_fixed") == "755" ]] || fail "migration keeps 0755 directory unchanged"
+pass "migration keeps 0755 directory unchanged"
+grep -q '#ff0000' "$already_fixed/color.json" || fail "migration keeps an existing user-owned color.json"
+pass "migration keeps an existing user-owned color.json"
+
+# Missing directories (browser never installed) are skipped without error.
+policy_dirs="$TMPDIR/does-not-exist"
+run_migration
+pass "migration skips missing policy directories"
+
+# The root-owned repair branch: report the fixture color.json as root-owned and
+# expect a chown to the current user.
+root_owned="$TMPDIR/root-owned"
+mkdir -p "$root_owned"
+chmod 755 "$root_owned"
+echo '{}' >"$root_owned/color.json"
+cat >"$stub_bin/stat" <<'STUB'
+#!/bin/bash
+if [[ $1 == "-c" && $2 == "%U" && $3 == "$STAT_ROOT_OWNER_FOR" ]]; then
+  echo root
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+STUB
+chmod +x "$stub_bin/stat"
+chown_log="$TMPDIR/chown.log"
+cat >"$stub_bin/sudo" <<STUB
+#!/bin/bash
+if [[ \$1 == chown ]]; then echo "\$*" >>"$chown_log"; fi
+exec "\$@"
+STUB
+chmod +x "$stub_bin/sudo"
+policy_dirs="$root_owned"
+STAT_ROOT_OWNER_FOR="$root_owned/color.json" run_migration
+grep -q "chown tester:" "$chown_log" || fail "migration reclaims root-owned color.json for the user"
+pass "migration reclaims root-owned color.json for the user"

--- a/test/shell.d/browser-policy-perms-test.sh
+++ b/test/shell.d/browser-policy-perms-test.sh
@@ -14,15 +14,21 @@ stub_bin="$TMPDIR/bin"
 sudo_log="$TMPDIR/sudo.log"
 mkdir -p "$stub_bin"
 
-# chmod, tee, and rm act on the fixture tree so the results can be inspected.
-# chown is recorded but not executed: changing ownership depends on the
-# runner's user and privileges, which the test must not rely on.
+# chmod and tee act on the fixture tree so the results can be inspected, and rm
+# is recorded and executed so planted entries really disappear. chown is recorded
+# but not executed: changing ownership depends on the runner's user and
+# privileges, which the test must not rely on.
 cat >"$stub_bin/sudo" <<STUB
 #!/bin/bash
-if [[ \$1 == chown ]]; then
-  echo "\$*" >>"$sudo_log"
-  exit 0
-fi
+case \${1:-} in
+  chown)
+    echo "\$*" >>"$sudo_log"
+    exit 0
+    ;;
+  rm)
+    echo "\$*" >>"$sudo_log"
+    ;;
+esac
 exec "\$@"
 STUB
 chmod +x "$stub_bin/sudo"
@@ -106,3 +112,36 @@ policy_dirs="$root_owned"
 STAT_ROOT_OWNER_FOR="$root_owned/color.json" run_migration
 grep -q "chown tester: $root_owned/color.json" "$sudo_log" || fail "migration reclaims root-owned color.json for the user"
 pass "migration reclaims root-owned color.json for the user"
+
+# Fixing the directory mode only stops future additions; entries planted while
+# it was world-writable must be cleaned out. Root-owned administrator policies
+# are preserved, anything else that is not color.json is removed.
+compromised="$TMPDIR/compromised"
+mkdir -p "$compromised"
+chmod 755 "$compromised"
+echo '{"ExtensionInstallForcelist": ["malicious"]}' >"$compromised/forced-extension.json"
+echo '{"HomepageLocation": "https://example.com"}' >"$compromised/admin-policy.json"
+echo '{}' >"$compromised/color.json"
+cat >"$stub_bin/stat" <<'STUB'
+#!/bin/bash
+if [[ $1 == "-c" && $2 == "%U" ]]; then
+  case $3 in
+    */admin-policy.json) echo root ;;
+    *) echo attacker ;;
+  esac
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+STUB
+chmod +x "$stub_bin/stat"
+: >"$sudo_log"
+policy_dirs="$compromised"
+run_migration
+[[ ! -e $compromised/forced-extension.json ]] || fail "migration removes attacker-planted policy files"
+pass "migration removes attacker-planted policy files"
+[[ -f $compromised/admin-policy.json ]] || fail "migration preserves root-owned administrator policies"
+pass "migration preserves root-owned administrator policies"
+[[ -f $compromised/color.json ]] || fail "migration keeps color.json while cleaning planted entries"
+pass "migration keeps color.json while cleaning planted entries"
+grep -q "rm -rf -- $compromised/forced-extension.json" "$sudo_log" || fail "migration removes planted entries with a privileged rm"
+pass "migration removes planted entries with a privileged rm"


### PR DESCRIPTION
## Summary

Fixes #5547.

The Chromium/Chrome/Edge/Brave managed-policy directories were created `chmod a+rw` (mode 0777) so that `omarchy-theme-set-browser` could write `color.json` as the unprivileged user. But a world-writable, root-owned browser policy directory lets any local user — or any process running as that user — drop or edit arbitrary managed policies (forced extensions, proxies, disabled security features). The browser only needs to *read* these files.

## Approach

Keep the directories at the default `0755` (root-writable, world-readable) and instead pre-create a single **user-owned** `color.json` at every creation site. A user can still update the contents of a file they own even inside a root-owned, non-writable directory, so theme syncing keeps working — but nothing can create, rename, or delete policy files anymore.

Creation sites updated:

- `install/config/theme-system.sh` — fresh installs (owns the file to `$OMARCHY_INSTALL_USER`)
- `bin/omarchy-install-browser` — Chrome/Edge/Brave/Brave Origin get a seeded `color.json`; Firefox/Zen distribution dirs only need the mkdir since their `policies.json` is copied as root
- `bin/omarchy-upgrade-to-quattro` — the 3.x→4.0 upgrade path (was `install -d -m 0777`)

A new migration repairs existing installs: restores `0755`, hands the user ownership of an existing root-owned `color.json`, and seeds the file when it is missing (without directory write access the theme command can only update an existing file). It no-ops when another user already claimed ownership.

## Testing

Added `test/shell.d/browser-policy-perms-test.sh` covering the migration: world-writable repair, missing-file seeding, idempotent re-runs, missing directories, and the root-owned reclaim branch. All pass; full `./test/all` suite shows no regressions.