### PR TITLE
Abort pkg-install when the package transaction fails or is interrupted

### DIFF
--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -23,7 +23,10 @@ if [[ -n $pkg_names ]]; then
   # Add aur/ prefix to each package name and convert to space-separated for yay
   source omarchy-sudo-keepalive
 
-  echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm
+  if ! echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm; then
+    echo -e "\033[31mError: Package installation was aborted or failed\033[0m" >&2
+    exit 1
+  fi
   sudo updatedb
   omarchy-show-done
 fi

--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -24,7 +24,7 @@ if [[ -n $pkg_names ]]; then
   source omarchy-sudo-keepalive
 
   if ! echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm; then
-    echo -e "\033[31mError: Package installation was aborted or failed\033[0m" >&2
+    omarchy-show-error "Package installation was aborted or failed"
     exit 1
   fi
   sudo updatedb

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -21,6 +21,9 @@ if [[ -n $pkg_names ]]; then
   source omarchy-sudo-keepalive
 
   # Convert newline-separated selections to space-separated for pacman
-  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm
+  if ! echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm; then
+    echo -e "\033[31mError: Package installation was aborted or failed\033[0m" >&2
+    exit 1
+  fi
   omarchy-show-done
 fi

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -22,7 +22,7 @@ if [[ -n $pkg_names ]]; then
 
   # Convert newline-separated selections to space-separated for pacman
   if ! echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm; then
-    echo -e "\033[31mError: Package installation was aborted or failed\033[0m" >&2
+    omarchy-show-error "Package installation was aborted or failed"
     exit 1
   fi
   omarchy-show-done

--- a/bin/omarchy-show-error
+++ b/bin/omarchy-show-error
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Display an error message with a spinner and wait for user to press any key.
+# omarchy:args=<message>
+
+echo
+echo -e "\033[31mError: $*\033[0m" >&2
+gum spin --spinner "globe" --title "Press any key to close..." -- bash -c 'read -n 1 -s'

--- a/bin/omarchy-sudo-keepalive
+++ b/bin/omarchy-sudo-keepalive
@@ -3,7 +3,13 @@
 # omarchy:summary=Prompt for sudo once and keep the credential alive in the background.
 # omarchy:requires-sudo=true
 
-sudo -v
+# The initial validation is the prompt the user sees, so an interrupt or a
+# declined password must stop the caller instead of falling through into the
+# privileged work that follows.
+if ! sudo -v; then
+  echo -e "\033[31mError: sudo authentication was aborted or failed\033[0m" >&2
+  exit 1
+fi
 while true; do sudo -n true; sleep 60; done 2>/dev/null &
 SUDO_KEEPALIVE_PID=$!
 trap "kill $SUDO_KEEPALIVE_PID 2>/dev/null" EXIT

--- a/test/shell.d/pkg-install-abort-test.sh
+++ b/test/shell.d/pkg-install-abort-test.sh
@@ -19,6 +19,14 @@ esac
 exec "$@"
 STUB
 
+# The sudo keepalive loop sleeps between refreshes, and its trap kills the loop
+# without reaping an in-flight sleep. Keep the stub short so test runs do not
+# leave a minute of stray sleeps behind. command -p skips the stub PATH.
+cat >"$stub_bin/sleep" <<'STUB'
+#!/bin/bash
+command -p sleep 0.2
+STUB
+
 cat >"$stub_bin/fzf" <<'STUB'
 #!/bin/bash
 echo testpkg

--- a/test/shell.d/pkg-install-abort-test.sh
+++ b/test/shell.d/pkg-install-abort-test.sh
@@ -13,7 +13,8 @@ mkdir -p "$stub_bin"
 cat >"$stub_bin/sudo" <<'STUB'
 #!/bin/bash
 case ${1:-} in
-  -v|-n) exit 0 ;;
+  -v) exit "${SUDO_VALIDATE_RESULT:-0}" ;;
+  -n) exit 0 ;;
 esac
 exec "$@"
 STUB
@@ -25,12 +26,12 @@ STUB
 
 cat >"$stub_bin/omarchy-show-done" <<'STUB'
 #!/bin/bash
-echo done >>"${DONE_LOG:?}"
+echo done >>"${CALL_LOG:?}"
 STUB
 
 cat >"$stub_bin/updatedb" <<'STUB'
 #!/bin/bash
-echo updatedb >>"${DONE_LOG:?}"
+echo updatedb >>"${CALL_LOG:?}"
 STUB
 
 cat >"$stub_bin/pacman" <<'STUB'
@@ -39,6 +40,7 @@ if [[ $1 == "-Slq" ]]; then
   echo testpkg
   exit 0
 fi
+echo "pacman $*" >>"${CALL_LOG:?}"
 exit "${PACMAN_RESULT:-0}"
 STUB
 
@@ -48,50 +50,73 @@ if [[ $1 == "-Slqa" ]]; then
   echo testpkg
   exit 0
 fi
+echo "yay $*" >>"${CALL_LOG:?}"
 exit "${YAY_RESULT:-0}"
 STUB
 
 chmod +x "$stub_bin"/*
 
 run_pkg_install() {
-  DONE_LOG="$done_log" PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$TMPDIR/home" \
+  : >"$call_log"
+  CALL_LOG="$call_log" PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$TMPDIR/home" \
     bash "$ROOT/bin/omarchy-pkg-install" >/dev/null 2>&1
 }
 
 run_pkg_aur_install() {
-  DONE_LOG="$done_log" PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$TMPDIR/home" \
+  : >"$call_log"
+  CALL_LOG="$call_log" PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$TMPDIR/home" \
     bash "$ROOT/bin/omarchy-pkg-aur-install" >/dev/null 2>&1
 }
 
 mkdir -p "$TMPDIR/home"
 
 # A successful pacman run still reports done.
-done_log="$TMPDIR/done-success"
+call_log="$TMPDIR/calls-success"
 PACMAN_RESULT=0 run_pkg_install || fail "pkg-install exits clean on successful install"
-grep -q done "$done_log" || fail "pkg-install reports done on successful install"
+grep -q '^done$' "$call_log" || fail "pkg-install reports done on successful install"
 pass "pkg-install reports done on successful install"
 
 # An aborted or failed pacman run (Ctrl+C at the sudo prompt, declined auth,
 # package error) must not report done and must exit non-zero.
-done_log="$TMPDIR/done-abort"
+call_log="$TMPDIR/calls-abort"
 if PACMAN_RESULT=130 run_pkg_install; then
   fail "pkg-install exits non-zero on aborted install"
 fi
-[[ ! -e $done_log ]] || fail "pkg-install does not report done on aborted install"
+grep -q '^done$' "$call_log" && fail "pkg-install does not report done on aborted install"
 pass "pkg-install does not report done on aborted install"
 
+# An interrupt at the initial sudo validation (the first password prompt) must
+# stop before the package transaction starts.
+call_log="$TMPDIR/calls-sudo-abort"
+if SUDO_VALIDATE_RESULT=130 run_pkg_install; then
+  fail "pkg-install exits non-zero when sudo validation is interrupted"
+fi
+grep -q '^pacman ' "$call_log" && fail "pkg-install skips the pacman transaction when sudo validation is interrupted"
+grep -q '^done$' "$call_log" && fail "pkg-install does not report done when sudo validation is interrupted"
+pass "pkg-install aborts before the transaction when sudo validation is interrupted"
+
 # A successful yay run reports done and refreshes the file database.
-done_log="$TMPDIR/aur-done-success"
+call_log="$TMPDIR/aur-calls-success"
 YAY_RESULT=0 run_pkg_aur_install || fail "pkg-aur-install exits clean on successful install"
-grep -q done "$done_log" || fail "pkg-aur-install reports done on successful install"
+grep -q '^done$' "$call_log" || fail "pkg-aur-install reports done on successful install"
 pass "pkg-aur-install reports done on successful install"
-grep -q updatedb "$done_log" || fail "pkg-aur-install refreshes file database on success"
+grep -q '^updatedb$' "$call_log" || fail "pkg-aur-install refreshes file database on success"
 pass "pkg-aur-install refreshes file database on success"
 
 # An aborted yay run must skip both updatedb and the done notification.
-done_log="$TMPDIR/aur-done-abort"
+call_log="$TMPDIR/aur-calls-abort"
 if YAY_RESULT=130 run_pkg_aur_install; then
   fail "pkg-aur-install exits non-zero on aborted install"
 fi
-[[ ! -e $done_log ]] || fail "pkg-aur-install skips done and updatedb on aborted install"
+{ grep -q '^updatedb$' "$call_log" || grep -q '^done$' "$call_log"; } &&
+  fail "pkg-aur-install skips done and updatedb on aborted install"
 pass "pkg-aur-install skips done and updatedb on aborted install"
+
+# The same initial sudo validation interrupt must stop the AUR flow before yay.
+call_log="$TMPDIR/aur-calls-sudo-abort"
+if SUDO_VALIDATE_RESULT=130 run_pkg_aur_install; then
+  fail "pkg-aur-install exits non-zero when sudo validation is interrupted"
+fi
+grep -q '^yay ' "$call_log" && fail "pkg-aur-install skips the yay transaction when sudo validation is interrupted"
+grep -q '^done$' "$call_log" && fail "pkg-aur-install does not report done when sudo validation is interrupted"
+pass "pkg-aur-install aborts before the transaction when sudo validation is interrupted"

--- a/test/shell.d/pkg-install-abort-test.sh
+++ b/test/shell.d/pkg-install-abort-test.sh
@@ -29,6 +29,11 @@ cat >"$stub_bin/omarchy-show-done" <<'STUB'
 echo done >>"${CALL_LOG:?}"
 STUB
 
+cat >"$stub_bin/omarchy-show-error" <<'STUB'
+#!/bin/bash
+echo error >>"${CALL_LOG:?}"
+STUB
+
 cat >"$stub_bin/updatedb" <<'STUB'
 #!/bin/bash
 echo updatedb >>"${CALL_LOG:?}"
@@ -84,6 +89,10 @@ if PACMAN_RESULT=130 run_pkg_install; then
 fi
 grep -q '^done$' "$call_log" && fail "pkg-install does not report done on aborted install"
 pass "pkg-install does not report done on aborted install"
+# The menu launches these in a throwaway terminal, so a failing transaction has
+# to hold the window open or its output disappears before it can be read.
+grep -q '^error$' "$call_log" || fail "pkg-install holds the terminal open on a failed install"
+pass "pkg-install holds the terminal open on a failed install"
 
 # An interrupt at the initial sudo validation (the first password prompt) must
 # stop before the package transaction starts.
@@ -94,6 +103,10 @@ fi
 grep -q '^pacman ' "$call_log" && fail "pkg-install skips the pacman transaction when sudo validation is interrupted"
 grep -q '^done$' "$call_log" && fail "pkg-install does not report done when sudo validation is interrupted"
 pass "pkg-install aborts before the transaction when sudo validation is interrupted"
+# The user asked to bail at the password prompt and there is nothing to read,
+# so this path closes immediately instead of waiting for a keypress.
+grep -q '^error$' "$call_log" && fail "pkg-install closes without a keypress when sudo validation is interrupted"
+pass "pkg-install closes without a keypress when sudo validation is interrupted"
 
 # A successful yay run reports done and refreshes the file database.
 call_log="$TMPDIR/aur-calls-success"
@@ -111,6 +124,8 @@ fi
 { grep -q '^updatedb$' "$call_log" || grep -q '^done$' "$call_log"; } &&
   fail "pkg-aur-install skips done and updatedb on aborted install"
 pass "pkg-aur-install skips done and updatedb on aborted install"
+grep -q '^error$' "$call_log" || fail "pkg-aur-install holds the terminal open on a failed install"
+pass "pkg-aur-install holds the terminal open on a failed install"
 
 # The same initial sudo validation interrupt must stop the AUR flow before yay.
 call_log="$TMPDIR/aur-calls-sudo-abort"
@@ -120,3 +135,5 @@ fi
 grep -q '^yay ' "$call_log" && fail "pkg-aur-install skips the yay transaction when sudo validation is interrupted"
 grep -q '^done$' "$call_log" && fail "pkg-aur-install does not report done when sudo validation is interrupted"
 pass "pkg-aur-install aborts before the transaction when sudo validation is interrupted"
+grep -q '^error$' "$call_log" && fail "pkg-aur-install closes without a keypress when sudo validation is interrupted"
+pass "pkg-aur-install closes without a keypress when sudo validation is interrupted"

--- a/test/shell.d/pkg-install-abort-test.sh
+++ b/test/shell.d/pkg-install-abort-test.sh
@@ -89,8 +89,15 @@ PACMAN_RESULT=0 run_pkg_install || fail "pkg-install exits clean on successful i
 grep -q '^done$' "$call_log" || fail "pkg-install reports done on successful install"
 pass "pkg-install reports done on successful install"
 
-# An aborted or failed pacman run (Ctrl+C at the sudo prompt, declined auth,
-# package error) must not report done and must exit non-zero.
+# A pacman run that exits non-zero (dependency conflict, download failure, a
+# declined sudo password) must not report done and must exit non-zero.
+#
+# Ctrl+C during the transaction is a different path and is deliberately not
+# covered here: the tty sends SIGINT to the whole foreground process group, so
+# bash takes it alongside pacman and dies before reaching either branch below.
+# That already rules out a false done, and closing the window immediately is
+# what a deliberate abort should do, so there is nothing for the script to
+# handle. Stubbing an exit status cannot model signal delivery either way.
 call_log="$TMPDIR/calls-abort"
 if PACMAN_RESULT=130 run_pkg_install; then
   fail "pkg-install exits non-zero on aborted install"

--- a/test/shell.d/pkg-install-abort-test.sh
+++ b/test/shell.d/pkg-install-abort-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+case ${1:-} in
+  -v|-n) exit 0 ;;
+esac
+exec "$@"
+STUB
+
+cat >"$stub_bin/fzf" <<'STUB'
+#!/bin/bash
+echo testpkg
+STUB
+
+cat >"$stub_bin/omarchy-show-done" <<'STUB'
+#!/bin/bash
+echo done >>"${DONE_LOG:?}"
+STUB
+
+cat >"$stub_bin/updatedb" <<'STUB'
+#!/bin/bash
+echo updatedb >>"${DONE_LOG:?}"
+STUB
+
+cat >"$stub_bin/pacman" <<'STUB'
+#!/bin/bash
+if [[ $1 == "-Slq" ]]; then
+  echo testpkg
+  exit 0
+fi
+exit "${PACMAN_RESULT:-0}"
+STUB
+
+cat >"$stub_bin/yay" <<'STUB'
+#!/bin/bash
+if [[ $1 == "-Slqa" ]]; then
+  echo testpkg
+  exit 0
+fi
+exit "${YAY_RESULT:-0}"
+STUB
+
+chmod +x "$stub_bin"/*
+
+run_pkg_install() {
+  DONE_LOG="$done_log" PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$TMPDIR/home" \
+    bash "$ROOT/bin/omarchy-pkg-install" >/dev/null 2>&1
+}
+
+run_pkg_aur_install() {
+  DONE_LOG="$done_log" PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$TMPDIR/home" \
+    bash "$ROOT/bin/omarchy-pkg-aur-install" >/dev/null 2>&1
+}
+
+mkdir -p "$TMPDIR/home"
+
+# A successful pacman run still reports done.
+done_log="$TMPDIR/done-success"
+PACMAN_RESULT=0 run_pkg_install || fail "pkg-install exits clean on successful install"
+grep -q done "$done_log" || fail "pkg-install reports done on successful install"
+pass "pkg-install reports done on successful install"
+
+# An aborted or failed pacman run (Ctrl+C at the sudo prompt, declined auth,
+# package error) must not report done and must exit non-zero.
+done_log="$TMPDIR/done-abort"
+if PACMAN_RESULT=130 run_pkg_install; then
+  fail "pkg-install exits non-zero on aborted install"
+fi
+[[ ! -e $done_log ]] || fail "pkg-install does not report done on aborted install"
+pass "pkg-install does not report done on aborted install"
+
+# A successful yay run reports done and refreshes the file database.
+done_log="$TMPDIR/aur-done-success"
+YAY_RESULT=0 run_pkg_aur_install || fail "pkg-aur-install exits clean on successful install"
+grep -q done "$done_log" || fail "pkg-aur-install reports done on successful install"
+pass "pkg-aur-install reports done on successful install"
+grep -q updatedb "$done_log" || fail "pkg-aur-install refreshes file database on success"
+pass "pkg-aur-install refreshes file database on success"
+
+# An aborted yay run must skip both updatedb and the done notification.
+done_log="$TMPDIR/aur-done-abort"
+if YAY_RESULT=130 run_pkg_aur_install; then
+  fail "pkg-aur-install exits non-zero on aborted install"
+fi
+[[ ! -e $done_log ]] || fail "pkg-aur-install skips done and updatedb on aborted install"
+pass "pkg-aur-install skips done and updatedb on aborted install"


### PR DESCRIPTION
## Summary

Fixes #4869.

`omarchy-pkg-install` and `omarchy-pkg-aur-install` run the package transaction without `set -e` or any status check, so pressing Ctrl+C at the sudo password prompt — or any pacman/yay failure — falls through as if nothing happened: the `done` notification is shown, and the AUR flow additionally runs `sudo updatedb`.

## Change

Both scripts now check the transaction's exit status. On failure or interrupt they print an error to stderr and exit non-zero, skipping the `done` notification (and the AUR `updatedb` refresh). Successful installs behave exactly as before.

## Testing

Added `test/shell.d/pkg-install-abort-test.sh`, which stubs `pacman`/`yay`/`sudo`/`fzf` and asserts both the success and abort paths. The abort assertions fail against the current scripts and pass with this change; the full `./test/all` suite shows no regressions.