### PR TITLE
Make keyboard backlight steps consistent in both directions

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -12,8 +12,9 @@ fi
 direction="${1:-up}"
 
 # Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
+leds_class="${OMARCHY_LEDS_CLASS:-/sys/class/leds}"
 device=""
-for candidate in /sys/class/leds/*kbd_backlight*; do
+for candidate in "$leds_class"/*kbd_backlight*; do
   if [[ -e $candidate ]]; then
     device="$(basename "$candidate")"
     break
@@ -37,22 +38,39 @@ fi
 max_brightness="$(brightnessctl -d "$device" max)"
 current_brightness="$(brightnessctl -d "$device" get)"
 
-# Calculate step as 10% of max brightness. Keyboards with many levels (e.g. 512)
-# need larger steps; keyboards with few levels (e.g. 3) fall back to step=1.
-step=$(( max_brightness / 10 ))
-(( step < 1 )) && step=1
-
-if [[ $direction == "cycle" ]]; then
-  new_brightness=$(( current_brightness + step ))
-  (( new_brightness > max_brightness )) && new_brightness=0
-elif [[ $direction == "up" ]]; then
-  new_brightness=$(( current_brightness + step ))
-  (( new_brightness > max_brightness )) && new_brightness=$max_brightness
-else
-  new_brightness=$(( current_brightness - step ))
-  (( new_brightness < 0 )) && new_brightness=0
+if (( max_brightness < 1 )); then
+  echo "Invalid keyboard backlight max brightness" >&2
+  exit 1
 fi
 
-# Set the new brightness.
+# Walk a fixed ladder of steps so the same levels are hit going up and down.
+# Keyboards with many levels (e.g. 512) use 10% steps; keyboards with few
+# levels (e.g. 3) fall back to one step per level.
+steps=10
+(( steps > max_brightness )) && steps=$max_brightness
+
+# Snap the current brightness to the nearest rung so an arbitrary starting
+# value still lands on the ladder.
+current_step=$(( (current_brightness * steps + max_brightness / 2) / max_brightness ))
+(( current_step > steps )) && current_step=$steps
+
+if [[ $direction == "cycle" ]]; then
+  current_step=$(( (current_step + 1) % (steps + 1) ))
+elif [[ $direction == "up" ]]; then
+  if (( current_step < steps )); then
+    (( ++current_step ))
+  fi
+else
+  if (( current_step > 0 )); then
+    (( --current_step ))
+  fi
+fi
+
+# Convert the rung back to a raw brightness value, rounding to the nearest
+# level so the bottom rung is off and the top rung reaches max.
+new_brightness=$(( (current_step * max_brightness + steps / 2) / steps ))
+
+# Set the new brightness. Report the rung's percentage, which is stable in
+# both directions, rather than deriving it from the raw value.
 brightnessctl -d "$device" set "$new_brightness" >/dev/null
-(( no_osd )) || omarchy-osd -i keyboard -p "$(( new_brightness * 100 / max_brightness ))"
+(( no_osd )) || omarchy-osd -i keyboard -p "$(( current_step * 100 / steps ))"

--- a/test/shell.d/brightness-keyboard-test.sh
+++ b/test/shell.d/brightness-keyboard-test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+
+# Emulate a keyboard backlight device. The max and current values are injected
+# per case; every `set` writes the requested raw level to SET_LOG.
+cat >"$stub_bin/brightnessctl" <<'STUB'
+#!/bin/bash
+if [[ $* == *" max" ]]; then
+  printf '%s\n' "${KBD_MAX:-102}"
+elif [[ $* == *" get" ]]; then
+  printf '%s\n' "${KBD_CURRENT:-0}"
+elif [[ $* == *" set"* ]]; then
+  printf '%s\n' "${*: -1}" >>"${SET_LOG:?}"
+fi
+exit 0
+STUB
+
+cat >"$stub_bin/omarchy-osd" <<'STUB'
+#!/bin/bash
+while [[ $# -gt 0 ]]; do
+  if [[ $1 == "-p" ]]; then printf '%s\n' "$2" >>"${OSD_LOG:?}"; fi
+  shift
+done
+exit 0
+STUB
+
+chmod +x "$stub_bin"/*
+
+# A fixture leds class so device detection succeeds without real hardware.
+leds="$TMPDIR/leds"
+mkdir -p "$leds/input::kbd_backlight"
+
+set_log="$TMPDIR/set.log"
+osd_log="$TMPDIR/osd.log"
+
+run_kbd() {
+  : >"$set_log"
+  : >"$osd_log"
+  KBD_MAX="$max" KBD_CURRENT="$current" SET_LOG="$set_log" OSD_LOG="$osd_log" \
+    OMARCHY_LEDS_CLASS="$leds" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-brightness-keyboard" "$@" >/dev/null ||
+    fail "brightness-keyboard $* exits clean"
+}
+
+last_set() { tail -n 1 "$set_log"; }
+last_osd() { tail -n 1 "$osd_log"; }
+
+# A laptop with 102 raw levels (e.g. a MacBook) used to climb 0,9,19,29,... on
+# the way up but 100,90,80,...,1 on the way down. Both directions must now walk
+# the same fixed rungs.
+max=102
+
+current=0 run_kbd up
+[[ $(last_set) == "10" && $(last_osd) == "10" ]] ||
+  fail "up from off lands on the first rung" "set=$(last_set) osd=$(last_osd)"
+pass "up from off lands on the first rung"
+
+current=10 run_kbd up
+[[ $(last_set) == "20" && $(last_osd) == "20" ]] ||
+  fail "up climbs one fixed rung" "set=$(last_set) osd=$(last_osd)"
+pass "up climbs one fixed rung"
+
+current=92 run_kbd up
+[[ $(last_set) == "102" && $(last_osd) == "100" ]] ||
+  fail "up reaches full brightness at the top rung" "set=$(last_set) osd=$(last_osd)"
+pass "up reaches full brightness at the top rung"
+
+current=102 run_kbd down
+[[ $(last_set) == "92" && $(last_osd) == "90" ]] ||
+  fail "down from full lands on the rung below" "set=$(last_set) osd=$(last_osd)"
+pass "down from full lands on the rung below"
+
+current=92 run_kbd down
+[[ $(last_set) == "82" && $(last_osd) == "80" ]] ||
+  fail "down descends the same rungs as up" "set=$(last_set) osd=$(last_osd)"
+pass "down descends the same rungs as up"
+
+current=10 run_kbd down
+[[ $(last_set) == "0" && $(last_osd) == "0" ]] ||
+  fail "down reaches off at the bottom rung" "set=$(last_set) osd=$(last_osd)"
+pass "down reaches off at the bottom rung"
+
+# Up and down are inverses: a step up followed by a step down returns to the
+# starting level.
+current=51 run_kbd up
+up_level=$(last_set)
+current=$up_level run_kbd down
+[[ $(last_set) == "51" ]] ||
+  fail "up then down returns to the starting level" "up=$up_level down=$(last_set)"
+pass "up then down returns to the starting level"
+
+# Cycle wraps from full back to off, and from off up to the first rung.
+current=102 run_kbd cycle
+[[ $(last_set) == "0" && $(last_osd) == "0" ]] ||
+  fail "cycle wraps from full to off" "set=$(last_set) osd=$(last_osd)"
+pass "cycle wraps from full to off"
+
+current=0 run_kbd cycle
+[[ $(last_set) == "10" && $(last_osd) == "10" ]] ||
+  fail "cycle advances from off to the first rung" "set=$(last_set) osd=$(last_osd)"
+pass "cycle advances from off to the first rung"
+
+# A coarse keyboard with only 3 levels falls back to one step per level instead
+# of rounding everything away.
+max=3
+
+current=0 run_kbd up
+[[ $(last_set) == "1" && $(last_osd) == "33" ]] ||
+  fail "coarse keyboard steps one level at a time" "set=$(last_set) osd=$(last_osd)"
+pass "coarse keyboard steps one level at a time"
+
+current=3 run_kbd down
+[[ $(last_set) == "2" && $(last_osd) == "66" ]] ||
+  fail "coarse keyboard descends one level at a time" "set=$(last_set) osd=$(last_osd)"
+pass "coarse keyboard descends one level at a time"


### PR DESCRIPTION
## Summary

Fixes #5414.

On keyboards whose `max_brightness` is not a multiple of the step (e.g. 102 on a MacBook Air), adding and subtracting a fixed raw step walks *different* rungs in each direction. The reporter saw:

- up: `0, 9, 19, 29, 39, 49, 58, 68, 78, 88, 98, 100`
- down: `100, 90, 80, 70, 60, 50, 41, 31, 21, 11, 1, 0`

so the minimal level was only reachable by going to full brightness first and carefully stepping down, and the same key press produced a different level depending on direction.

## Change

`omarchy-brightness-keyboard` now walks a fixed ladder of step indices instead of adding/subtracting a raw value:

1. Snap the current brightness to the nearest rung (so an arbitrary starting value still lands on the ladder).
2. Move one rung for `up`/`down` (or advance-and-wrap for `cycle`).
3. Convert the rung back to a raw value with rounding, so the bottom rung is exactly off and the top rung reaches max.
4. Report the rung's percentage to the OSD, which is stable in both directions, instead of deriving it from the raw value (the old truncating `raw * 100 / max` is what made the readout drift).

Keyboards with fewer levels than steps (e.g. 3) fall back to one step per level, preserving the previous behavior there. Both directions now hit the same fixed levels, and 0 and 100 are exact endpoints.

A small `OMARCHY_LEDS_CLASS` seam (default `/sys/class/leds`) makes device detection testable, matching the existing `OMARCHY_*` override pattern used elsewhere in `bin/`.

## Testing

Added `test/shell.d/brightness-keyboard-test.sh`, which stubs `brightnessctl`/`omarchy-osd` and covers the 102-level and 3-level cases: symmetric up/down rungs, up-then-down round-trips, cycle wrap, and exact 0/100 endpoints. Full `./test/all` suite shows no regressions.

cc maintainers — happy to tune the number of steps (currently 10, i.e. 10% rungs) if you'd prefer a coarser or finer ladder.