### PR TITLE
Classify Turing MX GPUs as GSP-capable, not legacy no-GSP

### DIFF
--- a/bin/omarchy-hw-nvidia-gsp
+++ b/bin/omarchy-hw-nvidia-gsp
@@ -2,5 +2,5 @@
 
 # omarchy:summary=Detect whether the computer has an NVIDIA GPU with GSP firmware (Turing or newer).
 
-# GTX 16xx, RTX 20xx-50xx, RTX Pro, Quadro RTX, datacenter A/H/T/L series.
-lspci | grep -i 'nvidia' | grep -qE "GTX 16[0-9]{2}|RTX [2-5][0-9]{3}|RTX PRO [0-9]{4}|Quadro RTX|RTX A[0-9]{4}|A[1-9][0-9]{2}|H[1-9][0-9]{2}|T4|L[0-9]+"
+# GTX 16xx, RTX 20xx-50xx, RTX Pro, Quadro RTX, datacenter A/H/T/L series, Turing+ MX (MX 4xx+).
+lspci | grep -i 'nvidia' | grep -qE "GTX 16[0-9]{2}|RTX [2-5][0-9]{3}|RTX PRO [0-9]{4}|Quadro RTX|RTX A[0-9]{4}|A[1-9][0-9]{2}|H[1-9][0-9]{2}|T4|L[0-9]+|MX *[4-9][0-9]{2}"

--- a/bin/omarchy-hw-nvidia-without-gsp
+++ b/bin/omarchy-hw-nvidia-without-gsp
@@ -2,5 +2,5 @@
 
 # omarchy:summary=Detect whether the computer has an NVIDIA GPU without GSP firmware (Maxwell/Pascal/Volta).
 
-# GTX 9xx/10xx, GT 10xx, Quadro P/M/GV, MX series, Titan X/Xp/V, Tesla V100.
-lspci | grep -i 'nvidia' | grep -qE "GTX (9[0-9]{2}|10[0-9]{2})|GT 10[0-9]{2}|Quadro [PM][0-9]{3,4}|Quadro GV100|MX *[0-9]+|Titan (X|Xp|V)|Tesla V100"
+# GTX 9xx/10xx, GT 10xx, Quadro P/M/GV, pre-Turing MX (MX 1xx-3xx), Titan X/Xp/V, Tesla V100.
+lspci | grep -i 'nvidia' | grep -qE "GTX (9[0-9]{2}|10[0-9]{2})|GT 10[0-9]{2}|Quadro [PM][0-9]{3,4}|Quadro GV100|MX *[1-3][0-9]{2}|Titan (X|Xp|V)|Tesla V100"

--- a/test/shell.d/nvidia-gsp-test.sh
+++ b/test/shell.d/nvidia-gsp-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+
+# Stub lspci to emit a configurable line.
+cat >"$stub_bin/lspci" <<'STUB'
+#!/bin/bash
+printf '%s\n' "${LSPCI_OUTPUT:-}"
+STUB
+chmod +x "$stub_bin/lspci"
+
+run_gsp() {
+  LSPCI_OUTPUT="$1" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-hw-nvidia-gsp"
+}
+
+run_without_gsp() {
+  LSPCI_OUTPUT="$1" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-hw-nvidia-without-gsp"
+}
+
+assert_classified() {
+  local line="$1"
+  local expect_gsp="$2"
+  local expect_without="$3"
+
+  local gsp=1 without=1
+  run_gsp "$line" && gsp=0 || gsp=1
+  run_without_gsp "$line" && without=0 || without=1
+
+  (( gsp == expect_gsp )) ||
+    fail "GSP detection for '$line'" "expected exit $expect_gsp, got $gsp"
+  (( without == expect_without )) ||
+    fail "no-GSP detection for '$line'" "expected exit $expect_without, got $without"
+  pass "'$line' is $(if (( expect_gsp == 0 )); then echo GSP; elif (( expect_without == 0 )); then echo no-GSP; else echo neither; fi)"
+}
+
+nvidia="02:00.0 3D controller: NVIDIA Corporation"
+
+# --- Turing MX cards (TU117, same generation as GTX 16xx, have GSP firmware) ---
+assert_classified "$nvidia TU117M [GeForce MX550]" 0 1
+assert_classified "$nvidia TU117 [GeForce MX450]" 0 1
+assert_classified "$nvidia TU117 [GeForce MX570]" 0 1
+
+# --- Pre-Turing MX cards (Pascal GP108/GP107, no GSP firmware) ---
+assert_classified "$nvidia GP108 [GeForce MX150]" 1 0
+assert_classified "$nvidia GP108 [GeForce MX250]" 1 0
+assert_classified "$nvidia GP108 [GeForce MX350]" 1 0
+
+# --- Other Turing+ (already correctly classified by existing patterns) ---
+assert_classified "$nvidia TU106 [GeForce GTX 1650]" 0 1
+assert_classified "$nvidia AD104 [GeForce RTX 4070]" 0 1
+
+# --- Other pre-Turing (already correctly classified by existing patterns) ---
+assert_classified "$nvidia GM200 [GeForce GTX 970]" 1 0
+assert_classified "$nvidia GP104 [GeForce GTX 1080]" 1 0
+
+# --- Non-NVIDIA GPU is classified as neither ---
+assert_classified "00:02.0 VGA compatible controller: Intel Iris Xe Graphics" 1 1


### PR DESCRIPTION
## Summary

Fixes #6216.

`omarchy-hw-nvidia-without-gsp` matched `MX *[0-9]+` unconditionally, treating every MX-branded card as pre-Turing (no GSP firmware). But NVIDIA kept the MX name into the Turing generation: **MX450, MX550, MX570** are TU117 chips — same generation as GTX 16xx, which the GSP detector already matches.

On a laptop with an MX550, this caused:
1. `omarchy-hw-nvidia-gsp` to miss it (no MX pattern in the GSP regex)
2. `omarchy-hw-nvidia-without-gsp` to catch it instead
3. `omarchy-install-gaming-gpu-lib32` (invoked during Steam install) to install `lib32-nvidia-580xx-utils`, conflicting with the correctly-installed mainline `nvidia-utils`

## Change

Split the MX range at the Turing boundary:

- **`omarchy-hw-nvidia-without-gsp`**: `MX *[0-9]+` → `MX *[1-3][0-9]{2}` — only pre-Turing MX (MX 110–350, all Pascal).
- **`omarchy-hw-nvidia-gsp`**: added `MX *[4-9][0-9]{2}` — Turing+ MX (MX 450+).

All three consumers (the install-time driver picker in `install/hardware/nvidia.sh`, the lib32 gaming installer, and the per-session `nvidia.lua` env setup) use a GSP-first / without-GSP-fallback chain, so Turing MX cards now get the mainline `nvidia-utils` driver instead of falling through to 580xx.

## Testing

Added `test/shell.d/nvidia-gsp-test.sh` with stubbed `lspci` covering Turing MX (450/550/570 → GSP), Pascal MX (150/250/350 → no-GSP), existing Turing+ (GTX 1650, RTX 4070 → GSP), existing pre-Turing (GTX 970/1080 → no-GSP), and a non-NVIDIA line (neither). The MX550 assertion fails against the original scripts and passes with this change.