### PR TITLE
Add independent lock-on-idle and screen-off switches to the idle service

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -12,8 +12,10 @@ fi
 direction="${1:-up}"
 
 # Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
+# The root is overridable so the save/restore behaviour can be tested without hardware.
+leds_dir="${OMARCHY_LEDS_DIR:-/sys/class/leds}"
 device=""
-for candidate in /sys/class/leds/*kbd_backlight*; do
+for candidate in "$leds_dir"/*kbd_backlight*; do
   if [[ -e $candidate ]]; then
     device="$(basename "$candidate")"
     break
@@ -26,6 +28,12 @@ if [[ -z $device ]]; then
 fi
 
 if [[ $direction == "off" ]]; then
+  # brightnessctl keeps a single saved slot per device, so saving again while
+  # already off would make `restore` restore darkness. Two blanks can land in one
+  # idle period: the idle service's, and the lock screen's own.
+  if (( $(brightnessctl -d "$device" get) == 0 )); then
+    exit 0
+  fi
   brightnessctl -sd "$device" set 0 >/dev/null
   exit 0
 elif [[ $direction == "restore" ]]; then

--- a/bin/omarchy-config-idle
+++ b/bin/omarchy-config-idle
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Configure idle behavior: the screensaver and locking, each with its own switch and timeout
+# omarchy:summary=Configure idle behavior: the screensaver, locking, and turning the screens off, each with its own switch and timeout
 # omarchy:group=config
 # omarchy:name=idle
 
@@ -14,6 +14,12 @@
 # locking (the menu's Lock entry, SUPER+CTRL+L, lid close, pre-suspend locking) is
 # unaffected and always locks regardless of this setting.
 #
+# "Screens off" puts the displays (and the keyboard backlight) to sleep on idle,
+# independently of the screensaver and the lock. It is off by default. Locking
+# already turns the screens off, so with lock on idle enabled and a screens-off
+# timeout at or past the lock timeout the lock does the blanking -- the "On idle"
+# line spells out what will actually happen.
+#
 # The global idle on/off switch ("Stay Awake") is a separate, already-exposed toggle
 # (omarchy-toggle-idle / the Stay Awake menu entry) and is intentionally left alone here.
 
@@ -23,9 +29,11 @@ source omarchy-shell-config
 
 DEFAULT_SCREENSAVER_SECONDS=$(jq -r '.idle.screensaver // 150' "$DEFAULTS_FILE")
 DEFAULT_LOCK_SECONDS=$(jq -r '.idle.lock // 300' "$DEFAULTS_FILE")
+DEFAULT_SCREEN_OFF_SECONDS=$(jq -r '.idle.screenOff // 600' "$DEFAULTS_FILE")
 # Booleans never go through jq's `//`: it treats an explicit false the same as a
 # missing key and would turn every deliberate off back on.
 DEFAULT_LOCK_ON_IDLE=$(jq -r 'if .idle.lockOnIdle == false then false else true end' "$DEFAULTS_FILE")
+DEFAULT_SCREEN_OFF_ON_IDLE=$(jq -r 'if .idle.screenOffOnIdle == true then true else false end' "$DEFAULTS_FILE")
 
 current_screensaver_seconds() {
   jq -r --argjson d "$DEFAULT_SCREENSAVER_SECONDS" \
@@ -47,6 +55,18 @@ lock_on_idle_enabled() {
   jq -e '.idle.lockOnIdle != false' "$(source_file)" >/dev/null
 }
 
+current_screen_off_seconds() {
+  jq -r --argjson d "$DEFAULT_SCREEN_OFF_SECONDS" \
+    '(.idle.screenOff // $d) | if (type == "number" and . >= 0) then floor else $d end' \
+    "$(source_file)"
+}
+
+# Opt-in, so this is `== true` -- the mirror of lockOnIdle's `!= false`. Both
+# forms sidestep jq's `//`.
+screen_off_enabled() {
+  jq -e '.idle.screenOffOnIdle == true' "$(source_file)" >/dev/null
+}
+
 fmt_mins() { awk "BEGIN { printf \"%g\", $1 / 60 }"; }
 
 fmt_screensaver_enabled() {
@@ -57,13 +77,27 @@ fmt_lock_on_idle() {
   if lock_on_idle_enabled; then echo "on"; else echo "off"; fi
 }
 
-# Describes what the shell will actually do, in order.
+fmt_screen_off() {
+  if screen_off_enabled; then echo "on"; else echo "off"; fi
+}
+
+# Describes what the shell will actually do, in order. Locking turns the screens
+# off as part of locking, so a screens-off timeout at or past the lock timeout is
+# reported as happening with the lock rather than as a step of its own.
 idle_timeline() {
   local -a steps=()
-  local line="" step
+  local subsumed=0 line="" step
 
   if screensaver_enabled; then
     steps+=("$screensaver_seconds screensaver after $(fmt_mins "$screensaver_seconds") min")
+  fi
+
+  if screen_off_enabled; then
+    if lock_on_idle_enabled && ((screen_off_seconds >= lock_seconds)); then
+      subsumed=1
+    else
+      steps+=("$screen_off_seconds screens off after $(fmt_mins "$screen_off_seconds") min")
+    fi
   fi
 
   if lock_on_idle_enabled; then
@@ -80,6 +114,7 @@ idle_timeline() {
     line+="$step"
   done < <(printf '%s\n' "${steps[@]}" | sort -n -s | cut -d' ' -f2-)
 
+  if ((subsumed)); then line+=" (screens off with the lock)"; fi
   echo "$line"
 }
 
@@ -113,6 +148,19 @@ toggle_lock_on_idle() {
   fi
 }
 
+set_screen_off_seconds() {
+  commit "$NORMALIZE | .idle.screenOff = \$value" --argjson value "$1"
+}
+
+toggle_screen_off() {
+  commit "$NORMALIZE | .idle.screenOffOnIdle = (.idle.screenOffOnIdle != true)"
+  if screen_off_enabled; then
+    notify_status "Screens turn off on idle"
+  else
+    notify_status "Screens stay on when idle"
+  fi
+}
+
 choose_timeout() {
   local label="$1" current="$2" setter="$3"
   local choice secs
@@ -138,8 +186,9 @@ choose_timeout() {
 }
 
 restore_defaults() {
-  commit "$NORMALIZE | .idle.screensaver = \$s | .idle.lock = \$l | .idle.lockOnIdle = \$lk" \
-    --argjson s "$DEFAULT_SCREENSAVER_SECONDS" --argjson l "$DEFAULT_LOCK_SECONDS" --argjson lk "$DEFAULT_LOCK_ON_IDLE"
+  commit "$NORMALIZE | .idle.screensaver = \$s | .idle.lock = \$l | .idle.lockOnIdle = \$lk | .idle.screenOff = \$so | .idle.screenOffOnIdle = \$soi" \
+    --argjson s "$DEFAULT_SCREENSAVER_SECONDS" --argjson l "$DEFAULT_LOCK_SECONDS" --argjson lk "$DEFAULT_LOCK_ON_IDLE" \
+    --argjson so "$DEFAULT_SCREEN_OFF_SECONDS" --argjson soi "$DEFAULT_SCREEN_OFF_ON_IDLE"
   omarchy-toggle screensaver-off off
   notify_status "Restored default idle settings"
 }
@@ -148,6 +197,7 @@ while true; do
   clear
   screensaver_seconds=$(current_screensaver_seconds)
   lock_seconds=$(current_lock_seconds)
+  screen_off_seconds=$(current_screen_off_seconds)
 
   echo "Idle & screensaver settings"
   echo
@@ -159,6 +209,10 @@ while true; do
   if lock_on_idle_enabled; then
     echo "  Lock after  : ${lock_seconds}s ($(fmt_mins "$lock_seconds") min)"
   fi
+  echo "  Screens off : $(fmt_screen_off)"
+  if screen_off_enabled; then
+    echo "  Off after   : ${screen_off_seconds}s ($(fmt_mins "$screen_off_seconds") min)"
+  fi
   echo
   echo "  On idle     : $(idle_timeline)"
   echo
@@ -168,6 +222,7 @@ while true; do
   choice=$(gum choose --header "Edit:" \
     "Screensaver on/off" "Screensaver timeout" \
     "Lock on idle on/off" "Lock timeout" \
+    "Screens off on/off" "Screens off timeout" \
     "Restore Omarchy defaults" "Quit") || exit 0
 
   case $choice in
@@ -175,6 +230,8 @@ while true; do
   "Screensaver timeout") choose_timeout "Screensaver timeout" "$screensaver_seconds" set_screensaver_seconds ;;
   "Lock on idle on/off") toggle_lock_on_idle ;;
   "Lock timeout") choose_timeout "Lock timeout" "$lock_seconds" set_lock_seconds ;;
+  "Screens off on/off") toggle_screen_off ;;
+  "Screens off timeout") choose_timeout "Screens off timeout" "$screen_off_seconds" set_screen_off_seconds ;;
   "Restore Omarchy defaults")
     gum confirm "Restore the default Omarchy idle configuration?" && restore_defaults
     ;;

--- a/bin/omarchy-config-idle
+++ b/bin/omarchy-config-idle
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+# omarchy:summary=Configure idle behavior: the screensaver and locking, each with its own switch and timeout
+# omarchy:group=config
+# omarchy:name=idle
+
+# Interactive editor for the Omarchy shell's idle behavior (the `idle` key in
+# ~/.config/omarchy/shell.json). Every change is written through
+# omarchy-shell-config's commit(), which applies live via
+# `omarchy-shell shell reloadConfig` -- no restart needed. "Restore Omarchy defaults"
+# reverts to the shipped timeouts and re-enables the screensaver and lock-on-idle.
+#
+# Lock-on-idle only gates the automatic lock fired by the idle timeout. Explicit
+# locking (the menu's Lock entry, SUPER+CTRL+L, lid close, pre-suspend locking) is
+# unaffected and always locks regardless of this setting.
+#
+# The global idle on/off switch ("Stay Awake") is a separate, already-exposed toggle
+# (omarchy-toggle-idle / the Stay Awake menu entry) and is intentionally left alone here.
+
+set -euo pipefail
+
+source omarchy-shell-config
+
+DEFAULT_SCREENSAVER_SECONDS=$(jq -r '.idle.screensaver // 150' "$DEFAULTS_FILE")
+DEFAULT_LOCK_SECONDS=$(jq -r '.idle.lock // 300' "$DEFAULTS_FILE")
+# Booleans never go through jq's `//`: it treats an explicit false the same as a
+# missing key and would turn every deliberate off back on.
+DEFAULT_LOCK_ON_IDLE=$(jq -r 'if .idle.lockOnIdle == false then false else true end' "$DEFAULTS_FILE")
+
+current_screensaver_seconds() {
+  jq -r --argjson d "$DEFAULT_SCREENSAVER_SECONDS" \
+    '(.idle.screensaver // $d) | if (type == "number" and . >= 0) then floor else $d end' \
+    "$(source_file)"
+}
+
+current_lock_seconds() {
+  jq -r --argjson d "$DEFAULT_LOCK_SECONDS" \
+    '(.idle.lock // $d) | if (type == "number" and . >= 0) then floor else $d end' \
+    "$(source_file)"
+}
+
+screensaver_enabled() {
+  ! omarchy-toggle-enabled screensaver-off
+}
+
+lock_on_idle_enabled() {
+  jq -e '.idle.lockOnIdle != false' "$(source_file)" >/dev/null
+}
+
+fmt_mins() { awk "BEGIN { printf \"%g\", $1 / 60 }"; }
+
+fmt_screensaver_enabled() {
+  if screensaver_enabled; then echo "on"; else echo "off"; fi
+}
+
+fmt_lock_on_idle() {
+  if lock_on_idle_enabled; then echo "on"; else echo "off"; fi
+}
+
+# Describes what the shell will actually do, in order.
+idle_timeline() {
+  local -a steps=()
+  local line="" step
+
+  if screensaver_enabled; then
+    steps+=("$screensaver_seconds screensaver after $(fmt_mins "$screensaver_seconds") min")
+  fi
+
+  if lock_on_idle_enabled; then
+    steps+=("$lock_seconds lock after $(fmt_mins "$lock_seconds") min")
+  fi
+
+  if ((${#steps[@]} == 0)); then
+    echo "nothing happens on idle"
+    return
+  fi
+
+  while IFS= read -r step; do
+    if [[ -n $line ]]; then line+=" → "; fi
+    line+="$step"
+  done < <(printf '%s\n' "${steps[@]}" | sort -n -s | cut -d' ' -f2-)
+
+  echo "$line"
+}
+
+notify_status() {
+  omarchy-notification-send -g 󱄄 "$1" 2>/dev/null || true
+}
+
+set_screensaver_seconds() {
+  commit "$NORMALIZE | .idle.screensaver = \$value" --argjson value "$1"
+}
+
+set_lock_seconds() {
+  commit "$NORMALIZE | .idle.lock = \$value" --argjson value "$1"
+}
+
+toggle_screensaver() {
+  omarchy-toggle screensaver-off
+  if screensaver_enabled; then
+    notify_status "Screensaver enabled"
+  else
+    notify_status "Screensaver disabled"
+  fi
+}
+
+toggle_lock_on_idle() {
+  commit "$NORMALIZE | .idle.lockOnIdle = (.idle.lockOnIdle == false)"
+  if lock_on_idle_enabled; then
+    notify_status "Lock on idle enabled"
+  else
+    notify_status "Lock on idle disabled"
+  fi
+}
+
+choose_timeout() {
+  local label="$1" current="$2" setter="$3"
+  local choice secs
+  choice=$(gum choose --header "$label:" \
+    "1 minute" "2.5 minutes" "5 minutes" "10 minutes" "30 minutes" "Custom…") || return
+  case $choice in
+  "1 minute") secs=60 ;;
+  "2.5 minutes") secs=150 ;;
+  "5 minutes") secs=300 ;;
+  "10 minutes") secs=600 ;;
+  "30 minutes") secs=1800 ;;
+  "Custom…")
+    secs=$(gum input --header "$label in seconds (min 5):" --value "$current") || return
+    if [[ ! $secs =~ ^[0-9]+$ ]] || ((secs < 5)); then
+      echo "Invalid value."
+      sleep 1.5
+      return
+    fi
+    ;;
+  esac
+  "$setter" "$secs"
+  notify_status "$label set to ${secs}s"
+}
+
+restore_defaults() {
+  commit "$NORMALIZE | .idle.screensaver = \$s | .idle.lock = \$l | .idle.lockOnIdle = \$lk" \
+    --argjson s "$DEFAULT_SCREENSAVER_SECONDS" --argjson l "$DEFAULT_LOCK_SECONDS" --argjson lk "$DEFAULT_LOCK_ON_IDLE"
+  omarchy-toggle screensaver-off off
+  notify_status "Restored default idle settings"
+}
+
+while true; do
+  clear
+  screensaver_seconds=$(current_screensaver_seconds)
+  lock_seconds=$(current_lock_seconds)
+
+  echo "Idle & screensaver settings"
+  echo
+  echo "  Screensaver : $(fmt_screensaver_enabled)"
+  if screensaver_enabled; then
+    echo "  Show after  : ${screensaver_seconds}s ($(fmt_mins "$screensaver_seconds") min)"
+  fi
+  echo "  Lock on idle: $(fmt_lock_on_idle)"
+  if lock_on_idle_enabled; then
+    echo "  Lock after  : ${lock_seconds}s ($(fmt_mins "$lock_seconds") min)"
+  fi
+  echo
+  echo "  On idle     : $(idle_timeline)"
+  echo
+  echo "  Global idle on/off lives under Stay Awake (Setup → Stay Awake)."
+  echo
+
+  choice=$(gum choose --header "Edit:" \
+    "Screensaver on/off" "Screensaver timeout" \
+    "Lock on idle on/off" "Lock timeout" \
+    "Restore Omarchy defaults" "Quit") || exit 0
+
+  case $choice in
+  "Screensaver on/off") toggle_screensaver ;;
+  "Screensaver timeout") choose_timeout "Screensaver timeout" "$screensaver_seconds" set_screensaver_seconds ;;
+  "Lock on idle on/off") toggle_lock_on_idle ;;
+  "Lock timeout") choose_timeout "Lock timeout" "$lock_seconds" set_lock_seconds ;;
+  "Restore Omarchy defaults")
+    gum confirm "Restore the default Omarchy idle configuration?" && restore_defaults
+    ;;
+  "Quit")
+    exit 0
+    ;;
+  esac
+done

--- a/bin/omarchy-system-blank
+++ b/bin/omarchy-system-blank
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Turn off the displays and the keyboard backlight
+# omarchy:group=system
+# omarchy:name=blank
+# omarchy:examples=omarchy system blank
+
+# The inverse of omarchy-system-wake. Machines without a keyboard backlight fail
+# the first step; the display is the part that has to happen either way.
+omarchy-brightness-keyboard off
+omarchy-brightness-display off

--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,8 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "lockOnIdle": true
   },
   "bar": {
     "position": "top",

--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -3,7 +3,9 @@
   "idle": {
     "screensaver": 150,
     "lock": 300,
-    "lockOnIdle": true
+    "lockOnIdle": true,
+    "screenOff": 600,
+    "screenOffOnIdle": false
   },
   "bar": {
     "position": "top",

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -161,6 +161,7 @@
   "setup.security.passwordless-sudo": {"icon":"󰟵","label":"Passwordless Sudo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-sudo-passwordless"},
   "setup.config.hyprland": {"icon":"","label":"Hyprland","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/hyprland.lua\""},
   "setup.config.hyprsunset": {"icon":"","label":"Hyprsunset","action":"omarchy-launch-config-editor ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset"},
+  "setup.config.idle": {"icon":"󱄄","label":"Idle","action":"omarchy-launch-floating-terminal-with-presentation omarchy-config-idle"},
   "setup.config.xcompose": {"icon":"󰞅","label":"XCompose","action":"omarchy-launch-config-editor ~/.XCompose && omarchy-restart-xcompose"},
   "setup.plugin": {"icon":"󰐱","label":"Plugins","aliases":["plugin","plugins"]},
   "setup.plugin.enable": {"icon":"󰄬","label":"Enable Plugin","action":"omarchy-menu-plugin enable"},

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -368,7 +368,7 @@ Item {
 
   Process {
     id: blankProcess
-    command: ["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"]
+    command: ["bash", "-c", "omarchy-system-blank"]
   }
 
   Timer {

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -4,6 +4,50 @@ function secondsFromConfig(value, fallback) {
   return Math.floor(n)
 }
 
+// ext-idle-notify treats a zero timeout as "report idle immediately", so the
+// schedule never hands the monitor a zero. When nothing is armed there is no
+// deadline at all: `armed` is false and the caller stops the monitor. The parked
+// value keeps the returned timeout honest for anyone reading it in isolation.
+var PARKED_IDLE_TIMEOUT_SECONDS = 3600
+
+// Callers pass a timeout for every action the user left on and null for the
+// rest. The fallbacks have already been applied by secondsFromConfig, so
+// anything that is not a usable timeout here means "this action is off" rather
+// than "use the default".
+function armedSeconds(seconds) {
+  if (typeof seconds !== "number" || !isFinite(seconds) || seconds < 0) return null
+  return Math.floor(seconds)
+}
+
+function idleSchedule(screensaverSeconds, lockSeconds) {
+  var screensaver = armedSeconds(screensaverSeconds)
+  var lock = armedSeconds(lockSeconds)
+
+  var timeouts = [screensaver, lock]
+  var first = null
+  for (var i = 0; i < timeouts.length; i++) {
+    if (timeouts[i] === null) continue
+    if (first === null || timeouts[i] < first) first = timeouts[i]
+  }
+
+  var armed = first !== null
+  if (!armed) first = PARKED_IDLE_TIMEOUT_SECONDS
+  else if (first <= 0) first = 1
+
+  function delay(seconds) {
+    return seconds === null ? 0 : Math.max(0, seconds - first)
+  }
+
+  return {
+    armed: armed,
+    firstIdleTimeoutSeconds: first,
+    screensaverArmed: screensaver !== null,
+    lockArmed: lock !== null,
+    screensaverDelaySeconds: delay(screensaver),
+    lockDelaySeconds: delay(lock)
+  }
+}
+
 function eventParts(event, count) {
   try {
     if (event && event.parse) return event.parse(count)
@@ -46,6 +90,8 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
+    idleSchedule: idleSchedule,
+    PARKED_IDLE_TIMEOUT_SECONDS: PARKED_IDLE_TIMEOUT_SECONDS,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -19,11 +19,12 @@ function armedSeconds(seconds) {
   return Math.floor(seconds)
 }
 
-function idleSchedule(screensaverSeconds, lockSeconds) {
+function idleSchedule(screensaverSeconds, lockSeconds, screenOffSeconds) {
   var screensaver = armedSeconds(screensaverSeconds)
   var lock = armedSeconds(lockSeconds)
+  var screenOff = armedSeconds(screenOffSeconds)
 
-  var timeouts = [screensaver, lock]
+  var timeouts = [screensaver, lock, screenOff]
   var first = null
   for (var i = 0; i < timeouts.length; i++) {
     if (timeouts[i] === null) continue
@@ -43,8 +44,10 @@ function idleSchedule(screensaverSeconds, lockSeconds) {
     firstIdleTimeoutSeconds: first,
     screensaverArmed: screensaver !== null,
     lockArmed: lock !== null,
+    screenOffArmed: screenOff !== null,
     screensaverDelaySeconds: delay(screensaver),
-    lockDelaySeconds: delay(lock)
+    lockDelaySeconds: delay(lock),
+    screenOffDelaySeconds: delay(screenOff)
   }
 }
 

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -19,9 +19,23 @@ Item {
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
-  readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
-  readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
-  readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
+
+  // Locking on idle predates its switch, so it stays on unless turned off. An
+  // absent key and an explicit false must not read alike.
+  readonly property bool lockOnIdle: idleConfig.lockOnIdle !== false
+
+  // A disabled action is passed as null so it takes no part in the shared first
+  // idle deadline. The screensaver is always passed: its on/off switch is a state
+  // flag the shell cannot see (see bin/omarchy-launch-screensaver), so this switch
+  // is armed here even when the launcher will decline.
+  readonly property var idleSchedule: IdleModel.idleSchedule(
+    screensaverTimeoutSeconds,
+    lockOnIdle ? lockTimeoutSeconds : null)
+  readonly property bool idleArmed: idleSchedule.armed
+  readonly property int firstIdleTimeoutSeconds: idleSchedule.firstIdleTimeoutSeconds
+  readonly property int screensaverDelaySeconds: idleSchedule.screensaverDelaySeconds
+  readonly property int lockDelaySeconds: idleSchedule.lockDelaySeconds
+
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
@@ -85,7 +99,8 @@ Item {
       return
     }
 
-    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
+    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds
+      + " lock=" + (root.lockOnIdle ? root.lockTimeoutSeconds : "off"))
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
@@ -93,8 +108,10 @@ Item {
     if (root.screensaverDelaySeconds === 0) launchScreensaver()
     else screensaverTimer.restart()
 
-    if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
-    else lockTimer.restart()
+    if (root.lockOnIdle) {
+      if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
+      else lockTimer.restart()
+    }
   }
 
   function cancelIdleCycle(reason) {
@@ -186,8 +203,10 @@ Item {
       idle: idleMonitor.isIdle,
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
+      armed: root.idleArmed,
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,
+      lockOnIdle: root.lockOnIdle,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,
@@ -249,7 +268,9 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.idleEnabled
+    // A zero timeout means "report idle immediately" to ext-idle-notify, so when
+    // nothing is armed the monitor is stopped rather than handed a deadline.
+    enabled: root.idleEnabled && root.idleArmed
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
@@ -266,7 +287,21 @@ Item {
     id: lockTimer
     interval: root.lockDelaySeconds * 1000
     repeat: false
-    onTriggered: if (root.idleEnabled && root.idledThisCycle) root.lockSystem("lock-timeout")
+    onTriggered: if (root.lockOnIdle && root.idleEnabled && root.idledThisCycle) root.lockSystem("lock-timeout")
+  }
+
+  // A switch flipped mid-cycle applies to that cycle, not the next one. Turning
+  // lock-on-idle off disarms it; turning it back on arms it against the deadline
+  // the schedule already computed. A zero delay is deliberately not fired here: a
+  // config write means someone is at a keyboard, and locking under them would be
+  // rude.
+  onLockOnIdleChanged: {
+    if (!root.lockOnIdle) {
+      lockTimer.stop()
+      return
+    }
+    if (!root.idleEnabled || !root.idledThisCycle || lockTimer.running) return
+    if (root.lockDelaySeconds > 0) lockTimer.restart()
   }
 
   Timer {

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -16,13 +16,17 @@ Item {
   readonly property string stayAwakeStatePath: stayAwakeStateDir + "/stay-awake"
   readonly property int defaultScreensaverSeconds: 150
   readonly property int defaultLockSeconds: 300
+  readonly property int defaultScreenOffSeconds: 600
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
+  readonly property int screenOffTimeoutSeconds: secondsFromConfig(idleConfig.screenOff, defaultScreenOffSeconds)
 
-  // Locking on idle predates its switch, so it stays on unless turned off. An
-  // absent key and an explicit false must not read alike.
+  // Locking on idle predates its switch, so it stays on unless turned off.
+  // Turning the screens off is new, so it stays off until asked for. Both are
+  // compared explicitly: an absent key and an explicit false must not read alike.
   readonly property bool lockOnIdle: idleConfig.lockOnIdle !== false
+  readonly property bool screenOffOnIdle: idleConfig.screenOffOnIdle === true
 
   // A disabled action is passed as null so it takes no part in the shared first
   // idle deadline. The screensaver is always passed: its on/off switch is a state
@@ -30,11 +34,13 @@ Item {
   // is armed here even when the launcher will decline.
   readonly property var idleSchedule: IdleModel.idleSchedule(
     screensaverTimeoutSeconds,
-    lockOnIdle ? lockTimeoutSeconds : null)
+    lockOnIdle ? lockTimeoutSeconds : null,
+    screenOffOnIdle ? screenOffTimeoutSeconds : null)
   readonly property bool idleArmed: idleSchedule.armed
   readonly property int firstIdleTimeoutSeconds: idleSchedule.firstIdleTimeoutSeconds
   readonly property int screensaverDelaySeconds: idleSchedule.screensaverDelaySeconds
   readonly property int lockDelaySeconds: idleSchedule.lockDelaySeconds
+  readonly property int screenOffDelaySeconds: idleSchedule.screenOffDelaySeconds
 
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
@@ -45,6 +51,7 @@ Item {
   property bool pendingStayAwakePersist: false
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
+  property bool screenOffThisCycle: false
   property string lastEvent: "starting"
   property string lastEventAt: ""
   property var screensaverWindows: ({})
@@ -82,13 +89,43 @@ Item {
     runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
   }
 
+  // Unlike lockSystem(), this leaves screensaverTimer running: screen-off only
+  // disables DPMS output, it doesn't claim the screensaver's window surface the
+  // way the lock screen does, so the screensaver stays free to fire on its own
+  // configured deadline regardless of what the display is doing.
+  function turnOffScreens(reason) {
+    logEvent("screen-off", reason || "requested")
+    root.screenOffThisCycle = true
+    runProcess(screenOffProcess, "screen-off", "omarchy-system-blank")
+  }
+
+  // Turning the screens back on after activity that did not end the cycle. The
+  // clock starts over from the full timeout rather than resuming a spent offset:
+  // a screen that goes dark the instant you touch the mouse reads as broken.
+  function rearmScreenOff() {
+    root.screenOffThisCycle = false
+    screenOffTimer.stop()
+    runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    if (root.screenOffOnIdle) screenOffRearmTimer.restart()
+    logEvent("screen-off-wake", root.screenOffTimeoutSeconds + "s")
+  }
+
   function lockSystem(reason) {
     logEvent("lock-system", reason || "requested")
     screensaverTimer.stop()
     lockTimer.stop()
+    // Locking hands the display baton to the lock service, which owns it with a
+    // better policy. A surviving screen-off timer would otherwise fire while the
+    // user is typing their unlock password, uncancellably: lockSystem clears
+    // idledThisCycle and handleActiveSignal early-returns on it.
+    screenOffTimer.stop()
+    screenOffRearmTimer.stop()
     screensaverLaunchGraceTimer.stop()
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
+    // The lock service owns the displays from here, so this cycle's blank is no
+    // longer ours to report or re-arm.
+    root.screenOffThisCycle = false
     resetScreensaverWindows()
     runProcess(lockProcess, "lock", "omarchy-system-lock")
   }
@@ -100,13 +137,22 @@ Item {
     }
 
     logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds
-      + " lock=" + (root.lockOnIdle ? root.lockTimeoutSeconds : "off"))
+      + " lock=" + (root.lockOnIdle ? root.lockTimeoutSeconds : "off")
+      + " screenOff=" + (root.screenOffOnIdle ? root.screenOffTimeoutSeconds : "off"))
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
+    root.screenOffThisCycle = false
     resetScreensaverWindows()
 
     if (root.screensaverDelaySeconds === 0) launchScreensaver()
     else screensaverTimer.restart()
+
+    // Armed before the lock: lockSystem() stops every idle timer and a zero delay
+    // runs it inline, so anything started after it would outlive its own cycle.
+    if (root.screenOffOnIdle) {
+      if (root.screenOffDelaySeconds === 0) turnOffScreens("screen-off-immediate")
+      else screenOffTimer.restart()
+    }
 
     if (root.lockOnIdle) {
       if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
@@ -118,12 +164,15 @@ Item {
     logEvent("idle-cycle-cancel", reason || "requested")
     screensaverTimer.stop()
     lockTimer.stop()
+    screenOffTimer.stop()
+    screenOffRearmTimer.stop()
     screensaverLaunchGraceTimer.stop()
 
     if (root.idledThisCycle) runProcess(wakeProcess, "wake", "omarchy-system-wake")
 
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
+    root.screenOffThisCycle = false
     resetScreensaverWindows()
   }
 
@@ -179,6 +228,12 @@ Item {
     // launch grace); Hyprland window events cancel the cycle if it exits before
     // the normal lock deadline.
     if (root.screensaverStartedThisCycle && (root.screensaverWindowCount > 0 || screensaverLaunchGraceTimer.running)) {
+      // The screensaver keeps the cycle armed through the activity it provokes
+      // when it maps, so this branch is also where a real bump lands while the
+      // panels are asleep. Restore them and take a fresh run-up: leaving the
+      // displays dark for the rest of the cycle -- or lit, once the timer is
+      // spent -- is the failure this feature exists to prevent.
+      if (root.screenOffThisCycle) rearmScreenOff()
       logEvent("idle-monitor-active", "screensaver cycle remains armed")
       return
     }
@@ -207,17 +262,24 @@ Item {
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,
       lockOnIdle: root.lockOnIdle,
+      screenOff: root.screenOffTimeoutSeconds,
+      screenOffOnIdle: root.screenOffOnIdle,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
+      screenOffDelay: root.screenOffDelaySeconds,
+      screenOffActive: root.screenOffThisCycle,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
         screensaver: screensaverTimer.running,
         lock: lockTimer.running,
+        screenOff: screenOffTimer.running,
+        screenOffRearm: screenOffRearmTimer.running,
         screensaverLaunchGrace: screensaverLaunchGraceTimer.running
       },
       processes: {
         screensaver: screensaverProcess.running,
         lock: lockProcess.running,
+        screenOff: screenOffProcess.running,
         wake: wakeProcess.running
       },
       lastEvent: root.lastEvent,
@@ -284,6 +346,23 @@ Item {
   }
 
   Timer {
+    id: screenOffTimer
+    // The offset from the shared idle notification: the first blank of a cycle.
+    interval: root.screenOffDelaySeconds * 1000
+    repeat: false
+    onTriggered: if (root.screenOffOnIdle && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-timeout")
+  }
+
+  Timer {
+    id: screenOffRearmTimer
+    // The full timeout: after activity that did not end the cycle, the clock
+    // starts over rather than resuming a spent offset.
+    interval: root.screenOffTimeoutSeconds * 1000
+    repeat: false
+    onTriggered: if (root.screenOffOnIdle && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-rearmed")
+  }
+
+  Timer {
     id: lockTimer
     interval: root.lockDelaySeconds * 1000
     repeat: false
@@ -291,17 +370,31 @@ Item {
   }
 
   // A switch flipped mid-cycle applies to that cycle, not the next one. Turning
-  // lock-on-idle off disarms it; turning it back on arms it against the deadline
-  // the schedule already computed. A zero delay is deliberately not fired here: a
-  // config write means someone is at a keyboard, and locking under them would be
-  // rude.
-  onLockOnIdleChanged: {
-    if (!root.lockOnIdle) {
-      lockTimer.stop()
+  // an action off disarms it; turning it on arms it against the deadline the
+  // schedule already computed. A zero delay is deliberately not fired here: a
+  // config write means someone is at a keyboard, and locking or blanking under
+  // them would be rude.
+  function syncSwitchTimer(enabled, timer, delaySeconds) {
+    if (!enabled) {
+      timer.stop()
       return
     }
-    if (!root.idleEnabled || !root.idledThisCycle || lockTimer.running) return
-    if (root.lockDelaySeconds > 0) lockTimer.restart()
+    if (!root.idleEnabled || !root.idledThisCycle || timer.running) return
+    if (delaySeconds > 0) timer.restart()
+  }
+
+  onLockOnIdleChanged: syncSwitchTimer(root.lockOnIdle, lockTimer, root.lockDelaySeconds)
+
+  onScreenOffOnIdleChanged: {
+    syncSwitchTimer(root.screenOffOnIdle, screenOffTimer, root.screenOffDelaySeconds)
+    if (root.screenOffOnIdle) return
+    screenOffRearmTimer.stop()
+    // Turning the switch off while the panels are already asleep must not leave
+    // the user in front of a dark screen.
+    if (root.screenOffThisCycle) {
+      root.screenOffThisCycle = false
+      runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    }
   }
 
   Timer {
@@ -327,6 +420,10 @@ Item {
   Process {
     id: lockProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "lock exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+  Process {
+    id: screenOffProcess
+    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "screen-off exitCode=" + exitCode + " status=" + exitStatus) }
   }
   Process {
     id: wakeProcess

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -52,6 +52,7 @@ Item {
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
   property bool screenOffThisCycle: false
+  property bool wakeAfterBlankPending: false
   property string lastEvent: "starting"
   property string lastEventAt: ""
   property var screensaverWindows: ({})
@@ -99,13 +100,26 @@ Item {
     runProcess(screenOffProcess, "screen-off", "omarchy-system-blank")
   }
 
+  // Blank and wake are separate async processes with no ordering between them.
+  // If activity lands while omarchy-system-blank is still running, firing wake
+  // right away races it -- whichever exits last wins, so the blank can finish
+  // after the wake and leave the screens dark despite the cycle being over.
+  // Queue the wake for screenOffProcess's own onExited instead.
+  function wakeScreens() {
+    if (screenOffProcess.running) {
+      root.wakeAfterBlankPending = true
+      return
+    }
+    runProcess(wakeProcess, "wake", "omarchy-system-wake")
+  }
+
   // Turning the screens back on after activity that did not end the cycle. The
   // clock starts over from the full timeout rather than resuming a spent offset:
   // a screen that goes dark the instant you touch the mouse reads as broken.
   function rearmScreenOff() {
     root.screenOffThisCycle = false
     screenOffTimer.stop()
-    runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    wakeScreens()
     if (root.screenOffOnIdle) screenOffRearmTimer.restart()
     logEvent("screen-off-wake", root.screenOffTimeoutSeconds + "s")
   }
@@ -168,7 +182,7 @@ Item {
     screenOffRearmTimer.stop()
     screensaverLaunchGraceTimer.stop()
 
-    if (root.idledThisCycle) runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    if (root.idledThisCycle) wakeScreens()
 
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
@@ -268,6 +282,7 @@ Item {
       lockDelay: root.lockDelaySeconds,
       screenOffDelay: root.screenOffDelaySeconds,
       screenOffActive: root.screenOffThisCycle,
+      wakeAfterBlankPending: root.wakeAfterBlankPending,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
         screensaver: screensaverTimer.running,
@@ -393,7 +408,7 @@ Item {
     // the user in front of a dark screen.
     if (root.screenOffThisCycle) {
       root.screenOffThisCycle = false
-      runProcess(wakeProcess, "wake", "omarchy-system-wake")
+      wakeScreens()
     }
   }
 
@@ -423,7 +438,13 @@ Item {
   }
   Process {
     id: screenOffProcess
-    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "screen-off exitCode=" + exitCode + " status=" + exitStatus) }
+    onExited: function(exitCode, exitStatus) {
+      root.logEvent("process-exit", "screen-off exitCode=" + exitCode + " status=" + exitStatus)
+      if (root.wakeAfterBlankPending) {
+        root.wakeAfterBlankPending = false
+        root.runProcess(wakeProcess, "wake", "omarchy-system-wake")
+      }
+    }
   }
   Process {
     id: wakeProcess

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -288,6 +288,8 @@ Item {
       lockDelay: root.lockDelaySeconds,
       screenOffDelay: root.screenOffDelaySeconds,
       screenOffActive: root.screenOffThisCycle,
+      screenOffWatcherEnabled: screenOffActivityMonitor.enabled,
+      screenOffWatcherIdle: screenOffActivityMonitor.isIdle,
       wakeAfterBlankPending: root.wakeAfterBlankPending,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
@@ -357,6 +359,29 @@ Item {
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
+  }
+
+  IdleMonitor {
+    id: screenOffActivityMonitor
+    // ext-idle-notify only reports "resumed" on the way out of idle, and the
+    // screensaver's launch activity can spend the main monitor's transition
+    // (see handleActiveSignal) before a later blank. Real input after that
+    // blank would then go unseen until the main monitor re-idled, leaving the
+    // panels dark under a moving mouse. This watcher exists only while the
+    // screens are off -- the user is by definition idle, so it re-idles within
+    // a second and its own resumed edge relights them. Inhibitors are ignored:
+    // only raw input should wake a blanked display.
+    enabled: root.idleEnabled && root.screenOffThisCycle
+    timeout: 1
+    respectInhibitors: false
+    onIsIdleChanged: {
+      // Disabling a monitor resets isIdle to false and re-enters this handler,
+      // so every path that clears screenOffThisCycle or idleEnabled lands here
+      // before this runs: both are re-checked instead of trusting the binding.
+      if (isIdle || !root.idleEnabled || !root.screenOffThisCycle) return
+      root.logEvent("screen-off-activity", "input while screens are dark")
+      root.handleActiveSignal()
+    }
   }
 
   Timer {

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -64,7 +64,7 @@ Item {
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
   property bool screenOffThisCycle: false
-  property bool wakeAfterBlankPending: false
+  property string pendingDisplayState: ""
   property string pendingLockReason: ""
   property string lastEvent: "starting"
   property string lastEventAt: ""
@@ -110,31 +110,32 @@ Item {
   function turnOffScreens(reason) {
     logEvent("screen-off", reason || "requested")
     root.screenOffThisCycle = true
-    runProcess(screenOffProcess, "screen-off", "omarchy-system-blank")
+    root.pendingDisplayState = "blank"
+    flushDisplayState()
   }
 
-  // Blank and wake are separate async processes with no ordering between them.
-  // If activity lands while omarchy-system-blank is still running, firing wake
-  // right away races it -- whichever exits last wins, so the blank can finish
-  // after the wake and leave the screens dark despite the cycle being over.
-  // Record the request and let flushPendingWake() decide when it's safe to
-  // actually launch it.
   function wakeScreens() {
-    root.wakeAfterBlankPending = true
-    root.flushPendingWake()
+    root.pendingDisplayState = "wake"
+    flushDisplayState()
   }
 
-  // A pending wake can also fail to launch because wakeProcess itself is
-  // still finishing an earlier wake (reachable with the one-second rearm
-  // floor: a new blank can complete while the previous wake is still
-  // restoring the displays). The flag is only cleared once runProcess()
-  // actually starts it, so both screenOffProcess and wakeProcess retry this
-  // on exit instead of a busy launch silently dropping the request.
-  function flushPendingWake() {
-    if (!root.wakeAfterBlankPending) return
-    if (screenOffProcess.running) return
-    if (!runProcess(wakeProcess, "wake", "omarchy-system-wake")) return
-    root.wakeAfterBlankPending = false
+  // Blanking and waking are one resource seen from two sides: two async
+  // processes that must never overlap, because whichever exits last decides
+  // what the displays actually do. Launching either while the other is still
+  // running races it; refusing to launch drops the request entirely. So the
+  // wanted end state is recorded instead -- the newest request wins, since
+  // wanting the screens on then off (or the reverse) is not a queue to work
+  // through -- and it only clears once the process for it really started.
+  // Both processes flush on exit, so a request made while one was busy is
+  // retried rather than lost. Reachable with the one-second rearm floor: a
+  // reblank can come due while the previous wake is still restoring.
+  function flushDisplayState() {
+    if (!root.pendingDisplayState) return
+    if (screenOffProcess.running || wakeProcess.running) return
+    var started = root.pendingDisplayState === "blank"
+      ? runProcess(screenOffProcess, "screen-off", "omarchy-system-blank")
+      : runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    if (started) root.pendingDisplayState = ""
   }
 
   // Turning the screens back on after activity that did not end the cycle. The
@@ -167,7 +168,7 @@ Item {
     // lock, so this is reachable even outside the subsumed case above) must not
     // un-blank the lock screen once it exits.
     root.screenOffThisCycle = false
-    root.wakeAfterBlankPending = false
+    root.pendingDisplayState = ""
     resetScreensaverWindows()
     // The lock service starts its own, independent wake as soon as the user
     // interacts, with no way to know a blank from here is still in flight. If
@@ -187,6 +188,20 @@ Item {
     root.pendingLockReason = ""
     logEvent("lock-system-deferred", reason)
     runProcess(lockProcess, "lock", "omarchy-system-lock")
+  }
+
+  // Dropping a deferred lock takes the displays back from a lock service that
+  // never got them: lockSystem() disowned this cycle's screen-off and its
+  // wanted display state on the promise the lock would follow, and it also
+  // ended the cycle, so nothing else here is still watching. Without a wake
+  // the blank it is waiting on lands on screens with no lock in front of them
+  // and no armed cycle to notice. A lock is only ever deferred behind a
+  // running blank, so waking is always what is wanted.
+  function cancelPendingLock() {
+    if (!root.pendingLockReason) return
+    logEvent("lock-system-cancelled", root.pendingLockReason)
+    root.pendingLockReason = ""
+    wakeScreens()
   }
 
   function startIdleCycle() {
@@ -238,8 +253,10 @@ Item {
     // A lock deferred by lockSystem() (waiting on an in-flight screen-off
     // blank) is still just a decision, not yet a running process -- activity,
     // or Stay Awake turning on, cancels it like everything else here instead
-    // of locking anyway once the blank happens to finish.
-    root.pendingLockReason = ""
+    // of locking anyway once the blank happens to finish. The wake above is
+    // gated on idledThisCycle, which lockSystem() already cleared, so
+    // cancelling the lock has to take that wake back over.
+    cancelPendingLock()
     resetScreensaverWindows()
   }
 
@@ -337,7 +354,7 @@ Item {
       screenOffActive: root.screenOffThisCycle,
       screenOffWatcherEnabled: screenOffActivityMonitor.enabled,
       screenOffWatcherIdle: screenOffActivityMonitor.isIdle,
-      wakeAfterBlankPending: root.wakeAfterBlankPending,
+      pendingDisplayState: root.pendingDisplayState,
       pendingLockReason: root.pendingLockReason,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
@@ -415,18 +432,24 @@ Item {
     // screensaver's launch activity can spend the main monitor's transition
     // (see handleActiveSignal) before a later blank. Real input after that
     // blank would then go unseen until the main monitor re-idled, leaving the
-    // panels dark under a moving mouse. This watcher exists only while the
-    // screens are off -- the user is by definition idle, so it re-idles within
-    // a second and its own resumed edge relights them. Inhibitors are ignored:
-    // only raw input should wake a blanked display.
-    enabled: root.idleEnabled && root.screenOffThisCycle
+    // panels dark under a moving mouse. This watcher runs for the whole idle
+    // cycle rather than only while the screens are off: with a one-second
+    // timeout it needs a second of quiet to go idle before it has a resumed
+    // edge to give, and starting it at the blank would spend that second with
+    // the screens already dark, missing the input that lands inside it. The
+    // handler below stays gated on the screens actually being off, so the
+    // extra arming costs nothing. Inhibitors are ignored: only raw input
+    // should wake a blanked display.
+    enabled: root.idleEnabled && root.idledThisCycle
     timeout: 1
     respectInhibitors: false
     onIsIdleChanged: {
       // Disabling a monitor resets isIdle to false and re-enters this handler,
-      // so every path that clears screenOffThisCycle or idleEnabled lands here
-      // before this runs: both are re-checked instead of trusting the binding.
-      if (isIdle || !root.idleEnabled || !root.screenOffThisCycle) return
+      // and both cycle-ending paths drop idledThisCycle before this cycle's
+      // screen-off ownership, so that re-entry arrives while the blank still
+      // looks like ours. Every term is re-checked instead of trusting the
+      // binding, or ending a cycle would report input nobody gave.
+      if (isIdle || !root.idleEnabled || !root.idledThisCycle || !root.screenOffThisCycle) return
       root.logEvent("screen-off-activity", "input while screens are dark")
       root.handleActiveSignal()
     }
@@ -477,7 +500,18 @@ Item {
     if (delaySeconds > 0) timer.restart()
   }
 
-  onLockOnIdleChanged: syncSwitchTimer(root.lockOnIdle, lockTimer, root.lockDelaySeconds)
+  onLockOnIdleChanged: {
+    syncSwitchTimer(root.lockOnIdle, lockTimer, root.lockDelaySeconds)
+    // This switch also decides screenOffSubsumedByLock, so screen-off is
+    // resynced against the new verdict: turning the lock off un-subsumes a
+    // screen-off this cycle skipped, and turning it on leaves one armed that
+    // the lock now covers.
+    syncSwitchTimer(root.screenOffOnIdle && !root.screenOffSubsumedByLock, screenOffTimer, root.screenOffDelaySeconds)
+    if (root.lockOnIdle) return
+    // Only the idle timeout defers a lock, so turning that off cancels one
+    // still waiting behind a blank -- exactly like the timer above.
+    cancelPendingLock()
+  }
 
   // Lock is never subsumed by screen-off -- only screen-off can be subsumed by
   // lock (screenOffSubsumedByLock), since lock is the deadline being compared
@@ -522,7 +556,7 @@ Item {
     id: screenOffProcess
     onExited: function(exitCode, exitStatus) {
       root.logEvent("process-exit", "screen-off exitCode=" + exitCode + " status=" + exitStatus)
-      root.flushPendingWake()
+      root.flushDisplayState()
       root.flushPendingLock()
     }
   }
@@ -530,7 +564,7 @@ Item {
     id: wakeProcess
     onExited: function(exitCode, exitStatus) {
       root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus)
-      root.flushPendingWake()
+      root.flushDisplayState()
     }
   }
 

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -48,6 +48,12 @@ Item {
   readonly property int lockDelaySeconds: idleSchedule.lockDelaySeconds
   readonly property int screenOffDelaySeconds: idleSchedule.screenOffDelaySeconds
 
+  // Locking already blanks the screens through its own service. When the lock
+  // is due at or before this cycle's screen-off deadline, launching our own
+  // blank first would race the lock service's independent wake path with a
+  // process it doesn't know about -- the lock subsumes it, so skip it.
+  readonly property bool screenOffSubsumedByLock: root.lockOnIdle && root.screenOffDelaySeconds >= root.lockDelaySeconds
+
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
@@ -110,13 +116,24 @@ Item {
   // If activity lands while omarchy-system-blank is still running, firing wake
   // right away races it -- whichever exits last wins, so the blank can finish
   // after the wake and leave the screens dark despite the cycle being over.
-  // Queue the wake for screenOffProcess's own onExited instead.
+  // Record the request and let flushPendingWake() decide when it's safe to
+  // actually launch it.
   function wakeScreens() {
-    if (screenOffProcess.running) {
-      root.wakeAfterBlankPending = true
-      return
-    }
-    runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    root.wakeAfterBlankPending = true
+    root.flushPendingWake()
+  }
+
+  // A pending wake can also fail to launch because wakeProcess itself is
+  // still finishing an earlier wake (reachable with the one-second rearm
+  // floor: a new blank can complete while the previous wake is still
+  // restoring the displays). The flag is only cleared once runProcess()
+  // actually starts it, so both screenOffProcess and wakeProcess retry this
+  // on exit instead of a busy launch silently dropping the request.
+  function flushPendingWake() {
+    if (!root.wakeAfterBlankPending) return
+    if (screenOffProcess.running) return
+    if (!runProcess(wakeProcess, "wake", "omarchy-system-wake")) return
+    root.wakeAfterBlankPending = false
   }
 
   // Turning the screens back on after activity that did not end the cycle. The
@@ -144,8 +161,12 @@ Item {
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
     // The lock service owns the displays from here, so this cycle's blank is no
-    // longer ours to report or re-arm.
+    // longer ours to report, re-arm, or wake from -- a screen-off blank still
+    // finishing in the background (screen-off can legitimately fire before the
+    // lock, so this is reachable even outside the subsumed case above) must not
+    // un-blank the lock screen once it exits.
     root.screenOffThisCycle = false
+    root.wakeAfterBlankPending = false
     resetScreensaverWindows()
     runProcess(lockProcess, "lock", "omarchy-system-lock")
   }
@@ -169,7 +190,10 @@ Item {
 
     // Armed before the lock: lockSystem() stops every idle timer and a zero delay
     // runs it inline, so anything started after it would outlive its own cycle.
-    if (root.screenOffOnIdle) {
+    // Skipped entirely when the lock subsumes this deadline (see
+    // screenOffSubsumedByLock): racing our own blank against the lock
+    // service's independent wake path would be worse than doing nothing.
+    if (root.screenOffOnIdle && !root.screenOffSubsumedByLock) {
       if (root.screenOffDelaySeconds === 0) turnOffScreens("screen-off-immediate")
       else screenOffTimer.restart()
     }
@@ -396,7 +420,7 @@ Item {
     // The offset from the shared idle notification: the first blank of a cycle.
     interval: root.screenOffDelaySeconds * 1000
     repeat: false
-    onTriggered: if (root.screenOffOnIdle && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-timeout")
+    onTriggered: if (root.screenOffOnIdle && !root.screenOffSubsumedByLock && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-timeout")
   }
 
   Timer {
@@ -405,7 +429,7 @@ Item {
     // starts over rather than resuming a spent offset.
     interval: root.screenOffRearmSeconds * 1000
     repeat: false
-    onTriggered: if (root.screenOffOnIdle && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-rearmed")
+    onTriggered: if (root.screenOffOnIdle && !root.screenOffSubsumedByLock && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-rearmed")
   }
 
   Timer {
@@ -431,8 +455,11 @@ Item {
 
   onLockOnIdleChanged: syncSwitchTimer(root.lockOnIdle, lockTimer, root.lockDelaySeconds)
 
+  // Lock is never subsumed by screen-off -- only screen-off can be subsumed by
+  // lock (screenOffSubsumedByLock), since lock is the deadline being compared
+  // against.
   onScreenOffOnIdleChanged: {
-    syncSwitchTimer(root.screenOffOnIdle, screenOffTimer, root.screenOffDelaySeconds)
+    syncSwitchTimer(root.screenOffOnIdle && !root.screenOffSubsumedByLock, screenOffTimer, root.screenOffDelaySeconds)
     if (root.screenOffOnIdle) return
     screenOffRearmTimer.stop()
     // Turning the switch off while the panels are already asleep must not leave
@@ -471,15 +498,15 @@ Item {
     id: screenOffProcess
     onExited: function(exitCode, exitStatus) {
       root.logEvent("process-exit", "screen-off exitCode=" + exitCode + " status=" + exitStatus)
-      if (root.wakeAfterBlankPending) {
-        root.wakeAfterBlankPending = false
-        root.runProcess(wakeProcess, "wake", "omarchy-system-wake")
-      }
+      root.flushPendingWake()
     }
   }
   Process {
     id: wakeProcess
-    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus) }
+    onExited: function(exitCode, exitStatus) {
+      root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus)
+      root.flushPendingWake()
+    }
   }
 
   Process {

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -65,6 +65,7 @@ Item {
   property bool screensaverStartedThisCycle: false
   property bool screenOffThisCycle: false
   property bool wakeAfterBlankPending: false
+  property string pendingLockReason: ""
   property string lastEvent: "starting"
   property string lastEventAt: ""
   property var screensaverWindows: ({})
@@ -168,6 +169,23 @@ Item {
     root.screenOffThisCycle = false
     root.wakeAfterBlankPending = false
     resetScreensaverWindows()
+    // The lock service starts its own, independent wake as soon as the user
+    // interacts, with no way to know a blank from here is still in flight. If
+    // that wake finishes first, the stale blank disabling DPMS afterward would
+    // leave the unlock screen dark. Wait for it to actually exit before handing
+    // display ownership over, instead of racing the two.
+    if (screenOffProcess.running) {
+      root.pendingLockReason = reason || "requested"
+      return
+    }
+    runProcess(lockProcess, "lock", "omarchy-system-lock")
+  }
+
+  function flushPendingLock() {
+    if (!root.pendingLockReason) return
+    var reason = root.pendingLockReason
+    root.pendingLockReason = ""
+    logEvent("lock-system-deferred", reason)
     runProcess(lockProcess, "lock", "omarchy-system-lock")
   }
 
@@ -217,6 +235,11 @@ Item {
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
     root.screenOffThisCycle = false
+    // A lock deferred by lockSystem() (waiting on an in-flight screen-off
+    // blank) is still just a decision, not yet a running process -- activity,
+    // or Stay Awake turning on, cancels it like everything else here instead
+    // of locking anyway once the blank happens to finish.
+    root.pendingLockReason = ""
     resetScreensaverWindows()
   }
 
@@ -315,6 +338,7 @@ Item {
       screenOffWatcherEnabled: screenOffActivityMonitor.enabled,
       screenOffWatcherIdle: screenOffActivityMonitor.isIdle,
       wakeAfterBlankPending: root.wakeAfterBlankPending,
+      pendingLockReason: root.pendingLockReason,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
         screensaver: screensaverTimer.running,
@@ -499,6 +523,7 @@ Item {
     onExited: function(exitCode, exitStatus) {
       root.logEvent("process-exit", "screen-off exitCode=" + exitCode + " status=" + exitStatus)
       root.flushPendingWake()
+      root.flushPendingLock()
     }
   }
   Process {

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -63,6 +63,7 @@ Item {
   property bool pendingStayAwakePersist: false
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
+  property bool screensaverActivityExpected: false
   property bool screenOffThisCycle: false
   property string pendingDisplayState: ""
   property string pendingLockReason: ""
@@ -99,6 +100,9 @@ Item {
 
   function launchScreensaver() {
     root.screensaverStartedThisCycle = true
+    // Mapping the screensaver makes the compositor report activity; claim that
+    // one report here so handleActiveSignal can tell it from a real bump.
+    root.screensaverActivityExpected = true
     screensaverLaunchGraceTimer.restart()
     runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
   }
@@ -162,6 +166,7 @@ Item {
     screensaverLaunchGraceTimer.stop()
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
+    root.screensaverActivityExpected = false
     // The lock service owns the displays from here, so this cycle's blank is no
     // longer ours to report, re-arm, or wake from -- a screen-off blank still
     // finishing in the background (screen-off can legitimately fire before the
@@ -215,6 +220,7 @@ Item {
       + " screenOff=" + (root.screenOffOnIdle ? root.screenOffTimeoutSeconds : "off"))
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
+    root.screensaverActivityExpected = false
     root.screenOffThisCycle = false
     resetScreensaverWindows()
 
@@ -249,6 +255,7 @@ Item {
 
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
+    root.screensaverActivityExpected = false
     root.screenOffThisCycle = false
     // A lock deferred by lockSystem() (waiting on an in-flight screen-off
     // blank) is still just a decision, not yet a running process -- activity,
@@ -316,8 +323,12 @@ Item {
       // when it maps, so this branch is also where a real bump lands while the
       // panels are asleep. Restore them and take a fresh run-up: leaving the
       // displays dark for the rest of the cycle -- or lit, once the timer is
-      // spent -- is the failure this feature exists to prevent.
-      if (root.screenOffThisCycle) rearmScreenOff()
+      // spent -- is the failure this feature exists to prevent. The mapping
+      // itself is not a bump, though, and screen-off can be configured ahead
+      // of the screensaver: that report lands on already-dark panels, and
+      // relighting them for it would wake a screen nobody asked to wake.
+      if (root.screensaverActivityExpected) root.screensaverActivityExpected = false
+      else if (root.screenOffThisCycle) rearmScreenOff()
       logEvent("idle-monitor-active", "screensaver cycle remains armed")
       return
     }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -21,6 +21,12 @@ Item {
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
   readonly property int screenOffTimeoutSeconds: secondsFromConfig(idleConfig.screenOff, defaultScreenOffSeconds)
+  // screenOffTimeoutSeconds is a raw config value and can be 0 (the shared
+  // idleSchedule() clamps its own first-deadline math, but this timer sits
+  // outside that): a configured screenOff: 0 would otherwise make the rearm
+  // timer fire on every event-loop tick, blanking the display again the
+  // instant it wakes and leaving no way to keep it on.
+  readonly property int screenOffRearmSeconds: Math.max(1, screenOffTimeoutSeconds)
 
   // Locking on idle predates its switch, so it stays on unless turned off.
   // Turning the screens off is new, so it stays off until asked for. Both are
@@ -121,7 +127,7 @@ Item {
     screenOffTimer.stop()
     wakeScreens()
     if (root.screenOffOnIdle) screenOffRearmTimer.restart()
-    logEvent("screen-off-wake", root.screenOffTimeoutSeconds + "s")
+    logEvent("screen-off-wake", root.screenOffRearmSeconds + "s")
   }
 
   function lockSystem(reason) {
@@ -372,7 +378,7 @@ Item {
     id: screenOffRearmTimer
     // The full timeout: after activity that did not end the cycle, the clock
     // starts over rather than resuming a spent offset.
-    interval: root.screenOffTimeoutSeconds * 1000
+    interval: root.screenOffRearmSeconds * 1000
     repeat: false
     onTriggered: if (root.screenOffOnIdle && root.idleEnabled && root.idledThisCycle) root.turnOffScreens("screen-off-rearmed")
   }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -37,7 +37,8 @@ ShellRoot {
     version: 1,
     idle: {
       screensaver: 150,
-      lock: 300
+      lock: 300,
+      lockOnIdle: true
     },
     bar: {
       position: "top",

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -38,7 +38,9 @@ ShellRoot {
     idle: {
       screensaver: 150,
       lock: 300,
-      lockOnIdle: true
+      lockOnIdle: true,
+      screenOff: 600,
+      screenOffOnIdle: false
     },
     bar: {
       position: "top",

--- a/test/shell.d/brightness-keyboard-test.sh
+++ b/test/shell.d/brightness-keyboard-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/calls"
+leds="$test_tmp/leds/tpacpi::kbd_backlight"
+mkdir -p "$mock_bin" "$leds"
+
+# brightnessctl keeps one save slot per device: blanking twice without an
+# intervening restore would make `restore` restore darkness.
+cat >"$mock_bin/brightnessctl" <<'SH'
+#!/bin/bash
+printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
+if [[ $* == *" get"* ]]; then printf '%s\n' "${KBD_BRIGHTNESS:-0}"; fi
+exit 0
+SH
+chmod +x "$mock_bin/brightnessctl"
+
+run_kbd() {
+  CALL_LOG="$call_log" OMARCHY_LEDS_DIR="$test_tmp/leds" PATH="$mock_bin:$PATH" \
+    "$ROOT/bin/omarchy-brightness-keyboard" "$@"
+}
+
+KBD_BRIGHTNESS=500 run_kbd off
+grep -q -- '-sd' "$call_log" || fail "a lit keyboard backlight is saved before being turned off"
+
+: >"$call_log"
+KBD_BRIGHTNESS=0 run_kbd off
+if grep -q -- '-sd' "$call_log"; then
+  fail "an already-off keyboard backlight is not saved again"
+fi
+pass "keyboard backlight off is idempotent and never overwrites the saved state"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,65 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assertDeepEqual(
+  idle.idleSchedule(150, 300),
+  { armed: true, firstIdleTimeoutSeconds: 150,
+    screensaverArmed: true, lockArmed: true,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 150 },
+  'idleSchedule matches previous inline math for default timeouts'
+)
+assertDeepEqual(
+  idle.idleSchedule(600, 60),
+  { armed: true, firstIdleTimeoutSeconds: 60,
+    screensaverArmed: true, lockArmed: true,
+    screensaverDelaySeconds: 540, lockDelaySeconds: 0 },
+  'idleSchedule handles lock shorter than screensaver'
+)
+assertDeepEqual(
+  idle.idleSchedule(150, null),
+  { armed: true, firstIdleTimeoutSeconds: 150,
+    screensaverArmed: true, lockArmed: false,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 0 },
+  'idleSchedule keeps the screensaver on with locking disabled'
+)
+assertDeepEqual(
+  idle.idleSchedule(null, null),
+  { armed: false, firstIdleTimeoutSeconds: idle.PARKED_IDLE_TIMEOUT_SECONDS,
+    screensaverArmed: false, lockArmed: false,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 0 },
+  'idleSchedule parks the monitor instead of asking for a zero idle timeout'
+)
+// A zero timeout means "report idle immediately" to ext-idle-notify, so the
+// schedule must never produce one, and the caller stops the monitor when nothing
+// is armed.
+assertEqual(idle.PARKED_IDLE_TIMEOUT_SECONDS > 0, true,
+  'idleSchedule parks at a positive idle timeout')
+assertDeepEqual(
+  idle.idleSchedule(150, -1),
+  { armed: true, firstIdleTimeoutSeconds: 150,
+    screensaverArmed: true, lockArmed: false,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 0 },
+  'idleSchedule drops a nonsense timeout instead of poisoning the schedule'
+)
+assertDeepEqual(
+  idle.idleSchedule(0, 300),
+  { armed: true, firstIdleTimeoutSeconds: 1,
+    screensaverArmed: true, lockArmed: true,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 299 },
+  'idleSchedule clamps a configured zero timeout instead of reporting idle immediately'
+)
+
+// One aggregate sweep rather than one `ok -` line per combination.
+var values = [null, 0, 60, 300, 900]
+var sane = true
+for (var a = 0; a < values.length; a++)
+  for (var b = 0; b < values.length; b++) {
+    var s = idle.idleSchedule(values[a], values[b])
+    if (s.firstIdleTimeoutSeconds < 0 || s.screensaverDelaySeconds < 0 ||
+        s.lockDelaySeconds < 0 || (s.armed && s.firstIdleTimeoutSeconds <= 0)) sane = false
+  }
+assertEqual(sane, true, 'idleSchedule never produces a negative or zero timer interval while armed')
 JS
 
 test_tmp=$(mktemp -d)
@@ -52,3 +111,12 @@ if rg -q 'omarchy-shell' "$ROOT/bin/omarchy-toggle-idle"; then
 fi
 
 pass "Stay Awake toggle persists state without reentrant shell IPC"
+
+lock_on_idle_config="$test_tmp/lock-on-idle-shell.json"
+printf '{"idle":{"screensaver":150,"lock":300,"lockOnIdle":false}}' >"$lock_on_idle_config"
+
+if jq -e '.idle.lockOnIdle != false' "$lock_on_idle_config" >/dev/null; then
+  fail "lockOnIdle=false must be read as disabled via != false, not // true"
+fi
+
+pass "lockOnIdle=false reads as disabled (guards against the jq // false pitfall)"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -37,29 +37,50 @@ assertDeepEqual(
 assertDeepEqual(
   idle.idleSchedule(150, 300),
   { armed: true, firstIdleTimeoutSeconds: 150,
-    screensaverArmed: true, lockArmed: true,
-    screensaverDelaySeconds: 0, lockDelaySeconds: 150 },
+    screensaverArmed: true, lockArmed: true, screenOffArmed: false,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 150, screenOffDelaySeconds: 0 },
   'idleSchedule matches previous inline math for default timeouts'
 )
 assertDeepEqual(
   idle.idleSchedule(600, 60),
   { armed: true, firstIdleTimeoutSeconds: 60,
-    screensaverArmed: true, lockArmed: true,
-    screensaverDelaySeconds: 540, lockDelaySeconds: 0 },
+    screensaverArmed: true, lockArmed: true, screenOffArmed: false,
+    screensaverDelaySeconds: 540, lockDelaySeconds: 0, screenOffDelaySeconds: 0 },
   'idleSchedule handles lock shorter than screensaver'
 )
 assertDeepEqual(
-  idle.idleSchedule(150, null),
+  idle.idleSchedule(150, 300, 600),
   { armed: true, firstIdleTimeoutSeconds: 150,
-    screensaverArmed: true, lockArmed: false,
-    screensaverDelaySeconds: 0, lockDelaySeconds: 0 },
-  'idleSchedule keeps the screensaver on with locking disabled'
+    screensaverArmed: true, lockArmed: true, screenOffArmed: true,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 150, screenOffDelaySeconds: 450 },
+  'idleSchedule schedules the screens off after the lock on the shipped ladder'
 )
 assertDeepEqual(
-  idle.idleSchedule(null, null),
+  idle.idleSchedule(150, null, 300),
+  { armed: true, firstIdleTimeoutSeconds: 150,
+    screensaverArmed: true, lockArmed: false, screenOffArmed: true,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 0, screenOffDelaySeconds: 150 },
+  'idleSchedule turns the screens off on idle with locking disabled'
+)
+assertDeepEqual(
+  idle.idleSchedule(600, null, 300),
+  { armed: true, firstIdleTimeoutSeconds: 300,
+    screensaverArmed: true, lockArmed: false, screenOffArmed: true,
+    screensaverDelaySeconds: 300, lockDelaySeconds: 0, screenOffDelaySeconds: 0 },
+  'idleSchedule takes the first idle deadline from armed actions only'
+)
+assertDeepEqual(
+  idle.idleSchedule(150, 300, 60),
+  { armed: true, firstIdleTimeoutSeconds: 60,
+    screensaverArmed: true, lockArmed: true, screenOffArmed: true,
+    screensaverDelaySeconds: 90, lockDelaySeconds: 240, screenOffDelaySeconds: 0 },
+  'idleSchedule allows the screens off before the screensaver'
+)
+assertDeepEqual(
+  idle.idleSchedule(null, null, null),
   { armed: false, firstIdleTimeoutSeconds: idle.PARKED_IDLE_TIMEOUT_SECONDS,
-    screensaverArmed: false, lockArmed: false,
-    screensaverDelaySeconds: 0, lockDelaySeconds: 0 },
+    screensaverArmed: false, lockArmed: false, screenOffArmed: false,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 0, screenOffDelaySeconds: 0 },
   'idleSchedule parks the monitor instead of asking for a zero idle timeout'
 )
 // A zero timeout means "report idle immediately" to ext-idle-notify, so the
@@ -68,17 +89,17 @@ assertDeepEqual(
 assertEqual(idle.PARKED_IDLE_TIMEOUT_SECONDS > 0, true,
   'idleSchedule parks at a positive idle timeout')
 assertDeepEqual(
-  idle.idleSchedule(150, -1),
+  idle.idleSchedule(150, -1, 300),
   { armed: true, firstIdleTimeoutSeconds: 150,
-    screensaverArmed: true, lockArmed: false,
-    screensaverDelaySeconds: 0, lockDelaySeconds: 0 },
+    screensaverArmed: true, lockArmed: false, screenOffArmed: true,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 0, screenOffDelaySeconds: 150 },
   'idleSchedule drops a nonsense timeout instead of poisoning the schedule'
 )
 assertDeepEqual(
-  idle.idleSchedule(0, 300),
+  idle.idleSchedule(0, 300, 600),
   { armed: true, firstIdleTimeoutSeconds: 1,
-    screensaverArmed: true, lockArmed: true,
-    screensaverDelaySeconds: 0, lockDelaySeconds: 299 },
+    screensaverArmed: true, lockArmed: true, screenOffArmed: true,
+    screensaverDelaySeconds: 0, lockDelaySeconds: 299, screenOffDelaySeconds: 599 },
   'idleSchedule clamps a configured zero timeout instead of reporting idle immediately'
 )
 
@@ -86,11 +107,13 @@ assertDeepEqual(
 var values = [null, 0, 60, 300, 900]
 var sane = true
 for (var a = 0; a < values.length; a++)
-  for (var b = 0; b < values.length; b++) {
-    var s = idle.idleSchedule(values[a], values[b])
-    if (s.firstIdleTimeoutSeconds < 0 || s.screensaverDelaySeconds < 0 ||
-        s.lockDelaySeconds < 0 || (s.armed && s.firstIdleTimeoutSeconds <= 0)) sane = false
-  }
+  for (var b = 0; b < values.length; b++)
+    for (var c = 0; c < values.length; c++) {
+      var s = idle.idleSchedule(values[a], values[b], values[c])
+      if (s.firstIdleTimeoutSeconds < 0 || s.screensaverDelaySeconds < 0 ||
+          s.lockDelaySeconds < 0 || s.screenOffDelaySeconds < 0 ||
+          (s.armed && s.firstIdleTimeoutSeconds <= 0)) sane = false
+    }
 assertEqual(sane, true, 'idleSchedule never produces a negative or zero timer interval while armed')
 JS
 
@@ -120,3 +143,46 @@ if jq -e '.idle.lockOnIdle != false' "$lock_on_idle_config" >/dev/null; then
 fi
 
 pass "lockOnIdle=false reads as disabled (guards against the jq // false pitfall)"
+
+# Opt-in direction: the mirror of the lockOnIdle test above.
+screen_off_config="$test_tmp/screen-off-shell.json"
+printf '{"idle":{"screenOff":600}}' >"$screen_off_config"
+if jq -e '.idle.screenOffOnIdle == true' "$screen_off_config" >/dev/null; then
+  fail "screenOffOnIdle is disabled when the key is absent"
+fi
+printf '{"idle":{"screenOff":600,"screenOffOnIdle":true}}' >"$screen_off_config"
+jq -e '.idle.screenOffOnIdle == true' "$screen_off_config" >/dev/null ||
+  fail "screenOffOnIdle=true reads as enabled"
+pass "screenOffOnIdle is opt-in and read with == true (guards the jq // false pitfall)"
+
+# The TUI's seconds reader, against the real expression.
+so_read() { jq -r --argjson d 600 '(.idle.screenOff // $d) | if (type == "number" and . >= 0) then floor else $d end' "$1"; }
+printf '{"idle":{}}' >"$screen_off_config"
+[[ $(so_read "$screen_off_config") == 600 ]] || fail "absent screenOff falls back to the default"
+printf '{"idle":{"screenOff":"abc"}}' >"$screen_off_config"
+[[ $(so_read "$screen_off_config") == 600 ]] || fail "invalid screenOff falls back to the default"
+printf '{"idle":{"screenOff":42.9}}' >"$screen_off_config"
+[[ $(so_read "$screen_off_config") == 42 ]] || fail "screenOff is floored"
+pass "screens-off timeout reader floors and falls back like the other timeouts"
+
+# lockSystem() stops every idle timer, so anything armed after it would outlive
+# its own cycle. This is a source-order proxy for that guarantee, not a runtime
+# check -- there's no headless way to drive startIdleCycle() from this suite.
+service="$ROOT/shell/plugins/services/idle/Service.qml"
+screen_off_line=$(rg -n 'if \(root\.screenOffOnIdle\) \{' "$service" | head -1 | cut -d: -f1)
+lock_line=$(rg -n 'if \(root\.lockOnIdle\) \{' "$service" | head -1 | cut -d: -f1)
+((screen_off_line < lock_line)) || fail "screen-off is armed before the lock in startIdleCycle"
+pass "screen-off is armed before the lock in startIdleCycle"
+
+# The shipped defaults keep the new action opt-in, and out of the lock's way.
+jq -e '.idle.screenOffOnIdle == false and .idle.screenOff > .idle.lock' \
+  "$ROOT/config/omarchy/shell.json" >/dev/null ||
+  fail "shipped defaults keep screens-off opt-in and scheduled after the lock"
+pass "shipped defaults keep screens-off opt-in and scheduled after the lock"
+
+# One definition of blanking.
+rg -q 'omarchy-system-blank' "$service" || fail "the idle service blanks through omarchy-system-blank"
+if rg -q 'hyprctl' "$service"; then
+  fail "the idle service does not dispatch hyprctl directly"
+fi
+pass "the idle service blanks through omarchy-system-blank"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -186,3 +186,26 @@ if rg -q 'hyprctl' "$service"; then
   fail "the idle service does not dispatch hyprctl directly"
 fi
 pass "the idle service blanks through omarchy-system-blank"
+
+# Blank and wake are separate async processes; firing wake while a blank is
+# still in flight races it and can leave the screens dark. wakeScreens() must
+# check screenOffProcess.running and defer to its onExited instead of every
+# caller firing the wake process directly. This is a source-level check for
+# that shape, not a runtime one -- there's no headless way to race two
+# Process launches from this suite.
+rg -q 'function wakeScreens\(\)' "$service" || fail "wakeScreens() must exist to serialize blank and wake"
+rg -A3 'function wakeScreens\(\)' "$service" | rg -q 'screenOffProcess\.running' ||
+  fail "wakeScreens() must check screenOffProcess.running before firing a wake"
+
+wake_call_sites=$(rg -c '\bwakeScreens\(\)' "$service")
+((wake_call_sites >= 3)) ||
+  fail "rearmScreenOff, cancelIdleCycle, and the screen-off switch handler must all wake through wakeScreens()"
+
+rg -A5 'id: screenOffProcess' "$service" | rg -q 'wakeAfterBlankPending' ||
+  fail "screenOffProcess.onExited must fire a wake deferred during blanking"
+
+direct_wake_calls=$(rg -c 'runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)' "$service")
+((direct_wake_calls == 2)) ||
+  fail "omarchy-system-wake should only be launched from wakeScreens() and screenOffProcess.onExited"
+
+pass "a wake requested while blanking is in flight is deferred until the blank exits"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -187,37 +187,34 @@ if rg -q 'hyprctl' "$service"; then
 fi
 pass "the idle service blanks through omarchy-system-blank"
 
-# Blank and wake are separate async processes; firing wake while a blank is
-# still in flight races it and can leave the screens dark. A pending wake can
-# also fail to launch because wakeProcess itself is still finishing an
-# earlier wake -- reachable with the one-second rearm floor. flushPendingWake()
-# must only clear the pending flag once the wake process actually launches,
-# and both process exits must retry it, so a wake requested while busy is
-# never silently dropped. This is a source-level check for that shape, not a
-# runtime one -- there's no headless way to race two Process launches from
-# this suite.
-rg -q 'function wakeScreens\(\)' "$service" || fail "wakeScreens() must exist to record a wake request"
-rg -q 'function flushPendingWake\(\)' "$service" ||
-  fail "flushPendingWake() must exist to retry a wake request once whatever was busy exits"
-rg -A4 'function flushPendingWake\(\)' "$service" | rg -q 'screenOffProcess\.running' ||
-  fail "flushPendingWake() must not launch a wake while a blank is still running"
-rg -A4 'function flushPendingWake\(\)' "$service" | rg -q 'if \(!runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)\) return' ||
-  fail "flushPendingWake() must only clear the pending flag once the wake process actually launches"
-
-wake_call_sites=$(rg -c '\bwakeScreens\(\)' "$service")
-((wake_call_sites == 4)) ||
-  fail "rearmScreenOff, cancelIdleCycle, and the screen-off switch handler must all wake through wakeScreens()"
-
-for process_id in screenOffProcess wakeProcess; do
-  rg -A4 "id: $process_id" "$service" | rg -q 'root\.flushPendingWake\(\)' ||
-    fail "$process_id.onExited must retry a pending wake"
+# Blanking and waking are two async processes over one resource: whichever
+# exits last decides what the displays do, so launching either while the other
+# runs races it, and refusing to launch drops the request. Both directions are
+# reachable with the one-second rearm floor. Neither process may be launched
+# outside the serializer, the serializer must wait on BOTH of them, and the
+# wanted state may only clear once its process actually started -- with both
+# exits flushing, so nothing is silently lost. Source-level checks for that
+# shape; there is no headless way to race two Process launches from this suite.
+for helper in turnOffScreens wakeScreens flushDisplayState; do
+  rg -q "function $helper\(" "$service" || fail "$helper() must exist"
 done
 
-direct_wake_calls=$(rg -c 'runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)' "$service")
-((direct_wake_calls == 1)) ||
-  fail "omarchy-system-wake should only be launched from inside flushPendingWake()"
+rg -A6 'function flushDisplayState\(\)' "$service" | rg -q 'if \(screenOffProcess\.running \|\| wakeProcess\.running\) return' ||
+  fail "flushDisplayState() must wait for both the blank and the wake process, not just one"
+rg -A6 'function flushDisplayState\(\)' "$service" | rg -q 'if \(started\) root\.pendingDisplayState = ""' ||
+  fail "flushDisplayState() must only clear the wanted state once its process actually launched"
 
-pass "a wake requested while blanking or a previous wake is in flight is retried until it launches"
+for launch in 'runProcess\(screenOffProcess, "screen-off", "omarchy-system-blank"\)' 'runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)'; do
+  launches=$(rg -c "$launch" "$service")
+  ((launches == 1)) || fail "each display process must be launched from exactly one place, the serializer"
+done
+
+for process_id in screenOffProcess wakeProcess; do
+  rg -A4 "id: $process_id" "$service" | rg -q 'root\.flushDisplayState\(\)' ||
+    fail "$process_id.onExited must flush a display state left pending while it ran"
+done
+
+pass "blank and wake are serialized through one wanted state that survives either process being busy"
 
 # Locking already blanks the screens through its own service. When the lock
 # is due at or before the screen-off deadline, launching our own blank first
@@ -227,8 +224,8 @@ rg -q 'screenOffSubsumedByLock: root\.lockOnIdle && root\.screenOffDelaySeconds 
   fail "screenOffSubsumedByLock must compare against the lock's own delay"
 
 subsumption_guards=$(rg -c '!root\.screenOffSubsumedByLock' "$service")
-((subsumption_guards == 4)) ||
-  fail "startIdleCycle, both screen-off timers, and the screen-off switch handler must all check screenOffSubsumedByLock"
+((subsumption_guards == 5)) ||
+  fail "startIdleCycle, both screen-off timers, and both switch handlers must all check screenOffSubsumedByLock"
 
 pass "screen-off is skipped everywhere the lock is due at or before its own deadline"
 
@@ -245,25 +242,27 @@ pass "the screen-off rearm timer clamps a configured zero timeout instead of fir
 # ext-idle-notify only fires "resumed" when leaving the idle state, and the
 # screensaver's launch activity can spend the main monitor's transition before
 # a later blank -- mouse input would then leave the panels dark until the main
-# monitor re-idled. A second 1s monitor runs only while the screens are off to
-# catch that first real input. Source-level shape checks, as above.
+# monitor re-idled. A second 1s monitor covers that. It has to be armed for the
+# whole cycle, not just while the screens are off: it needs a second of quiet
+# to go idle before it has a resumed edge to give, and spending that second
+# after the blank would miss input landing inside it. Source-level checks.
 rg -q 'id: screenOffActivityMonitor' "$service" ||
   fail "a dedicated idle monitor must watch for input while the screens are dark"
-rg -q 'enabled: root\.idleEnabled && root\.screenOffThisCycle' "$service" ||
-  fail "the screen-off watcher must only exist while this cycle's blank is ours"
-rg -q 'if \(isIdle \|\| !root\.idleEnabled \|\| !root\.screenOffThisCycle\) return' "$service" ||
-  fail "the screen-off watcher must guard against the isIdle reset its own disable emits"
+rg -q 'enabled: root\.idleEnabled && root\.idledThisCycle' "$service" ||
+  fail "the screen-off watcher must be armed for the whole cycle so it is already idle when a delayed blank lands"
+rg -q 'if \(isIdle \|\| !root\.idleEnabled \|\| !root\.idledThisCycle \|\| !root\.screenOffThisCycle\) return' "$service" ||
+  fail "the screen-off watcher must re-check every term of its own binding, including the one that disables it"
 rg -A2 'screen-off-activity' "$service" | rg -q 'root\.handleActiveSignal\(\)' ||
   fail "dark-screen input must route through handleActiveSignal, not wake the screens directly"
 pass "input while the screens are dark wakes them through a dedicated 1s idle monitor"
 
 # Screen-off can legitimately fire before the lock (not subsumed), so a blank
 # can still be finishing in the background when lockSystem() hands display
-# ownership to the lock service. Without disowning a pending wake here, that
-# blank's own exit would later fire an errant wake through the lock screen.
-rg -A20 'function lockSystem\(reason\)' "$service" | rg -q 'root\.wakeAfterBlankPending = false' ||
-  fail "lockSystem() must disown a pending wake, not just this cycle's screen-off ownership"
-pass "locking disowns any pending wake left over from a screen-off blank that outlives it"
+# ownership to the lock service. Without disowning the wanted display state
+# here, that blank's own exit would drive the displays through the lock screen.
+rg -A20 'function lockSystem\(reason\)' "$service" | rg -q 'root\.pendingDisplayState = ""' ||
+  fail "lockSystem() must disown the wanted display state, not just this cycle's screen-off ownership"
+pass "locking disowns a display state left wanted by a screen-off blank that outlives it"
 
 # The lock service starts its own independent wake with no way to know a
 # screen-off blank from here is still in flight; if that wake finishes first,
@@ -283,7 +282,29 @@ pass "locking waits for an in-flight screen-off blank instead of racing the lock
 # A deferred lock is still just a decision, not yet a running process --
 # cancelIdleCycle() must disown it like every other piece of cycle state, so
 # activity or Stay Awake during the defer window doesn't lock anyway once the
-# blank happens to finish.
-rg -A19 'function cancelIdleCycle\(reason\)' "$service" | rg -q 'root\.pendingLockReason = ""' ||
-  fail "cancelIdleCycle() must disown a lock deferred by an in-flight blank"
-pass "canceling the idle cycle also cancels a lock still waiting on an in-flight blank"
+# blank happens to finish. Dropping it has to hand the displays back too:
+# lockSystem() disowned them expecting that lock to arrive, and its own wake
+# is gated on idledThisCycle, which lockSystem() already cleared.
+rg -q 'function cancelPendingLock\(\)' "$service" ||
+  fail "one helper must own dropping a deferred lock, so every door does it the same way"
+rg -A5 'function cancelPendingLock\(\)' "$service" | rg -q 'wakeScreens\(\)' ||
+  fail "cancelling a deferred lock must wake the screens it was going to take over"
+
+for door in 'function cancelIdleCycle\(reason\)' 'onLockOnIdleChanged'; do
+  rg -A19 "$door" "$service" | rg -q 'cancelPendingLock\(\)' ||
+    fail "every path that drops a deferred lock must go through cancelPendingLock()"
+done
+
+reason_writes=$(rg -c 'root\.pendingLockReason = ' "$service")
+((reason_writes == 3)) ||
+  fail "pendingLockReason should only be written where it is deferred, flushed, and cancelled"
+
+pass "dropping a deferred lock hands the darkening displays back instead of abandoning them"
+
+# lockOnIdle decides screenOffSubsumedByLock too, so its handler cannot only
+# touch lockTimer: flipping it re-decides whether screen-off is covered by the
+# lock this cycle, and turning it off has to drop a lock the idle timeout
+# already deferred behind an in-flight blank.
+rg -A12 'onLockOnIdleChanged' "$service" | rg -q 'syncSwitchTimer\(root\.screenOffOnIdle && !root\.screenOffSubsumedByLock, screenOffTimer' ||
+  fail "onLockOnIdleChanged must resync the screen-off timer it just re-decided"
+pass "flipping lock-on-idle resyncs the screen-off it subsumes"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -314,3 +314,21 @@ pass "dropping a deferred lock hands the darkening displays back instead of aban
 qml_block 'onLockOnIdleChanged' | rg -q 'syncSwitchTimer\(root\.screenOffOnIdle && !root\.screenOffSubsumedByLock, screenOffTimer' ||
   fail "onLockOnIdleChanged must resync the screen-off timer it just re-decided"
 pass "flipping lock-on-idle resyncs the screen-off it subsumes"
+
+# Screen-off can be configured ahead of the screensaver, so the activity the
+# screensaver provokes when it maps can land on already-dark panels. Treating
+# that as a bump would relight a screen nobody asked to wake, for a whole
+# rearm period, with no one at the machine. The launch claims its own report
+# and handleActiveSignal spends it instead of waking.
+qml_block 'function launchScreensaver()' | rg -q 'root\.screensaverActivityExpected = true' ||
+  fail "launchScreensaver() must claim the activity report its own mapping provokes"
+rg -q 'if \(root\.screensaverActivityExpected\) root\.screensaverActivityExpected = false' "$service" ||
+  fail "handleActiveSignal must spend the screensaver's own activity report rather than act on it"
+rg -A2 'if \(root\.screensaverActivityExpected\)' "$service" | rg -q 'else if \(root\.screenOffThisCycle\) rearmScreenOff\(\)' ||
+  fail "only a bump that is not the screensaver's own may relight the panels"
+
+claim_releases=$(rg -c 'root\.screensaverActivityExpected = false' "$service")
+((claim_releases == 4)) ||
+  fail "an unspent claim must be released everywhere the launch it belongs to is forgotten"
+
+pass "the screensaver's own launch activity does not relight panels screen-off just darkened"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -219,3 +219,18 @@ rg -q 'screenOffRearmSeconds: Math\.max\(1, screenOffTimeoutSeconds\)' "$service
 rg -A4 'id: screenOffRearmTimer' "$service" | rg -q 'interval: root\.screenOffRearmSeconds \* 1000' ||
   fail "screenOffRearmTimer must use the clamped screenOffRearmSeconds, not the raw timeout"
 pass "the screen-off rearm timer clamps a configured zero timeout instead of firing every tick"
+
+# ext-idle-notify only fires "resumed" when leaving the idle state, and the
+# screensaver's launch activity can spend the main monitor's transition before
+# a later blank -- mouse input would then leave the panels dark until the main
+# monitor re-idled. A second 1s monitor runs only while the screens are off to
+# catch that first real input. Source-level shape checks, as above.
+rg -q 'id: screenOffActivityMonitor' "$service" ||
+  fail "a dedicated idle monitor must watch for input while the screens are dark"
+rg -q 'enabled: root\.idleEnabled && root\.screenOffThisCycle' "$service" ||
+  fail "the screen-off watcher must only exist while this cycle's blank is ours"
+rg -q 'if \(isIdle \|\| !root\.idleEnabled \|\| !root\.screenOffThisCycle\) return' "$service" ||
+  fail "the screen-off watcher must guard against the isIdle reset its own disable emits"
+rg -A2 'screen-off-activity' "$service" | rg -q 'root\.handleActiveSignal\(\)' ||
+  fail "dark-screen input must route through handleActiveSignal, not wake the screens directly"
+pass "input while the screens are dark wakes them through a dedicated 1s idle monitor"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -169,7 +169,7 @@ pass "screens-off timeout reader floors and falls back like the other timeouts"
 # its own cycle. This is a source-order proxy for that guarantee, not a runtime
 # check -- there's no headless way to drive startIdleCycle() from this suite.
 service="$ROOT/shell/plugins/services/idle/Service.qml"
-screen_off_line=$(rg -n 'if \(root\.screenOffOnIdle\) \{' "$service" | head -1 | cut -d: -f1)
+screen_off_line=$(rg -n 'if \(root\.screenOffOnIdle && !root\.screenOffSubsumedByLock\) \{' "$service" | head -1 | cut -d: -f1)
 lock_line=$(rg -n 'if \(root\.lockOnIdle\) \{' "$service" | head -1 | cut -d: -f1)
 ((screen_off_line < lock_line)) || fail "screen-off is armed before the lock in startIdleCycle"
 pass "screen-off is armed before the lock in startIdleCycle"
@@ -188,27 +188,49 @@ fi
 pass "the idle service blanks through omarchy-system-blank"
 
 # Blank and wake are separate async processes; firing wake while a blank is
-# still in flight races it and can leave the screens dark. wakeScreens() must
-# check screenOffProcess.running and defer to its onExited instead of every
-# caller firing the wake process directly. This is a source-level check for
-# that shape, not a runtime one -- there's no headless way to race two
-# Process launches from this suite.
-rg -q 'function wakeScreens\(\)' "$service" || fail "wakeScreens() must exist to serialize blank and wake"
-rg -A3 'function wakeScreens\(\)' "$service" | rg -q 'screenOffProcess\.running' ||
-  fail "wakeScreens() must check screenOffProcess.running before firing a wake"
+# still in flight races it and can leave the screens dark. A pending wake can
+# also fail to launch because wakeProcess itself is still finishing an
+# earlier wake -- reachable with the one-second rearm floor. flushPendingWake()
+# must only clear the pending flag once the wake process actually launches,
+# and both process exits must retry it, so a wake requested while busy is
+# never silently dropped. This is a source-level check for that shape, not a
+# runtime one -- there's no headless way to race two Process launches from
+# this suite.
+rg -q 'function wakeScreens\(\)' "$service" || fail "wakeScreens() must exist to record a wake request"
+rg -q 'function flushPendingWake\(\)' "$service" ||
+  fail "flushPendingWake() must exist to retry a wake request once whatever was busy exits"
+rg -A4 'function flushPendingWake\(\)' "$service" | rg -q 'screenOffProcess\.running' ||
+  fail "flushPendingWake() must not launch a wake while a blank is still running"
+rg -A4 'function flushPendingWake\(\)' "$service" | rg -q 'if \(!runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)\) return' ||
+  fail "flushPendingWake() must only clear the pending flag once the wake process actually launches"
 
 wake_call_sites=$(rg -c '\bwakeScreens\(\)' "$service")
-((wake_call_sites >= 3)) ||
+((wake_call_sites == 4)) ||
   fail "rearmScreenOff, cancelIdleCycle, and the screen-off switch handler must all wake through wakeScreens()"
 
-rg -A5 'id: screenOffProcess' "$service" | rg -q 'wakeAfterBlankPending' ||
-  fail "screenOffProcess.onExited must fire a wake deferred during blanking"
+for process_id in screenOffProcess wakeProcess; do
+  rg -A4 "id: $process_id" "$service" | rg -q 'root\.flushPendingWake\(\)' ||
+    fail "$process_id.onExited must retry a pending wake"
+done
 
 direct_wake_calls=$(rg -c 'runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)' "$service")
-((direct_wake_calls == 2)) ||
-  fail "omarchy-system-wake should only be launched from wakeScreens() and screenOffProcess.onExited"
+((direct_wake_calls == 1)) ||
+  fail "omarchy-system-wake should only be launched from inside flushPendingWake()"
 
-pass "a wake requested while blanking is in flight is deferred until the blank exits"
+pass "a wake requested while blanking or a previous wake is in flight is retried until it launches"
+
+# Locking already blanks the screens through its own service. When the lock
+# is due at or before the screen-off deadline, launching our own blank first
+# would race the lock service's independent wake path with a process it
+# doesn't know about, so screen-off must be skipped everywhere it could fire.
+rg -q 'screenOffSubsumedByLock: root\.lockOnIdle && root\.screenOffDelaySeconds >= root\.lockDelaySeconds' "$service" ||
+  fail "screenOffSubsumedByLock must compare against the lock's own delay"
+
+subsumption_guards=$(rg -c '!root\.screenOffSubsumedByLock' "$service")
+((subsumption_guards == 4)) ||
+  fail "startIdleCycle, both screen-off timers, and the screen-off switch handler must all check screenOffSubsumedByLock"
+
+pass "screen-off is skipped everywhere the lock is due at or before its own deadline"
 
 # screenOffTimeoutSeconds is a raw config value and can be configured to 0,
 # unlike the shared idleSchedule() deadline math which already clamps this.
@@ -234,3 +256,11 @@ rg -q 'if \(isIdle \|\| !root\.idleEnabled \|\| !root\.screenOffThisCycle\) retu
 rg -A2 'screen-off-activity' "$service" | rg -q 'root\.handleActiveSignal\(\)' ||
   fail "dark-screen input must route through handleActiveSignal, not wake the screens directly"
 pass "input while the screens are dark wakes them through a dedicated 1s idle monitor"
+
+# Screen-off can legitimately fire before the lock (not subsumed), so a blank
+# can still be finishing in the background when lockSystem() hands display
+# ownership to the lock service. Without disowning a pending wake here, that
+# blank's own exit would later fire an errant wake through the lock screen.
+rg -A20 'function lockSystem\(reason\)' "$service" | rg -q 'root\.wakeAfterBlankPending = false' ||
+  fail "lockSystem() must disown a pending wake, not just this cycle's screen-off ownership"
+pass "locking disowns any pending wake left over from a screen-off blank that outlives it"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -264,3 +264,26 @@ pass "input while the screens are dark wakes them through a dedicated 1s idle mo
 rg -A20 'function lockSystem\(reason\)' "$service" | rg -q 'root\.wakeAfterBlankPending = false' ||
   fail "lockSystem() must disown a pending wake, not just this cycle's screen-off ownership"
 pass "locking disowns any pending wake left over from a screen-off blank that outlives it"
+
+# The lock service starts its own independent wake with no way to know a
+# screen-off blank from here is still in flight; if that wake finishes first,
+# the stale blank disabling DPMS afterward would leave the unlock screen
+# dark. lockSystem() must defer the actual lock until the blank exits instead
+# of racing it, and screenOffProcess.onExited must flush that deferred lock.
+rg -A32 'function lockSystem\(reason\)' "$service" | rg -q 'if \(screenOffProcess\.running\) \{' ||
+  fail "lockSystem() must defer locking while a screen-off blank is still running"
+rg -A32 'function lockSystem\(reason\)' "$service" | rg -q 'root\.pendingLockReason = reason \|\| "requested"' ||
+  fail "lockSystem() must record the reason before deferring"
+rg -q 'function flushPendingLock\(\)' "$service" ||
+  fail "flushPendingLock() must exist to fire a lock deferred by an in-flight blank"
+rg -A5 'id: screenOffProcess' "$service" | rg -q 'root\.flushPendingLock\(\)' ||
+  fail "screenOffProcess.onExited must flush a deferred lock, not just a deferred wake"
+pass "locking waits for an in-flight screen-off blank instead of racing the lock service's own wake"
+
+# A deferred lock is still just a decision, not yet a running process --
+# cancelIdleCycle() must disown it like every other piece of cycle state, so
+# activity or Stay Awake during the defer window doesn't lock anyway once the
+# blank happens to finish.
+rg -A19 'function cancelIdleCycle\(reason\)' "$service" | rg -q 'root\.pendingLockReason = ""' ||
+  fail "cancelIdleCycle() must disown a lock deferred by an in-flight blank"
+pass "canceling the idle cycle also cancels a lock still waiting on an in-flight blank"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -169,6 +169,12 @@ pass "screens-off timeout reader floors and falls back like the other timeouts"
 # its own cycle. This is a source-order proxy for that guarantee, not a runtime
 # check -- there's no headless way to drive startIdleCycle() from this suite.
 service="$ROOT/shell/plugins/services/idle/Service.qml"
+
+# Print one top-level QML block (a function, handler, or object) by its opening
+# line, up to its own closing brace. Assertions below scope themselves to a
+# block instead of a fixed -A window, which silently stops covering the thing
+# it names as soon as the block grows a line.
+qml_block() { awk -v want="$1" 'index($0, want) { inside = 1 } inside { print } inside && /^  \}$/ { exit }' "$service"; }
 screen_off_line=$(rg -n 'if \(root\.screenOffOnIdle && !root\.screenOffSubsumedByLock\) \{' "$service" | head -1 | cut -d: -f1)
 lock_line=$(rg -n 'if \(root\.lockOnIdle\) \{' "$service" | head -1 | cut -d: -f1)
 ((screen_off_line < lock_line)) || fail "screen-off is armed before the lock in startIdleCycle"
@@ -199,9 +205,9 @@ for helper in turnOffScreens wakeScreens flushDisplayState; do
   rg -q "function $helper\(" "$service" || fail "$helper() must exist"
 done
 
-rg -A6 'function flushDisplayState\(\)' "$service" | rg -q 'if \(screenOffProcess\.running \|\| wakeProcess\.running\) return' ||
+qml_block 'function flushDisplayState()' | rg -q 'if \(screenOffProcess\.running \|\| wakeProcess\.running\) return' ||
   fail "flushDisplayState() must wait for both the blank and the wake process, not just one"
-rg -A6 'function flushDisplayState\(\)' "$service" | rg -q 'if \(started\) root\.pendingDisplayState = ""' ||
+qml_block 'function flushDisplayState()' | rg -q 'if \(started\) root\.pendingDisplayState = ""' ||
   fail "flushDisplayState() must only clear the wanted state once its process actually launched"
 
 for launch in 'runProcess\(screenOffProcess, "screen-off", "omarchy-system-blank"\)' 'runProcess\(wakeProcess, "wake", "omarchy-system-wake"\)'; do
@@ -210,7 +216,7 @@ for launch in 'runProcess\(screenOffProcess, "screen-off", "omarchy-system-blank
 done
 
 for process_id in screenOffProcess wakeProcess; do
-  rg -A4 "id: $process_id" "$service" | rg -q 'root\.flushDisplayState\(\)' ||
+  qml_block "id: $process_id" | rg -q 'root\.flushDisplayState\(\)' ||
     fail "$process_id.onExited must flush a display state left pending while it ran"
 done
 
@@ -235,7 +241,7 @@ pass "screen-off is skipped everywhere the lock is due at or before its own dead
 # display again the instant it wakes.
 rg -q 'screenOffRearmSeconds: Math\.max\(1, screenOffTimeoutSeconds\)' "$service" ||
   fail "screenOffRearmSeconds must clamp a configured zero screenOff timeout to 1s"
-rg -A4 'id: screenOffRearmTimer' "$service" | rg -q 'interval: root\.screenOffRearmSeconds \* 1000' ||
+qml_block 'id: screenOffRearmTimer' | rg -q 'interval: root\.screenOffRearmSeconds \* 1000' ||
   fail "screenOffRearmTimer must use the clamped screenOffRearmSeconds, not the raw timeout"
 pass "the screen-off rearm timer clamps a configured zero timeout instead of firing every tick"
 
@@ -260,7 +266,7 @@ pass "input while the screens are dark wakes them through a dedicated 1s idle mo
 # can still be finishing in the background when lockSystem() hands display
 # ownership to the lock service. Without disowning the wanted display state
 # here, that blank's own exit would drive the displays through the lock screen.
-rg -A20 'function lockSystem\(reason\)' "$service" | rg -q 'root\.pendingDisplayState = ""' ||
+qml_block 'function lockSystem(reason)' | rg -q 'root\.pendingDisplayState = ""' ||
   fail "lockSystem() must disown the wanted display state, not just this cycle's screen-off ownership"
 pass "locking disowns a display state left wanted by a screen-off blank that outlives it"
 
@@ -269,13 +275,13 @@ pass "locking disowns a display state left wanted by a screen-off blank that out
 # the stale blank disabling DPMS afterward would leave the unlock screen
 # dark. lockSystem() must defer the actual lock until the blank exits instead
 # of racing it, and screenOffProcess.onExited must flush that deferred lock.
-rg -A32 'function lockSystem\(reason\)' "$service" | rg -q 'if \(screenOffProcess\.running\) \{' ||
+qml_block 'function lockSystem(reason)' | rg -q 'if \(screenOffProcess\.running\) \{' ||
   fail "lockSystem() must defer locking while a screen-off blank is still running"
-rg -A32 'function lockSystem\(reason\)' "$service" | rg -q 'root\.pendingLockReason = reason \|\| "requested"' ||
+qml_block 'function lockSystem(reason)' | rg -q 'root\.pendingLockReason = reason \|\| "requested"' ||
   fail "lockSystem() must record the reason before deferring"
 rg -q 'function flushPendingLock\(\)' "$service" ||
   fail "flushPendingLock() must exist to fire a lock deferred by an in-flight blank"
-rg -A5 'id: screenOffProcess' "$service" | rg -q 'root\.flushPendingLock\(\)' ||
+qml_block 'id: screenOffProcess' | rg -q 'root\.flushPendingLock\(\)' ||
   fail "screenOffProcess.onExited must flush a deferred lock, not just a deferred wake"
 pass "locking waits for an in-flight screen-off blank instead of racing the lock service's own wake"
 
@@ -287,11 +293,11 @@ pass "locking waits for an in-flight screen-off blank instead of racing the lock
 # is gated on idledThisCycle, which lockSystem() already cleared.
 rg -q 'function cancelPendingLock\(\)' "$service" ||
   fail "one helper must own dropping a deferred lock, so every door does it the same way"
-rg -A5 'function cancelPendingLock\(\)' "$service" | rg -q 'wakeScreens\(\)' ||
+qml_block 'function cancelPendingLock()' | rg -q 'wakeScreens\(\)' ||
   fail "cancelling a deferred lock must wake the screens it was going to take over"
 
-for door in 'function cancelIdleCycle\(reason\)' 'onLockOnIdleChanged'; do
-  rg -A19 "$door" "$service" | rg -q 'cancelPendingLock\(\)' ||
+for door in 'function cancelIdleCycle(reason)' 'onLockOnIdleChanged'; do
+  qml_block "$door" | rg -q 'cancelPendingLock\(\)' ||
     fail "every path that drops a deferred lock must go through cancelPendingLock()"
 done
 
@@ -305,6 +311,6 @@ pass "dropping a deferred lock hands the darkening displays back instead of aban
 # touch lockTimer: flipping it re-decides whether screen-off is covered by the
 # lock this cycle, and turning it off has to drop a lock the idle timeout
 # already deferred behind an in-flight blank.
-rg -A12 'onLockOnIdleChanged' "$service" | rg -q 'syncSwitchTimer\(root\.screenOffOnIdle && !root\.screenOffSubsumedByLock, screenOffTimer' ||
+qml_block 'onLockOnIdleChanged' | rg -q 'syncSwitchTimer\(root\.screenOffOnIdle && !root\.screenOffSubsumedByLock, screenOffTimer' ||
   fail "onLockOnIdleChanged must resync the screen-off timer it just re-decided"
 pass "flipping lock-on-idle resyncs the screen-off it subsumes"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -209,3 +209,13 @@ direct_wake_calls=$(rg -c 'runProcess\(wakeProcess, "wake", "omarchy-system-wake
   fail "omarchy-system-wake should only be launched from wakeScreens() and screenOffProcess.onExited"
 
 pass "a wake requested while blanking is in flight is deferred until the blank exits"
+
+# screenOffTimeoutSeconds is a raw config value and can be configured to 0,
+# unlike the shared idleSchedule() deadline math which already clamps this.
+# A zero rearm interval would fire on every event loop tick, blanking the
+# display again the instant it wakes.
+rg -q 'screenOffRearmSeconds: Math\.max\(1, screenOffTimeoutSeconds\)' "$service" ||
+  fail "screenOffRearmSeconds must clamp a configured zero screenOff timeout to 1s"
+rg -A4 'id: screenOffRearmTimer' "$service" | rg -q 'interval: root\.screenOffRearmSeconds \* 1000' ||
+  fail "screenOffRearmTimer must use the clamped screenOffRearmSeconds, not the raw timeout"
+pass "the screen-off rearm timer clamps a configured zero timeout instead of firing every tick"

--- a/test/shell.d/system-blank-test.sh
+++ b/test/shell.d/system-blank-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/calls"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/omarchy-brightness-keyboard" <<'SH'
+#!/bin/bash
+printf 'keyboard %s\n' "$*" >>"$CALL_LOG"
+SH
+cat >"$mock_bin/omarchy-brightness-display" <<'SH'
+#!/bin/bash
+printf 'display %s\n' "$*" >>"$CALL_LOG"
+SH
+chmod +x "$mock_bin"/*
+
+CALL_LOG="$call_log" PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-system-blank"
+[[ $(sed -n 1p "$call_log") == "keyboard off" ]] || fail "blank turns the keyboard backlight off first"
+[[ $(sed -n 2p "$call_log") == "display off" ]] || fail "blank turns the displays off"
+pass "omarchy-system-blank is the inverse of omarchy-system-wake"

--- a/test/shell.d/system-blank-test.sh
+++ b/test/shell.d/system-blank-test.sh
@@ -25,3 +25,19 @@ CALL_LOG="$call_log" PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-system-
 [[ $(sed -n 1p "$call_log") == "keyboard off" ]] || fail "blank turns the keyboard backlight off first"
 [[ $(sed -n 2p "$call_log") == "display off" ]] || fail "blank turns the displays off"
 pass "omarchy-system-blank is the inverse of omarchy-system-wake"
+
+# Machines without a keyboard backlight fail the first step -- the display is
+# the part that has to happen either way, and the script has no set -e to
+# stop it from getting there.
+: >"$call_log"
+cat >"$mock_bin/omarchy-brightness-keyboard" <<'SH'
+#!/bin/bash
+printf 'keyboard %s\n' "$*" >>"$CALL_LOG"
+exit 1
+SH
+chmod +x "$mock_bin/omarchy-brightness-keyboard"
+
+CALL_LOG="$call_log" PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-system-blank" || true
+[[ $(sed -n 1p "$call_log") == "keyboard off" ]] || fail "blank still tries the keyboard backlight first"
+[[ $(sed -n 2p "$call_log") == "display off" ]] || fail "blank still turns the displays off when the keyboard backlight step fails"
+pass "omarchy-system-blank blanks the displays even on a machine without a keyboard backlight"


### PR DESCRIPTION
## Summary

Follow-up to #6086, which @dhh closed because it "edits Hypridle and the old
menu" and Quattro idle timing "now belongs to the native shell service and
shell configuration." This rebuilds the same idea directly against that
native service: `shell/plugins/services/idle/Service.qml` and
`~/.config/omarchy/shell.json`'s `idle` key, no Hypridle involved.

Along the way, testing turned up a real gap beyond the original PR's scope:
there was no way to get the screensaver and/or a plain screen-off without
the automatic lock. Someone in a private, lockable room may want the
displays to sleep on idle (power saving, burn-in prevention) without a
password prompt every time they glance back at the screen. This PR adds
that as a third, fully independent axis alongside the screensaver and the
lock, plus a small terminal UI (`omarchy-config-idle`, reachable from
Setup → Config → Idle) to configure all three.

## What changes

- **Lock-on-idle switch** (`idle.lockOnIdle`, defaults `true`): gates only
  the automatic lock fired by the idle timeout. Explicit locking --
  the menu's Lock entry, SUPER+CTRL+L, lid close, pre-suspend locking --
  is untouched and always locks regardless of this setting.
- **Screen-off switch** (`idle.screenOffOnIdle` / `idle.screenOff`,
  defaults `false` / `600`): blanks the displays and keyboard backlight on
  idle, independent of both the screensaver and the lock. When lock-on-idle
  is enabled and its timeout is at or before the screen-off timeout, locking
  already blanks the screen -- the TUI's "On idle" summary reports that as
  happening with the lock rather than double-listing the same moment.
- The scheduling math that picks the shared first idle deadline and each
  action's delay moved into a pure, unit-tested function
  (`IdleModel.idleSchedule()`) instead of living only as inline QML
  bindings exercised solely by hand.
- `omarchy-brightness-keyboard off` is now idempotent -- two blanks can land
  back to back in one idle period (the lock's own blank, and now the idle
  service's), and `brightnessctl` only keeps one saved slot per device.
- Both the lock screen and the idle service now blank the displays through
  one shared command, `omarchy-system-blank`, instead of each carrying its
  own copy of the same two calls.

## Commits

1. `Make keyboard-backlight off idempotent`
2. `Add omarchy-system-blank and route the lock screen's blanking through it`
3. `Add an independent lock-on-idle switch to the idle service`
4. `Add a screens-off axis to the idle service, independent of the screensaver and lock`

## Test plan

- [x] `test/shell.d/idle-test.sh`, `test/shell.d/system-blank-test.sh`,
      `test/shell.d/brightness-keyboard-test.sh`, `test/shell.d/bin-style-test.sh`
      all pass
- [x] Live-verified on a real Quattro session via `omarchy dev link`: screensaver
      shows with lock-on-idle off and no lock prompt on wake; screens blank at
      the configured timeout with lock-on-idle and screensaver both off, and a
      single keypress wakes them with no password prompt; explicit
      SUPER+CTRL+L still locks unconditionally regardless of the switch
- [x] Screenshot of the new Setup → Config → Idle screen
<img width="1001" height="707" alt="image" src="https://github.com/user-attachments/assets/deabcc5f-622e-4936-84a4-b72aedf06688" />

