### PR TITLE
Fix audio device labels and guard seamless output switching

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -64,9 +64,16 @@ function nodeProps(node) {
 function nodeLabel(node) {
   if (!node) return "Unknown"
   var p = nodeProps(node)
-  var nickname = friendlyDeviceLabel(node.nickname || node.nick || p["node.nick"] || p["device.profile.description"] || "")
-  if (nickname) return nickname
-  return friendlyDeviceLabel(node.description || p["node.description"] || node.name || "Unknown")
+  var description = friendlyDeviceLabel(node.description || p["node.description"] || "")
+  if (description) return description
+
+  var device = friendlyDeviceLabel(p["device.description"] || "")
+  var profile = friendlyDeviceLabel(p["device.profile.description"] || "")
+  if (device && profile && device.toLowerCase().indexOf(profile.toLowerCase()) === -1)
+    return device + " " + profile
+  if (device || profile) return device || profile
+
+  return friendlyDeviceLabel(node.nickname || node.nick || p["node.nick"] || node.name || "Unknown")
 }
 
 function isHeadphones(node) {

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -64,11 +64,13 @@ function nodeProps(node) {
 function nodeLabel(node) {
   if (!node) return "Unknown"
   var p = nodeProps(node)
+  var profile = friendlyDeviceLabel(p["device.profile.description"] || "")
   var description = friendlyDeviceLabel(node.description || p["node.description"] || "")
+  if (description && profile && description.toLowerCase().indexOf(profile.toLowerCase()) === -1)
+    return description + " " + profile
   if (description) return description
 
   var device = friendlyDeviceLabel(p["device.description"] || "")
-  var profile = friendlyDeviceLabel(p["device.profile.description"] || "")
   if (device && profile && device.toLowerCase().indexOf(profile.toLowerCase()) === -1)
     return device + " " + profile
   if (device || profile) return device || profile

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -24,6 +24,40 @@ assertEqual(
   'Microphone',
   'audio chooses friendly node labels'
 )
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
+    name: 'alsa_input.usb-SteelSeries.mono-chat',
+    nickname: 'SteelSeries Arctis 7',
+    description: 'SteelSeries Arctis 7 Chat',
+    properties: { 'node.nick': 'SteelSeries Arctis 7', 'device.profile.description': 'Chat' }
+  }),
+  'SteelSeries Arctis 7 Chat',
+  'audio prefers a descriptive input label over its nickname'
+)
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
+    name: 'alsa_output.usb-SteelSeries.stereo-game',
+    nickname: 'USB Audio #1',
+    description: 'SteelSeries Arctis 7 Game',
+    properties: { 'node.nick': 'USB Audio #1', 'device.profile.description': 'Game' }
+  }),
+  'SteelSeries Arctis 7 Game',
+  'audio keeps distinct profiles of the same output device'
+)
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
+    properties: {
+      'node.nick': 'USB Audio #1',
+      'device.description': 'SteelSeries Arctis 7',
+      'device.profile.description': 'Game'
+    }
+  }),
+  'SteelSeries Arctis 7 Game',
+  'audio reconstructs a descriptive label from device and profile metadata'
+)
 
 const headphones = { ready: true, name: 'bluez_output.airpods', properties: { 'device.product.name': 'AirPods Headphones' } }
 assert(audio.isHeadphones(headphones), 'audio detects headphone devices')
@@ -47,3 +81,53 @@ assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spo
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
 JS
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf -- "$test_tmp"' EXIT
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/calls.log"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/timeout" <<'SH'
+#!/bin/bash
+shift
+exec "$@"
+SH
+
+cat >"$mock_bin/wpctl" <<'SH'
+#!/bin/bash
+printf 'wpctl %s\n' "$*" >>"$AUDIO_TEST_LOG"
+SH
+
+cat >"$mock_bin/pactl" <<'SH'
+#!/bin/bash
+printf 'pactl %s\n' "$*" >>"$AUDIO_TEST_LOG"
+
+if [[ $1 == "list" && $2 == "sink-inputs" ]]; then
+  cat <<'EOF'
+Sink Input #11864
+        application.name = "cliamp"
+Sink Input #11865
+        node.name = "omarchy_speaker_tuning.capture"
+Sink Input #11866
+        application.name = "EasyEffects"
+EOF
+fi
+SH
+
+chmod +x "$mock_bin/timeout" "$mock_bin/wpctl" "$mock_bin/pactl"
+
+AUDIO_TEST_LOG="$call_log" PATH="$mock_bin:/usr/bin" \
+  "$ROOT/bin/omarchy-audio-output-set-default" 4735 \
+  alsa_output.usb-SteelSeries.stereo-game
+
+grep -Fx 'wpctl set-default 4735' "$call_log" >/dev/null ||
+  fail "audio output switch updates the PipeWire default"
+grep -Fx 'pactl set-default-sink alsa_output.usb-SteelSeries.stereo-game' "$call_log" >/dev/null ||
+  fail "audio output switch updates the PulseAudio default"
+grep -Fx 'pactl move-sink-input 11864 alsa_output.usb-SteelSeries.stereo-game' "$call_log" >/dev/null ||
+  fail "audio output switch moves active application streams"
+if grep -Eq 'move-sink-input (11865|11866)' "$call_log"; then
+  fail "audio output switch moves DSP streams"
+fi
+pass "audio output switch preserves playback without moving DSP streams"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -49,6 +49,15 @@ assertEqual(
 assertEqual(
   audio.nodeLabel({
     ready: true,
+    description: 'SteelSeries Arctis 7',
+    properties: { 'device.profile.description': 'Game' }
+  }),
+  'SteelSeries Arctis 7 Game',
+  'audio adds a missing profile to a generic node description'
+)
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
     properties: {
       'node.nick': 'USB Audio #1',
       'device.description': 'SteelSeries Arctis 7',


### PR DESCRIPTION
## Summary

- fix audio device detection by preferring descriptive PipeWire node metadata over ambiguous nicknames such as `USB Audio #1`
- preserve distinct device profiles such as `SteelSeries Arctis 7 Chat` and `SteelSeries Arctis 7 Game`, including a device/profile metadata fallback
- extend audio regression coverage for seamless output switching: active application streams follow the selected sink while DSP and EasyEffects streams remain untouched

No QML, layout, styling, or interaction behavior in the volume panel is changed.

## Verification

- `bash test/shell.d/audio-test.sh`
- shell test suite passed except for the pre-existing `model-usage-default-migration-test.sh` failure on the unmodified `quattro` head
- manually switched live `cliamp` playback between the Arctis Chat and Game outputs; playback continued without interruption and retained sink-input ID `11864`
- confirmed the panel reports the descriptive Chat/Game names for both outputs and inputs

## Before

Ambiguous nicknames hide the distinct Chat/Game profiles:

![Omarchy audio panel before the fix, showing ambiguous device nicknames](https://raw.githubusercontent.com/HANCORE-linux/omarchy/206c7e20/.github/pr-assets/audio-device-panel-before.png)

## After

Descriptive PipeWire metadata identifies the available profiles:

![Omarchy audio panel after the fix, showing descriptive Chat and Game device names](https://raw.githubusercontent.com/HANCORE-linux/omarchy/206c7e20/.github/pr-assets/audio-device-panel-after.png)
