### PR TITLE
Add per-scope sliders to display widget

### DIFF
--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 # omarchy:summary=Scale text everywhere — omarchy shell, GTK apps, and terminals
-# omarchy:args=[size|reset]
-# omarchy:examples=omarchy display text size | omarchy display text size 16 | omarchy display text size reset
+# omarchy:args=[--shell] [--gtk] [--terminals] [size|reset]
+# omarchy:examples=omarchy display text size | omarchy display text size 16 | omarchy display text size reset | omarchy display text size --shell 14
 
 # One knob for apparent text size across the desktop. It drives three settings
-# in lockstep, all anchored to the shell default of 12px:
+# in lockstep by default, all anchored to the shell default of 12px:
 #   • the omarchy shell's font base-size (~/.config/omarchy/shell.toml [font])
 #   • GNOME/GTK's text-scaling-factor    (12px -> 1.0, quantized so the GTK
 #     interface font lands on a whole point size, so 16 -> 15pt/11pt = 1.3636)
 #   • the terminal font point size       (12px -> 9pt, so terminal_pt = px * 9/12)
+# Scope flags address any subset without changing the unflagged behavior.
 # The shell override layers on top of the active theme (so the size survives
 # theme switches) and the shell watches the file, so shell text re-flows live.
 # Accepts an integer from 9 to 20 (px).
@@ -26,10 +27,14 @@ SHELL_DEFAULT_PX=12
 shell_config="$HOME/.config/omarchy/shell.toml"
 
 usage() {
-  echo "Usage: omarchy-display-text-size [size|reset]"
+  echo "Usage: omarchy-display-text-size [--shell] [--gtk] [--terminals] [size|reset]"
   echo "  (no args)   print the current text size, GTK factor, and terminal size"
   echo "  <size>      set text size in px ($MIN–$MAX); shell + GTK + terminals together"
   echo "  reset       return all three to their defaults (12px / 1.0 / 9pt)"
+  echo "  --shell     apply only to the omarchy shell font"
+  echo "  --gtk       apply only to GTK text scaling"
+  echo "  --terminals apply only to terminal font sizes"
+  echo "  Example: omarchy-display-text-size --shell 14"
 }
 
 # ---- shell base-size: the rem root every shell type size derives from ----
@@ -183,44 +188,115 @@ term_current_pt() {
   fi
 }
 
-case "${1:-}" in
-  -h | --help)
+for token in "$@"; do
+  if [[ $token == "-h" || $token == "--help" ]]; then
     usage
     exit 0
-    ;;
-  "")
-    cur="$(current_base_size)"
-    size="${cur:-12 (default)}"
-    factor="$(gsettings get "$GKEY_SCHEMA" "$GKEY_NAME" 2>/dev/null)"
-    term="$(term_current_pt)"
-    printf 'text size: %s px\ngtk text-scaling-factor: %s\nterminal font: %s pt\n' \
-      "$size" "$factor" "${term:-n/a}"
+  fi
+done
+
+# A valid size is 1-2 ASCII digits with no leading zero, in range. Pattern
+# ranges (not regex) because regex ranges follow locale collation and admit
+# fullwidth digits; the length cap keeps the arithmetic clear of 64-bit
+# wraparound. bash 5's globasciiranges keeps these pattern ranges ASCII-only.
+valid_size() {
+  [[ -n $1 && $1 != *[!0-9]* && $1 != 0* ]] && ((${#1} <= 2)) && (($1 >= MIN && $1 <= MAX))
+}
+
+do_shell=0
+do_gtk=0
+do_terminals=0
+action=""
+
+for token in "$@"; do
+  case "$token" in
+    --shell) do_shell=1 ;;
+    --gtk) do_gtk=1 ;;
+    --terminals) do_terminals=1 ;;
+    *)
+      # Dash-led ASCII numbers (-1) are size candidates, not flags, so they
+      # fall through to size validation.
+      if [[ $token == -* && -n ${token#-} && ${token#-} != *[!0-9]* ]] || [[ $token != -* ]]; then
+        if [[ -n $action ]]; then
+          usage >&2
+          exit 1
+        fi
+
+        action="$token"
+        if [[ $action != "reset" && $action != "default" ]] && ! valid_size "$action"; then
+          echo "Size must be an integer between $MIN and $MAX (px)." >&2
+          usage >&2
+          exit 1
+        fi
+      else
+        usage >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+scoped=$((do_shell || do_gtk || do_terminals))
+
+if [[ -z $action ]]; then
+  if ((scoped)); then
+    usage >&2
+    exit 1
+  fi
+
+  cur="$(current_base_size)"
+  size="${cur:-12 (default)}"
+  factor="$(gsettings get "$GKEY_SCHEMA" "$GKEY_NAME" 2>/dev/null)"
+  term="$(term_current_pt)"
+  printf 'text size: %s px\ngtk text-scaling-factor: %s\nterminal font: %s pt\n' \
+    "$size" "$factor" "${term:-n/a}"
+  exit 0
+fi
+
+if ((!scoped)); then
+  do_shell=1
+  do_gtk=1
+  do_terminals=1
+fi
+
+case "$action" in
+  reset | default)
+    if ((do_shell)); then
+      reset_base_size
+    fi
+
+    if ((do_gtk)); then
+      gsettings reset "$GKEY_SCHEMA" "$GKEY_NAME" 2>/dev/null || true
+    fi
+
+    if ((do_terminals)); then
+      set_terminal_size "$TERM_DEFAULT_PT"
+    fi
+
     exit 0
     ;;
-  reset | default)
-    reset_base_size
-    gsettings reset "$GKEY_SCHEMA" "$GKEY_NAME" 2>/dev/null || true
-    set_terminal_size "$TERM_DEFAULT_PT"
+  *)
+    size="$action"
+
+    # Shell side: base-size in px (the omarchy shell's rem root).
+    if ((do_shell)); then
+      set_base_size "$size"
+    fi
+
+    # GTK side: multiplier anchored so 12px == 1.0, quantized so the interface
+    # font renders at a whole point size. Raw ratios yield fractional point sizes,
+    # which GTK4 menus clip at the ascenders on scale-1 monitors.
+    if ((do_gtk)); then
+      factor="$(awk -v s="$size" -v b="$SHELL_DEFAULT_PX" -v f="$(gtk_font_pt)" \
+        'BEGIN { printf "%.4f", int(f * s / b + 0.5) / f }')"
+      set_factor "$factor"
+    fi
+
+    # Terminal side: point size anchored so 12px == 9pt.
+    if ((do_terminals)); then
+      set_terminal_size "$(term_pt_for "$size")"
+    fi
+
     exit 0
     ;;
 esac
-
-size="$1"
-if [[ ! $size =~ ^[0-9]+$ ]] || ((size < MIN || size > MAX)); then
-  echo "Size must be an integer between $MIN and $MAX (px)." >&2
-  usage >&2
-  exit 1
-fi
-
-# Shell side: base-size in px (the omarchy shell's rem root).
-set_base_size "$size"
-
-# GTK side: multiplier anchored so 12px == 1.0, quantized so the interface
-# font renders at a whole point size. Raw ratios yield fractional point sizes,
-# which GTK4 menus clip at the ascenders on scale-1 monitors.
-factor="$(awk -v s="$size" -v b="$SHELL_DEFAULT_PX" -v f="$(gtk_font_pt)" \
-  'BEGIN { printf "%.4f", int(f * s / b + 0.5) / f }')"
-set_factor "$factor"
-
-# Terminal side: point size anchored so 12px == 9pt.
-set_terminal_size "$(term_pt_for "$size")"

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -111,6 +111,23 @@ function parseDisplays(raw) {
   }
 }
 
+// omarchy-display-text-size reports GTK as a scale factor and terminals in
+// points, both against this reference. The panel shows every scope in px.
+var TEXT_REFERENCE_PX = 12
+var TERM_REFERENCE_PT = 9
+
+// 0 for a scope the status output doesn't describe (unset, "n/a", or garbage);
+// the row shows "—" rather than a made-up size.
+function parseTextSizeStatus(raw) {
+  var text = String(raw || "")
+  var gtk = text.match(/gtk text-scaling-factor:\s*([0-9.]+)/)
+  var term = text.match(/terminal font:\s*([0-9.]+)\s*pt/)
+  return {
+    gtkPx: gtk ? Number(gtk[1]) * TEXT_REFERENCE_PX : 0,
+    termPx: term ? Number(term[1]) * TEXT_REFERENCE_PX / TERM_REFERENCE_PT : 0
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -119,6 +136,7 @@ if (typeof module !== "undefined") {
     matchingScaleIndex: matchingScaleIndex,
     availableScales: availableScales,
     brightnessName: brightnessName,
-    parseDisplays: parseDisplays
+    parseDisplays: parseDisplays,
+    parseTextSizeStatus: parseTextSizeStatus
   }
 }

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -112,19 +112,32 @@ function parseDisplays(raw) {
 }
 
 // omarchy-display-text-size reports GTK as a scale factor and terminals in
-// points, both against this reference. The panel shows every scope in px.
+// points, both against this reference. The panel shows the GTK scope in px and
+// the terminal scope in its native points.
 var TEXT_REFERENCE_PX = 12
 var TERM_REFERENCE_PT = 9
 
+// Terminal pt ⇄ px against the 12px/9pt anchors. pxToPt mirrors the CLI's
+// term_pt_for, so an optimistic pxToPt(px) matches what the CLI writes.
+function ptToPx(pt) {
+  return Math.round(pt * TEXT_REFERENCE_PX / TERM_REFERENCE_PT)
+}
+
+function pxToPt(px) {
+  return Math.round(px * TERM_REFERENCE_PT / TEXT_REFERENCE_PX)
+}
+
 // 0 for a scope the status output doesn't describe (unset, "n/a", or garbage);
-// the row shows "—" rather than a made-up size.
+// the row shows "—" rather than a made-up size. The pt match accepts strings
+// Number() can't parse (e.g. "10..5"), so finite-check rather than pass NaN on.
 function parseTextSizeStatus(raw) {
   var text = String(raw || "")
   var gtk = text.match(/gtk text-scaling-factor:\s*([0-9.]+)/)
   var term = text.match(/terminal font:\s*([0-9.]+)\s*pt/)
+  var pt = term ? Number(term[1]) : 0
   return {
     gtkPx: gtk ? Number(gtk[1]) * TEXT_REFERENCE_PX : 0,
-    termPx: term ? Number(term[1]) * TEXT_REFERENCE_PX / TERM_REFERENCE_PT : 0
+    termPt: isFinite(pt) ? pt : 0
   }
 }
 
@@ -137,6 +150,8 @@ if (typeof module !== "undefined") {
     availableScales: availableScales,
     brightnessName: brightnessName,
     parseDisplays: parseDisplays,
-    parseTextSizeStatus: parseTextSizeStatus
+    parseTextSizeStatus: parseTextSizeStatus,
+    ptToPx: ptToPx,
+    pxToPt: pxToPt
   }
 }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -131,7 +131,9 @@ Panel {
         selectedIndex = sectionFirstIndex(focusSection)
       }
     } else {
-      if (!inSingleRow && selectedIndex > 0) { selectedIndex = selectedIndex - 1; return }
+      // Boundary is the section's first index, not 0 — expanded text size keeps
+      // its unified slider at the -1 sentinel above the scope rows.
+      if (!inSingleRow && selectedIndex > sectionFirstIndex(focusSection)) { selectedIndex = selectedIndex - 1; return }
       if (sIdx > 0) {
         var prev = sections[sIdx - 1]
         focusSection = prev

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -359,16 +359,23 @@ Panel {
     return textSizePreviewIndex >= 0 ? textSizeStops[textSizePreviewIndex] : Style.font.baseSize
   }
 
+  // Writes queued while the CLI is still applying an earlier one, keyed by
+  // scope so adjusting a second scope never drops the first. Latest value per
+  // scope wins; flushed in order from textScaleProc.onRunningChanged.
+  property var pendingTextWrites: ({})
+
   // scope "" writes every surface at once (the unified slider); otherwise it is
   // one of textScopeKeys and becomes the matching CLI flag. The row is updated
   // from what we asked for rather than read back — if the write fails, the next
   // status read corrects it.
   function writeTextSize(scope, px) {
-    var command = ["omarchy-display-text-size"]
-    if (scope !== "") command.push("--" + scope)
-    command.push(String(px))
-    textScaleProc.command = command
-    if (!textScaleProc.running) textScaleProc.running = true
+    if (textScaleProc.running) {
+      // A unified write supersedes any per-scope writes queued before it.
+      if (scope === "") root.pendingTextWrites = ({})
+      root.pendingTextWrites[scope] = px
+    } else {
+      startTextWrite(scope, px)
+    }
 
     if (scope === "" || scope === "gtk") root.gtkPx = px
     if (scope === "" || scope === "terminals") root.termPx = px
@@ -376,6 +383,14 @@ Panel {
       markReflowing()
       root.textSizePreviewIndex = nearestTextStop(px)
     }
+  }
+
+  function startTextWrite(scope, px) {
+    var command = ["omarchy-display-text-size"]
+    if (scope !== "") command.push("--" + scope)
+    command.push(String(px))
+    textScaleProc.command = command
+    textScaleProc.running = true
   }
 
   function setTextSize(px) {
@@ -527,6 +542,15 @@ Panel {
   Process {
     id: textScaleProc
     stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running) return
+      var scopes = Object.keys(root.pendingTextWrites)
+      if (scopes.length === 0) return
+      var scope = scopes[0]
+      var px = root.pendingTextWrites[scope]
+      delete root.pendingTextWrites[scope]
+      root.startTextWrite(scope, px)
+    }
   }
 
   // Reads the GTK factor and terminal point size for the scope rows. Wrapped in

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -62,6 +62,14 @@ Panel {
   // no pending change; follow Style.font.baseSize.
   property int textSizePreviewIndex: -1
 
+  // Per-surface rows behind the disclosure. The CLI reports GTK as a scale
+  // factor and terminals in points; both are shown in px against the 12px /
+  // 9pt reference it uses. 0 = not read yet, so the row shows "—".
+  readonly property var textScopeKeys: ["shell", "gtk", "terminals"]
+  property bool textSizeExpanded: false
+  property real gtkPx: 0
+  property real termPx: 0
+
   // A text-size change reflows the whole panel (both font and spacing scale),
   // which slides rows under a stationary pointer and fires synthetic hover.
   // While true, hover is not allowed to hijack the keyboard focus section —
@@ -83,15 +91,20 @@ Panel {
 
   function sectionCount(section) {
     if (section === "brightness") return 0  // only the slider sentinel at -1
-    if (section === "textsize") return 0    // slider sentinel at -1, like brightness
+    // Collapsed: just the slider sentinel at -1, like brightness. Expanded: the
+    // three scope rows at 0..2, with the unified slider still at -1.
+    if (section === "textsize") return textSizeExpanded ? textScopeKeys.length : 0
     if (section === "scale") return scaleValues.length
     if (section === "monitors") return displays.length
     return 0
   }
 
   function sectionIsSingleRow(section) {
-    // brightness and text size are lone sliders; scale presets sit horizontally.
-    return section === "brightness" || section === "textsize" || section === "scale"
+    // brightness and collapsed text size are lone sliders; scale presets sit
+    // horizontally. Expanded text size becomes a vertical row list.
+    return section === "brightness"
+      || (section === "textsize" && !textSizeExpanded)
+      || section === "scale"
   }
 
   function sectionFirstIndex(section) {
@@ -147,6 +160,12 @@ Panel {
   }
 
   function activateCursor() {
+    // Enter on the text-size header row opens/closes the scope rows. On a scope
+    // row it does nothing, like Enter on the brightness slider.
+    if (focusSection === "textsize") {
+      if (selectedIndex === -1) textSizeExpanded = !textSizeExpanded
+      return
+    }
     if (focusSection === "scale" && selectedIndex >= 0 && selectedIndex < scaleValues.length) {
       setScale(scaleValues[selectedIndex])
       return
@@ -167,6 +186,12 @@ Panel {
       return
     }
     var count = sectionCount(focusSection)
+    // Expanded text size keeps -1 (the unified slider) as a valid position
+    // alongside its scope rows.
+    if (focusSection === "textsize" && textSizeExpanded) {
+      selectedIndex = Math.max(-1, Math.min(count - 1, selectedIndex))
+      return
+    }
     if (sectionIsSingleRow(focusSection)) {
       // brightness/text size use the -1 sentinel; scale clamps into the presets.
       if (focusSection === "brightness" || focusSection === "textsize") selectedIndex = -1
@@ -332,9 +357,56 @@ Panel {
     return textSizePreviewIndex >= 0 ? textSizeStops[textSizePreviewIndex] : Style.font.baseSize
   }
 
-  function setTextSize(px) {
-    textScaleProc.command = ["omarchy-display-text-size", String(px)]
+  // scope "" writes every surface at once (the unified slider); otherwise it is
+  // one of textScopeKeys and becomes the matching CLI flag. The row is updated
+  // from what we asked for rather than read back — if the write fails, the next
+  // status read corrects it.
+  function writeTextSize(scope, px) {
+    var command = ["omarchy-display-text-size"]
+    if (scope !== "") command.push("--" + scope)
+    command.push(String(px))
+    textScaleProc.command = command
     if (!textScaleProc.running) textScaleProc.running = true
+
+    if (scope === "" || scope === "gtk") root.gtkPx = px
+    if (scope === "" || scope === "terminals") root.termPx = px
+    if (scope === "" || scope === "shell") {
+      markReflowing()
+      root.textSizePreviewIndex = nearestTextStop(px)
+    }
+  }
+
+  function setTextSize(px) {
+    writeTextSize("", px)
+  }
+
+  // px a scope row currently sits on. Shell follows Style's live base size, so
+  // it needs no read; the other two come from the status read.
+  function textScopePx(rowIndex) {
+    if (rowIndex === 0) return displayedTextPx()
+    if (rowIndex === 1) return root.gtkPx
+    return root.termPx
+  }
+
+  function adjustTextScope(rowIndex, deltaSteps) {
+    var px = textScopePx(rowIndex)
+    // Nothing read yet: the knob is a placeholder, so there is no stop to step
+    // from. Dragging still works — that picks a stop outright.
+    if (!px) return
+    var idx = nearestTextStop(px) + deltaSteps
+    if (idx < 0) idx = 0
+    if (idx > textSizeStops.length - 1) idx = textSizeStops.length - 1
+    writeTextSize(textScopeKeys[rowIndex], textSizeStops[idx])
+  }
+
+  function readTextScopes() {
+    if (!textStatusProc.running) textStatusProc.running = true
+  }
+
+  function updateTextScopes(raw) {
+    var parsed = Model.parseTextSizeStatus(raw)
+    root.gtkPx = parsed.gtkPx
+    root.termPx = parsed.termPx
   }
 
   function adjustTextSize(deltaSteps) {
@@ -354,8 +426,15 @@ Panel {
   // KeyboardPanel primes focus at open-time, so SUPER-bound IPC summons land
   // with j/k ready to navigate. Keep a default landing point, but don't paint
   // the cursor until hover or the first navigation key.
+  onTextSizeExpandedChanged: {
+    markReflowing()
+    if (textSizeExpanded) readTextScopes()
+    clampCursor()
+  }
+
   onOpenedChanged: {
     if (opened) {
+      textSizeExpanded = false
       refresh()
       if (brightnessAvailable) {
         focusSection = "brightness"
@@ -380,7 +459,12 @@ Panel {
     interval: 5000
     running: root.opened
     repeat: true
-    onTriggered: root.refresh()
+    onTriggered: {
+      root.refresh()
+      // Picks up GTK or terminal font changes made outside the panel, and lets
+      // a failed write correct itself while the section stays open.
+      if (root.textSizeExpanded) root.readTextScopes()
+    }
   }
 
   Process {
@@ -443,6 +527,18 @@ Panel {
     stdout: StdioCollector { waitForEnd: true }
   }
 
+  // Reads the GTK factor and terminal point size for the scope rows. Wrapped in
+  // timeout so a wedged gsettings can't leave this process running and block
+  // every later read through the guard in readTextScopes().
+  Process {
+    id: textStatusProc
+    command: ["timeout", "-k", "1", "3", "omarchy-display-text-size"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateTextScopes(text)
+    }
+  }
+
   // Clears the hover-suppression flag once the reflow triggered by a text-size
   // change has settled.
   Timer {
@@ -499,7 +595,10 @@ Panel {
         if (dy !== 0) root.moveCursor(dy)
         else if (dx !== 0) {
           if (root.focusSection === "brightness") root.adjustBrightness(dx * 5)
-          else if (root.focusSection === "textsize") root.adjustTextSize(dx)
+          else if (root.focusSection === "textsize") {
+            if (root.selectedIndex === -1) root.adjustTextSize(dx)
+            else root.adjustTextScope(root.selectedIndex, dx)
+          }
           else if (root.focusSection === "scale") root.moveCursorH(dx)
         }
       }
@@ -681,9 +780,50 @@ Panel {
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
-                anchors.right: parent.right
-                anchors.rightMargin: Style.space(6)
+                anchors.right: textSizeChevron.left
+                anchors.rightMargin: Style.space(4)
                 anchors.verticalCenter: parent.verticalCenter
+              }
+
+              // Bordered box so the section reads as openable before anyone
+              // hovers it; the chevron swings down when it opens.
+              BorderSurface {
+                id: textSizeChevron
+                width: Math.max(Style.space(18), chevronGlyph.implicitWidth + Style.space(6))
+                height: Math.max(Style.space(18), chevronGlyph.implicitHeight + Style.space(2))
+                radius: Style.cornerRadius
+                color: "transparent"
+                borderSpec: Border.controlSpec("normal", root.bar.foreground, Color.accent)
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(2)
+                anchors.verticalCenter: parent.verticalCenter
+
+                Text {
+                  id: chevronGlyph
+                  text: "󰅀"
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.body
+                  anchors.centerIn: parent
+                  rotation: root.textSizeExpanded ? 0 : -90
+
+                  Behavior on rotation {
+                    NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+                  }
+                }
+              }
+
+              // The whole header toggles, and selects the row so h/l keeps
+              // driving text size rather than wherever the cursor was.
+              MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                  root.cursorActive = true
+                  root.focusSection = "textsize"
+                  root.selectedIndex = -1
+                  root.textSizeExpanded = !root.textSizeExpanded
+                }
               }
             }
 
@@ -717,6 +857,38 @@ Panel {
                   root.focusSection = "textsize"
                   root.selectedIndex = -1
                 }
+              }
+            }
+
+            // Indented behind a hairline gutter so the rows read as children of
+            // TEXT SIZE.
+            Item {
+              id: textScopes
+              readonly property int gutter: Style.space(5)
+              readonly property int indent: Style.space(10)
+
+              visible: root.textSizeExpanded
+              width: parent.width
+              height: textScopeColumn.height
+
+              Rectangle {
+                x: textScopes.gutter
+                width: Style.spacing.hairline
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                color: Util.alpha(root.bar.foreground, 0.18)
+              }
+
+              Column {
+                id: textScopeColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: textScopes.indent
+                spacing: Style.space(6)
+
+                TextScopeRow { width: parent.width; label: "Shell"; rowIndex: 0 }
+                TextScopeRow { width: parent.width; label: "GTK apps"; rowIndex: 1 }
+                TextScopeRow { width: parent.width; label: "Terminals"; rowIndex: 2 }
               }
             }
           }
@@ -820,6 +992,88 @@ Panel {
             width: parent.width
             height: Style.space(4)
           }
+        }
+      }
+    }
+  }
+
+  component TextScopeRow: Column {
+    id: scopeRow
+    required property string label
+    required property int rowIndex
+
+    readonly property real px: root.textScopePx(rowIndex)
+
+    spacing: Style.space(4)
+
+    Item {
+      width: parent.width
+      implicitHeight: Math.max(scopeLabel.implicitHeight, scopeValue.implicitHeight)
+
+      Text {
+        id: scopeLabel
+        text: scopeRow.label
+        color: root.bar.foreground
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+        anchors.left: parent.left
+        anchors.leftMargin: Style.space(6)
+        anchors.right: scopeValue.left
+        anchors.rightMargin: Style.space(8)
+        anchors.verticalCenter: parent.verticalCenter
+        elide: Text.ElideRight
+      }
+
+      Text {
+        id: scopeValue
+        // Terminal points don't land on whole px, so allow one decimal.
+        text: scopeSlider.dragging
+              ? root.textSizeStops[Math.round(scopeSlider.liveValue)] + "px"
+              : (scopeRow.px ? Math.round(scopeRow.px * 10) / 10 + "px" : "—")
+        color: Qt.darker(root.bar.foreground, 1.4)
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+        anchors.right: parent.right
+        anchors.rightMargin: textSizeChevron.width + Style.space(4)
+        anchors.verticalCenter: parent.verticalCenter
+      }
+    }
+
+    CursorSurface {
+      width: parent.width
+      height: scopeSlider.implicitHeight + Style.spacing.controlGap
+      hasCursor: root.cursorActive && root.focusSection === "textsize"
+                 && root.selectedIndex === scopeRow.rowIndex
+      onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(scopeRow)
+      foreground: root.bar.foreground
+      outline: true
+
+      PanelSlider {
+        id: scopeSlider
+        bar: root.bar
+        anchors.fill: parent
+        anchors.leftMargin: Style.space(6)
+        anchors.rightMargin: Style.space(6)
+        minimum: 0
+        maximum: root.textSizeStops.length - 1
+        step: 1
+        integer: true
+        tickCount: root.textSizeStops.length
+        // Unread rows park on the 12px notch as a placeholder; the label says "—".
+        value: root.nearestTextStop(scopeRow.px || 12)
+        onReleased: function(v) {
+          root.writeTextSize(root.textScopeKeys[scopeRow.rowIndex],
+                             root.textSizeStops[Math.round(v)])
+        }
+      }
+
+      HoverHandler {
+        onHoveredChanged: if (hovered && !root.reflowingText) {
+          root.cursorActive = true
+          root.focusSection = "textsize"
+          root.selectedIndex = scopeRow.rowIndex
         }
       }
     }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -62,13 +62,28 @@ Panel {
   // no pending change; follow Style.font.baseSize.
   property int textSizePreviewIndex: -1
 
-  // Per-surface rows behind the disclosure. The CLI reports GTK as a scale
-  // factor and terminals in points; both are shown in px against the 12px /
-  // 9pt reference it uses. 0 = not read yet, so the row shows "—".
-  readonly property var textScopeKeys: ["shell", "gtk", "terminals"]
+  // Terminal row notches: every whole point whose px image passes the CLI's
+  // valid_size range (9–20px) — ptToPx(6) is 8px and ptToPx(16) is 21px, both
+  // rejected, and textScaleProc never checks the exit code, so an out-of-range
+  // write would be a silent no-op behind a stale optimistic row. pt→px→pt is
+  // the identity on 7–15, which is what lets writeTextSize's optimistic
+  // pxToPt(px) echo the chosen pt back instead of storing it directly.
+  readonly property var termSizeStops: [7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+  // Per-surface rows behind the disclosure, keyed by row index. The CLI
+  // reports GTK as a scale factor, shown in px against its 12px reference;
+  // terminals keep their native points. 0 = not read yet, so the row shows
+  // "—" with the placeholder notch. (Named textScopeSpecs because an
+  // unqualified `textScopes` inside the scope rows resolves to the gutter
+  // Item id below, not a root property.)
+  readonly property var textScopeSpecs: [
+    { key: "shell", stops: textSizeStops, unit: "px", placeholder: 12 },
+    { key: "gtk", stops: textSizeStops, unit: "px", placeholder: 12 },
+    { key: "terminals", stops: termSizeStops, unit: "pt", placeholder: 9 }
+  ]
   property bool textSizeExpanded: false
   property real gtkPx: 0
-  property real termPx: 0
+  property real termPt: 0
 
   // A text-size change reflows the whole panel (both font and spacing scale),
   // which slides rows under a stationary pointer and fires synthetic hover.
@@ -93,7 +108,7 @@ Panel {
     if (section === "brightness") return 0  // only the slider sentinel at -1
     // Collapsed: just the slider sentinel at -1, like brightness. Expanded: the
     // three scope rows at 0..2, with the unified slider still at -1.
-    if (section === "textsize") return textSizeExpanded ? textScopeKeys.length : 0
+    if (section === "textsize") return textSizeExpanded ? textScopeSpecs.length : 0
     if (section === "scale") return scaleValues.length
     if (section === "monitors") return displays.length
     return 0
@@ -336,15 +351,19 @@ Panel {
     if (!actionProc.running) actionProc.running = true
   }
 
-  // ---- Text size (shell base font + GTK text-scaling, via one CLI) ----
-  function nearestTextStop(px) {
+  // ---- Text size (shell base font, GTK text-scaling, terminal points — one CLI) ----
+  function nearestStop(stops, value) {
     var best = 0
     var bestDist = 1e9
-    for (var i = 0; i < textSizeStops.length; i++) {
-      var d = Math.abs(textSizeStops[i] - px)
+    for (var i = 0; i < stops.length; i++) {
+      var d = Math.abs(stops[i] - value)
       if (d < bestDist) { bestDist = d; best = i }
     }
     return best
+  }
+
+  function nearestTextStop(px) {
+    return nearestStop(textSizeStops, px)
   }
 
   // Effective stop index: the pending choice while a change is in flight,
@@ -365,9 +384,10 @@ Panel {
   property var pendingTextWrites: ({})
 
   // scope "" writes every surface at once (the unified slider); otherwise it is
-  // one of textScopeKeys and becomes the matching CLI flag. The row is updated
-  // from what we asked for rather than read back — if the write fails, the next
-  // status read corrects it.
+  // a textScopeSpecs key and becomes the matching CLI flag. px is always the
+  // CLI's unit; the terminal row's optimistic pt mirrors the CLI's own px→pt
+  // conversion. The row is updated from what we asked for rather than read
+  // back — if the write fails, the next status read corrects it.
   function writeTextSize(scope, px) {
     if (textScaleProc.running) {
       // A unified write supersedes any per-scope writes queued before it.
@@ -378,7 +398,7 @@ Panel {
     }
 
     if (scope === "" || scope === "gtk") root.gtkPx = px
-    if (scope === "" || scope === "terminals") root.termPx = px
+    if (scope === "" || scope === "terminals") root.termPt = Model.pxToPt(px)
     if (scope === "" || scope === "shell") {
       markReflowing()
       root.textSizePreviewIndex = nearestTextStop(px)
@@ -397,23 +417,34 @@ Panel {
     writeTextSize("", px)
   }
 
-  // px a scope row currently sits on. Shell follows Style's live base size, so
-  // it needs no read; the other two come from the status read.
-  function textScopePx(rowIndex) {
+  // Value a scope row currently sits on, in the row's own unit (px, or pt for
+  // terminals). Shell follows Style's live base size, so it needs no read; the
+  // other two come from the status read.
+  function textScopeValue(rowIndex) {
     if (rowIndex === 0) return displayedTextPx()
     if (rowIndex === 1) return root.gtkPx
-    return root.termPx
+    return root.termPt
+  }
+
+  // Single conversion site for row writes: takes a stop in the row's unit and
+  // hands writeTextSize the px the CLI accepts. `unit` doubles as the
+  // conversion selector, so a future pt row on a different anchor needs its
+  // own discriminator.
+  function writeTextScope(rowIndex, stopValue) {
+    var spec = textScopeSpecs[rowIndex]
+    writeTextSize(spec.key, spec.unit === "pt" ? Model.ptToPx(stopValue) : stopValue)
   }
 
   function adjustTextScope(rowIndex, deltaSteps) {
-    var px = textScopePx(rowIndex)
+    var value = textScopeValue(rowIndex)
     // Nothing read yet: the knob is a placeholder, so there is no stop to step
     // from. Dragging still works — that picks a stop outright.
-    if (!px) return
-    var idx = nearestTextStop(px) + deltaSteps
+    if (!value) return
+    var stops = textScopeSpecs[rowIndex].stops
+    var idx = nearestStop(stops, value) + deltaSteps
     if (idx < 0) idx = 0
-    if (idx > textSizeStops.length - 1) idx = textSizeStops.length - 1
-    writeTextSize(textScopeKeys[rowIndex], textSizeStops[idx])
+    if (idx > stops.length - 1) idx = stops.length - 1
+    writeTextScope(rowIndex, stops[idx])
   }
 
   function readTextScopes() {
@@ -423,7 +454,7 @@ Panel {
   function updateTextScopes(raw) {
     var parsed = Model.parseTextSizeStatus(raw)
     root.gtkPx = parsed.gtkPx
-    root.termPx = parsed.termPx
+    root.termPt = parsed.termPt
   }
 
   function adjustTextSize(deltaSteps) {
@@ -1028,7 +1059,8 @@ Panel {
     required property string label
     required property int rowIndex
 
-    readonly property real px: root.textScopePx(rowIndex)
+    readonly property var spec: root.textScopeSpecs[rowIndex]
+    readonly property real value: root.textScopeValue(rowIndex)
 
     spacing: Style.space(4)
 
@@ -1053,10 +1085,12 @@ Panel {
 
       Text {
         id: scopeValue
-        // Terminal points don't land on whole px, so allow one decimal.
+        // GTK's factor quantizes to whole points, so its px reads back
+        // fractional; the terminals row reads back whatever the config holds,
+        // which may be off-ladder. Allow one decimal on either.
         text: scopeSlider.dragging
-              ? root.textSizeStops[Math.round(scopeSlider.liveValue)] + "px"
-              : (scopeRow.px ? Math.round(scopeRow.px * 10) / 10 + "px" : "—")
+              ? scopeRow.spec.stops[Math.round(scopeSlider.liveValue)] + scopeRow.spec.unit
+              : (scopeRow.value ? Math.round(scopeRow.value * 10) / 10 + scopeRow.spec.unit : "—")
         color: Qt.darker(root.bar.foreground, 1.4)
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.caption
@@ -1083,15 +1117,15 @@ Panel {
         anchors.leftMargin: Style.space(6)
         anchors.rightMargin: Style.space(6)
         minimum: 0
-        maximum: root.textSizeStops.length - 1
+        maximum: scopeRow.spec.stops.length - 1
         step: 1
         integer: true
-        tickCount: root.textSizeStops.length
-        // Unread rows park on the 12px notch as a placeholder; the label says "—".
-        value: root.nearestTextStop(scopeRow.px || 12)
+        tickCount: scopeRow.spec.stops.length
+        // Unread rows park on the row's default notch (12px / 9pt) as a
+        // placeholder; the label says "—".
+        value: root.nearestStop(scopeRow.spec.stops, scopeRow.value || scopeRow.spec.placeholder)
         onReleased: function(v) {
-          root.writeTextSize(root.textScopeKeys[scopeRow.rowIndex],
-                             root.textSizeStops[Math.round(v)])
+          root.writeTextScope(scopeRow.rowIndex, scopeRow.spec.stops[Math.round(v)])
         }
       }
 

--- a/test/shell.d/display-text-size-test.sh
+++ b/test/shell.d/display-text-size-test.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+SANDBOXES=()
+
+cleanup() {
+  local sandbox
+  for sandbox in "${SANDBOXES[@]}"; do
+    rm -rf "$sandbox"
+  done
+}
+trap cleanup EXIT
+
+setup_sandbox() {
+  SANDBOX=$(mktemp -d)
+  SANDBOXES+=("$SANDBOX")
+
+  mkdir -p \
+    "$SANDBOX/home/.config"/{alacritty,kitty,ghostty,foot} \
+    "$SANDBOX/runtime" "$SANDBOX/bin" "$SANDBOX/log"
+
+  cat >"$SANDBOX/bin/stub" <<SH
+#!/bin/bash
+name="\${0##*/}"
+log_name="\$name"
+[[ \$name == "gsettings" && \$1 == "get" ]] && printf '1.0\n'
+[[ \$name == "omarchy-notification-send" ]] && log_name="notify"
+{
+  printf '%s' "\$1"
+  shift
+  printf ' %s' "\$@"
+  printf '\n'
+} >>"$SANDBOX/log/\$log_name.log"
+[[ \$name == "omarchy-notification-send" ]] && printf '42\n'
+exit 0
+SH
+  chmod +x "$SANDBOX/bin/stub"
+  for name in gsettings pkill pgrep omarchy-notification-send; do
+    ln -s stub "$SANDBOX/bin/$name"
+  done
+
+  printf '%s\n' "[font]" "size = 9" 'normal = { family = "Seed Alacritty" }' \
+    >"$SANDBOX/home/.config/alacritty/alacritty.toml"
+  printf '%s\n' "font_family Seed Kitty" "font_size 9.0" >"$SANDBOX/home/.config/kitty/kitty.conf"
+  printf '%s\n' "font-family = Seed Ghostty" "font-size = 9" >"$SANDBOX/home/.config/ghostty/config"
+  printf '%s\n' "[main]" "font=monospace:size=9" "pad=1x1" >"$SANDBOX/home/.config/foot/foot.ini"
+}
+
+seed_terminal_size() {
+  local size="$1"
+  sed -i "s/size = 9/size = $size/" "$SANDBOX/home/.config/alacritty/alacritty.toml"
+  sed -i "s/font_size 9.0/font_size $size.0/" "$SANDBOX/home/.config/kitty/kitty.conf"
+  sed -i "s/font-size = 9/font-size = $size/" "$SANDBOX/home/.config/ghostty/config"
+  sed -i "s/:size=9/:size=$size/" "$SANDBOX/home/.config/foot/foot.ini"
+}
+
+snapshot_configs() {
+  cp -r "$SANDBOX/home/.config" "$SANDBOX/before"
+}
+
+run_cli() {
+  STATUS=0
+  HOME="$SANDBOX/home" \
+  XDG_RUNTIME_DIR="$SANDBOX/runtime" \
+  PATH="$SANDBOX/bin:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-display-text-size" "$@" \
+    >"$SANDBOX/stdout" 2>"$SANDBOX/stderr" || STATUS=$?
+  OUT=$(<"$SANDBOX/stdout")
+  ERR=$(<"$SANDBOX/stderr")
+}
+
+assert_file_line() {
+  local relative="$1"
+  local expected="$2"
+  local description="$3"
+  local path="$SANDBOX/home/.config/$relative"
+  grep -Fqx -- "$expected" "$path" ||
+    fail "$description" "missing line: $expected"$'\n'"file: $path"
+}
+
+assert_log() {
+  local name="$1"
+  local expected="$2"
+  local description="$3"
+  local actual=""
+  [[ -f $SANDBOX/log/$name.log ]] && actual=$(<"$SANDBOX/log/$name.log")
+  [[ $actual == $expected ]] ||
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+}
+
+assert_terminal_configs_unchanged() {
+  local description="$1"
+  local relative
+  for relative in alacritty/alacritty.toml kitty/kitty.conf ghostty/config foot/foot.ini; do
+    cmp -s "$SANDBOX/before/$relative" "$SANDBOX/home/.config/$relative" ||
+      fail "$description" "changed: $relative"
+  done
+}
+
+assert_terminal_sizes() {
+  local size="$1"
+  local description="$2"
+  assert_file_line alacritty/alacritty.toml "size = $size" "$description: alacritty"
+  assert_file_line kitty/kitty.conf "font_size $size.0" "$description: kitty"
+  assert_file_line ghostty/config "font-size = $size" "$description: ghostty"
+  assert_file_line foot/foot.ini "font=monospace:size=$size" "$description: foot"
+}
+
+assert_terminal_side_effects() {
+  local description="$1"
+  assert_log pkill $'-USR1 kitty\n-SIGUSR2 ghostty' "$description: reload signals"
+  assert_log pgrep "-x foot" "$description: foot process check"
+  assert_log notify "Restart Foot to apply the new terminal font size -p" "$description: foot notification"
+}
+
+assert_no_terminal_side_effects() {
+  local description="$1"
+  local name
+  for name in pkill pgrep notify; do
+    [[ ! -s $SANDBOX/log/$name.log ]] ||
+      fail "$description: no $name invocation" "$(<"$SANDBOX/log/$name.log")"
+  done
+}
+
+assert_gtk_untouched() {
+  [[ ! -s $SANDBOX/log/gsettings.log ]] ||
+    fail "$1" "$(<"$SANDBOX/log/gsettings.log")"
+}
+
+assert_configs_unchanged() {
+  local description="$1"
+  local differences=""
+  differences=$(diff -r "$SANDBOX/before" "$SANDBOX/home/.config") ||
+    fail "$description" "$differences"
+}
+
+assert_sandbox_untouched() {
+  local description="$1"
+  assert_configs_unchanged "$description: configs unchanged"
+  [[ -z $(find "$SANDBOX/log" -type f -size +0c -print -quit) ]] ||
+    fail "$description: stub logs empty"
+}
+
+# 1. Unflagged status reports the whole-picture state.
+setup_sandbox
+sed -i "s/font-size = 9/font-size = 10/" "$SANDBOX/home/.config/ghostty/config"
+run_cli
+((STATUS == 0)) || fail "case 1 status exits successfully" "actual: $STATUS"
+[[ -z $ERR ]] || fail "case 1 status has empty stderr" "actual: $ERR"
+[[ $OUT == *"text size: 12 (default) px"* ]] ||
+  fail "case 1 reports the default shell size" "actual: $OUT"
+[[ $OUT == *"gtk text-scaling-factor: 1.0"* ]] ||
+  fail "case 1 reports the GTK factor" "actual: $OUT"
+[[ $OUT == *"terminal font: 10 pt"* ]] ||
+  fail "case 1 reads the Ghostty size first" "actual: $OUT"
+assert_log gsettings "get org.gnome.desktop.interface text-scaling-factor" "case 1 uses the gsettings read path"
+
+setup_sandbox
+rm -r "$SANDBOX/home/.config"/{alacritty,kitty,ghostty,foot}
+run_cli
+((STATUS == 0)) || fail "case 1 status without terminals exits successfully" "actual: $STATUS"
+[[ -z $ERR ]] || fail "case 1 status without terminals has empty stderr" "actual: $ERR"
+[[ $OUT == *"terminal font: n/a pt"* ]] ||
+  fail "case 1 reports no terminal config" "actual: $OUT"
+pass "case 1: unflagged status reports the current whole-picture state"
+
+# 2. Unflagged set updates every surface.
+setup_sandbox
+run_cli 16
+((STATUS == 0)) || fail "case 2 unflagged set exits successfully" "actual: $STATUS"
+[[ -z $ERR ]] || fail "case 2 unflagged set has empty stderr" "actual: $ERR"
+assert_file_line omarchy/shell.toml "[font]" "case 2 creates the shell font section"
+assert_file_line omarchy/shell.toml "base-size = 16" "case 2 sets the shell size"
+assert_log gsettings "set org.gnome.desktop.interface text-scaling-factor 1.3333" "case 2 sets the GTK factor"
+assert_terminal_sizes 12 "case 2 sets terminal sizes"
+assert_file_line alacritty/alacritty.toml 'normal = { family = "Seed Alacritty" }' "case 2 preserves the Alacritty family"
+assert_file_line kitty/kitty.conf "font_family Seed Kitty" "case 2 preserves the Kitty family"
+assert_file_line ghostty/config "font-family = Seed Ghostty" "case 2 preserves the Ghostty family"
+assert_file_line foot/foot.ini "pad=1x1" "case 2 preserves the Foot padding"
+assert_terminal_side_effects "case 2"
+pass "case 2: unflagged set updates every surface and reloads terminals"
+
+# 3. Unflagged reset returns every surface to its default.
+setup_sandbox
+seed_terminal_size 12
+mkdir -p "$SANDBOX/home/.config/omarchy"
+printf '%s\n' "[font]" "base-size = 16" "" "[bar]" 'position = "top"' \
+  >"$SANDBOX/home/.config/omarchy/shell.toml"
+run_cli reset
+((STATUS == 0)) || fail "case 3 unflagged reset exits successfully" "actual: $STATUS"
+! grep -Fq -- "base-size" "$SANDBOX/home/.config/omarchy/shell.toml" ||
+  fail "case 3 removes the shell base-size override"
+assert_file_line omarchy/shell.toml 'position = "top"' "case 3 preserves unrelated shell settings"
+assert_log gsettings "reset org.gnome.desktop.interface text-scaling-factor" "case 3 resets the GTK factor"
+assert_terminal_sizes 9 "case 3 resets terminal sizes"
+pass "case 3: unflagged reset returns every surface to its default"
+
+# 4. Shell-only set leaves GTK and terminal state untouched.
+setup_sandbox
+snapshot_configs
+run_cli --shell 16
+((STATUS == 0)) || fail "case 4 shell-only set exits successfully" "actual: $STATUS"
+assert_file_line omarchy/shell.toml "base-size = 16" "case 4 sets the shell size"
+assert_terminal_configs_unchanged "case 4 leaves terminal configs byte-identical"
+assert_gtk_untouched "case 4 does not invoke gsettings"
+assert_no_terminal_side_effects "case 4"
+pass "case 4: --shell updates only the shell"
+
+# 5. GTK-only set leaves shell and terminal files untouched.
+setup_sandbox
+snapshot_configs
+run_cli --gtk 16
+((STATUS == 0)) || fail "case 5 GTK-only set exits successfully" "actual: $STATUS"
+assert_log gsettings "set org.gnome.desktop.interface text-scaling-factor 1.3333" "case 5 sets the GTK factor"
+assert_configs_unchanged "case 5 leaves unscoped files byte-identical"
+assert_no_terminal_side_effects "case 5"
+pass "case 5: --gtk updates only GTK"
+
+# 6. Terminal-only set leaves shell and GTK untouched.
+setup_sandbox
+mkdir -p "$SANDBOX/home/.config/omarchy"
+printf '%s\n' "[bar]" 'position = "top"' \
+  >"$SANDBOX/home/.config/omarchy/shell.toml"
+cp "$SANDBOX/home/.config/omarchy/shell.toml" "$SANDBOX/shell-before"
+run_cli --terminals 16
+((STATUS == 0)) || fail "case 6 terminal-only set exits successfully" "actual: $STATUS"
+assert_terminal_sizes 12 "case 6 sets terminal sizes"
+assert_terminal_side_effects "case 6"
+cmp -s "$SANDBOX/shell-before" "$SANDBOX/home/.config/omarchy/shell.toml" ||
+  fail "case 6 leaves shell.toml byte-identical"
+assert_gtk_untouched "case 6 does not invoke gsettings"
+pass "case 6: --terminals updates only terminal configs"
+
+# 7. Two flags compose while leaving GTK untouched.
+setup_sandbox
+run_cli --shell --terminals 14
+((STATUS == 0)) || fail "case 7 two-scope set exits successfully" "actual: $STATUS"
+assert_file_line omarchy/shell.toml "base-size = 14" "case 7 sets the shell size"
+assert_terminal_sizes 11 "case 7 sets mapped terminal sizes"
+assert_gtk_untouched "case 7 does not invoke gsettings"
+pass "case 7: --shell and --terminals compose"
+
+# 8. GTK reset and default are both isolated.
+for action in reset default; do
+  setup_sandbox
+  seed_terminal_size 12
+  mkdir -p "$SANDBOX/home/.config/omarchy"
+  printf '%s\n' "[font]" "base-size = 16" \
+    >"$SANDBOX/home/.config/omarchy/shell.toml"
+  snapshot_configs
+  run_cli --gtk "$action"
+  ((STATUS == 0)) || fail "case 8 --gtk $action exits successfully" "actual: $STATUS"
+  assert_log gsettings "reset org.gnome.desktop.interface text-scaling-factor" "case 8 --gtk $action resets GTK"
+  assert_configs_unchanged "case 8 --gtk $action leaves files byte-identical"
+  assert_no_terminal_side_effects "case 8 --gtk $action"
+done
+pass "case 8: --gtk reset and default reset only GTK"
+
+# 9. A trailing shell flag scopes reset.
+setup_sandbox
+seed_terminal_size 12
+mkdir -p "$SANDBOX/home/.config/omarchy"
+printf '%s\n' "[font]" "base-size = 16" "" "[bar]" 'position = "top"' \
+  >"$SANDBOX/home/.config/omarchy/shell.toml"
+snapshot_configs
+run_cli reset --shell
+((STATUS == 0)) || fail "case 9 trailing shell flag exits successfully" "actual: $STATUS"
+! grep -Fq -- "base-size" "$SANDBOX/home/.config/omarchy/shell.toml" ||
+  fail "case 9 trailing shell flag removes the shell override"
+assert_file_line omarchy/shell.toml 'position = "top"' "case 9 trailing shell flag preserves unrelated shell settings"
+assert_terminal_configs_unchanged "case 9 leaves terminals byte-identical"
+assert_gtk_untouched "case 9 leaves GTK untouched"
+assert_no_terminal_side_effects "case 9"
+pass "case 9: reset --shell scopes the reset"
+
+# 10. Help takes precedence and never mutates.
+check_help() {
+  setup_sandbox
+  snapshot_configs
+  run_cli "$@"
+  ((STATUS == 0)) || fail "case 10 help exits successfully: $*" "actual: $STATUS"
+  [[ -z $ERR ]] || fail "case 10 help has empty stderr: $*" "actual: $ERR"
+  [[ $OUT == *"Usage:"* ]] ||
+    fail "case 10 help prints usage on stdout: $*" "actual: $OUT"
+  assert_sandbox_untouched "case 10 help leaves the sandbox untouched: $*"
+}
+
+check_help --shell --help
+check_help 16 --help
+pass "case 10: help is first and mutation-free"
+
+# 11. Validation distinguishes size diagnostics from usage errors.
+check_size_error() {
+  setup_sandbox
+  snapshot_configs
+  run_cli "$@"
+  ((STATUS == 1)) || fail "case 11 invalid size exits 1: $*" "actual: $STATUS"
+  [[ -z $OUT ]] || fail "case 11 invalid size has empty stdout: $*" "actual: $OUT"
+  [[ $ERR == *"Size must be an integer between 9 and 20 (px)."* ]] ||
+    fail "case 11 invalid size prints the size diagnostic: $*" "actual: $ERR"
+  [[ $ERR == *"Usage:"* ]] ||
+    fail "case 11 invalid size prints usage: $*" "actual: $ERR"
+  assert_sandbox_untouched "case 11 invalid size leaves the sandbox untouched: $*"
+}
+
+check_usage_error() {
+  setup_sandbox
+  snapshot_configs
+  run_cli "$@"
+  ((STATUS == 1)) || fail "case 11 usage error exits 1: $*" "actual: $STATUS"
+  [[ -z $OUT ]] || fail "case 11 usage error has empty stdout: $*" "actual: $OUT"
+  [[ $ERR == *"Usage:"* ]] ||
+    fail "case 11 usage error prints usage: $*" "actual: $ERR"
+  [[ $ERR != *"Size must be an integer between 9 and 20 (px)."* ]] ||
+    fail "case 11 usage error omits the size diagnostic: $*" "actual: $ERR"
+  assert_sandbox_untouched "case 11 usage error leaves the sandbox untouched: $*"
+}
+
+for size in 8 21 16.5 -1 08 １６ 18446744073709551625; do
+  check_size_error "$size"
+done
+check_usage_error --bogus 16
+check_usage_error --shell
+check_usage_error 16 foo
+pass "case 11: invalid argv fails before mutation with the right diagnostic"

--- a/test/shell.d/display-text-size-test.sh
+++ b/test/shell.d/display-text-size-test.sh
@@ -26,7 +26,14 @@ setup_sandbox() {
 #!/bin/bash
 name="\${0##*/}"
 log_name="\$name"
-[[ \$name == "gsettings" && \$1 == "get" ]] && printf '1.0\n'
+if [[ \$name == "gsettings" && \$1 == "get" ]]; then
+  # font-name drives GTK factor quantization; scaling-factor is the knob we set.
+  if [[ \$3 == "font-name" ]]; then
+    printf "'Cantarell 11'\n"
+  else
+    printf '1.0\n'
+  fi
+fi
 [[ \$name == "omarchy-notification-send" ]] && log_name="notify"
 {
   printf '%s' "\$1"
@@ -174,7 +181,8 @@ run_cli 16
 [[ -z $ERR ]] || fail "case 2 unflagged set has empty stderr" "actual: $ERR"
 assert_file_line omarchy/shell.toml "[font]" "case 2 creates the shell font section"
 assert_file_line omarchy/shell.toml "base-size = 16" "case 2 sets the shell size"
-assert_log gsettings "set org.gnome.desktop.interface text-scaling-factor 1.3333" "case 2 sets the GTK factor"
+# 16px with an 11pt interface font quantizes to 15/11 ≈ 1.3636 (whole-point GTK).
+assert_log gsettings $'get org.gnome.desktop.interface font-name\nset org.gnome.desktop.interface text-scaling-factor 1.3636' "case 2 sets the GTK factor"
 assert_terminal_sizes 12 "case 2 sets terminal sizes"
 assert_file_line alacritty/alacritty.toml 'normal = { family = "Seed Alacritty" }' "case 2 preserves the Alacritty family"
 assert_file_line kitty/kitty.conf "font_family Seed Kitty" "case 2 preserves the Kitty family"
@@ -214,7 +222,7 @@ setup_sandbox
 snapshot_configs
 run_cli --gtk 16
 ((STATUS == 0)) || fail "case 5 GTK-only set exits successfully" "actual: $STATUS"
-assert_log gsettings "set org.gnome.desktop.interface text-scaling-factor 1.3333" "case 5 sets the GTK factor"
+assert_log gsettings $'get org.gnome.desktop.interface font-name\nset org.gnome.desktop.interface text-scaling-factor 1.3636' "case 5 sets the GTK factor"
 assert_configs_unchanged "case 5 leaves unscoped files byte-identical"
 assert_no_terminal_side_effects "case 5"
 pass "case 5: --gtk updates only GTK"

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -75,4 +75,25 @@ assertDeepEqual(
 )
 
 assertDeepEqual(monitor.parseDisplays('{'), { displays: [], enabledDisplayCount: 0 }, 'monitor handles invalid display JSON')
+
+assertDeepEqual(
+  monitor.parseTextSizeStatus('text size: 12 px\ngtk text-scaling-factor: 1.25\nterminal font: 10.5 pt\n'),
+  { gtkPx: 15, termPx: 14 },
+  'monitor converts gtk factor and terminal points to px'
+)
+assertDeepEqual(
+  monitor.parseTextSizeStatus('text size: 12 px\ngtk text-scaling-factor: 1\nterminal font: n/a pt\n'),
+  { gtkPx: 12, termPx: 0 },
+  'monitor reports an undescribed terminal font as unavailable'
+)
+assertDeepEqual(
+  monitor.parseTextSizeStatus(''),
+  { gtkPx: 0, termPx: 0 },
+  'monitor reports empty text size status as unavailable'
+)
+assertDeepEqual(
+  monitor.parseTextSizeStatus('command not found'),
+  { gtkPx: 0, termPx: 0 },
+  'monitor reports malformed text size status as unavailable'
+)
 JS

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -78,22 +78,45 @@ assertDeepEqual(monitor.parseDisplays('{'), { displays: [], enabledDisplayCount:
 
 assertDeepEqual(
   monitor.parseTextSizeStatus('text size: 12 px\ngtk text-scaling-factor: 1.25\nterminal font: 10.5 pt\n'),
-  { gtkPx: 15, termPx: 14 },
-  'monitor converts gtk factor and terminal points to px'
+  { gtkPx: 15, termPt: 10.5 },
+  'monitor converts gtk factor to px and passes terminal points through'
+)
+assertDeepEqual(
+  monitor.parseTextSizeStatus('text size: 12 px\ngtk text-scaling-factor: 1\nterminal font: 11.0 pt\n'),
+  { gtkPx: 12, termPt: 11 },
+  'monitor reads a kitty-style decimal terminal point size'
 )
 assertDeepEqual(
   monitor.parseTextSizeStatus('text size: 12 px\ngtk text-scaling-factor: 1\nterminal font: n/a pt\n'),
-  { gtkPx: 12, termPx: 0 },
+  { gtkPx: 12, termPt: 0 },
   'monitor reports an undescribed terminal font as unavailable'
 )
 assertDeepEqual(
+  monitor.parseTextSizeStatus('text size: 12 px\ngtk text-scaling-factor: 1\nterminal font: 10..5 pt\n'),
+  { gtkPx: 12, termPt: 0 },
+  'monitor reports a malformed terminal point size as unavailable'
+)
+assertDeepEqual(
   monitor.parseTextSizeStatus(''),
-  { gtkPx: 0, termPx: 0 },
+  { gtkPx: 0, termPt: 0 },
   'monitor reports empty text size status as unavailable'
 )
 assertDeepEqual(
   monitor.parseTextSizeStatus('command not found'),
-  { gtkPx: 0, termPx: 0 },
+  { gtkPx: 0, termPt: 0 },
   'monitor reports malformed text size status as unavailable'
 )
+
+assertEqual(monitor.ptToPx(7), 9, 'monitor rounds 7pt down to 9px')
+assertEqual(monitor.ptToPx(8), 11, 'monitor rounds 8pt up to 11px')
+assertEqual(monitor.ptToPx(9), 12, 'monitor maps the 9pt terminal default onto the 12px anchor')
+assertEqual(monitor.ptToPx(11), 15, 'monitor rounds 11pt up to 15px')
+assertEqual(monitor.ptToPx(12), 16, 'monitor maps 12pt to 16px')
+assertEqual(monitor.ptToPx(14), 19, 'monitor rounds 14pt up to 19px')
+assertEqual(monitor.ptToPx(15), 20, 'monitor maps the largest terminal point stop to 20px')
+assertEqual(monitor.pxToPt(10), 8, 'monitor rounds 10px up to 8pt')
+assertEqual(monitor.pxToPt(14), 11, 'monitor rounds the 14px half-point boundary up to 11pt')
+for (let pt = 7; pt <= 15; pt++) {
+  assertEqual(monitor.pxToPt(monitor.ptToPx(pt)), pt, `terminal pt ${pt} round-trips through px`)
+}
 JS


### PR DESCRIPTION
## Summary

**Supersedes #6362.** This PR includes that CLI change and the monitor-panel UI that uses it, so the scope flags and the disclosure sliders land together.

- **CLI** (`omarchy-display-text-size`): `--shell`, `--gtk`, and `--terminals` set or reset each surface on its own; no flags keeps the existing one-knob behavior. GTK factor quantization from current `quattro` is preserved.
- **Monitor panel**: TEXT SIZE gains a disclosure chevron. Expanded rows for Shell, GTK apps, and Terminals write through the new flags. The unified slider above still sets all three together.
- **Status / polling**: rows update from the written value (CLI is authoritative); open-time status and a 5s poll pick up external gsettings/terminal changes. Undescribed scopes show "—" and refuse relative steps.
- **Terminals row in points**: the Terminals slider operates natively in whole points (7–15pt — exactly the points whose px images the CLI accepts and round-trips), labeled `11pt` instead of a derived `14.7px`. The CLI stays px-based; the panel converts at the edge.
- **Tests**: shell coverage for the scope flags, quantized GTK factor, and the pt⇄px conversion (round-trip and rounding-boundary pins).

### Why the GTK row can show an off-notch value

The CLI quantizes the GTK factor so the interface font lands on a whole point size, and the row displays the value read back from the CLI rather than the requested notch — so GTK can read back fractional px. The Terminals row no longer has this problem: it works in the terminal's native unit, so it reads back exactly the whole points the configs store (an off-ladder value set by hand, like `10.5`, still shows honestly with the knob on the nearest stop).

### Screenshot

Display panel with per-scope text size rows expanded:

![Per-scope text size sliders in the Display panel](https://github.com/jzetterman/omarchy/releases/download/pr-screenshot-assets/text-size-scope-sliders.png)

## Test plan

- [x] `./test/shell.d/display-text-size-test.sh` passes
- [ ] Unified TEXT SIZE slider still sets shell + GTK + terminals together
- [ ] Expand disclosure; each scope slider only changes that surface
- [ ] External gsettings / terminal config change is reflected after open or within the poll window
- [ ] Scopes with no status still show "—" and block relative steps; absolute drag still works
- [x] Terminals row shows whole points (`11pt`), parks a hand-set `10.5` on the 10 stop, and unread rows park on the 9pt placeholder
- [ ] Visual check: indentation, hairline gutter, no clipping when expanded (see screenshot)

