### PR TITLE
Enhance herdr command entries with descriptions

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -62,21 +62,25 @@ next_workspace = ["prefix+shift+n", "alt+down"]
 key = "ctrl+alt+shift+left"
 type = "shell"
 command = "herdr pane resize --current --direction left --amount 0.03"
+description = "resize left by ~5 columns/rows"
 
 [[keys.command]]
 key = "ctrl+alt+shift+down"
 type = "shell"
 command = "herdr pane resize --current --direction down --amount 0.03"
+description = "resize down by ~5 columns/rows"
 
 [[keys.command]]
 key = "ctrl+alt+shift+up"
 type = "shell"
 command = "herdr pane resize --current --direction up --amount 0.03"
+description = "resize up by ~5 columns/rows"
 
 [[keys.command]]
 key = "ctrl+alt+shift+right"
 type = "shell"
 command = "herdr pane resize --current --direction right --amount 0.03"
+description = "resize right by ~5 columns/rows"
 
 [ui]
 accent = "blue"


### PR DESCRIPTION
Without description, keybindings have a generic "custom command" title in herdr's help>keybindings window.
<img width="674" height="418" alt="Screenshot 2026-08-05 at 21 30 08" src="https://github.com/user-attachments/assets/012d4b28-83c3-4760-83dc-96cbd1cba75e" />
