### PR TITLE
Apply the terminal tag to Omarchy's own terminal windows

### DIFF
--- a/default/hypr/apps/terminals.lua
+++ b/default/hypr/apps/terminals.lua
@@ -1,3 +1,7 @@
--- Define terminal tag to style them uniformly.
-o.window("(Alacritty|kitty|com.mitchellh.ghostty|foot|wezterm)", { tag = "+terminal" })
-o.window({ tag = "terminal" }, { tag = "-default-opacity", opacity = "0.985 0.96" })
+-- Define terminal tag so themes and bindings can single terminals out. Omarchy
+-- launches TUIs and its own terminal windows under dedicated app-ids
+-- (org.omarchy.btop, org.omarchy.terminal, TUI.float, ...), so match those too.
+o.window(
+  "(Alacritty|kitty|com.mitchellh.ghostty|foot|wezterm|org\\.omarchy\\..*|TUI\\..*)",
+  { tag = "+terminal" }
+)

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -15,21 +15,21 @@ local function send_shortcut_once(mods, key)
   end
 end
 
-local terminal_classes = {
-  alacritty = true,
-  ["com.mitchellh.ghostty"] = true,
-  foot = true,
-  kitty = true,
-  wezterm = true,
-}
-
+-- Lean on the terminal tag from default/hypr/apps/terminals.lua so there's one
+-- definition of what counts as a terminal. Dynamic tags carry a trailing "*".
 local function active_window_is_terminal()
   local window = hl.get_active_window()
-  if not window or not window.class then
+  if not window then
     return false
   end
 
-  return terminal_classes[window.class:lower()] == true
+  for _, tag in ipairs(window.tags or {}) do
+    if tag:gsub("%*$", "") == "terminal" then
+      return true
+    end
+  end
+
+  return false
 end
 
 local function universal_clipboard_shortcut(default_mods, default_key, terminal_mods, terminal_key)


### PR DESCRIPTION
Fixes #6530.

`omarchy-launch-tui` launches with `--app-id=org.omarchy.<command>`, so a TUI window's class is `org.omarchy.btop`, not the terminal that drew it. The class regex in `default/hypr/apps/terminals.lua` never matched, and those windows went untagged:

```
class=org.omarchy.btop  initialClass=org.omarchy.btop  tags=default-opacity*,floating-window*
class=Alacritty         initialClass=Alacritty         tags=terminal*
```

Same gap for `org.omarchy.terminal` (menu actions, share flows, package install), `org.omarchy.screensaver`, and the `TUI.float` / `TUI.tile` classes `omarchy-tui-install` writes into desktop files.

The issue suggests matching on `initial_title` instead. That misses Omarchy's own launchers — `omarchy-launch-floating-terminal-with-presentation` passes `--title=Omarchy`, so the window's `initialTitle` is `Omarchy` — and it breaks for anyone who sets `window.title` in `alacritty.toml` or `title=` in `foot.ini`. Matching the class namespaces Omarchy owns is deterministic.

## Apply the terminal tag to Omarchy's own terminal windows

Extends the class match to `org.omarchy.*` and `TUI.*`, and drops the tag's opacity rule, which stripped `default-opacity` only to re-apply the identical `0.985 0.96`. `themes/kanagawa/hyprland.lua` is the tag's other consumer and still overrides through it — its rule loads after `windows.lua`, so it wins without the `-default-opacity` dance.

## Match terminals by tag for universal clipboard shortcuts

`default/hypr/bindings/clipboard.lua` kept a second, independent list of terminal classes with the same gap. That one is user-visible: `SUPER + C` in a TUI window fell through to the non-terminal branch and sent `CTRL + C` — an interrupt to btop or nvim — instead of `CTRL + Insert`. `SUPER + V` sent `CTRL + V` instead of `SHIFT + Insert`.

Rather than duplicating the fix, the binding now reads the tag, so there's one definition of what counts as a terminal. `hl.get_active_window()` returns userdata whose `tags` field comes back as `{"default-opacity*", "floating-window*", "terminal*"}`; the trailing `*` marks a dynamically applied tag, hence the strip.

## Verification

Live, on a real btop window launched through `omarchy-launch-tui`:

```
class=org.omarchy.btop tags=default-opacity*,floating-window*,terminal* is_terminal=true
```

Tags on the actual windows: `org.omarchy.btop` and `Alacritty` both get `terminal*`, `imv` does not.

Predicate driven through the real bind closures with a stubbed `hl`:

```
terminal only          -> CTRL+Insert     non-terminal   -> CTRL+C
terminal + others      -> CTRL+Insert     no tags        -> CTRL+C
static tag (no star)   -> CTRL+Insert     lookalike tag  -> CTRL+C
                                          nil window     -> CTRL+C
```

`hyprctl reload` clean, `hyprctl configerrors` empty, all three universal binds present. `./test/all` passes 1034 assertions; the one failure (`migration restarts the shell`) is pre-existing and fails identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)