### PR TITLE
Make model-usage's bar icon swappable

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -18,6 +18,11 @@ Panel {
   readonly property color track: Style.selectedFillFor(foreground, Color.accent)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
+  // The bar mark comes in two styles: one robot glyph, or one chip per agent
+  // with its mark and the percentage of its tightest limit. Right click flips
+  // between them.
+  readonly property bool usageIconStyle: String(setting("barIconStyle", "Robot")).toLowerCase() === "usage"
+
   readonly property var providers: usage.enabledProviders
   // The selection follows the provider, not the slot it happens to sit in: a
   // provider whose first scan lands while the panel is open would otherwise
@@ -52,6 +57,18 @@ Panel {
 
   function refreshNow() {
     usage.refreshAll(true)
+  }
+
+  // Applied locally first so the bar changes on the click itself; the
+  // shell.json write comes back through the bar as the same value.
+  function toggleIconStyle() {
+    var entry = { id: root.moduleName }
+    for (var key in root.settings) if (key !== "id") entry[key] = root.settings[key]
+    entry.barIconStyle = usageIconStyle ? "Robot" : "Usage"
+
+    root.settings = entry
+    if (root.bar && root.bar.shell && typeof root.bar.shell.updateEntryInline === "function")
+      root.bar.shell.updateEntryInline(root.moduleName, entry)
   }
 
   // ---------------------------------------------------------------- limits
@@ -116,6 +133,12 @@ Panel {
       if (!best || windows[i].percent > best.percent) best = windows[i]
     }
     return best
+  }
+
+  function barPercentText(p) {
+    var w = bindingWindow(p)
+    if (!w || !(w.percent >= 0)) return "—"
+    return Math.round(w.percent * 100) + "%"
   }
 
   function resetMsFor(w) {
@@ -256,9 +279,17 @@ Panel {
   // Nothing to report, nothing in the bar: Bar.qml collapses a slot whose item
   // is invisible, so the icon appears the moment the first scan finds usage and
   // stays away entirely on a machine that has never run either CLI.
+  readonly property Item barButton: usageIconStyle ? usageButton : button
+
   visible: providers.length > 0
-  implicitWidth: button.implicitWidth
-  implicitHeight: button.implicitHeight
+  implicitWidth: barButton.implicitWidth
+  implicitHeight: barButton.implicitHeight
+
+  function handleBarPress(buttonCode) {
+    if (buttonCode === Qt.RightButton) toggleIconStyle()
+    else if (buttonCode === Qt.MiddleButton) selectProvider(providerIndex + 1)
+    else toggle()
+  }
 
   onProviderIndexChanged: if (panelFlick) panelFlick.contentY = 0
   onOpenedChanged: if (opened) {
@@ -296,20 +327,53 @@ Panel {
 
   BarIconButton {
     id: button
+    visible: !root.usageIconStyle
     anchors.fill: parent
     bar: root.bar
     text: "󱚣"
     active: root.alarming
-    onPressed: function(buttonCode) {
-      if (buttonCode === Qt.RightButton) root.refreshNow()
-      else if (buttonCode === Qt.MiddleButton) root.selectProvider(root.providerIndex + 1)
-      else root.toggle()
+    onPressed: function(buttonCode) { root.handleBarPress(buttonCode) }
+  }
+
+  WidgetButton {
+    id: usageButton
+    visible: root.usageIconStyle
+    anchors.fill: parent
+    bar: root.bar
+    labelVisible: false
+    hasVisualContent: root.usageIconStyle
+    fixedWidth: root.bar && root.bar.vertical ? -1 : chipRow.implicitWidth + Style.space(16)
+    fixedHeight: root.bar && root.bar.vertical ? chipColumn.implicitHeight + Style.space(8) : -1
+    onPressed: function(buttonCode) { root.handleBarPress(buttonCode) }
+
+    Row {
+      id: chipRow
+      visible: !usageButton.vertical
+      anchors.centerIn: parent
+      spacing: Style.space(8)
+
+      Repeater {
+        model: root.providers
+        UsageChip { vertical: false }
+      }
+    }
+
+    Column {
+      id: chipColumn
+      visible: usageButton.vertical
+      anchors.centerIn: parent
+      spacing: Style.space(4)
+
+      Repeater {
+        model: root.providers
+        UsageChip { vertical: true }
+      }
     }
   }
 
   KeyboardPanel {
     id: panel
-    anchorItem: button
+    anchorItem: root.barButton
     owner: root
     bar: root.bar
     open: root.opened
@@ -364,42 +428,9 @@ Panel {
             fontFamily: root.fontFamily
 
             iconComponent: Component {
-              Item {
-                id: heroMark
-                property var candidates: root.iconCandidatesForProvider(root.provider, root.surface)
-                // Provider objects are rebuilt on every refresh, which churns the
-                // array's identity without changing its content. Restart the fallback
-                // walk only when the URLs change: re-pointing source at a URL whose
-                // load already failed emits no statusChanged, so an identity-only
-                // reset would strand the walker on a missing -light twin.
-                property string candidatesKey: candidates.join("\n")
-                property int candidateIndex: 0
-                onCandidatesKeyChanged: candidateIndex = 0
-
-                width: Style.font.display
-                height: Style.font.display
-
-                Image {
-                  id: heroMarkImage
-                  anchors.fill: parent
-                  source: heroMark.candidateIndex < heroMark.candidates.length ? heroMark.candidates[heroMark.candidateIndex] : ""
-                  sourceSize.width: Style.font.display * 2
-                  sourceSize.height: Style.font.display * 2
-                  fillMode: Image.PreserveAspectFit
-                  // Advancing source from inside its own status change trips the
-                  // binding-loop detector; defer the step one tick.
-                  onStatusChanged: if (status === Image.Error && heroMark.candidateIndex < heroMark.candidates.length)
-                    Qt.callLater(function() { heroMark.candidateIndex++ })
-                }
-
-                Text {
-                  anchors.centerIn: parent
-                  visible: heroMarkImage.status !== Image.Ready
-                  text: button.text
-                  color: root.foreground
-                  font.family: root.fontFamily
-                  font.pixelSize: Style.font.display
-                }
+              AgentMark {
+                provider: root.provider
+                surfaceColor: root.surface
               }
             }
           }
@@ -590,6 +621,86 @@ Panel {
           }
         }
       }
+    }
+  }
+
+  // An agent's mark with the by-convention fallback walk: the -light twin on
+  // light surfaces, then the plain mark, then the module's bar glyph.
+  component AgentMark: Item {
+    id: mark
+    property var provider: null
+    property color surfaceColor: Color.background
+    property real size: Style.font.display
+
+    // Provider objects are rebuilt on every refresh, which churns the
+    // array's identity without changing its content. Restart the fallback
+    // walk only when the URLs change: re-pointing source at a URL whose
+    // load already failed emits no statusChanged, so an identity-only
+    // reset would strand the walker on a missing -light twin.
+    property var candidates: root.iconCandidatesForProvider(provider, surfaceColor)
+    property string candidatesKey: candidates.join("\n")
+    property int candidateIndex: 0
+    onCandidatesKeyChanged: candidateIndex = 0
+
+    width: size
+    height: size
+
+    Image {
+      id: markImage
+      anchors.fill: parent
+      source: mark.candidateIndex < mark.candidates.length ? mark.candidates[mark.candidateIndex] : ""
+      sourceSize.width: mark.size * 2
+      sourceSize.height: mark.size * 2
+      fillMode: Image.PreserveAspectFit
+      // Advancing source from inside its own status change trips the
+      // binding-loop detector; defer the step one tick.
+      onStatusChanged: if (status === Image.Error && mark.candidateIndex < mark.candidates.length)
+        Qt.callLater(function() { mark.candidateIndex++ })
+    }
+
+    Text {
+      anchors.centerIn: parent
+      visible: markImage.status !== Image.Ready
+      text: button.text
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: mark.size
+    }
+  }
+
+  // One agent in the bar: its mark and the percentage of the window that
+  // stops the next prompt.
+  component UsageChip: Grid {
+    id: chip
+    required property var modelData
+    property bool vertical: false
+
+    readonly property real pct: {
+      var window = root.bindingWindow(modelData)
+      return window ? Number(window.percent) : -1
+    }
+    readonly property bool alarming: pct >= 0.9
+    readonly property real iconSize: Style.space(13)
+
+    columns: vertical ? 1 : 2
+    columnSpacing: Style.space(4)
+    rowSpacing: Style.space(1)
+    verticalItemAlignment: Grid.AlignVCenter
+    horizontalItemAlignment: Grid.AlignHCenter
+
+    AgentMark {
+      provider: chip.modelData
+      surfaceColor: root.bar ? root.bar.background : Color.bar.background
+      size: chip.iconSize
+      opacity: chip.alarming ? 0.75 : 1
+    }
+
+    Text {
+      text: root.barPercentText(chip.modelData)
+      color: chip.alarming ? root.urgent : usageButton.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: chip.alarming
     }
   }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -58,7 +58,9 @@ falls back to local stats only. A non-default Claude directory is honored via
 
 ## Interactions
 
-- Bar icon: left = panel, right = refresh, middle = next subscription.
+- Bar icon: left = panel, right = toggle icon style, middle = next
+  subscription. The icon comes in two styles: one robot glyph, or one chip
+  per agent with its mark and the percentage of its tightest limit.
 - Panel: `h`/`l` switch subscription, `j`/`k` scroll, `r` or Enter refresh,
   Tab moves to the neighboring bar panel, Esc closes.
 - IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next>`.
@@ -71,6 +73,7 @@ top-level keys can be set with
 
 | Key | Default | What it does |
 |---|---|---|
+| `barIconStyle` | `"Robot"` | `"Usage"` shows each agent's mark with its tightest limit |
 | `refreshIntervalSec` | `900` | How often the usage records regenerate |
 | `syncMode` | `"Off"` | `"On"` writes this machine's snapshot and merges the others |
 | `syncDir` | `""` | A folder synced by Syncthing, Dropbox, rsync, … |

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -22,6 +22,7 @@
         "claude": { "enabled": true },
         "codex": { "enabled": true }
       },
+      "barIconStyle": "Robot",
       "refreshIntervalSec": 900,
       "syncMode": "Off",
       "syncDir": "",
@@ -29,6 +30,7 @@
       "syncDeviceId": ""
     },
     "schema": [
+      { "key": "barIconStyle", "type": "enum", "label": "Bar icon", "options": ["Robot", "Usage"], "defaultValue": "Robot", "description": "Robot shows one glyph. Usage shows each agent's mark with the percentage of its tightest limit." },
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 30, "max": 3600, "step": 30, "defaultValue": 900 },
       { "key": "syncMode", "type": "enum", "label": "Synced aggregation", "options": ["Off", "On"], "defaultValue": "Off", "description": "When On, write this machine's local usage snapshot and merge snapshots from other machines." },
       { "key": "syncDir", "type": "path", "label": "Sync folder", "defaultValue": "", "description": "A folder synced by Syncthing, Dropbox, rsync, etc." },

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -67,7 +67,7 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.audio` | Volume icon + popup with master slider, output-device picker, per-app mixer | left = popup · right = mute · middle = popup · scroll = volume |
 | `omarchy.network` | Wi-Fi/Ethernet icon + popup with Wi-Fi scan, signal, connect, DNS provider selection | left = popup · right = nmtui |
 | `omarchy.tailscale` | Tailscale status, connection switcher, machine browser, and copy actions | left = popup · right = toggle · middle = refresh |
-| `omarchy.agents` | AI coding agent limits with pace, today, last week, and all-time model breakdown | left = panel · right = refresh · middle = next subscription |
+| `omarchy.agents` | AI coding agent limits with pace, today, last week, and all-time model breakdown | left = panel · right = toggle icon style · middle = next subscription |
 | `omarchy.power` | Battery/AC icon + popup with battery stats, power profiles, and system info | left = popup · right = toggle percentage |
 | `omarchy.bluetooth` | Bluetooth icon + popup with device list, connect/disconnect, battery | left = popup · right = toggle radio · middle = bluetoothctl TUI |
 | `omarchy.monitor` | Brightness and laptop display controls | left = popup |

--- a/test/shell.d/agents-icon-style-test.sh
+++ b/test/shell.d/agents-icon-style-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const manifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/agents/manifest.json', 'utf8'))
+
+// ---- the two styles
+assert(/setting\("barIconStyle", "Robot"\)/.test(panelSource), 'agents falls back to the robot style without a stored setting')
+assert(/visible: !root\.usageIconStyle/.test(panelSource), 'agents hides the robot button in usage style')
+assert(/visible: root\.usageIconStyle/.test(panelSource), 'agents shows the chips in usage style')
+assert(/component UsageChip/.test(panelSource) && /model: root\.providers/.test(panelSource), 'agents draws one chip per subscription')
+assert(/barPercentText/.test(panelSource) && /bindingWindow\(p\)/.test(panelSource), 'agents chips show the tightest limit')
+assert(/component AgentMark/.test(panelSource) && /iconCandidatesForProvider/.test(panelSource), 'agents chips reuse the mark fallback walk')
+
+// ---- the right-click toggle
+assert(/Qt\.RightButton\) toggleIconStyle\(\)/.test(panelSource), 'agents right click flips the icon style')
+assert(/else toggle\(\)/.test(panelSource), 'agents left click still reveals the panel')
+
+// ---- persistence
+assert(/for \(var key in root\.settings\) if \(key !== "id"\) entry\[key\] = root\.settings\[key\]/.test(panelSource), 'agents carries the existing settings into the persisted entry')
+assert(/entry\.barIconStyle = usageIconStyle \? "Robot" : "Usage"[\s\S]*root\.settings = entry[\s\S]*updateEntryInline/.test(panelSource), 'agents applies the flipped style locally and writes it to shell.json')
+
+// ---- shipped defaults
+const defaults = manifest.barWidget.defaults
+assertEqual(defaults.barIconStyle, 'Robot', 'agents ships the robot style as the default')
+const styleField = manifest.barWidget.schema.find(function(field) { return field.key === 'barIconStyle' })
+assert(!!styleField, 'agents exposes the icon style in the settings schema')
+assertEqual(styleField.type, 'enum', 'agents offers the icon style as a choice')
+assertDeepEqual(styleField.options, ['Robot', 'Usage'], 'agents offers exactly the two styles')
+assertEqual(styleField.defaultValue, defaults.barIconStyle, 'agents schema default matches the shipped default')
+JS


### PR DESCRIPTION
The new icon looks clean, but the old one was quite useful because it would tell you at a glance what your usage was - like the battery or wifi icons do. This PR adds the ability to swap between the two icon styles with a right-click menu.

https://github.com/user-attachments/assets/54388c89-637e-4379-b3d9-43e0a76ea9ec

The design is inspired by the tray icons right-click menu. The default icon is the robot.