### PR TITLE
Detect Elan match-on-chip fingerprint readers again

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -30,7 +30,10 @@ for dev in /sys/bus/usb/devices/*; do
   if [[ -r $dev/product ]]; then
     product=$(<"$dev/product")
     product=${product,,}
-    [[ $product == *fingerprint* || $product == *biometric* ]] && exit 0
+    # Elan's match-on-chip readers report "ELAN:ARM-M4", the family name
+    # rather than the function. Elan is left out of the vendor list below
+    # on purpose, so without this they match nothing.
+    [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* ]] && exit 0
   fi
 
   if [[ -r $dev/idVendor ]]; then

--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -31,7 +31,7 @@ for dev in /sys/bus/usb/devices/*; do
     product=$(<"$dev/product")
     product=${product,,}
     # Elan's match-on-chip readers report "ELAN:ARM-M4", the family name
-    # rather than the function. Elan is left out of the vendor list below
+    # rather than the function. Elan is left out of the vendor list above
     # on purpose, so without this they match nothing.
     [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* ]] && exit 0
   fi

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -83,9 +83,6 @@ fi
 
 omarchy-pkg-add libfprint fprintd usbutils
 
-# Configure PAM
-setup_pam_config
-
 # Enroll first fingerprint
 echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\e[0m"
 echo -e "Keep moving the finger around on sensor until the process completes.\n"
@@ -96,6 +93,12 @@ if sudo fprintd-enroll "$USER"; then
   # Verify
   echo -e "\nNow let's verify that it's working correctly.\n"
   if fprintd-verify; then
+    # PAM comes last, once a print is enrolled and verified. Detection only
+    # proves a reader is there, not that libfprint can drive it — an Elan MOC
+    # sensor outside the elanmoc table gets this far and then fails to enroll.
+    # Editing the stacks up front would leave those machines pointing at
+    # pam_fprintd with nothing to match.
+    setup_pam_config
     setup_lock_fingerprint_pam
     echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
     echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."


### PR DESCRIPTION
`omarchy-hw-fingerprint` does not detect Elan match-on-chip readers. On those machines:

- Setup > Security > Fingerprint is hidden
- `omarchy-setup-security-fingerprint` exits with "No fingerprint sensor detected"
- The first-run invitation never appears

Stock libfprint drives these readers fine, and `fprintd-list` finds them. Example: `04f3:0ca8` on an HP EliteBook X G2i.

## Why both checks miss it

1. Product string: the reader reports `ELAN:ARM-M4`, so `*fingerprint*` and `*biometric*` do not match.
2. Vendor ID: Elan's `04f3` is left out of `fingerprint_vendors` on purpose, because Elan also makes touchscreens.

## The fix

Add `elan:arm-m4` to the product string check.

The comment above the vendor list already says the excluded vendors "still match on the product string below when present". This makes that true for Elan. The vendor list and its `has_kernel_driver` guard are unchanged, so touchscreens still cannot cause a false positive.

`ELAN:ARM-M4` is a family name, not one device. libfprint uses it for `04f3:0c9c` and `04f3:0ca7` as well as `04f3:0ca8`, so one pattern covers all of them.

## This is a regression

Elan readers used to be detected:

- #681 reported this exact symptom on a Lenovo Yoga 7i
- #692 fixed it by adding `elan` to the old `lsusb` keyword check
- #3947 reported an Egis reader the keyword list also missed
- #3948 replaced the keywords with `fprintd-list`, which still found Elan
- e2bf0dab moved detection to sysfs so it can run before fprintd is installed. Elan coverage was dropped here.
- 6ebdfa38 added the `has_kernel_driver` guard and gated the menu row on the same check, so the row disappears too

## Testing

On the affected laptop the new pattern matches one device, and it is the reader:

```
$ ./bin/omarchy-hw-fingerprint; echo $?
0
```

With the check passing, the setup script gets past its hardware gate and the menu row appears. Fingerprint auth for polkit and the lock screen works on stock libfprint and fprintd, using the PAM config that script writes.
