### PR TITLE
Keep root= in the kernel cmdline when upgrading to Quattro

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -474,7 +474,7 @@ normalize_limine_config() {
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
   local cmdline param key path root_source root_uuid root_fstype subvol uki
-  local root_type=""
+  local root_stacks_crypt=0
   local config_paths=()
   local boot_params=()
   local missing=()
@@ -553,14 +553,18 @@ preserve_kernel_cmdline_root() {
   # root= left to copy, so derive it from the mounted root instead.
   if ((!have_root)); then
     # --nofsroot matters: without it findmnt appends the subvolume for a btrfs
-    # mount, so the source reads /dev/mapper/cryptroot[/@], lsblk cannot resolve
-    # that path, and the type below comes back empty. That is the layout Omarchy
-    # installs when encryption is picked, so the crypt gate would miss exactly the
-    # roots it exists for. root_type stays empty when findmnt cannot answer, which
-    # the root_uuid check below then catches.
+    # mount, so the source reads /dev/mapper/cryptroot[/@], which lsblk cannot
+    # resolve. That is the layout Omarchy installs when encryption is picked.
     root_source=$(findmnt -no SOURCE --nofsroot / 2>/dev/null || true)
-    if [[ -n $root_source ]]; then
-      root_type=$(lsblk -no TYPE "$root_source" 2>/dev/null | head -n1 || true)
+
+    # -s walks the parents, so a LUKS layer counts wherever it sits in the stack
+    # and not only when the root device is itself the dm-crypt target. On the
+    # standard full-disk-encryption layout, container -> LVM PV -> root LV, the
+    # root device's own type is lvm and a plain lsblk -no TYPE misses the crypt
+    # layer completely. root_stacks_crypt stays 0 when findmnt cannot answer,
+    # which the root_uuid check below then catches.
+    if [[ -n $root_source ]] && lsblk -nso TYPE "$root_source" 2>/dev/null | grep -qx crypt; then
+      root_stacks_crypt=1
     fi
 
     # An unlocked dm-crypt root reports its mapper device, whose UUID says
@@ -568,13 +572,12 @@ preserve_kernel_cmdline_root() {
     # produce a cmdline that still cannot boot, and the check at the end of this
     # function would then find root= and stay quiet about it.
     #
-    # This gates on the device mapper target type rather than reusing
-    # root_filesystem_encrypted(), which treats every /dev/mapper/* path and any
-    # non-empty /etc/crypttab as an encrypted root. That is the right side to err
-    # on where it is used, but here it would deny the repair to plain LVM, dm-raid
-    # and multipath roots, which need no unlock parameters: root=UUID= is enough
-    # once mkinitcpio's own hook assembles the device.
-    if [[ $root_type == "crypt" ]] && ((!have_unlock)); then
+    # Looking for a crypt layer rather than reusing root_filesystem_encrypted(),
+    # which treats every /dev/mapper/* path and any non-empty /etc/crypttab as an
+    # encrypted root. That is the right side to err on where it is used, but here
+    # it would deny the repair to LVM, dm-raid and multipath roots that carry no
+    # crypt layer: root=UUID= is enough once mkinitcpio's own hook assembles them.
+    if ((root_stacks_crypt)) && ((!have_unlock)); then
       warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, run limine-mkinitcpio, and confirm root= reaches /boot/limine.conf before rebooting."
       return 0
     fi

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -471,6 +471,89 @@ normalize_limine_config() {
   fi
 }
 
+preserve_kernel_cmdline_root() {
+  local default_conf=/etc/default/limine
+  local cmdline param key root_uuid root_fstype
+  local boot_params=()
+  local have_root=0
+
+  command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
+  as_root test -f /boot/limine.conf || return 0
+
+  # Any config layer that already pins root= is authoritative; leave it alone.
+  if as_root grep -rqs 'root=' \
+    "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/ /etc/kernel/cmdline; then
+    return 0
+  fi
+
+  # /etc/limine-entry-tool.d/omarchy-defaults.conf sets KERNEL_CMDLINE[default]
+  # with the += operator, and limine-entry-tool.conf documents what that costs:
+  # "+= appends parameters to an existing cmdline ... Ignores /etc/kernel/cmdline
+  # and /proc/cmdline". So the moment that drop-in lands, the tool stops
+  # auto-detecting the cmdline.
+  #
+  # Fresh installs are unaffected: the ISO writes /etc/default/limine from
+  # default/limine/default.conf with @@CMDLINE@@ substituted. Upgrades never
+  # created that file, so a pre-quattro install that relied on the auto-detected
+  # root= ends up with a cmdline that cannot mount the real root, and the next
+  # boot drops to an emergency shell with "Failed to mount '' on real root".
+  #
+  # This runs before the reboot, while the still-correct cmdline of the running
+  # kernel is readable from /proc/cmdline, and carries the boot-critical
+  # parameters over verbatim rather than reconstructing them.
+  cmdline=$(cat /proc/cmdline 2>/dev/null || true)
+  for param in $cmdline; do
+    key=${param%%=*}
+    case $key in
+      root)
+        have_root=1
+        boot_params+=("$param")
+        ;;
+      rootflags | rootfstype | resume | resume_offset | cryptdevice | cryptkey | rd.luks.name | rd.luks.uuid | rd.luks.options | rw | ro)
+        boot_params+=("$param")
+        ;;
+    esac
+  done
+
+  # Re-running the upgrade on an already-broken system: the booted cmdline has no
+  # root= left to copy, so derive it from the mounted root instead. Btrfs needs
+  # its subvolume as well, or the initramfs mounts the wrong tree.
+  if ((!have_root)); then
+    root_uuid=$(findmnt -no UUID / 2>/dev/null || true)
+    if [[ -z $root_uuid ]]; then
+      warn "Could not determine the root filesystem UUID; the kernel cmdline was left untouched. Confirm root= is present in /boot/limine.conf before rebooting."
+      return 0
+    fi
+
+    boot_params=("root=UUID=$root_uuid" rw)
+    root_fstype=$(findmnt -no FSTYPE / 2>/dev/null || true)
+    if [[ $root_fstype == btrfs ]]; then
+      local subvol
+      subvol=$(findmnt -no FSROOT / 2>/dev/null || true)
+      if [[ -n $subvol && $subvol != / ]]; then
+        boot_params+=("rootflags=subvol=${subvol#/}")
+      fi
+    fi
+  fi
+
+  log "Preserving the kernel cmdline root parameters in $default_conf"
+  as_root tee -a "$default_conf" >/dev/null <<EOF
+# Written by omarchy-upgrade-to-quattro. The drop-ins in
+# /etc/limine-entry-tool.d/ append to KERNEL_CMDLINE[default] with +=, which
+# stops limine-entry-tool from reading /etc/kernel/cmdline and /proc/cmdline, so
+# the parameters identifying the root filesystem have to be stated explicitly.
+# This file is loaded last, and += keeps the drop-in parameters rather than
+# replacing them.
+KERNEL_CMDLINE[default]+=" ${boot_params[*]}"
+EOF
+
+  as_root limine-mkinitcpio
+
+  if ! as_root grep -q 'root=' /boot/limine.conf; then
+    warn "root= is still missing from /boot/limine.conf. Do not reboot until the kernel cmdline is repaired, or the system will drop to an emergency shell."
+  fi
+}
+
 configure_snapper_policy() {
   local snapper_config_script=/usr/share/omarchy/install/config/snapper.sh
 
@@ -2251,6 +2334,7 @@ remove_conflicting_legacy_packages
 install_omarchy_quattro_packages
 install_hardware_transition_packages
 normalize_limine_config
+preserve_kernel_cmdline_root
 configure_snapper_policy
 configure_lock_authentication
 migrate_1password_beta_package

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -473,7 +473,8 @@ normalize_limine_config() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key root_source root_uuid root_fstype subvol uki
+  local cmdline param key path root_source root_type root_uuid root_fstype subvol uki
+  local config_paths=()
   local boot_params=()
   local missing=()
   local have_root=0 have_mount_mode=0 have_unlock=0
@@ -482,17 +483,28 @@ preserve_kernel_cmdline_root() {
   as_root test -f /boot/limine.conf || return 0
 
   # Any config layer that already pins root= is authoritative; leave it alone.
-  # Match real assignments only. limine-entry-tool.conf ships a commented
-  # example, "#KERNEL_CMDLINE[default]+=rw root=UUID=...", that a plain search
-  # for root= hits on every stock machine, which would make this a no-op exactly
-  # where it is needed.
-  if as_root grep -rhsE '^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root=' \
-    "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/ >/dev/null; then
+  #
+  # Two traps here. The pattern matches assignments rather than the bare string,
+  # because limine-entry-tool.conf ships "#KERNEL_CMDLINE[default]+=rw
+  # root=UUID=..." as a commented example that is present on every stock machine.
+  # And only existing paths are handed to grep: $default_conf is absent on
+  # exactly the upgraded machines this targets, and a missing operand makes grep
+  # exit 2, which is indistinguishable from "no match" for the caller. Filtering
+  # first keeps the exit status meaningful on any grep implementation.
+  for path in "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/; do
+    if as_root test -e "$path"; then
+      config_paths+=("$path")
+    fi
+  done
+
+  if ((${#config_paths[@]})) &&
+    as_root grep -rqE '^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root=' "${config_paths[@]}"; then
     return 0
   fi
 
   # /etc/kernel/cmdline holds bare parameters rather than shell assignments.
-  if as_root grep -qsE '(^|[[:space:]])root=' /etc/kernel/cmdline; then
+  if as_root test -e /etc/kernel/cmdline &&
+    as_root grep -qE '(^|[[:space:]])root=' /etc/kernel/cmdline; then
     return 0
   fi
 
@@ -530,7 +542,7 @@ preserve_kernel_cmdline_root() {
         have_unlock=1
         boot_params+=("$param")
         ;;
-      rootflags | rootfstype | rootwait | rootdelay | resume | resume_offset | rd.md.uuid | rd.dm.uuid)
+      rootflags | rootfstype | rootwait | rootdelay | resume | resume_offset | rd.lvm.lv | rd.lvm.vg | rd.md.uuid | rd.dm.uuid)
         boot_params+=("$param")
         ;;
     esac
@@ -540,12 +552,22 @@ preserve_kernel_cmdline_root() {
   # root= left to copy, so derive it from the mounted root instead.
   if ((!have_root)); then
     root_source=$(findmnt -no SOURCE / 2>/dev/null || true)
+    if [[ -n $root_source ]]; then
+      root_type=$(lsblk -no TYPE "$root_source" 2>/dev/null | head -n1 || true)
+    fi
 
     # An unlocked dm-crypt root reports its mapper device, whose UUID says
     # nothing about which container to unlock or how. Writing root= for it would
     # produce a cmdline that still cannot boot, and the check at the end of this
     # function would then find root= and stay quiet about it.
-    if [[ $root_source == /dev/mapper/* ]] && ((!have_unlock)); then
+    #
+    # This gates on the device mapper target type rather than reusing
+    # root_filesystem_encrypted(), which treats every /dev/mapper/* path and any
+    # non-empty /etc/crypttab as an encrypted root. That is the right side to err
+    # on where it is used, but here it would deny the repair to plain LVM, dm-raid
+    # and multipath roots, which need no unlock parameters: root=UUID= is enough
+    # once mkinitcpio's own hook assembles the device.
+    if [[ $root_type == "crypt" ]] && ((!have_unlock)); then
       warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, run limine-mkinitcpio, and confirm root= reaches /boot/limine.conf before rebooting."
       return 0
     fi
@@ -589,12 +611,17 @@ EOF
   # With omarchy-uki.conf among the drop-ins, the cmdline that actually boots is
   # the one embedded in the UKI rather than the copy limine.conf carries, so a
   # green limine.conf is not on its own proof that the machine will boot.
+  # Scoped to the CUSTOM_UKI_NAME=omarchy images limine-entry-tool generates, so a
+  # shared ESP carrying another distribution's UKIs, or a stub with no .cmdline
+  # section at all, cannot produce a false "do not reboot" warning. Read as root
+  # like every other /boot access here: an ESP mounted with a restrictive fmask
+  # would otherwise make find return nothing and the check pass in silence.
   if command -v objcopy >/dev/null 2>&1; then
     while read -r uki; do
       [[ -n $uki ]] || continue
-      objcopy -O binary --only-section=.cmdline "$uki" /dev/stdout 2>/dev/null |
+      as_root objcopy -O binary --only-section=.cmdline "$uki" /dev/stdout 2>/dev/null |
         tr -d '\0' | grep -q 'root=' || missing+=("$uki")
-    done < <(find /boot/EFI/Linux -maxdepth 1 -name '*.efi' 2>/dev/null)
+    done < <(as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi' 2>/dev/null)
   fi
 
   if ((${#missing[@]})); then

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -474,64 +474,30 @@ normalize_limine_config() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key path value root_source root_stack root_uuid root_fstype subvol uki
-  local root_stacks_crypt=0
-  local config_paths=()
+  local cmdline param key root_source root_stack root_uuid subvol uki
   local boot_params=()
   local missing=()
   local have_root=0 have_mount_mode=0 have_unlock=0
-  # Only the default key feeds the entries this repairs; the value is walked
-  # with param_re below rather than pattern-matched, so parameters that merely
-  # end in root= (systemd.volatile-root=) or carry it inside a quoted value
-  # (systemd.setenv="root=decoy") cannot count as a pin.
-  local pin_line='^[[:space:]]*KERNEL_CMDLINE\[default\][+]?='
-  # Kernel parameters can quote spaces (dm-mod.create="0 972 linear ...");
-  # word splitting would truncate them and glob-expand the rest.
-  local param_re='^[[:space:]]*(([^[:space:]"]|"[^"]*")+)'
 
   command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
   as_root test -f /boot/limine.conf || return 0
 
-  # A config layer that already pins root= on the default key is authoritative.
-  # Match assignment lines, not the bare string: limine-entry-tool.conf ships a
-  # commented "#KERNEL_CMDLINE[default]+=rw root=UUID=..." example on every
-  # machine. Only existing paths reach grep, since a missing operand makes it
-  # exit 2, which is indistinguishable from "no match". Only *.conf drop-ins
-  # count: the tool loads nothing else, so a .pacnew or .pacsave pinning root=
-  # must not disarm the fix.
-  for path in "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/*.conf; do
-    if as_root test -e "$path"; then
-      config_paths+=("$path")
-    fi
-  done
-
-  if ((${#config_paths[@]})); then
-    while IFS= read -r value; do
-      # Trim around the value before stripping one quote pair: the tool accepts
-      # whitespace between the operator and an opening quote.
-      value=${value#*=}
-      value=${value#"${value%%[![:space:]]*}"}
-      value=${value%"${value##*[![:space:]]}"}
-      value=${value#[\"\']}
-      value=${value%[\"\']}
-      while [[ $value =~ $param_re ]]; do
-        [[ ${BASH_REMATCH[1]} == root=* ]] && return 0
-        value=${value:${#BASH_REMATCH[0]}}
-      done
-    done < <(as_root grep -hE "$pin_line" "${config_paths[@]}")
-  fi
-
   # The omarchy-defaults.conf drop-in appends to KERNEL_CMDLINE[default] with
   # +=, which makes limine-entry-tool ignore /etc/kernel/cmdline and
-  # /proc/cmdline entirely — root= in /etc/kernel/cmdline never reaches the boot
-  # entries, so its presence there cannot count as a pin. Fresh installs pin
-  # root= in /etc/default/limine via the ISO; upgrades never created that file.
+  # /proc/cmdline. Fresh installs pin root= in /etc/default/limine via the ISO;
+  # upgrades never created that file, so root= silently drops out and the next
+  # boot lands in an emergency shell. Ask the tool for its effective default
+  # cmdline — the key this function appends to — rather than parsing the config
+  # layers ourselves.
+  if as_root limine-entry-tool --get-cmdline default 2>/dev/null |
+    grep -qE '(^|[[:space:]])root='; then
+    return 0
+  fi
+
   # Copy the boot-critical parameters of the running kernel verbatim, so a
   # PARTUUID, a LABEL or a bare device node all survive.
   cmdline=$(cat /proc/cmdline 2>/dev/null || true)
-  while [[ $cmdline =~ $param_re ]]; do
-    param=${BASH_REMATCH[1]}
-    cmdline=${cmdline:${#BASH_REMATCH[0]}}
+  for param in $cmdline; do
     key=${param%%=*}
     case $key in
       root)
@@ -552,83 +518,58 @@ preserve_kernel_cmdline_root() {
     esac
   done
 
-  # Re-running the upgrade on an already-broken system: the booted cmdline has no
-  # root= left to copy, so derive it from the mounted root instead.
+  # Already-broken system (booted through the emergency shell): derive root=
+  # from the mounted root instead. Refuse when the root sits on dm-crypt and
+  # the cmdline carries no unlock parameters, since root= alone would still not
+  # boot. lsblk -s walks the parents, where the crypt layer hides on
+  # LVM-on-LUKS; --nofsroot keeps findmnt from appending a btrfs subvolume
+  # lsblk cannot resolve; the capture keeps a SIGPIPE under pipefail from
+  # reading as "no crypt layer".
   if ((!have_root)); then
-    # --nofsroot: without it an encrypted btrfs root reads
-    # /dev/mapper/cryptroot[/@], which lsblk cannot resolve.
     root_source=$(findmnt -no SOURCE --nofsroot / 2>/dev/null || true)
-
-    # -s walks the parents: on the container -> LVM PV -> root LV layout the
-    # root device's own type is lvm, so only the stack reveals the crypt layer.
-    # Captured rather than piped into grep -q so a SIGPIPE under pipefail cannot
-    # read as "no crypt layer".
-    if [[ -n $root_source ]]; then
-      root_stack=$(lsblk -nso TYPE "$root_source" 2>/dev/null || true)
-      if grep -qx crypt <<<"$root_stack"; then
-        root_stacks_crypt=1
-      fi
-    fi
-
-    # An unlocked dm-crypt root reports its mapper device, whose UUID says
-    # nothing about which container to unlock or how; root= alone would still
-    # not boot. Not root_filesystem_encrypted(): its /dev/mapper/* and crypttab
-    # branches would deny the repair to LVM, dm-raid and multipath roots, where
-    # root=UUID= is enough.
-    if ((root_stacks_crypt)) && ((!have_unlock)); then
-      warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, run limine-mkinitcpio, and confirm root= reaches /boot/limine.conf before rebooting."
+    root_stack=$(lsblk -nso TYPE "$root_source" 2>/dev/null || true)
+    if grep -qx crypt <<<"$root_stack" && ((!have_unlock)); then
+      warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, then run limine-mkinitcpio."
       boot_cmdline_unsafe=1
       return 0
     fi
 
     root_uuid=$(findmnt -no UUID / 2>/dev/null || true)
     if [[ -z $root_uuid ]]; then
-      warn "Could not determine the root filesystem UUID; the kernel cmdline was left untouched. Confirm root= is present in /boot/limine.conf before rebooting."
+      warn "Could not determine the root filesystem UUID; the kernel cmdline was left untouched."
       boot_cmdline_unsafe=1
       return 0
     fi
 
-    # Prepend, so captured parameters survive; only assume a mount mode when
-    # the booted cmdline stated none.
     boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")
     ((have_mount_mode)) || boot_params+=(rw)
 
     # Btrfs needs its subvolume too, or the initramfs mounts the wrong tree.
-    root_fstype=$(findmnt -no FSTYPE / 2>/dev/null || true)
-    if [[ $root_fstype == "btrfs" ]]; then
-      subvol=$(findmnt -no FSROOT / 2>/dev/null || true)
-      if [[ -n $subvol && $subvol != "/" ]]; then
-        boot_params+=("rootflags=subvol=${subvol#/}")
-      fi
+    subvol=$(findmnt -no FSROOT / 2>/dev/null || true)
+    if [[ $(findmnt -no FSTYPE / 2>/dev/null) == "btrfs" && -n $subvol && $subvol != "/" ]]; then
+      boot_params+=("rootflags=subvol=${subvol#/}")
     fi
   fi
 
   log "Preserving the kernel cmdline root parameters in $default_conf"
   as_root tee -a "$default_conf" >/dev/null <<EOF
-# Written by omarchy-upgrade-to-quattro. The drop-ins in
-# /etc/limine-entry-tool.d/ append to KERNEL_CMDLINE[default] with +=, which
-# stops limine-entry-tool from reading /etc/kernel/cmdline and /proc/cmdline, so
-# the parameters identifying the root filesystem have to be stated explicitly.
-# This file takes priority over the drop-ins, and += keeps their parameters
-# rather than replacing them.
+# Written by omarchy-upgrade-to-quattro. The += drop-ins in
+# /etc/limine-entry-tool.d/ stop limine-entry-tool from reading
+# /etc/kernel/cmdline and /proc/cmdline, so the parameters identifying the
+# root filesystem have to be stated explicitly.
 KERNEL_CMDLINE[default]+=" ${boot_params[*]}"
 EOF
 
-  # Keep going on failure so the root= verification below still runs; the
-  # unsafe flag blocks the reboot at the end of the upgrade.
+  # Keep going on failure so the verification below still runs; the unsafe
+  # flag blocks the reboot at the end of the upgrade.
   if ! as_root limine-mkinitcpio; then
     warn "limine-mkinitcpio failed; the boot entries were not regenerated."
     boot_cmdline_unsafe=1
   fi
 
-  # Token-anchored, so netroot= or systemd.volatile-root= cannot stand in for
-  # root=.
   as_root grep -qE '(^|[[:space:]])root=' /boot/limine.conf || missing+=(/boot/limine.conf)
 
-  # With omarchy-uki.conf among the drop-ins, the cmdline that boots is the one
-  # embedded in the UKI, not the copy limine.conf carries. Scoped to the
-  # omarchy_linux*.efi images so a shared ESP cannot raise a false warning, and
-  # read as root so a restrictive ESP fmask cannot make the check pass silently.
+  # The cmdline that boots is the one embedded in the UKIs, so check those too.
   if command -v objcopy >/dev/null 2>&1; then
     while read -r uki; do
       [[ -n $uki ]] || continue

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -473,7 +473,8 @@ normalize_limine_config() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key path root_source root_type root_uuid root_fstype subvol uki
+  local cmdline param key path root_source root_uuid root_fstype subvol uki
+  local root_type=""
   local config_paths=()
   local boot_params=()
   local missing=()
@@ -551,7 +552,13 @@ preserve_kernel_cmdline_root() {
   # Re-running the upgrade on an already-broken system: the booted cmdline has no
   # root= left to copy, so derive it from the mounted root instead.
   if ((!have_root)); then
-    root_source=$(findmnt -no SOURCE / 2>/dev/null || true)
+    # --nofsroot matters: without it findmnt appends the subvolume for a btrfs
+    # mount, so the source reads /dev/mapper/cryptroot[/@], lsblk cannot resolve
+    # that path, and the type below comes back empty. That is the layout Omarchy
+    # installs when encryption is picked, so the crypt gate would miss exactly the
+    # roots it exists for. root_type stays empty when findmnt cannot answer, which
+    # the root_uuid check below then catches.
+    root_source=$(findmnt -no SOURCE --nofsroot / 2>/dev/null || true)
     if [[ -n $root_source ]]; then
       root_type=$(lsblk -no TYPE "$root_source" 2>/dev/null | head -n1 || true)
     fi

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -473,7 +473,7 @@ normalize_limine_config() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key path root_source root_uuid root_fstype subvol uki
+  local cmdline param key path root_source root_stack root_uuid root_fstype subvol uki
   local root_stacks_crypt=0
   local config_paths=()
   local boot_params=()
@@ -563,8 +563,17 @@ preserve_kernel_cmdline_root() {
     # root device's own type is lvm and a plain lsblk -no TYPE misses the crypt
     # layer completely. root_stacks_crypt stays 0 when findmnt cannot answer,
     # which the root_uuid check below then catches.
-    if [[ -n $root_source ]] && lsblk -nso TYPE "$root_source" 2>/dev/null | grep -qx crypt; then
-      root_stacks_crypt=1
+    if [[ -n $root_source ]]; then
+      # Captured rather than piped straight into grep -q: under pipefail a
+      # short-circuiting grep can leave the producer with SIGPIPE and turn the
+      # pipeline into 141, which would read as "no crypt layer" and disarm the
+      # gate silently. lsblk writes its whole table in one go, so this is out of
+      # reach in practice, but the gate should not be the thing that depends on
+      # how much output a helper happens to buffer.
+      root_stack=$(lsblk -nso TYPE "$root_source" 2>/dev/null || true)
+      if grep -qx crypt <<<"$root_stack"; then
+        root_stacks_crypt=1
+      fi
     fi
 
     # An unlocked dm-crypt root reports its mapper device, whose UUID says

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -56,6 +56,7 @@ channel_override_cli=0
 target_user="${OMARCHY_INSTALL_USER:-}"
 yes=0
 auto_reboot=0
+boot_cmdline_unsafe=0
 use_dev_packages=${OMARCHY_UPGRADE_DEV:-0}
 
 while (($#)); do
@@ -473,62 +474,64 @@ normalize_limine_config() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key path root_source root_stack root_uuid root_fstype subvol uki
+  local cmdline param key path value root_source root_stack root_uuid root_fstype subvol uki
   local root_stacks_crypt=0
   local config_paths=()
   local boot_params=()
   local missing=()
   local have_root=0 have_mount_mode=0 have_unlock=0
+  # Only the default key feeds the entries this repairs; the value is walked
+  # with param_re below rather than pattern-matched, so parameters that merely
+  # end in root= (systemd.volatile-root=) or carry it inside a quoted value
+  # (systemd.setenv="root=decoy") cannot count as a pin.
+  local pin_line='^[[:space:]]*KERNEL_CMDLINE\[default\][+]?='
+  # Kernel parameters can quote spaces (dm-mod.create="0 972 linear ...");
+  # word splitting would truncate them and glob-expand the rest.
+  local param_re='^[[:space:]]*(([^[:space:]"]|"[^"]*")+)'
 
   command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
   as_root test -f /boot/limine.conf || return 0
 
-  # Any config layer that already pins root= is authoritative; leave it alone.
-  #
-  # Two traps here. The pattern matches assignments rather than the bare string,
-  # because limine-entry-tool.conf ships "#KERNEL_CMDLINE[default]+=rw
-  # root=UUID=..." as a commented example that is present on every stock machine.
-  # And only existing paths are handed to grep: $default_conf is absent on
-  # exactly the upgraded machines this targets, and a missing operand makes grep
-  # exit 2, which is indistinguishable from "no match" for the caller. Filtering
-  # first keeps the exit status meaningful on any grep implementation.
-  for path in "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/; do
+  # A config layer that already pins root= on the default key is authoritative.
+  # Match assignment lines, not the bare string: limine-entry-tool.conf ships a
+  # commented "#KERNEL_CMDLINE[default]+=rw root=UUID=..." example on every
+  # machine. Only existing paths reach grep, since a missing operand makes it
+  # exit 2, which is indistinguishable from "no match". Only *.conf drop-ins
+  # count: the tool loads nothing else, so a .pacnew or .pacsave pinning root=
+  # must not disarm the fix.
+  for path in "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/*.conf; do
     if as_root test -e "$path"; then
       config_paths+=("$path")
     fi
   done
 
-  if ((${#config_paths[@]})) &&
-    as_root grep -rqE '^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root=' "${config_paths[@]}"; then
-    return 0
+  if ((${#config_paths[@]})); then
+    while IFS= read -r value; do
+      # Trim around the value before stripping one quote pair: the tool accepts
+      # whitespace between the operator and an opening quote.
+      value=${value#*=}
+      value=${value#"${value%%[![:space:]]*}"}
+      value=${value%"${value##*[![:space:]]}"}
+      value=${value#[\"\']}
+      value=${value%[\"\']}
+      while [[ $value =~ $param_re ]]; do
+        [[ ${BASH_REMATCH[1]} == root=* ]] && return 0
+        value=${value:${#BASH_REMATCH[0]}}
+      done
+    done < <(as_root grep -hE "$pin_line" "${config_paths[@]}")
   fi
 
-  # /etc/kernel/cmdline holds bare parameters rather than shell assignments.
-  if as_root test -e /etc/kernel/cmdline &&
-    as_root grep -qE '(^|[[:space:]])root=' /etc/kernel/cmdline; then
-    return 0
-  fi
-
-  # /etc/limine-entry-tool.d/omarchy-defaults.conf sets KERNEL_CMDLINE[default]
-  # with the += operator, and limine-entry-tool.conf documents what that costs:
-  # "+= appends parameters to an existing cmdline ... Ignores /etc/kernel/cmdline
-  # and /proc/cmdline". So the moment that drop-in lands, the tool stops
-  # auto-detecting the cmdline.
-  #
-  # Fresh installs are unaffected: the ISO writes /etc/default/limine from
-  # default/limine/default.conf with @@CMDLINE@@ substituted. Upgrades never
-  # created that file, so a pre-quattro install that relied on the auto-detected
-  # root= ends up with a cmdline that cannot mount the real root, and the next
-  # boot drops to an emergency shell with "Failed to mount '' on real root".
-  #
-  # This runs before the reboot, while the still-correct cmdline of the running
-  # kernel is readable from /proc/cmdline. Copying verbatim keeps whatever form
-  # the install already used, so a PARTUUID, a LABEL or a bare device node all
-  # survive. The allowlist covers the parameters that decide whether the
-  # initramfs can find and unlock the root; everything else is either supplied by
-  # the drop-ins or irrelevant to reaching the real root.
+  # The omarchy-defaults.conf drop-in appends to KERNEL_CMDLINE[default] with
+  # +=, which makes limine-entry-tool ignore /etc/kernel/cmdline and
+  # /proc/cmdline entirely — root= in /etc/kernel/cmdline never reaches the boot
+  # entries, so its presence there cannot count as a pin. Fresh installs pin
+  # root= in /etc/default/limine via the ISO; upgrades never created that file.
+  # Copy the boot-critical parameters of the running kernel verbatim, so a
+  # PARTUUID, a LABEL or a bare device node all survive.
   cmdline=$(cat /proc/cmdline 2>/dev/null || true)
-  for param in $cmdline; do
+  while [[ $cmdline =~ $param_re ]]; do
+    param=${BASH_REMATCH[1]}
+    cmdline=${cmdline:${#BASH_REMATCH[0]}}
     key=${param%%=*}
     case $key in
       root)
@@ -552,24 +555,15 @@ preserve_kernel_cmdline_root() {
   # Re-running the upgrade on an already-broken system: the booted cmdline has no
   # root= left to copy, so derive it from the mounted root instead.
   if ((!have_root)); then
-    # --nofsroot matters: without it findmnt appends the subvolume for a btrfs
-    # mount, so the source reads /dev/mapper/cryptroot[/@], which lsblk cannot
-    # resolve. That is the layout Omarchy installs when encryption is picked.
+    # --nofsroot: without it an encrypted btrfs root reads
+    # /dev/mapper/cryptroot[/@], which lsblk cannot resolve.
     root_source=$(findmnt -no SOURCE --nofsroot / 2>/dev/null || true)
 
-    # -s walks the parents, so a LUKS layer counts wherever it sits in the stack
-    # and not only when the root device is itself the dm-crypt target. On the
-    # standard full-disk-encryption layout, container -> LVM PV -> root LV, the
-    # root device's own type is lvm and a plain lsblk -no TYPE misses the crypt
-    # layer completely. root_stacks_crypt stays 0 when findmnt cannot answer,
-    # which the root_uuid check below then catches.
+    # -s walks the parents: on the container -> LVM PV -> root LV layout the
+    # root device's own type is lvm, so only the stack reveals the crypt layer.
+    # Captured rather than piped into grep -q so a SIGPIPE under pipefail cannot
+    # read as "no crypt layer".
     if [[ -n $root_source ]]; then
-      # Captured rather than piped straight into grep -q: under pipefail a
-      # short-circuiting grep can leave the producer with SIGPIPE and turn the
-      # pipeline into 141, which would read as "no crypt layer" and disarm the
-      # gate silently. lsblk writes its whole table in one go, so this is out of
-      # reach in practice, but the gate should not be the thing that depends on
-      # how much output a helper happens to buffer.
       root_stack=$(lsblk -nso TYPE "$root_source" 2>/dev/null || true)
       if grep -qx crypt <<<"$root_stack"; then
         root_stacks_crypt=1
@@ -577,28 +571,25 @@ preserve_kernel_cmdline_root() {
     fi
 
     # An unlocked dm-crypt root reports its mapper device, whose UUID says
-    # nothing about which container to unlock or how. Writing root= for it would
-    # produce a cmdline that still cannot boot, and the check at the end of this
-    # function would then find root= and stay quiet about it.
-    #
-    # Looking for a crypt layer rather than reusing root_filesystem_encrypted(),
-    # which treats every /dev/mapper/* path and any non-empty /etc/crypttab as an
-    # encrypted root. That is the right side to err on where it is used, but here
-    # it would deny the repair to LVM, dm-raid and multipath roots that carry no
-    # crypt layer: root=UUID= is enough once mkinitcpio's own hook assembles them.
+    # nothing about which container to unlock or how; root= alone would still
+    # not boot. Not root_filesystem_encrypted(): its /dev/mapper/* and crypttab
+    # branches would deny the repair to LVM, dm-raid and multipath roots, where
+    # root=UUID= is enough.
     if ((root_stacks_crypt)) && ((!have_unlock)); then
       warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, run limine-mkinitcpio, and confirm root= reaches /boot/limine.conf before rebooting."
+      boot_cmdline_unsafe=1
       return 0
     fi
 
     root_uuid=$(findmnt -no UUID / 2>/dev/null || true)
     if [[ -z $root_uuid ]]; then
       warn "Could not determine the root filesystem UUID; the kernel cmdline was left untouched. Confirm root= is present in /boot/limine.conf before rebooting."
+      boot_cmdline_unsafe=1
       return 0
     fi
 
-    # Prepend, so anything the loop did capture survives, and only assume a mount
-    # mode when the booted cmdline stated none.
+    # Prepend, so captured parameters survive; only assume a mount mode when
+    # the booted cmdline stated none.
     boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")
     ((have_mount_mode)) || boot_params+=(rw)
 
@@ -618,33 +609,37 @@ preserve_kernel_cmdline_root() {
 # /etc/limine-entry-tool.d/ append to KERNEL_CMDLINE[default] with +=, which
 # stops limine-entry-tool from reading /etc/kernel/cmdline and /proc/cmdline, so
 # the parameters identifying the root filesystem have to be stated explicitly.
-# This file is loaded last, and += keeps the drop-in parameters rather than
-# replacing them.
+# This file takes priority over the drop-ins, and += keeps their parameters
+# rather than replacing them.
 KERNEL_CMDLINE[default]+=" ${boot_params[*]}"
 EOF
 
-  as_root limine-mkinitcpio
+  # Keep going on failure so the root= verification below still runs; the
+  # unsafe flag blocks the reboot at the end of the upgrade.
+  if ! as_root limine-mkinitcpio; then
+    warn "limine-mkinitcpio failed; the boot entries were not regenerated."
+    boot_cmdline_unsafe=1
+  fi
 
-  as_root grep -q 'root=' /boot/limine.conf || missing+=(/boot/limine.conf)
+  # Token-anchored, so netroot= or systemd.volatile-root= cannot stand in for
+  # root=.
+  as_root grep -qE '(^|[[:space:]])root=' /boot/limine.conf || missing+=(/boot/limine.conf)
 
-  # With omarchy-uki.conf among the drop-ins, the cmdline that actually boots is
-  # the one embedded in the UKI rather than the copy limine.conf carries, so a
-  # green limine.conf is not on its own proof that the machine will boot.
-  # Scoped to the CUSTOM_UKI_NAME=omarchy images limine-entry-tool generates, so a
-  # shared ESP carrying another distribution's UKIs, or a stub with no .cmdline
-  # section at all, cannot produce a false "do not reboot" warning. Read as root
-  # like every other /boot access here: an ESP mounted with a restrictive fmask
-  # would otherwise make find return nothing and the check pass in silence.
+  # With omarchy-uki.conf among the drop-ins, the cmdline that boots is the one
+  # embedded in the UKI, not the copy limine.conf carries. Scoped to the
+  # omarchy_linux*.efi images so a shared ESP cannot raise a false warning, and
+  # read as root so a restrictive ESP fmask cannot make the check pass silently.
   if command -v objcopy >/dev/null 2>&1; then
     while read -r uki; do
       [[ -n $uki ]] || continue
       as_root objcopy -O binary --only-section=.cmdline "$uki" /dev/stdout 2>/dev/null |
-        tr -d '\0' | grep -q 'root=' || missing+=("$uki")
+        tr -d '\0' | grep -qE '(^|[[:space:]])root=' || missing+=("$uki")
     done < <(as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi' 2>/dev/null)
   fi
 
   if ((${#missing[@]})); then
     warn "root= is still missing from ${missing[*]}. Do not reboot until the kernel cmdline is repaired, or the system will drop to an emergency shell."
+    boot_cmdline_unsafe=1
   fi
 }
 
@@ -2462,7 +2457,9 @@ WARNING: You must address any errors in the above before rebooting.
 
 EOF
 
-if (( auto_reboot )); then
+if (( boot_cmdline_unsafe )); then
+  warn "Skipping reboot: root= could not be confirmed in the boot entries. Repair the kernel cmdline (see the warnings above) before rebooting, or the system will drop to an emergency shell."
+elif (( auto_reboot )); then
   log "Rebooting because --reboot was passed"
   as_root systemctl reboot
 elif gum confirm "Reboot to complete Quattro upgrade now?" </dev/tty; then

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -473,16 +473,26 @@ normalize_limine_config() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key root_uuid root_fstype
+  local cmdline param key root_source root_uuid root_fstype subvol uki
   local boot_params=()
-  local have_root=0
+  local missing=()
+  local have_root=0 have_mount_mode=0 have_unlock=0
 
   command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
   as_root test -f /boot/limine.conf || return 0
 
   # Any config layer that already pins root= is authoritative; leave it alone.
-  if as_root grep -rqs 'root=' \
-    "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/ /etc/kernel/cmdline; then
+  # Match real assignments only. limine-entry-tool.conf ships a commented
+  # example, "#KERNEL_CMDLINE[default]+=rw root=UUID=...", that a plain search
+  # for root= hits on every stock machine, which would make this a no-op exactly
+  # where it is needed.
+  if as_root grep -rhsE '^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root=' \
+    "$default_conf" /etc/limine-entry-tool.conf /etc/limine-entry-tool.d/ >/dev/null; then
+    return 0
+  fi
+
+  # /etc/kernel/cmdline holds bare parameters rather than shell assignments.
+  if as_root grep -qsE '(^|[[:space:]])root=' /etc/kernel/cmdline; then
     return 0
   fi
 
@@ -499,8 +509,11 @@ preserve_kernel_cmdline_root() {
   # boot drops to an emergency shell with "Failed to mount '' on real root".
   #
   # This runs before the reboot, while the still-correct cmdline of the running
-  # kernel is readable from /proc/cmdline, and carries the boot-critical
-  # parameters over verbatim rather than reconstructing them.
+  # kernel is readable from /proc/cmdline. Copying verbatim keeps whatever form
+  # the install already used, so a PARTUUID, a LABEL or a bare device node all
+  # survive. The allowlist covers the parameters that decide whether the
+  # initramfs can find and unlock the root; everything else is either supplied by
+  # the drop-ins or irrelevant to reaching the real root.
   cmdline=$(cat /proc/cmdline 2>/dev/null || true)
   for param in $cmdline; do
     key=${param%%=*}
@@ -509,28 +522,50 @@ preserve_kernel_cmdline_root() {
         have_root=1
         boot_params+=("$param")
         ;;
-      rootflags | rootfstype | resume | resume_offset | cryptdevice | cryptkey | rd.luks.name | rd.luks.uuid | rd.luks.options | rw | ro)
+      rw | ro)
+        have_mount_mode=1
+        boot_params+=("$param")
+        ;;
+      cryptdevice | cryptkey | rd.luks.name | rd.luks.uuid | rd.luks.options | rd.luks.key | rd.luks.crypttab | dm-mod.create)
+        have_unlock=1
+        boot_params+=("$param")
+        ;;
+      rootflags | rootfstype | rootwait | rootdelay | resume | resume_offset | rd.md.uuid | rd.dm.uuid)
         boot_params+=("$param")
         ;;
     esac
   done
 
   # Re-running the upgrade on an already-broken system: the booted cmdline has no
-  # root= left to copy, so derive it from the mounted root instead. Btrfs needs
-  # its subvolume as well, or the initramfs mounts the wrong tree.
+  # root= left to copy, so derive it from the mounted root instead.
   if ((!have_root)); then
+    root_source=$(findmnt -no SOURCE / 2>/dev/null || true)
+
+    # An unlocked dm-crypt root reports its mapper device, whose UUID says
+    # nothing about which container to unlock or how. Writing root= for it would
+    # produce a cmdline that still cannot boot, and the check at the end of this
+    # function would then find root= and stay quiet about it.
+    if [[ $root_source == /dev/mapper/* ]] && ((!have_unlock)); then
+      warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, run limine-mkinitcpio, and confirm root= reaches /boot/limine.conf before rebooting."
+      return 0
+    fi
+
     root_uuid=$(findmnt -no UUID / 2>/dev/null || true)
     if [[ -z $root_uuid ]]; then
       warn "Could not determine the root filesystem UUID; the kernel cmdline was left untouched. Confirm root= is present in /boot/limine.conf before rebooting."
       return 0
     fi
 
-    boot_params=("root=UUID=$root_uuid" rw)
+    # Prepend, so anything the loop did capture survives, and only assume a mount
+    # mode when the booted cmdline stated none.
+    boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")
+    ((have_mount_mode)) || boot_params+=(rw)
+
+    # Btrfs needs its subvolume too, or the initramfs mounts the wrong tree.
     root_fstype=$(findmnt -no FSTYPE / 2>/dev/null || true)
-    if [[ $root_fstype == btrfs ]]; then
-      local subvol
+    if [[ $root_fstype == "btrfs" ]]; then
       subvol=$(findmnt -no FSROOT / 2>/dev/null || true)
-      if [[ -n $subvol && $subvol != / ]]; then
+      if [[ -n $subvol && $subvol != "/" ]]; then
         boot_params+=("rootflags=subvol=${subvol#/}")
       fi
     fi
@@ -549,8 +584,21 @@ EOF
 
   as_root limine-mkinitcpio
 
-  if ! as_root grep -q 'root=' /boot/limine.conf; then
-    warn "root= is still missing from /boot/limine.conf. Do not reboot until the kernel cmdline is repaired, or the system will drop to an emergency shell."
+  as_root grep -q 'root=' /boot/limine.conf || missing+=(/boot/limine.conf)
+
+  # With omarchy-uki.conf among the drop-ins, the cmdline that actually boots is
+  # the one embedded in the UKI rather than the copy limine.conf carries, so a
+  # green limine.conf is not on its own proof that the machine will boot.
+  if command -v objcopy >/dev/null 2>&1; then
+    while read -r uki; do
+      [[ -n $uki ]] || continue
+      objcopy -O binary --only-section=.cmdline "$uki" /dev/stdout 2>/dev/null |
+        tr -d '\0' | grep -q 'root=' || missing+=("$uki")
+    done < <(find /boot/EFI/Linux -maxdepth 1 -name '*.efi' 2>/dev/null)
+  fi
+
+  if ((${#missing[@]})); then
+    warn "root= is still missing from ${missing[*]}. Do not reboot until the kernel cmdline is repaired, or the system will drop to an emergency shell."
   fi
 }
 

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -86,8 +86,6 @@ pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 # commented example, so the guard has to look for assignments and not for the
 # bare string, or it returns early on every stock machine.
 cmdline_guard='^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root='
-grep -qF "grep -rhsE '$cmdline_guard'" "$upgrade_to_quattro" ||
-  fail "kernel cmdline guard is anchored on an assignment"
 if printf '%s\n' '#KERNEL_CMDLINE[default]+=rw root=UUID=...' | grep -qE "$cmdline_guard"; then
   fail "kernel cmdline guard ignores the commented example in limine-entry-tool.conf"
 fi
@@ -96,12 +94,44 @@ if ! printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=x rw"' | grep -qE "$cmd
 fi
 pass "Omarchy 4 upgrade only treats real root= assignments as authoritative"
 
+# /etc/default/limine is absent on exactly the machines this targets, and a
+# missing operand makes grep exit 2, which the caller cannot tell apart from "no
+# match". The guard filters the paths first so the exit status stays meaningful.
+grep -F 'config_paths+=("$path")' "$upgrade_to_quattro" >/dev/null
+grep -F '((${#config_paths[@]})) &&' "$upgrade_to_quattro" >/dev/null
+guard_fixtures=$(mktemp -d)
+trap 'rm -rf "$guard_fixtures"' EXIT
+mkdir -p "$guard_fixtures/dropins"
+printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=real rw"' >"$guard_fixtures/dropins/99-pins.conf"
+guard_paths=()
+for guard_path in "$guard_fixtures/absent" "$guard_fixtures/dropins"; do
+  if [[ -e $guard_path ]]; then
+    guard_paths+=("$guard_path")
+  fi
+done
+if ! ((${#guard_paths[@]})) || ! grep -rqE "$cmdline_guard" "${guard_paths[@]}"; then
+  fail "kernel cmdline guard still detects a drop-in pinning root= when another path is absent"
+fi
+pass "Omarchy 4 upgrade cmdline guard survives a missing config path"
+
 grep -F 'boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")' "$upgrade_to_quattro" >/dev/null
 grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
-grep -F '/dev/mapper/*' "$upgrade_to_quattro" >/dev/null
 grep -F 'have_unlock' "$upgrade_to_quattro" >/dev/null
+# Gated on the mapper target type, not on the /dev/mapper/* prefix, so plain LVM,
+# dm-raid and multipath roots keep the repair path.
+grep -F 'lsblk -no TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null
+grep -F '[[ $root_type == "crypt" ]]' "$upgrade_to_quattro" >/dev/null
+if grep -F '[[ $root_source == /dev/mapper/* ]] && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null; then
+  fail "kernel cmdline repair path does not treat every /dev/mapper root as encrypted"
+fi
 pass "Omarchy 4 upgrade repair path keeps captured parameters and refuses a partial dm-crypt cmdline"
 
 grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
-grep -F '/boot/EFI/Linux' "$upgrade_to_quattro" >/dev/null
+grep -F 'as_root objcopy' "$upgrade_to_quattro" >/dev/null
+# Read as root like every other /boot access, and scoped to the images
+# limine-entry-tool generates, so a shared ESP cannot trigger a false warning.
+grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade verifies the cmdline embedded in the UKIs"
+
+grep -F 'rd.lvm.lv | rd.lvm.vg' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade carries the device assembly parameters over"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -82,15 +82,58 @@ grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
 grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 
+# Kernel parameters can quote spaces (dm-mod.create="0 972 linear ...");
+# word splitting would truncate them and glob-expand the rest.
+param_re='^[[:space:]]*(([^[:space:]"]|"[^"]*")+)'
+grep -F "param_re='^[[:space:]]*(([^[:space:]\"]|\"[^\"]*\")+)'" "$upgrade_to_quattro" >/dev/null
+
 # limine-entry-tool.conf ships "#KERNEL_CMDLINE[default]+=rw root=UUID=..." as a
-# commented example, so the guard has to look for assignments and not for the
-# bare string, or it returns early on every stock machine.
-cmdline_guard='^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root='
+# commented example, so the guard matches assignment lines and not the bare
+# string, and only the default key feeds the entries the fix repairs.
+cmdline_guard='^[[:space:]]*KERNEL_CMDLINE\[default\][+]?='
+grep -F "pin_line='^[[:space:]]*KERNEL_CMDLINE" "$upgrade_to_quattro" >/dev/null
 if printf '%s\n' '#KERNEL_CMDLINE[default]+=rw root=UUID=...' | grep -qE "$cmdline_guard"; then
   fail "kernel cmdline guard ignores the commented example in limine-entry-tool.conf"
 fi
+if printf '%s\n' 'KERNEL_CMDLINE[fallback]+=" root=UUID=x"' | grep -qE "$cmdline_guard"; then
+  fail "kernel cmdline guard does not let a fallback-only pin cover the default entries"
+fi
 if ! printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=x rw"' | grep -qE "$cmdline_guard"; then
   fail "kernel cmdline guard still matches a real assignment"
+fi
+# Mirrors the guard's value walk: root= must appear as its own parameter, so
+# systemd.volatile-root= and a quoted decoy cannot count as a pin.
+grep -F '[[ ${BASH_REMATCH[1]} == root=* ]] && return 0' "$upgrade_to_quattro" >/dev/null
+pin_value_has_root() {
+  local value=${1#*=}
+  value=${value#"${value%%[![:space:]]*}"}
+  value=${value%"${value##*[![:space:]]}"}
+  value=${value#[\"\']}
+  value=${value%[\"\']}
+  while [[ $value =~ $param_re ]]; do
+    [[ ${BASH_REMATCH[1]} == root=* ]] && return 0
+    value=${value:${#BASH_REMATCH[0]}}
+  done
+  return 1
+}
+pin_value_has_root 'KERNEL_CMDLINE[default]+=" root=UUID=x rw"' ||
+  fail "kernel cmdline guard still accepts a quoted root= pin"
+pin_value_has_root 'KERNEL_CMDLINE[default]+=root=UUID=x' ||
+  fail "kernel cmdline guard still accepts an unquoted root= pin"
+# The tool accepts whitespace between the operator and an opening quote.
+pin_value_has_root 'KERNEL_CMDLINE[default]= "root=UUID=x rw"' ||
+  fail "kernel cmdline guard still accepts a pin with whitespace before the quote"
+if pin_value_has_root 'KERNEL_CMDLINE[default]+=" systemd.volatile-root=1"'; then
+  fail "kernel cmdline guard does not mistake volatile-root= for a root= pin"
+fi
+if pin_value_has_root 'KERNEL_CMDLINE[default]+=systemd.setenv="root=decoy"'; then
+  fail "kernel cmdline guard does not mistake a quoted decoy for a root= pin"
+fi
+# Once the omarchy drop-in appends with +=, limine-entry-tool ignores
+# /etc/kernel/cmdline, so root= there never reaches the boot entries and must
+# not skip the fix.
+if grep -F 'as_root test -e /etc/kernel/cmdline' "$upgrade_to_quattro" >/dev/null; then
+  fail "kernel cmdline guard does not treat the ignored /etc/kernel/cmdline as authoritative"
 fi
 pass "Omarchy 4 upgrade only treats real root= assignments as authoritative"
 
@@ -98,21 +141,38 @@ pass "Omarchy 4 upgrade only treats real root= assignments as authoritative"
 # missing operand makes grep exit 2, which the caller cannot tell apart from "no
 # match". The guard filters the paths first so the exit status stays meaningful.
 grep -F 'config_paths+=("$path")' "$upgrade_to_quattro" >/dev/null
-grep -F '((${#config_paths[@]})) &&' "$upgrade_to_quattro" >/dev/null
+grep -F 'if ((${#config_paths[@]})); then' "$upgrade_to_quattro" >/dev/null
+# Only *.conf drop-ins count: the tool loads nothing else, so .pacnew or
+# .pacsave litter pinning root= must not disarm the fix.
+grep -F '/etc/limine-entry-tool.d/*.conf' "$upgrade_to_quattro" >/dev/null
 guard_fixtures=$(mktemp -d)
 trap 'rm -rf "$guard_fixtures"' EXIT
 mkdir -p "$guard_fixtures/dropins"
 printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=real rw"' >"$guard_fixtures/dropins/99-pins.conf"
+printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=stale rw"' >"$guard_fixtures/dropins/99-stale.conf.pacsave"
 guard_paths=()
-for guard_path in "$guard_fixtures/absent" "$guard_fixtures/dropins"; do
+for guard_path in "$guard_fixtures/absent" "$guard_fixtures/dropins"/*.conf; do
   if [[ -e $guard_path ]]; then
     guard_paths+=("$guard_path")
   fi
 done
-if ! ((${#guard_paths[@]})) || ! grep -rqE "$cmdline_guard" "${guard_paths[@]}"; then
+if ! ((${#guard_paths[@]})) || ! grep -qE "$cmdline_guard" "${guard_paths[@]}"; then
   fail "kernel cmdline guard still detects a drop-in pinning root= when another path is absent"
 fi
+[[ ${guard_paths[*]} == *"99-pins.conf"* && ${guard_paths[*]} != *"pacsave"* ]] ||
+  fail "kernel cmdline guard only reads *.conf drop-ins"
 pass "Omarchy 4 upgrade cmdline guard survives a missing config path"
+
+token_cmdline='root=UUID=x dm-mod.create="0 972 linear /dev/sda 0" rw'
+token_params=()
+while [[ $token_cmdline =~ $param_re ]]; do
+  token_params+=("${BASH_REMATCH[1]}")
+  token_cmdline=${token_cmdline:${#BASH_REMATCH[0]}}
+done
+(( ${#token_params[@]} == 3 )) || fail "kernel cmdline tokenizer splits three parameters"
+[[ ${token_params[1]} == 'dm-mod.create="0 972 linear /dev/sda 0"' ]] ||
+  fail "kernel cmdline tokenizer keeps quoted parameters intact"
+pass "Omarchy 4 upgrade copies quoted kernel parameters verbatim"
 
 grep -F 'boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")' "$upgrade_to_quattro" >/dev/null
 grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
@@ -138,6 +198,9 @@ pass "Omarchy 4 upgrade repair path keeps captured parameters and refuses a part
 
 grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
 grep -F 'as_root objcopy' "$upgrade_to_quattro" >/dev/null
+# Token-anchored, so netroot= or systemd.volatile-root= cannot satisfy the
+# verification.
+grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null
 # Read as root like every other /boot access, and scoped to the images
 # limine-entry-tool generates, so a shared ESP cannot trigger a false warning.
 grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null
@@ -145,3 +208,13 @@ pass "Omarchy 4 upgrade verifies the cmdline embedded in the UKIs"
 
 grep -F 'rd.lvm.lv | rd.lvm.vg' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade carries the device assembly parameters over"
+
+# A warning alone does not stop --reboot or a blind prompt confirmation; an
+# unverified cmdline has to block the reboot itself.
+grep -F 'boot_cmdline_unsafe=1' "$upgrade_to_quattro" >/dev/null
+grep -F 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" >/dev/null
+unsafe_line=$(grep -n 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" | cut -d: -f1)
+reboot_line=$(grep -n 'Rebooting because --reboot was passed' "$upgrade_to_quattro" | cut -d: -f1)
+[[ -n $unsafe_line && -n $reboot_line ]] || fail "reboot gate and reboot branch exist"
+(( unsafe_line < reboot_line )) || fail "an unverified kernel cmdline blocks the reboot"
+pass "Omarchy 4 upgrade refuses to reboot with an unverified kernel cmdline"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -119,21 +119,21 @@ grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/n
 grep -F 'have_unlock' "$upgrade_to_quattro" >/dev/null
 # Gated on the mapper target type, not on the /dev/mapper/* prefix, so plain LVM,
 # dm-raid and multipath roots keep the repair path.
-grep -F 'lsblk -no TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null
-grep -F '[[ $root_type == "crypt" ]]' "$upgrade_to_quattro" >/dev/null
 if grep -F '[[ $root_source == /dev/mapper/* ]] && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null; then
   fail "kernel cmdline repair path does not treat every /dev/mapper root as encrypted"
 fi
+# lsblk reports only the target's own type, which is lvm on the standard
+# container -> LVM PV -> root LV layout, so the crypt layer has to be looked for
+# across the parents with -s or full-disk encryption slips through.
+grep -F 'lsblk -nso TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null
+grep -F 'grep -qx crypt' "$upgrade_to_quattro" >/dev/null
+grep -F '((root_stacks_crypt)) && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null
 # Without --nofsroot findmnt appends the subvolume, so an encrypted btrfs root
-# reads /dev/mapper/cryptroot[/@], lsblk cannot resolve it, and the crypt gate
-# misses the one layout Omarchy installs when encryption is picked.
+# reads /dev/mapper/cryptroot[/@] and lsblk cannot resolve it at all.
 grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null
-if printf '%s\n' '/dev/mapper/cryptroot[/@]' | grep -qvE '\[' ; then
-  fail "the bracketed btrfs source form is what --nofsroot exists to strip"
-fi
-# root_type is read outside the branch that assigns it, and set -u treats a
-# declared-but-unassigned local as unbound.
-grep -F 'local root_type=""' "$upgrade_to_quattro" >/dev/null
+# Read outside the branch that assigns it, and set -u treats a declared-but-
+# unassigned local as unbound.
+grep -F 'local root_stacks_crypt=0' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade repair path keeps captured parameters and refuses a partial dm-crypt cmdline"
 
 grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -124,6 +124,16 @@ grep -F '[[ $root_type == "crypt" ]]' "$upgrade_to_quattro" >/dev/null
 if grep -F '[[ $root_source == /dev/mapper/* ]] && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null; then
   fail "kernel cmdline repair path does not treat every /dev/mapper root as encrypted"
 fi
+# Without --nofsroot findmnt appends the subvolume, so an encrypted btrfs root
+# reads /dev/mapper/cryptroot[/@], lsblk cannot resolve it, and the crypt gate
+# misses the one layout Omarchy installs when encryption is picked.
+grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null
+if printf '%s\n' '/dev/mapper/cryptroot[/@]' | grep -qvE '\[' ; then
+  fail "the bracketed btrfs source form is what --nofsroot exists to strip"
+fi
+# root_type is read outside the branch that assigns it, and set -u treats a
+# declared-but-unassigned local as unbound.
+grep -F 'local root_type=""' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade repair path keeps captured parameters and refuses a partial dm-crypt cmdline"
 
 grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -69,3 +69,15 @@ pass "Omarchy 4 upgrade refreshes application launchers"
 grep -F '/etc/systemd/system.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null
 grep -F '/etc/systemd/user.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade removes stale nofile drop-ins"
+
+cmdline_line=$(grep -n '^preserve_kernel_cmdline_root$' "$upgrade_to_quattro" | cut -d: -f1)
+packages_line=$(grep -n '^install_omarchy_quattro_packages$' "$upgrade_to_quattro" | cut -d: -f1)
+[[ -n $cmdline_line && -n $packages_line ]] || fail "kernel cmdline preservation and package install calls exist"
+(( packages_line < cmdline_line )) || fail "kernel cmdline preservation runs once limine-mkinitcpio is installed"
+grep -F '/etc/default/limine' "$upgrade_to_quattro" >/dev/null
+grep -F 'KERNEL_CMDLINE[default]+=" ${boot_params[*]}"' "$upgrade_to_quattro" >/dev/null
+grep -F 'cat /proc/cmdline' "$upgrade_to_quattro" >/dev/null
+grep -F 'findmnt -no UUID /' "$upgrade_to_quattro" >/dev/null
+grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
+grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -82,139 +82,29 @@ grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
 grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 
-# Kernel parameters can quote spaces (dm-mod.create="0 972 linear ...");
-# word splitting would truncate them and glob-expand the rest.
-param_re='^[[:space:]]*(([^[:space:]"]|"[^"]*")+)'
-grep -F "param_re='^[[:space:]]*(([^[:space:]\"]|\"[^\"]*\")+)'" "$upgrade_to_quattro" >/dev/null
+# The += drop-ins make limine-entry-tool ignore /etc/kernel/cmdline and
+# /proc/cmdline, so only the tool's own merge can say whether root= survives.
+# Queried for the default key, so a kernel-specific pin cannot cover for the
+# entries this repairs.
+grep -F 'limine-entry-tool --get-cmdline default' "$upgrade_to_quattro" >/dev/null
+grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade asks limine-entry-tool whether root= survives"
 
-# limine-entry-tool.conf ships "#KERNEL_CMDLINE[default]+=rw root=UUID=..." as a
-# commented example, so the guard matches assignment lines and not the bare
-# string, and only the default key feeds the entries the fix repairs.
-cmdline_guard='^[[:space:]]*KERNEL_CMDLINE\[default\][+]?='
-grep -F "pin_line='^[[:space:]]*KERNEL_CMDLINE" "$upgrade_to_quattro" >/dev/null
-if printf '%s\n' '#KERNEL_CMDLINE[default]+=rw root=UUID=...' | grep -qE "$cmdline_guard"; then
-  fail "kernel cmdline guard ignores the commented example in limine-entry-tool.conf"
-fi
-if printf '%s\n' 'KERNEL_CMDLINE[fallback]+=" root=UUID=x"' | grep -qE "$cmdline_guard"; then
-  fail "kernel cmdline guard does not let a fallback-only pin cover the default entries"
-fi
-if ! printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=x rw"' | grep -qE "$cmdline_guard"; then
-  fail "kernel cmdline guard still matches a real assignment"
-fi
-# Mirrors the guard's value walk: root= must appear as its own parameter, so
-# systemd.volatile-root= and a quoted decoy cannot count as a pin.
-grep -F '[[ ${BASH_REMATCH[1]} == root=* ]] && return 0' "$upgrade_to_quattro" >/dev/null
-pin_value_has_root() {
-  local value=${1#*=}
-  value=${value#"${value%%[![:space:]]*}"}
-  value=${value%"${value##*[![:space:]]}"}
-  value=${value#[\"\']}
-  value=${value%[\"\']}
-  while [[ $value =~ $param_re ]]; do
-    [[ ${BASH_REMATCH[1]} == root=* ]] && return 0
-    value=${value:${#BASH_REMATCH[0]}}
-  done
-  return 1
-}
-pin_value_has_root 'KERNEL_CMDLINE[default]+=" root=UUID=x rw"' ||
-  fail "kernel cmdline guard still accepts a quoted root= pin"
-pin_value_has_root 'KERNEL_CMDLINE[default]+=root=UUID=x' ||
-  fail "kernel cmdline guard still accepts an unquoted root= pin"
-# The tool accepts whitespace between the operator and an opening quote.
-pin_value_has_root 'KERNEL_CMDLINE[default]= "root=UUID=x rw"' ||
-  fail "kernel cmdline guard still accepts a pin with whitespace before the quote"
-if pin_value_has_root 'KERNEL_CMDLINE[default]+=" systemd.volatile-root=1"'; then
-  fail "kernel cmdline guard does not mistake volatile-root= for a root= pin"
-fi
-if pin_value_has_root 'KERNEL_CMDLINE[default]+=systemd.setenv="root=decoy"'; then
-  fail "kernel cmdline guard does not mistake a quoted decoy for a root= pin"
-fi
-# Once the omarchy drop-in appends with +=, limine-entry-tool ignores
-# /etc/kernel/cmdline, so root= there never reaches the boot entries and must
-# not skip the fix.
-if grep -F 'as_root test -e /etc/kernel/cmdline' "$upgrade_to_quattro" >/dev/null; then
-  fail "kernel cmdline guard does not treat the ignored /etc/kernel/cmdline as authoritative"
-fi
-pass "Omarchy 4 upgrade only treats real root= assignments as authoritative"
-
-# /etc/default/limine is absent on exactly the machines this targets, and a
-# missing operand makes grep exit 2, which the caller cannot tell apart from "no
-# match". The guard filters the paths first so the exit status stays meaningful.
-grep -F 'config_paths+=("$path")' "$upgrade_to_quattro" >/dev/null
-grep -F 'if ((${#config_paths[@]})); then' "$upgrade_to_quattro" >/dev/null
-# Only *.conf drop-ins count: the tool loads nothing else, so .pacnew or
-# .pacsave litter pinning root= must not disarm the fix.
-grep -F '/etc/limine-entry-tool.d/*.conf' "$upgrade_to_quattro" >/dev/null
-guard_fixtures=$(mktemp -d)
-trap 'rm -rf "$guard_fixtures"' EXIT
-mkdir -p "$guard_fixtures/dropins"
-printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=real rw"' >"$guard_fixtures/dropins/99-pins.conf"
-printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=stale rw"' >"$guard_fixtures/dropins/99-stale.conf.pacsave"
-guard_paths=()
-for guard_path in "$guard_fixtures/absent" "$guard_fixtures/dropins"/*.conf; do
-  if [[ -e $guard_path ]]; then
-    guard_paths+=("$guard_path")
-  fi
-done
-if ! ((${#guard_paths[@]})) || ! grep -qE "$cmdline_guard" "${guard_paths[@]}"; then
-  fail "kernel cmdline guard still detects a drop-in pinning root= when another path is absent"
-fi
-[[ ${guard_paths[*]} == *"99-pins.conf"* && ${guard_paths[*]} != *"pacsave"* ]] ||
-  fail "kernel cmdline guard only reads *.conf drop-ins"
-pass "Omarchy 4 upgrade cmdline guard survives a missing config path"
-
-token_cmdline='root=UUID=x dm-mod.create="0 972 linear /dev/sda 0" rw'
-token_params=()
-while [[ $token_cmdline =~ $param_re ]]; do
-  token_params+=("${BASH_REMATCH[1]}")
-  token_cmdline=${token_cmdline:${#BASH_REMATCH[0]}}
-done
-(( ${#token_params[@]} == 3 )) || fail "kernel cmdline tokenizer splits three parameters"
-[[ ${token_params[1]} == 'dm-mod.create="0 972 linear /dev/sda 0"' ]] ||
-  fail "kernel cmdline tokenizer keeps quoted parameters intact"
-pass "Omarchy 4 upgrade copies quoted kernel parameters verbatim"
-
-grep -F 'boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")' "$upgrade_to_quattro" >/dev/null
-grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
-grep -F 'have_unlock' "$upgrade_to_quattro" >/dev/null
-# Gated on a crypt layer in the stack, not on the /dev/mapper/* prefix, so plain
-# LVM, dm-raid and multipath roots keep the repair path.
-if grep -F '[[ $root_source == /dev/mapper/* ]] && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null; then
-  fail "kernel cmdline repair path does not treat every /dev/mapper root as encrypted"
-fi
-# lsblk reports only the target's own type, which is lvm on the standard
-# container -> LVM PV -> root LV layout, so the crypt layer has to be looked for
-# across the parents with -s or full-disk encryption slips through.
+# The crypt layer hides in the parents on LVM-on-LUKS, and a partial cmdline
+# for an encrypted root must not be written at all.
+grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null
 grep -F 'lsblk -nso TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null
 grep -F 'grep -qx crypt' "$upgrade_to_quattro" >/dev/null
-grep -F '((root_stacks_crypt)) && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null
-# Without --nofsroot findmnt appends the subvolume, so an encrypted btrfs root
-# reads /dev/mapper/cryptroot[/@] and lsblk cannot resolve it at all.
-grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null
-# Read outside the branch that assigns it, and set -u treats a declared-but-
-# unassigned local as unbound.
-grep -F 'local root_stacks_crypt=0' "$upgrade_to_quattro" >/dev/null
-pass "Omarchy 4 upgrade repair path keeps captured parameters and refuses a partial dm-crypt cmdline"
+grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade repair path refuses a partial dm-crypt cmdline"
 
+# The cmdline that boots is the one embedded in the UKIs, and an unverified
+# root= must block the reboot rather than just warn.
 grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
-grep -F 'as_root objcopy' "$upgrade_to_quattro" >/dev/null
-# Token-anchored, so netroot= or systemd.volatile-root= cannot satisfy the
-# verification.
-grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null
-# Read as root like every other /boot access, and scoped to the images
-# limine-entry-tool generates, so a shared ESP cannot trigger a false warning.
 grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null
-pass "Omarchy 4 upgrade verifies the cmdline embedded in the UKIs"
-
-grep -F 'rd.lvm.lv | rd.lvm.vg' "$upgrade_to_quattro" >/dev/null
-pass "Omarchy 4 upgrade carries the device assembly parameters over"
-
-# A warning alone does not stop --reboot or a blind prompt confirmation; an
-# unverified cmdline has to block the reboot itself.
 grep -F 'boot_cmdline_unsafe=1' "$upgrade_to_quattro" >/dev/null
-grep -F 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" >/dev/null
 unsafe_line=$(grep -n 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" | cut -d: -f1)
 reboot_line=$(grep -n 'Rebooting because --reboot was passed' "$upgrade_to_quattro" | cut -d: -f1)
 [[ -n $unsafe_line && -n $reboot_line ]] || fail "reboot gate and reboot branch exist"
 (( unsafe_line < reboot_line )) || fail "an unverified kernel cmdline blocks the reboot"
-pass "Omarchy 4 upgrade refuses to reboot with an unverified kernel cmdline"
+pass "Omarchy 4 upgrade verifies the UKIs and refuses to reboot unverified"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -81,3 +81,27 @@ grep -F 'findmnt -no UUID /' "$upgrade_to_quattro" >/dev/null
 grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
 grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
+
+# limine-entry-tool.conf ships "#KERNEL_CMDLINE[default]+=rw root=UUID=..." as a
+# commented example, so the guard has to look for assignments and not for the
+# bare string, or it returns early on every stock machine.
+cmdline_guard='^[[:space:]]*KERNEL_CMDLINE\[[^]]*\][+]?=.*root='
+grep -qF "grep -rhsE '$cmdline_guard'" "$upgrade_to_quattro" ||
+  fail "kernel cmdline guard is anchored on an assignment"
+if printf '%s\n' '#KERNEL_CMDLINE[default]+=rw root=UUID=...' | grep -qE "$cmdline_guard"; then
+  fail "kernel cmdline guard ignores the commented example in limine-entry-tool.conf"
+fi
+if ! printf '%s\n' 'KERNEL_CMDLINE[default]+=" root=UUID=x rw"' | grep -qE "$cmdline_guard"; then
+  fail "kernel cmdline guard still matches a real assignment"
+fi
+pass "Omarchy 4 upgrade only treats real root= assignments as authoritative"
+
+grep -F 'boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")' "$upgrade_to_quattro" >/dev/null
+grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
+grep -F '/dev/mapper/*' "$upgrade_to_quattro" >/dev/null
+grep -F 'have_unlock' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade repair path keeps captured parameters and refuses a partial dm-crypt cmdline"
+
+grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
+grep -F '/boot/EFI/Linux' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade verifies the cmdline embedded in the UKIs"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -117,8 +117,8 @@ pass "Omarchy 4 upgrade cmdline guard survives a missing config path"
 grep -F 'boot_params=("root=UUID=$root_uuid" "${boot_params[@]}")' "$upgrade_to_quattro" >/dev/null
 grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
 grep -F 'have_unlock' "$upgrade_to_quattro" >/dev/null
-# Gated on the mapper target type, not on the /dev/mapper/* prefix, so plain LVM,
-# dm-raid and multipath roots keep the repair path.
+# Gated on a crypt layer in the stack, not on the /dev/mapper/* prefix, so plain
+# LVM, dm-raid and multipath roots keep the repair path.
 if grep -F '[[ $root_source == /dev/mapper/* ]] && ((!have_unlock))' "$upgrade_to_quattro" >/dev/null; then
   fail "kernel cmdline repair path does not treat every /dev/mapper root as encrypted"
 fi


### PR DESCRIPTION
## What's wrong

Upgrading a pre-quattro install with `omarchy-upgrade-to-quattro` can leave the machine unbootable. The next boot fails with `ERROR: Failed to mount '' on real root` and drops to an emergency shell, because the cmdline has no `root=` at all:

```
initramfs_async=0 quiet splash loglevel=0 systemd.show_status=false rd.udev.log_level=0 vt.global_cursor_default=0
```

That is both `cmdline:` entries in `/boot/limine.conf` and the cmdline embedded in `/boot/EFI/Linux/omarchy_linux*.efi`. `fstab` is intact and nothing is corrupted, so the error points nowhere near the cause.

## Why

`/etc/limine-entry-tool.d/omarchy-defaults.conf` sets `KERNEL_CMDLINE[default]` with `+=`, and `limine-entry-tool.conf` documents the cost: `+= ... Ignores /etc/kernel/cmdline and /proc/cmdline`. Auto-detection stops the moment that drop-in lands.

Fresh installs are fine, the ISO writes `/etc/default/limine` from `default/limine/default.conf` with `@@CMDLINE@@` substituted. The upgrade path never created it, so an install that relied on the auto-detected `root=` loses it silently.

## The fix

`preserve_kernel_cmdline_root` runs after `normalize_limine_config`, so `limine-mkinitcpio` exists but the reboot has not happened yet and `/proc/cmdline` still holds the correct cmdline.

- Returns early when a config layer already pins `root=`. The pattern matches assignments, not the bare string, because `limine-entry-tool.conf` ships `#KERNEL_CMDLINE[default]+=rw root=UUID=...` on every machine. Only existing paths reach `grep`, since `/etc/default/limine` is absent here and a missing operand makes `grep` exit 2, indistinguishable from no match.
- Copies the boot-critical parameters verbatim, so a `PARTUUID`, a `LABEL` or a bare device node all survive: `root`, `rootflags`, `rootfstype`, `rootwait`, `rootdelay`, `resume`, `resume_offset`, `cryptdevice`, `cryptkey`, `rd.luks.*`, `dm-mod.create`, `rd.lvm.*`, `rd.md.uuid`, `rd.dm.uuid`, `rw`, `ro`. An allowlist rather than a denylist of the drop-in's own parameters, because that list is owned by `omarchy-settings` and anything added there would leak in and be duplicated.
- Writes to `/etc/default/limine`, loaded last, appending with `+=` so the drop-in parameters survive.
- Repairs as well as prevents: with no `root=` left to copy it derives one from `findmnt`, prepends it to whatever was captured, adds `rw` only if no mount mode was stated, and adds `rootflags=subvol=` on btrfs.
- Refuses to write a partial cmdline for an encrypted root with no unlock parameters, which would satisfy the final check while still failing to boot. The crypt layer is looked for across the parents with `lsblk -nso TYPE`, not on the root device alone: on the standard container to LVM PV to root LV layout the root's own type is `lvm` and a plain `lsblk -no TYPE` misses the encryption entirely. Roots with no crypt layer anywhere (LVM, dm-raid, multipath) keep the repair, since `root=UUID=` is enough once mkinitcpio assembles them. The source is read with `findmnt --nofsroot`, otherwise an encrypted btrfs root reads `/dev/mapper/cryptroot[/@]` and `lsblk` cannot resolve it at all. `root_filesystem_encrypted()` is not reused: its `/dev/mapper/*` and `/etc/crypttab` branches would deny the repair to unencrypted stacked roots.
- Verifies `root=` reached `/boot/limine.conf` and the `.cmdline` section of each `omarchy_linux*.efi`, since the embedded copy is what boots. Scoped to those names so a shared ESP cannot raise a false warning, and read through `as_root` so a restrictive ESP `fmask` cannot make the check pass in silence.

## Testing

`test/shell.d/upgrade-to-quattro-test.sh` gains six cases and passes 18/18; `bin-style-test.sh` passes. Two out-of-line harnesses cover the logic: seven cmdline inputs across LVM, dm-raid, dm-crypt with and without unlock parameters, a bare disk and a verbatim `root=PARTUUID=` copy; and a second stubbing `findmnt` and `lsblk` with real parent chains, covering LUKS at the root, LVM-on-LUKS with and without unlock parameters, LVM-on-LUKS under a subvolume, plain LVM, dm-raid and a bare disk, which reproduces both the encrypted-btrfs and the LVM-on-LUKS misses and the refusals once fixed.

Verified by hand on the affected machine (ext4 root, no LUKS, Limine, `linux` + `linux-g14`): writing `/etc/default/limine` and running `limine-mkinitcpio` restored `root=` to both `limine.conf` entries and both UKIs, and it boots again.

`test/shell` as a whole does not run here, `config-test.sh` wants an `omarchy-pkgs` checkout, unrelated to this change.

## Note

Recovery before this ships: at the emergency shell, `mount /dev/<root partition> /new_root` then `exit` boots normally, and `/etc/default/limine` can be written from there.
