### PR TITLE
Fail loudly when a pre-update snapshot isn't actually created

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -22,8 +22,6 @@ create)
   # The description is just a label, so never let it abort the snapshot.
   DESC="$(omarchy-version 2>/dev/null || echo unknown)"
 
-  echo -e "\e[32mCreate system snapshot\e[0m"
-
   # Get existing snapper config names from CSV output
   mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
 
@@ -32,9 +30,11 @@ create)
   # nothing has ever been captured.
   if (( ${#CONFIGS[@]} == 0 )); then
     echo -e "\e[33mNo Snapper configs found, so no snapshot was created.\e[0m" >&2
-    echo "Configure Snapper with: sudo bash $OMARCHY_PATH/install/config/snapper.sh" >&2
+    echo "Configure Snapper with: sudo bash -euo pipefail \"$OMARCHY_PATH/install/config/snapper.sh\"" >&2
     exit 1
   fi
+
+  echo -e "\e[32mCreate system snapshot\e[0m"
 
   for config in "${CONFIGS[@]}"; do
     sudo snapper -c "$config" create -c number -d "$DESC"

--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -27,6 +27,15 @@ create)
   # Get existing snapper config names from CSV output
   mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
 
+  # Snapper installed but unconfigured snapshots nothing. Staying quiet here
+  # reads as a successful snapshot, so the next update looks recoverable when
+  # nothing has ever been captured.
+  if (( ${#CONFIGS[@]} == 0 )); then
+    echo -e "\e[33mNo Snapper configs found, so no snapshot was created.\e[0m" >&2
+    echo "Configure Snapper with: sudo bash $OMARCHY_PATH/install/config/snapper.sh" >&2
+    exit 1
+  fi
+
   for config in "${CONFIGS[@]}"; do
     sudo snapper -c "$config" create -c number -d "$DESC"
     sudo snapper -c "$config" cleanup number

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -22,7 +22,11 @@ trap 'omarchy-update-stay-awake stop' EXIT
 omarchy-update-requires-free-space
 
 if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
-  omarchy-snapshot create || (($? == 127))
+  # 127 means Snapper is deliberately absent. Any other failure already said
+  # what went wrong, and a missing snapshot is not worth blocking an update
+  # over, but it must not pass for one either.
+  omarchy-snapshot create || (($? == 127)) ||
+    echo -e "\e[33mContinuing the update without a snapshot.\e[0m" >&2
 
   omarchy-update-stay-awake start
 

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -610,7 +610,11 @@ configure_lock_authentication() {
 }
 
 create_pre_upgrade_snapshot() {
-  omarchy-snapshot create || (($? == 127))
+  # 127 means Snapper is deliberately absent. Any other failure already said
+  # what went wrong, and a missing snapshot is not worth blocking the upgrade
+  # over, but it must not pass for one either.
+  omarchy-snapshot create || (($? == 127)) ||
+    echo -e "\e[33mContinuing the upgrade without a snapshot.\e[0m" >&2
 }
 
 remove_conflicting_legacy_packages() {

--- a/test/shell.d/snapshot-create-test.sh
+++ b/test/shell.d/snapshot-create-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+snapshot="$ROOT/bin/omarchy-snapshot"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$fake_bin/sudo"
+
+cat >"$fake_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$fake_bin/omarchy-cmd-missing"
+
+cat >"$fake_bin/omarchy-version" <<'STUB'
+#!/bin/bash
+echo 4.0.0
+STUB
+chmod +x "$fake_bin/omarchy-version"
+
+# Snapper with no configs: list-configs prints only the CSV header.
+cat >"$fake_bin/snapper" <<'STUB'
+#!/bin/bash
+printf 'snapper %s\n' "$*" >>"$TEST_LOG"
+if [[ "$*" == *"list-configs"* ]]; then
+  echo "config,subvolume"
+fi
+STUB
+chmod +x "$fake_bin/snapper"
+
+# A snapshot that silently creates nothing reads as a successful snapshot, so
+# an unconfigured Snapper has to fail loudly instead of passing for a backup.
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot" create 2>&1 >/dev/null)
+status=$?
+set -e
+
+(( status != 0 )) || fail "snapshot create fails when Snapper has no configs"
+grep -qF 'No Snapper configs found' <<<"$stderr" ||
+  fail "snapshot create reports that no snapshot was created" "$stderr"
+! grep -q '^snapper -c .* create ' "$test_tmp/calls.log" ||
+  fail "snapshot create does not invent a config to snapshot"
+pass "snapshot create fails loudly when Snapper is installed but unconfigured"
+
+cat >"$fake_bin/snapper" <<'STUB'
+#!/bin/bash
+printf 'snapper %s\n' "$*" >>"$TEST_LOG"
+if [[ "$*" == *"list-configs"* ]]; then
+  echo "config,subvolume"
+  echo "root,/"
+fi
+STUB
+chmod +x "$fake_bin/snapper"
+
+: >"$test_tmp/calls.log"
+TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot" create >/dev/null
+
+grep -qFx 'snapper -c root create -c number -d 4.0.0' "$test_tmp/calls.log" ||
+  fail "snapshot create snapshots each configured subvolume" "$(cat "$test_tmp/calls.log")"
+grep -qFx 'snapper -c root cleanup number' "$test_tmp/calls.log" ||
+  fail "snapshot create prunes older snapshots"
+pass "snapshot create snapshots every configured Snapper config"
+
+# Snapper being deliberately absent is the one skip that stays quiet, and the
+# update has to keep treating it as such.
+cat >"$fake_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+chmod +x "$fake_bin/omarchy-cmd-missing"
+
+set +e
+TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot" create >/dev/null 2>&1
+status=$?
+set -e
+
+(( status == 127 )) || fail "snapshot create exits 127 without snapper" "got $status"
+grep -qF 'omarchy-snapshot create || (($? == 127))' "$ROOT/bin/omarchy-update" ||
+  fail "update ignores only the missing-snapper exit code"
+pass "snapshot create keeps the quiet 127 path for systems without snapper"

--- a/test/shell.d/snapshot-create-test.sh
+++ b/test/shell.d/snapshot-create-test.sh
@@ -94,3 +94,11 @@ set -e
 grep -qF 'omarchy-snapshot create || (($? == 127))' "$ROOT/bin/omarchy-update" ||
   fail "update ignores only the missing-snapper exit code"
 pass "snapshot create keeps the quiet 127 path for systems without snapper"
+
+# The quattro upgrade runs under set -e, so a failed snapshot has to be warned
+# past there too or it aborts the whole upgrade at the snapshot step.
+grep -qF 'omarchy-snapshot create || (($? == 127))' "$ROOT/bin/omarchy-upgrade-to-quattro" ||
+  fail "upgrade ignores only the missing-snapper exit code"
+grep -qF 'Continuing the upgrade without a snapshot' "$ROOT/bin/omarchy-upgrade-to-quattro" ||
+  fail "upgrade continues past a failed snapshot instead of aborting"
+pass "upgrade to quattro survives a failed snapshot without passing it off"


### PR DESCRIPTION
## What's wrong

`omarchy-snapshot create` loops over the configs `snapper` reports:

```bash
mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')

for config in "${CONFIGS[@]}"; do
```

If `snapper` is installed but has no configs, `CONFIGS` is empty, the loop body never runs, and the command prints its green `Create system snapshot` header and exits `0` having captured nothing. `omarchy update` reports a snapshot on every run while none exist. The absence only surfaces when someone actually needs to roll back and finds the snapshot list empty.

`bin/omarchy-update` compounds it:

```bash
omarchy-snapshot create || (($? == 127))
```

`127` is the deliberate "snapper isn't installed, ignore it" path, but this expression swallows *every* other non-zero exit too, so a genuinely failed snapshot also passes silently.

## How I hit it

An unlucky ordering on a fresh 3.8.4 install. `limine-snapper-sync` self-configured at first boot before Omarchy's own setup, and its `create-config` failed:

```
limine-snapper-watcher[1214]: Btrfs.cc(createConfig):139 create subvolume failed, \
  btrfs_util_create_subvolume_fd() failed, errno:13 (Permission denied)
limine-snapper-watcher[1214]: Creating config failed (creating btrfs subvolume .snapshots failed).
limine-snapper-watcher[1214]: Failed: "snapper --no-dbus -c root create-config /" with exit code: 1
```

That left `/etc/snapper/configs/` empty and no `/.snapshots`, while `/etc/default/limine` was configured for snapshot boot entries — so everything looked set up. Weeks of updates each printed `Create system snapshot`. When I needed to undo a channel switch, there was nothing to roll back to.

Worth noting the install-side hole this came through **is already fixed on `quattro`**: `install/config/snapper.sh` now runs under `bash -eE`, and the `Normalize Snapper snapshot services` migration repairs exactly this broken state. This PR only addresses the reporting, which is what turned a recoverable install glitch into a silent one that persisted for weeks.

## What this changes

- `omarchy-snapshot create` exits non-zero with a warning when snapper reports no configs, pointing at `install/config/snapper.sh` to repair it.
- `omarchy-update` still continues past a failed snapshot — a missing snapshot shouldn't block an update — but now says so instead of proceeding as if protected. `127` stays silent, so systems deliberately without snapper are unaffected.

## Tests

Adds `test/shell.d/snapshot-create-test.sh` covering the empty-config failure, the normal multi-config path, and the quiet `127` path. It fails against the unpatched script.

`./test/cli` passes 102/102. In `./test/shell`, the pre-existing failures that need sibling `omarchy-pkgs`/`omarchy-iso` checkouts or a live session are unchanged.

I also checked the four `omarchy-update` outcomes (success, `127`, no-configs, unexpected crash) against real subprocess exit codes to confirm the added `||` doesn't trip the `ERR` trap and surface a spurious "Something went wrong during the update!" banner. It doesn't.