### PR TITLE
Stop Tuxedo backlight fix from aborting setup

### DIFF
--- a/install/hardware/fix-tuxedo-backlight.sh
+++ b/install/hardware/fix-tuxedo-backlight.sh
@@ -11,6 +11,8 @@ if cat /sys/class/dmi/id/sys_vendor 2>/dev/null | grep -qi "TUXEDO\|Slimbook"; t
 
   # Remove any orphaned clevo_xsm_wmi module files not managed by a package
   for f in /lib/modules/*/extra/clevo-xsm-wmi.ko; do
-    [ -f "$f" ] && rm "$f"
+    if [[ -f $f ]]; then
+      rm "$f"
+    fi
   done
 fi


### PR DESCRIPTION
Hardware setup aborts on every Tuxedo and Slimbook install.

`install/hardware/fix-tuxedo-backlight.sh` ends with a loop that removes orphaned `clevo-xsm-wmi.ko` files:

```bash
for f in /lib/modules/*/extra/clevo-xsm-wmi.ko; do
  [ -f "$f" ] && rm "$f"
done
```

That loop is the last statement in the script, so it sets the exit status. On a clean install there is no orphaned module, the glob doesn't expand, `[ -f "$f" ]` is false, and the trailing `&&` list leaves the script exiting **1**.

`run_logged` runs each leaf under `bash -eE` and returns that status, and `install/hardware/all.sh` is sourced by `bin/omarchy-setup-hardware` under `set -euo pipefail`. So the non-zero exit aborts hardware setup — `speaker-tuning.sh` and `pacman.sh` never run — and fails `omarchy-setup-system`.

The `if` guard on `sys_vendor` means only Tuxedo and Slimbook machines are affected; everything else exits 0.

## Fix

Use an `if` block, which returns 0 when the condition is false.

## Verification

Exercised both paths under the same `bash -eE -c 'source ...'` harness `run_logged` uses:

- glob matches nothing → exits 0 (was 1)
- glob matches → exits 0, file removed

`./test/all` shows one pre-existing failure (`bar icon geometry fixture exits cleanly`), identical with the change stashed — Quickshell can't start without a display.

## Note on a related report

A circulating report attributes this to the installer writing to `/sys/class/leds/rgb:kbd_backlight/multi_intensity` without error handling. That mechanism doesn't exist — the string appears nowhere in the tree or in history (`git log -S multi_intensity --all`). The script only installs the driver package, blacklists `clevo_xsm_wmi`, and removes orphaned module files. The symptom in that report is real; the cause is the exit status above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)