### PR TITLE
Default XKBLAYOUT so the migration runner survives its absence

### DIFF
--- a/migrations/1784476564.sh
+++ b/migrations/1784476564.sh
@@ -8,7 +8,8 @@ echo "Keep non-Latin keyboard layouts out of the initramfs so the LUKS passphras
 
 hooks_conf="/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
 
-layout=$(. /etc/vconsole.conf 2>/dev/null && echo "${XKBLAYOUT%%,*}")
+layout=$(. /etc/vconsole.conf 2>/dev/null && echo "${XKBLAYOUT-}")
+layout=${layout%%,*}
 
 if [[ $layout =~ ^(af|am|ara|bd|bg|by|et|ge|gr|il|in|iq|ir|kg|kh|kz|la|lk|mk|mm|mn|mv|np|rs|ru|sy|th|tj|ua)$ ]] &&
   [[ -f $hooks_conf ]] && grep -qx 'FILES+=(/etc/vconsole.conf)' "$hooks_conf"; then

--- a/test/shell.d/vconsole-layout-migration-test.sh
+++ b/test/shell.d/vconsole-layout-migration-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Keep non-Latin keyboard layouts out of the initramfs' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "non-Latin keyboard layout migration exists"
+
+# /etc/vconsole.conf normally carries only KEYMAP; XKBLAYOUT is written when an
+# X11 layout is set explicitly. Migrations run under bash -euo pipefail, so
+# reading XKBLAYOUT without a default aborts the runner on every install that
+# does not have one, taking every later migration with it.
+if ( set -u; unset XKBLAYOUT; : "${XKBLAYOUT%%,*}" ) 2>/dev/null; then
+  fail "an unset XKBLAYOUT is what set -u aborts on"
+fi
+if ! ( set -u; unset XKBLAYOUT; layout=${XKBLAYOUT-}; : "${layout%%,*}" ) 2>/dev/null; then
+  fail "defaulting XKBLAYOUT survives set -u"
+fi
+grep -F 'echo "${XKBLAYOUT-}"' "$migration" >/dev/null ||
+  fail "the migration reads XKBLAYOUT with a default"
+pass "keyboard layout migration survives a vconsole.conf without XKBLAYOUT"
+
+# The comma strip has to stay: XKBLAYOUT holds a comma-separated list and only
+# the first entry decides whether the initramfs can type a Latin passphrase.
+grep -F 'layout=${layout%%,*}' "$migration" >/dev/null ||
+  fail "the migration still narrows XKBLAYOUT to its first entry"
+if ( set -u; layout="ru,us"; layout=${layout%%,*}; [[ $layout == "ru,us" ]] ); then
+  fail "the comma strip reduces a layout list to its first entry"
+fi
+pass "keyboard layout migration still reads only the primary layout"


### PR DESCRIPTION
## What's wrong

Migration `1784476564` aborts the migration runner on any install whose `/etc/vconsole.conf` has no `XKBLAYOUT`, and takes every later migration with it:

```
Running migration (1784476564)
Keep non-Latin keyboard layouts out of the initramfs so the LUKS passphrase stays typeable
/usr/share/omarchy/migrations/1784476564.sh: line 11: XKBLAYOUT: unbound variable
Warning: Could not run Omarchy migrations; the user may be prompted to run them after login.
```

`omarchy-migrate` runs each migration with `bash -euo pipefail` and stops at the first failure, so on my machine 42 pending migrations were skipped. The message names a variable rather than the consequence, and the warning does not say which migrations did not run.

## Why

```sh
layout=$(. /etc/vconsole.conf 2>/dev/null && echo "${XKBLAYOUT%%,*}")
```

`/etc/vconsole.conf` normally carries only `KEYMAP`. `XKBLAYOUT` is written when an X11 layout is set explicitly, and nothing in this repo writes it. Mine is:

```
KEYMAP=us
```

So `XKBLAYOUT` is unset, `set -u` fires, and the migration never reaches the guard it exists for.

## The fix

Read it with a default, then narrow to the first entry as before. The comma strip has to stay, since `XKBLAYOUT` holds a list and only the primary layout decides whether the LUKS passphrase is typeable.

An empty layout does not match the non-Latin regex, so an install without `XKBLAYOUT` keeps `FILES+=(/etc/vconsole.conf)` bundled, which is the pre-existing behaviour for a Latin layout. The fix changes nothing for installs that do have `XKBLAYOUT`.

Same expansion appears in `config/mkinitcpio.conf.d/omarchy_hooks.conf`, but that one is sourced by mkinitcpio without `set -u`, so it degrades to an empty case instead of aborting. Left alone to keep this diff to the failure.

## Testing

New `test/shell.d/vconsole-layout-migration-test.sh`, 2 cases, both pass: an unset `XKBLAYOUT` is what `set -u` aborts on, defaulting it survives, and the comma strip still reduces a list to its first entry.

Verified end to end on the affected machine, which has `KEYMAP=us` and no `XKBLAYOUT`: `bash -euo pipefail migrations/1784476564.sh` aborted before, exits 0 after.
