### PR TITLE
Skip Snapper configuration on a root it cannot support

### DIFF
--- a/install/config/snapper.sh
+++ b/install/config/snapper.sh
@@ -1,8 +1,20 @@
 SNAPPER_CONFIG_PATH="${OMARCHY_SNAPPER_CONFIG_PATH:-/etc/snapper/configs/root}"
 SNAPPER_CONF_PATH="${OMARCHY_SNAPPER_CONF_PATH:-/etc/conf.d/snapper}"
 template="${OMARCHY_SNAPPER_TEMPLATE:-${OMARCHY_PATH:-/usr/share/omarchy}/default/snapper/root}"
+root_fstype="${OMARCHY_SNAPPER_ROOT_FSTYPE:-$(findmnt -no FSTYPE --target / 2>/dev/null || true)}"
 
 echo "Configuring Omarchy Snapper snapshot retention"
+
+# snapper create-config only works on a filesystem it supports, which for Omarchy
+# means btrfs. On any other root it fails with "Creating config failed
+# (/sbin/chsnap not installed)", and every caller runs this under
+# bash -euo pipefail, so that failure aborts omarchy-upgrade-to-quattro partway
+# through and stops migration 1781984677 along with every migration queued behind
+# it. Nothing below this point means anything without a config, so skip cleanly.
+if [[ $root_fstype != "btrfs" ]]; then
+  echo "Root filesystem is ${root_fstype:-unknown}, not btrfs: skipping Snapper configuration"
+  exit 0
+fi
 
 if [[ ! -f $SNAPPER_CONFIG_PATH ]]; then
   mkdir -p "$(dirname "$SNAPPER_CONFIG_PATH")"

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -60,6 +60,7 @@ pass "Limine Snapper warning notifier migration disables existing user autostart
 TEST_LOG="$test_tmp/calls.log" \
 PATH="$fake_bin:$PATH" \
 OMARCHY_SNAPPER_CONFIGURE_TEST=1 \
+OMARCHY_SNAPPER_ROOT_FSTYPE=btrfs \
 OMARCHY_PATH="$ROOT" \
 OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/etc/snapper/configs/root" \
 OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
@@ -86,6 +87,24 @@ grep -F 'sudo "$@"' "$migration" >/dev/null
 grep -F 'as_root env OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$snapper_config_script"' "$migration" >/dev/null
 ! grep -F 'NUMBER_LIMIT="5"' "$migration" >/dev/null || fail "Snapper service migration does not overwrite working custom retention"
 pass "Snapper service migration only repairs broken services idempotently"
+# snapper create-config cannot work off btrfs, and every caller runs this script
+# under bash -euo pipefail, so failing there aborts the Quattro upgrade and the
+# migration queued behind it. Skip cleanly instead of writing a config that the
+# filesystem cannot back.
+non_btrfs_tmp="$test_tmp/non-btrfs"
+mkdir -p "$non_btrfs_tmp"
+OMARCHY_SNAPPER_ROOT_FSTYPE=ext4 \
+OMARCHY_PATH="$ROOT" \
+OMARCHY_SNAPPER_CONFIG_PATH="$non_btrfs_tmp/etc/snapper/configs/root" \
+OMARCHY_SNAPPER_CONF_PATH="$non_btrfs_tmp/etc/conf.d/snapper" \
+  bash -euo pipefail "$ROOT/install/config/snapper.sh" >/dev/null ||
+  fail "snapshot configure exits cleanly on a root Snapper cannot support"
+[[ ! -e $non_btrfs_tmp/etc/snapper/configs/root ]] ||
+  fail "snapshot configure writes no Snapper config off btrfs"
+[[ ! -e $non_btrfs_tmp/etc/conf.d/snapper ]] ||
+  fail "snapshot configure enables no Snapper services off btrfs"
+pass "snapshot configure skips a root filesystem Snapper cannot support"
+
 
 # Checkouts differ per machine, so allow an explicit pointer at the sibling repo.
 # Accepts either the omarchy-pkgs checkout or its pkgbuilds/ directory.
@@ -155,3 +174,4 @@ if [[ -f $phases && -f $manifest ]]; then
   ! grep -F '/etc/systemd/system/timers.target.wants/snapper-timeline.timer' "$manifest" >/dev/null || fail "fresh ISO manifest does not enable snapper timeline timer"
 fi
 pass "omarchy-iso delegates Snapper setup to packaged system setup"
+


### PR DESCRIPTION
## What's wrong

`install/config/snapper.sh` has no filesystem guard, so on a root that Snapper cannot support it fails and takes its caller down with it. `omarchy-upgrade-to-quattro` aborted at `configure_snapper_policy`, step 10 of 26, on my ext4 install:

```
==> Configuring Omarchy snapshot retention
Configuring Omarchy Snapper snapshot retention
Creating config failed (/sbin/chsnap not installed).
```

Everything from `configure_lock_authentication` onward never ran, including `apply_user_transition`, the dotfile migration. Migration `1781984677` fails the same way for the same users, and since `omarchy-migrate` stops at the first failure it also blocks every migration queued behind it.

## Why

```sh
snapper --no-dbus -c root create-config / >/dev/null 2>&1 || snapper -c root create-config / >/dev/null
```

`create-config` only works on a filesystem Snapper supports, which for Omarchy means btrfs. Every caller runs the script under `bash -euo pipefail`, so the failure is fatal rather than skipped. Nothing after that line means anything without a config: the template install, `/etc/conf.d/snapper` and both timers all describe snapshots that cannot exist.

The Omarchy installer defaults to btrfs, which is why this stays invisible on a fresh install. It only shows up on a root that was set up some other way.

## The fix

Read the root filesystem type and skip cleanly when it is not btrfs, before anything is written. `run_logged` runs these scripts with `bash -eE "$script"` rather than sourcing them, so `exit 0` ends this script only.

The type goes through `OMARCHY_SNAPPER_ROOT_FSTYPE`, matching the existing `OMARCHY_SNAPPER_CONFIG_PATH`, `OMARCHY_SNAPPER_CONF_PATH` and `OMARCHY_SNAPPER_TEMPLATE` overrides, so both branches are testable.

## Testing

`test/shell.d/snapper-test.sh` gains a case: a non-btrfs root exits 0 and writes neither the Snapper config nor `/etc/conf.d/snapper`. The existing configure case now pins `OMARCHY_SNAPPER_ROOT_FSTYPE=btrfs` so it keeps exercising the full path.

Verified on the affected machine (ext4 root): the script exited 1 before and exits 0 writing nothing after. Run as root the failure message is the `chsnap` one above; unprivileged it is `No permissions.` Either way it is non-zero and fatal to the caller.

`omarchy-pkgs checkout is available for packaging coverage` fails in this checkout for want of a sibling `omarchy-pkgs`. It fails the same way on an unmodified `quattro`, unrelated to this change.
