### PR TITLE
Let [bar] in shell.toml set every token Style reads

### DIFF
--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -405,7 +405,7 @@ QtObject {
       } else if (section === "bar") {
         if (key === "scale-with-font") {
           nextBarScaleWithFont = boolToken(raw, nextBarScaleWithFont)
-        } else if (key === "size-horizontal" || key === "size-vertical") {
+        } else {
           var b = parseInt(raw, 10)
           if (isFinite(b)) barOut[key] = b
         }

--- a/test/shell.d/shell-token-overrides-test.sh
+++ b/test/shell.d/shell-token-overrides-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+style="$ROOT/shell/Commons/Style.qml"
+
+# Every token a section reads has to be writable by applyShellValues, or the
+# property is unreachable from any shell.toml, theme or user. [font] and
+# [spacing] pass unknown keys straight through; [bar] used to whitelist two of
+# its six, leaving icon-slot, icon-canvas, icon-font and status-slot dead.
+bar_branch=$(awk '/section === "bar"/,/section === "spacing"/' "$style")
+[[ -n $bar_branch ]] || fail "the [bar] branch of applyShellValues is readable"
+
+while read -r token; do
+  [[ -n $token ]] || continue
+  case $token in
+    scale-with-font) continue ;;
+  esac
+  if grep -qF "\"$token\"" <<<"$bar_branch"; then
+    fail "[bar] accepts $token without naming it, so new tokens do not need parser changes"
+  fi
+done < <(grep -oE 'barToken\("[a-z-]+"' "$style" | sed 's/barToken("//;s/"//')
+pass "every [bar] token Style reads can be set from shell.toml"


### PR DESCRIPTION
## What's wrong

`Style.qml` reads six `[bar]` tokens:

```qml
readonly property int sizeHorizontal: root.barToken("size-horizontal", 26)
readonly property int sizeVertical:   root.barToken("size-vertical",   28)
readonly property int iconSlot:       root.barToken("icon-slot",       27)
readonly property int iconCanvas:     root.barToken("icon-canvas",     16)
readonly property int iconFont:       root.barToken("icon-font",       13)
readonly property int statusSlot:     root.barToken("status-slot",     21)
```

`applyShellValues()` writes only two of them into `barOverrides`:

```js
} else if (section === "bar") {
  if (key === "scale-with-font") {
    nextBarScaleWithFont = boolToken(raw, nextBarScaleWithFont)
  } else if (key === "size-horizontal" || key === "size-vertical") {
    var b = parseInt(raw, 10)
    if (isFinite(b)) barOut[key] = b
  }
}
```

So `icon-slot`, `icon-canvas`, `icon-font` and `status-slot` are parsed and dropped. Nothing can set them: not `~/.config/omarchy/shell.toml`, and not a theme either, since themes go through the same function. Those four `barToken` lookups can only ever return their fallback.

It is silent, too. An unrecognised key produces no warning, so a `[bar]` block that does nothing looks like one that works.

## The fix

Let the `[bar]` branch pass unknown numeric keys through, which is what `[font]` and `[spacing]` already do:

```js
} else if (section === "font") {
  ...
  else fontOut[key] = ival
```

One line. No new tokens, no behaviour change unless someone sets a key that was previously ignored.

## On whether you want this at all

I am not sure this is the fix you want, so say the word and I will close it.

The defect is real either way: four properties are unreachable from any configuration. But there are two reasonable directions and it is your call which one:

1. Open the keys, as here.
2. Delete the four dead lookups, if bar icon sizing is deliberately not user-tunable.

I went with 1 because `size-horizontal` and `size-vertical` are already tunable, so bar geometry is not sealed off in principle, and because `[font]` and `[spacing]` accept any key. If the intent is that only bar *dimensions* are configurable and glyph sizing is not, 2 is the right patch and this one should go.

For what it is worth, the reason I found this: the weather glyph reads much smaller than its neighbours, since the weather icons are U+E3xx (legacy Weather Icons) while bluetooth and friends are U+F0Bxx (Material Design Icons), which fill their em box far more. That is a font design difference no global token can even out, and #5712 is the same complaint from the waybar era. Being able to set `status-slot` and `icon-font` is a partial workaround, not a fix for that, and I am not proposing one here.

## Testing

New `test/shell.d/shell-token-overrides-test.sh` asserts the invariant rather than the patch: every token `barToken()` reads must be writable by `applyShellValues`. It passes on this branch and fails on `quattro`, and it would catch the same class of mistake for any token added later.

Verified in the running shell: with the patch, `[bar] icon-font = 18` in `~/.config/omarchy/shell.toml` changes the bar glyphs after `omarchy-restart-shell`, and without it the same block does nothing.
