### PR TITLE
Prevent voxtype focus drift during dictation output

### DIFF
--- a/bin/omarchy-hyprland-follow-mouse-guard
+++ b/bin/omarchy-hyprland-follow-mouse-guard
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Snapshot and restore follow_mouse around voxtype output
+# omarchy:args=pause|resume
+# omarchy:hidden=true
+
+set -euo pipefail
+
+STATE_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy/voxtype-follow-mouse"
+
+case "${1:-}" in
+pause)
+  mkdir -p "$(dirname "$STATE_FILE")"
+  hyprctl -j getoption input:follow_mouse | jq -r '.int' >"$STATE_FILE"
+  hyprctl keyword input:follow_mouse 0
+  ;;
+resume)
+  if [[ -f $STATE_FILE ]]; then
+    hyprctl keyword input:follow_mouse "$(cat "$STATE_FILE")"
+    rm -f "$STATE_FILE"
+  fi
+  ;;
+*)
+  echo "Usage: omarchy-hyprland-follow-mouse-guard pause|resume" >&2
+  exit 1
+  ;;
+esac

--- a/default/voxtype/config.toml
+++ b/default/voxtype/config.toml
@@ -70,6 +70,11 @@ fallback_to_clipboard = true
 # 0 = fastest possible, increase if characters are dropped
 type_delay_ms = 1
 
+# Temporarily stop focus-follows-mouse while Voxtype emits synthetic keystrokes.
+# The post hook restores the user's current setting after output completes.
+pre_output_command = "omarchy-hyprland-follow-mouse-guard pause"
+post_output_command = "omarchy-hyprland-follow-mouse-guard resume"
+
 # Post-processing command (optional)
 # Pipe transcribed text through an external command for cleanup before output.
 # The command receives text on stdin and outputs processed text on stdout.


### PR DESCRIPTION
# Prevent voxtype focus drift during dictation output

## Problem

Omarchy ships voxtype with `mode = "type"`, which emits synthetic keystrokes through `wtype`. Hyprland's default `input:follow_mouse = 1` continuously moves keyboard focus to the window under the cursor.

During a long dictation, typing is not instantaneous — at `type_delay_ms = 1`, a 60-word sentence is ~300ms+ of continuous synthetic typing. If the pointer moves toward another window while that stream is in flight, focus can shift mid-stream and the remaining keystrokes land in the wrong window.

## Approach

The first fix was the simplest possible hook pair:

```toml
pre_output_command = "hyprctl keyword input:follow_mouse 0"
post_output_command = "hyprctl keyword input:follow_mouse 1"
```

That works on a stock Omarchy install, but it hardcodes the restore value. Anyone who has customized `follow_mouse` — `0`, `2`, `3`, etc. — would get reset to `1` after every dictation.

The final version snapshots the live setting before output and restores it afterward:

```toml
pre_output_command = "omarchy-hyprland-follow-mouse-guard pause"
post_output_command = "omarchy-hyprland-follow-mouse-guard resume"
```

`omarchy-hyprland-follow-mouse-guard` reads the current value with `hyprctl`, writes it to `$XDG_RUNTIME_DIR/omarchy/voxtype-follow-mouse`, disables `follow_mouse` for the typing window, then restores the saved value on resume.

## Naming

Follows the same hidden helper + paired subcommand pattern as [`omarchy-hyprland-reload-guard`](https://github.com/basecamp/omarchy/blob/quattro/bin/omarchy-hyprland-reload-guard) (`pause|resume`).

For voxtype hook wiring specifically, see [#4178](https://github.com/basecamp/omarchy/pull/4178) — that PR used inline `hyprctl` commands in `default/voxtype/config.toml` for modifier suppression. This change needs a small script because the restore value is user-specific.

## Verification

Tested on Hyprland 0.55.4:

```text
before:      input:follow_mouse = 1
set to:      input:follow_mouse = 0
restored to: input:follow_mouse = 1
```

Manual test: focus a text field, hold F9, dictate a long sentence, release F9, and move the mouse to another window while text is being emitted. Text should remain in the original window, and `follow_mouse` should return to its prior value afterward.

## Notes

- Keeps `mode = "type"` — no clipboard clobbering, no paste-semantics change.
- Runtime-only via `hyprctl keyword`; does not edit Hyprland config on disk.
