### PR TITLE
Use the gmux backlight instead of the Touch Bar on T2 Macs

### DIFF
--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -3,11 +3,14 @@
 # omarchy:summary=Print the most likely display backlight device.
 # omarchy:examples=omarchy-hw-display
 
+backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
+
 # Start with the first possible output, then refine to the most likely given an order heuristic.
-device="$(ls -1 /sys/class/backlight 2>/dev/null | head -n1)"
-for candidate in amdgpu_bl* intel_backlight acpi_video*; do
-  if [[ -e /sys/class/backlight/$candidate ]]; then
-    device="$candidate"
+# Glob the candidates in the loop list: [[ ]] does not do pathname expansion.
+device="$(ls -1 "$backlight_path" 2>/dev/null | head -n1)"
+for candidate in "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
+  if [[ -e $candidate ]]; then
+    device="${candidate##*/}"
     break
   fi
 done

--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -7,8 +7,11 @@ backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
 
 # Start with the first possible output, then refine to the most likely given an order heuristic.
 # Glob the candidates in the loop list: [[ ]] does not do pathname expansion.
-device="$(ls -1 "$backlight_path" 2>/dev/null | head -n1)"
-for candidate in "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
+# The Touch Bar on T2 Macs registers a backlight that never drives the display panel.
+device="$(ls -1 "$backlight_path" 2>/dev/null | grep -vx appletb_backlight | head -n1)"
+# gmux comes first: apple-gmux only registers when the kernel has already picked it, and on
+# dual-GPU Macs the GPU's own PWM stops driving the panel once that GPU suspends.
+for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
   if [[ -e $candidate ]]; then
     device="${candidate##*/}"
     break

--- a/test/shell.d/hw-display-test.sh
+++ b/test/shell.d/hw-display-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+write_backlights() {
+  rm -rf "$tmp_dir/backlight"
+  mkdir -p "$tmp_dir/backlight"
+
+  local device
+  for device in "$@"; do
+    mkdir -p "$tmp_dir/backlight/$device"
+  done
+}
+
+hw_display() {
+  OMARCHY_BACKLIGHT_PATH="$tmp_dir/backlight" "$ROOT/bin/omarchy-hw-display"
+}
+
+write_backlights intel_backlight
+device=$(hw_display)
+[[ $device == "intel_backlight" ]] || fail "the only backlight is used" "actual: $device"
+pass "the only backlight is used"
+
+write_backlights acpi_video0 amdgpu_bl1
+device=$(hw_display)
+[[ $device == "amdgpu_bl1" ]] || fail "globbed candidates beat the alphabetical fallback" "actual: $device"
+pass "globbed candidates beat the alphabetical fallback"
+
+write_backlights acpi_video0 intel_backlight
+device=$(hw_display)
+[[ $device == "intel_backlight" ]] || fail "the candidate order is honored" "actual: $device"
+pass "the candidate order is honored"
+
+write_backlights nvidia_wmi_ec_backlight
+device=$(hw_display)
+[[ $device == "nvidia_wmi_ec_backlight" ]] || fail "an unknown backlight falls back to the first device" "actual: $device"
+pass "an unknown backlight falls back to the first device"
+
+write_backlights
+if hw_display >/dev/null 2>&1; then
+  fail "no backlight device reports failure"
+fi
+pass "no backlight device reports failure"

--- a/test/shell.d/hw-display-test.sh
+++ b/test/shell.d/hw-display-test.sh
@@ -41,6 +41,22 @@ device=$(hw_display)
 [[ $device == "nvidia_wmi_ec_backlight" ]] || fail "an unknown backlight falls back to the first device" "actual: $device"
 pass "an unknown backlight falls back to the first device"
 
+write_backlights appletb_backlight gmux_backlight
+device=$(hw_display)
+[[ $device == "gmux_backlight" ]] || fail "a T2 Mac uses gmux instead of the Touch Bar" "actual: $device"
+pass "a T2 Mac uses gmux instead of the Touch Bar"
+
+write_backlights appletb_backlight
+if hw_display >/dev/null 2>&1; then
+  fail "the Touch Bar is never used as the display backlight"
+fi
+pass "the Touch Bar is never used as the display backlight"
+
+write_backlights acpi_video0 amdgpu_bl0 appletb_backlight gmux_backlight intel_backlight
+device=$(hw_display)
+[[ $device == "gmux_backlight" ]] || fail "gmux outranks the GPU backlights on dual-GPU Macs" "actual: $device"
+pass "gmux outranks the GPU backlights on dual-GPU Macs"
+
 write_backlights
 if hw_display >/dev/null 2>&1; then
   fail "no backlight device reports failure"


### PR DESCRIPTION
Fixes #6558.

On a T2 MacBook Pro, `/sys/class/backlight` holds `appletb_backlight` (the Touch Bar) and `gmux_backlight` (the display). Neither was a candidate in `omarchy-hw-display`, so the alphabetical fallback picked the Touch Bar and the brightness keys dimmed it instead of the screen.

Two commits:

**Match display backlight candidates against real globs.** `[[ ]]` does not do pathname expansion, so `[[ -e $backlight_path/amdgpu_bl* ]]` only ever tested for a file with a literal asterisk in its name. Every machine without `intel_backlight` silently fell through to the alphabetical first entry, which picks `acpi_video0` over `amdgpu_bl0`. Moving the globs into the `for` list fixes the heuristic that was already intended here.

**Use the gmux backlight instead of the Touch Bar on T2 Macs.** Adds `gmux_backlight` as a candidate and stops the fallback from ever landing on the Touch Bar, which is not a display panel on any Mac.

`gmux_backlight` is ranked above the GPU backlights: apple-gmux registers its device only when `acpi_video_get_backlight_type()` has already resolved to `acpi_backlight_apple_gmux`, so its presence in sysfs means the kernel already selected it for that machine. The driver also documents that on dual-GPU MacBook Pros either GPU may suspend, at which point the GPU's own PWM no longer drives the panel.

### Testing

`test/shell.d/hw-display-test.sh` is new and covers candidate priority, the glob fix, the T2 layout, and the failure cases. It needs the `OMARCHY_BACKLIGHT_PATH` override this PR adds, following the `OMARCHY_POWER_SUPPLY_PATH` pattern already used by `omarchy-power-present`.

Verified the suite catches the original bug: reverting just the glob hunk fails with `actual: acpi_video0`.

@twilightresonance86 could you confirm this fixes it on your machine? I don't have T2 hardware to test on. `omarchy-hw-display` should print `gmux_backlight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)