### PR TITLE
Stop the menu from opening on the previous evaluation's answers

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -947,8 +947,21 @@ Item {
 
   property var whenResults: ({})       // id → true|false (allow visibility)
   property var checkedResults: ({})    // id → true|false (show ✓)
+  property bool guardsPending: false
 
   function evaluateGuards() {
+    // Process ignores a command change while it is running, and `collected`
+    // belongs to the run in flight, so a second evaluation cannot overwrite
+    // the first: it would throw away the lines already read and never start.
+    // The surviving tail then lands as the whole answer, and every id lost
+    // with it goes back to showing, since a `when:` only hides on an explicit
+    // false. Wait for the run in flight and evaluate once it lands instead.
+    if (guardProc.running) {
+      root.guardsPending = true
+      return
+    }
+    root.guardsPending = false
+
     var script = ""
     var ids = Object.keys(root.items)
     for (var i = 0; i < ids.length; i++) {
@@ -994,6 +1007,9 @@ Item {
       root.whenResults = nextWhen
       root.checkedResults = nextChecked
       if (root.opened) root.rebuildDisplay()
+      // Run the evaluation that had to stand aside. Deferred by a turn so the
+      // process is settled before its command is set again.
+      if (root.guardsPending) Qt.callLater(function() { root.evaluateGuards() })
     }
   }
   PanelWindow {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -962,14 +962,7 @@ Item {
     }
     root.guardsPending = false
 
-    var script = ""
-    var ids = Object.keys(root.items)
-    for (var i = 0; i < ids.length; i++) {
-      var entry = root.items[ids[i]]
-      if (!entry) continue
-      if (entry.when) script += "if { " + entry.when + "; } >/dev/null 2>&1; then echo " + ids[i] + ":w:1; else echo " + ids[i] + ":w:0; fi\n"
-      if (entry.checked) script += "if { " + entry.checked + "; } >/dev/null 2>&1; then echo " + ids[i] + ":c:1; else echo " + ids[i] + ":c:0; fi\n"
-    }
+    var script = MenuModel.guardScript(root.items)
     if (!script) {
       root.whenResults = ({})
       root.checkedResults = ({})

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -979,7 +979,16 @@ Item {
     stdout: SplitParser {
       onRead: function(data) { guardProc.collected += data + "\n" }
     }
-    onExited: {
+    onExited: function(exitCode, exitStatus) {
+      // A batch that was killed rather than finished has only told us about
+      // the rows it reached, and a row whose `when:` went unanswered shows.
+      // Keep the last complete set rather than let a half-read one through.
+      // A signal leaves the exit code at 0, so the status is what tells us.
+      if (exitCode !== 0 || exitStatus !== 0) {
+        if (root.guardsPending) Qt.callLater(function() { root.evaluateGuards() })
+        return
+      }
+
       var nextWhen = ({})
       var nextChecked = ({})
       var lines = guardProc.collected.split("\n")

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -402,10 +402,16 @@ var GUARD_READERS = [
 // comes back and offers to install what is already there. A version
 // constraint (`bash>=1`) is not a name any set can answer, so it goes to
 // pacman itself; no shipped guard writes one.
+//
+// `pacman -Qi` wraps a long list across continuation lines whenever COLUMNS
+// is set in the environment, which a login shell may well have done, so the
+// parser follows the indented lines rather than reading the first one and
+// dropping half of what is installed.
 function guardHelpers() {
   return 'declare -A __omarchy_pkgs=()\n'
     + 'mapfile -t __omarchy_pkg_names < <({ pacman -Qq; LC_ALL=C pacman -Qi'
-    + " | awk -F': ' '/^Provides/ && $2 != \"None\" { n = split($2, p, \" \");"
+    + " | awk '/^[A-Za-z]/ { provides = ($0 ~ /^Provides/); sub(/^[^:]*: /, \"\") }"
+    + ' provides && $0 != "None" { n = split($0, p, " ");'
     + ' for (i = 1; i <= n; i++) { sub(/[<>=].*/, "", p[i]); print p[i] } }\'; } 2>/dev/null)\n'
     + 'for __omarchy_pkg in "${__omarchy_pkg_names[@]}"; do __omarchy_pkgs[$__omarchy_pkg]=1; done\n'
     + '__omarchy_pkg_has() { [[ -n ${__omarchy_pkgs[$1]-} ]] && return 0; '

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -372,12 +372,12 @@ function displayRow(items, itemOrder, checkedResults, entry, detail, score, sect
   }
 }
 
-// Commands a `checked:` expression reads a value out of. Each one is asked
-// the same question by every sibling row -- Defaults > Browser has seven rows
-// all comparing against `omarchy-default-browser` -- so the batch captures it
-// once and replays the answer for the rest of the run.
+// Commands a `checked:` expression reads a value out of. Every sibling row
+// asks the same one -- Defaults > Browser has seven rows all comparing
+// against `omarchy-default-browser` -- so the batch runs it once and the rows
+// read the captured answer.
 //
-// The captures have to be eager. These are read inside `$(...)`, and a value
+// The capture has to be eager. These are read inside `$(...)`, and a value
 // cached while one expression runs lives in that subshell only, so a lazy
 // memo never survives to the expression after it.
 var GUARD_READERS = [
@@ -391,41 +391,66 @@ var GUARD_READERS = [
 
 // Package and command presence account for most of what the guards ask, and
 // asked one at a time they are almost all fork: the shipped menu spends over
-// a second on them. Answer them inside the guard process instead, off one
-// package listing and bash's own PATH lookup. These shadow the real commands
-// for the batch only, and match them exit code for exit code, including no
-// arguments at all (present is true of nothing, missing is not).
+// a second on them. Answer them inside the guard process instead. These
+// shadow the real commands for the batch only, so they have to agree with
+// them everywhere, including for no arguments at all (present is true of
+// nothing, missing is not).
+//
+// `pacman -Q` resolves a name through what installed packages provide, not
+// just what they are called -- with gvim installed it reports `vim` as
+// present -- so the set has to carry provides too, or `install.editor.vim`
+// comes back and offers to install what is already there. A version
+// constraint (`bash>=1`) is not a name any set can answer, so it goes to
+// pacman itself; no shipped guard writes one.
 function guardHelpers() {
   return 'declare -A __omarchy_pkgs=()\n'
-    + 'while read -r __omarchy_pkg; do __omarchy_pkgs[$__omarchy_pkg]=1; done < <(pacman -Qq 2>/dev/null)\n'
-    + 'omarchy-pkg-present() { local p; for p in "$@"; do [[ -n ${__omarchy_pkgs[$p]-} ]] || return 1; done; return 0; }\n'
-    + 'omarchy-pkg-missing() { local p; for p in "$@"; do [[ -n ${__omarchy_pkgs[$p]-} ]] || return 0; done; return 1; }\n'
-    + 'omarchy-cmd-present() { local c; for c in "$@"; do type -P "$c" >/dev/null 2>&1 || return 1; done; return 0; }\n'
-    + 'omarchy-cmd-missing() { local c; for c in "$@"; do type -P "$c" >/dev/null 2>&1 || return 0; done; return 1; }\n'
+    + 'mapfile -t __omarchy_pkg_names < <({ pacman -Qq; LC_ALL=C pacman -Qi'
+    + " | awk -F': ' '/^Provides/ && $2 != \"None\" { n = split($2, p, \" \");"
+    + ' for (i = 1; i <= n; i++) { sub(/[<>=].*/, "", p[i]); print p[i] } }\'; } 2>/dev/null)\n'
+    + 'for __omarchy_pkg in "${__omarchy_pkg_names[@]}"; do __omarchy_pkgs[$__omarchy_pkg]=1; done\n'
+    + '__omarchy_pkg_has() { [[ -n ${__omarchy_pkgs[$1]-} ]] && return 0; '
+    + '[[ $1 == *[\\<\\>=]* ]] && { pacman -Q "$1" &>/dev/null; return; }; return 1; }\n'
+    + 'omarchy-pkg-present() { local p; for p in "$@"; do __omarchy_pkg_has "$p" || return 1; done; return 0; }\n'
+    + 'omarchy-pkg-missing() { local p; for p in "$@"; do __omarchy_pkg_has "$p" || return 0; done; return 1; }\n'
+    + 'omarchy-cmd-present() { local c; for c in "$@"; do command -v "$c" &>/dev/null || return 1; done; return 0; }\n'
+    + 'omarchy-cmd-missing() { local c; for c in "$@"; do command -v "$c" &>/dev/null || return 0; done; return 1; }\n'
 }
 
-// Only capture a reader the guards actually ask for, so an extension that
-// carries none of them pays for none of them.
+// Substitute the captured answer into the expression rather than shadowing
+// the reader with a function. `$(reader)` and the variable holding what it
+// printed are interchangeable -- both strip trailing newlines, both split the
+// same way unquoted -- while a function would also catch `command -v reader`,
+// `VAR=x reader`, and every other form, and answer those wrong. Anything but
+// the plain substitution is left alone to run the real command.
 function guardPrelude(guards) {
   var prelude = guardHelpers()
 
   for (var i = 0; i < GUARD_READERS.length; i++) {
-    var reader = GUARD_READERS[i]
-    if (guards.indexOf(reader) < 0) continue
-
-    var out = "__omarchy_read_" + i
-    var status = "__omarchy_status_" + i
-    prelude += out + "=$(" + reader + " 2>/dev/null); " + status + "=$?\n"
-      + reader + '() { (($#)) && { command ' + reader + ' "$@"; return; }; '
-      + "printf '%s\\n' \"$" + out + '"; return $' + status + "; }\n"
+    // The guards arrive already substituted, so what marks a reader as wanted
+    // is the slot standing in for it, not the call it replaced.
+    if (guards.indexOf(guardReaderSlot(i)) < 0) continue
+    // `|| :` so a reader that exits nonzero cannot take the batch down with
+    // it under a login shell that turned on errexit.
+    prelude += "__omarchy_read_" + i + "=$(" + GUARD_READERS[i] + " 2>/dev/null) || :\n"
   }
 
   return prelude
 }
 
+function guardReaderSlot(index) {
+  return "${__omarchy_read_" + index + "}"
+}
+
+function substituteGuardReaders(expression) {
+  for (var i = 0; i < GUARD_READERS.length; i++)
+    expression = expression.split("$(" + GUARD_READERS[i] + ")").join(guardReaderSlot(i))
+
+  return expression
+}
+
 function guardLine(id, tag, expression) {
-  return "if { " + expression + "; } >/dev/null 2>&1; then echo " + id + ":" + tag + ":1"
-    + "; else echo " + id + ":" + tag + ":0; fi\n"
+  return "if { " + substituteGuardReaders(expression) + "; } >/dev/null 2>&1; then echo "
+    + id + ":" + tag + ":1; else echo " + id + ":" + tag + ":0; fi\n"
 }
 
 // One bash script for every `when:` and `checked:` in the menu, reporting

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -372,8 +372,84 @@ function displayRow(items, itemOrder, checkedResults, entry, detail, score, sect
   }
 }
 
+// Commands a `checked:` expression reads a value out of. Each one is asked
+// the same question by every sibling row -- Defaults > Browser has seven rows
+// all comparing against `omarchy-default-browser` -- so the batch captures it
+// once and replays the answer for the rest of the run.
+//
+// The captures have to be eager. These are read inside `$(...)`, and a value
+// cached while one expression runs lives in that subshell only, so a lazy
+// memo never survives to the expression after it.
+var GUARD_READERS = [
+  "omarchy-channel-current",
+  "omarchy-default-agent",
+  "omarchy-default-browser",
+  "omarchy-default-editor",
+  "omarchy-default-terminal",
+  "omarchy-dns"
+]
+
+// Package and command presence account for most of what the guards ask, and
+// asked one at a time they are almost all fork: the shipped menu spends over
+// a second on them. Answer them inside the guard process instead, off one
+// package listing and bash's own PATH lookup. These shadow the real commands
+// for the batch only, and match them exit code for exit code, including no
+// arguments at all (present is true of nothing, missing is not).
+function guardHelpers() {
+  return 'declare -A __omarchy_pkgs=()\n'
+    + 'while read -r __omarchy_pkg; do __omarchy_pkgs[$__omarchy_pkg]=1; done < <(pacman -Qq 2>/dev/null)\n'
+    + 'omarchy-pkg-present() { local p; for p in "$@"; do [[ -n ${__omarchy_pkgs[$p]-} ]] || return 1; done; return 0; }\n'
+    + 'omarchy-pkg-missing() { local p; for p in "$@"; do [[ -n ${__omarchy_pkgs[$p]-} ]] || return 0; done; return 1; }\n'
+    + 'omarchy-cmd-present() { local c; for c in "$@"; do type -P "$c" >/dev/null 2>&1 || return 1; done; return 0; }\n'
+    + 'omarchy-cmd-missing() { local c; for c in "$@"; do type -P "$c" >/dev/null 2>&1 || return 0; done; return 1; }\n'
+}
+
+// Only capture a reader the guards actually ask for, so an extension that
+// carries none of them pays for none of them.
+function guardPrelude(guards) {
+  var prelude = guardHelpers()
+
+  for (var i = 0; i < GUARD_READERS.length; i++) {
+    var reader = GUARD_READERS[i]
+    if (guards.indexOf(reader) < 0) continue
+
+    var out = "__omarchy_read_" + i
+    var status = "__omarchy_status_" + i
+    prelude += out + "=$(" + reader + " 2>/dev/null); " + status + "=$?\n"
+      + reader + '() { (($#)) && { command ' + reader + ' "$@"; return; }; '
+      + "printf '%s\\n' \"$" + out + '"; return $' + status + "; }\n"
+  }
+
+  return prelude
+}
+
+function guardLine(id, tag, expression) {
+  return "if { " + expression + "; } >/dev/null 2>&1; then echo " + id + ":" + tag + ":1"
+    + "; else echo " + id + ":" + tag + ":0; fi\n"
+}
+
+// One bash script for every `when:` and `checked:` in the menu, reporting
+// `<id>:<w|c>:<0|1>` per line. Speed is the whole point: the menu opens on
+// the last evaluation's answers, so however long this takes is how long a row
+// can contradict the state it describes.
+function guardScript(items) {
+  var guards = ""
+  var ids = Object.keys(items || {})
+
+  for (var i = 0; i < ids.length; i++) {
+    var entry = items[ids[i]]
+    if (!entry) continue
+    if (entry.when) guards += guardLine(ids[i], "w", entry.when)
+    if (entry.checked) guards += guardLine(ids[i], "c", entry.checked)
+  }
+
+  return guards ? guardPrelude(guards) + guards : ""
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
+    guardReaders: GUARD_READERS,
+    guardScript: guardScript,
     stripJsonc: stripJsonc,
     normalizeAliases: normalizeAliases,
     normalizeItem: normalizeItem,

--- a/test/shell.d/menu-guards-test.sh
+++ b/test/shell.d/menu-guards-test.sh
@@ -13,6 +13,7 @@ const items = {
   'plain': { id: 'plain', label: 'No guards' }
 }
 const script = menu.guardScript(items)
+const browserSlot = `\${__omarchy_read_${menu.guardReaders.indexOf('omarchy-default-browser')}}`
 
 assert(
   script.includes('if { omarchy-pkg-present brave-bin; } >/dev/null 2>&1; then echo setup.default.browser.brave:w:1; else echo setup.default.browser.brave:w:0; fi'),
@@ -33,12 +34,30 @@ assertEqual(
   'guard script reads a value command once for the whole batch'
 )
 assert(
+  script.includes(`[[ "${browserSlot}" == "brave" ]]`) && !script.includes('"$(omarchy-default-browser)"'),
+  'guard script substitutes the captured answer into the expression'
+)
+assert(
   script.indexOf('__omarchy_read_') < script.indexOf('if { omarchy-pkg-present'),
   'guard script captures readers before any guard runs, since $() would trap a lazy memo in its subshell'
 )
+
+// Substitution is confined to the plain `$(reader)` form on purpose. A
+// function shadowing the name would also catch these, and answer them wrong.
+const untouched = menu.guardScript({
+  a: { id: 'a', when: 'command -v omarchy-dns' },
+  b: { id: 'b', when: '[[ "$(OMARCHY_PATH=/usr/share/omarchy omarchy-channel-current)" == "stable" ]]' },
+  c: { id: 'c', when: '(( $(omarchy-default-browser | wc -l) == 1 ))' }
+})
 assert(
-  menu.guardReaders.every(reader => !script.includes(`$(${reader} `) || reader === 'omarchy-default-browser'),
-  'guard script only captures the readers its guards actually ask for'
+  untouched.includes('command -v omarchy-dns')
+    && untouched.includes('$(OMARCHY_PATH=/usr/share/omarchy omarchy-channel-current)')
+    && untouched.includes('$(omarchy-default-browser | wc -l)'),
+  'guard script leaves every form but the plain substitution to run the real command'
+)
+assert(
+  !/^__omarchy_read_/m.test(untouched),
+  'guard script captures nothing when no guard uses the plain substitution'
 )
 
 // Every reader named in the shipped menu has to be listed, or it silently
@@ -56,67 +75,104 @@ assertDeepEqual(
 )
 JS
 
+prelude() {
+  node -e '
+    const path = require("path")
+    const menu = require(path.join(process.env.ROOT, "shell/plugins/menu/MenuModel.js"))
+    process.stdout.write(menu.guardScript({ probe: { id: "probe", when: "true" } }))
+  ' | command grep -v '^if {'
+}
+
 # The prelude shadows the real commands for the length of the batch, so it has
 # to answer exactly as they do -- including for arguments no shipped guard
 # passes today, which an extension is free to write tomorrow.
 stub_dir=$(mktemp -d)
 trap 'rm -rf "$stub_dir"' EXIT
 
+# `pacman -Q` resolves a name through what installed packages provide, so gvim
+# answers for vim and bash answers for sh. A set built from `pacman -Qq` alone
+# would miss both and offer to install what is already there.
 cat >"$stub_dir/pacman" <<'STUB'
 #!/bin/bash
-[[ $1 == "-Qq" ]] && { printf '%s\n' brave-bin zen-browser-bin vim; exit 0; }
-for pkg in "${@:2}"; do
-  case "$pkg" in brave-bin | zen-browser-bin | vim) ;; *) exit 1 ;; esac
-done
+case "$1" in
+-Qq)
+  printf '%s\n' bash gvim
+  ;;
+-Qi)
+  cat <<'INFO'
+Name            : bash
+Provides        : sh
+Name            : gvim
+Provides        : vim=9.2.0849-1  xxd
+INFO
+  ;;
+-Q)
+  shift
+  for want in "$@"; do
+    case "${want%%[<>=]*}" in bash | gvim | sh | vim | xxd) ;; *) exit 1 ;; esac
+  done
+  ;;
+esac
 exit 0
 STUB
 chmod +x "$stub_dir/pacman"
-printf '#!/bin/bash\nexit 0\n' >"$stub_dir/brave"
-chmod +x "$stub_dir/brave"
+printf '#!/bin/bash\nexit 0\n' >"$stub_dir/gvim"
+chmod +x "$stub_dir/gvim"
 
-prelude=$(node -e '
-const path = require("path")
-const menu = require(path.join(process.env.ROOT, "shell/plugins/menu/MenuModel.js"))
-process.stdout.write(menu.guardScript({ probe: { id: "probe", when: "true" } }))
-' | command grep -v '^if {')
+guard_prelude=$(prelude)
 
-for args in "brave-bin" "vim" "absent" "brave-bin vim" "brave-bin absent" ""; do
+# vim and sh are provided rather than installed; bash>=1 is a version
+# constraint no set can answer; cd is a shell builtin `command -v` finds and a
+# PATH search does not.
+for args in "bash" "vim" "sh" "xxd" "absent" "bash vim" "bash absent" "bash>=1" ""; do
   for helper in omarchy-pkg-present omarchy-pkg-missing; do
     real=0
     PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" $args >/dev/null 2>&1 || real=$?
     shadowed=0
-    PATH="$stub_dir:$PATH" bash -c "$prelude
+    PATH="$stub_dir:$PATH" bash -c "$guard_prelude
 $helper $args" >/dev/null 2>&1 || shadowed=$?
     ((real == shadowed)) || fail "$helper '$args' answers as the real command" "real: $real, shadowed: $shadowed"
   done
 done
-pass "guard prelude answers package presence as omarchy-pkg-present and omarchy-pkg-missing do"
+pass "guard prelude resolves packages through provides and constraints as pacman does"
 
-for args in "brave" "absent" "brave absent" ""; do
+for args in "gvim" "cd" "absent" "gvim absent" "gvim cd" ""; do
   for helper in omarchy-cmd-present omarchy-cmd-missing; do
     real=0
     PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" $args >/dev/null 2>&1 || real=$?
     shadowed=0
-    PATH="$stub_dir:$PATH" bash -c "$prelude
+    PATH="$stub_dir:$PATH" bash -c "$guard_prelude
 $helper $args" >/dev/null 2>&1 || shadowed=$?
     ((real == shadowed)) || fail "$helper '$args' answers as the real command" "real: $real, shadowed: $shadowed"
   done
 done
-pass "guard prelude answers command presence as omarchy-cmd-present and omarchy-cmd-missing do"
+pass "guard prelude resolves commands as omarchy-cmd-present and omarchy-cmd-missing do"
 
-# A reader is replaced by its captured answer, which has to read back the same
-# way -- the value, its exit status, and the trailing newline $() would strip.
-reader_check=$(PATH="$stub_dir:$PATH" bash -c '
+# A reader is replaced by what it printed, which has to compare identically to
+# the substitution it stood in for -- including the trailing newline $() drops.
+reader_script=$(node -e '
+  const path = require("path")
+  const menu = require(path.join(process.env.ROOT, "shell/plugins/menu/MenuModel.js"))
+  process.stdout.write(menu.guardScript({
+    hit: { id: "hit", checked: "[[ \"$(omarchy-dns)\" == \"Cloudflare\" ]]" },
+    miss: { id: "miss", checked: "[[ \"$(omarchy-dns)\" == \"Google\" ]]" }
+  }))
+')
+reader_result=$(bash -c '
+omarchy-dns() { printf "Cloudflare\n"; }
+export -f omarchy-dns
+'"$reader_script")
+[[ $reader_result == $'hit:c:1\nmiss:c:0' ]] ||
+  fail "guard prelude compares a captured reader as the substitution did" "got: $reader_result"
+pass "guard prelude compares a captured reader exactly as the substitution it replaced"
+
+# The batch inherits whatever a login shell left set. A reader that exits
+# nonzero must not take the rest of the menu's rows down with it.
+errexit_result=$(bash -e -c '
 omarchy-dns() { printf "Cloudflare\n"; return 3; }
 export -f omarchy-dns
-'"$(node -e '
-const path = require("path")
-const menu = require(path.join(process.env.ROOT, "shell/plugins/menu/MenuModel.js"))
-process.stdout.write(menu.guardScript({ probe: { id: "probe", checked: "[[ \"$(omarchy-dns)\" == \"Cloudflare\" ]]" } }))
-' | command grep -v '^if {')"'
-value=$(omarchy-dns) || status=$?
-printf "%s|%s|%s" "$value" "${status:-0}" "$(omarchy-dns | wc -l)"
-')
-[[ $reader_check == "Cloudflare|3|1" ]] ||
-  fail "guard prelude replays a captured reader verbatim" "got: $reader_check"
-pass "guard prelude replays a captured reader with its value, exit status, and line"
+'"$reader_script"'
+printf "survived\n"' 2>/dev/null)
+[[ $errexit_result == $'hit:c:1\nmiss:c:0\nsurvived' ]] ||
+  fail "guard batch survives a failing reader under errexit" "got: $errexit_result"
+pass "guard batch survives a reader that exits nonzero under errexit"

--- a/test/shell.d/menu-guards-test.sh
+++ b/test/shell.d/menu-guards-test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+
+const items = {
+  'setup.default.browser.brave': { id: 'setup.default.browser.brave', when: 'omarchy-pkg-present brave-bin', checked: '[[ "$(omarchy-default-browser)" == "brave" ]]' },
+  'setup.default.browser.zen': { id: 'setup.default.browser.zen', when: 'omarchy-pkg-present zen-browser-bin', checked: '[[ "$(omarchy-default-browser)" == "zen" ]]' },
+  'plain': { id: 'plain', label: 'No guards' }
+}
+const script = menu.guardScript(items)
+
+assert(
+  script.includes('if { omarchy-pkg-present brave-bin; } >/dev/null 2>&1; then echo setup.default.browser.brave:w:1; else echo setup.default.browser.brave:w:0; fi'),
+  'guard script reports a when: as <id>:w:<0|1>'
+)
+assert(
+  script.includes('then echo setup.default.browser.zen:c:1; else echo setup.default.browser.zen:c:0; fi'),
+  'guard script reports a checked: as <id>:c:<0|1>'
+)
+assert(!/\bplain:[wc]:/.test(script), 'guard script skips items with nothing to evaluate')
+assertEqual(menu.guardScript({ plain: items.plain }), '', 'guard script is empty when no item carries a guard')
+
+// The cost the menu is paying is per fork, not per expression, so what makes
+// the batch fast is asking each command once however many rows want it.
+assertEqual(
+  (script.match(/^__omarchy_read_\d+=\$\(omarchy-default-browser /gm) || []).length,
+  1,
+  'guard script reads a value command once for the whole batch'
+)
+assert(
+  script.indexOf('__omarchy_read_') < script.indexOf('if { omarchy-pkg-present'),
+  'guard script captures readers before any guard runs, since $() would trap a lazy memo in its subshell'
+)
+assert(
+  menu.guardReaders.every(reader => !script.includes(`$(${reader} `) || reader === 'omarchy-default-browser'),
+  'guard script only captures the readers its guards actually ask for'
+)
+
+// Every reader named in the shipped menu has to be listed, or it silently
+// keeps forking once per row that reads it.
+const fs = require('fs')
+const defaultItems = menu.parseMenuJsonc(fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8'))
+const guardText = defaultItems.map(item => `${item.when}\n${item.checked}`).join('\n')
+const repeated = [...new Set(
+  (guardText.match(/\$\((omarchy-[a-z0-9-]+)\)/g) || []).map(match => match.slice(2, -1))
+)].filter(command => guardText.split(`$(${command})`).length > 2)
+assertDeepEqual(
+  repeated.filter(command => !menu.guardReaders.includes(command)),
+  [],
+  'guard readers cover every command the shipped menu reads from more than one row'
+)
+JS
+
+# The prelude shadows the real commands for the length of the batch, so it has
+# to answer exactly as they do -- including for arguments no shipped guard
+# passes today, which an extension is free to write tomorrow.
+stub_dir=$(mktemp -d)
+trap 'rm -rf "$stub_dir"' EXIT
+
+cat >"$stub_dir/pacman" <<'STUB'
+#!/bin/bash
+[[ $1 == "-Qq" ]] && { printf '%s\n' brave-bin zen-browser-bin vim; exit 0; }
+for pkg in "${@:2}"; do
+  case "$pkg" in brave-bin | zen-browser-bin | vim) ;; *) exit 1 ;; esac
+done
+exit 0
+STUB
+chmod +x "$stub_dir/pacman"
+printf '#!/bin/bash\nexit 0\n' >"$stub_dir/brave"
+chmod +x "$stub_dir/brave"
+
+prelude=$(node -e '
+const path = require("path")
+const menu = require(path.join(process.env.ROOT, "shell/plugins/menu/MenuModel.js"))
+process.stdout.write(menu.guardScript({ probe: { id: "probe", when: "true" } }))
+' | command grep -v '^if {')
+
+for args in "brave-bin" "vim" "absent" "brave-bin vim" "brave-bin absent" ""; do
+  for helper in omarchy-pkg-present omarchy-pkg-missing; do
+    real=0
+    PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" $args >/dev/null 2>&1 || real=$?
+    shadowed=0
+    PATH="$stub_dir:$PATH" bash -c "$prelude
+$helper $args" >/dev/null 2>&1 || shadowed=$?
+    ((real == shadowed)) || fail "$helper '$args' answers as the real command" "real: $real, shadowed: $shadowed"
+  done
+done
+pass "guard prelude answers package presence as omarchy-pkg-present and omarchy-pkg-missing do"
+
+for args in "brave" "absent" "brave absent" ""; do
+  for helper in omarchy-cmd-present omarchy-cmd-missing; do
+    real=0
+    PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" $args >/dev/null 2>&1 || real=$?
+    shadowed=0
+    PATH="$stub_dir:$PATH" bash -c "$prelude
+$helper $args" >/dev/null 2>&1 || shadowed=$?
+    ((real == shadowed)) || fail "$helper '$args' answers as the real command" "real: $real, shadowed: $shadowed"
+  done
+done
+pass "guard prelude answers command presence as omarchy-cmd-present and omarchy-cmd-missing do"
+
+# A reader is replaced by its captured answer, which has to read back the same
+# way -- the value, its exit status, and the trailing newline $() would strip.
+reader_check=$(PATH="$stub_dir:$PATH" bash -c '
+omarchy-dns() { printf "Cloudflare\n"; return 3; }
+export -f omarchy-dns
+'"$(node -e '
+const path = require("path")
+const menu = require(path.join(process.env.ROOT, "shell/plugins/menu/MenuModel.js"))
+process.stdout.write(menu.guardScript({ probe: { id: "probe", checked: "[[ \"$(omarchy-dns)\" == \"Cloudflare\" ]]" } }))
+' | command grep -v '^if {')"'
+value=$(omarchy-dns) || status=$?
+printf "%s|%s|%s" "$value" "${status:-0}" "$(omarchy-dns | wc -l)"
+')
+[[ $reader_check == "Cloudflare|3|1" ]] ||
+  fail "guard prelude replays a captured reader verbatim" "got: $reader_check"
+pass "guard prelude replays a captured reader with its value, exit status, and line"

--- a/test/shell.d/menu-guards-test.sh
+++ b/test/shell.d/menu-guards-test.sh
@@ -92,6 +92,9 @@ trap 'rm -rf "$stub_dir"' EXIT
 # `pacman -Q` resolves a name through what installed packages provide, so gvim
 # answers for vim and bash answers for sh. A set built from `pacman -Qq` alone
 # would miss both and offer to install what is already there.
+#
+# `-Qi` wraps a long list onto indented continuation lines whenever COLUMNS is
+# set, so gvim's provides arrive the way a wrapped terminal would emit them.
 cat >"$stub_dir/pacman" <<'STUB'
 #!/bin/bash
 case "$1" in
@@ -102,8 +105,11 @@ case "$1" in
   cat <<'INFO'
 Name            : bash
 Provides        : sh
+Version         : 5.3.0-1
 Name            : gvim
-Provides        : vim=9.2.0849-1  xxd
+Provides        : vim=9.2.0849-1
+                  xxd
+Version         : 9.2-1
 INFO
   ;;
 -Q)
@@ -121,29 +127,36 @@ chmod +x "$stub_dir/gvim"
 
 guard_prelude=$(prelude)
 
-# vim and sh are provided rather than installed; bash>=1 is a version
-# constraint no set can answer; cd is a shell builtin `command -v` finds and a
-# PATH search does not.
-for args in "bash" "vim" "sh" "xxd" "absent" "bash vim" "bash absent" "bash>=1" ""; do
-  for helper in omarchy-pkg-present omarchy-pkg-missing; do
-    real=0
-    PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" $args >/dev/null 2>&1 || real=$?
-    shadowed=0
-    PATH="$stub_dir:$PATH" bash -c "$guard_prelude
-$helper $args" >/dev/null 2>&1 || shadowed=$?
-    ((real == shadowed)) || fail "$helper '$args' answers as the real command" "real: $real, shadowed: $shadowed"
+# Arguments reach both sides as argv. Interpolating them into the shadow's
+# script text would let `bash>=1` parse as a redirection, so the case that
+# exists to prove constraints work would quietly test `bash` instead.
+assert_helper_agrees() {
+  local description="$1" helper="$2"
+  shift 2
+
+  local real=0 shadowed=0
+  PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" "$@" >/dev/null 2>&1 || real=$?
+  PATH="$stub_dir:$PATH" bash -c "$guard_prelude"$'\n'"$helper \"\$@\"" "$helper" "$@" >/dev/null 2>&1 || shadowed=$?
+  ((real == shadowed)) || fail "$description" "$helper $*: real=$real shadowed=$shadowed"
+}
+
+# vim, sh and xxd are provided rather than installed, and xxd only appears on a
+# wrapped continuation line; bash>=1 is a version constraint no set can answer.
+pkg_cases=("bash" "vim" "sh" "xxd" "absent" "bash vim" "bash absent" "bash>=1" "vim>=1" "")
+for helper in omarchy-pkg-present omarchy-pkg-missing; do
+  for case in "${pkg_cases[@]}"; do
+    read -r -a argv <<<"$case"
+    assert_helper_agrees "guard prelude resolves packages as pacman does" "$helper" "${argv[@]}"
   done
 done
-pass "guard prelude resolves packages through provides and constraints as pacman does"
+pass "guard prelude resolves packages through provides, wrapping, and constraints as pacman does"
 
-for args in "gvim" "cd" "absent" "gvim absent" "gvim cd" ""; do
-  for helper in omarchy-cmd-present omarchy-cmd-missing; do
-    real=0
-    PATH="$stub_dir:$PATH" "$ROOT/bin/$helper" $args >/dev/null 2>&1 || real=$?
-    shadowed=0
-    PATH="$stub_dir:$PATH" bash -c "$guard_prelude
-$helper $args" >/dev/null 2>&1 || shadowed=$?
-    ((real == shadowed)) || fail "$helper '$args' answers as the real command" "real: $real, shadowed: $shadowed"
+# cd is a shell builtin `command -v` finds and a PATH search does not.
+cmd_cases=("gvim" "cd" "absent" "gvim absent" "gvim cd" "")
+for helper in omarchy-cmd-present omarchy-cmd-missing; do
+  for case in "${cmd_cases[@]}"; do
+    read -r -a argv <<<"$case"
+    assert_helper_agrees "guard prelude resolves commands as the real helper does" "$helper" "${argv[@]}"
   done
 done
 pass "guard prelude resolves commands as omarchy-cmd-present and omarchy-cmd-missing do"


### PR DESCRIPTION
Fixes #6595.

Two independent bugs kept guarded rows showing state that had already changed. Neither alone was sufficient.

## Guard evaluations clobbered each other

`evaluateGuards()` had no re-entrancy guard, unlike `loadProviderForMenu()` right next to it. A second call while one was in flight cleared `guardProc.collected` — throwing away lines the running script had already emitted — and then set `command`/`running`, both of which Quickshell ignores while a process runs. The surviving tail landed as the whole answer, and since `when:` only hides a row on an explicit false, every id lost with it went back to showing. That is Setup › Defaults › Browser listing browsers that are not installed.

It now queues and runs once the batch in flight lands.

@felixzsh diagnosed this in #6594 and closed it believing it was not the whole story. It was half of it, and the credit is theirs.

## The batch took long enough to see

The menu opens on the last evaluation's answers, so however long the batch takes is how long a row can contradict the state it describes: stop a recording and Screenrecord still offers to stop it, because the `pgrep` that would hide it is queued behind fifty package lookups.

Almost none of that was the questions — it was asking them one process at a time. The shipped menu calls `omarchy-pkg-present` 54 times and `omarchy-cmd-present` 23, and reads `omarchy-default-browser` once per row in Defaults › Browser. A prelude now answers all of it inside the one guard process, off one package listing, bash's own command lookup, and one capture per reader.

**1.49s → 0.33s**, with answers identical to evaluating all 175 guards on their own.

## Staying identical to the commands it stands in for

The prelude only helps if it is indistinguishable from what it shadows, which took a second pass:

- `pacman -Q` resolves a name through what installed packages **provide**, not just what they are called. With gvim installed it reports `vim` as present, so a set built from `pacman -Qq` alone would have brought `install.editor.vim` back to offer installing what was already there. The set carries provides too, and version constraints go to pacman.
- `omarchy-cmd-present` uses `command -v`, which finds builtins. `type -P` searches PATH alone and disagreed on every one.
- Readers are **substituted** into the expression rather than shadowed by a function. `$(reader)` and the variable holding what it printed are interchangeable; a function would also have caught `command -v omarchy-dns` and `VAR=x omarchy-channel-current` and answered those wrong. Every other form is left alone to run the real command, so an unusual guard is slow rather than wrong.
- A reader exiting nonzero could take the batch down under a login shell with `errexit`.

Results from a batch that was killed rather than finished are also no longer applied — a half-read batch leaves rows unanswered, and unanswered rows show, which is the failure this whole change exists to remove.

## Tests

New `test/shell.d/menu-guards-test.sh`. Beyond the script's shape, it checks the prelude against the real `bin/` helpers under a stub `pacman` that mimics provider resolution, across argument shapes including provided names, version constraints, a shell builtin, and no arguments at all. Each of those five disagreed before this branch:

| arg | real helper | before | after |
|---|---|---|---|
| `vim` (provided by gvim) | present | absent | present |
| `sh` (provided by bash) | present | absent | present |
| `xxd` | present | absent | present |
| `bash>=1` | present | absent | present |
| `cd` (builtin) | present | absent | present |

It also pins that every command the shipped menu reads from more than one row is registered, so adding one without registering it fails rather than silently going back to a fork per row.

`./test/cli` and `./test/shell` pass (1584 assertions). `model-usage-default-migration-test.sh` fails on this branch and on `quattro` alike — pre-existing and unrelated.

## Verified in the running shell

Screenrecord offers "Stop Screenrecording" only while recording and drops it once stopped, and Defaults › Browser lists exactly the installed browser with the ✓ on the current default.

## Left alone deliberately

The batch still runs under `bash -lc`. That is 68ms of pure login-profile sourcing, and dropping `-l` would take it to 0.26s, but guards would then see the shell's PATH rather than the login PATH and could hide rows for anyone whose profile extends it. Worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
