### PR TITLE
Add commented-out debug symbol repositories to the edge pacman config

### DIFF
--- a/default/pacman/pacman-edge.conf
+++ b/default/pacman/pacman-edge.conf
@@ -28,3 +28,18 @@ Include = /etc/pacman.d/mirrorlist
 [omarchy]
 SigLevel = Optional TrustAll
 Server = https://pkgs.omarchy.org/edge/$arch
+
+# Repositories for debug symbol packages.
+#
+# These upstream debug packages will only match core/extra/multilib packages from the Omarchy edge
+# channel. Also note that you may not need to enable these repositories for many debugging tools --
+# debuginfod will work fine if you're on Omarchy edge.
+#
+# [core-debug]
+# Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
+#
+# [extra-debug]
+# Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
+#
+# [multilib-debug]
+# Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch


### PR DESCRIPTION
The pacman configuration says nothing about debug symbol packages. Someone who wants `glibc-debug` so that gdb or Valgrind has symbols to work with has to discover on their own that Arch publishes `-debug` repositories, find a mirror that serves them, and work out that the versions only line up while the system tracks Arch current.

Appending the three repository sections to `pacman-edge.conf`, commented out, will put them within reach without turning them on. The comment records that the packages match the edge channel only, and that debuginfod already covers most debugging on edge, so enabling them is often unnecessary. Only the edge template gets them, because on stable and rc the upstream debug packages are newer than the pinned packages they would need to match.

ref: https://github.com/basecamp/omarchy/discussions/6185