### PR TITLE
Add native workspace overview

### DIFF
--- a/shell/plugins/README.md
+++ b/shell/plugins/README.md
@@ -17,6 +17,7 @@ User-installed plugins live alongside these conceptually but on disk under
 | Image picker  | `omarchy.image-picker`    | `overlay`               | `image-picker/ImagePicker.qml`        |
 | Emojis        | `omarchy.emojis`          | `overlay`               | `emojis/Emojis.qml`                   |
 | Clipboard mgr | `omarchy.clipboard`       | `overlay`               | `clipboard/Clipboard.qml`             |
+| Workspace overview | `omarchy.workspace-overview` | `overlay`          | `workspace-overview/WorkspaceOverview.qml` |
 | Reminders     | `omarchy.reminders`       | `overlay`               | `reminders/ReminderFlow.qml`          |
 | Omarchy menu  | `omarchy.menu`            | `menu`, `bar-widget`    | `menu/Menu.qml`, `menu/BarWidget.qml` |
 | Notifications | `omarchy.notifications`   | `service`               | `notifications/Service.qml`           |

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -65,7 +65,12 @@ BarWidget {
         verticalPadding: 6
         fixedWidth: root.vertical ? root.barSize : Style.space(20)
         fixedHeight: root.barSize
-        onPressed: function() { root.focusWorkspace(modelData) }
+        onPressed: function(button) {
+          if (button === Qt.RightButton && root.bar && root.bar.shell)
+            root.bar.shell.toggle("omarchy.workspace-overview", "{}")
+          else if (button === Qt.LeftButton)
+            root.focusWorkspace(modelData)
+        }
       }
     }
   }

--- a/shell/plugins/workspace-overview/WindowPreview.qml
+++ b/shell/plugins/workspace-overview/WindowPreview.qml
@@ -1,0 +1,177 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.Commons
+import qs.Ui
+
+BorderSurface {
+  id: root
+
+  required property var toplevel
+
+  readonly property var waylandToplevel: toplevel ? toplevel.wayland : null
+  readonly property bool activatable: waylandToplevel !== null || (toplevel && String(toplevel.address || "") !== "")
+  readonly property bool movable: toplevel !== null && String(toplevel.address || "") !== ""
+  readonly property bool dragging: dragProxy.dragSessionActive
+  readonly property string appId: waylandToplevel ? String(waylandToplevel.appId || "") : ""
+  readonly property string title: toplevel ? String(toplevel.title || appId || "Window") : "Window"
+  readonly property var desktopEntry: {
+    if (!appId) return null
+    return DesktopEntries.byId(appId) || DesktopEntries.heuristicLookup(appId)
+  }
+  readonly property string iconSource: {
+    if (!desktopEntry || !desktopEntry.icon) return ""
+    return Quickshell.iconPath(desktopEntry.icon, true)
+  }
+  readonly property real titleHeight: Math.min(height * 0.3,
+    Math.max(Style.space(28), Style.font.bodySmall + Style.spacing.controlPaddingY * 2))
+
+  signal activated()
+  signal dragStarted(var toplevel)
+  signal dragFinished(var toplevel)
+
+  radius: Style.cornerRadius
+  color: previewHover.hovered || dragging
+    ? Style.hoverFillFor(Color.menu.text, Color.accent)
+    : Util.alpha(Color.background, 0.52)
+  borderSpec: previewHover.hovered
+    ? Border.controlSpec("hover-cursor", Color.menu.text, Color.accent)
+    : Border.flat(Util.alpha(Color.menu.border, 0.32), Math.max(1, Style.normalBorderWidth))
+  clip: true
+  opacity: dragging ? 0.58 : 1
+
+  Behavior on color {
+    ColorAnimation { duration: 60 }
+  }
+
+  Behavior on opacity {
+    NumberAnimation { duration: 60 }
+  }
+
+  Item {
+    id: imageArea
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: titleBar.top
+    clip: true
+
+    ScreencopyView {
+      id: preview
+      anchors.centerIn: parent
+      captureSource: root.waylandToplevel
+      live: false
+      paintCursor: false
+      width: {
+        if (!hasContent || sourceSize.width <= 0 || sourceSize.height <= 0) return parent.width
+        return Math.min(parent.width, parent.height * sourceSize.width / sourceSize.height)
+      }
+      height: {
+        if (!hasContent || sourceSize.width <= 0 || sourceSize.height <= 0) return parent.height
+        return Math.min(parent.height, parent.width * sourceSize.height / sourceSize.width)
+      }
+      visible: hasContent
+    }
+
+    Image {
+      visible: !preview.hasContent && source !== ""
+      anchors.centerIn: parent
+      width: Math.min(parent.width, parent.height) * 0.34
+      height: width
+      source: root.iconSource
+      fillMode: Image.PreserveAspectFit
+      asynchronous: true
+      smooth: true
+      opacity: 0.72
+    }
+  }
+
+  Rectangle {
+    id: titleBar
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    height: root.titleHeight
+    color: Util.alpha(Color.menu.background, 0.92)
+
+    Row {
+      anchors.fill: parent
+      anchors.leftMargin: Style.spacing.md
+      anchors.rightMargin: Style.spacing.md
+      spacing: Style.spacing.sm
+
+      Image {
+        id: appIcon
+        visible: source !== ""
+        anchors.verticalCenter: parent.verticalCenter
+        width: visible ? Style.font.icon : 0
+        height: width
+        source: root.iconSource
+        fillMode: Image.PreserveAspectFit
+        asynchronous: true
+        smooth: true
+      }
+
+      Text {
+        anchors.verticalCenter: parent.verticalCenter
+        width: parent.width - (appIcon.visible ? appIcon.width + parent.spacing : 0)
+        text: root.title
+        color: Color.menu.text
+        font.family: Style.font.menuFamily
+        font.pixelSize: Style.font.bodySmall
+        elide: Text.ElideRight
+        verticalAlignment: Text.AlignVCenter
+      }
+    }
+  }
+
+  HoverHandler {
+    id: previewHover
+    cursorShape: root.dragging ? Qt.ClosedHandCursor
+      : (root.activatable || root.movable ? Qt.PointingHandCursor : Qt.ArrowCursor)
+  }
+
+  TapHandler {
+    acceptedButtons: Qt.LeftButton
+    enabled: root.activatable
+    onTapped: root.activated()
+  }
+
+  DragHandler {
+    id: previewDrag
+    acceptedButtons: Qt.LeftButton
+    enabled: root.movable
+    target: null
+    dragThreshold: Style.space(6)
+
+    onActiveChanged: {
+      if (active) {
+        dragProxy.dragSessionActive = true
+        root.dragStarted(root.toplevel)
+      } else if (dragProxy.dragSessionActive) {
+        dragProxy.Drag.drop()
+        dragProxy.dragSessionActive = false
+        root.dragFinished(root.toplevel)
+      }
+    }
+  }
+
+  Item {
+    id: dragProxy
+    property bool dragSessionActive: false
+    property real lastX: 0
+    property real lastY: 0
+
+    x: previewDrag.active ? previewDrag.centroid.position.x : lastX
+    y: previewDrag.active ? previewDrag.centroid.position.y : lastY
+    width: 1
+    height: 1
+    onXChanged: if (previewDrag.active) lastX = x
+    onYChanged: if (previewDrag.active) lastY = y
+    Drag.active: dragSessionActive
+    Drag.source: root
+    Drag.keys: ["omarchy-window"]
+    Drag.supportedActions: Qt.MoveAction
+    Drag.proposedAction: Qt.MoveAction
+  }
+}

--- a/shell/plugins/workspace-overview/WorkspaceCard.qml
+++ b/shell/plugins/workspace-overview/WorkspaceCard.qml
@@ -1,0 +1,163 @@
+import QtQuick
+import Quickshell.Hyprland
+import qs.Commons
+import qs.Ui
+
+BorderSurface {
+  id: root
+
+  required property int workspaceId
+  property var workspace: null
+  property bool focused: false
+  property bool addWorkspace: false
+  property bool keyboardSelected: false
+  property var draggedToplevel: null
+
+  readonly property var toplevelModel: workspace ? workspace.toplevels : []
+  readonly property int windowCount: workspace ? workspace.toplevels.values.length : 0
+  readonly property bool occupied: windowCount > 0
+  readonly property int previewColumns: windowCount === 2 ? 2 : Math.max(1, Math.ceil(Math.sqrt(windowCount)))
+  readonly property int previewRows: Math.max(1, Math.ceil(windowCount / previewColumns))
+  readonly property real headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
+  readonly property real previewSpacing: Style.spacing.sm
+  readonly property int draggedSourceWorkspaceId: draggedToplevel && draggedToplevel.workspace
+    ? Number(draggedToplevel.workspace.id) : -1
+  readonly property bool validDropTarget: draggedToplevel !== null
+    && String(draggedToplevel.address || "") !== ""
+    && workspaceId > 0 && workspaceId <= 10
+    && draggedSourceWorkspaceId !== workspaceId
+  readonly property bool dropHovered: validDropTarget && dropArea.containsDrag
+  readonly property var normalBorderSpec: keyboardSelected
+    ? Border.withWidth(Border.controlSpec("focus", Color.menu.text, Color.accent), Math.max(Style.space(2), Style.focusBorderWidth))
+    : (focused
+      ? Border.hyprlandActiveSpec(Color.accent, Math.max(1, Style.normalBorderWidth))
+      : (occupied
+        ? Border.surfaceSpec("menu", "border", Color.menu.border, Math.max(1, Style.normalBorderWidth))
+        : Border.flat(Util.alpha(Color.menu.border, 0.28), Math.max(1, Style.normalBorderWidth))))
+
+  signal workspaceActivated()
+  signal windowActivated(var toplevel)
+  signal windowDragStarted(var toplevel)
+  signal windowDragFinished(var toplevel)
+  signal windowDropped(var toplevel)
+
+  radius: Style.cornerRadius
+  color: occupied ? Color.menu.background : Util.alpha(Color.menu.background, 0.72)
+  borderSpec: dropHovered
+    ? Border.withWidth(Border.controlSpec("focus", Color.menu.text, Color.accent), Math.max(Style.space(2), Style.focusBorderWidth))
+    : (validDropTarget
+      ? Border.withWidth(Border.controlSpec("hover-cursor", Color.menu.text, Color.accent), Math.max(1, Style.hoverBorderWidth))
+      : normalBorderSpec)
+  clip: true
+
+  MouseArea {
+    anchors.fill: parent
+    z: 1
+    cursorShape: Qt.PointingHandCursor
+    onClicked: root.workspaceActivated()
+  }
+
+  Rectangle {
+    anchors.fill: parent
+    z: 2
+    color: root.dropHovered
+      ? Style.selectedFillFor(Color.menu.text, Color.accent)
+      : (root.validDropTarget || root.keyboardSelected
+        ? Style.hoverFillFor(Color.menu.text, Color.accent) : "transparent")
+
+    Behavior on color {
+      ColorAnimation { duration: 60 }
+    }
+  }
+
+  Text {
+    id: workspaceLabel
+    visible: !root.addWorkspace
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.leftMargin: Style.spacing.md
+    anchors.rightMargin: Style.spacing.md
+    height: root.headerHeight
+    text: root.workspaceId === 10 ? "Workspace 0" : "Workspace " + root.workspaceId
+    color: root.focused ? Color.accent : Color.menu.text
+    opacity: root.occupied || root.focused ? 1 : 0.58
+    font.family: Style.font.menuFamily
+    font.pixelSize: Style.font.title
+    font.bold: root.focused
+    elide: Text.ElideRight
+    verticalAlignment: Text.AlignVCenter
+  }
+
+  Text {
+    visible: !root.occupied && !root.addWorkspace
+    anchors.centerIn: previewArea
+    text: "Empty"
+    color: Color.menu.text
+    opacity: 0.42
+    font.family: Style.font.menuFamily
+    font.pixelSize: Style.font.body
+  }
+
+  Item {
+    id: previewArea
+    visible: !root.addWorkspace
+    z: 5
+    anchors.top: workspaceLabel.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    anchors.margins: Style.spacing.md
+
+    Grid {
+      anchors.fill: parent
+      columns: root.previewColumns
+      spacing: root.previewSpacing
+
+      Repeater {
+        model: root.toplevelModel
+
+        WindowPreview {
+          required property var modelData
+
+          width: Math.max(1, (previewArea.width - root.previewSpacing * (root.previewColumns - 1)) / root.previewColumns)
+          height: Math.max(1, (previewArea.height - root.previewSpacing * (root.previewRows - 1)) / root.previewRows)
+          toplevel: modelData
+          onActivated: root.windowActivated(modelData)
+          onDragStarted: root.windowDragStarted(modelData)
+          onDragFinished: root.windowDragFinished(modelData)
+        }
+      }
+    }
+  }
+
+  Text {
+    visible: root.addWorkspace
+    anchors.centerIn: parent
+    z: 3
+    text: "+"
+    color: Color.menu.text
+    opacity: root.dropHovered ? 1 : 0.58
+    font.family: Style.font.menuFamily
+    font.pixelSize: Style.font.displayLarge
+    horizontalAlignment: Text.AlignHCenter
+    verticalAlignment: Text.AlignVCenter
+  }
+
+  DropArea {
+    id: dropArea
+    anchors.fill: parent
+    z: 20
+    keys: ["omarchy-window"]
+    enabled: root.validDropTarget
+
+    onDropped: function(drop) {
+      if (!root.validDropTarget || !drop.source || !drop.source.toplevel) {
+        drop.accepted = false
+        return
+      }
+      drop.acceptProposedAction()
+      root.windowDropped(drop.source.toplevel)
+    }
+  }
+}

--- a/shell/plugins/workspace-overview/WorkspaceOverview.qml
+++ b/shell/plugins/workspace-overview/WorkspaceOverview.qml
@@ -1,0 +1,292 @@
+import QtQuick
+import Quickshell
+import Quickshell.Hyprland
+import Quickshell.Wayland
+import qs.Commons
+import qs.Ui
+
+Item {
+  id: root
+
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  property var shell: null
+  property var manifest: null
+  property bool opened: false
+  property var targetScreen: Quickshell.screens.length > 0 ? Quickshell.screens[0] : null
+  property var draggedToplevel: null
+  property int selectedCardIndex: -1
+
+  readonly property var workspaceModel: root.workspaceIds()
+  readonly property int workspaceCount: workspaceModel.length
+  readonly property int nextWorkspaceId: root.nextWorkspaceAfter(workspaceModel)
+  readonly property var overviewCardModel: {
+    var ids = workspaceModel.slice()
+    if (nextWorkspaceId > 0) ids.push(nextWorkspaceId)
+    return ids
+  }
+  readonly property int cardCount: overviewCardModel.length
+  readonly property real cardAspectRatio: 1.55
+  readonly property real outerMargin: Math.max(Style.gapsOut, Style.spacing.panelPadding)
+  readonly property real gridSpacing: Style.spacing.lg
+  readonly property real availableWidth: Math.max(1, panel.width - outerMargin * 2)
+  readonly property real availableHeight: Math.max(1, panel.height - outerMargin * 2)
+  readonly property int columns: Math.max(1, Math.min(cardCount,
+    Math.ceil(Math.sqrt(cardCount * availableWidth / availableHeight / cardAspectRatio))))
+  readonly property int rows: Math.max(1, Math.ceil(cardCount / columns))
+  readonly property real cardWidth: Math.max(1, Math.min(
+    Style.space(520),
+    (availableWidth - gridSpacing * (columns - 1)) / columns,
+    ((availableHeight - gridSpacing * (rows - 1)) / rows) * cardAspectRatio))
+  readonly property real cardHeight: Math.max(1, cardWidth / cardAspectRatio)
+
+  function workspaceById(id) {
+    var values = Hyprland.workspaces.values
+    for (var i = 0; i < values.length; i++) {
+      if (values[i].id === id) return values[i]
+    }
+    return null
+  }
+
+  function workspaceIds() {
+    var ids = [1, 2, 3, 4, 5]
+    var values = Hyprland.workspaces.values
+
+    for (var i = 0; i < values.length; i++) {
+      var id = values[i].id
+      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+    }
+
+    ids.sort(function(left, right) { return left - right })
+    return ids
+  }
+
+  function nextWorkspaceAfter(ids) {
+    if (!ids || ids.length === 0) return -1
+    var next = ids[ids.length - 1] + 1
+    return next <= 10 ? next : -1
+  }
+
+  function cardIndexAfterMove(index, dx, dy, count, columnCount) {
+    if (count <= 0) return -1
+    var current = Math.max(0, Math.min(index, count - 1))
+    var cols = Math.max(1, columnCount)
+    var row = Math.floor(current / cols)
+    var column = current % cols
+
+    if (dx < 0) return Math.max(row * cols, current - 1)
+    if (dx > 0) return Math.min(Math.min(row * cols + cols - 1, count - 1), current + 1)
+
+    var targetRow = Math.max(0, Math.min(Math.ceil(count / cols) - 1, row + dy))
+    return Math.min(targetRow * cols + column, count - 1)
+  }
+
+  function initialSelectedCardIndex() {
+    var focused = Hyprland.focusedWorkspace
+    if (focused) {
+      var index = root.workspaceModel.indexOf(focused.id)
+      if (index >= 0) return index
+    }
+    return root.cardCount > 0 ? 0 : -1
+  }
+
+  function moveCardSelection(dx, dy) {
+    root.selectedCardIndex = root.cardIndexAfterMove(
+      root.selectedCardIndex, dx, dy, root.cardCount, root.columns)
+  }
+
+  function activateSelectedCard() {
+    var index = root.selectedCardIndex
+    if (index < 0 || index >= root.cardCount) return
+    var workspaceId = root.overviewCardModel[index]
+    if (root.nextWorkspaceId > 0 && index === root.workspaceCount)
+      root.activateNextWorkspace()
+    else
+      root.activateWorkspace(root.workspaceById(workspaceId), workspaceId)
+  }
+
+  function normalizedAddress(toplevel) {
+    var address = String((toplevel && toplevel.address) || "").trim()
+    if (!address.match(/^(0x)?[0-9a-fA-F]+$/)) return ""
+    return address.indexOf("0x") === 0 ? address : "0x" + address
+  }
+
+  function sourceWorkspaceId(toplevel) {
+    return toplevel && toplevel.workspace ? Number(toplevel.workspace.id) : -1
+  }
+
+  function dispatchWorkspace(workspaceId) {
+    if (workspaceId <= 0 || workspaceId > 10) return false
+    if (Hyprland.usingLua)
+      Hyprland.dispatch("hl.dsp.focus({ workspace = \"" + workspaceId + "\" })")
+    else
+      Hyprland.dispatch("workspace " + workspaceId)
+    return true
+  }
+
+  function focusedScreen() {
+    var monitor = Hyprland.focusedMonitor
+    var screens = Quickshell.screens || []
+    if (monitor) {
+      for (var i = 0; i < screens.length; i++) {
+        if (screens[i] && screens[i].name === monitor.name) return screens[i]
+      }
+    }
+    return screens.length > 0 ? screens[0] : null
+  }
+
+  function open(payloadJson) {
+    root.targetScreen = root.focusedScreen()
+    root.draggedToplevel = null
+    root.selectedCardIndex = root.initialSelectedCardIndex()
+    root.opened = true
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function close() {
+    root.draggedToplevel = null
+    root.selectedCardIndex = -1
+    root.opened = false
+  }
+
+  function dismiss() {
+    root.draggedToplevel = null
+    root.selectedCardIndex = -1
+    root.opened = false
+    if (root.shell && typeof root.shell.hide === "function")
+      root.shell.hide((root.manifest && root.manifest.id) || "omarchy.workspace-overview")
+  }
+
+  function toggle() {
+    if (root.opened) root.dismiss()
+    else root.open("{}")
+  }
+
+  function activateWorkspace(workspace, workspaceId) {
+    if (workspace) workspace.activate()
+    else if (!root.dispatchWorkspace(workspaceId)) return
+    Qt.callLater(root.dismiss)
+  }
+
+  function activateNextWorkspace() {
+    var workspaceId = root.nextWorkspaceId
+    if (!root.dispatchWorkspace(workspaceId)) return
+    Qt.callLater(root.dismiss)
+  }
+
+  function activateWindow(toplevel) {
+    var address = root.normalizedAddress(toplevel)
+    var wayland = toplevel ? toplevel.wayland : null
+    if (address && Hyprland.usingLua)
+      Hyprland.dispatch("hl.dsp.focus({ window = \"address:" + address + "\" })")
+    else if (address)
+      Hyprland.dispatch("focuswindow address:" + address)
+    else if (wayland)
+      wayland.activate()
+    else
+      return
+    Qt.callLater(root.dismiss)
+  }
+
+  function moveWindowToWorkspace(toplevel, workspaceId) {
+    var address = root.normalizedAddress(toplevel)
+    var sourceId = root.sourceWorkspaceId(toplevel)
+    if (!address || workspaceId <= 0 || workspaceId > 10 || sourceId === workspaceId) return false
+
+    root.draggedToplevel = null
+    if (Hyprland.usingLua) {
+      Hyprland.dispatch("hl.dsp.window.move({ workspace = \"" + workspaceId
+        + "\", window = \"address:" + address + "\", follow = false })")
+    } else {
+      Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ",address:" + address)
+    }
+    return true
+  }
+
+  function beginWindowDrag(toplevel) {
+    if (root.normalizedAddress(toplevel)) root.draggedToplevel = toplevel
+  }
+
+  function endWindowDrag(toplevel) {
+    if (root.draggedToplevel === toplevel) root.draggedToplevel = null
+  }
+
+  PanelWindow {
+    id: panel
+
+    screen: root.targetScreen
+    visible: root.opened && root.targetScreen !== null
+    anchors { top: true; bottom: true; left: true; right: true }
+    color: "transparent"
+    WlrLayershell.namespace: "omarchy-workspace-overview"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    exclusionMode: ExclusionMode.Ignore
+
+    Rectangle {
+      anchors.fill: parent
+      color: Color.menu.scrim
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: root.dismiss()
+    }
+
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+      onMoveRequested: function(dx, dy) { root.moveCardSelection(dx, dy) }
+      onActivateRequested: root.activateSelectedCard()
+      onCloseRequested: root.dismiss()
+
+      Grid {
+        id: workspaceGrid
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        columns: root.columns
+        spacing: root.gridSpacing
+
+        Repeater {
+          model: root.overviewCardModel
+
+          WorkspaceCard {
+            required property int modelData
+            required property int index
+
+            readonly property bool isAddCard: root.nextWorkspaceId > 0
+              && index === root.workspaceCount
+
+            width: root.cardWidth
+            height: root.cardHeight
+            workspaceId: modelData
+            workspace: isAddCard ? null : root.workspaceById(modelData)
+            addWorkspace: isAddCard
+            draggedToplevel: root.draggedToplevel
+            keyboardSelected: index === root.selectedCardIndex
+            focused: !isAddCard && Hyprland.focusedWorkspace !== null
+              && Hyprland.focusedWorkspace.id === modelData
+            onWorkspaceActivated: {
+              if (isAddCard) root.activateNextWorkspace()
+              else root.activateWorkspace(workspace, modelData)
+            }
+            onWindowActivated: function(toplevel) { root.activateWindow(toplevel) }
+            onWindowDragStarted: function(toplevel) { root.beginWindowDrag(toplevel) }
+            onWindowDragFinished: function(toplevel) { root.endWindowDrag(toplevel) }
+            onWindowDropped: function(toplevel) { root.moveWindowToWorkspace(toplevel, modelData) }
+          }
+        }
+      }
+    }
+  }
+
+  Connections {
+    target: root.draggedToplevel
+    ignoreUnknownSignals: true
+    function onDestroyed() { root.draggedToplevel = null }
+  }
+
+  onCardCountChanged: {
+    if (root.selectedCardIndex >= root.cardCount)
+      root.selectedCardIndex = root.cardCount - 1
+  }
+}

--- a/shell/plugins/workspace-overview/manifest.json
+++ b/shell/plugins/workspace-overview/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.workspace-overview",
+  "name": "Workspace Overview",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Visual overview of workspaces and their windows",
+  "kinds": [
+    "overlay"
+  ],
+  "entryPoints": {
+    "overlay": "WorkspaceOverview.qml"
+  }
+}

--- a/test/shell.d/workspace-overview-test.sh
+++ b/test/shell.d/workspace-overview-test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const pluginDir = path.join(root, 'shell/plugins/workspace-overview')
+const manifest = JSON.parse(fs.readFileSync(path.join(pluginDir, 'manifest.json'), 'utf8'))
+const overview = fs.readFileSync(path.join(pluginDir, 'WorkspaceOverview.qml'), 'utf8')
+const card = fs.readFileSync(path.join(pluginDir, 'WorkspaceCard.qml'), 'utf8')
+const preview = fs.readFileSync(path.join(pluginDir, 'WindowPreview.qml'), 'utf8')
+const workspaces = fs.readFileSync(path.join(root, 'shell/plugins/bar/widgets/Workspaces.qml'), 'utf8')
+const tilingBindings = fs.readFileSync(path.join(root, 'default/hypr/bindings/tiling.lua'), 'utf8')
+
+function qmlFunction(source, name) {
+  const marker = `function ${name}(`
+  const functionStart = source.indexOf(marker)
+  assert(functionStart >= 0, `workspace overview defines ${name}`)
+  const argsStart = functionStart + marker.length
+  const argsEnd = source.indexOf(')', argsStart)
+  const bodyStart = source.indexOf('{', argsEnd)
+  let depth = 1
+  let cursor = bodyStart + 1
+  while (cursor < source.length && depth > 0) {
+    if (source[cursor] === '{') depth++
+    else if (source[cursor] === '}') depth--
+    cursor++
+  }
+  const args = source.slice(argsStart, argsEnd).split(',').map(value => value.trim()).filter(Boolean)
+  const body = source.slice(bodyStart + 1, cursor - 1)
+  return new Function(...args, body)
+}
+
+assertEqual(manifest.id, 'omarchy.workspace-overview', 'workspace overview uses the first-party plugin id')
+assertDeepEqual(manifest.kinds, ['overlay'], 'workspace overview is an overlay plugin')
+assert(manifest.keepLoaded === undefined, 'workspace overview unloads after it closes')
+assert(
+  manifest.entryPoints.overlay === 'WorkspaceOverview.qml'
+    && /function open\(payloadJson\)/.test(overview)
+    && /function close\(\)/.test(overview)
+    && /function toggle\(\)/.test(overview),
+  'workspace overview remains available through the standard shell plugin IPC lifecycle'
+)
+
+assert(
+  /var ids = \[1, 2, 3, 4, 5\][\s\S]*id > 0 && id <= 10/.test(overview),
+  'workspace overview follows the workspace bar model'
+)
+assert(
+  /model: root\.toplevelModel/.test(card) && /workspace \? workspace\.toplevels : \[\]/.test(card),
+  'workspace cards bind directly to native workspace toplevel models'
+)
+assert(
+  /if \(workspace\) workspace\.activate\(\)/.test(overview)
+    && /Qt\.callLater\(root\.dismiss\)/.test(overview),
+  'workspace card activation uses the native workspace API before deferred dismissal'
+)
+assert(
+  /MouseArea \{[\s\S]*onClicked: root\.workspaceActivated\(\)/.test(card)
+    && /TapHandler[\s\S]*onTapped: root\.activated\(\)/.test(preview),
+  'workspace and window clicks have separate pointer owners'
+)
+assert(
+  /ScreencopyView[\s\S]*captureSource: root\.waylandToplevel[\s\S]*live: false/.test(preview),
+  'window previews use one-shot native Wayland screencopy'
+)
+assert(
+  /Hyprland\.dispatch\("hl\.dsp\.focus\(\{ window = \\"address:[\s\S]*root\.dismiss\(\)/.test(overview),
+  'window selection uses canonical exact-address Hyprland focus and dismisses the overlay'
+)
+assert(
+  /else if \(wayland\)[\s\S]*wayland\.activate\(\)/.test(overview),
+  'window selection falls back to native Wayland activation when no address is mapped'
+)
+assert(
+  /WlrLayershell\.layer: WlrLayer\.Overlay/.test(overview)
+    && /WlrLayershell\.keyboardFocus: WlrKeyboardFocus\.Exclusive/.test(overview),
+  'workspace overview uses the standard focused overlay surface pattern'
+)
+assert(
+  /DropArea \{[\s\S]*keys: \["omarchy-window"\][\s\S]*root\.windowDropped\(drop\.source\.toplevel\)/.test(card),
+  'every workspace card accepts native window-preview drags'
+)
+assert(
+  /hl\.dsp\.window\.move\(\{ workspace = \\\"[\s\S]*window = \\\"address:[\s\S]*follow = false/.test(overview)
+    && /movetoworkspacesilent/.test(overview),
+  'window moves identify the exact address and use silent workspace semantics'
+)
+assert(
+  /sourceId === workspaceId\) return false/.test(overview),
+  'same-workspace window drops are ignored'
+)
+
+const normalizedAddress = qmlFunction(overview, 'normalizedAddress')
+assertEqual(normalizedAddress(null), '', 'missing toplevel address cancels window movement')
+assertEqual(normalizedAddress({ address: '' }), '', 'empty toplevel address cancels window movement')
+assertEqual(normalizedAddress({ address: 'abc123' }), '0xabc123', 'toplevel addresses gain the canonical hexadecimal prefix')
+assertEqual(normalizedAddress({ address: '0xabc123' }), '0xabc123', 'prefixed toplevel addresses remain unchanged')
+
+const nextWorkspaceAfter = qmlFunction(overview, 'nextWorkspaceAfter')
+assertEqual(nextWorkspaceAfter([1, 2, 3, 4, 5]), 6, 'initial workspace layout adds workspace 6')
+assertEqual(nextWorkspaceAfter([1, 2, 3, 4, 5, 6]), 7, 'existing workspace 6 advances the add card to workspace 7')
+assertEqual(nextWorkspaceAfter([1, 2, 3, 4, 5, 6, 7, 8, 9]), 10, 'workspace 9 advances the add card to workspace 10')
+assertEqual(nextWorkspaceAfter([1, 2, 3, 4, 5, 10]), -1, 'workspace 10 suppresses the add card')
+
+const cardIndexAfterMove = qmlFunction(overview, 'cardIndexAfterMove')
+assertEqual(cardIndexAfterMove(0, 1, 0, 6, 3), 1, 'Right selects the next workspace card')
+assertEqual(cardIndexAfterMove(1, 0, 1, 6, 3), 4, 'Down selects the workspace card below')
+assertEqual(cardIndexAfterMove(4, 0, -1, 6, 3), 1, 'Up selects the workspace card above')
+assertEqual(cardIndexAfterMove(3, -1, 0, 6, 3), 3, 'Left stops at the start of a grid row')
+assertEqual(cardIndexAfterMove(5, 0, 1, 7, 3), 6, 'Down reaches the plus card in an incomplete row')
+assert(
+  /if \(nextWorkspaceId > 0\) ids\.push\(nextWorkspaceId\)/.test(overview),
+  'the plus card follows the highest represented workspace in the responsive grid'
+)
+assert(
+  /function activateNextWorkspace[\s\S]*dispatchWorkspace\(workspaceId\)[\s\S]*Qt\.callLater\(root\.dismiss\)/.test(overview),
+  'plus click dispatches and activates the next workspace before closing'
+)
+const moveFunction = overview.slice(
+  overview.indexOf('function moveWindowToWorkspace'),
+  overview.indexOf('function beginWindowDrag')
+)
+assert(!/dismiss|activateWorkspace|dispatchWorkspace/.test(moveFunction), 'dragging a window does not activate a workspace or close the overview')
+assert(
+  /onWindowDropped: function\(toplevel\) \{ root\.moveWindowToWorkspace\(toplevel, modelData\) \}/.test(overview),
+  'dropping onto plus reuses silent specific-window movement without workspace activation'
+)
+assert(
+  /TapHandler[\s\S]*onTapped: root\.activated\(\)/.test(preview)
+    && /DragHandler[\s\S]*dragThreshold: Style\.space\(6\)/.test(preview)
+    && /dragProxy\.Drag\.drop\(\)[\s\S]*Drag\.active: dragSessionActive/.test(preview),
+  'window dragging starts after a pointer threshold and suppresses click activation'
+)
+assert(/function activateWindow[\s\S]*root\.dismiss\(\)/.test(overview), 'normal window clicks still dismiss the overview')
+assert(/PanelKeyCatcher[\s\S]*onCloseRequested: root\.dismiss\(\)/.test(overview), 'Escape still dismisses the overview')
+assert(
+  !/text: "Workspace Overview"/.test(overview),
+  'workspace overview omits the visible heading'
+)
+assert(
+  /PanelKeyCatcher[\s\S]*onMoveRequested:[\s\S]*moveCardSelection/.test(overview)
+    && /onActivateRequested: root\.activateSelectedCard\(\)/.test(overview)
+    && /keyboardSelected: index === root\.selectedCardIndex/.test(overview),
+  'arrow keys select workspace cards and Enter activates the selection'
+)
+assert(
+  /o\.bind\("ALT \+ TAB", "Focus on next window", hl\.dsp\.window\.cycle_next\(\)\)/.test(tilingBindings)
+    && /o\.bind\("ALT \+ SHIFT \+ TAB", "Focus on previous window", hl\.dsp\.window\.cycle_next\(\{ next = false \}\)\)/.test(tilingBindings)
+    && /o\.bind\("ALT \+ TAB", "Reveal active window on top", hl\.dsp\.window\.bring_to_top\(\)\)/.test(tilingBindings)
+    && /o\.bind\("ALT \+ SHIFT \+ TAB", "Reveal active window on top", hl\.dsp\.window\.bring_to_top\(\)\)/.test(tilingBindings)
+    && !/omarchy\.workspace-overview/.test(tilingBindings),
+  'the original Alt+Tab bindings remain intact and do not open the workspace overview'
+)
+assert(
+  /button === Qt\.RightButton[\s\S]*toggle\("omarchy\.workspace-overview"/.test(workspaces)
+    && /button === Qt\.LeftButton[\s\S]*focusWorkspace\(modelData\)/.test(workspaces),
+  'workspace buttons preserve left-click switching and add right-click overview toggling'
+)
+assert(!/hyprctl clients|hyprpm|hyprexpo/.test(overview + card + preview), 'workspace overview adds no client polling or external overview dependency')
+JS


### PR DESCRIPTION
## Summary

Adds a native Workspace Overview to Omarchy Quattro for quickly locating and switching between windows across workspaces.

The overview presents the current workspace/window state in a fullscreen responsive grid using Omarchy's existing Quickshell and Hyprland integration.

This addresses the workflow described in #6592, where users with multiple workspaces may lose track of which workspace contains a particular application.

Fixes #6592

## Features

- Displays Omarchy workspaces in a responsive fullscreen grid
- Shows the windows belonging to each workspace
- Uses native Wayland window previews through Quickshell
- Highlights the currently focused workspace
- Click a window to activate it
- Click a workspace to switch to it
- Right-click a workspace number in the bar to open the overview
- Arrow keys navigate the workspace grid
- `Enter` activates the selected workspace
- `Escape` closes the overview
- Selection initially follows the currently focused workspace
- Empty workspaces remain visible and easy to identify
- Follows Omarchy's existing theme, typography, spacing, and border system

The overview can also be opened directly through shell IPC:

```bash
omarchy-shell shell toggle omarchy.workspace-overview