### PR TITLE
Force a database refresh before installing keyrings during the Quattro upgrade

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -402,11 +402,16 @@ install_keyrings() {
   # database's checksum and abort --noconfirm transactions as "corrupted".
   as_root find /var/cache/pacman/pkg -maxdepth 1 -name 'omarchy-*' -delete 2>/dev/null || true
 
-  as_root pacman -Sy --noconfirm archlinux-keyring omarchy-keyring || {
+  # -Syy forces the database download. configure_pacman_channel just repointed
+  # the mirrors, and a plain -Sy keeps the legacy database whenever the new
+  # server's copy isn't newer, leaving stale checksums that no amount of
+  # re-downloading can satisfy.
+
+  as_root pacman -Syy --noconfirm archlinux-keyring omarchy-keyring || {
     warn "Keyring package install failed; attempting to trust the Omarchy packaging key directly."
     as_root pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org || true
     as_root pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571 || true
-    as_root pacman -Sy --noconfirm archlinux-keyring omarchy-keyring
+    as_root pacman -Syy --noconfirm archlinux-keyring omarchy-keyring
   }
 }
 

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -13,6 +13,14 @@ pacman_line=$(grep -n '^configure_pacman_channel$' "$upgrade_to_quattro" | cut -
 grep -F 'omarchy-snapshot create || (($? == 127))' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade snapshots the system before mutation"
 
+# The mirrors are repointed immediately before the keyrings go in, so only a
+# forced refresh replaces the legacy database and its stale checksums.
+grep -F 'pacman -Syy --noconfirm archlinux-keyring omarchy-keyring' "$upgrade_to_quattro" >/dev/null
+if grep -F 'pacman -Sy --noconfirm archlinux-keyring omarchy-keyring' "$upgrade_to_quattro" >/dev/null; then
+  fail "Omarchy 4 upgrade forces a database refresh before installing keyrings"
+fi
+pass "Omarchy 4 upgrade forces a database refresh before installing keyrings"
+
 grep -F 'pacman -Syu --needed' "$upgrade_to_quattro" >/dev/null
 grep -F 'omarchy-update-aur-pkgs' "$upgrade_to_quattro" >/dev/null
 grep -F 'omarchy-update-available' "$upgrade_to_quattro" >/dev/null


### PR DESCRIPTION
`configure_pacman_channel` rewrites the mirrorlist and the `[omarchy]` server, then `install_keyrings` ran `pacman -Sy`. That's a mirror swap, which is exactly the case a single `-y` doesn't cover: pacman conditions the database download on the local file's mtime, so when the new server's copy isn't newer it keeps the legacy database.

The stale database carries checksums for the old builds while the quattro server serves rebuilt bytes under the same name and version, so purging the package cache just re-downloads packages that still can't match. The upgrade wedges on "corrupted (checksum)" with no way out, and the fallback path repeated the same `-Sy`, so it couldn't recover either.

Both keyring calls now use `-Syy` to force the download.

Anyone already stuck mid-upgrade needs `sudo pacman -Syy` before re-running, since their database is stale from the earlier attempt.

Fixes #6576

— 🤖 Claude, posting on behalf of @dhh