### PR TITLE
Scope BROWSER to interactive shells so browsers can set themselves as default

### DIFF
--- a/default/bash/envs
+++ b/default/bash/envs
@@ -1,6 +1,11 @@
 # Editor used by CLI
 export EDITOR="${EDITOR:-omarchy-launch-editor --inline}"
 export SUDO_EDITOR="$EDITOR"
+
+# Used by terminal programs (like gh) to open URLs detached from the terminal
+# process tree. Shell-scoped on purpose: exporting BROWSER session-wide makes
+# xdg-settings refuse to change the default browser.
+export BROWSER="${BROWSER:-omarchy-launch-browser}"
 export BAT_THEME=ansi
 
 # Color man pages with bat

--- a/default/uwsm/default
+++ b/default/uwsm/default
@@ -3,8 +3,9 @@
 # Install other terminals via Install > Terminal
 export TERMINAL=xdg-terminal-exec
 
-# Used by terminal programs (like gh) to open URLs detached from the terminal process tree
-export BROWSER=omarchy-launch-browser
+# BROWSER is intentionally not exported here: session-wide, it makes xdg-settings
+# refuse to change the default browser, which breaks the browsers' own "Set as
+# default" buttons. Interactive shells get BROWSER from default/bash/envs instead.
 
 # Used by terminal programs to open files with the selected Omarchy default editor
 export EDITOR="omarchy-launch-editor --inline"

--- a/default/uwsm/env.d/10-omarchy
+++ b/default/uwsm/env.d/10-omarchy
@@ -9,7 +9,6 @@ if [ -f "${OMARCHY_PATH%/}/default/uwsm/default" ]; then
   . "${OMARCHY_PATH%/}/default/uwsm/default"
 else
   export TERMINAL=xdg-terminal-exec
-  export BROWSER=omarchy-launch-browser
   export EDITOR="omarchy-launch-editor --inline"
 fi
 

--- a/test/shell.d/browser-env-test.sh
+++ b/test/shell.d/browser-env-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+envs="$ROOT/default/bash/envs"
+uwsm_default="$ROOT/default/uwsm/default"
+uwsm_env="$ROOT/default/uwsm/env.d/10-omarchy"
+
+browser=$(env -u BROWSER bash -c 'source "$1"; printf "%s" "$BROWSER"' bash "$envs")
+[[ $browser == "omarchy-launch-browser" ]] || fail "bash env provides a default browser" "actual: $browser"
+pass "bash env provides a default browser"
+
+browser=$(BROWSER=firefox bash -c 'source "$1"; printf "%s" "$BROWSER"' bash "$envs")
+[[ $browser == "firefox" ]] || fail "bash env preserves the inherited browser" "actual: $browser"
+pass "bash env preserves the inherited browser"
+
+# A session-wide BROWSER makes xdg-settings refuse "set default-web-browser",
+# breaking the browsers' own "Set as default" buttons.
+browser=$(env -u BROWSER bash -c 'source "$1"; printf "%s" "${BROWSER:-}"' bash "$uwsm_default")
+[[ -z $browser ]] || fail "uwsm session env leaves BROWSER unset" "actual: $browser"
+pass "uwsm session env leaves BROWSER unset"
+
+! grep -q "export BROWSER" "$uwsm_env" || fail "uwsm env.d fallback leaves BROWSER unset"
+pass "uwsm env.d fallback leaves BROWSER unset"


### PR DESCRIPTION
Fixes #6590

Omarchy exports `BROWSER=omarchy-launch-browser` into the entire uwsm session. On a generic desktop like Hyprland, `xdg-settings` hard-refuses `set default-web-browser` whenever `$BROWSER` is set (`set_browser_generic` errors with "\$BROWSER is set and can't be changed with xdg-settings"). Since browsers' native "Set as default" buttons go through `xdg-settings`, they all silently failed under the Omarchy session — Vivaldi, Firefox, Zen, and the Chromium family alike. #6356 worked around this for Omarchy's own commands with `env -u BROWSER`, but couldn't help third-party callers.

The export only exists for terminal programs (like `gh`) to open URLs detached from the terminal process tree — nothing in the graphical session reads it (Omarchy's own code only ever unsets it, and GUI apps resolve URLs through the MIME handlers that `xdg-settings set` maintains). So this moves the export from `default/uwsm/default` to `default/bash/envs`, guarded as `${BROWSER:-...}` like the existing `EDITOR` export so user overrides still win:

- Browsers launched from the app launcher no longer see `$BROWSER`, so their "Set as default" buttons work.
- `gh` and other terminal programs still get the detached-launch behavior, since interactive shells source `envs`.
- Omarchy's own `env -u BROWSER` call sites are unaffected.

Known edge that remains: a browser launched *from a terminal* still inherits the shell's `BROWSER`, so its button still fails there; `omarchy default browser` covers that case.

New `test/shell.d/browser-env-test.sh` pins the default and inherited-override behavior in `envs` and asserts the uwsm session env no longer exports `BROWSER`.

— 🤖 Claude, posting on behalf of @dhh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUyYEmcFGbi3YcsqhZAjkT