### PR TITLE
stop omarchy-mise-install from overwriting symlink targets

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -14,6 +14,7 @@ bin=${3:-$command}
 
 mkdir -p "$HOME/.local/bin"
 
+rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 mise use -g "$package" || exit 1


### PR DESCRIPTION
Fixes #6618 

`cat >` follows symlinks, so the wrapper install could overwrite a real binary (hit this with official Grok after the Quattro migration). Remove the destination first so we replace `~/.local/bin/$command` itself.