### PR TITLE
Run every test file instead of stopping at the first failure

### DIFF
--- a/test/all
+++ b/test/all
@@ -8,7 +8,16 @@ tests=(
   "$ROOT/test/shell"
 )
 
+# Run every suite even when an earlier one fails, so a single failure can't
+# hide whole suites behind it.
+failed=()
 for test in "${tests[@]}"; do
   printf '==> %s\n' "${test#$ROOT/}"
-  "$test"
+  "$test" || failed+=("${test#$ROOT/}")
 done
+
+if (( ${#failed[@]} > 0 )); then
+  printf '\n%d of %d suites failed:\n' "${#failed[@]}" "${#tests[@]}" >&2
+  printf '  %s\n' "${failed[@]}" >&2
+  exit 1
+fi

--- a/test/shell
+++ b/test/shell
@@ -18,7 +18,19 @@ if (( ${#tests[@]} == 0 )); then
   exit 1
 fi
 
+# Keep going after a failing file. A test file exits at its first failed
+# assertion, so aborting the run there too would hide every file after it --
+# one packaging failure was masking 114 of 134 files.
+failed=()
 for test in "${tests[@]}"; do
   printf '==> %s\n' "${test#$ROOT/}"
-  bash "$test"
+  bash "$test" || failed+=("${test#$ROOT/}")
 done
+
+if (( ${#failed[@]} > 0 )); then
+  printf '\n%d of %d test files failed:\n' "${#failed[@]}" "${#tests[@]}" >&2
+  printf '  %s\n' "${failed[@]}" >&2
+  exit 1
+fi
+
+printf '\nAll %d test files passed.\n' "${#tests[@]}"


### PR DESCRIPTION
`test/shell` and `test/all` inherit `set -euo pipefail`, so the first failing test file aborts the whole run and every file behind it goes unreported. You fix that one, rerun, find the next, and repeat — a file at a time. On a 140-file suite, one unrelated failure can keep most of the suite from ever reporting.

This keeps the run going after a failing file, then lists which files failed and exits non-zero. Individual files still stop at their own first failed assertion, so per-file isolation is unchanged.

The files are already independent of one another — the set of failures is the same whether the run continues or stops at the first one — so nothing was relying on the early abort. It looks incidental rather than intended: the runner became a script in passing as part of "Add shell plugin model tests", and nothing in `test/`, `docs/`, or `agents/` mentions stopping early.

Verified both directions with a scratch suite: when every file passes the run exits 0 and prints `All N test files passed.`; when the *first* file fails, every later file still executes and the run exits 1 with the failing files listed.

If you'd rather have fail-fast for CI speed, I'm happy to make it opt-in via an env var instead — I just don't think it should be the silent default locally.
