### PR TITLE
Fix Battle.net micro-stutter by persisting DXVK shader cache

### DIFF
--- a/bin/omarchy-launch-battlenet
+++ b/bin/omarchy-launch-battlenet
@@ -42,6 +42,8 @@ env_args=(
   PROTONPATH=GE-Proton
   GAMEID=umu-battlenet
   PROTON_VERB=run
+  DXVK_STATE_CACHE_PATH="$PREFIX"
+  STAGING_SHARED_MEMORY=1
 )
 (( with_mangohud )) && env_args+=(MANGOHUD=1)
 


### PR DESCRIPTION
## Summary
- `omarchy-launch-battlenet` never set `DXVK_STATE_CACHE_PATH`, so the WINEPREFIX's shader cache never persisted to disk — every already-compiled DXVK shader had to recompile from scratch on each launch, producing micro-stutter (most noticeable in StarCraft II).
- Adds `DXVK_STATE_CACHE_PATH="$PREFIX"` and `STAGING_SHARED_MEMORY=1` to the env passed to `umu-run`, matching what a working Lutris install of the same `umu-run` + GE-Proton stack sets by default.

## Test plan
- [x] A/B tested against a fresh Lutris install of Battle.net/SC2 on the same GE-Proton/umu-run stack (which sets these and did not stutter) vs. the unpatched manual launch (which did).
- [x] Applied the same two env vars to a local prefix and confirmed the stutter disappeared.
- [x] `bash -n bin/omarchy-launch-battlenet` — syntax OK.
- [ ] Would appreciate a sanity check from anyone else running Battle.net games through this launcher, since I only tested against SC2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)