### PR TITLE
Fix invisible Helix cursorline, ruler, and picker highlights

### DIFF
--- a/default/themed/helix.toml.tpl
+++ b/default/themed/helix.toml.tpl
@@ -76,12 +76,12 @@
 "ui.bufferline.active" = { fg = "foreground", bg = "background", underline = { color = "color5", style = "line" } }
 
 "ui.text" = "foreground"
-"ui.text.focus" = { fg = "foreground", bg = "color0", modifiers = ["bold"] }
+"ui.text.focus" = { fg = "foreground", bg = "lighter_background", modifiers = ["bold"] }
 "ui.text.inactive" = { fg = "color8" }
 "ui.text.directory" = { fg = "color4" }
 
 "ui.virtual" = "color8"
-"ui.virtual.ruler" = { bg = "color0" }
+"ui.virtual.ruler" = { bg = "lighter_background" }
 "ui.virtual.indent-guide" = "color8"
 "ui.virtual.inlay-hint" = { fg = "color8" }
 "ui.virtual.jump-label" = { fg = "color1", modifiers = ["bold"] }
@@ -96,9 +96,9 @@
 "ui.cursor.primary.insert" = { fg = "background", bg = "color2" }
 "ui.cursor.primary.select" = { fg = "background", bg = "color5" }
 
-"ui.cursorline.primary" = { bg = "color0" }
+"ui.cursorline.primary" = { bg = "lighter_background" }
 
-"ui.highlight" = { bg = "color0", modifiers = ["bold"] }
+"ui.highlight" = { bg = "lighter_background", modifiers = ["bold"] }
 
 "ui.menu" = { fg = "foreground", bg = "background" }
 "ui.menu.selected" = { fg = "background", bg = "foreground", modifiers = ["bold"] }
@@ -118,6 +118,7 @@ hint = "color6"
 [palette]
 background = "{{ background }}"
 foreground = "{{ foreground }}"
+lighter_background = "{{ lighter_background }}"
 cursor = "{{ bright_foreground }}"
 selection_background = "{{ selection_background }}"
 selection_foreground = "{{ selection_foreground }}"


### PR DESCRIPTION
afa2839a5ac7 (Rename bg/fg palette keys to background/foreground)
aliased `color0` to plain background in theme color resolution, but
the Helix template still uses `color0` as the subtle surface shade
behind `ui.cursorline.primary`, `ui.virtual.ruler`, `ui.highlight`, and
`ui.text.focus`. All four now render at exactly the background color
and vanish: no cursorline, no ruler, and the picker's focused row is
only distinguishable by its bold text. This is the same failure that
d80c98f02546 ("Make color0 distinct from background/foreground and fix
helix theme", #5538) fixed back when themes defined color0 directly.

Point those scopes at `lighter_background`, the semantic key for a
surface one step off the background. Every first-party theme defines it
distinct from background except Last Horizon and Solitude, which
set the two equal on purpose; those, and legacy themes whose
`lighter_background` falls back to background, render exactly as they
do today.

Assisted-by: Claude:claude-fable-5
Signed-off-by: Luke Hsiao <luke@hsiao.dev>

---

## After / Before

`color0` resolves to plain background, so the four scopes that use it as a
subtle surface paint background-on-background.

Editor shots use `cursorline = true` and `rulers = [80]`. The picker shots need
no opt-in: `ui.text.focus` and `ui.highlight` are the default file picker, so
the focused row losing its background affects every user.

<img width="3940" height="2148" alt="helix-catppuccin-editor-after" src="https://github.com/user-attachments/assets/f78e23ad-68b1-41c5-9654-29a42a5ec068" />
<img width="3940" height="2148" alt="helix-catppuccin-editor-before" src="https://github.com/user-attachments/assets/adff7fd4-5e60-40e2-8af4-e2e0433fd720" />
<img width="3940" height="2148" alt="helix-catppuccin-latte-editor-after" src="https://github.com/user-attachments/assets/b3bb2be3-a24d-4cc3-80dd-cfdbc8e6f7f5" />
<img width="3940" height="2148" alt="helix-catppuccin-latte-editor-before" src="https://github.com/user-attachments/assets/13054e33-cee2-43dd-a1d0-6587d96e3cda" />
<img width="3940" height="2148" alt="helix-catppuccin-picker-after" src="https://github.com/user-attachments/assets/448daad6-bedd-4dcc-b348-51bcddc12a6e" />
<img width="3940" height="2148" alt="helix-catppuccin-picker-before" src="https://github.com/user-attachments/assets/c9311827-5994-47a7-a8cd-bc3d6727c099" />
<img width="3940" height="2148" alt="helix-tokyo-night-editor-after" src="https://github.com/user-attachments/assets/51fbcd0b-9e9c-46cf-8bc0-cdf770afba22" />
<img width="3940" height="2148" alt="helix-tokyo-night-editor-before" src="https://github.com/user-attachments/assets/04ecb187-c857-4388-a34c-c131bdde8d37" />

