### PR TITLE
Live-sync shell look from Hyprland and add hook

### DIFF
--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -287,6 +287,7 @@ This skill intentionally does not cover Omarchy source development. Do not use t
 - "Clear all reminders" -> `omarchy reminder clear`
 - "Customize the catppuccin theme colors" -> Overlay: put an edited `colors.toml` in `~/.config/omarchy/themes/catppuccin/`, then re-apply the theme (see `theming.md`)
 - "Run a script every time I change themes" -> Install it with `omarchy hook install theme-set <script>`
+- "Run a script every time the shell's style changes (rounding, gaps, theme)" -> Install it with `omarchy hook install shell-style-changed <script>`
 - "Change how workspace labels are rendered" -> Clone `omarchy.workspaces`, which switches the bar to `<username>.workspaces`, then edit the clone
 - "Lock after ten minutes" -> Set `idle.lock` to `600` in `~/.config/omarchy/shell.json`
 - "Reset shell/bar to defaults" -> `omarchy refresh shell`

--- a/default/agents/skills/omarchy/hooks.md
+++ b/default/agents/skills/omarchy/hooks.md
@@ -16,10 +16,16 @@ file first, if one exists.
 ├── post-boot.d/            # After the desktop starts
 ├── post-update.d/          # During `omarchy update`, after system packages and migrations
 ├── pre-refresh-pacman.d/   # Before `omarchy refresh pacman` re-syncs packages
+├── shell-style-changed.d/  # After Hyprland reloads; shell re-syncs rounding and gaps
 └── theme-set.d/            # After theme change (theme slug in $1)
 ```
 
-Example hook script:
+`shell-style-changed` fires whenever Hyprland reloads its config. The shell applies
+the new rounding and outer gaps to its own style; hooks can query Hyprland for any
+other look value (blur, opacity, shadows, ...) after the reload. A theme change also
+reloads Hyprland, so the hook fires on theme switches too.
+
+Example hook script (theme-set):
 ```bash
 #!/bin/bash
 THEME_NAME=$1

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -347,11 +347,30 @@ QtObject {
     readonly property int statusSlot:     root.barToken("status-slot",     21)
   }
 
+  // Track the two live look queries for the current refresh. The hook fires only
+  // after both have applied, so external automation never observes stale values.
+  property int pendingLookReads: 0
+  // A style refresh that lands while a user hook is still running must not be
+  // dropped; queue it and drain it from onExited.
+  property bool hookRunPending: false
+
   function refresh() {
+    pendingLookReads = 2
     hyprctlProc.running = true
     gapsOutProc.running = true
-    // Acknowledge a shell style refresh so external automation can react to
-    // look-affecting changes without re-running hyprctl.
+  }
+
+  function lookReadFinished() {
+    pendingLookReads -= 1
+    if (pendingLookReads > 0) return
+    runStyleHook()
+  }
+
+  function runStyleHook() {
+    if (styleHookProc.running) {
+      hookRunPending = true
+      return
+    }
     styleHookProc.running = true
   }
 
@@ -447,7 +466,10 @@ QtObject {
     command: ["hyprctl", "-j", "getoption", "decoration:rounding"]
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.applyRoundingJson(text)
+      onStreamFinished: {
+        root.applyRoundingJson(text)
+        root.lookReadFinished()
+      }
     }
   }
 
@@ -456,7 +478,10 @@ QtObject {
     command: ["hyprctl", "-j", "getoption", "general:gaps_out"]
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.applyGapsOutJson(text)
+      onStreamFinished: {
+        root.applyGapsOutJson(text)
+        root.lookReadFinished()
+      }
     }
   }
 
@@ -565,6 +590,12 @@ QtObject {
   property Process styleHookProc: Process {
     id: styleHookProc
     command: ["omarchy-hook", "shell-style-changed"]
+    onExited: function(exitCode) {
+      if (root.hookRunPending) {
+        root.hookRunPending = false
+        root.runStyleHook()
+      }
+    }
   }
 
   Component.onCompleted: {

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -350,6 +350,9 @@ QtObject {
   function refresh() {
     hyprctlProc.running = true
     gapsOutProc.running = true
+    // Acknowledge a shell style refresh so external automation can react to
+    // look-affecting changes without re-running hyprctl.
+    styleHookProc.running = true
   }
 
   function scheduleRefresh() {
@@ -557,6 +560,11 @@ QtObject {
     onTriggered: {
       if (hyprEventsProc.running) refreshTimer.restart()
     }
+  }
+
+  property Process styleHookProc: Process {
+    id: styleHookProc
+    command: ["omarchy-hook", "shell-style-changed"]
   }
 
   Component.onCompleted: {

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -508,6 +508,57 @@ QtObject {
     onLoadFailed: refreshTimer.restart()
   }
 
+  // Hyprland auto-reloads when any sourced config under ~/.config/hypr changes,
+  // so re-poll decoration:rounding and general:gaps_out to track looknfeel
+  // edits (rounding, gaps) live without restarting the shell.
+  property FileView hyprConfigDir: FileView {
+    path: Quickshell.env("HOME") + "/.config/hypr"
+    watchChanges: true
+    printErrors: false
+    onFileChanged: refreshTimer.restart()
+    onLoaded: refreshTimer.restart()
+    onLoadFailed: refreshTimer.restart()
+  }
+
+  // Hyprland reloads when sourced files change even via in-place writes, which a
+  // directory FileView cannot see (directory watches only report entry
+  // create/remove/rename). Listen on the instance event socket so any reload —
+  // atomic or in-place — re-syncs the shell from Hyprland's own detection.
+  property Process hyprEventsProc: Process {
+    id: hyprEventsProc
+    running: true
+    command: ["socat", "-U", "-", "UNIX-CONNECT:" + Quickshell.env("XDG_RUNTIME_DIR") + "/hypr/" + Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE") + "/.socket2.sock"]
+    stdout: SplitParser {
+      onRead: function(line) {
+        if (String(line).indexOf("configreloaded") === 0) refreshTimer.restart()
+      }
+    }
+  }
+
+  // Restart the event listener if Hyprland restarts and the socket goes away.
+  property Timer hyprEventsReconnect: Timer {
+    interval: 3000
+    repeat: true
+    running: true
+    onTriggered: {
+      if (!hyprEventsProc.running) {
+        hyprEventsProc.running = true
+        reconnectCheckTimer.restart()
+      }
+    }
+  }
+
+  // Only re-sync once the listener actually connected; a failed socat exits
+  // within milliseconds, so refreshing on every attempt would spam the shell
+  // and the style hook while Hyprland is down.
+  property Timer reconnectCheckTimer: Timer {
+    interval: 200
+    repeat: false
+    onTriggered: {
+      if (hyprEventsProc.running) refreshTimer.restart()
+    }
+  }
+
   Component.onCompleted: {
     refresh()
     resolveFontFamily()

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -536,34 +536,9 @@ QtObject {
     onTriggered: root.refresh()
   }
 
-  // `omarchy toggle window-gaps` creates/removes this flag file. Hyprland
-  // reloads its config when sourced files change, then hyprctl reflects
-  // the new effective value.
-  property FileView windowNoGapsToggle: FileView {
-    path: Quickshell.env("HOME") + "/.local/state/omarchy/toggles/hypr/window-no-gaps.lua"
-    watchChanges: true
-    printErrors: false
-    onFileChanged: refreshTimer.restart()
-    onLoaded: refreshTimer.restart()
-    onLoadFailed: refreshTimer.restart()
-  }
-
-  // Hyprland auto-reloads when any sourced config under ~/.config/hypr changes,
-  // so re-poll decoration:rounding and general:gaps_out to track looknfeel
-  // edits (rounding, gaps) live without restarting the shell.
-  property FileView hyprConfigDir: FileView {
-    path: Quickshell.env("HOME") + "/.config/hypr"
-    watchChanges: true
-    printErrors: false
-    onFileChanged: refreshTimer.restart()
-    onLoaded: refreshTimer.restart()
-    onLoadFailed: refreshTimer.restart()
-  }
-
-  // Hyprland reloads when sourced files change even via in-place writes, which a
-  // directory FileView cannot see (directory watches only report entry
-  // create/remove/rename). Listen on the instance event socket so any reload —
-  // atomic or in-place — re-syncs the shell from Hyprland's own detection.
+  // Hyprland reloads its config whenever any sourced file changes (atomic or
+  // in-place writes, hyprctl reload, theme switches, toggles). Listen on the
+  // instance event socket and re-sync the shell from Hyprland's own detection.
   property Process hyprEventsProc: Process {
     id: hyprEventsProc
     running: true

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -353,8 +353,15 @@ QtObject {
   // A style refresh that lands while a user hook is still running must not be
   // dropped; queue it and drain it from onExited.
   property bool hookRunPending: false
+  // A refresh that arrives while the previous look queries are still running
+  // must not be dropped; re-run it once the current reads finish.
+  property bool refreshPending: false
 
   function refresh() {
+    if (pendingLookReads > 0) {
+      refreshPending = true
+      return
+    }
     pendingLookReads = 2
     hyprctlProc.running = true
     gapsOutProc.running = true
@@ -363,6 +370,11 @@ QtObject {
   function lookReadFinished() {
     pendingLookReads -= 1
     if (pendingLookReads > 0) return
+    if (refreshPending) {
+      refreshPending = false
+      refresh()
+      return
+    }
     runStyleHook()
   }
 


### PR DESCRIPTION
Currently, when Hyprland's look is updated (for example, rounding), we need to run omarchy restart shell to see those changes in the shell. This PR adds an event listener for Hyprland's configreloaded event via its instance socket, so QML's Style.refresh() runs on every config reload.

also adds a shell-style-changed hook, this will be helpful for my pr #6593 to also support live changes for things like hyprland rounding config

constraints, theme switches also fire this hook, because its detected as a configreloaded event.