### PR TITLE
Add battery percentage toggle to omarchy menu 

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -84,6 +84,7 @@
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
   "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},
+  "trigger.toggle.battery-percentage": {"icon":"󰁹","label":"Battery Percentage","when":"omarchy-hw-laptop","action":"omarchy-shell omarchy.power togglePercentage"},
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},
   "trigger.toggle.window-gaps": {"icon":"","label":"Window Gaps","action":"omarchy-hyprland-window-gaps-toggle"},
   "trigger.toggle.one-window-ratio": {"icon":"","label":"1-Window Ratio","action":"omarchy-hyprland-window-single-square-aspect-toggle"},


### PR DESCRIPTION
Hi everyone! Hi dhh! I am happy to join the community.

I would like to start my contributions with a low hanging fruit. It took me an embarrassingly long amount of time to figure out that I could right-click on the battery icon to display percent. I imagine I will not be the only one, so I have added to the menu entry. The PR is trivial and self-explanatory, because all the plumbing was done before me. 

Thank you for your attention!
I will try to bring more meaningful contributions soon❤️