### PR TITLE
Quattro: Route app audio to individual outputs

### DIFF
--- a/bin/omarchy-audio-output-set-default
+++ b/bin/omarchy-audio-output-set-default
@@ -1,31 +1,54 @@
 #!/bin/bash
 
-# omarchy:summary=Set the default audio output and move active streams
-# omarchy:args=<node-id> <sink-name>
+# omarchy:summary=Set the default audio output and move streams following it
+# omarchy:args=<node-id> <sink-name> [current-sink-name]
 # omarchy:examples=omarchy audio output set default 42 alsa_output.pci-0000_00_1f.3.analog-stereo
 
 node_id=${1:-}
 sink_name=${2:-}
+old_sink_name=${3:-}
 
-if [[ -z $node_id || -z $sink_name ]]; then
-  echo "Usage: omarchy-audio-output-set-default <node-id> <sink-name>" >&2
+if (( $# < 2 || $# > 3 )) || [[ -z $node_id || -z $sink_name ]]; then
+  echo "Usage: omarchy-audio-output-set-default <node-id> <sink-name> [current-sink-name]" >&2
   exit 1
+fi
+
+# Capture the applications following the old default before changing it.
+# PipeWire records explicit per-application routes in the default metadata, so
+# checking the current sink alone is not enough: an explicitly routed stream may
+# happen to be on the old default and must still remain there.
+[[ -n $old_sink_name ]] || old_sink_name=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
+old_sink_index=$(timeout 2 pactl -f json list sinks 2>/dev/null |
+  jq -r --arg name "$old_sink_name" 'map(select(.name == $name))[0].index // empty' || true)
+
+following_inputs=()
+if [[ -n $old_sink_index && $old_sink_name != "$sink_name" ]]; then
+  if metadata=$(timeout 2 pw-metadata -n default 2>/dev/null); then
+    declare -A explicitly_targeted=()
+    while IFS=$'\t' read -r object_id target; do
+      if [[ $object_id =~ ^[0-9]+$ && $target != "-1" ]]; then
+        explicitly_targeted["$object_id"]=1
+      fi
+    done < <(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata")
+
+    while IFS=$'\t' read -r input object_id; do
+      [[ -n $input ]] || continue
+      if [[ -z $object_id || -z ${explicitly_targeted[$object_id]:-} ]]; then
+        following_inputs+=("$input")
+      fi
+    done < <(timeout 2 pactl -f json list sink-inputs 2>/dev/null |
+      jq -r --arg sink "$old_sink_index" '.[]
+        | select((.sink | tostring) == $sink)
+        | select(.properties."application.name" != null)
+        | select(.properties."application.name" != "EasyEffects")
+        | [.index, (.properties."object.id" // "")]
+        | @tsv' || true)
+  fi
 fi
 
 timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
 timeout 2 pactl set-default-sink "$sink_name" 2>/dev/null || true
 
-# Move only real application streams. A DSP filter-chain's own output is also a
-# sink input but carries no application.name, and moving it would rewire the
-# processing itself -- onto headphones, or into its own virtual sink, which is a
-# cycle. EasyEffects' output stream must stay put for the same reason.
-timeout 2 pactl list sink-inputs 2>/dev/null | awk '
-  /^Sink Input #/ {id = substr($3, 2)}
-  /application\.name = / {
-    app = $0
-    sub(/.*application\.name = "/, "", app)
-    sub(/"$/, "", app)
-    if (app != "EasyEffects") print id
-  }' | while read -r input; do
+for input in "${following_inputs[@]}"; do
   [[ -n $input ]] && timeout 2 pactl move-sink-input "$input" "$sink_name" 2>/dev/null || true
 done

--- a/bin/omarchy-audio-stream-route-set
+++ b/bin/omarchy-audio-stream-route-set
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# omarchy:summary=Route a live application audio stream to an output
+# omarchy:group=audio
+# omarchy:args=<stream-serial> <sink-serial> [override|default]
+
+stream=${1:-}
+sink=${2:-}
+mode=${3:-override}
+
+if (( $# < 2 || $# > 3 )) || [[ ! $stream =~ ^[0-9]+$ || ! $sink =~ ^[0-9]+$ ]] ||
+  [[ $mode != "override" && $mode != "default" ]]; then
+  echo "Usage: omarchy-audio-stream-route-set <stream-serial> <sink-serial> [override|default]" >&2
+  exit 1
+fi
+
+timeout 2 pactl move-sink-input "$stream" "$sink" || exit 1
+
+# Moving through Pulse normally marks a stream with an explicit target, except
+# when it is already on that sink. Write both target forms ourselves so pinning
+# to the current default is distinct from following it. Clear both when the user
+# returns to the default-following mode.
+stream_object_id=$(timeout 2 pactl -f json list sink-inputs 2>/dev/null |
+  jq -r --arg stream "$stream" 'map(select((.index | tostring) == $stream))[0].properties."object.id" // empty') || exit 1
+[[ $stream_object_id =~ ^[0-9]+$ ]] || exit 1
+
+if [[ $mode == "override" ]]; then
+  sink_object_id=$(timeout 2 pactl -f json list sinks 2>/dev/null |
+    jq -r --arg sink "$sink" 'map(select((.index | tostring) == $sink))[0].properties."object.id" // empty') || exit 1
+  [[ $sink_object_id =~ ^[0-9]+$ ]] || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" target.object "$sink" Spa:Id >/dev/null 2>&1 || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" target.node "$sink_object_id" Spa:Id >/dev/null 2>&1 || exit 1
+else
+  timeout 2 pw-metadata -n default -- "$stream_object_id" target.object -1 Spa:Id >/dev/null 2>&1 || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" target.node -1 Spa:Id >/dev/null 2>&1 || exit 1
+fi

--- a/bin/omarchy-audio-stream-routes
+++ b/bin/omarchy-audio-stream-routes
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# omarchy:summary=List live application audio routes as JSON
+# omarchy:group=audio
+
+if (( $# != 0 )); then
+  echo "Usage: omarchy-audio-stream-routes" >&2
+  exit 1
+fi
+
+set -o pipefail
+
+# PipeWire's Pulse server exposes its object.serial as the sink-input index and
+# the destination sink's object.serial as `sink`. Quickshell exposes those same
+# serials on its nodes, giving the native panel an exact, label-independent map.
+# Explicit targets live in PipeWire metadata; retain that distinction so an app
+# pinned to the current default is not presented as following the default.
+metadata=$(timeout 2 pw-metadata -n default 2>/dev/null) || exit 1
+explicit_targets=$(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata" |
+  awk -F '\t' '$2 != "-1" { print $1 }' |
+  jq -Rsc 'split("\n") | map(select(length > 0)) | map({key: ., value: true}) | from_entries') || exit 1
+
+timeout 2 pactl -f json list sink-inputs 2>/dev/null | jq -c --argjson explicit "$explicit_targets" '
+  map(
+    select(.index != null and .sink != null)
+    | {
+        key: (.index | tostring),
+        value: {
+          sink: (.sink | tostring),
+          mode: (if ($explicit[(.properties."object.id" | tostring)] // false) then "override" else "default" end)
+        }
+      }
+  )
+  | from_entries
+' || exit 1

--- a/shell/Ui/Dropdown.qml
+++ b/shell/Ui/Dropdown.qml
@@ -31,6 +31,17 @@ Item {
   property int rowHeight: Style.spacing.controlHeight
   property int popupRowHeight: Style.spacing.popupRowHeight
   property bool showLabel: true
+  property string popupDirection: "down"  // "down" | "up" | "right" | "left"
+  property string popupSideAlignment: "top"  // "top" | "center" | "bottom"
+  property int popupAnchorHeight: rowHeight
+  property int popupWidth: 0
+  property int popupGap: Style.spacing.xxs
+  property int popupOffsetX: 0
+  // Optional compact trigger that reduces the control to its directional
+  // submenu affordance while preserving pointer and keyboard behavior.
+  property bool chevronOnly: false
+  property bool showChevron: true
+  property bool triggerChrome: true
 
   // Panel-cursor flag. When true, the trigger renders the shared
   // hover-cursor state. Active Qt focus defaults to the same visuals.
@@ -87,9 +98,13 @@ Item {
 
       readonly property bool _focused: trigger.activeFocus
       readonly property bool _hot: triggerHover.hovered || root.hasCursor
-      readonly property var _borderSpec: Border.controlSpec(trigger._focused ? "focus" : (trigger._hot ? "hover-cursor" : "normal"), root.foreground, root.accent)
+      readonly property var _borderSpec: root.triggerChrome
+        ? Border.controlSpec(trigger._focused ? "focus" : (trigger._hot ? "hover-cursor" : "normal"), root.foreground, root.accent)
+        : Border.none()
 
-      color: Style.controlFill(trigger._focused, trigger._hot, root.foreground, root.accent)
+      color: root.triggerChrome
+        ? Style.controlFill(trigger._focused, trigger._hot, root.foreground, root.accent)
+        : "transparent"
       borderSpec: _borderSpec
 
       activeFocusOnTab: true
@@ -110,6 +125,7 @@ Item {
       }
 
       Text {
+        visible: !root.chevronOnly
         anchors.left: parent.left
         anchors.right: chevron.left
         anchors.verticalCenter: parent.verticalCenter
@@ -124,37 +140,83 @@ Item {
 
       Text {
         id: chevron
-        anchors.right: parent.right
+        visible: root.showChevron
+        anchors.right: root.chevronOnly ? undefined : parent.right
+        anchors.horizontalCenter: root.chevronOnly ? parent.horizontalCenter : undefined
         anchors.verticalCenter: parent.verticalCenter
-        anchors.rightMargin: trigger.borderRight + Style.spacing.controlGap
-        text: "󰅀"
+        anchors.rightMargin: root.chevronOnly ? 0 : trigger.borderRight + Style.spacing.controlGap
+        text: root.popupDirection === "right" ? "󰅂"
+          : (root.popupDirection === "left" ? "󰅁"
+          : (root.popupDirection === "up" ? "󰅃" : "󰅀"))
         color: Qt.darker(root.foreground, 1.2)
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
       }
 
       MouseArea {
+        property bool popupWasOpenOnPress: false
+
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
+        onPressed: popupWasOpenOnPress = popup.opened
         onClicked: {
           trigger.forceActiveFocus()
-          popup.opened ? popup.close() : popup.open()
+          popupWasOpenOnPress ? popup.close() : popup.open()
         }
       }
 
       Popup {
         id: popup
-        x: 0
-        y: trigger.height + Style.spacing.xxs
-        width: trigger.width
-        implicitHeight: Math.min(root.options.length * root.popupRowHeight + Math.max(0, root.options.length - 1) * Style.spacing.labelGap + Style.spacing.xxs,
-                                 root.popupRowHeight * 8 + 7 * Style.spacing.labelGap + Style.spacing.xxs)
+        popupType: Popup.Item
+        property real _anchorWindowX: 0
+        property real _anchorWindowY: 0
+        readonly property var _windowContent: trigger.Window.window
+          ? trigger.Window.window.contentItem : null
+        readonly property real _windowWidth: _windowContent ? _windowContent.width : 0
+        readonly property real _windowHeight: _windowContent ? _windowContent.height : 0
+        readonly property real _edgeMargin: Style.spacing.sm
+        readonly property real rowsHeight: root.options.length * root.popupRowHeight
+          + Math.max(0, root.options.length - 1) * Style.spacing.labelGap
+        readonly property real cappedRowsHeight: root.popupRowHeight * 8
+          + 7 * Style.spacing.labelGap
+        readonly property real _idealX: (root.popupDirection === "right" ? trigger.width + root.popupGap
+          : (root.popupDirection === "left" ? -width - root.popupGap : 0)) + root.popupOffsetX
+        readonly property real _idealY: root.popupDirection === "down" ? root.popupAnchorHeight + root.popupGap
+          : (root.popupDirection === "up" ? -implicitHeight - root.popupGap
+          : (root.popupSideAlignment === "center" ? (root.popupAnchorHeight - implicitHeight) / 2
+          : (root.popupSideAlignment === "bottom" ? root.popupAnchorHeight - implicitHeight : 0)))
+        x: _windowWidth > 0
+          ? Math.max(_edgeMargin - _anchorWindowX,
+              Math.min(_windowWidth - _edgeMargin - width - _anchorWindowX, _idealX))
+          : _idealX
+        y: _windowHeight > 0
+          ? Math.max(_edgeMargin - _anchorWindowY,
+              Math.min(_windowHeight - _edgeMargin - implicitHeight - _anchorWindowY, _idealY))
+          : _idealY
+        width: {
+          var desired = root.popupWidth > 0 ? root.popupWidth : trigger.width
+          return _windowWidth > 0
+            ? Math.min(desired, Math.max(0, _windowWidth - 2 * _edgeMargin)) : desired
+        }
         padding: Style.spacing.hairline
         leftPadding: Border.left(root.popupBorderSpec) + Style.spacing.hairline
         rightPadding: Border.right(root.popupBorderSpec) + Style.spacing.hairline
         topPadding: Border.top(root.popupBorderSpec) + Style.spacing.hairline
         bottomPadding: Border.bottom(root.popupBorderSpec) + Style.spacing.hairline
+        // Include the real insets in the popup height. If the viewport is even
+        // a few pixels shorter than its rows, ListView scrolls when keyboard
+        // selection reaches the last option and makes the whole menu appear to
+        // jump despite every option already fitting on screen.
+        implicitHeight: {
+          var desired = Math.min(rowsHeight, cappedRowsHeight) + topPadding + bottomPadding
+          return _windowHeight > 0
+            ? Math.min(desired, Math.max(0, _windowHeight - 2 * _edgeMargin)) : desired
+        }
         focus: true
+        // A trigger press is handled by the MouseArea above. Keeping it inside
+        // the close boundary prevents the default outside-press handler from
+        // closing first and making that same click immediately reopen it.
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
         background: BorderSurface {
           color: root.background
@@ -162,22 +224,51 @@ Item {
           radius: Style.cornerRadius
         }
 
+        function reposition() {
+          if (!_windowContent) return
+          var point = trigger.mapToItem(_windowContent, 0, 0)
+          _anchorWindowX = point.x
+          _anchorWindowY = point.y
+        }
+
+        onAboutToShow: reposition()
         onOpened: {
-          optionList.currentIndex = Math.max(0, optionList.indexOfValue(root.value))
+          reposition()
+          optionList.hoveredIndex = -1
+          optionList.pointerActive = false
+          // A caller may intentionally preserve a state that is not offered as
+          // a menu action. Leave it unhighlighted instead of pretending the
+          // first option is selected; Down/j still advances from -1 to row 0.
+          optionList.currentIndex = optionList.indexOfValue(root.value)
           optionList.forceActiveFocus()
         }
 
         contentItem: ListView {
           id: optionList
           spacing: Style.spacing.labelGap
+          property int hoveredIndex: -1
+          property bool pointerActive: false
+          readonly property int highlightedIndex: pointerActive && hoveredIndex >= 0
+            ? hoveredIndex : currentIndex
+
+          HoverHandler {
+            onHoveredChanged: if (!hovered) {
+              optionList.pointerActive = false
+              optionList.hoveredIndex = -1
+            }
+          }
 
           Keys.priority: Keys.BeforeItem
           Keys.onPressed: function(event) {
             if (event.key === Qt.Key_Escape) { popup.close(); event.accepted = true }
             else if (event.key === Qt.Key_Down || event.text === "j") {
+              optionList.pointerActive = false
+              optionList.hoveredIndex = -1
               optionList.currentIndex = Math.min(root.options.length - 1, optionList.currentIndex + 1)
               event.accepted = true
             } else if (event.key === Qt.Key_Up || event.text === "k") {
+              optionList.pointerActive = false
+              optionList.hoveredIndex = -1
               optionList.currentIndex = Math.max(0, optionList.currentIndex - 1)
               event.accepted = true
             } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
@@ -199,7 +290,6 @@ Item {
           function selectCurrent() {
             if (currentIndex < 0 || currentIndex >= root.options.length) return
             var v = root.optionValue(root.options[currentIndex])
-            root.value = v
             root.changed(v)
             popup.close()
           }
@@ -209,7 +299,7 @@ Item {
             required property int index
             width: optionList.width
             height: root.popupRowHeight
-            color: index === optionList.currentIndex
+            color: index === optionList.highlightedIndex
               ? Style.hoverFillFor(root.foreground, root.accent)
               : "transparent"
 
@@ -220,7 +310,8 @@ Item {
               anchors.leftMargin: Style.spacing.controlPaddingX
               anchors.rightMargin: Style.spacing.controlPaddingX
               text: root.optionLabel(modelData)
-              color: index === optionList.currentIndex ? Style.hoverStateColor(root.foreground, root.accent) : root.foreground
+              color: index === optionList.highlightedIndex
+                ? Style.hoverStateColor(root.foreground, root.accent) : root.foreground
               font.family: root.fontFamily
               font.pixelSize: Style.font.body
               elide: Text.ElideRight
@@ -230,8 +321,14 @@ Item {
               anchors.fill: parent
               hoverEnabled: true
               cursorShape: Qt.PointingHandCursor
-              onPositionChanged: optionList.currentIndex = parent.index
-              onClicked: optionList.selectCurrent()
+              onPositionChanged: {
+                optionList.pointerActive = true
+                optionList.hoveredIndex = parent.index
+              }
+              onClicked: {
+                optionList.currentIndex = parent.index
+                optionList.selectCurrent()
+              }
             }
           }
         }

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -61,6 +61,46 @@ function nodeProps(node) {
   return node && node.ready && node.properties ? node.properties : {}
 }
 
+function nodeSerial(node) {
+  var serial = nodeProps(node)["object.serial"]
+  return serial === undefined || serial === null ? "" : String(serial)
+}
+
+function streamOutputOptions(outputs, defaultOutput) {
+  var values = Array.isArray(outputs) ? outputs : []
+  var options = []
+  var defaultSerial = nodeSerial(defaultOutput)
+
+  for (var i = 0; i < values.length; i++) {
+    var candidate = values[i]
+    var serial = nodeSerial(candidate)
+    if (serial !== "" && serial === defaultSerial) {
+      options.push({ value: "default:" + serial, label: "Follow default output" })
+      options.push({ value: "override:" + serial, label: "Pin to " + nodeLabel(candidate) })
+      break
+    }
+  }
+
+  for (var j = 0; j < values.length; j++) {
+    var output = values[j]
+    var outputSerial = nodeSerial(output)
+    if (outputSerial === "" || outputSerial === defaultSerial) continue
+    options.push({ value: "override:" + outputSerial, label: nodeLabel(output) })
+  }
+  return options
+}
+
+function parseStreamOutputOption(value) {
+  var text = String(value || "")
+  var separator = text.indexOf(":")
+  if (separator < 1) return { mode: "", sink: "" }
+  var mode = text.substring(0, separator)
+  var sink = text.substring(separator + 1)
+  if ((mode !== "default" && mode !== "override") || !/^\d+$/.test(sink))
+    return { mode: "", sink: "" }
+  return { mode: mode, sink: sink }
+}
+
 function nodeLabel(node) {
   if (!node) return "Unknown"
   var p = nodeProps(node)
@@ -242,6 +282,9 @@ if (typeof module !== "undefined") {
     parseSinkAvailability: parseSinkAvailability,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
+    nodeSerial: nodeSerial,
+    streamOutputOptions: streamOutputOptions,
+    parseStreamOutputOption: parseStreamOutputOption,
     nodeLabel: nodeLabel,
     isHeadphones: isHeadphones,
     sinkGlyph: sinkGlyph,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -109,6 +109,21 @@ Panel {
   property var displayAudioSources: []
   property var displayAudioStreams: []
 
+  // Per-application routing is separate from the preferred default sink.
+  // pactl and Quickshell expose the same PipeWire object.serial values, so
+  // this map is exact even when several applications share a display name.
+  property var streamRoutes: ({})
+  property bool streamOutputMenuOpen: false
+  property string streamRouteReadError: ""
+  property string streamRouteSetError: ""
+  readonly property string streamRouteError: streamRouteSetError !== ""
+    ? streamRouteSetError : streamRouteReadError
+  property var pendingStreamRoute: null
+
+  // The default is ordered first and named by behavior. Applications on that
+  // option follow later default changes; all other routes stay on their device.
+  readonly property var streamOutputOptions: Model.streamOutputOptions(displayAudioSinks, sink)
+
   // A DSP sink -- a speaker tuning, or EasyEffects -- can be the selected output
   // without being where loudness lives: changing its volume alters the level going
   // *into* the processing, so the slider would move while the speakers did not,
@@ -302,8 +317,12 @@ Panel {
       return
     }
     if (focusSection === "streams" && selectedIndex >= 0) {
-      var st = displayAudioStreams[selectedIndex]
-      if (st && st.audio) st.audio.muted = !st.audio.muted
+      var row = streamRepeater.itemAt(selectedIndex)
+      if (row && displayAudioSinks.length > 1) row.toggleOutputMenu()
+      else {
+        var st = displayAudioStreams[selectedIndex]
+        if (st && st.audio) st.audio.muted = !st.audio.muted
+      }
     }
   }
 
@@ -315,6 +334,7 @@ Panel {
       cursorActive = false
       Qt.callLater(resetScroll)
     } else {
+      streamOutputMenuOpen = false
       clearDisplayAudioModels()
     }
   }
@@ -333,6 +353,7 @@ Panel {
     displayAudioSinks = listSnapshot(audioSinks)
     displayAudioSources = listSnapshot(audioSources)
     displayAudioStreams = listSnapshot(audioStreams)
+    refreshStreamRoutes()
     clampCursor()
   }
 
@@ -346,6 +367,67 @@ Panel {
     displayAudioSinks = []
     displayAudioSources = []
     displayAudioStreams = []
+    streamRoutes = ({})
+    streamRouteReadError = ""
+    streamRouteSetError = ""
+    pendingStreamRoute = null
+  }
+
+  function refreshStreamRoutes() {
+    if (!opened || displayAudioStreams.length === 0 || streamRoutesProc.running) return
+    streamRoutesProc.running = true
+  }
+
+  function updateStreamRoutes(raw) {
+    try {
+      var routes = JSON.parse(String(raw || "{}"))
+      if (!routes || typeof routes !== "object") routes = ({})
+      if (pendingStreamRoute)
+        routes[pendingStreamRoute.stream] = {
+          sink: pendingStreamRoute.sink,
+          mode: pendingStreamRoute.mode
+        }
+      streamRoutes = routes
+      streamRouteReadError = ""
+    } catch (e) {
+      streamRoutes = ({})
+      streamRouteReadError = "Could not read application outputs"
+    }
+  }
+
+  function streamSerial(node) {
+    return Model.nodeSerial(node)
+  }
+
+  function streamRoute(node) {
+    var serial = streamSerial(node)
+    if (serial === "") return null
+    var route = streamRoutes[serial]
+    return route && typeof route === "object" ? route : null
+  }
+
+  function setStreamRoute(node, optionValue) {
+    var streamSerialValue = streamSerial(node)
+    var route = Model.parseStreamOutputOption(optionValue)
+    if (streamSerialValue === "" || route.sink === "" || route.mode === "" || streamRouteSetProc.running) return
+
+    var next = ({})
+    for (var key in streamRoutes) next[key] = streamRoutes[key]
+    next[streamSerialValue] = { sink: route.sink, mode: route.mode }
+    streamRoutes = next
+    streamRouteSetError = ""
+    pendingStreamRoute = {
+      stream: streamSerialValue,
+      sink: route.sink,
+      mode: route.mode
+    }
+    streamRouteSetProc.command = [
+      "omarchy-audio-stream-route-set",
+      streamSerialValue,
+      route.sink,
+      route.mode
+    ]
+    streamRouteSetProc.running = true
   }
 
   // Keep the keyboard-focused row inside the visible viewport of the
@@ -462,12 +544,14 @@ Panel {
 
   function setDefaultSink(node) {
     if (!node) return
+    var previousSinkName = sink && sink.name ? String(sink.name) : ""
     Pipewire.preferredDefaultAudioSink = node
     if (node.id !== undefined && node.name) {
       Quickshell.execDetached([
         "omarchy-audio-output-set-default",
         String(node.id),
-        String(node.name)
+        String(node.name),
+        previousSinkName
       ])
     }
   }
@@ -601,6 +685,29 @@ Panel {
     }
   }
 
+  Process {
+    id: streamRoutesProc
+    command: ["omarchy-audio-stream-routes"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateStreamRoutes(text)
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0 && root.opened && root.displayAudioStreams.length > 0)
+        root.streamRouteReadError = "Could not read application outputs"
+    }
+  }
+
+  Process {
+    id: streamRouteSetProc
+    onExited: function(exitCode) {
+      if (exitCode !== 0) root.streamRouteSetError = "Could not change the application output"
+      else root.streamRouteSetError = ""
+      root.pendingStreamRoute = null
+      streamRouteRefreshTimer.restart()
+    }
+  }
+
   Timer {
     interval: 5000
     running: root.opened
@@ -625,6 +732,21 @@ Panel {
     interval: 75
     repeat: false
     onTriggered: root.refreshDisplayAudioModels()
+  }
+
+  Timer {
+    id: streamRouteRefreshTimer
+    interval: 150
+    repeat: false
+    onTriggered: root.refreshStreamRoutes()
+  }
+
+  Timer {
+    interval: 1500
+    running: root.opened && root.displayAudioStreams.length > 0
+    repeat: true
+    onTriggered: if (!root.streamOutputMenuOpen && !streamRouteSetProc.running)
+      root.refreshStreamRoutes()
   }
 
   BarIconButton {
@@ -660,6 +782,7 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
+      blocked: root.streamOutputMenuOpen
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) { root.cursorActive = true; return }
         if (dy !== 0) root.moveCursor(dy)
@@ -985,6 +1108,7 @@ Panel {
             }
 
             Repeater {
+              id: streamRepeater
               model: root.displayAudioStreams
 
               StreamRow {
@@ -994,6 +1118,16 @@ Panel {
                 node: modelData
                 rowIndex: index
               }
+            }
+
+            Text {
+              visible: root.streamRouteError !== ""
+              width: parent.width
+              text: root.streamRouteError
+              color: root.bar.urgent
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              wrapMode: Text.WordWrap
             }
           }
         }
@@ -1124,9 +1258,9 @@ Panel {
   }
 
   // Per-app stream row — cursor target inside the "streams" section.
-  // The stream has its own slider inline, so h/l from the keyboard
-  // adjusts THIS stream's volume (not the global output) when the cursor
-  // sits on this row. Enter/Space mutes the stream.
+  // The stream has its own slider inline, so h/l from the keyboard adjusts
+  // THIS stream's volume. With multiple outputs, a compact device button (or
+  // Enter/Space from the row cursor) opens routing; `m` remains direct mute.
   component StreamRow: CursorSurface {
     id: streamRow
     required property var node
@@ -1135,14 +1269,24 @@ Panel {
     readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
     readonly property bool isActive: root.streamRepresentsPlayer(node, root.activeMediaPlayer)
-
+    readonly property string streamSerial: root.streamSerial(node)
+    readonly property var currentRoute: root.streamRoute(node)
+    readonly property string sinkSerial: currentRoute ? String(currentRoute.sink || "") : ""
+    readonly property string routeMode: currentRoute ? String(currentRoute.mode || "") : ""
+    readonly property string routeOptionValue: routeMode !== "" && sinkSerial !== "" ? routeMode + ":" + sinkSerial : ""
+    readonly property bool routeIsExplicit: routeMode === "override"
     hasCursor: root.cursorActive && root.focusSection === "streams" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(streamRow)
-    current: isActive
     foreground: root.bar.foreground
     fill: root.hoverFill
-    currentFill: root.selectedFill
     implicitHeight: streamColumn.implicitHeight + Style.spacing.xl
+
+    function toggleOutputMenu() {
+      if (root.displayAudioSinks.length > 1 && streamRow.sinkSerial !== "" && routeDropdown.enabled)
+        routeDropdown.toggle()
+    }
+
+    Component.onDestruction: if (routeDropdown.popupOpen) root.streamOutputMenuOpen = false
 
     Column {
       id: streamColumn
@@ -1153,53 +1297,140 @@ Panel {
       anchors.rightMargin: Style.space(6)
       spacing: Style.space(2)
 
-      Row {
+      Item {
+        id: streamHeader
         width: parent.width
-        spacing: Style.space(8)
+        height: streamHeaderContent.implicitHeight
 
-        Text {
-          id: streamMuteIcon
-          text: streamRow.streamMuted ? "󰝟" : "󰕾"
-          color: root.bar.foreground
-          font.family: root.bar.fontFamily
-          font.pixelSize: Style.font.title
-          width: Style.space(22)
-          horizontalAlignment: Text.AlignHCenter
-          anchors.verticalCenter: parent.verticalCenter
-          opacity: streamRow.streamMuted ? 0.5 : 1.0
+        Row {
+          id: streamHeaderContent
+          anchors.fill: parent
+          spacing: Style.space(8)
 
-          MouseArea {
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-            onClicked: {
-              if (streamRow.node && streamRow.node.audio)
-                streamRow.node.audio.muted = !streamRow.node.audio.muted
+          Text {
+            id: streamMuteIcon
+            text: streamRow.streamMuted ? "󰝟" : "󰕾"
+            color: root.bar.foreground
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.title
+            width: Style.space(22)
+            horizontalAlignment: Text.AlignHCenter
+            anchors.verticalCenter: parent.verticalCenter
+            opacity: streamRow.streamMuted ? 0.5 : 1.0
+
+            MouseArea {
+              anchors.fill: parent
+              cursorShape: Qt.PointingHandCursor
+              onClicked: {
+                if (streamRow.node && streamRow.node.audio)
+                  streamRow.node.audio.muted = !streamRow.node.audio.muted
+              }
             }
+          }
+
+          Item {
+            id: streamNameArea
+            width: parent.width - streamMuteIcon.width - streamPct.width - Style.space(16)
+            height: Math.max(streamName.implicitHeight, routeChevron.visible ? routeChevron.height : 0)
+
+            Text {
+              id: streamName
+              text: root.streamLabel(streamRow.node)
+              color: root.bar.foreground
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.body
+              font.bold: streamRow.isActive
+              elide: Text.ElideRight
+              width: Math.min(implicitWidth, parent.width
+                - (routeChevron.visible ? routeChevron.width + Style.space(4) : 0))
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Text {
+              id: routeChevron
+              visible: root.displayAudioSinks.length > 1 && streamRow.sinkSerial !== ""
+              width: Style.space(22)
+              text: {
+                var position = root.bar ? root.bar.position : "left"
+                if (position === "top") return "󰅀"
+                if (position === "bottom") return "󰅃"
+                return position === "right" ? "󰅁" : "󰅂"
+              }
+              color: streamRow.routeIsExplicit
+                ? Style.selectedStateColor(root.bar.foreground, Color.accent)
+                : Qt.darker(root.bar.foreground, 1.2)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.body
+              horizontalAlignment: Text.AlignHCenter
+              anchors.left: streamName.right
+              anchors.leftMargin: Style.space(4)
+              anchors.verticalCenter: parent.verticalCenter
+            }
+          }
+
+          Text {
+            id: streamPct
+            text: Math.round(streamRow.streamVolume * 100) + "%"
+            color: Qt.darker(root.bar.foreground, 1.5)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+            width: Style.space(36)
+            horizontalAlignment: Text.AlignRight
+            anchors.verticalCenter: parent.verticalCenter
+            opacity: streamRow.streamMuted ? 0.5 : 1.0
           }
         }
 
-        Text {
-          text: root.streamLabel(streamRow.node)
-          color: root.bar.foreground
-          font.family: root.bar.fontFamily
-          font.pixelSize: Style.font.body
-          font.bold: streamRow.isActive
-          elide: Text.ElideRight
-          width: parent.width - streamMuteIcon.width - streamPct.width - Style.space(16)
-          anchors.verticalCenter: parent.verticalCenter
-        }
+        // Routing is a property of the application, so the dropdown's actual
+        // trigger spans the whole header. Its chrome is hidden: the adjacent
+        // chevron communicates the submenu while the speaker exclusively owns
+        // mute and the slider below continues to own volume changes.
+        Dropdown {
+          id: routeDropdown
+          anchors.left: parent.left
+          anchors.leftMargin: streamMuteIcon.width
+          anchors.right: parent.right
+          anchors.top: parent.top
+          anchors.bottom: parent.bottom
+          z: 1
+          visible: root.displayAudioSinks.length > 1 && streamRow.sinkSerial !== ""
+          rowHeight: height
+          popupRowHeight: Style.space(34)
+          popupDirection: {
+            var position = root.bar ? root.bar.position : "left"
+            if (position === "top") return "down"
+            if (position === "bottom") return "up"
+            return position === "right" ? "left" : "right"
+          }
+          popupGap: popupDirection === "left"
+            ? Style.space(6) + streamMuteIcon.width
+            : (popupDirection === "right" ? Style.space(6) : Style.spacing.xxs)
+          popupOffsetX: popupDirection === "down" || popupDirection === "up"
+            ? -Style.space(6) - streamMuteIcon.width : 0
+          popupSideAlignment: "center"
+          popupAnchorHeight: streamColumn.height
+          popupWidth: streamRow.width
+          chevronOnly: true
+          showChevron: false
+          triggerChrome: false
+          value: streamRow.routeOptionValue
+          options: root.streamOutputOptions
+          enabled: streamRow.streamSerial !== "" && !streamRouteSetProc.running
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
 
-        Text {
-          id: streamPct
-          text: Math.round(streamRow.streamVolume * 100) + "%"
-          color: Qt.darker(root.bar.foreground, 1.5)
-          font.family: root.bar.fontFamily
-          font.pixelSize: Style.font.caption
-          font.bold: true
-          width: Style.space(36)
-          horizontalAlignment: Text.AlignRight
-          anchors.verticalCenter: parent.verticalCenter
-          opacity: streamRow.streamMuted ? 0.5 : 1.0
+          onHovered: function(on) { if (on) {
+            root.cursorActive = true
+            root.focusSection = "streams"
+            root.selectedIndex = streamRow.rowIndex
+          } }
+          onChanged: function(route) { root.setStreamRoute(streamRow.node, route) }
+          onPopupOpenChanged: {
+            root.streamOutputMenuOpen = popupOpen
+            if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+          }
         }
       }
 

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -24,6 +24,24 @@ assertEqual(
   'Microphone',
   'audio chooses friendly node labels'
 )
+assertEqual(audio.nodeSerial({ ready: true, properties: { 'object.serial': 384 } }), '384', 'audio reads PipeWire object serials')
+assertEqual(audio.nodeSerial({ ready: false, properties: { 'object.serial': 384 } }), '', 'audio ignores unbound PipeWire object serials')
+const defaultOutput = { ready: true, properties: { 'object.serial': 85, 'node.nick': 'Laptop Speakers' } }
+const routedOutput = { ready: true, properties: { 'object.serial': 91, 'node.nick': 'USB Headset' } }
+const hdmiOutput = { ready: true, properties: { 'object.serial': 120, 'node.nick': 'HDMI Display' } }
+assertDeepEqual(
+  audio.streamOutputOptions([routedOutput, defaultOutput, hdmiOutput], defaultOutput),
+  [
+    { value: 'default:85', label: 'Follow default output' },
+    { value: 'override:85', label: 'Pin to Laptop Speakers' },
+    { value: 'override:91', label: 'USB Headset' },
+    { value: 'override:120', label: 'HDMI Display' }
+  ],
+  'audio distinguishes following from pinning to the current default'
+)
+assertDeepEqual(audio.parseStreamOutputOption('default:85'), { mode: 'default', sink: '85' }, 'audio parses a default-following route')
+assertDeepEqual(audio.parseStreamOutputOption('override:91'), { mode: 'override', sink: '91' }, 'audio parses an explicit route')
+assertDeepEqual(audio.parseStreamOutputOption('speaker'), { mode: '', sink: '' }, 'audio rejects malformed route options')
 
 const headphones = { ready: true, name: 'bluez_output.airpods', properties: { 'device.product.name': 'AirPods Headphones' } }
 assert(audio.isHeadphones(headphones), 'audio detects headphone devices')
@@ -47,3 +65,130 @@ assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spo
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
 JS
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+cat >"$tmp_dir/sink-inputs.json" <<'JSON'
+[
+  {"index": 384, "sink": 85, "properties": {"application.name": "Spotify", "object.id": 102}},
+  {"index": 512, "sink": 91, "properties": {"application.name": "Browser", "object.id": 103}},
+  {"index": 513, "sink": 85, "properties": {"application.name": "Pinned", "object.id": 106}},
+  {"index": 514, "sink": 85, "properties": {"application.name": "Legacy"}},
+  {"index": 600, "sink": 85, "properties": {"application.name": "EasyEffects", "object.id": 104}},
+  {"index": 700, "sink": 85, "properties": {"object.id": 105}}
+]
+JSON
+
+cat >"$tmp_dir/sinks.json" <<'JSON'
+[
+  {"index": 85, "name": "old-default", "properties": {"object.id": 201}},
+  {"index": 91, "name": "new-default", "properties": {"object.id": 202}}
+]
+JSON
+
+cat >"$tmp_dir/bin/pactl" <<'EOF'
+#!/bin/bash
+
+if [[ $1 == "-f" && $2 == "json" && $3 == "list" ]]; then
+  case "$4" in
+    sink-inputs) cat "$AUDIO_SINK_INPUTS_FIXTURE" ;;
+    sinks) cat "$AUDIO_SINKS_FIXTURE" ;;
+    *) exit 1 ;;
+  esac
+elif [[ $1 == "get-default-sink" ]]; then
+  printf '%s\n' "${AUDIO_DEFAULT_SINK:-old-default}"
+elif [[ $1 == "set-default-sink" ]]; then
+  printf '<%s>\n' "$@" >>"$AUDIO_CALLS_LOG"
+elif [[ $1 == "move-sink-input" ]]; then
+  printf '<%s>\n' "$@" >>"$AUDIO_CALLS_LOG"
+  [[ ${AUDIO_MOVE_FAIL:-0} == "0" ]]
+else
+  exit 1
+fi
+EOF
+chmod +x "$tmp_dir/bin/pactl"
+
+cat >"$tmp_dir/bin/wpctl" <<'EOF'
+#!/bin/bash
+
+printf '<wpctl:%s>\n' "$*" >>"$AUDIO_CALLS_LOG"
+EOF
+chmod +x "$tmp_dir/bin/wpctl"
+
+cat >"$tmp_dir/bin/pw-metadata" <<'EOF'
+#!/bin/bash
+
+if [[ $# == 2 && $1 == "-n" && $2 == "default" ]]; then
+  [[ ${AUDIO_METADATA_READ_FAIL:-0} == "0" ]] || exit 1
+  cat <<'METADATA'
+update: id:102 key:'target.object' value:'-1' type:'Spa:Id'
+update: id:102 key:'target.node' value:'-1' type:'Spa:Id'
+update: id:103 key:'target.object' value:'91' type:'Spa:Id'
+update: id:106 key:'target.object' value:'85' type:'Spa:Id'
+METADATA
+else
+  printf '<pw-metadata:%s>\n' "$*" >>"$AUDIO_CALLS_LOG"
+fi
+EOF
+chmod +x "$tmp_dir/bin/pw-metadata"
+
+export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
+export AUDIO_SINK_INPUTS_FIXTURE="$tmp_dir/sink-inputs.json"
+export AUDIO_SINKS_FIXTURE="$tmp_dir/sinks.json"
+export AUDIO_CALLS_LOG="$tmp_dir/calls"
+export AUDIO_DEFAULT_SINK=new-default
+
+"$ROOT/bin/omarchy-audio-output-set-default" 91 new-default old-default
+rg -Fx '<384>' "$AUDIO_CALLS_LOG" >/dev/null || fail "default output moves streams following the old default"
+rg -Fx '<514>' "$AUDIO_CALLS_LOG" >/dev/null || fail "default output handles streams without PipeWire object metadata"
+if rg -Fx '<512>' "$AUDIO_CALLS_LOG" >/dev/null; then
+  fail "default output preserves explicit application routes"
+fi
+if rg -Fx '<513>' "$AUDIO_CALLS_LOG" >/dev/null; then
+  fail "default output preserves an explicit route on the old default"
+fi
+if rg -Fx '<600>' "$AUDIO_CALLS_LOG" >/dev/null; then
+  fail "default output leaves the EasyEffects processing stream in place"
+fi
+pass "default output preserves per-application routes"
+: >"$AUDIO_CALLS_LOG"
+
+AUDIO_METADATA_READ_FAIL=1 "$ROOT/bin/omarchy-audio-output-set-default" 91 new-default old-default
+if rg -Fx '<move-sink-input>' "$AUDIO_CALLS_LOG" >/dev/null; then
+  fail "default output moves streams when explicit-route metadata is unavailable"
+fi
+pass "default output fails safe when explicit routes cannot be read"
+: >"$AUDIO_CALLS_LOG"
+
+routes=$("$ROOT/bin/omarchy-audio-stream-routes")
+[[ $(jq -r '.["384"].sink' <<<"$routes") == "85" ]] || fail "audio stream routes map an application serial to its sink serial"
+[[ $(jq -r '.["384"].mode' <<<"$routes") == "default" ]] || fail "audio stream routes identify default-following applications"
+[[ $(jq -r '.["512"].sink' <<<"$routes") == "91" ]] || fail "audio stream routes preserve multiple live routes"
+[[ $(jq -r '.["512"].mode' <<<"$routes") == "override" ]] || fail "audio stream routes identify explicit application outputs"
+"$ROOT/bin/omarchy-audio-stream-route-set" 384 85
+rg -Fx '<move-sink-input>' "$AUDIO_CALLS_LOG" >/dev/null || fail "audio stream route setter calls pactl"
+rg -Fx '<384>' "$AUDIO_CALLS_LOG" >/dev/null || fail "audio stream route setter preserves the stream serial"
+rg -Fx '<85>' "$AUDIO_CALLS_LOG" >/dev/null || fail "audio stream route setter preserves the sink serial"
+rg -Fx '<pw-metadata:-n default -- 102 target.object 85 Spa:Id>' "$AUDIO_CALLS_LOG" >/dev/null ||
+  fail "pinning to the current sink writes its serial as an explicit target object"
+rg -Fx '<pw-metadata:-n default -- 102 target.node 201 Spa:Id>' "$AUDIO_CALLS_LOG" >/dev/null ||
+  fail "pinning to the current sink writes its object id as an explicit target node"
+: >"$AUDIO_CALLS_LOG"
+if AUDIO_MOVE_FAIL=1 "$ROOT/bin/omarchy-audio-stream-route-set" 384 91; then
+  fail "audio stream route setter hides a failed move"
+fi
+: >"$AUDIO_CALLS_LOG"
+"$ROOT/bin/omarchy-audio-stream-route-set" 384 85 default
+rg -Fx '<pw-metadata:-n default -- 102 target.object -1 Spa:Id>' "$AUDIO_CALLS_LOG" >/dev/null ||
+  fail "choosing the default output clears the explicit target object"
+rg -Fx '<pw-metadata:-n default -- 102 target.node -1 Spa:Id>' "$AUDIO_CALLS_LOG" >/dev/null ||
+  fail "choosing the default output clears the explicit target node"
+if "$ROOT/bin/omarchy-audio-stream-route-set" spotify speakers >/dev/null 2>&1; then
+  fail "audio stream route setter rejects non-serial identifiers"
+fi
+if AUDIO_METADATA_READ_FAIL=1 "$ROOT/bin/omarchy-audio-stream-routes" >/dev/null 2>&1; then
+  fail "audio stream route reader treats missing target metadata as default-following"
+fi
+pass "audio stream routes are read, changed, and validated"


### PR DESCRIPTION
## Summary

- add an output selector to each live application stream when multiple outputs are available
- let applications either follow the system default or remain pinned to a selected output
- preserve explicit application routes when the global default output changes
- support pointer and keyboard interaction with placement matching every bar edge

## Why

Quattro moved stream naming and routing from Wiremix into the native audio panel. The native panel already identifies live application streams and controls their volume, but output selection is currently global: sending one application to another output still requires a terminal command or an external mixer.

This completes that native routing path without cluttering the quick panel. The control only appears when more than one output is available, and the existing controls keep their dedicated behavior:

- the speaker icon mutes the application
- the slider controls its volume
- clicking the application source box—apart from the mute button and volume slider—opens its output menu

Choosing **Follow default output** makes the stream follow future default-output changes. Choosing a named output pins that application to the device instead.

## Implementation

Application streams are mapped to their current sinks through PipeWire object serials rather than display-name matching. PipeWire target metadata distinguishes explicit routes from streams following the default, including the otherwise ambiguous case where an application is explicitly pinned to the current default device.

When the system default changes, only application streams following the previous default are moved. Explicit routes, EasyEffects, and non-application processing streams remain in place.

The output popup opens away from the bar, mirrors correctly between left and right layouts, stays within the display bounds, and supports up to eight visible entries before scrolling. The active player remains bold, while the row fill is reserved for pointer or keyboard focus so routing focus stays unambiguous.

## Preview
<img width="655" height="401" alt="image" src="https://github.com/user-attachments/assets/dc1d4b4c-5ae7-49a1-b2b6-3e3c90dcdd7a" />


## Verification

- `bash test/shell.d/audio-test.sh`
- `./test/cli`
- `qmllint -I shell shell/Ui/Dropdown.qml`
- manually tested routing, pinning, and following the default with two and three physical outputs
- manually tested pointer and keyboard selection across side and top bar layouts
