### PR TITLE
Keep the lock blank from turning the display off (DPMS link-drop crash)

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -16,6 +16,11 @@ Item {
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
 
+  // The lock blank only dims the keyboard backlight. Blanking the display
+  // (Hyprland DPMS-off) makes some monitors drop their link, tearing the
+  // output out from under the lock surface and killing the shell while it
+  // holds the session lock; the lock screen already covers the desktop, and
+  // real display-off still happens at suspend/lid-close.
   property bool lockRequested: false
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
@@ -368,7 +373,7 @@ Item {
 
   Process {
     id: blankProcess
-    command: ["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"]
+    command: ["bash", "-c", "omarchy-brightness-keyboard off"]
   }
 
   Timer {


### PR DESCRIPTION
## Summary

Follow-up to #6628 / #6630. The lock screen blanks the display after locking via `hyprctl dpms disable`, and on some monitors (notably over HDMI) DPMS-off makes the connector physically drop — aquamarine tears the output down under the lock surface, Quickshell hits an EGL fatal (`Could not create EGL surface … Invalid argument`) and the whole shell exits **while still holding ext-session-lock**, forcing a reboot.

This ships the DPMS-off workaround as a config option rather than a hardcoded change:

- `lock.displayBlank` (default `true` = unchanged behavior).
- Setting it to `false` keeps the keyboard blank but skips the display off.

Verified live on an affected system (Lenovo L24q over HDMI, i915): with `lock.displayBlank: false`, a full lock → blank-window → unlock cycle produces **0 connector disconnects** and the shell survives (previously a reproducible DPMS drop + crash every lock).

## Scope

The root cause is upstream (Hyprland/aquamarine escalating DPMS-off into a full disconnect; Quickshell qFataling on lock-surface output loss — quickshell #61/#76 family). `allow_session_lock_restore` + journal-persisted shell log + dead-lock restart recovery are handled by #6630. This PR is the omarchy-owned user-facing mitigation so affected setups stop forcing reboots.

## Notes

`shell.json` is canonical with no deep-merge, so a config lacking the `lock` key keeps the `true` default (verified against the QML resolution).
