### PR TITLE
Guard theme commands against path traversal

### DIFF
--- a/bin/omarchy-plymouth-set-by-theme
+++ b/bin/omarchy-plymouth-set-by-theme
@@ -14,6 +14,13 @@ fi
 
 theme=$1
 
+# Theme names are simple file names; reject anything that could walk out of
+# the themes directories before it reaches the sudo omarchy-plymouth-set.
+if [[ ! $theme =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Error: invalid theme name '$theme'." >&2
+  exit 1
+fi
+
 theme_dir=$(omarchy-theme-dir "$theme")
 
 theme_color() {

--- a/bin/omarchy-theme-remove
+++ b/bin/omarchy-theme-remove
@@ -19,12 +19,20 @@ else
 fi
 
 THEMES_DIR="$HOME/.config/omarchy/themes"
-THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
 # Ensure a theme was set
 if [[ -z $THEME_NAME ]]; then
   exit 1
 fi
+
+# Theme names are simple file names; reject anything that could walk out of
+# the themes directory (.. or path separators) before it reaches rm -rf.
+if [[ ! $THEME_NAME =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Error: invalid theme name '$THEME_NAME'." >&2
+  exit 1
+fi
+
+THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
 # Check if theme exists before attempting removal
 if [[ ! -d $THEME_PATH ]]; then

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -128,6 +128,14 @@ if [[ ${OMARCHY_THEME_HEADLESS:-} == "1" || ${OMARCHY_THEME_OFFLINE:-} == "1" ]]
   THEME_HEADLESS=1
 fi
 
+# Theme names are simple file names; reject anything that could walk out of
+# the themes directories (.. or path separators) before it reaches the
+# cp -r into next-theme and the rm -rf of current.
+if [[ ! $THEME_NAME =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Error: invalid theme name '$THEME_NAME'." >&2
+  exit 1
+fi
+
 if [[ ! -d $OMARCHY_THEMES_PATH/$THEME_NAME ]] && [[ ! -d $USER_THEMES_PATH/$THEME_NAME ]]; then
   echo "Theme '$THEME_NAME' does not exist"
   exit 1

--- a/test/cli
+++ b/test/cli
@@ -482,6 +482,55 @@ expected_background="$THEME_TMPDIR/.local/state/omarchy/current/theme/background
 [[ ! -e $THEME_TMPDIR/.config/omarchy/current ]] || fail "headless theme set avoids config current state"
 pass "headless theme set creates current background symlink"
 
+# Theme names are validated as simple file names so a `..` argument cannot walk
+# out of the themes directory and rm -rf / cp -r the user's config.
+TRAVERSAL_THEME_HOME="$PI_TMPDIR/traversal-home"
+mkdir -p "$TRAVERSAL_THEME_HOME/.config/omarchy/themes"
+mkdir -p "$TRAVERSAL_THEME_HOME/.local/state/omarchy/current/theme"
+printf 'marker\n' >"$TRAVERSAL_THEME_HOME/.config/omarchy/themes/keep.txt"
+printf 'marker\n' >"$TRAVERSAL_THEME_HOME/.local/state/omarchy/current/theme/keep.txt"
+
+if HOME="$TRAVERSAL_THEME_HOME" "$ROOT/bin/omarchy-theme-remove" .. >/dev/null 2>&1; then
+  fail "theme remove rejects .. traversal"
+fi
+[[ -f $TRAVERSAL_THEME_HOME/.config/omarchy/themes/keep.txt ]] || fail "theme remove .. does not delete the themes directory"
+pass "theme remove rejects .. traversal"
+
+if HOME="$TRAVERSAL_THEME_HOME" "$ROOT/bin/omarchy-theme-remove" ../.. >/dev/null 2>&1; then
+  fail "theme remove rejects ../.. traversal"
+fi
+[[ -f $TRAVERSAL_THEME_HOME/.config/omarchy/themes/keep.txt ]] || fail "theme remove ../.. does not delete the config tree"
+pass "theme remove rejects ../.. traversal"
+
+if HOME="$TRAVERSAL_THEME_HOME" "$ROOT/bin/omarchy-theme-remove" . >/dev/null 2>&1; then
+  fail "theme remove rejects the current directory"
+fi
+[[ -f $TRAVERSAL_THEME_HOME/.config/omarchy/themes/keep.txt ]] || fail "theme remove . does not delete the themes directory"
+pass "theme remove rejects the current directory"
+
+if HOME="$TRAVERSAL_THEME_HOME" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" .. >/dev/null 2>&1; then
+  fail "theme set rejects .. traversal"
+fi
+[[ ! -e $TRAVERSAL_THEME_HOME/.local/state/omarchy/current/next-theme ]] || fail "theme set .. does not create a next-theme"
+[[ -f $TRAVERSAL_THEME_HOME/.local/state/omarchy/current/theme/keep.txt ]] || fail "theme set .. does not replace the current theme"
+pass "theme set rejects .. traversal"
+
+if HOME="$TRAVERSAL_THEME_HOME" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "../.." >/dev/null 2>&1; then
+  fail "theme set rejects ../.. traversal"
+fi
+[[ -f $TRAVERSAL_THEME_HOME/.config/omarchy/themes/keep.txt ]] || fail "theme set ../.. does not touch the config tree"
+pass "theme set rejects ../.. traversal"
+
+# plymouth-set-by-theme feeds the name through omarchy-theme-dir into a sudo
+# write; it must reject traversal names too.
+if HOME="$TRAVERSAL_THEME_HOME" "$ROOT/bin/omarchy-plymouth-set-by-theme" .. >/dev/null 2>&1; then
+  fail "plymouth-set-by-theme rejects .. traversal"
+fi
+if HOME="$TRAVERSAL_THEME_HOME" "$ROOT/bin/omarchy-plymouth-set-by-theme" ../.. >/dev/null 2>&1; then
+  fail "plymouth-set-by-theme rejects ../.. traversal"
+fi
+pass "plymouth-set-by-theme rejects traversal names"
+
 MIGRATION_TMPDIR=$(mktemp -d)
 mkdir -p \
   "$MIGRATION_TMPDIR/.config/omarchy/current/theme" \


### PR DESCRIPTION
`omarchy theme remove` interpolates the theme name straight into an `rm -rf`:

```bash
THEME_PATH="$THEMES_DIR/$THEME_NAME"
rm -rf "$THEME_PATH"
```

An unvalidated name like `..` resolves to `~/.config`, so `omarchy theme remove ..` deletes the user's entire `~/.config/omarchy` directory. `omarchy theme set` and `omarchy-plymouth-set-by-theme` have the same hole, walking out of the themes directories into `cp -r` and a `sudo omarchy-plymouth-set` call.

Reject any name that isn't a plain file name — `^[A-Za-z0-9][A-Za-z0-9._-]*$` — before a destructive path is reached, matching the existing `valid_plugin_id` guard in the plugin commands. No legitimate theme is named `..`, so this only blocks garbage.

Added regression tests for `theme remove ..`/`../..`/`.`, `theme set ..`/`../..`, and `plymouth-set-by-theme ..`/`../..`; `./test/cli` passes 108 tests.