### PR TITLE
Add Hermes usage to agents monitor

### DIFF
--- a/bin/omarchy-agent-usage-hermes
+++ b/bin/omarchy-agent-usage-hermes
@@ -1,0 +1,398 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Hermes usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Hermes model usage into one display-ready JSON record.
+
+Hermes can switch providers and models inside one session, and auxiliary
+tasks can use a different route from the main agent. Read its SQLite usage
+ledger directly so the Omarchy agents panel preserves that attribution.
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+AGENT_ID = "hermes"
+AGENT_NAME = "Hermes"
+BUCKET_FIELDS = {
+  "input_tokens": "inputTokens",
+  "output_tokens": "outputTokens",
+  "cache_read_tokens": "cacheReadInputTokens",
+  "cache_write_tokens": "cacheCreationInputTokens",
+}
+
+LABEL_HELPER = r"""
+import json
+import sys
+
+from agent.models_dev import PROVIDER_TO_MODELS_DEV, fetch_models_dev
+from hermes_cli.models import provider_label
+
+routes = json.load(sys.stdin)
+catalog = fetch_models_dev(allow_network=False)
+labels = {}
+for route in routes:
+  key = str(route.get("key") or "")
+  provider = str(route.get("provider") or "unknown")
+  model = str(route.get("model") or "unknown")
+  provider_name = provider_label(provider) or provider
+  model_name = model
+
+  catalog_provider = PROVIDER_TO_MODELS_DEV.get(provider.lower(), provider.lower())
+  provider_data = catalog.get(catalog_provider)
+  models = provider_data.get("models") if isinstance(provider_data, dict) else None
+  if isinstance(models, dict):
+    model_data = models.get(model)
+    if not isinstance(model_data, dict):
+      lowered = model.lower()
+      model_data = next(
+        (value for model_id, value in models.items()
+         if str(model_id).lower() == lowered and isinstance(value, dict)),
+        None,
+      )
+    if isinstance(model_data, dict):
+      model_name = str(model_data.get("name") or model)
+
+  labels[key] = {"provider": provider_name, "model": model_name}
+
+json.dump(labels, sys.stdout, separators=(",", ":"))
+"""
+
+
+def number(value):
+  try:
+    return max(0, int(value or 0))
+  except (TypeError, ValueError):
+    return 0
+
+
+def local_day(value):
+  try:
+    return datetime.fromtimestamp(float(value)).astimezone().strftime("%Y-%m-%d")
+  except (TypeError, ValueError, OSError, OverflowError):
+    return ""
+
+
+def empty_bucket():
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def route_key(provider, model):
+  provider_id = str(provider or "unknown").strip() or "unknown"
+  model_id = str(model or "unknown").strip() or "unknown"
+  return f"{provider_id}::{model_id}", provider_id, model_id
+
+
+def hermes_runtime():
+  hermes_home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+  candidates = []
+  if os.environ.get("HERMES_INSTALL_DIR"):
+    candidates.append(Path(os.environ["HERMES_INSTALL_DIR"]))
+  candidates.extend([
+    hermes_home / "hermes-agent",
+    Path.home() / ".hermes" / "hermes-agent",
+    Path("/usr/local/lib/hermes-agent"),
+  ])
+
+  seen = set()
+  for root in candidates:
+    try:
+      resolved = root.resolve()
+    except OSError:
+      resolved = root
+    if resolved in seen:
+      continue
+    seen.add(resolved)
+    for environment in ("venv", ".venv"):
+      python = root / environment / "bin" / "python"
+      if python.is_file() and os.access(python, os.X_OK):
+        return root, python
+  return None, None
+
+
+def route_labels(routes):
+  fallback = {
+    key: {"provider": provider, "model": model}
+    for key, (provider, model) in routes.items()
+  }
+  if not routes:
+    return fallback
+
+  root, python = hermes_runtime()
+  if root is None or python is None:
+    return fallback
+
+  payload = [
+    {"key": key, "provider": provider, "model": model}
+    for key, (provider, model) in routes.items()
+  ]
+  env = os.environ.copy()
+  env.pop("PYTHONHOME", None)
+  env.pop("PYTHONPATH", None)
+  try:
+    result = subprocess.run(
+      [str(python), "-c", LABEL_HELPER],
+      cwd=root,
+      env=env,
+      input=json.dumps(payload),
+      text=True,
+      capture_output=True,
+      timeout=5,
+      check=False,
+    )
+    if result.returncode != 0:
+      return fallback
+    resolved = json.loads(result.stdout)
+  except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+    return fallback
+
+  if not isinstance(resolved, dict):
+    return fallback
+  for key, label in resolved.items():
+    if key not in fallback or not isinstance(label, dict):
+      continue
+    provider = str(label.get("provider") or "").strip()
+    model = str(label.get("model") or "").strip()
+    if provider:
+      fallback[key]["provider"] = provider
+    if model:
+      fallback[key]["model"] = model
+  return fallback
+
+
+def state_paths():
+  hermes_home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+  candidates = [hermes_home / "state.db"]
+
+  # Hermes intentionally anchors named profiles under ~/.hermes regardless
+  # of HERMES_HOME, so profile discovery must do the same.
+  profiles_root = Path.home() / ".hermes" / "profiles"
+  if profiles_root.is_dir():
+    candidates.extend(path / "state.db" for path in profiles_root.iterdir() if path.is_dir())
+
+  paths = []
+  seen = set()
+  for candidate in candidates:
+    try:
+      resolved = candidate.resolve()
+    except OSError:
+      resolved = candidate
+    if resolved in seen or not candidate.is_file():
+      continue
+    seen.add(resolved)
+    paths.append(candidate)
+  return sorted(paths, key=lambda path: str(path))
+
+
+def table_columns(conn, table):
+  try:
+    return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
+  except sqlite3.Error:
+    return set()
+
+
+def column(columns, name, fallback):
+  return f'"{name}"' if name in columns else fallback
+
+
+class Usage:
+  def __init__(self):
+    now = datetime.now()
+    self.today = now.strftime("%Y-%m-%d")
+    self.recent_dates = [
+      (now - timedelta(days=offset)).strftime("%Y-%m-%d")
+      for offset in range(6, -1, -1)
+    ]
+    self.recent = {day: 0 for day in self.recent_dates}
+    self.model_usage = {}
+    self.today_tokens = {}
+    self.total_sessions = set()
+    self.today_sessions = set()
+    self.active_dates = set()
+    self.providers = set()
+    self.models = set()
+    self.routes = {}
+
+  def add(self, day, session_key, provider, model, tokens):
+    total = sum(tokens.values())
+    if total <= 0:
+      return
+
+    key, provider_id, model_id = route_key(provider, model)
+    bucket = self.model_usage.setdefault(key, empty_bucket())
+    for source, target in BUCKET_FIELDS.items():
+      bucket[target] += number(tokens.get(source))
+
+    self.providers.add(provider_id)
+    self.models.add(model_id)
+    self.routes[key] = (provider_id, model_id)
+    self.total_sessions.add(session_key)
+    if day:
+      self.active_dates.add(day)
+    if day in self.recent:
+      self.recent[day] += total
+    if day == self.today:
+      self.today_sessions.add(session_key)
+      self.today_tokens[key] = self.today_tokens.get(key, 0) + total
+
+  def record(self, has_databases):
+    model_usage = {key: self.model_usage[key] for key in sorted(self.model_usage)}
+    today_tokens = {key: self.today_tokens[key] for key in sorted(self.today_tokens)}
+    today_total = sum(today_tokens.values())
+    tier = ""
+    if self.model_usage:
+      provider_count = len(self.providers)
+      model_count = len(self.models)
+      tier = (
+        f"{provider_count} provider{'s' if provider_count != 1 else ''}"
+        f" · {model_count} model{'s' if model_count != 1 else ''}"
+      )
+
+    return {
+      "schemaVersion": 1,
+      "id": AGENT_ID,
+      "name": AGENT_NAME,
+      "updatedAt": datetime.now(timezone.utc).isoformat(),
+      "ready": has_databases,
+      "hasLocalStats": has_databases,
+      "hasPromptStats": False,
+      "tierLabel": tier,
+      "limits": [],
+      "todayPrompts": 0,
+      "todaySessions": len(self.today_sessions),
+      "todayTotalTokens": today_total,
+      "todayTokensByModel": today_tokens,
+      "modelLabels": route_labels(self.routes),
+      "recentDays": [
+        {"date": day, "messageCount": self.recent[day]}
+        for day in self.recent_dates
+      ],
+      "totalPrompts": 0,
+      "totalSessions": len(self.total_sessions),
+      "activeDays": len(self.active_dates),
+      "activeDates": sorted(self.active_dates),
+      "modelUsage": model_usage,
+    }
+
+
+def scan_database(path, usage):
+  try:
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
+  except (OSError, sqlite3.Error) as exc:
+    print(f"Ignoring unreadable Hermes database {path}: {exc}", file=sys.stderr)
+    return
+
+  conn.row_factory = sqlite3.Row
+  try:
+    conn.execute("PRAGMA query_only = ON")
+    session_columns = table_columns(conn, "sessions")
+    if not {"id", "started_at"}.issubset(session_columns):
+      return
+
+    session_query = f"""
+      SELECT "id" AS id,
+             {column(session_columns, 'model', "'unknown'")} AS model,
+             {column(session_columns, 'billing_provider', "''")} AS billing_provider,
+             "started_at" AS started_at,
+             {column(session_columns, 'input_tokens', '0')} AS input_tokens,
+             {column(session_columns, 'output_tokens', '0')} AS output_tokens,
+             {column(session_columns, 'cache_read_tokens', '0')} AS cache_read_tokens,
+             {column(session_columns, 'cache_write_tokens', '0')} AS cache_write_tokens
+      FROM sessions
+    """
+    sessions = {}
+    database_id = str(path.resolve())
+    for row in conn.execute(session_query):
+      session_id = str(row["id"] or "")
+      if not session_id:
+        continue
+      sessions[session_id] = {
+        "key": database_id + "::" + session_id,
+        "day": local_day(row["started_at"]),
+        "model": row["model"],
+        "provider": row["billing_provider"],
+        "tokens": {field: number(row[field]) for field in BUCKET_FIELDS},
+      }
+
+    # Only main-loop rows participate in residual reconciliation. Auxiliary
+    # rows are absent from sessions totals, so subtracting them would hide
+    # legitimate main-loop usage when vision/compression spend is larger.
+    attributed_main = {
+      session_id: {field: 0 for field in BUCKET_FIELDS}
+      for session_id in sessions
+    }
+
+    model_columns = table_columns(conn, "session_model_usage")
+    if "session_id" in model_columns:
+      model_query = f"""
+        SELECT "session_id" AS session_id,
+               {column(model_columns, 'model', "'unknown'")} AS model,
+               {column(model_columns, 'billing_provider', "''")} AS billing_provider,
+               {column(model_columns, 'task', "''")} AS task,
+               {column(model_columns, 'input_tokens', '0')} AS input_tokens,
+               {column(model_columns, 'output_tokens', '0')} AS output_tokens,
+               {column(model_columns, 'cache_read_tokens', '0')} AS cache_read_tokens,
+               {column(model_columns, 'cache_write_tokens', '0')} AS cache_write_tokens
+        FROM session_model_usage
+      """
+      for row in conn.execute(model_query):
+        session_id = str(row["session_id"] or "")
+        session = sessions.get(session_id)
+        if session is None:
+          continue
+        tokens = {field: number(row[field]) for field in BUCKET_FIELDS}
+        usage.add(
+          session["day"], session["key"], row["billing_provider"],
+          row["model"], tokens,
+        )
+        if str(row["task"] or "") == "":
+          for field in BUCKET_FIELDS:
+            attributed_main[session_id][field] += tokens[field]
+
+    # Legacy and absolute-update sessions have aggregate counters that are
+    # not fully represented by per-route rows. Attribute only positive
+    # residuals to the route stored on the session itself.
+    for session_id, session in sessions.items():
+      residual = {
+        field: max(0, session["tokens"][field] - attributed_main[session_id][field])
+        for field in BUCKET_FIELDS
+      }
+      usage.add(
+        session["day"], session["key"], session["provider"],
+        session["model"], residual,
+      )
+  except sqlite3.Error as exc:
+    print(f"Ignoring unreadable Hermes database {path}: {exc}", file=sys.stderr)
+  finally:
+    conn.close()
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  # SQLite scans are local and cheap; accept the shared collector flags even
+  # though Hermes has no separate limits probe or cache to bypass.
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  parser.parse_args()
+
+  paths = state_paths()
+  usage = Usage()
+  for path in paths:
+    scan_database(path, usage)
+  print(json.dumps(usage.record(bool(paths)), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/bin/omarchy-agent-usage-hermes
+++ b/bin/omarchy-agent-usage-hermes
@@ -15,6 +15,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -196,6 +197,17 @@ def state_paths():
   return sorted(paths, key=lambda path: str(path))
 
 
+def database_recently_active(path, window_seconds=300):
+  now = time.time()
+  for candidate in (path, Path(str(path) + "-wal")):
+    try:
+      if 0 <= now - candidate.stat().st_mtime <= window_seconds:
+        return True
+    except OSError:
+      pass
+  return False
+
+
 def table_columns(conn, table):
   try:
     return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
@@ -224,6 +236,7 @@ class Usage:
     self.providers = set()
     self.models = set()
     self.routes = {}
+    self.retry_advised = False
 
   def add(self, day, session_key, provider, model, tokens):
     total = sum(tokens.values())
@@ -266,6 +279,7 @@ class Usage:
       "name": AGENT_NAME,
       "updatedAt": datetime.now(timezone.utc).isoformat(),
       "ready": has_databases,
+      "retryAdvised": self.retry_advised,
       "hasLocalStats": has_databases,
       "hasPromptStats": False,
       "tierLabel": tier,
@@ -389,6 +403,7 @@ def main():
 
   paths = state_paths()
   usage = Usage()
+  usage.retry_advised = any(database_recently_active(path) for path in paths)
   for path in paths:
     scan_database(path, usage)
   print(json.dumps(usage.record(bool(paths)), separators=(",", ":")))

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -261,6 +261,7 @@ Item {
       todaySessions: synced ? numberValue(stats.todaySessions) : numberValue(record.todaySessions),
       todayTotalTokens: synced ? numberValue(stats.todayTotalTokens) : numberValue(record.todayTotalTokens),
       todayTokensByModel: synced ? (stats.todayTokensByModel || ({})) : (record.todayTokensByModel || ({})),
+      modelLabels: synced ? (stats.modelLabels || ({})) : (record.modelLabels || ({})),
       recentDays: synced ? (stats.recentDays || []) : (record.recentDays || []),
       totalPrompts: synced ? numberValue(stats.totalPrompts) : numberValue(record.totalPrompts),
       totalSessions: synced ? numberValue(stats.totalSessions) : numberValue(record.totalSessions),
@@ -566,6 +567,7 @@ Item {
         todaySessions: 0,
         todayTotalTokens: 0,
         todayTokensByModel: ({}),
+        modelLabels: ({}),
         recentByDay: recentByDay,
         totalPrompts: 0,
         totalSessions: 0,
@@ -605,6 +607,10 @@ Item {
         for (var ad = 0; ad < activeDates.length; ad++) acc.activeDates[String(activeDates[ad])] = true
         acc.activeDays = Math.max(acc.activeDays, numberValue(stats.activeDays))
         combineObjectNumbers(additive, acc.todayTokensByModel, stats.todayTokensByModel || {})
+        var labels = stats.modelLabels || {}
+        for (var labelId in labels) {
+          if (!acc.modelLabels[labelId]) acc.modelLabels[labelId] = cloneValue(labels[labelId], ({}))
+        }
 
         var recent = Array.isArray(stats.recentDays) ? stats.recentDays : []
         for (var r = 0; r < recent.length; r++) {
@@ -639,6 +645,7 @@ Item {
         todaySessions: acc.todaySessions,
         todayTotalTokens: acc.todayTotalTokens,
         todayTokensByModel: acc.todayTokensByModel,
+        modelLabels: acc.modelLabels,
         recentDays: recentDays,
         totalPrompts: acc.totalPrompts,
         totalSessions: acc.totalSessions,
@@ -673,6 +680,7 @@ Item {
       todaySessions: numberValue(record.todaySessions),
       todayTotalTokens: numberValue(record.todayTotalTokens),
       todayTokensByModel: cloneValue(record.todayTokensByModel, ({})),
+      modelLabels: cloneValue(record.modelLabels, ({})),
       recentDays: cloneValue(record.recentDays, []),
       totalPrompts: numberValue(record.totalPrompts),
       totalSessions: numberValue(record.totalSessions),
@@ -720,12 +728,26 @@ Item {
     return word.charAt(0).toUpperCase() + word.slice(1)
   }
 
-  // Model ids arrive hyphenated with the version split across segments
-  // (`claude-opus-4-8`, `gpt-5.6-sol`). Rejoin the numeric run into one
-  // version and title-case the words around it.
-  function friendlyModelName(id) {
+  // Collectors may supply authoritative display labels for route ids. The
+  // raw provider and model remain the fallback, so evolving catalogues and
+  // custom endpoints never require a matching list in Omarchy. Other
+  // collectors retain the compact labels used before route ids existed.
+  function friendlyModelName(id, routeLabel) {
     if (!id) return "Unknown"
-    var name = String(id).replace(/^claude-/, "").replace(/-\d{8}$/, "")
+    if (routeLabel && typeof routeLabel === "object") {
+      var labelProvider = String(routeLabel.provider || "").trim()
+      var labelModel = String(routeLabel.model || "").trim()
+      if (labelProvider && labelModel) return labelProvider + " · " + labelModel
+    }
+    var route = String(id)
+    var separator = route.indexOf("::")
+    if (separator >= 0) {
+      var provider = route.slice(0, separator) || "unknown"
+      var model = route.slice(separator + 2) || "unknown"
+      return provider + " · " + model
+    }
+
+    var name = route.replace(/^claude-/, "").replace(/-\d{8}$/, "")
     var parts = name.split("-")
     var words = []
     var version = []

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -80,12 +80,11 @@ Item {
     scheduleSync()
   }
 
-  // A collector that could not reach its limits endpoint at all — typically
-  // the seconds after login before the network is up — writes retryAdvised
-  // into its record. Honor it with one sooner try instead of waiting out the
-  // full refresh interval; a run that reaches the endpoint clears the flag.
-  // Only the advising agents rerun, so an outage at one provider does not
-  // put every other collector on a 30-second treadmill.
+  // A collector that expects fresher data shortly writes retryAdvised into its
+  // record — usually while a login settles or a local agent finishes flushing
+  // its live token ledger. Honor it with one sooner try instead of waiting out
+  // the full refresh interval. Only the advising agents rerun, so activity at
+  // one provider does not put every collector on a 30-second treadmill.
   property var retryAgentIds: []
 
   Timer {

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -222,6 +222,7 @@ Panel {
 
   function modelRows(p) {
     var usageByModel = p ? (p.modelUsage || {}) : {}
+    var labelsByModel = p ? (p.modelLabels || {}) : {}
     var rows = []
     for (var id in usageByModel) {
       var bucket = usageByModel[id] || {}
@@ -230,7 +231,7 @@ Panel {
       var cacheRead = Number(bucket.cacheReadInputTokens || 0)
       var cacheWrite = Number(bucket.cacheCreationInputTokens || 0)
       rows.push({
-        name: usage.friendlyModelName(id),
+        name: usage.friendlyModelName(id, labelsByModel[id]),
         total: input + output + cacheRead + cacheWrite,
         input: input,
         output: output,
@@ -244,7 +245,7 @@ Panel {
 
   function modelTooltip(row) {
     if (!row) return ""
-    return "In " + usage.formatTokenCount(row.input)
+    return row.name + "\nIn " + usage.formatTokenCount(row.input)
       + " · out " + usage.formatTokenCount(row.output)
       + " · cache read " + usage.formatTokenCount(row.cacheRead)
       + " · cache write " + usage.formatTokenCount(row.cacheWrite)

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -50,11 +50,16 @@ prints the record contract (see the `claude` and `codex` collectors in
 with an `assets/<id>-light.svg` twin if the mark needs a dark variant for
 light surfaces — and the bar glyph stands in when there is none.
 
+Collectors may include a `modelLabels` object keyed like `modelUsage`, with
+`model` and `provider` display strings. The panel uses those source-provided
+labels and falls back to formatting the model key when they are absent.
+
 | Collector | Limits | Local stats |
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `hermes` | None — Hermes has no unified multi-provider quota | `~/.hermes/state.db` plus named-profile databases, split by billing provider and model |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via

--- a/test/shell.d/agent-usage-hermes-scanner-test.sh
+++ b/test/shell.d/agent-usage-hermes-scanner-test.sh
@@ -99,6 +99,10 @@ result=$(HOME="$test_home" HERMES_HOME="$test_home/.hermes" \
   fail "Hermes collector identifies itself without inventing unified limits" "$result"
 pass "Hermes collector identifies itself and reports no unified limits"
 
+[[ $(jq -r '.retryAdvised' <<<"$result") == true ]] ||
+  fail "Hermes collector does not retry while its local database is active" "$result"
+pass "Hermes collector retries while the local ledger is settling"
+
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == 192 ]] ||
   fail "Hermes collector reconciles main usage and adds auxiliary usage once" "$result"
 pass "Hermes collector reconciles main and auxiliary usage without double-counting"

--- a/test/shell.d/agent-usage-hermes-scanner-test.sh
+++ b/test/shell.d/agent-usage-hermes-scanner-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+require_command python3
+
+test_home=$(mktemp -d)
+trap 'rm -rf "$test_home"' EXIT
+
+python3 - "$test_home" <<'PY'
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+today = time.time()
+yesterday = today - 86400
+
+def sessions_table(conn):
+  conn.execute("""
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      model TEXT,
+      billing_provider TEXT,
+      started_at REAL NOT NULL,
+      input_tokens INTEGER DEFAULT 0,
+      output_tokens INTEGER DEFAULT 0,
+      cache_read_tokens INTEGER DEFAULT 0,
+      cache_write_tokens INTEGER DEFAULT 0
+    )
+  """)
+
+main_db = home / ".hermes" / "state.db"
+main_db.parent.mkdir(parents=True)
+conn = sqlite3.connect(main_db)
+sessions_table(conn)
+conn.execute("""
+  CREATE TABLE session_model_usage (
+    session_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    billing_provider TEXT NOT NULL DEFAULT '',
+    task TEXT NOT NULL DEFAULT '',
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0
+  )
+""")
+conn.executemany("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?)", [
+  ("shared-id", "claude-sonnet-4", "anthropic", today, 100, 50, 20, 10),
+  ("fallback", "kimi-k2.5", "openrouter", yesterday, 40, 20, 0, 0),
+])
+conn.executemany("INSERT INTO session_model_usage VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+  ("shared-id", "claude-sonnet-4", "anthropic", "", 60, 30, 10, 5, 15),
+  ("shared-id", "gpt-5.2-codex", "openai-codex", "", 20, 10, 0, 0, 5),
+  ("shared-id", "labs/future-model-v12", "FutureProvider", "vision", 5, 7, 0, 0, 3),
+])
+conn.commit()
+conn.close()
+
+# A legacy named profile without session_model_usage exercises aggregate
+# fallback and proves colliding session ids are distinct across databases.
+profile_db = home / ".hermes" / "profiles" / "coder" / "state.db"
+profile_db.parent.mkdir(parents=True)
+conn = sqlite3.connect(profile_db)
+sessions_table(conn)
+conn.execute(
+  "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  ("shared-id", "kimi-k2.5", "fireworks", yesterday, 30, 10, 5, 0),
+)
+conn.commit()
+conn.close()
+
+# One damaged profile must not hide healthy usage from the others.
+broken = home / ".hermes" / "profiles" / "broken" / "state.db"
+broken.parent.mkdir(parents=True)
+broken.write_text("not a sqlite database", encoding="utf-8")
+PY
+
+fake_runtime="$test_home/hermes-runtime"
+mkdir -p "$fake_runtime/venv/bin"
+cat >"$fake_runtime/venv/bin/python" <<'SH'
+#!/bin/bash
+cat >/dev/null
+printf '%s' '{"FutureProvider::labs/future-model-v12":{"provider":"Future Systems","model":"Future Model 12"}}'
+SH
+chmod +x "$fake_runtime/venv/bin/python"
+
+result=$(HOME="$test_home" HERMES_HOME="$test_home/.hermes" \
+  HERMES_INSTALL_DIR="$fake_runtime" \
+  "$ROOT/bin/omarchy-agent-usage-hermes" 2>/dev/null)
+
+[[ $(jq -r '.id + "/" + (.limits | tostring)' <<<"$result") == 'hermes/[]' ]] ||
+  fail "Hermes collector identifies itself without inventing unified limits" "$result"
+pass "Hermes collector identifies itself and reports no unified limits"
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == 192 ]] ||
+  fail "Hermes collector reconciles main usage and adds auxiliary usage once" "$result"
+pass "Hermes collector reconciles main and auxiliary usage without double-counting"
+
+[[ $(jq -c '.modelUsage["anthropic::claude-sonnet-4"]' <<<"$result") == '{"inputTokens":80,"outputTokens":40,"cacheReadInputTokens":20,"cacheCreationInputTokens":10}' ]] ||
+  fail "Hermes collector attributes only the positive main-loop residual" "$result"
+pass "Hermes collector attributes absolute-update residuals to the session route"
+
+[[ $(jq -r '.modelUsage | keys | map(select(endswith("::kimi-k2.5"))) | length' <<<"$result") == 2 ]] ||
+  fail "Hermes collector keeps identical models separate across providers" "$result"
+pass "Hermes collector separates identical models by billing provider"
+
+[[ $(jq -r '.modelUsage | has("FutureProvider::labs/future-model-v12")' <<<"$result") == true ]] ||
+  fail "Hermes collector preserves model and provider names from Hermes" "$result"
+pass "Hermes collector passes unfamiliar model and provider names through verbatim"
+
+[[ $(jq -c '.modelLabels["FutureProvider::labs/future-model-v12"]' <<<"$result") == '{"provider":"Future Systems","model":"Future Model 12"}' ]] ||
+  fail "Hermes collector uses labels resolved by the installed Hermes runtime" "$result"
+pass "Hermes collector lets Hermes supply model and provider display names"
+
+[[ $(jq -r '[.modelUsage[] | .inputTokens + .outputTokens + .cacheReadInputTokens + .cacheCreationInputTokens] | add' <<<"$result") == 297 ]] ||
+  fail "Hermes collector excludes reasoning tokens already contained in output" "$result"
+pass "Hermes collector does not double-count reasoning tokens"
+
+[[ $(jq -r '.totalSessions' <<<"$result") == 3 ]] ||
+  fail "Hermes collector distinguishes colliding session ids across profiles" "$result"
+[[ $(jq -r '.activeDays' <<<"$result") == 2 ]] ||
+  fail "Hermes collector aggregates active dates across profiles" "$result"
+[[ $(jq -r '.tierLabel' <<<"$result") == '5 providers · 4 models' ]] ||
+  fail "Hermes collector summarizes its multi-provider model mix" "$result"
+pass "Hermes collector aggregates named profiles"
+
+[[ $(jq -r '.hasPromptStats' <<<"$result") == false ]] ||
+  fail "Hermes collector does not label API calls as prompts" "$result"
+pass "Hermes collector avoids inventing prompt counts"


### PR DESCRIPTION
## Summary

- add a collector for token usage stored in Hermes' local SQLite session ledger
- preserve model switches and auxiliary-task usage by billing provider and model
- let Hermes supply human-readable provider/model labels from its local catalogue
- carry optional model labels through the agents widget and cross-device snapshots

## Why

Hermes can use several providers and models within the same session, so treating it like a single-subscription agent would lose important attribution. This adds one Hermes tab while keeping each provider/model route distinct and avoids presenting a misleading unified quota.

This is a follow-up to #6644, but it is intentionally independent: existing Hermes users can benefit even if the installation integration is not merged.

The collector reads `~/.hermes/state.db` and named-profile databases in read-only mode. It performs no paid model calls and uses Hermes' local model metadata without requiring a network request. Unknown or custom routes fall back to the exact identifiers Hermes recorded.

## Validation

- `bash test/shell.d/agent-usage-hermes-scanner-test.sh`
- Claude, Codex, Fireworks, and usage-update collector tests
- `./test/cli`
- live Quickshell load and panel layout check with multi-provider synthetic usage