### PR TITLE
Fix KeyboardLayout plugin label permanently displaying ENG on some systems

### DIFF
--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -34,16 +34,24 @@ BarWidget {
 
   Process {
     id: queryProc
-    command: ["bash", "-c", "hyprctl -j devices 2>/dev/null | sed -n '/keyboards/,$p' | head -200"]
+    command: ["bash", "-c", "hyprctl -j devices"]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        var match = String(text || "").match(/"active_keymap":\s*"([^"]+)"/)
-        if (!match) return
-        var full = match[1]
-        root.layoutFull = full
-        var token = full.split(/\s+/)[0]
-        root.layoutLabel = token.substring(0, 3).toUpperCase()
+        let data
+        try {
+          data = JSON.parse(text || "{}")
+        } catch (e) {
+          return
+        }
+
+        const keyboards = data.keyboards ?? []
+        const kb = keyboards.find(k => k.main) ?? keyboards[0]
+
+        if (!kb) return
+
+        root.layoutFull = kb.active_keymap
+        root.layoutLabel = kb.active_keymap.split(/\s+/)[0].substring(0, 3).toUpperCase()
       }
     }
   }

--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -12,6 +12,7 @@ BarWidget {
 
   property string layoutLabel: ""
   property string layoutFull: ""
+  property string keyboardName: ""
 
   function refresh() {
     if (!queryProc.running) queryProc.running = true
@@ -19,12 +20,16 @@ BarWidget {
 
   // fcitx5 binds a virtual keyboard and takes over the seat's main flag whenever
   // it injects, but that keyboard keeps the us layout the input method gave it.
-  function isTypedOn(kb) {
-    return kb.main && !String(kb.name).startsWith("hl-virtual-keyboard")
+  // Stay on the keyboard we last read until a real one is active again, so the
+  // label keeps tracking that keyboard's layout rather than freezing.
+  function selectKeyboard(keyboards) {
+    const typed = keyboards.filter(k => !String(k.name).startsWith("hl-virtual-keyboard"))
+    return typed.find(k => k.main) ?? typed.find(k => k.name === root.keyboardName)
   }
 
   function cycleLayout() {
-    Hyprland.dispatch("switchxkblayout current next")
+    if (!root.keyboardName) return
+    Hyprland.dispatch("switchxkblayout " + root.keyboardName + " next")
     refreshTimer.restart()
   }
 
@@ -46,13 +51,14 @@ BarWidget {
       onStreamFinished: {
         let kb
         try {
-          kb = JSON.parse(text || "{}").keyboards?.find(k => root.isTypedOn(k))
+          kb = root.selectKeyboard(JSON.parse(text || "{}").keyboards ?? [])
         } catch (e) {
           return
         }
 
         if (!kb || !kb.active_keymap) return
 
+        root.keyboardName = String(kb.name || "")
         root.layoutFull = kb.active_keymap
         root.layoutLabel = kb.active_keymap.split(/\s+/)[0].substring(0, 3).toUpperCase()
       }

--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -17,6 +17,12 @@ BarWidget {
     if (!queryProc.running) queryProc.running = true
   }
 
+  // fcitx5 binds a virtual keyboard and takes over the seat's main flag whenever
+  // it injects, but that keyboard keeps the us layout the input method gave it.
+  function isTypedOn(kb) {
+    return kb.main && !String(kb.name).startsWith("hl-virtual-keyboard")
+  }
+
   function cycleLayout() {
     Hyprland.dispatch("switchxkblayout current next")
     refreshTimer.restart()
@@ -40,7 +46,7 @@ BarWidget {
       onStreamFinished: {
         let kb
         try {
-          kb = JSON.parse(text || "{}").keyboards?.find(k => k.main)
+          kb = JSON.parse(text || "{}").keyboards?.find(k => root.isTypedOn(k))
         } catch (e) {
           return
         }

--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -38,17 +38,14 @@ BarWidget {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        let data
+        let kb
         try {
-          data = JSON.parse(text || "{}")
+          kb = JSON.parse(text || "{}").keyboards?.find(k => k.main)
         } catch (e) {
           return
         }
 
-        const keyboards = data.keyboards ?? []
-        const kb = keyboards.find(k => k.main) ?? keyboards[0]
-
-        if (!kb) return
+        if (!kb || !kb.active_keymap) return
 
         root.layoutFull = kb.active_keymap
         root.layoutLabel = kb.active_keymap.split(/\s+/)[0].substring(0, 3).toUpperCase()

--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -34,7 +34,7 @@ BarWidget {
 
   Process {
     id: queryProc
-    command: ["bash", "-c", "hyprctl -j devices"]
+    command: ["hyprctl", "-j", "devices"]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {


### PR DESCRIPTION
Fixes #6574 

Keyboard layout bar widget polls the current keyboard layout with a regex/sed combo from the output of `hyprctl -j devices`. The list includes every input device that libinput/evdev exposes with the EV_KEY capability, e.g. power button and multimedia keys.

In my case, on Framework 13 Pro, the first occurrence of `active_keymap` is found under keyboard device `frmw0004:00-32ac:0006-wireless-radio-control` - a device that never receives the toggle and stays permanently in `English (US)` layout, causing the plugin to permanently display "ENG" regardless of the actual keyboard layout.

```
"keyboards": [
    {
        "address": "0x55b9740bae40",
        "name": "frmw0004:00-32ac:0006-wireless-radio-control",
        "rules": "",
        "model": "",
        "layout": "us,ru",
        "variant": "",
        "options": "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
        "active_layout_index": 0,
        "active_keymap": "English (US)",
        "capsLock": false,
        "numLock": true,
        "main": false
    }, 
    ....
],
```

This PR replaces the regex/sed scrape of `hyprctl -j devices` with proper JSON parsing that picks the keyboard flagged `main: true`, which seems to correctly track whichever device's layout is actually switched.