### PR TITLE
Add local and remote Hermes usage sources to Agents panel

### DIFF
--- a/bin/omarchy-agent-meter
+++ b/bin/omarchy-agent-meter
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 
 # omarchy:summary=Collect remote AI gateway usage for the Omarchy agents panel
-# omarchy:args=<login|local|collect> [source...]
-# omarchy:examples=omarchy agent meter login hermes | omarchy agent meter local hermes | omarchy agent meter collect
+# omarchy:args=<login|local|remote|collect> [source...]
+# omarchy:examples=omarchy agent meter login hermes | omarchy agent meter local hermes | omarchy agent meter remote hermes
 
 """Lightweight system-wide collector for remote AI gateway usage.
 
@@ -158,6 +158,16 @@ def use_local_source(path, source_id):
     write_config(path, config)
 
 
+def use_remote_source(path, source_id):
+  config = load_config(path)
+  source_id = safe_id(source_id)
+  source = config["sources"].get(source_id)
+  if not isinstance(source, dict):
+    raise MeterError(f"unknown source: {source_id}")
+  source["enabled"] = True
+  write_config(path, config)
+
+
 class HermesAdapter:
   def __init__(self, source_id, config):
     self.source_id = safe_id(source_id)
@@ -233,40 +243,66 @@ class HermesAdapter:
       "modelUsage": {},
     }
 
+  def sessions(self):
+    rows = []
+    offset = 0
+    limit = 100
+    while True:
+      query = urllib.parse.urlencode({
+        "limit": limit,
+        "offset": offset,
+        "archived": "include",
+        "order": "recent",
+      })
+      response = self.get(f"/api/sessions?{query}")
+      page = response.get("sessions") if isinstance(response.get("sessions"), list) else []
+      rows.extend(row for row in page if isinstance(row, dict))
+      offset += len(page)
+      total = number(response.get("total"))
+      if not page or len(page) < limit or (total and offset >= total):
+        return rows
+
   def collect(self):
-    usage = self.get(f"/api/analytics/usage?days={self.period_days}")
+    session_rows = self.sessions()
     models_response = self.get(f"/api/analytics/models?days={self.period_days}")
-    daily_rows = usage.get("daily") if isinstance(usage.get("daily"), list) else []
     model_rows = models_response.get("models") if isinstance(models_response.get("models"), list) else []
-    totals = usage.get("totals") if isinstance(usage.get("totals"), dict) else {}
     now = datetime.now().astimezone()
+    cutoff = now.timestamp() - self.period_days * 86400
     today = now.strftime("%Y-%m-%d")
     recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
     recent = {day: 0 for day in recent_dates}
     daily = {}
     active_dates = set()
 
-    for raw in daily_rows:
-      if not isinstance(raw, dict):
+    for raw in session_rows:
+      try:
+        started_at = float(raw.get("started_at"))
+      except (TypeError, ValueError):
         continue
-      day = str(raw.get("day") or "")
-      if not day:
+      if started_at <= cutoff:
         continue
-      row = {
-        "inputTokens": number(raw.get("input_tokens")),
-        "outputTokens": number(raw.get("output_tokens")),
-        "cacheReadTokens": number(raw.get("cache_read_tokens")),
-        "cacheWriteTokens": number(raw.get("cache_write_tokens")),
-        "reasoningTokens": number(raw.get("reasoning_tokens")),
-        "sessions": number(raw.get("sessions")),
-        "apiCalls": number(raw.get("api_calls")),
-      }
-      daily[day] = row
+      day = datetime.fromtimestamp(started_at).astimezone().strftime("%Y-%m-%d")
+      row = daily.setdefault(day, {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0,
+        "reasoningTokens": 0,
+        "sessions": 0,
+        "apiCalls": 0,
+      })
+      row["inputTokens"] += number(raw.get("input_tokens"))
+      row["outputTokens"] += number(raw.get("output_tokens"))
+      row["cacheReadTokens"] += number(raw.get("cache_read_tokens"))
+      row["cacheWriteTokens"] += number(raw.get("cache_write_tokens"))
+      row["reasoningTokens"] += number(raw.get("reasoning_tokens"))
+      row["sessions"] += 1
+      row["apiCalls"] += number(raw.get("api_call_count"))
       total = token_total(row)
       if total > 0:
         active_dates.add(day)
       if day in recent:
-        recent[day] += total
+        recent[day] = total
 
     model_usage = {}
     model_labels = {}
@@ -296,6 +332,8 @@ class HermesAdapter:
       models.add(model)
 
     today_row = daily.get(today, {})
+    total_prompts = sum(number(row.get("apiCalls")) for row in daily.values())
+    total_sessions = sum(number(row.get("sessions")) for row in daily.values())
     tier = "Remote"
     if model_usage:
       tier += (
@@ -322,8 +360,8 @@ class HermesAdapter:
       "todayTokensByModel": {},
       "modelLabels": model_labels,
       "recentDays": [{"date": day, "messageCount": recent[day]} for day in recent_dates],
-      "totalPrompts": number(totals.get("total_api_calls")),
-      "totalSessions": number(totals.get("total_sessions")),
+      "totalPrompts": total_prompts,
+      "totalSessions": total_sessions,
       "activeDays": len(active_dates),
       "activeDates": sorted(active_dates),
       "modelUsage": model_usage,
@@ -400,6 +438,8 @@ def main():
   login_parser.add_argument("--stdin", action="store_true")
   local_parser = subparsers.add_parser("local")
   local_parser.add_argument("source")
+  remote_parser = subparsers.add_parser("remote")
+  remote_parser.add_argument("source")
   collect_parser = subparsers.add_parser("collect")
   collect_parser.add_argument("sources", nargs="*")
   args = parser.parse_args()
@@ -409,6 +449,8 @@ def main():
       use_local_source(args.config, args.source)
       print(args.source)
       return 0
+    if args.command == "remote":
+      use_remote_source(args.config, args.source)
     credentials = {}
     if args.command == "login" and args.stdin:
       try:
@@ -436,6 +478,8 @@ def main():
       return 0
     if args.command == "collect":
       return 1 if collect(select_adapters(available, args.sources)) else 0
+    if args.command == "remote":
+      return 1 if collect(select_adapters(available, [args.source])) else 0
   except (MeterError, KeyboardInterrupt) as error:
     print(f"omarchy-agent-meter: {error}", file=sys.stderr)
     return 1

--- a/bin/omarchy-agent-meter
+++ b/bin/omarchy-agent-meter
@@ -1,0 +1,445 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Collect remote AI gateway usage for the Omarchy agents panel
+# omarchy:args=<login|local|collect> [source...]
+# omarchy:examples=omarchy agent meter login hermes | omarchy agent meter local hermes | omarchy agent meter collect
+
+"""Lightweight system-wide collector for remote AI gateway usage.
+
+The meter owns authentication and normalized token accounting independently of
+the applications it observes. Provider adapters return the display-ready
+record contract consumed by omarchy.agents; no prompt or response content is
+read, stored, or written to the panel.
+"""
+
+import argparse
+import getpass
+import http.cookiejar
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+CONFIG_PATH = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "omarchy" / "agent-meter.json"
+STATE_ROOT = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "omarchy" / "agent-meter"
+USAGE_ROOT = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "omarchy" / "agents" / "usage"
+USER_AGENT = "omarchy-agent-meter/1"
+
+
+class MeterError(RuntimeError):
+  pass
+
+
+class AuthenticationRequired(MeterError):
+  pass
+
+
+def number(value):
+  try:
+    return max(0, int(value or 0))
+  except (TypeError, ValueError):
+    return 0
+
+
+def safe_id(value):
+  cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip()).strip("._-")
+  if not cleaned:
+    raise MeterError("source and record ids must contain a letter or number")
+  return cleaned[:80]
+
+
+def token_total(row):
+  # Reasoning is a subset of output in Hermes accounting, not another billable
+  # lane. Keep the detail on model buckets but never add it twice.
+  return sum(number(row.get(key)) for key in ("inputTokens", "outputTokens", "cacheReadTokens", "cacheWriteTokens"))
+
+
+def request_json(url, *, opener, method="GET", body=None, timeout=8):
+  payload = None
+  headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
+  if body is not None:
+    payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    headers["Content-Type"] = "application/json"
+  request = urllib.request.Request(url, data=payload, headers=headers, method=method)
+  try:
+    with opener.open(request, timeout=timeout) as response:
+      raw = response.read(4_000_000)
+  except urllib.error.HTTPError as error:
+    detail = ""
+    try:
+      detail = error.read(4096).decode("utf-8", "replace")
+    except OSError:
+      pass
+    if error.code == 401:
+      raise AuthenticationRequired("remote gateway login required") from error
+    raise MeterError(f"HTTP {error.code} from {url}: {detail or error.reason}") from error
+  except (OSError, urllib.error.URLError) as error:
+    raise MeterError(f"could not reach {url}: {error}") from error
+
+  try:
+    parsed = json.loads(raw)
+  except json.JSONDecodeError as error:
+    raise MeterError(f"invalid JSON from {url}") from error
+  if not isinstance(parsed, (dict, list)):
+    raise MeterError(f"unexpected response from {url}")
+  return parsed
+
+
+def source_url(raw):
+  value = str(raw or "").strip().rstrip("/")
+  if "://" not in value:
+    value = "http://" + value
+  parsed = urllib.parse.urlparse(value)
+  if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+    raise MeterError(f"invalid gateway URL: {value!r}")
+  if parsed.username or parsed.password:
+    raise MeterError("putting gateway credentials in the URL is not supported")
+  return value
+
+
+def load_config(path):
+  try:
+    config = json.loads(path.read_text(encoding="utf-8"))
+  except FileNotFoundError as error:
+    raise MeterError(f"configuration not found: {path}") from error
+  except (OSError, json.JSONDecodeError) as error:
+    raise MeterError(f"could not read configuration {path}: {error}") from error
+  if not isinstance(config, dict) or not isinstance(config.get("sources"), dict):
+    raise MeterError("configuration must contain a sources object")
+  return config
+
+
+def write_config(path, config):
+  path.parent.mkdir(parents=True, exist_ok=True)
+  descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+  try:
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+      json.dump(config, stream, indent=2)
+      stream.write("\n")
+    os.replace(temporary, path)
+  finally:
+    try:
+      os.unlink(temporary)
+    except FileNotFoundError:
+      pass
+
+
+def configure_hermes(path, source_id, url):
+  config = load_config(path) if path.is_file() else {"sources": {}}
+  source_id = safe_id(source_id)
+  previous = config["sources"].get(source_id)
+  previous = previous if isinstance(previous, dict) else {}
+  config["sources"][source_id] = {
+    **previous,
+    "type": "hermes",
+    "url": source_url(url),
+    "name": str(previous.get("name") or "Hermes"),
+    "periodDays": number(previous.get("periodDays") or 365),
+    "enabled": True,
+  }
+  write_config(path, config)
+
+
+def use_local_source(path, source_id):
+  if not path.is_file():
+    return
+  config = load_config(path)
+  source = config["sources"].get(safe_id(source_id))
+  if isinstance(source, dict):
+    source["enabled"] = False
+    write_config(path, config)
+
+
+class HermesAdapter:
+  def __init__(self, source_id, config):
+    self.source_id = safe_id(source_id)
+    self.record_id = self.source_id
+    self.name = str(config.get("name") or "Hermes").strip() or "Hermes"
+    self.base_url = source_url(config.get("url"))
+    self.period_days = min(365, max(1, number(config.get("periodDays") or 365)))
+    self.cookie_path = STATE_ROOT / "credentials" / f"{self.source_id}.cookies"
+    self.cookies = http.cookiejar.MozillaCookieJar(str(self.cookie_path))
+    try:
+      self.cookies.load(ignore_discard=True, ignore_expires=True)
+    except (FileNotFoundError, http.cookiejar.LoadError, OSError):
+      pass
+    self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self.cookies))
+
+  def save_cookies(self):
+    self.cookie_path.parent.mkdir(parents=True, exist_ok=True)
+    self.cookies.save(ignore_discard=True, ignore_expires=True)
+    self.cookie_path.chmod(0o600)
+
+  def get(self, path):
+    result = request_json(f"{self.base_url}{path}", opener=self.opener)
+    self.save_cookies()
+    return result
+
+  def login(self, username, password=None):
+    providers = request_json(f"{self.base_url}/api/auth/providers", opener=self.opener)
+    available = providers.get("providers") if isinstance(providers, dict) else []
+    password_provider = next(
+      (provider for provider in available if isinstance(provider, dict) and provider.get("supports_password")),
+      None,
+    )
+    if password_provider is None:
+      raise MeterError("this Hermes gateway does not advertise password login")
+    provider_id = str(password_provider.get("name") or "")
+    selected_username = str(username or "").strip()
+    if password is None:
+      selected_username = selected_username or input("Hermes gateway username: ").strip()
+      password = getpass.getpass("Hermes gateway password: ")
+    if not selected_username:
+      raise MeterError("username is required")
+    if not password:
+      raise MeterError("password is required")
+    result = request_json(
+      f"{self.base_url}/auth/password-login",
+      opener=self.opener,
+      method="POST",
+      body={"provider": provider_id, "username": selected_username, "password": password, "next": "/"},
+    )
+    if not isinstance(result, dict) or result.get("ok") is not True:
+      raise MeterError("Hermes gateway login failed")
+    self.save_cookies()
+    identity = self.get("/api/auth/me")
+    return str(identity.get("display_name") or identity.get("user_id") or selected_username)
+
+  def authentication_record(self):
+    return {
+      "schemaVersion": 1,
+      "id": self.record_id,
+      "name": self.name,
+      "updatedAt": datetime.now(timezone.utc).isoformat(),
+      "ready": False,
+      "remoteGateway": True,
+      "gatewayLoginAvailable": True,
+      "authRequired": True,
+      "gatewayUrl": self.base_url,
+      "usageStatusText": "Remote gateway login required",
+      "authHelpText": "Sign in below to restore remote Hermes usage.",
+      "hasLocalStats": False,
+      "hasPromptStats": False,
+      "limits": [],
+      "recentDays": [],
+      "modelUsage": {},
+    }
+
+  def collect(self):
+    usage = self.get(f"/api/analytics/usage?days={self.period_days}")
+    models_response = self.get(f"/api/analytics/models?days={self.period_days}")
+    daily_rows = usage.get("daily") if isinstance(usage.get("daily"), list) else []
+    model_rows = models_response.get("models") if isinstance(models_response.get("models"), list) else []
+    totals = usage.get("totals") if isinstance(usage.get("totals"), dict) else {}
+    now = datetime.now().astimezone()
+    today = now.strftime("%Y-%m-%d")
+    recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+    recent = {day: 0 for day in recent_dates}
+    daily = {}
+    active_dates = set()
+
+    for raw in daily_rows:
+      if not isinstance(raw, dict):
+        continue
+      day = str(raw.get("day") or "")
+      if not day:
+        continue
+      row = {
+        "inputTokens": number(raw.get("input_tokens")),
+        "outputTokens": number(raw.get("output_tokens")),
+        "cacheReadTokens": number(raw.get("cache_read_tokens")),
+        "cacheWriteTokens": number(raw.get("cache_write_tokens")),
+        "reasoningTokens": number(raw.get("reasoning_tokens")),
+        "sessions": number(raw.get("sessions")),
+        "apiCalls": number(raw.get("api_calls")),
+      }
+      daily[day] = row
+      total = token_total(row)
+      if total > 0:
+        active_dates.add(day)
+      if day in recent:
+        recent[day] += total
+
+    model_usage = {}
+    model_labels = {}
+    providers = set()
+    models = set()
+    for raw in model_rows:
+      if not isinstance(raw, dict):
+        continue
+      provider = str(raw.get("provider") or "unknown").strip() or "unknown"
+      model = str(raw.get("model") or "unknown").strip() or "unknown"
+      key = f"{provider}::{model}"
+      reasoning = number(raw.get("reasoning_tokens"))
+      bucket = {
+        "inputTokens": number(raw.get("input_tokens")),
+        "outputTokens": number(raw.get("output_tokens")),
+        "cacheReadInputTokens": number(raw.get("cache_read_tokens")),
+        "cacheCreationInputTokens": number(raw.get("cache_write_tokens")),
+        "reasoningOutputTokens": reasoning,
+      }
+      if not any(number(bucket.get(field)) for field in (
+        "inputTokens", "outputTokens", "cacheReadInputTokens", "cacheCreationInputTokens",
+      )):
+        continue
+      model_usage[key] = bucket
+      model_labels[key] = {"provider": provider, "model": model}
+      providers.add(provider)
+      models.add(model)
+
+    today_row = daily.get(today, {})
+    tier = "Remote"
+    if model_usage:
+      tier += (
+        f" · {len(providers)} provider{'s' if len(providers) != 1 else ''}"
+        f" · {len(models)} model{'s' if len(models) != 1 else ''}"
+      )
+    return {
+      "schemaVersion": 1,
+      "id": self.record_id,
+      "name": self.name,
+      "updatedAt": datetime.now(timezone.utc).isoformat(),
+      "ready": True,
+      "remoteGateway": True,
+      "gatewayLoginAvailable": True,
+      "authRequired": False,
+      "gatewayUrl": self.base_url,
+      "hasLocalStats": True,
+      "hasPromptStats": True,
+      "tierLabel": tier,
+      "limits": [],
+      "todayPrompts": number(today_row.get("apiCalls")),
+      "todaySessions": number(today_row.get("sessions")),
+      "todayTotalTokens": token_total(today_row),
+      "todayTokensByModel": {},
+      "modelLabels": model_labels,
+      "recentDays": [{"date": day, "messageCount": recent[day]} for day in recent_dates],
+      "totalPrompts": number(totals.get("total_api_calls")),
+      "totalSessions": number(totals.get("total_sessions")),
+      "activeDays": len(active_dates),
+      "activeDates": sorted(active_dates),
+      "modelUsage": model_usage,
+      "sourceLabel": f"Remote Hermes analytics · {self.base_url}",
+    }
+
+
+def adapters(config):
+  result = {}
+  for source_id, source in config.get("sources", {}).items():
+    if not isinstance(source, dict) or source.get("enabled") is False:
+      continue
+    kind = str(source.get("type") or "").strip().lower()
+    if kind == "hermes":
+      result[safe_id(source_id)] = HermesAdapter(source_id, source)
+    else:
+      raise MeterError(f"unsupported source type {kind!r} for {source_id}")
+  return result
+
+
+def atomic_write_record(record):
+  USAGE_ROOT.mkdir(parents=True, exist_ok=True)
+  record = dict(record)
+  record_id = safe_id(record.get("id"))
+  descriptor, temporary = tempfile.mkstemp(prefix=f".{record_id}.", dir=USAGE_ROOT, text=True)
+  try:
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+      json.dump(record, stream, separators=(",", ":"))
+      stream.write("\n")
+      stream.flush()
+      os.fsync(stream.fileno())
+    os.replace(temporary, USAGE_ROOT / f"{record_id}.json")
+  finally:
+    try:
+      os.unlink(temporary)
+    except FileNotFoundError:
+      pass
+
+
+def select_adapters(all_adapters, selected):
+  if not selected:
+    return all_adapters
+  wanted = {}
+  for source_id in selected:
+    key = safe_id(source_id)
+    if key not in all_adapters:
+      raise MeterError(f"unknown source: {source_id}")
+    wanted[key] = all_adapters[key]
+  return wanted
+
+
+def collect(selected):
+  failures = 0
+  for source_id, adapter in selected.items():
+    try:
+      atomic_write_record(adapter.collect())
+      print(source_id)
+    except AuthenticationRequired:
+      atomic_write_record(adapter.authentication_record())
+      print(source_id)
+    except MeterError as error:
+      failures += 1
+      print(f"omarchy-agent-meter: {source_id}: {error}", file=sys.stderr)
+  return failures
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--config", type=Path, default=CONFIG_PATH)
+  subparsers = parser.add_subparsers(dest="command", required=True)
+  login_parser = subparsers.add_parser("login")
+  login_parser.add_argument("source")
+  login_parser.add_argument("--username")
+  login_parser.add_argument("--stdin", action="store_true")
+  local_parser = subparsers.add_parser("local")
+  local_parser.add_argument("source")
+  collect_parser = subparsers.add_parser("collect")
+  collect_parser.add_argument("sources", nargs="*")
+  args = parser.parse_args()
+
+  try:
+    if args.command == "local":
+      use_local_source(args.config, args.source)
+      print(args.source)
+      return 0
+    credentials = {}
+    if args.command == "login" and args.stdin:
+      try:
+        credentials = json.loads(sys.stdin.readline())
+      except json.JSONDecodeError as error:
+        raise MeterError("invalid credentials input") from error
+      if not isinstance(credentials, dict):
+        raise MeterError("invalid credentials input")
+      if str(credentials.get("url") or "").strip():
+        configure_hermes(args.config, args.source, credentials["url"])
+    config = load_config(args.config)
+    available = adapters(config)
+    if args.command == "login":
+      selected = select_adapters(available, [args.source])
+      adapter = next(iter(selected.values()))
+      if not isinstance(adapter, HermesAdapter):
+        raise MeterError(f"{args.source} does not support interactive login")
+      password = None
+      username = args.username
+      if args.stdin:
+        username = str(credentials.get("username") or "")
+        password = str(credentials.get("password") or "")
+      identity = adapter.login(username, password)
+      print(f"Authenticated {args.source} as {identity}")
+      return 0
+    if args.command == "collect":
+      return 1 if collect(select_adapters(available, args.sources)) else 0
+  except (MeterError, KeyboardInterrupt) as error:
+    print(f"omarchy-agent-meter: {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-usage-hermes
+++ b/bin/omarchy-agent-usage-hermes
@@ -12,6 +12,7 @@ ledger directly so the Omarchy agents panel preserves that attribution.
 import argparse
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -28,6 +29,34 @@ BUCKET_FIELDS = {
   "cache_read_tokens": "cacheReadInputTokens",
   "cache_write_tokens": "cacheCreationInputTokens",
 }
+
+
+def configured_gateway_url():
+  path = Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config")) / "omarchy" / "agent-meter.json"
+  try:
+    config = json.loads(path.read_text(encoding="utf-8"))
+  except (FileNotFoundError, OSError, json.JSONDecodeError):
+    return ""
+  sources = config.get("sources") if isinstance(config, dict) else None
+  source = sources.get(AGENT_ID) if isinstance(sources, dict) else None
+  return str(source.get("url") or "") if isinstance(source, dict) else ""
+
+
+def hermes_installed(paths):
+  return bool(paths) or shutil.which("hermes") is not None or (
+    Path.home() / ".local" / "share" / "applications" / "hermes.desktop"
+  ).is_file()
+
+
+def database_recently_active(path, window_seconds=300):
+  now = time.time()
+  for candidate in (path, Path(str(path) + "-wal")):
+    try:
+      if 0 <= now - candidate.stat().st_mtime <= window_seconds:
+        return True
+    except OSError:
+      pass
+  return False
 
 LABEL_HELPER = r"""
 import json
@@ -197,17 +226,6 @@ def state_paths():
   return sorted(paths, key=lambda path: str(path))
 
 
-def database_recently_active(path, window_seconds=300):
-  now = time.time()
-  for candidate in (path, Path(str(path) + "-wal")):
-    try:
-      if 0 <= now - candidate.stat().st_mtime <= window_seconds:
-        return True
-    except OSError:
-      pass
-  return False
-
-
 def table_columns(conn, table):
   try:
     return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
@@ -260,7 +278,7 @@ class Usage:
       self.today_sessions.add(session_key)
       self.today_tokens[key] = self.today_tokens.get(key, 0) + total
 
-  def record(self, has_databases):
+  def record(self, has_databases, installed, gateway_url):
     model_usage = {key: self.model_usage[key] for key in sorted(self.model_usage)}
     today_tokens = {key: self.today_tokens[key] for key in sorted(self.today_tokens)}
     today_total = sum(today_tokens.values())
@@ -278,11 +296,15 @@ class Usage:
       "id": AGENT_ID,
       "name": AGENT_NAME,
       "updatedAt": datetime.now(timezone.utc).isoformat(),
-      "ready": has_databases,
+      "ready": installed,
+      "remoteGateway": False,
+      "gatewayLoginAvailable": installed,
+      "gatewayConfigured": gateway_url != "",
+      "gatewayUrl": gateway_url,
       "retryAdvised": self.retry_advised,
       "hasLocalStats": has_databases,
       "hasPromptStats": False,
-      "tierLabel": tier,
+      "tierLabel": tier or ("Local" if installed else ""),
       "limits": [],
       "todayPrompts": 0,
       "todaySessions": len(self.today_sessions),
@@ -406,7 +428,10 @@ def main():
   usage.retry_advised = any(database_recently_active(path) for path in paths)
   for path in paths:
     scan_database(path, usage)
-  print(json.dumps(usage.record(bool(paths)), separators=(",", ":")))
+  print(json.dumps(
+    usage.record(bool(paths), hermes_installed(paths), configured_gateway_url()),
+    separators=(",", ":"),
+  ))
 
 
 if __name__ == "__main__":

--- a/bin/omarchy-agent-usage-hermes
+++ b/bin/omarchy-agent-usage-hermes
@@ -1,0 +1,398 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Hermes usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Hermes model usage into one display-ready JSON record.
+
+Hermes can switch providers and models inside one session, and auxiliary
+tasks can use a different route from the main agent. Read its SQLite usage
+ledger directly so the Omarchy agents panel preserves that attribution.
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+AGENT_ID = "hermes"
+AGENT_NAME = "Hermes"
+BUCKET_FIELDS = {
+  "input_tokens": "inputTokens",
+  "output_tokens": "outputTokens",
+  "cache_read_tokens": "cacheReadInputTokens",
+  "cache_write_tokens": "cacheCreationInputTokens",
+}
+
+LABEL_HELPER = r"""
+import json
+import sys
+
+from agent.models_dev import PROVIDER_TO_MODELS_DEV, fetch_models_dev
+from hermes_cli.models import provider_label
+
+routes = json.load(sys.stdin)
+catalog = fetch_models_dev(allow_network=False)
+labels = {}
+for route in routes:
+  key = str(route.get("key") or "")
+  provider = str(route.get("provider") or "unknown")
+  model = str(route.get("model") or "unknown")
+  provider_name = provider_label(provider) or provider
+  model_name = model
+
+  catalog_provider = PROVIDER_TO_MODELS_DEV.get(provider.lower(), provider.lower())
+  provider_data = catalog.get(catalog_provider)
+  models = provider_data.get("models") if isinstance(provider_data, dict) else None
+  if isinstance(models, dict):
+    model_data = models.get(model)
+    if not isinstance(model_data, dict):
+      lowered = model.lower()
+      model_data = next(
+        (value for model_id, value in models.items()
+         if str(model_id).lower() == lowered and isinstance(value, dict)),
+        None,
+      )
+    if isinstance(model_data, dict):
+      model_name = str(model_data.get("name") or model)
+
+  labels[key] = {"provider": provider_name, "model": model_name}
+
+json.dump(labels, sys.stdout, separators=(",", ":"))
+"""
+
+
+def number(value):
+  try:
+    return max(0, int(value or 0))
+  except (TypeError, ValueError):
+    return 0
+
+
+def local_day(value):
+  try:
+    return datetime.fromtimestamp(float(value)).astimezone().strftime("%Y-%m-%d")
+  except (TypeError, ValueError, OSError, OverflowError):
+    return ""
+
+
+def empty_bucket():
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def route_key(provider, model):
+  provider_id = str(provider or "unknown").strip() or "unknown"
+  model_id = str(model or "unknown").strip() or "unknown"
+  return f"{provider_id}::{model_id}", provider_id, model_id
+
+
+def hermes_runtime():
+  hermes_home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+  candidates = []
+  if os.environ.get("HERMES_INSTALL_DIR"):
+    candidates.append(Path(os.environ["HERMES_INSTALL_DIR"]))
+  candidates.extend([
+    hermes_home / "hermes-agent",
+    Path.home() / ".hermes" / "hermes-agent",
+    Path("/usr/local/lib/hermes-agent"),
+  ])
+
+  seen = set()
+  for root in candidates:
+    try:
+      resolved = root.resolve()
+    except OSError:
+      resolved = root
+    if resolved in seen:
+      continue
+    seen.add(resolved)
+    for environment in ("venv", ".venv"):
+      python = root / environment / "bin" / "python"
+      if python.is_file() and os.access(python, os.X_OK):
+        return root, python
+  return None, None
+
+
+def route_labels(routes):
+  fallback = {
+    key: {"provider": provider, "model": model}
+    for key, (provider, model) in routes.items()
+  }
+  if not routes:
+    return fallback
+
+  root, python = hermes_runtime()
+  if root is None or python is None:
+    return fallback
+
+  payload = [
+    {"key": key, "provider": provider, "model": model}
+    for key, (provider, model) in routes.items()
+  ]
+  env = os.environ.copy()
+  env.pop("PYTHONHOME", None)
+  env.pop("PYTHONPATH", None)
+  try:
+    result = subprocess.run(
+      [str(python), "-c", LABEL_HELPER],
+      cwd=root,
+      env=env,
+      input=json.dumps(payload),
+      text=True,
+      capture_output=True,
+      timeout=5,
+      check=False,
+    )
+    if result.returncode != 0:
+      return fallback
+    resolved = json.loads(result.stdout)
+  except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+    return fallback
+
+  if not isinstance(resolved, dict):
+    return fallback
+  for key, label in resolved.items():
+    if key not in fallback or not isinstance(label, dict):
+      continue
+    provider = str(label.get("provider") or "").strip()
+    model = str(label.get("model") or "").strip()
+    if provider:
+      fallback[key]["provider"] = provider
+    if model:
+      fallback[key]["model"] = model
+  return fallback
+
+
+def state_paths():
+  hermes_home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+  candidates = [hermes_home / "state.db"]
+
+  # Hermes intentionally anchors named profiles under ~/.hermes regardless
+  # of HERMES_HOME, so profile discovery must do the same.
+  profiles_root = Path.home() / ".hermes" / "profiles"
+  if profiles_root.is_dir():
+    candidates.extend(path / "state.db" for path in profiles_root.iterdir() if path.is_dir())
+
+  paths = []
+  seen = set()
+  for candidate in candidates:
+    try:
+      resolved = candidate.resolve()
+    except OSError:
+      resolved = candidate
+    if resolved in seen or not candidate.is_file():
+      continue
+    seen.add(resolved)
+    paths.append(candidate)
+  return sorted(paths, key=lambda path: str(path))
+
+
+def table_columns(conn, table):
+  try:
+    return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
+  except sqlite3.Error:
+    return set()
+
+
+def column(columns, name, fallback):
+  return f'"{name}"' if name in columns else fallback
+
+
+class Usage:
+  def __init__(self):
+    now = datetime.now()
+    self.today = now.strftime("%Y-%m-%d")
+    self.recent_dates = [
+      (now - timedelta(days=offset)).strftime("%Y-%m-%d")
+      for offset in range(6, -1, -1)
+    ]
+    self.recent = {day: 0 for day in self.recent_dates}
+    self.model_usage = {}
+    self.today_tokens = {}
+    self.total_sessions = set()
+    self.today_sessions = set()
+    self.active_dates = set()
+    self.providers = set()
+    self.models = set()
+    self.routes = {}
+
+  def add(self, day, session_key, provider, model, tokens):
+    total = sum(tokens.values())
+    if total <= 0:
+      return
+
+    key, provider_id, model_id = route_key(provider, model)
+    bucket = self.model_usage.setdefault(key, empty_bucket())
+    for source, target in BUCKET_FIELDS.items():
+      bucket[target] += number(tokens.get(source))
+
+    self.providers.add(provider_id)
+    self.models.add(model_id)
+    self.routes[key] = (provider_id, model_id)
+    self.total_sessions.add(session_key)
+    if day:
+      self.active_dates.add(day)
+    if day in self.recent:
+      self.recent[day] += total
+    if day == self.today:
+      self.today_sessions.add(session_key)
+      self.today_tokens[key] = self.today_tokens.get(key, 0) + total
+
+  def record(self, has_databases):
+    model_usage = {key: self.model_usage[key] for key in sorted(self.model_usage)}
+    today_tokens = {key: self.today_tokens[key] for key in sorted(self.today_tokens)}
+    today_total = sum(today_tokens.values())
+    tier = ""
+    if self.model_usage:
+      provider_count = len(self.providers)
+      model_count = len(self.models)
+      tier = (
+        f"{provider_count} provider{'s' if provider_count != 1 else ''}"
+        f" · {model_count} model{'s' if model_count != 1 else ''}"
+      )
+
+    return {
+      "schemaVersion": 1,
+      "id": AGENT_ID,
+      "name": AGENT_NAME,
+      "updatedAt": datetime.now(timezone.utc).isoformat(),
+      "ready": has_databases,
+      "hasLocalStats": has_databases,
+      "hasPromptStats": False,
+      "tierLabel": tier,
+      "limits": [],
+      "todayPrompts": 0,
+      "todaySessions": len(self.today_sessions),
+      "todayTotalTokens": today_total,
+      "todayTokensByModel": today_tokens,
+      "modelLabels": route_labels(self.routes),
+      "recentDays": [
+        {"date": day, "messageCount": self.recent[day]}
+        for day in self.recent_dates
+      ],
+      "totalPrompts": 0,
+      "totalSessions": len(self.total_sessions),
+      "activeDays": len(self.active_dates),
+      "activeDates": sorted(self.active_dates),
+      "modelUsage": model_usage,
+    }
+
+
+def scan_database(path, usage):
+  try:
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
+  except (OSError, sqlite3.Error) as exc:
+    print(f"Ignoring unreadable Hermes database {path}: {exc}", file=sys.stderr)
+    return
+
+  conn.row_factory = sqlite3.Row
+  try:
+    conn.execute("PRAGMA query_only = ON")
+    session_columns = table_columns(conn, "sessions")
+    if not {"id", "started_at"}.issubset(session_columns):
+      return
+
+    session_query = f"""
+      SELECT "id" AS id,
+             {column(session_columns, 'model', "'unknown'")} AS model,
+             {column(session_columns, 'billing_provider', "''")} AS billing_provider,
+             "started_at" AS started_at,
+             {column(session_columns, 'input_tokens', '0')} AS input_tokens,
+             {column(session_columns, 'output_tokens', '0')} AS output_tokens,
+             {column(session_columns, 'cache_read_tokens', '0')} AS cache_read_tokens,
+             {column(session_columns, 'cache_write_tokens', '0')} AS cache_write_tokens
+      FROM sessions
+    """
+    sessions = {}
+    database_id = str(path.resolve())
+    for row in conn.execute(session_query):
+      session_id = str(row["id"] or "")
+      if not session_id:
+        continue
+      sessions[session_id] = {
+        "key": database_id + "::" + session_id,
+        "day": local_day(row["started_at"]),
+        "model": row["model"],
+        "provider": row["billing_provider"],
+        "tokens": {field: number(row[field]) for field in BUCKET_FIELDS},
+      }
+
+    # Only main-loop rows participate in residual reconciliation. Auxiliary
+    # rows are absent from sessions totals, so subtracting them would hide
+    # legitimate main-loop usage when vision/compression spend is larger.
+    attributed_main = {
+      session_id: {field: 0 for field in BUCKET_FIELDS}
+      for session_id in sessions
+    }
+
+    model_columns = table_columns(conn, "session_model_usage")
+    if "session_id" in model_columns:
+      model_query = f"""
+        SELECT "session_id" AS session_id,
+               {column(model_columns, 'model', "'unknown'")} AS model,
+               {column(model_columns, 'billing_provider', "''")} AS billing_provider,
+               {column(model_columns, 'task', "''")} AS task,
+               {column(model_columns, 'input_tokens', '0')} AS input_tokens,
+               {column(model_columns, 'output_tokens', '0')} AS output_tokens,
+               {column(model_columns, 'cache_read_tokens', '0')} AS cache_read_tokens,
+               {column(model_columns, 'cache_write_tokens', '0')} AS cache_write_tokens
+        FROM session_model_usage
+      """
+      for row in conn.execute(model_query):
+        session_id = str(row["session_id"] or "")
+        session = sessions.get(session_id)
+        if session is None:
+          continue
+        tokens = {field: number(row[field]) for field in BUCKET_FIELDS}
+        usage.add(
+          session["day"], session["key"], row["billing_provider"],
+          row["model"], tokens,
+        )
+        if str(row["task"] or "") == "":
+          for field in BUCKET_FIELDS:
+            attributed_main[session_id][field] += tokens[field]
+
+    # Legacy and absolute-update sessions have aggregate counters that are
+    # not fully represented by per-route rows. Attribute only positive
+    # residuals to the route stored on the session itself.
+    for session_id, session in sessions.items():
+      residual = {
+        field: max(0, session["tokens"][field] - attributed_main[session_id][field])
+        for field in BUCKET_FIELDS
+      }
+      usage.add(
+        session["day"], session["key"], session["provider"],
+        session["model"], residual,
+      )
+  except sqlite3.Error as exc:
+    print(f"Ignoring unreadable Hermes database {path}: {exc}", file=sys.stderr)
+  finally:
+    conn.close()
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  # SQLite scans are local and cheap; accept the shared collector flags even
+  # though Hermes has no separate limits probe or cache to bypass.
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  parser.parse_args()
+
+  paths = state_paths()
+  usage = Usage()
+  for path in paths:
+    scan_database(path, usage)
+  print(json.dumps(usage.record(bool(paths)), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/bin/omarchy-agent-usage-hermes
+++ b/bin/omarchy-agent-usage-hermes
@@ -15,6 +15,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -196,6 +197,17 @@ def state_paths():
   return sorted(paths, key=lambda path: str(path))
 
 
+def database_recently_active(path, window_seconds=300):
+  now = time.time()
+  for candidate in (path, Path(str(path) + "-wal")):
+    try:
+      if 0 <= now - candidate.stat().st_mtime <= window_seconds:
+        return True
+    except OSError:
+      pass
+  return False
+
+
 def table_columns(conn, table):
   try:
     return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
@@ -224,6 +236,7 @@ class Usage:
     self.providers = set()
     self.models = set()
     self.routes = {}
+    self.retry_advised = False
 
   def add(self, day, session_key, provider, model, tokens):
     total = sum(tokens.values())
@@ -266,6 +279,7 @@ class Usage:
       "name": AGENT_NAME,
       "updatedAt": datetime.now(timezone.utc).isoformat(),
       "ready": has_databases,
+      "retryAdvised": self.retry_advised,
       "hasLocalStats": has_databases,
       "hasPromptStats": False,
       "tierLabel": tier,
@@ -389,6 +403,7 @@ def main():
 
   paths = state_paths()
   usage = Usage()
+  usage.retry_advised = any(database_recently_active(path) for path in paths)
   for path in paths:
     scan_database(path, usage)
   print(json.dumps(usage.record(bool(paths)), separators=(",", ":")))

--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -15,6 +15,7 @@ mkdir -p "$USAGE_DIR"
 flags=()
 only=()
 declare -A excluded
+declare -A managed
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -51,12 +52,24 @@ collect() {
   mv "$tmp" "$USAGE_DIR/$agent.json"
 }
 
+meter="$OMARCHY_PATH/bin/omarchy-agent-meter"
+meter_config="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/agent-meter.json"
+if [[ -x $meter && -f $meter_config ]]; then
+  while IFS= read -r source; do
+    wanted "$source" || continue
+    if "$meter" --config "$meter_config" collect "$source" >/dev/null; then
+      managed[$source]=1
+    fi
+  done < <(jq -r '.sources | to_entries[] | select(.value.enabled != false) | .key' "$meter_config" 2>/dev/null)
+fi
+
 pids=()
 for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
   [[ -x $collector ]] || continue
   agent="${collector##*/omarchy-agent-usage-}"
   [[ $agent == "update" ]] && continue
   wanted "$agent" || continue
+  [[ -n ${managed[$agent]} ]] && continue
   collect "$collector" "$agent" &
   pids+=($!)
 done

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -261,6 +261,7 @@ Item {
       todaySessions: synced ? numberValue(stats.todaySessions) : numberValue(record.todaySessions),
       todayTotalTokens: synced ? numberValue(stats.todayTotalTokens) : numberValue(record.todayTotalTokens),
       todayTokensByModel: synced ? (stats.todayTokensByModel || ({})) : (record.todayTokensByModel || ({})),
+      modelLabels: synced ? (stats.modelLabels || ({})) : (record.modelLabels || ({})),
       recentDays: synced ? (stats.recentDays || []) : (record.recentDays || []),
       totalPrompts: synced ? numberValue(stats.totalPrompts) : numberValue(record.totalPrompts),
       totalSessions: synced ? numberValue(stats.totalSessions) : numberValue(record.totalSessions),
@@ -566,6 +567,7 @@ Item {
         todaySessions: 0,
         todayTotalTokens: 0,
         todayTokensByModel: ({}),
+        modelLabels: ({}),
         recentByDay: recentByDay,
         totalPrompts: 0,
         totalSessions: 0,
@@ -605,6 +607,10 @@ Item {
         for (var ad = 0; ad < activeDates.length; ad++) acc.activeDates[String(activeDates[ad])] = true
         acc.activeDays = Math.max(acc.activeDays, numberValue(stats.activeDays))
         combineObjectNumbers(additive, acc.todayTokensByModel, stats.todayTokensByModel || {})
+        var labels = stats.modelLabels || {}
+        for (var labelId in labels) {
+          if (!acc.modelLabels[labelId]) acc.modelLabels[labelId] = cloneValue(labels[labelId], ({}))
+        }
 
         var recent = Array.isArray(stats.recentDays) ? stats.recentDays : []
         for (var r = 0; r < recent.length; r++) {
@@ -639,6 +645,7 @@ Item {
         todaySessions: acc.todaySessions,
         todayTotalTokens: acc.todayTotalTokens,
         todayTokensByModel: acc.todayTokensByModel,
+        modelLabels: acc.modelLabels,
         recentDays: recentDays,
         totalPrompts: acc.totalPrompts,
         totalSessions: acc.totalSessions,
@@ -673,6 +680,7 @@ Item {
       todaySessions: numberValue(record.todaySessions),
       todayTotalTokens: numberValue(record.todayTotalTokens),
       todayTokensByModel: cloneValue(record.todayTokensByModel, ({})),
+      modelLabels: cloneValue(record.modelLabels, ({})),
       recentDays: cloneValue(record.recentDays, []),
       totalPrompts: numberValue(record.totalPrompts),
       totalSessions: numberValue(record.totalSessions),
@@ -720,12 +728,26 @@ Item {
     return word.charAt(0).toUpperCase() + word.slice(1)
   }
 
-  // Model ids arrive hyphenated with the version split across segments
-  // (`claude-opus-4-8`, `gpt-5.6-sol`). Rejoin the numeric run into one
-  // version and title-case the words around it.
-  function friendlyModelName(id) {
+  // Collectors may supply authoritative display labels for route ids. The
+  // raw provider and model remain the fallback, so evolving catalogues and
+  // custom endpoints never require a matching list in Omarchy. Other
+  // collectors retain the compact labels used before route ids existed.
+  function friendlyModelName(id, routeLabel) {
     if (!id) return "Unknown"
-    var name = String(id).replace(/^claude-/, "").replace(/-\d{8}$/, "")
+    if (routeLabel && typeof routeLabel === "object") {
+      var labelProvider = String(routeLabel.provider || "").trim()
+      var labelModel = String(routeLabel.model || "").trim()
+      if (labelProvider && labelModel) return labelProvider + " · " + labelModel
+    }
+    var route = String(id)
+    var separator = route.indexOf("::")
+    if (separator >= 0) {
+      var provider = route.slice(0, separator) || "unknown"
+      var model = route.slice(separator + 2) || "unknown"
+      return provider + " · " + model
+    }
+
+    var name = route.replace(/^claude-/, "").replace(/-\d{8}$/, "")
     var parts = name.split("-")
     var words = []
     var version = []

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -219,7 +219,7 @@ Item {
     return numberValue(p.totalPrompts) > 0 || numberValue(p.totalSessions) > 0
       || numberValue(p.activeDays) > 0 || numberValue(p.todayPrompts) > 0
       || numberValue(p.todaySessions) > 0 || (p.limits && p.limits.length > 0)
-      || !!p.balance
+      || !!p.balance || p.gatewayLoginAvailable === true
   }
 
   // A prepaid agent's credit ledger. Like rate limits, the balance is
@@ -249,6 +249,11 @@ Item {
       ready: record.ready === true || synced,
       usageStatusText: String(record.usageStatusText || ""),
       authHelpText: String(record.authHelpText || ""),
+      remoteGateway: record.remoteGateway === true,
+      gatewayLoginAvailable: record.gatewayLoginAvailable === true,
+      gatewayConfigured: record.gatewayConfigured === true,
+      authRequired: record.authRequired === true,
+      gatewayUrl: String(record.gatewayUrl || ""),
 
       // Rate limits and balances stay per-account and are never merged
       // across devices.

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -80,12 +80,11 @@ Item {
     scheduleSync()
   }
 
-  // A collector that could not reach its limits endpoint at all — typically
-  // the seconds after login before the network is up — writes retryAdvised
-  // into its record. Honor it with one sooner try instead of waiting out the
-  // full refresh interval; a run that reaches the endpoint clears the flag.
-  // Only the advising agents rerun, so an outage at one provider does not
-  // put every other collector on a 30-second treadmill.
+  // A collector that expects fresher data shortly writes retryAdvised into its
+  // record — usually while a login settles or a local agent finishes flushing
+  // its live token ledger. Honor it with one sooner try instead of waiting out
+  // the full refresh interval. Only the advising agents rerun, so activity at
+  // one provider does not put every collector on a 30-second treadmill.
   property var retryAgentIds: []
 
   Timer {

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -79,6 +79,15 @@ Panel {
     gatewayLoginProcess.running = true
   }
 
+  function useRemoteUsage() {
+    if (!provider || gatewayLoginProcess.running) return
+    gatewayLoginError = ""
+    gatewayLoginProcess.sourceId = provider.providerId
+    gatewayLoginProcess.credentials = ""
+    gatewayLoginProcess.command = ["omarchy-agent-meter", "remote", provider.providerId]
+    gatewayLoginProcess.running = true
+  }
+
   // Countdowns and "updated" read this instead of Date.now() so the
   // panel keeps telling the truth while it sits open.
   property double nowMs: Date.now()
@@ -664,11 +673,16 @@ Panel {
                   foreground: root.foreground
                   fontFamily: root.fontFamily
                   onClicked: {
-                    root.gatewayRemoteMode = true
-                    Qt.callLater(function() {
-                      if (gatewayUrl.text === "") gatewayUrl.forceActiveFocus()
-                      else gatewayUsername.forceActiveFocus()
-                    })
+                    if (root.provider && root.provider.remoteGateway !== true
+                        && root.provider.authRequired !== true)
+                      root.useRemoteUsage()
+                    else {
+                      root.gatewayRemoteMode = true
+                      Qt.callLater(function() {
+                        if (gatewayUrl.text === "") gatewayUrl.forceActiveFocus()
+                        else gatewayUsername.forceActiveFocus()
+                      })
+                    }
                   }
                 }
               }

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -222,6 +222,7 @@ Panel {
 
   function modelRows(p) {
     var usageByModel = p ? (p.modelUsage || {}) : {}
+    var labelsByModel = p ? (p.modelLabels || {}) : {}
     var rows = []
     for (var id in usageByModel) {
       var bucket = usageByModel[id] || {}
@@ -230,7 +231,7 @@ Panel {
       var cacheRead = Number(bucket.cacheReadInputTokens || 0)
       var cacheWrite = Number(bucket.cacheCreationInputTokens || 0)
       rows.push({
-        name: usage.friendlyModelName(id),
+        name: usage.friendlyModelName(id, labelsByModel[id]),
         total: input + output + cacheRead + cacheWrite,
         input: input,
         output: output,
@@ -244,7 +245,7 @@ Panel {
 
   function modelTooltip(row) {
     if (!row) return ""
-    return "In " + usage.formatTokenCount(row.input)
+    return row.name + "\nIn " + usage.formatTokenCount(row.input)
       + " · out " + usage.formatTokenCount(row.output)
       + " · cache read " + usage.formatTokenCount(row.cacheRead)
       + " · cache write " + usage.formatTokenCount(row.cacheWrite)

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -31,6 +31,53 @@ Panel {
   readonly property var provider: providers.length > 0 ? providers[providerIndex] : null
 
   property bool cursorActive: false
+  property bool gatewayLoginOpen: false
+  property string gatewayLoginError: ""
+  property bool gatewayRemoteMode: true
+  readonly property bool gatewayActionAvailable: !!provider
+    && provider.gatewayLoginAvailable === true
+
+  function openGatewayLogin() {
+    gatewayLoginError = ""
+    gatewayLoginOpen = true
+    gatewayRemoteMode = provider && (provider.remoteGateway === true || provider.authRequired === true)
+    gatewayUrl.text = provider ? String(provider.gatewayUrl || "") : ""
+    Qt.callLater(function() {
+      if (gatewayRemoteMode) {
+        if (gatewayUrl.text === "") gatewayUrl.forceActiveFocus()
+        else gatewayUsername.forceActiveFocus()
+      }
+    })
+  }
+
+  function submitGatewayLogin() {
+    if (!provider || gatewayLoginProcess.running) return
+    var url = gatewayUrl.text.trim()
+    var username = gatewayUsername.text.trim()
+    if (url === "" || username === "" || gatewayPassword.text === "") {
+      gatewayLoginError = "Enter the gateway URL, username, and password."
+      return
+    }
+    gatewayLoginError = ""
+    gatewayLoginProcess.sourceId = provider.providerId
+    gatewayLoginProcess.credentials = JSON.stringify({
+      url: url,
+      username: username,
+      password: gatewayPassword.text
+    })
+    gatewayPassword.text = ""
+    gatewayLoginProcess.command = ["omarchy-agent-meter", "login", provider.providerId, "--stdin"]
+    gatewayLoginProcess.running = true
+  }
+
+  function useLocalUsage() {
+    if (!provider || gatewayLoginProcess.running) return
+    gatewayLoginError = ""
+    gatewayLoginProcess.sourceId = provider.providerId
+    gatewayLoginProcess.credentials = ""
+    gatewayLoginProcess.command = ["omarchy-agent-meter", "local", provider.providerId]
+    gatewayLoginProcess.running = true
+  }
 
   // Countdowns and "updated" read this instead of Date.now() so the
   // panel keeps telling the truth while it sits open.
@@ -294,6 +341,12 @@ Panel {
   implicitHeight: button.implicitHeight
 
   onProviderIndexChanged: if (panelFlick) panelFlick.contentY = 0
+  onSelectedProviderIdChanged: {
+    gatewayLoginOpen = false
+    gatewayLoginError = ""
+    gatewayUrl.text = ""
+    gatewayPassword.text = ""
+  }
   onOpenedChanged: if (opened) {
     cursorActive = false
     nowMs = Date.now()
@@ -305,6 +358,35 @@ Panel {
   Main {
     id: usage
     settings: root.settings
+  }
+
+  Process {
+    id: gatewayLoginProcess
+    property string sourceId: ""
+    property string credentials: ""
+    stdinEnabled: true
+    running: false
+
+    onStarted: {
+      if (credentials !== "") write(credentials + "\n")
+      credentials = ""
+    }
+
+    stdout: StdioCollector { id: gatewayLoginStdout; waitForEnd: true }
+    stderr: StdioCollector { id: gatewayLoginStderr; waitForEnd: true }
+
+    onExited: function(exitCode) {
+      if (exitCode === 0) {
+        root.gatewayLoginOpen = false
+        root.gatewayLoginError = ""
+        usage.refreshAll(true)
+      } else {
+        var message = String(gatewayLoginStderr.text || gatewayLoginStdout.text || "Login failed").trim()
+        root.gatewayLoginError = message.replace(/^omarchy-agent-meter:\s*/, "")
+        if (root.gatewayRemoteMode)
+          Qt.callLater(function() { gatewayPassword.forceActiveFocus() })
+      }
+    }
   }
 
   // Cheap enough to keep running: it only re-evaluates text bindings, and a
@@ -355,6 +437,7 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
+      blocked: gatewayUrl.activeFocus || gatewayUsername.activeFocus || gatewayPassword.activeFocus
 
       onMoveRequested: function(dx, dy) {
         if (dx !== 0) {
@@ -365,7 +448,10 @@ Panel {
           panelFlick.contentY = root.clamp(panelFlick.contentY + dy * Style.space(56), 0,
                                            Math.max(0, panelFlick.contentHeight - panelFlick.height))
       }
-      onActivateRequested: root.refreshNow()
+      onActivateRequested: {
+        if (root.gatewayActionAvailable) root.openGatewayLogin()
+        else root.refreshNow()
+      }
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) { if (t === "r" || t === "R") root.refreshNow() }
@@ -506,6 +592,185 @@ Panel {
               font.family: root.fontFamily
               font.pixelSize: Style.font.caption
               wrapMode: Text.WordWrap
+            }
+          }
+
+          Button {
+            visible: root.gatewayActionAvailable && !root.gatewayLoginOpen
+            width: parent.width
+            text: root.provider && root.provider.authRequired === true
+              ? "Remote Gateway Login"
+              : (root.provider && root.provider.remoteGateway === true
+                  ? "Usage Source · Remote Gateway" : "Usage Source · This Computer")
+            iconText: root.provider && root.provider.remoteGateway === true ? "󰒍" : "󰍹"
+            bordered: true
+            leftAlign: true
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            onClicked: root.openGatewayLogin()
+          }
+
+          BorderSurface {
+            visible: root.gatewayActionAvailable && root.gatewayLoginOpen
+            width: parent.width
+            implicitHeight: gatewayLoginColumn.implicitHeight + Style.space(24)
+            color: root.alpha(root.foreground, 0.04)
+            borderSpec: Border.flat(root.alpha(root.foreground, 0.15), 1)
+            radius: Style.cornerRadius
+
+            Column {
+              id: gatewayLoginColumn
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              anchors.leftMargin: Style.space(12)
+              anchors.rightMargin: Style.space(12)
+              spacing: Style.space(8)
+
+              Text {
+                text: "Hermes Usage Source"
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.subtitle
+                font.bold: true
+              }
+
+              Row {
+                width: parent.width
+                spacing: Style.space(8)
+
+                Button {
+                  width: (parent.width - parent.spacing) / 2
+                  text: "This Computer"
+                  iconText: "󰍹"
+                  selected: !root.gatewayRemoteMode
+                  bordered: true
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  onClicked: {
+                    root.gatewayRemoteMode = false
+                    gatewayPassword.text = ""
+                    if (root.provider && (root.provider.remoteGateway === true || root.provider.authRequired === true))
+                      root.useLocalUsage()
+                  }
+                }
+
+                Button {
+                  width: (parent.width - parent.spacing) / 2
+                  text: "Remote Gateway"
+                  iconText: "󰒍"
+                  selected: root.gatewayRemoteMode
+                  bordered: true
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  onClicked: {
+                    root.gatewayRemoteMode = true
+                    Qt.callLater(function() {
+                      if (gatewayUrl.text === "") gatewayUrl.forceActiveFocus()
+                      else gatewayUsername.forceActiveFocus()
+                    })
+                  }
+                }
+              }
+
+              Text {
+                width: parent.width
+                text: root.gatewayRemoteMode
+                  ? "Read account-wide usage from Hermes running on another computer or server."
+                  : "Read usage directly from Hermes on this computer. No gateway login is required."
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.WordWrap
+              }
+
+              TextField {
+                id: gatewayUrl
+                visible: root.gatewayRemoteMode
+                width: parent.width
+                placeholderText: "Gateway URL · http://192.168.1.50:9119"
+                foreground: root.foreground
+                accent: Color.accent
+                enabled: !gatewayLoginProcess.running
+                onAccepted: gatewayUsername.forceActiveFocus()
+                Keys.onEscapePressed: {
+                  root.gatewayLoginOpen = false
+                  gatewayPassword.text = ""
+                }
+              }
+
+              TextField {
+                id: gatewayUsername
+                visible: root.gatewayRemoteMode
+                width: parent.width
+                placeholderText: "Username"
+                foreground: root.foreground
+                accent: Color.accent
+                enabled: !gatewayLoginProcess.running
+                onAccepted: gatewayPassword.forceActiveFocus()
+                Keys.onEscapePressed: {
+                  root.gatewayLoginOpen = false
+                  gatewayPassword.text = ""
+                }
+              }
+
+              TextField {
+                id: gatewayPassword
+                visible: root.gatewayRemoteMode
+                width: parent.width
+                password: true
+                placeholderText: "Password"
+                foreground: root.foreground
+                accent: Color.accent
+                enabled: !gatewayLoginProcess.running
+                onAccepted: root.submitGatewayLogin()
+                Keys.onEscapePressed: {
+                  root.gatewayLoginOpen = false
+                  text = ""
+                }
+              }
+
+              Text {
+                visible: root.gatewayLoginError !== ""
+                width: parent.width
+                text: root.gatewayLoginError
+                color: root.urgent
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.WordWrap
+              }
+
+              Row {
+                visible: root.gatewayRemoteMode
+                width: parent.width
+                spacing: Style.space(8)
+
+                Button {
+                  width: (parent.width - parent.spacing) / 2
+                  text: "Cancel"
+                  bordered: true
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  enabled: !gatewayLoginProcess.running
+                  onClicked: {
+                    root.gatewayLoginOpen = false
+                    gatewayPassword.text = ""
+                  }
+                }
+
+                Button {
+                  width: (parent.width - parent.spacing) / 2
+                  text: gatewayLoginProcess.running ? "Signing in…" : "Sign In"
+                  iconText: gatewayLoginProcess.running ? "󰑮" : "󰌾"
+                  iconSpinning: gatewayLoginProcess.running
+                  bordered: true
+                  active: true
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  enabled: !gatewayLoginProcess.running
+                  onClicked: root.submitGatewayLogin()
+                }
+              }
             }
           }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -50,11 +50,16 @@ prints the record contract (see the `claude` and `codex` collectors in
 with an `assets/<id>-light.svg` twin if the mark needs a dark variant for
 light surfaces — and the bar glyph stands in when there is none.
 
+Collectors may include a `modelLabels` object keyed like `modelUsage`, with
+`model` and `provider` display strings. The panel uses those source-provided
+labels and falls back to formatting the model key when they are absent.
+
 | Collector | Limits | Local stats |
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `hermes` | None — Hermes has no unified multi-provider quota | `~/.hermes/state.db` plus named-profile databases, split by billing provider and model |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -69,6 +69,26 @@ falls back to local stats only. A non-default Claude directory is honored via
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
 
+### Remote gateways
+
+Hermes defaults to **This Computer**, reading its local usage ledger without a
+login. The popup's **Usage Source** control can switch to account-wide data
+from a **Remote Gateway**, or back to local tracking later. The meter runs only
+during the panel's normal refresh and leaves no background process. Enter the
+remote URL, username, and password in the popup; the URL is prefilled on later
+logins and stored in
+`~/.config/omarchy/agent-meter.json`:
+
+```json
+{"sources":{"hermes":{"type":"hermes","url":"http://hermes:9119","name":"Hermes","periodDays":365}}}
+```
+
+When authentication expires, use **Remote Gateway Login** in the same popup;
+the credentials travel to the meter over stdin and are never command-line
+arguments. They stay in `~/.local/state/omarchy/agent-meter/`; nothing is
+installed in the gateway application's own configuration directory. If the
+remote collection fails, the matching local collector runs instead.
+
 ### Fireworks balance
 
 The collector first asks the account's `:getBalance` endpoint for the real

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -83,6 +83,12 @@ logins and stored in
 {"sources":{"hermes":{"type":"hermes","url":"http://hermes:9119","name":"Hermes","periodDays":365}}}
 ```
 
+The meter paginates the gateway's existing session-metadata endpoint and
+groups its timestamped token counters into this computer's local calendar
+days, matching Codex's seven-day layout without requiring gateway changes.
+Session titles, previews, prompts, and responses are never written to the
+agents panel record.
+
 When authentication expires, use **Remote Gateway Login** in the same popup;
 the credentials travel to the meter over stdin and are never command-line
 arguments. They stay in `~/.local/state/omarchy/agent-meter/`; nothing is

--- a/test/shell.d/agent-meter-test.sh
+++ b/test/shell.d/agent-meter-test.sh
@@ -14,8 +14,9 @@ trap '[[ -n $server_pid ]] && kill "$server_pid" 2>/dev/null || true; rm -rf "$t
 cat >"$test_root/server.py" <<'PY'
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
 
 port_file = sys.argv[1]
 
@@ -31,10 +32,11 @@ class Handler(BaseHTTPRequestHandler):
     self.wfile.write(payload)
 
   def do_GET(self):
-    today = datetime.now().strftime("%Y-%m-%d")
-    path = self.path.removeprefix("/locked")
-    locked = self.path.startswith("/locked/")
-    if locked and path.startswith("/api/analytics/") and "session=good" not in self.headers.get("Cookie", ""):
+    request = urlparse(self.path)
+    path = request.path.removeprefix("/locked")
+    locked = request.path.startswith("/locked/")
+    protected = path.startswith("/api/analytics/") or path.startswith("/api/sessions")
+    if locked and protected and "session=good" not in self.headers.get("Cookie", ""):
       self.send_json({"detail": "Unauthorized"}, 401)
       return
     if path == "/api/auth/providers":
@@ -46,25 +48,32 @@ class Handler(BaseHTTPRequestHandler):
       else:
         self.send_json({"display_name": "Meter Tester"})
       return
-    if path.startswith("/api/analytics/usage"):
-      body = {
-        "daily": [{
-          "day": today,
+    if path == "/api/sessions":
+      now = datetime.now().astimezone()
+      rows = [{
+          "id": "today",
+          "started_at": now.timestamp(),
           "input_tokens": 100,
           "output_tokens": 40,
           "cache_read_tokens": 20,
           "reasoning_tokens": 12,
-          "sessions": 2,
-          "api_calls": 5,
-        }],
-        "totals": {
-          "total_input": 100,
-          "total_output": 40,
-          "total_cache_read": 20,
-          "total_reasoning": 12,
-          "total_sessions": 2,
-          "total_api_calls": 5,
-        },
+          "api_call_count": 5,
+        }, {
+          "id": "yesterday",
+          "started_at": (now - timedelta(days=1)).timestamp(),
+          "input_tokens": 30,
+          "output_tokens": 10,
+          "cache_read_tokens": 0,
+          "reasoning_tokens": 0,
+          "api_call_count": 1,
+        }]
+      offset = int(parse_qs(request.query).get("offset", ["0"])[0])
+      limit = int(parse_qs(request.query).get("limit", ["20"])[0])
+      body = {
+        "sessions": rows[offset:offset + limit],
+        "total": len(rows),
+        "offset": offset,
+        "limit": limit,
       }
     elif path.startswith("/api/analytics/models"):
       body = {"models": [{
@@ -135,12 +144,16 @@ XDG_CONFIG_HOME="$test_root/config" XDG_STATE_HOME="$test_root/state" \
 record="$test_root/state/omarchy/agents/usage/hermes.json"
 [[ -f $record ]] || fail "meter did not write an agents-panel record"
 [[ $(jq -r '.todayTotalTokens' "$record") == 160 ]] ||
-  fail "meter counted reasoning twice or lost cache usage"
+  fail "meter did not group timestamped token usage into the local day"
+[[ $(jq -r '.todayPrompts' "$record") == 5 && $(jq -r '.todaySessions' "$record") == 1 ]] ||
+  fail "meter did not group timestamped activity into the local day"
+[[ $(jq -r --arg today "$(date +%F)" '.recentDays[] | select(.date == $today) | .messageCount' "$record") == 160 ]] ||
+  fail "meter did not preserve the standard current-day row"
 [[ $(jq -c '.modelLabels["ollama::future-coder:42b"]' "$record") == '{"provider":"ollama","model":"future-coder:42b"}' ]] ||
   fail "meter did not preserve dynamic provider and model attribution"
 [[ $(jq -r '.modelUsage["ollama::future-coder:42b"].reasoningOutputTokens' "$record") == 12 ]] ||
   fail "meter did not preserve reasoning detail"
-pass "system-wide meter normalizes remote Hermes analytics"
+pass "system-wide meter converts remote Hermes sessions into local calendar days"
 
 locked_record="$test_root/state/omarchy/agents/usage/locked.json"
 [[ $(jq -r '.authRequired' "$locked_record") == true ]] ||
@@ -180,3 +193,17 @@ XDG_CONFIG_HOME="$test_root/fresh-config" XDG_STATE_HOME="$test_root/fresh-state
 [[ $(jq -r '.sources.hermes.url' "$fresh_config") == "http://127.0.0.1:$port/locked" ]] ||
   fail "local usage forgets the previous remote gateway URL"
 pass "local usage preserves the remote gateway for later reconnection"
+
+cookie_path="$test_root/fresh-state/omarchy/agent-meter/credentials/hermes.cookies"
+cookie_before=$(sha256sum "$cookie_path" | cut -d' ' -f1)
+XDG_CONFIG_HOME="$test_root/fresh-config" XDG_STATE_HOME="$test_root/fresh-state" \
+  "$ROOT/bin/omarchy-agent-meter" --config "$fresh_config" remote hermes >/dev/null ||
+  fail "switching back to remote usage does not reuse the saved login"
+[[ $(jq -r '.sources.hermes.enabled' "$fresh_config") == true ]] ||
+  fail "remote usage does not re-enable the saved gateway"
+[[ $(jq -r '.authRequired' "$test_root/fresh-state/omarchy/agents/usage/hermes.json") == false ]] ||
+  fail "remote usage asks for credentials despite a valid saved login"
+cookie_after=$(sha256sum "$cookie_path" | cut -d' ' -f1)
+[[ $cookie_after == "$cookie_before" ]] ||
+  fail "switching usage sources replaced the saved gateway login"
+pass "local and remote usage switches preserve a valid gateway login"

--- a/test/shell.d/agent-meter-test.sh
+++ b/test/shell.d/agent-meter-test.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+test_root=$(mktemp -d)
+server_pid=""
+trap '[[ -n $server_pid ]] && kill "$server_pid" 2>/dev/null || true; rm -rf "$test_root"' EXIT
+
+cat >"$test_root/server.py" <<'PY'
+import json
+import sys
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+port_file = sys.argv[1]
+
+class Handler(BaseHTTPRequestHandler):
+  def send_json(self, body, status=200, cookie=""):
+    payload = json.dumps(body).encode()
+    self.send_response(status)
+    self.send_header("Content-Type", "application/json")
+    self.send_header("Content-Length", str(len(payload)))
+    if cookie:
+      self.send_header("Set-Cookie", cookie)
+    self.end_headers()
+    self.wfile.write(payload)
+
+  def do_GET(self):
+    today = datetime.now().strftime("%Y-%m-%d")
+    path = self.path.removeprefix("/locked")
+    locked = self.path.startswith("/locked/")
+    if locked and path.startswith("/api/analytics/") and "session=good" not in self.headers.get("Cookie", ""):
+      self.send_json({"detail": "Unauthorized"}, 401)
+      return
+    if path == "/api/auth/providers":
+      self.send_json({"providers": [{"name": "basic", "supports_password": True}]})
+      return
+    if path == "/api/auth/me":
+      if "session=good" not in self.headers.get("Cookie", ""):
+        self.send_json({"detail": "Unauthorized"}, 401)
+      else:
+        self.send_json({"display_name": "Meter Tester"})
+      return
+    if path.startswith("/api/analytics/usage"):
+      body = {
+        "daily": [{
+          "day": today,
+          "input_tokens": 100,
+          "output_tokens": 40,
+          "cache_read_tokens": 20,
+          "reasoning_tokens": 12,
+          "sessions": 2,
+          "api_calls": 5,
+        }],
+        "totals": {
+          "total_input": 100,
+          "total_output": 40,
+          "total_cache_read": 20,
+          "total_reasoning": 12,
+          "total_sessions": 2,
+          "total_api_calls": 5,
+        },
+      }
+    elif path.startswith("/api/analytics/models"):
+      body = {"models": [{
+        "provider": "ollama",
+        "model": "future-coder:42b",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "cache_read_tokens": 20,
+        "reasoning_tokens": 12,
+        "sessions": 2,
+        "api_calls": 5,
+      }]}
+    else:
+      self.send_error(404)
+      return
+    self.send_json(body)
+
+  def do_POST(self):
+    path = self.path.removeprefix("/locked")
+    if path != "/auth/password-login":
+      self.send_error(404)
+      return
+    length = int(self.headers.get("Content-Length", "0"))
+    body = json.loads(self.rfile.read(length) or b"{}")
+    if body.get("username") != "tester" or body.get("password") != "secret":
+      self.send_json({"ok": False}, 401)
+      return
+    self.send_json({"ok": True}, cookie="session=good; Path=/; HttpOnly")
+
+  def log_message(self, _format, *_args):
+    pass
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as stream:
+  stream.write(str(server.server_port))
+server.serve_forever()
+PY
+
+python3 "$test_root/server.py" "$test_root/port" &
+server_pid=$!
+for _ in {1..50}; do
+  [[ -s $test_root/port ]] && break
+  sleep 0.05
+done
+[[ -s $test_root/port ]] || fail "fake Hermes analytics server did not start"
+port=$(<"$test_root/port")
+
+cat >"$test_root/config.json" <<EOF
+{
+  "sources": {
+    "hermes": {
+      "type": "hermes",
+      "url": "http://127.0.0.1:$port",
+      "name": "Hermes"
+    },
+    "locked": {
+      "type": "hermes",
+      "url": "http://127.0.0.1:$port/locked",
+      "name": "Locked Hermes"
+    }
+  }
+}
+EOF
+
+XDG_CONFIG_HOME="$test_root/config" XDG_STATE_HOME="$test_root/state" \
+  "$ROOT/bin/omarchy-agent-meter" --config "$test_root/config.json" collect >/dev/null
+
+record="$test_root/state/omarchy/agents/usage/hermes.json"
+[[ -f $record ]] || fail "meter did not write an agents-panel record"
+[[ $(jq -r '.todayTotalTokens' "$record") == 160 ]] ||
+  fail "meter counted reasoning twice or lost cache usage"
+[[ $(jq -c '.modelLabels["ollama::future-coder:42b"]' "$record") == '{"provider":"ollama","model":"future-coder:42b"}' ]] ||
+  fail "meter did not preserve dynamic provider and model attribution"
+[[ $(jq -r '.modelUsage["ollama::future-coder:42b"].reasoningOutputTokens' "$record") == 12 ]] ||
+  fail "meter did not preserve reasoning detail"
+pass "system-wide meter normalizes remote Hermes analytics"
+
+locked_record="$test_root/state/omarchy/agents/usage/locked.json"
+[[ $(jq -r '.authRequired' "$locked_record") == true ]] ||
+  fail "meter does not publish a login action when remote authentication expires"
+pass "system-wide meter exposes remote authentication state"
+
+printf '%s\n' '{"username":"tester","password":"secret"}' | \
+  XDG_CONFIG_HOME="$test_root/config" XDG_STATE_HOME="$test_root/state" \
+  "$ROOT/bin/omarchy-agent-meter" --config "$test_root/config.json" login locked --stdin >/dev/null ||
+  fail "meter does not accept popup credentials over stdin"
+
+XDG_CONFIG_HOME="$test_root/config" XDG_STATE_HOME="$test_root/state" \
+  "$ROOT/bin/omarchy-agent-meter" --config "$test_root/config.json" collect locked >/dev/null ||
+  fail "meter cannot collect after an inline login"
+[[ $(jq -r '.authRequired' "$locked_record") == false ]] ||
+  fail "meter remains unauthenticated after an inline login"
+[[ $(stat -c '%a' "$test_root/state/omarchy/agent-meter/credentials/locked.cookies") == 600 ]] ||
+  fail "meter credentials are not private"
+pass "inline login restores remote collection without exposing credentials in argv"
+
+fresh_config="$test_root/fresh-config/agent-meter.json"
+printf '%s\n' "{\"url\":\"127.0.0.1:$port/locked\",\"username\":\"tester\",\"password\":\"secret\"}" | \
+  XDG_CONFIG_HOME="$test_root/fresh-config" XDG_STATE_HOME="$test_root/fresh-state" \
+  "$ROOT/bin/omarchy-agent-meter" --config "$fresh_config" login hermes --stdin >/dev/null ||
+  fail "first-time popup login cannot create gateway configuration"
+[[ $(jq -r '.sources.hermes.url' "$fresh_config") == "http://127.0.0.1:$port/locked" ]] ||
+  fail "first-time popup login does not retain the gateway URL"
+[[ $(stat -c '%a' "$fresh_config") == 600 ]] ||
+  fail "gateway configuration permissions are not private"
+pass "first-time popup login creates central gateway configuration"
+
+XDG_CONFIG_HOME="$test_root/fresh-config" XDG_STATE_HOME="$test_root/fresh-state" \
+  "$ROOT/bin/omarchy-agent-meter" --config "$fresh_config" local hermes >/dev/null ||
+  fail "popup cannot switch back to local Hermes usage"
+[[ $(jq -r '.sources.hermes.enabled' "$fresh_config") == false ]] ||
+  fail "local usage does not disable remote collection"
+[[ $(jq -r '.sources.hermes.url' "$fresh_config") == "http://127.0.0.1:$port/locked" ]] ||
+  fail "local usage forgets the previous remote gateway URL"
+pass "local usage preserves the remote gateway for later reconnection"

--- a/test/shell.d/agent-usage-hermes-scanner-test.sh
+++ b/test/shell.d/agent-usage-hermes-scanner-test.sh
@@ -99,6 +99,10 @@ result=$(HOME="$test_home" HERMES_HOME="$test_home/.hermes" \
   fail "Hermes collector identifies itself without inventing unified limits" "$result"
 pass "Hermes collector identifies itself and reports no unified limits"
 
+[[ $(jq -r '.retryAdvised' <<<"$result") == true ]] ||
+  fail "Hermes collector does not retry while its local database is active" "$result"
+pass "Hermes collector retries while the local ledger is settling"
+
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == 192 ]] ||
   fail "Hermes collector reconciles main usage and adds auxiliary usage once" "$result"
 pass "Hermes collector reconciles main and auxiliary usage without double-counting"

--- a/test/shell.d/agent-usage-hermes-scanner-test.sh
+++ b/test/shell.d/agent-usage-hermes-scanner-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+require_command python3
+
+test_home=$(mktemp -d)
+trap 'rm -rf "$test_home"' EXIT
+
+python3 - "$test_home" <<'PY'
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+today = time.time()
+yesterday = today - 86400
+
+def sessions_table(conn):
+  conn.execute("""
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      model TEXT,
+      billing_provider TEXT,
+      started_at REAL NOT NULL,
+      input_tokens INTEGER DEFAULT 0,
+      output_tokens INTEGER DEFAULT 0,
+      cache_read_tokens INTEGER DEFAULT 0,
+      cache_write_tokens INTEGER DEFAULT 0
+    )
+  """)
+
+main_db = home / ".hermes" / "state.db"
+main_db.parent.mkdir(parents=True)
+conn = sqlite3.connect(main_db)
+sessions_table(conn)
+conn.execute("""
+  CREATE TABLE session_model_usage (
+    session_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    billing_provider TEXT NOT NULL DEFAULT '',
+    task TEXT NOT NULL DEFAULT '',
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0
+  )
+""")
+conn.executemany("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?)", [
+  ("shared-id", "claude-sonnet-4", "anthropic", today, 100, 50, 20, 10),
+  ("fallback", "kimi-k2.5", "openrouter", yesterday, 40, 20, 0, 0),
+])
+conn.executemany("INSERT INTO session_model_usage VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", [
+  ("shared-id", "claude-sonnet-4", "anthropic", "", 60, 30, 10, 5, 15),
+  ("shared-id", "gpt-5.2-codex", "openai-codex", "", 20, 10, 0, 0, 5),
+  ("shared-id", "labs/future-model-v12", "FutureProvider", "vision", 5, 7, 0, 0, 3),
+])
+conn.commit()
+conn.close()
+
+# A legacy named profile without session_model_usage exercises aggregate
+# fallback and proves colliding session ids are distinct across databases.
+profile_db = home / ".hermes" / "profiles" / "coder" / "state.db"
+profile_db.parent.mkdir(parents=True)
+conn = sqlite3.connect(profile_db)
+sessions_table(conn)
+conn.execute(
+  "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  ("shared-id", "kimi-k2.5", "fireworks", yesterday, 30, 10, 5, 0),
+)
+conn.commit()
+conn.close()
+
+# One damaged profile must not hide healthy usage from the others.
+broken = home / ".hermes" / "profiles" / "broken" / "state.db"
+broken.parent.mkdir(parents=True)
+broken.write_text("not a sqlite database", encoding="utf-8")
+PY
+
+fake_runtime="$test_home/hermes-runtime"
+mkdir -p "$fake_runtime/venv/bin"
+cat >"$fake_runtime/venv/bin/python" <<'SH'
+#!/bin/bash
+cat >/dev/null
+printf '%s' '{"FutureProvider::labs/future-model-v12":{"provider":"Future Systems","model":"Future Model 12"}}'
+SH
+chmod +x "$fake_runtime/venv/bin/python"
+
+result=$(HOME="$test_home" HERMES_HOME="$test_home/.hermes" \
+  HERMES_INSTALL_DIR="$fake_runtime" \
+  "$ROOT/bin/omarchy-agent-usage-hermes" 2>/dev/null)
+
+[[ $(jq -r '.id + "/" + (.limits | tostring)' <<<"$result") == 'hermes/[]' ]] ||
+  fail "Hermes collector identifies itself without inventing unified limits" "$result"
+pass "Hermes collector identifies itself and reports no unified limits"
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == 192 ]] ||
+  fail "Hermes collector reconciles main usage and adds auxiliary usage once" "$result"
+pass "Hermes collector reconciles main and auxiliary usage without double-counting"
+
+[[ $(jq -c '.modelUsage["anthropic::claude-sonnet-4"]' <<<"$result") == '{"inputTokens":80,"outputTokens":40,"cacheReadInputTokens":20,"cacheCreationInputTokens":10}' ]] ||
+  fail "Hermes collector attributes only the positive main-loop residual" "$result"
+pass "Hermes collector attributes absolute-update residuals to the session route"
+
+[[ $(jq -r '.modelUsage | keys | map(select(endswith("::kimi-k2.5"))) | length' <<<"$result") == 2 ]] ||
+  fail "Hermes collector keeps identical models separate across providers" "$result"
+pass "Hermes collector separates identical models by billing provider"
+
+[[ $(jq -r '.modelUsage | has("FutureProvider::labs/future-model-v12")' <<<"$result") == true ]] ||
+  fail "Hermes collector preserves model and provider names from Hermes" "$result"
+pass "Hermes collector passes unfamiliar model and provider names through verbatim"
+
+[[ $(jq -c '.modelLabels["FutureProvider::labs/future-model-v12"]' <<<"$result") == '{"provider":"Future Systems","model":"Future Model 12"}' ]] ||
+  fail "Hermes collector uses labels resolved by the installed Hermes runtime" "$result"
+pass "Hermes collector lets Hermes supply model and provider display names"
+
+[[ $(jq -r '[.modelUsage[] | .inputTokens + .outputTokens + .cacheReadInputTokens + .cacheCreationInputTokens] | add' <<<"$result") == 297 ]] ||
+  fail "Hermes collector excludes reasoning tokens already contained in output" "$result"
+pass "Hermes collector does not double-count reasoning tokens"
+
+[[ $(jq -r '.totalSessions' <<<"$result") == 3 ]] ||
+  fail "Hermes collector distinguishes colliding session ids across profiles" "$result"
+[[ $(jq -r '.activeDays' <<<"$result") == 2 ]] ||
+  fail "Hermes collector aggregates active dates across profiles" "$result"
+[[ $(jq -r '.tierLabel' <<<"$result") == '5 providers · 4 models' ]] ||
+  fail "Hermes collector summarizes its multi-provider model mix" "$result"
+pass "Hermes collector aggregates named profiles"
+
+[[ $(jq -r '.hasPromptStats' <<<"$result") == false ]] ||
+  fail "Hermes collector does not label API calls as prompts" "$result"
+pass "Hermes collector avoids inventing prompt counts"

--- a/test/shell.d/agent-usage-hermes-scanner-test.sh
+++ b/test/shell.d/agent-usage-hermes-scanner-test.sh
@@ -91,7 +91,7 @@ printf '%s' '{"FutureProvider::labs/future-model-v12":{"provider":"Future System
 SH
 chmod +x "$fake_runtime/venv/bin/python"
 
-result=$(HOME="$test_home" HERMES_HOME="$test_home/.hermes" \
+result=$(HOME="$test_home" XDG_CONFIG_HOME="$test_home/.config" HERMES_HOME="$test_home/.hermes" \
   HERMES_INSTALL_DIR="$fake_runtime" \
   "$ROOT/bin/omarchy-agent-usage-hermes" 2>/dev/null)
 
@@ -102,6 +102,10 @@ pass "Hermes collector identifies itself and reports no unified limits"
 [[ $(jq -r '.retryAdvised' <<<"$result") == true ]] ||
   fail "Hermes collector does not retry while its local database is active" "$result"
 pass "Hermes collector retries while the local ledger is settling"
+
+[[ $(jq -r '.gatewayLoginAvailable, .gatewayUrl' <<<"$result") == true ]] ||
+  fail "installed Hermes does not expose first-time remote gateway setup" "$result"
+pass "Hermes collector exposes remote gateway setup after installation"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == 192 ]] ||
   fail "Hermes collector reconciles main usage and adds auxiliary usage once" "$result"

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -63,3 +63,56 @@ pass "update succeeds when the requested collectors all pass"
 [[ -e $usage_dir/skipped.json && ! -e $usage_dir/noisy.json ]] ||
   fail "update with agent arguments only runs the named collectors"
 pass "update with agent arguments only runs the named collectors"
+
+mkdir -p "$TEST_HOME/.config/omarchy"
+cat >"$TEST_HOME/.config/omarchy/agent-meter.json" <<'EOF'
+{"sources":{"good":{"type":"test"}}}
+EOF
+
+cat >"$FAKE_OMARCHY/bin/omarchy-agent-meter" <<'EOF'
+#!/bin/bash
+usage_dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
+mkdir -p "$usage_dir"
+echo '{"schemaVersion":1,"id":"good","name":"Remote Good","totalPrompts":9}' >"$usage_dir/good.json"
+EOF
+chmod +x "$FAKE_OMARCHY/bin/omarchy-agent-meter"
+
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" good 2>/dev/null ||
+  fail "update accepts a successful system meter collection"
+[[ $(jq -r '.name' "$usage_dir/good.json") == "Remote Good" ]] ||
+  fail "local collector overwrites a fresh system meter record"
+pass "update gives a successful system meter collection precedence"
+
+cat >"$FAKE_OMARCHY/bin/omarchy-agent-meter" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$FAKE_OMARCHY/bin/omarchy-agent-meter"
+
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" good 2>/dev/null ||
+  fail "update falls back when the system meter fails"
+[[ $(jq -r '.name' "$usage_dir/good.json") == "Good Agent" ]] ||
+  fail "update does not resume its local collector after a meter failure"
+pass "update falls back to the local collector when the meter fails"
+
+jq '.sources.good.enabled = false' "$TEST_HOME/.config/omarchy/agent-meter.json" \
+  >"$TEST_HOME/.config/omarchy/agent-meter.disabled.json"
+mv "$TEST_HOME/.config/omarchy/agent-meter.disabled.json" \
+  "$TEST_HOME/.config/omarchy/agent-meter.json"
+cat >"$FAKE_OMARCHY/bin/omarchy-agent-meter" <<'EOF'
+#!/bin/bash
+touch "$HOME/meter-called"
+exit 1
+EOF
+chmod +x "$FAKE_OMARCHY/bin/omarchy-agent-meter"
+
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" good 2>/dev/null ||
+  fail "update cannot use a local collector after remote tracking is disabled"
+[[ $(jq -r '.name' "$usage_dir/good.json") == "Good Agent" ]] ||
+  fail "disabled remote source still replaces local collection"
+[[ ! -e $TEST_HOME/meter-called ]] ||
+  fail "disabled remote source is still contacted"
+pass "update honors the local usage source selection"


### PR DESCRIPTION
## Summary

- add a system-wide, one-shot agent meter for Hermes gateway usage
- let Hermes users choose **This Computer** or **Remote Gateway** directly in the agents popup
- group timestamped remote session counters into the Omarchy computer's local calendar days, matching the existing Codex seven-day layout
- preserve the saved gateway session when switching to local usage and silently reuse it when switching back to remote
- show the inline login fields only when the gateway actually requires authentication
- collect provider and model names dynamically from Hermes instead of maintaining an Omarchy model list
- keep local collection as the default and fall back to it when a remote gateway cannot be reached

The meter has no daemon and installs nothing into Hermes' application data. Passwords are sent over stdin rather than process arguments; the saved gateway configuration and session cookie are written with mode `0600`. Session titles, previews, prompts, and responses are never written to the agents panel record.

## Relationship to the Hermes PRs

This builds on #6645 and should be reviewed as the commit after `65fbf31b`. Since that branch lives in a fork, GitHub will show #6645's commits in this PR until #6645 merges into `quattro`; the diff will then reduce automatically to the gateway integration.

This is separate from the optional Hermes installer in #6644, so people who already run Hermes can use the usage integration even if the installer is not merged.

## Testing

- `./test/cli`
- `bash test/shell.d/agent-meter-test.sh`
- `bash test/shell.d/agent-usage-hermes-scanner-test.sh`
- `bash test/shell.d/agent-usage-update-test.sh`
- `python -m py_compile bin/omarchy-agent-meter bin/omarchy-agent-usage-hermes`
- `git diff --check`
- live-tested real remote session timestamps crossing UTC/local midnight into the standard **Today** row
- live-tested local-to-remote switching with the saved cookie unchanged and no credential-field flash
- live-tested the themed source selector, first-time remote login form, switching back to local, and real local Hermes token collection

The full `./test/shell` run passes all Hermes tests. Its remaining failures on the test machine are unrelated: three packaging checks require a separate `omarchy-pkgs` checkout, and the existing multi-monitor runtime smoke check reports duplicate loading across every bar widget.
