### PR TITLE
Read /boot as root when looking for the Omarchy UKI

### DIFF
--- a/bin/omarchy-refresh-limine
+++ b/bin/omarchy-refresh-limine
@@ -3,9 +3,11 @@
 # omarchy:summary=Overwrite the user config for the Limine bootloader and rebuild it.
 # omarchy:requires-sudo=true
 
-if [[ -f /boot/EFI/Linux/omarchy_linux.efi ]] && [[ -f /boot/EFI/Linux/$(cat /etc/machine-id)_linux.efi ]]; then
+legacy_uki="/boot/EFI/Linux/$(cat /etc/machine-id)_linux.efi"
+
+if sudo test -f /boot/EFI/Linux/omarchy_linux.efi && sudo test -f "$legacy_uki"; then
   echo "Cleanup extra UKI"
-  sudo rm -f /boot/EFI/Linux/$(cat /etc/machine-id)_linux.efi
+  sudo rm -f "$legacy_uki"
 fi
 echo "Resetting limine config"
 

--- a/bin/omarchy-setup-direct-boot
+++ b/bin/omarchy-setup-direct-boot
@@ -38,7 +38,7 @@ if [[ -n $existing_entry ]]; then
 
   exit 0
 else
-  uki_file=$(find /boot/EFI/Linux/ -name "omarchy*.efi" -printf "%f\n" 2>/dev/null | head -1)
+  uki_file=$(sudo find /boot/EFI/Linux/ -name "omarchy*.efi" -printf "%f\n" 2>/dev/null | head -1)
 
   if [[ -z $uki_file ]]; then
     echo "Error: No Omarchy UKI found in /boot/EFI/Linux/" >&2


### PR DESCRIPTION
Fixes #6651.

On encrypted installs the ESP is mounted at `/boot` with `dmask=0077`, so the directory is root-only. Two commands probed it unprivileged and silently treated the resulting `EACCES` as "not found".

`omarchy-setup-direct-boot` searched for the UKI with a plain `find`, swallowed the permission error with `2>/dev/null`, and reported `Error: No Omarchy UKI found in /boot/EFI/Linux/` even though `omarchy_linux.efi` was sitting right there. That made direct boot unusable on every encrypted install.

`omarchy-refresh-limine` had the same flaw in its `[[ -f ... ]]` tests, where it failed quietly instead: both tests were always false, so the stale `<machine-id>_linux.efi` left over from pre-quattro custom-UKI installs was never cleaned up.

Both now read `/boot` through `sudo`, matching what `omarchy-upgrade-to-quattro` already does with `as_root find /boot/EFI/Linux`. `efibootmgr` and `findmnt` reads are left alone — they work fine unprivileged.

One behavior change worth noting: `omarchy-setup-direct-boot` now asks for the sudo password before the `gum confirm`, rather than after. The command is marked `requires-sudo=true` and the menu runs it in a floating terminal, so there is a prompt available either way.

— 🤖 Claude, posting on behalf of @dhh