### PR TITLE
Claude collector: attribute pi usage by provider, not api prefix

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -361,8 +361,7 @@ def scan_pi_usage(max_age_seconds: float) -> dict[str, Any] | None:
               if entry.get("type") != "message" or message.get("role") != "assistant":
                 continue
               provider = str(message.get("provider") or "")
-              api = str(message.get("api") or "")
-              if provider != "anthropic" and not api.startswith("anthropic"):
+              if provider != "anthropic":
                 continue
               unique_key = f"{path}:{entry.get('id') or line_number}"
               if unique_key in seen:

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -112,6 +112,7 @@ mkdir -p "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/pro
 cat >"$PI_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
 {"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","api":"anthropic-messages","model":"claude-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
 {"type":"message","id":"codex-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"openai-codex","model":"gpt-test","usage":{"input":999,"output":999}}}
+{"type":"message","id":"kimi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"kimi-coding","api":"anthropic-messages","model":"k3","usage":{"input":999,"output":999}}}
 EOF
 cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
 { "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "anthropic", "model": "claude-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }


### PR DESCRIPTION
## Problem

The Claude usage tab shows buckets for models that are not Claude at all.

On a machine without a Claude login, the bar still appeared with Kimi k3 / k3-256k values under the "Claude Code" label, charged entirely from local pi sessions.

## Root cause

`omarchy-agent-usage-claude`'s pi/omp scan included any session whose `api` field merely started with `anthropic`:

```python
if provider != "anthropic" and not api.startswith("anthropic"):
    continue
```

Kimi and other providers that speak the `anthropic-messages` protocol (`provider: kimi-coding`, `api: anthropic-messages`) were therefore attributed to Claude Code. Since the panel shows anything where `totalPrompts > 0`, a non-logged-in Claude still rendered a tab full of foreign models.

Falling back to `api` also risked counting a third-party router that presents an anthropic-style api but is not this subscription — the same class of bug the codex collector already avoids by matching `provider == "openai-codex"` exactly.

## Change

Match the codex collector's provider-only attribution: count a pi/omp session toward Claude usage **only when `provider == "anthropic"`**.

```python
if provider != "anthropic":
    continue
```

## Test

Adds a case to `agent-usage-claude-scanner-test.sh`: a `kimi-coding`-provider session using `api: anthropic-messages` (model `k3`) must be excluded from the Claude record, keeping `.todayTotalTokens == 49` and `.modelUsage` free of the `k3` bucket.
