### PR TITLE
Carry tmux's tab moves, zoom flag, and hostname into herdr

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -56,6 +56,10 @@ switch_tab = ["prefix+1..9", "alt+1..9"]
 previous_tab = ["prefix+p", "alt+left"]
 next_tab = ["prefix+n", "alt+right"]
 
+# Like swap-window -t -1/+1 on M-S-Left/Right
+move_tab_previous = "alt+shift+left"
+move_tab_next = "alt+shift+right"
+
 # Sessions -> workspaces
 new_workspace = "prefix+shift+c"
 rename_workspace = "prefix+shift+r"
@@ -80,3 +84,6 @@ prompt_new_tab_name = false
 
 # set -g mouse on
 mouse_capture = true
+
+# tmux showed #h in status-right; the ZOOM flag shows there automatically
+tab_bar_hostname = true

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -70,8 +70,9 @@ next_workspace = ["prefix+shift+n", "alt+down"]
 [ui]
 accent = "blue"
 
-# tmux drew single-line dividers between adjacent panes
+# tmux drew single-line dividers between adjacent panes and no outer frame
 pane_gaps = false
+pane_outer_borders = false
 
 # tmux had no scrollbar column beside its panes
 pane_scrollbars = false


### PR DESCRIPTION
Closes the remaining status-right and window-management gaps from the tmux setup, now that herdr carries the needed features in our fork build (submitted upstream as herdrdev/herdr#2560, #2561, and #2562):

- `move_tab_previous`/`move_tab_next` on `alt+shift+left/right` — tmux's `swap-window -t -1/+1` on `M-S-Left/Right`, wrapping at either end
- `tab_bar_hostname = true` puts the machine hostname at the right edge of the tab bar, where `#h` lived in status-right; remote sessions show the remote host
- the ZOOM flag from `#{?window_zoomed_flag,ZOOM ,}` now renders automatically as a right-aligned pill next to the hostname whenever the focused pane is zoomed — no config needed

Requires the `herdr` package at 0.8.0.r3, which pins the fork commit carrying all three patches plus the earlier resize bindings.

— 🤖 Claude, posting on behalf of @dhh
