### PR TITLE
Codex collector: strict provider attribution and thread-settings models

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -254,6 +254,26 @@ def scan_native_codex_sessions():
   for path in files:
     current_model = "codex"
     try:
+      # A session may log token counts before its first model event. Read the
+      # first model the file records so those early counts land on the real
+      # model instead of a generic "codex" bucket.
+      with path.open(errors="replace") as handle:
+        for raw in handle:
+          try:
+            entry = json.loads(raw)
+          except Exception:
+            continue
+          payload = entry.get("payload") or {}
+          if entry.get("type") == "turn_context":
+            current_model = model_name(payload.get("model") or payload.get("model_slug") or current_model)
+            break
+          if payload.get("type") == "thread_settings_applied":
+            current_model = model_name((payload.get("thread_settings") or {}).get("model") or current_model)
+            break
+    except Exception:
+      pass
+
+    try:
       with path.open(errors="replace") as handle:
         for raw in handle:
           try:
@@ -265,6 +285,14 @@ def scan_native_codex_sessions():
             current_model = model_name(payload.get("model") or payload.get("model_slug") or current_model)
             continue
           payload = entry.get("payload") or entry
+          if entry.get("type") == "event_msg":
+            payload = entry.get("payload") or {}
+            # Newer sessions record the model in thread_settings_applied (and
+            # omit turn_context), so they would otherwise fall into a generic
+            # "codex" bucket.
+            if payload.get("type") == "thread_settings_applied":
+              current_model = model_name((payload.get("thread_settings") or {}).get("model") or current_model)
+              continue
           if entry.get("type") == "response_item" and isinstance(payload, dict):
             payload = payload.get("payload") or payload
           if not isinstance(payload, dict):

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -166,8 +166,7 @@ def scan_pi_sessions():
       if message.get("role") != "assistant":
         continue
       provider = str(message.get("provider") or "")
-      api = str(message.get("api") or "")
-      if provider != "openai-codex" and not api.startswith("openai-codex"):
+      if provider != "openai-codex":
         continue
 
       usage = message.get("usage") or {}

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -63,6 +63,7 @@ mkdir -p "$PI_HOME/bin" "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/age
 cp "$TEST_HOME/bin/codex" "$PI_HOME/bin/codex"
 cat >"$PI_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
 {"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"openai-codex","api":"openai-codex-responses","model":"gpt-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
+{"type":"message","id":"pi-router-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"third-party-router","api":"openai-codex-responses","model":"gpt-5.6-sol","usage":{"input":500,"output":200,"totalTokens":700}}}
 EOF
 cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
 { "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "openai-codex", "model": "gpt-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }
@@ -77,6 +78,17 @@ result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex" XDG_DATA_HOME="$PI_HOME/.l
 [[ $(jq -c '.modelUsage' <<<"$result") == '{"gpt-pi":{"inputTokens":10,"outputTokens":4,"cacheReadInputTokens":3,"cacheCreationInputTokens":2},"gpt-omp":{"inputTokens":20,"outputTokens":5,"cacheReadInputTokens":4,"cacheCreationInputTokens":1}}' ]] ||
   fail "Codex collector filters pi and omp sessions to Codex providers" "$result"
 pass "Codex collector counts pi and omp subscription usage"
+
+# A third-party router can serve an openai-codex-style api while serving
+# models that are not this subscription. Attribution must stay strict to the
+# provider so those pods never land in the Codex record.
+result_router=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  PATH="$PI_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+[[ $(jq -r '.todayTotalTokens' <<<"$result_router") == "49" ]] ||
+  fail "Codex collector leaves no bucket for a third-party provider" "$result_router"
+[[ $(jq -r '((.modelUsage["gpt-5.6-sol"] // null) == null)' <<<"$result_router") == "true" ]] ||
+  fail "Codex collector ignores api-prefix lookalikes" "$result_router"
+pass "Codex collector ignores api-prefix lookalikes from other providers"
 
 # A subscription burned entirely through opencode has no native session files;
 # usage must come from opencode's message database, filtered to OpenAI.

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -40,16 +40,33 @@ cat >"$session" <<EOF
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}}}}
 EOF
 
+# A session with no turn_context at all: the model only appears in a
+# thread_settings_applied event, and the first token count precedes it. Both
+# the pre-pass model seeding and the in-loop lookup must attribute these
+# turns to the real model instead of a generic "codex" bucket.
+thread_session="$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)/rollout-thread.jsonl"
+cat >"$thread_session" <<EOF
+{"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":40,"cached_input_tokens":20,"output_tokens":10,"reasoning_output_tokens":2,"total_tokens":50},"last_token_usage":{"input_tokens":40,"cached_input_tokens":20,"output_tokens":10,"reasoning_output_tokens":2,"total_tokens":50}}}}
+{"timestamp":"$timestamp","type":"event_msg","payload":{"type":"thread_settings_applied","thread_settings":{"model":"gpt-thread","model_provider_id":"openai"}}}
+{"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":90,"cached_input_tokens":45,"output_tokens":22,"reasoning_output_tokens":4,"total_tokens":112},"last_token_usage":{"input_tokens":50,"cached_input_tokens":25,"output_tokens":12,"reasoning_output_tokens":2,"total_tokens":62}}}}
+EOF
+
 result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
 
-[[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "322" ]] ||
   fail "Codex collector counts each turn once" "$result"
 pass "Codex collector counts each turn once"
 
 [[ $(jq -c '.modelUsage["gpt-test"]' <<<"$result") == '{"inputTokens":70,"outputTokens":30,"cacheReadInputTokens":110,"cacheCreationInputTokens":0}' ]] ||
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
+
+[[ $(jq -c '.modelUsage["gpt-thread"]' <<<"$result") == '{"inputTokens":45,"outputTokens":22,"cacheReadInputTokens":45,"cacheCreationInputTokens":0}' ]] ||
+  fail "Codex collector attributes early token counts to the thread-settings model" "$result"
+[[ $(jq -c '.modelUsage | has("codex")' <<<"$result") == "false" ]] ||
+  fail "Codex collector leaves no generic codex bucket" "$result"
+pass "Codex collector attributes thread-settings sessions to their model"
 
 [[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
   fail "Codex collector identifies itself with an empty limits list" "$result"


### PR DESCRIPTION
Brings the Codex scanner fixes upstreamed in the `model-usage` plugin (PR #6478) into the new `omarchy.agents` collector design.

### Provider attribution is strict
Pi/omp sessions were charged to Codex when the `api` field merely started with `openai-codex`. A third-party router serving the same models behind an `openai-codex-responses` api was therefore added to this subscription's buckets. Only sessions whose `provider` is exactly `openai-codex` now count, matching the Claude collector fix (#6655).

**Test:** `test/shell.d/agent-usage-codex-scanner-test.sh` gains a third-party-router session using the `openai-codex-responses` api, which must not land in the Codex record.

**Models from thread settings:** sessions without `turn_context` record their model in `thread_settings_applied` (and may log token counts before any model event). A pre-pass seeds the first model-bearing entry, and `thread_settings_applied` updates are followed during the scan, so those turns land on the real model instead of a generic `codex` bucket (see commit `9394794b`, `acc72519` of #6478).

**Regression test:** a session whose model only appears in `thread_settings_applied`, with the first token count preceding it, is attributed correctly and leaves no generic bucket.