### PR TITLE
Add hyprland-config hook on config reload

### DIFF
--- a/bin/omarchy-hyprland-config-reloaded
+++ b/bin/omarchy-hyprland-config-reloaded
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# omarchy:summary=Fire the hyprland-config hook with the config files changed since the last Hyprland config reload.
+# omarchy:hidden=true
+
+set -euo pipefail
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/hyprland-config"
+SNAPSHOT="$STATE_DIR/snapshot"
+
+changed=()
+declare -A snapshot_hashes=()
+
+snapshot_exists=0
+[[ -f $SNAPSHOT ]] && snapshot_exists=1
+
+# Iterating the sorted glob keeps the reported file order deterministic.
+shopt -s nullglob
+for file in "$CONFIG_DIR"/*.lua; do
+  [[ -f $file ]] || continue
+  name=$(basename "$file")
+  hash=$(sha256sum "$file" | cut -d' ' -f1)
+  snapshot_hashes["$name"]=$hash
+
+  if (( snapshot_exists )); then
+    old_hash=$(grep -F "${name}=" "$SNAPSHOT" 2>/dev/null | cut -d= -f2- || true)
+    if [[ $old_hash != "$hash" ]]; then
+      changed+=("${name%.lua}")
+    fi
+  fi
+done
+
+mkdir -p "$STATE_DIR"
+: > "$SNAPSHOT.tmp"
+for name in "${!snapshot_hashes[@]}"; do
+  printf '%s=%s\n' "$name" "${snapshot_hashes[$name]}"
+done > "$SNAPSHOT.tmp"
+mv "$SNAPSHOT.tmp" "$SNAPSHOT"
+
+csv=$(IFS=,; printf '%s' "${changed[*]}")
+omarchy-hook hyprland-config "$csv"

--- a/default/agents/skills/omarchy/hooks.md
+++ b/default/agents/skills/omarchy/hooks.md
@@ -13,6 +13,7 @@ file first, if one exists.
 ~/.config/omarchy/hooks/
 ├── battery-low.d/          # Low battery (percentage in $1)
 ├── font-set.d/             # After font change (font name in $1)
+├── hyprland-config.d/      # After a successful Hyprland config reload (changed config files in $1)
 ├── post-boot.d/            # After the desktop starts
 ├── post-update.d/          # During `omarchy update`, after system packages and migrations
 ├── pre-refresh-pacman.d/   # Before `omarchy refresh pacman` re-syncs packages

--- a/default/agents/skills/omarchy/hyprland.md
+++ b/default/agents/skills/omarchy/hyprland.md
@@ -25,6 +25,10 @@ defaults, so overrides go here:
 - If `hyprctl configerrors` reports errors, address them and rerun validation until clean or until a real blocker is identified
 - Use `omarchy refresh hyprland` to reset the Lua config files to defaults
 
+**Automation hook:** `hyprland-config` fires on every successful reload, with the
+changed config files in `$1` (comma-separated, empty when nothing changed),
+named without the `.lua` extension (e.g. `bindings`, `looknfeel`). See `hooks.md`.
+
 The two `.conf` files are read by separate processes, so `hyprctl` neither
 applies nor validates them:
 - `hyprsunset.conf` (night light): apply changes with `omarchy restart hyprsunset`; reset with `omarchy refresh hyprsunset`

--- a/default/hypr/hooks.lua
+++ b/default/hypr/hooks.lua
@@ -1,0 +1,7 @@
+-- Fire Omarchy hooks whenever Hyprland finishes reloading its config.
+-- Runs only after a successful reload (syntax errors refuse the reload and
+-- never emit this event). The hook command diffs the config files against the
+-- last reload and reports the changed config files as its argument.
+hl.on("config.reloaded", function()
+  hl.exec_cmd("omarchy-hyprland-config-reloaded")
+end)

--- a/default/hypr/omarchy.lua
+++ b/default/hypr/omarchy.lua
@@ -5,6 +5,7 @@ local require_optional = require("default.hypr.require_optional")
 
 -- Use Omarchy defaults, but don't edit these directly.
 require("default.hypr.autostart")
+require("default.hypr.hooks")
 if _G.omarchy_default_bindings ~= false then
   require("default.hypr.bindings.media")
   require("default.hypr.bindings.clipboard")

--- a/test/shell.d/hyprland-config-reloaded-test.sh
+++ b/test/shell.d/hyprland-config-reloaded-test.sh
@@ -54,7 +54,7 @@ grep -Fx 'HOOK CALL: hyprland-config bindings,looknfeel' "$test_tmp/log.txt" >/d
 pass "config hook reports changed config files in filename order"
 
 run_hook
-[[ $(grep -c '^HOOK CALL:' "$test_tmp/log.txt") -eq 3 ]] || fail "unchanged reload still fires the hook"
+(( $(grep -c '^HOOK CALL:' "$test_tmp/log.txt") == 3 )) || fail "unchanged reload still fires the hook"
 grep -Fx 'HOOK CALL: hyprland-config ' "$test_tmp/log.txt" >/dev/null
 pass "unchanged reload fires the hook with no files"
 

--- a/test/shell.d/hyprland-config-reloaded-test.sh
+++ b/test/shell.d/hyprland-config-reloaded-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+require_command sha256sum
+
+command_path="$ROOT/bin/omarchy-hyprland-config-reloaded"
+hooks_lua="$ROOT/default/hypr/hooks.lua"
+
+grep -F '%.lua}' "$command_path" >/dev/null
+grep -F 'omarchy-hook hyprland-config "$csv"' "$command_path" >/dev/null
+grep -F 'omarchy/hyprland-config' "$command_path" >/dev/null
+grep -F 'SNAPSHOT=' "$command_path" >/dev/null
+pass "config hook reports changed config files by name"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+config_dir="$test_home/.config/hypr"
+mkdir -p "$stub_bin" "$config_dir"
+
+cat >"$stub_bin/omarchy-hook" <<SH
+#!/bin/bash
+echo "HOOK CALL: \$*" >>"\$TEST_LOG"
+SH
+chmod +x "$stub_bin/omarchy-hook"
+
+run_hook() {
+  HOME="$test_home" \
+  XDG_CONFIG_HOME="$test_home/.config" \
+  XDG_STATE_HOME="$test_home/.local/state" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$test_tmp/log.txt" \
+    "$command_path"
+}
+
+for file in bindings.lua looknfeel.lua monitors.lua input.lua autostart.lua hyprland.lua foo.lua; do
+  echo "-- $file" >"$config_dir/$file"
+done
+
+run_hook
+grep -Fx 'HOOK CALL: hyprland-config ' "$test_tmp/log.txt" >/dev/null
+pass "first config hook run establishes the baseline with no files"
+
+echo '-- changed' >>"$config_dir/bindings.lua"
+echo '-- changed' >>"$config_dir/looknfeel.lua"
+run_hook
+grep -Fx 'HOOK CALL: hyprland-config bindings,looknfeel' "$test_tmp/log.txt" >/dev/null
+pass "config hook reports changed config files in filename order"
+
+run_hook
+[[ $(grep -c '^HOOK CALL:' "$test_tmp/log.txt") -eq 3 ]] || fail "unchanged reload still fires the hook"
+grep -Fx 'HOOK CALL: hyprland-config ' "$test_tmp/log.txt" >/dev/null
+pass "unchanged reload fires the hook with no files"
+
+cat >"$test_tmp/hooks-check.lua" <<'LUA_EOF'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local registered = {}
+local exec_cmds = {}
+hl = {
+  on = function(event, callback)
+    registered[event] = callback
+  end,
+  exec_cmd = function(command)
+    exec_cmds[#exec_cmds + 1] = command
+  end,
+}
+
+require("default.hypr.hooks")
+
+if not registered["config.reloaded"] then
+  print("not ok - hooks module registers config.reloaded")
+  os.exit(1)
+end
+print("ok - hooks module registers config.reloaded")
+
+registered["config.reloaded"]()
+if exec_cmds[1] ~= "omarchy-hyprland-config-reloaded" then
+  print("not ok - config reload fires the hook command")
+  os.exit(1)
+end
+print("ok - config reload fires the hook command")
+LUA_EOF
+lua_output=$(OMARCHY_PATH="$ROOT" lua "$test_tmp/hooks-check.lua" 2>&1) || fail "hooks module lua check failed" "$lua_output"
+grep -q '^ok - hooks module registers config.reloaded$' <<<"$lua_output"
+grep -q '^ok - config reload fires the hook command$' <<<"$lua_output"
+pass "hooks module registers config.reloaded and fires the hook command"


### PR DESCRIPTION
Fires the `hyprland-config` hook after every successful Hyprland config
reload (login, file save, `hyprctl reload`), passing the changed config
files — comma-separated, no `.lua` extension — in `$1` (empty when nothing
changed).

- `default/hypr/hooks.lua` registers `hl.on("config.reloaded")`; syntax
  errors refuse the reload, so the hook never fires on broken configs.
- `bin/omarchy-hyprland-config-reloaded` diffs sha256 fingerprints of
  `~/.config/hypr/*.lua` against a state snapshot and runs
  `omarchy-hook hyprland-config "$1"`.
- Install scripts with `omarchy hook install hyprland-config <script>`.
- Docs (hooks.md, hyprland.md) and shell test included.

this pr supersedes #6639 , a correct way to live sync the shell will be using this hook

this will also be helpful for my pr  #6593 which already has hyprland look config sync, but just by reopening, not live