### PR TITLE
Swap terminaltexteffects for ttfx

### DIFF
--- a/bin/omarchy-debug-idle
+++ b/bin/omarchy-debug-idle
@@ -32,7 +32,7 @@ journalctl -t omarchy-shell -n "$lines" --no-pager --quiet 2>/dev/null || true
 
 section "Relevant processes"
 ps -eo pid=,args= \
-  | grep -E 'quickshell -n -p|omarchy-system-sleep-monitor|systemd-inhibit.*Lock screen before suspend|org\.omarchy\.screensaver|omarchy-screensaver|(^|/| )tte( |$)' \
+  | grep -E 'quickshell -n -p|omarchy-system-sleep-monitor|systemd-inhibit.*Lock screen before suspend|org\.omarchy\.screensaver|omarchy-screensaver|(^|/| )ttfx( |$)' \
   | grep -v grep || true
 
 section "Sleep lock service"

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Launch the Omarchy screensaver in the default terminal on the system with the correct font configuration.
 
-if omarchy-cmd-missing tte; then
+if omarchy-cmd-missing ttfx; then
   exit 1
 fi
 

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -402,7 +402,7 @@ greeter_screen() {
   # nested function so the wait loop below can repaint it verbatim if the VT
   # resizes out from under us: a late resize (virtio-gpu KMS handoff, or the SDL
   # window's size arriving) scrolls the old frame into the top-left and resets
-  # the DEC saved cursor tte paints from — exactly the tiled/garbled logo we saw
+  # the DEC saved cursor ttfx paints from — exactly the tiled/garbled logo we saw
   # on a fresh first boot. Redrawing on every resize beats any fixed-length
   # startup wait, which can only ever guess when the console has stopped moving.
   _greeter_draw() {
@@ -454,7 +454,7 @@ greeter_screen() {
 
     # ColorShift the logo: a green base (indexed color 2) with a cyan accent (6)
     # drifting through, settling on green. Indexed ANSI colors, not hex — the
-    # framebuffer console can't render tte's truecolor faithfully (it crushes the
+    # framebuffer console can't render ttfx's truecolor faithfully (it crushes the
     # palette to a muddy lavender), but the 16 indexed colors map to the Tokyo
     # Night palette and render true. One long-running invocation (many cycles) so
     # it never restarts — a restart is what flashed. The effect reads from
@@ -462,13 +462,13 @@ greeter_screen() {
     # --reuse-canvas paints upward from the saved cursor, anchored one row below
     # the logo to repaint exactly the rows drawn above. --canvas-width is cols-1
     # to stay off the autowrap column.
-    if command -v tte >/dev/null 2>&1; then
+    if command -v ttfx >/dev/null 2>&1; then
       printf '%s%d;1H\0337' "$CSI" "$((logo_row + LOGO_HEIGHT))"
-      # Run tte directly (not inside a `while` subshell) so $anim is tte's own
-      # PID: killing a wrapping subshell would orphan tte, which then keeps
+      # Run ttfx directly (not inside a `while` subshell) so $anim is ttfx's own
+      # PID: killing a wrapping subshell would orphan ttfx, which then keeps
       # painting the logo over the keyboard step. --cycles is high enough that it
       # never ends on its own before Return.
-      tte -i "$LOGO_PATH" \
+      ttfx -i "$LOGO_PATH" \
         --canvas-width "$((cols - 1))" \
         --anchor-text c \
         --frame-rate 60 \
@@ -485,8 +485,8 @@ greeter_screen() {
 
   _greeter_kill_anim() {
     [[ -n ${anim:-} ]] || return 0
-    # Guard both: `kill` returns non-zero if tte already exited (crash, or a
-    # resize race), and `wait` reports tte's kill signal (143) — either would
+    # Guard both: `kill` returns non-zero if ttfx already exited (crash, or a
+    # resize race), and `wait` reports ttfx's kill signal (143) — either would
     # abort provisioning under `set -e` and drop straight to the login screen.
     kill "$anim" 2>/dev/null || true
     wait "$anim" 2>/dev/null || true
@@ -527,7 +527,7 @@ greeter_screen() {
 
   trap - WINCH
   _greeter_kill_anim
-  # tte leaves the tty in raw/no-echo mode when killed; restore it or the gum
+  # ttfx leaves the tty in raw/no-echo mode when killed; restore it or the gum
   # prompts in the keyboard step that follows silently die. Then clear the
   # leftover animation frame.
   stty sane </dev/tty 2>/dev/null || true

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -8,7 +8,7 @@ screensaver_in_focus() {
 
 exit_screensaver() {
   hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
-  pkill -x tte 2>/dev/null
+  pkill -x ttfx 2>/dev/null
   pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null
   exit 0
 }
@@ -23,11 +23,11 @@ hyprctl eval 'hl.config({ cursor = { invisible = true } })' &>/dev/null || hyprc
 tty=$(tty 2>/dev/null)
 
 while true; do
-  tte -i ~/.config/omarchy/branding/screensaver.txt \
+  ttfx -i ~/.config/omarchy/branding/screensaver.txt \
     --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --no-eol --no-restore-cursor &
 
-  while pgrep -t "${tty#/dev/}" -x tte >/dev/null; do
+  while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do
     if read -n1 -t 1 || ! screensaver_in_focus; then
       exit_screensaver
     fi

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -104,7 +104,7 @@ postgresql-libs
 power-profiles-daemon
 python-gobject
 python-poetry-core
-python-terminaltexteffects
+ttfx
 qemu-user-static-binfmt
 qrencode
 quickshell-git

--- a/migrations/1786355450.sh
+++ b/migrations/1786355450.sh
@@ -1,0 +1,4 @@
+echo "Replace terminaltexteffects with ttfx"
+
+omarchy-pkg-add ttfx
+omarchy-pkg-drop python-terminaltexteffects


### PR DESCRIPTION
Replaces `python-terminaltexteffects` with [`ttfx`](https://github.com/omacom-io/ttfx), a Rust port that renders **byte-identical frames** as one dependency-free binary.

> [!IMPORTANT]
> Depends on omacom-io/omarchy-pkgs#127, which adds the `ttfx` package. That needs to land and build before this merges, since `omarchy-base.packages` references it.

### Why

The screensaver runs at `--frame-rate 120` with `--random-effect`. On a fullscreen canvas Python cannot hold that for the heavier effects — 120 fps needs ≤ 8.33 ms/frame:

| At 200×50 cells | ttfx | Python TTE |
|---|---|---|
| beams | 1.77 ms/frame (564 fps) | **14.14 ms/frame (71 fps)** |
| slide | 0.20 ms/frame | 3.78 ms/frame |
| waves | 0.24 ms/frame | 2.04 ms/frame |
| startup | 1.2 ms | 107 ms |

So today the screensaver visibly drops frames whenever `--random-effect` rolls a heavy one. Median speedup across all 37 effects is 9.6×.

It also takes Python off the base image for this purpose, and the first-boot provisioning animation in `omarchy-provision-owner` starts ~100 ms sooner — which is the moment it matters most, since it races the rest of first boot.

### What changed

Nothing but the command name — ttfx is CLI-compatible with `tte` (same option names, defaults, exit codes), so every existing invocation is byte-for-byte the same call:

- `install/omarchy-base.packages` — `python-terminaltexteffects` → `ttfx`
- `bin/omarchy-screensaver` — command, `pkill -x`, `pgrep -x`
- `bin/omarchy-launch-screensaver` — `omarchy-cmd-missing` guard
- `bin/omarchy-provision-owner` — the colorshift invocation (and comments)
- `bin/omarchy-debug-idle` — the process-match pattern

I verified both real invocations from this repo run unmodified under ttfx, including every flag they use: `--frame-rate`, `--canvas-width/height 0`, `--reuse-canvas`, `--anchor-canvas/text`, `--random-effect`, `--no-eol`, `--no-restore-cursor`, and colorshift's `--gradient-stops/-frames`, `--cycles`, `--final-gradient-stops`.

### On fidelity

This is a parity port, not a lookalike. CI checks it against upstream v0.15.0 on every push: 354 frame-parity cases byte-for-byte across configs and seeds, 41 full tty byte-stream cases (canvas prep, cursor moves, teardown), 19 CLI contract checks. Upstream's quirks are reproduced deliberately rather than fixed, down to Python's banker's rounding and its integer-floor-division gradients.

Credit for every effect and the engine design belongs to [ChrisBuilds](https://github.com/ChrisBuilds/terminaltexteffects); MIT licensed with the original copyright preserved.

### Worth a look before merging

`omarchy-provision-owner` runs on the framebuffer console at first boot, which is the one path I could not exercise here. It is guarded by `command -v ttfx`, so a missing binary degrades to no animation rather than breaking provisioning — but the truecolor-to-16-color behaviour on that console is worth a real first-boot check.

— 🤖 Claude, posting on behalf of @dhh
