### PR TITLE
Persist Bluetooth power state instead of forcing it off

### DIFF
--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -9,29 +9,74 @@
 # Powered key into /var/lib/bluetooth/<adapter>/settings, so bluetoothd has no
 # way to bring an adapter back up in the state the user left it. Driven by
 # omarchy-bluetooth-state.service, which saves on stop and restores on start.
+#
+# AutoEnable stays off so bluetoothd never powers the adapter itself. That is
+# what keeps restore deterministic: BlueZ powers adapters on asynchronously,
+# well after it takes its D-Bus name, so anything racing it to set the state
+# loses. Owning the power-on outright means there is no race to lose.
 
 STATE_FILE=${OMARCHY_BLUETOOTH_STATE_FILE:-/var/lib/omarchy/bluetooth-powered}
+ADAPTER_WAIT_TRIES=${OMARCHY_BLUETOOTH_ADAPTER_WAIT_TRIES:-20}
+
+show() {
+  timeout 2s bluetoothctl show 2>/dev/null
+}
+
+# bluetoothd registers the adapter on D-Bus a moment after it takes its bus
+# name, and systemd starts this unit the instant that name appears. Until the
+# adapter exists, `bluetoothctl show` reports no Powered line at all.
+wait_for_adapter() {
+  local i
+
+  for ((i = 0; i < ADAPTER_WAIT_TRIES; i++)); do
+    [[ $(show) == *"Powered:"* ]] && return 0
+    sleep 0.5
+  done
+
+  return 1
+}
 
 case "${1:-}" in
   save)
+    state=$(show)
+
+    # No adapter to read. Keep the last known state rather than recording a
+    # spurious "off" that the next boot would apply.
+    [[ $state == *"Powered:"* ]] || exit 0
+
     mkdir -p "$(dirname "$STATE_FILE")"
-    if [[ $(timeout 2s bluetoothctl show 2>/dev/null) == *"Powered: yes"* ]]; then
+    if [[ $state == *"Powered: yes"* ]]; then
       echo on >"$STATE_FILE"
     else
       echo off >"$STATE_FILE"
     fi
     ;;
   restore)
-    # No saved state means a fresh install, so leave the adapter alone and let
-    # BlueZ's own AutoEnable default power it on. Reaching for a default here
-    # instead would mean a failure in this unit could leave a brand new machine
-    # with Bluetooth dead and no obvious way to notice.
-    [[ -r $STATE_FILE ]] || exit 0
+    # No saved state means a fresh install, so power on and match what stock
+    # BlueZ would have done with AutoEnable left at its default.
+    target=on
+    if [[ -r $STATE_FILE ]]; then
+      read -r saved <"$STATE_FILE" || saved=""
+      [[ $saved == "on" || $saved == "off" ]] && target=$saved
+    fi
 
-    read -r state <"$STATE_FILE" || exit 0
-    [[ $state == "on" || $state == "off" ]] || exit 0
+    # Nothing to do, and nothing to race: with AutoEnable off, bluetoothd
+    # leaves the adapter down on its own.
+    [[ $target == "off" ]] && exit 0
 
-    timeout 5s bluetoothctl power "$state" >/dev/null 2>&1 || true
+    if ! wait_for_adapter; then
+      echo "omarchy-bluetooth-state: no adapter appeared, leaving power alone" >&2
+      exit 0
+    fi
+
+    [[ $(show) == *"Powered: yes"* ]] && exit 0
+
+    timeout 5s bluetoothctl power on >/dev/null 2>&1
+
+    # Worth a journal line: this is the failure that leaves a machine with
+    # Bluetooth off and no obvious cause.
+    [[ $(show) == *"Powered: yes"* ]] ||
+      echo "omarchy-bluetooth-state: failed to power the adapter on" >&2
     ;;
   *)
     echo "Usage: omarchy-bluetooth-state <save|restore>" >&2

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# omarchy:summary=Save and restore the Bluetooth power state across reboots
+# omarchy:group=bluetooth
+# omarchy:args=<save|restore>
+# omarchy:hidden=true
+
+# BlueZ does not persist an adapter's Powered property. Nothing ever writes a
+# Powered key into /var/lib/bluetooth/<adapter>/settings, so bluetoothd has no
+# way to bring an adapter back up in the state the user left it. Driven by
+# omarchy-bluetooth-state.service, which saves on stop and restores on start.
+
+STATE_FILE=${OMARCHY_BLUETOOTH_STATE_FILE:-/var/lib/omarchy/bluetooth-powered}
+
+case "${1:-}" in
+  save)
+    mkdir -p "$(dirname "$STATE_FILE")"
+    if [[ $(timeout 2s bluetoothctl show 2>/dev/null) == *"Powered: yes"* ]]; then
+      echo on >"$STATE_FILE"
+    else
+      echo off >"$STATE_FILE"
+    fi
+    ;;
+  restore)
+    # No saved state means a fresh install, so leave the adapter alone and let
+    # BlueZ's own AutoEnable default power it on. Reaching for a default here
+    # instead would mean a failure in this unit could leave a brand new machine
+    # with Bluetooth dead and no obvious way to notice.
+    [[ -r $STATE_FILE ]] || exit 0
+
+    read -r state <"$STATE_FILE" || exit 0
+    [[ $state == "on" || $state == "off" ]] || exit 0
+
+    timeout 5s bluetoothctl power "$state" >/dev/null 2>&1 || true
+    ;;
+  *)
+    echo "Usage: omarchy-bluetooth-state <save|restore>" >&2
+    exit 1
+    ;;
+esac

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -42,31 +42,45 @@ write_state() {
     mv -f "$STATE_FILE.new" "$STATE_FILE"
 }
 
-# Non-zero means no adapter could be read and nothing was recorded.
-save_state() {
+autoenable_disabled() {
+  awk '
+    /^[[:space:]]*\[/ { in_policy = ($0 ~ /^[[:space:]]*\[Policy\][[:space:]]*$/); next }
+    in_policy && /^AutoEnable=false$/ { found = 1 }
+    END { exit !found }
+  ' "$MAIN_CONF"
+}
+
+# Echoes on or off, or nothing at all when no adapter can be read.
+current_state() {
   local state
   state=$(show)
 
-  [[ $state == *"Powered:"* ]] || return 1
+  [[ $state == *"Powered:"* ]] || return 0
 
   if [[ $state == *"Powered: yes"* ]]; then
-    write_state on
+    echo on
   else
-    write_state off
+    echo off
   fi
 }
 
 case "${1:-}" in
   save)
-    # Keep the last known state rather than recording a spurious "off".
-    save_state || exit 0
+    # Keep the last known state rather than recording a spurious "off". A write
+    # that fails is a different matter, and worth failing ExecStop over.
+    current=$(current_state)
+
+    if [[ -n $current ]]; then
+      write_state "$current"
+    fi
     ;;
   seed)
     # Run once by the migration, which has no second chance. save records
     # nothing when no adapter is readable, and no state file at all is what
     # restore takes for a fresh install and powers on. Off is what the machine
     # has been booting into all along.
-    save_state || write_state off
+    current=$(current_state)
+    write_state "${current:-off}"
     ;;
   restore)
     # No state file at all means a fresh install, so match stock BlueZ and power
@@ -104,22 +118,31 @@ case "${1:-}" in
     ;;
   disable-autoenable)
     # A bluez .pacnew merge can drop the key, space it as "AutoEnable = true", or
-    # take main.conf away entirely, and BlueZ defaults the flag to true. Check
-    # what landed rather than trusting the rewrite to have matched something.
+    # take main.conf away entirely, and BlueZ defaults the flag to true. It also
+    # reads the key only from [Policy], so a match anywhere else does not count
+    # and both the rewrite and the check that follows stay inside that section.
     mkdir -p "$(dirname "$MAIN_CONF")"
     [[ -f $MAIN_CONF ]] || : >"$MAIN_CONF"
 
-    sed -i -E 's/^[[:space:]]*#?[[:space:]]*AutoEnable[[:space:]]*=.*/AutoEnable=false/' "$MAIN_CONF"
+    awk '
+      /^[[:space:]]*\[/ {
+        if (in_policy && !done) { print "AutoEnable=false"; done = 1 }
+        in_policy = ($0 ~ /^[[:space:]]*\[Policy\][[:space:]]*$/)
+        print; next
+      }
+      in_policy && /^[[:space:]]*#?[[:space:]]*AutoEnable[[:space:]]*=/ {
+        if (!done) { print "AutoEnable=false"; done = 1 }
+        next
+      }
+      { print }
+      END {
+        if (done) exit
+        if (!in_policy) { print ""; print "[Policy]" }
+        print "AutoEnable=false"
+      }
+    ' "$MAIN_CONF" >"$MAIN_CONF.new" && mv -f "$MAIN_CONF.new" "$MAIN_CONF"
 
-    if ! grep -qx 'AutoEnable=false' "$MAIN_CONF"; then
-      if grep -q '^\[Policy\]' "$MAIN_CONF"; then
-        sed -i '0,/^\[Policy\]/s//&\nAutoEnable=false/' "$MAIN_CONF"
-      else
-        printf '\n[Policy]\nAutoEnable=false\n' >>"$MAIN_CONF"
-      fi
-    fi
-
-    grep -qx 'AutoEnable=false' "$MAIN_CONF" || {
+    autoenable_disabled || {
       echo "omarchy-bluetooth-state: could not set AutoEnable=false in $MAIN_CONF" >&2
       exit 1
     }

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -22,13 +22,15 @@ show() {
 }
 
 # bluetoothd registers the adapter a moment after taking its bus name, and
-# systemd starts this unit the instant that name appears.
+# systemd starts this unit the instant that name appears. Leaves the reading in
+# ADAPTER_STATE so the caller does not have to ask again.
 wait_for_adapter() {
   local i
 
   for ((i = 0; i < ADAPTER_WAIT_TRIES; i++)); do
-    [[ $(show) == *"Powered:"* ]] && return 0
-    sleep 0.5
+    ADAPTER_STATE=$(show)
+    [[ $ADAPTER_STATE == *"Powered:"* ]] && return 0
+    ((i < ADAPTER_WAIT_TRIES - 1)) && sleep 0.5
   done
 
   return 1
@@ -94,7 +96,7 @@ case "${1:-}" in
       exit 0
     fi
 
-    [[ $(show) == *"Powered: yes"* ]] && exit 0
+    [[ $ADAPTER_STATE == *"Powered: yes"* ]] && exit 0
 
     timeout 5s bluetoothctl power on >/dev/null 2>&1
 

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -36,28 +36,54 @@ wait_for_adapter() {
   return 1
 }
 
+# Write beside the file and rename over it. save runs from ExecStop, so its
+# window is a machine on its way down: a truncating redirect that loses power
+# mid-write leaves a zero-byte file behind, and an empty file is not a state
+# anyone chose. A rename swaps the whole contents or nothing.
+write_state() {
+  mkdir -p "$(dirname "$STATE_FILE")" &&
+    echo "$1" >"$STATE_FILE.new" &&
+    mv -f "$STATE_FILE.new" "$STATE_FILE"
+}
+
+# Non-zero means no adapter could be read and nothing was recorded.
+save_state() {
+  local state
+  state=$(show)
+
+  [[ $state == *"Powered:"* ]] || return 1
+
+  if [[ $state == *"Powered: yes"* ]]; then
+    write_state on
+  else
+    write_state off
+  fi
+}
+
 case "${1:-}" in
   save)
-    state=$(show)
-
     # No adapter to read. Keep the last known state rather than recording a
     # spurious "off" that the next boot would apply.
-    [[ $state == *"Powered:"* ]] || exit 0
-
-    mkdir -p "$(dirname "$STATE_FILE")"
-    if [[ $state == *"Powered: yes"* ]]; then
-      echo on >"$STATE_FILE"
-    else
-      echo off >"$STATE_FILE"
-    fi
+    save_state || exit 0
     ;;
   restore)
-    # No saved state means a fresh install, so power on and match what stock
-    # BlueZ would have done with AutoEnable left at its default.
+    # No saved state at all means a fresh install, so power on and match what
+    # stock BlueZ would have done with AutoEnable left at its default.
     target=on
-    if [[ -r $STATE_FILE ]]; then
-      read -r saved <"$STATE_FILE" || saved=""
-      [[ $saved == "on" || $saved == "off" ]] && target=$saved
+
+    if [[ -e $STATE_FILE ]]; then
+      # A file that exists but reads back as neither "on" nor "off" is a write
+      # that never finished. Take it as off: coming up powered is the failure a
+      # user who turned Bluetooth off would actually notice, and powering on is
+      # only the right default when there is genuinely nothing saved.
+      saved=""
+      read -r saved <"$STATE_FILE" 2>/dev/null
+
+      if [[ $saved == "on" ]]; then
+        target=on
+      else
+        target=off
+      fi
     fi
 
     # Nothing to do, and nothing to race: with AutoEnable off, bluetoothd

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -5,15 +5,13 @@
 # omarchy:args=<save|restore|seed|disable-autoenable>
 # omarchy:hidden=true
 
-# BlueZ does not persist an adapter's Powered property. Nothing ever writes a
-# Powered key into /var/lib/bluetooth/<adapter>/settings, so bluetoothd has no
-# way to bring an adapter back up in the state the user left it. Driven by
+# BlueZ never persists an adapter's Powered property, so bluetoothd cannot bring
+# one back up in the state the user left it. Driven by
 # omarchy-bluetooth-state.service, which saves on stop and restores on start.
 #
-# AutoEnable stays off so bluetoothd never powers the adapter itself. That is
-# what keeps restore deterministic: BlueZ powers adapters on asynchronously,
-# well after it takes its D-Bus name, so anything racing it to set the state
-# loses. Owning the power-on outright means there is no race to lose.
+# AutoEnable stays off so bluetoothd never powers the adapter itself. BlueZ
+# powers adapters on asynchronously, long after taking its D-Bus name, so
+# anything racing it loses; owning the power-on means there is no race to lose.
 
 STATE_FILE=${OMARCHY_BLUETOOTH_STATE_FILE:-/var/lib/omarchy/bluetooth-powered}
 MAIN_CONF=${OMARCHY_BLUETOOTH_MAIN_CONF:-/etc/bluetooth/main.conf}
@@ -23,9 +21,8 @@ show() {
   timeout 2s bluetoothctl show 2>/dev/null
 }
 
-# bluetoothd registers the adapter on D-Bus a moment after it takes its bus
-# name, and systemd starts this unit the instant that name appears. Until the
-# adapter exists, `bluetoothctl show` reports no Powered line at all.
+# bluetoothd registers the adapter a moment after taking its bus name, and
+# systemd starts this unit the instant that name appears.
 wait_for_adapter() {
   local i
 
@@ -37,10 +34,8 @@ wait_for_adapter() {
   return 1
 }
 
-# Write beside the file and rename over it. save runs from ExecStop, so its
-# window is a machine on its way down: a truncating redirect that loses power
-# mid-write leaves a zero-byte file behind, and an empty file is not a state
-# anyone chose. A rename swaps the whole contents or nothing.
+# Rename over the file rather than truncating it: save runs from ExecStop, and a
+# redirect cut short by the shutdown would leave a zero-byte file behind.
 write_state() {
   mkdir -p "$(dirname "$STATE_FILE")" &&
     echo "$1" >"$STATE_FILE.new" &&
@@ -63,33 +58,24 @@ save_state() {
 
 case "${1:-}" in
   save)
-    # No adapter to read. Keep the last known state rather than recording a
-    # spurious "off" that the next boot would apply.
+    # Keep the last known state rather than recording a spurious "off".
     save_state || exit 0
     ;;
   seed)
-    # Run once by the migration, before the unit has ever started. A plain save
-    # is not enough here: it deliberately records nothing when no adapter can be
-    # read, and no state file at all is exactly what restore takes for a fresh
-    # install and powers on. The migration marks the machine done either way, so
-    # that would permanently flip Bluetooth on for someone who keeps it off.
-    save_state && exit 0
-
-    # Nothing readable, so record the state the machine is already living with.
-    # AutoEnable has been off with nothing owning the power-on, which means
-    # Bluetooth has been coming up off on every boot.
-    write_state off
+    # Run once by the migration, which has no second chance. save records
+    # nothing when no adapter is readable, and no state file at all is what
+    # restore takes for a fresh install and powers on. Off is what the machine
+    # has been booting into all along.
+    save_state || write_state off
     ;;
   restore)
-    # No saved state at all means a fresh install, so power on and match what
-    # stock BlueZ would have done with AutoEnable left at its default.
+    # No state file at all means a fresh install, so match stock BlueZ and power
+    # on. A file that reads back as neither value is a write that never
+    # finished: prefer off, since coming up powered is what a user who turned
+    # Bluetooth off would notice.
     target=on
 
     if [[ -e $STATE_FILE ]]; then
-      # A file that exists but reads back as neither "on" nor "off" is a write
-      # that never finished. Take it as off: coming up powered is the failure a
-      # user who turned Bluetooth off would actually notice, and powering on is
-      # only the right default when there is genuinely nothing saved.
       saved=""
       read -r saved <"$STATE_FILE" 2>/dev/null
 
@@ -100,8 +86,7 @@ case "${1:-}" in
       fi
     fi
 
-    # Nothing to do, and nothing to race: with AutoEnable off, bluetoothd
-    # leaves the adapter down on its own.
+    # Nothing to race: with AutoEnable off, bluetoothd leaves the adapter down.
     [[ $target == "off" ]] && exit 0
 
     if ! wait_for_adapter; then
@@ -113,29 +98,20 @@ case "${1:-}" in
 
     timeout 5s bluetoothctl power on >/dev/null 2>&1
 
-    # Worth a journal line: this is the failure that leaves a machine with
-    # Bluetooth off and no obvious cause.
+    # The failure that leaves a machine with Bluetooth off and no obvious cause.
     [[ $(show) == *"Powered: yes"* ]] ||
       echo "omarchy-bluetooth-state: failed to power the adapter on" >&2
     ;;
   disable-autoenable)
-    # AutoEnable=false is not a preference, it is the load-bearing half of the
-    # design above: leave it on and BlueZ powers adapters up on its own, so a
-    # saved "off" is silently ignored from then on. Rewriting an existing key is
-    # not enough to guarantee that, because a bluez .pacnew merge can drop the
-    # line outright or bring it back spaced as "AutoEnable = true". Check what
-    # actually landed and add the key when the rewrite matched nothing.
-    #
-    # An absent main.conf is not a free pass either: BlueZ defaults AutoEnable
-    # to true, so the file gets created rather than skipped.
+    # A bluez .pacnew merge can drop the key, space it as "AutoEnable = true", or
+    # take main.conf away entirely, and BlueZ defaults the flag to true. Check
+    # what landed rather than trusting the rewrite to have matched something.
     mkdir -p "$(dirname "$MAIN_CONF")"
     [[ -f $MAIN_CONF ]] || : >"$MAIN_CONF"
 
     sed -i -E 's/^[[:space:]]*#?[[:space:]]*AutoEnable[[:space:]]*=.*/AutoEnable=false/' "$MAIN_CONF"
 
     if ! grep -qx 'AutoEnable=false' "$MAIN_CONF"; then
-      # Under the existing [Policy] section, which is the only place BlueZ reads
-      # it, or in a fresh section when the file has none.
       if grep -q '^\[Policy\]' "$MAIN_CONF"; then
         sed -i '0,/^\[Policy\]/s//&\nAutoEnable=false/' "$MAIN_CONF"
       else

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Save and restore the Bluetooth power state across reboots
 # omarchy:group=bluetooth
-# omarchy:args=<save|restore|seed>
+# omarchy:args=<save|restore|seed|disable-autoenable>
 # omarchy:hidden=true
 
 # BlueZ does not persist an adapter's Powered property. Nothing ever writes a
@@ -16,6 +16,7 @@
 # loses. Owning the power-on outright means there is no race to lose.
 
 STATE_FILE=${OMARCHY_BLUETOOTH_STATE_FILE:-/var/lib/omarchy/bluetooth-powered}
+MAIN_CONF=${OMARCHY_BLUETOOTH_MAIN_CONF:-/etc/bluetooth/main.conf}
 ADAPTER_WAIT_TRIES=${OMARCHY_BLUETOOTH_ADAPTER_WAIT_TRIES:-20}
 
 show() {
@@ -117,8 +118,38 @@ case "${1:-}" in
     [[ $(show) == *"Powered: yes"* ]] ||
       echo "omarchy-bluetooth-state: failed to power the adapter on" >&2
     ;;
+  disable-autoenable)
+    # AutoEnable=false is not a preference, it is the load-bearing half of the
+    # design above: leave it on and BlueZ powers adapters up on its own, so a
+    # saved "off" is silently ignored from then on. Rewriting an existing key is
+    # not enough to guarantee that, because a bluez .pacnew merge can drop the
+    # line outright or bring it back spaced as "AutoEnable = true". Check what
+    # actually landed and add the key when the rewrite matched nothing.
+    #
+    # An absent main.conf is not a free pass either: BlueZ defaults AutoEnable
+    # to true, so the file gets created rather than skipped.
+    mkdir -p "$(dirname "$MAIN_CONF")"
+    [[ -f $MAIN_CONF ]] || : >"$MAIN_CONF"
+
+    sed -i -E 's/^[[:space:]]*#?[[:space:]]*AutoEnable[[:space:]]*=.*/AutoEnable=false/' "$MAIN_CONF"
+
+    if ! grep -qx 'AutoEnable=false' "$MAIN_CONF"; then
+      # Under the existing [Policy] section, which is the only place BlueZ reads
+      # it, or in a fresh section when the file has none.
+      if grep -q '^\[Policy\]' "$MAIN_CONF"; then
+        sed -i '0,/^\[Policy\]/s//&\nAutoEnable=false/' "$MAIN_CONF"
+      else
+        printf '\n[Policy]\nAutoEnable=false\n' >>"$MAIN_CONF"
+      fi
+    fi
+
+    grep -qx 'AutoEnable=false' "$MAIN_CONF" || {
+      echo "omarchy-bluetooth-state: could not set AutoEnable=false in $MAIN_CONF" >&2
+      exit 1
+    }
+    ;;
   *)
-    echo "Usage: omarchy-bluetooth-state <save|restore|seed>" >&2
+    echo "Usage: omarchy-bluetooth-state <save|restore|seed|disable-autoenable>" >&2
     exit 1
     ;;
 esac

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Save and restore the Bluetooth power state across reboots
 # omarchy:group=bluetooth
-# omarchy:args=<save|restore>
+# omarchy:args=<save|restore|seed>
 # omarchy:hidden=true
 
 # BlueZ does not persist an adapter's Powered property. Nothing ever writes a
@@ -66,6 +66,19 @@ case "${1:-}" in
     # spurious "off" that the next boot would apply.
     save_state || exit 0
     ;;
+  seed)
+    # Run once by the migration, before the unit has ever started. A plain save
+    # is not enough here: it deliberately records nothing when no adapter can be
+    # read, and no state file at all is exactly what restore takes for a fresh
+    # install and powers on. The migration marks the machine done either way, so
+    # that would permanently flip Bluetooth on for someone who keeps it off.
+    save_state && exit 0
+
+    # Nothing readable, so record the state the machine is already living with.
+    # AutoEnable has been off with nothing owning the power-on, which means
+    # Bluetooth has been coming up off on every boot.
+    write_state off
+    ;;
   restore)
     # No saved state at all means a fresh install, so power on and match what
     # stock BlueZ would have done with AutoEnable left at its default.
@@ -105,7 +118,7 @@ case "${1:-}" in
       echo "omarchy-bluetooth-state: failed to power the adapter on" >&2
     ;;
   *)
-    echo "Usage: omarchy-bluetooth-state <save|restore>" >&2
+    echo "Usage: omarchy-bluetooth-state <save|restore|seed>" >&2
     exit 1
     ;;
 esac

--- a/bin/omarchy-bluetooth-state
+++ b/bin/omarchy-bluetooth-state
@@ -42,14 +42,6 @@ write_state() {
     mv -f "$STATE_FILE.new" "$STATE_FILE"
 }
 
-autoenable_disabled() {
-  awk '
-    /^[[:space:]]*\[/ { in_policy = ($0 ~ /^[[:space:]]*\[Policy\][[:space:]]*$/); next }
-    in_policy && /^AutoEnable=false$/ { found = 1 }
-    END { exit !found }
-  ' "$MAIN_CONF"
-}
-
 # Echoes on or off, or nothing at all when no adapter can be read.
 current_state() {
   local state
@@ -87,21 +79,15 @@ case "${1:-}" in
     # on. A file that reads back as neither value is a write that never
     # finished: prefer off, since coming up powered is what a user who turned
     # Bluetooth off would notice.
-    target=on
+    saved=on
 
     if [[ -e $STATE_FILE ]]; then
       saved=""
       read -r saved <"$STATE_FILE" 2>/dev/null
-
-      if [[ $saved == "on" ]]; then
-        target=on
-      else
-        target=off
-      fi
     fi
 
     # Nothing to race: with AutoEnable off, bluetoothd leaves the adapter down.
-    [[ $target == "off" ]] && exit 0
+    [[ $saved == "on" ]] || exit 0
 
     if ! wait_for_adapter; then
       echo "omarchy-bluetooth-state: no adapter appeared, leaving power alone" >&2
@@ -140,9 +126,7 @@ case "${1:-}" in
         if (!in_policy) { print ""; print "[Policy]" }
         print "AutoEnable=false"
       }
-    ' "$MAIN_CONF" >"$MAIN_CONF.new" && mv -f "$MAIN_CONF.new" "$MAIN_CONF"
-
-    autoenable_disabled || {
+    ' "$MAIN_CONF" >"$MAIN_CONF.new" && mv -f "$MAIN_CONF.new" "$MAIN_CONF" || {
       echo "omarchy-bluetooth-state: could not set AutoEnable=false in $MAIN_CONF" >&2
       exit 1
     }

--- a/default/systemd/system/omarchy-bluetooth-state.service
+++ b/default/systemd/system/omarchy-bluetooth-state.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=Restore the Bluetooth power state across reboots
 Documentation=man:bluetoothctl(1)
-ConditionPathIsDirectory=/sys/class/bluetooth
+# NotEmpty rather than IsDirectory: the bluetooth core module creates this
+# directory whether or not a controller exists, and only registers the hciN
+# symlinks inside it once one does. Testing the directory alone would let this
+# run on a machine with no adapter, where save would record a spurious "off".
+ConditionDirectoryNotEmpty=/sys/class/bluetooth
 # Ordered after bluetoothd so restore has something to talk to. That ordering
 # is also what makes save work: systemd stops this unit before bluetooth.service
 # at shutdown, which is the only window where the adapter can still be read.

--- a/default/systemd/system/omarchy-bluetooth-state.service
+++ b/default/systemd/system/omarchy-bluetooth-state.service
@@ -3,8 +3,10 @@ Description=Restore the Bluetooth power state across reboots
 Documentation=man:bluetoothctl(1)
 # NotEmpty rather than IsDirectory: the bluetooth core module creates this
 # directory whether or not a controller exists, and only registers the hciN
-# symlinks inside it once one does. Testing the directory alone would let this
-# run on a machine with no adapter, where save would record a spurious "off".
+# symlinks inside it once one does. Testing the directory alone would run this
+# on every adapter-less machine, where restore has nothing to talk to and stalls
+# out its full wait before giving up. A controller hot-plugged later is not
+# picked up until the next boot, which is what AutoEnable=false already does.
 ConditionDirectoryNotEmpty=/sys/class/bluetooth
 # Ordered after bluetoothd so restore has something to talk to. That ordering
 # is also what makes save work: systemd stops this unit before bluetooth.service

--- a/default/systemd/system/omarchy-bluetooth-state.service
+++ b/default/systemd/system/omarchy-bluetooth-state.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Restore the Bluetooth power state across reboots
+Documentation=man:bluetoothctl(1)
+ConditionPathIsDirectory=/sys/class/bluetooth
+# Ordered after bluetoothd so restore has something to talk to. That ordering
+# is also what makes save work: systemd stops this unit before bluetooth.service
+# at shutdown, which is the only window where the adapter can still be read.
+After=bluetooth.service
+BindsTo=bluetooth.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/omarchy-bluetooth-state restore
+ExecStop=/usr/bin/omarchy-bluetooth-state save
+
+[Install]
+WantedBy=bluetooth.service

--- a/default/systemd/system/omarchy-bluetooth-state.service
+++ b/default/systemd/system/omarchy-bluetooth-state.service
@@ -14,6 +14,10 @@ BindsTo=bluetooth.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# Hardware that is present but never registers would otherwise hold the boot
+# transaction open for the adapter wait, and block the migration's synchronous
+# start for the same stretch.
+TimeoutStartSec=15s
 ExecStart=/usr/bin/omarchy-bluetooth-state restore
 ExecStop=/usr/bin/omarchy-bluetooth-state save
 

--- a/default/systemd/system/omarchy-bluetooth-state.service
+++ b/default/systemd/system/omarchy-bluetooth-state.service
@@ -2,15 +2,12 @@
 Description=Restore the Bluetooth power state across reboots
 Documentation=man:bluetoothctl(1)
 # NotEmpty rather than IsDirectory: the bluetooth core module creates this
-# directory whether or not a controller exists, and only registers the hciN
-# symlinks inside it once one does. Testing the directory alone would run this
-# on every adapter-less machine, where restore has nothing to talk to and stalls
-# out its full wait before giving up. A controller hot-plugged later is not
-# picked up until the next boot, which is what AutoEnable=false already does.
+# directory whether or not a controller exists, and only puts the hciN symlinks
+# in it once one does. Testing the directory alone would run restore on every
+# adapter-less machine, where it stalls out its full wait before giving up.
 ConditionDirectoryNotEmpty=/sys/class/bluetooth
-# Ordered after bluetoothd so restore has something to talk to. That ordering
-# is also what makes save work: systemd stops this unit before bluetooth.service
-# at shutdown, which is the only window where the adapter can still be read.
+# After bluetoothd so restore has something to talk to, and so systemd stops this
+# unit first at shutdown — the only window where save can still read the adapter.
 After=bluetooth.service
 BindsTo=bluetooth.service
 

--- a/install/hardware/bluetooth.sh
+++ b/install/hardware/bluetooth.sh
@@ -1,11 +1,16 @@
 systemctl enable bluetooth.service
 
-# Leave AutoEnable at BlueZ's default. Setting it to false does not make
-# bluetoothd remember anything -- BlueZ never persists the Powered property --
-# it only means "never power the adapter on", which left Bluetooth off at every
-# boot. omarchy-bluetooth-state reapplies whatever the user last chose, and does
-# nothing until there is a saved state, so a fresh install still comes up with
-# Bluetooth on exactly as stock Arch does.
+# AutoEnable=false does not make bluetoothd remember anything, because BlueZ
+# never persists the Powered property. It only means "never power the adapter
+# on", which is exactly what we want here: omarchy-bluetooth-state owns the
+# power-on and reapplies whatever the user last chose. Leaving AutoEnable on
+# instead would have BlueZ powering adapters up asynchronously, racing the
+# restore and winning. With no saved state yet, restore powers the adapter on,
+# so a fresh install still comes up with Bluetooth on exactly as stock does.
+if [[ -f /etc/bluetooth/main.conf ]]; then
+  sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
+fi
+
 install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
   /etc/systemd/system/omarchy-bluetooth-state.service
 systemctl enable omarchy-bluetooth-state.service

--- a/install/hardware/bluetooth.sh
+++ b/install/hardware/bluetooth.sh
@@ -1,6 +1,11 @@
 systemctl enable bluetooth.service
 
-# Persist last power state across reboots (default AutoEnable=true overrides it)
-if [[ -f /etc/bluetooth/main.conf ]]; then
-  sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
-fi
+# Leave AutoEnable at BlueZ's default. Setting it to false does not make
+# bluetoothd remember anything -- BlueZ never persists the Powered property --
+# it only means "never power the adapter on", which left Bluetooth off at every
+# boot. omarchy-bluetooth-state reapplies whatever the user last chose, and does
+# nothing until there is a saved state, so a fresh install still comes up with
+# Bluetooth on exactly as stock Arch does.
+install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
+  /etc/systemd/system/omarchy-bluetooth-state.service
+systemctl enable omarchy-bluetooth-state.service

--- a/install/hardware/bluetooth.sh
+++ b/install/hardware/bluetooth.sh
@@ -1,12 +1,8 @@
 systemctl enable bluetooth.service
 
-# AutoEnable=false does not make bluetoothd remember anything, because BlueZ
-# never persists the Powered property. It only means "never power the adapter
-# on", which is exactly what we want here: omarchy-bluetooth-state owns the
-# power-on and reapplies whatever the user last chose. Leaving AutoEnable on
-# instead would have BlueZ powering adapters up asynchronously, racing the
-# restore and winning. With no saved state yet, restore powers the adapter on,
-# so a fresh install still comes up with Bluetooth on exactly as stock does.
+# Hands the power-on to omarchy-bluetooth-state, which reapplies whatever the
+# user last chose. With no saved state yet it powers on, so a fresh install
+# still comes up with Bluetooth on exactly as stock does.
 omarchy-bluetooth-state disable-autoenable
 
 install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \

--- a/install/hardware/bluetooth.sh
+++ b/install/hardware/bluetooth.sh
@@ -7,9 +7,7 @@ systemctl enable bluetooth.service
 # instead would have BlueZ powering adapters up asynchronously, racing the
 # restore and winning. With no saved state yet, restore powers the adapter on,
 # so a fresh install still comes up with Bluetooth on exactly as stock does.
-if [[ -f /etc/bluetooth/main.conf ]]; then
-  sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
-fi
+omarchy-bluetooth-state disable-autoenable
 
 install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
   /etc/systemd/system/omarchy-bluetooth-state.service

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -13,4 +13,16 @@ fi
 sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
   /etc/systemd/system/omarchy-bluetooth-state.service
 sudo systemctl daemon-reload
+
+# Record the adapter as it is right now, before the unit starts. Without this
+# the first restore finds no saved state, reads the machine as a fresh install,
+# and powers the adapter on mid-update for anyone who deliberately keeps
+# Bluetooth off. Seeded, restore matches what is already there and does nothing.
+if ! omarchy-cmd-missing omarchy-bluetooth-state; then
+  sudo omarchy-bluetooth-state save
+fi
+
+# Nothing here restarts bluetooth.service, so connected peripherals stay
+# connected through the update. Starting the unit now means its ExecStop is in
+# place for the next shutdown, so the state is captured without a reboot first.
 sudo systemctl enable --now omarchy-bluetooth-state.service

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -1,0 +1,15 @@
+echo "Stop forcing Bluetooth off at every boot"
+
+# An earlier migration set AutoEnable=false on the theory that bluetoothd would
+# then restore the adapter's last power state. BlueZ has no such behaviour: it
+# never writes a Powered key into /var/lib/bluetooth/<adapter>/settings, so the
+# flag only ever meant "never power the adapter on" and Bluetooth came up off on
+# every boot. Put the default back and persist the state properly instead.
+if [[ -f /etc/bluetooth/main.conf ]] && grep -q '^AutoEnable=false$' /etc/bluetooth/main.conf; then
+  sudo sed -i 's/^AutoEnable=false$/AutoEnable=true/' /etc/bluetooth/main.conf
+fi
+
+sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
+  /etc/systemd/system/omarchy-bluetooth-state.service
+sudo systemctl daemon-reload
+sudo systemctl enable omarchy-bluetooth-state.service

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -25,4 +25,14 @@ fi
 # Nothing here restarts bluetooth.service, so connected peripherals stay
 # connected through the update. Starting the unit now means its ExecStop is in
 # place for the next shutdown, so the state is captured without a reboot first.
-sudo systemctl enable --now omarchy-bluetooth-state.service
+sudo systemctl enable omarchy-bluetooth-state.service
+
+# Only start it if bluetoothd is already up. The unit is BindsTo=bluetooth.service,
+# so starting it otherwise would pull bluetoothd up for someone who stopped it on
+# purpose, and fail outright if they masked it. Worse, the save above could not
+# read an adapter without a running daemon, so it seeded nothing, and restore
+# would then read the machine as a fresh install and power the adapter on. Left
+# enabled, WantedBy=bluetooth.service starts it the next time bluetoothd does.
+if systemctl is-active --quiet bluetooth.service; then
+  sudo systemctl start omarchy-bluetooth-state.service
+fi

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -1,15 +1,16 @@
-echo "Stop forcing Bluetooth off at every boot"
+echo "Remember the Bluetooth power state across reboots"
 
-# An earlier migration set AutoEnable=false on the theory that bluetoothd would
-# then restore the adapter's last power state. BlueZ has no such behaviour: it
-# never writes a Powered key into /var/lib/bluetooth/<adapter>/settings, so the
-# flag only ever meant "never power the adapter on" and Bluetooth came up off on
-# every boot. Put the default back and persist the state properly instead.
-if [[ -f /etc/bluetooth/main.conf ]] && grep -q '^AutoEnable=false$' /etc/bluetooth/main.conf; then
-  sudo sed -i 's/^AutoEnable=false$/AutoEnable=true/' /etc/bluetooth/main.conf
+# An earlier migration set AutoEnable=false believing bluetoothd would then
+# restore the adapter's last power state. BlueZ has no such behaviour: it never
+# writes a Powered key into /var/lib/bluetooth/<adapter>/settings, so the flag
+# only ever meant "never power the adapter on" and Bluetooth came up off on
+# every boot. Keep the flag, since owning the power-on is what makes the restore
+# deterministic, and install the piece that was missing.
+if [[ -f /etc/bluetooth/main.conf ]]; then
+  sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
 fi
 
 sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
   /etc/systemd/system/omarchy-bluetooth-state.service
 sudo systemctl daemon-reload
-sudo systemctl enable omarchy-bluetooth-state.service
+sudo systemctl enable --now omarchy-bluetooth-state.service

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -4,46 +4,37 @@ marker="${OMARCHY_BLUETOOTH_MIGRATION_MARKER:-/var/lib/omarchy/migrations/178630
 unit_dest="${OMARCHY_BLUETOOTH_STATE_UNIT:-/etc/systemd/system/omarchy-bluetooth-state.service}"
 
 # Everything below is machine-wide, but migration completion is recorded per
-# user, so a second account on this box would run all of it again. That rerun
-# would undo whatever an administrator changed in between: AutoEnable flipped
-# back, hand edits to the unit, or the unit disabled outright. Grepping for the
-# applied state cannot tell "never migrated" apart from "migrated, then changed
-# on purpose", so record the machine instead. Written only at the very end, so
-# an interrupted run is retried rather than skipped.
+# user, so a second account would run it all again and undo whatever an
+# administrator changed in between. Grepping for the applied state cannot tell
+# "never migrated" from "migrated, then changed on purpose", so record the
+# machine. Written last, so an interrupted run is retried rather than skipped.
 if [[ -e $marker ]]; then
   exit 0
 fi
 
 # An earlier migration set AutoEnable=false believing bluetoothd would then
-# restore the adapter's last power state. BlueZ has no such behaviour: it never
-# writes a Powered key into /var/lib/bluetooth/<adapter>/settings, so the flag
+# restore the adapter's last power state. It has no such behaviour, so the flag
 # only ever meant "never power the adapter on" and Bluetooth came up off on
-# every boot. Keep the flag, since owning the power-on is what makes the restore
-# deterministic, and install the piece that was missing.
+# every boot. Keep the flag and install the piece that was missing.
 sudo omarchy-bluetooth-state disable-autoenable
 
 sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
   "$unit_dest"
 sudo systemctl daemon-reload
 
-# Record the adapter as it is right now, before the unit starts. Without this
-# the first restore finds no saved state, reads the machine as a fresh install,
-# and powers the adapter on mid-update for anyone who deliberately keeps
-# Bluetooth off. Seeded, restore matches what is already there and does nothing.
-# seed rather than save because save records nothing when it cannot read an
-# adapter, and this runs once: a machine left unseeded stays that way.
+# Record the adapter as it is now, before the unit starts, so the first restore
+# does not read the machine as a fresh install and power it on mid-update. seed
+# rather than save because save records nothing when it cannot read an adapter.
 sudo omarchy-bluetooth-state seed
 
 # Nothing here restarts bluetooth.service, so connected peripherals stay
-# connected through the update. Starting the unit now means its ExecStop is in
-# place for the next shutdown, so the state is captured without a reboot first.
+# connected. Starting the unit now puts its ExecStop in place for the next
+# shutdown, capturing the state without a reboot first.
 sudo systemctl enable omarchy-bluetooth-state.service
 
-# Only start it if bluetoothd is already up. The unit is BindsTo=bluetooth.service,
-# so starting it otherwise would pull bluetoothd up for someone who stopped it on
-# purpose, and fail outright if they masked it. Left enabled,
-# WantedBy=bluetooth.service starts it the next time bluetoothd does, by which
-# point the seed above is already on disk for restore to read.
+# Only start it if bluetoothd is already up: BindsTo would otherwise pull it up
+# for someone who stopped it on purpose, and fail outright if they masked it.
+# Left enabled, WantedBy starts it the next time bluetoothd does.
 if systemctl is-active --quiet bluetooth.service; then
   sudo systemctl start omarchy-bluetooth-state.service
 fi

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -33,9 +33,9 @@ sudo systemctl daemon-reload
 # the first restore finds no saved state, reads the machine as a fresh install,
 # and powers the adapter on mid-update for anyone who deliberately keeps
 # Bluetooth off. Seeded, restore matches what is already there and does nothing.
-if ! omarchy-cmd-missing omarchy-bluetooth-state; then
-  sudo omarchy-bluetooth-state save
-fi
+# seed rather than save because save records nothing when it cannot read an
+# adapter, and this runs once: a machine left unseeded stays that way.
+sudo omarchy-bluetooth-state seed
 
 # Nothing here restarts bluetooth.service, so connected peripherals stay
 # connected through the update. Starting the unit now means its ExecStop is in
@@ -44,10 +44,9 @@ sudo systemctl enable omarchy-bluetooth-state.service
 
 # Only start it if bluetoothd is already up. The unit is BindsTo=bluetooth.service,
 # so starting it otherwise would pull bluetoothd up for someone who stopped it on
-# purpose, and fail outright if they masked it. Worse, the save above could not
-# read an adapter without a running daemon, so it seeded nothing, and restore
-# would then read the machine as a fresh install and power the adapter on. Left
-# enabled, WantedBy=bluetooth.service starts it the next time bluetoothd does.
+# purpose, and fail outright if they masked it. Left enabled,
+# WantedBy=bluetooth.service starts it the next time bluetoothd does, by which
+# point the seed above is already on disk for restore to read.
 if systemctl is-active --quiet bluetooth.service; then
   sudo systemctl start omarchy-bluetooth-state.service
 fi

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -1,5 +1,18 @@
 echo "Remember the Bluetooth power state across reboots"
 
+marker=/var/lib/omarchy/migrations/1786305695
+
+# Everything below is machine-wide, but migration completion is recorded per
+# user, so a second account on this box would run all of it again. That rerun
+# would undo whatever an administrator changed in between: AutoEnable flipped
+# back, hand edits to the unit, or the unit disabled outright. Grepping for the
+# applied state cannot tell "never migrated" apart from "migrated, then changed
+# on purpose", so record the machine instead. Written only at the very end, so
+# an interrupted run is retried rather than skipped.
+if [[ -e $marker ]]; then
+  exit 0
+fi
+
 # An earlier migration set AutoEnable=false believing bluetoothd would then
 # restore the adapter's last power state. BlueZ has no such behaviour: it never
 # writes a Powered key into /var/lib/bluetooth/<adapter>/settings, so the flag
@@ -36,3 +49,5 @@ sudo systemctl enable omarchy-bluetooth-state.service
 if systemctl is-active --quiet bluetooth.service; then
   sudo systemctl start omarchy-bluetooth-state.service
 fi
+
+sudo install -Dm644 /dev/null "$marker"

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -1,6 +1,8 @@
 echo "Remember the Bluetooth power state across reboots"
 
-marker=/var/lib/omarchy/migrations/1786305695
+marker="${OMARCHY_BLUETOOTH_MIGRATION_MARKER:-/var/lib/omarchy/migrations/1786305695}"
+main_conf="${OMARCHY_BLUETOOTH_MAIN_CONF:-/etc/bluetooth/main.conf}"
+unit_dest="${OMARCHY_BLUETOOTH_STATE_UNIT:-/etc/systemd/system/omarchy-bluetooth-state.service}"
 
 # Everything below is machine-wide, but migration completion is recorded per
 # user, so a second account on this box would run all of it again. That rerun
@@ -19,12 +21,12 @@ fi
 # only ever meant "never power the adapter on" and Bluetooth came up off on
 # every boot. Keep the flag, since owning the power-on is what makes the restore
 # deterministic, and install the piece that was missing.
-if [[ -f /etc/bluetooth/main.conf ]]; then
-  sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' /etc/bluetooth/main.conf
+if [[ -f $main_conf ]]; then
+  sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' "$main_conf"
 fi
 
 sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
-  /etc/systemd/system/omarchy-bluetooth-state.service
+  "$unit_dest"
 sudo systemctl daemon-reload
 
 # Record the adapter as it is right now, before the unit starts. Without this

--- a/migrations/1786305695.sh
+++ b/migrations/1786305695.sh
@@ -1,7 +1,6 @@
 echo "Remember the Bluetooth power state across reboots"
 
 marker="${OMARCHY_BLUETOOTH_MIGRATION_MARKER:-/var/lib/omarchy/migrations/1786305695}"
-main_conf="${OMARCHY_BLUETOOTH_MAIN_CONF:-/etc/bluetooth/main.conf}"
 unit_dest="${OMARCHY_BLUETOOTH_STATE_UNIT:-/etc/systemd/system/omarchy-bluetooth-state.service}"
 
 # Everything below is machine-wide, but migration completion is recorded per
@@ -21,9 +20,7 @@ fi
 # only ever meant "never power the adapter on" and Bluetooth came up off on
 # every boot. Keep the flag, since owning the power-on is what makes the restore
 # deterministic, and install the piece that was missing.
-if [[ -f $main_conf ]]; then
-  sudo sed -i 's/^#\?AutoEnable=.*/AutoEnable=false/' "$main_conf"
-fi
+sudo omarchy-bluetooth-state disable-autoenable
 
 sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-bluetooth-state.service" \
   "$unit_dest"

--- a/test/shell.d/bluetooth-migration-test.sh
+++ b/test/shell.d/bluetooth-migration-test.sh
@@ -37,9 +37,7 @@ exit 0
 STUB
 
 # seed only needs to be observed, but disable-autoenable has to actually rewrite
-# main.conf: whether the flag lands is what the assertions below are about. The
-# real command honours OMARCHY_BLUETOOTH_MAIN_CONF, and the sudo stub above
-# preserves the environment, so it edits the redirected file.
+# main.conf, so it runs for real against OMARCHY_BLUETOOTH_MAIN_CONF.
 cat >"$test_dir/bin/omarchy-bluetooth-state" <<STUB
 #!/bin/bash
 
@@ -105,8 +103,8 @@ pass "migration seeds the saved state before starting the unit"
 [[ -e $marker ]] || fail "migration records the machine as done"
 pass "migration records the machine as done"
 
-# A second user on the same box must not undo an administrator's opt-out made
-# after the first run, since migration completion is recorded per user.
+# Migration completion is recorded per user, so a second account must not undo
+# an administrator's opt-out made after the first run.
 printf '[Policy]\nAutoEnable=true\n' >"$main_conf"
 rm -f "$unit_dest"
 run_migration
@@ -136,10 +134,8 @@ grep -q '^systemctl start' "$CALLS" &&
   fail "migration does not start the unit while bluetoothd is down" "$(cat "$CALLS")"
 pass "migration does not start the unit while bluetoothd is down"
 
-# A bluez .pacnew merge can leave main.conf with no AutoEnable line at all.
-# Rewriting an existing key would match nothing here, and BlueZ defaults the
-# flag to true, so the adapter would go back to auto-powering and every saved
-# "off" would be ignored. The marker means this run is the only chance to fix it.
+# A bluez .pacnew merge can leave main.conf with no AutoEnable line at all, and
+# the marker means this run is the only chance to put it back.
 reset_machine
 printf '[General]\nName=Omarchy\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
 run_migration

--- a/test/shell.d/bluetooth-migration-test.sh
+++ b/test/shell.d/bluetooth-migration-test.sh
@@ -11,8 +11,8 @@ trap 'rm -rf "$test_dir"' EXIT
 
 mkdir -p "$test_dir/bin"
 
-# sudo runs the real command, so install and sed act on the redirected paths
-# below while systemctl and the state helper resolve to the stubs beside them.
+# sudo runs the real command, so install acts on the redirected paths below
+# while systemctl and the state helper resolve to the stubs beside them.
 cat >"$test_dir/bin/sudo" <<'STUB'
 #!/bin/bash
 
@@ -36,10 +36,17 @@ fi
 exit 0
 STUB
 
-cat >"$test_dir/bin/omarchy-bluetooth-state" <<'STUB'
+# seed only needs to be observed, but disable-autoenable has to actually rewrite
+# main.conf: whether the flag lands is what the assertions below are about. The
+# real command honours OMARCHY_BLUETOOTH_MAIN_CONF, and the sudo stub above
+# preserves the environment, so it edits the redirected file.
+cat >"$test_dir/bin/omarchy-bluetooth-state" <<STUB
 #!/bin/bash
 
-printf 'omarchy-bluetooth-state %s\n' "$*" >>"$CALLS"
+printf 'omarchy-bluetooth-state %s\n' "\$*" >>"\$CALLS"
+
+[[ \$1 == "disable-autoenable" ]] && exec "$ROOT/bin/omarchy-bluetooth-state" "\$@"
+exit 0
 STUB
 
 chmod +x "$test_dir/bin/"*
@@ -128,6 +135,22 @@ pass "migration still enables the unit while bluetoothd is down"
 grep -q '^systemctl start' "$CALLS" &&
   fail "migration does not start the unit while bluetoothd is down" "$(cat "$CALLS")"
 pass "migration does not start the unit while bluetoothd is down"
+
+# A bluez .pacnew merge can leave main.conf with no AutoEnable line at all.
+# Rewriting an existing key would match nothing here, and BlueZ defaults the
+# flag to true, so the adapter would go back to auto-powering and every saved
+# "off" would be ignored. The marker means this run is the only chance to fix it.
+reset_machine
+printf '[General]\nName=Omarchy\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
+run_migration
+
+grep -q '^AutoEnable=false$' "$main_conf" ||
+  fail "migration adds AutoEnable when main.conf has no such key" "$(cat "$main_conf")"
+pass "migration adds AutoEnable when main.conf has no such key"
+
+grep -q '^ReconnectAttempts=7$' "$main_conf" ||
+  fail "migration leaves the rest of the Policy section intact" "$(cat "$main_conf")"
+pass "migration leaves the rest of the Policy section intact"
 
 # An interrupted run must be retried by the next user rather than skipped.
 reset_machine

--- a/test/shell.d/bluetooth-migration-test.sh
+++ b/test/shell.d/bluetooth-migration-test.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1786305695.sh"
+unit_source="$ROOT/default/systemd/system/omarchy-bluetooth-state.service"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+
+# sudo runs the real command, so install and sed act on the redirected paths
+# below while systemctl and the state helper resolve to the stubs beside them.
+cat >"$test_dir/bin/sudo" <<'STUB'
+#!/bin/bash
+
+exec "$@"
+STUB
+
+cat >"$test_dir/bin/systemctl" <<'STUB'
+#!/bin/bash
+
+printf 'systemctl %s\n' "$*" >>"$CALLS"
+
+if [[ $1 == is-active ]]; then
+  [[ -n ${BLUETOOTHD_ACTIVE:-} ]] && exit 0
+  exit 1
+fi
+
+if [[ $1 == enable && -n ${ENABLE_FAILS:-} ]]; then
+  exit 1
+fi
+
+exit 0
+STUB
+
+cat >"$test_dir/bin/omarchy-bluetooth-state" <<'STUB'
+#!/bin/bash
+
+printf 'omarchy-bluetooth-state %s\n' "$*" >>"$CALLS"
+STUB
+
+cat >"$test_dir/bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+
+exit 1
+STUB
+
+chmod +x "$test_dir/bin/"*
+
+export CALLS="$test_dir/calls"
+
+marker="$test_dir/marker"
+main_conf="$test_dir/main.conf"
+unit_dest="$test_dir/omarchy-bluetooth-state.service"
+
+reset_machine() {
+  rm -f "$marker" "$unit_dest"
+  printf '[Policy]\n#AutoEnable=true\n' >"$main_conf"
+}
+
+run_migration() {
+  : >"$CALLS"
+
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_BLUETOOTH_MIGRATION_MARKER="$marker" \
+    OMARCHY_BLUETOOTH_MAIN_CONF="$main_conf" \
+    OMARCHY_BLUETOOTH_STATE_UNIT="$unit_dest" \
+    PATH="$test_dir/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+call_line() {
+  grep -n -- "$1" "$CALLS" | head -1 | cut -d: -f1
+}
+
+# A first run on a machine with bluetoothd up does the whole job.
+reset_machine
+export BLUETOOTHD_ACTIVE=1
+run_migration
+
+grep -q '^AutoEnable=false$' "$main_conf" ||
+  fail "migration turns AutoEnable off" "$(cat "$main_conf")"
+pass "migration turns AutoEnable off"
+
+cmp -s "$unit_source" "$unit_dest" ||
+  fail "migration installs the shipped unit"
+pass "migration installs the shipped unit"
+
+grep -q '^systemctl enable omarchy-bluetooth-state.service$' "$CALLS" ||
+  fail "migration enables the unit" "$(cat "$CALLS")"
+pass "migration enables the unit"
+
+grep -q '^systemctl start omarchy-bluetooth-state.service$' "$CALLS" ||
+  fail "migration starts the unit while bluetoothd is up" "$(cat "$CALLS")"
+pass "migration starts the unit while bluetoothd is up"
+
+(($(call_line '^omarchy-bluetooth-state save$') < $(call_line '^systemctl start'))) ||
+  fail "migration seeds the saved state before starting the unit" "$(cat "$CALLS")"
+pass "migration seeds the saved state before starting the unit"
+
+[[ -e $marker ]] || fail "migration records the machine as done"
+pass "migration records the machine as done"
+
+# A second user on the same box must not undo an administrator's opt-out made
+# after the first run, since migration completion is recorded per user.
+printf '[Policy]\nAutoEnable=true\n' >"$main_conf"
+rm -f "$unit_dest"
+run_migration
+
+grep -q '^AutoEnable=true$' "$main_conf" ||
+  fail "migration leaves a later AutoEnable opt-out alone" "$(cat "$main_conf")"
+pass "migration leaves a later AutoEnable opt-out alone"
+
+[[ ! -e $unit_dest ]] || fail "migration does not reinstall the unit on a second run"
+pass "migration does not reinstall the unit on a second run"
+
+[[ ! -s $CALLS ]] ||
+  fail "migration runs no systemctl on a second run" "$(cat "$CALLS")"
+pass "migration runs no systemctl on a second run"
+
+# With bluetoothd stopped, starting the unit would pull it back up through
+# BindsTo, so the unit is only enabled and left for the next bluetoothd start.
+reset_machine
+unset BLUETOOTHD_ACTIVE
+run_migration
+
+grep -q '^systemctl enable omarchy-bluetooth-state.service$' "$CALLS" ||
+  fail "migration still enables the unit while bluetoothd is down" "$(cat "$CALLS")"
+pass "migration still enables the unit while bluetoothd is down"
+
+grep -q '^systemctl start' "$CALLS" &&
+  fail "migration does not start the unit while bluetoothd is down" "$(cat "$CALLS")"
+pass "migration does not start the unit while bluetoothd is down"
+
+# An interrupted run must be retried by the next user rather than skipped.
+reset_machine
+export ENABLE_FAILS=1
+if run_migration 2>/dev/null; then
+  fail "migration fails when the unit cannot be enabled"
+fi
+pass "migration fails when the unit cannot be enabled"
+
+[[ ! -e $marker ]] || fail "migration leaves no marker behind when it fails"
+pass "migration leaves no marker behind when it fails"

--- a/test/shell.d/bluetooth-migration-test.sh
+++ b/test/shell.d/bluetooth-migration-test.sh
@@ -38,12 +38,12 @@ STUB
 
 # seed only needs to be observed, but disable-autoenable has to actually rewrite
 # main.conf, so it runs for real against OMARCHY_BLUETOOTH_MAIN_CONF.
-cat >"$test_dir/bin/omarchy-bluetooth-state" <<STUB
+cat >"$test_dir/bin/omarchy-bluetooth-state" <<'STUB'
 #!/bin/bash
 
-printf 'omarchy-bluetooth-state %s\n' "\$*" >>"\$CALLS"
+printf 'omarchy-bluetooth-state %s\n' "$*" >>"$CALLS"
 
-[[ \$1 == "disable-autoenable" ]] && exec "$ROOT/bin/omarchy-bluetooth-state" "\$@"
+[[ $1 == "disable-autoenable" ]] && exec "$ROOT/bin/omarchy-bluetooth-state" "$@"
 exit 0
 STUB
 

--- a/test/shell.d/bluetooth-migration-test.sh
+++ b/test/shell.d/bluetooth-migration-test.sh
@@ -42,12 +42,6 @@ cat >"$test_dir/bin/omarchy-bluetooth-state" <<'STUB'
 printf 'omarchy-bluetooth-state %s\n' "$*" >>"$CALLS"
 STUB
 
-cat >"$test_dir/bin/omarchy-cmd-missing" <<'STUB'
-#!/bin/bash
-
-exit 1
-STUB
-
 chmod +x "$test_dir/bin/"*
 
 export CALLS="$test_dir/calls"
@@ -97,7 +91,7 @@ grep -q '^systemctl start omarchy-bluetooth-state.service$' "$CALLS" ||
   fail "migration starts the unit while bluetoothd is up" "$(cat "$CALLS")"
 pass "migration starts the unit while bluetoothd is up"
 
-(($(call_line '^omarchy-bluetooth-state save$') < $(call_line '^systemctl start'))) ||
+(($(call_line '^omarchy-bluetooth-state seed$') < $(call_line '^systemctl start'))) ||
   fail "migration seeds the saved state before starting the unit" "$(cat "$CALLS")"
 pass "migration seeds the saved state before starting the unit"
 

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -149,3 +149,49 @@ unpowered_log=$(bluetooth_device_log no)
 grep -qx "power on" "$unpowered_log" ||
   fail "bluetooth powers the adapter on when it is off"
 pass "bluetooth powers the adapter on when it is off"
+
+# BlueZ never persists Powered, so the adapter state only survives a reboot if
+# omarchy-bluetooth-state saves it on the way down and reapplies it on the way up.
+unit="$ROOT/default/systemd/system/omarchy-bluetooth-state.service"
+
+grep -q '^ConditionPathIsDirectory=/sys/class/bluetooth$' "$unit" ||
+  fail "bluetooth state restore is skipped on machines without Bluetooth hardware"
+pass "bluetooth state restore is skipped on machines without Bluetooth hardware"
+
+# Without this ordering systemd may stop bluetoothd first and save reads nothing.
+grep -q '^After=bluetooth.service$' "$unit" ||
+  fail "bluetooth state save runs while bluetoothd is still up"
+pass "bluetooth state save runs while bluetoothd is still up"
+
+state_file="$device_tmp/bluetooth-powered"
+state_log="$device_tmp/state.log"
+
+bluetooth_state_run() {
+  local action="$1" powered="${2:-no}"
+
+  : >"$state_log"
+  PATH="$mock_bin:$PATH" BLUETOOTHCTL_LOG="$state_log" BLUETOOTHCTL_POWERED="$powered" \
+    OMARCHY_BLUETOOTH_STATE_FILE="$state_file" \
+    "$ROOT/bin/omarchy-bluetooth-state" "$action" ||
+    fail "omarchy-bluetooth-state $action exits cleanly"
+}
+
+rm -f "$state_file"
+bluetooth_state_run save yes
+[[ $(cat "$state_file") == "on" ]] || fail "bluetooth state records a powered adapter"
+pass "bluetooth state records a powered adapter"
+
+bluetooth_state_run save no
+[[ $(cat "$state_file") == "off" ]] || fail "bluetooth state records an unpowered adapter"
+pass "bluetooth state records an unpowered adapter"
+
+bluetooth_state_run restore
+grep -qx "power off" "$state_log" || fail "bluetooth state restores an adapter the user turned off"
+pass "bluetooth state restores an adapter the user turned off"
+
+# A fresh install has no saved state. Touching the adapter here would mean a
+# failure in this unit could leave a brand new machine with Bluetooth dead.
+rm -f "$state_file"
+bluetooth_state_run restore
+[[ -s $state_log ]] && fail "bluetooth state leaves a fresh install to BlueZ's own default"
+pass "bluetooth state leaves a fresh install to BlueZ's own default"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -154,7 +154,7 @@ pass "bluetooth powers the adapter on when it is off"
 # omarchy-bluetooth-state saves it on the way down and reapplies it on the way up.
 unit="$ROOT/default/systemd/system/omarchy-bluetooth-state.service"
 
-grep -q '^ConditionPathIsDirectory=/sys/class/bluetooth$' "$unit" ||
+grep -q '^ConditionDirectoryNotEmpty=/sys/class/bluetooth$' "$unit" ||
   fail "bluetooth state restore is skipped on machines without Bluetooth hardware"
 pass "bluetooth state restore is skipped on machines without Bluetooth hardware"
 

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -120,7 +120,10 @@ cat >"$mock_bin/bluetoothctl" <<'SH'
 #!/bin/bash
 
 printf '%s\n' "$*" >>"$BLUETOOTHCTL_LOG"
-[[ $1 == "show" ]] && printf '\tPowered: %s\n' "$BLUETOOTHCTL_POWERED"
+# "absent" stands in for bluetoothd running with no adapter registered yet,
+# where `bluetoothctl show` reports no Powered line at all.
+[[ $1 == "show" && $BLUETOOTHCTL_POWERED != "absent" ]] &&
+  printf '\tPowered: %s\n' "$BLUETOOTHCTL_POWERED"
 exit 0
 SH
 chmod +x "$mock_bin/bluetoothctl"
@@ -172,7 +175,8 @@ bluetooth_state_run() {
   : >"$state_log"
   PATH="$mock_bin:$PATH" BLUETOOTHCTL_LOG="$state_log" BLUETOOTHCTL_POWERED="$powered" \
     OMARCHY_BLUETOOTH_STATE_FILE="$state_file" \
-    "$ROOT/bin/omarchy-bluetooth-state" "$action" ||
+    OMARCHY_BLUETOOTH_ADAPTER_WAIT_TRIES=1 \
+    "$ROOT/bin/omarchy-bluetooth-state" "$action" 2>/dev/null ||
     fail "omarchy-bluetooth-state $action exits cleanly"
 }
 
@@ -185,13 +189,36 @@ bluetooth_state_run save no
 [[ $(cat "$state_file") == "off" ]] || fail "bluetooth state records an unpowered adapter"
 pass "bluetooth state records an unpowered adapter"
 
-bluetooth_state_run restore
-grep -qx "power off" "$state_log" || fail "bluetooth state restores an adapter the user turned off"
-pass "bluetooth state restores an adapter the user turned off"
+# Recording "off" here would hand the next boot a state the user never chose.
+bluetooth_state_run save absent
+[[ $(cat "$state_file") == "off" ]] || fail "bluetooth state keeps the last state when no adapter is readable"
+pass "bluetooth state keeps the last state when no adapter is readable"
 
-# A fresh install has no saved state. Touching the adapter here would mean a
-# failure in this unit could leave a brand new machine with Bluetooth dead.
+# AutoEnable is off, so bluetoothd leaves the adapter down by itself. Issuing a
+# power off here would be redundant, and racing BlueZ is what broke the first
+# cut of this: it powers adapters up asynchronously, long after taking its bus
+# name, so anything competing to set the state loses.
+bluetooth_state_run restore no
+grep -q "power" "$state_log" && fail "bluetooth state leaves a saved-off adapter alone"
+pass "bluetooth state leaves a saved-off adapter alone"
+
+echo on >"$state_file"
+bluetooth_state_run restore no
+grep -qx "power on" "$state_log" || fail "bluetooth state powers on an adapter the user left on"
+pass "bluetooth state powers on an adapter the user left on"
+
+bluetooth_state_run restore yes
+grep -qx "power on" "$state_log" && fail "bluetooth state skips an adapter that is already powered"
+pass "bluetooth state skips an adapter that is already powered"
+
+# A fresh install has no saved state and must come up powered, matching what
+# stock BlueZ would have done with AutoEnable left at its default.
 rm -f "$state_file"
-bluetooth_state_run restore
-[[ -s $state_log ]] && fail "bluetooth state leaves a fresh install to BlueZ's own default"
-pass "bluetooth state leaves a fresh install to BlueZ's own default"
+bluetooth_state_run restore no
+grep -qx "power on" "$state_log" || fail "bluetooth state powers on a fresh install"
+pass "bluetooth state powers on a fresh install"
+
+# Waiting forever on hardware that is not there would hold up the boot.
+bluetooth_state_run restore absent
+grep -q "power" "$state_log" && fail "bluetooth state gives up when no adapter appears"
+pass "bluetooth state gives up when no adapter appears"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -252,3 +252,50 @@ bluetooth_state_run seed yes
 [[ $(cat "$state_file") == "on" ]] ||
   fail "bluetooth state seeds the adapter as it actually is" "$(cat "$state_file")"
 pass "bluetooth state seeds the adapter as it actually is"
+
+# AutoEnable=false is the load-bearing half of the design: leave it on and BlueZ
+# powers adapters up on its own, so a saved "off" is silently ignored. A bluez
+# .pacnew merge can drop the key, space it out, or take main.conf away entirely,
+# and a rewrite that quietly matches nothing would hand the power-on back.
+main_conf="$device_tmp/main.conf"
+
+bluetooth_autoenable() {
+  OMARCHY_BLUETOOTH_MAIN_CONF="$main_conf" \
+    "$ROOT/bin/omarchy-bluetooth-state" disable-autoenable ||
+    fail "omarchy-bluetooth-state disable-autoenable exits cleanly" "$(cat "$main_conf")"
+}
+
+printf '[Policy]\n#AutoEnable=true\n' >"$main_conf"
+bluetooth_autoenable
+grep -qx 'AutoEnable=false' "$main_conf" ||
+  fail "bluetooth uncomments AutoEnable" "$(cat "$main_conf")"
+pass "bluetooth uncomments AutoEnable"
+
+printf '[Policy]\nAutoEnable = true\n' >"$main_conf"
+bluetooth_autoenable
+grep -qx 'AutoEnable=false' "$main_conf" ||
+  fail "bluetooth rewrites a spaced AutoEnable" "$(cat "$main_conf")"
+pass "bluetooth rewrites a spaced AutoEnable"
+
+printf '[General]\nName=Omarchy\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
+bluetooth_autoenable
+grep -qx 'AutoEnable=false' "$main_conf" ||
+  fail "bluetooth adds AutoEnable under an existing Policy section" "$(cat "$main_conf")"
+pass "bluetooth adds AutoEnable under an existing Policy section"
+
+grep -qx 'ReconnectAttempts=7' "$main_conf" ||
+  fail "bluetooth leaves the rest of the Policy section intact" "$(cat "$main_conf")"
+pass "bluetooth leaves the rest of the Policy section intact"
+
+printf '[General]\nName=Omarchy\n' >"$main_conf"
+bluetooth_autoenable
+grep -qx 'AutoEnable=false' "$main_conf" ||
+  fail "bluetooth adds a Policy section when main.conf has none" "$(cat "$main_conf")"
+pass "bluetooth adds a Policy section when main.conf has none"
+
+# An absent main.conf is not a free pass: BlueZ defaults AutoEnable to true.
+rm -f "$main_conf"
+bluetooth_autoenable
+grep -qx 'AutoEnable=false' "$main_conf" ||
+  fail "bluetooth writes main.conf when it does not exist" "$(cat "$main_conf")"
+pass "bluetooth writes main.conf when it does not exist"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -222,3 +222,17 @@ pass "bluetooth state powers on a fresh install"
 bluetooth_state_run restore absent
 grep -q "power" "$state_log" && fail "bluetooth state gives up when no adapter appears"
 pass "bluetooth state gives up when no adapter appears"
+
+# save runs from ExecStop, on a machine already on its way down. A truncating
+# redirect cut short there leaves a zero-byte file, so the write lands under a
+# temporary name and is renamed over the real one.
+bluetooth_state_run save yes
+[[ ! -e "$state_file.new" ]] || fail "bluetooth state leaves no half-written file behind"
+pass "bluetooth state leaves no half-written file behind"
+
+# And should an empty file turn up anyway, it is not a state anyone chose.
+# Powering on here is the failure a user who turned Bluetooth off would notice.
+: >"$state_file"
+bluetooth_state_run restore no
+grep -q "power" "$state_log" && fail "bluetooth state does not power on from an unfinished write"
+pass "bluetooth state does not power on from an unfinished write"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -253,21 +253,27 @@ bluetooth_autoenable() {
     fail "omarchy-bluetooth-state disable-autoenable exits cleanly" "$(cat "$main_conf")"
 }
 
+# BlueZ reads the key only from [Policy], so a match anywhere else is no good.
+policy_autoenable() {
+  awk '/^[[:space:]]*\[/ { in_policy = ($0 ~ /^\[Policy\]$/); next }
+       in_policy && /^AutoEnable=/ { print }' "$main_conf"
+}
+
 printf '[Policy]\n#AutoEnable=true\n' >"$main_conf"
 bluetooth_autoenable
-grep -qx 'AutoEnable=false' "$main_conf" ||
+[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
   fail "bluetooth uncomments AutoEnable" "$(cat "$main_conf")"
 pass "bluetooth uncomments AutoEnable"
 
 printf '[Policy]\nAutoEnable = true\n' >"$main_conf"
 bluetooth_autoenable
-grep -qx 'AutoEnable=false' "$main_conf" ||
+[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
   fail "bluetooth rewrites a spaced AutoEnable" "$(cat "$main_conf")"
 pass "bluetooth rewrites a spaced AutoEnable"
 
 printf '[General]\nName=Omarchy\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
 bluetooth_autoenable
-grep -qx 'AutoEnable=false' "$main_conf" ||
+[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
   fail "bluetooth adds AutoEnable under an existing Policy section" "$(cat "$main_conf")"
 pass "bluetooth adds AutoEnable under an existing Policy section"
 
@@ -277,13 +283,21 @@ pass "bluetooth leaves the rest of the Policy section intact"
 
 printf '[General]\nName=Omarchy\n' >"$main_conf"
 bluetooth_autoenable
-grep -qx 'AutoEnable=false' "$main_conf" ||
+[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
   fail "bluetooth adds a Policy section when main.conf has none" "$(cat "$main_conf")"
 pass "bluetooth adds a Policy section when main.conf has none"
 
 # An absent main.conf is not a free pass: BlueZ defaults AutoEnable to true.
 rm -f "$main_conf"
 bluetooth_autoenable
-grep -qx 'AutoEnable=false' "$main_conf" ||
+[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
   fail "bluetooth writes main.conf when it does not exist" "$(cat "$main_conf")"
 pass "bluetooth writes main.conf when it does not exist"
+
+# A key outside [Policy] is one BlueZ ignores, so rewriting it in place would
+# leave AutoEnable at its default while looking like the flag had landed.
+printf '[General]\nAutoEnable=true\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
+bluetooth_autoenable
+[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
+  fail "bluetooth ignores an AutoEnable outside the Policy section" "$(cat "$main_conf")"
+pass "bluetooth ignores an AutoEnable outside the Policy section"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -153,8 +153,6 @@ grep -qx "power on" "$unpowered_log" ||
   fail "bluetooth powers the adapter on when it is off"
 pass "bluetooth powers the adapter on when it is off"
 
-# BlueZ never persists Powered, so the adapter state only survives a reboot if
-# omarchy-bluetooth-state saves it on the way down and reapplies it on the way up.
 unit="$ROOT/default/systemd/system/omarchy-bluetooth-state.service"
 
 grep -q '^ConditionDirectoryNotEmpty=/sys/class/bluetooth$' "$unit" ||
@@ -194,10 +192,8 @@ bluetooth_state_run save absent
 [[ $(cat "$state_file") == "off" ]] || fail "bluetooth state keeps the last state when no adapter is readable"
 pass "bluetooth state keeps the last state when no adapter is readable"
 
-# AutoEnable is off, so bluetoothd leaves the adapter down by itself. Issuing a
-# power off here would be redundant, and racing BlueZ is what broke the first
-# cut of this: it powers adapters up asynchronously, long after taking its bus
-# name, so anything competing to set the state loses.
+# Racing BlueZ is what broke the first cut of this, and with AutoEnable off a
+# power off is redundant anyway.
 bluetooth_state_run restore no
 grep -q "power" "$state_log" && fail "bluetooth state leaves a saved-off adapter alone"
 pass "bluetooth state leaves a saved-off adapter alone"
@@ -211,8 +207,7 @@ bluetooth_state_run restore yes
 grep -qx "power on" "$state_log" && fail "bluetooth state skips an adapter that is already powered"
 pass "bluetooth state skips an adapter that is already powered"
 
-# A fresh install has no saved state and must come up powered, matching what
-# stock BlueZ would have done with AutoEnable left at its default.
+# Matching what stock BlueZ does with AutoEnable left at its default.
 rm -f "$state_file"
 bluetooth_state_run restore no
 grep -qx "power on" "$state_log" || fail "bluetooth state powers on a fresh install"
@@ -223,24 +218,19 @@ bluetooth_state_run restore absent
 grep -q "power" "$state_log" && fail "bluetooth state gives up when no adapter appears"
 pass "bluetooth state gives up when no adapter appears"
 
-# save runs from ExecStop, on a machine already on its way down. A truncating
-# redirect cut short there leaves a zero-byte file, so the write lands under a
-# temporary name and is renamed over the real one.
+# A truncating redirect cut short by the shutdown would leave a zero-byte file.
 bluetooth_state_run save yes
 [[ ! -e "$state_file.new" ]] || fail "bluetooth state leaves no half-written file behind"
 pass "bluetooth state leaves no half-written file behind"
 
-# And should an empty file turn up anyway, it is not a state anyone chose.
-# Powering on here is the failure a user who turned Bluetooth off would notice.
+# And should one turn up anyway, it is not a state anyone chose.
 : >"$state_file"
 bluetooth_state_run restore no
 grep -q "power" "$state_log" && fail "bluetooth state does not power on from an unfinished write"
 pass "bluetooth state does not power on from an unfinished write"
 
-# The migration seeds through this rather than save, because save deliberately
-# records nothing when it cannot read an adapter and the migration runs once.
-# Left unseeded, the next restore reads the machine as a fresh install and
-# powers the adapter on for someone who deliberately keeps Bluetooth off.
+# save records nothing when it cannot read an adapter, and the migration has no
+# second chance to correct a machine left unseeded.
 rm -f "$state_file"
 bluetooth_state_run seed absent
 [[ $(cat "$state_file") == "off" ]] ||
@@ -253,10 +243,8 @@ bluetooth_state_run seed yes
   fail "bluetooth state seeds the adapter as it actually is" "$(cat "$state_file")"
 pass "bluetooth state seeds the adapter as it actually is"
 
-# AutoEnable=false is the load-bearing half of the design: leave it on and BlueZ
-# powers adapters up on its own, so a saved "off" is silently ignored. A bluez
-# .pacnew merge can drop the key, space it out, or take main.conf away entirely,
-# and a rewrite that quietly matches nothing would hand the power-on back.
+# Leave AutoEnable on and BlueZ powers adapters up itself, ignoring every saved
+# "off", so a rewrite that quietly matches nothing has to be caught here.
 main_conf="$device_tmp/main.conf"
 
 bluetooth_autoenable() {

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -236,3 +236,19 @@ pass "bluetooth state leaves no half-written file behind"
 bluetooth_state_run restore no
 grep -q "power" "$state_log" && fail "bluetooth state does not power on from an unfinished write"
 pass "bluetooth state does not power on from an unfinished write"
+
+# The migration seeds through this rather than save, because save deliberately
+# records nothing when it cannot read an adapter and the migration runs once.
+# Left unseeded, the next restore reads the machine as a fresh install and
+# powers the adapter on for someone who deliberately keeps Bluetooth off.
+rm -f "$state_file"
+bluetooth_state_run seed absent
+[[ $(cat "$state_file") == "off" ]] ||
+  fail "bluetooth state seeds off when no adapter is readable" "$(cat "$state_file")"
+pass "bluetooth state seeds off when no adapter is readable"
+
+rm -f "$state_file"
+bluetooth_state_run seed yes
+[[ $(cat "$state_file") == "on" ]] ||
+  fail "bluetooth state seeds the adapter as it actually is" "$(cat "$state_file")"
+pass "bluetooth state seeds the adapter as it actually is"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -259,45 +259,35 @@ policy_autoenable() {
        in_policy && /^AutoEnable=/ { print }' "$main_conf"
 }
 
+assert_autoenable() {
+  local label="$1"
+
+  bluetooth_autoenable
+  [[ $(policy_autoenable) == "AutoEnable=false" ]] || fail "$label" "$(cat "$main_conf")"
+  pass "$label"
+}
+
 printf '[Policy]\n#AutoEnable=true\n' >"$main_conf"
-bluetooth_autoenable
-[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
-  fail "bluetooth uncomments AutoEnable" "$(cat "$main_conf")"
-pass "bluetooth uncomments AutoEnable"
+assert_autoenable "bluetooth uncomments AutoEnable"
 
 printf '[Policy]\nAutoEnable = true\n' >"$main_conf"
-bluetooth_autoenable
-[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
-  fail "bluetooth rewrites a spaced AutoEnable" "$(cat "$main_conf")"
-pass "bluetooth rewrites a spaced AutoEnable"
+assert_autoenable "bluetooth rewrites a spaced AutoEnable"
 
 printf '[General]\nName=Omarchy\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
-bluetooth_autoenable
-[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
-  fail "bluetooth adds AutoEnable under an existing Policy section" "$(cat "$main_conf")"
-pass "bluetooth adds AutoEnable under an existing Policy section"
+assert_autoenable "bluetooth adds AutoEnable under an existing Policy section"
 
 grep -qx 'ReconnectAttempts=7' "$main_conf" ||
   fail "bluetooth leaves the rest of the Policy section intact" "$(cat "$main_conf")"
 pass "bluetooth leaves the rest of the Policy section intact"
 
 printf '[General]\nName=Omarchy\n' >"$main_conf"
-bluetooth_autoenable
-[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
-  fail "bluetooth adds a Policy section when main.conf has none" "$(cat "$main_conf")"
-pass "bluetooth adds a Policy section when main.conf has none"
+assert_autoenable "bluetooth adds a Policy section when main.conf has none"
 
 # An absent main.conf is not a free pass: BlueZ defaults AutoEnable to true.
 rm -f "$main_conf"
-bluetooth_autoenable
-[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
-  fail "bluetooth writes main.conf when it does not exist" "$(cat "$main_conf")"
-pass "bluetooth writes main.conf when it does not exist"
+assert_autoenable "bluetooth writes main.conf when it does not exist"
 
 # A key outside [Policy] is one BlueZ ignores, so rewriting it in place would
 # leave AutoEnable at its default while looking like the flag had landed.
 printf '[General]\nAutoEnable=true\n\n[Policy]\nReconnectAttempts=7\n' >"$main_conf"
-bluetooth_autoenable
-[[ $(policy_autoenable) == "AutoEnable=false" ]] ||
-  fail "bluetooth ignores an AutoEnable outside the Policy section" "$(cat "$main_conf")"
-pass "bluetooth ignores an AutoEnable outside the Policy section"
+assert_autoenable "bluetooth ignores an AutoEnable outside the Policy section"


### PR DESCRIPTION
**Bluetooth currently comes up off on every boot.** #5683 set `AutoEnable=false` to make the power state stick. It turns out BlueZ does not persist `Powered` at all, so in practice that flag means *never power the adapter on* rather than *remember what it was*. This PR adds the missing piece so the state is genuinely remembered in both directions.

The same behaviour is reported independently in #5868, which is open, on a ThinkBook 15p, and in #5807 on an X1 Carbon.

---

## If remembered state is not wanted, flipping `AutoEnable` back to true is simpler than this PR

That is a one line revert of #5683, and it makes every boot come up with Bluetooth on rather than always off as it is today, matching stock Arch and closing #5868 and #5807 with no new code. The cost is #5684, whose reporter wanted an adapter they had turned off to stay off.

This PR exists because that case seemed worth keeping, but it is a product decision rather than a technical one. If "a reboot always comes back with Bluetooth on" is the preferred answer, that revert is strictly simpler than this PR.

## Why `AutoEnable` alone cannot carry the state

#5683 worked from this reading of BlueZ:

> With `AutoEnable=false` (BlueZ 5.66+), `bluetoothd` respects the persisted `Powered` state in `/var/lib/bluetooth/<MAC>/settings`

That belief is still shipping. It sits above the `sed` that applies the flag, at `install/hardware/bluetooth.sh:3`:

```bash
# Persist last power state across reboots (default AutoEnable=true overrides it)
```

It is a very easy conclusion to reach, and BlueZ does almost nothing to steer you away from it. The option sits under `[Policy]`, and the single function it gates is named `btd_adapter_restore_powered()`. I went looking for that persistence expecting to find it too.

It is not there. BlueZ never writes `Powered` to disk, so the flag disables the auto power-on rather than switching bluetoothd to a remembered state.

That also explains why the change read as correct at the time: #5684's symptom really does go away, because an adapter that is never powered on does stay off. The gap only appears in the other direction, which the original report had no reason to cover.

<details>
<summary>Source-level evidence, against tag <code>5.87</code> (the source Arch compiles)</summary>

Provenance, so this is checkable: the Arch PKGBUILD builds `git+https://github.com/bluez/bluez.git#tag=$pkgver` at `pkgver=5.87`, and `prepare()` runs only `autoreconf -vfi` with no patches in `source=()`. Line numbers below are from tag `5.87`, commit `65d11ed`. On the test machine `pacman -Qkk bluez` reports 0 altered files, so the running daemon is that build.

| Check | Result |
| --- | --- |
| `store_adapter_info()` (`src/adapter.c:565`), everything written to `settings` | `PairableTimeout`, `Discoverable`, `Alias` |
| `load_config()` (`src/adapter.c:6948`), everything read back | `Discoverable`, `DiscoverableTimeout`, `Name` |
| `"Powered"` string literals in `src/adapter.c` | 4 total: one D-Bus property table entry, three change notifications. None in a persistence path |

The adapter's `settings` file is consequently zero bytes and has never been written:

```
$ sudo ls -la /var/lib/bluetooth/DC:56:...:C8/
-rw------- 1 root root    0 Nov 10  2025 settings
```

[The upstream API docs](https://github.com/bluez/bluez/blob/master/doc/org.bluez.Adapter.rst) say so directly:

> The value of this property is not persistent. After restart or unplugging of the adapter it will reset back to false.

**The function that makes the premise so plausible.** `AutoEnable` gates exactly one call (`plugins/policy.c:901`):

```c
if (auto_enable)
        btd_adapter_restore_powered(adapter);
```

Which reads (`src/adapter.c:7970`):

```c
int btd_adapter_restore_powered(struct btd_adapter *adapter)
{
	bool powered;

	powered = btd_adapter_get_powered(adapter);
	...
	if (powered)
		return 0;

	set_mode(adapter, MGMT_OP_SET_POWERED, 0x01);

	return 0;
}
```

It never consults stored state. `btd_adapter_get_powered()` returns the current in-memory value, and if the adapter is not already up the function powers it on unconditionally. "Restore" here means *restore to powered*, not *restore what the user chose*.

**Not something a newer BlueZ fixes.** Upstream `master` at `690c16df` (2026-07-31) is identical on every check above: `store_adapter_info()` still writes only `PairableTimeout`, `Discoverable`, `DiscoverableTimeout` and `Alias`, `load_config()` reads back the same set, and the four `"Powered"` literals are still one property table entry and three change notifications. `btd_adapter_restore_powered()` has gained an rfkill branch since 5.87, but still reads only the live in-memory value and still calls `set_mode(adapter, MGMT_OP_SET_POWERED, 0x01)` unconditionally. 5.87 also remains the newest release tag, so there is no shipped version where this behaves differently.

</details>

## The fix

Keep `AutoEnable=false`, which #5683 already put in place, and add the part that has to come from us.

- `bin/omarchy-bluetooth-state`: `save` reads the adapter and writes `on`/`off`, `restore` reapplies it.
- `default/systemd/system/omarchy-bluetooth-state.service`: `ExecStart=... restore`, `ExecStop=... save`, ordered `After=bluetooth.service`. That ordering is load-bearing, because systemd stops this unit *before* bluetoothd at shutdown, which is the only window where `save` can still read the adapter.
- A migration installs and enables the unit for existing users.

Reading the adapter rather than hooking the toggle means the state follows whatever the user actually used, including `bluetui`, which is where #5684 came from, and not just Omarchy's own panel.

<details>
<summary>Why not keep <code>AutoEnable=true</code> and have the unit restore on top of it</summary>

This is not the revert described at the top, which drops persistence altogether. It means keeping the unit and letting BlueZ power adapters on as well, which was the first cut of this PR, and it does not work. systemd considers `bluetooth.service` started once bluetoothd takes its D-Bus name, but BlueZ powers adapters up asynchronously after that, so `restore` and BlueZ's auto power-on race, and BlueZ wins. Measured on hardware:

```
11:18:04.827  Started Bluetooth service
11:18:04.832  Starting Restore the Bluetooth power state...   (5ms later)
11:18:04.862  Finished Restore...                             (adapter came back on anyway)
```

Leaving `AutoEnable` off means nothing else touches adapter power, so there is no race to lose: a saved `off` needs no action at all, and a saved `on` is applied by us.

</details>

## What happens when an existing user updates

Nothing in this path restarts `bluetooth.service`, so connected peripherals stay connected through the update.

The migration records the adapter exactly as it already is before starting the unit. Without that seed, `restore` would run against an empty state file, read the machine as a fresh install, and power the adapter on mid-update for anyone who deliberately keeps Bluetooth off. Seeded, `restore` matches what is already there and does nothing in either direction.

Starting the unit during the migration rather than only enabling it puts `ExecStop` in place for the next shutdown, so the very next reboot already carries the user's real state. No `reboot-required` flag is needed, since persistence is live from the moment the migration finishes.

That start is conditional on bluetoothd already running, because the unit is `BindsTo=bluetooth.service`. An unconditional `enable --now` would pull bluetoothd up for anyone who had stopped it on purpose, and fail the migration outright for anyone who had masked it. It would also defeat the seed above, since without a running daemon the `save` cannot read an adapter and writes nothing at all, leaving `restore` to treat the machine as a fresh install and power the adapter on. Enabling without starting costs nothing, because `WantedBy=bluetooth.service` starts the unit the next time bluetoothd does.

All of that runs once per machine, not once per user. Migration completion is recorded per user, so on a shared box the migration would otherwise run again for the second account and undo anything the administrator had changed in between: `AutoEnable` flipped back, hand edits to the unit, or the unit disabled outright. A marker at `/var/lib/omarchy/migrations/1786305695`, written only after the work succeeds, makes later runs no-op while still letting an interrupted one retry.

## Safety

- **Fresh installs are unchanged.** With no saved state, `restore` powers the adapter on, so a new machine comes up with Bluetooth on exactly as a stock Arch install does.
- **Powering on waits for the adapter to appear**, since bluetoothd registers it a moment after taking its bus name and a `power on` issued before then silently does nothing. A failure is reported to the journal rather than swallowed, and `save` will not overwrite a good state when it cannot read the adapter.
- **Inert without a controller**, via `ConditionDirectoryNotEmpty=/sys/class/bluetooth`. `ConditionPathIsDirectory` would not be, since the bluetooth core module creates that directory whether or not an adapter exists. A controller hot-plugged into a machine that had none at boot is picked up on the next boot rather than immediately, which is already true of `AutoEnable=false` today.
- **Installs to `/etc/systemd/system`** rather than `/usr/lib`, keeping it out of package territory and clear of `unowned-system-paths-test.sh`.

## Testing

A/B against a stock install, restarting `bluetooth.service` as a stand-in for a reboot, measured on the hardware below. The restart is a fair proxy because `adapter_shutdown()` at `src/adapter.c:10936` issues `SET_POWERED 0x00` on daemon exit, so the controller really is powered down and re-probed:

```
A / control (what quattro ships today)
PASS: A1: adapter left ON comes back OFF     (the regression)
PASS: A2: adapter left OFF stays OFF          (what #5684 wanted)

B / with this PR
PASS: B1: fresh install comes up ON
PASS: B1: unit ran
PASS: B2: adapter left ON comes back ON       (regression fixed)
PASS: B3: adapter left OFF comes back OFF     (#5684 still fixed)

6 passed, 0 failed
```

Every assertion discriminates, since `AutoEnable` stays off throughout and nothing powers the adapter except the unit under test. Worth noting because the first cut of this harness ran the treatment arm with `AutoEnable=true`, where BlueZ powered the adapter on by itself and B1 and B2 passed whether or not `restore` did anything at all. Only B3 failed, and that is what exposed the race.

### Confirmed across a real shutdown

A restart is still only a proxy, so the regression case was then re-run as a two arm A/B across genuine power cycles on the same machine, control first, five minutes apart, with the same shutdown path in both:

| | control, stock `quattro` | treatment, this PR |
| --- | --- | --- |
| adapter before shutdown | on | on |
| `AutoEnable` | `false` | `false` |
| after cold boot | `Powered: no` | `Powered: yes` |

The control arm ran with none of this PR's files on disk, since they are not package owned and would otherwise survive an update and contaminate the comparison. In the treatment arm the journal shows `save` running at shutdown while bluetoothd was still up, and `restore` running two seconds into the next boot. With `AutoEnable=false` throughout, the unit is the only thing that can account for the adapter coming back on.

The off case was then power cycled too, on the same machine. The adapter was turned off, the machine shut down, and it came back `Powered: no` with the saved state reading `off`. On its own that outcome is not discriminating, because with `AutoEnable=false` nothing would have powered the adapter on regardless. What it does establish is that neither half of the unit misfires: the journal shows `save` running at shutdown and rewriting the state from `on` to `off`, and `restore` on the next boot leaving a saved-off adapter alone rather than reading it as a fresh install and powering it on. That last case is the one the `AutoEnable=true` cut of this PR got wrong.

`test/shell.d/bluetooth-test.sh` gains coverage using the mock `bluetoothctl` already in that file: save records powered and unpowered, save keeps the last state when no adapter is readable, restore leaves a saved-off adapter alone, restore powers on a saved-on adapter, restore skips an adapter that is already powered, restore powers on a fresh install, and restore gives up when no adapter appears.

`test/shell.d/bluetooth-migration-test.sh` covers the migration itself, driving the real file with `sudo`, `systemctl` and the state helper stubbed and its three paths redirected into a temp dir, the same way `t2-hardware-test.sh` drives `migrations/1785944594.sh`: a first run rewrites `AutoEnable`, installs the unit, seeds the state before starting anything, enables and starts; a second run leaves a later opt-out alone and issues no `systemctl` at all; a run with bluetoothd down enables without starting; and a failed run leaves no marker, so it retries. Each assertion was checked against a mutant, since dropping the marker check, dropping the `is-active` guard, or writing the marker early each has to fail one of them.

`test/all` shows no new failures. Four files fail identically before and after this change on a clean `quattro` checkout, all for want of a sibling `omarchy-pkgs` checkout in this environment: `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`, and `bin-style-test.sh`.

<details>
<summary>Test environment</summary>

| | |
| --- | --- |
| Machine | Framework Laptop 13 (AMD Ryzen AI 300 Series), BIOS 03.03 |
| CPU | AMD Ryzen AI 9 HX 370 w/ Radeon 890M |
| Bluetooth | MediaTek `0e8d:0717`, manufacturer `0x0046`, `btmtk`/`btusb` |
| Omarchy | 4.0.0.r1602.g9d61915-1, `quattro`, fully updated |
| Kernel | 7.1.6-arch1-1 |
| BlueZ | 5.87-2 |

Not hardware specific. #5684 was reported on an Intel AX211 running Omarchy 3.7.1, and the machine above is a MediaTek controller on a different driver running `quattro`. Different vendor, different generation, same behaviour, which is what a config flag rather than a driver quirk looks like. #5868 and #5807 are two machines again, a ThinkBook 15p and an X1 Carbon 7th gen, neither of which names its controller.

</details>







