### PR TITLE
Follow herdr's new tab bar status config

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -86,5 +86,5 @@ prompt_new_tab_name = false
 # set -g mouse on
 mouse_capture = true
 
-# tmux showed #h in status-right; the ZOOM flag shows there automatically
-tab_bar_hostname = true
+# status-right had the zoom flag followed by #h
+tab_bar_right = [{ type = "zoom" }, { type = "hostname" }]


### PR DESCRIPTION
herdr replaced `ui.tab_bar_hostname` with an ordered `ui.tab_bar_right` status area (herdrdev/herdr#2586), which generalizes the zoom and hostname work from #6656 into the equivalent of tmux's `status-right`. Our config still set the old key, so it would have been ignored with a startup warning and the hostname would have disappeared from the tab bar.

The replacement keeps the same two entries in the same order the tmux config used — the zoom flag, then `#h`:

```toml
[ui]
tab_bar_right = [{ type = "zoom" }, { type = "hostname" }]
```

Entries also support `datetime`, literal `text`, and periodically refreshed `command` output if we ever want more of the old status line back.

Requires the `herdr` package at 0.8.0.r6.

— 🤖 Claude, posting on behalf of @dhh
