### PR TITLE
Fix display backlight on Dell XPS OLED laptops

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -30,6 +30,8 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
 
+run_logged "$OMARCHY_INSTALL/hardware/dell/fix-dell-xps-oled-backlight.sh"
+
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"

--- a/install/hardware/dell/fix-dell-xps-oled-backlight.sh
+++ b/install/hardware/dell/fix-dell-xps-oled-backlight.sh
@@ -1,0 +1,25 @@
+# Display backlight fix for Dell XPS OLED laptops on Intel Panther Lake (Xe3).
+# Enabled only for the LG panel matched by omarchy-hw-dell-xps-oled for now.
+# Other panels need confirmation whether the issue exists there too.
+#
+# Without this, intel_backlight sysfs writes succeed and actual_brightness
+# tracks them, but the panel stays at one brightness.
+#
+# The panel's EDID carries no HDR static metadata, so the kernel suggests
+# enable_dpcd_backlight=3. Don't take that hint. 3 forces the Intel HDR
+# interface, which this panel accepts writes on but never acts on: brightness
+# arrives as nits in DPCD 0x354/0x355, yet 0x357 BRIGHTNESS_CONTROL_ENABLE
+# stays clear. 1 selects the VESA DPCD interface, which does work -- 0x721
+# reads 0x82 (AUX control mode plus PANEL_LUMINANCE_CONTROL_ENABLE), so the
+# level rides the luminance path and 0x734 tracks sysfs in millinits.
+#
+# Note the driver is xe, not i915: the kernel's own hint names
+# i915.enable_dpcd_backlight, the wrong module on Panther Lake.
+
+if omarchy-hw-dell-xps-oled; then
+  sudo mkdir -p /etc/limine-entry-tool.d
+  sudo tee /etc/limine-entry-tool.d/dell-xps-oled-backlight.conf >/dev/null <<'EOF'
+# Dell XPS OLED display backlight fix
+KERNEL_CMDLINE[default]+=" xe.enable_dpcd_backlight=1"
+EOF
+fi


### PR DESCRIPTION
Brightness on the Dell XPS 14's internal OLED is stuck at one level. `intel_backlight` writes succeed and `actual_brightness` tracks them, but the panel never visibly changes.

The panel's EDID carries no HDR static metadata, so the kernel prints its usual hint suggesting `enable_dpcd_backlight=3`. That hint is wrong twice over on this hardware:

- The module is **`xe`**, not `i915`, on Panther Lake.
- **`3` doesn't work.** It forces the Intel HDR backlight interface, which this panel accepts writes on but never acts on. The driver delivers brightness correctly — it arrives as nits in DPCD `0x354`/`0x355`, tracking sysfs exactly — but the panel leaves `0x357` `BRIGHTNESS_CONTROL_ENABLE` clear, so it takes the value and ignores it.

**`1`** selects the VESA DPCD interface, which the panel does honour. `0x721` reads `0x82` — AUX control mode plus `PANEL_LUMINANCE_CONTROL_ENABLE` — so the level rides the luminance path: the 24-bit target at `0x734` tracks sysfs in millinits (100% → `0x07d000`, 40% → `0x0320c8`). The HDR-metadata warning also stops appearing, since that path never reads HDR metadata.

Follows the existing ASUS Panther Lake backlight fix (#5620), and wires up `omarchy-hw-dell-xps-oled`, which shipped with no callers.

### Verification

Confirmed on XPS 14 DA14260 (LG Display panel, EDID id `30e4`, `linux-ptl` 7.1.5): brightness keys and `brightnessctl` work across the full range after rebooting with `=1`. Register values above were read from `/dev/drm_dp_aux0` under both parameter values. Sandbox-tested both the matching and non-matching detector paths with `sudo` stubbed.

`./test/cli` passes. `./test/shell` has 5 failures, all identical on a clean `quattro` checkout and unrelated to this change (3 need an `omarchy-pkgs` checkout, plus a Quickshell geometry test and a pre-existing `bin commands use command helpers` lint).

### Notes for review

- Scoped narrowly to the one panel `omarchy-hw-dell-xps-oled` matches, following the "for now" framing of the ASUS fix. Whether other XPS OLED panels need it is unconfirmed.
- Adds `install/hardware/dell/`, so Dell scripts now live in two places — the existing `install/hardware/dell-xps-touchpad-haptics.sh` is still at the top level. Happy to consolidate, but left it out to keep this atomic.

- The inline comment is deliberately verbose, mostly so coding agents have the reasoning on hand and don't "correct" the parameter back to the `=3` the kernel suggests. Entirely happy for it to be trimmed to match the surrounding style if you'd prefer.

