### PR TITLE
Add QR code capture

### DIFF
--- a/bin/omarchy-capture-qr
+++ b/bin/omarchy-capture-qr
@@ -4,16 +4,32 @@
 # omarchy:group=capture
 # omarchy:examples=omarchy capture qr
 
+# Keep hyprpicker alive until after grim captures so the screenshot sees the
+# frozen overlay rather than live content shifting during teardown.
+cleanup_freeze() {
+  [[ -n $PID ]] && kill $PID 2>/dev/null
+}
+trap cleanup_freeze EXIT
+
+hyprpicker -r -z >/dev/null 2>&1 &
+PID=$!
+sleep .1
 SELECTION=$(slurp 2>/dev/null)
+
 [[ -z $SELECTION ]] && exit 0
 
-RESULT=$(grim -g "$SELECTION" - | zbarimg -q --raw - 2>/dev/null) || {
+# Decode QR codes only. Leaving the other symbologies enabled lets dense screen
+# content false-positive as an EAN or Code 39 barcode and take over the clipboard.
+RESULT=$(grim -g "$SELECTION" - | zbarimg -q --raw -Sdisable -Sqrcode.enable - 2>/dev/null)
+
+if [[ -z $RESULT ]]; then
   omarchy-notification-send -g 󰐲 -u critical "No QR code found" "Select a region containing a QR code"
   exit 1
-}
+fi
 
-[[ -z $RESULT ]] && exit 1
-
-printf '%s\n' "$RESULT"
+# QR codes routinely carry secrets, like the otpauth:// URIs behind 2FA setup
+# codes, so the decoded value goes to the clipboard and nowhere else. Printing it
+# or putting it in the notification would leak it to the session journal and to
+# the notification history.
 printf '%s' "$RESULT" | wl-copy
-omarchy-notification-send -g 󰐲 "QR code copied to clipboard" "Result: $RESULT"
+omarchy-notification-send -g 󰐲 "QR code copied to clipboard"

--- a/bin/omarchy-capture-qr
+++ b/bin/omarchy-capture-qr
@@ -30,6 +30,7 @@ fi
 # QR codes routinely carry secrets, like the otpauth:// URIs behind 2FA setup
 # codes, so the decoded value goes to the clipboard and nowhere else. Printing it
 # or putting it in the notification would leak it to the session journal and to
-# the notification history.
-printf '%s' "$RESULT" | wl-copy
+# the notification history, and an unmarked copy would be retained by clipboard
+# history. Pasting still works; only the recorded copy is given up.
+printf '%s' "$RESULT" | wl-copy --sensitive
 omarchy-notification-send -g 󰐲 "QR code copied to clipboard"

--- a/bin/omarchy-capture-qr
+++ b/bin/omarchy-capture-qr
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Decode a QR code from a screenshot region
+# omarchy:group=capture
+# omarchy:examples=omarchy capture qr
+
+SELECTION=$(slurp 2>/dev/null)
+[[ -z $SELECTION ]] && exit 0
+
+RESULT=$(grim -g "$SELECTION" - | zbarimg -q --raw - 2>/dev/null) || {
+  omarchy-notification-send -g 󰐲 -u critical "No QR code found" "Select a region containing a QR code"
+  exit 1
+}
+
+[[ -z $RESULT ]] && exit 1
+
+printf '%s\n' "$RESULT"
+printf '%s' "$RESULT" | wl-copy
+omarchy-notification-send -g 󰐲 "QR code copied to clipboard" "Result: $RESULT"

--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -146,10 +146,11 @@ show_reminder_message_input() {
 }
 
 show_capture_menu() {
-  case $(menu "Capture" "  Screenshot\n  Screenrecord\n󰴑  Text Extraction\n󰃉  Color") in
+  case $(menu "Capture" "  Screenshot\n  Screenrecord\n󰴑  Text Extraction\n󰐲  QR Code\n󰃉  Color") in
   *Screenshot*) omarchy-capture-screenshot ;;
   *Screenrecord*) show_screenrecord_menu ;;
   *Text*) omarchy-capture-text-extraction ;;
+  *QR*) omarchy-capture-qr ;;
   *Color*) pkill hyprpicker || hyprpicker -a ;;
   *) back_to show_trigger_menu ;;
   esac

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -152,4 +152,5 @@ xmlstarlet
 xournalpp
 yaru-icon-theme
 yay
+zbar
 zoxide

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -1,0 +1,3 @@
+echo "Install QR code scanning support"
+
+omarchy-pkg-add zbar


### PR DESCRIPTION
## Summary

- add `omarchy capture qr` to decode a selected screen region
- copy the decoded value to the clipboard and show it in a notification
- add QR Code to the Capture menu
- install `zbar` for fresh and existing systems

## Motivation

QR codes often appear on the same computer where their contents are needed—for example, when importing an OTP/2FA setup code shown by a web app. Reading one currently means reaching for a phone or taking a screenshot and manually passing it through a decoder. This feature turns that whole detour into one Capture menu action: select the QR code, then its decoded value is immediately displayed and copied to the clipboard.

## Testing

- `bash test/omarchy-cli-test.sh`
- generated a QR code with `qrencode` and decoded it through the new command using the real `zbarimg`
- manually tested the Capture → QR Code menu flow