### PR TITLE
Generate image picker thumbnails with libvips in parallel

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -74,8 +74,9 @@ fi
 
 selection_file=$(mktemp)
 done_file=$(mktemp)
+pending_file=$(mktemp)
 rm -f "$done_file"
-trap 'rm -f "$selection_file" "$done_file"' EXIT
+trap 'rm -f "$selection_file" "$done_file" "$pending_file"' EXIT
 
 image_dirs_env=""
 for dir in "${image_dirs[@]}"; do
@@ -144,7 +145,8 @@ generate_thumbnail() {
   local tmp="$thumbnail.$$.jpg"
 
   if mkdir "$lock" 2>/dev/null; then
-    if magick "${image}[0]" -auto-orient -resize '1536x864^' -gravity center -extent '1536x864' -strip -quality 82 "$tmp"; then
+    # Callers fan out one generator per image, so keep each vips single-threaded.
+    if VIPS_CONCURRENCY=1 vipsthumbnail "$image" --size 1536x864 --smartcrop=centre --path "$tmp[Q=82,strip]"; then
       mv -f "$tmp" "$thumbnail"
     else
       rm -f "$tmp" "$thumbnail"
@@ -186,10 +188,19 @@ thumbnail_for() {
       return
     fi
 
-    generate_thumbnail "$image" "$thumbnail"
+    printf '%s\0%s\0' "$image" "$thumbnail" >>"$pending_file"
   fi
 
-  [[ -f $thumbnail ]] && printf '%s' "$thumbnail"
+  printf '%s' "$thumbnail"
+}
+
+# Generate every queued thumbnail at once; each vips run is single-threaded.
+drain_pending_thumbnails() {
+  [[ -s $pending_file ]] || return 0
+
+  export -f generate_thumbnail
+  xargs -a "$pending_file" -0 -n 2 -P "$(nproc)" \
+    bash -c 'generate_thumbnail "$1" "$2"' _ >/dev/null 2>&1 || true
 }
 
 if [[ $rows_cache_hit != true && -f $rows_cache_file && -f $rows_signature_file ]] && cmp -s "$rows_signature_file" <(printf '%s' "$rows_signature"); then
@@ -209,6 +220,22 @@ elif [[ $rows_cache_hit != true ]]; then
       rows+=$'\n'"$image"$'\t'"$thumbnail"
     fi
   done
+
+  drain_pending_thumbnails
+
+  if [[ -s $pending_file ]]; then
+    pruned=""
+    while IFS=$'\t' read -r row_image row_thumbnail; do
+      [[ -e $row_thumbnail ]] || continue
+
+      if [[ -z $pruned ]]; then
+        pruned="$row_image"$'\t'"$row_thumbnail"
+      else
+        pruned+=$'\n'"$row_image"$'\t'"$row_thumbnail"
+      fi
+    done <<<"$rows"
+    rows="$pruned"
+  fi
 
   if [[ $rows_cacheable == true ]]; then
     printf '%s' "$rows" >"$rows_cache_file"

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -69,6 +69,7 @@ lazydocker
 lazygit
 less
 libsecret
+libvips
 libyaml
 libreoffice-fresh
 llvm

--- a/migrations/1786386460.sh
+++ b/migrations/1786386460.sh
@@ -1,0 +1,3 @@
+echo "Generate image picker thumbnails with libvips"
+
+omarchy-pkg-add libvips


### PR DESCRIPTION
The image picker generated thumbnails one ImageMagick process at a time. This queues the missing ones and drains them across every core with `vipsthumbnail`.

Two things compound here. libvips decodes and encodes faster than ImageMagick — notably via shrink-on-load for JPEGs — and running the queue in parallel lets its higher per-process startup overlap instead of accumulating. Each worker is pinned to a single thread (`VIPS_CONCURRENCY=1`) so the fan-out owns the cores rather than fighting the library's own threading.

Cold cache, measured through this script on a 24-core machine:

| corpus | before | after |
| --- | --- | --- |
| 92 wallpapers (large JPEGs) | 14191 ms | 1348 ms |
| bundled theme previews | 1986 ms | 263 ms |

Parallelism alone accounts for part of that; libvips is worth a further 3.1x on the wallpaper corpus and 1.6x on the smaller previews.

Warm cache is unchanged, and so is the lazy interactive path, which already generated in the background per image.

`libvips` joins the base package list with a migration for existing installs. ImageMagick stays — it is still used by `omarchy-bar-text-color`, `omarchy-plymouth-set`, `omarchy-plymouth-preview`, `omarchy-transcode`, and `omarchy-transcode-ascii`, and libvips loads its ImageMagick module for BMP regardless.

— 🤖 Claude, posting on behalf of @dhh