### PR TITLE
Preserve borders on Google Meet browser windows

### DIFF
--- a/default/hypr/apps/pip.lua
+++ b/default/hypr/apps/pip.lua
@@ -11,8 +11,12 @@ o.window({ tag = "pip" }, {
   move = { "(monitor_w-window_w-40)", "(monitor_h*0.04)" },
 })
 
--- Google Meet PiP uses the meeting title instead of "Picture-in-Picture".
-o.window({ tag = "chromium-based-browser", title = "^Meet - .+" }, {
+-- Google Meet PiP titles omit the browser suffix used by regular Meet tabs.
+o.window({
+  tag = "chromium-based-browser",
+  title = "^Meet - .+",
+  initial_title = "negative:.* - (Chromium|Google Chrome|Brave|Microsoft Edge|Vivaldi|Helium)$",
+}, {
   tag = "-default-opacity",
   float = true,
   pin = true,

--- a/default/hypr/apps/pip.lua
+++ b/default/hypr/apps/pip.lua
@@ -15,7 +15,7 @@ o.window({ tag = "pip" }, {
 o.window({
   tag = "chromium-based-browser",
   title = "^Meet - .+",
-  initial_title = "negative:.* - (Chromium|Google Chrome|Brave|Microsoft Edge|Vivaldi|Helium)$",
+  initial_title = "negative:.* - .+ - (Chromium|Google Chrome|Brave|Microsoft Edge|Vivaldi|Helium)$",
 }, {
   tag = "-default-opacity",
   float = true,


### PR DESCRIPTION
## Problem

The Google Meet PiP rule matches every Chromium-based window whose title starts with `Meet - `. Normal Meet tabs use that title too, so their dynamic border becomes zero. When the Meet title is already available as the window maps, the static PiP effects also float, pin, resize, and move the normal browser window.

## Fix

Keep matching the Meet title, but exclude initial titles ending in the browser-brand suffixes used by Omarchy's supported Chromium browsers. Standalone web apps remain excluded by their application class, while legacy Meet PiP windows without a browser suffix continue to match.

## Screenshots

### Border detail

![Before and after border detail](https://github.com/user-attachments/assets/7a4a8ea2-18bb-4939-8941-ca60e560c21c)

<details>
<summary>Full-window comparison</summary>

![Before and after full-window comparison](https://github.com/user-attachments/assets/7e9a3874-e8ff-4a4f-8557-dcb3363dab7b)

</details>

## Testing

Tested on Hyprland 0.56.2 with Chromium 151:

- Normal Meet window with its title available at map: tiled, unpinned, 2px border
- Normal Meet window after a title transition: tiled, unpinned, 2px border
- Standalone Meet web app/PWA: tiled, unpinned, 2px border
- Standard Chromium `Picture in picture` window: floating, pinned, 600x338, borderless
- Legacy `Meet - ...` PiP title: floating, pinned, 600x338, borderless
- Browser-title matrix for Chromium, Google Chrome, Brave, Microsoft Edge, Vivaldi, and Helium: all remained tiled with 2px borders
- `bash test/shell.d/hyprland-default-config-test.sh`
- `git diff --check`
