### PR TITLE
Fix backlight on Dell XPS OLED laptops

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -52,6 +52,7 @@ run_logged $OMARCHY_INSTALL/config/hardware/intel/fix-wifi7-eht.sh
 run_logged $OMARCHY_INSTALL/config/hardware/intel/sof-firmware.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-asus-ptl-display-backlight.sh
+run_logged $OMARCHY_INSTALL/config/hardware/dell/fix-dell-xps-oled-backlight.sh
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-asus-ptl-b9406-display.sh
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-asus-ptl-b9406-touchpad.sh
 run_logged $OMARCHY_INSTALL/config/hardware/asus/fix-audio-mixer.sh

--- a/install/config/hardware/dell/fix-dell-xps-oled-backlight.sh
+++ b/install/config/hardware/dell/fix-dell-xps-oled-backlight.sh
@@ -1,0 +1,12 @@
+# Display backlight fix for Dell XPS OLED Panther Lake laptops.
+#
+# The affected LG OLED panel accepts intel_backlight sysfs writes but only
+# applies them through the VESA DPCD backlight interface.
+
+if omarchy-hw-dell-xps-oled; then
+  sudo mkdir -p /etc/limine-entry-tool.d
+  cat <<EOF | sudo tee /etc/limine-entry-tool.d/dell-xps-oled-backlight.conf >/dev/null
+# Dell XPS OLED display backlight fix
+KERNEL_CMDLINE[default]+=" xe.enable_dpcd_backlight=1"
+EOF
+fi

--- a/migrations/1786420555.sh
+++ b/migrations/1786420555.sh
@@ -1,0 +1,9 @@
+echo "Enable working display backlight on supported Dell XPS OLED laptops"
+
+if omarchy-hw-dell-xps-oled; then
+  source "$OMARCHY_PATH/install/config/hardware/dell/fix-dell-xps-oled-backlight.sh"
+
+  if omarchy-cmd-present limine-update; then
+    sudo limine-update
+  fi
+fi


### PR DESCRIPTION
## Problem
Supported Dell XPS OLED panels accept brightness writes but do not apply them through the default Xe backlight path.

## Approach
Add a hardware-gated Limine drop-in that selects the VESA DPCD backlight interface during installation, plus an update migration for existing supported systems.

## User impact
Brightness controls work across the panel range after rebooting.

## Test evidence
- `git diff --check`
- `bash -n install/config/hardware/dell/fix-dell-xps-oled-backlight.sh migrations/1786420555.sh`
- `bash test/omarchy-cli-test.sh`
