### PR TITLE
Modernize default Helix theme

### DIFF
--- a/default/themed/helix.toml.tpl
+++ b/default/themed/helix.toml.tpl
@@ -1,101 +1,101 @@
 # Syntax
-"keyword" = "color5"
-"keyword.control" = { fg = "color5", modifiers = ["italic"] }
-"function" = "color4"
-"function.builtin" = "color4"
-"function.macro" = "color5"
-"type" = "color3"
-"type.builtin" = "color5"
-"type.enum.variant" = "color6"
-"constructor" = "color4"
-"constant" = "color3"
-"constant.builtin" = "color3"
-"constant.numeric" = "color3"
-"constant.character" = "color6"
-"constant.character.escape" = "color5"
-"string" = "color2"
-"string.regexp" = "color5"
-"string.special" = "color4"
-"comment" = { fg = "color8", modifiers = ["italic"] }
+"keyword" = "magenta"
+"keyword.control" = { fg = "magenta", modifiers = ["italic"] }
+"function" = "blue"
+"function.builtin" = "blue"
+"function.macro" = "magenta"
+"type" = "yellow"
+"type.builtin" = "magenta"
+"type.enum.variant" = "cyan"
+"constructor" = "blue"
+"constant" = "yellow"
+"constant.builtin" = "yellow"
+"constant.numeric" = "yellow"
+"constant.character" = "cyan"
+"constant.character.escape" = "magenta"
+"string" = "green"
+"string.regexp" = "magenta"
+"string.special" = "blue"
+"comment" = { fg = "muted", modifiers = ["italic"] }
 "variable" = "foreground"
-"variable.parameter" = { fg = "color5", modifiers = ["italic"] }
-"variable.builtin" = "color1"
-"variable.other.member" = "color4"
-"label" = "color4"
-"punctuation" = "color8"
-"punctuation.special" = "color6"
-"operator" = "color6"
-"tag" = "color4"
-"namespace" = { fg = "color3", modifiers = ["italic"] }
-"special" = "color5"
-"attribute" = "color3"
+"variable.parameter" = { fg = "magenta", modifiers = ["italic"] }
+"variable.builtin" = "red"
+"variable.other.member" = "blue"
+"label" = "blue"
+"punctuation" = "muted"
+"punctuation.special" = "cyan"
+"operator" = "cyan"
+"tag" = "blue"
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
+"special" = "magenta"
+"attribute" = "yellow"
 
 # Markup
-"markup.heading" = "color1"
-"markup.heading.1" = "color1"
-"markup.heading.2" = "color3"
-"markup.heading.3" = "color3"
-"markup.heading.4" = "color2"
-"markup.heading.5" = "color4"
-"markup.heading.6" = "color5"
-"markup.list" = "color6"
-"markup.list.unchecked" = "color8"
-"markup.list.checked" = "color2"
-"markup.bold" = { fg = "color1", modifiers = ["bold"] }
-"markup.italic" = { fg = "color1", modifiers = ["italic"] }
+"markup.heading" = "red"
+"markup.heading.1" = "red"
+"markup.heading.2" = "yellow"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "magenta"
+"markup.list" = "cyan"
+"markup.list.unchecked" = "muted"
+"markup.list.checked" = "green"
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.link.url" = { fg = "color4", modifiers = ["italic", "underlined"] }
-"markup.link.text" = "color5"
-"markup.link.label" = "color4"
-"markup.raw" = "color2"
-"markup.quote" = "color5"
+"markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
+"markup.link.text" = "magenta"
+"markup.link.label" = "blue"
+"markup.raw" = "green"
+"markup.quote" = "magenta"
 
 # Diff
-"diff.plus" = "color2"
-"diff.minus" = "color1"
-"diff.delta" = "color4"
+"diff.plus" = "green"
+"diff.minus" = "red"
+"diff.delta" = "blue"
 
 # Leave the editor background transparent so the terminal background shows through
 "ui.background" = { }
 
-"ui.linenr" = { fg = "color8" }
+"ui.linenr" = { fg = "muted" }
 "ui.linenr.selected" = { fg = "foreground" }
 
 # Statusline uses an inverted band (background-color text on foreground-color
 # background) to guarantee contrast across both light and dark Omarchy themes.
 "ui.statusline" = { fg = "background", bg = "foreground" }
-"ui.statusline.inactive" = { fg = "background", bg = "color8" }
-"ui.statusline.normal" = { fg = "background", bg = "color4", modifiers = ["bold"] }
-"ui.statusline.insert" = { fg = "background", bg = "color2", modifiers = ["bold"] }
-"ui.statusline.select" = { fg = "background", bg = "color5", modifiers = ["bold"] }
+"ui.statusline.inactive" = { fg = "background", bg = "muted" }
+"ui.statusline.normal" = { fg = "background", bg = "blue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "background", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "background", bg = "magenta", modifiers = ["bold"] }
 
 "ui.popup" = { fg = "foreground", bg = "background" }
-"ui.window" = { fg = "color8" }
+"ui.window" = { fg = "muted" }
 "ui.help" = { fg = "foreground", bg = "background" }
 
-"ui.bufferline" = { fg = "color8", bg = "background" }
-"ui.bufferline.active" = { fg = "foreground", bg = "background", underline = { color = "color5", style = "line" } }
+"ui.bufferline" = { fg = "muted", bg = "background" }
+"ui.bufferline.active" = { fg = "foreground", bg = "background", underline = { color = "magenta", style = "line" } }
 
 "ui.text" = "foreground"
 "ui.text.focus" = { fg = "foreground", bg = "lighter_background", modifiers = ["bold"] }
-"ui.text.inactive" = { fg = "color8" }
-"ui.text.directory" = { fg = "color4" }
+"ui.text.inactive" = { fg = "muted" }
+"ui.text.directory" = { fg = "blue" }
 
-"ui.virtual" = "color8"
+"ui.virtual" = "muted"
 "ui.virtual.ruler" = { bg = "lighter_background" }
-"ui.virtual.indent-guide" = "color8"
-"ui.virtual.inlay-hint" = { fg = "color8" }
-"ui.virtual.jump-label" = { fg = "color1", modifiers = ["bold"] }
-"ui.virtual.whitespace" = "color8"
+"ui.virtual.indent-guide" = "muted"
+"ui.virtual.inlay-hint" = { fg = "muted" }
+"ui.virtual.jump-label" = { fg = "red", modifiers = ["bold"] }
+"ui.virtual.whitespace" = "muted"
 
 "ui.selection" = { bg = "selection_background", fg = "selection_foreground" }
 
-"ui.cursor" = { fg = "background", bg = "cursor" }
-"ui.cursor.primary" = { fg = "background", bg = "cursor" }
-"ui.cursor.match" = { fg = "color3", modifiers = ["bold"] }
-"ui.cursor.primary.normal" = { fg = "background", bg = "cursor" }
-"ui.cursor.primary.insert" = { fg = "background", bg = "color2" }
-"ui.cursor.primary.select" = { fg = "background", bg = "color5" }
+"ui.cursor" = { fg = "background", bg = "bright_foreground" }
+"ui.cursor.primary" = { fg = "background", bg = "bright_foreground" }
+"ui.cursor.match" = { fg = "yellow", modifiers = ["bold"] }
+"ui.cursor.primary.normal" = { fg = "background", bg = "bright_foreground" }
+"ui.cursor.primary.insert" = { fg = "background", bg = "green" }
+"ui.cursor.primary.select" = { fg = "background", bg = "magenta" }
 
 "ui.cursorline.primary" = { bg = "lighter_background" }
 
@@ -104,31 +104,29 @@
 "ui.menu" = { fg = "foreground", bg = "background" }
 "ui.menu.selected" = { fg = "background", bg = "foreground", modifiers = ["bold"] }
 
-"diagnostic.error" = { underline = { color = "color1", style = "curl" } }
-"diagnostic.warning" = { underline = { color = "color3", style = "curl" } }
-"diagnostic.info" = { underline = { color = "color4", style = "curl" } }
-"diagnostic.hint" = { underline = { color = "color6", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "cyan", style = "curl" } }
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
-error = "color1"
-warning = "color3"
-info = "color4"
-hint = "color6"
+error = "red"
+warning = "yellow"
+info = "blue"
+hint = "cyan"
 
 [palette]
 background = "{{ background }}"
-foreground = "{{ foreground }}"
 lighter_background = "{{ lighter_background }}"
-cursor = "{{ bright_foreground }}"
+foreground = "{{ foreground }}"
+bright_foreground = "{{ bright_foreground }}"
+muted = "{{ muted }}"
 selection_background = "{{ selection_background }}"
 selection_foreground = "{{ selection_foreground }}"
-color0 = "{{ background }}"
-color1 = "{{ red }}"
-color2 = "{{ green }}"
-color3 = "{{ yellow }}"
-color4 = "{{ blue }}"
-color5 = "{{ magenta }}"
-color6 = "{{ cyan }}"
-color7 = "{{ foreground }}"
-color8 = "{{ muted }}"
+red = "{{ red }}"
+green = "{{ green }}"
+yellow = "{{ yellow }}"
+blue = "{{ blue }}"
+magenta = "{{ magenta }}"
+cyan = "{{ cyan }}"

--- a/default/themed/helix.toml.tpl
+++ b/default/themed/helix.toml.tpl
@@ -31,6 +31,7 @@
 "attribute" = "color3"
 
 # Markup
+"markup.heading" = "color1"
 "markup.heading.1" = "color1"
 "markup.heading.2" = "color3"
 "markup.heading.3" = "color3"

--- a/default/themed/helix.toml.tpl
+++ b/default/themed/helix.toml.tpl
@@ -8,17 +8,16 @@
 "type.builtin" = "magenta"
 "type.enum.variant" = "cyan"
 "constructor" = "blue"
-"constant" = "yellow"
-"constant.builtin" = "yellow"
-"constant.numeric" = "yellow"
+"constant" = "orange"
 "constant.character" = "cyan"
 "constant.character.escape" = "magenta"
 "string" = "green"
 "string.regexp" = "magenta"
 "string.special" = "blue"
+"string.special.symbol" = "red"
 "comment" = { fg = "muted", modifiers = ["italic"] }
 "variable" = "foreground"
-"variable.parameter" = { fg = "magenta", modifiers = ["italic"] }
+"variable.parameter" = { fg = "red", modifiers = ["italic"] }
 "variable.builtin" = "red"
 "variable.other.member" = "blue"
 "label" = "blue"
@@ -27,13 +26,13 @@
 "operator" = "cyan"
 "tag" = "blue"
 "namespace" = { fg = "yellow", modifiers = ["italic"] }
-"special" = "magenta"
+"special" = "blue"
 "attribute" = "yellow"
 
 # Markup
 "markup.heading" = "red"
 "markup.heading.1" = "red"
-"markup.heading.2" = "yellow"
+"markup.heading.2" = "orange"
 "markup.heading.3" = "yellow"
 "markup.heading.4" = "green"
 "markup.heading.5" = "blue"
@@ -92,7 +91,7 @@
 
 "ui.cursor" = { fg = "background", bg = "bright_foreground" }
 "ui.cursor.primary" = { fg = "background", bg = "bright_foreground" }
-"ui.cursor.match" = { fg = "yellow", modifiers = ["bold"] }
+"ui.cursor.match" = { fg = "orange", modifiers = ["bold"] }
 "ui.cursor.primary.normal" = { fg = "background", bg = "bright_foreground" }
 "ui.cursor.primary.insert" = { fg = "background", bg = "green" }
 "ui.cursor.primary.select" = { fg = "background", bg = "magenta" }
@@ -127,6 +126,7 @@ selection_foreground = "{{ selection_foreground }}"
 red = "{{ red }}"
 green = "{{ green }}"
 yellow = "{{ yellow }}"
+orange = "{{ orange }}"
 blue = "{{ blue }}"
 magenta = "{{ magenta }}"
 cyan = "{{ cyan }}"


### PR DESCRIPTION
style(helix): provide bare `markup.heading` default color

Helix asks for a bare `markup.heading` wherever a language has no
heading levels. Its git-commit queries use it for the subject line
and its git-config queries use it for section headers, seven of
the 279 bundled query sets in total. This template only defined
`markup.heading.1` through `.6`, so Helix found no rule at all and those
lines fell back to `ui.text`. The subject of the commit message you are
writing looked no different from its paragraphs.

Matching `markup.heading.1` keeps an unleveled heading looking like
a level-one heading.

Tested: rendered this template for retro-82 and miasma, opened a
  COMMIT_EDITMSG in Helix under a pty, and read the emitted SGR colors
  back per line.

    retro-82  subject #f85525  body #f6dcac  comment #2a6b78
    miasma    subject #685742  body #c2c2b0  comment #666666

  No theme warnings in ~/.cache/helix/helix.log for either. Worth knowing
  for future edits here: an unresolved palette name fails quietly, with
  Helix logging `Malformed ANSI` and dropping the style, which looks the
  same on screen as having no rule at all.

Signed-off-by: Luke Hsiao <luke@hsiao.dev>
Assisted-by: Claude:claude-opus-5

---

style(helix): name palette colors instead of color0 through color8

The Helix template carried a second, private naming layer: the palette
defined color0 through color8 as aliases for the theme's real colors,
and every one of the 75 syntax and UI rules referenced those numbers.
Reading the file meant holding a mapping in your head to learn that
a keyword is magenta or that punctuation is muted, and the numbering
is borrowed from a 16-color terminal, which a Helix theme is not. The
aliases also lied by omission: color0 and color7 were duplicates of
background and foreground that no rule ever referenced.

This names every color for what it is. The palette now exposes
background, lighter_background, foreground, bright_foreground, muted,
the two selection colors, and the six hues, and each rule refers to one
of those. The `cursor` alias goes too, since `bright_foreground` says
the same thing without the indirection. Anyone inheriting this theme and
referencing `color4` will need to say `blue`, which is the point.

Tested: rendered the template for all 22 stock themes before and after,
resolved every rule through each file's own palette down to hex, and
compared. All 22 are byte-identical in effect, so this is provably a
rename and not a restyle. Then loaded all 22 rendered themes in Helix
by cycling `:theme` through them in one session: zero warnings in
~/.cache/helix/helix.log, which is the check that matters, since an
unresolvable palette name is dropped silently rather than refused.

Signed-off-by: Luke Hsiao <luke@hsiao.dev>
Assisted-by: Claude:claude-opus-5

---

style(helix): refine scope mapping for syntax-highlighting

Catppuccin maintains the most carefully tuned Helix theme going,
so where our mapping disagreed with theirs it was usually us being
arbitrary rather than deliberate. Three of their choices are worth
taking, and each one buys a distinction the old mapping threw away.

Constants become orange, which is Catppuccin's peach. They were yellow,
the same yellow as types and attributes, so a numeric literal and a type
name were indistinguishable. Since Helix resolves scopes by prefix, the
separate `constant.builtin` and `constant.numeric` rules were already
redundant with `constant` and are gone. Parameters become red italic,
Catppuccin's maroon; they were magenta, which is also the keyword
color, and in retro-82 that was literally invisible because that palette
defines blue and magenta as the same teal, so parameters and keywords
rendered identically. `markup.heading.2` becomes orange as well, which
stops it duplicating `markup.heading.3`, and `ui.cursor.match` follows
their peach for the matching bracket. Rounding it out, `special` moves
to blue and `string.special.symbol` gains the red rule Catppuccin has
and we lacked.

Orange is the one hue in the palette that was going unused and actually
carries new information: it is a distinct color from both yellow and red
in 18 of the 22 stock themes. The rest of the unused palette turned out
to be a mirage worth recording, so nobody repeats the search. `purple`
is a plain alias for `magenta` in all 22 themes, so Catppuccin's
lavender roles stay magenta here. `accent` duplicates an existing hue
in 19 of 22. The `bright_*` hues are not brighter in any useful sense:
bright_green bottoms out at 1.68:1 against its background versus 2.96:1
for plain green. Orange does carry the same caveat as red, sitting below
WCAG AA against the background in eight themes, but syntax hues are the
palette author's call and Catppuccin makes the same tradeoff.

What we deliberately do not copy: Catppuccin paints ui.background, while
we leave it empty so the terminal shows through, and their statusline
is subtext on a mantle surface, while ours inverts foreground and
background to guarantee contrast in both light and dark themes. Both of
those are existing Omarchy decisions with comments explaining them.

Signed-off-by: Luke Hsiao <luke@hsiao.dev>
Assisted-by: Claude:claude-opus-5

---

## Demo before/after

Across a sample of themes



<img width="1936" height="2510" alt="omarchy-helix-catppuccin" src="https://github.com/user-attachments/assets/cfea9a12-3db2-417f-84e3-ecee29520ed6" />
<img width="1936" height="2510" alt="omarchy-helix-catppuccin-latte" src="https://github.com/user-attachments/assets/2971ec8b-83d8-4cbc-962c-cc82390e1e77" />
<img width="1936" height="2510" alt="omarchy-helix-flexoki-light" src="https://github.com/user-attachments/assets/d164eaf8-5230-4deb-9107-5132138cb514" />
<img width="1936" height="2510" alt="omarchy-helix-gruvbox" src="https://github.com/user-attachments/assets/bc0b0414-ccab-41b9-b802-c75812f56a5c" />
<img width="1936" height="2510" alt="omarchy-helix-miasma" src="https://github.com/user-attachments/assets/5fa3a195-f59e-4b6e-b384-4b36be503e17" />
<img width="1936" height="2510" alt="omarchy-helix-nord" src="https://github.com/user-attachments/assets/2c45f80e-a15f-42e7-806c-845ed9b4afc5" />
<img width="1936" height="2510" alt="omarchy-helix-osaka-jade" src="https://github.com/user-attachments/assets/7f2f3d7d-f2eb-4fa2-8776-bf12d157b96a" />
<img width="1936" height="2510" alt="omarchy-helix-retro-82" src="https://github.com/user-attachments/assets/0aa7bfb9-1379-4ebc-bf94-7d473841fbde" />
<img width="1936" height="2510" alt="omarchy-helix-tokyo-night" src="https://github.com/user-attachments/assets/53994b0c-4676-4683-826b-40f0384eaa78" />
<img width="1936" height="2510" alt="omarchy-helix-white" src="https://github.com/user-attachments/assets/d4e5f328-e74f-4aed-a8be-a61fa13dd386" />



