### PR TITLE
Adding Atuin be default for better shell search / history

### DIFF
--- a/config/atuin/config.toml
+++ b/config/atuin/config.toml
@@ -1,5 +1,3 @@
-db_path = "~/.atuin/.history.db"
-key_path = "~/.atuin/.key"
 session_path = "~/.atuin/.session"
 update_check = true
 sync_address = "https://api.atuin.sh"

--- a/config/atuin/config.toml
+++ b/config/atuin/config.toml
@@ -1,0 +1,20 @@
+db_path = "~/.atuin/.history.db"
+key_path = "~/.atuin/.key"
+session_path = "~/.atuin/.session"
+update_check = true
+sync_address = "https://api.atuin.sh"
+sync_frequency = "1h"
+search_mode = "daemon-fuzzy"
+filter_mode = "host"
+enter_accept = true
+keymap_mode = "vim-normal"
+keymap_cursor = { vim_insert = "blink-bar", vim_normal = "steady-block" }
+
+[tmux]
+enabled = true
+width = "80%"
+height = "60%"
+
+[daemon]
+enabled = true
+autostart = true

--- a/default/bash/init
+++ b/default/bash/init
@@ -10,10 +10,6 @@ if command -v zoxide &> /dev/null; then
   eval "$(zoxide init bash)"
 fi
 
-if command -v atuin &> /dev/null; then
-  eval "$(atuin init bash)"
-fi
-
 if command -v try &> /dev/null; then
   try() {
     unset -f try
@@ -29,6 +25,11 @@ if command -v fzf &> /dev/null; then
   if [[ -f /usr/share/fzf/key-bindings.bash ]]; then
     source /usr/share/fzf/key-bindings.bash
   fi
+fi
+
+# Must load after fzf's key-bindings.bash so Atuin's Ctrl-R binding wins.
+if command -v atuin &> /dev/null; then
+  eval "$(atuin init bash)"
 fi
 
 source "$OMARCHY_PATH/default/bash/completions"

--- a/default/bash/init
+++ b/default/bash/init
@@ -10,6 +10,10 @@ if command -v zoxide &> /dev/null; then
   eval "$(zoxide init bash)"
 fi
 
+if command -v atuin &> /dev/null; then
+  eval "$(atuin init bash)"
+fi
+
 if command -v try &> /dev/null; then
   try() {
     unset -f try

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -4,6 +4,7 @@
 aether
 alsa-utils
 asdcontrol
+atuin
 avahi
 bash-completion
 bat

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -1,4 +1,3 @@
-omarchy-mise-install atuin
 omarchy-mise-install codex
 omarchy-mise-install claude
 omarchy-mise-install crush

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -1,3 +1,4 @@
+omarchy-mise-install atuin
 omarchy-mise-install codex
 omarchy-mise-install claude
 omarchy-mise-install crush

--- a/migrations/1786435126.sh
+++ b/migrations/1786435126.sh
@@ -1,0 +1,9 @@
+echo "Install Atuin as a base package and seed its config"
+
+if [[ -f $HOME/.local/bin/atuin ]] && grep -Fq 'mise use -g "atuin"' "$HOME/.local/bin/atuin"; then
+  rm -f "$HOME/.local/bin/atuin"
+fi
+
+omarchy-pkg-add atuin
+
+[[ -f $HOME/.config/atuin/config.toml ]] || omarchy-refresh-config atuin/config.toml


### PR DESCRIPTION
Adding Atuin by default, replacing fzf for searching previous shell history. Atuin can sync, search, and back up your shell history with end-to-end encryption. Making it great for keeping things synced across multiple machines.

https://atuin.sh/