### PR TITLE
Add folder transcoding

### DIFF
--- a/bin/omarchy-transcode
+++ b/bin/omarchy-transcode
@@ -15,6 +15,7 @@ Usage:
 
 With no input, pick a picture or video from ~/Pictures and ~/Videos,
 or only from --path when provided. Then pick the output format and resolution.
+When input is a directory, transcode matching direct child files only.
 
 Options:
   --path path  Limit interactive fuzzy file selection to this path
@@ -38,6 +39,17 @@ media_type() {
   video/*) echo video ;;
   *)
     echo "Unsupported file type: $mime" >&2
+    return 1
+    ;;
+  esac
+}
+
+media_type_for_format() {
+  case "$1" in
+  jpg | png) echo picture ;;
+  mp4 | gif) echo video ;;
+  *)
+    echo "Invalid format: $1" >&2
     return 1
     ;;
   esac
@@ -120,6 +132,67 @@ transcode_video() {
   esac
 }
 
+transcode_file() {
+  local input="$1" format="$2" resolution="$3"
+  local type output
+
+  type=$(media_type "$input")
+  output=$(output_path "$input" "$format" "$resolution")
+
+  if [[ $type == "video" ]]; then
+    transcode_video "$input" "$format" "$resolution" "$output"
+  else
+    transcode_picture "$input" "$format" "$resolution" "$output"
+  fi
+
+  printf '%s\n' "$output"
+}
+
+transcode_directory() {
+  local input="$1" format="$2" resolution="$3"
+  local target_type path type output count=0 skipped=0
+
+  target_type=$(media_type_for_format "$format")
+
+  shopt -s nullglob
+  for path in "$input"/*; do
+    [[ -f $path ]] || continue
+
+    if ! type=$(media_type "$path" 2>/dev/null); then
+      (( skipped += 1 ))
+      continue
+    fi
+
+    if [[ $type != "$target_type" ]]; then
+      (( skipped += 1 ))
+      continue
+    fi
+
+    output=$(output_path "$path" "$format" "$resolution")
+    if [[ $type == "video" ]]; then
+      omarchy-notification-send -g  "Transcoding video…" "$(basename -- "$path") to $format ($resolution)"
+      transcode_video "$path" "$format" "$resolution" "$output"
+    else
+      transcode_picture "$path" "$format" "$resolution" "$output"
+    fi
+
+    (( count += 1 ))
+    printf 'Transcoded %s -> %s\n' "$path" "$output"
+  done
+  shopt -u nullglob
+
+  if (( count == 0 )); then
+    echo "No supported $target_type files found in: $input" >&2
+    return 1
+  fi
+
+  omarchy-notification-send "Transcoded $count item(s) to $resolution $format" "Saved in $(basename -- "$input")"
+
+  if (( skipped > 0 )); then
+    printf 'Skipped %d unsupported or mismatched item(s).\n' "$skipped"
+  fi
+}
+
 copy_to_clipboard() {
   local output="$1"
   local uri
@@ -170,7 +243,26 @@ main() {
   fi
 
   [[ -n $input ]] || return 1
-  [[ -f $input ]] || { echo "File not found: $input" >&2; return 1; }
+  [[ -f $input || -d $input ]] || { echo "File or directory not found: $input" >&2; return 1; }
+
+  if [[ -d $input ]]; then
+    if [[ -z $format ]]; then
+      format=$(omarchy-menu-select "Select format" jpg png mp4 gif)
+    fi
+
+    type=$(media_type_for_format "$format")
+
+    if [[ -z $resolution ]]; then
+      if [[ $type == "picture" ]]; then
+        resolution=$(omarchy-menu-select "Select resolution" high medium low)
+      else
+        resolution=$(omarchy-menu-select "Select resolution" 4k 1080p 720p)
+      fi
+    fi
+
+    transcode_directory "$input" "$format" "$resolution"
+    return
+  fi
 
   type=$(media_type "$input")
 
@@ -190,15 +282,13 @@ main() {
     fi
   fi
 
-  output=$(output_path "$input" "$format" "$resolution")
-
   if [[ $type == "video" ]]; then
     omarchy-notification-send -g  "Transcoding video…" "$(basename -- "$input") to $format ($resolution)"
-    transcode_video "$input" "$format" "$resolution" "$output"
+    output=$(transcode_file "$input" "$format" "$resolution")
     copy_to_clipboard "$output"
     omarchy-notification-send -g  "Transcoded to $resolution $format" "Saved and copied to clipboard."
   else
-    transcode_picture "$input" "$format" "$resolution" "$output"
+    output=$(transcode_file "$input" "$format" "$resolution")
     copy_to_clipboard "$output"
     omarchy-notification-send -g  "Transcoded to $resolution $format" "Saved and copied to clipboard."
   fi

--- a/bin/omarchy-transcode
+++ b/bin/omarchy-transcode
@@ -4,7 +4,7 @@
 # omarchy:name=
 # omarchy:summary=Transcode pictures and videos for sharing
 # omarchy:args=[--path path] [input] [format] [resolution]
-# omarchy:examples=omarchy transcode|omarchy transcode --path ~/Downloads|omarchy transcode ~/Videos/demo.mov mp4 1080p|omarchy transcode ~/Pictures/background.heic jpg medium
+# omarchy:examples=omarchy transcode|omarchy transcode --path ~/Downloads|omarchy transcode ~/Videos/demo.mov mp4 1080p|omarchy transcode ~/Pictures/background.heic jpg medium|omarchy transcode ~/Pictures/export jpg medium
 
 set -euo pipefail
 
@@ -140,9 +140,9 @@ transcode_file() {
   output=$(output_path "$input" "$format" "$resolution")
 
   if [[ $type == "video" ]]; then
-    transcode_video "$input" "$format" "$resolution" "$output"
+    transcode_video "$input" "$format" "$resolution" "$output" || return
   else
-    transcode_picture "$input" "$format" "$resolution" "$output"
+    transcode_picture "$input" "$format" "$resolution" "$output" || return
   fi
 
   printf '%s\n' "$output"
@@ -150,7 +150,7 @@ transcode_file() {
 
 transcode_directory() {
   local input="$1" format="$2" resolution="$3"
-  local target_type path type output count=0 skipped=0
+  local target_type path type output count=0 failed=0 skipped=0
 
   target_type=$(media_type_for_format "$format")
 
@@ -168,29 +168,32 @@ transcode_directory() {
       continue
     fi
 
-    output=$(output_path "$path" "$format" "$resolution")
     if [[ $type == "video" ]]; then
       omarchy-notification-send -g  "Transcoding video…" "$(basename -- "$path") to $format ($resolution)"
-      transcode_video "$path" "$format" "$resolution" "$output"
-    else
-      transcode_picture "$path" "$format" "$resolution" "$output"
     fi
 
-    (( count += 1 ))
-    printf 'Transcoded %s -> %s\n' "$path" "$output"
+    if output=$(transcode_file "$path" "$format" "$resolution"); then
+      (( count += 1 ))
+      printf 'Transcoded %s -> %s\n' "$path" "$output"
+    else
+      (( failed += 1 ))
+      printf 'Failed to transcode %s\n' "$path" >&2
+    fi
   done
   shopt -u nullglob
 
-  if (( count == 0 )); then
+  if (( count == 0 && failed == 0 )); then
     echo "No supported $target_type files found in: $input" >&2
     return 1
   fi
 
-  omarchy-notification-send "Transcoded $count item(s) to $resolution $format" "Saved in $(basename -- "$input")"
+  omarchy-notification-send "Transcoded $count item(s) to $resolution $format" "$failed failed in $(basename -- "$input")"
 
   if (( skipped > 0 )); then
     printf 'Skipped %d unsupported or mismatched item(s).\n' "$skipped"
   fi
+
+  (( count > 0 ))
 }
 
 copy_to_clipboard() {

--- a/default/nautilus-python/extensions/transcode.py
+++ b/default/nautilus-python/extensions/transcode.py
@@ -8,14 +8,49 @@ require_version("Nautilus", "4.1")
 from gi.repository import GObject, Gio, Nautilus
 
 
-SUPPORTED_MIME_PREFIXES = ("image/", "video/")
-SUPPORTED_EXTENSIONS = {
-    ".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic", ".avif",
-    ".mp4", ".mov", ".m4v", ".mkv", ".webm", ".avi",
-}
+PICTURE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic", ".avif")
+VIDEO_EXTENSIONS = (".mp4", ".mov", ".m4v", ".mkv", ".webm", ".avi")
 
 
 class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
+    def _media_type(self, file):
+        mime = file.get_mime_type() or ""
+        if mime.startswith("image/"):
+            return "picture"
+        if mime.startswith("video/"):
+            return "video"
+
+        location = file.get_location()
+        if not location:
+            return None
+        path = (location.get_path() or "").lower()
+        if path.endswith(PICTURE_EXTENSIONS):
+            return "picture"
+        if path.endswith(VIDEO_EXTENSIONS):
+            return "video"
+        return None
+
+    def _batch_command(self, binary, media_type, paths):
+        if media_type == "picture":
+            format_options = "jpg png"
+            resolution_options = "high medium low"
+        else:
+            format_options = "mp4 gif"
+            resolution_options = "4k 1080p 720p"
+
+        commands = [
+            f"format=$(omarchy-menu-select 'Select {media_type} format' {format_options}) || exit 1",
+            f"resolution=$(omarchy-menu-select 'Select {media_type} resolution' {resolution_options}) || exit 1",
+        ]
+
+        for path in paths:
+            commands.append(
+                f"echo {shlex.quote(f'Transcoding {path}')} && "
+                f"{shlex.join([binary, path])} \"$format\" \"$resolution\" || true"
+            )
+
+        return "; ".join(commands)
+
     def _launch_transcode(self, paths):
         wrapper = shutil.which("omarchy-launch-floating-terminal-with-presentation")
         binary = shutil.which("omarchy-transcode")
@@ -23,27 +58,18 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
             return
 
         if len(paths) == 1:
-            cmd = shlex.join([binary, paths[0]])
+            cmd = shlex.join([binary, paths[0][1]])
         else:
-            cmd = "; ".join(
-                f"echo {shlex.quote(f'Transcoding {path}')} && "
-                f"{shlex.join([binary, path])} || true"
-                for path in paths
-            )
+            picture_paths = [path for media_type, path in paths if media_type == "picture"]
+            video_paths = [path for media_type, path in paths if media_type == "video"]
+            commands = []
+            if picture_paths:
+                commands.append(self._batch_command(binary, "picture", picture_paths))
+            if video_paths:
+                commands.append(self._batch_command(binary, "video", video_paths))
+            cmd = "; ".join(commands)
 
         Gio.Subprocess.new([wrapper, cmd], Gio.SubprocessFlags.NONE)
-
-    def _is_supported(self, file):
-        mime = file.get_mime_type() or ""
-        if mime.startswith(SUPPORTED_MIME_PREFIXES):
-            return True
-
-        location = file.get_location()
-        if not location:
-            return False
-        path = location.get_path() or ""
-        lower = path.lower()
-        return any(lower.endswith(ext) for ext in SUPPORTED_EXTENSIONS)
 
     def _selected_paths(self, files):
         paths = []
@@ -52,7 +78,8 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
         for file in files:
             if file.is_directory():
                 continue
-            if not self._is_supported(file):
+            media_type = self._media_type(file)
+            if not media_type:
                 continue
             location = file.get_location()
             if not location:
@@ -60,7 +87,7 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
             path = location.get_path()
             if path and path not in seen:
                 seen.add(path)
-                paths.append(path)
+                paths.append((media_type, path))
         return paths
 
     def _make_item(self, paths):

--- a/default/nautilus-python/extensions/transcode.py
+++ b/default/nautilus-python/extensions/transcode.py
@@ -42,13 +42,11 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
             f"format=$(omarchy-menu-select 'Select {media_type} format' {format_options}) || exit 1",
             f"resolution=$(omarchy-menu-select 'Select {media_type} resolution' {resolution_options}) || exit 1",
         ]
-
-        for path in paths:
-            commands.append(
-                f"echo {shlex.quote(f'Transcoding {path}')} && "
-                f"{shlex.join([binary, path])} \"$format\" \"$resolution\" || true"
-            )
-
+        commands.extend(
+            f"echo {shlex.quote(f'Transcoding {path}')} && "
+            f"{shlex.join([binary, path])} \"$format\" \"$resolution\" || true"
+            for path in paths
+        )
         return "; ".join(commands)
 
     def _launch_transcode(self, paths):
@@ -74,11 +72,12 @@ class TranscodeAction(GObject.GObject, Nautilus.MenuProvider):
     def _selected_paths(self, files):
         paths = []
         seen = set()
+        directories = [file for file in files if file.is_directory()]
+        if directories and len(files) != 1:
+            return []
 
         for file in files:
-            if file.is_directory():
-                continue
-            media_type = self._media_type(file)
+            media_type = "directory" if file.is_directory() else self._media_type(file)
             if not media_type:
                 continue
             location = file.get_location()

--- a/migrations/1778424449.sh
+++ b/migrations/1778424449.sh
@@ -1,0 +1,3 @@
+echo "Refresh Nautilus Transcode context menu"
+
+source "$OMARCHY_PATH/install/config/nautilus-python.sh"

--- a/migrations/1778424449.sh
+++ b/migrations/1778424449.sh
@@ -1,3 +1,0 @@
-echo "Refresh Nautilus Transcode context menu"
-
-source "$OMARCHY_PATH/install/config/nautilus-python.sh"

--- a/migrations/1786437940.sh
+++ b/migrations/1786437940.sh
@@ -1,0 +1,6 @@
+echo "Refresh Nautilus Transcode context menu"
+
+extensions_dir="$HOME/.local/share/nautilus-python/extensions"
+
+mkdir -p "$extensions_dir"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/transcode.py" "$extensions_dir/"

--- a/test/shell.d/transcode-test.sh
+++ b/test/shell.d/transcode-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+media_dir="$test_tmp/media folder"
+calls="$test_tmp/calls"
+mkdir -p "$stub_bin" "$media_dir/nested"
+touch "$media_dir/photo one.jpg" "$media_dir/movie one.mov" "$media_dir/notes.txt" "$media_dir/nested/hidden.jpg"
+
+cat >"$stub_bin/file" <<'SH'
+#!/bin/bash
+case "$3" in
+  *.jpg) echo image/jpeg ;;
+  *.mov) echo video/quicktime ;;
+  *) echo text/plain ;;
+esac
+SH
+
+cat >"$stub_bin/magick" <<'SH'
+#!/bin/bash
+printf 'magick:%s\n' "$*" >>"$TEST_CALLS"
+[[ $1 == *broken* ]] && exit 1
+touch "${!#}"
+SH
+
+cat >"$stub_bin/ffmpeg" <<'SH'
+#!/bin/bash
+printf 'ffmpeg:%s\n' "$*" >>"$TEST_CALLS"
+touch "${!#}"
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/wl-copy" <<'SH'
+#!/bin/bash
+echo clipboard >>"$TEST_CALLS"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_transcode() {
+  PATH="$stub_bin:$PATH" TEST_CALLS="$calls" "$ROOT/bin/omarchy-transcode" "$@"
+}
+
+run_transcode "$media_dir" jpg medium >"$test_tmp/pictures.out"
+[[ -f $media_dir/photo\ one-medium.jpg ]] || fail "folder transcoding writes the expected picture output"
+[[ ! -f $media_dir/nested/hidden-medium.jpg ]] || fail "folder transcoding only processes direct children"
+[[ $(grep -c '^magick:' "$calls") == 1 ]] || fail "picture folder transcoding filters non-picture files"
+grep -q 'Skipped 2 unsupported or mismatched item(s).' "$test_tmp/pictures.out" ||
+  fail "folder transcoding reports skipped files"
+grep -q '^clipboard$' "$calls" && fail "folder transcoding does not copy batch output to the clipboard"
+pass "folder transcoding filters pictures and stays non-recursive"
+
+: >"$calls"
+run_transcode "$media_dir" mp4 1080p >"$test_tmp/videos.out"
+[[ -f $media_dir/movie\ one-1080p.mp4 ]] || fail "folder transcoding writes the expected video output"
+grep -q 'ffmpeg:.*-c:a aac -b:a 192k -movflags +faststart' "$calls" ||
+  fail "folder transcoding preserves Quattro MP4 encoding options"
+grep -q '^clipboard$' "$calls" && fail "video folder transcoding does not copy batch output to the clipboard"
+pass "folder transcoding preserves Quattro video encoding"
+
+empty_dir="$test_tmp/empty"
+mkdir "$empty_dir"
+if run_transcode "$empty_dir" jpg low >"$test_tmp/empty.out" 2>"$test_tmp/empty.err"; then
+  fail "folder transcoding fails when no matching files exist"
+fi
+grep -q 'No supported picture files found' "$test_tmp/empty.err" ||
+  fail "folder transcoding explains an empty batch"
+pass "folder transcoding rejects an empty batch"
+
+failure_dir="$test_tmp/failures"
+mkdir "$failure_dir"
+touch "$failure_dir/broken.jpg" "$failure_dir/working.jpg"
+: >"$calls"
+run_transcode "$failure_dir" jpg low >"$test_tmp/failures.out" 2>"$test_tmp/failures.err"
+[[ -f $failure_dir/working-low.jpg ]] || fail "folder transcoding continues after a failed file"
+[[ ! -f $failure_dir/broken-low.jpg ]] || fail "folder transcoding does not report failed output as complete"
+grep -q 'Failed to transcode.*broken.jpg' "$test_tmp/failures.err" ||
+  fail "folder transcoding reports failed files"
+pass "folder transcoding continues after individual failures"
+
+migration_home="$test_tmp/migration-home"
+HOME="$migration_home" OMARCHY_PATH="$ROOT" bash -euo pipefail "$ROOT/migrations/1786437940.sh" >/dev/null
+cmp "$ROOT/default/nautilus-python/extensions/transcode.py" \
+  "$migration_home/.local/share/nautilus-python/extensions/transcode.py" >/dev/null ||
+  fail "folder transcoding migration refreshes the Quattro Nautilus extension"
+pass "folder transcoding migration uses the Quattro package layout"
+
+ROOT="$ROOT" python - <<'PY'
+import importlib.util
+import os
+import sys
+import types
+
+
+class GObjectBase:
+    pass
+
+
+class MenuProvider:
+    pass
+
+
+gi = types.ModuleType("gi")
+gi.require_version = lambda *_: None
+repository = types.ModuleType("gi.repository")
+repository.GObject = types.SimpleNamespace(GObject=GObjectBase)
+repository.Gio = types.SimpleNamespace(SubprocessFlags=types.SimpleNamespace(NONE=0))
+repository.Nautilus = types.SimpleNamespace(MenuProvider=MenuProvider)
+gi.repository = repository
+sys.modules["gi"] = gi
+sys.modules["gi.repository"] = repository
+
+path = os.path.join(os.environ["ROOT"], "default/nautilus-python/extensions/transcode.py")
+spec = importlib.util.spec_from_file_location("transcode", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+action = module.TranscodeAction()
+
+
+class Location:
+    def __init__(self, path):
+        self.path = path
+
+    def get_path(self):
+        return self.path
+
+
+class File:
+    def __init__(self, path, directory=False, mime=""):
+        self.path = path
+        self.directory = directory
+        self.mime = mime
+
+    def is_directory(self):
+        return self.directory
+
+    def get_mime_type(self):
+        return self.mime
+
+    def get_location(self):
+        return Location(self.path)
+
+
+folder = File("/tmp/media folder", directory=True)
+picture = File("/tmp/photo.jpg", mime="image/jpeg")
+second_picture = File("/tmp/second photo.jpg", mime="image/jpeg")
+assert action._selected_paths([folder]) == [("directory", "/tmp/media folder")]
+assert action._selected_paths([folder, picture]) == []
+assert action._selected_paths([picture]) == [("picture", "/tmp/photo.jpg")]
+
+command = action._batch_command("/usr/bin/omarchy-transcode", "picture", [
+    "/tmp/photo.jpg", "/tmp/second photo.jpg"
+])
+assert command.count("Select picture format") == 1
+assert command.count("Select picture resolution") == 1
+assert command.count("/usr/bin/omarchy-transcode") == 2
+PY
+pass "Nautilus supports folders and prompts once for multi-file batches"


### PR DESCRIPTION
### Summary
This pull request aims to make transcoding multiple files faster and more convenient:

1) Adding directory support to omarchy-transcode. For example, `omarchy-transcode folder/` transcodes all images or videos in folder/.

2) Changing the Nautilus integration to only ask about the output format once when multiple files are selected.

## Tests
- `./test/shell.d/transcode-test.sh`
- `./test/cli`
- `bash -n bin/omarchy-transcode migrations/1786437940.sh test/shell.d/transcode-test.sh`
- `python -m py_compile default/nautilus-python/extensions/transcode.py`
- `git diff --check upstream/quattro...HEAD`