### PR TITLE
Dismiss the low battery warning once charging

### DIFF
--- a/bin/omarchy-battery-low
+++ b/bin/omarchy-battery-low
@@ -1,17 +1,24 @@
 #!/bin/bash
 
 # omarchy:summary=Send the low battery warning notification and run battery-low hooks.
-# omarchy:args=<percentage>
+# omarchy:args=<percentage>|--dismiss
 # omarchy:hidden=true
 
 set -euo pipefail
 
+summary="Time to recharge!"
+
 if (($# != 1)); then
-  echo "Usage: omarchy-battery-low <percentage>" >&2
+  echo "Usage: omarchy-battery-low <percentage>|--dismiss" >&2
   exit 1
+fi
+
+if [[ $1 == "--dismiss" ]]; then
+  omarchy-notification-dismiss "$summary" >/dev/null 2>&1 || true
+  exit 0
 fi
 
 level=$1
 
-omarchy-notification-send -g 󱐋 -u critical "Time to recharge!" "Battery is down to ${level}%" -i battery-caution -t 30000
+omarchy-notification-send -g 󱐋 -u critical "$summary" "Battery is down to ${level}%" -i battery-caution -t 30000
 omarchy-hook battery-low "$level"

--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -7,15 +7,16 @@ function isDischarging(device, onBattery, dischargingState) {
   return !!(device && device.isPresent && onBattery && device.state === dischargingState)
 }
 
-function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
+function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified, alreadyDismissed) {
   var level = batteryPercentage(device)
-  if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
+  var low = level >= 0 && isDischarging(device, onBattery, dischargingState) && level <= threshold
 
-  var low = isDischarging(device, onBattery, dischargingState) && level <= threshold
   return {
     level: level,
     notify: low && !alreadyNotified,
-    notifiedLowBattery: low
+    dismiss: !low && !alreadyDismissed,
+    notifiedLowBattery: low,
+    dismissedLowBattery: !low
   }
 }
 

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -13,6 +13,8 @@ Item {
   readonly property int batteryThreshold: 10
   property string pendingPowerSource: ""
 
+  property bool dismissedLowBattery: false
+
   PersistentProperties {
     id: persisted
     reloadableId: "omarchy-battery"
@@ -28,9 +30,11 @@ Item {
   }
 
   function checkBattery() {
-    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
+    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery, dismissedLowBattery)
     persisted.notifiedLowBattery = state.notifiedLowBattery
+    dismissedLowBattery = state.dismissedLowBattery
     if (state.notify) sendLowBatteryWarning(state.level)
+    else if (state.dismiss) dismissLowBatteryWarning()
   }
 
   function sendLowBatteryWarning(level) {
@@ -40,6 +44,12 @@ Item {
       String(level)
     ]
     warningProcess.running = true
+  }
+
+  function dismissLowBatteryWarning() {
+    if (dismissProcess.running) return
+    dismissProcess.command = ["omarchy-battery-low", "--dismiss"]
+    dismissProcess.running = true
   }
 
   function applyPowerProfile() {
@@ -54,6 +64,8 @@ Item {
   }
 
   Process { id: warningProcess }
+
+  Process { id: dismissProcess }
 
   Process {
     id: powerProfileProcess

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -14,18 +14,56 @@ assert(battery.isDischarging({ isPresent: true, state: discharging }, true, disc
 assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, discharging), 'battery requires on-battery state')
 
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
-  { level: 8, notify: true, notifiedLowBattery: true },
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false, true),
+  { level: 8, notify: true, dismiss: false, notifiedLowBattery: true, dismissedLowBattery: false },
   'battery warns once under threshold'
 )
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true),
-  { level: 8, notify: false, notifiedLowBattery: true },
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true, false),
+  { level: 8, notify: false, dismiss: false, notifiedLowBattery: true, dismissedLowBattery: false },
   'battery keeps low-battery notified state'
 )
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, true),
-  { level: 40, notify: false, notifiedLowBattery: false },
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, true, false),
+  { level: 40, notify: false, dismiss: true, notifiedLowBattery: false, dismissedLowBattery: true },
   'battery clears notified state after recovery'
 )
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, false, discharging, 10, true, false),
+  { level: 8, notify: false, dismiss: true, notifiedLowBattery: false, dismissedLowBattery: true },
+  'battery dismisses the warning once charging'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, false, false),
+  { level: 40, notify: false, dismiss: true, notifiedLowBattery: false, dismissedLowBattery: true },
+  'battery clears a warning restored from a previous shell process'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, false, true),
+  { level: 40, notify: false, dismiss: false, notifiedLowBattery: false, dismissedLowBattery: true },
+  'battery dismisses only once per recovery'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: false, percentage: 0.5 }, false, discharging, 10, true, false),
+  { level: -1, notify: false, dismiss: true, notifiedLowBattery: false, dismissedLowBattery: true },
+  'battery dismisses the warning when the battery disappears'
+)
 JS
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+cat >"$tmp_dir/bin/omarchy-notification-dismiss" <<STUB
+#!/bin/bash
+
+printf '%s\n' "\$1" >"$tmp_dir/dismissed"
+STUB
+chmod +x "$tmp_dir/bin/omarchy-notification-dismiss"
+
+PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-low" --dismiss
+
+grep -Fx "Time to recharge!" "$tmp_dir/dismissed" >/dev/null ||
+  fail "battery low dismisses the recharge notification"
+
+pass "battery low dismisses the recharge notification"


### PR DESCRIPTION
The warning is sent with critical urgency, so it stays on screen until it is answered, but nothing ever took it back down: plugging in only cleared the service's internal notified flag and left the toast up for good.

The battery service now runs `omarchy-battery-low --dismiss` when the battery stops being low.