### PR TITLE
Fix unclickable tray submenus by drilling down inside the popup

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -51,8 +51,6 @@ BarWidget {
     ? submenuStack[submenuDepth - 1].opener.children
     : trayMenuOpener.children
 
-  onTrayMenuOpenChanged: if (!trayMenuOpen) resetTrayMenu()
-
   Component {
     id: submenuOpenerComponent
     QsMenuOpener {}
@@ -499,6 +497,13 @@ BarWidget {
     owner: root
     bar: root.bar
     open: root.trayMenuOpen
+    // The card fades out over 140ms (visible stays true for that whole time --
+    // see PopupCard's own visible: open || card.opacity > 0), so resetting on
+    // "open" would swap a live submenu for the root menu mid-fade: a visible
+    // flash, and a resize/reposition if the two have different geometry. Wait
+    // for the fade to actually finish. Switching to a different tray item
+    // still resets immediately, from openTrayMenu() itself.
+    onVisibleChanged: if (!visible) root.resetTrayMenu()
     padding: Style.space(8)
     borderColor: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45)
     contentWidth: trayMenuPopup.fittedContentWidth(Style.space(232))

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -33,6 +33,52 @@ BarWidget {
   property real revealProgress: expanded ? 1 : 0
   readonly property real revealExtent: drawerExtent * revealProgress
 
+  // Submenu drill-down state. QsMenuEntry.display() renders a *platform* menu,
+  // which Quickshell refuses unless the shell root sets `//@ pragma
+  // UseQApplication` - omarchy's shell.qml does not, so every submenu click was
+  // a silent no-op ("Cannot display PlatformMenuEntry as quickshell was not
+  // started in QApplication mode" in the shell log) and apps whose whole UI is
+  // submenus, e.g. radiotray-ng's station list, were unusable. QsMenuEntry
+  // inherits QsMenuHandle, so a child entry can feed a nested QsMenuOpener and
+  // render inside this popup instead of going through the platform. Each level
+  // keeps its own live opener: a child entry is owned by its parent opener's
+  // model, so collapsing the stack to a single opener would destroy the very
+  // entry being displayed (submenu turns up empty).
+  property var submenuStack: []
+  readonly property int submenuDepth: submenuStack.length
+  readonly property string currentTitle: submenuDepth > 0 ? submenuStack[submenuDepth - 1].title : ""
+  readonly property var currentChildren: submenuDepth > 0
+    ? submenuStack[submenuDepth - 1].opener.children
+    : trayMenuOpener.children
+
+  onTrayMenuOpenChanged: if (!trayMenuOpen) resetTrayMenu()
+
+  Component {
+    id: submenuOpenerComponent
+    QsMenuOpener {}
+  }
+
+  function resetTrayMenu() {
+    for (var i = 0; i < submenuStack.length; i++) submenuStack[i].opener.destroy()
+    submenuStack = []
+  }
+
+  function enterSubmenu(entry, title) {
+    var opener = submenuOpenerComponent.createObject(root, { menu: entry })
+    if (!opener) return
+    var stack = submenuStack.slice()
+    stack.push({ opener: opener, title: title })
+    submenuStack = stack
+  }
+
+  function leaveSubmenu() {
+    if (submenuStack.length === 0) return
+    var stack = submenuStack.slice()
+    var top = stack.pop()
+    submenuStack = stack
+    top.opener.destroy()
+  }
+
   function close() {
     managePopupOpen = false
     trayMenuOpen = false
@@ -47,6 +93,7 @@ BarWidget {
 
     activeTrayItem = item
     activeTrayAnchor = anchorItem
+    resetTrayMenu()
     trayMenuOpen = true
   }
 
@@ -464,8 +511,77 @@ BarWidget {
         width: trayMenuFlick.width
         spacing: 0
 
+        // Header for a drilled-into submenu: names where we are and walks back
+        // out. Only present below the root level, so the root menu is unchanged.
+        Item {
+          id: menuBackRow
+          visible: root.submenuDepth > 0
+          width: trayMenuColumn.width
+          implicitHeight: Style.space(30)
+
+          Rectangle {
+            anchors.fill: parent
+            radius: Math.max(2, Style.cornerRadius)
+            color: backMouse.containsMouse ? Style.hoverFillFor(root.foreground, root.foreground) : "transparent"
+          }
+
+          Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            width: Style.space(22)
+            horizontalAlignment: Text.AlignHCenter
+            text: "\u2039"
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.bodySmall
+          }
+
+          Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: Style.space(28)
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(10)
+            text: root.currentTitle
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            elide: Text.ElideRight
+          }
+
+          MouseArea {
+            id: backMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+              // Reset before the model swap so the parent level shows from
+              // the top (same ordering as the row delegate below).
+              trayMenuFlick.contentY = 0
+              root.leaveSubmenu()
+            }
+          }
+        }
+
+        Item {
+          visible: root.submenuDepth > 0
+          width: trayMenuColumn.width
+          implicitHeight: Style.space(11)
+
+          Rectangle {
+            anchors.left: parent.left
+            anchors.leftMargin: Style.space(10)
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(10)
+            anchors.verticalCenter: parent.verticalCenter
+            height: 1
+            color: Color.popups.border
+            opacity: 0.45
+          }
+        }
+
         Repeater {
-          model: trayMenuOpener.children
+          model: root.currentChildren
 
           delegate: Item {
             id: menuRow
@@ -474,8 +590,11 @@ BarWidget {
 
             readonly property string rowText: String(modelData.text || "")
             readonly property string activeTitle: root.activeTrayItem ? String(root.activeTrayItem.title || root.activeTrayItem.id || "") : ""
-            readonly property bool rootTitleEntry: index === 0 && modelData.hasChildren && rowText.toLowerCase() === activeTitle.toLowerCase()
-            readonly property bool leadingSeparator: modelData.isSeparator && index <= 1
+            // Both only ever describe the root menu; inside a submenu the first
+            // rows are real entries and must not be swallowed.
+            readonly property bool atRoot: root.submenuDepth === 0
+            readonly property bool rootTitleEntry: atRoot && index === 0 && modelData.hasChildren && rowText.toLowerCase() === activeTitle.toLowerCase()
+            readonly property bool leadingSeparator: atRoot && modelData.isSeparator && index <= 1
             readonly property bool hiddenRow: rootTitleEntry || leadingSeparator
 
             visible: !hiddenRow
@@ -564,8 +683,10 @@ BarWidget {
               cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
               onClicked: {
                 if (menuRow.modelData.hasChildren) {
-                  var point = menuRow.QsWindow.contentItem.mapFromItem(menuRow, menuRow.width, menuRow.height / 2)
-                  menuRow.modelData.display(menuRow.QsWindow.window, point.x, point.y)
+                  // Reset scroll BEFORE swapping the model: the swap destroys
+                  // this delegate synchronously and ids stop resolving after.
+                  trayMenuFlick.contentY = 0
+                  root.enterSubmenu(menuRow.modelData, menuRow.rowText)
                 } else {
                   menuRow.modelData.triggered()
                   root.close()

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -51,12 +51,32 @@ BarWidget {
     ? submenuStack[submenuDepth - 1].opener.children
     : trayMenuOpener.children
 
+  // Changing level rebuilds the row delegates synchronously, so the next
+  // row lands under a cursor that hasn't moved. Submenu clicks used to be
+  // silent no-ops, which trained users to click them twice, and that second
+  // click would now fire whatever entry took the spot. Ignore row clicks for
+  // a beat after each level change; a deliberate follow-up click is slower.
+  property bool menuLevelSettling: false
+
   Component {
     id: submenuOpenerComponent
     QsMenuOpener {}
   }
 
+  Timer {
+    id: menuLevelSettleTimer
+    interval: 250
+    onTriggered: root.menuLevelSettling = false
+  }
+
+  function settleMenuLevel() {
+    menuLevelSettling = true
+    menuLevelSettleTimer.restart()
+  }
+
   function resetTrayMenu() {
+    menuLevelSettling = false
+    menuLevelSettleTimer.stop()
     // Clear the reactive stack before tearing anything down, so no binding can
     // read a partially-destroyed opener while this runs. Then destroy deepest
     // first: an inner opener's menu entry is owned by its parent's children
@@ -73,6 +93,7 @@ BarWidget {
     var stack = submenuStack.slice()
     stack.push({ opener: opener, title: title })
     submenuStack = stack
+    settleMenuLevel()
   }
 
   function leaveSubmenu() {
@@ -81,6 +102,7 @@ BarWidget {
     var top = stack.pop()
     submenuStack = stack
     top.opener.destroy()
+    settleMenuLevel()
   }
 
   function close() {
@@ -570,6 +592,7 @@ BarWidget {
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
             onClicked: {
+              if (root.menuLevelSettling) return
               // Reset before the model swap so the parent level shows from
               // the top (same ordering as the row delegate below).
               trayMenuFlick.contentY = 0
@@ -697,6 +720,7 @@ BarWidget {
               enabled: !menuRow.modelData.isSeparator && menuRow.modelData.enabled
               cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
               onClicked: {
+                if (root.menuLevelSettling) return
                 if (menuRow.modelData.hasChildren) {
                   // Reset scroll BEFORE swapping the model: the swap destroys
                   // this delegate synchronously and ids stop resolving after.

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -529,31 +529,30 @@ BarWidget {
     padding: Style.space(8)
     borderColor: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45)
     contentWidth: trayMenuPopup.fittedContentWidth(Style.space(232))
-    contentHeight: trayMenuPopup.fittedContentHeight(trayMenuColumn.implicitHeight, Style.space(420))
+    contentHeight: trayMenuPopup.fittedContentHeight(menuHeaderHeight + trayMenuColumn.implicitHeight, Style.space(420))
 
-    Flickable {
-      id: trayMenuFlick
+    // Column skips invisible children but keeps reporting their height, so
+    // read the header's extent through its own visibility.
+    readonly property int menuHeaderHeight: menuHeader.visible ? menuHeader.implicitHeight : 0
+
+    Column {
+      id: trayMenuLayout
       anchors.fill: parent
-      contentWidth: width
-      contentHeight: trayMenuColumn.implicitHeight
-      clip: true
-      boundsBehavior: Flickable.StopAtBounds
-      flickableDirection: Flickable.VerticalFlick
-      interactive: contentHeight > height
+      spacing: 0
 
-      ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
-
+      // Header for a drilled-into submenu: names where we are and walks back
+      // out. Pinned above the Flickable rather than scrolling with the rows,
+      // so the way back stays reachable in a submenu taller than the card.
+      // Only present below the root level, so the root menu is unchanged.
       Column {
-        id: trayMenuColumn
-        width: trayMenuFlick.width
+        id: menuHeader
+        visible: root.submenuDepth > 0
+        width: trayMenuLayout.width
         spacing: 0
 
-        // Header for a drilled-into submenu: names where we are and walks back
-        // out. Only present below the root level, so the root menu is unchanged.
         Item {
           id: menuBackRow
-          visible: root.submenuDepth > 0
-          width: trayMenuColumn.width
+          width: menuHeader.width
           implicitHeight: Style.space(30)
 
           Rectangle {
@@ -602,8 +601,7 @@ BarWidget {
         }
 
         Item {
-          visible: root.submenuDepth > 0
-          width: trayMenuColumn.width
+          width: menuHeader.width
           implicitHeight: Style.space(11)
 
           Rectangle {
@@ -617,118 +615,138 @@ BarWidget {
             opacity: 0.45
           }
         }
+      }
 
-        Repeater {
-          model: root.currentChildren
+      Flickable {
+        id: trayMenuFlick
+        width: trayMenuLayout.width
+        height: trayMenuLayout.height - trayMenuPopup.menuHeaderHeight
+        contentWidth: width
+        contentHeight: trayMenuColumn.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        flickableDirection: Flickable.VerticalFlick
+        interactive: contentHeight > height
 
-          delegate: Item {
-            id: menuRow
-            required property var modelData
-            required property int index
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
 
-            readonly property string rowText: String(modelData.text || "")
-            readonly property string activeTitle: root.activeTrayItem ? String(root.activeTrayItem.title || root.activeTrayItem.id || "") : ""
-            // Both only ever describe the root menu; inside a submenu the first
-            // rows are real entries and must not be swallowed.
-            readonly property bool atRoot: root.submenuDepth === 0
-            readonly property bool rootTitleEntry: atRoot && index === 0 && modelData.hasChildren && rowText.toLowerCase() === activeTitle.toLowerCase()
-            readonly property bool leadingSeparator: atRoot && modelData.isSeparator && index <= 1
-            readonly property bool hiddenRow: rootTitleEntry || leadingSeparator
+        Column {
+          id: trayMenuColumn
+          width: trayMenuFlick.width
+          spacing: 0
 
-            visible: !hiddenRow
-            width: trayMenuColumn.width
-            implicitHeight: hiddenRow ? 0 : (modelData.isSeparator ? Style.space(11) : Style.space(30))
-            opacity: modelData.enabled ? 1.0 : 0.45
+          Repeater {
+            model: root.currentChildren
 
-            Rectangle {
-              visible: menuRow.modelData.isSeparator
-              anchors.left: parent.left
-              anchors.leftMargin: Style.space(10)
-              anchors.right: parent.right
-              anchors.rightMargin: Style.space(10)
-              anchors.verticalCenter: parent.verticalCenter
-              height: 1
-              color: Color.popups.border
-              opacity: 0.45
-            }
+            delegate: Item {
+              id: menuRow
+              required property var modelData
+              required property int index
 
-            Rectangle {
-              visible: !menuRow.modelData.isSeparator
-              anchors.fill: parent
-              radius: Math.max(2, Style.cornerRadius)
-              color: rowMouse.containsMouse && menuRow.modelData.enabled ? Style.hoverFillFor(root.foreground, root.foreground) : "transparent"
-            }
+              readonly property string rowText: String(modelData.text || "")
+              readonly property string activeTitle: root.activeTrayItem ? String(root.activeTrayItem.title || root.activeTrayItem.id || "") : ""
+              // Both only ever describe the root menu; inside a submenu the first
+              // rows are real entries and must not be swallowed.
+              readonly property bool atRoot: root.submenuDepth === 0
+              readonly property bool rootTitleEntry: atRoot && index === 0 && modelData.hasChildren && rowText.toLowerCase() === activeTitle.toLowerCase()
+              readonly property bool leadingSeparator: atRoot && modelData.isSeparator && index <= 1
+              readonly property bool hiddenRow: rootTitleEntry || leadingSeparator
 
-            Text {
-              visible: !menuRow.modelData.isSeparator && menuRow.modelData.buttonType !== QsMenuButtonType.None
-              anchors.verticalCenter: parent.verticalCenter
-              anchors.left: parent.left
-              width: Style.space(22)
-              horizontalAlignment: Text.AlignHCenter
-              text: menuRow.modelData.checkState === Qt.Checked ? "\uf00c" : ""
-              color: root.foreground
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
-            }
+              visible: !hiddenRow
+              width: trayMenuColumn.width
+              implicitHeight: hiddenRow ? 0 : (modelData.isSeparator ? Style.space(11) : Style.space(30))
+              opacity: modelData.enabled ? 1.0 : 0.45
 
-            Image {
-              id: menuIcon
-              visible: !menuRow.modelData.isSeparator && String(menuRow.modelData.icon || "") !== ""
-              anchors.verticalCenter: parent.verticalCenter
-              anchors.left: parent.left
-              anchors.leftMargin: Style.space(24)
-              width: Style.space(16)
-              height: Style.space(16)
-              fillMode: Image.PreserveAspectFit
-              // Decode at physical pixels: IconImage uses the logical size,
-              // which leaves PNG icons upscaled and blurry on HiDPI displays.
-              sourceSize.width: width * Screen.devicePixelRatio
-              sourceSize.height: height * Screen.devicePixelRatio
-              source: menuRow.modelData.icon
-            }
+              Rectangle {
+                visible: menuRow.modelData.isSeparator
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(10)
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(10)
+                anchors.verticalCenter: parent.verticalCenter
+                height: 1
+                color: Color.popups.border
+                opacity: 0.45
+              }
 
-            Text {
-              visible: !menuRow.modelData.isSeparator
-              anchors.verticalCenter: parent.verticalCenter
-              anchors.left: parent.left
-              anchors.leftMargin: menuIcon.visible ? Style.space(46) : Style.space(28)
-              anchors.right: submenuGlyph.left
-              anchors.rightMargin: Style.space(8)
-              text: menuRow.rowText
-              color: root.foreground
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
-              elide: Text.ElideRight
-            }
+              Rectangle {
+                visible: !menuRow.modelData.isSeparator
+                anchors.fill: parent
+                radius: Math.max(2, Style.cornerRadius)
+                color: rowMouse.containsMouse && menuRow.modelData.enabled ? Style.hoverFillFor(root.foreground, root.foreground) : "transparent"
+              }
 
-            Text {
-              id: submenuGlyph
-              visible: !menuRow.modelData.isSeparator && menuRow.modelData.hasChildren
-              anchors.verticalCenter: parent.verticalCenter
-              anchors.right: parent.right
-              anchors.rightMargin: Style.space(10)
-              text: "\u203a"
-              color: root.foreground
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
-            }
+              Text {
+                visible: !menuRow.modelData.isSeparator && menuRow.modelData.buttonType !== QsMenuButtonType.None
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                width: Style.space(22)
+                horizontalAlignment: Text.AlignHCenter
+                text: menuRow.modelData.checkState === Qt.Checked ? "\uf00c" : ""
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.bodySmall
+              }
 
-            MouseArea {
-              id: rowMouse
-              anchors.fill: parent
-              hoverEnabled: true
-              enabled: !menuRow.modelData.isSeparator && menuRow.modelData.enabled
-              cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-              onClicked: {
-                if (root.menuLevelSettling) return
-                if (menuRow.modelData.hasChildren) {
-                  // Reset scroll BEFORE swapping the model: the swap destroys
-                  // this delegate synchronously and ids stop resolving after.
-                  trayMenuFlick.contentY = 0
-                  root.enterSubmenu(menuRow.modelData, menuRow.rowText)
-                } else {
-                  menuRow.modelData.triggered()
-                  root.close()
+              Image {
+                id: menuIcon
+                visible: !menuRow.modelData.isSeparator && String(menuRow.modelData.icon || "") !== ""
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(24)
+                width: Style.space(16)
+                height: Style.space(16)
+                fillMode: Image.PreserveAspectFit
+                // Decode at physical pixels: IconImage uses the logical size,
+                // which leaves PNG icons upscaled and blurry on HiDPI displays.
+                sourceSize.width: width * Screen.devicePixelRatio
+                sourceSize.height: height * Screen.devicePixelRatio
+                source: menuRow.modelData.icon
+              }
+
+              Text {
+                visible: !menuRow.modelData.isSeparator
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.leftMargin: menuIcon.visible ? Style.space(46) : Style.space(28)
+                anchors.right: submenuGlyph.left
+                anchors.rightMargin: Style.space(8)
+                text: menuRow.rowText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.bodySmall
+                elide: Text.ElideRight
+              }
+
+              Text {
+                id: submenuGlyph
+                visible: !menuRow.modelData.isSeparator && menuRow.modelData.hasChildren
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(10)
+                text: "\u203a"
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.bodySmall
+              }
+
+              MouseArea {
+                id: rowMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                enabled: !menuRow.modelData.isSeparator && menuRow.modelData.enabled
+                cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: {
+                  if (root.menuLevelSettling) return
+                  if (menuRow.modelData.hasChildren) {
+                    // Reset scroll BEFORE swapping the model: the swap destroys
+                    // this delegate synchronously and ids stop resolving after.
+                    trayMenuFlick.contentY = 0
+                    root.enterSubmenu(menuRow.modelData, menuRow.rowText)
+                  } else {
+                    menuRow.modelData.triggered()
+                    root.close()
+                  }
                 }
               }
             }

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -77,6 +77,10 @@ BarWidget {
   function resetTrayMenu() {
     menuLevelSettling = false
     menuLevelSettleTimer.stop()
+    // Flickable keeps its offset across a model swap whenever the new content
+    // is still tall enough to hold it, so a menu dismissed while scrolled
+    // would otherwise reopen part-way down with its first entries off screen.
+    trayMenuFlick.contentY = 0
     // Clear the reactive stack before tearing anything down, so no binding can
     // read a partially-destroyed opener while this runs. Then destroy deepest
     // first: an inner opener's menu entry is owned by its parent's children

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -59,8 +59,14 @@ BarWidget {
   }
 
   function resetTrayMenu() {
-    for (var i = 0; i < submenuStack.length; i++) submenuStack[i].opener.destroy()
+    // Clear the reactive stack before tearing anything down, so no binding can
+    // read a partially-destroyed opener while this runs. Then destroy deepest
+    // first: an inner opener's menu entry is owned by its parent's children
+    // model, so destroying a parent first would invalidate an entry a still-
+    // live child opener references.
+    var openers = submenuStack
     submenuStack = []
+    for (var i = openers.length - 1; i >= 0; i--) openers[i].opener.destroy()
   }
 
   function enterSubmenu(entry, title) {
@@ -91,9 +97,13 @@ BarWidget {
       return
     }
 
+    // Reset before switching items: trayMenuOpener.menu binds to
+    // activeTrayItem.menu, so assigning a new item invalidates the old root's
+    // children immediately, before any nested opener referencing them would
+    // otherwise get torn down.
+    resetTrayMenu()
     activeTrayItem = item
     activeTrayAnchor = anchorItem
-    resetTrayMenu()
     trayMenuOpen = true
   }
 


### PR DESCRIPTION
## Problem

Clicking a tray menu entry that has children (a submenu) is a silent no-op. The shell log shows:

```
Cannot display PlatformMenuEntry as quickshell was not started in QApplication mode
```

Apps whose whole menu is submenus -- radiotray-ng's station list, for example -- are unusable through the tray.

## Root cause

The `hasChildren` branch in `Tray.qml` calls `QsMenuEntry.display()`, which renders a *platform* menu. Quickshell refuses that call unless the shell root sets `//@ pragma UseQApplication`, and `shell.qml` does not set it. The current code path can never work as shipped, on any machine.

## Why not just add the pragma

Adding `//@ pragma UseQApplication` would switch the entire shell from `QGuiApplication` to `QApplication`, pulling in QtWidgets and changing application-class behavior for the sake of one popup -- and the reward would be an unstyled platform menu appearing next to omarchy's own styled popup. The right-sized fix keeps the submenu inside the popup the shell already draws.

## What the fix does

+121 net lines in `Tray.qml`, no other files touched, no new imports. A child `QsMenuEntry` inherits `QsMenuHandle`, so it can feed a nested `QsMenuOpener` and render through the same row delegate instead of going through the platform. Each level keeps its own live opener on a stack -- a child entry is owned by its parent opener's model, so collapsing to a single reassigned opener would destroy the very entry being displayed. A back header row walks back out one level. The root menu renders exactly as before at depth 0, and items without a DBusMenu still use the existing platform fallback.

## Test plan

- [x] In daily production use on a real Omarchy desktop since 2026-08-08; radiotray-ng's station list is fully navigable
- [x] `test/shell.d/tray-test.sh` passes (pure model-layer test, unaffected -- `TrayModel.js` is untouched)
- [x] `test/shell.d/tray-menu-test.sh` guards the leaf-activation DBusMenu path, which this change leaves byte-identical; no new test added since the actual risk here lives entirely in Quickshell object lifecycle (`QsMenuOpener` creation/destruction, child-entry ownership by the parent's model), which isn't expressible as a Node-level assertion
