### PR TITLE
Add QR code capture

### DIFF
--- a/bin/omarchy-capture-qr
+++ b/bin/omarchy-capture-qr
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# omarchy:summary=Decode a QR code from a screenshot region
+# omarchy:group=capture
+# omarchy:examples=omarchy capture qr
+
+# Keep hyprpicker alive until after grim captures so the screenshot sees the
+# frozen overlay rather than live content shifting during teardown.
+cleanup_freeze() {
+  [[ -n $PID ]] && kill $PID 2>/dev/null
+}
+trap cleanup_freeze EXIT
+
+hyprpicker -r -z >/dev/null 2>&1 &
+PID=$!
+sleep .1
+SELECTION=$(slurp 2>/dev/null)
+
+[[ -z $SELECTION ]] && exit 0
+
+# Decode QR codes only. Leaving the other symbologies enabled lets dense screen
+# content false-positive as an EAN or Code 39 barcode and take over the clipboard.
+RESULT=$(grim -g "$SELECTION" - | zbarimg -q --raw -Sdisable -Sqrcode.enable - 2>/dev/null)
+
+if [[ -z $RESULT ]]; then
+  omarchy-notification-send -g 󰐲 -u critical "No QR code found" "Select a region containing a QR code"
+  exit 1
+fi
+
+# QR codes routinely carry secrets, like the otpauth:// URIs behind 2FA setup
+# codes, so the decoded value goes to the clipboard and nowhere else. Printing it
+# or putting it in the notification would leak it to the session journal and to
+# the notification history, and an unmarked copy would be retained by clipboard
+# history. Pasting still works; only the recorded copy is given up.
+printf '%s' "$RESULT" | wl-copy --sensitive
+omarchy-notification-send -g 󰐲 "QR code copied to clipboard"

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -53,6 +53,7 @@
   "trigger.capture.screenrecord.stop": {"icon":"","label":"Stop Screenrecording","when":"pgrep -f '^gpu-screen-recorder'","action":"omarchy-capture-screenrecording --stop-recording"},
   "trigger.capture.screenrecord": {"icon":"","label":"Screenrecord"},
   "trigger.capture.text": {"icon":"󰴑","label":"Text","action":"omarchy-capture-text"},
+  "trigger.capture.qr": {"icon":"󰐲","label":"QR Code","action":"omarchy-capture-qr"},
   "trigger.capture.color": {"icon":"󰃉","label":"Color","action":"pkill hyprpicker || hyprpicker -a"},
   "trigger.capture.screenrecord.no-audio": {"icon":"","label":"With no audio","action":"omarchy-capture-screenrecording"},
   "trigger.capture.screenrecord.desktop-audio": {"icon":"","label":"With desktop audio","action":"omarchy-capture-screenrecording --with-desktop-audio"},

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -146,4 +146,5 @@ xournalpp
 yaru-icon-theme
 yay
 yt-dlp
+zbar
 zoxide

--- a/migrations/1786447584.sh
+++ b/migrations/1786447584.sh
@@ -1,0 +1,3 @@
+echo "Install QR code scanning support"
+
+omarchy-pkg-add zbar


### PR DESCRIPTION
Adds `omarchy capture qr` and a QR Code entry to the Capture menu: select a screen region, and the QR code in it is decoded to the clipboard.

QR codes usually show up on the same machine where their contents are needed — importing an OTP/2FA setup code shown by a web app is the motivating case. Reading one currently means reaching for a phone, or screenshotting and passing the file through a decoder by hand.

This is a port of @Wondertan's #6679 to `quattro`, which needed reworking for the menu it doesn't share with `dev`: the entry moves to `default/omarchy/omarchy-menu.jsonc`, and the migration is renumbered to sort after the current ones. Original authorship is preserved on the commit.

Two things differ from #6679 as it stands:

**The decoded value only ever reaches the clipboard.** Given the motivating case is an OTP secret, the value is not printed to stdout (from the menu that is the session journal, so it would be written to disk) and not included in the notification body (on screen, and retained in notification history). The copy is marked `wl-copy --sensitive`, which offers the `x-kde-passwordManagerHint` type that `shell/plugins/clipboard/capture.sh` already gates on, so clipboard history skips the entry. Pasting is unaffected; only the recorded copy is given up. This matches `omarchy-capture-text`, which likewise reports only that it copied.

**Decoding is restricted to QR.** `zbarimg` enables every symbology by default, so as written it is not really a QR reader — a Code 128 barcode elsewhere in the selection decodes and takes the clipboard, and EAN/UPC can false-positive on dense screen content. `-Sdisable -Sqrcode.enable` makes the behaviour match what the command and the menu entry claim, and makes "No QR code found" accurate.

It also freezes the screen with `hyprpicker -r -z` before selecting, as the other region captures do, and folds the empty-result case into the same "No QR code found" notification instead of exiting silently.

`zbar` is added to the base packages and installed for existing systems by the migration. It pulls in `imagemagick`, which is already a base package, so the added footprint is about 250 KiB.

Closes #6679.

— 🤖 Claude, posting on behalf of @dhh
