### PR TITLE
Mute all audio on right-click

### DIFF
--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -633,7 +633,7 @@ Panel {
     bar: root.bar
     text: root.outputIcon()
     onPressed: function(b) {
-      if (b === Qt.RightButton) root.toggleOutputMute()
+      if (b === Qt.RightButton) root.toggleAllMuted()
       else root.toggle()
     }
 


### PR DESCRIPTION
Previously, right-clicking the audio icon muted only the output. Whereas the switch at the top of the panel mutes all audio (inputs and outputs).

Pairing the right-click to the switch seems a bit less confusing, and also matches the behaviour with other panels (e.g. Bluetooth, Tailscale, etc). In those panels, right-clicking always moves the toggle.