### PR TITLE
Enable WiFi 7 on Intel BE211 (quattro port of #6450)

### DIFF
--- a/install/hardware/intel/fix-wifi7-eht.sh
+++ b/install/hardware/intel/fix-wifi7-eht.sh
@@ -1,16 +1,13 @@
-# Temporary fix for Dell XPS 14/16 on Panther Lake
-# Disable WiFi 7 (EHT/802.11be) on Intel BE200/BE211 cards
-# The iwlwifi driver has a broken EHT RX data path — APs drop to MCS 0 NSS 1
-# when EHT is negotiated, making WiFi unusable. Disabling EHT falls
-# back to WiFi 6 (HE/802.11ax) which works at full speed.
-# This should be removed when Intel fixes the firmware/driver.
+# Temporarily disable WiFi 7 (EHT/802.11be) on Intel BE200 cards.
+# Linux kernel bug 221675 tracks a firmware assertion after warm reconnects
+# at 6 GHz/320 MHz. Disabling EHT avoids the failing channel context.
+# https://bugzilla.kernel.org/show_bug.cgi?id=221675
 
-if lspci -nn | grep -qE '\[8086:(e440|272b)\]'; then
+if lspci -nn | grep -q '\[8086:272b\]'; then
   mkdir -p /etc/modprobe.d
   cat > /etc/modprobe.d/iwlwifi-disable-eht.conf <<'EOF'
-# Temporary fix Dell XPS 14/16 on Panther lake
-# Disable WiFi 7 (EHT) on Intel BE200/BE211 — broken RX rate adaptation
-# Remove this file when fixes land in the iwlwifi EHT data path
+# Temporary workaround for Intel BE200 320 MHz firmware assertions
+# Remove this file when Linux kernel bug 221675 is fixed
 options iwlwifi disable_11be=Y
 EOF
 fi

--- a/migrations/1784508420.sh
+++ b/migrations/1784508420.sh
@@ -1,0 +1,184 @@
+echo "Enable WiFi 7 on Intel BE211 with Linux 7.1 or newer"
+
+wifi7_config_matches_omarchy_1784508420() {
+  local config_file=$1
+
+  printf '%s\n' \
+    '# Temporary fix Dell XPS 14/16 on Panther lake' \
+    '# Disable WiFi 7 (EHT) on Intel BE200/BE211 — broken RX rate adaptation' \
+    '# Remove this file when fixes land in the iwlwifi EHT data path' \
+    'options iwlwifi disable_11be=Y' |
+    sudo cmp -s "$config_file" -
+}
+
+enable_be211_wifi7() {
+  local wifi7_config="/etc/modprobe.d/iwlwifi-disable-eht.conf"
+  local wifi7_backup="${wifi7_config}.omarchy-1784508420-backup"
+  local kernel_modules_dir="/usr/lib/modules"
+  local kernel_found=false
+  local kernel_blocked=false
+  local eligible=true
+  local -a rebuild_command
+  local comparison
+  local extra
+  local kernel_dir
+  local package_query
+  local pkgbase_file
+  local package
+  local pci_devices
+  local queried_package
+  local version
+
+  if omarchy-cmd-present limine-mkinitcpio; then
+    rebuild_command=(sudo limine-mkinitcpio)
+  else
+    rebuild_command=(sudo mkinitcpio -P)
+  fi
+
+  # Decide eligibility before touching an interrupted attempt, so a machine that
+  # wants the workaround gone can finish the job with a single boot-image
+  # rebuild instead of restoring the config and immediately removing it again.
+  if ! pci_devices=$(lspci -nn); then
+    echo "Skipped $wifi7_config because PCI devices could not be inspected"
+    eligible=false
+  elif [[ $pci_devices != *"[8086:e440]"* ]]; then
+    eligible=false
+  elif [[ $pci_devices == *"[8086:272b]"* ]]; then
+    echo "Skipped $wifi7_config because Intel BE200 is also present"
+    eligible=false
+  fi
+
+  if [[ $eligible == "true" ]]; then
+    for kernel_dir in "$kernel_modules_dir"/*; do
+      [[ -d $kernel_dir ]] || continue
+
+      if [[ ! -d $kernel_dir/kernel &&
+        ! -f $kernel_dir/modules.builtin &&
+        ! -f $kernel_dir/modules.dep &&
+        ! -f $kernel_dir/vmlinuz ]]; then
+        continue
+      fi
+
+      kernel_found=true
+      pkgbase_file="$kernel_dir/pkgbase"
+      if [[ ! -f $pkgbase_file ]]; then
+        kernel_blocked=true
+        break
+      fi
+
+      package=$(<"$pkgbase_file")
+      if ! package_query=$(pacman -Q "$package" 2>/dev/null); then
+        kernel_blocked=true
+        break
+      fi
+
+      read -r queried_package version extra <<<"$package_query"
+      # Arch package names cannot contain shell glob characters.
+      # shellcheck disable=SC2053
+      if [[ $package_query == *$'\n'* || $queried_package != $package || -z $version || -n $extra ]]; then
+        kernel_blocked=true
+        break
+      fi
+
+      if ! comparison=$(vercmp "$version" 7.1 2>/dev/null) || [[ ! $comparison =~ ^-?[0-9]+$ ]]; then
+        kernel_blocked=true
+        break
+      fi
+
+      if (( comparison < 0 )); then
+        kernel_blocked=true
+        break
+      fi
+    done
+
+    if [[ $kernel_found == "false" || $kernel_blocked == "true" ]]; then
+      echo "Skipped $wifi7_config because not all installed kernels are Linux 7.1 or newer"
+      eligible=false
+    fi
+  fi
+
+  # Finish or undo an interrupted previous attempt.
+  if [[ ! -f $wifi7_config && -f $wifi7_backup ]]; then
+    if ! wifi7_config_matches_omarchy_1784508420 "$wifi7_backup"; then
+      echo "Unable to restore unexpected backup $wifi7_backup"
+      return 1
+    fi
+
+    if [[ $eligible == "true" ]]; then
+      if ! "${rebuild_command[@]}"; then
+        echo "ERROR: Failed to rebuild boot images after interrupted migration"
+        return 1
+      fi
+
+      omarchy-state set reboot-required ||
+        echo "WARNING: Failed to mark reboot-required; reboot to apply the WiFi 7 change"
+
+      sudo rm -f "$wifi7_backup" ||
+        echo "WARNING: Failed to remove $wifi7_backup; delete it manually"
+
+      return 0
+    fi
+
+    if ! sudo mv "$wifi7_backup" "$wifi7_config"; then
+      echo "ERROR: Failed to restore $wifi7_config from interrupted migration"
+      return 1
+    fi
+
+    if ! "${rebuild_command[@]}"; then
+      echo "ERROR: Failed to rebuild boot images after interrupted migration"
+      return 1
+    fi
+
+    omarchy-state set reboot-required ||
+      echo "WARNING: Failed to mark reboot-required after restoring $wifi7_config"
+
+    return 0
+  fi
+
+  [[ $eligible == "true" ]] || return 0
+
+  [[ -f $wifi7_config ]] || return 0
+
+  if ! wifi7_config_matches_omarchy_1784508420 "$wifi7_config"; then
+    echo "Skipped $wifi7_config because it is not the Omarchy-managed workaround"
+    return 0
+  fi
+
+  if [[ -e $wifi7_backup ]]; then
+    # Only a leftover copy of the very workaround being removed is safe to
+    # discard; anything else is unexpected state a migration should not destroy.
+    if ! wifi7_config_matches_omarchy_1784508420 "$wifi7_backup"; then
+      echo "Unable to migrate while unexpected backup exists at $wifi7_backup"
+      return 1
+    fi
+
+    if ! sudo rm -f "$wifi7_backup"; then
+      echo "ERROR: Failed to remove stale backup $wifi7_backup"
+      return 1
+    fi
+  fi
+
+  sudo mv "$wifi7_config" "$wifi7_backup" || return 1
+
+  if ! "${rebuild_command[@]}"; then
+    if ! sudo mv "$wifi7_backup" "$wifi7_config"; then
+      echo "ERROR: Failed to restore $wifi7_config after migration failure"
+      return 1
+    fi
+
+    if ! "${rebuild_command[@]}"; then
+      echo "ERROR: Failed to rebuild boot images with the restored WiFi workaround"
+    fi
+    return 1
+  fi
+
+  omarchy-state set reboot-required ||
+    echo "WARNING: Failed to mark reboot-required; reboot to apply the WiFi 7 change"
+
+  sudo rm -f "$wifi7_backup" ||
+    echo "WARNING: Failed to remove $wifi7_backup; delete it manually"
+
+  return 0
+}
+
+enable_be211_wifi7


### PR DESCRIPTION
Quattro port of #6450, which targets `dev` and cannot be retargeted as-is.

## Why a separate PR

#6450 is branched from `dev`, where this installer lives at
`install/config/hardware/intel/fix-wifi7-eht.sh`. On `quattro` it is
`install/hardware/intel/fix-wifi7-eht.sh`, and that is the path
`install/hardware/all.sh` actually sources. Retargeting #6450 to `quattro`
produces a PR that adds a file at a path quattro never runs, leaves the real
installer still matching `[8086:(e440|272b)]`, and drags in an unrelated
`ssh-port-forwarding` change from `dev`. Tested — it does not work.

## Changes

- Stop disabling EHT on BE211 (`8086:e440`).
- Keep the workaround for BE200 (`8086:272b`), where kernel bug 221675 still
  tracks a 320 MHz firmware assertion after warm reconnects.
- Add a migration removing the historical config from existing BE211 installs,
  gated on every installed kernel being Linux 7.1 or newer.

Keeps quattro `mkdir -p` + `cat >` rather than switching to `sudo tee`;
`omarchy-apply-hardware` already requires `EUID 0`, so the change stays limited
to the detection logic.

## Two fixes on top of #6450

1. **No double initramfs rebuild.** Eligibility is decided before the
   interrupted-recovery block, so an eligible machine with an orphaned backup
   finishes in one rebuild instead of restoring the config, rebuilding, then
   removing it and rebuilding again. Ineligible machines still restore.
2. **`config + backup both present` is no longer a dead end.** A stray backup
   byte-identical to the workaround being removed is discarded and the
   migration proceeds; anything else still hard-fails rather than destroying
   unexpected state.

## Validation

- `bash -n` clean on both files, mode 644, `git diff --check` clean.
- `./test/all`: one failure, `update-lock-test.sh`, confirmed pre-existing on
  clean `quattro` by stashing and re-running. ShellCheck not run (not installed
  on the test machine).
- Gates verified against a live BE211 (`8086:e440`, no BE200, kernels
  `linux-ptl 7.1.5.arch1-1` and `linux 7.1.7.arch1-1`): config matches the
  expected content byte-for-byte, so the migration takes the main path.

Migration not yet executed on hardware; that needs a reboot to confirm EHT
negotiates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uRU5yLNZLSBF2kKvyVad1