### PR TITLE
Accept either name for the lock authentication command

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -612,9 +612,17 @@ configure_snapper_policy() {
 }
 
 configure_lock_authentication() {
-  local apply_lock=/usr/share/omarchy/bin/omarchy-apply-lock
+  # The upgrade runs against whatever the channel currently ships, which can
+  # still predate the rename of omarchy-setup-lock to omarchy-apply-lock.
+  local apply_lock="" candidate
+  for candidate in /usr/share/omarchy/bin/omarchy-{apply,setup}-lock; do
+    if [[ -x $candidate ]]; then
+      apply_lock=$candidate
+      break
+    fi
+  done
 
-  [[ -x $apply_lock ]] || fail "$apply_lock is unavailable; lock screen authentication could not be configured."
+  [[ -n $apply_lock ]] || fail "Neither omarchy-apply-lock nor omarchy-setup-lock is available under /usr/share/omarchy/bin; lock screen authentication could not be configured."
 
   log "Configuring lock screen authentication"
   as_root env \


### PR DESCRIPTION
`omarchy-setup-lock` was renamed to `omarchy-apply-lock` in 536fcd5c. That commit reasoned that no compatibility route was needed because "the ISO installs the runtime from the mirror it ships with, so it moves to the new names in lockstep" — true for the ISO, but `omarchy-upgrade-to-quattro` is the one caller with no lockstep. It runs on a 3.x machine and calls into whatever the *channel* just installed, and every released package still ships `omarchy-setup-lock`.

So the upgrade aborted on every run:

```
Error: /usr/share/omarchy/bin/omarchy-apply-lock is unavailable; lock screen authentication could not be configured.

Upgrade incomplete - do NOT reboot.
```

It fails safe — before the point of no return, and re-running resumes — but it can't get past that step at all.

`configure_lock_authentication` now prefers the new name and falls back to the old one, so the upgrade works against both pre- and post-rename packages.

The same fix has already landed on `rc` (45acf301); this keeps the two copies of the script identical.

— 🤖 Claude, posting on behalf of @dhh