### PR TITLE
fix: collapse dropdown toggle on second click

### DIFF
--- a/shell/Ui/Dropdown.qml
+++ b/shell/Ui/Dropdown.qml
@@ -136,9 +136,14 @@ Item {
       MouseArea {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
+        // CloseOnReleaseOutside closes on release, so by click time the popup
+        // is already closed; the press-time state marks this as a collapse.
+        property bool _wasOpenAtPress: false
+        onPressed: _wasOpenAtPress = popup.opened
         onClicked: {
           trigger.forceActiveFocus()
-          popup.opened ? popup.close() : popup.open()
+          if (popup.opened || _wasOpenAtPress) popup.close()
+          else popup.open()
         }
       }
 
@@ -146,6 +151,7 @@ Item {
         id: popup
         x: 0
         y: trigger.height + Style.spacing.xxs
+        closePolicy: Popup.CloseOnReleaseOutside | Popup.CloseOnEscape
         width: trigger.width
         implicitHeight: Math.min(root.options.length * root.popupRowHeight + Math.max(0, root.options.length - 1) * Style.spacing.labelGap + Style.spacing.xxs,
                                  root.popupRowHeight * 8 + 7 * Style.spacing.labelGap + Style.spacing.xxs)

--- a/shell/Ui/MultiSelect.qml
+++ b/shell/Ui/MultiSelect.qml
@@ -324,14 +324,20 @@ Item {
       MouseArea {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
+        // CloseOnReleaseOutside closes on release, so by click time the popup
+        // is already closed; the press-time state marks this as a collapse.
+        property bool _wasOpenAtPress: false
+        onPressed: _wasOpenAtPress = popup.opened
         onClicked: {
           trigger.forceActiveFocus()
-          popup.opened ? popup.close() : popup.open()
+          if (popup.opened || _wasOpenAtPress) popup.close()
+          else popup.open()
         }
       }
 
       QQC.Popup {
         id: popup
+        closePolicy: QQC.Popup.CloseOnReleaseOutside | QQC.Popup.CloseOnEscape
         // Reparent to the window's content item so the popup is free of any
         // clipping ancestor. Position
         // and available height are recomputed on open and any time the

--- a/shell/Ui/SearchableDropdown.qml
+++ b/shell/Ui/SearchableDropdown.qml
@@ -158,9 +158,14 @@ Item {
       MouseArea {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
+        // CloseOnReleaseOutside closes on release, so by click time the popup
+        // is already closed; the press-time state marks this as a collapse.
+        property bool _wasOpenAtPress: false
+        onPressed: _wasOpenAtPress = popup.opened
         onClicked: {
           trigger.forceActiveFocus()
-          popup.opened ? popup.close() : popup.open()
+          if (popup.opened || _wasOpenAtPress) popup.close()
+          else popup.open()
         }
       }
 
@@ -169,6 +174,7 @@ Item {
         x: 0
         y: trigger.height + Style.spacing.xxs
         width: trigger.width
+        closePolicy: QQC.Popup.CloseOnReleaseOutside | QQC.Popup.CloseOnEscape
         implicitHeight: Math.max(root.popupMinHeight,
                                  Math.min(resultList.contentHeight + Style.space(50),
                                           root.popupRowHeight * 6 + 5 * Style.spacing.labelGap + Style.space(50)))


### PR DESCRIPTION
dropdown,  multi select, and searchable dropdown qml components try to expand again on click when they are already expanded, correct behavior should be to collapse