### PR TITLE
Prune the package cache before updating

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -22,6 +22,10 @@ trap 'omarchy-update-stay-awake stop' EXIT
 omarchy-update-requires-free-space
 
 if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
+  # Before the snapshot: the cache is on the snapshotted subvolume, so pruning
+  # after it frees nothing until that snapshot ages out.
+  omarchy-update-pkg-prune
+
   # 127 means Snapper is deliberately absent. Any other failure already said
   # what went wrong, and a missing snapshot is not worth blocking an update
   # over, but it must not pass for one either.

--- a/bin/omarchy-update-pkg-prune
+++ b/bin/omarchy-update-pkg-prune
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Prune superseded versions from the pacman package cache
+# omarchy:requires-sudo=true
+
+set -e
+
+# The cache is the only offline downgrade path, so keep two. Run before the
+# packages update and the installed version survives with a spare. paccache
+# retains by version order, never by what is installed.
+echo -e "\e[32m\nPrune package cache\e[0m"
+sudo paccache -rk2 || echo -e "\e[33mCould not prune the package cache.\e[0m" >&2

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -68,6 +68,7 @@ for command in \
   pkexec \
   systemd-inhibit \
   omarchy-update-dev \
+  omarchy-update-pkg-prune \
   omarchy-update-keyring \
   omarchy-update-system-pkgs \
   omarchy-migrate \

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -35,6 +35,7 @@ for command in \
   omarchy-toggle-idle \
   pkexec \
   systemd-inhibit \
+  omarchy-update-pkg-prune \
   omarchy-update-dev \
   omarchy-update-keyring \
   omarchy-update-system-pkgs \

--- a/test/shell.d/update-pkg-prune-test.sh
+++ b/test/shell.d/update-pkg-prune-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+run_pkg_prune() {
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-pkg-prune"
+}
+
+# Pin the keep count above one.
+write_stub sudo 'printf "%s\n" "$*" >"$PACCACHE_LOG"; exit 0'
+
+PACCACHE_LOG="$test_tmp/args" run_pkg_prune >"$test_tmp/prune.out" 2>&1
+grep -q 'paccache' "$test_tmp/args" || fail "cache prune runs paccache"
+grep -qE 'paccache .*-rk2' "$test_tmp/args" ||
+  fail "cache prune keeps more than one version" "$(cat "$test_tmp/args")"
+pass "cache prune leaves a rollback version to spare"
+
+# Housekeeping failure must not abort the update.
+write_stub sudo 'exit 1'
+run_pkg_prune >"$test_tmp/fail.out" 2>&1 ||
+  fail "cache prune survives paccache failure"
+grep -q 'Could not prune the package cache' "$test_tmp/fail.out" ||
+  fail "cache prune warns when it fails" "$(cat "$test_tmp/fail.out")"
+pass "cache prune warns but does not abort the update"
+
+# Ordering is the whole guarantee: rollback before the packages update, space
+# before the snapshot.
+line_of() {
+  grep -n "^[[:space:]]*$1\b" "$ROOT/bin/omarchy-update" | head -1 | cut -d: -f1
+}
+
+prune_line=$(line_of omarchy-update-pkg-prune)
+snapshot_line=$(line_of omarchy-snapshot)
+pkgs_line=$(line_of omarchy-update-system-pkgs)
+[[ -n $prune_line && -n $snapshot_line && -n $pkgs_line ]] ||
+  fail "omarchy-update runs the cache prune, the snapshot, and the packages update"
+
+(( prune_line < pkgs_line )) ||
+  fail "cache prune runs before the packages update" "prune: $prune_line, packages: $pkgs_line"
+pass "cache prune runs before the packages update"
+
+(( prune_line < snapshot_line )) ||
+  fail "cache prune runs before the snapshot" "prune: $prune_line, snapshot: $snapshot_line"
+pass "cache prune runs before the snapshot pins what it removes"


### PR DESCRIPTION
The pacman cache grows without bound across updates and nothing in the update flow ever reclaimed it. On this machine it had reached 7.4G across 732 archives, ~3.75 GiB of which are superseded versions nothing will install again.

Adds `omarchy-update-pkg-prune`, running `paccache -rk2` as the first step of an update.

## Why that placement

Both halves of it are load-bearing.

**Before the packages update.** The cache is Arch's only offline downgrade path — when an update breaks one package, reinstalling its predecessor from here is the surgical fix, where a snapshot rollback reverts every other package too. Pruning beforehand means the installed version is still the newest cached, so it survives along with a spare. Pruning *after* would make the newest cached version the freshly installed one, and cutting down to a single copy would delete exactly what a broken update needs.

**Before the snapshot.** The cache sits on the snapshotted root subvolume, so a prune taken after `omarchy-snapshot create` leaves the fresh snapshot holding those extents and reclaims nothing until it ages out of the number cleanup. Ordering it first is what makes the space actually come back.

`-k2` reclaims 3.75 GiB here, against 4.95 for `-k1` (which leaves no rollback candidate) and 3.11 for `-k3`.

## Failure handling

A failed prune warns and continues rather than aborting. Cache housekeeping shouldn't trip the update's ERR trap and tell the user their update went wrong. This got exercised for real: an early test run hit the unstubbed command with no sudo password available, and it warned and carried on with the cache untouched.

## Known limitations

Two things this deliberately does not do, both worth a second opinion:

- **It runs after `omarchy-update-requires-free-space`**, so it reclaims space during healthy updates but does not rescue a machine already under the 10 GiB gate — the case where the cache itself is what's blocking the update. Folding the prune into that gate and rechecking would fix it, at the cost of mutating the system before the user confirms.
- **`paccache` retains by version order and never consults what is installed.** The rollback guarantee therefore holds only while the installed version is among the two newest cached. A deliberate downgrade held with `IgnorePkg`, or repeated failed transactions, can stack newer archives on top of the installed one, and its copy becomes prunable like any other. Exempting installed versions is possible but needs real filename parsing.

Not included: `paccache -ruk0` for uninstalled packages, which is strictly safe and pairs naturally with `omarchy-update-orphan-pkgs`.

## Testing

New `test/shell.d/update-pkg-prune-test.sh` covers the keep count, the non-fatal failure path, and both ordering invariants by asserting line order in `omarchy-update`.

Also stubs the new command in `update-disk-space-test.sh` and `update-lock-test.sh`, both of which execute the real updater. Without that, `./test/shell` reaches a real `sudo paccache -rk2` and would prune the developer's own cache on a box with passwordless sudo. `update-lock-test.sh` was caught by a Codex review pass, not by me.

`./test/shell` (160 files) and `./test/cli` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
