### PR TITLE
Fix two races in the notification popup and history handling

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -92,6 +92,28 @@ function snapshotOf(notification, timestamp) {
   }
 }
 
+// Everything the popup card draws, and therefore everything an in-place
+// update has to write through to the row and its file.
+var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "exec", "urgency", "expireTimeout"]
+
+function popupRoles() {
+  return POPUP_ROLES
+}
+
+// Whether a refresh has anything to write. Each property a client updates
+// emits its own signal, and the catch-up refresh after a row is inserted
+// usually finds the object exactly as it was snapshotted — without this,
+// one update would rewrite the file several times over.
+function popupRowChanged(row, updated) {
+  var current = row || {}
+  var next = updated || {}
+  for (var i = 0; i < POPUP_ROLES.length; i++) {
+    var role = POPUP_ROLES[i]
+    if (current[role] !== next[role]) return true
+  }
+  return false
+}
+
 // A client updating a notification through replaces_id keeps the identity of
 // the popup it took over: the file name is the timestamp and id the popup was
 // first persisted under, and the restore, replace and archive paths all key
@@ -276,6 +298,8 @@ if (typeof module !== "undefined") {
     execFromHints: execFromHints,
     shouldRenderCompactGlyph: shouldRenderCompactGlyph,
     snapshotOf: snapshotOf,
+    popupRoles: popupRoles,
+    popupRowChanged: popupRowChanged,
     replacementSnapshot: replacementSnapshot,
     historyEntry: historyEntry,
     parseSettings: parseSettings,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -389,26 +389,37 @@ Item {
   // match these rows against fresh notifications.
   property var restoredPopups: ({})
 
+  // Entries are either { command } for a file job or { read: true } for a
+  // replay's directory read. Queueing the read rather than running it beside
+  // the queue is what makes it a barrier: it takes its place in line, so the
+  // history it sees is the one that existed when the replay was asked for.
+  // Everything queued after it — a clear, an archive, a silenced write — waits
+  // for it, and no amount of later traffic can push it back.
   property var popupFileQueue: []
 
   function enqueuePopupFileJob(command) {
-    popupFileQueue = popupFileQueue.concat([command])
+    popupFileQueue = popupFileQueue.concat([{ command: command }])
+    runNextPopupFileJob()
+  }
+
+  function enqueueHistoryRead() {
+    popupFileQueue = popupFileQueue.concat([{ read: true }])
     runNextPopupFileJob()
   }
 
   function runNextPopupFileJob() {
-    // A replay's directory read is a barrier in this queue. It only starts
-    // once everything queued ahead of it has landed, and everything queued
-    // behind it waits here until it finishes — so it sees the history exactly
-    // as it stood when the replay was asked for, not a clear or an archive
-    // half applied underneath the read.
-    if (readHistoryProc.running) return
-    if (popupFileProc.running || popupFileQueue.length === 0) {
-      if (!popupFileProc.running) startHistoryReadWhenIdle()
+    if (readHistoryProc.running || popupFileProc.running) return
+    if (popupFileQueue.length === 0) return
+
+    var job = popupFileQueue[0]
+    popupFileQueue = popupFileQueue.slice(1)
+
+    if (job.read) {
+      startHistoryRead()
       return
     }
-    popupFileProc.command = popupFileQueue[0]
-    popupFileQueue = popupFileQueue.slice(1)
+
+    popupFileProc.command = job.command
     popupFileProc.running = true
   }
 
@@ -504,28 +515,23 @@ Item {
   // by then, so they're handed over in memory instead of being waited for.
   property var replayCarryOver: []
 
-  // Set while a replay is waiting for the file queue to drain.
-  property bool historyReadPending: false
+  // Set from the moment a read is queued until it starts, so a second
+  // showHistory while one is still waiting its turn doesn't queue another.
+  property bool historyReadQueued: false
 
-  // Re-show what's in historyDir as toasts. Reading the directory is a
-  // subprocess, so the replay lands in replayHistory a moment later.
+  // Re-show what's in historyDir as toasts. The read goes through the file
+  // queue and its own subprocess, so the replay lands in replayHistory once
+  // the work queued ahead of it has finished.
   function showRecentHistory() {
-    if (readHistoryProc.running || service.historyReadPending) return "ok"
+    if (readHistoryProc.running || service.historyReadQueued) return "ok"
     service.replayCarryOver = liveRowsForReplay()
-    service.historyReadPending = true
-    startHistoryReadWhenIdle()
+    service.historyReadQueued = true
+    enqueueHistoryRead()
     return "ok"
   }
 
-  // The archives, silenced writes and clears the queue is still working
-  // through are what the replay is about to show. Reading the directory past
-  // them would replay a history that is one dismissal short, or one a clear
-  // was in the middle of emptying, so the read waits its turn.
-  function startHistoryReadWhenIdle() {
-    if (!service.historyReadPending) return
-    if (popupFileProc.running || popupFileQueue.length > 0) return
-
-    service.historyReadPending = false
+  function startHistoryRead() {
+    service.historyReadQueued = false
     readHistoryProc.command = ["bash", "-c",
       "awk 1 \"$1\"/*.json 2>/dev/null || true", "--", historyDir]
     readHistoryProc.running = true

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -183,6 +183,10 @@ Item {
     Qt.callLater(function() {
       removePopupsByOriginalId(snapshot.originalId, NotificationLogic.popupFileName(snapshot))
       popupModel.insert(0, snapshot)
+      // An update that arrived while the insert was deferred found no row to
+      // write to, and a property that already changed will not change again.
+      // Reading the object once the row exists catches up on it.
+      service.refreshPopup(notification, snapshot.originalId, snapshot.timestamp)
     })
   }
 
@@ -223,18 +227,12 @@ Item {
       return
     }
 
+    var roles = NotificationLogic.popupRoles()
     for (var i = 0; i < popupModel.count; i++) {
       var row = popupModel.get(i)
       if (!row || row.originalId !== originalId || row.timestamp !== timestamp) continue
-      popupModel.setProperty(i, "app", updated.app)
-      popupModel.setProperty(i, "appIcon", updated.appIcon)
-      popupModel.setProperty(i, "summary", updated.summary)
-      popupModel.setProperty(i, "body", updated.body)
-      popupModel.setProperty(i, "image", updated.image)
-      popupModel.setProperty(i, "glyph", updated.glyph)
-      popupModel.setProperty(i, "exec", updated.exec)
-      popupModel.setProperty(i, "urgency", updated.urgency)
-      popupModel.setProperty(i, "expireTimeout", updated.expireTimeout)
+      if (!NotificationLogic.popupRowChanged(row, updated)) return
+      for (var r = 0; r < roles.length; r++) popupModel.setProperty(i, roles[r], updated[roles[r]])
       // The file name is the timestamp and id this popup was persisted under,
       // so the rewrite lands on the same file: a restart restores the version
       // last shown, and so does the copy that ends up in history.

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -399,7 +399,10 @@ Item {
   }
 
   function runNextPopupFileJob() {
-    if (popupFileProc.running || popupFileQueue.length === 0) return
+    if (popupFileProc.running || popupFileQueue.length === 0) {
+      if (!popupFileProc.running) startHistoryReadWhenIdle()
+      return
+    }
     popupFileProc.command = popupFileQueue[0]
     popupFileQueue = popupFileQueue.slice(1)
     popupFileProc.running = true
@@ -494,15 +497,31 @@ Item {
   // by then, so they're handed over in memory instead of being waited for.
   property var replayCarryOver: []
 
+  // Set while a replay is waiting for the file queue to drain.
+  property bool historyReadPending: false
+
   // Re-show what's in historyDir as toasts. Reading the directory is a
   // subprocess, so the replay lands in replayHistory a moment later.
   function showRecentHistory() {
-    if (readHistoryProc.running) return "ok"
+    if (readHistoryProc.running || service.historyReadPending) return "ok"
     service.replayCarryOver = liveRowsForReplay()
+    service.historyReadPending = true
+    startHistoryReadWhenIdle()
+    return "ok"
+  }
+
+  // The archives, silenced writes and clears the queue is still working
+  // through are what the replay is about to show. Reading the directory past
+  // them would replay a history that is one dismissal short, or one a clear
+  // was in the middle of emptying, so the read waits its turn.
+  function startHistoryReadWhenIdle() {
+    if (!service.historyReadPending) return
+    if (popupFileProc.running || popupFileQueue.length > 0) return
+
+    service.historyReadPending = false
     readHistoryProc.command = ["bash", "-c",
       "awk 1 \"$1\"/*.json 2>/dev/null || true", "--", historyDir]
     readHistoryProc.running = true
-    return "ok"
   }
 
   // Copy the on-screen rows out of the model. The placeholder from an earlier

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -397,6 +397,12 @@ Item {
   }
 
   function runNextPopupFileJob() {
+    // A replay's directory read is a barrier in this queue. It only starts
+    // once everything queued ahead of it has landed, and everything queued
+    // behind it waits here until it finishes — so it sees the history exactly
+    // as it stood when the replay was asked for, not a clear or an archive
+    // half applied underneath the read.
+    if (readHistoryProc.running) return
     if (popupFileProc.running || popupFileQueue.length === 0) {
       if (!popupFileProc.running) startHistoryReadWhenIdle()
       return
@@ -484,6 +490,9 @@ Item {
   Process {
     id: readHistoryProc
     running: false
+    // Let the file queue go again, whatever the read did — a failed or empty
+    // read must not leave archives and clears parked behind it forever.
+    onExited: service.runNextPopupFileJob()
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: service.replayHistory(text)

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -170,6 +170,18 @@ assertEqual(
   '12345-12.json',
   'notifications keep the persisted file name across an in-place update'
 )
+assert(
+  !notifications.popupRowChanged(replacement, replacement),
+  'notifications skip a refresh that matches the row it would write'
+)
+assert(
+  notifications.popupRowChanged(replacement, Object.assign({}, replacement, { body: 'message 3' })),
+  'notifications refresh a row whose content moved on'
+)
+assert(
+  !notifications.popupRowChanged(replacement, Object.assign({}, replacement, { timestamp: 999 })),
+  'notifications ignore identity fields when deciding whether a refresh has work'
+)
 
 const settings = notifications.parseSettings(JSON.stringify({ version: 3, dnd: true }))
 assertEqual(settings.dnd, true, 'notifications parse the persisted DND state')
@@ -363,10 +375,6 @@ assert(
   'notifications service carries the toasts still on screen into the replay'
 )
 assert(
-  /function startHistoryReadWhenIdle\(\) \{[\s\S]{0,300}?if \(popupFileProc\.running \|\| popupFileQueue\.length > 0\) return/.test(serviceQml),
-  'notifications service reads history only once its queued file work has landed'
-)
-assert(
   /watchForUpdates\(notification, snapshot\)/.test(serviceQml),
   'notifications service watches a shown notification for in-place updates'
 )
@@ -375,8 +383,20 @@ assert(
   'notifications service refreshes the popup from every property the card draws'
 )
 assert(
-  /popupModel\.setProperty\(i, "summary", updated\.summary\)[\s\S]{0,600}?persistPopupFile\(updated\)/.test(serviceQml),
+  /popupModel\.setProperty\(i, roles\[r\], updated\[roles\[r\]\]\)[\s\S]{0,600}?persistPopupFile\(updated\)/.test(serviceQml),
   'notifications service rewrites both the row and its file when a notification is updated in place'
+)
+assert(
+  /if \(!NotificationLogic\.popupRowChanged\(row, updated\)\) return/.test(serviceQml),
+  'notifications service leaves the row and its file alone when a refresh finds nothing changed'
+)
+assert(
+  /popupModel\.insert\(0, snapshot\)[\s\S]{0,300}?service\.refreshPopup\(notification, snapshot\.originalId, snapshot\.timestamp\)/.test(serviceQml),
+  'notifications service catches up on an update that beat the deferred row insert'
+)
+assert(
+  /function startHistoryReadWhenIdle\(\) \{[\s\S]{0,300}?if \(popupFileProc\.running \|\| popupFileQueue\.length > 0\) return/.test(serviceQml),
+  'notifications service reads history only once its queued file work has landed'
 )
 assert(
   /onSummaryChanged: cardSlot\.remainingLifetime = 1\.0/.test(serviceQml),

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -395,11 +395,15 @@ assert(
   'notifications service catches up on an update that beat the deferred row insert'
 )
 assert(
-  /function startHistoryReadWhenIdle\(\) \{[\s\S]{0,300}?if \(popupFileProc\.running \|\| popupFileQueue\.length > 0\) return/.test(serviceQml),
-  'notifications service reads history only once its queued file work has landed'
+  /function showRecentHistory\(\)[\s\S]{0,300}?enqueueHistoryRead\(\)/.test(serviceQml),
+  'notifications service reads history from its place in the file queue'
 )
 assert(
-  /function runNextPopupFileJob\(\) \{[\s\S]{0,500}?if \(readHistoryProc\.running\) return/.test(serviceQml),
+  /if \(job\.read\) \{\s*\n\s*startHistoryRead\(\)/.test(serviceQml),
+  'notifications service runs the queued read when its turn comes'
+)
+assert(
+  /function runNextPopupFileJob\(\) \{\s*\n\s*if \(readHistoryProc\.running \|\| popupFileProc\.running\) return/.test(serviceQml),
   'notifications service holds queued file work until a history read finishes'
 )
 assert(

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -399,6 +399,14 @@ assert(
   'notifications service reads history only once its queued file work has landed'
 )
 assert(
+  /function runNextPopupFileJob\(\) \{[\s\S]{0,500}?if \(readHistoryProc\.running\) return/.test(serviceQml),
+  'notifications service holds queued file work until a history read finishes'
+)
+assert(
+  /id: readHistoryProc[\s\S]{0,300}?onExited: service\.runNextPopupFileJob\(\)/.test(serviceQml),
+  'notifications service releases the file queue even when a history read comes back empty'
+)
+assert(
   /onSummaryChanged: cardSlot\.remainingLifetime = 1\.0/.test(serviceQml),
   'notifications service restarts the countdown when a toast is updated under it'
 )

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -363,6 +363,10 @@ assert(
   'notifications service carries the toasts still on screen into the replay'
 )
 assert(
+  /function startHistoryReadWhenIdle\(\) \{[\s\S]{0,300}?if \(popupFileProc\.running \|\| popupFileQueue\.length > 0\) return/.test(serviceQml),
+  'notifications service reads history only once its queued file work has landed'
+)
+assert(
   /watchForUpdates\(notification, snapshot\)/.test(serviceQml),
   'notifications service watches a shown notification for in-place updates'
 )


### PR DESCRIPTION
Follow-ups to the notification work in ab57ad65 and cd84583b, from Copilot's review of the two PRs those shipped from and a codex pass over this branch. Kept together in one PR.

**The replay could read the history mid-write.** Popup files are written by a serialized queue of shell jobs, and `showHistory` read the directory as its own process alongside it. A dismissal issued a moment earlier could still be queued when the read ran, leaving that notification out of the replay it was the newest entry of; a `clear` issued a moment earlier could still be queued too, replaying entries it was about to remove. The read is now an entry in that queue rather than a process running beside it, which is what makes it a real barrier: it takes its place in line behind the work queued before the request and ahead of everything queued after, so a clear cannot delete files out from under `awk` mid-glob, no later job can overtake it, and unbroken file traffic cannot postpone it. It releases the queue on process exit rather than on output, so a read that comes back empty or fails cannot park the queue behind it.

**An update could arrive before its popup had a row.** Watching a notification for in-place updates starts when it is handed over, but the row those updates write to is inserted a tick later — deferred to keep a mid-incubation Repeater from being mutated underneath. A client fast enough to update inside that window found no row, and a property that has already changed does not change again, so the toast and its file stayed on the superseded content indefinitely. The row is now refreshed from the live notification once it exists. A refresh whose content matches the row it would write is dropped, which costs nothing in the common case and also collapses the several signals one multi-property update emits into a single rewrite.

Copilot's finding that the countdown should restart for every refreshed role, not just summary/body/image, I did not apply. The example given was urgency dropping from critical back to normal resuming a nearly-exhausted fraction, but a critical toast never ticks (`lifetime` is 0, so the timer never runs) and its remaining fraction is still a full 1.0 when it becomes normal. What is left is app name, icon, glyph and expire timeout, none of which change the text the user is reading, and resetting on those would let a client hold a toast on screen indefinitely by re-sending a hint.

Verified against the running shell: `dismissAll`, `showHistory` and `clear` issued back to back replays all four archived notifications and then empties the directory, so the archives landed ahead of the read and the clear behind it; a burst of eight notifications sent immediately after a replay request does not delay or displace it; new notifications still persist and archive after a read, including after one that found no history; and an in-place update still refreshes the toast and its persisted file.

— 🤖 Claude, posting on behalf of @dhh