### PR TITLE
Stop hybrid GPU mode queries from hanging

### DIFF
--- a/bin/omarchy-toggle-hybrid-gpu
+++ b/bin/omarchy-toggle-hybrid-gpu
@@ -24,7 +24,7 @@ fi
 
 gpu_mode=""
 for attempt in {1..3}; do
-  if gpu_mode=$(timeout 3s supergfxctl -g 2>/dev/null) && [[ -n $gpu_mode ]]; then
+  if gpu_mode=$(timeout --kill-after=1s 3s supergfxctl -g 2>/dev/null) && [[ -n $gpu_mode ]]; then
     break
   fi
 

--- a/bin/omarchy-toggle-hybrid-gpu
+++ b/bin/omarchy-toggle-hybrid-gpu
@@ -22,7 +22,20 @@ CONF
   sudo systemctl enable --now supergfxd
 fi
 
-gpu_mode=$(supergfxctl -g)
+gpu_mode=""
+for attempt in {1..3}; do
+  if gpu_mode=$(timeout 3s supergfxctl -g 2>/dev/null) && [[ -n $gpu_mode ]]; then
+    break
+  fi
+
+  gpu_mode=""
+  (( attempt < 3 )) && sleep 1
+done
+
+if [[ -z $gpu_mode ]]; then
+  echo "supergfxd is not responding. Try again, or check: systemctl status supergfxd" >&2
+  exit 1
+fi
 
 case "$gpu_mode" in
 "Integrated")

--- a/test/shell.d/hybrid-gpu-test.sh
+++ b/test/shell.d/hybrid-gpu-test.sh
@@ -40,17 +40,17 @@ STUB
 
 chmod +x "$fake_bin"/*
 
-TEST_TMP="$test_tmp" TEST_LOG="$test_tmp/calls.log" SUCCEED_ON_ATTEMPT=3 \
+TEST_TMP="$test_tmp" SUCCEED_ON_ATTEMPT=3 \
   PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" >/dev/null
 
 [[ $(<"$test_tmp/attempts") == "3" ]] || fail "hybrid GPU mode query retries transient failures"
 pass "hybrid GPU mode query recovers from a transient supergfxd failure"
 
-rm -f "$test_tmp/attempts" "$test_tmp/calls.log"
+rm -f "$test_tmp/attempts"
 
 set +e
 error=$(
-  TEST_TMP="$test_tmp" TEST_LOG="$test_tmp/calls.log" \
+  TEST_TMP="$test_tmp" \
     PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1 >/dev/null
 )
 status=$?
@@ -70,7 +70,7 @@ STUB
 chmod +x "$fake_bin/supergfxctl"
 
 set +e
-output=$(TEST_TMP="$test_tmp" PATH="$fake_bin:$PATH" timeout 15s bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1)
+output=$(TEST_TMP="$test_tmp" PATH="$fake_bin:$PATH" timeout 25s bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1)
 status=$?
 set -e
 

--- a/test/shell.d/hybrid-gpu-test.sh
+++ b/test/shell.d/hybrid-gpu-test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+
+cat >"$fake_bin/timeout" <<'STUB'
+#!/bin/bash
+printf 'timeout %s\n' "$*" >>"$TEST_LOG"
+shift
+exec "$@"
+STUB
+
+cat >"$fake_bin/sleep" <<'STUB'
+#!/bin/bash
+:
+STUB
+
+cat >"$fake_bin/gum" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+
+cat >"$fake_bin/supergfxctl" <<'STUB'
+#!/bin/bash
+attempts_file="$TEST_TMP/attempts"
+attempts=0
+[[ -f $attempts_file ]] && attempts=$(<"$attempts_file")
+attempts=$((attempts + 1))
+printf '%s\n' "$attempts" >"$attempts_file"
+
+if (( attempts < ${SUCCEED_ON_ATTEMPT:-999} )); then
+  exit 1
+fi
+
+echo Hybrid
+STUB
+
+chmod +x "$fake_bin"/*
+
+TEST_TMP="$test_tmp" TEST_LOG="$test_tmp/calls.log" SUCCEED_ON_ATTEMPT=3 \
+  PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" >/dev/null
+
+[[ $(<"$test_tmp/attempts") == "3" ]] || fail "hybrid GPU mode query retries transient failures"
+[[ $(grep -c '^timeout 3s supergfxctl -g$' "$test_tmp/calls.log") == "3" ]] ||
+  fail "hybrid GPU mode query bounds every attempt"
+pass "hybrid GPU mode query recovers from a transient supergfxd failure"
+
+rm -f "$test_tmp/attempts" "$test_tmp/calls.log"
+
+set +e
+error=$(
+  TEST_TMP="$test_tmp" TEST_LOG="$test_tmp/calls.log" \
+    PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1 >/dev/null
+)
+status=$?
+set -e
+
+(( status != 0 )) || fail "hybrid GPU mode query fails when supergfxd stays unavailable"
+[[ $(<"$test_tmp/attempts") == "3" ]] || fail "hybrid GPU mode query stops after three attempts"
+grep -qF 'supergfxd is not responding' <<<"$error" ||
+  fail "hybrid GPU mode query explains how to diagnose supergfxd" "$error"
+pass "hybrid GPU mode query fails clearly instead of hanging"

--- a/test/shell.d/hybrid-gpu-test.sh
+++ b/test/shell.d/hybrid-gpu-test.sh
@@ -13,13 +13,6 @@ cat >"$fake_bin/omarchy-cmd-missing" <<'STUB'
 exit 1
 STUB
 
-cat >"$fake_bin/timeout" <<'STUB'
-#!/bin/bash
-printf 'timeout %s\n' "$*" >>"$TEST_LOG"
-shift
-exec "$@"
-STUB
-
 cat >"$fake_bin/sleep" <<'STUB'
 #!/bin/bash
 :
@@ -51,8 +44,6 @@ TEST_TMP="$test_tmp" TEST_LOG="$test_tmp/calls.log" SUCCEED_ON_ATTEMPT=3 \
   PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" >/dev/null
 
 [[ $(<"$test_tmp/attempts") == "3" ]] || fail "hybrid GPU mode query retries transient failures"
-[[ $(grep -c '^timeout 3s supergfxctl -g$' "$test_tmp/calls.log") == "3" ]] ||
-  fail "hybrid GPU mode query bounds every attempt"
 pass "hybrid GPU mode query recovers from a transient supergfxd failure"
 
 rm -f "$test_tmp/attempts" "$test_tmp/calls.log"
@@ -70,3 +61,21 @@ set -e
 grep -qF 'supergfxd is not responding' <<<"$error" ||
   fail "hybrid GPU mode query explains how to diagnose supergfxd" "$error"
 pass "hybrid GPU mode query fails clearly instead of hanging"
+
+cat >"$fake_bin/supergfxctl" <<'STUB'
+#!/bin/bash
+trap '' TERM
+/usr/bin/sleep 30
+STUB
+chmod +x "$fake_bin/supergfxctl"
+
+set +e
+output=$(TEST_TMP="$test_tmp" PATH="$fake_bin:$PATH" timeout 15s bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1)
+status=$?
+set -e
+
+(( status != 124 )) || fail "hybrid GPU mode query terminates a blocked client"
+(( status != 0 )) || fail "hybrid GPU mode query reports a blocked client as unavailable"
+grep -qF 'supergfxd is not responding' <<<"$output" ||
+  fail "hybrid GPU mode query diagnoses a blocked client" "$output"
+pass "hybrid GPU mode query kills a client that ignores the timeout signal"


### PR DESCRIPTION
Stops Hybrid GPU setup from hanging indefinitely when supergfxd does not answer its mode query. Closes #6399.

## Problem

The first `supergfxctl -g` call can block forever immediately after supergfxd is installed and started, leaving the setup terminal stuck without an error or recovery path.

## Fix

Bound each mode query to three seconds, retry transient failures three times, and exit with a direct `systemctl status supergfxd` diagnostic when the daemon remains unavailable.
