### PR TITLE
Don't let a usbfs claim count as a kernel driver

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -18,9 +18,15 @@ usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 # — all bind one. Only the vendor-ID guess needs this; a device that names
 # itself a fingerprint reader is trusted outright.
 has_kernel_driver() {
-  local intf
+  local intf driver
   for intf in "$1"/*:*; do
-    [[ -e $intf/driver ]] && return 0
+    [[ -e $intf/driver ]] || continue
+    # usbfs is the exception: libusb claims an interface through it, so a reader
+    # fprintd is enrolling or verifying against binds a driver for as long as it
+    # holds the claim. That is userspace driving the device — what a reader is
+    # supposed to look like — so it must not read as a kernel driver here.
+    driver=$(readlink -f "$intf/driver")
+    [[ ${driver##*/} == "usbfs" ]] || return 0
   done
   return 1
 }

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -87,5 +87,19 @@ write_usb_devices '27c6:1234'
 bind_driver '1-0/1-0:1.0' uvcvideo
 assert_rejects "a vendor guess bound to a kernel driver is rejected"
 
+write_usb_devices '27c6:1234'
+bind_driver '1-0/1-0:1.0' usbfs
+assert_detects "a vendor guess claimed through usbfs is still detected"
+
+write_usb_devices '27c6:1234'
+bind_driver '1-0/1-0:1.0' usbfs
+bind_driver '1-0/1-0:1.1' uvcvideo
+assert_rejects "a real driver alongside a usbfs claim is still rejected"
+
+# The product-name branch is trusted outright, whatever is bound to it.
+write_usb_devices '27c6:1234:Goodix Fingerprint USB Device'
+bind_driver '1-0/1-0:1.0' uvcvideo
+assert_detects "a self-named reader is detected with a driver bound"
+
 write_usb_devices '1234:5678:Generic USB Device'
 assert_rejects "a machine with no matching USB devices detects nothing"


### PR DESCRIPTION
## Problem

`omarchy-hw-fingerprint` rejects a vendor-ID match when any interface has a driver bound. The reasoning holds — libfprint drives readers from userspace, so an idle reader sits there unbound — but libusb *claims* interfaces through a synthetic `usbfs` driver. The claim shows up in sysfs like any other binding, and it is held for exactly as long as fprintd is enrolling or verifying.

Readers whose product string names them take the earlier branch and never reach the check. The exposure is the ones that don't:

| Device | Product string | Path |
|---|---|---|
| `27c6:609c` | `Goodix Fingerprint USB Device` | product match — unaffected |
| `27c6:6594` | `Goodix USB2.0 MISC` | **vendor ID only — affected** |

On a `6594` machine the detector flips to "no reader" mid-authentication: the Fingerprint menu entry disappears and `install/user/first-run/setup-fingerprint.hook` stops firing, for the duration of the claim.

## Fix

Ignore a driver link resolving to `usbfs`; keep rejecting real ones. A device binding `uvcvideo` on one interface and holding a `usbfs` claim on another is still rejected. Also pins the product-string branch's deliberate bypass of this check, which nothing covered.

## Verification

Reproduced against a sysfs fixture through `OMARCHY_USB_DEVICES_PATH`. The new usbfs case fails against quattro's detector and passes with this one.

Not reproduced on physical hardware — I don't have a `6594` reader. The mechanism is read from the kernel's `usb_driver_claim_interface` path in `drivers/usb/core/devio.c` and libusb's Linux backend, not from observing the sysfs tree of an affected machine. Worth a sanity check by anyone who has one enrolled.

Found by a Codex review of #6737.

— 🤖 Claude, posting on behalf of @dhh