### PR TITLE
Install ChatGPT as a desktop app under Install > AI

### DIFF
--- a/applications/ChatGPT.desktop
+++ b/applications/ChatGPT.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Version=1.0
-Name=ChatGPT
-Exec=omarchy-launch-webapp https://chatgpt.com/
-Terminal=false
-Type=Application
-Icon=chatgpt
-StartupNotify=true

--- a/bin/omarchy-install-ai-chatgpt
+++ b/bin/omarchy-install-ai-chatgpt
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Install the ChatGPT desktop app
+# omarchy:requires-sudo=true
+
+set -e
+
+echo "Installing ChatGPT..."
+omarchy-pkg-add openai-codex-desktop
+
+echo "Opening ChatGPT..."
+setsid uwsm-app -- /usr/bin/chatgpt >/dev/null 2>&1 &
+
+echo ""
+echo "ChatGPT has been installed."

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -227,6 +227,7 @@
   "install.terminal.foot": {"icon":"","label":"Foot","when":"! omarchy-pkg-present foot","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal foot'"},
   "install.terminal.ghostty": {"icon":"","label":"Ghostty","when":"! omarchy-pkg-present ghostty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal ghostty'"},
   "install.terminal.kitty": {"icon":"","label":"Kitty","when":"! omarchy-pkg-present kitty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal kitty'"},
+  "install.ai.chatgpt": {"icon":"󱚤","label":"ChatGPT Desktop","when":"! omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-chatgpt"},
   "install.ai.dictation": {"icon":"","label":"Dictation","when":"! omarchy-pkg-present voxtype-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"},
   "install.ai.lm-studio": {"icon":"󱚤","label":"LM Studio","when":"! omarchy-pkg-present lmstudio-bin","action":"omarchy-install-app 'LM Studio' lmstudio-bin"},
   "install.ai.ollama": {"icon":"󱚤","label":"Ollama","when":"! omarchy-cmd-present ollama","action":"if omarchy-cmd-present nvidia-smi; then ollama_pkg=ollama-cuda; elif omarchy-cmd-present rocminfo; then ollama_pkg=ollama-rocm; else ollama_pkg=ollama; fi; omarchy-install-app Ollama \"$ollama_pkg\""},


### PR DESCRIPTION
Adds `Install > AI > ChatGPT Desktop`, installing the `openai-codex-desktop` package.

That package ships its own `chatgpt.desktop`, so the ChatGPT web app is dropped from the default set in the same change — otherwise fresh installs would show two identical-looking ChatGPT entries in the launcher. `SUPER + SHIFT + A` still opens the web version, which is the only place it was really used.

The bundled ChatGPT icon stays in `applications/icons`: the package's own `chatgpt.desktop` asks for `Icon=chatgpt` and ships no hicolor icon of its own, so it inherits ours.