### PR TITLE
Treat the compositor guard test's socket fixture as optional

### DIFF
--- a/test/shell.d/compositor-guard-test.sh
+++ b/test/shell.d/compositor-guard-test.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
-require_command python3
-
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
 
@@ -14,8 +12,16 @@ stub_bin="$test_dir/bin"
 mkdir -p "$runtime_dir" "$stub_bin"
 
 # A bound AF_UNIX socket outlives the process that bound it, which is exactly the
-# corpse a dead compositor leaves behind.
-python3 -c 'import socket, sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' "$runtime_dir/wayland-1"
+# corpse a dead compositor leaves behind. Binding one is the only way to get a
+# file that passes -S, and the sandboxes this guard exists for are the ones that
+# deny it, so treat the fixture as optional rather than fail there.
+socket_bound=1
+if command -v python3 >/dev/null; then
+  python3 -c 'import socket, sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' \
+    "$runtime_dir/wayland-1" 2>/dev/null || socket_bound=0
+else
+  socket_bound=0
+fi
 
 attempts_log="$test_dir/hyprctl-attempts"
 
@@ -67,6 +73,12 @@ pass "guard skips without a display"
 output=$(run_guard WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR="$test_dir/blocked")
 [[ $output == "$skipped" ]] || fail "guard skips when the socket is unreachable" "$output"
 pass "guard skips when the socket is unreachable"
+
+# Everything below needs a socket to stand in for a live or abandoned compositor.
+if (( ! socket_bound )); then
+  pass "cannot bind a Unix socket here; skipping the cases that need one"
+  exit 0
+fi
 
 # Hyprland can miss a single query mid-reconfigure, so only a compositor that
 # stays silent counts as gone.


### PR DESCRIPTION
Follow-up to #6749, which merged before this landed.

The guard test builds its fixture by binding a Unix socket, since that's the only way to get a file that passes `-S` and stand in for the socket an abandoned compositor leaves behind. Sandboxes that deny local `bind(2)` are the same ones the guard exists for, so there the fixture raised `PermissionError` and `set -e` took the whole file down before a single assertion — a new failure in exactly the environment #6743 was about.

The cases that need no socket now run first, and the rest skip when one can't be bound. The `require_command python3` hard dependency goes with it: a missing interpreter degrades the same way instead of failing the file.

Found by `codex exec review` at xhigh, which reproduced it under its own sandbox.

— 🤖 Claude, posting on behalf of @dhh
