### PR TITLE
Show a plug icon when plugged in but not charging

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -63,6 +63,25 @@ function chargeThresholdActive(device, onBattery, states) {
   return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
 }
 
+function fullyCharged(device, onBattery, states) {
+  var d = device || {}
+  return !!(d.isPresent && d.state === (states || {}).FullyCharged && !chargeThresholdActive(d, onBattery, states))
+}
+
+// Full covers the window where the battery has reached 100% but the state has
+// not caught up yet, which some firmware still reports as charging.
+function batteryFull(device, onBattery, states) {
+  var d = device || {}
+  if (!d.isPresent) return false
+  return fullyCharged(d, onBattery, states) || (!onBattery && batteryFraction(d) >= 1)
+}
+
+// Nothing is flowing into the battery: either it is topped up, or a charge
+// threshold is holding it below full.
+function batteryFlowIdle(device, onBattery, states) {
+  return batteryFull(device, onBattery, states) || chargeThresholdActive(device, onBattery, states)
+}
+
 function batteryIcon(device, onBattery, states) {
   var d = device || {}
   if (!d.isPresent) return ""
@@ -70,9 +89,10 @@ function batteryIcon(device, onBattery, states) {
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
-  var threshold = chargeThresholdActive(d, onBattery, states)
 
-  if (threshold) return defaultIcons[index]
+  // On external power with no current flowing, so a plug says more about the
+  // state than a charging icon that suggests the battery is still filling.
+  if (!onBattery && batteryFlowIdle(d, onBattery, states)) return "󰚥"
   if (d.state === states.FullyCharged) return "󰂅"
   if (!onBattery) return chargingIcons[index]
   return defaultIcons[index]
@@ -98,6 +118,9 @@ if (typeof module !== "undefined") {
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
+    fullyCharged: fullyCharged,
+    batteryFull: batteryFull,
+    batteryFlowIdle: batteryFlowIdle,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel
   }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -63,7 +63,7 @@ Panel {
 
   readonly property bool fullyCharged: {
     var device = UPower.displayDevice
-    return device && device.isPresent && device.state === UPowerDeviceState.FullyCharged && !root.chargeThresholdActive
+    return Model.fullyCharged(device, root.discharging, upowerStates())
   }
   readonly property bool discharging: {
     var device = UPower.displayDevice
@@ -73,8 +73,14 @@ Panel {
     var device = UPower.displayDevice
     return Model.chargeThresholdActive(device, root.discharging, upowerStates())
   }
-  readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
-  readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
+  readonly property bool batteryFull: {
+    var device = UPower.displayDevice
+    return Model.batteryFull(device, root.discharging, upowerStates())
+  }
+  readonly property bool batteryFlowIdle: {
+    var device = UPower.displayDevice
+    return Model.batteryFlowIdle(device, root.discharging, upowerStates())
+  }
 
   // 0..1 charge level, used by the visual progress bar.
   readonly property real batteryFraction: {

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -41,6 +41,17 @@ assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, true, states),
   'power shows battery icon when unplugged before battery state refreshes'
 )
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), '󰚥', 'power shows a plug when fully charged on external power')
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 1, state: states.Charging }, false, states), '󰚥', 'power shows a plug at full charge before the charged state refreshes')
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), '󰚥', 'power shows a plug when a charge threshold holds the battery below full')
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 1, state: states.FullyCharged }, true, states), '󰂅', 'power drops the plug at full charge once unplugged')
+
+assert(power.fullyCharged({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'power reads a topped up battery as fully charged')
+assert(!power.fullyCharged({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power does not read a threshold hold as fully charged')
+assert(power.batteryFull({ isPresent: true, percentage: 1, state: states.Charging }, false, states), 'power reads 100% as full before the charged state refreshes')
+assert(!power.batteryFull({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power does not read a threshold hold as full')
+assert(power.batteryFlowIdle({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power reads a threshold hold as idle flow')
+assert(!power.batteryFlowIdle({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not read active charging as idle flow')
 
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')


### PR DESCRIPTION
In 3.8, waybar showed the plugged-in glyph once the battery stopped taking a charge. The Quickshell power widget never picked that up: at 100% on AC it shows the charging icon, which reads as though current is still flowing into a battery that is already full.

The same is true while a firmware charge threshold holds the battery below full. That case showed the plain battery icon, indistinguishable from running on battery at the same level.

This widens the icon rule to "on external power with nothing flowing", which is the `batteryFlowIdle` state the panel already tracked:

* Plugged in and idle, either topped up or held by a charge threshold, shows a plug.
* Actively charging keeps the charging icon.
* On battery keeps the plain battery icon.

The panel still separates the two idle cases in words, labelling them "Fully charged" and "Threshold", so nothing is lost where there is room to say it.

The glyph is `nf-md-power_plug` (U+F06A5) rather than 3.8's `nf-fa-plug`, so the stroke weight matches the surrounding Material Design battery icons.

`fullyCharged`, `batteryFull`, and `batteryFlowIdle` move from `Panel.qml` into `Model.js`, since the icon and the panel's stats rows now depend on the same predicates and should not be able to drift apart.

## Verification

Checked on a laptop reporting `state: fully-charged`, `percentage: 100%`, `OnBattery: false`. The bar and the panel hero both render the plug at icon size, the panel still reads "FULLY CHARGED / 100%" with its stats rows intact, and the shell log shows no QML errors or binding loops.

`test/shell.d/power-test.sh` covers the new states, including the threshold hold, which cannot be exercised without writing `charge_control_end_threshold` on real hardware.

One consequence worth flagging: on a charge-limited machine, plugging in below the start threshold can now briefly show the plug before the charging icon, because UPower reports `FullyCharged` for a moment there (the window noted at `Panel.qml:428`). It is a truthful reading of that instant, but it is new visible behaviour.