### PR TITLE
Require a volume selector, not just root=, before calling a cmdline bootable

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -517,14 +517,24 @@ normalize_limine_config() {
   fi
 }
 
-root_param_regex='(^|[[:space:]])root=([^[:space:]]*)'
+# Captures the value of the *last* root=, which is the one that counts:
+# getarg reads the cmdline with tail -1, so a later root= overrides an earlier
+# one. The greedy prefix walks to the final occurrence. A value is required,
+# since a bare root= names nothing.
+root_param_regex='.*(^|[[:space:]])root=([^[:space:]]+)'
 
 # Naming an encrypted volume is what tells the initramfs to unlock it, so only
 # these prove a cmdline can reach an encrypted root. Keyfiles, ciphers and
-# crypttab switches modify an unlock selected elsewhere; on their own they
-# unlock nothing, so they must not vouch for a cmdline. A value is required:
-# a bare rd.luks.uuid= selects no volume either.
-unlock_selector_regex='(^|[[:space:]])(cryptdevice|dm-mod\.create|(rd\.)?luks\.(name|uuid))=[^[:space:]]'
+# crypttab switches modify an unlock selected elsewhere and open nothing on
+# their own, so they must not vouch for a cmdline.
+#
+# rd.luks.*/luks.* are deliberately absent. They are systemd's, and Omarchy
+# builds its initramfs with the busybox encrypt hook, which reads only
+# cryptdevice, cryptkey and crypto — it ignores every rd.luks parameter. A
+# machine carrying one and nothing else would be approved for a reboot into an
+# initramfs that cannot act on it. They are still copied forward below, so a
+# setup that does use them keeps them.
+unlock_selector_regex='(^|[[:space:]])(cryptdevice|dm-mod\.create)=[^[:space:]]'
 
 # Everything the unlock depends on, which is broader than what proves it:
 # these have to survive into the rebuilt cmdline even though none of them
@@ -563,6 +573,27 @@ cmdline_boots() {
   [[ $root_value != /dev/mapper/* && $root_value != /dev/dm-* ]]
 }
 
+# Whether any boot entry in a limine.conf can reach root. Judged one entry at
+# a time, because a root= in one entry and a selector in another compose into
+# nothing that boots, and only on the cmdline: keys — a title, a path or a
+# module_cmdline: is not the kernel command line, and a commented-out example
+# must not vouch for a live entry.
+limine_conf_boots() {
+  local text="$1" encrypted="$2" line
+  local cmdline_key_regex='^cmdline:[[:space:]]*'
+
+  # `|| [[ -n $line ]]` reads a final line that carries no trailing newline.
+  while IFS= read -r line || [[ -n $line ]]; do
+    line=${line#"${line%%[![:space:]]*}"}
+    [[ $line =~ $cmdline_key_regex ]] || continue
+    if cmdline_boots "${line#cmdline:}" "$encrypted"; then
+      return 0
+    fi
+  done <<<"$text"
+
+  return 1
+}
+
 # lsblk -s walks the parents, where the crypt layer hides on LVM-on-LUKS;
 # --nofsroot keeps findmnt from appending a btrfs subvolume lsblk cannot
 # resolve; the capture keeps a SIGPIPE under pipefail from reading as "no
@@ -579,10 +610,10 @@ root_on_dm_crypt() {
 
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline effective_cmdline entry uki_cmdline param root_uuid subvol uki
+  local cmdline effective_cmdline limine_conf uki_cmdline param root_uuid subvol uki
   local boot_params=()
   local missing=()
-  local have_root=0 have_mount_mode=0 have_unlock=0 encrypted_root=0 limine_boots=0
+  local have_root=0 have_mount_mode=0 have_unlock=0 encrypted_root=0
 
   command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
   as_root test -f /boot/limine.conf || return 0
@@ -689,20 +720,8 @@ EOF
     boot_cmdline_unsafe=1
   fi
 
-  # Judged one entry at a time: the file lists them all, and a root= in one
-  # entry with the selector in another composes into nothing that boots.
-  # Comments are skipped so a disabled line cannot vouch for a live one.
-  while IFS= read -r entry; do
-    entry=${entry#"${entry%%[![:space:]]*}"}
-    if [[ $entry == \#* ]]; then
-      continue
-    fi
-    if cmdline_boots "$entry" "$encrypted_root"; then
-      limine_boots=1
-      break
-    fi
-  done < <(as_root cat /boot/limine.conf 2>/dev/null || true)
-  ((limine_boots)) || missing+=(/boot/limine.conf)
+  limine_conf=$(as_root cat /boot/limine.conf 2>/dev/null || true)
+  limine_conf_boots "$limine_conf" "$encrypted_root" || missing+=(/boot/limine.conf)
 
   # The cmdline that boots is the one embedded in the UKIs, so check those too.
   if command -v objcopy >/dev/null 2>&1; then

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -517,15 +517,79 @@ normalize_limine_config() {
   fi
 }
 
+root_param_regex='(^|[[:space:]])root=([^[:space:]]*)'
+
+# Naming an encrypted volume is what tells the initramfs to unlock it, so only
+# these prove a cmdline can reach an encrypted root. Keyfiles, ciphers and
+# crypttab switches modify an unlock selected elsewhere; on their own they
+# unlock nothing, so they must not vouch for a cmdline. A value is required:
+# a bare rd.luks.uuid= selects no volume either.
+unlock_selector_regex='(^|[[:space:]])(cryptdevice|dm-mod\.create|(rd\.)?luks\.(name|uuid))=[^[:space:]]'
+
+# Everything the unlock depends on, which is broader than what proves it:
+# these have to survive into the rebuilt cmdline even though none of them
+# names a volume by itself. crypto= carries the cipher for a plain dm-crypt
+# root, and rd.luks.data=/rd.luks.options= carry a detached header.
+unlock_param_regex='(^|[[:space:]])(cryptdevice|cryptkey|crypto|dm-mod\.create|(rd\.)?luks\.(name|uuid|data|key|options|crypttab))='
+
+# Whether a kernel cmdline can reach the root filesystem at all. An encrypted
+# root needs a selector as well as root=, because root= alone names a
+# /dev/mapper node the initramfs will never create and the boot then fails
+# before root is mounted — no emergency shell, no journal, nothing to debug
+# from afterwards (#6728).
+#
+# Judges one entry at a time. A root= in one boot entry and a selector in
+# another compose into nothing bootable, so callers must not hand it a whole
+# file.
+cmdline_boots() {
+  local text="$1" encrypted="$2" root_value
+
+  [[ $text =~ $root_param_regex ]] || return 1
+  root_value=${BASH_REMATCH[2]}
+  ((encrypted)) || return 0
+
+  # Matched first: the selector test overwrites BASH_REMATCH.
+  if [[ $text =~ $unlock_selector_regex ]]; then
+    return 0
+  fi
+
+  # Without a selector the cmdline still boots when root= names the encrypted
+  # container itself — mkinitcpio's encrypt hook opens it as /dev/mapper/root
+  # when cryptdevice= is absent, and Booster does the same. It is a root=
+  # naming a mapper node with nothing to create it that cannot boot. A root=
+  # naming the filesystem inside the container is unbootable too, but telling
+  # that apart from a container needs the disk, so it is left approved rather
+  # than guessed at.
+  [[ $root_value != /dev/mapper/* && $root_value != /dev/dm-* ]]
+}
+
+# lsblk -s walks the parents, where the crypt layer hides on LVM-on-LUKS;
+# --nofsroot keeps findmnt from appending a btrfs subvolume lsblk cannot
+# resolve; the capture keeps a SIGPIPE under pipefail from reading as "no
+# crypt layer".
+root_on_dm_crypt() {
+  local root_source root_stack
+
+  root_source=$(findmnt -no SOURCE --nofsroot / 2>/dev/null || true)
+  [[ -n $root_source ]] || return 1
+
+  root_stack=$(lsblk -nso TYPE "$root_source" 2>/dev/null || true)
+  grep -qx crypt <<<"$root_stack"
+}
+
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key root_source root_stack root_uuid subvol uki
+  local cmdline effective_cmdline entry uki_cmdline param root_uuid subvol uki
   local boot_params=()
   local missing=()
-  local have_root=0 have_mount_mode=0 have_unlock=0
+  local have_root=0 have_mount_mode=0 have_unlock=0 encrypted_root=0 limine_boots=0
 
   command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
   as_root test -f /boot/limine.conf || return 0
+
+  if root_on_dm_crypt; then
+    encrypted_root=1
+  fi
 
   # The omarchy-defaults.conf drop-in appends to KERNEL_CMDLINE[default] with
   # +=, which makes limine-entry-tool ignore /etc/kernel/cmdline and
@@ -534,8 +598,8 @@ preserve_kernel_cmdline_root() {
   # boot lands in an emergency shell. Ask the tool for its effective default
   # cmdline — the key this function appends to — rather than parsing the config
   # layers ourselves.
-  if as_root limine-entry-tool --get-cmdline default 2>/dev/null |
-    grep -qE '(^|[[:space:]])root='; then
+  effective_cmdline=$(as_root limine-entry-tool --get-cmdline default 2>/dev/null || true)
+  if cmdline_boots "$effective_cmdline" "$encrypted_root"; then
     return 0
   fi
 
@@ -543,18 +607,24 @@ preserve_kernel_cmdline_root() {
   # PARTUUID, a LABEL or a bare device node all survive.
   cmdline=$(cat /proc/cmdline 2>/dev/null || true)
   for param in $cmdline; do
-    key=${param%%=*}
-    case $key in
+    # Copied on the broad expression, counted on the narrow one: a cipher or a
+    # keyfile has to survive into the new cmdline, but only a selector means
+    # the running kernel had enough to unlock with.
+    if [[ $param =~ $unlock_param_regex ]]; then
+      boot_params+=("$param")
+      if [[ $param =~ $unlock_selector_regex ]]; then
+        have_unlock=1
+      fi
+      continue
+    fi
+
+    case ${param%%=*} in
       root)
         have_root=1
         boot_params+=("$param")
         ;;
       rw | ro)
         have_mount_mode=1
-        boot_params+=("$param")
-        ;;
-      cryptdevice | cryptkey | rd.luks.name | rd.luks.uuid | rd.luks.options | rd.luks.key | rd.luks.crypttab | dm-mod.create)
-        have_unlock=1
         boot_params+=("$param")
         ;;
       rootflags | rootfstype | rootwait | rootdelay | resume | resume_offset | rd.lvm.lv | rd.lvm.vg | rd.md.uuid | rd.dm.uuid)
@@ -565,15 +635,11 @@ preserve_kernel_cmdline_root() {
 
   # Already-broken system (booted through the emergency shell): derive root=
   # from the mounted root instead. Refuse when the root sits on dm-crypt and
-  # the cmdline carries no unlock parameters, since root= alone would still not
-  # boot. lsblk -s walks the parents, where the crypt layer hides on
-  # LVM-on-LUKS; --nofsroot keeps findmnt from appending a btrfs subvolume
-  # lsblk cannot resolve; the capture keeps a SIGPIPE under pipefail from
-  # reading as "no crypt layer".
+  # nothing selects the volume to unlock: the UUID of a mounted encrypted root
+  # is the one *inside* the container, which resolves only once the container
+  # is already open, so there is nothing to derive that would boot.
   if ((!have_root)); then
-    root_source=$(findmnt -no SOURCE --nofsroot / 2>/dev/null || true)
-    root_stack=$(lsblk -nso TYPE "$root_source" 2>/dev/null || true)
-    if grep -qx crypt <<<"$root_stack" && ((!have_unlock)); then
+    if ((encrypted_root && !have_unlock)); then
       warn "The root filesystem is on dm-crypt and the booted kernel cmdline carries no unlock parameters, so they cannot be recovered automatically. Add root= and the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, then run limine-mkinitcpio."
       boot_cmdline_unsafe=1
       return 0
@@ -596,6 +662,17 @@ preserve_kernel_cmdline_root() {
     fi
   fi
 
+  # The line about to be written replaces one that may well have booted, so
+  # hold it to the same standard the verification below applies. Judging what
+  # was assembled rather than counting parameters keeps the encrypt hook's
+  # deprecated form — root= naming the container, no selector — from being
+  # refused as if it were the #6728 failure it resembles.
+  if ! cmdline_boots "${boot_params[*]}" "$encrypted_root"; then
+    warn "The kernel cmdline recovered from the running system cannot reach the root filesystem: root= names a device-mapper node and nothing on it says which encrypted volume to unlock. Add the matching cryptdevice or rd.luks.* parameters to $default_conf by hand, then run limine-mkinitcpio."
+    boot_cmdline_unsafe=1
+    return 0
+  fi
+
   log "Preserving the kernel cmdline root parameters in $default_conf"
   as_root tee -a "$default_conf" >/dev/null <<EOF
 # Written by omarchy-upgrade-to-quattro. The += drop-ins in
@@ -612,19 +689,36 @@ EOF
     boot_cmdline_unsafe=1
   fi
 
-  as_root grep -qE '(^|[[:space:]])root=' /boot/limine.conf || missing+=(/boot/limine.conf)
+  # Judged one entry at a time: the file lists them all, and a root= in one
+  # entry with the selector in another composes into nothing that boots.
+  # Comments are skipped so a disabled line cannot vouch for a live one.
+  while IFS= read -r entry; do
+    entry=${entry#"${entry%%[![:space:]]*}"}
+    if [[ $entry == \#* ]]; then
+      continue
+    fi
+    if cmdline_boots "$entry" "$encrypted_root"; then
+      limine_boots=1
+      break
+    fi
+  done < <(as_root cat /boot/limine.conf 2>/dev/null || true)
+  ((limine_boots)) || missing+=(/boot/limine.conf)
 
   # The cmdline that boots is the one embedded in the UKIs, so check those too.
   if command -v objcopy >/dev/null 2>&1; then
     while read -r uki; do
       [[ -n $uki ]] || continue
-      as_root objcopy -O binary --only-section=.cmdline "$uki" /dev/stdout 2>/dev/null |
-        tr -d '\0' | grep -E '(^|[[:space:]])root=' >/dev/null || missing+=("$uki")
+      uki_cmdline=$(as_root objcopy -O binary --only-section=.cmdline "$uki" /dev/stdout 2>/dev/null | tr -d '\0' || true)
+      cmdline_boots "$uki_cmdline" "$encrypted_root" || missing+=("$uki")
     done < <(as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi' 2>/dev/null)
   fi
 
   if ((${#missing[@]})); then
-    warn "root= is still missing from ${missing[*]}. Do not reboot until the kernel cmdline is repaired, or the system will drop to an emergency shell."
+    if ((encrypted_root)); then
+      warn "The kernel cmdline in ${missing[*]} cannot reach the root filesystem: root= or the cryptdevice/rd.luks.* parameters that unlock it are missing. Do not reboot until it is repaired, or the boot will fail before root is mounted."
+    else
+      warn "root= is still missing from ${missing[*]}. Do not reboot until the kernel cmdline is repaired, or the system will drop to an emergency shell."
+    fi
     boot_cmdline_unsafe=1
   fi
 }

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -195,11 +195,7 @@ grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
 grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null
 grep -F 'cmdline_boots "$uki_cmdline" "$encrypted_root"' "$upgrade_to_quattro" >/dev/null
 
-# /boot/limine.conf lists every entry, so it is judged one at a time: a root=
-# in one entry and a selector in another compose into nothing that boots.
-grep -F 'if cmdline_boots "$entry" "$encrypted_root"; then' "$upgrade_to_quattro" >/dev/null
-grep -F 'if [[ $entry == \#* ]]; then' "$upgrade_to_quattro" >/dev/null
-grep -F '((limine_boots)) || missing+=(/boot/limine.conf)' "$upgrade_to_quattro" >/dev/null
+grep -F 'limine_conf_boots "$limine_conf" "$encrypted_root" || missing+=(/boot/limine.conf)' "$upgrade_to_quattro" >/dev/null
 grep -F 'boot_cmdline_unsafe=1' "$upgrade_to_quattro" >/dev/null
 unsafe_line=$(grep -n 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" | cut -d: -f1)
 reboot_line=$(grep -n 'Rebooting because --reboot was passed' "$upgrade_to_quattro" | cut -d: -f1)
@@ -214,6 +210,7 @@ pass "Omarchy 4 upgrade verifies the UKIs and refuses to reboot unverified"
 cmdline_logic=$(
   grep -E '^(root_param_regex|unlock_selector_regex)=' "$upgrade_to_quattro"
   sed -n '/^cmdline_boots() {$/,/^}$/p' "$upgrade_to_quattro"
+  sed -n '/^limine_conf_boots() {$/,/^}$/p' "$upgrade_to_quattro"
 )
 grep -Fq 'cmdline_boots() {' <<<"$cmdline_logic" || fail "cmdline_boots is liftable from the upgrade script"
 eval "$cmdline_logic"
@@ -236,8 +233,6 @@ assert_stuck "no root= boots nothing" "quiet splash rw" 0
 assert_stuck "root= alone does not boot an encrypted root" "root=/dev/mapper/root rw" 1
 assert_stuck "a /dev/dm- node needs a selector too" "root=/dev/dm-0 rw" 1
 assert_boots "cryptdevice= selects the volume" "cryptdevice=PARTUUID=x:root root=/dev/mapper/root rw" 1
-assert_boots "rd.luks.uuid= selects the volume" "rd.luks.uuid=abc root=/dev/mapper/root rw" 1
-assert_boots "luks.name= selects the volume" "luks.name=abc=root root=/dev/mapper/root rw" 1
 assert_boots "dm-mod.create= creates the mapper" "root=/dev/mapper/root dm-mod.create=x rw" 1
 
 # Keyfiles, ciphers and crypttab switches modify an unlock chosen elsewhere.
@@ -245,7 +240,19 @@ assert_boots "dm-mod.create= creates the mapper" "root=/dev/mapper/root dm-mod.c
 assert_stuck "a keyfile alone selects no volume" "root=/dev/mapper/root cryptkey=rootfs:/key" 1
 assert_stuck "crypttab handling alone selects no volume" "root=/dev/mapper/root rd.luks.crypttab=0" 1
 assert_stuck "unlock options alone select no volume" "root=/dev/mapper/root rd.luks.options=discard" 1
-assert_stuck "a selector without a value selects no volume" "root=/dev/mapper/root rd.luks.uuid=" 1
+assert_stuck "a selector without a value selects no volume" "root=/dev/mapper/root cryptdevice=" 1
+
+# rd.luks.*/luks.* are systemd's. Omarchy builds its initramfs with the busybox
+# encrypt hook, which reads only cryptdevice, cryptkey and crypto, so a machine
+# carrying one of these and nothing else must not be approved for a reboot.
+assert_stuck "rd.luks.uuid= does not unlock an encrypt-hook initramfs" "rd.luks.uuid=abc root=/dev/mapper/root rw" 1
+assert_stuck "luks.name= does not unlock an encrypt-hook initramfs" "luks.name=abc=root root=/dev/mapper/root rw" 1
+
+# getarg reads the cmdline with tail -1, so a later root= overrides an earlier
+# one and the last value is the one that has to be judged.
+assert_stuck "the last root= is the one that counts" "root=UUID=abc root=/dev/mapper/root rw" 1
+assert_boots "an overridden mapper root= is not held against it" "root=/dev/mapper/root root=UUID=abc rw" 1
+assert_stuck "a bare root= names nothing" "root= rw" 0
 
 # The encrypt hook opens root= itself when cryptdevice= is absent, so a root=
 # naming the container rather than a mapper node still boots.
@@ -255,9 +262,36 @@ assert_boots "root= may name the encrypted container itself" "root=UUID=abc rw" 
 assert_stuck "a parameter merely ending in root= is not root=" "subroot=/dev/sda rw" 0
 assert_stuck "a parameter merely ending in cryptdevice= does not select" "root=/dev/mapper/root xcryptdevice=y" 1
 
-# /boot/limine.conf is judged one entry at a time, which is what stops a root=
-# in one entry and a selector in another from vouching for each other. Neither
-# half passes alone, so the loop over the file finds nothing bootable.
-assert_stuck "an entry carrying only root= does not boot" "  cmdline: root=/dev/mapper/root rw" 1
-assert_stuck "an entry carrying only a selector does not boot" "  cmdline: cryptdevice=x:root" 1
 pass "the kernel cmdline judgement requires a selector for an encrypted root"
+
+assert_conf_boots() {
+  limine_conf_boots "$2" "$3" || fail "$1"
+}
+
+assert_conf_stuck() {
+  if limine_conf_boots "$2" "$3"; then
+    fail "$1"
+  fi
+}
+
+assert_conf_boots "a working entry is found" $'/Omarchy\n  protocol: linux\n  cmdline: cryptdevice=x:root root=/dev/mapper/root rw' 1
+assert_conf_boots "an unencrypted entry needs only root=" $'/Omarchy\n  cmdline: root=UUID=abc rw' 0
+assert_conf_stuck "no entry at all boots nothing" $'/Omarchy\n  protocol: linux' 1
+
+# The whole point of judging per entry: neither half is bootable alone, so a
+# root= in one entry must not be rescued by a selector in another.
+assert_conf_stuck "one entry's selector does not rescue another's root=" \
+  $'/Omarchy\n  cmdline: root=/dev/mapper/root rw\n/Snapshot\n  cmdline: cryptdevice=x:root' 1
+
+# Only cmdline: keys are the kernel command line. A title, a path, a comment or
+# a module_cmdline: must not vouch for a broken entry.
+assert_conf_stuck "a commented example does not vouch for a live entry" \
+  $'#cmdline: cryptdevice=x:root root=/dev/mapper/root\n  cmdline: root=/dev/mapper/root rw' 1
+assert_conf_stuck "a module_cmdline: is not the kernel command line" \
+  $'  module_cmdline: cryptdevice=x:root root=/dev/mapper/root' 1
+
+# A generated file need not end in a newline, and dropping its last line would
+# refuse a machine that boots.
+printf -v unterminated '/Omarchy\n  cmdline: cryptdevice=x:root root=/dev/mapper/root rw'
+assert_conf_boots "a final line without a trailing newline is read" "$unterminated" 1
+pass "limine.conf is judged one boot entry at a time"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -152,28 +152,112 @@ grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 
 # The += drop-ins make limine-entry-tool ignore /etc/kernel/cmdline and
-# /proc/cmdline, so only the tool's own merge can say whether root= survives.
-# Queried for the default key, so a kernel-specific pin cannot cover for the
-# entries this repairs.
+# /proc/cmdline, so only the tool's own merge can say whether the cmdline
+# survives. Queried for the default key, so a kernel-specific pin cannot cover
+# for the entries this repairs, and judged by cmdline_boots so root= alone
+# cannot pass for an encrypted machine.
 grep -F 'limine-entry-tool --get-cmdline default' "$upgrade_to_quattro" >/dev/null
-grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null
-pass "Omarchy 4 upgrade asks limine-entry-tool whether root= survives"
+grep -F 'if cmdline_boots "$effective_cmdline" "$encrypted_root"; then' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade asks limine-entry-tool whether the cmdline still boots"
+
+# The line about to be written is judged before it replaces one that may have
+# booted, by the same predicate that guards and verifies.
+grep -F 'if ! cmdline_boots "${boot_params[*]}" "$encrypted_root"; then' "$upgrade_to_quattro" >/dev/null
+write_check_line=$(grep -n 'if ! cmdline_boots "${boot_params\[\*\]}" "\$encrypted_root"; then' "$upgrade_to_quattro" | cut -d: -f1)
+write_line=$(grep -n 'log "Preserving the kernel cmdline root parameters in \$default_conf"' "$upgrade_to_quattro" | cut -d: -f1)
+[[ -n $write_check_line && -n $write_line ]] || fail "the assembled cmdline is checked and written"
+(( write_check_line < write_line )) || fail "the assembled cmdline is checked before it is written"
+pass "Omarchy 4 upgrade refuses to write a cmdline that cannot reach root"
 
 # The crypt layer hides in the parents on LVM-on-LUKS, and a partial cmdline
-# for an encrypted root must not be written at all.
+# for an encrypted root must not be written at all — whichever half was
+# missing, not just when root= has to be derived.
 grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null
 grep -F 'lsblk -nso TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null
 grep -F 'grep -qx crypt' "$upgrade_to_quattro" >/dev/null
 grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
+refusal_line=$(grep -n 'if ((encrypted_root && !have_unlock)); then' "$upgrade_to_quattro" | cut -d: -f1)
+derive_line=$(grep -n 'root_uuid=$(findmnt -no UUID / 2>/dev/null || true)' "$upgrade_to_quattro" | cut -d: -f1)
+[[ -n $refusal_line && -n $derive_line ]] || fail "dm-crypt refusal and root= derivation exist"
+(( refusal_line < derive_line )) || fail "an unlockable cmdline is required before root= is derived"
 pass "Omarchy 4 upgrade repair path refuses a partial dm-crypt cmdline"
 
+# have_unlock decides whether the derived root= can ever be opened, so only a
+# selector may set it. A keyfile or a cipher unlocks nothing on its own, and
+# counting one would derive the inner UUID of a container nothing opens.
+grep -F 'if [[ $param =~ $unlock_selector_regex ]]; then' "$upgrade_to_quattro" >/dev/null
+grep -F 'have_unlock=1' "$upgrade_to_quattro" >/dev/null
+pass "Omarchy 4 upgrade counts only a selector as proof the root can be unlocked"
+
 # The cmdline that boots is the one embedded in the UKIs, and an unverified
-# root= must block the reboot rather than just warn.
+# cmdline must block the reboot rather than just warn.
 grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
 grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null
+grep -F 'cmdline_boots "$uki_cmdline" "$encrypted_root"' "$upgrade_to_quattro" >/dev/null
+
+# /boot/limine.conf lists every entry, so it is judged one at a time: a root=
+# in one entry and a selector in another compose into nothing that boots.
+grep -F 'if cmdline_boots "$entry" "$encrypted_root"; then' "$upgrade_to_quattro" >/dev/null
+grep -F 'if [[ $entry == \#* ]]; then' "$upgrade_to_quattro" >/dev/null
+grep -F '((limine_boots)) || missing+=(/boot/limine.conf)' "$upgrade_to_quattro" >/dev/null
 grep -F 'boot_cmdline_unsafe=1' "$upgrade_to_quattro" >/dev/null
 unsafe_line=$(grep -n 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" | cut -d: -f1)
 reboot_line=$(grep -n 'Rebooting because --reboot was passed' "$upgrade_to_quattro" | cut -d: -f1)
 [[ -n $unsafe_line && -n $reboot_line ]] || fail "reboot gate and reboot branch exist"
 (( unsafe_line < reboot_line )) || fail "an unverified kernel cmdline blocks the reboot"
 pass "Omarchy 4 upgrade verifies the UKIs and refuses to reboot unverified"
+
+# Every judgement above routes through cmdline_boots, so exercise it directly:
+# sourcing the upgrade script would run the upgrade, and the decision is what
+# the machine's next boot depends on. Lifted whole, so a rewrite that drops the
+# unlock check fails here rather than in a reader's boot loop.
+cmdline_logic=$(
+  grep -E '^(root_param_regex|unlock_selector_regex)=' "$upgrade_to_quattro"
+  sed -n '/^cmdline_boots() {$/,/^}$/p' "$upgrade_to_quattro"
+)
+grep -Fq 'cmdline_boots() {' <<<"$cmdline_logic" || fail "cmdline_boots is liftable from the upgrade script"
+eval "$cmdline_logic"
+
+assert_boots() {
+  cmdline_boots "$2" "$3" || fail "$1"
+}
+
+assert_stuck() {
+  if cmdline_boots "$2" "$3"; then
+    fail "$1"
+  fi
+}
+
+assert_boots "a plain root= boots an unencrypted machine" "root=UUID=abc rw" 0
+assert_stuck "no root= boots nothing" "quiet splash rw" 0
+
+# #6728: root= names a mapper node, and without a selector nothing creates it,
+# so the boot dies before root is mounted and leaves no journal behind.
+assert_stuck "root= alone does not boot an encrypted root" "root=/dev/mapper/root rw" 1
+assert_stuck "a /dev/dm- node needs a selector too" "root=/dev/dm-0 rw" 1
+assert_boots "cryptdevice= selects the volume" "cryptdevice=PARTUUID=x:root root=/dev/mapper/root rw" 1
+assert_boots "rd.luks.uuid= selects the volume" "rd.luks.uuid=abc root=/dev/mapper/root rw" 1
+assert_boots "luks.name= selects the volume" "luks.name=abc=root root=/dev/mapper/root rw" 1
+assert_boots "dm-mod.create= creates the mapper" "root=/dev/mapper/root dm-mod.create=x rw" 1
+
+# Keyfiles, ciphers and crypttab switches modify an unlock chosen elsewhere.
+# Taking one for proof would approve a cmdline that opens no volume at all.
+assert_stuck "a keyfile alone selects no volume" "root=/dev/mapper/root cryptkey=rootfs:/key" 1
+assert_stuck "crypttab handling alone selects no volume" "root=/dev/mapper/root rd.luks.crypttab=0" 1
+assert_stuck "unlock options alone select no volume" "root=/dev/mapper/root rd.luks.options=discard" 1
+assert_stuck "a selector without a value selects no volume" "root=/dev/mapper/root rd.luks.uuid=" 1
+
+# The encrypt hook opens root= itself when cryptdevice= is absent, so a root=
+# naming the container rather than a mapper node still boots.
+assert_boots "root= may name the encrypted container itself" "root=UUID=abc rw" 1
+
+# Parameters are matched whole, or a substring would pass an unbootable machine.
+assert_stuck "a parameter merely ending in root= is not root=" "subroot=/dev/sda rw" 0
+assert_stuck "a parameter merely ending in cryptdevice= does not select" "root=/dev/mapper/root xcryptdevice=y" 1
+
+# /boot/limine.conf is judged one entry at a time, which is what stops a root=
+# in one entry and a selector in another from vouching for each other. Neither
+# half passes alone, so the loop over the file finds nothing bootable.
+assert_stuck "an entry carrying only root= does not boot" "  cmdline: root=/dev/mapper/root rw" 1
+assert_stuck "an entry carrying only a selector does not boot" "  cmdline: cryptdevice=x:root" 1
+pass "the kernel cmdline judgement requires a selector for an encrypted root"


### PR DESCRIPTION
`preserve_kernel_cmdline_root` verifies its own work before letting the upgrade reboot: it greps `/boot/limine.conf` and each generated UKI, and an unverified result sets `boot_cmdline_unsafe` and blocks `--reboot`. That check greped for `root=` and nothing else, so it could not tell an encrypted machine that boots from one that cannot.

That is the wrong shape for a safety net, because #6579's history is this exact failure three times over — the repair logic writing an encrypted command line that satisfied the final check and still dropped the user in an emergency shell:

> On an encrypted root, findmnt reports the unlocked mapper device, whose UUID says nothing about which container to unlock. Emitting it produced a cmdline that still could not boot while satisfying the final check, so the user rebooted into the same emergency shell believing it was repaired.

Then again for LVM-on-LUKS, where the crypt layer hid in the parents; then again for the bracketed btrfs source `lsblk` couldn't resolve. Each time the derive logic was fixed and the net that was supposed to catch it stayed blind in the same place — a `root=` naming a `/dev/mapper` node with nothing on the command line to create it.

The function already knew an encrypted root needs both halves. It collects the unlock parameters and refuses to guess without them, but that knowledge lived only in the derive branch, and the verification, the early-return guard, and the write path each made their own weaker judgement.

**Scope, stated honestly:** no Omarchy code path currently produces a `root=` without a selector — the ISO substitutes the whole installer command line, the upgrade writes the whole harvested set, and every other drop-in adds non-root parameters only. The early-return guard's blind spot is therefore reachable only by a hand-edited config (`/etc/limine-entry-tool.conf:53` ships `#KERNEL_CMDLINE[default]+=rw root=UUID=...` as a commented example) or a limine install not provisioned by Omarchy. This PR is hardening a check that gates an automatic reboot, not a fix for a reproduced field failure.

## What changed

One predicate, `cmdline_boots`, now decides whether any command line can reach root, and it governs the guard, the line assembled from the running kernel before it is written, and the post-build verification of `/boot/limine.conf` and every UKI.

**Only a selector counts as proof.** `cryptdevice=` and `dm-mod.create=` name a volume to unlock. Keyfiles, ciphers and crypttab switches modify an unlock chosen elsewhere and open nothing on their own, so a cmdline carrying only `cryptkey=` or `rd.luks.options=` no longer passes, and a valueless `cryptdevice=` doesn't either.

`rd.luks.*`/`luks.*` are deliberately not selectors. They are systemd's, and Omarchy builds its initramfs with the busybox `encrypt` hook, which reads only `cryptdevice`, `cryptkey` and `crypto` — `grep rd.luks /usr/lib/initcpio/hooks/encrypt` returns nothing. Treating one as proof would approve a reboot into an initramfs that cannot act on it. They are still copied forward, along with `crypto=` and `rd.luks.data=` for plain-mode and detached-header roots, which the old copy loop dropped outright.

**The last `root=` is the one judged.** `getarg` reads the command line with `tail -1`, so a later `root=` overrides an earlier one; the predicate walks to the final occurrence rather than the first.

**What gets refused stays narrow.** mkinitcpio's `encrypt` hook opens `root=` itself when `cryptdevice=` is absent ([hooks/encrypt](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/install/encrypt) sets `DEPRECATED_CRYPT=1` and uses `root` as the container), so a `root=` naming the container rather than a mapper node still passes rather than collecting a warning. `/boot/limine.conf` is judged one entry at a time, reading the `cmdline:` keys and nothing else, because a `root=` in one entry and a selector in another compose into nothing that boots — and a title, a path, a `module_cmdline:` or the commented example in `/etc/limine-entry-tool.conf` must not vouch for a broken entry.

**Known limits, left in place deliberately.** A `root=UUID=…` naming the filesystem *inside* the container is unbootable but still approved: telling that apart from the container needs the disk, and the old check approved it too. A `cryptdevice=` whose mapper name doesn't match the one `root=` asks for is likewise approved — the parameters are harvested from a machine that booted, so a mismatch there is close to unreachable, and parsing the field to check would add more failure modes than it removes.

A `root=` naming the filesystem *inside* the container is unbootable too, but telling that apart from a container needs the disk, so it is left approved rather than guessed at — same as before this change.

## Notes

- The refusal moved into the `((!have_root))` branch it originally guarded, so nothing that previously wrote a cmdline is newly blocked; the `have_root` path is judged by the predicate instead, which is why the deprecated `encrypt` form doesn't trip it.
- An earlier revision of this branch exempted machines with `/etc/crypttab.initramfs`. That was wrong and is gone: only `sd-encrypt` copies that file into the image, and Omarchy ships the busybox `encrypt` hook, so the exemption would have let the derive path write a root-only cmdline for a machine that cannot use it.
- `omarchy-provision-owner` and `omarchy-system-factory-reset` write a standalone `cryptkey=rootfs:...` drop-in. Under a single broad expression that would have counted as proof the root could be unlocked; the selector/modifier split handles it correctly.
- `cmdline_boots` and its regexes are lifted out of the script and exercised directly in the test — sourcing the script would run the upgrade. Regressing the predicate back to `root=`-only makes the suite fail.

Refs #6728, which is what sent me looking here. I have not established that it is the cause of that report: a machine taking the normal upgrade path harvests `cryptdevice=` from `/proc/cmdline`, so the reporter's UKI should have carried it. The full `.cmdline` of their failing image would settle it either way.

— 🤖 Claude, posting on behalf of @dhh
