### PR TITLE
Keep shell tests inside their fixtures

### DIFF
--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+# The command fixture follows the runtime invariant and reads defaults through
+# OMARCHY_PATH. Point it at this checkout rather than whichever install launched
+# the test (or nothing at all on a non-Omarchy development machine).
+export OMARCHY_PATH="$ROOT"
+
 if perl -0ne 'exit(/drag\s*\.\s*target\s*:\s*[^;]*\bslot\b/s ? 0 : 1)' "$ROOT/shell/plugins/bar/Bar.qml"; then
   fail "bar module dragging must not mutate ModuleSlot positions"
 fi

--- a/test/shell.d/monitor-clamshell-scale-test.sh
+++ b/test/shell.d/monitor-clamshell-scale-test.sh
@@ -46,6 +46,11 @@ cat >"$stub_bin/omarchy-hyprland-monitor-internal-mirror" <<'SH'
 exit 0
 SH
 
+cat >"$stub_bin/omarchy-hyprland-monitor-laptop" <<'SH'
+#!/bin/bash
+echo eDP-1
+SH
+
 cat >"$stub_bin/omarchy-hyprland-monitor-external-active" <<'SH'
 #!/bin/bash
 [[ ${OMARCHY_TEST_EXTERNAL_ACTIVE:-false} == "true" ]]


### PR DESCRIPTION
The shell tests should not depend on the machine that happens to run them. These two fixtures were still borrowing state from an installed Omarchy environment.

<<< AI wording below >>>

## Problem

Two shell tests only passed reliably when launched from an already configured Omarchy session:

- the bar fixture inherited `OMARCHY_PATH`, so it failed when that runtime variable was absent and could read defaults from the installed tree when it pointed elsewhere
- the clamshell fixture never stubbed `omarchy-hyprland-monitor-laptop`, so it called the host detector and based its fake-monitor assertions on real hardware

This made clean-VM runs fail while Omarchy-hosted runs could hide the fixture gaps.

## Fix

Point the bar fixture at the checkout it is testing, and make the clamshell fixture return its declared fake laptop panel.

Runtime code is unchanged.

## Verification

- `env -u OMARCHY_PATH PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bash test/shell.d/bar-test.sh`
- `env -u OMARCHY_PATH PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bash test/shell.d/monitor-clamshell-scale-test.sh`
- `bash -n test/shell.d/bar-test.sh test/shell.d/monitor-clamshell-scale-test.sh`
- `git diff --check`