### PR TITLE
Stop ttfx before closing the screensaver terminal

### DIFF
--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -20,4 +20,5 @@ if pgrep -x "1password" >/dev/null && omarchy-cmd-present 1password; then
 fi
 
 # Avoid running screensaver when locked
+pkill -x ttfx 2>/dev/null || true
 pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null || true

--- a/test/shell.d/system-lock-test.sh
+++ b/test/shell.d/system-lock-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+call_log="$tmpdir/calls"
+mkdir -p "$mock_bin"
+
+for command in omarchy-shell hyprctl pkill; do
+  cat >"$mock_bin/$command" <<'SH'
+#!/bin/bash
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$CALL_LOG"
+SH
+done
+
+cat >"$mock_bin/pgrep" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$mock_bin"/*
+
+PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-lock"
+mapfile -t kills < <(rg '^pkill ' "$call_log")
+
+[[ ${kills[0]} == "pkill -x ttfx" ]] ||
+  fail "system lock stops ttfx before closing its terminal" "calls: ${kills[*]}"
+[[ ${kills[1]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
+  fail "system lock closes the screensaver terminal after ttfx" "calls: ${kills[*]}"
+pass "system lock stops ttfx before closing its terminal"


### PR DESCRIPTION
Fixes #6762.

`omarchy-system-lock` currently kills the screensaver terminal while `ttfx` is still rendering. Closing the PTY makes the next frame write return `EIO`; reporting that error to the same dead PTY then panics and writes a core dump.

Stop `ttfx` before closing the terminal, matching the existing dismissal path in `omarchy-screensaver`. Add a mocked command-order regression test so the lock path can be exercised without locking the test session.

— 🤖 Claude, posting on behalf of @dhh