### PR TITLE
fix(hypr): scale the floating agent window with the monitor

### DIFF
--- a/default/hypr/apps/agent.lua
+++ b/default/hypr/apps/agent.lua
@@ -1,3 +1,4 @@
 -- omarchy-agent gives every agent terminal the same app-id, so this
--- floats the keybinding, the menu, and a crash diagnosis alike.
-o.window("org\\.omarchy\\.agent", { float = true, center = true, size = { 1200, 800 } })
+-- floats the keybinding, the menu, and a crash diagnosis alike. The size
+-- scales with the monitor instead of pinning one pixel count everywhere.
+o.window("org\\.omarchy\\.agent", { float = true, center = true, size = { "(monitor_w*3/5)", "(monitor_h*4/5)" } })


### PR DESCRIPTION
The agent window rule pinned every agent terminal to a fixed 1200x800 float. On small screens that overflows the monitor (on a 1366x768 laptop the window was taller than the screen), and on large ones it stays arbitrarily small.

Scale it with the monitor instead, using the same windowrule expressions `pip.lua` and `webcam-overlay.lua` already rely on: 3/5 of the monitor width by 4/5 of its height, still floated and centered.

Verified live on a 1366x768 session: the window now opens 820x614, centered, and `test/shell.d/default-agent-test.sh` passes.