### PR TITLE
Open the agent in a normal tiled window

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -100,6 +100,6 @@ if [[ $inline == "true" ]]; then
   exec "${command[@]}"
 else
   # A fixed app-id rather than the default org.omarchy.<binary>, so every agent
-  # window shares one class for default/hypr/apps/agent.lua to float.
+  # window shares one class for window rules and themes to single out.
   exec omarchy-launch-tui --app-id=org.omarchy.agent "${command[@]}"
 fi

--- a/default/hypr/apps/agent.lua
+++ b/default/hypr/apps/agent.lua
@@ -1,3 +1,0 @@
--- omarchy-agent gives every agent terminal the same app-id, so this
--- floats the keybinding, the menu, and a crash diagnosis alike.
-o.window("org\\.omarchy\\.agent", { float = true, center = true, size = { 1200, 800 } })

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -316,7 +316,7 @@ assert_launched() {
   local description=$2
   shift 2
   # Every agent window launches under the same app-id, whichever agent is
-  # default, so default/hypr/apps/agent.lua can float them all.
+  # default, so window rules and themes see one class for all of them.
   local expected=(--app-id=org.omarchy.agent "$@")
 
   mapfile -d '' -t actual <"$launch_log"


### PR DESCRIPTION
The agent terminal floated at a fixed 1200x800, which overflows small and scaled displays. Window rules see logical pixels, not physical ones, so a 2560x1440 monitor at scale 1.6 is only 1600x900 to Hyprland and the window covered 89% of its height. This drops the floating rule entirely and lets the agent tile like any other window, which takes the fixed size with it.

Tiling here is the absence of a rule, the same way `TUI.tile` differs from `TUI.float` and how `org.omarchy.lazydocker` and `org.omarchy.cliamp` already open, so `default/hypr/apps/agent.lua` goes away rather than growing a smarter size expression. The shared `org.omarchy.agent` app-id is still worth keeping: `terminals.lua` matches `org\.omarchy\..*`, so the window keeps its `+terminal` tag and the terminal copy/paste chords and theme opacity that come with it.

Supersedes #6766, which approached the same overflow by deriving the size from the monitor.

One behavior change worth noting: the crash diagnosis notification opens the agent while you are in another app, so it now takes a tile in the current workspace instead of popping over what you were doing.

— 🤖 Claude, posting on behalf of @dhh