### PR TITLE
Stop closed network panels from leaving Wi-Fi scanning enabled

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -292,6 +292,29 @@ Panel {
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
 
+  // scannerEnabled lives on the shared WifiDevice, which has no reference
+  // counting, and a bar widget is instantiated once per monitor. Tracking the
+  // device this instance turned scanning on for keeps the release correct when
+  // the panel closes, the device is replaced, or the widget is destroyed —
+  // without a closed instance ever claiming the scanner.
+  property var scannerDevice: null
+
+  function setScannerEnabled(enabled) {
+    var nextDevice = opened ? wifiDevice : null
+
+    if (scannerDevice && scannerDevice !== nextDevice)
+      scannerDevice.scannerEnabled = false
+
+    scannerDevice = nextDevice
+
+    if (scannerDevice)
+      scannerDevice.scannerEnabled = enabled
+  }
+
+  Component.onDestruction: {
+    if (scannerDevice) scannerDevice.scannerEnabled = false
+  }
+
   // KeyboardPanel primes layer-shell focus whenever the panel opens. That's
   // what makes the SUPER+CTRL+W keybind land here with navigation ready.
   onOpenedChanged: {
@@ -305,6 +328,10 @@ Panel {
       syncBandIndex()
       cursorActive = false
     } else {
+      // Drop a restart armed by this open: without it a close/reopen inside
+      // the 100ms window reuses the running timer and re-enables the scanner
+      // almost immediately, undoing the deferral #6605 restored.
+      scanRestart.stop()
       // Reset throughput tracking so the next open doesn't compute a fake
       // rate from a sample taken minutes ago.
       prevSampleTime = 0
@@ -316,7 +343,7 @@ Panel {
       routerPingLatency = -1
       internetPingLatency = -1
       internetPingPacketLoss = 0
-      if (wifiDevice) wifiDevice.scannerEnabled = false
+      setScannerEnabled(false)
     }
   }
 
@@ -357,7 +384,7 @@ Panel {
   }
 
   onWifiDeviceChanged: {
-    if (wifiDevice) wifiDevice.scannerEnabled = opened
+    setScannerEnabled(true)
     syncWifiNetworks()
   }
 
@@ -452,13 +479,15 @@ Panel {
       bandProc.command = ["omarchy-network-band"]
       bandProc.running = true
     }
-    if (wifiDevice) {
+    // A closed panel has no nearby-network list to fill, and bare refresh()
+    // reaches here from action completion, timeouts and construction.
+    if (opened && wifiDevice) {
       if (scanWifi) {
         scanning = true
-        wifiDevice.scannerEnabled = false
+        setScannerEnabled(false)
         scanRestart.start()
       } else {
-        wifiDevice.scannerEnabled = true
+        setScannerEnabled(true)
       }
     }
     syncWifiNetworks()
@@ -792,8 +821,10 @@ Panel {
     interval: 100
     repeat: false
     onTriggered: {
-      if (root.wifiDevice) root.wifiDevice.scannerEnabled = true
-      scanDone.start()
+      if (root.opened && root.wifiDevice) {
+        root.setScannerEnabled(true)
+        scanDone.start()
+      }
     }
   }
 

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -37,13 +37,43 @@ assert(/root\.opened/.test(scanRestart[0]), 'network re-checks the panel before 
 assert(/scanRestart\.stop\(\)/.test(panelSource), 'network cancels a pending scan restart when the panel closes')
 
 // scannerEnabled lives on a shared WifiDevice with no reference counting, so
-// the panel has to release the device it enabled — including when the widget
-// is destroyed with the panel still open, as a bar reload does.
+// the panel has to own what it enabled. Run the helper's own JavaScript against
+// stand-in devices: the two invariants it carries are that a closed panel never
+// takes a device, and that adopting a new one releases the previous.
+const scannerHelper = panelSource.match(/function setScannerEnabled\(enabled\) \{[\s\S]*?\n {2}\}/)
+assert(scannerHelper, 'network has a scanner ownership helper')
+
+var opened = false
+var wifiDevice = { scannerEnabled: false }
+var scannerDevice = null
+eval(scannerHelper[0])
+
+setScannerEnabled(true)
+assert(
+  scannerDevice === null && wifiDevice.scannerEnabled === false,
+  'network does not let a closed panel claim or enable a scanner device'
+)
+
+var previousScannerDevice = { scannerEnabled: true }
+var replacementScannerDevice = { scannerEnabled: false }
+opened = true
+scannerDevice = previousScannerDevice
+wifiDevice = replacementScannerDevice
+setScannerEnabled(true)
+assert(
+  previousScannerDevice.scannerEnabled === false &&
+    scannerDevice === replacementScannerDevice &&
+    replacementScannerDevice.scannerEnabled === true,
+  'network releases the previous scanner device before enabling its replacement'
+)
+
+// Destruction is the case a guard-only fix misses: the widget dies with the
+// panel still open, as a bar reload does, and nothing else would release it.
 assert(
   /Component\.onDestruction[\s\S]{0,140}scannerDevice\.scannerEnabled = false/.test(panelSource),
   'network releases the scanner it owns when the widget is destroyed'
 )
-assert(!/wifiDevice\.scannerEnabled\s*=/.test(panelSource), 'network routes every scanner write through setScannerEnabled() so the device it enabled is the device it releases')
+assert(!/wifiDevice\.scannerEnabled\s*=/.test(panelSource), 'network writes scanner state through its owned device reference rather than the moving wifiDevice reference')
 
 // A row is a primitive snapshot that can outlive its WifiNetwork, and
 // disconnect() falls back to the live connection when handed null, so row

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -21,6 +21,30 @@ assert(barPress, 'network bar button has an onPressed handler')
 const barPressCode = barPress[0].replace(/\/\/.*$/gm, '')
 assert(!/refresh\(/.test(barPressCode), 'network bar click opens the panel without a second refresh that would undo the deferred scan')
 
+// A closed panel has no nearby-network list to fill. Quickshell's scanner
+// re-arms RequestScan on its own timer, and every sweep takes the radio off
+// the operating channel, so a scanner left enabled behind a closed panel keeps
+// degrading the connection it is scanning from.
+const refreshFn = panelSource.match(/function refresh\(scanWifi\)[\s\S]*?\n {2}\}/)
+assert(refreshFn, 'network has a refresh() function')
+assert(/if \(opened && wifiDevice\)/.test(refreshFn[0]), 'network only touches the scanner from refresh() while its panel is open')
+
+// The 100ms deferral can outlive the panel: closing inside the window would
+// otherwise re-enable scanning from a timer nobody is watching.
+const scanRestart = panelSource.match(/id: scanRestart[\s\S]*?onTriggered: \{[\s\S]*?\n {4}\}/)
+assert(scanRestart, 'network has the deferred scan restart timer')
+assert(/root\.opened/.test(scanRestart[0]), 'network re-checks the panel before the deferred restart re-enables scanning')
+assert(/scanRestart\.stop\(\)/.test(panelSource), 'network cancels a pending scan restart when the panel closes')
+
+// scannerEnabled lives on a shared WifiDevice with no reference counting, so
+// the panel has to release the device it enabled — including when the widget
+// is destroyed with the panel still open, as a bar reload does.
+assert(
+  /Component\.onDestruction[\s\S]{0,140}scannerDevice\.scannerEnabled = false/.test(panelSource),
+  'network releases the scanner it owns when the widget is destroyed'
+)
+assert(!/wifiDevice\.scannerEnabled\s*=/.test(panelSource), 'network routes every scanner write through setScannerEnabled() so the device it enabled is the device it releases')
+
 // A row is a primitive snapshot that can outlive its WifiNetwork, and
 // disconnect() falls back to the live connection when handed null, so row
 // activation must go through the guarded disconnectRow().


### PR DESCRIPTION
## Problem

The network bar widget leaves Quickshell's Wi-Fi scanner running after its
panel is gone.

`refresh()` defaults `scanWifi` to `false`, and its no-scan branch enables the
scanner unconditionally:

```qml
} else {
  wifiDevice.scannerEnabled = true
}
```

Five paths reach that branch with no panel on screen:

- `Component.onCompleted` — every new instance, so any bar reload or monitor
  hotplug re-arms it once the Networking backend is already warm
- `clearNetworkAction()` and `failNetworkAction()` — the `NetworkRow`
  connections stay alive after the popup hides, so a connect that resolves
  after the close lands here
- the band-change `actionProc` exit
- the 30s `actionTimeout`

`scanRestart` has the mirror-image gap: it enables the scanner 100ms after
`refresh(true)` without re-checking that the panel is still open, so closing
inside that window leaves it on.

Once enabled, the backend re-arms its own timer and keeps issuing
`RequestScan({})` with nothing to consume the results.

This is not a regression — `scannerEnabled = true` has been unguarded since
b19dc7ea. #6605 removed the bar-click `refresh()` that undid the deferral and
pinned that one call site with a test; the paths above were untouched.

The cost is not idle scan traffic. A sweep takes the radio off the operating
channel repeatedly, so a leaked scanner degrades the link it is scanning from.
Same machine, same AP, gateway ping — leaked scanner versus scanner off:

```
leaked   300 packets, 60s   rtt min/avg/max = 1.189/17.761/157.689 ms
leaked   200 packets, 40s   rtt min/avg/max = 1.117/28.924/162.642 ms
off      250 packets, 50s   rtt min/avg/max = 1.069/2.262/ 16.092 ms
```

That is roughly 8-13x the average latency and 10x the worst case, permanently,
on an otherwise idle link at -47dBm with zero tx retries. A sweep ran every 17s
and took 6.8s, so a sweep was in progress about 40% of wall-clock time; varying
the ping interval showed the radio cycling off the operating channel for ~150ms
out of every 204ms while one was running. Interactive traffic — SSH, calls,
anything latency-bound — sits inside that.

An A-B-A-B run with Quickshell scanning already disabled confirms the sweeps
alone cause it: 432 control packets stayed at or below 5.02ms, while manual
`nmcli` scans reached 120ms and 158ms. The magnitude depends on the radio and
on the PHY's regulatory state (every 5GHz channel is `no IR` here, so most of
the sweep is passive dwell). The frequency is this bug.

## Fix

Gate every scanner write on the panel being open, and give the panel explicit
ownership of the device it enabled.

- **`refresh()`** — the scanner block moves under `if (opened && wifiDevice)`.
  This covers `refresh(true)` too, which matters because `toggleNetwork()`
  schedules `Qt.callLater(refresh(true))` and that can land after a close. The
  `r` key also routes here; it already required an open panel, and now says so.
- **`scanRestart`** — `stop()` on close, and the callback re-checks
  `root.opened`. Both are needed: the guard alone still lets a close/reopen
  inside 100ms reuse the running timer and re-enable scanning immediately,
  undoing the deferral #6605 restored.
- **`scannerDevice`** — tracks the device this instance enabled, so close,
  device replacement and destruction release the right object. `findDevice()`
  prefers the connected interface, so on a multi-interface host `wifiDevice`
  can move between two live devices and the old one would keep scanning.
  `Component.onDestruction` releases without consulting `opened`, which is what
  covers a widget dying with its panel still open.

No cross-instance registry is needed. The bar builds one widget per monitor,
but the shell keeps a single popout open globally: every open flows through
`KeyboardPanel.onOpenChanged` into `Bar.requestPopout()`, which synchronously
closes the previous popout, and the cross-output dismissal surfaces give mouse
input the same exclusivity. A closed instance can only release, never claim.

**Trade-off:** the nearby-network list is no longer pre-warmed. Opening the
panel now shows KNOWN NETWORKS immediately and OTHER NETWORKS once the sweep
returns — about 7s on this hardware. That is the cost of not scanning behind a
closed panel, and it matches what `refresh(true)` was already deferring for.

## Tests

`test/shell.d/network-test.sh` gains asserts on `Panel.qml` source, in the style
of the existing bar-click assert: the scanner block is guarded by `opened`, the
deferred restart re-checks the panel, close cancels a pending restart,
destruction releases the owned device, and no write reaches
`wifiDevice.scannerEnabled` outside the helper. Each one fails against the
current file and passes with this change.

`./test/shell` passes — 2017 asserts, with the one pre-existing
`omarchy-pkgs checkout found` failure that also fails on a clean checkout here
because there is no sibling `omarchy-pkgs` tree.

Runtime, this exact code as a cloned plugin on an installed Quattro system,
two monitors and two live widget instances, `iw event` as the instrument:

| Scenario | Result |
|---|---|
| Panel closed, 55s | 0 scans |
| Panel open, 25s | 2 scans (0.8s and ~18s after opening); list populated |
| Closed again, 40s | 0 scans |
| `rescanPlugins` with the panel open, then 45s | 0 scans |
| Open/close in 536ms, then 45s | one scan while briefly open; 0 after |
| Open/close in 201ms, then 45s | 0 scans |

The reload-with-open-panel row is the case a guard-only fix fails: the widget
dies with `opened` still true and nothing writes `scannerEnabled = false`.

Measured on Omarchy 4.0.0.r1688.g438f7b3-1, kernel 7.1.8-arch1-3, Dell G3 3579,
quickshell-git 0.3.0.r20.g28771c7, qt6-declarative 6.11.1, NetworkManager
1.58.0, Qualcomm Atheros QCA9377 [168c:0042] on `ath10k_pci`, firmware
`WLAN.TF.2.1-00021-QCARMSWP-1`, regulatory domain BR, associated on 5805MHz at
-46dBm.

Not verified: `wifiDevice` moving between two live devices — reasoned from
`findDevice()`, needs a second Wi-Fi interface; an open/close cycle strictly
inside the 100ms window, since CLI overhead kept the fastest cycle at ~201ms,
so the timer-reuse property of `stop()` was not isolated at runtime; and two
panels open at once, which the popout exclusivity forbids.

One scan can still begin shortly after a close if `RequestScan` was already
dispatched. Clearing `scannerEnabled` stops the repeat timer, but
NetworkManager exposes no cancellation for a request in flight.

Left out: reference counting on `scannerEnabled` itself belongs in Quickshell,
not here.
