### PR TITLE
Wait for ttfx before closing its terminal

### DIFF
--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -21,4 +21,6 @@ fi
 
 # Avoid running screensaver when locked
 pkill -x ttfx 2>/dev/null || true
+# ttfx handles SIGTERM asynchronously, so keep its terminal alive until it exits.
+timeout 1s pidwait -x ttfx 2>/dev/null || true
 pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null || true

--- a/test/shell.d/system-lock-test.sh
+++ b/test/shell.d/system-lock-test.sh
@@ -11,7 +11,7 @@ mock_bin="$tmpdir/bin"
 call_log="$tmpdir/calls"
 mkdir -p "$mock_bin"
 
-for command in omarchy-shell hyprctl pkill; do
+for command in omarchy-shell hyprctl pkill timeout; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 printf '%s %s\n' "$(basename "$0")" "$*" >>"$CALL_LOG"
@@ -25,10 +25,12 @@ SH
 chmod +x "$mock_bin"/*
 
 PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-lock"
-mapfile -t kills < <(rg '^pkill ' "$call_log")
+mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 
-[[ ${kills[0]} == "pkill -x ttfx" ]] ||
-  fail "system lock stops ttfx before closing its terminal" "calls: ${kills[*]}"
-[[ ${kills[1]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
-  fail "system lock closes the screensaver terminal after ttfx" "calls: ${kills[*]}"
-pass "system lock stops ttfx before closing its terminal"
+[[ ${shutdown[0]} == "pkill -x ttfx" ]] ||
+  fail "system lock stops ttfx before closing its terminal" "calls: ${shutdown[*]}"
+[[ ${shutdown[1]} == "timeout 1s pidwait -x ttfx" ]] ||
+  fail "system lock waits for ttfx to exit" "calls: ${shutdown[*]}"
+[[ ${shutdown[2]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
+  fail "system lock closes the screensaver terminal after ttfx exits" "calls: ${shutdown[*]}"
+pass "system lock waits for ttfx before closing its terminal"


### PR DESCRIPTION
Fixes #6762.

This follows up on #6764. That change sends `SIGTERM` to `ttfx` before closing the screensaver terminal, but `pkill` returns as soon as the signal is sent. It does not wait for the process to exit.

`ttfx` handles `SIGTERM` asynchronously so it can finish its current loop and clean up the terminal. During that short window, the next command can still close the PTY. A final frame write then fails with `EIO`; trying to report that error to the same closed terminal panics and produces the `SIGABRT` core dump.

This change keeps the terminal alive until `ttfx` has exited by adding a bounded `pidwait` between the two kills. The one-second timeout keeps locking responsive if `ttfx` ever refuses to stop; normal shutdown should take only a few milliseconds.

The regression test now checks for all three operations in order: signal `ttfx`, wait for it to exit, then close the screensaver terminal.

## Checks

- `bash test/shell.d/system-lock-test.sh`
- `bash -n bin/omarchy-system-lock test/shell.d/system-lock-test.sh`
- Live delayed-process check confirming `pidwait` blocks until the matching process exits
