### PR TITLE
Add Agents widget toggle

### DIFF
--- a/bin/omarchy-toggle-agents-widget
+++ b/bin/omarchy-toggle-agents-widget
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the Agents bar widget
+
+set -euo pipefail
+
+enabled=$(omarchy-plugin-list --json | jq -r '.[] | select(.id == "omarchy.agents") | .enabled')
+
+case "$enabled" in
+  true)
+    omarchy-plugin-disable omarchy.agents
+    ;;
+  false)
+    omarchy-bar put omarchy.agents --section right --after omarchy.tray
+    ;;
+  *)
+    echo "omarchy-toggle-agents-widget: plugin 'omarchy.agents' is not known; run: omarchy-shell shell rescanPlugins" >&2
+    exit 1
+    ;;
+esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -87,6 +87,7 @@
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
   "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},
+  "trigger.toggle.agents-widget": {"icon":"󰚩","label":"Agents Widget","action":"omarchy-toggle-agents-widget"},
   "trigger.toggle.battery-percentage": {"icon":"󰁹","label":"Battery Percentage","when":"omarchy-hw-laptop","action":"omarchy-shell omarchy.power togglePercentage"},
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},
   "trigger.toggle.window-gaps": {"icon":"","label":"Window Gaps","action":"omarchy-hyprland-window-gaps-toggle"},

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -243,6 +243,11 @@ assertEqual(
   'omarchy-bar transparent toggle',
   'menu exposes Menu Bar transparency as a toggle'
 )
+assert(
+  defaultById['trigger.toggle.agents-widget'].label === 'Agents Widget'
+    && defaultById['trigger.toggle.agents-widget'].action === 'omarchy-toggle-agents-widget',
+  'menu exposes the Agents widget under Trigger > Toggle'
+)
 assertDeepEqual(
   defaultItems.filter(item => item.parent === 'setup.plugin').map(item => item.label),
   ['Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],


### PR DESCRIPTION
This adds an `Agents Widget` option to `Trigger > Toggle` so the agents bar widget can be shown or hidden from the menu.

IMO, the existing behaviour of: using an agent once == permanent widget in my menu bar, just looks like _**that guy**_ on macOS who has 50 bs applications running at once but doesn't gaf. 

Adding this to the toggle menu feels like a naturall place to look to turn this shit off. It's at least the first place I looked as an omarchy vet.

---
Tested with:
- `bash ./test/shell.d/menu-test.sh`
- `./test/cli`
