### PR TITLE
Make Escape go back a submenu before closing the menu

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1083,7 +1083,7 @@ Item {
             event.accepted = true
           } else if (event.key === Qt.Key_Escape) {
             if (root.filterText) root.setFilter("")
-            else root.cancel()
+            else if (!root.goBack()) root.cancel()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -367,6 +367,10 @@ assert(
   'menu Left key follows empty-filter Backspace navigation'
 )
 assert(
+  /event\.key === Qt\.Key_Escape[\s\S]*if \(root\.filterText\) root\.setFilter\(""\)\s*else if \(!root\.goBack\(\)\) root\.cancel\(\)/.test(menuQml),
+  'menu Escape goes back a submenu before closing at the root menu'
+)
+assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),
   'menu uses shared pointer movement gate in card coordinates'
 )


### PR DESCRIPTION
## Motivation

In the Omarchy menu, pressing `Escape` inside a submenu closes the whole launcher instead of returning to the previous menu. When navigating several levels deep with the keyboard, an instinctive `Esc` (the "go back" key in most launchers and TUIs) makes the menu vanish and you have to start over from the root.

`Backspace` and `Left` already navigate back; `Escape` was the odd one out.

## Change

One line in the menu's key handler:

```diff
 } else if (event.key === Qt.Key_Escape) {
   if (root.filterText) root.setFilter("")
-  else root.cancel()
+  else if (!root.goBack()) root.cancel()
   event.accepted = true
 }
```

`goBack()` pops the navigation stack and returns `false` at the root menu, where the handler falls back to the original `cancel()`.

## Behavior

| Situation | Before | After |
|---|---|---|
| `Esc` with text in the filter | Clears filter | Clears filter (unchanged) |
| `Esc` inside a submenu | **Closes the menu** | **Goes back to the previous menu** |
| `Esc` at the root menu | Closes the menu | Closes the menu (unchanged) |

## Testing

- Added a regex assertion to `test/shell.d/menu-test.sh` covering the new handler; `bash test/shell.d/menu-test.sh` passes (99 assertions).
- `./test/all`: the only failures (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`) also fail on a clean checkout of `quattro` in this environment — unrelated to this change.
- Verified in the running UI: I have been daily-driving this exact change as a shell plugin (cloned `omarchy.menu` with this one-line diff). Open menu → enter a submenu → `Esc` returns to the previous menu; `Esc` at the root still closes.