### PR TITLE
Drag a bar module off the bar to remove it with a poof

### DIFF
--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -23,12 +23,12 @@ import qs.Commons
 // Missing on purpose (for now): triggerMode ("hover"), containsMouse.
 //
 // Positioning: full-screen layer-shell with the card placed inside at
-// `cardOrigin`. We use the bar window's height/width for the perpendicular
-// axis (away-from-bar) because mapToItem on the anchor returns
+// `cardOrigin`. We use the bar's strip thickness (bar.barSize) for the
+// perpendicular axis (away-from-bar) because mapToItem on the anchor returns
 // bar-content-relative coords with internal layout offsets baked in
 // (e.g. ~13px from the bar's vertical centering of its widget row). The
 // parallel axis (along-the-bar) uses the anchor's content x/y since the
-// bar spans full screen on that axis.
+// bar window spans the full screen on that axis.
 //
 // Outside-click dismissal: an overlay MouseArea catches clicks, with the
 // QsWindow.mask subtracting the bar strip so clicks on the bar still
@@ -116,11 +116,7 @@ PanelWindow {
   // Clickable region is the whole screen. Clicks in the bar strip are
   // forwarded to registered bar buttons so switching between panel icons
   // works in one click even when the overlay surface is above the bar.
-  readonly property real _barStripSize: {
-    if (!bar) return 0
-    var actual = (root.barPos === "top" || root.barPos === "bottom") ? root.barH : root.barW
-    return Math.max(bar.barSize, actual) + root.gap
-  }
+  readonly property real _barStripSize: bar ? barThickness + gap : 0
   mask: Region {
     width: root.screenW
     height: root.screenH
@@ -140,7 +136,7 @@ PanelWindow {
   // full-width top bar, the content x maps directly to screen x; the y
   // returned here has the bar's internal padding baked in (e.g. ~13px
   // from vertical centering of the widget row), which is why `cardOrigin`
-  // below uses `barH` for the perpendicular axis instead of this y.
+  // below uses `barThickness` for the perpendicular axis instead of this y.
   readonly property point anchorScreenPos: {
     anchorWatcher.transform  // reactive dependency
     if (!anchorItem || !anchorWindow) return Qt.point(0, 0)
@@ -151,10 +147,10 @@ PanelWindow {
   readonly property real screenW: screen ? screen.width : 0
   readonly property real screenH: screen ? screen.height : 0
   readonly property real availableCardWidth: screenW > 0
-    ? Math.max(120, screenW - ((barPos === "left" || barPos === "right") ? barW + gap + margin : margin * 2))
+    ? Math.max(120, screenW - ((barPos === "left" || barPos === "right") ? barThickness + gap + margin : margin * 2))
     : 0
   readonly property real availableCardHeight: screenH > 0
-    ? Math.max(120, screenH - ((barPos === "top" || barPos === "bottom") ? barH + gap + margin : margin * 2))
+    ? Math.max(120, screenH - ((barPos === "top" || barPos === "bottom") ? barThickness + gap + margin : margin * 2))
     : 0
   readonly property real verticalContentInset: padding * 2 + Border.top(borderSpec) + Border.bottom(borderSpec)
 
@@ -179,16 +175,20 @@ PanelWindow {
   }
 
   // Desired top-left of the card in screen coordinates. For the
-  // perpendicular axis (away-from-bar) we anchor to the bar window's edge
+  // perpendicular axis (away-from-bar) we anchor to the bar strip's edge
   // directly — not the anchor item's y/x — because mapToItem(barContent)
   // returns coordinates in the bar's content space, which can be offset
-  // from the bar surface's screen-anchored corner by internal layout
-  // (centering wrappers, padding). The bar's surface IS aligned to its
-  // anchored screen edge, so using `barW`/`barH` gives the right edge
-  // regardless of how the bar's internal widgets are positioned. For the
-  // parallel axis (along the bar) the anchor item's reported position is
-  // still consistent with the bar content origin, so it's accurate for
-  // centering the card under the icon.
+  // from the strip's screen-anchored corner by internal layout (centering
+  // wrappers, padding). The bar window spans its whole screen, so its
+  // dimensions say nothing about the strip; the painted strip hugs the
+  // bar's anchored screen edge at `bar.barSize` thick, so `barThickness`
+  // gives the strip's inner edge regardless of how the bar's internal
+  // widgets are positioned. For the parallel axis (along the bar) the
+  // anchor item's reported position is still consistent with the bar
+  // content origin, so it's accurate for centering the card under the icon.
+  readonly property real barThickness: bar ? bar.barSize : 0
+  // Bar window dimensions, only for mapping overlay coordinates into
+  // bar-window content coordinates in barPoint() below.
   readonly property real barW: anchorWindow ? anchorWindow.width : screenW
   readonly property real barH: anchorWindow ? anchorWindow.height : 0
   readonly property point cardOrigin: {
@@ -196,22 +196,22 @@ PanelWindow {
     var x = 0, y = 0
     if (centerOnBar && (barPos === "top" || barPos === "bottom")) {
       x = screenW / 2 - contentWidth / 2
-      y = barPos === "bottom" ? screenH - barH - contentHeight - gap : barH + gap
+      y = barPos === "bottom" ? screenH - barThickness - contentHeight - gap : barThickness + gap
     } else if (centerOnBar) {
-      x = barPos === "left" ? barW + gap : screenW - barW - contentWidth - gap
+      x = barPos === "left" ? barThickness + gap : screenW - barThickness - contentWidth - gap
       y = screenH / 2 - contentHeight / 2
     } else if (barPos === "bottom") {
       x = anchorScreenPos.x + anchorW / 2 - contentWidth / 2
-      y = screenH - barH - contentHeight - gap
+      y = screenH - barThickness - contentHeight - gap
     } else if (barPos === "left") {
-      x = barW + gap
+      x = barThickness + gap
       y = anchorScreenPos.y + anchorH / 2 - contentHeight / 2
     } else if (barPos === "right") {
-      x = screenW - barW - contentWidth - gap
+      x = screenW - barThickness - contentWidth - gap
       y = anchorScreenPos.y + anchorH / 2 - contentHeight / 2
     } else { // "top" (default)
       x = anchorScreenPos.x + anchorW / 2 - contentWidth / 2
-      y = barH + gap
+      y = barThickness + gap
     }
     x = Math.max(margin, Math.min(x, screenW - contentWidth - margin))
     y = Math.max(margin, Math.min(y, screenH - contentHeight - margin))

--- a/shell/Ui/PopupCard.qml
+++ b/shell/Ui/PopupCard.qml
@@ -27,13 +27,16 @@ PopupWindow {
   readonly property bool containsMouse: cardHover.hovered
   readonly property real screenW: popupScreen ? popupScreen.width : 0
   readonly property real screenH: popupScreen ? popupScreen.height : 0
-  readonly property real barW: anchorWindow ? anchorWindow.width : 0
-  readonly property real barH: anchorWindow ? anchorWindow.height : 0
+  // Thickness of the painted bar strip. The bar window spans its whole
+  // screen (only the strip inside it is painted and takes input), so the
+  // window's dimensions say nothing about the bar; the bar's own barSize
+  // is the strip's thickness against its anchored screen edge.
+  readonly property real barThickness: bar ? bar.barSize : 0
   readonly property real availableCardWidth: screenW > 0
-    ? Math.max(120, screenW - ((bar && (bar.position === "left" || bar.position === "right")) ? barW : 0) - root.margin * 2)
+    ? Math.max(120, screenW - ((bar && (bar.position === "left" || bar.position === "right")) ? barThickness : 0) - root.margin * 2)
     : 0
   readonly property real availableCardHeight: screenH > 0
-    ? Math.max(120, screenH - ((bar && (bar.position === "top" || bar.position === "bottom")) ? barH : 0) - root.margin * 2)
+    ? Math.max(120, screenH - ((bar && (bar.position === "top" || bar.position === "bottom")) ? barThickness : 0) - root.margin * 2)
     : 0
   readonly property real verticalContentInset: padding * 2 + Border.top(borderSpec) + Border.bottom(borderSpec)
 
@@ -121,10 +124,14 @@ PopupWindow {
         var cy = 0;
         if (root.bar.position === "top" || root.bar.position === "bottom") {
           cx = window.width / 2 - popupWidth / 2
-          cy = root.bar.position === "bottom" ? -popupHeight - root.margin : window.height + root.margin
+          cy = root.bar.position === "bottom"
+            ? window.height - root.barThickness - popupHeight - root.margin
+            : root.barThickness + root.margin
           cx = Math.max(root.margin, Math.min(cx, window.width - popupWidth - root.margin))
         } else {
-          cx = root.bar.position === "left" ? window.width + root.margin : -popupWidth - root.margin
+          cx = root.bar.position === "left"
+            ? root.barThickness + root.margin
+            : window.width - root.barThickness - popupWidth - root.margin
           cy = window.height / 2 - popupHeight / 2
           cy = Math.max(root.margin, Math.min(cy, window.height - popupHeight - root.margin))
         }

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -100,6 +100,8 @@ Item {
   // Dragging a module this far past the bar edge arms removal. Generous
   // enough that overshooting a drop target keeps reading as a reorder.
   readonly property real barDragRemoveDistance: Style.spaceReal(48)
+  // Removal committed after the poof finishes: { region, name }.
+  property var barPendingRemoval: null
   property bool barPoofActive: false
   property var barPoofScreen: null
   property real barPoofX: 0
@@ -705,15 +707,34 @@ Item {
   // reorder only moves it: for a bar widget the layout entry is the whole
   // story, and a clone dragged off should vanish rather than resurrect the
   // widget it shadows the way a settings-page disable would.
-  function removeBarModule(source) {
+  //
+  // The config write is deferred until the poof has played. Persisting
+  // shell.json rebuilds every widget on every monitor, which stalls the
+  // render loop for long enough to swallow the whole burst; so the release
+  // hides the slot and starts the poof, and the write lands afterwards.
+  function scheduleModuleRemoval(source) {
     if (!source || !source.region || !source.moduleName) return false
     if (!root.shell || typeof root.shell.mutateShellConfig !== "function") return false
 
-    var changed = false
+    commitPendingRemoval()
+    barPendingRemoval = { region: source.region, name: source.moduleName }
+    return true
+  }
+
+  function commitPendingRemoval() {
+    var pending = barPendingRemoval
+    barPendingRemoval = null
+    if (!pending) return
+    if (!root.shell || typeof root.shell.mutateShellConfig !== "function") return
+
     root.shell.mutateShellConfig(function(config) {
-      changed = removeModuleFromConfig(config, source.region, source.moduleName)
+      removeModuleFromConfig(config, pending.region, pending.name)
     })
-    return changed
+  }
+
+  function isPendingRemoval(region, name) {
+    var pending = barPendingRemoval
+    return !!pending && pending.region === region && pending.name === name
   }
 
   function moduleRemoveDistance(scenePoint) {
@@ -734,11 +755,15 @@ Item {
   }
 
   // Outlives the burst animation slightly so the last frames are not cut off
-  // by the overlay window unmapping.
+  // by the overlay window unmapping, and only then commits the deferred
+  // removal — the rebuild it triggers would freeze a poof still playing.
   Timer {
     id: poofTimer
     interval: 520
-    onTriggered: root.barPoofActive = false
+    onTriggered: {
+      root.barPoofActive = false
+      root.commitPendingRemoval()
+    }
   }
 
   function moduleDropAtScene(scenePoint, sourceSlot) {
@@ -1679,6 +1704,10 @@ Item {
     }
     readonly property bool hovered: moduleHover.hovered
     readonly property bool dragSource: root.barDragSource === slot
+    // A module let go past the removal threshold vanishes from the bar the
+    // moment the poof starts, even though its layout entry survives until
+    // the deferred config write lands.
+    readonly property bool removalPending: root.isPendingRemoval(region, moduleName)
     readonly property bool panelOpen: root.activePopout === slot.activeItem
     // Modules bigger than the mark they want (a text label in a padded slot,
     // a multi-line stack on a vertical bar) can say how long the open-panel
@@ -1690,8 +1719,8 @@ Item {
       if (hint !== undefined && hint !== null && hint > 0) return Math.round(hint)
       return Math.max(Style.space(10), Math.round((root.vertical ? slot.height : slot.width) * 0.55))
     }
-    implicitWidth: activeItem && activeItem.visible ? (root.vertical ? root.barSize : activeItem.implicitWidth) : 0
-    implicitHeight: activeItem && activeItem.visible ? activeItem.implicitHeight : 0
+    implicitWidth: !removalPending && activeItem && activeItem.visible ? (root.vertical ? root.barSize : activeItem.implicitWidth) : 0
+    implicitHeight: !removalPending && activeItem && activeItem.visible ? activeItem.implicitHeight : 0
     width: implicitWidth
     height: implicitHeight
     z: modulePointer.dragging ? 100 : 0
@@ -1850,10 +1879,17 @@ Item {
         if (wasDragging) suppressClick = true
 
         dragging = false
+
+        // Order matters for an armed release: the poof state goes up before
+        // the drag state clears so the overlay window never unmaps between
+        // ghost and burst, and the slot hides via the pending removal in the
+        // same frame the ghost disappears.
+        if (wasDragging && removeArmed && root.scheduleModuleRemoval(slot))
+          root.playPoof(poofScreen, poofX, poofY)
+
         root.clearBarDrag()
 
         if (wasDragging && removeArmed) {
-          if (root.removeBarModule(slot)) root.playPoof(poofScreen, poofX, poofY)
           mouse.accepted = true
         } else if (wasDragging && targetSlot) {
           root.dropBarModuleAtTarget(slot, targetSlot, afterTarget)

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -114,6 +114,7 @@ Item {
   property var clickTargets: []
   property var moduleSlots: []
 
+
   function registerClickTarget(target) {
     if (!target || clickTargets.indexOf(target) !== -1) return
     var next = clickTargets.slice()
@@ -737,12 +738,23 @@ Item {
     return !!pending && pending.region === region && pending.name === name
   }
 
-  function moduleRemoveDistance(scenePoint) {
-    var window = barDragWindow
-    if (!window || !window.contentItem) return 0
+  // How far past the bar strip the drag point sits, in screen space. The
+  // strip, not the window, is the boundary: the window grows to the whole
+  // screen while a drag is live (see BarPanel.dragGrown), so its own bounds
+  // say nothing about leaving the bar.
+  function moduleRemoveDistance(screenPoint) {
+    var screen = barDragScreen
+    if (!screen) return 0
 
-    var barPoint = window.contentItem.mapFromItem(null, scenePoint.x, scenePoint.y)
-    return BarModel.dragDistanceOutside(barPoint, window.contentItem.width, window.contentItem.height)
+    var x = screenPoint.x
+    var y = screenPoint.y
+    if (vertical) {
+      if (position === "right") x -= Math.max(0, screen.width - barSize)
+      return BarModel.dragDistanceOutside({ x: x, y: y }, barSize, screen.height)
+    }
+
+    if (position === "bottom") y -= Math.max(0, screen.height - barSize)
+    return BarModel.dragDistanceOutside({ x: x, y: y }, screen.width, barSize)
   }
 
   function playPoof(screen, x, y) {
@@ -769,9 +781,16 @@ Item {
   function moduleDropAtScene(scenePoint, sourceSlot) {
     var sourceWindow = root.slotWindow(sourceSlot) || root.barDragWindow
     if (sourceWindow && sourceWindow.contentItem) {
+      // Free-space drops count only inside the bar strip. The window itself
+      // can be grown to the full screen mid-drag, so its bounds are not the
+      // bar's bounds.
       var barPoint = sourceWindow.contentItem.mapFromItem(null, scenePoint.x, scenePoint.y)
-      if (barPoint.x < 0 || barPoint.x > sourceWindow.contentItem.width ||
-          barPoint.y < 0 || barPoint.y > sourceWindow.contentItem.height)
+      var stripX = root.position === "right" ? sourceWindow.contentItem.width - root.barSize : 0
+      var stripY = root.position === "bottom" ? sourceWindow.contentItem.height - root.barSize : 0
+      var stripWidth = root.vertical ? root.barSize : sourceWindow.contentItem.width
+      var stripHeight = root.vertical ? sourceWindow.contentItem.height : root.barSize
+      if (barPoint.x < stripX || barPoint.x > stripX + stripWidth ||
+          barPoint.y < stripY || barPoint.y > stripY + stripHeight)
         return null
     }
 
@@ -1075,13 +1094,29 @@ Item {
   component BarPanel: PanelWindow {
     id: barWindow
 
+    // While this window's module or bar-move drag is live, the surface grows
+    // to cover its whole screen (transparent outside the painted strip). The
+    // pointer then never leaves the bar surface however far the drag goes,
+    // which is what keeps the gesture alive: the compositor re-picks a
+    // pointer target on any surface commit while nothing on the workspace
+    // holds keyboard focus — an empty workspace — and a pointer that has
+    // strayed onto another surface is ripped off the bar mid-drag, ending
+    // the gesture with a synthesized release.
+    // sameWindow, not identity: the drag records the QsWindow interface of
+    // the slot's window, which is not this PanelWindow object itself.
+    readonly property bool dragGrown: (root.barDragSource !== null && root.sameWindow(root.barDragWindow, barWindow)) ||
+      (root.barMoveActive && root.sameWindow(root.barMoveWindow, barWindow))
+
     // Hiding parks the bar just past its screen edge instead of unmapping it.
     // Unmapping frees the layer surface and the whole scene graph, so every
     // reveal has to rebuild them — new surface, re-shaped glyphs, re-uploaded
     // textures — which measures ~150ms against ~20ms to tear down. Parking
     // keeps the surface alive, so showing is only a margin change.
     visible: !remapGuard.remapping
-    exclusionMode: root.barHidden ? ExclusionMode.Ignore : ExclusionMode.Auto
+    // An explicit zone instead of Auto: the reserved area must stay the
+    // strip's thickness while the window is grown for a drag.
+    exclusionMode: root.barHidden ? ExclusionMode.Ignore : ExclusionMode.Normal
+    exclusiveZone: root.barSize
 
     ScreenMoveRemap {
       id: remapGuard
@@ -1096,31 +1131,51 @@ Item {
     }
 
     anchors {
-      top: root.position === "top" || root.vertical
-      bottom: root.position === "bottom" || root.vertical
-      left: root.position === "left" || !root.vertical
-      right: root.position === "right" || !root.vertical
+      top: root.position === "top" || root.vertical || barWindow.dragGrown
+      bottom: root.position === "bottom" || root.vertical || barWindow.dragGrown
+      left: root.position === "left" || !root.vertical || barWindow.dragGrown
+      right: root.position === "right" || !root.vertical || barWindow.dragGrown
     }
 
-    implicitWidth: root.vertical ? root.barSize : 0
-    implicitHeight: root.vertical ? 0 : root.barSize
-    color: root.transparent ? "transparent" : root.background
+    // A zero size on an anchored axis means "stretch": the strip's thickness
+    // normally, the whole screen while grown for a drag.
+    implicitWidth: root.vertical && !barWindow.dragGrown ? root.barSize : 0
+    implicitHeight: root.vertical || barWindow.dragGrown ? 0 : root.barSize
+    // The window is transparent; the strip below paints the bar. Painting the
+    // window would flood the whole screen with bar color while grown.
+    color: "transparent"
     surfaceFormat.opaque: false
     WlrLayershell.namespace: "omarchy-bar"
     WlrLayershell.layer: WlrLayer.Top
 
-    Loader {
-      anchors.fill: parent
-      sourceComponent: root.vertical ? verticalBar : horizontalBar
+    // The bar itself, pinned to its screen edge. Coincides with the window
+    // when not grown.
+    Item {
+      id: barStrip
 
-      // A child of the loader, not a sibling of the sections: an ancestor stays
-      // hovered while the pointer is over a widget, where a sibling would lose
-      // hover to the section the pointer entered.
-      HoverHandler {
-        onHoveredChanged: root.setBarHovered(hovered)
-        // Unplugging a monitor destroys its bar without a leave event, which
-        // would strand this surface's tally and hold the peek open for good.
-        Component.onDestruction: if (hovered) root.setBarHovered(false)
+      x: root.position === "right" ? parent.width - root.barSize : 0
+      y: root.position === "bottom" ? parent.height - root.barSize : 0
+      width: root.vertical ? root.barSize : parent.width
+      height: root.vertical ? parent.height : root.barSize
+
+      Rectangle {
+        anchors.fill: parent
+        color: root.transparent ? "transparent" : root.background
+      }
+
+      Loader {
+        anchors.fill: parent
+        sourceComponent: root.vertical ? verticalBar : horizontalBar
+
+        // A child of the loader, not a sibling of the sections: an ancestor stays
+        // hovered while the pointer is over a widget, where a sibling would lose
+        // hover to the section the pointer entered.
+        HoverHandler {
+          onHoveredChanged: root.setBarHovered(hovered)
+          // Unplugging a monitor destroys its bar without a leave event, which
+          // would strand this surface's tally and hold the peek open for good.
+          Component.onDestruction: if (hovered) root.setBarHovered(false)
+        }
       }
     }
 
@@ -1863,7 +1918,7 @@ Item {
           root.barDragTarget = drop ? drop.slot : null
           root.barDragAfter = drop ? drop.after : false
           root.barDragTargetGeometry = drop ? root.dropMarkerRect(drop.slot, drop.after) : null
-          root.barDragRemoveArmed = !drop && root.moduleRemoveDistance(scenePoint) >= root.barDragRemoveDistance
+          root.barDragRemoveArmed = !drop && root.moduleRemoveDistance(screenPoint) >= root.barDragRemoveDistance
         }
       }
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1131,16 +1131,23 @@ Item {
     }
 
     anchors {
-      top: root.position === "top" || root.vertical || barWindow.dragGrown
-      bottom: root.position === "bottom" || root.vertical || barWindow.dragGrown
-      left: root.position === "left" || !root.vertical || barWindow.dragGrown
-      right: root.position === "right" || !root.vertical || barWindow.dragGrown
+      top: root.position === "top" || root.vertical
+      bottom: root.position === "bottom" || root.vertical
+      left: root.position === "left" || !root.vertical
+      right: root.position === "right" || !root.vertical
     }
 
-    // A zero size on an anchored axis means "stretch": the strip's thickness
-    // normally, the whole screen while grown for a drag.
-    implicitWidth: root.vertical && !barWindow.dragGrown ? root.barSize : 0
-    implicitHeight: root.vertical || barWindow.dragGrown ? 0 : root.barSize
+    // The grow extends the requested size along the open axis; the anchors
+    // never change. Anchoring all four edges instead would void the
+    // exclusive zone — layer-shell reserves space from an anchored edge —
+    // and the tiled windows would jump up behind the bar for the length of
+    // the drag.
+    implicitWidth: root.vertical
+      ? (barWindow.dragGrown && barWindow.screen ? barWindow.screen.width : root.barSize)
+      : 0
+    implicitHeight: root.vertical
+      ? 0
+      : (barWindow.dragGrown && barWindow.screen ? barWindow.screen.height : root.barSize)
     // The window is transparent; the strip below paints the bar. Painting the
     // window would flood the whole screen with bar color while grown.
     color: "transparent"

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -94,6 +94,17 @@ Item {
   property real barDragScreenY: 0
   property real barDragOffsetX: 0
   property real barDragOffsetY: 0
+  // True once the drag has pulled far enough off the bar that releasing
+  // removes the module instead of reordering it.
+  property bool barDragRemoveArmed: false
+  // Dragging a module this far past the bar edge arms removal. Generous
+  // enough that overshooting a drop target keeps reading as a reorder.
+  readonly property real barDragRemoveDistance: Style.spaceReal(48)
+  property bool barPoofActive: false
+  property var barPoofScreen: null
+  property real barPoofX: 0
+  property real barPoofY: 0
+  property int barPoofSerial: 0
   property bool barMoveActive: false
   property string barMoveCandidate: ""
   property var barMoveWindow: null
@@ -191,6 +202,7 @@ Item {
     barDragTarget = null
     barDragTargetGeometry = null
     barDragAfter = false
+    barDragRemoveArmed = false
     barDragSceneX = 0
     barDragSceneY = 0
     barDragScreenX = 0
@@ -680,6 +692,55 @@ Item {
     return changed
   }
 
+  function removeModuleFromConfig(config, region, name) {
+    var entries = rawLayoutSection(config, region)
+    var index = rawEntryIndex(entries, name)
+    if (index < 0) return false
+
+    entries.splice(index, 1)
+    return true
+  }
+
+  // Drag-off removal drops the layout entry and nothing else, the same way a
+  // reorder only moves it: for a bar widget the layout entry is the whole
+  // story, and a clone dragged off should vanish rather than resurrect the
+  // widget it shadows the way a settings-page disable would.
+  function removeBarModule(source) {
+    if (!source || !source.region || !source.moduleName) return false
+    if (!root.shell || typeof root.shell.mutateShellConfig !== "function") return false
+
+    var changed = false
+    root.shell.mutateShellConfig(function(config) {
+      changed = removeModuleFromConfig(config, source.region, source.moduleName)
+    })
+    return changed
+  }
+
+  function moduleRemoveDistance(scenePoint) {
+    var window = barDragWindow
+    if (!window || !window.contentItem) return 0
+
+    var barPoint = window.contentItem.mapFromItem(null, scenePoint.x, scenePoint.y)
+    return BarModel.dragDistanceOutside(barPoint, window.contentItem.width, window.contentItem.height)
+  }
+
+  function playPoof(screen, x, y) {
+    barPoofScreen = screen
+    barPoofX = x
+    barPoofY = y
+    barPoofSerial++
+    barPoofActive = true
+    poofTimer.restart()
+  }
+
+  // Outlives the burst animation slightly so the last frames are not cut off
+  // by the overlay window unmapping.
+  Timer {
+    id: poofTimer
+    interval: 520
+    onTriggered: root.barPoofActive = false
+  }
+
   function moduleDropAtScene(scenePoint, sourceSlot) {
     var sourceWindow = root.slotWindow(sourceSlot) || root.barDragWindow
     if (sourceWindow && sourceWindow.contentItem) {
@@ -1155,12 +1216,15 @@ Item {
     readonly property bool screenMatches: root.barDragScreen === ghostScreen ||
       (root.barDragScreen && ghostScreen && root.barDragScreen.name && ghostScreen.name && root.barDragScreen.name === ghostScreen.name)
     readonly property bool active: root.barDragSource && root.barDragScreen && screenMatches
+    readonly property bool poofMatches: root.barPoofScreen === ghostScreen ||
+      (root.barPoofScreen && ghostScreen && root.barPoofScreen.name && ghostScreen.name && root.barPoofScreen.name === ghostScreen.name)
+    readonly property bool poofShown: root.barPoofActive && poofMatches
     readonly property var sourceItem: root.barDragSource ? root.barDragSource.activeItem : null
     readonly property int ghostPadding: Style.space(1)
     readonly property int ghostWidth: sourceItem ? Math.max(1, Math.ceil(sourceItem.width)) : 1
     readonly property int ghostHeight: sourceItem ? Math.max(1, Math.ceil(sourceItem.height)) : 1
 
-    visible: active && sourceItem !== null
+    visible: (active && sourceItem !== null) || poofShown
     color: "transparent"
     exclusionMode: ExclusionMode.Ignore
     WlrLayershell.namespace: "omarchy-bar-drag-ghost"
@@ -1179,11 +1243,18 @@ Item {
     mask: Region {}
 
     Item {
-      visible: ghostWindow.visible
+      visible: ghostWindow.active && ghostWindow.sourceItem !== null
       x: Math.round(root.barDragScreenX - root.barDragOffsetX - ghostWindow.ghostPadding)
       y: Math.round(root.barDragScreenY - root.barDragOffsetY - ghostWindow.ghostPadding)
       width: ghostWindow.ghostWidth + ghostWindow.ghostPadding * 2
       height: ghostWindow.ghostHeight + ghostWindow.ghostPadding * 2
+      // Pulling past the removal threshold shrinks and dims the ghost, the
+      // cue that letting go now poofs the module instead of reordering it.
+      scale: root.barDragRemoveArmed ? 0.82 : 1
+      opacity: root.barDragRemoveArmed ? 0.55 : 1
+
+      Behavior on scale { NumberAnimation { duration: 140; easing.type: Easing.OutCubic } }
+      Behavior on opacity { NumberAnimation { duration: 140; easing.type: Easing.OutCubic } }
 
       BorderSurface {
         anchors.fill: parent
@@ -1213,6 +1284,66 @@ Item {
       height: targetRect ? targetRect.height : 0
       color: Color.accent
       radius: Math.min(width, height) / 2
+    }
+
+    // The macOS-style puff of smoke a removed module vanishes in: a ring of
+    // soft dots that drift outward and fade around a collapsing center puff.
+    Item {
+      id: poofBurst
+
+      property real progress: 1
+
+      visible: ghostWindow.poofShown
+      x: Math.round(root.barPoofX)
+      y: Math.round(root.barPoofY)
+
+      Connections {
+        target: root
+        function onBarPoofSerialChanged() {
+          if (ghostWindow.poofMatches) poofAnimation.restart()
+        }
+      }
+
+      NumberAnimation {
+        id: poofAnimation
+        target: poofBurst
+        property: "progress"
+        from: 0
+        to: 1
+        duration: 460
+        easing.type: Easing.OutCubic
+      }
+
+      Rectangle {
+        readonly property real puffSize: Style.spaceReal(9) * (1.2 - poofBurst.progress * 0.6)
+
+        width: puffSize
+        height: puffSize
+        radius: puffSize / 2
+        x: -puffSize / 2
+        y: -puffSize / 2
+        color: root.barForeground
+        opacity: (1 - poofBurst.progress) * 0.7
+      }
+
+      Repeater {
+        model: 8
+
+        Rectangle {
+          required property int index
+          readonly property real angle: Math.PI * 2 * index / 8
+          readonly property real drift: Style.spaceReal(5) + Style.spaceReal(15) * poofBurst.progress
+          readonly property real puffSize: Style.spaceReal(4 + index % 3 * 2) * (0.6 + poofBurst.progress * 0.9)
+
+          width: puffSize
+          height: puffSize
+          radius: puffSize / 2
+          x: Math.cos(angle) * drift - puffSize / 2
+          y: Math.sin(angle) * drift - puffSize / 2
+          color: root.barForeground
+          opacity: (1 - poofBurst.progress) * 0.85
+        }
+      }
     }
   }
 
@@ -1703,6 +1834,7 @@ Item {
           root.barDragTarget = drop ? drop.slot : null
           root.barDragAfter = drop ? drop.after : false
           root.barDragTargetGeometry = drop ? root.dropMarkerRect(drop.slot, drop.after) : null
+          root.barDragRemoveArmed = !drop && root.moduleRemoveDistance(scenePoint) >= root.barDragRemoveDistance
         }
       }
 
@@ -1710,13 +1842,20 @@ Item {
         var wasDragging = dragging
         var targetSlot = root.barDragTarget
         var afterTarget = root.barDragAfter
+        var removeArmed = root.barDragRemoveArmed
+        var poofScreen = root.barDragScreen
+        var poofX = root.barDragScreenX
+        var poofY = root.barDragScreenY
 
         if (wasDragging) suppressClick = true
 
         dragging = false
         root.clearBarDrag()
 
-        if (wasDragging && targetSlot) {
+        if (wasDragging && removeArmed) {
+          if (root.removeBarModule(slot)) root.playPoof(poofScreen, poofX, poofY)
+          mouse.accepted = true
+        } else if (wasDragging && targetSlot) {
           root.dropBarModuleAtTarget(slot, targetSlot, afterTarget)
           mouse.accepted = true
         } else if (!wasDragging) {

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -739,9 +739,9 @@ Item {
   }
 
   // How far past the bar strip the drag point sits, in screen space. The
-  // strip, not the window, is the boundary: the window grows to the whole
-  // screen while a drag is live (see BarPanel.dragGrown), so its own bounds
-  // say nothing about leaving the bar.
+  // strip, not the window, is the boundary: the window spans the whole
+  // screen (see BarPanel), so its own bounds say nothing about leaving
+  // the bar.
   function moduleRemoveDistance(screenPoint) {
     var screen = barDragScreen
     if (!screen) return 0
@@ -782,8 +782,7 @@ Item {
     var sourceWindow = root.slotWindow(sourceSlot) || root.barDragWindow
     if (sourceWindow && sourceWindow.contentItem) {
       // Free-space drops count only inside the bar strip. The window itself
-      // can be grown to the full screen mid-drag, so its bounds are not the
-      // bar's bounds.
+      // spans the whole screen, so its bounds are not the bar's bounds.
       var barPoint = sourceWindow.contentItem.mapFromItem(null, scenePoint.x, scenePoint.y)
       var stripX = root.position === "right" ? sourceWindow.contentItem.width - root.barSize : 0
       var stripY = root.position === "bottom" ? sourceWindow.contentItem.height - root.barSize : 0
@@ -1104,7 +1103,7 @@ Item {
     // the gesture with a synthesized release.
     // sameWindow, not identity: the drag records the QsWindow interface of
     // the slot's window, which is not this PanelWindow object itself.
-    readonly property bool dragGrown: (root.barDragSource !== null && root.sameWindow(root.barDragWindow, barWindow)) ||
+    readonly property bool dragActive: (root.barDragSource !== null && root.sameWindow(root.barDragWindow, barWindow)) ||
       (root.barMoveActive && root.sameWindow(root.barMoveWindow, barWindow))
 
     // Hiding parks the bar just past its screen edge instead of unmapping it.
@@ -1114,7 +1113,7 @@ Item {
     // keeps the surface alive, so showing is only a margin change.
     visible: !remapGuard.remapping
     // An explicit zone instead of Auto: the reserved area must stay the
-    // strip's thickness while the window is grown for a drag.
+    // strip's thickness even though the window spans the screen.
     exclusionMode: root.barHidden ? ExclusionMode.Ignore : ExclusionMode.Normal
     exclusiveZone: root.barSize
 
@@ -1137,26 +1136,42 @@ Item {
       right: root.position === "right" || !root.vertical
     }
 
-    // The grow extends the requested size along the open axis; the anchors
-    // never change. Anchoring all four edges instead would void the
-    // exclusive zone — layer-shell reserves space from an anchored edge —
-    // and the tiled windows would jump up behind the bar for the length of
-    // the drag.
+    // The surface is full-screen along its open axis at all times; what a
+    // drag toggles is the input region below. Resizing the surface for the
+    // drag instead flashes the bar's stale strip buffer stretched across the
+    // new geometry until the freshly rendered frame lands — the dark blink —
+    // and the size must not come from anchoring all four edges either, which
+    // would void the exclusive zone (layer-shell reserves space from an
+    // anchored edge) and drop the tiled windows behind the bar.
     implicitWidth: root.vertical
-      ? (barWindow.dragGrown && barWindow.screen ? barWindow.screen.width : root.barSize)
+      ? (barWindow.screen ? barWindow.screen.width : root.barSize)
       : 0
     implicitHeight: root.vertical
       ? 0
-      : (barWindow.dragGrown && barWindow.screen ? barWindow.screen.height : root.barSize)
+      : (barWindow.screen ? barWindow.screen.height : root.barSize)
     // The window is transparent; the strip below paints the bar. Painting the
-    // window would flood the whole screen with bar color while grown.
+    // window would flood the whole screen with bar color.
     color: "transparent"
     surfaceFormat.opaque: false
     WlrLayershell.namespace: "omarchy-bar"
     WlrLayershell.layer: WlrLayer.Top
 
-    // The bar itself, pinned to its screen edge. Coincides with the window
-    // when not grown.
+    // Idle, only the strip takes input, so the transparent expanse stays
+    // click-through for the windows and desktop below. During this window's
+    // drag the whole surface takes input, which is what keeps the gesture
+    // alive: the pointer never has a reason to be handed to another surface,
+    // however far off the bar the drag goes.
+    mask: barWindow.dragActive ? null : stripInputRegion
+
+    Region {
+      id: stripInputRegion
+      x: root.position === "right" ? barWindow.width - root.barSize : 0
+      y: root.position === "bottom" ? barWindow.height - root.barSize : 0
+      width: root.vertical ? root.barSize : barWindow.width
+      height: root.vertical ? barWindow.height : root.barSize
+    }
+
+    // The bar itself, pinned to its screen edge.
     Item {
       id: barStrip
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -114,7 +114,6 @@ Item {
   property var clickTargets: []
   property var moduleSlots: []
 
-
   function registerClickTarget(target) {
     if (!target || clickTargets.indexOf(target) !== -1) return
     var next = clickTargets.slice()
@@ -178,10 +177,16 @@ Item {
     return targetWindow(slot.activeItem) || targetWindow(slot)
   }
 
+  function sameScreen(left, right) {
+    if (!left || !right) return false
+    if (left === right) return true
+    return !!left.name && !!right.name && left.name === right.name
+  }
+
   function sameWindow(left, right) {
     if (!left || !right) return false
     if (left === right) return true
-    return !!left.screen && !!right.screen && !!left.screen.name && !!right.screen.name && left.screen.name === right.screen.name
+    return sameScreen(left.screen, right.screen)
   }
 
   function targetTooltipHovered(target) {
@@ -722,11 +727,12 @@ Item {
     return true
   }
 
+  // Only scheduleModuleRemoval sets a pending removal, and it has already
+  // checked the mutator is wired.
   function commitPendingRemoval() {
     var pending = barPendingRemoval
     barPendingRemoval = null
     if (!pending) return
-    if (!root.shell || typeof root.shell.mutateShellConfig !== "function") return
 
     root.shell.mutateShellConfig(function(config) {
       removeModuleFromConfig(config, pending.region, pending.name)
@@ -757,10 +763,12 @@ Item {
     return BarModel.dragDistanceOutside({ x: x, y: y }, screen.width, barSize)
   }
 
-  function playPoof(screen, x, y) {
-    barPoofScreen = screen
-    barPoofX = x
-    barPoofY = y
+  // Bursts at the live drag point, so it must run before clearBarDrag
+  // wipes it.
+  function playPoof() {
+    barPoofScreen = barDragScreen
+    barPoofX = barDragScreenX
+    barPoofY = barDragScreenY
     barPoofSerial++
     barPoofActive = true
     poofTimer.restart()
@@ -780,18 +788,9 @@ Item {
 
   function moduleDropAtScene(scenePoint, sourceSlot) {
     var sourceWindow = root.slotWindow(sourceSlot) || root.barDragWindow
-    if (sourceWindow && sourceWindow.contentItem) {
-      // Free-space drops count only inside the bar strip. The window itself
-      // spans the whole screen, so its bounds are not the bar's bounds.
-      var barPoint = sourceWindow.contentItem.mapFromItem(null, scenePoint.x, scenePoint.y)
-      var stripX = root.position === "right" ? sourceWindow.contentItem.width - root.barSize : 0
-      var stripY = root.position === "bottom" ? sourceWindow.contentItem.height - root.barSize : 0
-      var stripWidth = root.vertical ? root.barSize : sourceWindow.contentItem.width
-      var stripHeight = root.vertical ? sourceWindow.contentItem.height : root.barSize
-      if (barPoint.x < stripX || barPoint.x > stripX + stripWidth ||
-          barPoint.y < stripY || barPoint.y > stripY + stripHeight)
-        return null
-    }
+    // Free-space drops count only inside the bar strip. The window itself
+    // spans the whole screen, so its bounds are not the bar's bounds.
+    if (moduleRemoveDistance(windowScreenPoint(scenePoint, sourceWindow)) > 0) return null
 
     var candidates = []
     for (var i = 0; i < moduleSlots.length; i++) {
@@ -1165,10 +1164,10 @@ Item {
 
     Region {
       id: stripInputRegion
-      x: root.position === "right" ? barWindow.width - root.barSize : 0
-      y: root.position === "bottom" ? barWindow.height - root.barSize : 0
-      width: root.vertical ? root.barSize : barWindow.width
-      height: root.vertical ? barWindow.height : root.barSize
+      x: barStrip.x
+      y: barStrip.y
+      width: barStrip.width
+      height: barStrip.height
     }
 
     // The bar itself, pinned to its screen edge.
@@ -1315,11 +1314,8 @@ Item {
     id: ghostWindow
 
     required property var ghostScreen
-    readonly property bool screenMatches: root.barDragScreen === ghostScreen ||
-      (root.barDragScreen && ghostScreen && root.barDragScreen.name && ghostScreen.name && root.barDragScreen.name === ghostScreen.name)
-    readonly property bool active: root.barDragSource && root.barDragScreen && screenMatches
-    readonly property bool poofMatches: root.barPoofScreen === ghostScreen ||
-      (root.barPoofScreen && ghostScreen && root.barPoofScreen.name && ghostScreen.name && root.barPoofScreen.name === ghostScreen.name)
+    readonly property bool active: root.barDragSource && root.sameScreen(root.barDragScreen, ghostScreen)
+    readonly property bool poofMatches: root.sameScreen(root.barPoofScreen, ghostScreen)
     readonly property bool poofShown: root.barPoofActive && poofMatches
     readonly property var sourceItem: root.barDragSource ? root.barDragSource.activeItem : null
     readonly property int ghostPadding: Style.space(1)
@@ -1453,9 +1449,7 @@ Item {
     id: moveGhostWindow
 
     required property var ghostScreen
-    readonly property bool screenMatches: root.barMoveScreen === ghostScreen ||
-      (root.barMoveScreen && ghostScreen && root.barMoveScreen.name && ghostScreen.name && root.barMoveScreen.name === ghostScreen.name)
-    visible: root.barMoveActive && screenMatches
+    visible: root.barMoveActive && root.sameScreen(root.barMoveScreen, ghostScreen)
     color: "transparent"
     exclusionMode: ExclusionMode.Ignore
     WlrLayershell.namespace: "omarchy-bar-move-ghost"
@@ -1949,9 +1943,6 @@ Item {
         var targetSlot = root.barDragTarget
         var afterTarget = root.barDragAfter
         var removeArmed = root.barDragRemoveArmed
-        var poofScreen = root.barDragScreen
-        var poofX = root.barDragScreenX
-        var poofY = root.barDragScreenY
 
         if (wasDragging) suppressClick = true
 
@@ -1962,7 +1953,7 @@ Item {
         // ghost and burst, and the slot hides via the pending removal in the
         // same frame the ghost disappears.
         if (wasDragging && removeArmed && root.scheduleModuleRemoval(slot))
-          root.playPoof(poofScreen, poofX, poofY)
+          root.playPoof()
 
         root.clearBarDrag()
 

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -208,12 +208,29 @@ function nearestDropTarget(candidates, point, vertical) {
   return best
 }
 
+// How far a dragged module sits outside the bar surface, in pixels. Zero
+// while the pointer is anywhere over the bar, so a drag along the bar can
+// never arm removal; the Euclidean distance past the nearest edge otherwise,
+// so a corner escape needs the same pull as a straight one.
+function dragDistanceOutside(point, width, height) {
+  var x = Number(point && point.x)
+  var y = Number(point && point.y)
+  var w = Number(width)
+  var h = Number(height)
+  if (!isFinite(x) || !isFinite(y) || !isFinite(w) || !isFinite(h)) return 0
+
+  var dx = x < 0 ? -x : (x > w ? x - w : 0)
+  var dy = y < 0 ? -y : (y > h ? y - h : 0)
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isDrawnSlot: isDrawnSlot,
     pickDrawnSlot: pickDrawnSlot,
     pickPanelSlot: pickPanelSlot,
     nearestDropTarget: nearestDropTarget,
+    dragDistanceOutside: dragDistanceOutside,
     normalizePosition: normalizePosition,
     entrySettings: entrySettings,
     entryId: entryId,

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -241,7 +241,7 @@ assertDeepEqual(
 )
 assertEqual(bar.nearestDropTarget([], { x: 10, y: 10 }, false), null, 'bar reports no insertion edge without targets')
 assert(
-  /contentItem\.mapFromItem\(null, scenePoint\.x, scenePoint\.y\)[\s\S]*?return null/.test(barSource),
+  /if \(moduleRemoveDistance\(windowScreenPoint\(scenePoint, sourceWindow\)\) > 0\) return null/.test(barSource),
   'bar rejects free-space drops after the pointer leaves the bar'
 )
 assert(
@@ -307,15 +307,12 @@ for (const edge of ['top', 'bottom', 'left', 'right']) {
 // Idle, only the strip may take input, or the transparent expanse would eat
 // every click meant for the windows and desktop below it.
 assert(
-  /Region \{\s*\n\s*id: stripInputRegion[\s\S]*?height: root\.vertical \? barWindow\.height : root\.barSize/.test(barSource),
+  /Region \{\s*\n\s*id: stripInputRegion\s*\n\s*x: barStrip\.x\s*\n\s*y: barStrip\.y\s*\n\s*width: barStrip\.width\s*\n\s*height: barStrip\.height/.test(barSource),
   'the idle input region is exactly the bar strip'
 )
-// The window is no longer the bar's boundary once it can grow, so both the
-// free-space drop rejection and the removal arming measure against the strip.
-assert(
-  /var stripX = root\.position === "right" \? sourceWindow\.contentItem\.width - root\.barSize : 0/.test(barSource),
-  'free-space drops are bounded by the strip, not the window'
-)
+// The window is not the bar's boundary — it spans the whole screen — so both
+// the free-space drop rejection and the removal arming measure against the
+// strip, through the one function that knows its screen-space geometry.
 assert(
   /function moduleRemoveDistance\(screenPoint\) \{[\s\S]*?barDragScreen[\s\S]*?dragDistanceOutside/.test(barSource),
   'removal distance is measured from the strip in screen space'
@@ -332,7 +329,7 @@ assert(
 // every widget on every monitor, which stalls rendering long enough to
 // swallow the whole animation.
 assert(
-  /if \(wasDragging && removeArmed && root\.scheduleModuleRemoval\(slot\)\)\s*\n\s*root\.playPoof\(poofScreen, poofX, poofY\)\s*\n\s*\n?\s*root\.clearBarDrag\(\)/.test(barSource),
+  /if \(wasDragging && removeArmed && root\.scheduleModuleRemoval\(slot\)\)\s*\n\s*root\.playPoof\(\)\s*\n\s*\n?\s*root\.clearBarDrag\(\)/.test(barSource),
   'an armed release starts the poof before the drag state clears'
 )
 assert(

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -284,16 +284,19 @@ assert(
   /root\.barMoveActive && root\.sameWindow\(root\.barMoveWindow, barWindow\)/.test(barSource),
   'the bar-move gesture grows the window too'
 )
+// The grow may only extend the requested size along the open axis. Anchoring
+// all four edges instead voids the exclusive zone — layer-shell reserves
+// space from an anchored edge — and tiled windows jump up behind the bar.
 for (const edge of ['top', 'bottom', 'left', 'right']) {
   assert(
-    new RegExp(`${edge}: root\\.position === "\\w+" \\|\\| ${edge === 'top' || edge === 'bottom' ? 'root\\.vertical' : '!root\\.vertical'} \\|\\| barWindow\\.dragGrown`).test(barSource),
-    `a grown bar anchors its ${edge} edge`
+    !new RegExp(`${edge}:[^\\n]*dragGrown`).test(barSource),
+    `a drag never changes the bar's ${edge} anchor`
   )
 }
 assert(
-  /implicitWidth: root\.vertical && !barWindow\.dragGrown \? root\.barSize : 0/.test(barSource) &&
-  /implicitHeight: root\.vertical \|\| barWindow\.dragGrown \? 0 : root\.barSize/.test(barSource),
-  'a grown bar stretches: layer-shell keeps a non-zero requested size fixed'
+  /implicitWidth: root\.vertical\s*\n\s*\? \(barWindow\.dragGrown && barWindow\.screen \? barWindow\.screen\.width : root\.barSize\)/.test(barSource) &&
+  /implicitHeight: root\.vertical\s*\n\s*\? 0\s*\n\s*: \(barWindow\.dragGrown && barWindow\.screen \? barWindow\.screen\.height : root\.barSize\)/.test(barSource),
+  'a grown bar extends its requested size along the open axis only'
 )
 // The window is no longer the bar's boundary once it can grow, so both the
 // free-space drop rejection and the removal arming measure against the strip.

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -269,11 +269,31 @@ assert(
   'clearing the drag disarms removal'
 )
 
-// The poof plays only for a removal that actually landed in the config, at
-// the point the module was let go.
+// An armed release must poof before the drag state clears — the overlay
+// window would unmap between ghost and burst otherwise — and must defer the
+// config write until the poof has played: persisting shell.json rebuilds
+// every widget on every monitor, which stalls rendering long enough to
+// swallow the whole animation.
 assert(
-  /if \(wasDragging && removeArmed\) \{\s*\n\s*if \(root\.removeBarModule\(slot\)\) root\.playPoof\(poofScreen, poofX, poofY\)/.test(barSource),
-  'an armed release removes the module and poofs where it was dropped'
+  /if \(wasDragging && removeArmed && root\.scheduleModuleRemoval\(slot\)\)\s*\n\s*root\.playPoof\(poofScreen, poofX, poofY\)\s*\n\s*\n?\s*root\.clearBarDrag\(\)/.test(barSource),
+  'an armed release starts the poof before the drag state clears'
+)
+assert(
+  !/removeModuleFromConfig[\s\S]{0,400}?onReleased/.test(barSource.slice(barSource.indexOf('onReleased'))),
+  'the release handler never writes the config synchronously'
+)
+const poofTimerBody = barSource.slice(barSource.indexOf('id: poofTimer'))
+assert(
+  /root\.commitPendingRemoval\(\)/.test(poofTimerBody.slice(0, poofTimerBody.indexOf('\n  }'))),
+  'the config write lands only after the poof has played'
+)
+
+// The module still vanishes at release, not half a second later: its slot
+// collapses while the removal is pending in the layout.
+assert(
+  /implicitWidth: !removalPending && activeItem && activeItem\.visible/.test(barSource) &&
+  /implicitHeight: !removalPending && activeItem && activeItem\.visible/.test(barSource),
+  'a module pending removal collapses out of the bar immediately'
 )
 
 // The ghost overlay is the poof's canvas, so it must stay mapped for the

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -247,6 +247,47 @@ assert(
   'bar draws the insertion marker above the bar in the drag overlay'
 )
 
+// Dragging a module off the bar removes it. The distance is zero anywhere
+// over the bar, so a drag along it can never arm removal, and Euclidean past
+// the nearest edge, so a corner escape needs the same pull as a straight one.
+assertEqual(bar.dragDistanceOutside({ x: 400, y: 13 }, 1920, 26), 0, 'a drag over the bar is never a removal')
+assertEqual(bar.dragDistanceOutside({ x: 400, y: 86 }, 1920, 26), 60, 'a drag below a top bar measures its pull straight down')
+assertEqual(bar.dragDistanceOutside({ x: -30, y: 66 }, 1920, 26), 50, 'a corner escape measures the diagonal, not one axis')
+assertEqual(bar.dragDistanceOutside({ x: 400, y: -25 }, 1920, 26), 25, 'a drag past the desktop-far edge also counts')
+assertEqual(bar.dragDistanceOutside(null, 1920, 26), 0, 'a missing drag point never arms removal')
+
+// Removal arms only when the pull is past the threshold with no insertion
+// edge under it, so an overshoot next to a drop target still reads as a
+// reorder, and it must reset with the rest of the drag state.
+assert(
+  /barDragRemoveArmed = !drop && root\.moduleRemoveDistance\(scenePoint\) >= root\.barDragRemoveDistance/.test(barSource),
+  'removal arms only past the pull threshold with no drop target in reach'
+)
+const clearBarDrag = barSource.slice(barSource.indexOf('function clearBarDrag'))
+assert(
+  /barDragRemoveArmed = false/.test(clearBarDrag.slice(0, clearBarDrag.indexOf('\n  }'))),
+  'clearing the drag disarms removal'
+)
+
+// The poof plays only for a removal that actually landed in the config, at
+// the point the module was let go.
+assert(
+  /if \(wasDragging && removeArmed\) \{\s*\n\s*if \(root\.removeBarModule\(slot\)\) root\.playPoof\(poofScreen, poofX, poofY\)/.test(barSource),
+  'an armed release removes the module and poofs where it was dropped'
+)
+
+// The ghost overlay is the poof's canvas, so it must stay mapped for the
+// burst after the drag state clears, while the ghost itself hides with the
+// drag rather than lingering through the animation.
+assert(
+  /visible: \(active && sourceItem !== null\) \|\| poofShown/.test(barSource),
+  'the drag overlay stays mapped while the poof plays'
+)
+assert(
+  /visible: ghostWindow\.active && ghostWindow\.sourceItem !== null/.test(barSource),
+  'the drag ghost hides with the drag instead of lingering through the poof'
+)
+
 // The open-panel mark sits on the module's desktop-facing edge at every
 // position: under a top bar, over a bottom one, inward from left and right.
 const indicator = barSource.slice(barSource.indexOf('id: openPanelIndicator'), barSource.indexOf('id: openPanelIndicator') + 1600)

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -273,30 +273,42 @@ assert(
 // The drag must survive leaving the bar on an empty workspace. The
 // compositor re-picks a pointer target on any surface commit while nothing
 // holds keyboard focus, and a pointer that has strayed onto another surface
-// is ripped off the bar mid-drag with a synthesized release. The bar window
-// therefore grows to cover its whole screen while its drag is live, so the
-// pointer never leaves the pressed surface however far the drag goes.
+// is ripped off the bar mid-drag with a synthesized release. The bar surface
+// therefore spans the whole screen at all times, and a live drag toggles
+// only its input region — never its size: resizing flashes the stale strip
+// buffer stretched across the new geometry, the dark full-screen blink.
 assert(
-  /readonly property bool dragGrown: \(root\.barDragSource !== null && root\.sameWindow\(root\.barDragWindow, barWindow\)\)/.test(barSource),
-  'the bar grows for its own live drag, matched by window rather than identity'
+  /readonly property bool dragActive: \(root\.barDragSource !== null && root\.sameWindow\(root\.barDragWindow, barWindow\)\)/.test(barSource),
+  'the bar arms drag input for its own drag, matched by window rather than identity'
 )
 assert(
   /root\.barMoveActive && root\.sameWindow\(root\.barMoveWindow, barWindow\)/.test(barSource),
-  'the bar-move gesture grows the window too'
+  'the bar-move gesture arms drag input too'
 )
-// The grow may only extend the requested size along the open axis. Anchoring
-// all four edges instead voids the exclusive zone — layer-shell reserves
-// space from an anchored edge — and tiled windows jump up behind the bar.
+assert(
+  /mask: barWindow\.dragActive \? null : stripInputRegion/.test(barSource),
+  'a drag toggles only the input region, never the surface size'
+)
+assert(
+  !/dragActive[^\n]*\?[^\n]*screen\.(width|height)/.test(barSource) &&
+  /implicitWidth: root\.vertical\s*\n\s*\? \(barWindow\.screen \? barWindow\.screen\.width : root\.barSize\)/.test(barSource) &&
+  /implicitHeight: root\.vertical\s*\n\s*\? 0\s*\n\s*: \(barWindow\.screen \? barWindow\.screen\.height : root\.barSize\)/.test(barSource),
+  'the bar surface spans the screen unconditionally instead of resizing mid-drag'
+)
+// Anchoring all four edges would void the exclusive zone — layer-shell
+// reserves space from an anchored edge — and tiled windows would jump up
+// behind the bar.
 for (const edge of ['top', 'bottom', 'left', 'right']) {
   assert(
-    !new RegExp(`${edge}:[^\\n]*dragGrown`).test(barSource),
+    !new RegExp(`${edge}:[^\\n]*dragActive`).test(barSource),
     `a drag never changes the bar's ${edge} anchor`
   )
 }
+// Idle, only the strip may take input, or the transparent expanse would eat
+// every click meant for the windows and desktop below it.
 assert(
-  /implicitWidth: root\.vertical\s*\n\s*\? \(barWindow\.dragGrown && barWindow\.screen \? barWindow\.screen\.width : root\.barSize\)/.test(barSource) &&
-  /implicitHeight: root\.vertical\s*\n\s*\? 0\s*\n\s*: \(barWindow\.dragGrown && barWindow\.screen \? barWindow\.screen\.height : root\.barSize\)/.test(barSource),
-  'a grown bar extends its requested size along the open axis only'
+  /Region \{\s*\n\s*id: stripInputRegion[\s\S]*?height: root\.vertical \? barWindow\.height : root\.barSize/.test(barSource),
+  'the idle input region is exactly the bar strip'
 )
 // The window is no longer the bar's boundary once it can grow, so both the
 // free-space drop rejection and the removal arming measure against the strip.

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -37,8 +37,14 @@ assert(
   'bar stays mapped while hidden so revealing it does not rebuild the surface'
 )
 assert(
-  /exclusionMode: root\.barHidden \? ExclusionMode\.Ignore : ExclusionMode\.Auto/.test(barSource),
+  /exclusionMode: root\.barHidden \? ExclusionMode\.Ignore : ExclusionMode\.Normal/.test(barSource),
   'a hidden bar reserves no space for itself'
+)
+// The zone is explicit because the window is not always strip-sized: it
+// grows to the whole screen during a drag, and Auto would reserve all of it.
+assert(
+  /exclusiveZone: root\.barSize/.test(barSource),
+  'the bar reserves exactly its strip regardless of window size'
 )
 for (const edge of ['top', 'bottom', 'left', 'right']) {
   assert(
@@ -260,8 +266,44 @@ assertEqual(bar.dragDistanceOutside(null, 1920, 26), 0, 'a missing drag point ne
 // edge under it, so an overshoot next to a drop target still reads as a
 // reorder, and it must reset with the rest of the drag state.
 assert(
-  /barDragRemoveArmed = !drop && root\.moduleRemoveDistance\(scenePoint\) >= root\.barDragRemoveDistance/.test(barSource),
+  /barDragRemoveArmed = !drop && root\.moduleRemoveDistance\(screenPoint\) >= root\.barDragRemoveDistance/.test(barSource),
   'removal arms only past the pull threshold with no drop target in reach'
+)
+
+// The drag must survive leaving the bar on an empty workspace. The
+// compositor re-picks a pointer target on any surface commit while nothing
+// holds keyboard focus, and a pointer that has strayed onto another surface
+// is ripped off the bar mid-drag with a synthesized release. The bar window
+// therefore grows to cover its whole screen while its drag is live, so the
+// pointer never leaves the pressed surface however far the drag goes.
+assert(
+  /readonly property bool dragGrown: \(root\.barDragSource !== null && root\.sameWindow\(root\.barDragWindow, barWindow\)\)/.test(barSource),
+  'the bar grows for its own live drag, matched by window rather than identity'
+)
+assert(
+  /root\.barMoveActive && root\.sameWindow\(root\.barMoveWindow, barWindow\)/.test(barSource),
+  'the bar-move gesture grows the window too'
+)
+for (const edge of ['top', 'bottom', 'left', 'right']) {
+  assert(
+    new RegExp(`${edge}: root\\.position === "\\w+" \\|\\| ${edge === 'top' || edge === 'bottom' ? 'root\\.vertical' : '!root\\.vertical'} \\|\\| barWindow\\.dragGrown`).test(barSource),
+    `a grown bar anchors its ${edge} edge`
+  )
+}
+assert(
+  /implicitWidth: root\.vertical && !barWindow\.dragGrown \? root\.barSize : 0/.test(barSource) &&
+  /implicitHeight: root\.vertical \|\| barWindow\.dragGrown \? 0 : root\.barSize/.test(barSource),
+  'a grown bar stretches: layer-shell keeps a non-zero requested size fixed'
+)
+// The window is no longer the bar's boundary once it can grow, so both the
+// free-space drop rejection and the removal arming measure against the strip.
+assert(
+  /var stripX = root\.position === "right" \? sourceWindow\.contentItem\.width - root\.barSize : 0/.test(barSource),
+  'free-space drops are bounded by the strip, not the window'
+)
+assert(
+  /function moduleRemoveDistance\(screenPoint\) \{[\s\S]*?barDragScreen[\s\S]*?dragDistanceOutside/.test(barSource),
+  'removal distance is measured from the strip in screen space'
 )
 const clearBarDrag = barSource.slice(barSource.indexOf('function clearBarDrag'))
 assert(


### PR DESCRIPTION
Dragging a widget off the bar now removes it, macOS-dock style: pull it past a threshold, the drag ghost shrinks and dims to signal removal, and on release the widget vanishes from the bar in a puff of smoke at the drop point. Reordering by drag is unchanged — removal only arms when the pull is well clear of the bar with no insertion edge in reach.


https://github.com/user-attachments/assets/25d296b0-f40d-419b-a29d-0e82f232cb49


## How it works

- **Arming**: while dragging, if there's no drop target and the pointer has pulled more than `Style.spaceReal(48)` past the bar strip (Euclidean past the nearest edge, so corner escapes need the same pull), the drag arms for removal. The geometry lives in `BarModel.js` so it's node-testable.
- **Feedback**: the ghost scales to 0.82 and fades to 0.55 while armed, and snaps back if the pointer returns within range.
- **Removal**: splices just that entry from its region in `shell.json` via the same `mutateShellConfig` path reorders use. A clone dragged off vanishes rather than resurrecting the widget it shadows (deliberate divergence from a settings-page disable, where restoring the source is the owner's intent).
- **Poof**: a ring of soft dots drifting outward around a collapsing center puff, drawn in the existing per-screen drag overlay in the bar's foreground color. The slot collapses at release, and the config write is deferred until the poof has played — persisting shell.json rebuilds every widget on every monitor, which stalls the render loop long enough to swallow the whole animation.

## Compositor findings along the way

Two Hyprland behaviors shaped the implementation, both found by driving real drags with a virtual uinput mouse:

1. **Drags died on empty workspaces.** Hyprland only holds a pressed surface's pointer focus while something on the workspace holds keyboard focus. On an empty workspace, any mid-drag refocus trigger rips the pointer off the bar and ends the gesture with a synthesized release. The bar surface now spans its whole screen at all times (transparent outside the painted strip, explicit exclusive zone so tiling is unaffected, input region masked to the strip when idle). A live drag toggles only the input region to full — the pointer then never has a reason to be handed to another surface. Arguably a compositor bug worth reporting upstream: pointer-focus retention during a button-drag shouldn't depend on keyboard focus.

2. **Resizing the surface for the drag flashed a full-screen dark blink** — the compositor stretches the stale strip buffer across the new geometry until the freshly rendered frame lands. Hence "always full-size + mask toggle" instead of growing on demand; an input-region change is a plain commit with nothing to stretch.

## Testing

- `./test/shell` bar suite extended: arming geometry unit tests, poof/commit ordering, the never-resize and strip-input-region invariants, and anchors that must not change during a drag (all four anchored would void the exclusive zone and drop tiled windows behind the bar).
- Verified live with injected pointer drags on both an empty workspace and one with windows: removal with poof, reorder, plain clicks, click-through of the transparent expanse, no re-tiling, and 60fps frame analysis showing no blink.

One trade-off to note: the bar's layer surface now always reports screen size in `hyprctl layers`. It's transparent and input-masked outside the strip, but if direct scanout for fullscreen apps ever gets picky about overlapping layer surfaces, this is the first place to look.