### PR TITLE
fix(shell): reload only the changed local plugin

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -90,14 +90,14 @@ QtObject {
     return manifest
   }
 
-  function entryPointUrl(manifest, kind) {
+  function entryPointUrl(manifest, kind, sourceDir) {
     if (!Util.isPlainObject(manifest)) return ""
     var ep = manifest.entryPoints ? manifest.entryPoints[kind] : null
     if (!ep) return ""
-    var dir = manifest.__sourceDir || ""
+    var dir = sourceDir || manifest.__sourceDir || ""
     if (!dir) return ""
     // Defense in depth: even after validateManifest, confirm the resolved
-    // path stays inside the plugin's sourceDir.
+    // path stays inside the selected source directory.
     var resolved = dir.replace(/\/$/, "") + "/" + String(ep)
     var expectedPrefix = dir.replace(/\/$/, "") + "/"
     if (resolved.indexOf(expectedPrefix) !== 0) {

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -29,7 +29,7 @@ QtObject {
   signal pluginsChanged()
   signal scanFinished()
   signal pluginLoadFailed(string id, string error)
-  signal localPluginChanged(string id)
+  signal localPluginChanged(string sourceDir)
 
   // ---------------------------------------------------------------- helpers
 
@@ -647,8 +647,8 @@ QtObject {
     ]
     stdout: SplitParser {
       onRead: function(path) {
-        var pluginId = registry.localPluginIdForPath(path)
-        if (pluginId) registry.localPluginChanged(pluginId)
+        var sourceDir = registry.localPluginSourceDirForPath(path)
+        if (sourceDir) registry.localPluginChanged(sourceDir)
       }
     }
     onExited: localPluginWatcherRestart.restart()
@@ -710,6 +710,21 @@ QtObject {
 
     var slash = relative.indexOf("/")
     return slash === -1 ? relative : relative.slice(0, slash)
+  }
+
+  function localPluginSourceDirForPath(filePath) {
+    var directory = localPluginIdForPath(filePath)
+    return directory ? pluginsDir.replace(/\/$/, "") + "/" + directory : ""
+  }
+
+  function pluginIdForSourceDir(sourceDir) {
+    var source = String(sourceDir || "").replace(/\/$/, "")
+    if (!source) return ""
+    for (var id in installedPlugins) {
+      var manifest = installedPlugins[id]
+      if (String(manifest.__sourceDir || "").replace(/\/$/, "") === source) return id
+    }
+    return ""
   }
 
   Component.onCompleted: ensureUserDir()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -884,11 +884,14 @@ ShellRoot {
     return shell.fullPluginReloading || shell.activePluginReloads[String(pluginId || "")] === true
   }
 
-  function queueLocalPluginReload(pluginId) {
-    var id = String(pluginId || "")
-    if (!id) return
+  function queueLocalPluginReload(sourceDir) {
+    var pluginId = shell.pluginRegistry.pluginIdForSourceDir(sourceDir)
+    if (!pluginId) {
+      shell.reloadPlugins()
+      return
+    }
     var reload = ({})
-    reload[id] = true
+    reload[pluginId] = true
     pendingLocalPluginReloads = shell.mergePluginReloads(pendingLocalPluginReloads, reload)
     localPluginReloadTimer.restart()
   }
@@ -901,8 +904,8 @@ ShellRoot {
     pendingLocalPluginReloads = ({})
     for (var id in reloads) shell.preparePanelReload(id)
 
-    // The watcher already resolved the owning plugin, so keep every unrelated
-    // service, panel, bar, and widget mounted while the registry rescans.
+    // Keep every unrelated service, panel, bar, and widget mounted while the
+    // registry rescans.
     activePluginReloads = reloads
     for (var pluginId in reloads) {
       shell.unloadPluginService(pluginId)
@@ -944,9 +947,9 @@ ShellRoot {
 
   Connections {
     target: shell.pluginRegistry
-    function onLocalPluginChanged(pluginId) {
-      console.log("Local plugin changed, reloading:", pluginId)
-      shell.queueLocalPluginReload(pluginId)
+    function onLocalPluginChanged(sourceDir) {
+      console.log("Local plugin changed, reloading:", sourceDir)
+      shell.queueLocalPluginReload(sourceDir)
     }
     function onScanFinished() {
       if (shell.fullPluginReloadPending) {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -212,7 +212,10 @@ ShellRoot {
   function pluginEntryPointUrl(manifest, kind) {
     if (!manifest) return ""
     var sourceDir = String(manifest.__sourceDir || "")
-    var revision = shell.pluginSourceRevisions[String(manifest.id || "")] || 0
+    // Revisions are keyed by source directory, not manifest id: the symlinked
+    // revision versions the directory's files, and a rescan may change which
+    // id a directory carries.
+    var revision = shell.pluginSourceRevisions[sourceDir] || 0
     if (revision > 0) {
       // A revisioned base URL also changes cache keys for relative QML and JS.
       var pluginsDir = shell.pluginRegistry.pluginsDir.replace(/\/$/, "")
@@ -786,7 +789,7 @@ ShellRoot {
 
       var registryKey = String(manifest.id)
       seen[registryKey] = true
-      if (targeted && reloadIds[registryKey] !== true) continue
+      if (targeted && !reloadIds[registryKey]) continue
 
       // Already loaded with matching source — leave it alone.
       var existing = pluginWidgetComponents[registryKey]
@@ -831,7 +834,7 @@ ShellRoot {
     var allIds = shell.barWidgetRegistry.availableIds()
     for (var i = 0; i < allIds.length; i++) {
       var id = allIds[i]
-      if (targeted && reloadIds[id] !== true) continue
+      if (targeted && !reloadIds[id]) continue
       if (!pluginWidgetComponents[id]) continue
       if (!seen[id]) {
         shell.barWidgetRegistry.unregister(id)
@@ -857,18 +860,20 @@ ShellRoot {
     return reloads && Object.keys(reloads).length > 0
   }
 
+  // Reload sets map pluginId -> sourceDir, so a rescan that changes which id
+  // a directory carries can still be reconciled afterwards.
   function mergePluginReloads(current, additions) {
     var next = ({})
-    for (var id in current) next[id] = true
-    for (var addedId in additions) next[addedId] = true
+    for (var id in current) next[id] = current[id]
+    for (var addedId in additions) next[addedId] = additions[addedId]
     return next
   }
 
   function preparePluginSourceRevision(reloads) {
     pluginSourceRevisionCounter++
     var next = ({})
-    for (var id in pluginSourceRevisions) next[id] = pluginSourceRevisions[id]
-    for (var reloadId in reloads) next[reloadId] = pluginSourceRevisionCounter
+    for (var dir in pluginSourceRevisions) next[dir] = pluginSourceRevisions[dir]
+    for (var reloadId in reloads) next[reloads[reloadId]] = pluginSourceRevisionCounter
     preparedPluginSourceRevisions = next
 
     var script = "mkdir -p -- \"$0/$2\" && ln -s -- \"$1\" \"$0/$2/plugins\""
@@ -900,7 +905,7 @@ ShellRoot {
   }
 
   function pluginReloadAffects(pluginId) {
-    return shell.fullPluginReloading || shell.activePluginReloads[String(pluginId || "")] === true
+    return shell.fullPluginReloading || !!shell.activePluginReloads[String(pluginId || "")]
   }
 
   function queueLocalPluginReload(sourceDir) {
@@ -914,7 +919,7 @@ ShellRoot {
       pendingLocalPluginFullReload = true
     } else {
       var reload = ({})
-      reload[pluginId] = true
+      reload[pluginId] = String(sourceDir)
       pendingLocalPluginReloads = shell.mergePluginReloads(pendingLocalPluginReloads, reload)
     }
     localPluginReloadTimer.restart()
@@ -995,7 +1000,16 @@ ShellRoot {
       }
 
       var fullReload = shell.fullPluginReloading
-      var reloads = shell.activePluginReloads
+      // A rescan can change which manifest id a reloaded directory carries;
+      // sync the directory's current id as well as the one it had before, so
+      // a renamed plugin is picked up and the old one dropped.
+      var reloads = ({})
+      for (var reloadId in shell.activePluginReloads) {
+        var reloadDir = shell.activePluginReloads[reloadId]
+        reloads[reloadId] = reloadDir
+        var currentId = shell.pluginRegistry.pluginIdForSourceDir(reloadDir)
+        if (currentId && currentId !== reloadId) reloads[currentId] = reloadDir
+      }
       // While a targeted reload gates the pluginsChanged handlers, only our
       // own rescan should bump registryRevision (by exactly one). Any extra
       // bump means shell.json or plugin enablement changed inside the window;

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -552,6 +552,13 @@ ShellRoot {
       return hidden === true
     }
     invokeIfLoaded(id, "close", null)
+    // Drop any queued open payloads: a payload staged for a load or reload
+    // still in flight must not reopen a panel the user just dismissed.
+    if (pendingPayloads[id]) {
+      var pendingNext = ({})
+      for (var p in pendingPayloads) if (p !== id) pendingNext[p] = pendingPayloads[p].slice()
+      pendingPayloads = pendingNext
+    }
     if (!openPanelIds[id]) return true
     var next = ({})
     for (var k in openPanelIds) if (k !== id) next[k] = openPanelIds[k]
@@ -686,6 +693,22 @@ ShellRoot {
     return out
   }
 
+  // Forget a panel's open state and any staged payload — for a plugin whose
+  // panel went away, they would otherwise replay on a later summon or enable.
+  function dropPanelStateFor(pluginId) {
+    var id = String(pluginId || "")
+    if (openPanelIds[id]) {
+      var opened = ({})
+      for (var openId in openPanelIds) if (openId !== id) opened[openId] = openPanelIds[openId]
+      openPanelIds = opened
+    }
+    if (pendingPayloads[id]) {
+      var pendingNext = ({})
+      for (var p in pendingPayloads) if (p !== id) pendingNext[p] = pendingPayloads[p].slice()
+      pendingPayloads = pendingNext
+    }
+  }
+
   function syncReloadedPanelEntries(reloadIds) {
     var next = panelEntries.slice()
     var changed = false
@@ -705,6 +728,7 @@ ShellRoot {
       } else if (index !== -1 && !entry) {
         next.splice(index, 1)
         changed = true
+        shell.dropPanelStateFor(id)
       }
     }
     if (changed) panelEntries = next
@@ -1017,6 +1041,12 @@ ShellRoot {
       var interrupted = shell.pluginRegistry.registryRevision !== shell.pluginReloadBaseRevision + 1
       shell._syncServices()
       if (fullReload || interrupted || !shell.hasPluginReloads(reloads)) {
+        // Replacing panelEntries wholesale skips syncReloadedPanelEntries'
+        // cleanup, so drop state for reloaded plugins whose panel went away.
+        if (!fullReload) {
+          for (var droppedId in reloads)
+            if (!shell.panelEntryFor(droppedId)) shell.dropPanelStateFor(droppedId)
+        }
         shell.panelEntries = shell.computePanelEntries()
         shell.syncPluginWidgets()
       } else {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -54,13 +54,17 @@ ShellRoot {
 
   property var defaultsConfig: builtinShellConfig
   property var shellConfig: builtinShellConfig
-  property bool pluginReloading: false
-  property bool pluginReloadPending: false
+  property bool fullPluginReloading: false
+  property bool fullPluginReloadPending: false
+  property var activePluginReloads: ({})
+  property var pendingLocalPluginReloads: ({})
+  property var pluginSourceRevisions: ({})
+  readonly property bool pluginReloading: fullPluginReloading || Object.keys(activePluginReloads).length > 0
 
   Timer {
     id: localPluginReloadTimer
     interval: 150
-    onTriggered: shell.reloadPlugins()
+    onTriggered: shell.reloadLocalPlugins()
   }
 
   onShellConfigChanged: {
@@ -182,7 +186,7 @@ ShellRoot {
     var revision = shell.pluginRegistry.registryRevision
     return shell.barManifestFor(shell.activeBarId)
   }
-  readonly property string activeBarSourceUrl: activeBarId === defaultBarId ? "" : shell.pluginRegistry.entryPointUrl(activeBarManifest, "bar")
+  readonly property string activeBarSourceUrl: activeBarId === defaultBarId ? "" : shell.pluginEntryPointUrl(activeBarManifest, "bar")
   property var bar: null
 
   onSelectedBarIdChanged: if (failedBarId !== "") failedBarId = ""
@@ -190,6 +194,15 @@ ShellRoot {
   function barManifestFor(pluginId) {
     var plugins = shell.pluginRegistry ? shell.pluginRegistry.installedPlugins : null
     return plugins ? plugins[String(pluginId || "")] || null : null
+  }
+
+  function pluginEntryPointUrl(manifest, kind) {
+    var url = shell.pluginRegistry.entryPointUrl(manifest, kind)
+    if (!url || !manifest) return url
+    // Destroyed Components can retain compiled QML past clearComponentCache().
+    // A per-plugin URL revision guarantees local edits load the new code.
+    var revision = shell.pluginSourceRevisions[String(manifest.id || "")] || 0
+    return revision > 0 ? url + "?reload=" + revision : url
   }
 
   function isBarOptionManifest(manifest) {
@@ -246,7 +259,9 @@ ShellRoot {
   Loader {
     id: pluginBarLoader
 
-    active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
+    active: !shell.pluginReloadAffects(shell.activeBarId)
+      && shell.activeBarId !== shell.defaultBarId
+      && shell.activeBarSourceUrl !== ""
     source: shell.activeBarId !== shell.defaultBarId ? shell.activeBarSourceUrl : ""
     asynchronous: true
     onLoaded: shell.configureBar(item, shell.activeBarManifest)
@@ -288,7 +303,7 @@ ShellRoot {
     if (!manifest) return null
     if (!Array.isArray(manifest.kinds) || manifest.kinds.indexOf("service") === -1) return null
     if (!manifest.entryPoints || !manifest.entryPoints.service) return null
-    var url = pluginRegistry.entryPointUrl(manifest, "service")
+    var url = shell.pluginEntryPointUrl(manifest, "service")
     if (!url) return null
 
     var comp = Qt.createComponent(url, Component.PreferSynchronous)
@@ -343,6 +358,16 @@ ShellRoot {
       for (var k in _services) if (k !== existingId) next[k] = _services[k]
       _services = next
     }
+  }
+
+  function unloadPluginService(pluginId) {
+    var key = String(pluginId || "")
+    var inst = _services[key]
+    if (!inst) return
+    if (typeof inst.destroy === "function") inst.destroy()
+    var next = ({})
+    for (var existingId in _services) if (existingId !== key) next[existingId] = _services[existingId]
+    _services = next
   }
 
   function unloadPluginServices() {
@@ -530,6 +555,19 @@ ShellRoot {
     panelLoaders = next
   }
 
+  function preparePanelReload(pluginId) {
+    var key = String(pluginId || "")
+    if (!key || shell.isBarWidgetPanelPlugin(key) || !shell.isPluginOpen(key)) return
+    shell.invokeIfLoaded(key, "close", null)
+
+    var next = ({})
+    for (var id in pendingPayloads) next[id] = pendingPayloads[id].slice()
+    var queue = next[key] || []
+    if (queue.length === 0) queue.push("")
+    next[key] = queue
+    pendingPayloads = next
+  }
+
   function unloadPanels() {
     for (var id in panelLoaders) hide(id)
     panelEntries = []
@@ -583,23 +621,53 @@ ShellRoot {
   // plugin's FloatingWindow + state survive between summons within a session.
   property var panelEntries: []
 
+  function panelKindForManifest(manifest) {
+    if (!manifest || !Array.isArray(manifest.kinds)) return ""
+    if (manifest.kinds.indexOf("panel") !== -1) return "panel"
+    if (manifest.kinds.indexOf("overlay") !== -1) return "overlay"
+    if (manifest.kinds.indexOf("menu") !== -1) return "menu"
+    return ""
+  }
+
+  function panelEntryFor(pluginId) {
+    var id = String(pluginId || "")
+    var manifest = shell.pluginRegistry.installedPlugins[id]
+    if (!shell.panelKindForManifest(manifest) || !shell.pluginRegistry.isEnabled(id)) return null
+    return { id: id }
+  }
+
   function computePanelEntries() {
     var out = []
     var plugins = shell.pluginRegistry.installedPlugins
-    var panelKinds = ["panel", "overlay", "menu"]
     for (var id in plugins) {
-      var m = plugins[id]
-      if (!m || !Array.isArray(m.kinds)) continue
-      var matched = false
-      for (var i = 0; i < panelKinds.length; i++)
-        if (m.kinds.indexOf(panelKinds[i]) !== -1) { matched = true; break }
-      if (!matched) continue
-      if (!shell.pluginRegistry.isEnabled(id)) continue
-      var kind = m.kinds.indexOf("panel") !== -1 ? "panel"
-        : (m.kinds.indexOf("overlay") !== -1 ? "overlay" : "menu")
-      out.push({ id: id, manifest: m, kind: kind, keepLoaded: m.keepLoaded === true })
+      var entry = shell.panelEntryFor(id)
+      if (entry) out.push(entry)
     }
     return out
+  }
+
+  function syncReloadedPanelEntries(reloadIds) {
+    var next = panelEntries.slice()
+    var changed = false
+    for (var id in reloadIds) {
+      var index = -1
+      for (var i = 0; i < next.length; i++) {
+        if (next[i].id === id) {
+          index = i
+          break
+        }
+      }
+
+      var entry = shell.panelEntryFor(id)
+      if (index === -1 && entry) {
+        next.push(entry)
+        changed = true
+      } else if (index !== -1 && !entry) {
+        next.splice(index, 1)
+        changed = true
+      }
+    }
+    if (changed) panelEntries = next
   }
 
   Connections {
@@ -615,14 +683,16 @@ ShellRoot {
       id: panelEntry
       required property var modelData
       readonly property string pluginId: modelData.id
-      readonly property var manifest: modelData.manifest
-      readonly property string entryKind: modelData.kind
-      readonly property bool keepLoaded: modelData.keepLoaded === true
-      readonly property string sourceUrl: shell.pluginRegistry.entryPointUrl(manifest, entryKind)
+      readonly property var manifest: shell.pluginRegistry.installedPlugins[pluginId] || null
+      readonly property string entryKind: shell.panelKindForManifest(manifest)
+      readonly property bool keepLoaded: manifest ? manifest.keepLoaded === true : false
+      readonly property string sourceUrl: shell.pluginEntryPointUrl(manifest, entryKind)
 
       property Loader panelLoader: Loader {
         source: panelEntry.sourceUrl
-        active: panelEntry.sourceUrl !== "" && (panelEntry.keepLoaded || shell.openPanelIds[panelEntry.pluginId] === true)
+        active: !shell.pluginReloadAffects(panelEntry.pluginId)
+          && panelEntry.sourceUrl !== ""
+          && (panelEntry.keepLoaded || shell.openPanelIds[panelEntry.pluginId] === true)
         asynchronous: true
         onLoaded: {
           if (!item) return
@@ -665,10 +735,12 @@ ShellRoot {
   }
 
   property var pluginWidgetComponents: ({})
+  property int pluginWidgetLoadRevision: 0
 
-  function syncPluginWidgets() {
+  function syncPluginWidgets(reloadIds) {
     var plugins = shell.pluginRegistry.installedPlugins
     var seen = ({})
+    var targeted = reloadIds && Object.keys(reloadIds).length > 0
 
     for (var pluginId in plugins) {
       var manifest = plugins[pluginId]
@@ -677,10 +749,11 @@ ShellRoot {
 
       var registryKey = String(manifest.id)
       seen[registryKey] = true
+      if (targeted && reloadIds[registryKey] !== true) continue
 
       // Already loaded with matching source — leave it alone.
       var existing = pluginWidgetComponents[registryKey]
-      var url = shell.pluginRegistry.entryPointUrl(manifest, "barWidget")
+      var url = shell.pluginEntryPointUrl(manifest, "barWidget")
       if (!url) {
         console.warn("Plugin " + manifest.id + " has no barWidget entry point")
         continue
@@ -721,6 +794,7 @@ ShellRoot {
     var allIds = shell.barWidgetRegistry.availableIds()
     for (var i = 0; i < allIds.length; i++) {
       var id = allIds[i]
+      if (targeted && reloadIds[id] !== true) continue
       if (!pluginWidgetComponents[id]) continue
       if (!seen[id]) {
         shell.barWidgetRegistry.unregister(id)
@@ -731,17 +805,75 @@ ShellRoot {
     }
   }
 
+  function unloadPluginWidget(pluginId) {
+    var key = String(pluginId || "")
+    shell.barWidgetRegistry.unregister(key)
+    shell.setPluginWidgetComponent(key, null)
+  }
+
   function unloadPluginWidgets() {
     for (var id in pluginWidgetComponents) shell.barWidgetRegistry.unregister(id)
     pluginWidgetComponents = ({})
   }
 
+  function hasPluginReloads(reloads) {
+    return reloads && Object.keys(reloads).length > 0
+  }
+
+  function mergePluginReloads(current, additions) {
+    var next = ({})
+    for (var id in current) next[id] = true
+    for (var addedId in additions) next[addedId] = true
+    return next
+  }
+
+  function bumpPluginSourceRevisions(reloads) {
+    var next = ({})
+    for (var id in pluginSourceRevisions) next[id] = pluginSourceRevisions[id]
+    for (var reloadId in reloads) next[reloadId] = (next[reloadId] || 0) + 1
+    pluginSourceRevisions = next
+  }
+
+  function pluginReloadAffects(pluginId) {
+    return shell.fullPluginReloading || shell.activePluginReloads[String(pluginId || "")] === true
+  }
+
+  function queueLocalPluginReload(pluginId) {
+    var id = String(pluginId || "")
+    if (!id) return
+    var reload = ({})
+    reload[id] = true
+    pendingLocalPluginReloads = shell.mergePluginReloads(pendingLocalPluginReloads, reload)
+    localPluginReloadTimer.restart()
+  }
+
+  function reloadLocalPlugins() {
+    if (!shell.hasPluginReloads(shell.pendingLocalPluginReloads)) return
+    if (shell.pluginReloading || shell.pluginRegistry.scanning) return
+
+    var reloads = shell.pendingLocalPluginReloads
+    pendingLocalPluginReloads = ({})
+    for (var id in reloads) shell.preparePanelReload(id)
+
+    // The watcher already resolved the owning plugin, so keep every unrelated
+    // service, panel, bar, and widget mounted while the registry rescans.
+    activePluginReloads = reloads
+    shell.bumpPluginSourceRevisions(reloads)
+    for (var pluginId in reloads) {
+      shell.unloadPluginService(pluginId)
+      shell.unloadPluginWidget(pluginId)
+    }
+    Qt.callLater(shell.finishPluginReload)
+  }
+
   function reloadPlugins() {
     if (shell.pluginReloading || shell.pluginRegistry.scanning) {
-      shell.pluginReloadPending = true
+      shell.fullPluginReloadPending = true
       return
     }
-    shell.pluginReloading = true
+    pendingLocalPluginReloads = ({})
+    activePluginReloads = ({})
+    fullPluginReloading = true
     shell.unloadPanels()
     shell.unloadPluginServices()
     shell.unloadPluginWidgets()
@@ -751,7 +883,14 @@ ShellRoot {
   function finishPluginReload() {
     if (!shell.pluginReloading) return
     if (shell.pluginRegistry.scanning) {
-      shell.pluginReloadPending = true
+      if (shell.fullPluginReloading) {
+        shell.fullPluginReloadPending = true
+      } else {
+        shell.pendingLocalPluginReloads = shell.mergePluginReloads(
+          shell.pendingLocalPluginReloads, shell.activePluginReloads)
+      }
+      shell.fullPluginReloading = false
+      shell.activePluginReloads = ({})
       return
     }
     if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
@@ -762,19 +901,32 @@ ShellRoot {
     target: shell.pluginRegistry
     function onLocalPluginChanged(pluginId) {
       console.log("Local plugin changed, reloading:", pluginId)
-      localPluginReloadTimer.restart()
+      shell.queueLocalPluginReload(pluginId)
     }
     function onScanFinished() {
-      if (shell.pluginReloadPending) {
-        shell.pluginReloadPending = false
-        shell.pluginReloading = false
+      if (shell.fullPluginReloadPending) {
+        shell.fullPluginReloadPending = false
+        shell.fullPluginReloading = false
+        shell.activePluginReloads = ({})
+        shell.pendingLocalPluginReloads = ({})
         Qt.callLater(shell.reloadPlugins)
         return
       }
-      shell.pluginReloading = false
+
+      var fullReload = shell.fullPluginReloading
+      var reloads = shell.activePluginReloads
       shell._syncServices()
-      shell.panelEntries = shell.computePanelEntries()
-      shell.syncPluginWidgets()
+      if (fullReload || !shell.hasPluginReloads(reloads)) {
+        shell.panelEntries = shell.computePanelEntries()
+        shell.syncPluginWidgets()
+      } else {
+        shell.syncReloadedPanelEntries(reloads)
+        shell.syncPluginWidgets(reloads)
+      }
+      shell.fullPluginReloading = false
+      shell.activePluginReloads = ({})
+      if (shell.hasPluginReloads(shell.pendingLocalPluginReloads))
+        Qt.callLater(shell.reloadLocalPlugins)
     }
   }
 
@@ -786,17 +938,27 @@ ShellRoot {
   }
 
   function loadPluginWidget(registryKey, url, meta) {
-    // Claim the key before the component exists. Qt.createComponent is
-    // asynchronous and syncPluginWidgets runs several times while the shell
-    // starts, so without a marker the later passes cannot tell a load in
-    // flight from one that never happened.
-    setPluginWidgetComponent(registryKey, { url: url, component: null })
+    // Claim the key before the component exists. The revision also prevents a
+    // canceled asynchronous load from registering after a targeted reload.
+    pluginWidgetLoadRevision++
+    var loadRevision = pluginWidgetLoadRevision
+    setPluginWidgetComponent(registryKey, {
+      url: url,
+      component: null,
+      loadRevision: loadRevision
+    })
 
     var comp = Qt.createComponent(url, Component.Asynchronous)
     function finalize() {
+      var pending = shell.pluginWidgetComponents[registryKey]
+      if (!pending || pending.loadRevision !== loadRevision) return
       if (comp.status === Component.Ready) {
         shell.barWidgetRegistry.register(registryKey, comp, meta)
-        shell.setPluginWidgetComponent(registryKey, { url: url, component: comp })
+        shell.setPluginWidgetComponent(registryKey, {
+          url: url,
+          component: comp,
+          loadRevision: loadRevision
+        })
       } else if (comp.status === Component.Error) {
         console.warn("Plugin widget " + registryKey + " failed: " + comp.errorString())
         // Drop the claim so a later rescan can retry.

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -59,6 +59,7 @@ ShellRoot {
   property var activePluginReloads: ({})
   property var pendingLocalPluginReloads: ({})
   property bool pendingLocalPluginFullReload: false
+  property int pluginReloadBaseRevision: 0
   property var pluginSourceRevisions: ({})
   property var preparedPluginSourceRevisions: ({})
   property int pluginSourceRevisionCounter: 0
@@ -930,6 +931,7 @@ ShellRoot {
 
     var reloads = shell.pendingLocalPluginReloads
     pendingLocalPluginReloads = ({})
+    pluginReloadBaseRevision = shell.pluginRegistry.registryRevision
     for (var id in reloads) shell.preparePanelReload(id)
 
     // Keep every unrelated service, panel, bar, and widget mounted while the
@@ -994,8 +996,13 @@ ShellRoot {
 
       var fullReload = shell.fullPluginReloading
       var reloads = shell.activePluginReloads
+      // While a targeted reload gates the pluginsChanged handlers, only our
+      // own rescan should bump registryRevision (by exactly one). Any extra
+      // bump means shell.json or plugin enablement changed inside the window;
+      // fall back to a full sync so that change is not silently dropped.
+      var interrupted = shell.pluginRegistry.registryRevision !== shell.pluginReloadBaseRevision + 1
       shell._syncServices()
-      if (fullReload || !shell.hasPluginReloads(reloads)) {
+      if (fullReload || interrupted || !shell.hasPluginReloads(reloads)) {
         shell.panelEntries = shell.computePanelEntries()
         shell.syncPluginWidgets()
       } else {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -304,6 +304,8 @@ ShellRoot {
   }
 
   property var _services: ({})
+  property int pluginServiceLoadRevision: 0
+  property var pluginServiceLoadRevisions: ({})
 
   function serviceFor(pluginId) {
     return _services[String(pluginId)] || null
@@ -311,6 +313,17 @@ ShellRoot {
 
   function firstPartyServiceFor(pluginId) {
     return serviceFor(pluginId)
+  }
+
+  function advancePluginServiceLoad(pluginId) {
+    var key = String(pluginId || "")
+    if (!key) return 0
+    pluginServiceLoadRevision++
+    var next = ({})
+    for (var id in pluginServiceLoadRevisions) next[id] = pluginServiceLoadRevisions[id]
+    next[key] = pluginServiceLoadRevision
+    pluginServiceLoadRevisions = next
+    return pluginServiceLoadRevision
   }
 
   function ensureService(pluginId) {
@@ -324,8 +337,10 @@ ShellRoot {
     var url = shell.pluginEntryPointUrl(manifest, "service")
     if (!url) return null
 
+    var loadRevision = shell.advancePluginServiceLoad(key)
     var comp = Qt.createComponent(url, Component.PreferSynchronous)
     function finalize() {
+      if (shell.pluginServiceLoadRevisions[key] !== loadRevision) return
       if (comp.status !== Component.Ready) {
         console.warn("service plugin load failed for " + key + ": " + comp.errorString())
         return
@@ -380,6 +395,7 @@ ShellRoot {
 
   function unloadPluginService(pluginId) {
     var key = String(pluginId || "")
+    shell.advancePluginServiceLoad(key)
     var inst = _services[key]
     if (!inst) return
     if (typeof inst.destroy === "function") inst.destroy()
@@ -389,6 +405,7 @@ ShellRoot {
   }
 
   function unloadPluginServices() {
+    pluginServiceLoadRevisions = ({})
     for (var existingId in _services) {
       var inst = _services[existingId]
       if (inst && typeof inst.destroy === "function") inst.destroy()
@@ -941,7 +958,8 @@ ShellRoot {
       shell.activePluginReloads = ({})
       return
     }
-    if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
+    if (shell.fullPluginReloading && typeof Qt.clearComponentCache === "function")
+      Qt.clearComponentCache()
     shell.pluginRegistry.rescan()
   }
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -59,12 +59,23 @@ ShellRoot {
   property var activePluginReloads: ({})
   property var pendingLocalPluginReloads: ({})
   property var pluginSourceRevisions: ({})
+  property var preparedPluginSourceRevisions: ({})
+  property int pluginSourceRevisionCounter: 0
+  readonly property string pluginReloadSession: String(Date.now()) + "-"
+    + String(Math.floor(Math.random() * 1000000))
+  readonly property string pluginReloadSourceRoot: Quickshell.env("XDG_RUNTIME_DIR")
+    + "/omarchy-shell/plugin-reloads/" + pluginReloadSession
   readonly property bool pluginReloading: fullPluginReloading || Object.keys(activePluginReloads).length > 0
 
   Timer {
     id: localPluginReloadTimer
     interval: 150
     onTriggered: shell.reloadLocalPlugins()
+  }
+
+  Process {
+    id: pluginSourceRevisionProcess
+    onExited: function(exitCode) { shell.finishPluginSourceRevisionPreparation(exitCode) }
   }
 
   onShellConfigChanged: {
@@ -197,12 +208,19 @@ ShellRoot {
   }
 
   function pluginEntryPointUrl(manifest, kind) {
-    var url = shell.pluginRegistry.entryPointUrl(manifest, kind)
-    if (!url || !manifest) return url
-    // Destroyed Components can retain compiled QML past clearComponentCache().
-    // A per-plugin URL revision guarantees local edits load the new code.
+    if (!manifest) return ""
+    var sourceDir = String(manifest.__sourceDir || "")
     var revision = shell.pluginSourceRevisions[String(manifest.id || "")] || 0
-    return revision > 0 ? url + "?reload=" + revision : url
+    if (revision > 0) {
+      // A revisioned base URL also changes cache keys for relative QML and JS.
+      var pluginsDir = shell.pluginRegistry.pluginsDir.replace(/\/$/, "")
+      var expectedPrefix = pluginsDir + "/"
+      if (sourceDir.indexOf(expectedPrefix) === 0) {
+        sourceDir = shell.pluginReloadSourceRoot + "/" + revision + "/plugins/"
+          + sourceDir.slice(expectedPrefix.length)
+      }
+    }
+    return shell.pluginRegistry.entryPointUrl(manifest, kind, sourceDir)
   }
 
   function isBarOptionManifest(manifest) {
@@ -827,11 +845,39 @@ ShellRoot {
     return next
   }
 
-  function bumpPluginSourceRevisions(reloads) {
+  function preparePluginSourceRevision(reloads) {
+    pluginSourceRevisionCounter++
     var next = ({})
     for (var id in pluginSourceRevisions) next[id] = pluginSourceRevisions[id]
-    for (var reloadId in reloads) next[reloadId] = (next[reloadId] || 0) + 1
-    pluginSourceRevisions = next
+    for (var reloadId in reloads) next[reloadId] = pluginSourceRevisionCounter
+    preparedPluginSourceRevisions = next
+
+    var script = "mkdir -p -- \"$0/$2\" && ln -s -- \"$1\" \"$0/$2/plugins\""
+    pluginSourceRevisionProcess.command = [
+      "bash", "-c", script,
+      pluginReloadSourceRoot,
+      pluginRegistry.pluginsDir,
+      String(pluginSourceRevisionCounter)
+    ]
+    pluginSourceRevisionProcess.running = true
+  }
+
+  function finishPluginSourceRevisionPreparation(exitCode) {
+    if (exitCode === 0) {
+      pluginSourceRevisions = preparedPluginSourceRevisions
+      preparedPluginSourceRevisions = ({})
+      Qt.callLater(shell.finishPluginReload)
+      return
+    }
+
+    console.warn("Could not prepare versioned plugin sources; falling back to a full plugin reload")
+    preparedPluginSourceRevisions = ({})
+    activePluginReloads = ({})
+    fullPluginReloading = true
+    shell.unloadPanels()
+    shell.unloadPluginServices()
+    shell.unloadPluginWidgets()
+    Qt.callLater(shell.finishPluginReload)
   }
 
   function pluginReloadAffects(pluginId) {
@@ -858,12 +904,11 @@ ShellRoot {
     // The watcher already resolved the owning plugin, so keep every unrelated
     // service, panel, bar, and widget mounted while the registry rescans.
     activePluginReloads = reloads
-    shell.bumpPluginSourceRevisions(reloads)
     for (var pluginId in reloads) {
       shell.unloadPluginService(pluginId)
       shell.unloadPluginWidget(pluginId)
     }
-    Qt.callLater(shell.finishPluginReload)
+    shell.preparePluginSourceRevision(reloads)
   }
 
   function reloadPlugins() {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -58,6 +58,7 @@ ShellRoot {
   property bool fullPluginReloadPending: false
   property var activePluginReloads: ({})
   property var pendingLocalPluginReloads: ({})
+  property bool pendingLocalPluginFullReload: false
   property var pluginSourceRevisions: ({})
   property var preparedPluginSourceRevisions: ({})
   property int pluginSourceRevisionCounter: 0
@@ -904,16 +905,26 @@ ShellRoot {
   function queueLocalPluginReload(sourceDir) {
     var pluginId = shell.pluginRegistry.pluginIdForSourceDir(sourceDir)
     if (!pluginId) {
-      shell.reloadPlugins()
-      return
+      // A directory the registry does not know yet — a new plugin still being
+      // written, or a stray file at the plugins root — needs a full reload to
+      // discover it. Still route it through the debounce timer: a burst of
+      // file events (git clone, an editor saving many files) must coalesce
+      // into one reload instead of tearing the shell down once per event.
+      pendingLocalPluginFullReload = true
+    } else {
+      var reload = ({})
+      reload[pluginId] = true
+      pendingLocalPluginReloads = shell.mergePluginReloads(pendingLocalPluginReloads, reload)
     }
-    var reload = ({})
-    reload[pluginId] = true
-    pendingLocalPluginReloads = shell.mergePluginReloads(pendingLocalPluginReloads, reload)
     localPluginReloadTimer.restart()
   }
 
   function reloadLocalPlugins() {
+    if (shell.pendingLocalPluginFullReload) {
+      shell.pendingLocalPluginFullReload = false
+      shell.reloadPlugins()
+      return
+    }
     if (!shell.hasPluginReloads(shell.pendingLocalPluginReloads)) return
     if (shell.pluginReloading || shell.pluginRegistry.scanning) return
 
@@ -937,6 +948,7 @@ ShellRoot {
       return
     }
     pendingLocalPluginReloads = ({})
+    pendingLocalPluginFullReload = false
     activePluginReloads = ({})
     fullPluginReloading = true
     shell.unloadPanels()
@@ -975,6 +987,7 @@ ShellRoot {
         shell.fullPluginReloading = false
         shell.activePluginReloads = ({})
         shell.pendingLocalPluginReloads = ({})
+        shell.pendingLocalPluginFullReload = false
         Qt.callLater(shell.reloadPlugins)
         return
       }
@@ -991,7 +1004,7 @@ ShellRoot {
       }
       shell.fullPluginReloading = false
       shell.activePluginReloads = ({})
-      if (shell.hasPluginReloads(shell.pendingLocalPluginReloads))
+      if (shell.hasPluginReloads(shell.pendingLocalPluginReloads) || shell.pendingLocalPluginFullReload)
         Qt.callLater(shell.reloadLocalPlugins)
     }
   }

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -440,6 +440,9 @@ ShellRoot {
     var cloneBase = registry.pluginsDir + "/dhh.clock"
     root.assertEqual(registry.localPluginIdForPath(cloneBase + "/BarWidget.qml"), "dhh.clock", "personal clone changes are watched")
     root.assertEqual(registry.localPluginIdForPath(registry.pluginsDir + "/acme.clock/BarWidget.qml"), "acme.clock", "installed plugin changes are watched")
+    root.assertEqual(registry.localPluginSourceDirForPath(cloneBase + "/BarWidget.qml"), cloneBase, "watched changes retain their source directory")
+    root.assertEqual(registry.pluginIdForSourceDir("/third/panel"), "third.panel", "source directories resolve to manifest ids")
+    root.assertEqual(registry.pluginIdForSourceDir("/third/missing"), "", "unknown source directories stay unresolved")
     root.assertEqual(registry.localPluginIdForPath(cloneBase + "/.git/index"), "", "plugin git metadata is ignored")
     root.assertEqual(registry.localPluginIdForPath(registry.pluginsDir + "/.clone.abc123/manifest.json"), "", "hidden staging and backup dirs are ignored")
 

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -134,6 +134,7 @@ ShellRoot {
     root.assertTrue(registry.installedPlugins["third.panel"].__isFirstParty === false, "third-party manifests are stamped")
     root.assertEqual(registry.installedPlugins["omarchy.grouped-panel"].__sourceDir, "/first/panels/grouped", "grouped plugin source paths are preserved")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel"), "file:///third/panel/Panel.qml", "entryPointUrl resolves plugin-relative paths")
+    root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel", "/revised/third.panel"), "file:///revised/third.panel/Panel.qml", "entryPointUrl accepts a revised source directory")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.widget"], "barWidget"), "file:///third/widget/Widget.qml", "entryPointUrl resolves bar widget paths")
 
     root.assertTrue(!has("omarchy.reserved"), "third-party omarchy namespace ids are rejected")

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -127,8 +127,119 @@ Item {
 }
 QML
 
-jq --arg target "$hot_reload_id" --arg sentinel "$reload_sentinel_id" '
-  .plugins = ((.plugins // []) + [{id: $target}, {id: $sentinel}])
+hot_reload_widget_id="acme.hot-reload-widget"
+hot_reload_widget_dir="$test_home/.config/omarchy/plugins/$hot_reload_widget_id"
+mkdir -p "$hot_reload_widget_dir"
+cat >"$hot_reload_widget_dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$hot_reload_widget_id",
+  "name": "Hot reload widget",
+  "version": "1.0.0",
+  "kinds": ["bar-widget"],
+  "entryPoints": {"barWidget": "Widget.qml"},
+  "barWidget": {
+    "displayName": "Hot reload widget",
+    "description": "Runtime hot reload fixture",
+    "category": "Test",
+    "allowMultiple": false
+  }
+}
+JSON
+cat >"$hot_reload_widget_dir/Widget.qml" <<'QML'
+import QtQuick
+
+Item {
+  implicitWidth: 12
+  implicitHeight: 12
+  Component.onCompleted: console.log("HOT_RELOAD_TARGET_WIDGET_BEFORE")
+}
+QML
+
+reload_sentinel_widget_id="acme.reload-sentinel-widget"
+reload_sentinel_widget_dir="$test_home/.config/omarchy/plugins/$reload_sentinel_widget_id"
+mkdir -p "$reload_sentinel_widget_dir"
+cat >"$reload_sentinel_widget_dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$reload_sentinel_widget_id",
+  "name": "Reload sentinel widget",
+  "version": "1.0.0",
+  "kinds": ["bar-widget"],
+  "entryPoints": {"barWidget": "Widget.qml"},
+  "barWidget": {
+    "displayName": "Reload sentinel widget",
+    "description": "Runtime hot reload sentinel",
+    "category": "Test",
+    "allowMultiple": false
+  }
+}
+JSON
+cat >"$reload_sentinel_widget_dir/Widget.qml" <<'QML'
+import QtQuick
+
+Item {
+  implicitWidth: 12
+  implicitHeight: 12
+  Component.onCompleted: console.log("HOT_RELOAD_SENTINEL_WIDGET")
+}
+QML
+
+hot_reload_bar_id="acme.hot-reload-bar"
+hot_reload_bar_dir="$test_home/.config/omarchy/plugins/$hot_reload_bar_id"
+mkdir -p "$hot_reload_bar_dir"
+cat >"$hot_reload_bar_dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$hot_reload_bar_id",
+  "name": "Hot reload bar",
+  "version": "1.0.0",
+  "kinds": ["bar"],
+  "entryPoints": {"bar": "Bar.qml"}
+}
+JSON
+cat >"$hot_reload_bar_dir/Bar.qml" <<QML
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+
+  property var barWidgetRegistry: null
+  property int count: 0
+  readonly property var targetWidget: {
+    var widgets = barWidgetRegistry ? barWidgetRegistry.widgets : ({})
+    return widgets["$hot_reload_widget_id"] ? widgets["$hot_reload_widget_id"].component : null
+  }
+  readonly property var sentinelWidget: {
+    var widgets = barWidgetRegistry ? barWidgetRegistry.widgets : ({})
+    return widgets["$reload_sentinel_widget_id"] ? widgets["$reload_sentinel_widget_id"].component : null
+  }
+
+  Component.onCompleted: console.log("HOT_RELOAD_TARGET_BAR_BEFORE")
+
+  Loader { sourceComponent: root.targetWidget }
+  Loader { sourceComponent: root.sentinelWidget }
+
+  IpcHandler {
+    target: "hot-reload-bar"
+
+    function increment(): string {
+      root.count++
+      return String(root.count)
+    }
+  }
+}
+QML
+
+jq --arg target "$hot_reload_id" \
+   --arg sentinel "$reload_sentinel_id" \
+   --arg targetWidget "$hot_reload_widget_id" \
+   --arg sentinelWidget "$reload_sentinel_widget_id" \
+   --arg targetBar "$hot_reload_bar_id" '
+  .plugins = ((.plugins // []) + [{id: $target}, {id: $sentinel}]) |
+  .bar.id = $targetBar |
+  .bar.layout.left += [{id: $targetWidget}, {id: $sentinelWidget}]
 ' "$ROOT/config/omarchy/shell.json" >"$test_home/.config/omarchy/shell.json"
 
 cat >"$stub_bin/omarchy-update-available" <<'SH'
@@ -211,7 +322,10 @@ done
 for _ in {1..80}; do
   if grep -q "HOT_RELOAD_TARGET_SERVICE_BEFORE" "$log" \
       && grep -q "HOT_RELOAD_TARGET_OVERLAY_BEFORE" "$log" \
-      && grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log"; then
+      && grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log" \
+      && grep -q "HOT_RELOAD_TARGET_WIDGET_BEFORE" "$log" \
+      && grep -q "HOT_RELOAD_SENTINEL_WIDGET" "$log" \
+      && grep -q "HOT_RELOAD_TARGET_BAR_BEFORE" "$log"; then
     break
   fi
   sleep 0.1
@@ -219,6 +333,9 @@ done
 grep -q "HOT_RELOAD_TARGET_SERVICE_BEFORE" "$log" || fail_with_log "hot reload target service starts"
 grep -q "HOT_RELOAD_TARGET_OVERLAY_BEFORE" "$log" || fail_with_log "hot reload target overlay starts"
 grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log" || fail_with_log "hot reload sentinel overlay starts"
+grep -q "HOT_RELOAD_TARGET_WIDGET_BEFORE" "$log" || fail_with_log "hot reload target widget starts"
+grep -q "HOT_RELOAD_SENTINEL_WIDGET" "$log" || fail_with_log "hot reload sentinel widget starts"
+grep -q "HOT_RELOAD_TARGET_BAR_BEFORE" "$log" || fail_with_log "hot reload target bar starts"
 sleep 0.1
 hot_reload_log_offset=$(wc -c <"$log")
 
@@ -265,6 +382,54 @@ if grep -qE "Cannot read property.*of null" "$hot_reload_log"; then
   fail_with_log "hot reload keeps unrelated bar widgets alive"
 fi
 pass "hot reload only rebuilds the changed plugin"
+
+bar_count=$(shell_ipc hot-reload-bar increment 2>/dev/null || true)
+[[ $bar_count == "1" ]] || fail_with_log "hot reload bar state starts"
+hot_reload_log_offset=$(wc -c <"$log")
+sed -i 's/HOT_RELOAD_TARGET_WIDGET_BEFORE/HOT_RELOAD_TARGET_WIDGET_AFTER/' "$hot_reload_widget_dir/Widget.qml"
+
+for _ in {1..80}; do
+  tail -c "+$(( hot_reload_log_offset + 1 ))" "$log" >"$hot_reload_log"
+  grep -q "HOT_RELOAD_TARGET_WIDGET_AFTER" "$hot_reload_log" && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while loading changed widget code"
+  fi
+  sleep 0.1
+done
+grep -q "HOT_RELOAD_TARGET_WIDGET_AFTER" "$hot_reload_log" || fail_with_log "changed widget code reloads"
+sleep 0.2
+tail -c "+$(( hot_reload_log_offset + 1 ))" "$log" >"$hot_reload_log"
+if grep -q "HOT_RELOAD_TARGET_WIDGET_BEFORE" "$hot_reload_log"; then
+  fail_with_log "stale widget loads stay canceled"
+fi
+if grep -q "HOT_RELOAD_SENTINEL_WIDGET" "$hot_reload_log"; then
+  fail_with_log "widget hot reload keeps unrelated widgets alive"
+fi
+if grep -q "HOT_RELOAD_TARGET_BAR_" "$hot_reload_log"; then
+  fail_with_log "widget hot reload keeps the active bar alive"
+fi
+bar_count=$(shell_ipc hot-reload-bar increment 2>/dev/null || true)
+[[ $bar_count == "2" ]] || fail_with_log "widget hot reload preserves active bar state"
+pass "hot reload only rebuilds the changed bar widget"
+
+hot_reload_log_offset=$(wc -c <"$log")
+sed -i 's/HOT_RELOAD_TARGET_BAR_BEFORE/HOT_RELOAD_TARGET_BAR_AFTER/' "$hot_reload_bar_dir/Bar.qml"
+
+for _ in {1..80}; do
+  tail -c "+$(( hot_reload_log_offset + 1 ))" "$log" >"$hot_reload_log"
+  grep -q "HOT_RELOAD_TARGET_BAR_AFTER" "$hot_reload_log" && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while loading changed bar code"
+  fi
+  sleep 0.1
+done
+grep -q "HOT_RELOAD_TARGET_BAR_AFTER" "$hot_reload_log" || fail_with_log "changed bar code reloads"
+bar_count=$(shell_ipc hot-reload-bar increment 2>/dev/null || true)
+[[ $bar_count == "1" ]] || fail_with_log "changed bar is recreated"
+pass "hot reload rebuilds the changed custom bar"
+
+[[ $(shell_ipc shell setPluginEnabled omarchy.bar true) == "ok" ]] ||
+  fail_with_log "runtime smoke test restores the built-in bar"
 
 [[ $(shell_ipc shell setPluginEnabled "$hot_reload_id" true) == "ok" ]] ||
   fail_with_log "installed plugin could not be enabled"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -52,7 +52,8 @@ ln -s "$ROOT/bin" "$test_root/bin"
 
 # Every plugin under ~/.config/omarchy/plugins hot-reloads, whoever wrote it.
 hot_reload_id="acme.hot-reload"
-hot_reload_dir="$test_home/.config/omarchy/plugins/$hot_reload_id"
+# Installed directory names are not required to match their manifest IDs.
+hot_reload_dir="$test_home/.config/omarchy/plugins/hot-reload-directory"
 mkdir -p "$hot_reload_dir"
 cat >"$hot_reload_dir/manifest.json" <<JSON
 {

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -460,6 +460,55 @@ pass "hot reload rebuilds the changed custom bar"
 [[ $(shell_ipc shell setPluginEnabled omarchy.bar true) == "ok" ]] ||
   fail_with_log "runtime smoke test restores the built-in bar"
 
+# A directory the registry does not know yet cannot be reloaded in a targeted
+# way; discovering it takes a full reload. A new plugin arrives as a burst of
+# file events (git clone, an editor writing several files), which must
+# coalesce into one reload instead of tearing the shell down once per event.
+discovered_id="acme.discovered"
+discovered_dir="$test_home/.config/omarchy/plugins/discovered-plugin"
+discovery_log_offset=$(wc -c <"$log")
+mkdir -p "$discovered_dir"
+cat >"$discovered_dir/Overlay.qml" <<'QML'
+import QtQuick
+
+Item {
+  function open(payloadJson) {}
+  function close() {}
+}
+QML
+cat >"$discovered_dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$discovered_id",
+  "name": "Discovered plugin",
+  "version": "1.0.0",
+  "kinds": ["overlay"],
+  "entryPoints": {"overlay": "Overlay.qml"}
+}
+JSON
+
+discovered=""
+for _ in {1..80}; do
+  discovered=$(shell_ipc shell listPlugins 2>/dev/null || true)
+  if jq -e --arg id "$discovered_id" 'any(.[]; .id == $id)' <<<"$discovered" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while discovering a new plugin"
+  fi
+  sleep 0.1
+done
+jq -e --arg id "$discovered_id" 'any(.[]; .id == $id)' <<<"$discovered" >/dev/null 2>&1 ||
+  fail_with_log "new local plugin is discovered without an explicit rescan"
+
+# The sentinel service restarts once per full reload; more than one restart in
+# this window means the file-event burst did not coalesce.
+sleep 0.7
+discovery_restarts=$(tail -c "+$(( discovery_log_offset + 1 ))" "$log" | grep -c "HOT_RELOAD_SENTINEL_SERVICE" || true)
+[[ $discovery_restarts == "1" ]] ||
+  fail_with_log "new plugin discovery coalesces into one full reload (saw $discovery_restarts sentinel restarts)"
+pass "new local plugin discovery reloads once"
+
 [[ $(shell_ipc shell setPluginEnabled "$hot_reload_id" true) == "ok" ]] ||
   fail_with_log "installed plugin could not be enabled"
 [[ $(shell_ipc shell summon omarchy.emojis "{}") == "ok" ]] ||

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -70,7 +70,16 @@ cat >"$hot_reload_dir/Service.qml" <<'QML'
 import QtQuick
 
 Item {
+  Child {}
+
   Component.onCompleted: console.log("HOT_RELOAD_TARGET_SERVICE_BEFORE")
+}
+QML
+cat >"$hot_reload_dir/Child.qml" <<'QML'
+import QtQuick
+
+Item {
+  Component.onCompleted: console.log("HOT_RELOAD_TARGET_CHILD_BEFORE")
 }
 QML
 cat >"$hot_reload_dir/Overlay.qml" <<'QML'
@@ -321,6 +330,7 @@ done
 
 for _ in {1..80}; do
   if grep -q "HOT_RELOAD_TARGET_SERVICE_BEFORE" "$log" \
+      && grep -q "HOT_RELOAD_TARGET_CHILD_BEFORE" "$log" \
       && grep -q "HOT_RELOAD_TARGET_OVERLAY_BEFORE" "$log" \
       && grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log" \
       && grep -q "HOT_RELOAD_TARGET_WIDGET_BEFORE" "$log" \
@@ -331,6 +341,7 @@ for _ in {1..80}; do
   sleep 0.1
 done
 grep -q "HOT_RELOAD_TARGET_SERVICE_BEFORE" "$log" || fail_with_log "hot reload target service starts"
+grep -q "HOT_RELOAD_TARGET_CHILD_BEFORE" "$log" || fail_with_log "hot reload target child starts"
 grep -q "HOT_RELOAD_TARGET_OVERLAY_BEFORE" "$log" || fail_with_log "hot reload target overlay starts"
 grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log" || fail_with_log "hot reload sentinel overlay starts"
 grep -q "HOT_RELOAD_TARGET_WIDGET_BEFORE" "$log" || fail_with_log "hot reload target widget starts"
@@ -382,6 +393,23 @@ if grep -qE "Cannot read property.*of null" "$hot_reload_log"; then
   fail_with_log "hot reload keeps unrelated bar widgets alive"
 fi
 pass "hot reload only rebuilds the changed plugin"
+
+hot_reload_log_offset=$(wc -c <"$log")
+sed -i 's/HOT_RELOAD_TARGET_CHILD_BEFORE/HOT_RELOAD_TARGET_CHILD_AFTER/' "$hot_reload_dir/Child.qml"
+
+for _ in {1..80}; do
+  tail -c "+$(( hot_reload_log_offset + 1 ))" "$log" >"$hot_reload_log"
+  grep -q "HOT_RELOAD_TARGET_CHILD_AFTER" "$hot_reload_log" && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while loading changed child code"
+  fi
+  sleep 0.1
+done
+grep -q "HOT_RELOAD_TARGET_CHILD_AFTER" "$hot_reload_log" || fail_with_log "changed imported child code reloads"
+if grep -q "HOT_RELOAD_TARGET_CHILD_BEFORE" "$hot_reload_log"; then
+  fail_with_log "changed imported child code does not reuse stale QML"
+fi
+pass "hot reload rebuilds changed imported QML"
 
 bar_count=$(shell_ipc hot-reload-bar increment 2>/dev/null || true)
 [[ $bar_count == "1" ]] || fail_with_log "hot reload bar state starts"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -60,19 +60,76 @@ cat >"$hot_reload_dir/manifest.json" <<JSON
   "id": "$hot_reload_id",
   "name": "Before Hot Reload",
   "version": "1.0.0",
-  "kinds": ["overlay"],
-  "entryPoints": {"overlay": "Overlay.qml"},
+  "kinds": ["service", "overlay"],
+  "entryPoints": {"service": "Service.qml", "overlay": "Overlay.qml"},
+  "keepLoaded": true,
   "omarchy": {"clonedFrom": "omarchy.emojis"}
 }
 JSON
+cat >"$hot_reload_dir/Service.qml" <<'QML'
+import QtQuick
+
+Item {
+  Component.onCompleted: console.log("HOT_RELOAD_TARGET_SERVICE_BEFORE")
+}
+QML
 cat >"$hot_reload_dir/Overlay.qml" <<'QML'
 import QtQuick
 
 Item {
+  Component.onCompleted: console.log("HOT_RELOAD_TARGET_OVERLAY_BEFORE")
   function open(payloadJson) {}
   function close() {}
 }
 QML
+
+reload_sentinel_id="acme.reload-sentinel"
+reload_sentinel_dir="$test_home/.config/omarchy/plugins/$reload_sentinel_id"
+mkdir -p "$reload_sentinel_dir"
+cat >"$reload_sentinel_dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$reload_sentinel_id",
+  "name": "Reload sentinel",
+  "version": "1.0.0",
+  "kinds": ["service", "overlay"],
+  "entryPoints": {"service": "Service.qml", "overlay": "Overlay.qml"},
+  "keepLoaded": true
+}
+JSON
+cat >"$reload_sentinel_dir/Service.qml" <<'QML'
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+  property int count: 0
+
+  Component.onCompleted: console.log("HOT_RELOAD_SENTINEL_SERVICE")
+
+  IpcHandler {
+    target: "hot-reload-sentinel"
+
+    function increment(): string {
+      root.count++
+      return String(root.count)
+    }
+  }
+}
+QML
+cat >"$reload_sentinel_dir/Overlay.qml" <<'QML'
+import QtQuick
+
+Item {
+  Component.onCompleted: console.log("HOT_RELOAD_SENTINEL_OVERLAY")
+  function open(payloadJson) {}
+  function close() {}
+}
+QML
+
+jq --arg target "$hot_reload_id" --arg sentinel "$reload_sentinel_id" '
+  .plugins = ((.plugins // []) + [{id: $target}, {id: $sentinel}])
+' "$ROOT/config/omarchy/shell.json" >"$test_home/.config/omarchy/shell.json"
 
 cat >"$stub_bin/omarchy-update-available" <<'SH'
 #!/bin/bash
@@ -140,6 +197,33 @@ jq -e '
 }
 pass "shell IPC lists plugin metadata"
 
+sentinel_count=""
+for _ in {1..80}; do
+  sentinel_count=$(shell_ipc hot-reload-sentinel increment 2>/dev/null || true)
+  [[ $sentinel_count == "1" ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited before hot reload fixtures became available"
+  fi
+  sleep 0.1
+done
+[[ $sentinel_count == "1" ]] || fail_with_log "hot reload sentinel service starts"
+
+for _ in {1..80}; do
+  if grep -q "HOT_RELOAD_TARGET_SERVICE_BEFORE" "$log" \
+      && grep -q "HOT_RELOAD_TARGET_OVERLAY_BEFORE" "$log" \
+      && grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log"; then
+    break
+  fi
+  sleep 0.1
+done
+grep -q "HOT_RELOAD_TARGET_SERVICE_BEFORE" "$log" || fail_with_log "hot reload target service starts"
+grep -q "HOT_RELOAD_TARGET_OVERLAY_BEFORE" "$log" || fail_with_log "hot reload target overlay starts"
+grep -q "HOT_RELOAD_SENTINEL_OVERLAY" "$log" || fail_with_log "hot reload sentinel overlay starts"
+sleep 0.1
+hot_reload_log_offset=$(wc -c <"$log")
+
+sed -i 's/HOT_RELOAD_TARGET_SERVICE_BEFORE/HOT_RELOAD_TARGET_SERVICE_AFTER/' "$hot_reload_dir/Service.qml"
+sed -i 's/HOT_RELOAD_TARGET_OVERLAY_BEFORE/HOT_RELOAD_TARGET_OVERLAY_AFTER/' "$hot_reload_dir/Overlay.qml"
 jq '.name = "After Hot Reload"' "$hot_reload_dir/manifest.json" >"$hot_reload_dir/manifest.json.tmp"
 mv "$hot_reload_dir/manifest.json.tmp" "$hot_reload_dir/manifest.json"
 
@@ -156,6 +240,31 @@ done
 [[ $hot_reload_name == "After Hot Reload" ]] ||
   fail_with_log "installed plugin changes reload without an explicit rescan"
 pass "installed plugin changes reload without an explicit rescan"
+
+hot_reload_log="$TMPDIR/hot-reload.log"
+for _ in {1..80}; do
+  tail -c "+$(( hot_reload_log_offset + 1 ))" "$log" >"$hot_reload_log"
+  if grep -q "HOT_RELOAD_TARGET_SERVICE_AFTER" "$hot_reload_log" \
+      && grep -q "HOT_RELOAD_TARGET_OVERLAY_AFTER" "$hot_reload_log"; then
+    break
+  fi
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while loading changed plugin code"
+  fi
+  sleep 0.1
+done
+grep -q "HOT_RELOAD_TARGET_SERVICE_AFTER" "$hot_reload_log" || fail_with_log "changed plugin service code reloads"
+grep -q "HOT_RELOAD_TARGET_OVERLAY_AFTER" "$hot_reload_log" || fail_with_log "changed plugin overlay code reloads"
+
+sentinel_count=$(shell_ipc hot-reload-sentinel increment 2>/dev/null || true)
+[[ $sentinel_count == "2" ]] || fail_with_log "hot reload keeps unrelated plugin services alive"
+if grep -q "HOT_RELOAD_SENTINEL_" "$hot_reload_log"; then
+  fail_with_log "hot reload keeps unrelated plugin panels alive"
+fi
+if grep -qE "Cannot read property.*of null" "$hot_reload_log"; then
+  fail_with_log "hot reload keeps unrelated bar widgets alive"
+fi
+pass "hot reload only rebuilds the changed plugin"
 
 [[ $(shell_ipc shell setPluginEnabled "$hot_reload_id" true) == "ok" ]] ||
   fail_with_log "installed plugin could not be enabled"


### PR DESCRIPTION
Fixes #6784

Editing one local plugin rebuilt every shell plugin, including every bar widget on every monitor. This caused a noticeable shell pause and restarted unrelated plugin state.

Local file events now reload only the affected plugin services, panels, and bar widgets. Each reload uses a revisioned source directory, so the entry point and its relative QML and JavaScript dependencies receive new URLs. Explicit plugin rescans still perform a full reload.

## Benchmark

Thirty edits to one local plugin, using isolated Quickshell instances on the same machine and upstream commit `38542a1f5137`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Typical reload time (median) | 773 ms | 212 ms | 72.6% lower |
| Slow reload time (95th percentile) | 843 ms | 234 ms | 72.2% lower |
| Quickshell CPU used across all edits | 19.39 s | 0.31 s | 98.4% lower |
| QML null-property warnings | 54,432 | 0 | Eliminated |
| Unrelated service restarts | 30 | 0 | Eliminated |

Definitions:

- **Median:** The middle result. Half of the reloads were faster and half were slower.
- **95th percentile:** The time within which 95% of reloads completed. Only the slowest 5% took longer.
- **Quickshell CPU:** The processor time Quickshell consumed across all 30 edits.
- **Null-property warning:** QML attempted to use an object that had temporarily been destroyed during the reload.
- **Unrelated service restart:** A background service from a different, unchanged plugin was restarted.

## Testing

- The targeted runtime checks pass for edits to service, overlay, bar-widget, custom-bar, and imported child QML, including an installed plugin whose directory differs from its manifest ID. They also verify preservation of unrelated plugin state and the absence of null-property warnings.
- `./test/shell`: 161 of 165 test files pass. Three failures require the absent sibling `omarchy-pkgs` checkout. The remaining two-monitor IPC assertion also fails on untouched upstream after a full rescan.
