### PR TITLE
Add widgets to the bar from a searchable picker

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -102,6 +102,7 @@
   "style.bar": {"icon":"󰍜","label":"Menu Bar"},
   "style.bar.position": {"icon":"","label":"Position"},
   "style.bar.transparency": {"icon":"󰂵","label":"Transparency","action":"omarchy-bar transparent toggle"},
+  "style.bar.add-widget": {"icon":"󰐕","label":"Add Widget","action":"omarchy-shell shell summon omarchy.widget-picker"},
   "style.hyprland": {"icon":"","label":"Hyprland","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/looknfeel.lua\""},
   "style.screensaver": {"icon":"󱄄","label":"Screensaver"},
   "style.about": {"icon":"","label":"About"},

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -749,6 +749,17 @@ Item {
     return dropBarModule(sourceSlot, targetSlot.region, beforeName)
   }
 
+  // The add button sits at the outer end of the right section, so its pick
+  // lands exactly where the button is: the end of that section. The screen
+  // rides along so the picker opens on the bar that was clicked.
+  function openWidgetPicker(window) {
+    if (!shell || typeof shell.summon !== "function") return
+
+    var placement = { section: "right", index: layoutEntries("right").length }
+    if (window && window.screen && window.screen.name) placement.screen = String(window.screen.name)
+    shell.summon("omarchy.widget-picker", JSON.stringify(placement))
+  }
+
   function moduleTargetClickable(target) {
     return target
       && target.visible !== false
@@ -1116,9 +1127,35 @@ Item {
         }
 
         RightModules {
+          id: rightModules
           anchors.right: parent.right
-          anchors.rightMargin: Style.space(8)
+          // The stock margin, widened only while the add button is revealed.
+          anchors.rightMargin: addWidgetButton.hunting ? Style.space(3) + addWidgetButton.implicitWidth : Style.space(8)
           anchors.verticalCenter: parent.verticalCenter
+
+          Behavior on anchors.rightMargin {
+            NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
+          }
+        }
+
+        AddWidgetButton {
+          id: addWidgetButton
+          anchors.right: parent.right
+          anchors.rightMargin: Style.space(3)
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        // The dwell trigger: the bar's natural end margin, widening to cover
+        // the revealed button so the hunt stays alive through the click.
+        Item {
+          anchors.left: rightModules.right
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          height: parent.height
+
+          HoverHandler {
+            onHoveredChanged: addWidgetButton.setHunting(hovered)
+          }
         }
       }
     }
@@ -1138,9 +1175,35 @@ Item {
         }
 
         RightModules {
+          id: rightModules
           anchors.bottom: parent.bottom
-          anchors.bottomMargin: Style.space(8)
+          // The stock margin, widened only while the add button is revealed.
+          anchors.bottomMargin: addWidgetButton.hunting ? Style.space(3) + addWidgetButton.implicitHeight : Style.space(8)
           anchors.horizontalCenter: parent.horizontalCenter
+
+          Behavior on anchors.bottomMargin {
+            NumberAnimation { duration: 140; easing.type: Easing.OutCubic }
+          }
+        }
+
+        AddWidgetButton {
+          id: addWidgetButton
+          anchors.bottom: parent.bottom
+          anchors.bottomMargin: Style.space(3)
+          anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        // The dwell trigger: the bar's natural end margin, widening to cover
+        // the revealed button so the hunt stays alive through the click.
+        Item {
+          anchors.top: rightModules.bottom
+          anchors.bottom: parent.bottom
+          anchors.horizontalCenter: parent.horizontalCenter
+          width: parent.width
+
+          HoverHandler {
+            onHoveredChanged: addWidgetButton.setHunting(hovered)
+          }
         }
       }
     }
@@ -1385,6 +1448,46 @@ Item {
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter
         }
       }
+    }
+  }
+
+  // A + at the bar's end that summons the widget picker, invisible and
+  // taking no space at all until a pointer dwells on the bar's end margin —
+  // someone hunting for it. Only then do the end widgets slide over to make
+  // room, the same manner as the indicators peek; ordinary traffic elsewhere
+  // on the bar, or crossing the corner on the way somewhere, changes nothing.
+  component AddWidgetButton: WidgetButton {
+    id: addButton
+
+    property bool hunting: false
+
+    // Driven by the dwell zone that spans the bar's end gap, which also
+    // keeps the reveal alive while the pointer is on the button itself.
+    function setHunting(hovered) {
+      if (hovered) {
+        huntDwell.restart()
+      } else {
+        huntDwell.stop()
+        hunting = false
+      }
+    }
+
+    bar: root
+    text: ""
+    tooltipText: "Add widget"
+    concealed: !hunting
+    interactive: hunting
+    horizontalMargin: 5
+    onPressed: function(button) {
+      if (button === Qt.LeftButton) root.openWidgetPicker(root.targetWindow(addButton))
+    }
+
+    // A deliberate pause, not a pass-through: nothing surfaces until the
+    // pointer has sat on the corner for a beat.
+    Timer {
+      id: huntDwell
+      interval: 600
+      onTriggered: addButton.hunting = true
     }
   }
 

--- a/shell/plugins/widget-picker/WidgetPicker.qml
+++ b/shell/plugins/widget-picker/WidgetPicker.qml
@@ -1,0 +1,312 @@
+import Quickshell
+import Quickshell.Wayland
+import QtQuick
+import qs.Commons
+import qs.Ui
+import "WidgetPickerModel.js" as PickerModel
+
+// The add-widget picker: a searchable list of every installed bar widget not
+// already on the bar. Summoned bare it appends at the widget's default spot;
+// summoned from a right-click on the bar it lands the pick on the insertion
+// edge that was under the pointer, carried in the summon payload.
+Item {
+  id: root
+
+  property var shell: null
+  property var manifest: null
+  property var pluginRegistry: null
+
+  property bool opened: false
+  property string filterText: ""
+  property int selectedIndex: 0
+  // { section?, before?/after? } in putBarWidget terms, from the summon payload.
+  property var placement: ({})
+  property string screenName: ""
+  property var rows: []
+  property var filteredRows: []
+
+  // Shares the [menu] surface tokens — themes that style the menu also style
+  // the picker.
+  property color background: Color.menu.background
+  property color foreground: Color.menu.text
+  property color border: Color.menu.border
+  property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
+  property color scrim: Color.menu.scrim
+  property color selectedBackground: Color.menu.selectedBackground
+  property color selectedText: Color.menu.selectedText
+  readonly property int cornerRadius: Style.cornerRadius
+  property string fontFamily: Style.font.menuFamily
+  property int contentMargin: Style.spacing.panelPadding
+  property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
+  property int contentSpacing: Style.spacing.md
+  property int rowHeight: Style.font.title + Style.font.body + Style.spacing.md * 2 + Style.spacing.xs
+  property int cardWidth: Math.min(Style.space(440), panel.width - Style.gapsOut * 2)
+  property int cardHeight: Math.min(Style.space(460), panel.height - Style.gapsOut * 2)
+
+  function open(payloadJson) {
+    var parsed = PickerModel.parsePlacement(payloadJson)
+    root.placement = parsed.placement
+    root.screenName = parsed.screen
+    root.filterText = ""
+    root.selectedIndex = 0
+    root.opened = true
+    root.rebuild()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function close() {
+    root.opened = false
+  }
+
+  function dismiss() {
+    root.opened = false
+    if (root.shell && typeof root.shell.hide === "function")
+      root.shell.hide((root.manifest && root.manifest.id) || "omarchy.widget-picker")
+  }
+
+  function rebuild() {
+    var installed = root.pluginRegistry ? root.pluginRegistry.installedPlugins : {}
+    var onBar = []
+    for (var id in installed) {
+      if (root.pluginRegistry.inBar(id)) onBar.push(id)
+    }
+    root.rows = PickerModel.pickerRows(installed, onBar)
+    root.refilter()
+  }
+
+  function refilter() {
+    root.filteredRows = PickerModel.filterRows(root.rows, root.filterText)
+    if (root.selectedIndex >= root.filteredRows.length) root.selectedIndex = Math.max(0, root.filteredRows.length - 1)
+    Qt.callLater(function() {
+      if (root.filteredRows.length > 0) resultList.positionViewAtIndex(root.selectedIndex, ListView.Contain)
+    })
+  }
+
+  function setFilter(nextFilter) {
+    root.filterText = nextFilter
+    root.selectedIndex = 0
+    root.refilter()
+  }
+
+  function select(delta) {
+    if (root.filteredRows.length === 0) return
+    root.selectedIndex = (root.selectedIndex + delta + root.filteredRows.length) % root.filteredRows.length
+    resultList.positionViewAtIndex(root.selectedIndex, ListView.Contain)
+  }
+
+  function activateIndex(index) {
+    var row = root.filteredRows[index]
+    if (!row || !root.pluginRegistry) return
+
+    var error = root.pluginRegistry.putBarWidget(row.id, root.placement)
+    root.dismiss()
+    if (error)
+      Quickshell.execDetached(["omarchy-notification-send", "Menu Bar", "Could not add " + row.name + ": " + error])
+  }
+
+  function screenByName(name) {
+    for (var i = 0; i < Quickshell.screens.length; i++) {
+      if (String(Quickshell.screens[i].name || "") === name) return Quickshell.screens[i]
+    }
+    return null
+  }
+
+  // A widget added or removed while the picker is open (another session, the
+  // CLI) changes what there is to offer.
+  Connections {
+    target: root.pluginRegistry
+    function onPluginsChanged() {
+      if (root.opened) root.rebuild()
+    }
+  }
+
+  PanelWindow {
+    id: panel
+
+    visible: root.opened
+    // Opens on the bar the summon named, or the default screen.
+    screen: root.screenByName(root.screenName) || Quickshell.screens[0]
+    anchors { top: true; bottom: true; left: true; right: true }
+    color: "transparent"
+    WlrLayershell.namespace: "omarchy-widget-picker"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    exclusionMode: ExclusionMode.Ignore
+
+    Rectangle {
+      anchors.fill: parent
+      color: root.scrim
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: root.dismiss()
+    }
+
+    BorderSurface {
+      id: card
+
+      width: root.cardWidth
+      height: root.cardHeight
+      radius: root.cornerRadius
+      anchors.centerIn: parent
+      color: root.background
+      borderSpec: root.borderSpec
+      padding: root.contentMargin
+
+      MouseArea { anchors.fill: parent; onClicked: {} }
+
+      Item {
+        id: keyCatcher
+
+        anchors.fill: parent
+        focus: true
+
+        Keys.priority: Keys.BeforeItem
+        Keys.onPressed: function(event) {
+          if (event.key === Qt.Key_Escape) {
+            if (root.filterText) root.setFilter("")
+            else root.dismiss()
+            event.accepted = true
+          } else if (Util.editsFilter(event, root.filterText)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
+            event.accepted = true
+          } else if (event.key === Qt.Key_Up) {
+            root.select(-1)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Down) {
+            root.select(1)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            root.activateIndex(root.selectedIndex)
+            event.accepted = true
+          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127) {
+            root.setFilter(root.filterText + event.text)
+            event.accepted = true
+          }
+        }
+      }
+
+      Column {
+        anchors.fill: parent
+        anchors.topMargin: card.contentTopInset
+        anchors.rightMargin: card.contentRightInset
+        anchors.bottomMargin: card.contentBottomInset
+        anchors.leftMargin: card.contentLeftInset
+        spacing: root.contentSpacing
+
+        Item {
+          width: parent.width
+          height: root.headerHeight
+
+          Text {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            text: root.filterText || "Add a widget…"
+            color: root.foreground
+            opacity: root.filterText ? 1 : 0.58
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.heading
+            elide: Text.ElideRight
+          }
+        }
+
+        Item {
+          width: parent.width
+          height: parent.height - root.headerHeight - root.contentSpacing
+
+          ListView {
+            id: resultList
+
+            anchors.fill: parent
+            model: root.filteredRows
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+
+            delegate: Rectangle {
+              id: rowDelegate
+
+              required property int index
+              required property var modelData
+
+              readonly property bool hasCursor: index === root.selectedIndex
+              readonly property color rowColor: hasCursor ? root.selectedText : root.foreground
+
+              width: resultList.width
+              height: root.rowHeight
+              radius: root.cornerRadius
+              color: hasCursor ? root.selectedBackground : "transparent"
+
+              Column {
+                anchors.left: parent.left
+                anchors.right: categoryLabel.left
+                anchors.leftMargin: Style.spacing.md
+                anchors.rightMargin: Style.spacing.md
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Style.spacing.xs
+
+                Text {
+                  width: parent.width
+                  text: rowDelegate.modelData.name
+                  color: rowDelegate.rowColor
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.title
+                  elide: Text.ElideRight
+                }
+
+                Text {
+                  width: parent.width
+                  text: rowDelegate.modelData.description
+                  visible: text !== ""
+                  color: rowDelegate.rowColor
+                  opacity: 0.62
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.body
+                  elide: Text.ElideRight
+                }
+              }
+
+              Text {
+                id: categoryLabel
+
+                anchors.right: parent.right
+                anchors.rightMargin: Style.spacing.md
+                anchors.verticalCenter: parent.verticalCenter
+                text: rowDelegate.modelData.category
+                color: rowDelegate.rowColor
+                opacity: 0.45
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+              }
+
+              MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onContainsMouseChanged: if (containsMouse) root.selectedIndex = rowDelegate.index
+                onClicked: root.activateIndex(rowDelegate.index)
+              }
+            }
+          }
+
+          Column {
+            anchors.centerIn: parent
+            spacing: Style.space(8)
+            visible: root.filteredRows.length === 0
+
+            Text {
+              width: parent.width
+              text: root.filterText ? "No matches for “" + root.filterText + "”" : "Every installed widget is already on the bar"
+              color: root.foreground
+              opacity: 0.7
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.title
+              horizontalAlignment: Text.AlignHCenter
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/widget-picker/WidgetPickerModel.js
+++ b/shell/plugins/widget-picker/WidgetPickerModel.js
@@ -1,0 +1,71 @@
+// Rows for the add-widget picker: every installed bar widget that is not
+// already on the bar, described the way its manifest presents itself.
+function pickerRows(installedPlugins, onBarIds) {
+  var onBar = {}
+  var ids = Array.isArray(onBarIds) ? onBarIds : []
+  for (var i = 0; i < ids.length; i++) onBar[String(ids[i])] = true
+
+  var rows = []
+  var plugins = installedPlugins || {}
+  for (var id in plugins) {
+    var manifest = plugins[id]
+    if (!manifest || !Array.isArray(manifest.kinds) || manifest.kinds.indexOf("bar-widget") === -1) continue
+    if (onBar[id]) continue
+
+    var meta = manifest.barWidget && typeof manifest.barWidget === "object" ? manifest.barWidget : {}
+    rows.push({
+      id: String(id),
+      name: String(meta.displayName || manifest.name || id),
+      description: String(meta.description || manifest.description || ""),
+      category: String(meta.category || "Other")
+    })
+  }
+
+  rows.sort(function(a, b) {
+    if (a.category !== b.category) return a.category < b.category ? -1 : 1
+    if (a.name !== b.name) return a.name < b.name ? -1 : 1
+    return a.id < b.id ? -1 : 1
+  })
+  return rows
+}
+
+// Case-insensitive substring match on anything the user can see, plus the id
+// they may know from the CLI.
+function filterRows(rows, filterText) {
+  var needle = String(filterText || "").trim().toLowerCase()
+  var values = Array.isArray(rows) ? rows : []
+  if (!needle) return values
+
+  return values.filter(function(row) {
+    var haystack = row.name + " " + row.id + " " + row.category + " " + row.description
+    return haystack.toLowerCase().indexOf(needle) !== -1
+  })
+}
+
+// The placement a bar right-click hands over, reduced to the keys
+// putBarWidget understands. Anything else in the payload is dropped so a
+// stray field can never reach the config mutation.
+function parsePlacement(payloadJson) {
+  var payload = {}
+  try {
+    payload = JSON.parse(String(payloadJson || "{}")) || {}
+  } catch (e) {
+    payload = {}
+  }
+
+  var placement = {}
+  if (payload.section) placement.section = String(payload.section)
+  if (payload.before) placement.before = String(payload.before)
+  else if (payload.after) placement.after = String(payload.after)
+  else if (isFinite(Number(payload.index)) && payload.index !== null && payload.index !== "")
+    placement.index = Math.max(0, Math.floor(Number(payload.index)))
+  return { placement: placement, screen: String(payload.screen || "") }
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    pickerRows: pickerRows,
+    filterRows: filterRows,
+    parsePlacement: parsePlacement
+  }
+}

--- a/shell/plugins/widget-picker/manifest.json
+++ b/shell/plugins/widget-picker/manifest.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.widget-picker",
+  "name": "Widget Picker",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "license": "MIT",
+  "description": "Add widgets to the bar",
+  "kinds": [
+    "overlay"
+  ],
+  "entryPoints": {
+    "overlay": "WidgetPicker.qml"
+  }
+}

--- a/test/shell.d/widget-picker-test.sh
+++ b/test/shell.d/widget-picker-test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const picker = requireFromRoot('shell/plugins/widget-picker/WidgetPickerModel.js')
+const pickerSource = fs.readFileSync(root + '/shell/plugins/widget-picker/WidgetPicker.qml', 'utf8')
+const barSource = fs.readFileSync(root + '/shell/plugins/bar/Bar.qml', 'utf8')
+const menuSource = fs.readFileSync(root + '/default/omarchy/omarchy-menu.jsonc', 'utf8')
+
+// The picker offers installed bar widgets that are not already on the bar,
+// described the way their manifests present themselves, in a stable
+// category-then-name order.
+const installed = {
+  'omarchy.weather': {
+    kinds: ['bar-widget'],
+    name: 'Weather',
+    barWidget: { displayName: 'Weather', description: 'Forecast at a glance', category: 'Info' }
+  },
+  'omarchy.audio': { kinds: ['bar-widget'], name: 'Audio', barWidget: { category: 'Hardware' } },
+  'omarchy.agents': { kinds: ['bar-widget'], name: 'Agents', barWidget: { category: 'AI' } },
+  'omarchy.menu': { kinds: ['bar-widget', 'menu'], name: 'Menu' },
+  'omarchy.bar': { kinds: ['bar'], name: 'Bar' },
+  'acme.broken': { name: 'No kinds at all' }
+}
+const rows = picker.pickerRows(installed, ['omarchy.audio'])
+assertDeepEqual(
+  rows.map(row => row.id),
+  ['omarchy.agents', 'omarchy.weather', 'omarchy.menu'],
+  'picker lists off-bar widgets sorted by category then name'
+)
+assertEqual(rows[1].description, 'Forecast at a glance', 'picker prefers the barWidget metadata description')
+assertEqual(rows[2].category, 'Other', 'picker files uncategorized widgets under Other')
+assertDeepEqual(picker.pickerRows(null, null), [], 'picker tolerates a missing registry')
+
+// Filtering matches anything the user can see, plus the id known from the CLI.
+assertDeepEqual(
+  picker.filterRows(rows, 'forecast').map(row => row.id),
+  ['omarchy.weather'],
+  'picker filter matches descriptions'
+)
+assertDeepEqual(
+  picker.filterRows(rows, 'omarchy.men').map(row => row.id),
+  ['omarchy.menu'],
+  'picker filter matches plugin ids'
+)
+assertDeepEqual(picker.filterRows(rows, '  '), rows, 'a blank filter keeps every row')
+
+// The summon payload reduces to the keys putBarWidget understands, and a
+// malformed payload degrades to the default placement instead of throwing.
+assertDeepEqual(
+  picker.parsePlacement('{"section":"right","before":"omarchy.clock","screen":"DP-3","stray":"x"}'),
+  { placement: { section: 'right', before: 'omarchy.clock' }, screen: 'DP-3' },
+  'picker keeps only placement keys from the payload'
+)
+assertDeepEqual(
+  picker.parsePlacement('{"after":"omarchy.tray"}'),
+  { placement: { after: 'omarchy.tray' }, screen: '' },
+  'picker carries after placements'
+)
+assertDeepEqual(
+  picker.parsePlacement('{"section":"right","index":9}'),
+  { placement: { section: 'right', index: 9 }, screen: '' },
+  'picker carries index placements for the end-of-bar add button'
+)
+assertDeepEqual(
+  picker.parsePlacement('{"index":"junk"}'),
+  { placement: {}, screen: '' },
+  'picker drops an index that is not a number'
+)
+assertDeepEqual(
+  picker.parsePlacement('not json'),
+  { placement: {}, screen: '' },
+  'picker shrugs off a malformed payload'
+)
+
+// Adding routes through the registry's put — the unattended verb that
+// tolerates a placement target the bar no longer carries.
+assert(
+  /pluginRegistry\.putBarWidget\(row\.id, root\.placement\)/.test(pickerSource),
+  'picker adds through the registry put with the summoned placement'
+)
+assert(
+  /function open\(payloadJson\)/.test(pickerSource) && /function close\(\)/.test(pickerSource),
+  'picker exposes the open and close lifecycle summon expects'
+)
+
+// The bar carries a + at its end that summons the picker, but an idle bar
+// must be pixel-identical to one without the feature: no reserved space, no
+// visible chrome. Only a pointer that dwells on the bar's end margin — a
+// hunt, not a pass-through or ordinary widget traffic — reveals it, and only
+// then do the end widgets slide over to make room.
+const addButton = barSource.slice(barSource.indexOf('component AddWidgetButton'))
+const addButtonBody = addButton.slice(0, addButton.indexOf('\n  }\n\n'))
+assert(
+  /concealed: !hunting/.test(addButtonBody) &&
+  /interactive: hunting/.test(addButtonBody) &&
+  !/keepSpace/.test(addButtonBody),
+  'the add button reveals only to a hunting pointer and reserves nothing'
+)
+assert(
+  /if \(hovered\) \{\s*\n\s*huntDwell\.restart\(\)/.test(addButtonBody) &&
+  /huntDwell\.stop\(\)\s*\n\s*hunting = false/.test(addButtonBody),
+  'the reveal waits for a dwell on the corner and hides the moment it ends'
+)
+assert(
+  !/barHovered/.test(addButtonBody),
+  'hovering the rest of the bar never reveals the add button'
+)
+assert(
+  /if \(button === Qt\.LeftButton\) root\.openWidgetPicker\(root\.targetWindow\(addButton\)\)/.test(addButtonBody),
+  'the add button answers a left click with the picker'
+)
+for (const orientation of ['horizontalBar', 'verticalBar']) {
+  const section = barSource.slice(barSource.indexOf('id: ' + orientation))
+  const body = section.slice(0, section.indexOf('\n    }\n'))
+  assert(
+    /AddWidgetButton \{/.test(body),
+    `the ${orientation} carries the add button`
+  )
+  assert(
+    /addWidgetButton\.hunting \? Style\.space\(3\) \+ addWidgetButton\.implicit(Width|Height) : Style\.space\(8\)/.test(body),
+    `the ${orientation} keeps its stock end margin until the button is revealed`
+  )
+  assert(
+    /HoverHandler \{\s*\n\s*onHoveredChanged: addWidgetButton\.setHunting\(hovered\)/.test(body),
+    `the ${orientation} dwell zone drives the hunt`
+  )
+}
+// The button sits at the outer end of the right section, so its pick lands
+// exactly where it is: appended to that section.
+assert(
+  /var placement = \{ section: "right", index: layoutEntries\("right"\)\.length \}/.test(barSource),
+  'the add button pick lands at the end of the right section'
+)
+assert(
+  /shell\.summon\("omarchy\.widget-picker", JSON\.stringify\(placement\)\)/.test(barSource),
+  'the bar summons the picker with that placement'
+)
+
+// The menu offers the same picker for people who never think to right-click.
+assert(
+  /"style\.bar\.add-widget":.*omarchy-shell shell summon omarchy\.widget-picker/.test(menuSource),
+  'the menu carries an Add Widget entry summoning the picker'
+)
+JS


### PR DESCRIPTION
Adding a widget to the bar previously meant the `omarchy-bar put` CLI or editing shell.json by hand. Now there's a picker too.

- Park the pointer on the bar's end margin for a beat and a + fades in (the end widgets slide over to make room, like the indicators peek). Clicking it opens the picker, and the pick lands right there, at the end of the bar. Idle, the bar is pixel-identical to today: no reserved space, no chrome, and ordinary bar traffic never reveals the button.
- Menu → Style → Menu Bar → Add Widget opens the same picker, placing picks at each widget's default spot.
- The picker lists every installed bar widget not already on the bar — first- and third-party alike — with name, description, and category from its manifest. Type to filter, arrows + Enter or click to add, Esc to dismiss. Styled on the menu/emoji overlay idiom, so themes apply.

Adds route through the registry's `putBarWidget`, with failures surfaced via `omarchy-notification-send`. List/filter/payload logic lives in `WidgetPickerModel.js` with node tests; `test/shell.d/widget-picker-test.sh` also pins the reveal contract (stock idle margin, dwell-only reveal, placement at the bar's end).


https://github.com/user-attachments/assets/b4330d5f-0226-42c2-acb0-8d50305b3f36

<img width="968" height="904" alt="screenshot-2026-08-13_00-35-44" src="https://github.com/user-attachments/assets/e6089d5a-5dd4-422f-86e6-5d0bd87907fd" />
<img width="640" height="523" alt="image" src="https://github.com/user-attachments/assets/4461aeec-2433-47c9-bf0d-1b9cec3fe43c" />
