### PR TITLE
Unmask wpa_supplicant left masked from the iwd era

### DIFF
--- a/migrations/1786567036.sh
+++ b/migrations/1786567036.sh
@@ -1,0 +1,26 @@
+echo "Unmask wpa_supplicant so NetworkManager can bring wifi back"
+
+# iwd-era installs may carry a wpa_supplicant.service mask, which breaks
+# NetworkManager's D-Bus activation of the supplicant and leaves every wifi
+# device unavailable (#6783).
+
+state=$(systemctl is-enabled wpa_supplicant.service 2>/dev/null || true)
+[[ $state == masked* ]] || exit 0
+
+sudo systemctl unmask wpa_supplicant.service
+
+# Older systemds leave a /run mask behind unless asked explicitly.
+state=$(systemctl is-enabled wpa_supplicant.service 2>/dev/null || true)
+if [[ $state == "masked-runtime" ]]; then
+  sudo systemctl unmask --runtime wpa_supplicant.service
+fi
+
+# No enable needed: NetworkManager D-Bus-activates the supplicant on demand.
+# But it stops retrying after five failures, so restart it when a wifi device
+# sits unavailable — except during the live Quattro upgrade, where iwd may
+# still carry the connection until the reboot.
+if [[ ${OMARCHY_UPGRADE_TO_QUATTRO_LIVE:-0} != "1" ]] &&
+  systemctl is-active --quiet NetworkManager.service 2>/dev/null &&
+  [[ $(LC_ALL=C nmcli -t -f TYPE,STATE device 2>/dev/null || true) == *"wifi:unavailable"* ]]; then
+  sudo systemctl restart NetworkManager.service || true
+fi


### PR DESCRIPTION
Quattro retires iwd and hands wifi to NetworkManager, which starts wpa_supplicant on demand through D-Bus activation. Installs from the iwd era may carry a mask of `wpa_supplicant.service` that once kept the supplicant out of iwd's way. Omarchy never wrote that mask, but on a machine that has one, the activation fails: NetworkManager retries five times, gives up, and every wifi device sits at "unavailable" — total network loss, on the machine the user would otherwise research the fix from.

This adds a migration that:

- Detects the mask via `systemctl is-enabled wpa_supplicant.service` and removes it, covering both a persistent `/etc` mask and a runtime `/run` mask on systemds whose plain `unmask` leaves the latter behind.
- Leaves the unit disabled, matching stock Arch: NetworkManager D-Bus-activates the supplicant, which works again once the mask is gone, so no `enable` is needed.
- Restarts NetworkManager only when it is active and a wifi device actually sits unavailable, so it re-probes the supplicant now instead of after the next reboot — and skips the restart during the live Quattro upgrade, where iwd may still be carrying the connection until the reboot and a restarted NetworkManager grabbing the adapter would set two supplicants fighting over it.

Unaffected systems exit at the first check, and a re-run after the repair finds nothing masked and does the same.

The issue also mentions a cosmetic "NOT CONNECTED" label in the network panel; that is left for a separate change to keep this one focused on the repair.

Fixes #6783

— 🤖 Claude, posting on behalf of @dhh