### PR TITLE
Arrange displays by dragging them

### DIFF
--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -1,11 +1,22 @@
 #!/bin/bash
 
 # omarchy:summary=Enable, disable, toggle, or recover mirroring the internal display to an external monitor
-# omarchy:args=<on|off|toggle|recover>
+# omarchy:args=<on|off|toggle|recover> [--quiet]
+
+# Callers that cycle mirroring as plumbing rather than as the user's request
+# pass --quiet, so a single action does not stack up notifications nobody asked
+# for. Failures still speak up.
+quiet=0
+[[ ${2:-} == "--quiet" ]] && quiet=1
+
+announce() {
+  ((quiet)) && return 0
+  omarchy-notification-send "$@"
+}
 
 TOGGLE="internal-monitor-mirror"
-TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 DISABLE_TOGGLE="internal-monitor-disable"
+TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
 # The first active external monitor
@@ -25,8 +36,31 @@ on() {
   omarchy-hyprland-toggle $DISABLE_TOGGLE off
 
   if omarchy-hyprland-toggle-disabled $TOGGLE; then
-    printf 'hl.monitor({ output = "%s", mode = "preferred", position = "auto", scale = 1, mirror = "%s" })\n' "$EXTERNAL" "$INTERNAL" >"$TOGGLE_FLAG"
-    omarchy-notification-send -g 󰍹 "Mirroring enabled ($EXTERNAL)"
+    # Pin the mirror to the source's position rather than "auto". A mirrored
+    # display has to occupy the same region as the display it mirrors, and
+    # "auto" only lands there while the output stays up: disabling and
+    # re-enabling it rebuilds the output from the rules, where the user's own
+    # monitors.lua entry supplies its extended position instead. The two then
+    # cover different regions and each shows different content while still
+    # reporting as mirroring.
+    local position
+    position=$(hyprctl monitors -j | jq -r --arg name "$INTERNAL" '[.[] | select(.name == $name)][0] | if . then "\(.x)x\(.y)" else "auto" end')
+    [[ $position =~ ^[0-9-]+x[0-9-]+$ ]] || position="auto"
+
+    # Carry the external display's rotation. Hyprland merges monitor rules per
+    # identifier, so anything this rule leaves out is dropped rather than kept,
+    # and a rotated display would start mirroring sideways relative to the panel
+    # it is on.
+    local transform
+    transform=$(hyprctl monitors -j | jq -r --arg name "$EXTERNAL" '[.[] | select(.name == $name)][0].transform // 0')
+    [[ $transform =~ ^[0-9]+$ ]] || transform=0
+
+    local transform_rule=""
+    ((transform != 0)) && transform_rule=", transform = $transform"
+
+    printf 'hl.monitor({ output = "%s", mode = "preferred", position = "%s", scale = 1, mirror = "%s"%s })\n' \
+      "$EXTERNAL" "$position" "$INTERNAL" "$transform_rule" >"$TOGGLE_FLAG"
+    announce -g 󰍹 "Mirroring enabled ($EXTERNAL)"
     hyprctl reload
   fi
 }
@@ -34,7 +68,7 @@ on() {
 off() {
   if omarchy-hyprland-toggle-enabled $TOGGLE; then
     omarchy-hyprland-toggle $TOGGLE off
-    omarchy-notification-send -g 󰍹 "Extended mode restored"
+    announce -g 󰍹 "Extended mode restored"
   fi
 }
 
@@ -47,7 +81,12 @@ toggle() {
 }
 
 recover() {
-  if ! omarchy-hyprland-monitor-external-active && omarchy-hyprland-toggle-enabled $TOGGLE; then
+  # Physical presence rather than Hyprland's enabled state. A display the user
+  # switched off is still plugged in, and dropping the mirror for it discards a
+  # deliberate choice that re-enabling then cannot restore. Unplugging still
+  # clears the mirror, since a rule pointing at an absent output would leave
+  # mirroring stuck on with nothing to mirror to.
+  if ! omarchy-hw-external-monitors && omarchy-hyprland-toggle-enabled $TOGGLE; then
     omarchy-hyprland-toggle $TOGGLE off
   fi
 }

--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -19,11 +19,13 @@ DISABLE_TOGGLE="internal-monitor-disable"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
-# The first active external monitor
-EXTERNAL=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not).name' | head -n 1)
+# Every active external monitor, not just the first. Mirroring means every other
+# display shows the laptop panel; leaving the second and third extended made
+# "Mirror" only half true, and which display got it came down to output order.
+mapfile -t EXTERNALS < <(hyprctl monitors -j | jq -r '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not).name')
 
 on() {
-  if [[ -z $EXTERNAL ]]; then
+  if ((${#EXTERNALS[@]} == 0)); then
     omarchy-notification-send -g 󰍹 "No external monitors found for mirror"
     exit 1
   fi
@@ -47,20 +49,28 @@ on() {
     position=$(hyprctl monitors -j | jq -r --arg name "$INTERNAL" '[.[] | select(.name == $name)][0] | if . then "\(.x)x\(.y)" else "auto" end')
     [[ $position =~ ^[0-9-]+x[0-9-]+$ ]] || position="auto"
 
-    # Carry the external display's rotation. Hyprland merges monitor rules per
-    # identifier, so anything this rule leaves out is dropped rather than kept,
-    # and a rotated display would start mirroring sideways relative to the panel
-    # it is on.
-    local transform
-    transform=$(hyprctl monitors -j | jq -r --arg name "$EXTERNAL" '[.[] | select(.name == $name)][0].transform // 0')
-    [[ $transform =~ ^[0-9]+$ ]] || transform=0
+    # Every mirror sits on the source's region, so they all take the same
+    # position. Rotation is per display: Hyprland merges monitor rules per
+    # identifier, so anything a rule leaves out is dropped rather than kept, and
+    # a rotated display would start mirroring sideways relative to the panel.
+    local external transform transform_rule
+    : >"$TOGGLE_FLAG"
+    for external in "${EXTERNALS[@]}"; do
+      transform=$(hyprctl monitors -j | jq -r --arg name "$external" '[.[] | select(.name == $name)][0].transform // 0')
+      [[ $transform =~ ^[0-9]+$ ]] || transform=0
 
-    local transform_rule=""
-    ((transform != 0)) && transform_rule=", transform = $transform"
+      transform_rule=""
+      ((transform != 0)) && transform_rule=", transform = $transform"
 
-    printf 'hl.monitor({ output = "%s", mode = "preferred", position = "%s", scale = 1, mirror = "%s"%s })\n' \
-      "$EXTERNAL" "$position" "$INTERNAL" "$transform_rule" >"$TOGGLE_FLAG"
-    announce -g 󰍹 "Mirroring enabled ($EXTERNAL)"
+      printf 'hl.monitor({ output = "%s", mode = "preferred", position = "%s", scale = 1, mirror = "%s"%s })\n' \
+        "$external" "$position" "$INTERNAL" "$transform_rule" >>"$TOGGLE_FLAG"
+    done
+
+    if ((${#EXTERNALS[@]} == 1)); then
+      announce -g 󰍹 "Mirroring enabled (${EXTERNALS[0]})"
+    else
+      announce -g 󰍹 "Mirroring enabled (${#EXTERNALS[@]} displays)"
+    fi
     hyprctl reload
   fi
 }

--- a/bin/omarchy-hyprland-monitor-rule
+++ b/bin/omarchy-hyprland-monitor-rule
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# omarchy:summary=Write a display's current geometry into hypr/monitors.lua
+# omarchy:args=<output>
+# omarchy:examples=omarchy hyprland monitor rule DP-1
+
+# Geometry belongs in the user's own monitors.lua, which is where they already
+# write it and where they expect to edit it afterwards. Keeping it anywhere else
+# means two files describing the same display, and whichever Hyprland loads last
+# silently wins — so a config edit stops taking effect with nothing to say why.
+#
+# The rule for a display is rewritten in place, keeping whichever identifier the
+# user already wrote for it. Only a display with no rule of its own gets a new
+# line appended.
+
+monitor_lua="$HOME/.config/hypr/monitors.lua"
+
+usage() {
+  echo "Usage: omarchy-hyprland-monitor-rule <output>" >&2
+}
+
+output="${1:-}"
+if [[ -z $output ]]; then
+  usage
+  exit 1
+fi
+
+if [[ ! -f $monitor_lua ]]; then
+  echo "No monitors.lua to write to: $monitor_lua" >&2
+  exit 1
+fi
+
+monitor="$(hyprctl monitors all -j | jq -e -c --arg name "$output" '[.[] | select(.name == $name)][0]')" || {
+  echo "No such display: $output" >&2
+  exit 1
+}
+
+description="$(printf '%s' "$monitor" | jq -r '.description // ""')"
+x="$(printf '%s' "$monitor" | jq -r '.x')"
+y="$(printf '%s' "$monitor" | jq -r '.y')"
+scale="$(printf '%s' "$monitor" | jq -r '.scale')"
+transform="$(printf '%s' "$monitor" | jq -r '.transform // 0')"
+
+# Hyprland reports scales as floats, and a rule reading `scale = 2.00000` is
+# noise in a file the user reads.
+scale="$(awk -v value="$scale" 'BEGIN { printf "%g", value }')"
+
+# Every line that configures this display, whatever shape it is written in.
+# Lua allows `hl.monitor { … }` without parentheses, spacing is free, and a line
+# may be indented — so match on content rather than on the formatting Omarchy
+# happens to ship. Hyprland also matches `desc:` by prefix and users abbreviate,
+# so a rule saying "desc:Acme Wide" configures a display reporting
+# "Acme Wide 42 SN123".
+matching_rule_lines() {
+  awk -v name="$output" -v description="$description" '
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^hl\.monitor[[:space:]]*[({]/) next
+      if (line ~ /^--/) next
+
+      if (match(line, /output[[:space:]]*=[[:space:]]*"[^"]*"/) == 0) {
+        # A rule whose display is named by something other than a literal, a
+        # variable say. It may or may not be this display, and guessing wrong
+        # means either mangling an unrelated rule or adding a second one for
+        # this display. Report it so the caller can decline.
+        print "?"
+        next
+      }
+
+      identifier = substr(line, RSTART, RLENGTH)
+      sub(/^output[[:space:]]*=[[:space:]]*"/, "", identifier)
+      sub(/"$/, "", identifier)
+
+      if (identifier == name) { print NR; next }
+      if (substr(identifier, 1, 5) == "desc:") {
+        key = substr(identifier, 6)
+        if (key != "" && description != "" && substr(description, 1, length(key)) == key) {
+          print NR
+          next
+        }
+      }
+    }
+  ' "$monitor_lua"
+}
+
+identifier_for() {
+  local line="$1"
+
+  # Keep the identifier the user chose for this display rather than swapping it
+  # for ours: theirs may be deliberate, and rewriting it would leave their other
+  # references — comments, notes — pointing at something that no longer exists.
+  if [[ -n $line ]]; then
+    sed -n "${line}p" "$monitor_lua" |
+      sed -E 's/.*output[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/'
+    return
+  fi
+
+  if [[ -n $description ]]; then
+    printf 'desc:%s\n' "$description"
+  else
+    printf '%s\n' "$output"
+  fi
+}
+
+mapfile -t matches < <(matching_rule_lines)
+
+# Decline rather than guess. Rewriting the wrong rule, or adding a second one
+# for a display that already has one, is worse than leaving the file alone and
+# saying so: two rules for one display means whichever Hyprland loads last wins
+# and silently drops whatever the other one said.
+for match in "${matches[@]}"; do
+  if [[ $match == "?" ]]; then
+    echo "Not editing $monitor_lua: it configures a display by something other than a literal name" >&2
+    exit 1
+  fi
+done
+
+if ((${#matches[@]} > 1)); then
+  echo "Not editing $monitor_lua: $output already has ${#matches[@]} rules" >&2
+  exit 1
+fi
+
+line="${matches[0]:-}"
+identifier="$(identifier_for "$line")"
+
+rule="hl.monitor({ output = \"$identifier\", mode = \"preferred\", position = \"${x}x${y}\", scale = $scale"
+((transform != 0)) && rule+=", transform = $transform"
+rule+=" })"
+
+tmp="$(mktemp)"
+if [[ -n $line ]]; then
+  awk -v target="$line" -v rule="$rule" 'NR == target { print rule; next } { print }' "$monitor_lua" >"$tmp"
+else
+  cat "$monitor_lua" >"$tmp"
+  printf '%s\n' "$rule" >>"$tmp"
+fi
+
+mv "$tmp" "$monitor_lua"

--- a/bin/omarchy-hyprland-monitor-rule
+++ b/bin/omarchy-hyprland-monitor-rule
@@ -166,6 +166,26 @@ identifier_for() {
   fi
 }
 
+# Keep the mode the user wrote, the same way the identifier is kept. Hyprland
+# merges monitor rules per identifier and drops whatever a rule leaves out, so
+# the rewritten rule has to restate a mode: saying "preferred" over a display
+# pinned to 2560x1440@144 would quietly drop it to whatever the monitor calls
+# best. This command changes geometry, so the mode it finds is the mode it
+# writes back. A rule that named no mode was already running the preferred one.
+mode_for() {
+  local first="$1" last="$2" existing
+
+  if [[ -n $first ]]; then
+    existing="$(sed -n "${first},${last}p" "$monitor_lua" | tr '\n' ' ')"
+    if [[ $existing =~ mode[[:space:]]*=[[:space:]]*\"([^\"]*)\" ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return
+    fi
+  fi
+
+  printf 'preferred\n'
+}
+
 # The indentation the rule already sits at, so replacing it does not shove it
 # against the margin in a file the user reads.
 indent_of() {
@@ -195,8 +215,9 @@ fi
 
 read -r first last <<<"${matches[0]:-}"
 identifier="$(identifier_for "$first" "$last")"
+mode="$(mode_for "$first" "$last")"
 
-rule="$(indent_of "$first")hl.monitor({ output = \"$identifier\", mode = \"preferred\", position = \"${x}x${y}\", scale = $scale"
+rule="$(indent_of "$first")hl.monitor({ output = \"$identifier\", mode = \"$mode\", position = \"${x}x${y}\", scale = $scale"
 ((transform != 0)) && rule+=", transform = $transform"
 rule+=" })"
 

--- a/bin/omarchy-hyprland-monitor-rule
+++ b/bin/omarchy-hyprland-monitor-rule
@@ -45,53 +45,116 @@ transform="$(printf '%s' "$monitor" | jq -r '.transform // 0')"
 # noise in a file the user reads.
 scale="$(awk -v value="$scale" 'BEGIN { printf "%g", value }')"
 
-# Every line that configures this display, whatever shape it is written in.
-# Lua allows `hl.monitor { … }` without parentheses, spacing is free, and a line
-# may be indented — so match on content rather than on the formatting Omarchy
-# happens to ship. Hyprland also matches `desc:` by prefix and users abbreviate,
-# so a rule saying "desc:Acme Wide" configures a display reporting
-# "Acme Wide 42 SN123".
+# Every rule that configures this display, whatever shape it is written in, as
+# a "first last" line range.
+#
+# A rule is a Lua statement, not a line: `hl.monitor({ … })` is as valid split
+# over six lines as it is on one, and both are ordinary things to write. So read
+# whole statements — track quoting and delimiter depth from `hl.monitor` to its
+# closing brace — rather than assuming the whole rule fits on the line its
+# `output` key happens to sit on. Lua also allows `hl.monitor { … }` without
+# parentheses, spacing is free, and a rule may be indented.
+#
+# Hyprland matches `desc:` by prefix and users abbreviate, so a rule saying
+# "desc:Acme Wide" configures a display reporting "Acme Wide 42 SN123".
 matching_rule_lines() {
   awk -v name="$output" -v description="$description" '
-    {
-      line = $0
-      sub(/^[[:space:]]+/, "", line)
-      if (line !~ /^hl\.monitor[[:space:]]*[({]/) next
-      if (line ~ /^--/) next
-
-      if (match(line, /output[[:space:]]*=[[:space:]]*"[^"]*"/) == 0) {
+    function report(first, last, text,   identifier, key) {
+      if (match(text, /output[[:space:]]*=[[:space:]]*"[^"]*"/) == 0) {
         # A rule whose display is named by something other than a literal, a
         # variable say. It may or may not be this display, and guessing wrong
         # means either mangling an unrelated rule or adding a second one for
         # this display. Report it so the caller can decline.
         print "?"
-        next
+        return
       }
 
-      identifier = substr(line, RSTART, RLENGTH)
+      identifier = substr(text, RSTART, RLENGTH)
       sub(/^output[[:space:]]*=[[:space:]]*"/, "", identifier)
       sub(/"$/, "", identifier)
 
-      if (identifier == name) { print NR; next }
+      if (identifier == name) { print first " " last; return }
       if (substr(identifier, 1, 5) == "desc:") {
         key = substr(identifier, 6)
-        if (key != "" && description != "" && substr(description, 1, length(key)) == key) {
-          print NR
-          next
-        }
+        if (key != "" && description != "" && substr(description, 1, length(key)) == key)
+          print first " " last
       }
+    }
+
+    {
+      line = $0
+      len = length(line)
+      i = 1
+
+      while (i <= len) {
+        c = substr(line, i, 1)
+
+        # A quote flips string state, and nothing inside a string counts as
+        # syntax: a description may hold braces, parentheses or a "--".
+        if (c == "\"") {
+          in_string = !in_string
+          if (collecting) buffer = buffer c
+          i++
+          continue
+        }
+
+        if (!in_string && substr(line, i, 2) == "--") break   # comment to end of line
+
+        if (in_string) {
+          if (collecting) buffer = buffer c
+          i++
+          continue
+        }
+
+        if (!collecting) {
+          if (substr(line, i, 10) == "hl.monitor") {
+            collecting = 1
+            depth = 0
+            first = NR
+            buffer = "hl.monitor"
+            i += 10
+            continue
+          }
+          i++
+          continue
+        }
+
+        buffer = buffer c
+        if (c == "(" || c == "{") depth++
+        else if (c == ")" || c == "}") {
+          depth--
+          if (depth <= 0) {
+            report(first, NR, buffer)
+            collecting = 0
+            buffer = ""
+          }
+        }
+        i++
+      }
+
+      # A statement continuing onto the next line: keep the tokens either side
+      # of the break apart.
+      if (collecting) buffer = buffer " "
+    }
+
+    END {
+      # An unterminated hl.monitor( … . Refuse to place this display rather than
+      # append a second rule below a broken one.
+      if (collecting) print "?"
     }
   ' "$monitor_lua"
 }
 
 identifier_for() {
-  local line="$1"
+  local first="$1" last="$2"
 
   # Keep the identifier the user chose for this display rather than swapping it
   # for ours: theirs may be deliberate, and rewriting it would leave their other
   # references — comments, notes — pointing at something that no longer exists.
-  if [[ -n $line ]]; then
-    sed -n "${line}p" "$monitor_lua" |
+  # The key can be on any line of the rule, so read the whole range.
+  if [[ -n $first ]]; then
+    sed -n "${first},${last}p" "$monitor_lua" |
+      tr '\n' ' ' |
       sed -E 's/.*output[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/'
     return
   fi
@@ -101,6 +164,15 @@ identifier_for() {
   else
     printf '%s\n' "$output"
   fi
+}
+
+# The indentation the rule already sits at, so replacing it does not shove it
+# against the margin in a file the user reads.
+indent_of() {
+  local first="$1"
+
+  [[ -n $first ]] || return 0
+  sed -n "${first}p" "$monitor_lua" | sed -E 's/^([[:space:]]*).*/\1/'
 }
 
 mapfile -t matches < <(matching_rule_lines)
@@ -121,16 +193,22 @@ if ((${#matches[@]} > 1)); then
   exit 1
 fi
 
-line="${matches[0]:-}"
-identifier="$(identifier_for "$line")"
+read -r first last <<<"${matches[0]:-}"
+identifier="$(identifier_for "$first" "$last")"
 
-rule="hl.monitor({ output = \"$identifier\", mode = \"preferred\", position = \"${x}x${y}\", scale = $scale"
+rule="$(indent_of "$first")hl.monitor({ output = \"$identifier\", mode = \"preferred\", position = \"${x}x${y}\", scale = $scale"
 ((transform != 0)) && rule+=", transform = $transform"
 rule+=" })"
 
+# A rule written across several lines collapses to the one line replacing it,
+# which is the shape every rule this command writes takes.
 tmp="$(mktemp)"
-if [[ -n $line ]]; then
-  awk -v target="$line" -v rule="$rule" 'NR == target { print rule; next } { print }' "$monitor_lua" >"$tmp"
+if [[ -n $first ]]; then
+  awk -v first="$first" -v last="$last" -v rule="$rule" '
+    NR == first { print rule }
+    NR >= first && NR <= last { next }
+    { print }
+  ' "$monitor_lua" >"$tmp"
 else
   cat "$monitor_lua" >"$tmp"
   printf '%s\n' "$rule" >>"$tmp"

--- a/default/hypr/apps/omarchy-shell.lua
+++ b/default/hypr/apps/omarchy-shell.lua
@@ -7,7 +7,7 @@ hl.layer_rule({ match = { namespace = "omarchy-bar" }, no_anim = true, animation
 -- Launcher, image selector, emojis, clipboard overlays, and keyboard-driven
 -- panels should pop without compositor layer fades. Panels keep their own
 -- QML opacity transition for normal open/close, and skip it for panel handoff.
-hl.layer_rule({ match = { namespace = "^(omarchy-menu|omarchy-image-selector|omarchy-emojis|omarchy-clipboard|omarchy-keyboard-panel)$" }, no_anim = true, animation = "none" })
+hl.layer_rule({ match = { namespace = "^(omarchy-menu|omarchy-image-selector|omarchy-emojis|omarchy-clipboard|omarchy-keyboard-panel|omarchy-display-arrange)$" }, no_anim = true, animation = "none" })
 
 -- Dev gallery is the main shell workbench; open it maximized like
 -- SUPER+ALT+F so component previews have the whole workspace.

--- a/migrations/1786611349.sh
+++ b/migrations/1786611349.sh
@@ -33,9 +33,19 @@ fi
 # leaving a machine extended that was mirroring when the migration started.
 previous=$(cat "$flag")
 
+# Switching mirroring off removes the rule and reloads Hyprland, so by the time
+# anything can fail the session is already extended. Putting the file back is
+# not enough on its own: without a reload the rule would claim mirroring while
+# the displays stay extended, which is the state this is here to avoid.
 restore() {
   printf '%s\n' "$previous" >"$flag"
-  echo "  could not pin the mirror, put the existing rule back"
+
+  if hyprctl reload >/dev/null 2>&1; then
+    echo "  could not pin the mirror, put the existing rule back"
+  else
+    echo "  could not pin the mirror, and could not reload to restore it"
+    echo "  mirroring is off until the next reload, and the rule is back in $flag"
+  fi
   exit 0
 }
 

--- a/migrations/1786611349.sh
+++ b/migrations/1786611349.sh
@@ -1,0 +1,53 @@
+echo "Pin an existing display mirror to the display it mirrors"
+
+# A mirror rule used to say position = "auto", which only lands on the mirrored
+# display while the output stays up: disable and re-enable it and the rule is
+# rebuilt from the user's own monitors.lua entry instead, so the two displays
+# cover different regions and each shows different content while still
+# reporting as mirroring. The rule now pins the source's position, but it is
+# only written when mirroring is switched on, so a machine already mirroring
+# keeps the old rule until someone happens to toggle it.
+
+flag="$HOME/.local/state/omarchy/toggles/hypr/internal-monitor-mirror.lua"
+
+# Not mirroring, or already pinned by a version that writes the position.
+[[ -f $flag ]] || exit 0
+grep -Fq 'position = "auto"' "$flag" || exit 0
+
+# Cycling is what rewrites the rule, and it can only be undone if both displays
+# are actually there: switching mirroring off and then failing to switch it back
+# on would leave the user extended with nothing saying why. Physical presence
+# rather than Hyprland's enabled state, since a display switched off is still
+# plugged in and can still be mirrored to once mirroring re-enables it.
+if ! omarchy-hw-external-monitors; then
+  echo "  no external display attached, leaving mirroring alone"
+  exit 0
+fi
+
+if [[ -z $(omarchy-hyprland-monitor-laptop) ]]; then
+  echo "  no laptop panel to mirror, leaving mirroring alone"
+  exit 0
+fi
+
+# Keep the rule as it stands so an incomplete cycle can be put back, rather than
+# leaving a machine extended that was mirroring when the migration started.
+previous=$(cat "$flag")
+
+restore() {
+  printf '%s\n' "$previous" >"$flag"
+  echo "  could not pin the mirror, put the existing rule back"
+  exit 0
+}
+
+# --quiet: the user did not ask for this, so a single repair should not stack up
+# notifications. Failures still speak up.
+omarchy-hyprland-monitor-internal-mirror off --quiet || restore
+omarchy-hyprland-monitor-internal-mirror on --quiet || restore
+
+# Only trust it once the new rule is actually on disk and no longer the old one.
+[[ -f $flag ]] || restore
+if grep -Fq 'position = "auto"' "$flag"; then
+  restore
+fi
+
+echo "  mirroring now holds the position of the display it mirrors"

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -595,9 +595,13 @@ Item {
             if (root.mirrorEnabled) return "MIRRORING — SWITCH TO EXTEND TO ARRANGE DISPLAYS"
             if (root.layoutOverlaps) return "DISPLAYS OVERLAP"
             if (!root.layoutContiguous) return "DISPLAYS MUST TOUCH — A GAP IS A DEAD ZONE FOR THE POINTER"
-            if (!root.hasChanges) return "DRAG A DISPLAY  ·  H J K L TO NUDGE  ·  R TO ROTATE"
+            // Nothing to say until something is actually wrong or pending: the
+            // controls below name themselves, and a single display has nothing
+            // to drag against anyway.
+            if (!root.hasChanges) return ""
             return "ENTER TO APPLY  ·  ESC TO CANCEL"
           }
+          visible: text !== ""
           color: root.layoutValid || root.awaitingConfirmation ? Qt.darker(Color.foreground, 1.4) : Color.accent
           font.family: Style.font.family
           font.pixelSize: Style.font.caption

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -380,8 +380,13 @@ Item {
     transforms = originalTransforms
     rects = originalRects
 
-    var previous = Model.positionsOf(Model.normalized(originalRects))
-    writeLayout(previous)
+    // Where the displays actually were, not the normalised version of it.
+    // Normalising is how the canvas draws a layout and how a new one is written,
+    // but putting one back is not writing a new one: a layout that started off
+    // the origin, anything with a display left of or above 0x0, would come back
+    // shifted, so the fail-safe meant to undo a change would make one of its
+    // own and there would be nothing left to undo it with.
+    writeLayout(Model.positionsOf(originalRects))
 
     // Step out once the layout is actually back, not before. Tearing this
     // overlay's surface down while Hyprland is still re-modesetting leaves

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -91,9 +91,6 @@ Item {
   function close() {
     opened = false
     closeWhenApplied = false
-    // An apply still in flight must not raise the window again behind a user
-    // who has just dismissed it.
-    reopenWhenApplied = false
     reopen.stop()
     revertTimer.stop()
     countdown.stop()
@@ -280,15 +277,11 @@ Item {
     countdown.restart()
     revertTimer.restart()
 
-    // Applying does not reload Hyprland: writeLayout sets each rule directly,
-    // precisely so no display takes a modeset. So there is nothing for the
-    // overlay to sit out — it stays up while the geometry moves under it.
-    //
-    // It is still stood back up once the work finishes, because a compositor
-    // that does take the surface leaves this believing it is still open, and
-    // the confirm-or-revert prompt has to be there to answer. Waiting on the
-    // apply itself rather than on a fixed delay keeps that to a blink.
-    reopenWhenApplied = true
+    // Nothing else to do. Applying does not reload Hyprland — writeLayout sets
+    // each rule directly, precisely so no display takes a modeset — so the
+    // surface this overlay is drawn on outlives the change, and the window can
+    // stay exactly where it is while the geometry moves under it. Dropping and
+    // raising it here to be safe would be the one thing that made it flash.
   }
 
   function confirmLayout() {
@@ -374,29 +367,14 @@ Item {
   }
 
   property bool closeWhenApplied: false
-  property bool reopenWhenApplied: false
 
   Process {
     id: applyProc
     stdout: StdioCollector { waitForEnd: true }
     onRunningChanged: {
-      if (running) return
-
-      if (root.closeWhenApplied) {
-        root.closeWhenApplied = false
-        root.reopenWhenApplied = false
-        root.close()
-        return
-      }
-
-      if (root.reopenWhenApplied) {
-        root.reopenWhenApplied = false
-        // Only a false-to-true turn builds a new surface, so a window that is
-        // still up is dropped and immediately raised again rather than left to
-        // an assumption about whether the compositor kept it.
-        root.opened = false
-        root.scheduleReopen(0)
-      }
+      if (running || !root.closeWhenApplied) return
+      root.closeWhenApplied = false
+      root.close()
     }
   }
 

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -70,14 +70,27 @@ Item {
 
   readonly property color scrim: Util.alpha(Color.background, 0.97)
 
+  // Long enough for Hyprland to finish re-modesetting every display after a
+  // layout is written. Only the paths that reconfigure outputs need to wait it
+  // out; an ordinary open has nothing settling and must not pay for it.
+  readonly property int settleDelay: 1500
+
+  function scheduleReopen(delay) {
+    reopen.interval = delay
+    reopen.restart()
+  }
+
   function open(payloadJson) {
     refresh()
 
     // Drop any stale window first. A previous apply may have reconfigured the
     // outputs and taken the surface with it, leaving this believing it is still
-    // open — in which case showing it again would do nothing at all.
+    // open — in which case showing it again would do nothing at all. Dropping
+    // it only needs to land before the window is stood back up, so this hands
+    // the change to the next event loop turn rather than waiting on a modeset
+    // that is not happening.
     opened = false
-    reopen.restart()
+    scheduleReopen(0)
   }
 
   function close() {
@@ -274,7 +287,7 @@ Item {
     // once the new geometry has settled, so the confirm-or-revert prompt is
     // still there to answer.
     opened = false
-    reopen.restart()
+    scheduleReopen(settleDelay)
   }
 
   function confirmLayout() {
@@ -303,9 +316,12 @@ Item {
     closeWhenApplied = true
   }
 
+  // Every caller goes through scheduleReopen, which sets the interval to suit
+  // what it is waiting for; the value here is only what the timer starts life
+  // holding.
   Timer {
     id: reopen
-    interval: 1500
+    interval: root.settleDelay
     repeat: false
     onTriggered: {
       root.refresh()

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -39,10 +39,20 @@ Item {
   // how displays relate in space, and it collapses the arrangement to a single
   // display, which is exactly what this canvas draws.
   property string mirroringMonitor: ""
-  property string internalMonitor: ""
-  property string externalMonitor: ""
   readonly property bool mirrorEnabled: mirroringMonitor !== ""
-  readonly property bool mirrorAvailable: internalMonitor !== "" && externalMonitor !== ""
+
+  // Offer mirroring against the displays that are actually live, which is what
+  // the canvas draws. `omarchy-monitor-state` names its internal and external
+  // displays out of `hyprctl monitors all`, so it names ones the user switched
+  // off too: gating on those put Mirror above a canvas holding a single
+  // rectangle, and pressing it silently re-enabled the panel that was off.
+  readonly property bool internalActive: Model.hasActiveDisplay(displays, true)
+  readonly property bool externalActive: Model.hasActiveDisplay(displays, false)
+
+  // Mirroring withdraws the mirrored output from the active listing altogether,
+  // so the pair test cannot hold while it is on. Keep the row up in that case
+  // regardless, or Extend becomes unreachable from the only place offering it.
+  readonly property bool mirrorAvailable: mirrorEnabled || (internalActive && externalActive)
 
   // Switching mode adds or removes an output, and this overlay is anchored to
   // one: mirroring withdraws the mirrored display from Wayland, which leaves
@@ -380,8 +390,6 @@ Item {
       waitForEnd: true
       onStreamFinished: {
         var lines = String(text || "").split("\n")
-        root.internalMonitor = String(lines[1] || "").trim()
-        root.externalMonitor = String(lines[2] || "").trim()
         root.mirroringMonitor = String(lines[4] || "").trim()
       }
     }

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -88,7 +88,21 @@ Item {
     scheduleReopen(0)
   }
 
+  // A layout that has been applied but not confirmed is only safe because it
+  // puts itself back. Every way out of that prompt other than Keep has to
+  // revert, including the ones that are not a decision about the layout at all:
+  // clicking the scrim, the toggle hotkey, a hide over IPC, switching to
+  // Mirror. Dropping the timer instead would make an arrangement the user could
+  // not see permanent, which is the one thing the prompt exists to prevent.
   function close() {
+    if (awaitingConfirmation) {
+      revertLayout()
+      return
+    }
+    dismiss()
+  }
+
+  function dismiss() {
     opened = false
     closeWhenApplied = false
     reopen.stop()
@@ -163,7 +177,20 @@ Item {
   readonly property bool layoutOverlaps: Model.anyOverlap(rects)
   readonly property bool layoutContiguous: Model.isContiguous(rects)
   readonly property bool layoutValid: !layoutOverlaps && layoutContiguous
-  readonly property var pendingChanges: Model.changedPositions(Model.normalized(originalRects), normalizedRects)
+  // What the canvas draws is normalised, so an edit is judged against the
+  // normalised layout: shifting every display by the same amount is not an edit.
+  //
+  // Writing is judged against where the displays actually are. A layout whose
+  // top-left is not already the origin — anything with a display left of or
+  // above 0x0 — moves under normalisation, so a display the user never touched
+  // can still need a new position. Writing only the ones they dragged would
+  // apply a normalised position beside an un-normalised one and leave the gap
+  // the canvas just showed them closing.
+  readonly property var pendingChanges: {
+    var edited = Model.changedPositions(Model.normalized(originalRects), normalizedRects)
+    if (Object.keys(edited).length === 0) return edited
+    return Model.changedPositions(originalRects, normalizedRects)
+  }
   readonly property bool rotationChanged: {
     for (var i = 0; i < displays.length; i++) {
       var name = displays[i].name
@@ -230,6 +257,24 @@ Item {
     return 1
   }
 
+  // The mode the display is actually running, to restate in its rule. Hyprland
+  // merges monitor rules per identifier and drops whatever a rule leaves out,
+  // so a rule saying "preferred" takes a display the user pinned to a mode like
+  // 2560x1440@144 and drops it back to whatever the monitor reports as best.
+  // Nothing here is trying to change the mode, so say the one already in use.
+  function modeOf(name) {
+    for (var i = 0; i < displays.length; i++) {
+      if (displays[i].name !== name) continue
+
+      var width = Number(displays[i].width)
+      var height = Number(displays[i].height)
+      var refresh = Number(displays[i].refreshRate)
+      if (width > 0 && height > 0 && refresh > 0) return width + "x" + height + "@" + refresh
+      break
+    }
+    return "preferred"
+  }
+
   // Geometry is applied first and then recorded in the user's own monitors.lua,
   // which is where they already write it and where they will edit it next.
   // Keeping it anywhere else means two files describing one display, and
@@ -238,8 +283,8 @@ Item {
     var commands = []
     for (var name in positions) {
       var transform = root.transformOf(name)
-      commands.push("hyprctl eval 'hl.monitor({ output = \"" + name + "\", mode = \"preferred\", position = \""
-        + positions[name] + "\", scale = " + root.scaleOf(name)
+      commands.push("hyprctl eval 'hl.monitor({ output = \"" + name + "\", mode = \"" + root.modeOf(name)
+        + "\", position = \"" + positions[name] + "\", scale = " + root.scaleOf(name)
         + (transform !== 0 ? ", transform = " + transform : "") + " })'")
       // A layout that could not be saved has to say so. The alternative is the
       // arrangement holding until the next reload and then reverting, with

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -328,9 +328,24 @@ Item {
       + " && sleep 0.4"
       + " && hyprctl dispatch \"hl.dsp.focus({ workspace = \\\"$workspace\\\" })\""
 
+    runScript(script)
+    return true
+  }
+
+  // Every write goes through one process, so a second asked for while the first
+  // is still running has to wait its turn. Assigning `command` and `running` to
+  // a Process that is already running starts nothing, so the second write would
+  // simply be dropped: press Escape during the apply's own settle and the
+  // revert never runs, while `closeWhenApplied` still takes the prompt away and
+  // leaves the layout applied. Queue it and run it when the first exits.
+  function runScript(script) {
+    if (applyProc.running) {
+      queuedScript = script
+      return
+    }
+
     applyProc.command = ["bash", "-c", script]
     applyProc.running = true
-    return true
   }
 
   function apply() {
@@ -437,11 +452,26 @@ Item {
   // until the revert it triggered has finished writing.
   property var pendingMirror: null
 
+  // A write asked for while another was still running.
+  property string queuedScript: ""
+
   Process {
     id: applyProc
     stdout: StdioCollector { waitForEnd: true }
     onRunningChanged: {
-      if (running || !root.closeWhenApplied) return
+      if (running) return
+
+      // Whatever was waiting on this process goes first, and everything that
+      // waits on the writing being finished waits for that too.
+      if (root.queuedScript !== "") {
+        var next = root.queuedScript
+        root.queuedScript = ""
+        applyProc.command = ["bash", "-c", next]
+        applyProc.running = true
+        return
+      }
+
+      if (!root.closeWhenApplied) return
       root.closeWhenApplied = false
 
       // Read before closing: closing clears the state this was waiting on.

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -315,16 +315,25 @@ Item {
     var commands = []
     for (var name in positions) {
       var transform = root.transformOf(name)
-      commands.push("hyprctl eval 'hl.monitor({ output = \"" + name + "\", mode = \"" + root.modeOf(name)
-        + "\", position = \"" + positions[name] + "\", scale = " + root.scaleOf(name)
-        + (transform !== 0 ? ", transform = " + transform : "") + " })'")
       // A layout that could not be saved has to say so. The alternative is the
       // arrangement holding until the next reload and then reverting, with
       // nothing having reported a problem.
-      commands.push("omarchy-hyprland-monitor-rule " + name
+      //
+      // The fallback is grouped, and the group hangs off the move rather than
+      // sitting beside it. Bash gives && and || the same precedence and reads
+      // left to right, so an ungrouped `move && save || warn` sends a failed
+      // move to the warning about saving, and then carries on to the next
+      // display with the whole run still reporting success. Only a failed save
+      // is recovered here; a failed move ends the run and says so through the
+      // exit status.
+      commands.push("hyprctl eval 'hl.monitor({ output = \"" + name + "\", mode = \"" + root.modeOf(name)
+        + "\", position = \"" + positions[name] + "\", scale = " + root.scaleOf(name)
+        + (transform !== 0 ? ", transform = " + transform : "") + " })'"
+        + " && { omarchy-hyprland-monitor-rule " + name
         + " || omarchy-notification-send -g \"" + Model.displayGlyph + "\" "
         + "\"Couldn't save " + name + " to monitors.lua\" "
-        + "\"Its rule there could not be identified, so the change lasts until the next reload\"")
+        + "\"Its rule there could not be identified, so the change lasts until the next reload\""
+        + "; }")
     }
     if (commands.length === 0) return false
 
@@ -475,9 +484,7 @@ Item {
   Process {
     id: applyProc
     stdout: StdioCollector { waitForEnd: true }
-    onRunningChanged: {
-      if (running) return
-
+    onExited: function(exitCode) {
       // Whatever was waiting on this process goes first, and everything that
       // waits on the writing being finished waits for that too.
       if (root.queuedScript !== "") {
@@ -490,6 +497,18 @@ Item {
 
       if (!root.closeWhenApplied) return
       root.closeWhenApplied = false
+
+      // Only step out once the layout is actually back. A revert that failed
+      // part way leaves the arrangement it was undoing on screen, and closing
+      // on it would be the same as never having reverted: the prompt would be
+      // gone with the change still applied. Stay up and say so instead.
+      if (exitCode !== 0) {
+        root.pendingMirror = null
+        Quickshell.execDetached(["omarchy-notification-send", "-g", Model.displayGlyph,
+          "Couldn't put the previous layout back",
+          "The displays are still arranged as they were just applied"])
+        return
+      }
 
       // Read before closing: closing clears the state this was waiting on.
       var wanted = root.pendingMirror

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -60,6 +60,25 @@ Item {
   // invisible overlay that swallows input until Escape. Close first, so the
   // outputs change with nothing anchored to them.
   function setMirror(enabled) {
+    // A layout waiting to be confirmed has to be put back before the outputs
+    // are reconfigured under it. Both the revert and the mirror write rules for
+    // the same displays, so starting them together would leave the geometry
+    // that ends up in the user's config to whichever finished last. Hold the
+    // mode switch until the revert has landed.
+    //
+    // A revert already on its way counts too: it clears the prompt as it starts
+    // but keeps writing for a moment afterwards, and a second press landing in
+    // that gap would race it just the same.
+    if (awaitingConfirmation || closeWhenApplied) {
+      pendingMirror = enabled
+      if (awaitingConfirmation) revertLayout()
+      return
+    }
+
+    applyMirror(enabled)
+  }
+
+  function applyMirror(enabled) {
     mirrorProc.command = ["omarchy-hyprland-monitor-internal-mirror", enabled ? "on" : "off"]
     if (!mirrorProc.running) mirrorProc.running = true
     close()
@@ -105,6 +124,7 @@ Item {
   function dismiss() {
     opened = false
     closeWhenApplied = false
+    pendingMirror = null
     reopen.stop()
     revertTimer.stop()
     countdown.stop()
@@ -413,13 +433,23 @@ Item {
 
   property bool closeWhenApplied: false
 
+  // A mode switch asked for while a layout was waiting to be confirmed, held
+  // until the revert it triggered has finished writing.
+  property var pendingMirror: null
+
   Process {
     id: applyProc
     stdout: StdioCollector { waitForEnd: true }
     onRunningChanged: {
       if (running || !root.closeWhenApplied) return
       root.closeWhenApplied = false
+
+      // Read before closing: closing clears the state this was waiting on.
+      var wanted = root.pendingMirror
+      root.pendingMirror = null
+
       root.close()
+      if (wanted !== null) root.applyMirror(wanted)
     }
   }
 

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -1,0 +1,643 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Quickshell.Wayland
+import qs.Ui
+import qs.Commons
+import "Model.js" as Model
+
+// Drag displays into position. Everything is drawn in logical pixels, which is
+// the space Hyprland positions displays in and the space the pointer crosses
+// between them — drawing mode sizes would show rectangles whose proportions
+// have nothing to do with how the desktop behaves.
+//
+// Applying a layout can strand the pointer or leave a display dark, and the
+// user cannot always click "undo" afterwards, so a change reverts itself
+// unless it is confirmed.
+Item {
+  id: root
+
+  property var shell: null
+  property bool opened: false
+
+  // The layout being edited, and the one to go back to.
+  property var rects: []
+  property var originalRects: []
+  property var displays: []
+  property string selectedName: ""
+
+  // Rotation is edited alongside position, since turning a display changes the
+  // edges it presents and therefore the layout around it. Keyed by display name.
+  property var transforms: ({})
+  property var originalTransforms: ({})
+
+  // Set while a layout is applied but not yet confirmed.
+  property bool awaitingConfirmation: false
+  property int secondsLeft: 0
+
+  // Mirroring belongs here rather than in the panel: it is the other answer to
+  // how displays relate in space, and it collapses the arrangement to a single
+  // display, which is exactly what this canvas draws.
+  property string mirroringMonitor: ""
+  property string internalMonitor: ""
+  property string externalMonitor: ""
+  readonly property bool mirrorEnabled: mirroringMonitor !== ""
+  readonly property bool mirrorAvailable: internalMonitor !== "" && externalMonitor !== ""
+
+  // Switching mode adds or removes an output, and this overlay is anchored to
+  // one: mirroring withdraws the mirrored display from Wayland, which leaves
+  // the window without a surface while it still holds keyboard focus — an
+  // invisible overlay that swallows input until Escape. Close first, so the
+  // outputs change with nothing anchored to them.
+  function setMirror(enabled) {
+    mirrorProc.command = ["omarchy-hyprland-monitor-internal-mirror", enabled ? "on" : "off"]
+    if (!mirrorProc.running) mirrorProc.running = true
+    close()
+  }
+
+  readonly property int snapThreshold: 60
+  readonly property int nudgeStep: 40
+
+  readonly property color scrim: Util.alpha(Color.background, 0.97)
+
+  function open(payloadJson) {
+    refresh()
+
+    // Drop any stale window first. A previous apply may have reconfigured the
+    // outputs and taken the surface with it, leaving this believing it is still
+    // open — in which case showing it again would do nothing at all.
+    opened = false
+    reopen.restart()
+  }
+
+  function close() {
+    opened = false
+    closeWhenApplied = false
+    reopen.stop()
+    revertTimer.stop()
+    countdown.stop()
+    awaitingConfirmation = false
+  }
+
+  function toggle() {
+    if (opened) close()
+    else open("")
+  }
+
+  function refresh() {
+    if (!stateProc.running) stateProc.running = true
+    if (!mirrorStateProc.running) mirrorStateProc.running = true
+  }
+
+  function selectedRect() {
+    for (var i = 0; i < rects.length; i++) {
+      if (rects[i].name === selectedName) return rects[i]
+    }
+    return null
+  }
+
+  function replaceRect(next) {
+    var out = []
+    for (var i = 0; i < rects.length; i++) {
+      out.push(rects[i].name === next.name ? next : rects[i])
+    }
+    rects = out
+  }
+
+  // Move a display and pull it onto its neighbours' edges. Both the pointer
+  // and the keyboard go through here so they cannot disagree about what a
+  // valid position is.
+  function moveTo(name, x, y) {
+    var moving = null
+    var others = []
+    for (var i = 0; i < rects.length; i++) {
+      if (rects[i].name === name) moving = rects[i]
+      else others.push(rects[i])
+    }
+    if (!moving) return
+
+    // Snap onto a neighbour's edge, push clear of anything still overlapping,
+    // then pull the display against a neighbour if it ended up floating. A drop
+    // always lands somewhere the layout can actually be used: no overlap, and
+    // no gap for the pointer to fall into.
+    var moved = { name: name, x: Math.round(x), y: Math.round(y), width: moving.width, height: moving.height }
+    moved = Model.pushOut(Model.snap(moved, others, root.snapThreshold), others)
+    replaceRect(Model.pushOut(Model.attach(moved, others), others))
+  }
+
+  function nudge(dx, dy) {
+    var rect = selectedRect()
+    if (!rect) return
+    moveTo(rect.name, rect.x + dx * root.nudgeStep, rect.y + dy * root.nudgeStep)
+  }
+
+  function selectNext(delta) {
+    if (rects.length === 0) return
+    var index = 0
+    for (var i = 0; i < rects.length; i++) {
+      if (rects[i].name === selectedName) index = i
+    }
+    index = (index + delta + rects.length) % rects.length
+    selectedName = rects[index].name
+  }
+
+  readonly property var normalizedRects: Model.normalized(rects)
+  readonly property bool layoutOverlaps: Model.anyOverlap(rects)
+  readonly property bool layoutContiguous: Model.isContiguous(rects)
+  readonly property bool layoutValid: !layoutOverlaps && layoutContiguous
+  readonly property var pendingChanges: Model.changedPositions(Model.normalized(originalRects), normalizedRects)
+  readonly property bool rotationChanged: {
+    for (var i = 0; i < displays.length; i++) {
+      var name = displays[i].name
+      if (transforms.hasOwnProperty(name) && transforms[name] !== (Number(displays[i].transform) || 0)) return true
+    }
+    return false
+  }
+  readonly property bool hasChanges: Object.keys(pendingWrites).length > 0
+
+  // Everything that needs writing: displays that moved, plus displays that
+  // turned. A rotation changes no position, so it would otherwise be invisible
+  // to a position diff.
+  readonly property var pendingWrites: {
+    var writes = {}
+    var changed = pendingChanges
+    for (var name in changed) writes[name] = changed[name]
+
+    var current = Model.positionsOf(normalizedRects)
+    for (var i = 0; i < displays.length; i++) {
+      var display = displays[i]
+      if (transforms.hasOwnProperty(display.name) &&
+          transforms[display.name] !== (Number(display.transform) || 0) &&
+          current.hasOwnProperty(display.name)) {
+        writes[display.name] = current[display.name]
+      }
+    }
+    return writes
+  }
+
+  function transformOf(name) {
+    if (transforms.hasOwnProperty(name)) return transforms[name]
+    for (var i = 0; i < displays.length; i++) {
+      if (displays[i].name === name) return Number(displays[i].transform) || 0
+    }
+    return 0
+  }
+
+  // Turning a display re-measures it, then settles the layout around the new
+  // shape the same way a drag does.
+  function rotateSelected() {
+    var rect = selectedRect()
+    if (!rect) return
+
+    var from = transformOf(rect.name)
+    var to = Model.nextTransform(from)
+
+    var others = []
+    for (var i = 0; i < rects.length; i++) {
+      if (rects[i].name !== rect.name) others.push(rects[i])
+    }
+
+    var next = Object.assign({}, transforms)
+    next[rect.name] = to
+    transforms = next
+
+    var turned = Model.rotated(rect, from, to)
+    replaceRect(Model.pushOut(Model.attach(Model.pushOut(turned, others), others), others))
+  }
+
+  function scaleOf(name) {
+    for (var i = 0; i < displays.length; i++) {
+      if (displays[i].name === name) return displays[i].scale
+    }
+    return 1
+  }
+
+  // Geometry is applied first and then recorded in the user's own monitors.lua,
+  // which is where they already write it and where they will edit it next.
+  // Keeping it anywhere else means two files describing one display, and
+  // whichever Hyprland loads last silently wins.
+  function writeLayout(positions) {
+    var commands = []
+    for (var name in positions) {
+      var transform = root.transformOf(name)
+      commands.push("hyprctl eval 'hl.monitor({ output = \"" + name + "\", mode = \"preferred\", position = \""
+        + positions[name] + "\", scale = " + root.scaleOf(name)
+        + (transform !== 0 ? ", transform = " + transform : "") + " })'")
+      // A layout that could not be saved has to say so. The alternative is the
+      // arrangement holding until the next reload and then reverting, with
+      // nothing having reported a problem.
+      commands.push("omarchy-hyprland-monitor-rule " + name
+        + " || omarchy-notification-send -g \"" + Model.displayGlyph + "\" "
+        + "\"Couldn't save " + name + " to monitors.lua\" "
+        + "\"Its rule there could not be identified, so the change lasts until the next reload\"")
+    }
+    if (commands.length === 0) return false
+
+    // No reload: the rules above are applied directly and then recorded in the
+    // user's config for next time, so there is nothing to re-read. That also
+    // spares every display a modeset, which is what used to park the pointer in
+    // a corner and leave windows sized for geometry on its way out.
+    //
+    // Windows still keep their dimensions until something makes the workspace
+    // lay out again, so re-select it afterwards.
+    var script = "workspace=\"$(hyprctl activeworkspace -j | jq -r .id)\"; "
+      + commands.join(" && ")
+      + " && sleep 0.4"
+      + " && hyprctl dispatch \"hl.dsp.focus({ workspace = \\\"$workspace\\\" })\""
+
+    applyProc.command = ["bash", "-c", script]
+    applyProc.running = true
+    return true
+  }
+
+  function apply() {
+    if (!hasChanges || !layoutValid) return
+    if (!writeLayout(pendingWrites)) return
+
+    awaitingConfirmation = true
+    secondsLeft = 15
+    countdown.restart()
+    revertTimer.restart()
+
+    // The write above reloads Hyprland and re-modesets every display, which
+    // destroys this overlay's surface underneath it. Stand the window back up
+    // once the new geometry has settled, so the confirm-or-revert prompt is
+    // still there to answer.
+    opened = false
+    reopen.restart()
+  }
+
+  function confirmLayout() {
+    awaitingConfirmation = false
+    revertTimer.stop()
+    countdown.stop()
+    originalRects = rects
+    close()
+  }
+
+  function revertLayout() {
+    awaitingConfirmation = false
+    revertTimer.stop()
+    countdown.stop()
+
+    transforms = originalTransforms
+    rects = originalRects
+
+    var previous = Model.positionsOf(Model.normalized(originalRects))
+    writeLayout(previous)
+
+    // Step out once the layout is actually back, not before. Tearing this
+    // overlay's surface down while Hyprland is still re-modesetting leaves
+    // windows sized for the geometry that is on its way out — the same
+    // sequence run from a shell, with no surface to destroy, comes out clean.
+    closeWhenApplied = true
+  }
+
+  Timer {
+    id: reopen
+    interval: 1500
+    repeat: false
+    onTriggered: {
+      root.refresh()
+      root.opened = true
+    }
+  }
+
+  Timer {
+    id: revertTimer
+    interval: 15000
+    repeat: false
+    onTriggered: root.revertLayout()
+  }
+
+  Timer {
+    id: countdown
+    interval: 1000
+    repeat: true
+    onTriggered: if (root.secondsLeft > 0) root.secondsLeft = root.secondsLeft - 1
+  }
+
+  Process {
+    id: stateProc
+    command: ["hyprctl", "monitors", "-j"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var parsed = []
+        try {
+          parsed = JSON.parse(String(text || "[]"))
+        } catch (e) {
+          parsed = []
+        }
+
+        root.displays = parsed
+        if (!root.awaitingConfirmation) {
+          root.transforms = ({})
+
+          var seen = ({})
+          for (var t = 0; t < parsed.length; t++) seen[parsed[t].name] = Number(parsed[t].transform) || 0
+          root.originalTransforms = seen
+        }
+        var next = Model.logicalRects(parsed)
+        root.rects = next
+        if (!root.awaitingConfirmation) root.originalRects = next
+        if (!root.selectedRect() && next.length > 0) root.selectedName = next[0].name
+      }
+    }
+  }
+
+  property bool closeWhenApplied: false
+
+  Process {
+    id: applyProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running || !root.closeWhenApplied) return
+      root.closeWhenApplied = false
+      root.close()
+    }
+  }
+
+  // Mirroring reconfigures outputs, so the canvas has to re-read rather than
+  // assume: a mirrored display stops being an independent output entirely.
+  Process {
+    id: mirrorProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: if (!running) mirrorSettle.restart()
+  }
+
+  Timer {
+    id: mirrorSettle
+    interval: 1200
+    repeat: false
+    onTriggered: root.refresh()
+  }
+
+  Process {
+    id: mirrorStateProc
+    command: ["omarchy-monitor-state"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var lines = String(text || "").split("\n")
+        root.internalMonitor = String(lines[1] || "").trim()
+        root.externalMonitor = String(lines[2] || "").trim()
+        root.mirroringMonitor = String(lines[4] || "").trim()
+      }
+    }
+  }
+
+  PanelWindow {
+    id: window
+
+    visible: root.opened
+    anchors { top: true; bottom: true; left: true; right: true }
+    color: "transparent"
+    WlrLayershell.namespace: "omarchy-display-arrange"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: root.opened ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+    exclusionMode: ExclusionMode.Ignore
+
+    Rectangle {
+      anchors.fill: parent
+      color: root.scrim
+    }
+
+    // Clicking away from the displays cancels, matching the image picker.
+    MouseArea {
+      anchors.fill: parent
+      onClicked: root.close()
+    }
+
+    FocusScope {
+      id: keys
+      anchors.fill: parent
+      focus: root.opened
+
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape) {
+          if (root.awaitingConfirmation) root.revertLayout()
+          else root.close()
+          event.accepted = true
+          return
+        }
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+          if (root.awaitingConfirmation) root.confirmLayout()
+          else root.apply()
+          event.accepted = true
+          return
+        }
+        if (event.text === "r" || event.text === "R") {
+          root.rotateSelected()
+          event.accepted = true
+          return
+        }
+        if (event.key === Qt.Key_Tab) {
+          root.selectNext(1)
+          event.accepted = true
+          return
+        }
+        if (event.key === Qt.Key_Left || event.text === "h") { root.nudge(-1, 0); event.accepted = true; return }
+        if (event.key === Qt.Key_Right || event.text === "l") { root.nudge(1, 0); event.accepted = true; return }
+        if (event.key === Qt.Key_Up || event.text === "k") { root.nudge(0, -1); event.accepted = true; return }
+        if (event.key === Qt.Key_Down || event.text === "j") { root.nudge(0, 1); event.accepted = true; return }
+      }
+
+      Column {
+        anchors.centerIn: parent
+        spacing: Style.space(20)
+
+        Text {
+          text: "ARRANGE DISPLAYS"
+          color: Color.foreground
+          font.family: Style.font.family
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          font.letterSpacing: 1.2
+          anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Row {
+          spacing: Style.space(10)
+          visible: root.mirrorAvailable
+          anchors.horizontalCenter: parent.horizontalCenter
+
+          Button {
+            text: "Extend"
+            fontSize: Style.font.body
+            foreground: Color.foreground
+            fontFamily: Style.font.family
+            horizontalPadding: Style.spacing.lg
+            verticalPadding: Style.spacing.controlPaddingY
+            bordered: true
+            active: !root.mirrorEnabled
+            onClicked: root.setMirror(false)
+          }
+
+          Button {
+            text: "Mirror"
+            fontSize: Style.font.body
+            foreground: Color.foreground
+            fontFamily: Style.font.family
+            horizontalPadding: Style.spacing.lg
+            verticalPadding: Style.spacing.controlPaddingY
+            bordered: true
+            active: root.mirrorEnabled
+            onClicked: root.setMirror(true)
+          }
+        }
+
+        // The canvas. Rectangles are the displays at their logical
+        // proportions, scaled together so their relative sizes stay honest.
+        Item {
+          id: canvas
+          width: Math.min(window.width - Style.space(160), Style.space(900))
+          height: Math.min(window.height - Style.space(260), Style.space(520))
+          anchors.horizontalCenter: parent.horizontalCenter
+
+          readonly property int pad: Style.space(40)
+          readonly property real fit: Model.fitScale(root.rects, width, height, pad)
+          readonly property var box: Model.bounds(root.rects)
+          readonly property real offsetX: (width - box.width * fit) / 2 - box.x * fit
+          readonly property real offsetY: (height - box.height * fit) / 2 - box.y * fit
+
+          function toCanvasX(x) { return offsetX + x * fit }
+          function toCanvasY(y) { return offsetY + y * fit }
+          function toLayoutX(x) { return (x - offsetX) / fit }
+          function toLayoutY(y) { return (y - offsetY) / fit }
+
+          Repeater {
+            model: root.rects
+
+            Rectangle {
+              id: tile
+              required property var modelData
+
+              readonly property bool isSelected: modelData.name === root.selectedName
+
+              x: canvas.toCanvasX(modelData.x)
+              y: canvas.toCanvasY(modelData.y)
+              width: modelData.width * canvas.fit
+              height: modelData.height * canvas.fit
+
+              radius: Style.cornerRadius
+              color: isSelected
+                ? Util.alpha(Color.accent, 0.28)
+                : Util.alpha(Color.foreground, 0.10)
+              border.width: isSelected ? 2 : 1
+              border.color: isSelected ? Color.accent : Qt.darker(Color.foreground, 1.5)
+
+              Column {
+                anchors.centerIn: parent
+                spacing: Style.space(4)
+
+                Text {
+                  text: tile.modelData.name
+                  color: Color.foreground
+                  font.family: Style.font.family
+                  font.pixelSize: Style.font.body
+                  font.bold: true
+                  anchors.horizontalCenter: parent.horizontalCenter
+                }
+
+                Text {
+                  text: tile.modelData.width + " x " + tile.modelData.height
+                    + (root.transformOf(tile.modelData.name) !== 0
+                       ? "  ·  " + Model.transformLabel(root.transformOf(tile.modelData.name)) : "")
+                  color: Qt.darker(Color.foreground, 1.4)
+                  font.family: Style.font.family
+                  font.pixelSize: Style.font.caption
+                  anchors.horizontalCenter: parent.horizontalCenter
+                }
+              }
+
+              // Qt moves the tile during the gesture and the layout is only
+              // written on release. Updating the model per mouse move rebuilds
+              // the Repeater's delegates underneath the pointer, which destroys
+              // the item being dragged mid-gesture.
+              MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.SizeAllCursor
+                enabled: !root.awaitingConfirmation
+                drag.target: tile
+                drag.axis: Drag.XAndYAxis
+                drag.smoothed: false
+
+                onPressed: root.selectedName = tile.modelData.name
+
+                onReleased: {
+                  root.moveTo(tile.modelData.name, canvas.toLayoutX(tile.x), canvas.toLayoutY(tile.y))
+
+                  // Dragging assigned x and y directly, which broke their
+                  // bindings; restore them so the tile follows the model again
+                  // once snapping has adjusted it.
+                  tile.x = Qt.binding(function() { return canvas.toCanvasX(tile.modelData.x) })
+                  tile.y = Qt.binding(function() { return canvas.toCanvasY(tile.modelData.y) })
+                }
+              }
+            }
+          }
+        }
+
+        // Why the layout cannot be applied, rather than a disabled button with
+        // no explanation.
+        Text {
+          text: {
+              if (root.awaitingConfirmation) return "KEEP THIS LAYOUT?  " + root.secondsLeft + "s"
+            if (root.mirrorEnabled) return "MIRRORING — SWITCH TO EXTEND TO ARRANGE DISPLAYS"
+            if (root.layoutOverlaps) return "DISPLAYS OVERLAP"
+            if (!root.layoutContiguous) return "DISPLAYS MUST TOUCH — A GAP IS A DEAD ZONE FOR THE POINTER"
+            if (!root.hasChanges) return "DRAG A DISPLAY  ·  H J K L TO NUDGE  ·  R TO ROTATE"
+            return "ENTER TO APPLY  ·  ESC TO CANCEL"
+          }
+          color: root.layoutValid || root.awaitingConfirmation ? Qt.darker(Color.foreground, 1.4) : Color.accent
+          font.family: Style.font.family
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          font.letterSpacing: 1.1
+          anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Row {
+          spacing: Style.space(10)
+          anchors.horizontalCenter: parent.horizontalCenter
+
+          Button {
+            text: "Rotate " + Model.transformLabel(Model.nextTransform(root.transformOf(root.selectedName)))
+            visible: !root.awaitingConfirmation && root.selectedName !== ""
+            fontSize: Style.font.body
+            foreground: Color.foreground
+            fontFamily: Style.font.family
+            horizontalPadding: Style.spacing.lg
+            verticalPadding: Style.spacing.controlPaddingY
+            bordered: true
+            onClicked: root.rotateSelected()
+          }
+
+          Button {
+            text: root.awaitingConfirmation ? "Keep" : "Apply"
+            foreground: Color.foreground
+            fontFamily: Style.font.family
+            fontSize: Style.font.body
+            horizontalPadding: Style.spacing.lg
+            verticalPadding: Style.spacing.controlPaddingY
+            bordered: true
+            active: root.awaitingConfirmation
+            onClicked: root.awaitingConfirmation ? root.confirmLayout() : root.apply()
+          }
+
+          Button {
+            text: root.awaitingConfirmation ? "Revert" : "Cancel"
+            foreground: Color.foreground
+            fontFamily: Style.font.family
+            fontSize: Style.font.body
+            horizontalPadding: Style.spacing.lg
+            verticalPadding: Style.spacing.controlPaddingY
+            bordered: true
+            onClicked: root.awaitingConfirmation ? root.revertLayout() : root.close()
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -54,6 +54,15 @@ Item {
   // regardless, or Extend becomes unreachable from the only place offering it.
   readonly property bool mirrorAvailable: mirrorEnabled || (internalActive && externalActive)
 
+  // Mirroring collapses every display onto one region, so there is no
+  // arrangement left to edit and the canvas draws the source alone. Writing a
+  // position for it would move it out from under the mirror rule, which pins
+  // the mirror to where the source was: the two would then cover different
+  // regions while still reporting as mirroring, which is the split this branch
+  // already had to fix once. Rotating is enough to reach it, since the lone
+  // display normalises to 0x0 whatever it was at.
+  readonly property bool editable: !mirrorEnabled
+
   // Switching mode adds or removes an output, and this overlay is anchored to
   // one: mirroring withdraws the mirrored display from Wayland, which leaves
   // the window without a surface while it still holds keyboard focus — an
@@ -89,7 +98,6 @@ Item {
 
   readonly property color scrim: Util.alpha(Color.background, 0.97)
 
-  // Long enough for Hyprland to finish re-modesetting every display after a
   function scheduleReopen(delay) {
     reopen.interval = delay
     reopen.restart()
@@ -178,6 +186,8 @@ Item {
   }
 
   function nudge(dx, dy) {
+    if (!editable) return
+
     var rect = selectedRect()
     if (!rect) return
     moveTo(rect.name, rect.x + dx * root.nudgeStep, rect.y + dy * root.nudgeStep)
@@ -251,6 +261,8 @@ Item {
   // Turning a display re-measures it, then settles the layout around the new
   // shape the same way a drag does.
   function rotateSelected() {
+    if (!editable) return
+
     var rect = selectedRect()
     if (!rect) return
 
@@ -349,7 +361,7 @@ Item {
   }
 
   function apply() {
-    if (!hasChanges || !layoutValid) return
+    if (!editable || !hasChanges || !layoutValid) return
     if (!writeLayout(pendingWrites)) return
 
     awaitingConfirmation = true
@@ -686,7 +698,7 @@ Item {
               MouseArea {
                 anchors.fill: parent
                 cursorShape: Qt.SizeAllCursor
-                enabled: !root.awaitingConfirmation
+                enabled: !root.awaitingConfirmation && root.editable
                 drag.target: tile
                 drag.axis: Drag.XAndYAxis
                 drag.smoothed: false
@@ -736,7 +748,7 @@ Item {
 
           Button {
             text: "Rotate " + Model.transformLabel(Model.nextTransform(root.transformOf(root.selectedName)))
-            visible: !root.awaitingConfirmation && root.selectedName !== ""
+            visible: root.editable && !root.awaitingConfirmation && root.selectedName !== ""
             fontSize: Style.font.body
             foreground: Color.foreground
             fontFamily: Style.font.family
@@ -748,6 +760,7 @@ Item {
 
           Button {
             text: root.awaitingConfirmation ? "Keep" : "Apply"
+            visible: root.editable || root.awaitingConfirmation
             foreground: Color.foreground
             fontFamily: Style.font.family
             fontSize: Style.font.body

--- a/shell/plugins/display-arrange/DisplayArrange.qml
+++ b/shell/plugins/display-arrange/DisplayArrange.qml
@@ -71,10 +71,6 @@ Item {
   readonly property color scrim: Util.alpha(Color.background, 0.97)
 
   // Long enough for Hyprland to finish re-modesetting every display after a
-  // layout is written. Only the paths that reconfigure outputs need to wait it
-  // out; an ordinary open has nothing settling and must not pay for it.
-  readonly property int settleDelay: 1500
-
   function scheduleReopen(delay) {
     reopen.interval = delay
     reopen.restart()
@@ -87,8 +83,7 @@ Item {
     // outputs and taken the surface with it, leaving this believing it is still
     // open — in which case showing it again would do nothing at all. Dropping
     // it only needs to land before the window is stood back up, so this hands
-    // the change to the next event loop turn rather than waiting on a modeset
-    // that is not happening.
+    // the change to the next event loop turn.
     opened = false
     scheduleReopen(0)
   }
@@ -96,6 +91,9 @@ Item {
   function close() {
     opened = false
     closeWhenApplied = false
+    // An apply still in flight must not raise the window again behind a user
+    // who has just dismissed it.
+    reopenWhenApplied = false
     reopen.stop()
     revertTimer.stop()
     countdown.stop()
@@ -282,12 +280,15 @@ Item {
     countdown.restart()
     revertTimer.restart()
 
-    // The write above reloads Hyprland and re-modesets every display, which
-    // destroys this overlay's surface underneath it. Stand the window back up
-    // once the new geometry has settled, so the confirm-or-revert prompt is
-    // still there to answer.
-    opened = false
-    scheduleReopen(settleDelay)
+    // Applying does not reload Hyprland: writeLayout sets each rule directly,
+    // precisely so no display takes a modeset. So there is nothing for the
+    // overlay to sit out — it stays up while the geometry moves under it.
+    //
+    // It is still stood back up once the work finishes, because a compositor
+    // that does take the surface leaves this believing it is still open, and
+    // the confirm-or-revert prompt has to be there to answer. Waiting on the
+    // apply itself rather than on a fixed delay keeps that to a blink.
+    reopenWhenApplied = true
   }
 
   function confirmLayout() {
@@ -321,7 +322,7 @@ Item {
   // holding.
   Timer {
     id: reopen
-    interval: root.settleDelay
+    interval: 0
     repeat: false
     onTriggered: {
       root.refresh()
@@ -373,14 +374,29 @@ Item {
   }
 
   property bool closeWhenApplied: false
+  property bool reopenWhenApplied: false
 
   Process {
     id: applyProc
     stdout: StdioCollector { waitForEnd: true }
     onRunningChanged: {
-      if (running || !root.closeWhenApplied) return
-      root.closeWhenApplied = false
-      root.close()
+      if (running) return
+
+      if (root.closeWhenApplied) {
+        root.closeWhenApplied = false
+        root.reopenWhenApplied = false
+        root.close()
+        return
+      }
+
+      if (root.reopenWhenApplied) {
+        root.reopenWhenApplied = false
+        // Only a false-to-true turn builds a new surface, so a window that is
+        // still up is dropped and immediately raised again rather than left to
+        // an assumption about whether the compositor kept it.
+        root.opened = false
+        root.scheduleReopen(0)
+      }
     }
   }
 

--- a/shell/plugins/display-arrange/Model.js
+++ b/shell/plugins/display-arrange/Model.js
@@ -6,6 +6,23 @@
 // show two rectangles whose relative sizes have nothing to do with how the
 // desktop behaves.
 
+// The built-in panel, by the connector names Hyprland gives it.
+function isInternalName(name) {
+  return /^(eDP|LVDS|DSI)-/.test(String(name || ""))
+}
+
+// Whether the live displays include a built-in panel, or an external one. Fed
+// the active listing rather than `monitors all`, so a display the user switched
+// off does not count as one that mirroring can act on.
+function hasActiveDisplay(displays, internal) {
+  if (!Array.isArray(displays)) return false
+
+  for (var i = 0; i < displays.length; i++) {
+    if (isInternalName(displays[i] && displays[i].name) === internal) return true
+  }
+  return false
+}
+
 // Transforms 1, 3, 5 and 7 are the 90 and 270 degree rotations, which swap the
 // display's width and height.
 function isRotated(transform) {
@@ -362,6 +379,8 @@ var displayGlyph = "\uf0379"
 if (typeof module !== "undefined") {
   module.exports = {
     displayGlyph: displayGlyph,
+    isInternalName: isInternalName,
+    hasActiveDisplay: hasActiveDisplay,
     isRotated: isRotated,
     logicalRect: logicalRect,
     logicalRects: logicalRects,

--- a/shell/plugins/display-arrange/Model.js
+++ b/shell/plugins/display-arrange/Model.js
@@ -1,0 +1,385 @@
+// Geometry for the display arrangement canvas.
+//
+// Everything here works in Hyprland's logical pixels — mode size divided by
+// scale — because that is the space positions are expressed in and the space
+// the pointer actually crosses between displays. Drawing raw mode sizes would
+// show two rectangles whose relative sizes have nothing to do with how the
+// desktop behaves.
+
+// Transforms 1, 3, 5 and 7 are the 90 and 270 degree rotations, which swap the
+// display's width and height.
+function isRotated(transform) {
+  var t = Number(transform)
+  return t === 1 || t === 3 || t === 5 || t === 7
+}
+
+// A display as it occupies the layout: logical size at its logical position.
+function logicalRect(display) {
+  if (!display) return null
+
+  var scale = Number(display.scale)
+  if (!isFinite(scale) || scale <= 0) scale = 1
+
+  var width = Number(display.width) / scale
+  var height = Number(display.height) / scale
+  if (!isFinite(width) || !isFinite(height)) return null
+
+  if (isRotated(display.transform)) {
+    var swap = width
+    width = height
+    height = swap
+  }
+
+  return {
+    name: String(display.name || ""),
+    x: Math.round(Number(display.x) || 0),
+    y: Math.round(Number(display.y) || 0),
+    width: Math.round(width),
+    height: Math.round(height)
+  }
+}
+
+function logicalRects(displays) {
+  var rects = []
+  if (!Array.isArray(displays)) return rects
+
+  for (var i = 0; i < displays.length; i++) {
+    var rect = logicalRect(displays[i])
+    if (rect && rect.width > 0 && rect.height > 0) rects.push(rect)
+  }
+  return rects
+}
+
+function bounds(rects) {
+  if (!Array.isArray(rects) || rects.length === 0) return { x: 0, y: 0, width: 0, height: 0 }
+
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (var i = 0; i < rects.length; i++) {
+    var r = rects[i]
+    if (r.x < minX) minX = r.x
+    if (r.y < minY) minY = r.y
+    if (r.x + r.width > maxX) maxX = r.x + r.width
+    if (r.y + r.height > maxY) maxY = r.y + r.height
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}
+
+// Scale factor that fits the whole layout inside the canvas with room to
+// spare, so a display dragged past the edge still has somewhere to go.
+function fitScale(rects, canvasWidth, canvasHeight, padding) {
+  var box = bounds(rects)
+  var pad = Number(padding) || 0
+  var availableWidth = Number(canvasWidth) - pad * 2
+  var availableHeight = Number(canvasHeight) - pad * 2
+
+  if (box.width <= 0 || box.height <= 0 || availableWidth <= 0 || availableHeight <= 0) return 1
+
+  return Math.min(availableWidth / box.width, availableHeight / box.height)
+}
+
+function overlaps(a, b) {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+}
+
+function anyOverlap(rects) {
+  for (var i = 0; i < rects.length; i++) {
+    for (var j = i + 1; j < rects.length; j++) {
+      if (overlaps(rects[i], rects[j])) return true
+    }
+  }
+  return false
+}
+
+// Gaps between displays are dead zones the pointer cannot cross, so a layout
+// wants every display touching at least one other. A single display is
+// trivially connected.
+function isContiguous(rects) {
+  if (!Array.isArray(rects) || rects.length < 2) return true
+
+  var seen = {}
+  var queue = [rects[0]]
+  seen[rects[0].name] = true
+
+  while (queue.length > 0) {
+    var current = queue.shift()
+    for (var i = 0; i < rects.length; i++) {
+      var other = rects[i]
+      if (seen[other.name]) continue
+      if (touches(current, other)) {
+        seen[other.name] = true
+        queue.push(other)
+      }
+    }
+  }
+
+  for (var j = 0; j < rects.length; j++) {
+    if (!seen[rects[j].name]) return false
+  }
+  return true
+}
+
+// Sharing an edge, not merely a corner: two displays meeting at a point leave
+// no width for the pointer to cross through.
+function touches(a, b) {
+  var horizontallyAdjacent = (a.x + a.width === b.x || b.x + b.width === a.x) &&
+    a.y < b.y + b.height && a.y + a.height > b.y
+  var verticallyAdjacent = (a.y + a.height === b.y || b.y + b.height === a.y) &&
+    a.x < b.x + b.width && a.x + a.width > b.x
+
+  return horizontallyAdjacent || verticallyAdjacent
+}
+
+// Pull a dragged display onto its neighbours' edges. Snapping is what makes a
+// layout usable rather than a nicety: a few logical pixels of gap is a strip
+// the pointer cannot cross, and a few pixels of overlap puts part of one
+// display underneath another.
+function snap(moving, others, threshold) {
+  var limit = Number(threshold)
+  if (!isFinite(limit) || limit <= 0) limit = 0
+
+  var x = moving.x
+  var y = moving.y
+  var bestX = limit + 1
+  var bestY = limit + 1
+
+  for (var i = 0; i < others.length; i++) {
+    var other = others[i]
+    if (other.name === moving.name) continue
+
+    // Edge-to-edge in x: right against left, left against right, plus the two
+    // flush alignments.
+    var xCandidates = [
+      other.x + other.width,
+      other.x - moving.width,
+      other.x,
+      other.x + other.width - moving.width
+    ]
+    for (var xi = 0; xi < xCandidates.length; xi++) {
+      var dx = Math.abs(xCandidates[xi] - moving.x)
+      if (dx <= limit && dx < bestX) {
+        bestX = dx
+        x = xCandidates[xi]
+      }
+    }
+
+    var yCandidates = [
+      other.y + other.height,
+      other.y - moving.height,
+      other.y,
+      other.y + other.height - moving.height
+    ]
+    for (var yi = 0; yi < yCandidates.length; yi++) {
+      var dy = Math.abs(yCandidates[yi] - moving.y)
+      if (dy <= limit && dy < bestY) {
+        bestY = dy
+        y = yCandidates[yi]
+      }
+    }
+  }
+
+  return { name: moving.name, x: Math.round(x), y: Math.round(y), width: moving.width, height: moving.height }
+}
+
+// Push a display clear of anything it lands on, by the shortest move that
+// frees it. Overlapping displays put part of one desktop underneath another,
+// and a layout that cannot express the mistake is better than one that reports
+// it: the user drops a display roughly where they want it and it settles
+// somewhere valid rather than refusing to apply.
+function pushOut(moving, others) {
+  var current = { name: moving.name, x: moving.x, y: moving.y, width: moving.width, height: moving.height }
+
+  // Each resolved collision can create another, so settle repeatedly. The
+  // bound is a guard against a pathological layout, not an expected path.
+  for (var pass = 0; pass < 8; pass++) {
+    var hit = null
+    for (var i = 0; i < others.length; i++) {
+      if (others[i].name !== current.name && overlaps(current, others[i])) {
+        hit = others[i]
+        break
+      }
+    }
+    if (!hit) return current
+
+    var candidates = [
+      { x: hit.x - current.width, y: current.y },
+      { x: hit.x + hit.width, y: current.y },
+      { x: current.x, y: hit.y - current.height },
+      { x: current.x, y: hit.y + hit.height }
+    ]
+
+    var best = null
+    var bestDistance = Infinity
+    for (var c = 0; c < candidates.length; c++) {
+      var dx = candidates[c].x - current.x
+      var dy = candidates[c].y - current.y
+      var distance = Math.abs(dx) + Math.abs(dy)
+      if (distance < bestDistance) {
+        bestDistance = distance
+        best = candidates[c]
+      }
+    }
+
+    current = { name: current.name, x: best.x, y: best.y, width: current.width, height: current.height }
+  }
+
+  return current
+}
+
+// Rotating a display swaps the edges it presents to the layout, so the canvas
+// has to re-measure it rather than just relabel it.
+function rotated(rect, fromTransform, toTransform) {
+  var swap = isRotated(fromTransform) !== isRotated(toTransform)
+  return {
+    name: rect.name,
+    x: rect.x,
+    y: rect.y,
+    width: swap ? rect.height : rect.width,
+    height: swap ? rect.width : rect.height
+  }
+}
+
+// The four rotations Omarchy offers, as Hyprland transform values.
+var TRANSFORMS = [0, 1, 2, 3]
+
+function nextTransform(transform) {
+  var index = TRANSFORMS.indexOf(Number(transform) || 0)
+  if (index < 0) index = 0
+  return TRANSFORMS[(index + 1) % TRANSFORMS.length]
+}
+
+function transformLabel(transform) {
+  switch (Number(transform) || 0) {
+    case 1: return "90°"
+    case 2: return "180°"
+    case 3: return "270°"
+    default: return "0°"
+  }
+}
+
+function clamp(value, low, high) {
+  if (low > high) return low
+  return Math.min(Math.max(value, low), high)
+}
+
+function touchesAny(rect, others) {
+  for (var i = 0; i < others.length; i++) {
+    if (others[i].name !== rect.name && touches(rect, others[i])) return true
+  }
+  return false
+}
+
+// Pull a display that is floating free onto its nearest neighbour. A gap
+// between displays is not a layout choice: it is a strip of desktop the pointer
+// cannot cross, so nothing useful lives there. Displays always end up touching.
+//
+// The perpendicular axis is clamped so they share a real edge rather than
+// meeting at a corner, which would leave nothing to cross through either.
+function attach(moving, others) {
+  if (!Array.isArray(others) || others.length === 0) return moving
+  if (touchesAny(moving, others)) return moving
+
+  var best = null
+  var bestDistance = Infinity
+
+  for (var i = 0; i < others.length; i++) {
+    var other = others[i]
+    if (other.name === moving.name) continue
+
+    // Share at least half of the smaller display's edge, so the crossing is
+    // wide enough to find with a pointer.
+    var shareY = Math.min(moving.height, other.height) / 2
+    var shareX = Math.min(moving.width, other.width) / 2
+    var alignedY = clamp(moving.y, other.y - moving.height + shareY, other.y + other.height - shareY)
+    var alignedX = clamp(moving.x, other.x - moving.width + shareX, other.x + other.width - shareX)
+
+    var candidates = [
+      { x: other.x + other.width, y: alignedY },
+      { x: other.x - moving.width, y: alignedY },
+      { x: alignedX, y: other.y + other.height },
+      { x: alignedX, y: other.y - moving.height }
+    ]
+
+    for (var c = 0; c < candidates.length; c++) {
+      var distance = Math.abs(candidates[c].x - moving.x) + Math.abs(candidates[c].y - moving.y)
+      if (distance < bestDistance) {
+        bestDistance = distance
+        best = candidates[c]
+      }
+    }
+  }
+
+  if (!best) return moving
+  return {
+    name: moving.name,
+    x: Math.round(best.x),
+    y: Math.round(best.y),
+    width: moving.width,
+    height: moving.height
+  }
+}
+
+// Shift the whole layout so its top-left sits at the origin. Hyprland accepts
+// negative positions, but keeping them non-negative makes the numbers readable
+// and keeps repeated edits from drifting away from zero.
+function normalized(rects) {
+  var box = bounds(rects)
+  var out = []
+
+  for (var i = 0; i < rects.length; i++) {
+    out.push({
+      name: rects[i].name,
+      x: rects[i].x - box.x,
+      y: rects[i].y - box.y,
+      width: rects[i].width,
+      height: rects[i].height
+    })
+  }
+  return out
+}
+
+function positionsOf(rects) {
+  var out = {}
+  for (var i = 0; i < rects.length; i++) out[rects[i].name] = rects[i].x + "x" + rects[i].y
+  return out
+}
+
+// Only displays that actually moved need writing, so an arrangement that
+// nudges one display does not rewrite every rule.
+function changedPositions(before, after) {
+  var from = positionsOf(before)
+  var to = positionsOf(after)
+  var changed = {}
+
+  for (var name in to) {
+    if (from[name] !== to[name]) changed[name] = to[name]
+  }
+  return changed
+}
+
+// The display glyph the panel and notifications use.
+var displayGlyph = "\uf0379"
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    displayGlyph: displayGlyph,
+    isRotated: isRotated,
+    logicalRect: logicalRect,
+    logicalRects: logicalRects,
+    bounds: bounds,
+    fitScale: fitScale,
+    overlaps: overlaps,
+    anyOverlap: anyOverlap,
+    touches: touches,
+    isContiguous: isContiguous,
+    snap: snap,
+    pushOut: pushOut,
+    attach: attach,
+    rotated: rotated,
+    nextTransform: nextTransform,
+    transformLabel: transformLabel,
+    touchesAny: touchesAny,
+    normalized: normalized,
+    positionsOf: positionsOf,
+    changedPositions: changedPositions
+  }
+}

--- a/shell/plugins/display-arrange/Model.js
+++ b/shell/plugins/display-arrange/Model.js
@@ -373,8 +373,10 @@ function changedPositions(before, after) {
   return changed
 }
 
-// The display glyph the panel and notifications use.
-var displayGlyph = "\uf0379"
+// The display glyph the panel and notifications use. Written literally: it sits
+// outside the basic plane, and a "\u" escape takes exactly four hex digits, so
+// "\uf0379" is U+F037 followed by a stray "9" rather than this one character.
+var displayGlyph = "\udb80\udf79"
 
 if (typeof module !== "undefined") {
   module.exports = {

--- a/shell/plugins/display-arrange/manifest.json
+++ b/shell/plugins/display-arrange/manifest.json
@@ -8,6 +8,7 @@
   "kinds": [
     "overlay"
   ],
+  "keepLoaded": true,
   "entryPoints": {
     "overlay": "DisplayArrange.qml"
   }

--- a/shell/plugins/display-arrange/manifest.json
+++ b/shell/plugins/display-arrange/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.display-arrange",
+  "name": "Display arrangement",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Drag displays into position, with edge snapping and a revert timer",
+  "kinds": [
+    "overlay"
+  ],
+  "entryPoints": {
+    "overlay": "DisplayArrange.qml"
+  }
+}

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -229,6 +229,14 @@ Panel {
     function hide() { root.close() }
   }
 
+  // Arranging displays needs more room than a bar dropdown, and moving a display
+  // under the panel that is moving it would be its own problem, so it opens as a
+  // fullscreen overlay and this panel gets out of the way.
+  function openArrangement() {
+    root.close()
+    if (bar && bar.shell) bar.shell.summon("omarchy.display-arrange", "")
+  }
+
   function refresh() {
     if (!stateProc.running) stateProc.running = true
   }
@@ -470,7 +478,12 @@ Panel {
     anchors.fill: parent
     bar: root.bar
     text: Quickshell.screens.length > 1 ? "󰍺" : "󰍹"
-    onPressed: function(b) { root.toggle() }
+    // Right-click opens the arrangement overlay, matching how the bluetooth and
+    // audio widgets hang their secondary action off the same button.
+    onPressed: function(b) {
+      if (b === Qt.RightButton) root.openArrangement()
+      else root.toggle()
+    }
     onWheelMoved: function(delta) {
       if (!root.brightnessAvailable) return
       var wheel = Util.wheelSteps(root.wheelAccumulator, delta)

--- a/test/shell.d/display-arrange-test.sh
+++ b/test/shell.d/display-arrange-test.sh
@@ -81,6 +81,22 @@ assertDeepEqual(
   'against where they actually are, the shifted neighbour needs writing too'
 )
 
+// --- putting a layout back means where it was, not a tidied version ---
+
+// Normalising is how a layout is drawn and how a new one is written. Reverting
+// is neither: a layout that started off the origin has to come back off the
+// origin, or the fail-safe meant to undo a change makes one of its own.
+assertDeepEqual(
+  arrange.positionsOf(offOrigin),
+  { 'eDP-1': '-1440x0', 'DP-7': '0x0' },
+  'a revert writes the positions the displays actually had'
+)
+assertDeepEqual(
+  arrange.positionsOf(arrange.normalized(offOrigin)),
+  { 'eDP-1': '0x0', 'DP-7': '1440x0' },
+  'the normalised version of those positions is a different layout'
+)
+
 // --- the canvas fits the whole layout ---
 
 const twoUp = [

--- a/test/shell.d/display-arrange-test.sh
+++ b/test/shell.d/display-arrange-test.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const arrange = requireFromRoot('shell/plugins/display-arrange/Model.js')
+
+// --- displays occupy logical space, not mode space ---
+
+assertDeepEqual(
+  arrange.logicalRect({ name: 'eDP-1', width: 2880, height: 1920, scale: 2, x: 0, y: 480 }),
+  { name: 'eDP-1', x: 0, y: 480, width: 1440, height: 960 },
+  'a display measures mode size divided by scale'
+)
+assertDeepEqual(
+  arrange.logicalRect({ name: 'DP-1', width: 2560, height: 1440, scale: 1, x: 0, y: 0, transform: 1 }),
+  { name: 'DP-1', x: 0, y: 0, width: 1440, height: 2560 },
+  'a rotated display swaps width and height'
+)
+assertDeepEqual(
+  arrange.logicalRect({ name: 'DP-1', width: 2560, height: 1440, scale: 0, x: 0, y: 0 }),
+  { name: 'DP-1', x: 0, y: 0, width: 2560, height: 1440 },
+  'a missing scale falls back to 1 rather than dividing by zero'
+)
+
+// --- the canvas fits the whole layout ---
+
+const twoUp = [
+  { name: 'eDP-1', x: 0, y: 480, width: 1440, height: 960 },
+  { name: 'DP-7', x: 1440, y: 0, width: 2560, height: 1440 }
+]
+assertDeepEqual(
+  arrange.bounds(twoUp),
+  { x: 0, y: 0, width: 4000, height: 1440 },
+  'bounds span every display'
+)
+assertEqual(arrange.fitScale(twoUp, 800, 400, 20), 760 / 4000, 'the layout fits the narrower axis')
+assertEqual(arrange.fitScale([], 800, 400, 20), 1, 'an empty layout needs no scaling')
+
+// --- overlap and contiguity, the two things a layout must get right ---
+
+assertEqual(arrange.anyOverlap(twoUp), false, 'displays side by side do not overlap')
+assertEqual(
+  arrange.anyOverlap([
+    { name: 'a', x: 0, y: 0, width: 100, height: 100 },
+    { name: 'b', x: 50, y: 50, width: 100, height: 100 }
+  ]),
+  true,
+  'displays sharing area overlap'
+)
+assertEqual(arrange.isContiguous(twoUp), true, 'touching displays are contiguous')
+assertEqual(
+  arrange.isContiguous([
+    { name: 'a', x: 0, y: 0, width: 100, height: 100 },
+    { name: 'b', x: 200, y: 0, width: 100, height: 100 }
+  ]),
+  false,
+  'a gap between displays is a dead zone the pointer cannot cross'
+)
+assertEqual(
+  arrange.isContiguous([
+    { name: 'a', x: 0, y: 0, width: 100, height: 100 },
+    { name: 'b', x: 100, y: 100, width: 100, height: 100 }
+  ]),
+  false,
+  'displays meeting at a corner alone leave no width to cross'
+)
+assertEqual(
+  arrange.isContiguous([{ name: 'a', x: 0, y: 0, width: 100, height: 100 }]),
+  true,
+  'a single display is trivially contiguous'
+)
+
+// --- snapping is what makes dragging usable ---
+
+const anchor = [{ name: 'DP-7', x: 1440, y: 0, width: 2560, height: 1440 }]
+assertDeepEqual(
+  arrange.snap({ name: 'eDP-1', x: 1435, y: 3, width: 1440, height: 960 }, anchor, 40),
+  { name: 'eDP-1', x: 1440, y: 0, width: 1440, height: 960 },
+  'a near miss snaps flush to the neighbour'
+)
+assertDeepEqual(
+  arrange.snap({ name: 'eDP-1', x: 10, y: 470, width: 1440, height: 960 }, anchor, 40),
+  { name: 'eDP-1', x: 0, y: 480, width: 1440, height: 960 },
+  'the left edge snaps against the neighbour and bottom edges align'
+)
+assertDeepEqual(
+  arrange.snap({ name: 'eDP-1', x: 600, y: 600, width: 1440, height: 960 }, anchor, 40),
+  { name: 'eDP-1', x: 600, y: 600, width: 1440, height: 960 },
+  'a display far from its neighbours is left where it was dropped'
+)
+
+// --- a display dropped on another is pushed clear ---
+
+assertDeepEqual(
+  arrange.pushOut({ name: 'a', x: 100, y: 0, width: 200, height: 200 },
+    [{ name: 'b', x: 0, y: 0, width: 200, height: 200 }]),
+  { name: 'a', x: 200, y: 0, width: 200, height: 200 },
+  'an overlapping display moves out the shortest way'
+)
+assertDeepEqual(
+  arrange.pushOut({ name: 'a', x: 0, y: 150, width: 200, height: 200 },
+    [{ name: 'b', x: 0, y: 0, width: 200, height: 200 }]),
+  { name: 'a', x: 0, y: 200, width: 200, height: 200 },
+  'a mostly-below overlap resolves downwards, not sideways'
+)
+assertDeepEqual(
+  arrange.pushOut({ name: 'a', x: 500, y: 500, width: 200, height: 200 },
+    [{ name: 'b', x: 0, y: 0, width: 200, height: 200 }]),
+  { name: 'a', x: 500, y: 500, width: 200, height: 200 },
+  'a display that overlaps nothing is left alone'
+)
+assertEqual(
+  arrange.anyOverlap([
+    { name: 'b', x: 0, y: 0, width: 200, height: 200 },
+    arrange.pushOut({ name: 'a', x: 10, y: 10, width: 200, height: 200 },
+      [{ name: 'b', x: 0, y: 0, width: 200, height: 200 }])
+  ]),
+  false,
+  'the result of a push never overlaps'
+)
+
+// --- a display left floating is pulled onto its neighbour ---
+
+const board = [{ name: 'b', x: 0, y: 0, width: 200, height: 200 }]
+
+assertDeepEqual(
+  arrange.attach({ name: 'a', x: 500, y: 0, width: 200, height: 200 }, board),
+  { name: 'a', x: 200, y: 0, width: 200, height: 200 },
+  'a display floating to the right is pulled against the right edge'
+)
+assertDeepEqual(
+  arrange.attach({ name: 'a', x: 0, y: 600, width: 200, height: 200 }, board),
+  { name: 'a', x: 0, y: 200, width: 200, height: 200 },
+  'a display floating below is pulled against the bottom edge'
+)
+assertDeepEqual(
+  arrange.attach({ name: 'a', x: 200, y: 0, width: 200, height: 200 }, board),
+  { name: 'a', x: 200, y: 0, width: 200, height: 200 },
+  'a display already touching is left where it is'
+)
+
+// Diagonally away, so it would meet at a corner without the clamp — which is
+// as uncrossable as a gap.
+const cornered = arrange.attach({ name: 'a', x: 600, y: 600, width: 200, height: 200 }, board)
+assertEqual(arrange.isContiguous(board.concat([cornered])), true, 'a diagonal drop still shares a real edge')
+assertEqual(arrange.anyOverlap(board.concat([cornered])), false, 'attaching never overlaps')
+
+// --- rotation re-measures the display, it does not just relabel it ---
+
+assertDeepEqual(
+  arrange.rotated({ name: 'a', x: 10, y: 20, width: 2560, height: 1440 }, 0, 1),
+  { name: 'a', x: 10, y: 20, width: 1440, height: 2560 },
+  'rotating to 90 degrees swaps the edges the layout sees'
+)
+assertDeepEqual(
+  arrange.rotated({ name: 'a', x: 0, y: 0, width: 1440, height: 2560 }, 1, 3),
+  { name: 'a', x: 0, y: 0, width: 1440, height: 2560 },
+  '90 to 270 keeps the same edges, both being quarter turns'
+)
+assertDeepEqual(
+  arrange.rotated({ name: 'a', x: 0, y: 0, width: 2560, height: 1440 }, 0, 2),
+  { name: 'a', x: 0, y: 0, width: 2560, height: 1440 },
+  '180 degrees leaves the edges alone'
+)
+assertEqual(arrange.nextTransform(0), 1, 'rotation steps through the quarter turns')
+assertEqual(arrange.nextTransform(3), 0, 'rotation wraps back to upright')
+assertEqual(arrange.transformLabel(3), '270°', 'each rotation has a readable label')
+
+// --- normalising keeps the numbers readable across repeated edits ---
+
+assertDeepEqual(
+  arrange.normalized([
+    { name: 'a', x: -1440, y: -480, width: 1440, height: 960 },
+    { name: 'b', x: 0, y: 0, width: 2560, height: 1440 }
+  ]),
+  [
+    { name: 'a', x: 0, y: 0, width: 1440, height: 960 },
+    { name: 'b', x: 1440, y: 480, width: 2560, height: 1440 }
+  ],
+  'a layout is shifted so its top-left sits at the origin'
+)
+
+// --- only what moved gets written ---
+
+assertDeepEqual(
+  arrange.changedPositions(twoUp, [
+    { name: 'eDP-1', x: 0, y: 0, width: 1440, height: 960 },
+    { name: 'DP-7', x: 1440, y: 0, width: 2560, height: 1440 }
+  ]),
+  { 'eDP-1': '0x0' },
+  'only displays that moved are written back'
+)
+assertDeepEqual(
+  arrange.changedPositions(twoUp, twoUp),
+  {},
+  'an unchanged layout writes nothing'
+)
+JS

--- a/test/shell.d/display-arrange-test.sh
+++ b/test/shell.d/display-arrange-test.sh
@@ -25,6 +25,29 @@ assertDeepEqual(
   'a missing scale falls back to 1 rather than dividing by zero'
 )
 
+// --- mirroring is offered against live displays, not switched-off ones ---
+
+assertEqual(arrange.isInternalName('eDP-1'), true, 'eDP is the built-in panel')
+assertEqual(arrange.isInternalName('DP-7'), false, 'DP is an external display')
+assertEqual(arrange.isInternalName(''), false, 'a nameless display is not the panel')
+
+const bothLive = [{ name: 'eDP-1' }, { name: 'DP-7' }]
+assertEqual(arrange.hasActiveDisplay(bothLive, true), true, 'the built-in panel is live')
+assertEqual(arrange.hasActiveDisplay(bothLive, false), true, 'the external display is live')
+
+// The regression: `hyprctl monitors all` still names a display the user
+// switched off, so gating mirroring on it offered Mirror with nothing to
+// mirror to, and pressing it re-enabled the panel that was deliberately off.
+const panelOff = [{ name: 'DP-7' }]
+assertEqual(arrange.hasActiveDisplay(panelOff, true), false, 'a switched-off panel is not live')
+assertEqual(arrange.hasActiveDisplay(panelOff, false), true, 'the external display is still live')
+
+const laptopOnly = [{ name: 'eDP-1' }]
+assertEqual(arrange.hasActiveDisplay(laptopOnly, false), false, 'no external display to mirror to')
+
+assertEqual(arrange.hasActiveDisplay([], true), false, 'no displays means nothing is live')
+assertEqual(arrange.hasActiveDisplay(null, true), false, 'a missing listing is not live')
+
 // --- the canvas fits the whole layout ---
 
 const twoUp = [

--- a/test/shell.d/display-arrange-test.sh
+++ b/test/shell.d/display-arrange-test.sh
@@ -48,6 +48,39 @@ assertEqual(arrange.hasActiveDisplay(laptopOnly, false), false, 'no external dis
 assertEqual(arrange.hasActiveDisplay([], true), false, 'no displays means nothing is live')
 assertEqual(arrange.hasActiveDisplay(null, true), false, 'a missing listing is not live')
 
+// --- the notification glyph is one character ---
+
+// A "\\u" escape takes exactly four hex digits, so writing this glyph escaped
+// yields U+F037 followed by a stray "9".
+assertEqual([...arrange.displayGlyph].length, 1, 'the display glyph is a single character')
+assertEqual(arrange.displayGlyph.codePointAt(0), 0xf0379, 'the display glyph is the one the panel uses')
+
+// --- a layout that does not start at the origin ---
+
+// The canvas draws a normalised layout, so a display left of 0x0 is drawn
+// shifted even when the user never touched it. Comparing where displays
+// actually are against where the canvas puts them is what catches that; against
+// the normalised original it looks unchanged, and writing only the display the
+// user dragged would leave the two covering different regions.
+const offOrigin = [
+  { name: 'eDP-1', x: -1440, y: 0, width: 1440, height: 900 },
+  { name: 'DP-7', x: 0, y: 0, width: 2560, height: 1440 }
+]
+const dragged = [
+  { name: 'eDP-1', x: -1440, y: 0, width: 1440, height: 900 },
+  { name: 'DP-7', x: 0, y: 100, width: 2560, height: 1440 }
+]
+assertDeepEqual(
+  arrange.changedPositions(arrange.normalized(offOrigin), arrange.normalized(dragged)),
+  { 'DP-7': '1440x100' },
+  'against the normalised original only the dragged display looks moved'
+)
+assertDeepEqual(
+  arrange.changedPositions(offOrigin, arrange.normalized(dragged)),
+  { 'eDP-1': '0x0', 'DP-7': '1440x100' },
+  'against where they actually are, the shifted neighbour needs writing too'
+)
+
 // --- the canvas fits the whole layout ---
 
 const twoUp = [

--- a/test/shell.d/mirror-pin-migration-test.sh
+++ b/test/shell.d/mirror-pin-migration-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1786611349.sh"
+[[ -f $migration ]] || fail "migration 1786611349.sh is missing"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+old_rule='hl.monitor({ output = "DP-7", mode = "preferred", position = "auto", scale = 1, mirror = "eDP-1" })'
+new_rule='hl.monitor({ output = "DP-7", mode = "preferred", position = "0x1000", scale = 1, mirror = "eDP-1" })'
+
+# $1 rule to start with ("" for none), $2 external attached, $3 switching mirroring back on succeeds
+setup() {
+  home_dir="$test_tmp/home"
+  stub_bin="$test_tmp/bin"
+  flag="$home_dir/.local/state/omarchy/toggles/hypr/internal-monitor-mirror.lua"
+
+  rm -rf "$home_dir" "$stub_bin"
+  mkdir -p "$stub_bin" "$home_dir/.local/state/omarchy/toggles/hypr"
+  [[ -n $1 ]] && printf '%s\n' "$1" >"$flag"
+
+  printf '#!/bin/bash\nexit %s\n' "$([[ $2 == yes ]] && echo 0 || echo 1)" >"$stub_bin/omarchy-hw-external-monitors"
+  printf '#!/bin/bash\necho eDP-1\n' >"$stub_bin/omarchy-hyprland-monitor-laptop"
+
+  # Stands in for the real command: switching off drops the rule, switching on
+  # writes a pinned one, and the caller decides whether that second step works.
+  cat >"$stub_bin/omarchy-hyprland-monitor-internal-mirror" <<SH
+#!/bin/bash
+rule="\$HOME/.local/state/omarchy/toggles/hypr/internal-monitor-mirror.lua"
+printf '%s\n' "\$*" >>"$test_tmp/calls"
+[[ \$1 == off ]] && { rm -f "\$rule"; exit 0; }
+[[ "$3" == yes ]] || exit 1
+printf '%s\n' '$new_rule' >"\$rule"
+SH
+
+  chmod +x "$stub_bin"/*
+  rm -f "$test_tmp/calls"
+}
+
+run_migration() {
+  HOME="$home_dir" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+}
+
+# --- the migration only speaks up when there is something to repair ---
+
+setup "" yes yes
+run_migration
+[[ ! -f $flag ]] || fail "a machine that is not mirroring gains a rule"
+[[ ! -f $test_tmp/calls ]] || fail "a machine that is not mirroring is left alone"
+pass "a machine that is not mirroring is left alone"
+
+setup "$new_rule" yes yes
+run_migration
+[[ $(cat "$flag") == "$new_rule" ]] || fail "an already-pinned rule is rewritten"
+[[ ! -f $test_tmp/calls ]] || fail "an already-pinned rule is cycled anyway"
+pass "an already-pinned rule is left alone, so a second run is a no-op"
+
+# --- the repair itself ---
+
+setup "$old_rule" yes yes
+run_migration
+[[ $(cat "$flag") == "$new_rule" ]] || fail "an auto-positioned rule is repinned"
+grep -Fq 'off --quiet' "$test_tmp/calls" || fail "mirroring is switched off quietly"
+grep -Fq 'on --quiet' "$test_tmp/calls" || fail "mirroring is switched back on quietly"
+pass "an auto-positioned rule is repinned by cycling mirroring"
+
+# The rule is only rewritten when mirroring is switched on, so the repair has to
+# cycle it. The user did not ask for that, so it must not announce itself.
+[[ $(grep -c -- '--quiet' "$test_tmp/calls") == "2" ]] ||
+  fail "every step of the repair is quiet"
+pass "the repair does not announce itself"
+
+# --- a repair that cannot finish puts things back ---
+
+setup "$old_rule" yes no
+run_migration
+[[ -f $flag ]] || fail "a failed repair leaves the machine extended"
+[[ $(cat "$flag") == "$old_rule" ]] || fail "a failed repair restores the rule that was there"
+pass "a repair that cannot switch mirroring back on restores the original rule"
+
+# Cycling needs somewhere to mirror to. Switching off and then failing to switch
+# back on would drop mirroring for a user who never asked to lose it.
+setup "$old_rule" no yes
+run_migration
+[[ $(cat "$flag") == "$old_rule" ]] || fail "an unplugged external leaves the rule alone"
+[[ ! -f $test_tmp/calls ]] || fail "an unplugged external is not cycled"
+pass "mirroring is not cycled with no external display attached"

--- a/test/shell.d/mirror-pin-migration-test.sh
+++ b/test/shell.d/mirror-pin-migration-test.sh
@@ -37,6 +37,13 @@ printf '%s\n' "\$*" >>"$test_tmp/calls"
 printf '%s\n' '$new_rule' >"\$rule"
 SH
 
+  # Switching mirroring off reloads Hyprland, so a rollback has to reload too
+  # or the rule and the live session disagree.
+  cat >"$stub_bin/hyprctl" <<SH
+#!/bin/bash
+printf 'hyprctl %s\n' "\$*" >>"$test_tmp/calls"
+SH
+
   chmod +x "$stub_bin"/*
   rm -f "$test_tmp/calls"
 }
@@ -81,6 +88,14 @@ run_migration
 [[ -f $flag ]] || fail "a failed repair leaves the machine extended"
 [[ $(cat "$flag") == "$old_rule" ]] || fail "a failed repair restores the rule that was there"
 pass "a repair that cannot switch mirroring back on restores the original rule"
+
+# Switching mirroring off already removed the rule and reloaded, so the session
+# is extended by the time anything can fail. Putting the file back without a
+# reload would leave the rule claiming mirroring while the displays stay
+# extended, which is the state the rollback exists to avoid.
+grep -Fq 'hyprctl reload' "$test_tmp/calls" ||
+  fail "restoring the rule reloads so the session matches it again"
+pass "a restored rule is reloaded rather than left disagreeing with the session"
 
 # Cycling needs somewhere to mirror to. Switching off and then failing to switch
 # back on would drop mirroring for a user who never asked to lose it.

--- a/test/shell.d/monitor-mirror-test.sh
+++ b/test/shell.d/monitor-mirror-test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+state_dir="$home_dir/.local/state/omarchy/toggles/hypr"
+mirror_flag="$state_dir/internal-monitor-mirror.lua"
+
+mkdir -p "$stub_bin" "$state_dir"
+
+# The monitor list is whatever the case under test exports, so one stub covers
+# a laptop alone, a laptop plus one external, and a laptop plus several.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "monitors" && $2 == "-j" ]]; then
+  printf '%s' "${OMARCHY_TEST_MONITORS:-[]}"
+elif [[ $1 == "reload" ]]; then
+  printf 'reload\n' >>"$OMARCHY_TEST_LOG"
+else
+  exit 1
+fi
+SH
+
+cat >"$stub_bin/omarchy-hyprland-monitor-laptop" <<'SH'
+#!/bin/bash
+printf '%s\n' "${OMARCHY_TEST_INTERNAL:-eDP-1}"
+SH
+
+cat >"$stub_bin/omarchy-hyprland-toggle" <<'SH'
+#!/bin/bash
+[[ $2 == "off" ]] && rm -f "$HOME/.local/state/omarchy/toggles/hypr/$1.lua"
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-hyprland-toggle-disabled" <<'SH'
+#!/bin/bash
+[[ ! -f "$HOME/.local/state/omarchy/toggles/hypr/$1.lua" ]]
+SH
+
+cat >"$stub_bin/omarchy-hyprland-toggle-enabled" <<'SH'
+#!/bin/bash
+[[ -f "$HOME/.local/state/omarchy/toggles/hypr/$1.lua" ]]
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf 'notify %s\n' "${*: -1}" >>"$OMARCHY_TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+mirror() {
+  HOME="$home_dir" \
+  PATH="$stub_bin:$PATH" \
+  OMARCHY_TEST_LOG="$test_tmp/log" \
+    bash "$ROOT/bin/omarchy-hyprland-monitor-internal-mirror" "$@"
+}
+
+laptop_and() {
+  local extra="$1"
+  printf '[{"name":"eDP-1","x":0,"y":1000,"transform":0}%s]' "$extra"
+}
+
+# --- mirroring covers every external, not just the first ---
+
+rm -f "$mirror_flag" "$test_tmp/log"
+OMARCHY_TEST_MONITORS=$(laptop_and ',{"name":"DP-7","x":0,"y":0,"transform":0}') mirror on
+
+grep -Fq 'output = "DP-7"' "$mirror_flag"
+grep -Fq 'mirror = "eDP-1"' "$mirror_flag"
+[[ $(grep -c 'hl.monitor' "$mirror_flag") == 1 ]]
+pass "a single external mirrors the laptop panel"
+
+rm -f "$mirror_flag" "$test_tmp/log"
+OMARCHY_TEST_MONITORS=$(laptop_and ',{"name":"DP-7","x":0,"y":0,"transform":0},{"name":"HDMI-A-1","x":2560,"y":0,"transform":0}') mirror on
+
+[[ $(grep -c 'hl.monitor' "$mirror_flag") == 2 ]]
+grep -Fq 'output = "DP-7"' "$mirror_flag"
+grep -Fq 'output = "HDMI-A-1"' "$mirror_flag"
+pass "a second external mirrors too rather than staying extended"
+
+# Each rule names the laptop as the source, so no external mirrors another
+# external and none is left showing its own content.
+[[ $(grep -c 'mirror = "eDP-1"' "$mirror_flag") == 2 ]]
+pass "the laptop panel is the source for every mirror"
+
+# --- the source's position is pinned onto every mirror ---
+
+[[ $(grep -c 'position = "0x1000"' "$mirror_flag") == 2 ]]
+pass "every mirror is pinned to the laptop panel's position"
+
+# --- rotation is carried per display, not copied from the first ---
+
+rm -f "$mirror_flag" "$test_tmp/log"
+OMARCHY_TEST_MONITORS=$(laptop_and ',{"name":"DP-7","x":0,"y":0,"transform":0},{"name":"HDMI-A-1","x":2560,"y":0,"transform":1}') mirror on
+
+grep -Eq 'output = "DP-7".*mirror = "eDP-1" \}' "$mirror_flag"
+grep -Fq 'transform = 1' "$mirror_flag"
+[[ $(grep -c 'transform =' "$mirror_flag") == 1 ]]
+pass "each external keeps its own rotation"
+
+# --- nothing to mirror to ---
+
+rm -f "$mirror_flag" "$test_tmp/log"
+OMARCHY_TEST_MONITORS=$(laptop_and '') mirror on || true
+
+[[ ! -f $mirror_flag ]]
+grep -Fq 'No external monitors found for mirror' "$test_tmp/log"
+pass "a laptop with no external refuses rather than writing an empty rule set"
+
+# --- turning it back off ---
+
+rm -f "$test_tmp/log"
+OMARCHY_TEST_MONITORS=$(laptop_and ',{"name":"DP-7","x":0,"y":0,"transform":0}') mirror on
+OMARCHY_TEST_MONITORS=$(laptop_and ',{"name":"DP-7","x":0,"y":0,"transform":0}') mirror off
+
+[[ ! -f $mirror_flag ]]
+pass "extending again clears every mirror rule at once"

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -94,8 +94,11 @@ grep -F 'omarchy-hyprland-toggle-enabled $TOGGLE || return 0' "$monitor_internal
 pass "internal monitor helper can re-enable disabled laptop displays"
 pass "internal monitor recovery only wakes displays when it re-enables one"
 
-grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_mirror" >/dev/null
-pass "internal mirror helper recovers when no active external display remains"
+# Physical presence, not Hyprland's enabled state: a display the user switched
+# off is still plugged in, and clearing the mirror for it discards a choice that
+# re-enabling cannot restore.
+grep -F 'omarchy-hw-external-monitors' "$monitor_mirror" >/dev/null
+pass "internal mirror helper recovers only when the external display is unplugged"
 
 grep -F 'switch:on:Lid Switch", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null
 grep -F 'switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null

--- a/test/shell.d/monitor-rule-test.sh
+++ b/test/shell.d/monitor-rule-test.sh
@@ -158,3 +158,46 @@ run_rule DP-1
 [[ $(grep -c '^hl.monitor' "$monitor_lua") == "1" ]] ||
   fail "a commented-out rule does not stand in for a real one"
 pass "a commented-out rule does not stand in for a real one"
+
+# A rule is a Lua statement, not a line. Splitting one over several lines is
+# ordinary formatting, and reading line-by-line saw `hl.monitor({` with no
+# output key on it, took the rule for one naming its display by a variable, and
+# refused to place a display whose rule was sitting right there.
+printf 'hl.monitor({\n  output = "DP-1",\n  position = "0x0",\n  scale = 1,\n})\n' >"$monitor_lua"
+run_rule DP-1
+[[ $(grep -c 'hl.monitor' "$monitor_lua") == "1" ]] ||
+  fail "a rule split over several lines is rewritten rather than duplicated"
+grep -Fq 'output = "DP-1"' "$monitor_lua" || fail "the rewritten rule keeps its display"
+pass "a rule split over several lines is rewritten rather than duplicated"
+
+# The identifier can sit on any line of the rule, and it is the user's choice to
+# keep — swapping it for ours leaves their comments pointing at nothing.
+printf 'hl.monitor({\n  output = "desc:Acme Wide",\n  scale = 1,\n})\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'output = "desc:Acme Wide"' "$monitor_lua" ||
+  fail "a multi-line rule keeps the identifier the user wrote"
+pass "a multi-line rule keeps the identifier the user wrote"
+
+# Only the rule being replaced may move; its neighbours are the user's file.
+printf 'hl.monitor({ output = "eDP-1", scale = 2 })\nhl.monitor({\n  output = "DP-1",\n  scale = 1,\n})\nhl.monitor({ output = "HDMI-A-1", scale = 1 })\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'output = "eDP-1", scale = 2' "$monitor_lua" || fail "the rule above is untouched"
+grep -Fq 'output = "HDMI-A-1", scale = 1' "$monitor_lua" || fail "the rule below is untouched"
+[[ $(grep -c 'hl.monitor' "$monitor_lua") == "3" ]] || fail "the file still holds three rules"
+pass "collapsing a multi-line rule leaves its neighbours alone"
+
+# Quoting decides what is syntax: a description may hold braces, parentheses or
+# a "--" without ending the rule or starting a comment.
+printf 'hl.monitor({ output = "desc:Weird (Brand) -- v2", scale = 1 })\nhl.monitor({ output = "DP-1", scale = 1 })\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'output = "desc:Weird (Brand) -- v2", scale = 1' "$monitor_lua" ||
+  fail "a description holding braces and dashes is left alone"
+pass "punctuation inside a description is not read as syntax"
+
+# An unterminated rule is a broken file, not a display without one: appending
+# below it would land the new rule inside the open call.
+printf 'hl.monitor({\n  output = "DP-1",\n' >"$monitor_lua"
+cp "$monitor_lua" "$test_tmp/unterminated.lua"
+run_rule DP-1 2>/dev/null && fail "an unterminated rule is refused"
+diff "$test_tmp/unterminated.lua" "$monitor_lua" >/dev/null || fail "a refused file is left untouched"
+pass "an unterminated rule is refused rather than appended to"

--- a/test/shell.d/monitor-rule-test.sh
+++ b/test/shell.d/monitor-rule-test.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+monitor_lua="$home_dir/.config/hypr/monitors.lua"
+
+mkdir -p "$stub_bin" "$home_dir/.config/hypr"
+
+# eDP-1 reports a description and sits at 0,960 scaled 2. DP-1 reports a
+# description with a serial on the end, which is what makes abbreviated rules
+# in a hand-written config the interesting case.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "monitors" && $2 == "all" && $3 == "-j" ]]; then
+  printf '[{"name":"eDP-1","description":"BOE Panel","x":0,"y":960,"scale":2.00000,"transform":%s},{"name":"DP-1","description":"Acme Wide 42 SN123","x":1440,"y":0,"scale":1,"transform":0},{"name":"HDMI-A-1","description":"","x":4000,"y":0,"scale":1,"transform":0}]' \
+    "${OMARCHY_TEST_TRANSFORM:-0}"
+else
+  exit 1
+fi
+SH
+chmod +x "$stub_bin"/*
+
+run_rule() {
+  HOME="$home_dir" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-hyprland-monitor-rule" "$@"
+}
+
+# A config shaped like one a user actually keeps: a stock catch-all, rules in
+# both identifier styles, comments, and commented-out examples.
+write_config() {
+  cat >"$monitor_lua" <<'LUA'
+-- See https://wiki.hypr.land/Configuring/Basics/Monitors/
+
+local omarchy_monitor_scale = 2
+
+hl.env("GDK_SCALE", "2")
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+
+-- Laptop left of the desk display, bottom edges aligned.
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "0x480", scale = 2 })
+hl.monitor({ output = "desc:Acme Wide", mode = "preferred", position = "1440x0", scale = 2 })
+
+-- Configure a specific monitor.
+-- hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "0x0", scale = 1 })
+LUA
+}
+
+rules_for() {
+  grep -c "output = \"$1\"" "$monitor_lua"
+}
+
+# --- a rule keyed by connector name is rewritten in place ---
+
+write_config
+run_rule eDP-1
+[[ $(rules_for "eDP-1") == "1" ]] || fail "the display keeps exactly one rule"
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "0x960", scale = 2 })' "$monitor_lua" >/dev/null ||
+  fail "the rule carries the display's current geometry"
+pass "a rule keyed by connector name is rewritten in place"
+
+# --- an abbreviated description still matches its display ---
+
+# Hyprland matches desc: by prefix, so a rule saying "desc:Acme Wide" configures
+# a display reporting "Acme Wide 42 SN123". Comparing identifiers exactly would
+# miss it and append a second rule for a display that already has one.
+write_config
+run_rule DP-1
+[[ $(grep -c 'output = "desc:Acme Wide"' "$monitor_lua") == "1" ]] ||
+  fail "an abbreviated description is matched rather than duplicated"
+grep -Fx 'hl.monitor({ output = "desc:Acme Wide", mode = "preferred", position = "1440x0", scale = 1 })' "$monitor_lua" >/dev/null ||
+  fail "the abbreviated rule keeps its identifier and takes the new geometry"
+pass "an abbreviated description is matched rather than duplicated"
+
+# --- a display with no rule of its own gets one ---
+
+write_config
+before=$(grep -c 'hl.monitor' "$monitor_lua")
+run_rule HDMI-A-1
+[[ $(grep -c 'hl.monitor' "$monitor_lua") == $((before + 1)) ]] ||
+  fail "a display with no rule gains exactly one"
+grep -Fx 'hl.monitor({ output = "HDMI-A-1", mode = "preferred", position = "4000x0", scale = 1 })' "$monitor_lua" >/dev/null ||
+  fail "a display without a description falls back to its connector name"
+pass "a display with no rule of its own gains one"
+
+# --- the rest of the file is left alone ---
+
+write_config
+cp "$monitor_lua" "$test_tmp/before.lua"
+run_rule eDP-1
+diff <(grep -v 'output = "eDP-1"' "$test_tmp/before.lua") <(grep -v 'output = "eDP-1"' "$monitor_lua") >/dev/null ||
+  fail "every other line survives untouched"
+grep -F -e '-- Laptop left of the desk display, bottom edges aligned.' "$monitor_lua" >/dev/null ||
+  fail "comments survive"
+grep -F -e '-- hl.monitor({ output = "DP-2"' "$monitor_lua" >/dev/null ||
+  fail "commented-out examples are not mistaken for rules"
+grep -F 'scale = omarchy_monitor_scale' "$monitor_lua" >/dev/null ||
+  fail "the catch-all is left alone"
+pass "everything else in the file survives untouched"
+
+# --- rotation ---
+
+write_config
+OMARCHY_TEST_TRANSFORM=1 run_rule eDP-1
+grep -F 'transform = 1' "$monitor_lua" >/dev/null || fail "a rotated display records its rotation"
+pass "a rotated display records its rotation"
+
+write_config
+run_rule eDP-1
+! grep -F 'transform' "$monitor_lua" >/dev/null || fail "an upright display records no rotation"
+pass "an upright display records no rotation"
+
+# --- refusals ---
+
+write_config
+run_rule DP-9 2>/dev/null && fail "an unknown display exits non-zero"
+run_rule 2>/dev/null && fail "a missing display name exits non-zero"
+diff "$test_tmp/before.lua" "$monitor_lua" >/dev/null || fail "a refused write leaves the file alone"
+pass "an unknown or missing display is refused without touching the file"
+
+# --- any single-line shape is recognised, and anything else is refused ---
+
+# A Lua config can be written many ways: no spaces, indented, or using Lua's
+# call-without-parentheses form. Matching the formatting Omarchy happens to ship
+# would append a second rule for a display that already has one.
+for shape in \
+  'hl.monitor({output="DP-1", scale=1})' \
+  '  hl.monitor({ output = "DP-1", scale = 1 })' \
+  'hl.monitor { output = "DP-1", scale = 1 }'; do
+  printf '%s\n' "$shape" >"$monitor_lua"
+  run_rule DP-1
+  [[ $(grep -c 'hl.monitor' "$monitor_lua") == "1" ]] ||
+    fail "a rule written as: $shape is rewritten rather than duplicated"
+done
+pass "any single-line shape is rewritten rather than duplicated"
+
+# Declining beats guessing: rewriting the wrong rule, or adding a second one,
+# means whichever Hyprland loads last wins and silently drops the other.
+printf 'local name = "DP-1"\nhl.monitor({ output = name, scale = 1 })\n' >"$monitor_lua"
+cp "$monitor_lua" "$test_tmp/variable.lua"
+run_rule DP-1 2>/dev/null && fail "a display named by a variable is refused"
+diff "$test_tmp/variable.lua" "$monitor_lua" >/dev/null || fail "a refused file is left untouched"
+pass "a display named by something other than a literal is refused"
+
+printf 'hl.monitor({ output = "DP-1", scale = 1 })\nhl.monitor({ output = "desc:Acme Wide", scale = 2 })\n' >"$monitor_lua"
+cp "$monitor_lua" "$test_tmp/two.lua"
+run_rule DP-1 2>/dev/null && fail "a display with two rules already is refused"
+diff "$test_tmp/two.lua" "$monitor_lua" >/dev/null || fail "a refused file is left untouched"
+pass "a display that already has two rules is refused"
+
+printf -- '-- hl.monitor({ output = "DP-1", scale = 1 })\n' >"$monitor_lua"
+run_rule DP-1
+[[ $(grep -c '^hl.monitor' "$monitor_lua") == "1" ]] ||
+  fail "a commented-out rule does not stand in for a real one"
+pass "a commented-out rule does not stand in for a real one"

--- a/test/shell.d/monitor-rule-test.sh
+++ b/test/shell.d/monitor-rule-test.sh
@@ -201,3 +201,33 @@ cp "$monitor_lua" "$test_tmp/unterminated.lua"
 run_rule DP-1 2>/dev/null && fail "an unterminated rule is refused"
 diff "$test_tmp/unterminated.lua" "$monitor_lua" >/dev/null || fail "a refused file is left untouched"
 pass "an unterminated rule is refused rather than appended to"
+
+# The rewritten rule has to restate a mode, because Hyprland merges rules per
+# identifier and drops whatever one leaves out. Which mode is the user's call,
+# not this command's: it is here to move a display, not to change its
+# resolution or refresh rate.
+printf 'hl.monitor({ output = "DP-1", mode = "2560x1440@144", scale = 1 })\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'mode = "2560x1440@144"' "$monitor_lua" ||
+  fail "a pinned mode survives a move"
+pass "a pinned mode survives a move"
+
+printf 'hl.monitor({ output = "DP-1", mode = "preferred", scale = 1 })\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'mode = "preferred"' "$monitor_lua" ||
+  fail "a rule asking for the preferred mode keeps asking for it"
+pass "a rule asking for the preferred mode keeps asking for it"
+
+# A rule naming no mode was already running the preferred one, so that is what
+# restating it means.
+printf 'hl.monitor({ output = "DP-1", scale = 1 })\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'mode = "preferred"' "$monitor_lua" ||
+  fail "a rule with no mode gains the preferred one"
+pass "a rule that named no mode is restated as preferred"
+
+printf 'hl.monitor({\n  output = "DP-1",\n  mode = "2560x1440@144",\n  scale = 1,\n})\n' >"$monitor_lua"
+run_rule DP-1
+grep -Fq 'mode = "2560x1440@144"' "$monitor_lua" ||
+  fail "a pinned mode on its own line survives a move"
+pass "a pinned mode survives even when the rule spans several lines"


### PR DESCRIPTION
**Adds an overlay for arranging displays by dragging them**, plus fixes for the
mirroring bugs found along the way.

**Try it:** right click the display widget in the bar.

Drag a display to move it, snapping against its neighbours. R rotates the
selected display. Enter applies. The layout reverts itself after 15 seconds
unless you confirm, so a bad arrangement cannot strand you on a screen you
cannot see.

https://github.com/user-attachments/assets/0de65393-e648-4235-b859-8fd57de53d6f

### Where settings go

Geometry is written to the user's own `~/.config/hypr/monitors.lua`. The
rule for that display is rewritten in place, keeping whichever identifier
is already there (name or `desc:`). Nothing is stored in a second file, so
a hand edit and the UI cannot disagree, and Hyprland stays authoritative:
the overlay never parses the config, it reads `hyprctl monitors`.

Rules split over several lines, indented, or written without parentheses
are all handled. Where a rule cannot be identified (named by a variable,
or two rules for one display) it declines and says so rather than guessing.

### Mirroring

Fixes reachable today from the existing menu entry:

- mirror the laptop panel to every external, not only the first
- pin the mirror to the source's position, so it survives an output cycle
- recover on physical presence, so switching a display off no longer
  silently drops the mirror
- a migration pins an existing mirror on upgrade, so the fix reaches
  machines that are already mirroring

### Tests

`./test/shell` covers the geometry model, the rule writer including the
Lua shapes above, the mirror rules and the migration. The graphical
acceptance suite has not been run.

### Notes

Combined with #6710, this PR aims to make multiple monitors pleasant to manage.

I only have one external display here, so multi-monitor mirroring is
covered by tests rather than by daily use.
