### PR TITLE
Fix notification focus for agent terminals

### DIFF
--- a/bin/omarchy-hyprland-focus-app
+++ b/bin/omarchy-hyprland-focus-app
@@ -21,7 +21,11 @@ address=$(
       'def matches($value): ($value // "") | test($pattern; "i");
        ([.[] | select(matches(.class))] +
         [.[] | select(matches(.initialClass))] +
-        [.[] | select(matches(.initialTitle))]) |
+        [.[] | select(
+          ((.class // "") == "org.omarchy.agent" or
+           (.initialClass // "") == "org.omarchy.agent") and
+          matches(.initialTitle)
+        )]) |
        first.address // empty'
 )
 

--- a/bin/omarchy-hyprland-focus-app
+++ b/bin/omarchy-hyprland-focus-app
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Focus a Hyprland window by application class
+# omarchy:summary=Focus a Hyprland window by application identity
 # omarchy:args=<app-name>
 # omarchy:examples=omarchy hyprland focus app Slack
 
@@ -12,10 +12,17 @@ usage() {
 app=${1:-}
 [[ -n $app ]] || usage
 
+# Keep current classes first, but fall back to stable launch-time identities.
+# Agent terminals notify as kitty/foot/etc. while their shared window class is
+# org.omarchy.agent, leaving the terminal name only in initialTitle.
 address=$(
   hyprctl clients -j 2>/dev/null |
     jq -r --arg pattern "$app" \
-      '[.[] | select((.class // "") | test($pattern; "i"))] | first.address // empty'
+      'def matches($value): ($value // "") | test($pattern; "i");
+       ([.[] | select(matches(.class))] +
+        [.[] | select(matches(.initialClass))] +
+        [.[] | select(matches(.initialTitle))]) |
+       first.address // empty'
 )
 
 [[ -n $address ]] || exit 1

--- a/bin/omarchy-hyprland-focus-app
+++ b/bin/omarchy-hyprland-focus-app
@@ -12,21 +12,17 @@ usage() {
 app=${1:-}
 [[ -n $app ]] || usage
 
-# Keep current classes first, but fall back to stable launch-time identities.
 # Agent terminals notify as kitty/foot/etc. while their shared window class is
-# org.omarchy.agent, leaving the terminal name only in initialTitle.
+# org.omarchy.agent, leaving the terminal name only in initialTitle. So match
+# by class first, then fall back to the launch-time title of agent windows.
 address=$(
   hyprctl clients -j 2>/dev/null |
     jq -r --arg pattern "$app" \
       'def matches($value): ($value // "") | test($pattern; "i");
-       ([.[] | select(matches(.class))] +
-        [.[] | select(matches(.initialClass))] +
-        [.[] | select(
-          ((.class // "") == "org.omarchy.agent" or
-           (.initialClass // "") == "org.omarchy.agent") and
-          matches(.initialTitle)
-        )]) |
-       first.address // empty'
+       first(
+         (.[] | select(matches(.class))),
+         (.[] | select(.initialClass == "org.omarchy.agent" and matches(.initialTitle)))
+       ).address // empty'
 )
 
 [[ -n $address ]] || exit 1

--- a/test/shell.d/hyprland-focus-app-test.sh
+++ b/test/shell.d/hyprland-focus-app-test.sh
@@ -43,3 +43,17 @@ grep -F 'hl.dsp.focus({ window = "address:0xagent" })' "$dispatch_log" >/dev/nul
   fail "app focus falls back to the initial window title"
 
 pass "app focus finds terminals launched under a shared agent class"
+
+clients_json='[
+  {"address":"0xbrowser","class":"chromium","initialClass":"chromium","initialTitle":"Mail settings"}
+]'
+rm -f "$dispatch_log"
+if PATH="$mock_bin:$PATH" OMARCHY_TEST_CLIENTS_JSON="$clients_json" \
+  OMARCHY_TEST_FOCUS_DISPATCH="$dispatch_log" \
+  bash "$ROOT/bin/omarchy-hyprland-focus-app" Mail; then
+  fail "app focus rejects title matches from non-agent windows"
+fi
+
+[[ ! -e $dispatch_log ]] || fail "app focus leaves focus unchanged for unrelated title matches"
+
+pass "app focus restricts title matching to agent terminals"

--- a/test/shell.d/hyprland-focus-app-test.sh
+++ b/test/shell.d/hyprland-focus-app-test.sh
@@ -13,7 +13,7 @@ mkdir -p "$mock_bin"
 cat >"$mock_bin/hyprctl" <<'SH'
 #!/bin/bash
 if [[ $1 == "clients" ]]; then
-  printf '[{"address":"0xabc","class":"chromium"}]\n'
+  printf '%s\n' "$OMARCHY_TEST_CLIENTS_JSON"
 elif [[ $1 == "dispatch" ]]; then
   printf '%s\n' "$2" >"$OMARCHY_TEST_FOCUS_DISPATCH"
 fi
@@ -21,10 +21,25 @@ SH
 chmod +x "$mock_bin/hyprctl"
 
 dispatch_log="$test_tmp/dispatch"
-PATH="$mock_bin:$PATH" OMARCHY_TEST_FOCUS_DISPATCH="$dispatch_log" \
-  bash "$ROOT/bin/omarchy-hyprland-focus-app" chromium
+clients_json='[{"address":"0xabc","class":"chromium"}]'
+PATH="$mock_bin:$PATH" OMARCHY_TEST_CLIENTS_JSON="$clients_json" \
+  OMARCHY_TEST_FOCUS_DISPATCH="$dispatch_log" \
+  bash "$ROOT/bin/omarchy-hyprland-focus-app" '^chromium$'
 
 grep -F 'hl.dsp.focus({ window = "address:0xabc" })' "$dispatch_log" >/dev/null || \
   fail "app focus uses the workspace-aware Hyprland dispatcher"
 
 pass "app focus follows windows across workspaces"
+
+clients_json='[
+  {"address":"0xviber","class":"com.viber.Viber","initialClass":"com.viber.Viber","initialTitle":"Viber"},
+  {"address":"0xagent","class":"org.omarchy.agent","initialClass":"org.omarchy.agent","initialTitle":"kitty"}
+]'
+PATH="$mock_bin:$PATH" OMARCHY_TEST_CLIENTS_JSON="$clients_json" \
+  OMARCHY_TEST_FOCUS_DISPATCH="$dispatch_log" \
+  bash "$ROOT/bin/omarchy-hyprland-focus-app" kitty
+
+grep -F 'hl.dsp.focus({ window = "address:0xagent" })' "$dispatch_log" >/dev/null || \
+  fail "app focus falls back to the initial window title"
+
+pass "app focus finds terminals launched under a shared agent class"


### PR DESCRIPTION
## What changed

- Match every Hyprland client by current class first, then `initialClass`.
- Fall back to `initialTitle` only for clients identified as Omarchy agent terminals.
- Keep the existing regex and case-insensitive matching behavior.
- Add regression coverage for a `kitty` notification whose window uses Omarchy's shared `org.omarchy.agent` class while an unrelated Viber window is present.

## Why

Omarchy agent terminals deliberately share the window class `org.omarchy.agent`, but terminal notifications still identify their sender as `kitty`, `foot`, and so on. The focus helper searched only the current class, so clicking an agent notification found no target. After the popup disappeared, Hyprland's focus-follows-mouse behavior could focus the unrelated window underneath it, making that application appear to hijack notifications.

This was reproduced with Codex notifications and Viber and was also present on earlier Omarchy versions, so it is a persistent identity-resolution bug rather than a recent regression.

### Viber example

The concrete failure looked like Viber had registered itself as the handler for every desktop notification, but Viber was not involved in notification routing:

1. Codex finished a task and its terminal sent a notification with `app_name=kitty`.
2. The Codex terminal window was launched by Omarchy with `class=org.omarchy.agent`; only its `initialTitle` still said `kitty`.
3. Clicking the notification made Omarchy run `omarchy-hyprland-focus-app kitty`.
4. The helper searched only the current `class`, found no `kitty` window, and therefore focused nothing.
5. Omarchy dismissed the popup. The pointer was now over the Viber window behind that popup, so Hyprland's `follow_mouse=1` behavior focused Viber.

The result was repeatable: clicking a Codex notification brought Viber forward, making Viber look like the notification action target. MIME defaults, the notification service owner, and the notification action were all correct; Viber was simply the window exposed beneath the popup after Omarchy failed to resolve the real sender window.

Hyprland retains the terminal identity in `initialTitle`, so using that field specifically for `org.omarchy.agent` clients gives the notification fallback a valid target without treating arbitrary window titles as application identities.

## Validation

- `mise exec node@26.5.0 -- ./test/all` — all 171 shell test files passed, along with the CLI suite.
- Regression test: an unrelated Chromium window initially titled `Mail settings` is not selected for an app named `Mail`.
- Live Hyprland check: `./bin/omarchy-hyprland-focus-app kitty` focused the exact `org.omarchy.agent` client address.
- Manual Codex-style notification test: clicking an `app_name=kitty` notification returned focus to the Codex agent window and did not focus Viber.
