### PR TITLE
Detect captive portals and offer to sign in

### DIFF
--- a/bin/omarchy-network-portal
+++ b/bin/omarchy-network-portal
@@ -1,0 +1,287 @@
+#!/bin/bash
+
+# omarchy:summary=Detect a captive portal and open its sign-in page
+# omarchy:group=network
+# omarchy:args=[--check|--url|--open|--watch]
+# omarchy:examples=omarchy network portal | omarchy network portal --open
+
+set -uo pipefail
+
+# nf-md-web, escaped so this file reads without a Nerd Font.
+readonly PORTAL_GLYPH=$'\U000f059f'
+
+# Only used when NetworkManager reports no check URI of its own.
+readonly FALLBACK_CHECK_URI="http://ping.archlinux.org/nm-check.txt"
+
+# A portal answers on the first request, so a longer wait only stalls the panel.
+readonly CONNECT_TIMEOUT=2
+readonly PROBE_TIMEOUT=3
+
+# --watch collapses the burst of events one reconnect emits, then ticks slowly so
+# a state the burst raced past is still picked up.
+readonly WATCH_DEBOUNCE=${OMARCHY_PORTAL_DEBOUNCE_SECONDS:-2}
+readonly WATCH_TICK=${OMARCHY_PORTAL_TICK_SECONDS:-5}
+
+# What has already been announced, kept in the runtime dir so a restarted
+# watcher does not toast a portal twice. The toasts are critical, so they sit
+# there until dealt with and a duplicate would stack visibly. Cleared on logout,
+# which is the longest a portal is worth remembering.
+readonly announced_state=${OMARCHY_PORTAL_STATE_FILE:-${XDG_RUNTIME_DIR:-/tmp}/omarchy/network-portal-announced}
+
+portal_device=""
+portal_label=""
+last_checked=0
+
+# Every value read back from nmcli goes through here. LC_ALL=C because nmcli
+# translates state words such as "connected", and `-e no` so an SSID containing
+# ':' or '\' comes back verbatim.
+nm_get() {
+  LC_ALL=C nmcli -e no -g "$@" 2>/dev/null
+}
+
+nm_property() {
+  busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager \
+    org.freedesktop.NetworkManager "$1" 2>/dev/null
+}
+
+# NetworkManager's own connectivity check is what spots a portal, so there is
+# nothing to report when it is unavailable or switched off.
+connectivity_check_usable() {
+  [[ $(nm_property ConnectivityCheckAvailable) == "b true" ]] &&
+    [[ $(nm_property ConnectivityCheckEnabled) == "b true" ]]
+}
+
+check_uri() {
+  local uri
+  uri=$(nm_property ConnectivityCheckUri)
+  uri=${uri#s }
+  uri=${uri#\"}
+  uri=${uri%\"}
+
+  printf '%s\n' "${uri:-$FALLBACK_CHECK_URI}"
+}
+
+# Wi-Fi and ethernet only. A portal lives on the local link, while tunnels and
+# bridges routinely sit at "limited" forever -- probing those would stall every
+# poll on a machine running a VPN or docker.
+#
+# Sorted so a device NetworkManager already calls "portal" is settled before any
+# "limited" one costs a probe.
+portal_candidates() {
+  nm_get DEVICE,TYPE,STATE,IP4-CONNECTIVITY device status |
+    awk -F: '($2 == "wifi" || $2 == "ethernet") && $3 == "connected" &&
+             ($4 == "portal" || $4 == "limited") { print $1 "\t" $4 }' |
+    sort -r -t$'\t' -k2,2
+}
+
+connection_name() {
+  nm_get GENERAL.CONNECTION device show "$1"
+}
+
+gateway_for() {
+  nm_get IP4.GATEWAY device show "$1"
+}
+
+# Bound to the device on purpose: a phone tether or VPN can own the default route
+# while the portal sits on another link, so an unbound request sails straight
+# past the portal and calls the network fine.
+probe() {
+  local device=$1 url=$2
+
+  curl --interface "$device" --silent --include \
+    --connect-timeout "$CONNECT_TIMEOUT" --max-time "$PROBE_TIMEOUT" "$url" 2>/dev/null
+}
+
+redirect_from() {
+  awk 'tolower($0) ~ /^location:/ { sub(/^[^:]*: */, ""); sub(/\r$/, ""); print; exit }' <<<"$1"
+}
+
+# WISPr portals advertise a login endpoint in the body. It is a form target
+# rather than a page worth opening, so it only ever serves as proof of an
+# interception, never as the URL handed to the browser.
+has_wispr_payload() {
+  [[ $1 == *"<WISPAccessGatewayParam"* || $1 == *"<LoginURL>"* ]]
+}
+
+# NetworkManager already proved the portal when it says "portal". A "limited"
+# device only counts once a probe sees an actual interception, which stops a
+# merely broken network -- or a router serving its own admin page -- from
+# claiming one.
+portal_confirmed() {
+  local device=$1 state=$2 response gateway
+
+  [[ $state == "portal" ]] && return 0
+
+  response=$(probe "$device" "$(check_uri)")
+  [[ -n $(redirect_from "$response") ]] && return 0
+  has_wispr_payload "$response" && return 0
+
+  gateway=$(gateway_for "$device")
+  [[ -n $gateway ]] || return 1
+
+  response=$(probe "$device" "http://$gateway")
+  [[ -n $(redirect_from "$response") ]]
+}
+
+# Sets portal_device and portal_label for the first intercepted link.
+find_portal() {
+  local device state
+
+  connectivity_check_usable || return 1
+
+  while IFS=$'\t' read -r device state; do
+    [[ -n $device ]] || continue
+    if portal_confirmed "$device" "$state"; then
+      portal_device=$device
+      portal_label=$(connection_name "$device")
+      return 0
+    fi
+  done < <(portal_candidates)
+
+  return 1
+}
+
+# The splash page a redirect points at is what a human signs in on. The gateway
+# is the fallback for a portal that intercepts without redirecting, which is
+# also the only thing left to try once pinned DNS stops the check URI resolving.
+login_url_for() {
+  local device=$1 response url gateway
+
+  response=$(probe "$device" "$(check_uri)")
+  url=$(redirect_from "$response")
+  if [[ -n $url ]]; then
+    printf '%s\n' "$url"
+    return 0
+  fi
+
+  gateway=$(gateway_for "$device")
+  [[ -n $gateway ]] || return 1
+
+  response=$(probe "$device" "http://$gateway")
+  url=$(redirect_from "$response")
+
+  printf '%s\n' "${url:-http://$gateway}"
+}
+
+# NetworkManager only re-checks connectivity every few minutes, so signing in
+# would otherwise leave the panel row and the bar icon stale. Backgrounded
+# because the answer is wanted on the next poll, not this one.
+request_recheck() {
+  nmcli networking connectivity check >/dev/null 2>&1 &
+}
+
+print_status() {
+  if ! find_portal; then
+    printf 'state\tnone\n'
+    return 0
+  fi
+
+  printf 'state\tportal\n'
+  printf 'device\t%s\n' "$portal_device"
+  printf 'label\t%s\n' "$portal_label"
+
+  request_recheck
+}
+
+print_url() {
+  find_portal || return 1
+  login_url_for "$portal_device"
+}
+
+open_portal() {
+  local url
+
+  url=$(print_url) || {
+    echo "Error: no captive portal detected." >&2
+    return 1
+  }
+
+  omarchy-launch-browser "$url"
+  request_recheck
+}
+
+read_announced() {
+  [[ -r $announced_state ]] && cat "$announced_state" 2>/dev/null
+}
+
+write_announced() {
+  mkdir -p "$(dirname "$announced_state")" 2>/dev/null || return 0
+  printf '%s\n' "$1" >"$announced_state" 2>/dev/null || true
+}
+
+announce_portal() {
+  local now=$EPOCHSECONDS
+
+  ((now - last_checked < WATCH_DEBOUNCE)) && return 0
+  last_checked=$now
+
+  if ! find_portal; then
+    # Cleared so rejoining the same network announces itself again.
+    rm -f "$announced_state" 2>/dev/null || true
+    return 0
+  fi
+
+  [[ "$portal_device/$portal_label" == "$(read_announced)" ]] && return 0
+
+  # The shell owns org.freedesktop.Notifications, so a toast sent while it is
+  # restarting is lost. Only a delivered one counts as announced.
+  omarchy-notification-wait || return 1
+
+  omarchy-notification-send \
+    --urgency critical \
+    --glyph "$PORTAL_GLYPH" \
+    --exec "omarchy-network-portal --open" \
+    "Sign in to $portal_label" \
+    "This network requires sign-in. Click to open the login page." &&
+    write_announced "$portal_device/$portal_label"
+}
+
+# nmcli monitor prints a line on every connectivity and device change, so a
+# portal joined mid-session is announced without polling for it.
+watch_portals() {
+  local status
+
+  announce_portal
+
+  nmcli monitor 2>/dev/null | while :; do
+    read -r -t "$WATCH_TICK" _
+    status=$?
+    # Only end-of-input means the monitor is gone; systemd restarts us to
+    # reattach. A read timeout is the slow tick and must keep the loop alive.
+    ((status == 0 || status > 128)) || break
+    announce_portal
+  done
+}
+
+usage() {
+  echo "Usage: omarchy-network-portal [--check|--url|--open|--watch]" >&2
+}
+
+if (($# == 0)); then
+  print_status
+  exit 0
+fi
+
+if (($# > 1)); then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  --check)
+    find_portal
+    ;;
+  --url)
+    print_url
+    ;;
+  --open)
+    open_portal
+    ;;
+  --watch)
+    watch_portals
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/default/systemd/user/omarchy-network-portal-watch.service
+++ b/default/systemd/user/omarchy-network-portal-watch.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Announce networks that need a captive portal sign-in
+# Needs the session bus to notify and the default browser to open the login
+# page, both up only after graphical-session.target, plus the bus NetworkManager
+# reports connectivity on.
+After=graphical-session.target dbus.socket
+Requires=dbus.socket
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-network-portal --watch
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-network-portal-watch.service

--- a/install/user/first-run/wifi.sh
+++ b/install/user/first-run/wifi.sh
@@ -31,6 +31,10 @@ announce_network() {
   # the wait gets the same hour-long budget as the link above.
   portal_waited=0
   while omarchy-network-portal --check; do
+    # The portal can sit on one link while another -- a phone tether, say --
+    # carries traffic, and then the update works right now. Machine-wide
+    # connectivity is the maximum across devices, so "full" means a link gets out.
+    if [[ $(LC_ALL=C nmcli networking connectivity) == "full" ]]; then break; fi
     if ((portal_waited >= 3600)); then return; fi
     sleep 30
     ((portal_waited += 30))

--- a/install/user/first-run/wifi.sh
+++ b/install/user/first-run/wifi.sh
@@ -25,10 +25,16 @@ announce_network() {
 
   # A captive portal answers DHCP and passes nm-online while still blocking the
   # mirrors, so prompting for an update here would only hand the user a failed
-  # one. omarchy-network-portal-watch.service is already asking them to sign in.
-  if omarchy-network-portal --check; then
-    return
-  fi
+  # one. Hold the prompt until sign-in lands rather than dropping it: first run
+  # happens once, so returning here would cost this user the prompt for good.
+  # omarchy-network-portal-watch.service is already asking them to sign in, and
+  # the wait gets the same hour-long budget as the link above.
+  portal_waited=0
+  while omarchy-network-portal --check; do
+    if ((portal_waited >= 3600)); then return; fi
+    sleep 30
+    ((portal_waited += 30))
+  done
 
   notify_update
 }

--- a/install/user/first-run/wifi.sh
+++ b/install/user/first-run/wifi.sh
@@ -23,6 +23,13 @@ announce_network() {
     nm-online -q -t 3600 || return
   fi
 
+  # A captive portal answers DHCP and passes nm-online while still blocking the
+  # mirrors, so prompting for an update here would only hand the user a failed
+  # one. omarchy-network-portal-watch.service is already asking them to sign in.
+  if omarchy-network-portal --check; then
+    return
+  fi
+
   notify_update
 }
 

--- a/migrations/1786624519.sh
+++ b/migrations/1786624519.sh
@@ -1,0 +1,21 @@
+echo "Announce networks that need a captive portal sign-in"
+
+# install/user/first-run/enable-user-units.sh is skipped after the first login,
+# so existing installs need the unit enabled here.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# `systemctl enable` needs a live user manager, which an update from a TTY does
+# not have, so fall back to writing the symlink it would have written.
+if ! systemctl --user enable omarchy-network-portal-watch.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-network-portal-watch.service \
+    "$wants_dir/omarchy-network-portal-watch.service"
+fi
+
+# Nothing to start into over SSH; the next graphical login handles it. A failed
+# start only delays portal toasts, so it stays quiet.
+if systemctl --user is-active --quiet graphical-session.target; then
+  systemctl --user start omarchy-network-portal-watch.service >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -141,6 +141,7 @@ package_defaults = [
   ("default/systemd/user/omarchy-tailscale-receive.service", "/usr/lib/systemd/user/omarchy-tailscale-receive.service", "systemd/user/omarchy-tailscale-receive.service"),
   ("default/systemd/user/omarchy-fcitx5.service", "/usr/lib/systemd/user/omarchy-fcitx5.service", "systemd/user/omarchy-fcitx5.service"),
   ("default/systemd/user/omarchy-crash-watch.service", "/usr/lib/systemd/user/omarchy-crash-watch.service", "systemd/user/omarchy-crash-watch.service"),
+  ("default/systemd/user/omarchy-network-portal-watch.service", "/usr/lib/systemd/user/omarchy-network-portal-watch.service", "systemd/user/omarchy-network-portal-watch.service"),
   ("default/systemd/zram-generator.conf.d/90-omarchy.conf", "/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf", "systemd/zram-generator.conf.d/90-omarchy.conf"),
   ("default/fonts/omarchy/omarchy.ttf", "/usr/share/fonts/omarchy/omarchy.ttf", "omarchy.ttf"),
   ("default/snapper/root", "/etc/snapper/config-templates/omarchy", "snapper/root"),

--- a/test/shell.d/network-portal-test.sh
+++ b/test/shell.d/network-portal-test.sh
@@ -21,6 +21,15 @@ assert(
   /notify_update/.test(announce[0].split('while omarchy-network-portal --check; do')[1] || ''),
   'first run still reaches the update prompt once the portal clears'
 )
+
+// A tether at full connectivity can carry the update while the portal on
+// another link waits, so the loop must yield to the machine-wide answer
+// instead of holding the prompt for its full hour.
+const portalWait = announce[0].split('while omarchy-network-portal --check; do')[1] || ''
+assert(
+  /if \[\[ \$\(LC_ALL=C nmcli networking connectivity\) == "full" \]\]; then break; fi/.test(portalWait),
+  'first run releases the update prompt when another link has full connectivity'
+)
 JS
 
 # The command talks to nmcli, busctl and curl, so the stubs below stand in for

--- a/test/shell.d/network-portal-test.sh
+++ b/test/shell.d/network-portal-test.sh
@@ -4,6 +4,25 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+run_node_test <<'JS'
+const fs = require('fs')
+
+// First run happens once per user, so the update prompt behind a portal has to
+// be deferred rather than dropped -- an early return costs that user the prompt
+// permanently, even after they sign in.
+const firstRunWifi = fs.readFileSync(root + '/install/user/first-run/wifi.sh', 'utf8')
+const announce = firstRunWifi.match(/announce_network\(\) \{[\s\S]*?\n\}/)
+assert(announce, 'first-run wifi has an announce_network function')
+assert(
+  /while omarchy-network-portal --check; do/.test(announce[0]),
+  'first run waits out a captive portal instead of abandoning the update prompt'
+)
+assert(
+  /notify_update/.test(announce[0].split('while omarchy-network-portal --check; do')[1] || ''),
+  'first run still reaches the update prompt once the portal clears'
+)
+JS
+
 # The command talks to nmcli, busctl and curl, so the stubs below stand in for
 # all three. That makes the interesting cases -- which the live network cannot be
 # put into on demand -- reachable from the suite.

--- a/test/shell.d/network-portal-test.sh
+++ b/test/shell.d/network-portal-test.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The command talks to nmcli, busctl and curl, so the stubs below stand in for
+# all three. That makes the interesting cases -- which the live network cannot be
+# put into on demand -- reachable from the suite.
+stub_dir=$(mktemp -d)
+trap 'rm -rf "$stub_dir"' EXIT
+
+cat >"$stub_dir/busctl" <<'STUB'
+#!/bin/bash
+case "$*" in
+  *ConnectivityCheckAvailable*) echo "b ${STUB_CHECK_AVAILABLE:-true}" ;;
+  *ConnectivityCheckEnabled*) echo "b ${STUB_CHECK_ENABLED:-true}" ;;
+  *ConnectivityCheckUri*) echo 's "http://check.invalid/nm-check.txt"' ;;
+esac
+STUB
+
+# Answers the aggregate connectivity question with "full" on purpose: reading it
+# is the mistake this whole command exists to avoid, so anything that consults it
+# should come out of the suite looking online.
+cat >"$stub_dir/nmcli" <<'STUB'
+#!/bin/bash
+case "$*" in
+  *"DEVICE,TYPE,STATE,IP4-CONNECTIVITY device status"*) printf '%s\n' "$STUB_DEVICES" ;;
+  *"GENERAL.CONNECTION device show"*) echo "${STUB_LABEL:-Some Network}" ;;
+  *"IP4.GATEWAY device show"*) echo "${STUB_GATEWAY:-}" ;;
+  *"networking connectivity"*) echo "full" ;;
+esac
+STUB
+
+# Counts probes as well as answering them: a portal NetworkManager already
+# identified must cost none at all.
+cat >"$stub_dir/curl" <<'STUB'
+#!/bin/bash
+echo probe >>"$STUB_PROBE_LOG"
+[[ -n ${STUB_RESPONSE:-} ]] || exit 7
+printf '%s' "$STUB_RESPONSE"
+STUB
+
+cat >"$stub_dir/omarchy-launch-browser" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$1" >>"$STUB_BROWSER_LOG"
+STUB
+
+chmod +x "$stub_dir"/*
+
+export STUB_PROBE_LOG="$stub_dir/probes"
+export STUB_BROWSER_LOG="$stub_dir/browser"
+: >"$STUB_PROBE_LOG"
+: >"$STUB_BROWSER_LOG"
+
+portal="$ROOT/bin/omarchy-network-portal"
+
+run_portal() {
+  local mode=${1:-}
+  : >"$STUB_PROBE_LOG"
+  if [[ -n $mode ]]; then
+    PATH="$stub_dir:$PATH" "$portal" "$mode"
+  else
+    PATH="$stub_dir:$PATH" "$portal"
+  fi
+}
+
+probe_count() {
+  wc -l <"$STUB_PROBE_LOG" | tr -d ' '
+}
+
+# The case that matters most: a phone tether at "full" makes NetworkManager's
+# aggregate connectivity read "full" while the Wi-Fi behind it is intercepted.
+# Reading the manager-level property instead of the per-device one reports this
+# machine as online.
+export STUB_DEVICES='enu1:ethernet:connected:full
+wlan0:wifi:connected:portal
+tailscale0:tun:connected (externally):limited
+docker0:bridge:connected (externally):none'
+export STUB_LABEL='@Hyatt_Wifi'
+export STUB_GATEWAY='172.20.0.1'
+unset STUB_RESPONSE
+
+status=$(run_portal)
+[[ $status == *"state	portal"* ]] || fail "reports a portal when a full-connectivity device masks it" "$status"
+[[ $status == *"device	wlan0"* ]] || fail "names the intercepted device, not the one with a working route" "$status"
+[[ $status == *"label	@Hyatt_Wifi"* ]] || fail "reports the intercepted connection's name" "$status"
+pass "portal status survives a tether that reports full connectivity"
+
+run_portal >/dev/null
+[[ $(probe_count) == 0 ]] || fail "settles a known portal without probing" "probes: $(probe_count)"
+pass "a device NetworkManager already calls portal costs no probe"
+
+# Ordering, asserted by cost. The limited device is listed first and is a real
+# ethernet link, so it survives the type filter -- only sorting the known portal
+# ahead of it keeps its probe from being paid for on every poll.
+export STUB_DEVICES='enu1:ethernet:connected:limited
+wlan0:wifi:connected:portal'
+status=$(run_portal)
+[[ $status == *"device	wlan0"* ]] || fail "prefers the known portal over a merely limited device" "$status"
+[[ $(probe_count) == 0 ]] || fail "does not probe a limited device when a known portal is available" "probes: $(probe_count)"
+pass "a known portal is settled before a limited device costs a probe"
+
+export STUB_DEVICES='enu1:ethernet:connected:full
+wlan0:wifi:connected:portal
+tailscale0:tun:connected (externally):limited
+docker0:bridge:connected (externally):none'
+
+if ! run_portal --check >/dev/null; then
+  fail "--check exits 0 while a portal is present"
+fi
+pass "--check exits 0 while a portal is present"
+
+# Tunnels and bridges sit at limited or none indefinitely, so they must never be
+# probed or reported.
+export STUB_DEVICES='tailscale0:tun:connected (externally):limited
+docker0:bridge:connected (externally):none
+lo:loopback:connected (externally):unknown'
+status=$(run_portal)
+[[ $status == *"state	none"* ]] || fail "ignores tunnels, bridges and loopback" "$status"
+[[ $(probe_count) == 0 ]] || fail "never probes a tunnel or bridge" "probes: $(probe_count)"
+pass "non-physical devices are neither probed nor reported"
+
+if run_portal --check >/dev/null; then
+  fail "--check exits non-zero with no portal"
+fi
+pass "--check exits non-zero with no portal"
+
+# A "limited" device is only a portal once a probe sees an interception. A router
+# serving its own page, or a plainly broken uplink, must not be called one.
+export STUB_DEVICES='wlan0:wifi:connected:limited'
+export STUB_RESPONSE='HTTP/1.1 200 OK
+Content-Type: text/html
+
+<html><body>Router admin</body></html>'
+status=$(run_portal)
+[[ $status == *"state	none"* ]] || fail "does not call a limited device a portal without an interception" "$status"
+pass "a limited device serving an ordinary page is not a portal"
+
+# Pinned DNS keeps NetworkManager's check from resolving, so an intercepted
+# network lands at "limited" rather than "portal". The redirect is what proves it.
+export STUB_RESPONSE='HTTP/1.0 302 RD
+Location: https://splash.skyadmin.io?UI=0a95dc
+
+'
+status=$(run_portal)
+[[ $status == *"state	portal"* ]] || fail "confirms a limited device that redirects" "$status"
+pass "a limited device that redirects is reported as a portal"
+
+url=$(run_portal --url)
+[[ $url == "https://splash.skyadmin.io?UI=0a95dc" ]] || fail "--url returns the splash page from the redirect" "$url"
+pass "--url returns the splash page a redirect points at"
+
+# WISPr proves an interception, but its LoginURL is a form endpoint rather than a
+# page worth opening, so the browser must not be sent there.
+export STUB_RESPONSE='HTTP/1.1 200 OK
+
+<WISPAccessGatewayParam><Redirect><LoginURL>https://ssl.certificate.com:1112/usg/process</LoginURL></Redirect></WISPAccessGatewayParam>'
+status=$(run_portal)
+[[ $status == *"state	portal"* ]] || fail "treats a WISPr payload as an interception" "$status"
+url=$(run_portal --url)
+[[ $url != *"ssl.certificate.com"* ]] || fail "--url must not hand the WISPr form endpoint to a browser" "$url"
+[[ $url == "http://172.20.0.1" ]] || fail "--url falls back to the gateway when nothing redirects" "$url"
+pass "a WISPr payload counts as a portal without becoming the browser target"
+
+: >"$STUB_BROWSER_LOG"
+run_portal --open >/dev/null
+[[ $(cat "$STUB_BROWSER_LOG") == "http://172.20.0.1" ]] || fail "--open hands the resolved URL to the default browser" "$(cat "$STUB_BROWSER_LOG")"
+pass "--open opens the resolved URL in the default browser"
+
+# Without NetworkManager's connectivity check there is no portal signal to read,
+# so the command has to stay quiet rather than probe every device itself.
+export STUB_DEVICES='wlan0:wifi:connected:portal'
+STUB_CHECK_ENABLED=false status=$(STUB_CHECK_ENABLED=false run_portal)
+[[ $status == *"state	none"* ]] || fail "stays quiet when connectivity checking is disabled" "$status"
+pass "a disabled connectivity check reports no portal"
+
+STUB_CHECK_AVAILABLE=false status=$(STUB_CHECK_AVAILABLE=false run_portal)
+[[ $status == *"state	none"* ]] || fail "stays quiet when connectivity checking is unavailable" "$status"
+pass "an unavailable connectivity check reports no portal"
+
+# --watch, driven by a finite stand-in for `nmcli monitor`. The toasts are
+# critical, so they stay on screen until dealt with and every duplicate stacks
+# visibly -- worth pinning without depending on a live desktop.
+cat >"$stub_dir/omarchy-notification-wait" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+cat >"$stub_dir/omarchy-notification-send" <<'STUB'
+#!/bin/bash
+printf '%s\n' "${*: -2:1}" >>"$STUB_NOTIFY_LOG"
+STUB
+
+# The monitor stand-in emits several lines and exits, which ends the watch loop
+# the same way a NetworkManager restart would.
+cat >"$stub_dir/nmcli" <<'STUB'
+#!/bin/bash
+case "$*" in
+  monitor) printf 'wlan0: connected\nwlan0: connectivity is now portal\nwlan0: update\n' ;;
+  *"DEVICE,TYPE,STATE,IP4-CONNECTIVITY device status"*) printf '%s\n' "$STUB_DEVICES" ;;
+  *"GENERAL.CONNECTION device show"*) echo "${STUB_LABEL:-Some Network}" ;;
+  *"IP4.GATEWAY device show"*) echo "${STUB_GATEWAY:-}" ;;
+  *"networking connectivity"*) echo "full" ;;
+esac
+STUB
+chmod +x "$stub_dir"/omarchy-notification-wait "$stub_dir"/omarchy-notification-send "$stub_dir"/nmcli
+
+export STUB_NOTIFY_LOG="$stub_dir/notifications"
+announced_state="$stub_dir/announced"
+
+run_watch() {
+  : >"$STUB_NOTIFY_LOG"
+  OMARCHY_PORTAL_DEBOUNCE_SECONDS=0 OMARCHY_PORTAL_TICK_SECONDS=1 \
+    OMARCHY_PORTAL_STATE_FILE="$announced_state" \
+    PATH="$stub_dir:$PATH" timeout 10 "$portal" --watch >/dev/null 2>&1 || true
+}
+
+notify_count() {
+  wc -l <"$STUB_NOTIFY_LOG" | tr -d ' '
+}
+
+export STUB_DEVICES='enu1:ethernet:connected:full
+wlan0:wifi:connected:portal'
+rm -f "$announced_state"
+
+run_watch
+[[ $(notify_count) == 1 ]] || fail "announces a portal once across a burst of events" "notifications: $(notify_count)"
+[[ $(cat "$STUB_NOTIFY_LOG") == "Sign in to @Hyatt_Wifi" ]] || fail "names the network in the toast" "$(cat "$STUB_NOTIFY_LOG")"
+pass "a burst of connectivity events yields one toast"
+
+# A restarted watcher -- systemd sets Restart=always, and the loop ends whenever
+# NetworkManager goes away -- must not toast the same portal again.
+run_watch
+[[ $(notify_count) == 0 ]] || fail "does not re-announce the same portal after a restart" "notifications: $(notify_count)"
+pass "a restarted watcher does not stack a duplicate toast"
+
+# Signing in clears the state, so the next portal is announced again.
+export STUB_DEVICES='enu1:ethernet:connected:full'
+run_watch
+[[ $(notify_count) == 0 ]] || fail "says nothing once the portal is gone" "notifications: $(notify_count)"
+[[ -e $announced_state ]] && fail "clears the announced marker once the portal is gone"
+pass "a cleared portal forgets what it announced"
+
+export STUB_DEVICES='enu1:ethernet:connected:full
+wlan0:wifi:connected:portal'
+run_watch
+[[ $(notify_count) == 1 ]] || fail "announces again after rejoining a portal network" "notifications: $(notify_count)"
+pass "rejoining a portal network announces it again"


### PR DESCRIPTION
Joining a network behind a captive portal leaves Omarchy silently half-connected: DHCP succeeds, the bar shows a normal Wi-Fi icon, and nothing on the desktop explains why traffic goes nowhere.

Since this PR was opened, 41a40ccc landed the panel half of that — status, sign-in action and keyboard route, driven by NetworkManager's own connectivity state. **I've rebased onto `quattro` and dropped my panel changes entirely**; `Panel.qml` and `Model.js` are now byte-identical to `quattro`. That approach is the better one, and the comment it added ("consume its native notifications rather than running a second curl loop") is right.

What is left is the part the panel cannot cover: **you have to open the panel to see any of it.** This adds a session watcher that tells you, once per intercepted network, without you going looking.

<img width="898" alt="Desktop notification reading: Sign in to Guest_WiFi. This network requires sign-in. Click to open the login page." src="https://github.com/user-attachments/assets/48483511-7483-40df-8b6c-738d9b615fcd" />

SSID is a placeholder.

`omarchy-network-portal` backs it, and is useful on its own — `--check` for scripts, `--url` for the resolved splash page, `--open` to sign in.

Two details worth calling out:

- Detection reads **per-device** `IP4-CONNECTIVITY`, not the manager-level `Connectivity` property. That property is the maximum across devices, so with a phone tether up it reads `full` while the Wi-Fi behind it sits at `portal`. Probes are bound to the device for the same reason — the default route may belong to a different link entirely.
- A device at `limited` is only called a portal once a probe actually sees an interception. That keeps a merely broken uplink, or a router serving its own admin page, from producing a bogus prompt. It also matters because `omarchy-dns` can pin DNS system-wide, which makes an intercepted network report `limited` instead of `portal`.

The other half is first run: a portal answers DHCP and passes `nm-online`, so the update prompt fired behind one and handed the user a failed update. First run happens once per user, so it waits the portal out on the same hour-long budget the link wait above it already uses rather than returning early and costing that user the prompt for good. The wait yields to machine-wide connectivity — that property is the maximum across devices, so a `full` reading means some link gets out and the update can run now even while another sits behind a portal.

Verified end to end against a real hotel portal: detected while a USB tether masked it, the toast named the network, and clicking it opened the splash page in the default browser.

**Packaging prerequisite:** `omarchy-settings` installs systemd user units explicitly, so `omarchy-pkgs` needs one line (omacom/omarchy-pkgs#147) — without it `enable-user-units.sh` aborts first-run under `set -euo pipefail` rather than just skipping the watcher:

```
install -Dm644 default/systemd/user/omarchy-network-portal-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-network-portal-watch.service"
```

`test/shell.d/config-test.sh` fails until that lands, by design — it pins the requirement the same way every other shipped unit is pinned.

## Test plan

- [x] `./test/cli && ./test/shell`
- [x] `test/shell.d/network-captive-portal-test.sh` still passes — the panel is untouched by this branch
- [x] Join a captive-portal network — toast names it, clicking opens the login page in the default browser
- [x] Sign in — the toast does not reappear
- [x] With a second link up (tether or ethernet) reporting `full`, the portal is still detected
- [ ] With `omarchy dns Cloudflare` set, a portal network is still detected
