### PR TITLE
Avoid Cursor Agent CPU loops during theme changes

### DIFF
--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -150,4 +150,4 @@ set_theme() {
 ! omarchy-toggle-enabled skip-vscode-theme-changes && set_theme "code" "$HOME/.config/Code/User/settings.json" "$HOME/.vscode/extensions"
 ! omarchy-toggle-enabled skip-vscode-insiders-theme-changes && set_theme "code-insiders" "$HOME/.config/Code - Insiders/User/settings.json" "$HOME/.vscode-insiders/extensions"
 ! omarchy-toggle-enabled skip-codium-theme-changes && set_theme "codium" "$HOME/.config/VSCodium/User/settings.json" "$HOME/.vscode-oss/extensions"
-! omarchy-toggle-enabled skip-cursor-theme-changes && set_theme "cursor" "$HOME/.config/Cursor/User/settings.json" "$HOME/.cursor/extensions"
+! omarchy-toggle-enabled skip-cursor-theme-changes && set_theme "/usr/bin/cursor" "$HOME/.config/Cursor/User/settings.json" "$HOME/.cursor/extensions"

--- a/test/shell.d/vscode-theme-test.sh
+++ b/test/shell.d/vscode-theme-test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+FAKE_BIN="$TEST_HOME/bin"
+CURRENT_THEME="$TEST_HOME/.local/state/omarchy/current/theme"
+mkdir -p "$FAKE_BIN" "$CURRENT_THEME"
+
+cat >"$FAKE_BIN/omarchy-cmd-present" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$1" >>"$EDITOR_PROBE_LOG"
+exit 1
+EOF
+
+cat >"$FAKE_BIN/omarchy-toggle-enabled" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
+cat >"$FAKE_BIN/cursor" <<'EOF'
+#!/bin/bash
+touch "$CURSOR_SHIM_CALLED"
+exit 1
+EOF
+
+chmod +x "$FAKE_BIN"/*
+printf '{"name":"Hackerman","extension":"akamud.vscode-theme-onedark"}\n' >"$CURRENT_THEME/vscode.json"
+
+EDITOR_PROBE_LOG="$TEST_HOME/editor-probes.log" \
+  CURSOR_SHIM_CALLED="$TEST_HOME/cursor-shim-called" \
+  PATH="$FAKE_BIN:$ROOT/bin:$PATH" \
+  HOME="$TEST_HOME" \
+  "$ROOT/bin/omarchy-theme-set-vscode"
+
+grep -Fxq '/usr/bin/cursor' "$TEST_HOME/editor-probes.log" || fail "VS Code theme sync probes the packaged Cursor executable"
+[[ ! -e $TEST_HOME/cursor-shim-called ]] || fail "VS Code theme sync ignores a PATH-provided Cursor Agent shim"
+[[ ! -e $TEST_HOME/.config/Cursor/User/settings.json ]] || fail "VS Code theme sync skips Cursor when the packaged executable is unavailable"
+pass "VS Code theme sync selects the packaged Cursor executable"


### PR DESCRIPTION
Changing themes can start a recursive `cursor --list-extensions` process when Cursor Agent is installed but Cursor IDE is not, consuming a CPU core indefinitely. This change only synchronizes Cursor themes when the explicitly installed Cursor IDE executable is present; it does not install Cursor.

## What changed

- select Cursor IDE through its packaged `/usr/bin/cursor` executable during theme sync
- ignore PATH-provided commands such as the Cursor Agent compatibility shim
- cover Cursor command shadowing with a focused shell regression test

## Why

Cursor Agent installs a `cursor` compatibility shim even when Cursor IDE is not installed. With equivalent spellings of `~/.local/bin` in `PATH`, that shim can recursively execute itself when Omarchy runs `cursor --list-extensions`, consuming a CPU core indefinitely after each theme change.

This is the behavior previously reported in #3086. Omarchy installs Cursor IDE through `cursor-bin`, which provides `/usr/bin/cursor`, so selecting that executable directly distinguishes an existing supported IDE installation from the Agent shim without adding delay, changing the other VS Code-derived editors, or installing Cursor.

## Testing

- `./test/shell.d/vscode-theme-test.sh` — passes; confirms a PATH-provided Cursor Agent shim is ignored
- `./test/shell` — the new test passes; the existing `test/shell.d/config-test.sh` package-contract check fails on the current `quattro` baseline
