### PR TITLE
Make terminal applications follow Omarchy themes

### DIFF
--- a/bin/omarchy-theme-set-codex
+++ b/bin/omarchy-theme-set-codex
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# omarchy:summary=Configure Codex to use terminal palette colors
+# omarchy:args=[--activate]
+# omarchy:hidden=true
+
+set -euo pipefail
+
+CODEX_CONFIG_DIR="${CODEX_HOME:-$HOME/.codex}"
+CODEX_CONFIG_PATH="${CODEX_CONFIG_PATH:-$CODEX_CONFIG_DIR/config.toml}"
+CODEX_ACTIVATE=0
+
+usage() {
+  echo "Usage: omarchy-theme-set-codex [--activate]"
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --activate)
+      CODEX_ACTIVATE=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Activation is deliberately separate from normal theme switches. Once Codex
+# uses its built-in ANSI theme, the terminal palette follows Omarchy without
+# repeatedly overwriting a later theme selected with Codex's /theme command.
+(( CODEX_ACTIVATE == 1 )) || exit 0
+
+mkdir -p "$(dirname "$CODEX_CONFIG_PATH")"
+
+if [[ ! -f $CODEX_CONFIG_PATH ]]; then
+  printf '[tui]\ntheme = "ansi"\n' >"$CODEX_CONFIG_PATH"
+  exit 0
+fi
+
+tmp=$(mktemp)
+awk '
+  function section(line) {
+    return line ~ /^[[:space:]]*\[[^][]+\][[:space:]]*(#.*)?$/
+  }
+
+  function tui_section(line) {
+    return line ~ /^[[:space:]]*\[tui\][[:space:]]*(#.*)?$/
+  }
+
+  function add_theme_if_missing() {
+    if (in_tui && !wrote_theme) {
+      print "theme = \"ansi\""
+      wrote_theme = 1
+    }
+  }
+
+  BEGIN { at_root = 1 }
+
+  at_root && /^[[:space:]]*tui\.theme[[:space:]]*=/ {
+    print "tui.theme = \"ansi\""
+    saw_tui = 1
+    wrote_theme = 1
+    next
+  }
+
+  section($0) {
+    add_theme_if_missing()
+    at_root = 0
+    in_tui = tui_section($0)
+    if (in_tui) {
+      saw_tui = 1
+      wrote_theme = 0
+    }
+    print
+    next
+  }
+
+  in_tui && /^[[:space:]]*theme[[:space:]]*=/ {
+    if (!wrote_theme) {
+      print "theme = \"ansi\""
+      wrote_theme = 1
+    }
+    next
+  }
+
+  { print }
+
+  END {
+    add_theme_if_missing()
+    if (!saw_tui) {
+      if (NR) print ""
+      print "[tui]"
+      print "theme = \"ansi\""
+    }
+  }
+' "$CODEX_CONFIG_PATH" >"$tmp"
+
+if ! cmp -s "$tmp" "$CODEX_CONFIG_PATH"; then
+  # Write through the path so dotfile symlinks remain intact.
+  cat "$tmp" >"$CODEX_CONFIG_PATH"
+fi
+rm -f "$tmp"

--- a/bin/omarchy-theme-set-grok
+++ b/bin/omarchy-theme-set-grok
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# omarchy:summary=Configure Grok to use terminal palette colors
+# omarchy:args=[--activate]
+# omarchy:hidden=true
+
+set -euo pipefail
+
+GROK_CONFIG_DIR="${GROK_CONFIG_DIR:-$HOME/.grok}"
+GROK_CONFIG_PATH="${GROK_CONFIG_PATH:-$GROK_CONFIG_DIR/config.toml}"
+GROK_ACTIVATE=0
+
+usage() {
+  echo "Usage: omarchy-theme-set-grok [--activate]"
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --activate)
+      GROK_ACTIVATE=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Grok's "minimal" color theme is independent of its screen mode and renders
+# with the terminal palette. Activate it once, then let later user choices win.
+(( GROK_ACTIVATE == 1 )) || exit 0
+
+mkdir -p "$(dirname "$GROK_CONFIG_PATH")"
+
+if [[ ! -f $GROK_CONFIG_PATH ]]; then
+  printf '[ui]\ntheme = "minimal"\n' >"$GROK_CONFIG_PATH"
+  exit 0
+fi
+
+tmp=$(mktemp)
+awk '
+  function section(line) {
+    return line ~ /^[[:space:]]*\[[^][]+\][[:space:]]*(#.*)?$/
+  }
+
+  function ui_section(line) {
+    return line ~ /^[[:space:]]*\[ui\][[:space:]]*(#.*)?$/
+  }
+
+  function add_theme_if_missing() {
+    if (in_ui && !wrote_theme) {
+      print "theme = \"minimal\""
+      wrote_theme = 1
+    }
+  }
+
+  BEGIN { at_root = 1 }
+
+  at_root && /^[[:space:]]*ui\.theme[[:space:]]*=/ {
+    print "ui.theme = \"minimal\""
+    saw_ui = 1
+    wrote_theme = 1
+    next
+  }
+
+  section($0) {
+    add_theme_if_missing()
+    at_root = 0
+    in_ui = ui_section($0)
+    if (in_ui) {
+      saw_ui = 1
+      wrote_theme = 0
+    }
+    print
+    next
+  }
+
+  in_ui && /^[[:space:]]*theme[[:space:]]*=/ {
+    if (!wrote_theme) {
+      print "theme = \"minimal\""
+      wrote_theme = 1
+    }
+    next
+  }
+
+  { print }
+
+  END {
+    add_theme_if_missing()
+    if (!saw_ui) {
+      if (NR) print ""
+      print "[ui]"
+      print "theme = \"minimal\""
+    }
+  }
+' "$GROK_CONFIG_PATH" >"$tmp"
+
+if ! cmp -s "$tmp" "$GROK_CONFIG_PATH"; then
+  # Write through the path so dotfile symlinks remain intact.
+  cat "$tmp" >"$GROK_CONFIG_PATH"
+fi
+rm -f "$tmp"

--- a/install/user/theme.sh
+++ b/install/user/theme.sh
@@ -10,7 +10,13 @@ if [[ ! -s $HOME/.local/state/omarchy/current/theme.name ]]; then
     omarchy-theme-set "Tokyo Night"
   fi
 fi
+
+# Terminal applications follow Omarchy by default while remaining free to use
+# a different theme after installation.
+omarchy-theme-set-codex --activate
+omarchy-theme-set-grok --activate
 omarchy-theme-set-pi --activate
+omarchy-theme-set-claude --activate
 
 mkdir -p ~/.config/btop/themes
 ln -snf "$HOME/.local/state/omarchy/current/theme/btop.theme" ~/.config/btop/themes/current.theme

--- a/migrations/1786633468.sh
+++ b/migrations/1786633468.sh
@@ -1,0 +1,84 @@
+echo "Make Herdr follow the Omarchy terminal palette"
+
+config_file="${HERDR_CONFIG_PATH:-$HOME/.config/herdr/config.toml}"
+
+# New installs already receive theme.name = "terminal" from the shipped config,
+# but the first Herdr migration deliberately kept configs from standalone
+# installs. Move those existing configs onto the same integration once, without
+# replacing any of their keybindings, UI settings, or other preferences.
+[[ -f $config_file ]] || exit 0
+
+tmp=$(mktemp)
+
+awk '
+  function section(line) {
+    return line ~ /^[[:space:]]*\[[^][]+\][[:space:]]*(#.*)?$/
+  }
+
+  function theme_section(line) {
+    return line ~ /^[[:space:]]*\[theme\][[:space:]]*(#.*)?$/
+  }
+
+  function add_name_if_missing() {
+    if (in_theme && !wrote_name) {
+      print "name = \"terminal\""
+      wrote_name = 1
+    }
+  }
+
+  section($0) {
+    add_name_if_missing()
+    in_theme = theme_section($0)
+    if (in_theme) {
+      saw_theme = 1
+      wrote_name = 0
+    }
+    print
+    next
+  }
+
+  in_theme && /^[[:space:]]*name[[:space:]]*=/ {
+    if (!wrote_name) {
+      print "name = \"terminal\""
+      wrote_name = 1
+    }
+    next
+  }
+
+  { print }
+
+  END {
+    add_name_if_missing()
+    if (!saw_theme) {
+      if (NR) print ""
+      print "[theme]"
+      print "name = \"terminal\""
+    }
+  }
+' "$config_file" >"$tmp"
+
+if cmp -s "$tmp" "$config_file"; then
+  rm -f "$tmp"
+  exit 0
+fi
+
+# Do not turn a hand-edited but usable config into one Herdr refuses to load.
+# HERDR_CONFIG_PATH also keeps this validation isolated from the running server.
+if ! HERDR_CONFIG_PATH="$tmp" herdr config check >/dev/null; then
+  echo "Could not update $config_file; the generated Herdr config did not validate." >&2
+  rm -f "$tmp"
+  exit 0
+fi
+
+backup="$config_file.bak.$(date +%s)"
+cp -p "$config_file" "$backup"
+
+# Write through the path so configs linked from a dotfiles repository keep the
+# same symlink and target.
+cat "$tmp" >"$config_file"
+rm -f "$tmp"
+
+echo "Set Herdr to follow Omarchy themes. Saved backup as $backup."
+if ! omarchy-restart-herdr; then
+  echo "Could not reload Herdr; the new theme will apply the next time Herdr starts." >&2
+fi

--- a/migrations/1786633468.sh
+++ b/migrations/1786633468.sh
@@ -1,6 +1,6 @@
 echo "Make Herdr follow the Omarchy terminal palette"
 
-config_file="${HERDR_CONFIG_PATH:-$HOME/.config/herdr/config.toml}"
+config_file="${HERDR_CONFIG_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/herdr/config.toml}"
 
 # New installs already receive theme.name = "terminal" from the shipped config,
 # but the first Herdr migration deliberately kept configs from standalone

--- a/migrations/1786637624.sh
+++ b/migrations/1786637624.sh
@@ -1,0 +1,23 @@
+echo "Make terminal AI tools follow the Omarchy palette"
+
+current_theme="$HOME/.local/state/omarchy/current/theme"
+
+# These activations happen once. Codex and Grok then inherit every palette
+# change from the terminal, while Claude and Pi continue receiving generated
+# Omarchy theme files from the normal theme-switch hooks.
+if [[ -d $HOME/.codex ]]; then
+  omarchy-theme-set-codex --activate
+fi
+
+if [[ -d $HOME/.grok ]]; then
+  omarchy-theme-set-grok --activate
+fi
+
+if [[ -d $HOME/.claude && -f $current_theme/claude.json ]]; then
+  omarchy-theme-set-claude --activate
+fi
+
+if [[ -d $HOME/.pi/agent && -f $current_theme/pi.json ]]; then
+  rm -f "$HOME/.pi/agent/extensions/omarchy-system-theme.ts"
+  omarchy-theme-set-pi --activate
+fi

--- a/test/shell.d/herdr-theme-migration-test.sh
+++ b/test/shell.d/herdr-theme-migration-test.sh
@@ -51,7 +51,8 @@ reset_home() {
 }
 
 run_migration() {
-  HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+  HOME="$home" XDG_CONFIG_HOME="${TEST_XDG_CONFIG_HOME:-}" PATH="$test_dir/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
 }
 
 reset_home
@@ -85,8 +86,10 @@ pass "Herdr migration selects the terminal theme and keeps other preferences"
 backup="$config_file.bak.1234567890"
 cmp -s "$test_dir/original-config" "$backup" ||
   fail "Herdr migration backs up the original config" "$(diff -u "$test_dir/original-config" "$backup" || true)"
-[[ $(wc -l <"$HERDR_CALLS") == 1 ]] || fail "Herdr migration validates once"
-[[ $(wc -l <"$HERDR_RESTARTS") == 1 ]] || fail "Herdr migration reloads once"
+validation_count=$(wc -l <"$HERDR_CALLS")
+restart_count=$(wc -l <"$HERDR_RESTARTS")
+(( validation_count == 1 )) || fail "Herdr migration validates once"
+(( restart_count == 1 )) || fail "Herdr migration reloads once"
 pass "Herdr migration validates, backs up, and reloads"
 
 : >"$HERDR_CALLS"
@@ -108,7 +111,8 @@ prefix = "ctrl+space"
 EOF
 
 run_migration
-[[ $(sed -n '/^\[theme\]$/,/^\[/p' "$config_file" | grep -c '^name = "terminal"$') == 1 ]] ||
+theme_name_count=$(sed -n '/^\[theme\]$/,/^\[/p' "$config_file" | grep -c '^name = "terminal"$' || true)
+(( theme_name_count == 1 )) ||
   fail "Herdr migration adds a missing name inside the theme section" "$(cat "$config_file")"
 grep -Fxq 'prefix = "ctrl+space"' "$config_file" || fail "Herdr migration keeps the following section"
 pass "Herdr migration fills an existing theme section"
@@ -148,6 +152,21 @@ run_migration
 pass "Herdr migration leaves a missing config to the install path"
 
 reset_home
+TEST_XDG_CONFIG_HOME="$home/custom-config"
+xdg_config_file="$TEST_XDG_CONFIG_HOME/herdr/config.toml"
+mkdir -p "$(dirname "$xdg_config_file")"
+cat >"$xdg_config_file" <<'EOF'
+[theme]
+name = "nord"
+EOF
+
+run_migration
+grep -Fxq 'name = "terminal"' "$xdg_config_file" || fail "Herdr migration ignores XDG_CONFIG_HOME"
+[[ ! -e $config_file ]] || fail "Herdr migration writes the fallback config when XDG_CONFIG_HOME is set"
+pass "Herdr migration follows Herdr's XDG-aware config lookup"
+unset TEST_XDG_CONFIG_HOME
+
+reset_home
 mkdir -p "$home/dotfiles"
 cat >"$home/dotfiles/herdr.toml" <<'EOF'
 [theme]
@@ -157,7 +176,8 @@ ln -s "$home/dotfiles/herdr.toml" "$config_file"
 
 run_migration
 [[ -L $config_file ]] || fail "Herdr migration preserves a config symlink"
-[[ $(readlink "$config_file") == "$home/dotfiles/herdr.toml" ]] || fail "Herdr migration preserves the symlink target"
+symlink_target=$(readlink "$config_file")
+[[ $symlink_target == $home/dotfiles/herdr.toml ]] || fail "Herdr migration preserves the symlink target"
 grep -Fxq 'name = "terminal"' "$home/dotfiles/herdr.toml" || fail "Herdr migration writes through the symlink"
 pass "Herdr migration preserves dotfile symlinks"
 

--- a/test/shell.d/herdr-theme-migration-test.sh
+++ b/test/shell.d/herdr-theme-migration-test.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1786633468.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+
+cat >"$test_dir/bin/herdr" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$HERDR_CALLS"
+
+if [[ $* == "config check" ]]; then
+  grep -q 'invalid = ' "$HERDR_CONFIG_PATH" && exit 1
+fi
+
+exit 0
+STUB
+
+cat >"$test_dir/bin/omarchy-restart-herdr" <<'STUB'
+#!/bin/bash
+
+echo restart >>"$HERDR_RESTARTS"
+exit "${HERDR_RESTART_STATUS:-0}"
+STUB
+
+cat >"$test_dir/bin/date" <<'STUB'
+#!/bin/bash
+
+[[ ${1:-} == "+%s" ]] && echo 1234567890
+STUB
+
+chmod +x "$test_dir/bin/"*
+
+export HERDR_CALLS="$test_dir/herdr-calls"
+export HERDR_RESTARTS="$test_dir/herdr-restarts"
+
+home="$test_dir/home"
+config_file="$home/.config/herdr/config.toml"
+
+reset_home() {
+  rm -rf "$home"
+  mkdir -p "$(dirname "$config_file")"
+  : >"$HERDR_CALLS"
+  : >"$HERDR_RESTARTS"
+}
+
+run_migration() {
+  HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+}
+
+reset_home
+cat >"$config_file" <<'EOF'
+onboarding = false
+
+[ui]
+agent_panel_sort = "priority"
+
+[theme]
+name = "catppuccin-latte"
+auto_switch = false
+
+[experimental]
+pane_history = true
+EOF
+cp "$config_file" "$test_dir/original-config"
+
+run_migration
+
+grep -Fxq 'name = "terminal"' "$config_file" ||
+  fail "Herdr migration selects the terminal theme" "$(cat "$config_file")"
+grep -q 'catppuccin-latte' "$config_file" &&
+  fail "Herdr migration removes the pinned theme"
+grep -Fxq 'agent_panel_sort = "priority"' "$config_file" ||
+  fail "Herdr migration keeps UI preferences"
+grep -Fxq 'pane_history = true' "$config_file" ||
+  fail "Herdr migration keeps experimental preferences"
+pass "Herdr migration selects the terminal theme and keeps other preferences"
+
+backup="$config_file.bak.1234567890"
+cmp -s "$test_dir/original-config" "$backup" ||
+  fail "Herdr migration backs up the original config" "$(diff -u "$test_dir/original-config" "$backup" || true)"
+[[ $(wc -l <"$HERDR_CALLS") == 1 ]] || fail "Herdr migration validates once"
+[[ $(wc -l <"$HERDR_RESTARTS") == 1 ]] || fail "Herdr migration reloads once"
+pass "Herdr migration validates, backs up, and reloads"
+
+: >"$HERDR_CALLS"
+: >"$HERDR_RESTARTS"
+before=$(sha256sum "$config_file")
+run_migration
+[[ $before == $(sha256sum "$config_file") ]] || fail "Herdr migration is idempotent"
+[[ ! -s $HERDR_CALLS ]] || fail "idempotent Herdr migration skips validation"
+[[ ! -s $HERDR_RESTARTS ]] || fail "idempotent Herdr migration skips reload"
+pass "Herdr migration is idempotent"
+
+reset_home
+cat >"$config_file" <<'EOF'
+[theme]
+auto_switch = false
+
+[keys]
+prefix = "ctrl+space"
+EOF
+
+run_migration
+[[ $(sed -n '/^\[theme\]$/,/^\[/p' "$config_file" | grep -c '^name = "terminal"$') == 1 ]] ||
+  fail "Herdr migration adds a missing name inside the theme section" "$(cat "$config_file")"
+grep -Fxq 'prefix = "ctrl+space"' "$config_file" || fail "Herdr migration keeps the following section"
+pass "Herdr migration fills an existing theme section"
+
+reset_home
+cat >"$config_file" <<'EOF'
+onboarding = false
+
+[ui]
+accent = "cyan"
+EOF
+
+run_migration
+tail -n 2 "$config_file" | grep -Fxq '[theme]' ||
+  fail "Herdr migration adds a missing theme section" "$(cat "$config_file")"
+tail -n 1 "$config_file" | grep -Fxq 'name = "terminal"' ||
+  fail "Herdr migration adds the terminal theme to a new section"
+pass "Herdr migration adds a missing theme section"
+
+reset_home
+cat >"$config_file" <<'EOF'
+[theme]
+name = "terminal"
+EOF
+
+before=$(sha256sum "$config_file")
+run_migration
+[[ $before == $(sha256sum "$config_file") ]] || fail "terminal config remains unchanged"
+[[ ! -e $config_file.bak.1234567890 ]] || fail "terminal config gets no needless backup"
+[[ ! -s $HERDR_CALLS && ! -s $HERDR_RESTARTS ]] || fail "terminal config gets no needless work"
+pass "Herdr migration skips an already integrated config"
+
+reset_home
+run_migration
+[[ ! -e $config_file ]] || fail "Herdr migration does not create an unowned config"
+[[ ! -s $HERDR_CALLS && ! -s $HERDR_RESTARTS ]] || fail "missing Herdr config gets no work"
+pass "Herdr migration leaves a missing config to the install path"
+
+reset_home
+mkdir -p "$home/dotfiles"
+cat >"$home/dotfiles/herdr.toml" <<'EOF'
+[theme]
+name = "nord"
+EOF
+ln -s "$home/dotfiles/herdr.toml" "$config_file"
+
+run_migration
+[[ -L $config_file ]] || fail "Herdr migration preserves a config symlink"
+[[ $(readlink "$config_file") == "$home/dotfiles/herdr.toml" ]] || fail "Herdr migration preserves the symlink target"
+grep -Fxq 'name = "terminal"' "$home/dotfiles/herdr.toml" || fail "Herdr migration writes through the symlink"
+pass "Herdr migration preserves dotfile symlinks"
+
+reset_home
+cat >"$config_file" <<'EOF'
+invalid = value
+
+[theme]
+name = "dracula"
+EOF
+cp "$config_file" "$test_dir/invalid-config"
+
+run_migration
+cmp -s "$test_dir/invalid-config" "$config_file" || fail "failed validation leaves the config untouched"
+[[ ! -e $config_file.bak.1234567890 ]] || fail "failed validation creates no misleading backup"
+[[ ! -s $HERDR_RESTARTS ]] || fail "failed validation does not reload Herdr"
+pass "Herdr migration fails closed when validation rejects the candidate"
+
+reset_home
+cat >"$config_file" <<'EOF'
+[theme]
+name = "rose-pine"
+EOF
+
+HERDR_RESTART_STATUS=1 run_migration
+grep -Fxq 'name = "terminal"' "$config_file" || fail "reload failure keeps the valid migration"
+[[ -f $config_file.bak.1234567890 ]] || fail "reload failure keeps the migration backup"
+pass "Herdr migration survives a transient live reload failure"

--- a/test/shell.d/terminal-ai-theme-helpers-test.sh
+++ b/test/shell.d/terminal-ai-theme-helpers-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+codex_config="$test_dir/codex/config.toml"
+grok_config="$test_dir/grok/config.toml"
+
+mkdir -p "$(dirname "$codex_config")" "$(dirname "$grok_config")"
+cat >"$codex_config" <<'EOF'
+model = "gpt-5.6"
+
+[tui]
+theme = "catppuccin-latte"
+notifications = false
+
+[features]
+multi_agent = true
+EOF
+cat >"$grok_config" <<'EOF'
+[ui]
+theme = "auto"
+screen_mode = "alternate"
+
+[privacy]
+analytics = false
+EOF
+
+CODEX_CONFIG_PATH="$codex_config" "$ROOT/bin/omarchy-theme-set-codex"
+GROK_CONFIG_PATH="$grok_config" "$ROOT/bin/omarchy-theme-set-grok"
+grep -Fxq 'theme = "catppuccin-latte"' "$codex_config" || fail "Codex helper changes the theme without activation"
+grep -Fxq 'theme = "auto"' "$grok_config" || fail "Grok helper changes the theme without activation"
+pass "terminal palette helpers do nothing during ordinary theme switches"
+
+CODEX_CONFIG_PATH="$codex_config" "$ROOT/bin/omarchy-theme-set-codex" --activate
+GROK_CONFIG_PATH="$grok_config" "$ROOT/bin/omarchy-theme-set-grok" --activate
+
+grep -Fxq 'theme = "ansi"' "$codex_config" || fail "Codex helper does not select its ANSI theme"
+grep -Fxq 'model = "gpt-5.6"' "$codex_config" || fail "Codex helper loses top-level preferences"
+grep -Fxq 'notifications = false' "$codex_config" || fail "Codex helper loses TUI preferences"
+grep -Fxq 'multi_agent = true' "$codex_config" || fail "Codex helper loses feature preferences"
+grep -Fxq 'theme = "minimal"' "$grok_config" || fail "Grok helper does not select its terminal palette theme"
+grep -Fxq 'screen_mode = "alternate"' "$grok_config" || fail "Grok helper changes screen mode"
+grep -Fxq 'analytics = false' "$grok_config" || fail "Grok helper loses privacy preferences"
+pass "terminal palette helpers preserve unrelated settings"
+
+codex_before=$(sha256sum "$codex_config")
+grok_before=$(sha256sum "$grok_config")
+CODEX_CONFIG_PATH="$codex_config" "$ROOT/bin/omarchy-theme-set-codex" --activate
+GROK_CONFIG_PATH="$grok_config" "$ROOT/bin/omarchy-theme-set-grok" --activate
+[[ $codex_before == $(sha256sum "$codex_config") ]] || fail "Codex activation is not idempotent"
+[[ $grok_before == $(sha256sum "$grok_config") ]] || fail "Grok activation is not idempotent"
+pass "terminal palette activation is idempotent"
+
+printf 'tui.theme = "dracula"\nmodel = "keep-me"\n' >"$codex_config"
+printf 'ui.theme = "auto"\nmodel = "keep-me"\n' >"$grok_config"
+CODEX_CONFIG_PATH="$codex_config" "$ROOT/bin/omarchy-theme-set-codex" --activate
+GROK_CONFIG_PATH="$grok_config" "$ROOT/bin/omarchy-theme-set-grok" --activate
+grep -Fxq 'tui.theme = "ansi"' "$codex_config" || fail "Codex helper does not support a dotted theme key"
+grep -Fxq 'ui.theme = "minimal"' "$grok_config" || fail "Grok helper does not support a dotted theme key"
+[[ $(grep -c '^\[tui\]$' "$codex_config") == 0 ]] || fail "Codex helper duplicates a dotted theme setting"
+[[ $(grep -c '^\[ui\]$' "$grok_config") == 0 ]] || fail "Grok helper duplicates a dotted theme setting"
+pass "terminal palette helpers support dotted TOML keys"
+
+mkdir -p "$test_dir/dotfiles"
+printf '[tui]\ntheme = "solarized"\n' >"$test_dir/dotfiles/codex.toml"
+printf '[ui]\ntheme = "auto"\n' >"$test_dir/dotfiles/grok.toml"
+ln -sf "$test_dir/dotfiles/codex.toml" "$codex_config"
+ln -sf "$test_dir/dotfiles/grok.toml" "$grok_config"
+CODEX_CONFIG_PATH="$codex_config" "$ROOT/bin/omarchy-theme-set-codex" --activate
+GROK_CONFIG_PATH="$grok_config" "$ROOT/bin/omarchy-theme-set-grok" --activate
+[[ -L $codex_config && -L $grok_config ]] || fail "terminal palette helpers replace config symlinks"
+grep -Fxq 'theme = "ansi"' "$test_dir/dotfiles/codex.toml" || fail "Codex helper does not write through a symlink"
+grep -Fxq 'theme = "minimal"' "$test_dir/dotfiles/grok.toml" || fail "Grok helper does not write through a symlink"
+pass "terminal palette helpers preserve dotfile symlinks"

--- a/test/shell.d/terminal-ai-theme-migration-test.sh
+++ b/test/shell.d/terminal-ai-theme-migration-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1786637624.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+
+for command in codex grok claude pi; do
+  cat >"$test_dir/bin/omarchy-theme-set-$command" <<'STUB'
+#!/bin/bash
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$AI_THEME_CALLS"
+STUB
+done
+chmod +x "$test_dir/bin/"*
+
+home="$test_dir/home"
+calls="$test_dir/calls"
+export AI_THEME_CALLS="$calls"
+
+mkdir -p \
+  "$home/.codex" \
+  "$home/.grok" \
+  "$home/.claude" \
+  "$home/.pi/agent/extensions" \
+  "$home/.local/state/omarchy/current/theme"
+touch \
+  "$home/.pi/agent/extensions/omarchy-system-theme.ts" \
+  "$home/.local/state/omarchy/current/theme/claude.json" \
+  "$home/.local/state/omarchy/current/theme/pi.json"
+
+HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+
+for command in codex grok claude pi; do
+  grep -Fx "omarchy-theme-set-$command --activate" "$calls" >/dev/null ||
+    fail "terminal AI migration activates $command"
+done
+[[ ! -e $home/.pi/agent/extensions/omarchy-system-theme.ts ]] ||
+  fail "terminal AI migration removes the obsolete Pi extension"
+pass "terminal AI migration activates installed supported tools"
+
+: >"$calls"
+rm -rf "$home"
+mkdir -p "$home"
+HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+[[ ! -s $calls ]] || fail "terminal AI migration touches unconfigured tools"
+pass "terminal AI migration skips tools without existing state"

--- a/test/shell.d/user-theme-test.sh
+++ b/test/shell.d/user-theme-test.sh
@@ -14,25 +14,32 @@ printf '%s\n' "$*" >>"$OMARCHY_TEST_THEME_CALLS"
 SH
 chmod +x "$mock_bin/omarchy-theme-set"
 
-for command in omarchy-theme-set-pi; do
+for command in omarchy-theme-set-codex omarchy-theme-set-grok omarchy-theme-set-pi omarchy-theme-set-claude; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
-exit 0
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$OMARCHY_TEST_APP_THEME_CALLS"
 SH
   chmod +x "$mock_bin/$command"
 done
 
 calls="$test_tmp/theme-calls"
+app_theme_calls="$test_tmp/app-theme-calls"
 touch "$test_tmp/home/.config/chromium/SingletonLock"
-HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEME_CALLS="$calls" \
+HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEME_CALLS="$calls" OMARCHY_TEST_APP_THEME_CALLS="$app_theme_calls" \
   bash "$ROOT/install/user/theme.sh"
 grep -Fx 'Tokyo Night' "$calls" >/dev/null || fail "user theme setup seeds Tokyo Night when no theme exists"
 [[ -f $test_tmp/home/.config/chromium/SingletonLock ]] || fail "runtime user theme setup preserves Chromium's singleton lock"
+for command in codex grok pi claude; do
+  grep -Fx "omarchy-theme-set-$command --activate" "$app_theme_calls" >/dev/null ||
+    fail "user theme setup activates the $command terminal theme"
+done
 
 : >"$calls"
+: >"$app_theme_calls"
 printf 'Solitude\n' >"$test_tmp/home/.local/state/omarchy/current/theme.name"
-HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEME_CALLS="$calls" \
+HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEME_CALLS="$calls" OMARCHY_TEST_APP_THEME_CALLS="$app_theme_calls" \
   bash "$ROOT/install/user/theme.sh"
 [[ ! -s $calls ]] || fail "user theme setup preserves an existing theme"
+[[ $(wc -l <"$app_theme_calls") == 4 ]] || fail "user theme setup activates terminal apps with an existing Omarchy theme"
 
-pass "user theme setup only seeds the default theme once"
+pass "user theme setup seeds once and activates terminal application themes"


### PR DESCRIPTION
## Summary

- migrate existing Herdr installs to its terminal-palette theme
- activate Codex's `ansi` theme and Grok's terminal-palette `minimal` color theme for new and existing installs
- activate Claude and Pi's existing generated Omarchy themes, including removal of Pi's retired light/dark extension
- preserve all unrelated settings, symlinked dotfile targets, and later user theme choices

OpenCode already follows `system` and reloads on Omarchy theme changes, so it needs no additional migration.

## Design

The integrations are activated once rather than forced on every theme switch:

- Herdr, Codex, and Grok inherit the palette directly from the terminal. Their config does not need to be rewritten when Omarchy changes theme.
- Claude and Pi select a fixed Omarchy theme name once. Their existing `omarchy-theme-set-claude` and `omarchy-theme-set-pi` hooks keep the generated palette files current and hot-reload running sessions.

This makes following Omarchy the default while allowing a later explicit theme choice in any application to remain authoritative.

## Existing installs

The Herdr migration validates its candidate config, creates a timestamped backup, preserves dotfile symlinks, and reloads Herdr when possible.

A separate migration updates only AI tools with existing config/state directories. It activates the supported integration for Codex, Grok, Claude, and Pi and removes Pi's obsolete `omarchy-system-theme.ts` extension.

## Verification

- focused Herdr migration coverage passes replacement, missing section/key, already-correct and absent configs, idempotence, backup, symlink, validation-failure, and reload-failure cases
- focused AI helper coverage passes no-op switching, setting preservation, idempotence, dotted TOML keys, and dotfile symlinks
- focused AI migration and installer coverage passes installed/missing tool behavior and Pi extension cleanup
- real Codex accepts `tui.theme = "ansi"`; isolated Grok `inspect --json` accepts `[ui] theme = "minimal"` without warnings
- live Matte Black -> Catppuccin Latte switching updates Claude and Pi from the generated dark palette to the light palette while Codex and Grok remain terminal-native
- bash syntax and `git diff --check` pass

The aggregate CLI/shell baseline currently has unrelated failures that reproduce outside this change: the CLI expects Tokyo Night's retired `0-swirl-buck.jpg`, while shell failures depend on unavailable/untrusted local fixtures and existing packaging assertions. All new focused tests pass within the aggregate runs.
