### PR TITLE
Stop screensavers through their supervisors

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -1,26 +1,39 @@
 #!/bin/bash
 
-# omarchy:summary=Run the Omarchy screensaver using random effects from TTE.
+# omarchy:summary=Run the Omarchy screensaver using random ttfx effects
+
+renderer_pid=
+shutdown=0
 
 screensaver_in_focus() {
   hyprctl activewindow -j | jq -e '.class == "org.omarchy.screensaver"' >/dev/null 2>&1
 }
 
-exit_screensaver() {
-  hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
-  pkill -x ttfx 2>/dev/null
-  pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null
-  exit 0
+request_shutdown() {
+  (( shutdown )) && return
+
+  shutdown=1
+  trap '' SIGINT SIGTERM SIGHUP SIGQUIT
+
+  # One dismissed monitor dismisses them all. Each supervisor still owns and
+  # reaps only its own renderer, so every terminal keeps its PTY alive through
+  # ttfx's shutdown.
+  pkill -x omarchy-saver 2>/dev/null || true
 }
 
 # Exit the screensaver on signals and input from keyboard and mouse
-trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
+trap request_shutdown SIGINT SIGTERM SIGHUP SIGQUIT
+
+# Give the supervisor a stable, unambiguous process name for coordinated exit.
+# This runs after installing traps and before checking the lock state so a lock
+# can never miss a supervisor that is about to start ttfx.
+printf 'omarchy-saver' >/proc/self/comm
+
+[[ $(omarchy-shell lock isLocked 2>/dev/null) == "true" ]] && exit 0
 
 printf '\033]11;rgb:00/00/00\007'  # Set background color to black
 
 hyprctl eval 'hl.config({ cursor = { invisible = true } })' &>/dev/null || hyprctl keyword cursor:invisible true &>/dev/null
-
-tty=$(tty 2>/dev/null)
 
 # Terminals allocate the pty at the default 80x24 and only resize it once the
 # compositor has told the window how big it is. ttfx measures the terminal once,
@@ -28,21 +41,60 @@ tty=$(tty 2>/dev/null)
 # paints it into the corner of a fullscreen window.
 wait_for_terminal_resize() {
   local deadline=$((SECONDS + 2))
-  while ((SECONDS < deadline)) && [[ $(stty size 2>/dev/null) == "24 80" ]]; do
+  while (( ! shutdown && SECONDS < deadline)) && [[ $(stty size 2>/dev/null) == "24 80" ]]; do
     sleep 0.02
   done
 }
 
+renderer_running() {
+  local running_pid
+
+  while read -r running_pid; do
+    [[ $running_pid == $renderer_pid ]] && return 0
+  done <<<"$(jobs -pr)"
+
+  return 1
+}
+
+stop_renderer() {
+  local attempt
+
+  [[ -n $renderer_pid ]] || return
+
+  if renderer_running; then
+    kill -TERM "$renderer_pid" 2>/dev/null || true
+
+    for ((attempt = 0; attempt < 100; attempt++)); do
+      renderer_running || break
+      sleep 0.01
+    done
+
+    renderer_running && kill -KILL "$renderer_pid" 2>/dev/null || true
+  fi
+
+  wait "$renderer_pid" 2>/dev/null || true
+  renderer_pid=
+}
+
 wait_for_terminal_resize
 
-while true; do
+while (( ! shutdown )); do
   ttfx -i ~/.config/omarchy/branding/screensaver.txt \
     --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --no-eol --no-restore-cursor &
+  renderer_pid=$!
 
-  while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do
+  while (( ! shutdown )) && renderer_running; do
+    (( shutdown )) && break
+
     if read -n1 -t 1 || ! screensaver_in_focus; then
-      exit_screensaver
+      request_shutdown
     fi
   done
+
+  (( shutdown )) || wait "$renderer_pid" 2>/dev/null || true
+  (( shutdown )) || renderer_pid=
 done
+
+stop_renderer
+hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true

--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -20,7 +20,6 @@ if pgrep -x "1password" >/dev/null && omarchy-cmd-present 1password; then
 fi
 
 # Avoid running screensaver when locked
-pkill -x ttfx 2>/dev/null || true
-# ttfx handles SIGTERM asynchronously, so keep its terminal alive until it exits.
-timeout 1s pidwait -x ttfx 2>/dev/null || true
-pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null || true
+pkill -x omarchy-saver 2>/dev/null || true
+# Each supervisor reaps its own ttfx before exiting and closing its terminal.
+timeout 2s pidwait -x omarchy-saver 2>/dev/null || true

--- a/default/ghostty/screensaver
+++ b/default/ghostty/screensaver
@@ -1,3 +1,4 @@
 window-padding-x = 0
 window-padding-y = 0
 window-padding-color = "extend-always"
+wait-after-command = false

--- a/test/shell.d/screensaver-test.sh
+++ b/test/shell.d/screensaver-test.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+mock_bin="$tmpdir/bin"
+call_log="$tmpdir/calls"
+mkdir -p "$mock_bin"
+
+terminal_pids=()
+unrelated_pid=
+
+cleanup() {
+  local pid
+
+  for pid in "${terminal_pids[@]}" ${unrelated_pid:-}; do
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  pkill -x omarchy-saver 2>/dev/null || true
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cat >"$mock_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "${LOCKED:-false}"
+SH
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ $* == "activewindow -j" ]] && printf '{"class":"org.omarchy.screensaver"}\n'
+SH
+
+cat >"$mock_bin/jq" <<'SH'
+#!/bin/bash
+cat >/dev/null
+exit 0
+SH
+
+cat >"$mock_bin/stty" <<'SH'
+#!/bin/bash
+printf '30 100\n'
+SH
+
+cat >"$mock_bin/ttfx" <<'SH'
+#!/bin/bash
+
+if [[ ${1:-} == "--unrelated" ]]; then
+  trap 'printf "unrelated-term\n" >>"$CALL_LOG"; exit 0' TERM
+  printf 'unrelated-start\n' >>"$CALL_LOG"
+elif [[ ${SAVER_MODE:-} == "ignore-term" ]]; then
+  trap '' TERM
+  printf 'renderer-%s-start\n' "$SAVER_LABEL" >>"$CALL_LOG"
+else
+  trap 'printf "renderer-%s-term\n" "$SAVER_LABEL" >>"$CALL_LOG"; sleep 0.15; printf "renderer-%s-exit\n" "$SAVER_LABEL" >>"$CALL_LOG"; exit 0' TERM
+  printf 'renderer-%s-start\n' "$SAVER_LABEL" >>"$CALL_LOG"
+fi
+
+while true; do
+  sleep 0.02
+done
+SH
+
+chmod +x "$mock_bin"/*
+
+wait_for_count() {
+  local pattern="$1"
+  local expected="$2"
+  local description="$3"
+  local attempt count
+
+  for ((attempt = 0; attempt < 300; attempt++)); do
+    count=$(rg -c "$pattern" "$call_log" 2>/dev/null || true)
+    [[ ${count:-0} == "$expected" ]] && return
+    sleep 0.01
+  done
+
+  fail "$description" "calls: $(cat "$call_log" 2>/dev/null || true)"
+}
+
+wait_for_exit() {
+  local pid="$1"
+  local description="$2"
+  local attempt
+
+  for ((attempt = 0; attempt < 300; attempt++)); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.01
+  done
+
+  fail "$description" "process $pid is still running"
+}
+
+line_number() {
+  rg -n "^$1$" "$call_log" | cut -d: -f1
+}
+
+run_screensaver() {
+  local label="$1"
+  local mode="${2:-normal}"
+
+  PATH="$mock_bin:$PATH" CALL_LOG="$call_log" SAVER_LABEL="$label" SAVER_MODE="$mode" \
+    "$ROOT/bin/omarchy-screensaver" < <(sleep 10) >/dev/null 2>&1
+  printf 'terminal-%s-exit\n' "$label" >>"$call_log"
+}
+
+PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$mock_bin/ttfx" --unrelated &
+unrelated_pid=$!
+
+run_screensaver a &
+terminal_pids+=("$!")
+run_screensaver b &
+terminal_pids+=("$!")
+
+wait_for_count '^renderer-[ab]-start$' 2 "both screensaver renderers start"
+wait_for_count '^unrelated-start$' 1 "the unrelated ttfx starts"
+
+mapfile -t supervisors < <(pgrep -x omarchy-saver)
+(( ${#supervisors[@]} == 2 )) ||
+  fail "each screensaver has a named supervisor" "pids: ${supervisors[*]}"
+
+# A signal delivered to one monitor must coordinate shutdown across all monitors.
+kill -TERM "${supervisors[0]}"
+
+for pid in "${terminal_pids[@]}"; do
+  wait_for_exit "$pid" "screensaver terminal exits after its renderer"
+  wait "$pid"
+done
+terminal_pids=()
+
+kill -0 "$unrelated_pid" 2>/dev/null ||
+  fail "screensaver shutdown leaves unrelated ttfx processes alone"
+[[ $(rg -c '^renderer-[ab]-start$' "$call_log") == "2" ]] ||
+  fail "screensaver supervisors do not respawn renderers during shutdown" "calls: $(cat "$call_log")"
+
+for label in a b; do
+  term_line=$(line_number "renderer-$label-term")
+  renderer_exit_line=$(line_number "renderer-$label-exit")
+  terminal_exit_line=$(line_number "terminal-$label-exit")
+
+  (( term_line < renderer_exit_line && renderer_exit_line < terminal_exit_line )) ||
+    fail "screensaver $label reaps its renderer before the terminal exits" "calls: $(cat "$call_log")"
+done
+pass "screensaver supervisors reap only their own renderers before exiting"
+
+run_screensaver stubborn ignore-term &
+terminal_pids+=("$!")
+wait_for_count '^renderer-stubborn-start$' 1 "the stubborn renderer starts"
+
+mapfile -t supervisors < <(pgrep -x omarchy-saver)
+(( ${#supervisors[@]} == 1 )) ||
+  fail "the stubborn renderer has one supervisor" "pids: ${supervisors[*]}"
+kill -TERM "${supervisors[0]}"
+wait_for_exit "${terminal_pids[0]}" "a renderer ignoring SIGTERM is stopped within the grace period"
+wait "${terminal_pids[0]}"
+terminal_pids=()
+
+[[ -z $(rg '^renderer-stubborn-exit$' "$call_log" || true) ]] ||
+  fail "the stubborn renderer requires forced termination" "calls: $(cat "$call_log")"
+pass "screensaver supervisor bounds renderer shutdown"
+
+before=$(rg -c '^renderer-.*-start$' "$call_log")
+PATH="$mock_bin:$PATH" CALL_LOG="$call_log" SAVER_LABEL=locked LOCKED=true \
+  "$ROOT/bin/omarchy-screensaver" </dev/null >/dev/null 2>&1
+after=$(rg -c '^renderer-.*-start$' "$call_log")
+[[ $after == "$before" ]] ||
+  fail "a screensaver starting during lock does not launch ttfx" "calls: $(cat "$call_log")"
+pass "screensaver does not start a renderer while locked"
+
+kill -TERM "$unrelated_pid"
+wait "$unrelated_pid"
+unrelated_pid=

--- a/test/shell.d/system-lock-test.sh
+++ b/test/shell.d/system-lock-test.sh
@@ -27,10 +27,10 @@ chmod +x "$mock_bin"/*
 PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-lock"
 mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 
-[[ ${shutdown[0]} == "pkill -x ttfx" ]] ||
-  fail "system lock stops ttfx before closing its terminal" "calls: ${shutdown[*]}"
-[[ ${shutdown[1]} == "timeout 1s pidwait -x ttfx" ]] ||
-  fail "system lock waits for ttfx to exit" "calls: ${shutdown[*]}"
-[[ ${shutdown[2]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
-  fail "system lock closes the screensaver terminal after ttfx exits" "calls: ${shutdown[*]}"
-pass "system lock waits for ttfx before closing its terminal"
+[[ ${shutdown[0]} == "pkill -x omarchy-saver" ]] ||
+  fail "system lock stops the screensaver supervisors" "calls: ${shutdown[*]}"
+[[ ${shutdown[1]} == "timeout 2s pidwait -x omarchy-saver" ]] ||
+  fail "system lock waits for the screensaver supervisors" "calls: ${shutdown[*]}"
+(( ${#shutdown[@]} == 2 )) ||
+  fail "system lock does not kill ttfx or its terminal directly" "calls: ${shutdown[*]}"
+pass "system lock lets screensaver supervisors close their terminals"


### PR DESCRIPTION
## Problem

Follow-up to #6764 and #6773.

Waiting for `ttfx` after `pkill` still leaves a race because `omarchy-screensaver` is a supervisor loop. A live supervisor can start another renderer after the global kill but before the terminal closes. `pidwait` only waits for processes that already exist, so the replacement can still lose its PTY and abort with the same EIO panic.

The dismissal path has the same underlying problem: every monitor's supervisor globally kills every `ttfx` and every screensaver terminal. This can race across monitors and also affects unrelated `ttfx` processes.

## Solution

Make each screensaver supervisor own its renderer lifecycle:

- coordinate multi-monitor dismissal by signalling supervisors rather than renderers or terminals
- track the exact `ttfx` child and prevent respawning once shutdown starts
- terminate and reap that child before allowing the terminal to close
- force-stop a renderer if it does not exit within the grace period
- prevent a renderer from starting during a concurrent lock
- explicitly disable Ghostty's hold-after-command behavior

`omarchy-system-lock` now signals and briefly waits for the supervisors. It no longer kills `ttfx` or closes its PTY directly.

## Tests

- `bash test/shell.d/screensaver-test.sh`
- `bash test/shell.d/system-lock-test.sh`
- `bash test/shell.d/bin-style-test.sh`
- `bash -n bin/omarchy-screensaver bin/omarchy-system-lock test/shell.d/screensaver-test.sh test/shell.d/system-lock-test.sh`

The lifecycle test covers two monitors, delayed renderer shutdown, respawn prevention, unrelated `ttfx` processes, forced termination, and a concurrent lock. It also passed ten consecutive runs.
