### PR TITLE
Keep AppLibrary scans out of login shells

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -187,9 +187,13 @@ Item {
     property string text: ""
   }
 
+  // Both scans must run in non-login shells. A login shell sources the user's
+  // profile, and tools like mise touch ~/.local/share on activation — a
+  // directory the desktop-entry watcher monitors — so every scan would
+  // trigger the next one, pinning a core at idle.
   Process {
     id: hiddenEntryScan
-    command: ["bash", "-lc", root.hiddenEntryScanCommand()]
+    command: ["bash", "-c", root.hiddenEntryScanCommand()]
     stdout: SplitParser { onRead: function(line) { hiddenEntryOutput.text += line + "\n" } }
     onStarted: hiddenEntryOutput.text = ""
     onExited: root.loadDesktopHiddenEntries(hiddenEntryOutput.text)
@@ -197,7 +201,7 @@ Item {
 
   Process {
     id: iconIndexScan
-    command: ["bash", "-lc", root.iconIndexScanCommand()]
+    command: ["bash", "-c", root.iconIndexScanCommand()]
     stdout: SplitParser { onRead: function(line) { root.indexIconLine(line) } }
     onStarted: root.pendingIconIndex = ({})
     // Swapping the property re-evaluates every iconSource() binding, so

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -115,6 +115,13 @@ assert(
 )
 
 assert(
+  appLibraryQml.includes('command: ["bash", "-c", root.hiddenEntryScanCommand()]') &&
+    appLibraryQml.includes('command: ["bash", "-c", root.iconIndexScanCommand()]') &&
+    !appLibraryQml.includes('"-lc"'),
+  'app library scans avoid login shells whose profile activation retriggers the desktop-entry watcher'
+)
+
+assert(
   /if \(active === "apps"\) \{[\s\S]*?rows\.sort\(function\(a, b\)/.test(menuQml),
   'apps menu enforces alphabetical display order after provider refreshes'
 )


### PR DESCRIPTION
## What changed

- Run the AppLibrary hidden-entry and icon-index scans with `bash -c` instead of `bash -lc`.

## Why

Fixes #6806.

A login shell sources the user's profile, and tools like mise touch `~/.local/share` on every activation. Quickshell's desktop-entry watcher monitors that tree, so each scan retriggered the next:

1. AppLibrary starts a scan via `bash -lc`
2. The login shell runs `mise activate bash`, which updates `~/.local/share/mise`
3. `DesktopEntryMonitor` sees the directory change and fires `valuesChanged`
4. AppLibrary starts another scan

That self-sustaining loop pinned ~20% of a core at idle. The scans only use bash builtins, `find`, and `sort` from the standard paths the uwsm session already provides, so they never needed the login environment.

— 🤖 Claude, posting on behalf of @dhh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRZnYKXvZZSPqq6XDUiCSL