### PR TITLE
Blank the lock screen while the fingerprint reader waits

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -424,7 +424,10 @@ Item {
         root.armBlankTimer()
         return
       }
-      if (root.lockRequested && !root.authenticating) root.runBlank()
+      // Only a password check in flight should hold the display up. The
+      // fingerprint PAM stays armed for the whole lock, so gating on
+      // `authenticating` here would keep the panel lit until unlock.
+      if (root.lockRequested && !root.authenticatingPassword) root.runBlank()
     }
   }
 
@@ -472,9 +475,9 @@ Item {
     }
   }
 
-  onAuthenticatingChanged: {
+  onAuthenticatingPasswordChanged: {
     if (!lockRequested) return
-    if (authenticating) idleBlankTimer.stop()
+    if (authenticatingPassword) idleBlankTimer.stop()
     else armBlankTimer()
   }
 

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// The fingerprint PAM stays armed for the whole lock waiting for a finger, so
+// `authenticating` is true from lock until unlock on every machine with a
+// reader enrolled. Gating the blank on it leaves the panel lit all night.
+assert(
+  /if \(root\.lockRequested && !root\.authenticatingPassword\) root\.runBlank\(\)/.test(serviceQml),
+  'only a password check in flight stops the blank timer from blanking'
+)
+
+assert(
+  !/idleBlankTimer[\s\S]*?!root\.authenticating\)/.test(serviceQml),
+  'the blank timer never gates on the combined authenticating state'
+)
+
+assert(
+  /onAuthenticatingPasswordChanged: \{\s*if \(!lockRequested\) return\s*if \(authenticatingPassword\) idleBlankTimer\.stop\(\)\s*else armBlankTimer\(\)/.test(serviceQml),
+  'the blank timer is held off by password entry and re-armed when it finishes'
+)
+
+assert(
+  !/onAuthenticatingChanged:/.test(serviceQml),
+  'the combined authenticating state no longer drives the blank timer'
+)
+JS


### PR DESCRIPTION
## Problem

With a fingerprint enrolled, the lock screen never turns the display off. The panel stays lit for as long as the machine is locked.

`idleBlankTimer` is gated on `authenticating`:

```qml
readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating

onAuthenticatingChanged: {
  if (!lockRequested) return
  if (authenticating) idleBlankTimer.stop()
  else armBlankTimer()
}
```

The gate is meant to keep the display up while a password is being checked. But `startFingerprint()` runs as soon as the session lock goes secure and the fingerprint PAM then sits armed for the whole lock waiting for a finger, so `fingerprintAuthenticating` — and therefore `authenticating` — is true from lock until unlock. The timer armed by `beginLock()` is stopped immediately and never re-armed, and `runBlank()` never runs.

Measured on a locked session (idle, no input) before the fix:

```
11:42:46 dpms=true {"locked":true,"secure":true,"authenticating":true}
...
11:43:13 dpms=true {"locked":true,"secure":true,"authenticating":true}
```

`authenticating` stays true and DPMS never goes down. Machines without a reader are unaffected, which is why this isn't universally visible.

## Fix

Gate the blank on `authenticatingPassword` instead of the combined state. A password check in flight still holds the display up; the passive fingerprint wait no longer does. Fingerprint unlock is untouched — the reader stays armed while the panel is off, and `runWake()` on lock-screen input still re-arms the blank on its normal 5s run-up.

After, same measurement:

```
11:54:57 dpms=true  {"locked":true,"secure":true,"authenticating":true}
11:54:59 dpms=false {"locked":true,"secure":true,"authenticating":true}
11:55:11 dpms=false {"locked":true,"secure":true,"authenticating":true}
```

The blank fires at +5s as intended and the display stays off until input wakes it.

## Verification

- Verified in the running UI on Omarchy 3.1.2 / Hyprland 0.56.2, laptop with an enrolled fingerprint reader (eDP-1): four lock cycles sampling `hyprctl monitors` and `omarchy-shell lock status`. Both password and fingerprint unlock still work, and touching the trackpad while blanked wakes the panel and re-arms the timer.
- Added `test/shell.d/lock-blank-fingerprint-test.sh`, which fails on the current gate and passes with this change.
- `./test/all` — the only failures are the three `omarchy-pkgs` checkout tests (`config`, `snapper`, `unowned-system-paths`), which fail identically on a clean tree here because that sibling checkout isn't present.