### PR TITLE
Recover updates from retired package conflicts

### DIFF
--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -10,21 +10,29 @@ echo -e "\e[32m\nUpdate system packages\e[0m"
 errors=$(mktemp)
 trap 'rm -f "$errors"' EXIT
 
+pacman_options=(-Syu --noconfirm --overwrite '/usr/share/omarchy/*')
+if [[ ${OMARCHY_UPDATE_CONFLICT:-} == 1 &&
+  ${OMARCHY_UPDATE_RETRY:-} == 1 &&
+  ${OMARCHY_UPDATE_REMOVE_CONFLICTS:-} == 1 ]]; then
+  # Pacman's conflict-removal question is bit 4. This is set only by the
+  # conflict handler after it proves every removal is a retired dependency.
+  pacman_options+=(--ask 4)
+fi
+
 # /usr/share/omarchy is wholly Omarchy's; files can land there unowned and would
 # otherwise abort the upgrade. Packaged content wins there.
 #
 # Progress bars stay on stdout. Errors are on stderr, kept for the conflict
 # handler below; LC_ALL=C is what keeps them parseable in any locale.
-if sudo env LC_ALL=C OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm \
-  --overwrite '/usr/share/omarchy/*' 2>"$errors"; then
+if sudo env LC_ALL=C OMARCHY_UPDATE_PACMAN=1 pacman "${pacman_options[@]}" 2>"$errors"; then
   cat "$errors" >&2
   exit 0
 fi
 cat "$errors" >&2
 
-# An upgrade blocked only by files pacman doesn't own yet is the one failure
-# worth retrying: the handler clears them and runs this again. Anything else,
-# including a second failure, is for a human.
+# The conflict handler retries only failures it can settle without guessing:
+# unowned Omarchy files and dependency packages no longer in the sync repos.
+# Anything else, including a second failure, is for a human.
 [[ ${OMARCHY_UPDATE_RETRY:-} != 1 ]] || exit 1
 # exec, so the EXIT trap above does not fire and the handler can still read the
 # report. It takes over deleting it.

--- a/bin/omarchy-update-system-pkgs-when-conflicted
+++ b/bin/omarchy-update-system-pkgs-when-conflicted
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# omarchy:summary=Retry a system package update after resolving file conflicts
+# omarchy:summary=Retry a system package update after resolving safe conflicts
 # omarchy:hidden=true
 
 # Internal to omarchy-update-system-pkgs. Not a command to run by hand: it acts
 # on a pacman error report, and an old or hand-written one would move live files
 # out of the way for an upgrade that is not happening.
 #
-# Paths written by a script rather than installed by a package -- an earlier
-# release's installer, an in-place edit -- belong to nobody, and pacman refuses
-# to install over a file it doesn't own. This clears them and runs the upgrade
-# again.
+# This recovers from two conflicts that can be settled without guessing:
+# unowned files under Omarchy's package paths, and dependency-installed packages
+# absent from the sync repositories when a repository package conflicts with
+# them. Anything involving an explicit or still-published package stops.
 
 set -e
 
@@ -56,6 +56,31 @@ restore_moved() {
 # Cleaning it up is this script's job from now on.
 trap 'restore_moved; rm -f "$errors"' EXIT
 trap 'exit 1' INT TERM
+
+# Pacman defaults conflict removals to No under --noconfirm. An obsolete split
+# package can therefore block every unattended update even though the upgrade
+# transaction knows how to remove it safely. Only invert those prompts when
+# every package is both dependency-installed and absent from the freshly
+# synchronized repositories. This refuses packages the user chose explicitly
+# and any package still published by a configured repository.
+mapfile -t retired_dependencies < <(
+  grep -oP '^:: .+ are in conflict(?: \([^)]*\))?\. Remove \K[^?]+(?=\? \[y/N\]$)' "$errors" |
+    while IFS= read -r package; do
+      pacman -Qdq "$package" &>/dev/null && pacman -Qmq "$package" &>/dev/null && echo "$package"
+    done
+)
+
+conflict_removal_count=$(grep -cP '^:: .+ are in conflict(?: \([^)]*\))?\. Remove [^?]+\? \[y/N\]$' "$errors" || true)
+if (( conflict_removal_count > 0 )); then
+  (( ${#retired_dependencies[@]} == conflict_removal_count )) || exit 1
+
+  echo -e "\e[33m\nRemoving dependency packages no longer in configured repositories:\e[0m"
+  printf '  %s\n' "${retired_dependencies[@]}"
+  echo
+
+  OMARCHY_UPDATE_REMOVE_CONFLICTS=1 OMARCHY_UPDATE_RETRY=1 omarchy-update-system-pkgs
+  exit $?
+fi
 
 # Paths one of these packages installs that pacman doesn't own. Moving them out
 # of the way is what lets the upgrade through, and works on a leftover directory

--- a/test/shell.d/update-file-conflict-test.sh
+++ b/test/shell.d/update-file-conflict-test.sh
@@ -25,6 +25,17 @@ if [[ $1 == -Qo ]]; then
   exit $?
 fi
 
+if [[ $1 == -Qdq ]]; then
+  [[ " $DEPENDENCY_PACKAGES " == *" $2 "* ]]
+  exit $?
+fi
+
+if [[ $1 == -Qmq ]]; then
+  [[ " $RETIRED_PACKAGES " == *" $2 "* ]]
+  exit $?
+fi
+
+printf '%s\n' "$*" >>"$PACMAN_CALLS"
 attempt=$(($(cat "$PACMAN_ATTEMPTS") + 1))
 echo "$attempt" >"$PACMAN_ATTEMPTS"
 if ((attempt == 1)); then
@@ -51,6 +62,10 @@ run_update() {
     PACMAN_ATTEMPTS="$test_tmp/attempts" \
     CONFLICT_REPORT="$test_tmp/report" \
     OWNED_PATHS="${OWNED_PATHS:-}" \
+    DEPENDENCY_PACKAGES="${DEPENDENCY_PACKAGES:-}" \
+    RETIRED_PACKAGES="${RETIRED_PACKAGES:-}" \
+    PACMAN_CALLS="$test_tmp/pacman-calls" \
+    OMARCHY_UPDATE_REMOVE_CONFLICTS="${OMARCHY_UPDATE_REMOVE_CONFLICTS:-}" \
     PATH="$stub_bin:$ROOT/bin:$PATH" \
     bash "$ROOT/bin/omarchy-update-system-pkgs"
 }
@@ -58,6 +73,7 @@ run_update() {
 # $1 blamed package, $2 path, $3 optional owning package.
 write_report() {
   echo 0 >"$test_tmp/attempts"
+  : >"$test_tmp/pacman-calls"
   {
     echo "error: failed to commit transaction (conflicting files)"
     echo "$1: $2 exists in filesystem${3:+ (owned by $3)}"
@@ -67,6 +83,7 @@ write_report() {
 # Raw conflict lines, for reports the recovery must refuse wholesale.
 write_raw_report() {
   echo 0 >"$test_tmp/attempts"
+  : >"$test_tmp/pacman-calls"
   {
     echo "error: failed to commit transaction (conflicting files)"
     printf '%s\n' "$@"
@@ -251,6 +268,68 @@ fi
   fail "a symlink that dangles from the quarantine is never restored"
 pass "a dangling symlink is restored rather than stranded in the quarantine"
 
+# Repository package splits occasionally retire a dependency by moving its
+# contents into another package. Pacman knows the transaction is valid but its
+# conflict-removal prompt defaults to No under --noconfirm.
+write_raw_report \
+  ":: qemu-common-11.1.0-1 and qemu-block-gluster-11.0.3-1 are in conflict (qemu-block-gluster). Remove qemu-block-gluster? [y/N]" \
+  "error: unresolvable package conflicts detected" \
+  "error: failed to prepare transaction (conflicting dependencies)"
+DEPENDENCY_PACKAGES=qemu-block-gluster RETIRED_PACKAGES=qemu-block-gluster \
+  run_update >"$test_tmp/out" 2>"$test_tmp/err" ||
+  fail "a retired dependency blocks the package update"
+[[ $(cat "$test_tmp/attempts") == 2 ]] ||
+  fail "a retired dependency does not get one conflict-removal retry"
+tail -n 1 "$test_tmp/pacman-calls" | grep -q -- '--ask 4' ||
+  fail "the retry does not accept Pacman's conflict-removal prompt"
+grep -qF 'qemu-block-gluster' "$test_tmp/out" ||
+  fail "the update does not say which retired dependency it is removing"
+pass "a retired dependency is removed atomically with its replacement"
+
+# A package the user explicitly installed is their decision even after its
+# repository retires it. Never turn every package conflict into an automatic
+# removal just because this one transition is safe.
+write_raw_report \
+  ":: next-package-2-1 and chosen-package-1-1 are in conflict. Remove chosen-package? [y/N]" \
+  "error: unresolvable package conflicts detected"
+if RETIRED_PACKAGES=chosen-package run_update >"$test_tmp/out" 2>"$test_tmp/err"; then
+  fail "an explicitly installed package is removed to complete an update"
+fi
+[[ $(cat "$test_tmp/attempts") == 1 ]] ||
+  fail "an explicit package conflict triggers a retry"
+! grep -q -- '--ask 4' "$test_tmp/pacman-calls" ||
+  fail "an explicit package conflict is accepted non-interactively"
+pass "an explicit retired package conflict stays a human decision"
+
+# A dependency that still exists in a sync repository may be temporarily
+# conflicting or intentionally held. Its maintainer has not retired it, so the
+# update must not infer permission to remove it.
+write_raw_report \
+  ":: next-package-2-1 and published-package-1-1 are in conflict. Remove published-package? [y/N]" \
+  "error: unresolvable package conflicts detected"
+if DEPENDENCY_PACKAGES=published-package run_update >"$test_tmp/out" 2>"$test_tmp/err"; then
+  fail "a still-published dependency is removed to complete an update"
+fi
+[[ $(cat "$test_tmp/attempts") == 1 ]] ||
+  fail "a published package conflict triggers a retry"
+pass "a still-published dependency conflict stays a human decision"
+
+# Every removal prompt must be safe. Accepting only the first would let Pacman
+# decide the second one non-interactively under the same --ask bit.
+write_raw_report \
+  ":: replacement-one-2-1 and retired-dependency-1-1 are in conflict. Remove retired-dependency? [y/N]" \
+  ":: replacement-two-2-1 and explicit-package-1-1 are in conflict. Remove explicit-package? [y/N]" \
+  "error: unresolvable package conflicts detected"
+if DEPENDENCY_PACKAGES=retired-dependency RETIRED_PACKAGES="retired-dependency explicit-package" \
+  run_update >"$test_tmp/out" 2>"$test_tmp/err"; then
+  fail "a mixed safe and unsafe conflict set is accepted"
+fi
+[[ $(cat "$test_tmp/attempts") == 1 ]] ||
+  fail "a mixed conflict set triggers a partial retry"
+! grep -q -- '--ask 4' "$test_tmp/pacman-calls" ||
+  fail "a mixed conflict set accepts every removal prompt"
+pass "package conflict recovery is all-or-nothing"
+
 # The handler acts on a pacman report; an old or hand-written one would move
 # live files aside for an upgrade that is not happening.
 fresh_work
@@ -269,8 +348,10 @@ pass "the handler refuses a report handed to it outside an update"
 fresh_work
 : >"$test_tmp/report"
 echo 1 >"$test_tmp/attempts"
-run_update >"$test_tmp/out" 2>"$test_tmp/err" ||
+OMARCHY_UPDATE_REMOVE_CONFLICTS=1 run_update >"$test_tmp/out" 2>"$test_tmp/err" ||
   fail "a clean upgrade fails"
 [[ $(cat "$test_tmp/attempts") == 2 ]] ||
   fail "a clean upgrade runs more than one pacman transaction"
-pass "a clean upgrade runs a single pacman transaction"
+! grep -q -- '--ask 4' "$test_tmp/pacman-calls" ||
+  fail "a caller can enable automatic conflict removals directly"
+pass "a clean upgrade runs once without accepting conflict removals"


### PR DESCRIPTION
Keep upstream package splits from wedging unattended updates.

<<< AI wording below >>>

## Problem

`pacman -Syu --noconfirm` answers No to package-conflict removal prompts. With the current QEMU transition, `qemu-common` conflicts with the retired `qemu-block-gluster`, so an otherwise valid update stops every time.

## Fix

- Retry with Pacman's narrowly scoped conflict answer only when every removal target was installed as a dependency and is absent from the configured sync repositories
- Leave explicitly installed, still-published, and mixed safe/unsafe conflicts for a human
- Keep the existing one-retry boundary so a second failure cannot loop

Fixes #6818.

## Verification

- `bash test/shell.d/update-file-conflict-test.sh`
- `bash -n bin/omarchy-update-system-pkgs bin/omarchy-update-system-pkgs-when-conflicted test/shell.d/update-file-conflict-test.sh`
- `git diff --check`
