### PR TITLE
Open the first agent session in a normal tiled window too

### DIFF
--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -57,9 +57,9 @@ fi
 mkdir -p "$(dirname "$agent_file")"
 printf '%s\n' "$agent" >"$agent_file"
 
-if [[ $installing == "true" ]]; then
-  printf '\033[2J\033[3J\033[H'
-  exec omarchy-agent --inline
-else
-  exec omarchy-agent
-fi
+# The installation terminal is a floating one-off under org.omarchy.terminal,
+# so opening the agent inline there left the first session fixed at 875x600
+# under an app-id the agent window rules never match. Handing off to the
+# normal launch replaces it with the same tiled org.omarchy.agent window
+# every later launch gets.
+exec omarchy-agent

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -253,12 +253,12 @@ mapfile -d '' -t mise_args <"$mise_log"
   fail "visible agent installation activates the provider globally through mise"
 [[ $(omarchy-default-agent) == "copilot" ]] || fail "visible agent installation changes the selection after mise succeeds"
 [[ ! -s $notification_history ]] || fail "visible agent installation leaves progress to the terminal"
-[[ $(<"$test_tmp/install-output") == $'\033[2J\033[3J\033[H' ]] ||
-  fail "visible agent installation clears its terminal before opening the agent"
+[[ ! -s $test_tmp/install-output ]] ||
+  fail "visible agent installation leaves its terminal for the normal launch to replace"
 mapfile -d '' -t agent_open_args <"$agent_open_log"
-[[ ${#agent_open_args[@]} == 2 && ${agent_open_args[0]} == "omarchy-agent" && ${agent_open_args[1]} == "--inline" ]] ||
-  fail "newly installed agent opens in the installation terminal"
-pass "missing agents install visibly and open in the same terminal"
+[[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
+  fail "newly installed agent opens through the normal launch"
+pass "missing agents install visibly and open like every later launch"
 
 : >"$notification_history"
 : >"$agent_open_log"


### PR DESCRIPTION
Since 38542a1 the agent opens tiled, but the session that opens right after picking a default agent for the first time doesn't. `omarchy-default-agent` installs a missing agent inside `omarchy-launch-floating-terminal-with-presentation` and then `exec`s `omarchy-agent --inline`, so that first session runs inside the installation terminal: floating, fixed at 875x600 via the `floating-window` tag, and under `org.omarchy.terminal` rather than `org.omarchy.agent` — the app-id the agent window rules and themes single out. That's the fixed-logical-size shape 38542a1 removed, kept alive on exactly the session every new user meets first. Close it, press the keybinding again, and the window is suddenly tiled and full-size.

## Changes

- After a visible install writes the default, `omarchy-default-agent` now hands off to the normal `omarchy-agent` launch instead of running inline. The launch `setsid`s a fresh terminal under `org.omarchy.agent`, so the installation terminal closes and the first session opens tiled, identical to every later launch.
- The screen clear before the inline exec goes with it — there is no longer a terminal being reused to clear.
- `omarchy agent --inline` and the `a` alias are untouched; they are the deliberate run-in-this-terminal path.

## Testing

`default-agent-test.sh` already pinned the install flow; the two assertions that expected the inline reuse now expect the plain launch and no clear escape in the install output. All 23 checks in the file pass, and reverting only `bin/omarchy-default-agent` fails at the first of them (`visible agent installation leaves its terminal for the normal launch to replace`), so the test pins the fix.
