### PR TITLE
Show Bluetooth device kind on each row

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -38,6 +38,35 @@ function hasHumanName(device) {
   return label !== "" && !isUuidLike(label) && !isAddressLike(label)
 }
 
+function deviceIconName(device) {
+  if (!device) return ""
+  return String(device.icon || "").trim().toLowerCase().replace(/-symbolic$/, "")
+}
+
+function deviceKind(device) {
+  var icon = deviceIconName(device)
+  if (icon.indexOf("audio-card") === 0 || icon.indexOf("audio-speaker") === 0) return "speaker"
+  if (icon.indexOf("audio-headphone") === 0) return "headphones"
+  if (icon.indexOf("audio-headset") === 0) return "headset"
+  if (icon.indexOf("input-keyboard") === 0) return "keyboard"
+  if (icon.indexOf("input-mouse") === 0) return "mouse"
+  if (icon.indexOf("input-gaming") === 0) return "gamepad"
+  if (icon.indexOf("input-tablet") === 0) return "tablet"
+  if (icon === "phone" || icon.indexOf("phone-") === 0) return "phone"
+  return ""
+}
+
+function deviceGlyph(kind, connected) {
+  if (kind === "speaker") return "󰓃"
+  if (kind === "headphones" || kind === "headset") return "󰋋"
+  if (kind === "keyboard") return "󰌌"
+  if (kind === "mouse") return "󰍽"
+  if (kind === "gamepad") return "󰊴"
+  if (kind === "tablet") return "󰓫"
+  if (kind === "phone") return "󰄜"
+  return connected ? "󰂱" : "󰂯"
+}
+
 function nodeProps(node) {
   return node && node.ready && node.properties ? node.properties : {}
 }
@@ -91,6 +120,7 @@ function deviceRow(d) {
     address: d.address || "",
     name: d.name || "",
     deviceName: d.deviceName || "",
+    icon: d.icon || "",
     connected: !!d.connected,
     state: d.state !== undefined ? d.state : -1,
     batteryAvailable: !!d.batteryAvailable,
@@ -162,6 +192,9 @@ if (typeof module !== "undefined") {
     isAddressLike: isAddressLike,
     normalizedAddress: normalizedAddress,
     hasHumanName: hasHumanName,
+    deviceIconName: deviceIconName,
+    deviceKind: deviceKind,
+    deviceGlyph: deviceGlyph,
     nodeProps: nodeProps,
     nodeText: nodeText,
     bluetoothSinkMatchesDevice: bluetoothSinkMatchesDevice,

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -971,7 +971,7 @@ Panel {
 
       Text {
         id: deviceIcon
-        text: row.isConnected ? "󰂱" : "󰂯"
+        text: Model.deviceGlyph(Model.deviceKind(row.dev), row.isConnected)
         color: row.statusColor
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.heading

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -56,6 +56,16 @@ assertEqual(bluetooth.normalizedAddress('AA:BB_CC-dd-ee-ff'), 'aabbccddeeff', 'b
 assert(!bluetooth.hasHumanName({ name: 'AA:BB:CC:DD:EE:FF' }), 'bluetooth rejects address-only device labels')
 assert(bluetooth.hasHumanName({ deviceName: 'MX Master 3S' }), 'bluetooth accepts human device labels')
 
+assertEqual(bluetooth.deviceKind({ icon: 'audio-card' }), 'speaker', 'bluetooth maps audio-card to speaker')
+assertEqual(bluetooth.deviceKind({ icon: 'audio-headphones' }), 'headphones', 'bluetooth maps audio-headphones')
+assertEqual(bluetooth.deviceKind({ icon: 'input-keyboard' }), 'keyboard', 'bluetooth maps input-keyboard')
+assertEqual(bluetooth.deviceKind({ icon: 'input-mouse' }), 'mouse', 'bluetooth maps input-mouse')
+assertEqual(bluetooth.deviceKind({ icon: 'input-gaming' }), 'gamepad', 'bluetooth maps input-gaming')
+assertEqual(bluetooth.deviceKind({ icon: '' }), '', 'bluetooth gives icon-less devices no kind')
+assertEqual(bluetooth.deviceGlyph('speaker', false), '󰓃', 'bluetooth uses the speaker glyph')
+assertEqual(bluetooth.deviceGlyph('keyboard', true), '󰌌', 'bluetooth uses the keyboard glyph')
+assertEqual(bluetooth.deviceGlyph('', true), '󰂱', 'bluetooth keeps the connected glyph when kind is unknown')
+
 const devices = [
   { name: 'Speaker', connected: false, paired: true, address: '2' },
   { name: 'Headphones', connected: true, address: '1' },
@@ -79,6 +89,15 @@ const lists = bluetooth.deviceLists(devices)
 assertDeepEqual(lists.connected.map(bluetooth.deviceLabel), ['Headphones'], 'bluetooth groups connected devices')
 assertDeepEqual(lists.known.map(bluetooth.deviceLabel), ['Mouse', 'Speaker'], 'bluetooth groups known devices by label')
 assertDeepEqual(lists.discovered.map(bluetooth.deviceLabel), ['Keyboard'], 'bluetooth groups discovered devices')
+assertDeepEqual(
+  bluetooth.deviceLists([
+    { name: 'soundcore Boom 2', address: 'aa', icon: 'audio-card' },
+    { name: 'soundcore Boom 2', address: 'bb' },
+    { name: 'FB0467', address: 'cc' }
+  ]).discovered.map(function(d) { return d.address }).sort(),
+  ['aa', 'bb', 'cc'],
+  'bluetooth keeps every named device in Available, including icon-less radios'
+)
 assertDeepEqual(bluetooth.visibleSections(lists, true), ['connected', 'known', 'discovered'], 'bluetooth shows discovered section while scanning')
 assertDeepEqual(bluetooth.visibleSections(lists, false), ['connected', 'known'], 'bluetooth hides discovered section when not scanning')
 
@@ -94,7 +113,7 @@ assertDeepEqual(arrayLikeLists.discovered.map(bluetooth.deviceLabel), ['Gamepad'
 
 assertDeepEqual(
   bluetooth.deviceRow({ name: 'Deadbeef', address: '1', connected: false }),
-  { address: '1', name: 'Deadbeef', deviceName: '', connected: false, state: -1, batteryAvailable: false, battery: 0, pairing: false },
+  { address: '1', name: 'Deadbeef', deviceName: '', icon: '', connected: false, state: -1, batteryAvailable: false, battery: 0, pairing: false },
   'bluetooth projects device rows with primitives only'
 )
 assertEqual(


### PR DESCRIPTION
## Problem

Every row in the Bluetooth panel uses the same pair of glyphs: connected `󰂱`, everything else `󰂯`. A speaker, a keyboard, a mouse, and a pair of headphones look identical. The only way to tell them apart is the name.

That is worse than it sounds on dual-radio hardware. A Soundcore Boom 2 (and similar Anker speakers) advertises two devices with the same name: a classic A2DP speaker (`Icon: audio-card`) and a BLE app radio with no icon and no audio sink. In the panel they are two rows that say "soundcore Boom 2" with the same Bluetooth rune. Pairing the BLE one succeeds, produces no sink, and the audio panel has nothing to switch to.

BlueZ already classifies the useful ones. Quickshell exposes that as `BluetoothDevice.icon` (`audio-card`, `audio-headphones`, `input-keyboard`, `input-mouse`, `input-gaming`, …). The panel never read it. The audio panel already maps the same ideas to speaker / headphone glyphs.

## What changes

`Model.js` maps `device.icon` to a kind, then to a glyph:

| BlueZ `Icon` | Kind | Glyph |
|---|---|---|
| `audio-card`, `audio-speakers` | speaker | `󰓃` (same as the audio panel) |
| `audio-headphones`, `audio-headset` | headphones / headset | `󰋋` |
| `input-keyboard` | keyboard | `󰌌` |
| `input-mouse` | mouse | `󰍽` |
| `input-gaming` | gamepad | `󰊴` |
| `input-tablet` | tablet | `󰓫` |
| `phone` | phone | `󰄜` |
| empty / unknown | — | the existing `󰂱` / `󰂯` |

`Panel.qml` uses that for the row icon. One line. `deviceRow()` carries `icon` so the primitive-only delegates can still render after a BlueZ object goes away.

<img width="740" height="1192" alt="screenshot-2026-08-13_17-56-20" src="https://github.com/user-attachments/assets/099a1a94-1bd5-45df-9155-d7acd80166b6" />


## What this does not do

- It does not hide rows. Available still lists every named device, including icon-less companion radios and stray LE names. Filtering that list was considered and dropped: the panel does not decide what the user is allowed to see.
- It does not change pair / connect / forget.
- It does not move the default sink.
- It does not add MAC addresses to the UI.

An icon-less radio still looks like a generic Bluetooth device. That is honest. The speaker radio next to it now looks like a speaker.

## Tests

`test/shell.d/bluetooth-test.sh` covers the icon → kind → glyph map and asserts a same-name speaker plus an icon-less companion both stay in Available.

```
bash test/shell.d/bluetooth-test.sh
```

## Test plan

- [x] `bash test/shell.d/bluetooth-test.sh`
- [x] Speaker / headphones / keyboard / mouse / gamepad rows use the matching glyph
- [x] A device with no BlueZ icon still uses `󰂱` / `󰂯`
- [x] Available still lists unpaired neighbors while the panel is open and scanning