### PR TITLE
Capture image-data avatars so notification history can show them

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -195,8 +195,9 @@ function popupFileName(entry) {
 // senders (all Omarchy web apps) delete their scoped /tmp files on close,
 // and image-data hints surface as in-process image:// URLs that die with
 // the server object. Persisted entries therefore reference their own
-// copies, named by the entry's file stem so cleanup can find them from
-// the JSON file name alone.
+// copies — duplicated files for the former, PNGs grabbed off the live
+// object for the latter (see ImageCapture) — named by the entry's file
+// stem so cleanup can find them from the JSON file name alone.
 
 var PERSISTED_IMAGE_ROLES = ["appIcon", "image"]
 
@@ -216,29 +217,36 @@ function localImageFile(value) {
   return s.charAt(0) === "/" ? s : ""
 }
 
-// The entry as it should hit the disk, plus the copies that make it true.
-// File-backed images redirect to their copy under imagesDir; dead image://
-// URLs drop to "" (the card falls back to the app icon). Already-redirected
-// values map onto themselves and produce no copy, keeping restores no-ops.
+// The entry as it should hit the disk, plus the work that makes it true:
+// `copies` are file-backed images to duplicate under imagesDir, `captures`
+// are in-process image:// URLs whose pixels must be grabbed to a PNG while
+// the sender is still alive. Values already pointing under imagesDir are
+// kept as they are, so restores and replays stay no-ops.
 function persistablePopup(entry, imagesDir) {
   var e = entry || {}
   var out = {}
   for (var key in e) out[key] = e[key]
+  var dir = String(imagesDir || "")
   var copies = []
+  var captures = []
   for (var i = 0; i < PERSISTED_IMAGE_ROLES.length; i++) {
     var role = PERSISTED_IMAGE_ROLES[i]
     var value = String(out[role] || "")
     if (!value) continue
+    var target = dir + imageStem(e) + "-" + role
     var source = localImageFile(value)
     if (source) {
-      var copy = String(imagesDir || "") + imageStem(e) + "-" + role
-      if (source !== copy) copies.push({ from: source, to: copy })
-      out[role] = "file://" + copy
+      if (dir && source.indexOf(dir) === 0) continue
+      copies.push({ from: source, to: target })
+      out[role] = "file://" + target
     } else if (value.indexOf("image://") === 0) {
-      out[role] = ""
+      // grabToImage saves by extension, so captures carry one; the cleanup
+      // globs all match on the stem prefix and tolerate it.
+      captures.push({ url: value, to: target + ".png" })
+      out[role] = "file://" + target + ".png"
     }
   }
-  return { entry: out, copies: copies }
+  return { entry: out, copies: copies, captures: captures }
 }
 
 function serializePopup(entry, normalUrgency) {

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -414,6 +414,26 @@ Item {
     running: false
   }
 
+  // Grabs image-data pixels (in-process image:// URLs) into files under
+  // imagesDir so persisted entries can reference them past the sender.
+  ImageCapture { id: imageCapture }
+
+  // Kick off the image:// grabs a persistable entry needs. `done` fires once
+  // every capture has finished, successfully or not.
+  function startCaptures(captures, done) {
+    var remaining = captures.length
+    if (remaining === 0) {
+      if (done) done()
+      return
+    }
+    for (var i = 0; i < captures.length; i++) {
+      imageCapture.request(captures[i].url, captures[i].to, function() {
+        remaining--
+        if (remaining === 0 && done) done()
+      })
+    }
+  }
+
   // ---------------------------------------------------- popup persistence
   //
   // Mirror every on-screen popup to its own file under popupStateDir so
@@ -499,7 +519,11 @@ Item {
     // summaries/bodies with quotes or backticks can't break the command. The
     // mkdir guards notifications that arrive before ensureDirsProc has run.
     // Copies run before the JSON referencing them, while the source exists.
+    // Captures run beside the write, not ahead of it: the JSON references
+    // the capture's target optimistically, and a card that finds the file
+    // missing falls back to the app icon.
     var persistable = NotificationLogic.persistablePopup(snapshot, imagesDir)
+    startCaptures(persistable.captures)
     var command = ["bash", "-c",
       "mkdir -p \"$1\" \"$2\" || exit 0\n" +
       "dir=\"$1\" json=\"$3\" name=\"$4\"\n" +
@@ -567,6 +591,15 @@ Item {
       return
     }
     var persistable = NotificationLogic.persistablePopup(entry, imagesDir)
+    // `done` releases the silenced notification (see writeSilenced), and the
+    // captures read pixels off that live object — so completion waits for
+    // them as well as the file write.
+    var pending = 2
+    function finished() {
+      pending--
+      if (pending === 0 && done) done()
+    }
+    startCaptures(persistable.captures, finished)
     var command = ["bash", "-c",
       "mkdir -p \"$1\" \"$5\" || exit 0\n" +
       "hist=\"$1\" limit=\"$2\" name=\"$3\" json=\"$4\" imgs=\"$5\"\n" +
@@ -581,7 +614,7 @@ Item {
       imagesDir]
     for (var i = 0; i < persistable.copies.length; i++)
       command.push(persistable.copies[i].from, persistable.copies[i].to)
-    enqueuePopupFileJob(command, done)
+    enqueuePopupFileJob(command, finished)
   }
 
   function clearHistory() {

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -426,12 +426,26 @@ Item {
       if (done) done()
       return
     }
-    for (var i = 0; i < captures.length; i++) {
-      imageCapture.request(captures[i].url, captures[i].to, function() {
+    function one(job) {
+      imageCapture.request(job.url, job.to, function() {
+        service.sweepCaptureImage(job.to)
         remaining--
         if (remaining === 0 && done) done()
       })
     }
+    for (var i = 0; i < captures.length; i++) one(captures[i])
+  }
+
+  // Captures run outside the file queue, so one can land after the trim,
+  // clear, or delete that removed its entry — recreating an image nothing
+  // owns until the startup sweep. Re-check this one file through the queue:
+  // queued behind whatever removed the entry, it sees the final state.
+  function sweepCaptureImage(to) {
+    enqueuePopupFileJob(["bash", "-c",
+      "stem=\"${3##*/}\"\n" +
+      "stem=\"${stem%-*}\"\n" +
+      "[[ -e $1/$stem.json || -e $2/$stem.json ]] || rm -f \"$3\"", "--",
+      popupStateDir, historyDir, to])
   }
 
   // ---------------------------------------------------- popup persistence

--- a/shell/plugins/notifications/components/ImageCapture.qml
+++ b/shell/plugins/notifications/components/ImageCapture.qml
@@ -1,0 +1,115 @@
+// Captures in-process image:// URLs into files under the notification state
+// dir. An image-data hint only exists as pixels served by the live
+// Notification object's image provider — there is no file to copy, and the
+// pixels die with the sender. Rendering the URL into an Image and grabbing
+// the result is the only way to keep them.
+//
+// grabToImage needs its item attached to a mapped window, and a DND-silenced
+// notification never puts one on screen — so captures run inside a 1x1
+// transparent overlay surface that maps only while a grab is pending.
+
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+
+Item {
+  id: capture
+
+  // Pending {url, to, done} jobs. One at a time: a single Image is the
+  // render source, and each grab must finish before its source changes.
+  property var queue: []
+  property var current: null
+
+  // Largest edge a capture keeps. Avatars are small; a hostile sender must
+  // not be able to park a wall-sized image in the state dir.
+  readonly property int maxDimension: 512
+
+  function request(url, to, done) {
+    queue.push({ url: String(url || ""), to: String(to || ""), done: done || null })
+    pump()
+  }
+
+  function pump() {
+    if (current || queue.length === 0) return
+    current = queue.shift()
+    grabber.source = current.url
+    deadline.restart()
+    attempt()
+  }
+
+  // Runs on every state change that could unblock the grab: the image loads,
+  // the surface maps. grabToImage fails until the window is mapped and has
+  // rendered, so a false start just retries until the deadline gives up.
+  function attempt() {
+    if (!capture.current) return
+    if (grabber.status === Image.Error) {
+      finish(false)
+      return
+    }
+    if (grabber.status !== Image.Ready) return
+    var w = Math.max(1, grabber.implicitWidth)
+    var h = Math.max(1, grabber.implicitHeight)
+    var scale = Math.min(1, maxDimension / Math.max(w, h))
+    var job = capture.current
+    var started = grabber.grabToImage(function(result) {
+      if (capture.current !== job) return
+      capture.finish(result.saveToFile(job.to))
+    }, Qt.size(Math.max(1, Math.round(w * scale)), Math.max(1, Math.round(h * scale))))
+    if (!started) retry.restart()
+  }
+
+  function finish(ok) {
+    var job = current
+    if (!job) return
+    current = null
+    grabber.source = ""
+    deadline.stop()
+    retry.stop()
+    if (job.done) {
+      try {
+        job.done(!!ok)
+      } catch (e) {
+        console.warn("notifications: capture callback failed:", e)
+      }
+    }
+    pump()
+  }
+
+  Timer {
+    id: retry
+    interval: 100
+    onTriggered: capture.attempt()
+  }
+
+  // A sender can die mid-grab (its provider then never loads) — give up so
+  // the queue moves on; the entry's card falls back to the app icon.
+  Timer {
+    id: deadline
+    interval: 3000
+    onTriggered: capture.finish(false)
+  }
+
+  PanelWindow {
+    visible: capture.current !== null
+    WlrLayershell.namespace: "omarchy-notification-capture"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    exclusionMode: ExclusionMode.Ignore
+    color: "transparent"
+    implicitWidth: 1
+    implicitHeight: 1
+    anchors { top: true; left: true }
+    mask: Region {}
+
+    Image {
+      id: grabber
+      // Off the 1x1 surface: the grab renders the item into its own buffer,
+      // so the image itself must never paint on screen.
+      x: 4
+      y: 4
+      cache: false
+      asynchronous: true
+      onStatusChanged: capture.attempt()
+    }
+  }
+}

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -34,9 +34,14 @@ BorderSurface {
 
   signal closeRequested()
   signal cardClicked()
+  // A persisted image reference can go stale — a capture that never landed,
+  // a trimmed copy — so a load failure falls back to the app icon.
+  property bool imageFailed: false
+  onImageChanged: imageFailed = false
+
   // Prefer per-notification media/avatar data, then fall back to the app icon.
   // The `check` flag avoids Qt's missing-texture placeholder for unknown names.
-  readonly property string smallIconSource: image.length > 0 ? image : iconSource(appIcon)
+  readonly property string smallIconSource: image.length > 0 && !imageFailed ? image : iconSource(appIcon)
   readonly property bool hasGlyph: glyph.length > 0
   readonly property bool compactGlyph: NotificationLogic.shouldRenderCompactGlyph(glyph, smallIconSource, singleLineToast)
   readonly property bool hasSmallIcon: smallIconSource.length > 0
@@ -128,6 +133,12 @@ BorderSurface {
           asynchronous: true
           smooth: true
           visible: !root.hasGlyph || smallIconImage.status === Image.Ready
+          // When image.length > 0 and imageFailed is still false, the source
+          // IS the image — so this error is the image's, not the app icon's.
+          onStatusChanged: {
+            if (status === Image.Error && root.image.length > 0 && !root.imageFailed)
+              root.imageFailed = true
+          }
         }
 
         // Glyph fallback (Nerd Font character) when no image icon is

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -472,6 +472,11 @@ assert(
   'notifications service grabs image-data pixels when persisting a popup'
 )
 assert(
+  /service\.sweepCaptureImage\(job\.to\)/.test(serviceQml) &&
+    /function sweepCaptureImage\(to\)[\s\S]{0,500}?\|\| rm -f \\"\$3\\"/.test(serviceQml),
+  'notifications service sweeps a capture that landed after its entry was removed'
+)
+assert(
   /startCaptures\(persistable\.captures, finished\)[\s\S]{0,1000}?enqueuePopupFileJob\(command, finished\)/.test(serviceQml),
   'notifications service holds a silenced notification for its captures as well as its write'
 )

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -289,22 +289,35 @@ assertEqual(
   'file:///state/images/2000-9-appIcon',
   'notifications persist the image copy instead of the sender-owned original'
 )
-assertEqual(persistable.entry.image, '', 'notifications drop dead in-process image URLs from persisted entries')
+assertDeepEqual(
+  persistable.captures,
+  [{ url: 'image://notifs/9', to: '/state/images/2000-9-image.png' }],
+  'notifications capture in-process image URLs while the sender is alive'
+)
+assertEqual(
+  persistable.entry.image,
+  'file:///state/images/2000-9-image.png',
+  'notifications persist the capture an in-process image URL will be grabbed to'
+)
 assertEqual(persistable.entry.summary, 'Hi', 'notifications leave the rest of the persisted entry untouched')
 
 const repersisted = notifications.persistablePopup(persistable.entry, '/state/images/')
 assertDeepEqual(repersisted.copies, [], 'notifications do not re-copy an entry already pointing at its copies')
+assertDeepEqual(repersisted.captures, [], 'notifications do not re-capture an entry already pointing at its capture')
 assertEqual(
   repersisted.entry.appIcon,
   'file:///state/images/2000-9-appIcon',
   'notifications keep a restored entry pointing at its existing copy'
 )
-
 assertEqual(
-  notifications.persistablePopup({ id: 9, originalId: 9, timestamp: 2000, appIcon: 'mail', image: '' }, '/state/images/').copies.length,
-  0,
-  'notifications leave themed icons alone when persisting'
+  repersisted.entry.image,
+  'file:///state/images/2000-9-image.png',
+  'notifications keep a restored entry pointing at its existing capture'
 )
+
+const themedOnly = notifications.persistablePopup({ id: 9, originalId: 9, timestamp: 2000, appIcon: 'mail', image: '' }, '/state/images/')
+assertEqual(themedOnly.copies.length, 0, 'notifications leave themed icons alone when persisting')
+assertEqual(themedOnly.captures.length, 0, 'notifications have nothing to capture without an in-process image URL')
 assertEqual(
   notifications.imageStem({ originalId: 9, timestamp: 2000 }) + '.json',
   notifications.popupFileName({ originalId: 9, timestamp: 2000 }),
@@ -453,6 +466,28 @@ assert(
 assert(
   /function sweepOrphanImages\(\)[\s\S]{0,400}?\|\| rm -f \\"\$img\\"/.test(serviceQml),
   'notifications service sweeps image copies whose JSON never landed'
+)
+assert(
+  /var persistable = NotificationLogic\.persistablePopup\(snapshot, imagesDir\)\s*\n\s*startCaptures\(persistable\.captures\)/.test(serviceQml),
+  'notifications service grabs image-data pixels when persisting a popup'
+)
+assert(
+  /startCaptures\(persistable\.captures, finished\)[\s\S]{0,1000}?enqueuePopupFileJob\(command, finished\)/.test(serviceQml),
+  'notifications service holds a silenced notification for its captures as well as its write'
+)
+
+const captureQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/components/ImageCapture.qml'), 'utf8')
+assert(
+  /grabToImage\(function\(result\) \{[\s\S]{0,200}?saveToFile\(job\.to\)/.test(captureQml),
+  'notifications capture grabs the rendered image into the persisted file'
+)
+assert(
+  /visible: capture\.current !== null/.test(captureQml),
+  'notifications capture surface maps only while a grab is pending'
+)
+assert(
+  /id: deadline[\s\S]{0,120}?onTriggered: capture\.finish\(false\)/.test(captureQml),
+  'notifications capture gives up on a sender that dies mid-grab'
 )
 assert(
   /service\.replayCarryOver = liveRowsForReplay\(\)/.test(serviceQml),


### PR DESCRIPTION
Recalling notification history showed the Signal logo instead of the sender's avatar. Signal (and other chat apps) send avatars as raw pixels in the `image-data` hint, which Quickshell serves from an in-process `image://` provider that dies with the notification — there is no file to copy, so persisted entries dropped the image and replays fell back to the app icon.

## What changed

- **`components/ImageCapture.qml`** (new): renders an `image://` URL into an offscreen `Image` and saves it with `grabToImage().saveToFile()`. A grab needs a mapped, rendered window and a DND-silenced notification never shows one, so captures run in a 1x1 transparent overlay surface that maps only while a grab is pending, with a retry loop and a deadline for senders that die mid-grab.
- **`NotificationLogic.js`**: `persistablePopup` returns a `captures` list for `image://` values and points the persisted entry at the capture target, instead of blanking the image. Values already under the images dir pass through untouched, keeping restores and replays no-ops.
- **`Service.qml`**: starts captures when persisting. Popup writes don't wait — the JSON references the capture optimistically. The silenced path holds the tracked notification until captures finish as well as the write, since the grab reads pixels off the live object.
- **`components/NotificationCard.qml`**: a stale image reference (failed capture, trimmed copy) now falls back to the app icon instead of hiding the icon slot.

Captured PNGs are named by the entry's file stem, so the existing `<stem>-*` cleanup globs (history trim, superseded-popup delete, orphan sweep) handle them with no changes.

## Verification

- Extended `test/shell.d/notifications-test.sh` covering the capture plan, no-op repersists, and the service/component wiring; suite passes.
- Live in the running shell: sent a synthetic `image-data` notification (checkerboard avatar, same mechanism as Signal). The avatar showed on the live toast, survived dismissal into history replay, and was captured for a DND-silenced notification with no popup on screen. Shell log clean.

Entries persisted before this change keep the app-icon fallback — their pixels died with the original notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)