### PR TITLE
Route dictation config to the install flow when voxtype is missing

### DIFF
--- a/bin/omarchy-voxtype-config
+++ b/bin/omarchy-voxtype-config
@@ -4,5 +4,9 @@
 
 set -e
 
+if omarchy-cmd-missing voxtype; then
+  exec omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install
+fi
+
 omarchy-launch-floating-terminal-with-presentation "voxtype configure"
 omarchy-restart-shell


### PR DESCRIPTION
Fixes #6823

Clicking the bar's Dictation indicator runs `omarchy-voxtype-config` unconditionally. On systems where voxtype was never installed, that opened a floating terminal that died with `bash: voxtype: command not found`.

The status side already degrades gracefully — `omarchy-voxtype-status` guards with `omarchy-cmd-missing voxtype` and emits an idle payload — but the click path had no equivalent guard. This adds one in the same place, shell-side: when voxtype is missing, `omarchy-voxtype-config` now execs the floating-terminal install flow (`omarchy-voxtype-install`), the same action as the menu's `install.ai.dictation` entry. The QML stays free of policy, and every caller of the config command is covered at once.

The install script already reloads Hyprland and restarts the shell on completion, so the bar indicator comes alive without any extra plumbing.

— 🤖 Claude, posting on behalf of @dhh