### PR TITLE
[Quattro] Bug fix. Keep the Copy URL migration's browser prompt visible

### DIFF
--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -134,12 +134,14 @@ if (( ! ${#pending[@]} )) && ! unverified_repairs_exist; then
 fi
 
 # A running browser holds Preferences in memory and rewrites the file on exit,
-# reverting the repair, so ask for the windows to be closed first. Without a
-# terminal to ask in, gum fails; then — as on decline — fail so the migration
-# stays pending, and the login notifier keeps prompting until a rerun goes
-# through with browsers closed.
+# reverting the repair, so ask for the windows to be closed first. gum draws
+# the prompt on stderr, so it must stay attached: suppressing it leaves gum
+# waiting for a keypress behind an unpainted screen. Without a terminal to ask
+# in, gum fails; then — as on decline — fail so the migration stays pending,
+# and the login notifier keeps prompting until a rerun goes through with
+# browsers closed.
 while browsers_running; do
-  if ! gum confirm "Close all browser windows to repair the Copy URL shortcut, then continue" 2>/dev/null; then
+  if ! gum confirm "Close all browser windows to repair the Copy URL shortcut, then continue"; then
     echo "A running browser would undo the Copy URL shortcut repair." >&2
     echo "Close all browser windows, then run: omarchy-migrate" >&2
     exit 1

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -45,6 +45,20 @@ run_migration && fail "migration defers while a browser is running"
   fail "migration leaves preferences alone while a browser is running"
 pass "migration defers the repair while a browser is running"
 
+# gum paints its prompt on stderr, so that stream has to stay attached:
+# suppressing it leaves gum reading keys behind an unpainted screen, which
+# reads as a hung update.
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+echo "gum-prompt-painted" >&2
+exit 1
+STUB
+prompt_stderr="$test_dir/prompt-stderr"
+HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>"$prompt_stderr" &&
+  fail "migration defers when the browser prompt is declined"
+grep -q "gum-prompt-painted" "$prompt_stderr" || fail "migration keeps the browser prompt visible"
+pass "migration keeps the browser prompt visible"
+
 # Confirming the prompt after closing the browser lets the repair proceed.
 cat >"$stub_bin/gum" <<'STUB'
 #!/bin/bash


### PR DESCRIPTION
An update with a browser open stops after `Running migration (1786643346)` and looks hung. It isn't: `gum confirm` draws its entire UI on stderr, so the migration's `2>/dev/null` discards the prompt while gum still holds the terminal in raw mode reading keys. The user sees a frozen screen with a live prompt behind it, and typed keys don't echo either.

Dropping the redirect restores the prompt. It was only ever hiding gum's own "no TTY" error in the headless case — where the migration already prints its own explanation on stderr before deferring — and no other `gum confirm` in the repo suppresses stderr.

Worth noting how the stall compounds: declining (or blindly answering) leaves the migration `exit 1`, and `omarchy-update` runs under `set -e`, so the whole update aborts before the post-update hook, AUR packages, mise, and orphan cleanup — then re-prompts, still invisibly, at the next login.

The regression test asserts the prompt's stderr reaches the caller; it fails with the redirect restored.

Fixes #6841

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So4yKzTDdJJp7orjnF8i1J