### PR TITLE
Fix jittery scrolling on Dell XPS 13 Wildcat Lake by disabling PSR and Panel Replay

### DIFF
--- a/bin/omarchy-hw-intel-wcl
+++ b/bin/omarchy-hw-intel-wcl
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer has an Intel Wildcat Lake GPU.
+
+lspci | grep -iE 'vga|3d|display' | grep -qi 'wildcat lake'

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -23,6 +23,7 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/ptl-kernel.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/ipu7-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"
+run_logged "$OMARCHY_INSTALL/hardware/intel/fix-xps-wcl-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/sof-firmware.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"

--- a/install/hardware/intel/fix-xps-wcl-display.sh
+++ b/install/hardware/intel/fix-xps-wcl-display.sh
@@ -1,0 +1,21 @@
+# Display fix for Dell XPS 13 on Wildcat Lake (Xe3 iGPU).
+#
+# The eDP panel negotiates Panel Replay Selective Update (Early Transport)
+# by default, and its sleep/wake path stalls frame updates: the panel drops
+# into self-refresh between updates and wakes late, so frames are skipped in
+# bursts during scrolling and animation (i915_edp_psr_status shows the source
+# sitting in SLEEP). Toggling i915_edp_psr_debug at runtime confirms the
+# panel is the cause. Same Xe3 pathology as the ASUS B9406 fix, on the
+# Wildcat Lake generation the old Panther Lake XPS gate never matched.
+#
+# Both knobs are needed: xe.enable_psr=0 does not cover Panel Replay, and
+# disabling only Panel Replay falls back to PSR2 selective fetch, which
+# stutters the same way on this panel.
+
+if omarchy-hw-match "XPS" && omarchy-hw-intel-wcl; then
+  mkdir -p /etc/limine-entry-tool.d
+  cat > /etc/limine-entry-tool.d/dell-xps-wcl-display.conf <<'EOF'
+# Dell XPS (Wildcat Lake / Xe3) display workaround
+KERNEL_CMDLINE[default]+=" xe.enable_psr=0 xe.enable_panel_replay=0"
+EOF
+fi


### PR DESCRIPTION
Scrolling and animation on the Dell XPS 13 DX13260 (Wildcat Lake, 2560x1600@120Hz IPS eDP) is visibly juddery out of the box: frames are skipped in bursts, so motion looks like it runs at a much lower framerate than the panel. Mainly observed while scrolling in Google Chrome (x.com and other sites), but the stall is panel-level, not app-level — a clean flag-less Chrome profile reproduced it identically.

The panel negotiates **Panel Replay Selective Update (Early Transport)** by default and its sleep/wake path stalls frame updates — `i915_edp_psr_status` shows the source sitting in `SLEEP` with Panel Replay SU active. Disabling it at runtime makes scrolling smooth immediately, which isolates the panel as the cause:

```
echo 1 | sudo tee /sys/kernel/debug/dri/0000:00:02.0/i915_edp_psr_debug
```

This is the same Xe3 pathology as `fix-asus-ptl-b9406-display.sh`, and the same class of issue the old Panther Lake XPS fix (#5315) covered before it was retired in favor of linux-ptl kernel patches — but Wildcat Lake XPS machines run the stock Arch kernel (7.1.8 here), where the problem is alive and well, and the PTL gate never matched this generation.

Both parameters are needed: `xe.enable_psr=0` does not cover Panel Replay (per the B9406 fix), and disabling only Panel Replay falls back to PSR2 selective fetch, which stutters the same way on this panel.

## Tradeoff

PSR/Panel Replay exist purely for power saving: with a static screen the panel refreshes itself from its own buffer so the display engine and eDP link can sleep. Disabling both costs roughly 0.5–1.5W while the screen is static (near zero during video/scrolling, when self-refresh can't engage anyway) — so some idle battery life is traded for correct frame delivery. No functional downside; this is the same trade the B9406 fix and the old #5315 already make on their hardware. If the panel's wake path gets fixed in the kernel later (as happened for PTL via linux-ptl), this workaround can be retired the same way.

Tested on XPS 13 DX13260 (Core 5 320, `lspci`: "Wildcat Lake [Intel Graphics]"). Happy to add a migration for existing installs if you'd like — kept it install-only to match the B9406 precedent.

Fixes #6853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)