### PR TITLE
Point the headless theme test at the renumbered Tokyo Night background

### DIFF
--- a/test/cli
+++ b/test/cli
@@ -513,7 +513,7 @@ pass "claude theme activation preserves configured settings"
 make_tmpdir THEME_TMPDIR
 OMARCHY_PATH="$ROOT" HOME="$THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"
 background_path=$(readlink -f "$THEME_TMPDIR/.local/state/omarchy/current/background" 2>/dev/null || true)
-expected_background="$THEME_TMPDIR/.local/state/omarchy/current/theme/backgrounds/0-swirl-buck.jpg"
+expected_background="$THEME_TMPDIR/.local/state/omarchy/current/theme/backgrounds/0-winding-road.jpg"
 [[ $background_path == "$expected_background" ]] || fail "headless theme set creates current background symlink"
 [[ -f $background_path ]] || fail "headless theme background target exists"
 [[ ! -e $THEME_TMPDIR/.config/omarchy/current ]] || fail "headless theme set avoids config current state"


### PR DESCRIPTION
test/cli has been red on quattro since 9c9e0829 renumbered the Tokyo Night backgrounds: the headless theme-set assertion still expects `0-swirl-buck.jpg`, but that file is now `2-swirl-buck.jpg` and the theme's first background is `0-winding-road.jpg`. Every PR branched from quattro currently inherits the failure.

— 🤖 Claude, posting on behalf of @dhh