### PR TITLE
Suppress LocalSend's redundant tray item

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -159,9 +159,9 @@ BarWidget {
     return "drawer"
   }
 
-  function ownedByDedicatedWidget(item) {
+  function ownedByOmarchy(item) {
     var layout = root.bar && root.bar.layoutConfig ? root.bar.layoutConfig : null
-    return TrayModel.ownedByDedicatedWidget(item, layout)
+    return TrayModel.ownedByOmarchy(item, layout)
   }
 
   function bucket(category) {
@@ -170,7 +170,7 @@ BarWidget {
     for (var i = 0; i < values.length; i++) {
       var item = values[i]
       if (item.status === Status.Passive) continue
-      if (ownedByDedicatedWidget(item)) continue
+      if (ownedByOmarchy(item)) continue
       if (category === "all") {
         result.push(item)
         continue

--- a/shell/plugins/bar/widgets/TrayModel.js
+++ b/shell/plugins/bar/widgets/TrayModel.js
@@ -2,11 +2,11 @@ function text(value) {
   return String(value || "").toLowerCase()
 }
 
-function isDropboxTrayItem(item) {
+function itemNamed(item, name) {
   if (!item) return false
-  return text(item.id).indexOf("dropbox") !== -1
-    || text(item.title).indexOf("dropbox") !== -1
-    || text(item.tooltipTitle).indexOf("dropbox") !== -1
+  return text(item.id).indexOf(name) !== -1
+    || text(item.title).indexOf(name) !== -1
+    || text(item.tooltipTitle).indexOf(name) !== -1
 }
 
 function entryId(entry) {
@@ -30,15 +30,19 @@ function layoutHasWidget(layout, id) {
   return false
 }
 
-function ownedByDedicatedWidget(item, layout) {
-  return layoutHasWidget(layout, "omarchy.dropbox") && isDropboxTrayItem(item)
+// LocalSend's item shows no state, offers only Open and Quit, and its primary
+// click is a no-op, so Share > Receive is the whole surface. Hiding it by hand
+// doesn't stick either: LocalSend picks a fresh tray id every launch.
+function ownedByOmarchy(item, layout) {
+  return itemNamed(item, "localsend")
+    || (layoutHasWidget(layout, "omarchy.dropbox") && itemNamed(item, "dropbox"))
 }
 
 if (typeof module !== "undefined") {
   module.exports = {
-    isDropboxTrayItem: isDropboxTrayItem,
+    itemNamed: itemNamed,
     entryId: entryId,
     layoutHasWidget: layoutHasWidget,
-    ownedByDedicatedWidget: ownedByDedicatedWidget
+    ownedByOmarchy: ownedByOmarchy
   }
 }

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -7,9 +7,10 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test "tray model helpers" <<'JS'
 const tray = requireFromRoot('shell/plugins/bar/widgets/TrayModel.js')
 
-assert(tray.isDropboxTrayItem({ id: 'dropbox-client' }), 'tray detects dropbox item ids')
-assert(tray.isDropboxTrayItem({ title: 'Dropbox' }), 'tray detects dropbox item titles')
-assert(!tray.isDropboxTrayItem({ id: 'nextcloud' }), 'tray ignores non-dropbox items')
+assert(tray.itemNamed({ id: 'dropbox-client' }, 'dropbox'), 'tray matches item ids')
+assert(tray.itemNamed({ title: 'Dropbox' }, 'dropbox'), 'tray matches item titles')
+assert(tray.itemNamed({ tooltipTitle: 'LocalSend' }, 'localsend'), 'tray matches item tooltips')
+assert(!tray.itemNamed({ id: 'nextcloud' }, 'dropbox'), 'tray ignores items named for something else')
 
 const layout = {
   left: [{ id: 'omarchy.menu' }],
@@ -18,7 +19,8 @@ const layout = {
 }
 
 assert(tray.layoutHasWidget(layout, 'omarchy.dropbox'), 'tray finds dedicated dropbox widget in layout')
-assert(tray.ownedByDedicatedWidget({ id: 'dropbox' }, layout), 'tray suppresses dropbox when dedicated widget is in bar')
-assert(!tray.ownedByDedicatedWidget({ id: 'dropbox' }, { left: [], center: [], right: [] }), 'tray keeps dropbox when dedicated widget is absent')
-assert(!tray.ownedByDedicatedWidget({ id: 'nextcloud' }, layout), 'tray keeps unrelated tray items')
+assert(tray.ownedByOmarchy({ id: 'dropbox' }, layout), 'tray suppresses dropbox when dedicated widget is in bar')
+assert(!tray.ownedByOmarchy({ id: 'dropbox' }, { left: [], center: [], right: [] }), 'tray keeps dropbox when dedicated widget is absent')
+assert(tray.ownedByOmarchy({ id: 'qlBCprNUqU', title: 'localsend' }, { left: [], center: [], right: [] }), 'tray suppresses localsend regardless of layout')
+assert(!tray.ownedByOmarchy({ id: 'nextcloud' }, layout), 'tray keeps unrelated tray items')
 JS


### PR DESCRIPTION
LocalSend ships in the default package set and starts hidden into the tray, where its item does nothing useful: it shows no state, a primary click is a silent no-op, and the menu offers only Open and Quit. Omarchy already opens it through `Trigger > Share > Receive`.

The item's Ayatana StatusNotifierItem exposes no `ItemIsMenu` property and no `Activate` handler, confirmed against a live instance:

```
.Id     property s "qlBCprNUqU"
.Title  property s "localsend"
ItemIsMenu: no such property
$ busctl --user call ... org.kde.StatusNotifierItem Activate ii 0 0
Call failed: No handler for Activate
```

Quickshell defaults a missing `ItemIsMenu` to false, so `Tray.qml` takes the `activate()` branch on primary click and nothing happens. Hiding the item by hand doesn't help either — the tray persists the raw item id, and LocalSend generates a new one on every launch (`qlBCprNUqU` above was gone after a restart).

So the tray drops it, reusing the shape that already drops Dropbox's item when the dedicated Dropbox widget owns that surface. LocalSend keeps running in the background and its window is still one `Super+Ctrl+S > Receive` away.

Verified in the running bar by pinning LocalSend's item so it renders unconditionally: visible before the change, gone after, with the rest of the bar unchanged.

Closes #6838

— 🤖 Claude, posting on behalf of @dhh
