### PR TITLE
Stop upgraded laptops reverting to performance mode on AC

### DIFF
--- a/migrations/1786691707.sh
+++ b/migrations/1786691707.sh
@@ -1,12 +1,13 @@
 echo "Remove legacy power profile udev rules superseded by Quattro"
 
 rules_dir="${OMARCHY_POWERPROFILES_UDEV_RULES_DIR:-/etc/udev/rules.d}"
+legacy_rule="$rules_dir/99-power-profile.rules"
+retired_package_rule="$rules_dir/99-omarchy-power-profile.rules"
 
 # Quattro restores per-source preferences through the shell's UPower service.
 # Rules left by older releases run the same helper through the system manager,
 # where it cannot see the user's saved preference and falls back to performance.
-sudo rm -f \
-  "$rules_dir/99-power-profile.rules" \
-  "$rules_dir/99-omarchy-power-profile.rules"
-
-sudo udevadm control --reload 2>/dev/null
+if [[ -e $legacy_rule || -L $legacy_rule || -e $retired_package_rule || -L $retired_package_rule ]]; then
+  sudo rm -f "$legacy_rule" "$retired_package_rule"
+  sudo udevadm control --reload 2>/dev/null
+fi

--- a/migrations/1786691707.sh
+++ b/migrations/1786691707.sh
@@ -1,0 +1,12 @@
+echo "Remove legacy power profile udev rules superseded by Quattro"
+
+rules_dir="${OMARCHY_POWERPROFILES_UDEV_RULES_DIR:-/etc/udev/rules.d}"
+
+# Quattro restores per-source preferences through the shell's UPower service.
+# Rules left by older releases run the same helper through the system manager,
+# where it cannot see the user's saved preference and falls back to performance.
+sudo rm -f \
+  "$rules_dir/99-power-profile.rules" \
+  "$rules_dir/99-omarchy-power-profile.rules"
+
+sudo udevadm control --reload 2>/dev/null

--- a/test/shell.d/powerprofiles-udev-migration-test.sh
+++ b/test/shell.d/powerprofiles-udev-migration-test.sh
@@ -9,11 +9,13 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 rules_dir="$test_tmp/rules.d"
+sudo_calls="$test_tmp/sudo-calls"
 udevadm_calls="$test_tmp/udevadm-calls"
 mkdir -p "$stub_bin" "$rules_dir"
 
 cat >"$stub_bin/sudo" <<'STUB'
 #!/bin/bash
+printf '%s\n' "$*" >>"$SUDO_CALLS"
 exec "$@"
 STUB
 
@@ -29,6 +31,7 @@ migration="$ROOT/migrations/1786691707.sh"
 run_migration() {
   PATH="$stub_bin:$PATH" \
     OMARCHY_POWERPROFILES_UDEV_RULES_DIR="$rules_dir" \
+    SUDO_CALLS="$sudo_calls" \
     UDEVADM_CALLS="$udevadm_calls" \
     bash -euo pipefail "$migration" >/dev/null
 }
@@ -52,5 +55,12 @@ pass "power profile migration removes only retired Omarchy rules"
   fail "power profile migration reloads udev without retriggering power events" "$(<"$udevadm_calls")"
 pass "power profile migration reloads udev without triggering a profile race"
 
+: >"$sudo_calls"
+: >"$udevadm_calls"
 run_migration
-pass "power profile migration is idempotent"
+
+[[ ! -s $sudo_calls ]] ||
+  fail "power profile migration avoids sudo after the machine-wide repair" "$(<"$sudo_calls")"
+[[ ! -s $udevadm_calls ]] ||
+  fail "power profile migration avoids a redundant udev reload" "$(<"$udevadm_calls")"
+pass "power profile migration is a machine-level no-op after repair"

--- a/test/shell.d/powerprofiles-udev-migration-test.sh
+++ b/test/shell.d/powerprofiles-udev-migration-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+rules_dir="$test_tmp/rules.d"
+udevadm_calls="$test_tmp/udevadm-calls"
+mkdir -p "$stub_bin" "$rules_dir"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+
+cat >"$stub_bin/udevadm" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$UDEVADM_CALLS"
+STUB
+
+chmod +x "$stub_bin/sudo" "$stub_bin/udevadm"
+
+migration="$ROOT/migrations/1786691707.sh"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    OMARCHY_POWERPROFILES_UDEV_RULES_DIR="$rules_dir" \
+    UDEVADM_CALLS="$udevadm_calls" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+touch \
+  "$rules_dir/99-power-profile.rules" \
+  "$rules_dir/99-omarchy-power-profile.rules" \
+  "$rules_dir/99-unrelated.rules"
+
+run_migration
+
+[[ ! -e $rules_dir/99-power-profile.rules ]] ||
+  fail "power profile migration removes the pre-package legacy rule"
+[[ ! -e $rules_dir/99-omarchy-power-profile.rules ]] ||
+  fail "power profile migration removes the retired package rule"
+[[ -e $rules_dir/99-unrelated.rules ]] ||
+  fail "power profile migration leaves unrelated udev rules alone"
+pass "power profile migration removes only retired Omarchy rules"
+
+[[ $(<"$udevadm_calls") == "control --reload" ]] ||
+  fail "power profile migration reloads udev without retriggering power events" "$(<"$udevadm_calls")"
+pass "power profile migration reloads udev without triggering a profile race"
+
+run_migration
+pass "power profile migration is idempotent"


### PR DESCRIPTION
## Why this matters

On upgraded laptops that still carry an old Omarchy udev rule, selecting `balanced` or `power-saver` in Quattro does not reliably stick. Waking the laptop or changing AC state can silently force it back to `performance`, causing unnecessary heat and loud fan noise—the "jet engine" behavior—and making the new power-profile panel appear broken.

The panel is saving the user's choice correctly. A rule left behind by an older Omarchy release overrides it. Without an upgrade cleanup, affected users will continue hitting the same regression even though the new preference UI works as designed.

## Cause

Quattro remembers the user's per-source power-profile choices and applies them through the user shell's UPower service. Upgraded systems can still have `/etc/udev/rules.d/99-power-profile.rules`, written by an older Omarchy migration and no longer owned by a package.

That rule invokes `omarchy-powerprofiles-set` through the system manager whenever a `power_supply` event occurs. In that context the helper cannot see the user's saved state and falls back to `performance` on AC, overriding the profile selected in the panel after resumes and other power events.

This follows the power-profile work in #4958, #5621, #6046, and #6091.

## Fix

- Remove both retired Omarchy power-profile udev rule names during migration.
- Reload udev without retriggering power events and causing another profile race.
- Cover targeted cleanup, unrelated-rule preservation, reload behavior, and idempotence.

## Verification

- Reproduced on an upgraded `4.0.0rc5-1` laptop with saved and active AC profile set to `balanced`.
- Disabled the stale rule and reloaded udev, then triggered the same `power_supply` events: the profile remained `balanced` and no legacy service was launched.
- `bash test/shell.d/powerprofiles-udev-migration-test.sh`
- `bash test/shell.d/powerprofiles-set-test.sh`
- `./test/all` in headless mode: all 179 test files passed.
