### PR TITLE
Ignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Python bytecode (orchestrator)
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

- ignore Python `__pycache__` directories and `.pyc` bytecode
- keep the 3.x worktree clean after running Quattro Python helpers

## Verification

- `git status --ignored` reports `bin/__pycache__/` as ignored
- `git diff --check`