### PR TITLE
Default agents panel to selected agent

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -17,15 +17,23 @@ Panel {
   readonly property color surface: Color.popups.background
   readonly property color track: Style.selectedFillFor(foreground, Color.accent)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+  readonly property string home: Quickshell.env("HOME") || ""
+  readonly property string defaultAgentPath: home + "/.config/omarchy/defaults/agent"
 
   readonly property var providers: usage.enabledProviders
   // The selection follows the provider, not the slot it happens to sit in: a
   // provider whose first scan lands while the panel is open would otherwise
-  // shift the list underneath you and swap out what you were reading.
+  // shift the list underneath you and swap out what you were reading. Until
+  // you choose a provider in the panel, follow Omarchy's configured default.
   property string selectedProviderId: ""
+  property string defaultAgentId: ""
   readonly property int providerIndex: {
     for (var i = 0; i < providers.length; i++)
       if (providers[i].providerId === selectedProviderId) return i
+
+    for (var j = 0; j < providers.length; j++)
+      if (providers[j].providerId === defaultAgentId) return j
+
     return 0
   }
   readonly property var provider: providers.length > 0 ? providers[providerIndex] : null
@@ -62,6 +70,15 @@ Panel {
   function launchAgent() {
     if (root.bar) root.bar.run("omarchy-agent --pick")
     root.close()
+  }
+
+  FileView {
+    path: root.defaultAgentPath
+    watchChanges: true
+    printErrors: false
+    onFileChanged: reload()
+    onLoaded: root.defaultAgentId = String(text() || "").trim()
+    onLoadFailed: root.defaultAgentId = ""
   }
 
   // ---------------------------------------------------------------- limits

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -8,6 +8,10 @@ run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
 
+assert(/defaultAgentPath: home \+ "\/\.config\/omarchy\/defaults\/agent"/.test(panelSource), 'agents panel reads the configured default agent')
+assert(/path: root\.defaultAgentPath[\s\S]{0,160}?watchChanges: true[\s\S]{0,160}?onFileChanged: reload\(\)/.test(panelSource), 'agents panel watches default-agent changes')
+assert(/onLoaded: root\.defaultAgentId = String\(text\(\) \|\| ""\)\.trim\(\)/.test(panelSource), 'agents panel loads the default agent id')
+assert(/providerId === selectedProviderId\) return i[\s\S]{0,160}?providerId === defaultAgentId\) return j[\s\S]{0,80}?return 0/.test(panelSource), 'agents panel prefers an explicit selection, then the configured default')
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
 assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelSource), 'agents right click launches the agent')


### PR DESCRIPTION
## Summary

- read the configured default agent in the Agents panel
- show that provider by default while preserving an explicit in-panel selection
- watch the default-agent file for live changes
- derive the shared icon alarm from the correct provider on startup

## Verification

- `bash test/shell.d/agents-panel-test.sh`
- restarted the checkout shell with Codex configured as default
- confirmed the panel opened on Codex at 11% instead of exhausted Claude/Fable limits
- inspected a fullscreen screenshot for clipping, overlap, focus, and stale state