### PR TITLE
Keep the menu populated across git swaps of its definition file

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -924,8 +924,24 @@ Item {
     path: root.defaultMenuPath
     watchChanges: true
     printErrors: false
-    onLoaded: { root.defaultMenuItems = root.parseMenuJsonc(text()); root.rebuildItemsFromSources() }
+    onLoaded: {
+      // Git replaces the file by inode swap, so a reload can catch the gap
+      // and read nothing. The shipped menu is never empty: keep the current
+      // rows and retry instead of blanking the menu until a shell restart.
+      var items = root.parseMenuJsonc(text())
+      if (items.length === 0) { defaultMenuRetry.restart(); return }
+      root.defaultMenuItems = items
+      root.rebuildItemsFromSources()
+    }
+    onLoadFailed: defaultMenuRetry.restart()
     onFileChanged: reload()
+  }
+
+  Timer {
+    id: defaultMenuRetry
+    interval: 500
+    repeat: false
+    onTriggered: defaultMenuFile.reload()
   }
 
   FileView {


### PR DESCRIPTION
The menu watches `omarchy-menu.jsonc` so live edits apply without a shell restart, but git updates the file by inode swap, and a reload can land in the gap: the read comes back empty or fails outright, the menu blanks, and no further watch event arrives to recover it. Dev-channel machines hit this every time a checkout or rebase touches the file.

This treats a failed load or an empty parse of the default file as a torn read: keep the current rows and arm a 500ms retry instead of blanking the menu — the same retry-timer idiom `Style.qml` already uses for its watched files. The user-extension file keeps its existing behavior, since that file legitimately may not exist.

Verified live: moved the definition file away for two seconds and back (a harsher version of git's swap — the exact sequence that emptied the menu on my machine today); the menu recovered on its own and summoned fully populated. `./test/shell` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)