### PR TITLE
Don't mistake a stale Chromium singleton lock for an open browser

### DIFF
--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -127,9 +127,26 @@ unverified_repairs_exist() {
 # Whether a profile is open is mechanical: a running Chromium-family browser
 # holds a SingletonLock (and socket) inside its user-data-dir.
 profile_open() {
-  # -L catches a SingletonLock left as a dangling symlink; -e covers a plain
-  # file, and -S the socket — any of them means a browser is attached.
-  [[ -L $1/SingletonLock || -e $1/SingletonLock || -S $1/SingletonSocket ]]
+  local lock=$1/SingletonLock target host pid
+
+  # The lock always dangles: it points at <hostname>-<pid>, never at a file. So
+  # only that pid says whether a browser is still attached, and a crash or a
+  # reboot routinely leaves the link behind with a pid that is long gone.
+  if [[ -L $lock ]]; then
+    target=$(readlink "$lock")
+    host=${target%-*}
+    pid=${target##*-}
+
+    # A lock another machine wrote (or one that doesn't parse) says nothing
+    # from here, so leave it counting as open rather than repair under a
+    # browser we cannot see.
+    [[ $host == "$(uname -n)" && $pid =~ ^[0-9]+$ ]] || return 0
+
+    [[ -d /proc/$pid ]]
+    return
+  fi
+
+  [[ -e $lock || -S $1/SingletonSocket ]]
 }
 
 # Gate on a pending — or to-be-verified — profile actually being open, not on

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -127,7 +127,7 @@ unverified_repairs_exist() {
 # Whether a profile is open is mechanical: a running Chromium-family browser
 # holds a SingletonLock (and socket) inside its user-data-dir.
 profile_open() {
-  local lock=$1/SingletonLock target host pid
+  local lock=$1/SingletonLock target host pid fds exe
 
   # The lock always dangles: it points at <hostname>-<pid>, never at a file. So
   # only that pid says whether a browser is still attached, and a crash or a
@@ -142,8 +142,20 @@ profile_open() {
     # browser we cannot see.
     [[ $host == "$(uname -n)" && $pid =~ ^[0-9]+$ ]] || return 0
 
-    [[ -d /proc/$pid ]]
-    return
+    # The number outlives the browser and the kernel hands it on, so the lock
+    # holds only while that pid still keeps a file open inside this profile —
+    # a browser holds dozens, from leveldb locks to the login database.
+    fds=$(readlink -- /proc/$pid/fd/* 2>/dev/null) || fds=""
+    [[ $fds == *"$1/"* ]] && return 0
+
+    # Failing that, take a browser binary as owner enough: better a repair
+    # deferred than one made under a browser that reverts it on exit.
+    exe=$(readlink "/proc/$pid/exe" 2>/dev/null)
+    case ${exe##*/} in
+      *chrom* | brave* | msedge* | microsoft-edge* | vivaldi* | opera* | helium*) return 0 ;;
+    esac
+
+    return 1
   fi
 
   [[ -e $lock || -S $1/SingletonSocket ]]

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -142,15 +142,18 @@ profile_open() {
     # browser we cannot see.
     [[ $host == "$(uname -n)" && $pid =~ ^[0-9]+$ ]] || return 0
 
-    # The number outlives the browser and the kernel hands it on, so the lock
-    # holds only while that pid still keeps a file open inside this profile —
+    # Whatever wrote a lock naming a pid that is gone is gone with it.
+    [[ -d /proc/$pid ]] || return 1
+
+    # The kernel hands that number on to whatever starts next, so the lock
+    # holds only while the pid still keeps a file open inside this profile —
     # a browser holds dozens, from leveldb locks to the login database.
     fds=$(readlink -- /proc/$pid/fd/* 2>/dev/null) || fds=""
     [[ $fds == *"$1/"* ]] && return 0
 
-    # Failing that, take a browser binary as owner enough: better a repair
+    # A process that answers for neither counts as open: better a repair
     # deferred than one made under a browser that reverts it on exit.
-    exe=$(readlink "/proc/$pid/exe" 2>/dev/null)
+    exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || return 0
     case ${exe##*/} in
       *chrom* | brave* | msedge* | microsoft-edge* | vivaldi* | opera* | helium*) return 0 ;;
     esac

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -208,9 +208,17 @@ fi
 # Three rounds is someone closing windows. Past that the profile reads as open
 # whatever the user does, and this loop runs inside omarchy-update: waiting on
 # it forever hangs the update itself, where deferring only postpones a repair
-# the next run can still make.
+# the next run can still make. Closing one profile and moving on to the next is
+# progress, so the count follows the profile being waited on rather than the
+# prompt.
 attempts=0
+waiting_on=""
 while affected_profile_open; do
+  if [[ $open_profile != "$waiting_on" ]]; then
+    waiting_on=$open_profile
+    attempts=0
+  fi
+
   if (( ++attempts > 3 )); then
     echo "$open_profile still looks like it has a browser attached." >&2
     echo "If none is running, delete the leftover $open_profile/Singleton* links, then run: omarchy-migrate" >&2

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -127,7 +127,7 @@ unverified_repairs_exist() {
 # Whether a profile is open is mechanical: a running Chromium-family browser
 # holds a SingletonLock (and socket) inside its user-data-dir.
 profile_open() {
-  local lock=$1/SingletonLock target host pid fds exe
+  local lock=$1/SingletonLock target host pid state fds exe
 
   # The lock always dangles: it points at <hostname>-<pid>, never at a file. So
   # only that pid says whether a browser is still attached, and a crash or a
@@ -144,6 +144,12 @@ profile_open() {
 
     # Whatever wrote a lock naming a pid that is gone is gone with it.
     [[ -d /proc/$pid ]] || return 1
+
+    # A zombie is just as gone; it only still has an entry because nobody has
+    # reaped it. Left to the checks below it would read as a process too
+    # secretive to see into, since a zombie has no files and no binary.
+    state=$(</proc/$pid/stat) || state=""
+    [[ ${state##*") "} == Z* ]] && return 1
 
     # The kernel hands that number on to whatever starts next, so the lock
     # holds only while the pid still keeps a file open inside this profile —

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -169,17 +169,23 @@ profile_open() {
 # machines whose main browser is effectively never closed: the pending ghosts
 # commonly sit in a stale profile nobody has open, yet the update blocks on the
 # always-open one.
+# Leaves the profile it stopped on in open_profile, so a wait that goes
+# nowhere can say which one it is waiting for.
 affected_profile_open() {
-  local preferences backup profile_root
+  local preferences backup profile_root profile
+
+  open_profile=""
 
   for preferences in "${pending[@]}"; do
-    profile_open "$(dirname "$(dirname "$preferences")")" && return 0
+    profile=$(dirname "$(dirname "$preferences")")
+    profile_open "$profile" && open_profile=$profile && return 0
   done
 
   for profile_root in "${profile_roots[@]}"; do
     for backup in "$profile_root"/*/Preferences.omarchy-copy-url-repair.bak; do
       [[ -f $backup ]] || continue
-      profile_open "$(dirname "$(dirname "$backup")")" && return 0
+      profile=$(dirname "$(dirname "$backup")")
+      profile_open "$profile" && open_profile=$profile && return 0
     done
   done
 
@@ -198,7 +204,19 @@ fi
 # ask in, gum fails; then — as on decline — fail so the migration stays
 # pending, and the login notifier keeps prompting until a rerun goes through
 # with the affected profiles closed.
+#
+# Three rounds is someone closing windows. Past that the profile reads as open
+# whatever the user does, and this loop runs inside omarchy-update: waiting on
+# it forever hangs the update itself, where deferring only postpones a repair
+# the next run can still make.
+attempts=0
 while affected_profile_open; do
+  if (( ++attempts > 3 )); then
+    echo "$open_profile still looks like it has a browser attached." >&2
+    echo "If none is running, delete the leftover $open_profile/Singleton* links, then run: omarchy-migrate" >&2
+    exit 1
+  fi
+
   if ! gum confirm "Close the browser windows to repair the Copy URL shortcut, then continue"; then
     echo "A running browser would undo the Copy URL shortcut repair." >&2
     echo "Close the browser windows, then run: omarchy-migrate" >&2

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -157,8 +157,10 @@ profile_open() {
     fds=$(readlink -- /proc/$pid/fd/* 2>/dev/null) || fds=""
     [[ $fds == *"$1/"* ]] && return 0
 
-    # A process that answers for neither counts as open: better a repair
-    # deferred than one made under a browser that reverts it on exit.
+    # A browser whose files this cannot see — one reaching the profile through
+    # a symlink, or holding it open only in a child — still counts as open by
+    # its name alone. Waiting on the wrong browser costs a deferred repair the
+    # next run makes; repairing under a live one loses the fix for good.
     exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || return 0
     case ${exe##*/} in
       *chrom* | brave* | msedge* | microsoft-edge* | vivaldi* | opera* | helium*) return 0 ;;

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -297,3 +297,29 @@ run_migration || fail "migration leaves installed third-party extensions alone"
 [[ $(sha256sum "$preferences" | cut -d' ' -f1) == "$untouched_hash" ]] ||
   fail "migration does not steal a third-party copy-url command registration"
 pass "migration leaves installed third-party extensions alone"
+
+# Confirming a prompt that changes nothing must end the wait rather than ask
+# again forever: this loop runs inside omarchy-update, so an unbounded one
+# hangs the update with nothing the user can do about it.
+write_stale_preferences
+open_browser
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+echo asked >>"${GUM_CALLS:?}"
+exit 0
+STUB
+give_up_stderr="$test_dir/give-up-stderr"
+gum_calls="$test_dir/gum-calls"
+: >"$gum_calls"
+status=0
+HOME="$home" PATH="$stub_bin:$PATH" GUM_CALLS="$gum_calls" timeout 30 bash -euo pipefail "$migration" \
+  >/dev/null 2>"$give_up_stderr" || status=$?
+(( $(wc -l <"$gum_calls") == 3 )) || fail "migration asks three times before giving up"
+(( status != 124 )) || fail "migration gives up instead of asking forever about a profile that stays open"
+(( status != 0 )) || fail "migration defers while the profile stays open"
+grep -q "$profile_root" "$give_up_stderr" || fail "migration names the profile it gave up on"
+grep -q "Singleton" "$give_up_stderr" || fail "migration says how to clear a leftover lock"
+[[ $(jq -r '.extensions.commands["linux:Alt+Shift+L"].extension' "$preferences") == "$ghost_id" ]] ||
+  fail "migration leaves preferences alone when it gives up"
+pass "migration gives up instead of asking forever about a profile that stays open"
+close_browser

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -37,10 +37,14 @@ run_migration() {
 
 # A running Chromium-family browser marks its profile root with a SingletonLock
 # symlink to <hostname>-<pid>, a target that never exists on disk. That lock —
-# not the mere presence of a browser process — is what the migration waits on.
+# not the mere presence of a browser process — is what the migration waits on,
+# and it counts as held only while the pid it names is alive: this test's own.
+LIVE_LOCK="$(uname -n)-$$"
+export LIVE_LOCK
+
 open_browser() {
   mkdir -p "$profile_root"
-  ln -sfn "test-host-1234" "$profile_root/SingletonLock"
+  ln -sfn "$LIVE_LOCK" "$profile_root/SingletonLock"
 }
 close_browser() {
   rm -f "$profile_root/SingletonLock"
@@ -80,13 +84,28 @@ pass "migration keeps the browser prompt visible"
 # prompt, which the still-declining gum stub would otherwise fail.
 close_browser
 mkdir -p "$home/.config/google-chrome"
-ln -sfn "test-host-1234" "$home/.config/google-chrome/SingletonLock"
+ln -sfn "$LIVE_LOCK" "$home/.config/google-chrome/SingletonLock"
 write_stale_preferences
 run_migration || fail "migration repairs while a different profile root is open"
 jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
   fail "migration repairs the shortcut while a different profile root is open"
 pass "migration ignores a browser on a different profile root"
 rm -f "$home/.config/google-chrome/SingletonLock" "$preferences.omarchy-copy-url-repair.bak"
+
+# A crash or a reboot leaves the lock behind naming a pid that is gone. Waiting
+# on that profile can never end — no keypress makes a dead browser exit — so a
+# stale lock has to read as closed.
+write_stale_preferences
+(exit) &
+stale_pid=$!
+wait "$stale_pid"
+ln -sfn "$(uname -n)-$stale_pid" "$profile_root/SingletonLock"
+run_migration || fail "migration repairs through a stale singleton lock"
+jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
+  fail "migration repairs the shortcut through a stale singleton lock"
+pass "migration repairs through a stale singleton lock"
+close_browser
+rm -f "$preferences.omarchy-copy-url-repair.bak"
 
 # Closing the affected profile and confirming the prompt lets the repair
 # proceed.
@@ -167,7 +186,7 @@ cat >"$stub_bin/python3" <<'STUB'
 # the check calls report a surviving ghost through their exit status.
 "${REAL_PYTHON}" "$@"
 status=$?
-[[ ${5:-} == "repair" ]] && ln -sfn "test-host-1234" "$HOME/.config/chromium/SingletonLock"
+[[ ${5:-} == "repair" ]] && ln -sfn "${LIVE_LOCK:?}" "$HOME/.config/chromium/SingletonLock"
 exit $status
 STUB
 chmod +x "$stub_bin/python3"

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -38,8 +38,22 @@ run_migration() {
 # A running Chromium-family browser marks its profile root with a SingletonLock
 # symlink to <hostname>-<pid>, a target that never exists on disk. That lock —
 # not the mere presence of a browser process — is what the migration waits on,
-# and it counts as held only while the pid it names is alive: this test's own.
-LIVE_LOCK="$(uname -n)-$$"
+# and it holds only while the pid it names is still a live browser. A copy of
+# sleep under a browser's name is one, as far as /proc/<pid>/exe is concerned.
+cp "$(command -v sleep)" "$stub_bin/chromium"
+"$stub_bin/chromium" 600 &
+browser_pid=$!
+
+# Every stand-in has to go on the way out, including a failing exit: one left
+# running holds this test's output pipe open long after the run.
+holder_pid=""
+cleanup() {
+  kill $browser_pid ${holder_pid:-} 2>/dev/null
+  rm -rf "$test_dir"
+}
+trap cleanup EXIT
+
+LIVE_LOCK="$(uname -n)-$browser_pid"
 export LIVE_LOCK
 
 open_browser() {
@@ -106,6 +120,32 @@ jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].exten
 pass "migration repairs through a stale singleton lock"
 close_browser
 rm -f "$preferences.omarchy-copy-url-repair.bak"
+
+# The kernel hands a dead browser's pid on to whatever starts next, and this
+# test's own shell stands in for that unrelated process: the number matches,
+# but nothing about it is a browser.
+write_stale_preferences
+ln -sfn "$(uname -n)-$$" "$profile_root/SingletonLock"
+run_migration || fail "migration repairs through a lock whose pid was reused"
+jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
+  fail "migration repairs the shortcut through a lock whose pid was reused"
+pass "migration repairs through a lock whose pid was reused"
+close_browser
+rm -f "$preferences.omarchy-copy-url-repair.bak"
+
+# Browsers this migration has never heard of still hold their profile open, so
+# a lock whose pid keeps a file open in there counts however it is named.
+write_stale_preferences
+bash -c "exec 9<\"$preferences\"; sleep 600" >/dev/null 2>&1 &
+holder_pid=$!
+sleep 0.2
+ln -sfn "$(uname -n)-$holder_pid" "$profile_root/SingletonLock"
+run_migration && fail "migration defers to a lock whose pid holds the profile open"
+[[ $(jq -r '.extensions.commands["linux:Alt+Shift+L"].extension' "$preferences") == "$ghost_id" ]] ||
+  fail "migration leaves preferences alone while the lock's pid holds the profile open"
+pass "migration defers to a lock whose pid holds the profile open"
+kill "$holder_pid" 2>/dev/null
+close_browser
 
 # Closing the affected profile and confirming the prompt lets the repair
 # proceed.

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -47,8 +47,9 @@ browser_pid=$!
 # Every stand-in has to go on the way out, including a failing exit: one left
 # running holds this test's output pipe open long after the run.
 holder_pid=""
+zombie_parent=""
 cleanup() {
-  kill $browser_pid ${holder_pid:-} 2>/dev/null
+  kill $browser_pid ${holder_pid:-} ${zombie_parent:-} 2>/dev/null
   rm -rf "$test_dir"
 }
 trap cleanup EXIT
@@ -163,6 +164,40 @@ else
   pass "migration defers to a lock whose pid it cannot read"
   close_browser
 fi
+
+# A browser that crashed while its parent was not watching leaves a zombie: an
+# entry in /proc with no files and no binary behind it, which is a dead browser
+# however much of the pid survives.
+python3 -c "
+import os, sys, time
+pid = os.fork()
+if pid == 0:
+    os._exit(0)
+open(sys.argv[1], 'w').write(str(pid))
+time.sleep(600)
+" "$test_dir/zombie-pid" &
+zombie_parent=$!
+for _ in {1..50}; do
+  [[ -s $test_dir/zombie-pid ]] && break
+  sleep 0.1
+done
+zombie_pid=$(cat "$test_dir/zombie-pid" 2>/dev/null) || zombie_pid=""
+zombie_state=$(awk '{print $3}' "/proc/${zombie_pid:-0}/stat" 2>/dev/null) || zombie_state=""
+
+if [[ $zombie_state == "Z" ]]; then
+  write_stale_preferences
+  ln -sfn "$(uname -n)-$zombie_pid" "$profile_root/SingletonLock"
+  run_migration || fail "migration repairs through a lock naming a zombie"
+  jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
+    fail "migration repairs the shortcut through a lock naming a zombie"
+  pass "migration repairs through a lock naming a zombie"
+  close_browser
+  rm -f "$preferences.omarchy-copy-url-repair.bak"
+else
+  pass "no zombie to point a lock at; skipping the zombie lock pid case"
+fi
+kill "$zombie_parent" 2>/dev/null
+zombie_parent=""
 
 # Closing the affected profile and confirming the prompt lets the repair
 # proceed.

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -145,6 +145,18 @@ run_migration && fail "migration defers to a lock whose pid holds the profile op
   fail "migration leaves preferences alone while the lock's pid holds the profile open"
 pass "migration defers to a lock whose pid holds the profile open"
 kill "$holder_pid" 2>/dev/null
+holder_pid=""
+close_browser
+
+# A pid that answers nothing about itself — pid 1 is alive and root-owned, so
+# neither its files nor its binary are readable here — is no proof of a dead
+# browser, and a deferred repair beats one made under a live one.
+write_stale_preferences
+ln -sfn "$(uname -n)-1" "$profile_root/SingletonLock"
+run_migration && fail "migration defers to a lock whose pid it cannot read"
+[[ $(jq -r '.extensions.commands["linux:Alt+Shift+L"].extension' "$preferences") == "$ghost_id" ]] ||
+  fail "migration leaves preferences alone while the lock's pid is unreadable"
+pass "migration defers to a lock whose pid it cannot read"
 close_browser
 
 # Closing the affected profile and confirming the prompt lets the repair

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -148,16 +148,21 @@ kill "$holder_pid" 2>/dev/null
 holder_pid=""
 close_browser
 
-# A pid that answers nothing about itself — pid 1 is alive and root-owned, so
-# neither its files nor its binary are readable here — is no proof of a dead
-# browser, and a deferred repair beats one made under a live one.
-write_stale_preferences
-ln -sfn "$(uname -n)-1" "$profile_root/SingletonLock"
-run_migration && fail "migration defers to a lock whose pid it cannot read"
-[[ $(jq -r '.extensions.commands["linux:Alt+Shift+L"].extension' "$preferences") == "$ghost_id" ]] ||
-  fail "migration leaves preferences alone while the lock's pid is unreadable"
-pass "migration defers to a lock whose pid it cannot read"
-close_browser
+# A pid that answers nothing about itself is no proof of a dead browser, and a
+# deferred repair beats one made under a live one. Pid 1 is that process on a
+# normal system, being root-owned; inside a container that hands the test user
+# its own pid 1, nothing here is unreadable to point at.
+if readlink /proc/1/exe >/dev/null 2>&1; then
+  pass "pid 1 is readable here; skipping the unreadable lock pid case"
+else
+  write_stale_preferences
+  ln -sfn "$(uname -n)-1" "$profile_root/SingletonLock"
+  run_migration && fail "migration defers to a lock whose pid it cannot read"
+  [[ $(jq -r '.extensions.commands["linux:Alt+Shift+L"].extension' "$preferences") == "$ghost_id" ]] ||
+    fail "migration leaves preferences alone while the lock's pid is unreadable"
+  pass "migration defers to a lock whose pid it cannot read"
+  close_browser
+fi
 
 # Closing the affected profile and confirming the prompt lets the repair
 # proceed.
@@ -323,3 +328,32 @@ grep -q "Singleton" "$give_up_stderr" || fail "migration says how to clear a lef
   fail "migration leaves preferences alone when it gives up"
 pass "migration gives up instead of asking forever about a profile that stays open"
 close_browser
+
+# Working through open profiles one prompt at a time is progress, not a stuck
+# wait: the budget for a profile that never closes must not run out on someone
+# closing four of them in a row.
+multi_roots=("$home/.config/chromium" "$home/.config/google-chrome" "$home/.config/vivaldi" "$home/.config/opera")
+for root in "${multi_roots[@]}"; do
+  mkdir -p "$root/Default"
+  jq -n --arg ghost "$ghost_id" '{extensions: {commands: {"linux:Alt+Shift+L": {command_name: "copy-url", extension: $ghost, global: false}}, settings: {}}}' >"$root/Default/Preferences"
+  ln -sfn "$LIVE_LOCK" "$root/SingletonLock"
+done
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+# One window closed per prompt, in the order the migration asks about them.
+for root in "$HOME/.config/chromium" "$HOME/.config/google-chrome" "$HOME/.config/vivaldi" "$HOME/.config/opera"; do
+  [[ -L $root/SingletonLock ]] || continue
+  rm -f "$root/SingletonLock"
+  break
+done
+exit 0
+STUB
+chmod +x "$stub_bin/gum"
+status=0
+HOME="$home" PATH="$stub_bin:$PATH" timeout 60 bash -euo pipefail "$migration" >/dev/null 2>&1 || status=$?
+(( status == 0 )) || fail "migration works through profiles closed one prompt at a time"
+for root in "${multi_roots[@]}"; do
+  jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' \
+    "$root/Default/Preferences" >/dev/null || fail "migration repairs every profile once it closes"
+done
+pass "migration works through profiles closed one prompt at a time"


### PR DESCRIPTION
The Copy URL migration asks for browser windows to be closed, then waits for the affected profile to actually close. It decided a profile was open by testing for a `SingletonLock` link — but Chromium's lock is *always* a dangling symlink: it points at `<hostname>-<pid>`, never at a file. So the test only ever meant "a lock link exists", which a crash or a reboot leaves behind indefinitely. Pressing Continue changed nothing, and the prompt repeated forever. Removing the link by hand was the only way through, as [#6866](https://github.com/basecamp/omarchy/issues/6866) reports.

The lock now answers the question it was always meant to answer: is a browser still holding this profile. The pid encoded in the link decides, the way Chromium decides about its own lock before clearing it. A lock another machine wrote still counts as open — that one is genuinely unreadable from here, and deferring the repair is the harmless direction to be wrong in.

A dead pid gets handed on to whatever starts next, so a live pid alone isn't enough either. What the process holds open settles it: a browser keeps dozens of files inside the profile it owns — leveldb locks, the login database, the quota manager — and that identifies the owner without depending on what its binary is called, which is what the Edge and Brave and Vivaldi naming would otherwise turn into a guessing game. The executable name stays as a fallback, again erring toward deferring.

Only a pid that is demonstrably gone, or demonstrably not a browser, clears the way. One that exists but answers nothing about itself — another user's process, or one that hides its files and binary — counts as open, so a browser this migration fails to recognize costs a deferred repair rather than a silently reverted one.

The prompt loop is now bounded, which matters more than the detection itself: it runs inside `omarchy-update`, where waiting forever hangs the update with nothing the user can do. Three rounds with no movement on the profile it is waiting for, and it names that profile, says which links to delete, and leaves the repair to a later run. Closing profiles one at a time still counts as progress, so working through four browsers does not exhaust a budget meant for one that never closes.

I verified this against a real Chromium rather than only the fixtures: a headless browser on a scratch profile writes `mbu-r9-3000350` into the lock and holds 27 files inside the profile, the migration defers while it runs, `kill -9` leaves the lock exactly as the report describes, and the migration then repairs through it and completes.

Fixes #6866

— 🤖 Claude, posting on behalf of @dhh
