### PR TITLE
Fix emoji paste in Firefox

### DIFF
--- a/bin/omarchy-menu-emoji-insert
+++ b/bin/omarchy-menu-emoji-insert
@@ -14,7 +14,7 @@ printf '%s' "$emoji" | wl-copy --type text/plain --sensitive --foreground &
 copy_pid=$!
 
 sleep 0.15
-wtype -M shift -k Insert -m shift 2>/dev/null || true
+wtype -M ctrl -M shift -k v -m shift -m ctrl 2>/dev/null || true
 sleep 0.2
 
 kill "$copy_pid" 2>/dev/null || true

--- a/test/shell.d/emojis-test.sh
+++ b/test/shell.d/emojis-test.sh
@@ -84,5 +84,5 @@ pass "emoji insert helper copies emoji transiently"
 [[ $(<"$TMPDIR/emoji.args") == "--type text/plain --sensitive --foreground" ]] || fail "emoji insert helper serves sensitive transient clipboard in foreground"
 pass "emoji insert helper serves transient clipboard in foreground"
 
-[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "emoji insert helper pastes with shift insert"
-pass "emoji insert helper pastes with shift insert"
+[[ $(<"$TMPDIR/wtype") == "-M ctrl -M shift -k v -m shift -m ctrl" ]] || fail "emoji insert helper pastes as plain text"
+pass "emoji insert helper pastes as plain text"


### PR DESCRIPTION
## What changed

Use `Ctrl+Shift+V` instead of `Shift+Insert` when inserting an emoji.

## Why

The emoji picker copies the selected emoji to a temporary clipboard and simulates a paste. `Shift+Insert` does not paste into Firefox inputs under native Wayland, while `Ctrl+Shift+V` works as a plain-text paste across both GUI applications and terminals.

Manually verified with:

- Firefox
- Chrome
- Ghostty
- Obsidian

## Tests

- Updated the emoji insertion regression test
- `bash test/shell.d/emojis-test.sh`