### PR TITLE
Fix Windows VM launch never opening an RDP window

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -336,6 +336,18 @@ To stop: omarchy-windows-vm stop"
     "" \
     "$LIFECYCLE"
 
+  # FreeRDP 3 tries Kerberos before NTLM for NLA, and krb5 ships /etc/krb5.conf
+  # as the MIT sample with default_realm = ATHENA.MIT.EDU. Every connect then
+  # goes looking for MIT's KDC: with internet up it fails fast, but off the
+  # network each attempt blocks ~23s and no RDP window is ever drawn. The VM
+  # authenticates against a local Windows account, so point FreeRDP at a
+  # realm-less config and let it fall straight through to NTLM.
+  KRB5_CONF="$(dirname "$COMPOSE_FILE")/krb5.conf"
+  if [[ ! -f $KRB5_CONF ]]; then
+    printf '[libdefaults]\n  dns_lookup_kdc = false\n  dns_lookup_realm = false\n' >"$KRB5_CONF"
+  fi
+  export KRB5_CONFIG="$KRB5_CONF"
+
   # Detect display scale from Hyprland
   HYPR_SCALE=$(hyprctl monitors -j | jq -r '.[] | select (.focused == true) | .scale')
   SCALE_PERCENT=$(echo "$HYPR_SCALE" | awk '{print int($1 * 100)}')

--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -297,20 +297,27 @@ launch_windows() {
       omarchy-notification-send -u critical "Windows VM" "Failed to start Windows VM"
       exit 1
     fi
-
-    echo "Waiting for Windows VM to start..."
-    WAIT_COUNT=0
-    until docker logs omarchy-windows 2>&1 | grep -qi "windows started successfully"; do
-      sleep 2
-      WAIT_COUNT=$((WAIT_COUNT + 1))
-      if (( WAIT_COUNT > 60 )); then  # 2 minutes timeout
-        echo ""
-        echo "❌ Timeout: Windows VM failed to start within 2 minutes"
-        echo "   Check logs: docker logs omarchy-windows"
-        exit 1
-      fi
-    done
   fi
+
+  # docker logs keeps output across stop/start and is only cleared when the
+  # container is removed, so an unanchored grep matches "started successfully"
+  # from an earlier boot and returns immediately. Anchor the scan to the current
+  # container start, and run it even when the container was already up: the
+  # image restarts the guest in place whenever Windows reboots.
+  STARTED_AT=$(docker inspect --format='{{.State.StartedAt}}' omarchy-windows)
+
+  echo "Waiting for Windows VM to start..."
+  WAIT_COUNT=0
+  until docker logs --since "$STARTED_AT" omarchy-windows 2>&1 | grep -qi "windows started successfully"; do
+    sleep 2
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    if (( WAIT_COUNT > 60 )); then  # 2 minutes timeout
+      echo ""
+      echo "❌ Timeout: Windows VM failed to start within 2 minutes"
+      echo "   Check logs: docker logs omarchy-windows"
+      exit 1
+    fi
+  done
 
   # Build the connection info
   if [[ $KEEP_ALIVE = "true" ]]; then

--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -304,11 +304,17 @@ launch_windows() {
   # from an earlier boot and returns immediately. Anchor the scan to the current
   # container start, and run it even when the container was already up: the
   # image restarts the guest in place whenever Windows reboots.
-  STARTED_AT=$(docker inspect --format='{{.State.StartedAt}}' omarchy-windows)
+  windows_started() {
+    local started_at
+    started_at=$(docker inspect --format='{{.State.StartedAt}}' omarchy-windows 2>/dev/null)
+    # An empty --since would drop the filter and match a stale boot again
+    [[ -n $started_at ]] || return 1
+    docker logs --since "$started_at" omarchy-windows 2>&1 | grep -qi "windows started successfully"
+  }
 
   echo "Waiting for Windows VM to start..."
   WAIT_COUNT=0
-  until docker logs --since "$STARTED_AT" omarchy-windows 2>&1 | grep -qi "windows started successfully"; do
+  until windows_started; do
     sleep 2
     WAIT_COUNT=$((WAIT_COUNT + 1))
     if (( WAIT_COUNT > 60 )); then  # 2 minutes timeout


### PR DESCRIPTION
Fixes #6882.

`omarchy-windows-vm launch` starts the container and then exits without ever opening an RDP window. From the user's side the VM just appears to refuse to start, and `Terminal=false` on the desktop entry hides every error. Two independent causes, one commit each.

### Wait for the current Windows boot before connecting RDP

`docker logs` retains output across `docker stop` / `docker start` and is only cleared when the container is *removed*, so any container that outlives a session already holds `Windows started successfully` lines from previous boots. The readiness loop matched one of those on its first iteration and fired `xfreerdp3` about a second after `docker compose up -d`, while the guest was still in firmware. On the affected machine the guest needs ~30s to reach that message, so the client was starting ~29s early.

The wait was also skipped entirely when the container was already running, which is not the same as the guest being up: the image restarts Windows in place whenever it reboots.

Anchoring the scan to `.State.StartedAt` and running it unconditionally covers both.

### Skip Kerberos when connecting to the Windows VM

FreeRDP 3 attempts Kerberos before NTLM for NLA, and Arch's `krb5` ships `/etc/krb5.conf` as the upstream MIT sample with `default_realm = ATHENA.MIT.EDU`. Every launch therefore tries to reach MIT's KDC:

- with working internet the KDC answers with an error and FreeRDP falls back to NTLM in under a second, so nobody notices
- with no or degraded internet each attempt blocks ~23s (`Cannot contact any KDC for realm 'ATHENA.MIT.EDU'`) and `xfreerdp3` sits in `CLOSE-WAIT` without drawing a window

Same symptom as the first bug, unrelated cause. This is the root cause behind #4365, which was closed without a change here. Pointing `KRB5_CONFIG` at a realm-less config makes Kerberos fail instantly and hands the connection to NTLM, which is what the local Windows account uses anyway. The config is written next to `docker-compose.yml` on first launch and left alone afterwards, so a user who does want Kerberos can edit it.

### Verification

Measured on Omarchy 4.0.0, i9-12900H, freerdp 2:3.30.0-2, dockurr/windows v5.16, cold container start each time:

| | time to RDP window |
|---|---|
| before, container stopped rather than removed | never — client fires early, connection resets |
| before, no internet | never — hangs in Kerberos |
| after | 36s, boot-bound |

`./test/all` shows the same 5 pre-existing failures on this branch and on a clean `quattro` checkout (`bar-icon-geometry`, and three `omarchy-pkgs` checkout tests that need the sibling repo). `test/shell.d/windows-vm-test.sh` passes.

### Not addressed here

`launch` still treats "RDP client exited" as "user is done" and stops the VM, so a connection failure silently tears the VM down — that is #5202 and wants its own change.
