### PR TITLE
Dismiss an open shell panel with Super+W

### DIFF
--- a/bin/omarchy-hyprland-window-close
+++ b/bin/omarchy-hyprland-window-close
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Close the focused window, or hide an open shell panel
+
+result=$(OMARCHY_SHELL_IPC_TIMEOUT=0.5s omarchy-shell shell hideOpen 2>/dev/null) || true
+[[ $result == hidden ]] && exit 0
+
+hyprctl dispatch 'hl.dsp.window.close()' >/dev/null 2>&1 || hyprctl dispatch killactive >/dev/null

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,4 +1,4 @@
-o.bind("SUPER + W", "Close window", hl.dsp.window.close())
+o.bind("SUPER + W", "Close window", "omarchy-hyprland-window-close")
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -96,6 +96,7 @@ individual plugins (`bar`, `image-selector`, …).
 | `ping`                                | health check                    |
 | `summon <id> <payloadJson>`           | load + open a plugin            |
 | `hide <id>`                           | close a previously-summoned     |
+| `hideOpen`                            | close an open panel/overlay (`hidden` / `none`) |
 | `toggle <id> <payloadJson>`           | summon if closed, hide if open  |
 | `call <id> <method> <arg>`            | call an already-loaded plugin   |
 | `rescanPlugins`                       | re-walk plugin dirs and hot-reload plugin code |

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -10,7 +10,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Alt + Space` | Apps menu |
 | `Super + Escape` | System menu (suspend, restart, etc)  |
 | `Super + Ctrl + L` | Lock computer |
-| `Super + W`               | Close window             |
+| `Super + W`               | Close window (or an open panel) |
 | `Ctrl + Alt + Del` | Close all windows |
 | `Super + T`               | Toggle window between tiling/floating             |
 | `Super + J` | Toggle window position (horizontal/vertical) |

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -534,6 +534,27 @@ Item {
     return !!item && item.opened === true
   }
 
+  // Super+W (and hideOpen) need the open popout without knowing its plugin id.
+  function hideOpenPanel() {
+    if (activePopout && typeof activePopout.close === "function") {
+      activePopout.close()
+      return true
+    }
+    var candidates = []
+    for (var i = 0; i < moduleSlots.length; i++) {
+      var slot = moduleSlots[i]
+      if (!slot || !slot.activeItem) continue
+      var item = slot.activeItem
+      if (typeof item.close === "function" && item.opened === true)
+        candidates.push({ slot: slot, screenName: slotScreenName(slot), opened: true })
+    }
+    var chosen = BarModel.pickPanelSlot(candidates, focusedScreenName())
+    var openItem = chosen ? chosen.activeItem : null
+    if (!openItem || typeof openItem.close !== "function") return false
+    openItem.close()
+    return true
+  }
+
   function entrySettings(entry) {
     return BarModel.entrySettings(entry)
   }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -512,6 +512,26 @@ ShellRoot {
     return isPluginOpen(id) ? hide(id) : summon(id, payloadJson)
   }
 
+  // Super+W asks this before closing the focused window. OSD is a keep-loaded
+  // panel that reports opened while a toast is up; it must not steal the key.
+  function hideOpen() {
+    var ids = []
+    var seen = ({})
+    function consider(pluginId) {
+      var id = String(pluginId || "")
+      if (!id || seen[id] || id === "omarchy.osd") return
+      seen[id] = true
+      if (isPluginOpen(id)) ids.push(id)
+    }
+    for (var openId in openPanelIds) consider(openId)
+    for (var loaderId in panelLoaders) consider(loaderId)
+    if (ids.length > 0) {
+      for (var i = 0; i < ids.length; i++) hide(ids[i])
+      return true
+    }
+    return !!(shell.bar && typeof shell.bar.hideOpenPanel === "function" && shell.bar.hideOpenPanel())
+  }
+
   // Map of pluginId -> Loader, populated by the Instantiator delegate below.
   property var panelLoaders: ({})
 
@@ -1005,6 +1025,10 @@ ShellRoot {
 
     function hide(id: string): void {
       shell.hide(id)
+    }
+
+    function hideOpen(): string {
+      return shell.hideOpen() ? "hidden" : "none"
     }
 
     function toggle(id: string, payloadJson: string): void {

--- a/test/acceptance.d/panels-test.sh
+++ b/test/acceptance.d/panels-test.sh
@@ -115,6 +115,15 @@ screenshot "success-panel-focus-prime-reopened"
 wtype -k Escape
 wait_until "Escape closes a panel reopened during fade" 15 layer_absent "omarchy-keyboard-panel"
 
+if command -v omarchy-hyprland-window-close >/dev/null; then
+  omarchy-shell shell summon omarchy.network >/dev/null
+  wait_until "network panel opens for Super+W close" 15 layer_present "omarchy-keyboard-panel"
+  omarchy-hyprland-window-close
+  wait_until "window close hides the open panel" 15 layer_absent "omarchy-keyboard-panel"
+else
+  pass "window-close command not installed; skipping Super+W panel dismiss"
+fi
+
 trap - EXIT
 restore_weather
 exit $status

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -200,6 +200,19 @@ assert(
   'shell toggles a bar panel by its position over IPC'
 )
 
+assert(
+  /function hideOpenPanel\(\) \{[\s\S]*?activePopout[\s\S]*?opened === true/.test(barSource),
+  'bar can close the open popout without a plugin id'
+)
+assert(
+  /function hideOpen\(\) \{[\s\S]*?omarchy\.osd[\s\S]*?hideOpenPanel/.test(shellSource),
+  'shell hideOpen skips OSD and then closes a bar popout'
+)
+assert(
+  /function hideOpen\(\): string \{[\s\S]*?shell\.hideOpen\(\)/.test(shellSource),
+  'shell exposes hideOpen over IPC'
+)
+
 const clockSlot = { id: 'clock' }
 const traySlot = { id: 'tray' }
 const horizontalTargets = [

--- a/test/shell.d/hyprland-window-close-test.sh
+++ b/test/shell.d/hyprland-window-close-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+hyprctl_log="$test_tmp/hyprctl.log"
+shell_log="$test_tmp/omarchy-shell.log"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+SH
+chmod +x "$mock_bin/hyprctl"
+
+cat >"$mock_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SHELL_LOG"
+if [[ ${OMARCHY_SHELL_RESULT:-} == fail ]]; then
+  echo "omarchy-shell is not running" >&2
+  exit 1
+fi
+printf '%s\n' "${OMARCHY_SHELL_RESULT:-none}"
+SH
+chmod +x "$mock_bin/omarchy-shell"
+
+run_close() {
+  : >"$hyprctl_log"
+  : >"$shell_log"
+  PATH="$mock_bin:$PATH" HYPRCTL_LOG="$hyprctl_log" SHELL_LOG="$shell_log" \
+    OMARCHY_SHELL_RESULT="$1" \
+    "$ROOT/bin/omarchy-hyprland-window-close"
+}
+
+grep -Fq '"omarchy-hyprland-window-close"' "$ROOT/default/hypr/bindings/tiling.lua" ||
+  fail "SUPER + W closes through omarchy-hyprland-window-close"
+pass "SUPER + W closes through omarchy-hyprland-window-close"
+
+grep -Fq 'OMARCHY_SHELL_IPC_TIMEOUT=0.5s' "$ROOT/bin/omarchy-hyprland-window-close" ||
+  fail "close uses a GNU timeout duration the shell IPC wrapper accepts"
+pass "close uses a GNU timeout duration the shell IPC wrapper accepts"
+
+run_close hidden
+[[ -s $hyprctl_log ]] && fail "hidden panel skip does not dispatch window close"
+grep -Fq 'shell hideOpen' "$shell_log" || fail "close asks the shell to hide an open panel"
+pass "an open panel is hidden instead of the window"
+
+run_close none
+grep -Fq 'dispatch hl.dsp.window.close()' "$hyprctl_log" ||
+  fail "no panel falls through to the Lua window close"
+pass "no open panel closes the focused window"
+
+run_close fail
+grep -Fq 'dispatch hl.dsp.window.close()' "$hyprctl_log" ||
+  fail "a missing shell still closes the focused window"
+pass "a missing shell still closes the focused window"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -182,6 +182,12 @@ shell_ipc_quiet shell hide omarchy.menu >/dev/null
 [[ $(shell_ipc shell summon missing.plugin "{}") == "unknown" ]] || fail_with_log "shell IPC rejects unknown plugin"
 pass "shell IPC summon and hide contract works"
 
+[[ $(shell_ipc shell hideOpen) == "none" ]] || fail_with_log "hideOpen reports none when nothing is open"
+[[ $(shell_ipc shell summon omarchy.emojis "{}") == "ok" ]] || fail_with_log "shell IPC summons emojis for hideOpen"
+[[ $(shell_ipc shell hideOpen) == "hidden" ]] || fail_with_log "hideOpen hides a summoned overlay"
+[[ $(shell_ipc shell hideOpen) == "none" ]] || fail_with_log "hideOpen reports none after dismissing the overlay"
+pass "shell IPC hideOpen dismisses an open overlay"
+
 [[ $(shell_ipc notifications ping) == "ok" ]] || fail_with_log "notifications IPC responds"
 [[ $(shell_ipc notifications setDnd false) == "off" ]] || fail_with_log "notifications IPC toggles DND"
 [[ $(shell_ipc media ping) == "ok" ]] || fail_with_log "media IPC responds"


### PR DESCRIPTION
## Summary

Super+W closed the focused Hyprland window even when a Quickshell panel, menu, or overlay was on screen. Escape already dismissed that surface; Super+W never reached it because Hyprland consumed the bind first.

The key now asks the shell to hide whatever is showing, then closes the window only when nothing is open.

## Change

- Super+W runs `omarchy-hyprland-window-close` instead of the native `hl.dsp.window.close()` dispatcher.
- New `shell hideOpen` IPC returns `hidden` or `none`. It closes summoned loader plugins (menu, emojis, clipboard, image picker, reminders, and other panel/overlay/menu kinds), then the bar's open popout.
- `omarchy.osd` is skipped so a volume or brightness toast does not steal the key. Notifications, lock, and polkit are not on this path.
- The command uses a 0.5s `omarchy-shell` timeout (GNU `timeout` does not accept an `ms` suffix). A down or missing shell still closes the focused window.

## Testing

```bash
./test/shell.d/hyprland-window-close-test.sh
./test/shell.d/bar-test.sh
./test/shell.d/runtime-smoke-test.sh
./test/all
```

Focused close, bar, and runtime-smoke tests passed, including a live smoke case that summoned emojis and got `hidden` then `none`.

`./test/all` was run. The changed-area tests passed. Four unrelated local/baseline failures remained:

- `bar-icon-geometry-test.sh`: existing subpixel icon-centering mismatch
- `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`: require a separate `omarchy-pkgs` checkout, which was not available locally

Manual check on quattro: opened the network panel with Super+Ctrl+W, pressed Super+W, the panel closed and the focused window stayed. A second Super+W closed the window. A volume OSD left Super+W closing the window.