### PR TITLE
Refuse to remove a browser that is still running

### DIFF
--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -18,8 +18,46 @@ set_fallback_default_browser() {
   fi
 }
 
+# Is any running process executing a binary owned by this package? Matching on
+# package contents rather than process names keeps this correct for every
+# browser without hardcoding install paths, and avoids the Brave/Brave Origin
+# ambiguity (both run a process simply named "brave").
+package_is_running() {
+  local package=$1 exe
+  local -A owned_files=()
+
+  omarchy-pkg-present "$package" || return 1
+
+  while IFS= read -r file; do
+    owned_files[$file]=1
+  done < <(pacman -Qlq "$package" 2>/dev/null)
+
+  for exe_link in /proc/[0-9]*/exe; do
+    exe=$(readlink "$exe_link" 2>/dev/null) || continue
+    # A running process whose binary was already deleted reports "<path> (deleted)"
+    exe=${exe%" (deleted)"}
+    [[ -n ${owned_files[$exe]} ]] && return 0
+  done
+
+  return 1
+}
+
+# Removing the package out from under a running browser leaves it executing from
+# deleted inodes: the window stays up, but every child process it spawns from
+# then on dies on a fatal startup error. Refuse rather than let that happen.
+ensure_not_running() {
+  local name=$1 package=$2
+
+  if package_is_running "$package"; then
+    echo "$name is still running. Quit it first, then run this again." >&2
+    echo "Removing it now would leave the running instance crashing until it is closed." >&2
+    exit 1
+  fi
+}
+
 case $1 in
 chrome)
+  ensure_not_running Chrome google-chrome
   echo "Removing Chrome..."
   set_fallback_default_browser google-chrome.desktop
   omarchy-pkg-drop google-chrome
@@ -27,6 +65,7 @@ chrome)
   sudo rm -f /etc/opt/chrome/policies/managed/color.json
   ;;
 edge)
+  ensure_not_running Edge microsoft-edge-stable-bin
   echo "Removing Edge..."
   set_fallback_default_browser microsoft-edge.desktop
   omarchy-pkg-drop microsoft-edge-stable-bin
@@ -34,6 +73,7 @@ edge)
   sudo rm -f /etc/opt/edge/policies/managed/color.json
   ;;
 brave)
+  ensure_not_running Brave brave-bin
   echo "Removing Brave..."
   set_fallback_default_browser brave-browser.desktop
   omarchy-pkg-drop brave-bin
@@ -44,6 +84,7 @@ brave)
   fi
   ;;
 brave-origin)
+  ensure_not_running "Brave Origin" brave-origin-bin
   echo "Removing Brave Origin..."
   set_fallback_default_browser brave-origin.desktop
   omarchy-pkg-drop brave-origin-bin
@@ -54,11 +95,13 @@ brave-origin)
   fi
   ;;
 firefox)
+  ensure_not_running Firefox firefox
   echo "Removing Firefox..."
   set_fallback_default_browser firefox.desktop
   omarchy-pkg-drop firefox
   ;;
 zen)
+  ensure_not_running Zen zen-browser-bin
   echo "Removing Zen..."
   set_fallback_default_browser zen.desktop
   omarchy-pkg-drop zen-browser-bin


### PR DESCRIPTION
`omarchy-remove-browser` hands the package straight to `omarchy-pkg-drop` without checking whether the browser is running. If it is, pacman deletes the install out from under a live process. The browser survives on deleted inodes — its window stays up and fully usable, so nothing on screen suggests a problem — but every child process it spawns from then on dies during startup. Removing Chrome while it was open left a browser that looked completely normal and quietly produced three core dumps over the next two hours.

Nothing is wrong with the browser's behavior here. Chrome's crashes are `SIGTRAP` from its own `IMMEDIATE_CRASH()` (`int3; ud2`), which is the correct response to finding its install directory gone. The defect is that removal is allowed to create that state at all, and every branch shares it — `chrome`, `brave`, `brave-origin`, `edge`, `firefox`, `zen` all call `omarchy-pkg-drop` unguarded.

The guard asks whether any running process is executing a binary owned by the package about to be removed, by intersecting `pacman -Qlq` against the `/proc/*/exe` links. Matching on package contents rather than process names avoids hardcoding install paths that would drift as packages change layout, and it settles the Brave/Brave Origin case that `omarchy-theme-set-browser` already documents — both run a process named simply `brave`, so no name match can separate them. It also catches a browser already running from a deleted install, since `/proc/<pid>/exe` still resolves to the original path with a ` (deleted)` suffix. It reuses `omarchy-pkg-present`, adds no dependencies, and costs ~62ms once, on a command that is about to run a pacman transaction anyway.

It refuses rather than prompting, so it stays correct under `--noconfirm` and for non-interactive callers. Easy to turn into an offer to close the browser if you'd rather.

Tested on Omarchy 4.0.0-1 against a live Chrome 151.0.7922.137 with `omarchy-pkg-drop` and `sudo` stubbed, so a failing guard would announce itself instead of actually removing anything: the patched script refuses and never reaches `omarchy-pkg-drop`, while the same run on `quattro` sails straight into it and reproduces the bug. Also covered: an uninstalled browser still proceeds, a bad argument still prints usage, and the matcher correctly separates a running package from an installed-but-idle one and an absent one. A separate test runs a real process from a genuinely deleted binary.

That last test earned its place. The first version of this stripped the suffix with `${exe% (deleted)}`, which silently does nothing — bash reads the parentheses as a glob, so the path never matches and a half-removed browser sails through the guard. It needs the quoted form, `${exe%" (deleted)"}`. The one case the whole patch exists to prevent was the one that would have shipped broken.

One limit worth flagging: only Chrome was installed on the machine this was written on, so the end-to-end refuse/proceed behavior is verified for Chrome alone. The other five run the identical code path with only the package name differing, and the matcher is unit-tested against absent packages, but I have not watched Brave, Edge, Firefox, or Zen actually get blocked. The Brave / Brave Origin pair is the one I'd most want a second pair of eyes on.

Fixes #6905

🤖 Generated with [Claude Code](https://claude.com/claude-code)
