### PR TITLE
Fix FIDO2 setup on keys that require user verification

### DIFF
--- a/bin/omarchy-setup-security-fido2
+++ b/bin/omarchy-setup-security-fido2
@@ -118,7 +118,11 @@ if [[ ! -f $authfile ]]; then
   # closed pipe as soon as a second key is attached, and pipefail reports that
   # SIGPIPE as a failure that set -e acts on.
   device=${tokens%%:*}
-  device_info=$(fido2-token -I "$device")
+
+  if ! device_info=$(fido2-token -I "$device"); then
+    echo -e "\e[31m\nCouldn't read the FIDO2 key's capabilities. Replug it and try again.\e[0m"
+    exit 1
+  fi
 
   # Refuse a key that cannot be registered before asking for a password, not
   # after.

--- a/bin/omarchy-setup-security-fido2
+++ b/bin/omarchy-setup-security-fido2
@@ -16,6 +16,44 @@ check_fido2_hardware() {
   return 0
 }
 
+# CTAP options come back as one comma-separated line where a leading "no" means
+# the key supports the option but it is not configured: clientPin means a PIN is
+# set, noclientPin means the key takes one and nobody has. Comparing with a
+# comma on each side is what keeps nouv from reading as uv.
+fido2_option_enabled() {
+  local name=$1 info=$2 options
+
+  options=$(sed -n 's/^options:[[:space:]]*//p' <<<"$info" | tr -d ' ')
+
+  [[ ,$options, == *",$name,"* ]]
+}
+
+# A key enforcing alwaysUv refuses every assertion that does not carry user
+# verification, so a presence-only credential can never authenticate with it:
+# the key never lights up, and sudo falls through to the password. A key that
+# does not enforce it is registered exactly as before, PIN or not. What is
+# recorded here is a requirement the authenticator states, not a policy added
+# on top of one.
+#
+# Recorded per credential rather than as a pinverification= module argument,
+# which pam_u2f ORs with each credential's own flag and would therefore force a
+# PIN onto every key in the mapping file, including one that has none.
+set_registration_flags() {
+  local info=$1
+
+  REGISTRATION_FLAGS=()
+
+  if fido2_option_enabled alwaysUv "$info"; then
+    if fido2_option_enabled uv "$info"; then
+      REGISTRATION_FLAGS=(-V)
+    elif fido2_option_enabled clientPin "$info"; then
+      REGISTRATION_FLAGS=(-N)
+    else
+      return 1
+    fi
+  fi
+}
+
 setup_pam_config() {
   # Configure sudo
   if ! grep -q pam_u2f.so /etc/pam.d/sudo; then
@@ -75,9 +113,28 @@ if [[ -L $authfile || ( -e $authfile && ! -f $authfile ) ]]; then
 fi
 
 if [[ ! -f $authfile ]]; then
+  # check_fido2_hardware already read the device list, whose first field is the
+  # path. Piping it through head again would leave fido2-token writing into a
+  # closed pipe as soon as a second key is attached, and pipefail reports that
+  # SIGPIPE as a failure that set -e acts on.
+  device=${tokens%%:*}
+  device_info=$(fido2-token -I "$device")
+
+  # Refuse a key that cannot be registered before asking for a password, not
+  # after.
+  if ! set_registration_flags "$device_info"; then
+    echo -e "\e[31m\nThis key always requires user verification, but has no PIN set.\e[0m"
+    echo "Set one with: fido2-token -S $device"
+    exit 1
+  fi
+
   sudo install -d -m 755 -o root -g root "$authdir"
   echo -e "\e[32m\nLet's setup your device by confirming on the device now.\e[0m"
-  echo -e "Touch your FIDO2 key when it lights up...\n"
+  if [[ ${REGISTRATION_FLAGS[0]-} == "-N" ]]; then
+    echo -e "Enter your key's PIN when asked, then touch the key when it lights up...\n"
+  else
+    echo -e "Touch your FIDO2 key when it lights up...\n"
+  fi
 
   # A unique sibling created by root cannot be replaced by another process
   # running as this user. Stream pamu2fcfg into it instead of asking root to
@@ -119,7 +176,7 @@ if [[ ! -f $authfile ]]; then
     exit 1
   fi
 
-  if pamu2fcfg | sudo tee "$stage" >/dev/null && [[ -s $stage ]]; then
+  if pamu2fcfg "${REGISTRATION_FLAGS[@]}" | sudo tee "$stage" >/dev/null && [[ -s $stage ]]; then
     sudo chmod 644 "$stage"
     sudo mv -Tf "$stage" "$authfile"
     stage=""

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -11,11 +11,14 @@ stub_bin="$test_tmp/bin"
 stages="$test_tmp/stages.log"
 calls="$test_tmp/calls.log"
 pamu_targets="$test_tmp/pamu-targets.log"
+pamu_args="$test_tmp/pamu-args.log"
 bare_mktemp="$test_tmp/bare-mktemp.log"
 credential="tester:credential-handle,public-key,es256,+presence"
 authdir="$test_tmp/etc-fido2"
 authfile="$authdir/fido2"
 setup_copy="$test_tmp/setup.sh"
+default_token_info='options: rk, up, noplat, clientPin, pinUvAuthToken'
+token_info=$default_token_info
 mkdir -p "$stub_bin"
 
 cleanup() {
@@ -203,10 +206,27 @@ case "${1:-}" in
 esac
 SH
 
+# The setup reads the authenticator's own CTAP options before it registers
+# anything, so -I answers as whichever class of key the case under test stands
+# in for. Pinning the device operand also proves the setup probes the key it
+# discovered rather than a path of its own invention.
 cat >"$stub_bin/fido2-token" <<'SH'
 #!/bin/bash
 
-echo '/dev/hidraw0: vendor=0x1050, product=0x0407 (Yubico YubiKey)'
+set -euo pipefail
+
+case "${1:-}" in
+  -L)
+    printf '%s\n' '/dev/hidraw0: vendor=0x1050, product=0x0407 (Yubico YubiKey)'
+    ;;
+  -I)
+    [[ ${2:-} == "/dev/hidraw0" ]] || exit 94
+    printf '%s\n' "$TEST_TOKEN_INFO"
+    ;;
+  *)
+    exit 93
+    ;;
+esac
 SH
 
 cat >"$stub_bin/omarchy-pkg-add" <<'SH'
@@ -220,6 +240,15 @@ cat >"$stub_bin/pamu2fcfg" <<'SH'
 #!/bin/bash
 
 set -euo pipefail
+
+# printf runs its format once even with nothing to substitute, so an
+# unconditional '\t%s' would log a phantom empty argument for the no-flag case
+# and the assertion below would be reading the stub rather than the setup.
+printf 'pamu2fcfg' >>"$TEST_PAMU_ARGS"
+if (( $# > 0 )); then
+  printf '\t%s' "$@" >>"$TEST_PAMU_ARGS"
+fi
+printf '\n' >>"$TEST_PAMU_ARGS"
 
 target=$(readlink /proc/self/fd/1)
 printf '%s\n' "$target" >>"$TEST_PAMU_TARGETS"
@@ -249,7 +278,9 @@ reset_run() {
   : >"$calls"
   : >"$stages"
   : >"$pamu_targets"
+  : >"$pamu_args"
   : >"$bare_mktemp"
+  token_info=$default_token_info
   rm -rf "$authdir"
 }
 
@@ -262,7 +293,8 @@ invoke_setup() {
   TEST_AUTHDIR="$authdir" TEST_AUTHFILE="$authfile" TEST_BARE_MKTEMP="$bare_mktemp" \
     TEST_CREDENTIAL="$credential" TEST_FAIL_CHMOD="$fail_chmod" TEST_FAIL_MV="$fail_mv" \
     TEST_LOG="$calls" TEST_MKTEMP_MODE="$mktemp_mode" TEST_PAMU_MODE="$pamu_mode" \
-    TEST_PAMU_TARGETS="$pamu_targets" TEST_STAGES="$stages" TEST_TMP="$test_tmp" \
+    TEST_PAMU_ARGS="$pamu_args" TEST_PAMU_TARGETS="$pamu_targets" TEST_STAGES="$stages" \
+    TEST_TMP="$test_tmp" TEST_TOKEN_INFO="$token_info" \
     PATH="$stub_bin:$ROOT/bin:$PATH" \
     bash "$setup_copy" </dev/null >/dev/null
 }
@@ -478,3 +510,68 @@ invoke_setup success 0 0 nonregular >/dev/null 2>&1 &&
   fail "a nonregular stage is never published" "$(cat "$calls")"
 [[ ! -e $authfile ]] || fail "a nonregular stage publishes no authfile"
 pass "FIDO2 setup rejects nonregular mktemp output before any privileged write"
+
+# The authenticator decides the credential's flags, not this script. A key that
+# enforces alwaysUv rejects every assertion that does not carry user
+# verification, so a presence-only credential can never authenticate with it and
+# setup reports a success that sudo then falls through. A key that does not
+# enforce it is registered exactly as it was before, PIN or no PIN: what is
+# recorded here is a requirement the key states, never a policy added on top.
+assert_flags_for() {
+  local description=$1 options=$2 expected=$3
+  local logged
+
+  reset_run
+  token_info=$options
+  run_setup
+
+  logged=$(cat "$pamu_args")
+  [[ $logged == "$expected" ]] ||
+    fail "$description" "pamu2fcfg was invoked as: $logged"
+  [[ -f $authfile && $(<"$authfile") == "$credential" ]] ||
+    fail "$description" "no credential was published"
+  pass "$description"
+}
+
+assert_flags_for "a key that always requires verification records its PIN" \
+  'options: rk, up, noplat, alwaysUv, credMgmt, clientPin, pinUvAuthToken' \
+  $'pamu2fcfg\t-N'
+
+assert_flags_for "a key with built-in verification records that rather than its PIN" \
+  'options: rk, up, uv, alwaysUv, clientPin, bioEnroll' \
+  $'pamu2fcfg\t-V'
+
+# nouv is the option present and false: built-in verification the key supports
+# but nobody has configured. Reading it as configured would record -V and leave
+# the credential unusable for the same reason as before.
+assert_flags_for "an alwaysUv key with unconfigured built-in verification falls back to its PIN" \
+  'options: rk, up, nouv, alwaysUv, clientPin' \
+  $'pamu2fcfg\t-N'
+
+assert_flags_for "a PIN-capable key that does not require verification is registered as before" \
+  'options: rk, up, noplat, clientPin, pinUvAuthToken' \
+  'pamu2fcfg'
+
+assert_flags_for "a key with built-in verification but no alwaysUv is registered as before" \
+  'options: rk, up, uv, clientPin, bioEnroll' \
+  'pamu2fcfg'
+
+assert_flags_for "a U2F-only key that reports no options at all is registered as before" \
+  '/dev/hidraw0: vendor=0x1050, product=0x0407 (Yubico YubiKey)' \
+  'pamu2fcfg'
+
+# alwaysUv with neither a PIN nor configured built-in verification cannot
+# produce a credential that authenticates. Say so instead of registering one,
+# and say it before the first sudo: a key that cannot be set up is not worth a
+# password prompt.
+reset_run
+token_info='options: rk, up, alwaysUv, noclientPin'
+invoke_setup >/dev/null 2>&1 &&
+  fail "FIDO2 setup refuses a key requiring verification it cannot perform"
+[[ ! -s $stages && ! -s $pamu_targets && ! -s $pamu_args ]] ||
+  fail "FIDO2 setup stages nothing for a key it cannot register"
+[[ ! -e $authfile ]] ||
+  fail "FIDO2 setup publishes nothing for a key it cannot register"
+[[ ! -s $calls ]] ||
+  fail "FIDO2 setup refuses an unregisterable key before it escalates" "$(cat "$calls")"
+pass "FIDO2 setup refuses an alwaysUv key with no verification configured, before escalating"

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -12,6 +12,7 @@ stages="$test_tmp/stages.log"
 calls="$test_tmp/calls.log"
 pamu_targets="$test_tmp/pamu-targets.log"
 pamu_args="$test_tmp/pamu-args.log"
+output="$test_tmp/output.log"
 bare_mktemp="$test_tmp/bare-mktemp.log"
 credential="tester:credential-handle,public-key,es256,+presence"
 authdir="$test_tmp/etc-fido2"
@@ -19,6 +20,7 @@ authfile="$authdir/fido2"
 setup_copy="$test_tmp/setup.sh"
 default_token_info='options: rk, up, noplat, clientPin, pinUvAuthToken'
 token_info=$default_token_info
+token_info_fails=0
 mkdir -p "$stub_bin"
 
 cleanup() {
@@ -221,6 +223,7 @@ case "${1:-}" in
     ;;
   -I)
     [[ ${2:-} == "/dev/hidraw0" ]] || exit 94
+    [[ $TEST_TOKEN_INFO_FAILS == "0" ]] || exit 1
     printf '%s\n' "$TEST_TOKEN_INFO"
     ;;
   *)
@@ -280,7 +283,9 @@ reset_run() {
   : >"$pamu_targets"
   : >"$pamu_args"
   : >"$bare_mktemp"
+  : >"$output"
   token_info=$default_token_info
+  token_info_fails=0
   rm -rf "$authdir"
 }
 
@@ -295,8 +300,9 @@ invoke_setup() {
     TEST_LOG="$calls" TEST_MKTEMP_MODE="$mktemp_mode" TEST_PAMU_MODE="$pamu_mode" \
     TEST_PAMU_ARGS="$pamu_args" TEST_PAMU_TARGETS="$pamu_targets" TEST_STAGES="$stages" \
     TEST_TMP="$test_tmp" TEST_TOKEN_INFO="$token_info" \
+    TEST_TOKEN_INFO_FAILS="$token_info_fails" \
     PATH="$stub_bin:$ROOT/bin:$PATH" \
-    bash "$setup_copy" </dev/null >/dev/null
+    bash "$setup_copy" </dev/null >"$output"
 }
 
 run_setup() {
@@ -575,3 +581,19 @@ invoke_setup >/dev/null 2>&1 &&
 [[ ! -s $calls ]] ||
   fail "FIDO2 setup refuses an unregisterable key before it escalates" "$(cat "$calls")"
 pass "FIDO2 setup refuses an alwaysUv key with no verification configured, before escalating"
+
+# fido2-token -I failing aborted the setup through set -e, printing nothing at
+# all: the terminal closed on a successful-looking run that had registered
+# nothing. Assert the explanation, not just the exit status.
+reset_run
+token_info_fails=1
+invoke_setup >/dev/null 2>&1 &&
+  fail "FIDO2 setup fails when it cannot read the key's capabilities"
+grep -Fq "Couldn't read the FIDO2 key's capabilities" "$output" ||
+  fail "FIDO2 setup says why it gave up on a key it cannot read" "$(cat "$output")"
+[[ ! -s $stages && ! -s $pamu_args ]] ||
+  fail "FIDO2 setup stages nothing for a key it cannot read"
+[[ ! -e $authfile ]] || fail "FIDO2 setup publishes nothing for a key it cannot read"
+[[ ! -s $calls ]] ||
+  fail "FIDO2 setup gives up on an unreadable key before it escalates" "$(cat "$calls")"
+pass "FIDO2 setup reports why it bailed when the key cannot be read"


### PR DESCRIPTION
`omarchy-setup-security-fido2` cannot produce a working configuration on any
authenticator that enforces CTAP 2.1 `alwaysUv`. Setup reports success, and then
every `sudo` falls through to the password prompt.

The authenticator (a Token2 FIDO2 key, but this applies to any key with
`alwaysUv` set, including a YubiKey configured that way):

```
$ fido2-token -I /dev/hidraw3
options: rk, up, noplat, alwaysUv, credMgmt, authnrCfg, clientPin,
         largeBlobs, pinUvAuthToken, setMinPINLength, nomakeCredUvNotRqd
```

`alwaysUv` means the key refuses any assertion that does not carry user
verification, e.g. a valid PIN. But `pamu2fcfg` with no flags records a
presence-only credential:

```
$ cut -d, -f4 /etc/fido2/fido2
+presence
```

So `pam_u2f` asks for an assertion with verification off, the key rejects it
with `FIDO_ERR_PIN_REQUIRED` before it even lights up, and because the rule is
`sufficient` the stack continues to `system-auth` and prompts for the password.
The key never blinks; the "touch" message is `cue`, printed before the attempt.

## The fix

Read the authenticator's CTAP options and pass `-V` (built-in verification) or
`-N` (PIN) to `pamu2fcfg` accordingly — **only for a key that enforces
`alwaysUv`**. A key that does not is registered exactly as it is today, PIN or
no PIN. What gets recorded is a requirement the authenticator states, not a
policy this change adds on top of one, so nothing that works today behaves
differently.

| Authenticator | Flags |
|---|---|
| `alwaysUv`, PIN set | `-N` |
| `alwaysUv`, built-in verification configured | `-V` |
| `alwaysUv`, neither | refused, pointing at `fido2-token -S` |
| PIN set, no `alwaysUv` | none — unchanged |
| Built-in verification, no `alwaysUv` | none — unchanged |
| U2F-only, no options line | none — unchanged |

Recorded per credential rather than by adding `pinverification=1` to the module
line, because `pam_u2f` ORs the module option with the credential's own flag:

```c
/* util.c, parse_opts() */
if (cfg->userpresence == 1 || strstr(attr, "+presence")) opts->up = FIDO_OPT_TRUE;
else if (cfg->userpresence == 0)                         opts->up = FIDO_OPT_FALSE;
else                                                     opts->up = FIDO_OPT_OMIT;
```

A module-wide setting would force a PIN onto every key in the mapping file,
including one that has none. Per-credential flags let a PIN-mandatory key and a
touch-only key coexist for the same user.

The probe runs before the first `sudo`, so a key that cannot be registered never
costs a password prompt.

## Rebased onto #7904

This PR originally carried a second commit installing the mapping file
`root:root`, because `pamu2fcfg >/tmp/fido2` followed by `sudo mv` preserved the
invoking user's ownership. #7904 has since fixed that and considerably more
besides — the predictable `/tmp` path, symlinks at both `/etc/fido2` and the
authfile, a non-regular path at either, and a migration for existing installs.
That commit is dropped as superseded; the branch is rebased onto #7904 and now
carries only the `alwaysUv` fix.


## Testing

`test/shell.d/security-fido2-test.sh` gains the authenticator matrix, driven end
to end through the real script rather than as a unit test: the `fido2-token` stub
answers `-I` as each class of key, the `pamu2fcfg` stub records its argv, and
each case asserts the exact flags and that a credential was published. It also
covers both refusal paths — an `alwaysUv` key with no verification configured,
and a key whose capabilities cannot be read — including that each happens before
anything escalates and that the second explains itself rather than dying
silently through `set -e`.

Every new assertion was checked against a mutation that defeats it: the
`alwaysUv` gate removed, the `no`-prefix boundary lost so `nouv` reads as `uv`,
`-V` and `-N` swapped, the flags not passed through to `pamu2fcfg`, the refusal
moved after `sudo install -d`, and the capability guard reverted.

`./test/all` matches a clean `quattro` checkout run from the same directory.

End to end on the real key, against a scratch authfile: `fido2-token -I` reports
`alwaysUv` and `clientPin`, `pamu2fcfg -N` takes the PIN and the touch, and the
credential lands as `+presence+pin` — where the unpatched script writes
`+presence` from the same key and `sudo` then falls through to the password.
