### PR TITLE
Keep Wi-Fi indicator online when AP object is missing

### DIFF
--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -20,6 +20,20 @@ function connectionIcon(kind, signalStrength) {
   return "󰤮"
 }
 
+function connectionKind(wiredConnected, wifiNetworkConnected, wifiDeviceConnected) {
+  if (wiredConnected) return "ethernet"
+  if (wifiNetworkConnected || wifiDeviceConnected) return "wifi"
+  return "disconnected"
+}
+
+function connectionSignalStrength(networkStrength, wifiConnected) {
+  if (networkStrength !== null && networkStrength !== undefined) {
+    return Math.round((networkStrength || 0) * 100)
+  }
+
+  return wifiConnected ? 0 : -1
+}
+
 function formatHeaderSpeed(mbps) {
   var v = parseInt(mbps, 10)
   if (!v || v < 0) return ""
@@ -342,6 +356,8 @@ if (typeof module !== "undefined") {
     parseNetworkStatus: parseNetworkStatus,
     wifiIconFor: wifiIconFor,
     connectionIcon: connectionIcon,
+    connectionKind: connectionKind,
+    connectionSignalStrength: connectionSignalStrength,
     formatHeaderSpeed: formatHeaderSpeed,
     formatHeaderFreq: formatHeaderFreq,
     headerDetail: headerDetail,

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -434,16 +434,20 @@ Panel {
 
   // Bar pill state, derived from the native NetworkManager service so the
   // icon reflects connection changes without polling. Wired is preferred
-  // when both are up, matching the default-route device.
+  // when both are up, matching the default-route device. Some NetworkManager
+  // backends report the Wi-Fi device as connected before exposing the current
+  // access point in the scan list, so keep the bar online from device state.
   readonly property var wiredDevice: findDevice(DeviceType.Wired)
-  readonly property string kind: {
-    if (wiredDevice && wiredDevice.connected) return "ethernet"
-    if (connectedWifiNetwork) return "wifi"
-    return "disconnected"
-  }
-  readonly property int signalStrength: connectedWifiNetwork
-    ? Math.round((connectedWifiNetwork.signalStrength || 0) * 100)
-    : -1
+  readonly property bool wifiConnected: !!connectedWifiNetwork || !!(wifiDevice && wifiDevice.connected)
+  readonly property string kind: Model.connectionKind(
+    !!(wiredDevice && wiredDevice.connected),
+    !!connectedWifiNetwork,
+    !!(wifiDevice && wifiDevice.connected)
+  )
+  readonly property int signalStrength: Model.connectionSignalStrength(
+    connectedWifiNetwork ? connectedWifiNetwork.signalStrength : null,
+    wifiConnected
+  )
 
   function copyToClipboard(value) {
     if (!value || !root.bar) return

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -90,6 +90,13 @@ assertDeepEqual(
   'network parses bar status'
 )
 assertEqual(network.connectionIcon('wifi', 80), network.wifiIconFor(80), 'network maps wifi icon from signal')
+assertEqual(network.connectionKind(false, false, false), 'disconnected', 'network reports disconnected when no device is online')
+assertEqual(network.connectionKind(true, true, true), 'ethernet', 'network prefers ethernet when multiple devices are online')
+assertEqual(network.connectionKind(false, true, false), 'wifi', 'network reports wifi from a connected access point')
+assertEqual(network.connectionKind(false, false, true), 'wifi', 'network reports wifi from a connected device when access points are missing')
+assertEqual(network.connectionSignalStrength(0.78, true), 78, 'network maps access-point signal strength to percent')
+assertEqual(network.connectionSignalStrength(null, true), 0, 'network keeps connected wifi online when signal strength is unknown')
+assertEqual(network.connectionSignalStrength(null, false), -1, 'network has no signal strength while disconnected')
 assertEqual(network.formatHeaderSpeed('1000'), '1gbit', 'network formats gigabit speed')
 assertEqual(network.formatHeaderSpeed('2500'), '2.5gbit', 'network formats fractional gigabit speed')
 assertEqual(network.formatHeaderFreq('2462'), '2.4ghz', 'network formats 2.4GHz wifi band')


### PR DESCRIPTION
## Summary

- keep the network bar widget in Wi-Fi state when NetworkManager reports the Wi-Fi device as connected but Quickshell has no connected access-point object
- preserve wired-over-wifi precedence
- add regression coverage for the device-connected/AP-missing state

## Reproduction

On an upgraded Quattro install, the machine is online through Wi-Fi:

```bash
nmcli device status
# wlp0s20f3  wifi  connected  ExampleWifi

nmcli networking connectivity check
# full

omarchy-network-status
# wifi ExampleWifi 67 6135.0
```

A small Quickshell probe showed the native NetworkManager backend had the device connected while its AP list was empty:

```text
backend=1 wifiEnabled=true deviceCount=1
device[0] name=wlp0s20f3 type=1 connected=true state=2
device[0].networkCount=0
```

The panel previously derived `kind === "wifi"` only from `connectedWifiNetwork`, so this state rendered the disconnected icon even though the network was online.

## Tests

- `bash test/shell.d/network-test.sh`
- `bash test/shell.d/plugin-validate-test.sh`

I also ran `bash test/shell.d/runtime-smoke-test.sh`; it reached the shell IPC checks and then failed an existing handler-count assertion in this live session: `each widget registers its IPC handler once per screen (saw 6 for 3 screen(s))`.
