### PR TITLE
Stop DaVinci Resolve dialogs from recapturing pointer focus

### DIFF
--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -10,4 +10,5 @@ o.window(".*[Rr]esolve.*", {
 })
 
 o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { fullscreen = true })
-o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager|Preferences|Find Directory)$" }, { stay_focused = false })
+-- Resolve exposes the Voiceover panel under the generic "Dialog" title.
+o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager|Preferences|Find Directory|Dialog)$" }, { stay_focused = false })

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -3,6 +3,7 @@
 o.window(".*[Rr]esolve.*", {
   float = true,
   stay_focused = true,
+  -- Prevent modal dialog pointer warps when focus follows the mouse.
   no_follow_mouse = true,
   tag = "-default-opacity",
   opacity = "1 1",

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -3,9 +3,10 @@
 o.window(".*[Rr]esolve.*", {
   float = true,
   stay_focused = true,
+  no_follow_mouse = true,
   tag = "-default-opacity",
   opacity = "1 1",
 })
 
 o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { fullscreen = true })
-o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager)$" }, { stay_focused = false })
+o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager|Preferences|Find Directory)$" }, { stay_focused = false })


### PR DESCRIPTION
Opening Preferences > Media Storage > Add traps the pointer in Resolve's Find Directory dialog. It also prevents the screenshot selector from receiving pointer movement.

#6430 let the main Resolve window and Project Manager yield focus, but Preferences and Find Directory remain stay-focused. The screenshot selector is a layer surface, so even one pinned Resolve dialog can keep pointer events away from it.

This keeps `stay_focused` for Resolve's transient popups while allowing Preferences and Find Directory to yield focus. It also disables hover-driven focus changes within Resolve, preventing Hyprland from warping the pointer back into a modal dialog. Resolve windows still focus normally when clicked.

Addresses #5887. Supersedes #5926.

Verified on Quattro with Resolve 20:

- Preferences and Media Storage > Add remain usable
- the pointer can leave Find Directory without warping
- Super+Shift+S works from Preferences and Find Directory
- cancelling capture returns to the dialog
- other Resolve dialogs remain clickable
- Lua syntax, CLI tests, and packaging checks pass
