### PR TITLE
Preview fonts in the font menu

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -373,6 +373,7 @@ Item {
         parent: menuId,
         kind: "action",
         icon: (value === current) ? "✓" : (spec.icon || ""),
+        labelFont: providerKey === "fonts" ? value : "",
         label: label,
         title: "",
         target: "",
@@ -533,6 +534,7 @@ Item {
         kind: "dmenu",
         icon: icon,
         iconFont: "",
+        labelFont: "",
         appIcon: "",
         appId: "",
         label: label,
@@ -1203,6 +1205,7 @@ Item {
               required property string kind
               required property string icon
               required property string iconFont
+              required property string labelFont
               required property string appIcon
               required property string appId
               required property string label
@@ -1279,7 +1282,7 @@ Item {
                   width: parent.width
                   text: row.label
                   color: row.hasCursor ? root.selectedText : root.foreground
-                  font.family: root.fontFamily
+                  font.family: row.labelFont.length > 0 ? row.labelFont : root.fontFamily
                   font.pixelSize: Style.font.heading
                   font.weight: Font.Medium
                   elide: Text.ElideRight
@@ -1299,11 +1302,24 @@ Item {
 
               Row {
                 id: trail
-                width: Style.space(14)
+                width: row.labelFont.length > 0 ? Style.space(82) : Style.space(14)
                 anchors.right: parent.right
                 anchors.rightMargin: root.rowReservedBorderRight + Style.space(8)
                 y: contentColumn.y + labelText.y + (labelText.height - height) / 2
                 spacing: 0
+
+                Text {
+                  visible: row.labelFont.length > 0
+                  width: visible ? Style.space(68) : 0
+                  text: "Ag 01"
+                  color: row.hasCursor ? root.selectedText : root.foreground
+                  opacity: row.hasCursor ? 1 : 0.72
+                  font.family: row.labelFont
+                  font.pixelSize: Style.font.heading
+                  font.weight: Font.Normal
+                  horizontalAlignment: Text.AlignRight
+                  verticalAlignment: Text.AlignVCenter
+                }
 
                 Text {
                   visible: false

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -358,6 +358,7 @@ function displayRow(items, itemOrder, checkedResults, entry, detail, score, sect
     kind: entry.kind,
     icon: entry.icon,
     iconFont: entry.iconFont || "",
+    labelFont: entry.labelFont || "",
     appIcon: entry.appIcon || "",
     appId: entry.appId || "",
     label: labelFor(entry, checkedResults),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -92,6 +92,7 @@ assertDeepEqual(
     kind: 'action',
     icon: '',
     iconFont: '',
+    labelFont: '',
     appIcon: '',
     appId: '',
     label: 'Theme picker',
@@ -348,6 +349,12 @@ assertEqual(
 assert(
   /font\.family: row\.iconFont\.length > 0 \? row\.iconFont : root\.fontFamily/.test(menuQml),
   'menu rows support per-icon font families'
+)
+assert(
+  /labelFont: providerKey === "fonts" \? value : ""/.test(menuQml)
+    && /font\.family: row\.labelFont\.length > 0 \? row\.labelFont : root\.fontFamily/.test(menuQml)
+    && /text: "Ag 01"[\s\S]*font\.family: row\.labelFont/.test(menuQml),
+  'font provider rows preview each family in their label and specimen'
 )
 
 assert(


### PR DESCRIPTION
## Summary

- render each Style → Font entry in its corresponding font family
- add a compact `Ag 01` specimen so similar monospaced families are easier to compare
- keep checkmarks, icons, headers, details, and non-font menu rows in the active Omarchy font
- cover the new row data and rendering contract in the focused menu test

## Why

The font picker rendered every family name using the currently active menu font. That made installed fonts look identical until one was selected and applied. Font provider rows now carry their family through the display model and use it for both the label and a compact specimen.

## Before / after

| Before — packaged shell | After — checkout fix |
| --- | --- |
| ![Font menu before: every row uses the active menu font](https://raw.githubusercontent.com/dna737/omarchy/d91b5ff286a3c264748e637e3b0f21228fe870db/pr-assets/font-menu-before.png) | ![Font menu after: each row includes a candidate-family specimen](https://raw.githubusercontent.com/dna737/omarchy/d91b5ff286a3c264748e637e3b0f21228fe870db/pr-assets/font-menu-fixed.png) |

## User impact

Users can compare installed fonts directly in Style → Font without changing fonts repeatedly. The menu retains its existing one-line row height and selection behavior.

## Verification

- `bash test/shell.d/menu-test.sh`
- `./test/all` (the changed menu test passed; the aggregate run retained four unrelated shell-test failures: `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` require an `omarchy-pkgs` checkout, while `network-qr-test.sh` exits during its existing interface auto-detection case)
- `git diff --check`
- dev-linked the checkout and visually inspected the running Style → Font menu for distinct families, selection/checkmark behavior, clipping, overlap, and unchanged row height
