### PR TITLE
Install the CS4208 speaker driver on 12-inch MacBooks

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -33,6 +33,7 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-cs4208-audio.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"

--- a/install/hardware/apple/fix-cs4208-audio.sh
+++ b/install/hardware/apple/fix-cs4208-audio.sh
@@ -1,0 +1,14 @@
+# Enable speakers on 12-inch MacBooks (MacBook9,1 / 2016 and MacBook10,1 / 2017).
+# Mainline snd_hda_codec_cs420x detects the CS4208 but never runs the macOS
+# init that powers the speaker amplifier, so PipeWire plays to a silent analog
+# path. The out-of-tree module replays that init.
+# MacBook8,1 (2015) is not supported by this driver.
+# https://github.com/leifliddy/macbook12-audio-driver
+# https://github.com/basecamp/omarchy/issues/2101
+
+product_name="${OMARCHY_MACBOOK12_AUDIO_MODEL:-$(cat /sys/class/dmi/id/product_name 2>/dev/null)}"
+if [[ $product_name == "MacBook9,1" || $product_name == "MacBook10,1" ]]; then
+  echo "Detected 12-inch MacBook with CS4208 audio"
+
+  omarchy-pkg-add macbook12-audio-driver-dkms
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -26,6 +26,7 @@ linux-headers
 linux-ptl
 linux-ptl-headers
 macbook12-spi-driver-dkms
+macbook12-audio-driver-dkms
 nvidia-580xx-dkms
 nvidia-dkms
 nvidia-open-dkms

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -35,7 +35,7 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 3. Select the orange EFI Boot device
 4. Proceed with the [install as normal](02-getting-started.md)
 
-The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.
+The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, the CS4208 speaker driver on the 12-inch MacBook (2016 and 2017), and an NVMe suspend fix for those same models.
 
 ### Known Limitations
 

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -35,7 +35,7 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 3. Select the orange EFI Boot device
 4. Proceed with the [install as normal](02-getting-started.md)
 
-The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, the CS4208 speaker driver on the 12-inch MacBook (2016 and 2017), and an NVMe suspend fix for those same models.
+The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, an NVMe suspend fix for those same models, and the CS4208 speaker driver on the 12-inch MacBook (2016 and 2017).
 
 ### Known Limitations
 

--- a/migrations/1786719479.sh
+++ b/migrations/1786719479.sh
@@ -15,7 +15,7 @@ if omarchy-pkg-present macbook12-audio-driver-dkms; then
   exit 0
 fi
 
-if dkms status 2>/dev/null | grep -q '^macbook12-audio/'; then
+if dkms status 2>/dev/null | grep -q '^macbook12-audio-driver/'; then
   exit 0
 fi
 

--- a/migrations/1786719479.sh
+++ b/migrations/1786719479.sh
@@ -1,0 +1,23 @@
+echo "Install the CS4208 speaker driver on 12-inch MacBooks"
+
+# Fresh installs get this from install/hardware/apple/fix-cs4208-audio.sh.
+# Existing MacBook9,1 / MacBook10,1 installs still have silent speakers:
+# mainline detects the codec and PipeWire plays, but the speaker amp is never
+# enabled. Skip machines that already have the packaged module or the same
+# DKMS driver installed by hand.
+
+product_name="${OMARCHY_MACBOOK12_AUDIO_MODEL:-$(cat /sys/class/dmi/id/product_name 2>/dev/null)}"
+if [[ $product_name != "MacBook9,1" && $product_name != "MacBook10,1" ]]; then
+  exit 0
+fi
+
+if omarchy-pkg-present macbook12-audio-driver-dkms; then
+  exit 0
+fi
+
+if dkms status 2>/dev/null | grep -q '^macbook12-audio/'; then
+  exit 0
+fi
+
+omarchy-pkg-add macbook12-audio-driver-dkms
+omarchy-state set reboot-required

--- a/test/shell.d/cs4208-audio-test.sh
+++ b/test/shell.d/cs4208-audio-test.sh
@@ -50,7 +50,8 @@ cat >"$stub_bin/dkms" <<'SH'
 #!/bin/bash
 
 if (( ${CS4208_DKMS_INSTALLED:-0} == 1 )); then
-  echo 'macbook12-audio/0.1, 7.1.8-arch1-3, x86_64: installed (Original modules exist)'
+  # The name upstream's dkms.conf registers, which is what dkms status prints.
+  echo 'macbook12-audio-driver/0.1, 7.1.8-arch1-3, x86_64: installed (Original modules exist)'
   exit 0
 fi
 echo 'macbook12-spi-driver/0+git.315: added'

--- a/test/shell.d/cs4208-audio-test.sh
+++ b/test/shell.d/cs4208-audio-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-cs4208-audio.sh"
+all="$ROOT/install/hardware/all.sh"
+other_packages="$ROOT/install/omarchy-other.packages"
+migration="$ROOT/migrations/1786719479.sh"
+
+grep -q 'apple/fix-cs4208-audio.sh' "$all" ||
+  fail "the CS4208 audio fix runs during hardware setup"
+grep -qx 'macbook12-audio-driver-dkms' "$other_packages" ||
+  fail "the ISO caches the CS4208 speaker driver"
+grep -Fq 'MacBook9,1' "$leaf" && grep -Fq 'MacBook10,1' "$leaf" ||
+  fail "the CS4208 leaf matches the 12-inch MacBooks"
+pass "the CS4208 audio fix is wired into setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+
+(( ${CS4208_PKG_PRESENT:-0} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/dkms" <<'SH'
+#!/bin/bash
+
+if (( ${CS4208_DKMS_INSTALLED:-0} == 1 )); then
+  echo 'macbook12-audio/0.1, 7.1.8-arch1-3, x86_64: installed (Original modules exist)'
+  exit 0
+fi
+echo 'macbook12-spi-driver/0+git.315: added'
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local model="$1"
+  : >"$calls"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_MACBOOK12_AUDIO_MODEL="$model" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf "MacBook10,1" >/dev/null
+grep -Fq $'omarchy-pkg-add\tmacbook12-audio-driver-dkms' "$calls" ||
+  fail "a 2017 12-inch MacBook gets the CS4208 driver" "$(cat "$calls")"
+pass "a 2017 12-inch MacBook gets the CS4208 driver"
+
+run_leaf "MacBook9,1" >/dev/null
+grep -Fq $'omarchy-pkg-add\tmacbook12-audio-driver-dkms' "$calls" ||
+  fail "a 2016 12-inch MacBook gets the CS4208 driver" "$(cat "$calls")"
+pass "a 2016 12-inch MacBook gets the CS4208 driver"
+
+run_leaf "MacBook8,1" >/dev/null
+[[ ! -s $calls ]] || fail "the 2015 12-inch MacBook is left alone" "$(cat "$calls")"
+pass "the 2015 12-inch MacBook is left alone"
+
+run_leaf "MacBookPro14,1" >/dev/null
+[[ ! -s $calls ]] || fail "a MacBook Pro is left alone" "$(cat "$calls")"
+pass "a MacBook Pro is left alone"
+
+run_leaf "XPS 13 9310" >/dev/null
+[[ ! -s $calls ]] || fail "non-Apple hardware is left alone" "$(cat "$calls")"
+pass "non-Apple hardware is left alone"
+
+run_migration() {
+  : >"$calls"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_MACBOOK12_AUDIO_MODEL="$1" \
+    CS4208_PKG_PRESENT="${2:-0}" \
+    CS4208_DKMS_INSTALLED="${3:-0}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration "MacBook10,1" 0 0
+grep -Fq $'omarchy-pkg-add\tmacbook12-audio-driver-dkms' "$calls" ||
+  fail "the migration installs the CS4208 driver" "$(cat "$calls")"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the reboot that loads the module" "$(cat "$calls")"
+pass "the migration installs the CS4208 driver"
+
+run_migration "MacBook10,1" 1 0
+[[ ! -s $calls ]] || fail "the migration skips a machine that already has the package" "$(cat "$calls")"
+pass "the migration skips a machine that already has the package"
+
+run_migration "MacBook10,1" 0 1
+[[ ! -s $calls ]] || fail "the migration skips a hand-installed DKMS driver" "$(cat "$calls")"
+pass "the migration skips a hand-installed DKMS driver"
+
+run_migration "MacBookPro14,1" 0 0
+[[ ! -s $calls ]] || fail "the migration skips unrelated hardware" "$(cat "$calls")"
+pass "the migration skips unrelated hardware"


### PR DESCRIPTION
## Summary

On the 12-inch MacBook (`MacBook9,1` / 2016 and `MacBook10,1` / 2017), mainline `snd_hda_codec_cs420x` detects the Cirrus Logic CS4208 and PipeWire plays to it, but the speaker amplifier is never enabled. The OS thinks audio is working; the speakers stay silent. Headphones can still work because they use a different path.

This is the same gap as #2101. Grok diagnosed it on a `MacBook10,1` running Omarchy 4, installed [leifliddy/macbook12-audio-driver](https://github.com/leifliddy/macbook12-audio-driver) via DKMS, and speakers came up. This PR is that fix paid forward to the next installer.

## What it does

- New hardware leaf `install/hardware/apple/fix-cs4208-audio.sh`, same shape as the SPI keyboard fix: detect `MacBook9,1` / `MacBook10,1`, then `omarchy-pkg-add macbook12-audio-driver-dkms`.
- `MacBook8,1` (2015) is left alone; that model is not supported by this driver.
- Migration `1786719479.sh` for existing installs. No-ops if the package is already present or if the same DKMS module was installed by hand.
- Cached in `install/omarchy-other.packages` so the ISO can ship it.
- Manual note in `manual/44-mac-support.md`.

Omarchy already applies software volume globally, so the extra WirePlumber soft-mixer step from the driver README is not needed here.

## Package

This needs `macbook12-audio-driver-dkms` in `pkgs.omarchy.org`, built from https://github.com/leifliddy/macbook12-audio-driver — the same source that restored speakers on the machine this was written on.

It is not in the repo yet. Land the package with this PR (or immediately before), the way `macbook12-spi-driver-dkms` already is. The DKMS `PRE_BUILD` downloads matching kernel HD-audio headers on the target, so the package only needs to ship the driver source and `dkms.conf`.

## Test plan

- [x] `test/shell.d/cs4208-audio-test.sh` — leaf and migration fire only on `MacBook9,1` / `MacBook10,1`, skip 2015 / Pro / non-Apple, skip when the package or a hand-installed DKMS module is already there
- [x] Verified on a 2017 12-inch MacBook (`MacBook10,1`): after the DKMS module, speakers play; jack switch still works