### PR TITLE
Prevent togglesplit error in scrolling layout

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,7 +1,13 @@
 o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle window split", function()
+  local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()
+
+  if workspace and workspace.tiled_layout == "dwindle" then
+    hl.dispatch(hl.dsp.layout("togglesplit"))
+  end
+end)
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,13 +1,17 @@
 o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", function()
-  local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()
+local function layout_dispatch(layout, dispatcher)
+  return function()
+    local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()
 
-  if workspace and workspace.tiled_layout == "dwindle" then
-    hl.dispatch(hl.dsp.layout("togglesplit"))
+    if workspace and workspace.tiled_layout == layout then
+      hl.dispatch(dispatcher)
+    end
   end
-end)
+end
+
+o.bind("SUPER + J", "Toggle window split", layout_dispatch("dwindle", hl.dsp.layout("togglesplit")))
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,6 +1,10 @@
 o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
+-- Only Dwindle answers the togglesplit layoutmsg; Scrolling rejects it at ERROR
+-- level, which pops a "Runtime error in lua" toast on every keypress. Mirror
+-- Hyprland's own targeting (special workspace first, then the active one) so the
+-- guard picks the same workspace the dispatcher would have hit.
 local function layout_dispatch(layout, dispatcher)
   return function()
     local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()

--- a/test/shell.d/hyprland-togglesplit-test.sh
+++ b/test/shell.d/hyprland-togglesplit-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+output=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return {}
+    end,
+  })
+end
+
+local bindings = {}
+local dispatched = {}
+local workspace = { tiled_layout = "scrolling" }
+local special_workspace = nil
+
+hl = setmetatable({
+  dsp = proxy(),
+  bind = function(keys, dispatcher)
+    bindings[keys] = dispatcher
+  end,
+  dispatch = function(dispatcher)
+    table.insert(dispatched, dispatcher)
+  end,
+  get_active_workspace = function()
+    return workspace
+  end,
+  get_active_special_workspace = function()
+    return special_workspace
+  end,
+}, {
+  __index = function()
+    return function() end
+  end,
+})
+
+require("default.hypr.helpers")
+require("default.hypr.bindings.tiling")
+
+local toggle_split = bindings["SUPER + J"]
+assert(type(toggle_split) == "function")
+
+toggle_split()
+assert(#dispatched == 0)
+
+workspace = { tiled_layout = "dwindle" }
+toggle_split()
+assert(#dispatched == 1)
+
+special_workspace = { tiled_layout = "scrolling" }
+toggle_split()
+assert(#dispatched == 1)
+LUA
+)
+
+[[ -z $output ]] || fail "toggle split binding produces no output" "$output"
+pass "toggle split only dispatches in a Dwindle workspace"

--- a/test/shell.d/hyprland-togglesplit-test.sh
+++ b/test/shell.d/hyprland-togglesplit-test.sh
@@ -4,7 +4,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
 
-output=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+if ! output=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
 package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local function proxy()
@@ -67,7 +67,9 @@ special_workspace = { tiled_layout = "scrolling" }
 toggle_split()
 assert(#dispatched == 1)
 LUA
-)
+); then
+  fail "toggle split binding assertions pass" "$output"
+fi
 
 [[ -z $output ]] || fail "toggle split binding produces no output" "$output"
 pass "toggle split only dispatches in a Dwindle workspace"

--- a/test/shell.d/hyprland-togglesplit-test.sh
+++ b/test/shell.d/hyprland-togglesplit-test.sh
@@ -24,9 +24,13 @@ local bindings = {}
 local dispatched = {}
 local workspace = { tiled_layout = "scrolling" }
 local special_workspace = nil
+local dsp = proxy()
+dsp.layout = function(message)
+  return "layout:" .. message
+end
 
 hl = setmetatable({
-  dsp = proxy(),
+  dsp = dsp,
   bind = function(keys, dispatcher)
     bindings[keys] = dispatcher
   end,
@@ -57,6 +61,7 @@ assert(#dispatched == 0)
 workspace = { tiled_layout = "dwindle" }
 toggle_split()
 assert(#dispatched == 1)
+assert(dispatched[1] == "layout:togglesplit")
 
 special_workspace = { tiled_layout = "scrolling" }
 toggle_split()

--- a/test/shell.d/hyprland-togglesplit-test.sh
+++ b/test/shell.d/hyprland-togglesplit-test.sh
@@ -66,6 +66,11 @@ assert(dispatched[1] == "layout:togglesplit")
 special_workspace = { tiled_layout = "scrolling" }
 toggle_split()
 assert(#dispatched == 1)
+
+special_workspace = { tiled_layout = "dwindle" }
+toggle_split()
+assert(#dispatched == 2)
+assert(dispatched[2] == "layout:togglesplit")
 LUA
 ); then
   fail "toggle split binding assertions pass" "$output"

--- a/test/shell.d/hyprland-togglesplit-test.sh
+++ b/test/shell.d/hyprland-togglesplit-test.sh
@@ -4,7 +4,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
 
-if ! output=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+if ! output=$(OMARCHY_PATH="$ROOT" lua 2>&1 <<'LUA'
 package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local function proxy()
@@ -73,7 +73,7 @@ assert(#dispatched == 2)
 assert(dispatched[2] == "layout:togglesplit")
 LUA
 ); then
-  fail "toggle split binding assertions pass" "$output"
+  fail "toggle split binding assertions failed" "$output"
 fi
 
 [[ -z $output ]] || fail "toggle split binding produces no output" "$output"


### PR DESCRIPTION
Prevent Super+J from dispatching togglesplit outside Dwindle layouts.

  The shortcut now checks the active (including special) workspace layout before dispatching. Added regression coverage
  for Dwindle and Scrolling workspaces.

  Tested with ./test/all.