### PR TITLE
Enable palm rejection on T2 MacBooks

### DIFF
--- a/default/udev/apple-t2-touchpad.rules
+++ b/default/udev/apple-t2-touchpad.rules
@@ -1,4 +1,7 @@
 # The T2 BCE driver exposes the built-in MacBook touchpad over a virtual USB
 # bus, causing systemd's input_id helper to classify it as external. Mark only
 # the touchpad interface as internal so libinput can enable disable-while-typing.
-ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INTEGRATION}="internal", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+#
+# The product ID varies by model: these are every WELLSPRINGT2 keyboard/trackpad
+# ID hid-apple binds to, which is the device the trackpad hangs off.
+ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0278|027[a-f]|0280|0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INTEGRATION}="internal", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"

--- a/default/udev/apple-t2-touchpad.rules
+++ b/default/udev/apple-t2-touchpad.rules
@@ -1,0 +1,4 @@
+# The T2 BCE driver exposes the built-in MacBook touchpad over a virtual USB
+# bus, causing systemd's input_id helper to classify it as external. Mark only
+# the touchpad interface as internal so libinput can enable disable-while-typing.
+ACTION!="remove", KERNEL=="event[0-9]*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"

--- a/default/udev/apple-t2-touchpad.rules
+++ b/default/udev/apple-t2-touchpad.rules
@@ -1,4 +1,4 @@
 # The T2 BCE driver exposes the built-in MacBook touchpad over a virtual USB
 # bus, causing systemd's input_id helper to classify it as external. Mark only
 # the touchpad interface as internal so libinput can enable disable-while-typing.
-ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INTEGRATION}="internal", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"

--- a/default/udev/apple-t2-touchpad.rules
+++ b/default/udev/apple-t2-touchpad.rules
@@ -1,4 +1,4 @@
 # The T2 BCE driver exposes the built-in MacBook touchpad over a virtual USB
 # bus, causing systemd's input_id helper to classify it as external. Mark only
 # the touchpad interface as internal so libinput can enable disable-while-typing.
-ACTION!="remove", KERNEL=="event[0-9]*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"
+ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_VENDOR_ID}=="05ac", ENV{ID_MODEL_ID}=="0340", ENV{ID_INPUT_TOUCHPAD}=="1", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal"

--- a/install/hardware/apple/fix-t2.sh
+++ b/install/hardware/apple/fix-t2.sh
@@ -19,6 +19,12 @@ if lspci -nn | grep "106b:180[12]" >/dev/null; then
     echo "hci_bcm4377"
   } > /etc/modules-load.d/t2.conf
 
+  # The virtual USB bus makes udev mistake the built-in touchpad for an
+  # external one, preventing libinput from disabling it while typing.
+  mkdir -p /etc/udev/rules.d
+  cp -f "$OMARCHY_PATH/default/udev/apple-t2-touchpad.rules" \
+    /etc/udev/rules.d/99-omarchy-apple-t2-touchpad.rules
+
   # linux-t2 7.1.4 replaced the apple-bce driver with t2bce; t2bce_vhci is the
   # virtual USB host controller the internal keyboard hangs off, and mkinitcpio
   # pulls t2bce_core/t2bce_dma in via module dependencies.

--- a/install/hardware/apple/fix-t2.sh
+++ b/install/hardware/apple/fix-t2.sh
@@ -21,8 +21,7 @@ if lspci -nn | grep "106b:180[12]" >/dev/null; then
 
   # The virtual USB bus makes udev mistake the built-in touchpad for an
   # external one, preventing libinput from disabling it while typing.
-  mkdir -p /etc/udev/rules.d
-  cp -f "$OMARCHY_PATH/default/udev/apple-t2-touchpad.rules" \
+  install -D -m 0644 "$OMARCHY_PATH/default/udev/apple-t2-touchpad.rules" \
     /etc/udev/rules.d/99-omarchy-apple-t2-touchpad.rules
 
   # linux-t2 7.1.4 replaced the apple-bce driver with t2bce; t2bce_vhci is the

--- a/migrations/1786776556.sh
+++ b/migrations/1786776556.sh
@@ -1,0 +1,17 @@
+echo "Enable palm rejection on T2 MacBook touchpads"
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
+  exit 0
+fi
+
+rule="${OMARCHY_T2_TOUCHPAD_RULE:-/etc/udev/rules.d/99-omarchy-apple-t2-touchpad.rules}"
+source_rule="$OMARCHY_PATH/default/udev/apple-t2-touchpad.rules"
+
+if [[ -f $rule ]] && cmp -s "$source_rule" "$rule"; then
+  exit 0
+fi
+
+sudo install -D -m 0644 "$source_rule" "$rule"
+
+# Libinput must reopen the device to pick up its new integration type.
+omarchy-state set reboot-required

--- a/migrations/1786776556.sh
+++ b/migrations/1786776556.sh
@@ -4,8 +4,8 @@ if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
   exit 0
 fi
 
-rule="${OMARCHY_T2_TOUCHPAD_RULE:-/etc/udev/rules.d/99-omarchy-apple-t2-touchpad.rules}"
 source_rule="$OMARCHY_PATH/default/udev/apple-t2-touchpad.rules"
+rule=/etc/udev/rules.d/99-omarchy-apple-t2-touchpad.rules
 
 if [[ -f $rule ]] && cmp -s "$source_rule" "$rule"; then
   exit 0

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -24,12 +24,15 @@ grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sl
   fail "the ISO no longer caches tiny-dfr"
 grep -Fq 'ID_INPUT_TOUCHPAD_INTEGRATION}="internal"' "$touchpad_rule" ||
   fail "T2 touchpad rule enables libinput disable-while-typing"
+grep -Fq 'ID_INTEGRATION}="internal"' "$touchpad_rule" ||
+  fail "T2 touchpad rule sets systemd's canonical integration property"
 grep -Fq 'ID_VENDOR_ID}=="05ac"' "$touchpad_rule" &&
   grep -Fq 'ID_MODEL_ID}=="0340"' "$touchpad_rule" &&
   grep -Fq 'ID_INPUT_TOUCHPAD}=="1"' "$touchpad_rule" ||
   fail "T2 touchpad rule is limited to the affected Apple touchpad"
-grep -Fq '99-omarchy-apple-t2-touchpad.rules' "$fix_t2" ||
-  fail "fresh T2 setup installs the touchpad integration rule"
+grep -Fq 'install -D -m 0644' "$fix_t2" &&
+  grep -Fq '99-omarchy-apple-t2-touchpad.rules' "$fix_t2" ||
+  fail "fresh T2 setup installs the touchpad integration rule with fixed permissions"
 grep -Fq '106b:180[12]' "$touchpad_migration" ||
   fail "T2 touchpad migration is limited to T2 hardware"
 pass "fresh T2 setup uses t2bce-compatible suspend, fan, and Touch Bar defaults"

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -27,9 +27,9 @@ grep -Fq 'ID_INPUT_TOUCHPAD_INTEGRATION}="internal"' "$touchpad_rule" ||
 grep -Fq 'ID_INTEGRATION}="internal"' "$touchpad_rule" ||
   fail "T2 touchpad rule sets systemd's canonical integration property"
 grep -Fq 'ID_VENDOR_ID}=="05ac"' "$touchpad_rule" &&
-  grep -Fq 'ID_MODEL_ID}=="0340"' "$touchpad_rule" &&
+  grep -Fq 'ID_MODEL_ID}=="0278|027[a-f]|0280|0340"' "$touchpad_rule" &&
   grep -Fq 'ID_INPUT_TOUCHPAD}=="1"' "$touchpad_rule" ||
-  fail "T2 touchpad rule is limited to the affected Apple touchpad"
+  fail "T2 touchpad rule covers every T2 keyboard/trackpad and nothing else"
 grep -Fq 'install -D -m 0644' "$fix_t2" &&
   grep -Fq '99-omarchy-apple-t2-touchpad.rules' "$fix_t2" ||
   fail "fresh T2 setup installs the touchpad integration rule with fixed permissions"

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -24,8 +24,14 @@ grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sl
   fail "the ISO no longer caches tiny-dfr"
 grep -Fq 'ID_INPUT_TOUCHPAD_INTEGRATION}="internal"' "$touchpad_rule" ||
   fail "T2 touchpad rule enables libinput disable-while-typing"
+grep -Fq 'ID_VENDOR_ID}=="05ac"' "$touchpad_rule" &&
+  grep -Fq 'ID_MODEL_ID}=="0340"' "$touchpad_rule" &&
+  grep -Fq 'ID_INPUT_TOUCHPAD}=="1"' "$touchpad_rule" ||
+  fail "T2 touchpad rule is limited to the affected Apple touchpad"
 grep -Fq '99-omarchy-apple-t2-touchpad.rules' "$fix_t2" ||
   fail "fresh T2 setup installs the touchpad integration rule"
+grep -Fq '106b:180[12]' "$touchpad_migration" ||
+  fail "T2 touchpad migration is limited to T2 hardware"
 pass "fresh T2 setup uses t2bce-compatible suspend, fan, and Touch Bar defaults"
 
 test_tmp=$(mktemp -d)
@@ -77,14 +83,6 @@ cat >"$stub_bin/omarchy-pkg-drop" <<'SH'
 #!/bin/bash
 
 printf 'omarchy-pkg-drop' >>"$TEST_LOG"
-printf '\t%s' "$@" >>"$TEST_LOG"
-printf '\n' >>"$TEST_LOG"
-SH
-
-cat >"$stub_bin/omarchy-state" <<'SH'
-#!/bin/bash
-
-printf 'omarchy-state' >>"$TEST_LOG"
 printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
 SH
@@ -226,45 +224,3 @@ grep -Fxq 'limine-mkinitcpio' "$calls" ||
   fail "T2 rerun migration rebuilds the boot image"
 [[ -f $repair_marker ]] || fail "T2 rerun migration records the machine-wide repair"
 pass "T2 rerun migration repairs installs the broken hardware check skipped"
-
-touchpad_rule_target="$test_tmp/99-omarchy-apple-t2-touchpad.rules"
-: >"$calls"
-
-PATH="$stub_bin:$PATH" \
-  TEST_LOG="$calls" \
-  T2_HARDWARE=1 \
-  OMARCHY_PATH="$ROOT" \
-  OMARCHY_T2_TOUCHPAD_RULE="$touchpad_rule_target" \
-  bash -euo pipefail "$touchpad_migration" >/dev/null
-
-cmp -s "$touchpad_rule" "$touchpad_rule_target" ||
-  fail "T2 touchpad migration installs the integration rule"
-grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
-  fail "T2 touchpad migration requests a reboot"
-pass "T2 touchpad migration repairs existing installs"
-
-: >"$calls"
-
-PATH="$stub_bin:$PATH" \
-  TEST_LOG="$calls" \
-  T2_HARDWARE=1 \
-  OMARCHY_PATH="$ROOT" \
-  OMARCHY_T2_TOUCHPAD_RULE="$touchpad_rule_target" \
-  bash -euo pipefail "$touchpad_migration" >/dev/null
-
-[[ ! -s $calls ]] || fail "an already repaired T2 touchpad is left unchanged" "$(cat "$calls")"
-pass "T2 touchpad migration is idempotent"
-
-: >"$calls"
-rm -f "$touchpad_rule_target"
-
-PATH="$stub_bin:$PATH" \
-  TEST_LOG="$calls" \
-  T2_HARDWARE=0 \
-  OMARCHY_PATH="$ROOT" \
-  OMARCHY_T2_TOUCHPAD_RULE="$touchpad_rule_target" \
-  bash -euo pipefail "$touchpad_migration" >/dev/null
-
-[[ ! -e $touchpad_rule_target ]] || fail "non-T2 systems do not receive the touchpad rule"
-[[ ! -s $calls ]] || fail "non-T2 systems skip the touchpad repair" "$(cat "$calls")"
-pass "T2 touchpad migration skips unrelated hardware"

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -7,6 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
 other_packages="$ROOT/install/omarchy-other.packages"
 migration="$ROOT/migrations/1785944594.sh"
+touchpad_rule="$ROOT/default/udev/apple-t2-touchpad.rules"
+touchpad_migration="$ROOT/migrations/1786776556.sh"
 
 grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sleep_default=deep"' "$fix_t2" ||
   fail "T2 setup installs the suspend kernel parameters"
@@ -20,6 +22,10 @@ grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sl
   fail "T2 setup leaves optional Touch Bar customization uninstalled"
 ! grep -qx 'tiny-dfr' "$other_packages" ||
   fail "the ISO no longer caches tiny-dfr"
+grep -Fq 'ID_INPUT_TOUCHPAD_INTEGRATION}="internal"' "$touchpad_rule" ||
+  fail "T2 touchpad rule enables libinput disable-while-typing"
+grep -Fq '99-omarchy-apple-t2-touchpad.rules' "$fix_t2" ||
+  fail "fresh T2 setup installs the touchpad integration rule"
 pass "fresh T2 setup uses t2bce-compatible suspend, fan, and Touch Bar defaults"
 
 test_tmp=$(mktemp -d)
@@ -71,6 +77,14 @@ cat >"$stub_bin/omarchy-pkg-drop" <<'SH'
 #!/bin/bash
 
 printf 'omarchy-pkg-drop' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
 printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
 SH
@@ -212,3 +226,45 @@ grep -Fxq 'limine-mkinitcpio' "$calls" ||
   fail "T2 rerun migration rebuilds the boot image"
 [[ -f $repair_marker ]] || fail "T2 rerun migration records the machine-wide repair"
 pass "T2 rerun migration repairs installs the broken hardware check skipped"
+
+touchpad_rule_target="$test_tmp/99-omarchy-apple-t2-touchpad.rules"
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=1 \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_T2_TOUCHPAD_RULE="$touchpad_rule_target" \
+  bash -euo pipefail "$touchpad_migration" >/dev/null
+
+cmp -s "$touchpad_rule" "$touchpad_rule_target" ||
+  fail "T2 touchpad migration installs the integration rule"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "T2 touchpad migration requests a reboot"
+pass "T2 touchpad migration repairs existing installs"
+
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=1 \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_T2_TOUCHPAD_RULE="$touchpad_rule_target" \
+  bash -euo pipefail "$touchpad_migration" >/dev/null
+
+[[ ! -s $calls ]] || fail "an already repaired T2 touchpad is left unchanged" "$(cat "$calls")"
+pass "T2 touchpad migration is idempotent"
+
+: >"$calls"
+rm -f "$touchpad_rule_target"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=0 \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_T2_TOUCHPAD_RULE="$touchpad_rule_target" \
+  bash -euo pipefail "$touchpad_migration" >/dev/null
+
+[[ ! -e $touchpad_rule_target ]] || fail "non-T2 systems do not receive the touchpad rule"
+[[ ! -s $calls ]] || fail "non-T2 systems skip the touchpad repair" "$(cat "$calls")"
+pass "T2 touchpad migration skips unrelated hardware"


### PR DESCRIPTION
## Summary

- classify the built-in T2 MacBook touchpad as internally integrated
- install the udev rule during fresh T2 hardware setup
- migrate existing T2 installations and request a reboot
- cover installation, migration, idempotence, and non-T2 exclusion in tests

## Why

The `t2bce` driver exposes the built-in keyboard and trackpad through a virtual USB bus. systemd therefore labels the touchpad as externally integrated, so libinput does not pair it with the internal keyboard for disable-while-typing. Palm contact can then scroll or move the pointer while typing.

The rule is limited to Apple `05ac:0340` event devices already identified as touchpads and changes only `ID_INPUT_TOUCHPAD_INTEGRATION` to `internal`.

## Validation

- `udevadm verify default/udev/apple-t2-touchpad.rules`
- `bash -n install/hardware/apple/fix-t2.sh migrations/1786776556.sh test/shell.d/t2-hardware-test.sh`
- `bash test/shell.d/t2-hardware-test.sh`
- `git diff --check`
- verified on a 2019 Intel MacBook Pro with T2 (`linux-t2` 7.1.8): udev changed the built-in touchpad from `external` to `internal`

`./test/shell` reaches and passes the added T2 coverage. Its unrelated environment-dependent checks require the separate `omarchy-pkgs` checkout; the runtime smoke test also conflicts with the active desktop shell.
