### PR TITLE
    Prefer Tailscale machine names in the panel

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -31,7 +31,6 @@ function shortDnsName(name) {
 
 function displayHostName(hostName, dnsName) {
   var host = String(hostName || "")
-  if (host !== "" && host.toLowerCase() !== "localhost") return host
   return shortDnsName(dnsName) || host || "Unknown"
 }
 

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -23,7 +23,8 @@ assertDeepEqual(
 )
 
 assertEqual(tailscale.cleanDnsName('work.tailnet.ts.net.'), 'work.tailnet.ts.net', 'tailscale strips trailing DNS dot')
-assertEqual(tailscale.displayHostName('localhost', 'work.tailnet.ts.net.'), 'work', 'tailscale falls back from localhost to short DNS name')
+assertEqual(tailscale.displayHostName('old-hostname', 'renamed-machine.tailnet.ts.net.'), 'renamed-machine', 'tailscale prefers renamed machine DNS name')
+assertEqual(tailscale.displayHostName('workstation', ''), 'workstation', 'tailscale falls back to OS hostname without a DNS name')
 
 const status = tailscale.parseStatus(JSON.stringify({
   BackendState: 'Running',


### PR DESCRIPTION
  ## Summary

  Prefer Tailscale's editable machine name from `DNSName` over the device's OS `HostName` in the
  Tailscale panel.

  The machine name is user-editable in the Tailscale admin console and is the name displayed by
  the Windows and macOS clients. Fall back to the OS hostname when no DNS name is available.

  ## Testing

  - Added regression coverage for renamed machines
  - Verified fallback behavior when `DNSName` is missing
  - Ran the focused Tailscale shell test
  - Verified locally against real exit nodes with differing `HostName` and `DNSName`