### PR TITLE
Fix Voxtype dictation click error for upgraded accounts

### DIFF
--- a/bin/omarchy-voxtype-open-config
+++ b/bin/omarchy-voxtype-open-config
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Open Voxtype configuration, or the installer if Voxtype isn't installed yet
+
+set -e
+
+if omarchy-cmd-missing voxtype; then
+  omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install
+else
+  omarchy-voxtype-config
+fi

--- a/install/user/first-run/install-voxtype.hook
+++ b/install/user/first-run/install-voxtype.hook
@@ -2,7 +2,9 @@
 
 set -e
 
-if omarchy-done ensure voxtype-install-invitation; then
+# Upgraded accounts reach this hook through a backfill migration, and Voxtype
+# predates the upgrade, so many of them already run it. Invite only who needs it.
+if omarchy-cmd-missing voxtype && omarchy-done ensure voxtype-install-invitation; then
   omarchy-notification-send -u critical -g  "Install Dictation with Voxtype" \
     "Click to install voice dictation for Omarchy." \
     --exec "omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"

--- a/migrations/1786719479.sh
+++ b/migrations/1786719479.sh
@@ -1,0 +1,9 @@
+echo "Invite existing installs to install Voxtype dictation"
+
+# The invitation is installed by first-run, which existing accounts have already
+# marked complete, so they would never receive it — the same gap fixed for the
+# agent-picker invitation in 1786549201.sh.
+#
+# Post-update hooks run later in this same update, so the invitation appears
+# without waiting for another one. The hook decides whether to notify.
+omarchy-hook-install post-update "$OMARCHY_PATH/install/user/first-run/install-voxtype.hook"

--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -33,6 +33,6 @@ BarIndicator {
 
   onPressed: function() {
     if (!root.bar) return
-    root.bar.run("omarchy-cmd-missing voxtype && omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install || omarchy-voxtype-config")
+    root.bar.run("omarchy-voxtype-open-config")
   }
 }

--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -33,6 +33,6 @@ BarIndicator {
 
   onPressed: function() {
     if (!root.bar) return
-    root.bar.run("omarchy-voxtype-config")
+    root.bar.run("omarchy-cmd-missing voxtype && omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install || omarchy-voxtype-config")
   }
 }

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -204,7 +204,7 @@ ShellRoot {
         root.injectBar(dictation)
         dictation.triggerPress(Qt.LeftButton)
         dictation.triggerPress(Qt.RightButton)
-        root.assertTrue(root.commandCount("omarchy-voxtype-config") === 2, "Dictation clicks run config command")
+        root.assertTrue(root.commandCount("omarchy-cmd-missing voxtype && omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install || omarchy-voxtype-config") === 2, "Dictation clicks check voxtype install state before opening config")
         root.assertTrue(root.commandCount("omarchy-voxtype-model") === 0, "Dictation clicks do not run model command")
       }
 

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -204,7 +204,7 @@ ShellRoot {
         root.injectBar(dictation)
         dictation.triggerPress(Qt.LeftButton)
         dictation.triggerPress(Qt.RightButton)
-        root.assertTrue(root.commandCount("omarchy-cmd-missing voxtype && omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install || omarchy-voxtype-config") === 2, "Dictation clicks check voxtype install state before opening config")
+        root.assertTrue(root.commandCount("omarchy-voxtype-open-config") === 2, "Dictation clicks open config, checking voxtype install state first")
         root.assertTrue(root.commandCount("omarchy-voxtype-model") === 0, "Dictation clicks do not run model command")
       }
 

--- a/test/shell.d/voxtype-invitation-test.sh
+++ b/test/shell.d/voxtype-invitation-test.sh
@@ -33,12 +33,30 @@ echo "systemd-run:$*" >>"$TEST_LOG"
 EOF
 chmod +x "$test_bin/systemd-run"
 
+# Stub the presence check rather than the PATH: the hook needs the real
+# coreutils, so a voxtype on the host (e.g. this dev machine) would otherwise
+# decide the test.
+cat >"$test_bin/omarchy-cmd-missing" <<'EOF'
+#!/bin/bash
+[[ -n $TEST_VOXTYPE_MISSING ]]
+EOF
+chmod +x "$test_bin/omarchy-cmd-missing"
+
 run_invitation_hook() {
+  local voxtype_missing=$1
+
   cp "$ROOT/install/user/first-run/install-voxtype.hook" "$hook_path"
-  HOME="$test_home" PATH="$test_bin:$ROOT/bin:$PATH" TEST_LOG="$log_file" bash "$hook_path"
+  HOME="$test_home" PATH="$test_bin:$ROOT/bin:$PATH" TEST_LOG="$log_file" \
+    TEST_VOXTYPE_MISSING="$voxtype_missing" bash "$hook_path"
 }
 
-run_invitation_hook
+run_invitation_hook ""
+
+[[ -s $log_file ]] && fail "Voxtype invitation stays quiet when voxtype is installed" "$(cat "$log_file")"
+[[ -f $test_home/.local/state/omarchy/done/voxtype-install-invitation ]] &&
+  fail "Voxtype invitation keeps its one-time marker unspent while voxtype is installed"
+
+run_invitation_hook 1
 
 [[ -f $test_home/.local/state/omarchy/done/voxtype-install-invitation ]] || fail "Voxtype invitation records completion"
 [[ -f $hook_path ]] || fail "Voxtype invitation keeps its hook installed"
@@ -47,7 +65,8 @@ grep -qx 'exec:omarchy-launch-floating-terminal-with-presentation omarchy-voxtyp
   fail "Voxtype invitation attaches the installer to the notification"
 grep -q '^systemd-run:' "$log_file" && fail "Voxtype invitation needs no unit to hold an unanswered toast"
 
-HOME="$test_home" PATH="$test_bin:$ROOT/bin:$PATH" TEST_LOG="$log_file" bash "$hook_path"
+HOME="$test_home" PATH="$test_bin:$ROOT/bin:$PATH" TEST_LOG="$log_file" \
+  TEST_VOXTYPE_MISSING=1 bash "$hook_path"
 
 [[ -f $hook_path ]] || fail "completed Voxtype invitation keeps its hook installed"
 [[ $(grep -c '^notification$' "$log_file") -eq 1 ]] || fail "completed Voxtype invitation hook does not notify again"

--- a/test/shell.d/voxtype-open-config-test.sh
+++ b/test/shell.d/voxtype-open-config-test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_bin=$(mktemp -d)
+log_file=$(mktemp)
+
+cleanup() {
+  rm -rf "$test_bin"
+  rm -f "$log_file"
+}
+trap cleanup EXIT
+
+cat >"$test_bin/omarchy-launch-floating-terminal-with-presentation" <<'EOF'
+#!/bin/bash
+echo "install:$*" >>"$TEST_LOG"
+EOF
+chmod +x "$test_bin/omarchy-launch-floating-terminal-with-presentation"
+
+cat >"$test_bin/omarchy-voxtype-config" <<'EOF'
+#!/bin/bash
+echo "config" >>"$TEST_LOG"
+EOF
+chmod +x "$test_bin/omarchy-voxtype-config"
+
+run_open_config() {
+  local path=$1
+  PATH="$path" TEST_LOG="$log_file" /bin/bash "$ROOT/bin/omarchy-voxtype-open-config"
+}
+
+# voxtype missing: use a PATH scoped to the stubs so a real voxtype
+# elsewhere on the host (e.g. this dev machine) can't leak in.
+run_open_config "$test_bin:$ROOT/bin"
+[[ $(cat "$log_file") == "install:omarchy-voxtype-install" ]] ||
+  fail "opens the installer when voxtype is missing" "$(cat "$log_file")"
+
+: >"$log_file"
+
+cat >"$test_bin/voxtype" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$test_bin/voxtype"
+
+# voxtype present: only config runs, never the installer
+run_open_config "$test_bin:$ROOT/bin"
+[[ $(cat "$log_file") == "config" ]] ||
+  fail "opens config when voxtype is installed" "$(cat "$log_file")"
+
+pass "Voxtype open-config dispatches to the installer or config based on install state, never both"


### PR DESCRIPTION
## Summary

Found when trying to dictate via the Quickshell bar button, on a laptop
upgraded from an earlier Omarchy release to Quattro (not a fresh install).
Clicking the bar's dictation indicator threw a raw
`bash: line 1: voxtype: command not found` instead of guiding the user to
install it.

Two related, separable problems:

1. **`Dictation.qml`'s click handler had no install-state guard.** It
   unconditionally ran `voxtype configure` regardless of whether the
   `voxtype-bin` package was present, unlike the Hyprland keybindings for the
   same feature, which already gate on `o.cmd_present("voxtype")`.

2. **An upgraded device never receives the Voxtype install invitation at
   all.** The one-time "Install Dictation with Voxtype" notification is
   registered by `omarchy-provision-first-run`
   (`install/user/first-run/install-voxtype.hook` → `post-update.d`), but
   that whole sequence is gated on the `first-run-user` completion marker.
   Quattro's upgrade path marks that marker complete on upgrade so the device
   doesn't get re-served unrelated first-login setup (welcome toast, GNOME
   theme, etc.) — but the side effect is that an upgraded device also never
   gets registered for the Voxtype invitation, since it rides on the same
   first-run sequence. This is the same class of bug already fixed once for
   the agent-picker invitation in `1786549201.sh`; this PR applies the
   identical backfill-migration pattern for Voxtype.

## Changes

- `bin/omarchy-voxtype-open-config`: new command the Dictation click hands
  off to — checks `omarchy-cmd-missing voxtype` and routes to
  `omarchy-voxtype-install` (via the same floating-terminal presentation the
  installer already uses) when missing, otherwise `omarchy-voxtype-config`.
- `shell/plugins/bar/indicators/Dictation.qml`: click now calls the single
  `omarchy-voxtype-open-config` entrypoint instead of unconditionally opening
  config.
- `migrations/1786719479.sh`: backfill-install the `install-voxtype.hook`
  post-update hook for devices that already completed first-run before
  Voxtype existed, mirroring `1786549201.sh`.
- `test/shell.d/fixtures/indicator-contract/shell.qml`: update the Dictation
  click assertion for the new command name.
- `test/shell.d/voxtype-open-config-test.sh`: new focused test covering the
  install/config branch logic.

## Test plan

- [x] `./test/cli` passes
- [x] `./test/shell` — `indicator-contract-test.sh` and the new
      `voxtype-open-config-test.sh` pass; the 3 other failures in the full
      run (`config-test.sh`, `snapper-test.sh`,
      `unowned-system-paths-test.sh`) are pre-existing on a clean
      `upstream/quattro` checkout, unrelated to this change
- [x] Verified live on the upgraded laptop: cloned `omarchy.indicators`
      locally, applied the same click-handler fix, confirmed the install
      prompt opens correctly instead of erroring, then installed Voxtype and
      confirmed dictation works end-to-end (this PR description was partly
      dictated with it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
