### PR TITLE
Fix seven issues reported after 4.0.0

### DIFF
--- a/bin/omarchy-menu-plugin
+++ b/bin/omarchy-menu-plugin
@@ -38,7 +38,7 @@ id=$(cut -f2 <<<"$selection")
 
 if [[ $1 == "clone" ]]; then
   omarchy-launch-floating-terminal-with-presentation \
-    "omarchy-plugin-clone --edit $(printf '%q' "$id")"
+    "omarchy-plugin-clone $(printf '%q' "$id") --edit"
 elif [[ $1 == "remove" ]]; then
   omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove $(printf '%q' "$id")"
 else

--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -22,7 +22,7 @@ rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g "$package" || exit 1
+mise use -g --quiet "$package" || exit 1
 exec mise x "$package" -- "$bin" "\$@"
 EOF
 

--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -297,20 +297,30 @@ launch_windows() {
       omarchy-notification-send -u critical "Windows VM" "Failed to start Windows VM"
       exit 1
     fi
-
-    echo "Waiting for Windows VM to start..."
-    WAIT_COUNT=0
-    until docker logs omarchy-windows 2>&1 | grep -qi "windows started successfully"; do
-      sleep 2
-      WAIT_COUNT=$((WAIT_COUNT + 1))
-      if (( WAIT_COUNT > 60 )); then  # 2 minutes timeout
-        echo ""
-        echo "❌ Timeout: Windows VM failed to start within 2 minutes"
-        echo "   Check logs: docker logs omarchy-windows"
-        exit 1
-      fi
-    done
   fi
+
+  # The container's log survives stop/start, so an unscoped scan matches the
+  # previous boot's line and returns immediately. Re-read the start time on every
+  # poll so a restart mid-wait moves the window off the boot we were watching.
+  windows_started() {
+    local started_at
+    started_at=$(docker inspect --format='{{.State.StartedAt}}' omarchy-windows 2>/dev/null) || return 1
+    [[ -n $started_at ]] || return 1
+    docker logs --since "$started_at" omarchy-windows 2>&1 | grep -qi "windows started successfully"
+  }
+
+  echo "Waiting for Windows VM to start..."
+  WAIT_COUNT=0
+  until windows_started; do
+    sleep 2
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    if (( WAIT_COUNT > 60 )); then # 2 minutes timeout
+      echo ""
+      echo "❌ Timeout: Windows VM failed to start within 2 minutes"
+      echo "   Check logs: docker logs omarchy-windows"
+      exit 1
+    fi
+  done
 
   # Build the connection info
   if [[ $KEEP_ALIVE = "true" ]]; then

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -18,9 +18,18 @@ local function file_exists(path)
   return false
 end
 
+-- Hyprland reaps its own children, so os.execute() can't retrieve an exit status
+-- from inside the compositor. Read a marker off stdout instead.
 function o.shell_succeeds(command)
-  local ok, _, code = os.execute(command .. " >/dev/null 2>&1")
-  return ok == true or ok == 0 or code == 0
+  local pipe = io.popen(command .. " >/dev/null 2>&1 && echo OK")
+  if not pipe then
+    return false
+  end
+
+  local output = pipe:read("*a") or ""
+  pipe:close()
+
+  return output:find("OK", 1, true) ~= nil
 end
 
 function o.cmd_present(command)

--- a/migrations/1785846769.sh
+++ b/migrations/1785846769.sh
@@ -4,6 +4,6 @@ if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
   omarchy-mise-install github:can1357/oh-my-pi omp
   omarchy-mise-install npm:@xai-official/grok grok
   omarchy-mise-install crush
-elif [[ -f $HOME/.local/bin/omp ]] && grep -Fq 'mise use -g "oh-my-pi"' "$HOME/.local/bin/omp"; then
+elif [[ -f $HOME/.local/bin/omp ]] && grep -Eq 'mise use -g .*"oh-my-pi"' "$HOME/.local/bin/omp"; then
   rm -f "$HOME/.local/bin/omp"
 fi

--- a/migrations/1786782461.sh
+++ b/migrations/1786782461.sh
@@ -1,0 +1,18 @@
+echo "Remove the literal \\n[text-bindings] line an earlier migration wrote into foot.ini"
+
+# A 3.8.3 migration appended the section header with `sed -i '$a\\\n[text-bindings]'`,
+# one backslash too many, so GNU sed wrote the literal three-character line
+# "\n[text-bindings]" instead of a blank line plus a header. foot rejects it with
+# "syntax error: key/value pair has no value" and stops reading the rest of the file.
+#
+# The later text-binding migration looks for the header with `grep -qxF`, which the
+# literal line doesn't match, so it appends a second real [text-bindings] section and
+# leaves the broken line in place. Removing the line is what actually repairs the
+# config; the duplicate section that migration added is valid and harmless.
+
+foot_config="$HOME/.config/foot/foot.ini"
+
+[[ -f $foot_config ]] || exit 0
+grep -qxF '\n[text-bindings]' "$foot_config" || exit 0
+
+sed -i '/^\\n\[text-bindings\]$/d' "$foot_config"

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1417,6 +1417,9 @@ Item {
     }
 
     onPressAndHold: function(mouse) {
+      // A widget above us propagates its composed press-and-hold down here without
+      // ever handing over the grab, so we'd get no release or cancel to end the move.
+      if (!gestureArea.pressed) return
       startDrag(mouse.x, mouse.y)
     }
 

--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -53,7 +53,9 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    // toLocaleString, not Qt.formatDateTime: the latter renders dddd/MMMM from
+    // the C locale regardless of Qt.locale(), so day and month names stay English.
+    return date.toLocaleString(Qt.locale(), activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -105,7 +105,7 @@ assert_lazy_stub() {
   "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
-  [[ ${mise_calls[0]} == "use -g $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
     fail "$command lazy stub preserves its mise package"
 }
 

--- a/test/shell.d/menu-plugin-test.sh
+++ b/test/shell.d/menu-plugin-test.sh
@@ -111,7 +111,7 @@ pick clone "$(printf 'Clock\tomarchy.clock')"
 [[ $ROWS == *"Clock"* && $ROWS != *"Weather"* ]] ||
   fail "clone picker offers only built-in plugins" "$ROWS"
 pass "clone picker offers built-in plugins"
-[[ $CALLS == *"terminal: omarchy-plugin-clone --edit omarchy.clock"* ]] ||
+[[ $CALLS == *"terminal: omarchy-plugin-clone omarchy.clock --edit"* ]] ||
   fail "clone picker delegates cloning and editing to the clone command" "$CALLS"
 pass "clone picker clones and opens the personal plugin"
 


### PR DESCRIPTION
Triage of the 33 issues filed since the 4.0.0 release. These are the seven that were confirmed against the code, have a contained fix, and could be verified here. Each commit closes one issue.

**#6903 — foot.ini syntax error on startup.** A 3.8.3 migration appended the section header with `sed -i '$a\\\n[text-bindings]'`, one backslash too many, so sed wrote the literal characters `\n[text-bindings]` as a line. foot rejects it and stops reading the rest of the file. The later text-binding migration looks for the header with `grep -qxF`, misses the broken line, and appends a *second* section, so the config stays broken across the Quattro upgrade. New migration deletes the literal line; verified `foot --check-config` passes afterward, and that it no-ops on healthy and missing configs.

**#6914 — `o.shell_succeeds()` always false inside Hyprland.** Hyprland reaps its own children, so `os.execute()` gets ECHILD from waitpid and never sees an exit status. Confirmed live: `o.shell_succeeds("true")` returned `false` on this machine. The only callers are `hypr/nvidia.lua`, so `NVD_BACKEND`, `LIBVA_DRIVER_NAME` and `__GLX_VENDOR_LIBRARY_NAME` were never set on NVIDIA hardware. Now reads a marker off stdout; verified inside the running compositor.

**#6908 — mise wrappers pollute stdout.** `mise use -g` announces the resolved tool on stdout, so every wrapped command prepended a `tools:` line to its own output, corrupting anything speaking a protocol over stdout such as `codex app-server`. This one bit repeatedly during the triage itself — several `grep` calls in this work came back with a `tools:` line stuck to the front. Fixed with `--quiet`, which keeps errors on stderr and preserves the exit status.

**#6934 — bar clock always English.** `Qt.formatDateTime` renders `dddd`/`MMMM` from the C locale whatever `Qt.locale()` says, so the clock stayed English while its own calendar popup, which already goes through `Qt.locale()`, did not. Checked all twelve shipped presets: byte-identical under the C locale, correctly localized under `de_DE`.

**#6913 — Clone Plugin fails with "unknown clone option".** The menu passed `--edit` ahead of the plugin id, but `omarchy-plugin-clone` only accepts the id as the first argument, so it fell through to the unknown-option branch and every clone from Setup > Plugins failed. Argument order swapped.

**#6881 — bar stuck in move mode.** Bar widgets propagate their composed press-and-hold down to the center gesture area without handing over the grab, so the gesture area started a bar move and then got neither a release nor a cancel to end it — the move ghost stayed on screen for the rest of the session. Confirmed the two paths are distinguishable under Qt 6.11: the propagated event arrives with `pressed=false` and no release, a genuine hold with `pressed=true`. Guarded on that. Note the reported ~200ms trigger is actually ~800ms, since the timer runs on the grabbing widget, not the gesture area.

**#6882 — Windows VM connects before the guest is ready.** The readiness scan read the container's whole log, which survives stop/start, so it matched the previous boot's line and launched `xfreerdp3` immediately. The wait also sat inside the not-running branch, skipping it entirely for a container that was already up. The scan is now scoped to the container's current start time, re-read on each poll so a restart mid-wait cannot match the boot we were watching.

Reviewed with codex at xhigh; the one finding it raised that held up (the start time being sampled once) is folded into the last commit.

— 🤖 Claude, posting on behalf of @dhh