### PR TITLE
Repair foot.ini configs holding a literal \n[text-bindings] line

### DIFF
--- a/migrations/1786782461.sh
+++ b/migrations/1786782461.sh
@@ -1,0 +1,18 @@
+echo "Remove the literal \\n[text-bindings] line an earlier migration wrote into foot.ini"
+
+# A 3.8.3 migration appended the section header with `sed -i '$a\\\n[text-bindings]'`,
+# one backslash too many, so GNU sed wrote a backslash and an "n" as two ordinary
+# characters ahead of the section name, leaving the single line \n[text-bindings]
+# where a blank line and a [text-bindings] header belong. foot rejects it with
+# "syntax error: key/value pair has no value" and stops reading the rest of the file.
+#
+# The later text-binding migration looks for the header with `grep -qxF`, which the
+# literal line doesn't match, so it appends a second real [text-bindings] section and
+# leaves the broken line in place. Removing the line is what actually repairs the
+# config; the duplicate section that migration added is valid and harmless.
+
+foot_config="$HOME/.config/foot/foot.ini"
+
+if [[ -f $foot_config ]] && grep -qxF '\n[text-bindings]' "$foot_config"; then
+  sed -i '/^\\n\[text-bindings\]$/d' "$foot_config"
+fi


### PR DESCRIPTION
A 3.8.3 migration appended the section header with `sed -i '$a\\\n[text-bindings]'` — one backslash too many — so GNU sed wrote the literal characters `\n[text-bindings]` as a line rather than a newline plus the header. foot rejects it and stops reading the rest of the file:

```
err: config.c:3268: foot.ini:6: [key-bindings].\n[text-bindings]: syntax error: key/value pair has no value
```

Quattro makes it worse rather than repairing it. The later text-binding migration looks for the header with `grep -qxF '[text-bindings]'`, which the literal line does not match, so it falls through and appends a *second*, correct section while leaving the broken line in place. Every affected user stays broken across the upgrade.

This migration deletes the literal line. The duplicate section the other migration added is valid and harmless, so it is left alone.

Reproduced the original 3.8.3 breakage byte-for-byte, confirmed Quattro's migration adds the duplicate without fixing it, and confirmed `foot --check-config` passes after the repair. The `grep -qxF` guard makes it a no-op on healthy configs, and it is idempotent and inert when no foot.ini exists.

Closes #6903

— 🤖 Claude, posting on behalf of @dhh