### PR TITLE
Fix o.shell_succeeds() always returning false inside Hyprland

### DIFF
--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -18,9 +18,20 @@ local function file_exists(path)
   return false
 end
 
+-- Hyprland reaps its own children, so os.execute() can't retrieve an exit status
+-- from inside the compositor. Read a marker off stdout instead.
 function o.shell_succeeds(command)
-  local ok, _, code = os.execute(command .. " >/dev/null 2>&1")
-  return ok == true or ok == 0 or code == 0
+  -- Subshell, so the redirection covers every command rather than binding to
+  -- the last one and letting an earlier one write its own OK into the pipe.
+  local pipe = io.popen("( " .. command .. " ) >/dev/null 2>&1 && echo OK")
+  if not pipe then
+    return false
+  end
+
+  local output = pipe:read("*a") or ""
+  pipe:close()
+
+  return output:find("OK", 1, true) ~= nil
 end
 
 function o.cmd_present(command)


### PR DESCRIPTION
Hyprland reaps its own children, so `os.execute()` gets ECHILD from `waitpid` and never sees an exit status. Every call reported failure. Confirmed against the running compositor:

```
$ hyprctl repl 'return tostring(o.shell_succeeds("true"))'
false
```

The only callers are `default/hypr/nvidia.lua`, so `NVD_BACKEND`, `LIBVA_DRIVER_NAME` and `__GLX_VENDOR_LIBRARY_NAME` were never set on NVIDIA hardware.

Reads a marker off stdout instead, which does not depend on reaping the child. `io.popen`'s own close status is unreliable for the same reason, so it is deliberately not checked.

Verified inside the running compositor (`true` → true, `false` → false) and standalone, where a command that writes its own output to stdout still reports correctly.

Note this cannot be caught by a unit test: `test/shell.d/hyprland-default-config-test.sh` runs under standalone `lua`, where `os.execute` behaves normally.

Closes #6914

— 🤖 Claude, posting on behalf of @dhh