### PR TITLE
Keep mise wrappers from writing to stdout

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -22,7 +22,7 @@ rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g "$package" || exit 1
+mise use -g --quiet "$package" || exit 1
 exec mise x "$package" -- "$bin" "\$@"
 EOF
 

--- a/migrations/1785846769.sh
+++ b/migrations/1785846769.sh
@@ -4,6 +4,6 @@ if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
   omarchy-mise-install github:can1357/oh-my-pi omp
   omarchy-mise-install npm:@xai-official/grok grok
   omarchy-mise-install crush
-elif [[ -f $HOME/.local/bin/omp ]] && grep -Fq 'mise use -g "oh-my-pi"' "$HOME/.local/bin/omp"; then
+elif [[ -f $HOME/.local/bin/omp ]] && grep -Eq 'mise use -g .*"oh-my-pi"' "$HOME/.local/bin/omp"; then
   rm -f "$HOME/.local/bin/omp"
 fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -105,7 +105,7 @@ assert_lazy_stub() {
   "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
-  [[ ${mise_calls[0]} == "use -g $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
     fail "$command lazy stub preserves its mise package"
 }
 
@@ -138,6 +138,24 @@ source "$ROOT/migrations/1785617047.sh" >/dev/null
 source "$ROOT/migrations/1785846769.sh" >/dev/null
 [[ ! -s $stub_log ]] || fail "agent migrations respect the preinstall opt-out"
 [[ ! -e $test_home/.local/bin/omp ]] || fail "agent migration removes the obsolete Oh My Pi wrapper after opt-out"
+
+# The matcher has to catch a bare oh-my-pi wrapper from either generation of the
+# installer, and leave a wrapper built on the fully qualified package alone.
+for obsolete_form in 'mise use -g "oh-my-pi"' 'mise use -g --quiet "oh-my-pi"'; do
+  printf '#!/bin/bash\n%s || exit 1\n' "$obsolete_form" >"$test_home/.local/bin/omp"
+  chmod +x "$test_home/.local/bin/omp"
+  source "$ROOT/migrations/1785846769.sh" >/dev/null
+  [[ ! -e $test_home/.local/bin/omp ]] ||
+    fail "agent migration removes a wrapper built on [$obsolete_form]"
+done
+
+printf '#!/bin/bash\nmise use -g --quiet "%s" || exit 1\n' "$omp_package" >"$test_home/.local/bin/omp"
+chmod +x "$test_home/.local/bin/omp"
+source "$ROOT/migrations/1785846769.sh" >/dev/null
+[[ -e $test_home/.local/bin/omp ]] ||
+  fail "agent migration keeps a wrapper built on $omp_package"
+rm -f "$test_home/.local/bin/omp"
+
 rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"
 


### PR DESCRIPTION
`mise use -g` announces the resolved tool on stdout, not stderr, so every mise-wrapped command prepended a line like

```
mise ~/.config/mise/config.toml tools: claude@2.1.232
```

to its own output. That corrupts anything speaking a protocol over stdout, such as `codex app-server`.

This one is easy to confirm from the outside: it bit repeatedly while triaging the post-4.0 issues, with several `grep` calls in unrelated work coming back with a `tools:` line stuck to the front of their output.

`--quiet` suppresses the announcement, keeps errors on stderr, and preserves the exit status, so the `|| exit 1` guard still works.

The obsolete-wrapper check in `migrations/1785846769.sh` matched the generated command verbatim, so it is loosened to match the package rather than the flags. Confirmed it still matches both the old and new bare-package wrapper forms and still leaves the `github:can1357/oh-my-pi` wrapper alone.

Existing wrappers in `~/.local/bin` are stale copies and keep the old line until regenerated.

Closes #6908

— 🤖 Claude, posting on behalf of @dhh