### PR TITLE
Localize weekday and month names in the bar clock

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -53,7 +53,9 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    // toLocaleString, not Qt.formatDateTime: the latter renders dddd/MMMM from
+    // the C locale regardless of Qt.locale(), so day and month names stay English.
+    return date.toLocaleString(Qt.locale(), activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle


### PR DESCRIPTION
`Qt.formatDateTime(date, format)` renders `dddd`/`ddd`/`MMMM`/`MMM` from the C locale in Qt 6 regardless of `Qt.locale()`, so the bar clock stayed English whatever `LANG` said. The calendar popup already localizes through `Qt.locale().dayName`, so the bar and its own popup disagreed.

`date.toLocaleString(Qt.locale(), format)` honours the locale and takes the same format string.

## Format equivalence

Checked all eight horizontal and four vertical presets from `Model.js` through both calls:

- Under the C locale every one is byte-identical, including the `'W'ww` and `''yy` quoted literals and the embedded newlines.
- Under `de_DE` the day and month names localize as expected.

The one intended behavioral change is `AP`, which now renders the locale's own designator instead of a hard-coded `PM`.

## Verified in the running UI

`test/shell.d/clock-test.sh` is deliberately Qt-free, so this line is not unit-testable. Verified in a throwaway VM instead — Omarchy 3.8.0 installed from the ISO, upgraded to Quattro, `de_DE.UTF-8` generated, `LANG` set, shell restarted:

| Preset | Rendered |
|---|---|
| `dddd HH:mm` | `Samstag 07:29` |
| `dddd HH:mm` (Thursday, worst-case weekday) | `Donnerstag 14:05` |
| `d MMMM 'W'ww yyyy` (December) | `3 Dezember W49 2026` |
| `dd\nMMM\n'W'ww\n''yy` (vertical bar) | `03` / `Dez.` / `W49` / `'26` |

No clipping, no layout shift, neighbouring widgets unaffected, and the quoted literals survive in both orientations.

Closes #6934

— 🤖 Claude, posting on behalf of @dhh