### PR TITLE
Fix Clone Plugin failing with "unknown clone option"

### DIFF
--- a/bin/omarchy-menu-plugin
+++ b/bin/omarchy-menu-plugin
@@ -38,7 +38,7 @@ id=$(cut -f2 <<<"$selection")
 
 if [[ $1 == "clone" ]]; then
   omarchy-launch-floating-terminal-with-presentation \
-    "omarchy-plugin-clone --edit $(printf '%q' "$id")"
+    "omarchy-plugin-clone $(printf '%q' "$id") --edit"
 elif [[ $1 == "remove" ]]; then
   omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove $(printf '%q' "$id")"
 else

--- a/test/shell.d/menu-plugin-test.sh
+++ b/test/shell.d/menu-plugin-test.sh
@@ -111,7 +111,7 @@ pick clone "$(printf 'Clock\tomarchy.clock')"
 [[ $ROWS == *"Clock"* && $ROWS != *"Weather"* ]] ||
   fail "clone picker offers only built-in plugins" "$ROWS"
 pass "clone picker offers built-in plugins"
-[[ $CALLS == *"terminal: omarchy-plugin-clone --edit omarchy.clock"* ]] ||
+[[ $CALLS == *"terminal: omarchy-plugin-clone omarchy.clock --edit"* ]] ||
   fail "clone picker delegates cloning and editing to the clone command" "$CALLS"
 pass "clone picker clones and opens the personal plugin"
 


### PR DESCRIPTION
`omarchy-menu-plugin` built the command flag-first as `omarchy-plugin-clone --edit <id>`, but `omarchy-plugin-clone` only accepts the source id as `$1` and only when it does not start with `--`. The flag was consumed by the option loop and the id fell through to the catch-all:

```
$ omarchy-plugin-clone --edit omarchy.weather
omarchy-plugin-clone: unknown clone option: omarchy.weather
```

So every clone from Setup > Plugins failed. Swapping the order to `<id> --edit` matches what the parser accepts; verified the old order fails and the new order proceeds to clone.

`test/shell.d/menu-plugin-test.sh` asserted the old string and is updated to match.

Closes #6913

— 🤖 Claude, posting on behalf of @dhh