### PR TITLE
Stop the bar sticking in move mode after a press-and-hold on a widget

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1417,6 +1417,9 @@ Item {
     }
 
     onPressAndHold: function(mouse) {
+      // A widget above us propagates its composed press-and-hold down here without
+      // ever handing over the grab, so we'd get no release or cancel to end the move.
+      if (!gestureArea.pressed) return
       startDrag(mouse.x, mouse.y)
     }
 

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -14,6 +14,17 @@ if rg -q 'barMoveSettling|barMoveSettleTimer' "$ROOT/shell/plugins/bar/Bar.qml";
 fi
 pass "bar move outline has no post-release settling state"
 
+# A widget above the gesture area propagates its composed press-and-hold down
+# without handing over the grab, so the resulting move gets neither a release
+# nor a cancel and the ghost stays up for the session. Only the grabbing area
+# reports pressed, which is what separates the two, so the guard has to stay
+# ahead of the drag.
+if ! perl -0ne 'exit(/onPressAndHold:\s*function[^{]*\{[^}]*?\bpressed\b[^}]*?\bstartDrag\b/s ? 0 : 1)' \
+  "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar move ignores a press-and-hold the gesture area does not hold the press for"
+fi
+pass "bar move ignores a press-and-hold propagated from a widget above"
+
 run_node_test <<'JS'
 const fs = require('fs')
 const bar = requireFromRoot('shell/plugins/bar/BarModel.js')


### PR DESCRIPTION
`modulePointer` sets `propagateComposedEvents: true` and has no `onPressAndHold`, so Qt propagates the composed event down to `CenterGestureArea` without ever handing over the grab. The gesture area starts a bar move, then receives neither `onReleased` nor `onCanceled` — the only two callers of `finishBarMove()`/`clearBarMove()` — so `barMoveActive` is never cleared and the move ghost stays on screen for the rest of the session.

The two paths are cleanly distinguishable, confirmed with a two-MouseArea reproduction under Qt 6.11:

```
propagated from a widget above: ["inner.pressed", "outer.pressAndHold pressed=false", "inner.released"]
genuine hold on the gesture area: ["outer.pressed", "outer.pressAndHold pressed=true", "outer.released"]
```

The leaked event arrives with `pressed=false` and is followed by no release or cancel on that area, so guarding on `gestureArea.pressed` rejects exactly the bad case and leaves a genuine press-and-hold untouched. Guarding here is better than clearing the state from `modulePointer.onReleased`, which would start the spurious move and then paper over it.

One correction to the report: the trigger is ~800ms, not 200ms. `pressAndHoldInterval: 200` belongs to `CenterGestureArea`, but the timer runs on the grabbing area, which uses Qt's default. Measured 300ms and 600ms holds do not leak; 900ms and 1200ms do.

Closes #6881

— 🤖 Claude, posting on behalf of @dhh