### PR TITLE
Wait for the Windows VM to be ready before connecting

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -297,20 +297,30 @@ launch_windows() {
       omarchy-notification-send -u critical "Windows VM" "Failed to start Windows VM"
       exit 1
     fi
-
-    echo "Waiting for Windows VM to start..."
-    WAIT_COUNT=0
-    until docker logs omarchy-windows 2>&1 | grep -qi "windows started successfully"; do
-      sleep 2
-      WAIT_COUNT=$((WAIT_COUNT + 1))
-      if (( WAIT_COUNT > 60 )); then  # 2 minutes timeout
-        echo ""
-        echo "❌ Timeout: Windows VM failed to start within 2 minutes"
-        echo "   Check logs: docker logs omarchy-windows"
-        exit 1
-      fi
-    done
   fi
+
+  # The container's log survives stop/start, so an unscoped scan matches the
+  # previous boot's line and returns immediately. Re-read the start time on every
+  # poll so a restart mid-wait moves the window off the boot we were watching.
+  windows_started() {
+    local started_at
+    started_at=$(docker inspect --format='{{.State.StartedAt}}' omarchy-windows 2>/dev/null) || return 1
+    [[ -n $started_at ]] || return 1
+    docker logs --since "$started_at" omarchy-windows 2>&1 | grep -qi "windows started successfully"
+  }
+
+  echo "Waiting for Windows VM to start..."
+  WAIT_COUNT=0
+  until windows_started; do
+    sleep 2
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    if (( WAIT_COUNT > 60 )); then # 2 minutes timeout
+      echo ""
+      echo "❌ Timeout: Windows VM failed to start within 2 minutes"
+      echo "   Check logs: docker logs omarchy-windows"
+      exit 1
+    fi
+  done
 
   # Build the connection info
   if [[ $KEEP_ALIVE = "true" ]]; then


### PR DESCRIPTION
Two separate reasons `xfreerdp3` could fire before the guest was up:

1. The readiness scan ran `docker logs` unscoped. A container's log survives `docker stop`/`start`, so it matched the *previous* boot's "windows started successfully" line and returned on the first iteration.
2. The whole wait sat inside the `if [[ $CONTAINER_STATUS != "running" ]]` branch, so a container that was already up skipped readiness entirely.

The scan is now scoped to the container's current `.State.StartedAt` and the wait is hoisted out of the branch so it always runs. The start time is re-read on every poll rather than sampled once, so a restart mid-wait moves the window off the boot we were watching instead of matching its stale success line.

`Terminal=false` on the generated desktop entry is why this surfaced as a silent failure rather than a visible freerdp error.

The Kerberos hang raised in the follow-up comment is a separate, additive fix and is not included here.

Closes #6882

— 🤖 Claude, posting on behalf of @dhh