### PR TITLE
Fall back to the generated VS Code theme when none is named

### DIFF
--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -119,8 +119,12 @@ set_theme() {
       ! "$editor_cmd" --list-extensions 2>/dev/null | grep -Fxq "$extension"; then
       "$editor_cmd" --install-extension "$extension" >/dev/null 2>&1
     fi
-  elif [[ -f "$GENERATED_THEME" ]]; then
-    # VS Code only discovers local color themes through an extension package.
+  fi
+
+  if [[ -z "$theme_name" && -f "$GENERATED_THEME" ]]; then
+    # No preferred 3rd-party theme named (or the descriptor didn't resolve
+    # one): fall back to the generated theme. VS Code only discovers local
+    # color themes through an extension package.
     install_generated_extension "$ext_base/$GENERATED_EXTENSION_NAME"
     theme_name="Omarchy"
   fi

--- a/test/shell.d/vscode-theme-test.sh
+++ b/test/shell.d/vscode-theme-test.sh
@@ -40,10 +40,10 @@ grep -Fxq '/usr/bin/cursor' "$TEST_HOME/editor-probes.log" || fail "VS Code them
 [[ ! -e $TEST_HOME/.config/Cursor/User/settings.json ]] || fail "VS Code theme sync skips Cursor when the packaged executable is unavailable"
 pass "VS Code theme sync selects the packaged Cursor executable"
 
-# A theme descriptor always exists once a theme has been applied, even when it
-# names no preferred 3rd-party theme. The generated local theme is the only
-# fallback VS Code-family editors can discover, so an empty/absent name must
-# not be mistaken for "descriptor present, nothing further to do".
+# A theme can ship a descriptor that names no usable 3rd-party theme. The
+# generated local theme is the only fallback VS Code-family editors can
+# discover, so an empty name must not be mistaken for "descriptor present,
+# nothing further to do".
 GENERATED_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME" "$GENERATED_HOME"' EXIT
 

--- a/test/shell.d/vscode-theme-test.sh
+++ b/test/shell.d/vscode-theme-test.sh
@@ -39,3 +39,44 @@ grep -Fxq '/usr/bin/cursor' "$TEST_HOME/editor-probes.log" || fail "VS Code them
 [[ ! -e $TEST_HOME/cursor-shim-called ]] || fail "VS Code theme sync ignores a PATH-provided Cursor Agent shim"
 [[ ! -e $TEST_HOME/.config/Cursor/User/settings.json ]] || fail "VS Code theme sync skips Cursor when the packaged executable is unavailable"
 pass "VS Code theme sync selects the packaged Cursor executable"
+
+# A theme descriptor always exists once a theme has been applied, even when it
+# names no preferred 3rd-party theme. The generated local theme is the only
+# fallback VS Code-family editors can discover, so an empty/absent name must
+# not be mistaken for "descriptor present, nothing further to do".
+GENERATED_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$GENERATED_HOME"' EXIT
+
+CODIUM_HOME="$GENERATED_HOME/home"
+CODIUM_BIN="$GENERATED_HOME/bin"
+CODIUM_CURRENT_THEME="$CODIUM_HOME/.local/state/omarchy/current/theme"
+mkdir -p "$CODIUM_BIN" "$CODIUM_CURRENT_THEME"
+
+cat >"$CODIUM_BIN/omarchy-cmd-present" <<'EOF'
+#!/bin/bash
+[[ $1 == codium ]]
+EOF
+
+cat >"$CODIUM_BIN/omarchy-toggle-enabled" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
+cat >"$CODIUM_BIN/codium" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+chmod +x "$CODIUM_BIN"/*
+printf '{"name":"","extension":""}\n' >"$CODIUM_CURRENT_THEME/vscode.json"
+printf '{"name":"Omarchy","type":"dark","colors":{}}\n' >"$CODIUM_CURRENT_THEME/vscode-theme.json"
+
+PATH="$CODIUM_BIN:$ROOT/bin:$PATH" HOME="$CODIUM_HOME" "$ROOT/bin/omarchy-theme-set-vscode"
+
+GENERATED_SETTINGS="$CODIUM_HOME/.config/VSCodium/User/settings.json"
+[[ -e $GENERATED_SETTINGS ]] || fail "VS Code theme sync writes settings when no preferred theme is named"
+grep -Fq '"workbench.colorTheme": "Omarchy"' "$GENERATED_SETTINGS" ||
+  fail "VS Code theme sync falls back to the generated theme when the descriptor names none"
+[[ -e $CODIUM_HOME/.vscode-oss/extensions/omarchy-theme/themes/omarchy-color-theme.json ]] ||
+  fail "VS Code theme sync installs the generated local theme extension"
+pass "VS Code theme sync falls back to the generated theme when no preferred theme is named"


### PR DESCRIPTION
## Summary
- `omarchy-theme-set-vscode`'s `set_theme()` branched on whether the theme descriptor (`vscode.json`) *exists*, not on whether it actually names a preferred 3rd-party theme. Since Omarchy generates that descriptor for every theme, the `elif` fallback that installs the generated local color theme extension was unreachable — any theme without a marketplace extension pairing (its `name`/`extension` fields empty) left VS Code/VSCodium/Cursor on whatever `workbench.colorTheme` they already had instead of the theme's actual generated colors.
- Fix: check `theme_name` for emptiness after reading the descriptor, rather than branching on the descriptor file's mere existence.

## Test plan
- [x] Added a regression test (`test/shell.d/vscode-theme-test.sh`) covering an empty-name/empty-extension descriptor with a generated theme present; confirmed it fails against the pre-fix code and passes with the fix.
- [x] Existing test in the same file (packaged-Cursor selection) still passes.
- [x] Reproduced live on an upgraded Quattro host: a repo-managed theme with no marketplace pairing left VSCodium on the wrong theme; after the fix, `workbench.colorTheme` correctly resolves to the generated `Omarchy` extension with the theme's real colors.