### PR TITLE
Add hover-revealed close button to notification toasts

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -154,6 +154,8 @@ BorderSurface {
       ColumnLayout {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter
+        // Keep the first line clear of the hover-revealed close button.
+        Layout.rightMargin: Style.space(10)
         spacing: Style.space(2)
 
         Text {
@@ -183,6 +185,36 @@ BorderSurface {
           maximumLineCount: 3
         }
       }
+    }
+  }
+
+  // Hover-revealed close. Stacked after mainColumn so its MouseArea sits
+  // above the full-card one and the click never reaches cardClicked.
+  Item {
+    anchors.top: parent.top
+    anchors.right: parent.right
+    anchors.topMargin: root.borderTop + Style.space(3)
+    anchors.rightMargin: root.borderRight + Style.space(3)
+    width: Style.space(18)
+    height: Style.space(18)
+    visible: opacity > 0
+    opacity: root.hovered ? 1 : 0
+
+    Behavior on opacity { NumberAnimation { duration: 100 } }
+
+    Text {
+      anchors.centerIn: parent
+      text: "✕"
+      color: closeArea.containsMouse ? Color.notifications.text : root.dimColor
+      font.pixelSize: Math.round(Style.font.caption * 1.44)
+    }
+
+    MouseArea {
+      id: closeArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: root.closeRequested()
     }
   }
 


### PR DESCRIPTION
Hovering a notification toast now reveals a small ✕ in the upper-right corner of the card. Clicking it dismisses the notification without invoking its default action — same as right-click, but discoverable.

- The button only renders while the card is hovered (100ms fade), so toasts look unchanged at rest.
- It stacks above the full-card MouseArea, so the click never falls through to the invoke action.
- The text column reserves the button's corner zone, so long first lines can't run under the ✕.

Verified live in the running shell (hover reveal, close-without-invoke, long-text clearance) and `./test/shell` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)