### PR TITLE
Pin root= before the packages that can drop it

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -517,27 +517,46 @@ normalize_limine_config() {
   fi
 }
 
+# True when a limine config layer states root= itself, rather than leaving it to
+# the /proc/cmdline fallback that the first += drop-in switches off.
+# Only the default profile matters here: that is the key this function appends
+# to and the one the boot entries are built from. Globbing and reading both run
+# as root so an unreadable drop-in directory cannot read as "nothing is pinned".
+kernel_cmdline_root_pinned() {
+  as_root bash -c '
+    shopt -s nullglob
+    for conf in /etc/limine-entry-tool.conf /etc/default/limine /etc/limine-entry-tool.d/*.conf; do
+      [[ -f $conf ]] || continue
+      grep -qE "^[^#]*KERNEL_CMDLINE\[default\]\+?=[\"'\'']?([^\"'\'']*[[:space:]])?root=" "$conf" && exit 0
+    done
+    exit 1
+  '
+}
+
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
-  local cmdline param key root_source root_stack root_uuid subvol uki
+  local cmdline param key root_source root_stack root_uuid subvol
   local boot_params=()
-  local missing=()
   local have_root=0 have_mount_mode=0 have_unlock=0
 
-  command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
+  # Gate on limine being what boots this machine, not on limine-mkinitcpio being
+  # installed: this now runs before the transaction that can install it, and a
+  # machine still missing it is exactly one that must be pinned first.
   as_root test -f /boot/limine.conf || return 0
 
   # The omarchy-defaults.conf drop-in appends to KERNEL_CMDLINE[default] with
   # +=, which makes limine-entry-tool ignore /etc/kernel/cmdline and
   # /proc/cmdline. Fresh installs pin root= in /etc/default/limine via the ISO;
   # upgrades never created that file, so root= silently drops out and the next
-  # boot lands in an emergency shell. Ask the tool for its effective default
-  # cmdline — the key this function appends to — rather than parsing the config
-  # layers ourselves.
-  if as_root limine-entry-tool --get-cmdline default 2>/dev/null |
-    grep -qE '(^|[[:space:]])root='; then
-    return 0
-  fi
+  # boot lands in an emergency shell.
+  #
+  # Ask the config layers whether root= is stated explicitly rather than asking
+  # the tool for its effective cmdline. The effective cmdline still resolves
+  # root= from the /proc/cmdline fallback right up until the first += drop-in
+  # lands, so it reports healthy on exactly the machines that are about to
+  # break — and this has to run before the package transaction installs that
+  # drop-in.
+  kernel_cmdline_root_pinned && return 0
 
   # Copy the boot-critical parameters of the running kernel verbatim, so a
   # PARTUUID, a LABEL or a bare device node all survive.
@@ -604,6 +623,17 @@ preserve_kernel_cmdline_root() {
 # root filesystem have to be stated explicitly.
 KERNEL_CMDLINE[default]+=" ${boot_params[*]}"
 EOF
+}
+
+# Runs after the package transaction, which is what rebuilds the UKIs through
+# the limine hook. Regenerating here too keeps a machine whose kernel was not
+# bumped from carrying stale entries.
+verify_kernel_cmdline_root() {
+  local uki
+  local missing=()
+
+  command -v limine-mkinitcpio >/dev/null 2>&1 || return 0
+  as_root test -f /boot/limine.conf || return 0
 
   # Keep going on failure so the verification below still runs; the unsafe
   # flag blocks the reboot at the end of the upgrade.
@@ -2322,10 +2352,11 @@ install_keyrings
 remove_legacy_installer_package
 remove_legacy_limine_configs
 remove_conflicting_legacy_packages
+preserve_kernel_cmdline_root
 install_omarchy_quattro_packages
 install_hardware_transition_packages
 normalize_limine_config
-preserve_kernel_cmdline_root
+verify_kernel_cmdline_root
 configure_snapper_policy
 configure_lock_authentication
 migrate_1password_beta_package

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -141,8 +141,14 @@ pass "Omarchy 4 upgrade removes stale nofile drop-ins"
 
 cmdline_line=$(grep -n '^preserve_kernel_cmdline_root$' "$upgrade_to_quattro" | cut -d: -f1)
 packages_line=$(grep -n '^install_omarchy_quattro_packages$' "$upgrade_to_quattro" | cut -d: -f1)
-[[ -n $cmdline_line && -n $packages_line ]] || fail "kernel cmdline preservation and package install calls exist"
-(( packages_line < cmdline_line )) || fail "kernel cmdline preservation runs once limine-mkinitcpio is installed"
+verify_line=$(grep -n '^verify_kernel_cmdline_root$' "$upgrade_to_quattro" | cut -d: -f1)
+[[ -n $cmdline_line && -n $packages_line && -n $verify_line ]] ||
+  fail "kernel cmdline preservation, verification and package install calls exist"
+# The package transaction installs the += drop-in that drops root=, so the pin
+# has to be on disk before it runs or the UKI it bakes is unbootable.
+(( cmdline_line < packages_line )) || fail "kernel cmdline is pinned before the packages that can drop root="
+# The UKIs are rebuilt by the transaction, so they can only be checked after it.
+(( verify_line > packages_line )) || fail "kernel cmdline is verified after the packages are installed"
 grep -F '/etc/default/limine' "$upgrade_to_quattro" >/dev/null
 grep -F 'KERNEL_CMDLINE[default]+=" ${boot_params[*]}"' "$upgrade_to_quattro" >/dev/null
 grep -F 'cat /proc/cmdline' "$upgrade_to_quattro" >/dev/null
@@ -151,13 +157,15 @@ grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
 grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 
-# The += drop-ins make limine-entry-tool ignore /etc/kernel/cmdline and
-# /proc/cmdline, so only the tool's own merge can say whether root= survives.
-# Queried for the default key, so a kernel-specific pin cannot cover for the
-# entries this repairs.
-grep -F 'limine-entry-tool --get-cmdline default' "$upgrade_to_quattro" >/dev/null
-grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null
-pass "Omarchy 4 upgrade asks limine-entry-tool whether root= survives"
+# The tool's effective cmdline still resolves root= from /proc/cmdline until the
+# first += drop-in lands, so it reads healthy on exactly the machines about to
+# break. Ask the config layers whether root= is stated instead, for the default
+# key alone so a fallback or kernel-specific pin cannot cover for it.
+grep -F 'kernel_cmdline_root_pinned' "$upgrade_to_quattro" >/dev/null
+grep -F 'KERNEL_CMDLINE\[default\]' "$upgrade_to_quattro" >/dev/null
+! grep -F 'limine-entry-tool --get-cmdline' "$upgrade_to_quattro" >/dev/null ||
+  fail "the pin check does not depend on the fallback it is about to lose"
+pass "Omarchy 4 upgrade checks whether root= is pinned in the limine config"
 
 # The crypt layer hides in the parents on LVM-on-LUKS, and a partial cmdline
 # for an encrypted root must not be written at all.


### PR DESCRIPTION
Reproduced #6894 in a VM, upgrading a real 3.8.0 install from the ISO.

## What is actually happening

`limine-entry-tool` falls back to `/proc/cmdline` for `root=` only while nothing appends to `KERNEL_CMDLINE`. Installing `omarchy-settings` lands `omarchy-defaults.conf`, which appends with `+=` and switches that fallback off. A kernel bump in the same transaction then fires the limine hook and bakes a UKI whose cmdline is only:

```
initramfs_async=0 quiet splash loglevel=0 systemd.show_status=false rd.udev.log_level=0 vt.global_cursor_default=0
```

`preserve_kernel_cmdline_root` repaired that afterwards, so a completed upgrade did boot. The problem is the gap in between.

## Measured

Sampling `/boot/limine.conf` and every UKI's embedded cmdline every 2s across the whole upgrade:

| Scenario | Result |
|---|---|
| Fresh 3.8.0 ISO install (`/etc/default/limine` already pins `root=`) | `root=` never dropped, even though the kernel was bumped 7.0.3 → 7.1.8 and the UKI was rebuilt mid-upgrade. Booted fine. |
| Legacy install with no `KERNEL_CMDLINE` (pre-dates the ISO pin, `root=` resolved via the fallback) | `root=` absent from the UKI for **~10 seconds**, then repaired. Booted fine. |
| That same 10s state, booted | `ERROR: Failed to mount '' on real root` → emergency shell |

So this is not every upgrade, and not the multi-minute window it might look like — but on installs that pre-date the ISO pinning `root=`, there is a real interval where the machine will not boot, and anything that interrupts the upgrade there strands it exactly as reported.

## The fix

Pinning cannot wait until after the packages land. The old guard could not simply be moved earlier either: it asked the tool for its *effective* cmdline, which still resolves `root=` through the fallback right up until the drop-in arrives — so it reports healthy on precisely the machines that are about to break, and would have made an early call a no-op.

So the guard now asks the config layers whether `root=` is stated explicitly, for the `default` profile alone, and the pin runs before the package transaction. Verification stays after it, since that is what rebuilds the UKIs. The pin also no longer gates on `limine-mkinitcpio` being installed, because it now runs before the transaction that can install it — a machine still missing it is exactly one that needs pinning first.

## Verified

Same VM, same instrumentation, after the change:

- Legacy install: **0** samples without `root=` across the entire upgrade, with the same 7.0.3 → 7.1.8 kernel bump. Boots.
- Already-pinned install: correctly skipped, no duplicate pin appended, `/etc/default/limine` unchanged. Boots.

Reviewed with codex at xhigh; its findings on the guard (profile-specific matching, unquoted assignments, the extra config layer, root-side globbing, and the `limine-mkinitcpio` gate) are folded in. The ordering assertion in `upgrade-to-quattro-test.sh` encoded the old sequence and now asserts the new invariant in both directions.

Closes #6894

— 🤖 Claude, posting on behalf of @dhh