### PR TITLE
Render bar label text with NativeRendering

### DIFF
--- a/shell/plugins/bar/widgets/ActiveWindow.qml
+++ b/shell/plugins/bar/widgets/ActiveWindow.qml
@@ -36,6 +36,7 @@ BarWidget {
       color: root.bar ? root.bar.barForeground : Color.foreground
       font.family: root.bar ? root.bar.fontFamily : Style.font.family
       font.pixelSize: Style.font.body
+      renderType: Text.NativeRendering
       elide: Text.ElideRight
       opacity: 0.85
     }

--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -37,6 +37,7 @@ BarWidget {
       color: activePlayer && activePlayer.isPlaying ? root.bar.barForeground : Qt.darker(root.bar.barForeground, 1.5)
       font.family: root.bar.fontFamily
       font.pixelSize: Style.font.body
+      renderType: Text.NativeRendering
       Behavior on color {
         enabled: !root.bar || root.bar.foregroundAnimationEnabled
         ColorAnimation { duration: 160 }
@@ -57,6 +58,7 @@ BarWidget {
         color: root.bar.barForeground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
+        renderType: Text.NativeRendering
         anchors.verticalCenter: parent.verticalCenter
 
         property bool needsScroll: implicitWidth > scrollClip.width


### PR DESCRIPTION
## Problem

On an HDR output with a transparent bar, the labels in `omarchy.active-window` and `omarchy.media` show visible colour banding on the glyph edges. Every other widget on the same bar — clock, workspaces, keyboard layout, tray — renders cleanly.

## Cause

Those two widgets draw their labels with a bare `Text`, which defaults to `Text.QtRendering`. Every other bar label goes through `Ui/WidgetButton.qml` or `Ui/OpticalGlyph.qml`, and those are the only two components in `shell/` that set `renderType: Text.NativeRendering`.

Distance-field text (`QtRendering`) generates its anti-aliasing analytically in the shader, producing a smooth continuous alpha ramp across each glyph edge. With `bar.transparent = true` those alpha values are not resolved inside the shell's own surface — the compositor resolves them, and on an HDR output that blend happens across the PQ transfer curve, which is steep near black. The smooth ramp spreads into distinct bands. `NativeRendering` rasterizes through FreeType with hinting: a short, pixel-snapped ramp with few intermediate alpha levels, which does not band.

Both conditions are required. An opaque bar hides it because the glyphs are then composited inside the shell's own surface, and an SDR output hides it because there is no PQ curve to stretch the ramp.

Because the banding is introduced during the compositor's colour conversion, it does not appear in screenshots — `grim` captures the pre-conversion buffer, so a screen grab of the bug looks clean. That is why no capture is attached.

## Fix

Set `renderType: Text.NativeRendering` on the three bar-surface labels, matching what `WidgetButton` and `OpticalGlyph` already do.

The remaining bare `Text` items in `Tray.qml` and in the media panel sit on opaque `PopupCard` / `BorderSurface` backings, so they are unaffected and are left alone.

## Verification

Reproduced and fixed on hardware: Hyprland 0.56.2, AMD RX 9070 (amdgpu), Dell AW3225QF QD-OLED at `cm = hdr`, `bitdepth = 10`, `sdr_max_luminance = 220`, `bar.transparent = true`, Omarchy 4.0.0-1.

Both widgets were verified in the running bar with the identical change applied, via cloned copies of each widget:

- **active-window** — banding gone, label renders clean.
- **media** — banding gone. Specifically checked with a long track title so the label scrolls: `NativeRendering` snaps glyphs to the pixel grid, so the marquee was the plausible regression here, and it scrolls smoothly with no shimmer.

Bisected against a cloned `omarchy.active-window` with everything else held constant. `renderType` was the single change that resolved it; ruled out along the way were `sdrbrightness`, `clip: true`, text colour, `opacity`, the width animation, `elide`, `debug:damage_tracking`, and the `render:use_fp16` / `render:fp16_sdr_tf` / `render:non_shader_cm` pipeline options. `fp16_sdr_tf` is documented as SDR-mode only, so it is a no-op while the output is in HDR mode.

`./test/all` shows no change: `config`, `runtime-smoke`, `snapper` and `unowned-system-paths` fail identically before and after this commit on the same machine.

## Note for maintainers, unrelated to this diff

`shell/plugins/services/media/BarWidget.qml` resolves its service with `bar?.shell?.firstPartyServiceFor("omarchy.media")`. Since `omarchy plugin clone` disables the source plugin, a cloned media widget's lookup returns null, `hasMedia` goes false, and the widget silently disappears rather than reporting an error — so `omarchy.media` cannot be customised by cloning the way other widgets can. Happy to open that separately if it is worth fixing.