### PR TITLE
Preserve terminal font size when changing font family

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -41,7 +41,14 @@ if [[ -f ~/.config/ghostty/config ]]; then
 fi
 
 if [[ -f ~/.config/foot/foot.ini ]]; then
-  sed -i "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
+  # Preserve the existing :size=N (set by omarchy display text size) so a
+  # family change never resets the terminal font size. Fall back to the
+  # default 9pt when no size is present.
+  foot_size="$(sed -n 's/^font=.*:size=\([0-9.]\+\).*/\1/p' ~/.config/foot/foot.ini | head -1)"
+  if [[ -z $foot_size ]]; then
+    foot_size=9
+  fi
+  sed -i "s/^font=.*/font=$font_name:size=$foot_size/g" ~/.config/foot/foot.ini
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -41,9 +41,7 @@ if [[ -f ~/.config/ghostty/config ]]; then
 fi
 
 if [[ -f ~/.config/foot/foot.ini ]]; then
-  # Preserve the existing :size=N (set by omarchy display text size) so a
-  # family change never resets the terminal font size. Fall back to the
-  # default 9pt when no size is present.
+  # Preserve the configured size; Foot defaults to 9 when none is present.
   foot_size="$(sed -n 's/^font=.*:size=\([0-9.]\+\).*/\1/p' ~/.config/foot/foot.ini | head -1)"
   if [[ -z $foot_size ]]; then
     foot_size=9

--- a/test/cli
+++ b/test/cli
@@ -247,6 +247,53 @@ pass "safe dispatch works for font list"
 "$CLI" font current >/dev/null
 pass "safe dispatch works for font current"
 
+# omarchy-font-set must swap only the family and preserve the terminal font
+# size that omarchy display text size chose. Foot's :size was hardcoded back
+# to 9 on every family change while kitty/alacritty/ghostty kept theirs.
+make_tmpdir FONT_TMPDIR
+mkdir -p "$FONT_TMPDIR/.config/foot" "$FONT_TMPDIR/.config/kitty" \
+  "$FONT_TMPDIR/.config/alacritty" "$FONT_TMPDIR/.config/ghostty" \
+  "$FONT_TMPDIR/.config/fontconfig" "$FONT_TMPDIR/fake-bin"
+cat >"$FONT_TMPDIR/.config/foot/foot.ini" <<'EOF'
+font=JetBrainsMono Nerd Font:size=12
+EOF
+cat >"$FONT_TMPDIR/.config/kitty/kitty.conf" <<'EOF'
+font_family JetBrainsMono Nerd Font
+font_size 12.0
+EOF
+cat >"$FONT_TMPDIR/.config/alacritty/alacritty.toml" <<'EOF'
+size = 12
+EOF
+cat >"$FONT_TMPDIR/.config/ghostty/config" <<'EOF'
+font-size = 12
+EOF
+# Stub the heavy side effects so the test is hermetic: shell restart, hooks,
+# notifications, and signals to real terminal processes.
+for shim in omarchy-restart-shell omarchy-hook omarchy-notification-send pkill; do
+  cat >"$FONT_TMPDIR/fake-bin/$shim" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$FONT_TMPDIR/fake-bin/$shim"
+done
+
+# The family argument must exist in fontconfig; use any installed monospace.
+FONT_FAMILY="$(fc-list :spacing=100 -f '%{family[0]}\n' | head -1)"
+PATH="$FONT_TMPDIR/fake-bin:$ROOT/bin:$PATH" HOME="$FONT_TMPDIR" \
+  "$ROOT/bin/omarchy-font-set" "$FONT_FAMILY" >/dev/null
+
+printf 'font=%s:size=12\n' "$FONT_FAMILY" >"$FONT_TMPDIR/expected-foot"
+if ! diff -q "$FONT_TMPDIR/expected-foot" "$FONT_TMPDIR/.config/foot/foot.ini" >/dev/null; then
+  fail "font set preserves the Foot size set by omarchy display text size"
+fi
+pass "font set preserves the Foot size set by omarchy display text size"
+grep -qx 'font_size 12.0' "$FONT_TMPDIR/.config/kitty/kitty.conf" || fail "font set preserves kitty size"
+pass "font set preserves kitty size"
+grep -qx 'size = 12' "$FONT_TMPDIR/.config/alacritty/alacritty.toml" || fail "font set preserves alacritty size"
+pass "font set preserves alacritty size"
+grep -qx 'font-size = 12' "$FONT_TMPDIR/.config/ghostty/config" || fail "font set preserves ghostty size"
+pass "font set preserves ghostty size"
+
 make_tmpdir PI_TMPDIR
 NEXT_THEME="$PI_TMPDIR/.local/state/omarchy/current/next-theme"
 CURRENT_THEME="$PI_TMPDIR/.local/state/omarchy/current/theme"

--- a/test/cli
+++ b/test/cli
@@ -277,8 +277,17 @@ EOF
   chmod +x "$FONT_TMPDIR/fake-bin/$shim"
 done
 
-# The family argument must exist in fontconfig; use any installed monospace.
-FONT_FAMILY="$(fc-list :spacing=100 -f '%{family[0]}\n' | head -1)"
+# The family argument must exist in fontconfig. Resolve the monospace alias
+# deterministically with fc-match and fall back to enumerating fc-list; the
+# command's own validation requires a family that fontconfig knows about.
+if command -v fc-match >/dev/null 2>&1; then
+  FONT_FAMILY="$(fc-match -f '%{family[0]}\n' monospace | head -1)"
+else
+  FONT_FAMILY="$(fc-list :spacing=100 -f '%{family[0]}\n' | head -1)"
+fi
+if [[ -z $FONT_FAMILY ]]; then
+  fail "fontconfig has no resolvable monospace family for the font-set size test"
+fi
 PATH="$FONT_TMPDIR/fake-bin:$ROOT/bin:$PATH" HOME="$FONT_TMPDIR" \
   "$ROOT/bin/omarchy-font-set" "$FONT_FAMILY" >/dev/null
 

--- a/test/cli
+++ b/test/cli
@@ -247,9 +247,6 @@ pass "safe dispatch works for font list"
 "$CLI" font current >/dev/null
 pass "safe dispatch works for font current"
 
-# omarchy-font-set must swap only the family and preserve the terminal font
-# size that omarchy display text size chose. Foot's :size was hardcoded back
-# to 9 on every family change while kitty/alacritty/ghostty kept theirs.
 make_tmpdir FONT_TMPDIR
 mkdir -p "$FONT_TMPDIR/.config/foot" "$FONT_TMPDIR/.config/kitty" \
   "$FONT_TMPDIR/.config/alacritty" "$FONT_TMPDIR/.config/ghostty" \
@@ -267,8 +264,6 @@ EOF
 cat >"$FONT_TMPDIR/.config/ghostty/config" <<'EOF'
 font-size = 12
 EOF
-# Stub the heavy side effects so the test is hermetic: shell restart, hooks,
-# notifications, and signals to real terminal processes.
 for shim in omarchy-restart-shell omarchy-hook omarchy-notification-send pkill; do
   cat >"$FONT_TMPDIR/fake-bin/$shim" <<'EOF'
 #!/bin/bash
@@ -277,31 +272,38 @@ EOF
   chmod +x "$FONT_TMPDIR/fake-bin/$shim"
 done
 
-# The family argument must exist in fontconfig. Resolve the monospace alias
-# deterministically with fc-match and fall back to enumerating fc-list; the
-# command's own validation requires a family that fontconfig knows about.
+# omarchy-font-set validates the family through fontconfig.
+FONTCONFIG_AVAILABLE=0
 if command -v fc-match >/dev/null 2>&1; then
   FONT_FAMILY="$(fc-match -f '%{family[0]}\n' monospace | head -1)"
+  FONTCONFIG_AVAILABLE=1
+elif command -v fc-list >/dev/null 2>&1; then
+  FONT_FAMILY="$(fc-list :spacing=100 -f '%{family[0]}\n' | sed -n '1p')"
+  FONTCONFIG_AVAILABLE=1
 else
-  FONT_FAMILY="$(fc-list :spacing=100 -f '%{family[0]}\n' | head -1)"
+  pass "fontconfig tools unavailable; skipping font-set size test"
 fi
-if [[ -z $FONT_FAMILY ]]; then
-  fail "fontconfig has no resolvable monospace family for the font-set size test"
-fi
-PATH="$FONT_TMPDIR/fake-bin:$ROOT/bin:$PATH" HOME="$FONT_TMPDIR" \
-  "$ROOT/bin/omarchy-font-set" "$FONT_FAMILY" >/dev/null
 
-printf 'font=%s:size=12\n' "$FONT_FAMILY" >"$FONT_TMPDIR/expected-foot"
-if ! diff -q "$FONT_TMPDIR/expected-foot" "$FONT_TMPDIR/.config/foot/foot.ini" >/dev/null; then
-  fail "font set preserves the Foot size set by omarchy display text size"
+if (( FONTCONFIG_AVAILABLE )); then
+  if [[ -z $FONT_FAMILY ]]; then
+    fail "fontconfig has no resolvable monospace family for the font-set size test"
+  fi
+
+  PATH="$FONT_TMPDIR/fake-bin:$ROOT/bin:$PATH" HOME="$FONT_TMPDIR" \
+    "$ROOT/bin/omarchy-font-set" "$FONT_FAMILY" >/dev/null
+
+  printf 'font=%s:size=12\n' "$FONT_FAMILY" >"$FONT_TMPDIR/expected-foot"
+  if ! diff -q "$FONT_TMPDIR/expected-foot" "$FONT_TMPDIR/.config/foot/foot.ini" >/dev/null; then
+    fail "font set preserves the Foot size set by omarchy display text size"
+  fi
+  pass "font set preserves the Foot size set by omarchy display text size"
+  grep -qx 'font_size 12.0' "$FONT_TMPDIR/.config/kitty/kitty.conf" || fail "font set preserves kitty size"
+  pass "font set preserves kitty size"
+  grep -qx 'size = 12' "$FONT_TMPDIR/.config/alacritty/alacritty.toml" || fail "font set preserves alacritty size"
+  pass "font set preserves alacritty size"
+  grep -qx 'font-size = 12' "$FONT_TMPDIR/.config/ghostty/config" || fail "font set preserves ghostty size"
+  pass "font set preserves ghostty size"
 fi
-pass "font set preserves the Foot size set by omarchy display text size"
-grep -qx 'font_size 12.0' "$FONT_TMPDIR/.config/kitty/kitty.conf" || fail "font set preserves kitty size"
-pass "font set preserves kitty size"
-grep -qx 'size = 12' "$FONT_TMPDIR/.config/alacritty/alacritty.toml" || fail "font set preserves alacritty size"
-pass "font set preserves alacritty size"
-grep -qx 'font-size = 12' "$FONT_TMPDIR/.config/ghostty/config" || fail "font set preserves ghostty size"
-pass "font set preserves ghostty size"
 
 make_tmpdir PI_TMPDIR
 NEXT_THEME="$PI_TMPDIR/.local/state/omarchy/current/next-theme"


### PR DESCRIPTION
## What

`omarchy font set <name>` (and the settings-menu **Style → Font** picker) now swaps only the font **family** and keeps the existing terminal **size**. Foot previously had its size hardcoded back to 9pt on every family change, silently undoing the size chosen via `omarchy display text size` or the display-panel slider.

## Why

The Foot branch of `bin/omarchy-font-set` rewrote the whole `font=` line with a hardcoded `:size=9`:

```bash
sed -i "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
```

kitty, alacritty, and ghostty only get their family line rewritten, so they keep their size. Foot was the inconsistent outlier — the font picker in the GUI silently reset Foot's text size to 9 while everything else stayed scaled.

## Change

- `bin/omarchy-font-set`: read the existing `:size=N` from foot.ini and reuse it when swapping the family; fall back to 9pt when no size is present.
- `test/cli`: regression test covering Foot plus the three other terminals, using the harness's fake-bin pattern to stay hermetic.

## Verification

- Reproduced on 4.0.0-1 via both CLI and the GUI (slider → 16, then font picker → Foot back to 9).
- With the fix, Foot keeps `:size=12` across a family change, matching kitty/alacritty/ghostty.
- `./test/all`: CLI suite fully green including the new tests. The only shell-suite failures are the pre-existing `omarchy-pkgs` checkout-dependent tests (config-test, snapper-test, unowned-system-paths-test), which fail identically on unmodified `origin/quattro` in this environment.

Fixes #6957