### PR TITLE
Require checking for duplicate issues and pending fixes before filing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,6 +7,18 @@ body:
       value: |
         Remember: Omarchy is an open source gift, not a product you bought from a vendor
 
+  - type: checkboxes
+    id: checked-existing
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched [open and closed issues](https://github.com/basecamp/omarchy/issues?q=is%3Aissue) for this and found nothing matching
+          required: true
+        - label: I checked [pull requests](https://github.com/basecamp/omarchy/pulls?q=is%3Apr) for an existing fix, open or merged
+          required: true
+        - label: I confirmed this still happens on the latest Omarchy release, not just an older install
+          required: true
+
   - type: input
     id: system-details
     attributes:

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -54,6 +54,14 @@ Include **closed** issues. A matching issue closed as fixed, when the crash stil
 reproduces on a current system, is a regression — and reporting that is worth far
 more than another duplicate.
 
+Also search pull requests, open and merged — a fix already merged but not yet in
+a release means "update and it's fixed," not a new bug; an open PR means point
+the user at it instead of filing a duplicate:
+
+```bash
+gh pr list --repo basecamp/omarchy --state all --search "<signal> <program>"
+```
+
 ## Adding to an existing report
 
 If a plausible match comes back, read it properly first:

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -54,9 +54,11 @@ Include **closed** issues. A matching issue closed as fixed, when the crash stil
 reproduces on a current system, is a regression — and reporting that is worth far
 more than another duplicate.
 
-Also search pull requests, open and merged — a fix already merged but not yet in
-a release means "update and it's fixed," not a new bug; an open PR means point
-the user at it instead of filing a duplicate:
+Also search pull requests, open and merged — a merged-but-unreleased fix means
+it's on the default branch and will ship in the next release, not something the
+user can install yet via `omarchy update`, so only worth a new report if it
+still reproduces after that release ships. An open PR means point the user at
+it instead of filing a duplicate:
 
 ```bash
 gh pr list --repo basecamp/omarchy --state all --search "<signal> <program>"

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -36,9 +36,11 @@ report at all. Before drafting anything, confirm all three:
    ```bash
    gh issue list --repo basecamp/omarchy --state all --search "<keywords>"
    ```
-3. **No pull request already fixes it**, open or merged. A merged PR not yet
-   in a release means "update and it's fixed," not a new bug. An open PR
-   means point the user at it instead of filing a duplicate.
+3. **No pull request already fixes it**, open or merged. A merged-but-unreleased
+   PR means the fix is on the default branch and will ship in the next
+   release — not installable yet via `omarchy update`, so only worth a new
+   report if it still reproduces after that release ships. An open PR means
+   point the user at it instead of filing a duplicate.
    ```bash
    gh pr list --repo basecamp/omarchy --state all --search "<keywords>"
    ```

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -23,9 +23,13 @@ report at all. Before drafting anything, confirm all three:
    upstream tag** — not just the default branch, since an unreleased fix
    there wouldn't apply to what's actually installed, and a fix already
    released after the installed version means it's not a live bug either.
+   `omarchy version` doesn't necessarily match a release tag verbatim (it may
+   carry a packaging suffix, e.g. `4.0.0-1` for tag `v4.0.0`), so look up the
+   matching tag rather than assuming a `v<version>` prefix:
    ```bash
    omarchy version
-   curl -fsSL "https://raw.githubusercontent.com/basecamp/omarchy/v<version>/<path>"
+   gh release list --repo basecamp/omarchy   # find the matching tag
+   curl -fsSL "https://raw.githubusercontent.com/basecamp/omarchy/<tag>/<path>"
    # diff that against the local file/behavior
    ```
 2. **No existing issue already covers it** — search open *and* closed. A

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -14,6 +14,37 @@ right place:
   https://omarchy.org/discord. Start here when the problem isn't clearly a bug
   in Omarchy itself.
 
+## Verify Before Filing
+
+A duplicate or already-fixed report costs a maintainer more time than no
+report at all. Before drafting anything, confirm all three:
+
+1. **It reproduces against the exact installed version, on the matching
+   upstream tag** — not just the default branch, since an unreleased fix
+   there wouldn't apply to what's actually installed, and a fix already
+   released after the installed version means it's not a live bug either.
+   ```bash
+   omarchy version
+   curl -fsSL "https://raw.githubusercontent.com/basecamp/omarchy/v<version>/<path>"
+   # diff that against the local file/behavior
+   ```
+2. **No existing issue already covers it** — search open *and* closed. A
+   closed-as-fixed issue that still reproduces on the current release is a
+   regression worth reporting; a closed-as-not-a-bug issue on the same
+   symptom (e.g. a stale local dependency, not an Omarchy bug) means don't
+   file at all.
+   ```bash
+   gh issue list --repo basecamp/omarchy --state all --search "<keywords>"
+   ```
+3. **No pull request already fixes it**, open or merged. A merged PR not yet
+   in a release means "update and it's fixed," not a new bug. An open PR
+   means point the user at it instead of filing a duplicate.
+   ```bash
+   gh pr list --repo basecamp/omarchy --state all --search "<keywords>"
+   ```
+
+Only proceed to drafting a report once all three come back clean.
+
 ## Filing a Good Bug Report
 
 The bug template asks for system details (CPU, GPU, Omarchy version), a


### PR DESCRIPTION
## Why

Issue #6648 is a concrete example of what this prevents: a report that
turned out to be a stale local plugin lock, not an Omarchy bug, closed
after a maintainer had to spend time investigating it. Neither the bug
report template nor the general-purpose `contributing.md` skill prompts
for a duplicate check or a version-matched reproduction before filing.

Omarchy already partially enforces this elsewhere: the `diagnose-crash`
agent skill's `reporting.md` requires searching open *and* closed issues,
and treats a closed-as-fixed issue that still reproduces as a regression
worth reporting, before it lets an AI agent file anything on a user's
behalf. It was missing a check for pull requests though, so this also
closes that gap there and in `contributing.md`, brings the same
discipline to the human-facing template, so it applies regardless of how
someone files.

## What

- **`bug.yml`**: three required checkboxes before the existing fields —
  searched issues, checked PRs, confirmed on latest release. GitHub's
  native `required: true` on `type: checkboxes` blocks submission until
  acknowledged, not just a markdown reminder someone can skip past.
- **`omarchy/contributing.md`**: new "Verify Before Filing" section
  requiring a version-matched upstream diff, an issue search, and a PR
  search before any agent drafts a report.
- **`diagnose-crash/reporting.md`**: added the PR-search step it was
  missing, next to its existing issue-search requirement.

## Test plan

- [x] Validated `bug.yml` YAML (`ruby -ryaml`)
- [x] `./test/cli` passes
- `./test/shell` has pre-existing failures on this machine from an
  unrelated missing `mise` Node pin; none of the failing tests reference
  any of the three files changed here (confirmed via
  `grep -rl` across `test/`), and none of these files have any existing
  test coverage

---
Filed by Claude Sonnet 5 via Claude Code, with @guirossibrum.