### PR TITLE
Bar widget group

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -152,6 +152,11 @@ Rules:
 6. `allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
 8. `version: 1` is required.
+9. A `bar.layout.<section>` entry may be a **group**:
+   `{ "type": "group", "collapsed": true, "items": [ ... ] }`. It wraps its
+   `items` behind a collapsible chevron (the tray-drawer gesture) and nests
+   ordinary entries. Groups are additive — older flat layouts stay valid without
+   a migration. See [`../shell/plugins/bar/README.md`](../shell/plugins/bar/README.md#widget-groups).
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -121,7 +121,7 @@ QtObject {
     // id of its own (one is optional, for addressing), so it must be recognized
     // before the id branch below, which would otherwise drop it. Its children
     // are normalized recursively so the same rules apply at every depth.
-    if (isPlainObject(entry) && entry.type === "group") {
+    if (isPlainObject(entry) && String(entry.type || "") === "group") {
       var group = cloneJson(entry)
       if (group.id) group.id = canonicalWidgetId(group.id)
       group.items = normalizeLayoutSection(group.items)

--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -117,6 +117,16 @@ QtObject {
   // input config; consumers can mutate without leaking back to shell.json.
   function normalizeLayoutEntry(entry) {
     if (typeof entry === "string") return { id: canonicalWidgetId(entry) }
+    // A group wraps child entries behind a collapsible chevron. It has no widget
+    // id of its own (one is optional, for addressing), so it must be recognized
+    // before the id branch below, which would otherwise drop it. Its children
+    // are normalized recursively so the same rules apply at every depth.
+    if (isPlainObject(entry) && entry.type === "group") {
+      var group = cloneJson(entry)
+      if (group.id) group.id = canonicalWidgetId(group.id)
+      group.items = normalizeLayoutSection(group.items)
+      return group
+    }
     if (isPlainObject(entry) && entry.id) {
       var copy = cloneJson(entry)
       copy.id = canonicalWidgetId(copy.id)

--- a/shell/Ui/BarCollapsible.qml
+++ b/shell/Ui/BarCollapsible.qml
@@ -48,11 +48,12 @@ Item {
   signal chevronPressed(int button)
 
   // A hover reveals transiently; a chevron click pins the drawer open so it
-  // survives the pointer leaving. collapsedByDefault only *seeds* the initial
-  // pinned state; freeze the binding on completion so a later collapsedByDefault
-  // change (e.g. a future in-place group update) can't retroactively flip it.
+  // survives the pointer leaving. pinnedOpen follows collapsedByDefault until the
+  // first chevron click breaks the binding and hands control to the user. It must
+  // stay a live binding: BarGroup sets the group's entry — and thus
+  // collapsedByDefault — right after load, so freezing on completion would lock in
+  // the pre-entry default and ignore a configured collapsed: false.
   property bool pinnedOpen: !collapsedByDefault
-  Component.onCompleted: pinnedOpen = !collapsedByDefault
   property bool hovered: false
   readonly property bool open: pinnedOpen || (expandOnHover && hovered)
 

--- a/shell/Ui/BarCollapsible.qml
+++ b/shell/Ui/BarCollapsible.qml
@@ -84,10 +84,10 @@ Item {
     function contains(point: point): bool {
       if (root.vertical) {
         if (point.x < 0 || point.x > root.width) return false
-        return point.y >= root.chevronOffset && point.y <= root.implicitHeight
+        return point.y >= root.chevronOffset && point.y <= root.height
       }
       if (point.y < 0 || point.y > root.height) return false
-      return point.x >= root.chevronOffset && point.x <= root.implicitWidth
+      return point.x >= root.chevronOffset && point.x <= root.width
     }
   }
 

--- a/shell/Ui/BarCollapsible.qml
+++ b/shell/Ui/BarCollapsible.qml
@@ -125,14 +125,17 @@ Item {
     clip: true
 
     // The content is laid out at its full extent regardless of how far the
-    // drawer has opened, so its widgets never reflow as it animates.
+    // drawer has opened, so its widgets never reflow as it animates. On the
+    // cross axis it is sized to the content and centered, so content shorter
+    // than the bar (e.g. tray icons) sits centered like the pinned items rather
+    // than top/left-aligned — matching the tray drawer's original centering.
     Loader {
       id: contentLoader
-      x: root.vertical ? 0 : Math.round(root.contentOffset)
-      y: root.vertical ? Math.round(root.contentOffset) : 0
-      width: root.vertical ? root.barSize : root.drawerExtent
-      height: root.vertical ? root.drawerExtent : root.barSize
       sourceComponent: root.contentComponent
+      x: root.vertical ? Math.round((root.barSize - implicitWidth) / 2) : Math.round(root.contentOffset)
+      y: root.vertical ? Math.round(root.contentOffset) : Math.round((root.barSize - implicitHeight) / 2)
+      width: root.vertical ? implicitWidth : root.drawerExtent
+      height: root.vertical ? root.drawerExtent : implicitHeight
     }
   }
 }

--- a/shell/Ui/BarCollapsible.qml
+++ b/shell/Ui/BarCollapsible.qml
@@ -2,22 +2,20 @@ import QtQuick
 import qs.Commons
 
 // Collapsible bar container. Hides its content behind a chevron and reveals it
-// with the same hover-to-expand motion the system tray drawer uses, so a group
-// of bar widgets can be tucked away and slid back into view.
+// with a hover-to-expand slide. This is the single source of the collapse/expand
+// motion for the bar: the system tray drawer and the widget group both use it,
+// so the two never drift.
 //
-// The animation constants (600ms, OutCubic) are meant to be the shared source
-// of truth for every collapsing bar surface: the tray drawer in
-// `plugins/bar/widgets/Tray.qml` currently inlines the same values and is meant
-// to migrate onto this component so the two never drift.
+// Two layout modes:
+//   reserveSpace: false (default, widget groups) — space-saving: collapsed the
+//     container is just the chevron and it grows to fit its content as it opens.
+//   reserveSpace: true (system tray) — the full extent is always reserved; the
+//     chevron migrates and the content slides in and out beneath it, and the
+//     empty reserved area is masked so it does not steal hover or clicks.
 //
-// This first cut is space-saving: collapsed the container is just the chevron,
-// and it grows to fit its content as it opens. (The tray additionally reserves
-// its full extent while collapsed; adding that mode here is the follow-up that
-// lets the tray adopt this component.)
-//
-// Content is supplied as a Component rather than as default children so the
-// chevron and clip declared below are not swallowed by a default-property alias,
-// and so the instantiated item is available to measure for the drawer extent.
+// Content is supplied as a Component (not default children) so the chevron and
+// clip below are not swallowed by a default-property alias, and so the loaded
+// item is available to measure for the drawer extent.
 Item {
   id: root
 
@@ -34,11 +32,20 @@ Item {
 
   property bool collapsedByDefault: true
   property bool expandOnHover: true
+  // Reserve the full extent while collapsed (tray drawer) instead of shrinking
+  // to just the chevron (widget group).
+  property bool reserveSpace: false
+  // Left-click the chevron to pin the drawer open. The tray drives reveal by
+  // hover alone and uses the chevron's right button for its manage popup, so it
+  // turns this off and listens to chevronPressed instead.
+  property bool pinOnClick: true
   // Chevron glyph (the same one the tray drawer uses). Escaped codepoint on
   // purpose: raw Nerd Font glyphs can be mangled by file tooling, so the default
   // stays stable this way.
   property string icon: "\uf053"
   property int animationDuration: 600
+
+  signal chevronPressed(int button)
 
   // A hover reveals transiently; a chevron click pins the drawer open so it
   // survives the pointer leaving. collapsedByDefault seeds the pinned state.
@@ -50,12 +57,39 @@ Item {
   property real revealProgress: open ? 1 : 0
   readonly property real revealExtent: drawerExtent * revealProgress
 
+  // Extent occupied beyond the chevron: the full drawer when space is reserved,
+  // otherwise only the slice revealed so far.
+  readonly property real reservedExtent: reserveSpace ? drawerExtent : revealExtent
+  // In reserve mode the chevron migrates as the drawer opens and the content
+  // slides under it; in space-saving mode the chevron is fixed and the content
+  // is wiped in from it.
+  readonly property real chevronOffset: reserveSpace ? (drawerExtent - revealExtent) : 0
+  readonly property real clipExtent: reserveSpace ? drawerExtent : revealExtent
+  readonly property real contentOffset: reserveSpace ? (drawerExtent - revealExtent) : 0
+
   Behavior on revealProgress {
     NumberAnimation { duration: root.animationDuration; easing.type: Easing.OutCubic }
   }
 
-  implicitWidth: vertical ? barSize : Math.round(chevron.implicitWidth + revealExtent)
-  implicitHeight: vertical ? Math.round(chevron.implicitHeight + revealExtent) : barSize
+  implicitWidth: vertical ? barSize : Math.round(chevron.implicitWidth + reservedExtent)
+  implicitHeight: vertical ? Math.round(chevron.implicitHeight + reservedExtent) : barSize
+
+  // Reserved-but-empty space must not react to the pointer, or hovering the gap
+  // beside a collapsed drawer would expand it and clicks would be swallowed.
+  // Only the chevron and the revealed content are live. Nothing to mask in
+  // space-saving mode, where the block shrinks to the chevron.
+  containmentMask: root.reserveSpace ? reserveMask : null
+  QtObject {
+    id: reserveMask
+    function contains(point: point): bool {
+      if (root.vertical) {
+        if (point.x < 0 || point.x > root.width) return false
+        return point.y >= root.chevronOffset && point.y <= root.implicitHeight
+      }
+      if (point.y < 0 || point.y > root.height) return false
+      return point.x >= root.chevronOffset && point.x <= root.implicitWidth
+    }
+  }
 
   // Whole-container hover drives the transient reveal. A HoverHandler on the
   // root sees the chevron and the revealed content as one region, so sliding
@@ -68,34 +102,34 @@ Item {
   BarIconButton {
     id: chevron
     bar: root.bar
-    x: 0
-    y: 0
+    x: root.vertical ? 0 : root.chevronOffset
+    y: root.vertical ? root.chevronOffset : 0
     width: implicitWidth
     height: implicitHeight
     text: root.icon
     textRotation: root.vertical ? 90 : 0
-    // Left-click pins/unpins; the reveal itself is handled by hover above.
     onPressed: function(button) {
-      if (button === Qt.LeftButton) root.pinnedOpen = !root.pinnedOpen
+      root.chevronPressed(button)
+      if (root.pinOnClick && button === Qt.LeftButton) root.pinnedOpen = !root.pinnedOpen
     }
   }
 
-  // The revealed slice. Clipped so the content is wiped in from the chevron as
-  // the slice grows, and so a partially-open drawer never paints past its edge.
+  // The revealed slice. Clipped so the content is wiped/slid in from the chevron
+  // as the slice grows, and so a partially-open drawer never paints past its edge.
   Item {
     id: revealClip
     x: root.vertical ? 0 : chevron.implicitWidth
     y: root.vertical ? chevron.implicitHeight : 0
-    width: root.vertical ? root.barSize : Math.round(root.revealExtent)
-    height: root.vertical ? Math.round(root.revealExtent) : root.barSize
+    width: root.vertical ? root.barSize : Math.round(root.clipExtent)
+    height: root.vertical ? Math.round(root.clipExtent) : root.barSize
     clip: true
 
-    // The content is laid out at its full extent regardless of how far the slice
-    // has opened, so its widgets never reflow as the drawer animates.
+    // The content is laid out at its full extent regardless of how far the
+    // drawer has opened, so its widgets never reflow as it animates.
     Loader {
       id: contentLoader
-      x: 0
-      y: 0
+      x: root.vertical ? 0 : Math.round(root.contentOffset)
+      y: root.vertical ? Math.round(root.contentOffset) : 0
       width: root.vertical ? root.barSize : root.drawerExtent
       height: root.vertical ? root.drawerExtent : root.barSize
       sourceComponent: root.contentComponent

--- a/shell/Ui/BarCollapsible.qml
+++ b/shell/Ui/BarCollapsible.qml
@@ -48,8 +48,11 @@ Item {
   signal chevronPressed(int button)
 
   // A hover reveals transiently; a chevron click pins the drawer open so it
-  // survives the pointer leaving. collapsedByDefault seeds the pinned state.
+  // survives the pointer leaving. collapsedByDefault only *seeds* the initial
+  // pinned state; freeze the binding on completion so a later collapsedByDefault
+  // change (e.g. a future in-place group update) can't retroactively flip it.
   property bool pinnedOpen: !collapsedByDefault
+  Component.onCompleted: pinnedOpen = !collapsedByDefault
   property bool hovered: false
   readonly property bool open: pinnedOpen || (expandOnHover && hovered)
 

--- a/shell/Ui/BarCollapsible.qml
+++ b/shell/Ui/BarCollapsible.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import qs.Commons
+
+// Collapsible bar container. Hides its content behind a chevron and reveals it
+// with the same hover-to-expand motion the system tray drawer uses, so a group
+// of bar widgets can be tucked away and slid back into view.
+//
+// The animation constants (600ms, OutCubic) are meant to be the shared source
+// of truth for every collapsing bar surface: the tray drawer in
+// `plugins/bar/widgets/Tray.qml` currently inlines the same values and is meant
+// to migrate onto this component so the two never drift.
+//
+// This first cut is space-saving: collapsed the container is just the chevron,
+// and it grows to fit its content as it opens. (The tray additionally reserves
+// its full extent while collapsed; adding that mode here is the follow-up that
+// lets the tray adopt this component.)
+//
+// Content is supplied as a Component rather than as default children so the
+// chevron and clip declared below are not swallowed by a default-property alias,
+// and so the instantiated item is available to measure for the drawer extent.
+Item {
+  id: root
+
+  // Host bar, injected by the caller. Supplies vertical / barSize / theming for
+  // the chevron. Left null the component still lays out with Style fallbacks.
+  property var bar: null
+  readonly property bool vertical: bar ? bar.vertical : false
+  readonly property int barSize: bar ? bar.barSize : Style.bar.sizeHorizontal
+
+  // The content to reveal. Its implicit size along the bar axis is the extent
+  // the drawer opens to.
+  property Component contentComponent: null
+  readonly property Item body: contentLoader.item
+
+  property bool collapsedByDefault: true
+  property bool expandOnHover: true
+  // Chevron glyph (the same one the tray drawer uses). Escaped codepoint on
+  // purpose: raw Nerd Font glyphs can be mangled by file tooling, so the default
+  // stays stable this way.
+  property string icon: "\uf053"
+  property int animationDuration: 600
+
+  // A hover reveals transiently; a chevron click pins the drawer open so it
+  // survives the pointer leaving. collapsedByDefault seeds the pinned state.
+  property bool pinnedOpen: !collapsedByDefault
+  property bool hovered: false
+  readonly property bool open: pinnedOpen || (expandOnHover && hovered)
+
+  readonly property real drawerExtent: body ? (vertical ? body.implicitHeight : body.implicitWidth) : 0
+  property real revealProgress: open ? 1 : 0
+  readonly property real revealExtent: drawerExtent * revealProgress
+
+  Behavior on revealProgress {
+    NumberAnimation { duration: root.animationDuration; easing.type: Easing.OutCubic }
+  }
+
+  implicitWidth: vertical ? barSize : Math.round(chevron.implicitWidth + revealExtent)
+  implicitHeight: vertical ? Math.round(chevron.implicitHeight + revealExtent) : barSize
+
+  // Whole-container hover drives the transient reveal. A HoverHandler on the
+  // root sees the chevron and the revealed content as one region, so sliding
+  // from the chevron onto the content does not collapse it mid-motion.
+  HoverHandler {
+    enabled: root.expandOnHover
+    onHoveredChanged: root.hovered = hovered
+  }
+
+  BarIconButton {
+    id: chevron
+    bar: root.bar
+    x: 0
+    y: 0
+    width: implicitWidth
+    height: implicitHeight
+    text: root.icon
+    textRotation: root.vertical ? 90 : 0
+    // Left-click pins/unpins; the reveal itself is handled by hover above.
+    onPressed: function(button) {
+      if (button === Qt.LeftButton) root.pinnedOpen = !root.pinnedOpen
+    }
+  }
+
+  // The revealed slice. Clipped so the content is wiped in from the chevron as
+  // the slice grows, and so a partially-open drawer never paints past its edge.
+  Item {
+    id: revealClip
+    x: root.vertical ? 0 : chevron.implicitWidth
+    y: root.vertical ? chevron.implicitHeight : 0
+    width: root.vertical ? root.barSize : Math.round(root.revealExtent)
+    height: root.vertical ? Math.round(root.revealExtent) : root.barSize
+    clip: true
+
+    // The content is laid out at its full extent regardless of how far the slice
+    // has opened, so its widgets never reflow as the drawer animates.
+    Loader {
+      id: contentLoader
+      x: 0
+      y: 0
+      width: root.vertical ? root.barSize : root.drawerExtent
+      height: root.vertical ? root.drawerExtent : root.barSize
+      sourceComponent: root.contentComponent
+    }
+  }
+}

--- a/shell/Ui/qmldir
+++ b/shell/Ui/qmldir
@@ -1,5 +1,6 @@
 module qs.Ui
 
+BarCollapsible 1.0 BarCollapsible.qml
 BarIndicator 1.0 BarIndicator.qml
 BarIconButton 1.0 BarIconButton.qml
 BarWidget 1.0 BarWidget.qml

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -574,6 +574,10 @@ Item {
     return BarModel.customModuleType(entry)
   }
 
+  function groupItems(entry) {
+    return BarModel.groupItems(entry)
+  }
+
   function customModuleSource(entry) {
     var source = BarModel.customModulePath(entry, home, omarchyConfigDir)
     return source ? Util.fileUrl(source) : ""
@@ -693,6 +697,10 @@ Item {
     for (var i = 0; i < moduleSlots.length; i++) {
       var slot = moduleSlots[i]
       if (!slot || slot === sourceSlot || !slot.visible || slot.width <= 0 || slot.height <= 0) continue
+      // A group and its children are not drop targets: their ids do not address
+      // the top-level layout a drop is persisted against. Drops snap to the
+      // nearest ordinary widget instead.
+      if (slot.isGroup || !slot.draggable) continue
       if (sourceWindow && !root.sameWindow(root.slotWindow(slot), sourceWindow)) continue
 
       var slotPoint = { x: slot.x, y: slot.y }
@@ -1472,6 +1480,9 @@ Item {
 
     property var entries: []
     property string region: ""
+    // Children of a group opt out of individual dragging: the drawer reorders
+    // as one block, and drop persistence addresses top-level entries by id.
+    property bool draggable: true
 
     visible: entries.length > 0
     // A hidden list must not build its modules. The center section declares
@@ -1497,6 +1508,7 @@ Item {
             required property var modelData
             entry: modelData
             region: moduleListRoot.region
+            draggable: moduleListRoot.draggable
           }
         }
       }
@@ -1515,10 +1527,20 @@ Item {
             required property var modelData
             entry: modelData
             region: moduleListRoot.region
+            draggable: moduleListRoot.draggable
           }
         }
       }
     }
+  }
+
+  // The child list for a group is a plain ModuleList, handed to BarGroup (a
+  // file type) as a Component. Passing it at runtime — rather than BarGroup
+  // naming ModuleList, or ModuleSlot naming an inline group component — is what
+  // keeps the bar's inline components from forming a resolution cycle.
+  Component {
+    id: groupListComponent
+    ModuleList {}
   }
 
   component ModuleSlot: Item {
@@ -1526,9 +1548,13 @@ Item {
 
     required property var entry
     property string region: ""
+    // Slots inside a group opt out of individual dragging; the group reorders
+    // as one block. Top-level slots are draggable as before.
+    property bool draggable: true
     readonly property string moduleName: root.entryId(entry)
     readonly property var moduleSettings: root.entrySettings(entry)
     readonly property string customType: root.customModuleType(entry)
+    readonly property bool isGroup: customType === "group"
     // Re-evaluate when the registry mutates (Component reference changes,
     // plugin enabled/disabled, etc.). Reading the `widgets` property creates
     // the binding dependency — the wrapped function call alone wouldn't.
@@ -1542,6 +1568,7 @@ Item {
     readonly property bool commandCustom: customType === "command"
     readonly property bool registered: registryComponent !== null
     readonly property var activeItem: {
+      if (isGroup) return groupLoader.item
       if (registered) return registryLoader.item
       if (qmlCustom) return qmlLoader.item
       return componentLoader.item
@@ -1585,11 +1612,31 @@ Item {
 
     Loader {
       id: componentLoader
-      active: !slot.qmlCustom && !slot.registered
+      active: !slot.qmlCustom && !slot.registered && !slot.isGroup
       sourceComponent: slot.commandCustom ? customCommandModuleComponent : emptyModuleComponent
       anchors.fill: parent
       opacity: slot.dragSource ? 0.22 : 1.0
       onLoaded: {
+        slot.injectProps()
+        Qt.callLater(slot.injectProps)
+      }
+    }
+
+    Loader {
+      id: groupLoader
+      active: slot.isGroup
+      // Loaded from a file (not an inline component) so the group -> slot -> group
+      // recursion does not make the bar's inline components form a cycle.
+      source: slot.isGroup ? Qt.resolvedUrl("BarGroup.qml") : ""
+      anchors.fill: parent
+      opacity: slot.dragSource ? 0.22 : 1.0
+      onLoaded: {
+        if (item) {
+          item.bar = root
+          item.entry = slot.entry
+          item.region = slot.region
+          item.listComponent = groupListComponent
+        }
         slot.injectProps()
         Qt.callLater(slot.injectProps)
       }
@@ -1654,7 +1701,11 @@ Item {
       property bool suppressClick: false
       property real pressedX: 0
       property real pressedY: 0
+      // A group and its children are not individually draggable: the group has
+      // no id to persist a move against, and its children reorder as one block.
+      // Clicks still route normally — only drag initiation is gated here.
       readonly property bool canReorder: root.shell && typeof root.shell.mutateShellConfig === "function"
+        && slot.draggable && !slot.isGroup
       readonly property real dragThreshold: Style.space(4)
 
       anchors.fill: parent

--- a/shell/plugins/bar/BarGroup.qml
+++ b/shell/plugins/bar/BarGroup.qml
@@ -33,9 +33,10 @@ Item {
     bar: root.bar
     collapsedByDefault: root.groupSettings.collapsed !== false
     expandOnHover: root.groupSettings.expandOnHover !== false
-    // Defaults to the tray drawer's chevron; an entry may override it via "icon".
+    // A distinct default glyph so a group next to the tray drawer does not read
+    // as a second tray; an entry may override it via "icon".
     icon: root.groupSettings.icon !== undefined && root.groupSettings.icon !== null
-      ? String(root.groupSettings.icon) : "\uf053"
+      ? String(root.groupSettings.icon) : "\uf141"
 
     contentComponent: Component {
       Loader {

--- a/shell/plugins/bar/BarGroup.qml
+++ b/shell/plugins/bar/BarGroup.qml
@@ -1,0 +1,52 @@
+import QtQuick
+import qs.Ui
+import "BarModel.js" as BarModel
+
+// A collapsible group of bar widgets. Kept in its own file rather than an inline
+// component of Bar.qml on purpose: a group contains widget slots, and a widget
+// slot may itself be a group, so an inline component would make Bar.qml's
+// components form a resolution cycle — which QML forbids ("Inline components
+// form a cycle!"). A file type can be referenced recursively, so the recursion
+// lives here.
+//
+// The children are rendered by a ModuleList handed in as `listComponent` (a
+// runtime Component created by Bar.qml), so this file never names the bar's
+// inline ModuleList / ModuleSlot types and the cycle stays broken.
+Item {
+  id: root
+
+  property var bar: null
+  property var entry: null
+  property string region: ""
+  // A bare ModuleList component supplied by the bar; its entries/region are
+  // filled once it loads.
+  property Component listComponent: null
+
+  readonly property var groupSettings: BarModel.entrySettings(entry)
+
+  implicitWidth: collapsible.implicitWidth
+  implicitHeight: collapsible.implicitHeight
+
+  BarCollapsible {
+    id: collapsible
+    anchors.fill: parent
+    bar: root.bar
+    collapsedByDefault: root.groupSettings.collapsed !== false
+    expandOnHover: root.groupSettings.expandOnHover !== false
+    // Defaults to the tray drawer's chevron; an entry may override it via "icon".
+    icon: root.groupSettings.icon !== undefined && root.groupSettings.icon !== null
+      ? String(root.groupSettings.icon) : "\uf053"
+
+    contentComponent: Component {
+      Loader {
+        sourceComponent: root.listComponent
+        onLoaded: {
+          if (!item) return
+          item.entries = BarModel.groupItems(root.entry)
+          item.region = root.region
+          item.draggable = false
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -123,6 +123,27 @@ function customModuleType(entry) {
   return ""
 }
 
+// A group is a structural entry that wraps child widgets behind a collapsible
+// chevron. It carries type:"group" and an items[] array; an id is optional and
+// only used for addressing. Because customModuleType() reports "group" for it,
+// the inline-settings delta already treats any change inside a group as
+// structural and rebuilds the section — groups are opaque to the live patch for
+// now, which is correct if not yet optimal.
+function isGroupEntry(entry) {
+  return isPlainObject(entry) && String(entry.type || "") === "group"
+}
+
+function groupItems(entry) {
+  if (!isGroupEntry(entry)) return []
+  var items = entry.items
+  // Array.isArray() returns false for an array created in another QML JS realm
+  // (the entry is built in Bar.qml but read from BarGroup.qml), so accept any
+  // length-shaped value too rather than dropping the children.
+  if (Array.isArray(items)) return items
+  if (items && typeof items.length === "number") return items
+  return []
+}
+
 function customModulePath(entry, home, configDir) {
   var settings = entrySettings(entry)
   var name = entryId(entry)
@@ -226,6 +247,8 @@ if (typeof module !== "undefined") {
     expandPath: expandPath,
     customModuleSafeName: customModuleSafeName,
     customModuleType: customModuleType,
-    customModulePath: customModulePath
+    customModulePath: customModulePath,
+    isGroupEntry: isGroupEntry,
+    groupItems: groupItems
   }
 }

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -138,10 +138,15 @@ function groupItems(entry) {
   var items = entry.items
   // Array.isArray() returns false for an array created in another QML JS realm
   // (the entry is built in Bar.qml but read from BarGroup.qml), so accept
-  // array-like objects too rather than dropping the children.
+  // array-like objects too rather than dropping the children. Convert any
+  // accepted array-like object into a real local Array so QML/JS consumers can
+  // safely use Array semantics.
   if (Array.isArray(items)) return items
-  if (items && typeof items === "object" && typeof items.length === "number")
-    return items
+  if (items && typeof items === "object" && typeof items.length === "number") {
+    var result = []
+    for (var i = 0; i < items.length; ++i) result.push(items[i])
+    return result
+  }
   return []
 }
 

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -137,10 +137,11 @@ function groupItems(entry) {
   if (!isGroupEntry(entry)) return []
   var items = entry.items
   // Array.isArray() returns false for an array created in another QML JS realm
-  // (the entry is built in Bar.qml but read from BarGroup.qml), so accept any
-  // length-shaped value too rather than dropping the children.
+  // (the entry is built in Bar.qml but read from BarGroup.qml), so accept
+  // array-like objects too rather than dropping the children.
   if (Array.isArray(items)) return items
-  if (items && typeof items.length === "number") return items
+  if (items && typeof items === "object" && typeof items.length === "number")
+    return items
   return []
 }
 

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -136,12 +136,12 @@ function isGroupEntry(entry) {
 function groupItems(entry) {
   if (!isGroupEntry(entry)) return []
   var items = entry.items
-  // Array.isArray() returns false for an array created in another QML JS realm
-  // (the entry is built in Bar.qml but read from BarGroup.qml), so accept
-  // array-like objects too rather than dropping the children. Convert any
-  // accepted array-like object into a real local Array so QML/JS consumers can
-  // safely use Array semantics.
-  if (Array.isArray(items)) return items
+  // Always return a fresh local Array so callers get real Array semantics and
+  // can't mutate the config-derived layout in place. Array.isArray() also
+  // returns false for an array created in another QML JS realm (the entry is
+  // built in Bar.qml but read from BarGroup.qml), so accept array-like objects
+  // too rather than dropping the children.
+  if (Array.isArray(items)) return items.slice()
   if (items && typeof items === "object" && typeof items.length === "number") {
     var result = []
     for (var i = 0; i < items.length; ++i) result.push(items[i])

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -108,8 +108,8 @@ Group settings:
   an `{ id, ...settings }` object, or a custom `command`/`qml` module), so
   children keep their own settings, panels, and IPC ids.
 - `collapsed` — start collapsed (default `true`). Set `false` to start open.
-- `expandOnHover` — reveal on hover (default `true`). With it `false`, click the
-  chevron to toggle.
+- `expandOnHover` — reveal on hover (default `true`). With it set to `false`, click
+  the chevron to toggle.
 - `icon` — override the chevron glyph.
 - `id` — optional; only needed if you want to address the group by id.
 

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -74,6 +74,54 @@ Example `shell.json` (bar subtree only shown):
 
 The `omarchy.indicators` widget loads individual bar indicators from `indicators/`. Omit `items` (or set it to an empty array) to show all indicators in the default order, or set `items` to a subset such as `["Dnd", "Reminder", "NightLight"]`. Set `alwaysShow` to `true` to keep inactive indicators visible instead of revealing them only on hover. Multiple `omarchy.indicators` instances are allowed, so different sections can show different subsets.
 
+## Widget groups
+
+Wrap several widgets in a `type: "group"` entry to tuck them behind a collapsible
+chevron that reveals them on hover — the same gesture the system tray drawer
+uses. A group is just another entry in the same flat `bar.layout.<section>` array,
+so existing layouts keep working unchanged and no migration is needed.
+
+```json
+{
+  "version": 1,
+  "bar": {
+    "layout": {
+      "right": [
+        {
+          "type": "group",
+          "collapsed": true,
+          "items": [
+            { "id": "omarchy.agents" },
+            { "id": "omarchy.system-update" }
+          ]
+        },
+        { "id": "omarchy.audio" }
+      ]
+    }
+  }
+}
+```
+
+Group settings:
+
+- `items` — the child entries. Each child is an ordinary bar entry (a string id,
+  an `{ id, ...settings }` object, or a custom `command`/`qml` module), so
+  children keep their own settings, panels, and IPC ids.
+- `collapsed` — start collapsed (default `true`). Set `false` to start open.
+- `expandOnHover` — reveal on hover (default `true`). With it `false`, click the
+  chevron to toggle.
+- `icon` — override the chevron glyph.
+- `id` — optional; only needed if you want to address the group by id.
+
+Left-clicking the chevron pins the drawer open so it stays revealed after the
+pointer leaves; clicking again unpins it.
+
+A group is repositioned as one block by editing `shell.json`; its widgets are not
+individually draggable and dragging the group itself is not yet supported.
+Widgets inside a group are reachable by id (`omarchy toggle <id>`) but not by the
+positional panel hotkeys, which count only top-level widgets. Do not nest
+`omarchy.tray` inside a group.
+
 ## Orientation
 
 All widgets work in `top`, `bottom`, `left`, and `right` positions. Popups anchor on the side opposite the bar edge, sliding into the workspace. Vertical bars use 28px width; widgets that show text fall back to compact icon-only forms (e.g. `media` hides its scrolling label).

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -11,7 +11,6 @@ BarWidget {
   id: root
   moduleName: "omarchy.tray"
 
-  property bool expanded: false
   property bool managePopupOpen: false
   property bool trayMenuOpen: false
   property var activeTrayItem: null
@@ -27,11 +26,8 @@ BarWidget {
   readonly property int trayItemExtent: Style.bar.iconSlot
   readonly property int trayItemGap: 0
   readonly property int trayJoinGap: 0
-  readonly property int drawerExtent: drawerCount > 0 ? drawerCount * trayItemExtent + (drawerCount - 1) * trayItemGap : 0
   // Match Waybar's group/tray-expander drawer transition-duration.
   readonly property int animationDuration: 600
-  property real revealProgress: expanded ? 1 : 0
-  readonly property real revealExtent: drawerExtent * revealProgress
 
   // Submenu drill-down state. QsMenuEntry.display() renders a *platform* menu,
   // which Quickshell refuses unless the shell root sets `//@ pragma
@@ -215,10 +211,6 @@ BarWidget {
   implicitWidth: root.vertical ? root.barSize : trayContent.implicitWidth
   implicitHeight: root.vertical ? trayContent.implicitHeight : root.barSize
 
-  Behavior on revealProgress {
-    NumberAnimation { duration: root.animationDuration; easing.type: Easing.OutCubic }
-  }
-
   Loader {
     id: trayContent
     anchors.fill: parent
@@ -231,65 +223,25 @@ BarWidget {
     Item {
       id: horizontalTrayRoot
 
-      readonly property int pinnedWidth: pinnedRow.implicitWidth
-      readonly property int drawerBlockWidth: root.allItems.length > 0 ? expandIcon.implicitWidth + root.drawerExtent : 0
+      readonly property int drawerBlockWidth: horizontalDrawer.visible ? horizontalDrawer.implicitWidth : 0
 
-      implicitWidth: pinnedWidth + drawerBlockWidth
+      implicitWidth: drawerBlockWidth + pinnedRow.implicitWidth
       implicitHeight: root.barSize
 
-      // Mask out the empty area the collapsed drawer reserves for its slide-in,
-      // so hovering it doesn't trigger expand and clicks pass through.
-      containmentMask: QtObject {
-        function contains(point: point): bool {
-          if (point.y < 0 || point.y > horizontalTrayRoot.height) return false
-          // Drawer reveals leftward; chevron sits at the right end when collapsed
-          // and slides left as it opens. The visible region starts at the chevron.
-          var chevronX = root.drawerExtent - root.revealExtent
-          if (point.x >= chevronX && point.x <= horizontalTrayRoot.drawerBlockWidth) return true
-          // Pinned items, placed to the right of the drawer block.
-          var pinnedStart = horizontalTrayRoot.drawerBlockWidth
-          return point.x >= pinnedStart && point.x <= horizontalTrayRoot.implicitWidth
-        }
-      }
-
-      Item {
-        id: drawerArea
-        x: 0
-        width: horizontalTrayRoot.drawerBlockWidth
-        height: root.barSize
+      BarCollapsible {
+        id: horizontalDrawer
+        bar: root.bar
+        reserveSpace: true
+        pinOnClick: false
+        animationDuration: root.animationDuration
         visible: root.allItems.length > 0
-
-        HoverHandler {
-          onHoveredChanged: root.expanded = hovered
+        onChevronPressed: function(button) {
+          if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
         }
-
-        BarIconButton {
-          id: expandIcon
-          bar: root.bar
-          width: implicitWidth
-          height: implicitHeight
-          x: root.drawerExtent - root.revealExtent
-          text: "\uf053"
-          onPressed: function(button) {
-            if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
-          }
-        }
-
-        Item {
-          id: trayClip
-          x: expandIcon.width
-          anchors.verticalCenter: parent.verticalCenter
-          width: root.drawerExtent
-          height: root.barSize
-          clip: true
-
+        contentComponent: Component {
           Row {
-            id: trayIcons
-            x: root.drawerExtent - root.revealExtent
-            anchors.verticalCenter: parent.verticalCenter
             spacing: root.trayItemGap
             layer.enabled: true
-
             Repeater {
               model: root.drawerItems
               TrayItem {}
@@ -300,7 +252,7 @@ BarWidget {
 
       Row {
         id: pinnedRow
-        x: drawerArea.x + horizontalTrayRoot.drawerBlockWidth
+        x: horizontalTrayRoot.drawerBlockWidth
         anchors.verticalCenter: parent.verticalCenter
         spacing: root.trayItemGap
         leftPadding: root.pinnedItems.length > 0 && root.allItems.length > 0 ? root.trayJoinGap : 0
@@ -318,61 +270,25 @@ BarWidget {
     Item {
       id: verticalTrayRoot
 
-      readonly property int pinnedHeight: pinnedCol.implicitHeight
-      readonly property int drawerBlockHeight: root.allItems.length > 0 ? expandIcon.implicitHeight + root.drawerExtent : 0
+      readonly property int drawerBlockHeight: verticalDrawer.visible ? verticalDrawer.implicitHeight : 0
 
       implicitWidth: root.barSize
-      implicitHeight: pinnedHeight + drawerBlockHeight
+      implicitHeight: drawerBlockHeight + pinnedCol.implicitHeight
 
-      containmentMask: QtObject {
-        function contains(point: point): bool {
-          if (point.x < 0 || point.x > verticalTrayRoot.width) return false
-          var chevronY = root.drawerExtent - root.revealExtent
-          if (point.y >= chevronY && point.y <= verticalTrayRoot.drawerBlockHeight) return true
-          var pinnedStart = verticalTrayRoot.drawerBlockHeight
-          return point.y >= pinnedStart && point.y <= verticalTrayRoot.implicitHeight
-        }
-      }
-
-      Item {
-        id: drawerArea
-        y: 0
-        width: root.barSize
-        height: verticalTrayRoot.drawerBlockHeight
+      BarCollapsible {
+        id: verticalDrawer
+        bar: root.bar
+        reserveSpace: true
+        pinOnClick: false
+        animationDuration: root.animationDuration
         visible: root.allItems.length > 0
-
-        HoverHandler {
-          onHoveredChanged: root.expanded = hovered
+        onChevronPressed: function(button) {
+          if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
         }
-
-        BarIconButton {
-          id: expandIcon
-          bar: root.bar
-          width: implicitWidth
-          height: implicitHeight
-          y: root.drawerExtent - root.revealExtent
-          text: "\uf053"
-          textRotation: 90
-          onPressed: function(button) {
-            if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
-          }
-        }
-
-        Item {
-          id: trayClip
-          y: expandIcon.height
-          anchors.horizontalCenter: parent.horizontalCenter
-          width: root.barSize
-          height: root.drawerExtent
-          clip: true
-
+        contentComponent: Component {
           Column {
-            id: trayIcons
-            y: root.drawerExtent - root.revealExtent
-            anchors.horizontalCenter: parent.horizontalCenter
             spacing: root.trayItemGap
             layer.enabled: true
-
             Repeater {
               model: root.drawerItems
               TrayItem {}
@@ -383,7 +299,7 @@ BarWidget {
 
       Column {
         id: pinnedCol
-        y: drawerArea.y + verticalTrayRoot.drawerBlockHeight
+        y: verticalTrayRoot.drawerBlockHeight
         anchors.horizontalCenter: parent.horizontalCenter
         spacing: root.trayItemGap
         topPadding: root.pinnedItems.length > 0 && root.allItems.length > 0 ? root.trayJoinGap : 0

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -234,6 +234,10 @@ BarWidget {
         reserveSpace: true
         pinOnClick: false
         animationDuration: root.animationDuration
+        // Size explicitly to the reserved drawer block so the hover/click area
+        // is unambiguous (Item defaults to implicit size, but be explicit here).
+        width: implicitWidth
+        height: root.barSize
         visible: root.allItems.length > 0
         onChevronPressed: function(button) {
           if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
@@ -281,6 +285,10 @@ BarWidget {
         reserveSpace: true
         pinOnClick: false
         animationDuration: root.animationDuration
+        // Size explicitly to the reserved drawer block so the hover/click area
+        // is unambiguous (Item defaults to implicit size, but be explicit here).
+        width: root.barSize
+        height: implicitHeight
         visible: root.allItems.length > 0
         onChevronPressed: function(button) {
           if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen

--- a/test/acceptance.d/bar-group-test.sh
+++ b/test/acceptance.d/bar-group-test.sh
@@ -17,8 +17,12 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 abs_omarchy="$HOME/.local/share/omarchy"
 
+# Track whether OMARCHY_PATH was set in the session env, so restore() puts it
+# back exactly — unsetting it when it was never set rather than defaulting it to
+# a value and permanently changing the environment.
 original_path=$(systemctl --user show-environment 2>/dev/null | sed -n 's/^OMARCHY_PATH=//p' | tail -1)
-: "${original_path:=/usr/share/omarchy}"
+had_omarchy_path=0
+[[ -n $original_path ]] && had_omarchy_path=1
 
 config_dir="$HOME/.config/omarchy"
 config="$config_dir/shell.json"
@@ -38,7 +42,11 @@ restore() {
     rm -f "$config"
   fi
   rm -f "$backup"
-  systemctl --user set-environment OMARCHY_PATH="$original_path" >/dev/null 2>&1 || true
+  if (( had_omarchy_path )); then
+    systemctl --user set-environment OMARCHY_PATH="$original_path" >/dev/null 2>&1 || true
+  else
+    systemctl --user unset-environment OMARCHY_PATH >/dev/null 2>&1 || true
+  fi
   omarchy-restart-shell >/dev/null 2>&1 || true
 }
 trap restore EXIT

--- a/test/acceptance.d/bar-group-test.sh
+++ b/test/acceptance.d/bar-group-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Exercise the collapsible widget group: a `type: "group"` layout entry that
+# wraps children behind a chevron and reveals them like the tray drawer. The
+# regression this guards is that older code dropped id-less group entries during
+# layout normalization, so the grouped widgets vanished. Here the bar must keep
+# rendering with a group configured, in both collapsed and expanded states.
+#
+# The acceptance harness syncs this checkout into ~/.local/share/omarchy but
+# leaves the live shell running the stock system path, so first repoint the
+# session at the synced checkout and restart, or the shell under test would be
+# the stock one without the group code.
+
+abs_omarchy="$HOME/.local/share/omarchy"
+
+original_path=$(systemctl --user show-environment 2>/dev/null | sed -n 's/^OMARCHY_PATH=//p' | tail -1)
+: "${original_path:=/usr/share/omarchy}"
+
+config_dir="$HOME/.config/omarchy"
+config="$config_dir/shell.json"
+backup="$(mktemp)"
+had_config=0
+
+mkdir -p "$config_dir"
+if [[ -f $config ]]; then
+  cp "$config" "$backup"
+  had_config=1
+fi
+
+restore() {
+  if (( had_config )); then
+    cp "$backup" "$config"
+  else
+    rm -f "$config"
+  fi
+  rm -f "$backup"
+  systemctl --user set-environment OMARCHY_PATH="$original_path" >/dev/null 2>&1 || true
+  omarchy-restart-shell >/dev/null 2>&1 || true
+}
+trap restore EXIT
+
+# A layout with the tray drawer and a widget group side by side, so a captured
+# screenshot shows the group chevron behaving like the tray's.
+write_group_config() {
+  local collapsed="$1"
+
+  cat >"$config" <<JSON
+{
+  "version": 1,
+  "bar": {
+    "position": "top",
+    "centerAnchor": "omarchy.clock",
+    "layout": {
+      "left": [ { "id": "omarchy.menu" }, { "id": "omarchy.workspaces" } ],
+      "center": [ { "id": "omarchy.clock", "format": "dddd HH:mm" } ],
+      "right": [
+        { "id": "omarchy.tray" },
+        {
+          "type": "group",
+          "collapsed": $collapsed,
+          "items": [
+            { "id": "omarchy.system-update" },
+            { "id": "omarchy.bluetooth" },
+            { "id": "omarchy.network" }
+          ]
+        },
+        { "id": "omarchy.audio" },
+        { "id": "omarchy.power" }
+      ]
+    }
+  }
+}
+JSON
+}
+
+# Load the synced checkout so the code under test is what actually renders.
+write_group_config true
+systemctl --user set-environment OMARCHY_PATH="$abs_omarchy"
+omarchy-restart-shell >/dev/null 2>&1 || true
+wait_until "shell restarts on the synced checkout with a collapsed group" 40 layer_on_screen "omarchy-bar"
+sleep 3
+screenshot "success-bar-group-collapsed"
+pass "bar renders a collapsed widget group without dropping it"
+
+# Expanded (collapsed:false starts the drawer open) so a screenshot captures the
+# revealed widgets — the state a hover produces. Adding/removing a group is a
+# structural change, so a config reload rebuilds the section.
+write_group_config false
+omarchy-shell shell reloadConfig >/dev/null 2>&1 || omarchy-restart-shell >/dev/null 2>&1 || true
+sleep 3
+wait_until "bar renders with an expanded group" 20 layer_on_screen "omarchy-bar"
+screenshot "success-bar-group-expanded"
+pass "bar renders an expanded widget group with its children visible"

--- a/test/acceptance.d/bar-group-test.sh
+++ b/test/acceptance.d/bar-group-test.sh
@@ -17,12 +17,13 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 abs_omarchy="$HOME/.local/share/omarchy"
 
-# Track whether OMARCHY_PATH was set in the session env, so restore() puts it
-# back exactly — unsetting it when it was never set rather than defaulting it to
-# a value and permanently changing the environment.
-original_path=$(systemctl --user show-environment 2>/dev/null | sed -n 's/^OMARCHY_PATH=//p' | tail -1)
+# Track whether OMARCHY_PATH is present in the session env by its line (not a
+# non-empty value), so restore() puts it back exactly — including an empty value
+# — and only unsets it when it was truly absent.
+env_dump=$(systemctl --user show-environment 2>/dev/null)
 had_omarchy_path=0
-[[ -n $original_path ]] && had_omarchy_path=1
+grep -q '^OMARCHY_PATH=' <<<"$env_dump" && had_omarchy_path=1
+original_path=$(sed -n 's/^OMARCHY_PATH=//p' <<<"$env_dump" | tail -1)
 
 config_dir="$HOME/.config/omarchy"
 config="$config_dir/shell.json"

--- a/test/shell.d/bar-group-test.sh
+++ b/test/shell.d/bar-group-test.sh
@@ -44,7 +44,7 @@ assertEqual(
 
 // Layout normalization must keep group entries (they have no id of their own)
 // and normalize their children recursively, or the group would be dropped.
-assert(/entry\.type === "group"/.test(utilSource), 'layout normalization preserves group entries')
+assert(/entry\.type[\s\S]*?=== "group"/.test(utilSource), 'layout normalization preserves group entries')
 assert(
   /group\.items = normalizeLayoutSection\(group\.items\)/.test(utilSource),
   'layout normalization recurses into group items'

--- a/test/shell.d/bar-group-test.sh
+++ b/test/shell.d/bar-group-test.sh
@@ -12,6 +12,7 @@ const utilSource = fs.readFileSync(root + '/shell/Commons/Util.qml', 'utf8')
 const uiQmldir = fs.readFileSync(root + '/shell/Ui/qmldir', 'utf8')
 const collapsibleSource = fs.readFileSync(root + '/shell/Ui/BarCollapsible.qml', 'utf8')
 const barGroupSource = fs.readFileSync(root + '/shell/plugins/bar/BarGroup.qml', 'utf8')
+const traySource = fs.readFileSync(root + '/shell/plugins/bar/widgets/Tray.qml', 'utf8')
 
 // A type:"group" entry is a structural wrapper the bar renders as a collapsible
 // drawer of child widgets. BarModel recognises it and reads its children.
@@ -81,4 +82,14 @@ assert(
   'the collapsible animates its reveal with an OutCubic curve'
 )
 assert(/animationDuration: 600/.test(collapsibleSource), 'the collapsible matches the tray drawer duration')
+
+// The tray drawer and the widget group share BarCollapsible rather than forking
+// the collapse/expand animation. The collapsible offers the tray's reserve-space
+// mode and a chevron-press hook for its manage popup, and the tray drives both
+// through it instead of running its own reveal.
+assert(/property bool reserveSpace/.test(collapsibleSource), 'the collapsible offers a reserve-space (tray) mode')
+assert(/signal chevronPressed/.test(collapsibleSource), 'the collapsible exposes chevron presses for the tray manage popup')
+assert(/BarCollapsible \{[\s\S]*?reserveSpace: true/.test(traySource), 'the tray drawer uses BarCollapsible in reserve-space mode')
+assert(/onChevronPressed:[\s\S]*?managePopupOpen/.test(traySource), 'the tray opens its manage popup from the shared chevron')
+assert(!/Behavior on revealProgress/.test(traySource), 'the tray no longer runs its own forked reveal animation')
 JS

--- a/test/shell.d/bar-group-test.sh
+++ b/test/shell.d/bar-group-test.sh
@@ -26,6 +26,7 @@ assertDeepEqual(
   ['omarchy.agents', 'omarchy.system-update'],
   'bar reads a group child ids'
 )
+assert(bar.groupItems(group) !== group.items, 'bar returns a fresh group items array, not the config reference')
 assertDeepEqual(bar.groupItems({ id: 'omarchy.clock' }), [], 'a non-group has no group items')
 assertDeepEqual(bar.groupItems({ type: 'group' }), [], 'a group with no items reads as empty')
 assertEqual(bar.entryId(group), '', 'an id-less group has no entry id')

--- a/test/shell.d/bar-group-test.sh
+++ b/test/shell.d/bar-group-test.sh
@@ -78,10 +78,10 @@ assert(/if \(slot\.isGroup \|\| !slot\.draggable\) continue/.test(barSource), 'a
 // The shared collapsible is registered and reuses the tray drawer motion.
 assert(/BarCollapsible 1\.0 BarCollapsible\.qml/.test(uiQmldir), 'the shared collapsible is registered in the Ui module')
 assert(
-  /duration: root\.animationDuration; easing\.type: Easing\.OutCubic/.test(collapsibleSource),
+  /duration:\s*root\.animationDuration[\s\S]*?easing\.type:\s*Easing\.OutCubic/.test(collapsibleSource),
   'the collapsible animates its reveal with an OutCubic curve'
 )
-assert(/animationDuration: 600/.test(collapsibleSource), 'the collapsible matches the tray drawer duration')
+assert(/animationDuration:\s*600/.test(collapsibleSource), 'the collapsible matches the tray drawer duration')
 
 // The tray drawer and the widget group share BarCollapsible rather than forking
 // the collapse/expand animation. The collapsible offers the tray's reserve-space

--- a/test/shell.d/bar-group-test.sh
+++ b/test/shell.d/bar-group-test.sh
@@ -43,6 +43,13 @@ assertEqual(
   'bar rebuilds when a group changes rather than patching in place'
 )
 
+// The assertions above run BarModel's exported helpers to validate behavior.
+// The source-text regex checks below are deliberate: they guard QML *structure*
+// the node harness cannot execute — e.g. that a group renders through the
+// BarGroup file rather than an inline component (the fix for a load-time
+// "inline components form a cycle" crash). Each is scoped to a specific
+// regression with no runtime equivalent in this suite.
+
 // Layout normalization must keep group entries (they have no id of their own)
 // and normalize their children recursively, or the group would be dropped.
 assert(/entry\.type[\s\S]*?=== "group"/.test(utilSource), 'layout normalization preserves group entries')

--- a/test/shell.d/bar-group-test.sh
+++ b/test/shell.d/bar-group-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const bar = requireFromRoot('shell/plugins/bar/BarModel.js')
+const barSource = fs.readFileSync(root + '/shell/plugins/bar/Bar.qml', 'utf8')
+const utilSource = fs.readFileSync(root + '/shell/Commons/Util.qml', 'utf8')
+const uiQmldir = fs.readFileSync(root + '/shell/Ui/qmldir', 'utf8')
+const collapsibleSource = fs.readFileSync(root + '/shell/Ui/BarCollapsible.qml', 'utf8')
+const barGroupSource = fs.readFileSync(root + '/shell/plugins/bar/BarGroup.qml', 'utf8')
+
+// A type:"group" entry is a structural wrapper the bar renders as a collapsible
+// drawer of child widgets. BarModel recognises it and reads its children.
+const group = { type: 'group', collapsed: true, items: [{ id: 'omarchy.agents' }, { id: 'omarchy.system-update' }] }
+assert(bar.isGroupEntry(group), 'bar recognises a group entry')
+assert(!bar.isGroupEntry({ id: 'omarchy.clock' }), 'a plain widget entry is not a group')
+assert(!bar.isGroupEntry('omarchy.clock'), 'a string entry is not a group')
+assert(!bar.isGroupEntry(null), 'a missing entry is not a group')
+assertDeepEqual(
+  bar.groupItems(group).map(bar.entryId),
+  ['omarchy.agents', 'omarchy.system-update'],
+  'bar reads a group child ids'
+)
+assertDeepEqual(bar.groupItems({ id: 'omarchy.clock' }), [], 'a non-group has no group items')
+assertDeepEqual(bar.groupItems({ type: 'group' }), [], 'a group with no items reads as empty')
+assertEqual(bar.entryId(group), '', 'an id-less group has no entry id')
+assertEqual(bar.customModuleType(group), 'group', 'a group reports its type')
+
+// A change anywhere inside a group is structural for the live patch: the delta
+// is null so the section rebuilds rather than patching a nested entry in place.
+assertEqual(
+  bar.inlineSettingsDelta(
+    { left: [group], center: [], right: [] },
+    { left: [{ type: 'group', collapsed: false, items: group.items }], center: [], right: [] }
+  ),
+  null,
+  'bar rebuilds when a group changes rather than patching in place'
+)
+
+// Layout normalization must keep group entries (they have no id of their own)
+// and normalize their children recursively, or the group would be dropped.
+assert(/entry\.type === "group"/.test(utilSource), 'layout normalization preserves group entries')
+assert(
+  /group\.items = normalizeLayoutSection\(group\.items\)/.test(utilSource),
+  'layout normalization recurses into group items'
+)
+
+// The bar renders a group through the shared collapsible container, not the
+// registry or custom-module loaders.
+assert(/readonly property bool isGroup: customType === "group"/.test(barSource), 'bar marks a group slot')
+assert(/if \(isGroup\) return groupLoader\.item/.test(barSource), 'bar routes a group slot to the group loader')
+
+// A group is rendered from the BarGroup *file* and handed a plain ModuleList as a
+// runtime Component. This is what keeps the group -> slot -> group recursion from
+// making the bar's inline components form a cycle (QML forbids that, and it is a
+// load-time crash, not something qmllint catches).
+assert(/source: slot\.isGroup \? Qt\.resolvedUrl\("BarGroup\.qml"\)/.test(barSource), 'bar loads a group from the BarGroup file, not an inline component')
+assert(/id: groupListComponent[\s\S]{0,40}ModuleList \{\}/.test(barSource), 'bar hands the group a plain ModuleList component')
+assert(/BarCollapsible \{/.test(barGroupSource), 'the group renders inside the shared collapsible')
+// Guard the cycle fix: the group file must not name the bar's inline types.
+const barGroupCode = barGroupSource.replace(/\/\/.*$/gm, '')
+assert(!/\bModuleList\b|\bModuleSlot\b/.test(barGroupCode), 'the group file names no inline bar types, so the recursion stays file-based')
+assert(
+  /active: !slot\.qmlCustom && !slot\.registered && !slot\.isGroup/.test(barSource),
+  'a group slot is kept out of the empty-module fallback'
+)
+
+// A group and its children are not draggable, and are excluded as drop targets,
+// so a reorder never tries to persist an id-less or nested entry.
+assert(/&& slot\.draggable && !slot\.isGroup/.test(barSource), 'a group is not a drag source')
+assert(/if \(slot\.isGroup \|\| !slot\.draggable\) continue/.test(barSource), 'a group is not a drop target')
+
+// The shared collapsible is registered and reuses the tray drawer motion.
+assert(/BarCollapsible 1\.0 BarCollapsible\.qml/.test(uiQmldir), 'the shared collapsible is registered in the Ui module')
+assert(
+  /duration: root\.animationDuration; easing\.type: Easing\.OutCubic/.test(collapsibleSource),
+  'the collapsible animates its reveal with an OutCubic curve'
+)
+assert(/animationDuration: 600/.test(collapsibleSource), 'the collapsible matches the tray drawer duration')
+JS


### PR DESCRIPTION
Adds a `type: "group"` bar-layout entry that tucks widgets behind a collapsible chevron and reveals them on hover the same drawer UX the system tray already provides. Addresses #6355.

```jsonc
{
  "type": "group",
  "collapsed": true,
  "items": [
    { "id": "omarchy.agents" },
    { "id": "omarchy.system-update" },
    { "id": "omarchy.bluetooth" }
  ]
}
```

## Design

- **Nesting primitive.** A group is just another entry in the flat `bar.layout.<section>` array whose `items[]` holds ordinary entries, so groups can go in any section and you can have more than one. Existing flat layouts are untouched **no migration**.
- **One shared drawer, not a fork.** The collapse/expand is extracted into `shell/Ui/BarCollapsible.qml`, and the **tray drawer is migrated onto it**, so the group and the tray share a single implementation of the 600ms OutCubic
  reveal instead of drifting. `BarCollapsible` has a space-saving mode (groups collapse to just the chevron) and a reserve-space mode (the tray keeps its width, chevron migrating).
- **Recursion done right.** The group renderer lives in its own file (`BarGroup.qml`) and receives its child list as a runtime `Component`, so the group → slot → group recursion doesn't make the bar's inline components form a QML cycle.
- **Distinct chevron.** A group defaults to an ellipsis glyph so a group next to the tray doesn't read as a second tray drawer; override with `"icon"`.

## Screenshots

| Collapsed | Expanded |
|---|---|
| <img width="1366" height="64" alt="1-group-collapsed" src="https://github.com/user-attachments/assets/50a5cd2b-5d67-461d-955a-b359d702293e" />| <img width="1366" height="72" alt="2-group-expanded" src="https://github.com/user-attachments/assets/d9b5562a-c9d2-47cf-b4df-ae523b6bc0b3" />|

Tray drawer (`‹`) and a group (`⋯`) side by side, visually distinct:
_3-tray-and-group-distinct-chevrons.png_
<img width="1366" height="72" alt="3-tray-and-group-distinct-chevrons" src="https://github.com/user-attachments/assets/3cb1ae72-e401-40cc-ab66-fc9ddcdfa0f7" />

## Testing

- `test/shell.d/bar-group-test.sh` BarModel/normalization + guards that the tray shares `BarCollapsible` (can't silently re-fork).
- `test/acceptance.d/bar-group-test.sh` graphical: collapsed + expanded states.
- `qmllint` clean; verified live on Omarchy 4.0.
-  Existing `tray` / `tray-menu` tests still pass.

