### PR TITLE
Remove unsafe Ghostty epoll workaround

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -36,6 +36,3 @@ keybind = super+control+shift+alt+arrow_right=resize_split:right,100
 
 # Slowdown mouse scrolling
 mouse-scroll-multiplier = 0.95
-
-# Fix general slowness on hyprland (https://github.com/ghostty-org/ghostty/discussions/3224)
-async-backend = epoll

--- a/migrations/1786790068.sh
+++ b/migrations/1786790068.sh
@@ -1,0 +1,10 @@
+echo "Stop forcing Ghostty's epoll backend"
+
+ghostty_config="$HOME/.config/ghostty/config"
+
+[[ -f $ghostty_config ]] || exit 0
+
+sed -i --follow-symlinks '\|^# Fix general slowness on hyprland (https://github\.com/ghostty-org/ghostty/discussions/3224)$| {
+  $!N
+  \|^# Fix general slowness on hyprland (https://github\.com/ghostty-org/ghostty/discussions/3224)\nasync-backend = epoll$|d
+}' "$ghostty_config"

--- a/test/shell.d/ghostty-epoll-migration-test.sh
+++ b/test/shell.d/ghostty-epoll-migration-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1786790068.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+ghostty_config="$home/.config/ghostty/config"
+workaround_comment="# Fix general slowness on hyprland (https://github.com/ghostty-org/ghostty/discussions/3224)"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+reset_config() {
+  mkdir -p "$(dirname "$ghostty_config")"
+  cp "$ROOT/config/ghostty/config" "$ghostty_config"
+}
+
+reset_config
+printf '\n%s\n%s\n' "$workaround_comment" 'async-backend = epoll' >>"$ghostty_config"
+
+run_migration
+
+grep -qxF "$workaround_comment" "$ghostty_config" &&
+  fail "migration removes the Omarchy Ghostty workaround comment"
+grep -qxF 'async-backend = epoll' "$ghostty_config" &&
+  fail "migration removes the Omarchy Ghostty epoll setting"
+pass "migration removes the shipped Ghostty epoll workaround"
+
+before=$(sha256sum "$ghostty_config")
+run_migration
+[[ $before == $(sha256sum "$ghostty_config") ]] || fail "Ghostty epoll migration is idempotent"
+pass "Ghostty epoll migration is idempotent"
+
+reset_config
+printf '\n%s\n' 'async-backend = epoll' >>"$ghostty_config"
+run_migration
+grep -qxF 'async-backend = epoll' "$ghostty_config" ||
+  fail "migration preserves an independently configured epoll backend"
+pass "migration preserves an independently configured epoll backend"
+
+reset_config
+printf '\n%s\n%s\n' "$workaround_comment" 'async-backend = io_uring' >>"$ghostty_config"
+before=$(sha256sum "$ghostty_config")
+run_migration
+[[ $before == $(sha256sum "$ghostty_config") ]] ||
+  fail "migration preserves a customized Omarchy backend stanza"
+pass "migration preserves a customized Omarchy backend stanza"
+
+mkdir -p "$home/dotfiles"
+cp "$ROOT/config/ghostty/config" "$home/dotfiles/ghostty-config"
+printf '\n%s\n%s\n' "$workaround_comment" 'async-backend = epoll' >>"$home/dotfiles/ghostty-config"
+ln -sfn "$home/dotfiles/ghostty-config" "$ghostty_config"
+
+run_migration
+
+[[ -L $ghostty_config ]] || fail "migration preserves a symlinked Ghostty config"
+grep -qxF 'async-backend = epoll' "$home/dotfiles/ghostty-config" &&
+  fail "migration cleans the symlinked Ghostty config target"
+pass "migration writes through a symlinked Ghostty config"


### PR DESCRIPTION
## Summary

- Stop forcing Ghostty's epoll backend in the shipped config.
- Remove the exact Omarchy-authored workaround stanza from existing user configs.
- Preserve independently configured backends and symlinked dotfiles.
- Add focused migration regression coverage.

## Why

Omarchy currently forces `async-backend = epoll` as a workaround for Ghostty I/O pressure. The crash documented in #6868 occurs in that epoll-specific path and can repeatedly terminate Ghostty on x86_64.

Removing the override lets Ghostty select its default backend until the upstream queue crash is fixed.

Fixes #6868

## Testing

- `git diff --check`
- `bash -n migrations/1786790068.sh test/shell.d/ghostty-epoll-migration-test.sh`
- `bash test/shell.d/ghostty-epoll-migration-test.sh`
