### PR TITLE
Offer an explicit Tailscale DNS repair when nameservers are unreachable

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -64,7 +64,7 @@ Every panel takes the keyboard as well as the mouse: arrows move, Return activat
 
 Two more widgets appear on the bar only once you install the matching service from **Install → Service**, and both are worth knowing about because they do more than report status.
 
-The **Tailscale** panel connects and disconnects the tailnet, switches between accounts, and picks an exit node (your own machines and Mullvad regions both show up in that list). It also browses your machines — and with one selected, `s` sends files to it over Taildrop, which is the fastest way to move a file to your phone or another laptop. `c` copies the machine's IP, `n` its name, and `d` its full DNS name. There's a send button on each machine row too, if you'd rather click. The same thing from the terminal is `omarchy tailscale send <machine> [file...]`.
+The **Tailscale** panel connects and disconnects the tailnet, switches between accounts, and picks an exit node (your own machines and Mullvad regions both show up in that list). It also browses your machines — and with one selected, `s` sends files to it over Taildrop, which is the fastest way to move a file to your phone or another laptop. `c` copies the machine's IP, `n` its name, and `d` its full DNS name. There's a send button on each machine row too, if you'd rather click. The same thing from the terminal is `omarchy tailscale send <machine> [file...]`. If tailnet DNS is unreachable, the panel says so and asks whether to accept advertised subnet routes or keep local DNS, instead of silently sitting on Connected.
 
 The **Dropbox** panel handles login, shows how much storage you've used, and lists recently synced files.
 

--- a/manual/35-networking.md
+++ b/manual/35-networking.md
@@ -38,6 +38,8 @@ SSH is off until you turn it on with _Setup > Security > SSHD_, which starts the
 
 That gives you a Tailscale panel in the bar, which connects and disconnects the tailnet, switches accounts, and picks an exit node — your own machines and Mullvad regions both show up in the list. It also browses your machines, and that's where Taildrop lives: select a machine and press `s` to send it files, or `c`, `n`, and `d` to copy its IP, name, or full DNS name. The terminal equivalent is `omarchy tailscale send <machine> [file...]`, and files sent to you land in `~/Downloads` automatically.
 
+If the tailnet pushes DNS servers this machine cannot reach — usually because those servers sit on advertised subnet routes that have not been accepted — the panel says so instead of reporting a clean Connected state. It then asks you to accept those routes or to keep using local DNS. It will not accept routes on its own.
+
 Installing it also adds a web app for the Tailscale admin console.
 
 ## When it stops working

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -220,6 +220,77 @@ function mullvadCountryOptions(nodes) {
   return mullvadRegionOptions(nodes)
 }
 
+function isSubnetRoute(cidr) {
+  var value = String(cidr || "")
+  if (value === "" || value === "0.0.0.0/0" || value === "::/0") return false
+  if (/^100\./.test(value)) return false
+  if (/^fd7a:115c:a1e0:/i.test(value)) return false
+  return true
+}
+
+function advertisedRoutesFromPeers(rawPeers) {
+  var seen = {}
+  var result = []
+  if (!rawPeers || typeof rawPeers !== "object") return result
+  for (var id in rawPeers) {
+    var peer = rawPeers[id] || {}
+    var routes = peer.PrimaryRoutes || []
+    for (var i = 0; i < routes.length; i++) {
+      var route = String(routes[i] || "")
+      if (!isSubnetRoute(route) || seen[route]) continue
+      seen[route] = true
+      result.push(route)
+    }
+  }
+  result.sort()
+  return result
+}
+
+function formatRouteSummary(routes, limit) {
+  var values = Array.isArray(routes) ? routes.slice() : []
+  var cap = typeof limit === "number" && limit > 0 ? limit : 4
+  if (values.length === 0) return ""
+  if (values.length <= cap) return values.join(", ")
+  return values.slice(0, cap).join(", ") + ", and " + (values.length - cap) + " more"
+}
+
+function classifyHealth(health) {
+  var messages = Array.isArray(health) ? health : []
+  var notices = []
+  var dnsUnreachable = false
+  var routesNotAccepted = false
+  for (var i = 0; i < messages.length; i++) {
+    var text = String(messages[i] || "").trim()
+    if (text === "") continue
+    notices.push(text)
+    if (/can'?t reach the configured DNS servers/i.test(text)) dnsUnreachable = true
+    if (/advertising routes but --accept-routes is false/i.test(text)) routesNotAccepted = true
+  }
+  return {
+    notices: notices,
+    dnsUnreachable: dnsUnreachable,
+    routesNotAccepted: routesNotAccepted
+  }
+}
+
+function dnsRepairActions(dnsUnreachable, routesNotAccepted) {
+  var actions = []
+  if (!dnsUnreachable) return actions
+  if (routesNotAccepted) {
+    actions.push({
+      id: "routes",
+      title: "Accept subnet routes",
+      subtitle: "Reach the tailnet's DNS servers via advertised routes"
+    })
+  }
+  actions.push({
+    id: "dns",
+    title: "Don't use tailnet DNS",
+    subtitle: "Keep using this machine's DNS resolvers"
+  })
+  return actions
+}
+
 function parseStatus(raw) {
   var text = String(raw || "").trim()
   if (text === "") return { ok: true, unavailable: true, message: "Disconnected" }
@@ -232,6 +303,8 @@ function parseStatus(raw) {
     var peers = []
     var exitNodes = []
     var rawPeers = data.Peer || {}
+    var health = classifyHealth(data.Health)
+    var advertisedRoutes = advertisedRoutesFromPeers(rawPeers)
 
     for (var id in rawPeers) {
       var peer = rawPeers[id] || {}
@@ -263,7 +336,9 @@ function parseStatus(raw) {
       selfUserId: String(self.UserID || ""),
       fileSharing: hasFileSharing(self),
       peers: peers,
-      exitNodes: exitNodes
+      exitNodes: exitNodes,
+      health: health,
+      advertisedRoutes: advertisedRoutes
     }
   } catch (e) {
     return { ok: false, unavailable: true, message: "Status error", error: "Failed to parse tailscale status" }
@@ -319,6 +394,11 @@ if (typeof module !== "undefined") {
     parseExitNodeList: parseExitNodeList,
     mullvadRegionOptions: mullvadRegionOptions,
     mullvadCountryOptions: mullvadCountryOptions,
+    isSubnetRoute: isSubnetRoute,
+    advertisedRoutesFromPeers: advertisedRoutesFromPeers,
+    formatRouteSummary: formatRouteSummary,
+    classifyHealth: classifyHealth,
+    dnsRepairActions: dnsRepairActions,
     parseStatus: parseStatus,
     parseAccounts: parseAccounts
   }

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -220,10 +220,18 @@ function mullvadCountryOptions(nodes) {
   return mullvadRegionOptions(nodes)
 }
 
+function isCgnatIPv4(cidr) {
+  var match = String(cidr || "").match(/^(\d+)\.(\d+)\./)
+  if (!match) return false
+  var first = parseInt(match[1], 10)
+  var second = parseInt(match[2], 10)
+  return first === 100 && second >= 64 && second <= 127
+}
+
 function isSubnetRoute(cidr) {
   var value = String(cidr || "")
   if (value === "" || value === "0.0.0.0/0" || value === "::/0") return false
-  if (/^100\./.test(value)) return false
+  if (isCgnatIPv4(value)) return false
   if (/^fd7a:115c:a1e0:/i.test(value)) return false
   return true
 }
@@ -394,6 +402,7 @@ if (typeof module !== "undefined") {
     parseExitNodeList: parseExitNodeList,
     mullvadRegionOptions: mullvadRegionOptions,
     mullvadCountryOptions: mullvadCountryOptions,
+    isCgnatIPv4: isCgnatIPv4,
     isSubnetRoute: isSubnetRoute,
     advertisedRoutesFromPeers: advertisedRoutesFromPeers,
     formatRouteSummary: formatRouteSummary,

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -14,6 +14,7 @@ Panel {
 
   property string focusSection: "header"
   property int headerIndex: 0
+  property int dnsActionIndex: 0
   property int accountIndex: 0
   property int peerIndex: 0
   property int exitNodeIndex: 0
@@ -42,6 +43,8 @@ Panel {
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
+  readonly property bool showDnsRepair: tailscale.active && tailscale.dnsUnreachable
+  readonly property var dnsActions: dnsRepairActions()
   readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
   readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
@@ -56,6 +59,35 @@ Panel {
   readonly property color barIconColor: tailscale.active ? barForeground : Qt.darker(barForeground, 1.55)
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
+
+  function dnsRepairActions() {
+    var actions = []
+    if (!showDnsRepair) return actions
+    if (tailscale.routesNotAccepted) {
+      actions.push({
+        id: "routes",
+        title: "Accept subnet routes",
+        subtitle: "Reach the tailnet's DNS servers via advertised routes"
+      })
+    }
+    actions.push({
+      id: "dns",
+      title: "Don't use tailnet DNS",
+      subtitle: "Keep using this machine's DNS resolvers"
+    })
+    return actions
+  }
+
+  function selectedDnsAction() {
+    if (dnsActions.length === 0) return null
+    return dnsActions[Math.max(0, Math.min(dnsActionIndex, dnsActions.length - 1))]
+  }
+
+  function activateDnsAction(action) {
+    if (!action) return
+    if (action.id === "routes") tailscale.acceptRoutes()
+    else if (action.id === "dns") tailscale.ignoreTailnetDns()
+  }
 
   function selectedPeer() {
     if (tailscale.peers.length === 0) return null
@@ -177,17 +209,39 @@ Panel {
     return tailscale.accounts[Math.max(0, Math.min(accountIndex, tailscale.accounts.length - 1))]
   }
 
+  function sectionAfterHeader() {
+    if (showDnsRepair) return "dns"
+    if (tailscale.accountsAccessDenied) return "auth"
+    if (tailscale.accounts.length > 1) return "accounts"
+    if (showExitNodes) return "exitNodes"
+    if (showPeers) return "peers"
+    return "header"
+  }
+
+  function sectionBefore(section) {
+    if (section === "auth" || section === "accounts" || section === "exitNodes" || section === "peers") {
+      if (section === "accounts" && tailscale.accountsAccessDenied) return "auth"
+      if ((section === "exitNodes" || section === "peers") && tailscale.accounts.length > 1) return "accounts"
+      if ((section === "exitNodes" || section === "peers") && tailscale.accountsAccessDenied) return "auth"
+      if (section === "peers" && showExitNodes) return "exitNodes"
+      if (showDnsRepair) return "dns"
+    }
+    return "header"
+  }
+
   function ensureCursor() {
     if (headerIndex < 0) headerIndex = 0
     if (headerIndex > 0) headerIndex = 0
+    if (dnsActionIndex >= dnsActions.length) dnsActionIndex = Math.max(0, dnsActions.length - 1)
     if (accountIndex >= tailscale.accounts.length) accountIndex = Math.max(0, tailscale.accounts.length - 1)
     if (peerIndex >= tailscale.peers.length) peerIndex = Math.max(0, tailscale.peers.length - 1)
     if (exitNodeIndex >= exitNodes.length) exitNodeIndex = Math.max(0, exitNodes.length - 1)
     if (mullvadRegionIndex >= filteredMullvadRegions.length) mullvadRegionIndex = Math.max(0, filteredMullvadRegions.length - 1)
-    if (focusSection === "auth" && !tailscale.accountsAccessDenied) focusSection = tailscale.accounts.length > 1 ? "accounts" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
-    if (focusSection === "accounts" && tailscale.accounts.length <= 1) focusSection = tailscale.accountsAccessDenied ? "auth" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
-    if (focusSection === "peers" && !showPeers) focusSection = showExitNodes ? "exitNodes" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : "header"))
-    if (focusSection === "exitNodes" && !showExitNodes) focusSection = showPeers ? "peers" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : "header"))
+    if (focusSection === "dns" && !showDnsRepair) focusSection = sectionAfterHeader()
+    if (focusSection === "auth" && !tailscale.accountsAccessDenied) focusSection = tailscale.accounts.length > 1 ? "accounts" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : (showDnsRepair ? "dns" : "header")))
+    if (focusSection === "accounts" && tailscale.accounts.length <= 1) focusSection = tailscale.accountsAccessDenied ? "auth" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : (showDnsRepair ? "dns" : "header")))
+    if (focusSection === "peers" && !showPeers) focusSection = showExitNodes ? "exitNodes" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : (showDnsRepair ? "dns" : "header")))
+    if (focusSection === "exitNodes" && !showExitNodes) focusSection = showPeers ? "peers" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : (showDnsRepair ? "dns" : "header")))
   }
 
   function moveCursor(dx, dy) {
@@ -195,20 +249,26 @@ Panel {
     ensureCursor()
     if (dy !== 0) {
       if (focusSection === "header") {
-        if (dy > 0) {
-          if (tailscale.accountsAccessDenied) focusSection = "auth"
+        if (dy > 0) focusSection = sectionAfterHeader()
+      } else if (focusSection === "dns") {
+        if (dy < 0) {
+          if (dnsActionIndex <= 0) focusSection = "header"
+          else dnsActionIndex--
+        } else {
+          if (dnsActionIndex < dnsActions.length - 1) dnsActionIndex++
+          else if (tailscale.accountsAccessDenied) focusSection = "auth"
           else if (tailscale.accounts.length > 1) focusSection = "accounts"
           else if (showExitNodes) focusSection = "exitNodes"
           else if (showPeers) focusSection = "peers"
         }
       } else if (focusSection === "auth") {
-        if (dy < 0) focusSection = "header"
+        if (dy < 0) focusSection = sectionBefore("auth")
         else if (tailscale.accounts.length > 1) focusSection = "accounts"
         else if (showExitNodes) focusSection = "exitNodes"
         else if (showPeers) focusSection = "peers"
       } else if (focusSection === "accounts") {
         if (dy < 0) {
-          if (accountIndex <= 0) focusSection = tailscale.accountsAccessDenied ? "auth" : "header"
+          if (accountIndex <= 0) focusSection = sectionBefore("accounts")
           else accountIndex--
         } else {
           if (accountIndex < tailscale.accounts.length - 1) accountIndex++
@@ -217,14 +277,14 @@ Panel {
         }
       } else if (focusSection === "peers") {
         if (dy < 0) {
-          if (peerIndex <= 0) focusSection = showExitNodes ? "exitNodes" : (tailscale.accounts.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header"))
+          if (peerIndex <= 0) focusSection = sectionBefore("peers")
           else peerIndex--
         } else if (peerIndex < tailscale.peers.length - 1) {
           peerIndex++
         }
       } else if (focusSection === "exitNodes") {
         if (dy < 0) {
-          if (exitNodeIndex <= 0) focusSection = tailscale.accounts.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header")
+          if (exitNodeIndex <= 0) focusSection = sectionBefore("exitNodes")
           else exitNodeIndex--
         } else if (exitNodeIndex < exitNodes.length - 1) {
           exitNodeIndex++
@@ -241,6 +301,8 @@ Panel {
     ensureCursor()
     if (focusSection === "header") {
       tailscale.toggleTailscale()
+    } else if (focusSection === "dns") {
+      activateDnsAction(selectedDnsAction())
     } else if (focusSection === "auth") {
       tailscale.authorizeTailscaleOperator()
     } else if (focusSection === "accounts") {
@@ -328,6 +390,12 @@ Panel {
     focusSection = "auth"
   }
 
+  function setDnsCursor(index) {
+    cursorActive = true
+    focusSection = "dns"
+    dnsActionIndex = index
+  }
+
   function setHeaderCursor() {
     cursorActive = true
     focusSection = "header"
@@ -347,6 +415,7 @@ Panel {
   onExitNodeIndexChanged: scrollCursorIntoView()
   onMullvadRegionIndexChanged: if (mullvadPickerOpen) scrollMullvadRegionCursorIntoView()
   onShowConnectionsChanged: ensureCursor()
+  onShowDnsRepairChanged: ensureCursor()
   onShowPeersChanged: ensureCursor()
   onShowExitNodesChanged: ensureCursor()
   onFilteredMullvadRegionsChanged: ensureCursor()
@@ -361,6 +430,7 @@ Panel {
     function onPeersChanged() { root.ensureCursor() }
     function onAccountsChanged() { root.ensureCursor() }
     function onAccountsAccessDeniedChanged() { root.ensureCursor() }
+    function onDnsUnreachableChanged() { root.ensureCursor() }
   }
 
   IpcHandler {
@@ -389,7 +459,7 @@ Panel {
           color: root.barIconColor
           badgeColor: root.urgent
           crossed: !tailscale.active && !tailscale.needsLogin
-          warning: tailscale.needsLogin
+          warning: tailscale.needsLogin || tailscale.dnsUnreachable
         }
       }
     }
@@ -458,7 +528,7 @@ Panel {
               id: hero
               width: parent.width
               title: tailscale.installed ? (tailscale.selfName || "Tailscale") : "Tailscale"
-              meta: tailscale.active ? root.heroPhraseText : "Tailscale is disconnected"
+              meta: !tailscale.active ? "Tailscale is disconnected" : (tailscale.dnsUnreachable ? "Can't reach tailnet DNS" : root.heroPhraseText)
               foreground: root.foreground
               fontFamily: root.fontFamily
               iconOpacity: tailscale.active ? 1.0 : 0.5
@@ -469,7 +539,7 @@ Panel {
                   color: root.iconColor
                   badgeColor: root.urgent
                   crossed: !tailscale.active && !tailscale.needsLogin
-                  warning: tailscale.needsLogin
+                  warning: tailscale.needsLogin || tailscale.dnsUnreachable
                 }
               }
 
@@ -505,6 +575,55 @@ Panel {
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
             wrapMode: Text.WordWrap
+          }
+
+          PanelSeparator {
+            visible: root.showDnsRepair
+            foreground: root.foreground
+          }
+
+          Column {
+            visible: root.showDnsRepair
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSectionHeader {
+              text: "DNS"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            Text {
+              width: parent.width
+              text: tailscale.routesNotAccepted
+                ? "Tailscale can't reach the DNS servers your tailnet specified. Those servers are on advertised routes this machine has not accepted."
+                : "Tailscale can't reach the DNS servers your tailnet specified."
+              color: root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              wrapMode: Text.WordWrap
+            }
+
+            Text {
+              visible: tailscale.advertisedRouteSummary !== ""
+              width: parent.width
+              text: tailscale.advertisedRouteSummary
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              wrapMode: Text.WordWrap
+            }
+
+            Repeater {
+              model: root.dnsActions
+              DnsActionRow {
+                required property var modelData
+                required property int index
+                width: parent.width
+                action: modelData
+                rowIndex: index
+              }
+            }
           }
 
           CursorSurface {
@@ -716,7 +835,7 @@ Panel {
   Timer {
     id: phraseTimer
     interval: 2800
-    running: root.opened && tailscale.active
+    running: root.opened && tailscale.active && !tailscale.dnsUnreachable
     repeat: true
     onTriggered: phraseSwap.restart()
   }
@@ -733,6 +852,67 @@ Panel {
     PropertyAnimation {
       target: hero; property: "metaOpacity"
       to: 1.0; duration: 260; easing.type: Easing.InQuad
+    }
+  }
+
+  component DnsActionRow: CursorSurface {
+    id: dnsRow
+    property var action: null
+    property int rowIndex: 0
+
+    hasCursor: root.cursorActive && root.focusSection === "dns" && root.dnsActionIndex === rowIndex
+    foreground: root.foreground
+
+    implicitHeight: dnsInner.implicitHeight + Style.spacing.rowPaddingX
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: tailscale.busy ? Qt.ArrowCursor : Qt.PointingHandCursor
+      enabled: !tailscale.busy
+      onEntered: root.setDnsCursor(dnsRow.rowIndex)
+      onClicked: root.activateDnsAction(dnsRow.action)
+    }
+
+    RowLayout {
+      id: dnsInner
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      spacing: Style.space(8)
+
+      Text {
+        text: dnsRow.action && dnsRow.action.id === "routes" ? "󰩠" : "󰖟"
+        color: root.dim
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.heading
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Style.space(1)
+
+        Text {
+          Layout.fillWidth: true
+          text: dnsRow.action ? dnsRow.action.title : ""
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+        }
+
+        Text {
+          Layout.fillWidth: true
+          text: dnsRow.action ? dnsRow.action.subtitle : ""
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+      }
     }
   }
 

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -44,7 +44,7 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
   readonly property bool showDnsRepair: tailscale.active && tailscale.dnsUnreachable
-  readonly property var dnsActions: dnsRepairActions()
+  readonly property var dnsActions: showDnsRepair ? tailscale.dnsRepairActions : []
   readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
   readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
@@ -59,24 +59,6 @@ Panel {
   readonly property color barIconColor: tailscale.active ? barForeground : Qt.darker(barForeground, 1.55)
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
-
-  function dnsRepairActions() {
-    var actions = []
-    if (!showDnsRepair) return actions
-    if (tailscale.routesNotAccepted) {
-      actions.push({
-        id: "routes",
-        title: "Accept subnet routes",
-        subtitle: "Reach the tailnet's DNS servers via advertised routes"
-      })
-    }
-    actions.push({
-      id: "dns",
-      title: "Don't use tailnet DNS",
-      subtitle: "Keep using this machine's DNS resolvers"
-    })
-    return actions
-  }
 
   function selectedDnsAction() {
     if (dnsActions.length === 0) return null

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -11,6 +11,7 @@ Native Omarchy bar widget for Tailscale.
 - Browse machines from `tailscale status --json`
 - Copy a machine's Tailscale IP, host name, or DNS name
 - Send files to a machine with Taildrop, when the tailnet allows file sharing
+- When tailnet DNS is unreachable, offer an explicit choice: accept advertised subnet routes, or keep local DNS. Routes stay off unless you pick them.
 
 ## Keyboard shortcuts
 

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -44,6 +44,7 @@ Item {
   property bool routesNotAccepted: false
   property var advertisedRoutes: []
   readonly property string advertisedRouteSummary: Model.formatRouteSummary(advertisedRoutes, 4)
+  readonly property var dnsRepairActions: Model.dnsRepairActions(dnsUnreachable, routesNotAccepted)
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
   readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || operatorProcess.running || exitNodeProcess.running

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -40,6 +40,10 @@ Item {
   property bool accountsAccessDenied: false
   property string actionStatus: ""
   property string lastError: ""
+  property bool dnsUnreachable: false
+  property bool routesNotAccepted: false
+  property var advertisedRoutes: []
+  readonly property string advertisedRouteSummary: Model.formatRouteSummary(advertisedRoutes, 4)
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
   readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || operatorProcess.running || exitNodeProcess.running
@@ -220,6 +224,9 @@ Item {
     switchingAccountId = ""
     settingExitNodeId = ""
     accountsAccessDenied = false
+    dnsUnreachable = false
+    routesNotAccepted = false
+    advertisedRoutes = []
   }
 
   function parseStatus(raw) {
@@ -250,9 +257,18 @@ Item {
     peers = parsed.running ? parsed.peers : []
     tailnetExitNodes = parsed.running ? parsed.exitNodes : []
     exitNodes = parsed.running ? tailnetExitNodes.concat(mullvadRegions) : []
+    dnsUnreachable = parsed.running && parsed.health && parsed.health.dnsUnreachable === true
+    routesNotAccepted = parsed.running && parsed.health && parsed.health.routesNotAccepted === true
+    advertisedRoutes = parsed.running && parsed.advertisedRoutes ? parsed.advertisedRoutes : []
 
     if (needsLogin) statusText = "Needs login"
-    else if (running) {
+    else if (running && dnsUnreachable) {
+      statusText = "DNS unreachable"
+      _loginInProgress = false
+      _loginUrlOpened = false
+      _preLoginAuthUrl = ""
+      loginTimeoutTimer.stop()
+    } else if (running) {
       statusText = "Connected"
       _loginInProgress = false
       _loginUrlOpened = false
@@ -352,6 +368,16 @@ Item {
     actionStatus = "Authorizing Tailscale operator..."
     operatorProcess.command = ["pkexec", "tailscale", "set", "--operator=" + userName]
     operatorProcess.running = true
+  }
+
+  function acceptRoutes() {
+    if (!installed || actionProcess.running) return
+    runAction(["tailscale", "set", "--accept-routes"], "Accepting subnet routes...")
+  }
+
+  function ignoreTailnetDns() {
+    if (!installed || actionProcess.running) return
+    runAction(["tailscale", "set", "--accept-dns=false"], "Keeping local DNS...")
   }
 
   function runAction(command, label) {

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -10,6 +10,11 @@ const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
+assert(panelSource.includes('Accept subnet routes'), 'tailscale panel offers an explicit accept-routes repair')
+assert(panelSource.includes("Don't use tailnet DNS"), 'tailscale panel offers an explicit keep-local-DNS repair')
+assert(panelSource.includes('tailscale.acceptRoutes()'), 'tailscale panel accepts routes only from the repair action')
+assert(panelSource.includes('tailscale.ignoreTailnetDns()'), 'tailscale panel disables tailnet DNS only from the repair action')
+assert(!/tailscale up --accept-routes/.test(panelSource), 'tailscale panel does not pass --accept-routes to up')
 
 assertDeepEqual(
   tailscale.filterIPv4(['100.64.0.1', 'fd7a:115c:a1e0::1', '192.168.1.2']),
@@ -87,6 +92,8 @@ const status = tailscale.parseStatus(JSON.stringify({
 
 assert(status.ok && status.running, 'tailscale parses running status')
 assertEqual(status.selfIp, '100.74.97.73', 'tailscale parses self IP')
+assert(!status.health.dnsUnreachable && !status.health.routesNotAccepted, 'tailscale treats missing Health as a clean connection')
+assertDeepEqual(status.advertisedRoutes, [], 'tailscale reports no advertised routes when peers have none')
 assertDeepEqual(status.peers.map(peer => peer.HostName), ['alpha', 'zed'], 'tailscale filters offline and Mullvad peers and sorts online peers')
 assertDeepEqual(status.peers[0].TailscaleIPv6, ['fd7a:115c:a1e0::1901:334b'], 'tailscale preserves peer IPv6 addresses for copy menu')
 assert(status.peers[1].ExitNodeOption && status.peers[1].ExitNode, 'tailscale preserves exit node flags')
@@ -207,4 +214,66 @@ assertDeepEqual(
 
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')
+
+const brokenDns = tailscale.parseStatus(JSON.stringify({
+  BackendState: 'Running',
+  Health: [
+    "Tailscale can't reach the configured DNS servers. Internet connectivity may be affected.",
+    'Some peers are advertising routes but --accept-routes is false',
+    'Tailscale is stopped.'
+  ],
+  Self: {
+    HostName: 'laptop',
+    DNSName: 'laptop.tailnet.ts.net.',
+    TailscaleIPs: ['100.68.199.45']
+  },
+  Peer: {
+    vpn: {
+      HostName: 'vpn',
+      DNSName: 'vpn.tailnet.ts.net.',
+      TailscaleIPs: ['100.1.1.9'],
+      Online: true,
+      OS: 'linux',
+      PrimaryRoutes: ['10.2.0.0/16', '10.1.0.0/16', '0.0.0.0/0', '100.64.0.0/10']
+    }
+  }
+}))
+
+assert(brokenDns.health.dnsUnreachable, 'tailscale detects unreachable tailnet DNS from Health')
+assert(brokenDns.health.routesNotAccepted, 'tailscale detects unaccepted advertised routes from Health')
+assertDeepEqual(
+  brokenDns.advertisedRoutes,
+  ['10.1.0.0/16', '10.2.0.0/16'],
+  'tailscale lists advertised subnet routes and skips default and CGNAT prefixes'
+)
+assertEqual(
+  tailscale.formatRouteSummary(brokenDns.advertisedRoutes, 4),
+  '10.1.0.0/16, 10.2.0.0/16',
+  'tailscale formats a short advertised-route summary'
+)
+assertEqual(
+  tailscale.formatRouteSummary(['10.1.0.0/16', '10.2.0.0/16', '10.70.0.0/15', '10.72.0.0/15', '10.250.0.0/16'], 4),
+  '10.1.0.0/16, 10.2.0.0/16, 10.70.0.0/15, 10.72.0.0/15, and 1 more',
+  'tailscale elides long advertised-route lists'
+)
+assertDeepEqual(
+  tailscale.dnsRepairActions(true, true).map(action => action.id),
+  ['routes', 'dns'],
+  'tailscale offers both repairs when DNS is unreachable and routes are unaccepted'
+)
+assertDeepEqual(
+  tailscale.dnsRepairActions(true, false).map(action => action.id),
+  ['dns'],
+  'tailscale only offers keeping local DNS when routes are not the cause'
+)
+assertDeepEqual(
+  tailscale.dnsRepairActions(false, true),
+  [],
+  'tailscale does not prompt to accept routes unless DNS is unreachable'
+)
+assertDeepEqual(
+  tailscale.classifyHealth([]),
+  { notices: [], dnsUnreachable: false, routesNotAccepted: false },
+  'tailscale classifies empty Health as clean'
+)
 JS

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -10,8 +10,7 @@ const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
-assert(panelSource.includes('Accept subnet routes'), 'tailscale panel offers an explicit accept-routes repair')
-assert(panelSource.includes("Don't use tailnet DNS"), 'tailscale panel offers an explicit keep-local-DNS repair')
+assert(panelSource.includes('tailscale.dnsRepairActions'), 'tailscale panel uses the shared DNS repair actions')
 assert(panelSource.includes('tailscale.acceptRoutes()'), 'tailscale panel accepts routes only from the repair action')
 assert(panelSource.includes('tailscale.ignoreTailnetDns()'), 'tailscale panel disables tailnet DNS only from the repair action')
 assert(!/tailscale up --accept-routes/.test(panelSource), 'tailscale panel does not pass --accept-routes to up')
@@ -234,7 +233,7 @@ const brokenDns = tailscale.parseStatus(JSON.stringify({
       TailscaleIPs: ['100.1.1.9'],
       Online: true,
       OS: 'linux',
-      PrimaryRoutes: ['10.2.0.0/16', '10.1.0.0/16', '0.0.0.0/0', '100.64.0.0/10']
+      PrimaryRoutes: ['10.2.0.0/16', '10.1.0.0/16', '0.0.0.0/0', '100.64.0.0/10', '100.1.0.0/16']
     }
   }
 }))
@@ -243,12 +242,16 @@ assert(brokenDns.health.dnsUnreachable, 'tailscale detects unreachable tailnet D
 assert(brokenDns.health.routesNotAccepted, 'tailscale detects unaccepted advertised routes from Health')
 assertDeepEqual(
   brokenDns.advertisedRoutes,
-  ['10.1.0.0/16', '10.2.0.0/16'],
+  ['10.1.0.0/16', '10.2.0.0/16', '100.1.0.0/16'],
   'tailscale lists advertised subnet routes and skips default and CGNAT prefixes'
 )
+assert(tailscale.isCgnatIPv4('100.64.0.0/10') && tailscale.isCgnatIPv4('100.127.1.0/24'), 'tailscale treats 100.64.0.0/10 as CGNAT')
+assert(!tailscale.isCgnatIPv4('100.1.0.0/16') && !tailscale.isCgnatIPv4('100.63.0.0/16') && !tailscale.isCgnatIPv4('100.128.0.0/16'), 'tailscale does not treat the rest of 100.0.0.0/8 as CGNAT')
+assert(tailscale.isSubnetRoute('100.1.0.0/16'), 'tailscale keeps advertised 100.x routes outside CGNAT')
+assert(!tailscale.isSubnetRoute('100.100.100.0/24'), 'tailscale skips Tailscale CGNAT prefixes')
 assertEqual(
   tailscale.formatRouteSummary(brokenDns.advertisedRoutes, 4),
-  '10.1.0.0/16, 10.2.0.0/16',
+  '10.1.0.0/16, 10.2.0.0/16, 100.1.0.0/16',
   'tailscale formats a short advertised-route summary'
 )
 assertEqual(


### PR DESCRIPTION
Fixes #6962.

The Tailscale widget reported Connected while the daemon was already saying it could not reach tailnet DNS. That happens when `--accept-dns` is on (Linux default) and the nameservers live on advertised subnet routes that this machine has not accepted (`--accept-routes` is off).

This PR surfaces that `Health` state and asks for an explicit choice. It does **not** turn `--accept-routes` on by default.

## Behavior

- Hero and bar icon stop looking like a clean connection when DNS is unreachable (`Can't reach tailnet DNS`)
- A DNS section explains the failure
- If peers are advertising routes that have not been accepted, offer **Accept subnet routes** (`tailscale set --accept-routes`) and list the prefixes
- Always offer **Don't use tailnet DNS** (`tailscale set --accept-dns=false`)
- Later on/off stays a flagless `tailscale up` / `down`, so the choice is not reset
- Unaccepted routes alone do not prompt. Only an unreachable-DNS Health line opens the repair

## Why not flip the default

Accepting routes installs every advertised prefix into the routing table. That can be office or lab networks, or a range that overlaps the user's LAN. Users who never opted in should not get that path. The installer already passing `--accept-routes` is the aggressive choice; this PR does not copy it into the widget.

## Testing

- `bash test/shell.d/tailscale-test.sh`
- `git diff --check`
- `./test/shell` — the three failures are the missing `omarchy-pkgs` checkout, unrelated to this change
- Verified in the running panel:
  - healthy connect still looks like today (no DNS section)
  - routes-only Health does not prompt
  - when DNS is unreachable, the repair section, both actions, and wrapping prefix list render without clipping the existing machines list