### PR TITLE
Share clipboard via LocalSend's native text argument

### DIFF
--- a/bin/omarchy-menu-share
+++ b/bin/omarchy-menu-share
@@ -15,11 +15,10 @@ MODE="$1"
 shift
 
 if [[ $MODE == "clipboard" ]]; then
-  TEMP_FILE=$(mktemp --suffix=.txt)
-  wl-paste >"$TEMP_FILE"
-  FILE_ARRAY=("$TEMP_FILE")
+  # LocalSend 1.18+ opens the GUI with text passed directly, no temp file needed
+  LAUNCH=(localsend --text "$(wl-paste)")
 elif (($# > 0)); then
-  FILE_ARRAY=("$@")
+  LAUNCH=(localsend --headless send "$@")
 else
   if [[ $MODE == "folder" ]]; then
     select_args=(--title "Share folder" --directory)
@@ -39,12 +38,13 @@ else
 
   [[ -n $picked ]] || exit 0
   readarray -t FILE_ARRAY <<<"$picked"
+  LAUNCH=(localsend --headless send "${FILE_ARRAY[@]}")
 fi
 
 # Run LocalSend in its own systemd service (detached from terminal)
-systemd-run --user --quiet --collect localsend --headless send "${FILE_ARRAY[@]}"
-
-# Note: Temporary file will remain until system cleanup for clipboard mode
-# This ensures the file content is available for the LocalSend GUI
+if ! systemd-run --user --quiet --collect "${LAUNCH[@]}"; then
+  omarchy-notification-send -g "" -u critical "Could not share" "LocalSend failed to start"
+  exit 1
+fi
 
 exit 0


### PR DESCRIPTION
## What

Replaces the clipboard share's temp-file mechanism with LocalSend 1.18's native `--text` argument ([localsend/localsend#2661](https://github.com/localsend/localsend/pull/2661), disclosure: I authored that upstream PR), which opens the GUI with a text message staged for sending.

- **Before:** clipboard → `mktemp --suffix=.txt` → `localsend --headless send <tmpfile>` — the temp file lingered until system cleanup and the clipboard arrived as a file attachment
- **After:** clipboard → `localsend --text "$(wl-paste)"` — no temp file, arrives as a proper LocalSend text message

File/folder sharing is unchanged; all modes now share a single `systemd-run` invocation via a `LAUNCH` array.

## Notes

- Requires localsend >= 1.18 (Arch repos already ship 1.18.1)
- `systemd-run` launch failures (e.g. clipboard text beyond the ~128 KiB per-argument kernel limit) now surface a critical notification instead of silently exiting 0

## Testing

- `bash -n`, `./test/cli`
- Live on Omarchy with localsend 1.18.1-1: `omarchy share clipboard` opens the LocalSend GUI on the Send tab with the clipboard text staged (verified byte-exact), detached in its own transient user service as before
- Failure path: >128 KiB clipboard text → notification shown, exit 1