### PR TITLE
Link agent skills only where they are actually read

### DIFF
--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -84,14 +84,14 @@ fi
 # Dev-aware skill symlinks. Cannot live in /etc/skel because OMARCHY_PATH may
 # point at a dev checkout (omarchy dev link) where the target differs.
 # Loops every skill directory, so shipping a new one needs no edit here.
-mkdir -p ~/.agents/skills ~/.claude/skills ~/.codex/skills ~/.pi/agent/skills
+# Codex and Pi both discover ~/.agents/skills, so they need no directory of
+# their own. Claude Code reads only ~/.claude/skills.
+mkdir -p ~/.agents/skills ~/.claude/skills
 for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   skill=${skill%/}
   name=${skill##*/}
   ln -sfn "$skill" ~/.agents/skills/"$name"
   ln -sfn "$skill" ~/.claude/skills/"$name"
-  ln -sfn "$skill" ~/.codex/skills/"$name"
-  ln -sfn "$skill" ~/.pi/agent/skills/"$name"
 done
 
 mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1942,12 +1942,10 @@ done
 repair_sleep_lock_unit_override
 install_bash_startup
 
-mkdir -p "$HOME/.agents/skills" "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.pi/agent/skills"
+mkdir -p "$HOME/.agents/skills" "$HOME/.claude/skills"
 if [[ -d $root/default/agents/skills/omarchy ]]; then
   ln -sfn "$root/default/agents/skills/omarchy" "$HOME/.agents/skills/omarchy"
   ln -sfn "$root/default/agents/skills/omarchy" "$HOME/.claude/skills/omarchy"
-  ln -sfn "$root/default/agents/skills/omarchy" "$HOME/.codex/skills/omarchy"
-  ln -sfn "$root/default/agents/skills/omarchy" "$HOME/.pi/agent/skills/omarchy"
 fi
 
 mkdir -p "$HOME/.local/state/omarchy/toggles/hypr"

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -177,9 +177,10 @@ Runs once per user. It does **not** copy `~/.config/**`, `~/.bashrc`,
 `flags.lua`, or the nautilus extensions — `/etc/skel` already seeded those.
 It only does the things `/etc/skel` can't:
 
-- Skill symlinks `~/.{agents,claude,codex,pi/agent}/skills/omarchy` →
+- Skill symlinks `~/.{agents,claude}/skills/omarchy` →
   `$OMARCHY_PATH/default/agents/skills/omarchy`. Symlinks (not copies) so
-  `omarchy dev link` against a dev checkout repoints them correctly.
+  `omarchy dev link` against a dev checkout repoints them correctly. Codex and
+  Pi both read `~/.agents/skills`; only Claude Code needs its own directory.
 - `xdg-user-dirs-update` (Templates/Public/Desktop folded back into `$HOME`)
   and `~/.config/gtk-3.0/bookmarks` (needs `$HOME` expansion).
 - Hyprland's package-owned default input reads `XKBLAYOUT` / `XKBVARIANT`

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -46,6 +46,6 @@ Omarchy recommends two ways of running local LLM models: LM Studio and Ollama. L
 
 ### The Omarchy Skill
 
-Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It's symlinked into the skill directories for Claude Code (`~/.claude/skills`), Codex (`~/.codex/skills`), Pi (`~/.pi/agent/skills`), and the generic `~/.agents/skills` location, so most harnesses pick it up automatically.
+Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It's symlinked into the generic `~/.agents/skills` location, which Codex and Pi both read, and into `~/.claude/skills` for Claude Code, so most harnesses pick it up automatically.
 
 But you should treat this skill as experimental. Different models will use it to different effect. It's best to run in plan mode first, so you have an idea of what the agent would like to change. And then be ready to rollback changes or even invoking `omarchy reinstall configs`, if the agent makes a mess of everything.

--- a/migrations/1786801363.sh
+++ b/migrations/1786801363.sh
@@ -1,0 +1,21 @@
+echo "Drop the redundant Codex and Pi skill symlinks"
+
+# Codex and Pi both discover ~/.agents/skills, so the per-harness copies never
+# added anything. Only reclaim links pointing at Omarchy's own skills; anything
+# else in those directories belongs to the user or the harness.
+skills_source="$OMARCHY_PATH/default/agents/skills"
+
+for skills_dir in ~/.codex/skills ~/.pi/agent/skills; do
+  [[ -d $skills_dir ]] || continue
+
+  for link in "$skills_dir"/*; do
+    [[ -L $link ]] || continue
+
+    target=$(readlink -f "$link") || continue
+    [[ $target == "$(readlink -f "$skills_source")"/* ]] && rm "$link"
+  done
+done
+
+# Pi's directory only ever held these links, so clear it out when it is empty.
+# Codex keeps its own .system directory there, so leave that one alone.
+rmdir ~/.pi/agent/skills 2>/dev/null || true

--- a/test/shell.d/skill-symlink-trim-migration-test.sh
+++ b/test/shell.d/skill-symlink-trim-migration-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1786801363.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+skills_source="$test_dir/omarchy/default/agents/skills"
+mkdir -p "$skills_source/omarchy" "$skills_source/diagnose-crash"
+
+home="$test_dir/home"
+
+run_migration() {
+  HOME="$home" OMARCHY_PATH="$test_dir/omarchy" bash -euo pipefail "$migration" >/dev/null
+}
+
+seed_home() {
+  rm -rf "$home"
+  mkdir -p "$home/.codex/skills/.system" "$home/.pi/agent/skills"
+
+  ln -sfn "$skills_source/omarchy" "$home/.codex/skills/omarchy"
+  ln -sfn "$skills_source/diagnose-crash" "$home/.codex/skills/diagnose-crash"
+  ln -sfn "$skills_source/omarchy" "$home/.pi/agent/skills/omarchy"
+
+  # A skill the user installed themselves, and one they pointed elsewhere.
+  mkdir -p "$home/.codex/skills/hand-written" "$test_dir/elsewhere"
+  touch "$home/.codex/skills/hand-written/SKILL.md"
+  ln -sfn "$test_dir/elsewhere" "$home/.codex/skills/foreign"
+}
+
+seed_home
+run_migration
+
+[[ ! -e $home/.codex/skills/omarchy && ! -e $home/.codex/skills/diagnose-crash ]] ||
+  fail "migration drops the Codex links to Omarchy's skills"
+pass "migration drops the Codex links to Omarchy's skills"
+
+[[ -f $home/.codex/skills/hand-written/SKILL.md ]] ||
+  fail "migration keeps a hand-written skill"
+pass "migration keeps a hand-written skill"
+
+[[ -L $home/.codex/skills/foreign ]] ||
+  fail "migration keeps a link pointing outside Omarchy"
+pass "migration keeps a link pointing outside Omarchy"
+
+[[ -d $home/.codex/skills/.system ]] ||
+  fail "migration keeps Codex's own .system directory"
+pass "migration keeps Codex's own .system directory"
+
+[[ ! -e $home/.pi/agent/skills ]] ||
+  fail "migration prunes the emptied Pi skills directory"
+pass "migration prunes the emptied Pi skills directory"
+
+run_migration
+[[ -f $home/.codex/skills/hand-written/SKILL.md && ! -e $home/.pi/agent/skills ]] ||
+  fail "migration is idempotent"
+pass "migration is idempotent"
+
+# Nothing to do on a machine that never had either directory.
+rm -rf "$home"
+mkdir -p "$home"
+run_migration
+pass "migration succeeds when neither directory exists"
+
+# A Pi directory holding something else is left in place rather than pruned.
+seed_home
+mkdir -p "$home/.pi/agent/skills/keep-me"
+run_migration
+
+[[ -d $home/.pi/agent/skills/keep-me ]] ||
+  fail "migration leaves a Pi directory that still holds something"
+pass "migration leaves a Pi directory that still holds something"


### PR DESCRIPTION
Omarchy symlinks its shipped skills into four directories: `~/.agents/skills`, `~/.claude/skills`, `~/.codex/skills`, and `~/.pi/agent/skills`. Two of those are redundant.

Codex discovers `~/.agents/skills` — I confirmed it by planting a skill there and nowhere else, then asking codex to list what it could see, and it showed up. Pi documents the same thing in its own `docs/skills.md`, which lists global discovery as `~/.pi/agent/skills/` and `~/.agents/skills/`, then explains separately how to add Claude Code or Codex directories if you want those. Claude Code is the odd one out: its binary carries 93 references to `.claude/skills` and none at all to `.agents/skills`, so it genuinely needs its own.

So the required set is `~/.agents/skills` for Codex and Pi, plus `~/.claude/skills` for Claude Code. `bin/omarchy-provision-user` and `bin/omarchy-upgrade-to-quattro` now write only those two, and a migration reclaims the links already written to the other two.

The migration only removes symlinks resolving inside `$OMARCHY_PATH/default/agents/skills`, so a skill the user put there themselves, a link they pointed somewhere else, and Codex's own `.system` directory all survive. It clears `~/.pi/agent/skills` when that leaves it empty, since it never held anything else, and leaves `~/.codex/skills` in place because Codex keeps `.system` in it.

The two historical migrations that wrote these links are left untouched — their markers are already written, so editing them would change nothing for anyone.

One caveat worth knowing: this assumes a Codex new enough to discover `~/.agents/skills`. Verified on 0.147.0, which is what Omarchy installs; anyone pinned to an older Codex would lose the skill until they update.

— 🤖 Claude, posting on behalf of @dhh