### PR TITLE
Keep older sharp releases from compiling against global libvips

### DIFF
--- a/default/bash/env-bootstrap
+++ b/default/bash/env-bootstrap
@@ -39,3 +39,10 @@ case ":$PATH:" in
   *) PATH="${PATH:+$PATH:}$HOME/.local/bin" ;;
 esac
 export PATH
+
+# Omarchy installs libvips for image-picker thumbnails, not as a Node.js build
+# dependency. Keep sharp <= 0.34 on its packaged binaries unless the user opts
+# in to the system libvips by setting this variable to an empty value.
+if [ -z "${SHARP_IGNORE_GLOBAL_LIBVIPS+x}" ]; then
+  export SHARP_IGNORE_GLOBAL_LIBVIPS=1
+fi

--- a/default/bash/env-bootstrap
+++ b/default/bash/env-bootstrap
@@ -41,8 +41,8 @@ esac
 export PATH
 
 # Omarchy installs libvips for image-picker thumbnails, not as a Node.js build
-# dependency. Keep sharp <= 0.34 on its packaged binaries unless the user opts
-# in to the system libvips by setting this variable to an empty value.
-if [ -z "${SHARP_IGNORE_GLOBAL_LIBVIPS+x}" ]; then
+# dependency. Keep sharp on its packaged binaries unless the user explicitly
+# opts in to the system libvips.
+if [[ -z ${SHARP_IGNORE_GLOBAL_LIBVIPS+x} && -z ${SHARP_FORCE_GLOBAL_LIBVIPS+x} ]]; then
   export SHARP_IGNORE_GLOBAL_LIBVIPS=1
 fi

--- a/test/shell.d/sharp-env-test.sh
+++ b/test/shell.d/sharp-env-test.sh
@@ -6,10 +6,20 @@ source "$(dirname "$0")/base-test.sh"
 
 bootstrap="$ROOT/default/bash/env-bootstrap"
 
-sharp_ignore=$(env -u SHARP_IGNORE_GLOBAL_LIBVIPS bash -c 'source "$1"; printf "%s" "$SHARP_IGNORE_GLOBAL_LIBVIPS"' bash "$bootstrap")
-[[ $sharp_ignore == 1 ]] || fail "env bootstrap ignores the Omarchy-provided libvips for sharp" "actual: $sharp_ignore"
+if ! sharp_ignore=$(env -u SHARP_IGNORE_GLOBAL_LIBVIPS -u SHARP_FORCE_GLOBAL_LIBVIPS bash -c 'source "$1" || exit 1; printf "%s" "$SHARP_IGNORE_GLOBAL_LIBVIPS"' bash "$bootstrap"); then
+  fail "env bootstrap ignores the Omarchy-provided libvips for sharp" "failed to source: $bootstrap"
+fi
+[[ $sharp_ignore == "1" ]] || fail "env bootstrap ignores the Omarchy-provided libvips for sharp" "actual: $sharp_ignore"
 pass "env bootstrap ignores the Omarchy-provided libvips for sharp"
 
-sharp_ignore=$(SHARP_IGNORE_GLOBAL_LIBVIPS= bash -c 'source "$1"; printf "<%s>" "$SHARP_IGNORE_GLOBAL_LIBVIPS"' bash "$bootstrap")
+if ! sharp_ignore=$(env -u SHARP_FORCE_GLOBAL_LIBVIPS SHARP_IGNORE_GLOBAL_LIBVIPS= bash -c 'source "$1" || exit 1; printf "<%s>" "$SHARP_IGNORE_GLOBAL_LIBVIPS"' bash "$bootstrap"); then
+  fail "env bootstrap preserves an explicit sharp system-libvips opt-in" "failed to source: $bootstrap"
+fi
 [[ $sharp_ignore == "<>" ]] || fail "env bootstrap preserves an explicit sharp system-libvips opt-in" "actual: $sharp_ignore"
 pass "env bootstrap preserves an explicit sharp system-libvips opt-in"
+
+if ! sharp_env=$(env -u SHARP_IGNORE_GLOBAL_LIBVIPS SHARP_FORCE_GLOBAL_LIBVIPS=1 bash -c 'source "$1" || exit 1; printf "%s:%s" "$SHARP_FORCE_GLOBAL_LIBVIPS" "${SHARP_IGNORE_GLOBAL_LIBVIPS+set}"' bash "$bootstrap"); then
+  fail "env bootstrap preserves sharp's force-global override" "failed to source: $bootstrap"
+fi
+[[ $sharp_env == "1:" ]] || fail "env bootstrap preserves sharp's force-global override" "actual: $sharp_env"
+pass "env bootstrap preserves sharp's force-global override"

--- a/test/shell.d/sharp-env-test.sh
+++ b/test/shell.d/sharp-env-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+bootstrap="$ROOT/default/bash/env-bootstrap"
+
+sharp_ignore=$(env -u SHARP_IGNORE_GLOBAL_LIBVIPS bash -c 'source "$1"; printf "%s" "$SHARP_IGNORE_GLOBAL_LIBVIPS"' bash "$bootstrap")
+[[ $sharp_ignore == 1 ]] || fail "env bootstrap ignores the Omarchy-provided libvips for sharp" "actual: $sharp_ignore"
+pass "env bootstrap ignores the Omarchy-provided libvips for sharp"
+
+sharp_ignore=$(SHARP_IGNORE_GLOBAL_LIBVIPS= bash -c 'source "$1"; printf "<%s>" "$SHARP_IGNORE_GLOBAL_LIBVIPS"' bash "$bootstrap")
+[[ $sharp_ignore == "<>" ]] || fail "env bootstrap preserves an explicit sharp system-libvips opt-in" "actual: $sharp_ignore"
+pass "env bootstrap preserves an explicit sharp system-libvips opt-in"


### PR DESCRIPTION
I’m a Netlify employee, so naturally one of my first tasks on a new Omarchy Quattro install was getting the Netlify CLI installed:

```bash
npm install -g netlify-cli
```

The install failed when sharp 0.34.5 tried to build from source:

```text
sharp: Attempting to build from source via node-gyp
sharp: Please add node-addon-api to your dependencies
```

Turns out #6686 added libvips for image-picker thumbnails. That makes the image picker faster, but sharp 0.34 and earlier see the globally installed libvips and assume they should compile against it. The Netlify CLI currently pulls sharp 0.34.5 through `@netlify/images` and `ipx`, but that dependency tree doesn’t include `node-addon-api`, so the entire install fails.

Sharp 0.35 makes source builds opt-in, but `netlify-cli@27.1.1` still installs sharp 0.34.5, so this affects current Netlify CLI installs.

This change sets `SHARP_IGNORE_GLOBAL_LIBVIPS=1` in Omarchy’s shared environment bootstrap when the variable hasn’t already been set. That keeps older versions of sharp on their packaged binaries without removing the libvips package Omarchy needs.

Anyone who intentionally wants sharp to use the system libvips can still opt in for a command:

```bash
SHARP_IGNORE_GLOBAL_LIBVIPS= npm install
```

I added regression tests for both behaviors. Without the new default, the Netlify CLI install fails. With the patched environment, it installs and reports:

```text
netlify-cli/27.1.1 linux-x64 node-v24.19.0
```

I also ran `./test/all`; all 181 test files passed.
