### PR TITLE
multi-monitor window highlighting in slurp capture

### DIFF
--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -37,25 +37,33 @@ JQ_MONITOR_GEO='
     end;
 '
 
-active_workspace() {
-  hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id'
+# Workspace ids visible on any connected monitor, as a JSON array.
+active_workspaces() {
+  hyprctl monitors -j | jq -c 'map(.activeWorkspace.id)'
 }
 
 # Hidden group members and windows stacked at identical geometry collapse to
 # one rectangle: slurp cannot tell them apart, and duplicates would stall the
 # Tab cycle on the first copy.
 window_rects() {
-  hyprctl clients -j | jq -r --arg ws "$(active_workspace)" \
-    '[.[] | select(.workspace.id == ($ws | tonumber) and .hidden != true) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"] | unique[]'
+  local monitors_json clients_json
+  monitors_json=${1:-$(hyprctl monitors -j)}
+  clients_json=${2:-$(hyprctl clients -j)}
+
+  echo "$clients_json" | jq -r --argjson ws "$(echo "$monitors_json" | jq -c 'map(.activeWorkspace.id)')" \
+    '[.[] | select((.workspace.id as $id | $ws | index($id)) and .hidden != true) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"] | unique[]'
 }
 
 monitor_rects() {
-  hyprctl monitors -j | jq -r --arg ws "$(active_workspace)" "${JQ_MONITOR_GEO} .[] | select(.activeWorkspace.id == (\$ws | tonumber)) | format_geo"
+  local monitors_json=${1:-$(hyprctl monitors -j)}
+  echo "$monitors_json" | jq -r "${JQ_MONITOR_GEO} .[] | format_geo"
 }
 
 get_rectangles() {
-  monitor_rects
-  window_rects
+  local monitors_json=$(hyprctl monitors -j)
+  local clients_json=$(hyprctl clients -j)
+  monitor_rects "$monitors_json"
+  window_rects "$monitors_json" "$clients_json"
 }
 
 focused_monitor_geo() {


### PR DESCRIPTION
Using the capture when you have more the one monitor doesnt let you auto capture the open windows in other monitors that you are not focused on.

get_rectangles() only queried the focused monitor's workspace, so on multi-monitor setups the picker was blind to windows on other screens — window capture required a manual click-and-drag and --select-window/Tab navigation skipped those windows entirely.

The fix now:

- Returns geometries for all connected monitors.

- Builds an array of active workspace IDs across every screen and filters the hyprctl clients list against it, so windows on any visible workspace are pickable.

- Fetches hyprctl monitors/clients once and reuses the JSON via jq --argjson (plus --argjson active-workspace array).
Same code now powers omarchy-capture-region, so screenshots, recordings, and window navigation all highlight across monitors.

<img width="1905" height="1037" alt="screenshot-2026-08-15_17-52-38" src="https://github.com/user-attachments/assets/3f33e0c7-4385-45c9-aeea-96b4f782b3a3" />

<img width="1920" height="1080" alt="screenshot-2026-08-15_17-52-50" src="https://github.com/user-attachments/assets/d05a2a7a-c09b-493a-a8bb-ee85e70f9670" />

