### PR TITLE
Keep the calendar's day names in English

### DIFF
--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -64,7 +64,11 @@ Panel {
   // convention. Clicking the grid's "W" heading writes the choice back to
   // shell.json.
   readonly property int weekStart: Model.normalizedWeekStart(setting("weekStartDay", null), Qt.locale().firstDayOfWeek)
-  readonly property string nextWeekStartLabel: Qt.locale().dayName(Model.toggledWeekStart(weekStart), Locale.LongFormat)
+  // The interface is English throughout, so day names are not taken from the
+  // system locale. Where the week starts still is: that is a regional
+  // convention rather than a translation, and it stays overridable above.
+  readonly property var labelLocale: Qt.locale("en_US")
+  readonly property string nextWeekStartLabel: labelLocale.dayName(Model.toggledWeekStart(weekStart), Locale.LongFormat)
   readonly property var weekdays: Model.weekdayOrder(weekStart)
   readonly property var weeks: Model.monthGrid(viewYear, viewMonth, weekStart, todayKey)
 
@@ -213,10 +217,9 @@ Panel {
     setWeekStart(Model.toggledWeekStart(root.weekStart))
   }
 
-  // Locale short day names, trimmed of the trailing period some locales
-  // carry ("man." -> "MAN") so the header row stays a clean band of caps.
+  // English short day names, matching the rest of the interface.
   function weekdayLabel(weekday) {
-    return String(Qt.locale().dayName(weekday, Locale.ShortFormat)).replace(/\.$/, "").toUpperCase()
+    return String(labelLocale.dayName(weekday, Locale.ShortFormat)).toUpperCase()
   }
 
   SystemClock {


### PR DESCRIPTION
The shell is English throughout, so anything currently following the system locale is doing it by accident. I went looking for what that covers.

Two places, both in the clock panel, were reading day names off `Qt.locale()`:

- the calendar grid's header row (`weekdayLabel`)
- the label on the week-start toggle (`nextWeekStartLabel`)

On a German desktop those drew `MO DI MI DO FR SA SO` and "Montag" over an interface that is English everywhere else. They take their names from `en_US` now.

**Where the week starts is deliberately left alone.** `firstDayOfWeek` is a regional convention rather than a translation — and it is not interchangeable here: the system and C locales report Monday while `en_US` reports Sunday, so routing it through the same locale would have quietly moved every user's calendar to a Sunday start. It also remains overridable through `weekStartDay`.

The trailing-period strip goes with the change; it existed only for locales like `man.` that this no longer renders.

## What else was checked

Everything else in `shell/` is already consistent, mostly by accident rather than design:

- `Qt.formatDate` / `Qt.formatDateTime` render `dddd`/`MMMM` from the C locale regardless of `Qt.locale()`, so the bar clock, the calendar's month headings and the weather day names are already English.
- `agents/Panel.qml` uses a hardcoded English array.
- `Qt.locale()` survives in two more spots, both regional conventions with an explicit user setting rather than translated text: the week start above, and the weather panel's imperial/metric default.
- `localeCompare` appears in a few sort comparators. That is ordering, not displayed text, so I left it.

## Verified

Rendered the header row, the toggle label and the month headings under `C`, `de_DE.UTF-8` and `fr_FR.UTF-8`: identical English output in all three (`MON TUE WED THU FRI SAT SUN`, `Sunday`/`Monday`, `DECEMBER 2026`), with `firstDayOfWeek` still reporting the locale's own value.

Supersedes #6941, which went the other way and localized the bar clock to match the calendar. Closing that one — this is the direction that matches the rest of the OS, and a real system-wide translation is a separate future project.

— 🤖 Claude, posting on behalf of @dhh