### PR TITLE
Format the whole speed test dial for the locale

### DIFF
--- a/shell/Ui/SpeedTestOverlay.qml
+++ b/shell/Ui/SpeedTestOverlay.qml
@@ -369,7 +369,13 @@ PanelWindow {
 
       Text {
         anchors.horizontalCenter: parent.horizontalCenter
-        text: dial.reading < 10 ? dial.reading.toFixed(1) : Math.round(dial.reading).toLocaleString(Qt.locale(), 'f', 0)
+        // Both branches go through the locale: a reading is a measurement, so
+        // its separators follow the system's number conventions rather than the
+        // interface language. toFixed would have hardcoded a dot below 10 while
+        // everything above it was already grouped for the locale.
+        text: dial.reading < 10
+          ? dial.reading.toLocaleString(Qt.locale(), 'f', 1)
+          : Math.round(dial.reading).toLocaleString(Qt.locale(), 'f', 0)
         color: root.onScrim
         font.family: root.fontFamily
         font.pixelSize: Style.font.display


### PR DESCRIPTION
Follow-up to the locale sweep in #6988. That one established the split: interface text is English, regional conventions follow the system. The speed test dial was on the wrong side of that line in one direction — it was half-localized.

`SpeedTestOverlay.qml` grouped its digits for the locale above 10, but fell through to `toFixed(1)` below 10, which hardcodes a dot. So the same dial switched decimal convention halfway up the scale:

| Locale | Before | After |
|---|---|---|
| `en_US` | `9.5` … `1,235` | `9.5` … `1,235` (unchanged) |
| `de_DE` | `9.5` … `1.235` | `9,5` … `1.235` |
| `fr_FR` | `9.5` … `1 235` | `9,5` … `1 235` |

Both branches go through the locale now. A reading is a measurement rather than interface text, so its separators follow the system's number conventions even though the interface itself stays English — the same reasoning that leaves the weather panel's imperial/metric default and the calendar's first-day-of-week alone in #6988.

This is the only number-formatting site across all three speed test surfaces: the internet and disk panels both feed this shared overlay, and neither formats anything itself.

## Verified

Rendered `0, 0.4, 5.25, 9.96, 10, 94.6, 940, 1234.6, 10450.2` under `en_US`, `de_DE` and `fr_FR`. Every locale is now internally consistent across the 10 boundary, and `en_US` is byte-identical to before. `qmllint` reports the same 209 lines as the unpatched file, so no new warnings.

— 🤖 Claude, posting on behalf of @dhh