### PR TITLE
Make Omarchy's automatic monitor management toggleable

### DIFF
--- a/bin/omarchy-hw-recover-internal-monitor
+++ b/bin/omarchy-hw-recover-internal-monitor
@@ -2,6 +2,8 @@
 
 # omarchy:summary=Clear the internal-monitor-disable toggle if no external display is connected.
 
+omarchy-toggle-enabled monitor-management || exit 0
+
 TOGGLE="$HOME/.local/state/omarchy/toggles/hypr/internal-monitor-disable.lua"
 
 if [[ -f $TOGGLE ]] && ! omarchy-hw-external-monitors; then

--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -3,6 +3,8 @@
 # omarchy:summary=Apply clamshell display state to Hyprland monitors
 # omarchy:hidden=true
 
+omarchy-toggle-enabled monitor-management || exit 0
+
 TOGGLES_DIR="$HOME/.local/state/omarchy/toggles/hypr"
 CLAMSHELL_FLAG="$TOGGLES_DIR/internal-monitor-clamshell.lua"
 MANUAL_DISABLE_FLAG="$TOGGLES_DIR/internal-monitor-disable.lua"

--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -7,6 +7,8 @@ TOGGLE="internal-monitor-disable"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 MIRROR_TOGGLE="internal-monitor-mirror"
 
+omarchy-toggle-enabled monitor-management || exit 0
+
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
 
 wake() {

--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -7,6 +7,8 @@ TOGGLE="internal-monitor-mirror"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 DISABLE_TOGGLE="internal-monitor-disable"
 
+omarchy-toggle-enabled monitor-management || exit 0
+
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
 # The first active external monitor
 EXTERNAL=$(hyprctl monitors -j | jq -r '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not).name' | head -n 1)

--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -2,6 +2,8 @@
 
 # omarchy:summary=Watch Hyprland monitor events and recover monitor toggles when a monitor is removed
 
+omarchy-toggle-enabled monitor-management || exit 0
+
 SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
 LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-clamshell.lock"
 MODELESS_LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-modeless.lock"

--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -2,13 +2,13 @@
 
 # omarchy:summary=Watch Hyprland monitor events and recover monitor toggles when a monitor is removed
 
-omarchy-toggle-enabled monitor-management || exit 0
-
 SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
 LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-clamshell.lock"
 MODELESS_LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-modeless.lock"
 
 sync_clamshell() {
+  omarchy-toggle-enabled monitor-management || return 0
+
   (
     flock -n 9 || exit 0
     omarchy-hyprland-monitor-clamshell
@@ -38,6 +38,11 @@ recover_modeless() {
     local delay=3 state reloaded unanswered=0
 
     while true; do
+      if ! omarchy-toggle-enabled monitor-management; then
+        sleep 2
+        continue
+      fi
+
       omarchy-hyprland-monitor-modeless
       state=$?
 
@@ -51,7 +56,9 @@ recover_modeless() {
 
       reloaded=0
       # Reloading into half-replaced package config is what the guard prevents.
-      if (( state == 0 )) && ! omarchy-hyprland-reload-guard paused; then
+      if (( state == 0 )) &&
+        omarchy-toggle-enabled monitor-management &&
+        ! omarchy-hyprland-reload-guard paused; then
         hyprctl reload >/dev/null 2>&1 || true
         reloaded=1
       fi

--- a/manual/33-monitors.md
+++ b/manual/33-monitors.md
@@ -42,6 +42,8 @@ Hyprland works great with multiple screens. Read more about how to lay them out 
 
 You can also checkout [Hyprmon](https://github.com/erans/hyprmon/), if you'd like a TUI to help you with the positioning of multiple screens.
 
+If another monitor manager handles hotplug and lid events, turn Omarchy's automatic monitor management off with `omarchy toggle monitor-management off`. Run `omarchy toggle monitor-management on` to hand control back to Omarchy.
+
 ### Controlling brightness
 
 Monitor brightness is controlled by the dedicated function keys for brightness up/down. If you hold down shift while pressing these, you'll go to maximum or minimum brightness. The keys control the display you're focused on, so external monitors that speak DDC/CI are adjusted the same way as the laptop screen.

--- a/migrations/1786813000.sh
+++ b/migrations/1786813000.sh
@@ -1,0 +1,3 @@
+echo "Enable Omarchy monitor management by default"
+
+omarchy-toggle monitor-management on

--- a/test/shell.d/monitor-clamshell-scale-test.sh
+++ b/test/shell.d/monitor-clamshell-scale-test.sh
@@ -15,6 +15,8 @@ state_dir="$home_dir/.local/state/omarchy/toggles/hypr"
 scale_state="$state_dir/internal-monitor-scale"
 
 mkdir -p "$stub_bin" "$home_dir/.config/hypr"
+mkdir -p "$home_dir/.local/state/omarchy/toggles"
+touch "$home_dir/.local/state/omarchy/toggles/monitor-management"
 
 cat >"$stub_bin/hyprctl" <<'SH'
 #!/bin/bash

--- a/test/shell.d/monitor-management-test.sh
+++ b/test/shell.d/monitor-management-test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+command_log="$test_tmp/commands.log"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-hyprland-monitor-laptop" <<'SH'
+#!/bin/bash
+printf 'clamshell continued\n' >>"$OMARCHY_TEST_COMMAND_LOG"
+SH
+
+cat >"$stub_bin/socat" <<'SH'
+#!/bin/bash
+printf 'watcher continued\n' >>"$OMARCHY_TEST_COMMAND_LOG"
+SH
+
+cat >"$stub_bin/omarchy-hw-external-monitors" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+chmod +x "$stub_bin"/*
+
+HOME="$test_tmp/home" \
+  PATH="$ROOT/bin:$PATH" \
+  bash "$ROOT/migrations/1786813000.sh" >/dev/null
+
+HOME="$test_tmp/home" PATH="$ROOT/bin:$PATH" omarchy-toggle-enabled monitor-management ||
+  fail "monitor management was not enabled by default"
+
+HOME="$test_tmp/home" \
+  PATH="$ROOT/bin:$PATH" \
+  omarchy-toggle monitor-management off
+
+if HOME="$test_tmp/home" PATH="$ROOT/bin:$PATH" omarchy-toggle-enabled monitor-management; then
+  fail "monitor management reported enabled after it was turned off"
+fi
+
+internal_toggle="$test_tmp/home/.local/state/omarchy/toggles/hypr/internal-monitor-disable.lua"
+mkdir -p "$(dirname "$internal_toggle")"
+touch "$internal_toggle"
+
+HOME="$test_tmp/home" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-hw-recover-internal-monitor"
+
+[[ -e $internal_toggle ]] || fail "startup recovery changed monitor state while monitor management was disabled"
+
+HOME="$test_tmp/home" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  OMARCHY_TEST_COMMAND_LOG="$command_log" \
+  "$ROOT/bin/omarchy-hyprland-monitor-clamshell"
+
+HOME="$test_tmp/home" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  XDG_RUNTIME_DIR="$test_tmp/run" \
+  HYPRLAND_INSTANCE_SIGNATURE=test \
+  OMARCHY_TEST_COMMAND_LOG="$command_log" \
+  "$ROOT/bin/omarchy-hyprland-monitor-watch"
+
+[[ ! -e $command_log ]] || fail "automatic monitor commands ran while monitor management was disabled"
+
+HOME="$test_tmp/home" \
+  PATH="$ROOT/bin:$PATH" \
+  omarchy-toggle monitor-management on
+
+[[ -e $test_tmp/home/.local/state/omarchy/toggles/monitor-management ]] || fail "monitor management remained disabled after turning it on"
+HOME="$test_tmp/home" PATH="$ROOT/bin:$PATH" omarchy-toggle-enabled monitor-management ||
+  fail "monitor management did not report enabled after it was turned on"
+
+HOME="$test_tmp/home" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-hw-recover-internal-monitor"
+
+[[ ! -e $internal_toggle ]] || fail "startup recovery did not resume after monitor management was enabled"
+pass "external monitor managers can turn Omarchy's automatic monitor handling off and on"

--- a/test/shell.d/monitor-management-test.sh
+++ b/test/shell.d/monitor-management-test.sh
@@ -5,20 +5,47 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 test_tmp=$(mktemp -d)
-trap 'rm -rf "$test_tmp"' EXIT
+watch_pid=""
+events_fd=""
+
+stop_watcher() {
+  local child descendants
+
+  if [[ -n $watch_pid ]]; then
+    descendants=$(pgrep -P "$watch_pid" 2>/dev/null || true)
+    for child in $descendants; do
+      descendants+=" $(pgrep -P "$child" 2>/dev/null || true)"
+    done
+
+    kill -KILL "$watch_pid" 2>/dev/null || true
+    wait "$watch_pid" 2>/dev/null || true
+    for child in $descendants; do
+      kill -KILL "$child" 2>/dev/null || true
+    done
+    watch_pid=""
+  fi
+
+  if [[ -n $events_fd ]]; then
+    exec {events_fd}>&-
+    events_fd=""
+  fi
+}
+
+cleanup() {
+  stop_watcher
+  rm -rf "$test_tmp"
+}
+trap cleanup EXIT
 
 stub_bin="$test_tmp/bin"
+watcher_bin="$test_tmp/watcher-bin"
 command_log="$test_tmp/commands.log"
-mkdir -p "$stub_bin"
+events="$test_tmp/events"
+mkdir -p "$stub_bin" "$watcher_bin"
 
 cat >"$stub_bin/omarchy-hyprland-monitor-laptop" <<'SH'
 #!/bin/bash
 printf 'clamshell continued\n' >>"$OMARCHY_TEST_COMMAND_LOG"
-SH
-
-cat >"$stub_bin/socat" <<'SH'
-#!/bin/bash
-printf 'watcher continued\n' >>"$OMARCHY_TEST_COMMAND_LOG"
 SH
 
 cat >"$stub_bin/omarchy-hw-external-monitors" <<'SH'
@@ -26,7 +53,66 @@ cat >"$stub_bin/omarchy-hw-external-monitors" <<'SH'
 exit 1
 SH
 
-chmod +x "$stub_bin"/*
+cat >"$watcher_bin/omarchy-hw-laptop" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$watcher_bin/omarchy-hyprland-monitor-clamshell" <<'SH'
+#!/bin/bash
+printf 'clamshell continued\n' >>"$OMARCHY_TEST_COMMAND_LOG"
+SH
+
+cat >"$watcher_bin/omarchy-hyprland-monitor-modeless" <<'SH'
+#!/bin/bash
+printf 'modeless checked\n' >>"$OMARCHY_TEST_COMMAND_LOG"
+exit 0
+SH
+
+cat >"$watcher_bin/omarchy-hyprland-reload-guard" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$watcher_bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ ${1:-} == "reload" ]] && printf 'monitor config reloaded\n' >>"$OMARCHY_TEST_COMMAND_LOG"
+SH
+
+cat >"$watcher_bin/socat" <<'SH'
+#!/bin/bash
+exec cat "$OMARCHY_TEST_EVENTS"
+SH
+
+chmod +x "$stub_bin"/* "$watcher_bin"/*
+
+await_log_line() {
+  local line="$1" waited
+
+  for ((waited = 0; waited < 100; waited++)); do
+    grep -Fqx "$line" "$command_log" 2>/dev/null && return 0
+    sleep 0.05
+  done
+
+  return 1
+}
+
+start_watcher() {
+  rm -f "$events"
+  mkdir -p "$test_tmp/run"
+  mkfifo "$events"
+
+  HOME="$test_tmp/home" \
+    PATH="$watcher_bin:$ROOT/bin:$PATH" \
+    XDG_RUNTIME_DIR="$test_tmp/run" \
+    HYPRLAND_INSTANCE_SIGNATURE=test \
+    OMARCHY_TEST_COMMAND_LOG="$command_log" \
+    OMARCHY_TEST_EVENTS="$events" \
+    "$ROOT/bin/omarchy-hyprland-monitor-watch" &
+  watch_pid=$!
+
+  exec {events_fd}>"$events"
+}
 
 HOME="$test_tmp/home" \
   PATH="$ROOT/bin:$PATH" \
@@ -58,14 +144,11 @@ HOME="$test_tmp/home" \
   OMARCHY_TEST_COMMAND_LOG="$command_log" \
   "$ROOT/bin/omarchy-hyprland-monitor-clamshell"
 
-HOME="$test_tmp/home" \
-  PATH="$stub_bin:$ROOT/bin:$PATH" \
-  XDG_RUNTIME_DIR="$test_tmp/run" \
-  HYPRLAND_INSTANCE_SIGNATURE=test \
-  OMARCHY_TEST_COMMAND_LOG="$command_log" \
-  "$ROOT/bin/omarchy-hyprland-monitor-watch"
+start_watcher
+sleep 0.2
 
 [[ ! -e $command_log ]] || fail "automatic monitor commands ran while monitor management was disabled"
+kill -0 "$watch_pid" 2>/dev/null || fail "monitor watcher exited while monitor management was disabled"
 
 HOME="$test_tmp/home" \
   PATH="$ROOT/bin:$PATH" \
@@ -73,7 +156,33 @@ HOME="$test_tmp/home" \
 
 [[ -e $test_tmp/home/.local/state/omarchy/toggles/monitor-management ]] || fail "monitor management remained disabled after turning it on"
 HOME="$test_tmp/home" PATH="$ROOT/bin:$PATH" omarchy-toggle-enabled monitor-management ||
-  fail "monitor management did not report enabled after it was turned on"
+  fail "monitor management did not report enabled after turning it on"
+
+printf 'monitoradded>>DP-1\n' >&"$events_fd"
+await_log_line "clamshell continued" || fail "running monitor watcher did not resume clamshell handling"
+await_log_line "monitor config reloaded" || fail "running monitor watcher did not resume modeless recovery"
+
+HOME="$test_tmp/home" \
+  PATH="$ROOT/bin:$PATH" \
+  omarchy-toggle monitor-management off
+
+: >"$command_log"
+printf 'monitoradded>>DP-2\n' >&"$events_fd"
+printf 'configreloaded>>\n' >&"$events_fd"
+sleep 1.5
+
+[[ ! -s $command_log ]] || fail "running monitor watcher changed monitor state after management was disabled"
+kill -0 "$watch_pid" 2>/dev/null || fail "monitor watcher exited instead of becoming ineffective"
+
+HOME="$test_tmp/home" \
+  PATH="$ROOT/bin:$PATH" \
+  omarchy-toggle monitor-management on
+
+printf 'monitorremoved>>DP-2\n' >&"$events_fd"
+await_log_line "clamshell continued" || fail "same monitor watcher did not resume after management was re-enabled"
+await_log_line "monitor config reloaded" || fail "modeless recovery did not resume after management was re-enabled"
+
+stop_watcher
 
 HOME="$test_tmp/home" \
   PATH="$stub_bin:$ROOT/bin:$PATH" \

--- a/test/shell.d/monitor-management-test.sh
+++ b/test/shell.d/monitor-management-test.sh
@@ -111,7 +111,7 @@ start_watcher() {
     "$ROOT/bin/omarchy-hyprland-monitor-watch" &
   watch_pid=$!
 
-  exec {events_fd}>"$events"
+  exec {events_fd}<>"$events"
 }
 
 HOME="$test_tmp/home" \

--- a/test/shell.d/monitor-management-test.sh
+++ b/test/shell.d/monitor-management-test.sh
@@ -129,6 +129,13 @@ if HOME="$test_tmp/home" PATH="$ROOT/bin:$PATH" omarchy-toggle-enabled monitor-m
   fail "monitor management reported enabled after it was turned off"
 fi
 
+HOME="$test_tmp/home" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-monitor-internal" toggle || true
+HOME="$test_tmp/home" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-monitor-internal-mirror" toggle || true
+[[ ! -e $command_log ]] || fail "laptop display keybindings ran while monitor management was disabled"
+pass "laptop display keybindings respect external monitor ownership"
+
 internal_toggle="$test_tmp/home/.local/state/omarchy/toggles/hypr/internal-monitor-disable.lua"
 mkdir -p "$(dirname "$internal_toggle")"
 touch "$internal_toggle"

--- a/test/shell.d/monitor-modeless-test.sh
+++ b/test/shell.d/monitor-modeless-test.sh
@@ -50,6 +50,8 @@ trap cleanup EXIT
 fake_bin="$test_tmp/bin"
 mkdir -p "$fake_bin"
 
+HOME="$test_tmp/home" PATH="$ROOT/bin:$PATH" omarchy-toggle monitor-management on
+
 monitors_file="$test_tmp/monitors.json"
 reload_log="$test_tmp/reload.log"
 recovered="$test_tmp/recovered.json"
@@ -163,6 +165,7 @@ start_watcher() {
   rm -f "$events"
   mkfifo "$events"
 
+  HOME="$test_tmp/home" \
   PATH="$fake_bin:$PATH" \
   XDG_RUNTIME_DIR="$test_tmp" \
   HYPRLAND_INSTANCE_SIGNATURE=test \

--- a/test/shell.d/monitor-output-name-test.sh
+++ b/test/shell.d/monitor-output-name-test.sh
@@ -36,6 +36,7 @@ make_stub hyprctl 'case "$1" in
 esac'
 
 eval_log="$tmpdir/eval.log"
+HOME="$home_dir" PATH="$ROOT/bin:$PATH" omarchy-toggle monitor-management on
 
 run_monitor() {
   local command=$1


### PR DESCRIPTION
## What changed

- Add `omarchy toggle monitor-management on|off` and respect it in the monitor watcher, clamshell reconciler, and startup recovery.
- Keep the monitor watcher subscribed while management is off, but make its clamshell and modeless-recovery actions ineffective so the same watcher resumes cleanly when management is turned back on.
- Document how an external monitor manager can claim and release automatic monitor handling.
- Verify that no automatic monitor-management entry point changes monitor state while monitor management is off.

## Why

Monitor configuration needs one active owner. Omarchy currently changes monitor state from several independent places:

- the monitor watcher
- clamshell reconciliation, called from the watcher, lid bindings, lock/wake, and sleep handling
- startup recovery
- monitor scaling commands and the display panel

These paths use different sources of truth, including compositor state, DRM state, parsed Lua, and toggle files, with no shared ownership boundary. One path can apply a valid layout and another can overwrite it seconds later. This is an architectural problem rather than another isolated parser edge case.

The newer reports make that especially clear:

- #8103: Omarchy's scaling command applies a change, then Omarchy's clamshell poll restores the old value.
- #8123: a valid configuration written by `nwg-displays` is misread and overwritten.
- #7084: a valid layout written by HyprMon in its own loaded Lua file is invisible to the clamshell parser and is overwritten.
- crmne/hyprmoncfg#48: typing or moving the mouse on the Quattro lock screen runs `omarchy-system-wake`, which calls the clamshell reconciler directly. It enables an internal panel that hyprmoncfg intentionally disabled; hyprmoncfg restores the profile, and the two repeat, making the lock screen flash.

That last case also shows why stopping `omarchy-hyprland-monitor-watch` is not sufficient: other entry points continue changing monitor state directly.

This exposes a mismatch in Omarchy's own guidance. The monitor guide points users to [HyprMon](https://github.com/erans/hyprmon/), but #7084 shows its valid `hyprmon.lua` layout being overwritten because Omarchy's clamshell logic only inspects `~/.config/hypr/monitors.lua`.

[hyprmoncfg](https://github.com/crmne/hyprmoncfg) currently works as well as it does on Quattro only because it carries several Omarchy-specific workarounds: it loads its generated configuration last, records the internal-panel scale where Omarchy expects it, suppresses the monitor watcher, and reasserts profiles after direct monitor changes. Even those measures cannot safely cover every independent entry point, as the lock-screen loop demonstrates.

Requiring every external monitor manager to reverse-engineer and neutralize each current and future Omarchy script is not a sustainable integration model. hyprmoncfg instead has one long-running owner: lid, hotplug, wake, and resume events go through one reconciliation loop and one monitor writer. It has used that model successfully for months.

This also follows the direction laid out in #2858: an event-driven architecture, with the work taken on by someone who actually uses and tests multiple displays.

Omarchy does not need to adopt that implementation or remove its own monitor handling. It only needs a supported way to stand down when the user delegates ownership to another manager. That is the narrow contract this PR adds. Monitor management remains enabled by default, so existing behavior does not change. When explicitly disabled, every automatic Omarchy entry point becomes inert; when re-enabled, the same watcher resumes normally.

## Related reports and work

Reports showing monitor paths overriding requested state:

- #6909
- #7084
- #8103
- #8123
- crmne/hyprmoncfg#43
- crmne/hyprmoncfg#44
- crmne/hyprmoncfg#48
- crmne/omarchy-hyprmoncfg#1

#7146 fixes specific parser cases while Omarchy remains the active monitor manager. It is complementary, but parser fixes cannot establish ownership or prevent direct clamshell, wake, and startup paths from competing with an external manager.

## Testing

- `bash test/shell.d/monitor-management-test.sh`
- `bash test/shell.d/monitor-modeless-test.sh`
- `bash test/shell.d/monitor-recovery-test.sh`
- `bash test/shell.d/monitor-clamshell-scale-test.sh`
- `./test/cli`