### PR TITLE
Cold-probe RTL8852BE after s2idle so Wi-Fi comes back

### DIFF
--- a/default/systemd/system-sleep/rtw89-8852be
+++ b/default/systemd/system-sleep/rtw89-8852be
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# RTL8852BE (10ec:b852) comes back wedged from s2idle. rtw89 resume fails with
+# "failed to write DBI", "xtal si not ready", and "mac preinit fail, ret: -110";
+# userspace then cannot bring the iface UP. Cold-probe after resume instead.
+# Remove when the rtw89 resume path can reinit this chip.
+
+rtw89_8852be_present() {
+  local dev
+  for dev in /sys/bus/pci/devices/*; do
+    [[ -f $dev/vendor && -f $dev/device ]] || continue
+    if [[ $(<"$dev/vendor") == "0x10ec" && $(<"$dev/device") == "0xb852" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if rtw89_8852be_present; then
+  case $1 in
+    pre)
+      logger "omarchy: unloading rtw89_8852be before $2"
+      modprobe -r rtw89_8852be rtw89_8852b rtw89_8852b_common rtw89_pci rtw89_core || true
+      ;;
+    post)
+      logger "omarchy: reloading rtw89_8852be after $2"
+      modprobe rtw89_8852be || true
+      ;;
+  esac
+fi

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -125,7 +125,11 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
   ├─ systemd/system-sleep/{force-igpu,
-  │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
+  │    keyboard-backlight,unmount-fuse,
+  │    rtw89-8852be}                                    /usr/lib/systemd/system-sleep/
+  │                                                       (rtw89-8852be and force-igpu
+  │                                                       are copied only on machines
+  │                                                       that need them)
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/
   ├─ fonts/omarchy/omarchy.ttf                          /usr/share/fonts/omarchy/
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -40,6 +40,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
+run_logged "$OMARCHY_INSTALL/hardware/realtek/fix-rtw89-8852be-resume.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-yt6801-ethernet-adapter.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-tuxedo-backlight.sh"

--- a/install/hardware/realtek/fix-rtw89-8852be-resume.sh
+++ b/install/hardware/realtek/fix-rtw89-8852be-resume.sh
@@ -1,0 +1,13 @@
+# RTL8852BE firmware/PCI comes back wedged from s2idle — the rtw89 resume
+# path fails with DBI / xtal / mac preinit -110, and rfkill/nmcli cannot
+# recover it. Install a sleep hook that cold-probes the driver instead.
+# Remove when a later kernel can resume this chip.
+
+if lspci -nn | grep -E '\[10ec:b852\]' >/dev/null; then
+  echo "Detected RTL8852BE; installing s2idle Wi-Fi resume hook"
+
+  dest=/usr/lib/systemd/system-sleep/rtw89-8852be
+  mkdir -p "$(dirname "$dest")"
+  cp -p "$OMARCHY_PATH/default/systemd/system-sleep/rtw89-8852be" "$dest"
+  chmod +x "$dest"
+fi

--- a/install/hardware/realtek/fix-rtw89-8852be-resume.sh
+++ b/install/hardware/realtek/fix-rtw89-8852be-resume.sh
@@ -2,8 +2,13 @@
 # path fails with DBI / xtal / mac preinit -110, and rfkill/nmcli cannot
 # recover it. Install a sleep hook that cold-probes the driver instead.
 # Remove when a later kernel can resume this chip.
+#
+# Buffer lspci before matching. A piped grep can SIGPIPE a chatty lspci
+# under pipefail and look like "no such hardware" (#6608).
 
-if lspci -nn | grep -E '\[10ec:b852\]' >/dev/null; then
+pci_info=$(lspci -nn)
+
+if [[ $pci_info == *'[10ec:b852]'* ]]; then
   echo "Detected RTL8852BE; installing s2idle Wi-Fi resume hook"
 
   dest=/usr/lib/systemd/system-sleep/rtw89-8852be

--- a/migrations/1786812448.sh
+++ b/migrations/1786812448.sh
@@ -7,7 +7,11 @@ echo "Install the RTL8852BE s2idle Wi-Fi resume hook on machines that need it"
 src="${OMARCHY_RTW89_HOOK_SRC:-$OMARCHY_PATH/default/systemd/system-sleep/rtw89-8852be}"
 dest="${OMARCHY_RTW89_HOOK_DST:-/usr/lib/systemd/system-sleep/rtw89-8852be}"
 
-if ! lspci -nn | grep -E '\[10ec:b852\]' >/dev/null; then
+# Buffer lspci before matching. A piped grep can SIGPIPE a chatty lspci
+# under pipefail and look like "no such hardware" (#6608).
+pci_info=$(lspci -nn)
+
+if [[ $pci_info != *'[10ec:b852]'* ]]; then
   exit 0
 fi
 

--- a/migrations/1786812448.sh
+++ b/migrations/1786812448.sh
@@ -1,0 +1,20 @@
+echo "Install the RTL8852BE s2idle Wi-Fi resume hook on machines that need it"
+
+# Fresh installs get this from install/hardware/realtek/fix-rtw89-8852be-resume.sh.
+# Existing installs never ran that leaf. The hook is hardware-conditional and is
+# not packaged for every machine; copy it only when the chip is present.
+
+src="${OMARCHY_RTW89_HOOK_SRC:-$OMARCHY_PATH/default/systemd/system-sleep/rtw89-8852be}"
+dest="${OMARCHY_RTW89_HOOK_DST:-/usr/lib/systemd/system-sleep/rtw89-8852be}"
+
+if ! lspci -nn | grep -E '\[10ec:b852\]' >/dev/null; then
+  exit 0
+fi
+
+if [[ -f $dest ]] && cmp -s "$src" "$dest"; then
+  exit 0
+fi
+
+sudo mkdir -p "$(dirname "$dest")"
+sudo cp -p "$src" "$dest"
+sudo chmod +x "$dest"

--- a/test/shell.d/rtw89-8852be-resume-test.sh
+++ b/test/shell.d/rtw89-8852be-resume-test.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/realtek/fix-rtw89-8852be-resume.sh"
+hook="$ROOT/default/systemd/system-sleep/rtw89-8852be"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1786812448.sh"
+
+grep -q 'realtek/fix-rtw89-8852be-resume.sh' "$all" ||
+  fail "the RTL8852BE resume hook runs during hardware setup"
+[[ -x $hook ]] || fail "the sleep hook is executable so systemd-sleep will run it"
+pass "the RTL8852BE resume hook is wired and executable"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin" "$test_tmp/pci"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${RTW89_HARDWARE:-0} == 1 )); then
+  echo '02:00.0 Network controller [0280]: Realtek RTL8852BE [10ec:b852]'
+fi
+for _ in {1..4096}; do
+  echo '00:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/modprobe" <<'SH'
+#!/bin/bash
+
+printf 'modprobe' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/logger" <<'SH'
+#!/bin/bash
+
+printf 'logger' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local script="$test_tmp/leaf.sh"
+  rm -rf "$test_tmp/sleep"
+  mkdir -p "$test_tmp/sleep"
+
+  sed -e "s|/usr/lib/systemd/system-sleep|$test_tmp/sleep|g" "$leaf" >"$script"
+
+  RTW89_HARDWARE="${1:-0}" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+run_leaf 1 >/dev/null
+[[ -x $test_tmp/sleep/rtw89-8852be ]] ||
+  fail "the leaf installs an executable hook" "$(ls -la "$test_tmp/sleep" 2>&1)"
+cmp -s "$hook" "$test_tmp/sleep/rtw89-8852be" ||
+  fail "the installed hook matches the packaged source"
+pass "the leaf installs the hook on RTL8852BE"
+
+run_leaf 0 >/dev/null
+[[ ! -e $test_tmp/sleep/rtw89-8852be ]] ||
+  fail "the leaf leaves other hardware alone"
+pass "the leaf leaves other hardware alone"
+
+write_pci() {
+  local present="$1"
+  rm -rf "$test_tmp/pci"
+  mkdir -p "$test_tmp/pci/0000:02:00.0"
+  if (( present )); then
+    printf '0x10ec\n' >"$test_tmp/pci/0000:02:00.0/vendor"
+    printf '0xb852\n' >"$test_tmp/pci/0000:02:00.0/device"
+  else
+    printf '0x8086\n' >"$test_tmp/pci/0000:02:00.0/vendor"
+    printf '0x272b\n' >"$test_tmp/pci/0000:02:00.0/device"
+  fi
+}
+
+run_hook() {
+  local present="$1" phase="$2"
+  write_pci "$present"
+  : >"$calls"
+
+  local script="$test_tmp/hook.sh"
+  sed -e "s|/sys/bus/pci/devices|$test_tmp/pci|g" "$hook" >"$script"
+  chmod +x "$script"
+
+  TEST_LOG="$calls" PATH="$stub_bin:$PATH" \
+    bash "$script" "$phase" suspend
+}
+
+run_hook 1 pre
+grep -Fq $'modprobe\t-r\trtw89_8852be\trtw89_8852b\trtw89_8852b_common\trtw89_pci\trtw89_core' "$calls" ||
+  fail "pre suspend unloads the rtw89 stack" "$(cat "$calls")"
+pass "pre suspend unloads the rtw89 stack"
+
+run_hook 1 post
+grep -Fq $'modprobe\trtw89_8852be' "$calls" ||
+  fail "post resume reloads rtw89_8852be" "$(cat "$calls")"
+! grep -Fq $'modprobe\t-r' "$calls" ||
+  fail "post resume does not unload the driver" "$(cat "$calls")"
+pass "post resume reloads rtw89_8852be"
+
+run_hook 0 pre
+[[ ! -s $calls ]] || fail "the hook is silent without RTL8852BE" "$(cat "$calls")"
+run_hook 0 post
+[[ ! -s $calls ]] || fail "the hook is silent without RTL8852BE" "$(cat "$calls")"
+pass "the hook is a no-op without RTL8852BE"
+
+run_migration() {
+  local present="$1"
+  : >"$calls"
+  RTW89_HARDWARE="$present" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_RTW89_HOOK_SRC="$hook" \
+    OMARCHY_RTW89_HOOK_DST="$test_tmp/sleep/rtw89-8852be" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/sleep"
+run_migration 1
+[[ -x $test_tmp/sleep/rtw89-8852be ]] ||
+  fail "the migration installs the hook" "$(ls -la "$test_tmp/sleep" 2>&1)"
+grep -Fq $'sudo\tcp\t-p' "$calls" ||
+  fail "the migration copies the hook as root" "$(cat "$calls")"
+pass "the migration installs the hook on RTL8852BE"
+
+run_migration 1
+[[ ! -s $calls ]] || fail "the migration is idempotent" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+rm -rf "$test_tmp/sleep"
+run_migration 0
+[[ ! -e $test_tmp/sleep/rtw89-8852be ]] ||
+  fail "the migration skips other hardware"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on other hardware" "$(cat "$calls")"
+pass "the migration skips other hardware"

--- a/test/shell.d/rtw89-8852be-resume-test.sh
+++ b/test/shell.d/rtw89-8852be-resume-test.sh
@@ -12,6 +12,8 @@ migration="$ROOT/migrations/1786812448.sh"
 grep -q 'realtek/fix-rtw89-8852be-resume.sh' "$all" ||
   fail "the RTL8852BE resume hook runs during hardware setup"
 [[ -x $hook ]] || fail "the sleep hook is executable so systemd-sleep will run it"
+! grep -E 'lspci[^\n]*\|' "$leaf" "$migration" ||
+  fail "hardware detection buffers lspci instead of piping it to grep"
 pass "the RTL8852BE resume hook is wired and executable"
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
Fixes #7003.

RTL8852BE (`10ec:b852`) comes back from `s2idle` with the rtw89 resume path wedged (`failed to write DBI`, `xtal si not ready`, `mac preinit fail, ret: -110`). `omarchy-restart-wifi` only toggles rfkill/nmcli, so it cannot recover a dead phy.

This follows the existing hardware-conditional sleep-hook pattern (`force-igpu`, `unowned-system-paths-test`): the hook is not packaged for every machine. Setup copies it only when `lspci` sees `10ec:b852`. A migration does the same for existing installs. The hook itself also gates on the PCI ID and is a no-op anywhere else.

`rtw89_pci` ASPM module options (`disable_clkreq` / `disable_aspm_l1` / `disable_aspm_l1ss`) were tried first and did not prevent `mac preinit -110`. The hook is the piece that actually brings the radio back: unload on `pre`, `modprobe rtw89_8852be` on `post` (cold init).

Tested on an ASUS Vivobook S 14 S3407CA (AzureWave `1a3b:5471`) by closing the lid and unlocking. Related: #5003 (same chip; restarting NetworkManager is the wrong layer).

Remove `default/systemd/system-sleep/rtw89-8852be` when rtw89 can resume this chip.