### PR TITLE
Render the Plymouth theme at the display's device scale

### DIFF
--- a/bin/omarchy-plymouth-activate
+++ b/bin/omarchy-plymouth-activate
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# omarchy:summary=Select the Omarchy Plymouth theme and rebuild the initramfs
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# omarchy-plymouth-generate renders the theme's art at the display's device
+# scale, so plymouthd must not scale it a second time: with the art already
+# sized in device pixels, one logical pixel has to equal one device pixel.
+#
+# plymouth-set-default-theme rewrites only the Theme key, so DeviceScale
+# survives a theme switch. The plymouth mkinitcpio hook bundles this config
+# into the initramfs, which is where the disk passphrase is asked for.
+
+set -euo pipefail
+
+conf=/etc/plymouth/plymouthd.conf
+
+sudo python3 - "$conf" <<'PY'
+import os, sys
+
+path = sys.argv[1]
+lines = open(path).read().splitlines() if os.path.exists(path) else []
+
+out, in_daemon, written, seen_daemon = [], False, False, False
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        if in_daemon and not written:
+            out.append("DeviceScale=1")
+            written = True
+        in_daemon = stripped == "[Daemon]"
+        seen_daemon = seen_daemon or in_daemon
+        out.append(line)
+        continue
+    if in_daemon and stripped.split("=")[0].strip() == "DeviceScale":
+        if not written:
+            out.append("DeviceScale=1")
+            written = True
+        continue
+    out.append(line)
+
+if in_daemon and not written:
+    out.append("DeviceScale=1")
+    written = True
+if not seen_daemon:
+    out += ["[Daemon]", "DeviceScale=1"]
+
+open(path, "w").write("\n".join(out) + "\n")
+PY
+
+sudo plymouth-set-default-theme omarchy
+
+if omarchy-cmd-present limine-mkinitcpio; then
+  sudo limine-mkinitcpio
+else
+  sudo mkinitcpio -P
+fi

--- a/bin/omarchy-plymouth-device-scale
+++ b/bin/omarchy-plymouth-device-scale
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# omarchy:summary=Print the device scale Plymouth picks for the primary display
+# omarchy:hidden=true
+
+# Mirrors get_device_scale() in plymouth's src/libply/ply-utils.c so generated
+# theme assets match what plymouthd would do on its own:
+#
+#   diag_inches  = hypot(width_mm, height_mm) / 25.4
+#   physical_dpi = hypot(width_px, height_px) / diag_inches
+#   target_dpi   = diag_inches >= 20 ? 110 : 135
+#   scale        = (physical_dpi / target_dpi) > 1.625 ? 2 : 1
+#
+# Falls back to 1 whenever the panel cannot be measured, which is what plymouth
+# does with a missing or bogus physical size.
+
+for conn in /sys/class/drm/card*-*; do
+  [[ -r $conn/status ]] || continue
+  [[ $(<"$conn/status") == connected ]] || continue
+
+  mode=$(head -n1 "$conn/modes" 2>/dev/null) || continue
+  [[ $mode =~ ^([0-9]+)x([0-9]+) ]] || continue
+
+  # EDID 1.x basic display parameters: byte 0x15 = h size (cm), 0x16 = v size.
+  read -r wcm hcm < <(od -An -tu1 -j21 -N2 "$conn/edid" 2>/dev/null)
+  [[ -n ${wcm:-} && -n ${hcm:-} ]] || continue
+  ((wcm > 0 && hcm > 0)) || continue
+
+  awk -v w="${BASH_REMATCH[1]}" -v h="${BASH_REMATCH[2]}" \
+      -v wmm="$((wcm * 10))" -v hmm="$((hcm * 10))" '
+    BEGIN {
+      # An aspect ratio encoded where the physical size belongs is not a size.
+      if ((wmm == 160 && hmm == 90) || (wmm == 160 && hmm == 100) ||
+          (wmm == 10 && hmm == 10)) { print 1; exit }
+      diag_in = sqrt(wmm * wmm + hmm * hmm) / 25.4
+      dpi     = sqrt(w * w + h * h) / diag_in
+      target  = (diag_in >= 20) ? 110 : 135
+      print (dpi / target > 1.625) ? 2 : 1
+    }'
+  exit 0
+done
+
+echo 1

--- a/bin/omarchy-plymouth-generate
+++ b/bin/omarchy-plymouth-generate
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# omarchy:summary=Render the Plymouth theme assets and script for a device scale
+# omarchy:args=<theme-dir> <text-hex> [scale]
+# omarchy:hidden=true
+
+# Plymouth picks a device scale from the panel's DPI and resamples every sprite
+# to match, so 1x art reaches a HiDPI framebuffer through an upscale. The entry
+# field suffers worst: its border is baked in as 58%-alpha / solid / 58%-alpha
+# rows, an anti-aliased line frozen into a bitmap that stays soft at any scale.
+#
+# This renders each asset at its final device-pixel size instead, from the
+# vector sources in default/plymouth/src, and expresses the script's hard-coded
+# 1x constants in terms of a generated `global.scale`. Callers pin DeviceScale=1
+# (see omarchy-plymouth-activate) so plymouthd blits the result 1:1.
+#
+# Operates in place on a directory that already holds a copy of
+# default/plymouth. Prints the scale it rendered for.
+
+set -euo pipefail
+
+theme_dir="${1:?Usage: omarchy-plymouth-generate <theme-dir> <text-hex> [scale]}"
+text_hex="${2:?Usage: omarchy-plymouth-generate <theme-dir> <text-hex> [scale]}"
+scale="${3:-$(omarchy-plymouth-device-scale)}"
+
+omarchy-plymouth-render-icons "$theme_dir" "$text_hex" "$scale"
+
+# The logo is pixel art, so nearest-neighbour reproduces it exactly at any
+# integer scale. Themes supply their own, so it is scaled rather than redrawn.
+magick "$theme_dir/logo.png" -filter point -resize "$((100 * scale))%" "$theme_dir/logo.png"
+
+# progress_bar takes the theme's text colour; progress_box keeps its own.
+magick -size "$((300 * scale))x$((10 * scale))" "xc:$text_hex" "$theme_dir/progress_bar.png"
+magick -size "$((300 * scale))x$((10 * scale))" "xc:#292E42" "$theme_dir/progress_box.png"
+
+sed -i -e "s/^global.scale = .*/global.scale = $scale;/" "$theme_dir/omarchy.script"
+sed -i -E "s/^(MonospaceFont|Font)=Cantarell [0-9]+/\1=Cantarell $((11 * scale))/" \
+  "$theme_dir/omarchy.plymouth"
+
+echo "$scale"

--- a/bin/omarchy-plymouth-preview
+++ b/bin/omarchy-plymouth-preview
@@ -38,9 +38,9 @@ trap 'rm -rf "$staging_dir"' EXIT
 find "$OMARCHY_PATH/default/plymouth" -maxdepth 1 -type f -exec cp -t "$staging_dir/" {} +
 cp "$logo_path" "$staging_dir/logo.png"
 
-for asset in bullet.png entry.png lock.png; do
-  magick "$staging_dir/$asset" -channel RGB +level-colors "#$text_hex","#$text_hex" "$staging_dir/$asset"
-done
+# A preview is a fixed-size thumbnail, so the icons stay at 1x here regardless
+# of what scale the installed theme was rendered for.
+omarchy-plymouth-render-icons "$staging_dir" "#$text_hex"
 
 canvas_w=1920
 canvas_h=1080

--- a/bin/omarchy-plymouth-render-icons
+++ b/bin/omarchy-plymouth-render-icons
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# omarchy:summary=Render the Plymouth entry field, lock and bullet at a scale
+# omarchy:args=<output-dir> <text-hex> [scale]
+# omarchy:hidden=true
+
+# These three are drawn from vector rather than shipped as bitmaps because
+# neither survives resampling: entry.png's border is baked in as
+# 58%-alpha / solid / 58%-alpha rows — an anti-aliased line frozen into a
+# bitmap — and lock.png is anti-aliased throughout. Rendering them at the size
+# they will actually occupy is the only way to get a crisp edge.
+#
+# Consumers want different scales: Plymouth needs the display's device scale,
+# while SDDM (Qt, scales itself) and the theme previews (fixed-size thumbnails)
+# want 1x.
+
+set -euo pipefail
+
+out_dir="${1:?Usage: omarchy-plymouth-render-icons <output-dir> <text-hex> [scale]}"
+text_hex="${2:?Usage: omarchy-plymouth-render-icons <output-dir> <text-hex> [scale]}"
+scale="${3:-1}"
+
+src_dir="$OMARCHY_PATH/default/plymouth/src"
+
+[[ $text_hex =~ ^#[0-9a-fA-F]{6}$ ]] || { echo "text colour must be #RRGGBB" >&2; exit 1; }
+[[ $scale =~ ^[1-9][0-9]*$ ]] || { echo "scale must be a positive integer" >&2; exit 1; }
+
+render() { # render <name> <1x-width> <1x-height>
+  sed "s/#C0CAF5/$text_hex/g" "$src_dir/$1.svg" |
+    rsvg-convert -w "$(($2 * scale))" -h "$(($3 * scale))" -o "$out_dir/$1.png"
+}
+
+render entry 286 48
+render lock 84 96
+render bullet 7 7

--- a/bin/omarchy-plymouth-set
+++ b/bin/omarchy-plymouth-set
@@ -50,18 +50,10 @@ sed -i \
   -e "s/^Window.SetBackgroundBottomColor.*/Window.SetBackgroundBottomColor($bg_r, $bg_g, $bg_b);/" \
   "$staging_dir/omarchy.script"
 
-for asset in bullet.png entry.png lock.png progress_bar.png; do
-  magick "$staging_dir/$asset" -channel RGB +level-colors "#$text_hex","#$text_hex" "$staging_dir/$asset"
-done
+omarchy-plymouth-generate "$staging_dir" "#$text_hex" >/dev/null
 
 sudo cp -a --no-preserve=mode,ownership "$staging_dir/." "$theme_dir/"
-sudo plymouth-set-default-theme omarchy
-
-if omarchy-cmd-present limine-mkinitcpio; then
-  sudo limine-mkinitcpio
-else
-  sudo mkinitcpio -P
-fi
+omarchy-plymouth-activate
 
 # Sync the SDDM login screen with the same colors and logo.
 sddm_dir="/usr/share/sddm/themes/omarchy"
@@ -73,11 +65,19 @@ sed \
   "$sddm_template" | sudo tee "$sddm_dir/Main.qml" >/dev/null
 
 sudo cp "$logo_path" "$sddm_dir/logo.png"
+
+# SDDM is a Qt app and does its own HiDPI scaling, so it keeps the art at 1x
+# while Plymouth's copy above is rendered for the display's device scale.
+sddm_stage=$(mktemp -d)
+trap 'rm -rf "$staging_dir" "$sddm_stage"' EXIT
+
+omarchy-plymouth-render-icons "$sddm_stage" "#$text_hex"
 for asset in bullet.png entry.png lock.png; do
-  sudo cp "$staging_dir/$asset" "$sddm_dir/$asset"
+  sudo cp "$sddm_stage/$asset" "$sddm_dir/$asset"
 done
+
+omarchy-plymouth-render-icons "$sddm_stage" "#f7768e"
 for asset in entry lock; do
-  magick "$staging_dir/$asset.png" -channel RGB +level-colors "#f7768e","#f7768e" "$staging_dir/$asset-failed.png"
-  sudo cp "$staging_dir/$asset-failed.png" "$sddm_dir/$asset-failed.png"
+  sudo cp "$sddm_stage/$asset.png" "$sddm_dir/$asset-failed.png"
 done
 sudo rm -f "$sddm_dir/logo.svg"

--- a/bin/omarchy-refresh-plymouth
+++ b/bin/omarchy-refresh-plymouth
@@ -3,11 +3,15 @@
 # omarchy:summary=Overwrite the user config for the Plymouth drive decryption and boot sequence with the Omarchy default and rebuild it.
 # omarchy:requires-sudo=true
 
-sudo cp -r "$OMARCHY_PATH/default/plymouth/." /usr/share/plymouth/themes/omarchy/
-sudo plymouth-set-default-theme omarchy
+theme_dir="/usr/share/plymouth/themes/omarchy"
+staging_dir=$(mktemp -d)
+trap 'rm -rf "$staging_dir"' EXIT
 
-if omarchy-cmd-present limine-mkinitcpio; then
-  sudo limine-mkinitcpio
-else
-  sudo mkinitcpio -P
-fi
+cp -r "$OMARCHY_PATH/default/plymouth/." "$staging_dir/"
+
+# The defaults ship 1x art; render it for this display's device scale.
+omarchy-plymouth-generate "$staging_dir" "#C0CAF5" >/dev/null
+rm -rf "$staging_dir/src"
+
+sudo cp -a --no-preserve=mode,ownership "$staging_dir/." "$theme_dir/"
+omarchy-plymouth-activate

--- a/default/plymouth/omarchy.script
+++ b/default/plymouth/omarchy.script
@@ -1,5 +1,10 @@
 # Omarchy Plymouth Theme Script
 
+# Every pixel constant below is written in 1x logical units and multiplied by
+# this scale. omarchy-plymouth-generate rewrites the line to match the art it
+# renders for the display; 1 is the plain unscaled theme.
+global.scale = 1;
+
 Window.SetBackgroundTopColor(0.101, 0.105, 0.149);
 Window.SetBackgroundBottomColor(0.101, 0.105, 0.149);
 
@@ -109,19 +114,19 @@ bullet.image = Image("bullet.png");
 
 entry.sprite = Sprite(entry.image);
 entry.x = Window.GetWidth() / 2 - entry.image.GetWidth() / 2;
-entry.y = logo.sprite.GetY() + logo.image.GetHeight() + 40;
+entry.y = logo.sprite.GetY() + logo.image.GetHeight() + 40 * global.scale;
 entry.sprite.SetPosition(entry.x, entry.y, 10001);
 entry.sprite.SetOpacity(0);
 
 # Scale lock to be slightly shorter than entry field height
 # Original lock is 84x96, entry height determines scale
 lock_height = entry.image.GetHeight() * 0.8;
-lock_scale = lock_height / 96;
-lock_width = 84 * lock_scale;
+lock_scale = lock_height / (96 * global.scale);
+lock_width = 84 * global.scale * lock_scale;
 
 scaled_lock = lock.image.Scale(lock_width, lock_height);
 lock.sprite = Sprite(scaled_lock);
-lock.x = entry.x - lock_width - 15;
+lock.x = entry.x - lock_width - 15 * global.scale;
 lock.y = entry.y + entry.image.GetHeight() / 2 - lock_height / 2;
 lock.sprite.SetPosition(lock.x, lock.y, 10001);
 lock.sprite.SetOpacity(0);
@@ -165,10 +170,10 @@ fun display_password_callback(prompt, bullets) {
   for (index = 0; index < bullets_to_show; index++) {
     if (!bullet.sprites[index]) {
       # Scale bullet image to 7x7 pixels
-      scaled_bullet = bullet.image.Scale(7, 7);
+      scaled_bullet = bullet.image.Scale(7 * global.scale, 7 * global.scale);
       bullet.sprites[index] = Sprite(scaled_bullet);
-      bullet.x = entry.x + 20 + index * (7 + 5);
-      bullet.y = entry.y + entry.image.GetHeight() / 2 - 3.5;
+      bullet.x = entry.x + (20 + index * (7 + 5)) * global.scale;
+      bullet.y = entry.y + entry.image.GetHeight() / 2 - 3.5 * global.scale;
       bullet.sprites[index].SetPosition(bullet.x, bullet.y, 10002);
     }
 
@@ -219,7 +224,7 @@ Plymouth.SetBootProgressFunction(progress_callback);
 #----------------------------------------- Message --------------------------------
 
 message_sprite = Sprite();
-message_sprite.SetPosition(10, 10, 10000);
+message_sprite.SetPosition(10 * global.scale, 10 * global.scale, 10000);
 
 fun display_message_callback(text) {
   message = Image.Text(text, 1, 1, 1);

--- a/default/plymouth/src/bullet.svg
+++ b/default/plymouth/src/bullet.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="7" height="7" viewBox="0 0 7 7">
+  <!-- Drawn at its final on-screen size; the theme script no longer downscales. -->
+  <circle cx="3.5" cy="3.5" r="3.5" fill="#C0CAF5"/>
+</svg>

--- a/default/plymouth/src/entry.svg
+++ b/default/plymouth/src/entry.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="286" height="48" viewBox="0 0 286 48">
+  <!-- Authored in 1x logical units; rendered at the target device scale.
+       Half-pixel offsets keep the 1-unit stroke on the pixel grid so it stays
+       crisp at every integer scale. -->
+  <rect x="0.5" y="0.5" width="285" height="47"
+        fill="#000000" fill-opacity="0.051"
+        stroke="#C0CAF5" stroke-width="1"/>
+</svg>

--- a/default/plymouth/src/lock.svg
+++ b/default/plymouth/src/lock.svg
@@ -1,0 +1,8 @@
+<!-- lock-closed (solid) from Heroicons, MIT licensed, https://heroicons.com
+     The viewBox is widened from the icon's own 16.5x21 of drawn content to an
+     84:96 slot, matching the dimensions the theme script derives the lock's
+     placement from. #C0CAF5 is the recolour token. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.8125 1.5 18.375 21" width="84" height="96">
+  <path fill="#C0CAF5" fill-rule="evenodd" clip-rule="evenodd"
+        d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" />
+</svg>

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -68,6 +68,7 @@ kernel-modules-hook
 lazydocker
 lazygit
 less
+librsvg
 libsecret
 libvips
 libyaml


### PR DESCRIPTION
## The problem

Plymouth reads the panel's physical size from the EDID and derives a device scale from it, then resamples every sprite to match. From `get_device_scale()` in `src/libply/ply-utils.c`:

```
diag_inches  = hypot(width_mm, height_mm) / 25.4
physical_dpi = hypot(width_px, height_px) / diag_inches
target_dpi   = diag_inches >= 20 ? 110 : 135
scale        = (physical_dpi / target_dpi) > 1.625 ? 2 : 1
```

On the 27" 5K display I hit this on:

```
5120x2880 on 600x330 mm  ->  27.0"  ->  218 DPI
target_dpi = 110         ->  perfect_scale = 1.98
1.98 > 1.625             ->  device_scale = 2
```

The theme ships only 1x art, so at scale 2 the disk-passphrase screen reaches the framebuffer through a 2x upscale. It reads as if the boot screen is running at a lower resolution than the desktop.

Two assets could not survive resampling at any scale:

- **`entry.png`** bakes its border in as three rows of pixels — 58% alpha, solid, 58% alpha. That is an anti-aliased 1px line frozen into a bitmap, so the entry field has a soft double edge even at 1x.
- **`lock.png`** is anti-aliased throughout, so upscaling only enlarges the existing gradient.

## Why it has to happen at install time

The script plugin exposes `Window.GetWidth/GetHeight/GetX/GetY`, `Image.Scale` and `Plymouth.GetMode`, but no accessor for the device scale and no `@2x` asset lookup. A theme cannot adapt at runtime, so the scale has to be resolved when the theme is installed and the initramfs is rebuilt — which is already where `omarchy-plymouth-set` generates art with ImageMagick.

## What this does

- `entry`, `lock` and `bullet` move to vector sources under `default/plymouth/src`, rendered at the size they will actually occupy. Authored in 1x logical units with half-pixel offsets so strokes stay on the pixel grid at every integer scale.
- The logo stays a bitmap. It is 96% hard-edged pixel art, so nearest-neighbour reproduces it exactly.
- The script's hard-coded 1x constants are expressed in terms of a generated `global.scale`:

  ```diff
  +global.scale = 1;
  -entry.y = logo.sprite.GetY() + logo.image.GetHeight() + 40;
  +entry.y = logo.sprite.GetY() + logo.image.GetHeight() + 40 * global.scale;
  -lock_scale = lock_height / 96;
  +lock_scale = lock_height / (96 * global.scale);
  ```

- `DeviceScale=1` is pinned in `plymouthd.conf`, so plymouthd stops scaling art that already sits in device pixels. `plymouth-set-default-theme` rewrites only the `Theme` key, so it survives theme switches, and the plymouth mkinitcpio hook bundles the config into the initramfs.

Four hidden commands carry it: `device-scale` reads the scale, `render-icons` draws the three vector assets at a given scale, `generate` produces a whole theme directory, `activate` pins DeviceScale and rebuilds the initramfs. `activate` also absorbs the theme-select and initramfs-rebuild block that `omarchy-plymouth-set` and `omarchy-refresh-plymouth` each carried separately.

SDDM is Qt and scales itself, so it keeps the icons at 1x. Theme previews are fixed-size thumbnails and keep 1x too.

**At `global.scale = 1` the script behaves exactly as before**, and the generated assets come out at the shipped dimensions — 286x48, 84x96, 800x188, 300x10. Nothing changes on a standard-DPI display beyond the entry field and lock icon gaining crisp edges.

## Draft, because these are open

1. **Not yet verified on real hardware.** I have not rebooted with this installed. The device-scale figure is computed from Plymouth's own formula and the generator is tested end to end, but the actual boot screen is unconfirmed. This is the main thing to resolve before it leaves draft.

2. **The lock icon changes appearance.** It is now Heroicons `lock-closed` (MIT), which has no keyhole and a thinner shackle than the current art. Using a real vector source beats tracing the PNG, but it is a design change riding along with a rendering fix — say the word and I will trace the existing shape instead so the look is preserved exactly.

3. **`librsvg` added to `omarchy-base.packages`.** It already arrives via gtk3/gtk4/hyprcursor/hyprgraphics, so this only makes an existing transitive dependency explicit. Happy to drop it and guard with `omarchy-cmd-present` instead if you would rather not add the line.

4. **Packaging coverage not checked.** `test/shell.d/unowned-system-paths-test.sh` needs a sibling `omarchy-pkgs` checkout, which I do not have, so the four new `bin/` commands and `default/plymouth/src/` have not been verified against the PKGBUILD.

5. **`DeviceScale=1` is a single-display assumption.** Attach a monitor with a different DPI and the art no longer matches until the theme is regenerated. Plymouth picks one scale for the whole session, so a mixed-DPI setup cannot be right on both screens either way. A `monitor-hotplug` hook calling `omarchy-refresh-plymouth` would cover it, but that felt like scope.

## Tests

`./test/cli` passes. `./test/shell` has 3 failures — `config`, `snapper`, `unowned-system-paths` — all of them pre-existing on a clean checkout of `quattro` here, all from the missing `omarchy-pkgs` checkout.
