### PR TITLE
Keep bar clicks out of login shells

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -32,7 +32,7 @@ BarWidget {
 
   function focusWorkspace(id) {
     if (!root.bar) return
-    root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
+    Hyprland.dispatch("hl.dsp.focus({ workspace = \"" + id + "\" })")
   }
 
   readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)

--- a/shell/plugins/menu/BarWidget.qml
+++ b/shell/plugins/menu/BarWidget.qml
@@ -17,8 +17,12 @@ BarWidget {
     horizontalMargin: 7.5
     onPressed: function(button) {
       if (!root.bar) return
-      if (button === Qt.RightButton) root.bar.run("xdg-terminal-exec")
-      else root.bar.run("omarchy-shell shell toggle omarchy.menu '{\"menu\":\"root\"}'")
+      if (button === Qt.RightButton)
+        root.bar.run("xdg-terminal-exec")
+      else if (root.bar.shell && typeof root.bar.shell.toggle === "function")
+        root.bar.shell.toggle("omarchy.menu", JSON.stringify({ menu: "root" }))
+      else
+        root.bar.run("omarchy-shell shell toggle omarchy.menu '{\"menu\":\"root\"}'")
     }
   }
 }

--- a/test/shell.d/bar-click-test.sh
+++ b/test/shell.d/bar-click-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+// bar.run() starts a login shell on purpose (see shell-launch-test.sh), so
+// click handlers that can reach their target in process must stay off it.
+const menuQml = fs.readFileSync(
+  path.join(root, 'shell/plugins/menu/BarWidget.qml'), 'utf8')
+
+assert(
+  /onPressed:[\s\S]*?root\.bar\.shell\.toggle\("omarchy\.menu"/.test(menuQml),
+  'menu widget toggles the menu plugin in process'
+)
+
+JS

--- a/test/shell.d/bar-click-test.sh
+++ b/test/shell.d/bar-click-test.sh
@@ -17,4 +17,12 @@ assert(
   'menu widget toggles the menu plugin in process'
 )
 
+const workspacesQml = fs.readFileSync(
+  path.join(root, 'shell/plugins/bar/widgets/Workspaces.qml'), 'utf8')
+
+assert(
+  /function focusWorkspace\(id\)[\s\S]*?Hyprland\.dispatch\(/.test(workspacesQml),
+  'workspace widget dispatches over Hyprland IPC'
+)
+
 JS


### PR DESCRIPTION
Clicking the bar's menu icon spawns a login shell and a `qs ipc` client to send a message back to the *same* Quickshell process it came from. The menu plugin already lives there. `bar.run()` uses `bash -lc`, so every click also sources the user's whole login profile.

The workspace switcher does the same, running `hyprctl` through a login shell even though the widget already reads its state over Hyprland IPC.

**Fix:** menu calls `shell.toggle()` directly (old command kept as a fallback); workspaces use `Hyprland.dispatch()`.

## Numbers

Per click: **3 subprocesses → 0**, ~92 ms → in process.

The process count is the same anywhere. The milliseconds depend on your profile, mine has a `/etc/profile.d` script that starts Python, so a login shell costs ~50 ms warm, ~110 ms after boot.

On the unpatched build both paths spawn 3 processes, but `SUPER+SPACE` takes 45 ms and a click takes 92 ms. Hyprland execs directly; the click pays `bash -lc` first. That gap is the login shell.

## Videos

The overlay counts subprocesses per click.


https://github.com/user-attachments/assets/95a6021b-8b77-4bbf-86a5-cbf44fd75fc2


https://github.com/user-attachments/assets/1999c3c3-ec4e-4c25-8cb3-3e92d7e7605c

## Notes

- `SUPER+SPACE` is unchanged and still spawns 3 it comes from Hyprland, so it has to.
- `Util.execDetached` keeps `bash -lc`; that is deliberate and `shell-launch-test.sh` asserts it. This only changes two click handlers that never needed to leave the process.
- Same idea as #6815 and a64d895a.