### PR TITLE
Keep concurrent mise wrappers from corrupting config.toml

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -18,11 +18,14 @@ mkdir -p "$HOME/.local/bin"
 # hold a new version back for days after it ships. Exported rather than set on
 # the install line alone, so resolving the version to execute agrees with the
 # one just installed.
+#
+# mise use -g rewrites ~/.config/mise/config.toml whole, so concurrent wrappers
+# (an agent host probing claude, codex and gh at once) drop each other's tools.
 rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g --quiet "$package" || exit 1
+flock "\${XDG_RUNTIME_DIR:-/tmp}/omarchy-mise-use.lock" mise use -g --quiet "$package" || exit 1
 exec mise x "$package" -- "$bin" "\$@"
 EOF
 

--- a/migrations/1786818022.sh
+++ b/migrations/1786818022.sh
@@ -1,0 +1,12 @@
+echo "Regenerate mise wrappers to serialize their config writes"
+
+for wrapper in "$HOME/.local/bin"/*; do
+  [[ -f $wrapper && -x $wrapper ]] || continue
+
+  package=$(sed -n 's/^mise use -g \(--quiet \)\{0,1\}"\(.*\)" || exit 1$/\2/p' "$wrapper")
+  bin=$(sed -n 's/^exec mise x "[^"]*" -- "\([^"]*\)" "\$@"$/\1/p' "$wrapper")
+
+  if [[ -n $package && -n $bin ]]; then
+    omarchy-mise-install "$package" "$(basename "$wrapper")" "$bin"
+  fi
+done

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -114,6 +114,10 @@ assert_lazy_stub "$omp_package" omp
 assert_lazy_stub "$crush_package" crush
 pass "custom agent lazy stubs preserve their mise packages"
 
+grep -Fxq 'flock "${XDG_RUNTIME_DIR:-/tmp}/omarchy-mise-use.lock" mise use -g --quiet "'"$grok_package"'" || exit 1' "$test_home/.local/bin/grok" ||
+  fail "lazy stub serializes its mise use -g config write"
+pass "custom agent lazy stubs serialize their mise config writes"
+
 source "$ROOT/install/user/mise.sh"
 grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "user setup creates the Oh My Pi lazy stub"


### PR DESCRIPTION
## Problem

Each mise wrapper in `~/.local/bin` runs `mise use -g <pkg>` at every start. `mise use -g` rewrites `~/.config/mise/config.toml` from its own copy of the file. When two wrappers start at the same time, they race. The second writer removes the tool of the first writer, or it leaves the file half-written.

Agent hosts start wrappers this way. t3code runs `claude`, `codex` and `gh` at the same time on startup. After one such start, my config file was:

```
[tools]
codex = "latest"
t"
```

After that, every mise-backed tool failed with `Error loading settings file: TOML parse error at line 3`. t3code showed "Claude Agent CLI is installed but failed to run", "Codex App Server process exited with code 1" and "GitHub CLI command failed". The terminal failed in the same way. The failures stopped only after I repaired the file by hand.

## Proof

mise rewrites the config file in place. The inode is the same before and after `mise use -g`. When a shorter write follows a longer one, the tail of the old file stays. The corrupt file above shows this: mise wrote `[tools]\ncodex = "latest"\n` (25 bytes) over `[tools]\nopencode = "latest"\n` (28 bytes). Bytes 25–27 of the longer file are `t"\n`.

Test: a config file with 7 tools, 12 wrappers started at the same time (3× claude/codex/gh/opencode), 8 runs. Tools left in the config file after each run:

```
current template:  7 2 7 7 7 7 3 4
patched template:  7 7 7 7 7 7 7 7
```

To reproduce on an Omarchy machine (make a backup of the config file first):

```bash
for r in 1 2 3; do for t in claude codex gh opencode; do ( ~/.local/bin/$t --version >/dev/null 2>&1 & ); done; done
sleep 5; grep -c ' = ' ~/.config/mise/config.toml   # < your tool count => tools dropped
```

## Fix

Run `mise use -g` under `flock`, so wrappers that start at the same time take turns. This is one line in the template. Nothing else changes: `--quiet`, `MISE_MINIMUM_RELEASE_AGE=0`, and always the latest version.

A migration regenerates the wrappers on existing installs. This also brings `--quiet` (#6940) to those installs. That fix shipped without a migration, so existing wrappers still print the `tools:` line on stdout.

One new assertion in `default-agent-test.sh` makes sure that the wrapper keeps the lock. `./test/all` passes, except `omarchy-pkgs checkout found for PKGBUILD coverage`. That test needs a second checkout and fails the same way on `master`.

https://claude.ai/code/session_01LUwsy8YsMtkjbgmQp9YEzq
