### PR TITLE
Show recent emojis first in picker

### DIFF
--- a/shell/plugins/emojis/EmojiSearch.js
+++ b/shell/plugins/emojis/EmojiSearch.js
@@ -7,6 +7,50 @@ function parseEmojis(raw) {
   }
 }
 
+function normalizeRecentEmojis(values, limit) {
+  var source = Array.isArray(values) ? values : []
+  var max = limit === undefined || limit === null ? source.length : Number(limit)
+  if (isNaN(max)) max = source.length
+  max = Math.max(0, Math.floor(max))
+
+  var out = []
+  var seen = {}
+
+  for (var i = 0; i < source.length && out.length < max; i++) {
+    var emoji = typeof source[i] === "string" ? source[i] : ""
+    if (!emoji || seen[emoji]) continue
+    seen[emoji] = true
+    out.push(emoji)
+  }
+
+  return out
+}
+
+function parseRecentEmojis(raw) {
+  try {
+    return normalizeRecentEmojis(JSON.parse(String(raw || "")))
+  } catch (e) {
+    return []
+  }
+}
+
+function addRecentEmoji(recentEmojis, emoji, limit, emojis) {
+  var recent = normalizeRecentEmojis([emoji].concat(Array.isArray(recentEmojis) ? recentEmojis : []))
+  if (!Array.isArray(emojis)) return normalizeRecentEmojis(recent, limit)
+
+  var valid = {}
+  for (var i = 0; i < emojis.length; i++) {
+    var item = emojis[i]
+    if (item && item.e) valid[item.e] = true
+  }
+
+  var out = []
+  for (var j = 0; j < recent.length; j++) {
+    if (valid[recent[j]]) out.push(recent[j])
+  }
+  return normalizeRecentEmojis(out, limit)
+}
+
 function normalizedQuery(query) {
   return String(query || "").trim().toLowerCase()
 }
@@ -37,10 +81,44 @@ function filterEmojis(emojis, query, limit) {
   return out
 }
 
+function displayEmojis(emojis, recentEmojis, query, recentLimit, limit) {
+  var values = Array.isArray(emojis) ? emojis : []
+  var out = filterEmojis(values, query, limit)
+  var recent = normalizeRecentEmojis(recentEmojis)
+  var maxRecent = Number(recentLimit)
+  if (isNaN(maxRecent)) maxRecent = 0
+  maxRecent = Math.max(0, Math.floor(maxRecent))
+  if (normalizedQuery(query) || recent.length === 0 || maxRecent === 0 || out.length === 0) return out
+
+  var byEmoji = {}
+  for (var i = 0; i < values.length; i++) {
+    var item = values[i]
+    if (item && item.e && byEmoji[item.e] === undefined) byEmoji[item.e] = item
+  }
+
+  var promoted = []
+  var promotedEmoji = {}
+  for (var j = 0; j < recent.length && promoted.length < maxRecent; j++) {
+    var emoji = recent[j]
+    if (byEmoji[emoji] === undefined) continue
+    promoted.push(byEmoji[emoji])
+    promotedEmoji[emoji] = true
+  }
+
+  for (var k = 0; k < out.length; k++) {
+    if (!promotedEmoji[out[k].e]) promoted.push(out[k])
+  }
+
+  return promoted.slice(0, out.length)
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     parseEmojis: parseEmojis,
+    parseRecentEmojis: parseRecentEmojis,
+    addRecentEmoji: addRecentEmoji,
     normalizedQuery: normalizedQuery,
-    filterEmojis: filterEmojis
+    filterEmojis: filterEmojis,
+    displayEmojis: displayEmojis
   }
 }

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -18,7 +18,11 @@ Item {
   property int selectedIndex: 0
   property bool cursorActive: false
   property var emojis: []
+  property var recentEmojis: []
+  property bool recentEmojisLoaded: false
+  property var pendingRecentEmojis: []
   property var filteredEmojis: []
+  readonly property string recentEmojisPath: Quickshell.env("HOME") + "/.local/state/omarchy/recent-emojis.json"
 
   // Shares the [menu] surface tokens — themes that style the menu also
   // style emojis. Selected-cell colors composed in the
@@ -40,7 +44,8 @@ Item {
 
   property int cellWidth: Math.max(Style.space(44), Style.font.display + Style.spacing.md)
   property int cellHeight: Math.max(Style.space(44), Style.font.display + Style.spacing.md)
-  property int columns: Math.floor((cardWidth - contentMargin * 2) / cellWidth)
+  property int columns: Math.max(1, Math.floor(resultGrid.width / cellWidth))
+  onColumnsChanged: if (root.opened) root.rebuildDisplay()
 
   function open(payloadJson) {
     root.opened = true
@@ -71,8 +76,35 @@ Item {
     if (root.opened) root.rebuildDisplay()
   }
 
+  function loadRecentEmojis(raw) {
+    root.recentEmojis = EmojiSearch.parseRecentEmojis(raw)
+    root.recentEmojisLoaded = true
+
+    var pending = root.pendingRecentEmojis
+    root.pendingRecentEmojis = []
+    for (var i = 0; i < pending.length; i++) {
+      root.recentEmojis = EmojiSearch.addRecentEmoji(root.recentEmojis, pending[i], Math.max(1, root.columns), root.emojis)
+    }
+    if (pending.length > 0) root.saveRecentEmojis()
+    if (root.opened) root.rebuildDisplay()
+  }
+
+  function rememberEmoji(emoji) {
+    if (!root.recentEmojisLoaded) {
+      root.pendingRecentEmojis = root.pendingRecentEmojis.concat([emoji])
+      return
+    }
+
+    root.recentEmojis = EmojiSearch.addRecentEmoji(root.recentEmojis, emoji, Math.max(1, root.columns), root.emojis)
+    root.saveRecentEmojis()
+  }
+
+  function saveRecentEmojis() {
+    recentEmojisFile.setText(JSON.stringify(root.recentEmojis, null, 2) + "\n")
+  }
+
   function rebuildDisplay() {
-    var out = EmojiSearch.filterEmojis(root.emojis, root.filterText, 1000)
+    var out = EmojiSearch.displayEmojis(root.emojis, root.recentEmojis, root.filterText, root.columns, 1000)
     root.filteredEmojis = out
 
     displayModel.clear()
@@ -147,6 +179,7 @@ Item {
 
   function applySelected(emoji) {
     if (!emoji) return
+    root.rememberEmoji(emoji)
     root.dismiss()
     Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-menu-emoji-insert", emoji])
   }
@@ -156,6 +189,17 @@ Item {
   FileView {
     path: root.omarchyPath + "/shell/plugins/emojis/emojis.json"
     onLoaded: root.loadEmojis(text())
+  }
+
+  FileView {
+    id: recentEmojisFile
+    path: root.recentEmojisPath
+    watchChanges: true
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root.loadRecentEmojis(text())
+    onLoadFailed: root.loadRecentEmojis("[]")
+    onFileChanged: reload()
   }
   PanelWindow {
     id: panel

--- a/test/acceptance.d/shell-surfaces-test.sh
+++ b/test/acceptance.d/shell-surfaces-test.sh
@@ -4,6 +4,30 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+RECENT_EMOJIS_FILE="$HOME/.local/state/omarchy/recent-emojis.json"
+recent_emojis_backup=$(mktemp)
+recent_emojis_existed=0
+
+if [[ -f $RECENT_EMOJIS_FILE ]]; then
+  cp "$RECENT_EMOJIS_FILE" "$recent_emojis_backup"
+  recent_emojis_existed=1
+fi
+
+restore_recent_emojis() {
+  omarchy-shell shell hide omarchy.emojis >/dev/null 2>&1 || true
+
+  if ((recent_emojis_existed)); then
+    mkdir -p "$(dirname "$RECENT_EMOJIS_FILE")"
+    cp "$recent_emojis_backup" "$RECENT_EMOJIS_FILE"
+  else
+    rm -f "$RECENT_EMOJIS_FILE"
+  fi
+
+  rm -f "$recent_emojis_backup"
+}
+
+trap restore_recent_emojis EXIT
+
 open_and_close() {
   local name="$1" plugin="$2" namespace="$3" payload="${4:-}"
 
@@ -30,6 +54,17 @@ sleep 1
 screenshot "success-emoji-picker-search"
 wtype -k Return
 wait_until "emoji picker selection closes" 15 layer_absent "omarchy-emojis"
+wait_until "emoji selection is remembered" 15 jq -e '.[0] == "\uD83D\uDE80"' "$RECENT_EMOJIS_FILE"
+
+omarchy-restart-shell
+wait_until "shell restarts after emoji selection" 30 omarchy-shell shell ping
+
+omarchy-shell shell summon omarchy.emojis >/dev/null
+wait_until "emoji picker reopens with recents" 15 layer_present "omarchy-emojis"
+sleep 1
+screenshot "success-emoji-picker-recents"
+omarchy-shell shell hide omarchy.emojis >/dev/null
+wait_until "emoji picker closes after recents check" 15 layer_absent "omarchy-emojis"
 
 # Seed two clipboard entries, search for the older one, and copy it back out.
 clipboard_token="Omarchy acceptance clipboard $(date +%s)"

--- a/test/shell.d/emojis-test.sh
+++ b/test/shell.d/emojis-test.sh
@@ -14,6 +14,12 @@ const data = emojis.parseEmojis(raw)
 assert(data.length > 1000, 'emoji dataset parses')
 assertDeepEqual(emojis.parseEmojis('{'), [], 'invalid emoji JSON parses as empty list')
 assertDeepEqual(emojis.parseEmojis('{"e":"nope"}'), [], 'non-array emoji JSON parses as empty list')
+assertDeepEqual(emojis.parseRecentEmojis('{'), [], 'invalid recent emoji JSON parses as empty list')
+assertDeepEqual(
+  emojis.parseRecentEmojis('["b", "a", "b", "", 42]'),
+  ['b', 'a'],
+  'recent emoji parsing removes duplicates and invalid values'
+)
 
 const fixture = [
   { e: 'a', k: 'grinning face smile happy' },
@@ -37,6 +43,30 @@ assertDeepEqual(
   emojis.filterEmojis(fixture, '', 0),
   [],
   'emoji filtering supports zero result limit'
+)
+
+assertDeepEqual(
+  emojis.addRecentEmoji(['b', 'a'], 'a', 2),
+  ['a', 'b'],
+  'using an emoji moves it to the front of the recent row'
+)
+
+assertDeepEqual(
+  emojis.addRecentEmoji(['missing', 'b'], 'a', 2, fixture),
+  ['a', 'b'],
+  'using an emoji drops stale entries before limiting the recent row'
+)
+
+assertDeepEqual(
+  emojis.displayEmojis(fixture, ['missing', 'c', 'b'], '', 2, 1000).map(item => item.e),
+  ['c', 'b', 'a'],
+  'valid recent emojis are promoted to the first row'
+)
+
+assertDeepEqual(
+  emojis.displayEmojis(fixture, ['c', 'b'], 'joy', 2, 1000).map(item => item.e),
+  ['b'],
+  'recent emojis do not change search result ordering'
 )
 
 assertEqual(


### PR DESCRIPTION
## Summary

- persist emoji picker selections as a newest-first, deduplicated recent list
- promote up to the rendered grid's column count across the first row when no search is active
- preserve the existing dataset order for typed searches and ignore stale persisted entries
- cover model behavior and persisted reloads, including restoring acceptance-test state

## Proof

![Recent emojis across the picker top row](https://raw.githubusercontent.com/m00nreal/omarchy/2623819ba773c16d81d1a9551a03ef4b0ee9940c/recent-emojis-picker.png)

https://github.com/user-attachments/assets/2fce7e16-57a4-4681-88d1-b20c7a192d04



Validated on a live dev-linked Omarchy checkout at 2560x1440:

- recent selections appear newest-first across exactly the top row
- selecting an older emoji moves it to the first position without duplication
- restarting the shell preserves the recent row
- typed searches retain their existing ordering

## Testing

- `bash test/shell.d/emojis-test.sh`
- `bash test/shell.d/manifest-entrypoints-test.sh`
- `qmllint -I shell shell/plugins/emojis/Emojis.qml`
- `bash -n test/acceptance.d/shell-surfaces-test.sh`
- `git diff --check`
- `./test/all` (179/180 shell test files pass; the remaining Bluetooth icon geometry tolerance failure reproduces unchanged on pristine `upstream/quattro`)

The full disposable-VM acceptance suite was not run because no generated Omarchy ISO was available. The updated acceptance flow selects an emoji, verifies persistence, restarts the shell, captures the restored recent row, and restores the previous state file.
