### PR TITLE
Float Java AWT XWayland popups instead of tiling them

### DIFF
--- a/default/hypr/windows.lua
+++ b/default/hypr/windows.lua
@@ -18,6 +18,20 @@ o.window(
   { no_focus = true }
 )
 
+-- Java AWT tooltips/menus are real X11 windows that reuse the parent class
+-- and title themselves win0, win1, ... A class-only tile/maximize rule
+-- stretches them over the whole client. Float and keep them unfocused.
+o.window({
+  class = ".*",
+  title = "^win[0-9]+$",
+  xwayland = true,
+}, {
+  float = true,
+  no_initial_focus = true,
+  no_focus = true,
+  no_follow_mouse = true,
+})
+
 -- App-specific tweaks (may remove default-opacity tag).
 require("default.hypr.apps")
 


### PR DESCRIPTION
## Why

This is not an app-specific bug. Two Quattro default-config interactions break a class of X11 / Java clients. Native Wayland GTK/Qt is mostly fine.

### 1. AWT popups reuse the parent window class (this PR)

Java tooltips, menus, and tiny dialogs are real X11 windows:

- **class:** same as the parent (`jetbrains-idea`, `ghidra`, …)
- **title:** `win0`, `win1`, `win23`

Hyprland treats that as another normal client. Any **class-only** rule (`fullscreen`, `maximize`, `tile`, `center`) stretches a ~20×20 grey tooltip over the tile. The hint text sits in the top-left of a huge grey box.

Omarchy already floats *empty* class+title XWayland windows in `default/hypr/windows.lua`. AWT popups do not match that rule, because they keep the parent class.

This PR adds the generic companion rule:

```lua
o.window({
  class = ".*",
  title = "^win[0-9]+$",
  xwayland = true,
}, {
  float = true,
  no_initial_focus = true,
  no_focus = true,
  no_follow_mouse = true,
})
```

Verified on Hyprland 0.56.2 / Omarchy 4.0.0-1: hover tooltips stay small and do not steal focus.

### 2. Related default: `GDK_SCALE=2` vs unscaled XWayland (not in this PR)

Packaged `monitors.lua` hardcodes `GDK_SCALE=2` while monitor scale is `"auto"`. Packaged `envs.lua` sets `xwayland.force_zero_scaling = true`.

On a 1080p HiDPI laptop, `scale = auto` lands on **1.5** (and can flip to **2**). Three layers then disagree:

| Layer | Size the app is told |
|---|---|
| Hyprland layout | Logical `1280×720` (`1920 / 1.5`) |
| XWayland (`force_zero_scaling`) | Physical `1920×1080`, 1:1 |
| Session env | `GDK_SCALE=2` for every child |

X11 / Java AWT see a 1920-wide X screen **and** honor `GDK_SCALE=2`. Toolkit minimum sizes double. Extra chrome then requests a width past 1920. A tiling compositor will not shift the toplevel left the way Plasma does.

Workaround (process-only, do not change global `GDK_SCALE`):

```bash
GDK_SCALE=1 GDK_DPI_SCALE=1 JAVA_TOOL_OPTIONS=-Dsun.java2d.uiScale=1 <command>
```

Suggested follow-up: derive `GDK_SCALE` from the applied monitor scale, or export it only for Wayland GTK when `force_zero_scaling` is on.

Related: #2824, #758, #6911.

## Test plan

- [x] Hover a toolbar/control in a Java AWT app under XWayland: tooltip stays a small floating box, does not fill the client
- [ ] Confirm empty-class XWayland drag windows still get the existing no-focus rule
- [ ] Confirm main tiled/maximized Java windows are unchanged