### PR TITLE
Fix inverted on/off semantics in omarchy-toggle-bar

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,4 +4,8 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+case "${1:-toggle}" in
+  on) omarchy-toggle bar-off off ;;
+  off) omarchy-toggle bar-off on ;;
+  *) omarchy-toggle bar-off toggle ;;
+esac

--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -7,5 +7,9 @@
 case "${1:-toggle}" in
   on) omarchy-toggle bar-off off ;;
   off) omarchy-toggle bar-off on ;;
-  *) omarchy-toggle bar-off toggle ;;
+  toggle) omarchy-toggle bar-off toggle ;;
+  *)
+    echo "Usage: omarchy-toggle-bar [toggle|on|off]" >&2
+    exit 1
+    ;;
 esac

--- a/test/acceptance.d/session-test.sh
+++ b/test/acceptance.d/session-test.sh
@@ -30,16 +30,16 @@ wait_until "background layer is on screen" 30 layer_on_screen "omarchy-backgroun
 # Hiding parks the bar off-screen without unmapping its layer surface, and
 # revealing brings that same surface back on-screen.
 restore_bar_visibility() {
-  omarchy-toggle-bar off >/dev/null 2>&1 || true
+  omarchy-toggle-bar on >/dev/null 2>&1 || true
 }
 trap restore_bar_visibility EXIT
 
-omarchy-toggle-bar on
+omarchy-toggle-bar off
 wait_until "hidden bar layer stays mapped" 15 layer_present "omarchy-bar"
 wait_until "hidden bar layer parks off screen" 15 layer_off_screen "omarchy-bar"
 screenshot "success-bar-hidden"
 
-omarchy-toggle-bar off
+omarchy-toggle-bar on
 wait_until "revealed bar layer returns on screen" 15 layer_on_screen "omarchy-bar"
 screenshot "success-bar-revealed"
 trap - EXIT

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -40,14 +40,14 @@ HOME="$test_home" omarchy-toggle example toggle
 [[ ! -f $flag ]] || fail "generic toggle flips enabled state off"
 pass "generic toggle flips enabled state off"
 
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on enables bar-off toggle"
-pass "bar on enables bar-off toggle"
-
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on is idempotent"
-pass "bar on is idempotent"
+HOME="$test_home" omarchy-toggle-bar off
+[[ -f $bar_flag ]] || fail "bar off enables bar-off toggle"
+pass "bar off enables bar-off toggle"
 
 HOME="$test_home" omarchy-toggle-bar off
-[[ ! -f $bar_flag ]] || fail "bar off disables bar-off toggle"
-pass "bar off disables bar-off toggle"
+[[ -f $bar_flag ]] || fail "bar off is idempotent"
+pass "bar off is idempotent"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on disables bar-off toggle"
+pass "bar on disables bar-off toggle"

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -51,3 +51,7 @@ pass "bar off is idempotent"
 HOME="$test_home" omarchy-toggle-bar on
 [[ ! -f $bar_flag ]] || fail "bar on disables bar-off toggle"
 pass "bar on disables bar-off toggle"
+
+HOME="$test_home" omarchy-toggle-bar bogus 2>/dev/null && fail "bar rejects an unknown action"
+[[ ! -f $bar_flag ]] || fail "bar rejects an unknown action" "unknown action changed the bar-off flag"
+pass "bar rejects an unknown action"


### PR DESCRIPTION
## Summary
- `omarchy-toggle-bar` forwarded its `on`/`off` argument straight through to the underlying `bar-off` state flag without inverting it, so `omarchy toggle bar on` actually **hid** the bar and `omarchy toggle bar off` **showed** it — the opposite of the command's own summary and documented examples.
- Inverted the mapping in `bin/omarchy-toggle-bar` (`on` -> disable `bar-off`, `off` -> enable `bar-off`), leaving generic `toggle` untouched since it's symmetric.
- Updated `test/shell.d/toggle-test.sh` and `test/acceptance.d/session-test.sh`, which had encoded the previous (inverted) behavior as the expected/correct behavior.

Fixes #7022

## Test plan
- [x] `./test/cli` passes
- [x] `./test/shell` — all suites pass except 3 pre-existing failures unrelated to this change (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`), which also fail on `master` in this environment because no `omarchy-pkgs` checkout is available (`OMARCHY_PKGS_PATH` unset) — verified by stashing this change and re-running those 3 files against unmodified `master`
- [x] `test/shell.d/toggle-test.sh` passes in isolation with the new expected on/off directions
- [ ] `test/acceptance.d/session-test.sh` (graphical acceptance test) not run — requires the disposable VM environment; updated to match the corrected semantics but not executed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)