### PR TITLE
Fix cloned bar plugins failing to load (required properties)

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -11,15 +11,18 @@ import "BarModel.js" as BarModel
 Item {
   id: root
 
-  // The omarchy-shell host injects omarchyPath from OMARCHY_PATH.
-  required property string omarchyPath
+  // The omarchy-shell host injects omarchyPath from OMARCHY_PATH. Not
+  // required: the plugin bar loader assigns it after creation (Loader's
+  // dynamic `source:` instantiation can't satisfy required properties the
+  // way the default bar's inline Component literal can).
+  property string omarchyPath: ""
   // Injected by the host shell so bar slots can resolve enabled widgets.
-  required property var barWidgetRegistry
+  property var barWidgetRegistry: null
   // Injected by the host shell every time shell.json is reloaded. Holds the
   // `bar:` subtree: position, centerAnchor, layout. The host owns file IO;
   // the bar just renders whatever it's handed. The bar font follows the
   // OS-level fontconfig monospace binding — it is not stored in shell.json.
-  required property var barConfig
+  property var barConfig: null
   // Injected by the host shell. Used for shell-wide actions such as opening
   // settings and persisting inline widget state.
   property var shell: null

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,8 +253,7 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
+        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId)
         shell.failedBarId = shell.activeBarId
       }
     }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,7 +253,13 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId)
+        // A Loader has no errorString() of its own. The component it built
+        // from `source` holds the failure, so the reason has to come from
+        // there — without it a plugin author is told only that their bar
+        // failed, never why.
+        var detail = sourceComponent ? sourceComponent.errorString() : ""
+        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to "
+          + shell.defaultBarId + (detail ? ": " + detail : ""))
         shell.failedBarId = shell.activeBarId
       }
     }
@@ -638,11 +644,11 @@ ShellRoot {
         }
         onStatusChanged: {
           if (status === Loader.Error) {
-            // Loader.errorString() reflects the source-load failure even when
-            // sourceComponent is null. Surface both so the user sees something
-            // actionable instead of a panel that silently refuses to open.
-            var detail = errorString && errorString() ? errorString() : ""
-            if (!detail && sourceComponent) detail = sourceComponent.errorString()
+            // A Loader has no errorString() of its own; the component it built
+            // from `source` holds the failure. Reading it off the Loader threw
+            // a ReferenceError here, which skipped the hide() below and left
+            // the panel stuck in openPanelIds with nothing logged.
+            var detail = sourceComponent ? sourceComponent.errorString() : ""
             console.warn("panel plugin " + panelEntry.pluginId + " failed to load:", detail)
             shell.hide(panelEntry.pluginId)
           }


### PR DESCRIPTION
## Summary

Fixes #6971 — `omarchy plugin clone omarchy.bar` (or any custom bar) fails to load, taking the bar down on every monitor.

Root cause: `Bar.qml` declares `omarchyPath`, `barWidgetRegistry`, and `barConfig` as `required property`. The stock bar satisfies these via an inline `Component` literal in `shell.qml` that binds them declaratively at creation time. Cloned/custom bars instead load through `pluginBarLoader`, a plain `Loader { source: ... }`, which has no way to supply property values before the component finishes creating — so *any* clone of `omarchy.bar`, even byte-for-byte unmodified, fails required-property checks and never renders.

A second bug in the same code path made this worse: `pluginBarLoader`'s `onStatusChanged` handler referenced a bare `errorString` identifier that doesn't exist in scope, throwing a `ReferenceError` before `shell.failedBarId` could be set. That skipped the fallback-to-`omarchy.bar` path entirely, so a failed custom bar left no bar on screen instead of recovering.

## Changes

1. `shell/plugins/bar/Bar.qml` — make the three shell-injected properties non-required with safe defaults, matching the pattern already used by every other plugin kind (panels use plain `property`, assigned post-creation via `onLoaded`/`configureBar`). `barConfig` already guards against a not-yet-set value via `Util.isPlainObject(barConfig) ? barConfig : fallbackBarConfig`, and `barWidgetRegistry` is only read once real layout entries exist, which only happens after `configureBar` has run — so no runtime behavior changes for the default bar, and cloned bars now load correctly.
2. `shell/shell.qml` — drop the broken `errorString` reference in `pluginBarLoader`'s error handler so a genuine load failure now correctly falls back to `omarchy.bar` instead of throwing and leaving no bar at all.

## Verification

Reproduced the exact repro from #6971 with a live `quickshell` instance (isolated `OMARCHY_PATH`/`HOME`, real Hyprland compositor) cloning `omarchy.bar` unmodified:

- **Before the fix:** no `omarchy-bar` layer-shell surface for the test instance in `hyprctl layers`, and the log showed exactly the warnings from the issue (`Required property omarchyPath/barWidgetRegistry/barConfig was not initialized`, `ReferenceError: errorString is not defined`).
- **After the fix:** the cloned bar renders a real `omarchy-bar` layer-shell surface on every monitor, and the log has zero related warnings.

Also ran the full test suite (`./test/all`); all bar/plugin-clone tests pass. The 4 unrelated failures (missing `omarchy-pkgs` checkout, an IPC-handler-count timing quirk, snapper/unowned-paths environment checks) reproduce identically on `quattro` with no changes applied, so they're pre-existing and unrelated to this fix.

## Test plan

- [x] `./test/shell.d/bar-widget-contract-test.sh`
- [x] `./test/shell.d/plugin-clone-test.sh`
- [x] `./test/all` (4 pre-existing, unrelated failures reproduce without this change)
- [x] Live repro: clone `omarchy.bar` unmodified, restart shell, confirm bar renders on all monitors with no warnings

---
This issue was addressed by Claude Code.