### PR TITLE
Prevent migration (1786643346) from hanging on stale browser lock files

### DIFF
--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -127,9 +127,25 @@ unverified_repairs_exist() {
 # Whether a profile is open is mechanical: a running Chromium-family browser
 # holds a SingletonLock (and socket) inside its user-data-dir.
 profile_open() {
-  # -L catches a SingletonLock left as a dangling symlink; -e covers a plain
-  # file, and -S the socket — any of them means a browser is attached.
-  [[ -L $1/SingletonLock || -e $1/SingletonLock || -S $1/SingletonSocket ]]
+  local lock="$1/SingletonLock"
+
+  # If there is no lock or socket, the profile is definitely closed
+  [[ -L $lock || -e $lock || -S $1/SingletonSocket ]] || return 1
+
+  # If it is a symlink, verify the process is actually running
+  if [[ -L $lock ]]; then
+    local target
+    target=$(readlink "$lock")
+    local pid="${target##*-}"
+
+    # If the PID is a number but the process isn't running, it's a ghost lock
+    # kill -0 simply checks if the process is running or not
+    if [[ "$pid" =~ ^[0-9]+$ ]] && ! kill -0 "$pid" 2>/dev/null; then
+      return 1
+    fi
+  fi
+
+  return 0
 }
 
 # Gate on a pending — or to-be-verified — profile actually being open, not on

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -31,6 +31,10 @@ mkdir -p "$stub_bin"
 REAL_PYTHON=$(command -v python3)
 export REAL_PYTHON
 
+# Use this script's process ID as the "browser test process" to check if the "test browser ID" is alive or not
+# via the profile_open() function in the migration (1786643346)
+export TEST_PID=$$
+
 run_migration() {
   HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1
 }
@@ -40,7 +44,7 @@ run_migration() {
 # not the mere presence of a browser process — is what the migration waits on.
 open_browser() {
   mkdir -p "$profile_root"
-  ln -sfn "test-host-1234" "$profile_root/SingletonLock"
+  ln -sfn "test-host-$TEST_PID" "$profile_root/SingletonLock"
 }
 close_browser() {
   rm -f "$profile_root/SingletonLock"
@@ -80,7 +84,7 @@ pass "migration keeps the browser prompt visible"
 # prompt, which the still-declining gum stub would otherwise fail.
 close_browser
 mkdir -p "$home/.config/google-chrome"
-ln -sfn "test-host-1234" "$home/.config/google-chrome/SingletonLock"
+ln -sfn "test-host-$TEST_PID" "$home/.config/google-chrome/SingletonLock"
 write_stale_preferences
 run_migration || fail "migration repairs while a different profile root is open"
 jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
@@ -167,7 +171,7 @@ cat >"$stub_bin/python3" <<'STUB'
 # the check calls report a surviving ghost through their exit status.
 "${REAL_PYTHON}" "$@"
 status=$?
-[[ ${5:-} == "repair" ]] && ln -sfn "test-host-1234" "$HOME/.config/chromium/SingletonLock"
+[[ ${5:-} == "repair" ]] && ln -sfn "test-host-$TEST_PID" "$HOME/.config/chromium/SingletonLock"
 exit $status
 STUB
 chmod +x "$stub_bin/python3"


### PR DESCRIPTION
# The Problem

If a user's machine crashes or hard-reboots while Chromium processes are open, a stale `SingletonLock` symlink may be left behind. The migration script previously only checks for the existence of the lock file which causes the migration to get stuck indefinitely. 

# The Fix

`1786643346.sh`

Updated `profile_open()` in the migration script to extract the PID of the `SingletonLock` symlink and verify if the process is actually alive via `kill -0`. If the process doesn't exists, the lock file is considered orphaned and ignored.

# Test fix 
`copy-url-shortcut-migration-test.sh`

Because the migration now checks if the process is alive, the dummy `test-host-1234` process is no longer reliable. So the test now uses its own PID (via `$$`) as an alive test process. 


+ This closes Issue #7019 
