### PR TITLE
Show the new track on the media OSD instead of the player name

### DIFF
--- a/shell/plugins/services/media/MediaModel.js
+++ b/shell/plugins/services/media/MediaModel.js
@@ -12,6 +12,10 @@ function hasTrackMetadata(player) {
   return !!(player && (player.trackTitle || player.trackArtist || player.trackAlbum || player.trackArtUrl))
 }
 
+function hasTrackTitle(player) {
+  return !!(player && player.trackTitle)
+}
+
 function playerCanControl(player) {
   return !!(player && (player.canTogglePlaying || player.canPlay || player.canPause || player.canGoNext || player.canGoPrevious))
 }
@@ -124,6 +128,7 @@ if (typeof module !== "undefined") {
     isProxyPlayer: isProxyPlayer,
     hasMetadata: hasMetadata,
     hasTrackMetadata: hasTrackMetadata,
+    hasTrackTitle: hasTrackTitle,
     playerCanControl: playerCanControl,
     canHandleAction: canHandleAction,
     canCycleSource: canCycleSource,

--- a/shell/plugins/services/media/Service.qml
+++ b/shell/plugins/services/media/Service.qml
@@ -258,8 +258,7 @@ Item {
         iconName: iconName,
         player: player,
         playerKey: playerKey(player),
-        before: beforeTrackSignature,
-        attempts: 0
+        before: beforeTrackSignature
       }
       trackOsdTimer.restart()
     } else {
@@ -267,21 +266,36 @@ Item {
     }
   }
 
+  function showPendingTrackOsd(player) {
+    var pending = pendingTrackOsd
+    pendingTrackOsd = null
+    trackOsdTimer.stop()
+    root.showOsd(pending.actionLabel, pending.iconName, player)
+  }
+
   function flushPendingTrackOsd(force) {
     var pending = pendingTrackOsd
     if (!pending) return
 
     var player = playerForKey(pending.playerKey) || pending.player
-    if (force || MediaModel.trackChanged(pending.before, player) || pending.attempts >= 10) {
-      pendingTrackOsd = null
-      trackOsdTimer.stop()
-      root.showOsd(pending.actionLabel, pending.iconName, player)
+    // Players like Chromium blank the track metadata for a moment while
+    // switching tracks, so a track change only counts once the new title has
+    // arrived. The timer force-flushes for players that never deliver one.
+    if (!force && !(MediaModel.trackChanged(pending.before, player) && MediaModel.hasTrackTitle(player)))
       return
-    }
 
-    pending.attempts = pending.attempts + 1
-    pendingTrackOsd = pending
-    trackOsdTimer.restart()
+    showPendingTrackOsd(player)
+  }
+
+  function seekedDuringPendingTrackOsd(player) {
+    var pending = pendingTrackOsd
+    if (!pending || playerKey(player) !== pending.playerKey) return
+
+    // A seek that arrives with the metadata untouched means the command
+    // restarted the current track (previous on a track that has played a
+    // while): no track change will follow, so show the OSD as-is.
+    if (!MediaModel.trackChanged(pending.before, player) && MediaModel.hasTrackTitle(player))
+      showPendingTrackOsd(player)
   }
 
   function selectPlayer(key) {
@@ -443,14 +457,16 @@ Item {
       required property var modelData
       target: modelData
       function onIsPlayingChanged() { root.syncPlayingOrder() }
+      function onPostTrackChanged() { root.flushPendingTrackOsd(false) }
+      function onPositionChanged() { root.seekedDuringPendingTrackOsd(modelData) }
     }
   }
 
   Timer {
     id: trackOsdTimer
-    interval: 120
+    interval: 2000
     repeat: false
-    onTriggered: root.flushPendingTrackOsd(false)
+    onTriggered: root.flushPendingTrackOsd(true)
   }
 
   PwObjectTracker { objects: root.playbackStreams }

--- a/test/shell.d/media-test.sh
+++ b/test/shell.d/media-test.sh
@@ -11,6 +11,8 @@ assert(media.isProxyPlayer({ dbusName: 'org.mpris.MediaPlayer2.playerctld' }), '
 assert(media.isProxyPlayer({ desktopEntry: 'playerctld' }), 'media detects playerctld proxy by desktop entry')
 assert(media.hasMetadata({ identity: 'Spotify' }), 'media detects identity metadata')
 assert(media.hasTrackMetadata({ trackTitle: 'Track' }), 'media detects track metadata')
+assert(media.hasTrackTitle({ trackTitle: 'Track' }), 'media detects track titles')
+assert(!media.hasTrackTitle({ trackArtUrl: 'file:///cover.jpg' }), 'media ignores blank titles with stale art')
 assert(media.playerCanControl({ canGoNext: true }), 'media detects controllable players')
 assert(media.canHandleAction({ canTogglePlaying: true }, 'playPause'), 'media maps playPause capability')
 assert(media.canCycleSource({ identity: 'Spotify', canPlay: true }), 'media detects cycleable sources')


### PR DESCRIPTION
Pressing next/previous while a Chromium-based player (e.g. YouTube Music as a web app) is active shows "Chromium" on the OSD instead of the track that starts playing.

Chromium blanks its MPRIS metadata for about a second while switching tracks. The blank state counts as a track change, so the pending OSD flushed while the title was still empty and fell back to the player identity. Watching D-Bus during a skip: the metadata blanks ~1ms after `Next`, and the new title only arrives ~1s later — past the old 1.2s polling cap often enough that the fallback also fired with a blank title.

This replaces the 120ms polling loop with Quickshell's own signals:

- `postTrackChanged` flushes the pending OSD once the new track's title has actually arrived. It fires after all track fields have settled, so the artist is included too.
- `positionChanged` (MPRIS `Seeked`) with untouched metadata detects previous restarting the current track — that path never changes the metadata, so it used to sit on the fallback timeout.
- A single-shot 2s deadline remains as the only fallback, for players that never deliver an event (twice the slowest observed publisher).

Tested with YouTube Music as a Chromium web app: skipping shows "Track - Artist" the moment Chromium publishes it, previous mid-track shows the current track immediately, and pause/play behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)