### PR TITLE
Add Howdy face authentication setup

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -345,8 +345,9 @@ show_setup_power_menu() {
 }
 
 show_setup_security_menu() {
-  case $(menu "Setup" "󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Setup" "󰈷  Fingerprint\n󰗹  Howdy Face ID\n  Fido2") in
   *Fingerprint*) present_terminal omarchy-setup-security-fingerprint ;;
+  *Howdy*) present_terminal omarchy-setup-security-howdy ;;
   *Fido2*) present_terminal omarchy-setup-security-fido2 ;;
   *) show_setup_menu ;;
   esac
@@ -677,8 +678,9 @@ show_remove_menu() {
 }
 
 show_remove_security_menu() {
-  case $(menu "Remove" "󰈷  Fingerprint\n  Fido2") in
+  case $(menu "Remove" "󰈷  Fingerprint\n󰗹  Howdy Face ID\n  Fido2") in
   *Fingerprint*) present_terminal omarchy-remove-security-fingerprint ;;
+  *Howdy*) present_terminal omarchy-remove-security-howdy ;;
   *Fido2*) present_terminal omarchy-remove-security-fido2 ;;
   *) show_remove_menu ;;
   esac

--- a/bin/omarchy-remove-security-howdy
+++ b/bin/omarchy-remove-security-howdy
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# omarchy:summary=Remove Howdy face authentication from sudo and polkit
+# omarchy:requires-sudo=true
+
+set -e
+
+
+remove_pam_config() {
+  if grep -q 'pam_howdy\.so' /etc/pam.d/sudo; then
+    echo "Removing face authentication from sudo..."
+    sudo sed -i '/pam_howdy\.so/d' /etc/pam.d/sudo
+  fi
+
+  if [[ -f /etc/pam.d/polkit-1 ]] && grep -q 'pam_howdy\.so' /etc/pam.d/polkit-1; then
+    echo "Removing face authentication from polkit..."
+    sudo sed -i '/pam_howdy\.so/d' /etc/pam.d/polkit-1
+  fi
+}
+
+echo -e "\e[32mRemoving Howdy face authentication.\n\e[0m"
+
+remove_pam_config
+
+echo "Removing Howdy..."
+omarchy-pkg-drop howdy-next
+
+echo -e "\e[32mHowdy face authentication has been removed.\e[0m"

--- a/bin/omarchy-setup-security-howdy
+++ b/bin/omarchy-setup-security-howdy
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# omarchy:summary=Set up Howdy face authentication for sudo and polkit
+# omarchy:requires-sudo=true
+
+set -e
+
+
+find_ir_camera() {
+  local sys_device device name
+
+  for sys_device in /sys/class/video4linux/video*; do
+    [[ -e $sys_device ]] || continue
+
+    name=$(<"$sys_device/name")
+    if [[ $name =~ [Ii]nfrared|[[:space:]]IR([[:space:]]|$)|Integrated[[:space:]]I ]]; then
+      device="/dev/${sys_device##*/}"
+      if v4l2-ctl --device "$device" --all 2>/dev/null | grep -q 'Video Capture'; then
+        printf '%s\n' "$device"
+        return 0
+      fi
+    fi
+  done
+
+  return 1
+}
+
+setup_pam_config() {
+  if ! grep -q 'pam_howdy\.so' /etc/pam.d/sudo; then
+    echo "Configuring sudo for face authentication..."
+    sudo sed -i '1i auth    sufficient pam_howdy.so' /etc/pam.d/sudo
+  fi
+
+  if [[ -f /etc/pam.d/polkit-1 ]] && ! grep -q 'pam_howdy\.so' /etc/pam.d/polkit-1; then
+    echo "Configuring polkit for face authentication..."
+    sudo sed -i '1i auth      sufficient pam_howdy.so' /etc/pam.d/polkit-1
+  elif [[ ! -f /etc/pam.d/polkit-1 ]]; then
+    echo "Creating polkit configuration with face authentication..."
+    sudo tee /etc/pam.d/polkit-1 >/dev/null <<'EOF'
+auth      sufficient pam_howdy.so
+auth      required pam_unix.so
+
+account   required pam_unix.so
+password  required pam_unix.so
+session   required pam_unix.so
+EOF
+  fi
+}
+
+echo -e "\e[32mSetting up Howdy face authentication.\n\e[0m"
+echo "Installing required packages..."
+
+omarchy-pkg-add v4l-utils
+omarchy-pkg-aur-add howdy-next
+
+if ! camera=$(find_ir_camera); then
+  echo -e "\e[31m\nNo usable infrared camera was detected.\e[0m"
+  echo "Check that the camera is enabled and exposed as a V4L2 capture device."
+  exit 1
+fi
+
+echo "Using infrared camera at $camera."
+sudo howdy download-models
+sudo howdy set device_path "$camera"
+
+echo -e "\e[32m\nLook directly at the camera to enroll your face.\e[0m"
+sudo howdy -U "$USER" add
+
+setup_pam_config
+
+echo -e "\nTesting face recognition..."
+if sudo howdy -U "$USER" test; then
+  echo -e "\e[32m\nHowdy face authentication is configured.\e[0m"
+  echo "You can use it for sudo and polkit; your password remains available as fallback."
+else
+  echo -e "\e[31m\nFace recognition failed. Run 'sudo howdy -U $USER test' to troubleshoot.\e[0m"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add `omarchy setup security howdy` to install Howdy Next and detect an infrared V4L2 capture device
- download the OpenCV recognition models, configure the detected camera, enroll the user, and run a verification test
- enable Howdy for sudo and Polkit while retaining password fallback
- add a matching removal command and expose both actions in the Security menus

## Safety

- PAM entries use `sufficient`, so password authentication remains available
- setup aborts if no usable IR capture device is found
- lock-screen PAM is intentionally unchanged because Hyprlock does not initiate generic face authentication in parallel like its dedicated fingerprint flow

## Testing

- `bash -n bin/omarchy-setup-security-howdy bin/omarchy-remove-security-howdy bin/omarchy-menu`
- `git diff --check`
- `bash test/omarchy-cli-test.sh`