### PR TITLE
Enable Dell XPS 13 sidecar speaker amplifiers

### DIFF
--- a/bin/omarchy-hw-dell-xps13-sidecar-amps
+++ b/bin/omarchy-hw-dell-xps13-sidecar-amps
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Match the Dell XPS 13 DX13260 that requires the sidecar amplifier workaround.
+
+product_sku="${OMARCHY_DMI_PRODUCT_SKU:-/sys/class/dmi/id/product_sku}"
+
+omarchy-hw-match "DX13260" &&
+  grep -qix "0E53" "$product_sku" 2>/dev/null

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -25,6 +25,10 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/sof-firmware.sh"
 
+# Rebuilds the boot image, so it has to follow the Panther Lake kernel swap
+# above rather than sit with the other Dell leaf at the top of this file.
+run_logged "$OMARCHY_INSTALL/hardware/dell-xps13-sidecar-amps.sh"
+
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"

--- a/install/hardware/dell-xps13-sidecar-amps.sh
+++ b/install/hardware/dell-xps13-sidecar-amps.sh
@@ -1,0 +1,10 @@
+# Enable the temporary sidecar amplifier workaround on the exact Dell XPS 13 model that needs it.
+#
+# Pacman registers a package even when its post_install scriptlet fails, so the
+# apply command runs explicitly here: a failed cleanup or boot-image rebuild has
+# to reach the caller rather than hide behind a successfully registered package.
+
+if omarchy-hw-dell-xps13-sidecar-amps; then
+  omarchy-pkg-add dell-xps13-sidecar-amps &&
+    sudo dell-xps13-sidecar-amps-apply
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -61,6 +61,7 @@ linux-firmware-marvell
 
 # Dell laptop support packages
 dell-xps-touchpad-haptics
+dell-xps13-sidecar-amps
 
 # Speaker tunings (LV2 limiter every tuning ends in)
 lsp-plugins-lv2

--- a/migrations/1787666837.sh
+++ b/migrations/1787666837.sh
@@ -1,0 +1,6 @@
+echo "Enable Dell XPS 13 sidecar speaker amplifiers"
+
+if omarchy-hw-dell-xps13-sidecar-amps; then
+  source "$OMARCHY_PATH/install/hardware/dell-xps13-sidecar-amps.sh"
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/xps13-sidecar-amps-test.sh
+++ b/test/shell.d/xps13-sidecar-amps-test.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-dell-xps13-sidecar-amps"
+leaf="$ROOT/install/hardware/dell-xps13-sidecar-amps.sh"
+all="$ROOT/install/hardware/all.sh"
+migration=$(grep -l "dell-xps13-sidecar-amps" "$ROOT"/migrations/*.sh | head -1)
+
+grep -q 'run_logged .*hardware/dell-xps13-sidecar-amps.sh' "$all" ||
+  fail "the sidecar amplifier workaround runs during hardware setup"
+pass "the sidecar amplifier workaround runs during hardware setup"
+
+# The apply step rebuilds the boot image, so it has to see the Panther Lake
+# kernel that ptl-kernel.sh swaps in rather than the stock one it replaces.
+ptl_line=$(grep -n 'hardware/intel/ptl-kernel.sh' "$all" | cut -d: -f1)
+amps_line=$(grep -n 'hardware/dell-xps13-sidecar-amps.sh' "$all" | cut -d: -f1)
+((ptl_line < amps_line)) ||
+  fail "the sidecar amplifier workaround runs after the Panther Lake kernel swap"
+pass "the sidecar amplifier workaround runs after the Panther Lake kernel swap"
+
+[[ -n $migration ]] || fail "a migration enables the workaround on existing installs"
+pass "a migration enables the workaround on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+[[ ${TEST_PRODUCT_NAME:-} == *"$1"* ]]
+SH
+
+cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add %s\n' "$*" >>"$CALL_LOG"
+exit "${TEST_PKG_ADD_STATUS:-0}"
+SH
+
+cat >"$test_tmp/bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$test_tmp/bin/dell-xps13-sidecar-amps-apply" <<'SH'
+#!/bin/bash
+printf 'apply\n' >>"$CALL_LOG"
+exit "${TEST_APPLY_STATUS:-0}"
+SH
+
+cat >"$test_tmp/bin/omarchy-state" <<'SH'
+#!/bin/bash
+printf 'state %s\n' "$*" >>"$CALL_LOG"
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+sku_file="$test_tmp/product_sku"
+call_log="$test_tmp/calls.log"
+
+run_detector() {
+  printf '%s\n' "${2-0E53}" >"$sku_file"
+  PATH="$test_tmp/bin:$PATH" \
+    TEST_PRODUCT_NAME="${1-XPS 13 DX13260}" \
+    OMARCHY_DMI_PRODUCT_SKU="${3-$sku_file}" \
+    bash "$detector"
+}
+
+run_detector || fail "the detector matches the DX13260 with SKU 0E53"
+pass "the detector matches the DX13260 with SKU 0E53"
+
+run_detector "XPS 13 DX13261" && fail "the detector rejects another model"
+pass "the detector rejects another model"
+
+run_detector "XPS 13 DX13260" "0E54" && fail "the detector rejects another SKU"
+pass "the detector rejects another SKU"
+
+# An exact match must not be satisfied by a SKU that merely contains it.
+run_detector "XPS 13 DX13260" "0E530" && fail "the detector rejects a longer SKU"
+pass "the detector rejects a longer SKU"
+
+run_detector "XPS 13 DX13260" "0E53" "$test_tmp/absent" &&
+  fail "the detector fails closed when the SKU attribute is missing"
+pass "the detector fails closed when the SKU attribute is missing"
+
+# Sourced the way run_logged runs it.
+run_leaf() {
+  : >"$call_log"
+  printf '0E53\n' >"$sku_file"
+  PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    CALL_LOG="$call_log" \
+    TEST_PRODUCT_NAME="${1-XPS 13 DX13260}" \
+    TEST_PKG_ADD_STATUS="${2:-0}" \
+    TEST_APPLY_STATUS="${3:-0}" \
+    OMARCHY_DMI_PRODUCT_SKU="$sku_file" \
+    bash -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf || fail "the leaf installs and applies on the target machine"
+grep -q 'pkg-add dell-xps13-sidecar-amps' "$call_log" ||
+  fail "the leaf installs the package on the target machine"
+grep -q '^apply$' "$call_log" ||
+  fail "the leaf applies the workaround on the target machine"
+pass "the leaf installs and applies on the target machine"
+
+run_leaf "ThinkPad X1" || fail "the leaf no-ops on other hardware"
+[[ -s $call_log ]] && fail "the leaf no-ops on other hardware"
+pass "the leaf no-ops on other hardware"
+
+# Pacman registers a package even when its scriptlet fails, so a failing apply
+# has to surface rather than be swallowed by a successful install.
+run_leaf "XPS 13 DX13260" 0 1 && fail "a failing apply fails the leaf"
+pass "a failing apply fails the leaf"
+
+run_leaf "XPS 13 DX13260" 1 && fail "a failing package install fails the leaf"
+grep -q '^apply$' "$call_log" && fail "a failing package install skips the apply"
+pass "a failing package install fails the leaf without applying"
+
+# The migration runner uses bash -euo pipefail and only records the migration
+# when it exits clean, so a failed apply has to leave reboot-required unset.
+run_migration() {
+  : >"$call_log"
+  printf '0E53\n' >"$sku_file"
+  PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    CALL_LOG="$call_log" \
+    OMARCHY_PATH="$ROOT" \
+    TEST_PRODUCT_NAME="${1-XPS 13 DX13260}" \
+    TEST_APPLY_STATUS="${2:-0}" \
+    OMARCHY_DMI_PRODUCT_SKU="$sku_file" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration || fail "the migration applies the workaround and asks for a reboot"
+grep -q 'state set reboot-required' "$call_log" ||
+  fail "the migration applies the workaround and asks for a reboot"
+pass "the migration applies the workaround and asks for a reboot"
+
+run_migration "XPS 13 DX13260" 1 && fail "a failing apply leaves the migration pending"
+grep -q 'state set reboot-required' "$call_log" &&
+  fail "a failing apply does not mark reboot-required"
+pass "a failing apply leaves the migration pending without marking reboot-required"
+
+run_migration "ThinkPad X1" || fail "the migration no-ops on other hardware"
+[[ -s $call_log ]] && fail "the migration no-ops on other hardware"
+pass "the migration no-ops on other hardware"


### PR DESCRIPTION
## Summary

The Dell XPS 13 DX13260 plays through one speaker amplifier with no bass: its two CS35L56 sidecar amps never load firmware because `sof_sdw` only learns the machine needs `SOC_SDW_SIDECAR_AMPS` in Linux 7.2, through [`efd80de2de9d`](https://github.com/torvalds/linux/commit/efd80de2de9d06ddf0eee55ca11b04e39bfc7cd8). Arch is on 7.1, and Omarchy's own `linux-ptl` is 7.1.8 with display patches only, so nothing on the machine selects that path today.

This installs [`dell-xps13-sidecar-amps`](https://github.com/omacom-io/omarchy-pkgs/pull/150) — a temporary package that selects the same driver path with a module override — on that exact machine and nowhere else, on fresh installs and on existing ones.

Closes #7427.

## Design

The detector requires both the `DX13260` product name and SKU `0E53`. The override forces a quirk value rather than merging into one — `sof_sdw` assigns `sof_sdw_quirk = quirk_override` — so a machine that matches by mistake loses whatever quirk the kernel would have chosen for itself.

Pacman registers a package even when its `post_install` scriptlet fails, so the hardware leaf calls `dell-xps13-sidecar-amps-apply` itself rather than trusting the install to have applied. A failed legacy cleanup or boot-image rebuild has to reach the caller instead of hiding behind a package pacman considers installed. That is also why the migration marks `reboot-required` only after the apply succeeds: a migration that exits non-zero keeps no completion marker, so the next run retries the apply even though pacman already has the package.

The leaf runs after `intel/ptl-kernel.sh` rather than beside the other Dell leaf at the top of `install/hardware/all.sh`, so its boot-image rebuild sees the Panther Lake kernel that step swaps in rather than the stock one it removes.

`install/omarchy-other.packages` seeds the ISO's offline mirror; it is not a target-install list, so the package is available to an offline install without landing on non-matching machines. This is the same pattern `dell-xps-touchpad-haptics` uses.

## Merge order

This must not merge or enter an ISO build until [omacom-io/omarchy-pkgs#150](https://github.com/omacom-io/omarchy-pkgs/pull/150) has merged and `dell-xps13-sidecar-amps 1.0.0-2` is published in the edge x86_64 repository. The builder folds every `omarchy-other.packages` entry into one `pacman -Syw` transaction under `set -e`, so an unpublished package fails every ISO build, including ISOs for hardware that will never use it.

## Removal

The override becomes redundant once every bootable kernel carries the upstream commit, and it stays harmless at that point only because upstream sets exactly `SOC_SDW_SIDECAR_AMPS` for `1028:0e53` and the override forces the same value. Since the module parameter replaces the quirk rather than merging into it, a future kernel that adds a bit to that entry would have it overwritten, so this package should be retired by a migration once Arch ships 7.2.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
