### PR TITLE
Add per application output routing to the audio mixer

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -243,9 +243,23 @@ function streamRepresentsPlayer(node, player, players, streams) {
 // -1, which hands the stream back to the default output.
 var DEFAULT_ROUTE = "__default__"
 
-function routeTargetOf(node) {
-  var props = nodeProps(node)
-  var target = props["target.object"]
+// pw-metadata writes target.object into the separate "default" metadata
+// object rather than back into the node's own properties, so the current
+// routing has to be read from there. Lines look like:
+//   update: id:120 key:'target.object' value:'alsa_output.analog-stereo' ...
+function parseRouteTargets(raw) {
+  var targets = {}
+  var pattern = /id:(\d+)\s+key:'target\.object'\s+value:'([^']*)'/g
+  var match
+  while ((match = pattern.exec(String(raw || ""))) !== null) {
+    targets[match[1]] = match[2]
+  }
+  return targets
+}
+
+function routeTargetOf(node, targets) {
+  if (!node) return DEFAULT_ROUTE
+  var target = targets ? targets[String(node.id)] : undefined
   if (target === undefined || target === null || target === "" || String(target) === "-1") return DEFAULT_ROUTE
   return String(target)
 }
@@ -282,16 +296,16 @@ function sinkNamed(sinks, name) {
 
 // Prefer where the stream is linked, and fall back to the pinned preference,
 // because a link group is not always resolved for a stream that just started.
-function routeLabel(node, sinks, linkedSink) {
+function routeLabel(node, sinks, linkedSink, targets) {
   if (linkedSink) return nodeLabel(linkedSink)
-  var target = routeTargetOf(node)
+  var target = routeTargetOf(node, targets)
   if (target === DEFAULT_ROUTE) return "Follow default output"
   var sink = sinkNamed(sinks, target)
   return sink ? nodeLabel(sink) : String(target)
 }
 
-function routeIsPinned(node) {
-  return routeTargetOf(node) !== DEFAULT_ROUTE
+function routeIsPinned(node, targets) {
+  return routeTargetOf(node, targets) !== DEFAULT_ROUTE
 }
 
 if (typeof module !== "undefined") {
@@ -302,6 +316,7 @@ if (typeof module !== "undefined") {
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
     DEFAULT_ROUTE: DEFAULT_ROUTE,
+    parseRouteTargets: parseRouteTargets,
     routeTargetOf: routeTargetOf,
     routeCommand: routeCommand,
     routeOptions: routeOptions,

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -233,6 +233,67 @@ function streamRepresentsPlayer(node, player, players, streams) {
   return streamRepresentsMprisPlayer(streamLabel(node, players, streams), playerLabel)
 }
 
+
+// Per application output routing.
+//
+// The mixer sets each stream's volume and mute but leaves it on whatever the
+// default output happens to be. Routing writes a pipewire metadata key against
+// the stream's node id, which moves the running stream and is remembered by
+// wireplumber for the next stream that application opens. Clearing it writes
+// -1, which hands the stream back to the default output.
+var DEFAULT_ROUTE = "__default__"
+
+function routeTargetOf(node) {
+  var props = nodeProps(node)
+  var target = props["target.object"]
+  if (target === undefined || target === null || target === "" || String(target) === "-1") return DEFAULT_ROUTE
+  return String(target)
+}
+
+function routeCommand(nodeId, sinkName) {
+  var value = !sinkName || sinkName === DEFAULT_ROUTE ? "-1" : String(sinkName)
+  return ["pw-metadata", "-n", "default", String(nodeId), "target.object", value]
+}
+
+function routeOptions(sinks) {
+  var options = [DEFAULT_ROUTE]
+  var list = sinks || []
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] && list[i].name) options.push(String(list[i].name))
+  }
+  return options
+}
+
+function nextRouteTarget(options, current) {
+  var list = options || []
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] === current) return list[(i + 1) % list.length]
+  }
+  return list.length > 0 ? list[0] : DEFAULT_ROUTE
+}
+
+function sinkNamed(sinks, name) {
+  var list = sinks || []
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] && String(list[i].name) === String(name)) return list[i]
+  }
+  return null
+}
+
+// Prefer where the stream is linked, and fall back to the pinned preference,
+// because a link group is not always resolved for a stream that just started.
+function routeLabel(node, sinks, linkedSink) {
+  if (linkedSink) return nodeLabel(linkedSink)
+  var target = routeTargetOf(node)
+  if (target === DEFAULT_ROUTE) return "Follow default output"
+  var sink = sinkNamed(sinks, target)
+  return sink ? nodeLabel(sink) : String(target)
+}
+
+function routeIsPinned(node) {
+  return routeTargetOf(node) !== DEFAULT_ROUTE
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isPlaybackStream: isPlaybackStream,
@@ -240,6 +301,14 @@ if (typeof module !== "undefined") {
     listSnapshot: listSnapshot,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
+    DEFAULT_ROUTE: DEFAULT_ROUTE,
+    routeTargetOf: routeTargetOf,
+    routeCommand: routeCommand,
+    routeOptions: routeOptions,
+    nextRouteTarget: nextRouteTarget,
+    sinkNamed: sinkNamed,
+    routeLabel: routeLabel,
+    routeIsPinned: routeIsPinned,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -443,6 +443,12 @@ Panel {
     source.audio.volume = Math.max(0, Math.min(1, v))
   }
 
+  function cycleStreamRoute(node) {
+    if (!node) return
+    var options = Model.routeOptions(root.candidateSinks)
+    Quickshell.execDetached(Model.routeCommand(node.id, Model.nextRouteTarget(options, Model.routeTargetOf(node))))
+  }
+
   function toggleOutputMute() {
     if (volumeSink && volumeSink.audio) volumeSink.audio.muted = !volumeSink.audio.muted
   }
@@ -655,7 +661,7 @@ Panel {
     open: root.opened
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(380))
-    contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(560))
+    contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(620))
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -669,6 +675,15 @@ Panel {
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
+        // 'o' sends the focused stream to the next output device.
+        if (t === "o" || t === "O") {
+          if (!root.cursorActive) return
+          if (root.focusSection === "streams" && root.selectedIndex >= 0
+              && root.selectedIndex < root.displayAudioStreams.length) {
+            root.cycleStreamRoute(root.displayAudioStreams[root.selectedIndex])
+          }
+          return
+        }
         // 'm' mutes whatever the cursor is on: focused section's slider
         // for output/input, the focused stream for streams.
         if (t === "m" || t === "M") {
@@ -1143,6 +1158,10 @@ Panel {
     readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
     readonly property bool isActive: root.streamRepresentsPlayer(node, root.activeMediaPlayer)
+    readonly property var linkedSink: streamLinks.linkGroups && streamLinks.linkGroups.values.length > 0
+      ? streamLinks.linkGroups.values[0].target
+      : null
+    readonly property bool routePinned: Model.routeIsPinned(streamRow.node)
 
     hasCursor: root.cursorActive && root.focusSection === "streams" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(streamRow)
@@ -1151,6 +1170,11 @@ Panel {
     fill: root.hoverFill
     currentFill: root.selectedFill
     implicitHeight: streamColumn.implicitHeight + Style.spacing.xl
+
+    PwNodeLinkTracker {
+      id: streamLinks
+      node: streamRow.node
+    }
 
     Column {
       id: streamColumn
@@ -1229,6 +1253,45 @@ Panel {
         onRightClicked: {
           if (streamRow.node && streamRow.node.audio)
             streamRow.node.audio.muted = !streamRow.node.audio.muted
+        }
+      }
+
+      // Which output this application comes out of. Click to send it to the
+      // next device, and again to hand it back to the default. Hidden when
+      // there is only one output, where there is nothing to choose.
+      Item {
+        visible: root.candidateSinks.length > 1
+        width: parent.width
+        implicitHeight: visible ? routeText.implicitHeight : 0
+        height: implicitHeight
+
+        Text {
+          id: routeIcon
+          anchors.left: parent.left
+          anchors.verticalCenter: parent.verticalCenter
+          text: streamRow.routePinned ? "\udb81\udd31" : "\udb80\udc54"
+          color: Qt.darker(root.bar.foreground, streamRow.routePinned ? 1.2 : 1.6)
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.caption
+        }
+
+        Text {
+          id: routeText
+          anchors.left: routeIcon.right
+          anchors.leftMargin: Style.space(6)
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          text: Model.routeLabel(streamRow.node, root.candidateSinks, streamRow.linkedSink)
+          color: Qt.darker(root.bar.foreground, streamRow.routePinned ? 1.2 : 1.6)
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          cursorShape: Qt.PointingHandCursor
+          onClicked: root.cycleStreamRoute(streamRow.node)
         }
       }
     }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -310,6 +310,7 @@ Panel {
   onOpenedChanged: {
     if (opened) {
       refreshDisplayAudioModels()
+      routeTargetsProc.restart()
       focusSection = "output"
       selectedIndex = -1  // first keyboard cursor reveal starts on the output slider
       cursorActive = false
@@ -443,10 +444,33 @@ Panel {
     source.audio.volume = Math.max(0, Math.min(1, v))
   }
 
+  // Routing offers the same sinks the picker does. candidateSinks still holds
+  // outputs sinkAvailable() removes, including the physical sink hidden behind
+  // speaker tuning, and sending a stream there would bypass the tuning.
   function cycleStreamRoute(node) {
     if (!node) return
-    var options = Model.routeOptions(root.candidateSinks)
-    Quickshell.execDetached(Model.routeCommand(node.id, Model.nextRouteTarget(options, Model.routeTargetOf(node))))
+    var options = Model.routeOptions(root.audioSinks)
+    var next = Model.nextRouteTarget(options, Model.routeTargetOf(node, root.routeTargets))
+    Quickshell.execDetached(Model.routeCommand(node.id, next))
+    routeTargetsProc.restart()
+  }
+
+  // The routing lives in the default metadata object, so it is read back from
+  // there rather than from the node properties.
+  property var routeTargets: ({})
+
+  Process {
+    id: routeTargetsProc
+    command: ["pw-metadata", "-n", "default"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.routeTargets = Model.parseRouteTargets(text)
+    }
+
+    function restart() {
+      if (running) return
+      running = true
+    }
   }
 
   function toggleOutputMute() {
@@ -1158,10 +1182,10 @@ Panel {
     readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
     readonly property bool isActive: root.streamRepresentsPlayer(node, root.activeMediaPlayer)
-    readonly property var linkedSink: streamLinks.linkGroups && streamLinks.linkGroups.values.length > 0
-      ? streamLinks.linkGroups.values[0].target
+    readonly property var linkedSink: streamLinks.linkGroups.length > 0
+      ? streamLinks.linkGroups[0].target
       : null
-    readonly property bool routePinned: Model.routeIsPinned(streamRow.node)
+    readonly property bool routePinned: Model.routeIsPinned(streamRow.node, root.routeTargets)
 
     hasCursor: root.cursorActive && root.focusSection === "streams" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(streamRow)
@@ -1281,7 +1305,7 @@ Panel {
           anchors.leftMargin: Style.space(6)
           anchors.right: parent.right
           anchors.verticalCenter: parent.verticalCenter
-          text: Model.routeLabel(streamRow.node, root.candidateSinks, streamRow.linkedSink)
+          text: Model.routeLabel(streamRow.node, root.audioSinks, streamRow.linkedSink, root.routeTargets)
           color: Qt.darker(root.bar.foreground, streamRow.routePinned ? 1.2 : 1.6)
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.caption

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -1293,6 +1293,7 @@ Panel {
 
         Text {
           id: routeIcon
+          textFormat: Text.PlainText
           anchors.left: parent.left
           anchors.verticalCenter: parent.verticalCenter
           text: streamRow.routePinned ? "\udb81\udd31" : "\udb80\udc54"
@@ -1303,6 +1304,7 @@ Panel {
 
         Text {
           id: routeText
+          textFormat: Text.PlainText
           anchors.left: routeIcon.right
           anchors.leftMargin: Style.space(6)
           anchors.right: parent.right

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -1282,9 +1282,11 @@ Panel {
 
       // Which output this application comes out of. Click to send it to the
       // next device, and again to hand it back to the default. Hidden when
-      // there is only one output, where there is nothing to choose.
+      // there is only one output to choose from, counted after sinkAvailable()
+      // has removed the ones routing will not offer, so the row cannot appear
+      // with nothing to cycle to.
       Item {
-        visible: root.candidateSinks.length > 1
+        visible: root.audioSinks.length > 1
         width: parent.width
         implicitHeight: visible ? routeText.implicitHeight : 0
         height: implicitHeight

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -31,6 +31,31 @@ assertEqual(audio.sinkGlyph(headphones), '󰋋', 'audio uses headphone sink glyp
 assert(audio.sourceGlyph({ ready: true, properties: { 'device.icon-name': 'camera-webcam' } }).length > 0, 'audio maps webcam source glyph')
 
 assertEqual(audio.friendlyStreamLabel('spotify'), 'Spotify', 'audio normalizes known stream labels')
+
+assertDeepEqual(
+  audio.routeCommand(64, 'alsa_output.analog-stereo'),
+  ['pw-metadata', '-n', 'default', '64', 'target.object', 'alsa_output.analog-stereo'],
+  'audio pins a stream to an output'
+)
+assertDeepEqual(
+  audio.routeCommand(64, audio.DEFAULT_ROUTE),
+  ['pw-metadata', '-n', 'default', '64', 'target.object', '-1'],
+  'audio hands a stream back to the default output'
+)
+assertEqual(audio.routeTargetOf({ ready: true, properties: {} }), audio.DEFAULT_ROUTE, 'audio reads an unpinned stream as following the default')
+assertEqual(audio.routeTargetOf({ ready: true, properties: { 'target.object': '-1' } }), audio.DEFAULT_ROUTE, 'audio reads a cleared pin as following the default')
+assertEqual(audio.routeTargetOf({ ready: true, properties: { 'target.object': 'sink.a' } }), 'sink.a', 'audio reads a pinned stream')
+assert(!audio.routeIsPinned({ ready: true, properties: {} }), 'audio reports an unpinned stream')
+
+const routeSinks = [
+  { ready: true, name: 'sink.a', nickname: 'Speakers' },
+  { ready: true, name: 'sink.b', nickname: 'HDMI' }
+]
+assertDeepEqual(audio.routeOptions(routeSinks), [audio.DEFAULT_ROUTE, 'sink.a', 'sink.b'], 'audio offers the default output first')
+assertEqual(audio.nextRouteTarget(audio.routeOptions(routeSinks), audio.DEFAULT_ROUTE), 'sink.a', 'audio cycles from the default to the first output')
+assertEqual(audio.nextRouteTarget(audio.routeOptions(routeSinks), 'sink.b'), audio.DEFAULT_ROUTE, 'audio cycles from the last output back to the default')
+assertEqual(audio.routeLabel({ ready: true, properties: {} }, routeSinks, null), 'Follow default output', 'audio labels an unpinned stream')
+assertEqual(audio.routeLabel({ ready: true, properties: { 'target.object': 'sink.a' } }, routeSinks, null), 'Speakers', 'audio labels a pinned stream by device')
 assert(audio.streamRepresentsMprisPlayer('Chromium', 'Chromium Browser'), 'audio matches related stream and MPRIS labels')
 
 const players = [

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -42,10 +42,20 @@ assertDeepEqual(
   ['pw-metadata', '-n', 'default', '64', 'target.object', '-1'],
   'audio hands a stream back to the default output'
 )
-assertEqual(audio.routeTargetOf({ ready: true, properties: {} }), audio.DEFAULT_ROUTE, 'audio reads an unpinned stream as following the default')
-assertEqual(audio.routeTargetOf({ ready: true, properties: { 'target.object': '-1' } }), audio.DEFAULT_ROUTE, 'audio reads a cleared pin as following the default')
-assertEqual(audio.routeTargetOf({ ready: true, properties: { 'target.object': 'sink.a' } }), 'sink.a', 'audio reads a pinned stream')
-assert(!audio.routeIsPinned({ ready: true, properties: {} }), 'audio reports an unpinned stream')
+const routeMetadata = [
+  "update: id:120 key:'target.object' value:'sink.a' type:'(null)'",
+  "update: id:121 key:'target.object' value:'-1' type:'(null)'",
+  "update: id:122 key:'volume' value:'0.5' type:'(null)'"
+].join('\n')
+const routeTargets = audio.parseRouteTargets(routeMetadata)
+
+assertDeepEqual(routeTargets, { '120': 'sink.a', '121': '-1' }, 'audio reads routing out of the default metadata object')
+assertDeepEqual(audio.parseRouteTargets(''), {}, 'audio handles empty metadata')
+assertEqual(audio.routeTargetOf({ id: 120 }, routeTargets), 'sink.a', 'audio reads a pinned stream')
+assertEqual(audio.routeTargetOf({ id: 121 }, routeTargets), audio.DEFAULT_ROUTE, 'audio reads a cleared pin as following the default')
+assertEqual(audio.routeTargetOf({ id: 999 }, routeTargets), audio.DEFAULT_ROUTE, 'audio reads an unlisted stream as following the default')
+assert(audio.routeIsPinned({ id: 120 }, routeTargets), 'audio reports a pinned stream')
+assert(!audio.routeIsPinned({ id: 999 }, routeTargets), 'audio reports an unpinned stream')
 
 const routeSinks = [
   { ready: true, name: 'sink.a', nickname: 'Speakers' },
@@ -54,8 +64,9 @@ const routeSinks = [
 assertDeepEqual(audio.routeOptions(routeSinks), [audio.DEFAULT_ROUTE, 'sink.a', 'sink.b'], 'audio offers the default output first')
 assertEqual(audio.nextRouteTarget(audio.routeOptions(routeSinks), audio.DEFAULT_ROUTE), 'sink.a', 'audio cycles from the default to the first output')
 assertEqual(audio.nextRouteTarget(audio.routeOptions(routeSinks), 'sink.b'), audio.DEFAULT_ROUTE, 'audio cycles from the last output back to the default')
-assertEqual(audio.routeLabel({ ready: true, properties: {} }, routeSinks, null), 'Follow default output', 'audio labels an unpinned stream')
-assertEqual(audio.routeLabel({ ready: true, properties: { 'target.object': 'sink.a' } }, routeSinks, null), 'Speakers', 'audio labels a pinned stream by device')
+assertEqual(audio.routeLabel({ id: 999 }, routeSinks, null, routeTargets), 'Follow default output', 'audio labels an unpinned stream')
+assertEqual(audio.routeLabel({ id: 120 }, routeSinks, null, routeTargets), 'Speakers', 'audio labels a pinned stream by device')
+assertEqual(audio.routeLabel({ id: 999 }, routeSinks, routeSinks[1], routeTargets), 'HDMI', 'audio prefers the linked output over the pin')
 assert(audio.streamRepresentsMprisPlayer('Chromium', 'Chromium Browser'), 'audio matches related stream and MPRIS labels')
 
 const players = [


### PR DESCRIPTION
The per-app mixer sets each stream's volume and mute, but every application stays on whatever the default output is. There is no way to keep a call on the headset while music plays through speakers, short of dropping to `pw-metadata` by hand.

Each stream row gains one line showing the output it is actually coming out of. Click it, or press `o` with the cursor on the row, and the application moves to the next device, then eventually back to following the default. The line is hidden when only one output exists, since there is nothing to choose then.

Routing writes `target.object` against the stream's node id:

```sh
pw-metadata -n default <node-id> target.object <sink-name>
```

WirePlumber moves the running stream and remembers the choice for the next stream that application opens. Cycling back to the default writes `-1`, which clears it.

Two details worth flagging for review:

- The label prefers the sink the stream is genuinely linked to, read from a `PwNodeLinkTracker`, and falls back to the pinned preference. A stream that has only just started does not always have a resolved link group, and showing the preference is better than showing nothing.
- `contentHeight` for the panel moves from 560 to 620 to fit the extra line. Without that the last row is clipped, since the panel does not scroll.

`test/shell.d/audio-test.sh` goes from 11 assertions to 24, covering the command shape, reading a pinned or cleared target, the cycle order, and the labels. Verified in the running shell on Omarchy 4.0.0 with three sinks and two playing applications: the line renders per stream, and moving a stream between sinks is audible.

Preview:
<img width="384" height="609" alt="image" src="https://github.com/user-attachments/assets/e112ed88-aa00-4679-ac82-ed12b64e4dc0" />

## Known limitation: EasyEffects

When EasyEffects is in the chain the stream links to its virtual sink, so that is the name this row shows rather than the device the sound leaves by. #8713 and #9132 both resolve the effective device behind EasyEffects in `bin/omarchy-audio-output-sink`. Whichever of the two lands is the right thing for this label to consult; it is not worth a third resolver here.

## Related work

Other open PRs touch this panel, and it is worth being explicit about how they sit against this one.

**#6641 is the same feature, done differently, and only one of them should land.** It offers the outputs in a dropdown rather than cycling through them, adds an explicit "Follow default output" state, and moves only the streams that were following the previous default when the system default changes. It also identifies streams by PipeWire object serial rather than by node id. I checked whether that matters here, since a reused id could otherwise carry a stale pin onto a different application: it does not. Pinning a stream through `target.object` and then killing it clears the entry with the node, measured on PipeWire against a stream opened for the test, so the metadata cannot outlive the id it names. The real difference between the two is the interface, not the identity. This PR is the smaller surface: no new UI component, no new binaries, one line per stream. Pick whichever fits the panel better, and take #6641's serial-based identity either way.

**#7783 will conflict with this, and it should win.** It takes live `PwNode` objects out of the audio panel's Repeater models because Qt dereferences a deleted node without a null check and segfaults the shell, reported independently five times. This PR adds a routing row inside that same stream Repeater and passes `streamRow.node` into the label, which is exactly the pattern it removes. If #7783 lands first I will rebase this onto it and resolve the label through its `nodeFor()` binding rather than holding the node. In the meantime every helper this adds takes a missing node without throwing: `routeTargetOf` returns the default route for a null node and `cycleStreamRoute` returns early.

**#8820 will conflict with this.** It is the other open change to `Model.js`, `Panel.qml` and `audio-test.sh` in this panel, at +386/-13, adding inactive card outputs to the picker. It also changes which sinks the panel lists, which is the list this row cycles through. No opinion on which should go first; whichever does, the other is a small rebase.

Also in the same area, none of them conflicting: #6548 on device labels and switching guards, #7205 and #7308 on sinks with multiple ports, which affect the names this row displays, and #9221 on AirPlay outputs, which is a source of the extra sinks that make this row appear at all.

## 2026-09-01

Rebased onto current `quattro` (b71dcad9) with no conflicts.

- **Declared `textFormat` on both `Text` elements this adds.** #8397 landed on 28 August and requires it on every `Text` that renders a non-literal value, enforced by `test/shell.d/qml-text-format-test.sh`. Rebasing without this made the suite fail on exactly these two elements and nothing else. The label is the one that matters: it renders a sink name that comes from device metadata, so leaving the format to be guessed lets a device call itself something that gets read as markup.
- **Added #8820 to related work.** It is a real conflict on all three of this PR's files and was not previously named.
- **Added the EasyEffects limitation** and pointed it at #8713 and #9132 rather than resolving it here.
- **Added #9221** as a neighbour that increases the sink count this row depends on.
- **Noted the null handling** that already exists in the helpers, since #7783 landing first is the expected order.
- **Corrected the assertion count** to 24, up from 11 on `quattro`; the description still said 11 added, which was the count before the two later commits on this branch.
- `audio-test.sh` (35 checks) and `qml-text-format-test.sh` both pass on the rebase.
