### PR TITLE
Support Firefox as a web app browser

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -6,8 +6,15 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium* | firefox*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+binary=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+
+if [[ -z $binary ]]; then
+  echo "error: no browser installed that supports web app mode ($browser not found)" >&2
+  exit 1
+fi
+
+exec setsid uwsm-app -- "$binary" --app="$1" "${@:2}"

--- a/test/shell.d/launch-webapp-test.sh
+++ b/test/shell.d/launch-webapp-test.sh
@@ -58,7 +58,7 @@ grep -F '/usr/bin/chromium --app=https://messenger.com' "$launch_log" >/dev/null
   fail "webapp launcher keeps the chromium fallback for unsupported browsers" "launch: $(cat "$launch_log")"
 pass "webapp launcher keeps the chromium fallback for unsupported browsers"
 
-rm -f "$test_home/.local/share/applications/chromium.desktop"
+rm -f "$test_home/.local/share/applications/chromium.desktop" "$test_home/.local/share/applications/firefox.desktop"
 
 HOME="$test_home" PATH="$mock_bin:$PATH" BROWSER=epiphany.desktop \
   OMARCHY_TEST_WEBAPP_LAUNCH="$launch_log" \

--- a/test/shell.d/launch-webapp-test.sh
+++ b/test/shell.d/launch-webapp-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications"
+
+cat >"$test_home/.local/share/applications/firefox.desktop" <<'EOF'
+[Desktop Entry]
+Exec=/usr/lib/firefox/firefox %u
+EOF
+
+cat >"$test_home/.local/share/applications/chromium.desktop" <<'EOF'
+[Desktop Entry]
+Exec=/usr/bin/chromium %U
+EOF
+
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+printf '%s\n' "$BROWSER"
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_WEBAPP_LAUNCH"
+SH
+
+chmod +x "$mock_bin"/*
+
+launch_log="$test_tmp/launch"
+
+HOME="$test_home" PATH="$mock_bin:$PATH" BROWSER=firefox.desktop \
+  OMARCHY_TEST_WEBAPP_LAUNCH="$launch_log" \
+  bash "$ROOT/bin/omarchy-launch-webapp" "https://messenger.com"
+
+grep -F '/usr/lib/firefox/firefox --app=https://messenger.com' "$launch_log" >/dev/null ||
+  fail "webapp launcher uses the default browser binary with --app" "launch: $(cat "$launch_log")"
+pass "webapp launcher uses the default browser binary with --app"
+
+: >"$launch_log"
+
+HOME="$test_home" PATH="$mock_bin:$PATH" BROWSER=chromium.desktop \
+  OMARCHY_TEST_WEBAPP_LAUNCH="$launch_log" \
+  bash "$ROOT/bin/omarchy-launch-webapp" "https://messenger.com"
+
+grep -F '/usr/bin/chromium --app=https://messenger.com' "$launch_log" >/dev/null ||
+  fail "webapp launcher keeps the chromium fallback for unsupported browsers" "launch: $(cat "$launch_log")"
+pass "webapp launcher keeps the chromium fallback for unsupported browsers"
+
+rm -f "$test_home/.local/share/applications/chromium.desktop"
+
+HOME="$test_home" PATH="$mock_bin:$PATH" BROWSER=epiphany.desktop \
+  OMARCHY_TEST_WEBAPP_LAUNCH="$launch_log" \
+  bash "$ROOT/bin/omarchy-launch-webapp" "https://messenger.com" >"$test_tmp/stdout" 2>"$test_tmp/stderr" &&
+  fail "webapp launcher fails when no --app-capable browser is installed"
+
+grep -F 'no browser installed' "$test_tmp/stderr" >/dev/null ||
+  fail "webapp launcher reports a clear error when no --app-capable browser is installed" "$(cat "$test_tmp/stderr")"
+pass "webapp launcher reports a clear error when no --app-capable browser is installed"


### PR DESCRIPTION
Closes #7034

## Problem

`omarchy launch webapp <url>` fails on systems where Firefox is the default
browser:

```
error: path "--app=https://messenger.com" does not exist!
```

`bin/omarchy-launch-webapp` only whitelists Chromium-family browsers
(`google-chrome`, `brave`, `microsoft-edge`, `opera`, `vivaldi`, `helium`)
for `--app=<url>` app mode and falls back to a hardcoded `chromium.desktop`
for everything else. On a Firefox-only install `chromium.desktop` doesn't
exist, so the `sed` extraction returns an empty binary and the command
degrades to `uwsm-app -- --app="<url>"`, which then errors on the `--app`
argument as if it were a path.

## Fix

- Add `firefox*` to the supported browser list. Firefox supports
  `--app=<url>` app mode.
- Resolve the browser binary up front and fail with a clear error instead of
  handing `uwsm-app` an empty executable when no `--app`-capable browser can
  be found (e.g. an unsupported default browser with chromium also missing).

## Testing

New `test/shell.d/launch-webapp-test.sh` covers:

- Firefox as the default browser → launches Firefox with `--app=<url>`.
- Unsupported default browser with chromium present → chromium fallback still
  works.
- Unsupported default browser with no chromium → clear error, no cryptic
  `uwsm-app` failure.

The existing shell-suite failures (bar widget timeout, missing `omarchy-pkgs`
checkout, missing compositor) are pre-existing environment issues and fail on
`quattro` without this change as well.