### PR TITLE
Add Ctrl-N and Ctrl-P menu navigation

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1139,10 +1139,12 @@ Item {
           } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
             root.goBack()
             event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
+          } else if (event.key === Qt.Key_Up ||
+                     (event.key === Qt.Key_P && (event.modifiers & Qt.ControlModifier))) {
             root.select(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Down) {
+          } else if (event.key === Qt.Key_Down ||
+                     (event.key === Qt.Key_N && (event.modifiers & Qt.ControlModifier))) {
             root.select(1)
             event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -421,6 +421,11 @@ assert(
   /function select\(delta\)[\s\S]*root\.disarmPointer\(\)[\s\S]*selectedIndex =/.test(menuQml),
   'menu keyboard navigation disarms pointer selection'
 )
+assert(
+  /event\.key === Qt\.Key_Up \|\|\s*\(event\.key === Qt\.Key_P && \(event\.modifiers & Qt\.ControlModifier\)\)/.test(menuQml)
+    && /event\.key === Qt\.Key_Down \|\|\s*\(event\.key === Qt\.Key_N && \(event\.modifiers & Qt\.ControlModifier\)\)/.test(menuQml),
+  'menu supports Ctrl+P and Ctrl+N as keyboard navigation aliases'
+)
 // A dimmed row is not a target: the cursor steps over it, the pointer refuses
 // to land on it, and neither Enter nor a click can reach it.
 assert(


### PR DESCRIPTION
## Summary

- navigate down in the Omarchy menu with Ctrl+N
- navigate up with Ctrl+P
- retain the existing arrow-key behavior and add regression coverage

## Testing

- `bash test/shell.d/menu-test.sh`
- `qmllint -I shell shell/plugins/menu/Menu.qml`
- live UI verification with `wtype`: Ctrl+N moved the highlight from Apps to Learn, and Ctrl+P moved it back to Apps
- `./test/shell`: menu coverage passed; the run had four unrelated environment failures (`config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` require an `omarchy-pkgs` checkout; `network-qr-test.sh` failed its sandboxed Wi-Fi auto-detection case)