### PR TITLE
Superseded by #6929: T2 Radeon low-power mode

### DIFF
--- a/default/systemd/system/omarchy-t2-dgpu-low-power.service
+++ b/default/systemd/system/omarchy-t2-dgpu-low-power.service
@@ -1,14 +1,13 @@
 [Unit]
-Description=Power off the T2 MacBook discrete GPU in integrated mode
+Description=Keep the T2 MacBook discrete GPU in low-power mode
 After=systemd-modules-load.service
 Before=display-manager.service
 ConditionPathExists=/etc/modprobe.d/apple-gmux.conf
-RequiresMountsFor=/sys/kernel/debug
 
 [Service]
 Type=oneshot
 ExecCondition=/usr/bin/grep -Eq '^[[:space:]]*options[[:space:]]+apple-gmux[[:space:]].*force_igd=(y|Y|1)([[:space:]]|$)' /etc/modprobe.d/apple-gmux.conf
-ExecStart=/bin/bash -c 'for _ in {1..30}; do if [[ -e /sys/kernel/debug/vgaswitcheroo/switch ]]; then echo OFF > /sys/kernel/debug/vgaswitcheroo/switch; exit; fi; sleep 1; done; exit 1'
+ExecStart=/bin/bash -c 'for _ in {1..30}; do for level in /sys/bus/pci/drivers/amdgpu/0000:*/power_dpm_force_performance_level; do [[ -e $level ]] || continue; echo low > "$level"; exit; done; sleep 1; done; exit 1'
 
 [Install]
 WantedBy=multi-user.target

--- a/default/systemd/system/omarchy-t2-dgpu-off.service
+++ b/default/systemd/system/omarchy-t2-dgpu-off.service
@@ -3,6 +3,7 @@ Description=Power off the T2 MacBook discrete GPU in integrated mode
 After=systemd-modules-load.service
 Before=display-manager.service
 ConditionPathExists=/etc/modprobe.d/apple-gmux.conf
+RequiresMountsFor=/sys/kernel/debug
 
 [Service]
 Type=oneshot

--- a/default/systemd/system/omarchy-t2-dgpu-off.service
+++ b/default/systemd/system/omarchy-t2-dgpu-off.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Power off the T2 MacBook discrete GPU in integrated mode
+After=systemd-modules-load.service
+Before=display-manager.service
+ConditionPathExists=/etc/modprobe.d/apple-gmux.conf
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/grep -Eq '^[[:space:]]*options[[:space:]]+apple-gmux[[:space:]].*force_igd=(y|Y|1)([[:space:]]|$)' /etc/modprobe.d/apple-gmux.conf
+ExecStart=/bin/bash -c 'for _ in {1..30}; do if [[ -e /sys/kernel/debug/vgaswitcheroo/switch ]]; then echo OFF > /sys/kernel/debug/vgaswitcheroo/switch; exit; fi; sleep 1; done; exit 1'
+
+[Install]
+WantedBy=multi-user.target

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -35,6 +35,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2-dgpu-power.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-t2-dgpu-power.sh
+++ b/install/hardware/apple/fix-t2-dgpu-power.sh
@@ -1,0 +1,11 @@
+pci_devices="$(lspci -nn)"
+
+if grep -q '106b:180[12]' <<<"$pci_devices" &&
+  grep -q 'VGA compatible controller.*\[8086:' <<<"$pci_devices" &&
+  grep -q 'VGA compatible controller.*\[1002:' <<<"$pci_devices"; then
+  service_source="${OMARCHY_T2_DGPU_SERVICE_SOURCE:-$OMARCHY_PATH/default/systemd/system/omarchy-t2-dgpu-off.service}"
+  service_path="${OMARCHY_T2_DGPU_SERVICE_PATH:-/etc/systemd/system/omarchy-t2-dgpu-off.service}"
+
+  install -Dm644 "$service_source" "$service_path"
+  systemctl enable omarchy-t2-dgpu-off.service
+fi

--- a/install/hardware/apple/fix-t2-dgpu-power.sh
+++ b/install/hardware/apple/fix-t2-dgpu-power.sh
@@ -3,9 +3,9 @@ pci_devices="$(lspci -nn)"
 if grep -q '106b:180[12]' <<<"$pci_devices" &&
   grep -q 'VGA compatible controller.*\[8086:' <<<"$pci_devices" &&
   grep -q 'VGA compatible controller.*\[1002:' <<<"$pci_devices"; then
-  service_source="${OMARCHY_T2_DGPU_SERVICE_SOURCE:-$OMARCHY_PATH/default/systemd/system/omarchy-t2-dgpu-off.service}"
-  service_path="${OMARCHY_T2_DGPU_SERVICE_PATH:-/etc/systemd/system/omarchy-t2-dgpu-off.service}"
+  service_source="${OMARCHY_T2_DGPU_SERVICE_SOURCE:-$OMARCHY_PATH/default/systemd/system/omarchy-t2-dgpu-low-power.service}"
+  service_path="${OMARCHY_T2_DGPU_SERVICE_PATH:-/etc/systemd/system/omarchy-t2-dgpu-low-power.service}"
 
   install -Dm644 "$service_source" "$service_path"
-  systemctl enable omarchy-t2-dgpu-off.service
+  systemctl enable omarchy-t2-dgpu-low-power.service
 fi

--- a/migrations/1786820569.sh
+++ b/migrations/1786820569.sh
@@ -1,0 +1,20 @@
+echo "Enable integrated-mode Radeon power-off on hybrid T2 MacBooks"
+
+repair_marker="${OMARCHY_T2_DGPU_REPAIR_MARKER:-/var/lib/omarchy/migrations/1786820569}"
+if [[ -e $repair_marker ]]; then
+  exit 0
+fi
+
+pci_devices="$(lspci -nn)"
+if ! grep -q '106b:180[12]' <<<"$pci_devices" ||
+  ! grep -q 'VGA compatible controller.*\[8086:' <<<"$pci_devices" ||
+  ! grep -q 'VGA compatible controller.*\[1002:' <<<"$pci_devices"; then
+  exit 0
+fi
+
+service_source="${OMARCHY_T2_DGPU_SERVICE_SOURCE:-$OMARCHY_PATH/default/systemd/system/omarchy-t2-dgpu-off.service}"
+service_path="${OMARCHY_T2_DGPU_SERVICE_PATH:-/etc/systemd/system/omarchy-t2-dgpu-off.service}"
+
+sudo install -Dm644 "$service_source" "$service_path"
+sudo systemctl enable omarchy-t2-dgpu-off.service
+sudo install -Dm644 /dev/null "$repair_marker"

--- a/migrations/1786820569.sh
+++ b/migrations/1786820569.sh
@@ -1,4 +1,4 @@
-echo "Enable integrated-mode Radeon power-off on hybrid T2 MacBooks"
+echo "Keep Radeon in low-power mode on hybrid T2 MacBooks"
 
 repair_marker="${OMARCHY_T2_DGPU_REPAIR_MARKER:-/var/lib/omarchy/migrations/1786820569}"
 if [[ -e $repair_marker ]]; then
@@ -12,9 +12,9 @@ if ! grep -q '106b:180[12]' <<<"$pci_devices" ||
   exit 0
 fi
 
-service_source="${OMARCHY_T2_DGPU_SERVICE_SOURCE:-$OMARCHY_PATH/default/systemd/system/omarchy-t2-dgpu-off.service}"
-service_path="${OMARCHY_T2_DGPU_SERVICE_PATH:-/etc/systemd/system/omarchy-t2-dgpu-off.service}"
+service_source="${OMARCHY_T2_DGPU_SERVICE_SOURCE:-$OMARCHY_PATH/default/systemd/system/omarchy-t2-dgpu-low-power.service}"
+service_path="${OMARCHY_T2_DGPU_SERVICE_PATH:-/etc/systemd/system/omarchy-t2-dgpu-low-power.service}"
 
 sudo install -Dm644 "$service_source" "$service_path"
-sudo systemctl enable omarchy-t2-dgpu-off.service
+sudo systemctl enable omarchy-t2-dgpu-low-power.service
 sudo install -Dm644 /dev/null "$repair_marker"

--- a/test/shell.d/t2-dgpu-power-test.sh
+++ b/test/shell.d/t2-dgpu-power-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+installer="$ROOT/install/hardware/apple/fix-t2-dgpu-power.sh"
+service="$ROOT/default/systemd/system/omarchy-t2-dgpu-off.service"
+migration="$ROOT/migrations/1786820569.sh"
+
+grep -Fxq 'After=systemd-modules-load.service' "$service" ||
+  fail "the T2 dGPU service waits for graphics modules"
+grep -Fxq 'Before=display-manager.service' "$service" ||
+  fail "the T2 dGPU service runs before the display manager"
+grep -Fq 'force_igd=(y|Y|1)' "$service" ||
+  fail "the T2 dGPU service only runs in integrated mode"
+grep -Fq 'echo OFF > /sys/kernel/debug/vgaswitcheroo/switch' "$service" ||
+  fail "the T2 dGPU service powers Radeon off through vga_switcheroo"
+pass "the T2 dGPU service follows the selected graphics mode"
+
+grep -Fq 'apple/fix-t2-dgpu-power.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "fresh installs run the T2 dGPU setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+service_path="$test_tmp/etc/systemd/system/omarchy-t2-dgpu-off.service"
+repair_marker="$test_tmp/var/lib/omarchy/migrations/1786820569"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+if (( ${T2_HARDWARE:-0} )); then
+  echo '04:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+if (( ${INTEL_GPU:-0} )); then
+  echo '00:02.0 VGA compatible controller [0300]: Intel UHD Graphics [8086:3e9b]'
+fi
+if (( ${AMD_GPU:-0} )); then
+  echo '03:00.0 VGA compatible controller [0300]: AMD Radeon Pro [1002:7340]'
+fi
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_installer() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_DGPU_SERVICE_PATH="$service_path" \
+    T2_HARDWARE="${T2_HARDWARE:-1}" \
+    INTEL_GPU="${INTEL_GPU:-1}" \
+    AMD_GPU="${AMD_GPU:-1}" \
+    bash -euo pipefail "$installer"
+}
+
+run_installer
+
+cmp -s "$service" "$service_path" ||
+  fail "fresh hybrid T2 installs copy the dGPU service"
+grep -Fxq $'systemctl\tenable\tomarchy-t2-dgpu-off.service' "$calls" ||
+  fail "fresh hybrid T2 installs enable the dGPU service"
+pass "fresh hybrid T2 installs enable automatic Radeon power-off"
+
+rm -f "$service_path"
+: >"$calls"
+AMD_GPU=0 run_installer
+
+[[ ! -e $service_path ]] || fail "iGPU-only T2 Macs skip the dGPU service"
+[[ ! -s $calls ]] || fail "iGPU-only T2 Macs leave systemd unchanged" "$(cat "$calls")"
+pass "iGPU-only T2 Macs skip Radeon power management"
+
+: >"$calls"
+T2_HARDWARE=0 run_installer
+
+[[ ! -e $service_path ]] || fail "non-T2 hybrid laptops skip the dGPU service"
+[[ ! -s $calls ]] || fail "non-T2 hybrid laptops leave systemd unchanged" "$(cat "$calls")"
+pass "non-T2 hybrid laptops skip the T2-specific service"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_DGPU_SERVICE_PATH="$service_path" \
+    OMARCHY_T2_DGPU_REPAIR_MARKER="$repair_marker" \
+    T2_HARDWARE="${T2_HARDWARE:-1}" \
+    INTEL_GPU="${INTEL_GPU:-1}" \
+    AMD_GPU="${AMD_GPU:-1}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+: >"$calls"
+run_migration
+
+cmp -s "$service" "$service_path" ||
+  fail "the migration installs the dGPU service on existing hybrid T2 Macs"
+grep -Fxq $'sudo\tsystemctl\tenable\tomarchy-t2-dgpu-off.service' "$calls" ||
+  fail "the migration enables the dGPU service"
+[[ -f $repair_marker ]] || fail "the migration records the machine-wide repair"
+! grep -Eq $'systemctl\t(enable --now|start)' "$calls" ||
+  fail "the migration waits until reboot to change GPU power"
+pass "the migration prepares existing hybrid T2 Macs for the next boot"
+
+: >"$calls"
+run_migration
+
+[[ ! -s $calls ]] || fail "an already migrated machine is left unchanged" "$(cat "$calls")"
+pass "the T2 dGPU migration is machine-idempotent"
+
+rm -f "$repair_marker"
+: >"$calls"
+T2_HARDWARE=0 run_migration
+
+[[ ! -e $repair_marker ]] || fail "non-T2 machines skip the dGPU migration"
+[[ ! -s $calls ]] || fail "non-T2 machines migrate without privileged work" "$(cat "$calls")"
+pass "the migration skips unrelated hardware without prompting"

--- a/test/shell.d/t2-dgpu-power-test.sh
+++ b/test/shell.d/t2-dgpu-power-test.sh
@@ -12,6 +12,8 @@ grep -Fxq 'After=systemd-modules-load.service' "$service" ||
   fail "the T2 dGPU service waits for graphics modules"
 grep -Fxq 'Before=display-manager.service' "$service" ||
   fail "the T2 dGPU service runs before the display manager"
+grep -Fxq 'RequiresMountsFor=/sys/kernel/debug' "$service" ||
+  fail "the T2 dGPU service waits for debugfs"
 grep -Fq 'force_igd=(y|Y|1)' "$service" ||
   fail "the T2 dGPU service only runs in integrated mode"
 grep -Fq 'echo OFF > /sys/kernel/debug/vgaswitcheroo/switch' "$service" ||

--- a/test/shell.d/t2-dgpu-power-test.sh
+++ b/test/shell.d/t2-dgpu-power-test.sh
@@ -5,19 +5,21 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 installer="$ROOT/install/hardware/apple/fix-t2-dgpu-power.sh"
-service="$ROOT/default/systemd/system/omarchy-t2-dgpu-off.service"
+service="$ROOT/default/systemd/system/omarchy-t2-dgpu-low-power.service"
 migration="$ROOT/migrations/1786820569.sh"
 
 grep -Fxq 'After=systemd-modules-load.service' "$service" ||
   fail "the T2 dGPU service waits for graphics modules"
 grep -Fxq 'Before=display-manager.service' "$service" ||
   fail "the T2 dGPU service runs before the display manager"
-grep -Fxq 'RequiresMountsFor=/sys/kernel/debug' "$service" ||
-  fail "the T2 dGPU service waits for debugfs"
 grep -Fq 'force_igd=(y|Y|1)' "$service" ||
   fail "the T2 dGPU service only runs in integrated mode"
-grep -Fq 'echo OFF > /sys/kernel/debug/vgaswitcheroo/switch' "$service" ||
-  fail "the T2 dGPU service powers Radeon off through vga_switcheroo"
+grep -Fq 'power_dpm_force_performance_level' "$service" ||
+  fail "the T2 dGPU service waits for the Radeon DPM control"
+grep -Fq 'echo low > "$level"' "$service" ||
+  fail "the T2 dGPU service selects the safe low-power level"
+! grep -Fq 'vgaswitcheroo' "$service" ||
+  fail "the T2 dGPU service must not cut Radeon power"
 pass "the T2 dGPU service follows the selected graphics mode"
 
 grep -Fq 'apple/fix-t2-dgpu-power.sh' "$ROOT/install/hardware/all.sh" ||
@@ -28,7 +30,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 calls="$test_tmp/calls.log"
-service_path="$test_tmp/etc/systemd/system/omarchy-t2-dgpu-off.service"
+service_path="$test_tmp/etc/systemd/system/omarchy-t2-dgpu-low-power.service"
 repair_marker="$test_tmp/var/lib/omarchy/migrations/1786820569"
 mkdir -p "$stub_bin"
 : >"$calls"
@@ -81,9 +83,9 @@ run_installer
 
 cmp -s "$service" "$service_path" ||
   fail "fresh hybrid T2 installs copy the dGPU service"
-grep -Fxq $'systemctl\tenable\tomarchy-t2-dgpu-off.service' "$calls" ||
+grep -Fxq $'systemctl\tenable\tomarchy-t2-dgpu-low-power.service' "$calls" ||
   fail "fresh hybrid T2 installs enable the dGPU service"
-pass "fresh hybrid T2 installs enable automatic Radeon power-off"
+pass "fresh hybrid T2 installs enable safe Radeon power management"
 
 rm -f "$service_path"
 : >"$calls"
@@ -117,7 +119,7 @@ run_migration
 
 cmp -s "$service" "$service_path" ||
   fail "the migration installs the dGPU service on existing hybrid T2 Macs"
-grep -Fxq $'sudo\tsystemctl\tenable\tomarchy-t2-dgpu-off.service' "$calls" ||
+grep -Fxq $'sudo\tsystemctl\tenable\tomarchy-t2-dgpu-low-power.service' "$calls" ||
   fail "the migration enables the dGPU service"
 [[ -f $repair_marker ]] || fail "the migration records the machine-wide repair"
 ! grep -Eq $'systemctl\t(enable --now|start)' "$calls" ||


### PR DESCRIPTION
> Superseded by #6929, which now owns both T2 graphics-mode selection and the safe Radeon low-power policy.

## Investigation result

The original version of this PR powered Radeon off through `vga_switcheroo`. Real suspend testing on a MacBookPro16,1 showed that an OFF Radeon leaves its upstream PCI bridges inaccessible during ACPI S3 preparation. Resume then waits 65 seconds for AMD and fails to recover Broadcom Wi-Fi and Thunderbolt USB controllers.

A test kernel that skipped AMD reset callbacks removed the first AMD error but did not repair the platform-level PCI failure. Full dGPU power-off therefore is not safe as an Omarchy default on this hardware.

Keeping Radeon powered at the supported `low` DPM level completed deep S3 and restored Wi-Fi normally. That policy has moved into #6929 as a udev rule tied directly to the integrated/dedicated mode toggle:

- integrated mode installs the `low` DPM rule
- dedicated mode removes it and restores normal automatic performance
- no `vga_switcheroo OFF` path remains

This PR is retained as the investigation record and is closed as superseded.