### PR TITLE
Fix unreachable Bluetooth toggle when radio is off

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -30,13 +30,18 @@ Panel {
   // adapter === null, which is what keeps the icon and its toggle reachable
   // after Bluetooth is switched off.
   //
-  // Hardware presence is assumed (true) until a probe proves otherwise: a
-  // cleanly run probe concludes yes or no from rfkill's stdout, and when a
-  // probe cannot run at all the state falls back to adapter presence — the
-  // same gate the widget used before. An adapter that appears at any point
-  // is authoritative and clears a stale "no hardware" answer.
+  // Hardware presence is assumed (true) until a probe proves otherwise. Only
+  // a definitive probe — clean exit, empty stdout, no live adapter — may
+  // conclude "no hardware"; an inconclusive probe (failed spawn or non-zero
+  // exit) keeps the previous value, so probe uncertainty can never hide the
+  // panel or strand a deferred power-on. An adapter that appears at any
+  // point is authoritative and clears a stale "no hardware" answer.
   property bool hardwarePresent: true
   property bool probePending: false
+  // False until the first probe (or an adapter) settles the question; the
+  // widget falls back to the plain adapter gate while unknown, which avoids
+  // a brief phantom panel on machines without Bluetooth hardware.
+  property bool hardwarePresenceKnown: false
   // Set when the user asks to power on while the first probe's answer is
   // still unknown; acted on once that probe confirms the radio exists.
   property bool deferredPowerOn: false
@@ -78,6 +83,7 @@ Panel {
   function probeHardware() {
     if (root.probePending) return
     root.probePending = true
+    root.lastProbeStdout = ""
     probeWatchdog.start()
     rfkillProbe.running = true
   }
@@ -85,9 +91,10 @@ Panel {
   // Single completion path for every probe; the probePending gate drops any
   // late signal from a superseded run. A live adapter is authoritative (a
   // probe started before a dongle appeared may report a stale empty
-  // listing), and a probe that did not run cleanly — non-zero exit, or the
-  // watchdog's -1 sentinel — falls back to adapter presence rather than
-  // concluding "no hardware".
+  // listing). An inconclusive probe — non-zero exit, or the watchdog's
+  // sentinel — changes nothing: hardwarePresent keeps its previous value and
+  // a deferred power-on survives for a later definitive probe, so probe
+  // uncertainty can never hide the panel or drop the user's intent.
   function finishProbe(exitCode) {
     probeWatchdog.stop()
     if (!root.probePending) return
@@ -96,13 +103,15 @@ Panel {
     // run. A real exit leaves no process behind to stop.
     if (exitCode === root.probeSpawnFailedExitCode) rfkillProbe.running = false
     root.probePending = false
-    root.hardwarePresent = exitCode === 0
-      ? root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
-      : root.adapter !== null
-    if (root.deferredPowerOn) {
-      root.deferredPowerOn = false
-      if (root.hardwarePresent && (root.adapter === null || !root.adapter.enabled))
-        Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+    root.hardwarePresenceKnown = true
+    if (exitCode === 0) {
+      root.hardwarePresent = root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
+      // Definitive answer: act on the deferred intent now, or drop it.
+      if (root.deferredPowerOn) {
+        root.deferredPowerOn = false
+        if (root.hardwarePresent && (root.adapter === null || !root.adapter.enabled))
+          Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+      }
     }
   }
 
@@ -120,6 +129,7 @@ Panel {
         // probe is left to finish (it reads live rfkill state and reaches
         // the same conclusion). Honor a deferred power-on instead of
         // dropping it when the adapter is back but still powered off.
+        root.hardwarePresenceKnown = true
         root.hardwarePresent = true
         if (root.deferredPowerOn) {
           root.deferredPowerOn = false
@@ -604,7 +614,7 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: hardwarePresent
+  visible: hardwarePresenceKnown ? hardwarePresent : adapter !== null
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -40,6 +40,9 @@ Panel {
   // Set when the user asks to power on while the first probe's answer is
   // still unknown; acted on once that probe confirms the radio exists.
   property bool deferredPowerOn: false
+  // Sentinel finishProbe receives when the watchdog gives up on a probe that
+  // never signalled completion (missing executable or a hung process).
+  readonly property int probeSpawnFailedExitCode: -1
   property string lastProbeStdout: ""
 
   Process {
@@ -69,7 +72,7 @@ Panel {
   Timer {
     id: probeWatchdog
     interval: 2000
-    onTriggered: root.finishProbe(-1)
+    onTriggered: root.finishProbe(root.probeSpawnFailedExitCode)
   }
 
   function probeHardware() {
@@ -88,6 +91,10 @@ Panel {
   function finishProbe(exitCode) {
     probeWatchdog.stop()
     if (!root.probePending) return
+    // A watchdog timeout means the process never completed: stop it so the
+    // next probe starts from a clean slate instead of stacking on a hung
+    // run. A real exit leaves no process behind to stop.
+    if (exitCode === root.probeSpawnFailedExitCode) rfkillProbe.running = false
     root.probePending = false
     root.hardwarePresent = exitCode === 0
       ? root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
@@ -740,9 +747,10 @@ Panel {
       if (hardwarePresent && !probePending) {
         Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
       } else if (probePending) {
-        // The first probe hasn't answered yet; remember the intent instead
-        // of acting on the unverified default (finishProbe runs the command).
-        deferredPowerOn = true
+        // The first probe hasn't answered yet; record the intent instead of
+        // acting on the unverified default (finishProbe runs the command).
+        // Each click toggles it, so a change of mind can cancel the request.
+        deferredPowerOn = !deferredPowerOn
       }
       return
     }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -23,6 +23,42 @@ Panel {
 
   readonly property var adapter: Bluetooth.defaultAdapter
 
+  // A soft-blocked radio disappears from BlueZ entirely, so a missing adapter
+  // is ambiguous: it can mean "turned off" or "no hardware". The kernel's
+  // rfkill switch (e.g. tpacpi_bluetooth_sw) outlives the block, so probe it
+  // to tell the two apart. Everything UI-facing keys off this instead of
+  // adapter === null, which is what keeps the icon and its toggle reachable
+  // after Bluetooth is switched off.
+  property bool hardwarePresent: true
+  property bool probePending: false
+
+  Process {
+    id: rfkillProbe
+    command: ["rfkill", "list", "bluetooth"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        root.hardwarePresent = String(text || "").trim().length > 0
+        root.probePending = false
+      }
+    }
+  }
+
+  function probeHardware() {
+    if (root.probePending) return
+    root.probePending = true
+    rfkillProbe.running = true
+  }
+
+  Component.onCompleted: root.probeHardware()
+
+  Connections {
+    target: Bluetooth
+    function onDefaultAdapterChanged() {
+      if (Bluetooth.defaultAdapter === null) root.probeHardware()
+    }
+  }
+
   // True while this instance owes BlueZ a StopDiscovery: set when it starts
   // discovery (or opens onto a session already running) and cleared once
   // discovery is confirmed down after close. Ownership, not state — BlueZ's
@@ -56,7 +92,7 @@ Panel {
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
   readonly property string icon: {
-    if (!adapter) return ""
+    if (!adapter) return hardwarePresent ? "󰂲" : ""
     if (!adapter.enabled) return "󰂲"
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
@@ -75,7 +111,7 @@ Panel {
   ]
   readonly property bool rotatingPhrases: adapter && adapter.enabled
   readonly property string heroStatusText: {
-    if (!adapter) return "No adapter"
+    if (!adapter) return hardwarePresent ? "Turned Off" : "No adapter"
     if (!adapter.enabled) return "Turned Off"
     return activePhrases[phraseIndex % activePhrases.length]
   }
@@ -497,7 +533,7 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: adapter !== null
+  visible: hardwarePresent
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
@@ -633,7 +669,13 @@ Panel {
   // switch only moves once BlueZ catches up, so a second click inside that window
   // would re-read the old state and undo the first.
   function toggleBluetooth() {
-    if (!adapter) return
+    if (!adapter) {
+      // The block removed the adapter from BlueZ; only an unblock brings it
+      // back. Bailing here left a toggled-off radio with no way back on from
+      // the UI.
+      if (hardwarePresent) Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+      return
+    }
     Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
   }
 
@@ -711,7 +753,7 @@ Panel {
           // header's only cursor target.
           ToggleSwitch {
             id: powerSwitch
-            visible: !!root.adapter
+            visible: root.hardwarePresent
             checked: !!root.adapter && root.adapter.enabled
             hasCursor: root.headerHasCursor
             foreground: root.bar.foreground
@@ -864,8 +906,8 @@ Panel {
 
         Text {
           visible: root.connectedDevices.length === 0 && root.scrollRows.length === 0
-          text: !root.adapter ? "No Bluetooth adapter"
-              : !root.adapter.enabled ? "Turn Bluetooth on to scan"
+          text: !root.hardwarePresent ? "No Bluetooth adapter"
+              : !root.adapter || !root.adapter.enabled ? "Turn Bluetooth on to scan"
               : "Scanning for devices…"
           color: Qt.darker(root.bar.foreground, 1.5)
           font.family: root.bar.fontFamily

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -31,60 +31,77 @@ Panel {
   // after Bluetooth is switched off.
   //
   // Hardware presence is assumed (true) until a probe proves otherwise: a
-  // completed probe concludes yes or no from rfkill's stdout, and when the
-  // probe cannot run at all (missing rfkill) the state falls back to adapter
-  // presence — the same gate the widget used before. An adapter that appears
-  // at any point is authoritative and clears a stale "no hardware" answer.
+  // cleanly run probe concludes yes or no from rfkill's stdout, and when a
+  // probe cannot run at all the state falls back to adapter presence — the
+  // same gate the widget used before. An adapter that appears at any point
+  // is authoritative and clears a stale "no hardware" answer.
   property bool hardwarePresent: true
   property bool probePending: false
   // Set when the user asks to power on while the first probe's answer is
-  // still unknown; acted on once that probe concludes the radio exists.
+  // still unknown; acted on once that probe confirms the radio exists.
   property bool deferredPowerOn: false
+  property string lastProbeStdout: ""
 
   Process {
     id: rfkillProbe
     // Direct call, no shell: `rfkill list bluetooth` prints one or more
     // radio entries whenever Bluetooth hardware exists (blocked or not) and
-    // nothing on machines without it. A failed spawn (missing executable)
-    // surfaces as errorOccurred and never reaches the stream.
+    // nothing on machines without it. The exit code tells a clean empty
+    // listing (no hardware) apart from a failed run (tool unusable).
     command: ["rfkill", "list", "bluetooth"]
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.finishProbe(String(text || "").trim().length > 0)
+      onStreamFinished: root.lastProbeStdout = String(text || "")
     }
-    // A probe that never ran can't conclude anything: fall back to adapter
-    // presence, and drop a deferred power-on so a stale intent can't fire
-    // against a much later, unrelated probe.
-    onErrorOccurred: {
-      root.probePending = false
-      root.deferredPowerOn = false
-      root.hardwarePresent = Bluetooth.defaultAdapter !== null
+    // exited is the process-completion signal and carries the exit code. It
+    // fires after stdout has been fully collected, so lastProbeStdout is
+    // complete here. A failed spawn never reaches it — the watchdog handles
+    // that case.
+    onExited: function(exitCode, exitStatus) {
+      probeWatchdog.stop()
+      root.finishProbe(exitCode)
     }
+  }
+
+  // rfkill completes in milliseconds; if no exited signal arrives by now the
+  // probe never ran (missing executable), which would otherwise strand
+  // probePending with no signal to clear it.
+  Timer {
+    id: probeWatchdog
+    interval: 2000
+    onTriggered: root.finishProbe(-1)
   }
 
   function probeHardware() {
     if (root.probePending) return
     root.probePending = true
+    probeWatchdog.start()
     rfkillProbe.running = true
   }
 
-  // Single completion path for every probe. The probePending gate drops any
-  // late signal from a superseded run, which keeps one probe in flight at a
-  // time. A live adapter is authoritative even here: a probe that started
-  // before a dongle appeared may report a stale empty listing, so it must
-  // not flip hardwarePresent back to false.
-  function finishProbe(devicesListed) {
+  // Single completion path for every probe; the probePending gate drops any
+  // late signal from a superseded run. A live adapter is authoritative (a
+  // probe started before a dongle appeared may report a stale empty
+  // listing), and a probe that did not run cleanly — non-zero exit, or the
+  // watchdog's -1 sentinel — falls back to adapter presence rather than
+  // concluding "no hardware".
+  function finishProbe(exitCode) {
+    probeWatchdog.stop()
     if (!root.probePending) return
     root.probePending = false
-    root.hardwarePresent = root.adapter !== null || devicesListed
+    root.hardwarePresent = exitCode === 0
+      ? root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
+      : root.adapter !== null
     if (root.deferredPowerOn) {
       root.deferredPowerOn = false
-      if (root.hardwarePresent && !root.adapter)
+      if (root.hardwarePresent && (root.adapter === null || !root.adapter.enabled))
         Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
     }
   }
 
-  Component.onCompleted: root.probeHardware()
+  // Hardware presence is already known while an adapter exists; only probe
+  // when there is none to disambiguate.
+  Component.onCompleted: { if (root.adapter === null) root.probeHardware() }
 
   Connections {
     target: Bluetooth
@@ -92,12 +109,16 @@ Panel {
       if (Bluetooth.defaultAdapter === null) {
         root.probeHardware()
       } else {
-        // An adapter existing is definitive proof of hardware; clear any
-        // stale "no hardware" conclusion (e.g. a dongle plugged in later).
-        // An in-flight probe is left to finish — it reads live rfkill state
-        // and reaches the same conclusion.
+        // Adapter presence is definitive proof of hardware; an in-flight
+        // probe is left to finish (it reads live rfkill state and reaches
+        // the same conclusion). Honor a deferred power-on instead of
+        // dropping it when the adapter is back but still powered off.
         root.hardwarePresent = true
-        root.deferredPowerOn = false
+        if (root.deferredPowerOn) {
+          root.deferredPowerOn = false
+          if (!root.adapter.enabled)
+            Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+        }
       }
     }
   }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -92,9 +92,14 @@ Panel {
   // late signal from a superseded run. A live adapter is authoritative (a
   // probe started before a dongle appeared may report a stale empty
   // listing). An inconclusive probe — non-zero exit, or the watchdog's
-  // sentinel — changes nothing: hardwarePresent keeps its previous value and
-  // a deferred power-on survives for a later definitive probe, so probe
-  // uncertainty can never hide the panel or drop the user's intent.
+  // sentinel — changes nothing: presence stays unknown, hardwarePresent keeps
+  // its previous value and a deferred power-on survives for a later definitive
+  // probe, so probe uncertainty can never hide the panel or drop the user's
+  // intent. Leaving it unknown matters: hardwarePresent defaults to true, so
+  // marking an inconclusive probe "known" would promote that optimistic guess
+  // into the answer and show the panel on a machine with no Bluetooth at all
+  // (`rfkill list` exits non-zero when /dev/rfkill is absent, as on a VM with
+  // no radios). Unknown falls back to the plain adapter gate, which hides it.
   function finishProbe(exitCode) {
     probeWatchdog.stop()
     if (!root.probePending) return
@@ -103,8 +108,8 @@ Panel {
     // run. A real exit leaves no process behind to stop.
     if (exitCode === root.probeSpawnFailedExitCode) rfkillProbe.running = false
     root.probePending = false
-    root.hardwarePresenceKnown = true
     if (exitCode === 0) {
+      root.hardwarePresenceKnown = true
       root.hardwarePresent = root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
       // Definitive answer: act on the deferred intent now, or drop it.
       if (root.deferredPowerOn) {

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -48,6 +48,10 @@ Panel {
   // Sentinel finishProbe receives when the watchdog gives up on a probe that
   // never signalled completion (missing executable or a hung process).
   readonly property int probeSpawnFailedExitCode: -1
+  // How long a probe may run before the watchdog gives up on it. rfkill
+  // answers in milliseconds; the timeout exists only to unstick a probe that
+  // never completed, so a hung process cannot strand probePending.
+  readonly property int probeWatchdogMs: 2000
   property string lastProbeStdout: ""
 
   Process {
@@ -61,13 +65,13 @@ Panel {
       waitForEnd: true
       onStreamFinished: root.lastProbeStdout = String(text || "")
     }
-    // exited is the process-completion signal and carries the exit code. It
-    // fires after stdout has been fully collected, so lastProbeStdout is
-    // complete here. A failed spawn never reaches it — the watchdog handles
-    // that case.
+    // exited is the process-completion signal and carries the exit code and
+    // exit status. It fires after stdout has been fully collected, so
+    // lastProbeStdout is complete here. A failed spawn never reaches it — the
+    // watchdog handles that case.
     onExited: function(exitCode, exitStatus) {
       probeWatchdog.stop()
-      root.finishProbe(exitCode)
+      root.finishProbe(exitCode, exitStatus)
     }
   }
 
@@ -76,7 +80,7 @@ Panel {
   // probePending with no signal to clear it.
   Timer {
     id: probeWatchdog
-    interval: 2000
+    interval: root.probeWatchdogMs
     onTriggered: root.finishProbe(root.probeSpawnFailedExitCode)
   }
 
@@ -91,8 +95,9 @@ Panel {
   // Single completion path for every probe; the probePending gate drops any
   // late signal from a superseded run. A live adapter is authoritative (a
   // probe started before a dongle appeared may report a stale empty
-  // listing). An inconclusive probe — non-zero exit, or the watchdog's
-  // sentinel — changes nothing: presence stays unknown, hardwarePresent keeps
+  // listing). An inconclusive probe — non-zero exit, abnormal termination,
+  // or the watchdog's sentinel — changes nothing: presence stays unknown,
+  // hardwarePresent keeps
   // its previous value and a deferred power-on survives for a later definitive
   // probe, so probe uncertainty can never hide the panel or drop the user's
   // intent. Leaving it unknown matters: hardwarePresent defaults to true, so
@@ -100,7 +105,7 @@ Panel {
   // into the answer and show the panel on a machine with no Bluetooth at all
   // (`rfkill list` exits non-zero when /dev/rfkill is absent, as on a VM with
   // no radios). Unknown falls back to the plain adapter gate, which hides it.
-  function finishProbe(exitCode) {
+  function finishProbe(exitCode, exitStatus) {
     probeWatchdog.stop()
     if (!root.probePending) return
     // A watchdog timeout means the process never completed: stop it so the
@@ -108,7 +113,12 @@ Panel {
     // run. A real exit leaves no process behind to stop.
     if (exitCode === root.probeSpawnFailedExitCode) rfkillProbe.running = false
     root.probePending = false
-    if (exitCode === 0) {
+    // Definitive only on a clean run. The exitStatus check is belt-and-
+    // suspenders: a signal-killed process already reports the signal number
+    // as its exit code (SIGKILL -> 9, SIGTERM -> 15), so exitCode === 0 alone
+    // would never admit a crash — the explicit check just states the
+    // "clean exit only" invariant.
+    if (exitCode === 0 && exitStatus === 0) {
       root.hardwarePresenceKnown = true
       root.hardwarePresent = root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
       // Definitive answer: act on the deferred intent now, or drop it.
@@ -208,7 +218,7 @@ Panel {
   ]
   readonly property bool rotatingPhrases: adapter && adapter.enabled
   readonly property string heroStatusText: {
-    if (!adapter) return hardwarePresenceKnown ? (hardwarePresent ? "Turned Off" : "No adapter") : ""
+    if (!adapter) return hardwarePresenceKnown ? (hardwarePresent ? "Turned Off" : "No Bluetooth adapter") : ""
     if (!adapter.enabled) return "Turned Off"
     return activePhrases[phraseIndex % activePhrases.length]
   }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -48,6 +48,11 @@ Panel {
   // Sentinel finishProbe receives when the watchdog gives up on a probe that
   // never signalled completion (missing executable or a hung process).
   readonly property int probeSpawnFailedExitCode: -1
+  // Sentinel finishProbe receives as exitStatus from the watchdog. The probe
+  // never completed, so it is never a clean exit (QProcess reports abnormal
+  // termination as exitStatus 1 / CrashExit); a non-zero status keeps the
+  // "clean exit only" gate closed regardless of the sentinel exit code.
+  readonly property int probeSpawnFailedExitStatus: 1
   // How long a probe may run before the watchdog gives up on it. rfkill
   // answers in milliseconds; the timeout exists only to unstick a probe that
   // never completed, so a hung process cannot strand probePending.
@@ -81,7 +86,7 @@ Panel {
   Timer {
     id: probeWatchdog
     interval: root.probeWatchdogMs
-    onTriggered: root.finishProbe(root.probeSpawnFailedExitCode)
+    onTriggered: root.finishProbe(root.probeSpawnFailedExitCode, root.probeSpawnFailedExitStatus)
   }
 
   function probeHardware() {
@@ -864,10 +869,12 @@ Panel {
           }
 
           // Compact on/off switch on the trailing edge of the hero, and the
-          // header's only cursor target.
+          // header's only cursor target. Same known/unknown gate as the panel
+          // root and the icon: while presence is unknown, the switch follows
+          // the adapter instead of the optimistic hardwarePresent default.
           ToggleSwitch {
             id: powerSwitch
-            visible: root.hardwarePresent
+            visible: root.hardwarePresenceKnown ? root.hardwarePresent : root.adapter !== null
             checked: !!root.adapter && root.adapter.enabled
             hasCursor: root.headerHasCursor
             foreground: root.bar.foreground

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -29,19 +29,36 @@ Panel {
   // to tell the two apart. Everything UI-facing keys off this instead of
   // adapter === null, which is what keeps the icon and its toggle reachable
   // after Bluetooth is switched off.
+  //
+  // Hardware presence is assumed (true) until a probe proves otherwise: only
+  // a cleanly run probe with a definite yes/no answer may move it, so a
+  // missing or failing rfkill can never hide the panel, and an adapter that
+  // reappears immediately clears any stale "no hardware" conclusion.
   property bool hardwarePresent: true
   property bool probePending: false
 
   Process {
     id: rfkillProbe
-    command: ["rfkill", "list", "bluetooth"]
+    // Three-state answer on stdout so the conclusion needs neither the exit
+    // code nor stderr: "yes" (a radio is listed), "no" (clean probe, none),
+    // "unknown" (rfkill unavailable). Anything else keeps the previous value.
+    command: ["sh", "-c",
+      "if ! command -v rfkill >/dev/null 2>&1; then echo unknown;"
+      + " elif rfkill list bluetooth 2>/dev/null | grep -q .; then echo yes;"
+      + " else echo no; fi"]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        root.hardwarePresent = String(text || "").trim().length > 0
         root.probePending = false
+        var answer = String(text || "").trim()
+        if (answer === "yes") root.hardwarePresent = true
+        else if (answer === "no") root.hardwarePresent = false
       }
     }
+    // A run that never delivers output (e.g. failed start) must not strand
+    // probePending; the hardware conclusion simply stays "unknown".
+    onErrorOccurred: root.probePending = false
+    onExited: root.probePending = false
   }
 
   function probeHardware() {
@@ -55,7 +72,14 @@ Panel {
   Connections {
     target: Bluetooth
     function onDefaultAdapterChanged() {
-      if (Bluetooth.defaultAdapter === null) root.probeHardware()
+      if (Bluetooth.defaultAdapter === null) {
+        root.probeHardware()
+      } else {
+        // An adapter existing is definitive proof of hardware; clear any
+        // stale "no hardware" conclusion (e.g. a dongle plugged in later).
+        root.hardwarePresent = true
+        root.probePending = false
+      }
     }
   }
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -112,17 +112,32 @@ Panel {
       root.hardwarePresenceKnown = true
       root.hardwarePresent = root.adapter !== null || String(root.lastProbeStdout).trim().length > 0
       // Definitive answer: act on the deferred intent now, or drop it.
-      if (root.deferredPowerOn) {
-        root.deferredPowerOn = false
-        if (root.hardwarePresent && (root.adapter === null || !root.adapter.enabled))
-          Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
-      }
+      root.applyDeferredPowerOnIfNeeded()
     }
   }
 
+  // Consume a deferred power-on once the probe (or an adapter) confirms the
+  // radio exists. Shared by finishProbe and onDefaultAdapterChanged so the
+  // two consumption paths cannot drift apart; in the adapter-changed path
+  // adapter is non-null, so the null half of the condition is inert there.
+  function applyDeferredPowerOnIfNeeded() {
+    if (!root.deferredPowerOn) return
+    root.deferredPowerOn = false
+    if (root.hardwarePresent && (root.adapter === null || !root.adapter.enabled))
+      Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+  }
+
   // Hardware presence is already known while an adapter exists; only probe
-  // when there is none to disambiguate.
-  Component.onCompleted: { if (root.adapter === null) root.probeHardware() }
+  // when there is none to disambiguate. An adapter present at startup also
+  // settles the question, so the flags leave their initial 'unknown' state
+  // instead of staying unset until the first probe or a later change.
+  Component.onCompleted: {
+    if (root.adapter === null) root.probeHardware()
+    else {
+      root.hardwarePresenceKnown = true
+      root.hardwarePresent = true
+    }
+  }
 
   Connections {
     target: Bluetooth
@@ -136,11 +151,7 @@ Panel {
         // dropping it when the adapter is back but still powered off.
         root.hardwarePresenceKnown = true
         root.hardwarePresent = true
-        if (root.deferredPowerOn) {
-          root.deferredPowerOn = false
-          if (!root.adapter.enabled)
-            Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
-        }
+        root.applyDeferredPowerOnIfNeeded()
       }
     }
   }
@@ -178,7 +189,7 @@ Panel {
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
   readonly property string icon: {
-    if (!adapter) return hardwarePresent ? "󰂲" : ""
+    if (!adapter) return hardwarePresenceKnown && hardwarePresent ? "󰂲" : ""
     if (!adapter.enabled) return "󰂲"
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
@@ -197,7 +208,7 @@ Panel {
   ]
   readonly property bool rotatingPhrases: adapter && adapter.enabled
   readonly property string heroStatusText: {
-    if (!adapter) return hardwarePresent ? "Turned Off" : "No adapter"
+    if (!adapter) return hardwarePresenceKnown ? (hardwarePresent ? "Turned Off" : "No adapter") : ""
     if (!adapter.enabled) return "Turned Off"
     return activePhrases[phraseIndex % activePhrases.length]
   }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -30,41 +30,51 @@ Panel {
   // adapter === null, which is what keeps the icon and its toggle reachable
   // after Bluetooth is switched off.
   //
-  // Hardware presence is assumed (true) until a probe proves otherwise: only
-  // a cleanly run probe with a definite yes/no answer may move it, so a
-  // missing or failing rfkill can never hide the panel, and an adapter that
-  // reappears immediately clears any stale "no hardware" conclusion.
+  // Hardware presence is assumed (true) until a probe proves otherwise: a
+  // completed probe may conclude yes or no from rfkill's stdout, while a
+  // probe that never runs (missing rfkill) concludes nothing and keeps the
+  // previous value. An adapter that reappears immediately clears any stale
+  // "no hardware" conclusion.
   property bool hardwarePresent: true
   property bool probePending: false
+  // Set when the user asks to power on while the first probe's answer is
+  // still unknown; acted on once that probe concludes the radio exists.
+  property bool deferredPowerOn: false
 
   Process {
     id: rfkillProbe
-    // Three-state answer on stdout so the conclusion needs neither the exit
-    // code nor stderr: "yes" (a radio is listed), "no" (clean probe, none),
-    // "unknown" (rfkill unavailable). Anything else keeps the previous value.
-    command: ["sh", "-c",
-      "if ! command -v rfkill >/dev/null 2>&1; then echo unknown;"
-      + " elif rfkill list bluetooth 2>/dev/null | grep -q .; then echo yes;"
-      + " else echo no; fi"]
+    // Direct call, no shell: `rfkill list bluetooth` prints one or more
+    // radio entries whenever Bluetooth hardware exists (blocked or not) and
+    // nothing on machines without it. A failed spawn (missing executable)
+    // surfaces as errorOccurred and never reaches the stream.
+    command: ["rfkill", "list", "bluetooth"]
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: {
-        root.probePending = false
-        var answer = String(text || "").trim()
-        if (answer === "yes") root.hardwarePresent = true
-        else if (answer === "no") root.hardwarePresent = false
-      }
+      onStreamFinished: root.finishProbe(String(text || "").trim().length > 0)
     }
-    // A run that never delivers output (e.g. failed start) must not strand
-    // probePending; the hardware conclusion simply stays "unknown".
+    // Never strand a probe: a run that produced no stream can't conclude
+    // anything, so it just leaves hardwarePresent at its previous value.
     onErrorOccurred: root.probePending = false
-    onExited: root.probePending = false
   }
 
   function probeHardware() {
     if (root.probePending) return
     root.probePending = true
     rfkillProbe.running = true
+  }
+
+  // Single completion path for every probe. The probePending gate drops any
+  // late signal from a superseded run, which keeps one probe in flight at a
+  // time.
+  function finishProbe(devicesListed) {
+    if (!root.probePending) return
+    root.probePending = false
+    root.hardwarePresent = devicesListed
+    if (root.deferredPowerOn) {
+      root.deferredPowerOn = false
+      if (root.hardwarePresent && !root.adapter)
+        Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+    }
   }
 
   Component.onCompleted: root.probeHardware()
@@ -77,8 +87,10 @@ Panel {
       } else {
         // An adapter existing is definitive proof of hardware; clear any
         // stale "no hardware" conclusion (e.g. a dongle plugged in later).
+        // An in-flight probe is left to finish — it reads live rfkill state
+        // and reaches the same conclusion.
         root.hardwarePresent = true
-        root.probePending = false
+        root.deferredPowerOn = false
       }
     }
   }
@@ -697,7 +709,13 @@ Panel {
       // The block removed the adapter from BlueZ; only an unblock brings it
       // back. Bailing here left a toggled-off radio with no way back on from
       // the UI.
-      if (hardwarePresent) Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+      if (hardwarePresent && !probePending) {
+        Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+      } else if (probePending) {
+        // The first probe hasn't answered yet; remember the intent instead
+        // of acting on the unverified default (finishProbe runs the command).
+        deferredPowerOn = true
+      }
       return
     }
     Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -31,10 +31,10 @@ Panel {
   // after Bluetooth is switched off.
   //
   // Hardware presence is assumed (true) until a probe proves otherwise: a
-  // completed probe may conclude yes or no from rfkill's stdout, while a
-  // probe that never runs (missing rfkill) concludes nothing and keeps the
-  // previous value. An adapter that reappears immediately clears any stale
-  // "no hardware" conclusion.
+  // completed probe concludes yes or no from rfkill's stdout, and when the
+  // probe cannot run at all (missing rfkill) the state falls back to adapter
+  // presence — the same gate the widget used before. An adapter that appears
+  // at any point is authoritative and clears a stale "no hardware" answer.
   property bool hardwarePresent: true
   property bool probePending: false
   // Set when the user asks to power on while the first probe's answer is
@@ -52,9 +52,14 @@ Panel {
       waitForEnd: true
       onStreamFinished: root.finishProbe(String(text || "").trim().length > 0)
     }
-    // Never strand a probe: a run that produced no stream can't conclude
-    // anything, so it just leaves hardwarePresent at its previous value.
-    onErrorOccurred: root.probePending = false
+    // A probe that never ran can't conclude anything: fall back to adapter
+    // presence, and drop a deferred power-on so a stale intent can't fire
+    // against a much later, unrelated probe.
+    onErrorOccurred: {
+      root.probePending = false
+      root.deferredPowerOn = false
+      root.hardwarePresent = Bluetooth.defaultAdapter !== null
+    }
   }
 
   function probeHardware() {
@@ -65,11 +70,13 @@ Panel {
 
   // Single completion path for every probe. The probePending gate drops any
   // late signal from a superseded run, which keeps one probe in flight at a
-  // time.
+  // time. A live adapter is authoritative even here: a probe that started
+  // before a dongle appeared may report a stale empty listing, so it must
+  // not flip hardwarePresent back to false.
   function finishProbe(devicesListed) {
     if (!root.probePending) return
     root.probePending = false
-    root.hardwarePresent = devicesListed
+    root.hardwarePresent = root.adapter !== null || devicesListed
     if (root.deferredPowerOn) {
       root.deferredPowerOn = false
       if (root.hardwarePresent && !root.adapter)


### PR DESCRIPTION
## Bug

Turning Bluetooth off from the Bluetooth panel leaves no way to turn it back on from the UI.

`omarchy-bluetooth-power off` moves the rfkill soft block (deliberately — it survives reboots where BlueZ's `Powered` does not). A soft-blocked radio is then **dropped from BlueZ entirely**: `bluetoothctl list` is empty and `Bluetooth.defaultAdapter` becomes `null`. The panel keys its UI off `adapter`:

- `icon` returns `""` for a null adapter, and the root is `visible: adapter !== null` — the bar button collapses to zero width, so the icon disappears.
- `toggleBluetooth()` starts with `if (!adapter) return` — with the adapter gone it can't do anything.
- The hero power switch is `visible: !!root.adapter` — hidden.

Result: once off, the icon is gone and every in-panel path (switch, right-click, `B` key, `SUPER+CTRL+B`) is a dead end. The only recovery is the CLI (`omarchy bluetooth power on`). Related complaints from the other direction (icon not reflecting the off state): #3599, discussion #3675.

## Fix

A missing adapter is ambiguous — it can mean "turned off" or "no hardware" — so probe the kernel's rfkill switch (`rfkill list bluetooth`; e.g. `tpacpi_bluetooth_sw` outlives the block) to tell the two apart. Everything UI-facing keys off the resulting `hardwarePresent` instead of `adapter === null`:

- widget stays in the bar with the off glyph (`󰂲`) when the radio is off; still hidden on machines with no Bluetooth hardware
- `toggleBluetooth()` with a null adapter and hardware present runs `omarchy-bluetooth-power on`
- hero switch stays visible (unchecked) while off
- status text: "Turned Off" when hardware present, "No adapter" only when there is none

The probe reuses the existing `Process` + `StdioCollector` idiom from `Commons/Style.qml` and re-runs whenever the adapter drops (covers USB dongle hotplug).

## Verification

On a ThinkPad T470 (built-in Intel 8265):

1. `rfkill block bluetooth` → adapter disappears from BlueZ (`bluetoothctl list` empty).
2. `omarchy-shell shell toggle omarchy.bluetooth` (the `SUPER+CTRL+B` path) still opens the panel; hero shows "Turned Off" with the switch.
3. Toggling (switch / right-click / `B` / `omarchy.bluetooth toggleBluetooth` IPC) runs `omarchy-bluetooth-power on` → rfkill unblocked, adapter back (`Powered: yes`).
4. Icon shows the off glyph while blocked, normal glyphs (on/connected) once back up.

`./test/shell` cannot complete in this environment: the test harness invokes `node` through Bun's wrapper, which errors with "Missing script to execute" — 46 of 180 files fail identically on a pristine checkout (verified by stash). The `bluetooth-test.sh` failure is that same environment error, not this change.
