### PR TITLE
fix: ensure bluetooth panel stays visible when adapter is soft-blocked

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -741,7 +741,7 @@ Panel {
       Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
       return
     }
-    Quickshell.execDetached(["omarchy-bluetooth-power", targetState ? "on" : "off"])
+    Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
   }
 
   IpcHandler {

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -23,6 +23,78 @@ Panel {
 
   readonly property var adapter: Bluetooth.defaultAdapter
 
+  // True when BlueZ exposes an adapter or rfkill indicates Bluetooth hardware is present on the system.
+  property bool hardwarePresent: false
+  onAdapterChanged: {
+    if (adapter) {
+      probeTimeout.stop()
+      hardwareCheck.running = false
+      root.hardwarePresent = true
+    } else {
+      root.hasPendingPowerState = false
+      root.pendingPowerState = false
+      powerTimer.stop()
+      root.hardwarePresent = false
+      root.startHardwareProbe()
+    }
+  }
+
+  function startHardwareProbe() {
+    hardwareCheckStdout.lastOutput = ""
+    hardwareCheck.running = true
+    probeTimeout.restart()
+  }
+
+  // How long to wait for the hardware probe before assuming hardware is present
+  readonly property int hardwareProbeTimeout: 2000
+
+  Timer {
+    id: probeTimeout
+    interval: root.hardwareProbeTimeout
+    onTriggered: {
+      if (!root.adapter && hardwareCheck.running) {
+        hardwareCheck.running = false
+        // If rfkill probe hangs or times out, assume hardware is present so controls aren't locked
+        root.hardwarePresent = true
+      }
+    }
+  }
+
+  // When BlueZ has no default adapter (e.g. rfkill soft-blocked), probe rfkill
+  // to detect if hardware is present so the panel can remain available to power it on.
+  Process {
+    id: hardwareCheck
+    command: ["rfkill", "list", "bluetooth"]
+    running: false
+    stdout: StdioCollector {
+      id: hardwareCheckStdout
+      waitForEnd: true
+      onStreamFinished: {
+        if (!root.adapter) {
+          root.hardwarePresent = String(text).trim().length > 0
+        }
+      }
+    }
+    onExited: function(exitCode) {
+      probeTimeout.stop()
+      if (root.adapter) {
+        root.hardwarePresent = true
+      } else if (exitCode !== 0) {
+        // If rfkill command is missing, permission-restricted, or errored out,
+        // treat hardware as unknown/present so the user is not locked out of controls.
+        root.hardwarePresent = true
+      }
+    }
+  }
+
+  Component.onCompleted: {
+    if (root.adapter) {
+      root.hardwarePresent = true
+    } else {
+      root.startHardwareProbe()
+    }
+  }
+
   // True while this instance owes BlueZ a StopDiscovery: set when it starts
   // discovery (or opens onto a session already running) and cleared once
   // discovery is confirmed down after close. Ownership, not state — BlueZ's
@@ -56,7 +128,8 @@ Panel {
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
   readonly property string icon: {
-    if (!adapter) return ""
+    if (!hardwarePresent) return ""
+    if (!adapter) return "󰂲"
     if (!adapter.enabled) return "󰂲"
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
@@ -75,7 +148,9 @@ Panel {
   ]
   readonly property bool rotatingPhrases: adapter && adapter.enabled
   readonly property string heroStatusText: {
-    if (!adapter) return "No adapter"
+    if (!hardwarePresent) return "No Bluetooth adapter"
+    if (hasPendingPowerState) return pendingPowerState ? "Turning on…" : "Turning off…"
+    if (!adapter) return "Turned Off"
     if (!adapter.enabled) return "Turned Off"
     return activePhrases[phraseIndex % activePhrases.length]
   }
@@ -497,7 +572,7 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: adapter !== null
+  visible: root.hardwarePresent || hardwareCheck.running
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
@@ -632,9 +707,42 @@ Panel {
   // Asking for a direction rather than a toggle: the helper runs detached and the
   // switch only moves once BlueZ catches up, so a second click inside that window
   // would re-read the old state and undo the first.
+  property bool pendingPowerState: false
+  property bool hasPendingPowerState: false
+  readonly property bool effectiveEnabled: hasPendingPowerState ? pendingPowerState : (!!adapter && adapter.enabled)
+  readonly property bool isActuallyOn: !!adapter && adapter.enabled
+  onIsActuallyOnChanged: {
+    hasPendingPowerState = false
+    powerTimer.stop()
+  }
+
+  // How long to wait for the UI to stay in a pending state before falling back
+  readonly property int pendingPowerStateTimeout: 6000
+
+  Timer {
+    id: powerTimer
+    interval: root.pendingPowerStateTimeout
+    onTriggered: {
+      root.hasPendingPowerState = false
+      root.pendingPowerState = false
+    }
+  }
+
   function toggleBluetooth() {
-    if (!adapter) return
-    Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
+    if (!hardwarePresent || hasPendingPowerState) return
+
+    let isCurrentlyOn = !!adapter && adapter.enabled
+    let targetState = !isCurrentlyOn
+
+    root.pendingPowerState = targetState
+    root.hasPendingPowerState = true
+    powerTimer.restart()
+
+    if (!adapter) {
+      Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+      return
+    }
+    Quickshell.execDetached(["omarchy-bluetooth-power", targetState ? "on" : "off"])
   }
 
   IpcHandler {
@@ -704,15 +812,16 @@ Panel {
             color: root.bar.foreground
             font.family: root.bar.fontFamily
             font.pixelSize: Style.font.display
-            opacity: root.adapter && root.adapter.enabled ? 1.0 : 0.5
+            opacity: root.effectiveEnabled ? 1.0 : 0.5
           }
 
           // Compact on/off switch on the trailing edge of the hero, and the
           // header's only cursor target.
           ToggleSwitch {
             id: powerSwitch
-            visible: !!root.adapter
-            checked: !!root.adapter && root.adapter.enabled
+            visible: root.hardwarePresent
+            busy: root.hasPendingPowerState
+            checked: root.effectiveEnabled
             hasCursor: root.headerHasCursor
             foreground: root.bar.foreground
             anchors.right: parent.right
@@ -864,8 +973,8 @@ Panel {
 
         Text {
           visible: root.connectedDevices.length === 0 && root.scrollRows.length === 0
-          text: !root.adapter ? "No Bluetooth adapter"
-              : !root.adapter.enabled ? "Turn Bluetooth on to scan"
+          text: !root.hardwarePresent ? "No Bluetooth adapter"
+              : (!root.adapter || !root.adapter.enabled) ? "Turn Bluetooth on to scan"
               : "Scanning for devices…"
           color: Qt.darker(root.bar.foreground, 1.5)
           font.family: root.bar.fontFamily

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -25,38 +25,62 @@ Panel {
 
   // True when BlueZ exposes an adapter or rfkill indicates Bluetooth hardware is present on the system.
   property bool hardwarePresent: false
+  property bool hardwarePresenceKnown: false
+  property bool probePending: false
+
   onAdapterChanged: {
     if (adapter) {
-      probeTimeout.stop()
+      probeWatchdog.stop()
       hardwareCheck.running = false
+      root.probePending = false
+      root.hardwarePresenceKnown = true
       root.hardwarePresent = true
+      root.hasPendingPowerState = false
+      root.pendingPowerState = false
+      powerTimer.stop()
     } else {
       root.hasPendingPowerState = false
       root.pendingPowerState = false
       powerTimer.stop()
-      root.hardwarePresent = false
+      // Do not clear hardwarePresent here -- keeping the previous state
+      // avoids icon and switch flicker during the probe when powering off.
       root.startHardwareProbe()
     }
   }
 
   function startHardwareProbe() {
+    if (probePending) return
+    probePending = true
+    probeWatchdog.restart()
     hardwareCheck.running = true
-    probeTimeout.restart()
   }
 
-  // How long to wait for the hardware probe before assuming hardware is present
+  function finishProbe(exitCode, stdoutText) {
+    probeWatchdog.stop()
+    if (!probePending) return
+    probePending = false
+    hardwareCheck.running = false
+
+    root.hardwarePresenceKnown = true
+    if (root.adapter) {
+      root.hardwarePresent = true
+    } else if (exitCode === 0) {
+      root.hardwarePresent = String(stdoutText).trim().length > 0
+    } else {
+      // Non-zero exit or abnormal exit (e.g. kernel without /dev/rfkill or VM without radios):
+      // On machines without Bluetooth hardware, rfkill exits non-zero.
+      // Therefore, non-zero exit means hardware is NOT present.
+      root.hardwarePresent = false
+    }
+  }
+
+  // How long to wait for the hardware probe before timing out
   readonly property int hardwareProbeTimeout: 2000
 
   Timer {
-    id: probeTimeout
+    id: probeWatchdog
     interval: root.hardwareProbeTimeout
-    onTriggered: {
-      if (!root.adapter && hardwareCheck.running) {
-        hardwareCheck.running = false
-        // If rfkill probe hangs or times out, assume hardware is present so controls aren't locked
-        root.hardwarePresent = true
-      }
-    }
+    onTriggered: root.finishProbe(-1, "")
   }
 
   // When BlueZ has no default adapter (e.g. rfkill soft-blocked), probe rfkill
@@ -69,25 +93,29 @@ Panel {
       id: hardwareCheckStdout
       waitForEnd: true
       onStreamFinished: {
-        if (!root.adapter) {
-          root.hardwarePresent = String(text).trim().length > 0
-        }
+        // Output handled upon process exit / completion
       }
     }
     onExited: function(exitCode) {
-      probeTimeout.stop()
-      if (root.adapter) {
-        root.hardwarePresent = true
-      } else if (exitCode !== 0) {
-        // If rfkill command is missing, permission-restricted, or errored out,
-        // treat hardware as unknown/present so the user is not locked out of controls.
-        root.hardwarePresent = true
+      root.finishProbe(exitCode, hardwareCheckStdout.text)
+    }
+    onRunningChanged: {
+      // Quickshell's Process does not emit exited when a binary fails to start (FailedToStart),
+      // only transitioning running back to false. Catch this immediately so probePending
+      // is not left stranded until the watchdog fires.
+      if (!running && root.probePending) {
+        Qt.callLater(function() {
+          if (!hardwareCheck.running && root.probePending) {
+            root.finishProbe(-1, "")
+          }
+        })
       }
     }
   }
 
   Component.onCompleted: {
     if (root.adapter) {
+      root.hardwarePresenceKnown = true
       root.hardwarePresent = true
     } else {
       root.startHardwareProbe()
@@ -571,7 +599,7 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: root.hardwarePresent || hardwareCheck.running
+  visible: root.hardwarePresenceKnown ? root.hardwarePresent : (root.adapter !== null)
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -35,9 +35,9 @@ Panel {
       root.probePending = false
       root.hardwarePresenceKnown = true
       root.hardwarePresent = true
-      root.hasPendingPowerState = false
-      root.pendingPowerState = false
-      powerTimer.stop()
+      // The pending state is not cleared here: BlueZ exposes the adapter before
+      // AutoEnable powers it, so "Turning on…" has to outlive its arrival.
+      // onIsActuallyOnChanged clears it when the radio is really up.
     } else {
       root.hasPendingPowerState = false
       root.pendingPowerState = false

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -27,6 +27,7 @@ Panel {
   property bool hardwarePresent: false
   property bool hardwarePresenceKnown: false
   property bool probePending: false
+  property int probeGeneration: 0
 
   onAdapterChanged: {
     if (adapter) {
@@ -50,14 +51,15 @@ Panel {
 
   function startHardwareProbe() {
     if (probePending) return
+    probeGeneration++
     probePending = true
     probeWatchdog.restart()
     hardwareCheck.running = true
   }
 
-  function finishProbe(exitCode, stdoutText) {
+  function finishProbe(generation, exitCode, stdoutText) {
+    if (generation !== root.probeGeneration || !probePending) return
     probeWatchdog.stop()
-    if (!probePending) return
     probePending = false
     hardwareCheck.running = false
 
@@ -65,12 +67,16 @@ Panel {
     if (root.adapter) {
       root.hardwarePresent = true
     } else if (exitCode === 0) {
+      // util-linux rfkill exits 0 when it runs successfully.
+      // On machines without Bluetooth hardware, stdout is empty.
+      // On machines with Bluetooth hardware (even if soft-blocked), stdout lists devices.
       root.hardwarePresent = String(stdoutText).trim().length > 0
     } else {
-      // Non-zero exit or abnormal exit (e.g. kernel without /dev/rfkill or VM without radios):
-      // On machines without Bluetooth hardware, rfkill exits non-zero.
-      // Therefore, non-zero exit means hardware is NOT present.
-      root.hardwarePresent = false
+      // Inconclusive probe (watchdog timeout or abnormal process termination):
+      // On machines with no Bluetooth hardware, rfkill exits 0 with empty output.
+      // A non-zero exit or watchdog trigger is not evidence of hardware absence.
+      // Default to assuming hardware is present so controls are not permanently locked out.
+      root.hardwarePresent = true
     }
   }
 
@@ -80,14 +86,14 @@ Panel {
   Timer {
     id: probeWatchdog
     interval: root.hardwareProbeTimeout
-    onTriggered: root.finishProbe(-1, "")
+    onTriggered: root.finishProbe(root.probeGeneration, -1, "")
   }
 
   // When BlueZ has no default adapter (e.g. rfkill soft-blocked), probe rfkill
   // to detect if hardware is present so the panel can remain available to power it on.
   Process {
     id: hardwareCheck
-    command: ["rfkill", "list", "bluetooth"]
+    command: ["rfkill", "-n", "-o", "DEVICE", "list", "bluetooth"]
     running: false
     stdout: StdioCollector {
       id: hardwareCheckStdout
@@ -97,16 +103,17 @@ Panel {
       }
     }
     onExited: function(exitCode) {
-      root.finishProbe(exitCode, hardwareCheckStdout.text)
+      root.finishProbe(root.probeGeneration, exitCode, hardwareCheckStdout.text)
     }
     onRunningChanged: {
       // Quickshell's Process does not emit exited when a binary fails to start (FailedToStart),
       // only transitioning running back to false. Catch this immediately so probePending
       // is not left stranded until the watchdog fires.
       if (!running && root.probePending) {
+        var currentGen = root.probeGeneration
         Qt.callLater(function() {
-          if (!hardwareCheck.running && root.probePending) {
-            root.finishProbe(-1, "")
+          if (!hardwareCheck.running && root.probePending && root.probeGeneration === currentGen) {
+            root.finishProbe(currentGen, -1, "")
           }
         })
       }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -40,7 +40,6 @@ Panel {
   }
 
   function startHardwareProbe() {
-    hardwareCheckStdout.lastOutput = ""
     hardwareCheck.running = true
     probeTimeout.restart()
   }

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -19,6 +19,13 @@ assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so 
 // Writing adapter.enabled sets BlueZ Powered, which does not survive a reboot.
 assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
 assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the adapter power state directly')
+assert(/if \(!adapter\) \{\s+Quickshell\.execDetached\(\["omarchy-bluetooth-power", "on"\]\)/.test(panelSource), 'bluetooth unblocks radio through helper when adapter is soft-blocked')
+
+// Hardware presence probe keeps the panel visible and toggle functional when the adapter is soft-blocked.
+assert(/visible: root\.hardwarePresenceKnown \? root\.hardwarePresent : \(root\.adapter !== null\)/.test(panelSource), 'bluetooth panel visibility gates on probed hardware presence')
+assert(/property int probeGeneration: 0/.test(panelSource), 'bluetooth probe tracks generation to prevent cross-probe races')
+assert(/command: \["rfkill", "-n", "-o", "DEVICE", "list", "bluetooth"\]/.test(panelSource), 'bluetooth probes hardware via named-column rfkill')
+
 
 // Discovery is a BlueZ session that nothing ends at panel close: it persists
 // until StopDiscovery or until quickshell's D-Bus connection drops with the


### PR DESCRIPTION
### Summary
When Bluetooth is soft-blocked at boot via `rfkill`, BlueZ does not expose a default adapter object. Previously, this caused the panel to treat the hardware as missing or showed "Turned Off" inconsistently.

### Changes
- Probe `rfkill` when `adapter` is null to distinguish soft-blocked hardware from physically absent hardware.
- Implement optimistic power state toggling with `ToggleSwitch` busy state to provide immediate UI feedback without double-toggle races.
- Gracefully handle probe timeouts, signal ordering, and execution failures without flickering or locking users out of controls.