### PR TITLE
Allow switching Wi-Fi networks during authentication

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -423,8 +423,8 @@ Panel {
     if (selectedIndex < 0 || selectedIndex >= wifiNetworks.length) return
     var net = wifiNetworks[selectedIndex]
     if (!net) return
-    if (wifiActionFocused) {
-      if (canForgetNetwork(net) && !busy) forget(net)
+    if (wifiActionFocused && canForgetNetwork(net) && !busy) {
+      forget(net)
       return
     }
     activateNetwork(net)

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -420,16 +420,14 @@ Panel {
   // connected → disconnect, protected-unknown → password prompt,
   // open/known → connect.
   function activateSelected() {
-    if (busy || selectedIndex < 0 || selectedIndex >= wifiNetworks.length) return
+    if (selectedIndex < 0 || selectedIndex >= wifiNetworks.length) return
     var net = wifiNetworks[selectedIndex]
     if (!net) return
-    if (wifiActionFocused && canForgetNetwork(net)) { forget(net); return }
-    // Only act on a row that still resolves. disconnect() falls back to
-    // connectedWifiNetwork when handed null, so a row left stale by scan churn
-    // would otherwise tear down whatever is connected now instead.
-    if (net.connected) { disconnectRow(net.ssid); return }
-    if (isProtected(net.security) && !net.known) { openPasswordPrompt(net.ssid); return }
-    connectKnown(net.ssid)
+    if (wifiActionFocused) {
+      if (canForgetNetwork(net) && !busy) forget(net)
+      return
+    }
+    activateNetwork(net)
   }
 
   // Bar pill state, derived from the native NetworkManager service so the
@@ -719,6 +717,52 @@ Panel {
     // throws, etc.), clear the busy state so the row doesn't get stuck on
     // "Connecting…" / "Disconnecting…" forever.
     actionTimeout.restart()
+  }
+
+  // Native NetworkManager connections can replace one another. Stop tracking
+  // the old attempt before disconnecting it, so its completion signals cannot
+  // clear the state of the network the user picked next.
+  function cancelActiveConnect() {
+    if (actionKind !== "connect" || enterpriseConnect.running) return false
+
+    var network = networkForSsid(actionSsid)
+    actionTimeout.stop()
+    actionSsid = ""
+    actionKind = ""
+    failureSsid = ""
+    failureReason = ""
+    cancelPasswordPrompt()
+
+    if (network) network.disconnect()
+    return true
+  }
+
+  function canReplaceActiveConnect(net) {
+    return !!net && actionKind === "connect" && !enterpriseConnect.running
+      && actionSsid !== (net.ssid || "")
+  }
+
+  function activateNetwork(net) {
+    if (!net) return
+
+    var replacedConnect = false
+    if (busy) {
+      if (!canReplaceActiveConnect(net) || !cancelActiveConnect()) return
+      replacedConnect = true
+    }
+
+    // The previous connection can remain active while NetworkManager tries a
+    // new one. Picking it again cancels the new attempt and keeps the working
+    // connection instead of disconnecting it.
+    if (net.connected) {
+      if (!replacedConnect) disconnectRow(net.ssid)
+      return
+    }
+    if (isProtected(net.security) && !net.known) {
+      openPasswordPrompt(net.ssid)
+      return
+    }
+    connectKnown(net.ssid)
   }
 
   function clearNetworkAction() {
@@ -1673,7 +1717,7 @@ Panel {
       hoverEnabled: true
       acceptedButtons: Qt.LeftButton
       cursorShape: Qt.PointingHandCursor
-      enabled: !root.busy
+      enabled: !root.busy || root.canReplaceActiveConnect(row.net)
 
       // Move the cursor here when the mouse enters; mouse leaving doesn't
       // clear it (so the cursor stays where the mouse last was and
@@ -1688,15 +1732,7 @@ Panel {
         root.focusSection = "wifi"
         root.selectedIndex = row.index
         root.wifiActionFocused = false
-        if (row.isConnected) {
-          root.disconnectRow(row.net.ssid)
-          return
-        }
-        if (row.isProtected && !row.isKnown) {
-          root.openPasswordPrompt(row.net.ssid)
-          return
-        }
-        root.connectKnown(row.net.ssid)
+        root.activateNetwork(row.net)
       }
     }
 

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -84,6 +84,18 @@ assert(
 )
 assert(!/disconnect\(\s*(root\.)?networkForSsid\(/.test(panelSource), 'network never passes an unguarded networkForSsid() lookup to disconnect()')
 
+// A password attempt can take 25 seconds to fail. Other rows must remain
+// available so the user can leave that attempt without waiting for its
+// timeout. Enterprise connections use a separate nmcli process and remain
+// serialized because stopping that process can leave a partial profile.
+const cancelConnect = panelSource.match(/function cancelActiveConnect\(\) \{[\s\S]*?\n {2}\}/)
+assert(cancelConnect, 'network has a helper to cancel the active connection attempt')
+assert(/actionSsid = ""[\s\S]*actionKind = ""[\s\S]*network\.disconnect\(\)/.test(cancelConnect[0]), 'network stops tracking an attempt before disconnecting it')
+assert(/enterpriseConnect\.running/.test(cancelConnect[0]), 'network does not interrupt an enterprise connection process')
+assert(/enabled: !root\.busy \|\| root\.canReplaceActiveConnect\(row\.net\)/.test(panelSource), 'other network rows stay enabled during a native connection attempt')
+assert(/function activateSelected\(\)[\s\S]*activateNetwork\(net\)/.test(panelSource), 'keyboard activation can replace a connection attempt')
+assert(/onClicked:[\s\S]*root\.activateNetwork\(row\.net\)/.test(panelSource), 'pointer activation can replace a connection attempt')
+
 assertDeepEqual(
   network.parseNetworkStatus('wifi\tCafe WiFi\t78\t5200\n'),
   { kind: 'wifi', label: 'Cafe WiFi', signalStrength: 78, frequency: '5200' },

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -9,6 +9,19 @@ const fs = require('fs')
 const network = requireFromRoot('shell/plugins/panels/network/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
 
+function qmlFunction(name) {
+  const start = panelSource.indexOf(`function ${name}(`)
+  if (start < 0) return null
+
+  const bodyStart = panelSource.indexOf('{', start)
+  var depth = 0
+  for (var index = bodyStart; index < panelSource.length; index++) {
+    if (panelSource[index] === '{') depth++
+    else if (panelSource[index] === '}' && --depth === 0) return panelSource.slice(start, index + 1)
+  }
+  return null
+}
+
 assert(/IpcHandler[\s\S]*?function toggleNetwork\(\) \{ root\.toggleNetwork\(\) \}/.test(panelSource), 'network exposes the Wi-Fi radio toggle over IPC')
 assert(/manageIpc: false/.test(panelSource), 'network owns its IPC handler so it can extend the target methods')
 
@@ -88,12 +101,37 @@ assert(!/disconnect\(\s*(root\.)?networkForSsid\(/.test(panelSource), 'network n
 // available so the user can leave that attempt without waiting for its
 // timeout. Enterprise connections use a separate nmcli process and remain
 // serialized because stopping that process can leave a partial profile.
-const cancelConnect = panelSource.match(/function cancelActiveConnect\(\) \{[\s\S]*?\n {2}\}/)
+const cancelConnect = qmlFunction('cancelActiveConnect')
 assert(cancelConnect, 'network has a helper to cancel the active connection attempt')
-assert(/actionSsid = ""[\s\S]*actionKind = ""[\s\S]*network\.disconnect\(\)/.test(cancelConnect[0]), 'network stops tracking an attempt before disconnecting it')
-assert(/enterpriseConnect\.running/.test(cancelConnect[0]), 'network does not interrupt an enterprise connection process')
+const clearSsid = cancelConnect.indexOf('actionSsid = ""')
+const clearKind = cancelConnect.indexOf('actionKind = ""')
+const disconnectNetwork = cancelConnect.indexOf('network.disconnect()')
+assert(clearSsid >= 0 && clearKind > clearSsid && disconnectNetwork > clearKind, 'network stops tracking an attempt before disconnecting it')
+assert(cancelConnect.includes('enterpriseConnect.running'), 'network does not interrupt an enterprise connection process')
 assert(/enabled: !root\.busy \|\| root\.canReplaceActiveConnect\(row\.net\)/.test(panelSource), 'other network rows stay enabled during a native connection attempt')
-assert(/function activateSelected\(\)[\s\S]*activateNetwork\(net\)/.test(panelSource), 'keyboard activation can replace a connection attempt')
+const activateSelectedSource = qmlFunction('activateSelected')
+assert(activateSelectedSource, 'network has a keyboard activation helper')
+var selectedIndex = 0
+var wifiNetworks = [{}]
+var wifiActionFocused = true
+var busy = true
+var forgettable = true
+var activationCalls = []
+function canForgetNetwork() { return forgettable }
+function forget() { activationCalls.push('forget') }
+function activateNetwork() { activationCalls.push('activate') }
+eval(activateSelectedSource)
+activateSelected()
+assertDeepEqual(activationCalls, ['activate'], 'keyboard activation falls through to the primary action while forget is busy')
+busy = false
+forgettable = false
+activationCalls = []
+activateSelected()
+assertDeepEqual(activationCalls, ['activate'], 'keyboard activation falls through to the primary action when the network cannot be forgotten')
+forgettable = true
+activationCalls = []
+activateSelected()
+assertDeepEqual(activationCalls, ['forget'], 'keyboard activation stops after forgetting the network')
 assert(/onClicked:[\s\S]*root\.activateNetwork\(row\.net\)/.test(panelSource), 'pointer activation can replace a connection attempt')
 
 assertDeepEqual(


### PR DESCRIPTION
## Summary

- Let the user select another Wi-Fi network during a normal connection attempt.
- Cancel the old attempt before starting the selected network.
- Keep enterprise Wi-Fi connection attempts non-interruptible.

## Why this is useful

This is a quality-of-life improvement for recovering from a failed Wi-Fi login.

A wrong password currently disables every network row until the connection attempt times out. The user must wait before selecting another network. This change removes that delay and makes the network panel feel more responsive.

## Video

The video enters an incorrect password for `Omarchy PR Test`, then selects another network. The second attempt starts approximately 0.4 seconds after the selection. Other SSIDs are partially redacted.

![Wi-Fi network switching demo](https://raw.githubusercontent.com/andrewxwrz/omarchy/pr-assets-network-switch/network-switch-demo.gif)

[Watch the H.264 MP4](https://raw.githubusercontent.com/andrewxwrz/omarchy/pr-assets-network-switch/network-switch-demo.mp4)

## Testing

- `OMARCHY_PATH=/home/dev/src/omarchy bash test/shell.d/network-test.sh`
- `OMARCHY_PATH=/home/dev/src/omarchy OMARCHY_PKGS_PATH=/home/dev/src/omarchy-pkgs ./test/all`
- Manual test with a wrong hotspot password and an immediate switch to another network