### PR TITLE
Migrate Brave Origin Beta profile data to stable

### DIFF
--- a/migrations/1786851224.sh
+++ b/migrations/1786851224.sh
@@ -13,6 +13,7 @@ if [[ -d $beta ]]; then
   if profile_open "$beta" || { [[ -d $stable ]] && profile_open "$stable"; }; then
     echo "Brave is running — skipping profile migration." >&2
     echo "Quit Brave completely, then run: omarchy-update" >&2
+    exit 1
   else
     if [[ -d $stable ]]; then
       backup="$stable.bak.$(date +%Y%m%d%H%M%S)"
@@ -22,7 +23,7 @@ if [[ -d $beta ]]; then
 
     mv "$beta" "$stable"
     rm -f "$stable"/Singleton*
-    rm -rf ~/.cache/BraveSoftware/Brave-Origin-Beta
+    rm -rf "$HOME/.cache/BraveSoftware/Brave-Origin-Beta"
 
     echo "Beta profile migrated. Previous stable data (if any) kept as a .bak directory."
   fi

--- a/migrations/1786851224.sh
+++ b/migrations/1786851224.sh
@@ -17,11 +17,14 @@ if [[ -d $beta ]]; then
   else
     if [[ -d $stable ]]; then
       backup="$stable.bak.$(date +%Y%m%d%H%M%S)"
-      mv "$stable" "$backup"
+      mv -T "$stable" "$backup"
       echo "Existing stable profile preserved at $backup"
     fi
 
-    mv "$beta" "$stable"
+    # -T so a destination that exists is replaced rather than moved into. A
+    # plain mv would nest the profile as Brave-Origin/Brave-Origin-Beta and
+    # still report success, stranding the data the migration exists to rescue.
+    mv -T "$beta" "$stable"
     rm -f "$stable"/Singleton*
     rm -rf "$HOME/.cache/BraveSoftware/Brave-Origin-Beta"
 

--- a/migrations/1786851224.sh
+++ b/migrations/1786851224.sh
@@ -1,0 +1,29 @@
+echo "Migrate Brave Origin Beta profile data to stable"
+
+beta=~/.config/BraveSoftware/Brave-Origin-Beta
+stable=~/.config/BraveSoftware/Brave-Origin
+
+# A running Chromium-family browser holds a SingletonLock (and socket) inside
+# its user-data-dir; -L also catches a lock left as a dangling symlink.
+profile_open() {
+  [[ -L $1/SingletonLock || -e $1/SingletonLock || -S $1/SingletonSocket ]]
+}
+
+if [[ -d $beta ]]; then
+  if profile_open "$beta" || { [[ -d $stable ]] && profile_open "$stable"; }; then
+    echo "Brave is running — skipping profile migration." >&2
+    echo "Quit Brave completely, then run: omarchy-update" >&2
+  else
+    if [[ -d $stable ]]; then
+      backup="$stable.bak.$(date +%Y%m%d%H%M%S)"
+      mv "$stable" "$backup"
+      echo "Existing stable profile preserved at $backup"
+    fi
+
+    mv "$beta" "$stable"
+    rm -f "$stable"/Singleton*
+    rm -rf ~/.cache/BraveSoftware/Brave-Origin-Beta
+
+    echo "Beta profile migrated. Previous stable data (if any) kept as a .bak directory."
+  fi
+fi


### PR DESCRIPTION
## Summary
`migrations/1784510887.sh` switches the Brave package from `brave-origin-beta-bin` to `brave-origin-bin`, but leaves the user's profile data behind in `~/.config/BraveSoftware/Brave-Origin-Beta`. Stable Brave reads from `~/.config/BraveSoftware/Brave-Origin` instead, so it comes up as a fresh install — no bookmarks, history, passwords, cookies, extensions, or additional profiles. Observed on a real machine: a 1.6 GB beta directory (8 profiles) sitting next to a 115 MB freshly-initialized stable directory with just one.

This adds a **new** migration rather than editing `1784510887.sh` — everyone affected has already run it, so editing it fixes nobody.

- Moves (not copies) the whole beta directory in one `mv`: same filesystem, atomic, no extra disk space needed. `Local State` maps profile directories to display names and per-profile prefs depend on it, so the two directories must never be merged.
- If a stable directory already exists, it's renamed to a timestamped `<dir>.bak.<datetime>` sibling rather than deleted — swapping the two back restores the pre-migration state exactly.
- Skips (leaving both directories untouched) if either profile looks currently open, checked the same way `migrations/1786643346.sh` does: a `SingletonLock` (plain file or dangling symlink) or `SingletonSocket`inside the profile directory. Prints instructions to quit Brave and re-run `omarchy-update`.
- No-ops cleanly when the beta directory is absent (never installed, or already migrated).

## Testing
Verified all four directory-state combinations (beta+stable, beta-only, stable-only, neither) plus the running-browser skip, under a synthetic `$HOME`.

Also ran it for real on my own machine against a genuine beta profile (1.6 GB,8 profiles: WorkStation, YT, SH Linkedin, Python Course, Kimi Test, TK Vai,play store, surfshark vpn). Worth flagging: on this machine a real running Brave process left **no** `SingletonLock`/`SingletonSocket` files in its profile directory at all — the lock-file guard alone didn't detect it as running. I confirmed via `pgrep`/`ps` that Brave was fully quit before running the migration for real, so nothing was corrupted, but the lock-file check inherited from `1786643346.sh` may not be sufficient on its own for every Brave build/desktop combination. After the real run: all 8 profiles, their display names, bookmarks, history, and extensions came across correctly, and Brave started up normally afterward with all cookies and data.