### PR TITLE
Remember cursor position when navigating back in the root menu

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -726,10 +726,11 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoreIndex) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
+    if (pushHistory && id !== root.activeMenu)
+      root.navStack = root.navStack.concat([{ id: root.activeMenu, index: root.selectedIndex }])
     root.activeMenu = id
     root.filterText = ""
     root.selectedIndex = 0
@@ -739,6 +740,8 @@ Item {
     root.rebuildDisplay()
     root.invalidateVolatileProvider(id)
     root.loadProviderForMenu(id)
+    if (restoreIndex !== undefined && restoreIndex >= 0 && restoreIndex < displayModel.count)
+      root.selectedIndex = restoreIndex
   }
 
   function goBack() {
@@ -747,7 +750,7 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous, false)
+      root.setActiveMenu(previous.id, false, false, previous.index)
       return true
     }
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -460,12 +460,26 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoreIndex\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
   'menu Left key follows empty-filter Backspace navigation'
+)
+// Drilling into a submenu remembers the row you left behind, so goBack can
+// put the cursor back on it instead of resetting to the top of the list.
+assert(
+  /if \(pushHistory && id !== root\.activeMenu\)\s*\n\s*root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, index: root\.selectedIndex \}\]\)/.test(menuQml),
+  'menu history remembers the selected row of the menu being left'
+)
+assert(
+  /function goBack\(\)[\s\S]*?root\.setActiveMenu\(previous\.id, false, false, previous\.index\)/.test(menuQml),
+  'menu goBack restores the remembered row of the menu it returns to'
+)
+assert(
+  /if \(restoreIndex !== undefined && restoreIndex >= 0 && restoreIndex < displayModel\.count\)\s*\n\s*root\.selectedIndex = restoreIndex/.test(menuQml),
+  'menu only restores the remembered row when it still fits the rebuilt list'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),


### PR DESCRIPTION
When navigating backwards in the menu, you are always returned to the first item in the list. This change makes it so that it remembers what index you came from. I find this helpful for exploring the menu when I don't necessarily know what all the options are (yet)!