### PR TITLE
menu: add web search fallback for unmatched queries

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -634,18 +634,42 @@ Item {
         else drilldownRows.push(row)
       }
 
-      var searchSort = function(a, b) {
-        if (a.score !== b.score) return a.score - b.score
-        return a.path.localeCompare(b.path)
-      }
+      if (currentRows.length === 0 && drilldownRows.length === 0) {
+        // Nothing matched: offer to hand the query to the default browser
+        // instead of returning an empty list the user has to Esc out of.
+        var searchUrl = "https://www.google.com/search?q=" + encodeURIComponent(query)
+        rows.push({
+          itemId: "search-web." + query,
+          disabled: false,
+          kind: "action",
+          icon: "",
+          iconFont: "",
+          appIcon: "",
+          appId: "",
+          label: "Search for \"" + query + "\" in browser",
+          target: "",
+          detail: "Open in default browser",
+          path: "web search",
+          childCount: 0,
+          action: "omarchy-launch-browser " + Util.shellQuote(searchUrl),
+          provider: "",
+          score: -1,
+          section: ""
+        })
+      } else {
+        var searchSort = function(a, b) {
+          if (a.score !== b.score) return a.score - b.score
+          return a.path.localeCompare(b.path)
+        }
 
-      currentRows.sort(searchSort)
-      drilldownRows.sort(searchSort)
-      root.searchDivider = currentRows.length > 0 && drilldownRows.length > 0
-      if (root.searchDivider) {
-        for (var d = 0; d < drilldownRows.length; d++) drilldownRows[d].section = "drilldown"
+        currentRows.sort(searchSort)
+        drilldownRows.sort(searchSort)
+        root.searchDivider = currentRows.length > 0 && drilldownRows.length > 0
+        if (root.searchDivider) {
+          for (var d = 0; d < drilldownRows.length; d++) drilldownRows[d].section = "drilldown"
+        }
+        rows = currentRows.concat(drilldownRows)
       }
-      rows = currentRows.concat(drilldownRows)
     } else {
       for (var j = 0; j < root.itemOrder.length; j++) {
         var child = root.item(root.itemOrder[j])

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -96,6 +96,10 @@ assert(
   /function matchesQuery\(entry, query\) \{\s*\n\s*return MenuModel\.matchesQuery\(entry, query, root\.isVisible\(entry\) && !root\.isDisabled\(entry\)\)/.test(menuQml),
   'menu search skips disabled rows, which belong to the submenu they sit in rather than a list of what you can do'
 )
+assert(
+  /if \(currentRows\.length === 0 && drilldownRows\.length === 0\) \{[\s\S]*?var searchUrl = "https:\/\/www\.google\.com\/search\?q=" \+ encodeURIComponent\(query\)[\s\S]*?rows\.push\(\{\s*\n\s*itemId: "search-web\." \+ query,[\s\S]*?kind: "action",[\s\S]*?action: "omarchy-launch-browser " \+ Util\.shellQuote\(searchUrl\),/.test(menuQml),
+  'menu offers to search the default browser when a query matches nothing'
+)
 
 const entry = merged.items['style.theme']
 assert(menu.matchesQuery(entry, 'theme', true), 'menu matches labels and aliases')


### PR DESCRIPTION
When a search in the app menu matches nothing, show a fallback row that opens the query in the user's default browser via Google, instead of presenting an empty list the user has to Esc out of.

The fallback row:
- Shows a search icon and "Search for \"query\" in browser"
- Activates via `omarchy-launch-browser`, which uses the XDG default browser
- Query is URL-encoded and shell-quoted for safe handling of special characters

```
# To test:
1. Open the menu
2. Type a query with no matches (e.g. "zzzzz")
3. Confirm the fallback row appears
4. Press Enter — Google opens in your default browser
```