### PR TITLE
Add qt6-imageformats so Quickshell can render WebP wallpapers

### DIFF
--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -37,6 +37,7 @@ pipewire
 pipewire-alsa
 pipewire-jack
 pipewire-pulse
+qt6-imageformats
 qt6-wayland
 snapper
 sof-firmware


### PR DESCRIPTION
Some themes (e.g. aetheria) ship their 4K wallpapers as WebP to cut theme cache size — less local disk and less RAM while the background is displayed. Qt6 on Arch only decodes gif/ico/jpeg out of the box; the WebP decoder (libqwebp.so) ships in the qt6-imageformats package, which is not currently installed. Without it, the Omarchy shell's background plugin fails to load WebP wallpapers and no background is shown.