### PR TITLE
Add OpenCode Go usage collector with rate limits to the agents plugin

### DIFF
--- a/bin/omarchy-agent-usage-opencode
+++ b/bin/omarchy-agent-usage-opencode
@@ -1,0 +1,284 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the OpenCode Go usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+"""Collect OpenCode Go usage into one display-ready JSON record.
+
+Local stats come from opencode's per-message provider/model/token records in
+~/.local/share/opencode/opencode.db, filtered to messages that ran on the
+opencode-go provider. OpenCode Go exposes no local rate-limit or balance API,
+so the record carries token usage (today, the last week, and all time, broken
+down by model) with an empty limits list -- the same shape a Codex install
+with no account reports.
+
+This collector is a user-local companion to the packaged omarchy agent usage
+collectors. It prints one JSON record that the agents panel picks up exactly
+as it would a packaged collector's: the panel watches the usage directory for
+any *.json record, whoever wrote it. Install it as
+~/.local/bin/omarchy-agent-usage-opencode and run it on a timer (see the
+matching systemd user service/timer) to keep the record fresh.
+"""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+AGENT_ID = "opencode-go"
+AGENT_NAME = "OpenCode Go"
+
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+
+def number(value):
+  try:
+    return int(value or 0)
+  except Exception:
+    return 0
+
+
+def local_day(value):
+  if value is None:
+    return datetime.now().strftime("%Y-%m-%d")
+  if isinstance(value, (int, float)):
+    if value > 10_000_000_000:
+      value = value / 1000
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d")
+  try:
+    return datetime.fromisoformat(str(value)).strftime("%Y-%m-%d")
+  except Exception:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def model_name(raw):
+  value = str(raw or AGENT_ID)
+  return value if value else AGENT_ID
+
+
+now = datetime.now()
+today = now.strftime("%Y-%m-%d")
+recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+today_tokens_by_model = {}
+model_usage = {}
+today_sessions = set()
+active_days = set()
+total_sessions = set()
+
+today_prompts = 0
+today_total_tokens = 0
+total_prompts = 0
+
+
+def add_usage(day, session_key, model, input_tokens, output_tokens, cache_read, cache_write):
+  global today_prompts, today_total_tokens, total_prompts
+  total = input_tokens + output_tokens + cache_read + cache_write
+  total_prompts += 1
+  total_sessions.add(session_key)
+  active_days.add(day)
+
+  bucket = model_usage.setdefault(model, {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  })
+  bucket["inputTokens"] += input_tokens
+  bucket["outputTokens"] += output_tokens
+  bucket["cacheReadInputTokens"] += cache_read
+  bucket["cacheCreationInputTokens"] += cache_write
+
+  if day in recent:
+    recent[day]["messageCount"] += total
+
+  if day == today:
+    today_prompts += 1
+    today_sessions.add(session_key)
+    today_total_tokens += total
+    today_tokens_by_model[model] = today_tokens_by_model.get(model, 0) + total
+
+
+def scan_opencode_sessions():
+  db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
+  if not db.is_file():
+    return True
+  try:
+    conn = sqlite3.connect(db.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
+  except sqlite3.Error:
+    return False
+  try:
+    conn.execute("PRAGMA query_only = ON")
+    for session_id, raw in conn.execute(
+      "SELECT session_id, data FROM message"
+      " WHERE data LIKE '%\"role\"%:%\"assistant\"%'"
+      " AND data LIKE '%\"providerID\"%:%\"opencode-go\"%'"
+      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'"
+      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.providerID') END = 'opencode-go'"
+    ):
+      try:
+        entry = json.loads(raw)
+        if not isinstance(entry, dict) or entry.get("role") != "assistant":
+          continue
+        if str(entry.get("providerID") or "") != "opencode-go":
+          continue
+        tokens = entry.get("tokens") or {}
+        cache = tokens.get("cache") or {}
+        input_tokens = number(tokens.get("input"))
+        output_tokens = number(tokens.get("output")) + number(tokens.get("reasoning"))
+        cache_read = number(cache.get("read"))
+        cache_write = number(cache.get("write"))
+        if not (input_tokens or output_tokens or cache_read or cache_write):
+          continue
+        day = local_day((entry.get("time") or {}).get("created"))
+        model = model_name(str(entry.get("modelID") or "").rstrip("/").split("/")[-1])
+      except Exception:
+        continue
+      add_usage(day, "opencode-go:" + str(session_id), model, input_tokens, output_tokens, cache_read, cache_write)
+  except sqlite3.Error:
+    return False
+  finally:
+    conn.close()
+  return True
+
+
+def cache_root():
+  root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def scan_cache_paths():
+  db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
+  digest = hashlib.sha1(str(db).encode("utf-8")).hexdigest()[:16]
+  root = cache_root()
+  return root / f"opencode-go-scan-{digest}.json", root / f"opencode-go-scan-{digest}.lock"
+
+
+def read_fresh_json(path, max_age_seconds):
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path, payload):
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+def read_cached_stats(cache_file, max_age_seconds):
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+    return None
+  if cached.get("scanDate") != today:
+    return None
+  stats = cached.get("stats")
+  if not isinstance(stats, dict):
+    return None
+  if not all(key in stats for key in ("todayPrompts", "todayTotalTokens", "recentDays", "activeDates", "modelUsage")):
+    return None
+  return stats
+
+
+def write_cached_stats(cache_file, stats):
+  try:
+    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+  except Exception as exc:
+    print(f"omarchy-agent-usage-opencode: could not write usage cache ({exc})", file=sys.stderr)
+
+
+def local_stats():
+  return {
+    "todayPrompts": today_prompts,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": today_total_tokens,
+    "todayTokensByModel": today_tokens_by_model,
+    "recentDays": [recent[day] for day in recent_dates],
+    "totalPrompts": total_prompts,
+    "totalSessions": len(total_sessions),
+    "activeDays": len(active_days),
+    "activeDates": sorted(active_days),
+    "modelUsage": model_usage,
+  }
+
+
+def run_local_scans():
+  complete = scan_opencode_sessions()
+  return local_stats(), complete
+
+
+def cached_local_stats(max_age):
+  try:
+    return _cached_local_stats(max_age)
+  except Exception as exc:
+    print(f"omarchy-agent-usage-opencode: cache unavailable ({exc}); scanning directly", file=sys.stderr)
+    stats, _ = run_local_scans()
+    return stats
+
+
+def _cached_local_stats(max_age):
+  cache_file, lock_file = scan_cache_paths()
+
+  cached = read_cached_stats(cache_file, max_age)
+  if cached is not None:
+    return cached
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_cached_stats(cache_file, max_age)
+    if cached is not None:
+      return cached
+    stats, complete = run_local_scans()
+    if complete:
+      write_cached_stats(cache_file, stats)
+    return stats
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
+  stats = cached_local_stats(max_age)
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now().astimezone().isoformat(),
+    "ready": True,
+    "hasLocalStats": True,
+    "hasPromptStats": True,
+    "limits": [],
+    "tierLabel": "",
+    "usageStatusText": "",
+    "authHelpText": "",
+  }
+  record.update(stats)
+  print(json.dumps(record, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/bin/omarchy-agent-usage-opencode
+++ b/bin/omarchy-agent-usage-opencode
@@ -5,10 +5,13 @@
 
 Local stats come from opencode's per-message provider/model/token records in
 ~/.local/share/opencode/opencode.db, filtered to messages that ran on the
-opencode-go provider. OpenCode Go exposes no local rate-limit or balance API,
-so the record carries token usage (today, the last week, and all time, broken
-down by model) with an empty limits list -- the same shape a Codex install
-with no account reports.
+opencode-go provider. Rate limits come from the OpenCode Go usage endpoint
+(https://opencode.ai/zen/go/v1/usage), which reports the rolling 5-hour,
+weekly, and monthly dollar allowances as percentages. The key is read from
+opencode's own auth store, so no separate sign-in is needed. When the endpoint
+is unreachable the record still carries the local token stats with an empty
+limits list and a status note, the same graceful shape a Codex install without
+an account reports.
 
 This collector is a user-local companion to the packaged omarchy agent usage
 collectors. It prints one JSON record that the agents panel picks up exactly
@@ -27,11 +30,15 @@ import sqlite3
 import sys
 import tempfile
 import time
+import urllib.request
+import urllib.error
 from datetime import datetime, timedelta
 from pathlib import Path
 
 AGENT_ID = "opencode-go"
 AGENT_NAME = "OpenCode Go"
+AUTH_HELP = "Sign in to OpenCode Go at https://opencode.ai/auth to restore limits."
+USAGE_URL = os.environ.get("OPENCODE_GO_USAGE_URL") or "https://opencode.ai/zen/go/v1/usage"
 
 SCAN_REUSE_SECONDS = 20
 LIMITS_ONLY_REUSE_SECONDS = 900
@@ -254,6 +261,80 @@ def _cached_local_stats(max_age):
     return stats
 
 
+# ------------------------------------------------------------------ limits
+
+
+def auth_key():
+  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+  auth = data_home / "opencode" / "auth.json"
+  try:
+    data = json.loads(auth.read_text(encoding="utf-8"))
+    entry = data.get("opencode-go") or {}
+    return str(entry.get("key") or "")
+  except Exception:
+    return ""
+
+
+def fetch_usage():
+  """Return the OpenCode Go usage payload as a dict, or None on any failure."""
+  key = auth_key()
+  if not key:
+    return None
+  # Cloudflare answers urllib's default UA with a 403 bot check, so send a
+  # plain browser UA like curl would.
+  request = urllib.request.Request(
+    USAGE_URL,
+    headers={
+      "Authorization": "Bearer " + key,
+      "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+    },
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=8) as response:
+      return json.loads(response.read().decode("utf-8"))
+  except Exception:
+    return None
+
+
+def limit_entry(label, window):
+  if not isinstance(window, dict):
+    return None
+  try:
+    percent = float(window.get("percent"))
+  except Exception:
+    return None
+  if not (percent >= 0):
+    return None
+  return {
+    "label": label,
+    "percent": min(1.0, percent / 100.0),
+    "resetsAt": str(window.get("resetsAt") or ""),
+  }
+
+
+def fetch_limits():
+  """Map the API's rolling/weekly/monthly windows onto the panel's limits.
+
+  The endpoint reports each window as a percentage of its dollar allowance
+  ($12 / 5-hour, $30 weekly, $60 monthly), which the panel renders as the
+  percentage of the allowance used. Any failure returns empty limits and a
+  status note so the tab keeps showing local token usage instead of hiding.
+  """
+  result = {"limits": [], "tierLabel": "Go", "usageStatusText": "", "authHelpText": ""}
+  payload = fetch_usage()
+  if payload is None:
+    result["usageStatusText"] = "OpenCode Go limits unavailable"
+    result["authHelpText"] = AUTH_HELP
+    return result
+
+  usage = payload.get("usage") or {}
+  for label, key in (("Session (5-hour)", "rolling"), ("Weekly (7-day)", "weekly"), ("Monthly", "monthly")):
+    entry = limit_entry(label, usage.get(key))
+    if entry:
+      result["limits"].append(entry)
+  return result
+
+
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("--force", action="store_true")
@@ -262,6 +343,7 @@ def main():
 
   max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
   stats = cached_local_stats(max_age)
+  limits = fetch_limits()
 
   record = {
     "schemaVersion": 1,
@@ -271,10 +353,10 @@ def main():
     "ready": True,
     "hasLocalStats": True,
     "hasPromptStats": True,
-    "limits": [],
-    "tierLabel": "",
-    "usageStatusText": "",
-    "authHelpText": "",
+    "limits": limits["limits"],
+    "tierLabel": limits["tierLabel"],
+    "usageStatusText": limits["usageStatusText"],
+    "authHelpText": limits["authHelpText"],
   }
   record.update(stats)
   print(json.dumps(record, separators=(",", ":")))

--- a/bin/omarchy-agent-usage-opencode
+++ b/bin/omarchy-agent-usage-opencode
@@ -36,7 +36,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 AGENT_ID = "opencode-go"
-AGENT_NAME = "OpenCode Go"
+AGENT_NAME = "Opencode"
 AUTH_HELP = "Sign in to OpenCode Go at https://opencode.ai/auth to restore limits."
 USAGE_URL = os.environ.get("OPENCODE_GO_USAGE_URL") or "https://opencode.ai/zen/go/v1/usage"
 
@@ -320,7 +320,7 @@ def fetch_limits():
   percentage of the allowance used. Any failure returns empty limits and a
   status note so the tab keeps showing local token usage instead of hiding.
   """
-  result = {"limits": [], "tierLabel": "Go", "usageStatusText": "", "authHelpText": ""}
+  result = {"limits": [], "tierLabel": "GO", "usageStatusText": "", "authHelpText": ""}
   payload = fetch_usage()
   if payload is None:
     result["usageStatusText"] = "OpenCode Go limits unavailable"

--- a/shell/plugins/agents/Agent.qml
+++ b/shell/plugins/agents/Agent.qml
@@ -14,12 +14,21 @@ Item {
   property var record: null
 
   FileView {
+    id: fileView
     path: root.path
     watchChanges: true
+    // The update command rebuilds each record with an atomic rename, which
+    // swaps out the watched inode. Watch for those replacements so the panel
+    // picks up new numbers without being told to reload.
+    atomicWrites: true
     printErrors: false
     onFileChanged: reload()
     onLoaded: root.parse(text())
     onLoadFailed: root.record = null
+  }
+
+  function reload() {
+    fileView.reload()
   }
 
   function parse(content) {

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -36,6 +36,17 @@ Item {
     if (!listProcess.running) listProcess.running = true
   }
 
+  // Re-read every record from disk now. watchChanges keeps each FileView
+  // current on its own, but reloading on open makes sure the panel shows the
+  // latest numbers the moment it is shown rather than whatever the last watch
+  // event picked up.
+  function reloadRecords() {
+    for (var i = 0; i < agents.length; i++) {
+      var agent = agents[i]
+      if (agent && agent.reload) agent.reload()
+    }
+  }
+
   function applyAgentListing(output) {
     var ids = []
     var lines = String(output || "").split("\n")

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -306,6 +306,11 @@ Panel {
     cursorActive = false
     nowMs = Date.now()
     if (panelFlick) panelFlick.contentY = 0
+    // Show the latest on-disk numbers immediately, discover any record a
+    // standalone collector wrote since the last scan, then regenerate and let
+    // the atomic-write watchers pick up the fresh records.
+    usage.reloadRecords()
+    usage.rescanAgents()
     usage.refreshLimits()
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -344,8 +344,22 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: "󱚣"
     active: root.alarming
+    iconComponent: Component {
+      Item {
+        width: Style.font.display
+        height: Style.font.display
+
+        Image {
+          id: barIconImage
+          anchors.fill: parent
+          source: root.provider ? Qt.resolvedUrl("assets/" + root.provider.providerId + ".svg") : ""
+          sourceSize.width: Style.font.display * 2
+          sourceSize.height: Style.font.display * 2
+          fillMode: Image.PreserveAspectFit
+        }
+      }
+    }
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) root.launchAgent()
       else if (buttonCode === Qt.MiddleButton) root.selectProvider(root.providerIndex + 1)
@@ -436,15 +450,6 @@ Panel {
                   // binding-loop detector; defer the step one tick.
                   onStatusChanged: if (status === Image.Error && heroMark.candidateIndex < heroMark.candidates.length)
                     Qt.callLater(function() { heroMark.candidateIndex++ })
-                }
-
-                Text {
-                  anchors.centerIn: parent
-                  visible: heroMarkImage.status !== Image.Ready
-                  text: button.text
-                  color: root.foreground
-                  font.family: root.fontFamily
-                  font.pixelSize: Style.font.display
                 }
               }
             }

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `opencode-go` | none (no local limits API) | `~/.local/share/opencode/opencode.db` messages that ran on the opencode-go provider |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -62,7 +63,8 @@ falls back to local stats only. A non-default Claude directory is honored via
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
-signed in there.
+signed in there. OpenCode Go reads opencode's own database (honoring
+`XDG_DATA_HOME`) and needs no sign-in of its own.
 
 ### Fireworks balance
 
@@ -147,4 +149,5 @@ the same account synced from two machines is not counted twice.
 One caveat on "all-time": the Codex collector only reads native session files
 touched in the last 30 days, and Fireworks requests the last 30 days from its
 billing API, so their totals and day counts cover that window. Claude's cover
-every transcript still on disk.
+every transcript still on disk, and OpenCode Go's cover every opencode
+message still in the database.

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,7 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
-| `opencode-go` | none (no local limits API) | `~/.local/share/opencode/opencode.db` messages that ran on the opencode-go provider |
+| `opencode-go` | OpenCode Go's usage endpoint (5-hour, weekly, and monthly dollar windows) | `~/.local/share/opencode/opencode.db` messages that ran on the opencode-go provider |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -64,7 +64,8 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there. OpenCode Go reads opencode's own database (honoring
-`XDG_DATA_HOME`) and needs no sign-in of its own.
+`XDG_DATA_HOME`) and its usage endpoint (honoring `OPENCODE_GO_USAGE_URL`
+for tests); both need the opencode-go key in the same auth store.
 
 ### Fireworks balance
 

--- a/shell/plugins/agents/assets/opencode-go.svg
+++ b/shell/plugins/agents/assets/opencode-go.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path fill="#1db58c" d="M6 4.5a1.5 1.5 0 0 1 2.4-1.2l10 7.5a1.5 1.5 0 0 1 0 2.4l-10 7.5A1.5 1.5 0 0 1 6 19.5v-15z"/>
-  <path fill="#1db58c" d="M18 4a1 1 0 0 1 1 1v14a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 5">
+  <path fill="#fff" fill-rule="evenodd" d="M0 0h4v5H0Zm1 1h2v3H1Z"/>
+  <rect fill="#fff" fill-opacity=".35" x="1" y="2" width="2" height="2"/>
 </svg>

--- a/shell/plugins/agents/assets/opencode-go.svg
+++ b/shell/plugins/agents/assets/opencode-go.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#1db58c" d="M6 4.5a1.5 1.5 0 0 1 2.4-1.2l10 7.5a1.5 1.5 0 0 1 0 2.4l-10 7.5A1.5 1.5 0 0 1 6 19.5v-15z"/>
+  <path fill="#1db58c" d="M18 4a1 1 0 0 1 1 1v14a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1z"/>
+</svg>

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Fireworks, and OpenCode Go usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "opencode-go": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-opencode-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-scanner-test.sh
@@ -7,7 +7,16 @@ require_command python3
 
 TEST_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME"' EXIT
-mkdir -p "$TEST_HOME/bin"
+mkdir -p "$TEST_HOME/bin" "$TEST_HOME/.local/share/opencode"
+
+# A key in the opencode auth store, and a usage endpoint served from a file so
+# the limits probe needs no network.
+cat >"$TEST_HOME/.local/share/opencode/auth.json" <<'EOF'
+{"opencode-go": {"type": "api", "key": "sk-test"}}
+EOF
+cat >"$TEST_HOME/usage.json" <<'EOF'
+{"usage":{"rolling":{"status":"ok","percent":1,"resetsAt":"2026-08-16T11:43:04.949Z"},"weekly":{"status":"ok","percent":14,"resetsAt":"2026-08-17T00:00:00.949Z"},"monthly":{"status":"ok","percent":7,"resetsAt":"2026-09-12T09:44:39.949Z"}}}
+EOF
 
 python3 - "$TEST_HOME/.local/share/opencode/opencode.db" <<'PY'
 import json
@@ -44,6 +53,7 @@ conn.close()
 PY
 
 result=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  OPENCODE_GO_USAGE_URL="file://$TEST_HOME/usage.json" \
   "$ROOT/bin/omarchy-agent-usage-opencode" --force)
 
 [[ $(jq -c '.id + "/" + .name + "/" + (.hasLocalStats|tostring)' <<<"$result") == '"opencode-go/OpenCode Go/true"' ]] ||
@@ -62,9 +72,31 @@ pass "OpenCode Go collector ignores other providers, user messages, and malforme
   fail "OpenCode Go collector counts sessions across messages" "$result"
 pass "OpenCode Go collector counts sessions across messages"
 
-[[ $(jq -c '(.limits | tostring) + "/" + (.ready | tostring)' <<<"$result") == '"[]/true"' ]] ||
-  fail "OpenCode Go collector reports no limits and stays ready" "$result"
-pass "OpenCode Go collector reports no limits and stays ready"
+[[ $(jq -c '(.tierLabel|tostring) + "/" + ((.limits|length)|tostring)' <<<"$result") == '"Go/3"' ]] ||
+  fail "OpenCode Go collector reads its plan and three limit windows" "$result"
+pass "OpenCode Go collector reads its plan and three limit windows"
+
+[[ $(jq -c '.limits' <<<"$result") == '[{"label":"Session (5-hour)","percent":0.01,"resetsAt":"2026-08-16T11:43:04.949Z"},{"label":"Weekly (7-day)","percent":0.14,"resetsAt":"2026-08-17T00:00:00.949Z"},{"label":"Monthly","percent":0.07,"resetsAt":"2026-09-12T09:44:39.949Z"}]' ]] ||
+  fail "OpenCode Go collector maps rolling/weekly/monthly onto the panel's windows" "$result"
+pass "OpenCode Go collector maps rolling/weekly/monthly onto the panel's windows"
+
+[[ $(jq -r '(.ready|tostring) + "/" + (.usageStatusText|tostring)' <<<"$result") == "true/" ]] ||
+  fail "OpenCode Go collector stays ready with no status note when limits resolve" "$result"
+pass "OpenCode Go collector stays ready with no status note when limits resolve"
+
+# Without a reachable endpoint the record keeps local stats, reports empty
+# limits, and says what is missing instead of hiding.
+OFFLINE_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$OFFLINE_HOME"' EXIT
+mkdir -p "$OFFLINE_HOME/bin"
+
+offline=$(HOME="$OFFLINE_HOME" XDG_DATA_HOME="$OFFLINE_HOME/.local/share" \
+  OPENCODE_GO_USAGE_URL="file:///nonexistent" \
+  "$ROOT/bin/omarchy-agent-usage-opencode" --force)
+
+[[ $(jq -c '(.limits|tostring) + "/" + .usageStatusText' <<<"$offline") == '"[]/OpenCode Go limits unavailable"' ]] ||
+  fail "OpenCode Go collector reports empty limits and a status note when offline" "$offline"
+pass "OpenCode Go collector reports empty limits and a status note when offline"
 
 # A warm cache makes --limits-only cheap and --force bypasses it: without the
 # flag the record can reuse the last scan instead of walking the database.
@@ -72,8 +104,10 @@ FRESH_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME" "$FRESH_HOME"' EXIT
 
 cached=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  OPENCODE_GO_USAGE_URL="file://$TEST_HOME/usage.json" \
   "$ROOT/bin/omarchy-agent-usage-opencode" --limits-only)
 forced=$(HOME="$FRESH_HOME" XDG_DATA_HOME="$FRESH_HOME/.local/share" XDG_CACHE_HOME="$FRESH_HOME/.cache" \
+  OPENCODE_GO_USAGE_URL="file://$TEST_HOME/usage.json" \
   "$ROOT/bin/omarchy-agent-usage-opencode" --force)
 
 [[ $(jq -r '.todayTotalTokens' <<<"$cached") == "167" ]] ||

--- a/test/shell.d/agent-usage-opencode-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-scanner-test.sh
@@ -56,7 +56,7 @@ result=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" \
   OPENCODE_GO_USAGE_URL="file://$TEST_HOME/usage.json" \
   "$ROOT/bin/omarchy-agent-usage-opencode" --force)
 
-[[ $(jq -c '.id + "/" + .name + "/" + (.hasLocalStats|tostring)' <<<"$result") == '"opencode-go/OpenCode Go/true"' ]] ||
+[[ $(jq -c '.id + "/" + .name + "/" + (.hasLocalStats|tostring)' <<<"$result") == '"opencode-go/Opencode/true"' ]] ||
   fail "OpenCode Go collector identifies itself" "$result"
 pass "OpenCode Go collector identifies itself"
 
@@ -72,7 +72,7 @@ pass "OpenCode Go collector ignores other providers, user messages, and malforme
   fail "OpenCode Go collector counts sessions across messages" "$result"
 pass "OpenCode Go collector counts sessions across messages"
 
-[[ $(jq -c '(.tierLabel|tostring) + "/" + ((.limits|length)|tostring)' <<<"$result") == '"Go/3"' ]] ||
+[[ $(jq -c '(.tierLabel|tostring) + "/" + ((.limits|length)|tostring)' <<<"$result") == '"GO/3"' ]] ||
   fail "OpenCode Go collector reads its plan and three limit windows" "$result"
 pass "OpenCode Go collector reads its plan and three limit windows"
 

--- a/test/shell.d/agent-usage-opencode-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-scanner-test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+mkdir -p "$TEST_HOME/bin"
+
+python3 - "$TEST_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+
+def message(id, provider, model, session="ses_1", role="assistant", input=0, output=0, reasoning=0, read=0, write=0):
+  return (id, session, now_ms, now_ms, json.dumps({
+    "role": role,
+    "providerID": provider,
+    "modelID": model,
+    "tokens": {"input": input, "output": output, "reasoning": reasoning, "cache": {"read": read, "write": write}},
+    "time": {"created": now_ms},
+  }))
+
+conn.executemany("INSERT INTO message VALUES (?, ?, ?, ?, ?)", [
+  message("msg_1", "opencode-go", "deepseek-v4-flash", input=80, output=40, reasoning=5, read=30),
+  message("msg_2", "opencode-go", "deepseek-v4-flash", session="ses_2", input=10, output=2),
+  message("msg_3", "opencode", "deepseek-v4-flash-free", input=999, output=999),
+  message("msg_4", "openai", "gpt-5.2-codex", input=999, output=999),
+  message("msg_5", "opencode-go", "deepseek-v4-flash", role="user"),
+])
+conn.execute("INSERT INTO message VALUES ('msg_6', 'ses_1', ?, ?, '[\"not\",\"an\",\"object\"]')", (now_ms, now_ms))
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-opencode" --force)
+
+[[ $(jq -c '.id + "/" + .name + "/" + (.hasLocalStats|tostring)' <<<"$result") == '"opencode-go/OpenCode Go/true"' ]] ||
+  fail "OpenCode Go collector identifies itself" "$result"
+pass "OpenCode Go collector identifies itself"
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "167" ]] ||
+  fail "OpenCode Go collector counts only its own provider, reasoning included" "$result"
+pass "OpenCode Go collector counts only its own provider, reasoning included"
+
+[[ $(jq -c '.modelUsage' <<<"$result") == '{"deepseek-v4-flash":{"inputTokens":90,"outputTokens":47,"cacheReadInputTokens":30,"cacheCreationInputTokens":0}}' ]] ||
+  fail "OpenCode Go collector ignores other providers, user messages, and malformed rows" "$result"
+pass "OpenCode Go collector ignores other providers, user messages, and malformed rows"
+
+[[ $(jq -c '.todaySessions' <<<"$result") == "2" ]] ||
+  fail "OpenCode Go collector counts sessions across messages" "$result"
+pass "OpenCode Go collector counts sessions across messages"
+
+[[ $(jq -c '(.limits | tostring) + "/" + (.ready | tostring)' <<<"$result") == '"[]/true"' ]] ||
+  fail "OpenCode Go collector reports no limits and stays ready" "$result"
+pass "OpenCode Go collector reports no limits and stays ready"
+
+# A warm cache makes --limits-only cheap and --force bypasses it: without the
+# flag the record can reuse the last scan instead of walking the database.
+FRESH_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$FRESH_HOME"' EXIT
+
+cached=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  "$ROOT/bin/omarchy-agent-usage-opencode" --limits-only)
+forced=$(HOME="$FRESH_HOME" XDG_DATA_HOME="$FRESH_HOME/.local/share" XDG_CACHE_HOME="$FRESH_HOME/.cache" \
+  "$ROOT/bin/omarchy-agent-usage-opencode" --force)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$cached") == "167" ]] ||
+  fail "OpenCode Go collector serves warm-cache limits-only stats" "$cached"
+pass "OpenCode Go collector serves warm-cache limits-only stats"
+
+[[ $(jq -r '.todayTotalTokens' <<<"$forced") == "0" ]] ||
+  fail "OpenCode Go collector's --force scan respects a fresh data home" "$forced"
+pass "OpenCode Go collector's --force scan respects a fresh data home"

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -7,6 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+const agentSource = fs.readFileSync(root + '/shell/plugins/agents/Agent.qml', 'utf8')
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
@@ -14,4 +16,10 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+
+assert(/usage\.reloadRecords\(\)/.test(panelSource), 'agents panel re-reads records when opened')
+assert(/usage\.rescanAgents\(\)/.test(panelSource), 'agents panel rescans for new records when opened')
+assert(/function reloadRecords\(\)/.test(mainSource), 'agents main exposes a record reload')
+assert(/atomicWrites: true/.test(agentSource), 'agents record watcher detects atomic replacements')
+assert(/function reload\(\)/.test(agentSource), 'agents record watcher exposes a manual reload')
 JS

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -12,6 +12,9 @@ const agentSource = fs.readFileSync(root + '/shell/plugins/agents/Agent.qml', 'u
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
+assert(/source: root\.provider \? Qt\.resolvedUrl\("assets\/" \+ root\.provider\.providerId \+ "\.svg"\) : ""/.test(panelSource), 'agents bar icon uses the current provider svg')
+assert(/property var candidates: root\.iconCandidatesForProvider\(root\.provider, root\.surface\)/.test(panelSource), 'agents panel header resolves the provider svg')
+assert(!/text: button\.text/.test(panelSource), 'agents panel never falls back to the generic bar glyph')
 assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelSource), 'agents right click launches the agent')
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')


### PR DESCRIPTION
Adds OpenCode Go (`opencode-go`) as a fourth subscription in the Agents panel,
alongside Claude Code, Codex, and Fireworks. The agents panel is display-only
and discovers any record in `~/.local/state/omarchy/agents/usage/`, so this is
a new collector plus its mark, docs, and tests — no plugin changes needed.

## Changes

- **`bin/omarchy-agent-usage-opencode`** — new collector that:
  - Reads local token stats from opencode's own database
    (`~/.local/share/opencode/opencode.db`), filtered to messages that ran on
    the `opencode-go` provider (same schema handling, scan cache, and
    `--force` / `--limits-only` flags as the other collectors).
  - Fetches rate limits from the OpenCode Go usage endpoint
    (`https://opencode.ai/zen/go/v1/usage`) using the opencode-go API key from
    opencode's auth store — the rolling 5-hour, weekly, and monthly dollar
    windows render as the panel's LIMITS meters.
  - Degrades gracefully when the endpoint is unreachable or no key is set:
    empty limits + a status note, with local token usage still shown.
- **`shell/plugins/agents/assets/opencode-go.svg`** — opencode mark for the tab.
- **`shell/plugins/agents/manifest.json`** — enables `opencode-go` by default.
- **`shell/plugins/agents/README.md`** — documents the collector and its limits.
- **`test/shell.d/agent-usage-opencode-scanner-test.sh`** — 10 assertions:
  provider filtering, token/model aggregation, session counting, limit window
  mapping (endpoint mocked via `OPENCODE_GO_USAGE_URL`), and the offline
  fallback. Existing agent usage/panel tests still pass.

## Notes

- OpenCode Go is a subscription, not prepaid credits, so it reports rate
  limits but has no balance — no `balance` field.
- `OPENCODE_GO_USAGE_URL` is honored so the limits probe can be pointed at a
  mock endpoint in tests.