### PR TITLE
Fix polkit password dots rendering as tiny specks

### DIFF
--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -317,7 +317,9 @@ Item {
             font.family: root.fontFamily
             font.pixelSize: Style.font.iconLarge
             echoMode: root.responseVisible ? TextInput.Normal : TextInput.Password
-            passwordCharacter: "\u2022"
+            // U+25CF, not U+2022: in monospace Nerd Fonts the bullet renders at
+            // ~24% of em height, so at this field's 18px the dots read as specks.
+            passwordCharacter: "\u25CF"
             color: root.errorFlash ? Color.polkit.textError : root.foreground
             cursorVisible: activeFocus && !root.submitted && !root.errorFlash
             readOnly: root.submitted || root.errorFlash


### PR DESCRIPTION
The polkit authentication dialog masked passwords with the bullet character
U+2022 (`•`). In monospace Nerd Fonts that glyph's filled area is only ~24%
of em height, so at the field's 18px font (`Style.font.iconLarge`) each dot
draws as a ~4px speck — far smaller than the "Enter password" placeholder and
plaintext beside it.

The lock screen (`shell/plugins/lock/LockView.qml`) and Qt's platform default
(`QStyleHints::passwordMaskCharacter()`) both use the solid circle U+25CF
(`●`), which renders at ~62% of em height and reads as a proper mask dot.

**Change:** switch `passwordCharacter` from `"\u2022"` to `"\u25CF"`, with a
comment explaining the glyph-metrics rationale so it isn't regressed.

**Verified:**
- Glyph measurements in the default font (JetBrainsMono Nerd Font): `●` bbox
  620/1000 em, `•` bbox 240/1000 em.
- `bash test/shell.d/polkit-test.sh` — all 8 assertions pass.
- Change runs live on the reporter's machine via a cloned `agx.polkit` plugin.

Steps to reproduce: trigger any polkit prompt (e.g. a GUI app requiring root)
and type a password; the mask dots appear as ~4px specks at 18px text.