### PR TITLE
Add Hermes HUD window rules

### DIFF
--- a/default/hypr/apps/hermes.lua
+++ b/default/hypr/apps/hermes.lua
@@ -1,4 +1,4 @@
--- Hermes Desktop's transparent, frameless HUD manages its own geometry.
+-- Hermes Desktop's frameless HUD manages its own geometry.
 o.window({ class = "^Hermes$", title = "^Hermes HUD$" }, {
   tag = "-default-opacity",
   float = true,

--- a/default/hypr/apps/hermes.lua
+++ b/default/hypr/apps/hermes.lua
@@ -1,0 +1,7 @@
+-- Hermes Desktop's transparent, frameless HUD manages its own geometry.
+o.window({ class = "^Hermes$", title = "^Hermes HUD$" }, {
+  tag = "-default-opacity",
+  float = true,
+  border_size = 0,
+  opacity = "1 1",
+})


### PR DESCRIPTION
## Summary

- add a dedicated Hyprland rule for the Hermes Desktop HUD
- keep the HUD floating and remove the compositor border
- bypass Omarchy's default window opacity so Hermes' own per-pixel transparency remains intact
- match only `Hermes HUD`, leaving the regular Hermes window unchanged

## Context

Hermes renders its HUD as a transparent, frameless Electron window. Without a dedicated rule, compositor decoration and Omarchy's default opacity can produce an outlined, muddy transparent canvas around the compact prompt.

Current Hermes releases can also restore stale or malformed persisted HUD bounds. That geometry belongs to the application and cannot be repaired safely with an Omarchy size rule: Hermes creates the HUD as non-resizable and is responsible for display-aware placement and persistence.

NousResearch/hermes-agent#87109 adds a visible **Reset layout** action, temporarily enables resizing during reset, restores a display-aware 620x320 default, and persists the repaired bounds. This Omarchy rule intentionally avoids forcing a size or position, so it remains compatible when that fix lands.

This complements #6644, which adds broader optional Hermes integration but currently has no HUD-specific window rule.

## Testing

- `luac -p default/hypr/apps/hermes.lua`
- `bash test/shell.d/hyprland-default-config-test.sh`
- `hyprctl reload` with no config errors
- visually verified on Hyprland: floating 620x320 HUD, native transparency, and no compositor border
- `./test/all` (unrelated environment/baseline failures: three packaging checks require a separate `omarchy-pkgs` checkout; `network-qr-test.sh` also fails its interface auto-detection case when run in isolation)
