### PR TITLE
Only treat lost focus as a dismissal once the screensaver has held focus

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -6,6 +6,14 @@ screensaver_in_focus() {
   hyprctl activewindow -j | jq -e '.class == "org.omarchy.screensaver"' >/dev/null 2>&1
 }
 
+# `hyprctl activewindow` only ever reports toplevels. A layer surface holding
+# keyboard focus -- an open bar panel -- leaves the previously focused terminal
+# as the active window, so a screensaver that maps behind one never becomes
+# active at all. Only a screensaver that has actually held focus can have lost
+# it, so latch that first and treat the absence of focus as a dismissal only
+# afterwards.
+was_focused=0
+
 exit_screensaver() {
   hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
   pkill -x ttfx 2>/dev/null
@@ -41,7 +49,13 @@ while true; do
     --random-effect --no-eol --no-restore-cursor &
 
   while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do
-    if read -n1 -t 1 || ! screensaver_in_focus; then
+    if screensaver_in_focus; then
+      was_focused=1
+    elif ((was_focused)); then
+      exit_screensaver
+    fi
+
+    if read -n1 -t 1; then
       exit_screensaver
     fi
   done


### PR DESCRIPTION
The screensaver's watchdog exits when `hyprctl activewindow` stops reporting the screensaver's class, which is meant to catch the user clicking away onto another window. `hyprctl activewindow` only ever reports toplevels, so it cannot see a layer surface. When a bar panel is open it holds layer-shell keyboard focus (`shell/Ui/KeyboardPanel.qml:98`) and the newly mapped screensaver never becomes the active toplevel at all -- the panel leaves the previously focused terminal sitting there as `activewindow`. `bin/omarchy-screensaver:44` then reads "never acquired focus" as "the user dismissed me" and the screensaver kills itself on the first tick of the loop, about one second after it appeared. That matches the lifetimes the reporter measured across five failures (1.046, 1.044, 1.228, 1.235, 1.235s): the 1.000s `read -n1 -t 1` timeout plus the `wait_for_terminal_resize` prefix.

The damage is not just the flash of a window. The idle service watches for the screensaver's window closing and treats it as activity: `handleScreensaverWindowClosed` cancels the idle cycle with `screensaver-dismissed` (`shell/plugins/services/idle/Service.qml:138`), and `cancelIdleCycle` stops the pending lock timer. Leaving the battery dropdown open and walking away therefore leaves the machine idle and unlocked.

This latches a flag the first time the screensaver is genuinely focused, and only counts the absence of focus as a dismissal after that. Sampling focus before the blocking read rather than after it means a normal launch latches immediately, so clicking away is still detected within the same second as before.

This deliberately fixes only half of #6917. With a panel open the `fullscreen` window rule also fails to apply and the screensaver draws as a floating 700x500 window. `default/hypr/apps/system.lua:35` registers that rule through Hyprland's own `hl.window_rule` (via the thin wrapper at `default/hypr/helpers.lua:142`) and Omarchy has no other fullscreen path, so the failure is inside the compositor and not fixable here. What is left after this change is a screensaver that stays up, keeps the lock timer armed, and locks on schedule -- but is still a small floating box on that cycle. Making it go fullscreen regardless, or closing open panels before launching, is a call for you rather than a defect to correct.

Not a duplicate of #6995, which needs a lock already in flight, launches a second screensaver into it, and ends in a ttfx `SIGABRT` with a core dump. This one needs no lock at all and leaves no core dump.

Touches the same loop as the open #6813, which keeps the `read -n1 -t 1 || ! screensaver_in_focus` condition verbatim and so does not fix this; whichever lands second will need a small rebase.

Fixes #6917
