### PR TITLE
Skip the sleep lock repair when the unit is not installed

### DIFF
--- a/migrations/1785608166.sh
+++ b/migrations/1785608166.sh
@@ -39,6 +39,17 @@ if ! error=$(systemctl --user daemon-reload 2>&1); then
   exit 1
 fi
 
+# An install where the unit never reached a systemd search path has no monitor
+# to repair, and every systemctl call below would fail on a unit the manager
+# does not know -- taking the rest of the migration queue with it.
+if ! load_state=$(systemctl --user show --property=LoadState --value omarchy-sleep-lock.service 2>&1); then
+  echo "Could not inspect omarchy-sleep-lock.service: $load_state"
+  echo "The pre-suspend lock repair will be retried by omarchy-migrate."
+  exit 1
+elif [[ $load_state == "not-found" ]]; then
+  exit 0
+fi
+
 if ! graphical_state=$(systemctl --user show --property=ActiveState --value graphical-session.target 2>&1); then
   echo "Could not inspect graphical-session.target: $graphical_state"
   echo "The pre-suspend lock repair will be retried by omarchy-migrate."

--- a/test/shell.d/sleep-lock-environment-migration-test.sh
+++ b/test/shell.d/sleep-lock-environment-migration-test.sh
@@ -32,6 +32,13 @@ case "$*" in
     fi
     printf '%s\n' "${GRAPHICAL_STATE:-inactive}"
     ;;
+  '--user show --property=LoadState --value omarchy-sleep-lock.service')
+    if [[ ${FAIL_SYSTEMCTL_ACTION:-} == "show-load-state" ]]; then
+      echo "load state lookup failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "${SLEEP_LOCK_LOAD_STATE:-loaded}"
+    ;;
   '--user show --property=ActiveState --value omarchy-sleep-lock.service')
     printf '%s\n' "${SLEEP_LOCK_STATE:-inactive}"
     ;;
@@ -160,3 +167,25 @@ deferred_call_count=$(wc -l <"$deferred_calls")
 (( deferred_call_count == 1 )) ||
   fail "sleep lock migration tries to mutate a user manager that is not running"
 pass "sleep lock migration defers safely when no user manager is running"
+
+for graphical_state in active inactive; do
+  unknown_home="$test_tmp/unknown-$graphical_state-home"
+  unknown_calls="$test_tmp/unknown-$graphical_state-calls"
+
+  run_migration "$unknown_home" "$unknown_calls" \
+    env GRAPHICAL_STATE="$graphical_state" SLEEP_LOCK_LOAD_STATE=not-found >/dev/null ||
+    fail "sleep lock migration fails on a $graphical_state session that has no such unit"
+
+  grep -Ex -- '--user (stop|restart|reset-failed) omarchy-sleep-lock.service' "$unknown_calls" >/dev/null &&
+    fail "sleep lock migration acts on a unit the $graphical_state session's manager does not know"
+  pass "sleep lock migration no-ops on a $graphical_state session that has no such unit"
+done
+
+load_failed_calls="$test_tmp/load-failed-calls"
+if run_migration "$test_tmp/load-failed-home" "$load_failed_calls" \
+  env FAIL_SYSTEMCTL_ACTION=show-load-state >"$test_tmp/load-failed-output" 2>&1; then
+  fail "sleep lock migration ignores a failed unit-load inspection"
+fi
+grep -F 'Could not inspect omarchy-sleep-lock.service' "$test_tmp/load-failed-output" >/dev/null ||
+  fail "sleep lock migration does not report a failed unit-load inspection"
+pass "sleep lock migration keeps an indeterminate unit-load repair retryable"


### PR DESCRIPTION
`migrations/1785608166.sh` drives `systemctl --user` at `omarchy-sleep-lock.service` without first asking whether the user manager knows the unit. On an install where that unit never reached a systemd search path — a pre-4 checkout that only carries it at `default/systemd/user/omarchy-sleep-lock.service` inside its own tree — `reset-failed` exits 1 and `stop` exits 5 with `Unit omarchy-sleep-lock.service not loaded`, so the migration fails in both the active branch (`migrations/1785608166.sh:49`) and the inactive one (`migrations/1785608166.sh:70`).

The damage is not contained to this migration. `omarchy-migrate` runs each migration as an unguarded command under `set -euo pipefail` (`bin/omarchy-migrate:6` and `bin/omarchy-migrate:93`), so a non-zero exit ends the whole run before the marker is written. `1785608166.sh` is 51st of the 79 shipped migrations, which leaves the 28 queued behind it pending forever, exactly as reported. `omarchy-update` then aborts on the same status before `omarchy-hook post-update` and everything after it (`bin/omarchy-update:48`).

There is nothing to repair when the unit does not exist, so this treats a `not-found` `LoadState` as a clean no-op while keeping a failed inspection retryable, matching how `migrations/1786567036.sh` and `migrations/1785424256.sh` guard systemd state. Affected machines never wrote the marker, so the corrected migration runs on their next `omarchy-migrate` and releases the queue.

This is the first of the two defects in the report. The second — that `omarchy-migrate` has no per-migration failure isolation, so any one failing migration blocks every later one — is left alone deliberately: fail-fast is the tested contract (`test/shell.d/migrate-scope-test.sh`), the earlier skip-and-continue prompt was removed on purpose in 75cb4f71, and changing it is a design call. #7019 is the same structural exposure with a different migration.

Fixes #7078
