### PR TITLE
Stop the idle service starting a cycle on top of the lock it just asked for

### DIFF
--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -25,6 +25,13 @@ Item {
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
+  // The lock plugin is a service in this same process, so its state is readable
+  // directly. The shell-out guard below cannot see a lock that is still in
+  // flight, and reports nothing at all when the IPC call fails.
+  readonly property var lockService: shell && shell.serviceFor ? shell.serviceFor("omarchy.lock") : null
+  readonly property bool lockInFlight: lockCommandPending || !!(lockService && lockService.locked)
+
+  property bool lockCommandPending: false
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
@@ -63,6 +70,11 @@ Item {
   }
 
   function launchScreensaver() {
+    if (root.lockInFlight) {
+      logEvent("screensaver-skip", "lock-in-flight")
+      return
+    }
+
     root.screensaverStartedThisCycle = true
     screensaverLaunchGraceTimer.restart()
     runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
@@ -76,12 +88,29 @@ Item {
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
-    runProcess(lockProcess, "lock", "omarchy-system-lock")
+
+    // omarchy-system-lock takes about a second to reach the lock service, and
+    // until it gets there the lock is not visible to anything. Cover that with
+    // the command itself -- bounded, so a lock that never returns cannot park
+    // idle handling for the rest of the session.
+    if (runProcess(lockProcess, "lock", "omarchy-system-lock")) {
+      root.lockCommandPending = true
+      lockCommandTimer.restart()
+    }
   }
 
   function startIdleCycle() {
     if (root.idledThisCycle) {
       logEvent("idle-cycle-already-running")
+      return
+    }
+
+    // lockSystem() clears idledThisCycle before the lock exists, so the next
+    // idle re-assertion is free to start a whole new cycle -- and with the
+    // usual screensaver <= lock configuration that cycle launches a screensaver
+    // immediately, into a session that is on its way down.
+    if (root.lockInFlight) {
+      logEvent("idle-cycle-skip", "lock-in-flight")
       return
     }
 
@@ -184,6 +213,7 @@ Item {
       stayAwakeStateLoaded: root.stayAwakeStateLoaded,
       stayAwakeStatePath: root.stayAwakeStatePath,
       idle: idleMonitor.isIdle,
+      lockInFlight: root.lockInFlight,
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
@@ -270,6 +300,16 @@ Item {
   }
 
   Timer {
+    id: lockCommandTimer
+    interval: 15000
+    repeat: false
+    onTriggered: {
+      root.lockCommandPending = false
+      root.logEvent("lock-command-timeout")
+    }
+  }
+
+  Timer {
     id: screensaverLaunchGraceTimer
     interval: 3000
     repeat: false
@@ -291,7 +331,11 @@ Item {
   }
   Process {
     id: lockProcess
-    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "lock exitCode=" + exitCode + " status=" + exitStatus) }
+    onExited: function(exitCode, exitStatus) {
+      root.lockCommandPending = false
+      lockCommandTimer.stop()
+      root.logEvent("process-exit", "lock exitCode=" + exitCode + " status=" + exitStatus)
+    }
   }
   Process {
     id: wakeProcess

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,54 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/idle/Service.qml'), 'utf8')
+
+// The lock plugin runs in this process, so its state is readable without the
+// shell-out, which reports nothing at all when the IPC call fails.
+assert(
+  /readonly property var lockService: shell && shell\.serviceFor \? shell\.serviceFor\("omarchy\.lock"\) : null/.test(serviceQml),
+  'the idle service reads lock state from the lock service in-process'
+)
+
+// omarchy-system-lock takes about a second to reach the lock service, and the
+// lock is not visible anywhere until it gets there.
+assert(
+  /readonly property bool lockInFlight: lockCommandPending \|\| !!\(lockService && lockService\.locked\)/.test(serviceQml),
+  'a lock counts as in flight from the moment its command is spawned'
+)
+
+assert(
+  /if \(runProcess\(lockProcess, "lock", "omarchy-system-lock"\)\) \{\s*\n\s*root\.lockCommandPending = true\s*\n\s*lockCommandTimer\.restart\(\)/.test(serviceQml),
+  'spawning the lock command marks it pending'
+)
+
+// A lock command that never returns would otherwise park idle handling for the
+// rest of the session.
+assert(
+  /id: lockProcess\s*\n\s*onExited: function\(exitCode, exitStatus\) \{\s*\n\s*root\.lockCommandPending = false/.test(serviceQml),
+  'the lock command stops being pending when it exits'
+)
+
+assert(
+  /id: lockCommandTimer\s*\n\s*interval: 15000[\s\S]{0,200}?root\.lockCommandPending = false/.test(serviceQml),
+  'a lock command that never exits stops being pending on its own'
+)
+
+// lockSystem() clears idledThisCycle, so the next idle re-assertion would
+// otherwise start a fresh cycle on top of the lock it just asked for.
+assert(
+  /if \(root\.lockInFlight\) \{\s*\n\s*logEvent\("idle-cycle-skip", "lock-in-flight"\)\s*\n\s*return\s*\n\s*\}\s*\n\s*logEvent\("idle-cycle-start"/.test(serviceQml),
+  'no idle cycle begins while a lock is in flight'
+)
+
+// screensaver <= lock makes screensaverDelaySeconds 0, so a cycle that slips
+// through launches a screensaver into the pending lock immediately.
+assert(
+  /function launchScreensaver\(\) \{\s*\n\s*if \(root\.lockInFlight\) \{\s*\n\s*logEvent\("screensaver-skip", "lock-in-flight"\)\s*\n\s*return/.test(serviceQml),
+  'no screensaver launches while a lock is in flight'
+)
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
`lockSystem()` clears `idledThisCycle` and then spawns `omarchy-system-lock` as a subprocess (`shell/plugins/services/idle/Service.qml:76`, `:79`). Reaching the lock service from there takes about a second — `bash`, then `bin/omarchy-shell`, then a `qs ipc` round trip into `beginLock()` — and for that whole second nothing anywhere reports a lock. `startIdleCycle()` consults no lock state at all, so the next idle re-assertion starts a brand-new cycle; because `screensaverDelaySeconds` is 0 whenever `screensaver <= lock` (the normal configuration), that cycle launches a second screensaver immediately, into a session that is already going down. Its `ttfx` is born inside the lock window and aborts as soon as its terminal is torn out from under it.

The reporter's timeline shows the gap exactly: `process-start: lock` at 15:01:13.428, `idle-cycle-start` and `process-start: screensaver` at 15:01:14.406, and `lock-requested` only at 15:01:14.462 — the second screensaver went out 56ms before the lock service had any state to report.

The only lock check on that path was the shell-out `[[ $(omarchy-shell lock isLocked 2>/dev/null) == "true" ]] || omarchy-launch-screensaver`. It cannot see a lock that has not arrived yet, and `omarchy-shell` prints nothing on stdout when the IPC call times out, when the shell is not ready, or when it is not running (`bin/omarchy-shell:13`, `:62`, `:74`) — with stderr discarded, an empty answer is not `"true"` and the launcher runs. The guard fails open, at the one moment the shell is busiest bringing a lock surface up.

The lock plugin is a service in this same Quickshell process, so read its state directly instead of asking through a subprocess. A lock counts as in flight from the moment its command is spawned until the lock service reports it done, and neither a new idle cycle nor a screensaver starts while one is. The spawn half is bounded by a timer, so a lock command that never returns cannot park idle handling for the rest of the session.

Two notes on the report itself. The reporter attributes the second idle event to the lock script's `pkill` destroying the first screensaver's window, but that `pkill` runs after `omarchy-shell lock lock` returns (`bin/omarchy-system-lock:8`, `:23`), i.e. after `lock-requested` — so it cannot have caused an idle event 56ms earlier. The cause is simpler and broader: `lockSystem()` re-arms `startIdleCycle()` the moment it fires, and the service already documents that screensaver window churn makes the compositor report activity (`Service.qml:160`), so idle re-assertions during a screensaver cycle are routine. And `isLocked` does already cover the pending phase — `locked` is `lockRequested || sessionLock.locked || sessionLock.secure` (`shell/plugins/lock/Service.qml:37`) and `lockRequested` is set at the top of `beginLock()` — so the issue title's "isLocked guard passes while lock-pending" is not what happens. The window is before the lock service is reached at all, plus the guard's fail-open behaviour.

This does not close #6762 / #6764 or omacom-io/ttfx#10: a screensaver that was already up when the lock fires is still killed by the lock script's teardown, and `ttfx` still aborts rather than exiting cleanly on EIO. It removes the third race, where the screensaver is created after the lock has started.

Fixes #6995
