### PR TITLE
Prevent screensaver launch during lock transitions

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -4,6 +4,10 @@ function secondsFromConfig(value, fallback) {
   return Math.floor(n)
 }
 
+function lockInProgress(lockProcessRunning, lockServiceLocked) {
+  return !!lockProcessRunning || !!lockServiceLocked
+}
+
 function eventParts(event, count) {
   try {
     if (event && event.parse) return event.parse(count)
@@ -46,6 +50,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
+    lockInProgress: lockInProgress,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -62,7 +62,17 @@ Item {
     return true
   }
 
+  function lockInProgress() {
+    var lockService = root.shell ? root.shell.firstPartyServiceFor("omarchy.lock") : null
+    return IdleModel.lockInProgress(lockProcess.running, lockService && lockService.locked)
+  }
+
   function launchScreensaver() {
+    if (lockInProgress()) {
+      logEvent("screensaver-skip", "lock-in-progress")
+      return
+    }
+
     root.screensaverStartedThisCycle = true
     screensaverLaunchGraceTimer.restart()
     runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
@@ -82,6 +92,11 @@ Item {
   function startIdleCycle() {
     if (root.idledThisCycle) {
       logEvent("idle-cycle-already-running")
+      return
+    }
+
+    if (lockInProgress()) {
+      logEvent("idle-cycle-skip", "lock-in-progress")
       return
     }
 

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -5,11 +5,25 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/idle/Service.qml'), 'utf8')
 
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+
+assertEqual(idle.lockInProgress(false, false), false, 'idle runs while no lock is active')
+assertEqual(idle.lockInProgress(true, false), true, 'idle waits for its lock process')
+assertEqual(idle.lockInProgress(false, true), true, 'idle waits for the shell lock service')
+assert(
+  /function launchScreensaver\(\) \{\s*if \(lockInProgress\(\)\)/.test(serviceQml),
+  'idle rechecks the lock before launching a screensaver'
+)
+assert(
+  /function startIdleCycle\(\) \{[\s\S]*?if \(lockInProgress\(\)\)/.test(serviceQml),
+  'idle refuses a new cycle during a lock transition'
+)
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(


### PR DESCRIPTION
Fixes #6995.

Destroying the screensaver during an idle lock can make Hyprland report idle again. The idle service may then start a second cycle while the lock is still pending, launching a new screensaver whose terminal is immediately destroyed. Its ttfx renderer consequently aborts after receiving EIO.

Block idle-cycle startup and recheck delayed screensaver launches whenever:

- the idle service’s lock subprocess is running, or
- the in-process omarchy.lock service reports locked, including lockRequested.

The in-process check avoids the fall-through behavior of the existing shell IPC guard during lock
transitions.

This complements #6813: that PR fixes renderer/supervisor teardown, while this change prevents an entirely new screensaver from existing launched during the pending lock.

Tests:

- bash test/shell.d/idle-test.sh
- ./test/all — all applicable tests pass; three packaging-coverage tests require an omarchy-pkgs checkout.