### PR TITLE
Update installed plugins with Omarchy

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -48,6 +48,17 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
   omarchy-migrate
   omarchy-hook post-update
   omarchy-update-aur-pkgs
+
+  if compgen -G "$HOME/.config/omarchy/plugins/*/.git" >/dev/null; then
+    plugin_update_args=()
+    if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 ]]; then
+      plugin_update_args=(--yes)
+    fi
+    if ! omarchy-plugin-update "${plugin_update_args[@]}"; then
+      echo -e "\e[33mCould not update one or more plugins; continuing.\e[0m" >&2
+    fi
+  fi
+
   omarchy-update-mise
   omarchy-update-orphan-pkgs
 

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -36,7 +36,10 @@ steps=(
 for step in "${steps[@]}"; do
   cat >"$stub_bin/$step" <<'STUB'
 #!/bin/bash
-printf '%s unattended=%s args=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" "$*" >>"$STEP_LOG"
+if [[ ${0##*/} == omarchy-plugin-update ]]; then
+  printf '%s\n' "${1:-}" >"$PLUGIN_UPDATE_ARG_LOG"
+fi
+printf '%s unattended=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" >>"$STEP_LOG"
 [[ ${FAILING_STEP:-} != "${0##*/}" ]] || exit 1
 STUB
   chmod +x "$stub_bin/$step"
@@ -47,6 +50,7 @@ done
 run_update() {
   : >"$test_tmp/steps"
   STEP_LOG="$test_tmp/steps" \
+    PLUGIN_UPDATE_ARG_LOG="$test_tmp/plugin-update-arg" \
     FAILING_STEP="${FAILING_STEP:-}" \
     OMARCHY_UPDATE_LOGGED=1 \
     HOME="$test_tmp/home" \
@@ -90,16 +94,16 @@ diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
   fail "an update where everything works does not run every step in order" "$(cat "$test_tmp/order")"
 pass "an update where every step works runs all of them, in order"
 
-grep -q '^omarchy-update-system-pkgs unattended=1 ' "$test_tmp/steps" ||
+grep -q '^omarchy-update-system-pkgs unattended=1$' "$test_tmp/steps" ||
   fail "-y does not mark the update unattended"
-grep -q '^omarchy-plugin-update unattended=1 args=--yes$' "$test_tmp/steps" ||
+grep -qx -- '--yes' "$test_tmp/plugin-update-arg" ||
   fail "-y does not approve plugin updates without another prompt"
 run_update </dev/null || fail "a confirmed update reports a failure"
 diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
   fail "a confirmed update runs a different set of steps" "$(cat "$test_tmp/order")"
-grep -q '^omarchy-update-system-pkgs unattended= ' "$test_tmp/steps" ||
+grep -q '^omarchy-update-system-pkgs unattended=$' "$test_tmp/steps" ||
   fail "an update a person confirmed is treated as unattended"
-grep -q '^omarchy-plugin-update unattended= args=$' "$test_tmp/steps" ||
+grep -qx '' "$test_tmp/plugin-update-arg" ||
   fail "an interactive update does not leave plugin review enabled"
 pass "-y is what marks an update unattended, not the update itself"
 

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -90,14 +90,14 @@ diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
   fail "an update where everything works does not run every step in order" "$(cat "$test_tmp/order")"
 pass "an update where every step works runs all of them, in order"
 
-grep -q '^omarchy-update-system-pkgs unattended=1 args=$' "$test_tmp/steps" ||
+grep -q '^omarchy-update-system-pkgs unattended=1 ' "$test_tmp/steps" ||
   fail "-y does not mark the update unattended"
 grep -q '^omarchy-plugin-update unattended=1 args=--yes$' "$test_tmp/steps" ||
   fail "-y does not approve plugin updates without another prompt"
 run_update </dev/null || fail "a confirmed update reports a failure"
 diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
   fail "a confirmed update runs a different set of steps" "$(cat "$test_tmp/order")"
-grep -q '^omarchy-update-system-pkgs unattended= args=$' "$test_tmp/steps" ||
+grep -q '^omarchy-update-system-pkgs unattended= ' "$test_tmp/steps" ||
   fail "an update a person confirmed is treated as unattended"
 grep -q '^omarchy-plugin-update unattended= args=$' "$test_tmp/steps" ||
   fail "an interactive update does not leave plugin review enabled"

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -25,6 +25,7 @@ steps=(
   omarchy-migrate
   omarchy-hook
   omarchy-update-aur-pkgs
+  omarchy-plugin-update
   omarchy-update-mise
   omarchy-update-orphan-pkgs
   omarchy-update-analyze-logs
@@ -35,7 +36,7 @@ steps=(
 for step in "${steps[@]}"; do
   cat >"$stub_bin/$step" <<'STUB'
 #!/bin/bash
-printf '%s unattended=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" >>"$STEP_LOG"
+printf '%s unattended=%s args=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" "$*" >>"$STEP_LOG"
 [[ ${FAILING_STEP:-} != "${0##*/}" ]] || exit 1
 STUB
   chmod +x "$stub_bin/$step"
@@ -48,6 +49,7 @@ run_update() {
   STEP_LOG="$test_tmp/steps" \
     FAILING_STEP="${FAILING_STEP:-}" \
     OMARCHY_UPDATE_LOGGED=1 \
+    HOME="$test_tmp/home" \
     PATH="$stub_bin:$PATH" \
     bash "$ROOT/bin/omarchy-update" "$@" >"$test_tmp/out" 2>"$test_tmp/err"
 }
@@ -72,6 +74,7 @@ expected_steps() {
     omarchy-migrate \
     omarchy-hook \
     omarchy-update-aur-pkgs \
+    omarchy-plugin-update \
     omarchy-update-mise \
     omarchy-update-orphan-pkgs \
     omarchy-update-analyze-logs \
@@ -80,18 +83,24 @@ expected_steps() {
     omarchy-update-restart
 }
 
+mkdir -p "$test_tmp/home/.config/omarchy/plugins/test.plugin/.git"
+
 run_update -y || fail "an update where everything works reports a failure"
 diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
   fail "an update where everything works does not run every step in order" "$(cat "$test_tmp/order")"
 pass "an update where every step works runs all of them, in order"
 
-grep -q '^omarchy-update-system-pkgs unattended=1$' "$test_tmp/steps" ||
+grep -q '^omarchy-update-system-pkgs unattended=1 args=$' "$test_tmp/steps" ||
   fail "-y does not mark the update unattended"
+grep -q '^omarchy-plugin-update unattended=1 args=--yes$' "$test_tmp/steps" ||
+  fail "-y does not approve plugin updates without another prompt"
 run_update </dev/null || fail "a confirmed update reports a failure"
 diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
   fail "a confirmed update runs a different set of steps" "$(cat "$test_tmp/order")"
-grep -q '^omarchy-update-system-pkgs unattended=$' "$test_tmp/steps" ||
+grep -q '^omarchy-update-system-pkgs unattended= args=$' "$test_tmp/steps" ||
   fail "an update a person confirmed is treated as unattended"
+grep -q '^omarchy-plugin-update unattended= args=$' "$test_tmp/steps" ||
+  fail "an interactive update does not leave plugin review enabled"
 pass "-y is what marks an update unattended, not the update itself"
 
 # Migrations ship with the packages the upgrade installs and are written against


### PR DESCRIPTION
Git-managed shell plugins currently require a separate update command. This runs the existing plugin updater as part of `omarchy update` when plugins are installed.

Interactive updates keep the existing per-plugin diff and confirmation; `omarchy update -y` passes `--yes`. Plugin failures warn without preventing the main update from finishing.

Tests:
- `bash test/shell.d/update-sequence-test.sh`
- `./test/cli`