### PR TITLE
Add inline calculator to Omarchy menu

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -130,6 +130,17 @@ Adding a provider means adding an entry to the `providers` map in `Menu.qml`
 (script, icon, `actionFor`, optionally `volatile`) and pointing a submenu at
 it with `provider:`.
 
+## Inline calculator
+
+A search beginning with `=` is evaluated by `qalc` after a short debounce.
+The answer appears as the first menu row, and selecting it copies the answer
+to the clipboard. The prefix is deliberate: it keeps searches containing
+numbers from accidentally triggering the calculator.
+
+`MenuModel.js` owns expression and result normalization so the edge cases stay
+headless-testable. `Menu.qml` owns the asynchronous process, discards stale
+answers when the query changes, and caps each calculation at 250 ms.
+
 ## Driving the menu from the CLI
 
 `bin/omarchy-menu` is a thin wrapper over the standard plugin IPC surface:

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -68,6 +68,7 @@ kernel-modules-hook
 lazydocker
 lazygit
 less
+libqalculate
 libsecret
 libvips
 libyaml

--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -6,7 +6,7 @@ If you've spent years on macOS or Windows, your fingers know a hundred things yo
 
 All the muscle memory you've built around Cmd or the Windows key transfers to one key: Super. That's the Windows key on a PC keyboard, and it's the anchor for nearly every hotkey in Omarchy.
 
-Your Spotlight or Raycast or Start-menu reflex becomes `Super + Space`. That opens the Omarchy menu, which launches apps, changes settings, installs software, captures the screen — just about everything. Start typing to filter. There's also a dedicated apps-only menu on `Super + Alt + Space`. See [navigation](04-navigation.md).
+Your Spotlight or Raycast or Start-menu reflex becomes `Super + Space`. That opens the Omarchy menu, which launches apps, changes settings, installs software, captures the screen — just about everything. Start typing to filter, or prefix an expression with `=` to calculate it and press `Enter` to copy the result. There's also a dedicated apps-only menu on `Super + Alt + Space`. See [navigation](04-navigation.md).
 
 ### There's no dock and no desktop icons
 

--- a/migrations/1786881090.sh
+++ b/migrations/1786881090.sh
@@ -1,0 +1,3 @@
+echo "Install inline menu calculator support"
+
+omarchy-pkg-add libqalculate

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1034,8 +1034,8 @@ Item {
         && completedQuery === root.calculatorQueuedQuery
         && completedQuery === MenuModel.calculatorExpression(root.filterText)
 
-      if (isCurrent && answer) {
-        root.calculatorResultQuery = completedQuery
+      if (isCurrent) {
+        root.calculatorResultQuery = answer ? completedQuery : ""
         root.calculatorResult = answer
         if (root.opened) root.rebuildDisplay()
       }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -74,6 +74,42 @@ Item {
   property var providersLoaded: ({})
   property var providerQueue: []
   property int providerRevision: 0
+  property string calculatorQueuedQuery: ""
+  property string calculatorRunningQuery: ""
+  property string calculatorResultQuery: ""
+  property string calculatorResult: ""
+
+  function scheduleCalculation(value) {
+    var query = root.dmenuActive ? "" : MenuModel.calculatorExpression(value)
+    root.calculatorQueuedQuery = query
+    calculatorDebounce.stop()
+
+    if (root.calculatorResultQuery !== query) {
+      root.calculatorResultQuery = ""
+      root.calculatorResult = ""
+    }
+
+    if (query) calculatorDebounce.restart()
+  }
+
+  function startQueuedCalculation() {
+    if (!root.calculatorQueuedQuery || calculatorProc.running) return
+    root.calculatorRunningQuery = root.calculatorQueuedQuery
+    calculatorProc.collected = ""
+    calculatorProc.command = ["qalc", "-t", "-m", "250", "--", root.calculatorRunningQuery]
+    calculatorProc.running = true
+  }
+
+  function copyCalculatorResult(value) {
+    var answer = String(value || "")
+    if (!answer) return
+    Quickshell.execDetached(["wl-copy", "--", answer])
+    root.opened = false
+    root.filterText = ""
+    root.calculatorQueuedQuery = ""
+    root.calculatorResultQuery = ""
+    root.calculatorResult = ""
+  }
 
   // Shared application engine (entries, hidden filters, icons, launch,
   // removal), owned by the shell and also used by the standalone launcher.
@@ -671,6 +707,29 @@ Item {
       }
     }
 
+    if (query
+        && root.calculatorResult
+        && root.calculatorResultQuery === MenuModel.calculatorExpression(query)) {
+      rows.unshift({
+        itemId: "calculator.result",
+        disabled: false,
+        kind: "calculator",
+        icon: "󰃬",
+        iconFont: "",
+        appIcon: "",
+        appId: "",
+        label: root.calculatorResult,
+        target: "",
+        detail: "Press Enter to copy · =" + root.calculatorResultQuery,
+        path: "",
+        childCount: 0,
+        action: "",
+        provider: "",
+        score: -1,
+        section: ""
+      })
+    }
+
     for (var k = 0; k < rows.length; k++) displayModel.append(rows[k])
     layoutSerial += 1
 
@@ -723,6 +782,7 @@ Item {
     root.cursorActive = root.mode !== "input"
     root.disarmPointer()
     if (!root.dmenuActive && root.filterText.trim()) root.loadProvidersForSearch()
+    root.scheduleCalculation(root.filterText)
     root.rebuildDisplay()
   }
 
@@ -781,6 +841,8 @@ Item {
       opened = false
       filterText = ""
       if (root.appLibrary) root.appLibrary.launch(appId, label)
+    } else if (row.kind === "calculator") {
+      root.copyCalculatorResult(row.label)
     } else {
       root.applySelected(row.itemId, row.action)
     }
@@ -944,6 +1006,43 @@ Item {
     onExited: {
       if (root.applySerial === root.requestSerial)
         root.opened = false
+    }
+  }
+
+  Timer {
+    id: calculatorDebounce
+    interval: 80
+    repeat: false
+    onTriggered: root.startQueuedCalculation()
+  }
+
+  Process {
+    id: calculatorProc
+    property string collected: ""
+    stdout: SplitParser {
+      onRead: function(data) { calculatorProc.collected += data + "\n" }
+    }
+    onExited: function(exitCode, exitStatus) {
+      var completedQuery = root.calculatorRunningQuery
+      var answer = MenuModel.calculatorResult(
+        calculatorProc.collected,
+        completedQuery,
+        exitCode,
+        exitStatus
+      )
+      var isCurrent = completedQuery
+        && completedQuery === root.calculatorQueuedQuery
+        && completedQuery === MenuModel.calculatorExpression(root.filterText)
+
+      if (isCurrent && answer) {
+        root.calculatorResultQuery = completedQuery
+        root.calculatorResult = answer
+        if (root.opened) root.rebuildDisplay()
+      }
+
+      root.calculatorRunningQuery = ""
+      if (root.calculatorQueuedQuery && root.calculatorQueuedQuery !== completedQuery)
+        Qt.callLater(function() { root.startQueuedCalculation() })
     }
   }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1257,7 +1257,7 @@ Item {
             } else if (root.cursorActive) root.activateIndex(root.selectedIndex)
             else root.settleCursor()
             event.accepted = true
-          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
+          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && !(event.modifiers & ~(Qt.ShiftModifier | Qt.KeypadModifier))) {
             root.setFilter(root.filterText + event.text)
             event.accepted = true
           }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -4,6 +4,28 @@ function stripJsonc(raw) {
     .replace(/,(\s*[}\]])/g, "$1")
 }
 
+function calculatorExpression(value) {
+  var raw = String(value || "").trim()
+  if (raw.charAt(0) !== "=") return ""
+
+  var expression = raw.substring(1).trim()
+  return expression && expression.length <= 160 ? expression : ""
+}
+
+function calculatorResult(output, expression, exitCode, exitStatus) {
+  if (exitCode !== 0 || exitStatus !== 0) return ""
+
+  var source = String(expression || "").trim()
+  var answer = String(output || "").trim().replace(/\s*\n\s*/g, " ")
+  if (!source || !answer || answer.length > 240) return ""
+  if (answer.toLowerCase().indexOf("error") === 0) return ""
+
+  var normalized = function(value) {
+    return String(value || "").replace(/\s+/g, "").toLowerCase()
+  }
+  return normalized(answer) === normalized(source) ? "" : answer
+}
+
 function normalizeAliases(value) {
   if (Array.isArray(value)) return value.filter(function(v) { return v })
   if (typeof value === "string" && value) return [value]
@@ -494,6 +516,8 @@ if (typeof module !== "undefined") {
   module.exports = {
     guardReaders: GUARD_READERS,
     guardScript: guardScript,
+    calculatorExpression: calculatorExpression,
+    calculatorResult: calculatorResult,
     stripJsonc: stripJsonc,
     normalizeAliases: normalizeAliases,
     normalizeItem: normalizeItem,

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -1,3 +1,6 @@
+var CALCULATOR_MAX_EXPRESSION_LENGTH = 160
+var CALCULATOR_MAX_RESULT_LENGTH = 240
+
 function stripJsonc(raw) {
   return String(raw || "")
     .replace(/^\s*\/\/[^\n]*(\n|$)/gm, "")
@@ -9,7 +12,7 @@ function calculatorExpression(value) {
   if (raw.charAt(0) !== "=") return ""
 
   var expression = raw.substring(1).trim()
-  return expression && expression.length <= 160 ? expression : ""
+  return expression && expression.length <= CALCULATOR_MAX_EXPRESSION_LENGTH ? expression : ""
 }
 
 function calculatorResult(output, expression, exitCode, exitStatus) {
@@ -17,7 +20,7 @@ function calculatorResult(output, expression, exitCode, exitStatus) {
 
   var source = String(expression || "").trim()
   var answer = String(output || "").trim().replace(/\s*\n\s*/g, " ")
-  if (!source || !answer || answer.length > 240) return ""
+  if (!source || !answer || answer.length > CALCULATOR_MAX_RESULT_LENGTH) return ""
   if (answer.toLowerCase().indexOf("error") === 0) return ""
 
   var normalized = function(value) {

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -41,6 +41,10 @@ assert(
   menuQml.includes('root.calculatorResultQuery = answer ? completedQuery : ""'),
   'menu clears stale calculator results when a current evaluation fails'
 )
+assert(
+  menuQml.includes('!(event.modifiers & ~(Qt.ShiftModifier | Qt.KeypadModifier))'),
+  'menu accepts numpad text while preserving modified-key shortcuts'
+)
 
 const parsed = menu.parseMenuJsonc(`
 {

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -9,6 +9,32 @@ const fs = require('fs')
 const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
 const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
 const defaultMenuJsonc = fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8')
+const basePackages = fs.readFileSync(path.join(root, 'install/omarchy-base.packages'), 'utf8').split(/\s+/)
+
+assertEqual(menu.calculatorExpression('=25*18'), '25*18', 'menu recognizes a prefixed calculator expression')
+assertEqual(menu.calculatorExpression('  = sqrt(81)  '), 'sqrt(81)', 'menu trims calculator expressions')
+assertEqual(menu.calculatorExpression('25*18'), '', 'menu requires the calculator prefix')
+assertEqual(menu.calculatorExpression('='), '', 'menu ignores an empty calculator expression')
+assertEqual(menu.calculatorResult('450\n', '25*18', 0, 0), '450', 'menu normalizes calculator output')
+assertEqual(menu.calculatorResult('1 / 0\n', '1/0', 0, 0), '', 'menu hides symbolic calculator failures that echo the input')
+assertEqual(menu.calculatorResult('error: bad input\n', 'bad input', 0, 0), '', 'menu hides calculator errors')
+assertEqual(menu.calculatorResult('450\n', '25*18', 1, 0), '', 'menu hides failed calculator processes')
+assert(basePackages.includes('libqalculate'), 'base packages provide qalc for the inline calculator')
+assert(
+  fs.readdirSync(path.join(root, 'migrations')).some(file =>
+    file.endsWith('.sh')
+      && fs.readFileSync(path.join(root, 'migrations', file), 'utf8').includes('omarchy-pkg-add libqalculate')
+  ),
+  'a migration installs qalc on existing systems'
+)
+assert(
+  menuQml.includes('calculatorProc.command = ["qalc", "-t", "-m", "250", "--", root.calculatorRunningQuery]'),
+  'menu evaluates calculator expressions with a bounded direct qalc process'
+)
+assert(
+  menuQml.includes('Quickshell.execDetached(["wl-copy", "--", answer])'),
+  'menu copies calculator answers without shell interpolation'
+)
 
 const parsed = menu.parseMenuJsonc(`
 {

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -15,10 +15,12 @@ assertEqual(menu.calculatorExpression('=25*18'), '25*18', 'menu recognizes a pre
 assertEqual(menu.calculatorExpression('  = sqrt(81)  '), 'sqrt(81)', 'menu trims calculator expressions')
 assertEqual(menu.calculatorExpression('25*18'), '', 'menu requires the calculator prefix')
 assertEqual(menu.calculatorExpression('='), '', 'menu ignores an empty calculator expression')
+assertEqual(menu.calculatorExpression(`=${'1'.repeat(161)}`), '', 'menu bounds calculator expression length')
 assertEqual(menu.calculatorResult('450\n', '25*18', 0, 0), '450', 'menu normalizes calculator output')
 assertEqual(menu.calculatorResult('1 / 0\n', '1/0', 0, 0), '', 'menu hides symbolic calculator failures that echo the input')
 assertEqual(menu.calculatorResult('error: bad input\n', 'bad input', 0, 0), '', 'menu hides calculator errors')
 assertEqual(menu.calculatorResult('450\n', '25*18', 1, 0), '', 'menu hides failed calculator processes')
+assertEqual(menu.calculatorResult('1'.repeat(241), 'long result', 0, 0), '', 'menu bounds calculator result length')
 assert(basePackages.includes('libqalculate'), 'base packages provide qalc for the inline calculator')
 assert(
   fs.readdirSync(path.join(root, 'migrations')).some(file =>
@@ -34,6 +36,10 @@ assert(
 assert(
   menuQml.includes('Quickshell.execDetached(["wl-copy", "--", answer])'),
   'menu copies calculator answers without shell interpolation'
+)
+assert(
+  menuQml.includes('root.calculatorResultQuery = answer ? completedQuery : ""'),
+  'menu clears stale calculator results when a current evaluation fails'
 )
 
 const parsed = menu.parseMenuJsonc(`


### PR DESCRIPTION
## Summary

- add `=`-prefixed inline calculations to the Quickshell menu
- debounce and bound `qalc` evaluation, show the answer first, and copy it on Enter
- restore `libqalculate` for fresh and existing Quattro systems
- document the workflow and cover parsing, failure, dependency, and command-safety paths

This restores the calculator workflow introduced for Walker in #362 while preserving the explicit prefix favored in #5088.

## Testing

- `qmllint shell/plugins/menu/Menu.qml`
- `bash test/shell.d/menu-test.sh`
- `./test/all` — 179/180 test files pass; `bar-icon-geometry-test.sh` misses its half-pixel tolerance by 0.09375 px and reproduces identically on untouched `upstream/quattro` under this compositor
- visually verified `=25*18` renders `450` first, Enter copies `450`, and unprefixed `25*18` remains a regular search