### PR TITLE
Fix omarchy-battery-status to report combined capacity on multi-battery laptops

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,10 +18,10 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
-
-battery_info=$(upower -i "$battery")
+battery=/org/freedesktop/UPower/devices/DisplayDevice
+battery_info=$(upower -i "$battery" 2>/dev/null)
+[[ -z $battery_info ]] && exit 0
+grep -q 'present:\s*yes' <<<"$battery_info" || exit 0
 
 percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
 capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")


### PR DESCRIPTION
`omarchy-battery-status` picks the first battery device alphabetically (`upower -e | grep BAT | head -n 1`), which on dual-battery ThinkPads (e.g. T480 with an internal + hot-swap bay battery) only reports one battery's percentage/capacity/cycles while silently ignoring the other.

This visibly disagrees with the power panel's progress bar and icon, which already correctly bind to UPower's composite `DisplayDevice` (`Quickshell.Services.UPower`'s `UPower.displayDevice`) — so the panel shows a percentage number and a bar telling two different stories.

This points the script at the same `DisplayDevice` object the panel already uses, and checks its `present` state (mirroring the QML's `isPresent` check) instead of relying on the removed enumerate step to signal "no battery".

Verified on a ThinkPad T480 with BAT0 (13.49Wh full) + BAT1 (23.72Wh full): before, showed `36% / 13Wh`; after, correctly shows `~73% / 37Wh`, matching `upower -i DisplayDevice` directly.