### PR TITLE
Install CS8409 speaker driver on 2016-2017 MacBook Pros

### DIFF
--- a/bin/omarchy-hw-apple-cs8409
+++ b/bin/omarchy-hw-apple-cs8409
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer is a 2016–2017 MacBook Pro with CS8409 audio
+# omarchy:hidden=true
+
+# Cirrus CS8409 + MAX98706/SSM3515/TAS5764L. In-tree snd_hda_codec_cs8409
+# does not program those amps. Covers the 2016–2017 13" and 15" MacBook Pros
+# (including the two-port 13" models that have no Touch Bar). T2 and later
+# use a different codec and must not get this driver.
+product_name=$(cat "${OMARCHY_DMI_PRODUCT_NAME:-/sys/class/dmi/id/product_name}" 2>/dev/null)
+[[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123] ]]

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -33,6 +33,7 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-cs8409-audio.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"

--- a/install/hardware/apple/fix-cs8409-audio.sh
+++ b/install/hardware/apple/fix-cs8409-audio.sh
@@ -1,0 +1,8 @@
+# 2016–2017 MacBook Pros use CS8409 HDA. The in-tree codec driver leaves
+# the speaker amps unprogrammed; snd-hda-macbookpro-dkms is the Apple path.
+
+if omarchy-hw-apple-cs8409; then
+  echo "Detected MacBook with Cirrus CS8409 audio"
+
+  omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms
+fi

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -35,7 +35,7 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 3. Select the orange EFI Boot device
 4. Proceed with the [install as normal](02-getting-started.md)
 
-The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.
+The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, the CS8409 speaker driver on 2016–2017 MacBook Pros, and an NVMe suspend fix for those same models.
 
 ### Known Limitations
 
@@ -51,7 +51,7 @@ The Apple T1 chip was introduced in late 2016 and used exclusively in the first-
 #### Known Issues
 
 - Touch Bar is non-functional
-- Sound is not functioning
+- Internal microphone capture is quiet and not fully wired up yet. Speakers and headphones work; the installer installs the CS8409 driver (`snd-hda-macbookpro-dkms`) automatically. Reboot once after install so the patched module replaces the silent in-tree codec.
 
 #### Devices with T2 Chip
 

--- a/migrations/1786889011.sh
+++ b/migrations/1786889011.sh
@@ -1,0 +1,8 @@
+echo "Install the CS8409 MacBook speaker driver"
+
+# 2016–2017 MacBook Pros only. T2 and other Apple hardware is unchanged.
+if ! omarchy-hw-apple-cs8409; then
+  exit 0
+fi
+
+omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms

--- a/test/shell.d/cs8409-audio-test.sh
+++ b/test/shell.d/cs8409-audio-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hw="$ROOT/bin/omarchy-hw-apple-cs8409"
+fix="$ROOT/install/hardware/apple/fix-cs8409-audio.sh"
+migration="$ROOT/migrations/1786889011.sh"
+manual="$ROOT/manual/44-mac-support.md"
+
+assert_hw() {
+  local model=$1 expect=$2 description=$3
+  local tmp
+  tmp=$(mktemp)
+  printf '%s\n' "$model" >"$tmp"
+  if OMARCHY_DMI_PRODUCT_NAME="$tmp" "$hw"; then
+    [[ $expect == yes ]] || fail "$description"
+  else
+    [[ $expect == no ]] || fail "$description"
+  fi
+  rm -f "$tmp"
+  pass "$description"
+}
+
+assert_hw MacBookPro14,3 yes "MacBookPro14,3 has CS8409 audio"
+assert_hw MacBookPro14,2 yes "MacBookPro14,2 has CS8409 audio"
+assert_hw MacBookPro14,1 yes "MacBookPro14,1 has CS8409 audio"
+assert_hw MacBookPro13,3 yes "MacBookPro13,3 has CS8409 audio"
+assert_hw MacBookPro13,2 yes "MacBookPro13,2 has CS8409 audio"
+assert_hw MacBookPro13,1 yes "MacBookPro13,1 has CS8409 audio"
+assert_hw MacBookPro15,1 no "MacBookPro15,1 is T2, not CS8409"
+assert_hw MacBook8,1 no "MacBook8,1 is SPI-only"
+
+grep -Fq 'fix-cs8409-audio.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "hardware install runs the CS8409 hook"
+pass "CS8409 install hook is wired"
+
+grep -Fq 'snd-hda-macbookpro-dkms' "$fix" ||
+  fail "install hook names the omarchy-pkgs package"
+grep -Fq 'omarchy-hw-apple-cs8409' "$fix" ||
+  fail "install hook is gated on CS8409 detection"
+pass "install hook installs snd-hda-macbookpro-dkms"
+
+grep -Fq 'snd-hda-macbookpro-dkms' "$manual" ||
+  fail "Mac support chapter names the CS8409 package"
+! grep -q 'Sound is not functioning' "$manual" ||
+  fail "Mac support chapter no longer lists speakers as unsupported"
+pass "Mac support chapter documents CS8409 speakers"
+
+[[ -f $migration ]] || fail "CS8409 migration exists"
+grep -Fq 'omarchy-hw-apple-cs8409' "$migration" ||
+  fail "migration is gated on CS8409 detection"
+grep -Fq 'snd-hda-macbookpro-dkms' "$migration" ||
+  fail "migration installs the CS8409 package"
+! head -1 "$migration" | grep -q '^#!' ||
+  fail "migration has no shebang"
+pass "migration installs the driver on CS8409 hardware only"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+chmod +x "$stub_bin/omarchy-pkg-add"
+
+dmi="$test_tmp/dmi"
+printf 'MacBookPro14,1\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  bash -c 'source "$1"' _ "$fix"
+grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "install hook adds headers and the CS8409 package on a two-port 13-inch"
+pass "install hook runs on MacBookPro14,1 (CS8409, no Touch Bar)"
+
+: >"$calls"
+printf 'MacBookPro15,1\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  bash -c 'source "$1"' _ "$fix"
+[[ ! -s $calls ]] || fail "T2 hardware skips the CS8409 package" "$(cat "$calls")"
+pass "install hook skips T2 hardware"
+
+: >"$calls"
+printf 'MacBookPro14,3\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  bash -euo pipefail "$migration" >/dev/null
+grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "migration installs the CS8409 package on a 15-inch T1"
+pass "migration installs the driver on MacBookPro14,3"
+
+: >"$calls"
+printf 'MacBookPro16,1\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  bash -euo pipefail "$migration" >/dev/null
+[[ ! -s $calls ]] || fail "migration skips non-CS8409 hardware" "$(cat "$calls")"
+pass "migration skips non-CS8409 hardware"

--- a/test/shell.d/cs8409-audio-test.sh
+++ b/test/shell.d/cs8409-audio-test.sh
@@ -11,15 +11,16 @@ manual="$ROOT/manual/44-mac-support.md"
 
 assert_hw() {
   local model=$1 expect=$2 description=$3
-  local tmp
+  local tmp got
   tmp=$(mktemp)
   printf '%s\n' "$model" >"$tmp"
   if OMARCHY_DMI_PRODUCT_NAME="$tmp" "$hw"; then
-    [[ $expect == yes ]] || fail "$description"
+    got=yes
   else
-    [[ $expect == no ]] || fail "$description"
+    got=no
   fi
   rm -f "$tmp"
+  [[ $got == "$expect" ]] || fail "$description"
   pass "$description"
 }
 


### PR DESCRIPTION
## Why

2016–2017 MacBook Pros (`MacBookPro13,1`–`14,3`, including the two-port 13\" models with no Touch Bar) use Cirrus CS8409 HDA plus external speaker amps. In-tree `snd_hda_codec_cs8409` leaves those amps unprogrammed. The sink shows up unmuted; speakers stay silent.

The manual currently lists sound as not functioning. This replaces that with an installer hook. Verified end-to-end on a MacBookPro14,3: patched module loads after reboot, dmesg takes the Apple path, speakers play.

**Depends on the package:** https://github.com/omacom-io/omarchy-pkgs/pull/155. That adds `snd-hda-macbookpro-dkms` to omarchy-pkgs. The hook cannot succeed until that package is in the repo.

## What

- `omarchy-hw-apple-cs8409` matches `MacBookPro13,[123]|MacBookPro14,[123]`. T2 and later are excluded.
- `install/hardware/apple/fix-cs8409-audio.sh` installs `linux-headers` and `snd-hda-macbookpro-dkms`.
- Migration `1786889011` does the same for existing installs.
- Manual: speakers/headphones work; internal mic is still quiet/incomplete (upstream).

No udev, no modules-load. The HDA stack autoloads; DKMS puts the patched `snd-hda-codec-cs8409` in `updates/` so it wins after reboot.

## Test plan

- [x] `./test/cli`
- [x] `test/shell.d/cs8409-audio-test.sh`
- [x] MacBookPro14,3: reboot after the driver is installed → speakers play