### PR TITLE
fix: respect OpenCode v2 next pins in mise wrappers

### DIFF
--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -45,15 +45,15 @@ if [[ $installing == "false" ]] && ! mise where "$agent_package" &>/dev/null; th
   exec omarchy-launch-floating-terminal-with-presentation omarchy-default-agent --install "$agent"
 fi
 
-if ! mise where "$agent_package" &>/dev/null; then
-  if ! mise use -g "$agent_package"; then
-    if [[ $installing == "true" ]]; then
-      echo "Could not install $name with mise" >&2
-    else
-      echo "Could not set $name as the default coding agent" >&2
-    fi
-    exit 1
+if [[ $agent == "opencode" ]] && mise where "$agent_package" &>/dev/null; then
+  :
+elif ! mise use -g "$agent_package"; then
+  if [[ $installing == "true" ]]; then
+    echo "Could not install $name with mise" >&2
+  else
+    echo "Could not set $name as the default coding agent" >&2
   fi
+  exit 1
 fi
 
 mkdir -p "$(dirname "$agent_file")"

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -26,7 +26,7 @@ fi
 case "$1" in
 pi) agent="pi"; name="Pi" ;;
 omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-my-pi" ;;
-opencode | open-code) agent="opencode"; name="OpenCode" ;;
+opencode | open-code) agent="opencode"; name="OpenCode"; agent_package="npm:@opencode-ai/cli" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
 codex) agent="codex"; name="Codex" ;;
 crush) agent="crush"; name="Crush" ;;
@@ -45,13 +45,15 @@ if [[ $installing == "false" ]] && ! mise where "$agent_package" &>/dev/null; th
   exec omarchy-launch-floating-terminal-with-presentation omarchy-default-agent --install "$agent"
 fi
 
-if ! mise use -g "$agent_package"; then
-  if [[ $installing == "true" ]]; then
-    echo "Could not install $name with mise" >&2
-  else
-    echo "Could not set $name as the default coding agent" >&2
+if ! mise where "$agent_package" &>/dev/null; then
+  if ! mise use -g "$agent_package"; then
+    if [[ $installing == "true" ]]; then
+      echo "Could not install $name with mise" >&2
+    else
+      echo "Could not set $name as the default coding agent" >&2
+    fi
+    exit 1
   fi
-  exit 1
 fi
 
 mkdir -p "$(dirname "$agent_file")"

--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -22,7 +22,9 @@ rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g --quiet "$package" || exit 1
+if ! mise where "$package" &>/dev/null; then
+  mise use -g --quiet "$package" || exit 1
+fi
 exec mise x "$package" -- "$bin" "\$@"
 EOF
 

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -4,7 +4,7 @@ omarchy-mise-install crush
 omarchy-mise-install gemini
 omarchy-mise-install gh
 omarchy-mise-install copilot
-omarchy-mise-install opencode
+omarchy-mise-install npm:@opencode-ai/cli opencode
 omarchy-mise-install npm:playwright playwright
 omarchy-mise-install pi
 omarchy-mise-install github:can1357/oh-my-pi omp

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -16,13 +16,7 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 
 To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`. The stubs are kept current along with everything else mise manages when you run `omarchy update` (or the `mup` alias).
 
-OpenCode ships through `npm:@opencode-ai/cli`. Omarchy lazy-installs the npm `latest` release by default; pin another channel in `~/.config/mise/config.toml` when you want a different line, for example OpenCode v2:
-
-```bash
-mise use -g npm:@opencode-ai/cli@next
-```
-
-Once pinned, `omarchy update` upgrades within that tag and the OpenCode wrapper will not reset the pin.
+OpenCode ships through `npm:@opencode-ai/cli`. Pin a different release line in `~/.config/mise/config.toml` when you want one, for example OpenCode v2 with `mise use -g npm:@opencode-ai/cli@next`.
 
 ### The default agent
 

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -16,6 +16,14 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 
 To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`. The stubs are kept current along with everything else mise manages when you run `omarchy update` (or the `mup` alias).
 
+OpenCode ships through `npm:@opencode-ai/cli`. Omarchy lazy-installs the npm `latest` release by default; pin another channel in `~/.config/mise/config.toml` when you want a different line, for example OpenCode v2:
+
+```bash
+mise use -g npm:@opencode-ai/cli@next
+```
+
+Once pinned, `omarchy update` upgrades within that tag and the OpenCode wrapper will not reset the pin.
+
 ### The default agent
 
 Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.

--- a/migrations/1786891392.sh
+++ b/migrations/1786891392.sh
@@ -1,0 +1,18 @@
+echo "Point OpenCode at the npm package and stop fighting v2 next pins"
+
+opencode_package="npm:@opencode-ai/cli"
+mise_config="$HOME/.config/mise/config.toml"
+wrapper="$HOME/.local/bin/opencode"
+
+if [[ -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  if [[ -f $wrapper ]] && grep -Eq 'mise use -g (--quiet )?"opencode"' "$wrapper"; then
+    rm -f "$wrapper"
+  fi
+  exit 0
+fi
+
+omarchy-mise-install "$opencode_package" opencode
+
+if [[ -f $mise_config ]] && grep -q '@opencode-ai/cli' "$mise_config" && omarchy-cmd-present mise; then
+  mise unuse -g opencode &>/dev/null || true
+fi

--- a/migrations/1786891392.sh
+++ b/migrations/1786891392.sh
@@ -1,18 +1,16 @@
-echo "Point OpenCode at the npm package and stop fighting v2 next pins"
+echo "Point OpenCode at the npm package"
 
 opencode_package="npm:@opencode-ai/cli"
-mise_config="$HOME/.config/mise/config.toml"
-wrapper="$HOME/.local/bin/opencode"
 
 if [[ -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
-  if [[ -f $wrapper ]] && grep -Eq 'mise use -g (--quiet )?"opencode"' "$wrapper"; then
-    rm -f "$wrapper"
+  if [[ -f $HOME/.local/bin/opencode ]] && grep -Eq 'mise use -g (--quiet )?"opencode"' "$HOME/.local/bin/opencode"; then
+    rm -f "$HOME/.local/bin/opencode"
   fi
   exit 0
 fi
 
 omarchy-mise-install "$opencode_package" opencode
 
-if [[ -f $mise_config ]] && grep -q '@opencode-ai/cli' "$mise_config" && omarchy-cmd-present mise; then
+if [[ -f $HOME/.config/mise/config.toml ]] && grep -q '@opencode-ai/cli' "$HOME/.config/mise/config.toml" && omarchy-cmd-present mise; then
   mise unuse -g opencode &>/dev/null || true
 fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -95,29 +95,39 @@ export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
 grok_package="npm:@xai-official/grok"
 omp_package="github:can1357/oh-my-pi"
 crush_package="crush"
+opencode_package="npm:@opencode-ai/cli"
 
 assert_lazy_stub() {
   local package=$1
   local command=$2
 
   : >"$mise_history"
-  "$ROOT/bin/omarchy-mise-install" "$package" "$command"
-  "$test_home/.local/bin/$command" --version
+  OMARCHY_TEST_AGENT_INSTALLED=false "$ROOT/bin/omarchy-mise-install" "$package" "$command"
+  OMARCHY_TEST_AGENT_INSTALLED=false "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
-  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
-    fail "$command lazy stub preserves its mise package"
+  [[ ${mise_calls[0]} == "where $package" && ${mise_calls[1]} == "use -g --quiet $package" && ${mise_calls[2]} == "x $package -- $command --version" ]] ||
+    fail "$command lazy stub installs through mise on first run"
+
+  : >"$mise_history"
+  OMARCHY_TEST_AGENT_INSTALLED=true "$test_home/.local/bin/$command" --version
+  mapfile -t mise_calls <"$mise_history"
+
+  [[ ${mise_calls[0]} == "where $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+    fail "$command lazy stub preserves an existing mise pin"
 }
 
 assert_lazy_stub "$grok_package" grok
 assert_lazy_stub "$omp_package" omp
 assert_lazy_stub "$crush_package" crush
+assert_lazy_stub "$opencode_package" opencode
 pass "custom agent lazy stubs preserve their mise packages"
 
 source "$ROOT/install/user/mise.sh"
 grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "user setup creates the Oh My Pi lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the Crush lazy stub"
+grep -Fx "$opencode_package opencode" "$stub_log" >/dev/null || fail "user setup creates the OpenCode lazy stub"
 pass "user setup creates the custom agent lazy stubs"
 
 : >"$stub_log"
@@ -158,6 +168,18 @@ rm -f "$test_home/.local/bin/omp"
 
 rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"
+
+: >"$stub_log"
+printf '#!/bin/bash\nmise use -g --quiet "opencode" || exit 1\n' >"$test_home/.local/bin/opencode"
+chmod +x "$test_home/.local/bin/opencode"
+mkdir -p "$test_home/.config/mise"
+printf '[tools]\n"npm:@opencode-ai/cli" = "next"\n' >"$test_home/.config/mise/config.toml"
+PATH="$ROOT/bin:$mock_bin:$PATH" source "$ROOT/migrations/1786891392.sh" >/dev/null
+grep -Fq "$opencode_package" "$test_home/.local/bin/opencode" ||
+  fail "OpenCode migration installs the npm lazy stub"
+grep -Fq 'mise where "npm:@opencode-ai/cli"' "$test_home/.local/bin/opencode" ||
+  fail "OpenCode migration preserves existing mise pins in the wrapper"
+pass "OpenCode migration points existing v2 installs at the npm package"
 
 omarchy-remove-preinstalls >/dev/null
 for command in omp grok crush; do
@@ -225,7 +247,7 @@ declare -A expected_agents=(
 declare -A expected_packages=(
   [pi]="pi"
   [omp]="$omp_package"
-  [opencode]="opencode"
+  [opencode]="$opencode_package"
   [claude]="claude"
   [codex]="codex"
   [crush]="$crush_package"
@@ -237,12 +259,12 @@ declare -A expected_packages=(
 for selection in "${!expected_agents[@]}"; do
   expected=${expected_agents[$selection]}
   : >"$agent_open_log"
+  : >"$mise_history"
   OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent "$selection"
   [[ $(omarchy-default-agent) == $expected ]] || fail "default agent canonicalizes $selection"
 
-  mapfile -d '' -t mise_args <"$mise_log"
-  [[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == ${expected_packages[$expected]} ]] ||
-    fail "default agent installs $selection globally through mise"
+  grep -Eq '^use -g ' "$mise_history" &&
+    fail "default agent preserves an existing mise pin when selecting $selection"
 
   mapfile -d '' -t agent_open_args <"$agent_open_log"
   [[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
@@ -281,12 +303,12 @@ pass "missing agents install visibly and open in the same terminal"
 : >"$notification_history"
 : >"$agent_open_log"
 : >"$terminal_log"
+: >"$mise_history"
 OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent github-copilot
 [[ ! -s $terminal_log ]] || fail "installed agent selection skips the terminal"
 [[ ! -s $notification_history ]] || fail "installed agent selection skips notifications"
-mapfile -d '' -t mise_args <"$mise_log"
-[[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == "copilot" ]] ||
-  fail "default agent still activates an installed provider globally through mise"
+grep -Eq '^use -g ' "$mise_history" &&
+  fail "installed agent selection preserves an existing mise pin"
 mapfile -d '' -t agent_open_args <"$agent_open_log"
 [[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
   fail "installed agent opens in a new terminal after selection"
@@ -316,15 +338,17 @@ pass "default agent opens only after mise installs the provider"
 
 : >"$notification_history"
 : >"$agent_open_log"
-if OMARCHY_TEST_AGENT_INSTALLED=true OMARCHY_TEST_MISE_FAIL=true omarchy-default-agent codex >"$test_tmp/setup-failure-output" 2>&1; then
-  fail "default agent rejects a failed mise activation"
-fi
-[[ $(omarchy-default-agent) == "copilot" ]] || fail "failed activation preserves the current default agent"
-grep -F "Could not set Codex as the default coding agent" "$test_tmp/setup-failure-output" >/dev/null ||
-  fail "default agent reports a failed activation for an installed provider"
-[[ ! -s $notification_history ]] || fail "failed activation skips notifications"
-[[ ! -s $agent_open_log ]] || fail "failed activation does not open an agent"
-pass "default agent reports mise failures without notifications"
+: >"$mise_history"
+OMARCHY_TEST_AGENT_INSTALLED=true OMARCHY_TEST_MISE_FAIL=true omarchy-default-agent codex
+[[ $(omarchy-default-agent) == "codex" ]] ||
+  fail "installed agent selection succeeds without reactivating through mise"
+grep -Eq '^use -g ' "$mise_history" &&
+  fail "installed agent selection skips mise when the provider is already present"
+[[ ! -s $notification_history ]] || fail "installed agent selection skips notifications"
+mapfile -d '' -t agent_open_args <"$agent_open_log"
+[[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
+  fail "installed agent opens after selection without mise reactivation"
+pass "default agent selects installed providers without reactivating through mise"
 
 rm "$mock_bin/omarchy-agent"
 hash -r

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -263,8 +263,14 @@ for selection in "${!expected_agents[@]}"; do
   OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent "$selection"
   [[ $(omarchy-default-agent) == $expected ]] || fail "default agent canonicalizes $selection"
 
-  grep -Eq '^use -g ' "$mise_history" &&
-    fail "default agent preserves an existing mise pin when selecting $selection"
+  if [[ $expected == "opencode" ]]; then
+    grep -Eq '^use -g ' "$mise_history" &&
+      fail "default agent preserves an existing OpenCode mise pin"
+  else
+    mapfile -d '' -t mise_args <"$mise_log"
+    [[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == ${expected_packages[$expected]} ]] ||
+      fail "default agent installs $selection globally through mise"
+  fi
 
   mapfile -d '' -t agent_open_args <"$agent_open_log"
   [[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
@@ -303,12 +309,12 @@ pass "missing agents install visibly and open in the same terminal"
 : >"$notification_history"
 : >"$agent_open_log"
 : >"$terminal_log"
-: >"$mise_history"
 OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent github-copilot
 [[ ! -s $terminal_log ]] || fail "installed agent selection skips the terminal"
 [[ ! -s $notification_history ]] || fail "installed agent selection skips notifications"
-grep -Eq '^use -g ' "$mise_history" &&
-  fail "installed agent selection preserves an existing mise pin"
+mapfile -d '' -t mise_args <"$mise_log"
+[[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == "copilot" ]] ||
+  fail "default agent still activates an installed provider globally through mise"
 mapfile -d '' -t agent_open_args <"$agent_open_log"
 [[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
   fail "installed agent opens in a new terminal after selection"
@@ -338,17 +344,15 @@ pass "default agent opens only after mise installs the provider"
 
 : >"$notification_history"
 : >"$agent_open_log"
-: >"$mise_history"
-OMARCHY_TEST_AGENT_INSTALLED=true OMARCHY_TEST_MISE_FAIL=true omarchy-default-agent codex
-[[ $(omarchy-default-agent) == "codex" ]] ||
-  fail "installed agent selection succeeds without reactivating through mise"
-grep -Eq '^use -g ' "$mise_history" &&
-  fail "installed agent selection skips mise when the provider is already present"
-[[ ! -s $notification_history ]] || fail "installed agent selection skips notifications"
-mapfile -d '' -t agent_open_args <"$agent_open_log"
-[[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
-  fail "installed agent opens after selection without mise reactivation"
-pass "default agent selects installed providers without reactivating through mise"
+if OMARCHY_TEST_AGENT_INSTALLED=true OMARCHY_TEST_MISE_FAIL=true omarchy-default-agent codex >"$test_tmp/setup-failure-output" 2>&1; then
+  fail "default agent rejects a failed mise activation"
+fi
+[[ $(omarchy-default-agent) == "copilot" ]] || fail "failed activation preserves the current default agent"
+grep -F "Could not set Codex as the default coding agent" "$test_tmp/setup-failure-output" >/dev/null ||
+  fail "default agent reports a failed activation for an installed provider"
+[[ ! -s $notification_history ]] || fail "failed activation skips notifications"
+[[ ! -s $agent_open_log ]] || fail "failed activation does not open an agent"
+pass "default agent reports mise failures without notifications"
 
 rm "$mock_bin/omarchy-agent"
 hash -r


### PR DESCRIPTION
## Summary

- Point the OpenCode lazy stub at `npm:@opencode-ai/cli` instead of aqua `opencode` (v1)
- Install mise tools from wrappers only when missing, so explicit pins like `@next` survive normal use
- Skip default-agent reactivation for OpenCode when it is already installed (other agents unchanged)
- Migrate existing installs: regenerate the npm wrapper and drop a stale aqua `opencode` pin when npm is already configured

## Problem

Users on OpenCode v2 (`npm:@opencode-ai/cli@next`) kept getting pushed toward v1 stable because Omarchy installed aqua `opencode`, re-ran `mise use -g opencode` from the wrapper, and `omarchy update` upgraded the conflicting aqua entry.

## Test plan

- [x] `./test/all`
- [x] `bash test/shell.d/default-agent-test.sh`
- [ ] After merge: on a machine pinned to `npm:@opencode-ai/cli@next`, confirm `mise outdated` no longer reports aqua `opencode` and `c`/`opencode` stay on `next` across `omarchy update`