### PR TITLE
Window VM start then stop, add retry mechanism for RDP connection

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -366,8 +366,34 @@ To stop: omarchy-windows-vm stop"
   fi
   # If scale is less than 130%, don't set any scale (use default 100)
 
-  # Connect with RDP in fullscreen (auto-detects resolution)
-  xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 -grab-keyboard /sound /microphone /clipboard /cert:ignore /title:"Windows VM - Omarchy" /dynamic-resolution /gfx:AVC444 /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
+  # Retry RDP connection: Windows RDP service may need extra time after the VM
+  # reports "started successfully". Retry on connection failure, but stop once
+  # a session connects and the user closes it normally (exit code 0).
+  RDP_MAX_RETRIES=5
+  RDP_RETRY_DELAY=3
+  RDP_ATTEMPT=0
+
+  while (( RDP_ATTEMPT < RDP_MAX_RETRIES )); do
+    (( RDP_ATTEMPT++ ))
+
+    # Connect with RDP in fullscreen (auto-detects resolution)
+    xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 -grab-keyboard /sound /microphone /clipboard /cert:ignore /title:"Windows VM - Omarchy" /dynamic-resolution /gfx:AVC444 /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
+    rdp_exit=$?
+
+    if (( rdp_exit == 0 )); then
+      break
+    fi
+
+    if (( RDP_ATTEMPT < RDP_MAX_RETRIES )); then
+      echo "RDP connection failed (attempt $RDP_ATTEMPT/$RDP_MAX_RETRIES). Retrying in ${RDP_RETRY_DELAY}s..."
+      sleep "$RDP_RETRY_DELAY"
+    else
+      echo ""
+      echo "❌ Failed to connect via RDP after $RDP_MAX_RETRIES attempts."
+      echo "   The VM may still be running. Try connecting manually:"
+      echo "   omarchy-windows-vm launch"
+    fi
+  done
 
   # After RDP closes, stop the container unless --keep-alive was specified
   if [[ $KEEP_ALIVE = "false" ]]; then


### PR DESCRIPTION
Implement retry logic for RDP connection attempts with a maximum of 5 retries and a delay between attempts. 
When start window vm by: omarchy-windows-vm launch , it start but cause dont have keep option then window vm been close: docker-compose -f "$COMPOSE_FILE" down
The issue is that `omarchy-windows-vm launch` tries to connect via RDP immediate...
The problem is a race condition: the script detects "Windows started successfully" in docker logs (meaning QEMU/the guest agent is up), but the Windows RDP service (TermService) needs a few more seconds to start accepting connections. The script then calls xfreerdp3 once, it gets Connection reset by peer, and because there's no -k flag, it immediately tears down the container.

Log before fix: 
  [21:30:29:707] [346568:000549ca] [ERROR][com.freerdp.core.transport] - [transport_read_layer]: BIO_read returned a system error 104: Connection reset by peer
  [21:30:29:707] [346568:000549ca] [ERROR][com.freerdp.core] - [transport_read_layer]: ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]
  [21:30:29:707] [346568:000549ca] [ERROR][com.freerdp.core] - [freerdp_connect]: freerdp_post_connect failed

  RDP session closed. Stopping Windows VM...
  [+] down 2/2
   ✔ Container omarchy-windows Removed
  14.4s
   ✔ Network windows_default   Removed
  0.1s

After fix run success: omarchy-windows-vm launch
Log retry:
[21:39:27:150] [360069:00057e87] [ERROR][com.freerdp.core] - [transport_read_layer]: ERRCONNECT_CONNECT_TRANSPORT_FAILED [0x0002000D]
[21:39:27:150] [360069:00057e87] [ERROR][com.freerdp.core] - [freerdp_connect]: freerdp_post_connect failed
RDP connection failed (attempt 1/5). Retrying in 3s...

Here's the flow:

    Attempt 1 → xfreerdp3 connects
      ├─ Exit 0 (success, user closed RDP window) → break, done ✅
      └─ Non-zero (connection failed) → "Retrying in 3s..." → sleep 3

    Attempt 2 → xfreerdp3 connects
      ├─ Exit 0 → break, done ✅
      └─ Non-zero → "Retrying in 3s..." → sleep 3

    Attempt 3 → ...same pattern...
    Attempt 4 → ...same pattern...

    Attempt 5 → xfreerdp3 connects
      ├─ Exit 0 → break, done ✅
      └─ Non-zero → "❌ Failed after 5 attempts" (gives up)

  ### In plain terms:
  1. Try connecting to Windows via RDP
  2. If it worked (exit code 0 = user connected and later closed the window) → stop, we're done
  3. If it failed (exit code non-zero = connection refused/reset because Windows RDP service isn't ready yet):
      • If we haven't hit 5 attempts yet → print a message, wait 3 seconds, try again
      • If that was the 5th attempt → give up and print an error
  4. The worst case wait is ~15 seconds (5 attempts × 3s delay) before giving up

  This solves the cold-start timing issue where the VM container reports "started successfully" but Windows needs a few more seconds to initialize its RDP service.
