### PR TITLE
feat: allow output volume over-amplification to 150%

### DIFF
--- a/bin/omarchy-audio-output-volume
+++ b/bin/omarchy-audio-output-volume
@@ -6,6 +6,8 @@
 
 action="${1:-}"
 
+max_percent=150
+
 if [[ -z $action ]]; then
   echo "Usage: omarchy-audio-output-volume <raise|lower|mute-toggle|+N|-N>"
   exit 1
@@ -63,7 +65,7 @@ elif [[ $action =~ ^([+-])([0-9]+)$ ]]; then
 
   if [[ $direction == "+" ]]; then
     next=$((current + step))
-    ((next <= 100)) || next=100
+    ((next <= max_percent)) || next=$max_percent
   else
     next=$((current - step))
     ((next >= 0)) || next=0

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -26,6 +26,7 @@ function outputVolumeName(volume, muted) {
   if (muted) return "Muted"
   var p = Math.round(volume * 100)
   if (p === 0) return "Silenced"
+  if (p > 100) return "Overdrive"
   if (p >= 100) return "Concert hall"
   if (p >= 85) return "Party mode"
   if (p >= 70) return "Cranked up"

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -425,7 +425,7 @@ Panel {
 
   function setOutputVolume(v) {
     if (!volumeSink || !volumeSink.audio) return outputVolume
-    var volume = Math.max(0, Math.min(1, v))
+    var volume = Math.max(0, Math.min(1.5, v))
     volumeSink.audio.volume = volume
     return volume
   }
@@ -828,7 +828,7 @@ Panel {
                 anchors.leftMargin: Style.space(6)
                 anchors.rightMargin: Style.space(6)
                 minimum: 0
-                maximum: 1
+                maximum: 1.5
                 step: 0.05
                 value: root.outputVolume
                 opacity: root.outputMuted ? 0.5 : 1.0

--- a/test/shell.d/audio-output-volume-test.sh
+++ b/test/shell.d/audio-output-volume-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/omarchy-audio-output-sink" <<'SH'
+#!/bin/bash
+echo "test-sink"
+SH
+
+cat >"$mock_bin/pactl" <<'SH'
+#!/bin/bash
+case "$1 $2" in
+  "get-sink-volume test-sink")
+    echo "Volume: front-left: 100% / front-right: 100%"
+    ;;
+  "get-sink-mute test-sink")
+    echo "Mute: no"
+    ;;
+  "set-sink-mute test-sink")
+    ;;
+  "set-sink-volume test-sink")
+    echo "$3" >"$OMARCHY_TEST_LAST_VOLUME"
+    ;;
+  *)
+    echo "unexpected pactl call: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+
+cat >"$mock_bin/omarchy-osd" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >"$OMARCHY_TEST_OSD_LOG"
+SH
+
+chmod +x "$mock_bin"/*
+
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+export OMARCHY_TEST_LAST_VOLUME="$test_tmp/last-volume"
+export OMARCHY_TEST_OSD_LOG="$test_tmp/osd-log"
+
+omarchy-audio-output-volume raise
+[[ $(<"$OMARCHY_TEST_LAST_VOLUME") == "105%" ]] ||
+  fail "volume raise steps by five below the cap"
+
+: >"$OMARCHY_TEST_LAST_VOLUME"
+printf 'Volume: front-left: 148%% / front-right: 148%%\n' >"$test_tmp/current-volume"
+cat >"$mock_bin/pactl" <<SH
+#!/bin/bash
+case "\$1 \$2" in
+  "get-sink-volume test-sink")
+    cat "$test_tmp/current-volume"
+    ;;
+  "get-sink-mute test-sink")
+    echo "Mute: no"
+    ;;
+  "set-sink-mute test-sink")
+    ;;
+  "set-sink-volume test-sink")
+    echo "\$3" >"$OMARCHY_TEST_LAST_VOLUME"
+    ;;
+  *)
+    echo "unexpected pactl call: \$*" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$mock_bin/pactl"
+
+omarchy-audio-output-volume +5
+[[ $(<"$OMARCHY_TEST_LAST_VOLUME") == "150%" ]] ||
+  fail "volume raise caps at one hundred fifty percent"
+
+pass "output volume keys allow over-amplification to one hundred fifty percent"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -15,6 +15,7 @@ assert(audio.isAudioSource({ type: 'Audio/Source' }), 'audio detects typed sourc
 
 assertEqual(audio.outputVolumeName(0, false), 'Silenced', 'audio labels silent output')
 assertEqual(audio.outputVolumeName(0.9, false), 'Party mode', 'audio labels loud output')
+assertEqual(audio.outputVolumeName(1.2, false), 'Overdrive', 'audio labels over-amplified output')
 assertEqual(audio.outputVolumeName(0.5, true), 'Muted', 'audio labels muted output')
 
 assertDeepEqual(audio.parseSinkAvailability('alsa_output\t1\nhdmi_output\t0\n'), { alsa_output: true, hdmi_output: false }, 'audio parses sink availability')


### PR DESCRIPTION
## Summary

- Raise the output volume cap from 100% to 150% in `omarchy-audio-output-volume` (volume keys / OSD)
- Match the audio panel slider and keyboard adjustments, which already allowed 150% on per-stream controls but capped the main output at 100%
- Label volumes above 100% as "Overdrive" in the audio panel hero text

## Motivation

PipeWire/PulseAudio allow software amplification above 100%. Omarchy's volume keys and main output slider were capped at 100%, so users who wanted louder output had to override Hyprland bindings and maintain a forked audio panel locally.

## Test plan

- [x] `bash test/shell.d/audio-output-volume-test.sh`
- [x] `bash test/shell.d/audio-test.sh`
- [ ] Volume keys reach 150% and show the OSD percentage above 100
- [ ] Audio panel output slider reaches 150% and shows the Overdrive label above 100%


Made with [Cursor](https://cursor.com)