### PR TITLE
Eliminate shell spawning latency on bar widget clicks

### DIFF
--- a/shell/plugins/bar/widgets/Microphone.qml
+++ b/shell/plugins/bar/widgets/Microphone.qml
@@ -42,8 +42,15 @@ BarWidget {
     active: root.inUse
     tooltipText: root.muted ? "Microphone muted" : (root.inUse ? "Microphone in use" : "Microphone live")
     onPressed: function(b) {
-      if (b === Qt.MiddleButton) root.bar.run("omarchy-shell shell toggle omarchy.audio")
-      else root.toggleMute()
+      if (b === Qt.MiddleButton) {
+        if (root.bar && root.bar.shell && typeof root.bar.shell.toggle === "function") {
+          root.bar.shell.toggle("omarchy.audio")
+        } else if (root.bar) {
+          root.bar.run("omarchy-shell shell toggle omarchy.audio")
+        }
+      } else {
+        root.toggleMute()
+      }
     }
     onWheelMoved: function(delta) {
       if (!root.source || !root.source.audio) return

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -31,8 +31,7 @@ BarWidget {
   }
 
   function focusWorkspace(id) {
-    if (!root.bar) return
-    root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
+    Hyprland.dispatch("hl.dsp.focus({ workspace = \"" + id + "\" })")
   }
 
   readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)

--- a/shell/plugins/menu/BarWidget.qml
+++ b/shell/plugins/menu/BarWidget.qml
@@ -17,8 +17,13 @@ BarWidget {
     horizontalMargin: 7.5
     onPressed: function(button) {
       if (!root.bar) return
-      if (button === Qt.RightButton) root.bar.run("xdg-terminal-exec")
-      else root.bar.run("omarchy-shell shell toggle omarchy.menu '{\"menu\":\"root\"}'")
+      if (button === Qt.RightButton) {
+        root.bar.run("xdg-terminal-exec")
+      } else if (root.bar.shell && typeof root.bar.shell.toggle === "function") {
+        root.bar.shell.toggle("omarchy.menu", JSON.stringify({ menu: "root" }))
+      } else {
+        root.bar.run("omarchy-shell shell toggle omarchy.menu '{\"menu\":\"root\"}'")
+      }
     }
   }
 }

--- a/test/shell.d/bar-fast-dispatch-test.sh
+++ b/test/shell.d/bar-fast-dispatch-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const workspacesSource = fs.readFileSync(root + '/shell/plugins/bar/widgets/Workspaces.qml', 'utf8')
+const menuWidgetSource = fs.readFileSync(root + '/shell/plugins/menu/BarWidget.qml', 'utf8')
+const micWidgetSource = fs.readFileSync(root + '/shell/plugins/bar/widgets/Microphone.qml', 'utf8')
+
+// Workspaces should use Hyprland.dispatch directly instead of shelling out to hyprctl
+assert(
+  /function focusWorkspace\(id\) \{\s*Hyprland\.dispatch\("hl\.dsp\.focus\(\{ workspace = \\"" \+ id \+ "\\" \}\)"\)\s*\}/.test(workspacesSource),
+  'workspaces widget focuses workspaces via direct Hyprland.dispatch'
+)
+assert(
+  !/root\.bar\.run\("hyprctl dispatch/.test(workspacesSource),
+  'workspaces widget does not spawn a shell or hyprctl process to focus workspaces'
+)
+
+// Menu button should toggle in-process via root.bar.shell.toggle when available
+assert(
+  /root\.bar\.shell\.toggle\("omarchy\.menu",\s*JSON\.stringify\(\{\s*menu:\s*"root"\s*\}\)\)/.test(menuWidgetSource),
+  'menu bar widget toggles menu directly in-process via root.bar.shell'
+)
+assert(
+  /root\.bar\.run\("omarchy-shell shell toggle omarchy\.menu/.test(menuWidgetSource),
+  'menu bar widget retains fallback shell toggle when root.bar.shell is unavailable'
+)
+
+// Microphone widget middle click should toggle audio in-process via root.bar.shell.toggle when available
+assert(
+  /root\.bar\.shell\.toggle\("omarchy\.audio"\)/.test(micWidgetSource),
+  'microphone widget toggles audio panel in-process via root.bar.shell'
+)
+assert(
+  /root\.bar\.run\("omarchy-shell shell toggle omarchy\.audio"\)/.test(micWidgetSource),
+  'microphone widget retains fallback shell toggle when root.bar.shell is unavailable'
+)
+JS


### PR DESCRIPTION
Fixes #7093
Credit to @ohai89 for the detailed issue report and initial diagnosis.

### What happened
Clicking workspace pills, the main menu button, or middle-clicking the microphone widget had a noticeable delay (~100ms+) compared to using keybindings. 

This happened because those click actions were routing through `Bar.run()`, which calls `Util.execDetached()`. That spawns `bash -lc` on every click, forcing bash to re-source `/etc/profile` and `~/.bash_profile` every single time, on top of the fork/exec overhead and opening redundant IPC sockets.

### Changes
1. **Workspaces (`Workspaces.qml`)**: switched `focusWorkspace` to use `Hyprland.dispatch(...)` directly. Quickshell already imports `Quickshell.Hyprland` and keeps an open socket connection to Hyprland, so this switches workspaces instantly with no process spawning.
2. **Menu & Mic (`menu/BarWidget.qml`, `Microphone.qml`)**: switched click actions to call `root.bar.shell.toggle(...)` directly in-process instead of running `omarchy-shell shell toggle ...` through bash. Kept the CLI call as a fallback in case `root.bar.shell` is unset.
3. **Why `Util.execDetached` wasn't changed**: I decided against changing `Util.execDetached` globally from `bash -lc` to `bash -c` since external tools or custom user scripts might rely on login shell profiles for `$PATH` and env vars. Internal bar clicks shouldn't be using `execDetached` anyway.

### Testing
Added `test/shell.d/bar-fast-dispatch-test.sh` to verify direct Hyprland dispatch and in-process shell toggles. Tests pass.