### PR TITLE
Add drag-to-arrange monitor layout in Display

### DIFF
--- a/bin/omarchy-hyprland-monitor-layout
+++ b/bin/omarchy-hyprland-monitor-layout
@@ -1,0 +1,386 @@
+#!/bin/bash
+
+# omarchy:summary=Read or apply a snapped Hyprland monitor layout
+# omarchy:args=state|apply '<json>'|place [NAME] <left|right|top|bottom>
+# omarchy:examples=omarchy hyprland monitor layout state | omarchy hyprland monitor layout place right
+
+set -euo pipefail
+
+LAYOUT_START="-- omarchy-layout-managed:start"
+LAYOUT_END="-- omarchy-layout-managed:end"
+
+layout_is_internal() {
+  [[ $1 =~ ^(eDP|LVDS|DSI)- ]]
+}
+
+layout_state_from_hypr() {
+  local hypr_json="$1"
+  local external="$2"
+  local clamshell="$3"
+  jq -c \
+    --argjson external "$external" \
+    --argjson clamshell "$clamshell" '
+      def internal: test("^(eDP|LVDS|DSI)-");
+      {
+        monitors: [.[] | {
+          name,
+          width,
+          height,
+          x,
+          y,
+          scale,
+          refreshRate: (.refreshRate | floor),
+          enabled: (.disabled != true),
+          focused: (.focused == true),
+          internal: (.name | internal)
+        }],
+        externalConnected: $external,
+        clamshell: $clamshell,
+        internalOn: (any(.[]; (.name | internal) and (.disabled != true))),
+        mirrorOn: (any(.[]; .mirrorOf != "none"))
+      }
+    ' <<<"$hypr_json"
+}
+
+layout_is_laptop_only() {
+  local hypr_json="$1"
+  jq -e '
+    def internal: test("^(eDP|LVDS|DSI)-");
+    all(.[]; ((.name | internal) or (.disabled == true)))
+  ' <<<"$hypr_json" >/dev/null
+}
+
+layout_merged_rects() {
+  local hypr_json="$1"
+  local apply_json="$2"
+  jq -c --argjson apply "$apply_json" '
+    def internal: test("^(eDP|LVDS|DSI)-");
+    ($apply.monitors) as $want
+    | [
+        .[]
+        | select(.disabled != true)
+        | . as $live
+        | ($want[] | select(.name == $live.name)) as $pos
+        | {
+            name: $live.name,
+            x: $pos.x,
+            y: $pos.y,
+            w: (($live.width / $live.scale) | floor),
+            h: (($live.height / $live.scale) | floor)
+          }
+      ]
+  ' <<<"$hypr_json"
+}
+
+layout_validate_apply() {
+  local hypr_json="$1"
+  local apply_json="$2"
+  local names missing rects apply_count live_enabled_count rects_count
+
+  if jq -e '(.monitors | length) == 0' <<<"$apply_json" >/dev/null; then
+    echo "unknown" >&2
+    return 1
+  fi
+
+  names=$(jq -r '.[].name' <<<"$hypr_json")
+  missing=$(jq -r --arg names "$names" '
+    .monitors[].name as $n
+    | select(($names | split("\n") | index($n)) == null)
+    | $n
+  ' <<<"$apply_json")
+  if [[ -n $missing ]]; then
+    echo "unknown" >&2
+    return 1
+  fi
+
+  if ! rects=$(layout_merged_rects "$hypr_json" "$apply_json"); then
+    echo "unknown" >&2
+    return 1
+  fi
+
+  apply_count=$(jq '.monitors | length' <<<"$apply_json")
+  live_enabled_count=$(jq '[.[] | select(.disabled != true)] | length' <<<"$hypr_json")
+  rects_count=$(jq 'length' <<<"$rects")
+  if [[ $rects_count != "$apply_count" || $rects_count != "$live_enabled_count" ]]; then
+    echo "unknown" >&2
+    return 1
+  fi
+
+  if jq -e '
+    . as $all
+    | any(
+        range(0; length) as $i
+        | range($i + 1; length) as $j
+        | $all[$i] as $a | $all[$j] as $b
+        | ($a.x < $b.x + $b.w) and ($b.x < $a.x + $a.w)
+          and ($a.y < $b.y + $b.h) and ($b.y < $a.y + $a.h)
+      )
+  ' <<<"$rects" >/dev/null; then
+    echo "overlap" >&2
+    return 1
+  fi
+
+  if ! jq -e '
+    def edge($a; $b):
+      (($a.x + $a.w == $b.x) or ($b.x + $b.w == $a.x))
+        and ($a.y < $b.y + $b.h) and ($b.y < $a.y + $a.h)
+      or (($a.y + $a.h == $b.y) or ($b.y + $b.h == $a.y))
+        and ($a.x < $b.x + $b.w) and ($b.x < $a.x + $a.w);
+    def neighbors:
+      . as $all
+      | [ range(0; length) as $i | [
+            range(0; length) as $j
+            | select($i != $j and edge($all[$i]; $all[$j]))
+            | $j
+          ] ];
+    if length <= 1 then true else
+      (neighbors) as $n
+      | {q:[0], seen:{ "0": true }}
+      | until((.q | length) == 0;
+          .q[0] as $i
+          | .q = .q[1:]
+          | reduce ($n[$i][]) as $j
+              (.; if .seen[$j|tostring] then . else .seen[$j|tostring] = true | .q += [$j] end)
+        )
+      | (.seen | length) == ($n | length)
+    end
+  ' <<<"$rects" >/dev/null; then
+    echo "disconnected" >&2
+    return 1
+  fi
+}
+
+layout_keyword_lines() {
+  local hypr_json="$1"
+  local apply_json="$2"
+  jq -r --argjson apply "$apply_json" '
+    . as $live
+    | $apply.monitors[]
+    | . as $pos
+    | ($live[] | select(.name == $pos.name)) as $m
+    | "\($m.name),\($m.width)x\($m.height)@\($m.refreshRate | floor),\($pos.x)x\($pos.y),\($m.scale)"
+  ' <<<"$hypr_json"
+}
+
+layout_managed_block() {
+  local hypr_json="$1"
+  local apply_json="$2"
+  {
+    printf '%s\n' "$LAYOUT_START"
+    jq -r --argjson apply "$apply_json" '
+      . as $live
+      | $apply.monitors[]
+      | . as $pos
+      | ($live[] | select(.name == $pos.name)) as $m
+      | "hl.monitor({ output = \"\($m.name)\", mode = \"\($m.width)x\($m.height)@\($m.refreshRate | floor)\", position = \"\($pos.x)x\($pos.y)\", scale = \($m.scale) })"
+    ' <<<"$hypr_json"
+    jq -r --argjson apply "$apply_json" '
+      .[]
+      | select(.disabled == true)
+      | "hl.monitor({ output = \"\(.name)\", disabled = true })"
+    ' <<<"$hypr_json"
+    printf '%s\n' "$LAYOUT_END"
+  }
+}
+
+layout_patch_lua() {
+  local src="$1"
+  local block="$2"
+  if grep -q -F -e "$LAYOUT_START" <<<"$src"; then
+    awk -v start="$LAYOUT_START" -v end="$LAYOUT_END" -v block="$block" '
+      $0 == start { lines[n++] = block; skip = 1; next }
+      skip && $0 == end { skip = 0; next }
+      !skip { lines[n++] = $0 }
+      END {
+        if (skip) exit 1
+        for (i = 0; i < n; i++) print lines[i]
+      }
+    ' <<<"$src"
+  else
+    printf '%s\n\n%s\n' "$src" "$block"
+  fi
+}
+
+layout_place_json() {
+  local hypr_json="$1"
+  local name="$2"
+  local side="$3"
+  jq -ce --arg name "$name" --arg side "$side" '
+    def lw: ((.width / .scale) | floor);
+    def lh: ((.height / .scale) | floor);
+    [.[] | select(.disabled != true)] as $en
+    | ($en | map(select(.name == $name))[0]) as $m
+    | ($en | map(select(.name != $name))[0]) as $o
+    | if $m == null or $o == null then error("unknown") else . end
+    | ($m | lw) as $mw
+    | ($m | lh) as $mh
+    | ($o | lw) as $ow
+    | ($o | lh) as $oh
+    | (if $side == "right" then {x: ($o.x + $ow), y: $o.y}
+       elif $side == "left" then {x: ($o.x - $mw), y: $o.y}
+       elif $side == "bottom" then {x: $o.x, y: ($o.y + $oh)}
+       elif $side == "top" then {x: $o.x, y: ($o.y - $mh)}
+       else error("unknown") end) as $pos
+    | { monitors: [ $en[] | {
+          name,
+          x: (if .name == $name then $pos.x else .x end),
+          y: (if .name == $name then $pos.y else .y end)
+        } ] }
+  ' <<<"$hypr_json"
+}
+
+layout_read_hypr() {
+  if [[ -n ${OMARCHY_MONITOR_LAYOUT_MONITORS_JSON:-} ]]; then
+    cat "$OMARCHY_MONITOR_LAYOUT_MONITORS_JSON"
+    return
+  fi
+  hyprctl monitors all -j
+}
+
+layout_read_external() {
+  if [[ -n ${OMARCHY_MONITOR_LAYOUT_EXTERNAL:-} ]]; then
+    printf '%s' "$OMARCHY_MONITOR_LAYOUT_EXTERNAL"
+    return
+  fi
+  if omarchy-hw-external-monitors >/dev/null 2>&1; then
+    echo true
+  else
+    echo false
+  fi
+}
+
+layout_read_clamshell() {
+  if [[ -n ${OMARCHY_MONITOR_LAYOUT_CLAMSHELL:-} ]]; then
+    printf '%s' "$OMARCHY_MONITOR_LAYOUT_CLAMSHELL"
+    return
+  fi
+  if omarchy-hw-clamshell >/dev/null 2>&1; then
+    echo true
+  else
+    echo false
+  fi
+}
+
+layout_print_state() {
+  layout_state_from_hypr "$(layout_read_hypr)" "$(layout_read_external)" "$(layout_read_clamshell)"
+}
+
+layout_lua_path() {
+  printf '%s' "${OMARCHY_MONITOR_LAYOUT_LUA_PATH:-$HOME/.config/hypr/monitors.lua}"
+}
+
+layout_cmd_state() {
+  layout_print_state
+}
+
+layout_cmd_apply() {
+  local apply_json="$1"
+  local hypr_json err
+  hypr_json=$(layout_read_hypr)
+
+  if layout_is_laptop_only "$hypr_json"; then
+    layout_print_state
+    return 0
+  fi
+
+  if ! err=$(layout_validate_apply "$hypr_json" "$apply_json" 2>&1); then
+    echo "$err" >&2
+    layout_print_state
+    return 1
+  fi
+
+  if [[ ${OMARCHY_MONITOR_LAYOUT_DRY_RUN:-0} == 1 ]]; then
+    jq -nc --arg lines "$(layout_keyword_lines "$hypr_json" "$apply_json")" --arg block "$(layout_managed_block "$hypr_json" "$apply_json")" '
+      { keywords: ($lines | split("\n") | map(select(length > 0))), block: $block }
+    '
+    return 0
+  fi
+
+  if [[ ${OMARCHY_MONITOR_LAYOUT_WRITE_ONLY:-0} != 1 ]]; then
+    while IFS= read -r spec; do
+      hyprctl keyword monitor "$spec" >/dev/null
+    done < <(layout_keyword_lines "$hypr_json" "$apply_json")
+  fi
+
+  local lua_path patched
+  lua_path=$(layout_lua_path)
+  if ! patched=$(layout_patch_lua "$(cat "$lua_path")" "$(layout_managed_block "$hypr_json" "$apply_json")"); then
+    echo "unknown" >&2
+    return 1
+  fi
+
+  local bak ts i
+  ts=$(date +%s)
+  bak="${lua_path}.bak.$ts"
+  i=0
+  while [[ -e $bak ]]; do
+    i=$((i + 1))
+    bak="${lua_path}.bak.${ts}.$i"
+  done
+  cp "$lua_path" "$bak"
+
+  local tmp
+  tmp=$(mktemp "${lua_path}.tmp.XXXXXX")
+  printf '%s\n' "$patched" >"$tmp"
+  chmod --reference="$lua_path" "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$lua_path"
+
+  if [[ ${OMARCHY_MONITOR_LAYOUT_WRITE_ONLY:-0} == 1 ]]; then
+    layout_print_state
+    return 0
+  fi
+
+  hyprctl reload >/dev/null
+  local errors
+  errors=$(hyprctl configerrors)
+  if [[ -n $errors ]]; then
+    echo "$errors" >&2
+    return 1
+  fi
+  layout_print_state
+}
+
+layout_cmd_place() {
+  local hypr_json name side apply_json
+  hypr_json=$(layout_read_hypr)
+  if [[ $# -eq 1 ]]; then
+    side=$1
+    name=$(jq -r '.[] | select(.disabled != true and ((.name | test("^(eDP|LVDS|DSI)-")) | not)) | .name' <<<"$hypr_json" | head -n 1)
+  else
+    name=$1
+    side=$2
+  fi
+  if [[ -z $name || -z $side ]]; then
+    echo "usage: omarchy-hyprland-monitor-layout place [NAME] <left|right|top|bottom>" >&2
+    exit 2
+  fi
+  if ! apply_json=$(layout_place_json "$hypr_json" "$name" "$side"); then
+    echo "unknown" >&2
+    layout_print_state
+    return 1
+  fi
+  layout_cmd_apply "$apply_json"
+}
+
+if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
+  return 0
+fi
+
+case "${1:-}" in
+  state) layout_cmd_state ;;
+  apply)
+    if [[ -z ${2:-} ]]; then
+      echo "usage: omarchy-hyprland-monitor-layout apply '<json>'" >&2
+      exit 2
+    fi
+    layout_cmd_apply "$2"
+    ;;
+  place)
+    shift
+    layout_cmd_place "$@"
+    ;;
+  *)
+    echo "usage: omarchy-hyprland-monitor-layout state|apply '<json>'|place [NAME] <left|right|top|bottom>" >&2
+    exit 2
+    ;;
+esac

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -111,6 +111,80 @@ function parseDisplays(raw) {
   }
 }
 
+function layoutSize(width, height, scale) {
+  var s = Number(scale)
+  if (!isFinite(s) || s <= 0) s = 1
+  return {
+    w: Math.floor(Number(width) / s),
+    h: Math.floor(Number(height) / s)
+  }
+}
+
+function snapPosition(moved, others) {
+  return snapWindows(moved, others)
+}
+
+function snapWindows(moved, others, prefer) {
+  function clamp(v, a, b) {
+    if (a > b) return Math.round((a + b) / 2)
+    if (v < a) return a
+    if (v > b) return b
+    return v
+  }
+
+  function sideFor(o) {
+    var cx = moved.x + moved.w / 2
+    var cy = moved.y + moved.h / 2
+    var left = o.x
+    var right = o.x + o.w
+    var top = o.y
+    var bottom = o.y + o.h
+    var outLeft = Math.max(0, left - cx)
+    var outRight = Math.max(0, cx - right)
+    var outTop = Math.max(0, top - cy)
+    var outBottom = Math.max(0, cy - bottom)
+    var outX = Math.max(outLeft, outRight)
+    var outY = Math.max(outTop, outBottom)
+    if (prefer === "vertical") return outTop > 0 || (outY === 0 && (cy - top) < (bottom - cy)) ? "top" : "bottom"
+    if (prefer === "horizontal") return outLeft > 0 || (outX === 0 && (cx - left) < (right - cx)) ? "left" : "right"
+    if (outY > outX) return outTop > 0 ? "top" : "bottom"
+    if (outX > outY) return outLeft > 0 ? "left" : "right"
+    var distLeft = cx - left
+    var distRight = right - cx
+    var distTop = cy - top
+    var distBottom = bottom - cy
+    var nearest = Math.min(distLeft, distRight, distTop, distBottom)
+    if (nearest === distBottom) return "bottom"
+    if (nearest === distTop) return "top"
+    if (nearest === distLeft) return "left"
+    return "right"
+  }
+
+  var best = null
+  var bestDist = Infinity
+  var overlap = 48
+  for (var i = 0; i < others.length; i++) {
+    var o = others[i]
+    var minY = o.y + overlap - moved.h
+    var maxY = o.y + o.h - overlap
+    var minX = o.x + overlap - moved.w
+    var maxX = o.x + o.w - overlap
+    var side = sideFor(o)
+    var c = side === "right" ? { side: "right", x: o.x + o.w, y: clamp(moved.y, minY, maxY) }
+      : side === "left" ? { side: "left", x: o.x - moved.w, y: clamp(moved.y, minY, maxY) }
+      : side === "bottom" ? { side: "bottom", x: clamp(moved.x, minX, maxX), y: o.y + o.h }
+      : { side: "top", x: clamp(moved.x, minX, maxX), y: o.y - moved.h }
+    var dx = c.x - moved.x
+    var dy = c.y - moved.y
+    var dist = dx * dx + dy * dy
+    if (dist < bestDist) {
+      bestDist = dist
+      best = c
+    }
+  }
+  return best
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -119,6 +193,9 @@ if (typeof module !== "undefined") {
     matchingScaleIndex: matchingScaleIndex,
     availableScales: availableScales,
     brightnessName: brightnessName,
-    parseDisplays: parseDisplays
+    parseDisplays: parseDisplays,
+    layoutSize: layoutSize,
+    snapPosition: snapPosition,
+    snapWindows: snapWindows
   }
 }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -26,6 +26,18 @@ Panel {
   property string monitorScale: ""
   property var displays: []
   property int enabledDisplayCount: 0
+  property var layoutMonitors: []
+  property bool externalConnected: false
+  property bool clamshell: false
+  property bool internalOn: false
+  property bool mirrorOn: false
+  property string layoutError: ""
+  property bool layoutReady: false
+  property bool layoutReadOnly: false
+  property bool keepLayoutError: false
+  property bool dragging: false
+  property string placeTarget: ""
+  readonly property string layoutHelper: "omarchy-hyprland-monitor-layout"
 
   // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
@@ -37,8 +49,6 @@ Panel {
   //   "scale"      - 6 Button scale presets; treated as a single
   //                  horizontal row from j/k's perspective. h/l moves
   //                  between presets, identical to bluetooth's header.
-  //   "monitors"   - vertical display row list for enabling/disabling displays;
-  //                  j/k walks each row.
   // Mouse hover on a target updates root state via the components' `hovered`
   // signal so keyboard cursor and pointer share one highlight.
   readonly property var scalePresets: ["1", "1.25", "1.6", "2", "3", "4"]
@@ -77,7 +87,6 @@ Panel {
     if (brightnessAvailable) list.push("brightness")
     list.push("textsize")
     list.push("scale")
-    if (displays.length > 1) list.push("monitors")
     return list
   }
 
@@ -85,7 +94,6 @@ Panel {
     if (section === "brightness") return 0  // only the slider sentinel at -1
     if (section === "textsize") return 0    // slider sentinel at -1, like brightness
     if (section === "scale") return scaleValues.length
-    if (section === "monitors") return displays.length
     return 0
   }
 
@@ -150,10 +158,6 @@ Panel {
     if (focusSection === "scale" && selectedIndex >= 0 && selectedIndex < scaleValues.length) {
       setScale(scaleValues[selectedIndex])
       return
-    }
-    if (focusSection === "monitors" && selectedIndex >= 0 && selectedIndex < displays.length) {
-      var d = displays[selectedIndex]
-      if (d) toggleDisplay(d.name, d.enabled)
     }
     // brightness: no separate action; the slider value is the action.
   }
@@ -231,6 +235,183 @@ Panel {
 
   function refresh() {
     if (!stateProc.running) stateProc.running = true
+    refreshLayout()
+  }
+
+  function refreshLayout() {
+    if (root.dragging) return
+    if (!layoutProc.running) layoutProc.running = true
+  }
+
+  function applyLayoutFlags(obj) {
+    root.layoutMonitors = obj.monitors || []
+    root.externalConnected = obj.externalConnected === true
+    root.clamshell = obj.clamshell === true
+    root.internalOn = obj.internalOn === true
+    root.mirrorOn = obj.mirrorOn === true
+    root.layoutReady = true
+    root.layoutReadOnly = false
+    if (root.keepLayoutError)
+      root.keepLayoutError = false
+    else
+      root.layoutError = ""
+  }
+
+  function runStock(bin, action) {
+    actionProc.command = [bin, action]
+    if (!actionProc.running) actionProc.running = true
+  }
+
+  function enabledLayoutMonitors() {
+    var out = []
+    for (var i = 0; i < layoutMonitors.length; i++) {
+      if (layoutMonitors[i] && layoutMonitors[i].enabled) out.push(layoutMonitors[i])
+    }
+    return out
+  }
+
+  function disabledLayoutMonitors() {
+    var out = []
+    for (var i = 0; i < layoutMonitors.length; i++) {
+      if (layoutMonitors[i] && !layoutMonitors[i].enabled) out.push(layoutMonitors[i])
+    }
+    return out
+  }
+
+  function toRect(m) {
+    var size = Model.layoutSize(m.width, m.height, m.scale)
+    return { name: m.name, x: m.x, y: m.y, w: size.w, h: size.h }
+  }
+
+  function canvasItems() {
+    var enabled = enabledLayoutMonitors()
+    var items = []
+    for (var i = 0; i < enabled.length; i++) {
+      var m = enabled[i]
+      var size = Model.layoutSize(m.width, m.height, m.scale)
+      items.push({
+        output: m.name,
+        posX: m.x,
+        posY: m.y,
+        layoutW: size.w,
+        layoutH: size.h,
+        modeW: m.width,
+        modeH: m.height,
+        scaleLabel: m.scale,
+        focused: m.focused === true
+      })
+    }
+    return items
+  }
+
+  function arrangementSide() {
+    var list = canvasItems()
+    if (list.length < 2) return ""
+    var moved = null
+    var other = null
+    var i
+    if (root.placeTarget) {
+      for (i = 0; i < list.length; i++) {
+        if (list[i].output === root.placeTarget) moved = list[i]
+        else if (!other) other = list[i]
+      }
+    }
+    if (!moved) {
+      moved = list[0]
+      other = list[1]
+    }
+    if (!other) {
+      for (i = 0; i < list.length; i++) {
+        if (list[i].output !== moved.output) {
+          other = list[i]
+          break
+        }
+      }
+    }
+    if (!moved || !other) return ""
+    var cx = moved.posX + moved.layoutW / 2
+    var cy = moved.posY + moved.layoutH / 2
+    if (cy >= other.posY + other.layoutH) return "bottom"
+    if (cy <= other.posY) return "top"
+    if (cx >= other.posX + other.layoutW) return "right"
+    if (cx <= other.posX) return "left"
+    return ""
+  }
+
+  function sideCaption(side) {
+    if (side === "left") return "LEFT"
+    if (side === "right") return "RIGHT"
+    if (side === "top") return "ABOVE"
+    if (side === "bottom") return "BELOW"
+    return ""
+  }
+
+  function commitDrag(name, x, y) {
+    var enabled = enabledLayoutMonitors()
+    if (enabled.length <= 1 || root.layoutReadOnly) {
+      root.dragging = false
+      return
+    }
+    var moved = null
+    var current = null
+    var others = []
+    for (var i = 0; i < enabled.length; i++) {
+      var r = toRect(enabled[i])
+      if (enabled[i].name === name) {
+        current = { x: r.x, y: r.y }
+        r.x = x
+        r.y = y
+        moved = r
+      } else {
+        others.push(r)
+      }
+    }
+    if (!moved || !others.length) {
+      root.dragging = false
+      return
+    }
+    var snapped = Model.snapWindows(moved, others)
+    if (!snapped || (current && snapped.x === current.x && snapped.y === current.y)) {
+      root.dragging = false
+      return
+    }
+    applySnapped(name, snapped.x, snapped.y)
+  }
+
+  function applySnapped(name, x, y) {
+    var next = []
+    var payload = { monitors: [] }
+    for (var j = 0; j < layoutMonitors.length; j++) {
+      var item = layoutMonitors[j]
+      var nx = item.name === name ? x : item.x
+      var ny = item.name === name ? y : item.y
+      next.push({
+        name: item.name,
+        width: item.width,
+        height: item.height,
+        x: nx,
+        y: ny,
+        scale: item.scale,
+        refreshRate: item.refreshRate,
+        enabled: item.enabled,
+        focused: item.focused,
+        internal: item.internal
+      })
+      if (item.enabled)
+        payload.monitors.push({ name: item.name, x: nx, y: ny })
+    }
+    root.layoutMonitors = next
+    applyLayoutProc.running = false
+    applyLayoutProc.command = [root.layoutHelper, "apply", JSON.stringify(payload)]
+    applyLayoutProc.running = true
+  }
+
+  function placeBeside(side) {
+    var args = [root.layoutHelper, "place"]
+    if (root.placeTarget) args.push(root.placeTarget)
+    args.push(side)
+    applyLayoutProc.command = args
+    if (!applyLayoutProc.running) applyLayoutProc.running = true
   }
 
   function setBrightness(value) {
@@ -349,7 +530,10 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  Component.onCompleted: refresh()
+  Component.onCompleted: {
+    refresh()
+    layoutMissingCheck.start()
+  }
 
   // KeyboardPanel primes focus at open-time, so SUPER-bound IPC summons land
   // with j/k ready to navigate. Keep a default landing point, but don't paint
@@ -380,7 +564,79 @@ Panel {
     interval: 5000
     running: root.opened
     repeat: true
-    onTriggered: root.refresh()
+    onTriggered: {
+      root.refresh()
+      root.refreshLayout()
+    }
+  }
+
+  Timer {
+    id: layoutMissingCheck
+    interval: 200
+    repeat: false
+    onTriggered: {
+      if (!root.layoutReady && root.layoutError === "") {
+        root.layoutError = "layout helper missing"
+        root.layoutReadOnly = true
+      }
+    }
+  }
+
+  Process {
+    id: layoutProc
+    command: [root.layoutHelper, "state"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        try {
+          root.applyLayoutFlags(JSON.parse(String(text || "{}")))
+        } catch (e) {
+          root.layoutError = "layout helper failed"
+          root.layoutReadOnly = true
+        }
+      }
+    }
+    onExited: function(code) {
+      if (code !== 0 && !root.layoutReady) {
+        root.layoutError = "layout helper missing"
+        root.layoutReadOnly = true
+      }
+    }
+  }
+
+  Process {
+    id: applyLayoutProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        try {
+          var obj = JSON.parse(String(text || "{}"))
+          if (obj.monitors) root.applyLayoutFlags(obj)
+        } catch (e) {
+          if (!root.layoutError)
+            root.layoutError = "layout helper failed"
+          root.keepLayoutError = true
+          root.refreshLayout()
+        }
+      }
+    }
+    stderr: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var err = String(text || "").trim()
+        if (err) {
+          root.layoutError = err
+          root.keepLayoutError = true
+        }
+      }
+    }
+    onExited: function(code) {
+      root.dragging = false
+      if (code !== 0) {
+        root.keepLayoutError = true
+        root.refreshLayout()
+      }
+    }
   }
 
   Process {
@@ -488,7 +744,7 @@ Panel {
     bar: root.bar
     open: root.opened
     focusTarget: keyCatcher
-    contentWidth: panel.fittedContentWidth(Style.space(380))
+    contentWidth: panel.fittedContentWidth(Style.space(Quickshell.screens.length > 1 ? 520 : 380))
     contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(560))
 
     PanelKeyCatcher {
@@ -516,7 +772,7 @@ Panel {
         Binding {
           target: scrollArea.contentItem
           property: "interactive"
-          value: panelColumn.implicitHeight > scrollArea.height
+          value: panelColumn.implicitHeight > scrollArea.height && !root.dragging
         }
 
         Column {
@@ -785,33 +1041,206 @@ Panel {
             }
           }
 
-          // ---------- Monitors ----------
           PanelSeparator {
-            visible: root.displays.length > 1
             foreground: root.bar.foreground
           }
 
-          Column {
+          Text {
+            visible: root.layoutError !== ""
             width: parent.width
-            spacing: Style.space(10)
-            visible: root.displays.length > 1
+            text: root.layoutError
+            color: root.bar.foreground
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.Wrap
+          }
 
-            PanelSectionHeader {
-              text: "DISPLAYS"
-              foreground: root.bar.foreground
-              fontFamily: root.bar.fontFamily
+          Row {
+            width: parent.width
+            spacing: Style.space(6)
+
+            StatusChip {
+              label: root.externalConnected ? "EXT · connected" : "EXT · none"
+              clickable: false
             }
+            StatusChip {
+              label: root.clamshell ? "CLAM · on" : "CLAM · off"
+              clickable: false
+            }
+            StatusChip {
+              label: root.internalOn ? "INT · on" : "INT · off"
+              clickable: true
+              onActivated: root.runStock("omarchy-hyprland-monitor-internal", "toggle")
+            }
+            StatusChip {
+              label: root.mirrorOn ? "MIRROR · on" : "MIRROR · off"
+              clickable: true
+              onActivated: root.runStock("omarchy-hyprland-monitor-internal-mirror", "toggle")
+            }
+          }
+
+          Text {
+            width: parent.width
+            visible: canvasHost.canvasList.length > 1
+            text: root.sideCaption(root.arrangementSide())
+            color: Qt.darker(root.bar.foreground, 1.4)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+          }
+
+          Text {
+            width: parent.width
+            visible: Quickshell.screens.length > 1
+            text: "Drag a display to rearrange"
+            color: Qt.darker(root.bar.foreground, 1.4)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+          }
+
+          Item {
+            id: canvasHost
+            width: parent.width
+            height: Style.space(280)
+            clip: true
+            readonly property var canvasList: root.canvasItems()
+            readonly property var bounds: {
+              var list = canvasList
+              if (!list.length) return { x: 0, y: 0, w: 1, h: 1 }
+              var minX = 1e9, minY = 1e9, maxX = -1e9, maxY = -1e9
+              var padX = 0
+              var padY = 0
+              for (var i = 0; i < list.length; i++) {
+                var r = list[i]
+                if (r.posX < minX) minX = r.posX
+                if (r.posY < minY) minY = r.posY
+                if (r.posX + r.layoutW > maxX) maxX = r.posX + r.layoutW
+                if (r.posY + r.layoutH > maxY) maxY = r.posY + r.layoutH
+                if (r.layoutW > padX) padX = r.layoutW
+                if (r.layoutH > padY) padY = r.layoutH
+              }
+              padX = Math.round(padX * 0.55)
+              padY = Math.round(padY * 0.55)
+              return { x: minX - padX, y: minY - padY, w: Math.max(1, maxX - minX + padX * 2), h: Math.max(1, maxY - minY + padY * 2) }
+            }
+            readonly property real fit: Math.min(width / bounds.w, height / bounds.h) * 0.92
 
             Repeater {
-              model: root.displays
-
-              MonitorRow {
-                required property var modelData
+              model: canvasHost.canvasList.length
+              CursorSurface {
+                id: tile
                 required property int index
+                readonly property var mon: canvasHost.canvasList[index]
+                readonly property real baseX: mon ? (mon.posX - canvasHost.bounds.x) * canvasHost.fit + (canvasHost.width - canvasHost.bounds.w * canvasHost.fit) / 2 : 0
+                readonly property real baseY: mon ? (mon.posY - canvasHost.bounds.y) * canvasHost.fit + (canvasHost.height - canvasHost.bounds.h * canvasHost.fit) / 2 : 0
+                property real dragDx: 0
+                property real dragDy: 0
 
-                width: panelColumn.width
-                display: modelData
-                rowIndex: index
+                width: mon ? mon.layoutW * canvasHost.fit : 0
+                height: mon ? mon.layoutH * canvasHost.fit : 0
+                x: baseX + (drag.active ? drag.translation.x : 0)
+                y: baseY + (drag.active ? drag.translation.y : 0)
+                visible: !!mon
+                foreground: root.bar.foreground
+                fill: Style.hoverFillFor(root.bar.foreground, Color.accent)
+                currentFill: Style.selectedFillFor(root.bar.foreground, Color.accent)
+                current: !!mon && (mon.focused || root.placeTarget === mon.output)
+                hasCursor: drag.active
+                bordered: true
+
+                Column {
+                  anchors.centerIn: parent
+                  spacing: Style.space(2)
+                  width: Math.max(0, parent.width - Style.space(12))
+
+                  Text {
+                    text: String(tile.index + 1)
+                    color: root.bar.foreground
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.title
+                    font.bold: true
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                  }
+
+                  Text {
+                    text: tile.mon ? tile.mon.output : ""
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.caption
+                    font.bold: true
+                    font.letterSpacing: 1.2
+                    elide: Text.ElideRight
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                  }
+                }
+
+                DragHandler {
+                  id: drag
+                  enabled: canvasHost.canvasList.length > 1 && !root.layoutReadOnly && !!tile.mon
+                  target: null
+                  acceptedButtons: Qt.LeftButton
+                  grabPermissions: PointerHandler.CanTakeOverFromAnything
+                  onTranslationChanged: {
+                    if (!active) return
+                    tile.dragDx = translation.x
+                    tile.dragDy = translation.y
+                  }
+                  onActiveChanged: {
+                    if (!tile.mon) return
+                    if (active) {
+                      tile.dragDx = 0
+                      tile.dragDy = 0
+                      root.dragging = true
+                      root.placeTarget = tile.mon.output
+                      return
+                    }
+                    var dx = tile.dragDx
+                    var dy = tile.dragDy
+                    if (dx === 0 && dy === 0) {
+                      dx = translation.x
+                      dy = translation.y
+                    }
+                    var layoutX = tile.mon.posX + dx / canvasHost.fit
+                    var layoutY = tile.mon.posY + dy / canvasHost.fit
+                    root.commitDrag(tile.mon.output, Math.round(layoutX), Math.round(layoutY))
+                  }
+                }
+
+                TapHandler {
+                  enabled: !!tile.mon
+                  acceptedButtons: Qt.LeftButton
+                  onTapped: if (tile.mon) root.placeTarget = tile.mon.output
+                }
+              }
+            }
+          }
+
+          Row {
+            visible: Quickshell.screens.length > 1
+            width: parent.width
+            spacing: Style.space(6)
+
+            StatusChip { label: "LEFT"; clickable: true; onActivated: root.placeBeside("left") }
+            StatusChip { label: "RIGHT"; clickable: true; onActivated: root.placeBeside("right") }
+            StatusChip { label: "ABOVE"; clickable: true; onActivated: root.placeBeside("top") }
+            StatusChip { label: "BELOW"; clickable: true; onActivated: root.placeBeside("bottom") }
+          }
+
+          Row {
+            visible: root.disabledLayoutMonitors().length > 0
+            width: parent.width
+            spacing: Style.space(6)
+            Repeater {
+              model: root.disabledLayoutMonitors()
+              Text {
+                required property var modelData
+                text: modelData.name + " · off"
+                opacity: 0.45
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.caption
               }
             }
           }
@@ -850,73 +1279,20 @@ Panel {
     }
   }
 
-  component MonitorRow: CursorSurface {
-    id: monitorRow
-    required property var display
-    required property int rowIndex
-
-    readonly property bool isFocused: display && display.focused
-    readonly property bool canToggle: display && (!display.enabled || root.enabledDisplayCount > 1)
-
-    hasCursor: root.cursorActive && root.focusSection === "monitors" && root.selectedIndex === rowIndex
-    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(monitorRow)
-    current: isFocused
+  component StatusChip: Button {
+    id: chip
+    required property string label
+    property bool clickable: false
+    property bool on: false
+    signal activated()
+    text: chip.label
+    fontSize: Style.font.caption
     foreground: root.bar.foreground
-    fill: Style.hoverFillFor(root.bar.foreground, Color.accent)
-    currentFill: Style.selectedFillFor(root.bar.foreground, Color.accent)
-    implicitHeight: monitorInner.implicitHeight + Style.spacing.xl
-    opacity: canToggle ? 1.0 : 0.45
-
-    Row {
-      id: monitorInner
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.verticalCenter: parent.verticalCenter
-      anchors.leftMargin: Style.space(6)
-      anchors.rightMargin: Style.space(6)
-      spacing: Style.space(8)
-
-      Text {
-        text: "󰍹"
-        color: root.bar.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.title
-        width: Style.space(22)
-        horizontalAlignment: Text.AlignHCenter
-        anchors.verticalCenter: parent.verticalCenter
-      }
-
-      Text {
-        text: monitorRow.display.name + (monitorRow.display.focused ? " · focused" : "")
-        color: root.bar.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.body
-        elide: Text.ElideRight
-        width: parent.width - Style.space(22) - Style.space(14) - Style.space(16)
-        anchors.verticalCenter: parent.verticalCenter
-      }
-
-      Text {
-        text: monitorRow.display.enabled ? "󰄬" : ""
-        color: root.bar.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.subtitle
-        width: Style.space(14)
-        horizontalAlignment: Text.AlignRight
-        anchors.verticalCenter: parent.verticalCenter
-      }
-    }
-
-    MouseArea {
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: monitorRow.canToggle ? Qt.PointingHandCursor : Qt.ArrowCursor
-      onContainsMouseChanged: if (containsMouse && !root.reflowingText) {
-        root.cursorActive = true
-        root.focusSection = "monitors"
-        root.selectedIndex = monitorRow.rowIndex
-      }
-      onClicked: if (monitorRow.canToggle) root.toggleDisplay(monitorRow.display.name, monitorRow.display.enabled)
-    }
+    fontFamily: root.bar.fontFamily
+    horizontalPadding: Style.spacing.sm
+    verticalPadding: Style.spacing.controlPaddingY
+    bordered: true
+    active: chip.on
+    onClicked: if (chip.clickable) chip.activated()
   }
 }

--- a/test/shell.d/fixtures/monitor-layout/hypr-disabled.json
+++ b/test/shell.d/fixtures/monitor-layout/hypr-disabled.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "eDP-2",
+    "width": 2560,
+    "height": 1600,
+    "refreshRate": 165.002,
+    "x": 0,
+    "y": 0,
+    "scale": 2,
+    "focused": true,
+    "disabled": false,
+    "mirrorOf": "none"
+  },
+  {
+    "name": "HDMI-A-1",
+    "width": 1920,
+    "height": 1080,
+    "refreshRate": 60.0,
+    "x": 0,
+    "y": 0,
+    "scale": 1,
+    "focused": false,
+    "disabled": true,
+    "mirrorOf": "none"
+  }
+]

--- a/test/shell.d/fixtures/monitor-layout/hypr-laptop-external.json
+++ b/test/shell.d/fixtures/monitor-layout/hypr-laptop-external.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "eDP-2",
+    "width": 2560,
+    "height": 1600,
+    "refreshRate": 165.002,
+    "x": 0,
+    "y": 0,
+    "scale": 2,
+    "focused": true,
+    "disabled": false,
+    "mirrorOf": "none"
+  },
+  {
+    "name": "DP-1",
+    "width": 2560,
+    "height": 1440,
+    "refreshRate": 144.0,
+    "x": 1280,
+    "y": 0,
+    "scale": 1,
+    "focused": false,
+    "disabled": false,
+    "mirrorOf": "none"
+  }
+]

--- a/test/shell.d/fixtures/monitor-layout/hypr-laptop-only.json
+++ b/test/shell.d/fixtures/monitor-layout/hypr-laptop-only.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "eDP-2",
+    "width": 2560,
+    "height": 1600,
+    "refreshRate": 165.002,
+    "x": 0,
+    "y": 0,
+    "scale": 2,
+    "focused": true,
+    "disabled": false,
+    "mirrorOf": "none"
+  }
+]

--- a/test/shell.d/fixtures/monitor-layout/hypr-mirror.json
+++ b/test/shell.d/fixtures/monitor-layout/hypr-mirror.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "eDP-2",
+    "width": 2560,
+    "height": 1600,
+    "refreshRate": 165.002,
+    "x": 0,
+    "y": 0,
+    "scale": 2,
+    "focused": true,
+    "disabled": false,
+    "mirrorOf": "none"
+  },
+  {
+    "name": "DP-1",
+    "width": 2560,
+    "height": 1440,
+    "refreshRate": 144.0,
+    "x": 0,
+    "y": 0,
+    "scale": 1,
+    "focused": false,
+    "disabled": false,
+    "mirrorOf": "eDP-2"
+  }
+]

--- a/test/shell.d/fixtures/monitor-layout/monitors.lua
+++ b/test/shell.d/fixtures/monitor-layout/monitors.lua
@@ -1,0 +1,8 @@
+-- See https://wiki.hypr.land/Configuring/Basics/Monitors/
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = "auto"
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+
+-- leftover user comment

--- a/test/shell.d/hyprland-monitor-layout-test.sh
+++ b/test/shell.d/hyprland-monitor-layout-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+source "$ROOT/bin/omarchy-hyprland-monitor-layout"
+
+FIXTURES="$ROOT/test/shell.d/fixtures/monitor-layout"
+CLI="$ROOT/bin/omarchy-hyprland-monitor-layout"
+
+layout_is_internal "eDP-2" || fail "eDP-2 is internal"
+layout_is_internal "DP-1" && fail "DP-1 is not internal"
+pass "internal output names"
+
+laptop=$(<"$FIXTURES/hypr-laptop-only.json")
+got=$(layout_state_from_hypr "$laptop" false false)
+[[ $(jq -r '.monitors[0].internal' <<<"$got") == "true" ]] || fail "laptop-only marks eDP internal"
+[[ $(jq -r '.externalConnected' <<<"$got") == "false" ]] || fail "laptop-only has no external"
+pass "state from laptop-only fixture"
+
+pair=$(<"$FIXTURES/hypr-laptop-external.json")
+got=$(layout_state_from_hypr "$pair" true false)
+[[ $(jq -r '.monitors[1].internal' <<<"$got") == "false" ]] || fail "DP-1 is external"
+[[ $(jq -r '.monitors[1].x' <<<"$got") == "1280" ]] || fail "DP-1 x from fixture"
+pass "state from laptop+external fixture"
+
+disabled=$(<"$FIXTURES/hypr-disabled.json")
+got=$(layout_state_from_hypr "$disabled" true false)
+[[ $(jq -r '.monitors[1].enabled' <<<"$got") == "false" ]] || fail "disabled HDMI"
+pass "state from disabled fixture"
+
+mirrored=$(<"$FIXTURES/hypr-mirror.json")
+got=$(layout_state_from_hypr "$mirrored" true false)
+[[ $(jq -r '.mirrorOn' <<<"$got") == "true" ]] || fail "mirror on"
+pass "state from mirror fixture"
+
+layout_is_laptop_only "$laptop" || fail "laptop-only detection"
+layout_is_laptop_only "$pair" && fail "pair is not laptop-only"
+pass "laptop-only detection"
+
+ok='{"monitors":[{"name":"eDP-2","x":0,"y":0},{"name":"DP-1","x":1280,"y":0}]}'
+layout_validate_apply "$pair" "$ok" || fail "valid side-by-side"
+pass "validate side-by-side"
+
+unknown='{"monitors":[{"name":"eDP-2","x":0,"y":0},{"name":"HDMI-A-9","x":1280,"y":0}]}'
+if layout_validate_apply "$pair" "$unknown" 2>/tmp/layout-err; then
+  fail "unknown output accepted"
+fi
+[[ $(cat /tmp/layout-err) == "unknown" ]] || fail "unknown stderr"
+pass "reject unknown output"
+
+overlap='{"monitors":[{"name":"eDP-2","x":0,"y":0},{"name":"DP-1","x":100,"y":0}]}'
+if layout_validate_apply "$pair" "$overlap" 2>/tmp/layout-err; then
+  fail "overlap accepted"
+fi
+[[ $(cat /tmp/layout-err) == "overlap" ]] || fail "overlap stderr"
+pass "reject overlap"
+
+island='{"monitors":[{"name":"eDP-2","x":0,"y":0},{"name":"DP-1","x":4000,"y":0}]}'
+if layout_validate_apply "$pair" "$island" 2>/tmp/layout-err; then
+  fail "island accepted"
+fi
+[[ $(cat /tmp/layout-err) == "disconnected" ]] || fail "disconnected stderr"
+pass "reject disconnected"
+
+omitted='{"monitors":[{"name":"eDP-2","x":0,"y":0}]}'
+if layout_validate_apply "$pair" "$omitted" 2>/tmp/layout-err; then
+  fail "omitted live monitor accepted"
+fi
+pass "reject omitted live monitor"
+
+empty='{"monitors":[]}'
+if layout_validate_apply "$pair" "$empty" 2>/tmp/layout-err; then
+  fail "empty payload accepted"
+fi
+pass "reject empty payload"
+
+chain='[
+  {"name":"DP-1","width":100,"height":100,"refreshRate":60.0,"x":0,"y":0,"scale":1,"focused":true,"disabled":false,"mirrorOf":"none"},
+  {"name":"DP-2","width":100,"height":100,"refreshRate":60.0,"x":100,"y":0,"scale":1,"focused":false,"disabled":false,"mirrorOf":"none"},
+  {"name":"DP-3","width":100,"height":100,"refreshRate":60.0,"x":200,"y":0,"scale":1,"focused":false,"disabled":false,"mirrorOf":"none"}
+]'
+chain_apply='{"monitors":[{"name":"DP-1","x":0,"y":0},{"name":"DP-2","x":100,"y":0},{"name":"DP-3","x":200,"y":0}]}'
+layout_validate_apply "$chain" "$chain_apply" || fail "3-monitor chain"
+pass "validate 3-monitor chain"
+
+apply='{"monitors":[{"name":"eDP-2","x":0,"y":0},{"name":"DP-1","x":1280,"y":0}]}'
+got=$(layout_keyword_lines "$pair" "$apply")
+want=$'eDP-2,2560x1600@165,0x0,2\nDP-1,2560x1440@144,1280x0,1'
+[[ $got == "$want" ]] || fail "keyword lines" "got: $got"
+pass "keyword lines"
+
+block=$(layout_managed_block "$pair" "$apply")
+[[ $(printf '%s\n' "$block" | head -n 1) == "$LAYOUT_START" ]] || fail "block start"
+[[ $(printf '%s\n' "$block" | tail -n 1) == "$LAYOUT_END" ]] || fail "block end"
+pass "managed block markers"
+
+src=$(<"$FIXTURES/monitors.lua")
+once=$(layout_patch_lua "$src" "$(layout_managed_block "$pair" "$apply")")
+[[ $once == *"local omarchy_gdk_scale = 2"* ]] || fail "patch keeps GDK_SCALE"
+[[ $once == *"leftover user comment"* ]] || fail "patch keeps user comment"
+pass "first lua patch keeps surrounding text"
+
+twice=$(layout_patch_lua "$once" "$(layout_managed_block "$pair" "$apply")")
+start_count=$(grep -c -F -e "$LAYOUT_START" <<<"$twice")
+[[ $start_count == "1" ]] || fail "second patch duplicates markers"
+pass "second lua patch is idempotent"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+cp "$FIXTURES/monitors.lua" "$WORKDIR/monitors.lua"
+
+export OMARCHY_MONITOR_LAYOUT_DRY_RUN=1
+export OMARCHY_MONITOR_LAYOUT_MONITORS_JSON="$FIXTURES/hypr-laptop-only.json"
+export OMARCHY_MONITOR_LAYOUT_EXTERNAL=false
+export OMARCHY_MONITOR_LAYOUT_CLAMSHELL=false
+export OMARCHY_MONITOR_LAYOUT_LUA_PATH="$WORKDIR/monitors.lua"
+
+got=$("$CLI" state)
+[[ $(jq -r '.externalConnected' <<<"$got") == "false" ]] || fail "cli state laptop"
+pass "cli state"
+
+apply_one='{"monitors":[{"name":"eDP-2","x":0,"y":0}]}'
+"$CLI" apply "$apply_one" >/tmp/layout-apply-out
+grep -q -F -e "$LAYOUT_START" "$WORKDIR/monitors.lua" && fail "laptop apply wrote lua"
+pass "laptop apply is a no-op"
+
+export OMARCHY_MONITOR_LAYOUT_MONITORS_JSON="$FIXTURES/hypr-laptop-external.json"
+export OMARCHY_MONITOR_LAYOUT_EXTERNAL=true
+apply_pair='{"monitors":[{"name":"eDP-2","x":0,"y":0},{"name":"DP-1","x":1280,"y":0}]}'
+got=$("$CLI" apply "$apply_pair")
+[[ $(jq -r '.keywords[1]' <<<"$got") == "DP-1,2560x1440@144,1280x0,1" ]] || fail "dry-run keyword"
+grep -q -F -e "$LAYOUT_START" "$WORKDIR/monitors.lua" && fail "dry-run wrote lua"
+pass "cli dry-run apply"
+
+unset OMARCHY_MONITOR_LAYOUT_DRY_RUN
+export OMARCHY_MONITOR_LAYOUT_WRITE_ONLY=1
+"$CLI" apply "$apply_pair" >/dev/null
+bak=$(find "$WORKDIR" -name 'monitors.lua.bak.*' | wc -l)
+[[ $bak == "1" ]] || fail "first write backup count $bak"
+"$CLI" apply "$apply_pair" >/dev/null
+bak=$(find "$WORKDIR" -name 'monitors.lua.bak.*' | wc -l)
+[[ $bak == "2" ]] || fail "second write backup count $bak"
+pass "lua backups on write"
+
+run_node_test <<'JS'
+const model = requireFromRoot('shell/plugins/panels/monitor/Model.js')
+assertDeepEqual(model.layoutSize(2560, 1600, 2), { w: 1280, h: 800 }, 'layout size divides by scale')
+
+const laptop = { name: 'eDP-2', x: 0, y: 0, w: 1280, h: 800 }
+const ext = { name: 'DP-1', x: 1400, y: 40, w: 2560, h: 1440 }
+const snapped = model.snapPosition(ext, [laptop])
+assertEqual(snapped.side, 'right', 'snap to right')
+assertEqual(snapped.x, 1280, 'snap right x')
+
+const above = model.snapPosition({ name: 'DP-1', x: 10, y: -900, w: 2560, h: 1440 }, [laptop])
+assertEqual(above.side, 'top', 'snap to top')
+assertEqual(above.y, -1440, 'snap top y')
+
+const stacked = { name: 'DP-2', x: 1280, y: 0, w: 2560, h: 1440 }
+const underCenter = model.snapWindows({ name: 'eDP-2', x: 1920, y: 1500, w: 1280, h: 800 }, [stacked])
+assertEqual(underCenter.side, 'bottom', 'drop under center stays on bottom')
+assertEqual(underCenter.x, 1920, 'drop under center keeps x')
+assertEqual(underCenter.y, 1440, 'drop under center y')
+JS


### PR DESCRIPTION
## Summary
- Replace the Display panel's monitor list with a spatial canvas: drag numbered rectangles to snap left/right/above/below, then apply live via `hyprctl` and persist a managed block in `~/.config/hypr/monitors.lua`.
- Add `omarchy-hyprland-monitor-layout` (`omarchy hyprland monitor layout`) for `state`, `apply`, and `place`, with overlap/island validation and per-write backups.
- Snap from the drop position (not travel distance) so a display dragged under a wider neighbor stays on that bottom edge.

## Test plan
- [x] `test/shell.d/hyprland-monitor-layout-test.sh` (state, validate, lua patch, CLI dry-run/write, snap math)
- [x] `./test/cli` (command metadata / routing)
- [ ] Open Super+Ctrl+D with laptop + external: drag a display under/beside the other and confirm it stays
- [ ] Confirm `~/.config/hypr/monitors.lua` gains a single `-- omarchy-layout-managed` block and GDK_SCALE / catch-all `output = ""` stay untouched
- [ ] Laptop-only: canvas shows one display; apply is a no-op
- [ ] LEFT/RIGHT/ABOVE/BELOW chips and INT/MIRROR toggles still work


Made with [Cursor](https://cursor.com)