### PR TITLE
Perf: Reduce the crash watcher's memory  footprint by ~90%

### DIFF
--- a/bin/omarchy-crash-watch
+++ b/bin/omarchy-crash-watch
@@ -3,13 +3,13 @@
 # omarchy:summary=Watch for process crashes and offer an AI diagnosis
 # omarchy:hidden=true
 
-# systemd-coredump journals every core dump under a known MESSAGE_ID with
-# structured COREDUMP_* fields, which carry more than the core filenames do.
+# systemd-coredump (Storage=external, the default) writes one compressed core
+# file per crash, named core.<comm>.<uid>.<boot-id>.<pid>.<timestamp>.zst, and
+# journals the COREDUMP_* details under a known MESSAGE_ID. Watching the
+# directory with inotify costs a few MB; the per-crash details come from one
+# transient coredumpctl lookup, so nothing is retained between crashes.
 
 set -uo pipefail
-
-# See systemd.journal-fields(7).
-readonly COREDUMP_MESSAGE_ID=fc2e22bc6ee647b6b90729ab34a250b1
 
 # nf-md-robot_dead, escaped so this file reads without a Nerd Font.
 readonly CRASH_GLYPH=$'\U000f16a1'
@@ -20,6 +20,9 @@ readonly dedupe_seconds=${OMARCHY_CRASH_DEDUPE_SECONDS:-60}
 
 # Extended regex of process names never worth announcing.
 readonly ignore_pattern=${OMARCHY_CRASH_IGNORE:-}
+
+# Where systemd-coredump stores cores with Storage=external (the default).
+readonly coredump_dir=/var/lib/systemd/coredump
 
 declare -A last_notified
 
@@ -45,23 +48,25 @@ announce() {
     --exec omarchy-agent-crash "$pid" "$comm" "$exe" "$signal"
 }
 
-# -n 0 so a restart does not re-announce crashes already dealt with.
-journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
-  while IFS= read -r entry; do
-    # A dash for a field that is empty as well as one that is missing: tab is
-    # IFS whitespace, so an empty field collapses into the next delimiter and
-    # every field after it shifts along one. A process can set its own comm to
-    # nothing, and that crash used to be read as somebody else's and dropped.
-    IFS=$'\t' read -r uid comm pid exe signal < <(
-      jq -r 'def field: if . == null or . == "" then "-" else . end;
-             [(._UID | field),
-              (.COREDUMP_COMM | field),
-              (.COREDUMP_PID | field),
-              (.COREDUMP_EXE | field),
-              (.COREDUMP_SIGNAL_NAME | field)] | @tsv' <<<"$entry" 2>/dev/null
+# A new core file means a crash; there is nothing to watch while idle. A
+# restart misses crashes that happened while it was down; core files already
+# on disk are not replayed.
+inotifywait -m -e create -e moved_to --format '%f' "$coredump_dir" 2>/dev/null |
+  while IFS= read -r filename; do
+    # core.<comm>.<uid>.<boot-id>.<pid>.<timestamp>[.ext]. comm keeps its
+    # spaces, so each field is read from its own line.
+    {
+      IFS= read -r comm
+      read -r uid
+      read -r boot_id
+      read -r pid
+    } < <(
+      [[ $filename =~ ^core\.(.+)\.([0-9]+)\.([0-9a-f]{32})\.([0-9]+)\.[0-9]+(\.[^.]+)?$ ]] &&
+        printf '%s\n%s\n%s\n%s\n' \
+          "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
     )
 
-    [[ $pid =~ ^[0-9]+$ ]] || continue
+    [[ $uid =~ ^[0-9]+$ && $pid =~ ^[0-9]+$ ]] || continue
 
     # The toast only offers a diagnosis, so it has nothing to offer until an
     # agent is chosen. Checked per crash, not at startup, so picking one takes
@@ -69,12 +74,23 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     [[ -n $(omarchy-default-agent) ]] || continue
 
     # Only this user's crashes; a daemon dumping core is a sysadmin's problem.
-    [[ $uid =~ ^[0-9]+$ ]] || continue
     ((uid == UID)) || continue
 
-    # comm is truncated to 15 characters, so prefer the executable's basename.
+    # The filename carries the boot id, so the lookup matches the exact crash
+    # rather than whatever process later reused the pid. Tolerated failures
+    # still announce, just with the truncated comm and no signal. Runs before
+    # the name filters so they operate on the name that will be announced.
     name=$comm
+
+    IFS=$'\t' read -r exe signal < <(
+      coredumpctl info "COREDUMP_PID=$pid" "_BOOT_ID=$boot_id" 2>/dev/null |
+        awk '/^ +Executable: /{sub(/^ +Executable: /, ""); exe=$0}
+             /^ +Signal: /{sub(/^ +Signal: [0-9]+ \(/, ""); sub(/\).*/, ""); sig=$0}
+             END{print exe "\t" sig}'
+    )
     [[ $exe == /* ]] && name=${exe##*/}
+    [[ -n $exe ]] || exe=unknown
+    [[ -n $signal ]] || signal=unknown
 
     # A process can set its own comm to anything prctl takes, slashes included,
     # and a crash with no recorded executable falls back to it. The mute below
@@ -103,7 +119,7 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     (((now - ${last_notified[$name]:-0}) < dedupe_seconds)) && continue
 
     # Only a delivered toast starts the dedupe window. A failed send that
-    # counted would suppress the rest of a crash loop for a minute, and
-    # `journalctl -n 0` never replays what was missed.
+    # counted would suppress the rest of a crash loop for a minute, and there
+    # is no replay of earlier cores to make up for a missed toast.
     announce "$name" "$pid" "$exe" "$signal" && last_notified[$name]=$now
   done

--- a/bin/omarchy-crash-watch
+++ b/bin/omarchy-crash-watch
@@ -77,17 +77,24 @@ inotifywait -m -e create -e moved_to --format '%f' "$coredump_dir" 2>/dev/null |
     ((uid == UID)) || continue
 
     # The filename carries the boot id, so the lookup matches the exact crash
-    # rather than whatever process later reused the pid. Tolerated failures
-    # still announce, just with the truncated comm and no signal. Runs before
-    # the name filters so they operate on the name that will be announced.
+    # rather than whatever process later reused the pid. systemd-coredump
+    # writes the core file before it journals the entry, so give the entry a
+    # beat to land before falling back to less detail. Runs before the name
+    # filters so they operate on the name that will be announced.
     name=$comm
 
-    IFS=$'\t' read -r exe signal < <(
-      coredumpctl info "COREDUMP_PID=$pid" "_BOOT_ID=$boot_id" 2>/dev/null |
-        awk '/^ +Executable: /{sub(/^ +Executable: /, ""); exe=$0}
-             /^ +Signal: /{sub(/^ +Signal: [0-9]+ \(/, ""); sub(/\).*/, ""); sig=$0}
-             END{print exe "\t" sig}'
-    )
+    attempts=0
+    while (( attempts < 20 )); do
+      IFS=$'\t' read -r exe signal < <(
+        coredumpctl info "COREDUMP_PID=$pid" "_BOOT_ID=$boot_id" 2>/dev/null |
+          awk '/^ +Executable: /{sub(/^ +Executable: /, ""); exe=$0}
+               /^ +Signal: /{sub(/^ +Signal: [0-9]+ \(/, ""); sub(/\).*/, ""); sig=$0}
+               END{print exe "\t" sig}'
+      )
+      [[ -n $exe || -n $signal ]] && break
+      sleep 0.1
+      ((attempts++))
+    done
     [[ $exe == /* ]] && name=${exe##*/}
     [[ -n $exe ]] || exe=unknown
     [[ -n $signal ]] || signal=unknown

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -167,12 +167,13 @@ Everything goes through the same sender contract, so the pieces are small:
 
 - **Low battery** — `omarchy-battery-low` sends a critical toast and runs the
   `battery-low` hook.
-- **Crash capture** — `omarchy-crash-watch` follows the systemd-coredump
-  journal stream and announces each crashed program (deduped per minute) as a
-  critical toast whose click runs `omarchy-agent-crash` (via `--exec`, so a
-  hostile process name stays a discrete argument). It waits for the
-  server first: a shell crash takes the notification server down with it, and
-  that crash is the one most worth reporting.
+- **Crash capture** — `omarchy-crash-watch` watches the systemd-coredump
+  directory with inotify for new core files (a few MB idle) and announces
+  each crashed program (deduped per minute) as a critical toast whose click
+  runs `omarchy-agent-crash` (via `--exec`, so a hostile process name stays
+  a discrete argument). It waits for the server first: a shell crash takes
+  the notification server down with it, and that crash is the one most
+  worth reporting.
 - **Pending migrations** — `omarchy-migrate-notify` (from its user service
   after `graphical-session.target`) waits for the server, then sends a
   critical toast whose click opens a terminal running `omarchy-migrate`,

--- a/migrations/1786894219.sh
+++ b/migrations/1786894219.sh
@@ -1,0 +1,17 @@
+echo "Restart the crash watcher so it picks up the inotify rewrite"
+
+# omarchy-crash-watch followed the journal with journalctl -f, mapping the
+# whole journal into memory; the rewrite watches the systemd-coredump
+# directory with inotify instead, at a few MB. pacman replaces the script on
+# update, but the running service keeps the old one in memory until it
+# restarts, so restart it here for the memory win to land during the update
+# instead of at the next login.
+
+# The unit's ConditionPathExists re-checks the same toggle flag at every
+# start, so a watcher the user disabled stays off: honoring the flag here
+# makes this migration a no-op for them. Only nudge a watcher that is
+# actually running; a stopped one stays stopped.
+[[ -f "$HOME/.local/state/omarchy/toggles/crash-capture-off" ]] && exit 0
+
+systemctl --user is-active omarchy-crash-watch.service >/dev/null 2>&1 &&
+  systemctl --user restart omarchy-crash-watch.service >/dev/null 2>&1 || true

--- a/test/shell.d/crash-watch-test.sh
+++ b/test/shell.d/crash-watch-test.sh
@@ -18,7 +18,7 @@ boot=deadbeefdeadbeefdeadbeefdeadbeef
 # like a watch that dropped. The watcher must process every name it sees.
 cat >"$TMPDIR/bin/inotifywait" <<'SH'
 #!/bin/bash
-printf '%s\n' $WATCH_ITEMS
+tr ' ' '\n' <<<"$WATCH_ITEMS"
 SH
 
 # coredumpctl: the watcher calls `info COREDUMP_PID=<pid> _BOOT_ID=<boot>`;

--- a/test/shell.d/crash-watch-test.sh
+++ b/test/shell.d/crash-watch-test.sh
@@ -9,7 +9,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 mkdir -p "$TMPDIR/bin"
 NOTIFY_LOG="$TMPDIR/notify-log"
+FAIL_COUNT="$TMPDIR/fail-count"
 : >"$NOTIFY_LOG"
+: >"$FAIL_COUNT"
 
 uid=$(id -u)
 boot=deadbeefdeadbeefdeadbeefdeadbeef
@@ -23,7 +25,8 @@ SH
 
 # coredumpctl: the watcher calls `info COREDUMP_PID=<pid> _BOOT_ID=<boot>`;
 # reply with the fields the awk extraction reads. Unknown pids get no entry,
-# exercising the tolerated-lookup-failure path.
+# exercising the tolerated-lookup-failure path. pid 5001 fails twice first,
+# exercising the retry that waits for the journal entry to land.
 cat >"$TMPDIR/bin/coredumpctl" <<'SH'
 #!/bin/bash
 case "$2" in
@@ -35,6 +38,16 @@ case "$2" in
       '           PID: 1002 (other)' \
       '        Signal: 6 (ABRT)' \
       '    Executable: /usr/bin/other-real' ;;
+  COREDUMP_PID=5001)
+    fails=$(cat "$FAIL_COUNT" 2>/dev/null || printf '0')
+    if (( fails < 2 )); then
+      printf '%s\n' "$((fails + 1))" >"$FAIL_COUNT"
+      exit 1
+    fi
+    printf '%s\n' \
+      '           PID: 5001 (slowcore)' \
+      '        Signal: 6 (ABRT)' \
+      '    Executable: /usr/bin/slowcore-real' ;;
   *) : ;;
 esac
 SH
@@ -61,7 +74,7 @@ run_watch() {
   shift
   (
     export PATH="$TMPDIR/bin:$ROOT/bin:$PATH"
-    export WATCH_ITEMS="$items" NOTIFY_LOG="$NOTIFY_LOG"
+    export WATCH_ITEMS="$items" NOTIFY_LOG="$NOTIFY_LOG" FAIL_COUNT="$FAIL_COUNT"
     for kv in "$@"; do export "$kv"; done
     "$ROOT/bin/omarchy-crash-watch"
   )
@@ -133,3 +146,14 @@ grep -Fq "Process crashed: barecomm" "$NOTIFY_LOG" ||
 grep -Fq "omarchy-agent-crash 3001 barecomm unknown unknown" "$NOTIFY_LOG" ||
   fail "falls back to unknown executable and signal"
 pass "watcher tolerates a failed coredumpctl lookup"
+
+: >"$NOTIFY_LOG"
+: >"$FAIL_COUNT"
+run_watch "$(core_file slowcore "$uid" 5001)"
+[[ $(notify_count) -eq 1 ]] ||
+  fail "crash whose journal entry lands late is still announced" "got: $(notify_count) toasts"
+grep -Fq "Process crashed: slowcore-real" "$NOTIFY_LOG" ||
+  fail "the retry recovered the executable"
+grep -Fq "omarchy-agent-crash 5001 slowcore-real /usr/bin/slowcore-real ABRT" "$NOTIFY_LOG" ||
+  fail "the retry recovered the signal"
+pass "watcher retries the lookup until the journal entry lands"

--- a/test/shell.d/crash-watch-test.sh
+++ b/test/shell.d/crash-watch-test.sh
@@ -61,7 +61,7 @@ run_watch() {
   shift
   (
     export PATH="$TMPDIR/bin:$ROOT/bin:$PATH"
-    export WATCH_ITEMS=$items NOTIFY_LOG=$NOTIFY_LOG
+    export WATCH_ITEMS="$items" NOTIFY_LOG="$NOTIFY_LOG"
     for kv in "$@"; do export "$kv"; done
     "$ROOT/bin/omarchy-crash-watch"
   )

--- a/test/shell.d/crash-watch-test.sh
+++ b/test/shell.d/crash-watch-test.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+NOTIFY_LOG="$TMPDIR/notify-log"
+: >"$NOTIFY_LOG"
+
+uid=$(id -u)
+boot=deadbeefdeadbeefdeadbeefdeadbeef
+
+# inotifywait: emit the scripted core filenames from $WATCH_ITEMS, then exit
+# like a watch that dropped. The watcher must process every name it sees.
+cat >"$TMPDIR/bin/inotifywait" <<'SH'
+#!/bin/bash
+printf '%s\n' $WATCH_ITEMS
+SH
+
+# coredumpctl: the watcher calls `info COREDUMP_PID=<pid> _BOOT_ID=<boot>`;
+# reply with the fields the awk extraction reads. Unknown pids get no entry,
+# exercising the tolerated-lookup-failure path.
+cat >"$TMPDIR/bin/coredumpctl" <<'SH'
+#!/bin/bash
+case "$2" in
+  COREDUMP_PID=1001) printf '%s\n' \
+      '           PID: 1001 (foo-bar)' \
+      '        Signal: 11 (SEGV) si_code: SI_KERNEL' \
+      '    Executable: /usr/bin/foo-bar-real' ;;
+  COREDUMP_PID=1002) printf '%s\n' \
+      '           PID: 1002 (other)' \
+      '        Signal: 6 (ABRT)' \
+      '    Executable: /usr/bin/other-real' ;;
+  *) : ;;
+esac
+SH
+
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+SH
+
+cat >"$TMPDIR/bin/omarchy-notification-wait" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$TMPDIR/bin/omarchy-default-agent" <<'SH'
+#!/bin/bash
+printf '%s\n' default-agent
+SH
+
+chmod +x "$TMPDIR/bin"/*
+
+run_watch() {
+  local items=$1
+  shift
+  (
+    export PATH="$TMPDIR/bin:$ROOT/bin:$PATH"
+    export WATCH_ITEMS=$items NOTIFY_LOG=$NOTIFY_LOG
+    for kv in "$@"; do export "$kv"; done
+    "$ROOT/bin/omarchy-crash-watch"
+  )
+}
+
+notify_count() {
+  wc -l <"$NOTIFY_LOG"
+}
+
+core_file() { # comm uid pid
+  printf 'core.%s.%s.%s.%s.1786000000000000.zst' "$1" "$2" "$boot" "$3"
+}
+
+: >"$NOTIFY_LOG"
+run_watch "$(core_file foo-bar "$uid" 1001) $(core_file other "$uid" 1002)"
+[[ $(notify_count) -eq 2 ]] ||
+  fail "one toast per crash" "got: $(notify_count) toasts"
+grep -Fq "Process crashed: foo-bar-real" "$NOTIFY_LOG" ||
+  fail "toast uses the executable basename, not the 15-char comm"
+grep -Fq "Process crashed: other-real" "$NOTIFY_LOG" ||
+  fail "toast for the second crash"
+grep -Fq "omarchy-agent-crash 1001 foo-bar-real /usr/bin/foo-bar-real SEGV" "$NOTIFY_LOG" ||
+  fail "diagnosis command carries pid, name, executable, and signal"
+grep -Fq "omarchy-agent-crash 1002 other-real /usr/bin/other-real ABRT" "$NOTIFY_LOG" ||
+  fail "diagnosis command for the second crash"
+! grep -Fq "Process crashed: foo-bar " "$NOTIFY_LOG" ||
+  fail "truncated comm never reaches the toast when the executable is known"
+pass "watcher announces crashes with name, executable, and signal"
+
+: >"$NOTIFY_LOG"
+run_watch \
+  "$(core_file alien 424242 3001) $(core_file omarchy-agent-foo "$uid" 1002) $(core_file other "$uid" 1002)" \
+  OMARCHY_CRASH_DEDUPE_SECONDS=0
+[[ $(notify_count) -eq 1 ]] ||
+  fail "foreign-uid and omarchy-own crashes are skipped" "got: $(notify_count) toasts"
+grep -Fq "Process crashed: other-real" "$NOTIFY_LOG" ||
+  fail "the remaining crash is still announced"
+pass "watcher skips other users' and its own crashes"
+
+: >"$NOTIFY_LOG"
+run_watch "$(core_file foo-bar "$uid" 1001) $(core_file other "$uid" 1002)" \
+  OMARCHY_CRASH_IGNORE='foo'
+[[ $(notify_count) -eq 1 ]] ||
+  fail "ignored patterns are not announced" "got: $(notify_count) toasts"
+grep -Fq "Process crashed: other-real" "$NOTIFY_LOG" ||
+  fail "non-ignored crashes are still announced"
+pass "watcher honors the ignore pattern"
+
+: >"$NOTIFY_LOG"
+run_watch "$(core_file foo-bar "$uid" 1001) $(core_file foo-bar "$uid" 1001)" \
+  OMARCHY_CRASH_DEDUPE_SECONDS=3600
+[[ $(notify_count) -eq 1 ]] ||
+  fail "duplicate core files within the dedupe window are announced once" "got: $(notify_count) toasts"
+pass "watcher dedupes crash loops per window"
+
+: >"$NOTIFY_LOG"
+run_watch "$(core_file foo-bar "$uid" 1001) $(core_file foo-bar "$uid" 1001)" \
+  OMARCHY_CRASH_DEDUPE_SECONDS=0
+[[ $(notify_count) -eq 2 ]] ||
+  fail "a zero dedupe window announces every core file" "got: $(notify_count) toasts"
+pass "watcher announces again outside the dedupe window"
+
+: >"$NOTIFY_LOG"
+run_watch "$(core_file barecomm "$uid" 3001)"
+[[ $(notify_count) -eq 1 ]] ||
+  fail "crash without a coredumpctl entry is still announced"
+grep -Fq "Process crashed: barecomm" "$NOTIFY_LOG" ||
+  fail "falls back to the truncated comm from the filename"
+grep -Fq "omarchy-agent-crash 3001 barecomm unknown unknown" "$NOTIFY_LOG" ||
+  fail "falls back to unknown executable and signal"
+pass "watcher tolerates a failed coredumpctl lookup"


### PR DESCRIPTION
tl;dr:
The crash watcher follows the system journal, which its memory-heavy over time. this pr uses the core-dump directory with inotify instead.

Problem. The crash watcher follows the system journal with journalctl -f, which opens and maps every journal file it can find. With a 1.3 GB journal that mean around 200 MB of memory for the watcher alone (up to 400 MB in fresh runs), plus close to a gigabyte of page cache charged to its service, creeping up as the journal grows.

Change. systemd-coredump already writes one core file per crash, named core.comm.uid.bootid.pid.timestamp.zst. The watcher now watches that folder with inotify instead: about 4 MB idle, and nothing kept in memory between crashes. The program name, executable, and signal shown in the notification come from a coredumpctl lookup per crash, matched by pid and boot id so a reused pid can never point at the wrong crash. systemd-coredump writes the core file before it journals the entry, so the lookup retries briefly (up to two seconds) to let the entry land; the toast only falls back to the truncated comm and an unknown signal when the entry truly never appears, and clicking it always runs a full diagnosis from coredumpctl regardless.

No behavior changes. The same critical notification with the click-to-diagnose action, the per-minute dedupe for crash loops, the uid filter, ignore patterns, and self-exclusion all work exactly as before. Clicking the notification still opens the AI diagnosis, which reads the crash details itself. A restart only misses crashes that happened while it was down, just like before. inotify-tools was already an Omarchy dependency.

Testing. A new crash-watch-test.sh covers the notification contents, the uid and ignore filters, self-exclusion, dedupe, and the lookup-failure fallback, using mocked inotifywait, coredumpctl, and notification scripts. Verified live: the watcher's memory dropped from about 400 MB to 4MB.