### PR TITLE
Add OpenCode Go to AI usage widget

### DIFF
--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -406,7 +406,9 @@ def fetch_limits(api_key_value: str, usage_url: str) -> tuple[list[Any], str, st
       return cached, "OpenCode Go limits stale", "", True
     return [], "OpenCode Go limits unavailable", "Could not reach opencode.ai.", True
 
-  usage = payload.get("usage") if isinstance(payload, dict) else {}
+  usage = payload.get("usage") if isinstance(payload, dict) else None
+  if not isinstance(usage, dict):
+    usage = {}
   windows = [
     ("Rolling (5-hour)", usage.get("rolling")),
     ("Weekly (7-day)", usage.get("weekly")),
@@ -416,7 +418,7 @@ def fetch_limits(api_key_value: str, usage_url: str) -> tuple[list[Any], str, st
   for label, window in windows:
     if not isinstance(window, dict):
       continue
-    if window.get("percent") is None or not window.get("resetsAt"):
+    if window.get("percent") is None:
       continue
     limits.append({
       "label": label,

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -1,0 +1,455 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the OpenCode Go usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect OpenCode Go usage into one display-ready JSON record.
+
+Local token stats come from opencode's own database: every assistant message
+whose providerID is "opencode-go", the subscription opencode sells as "Go".
+Rate-limit windows come from opencode's key-authenticated usage endpoint; the
+key is read from OPENCODE_API_KEY or opencode's own auth.json. The agents panel
+only ever reads the JSON this prints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "opencode-go"
+AGENT_NAME = "OpenCode Go"
+TIER_LABEL = "Go"
+AUTH_HELP = "Sign in to OpenCode Go in opencode, or set OPENCODE_API_KEY."
+USAGE_URL = "https://opencode.ai/zen/go/v1/usage"
+# opencode.ai sits behind Cloudflare and rejects the default urllib agent.
+USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
+
+# A scan this recent is only reused to dedup concurrent collector runs (the
+# update command backgrounds one per agent while the panel refreshes on its
+# own); every periodic widget refresh lands a real rescan. --limits-only
+# promises only fresh limits, so it may reuse a scan for far longer.
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+
+def number(value: Any) -> int:
+  try:
+    return int(value or 0)
+  except (TypeError, ValueError):
+    return 0
+
+
+def model_name(raw: Any) -> str:
+  value = str(raw or "").rstrip("/").split("/")[-1]
+  return value or "opencode-go"
+
+
+def local_day(value: Any) -> str:
+  if value is None:
+    return datetime.now().strftime("%Y-%m-%d")
+  if isinstance(value, (int, float)):
+    if value > 10_000_000_000:
+      value = value / 1000
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d")
+  text = str(value)
+  try:
+    parsed = datetime.fromisoformat(text[:-1] + "+00:00" if text.endswith("Z") else text)
+    if parsed.tzinfo is not None:
+      parsed = parsed.astimezone()
+    return parsed.strftime("%Y-%m-%d")
+  except ValueError:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def empty_bucket() -> dict[str, int]:
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def empty_stats() -> dict[str, Any]:
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [],
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+  }
+
+
+def base_record(**overrides: Any) -> dict[str, Any]:
+  record: dict[str, Any] = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": False,
+    "hasLocalStats": False,
+    "tierLabel": TIER_LABEL,
+    "usageStatusText": "",
+    "authHelpText": "",
+    "limits": [],
+  }
+  record.update(overrides)
+  return record
+
+
+def data_home() -> Path:
+  return Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+
+
+def opencode_db_path() -> Path:
+  return data_home() / "opencode" / "opencode.db"
+
+
+def opencode_auth_path() -> Path:
+  return data_home() / "opencode" / "auth.json"
+
+
+def today_and_recent() -> tuple[str, list[str]]:
+  now = datetime.now()
+  today = now.strftime("%Y-%m-%d")
+  recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+  return today, recent_dates
+
+
+# --------------------------------------------------------------------- scan
+
+def scan_opencode_go() -> tuple[dict[str, Any], bool]:
+  """Scan opencode.db for opencode-go assistant messages.
+
+  Returns (stats, complete). A False `complete` means the database read failed
+  part-way; the returned numbers are still served, but must not be cached as
+  if they were the whole story.
+  """
+  today, recent_dates = today_and_recent()
+  stats = empty_stats()
+  stats["recentDays"] = [{"date": day, "messageCount": 0} for day in recent_dates]
+
+  db = opencode_db_path()
+  if not db.is_file():
+    return stats, True
+
+  try:
+    conn = sqlite3.connect(db.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
+  except sqlite3.Error:
+    return stats, False
+
+  recent = {day: 0 for day in recent_dates}
+  today_by_model: dict[str, int] = {}
+  model_usage: dict[str, dict[str, int]] = {}
+  active_dates: set[str] = set()
+  today_sessions: set[str] = set()
+  total_sessions: set[str] = set()
+  today_prompts = 0
+  total_prompts = 0
+  today_total = 0
+
+  try:
+    conn.execute("PRAGMA query_only = ON")
+    for session_id, raw in conn.execute(
+      "SELECT session_id, data FROM message"
+      " WHERE data LIKE '%\"role\"%:%\"assistant\"%'"
+      " AND data LIKE '%\"providerID\"%:%\"opencode-go\"%'"
+      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'"
+      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.providerID') END = 'opencode-go'"
+    ):
+      try:
+        entry = json.loads(raw)
+        if not isinstance(entry, dict) or entry.get("role") != "assistant":
+          continue
+        if str(entry.get("providerID") or "") != "opencode-go":
+          continue
+        tokens = entry.get("tokens") or {}
+        cache = tokens.get("cache") or {}
+        input_tokens = number(tokens.get("input"))
+        # opencode keeps thinking tokens out of output; both are generated.
+        output_tokens = number(tokens.get("output")) + number(tokens.get("reasoning"))
+        cache_read = number(cache.get("read"))
+        cache_write = number(cache.get("write"))
+        if not (input_tokens or output_tokens or cache_read or cache_write):
+          continue
+        day = local_day((entry.get("time") or {}).get("created"))
+        model = model_name(entry.get("modelID"))
+      except Exception:
+        continue
+
+      total = input_tokens + output_tokens + cache_read + cache_write
+      session_key = "opencode-go:" + str(session_id)
+      total_prompts += 1
+      total_sessions.add(session_key)
+      active_dates.add(day)
+
+      bucket = model_usage.setdefault(model, empty_bucket())
+      bucket["inputTokens"] += input_tokens
+      bucket["outputTokens"] += output_tokens
+      bucket["cacheReadInputTokens"] += cache_read
+      bucket["cacheCreationInputTokens"] += cache_write
+
+      if day in recent:
+        recent[day] += total
+      if day == today:
+        today_prompts += 1
+        today_sessions.add(session_key)
+        today_total += total
+        today_by_model[model] = today_by_model.get(model, 0) + total
+
+    stats = {
+      "todayPrompts": today_prompts,
+      "todaySessions": len(today_sessions),
+      "todayTotalTokens": today_total,
+      "todayTokensByModel": today_by_model,
+      "recentDays": [{"date": day, "messageCount": recent[day]} for day in recent_dates],
+      "totalPrompts": total_prompts,
+      "totalSessions": len(total_sessions),
+      "activeDays": len(active_dates),
+      "activeDates": sorted(active_dates),
+      "modelUsage": model_usage,
+    }
+  except sqlite3.Error:
+    return stats, False
+  finally:
+    conn.close()
+  return stats, True
+
+
+# -------------------------------------------------------------------- cache
+
+def cache_root() -> Path:
+  root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def scan_cache_paths() -> tuple[Path, Path]:
+  digest = hashlib.sha1(str(opencode_db_path()).encode("utf-8")).hexdigest()[:16]
+  root = cache_root()
+  return root / f"opencode-go-scan-{digest}.json", root / f"opencode-go-scan-{digest}.lock"
+
+
+def read_fresh_json(path: Path, max_age_seconds: int) -> Any | None:
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path: Path, payload: Any) -> None:
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+def read_cached_stats(cache_file: Path, max_age_seconds: int, today: str) -> dict[str, Any] | None:
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+    return None
+  if cached.get("scanDate") != today:
+    return None
+  stats = cached.get("stats")
+  return stats if isinstance(stats, dict) else None
+
+
+def write_cached_stats(cache_file: Path, stats: dict[str, Any], today: str) -> None:
+  try:
+    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+  except Exception as exc:
+    print(f"omarchy-agent-usage-opencode-go: could not write scan cache ({exc})", file=sys.stderr)
+
+
+def cached_local_stats(max_age: int) -> tuple[dict[str, Any], bool]:
+  try:
+    return _cached_local_stats(max_age)
+  except Exception as exc:
+    print(f"omarchy-agent-usage-opencode-go: cache unavailable ({exc}); scanning directly", file=sys.stderr)
+    return scan_opencode_go()
+
+
+def _cached_local_stats(max_age: int) -> tuple[dict[str, Any], bool]:
+  today, _ = today_and_recent()
+  cache_file, lock_file = scan_cache_paths()
+
+  cached = read_cached_stats(cache_file, max_age, today)
+  if cached is not None:
+    return cached, True
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_cached_stats(cache_file, max_age, today)
+    if cached is not None:
+      return cached, True
+    stats, complete = scan_opencode_go()
+    # An interrupted scan still serves this run, but caching it would suppress
+    # the missing usage for every reader until the cache expires.
+    if complete:
+      write_cached_stats(cache_file, stats, today)
+    return stats, complete
+
+
+# ------------------------------------------------------------------- limits
+
+def read_opencode_key(path: Path) -> str:
+  try:
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+  except (OSError, json.JSONDecodeError):
+    return ""
+  if not isinstance(parsed, dict):
+    return ""
+  for name in ("opencode-go", "opencode"):
+    entry = parsed.get(name)
+    if isinstance(entry, dict) and entry.get("key"):
+      return str(entry["key"]).strip()
+  return ""
+
+
+def api_key() -> str:
+  return str(os.environ.get("OPENCODE_API_KEY", "")).strip() or read_opencode_key(opencode_auth_path())
+
+
+def limits_cache_path() -> Path:
+  return cache_root() / "opencode-go-limits.json"
+
+
+def read_limits_cache() -> list[Any]:
+  try:
+    parsed = json.loads(limits_cache_path().read_text(encoding="utf-8"))
+    limits = parsed.get("limits") if isinstance(parsed, dict) else None
+    return limits if isinstance(limits, list) else []
+  except Exception:
+    return []
+
+
+def write_limits_cache(limits: list[Any]) -> None:
+  try:
+    write_json(limits_cache_path(), {"limits": limits})
+  except Exception:
+    pass
+
+
+def normalize_percent(value: Any) -> float:
+  try:
+    percent = float(value)
+  except (TypeError, ValueError):
+    return 0.0
+  return max(0.0, min(100.0, percent)) / 100.0
+
+
+def normalize_resets_at(value: Any) -> str:
+  text = str(value or "").strip()
+  if text.endswith("Z"):
+    text = text[:-1] + "+00:00"
+  return text
+
+
+def fetch_limits(api_key_value: str, usage_url: str) -> tuple[list[Any], str, str, bool]:
+  """Return (limits, usage_status_text, auth_help_text, retry_advised)."""
+  if not api_key_value:
+    return [], "", "", False
+
+  request = urllib.request.Request(
+    usage_url,
+    headers={"Authorization": "Bearer " + api_key_value, "Accept": "application/json", "User-Agent": USER_AGENT},
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=10) as response:
+      payload = json.load(response)
+  except urllib.error.HTTPError as error:
+    if error.code == 401:
+      return [], "OpenCode Go limits unavailable", "opencode.ai rejected the API key.", False
+    if error.code == 403:
+      return [], "OpenCode Go limits unavailable", "This key has no OpenCode Go subscription.", False
+    return [], "OpenCode Go limits unavailable", "opencode.ai returned HTTP %d." % error.code, False
+  except Exception:
+    # A flaky network should not blank the meters: reuse the last-known-good
+    # limits and ask the panel to retry soon.
+    cached = read_limits_cache()
+    if cached:
+      return cached, "OpenCode Go limits stale", "", True
+    return [], "OpenCode Go limits unavailable", "Could not reach opencode.ai.", True
+
+  usage = payload.get("usage") if isinstance(payload, dict) else {}
+  windows = [
+    ("Rolling (5-hour)", usage.get("rolling")),
+    ("Weekly (7-day)", usage.get("weekly")),
+    ("Monthly (30-day)", usage.get("monthly")),
+  ]
+  limits: list[Any] = []
+  for label, window in windows:
+    if not isinstance(window, dict):
+      continue
+    if window.get("percent") is None or not window.get("resetsAt"):
+      continue
+    limits.append({
+      "label": label,
+      "percent": normalize_percent(window.get("percent")),
+      "resetsAt": normalize_resets_at(window.get("resetsAt")),
+    })
+  if not limits:
+    return [], "OpenCode Go limits unavailable", "No usage data returned for this key.", False
+  write_limits_cache(limits)
+  return limits, "", "", False
+
+
+# ---------------------------------------------------------------------- main
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Print the OpenCode Go usage record as JSON")
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  parser.add_argument("--usage-url", default=os.environ.get("OPENCODE_GO_USAGE_URL", USAGE_URL))
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
+  stats, _ = cached_local_stats(max_age)
+
+  record = base_record(hasLocalStats=opencode_db_path().is_file())
+  record.update(stats)
+
+  limits, usage_status, auth_help, retry_advised = fetch_limits(api_key(), args.usage_url)
+  record["limits"] = limits
+  if usage_status:
+    record["usageStatusText"] = usage_status
+  if auth_help:
+    record["authHelpText"] = auth_help
+  if retry_advised:
+    record["retryAdvised"] = True
+  record["ready"] = record["hasLocalStats"] or bool(limits)
+
+  print(json.dumps(record, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -31,7 +32,6 @@ from typing import Any
 AGENT_ID = "opencode-go"
 AGENT_NAME = "OpenCode Go"
 TIER_LABEL = "Go"
-AUTH_HELP = "Sign in to OpenCode Go in opencode, or set OPENCODE_API_KEY."
 USAGE_URL = "https://opencode.ai/zen/go/v1/usage"
 # opencode.ai sits behind Cloudflare and rejects the default urllib agent.
 USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
@@ -377,6 +377,8 @@ def fetch_limits(api_key_value: str, usage_url: str) -> tuple[list[Any], str, st
   """Return (limits, usage_status_text, auth_help_text, retry_advised)."""
   if not api_key_value:
     return [], "", "", False
+  if urllib.parse.urlparse(usage_url).scheme != "https":
+    return [], "OpenCode Go limits unavailable", "The usage endpoint must be HTTPS.", False
 
   request = urllib.request.Request(
     usage_url,
@@ -390,6 +392,11 @@ def fetch_limits(api_key_value: str, usage_url: str) -> tuple[list[Any], str, st
       return [], "OpenCode Go limits unavailable", "opencode.ai rejected the API key.", False
     if error.code == 403:
       return [], "OpenCode Go limits unavailable", "This key has no OpenCode Go subscription.", False
+    if error.code == 429 or 500 <= error.code < 600:
+      cached = read_limits_cache()
+      if cached:
+        return cached, "OpenCode Go limits stale", "", True
+      return [], "OpenCode Go limits unavailable", "opencode.ai returned HTTP %d." % error.code, True
     return [], "OpenCode Go limits unavailable", "opencode.ai returned HTTP %d." % error.code, False
   except Exception:
     # A flaky network should not blank the meters: reuse the last-known-good

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -26,7 +26,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, Fireworks, and OpenCode Go are covered out of the box.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -26,7 +26,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, Fireworks, and OpenCode Go are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of each rate-limit window (rolling 5-hour, weekly, and monthly — or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, Fireworks, and OpenCode Go are covered out of the box.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `opencode-go` | OpenCode Go's key-authenticated usage endpoint (5-hour rolling + weekly + monthly) | opencode sessions on the `opencode-go` provider |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -62,7 +63,8 @@ falls back to local stats only. A non-default Claude directory is honored via
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
-signed in there.
+signed in there. OpenCode Go reads `OPENCODE_API_KEY` first, then the key
+opencode stores in `~/.local/share/opencode/auth.json`.
 
 ### Fireworks balance
 
@@ -128,7 +130,8 @@ edit `shell.json` directly):
 omarchy bar set omarchy.agents providers '{
   "claude": { "enabled": true },
   "codex": { "enabled": false },
-  "fireworks": { "enabled": true }
+  "fireworks": { "enabled": true },
+  "opencode-go": { "enabled": true }
 }' --json
 ```
 

--- a/shell/plugins/agents/assets/opencode-go-light.svg
+++ b/shell/plugins/agents/assets/opencode-go-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 300" fill="none">
+  <path d="M180 240H60V120H180V240Z" fill="#CFCECD"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#211E1E"/>
+</svg>

--- a/shell/plugins/agents/assets/opencode-go.svg
+++ b/shell/plugins/agents/assets/opencode-go.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 300" fill="none">
+  <path d="M180 240H60V120H180V240Z" fill="#4B4646"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#F1ECEC"/>
+</svg>

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Fireworks, and OpenCode Go usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "opencode-go": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-opencode-go-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-scanner-test.sh
@@ -149,7 +149,7 @@ result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_H
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
   fail "OpenCode Go collector writes a fresh local-stats cache on first scan" "$result"
 cache_file=$(find "$CACHE_HOME/.cache/omarchy/agent-usage" -maxdepth 1 -name 'opencode-go-scan-*.json' -print -quit 2>/dev/null)
-[[ -n $cache_file && -s $cache_file ]] ||
+[[ -n "$cache_file" && -s "$cache_file" ]] ||
   fail "OpenCode Go collector leaves a cache file behind" "$result"
 [[ $(jq -r '.schemaVersion' "$cache_file") == "1" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
   fail "OpenCode Go collector writes a versioned cache envelope" "$result"

--- a/test/shell.d/agent-usage-opencode-go-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-scanner-test.sh
@@ -193,7 +193,8 @@ pass "OpenCode Go collector --force rescans past the cache"
 # The limits fetch and key resolution are exercised without the network by
 # importing the module and stubbing urlopen, the same way the Fireworks
 # scanner test stubs its client.
-if ! python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" "$TEST_HOME/.local/share" <<'PY'
+if ! HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" "$TEST_HOME/.local/share" <<'PY'
 import importlib.machinery
 import importlib.util
 import json

--- a/test/shell.d/agent-usage-opencode-go-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-scanner-test.sh
@@ -12,7 +12,7 @@ trap 'rm -rf "$TEST_HOME"' EXIT
 # default record: the update runner writes whatever valid JSON appears on
 # stdout, and a machine that never ran opencode shows no tab.
 no_source=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
-  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go")
+  OPENCODE_API_KEY='' "$ROOT/bin/omarchy-agent-usage-opencode-go")
 
 [[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasLocalStats | tostring)' <<<"$no_source") == "opencode-go:false:false" ]] ||
   fail "OpenCode Go collector prints a valid hidden record without a database or key" "$no_source"
@@ -58,7 +58,7 @@ conn.close()
 PY
 
 result=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
-  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
+  OPENCODE_API_KEY='' "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "155" ]] ||
   fail "OpenCode Go collector counts opencode-go usage, reasoning included, from opencode sessions" "$result"
@@ -110,7 +110,7 @@ conn.close()
 PY
 
 result=$(HOME="$MALFORMED_HOME" XDG_DATA_HOME="$MALFORMED_HOME/.local/share" XDG_CACHE_HOME="$MALFORMED_HOME/.cache" \
-  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go")
+  OPENCODE_API_KEY='' "$ROOT/bin/omarchy-agent-usage-opencode-go")
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "12" ]] ||
   fail "OpenCode Go collector counts good rows past malformed ones" "$result"
@@ -145,10 +145,10 @@ conn.close()
 PY
 
 result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_HOME="$CACHE_HOME/.cache" \
-  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go")
+  OPENCODE_API_KEY='' "$ROOT/bin/omarchy-agent-usage-opencode-go")
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
   fail "OpenCode Go collector writes a fresh local-stats cache on first scan" "$result"
-cache_file=$(ls "$CACHE_HOME/.cache/omarchy/agent-usage/"/opencode-go-scan-*.json 2>/dev/null | head -n 1)
+cache_file=$(find "$CACHE_HOME/.cache/omarchy/agent-usage" -maxdepth 1 -name 'opencode-go-scan-*.json' -print -quit 2>/dev/null)
 [[ -n $cache_file && -s $cache_file ]] ||
   fail "OpenCode Go collector leaves a cache file behind" "$result"
 [[ $(jq -r '.schemaVersion' "$cache_file") == "1" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
@@ -179,13 +179,13 @@ conn.close()
 PY
 
 result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_HOME="$CACHE_HOME/.cache" \
-  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go" --limits-only)
+  OPENCODE_API_KEY='' "$ROOT/bin/omarchy-agent-usage-opencode-go" --limits-only)
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
   fail "OpenCode Go collector --limits-only reuses cached local stats" "$result"
 pass "OpenCode Go collector --limits-only reuses cached local stats"
 
 result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_HOME="$CACHE_HOME/.cache" \
-  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
+  OPENCODE_API_KEY='' "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "15" ]] ||
   fail "OpenCode Go collector --force rescans past the cache" "$result"
 pass "OpenCode Go collector --force rescans past the cache"
@@ -193,7 +193,7 @@ pass "OpenCode Go collector --force rescans past the cache"
 # The limits fetch and key resolution are exercised without the network by
 # importing the module and stubbing urlopen, the same way the Fireworks
 # scanner test stubs its client.
-python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" "$TEST_HOME/.local/share" <<'PY'
+if ! python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" "$TEST_HOME/.local/share" <<'PY'
 import importlib.machinery
 import importlib.util
 import json
@@ -233,7 +233,7 @@ scanner.urllib.request.urlopen = respond({"usage": {
   "weekly": {"status": "ok", "percent": 50, "resetsAt": "2026-08-17T00:00:00Z"},
   "monthly": {"status": "ok", "percent": 0.5, "resetsAt": "2026-08-28T00:00:00Z"},
 }})
-limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://stub")
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
 assert [w["label"] for w in limits] == ["Rolling (5-hour)", "Weekly (7-day)", "Monthly (30-day)"]
 assert limits[0]["percent"] == 0.01, limits[0]
 assert limits[1]["percent"] == 0.5, limits[1]
@@ -242,16 +242,51 @@ assert limits[0]["resetsAt"] == "2026-08-16T06:00:00+00:00", limits[0]
 assert usage_status == "" and auth_help == "" and retry is False
 
 # A missing key is a clean no-op, not an error card.
-limits, usage_status, auth_help, retry = scanner.fetch_limits("", "http://stub")
+limits, usage_status, auth_help, retry = scanner.fetch_limits("", "https://stub")
 assert limits == [] and usage_status == "" and auth_help == "" and retry is False
 
 # Auth failures map to stable help text and never reuse stale limits.
 scanner.urllib.request.urlopen = http_error(401)
-limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://stub")
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
 assert auth_help == "opencode.ai rejected the API key.", auth_help
 scanner.urllib.request.urlopen = http_error(403)
-limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://stub")
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
 assert auth_help == "This key has no OpenCode Go subscription.", auth_help
+
+# The key must never travel over a non-HTTPS endpoint.
+scanner.urllib.request.urlopen = respond({"usage": {
+  "rolling": {"status": "ok", "percent": 10, "resetsAt": "2026-08-16T06:00:00Z"},
+}})
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://insecure")
+assert limits == [] and usage_status == "OpenCode Go limits unavailable" and retry is False, (limits, usage_status, retry)
+assert "HTTPS" in auth_help, auth_help
+
+# Transient failures (429, 5xx, and network errors) reuse cached limits and
+# ask the panel to retry, instead of blanking the meters.
+os.environ["XDG_CACHE_HOME"] = str(Path(sys.argv[2]) / "cache")
+scanner.urllib.request.urlopen = respond({"usage": {
+  "rolling": {"status": "ok", "percent": 10, "resetsAt": "2026-08-16T06:00:00Z"},
+}})
+limits, _, _, _ = scanner.fetch_limits("sk-test", "https://stub")
+assert limits and limits[0]["percent"] == 0.1, limits
+
+scanner.urllib.request.urlopen = http_error(429)
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
+assert limits and limits[0]["percent"] == 0.1, limits
+assert usage_status == "OpenCode Go limits stale" and auth_help == "" and retry is True, (usage_status, auth_help, retry)
+
+scanner.urllib.request.urlopen = http_error(503)
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
+assert limits and limits[0]["percent"] == 0.1, limits
+assert usage_status == "OpenCode Go limits stale" and auth_help == "" and retry is True, (usage_status, auth_help, retry)
+
+def url_error(*a, **k):
+  raise urllib.error.URLError("network down")
+
+scanner.urllib.request.urlopen = url_error
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
+assert limits and limits[0]["percent"] == 0.1, limits
+assert usage_status == "OpenCode Go limits stale" and auth_help == "" and retry is True, (usage_status, auth_help, retry)
 
 # OPENCODE_API_KEY wins over opencode's own auth.json.
 os.environ["XDG_DATA_HOME"] = sys.argv[2]
@@ -265,6 +300,7 @@ assert scanner.api_key() == "sk-from-auth-file"
 
 print("limits and key checks ok")
 PY
-
-[[ $? -eq 0 ]] || fail "OpenCode Go collector limits and key resolution checks"
+then
+  fail "OpenCode Go collector limits and key resolution checks"
+fi
 pass "OpenCode Go collector maps limits, scales percent, and resolves keys"

--- a/test/shell.d/agent-usage-opencode-go-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-scanner-test.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# Without a database or key the collector must still print a full, hidden-by-
+# default record: the update runner writes whatever valid JSON appears on
+# stdout, and a machine that never ran opencode shows no tab.
+no_source=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go")
+
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasLocalStats | tostring)' <<<"$no_source") == "opencode-go:false:false" ]] ||
+  fail "OpenCode Go collector prints a valid hidden record without a database or key" "$no_source"
+[[ $(jq -r '((.limits | length) | tostring) + ":" + .authHelpText' <<<"$no_source") == "0:" ]] ||
+  fail "OpenCode Go collector stays clean (no limits, no auth hint) without a key" "$no_source"
+pass "OpenCode Go collector prints a valid hidden record without a database or key"
+
+# A subscription burned through opencode has no native session files; usage
+# must come from opencode's message database, filtered to the opencode-go
+# provider. Reasoning folds into output and the cache split stays separate.
+python3 - "$TEST_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+
+def message(id, provider, model, role="assistant", input=0, output=0, reasoning=0, read=0, write=0, compact=False):
+  payload = {
+    "role": role,
+    "providerID": provider,
+    "modelID": model,
+    "tokens": {"input": input, "output": output, "reasoning": reasoning, "cache": {"read": read, "write": write}},
+    "time": {"created": now_ms},
+  }
+  return (id, "ses_1", now_ms, now_ms, json.dumps(payload, separators=(",", ":") if compact else None))
+
+conn.executemany("INSERT INTO message VALUES (?, ?, ?, ?, ?)", [
+  message("m_1", "opencode-go", "kimi-k2.6", input=80, output=40, reasoning=5, read=30, compact=True),
+  message("m_2", "anthropic", "claude-opus-5", input=999, output=999),
+  message("m_3", "opencode-go", "kimi-k2.6", role="user", input=999, output=999),
+  message("m_4", "opencode-go-proxy", "kimi-k2.6", input=999, output=999),
+  message("m_5", "openai", "gpt-5.2-codex", input=999, output=999),
+])
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_HOME/.local/share" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "155" ]] ||
+  fail "OpenCode Go collector counts opencode-go usage, reasoning included, from opencode sessions" "$result"
+[[ $(jq -c '.modelUsage["kimi-k2.6"]' <<<"$result") == '{"inputTokens":80,"outputTokens":45,"cacheReadInputTokens":30,"cacheCreationInputTokens":0}' ]] ||
+  fail "OpenCode Go collector does not double-count cache or reasoning tokens" "$result"
+[[ $(jq -r '.todayPrompts' <<<"$result") == "1" && $(jq -r '.totalPrompts' <<<"$result") == "1" ]] ||
+  fail "OpenCode Go collector counts one prompt for the one matching message" "$result"
+pass "OpenCode Go collector counts opencode-go usage from opencode sessions"
+
+# The provider match must be exact: prefix-colliding providers, other
+# providers, and user messages stay out. Malformed rows must not abort the
+# scan (json_valid guards the parse).
+MALFORMED_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$MALFORMED_HOME"' EXIT
+
+python3 - "$MALFORMED_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+
+def good(input):
+  return ("ses_1", now_ms, now_ms, json.dumps({
+    "role": "assistant", "providerID": "opencode-go", "modelID": "kimi-k2.6",
+    "tokens": {"input": input, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+    "time": {"created": now_ms},
+  }))
+
+rows = [("mm_1", *good(5))]
+rows.append(("mm_2", *good(7)))
+# Valid JSON followed by trailing garbage: json_valid turns this into a skip.
+garbage = json.dumps({
+  "role": "assistant", "providerID": "opencode-go", "modelID": "kimi-k2.6",
+  "tokens": {"input": 999, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+  "time": {"created": now_ms}}) + " trailing-garbage"
+rows.append(("mm_3", "ses_1", now_ms, now_ms, garbage))
+# Not JSON at all.
+rows.append(("mm_4", "ses_1", now_ms, now_ms, "this is not json"))
+conn.executemany("INSERT INTO message VALUES (?, ?, ?, ?, ?)", rows)
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$MALFORMED_HOME" XDG_DATA_HOME="$MALFORMED_HOME/.local/share" XDG_CACHE_HOME="$MALFORMED_HOME/.cache" \
+  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go")
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "12" ]] ||
+  fail "OpenCode Go collector counts good rows past malformed ones" "$result"
+pass "OpenCode Go collector counts good rows past malformed ones"
+
+# A warm cache makes --limits-only cheap: local stats come from the last scan
+# instead of another walk over the database, and --force bypasses it.
+CACHE_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$MALFORMED_HOME" "$CACHE_HOME"' EXIT
+
+python3 - "$CACHE_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+conn.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", (
+  "c_1", "ses_1", now_ms, now_ms, json.dumps({
+    "role": "assistant", "providerID": "opencode-go", "modelID": "kimi-k2.6",
+    "tokens": {"input": 5, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+    "time": {"created": now_ms},
+  }),
+))
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_HOME="$CACHE_HOME/.cache" \
+  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go")
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
+  fail "OpenCode Go collector writes a fresh local-stats cache on first scan" "$result"
+cache_file=$(ls "$CACHE_HOME/.cache/omarchy/agent-usage/"/opencode-go-scan-*.json 2>/dev/null | head -n 1)
+[[ -n $cache_file && -s $cache_file ]] ||
+  fail "OpenCode Go collector leaves a cache file behind" "$result"
+[[ $(jq -r '.schemaVersion' "$cache_file") == "1" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
+  fail "OpenCode Go collector writes a versioned cache envelope" "$result"
+pass "OpenCode Go collector writes a local-stats cache on first scan"
+
+# A new opencode-go message changes what a scan would find; a --limits-only
+# run must reuse the cached stats instead of rescanning.
+python3 - "$CACHE_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+conn = sqlite3.connect(db)
+now_ms = int(time.time() * 1000)
+conn.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", (
+  "c_2", "ses_1", now_ms, now_ms, json.dumps({
+    "role": "assistant", "providerID": "opencode-go", "modelID": "kimi-k2.6",
+    "tokens": {"input": 10, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+    "time": {"created": now_ms},
+  }),
+))
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_HOME="$CACHE_HOME/.cache" \
+  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go" --limits-only)
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
+  fail "OpenCode Go collector --limits-only reuses cached local stats" "$result"
+pass "OpenCode Go collector --limits-only reuses cached local stats"
+
+result=$(HOME="$CACHE_HOME" XDG_DATA_HOME="$CACHE_HOME/.local/share" XDG_CACHE_HOME="$CACHE_HOME/.cache" \
+  OPENCODE_API_KEY= "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "15" ]] ||
+  fail "OpenCode Go collector --force rescans past the cache" "$result"
+pass "OpenCode Go collector --force rescans past the cache"
+
+# The limits fetch and key resolution are exercised without the network by
+# importing the module and stubbing urlopen, the same way the Fireworks
+# scanner test stubs its client.
+python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" "$TEST_HOME/.local/share" <<'PY'
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+
+loader = importlib.machinery.SourceFileLoader("opencode_go_collector", str(Path(sys.argv[1])))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+scanner = importlib.util.module_from_spec(spec)
+loader.exec_module(scanner)
+
+class FakeResponse:
+  def __init__(self, payload):
+    self.payload = payload
+    self.status = 200
+  def read(self):
+    return json.dumps(self.payload).encode("utf-8")
+  def __enter__(self):
+    return self
+  def __exit__(self, *args):
+    return False
+
+def respond(payload):
+  return lambda *a, **k: FakeResponse(payload)
+
+def http_error(code):
+  def raiser(*a, **k):
+    raise urllib.error.HTTPError("http://stub", code, "{}", {}, None)
+  return raiser
+
+# The endpoint reports percent as 0..100; a value of exactly 1 means 1% and
+# must never be rescaled to 100. A fraction is scaled by the same rule.
+scanner.urllib.request.urlopen = respond({"usage": {
+  "rolling": {"status": "ok", "percent": 1, "resetsAt": "2026-08-16T06:00:00Z"},
+  "weekly": {"status": "ok", "percent": 50, "resetsAt": "2026-08-17T00:00:00Z"},
+  "monthly": {"status": "ok", "percent": 0.5, "resetsAt": "2026-08-28T00:00:00Z"},
+}})
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://stub")
+assert [w["label"] for w in limits] == ["Rolling (5-hour)", "Weekly (7-day)", "Monthly (30-day)"]
+assert limits[0]["percent"] == 0.01, limits[0]
+assert limits[1]["percent"] == 0.5, limits[1]
+assert limits[2]["percent"] == 0.005, limits[2]
+assert limits[0]["resetsAt"] == "2026-08-16T06:00:00+00:00", limits[0]
+assert usage_status == "" and auth_help == "" and retry is False
+
+# A missing key is a clean no-op, not an error card.
+limits, usage_status, auth_help, retry = scanner.fetch_limits("", "http://stub")
+assert limits == [] and usage_status == "" and auth_help == "" and retry is False
+
+# Auth failures map to stable help text and never reuse stale limits.
+scanner.urllib.request.urlopen = http_error(401)
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://stub")
+assert auth_help == "opencode.ai rejected the API key.", auth_help
+scanner.urllib.request.urlopen = http_error(403)
+limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "http://stub")
+assert auth_help == "This key has no OpenCode Go subscription.", auth_help
+
+# OPENCODE_API_KEY wins over opencode's own auth.json.
+os.environ["XDG_DATA_HOME"] = sys.argv[2]
+auth_path = Path(sys.argv[2]) / "opencode" / "auth.json"
+auth_path.parent.mkdir(parents=True, exist_ok=True)
+auth_path.write_text(json.dumps({"opencode-go": {"key": "sk-from-auth-file"}}))
+os.environ["OPENCODE_API_KEY"] = "sk-from-env"
+assert scanner.api_key() == "sk-from-env"
+os.environ.pop("OPENCODE_API_KEY")
+assert scanner.api_key() == "sk-from-auth-file"
+
+print("limits and key checks ok")
+PY
+
+[[ $? -eq 0 ]] || fail "OpenCode Go collector limits and key resolution checks"
+pass "OpenCode Go collector maps limits, scales percent, and resolves keys"

--- a/test/shell.d/agent-usage-opencode-go-scanner-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-scanner-test.sh
@@ -246,6 +246,20 @@ assert usage_status == "" and auth_help == "" and retry is False
 limits, usage_status, auth_help, retry = scanner.fetch_limits("", "https://stub")
 assert limits == [] and usage_status == "" and auth_help == "" and retry is False
 
+# A 200 carrying no usage object — an error body, or a key the endpoint has
+# nothing to say about — reads as no limits rather than raising.
+for payload in ({}, {"usage": None}, {"usage": ["rolling"]}, {"error": "no subscription"}):
+  scanner.urllib.request.urlopen = respond(payload)
+  limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")
+  assert limits == [] and auth_help == "No usage data returned for this key.", (payload, limits, auth_help)
+
+# The percentage is the number that decides whether the next prompt lands, so a
+# window keeps its meter when the reset time is missing; the panel just drops
+# the countdown.
+scanner.urllib.request.urlopen = respond({"usage": {"rolling": {"status": "ok", "percent": 93}}})
+limits, _, _, _ = scanner.fetch_limits("sk-test", "https://stub")
+assert limits == [{"label": "Rolling (5-hour)", "percent": 0.93, "resetsAt": ""}], limits
+
 # Auth failures map to stable help text and never reuse stale limits.
 scanner.urllib.request.urlopen = http_error(401)
 limits, usage_status, auth_help, retry = scanner.fetch_limits("sk-test", "https://stub")


### PR DESCRIPTION
## Summary

Adds an OpenCode Go tab to the agents panel.

![OpenCode Go panel](https://files.catbox.moe/3efqbh.png)

## Changes

- `bin/omarchy-agent-usage-opencode-go` — collector
- `shell/plugins/agents/assets/opencode-go{,-light}.svg` — logo
- `manifest.json`, `README.md`, `manual/17-ai.md` — defaults + docs
- `test/shell.d/agent-usage-opencode-go-scanner-test.sh` — tests

Built with OpenCode Go :), Kimi K3 & DeepSeek V4 Pro
