### PR TITLE
Keep the lock screen fingerprint working across suspend, and show when the reader is unavailable

### DIFF
--- a/bin/omarchy-apply-lock
+++ b/bin/omarchy-apply-lock
@@ -46,6 +46,8 @@ EOF
 # here rather than leaving the pair to drift apart between setups and updates.
 resume_hook_src="$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume"
 resume_hook_dst=/usr/lib/systemd/system-sleep/fprintd-resume
+stop_timeout_src="$OMARCHY_PATH/default/systemd/system/fprintd.service.d/10-stop-timeout.conf"
+stop_timeout_dst=/etc/systemd/system/fprintd.service.d/10-stop-timeout.conf
 
 # One " - #N: finger" line per enrolled print; a user without any gets "has no
 # fingers enrolled" instead, which must not count.
@@ -58,8 +60,17 @@ auth       required                    pam_fprintd.so
 account    include                     system-local-login
 EOF
   as_root install -Dm755 -o root -g root "$resume_hook_src" "$resume_hook_dst"
+  as_root install -Dm644 -o root -g root "$stop_timeout_src" "$stop_timeout_dst"
+  as_root systemctl daemon-reload
 else
   as_root rm -f /etc/pam.d/omarchy-lock-fingerprint "$resume_hook_dst"
+  # Only reload when something was there: this branch also runs in the
+  # install chroot, where there is no systemd to reload.
+  if [[ -e $stop_timeout_dst ]]; then
+    as_root rm -f "$stop_timeout_dst"
+    as_root rmdir --ignore-fail-on-non-empty "$(dirname "$stop_timeout_dst")"
+    as_root systemctl daemon-reload
+  fi
 fi
 
 # omarchy-shell can't reach a running shell during chroot install. The echo

--- a/bin/omarchy-apply-lock
+++ b/bin/omarchy-apply-lock
@@ -47,8 +47,10 @@ EOF
 resume_hook_src="$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume"
 resume_hook_dst=/usr/lib/systemd/system-sleep/fprintd-resume
 
+# One " - #N: finger" line per enrolled print; a user without any gets "has no
+# fingers enrolled" instead, which must not count.
 if [[ -x /usr/bin/fprintd-list ]] &&
-  /usr/bin/fprintd-list "$target_user" 2>/dev/null | grep -qi finger; then
+  /usr/bin/fprintd-list "$target_user" 2>/dev/null | grep -q ' - #'; then
   echo "Configuring lock screen fingerprint authentication..."
   as_root tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null <<'EOF'
 #%PAM-1.0

--- a/bin/omarchy-apply-lock
+++ b/bin/omarchy-apply-lock
@@ -40,6 +40,13 @@ auth       required                    pam_faillock.so authsucc
 account    include                     system-local-login
 EOF
 
+# The resume hook restarts fprintd after suspend so a verify wedged by the
+# sleep cannot leave the reader dead on the lock screen. It belongs exactly
+# where the fingerprint PAM file does, so install and remove them together
+# here rather than leaving the pair to drift apart between setups and updates.
+resume_hook_src="$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume"
+resume_hook_dst=/usr/lib/systemd/system-sleep/fprintd-resume
+
 if [[ -x /usr/bin/fprintd-list ]] &&
   /usr/bin/fprintd-list "$target_user" 2>/dev/null | grep -qi finger; then
   echo "Configuring lock screen fingerprint authentication..."
@@ -48,8 +55,9 @@ if [[ -x /usr/bin/fprintd-list ]] &&
 auth       required                    pam_fprintd.so
 account    include                     system-local-login
 EOF
+  as_root install -Dm755 -o root -g root "$resume_hook_src" "$resume_hook_dst"
 else
-  as_root rm -f /etc/pam.d/omarchy-lock-fingerprint
+  as_root rm -f /etc/pam.d/omarchy-lock-fingerprint "$resume_hook_dst"
 fi
 
 # omarchy-shell can't reach a running shell during chroot install. The echo

--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -27,11 +27,19 @@ remove_lock_fingerprint_pam() {
   fi
 }
 
+remove_resume_hook() {
+  if [[ -f /usr/lib/systemd/system-sleep/fprintd-resume ]]; then
+    echo "Removing fingerprint resume hook..."
+    sudo rm -f /usr/lib/systemd/system-sleep/fprintd-resume
+  fi
+}
+
 
 echo -e "\e[32mRemoving fingerprint scanner from authentication.\n\e[0m"
 
 remove_pam_config
 remove_lock_fingerprint_pam
+remove_resume_hook
 
 echo "Removing fingerprint packages..."
 omarchy-pkg-drop fprintd libfprint libfprint-git

--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -32,6 +32,12 @@ remove_resume_hook() {
     echo "Removing fingerprint resume hook..."
     sudo rm -f /usr/lib/systemd/system-sleep/fprintd-resume
   fi
+  if [[ -f /etc/systemd/system/fprintd.service.d/10-stop-timeout.conf ]]; then
+    echo "Removing fprintd stop timeout bound..."
+    sudo rm -f /etc/systemd/system/fprintd.service.d/10-stop-timeout.conf
+    sudo rmdir --ignore-fail-on-non-empty /etc/systemd/system/fprintd.service.d
+    sudo systemctl daemon-reload
+  fi
 }
 
 

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -69,9 +69,11 @@ install_resume_hook() {
   # A verify interrupted by suspend can wedge fprintd's device claim, leaving
   # the reader dead on the lock screen after resume until fprintd idle-exits.
   # The hook restarts fprintd on resume to clear it; see the hook for details.
+  # install sets owner and mode explicitly: systemd-sleep execs the hook, so
+  # it must be executable, and a `cp -p` would carry over the checkout's user
+  # ownership and whatever mode the tree happens to have.
   echo "Installing fingerprint resume hook..."
-  sudo mkdir -p /usr/lib/systemd/system-sleep
-  sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume" /usr/lib/systemd/system-sleep/
+  sudo install -Dm755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume" /usr/lib/systemd/system-sleep/fprintd-resume
 }
 
 

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -74,6 +74,12 @@ install_resume_hook() {
   # ownership and whatever mode the tree happens to have.
   echo "Installing fingerprint resume hook..."
   sudo install -Dm755 -o root -g root "$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume" /usr/lib/systemd/system-sleep/fprintd-resume
+
+  # A wedged fprintd can ignore SIGTERM, so the restart would otherwise wait
+  # out the full stop timeout before SIGKILL; bound it so the reader is back
+  # within seconds of resume.
+  sudo install -Dm644 -o root -g root "$OMARCHY_PATH/default/systemd/system/fprintd.service.d/10-stop-timeout.conf" /etc/systemd/system/fprintd.service.d/10-stop-timeout.conf
+  sudo systemctl daemon-reload
 }
 
 

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -65,6 +65,15 @@ account    include                     system-local-login
 EOF
 }
 
+install_resume_hook() {
+  # A verify interrupted by suspend can wedge fprintd's device claim, leaving
+  # the reader dead on the lock screen after resume until fprintd idle-exits.
+  # The hook restarts fprintd on resume to clear it; see the hook for details.
+  echo "Installing fingerprint resume hook..."
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume" /usr/lib/systemd/system-sleep/
+}
+
 
 echo -e "\e[32mSetting up fingerprint scanner for authentication.\n\e[0m"
 
@@ -100,6 +109,7 @@ if sudo fprintd-enroll "$USER"; then
     # pam_fprintd with nothing to match.
     setup_pam_config
     setup_lock_fingerprint_pam
+    install_resume_hook
     echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
     echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
   else

--- a/default/systemd/system-sleep/fprintd-resume
+++ b/default/systemd/system-sleep/fprintd-resume
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# A fingerprint verify still open when the machine suspends leaves fprintd
+# unable to hand the reader back: the verify dies with "Cannot run while
+# suspended" and the follow-up ReleaseDevice fails on the still-busy device.
+# The wedged claim then rejects every lock-screen attempt after resume until
+# fprintd exits on its own 30-second idle timer — so the reader looks dead for
+# up to half a minute while retries keep it from ever reaching that timer.
+#
+# Restarting fprintd on resume drops the claim so the reader answers on the
+# first touch instead. try-restart is a no-op when fprintd is not running,
+# which is the common case (nothing held the reader across the suspend), so a
+# healthy resume pays nothing.
+#
+# Installed by omarchy-setup-security-fingerprint, so its presence already
+# means a fingerprint reader is configured.
+
+if [[ $1 == "post" ]]; then
+  systemctl try-restart fprintd.service 2>/dev/null || true
+fi

--- a/default/systemd/system-sleep/fprintd-resume
+++ b/default/systemd/system-sleep/fprintd-resume
@@ -4,17 +4,33 @@
 # unable to hand the reader back: the verify dies with "Cannot run while
 # suspended" and the follow-up ReleaseDevice fails on the still-busy device.
 # The wedged claim then rejects every lock-screen attempt after resume until
-# fprintd exits on its own 30-second idle timer — so the reader looks dead for
-# up to half a minute while retries keep it from ever reaching that timer.
+# fprintd exits on its own 30-second idle timer, and each attempt re-arms that
+# timer — so without this hook the reader only recovers once the lock screen's
+# backoff leaves fprintd alone for long enough, about a minute at best.
+#
+# This is a workaround for an upstream fprintd defect, tracked at
+# https://gitlab.freedesktop.org/libfprint/fprintd/-/issues/173 (same shape in
+# fprintd#216): the daemon's own suspend handling kills the verify but the
+# release then fails, wedging the claim. Once fixed there, this hook and the
+# stop-timeout drop-in beside it can be removed.
 #
 # Restarting fprintd on resume drops the claim so the reader answers on the
-# first touch instead. try-restart is a no-op when fprintd is not running,
-# which is the common case (nothing held the reader across the suspend), so a
-# healthy resume pays nothing.
+# first touch instead. Omarchy locks before every suspend and the lock screen
+# opens a verify at once, so fprintd is running and claimed at nearly every
+# resume: the restart is real, not a no-op. A claim-wedged fprintd is idle and
+# exits on SIGTERM in milliseconds; one wedged on a stale device handle does
+# not, and rides out the stop timeout the sibling drop-in bounds.
 #
-# Installed by omarchy-setup-security-fingerprint, so its presence already
-# means a fingerprint reader is configured.
+# Installed next to /etc/pam.d/omarchy-lock-fingerprint by omarchy-apply-lock
+# and omarchy-setup-security-fingerprint, so its presence already means a
+# fingerprint reader is configured.
 
 if [[ $1 == "post" ]]; then
-  systemctl try-restart fprintd.service 2>/dev/null || true
+  # User sessions stay frozen until this hook returns, so do not wait for the
+  # restart: enqueue the job and let systemd run it as the desktop thaws. A
+  # wedged fprintd can ignore SIGTERM, and a synchronous restart would hold
+  # the thaw for its whole stop timeout precisely in the case the hook exists
+  # for. The lock screen tolerates the restart landing under its first attempt:
+  # that attempt fails and the next, a second later, claims the fresh daemon.
+  systemctl --no-block try-restart fprintd.service 2>/dev/null || true
 fi

--- a/default/systemd/system/fprintd.service.d/10-stop-timeout.conf
+++ b/default/systemd/system/fprintd.service.d/10-stop-timeout.conf
@@ -1,0 +1,11 @@
+# Installed next to the fprintd-resume sleep hook, which restarts fprintd on
+# every resume. An fprintd wedged on a stale device handle (the reader
+# re-enumerated across the sleep) does not answer SIGTERM, so that restart
+# would otherwise wait out the whole stop timeout before SIGKILL, keeping the
+# reader dead for that long after every wake it happens on. Bound it so the
+# restart lands within seconds.
+#
+# Numbered so an administrator's own drop-in (systemctl edit writes
+# override.conf) sorts after it and wins.
+[Service]
+TimeoutStopSec=3s

--- a/migrations/1787505445.sh
+++ b/migrations/1787505445.sh
@@ -1,0 +1,18 @@
+echo "Install the fingerprint resume hook on existing fingerprint setups"
+
+# omarchy-setup-security-fingerprint gained a system-sleep hook that restarts
+# fprintd on resume, so a verify wedged by suspend cannot leave the reader dead
+# on the lock screen. New setups install it; a machine that enrolled a finger
+# before the hook existed never re-runs setup, so drop it in here.
+
+hook_src="${OMARCHY_FPRINTD_RESUME_SRC:-$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume}"
+hook_dst="${OMARCHY_FPRINTD_RESUME_DST:-/usr/lib/systemd/system-sleep/fprintd-resume}"
+lock_pam="${OMARCHY_LOCK_FINGERPRINT_PAM:-/etc/pam.d/omarchy-lock-fingerprint}"
+
+# Only where fingerprint is configured, and only when the hook is absent -- an
+# existing copy may be newer or hand-edited, so leave it alone. install -Dm755
+# sets the executable bit explicitly, which systemd-sleep requires to run it.
+[[ -f $lock_pam && -f $hook_src && ! -e $hook_dst ]] || exit 0
+
+echo "Installing the fprintd resume hook"
+sudo install -Dm755 "$hook_src" "$hook_dst"

--- a/migrations/1787505445.sh
+++ b/migrations/1787505445.sh
@@ -2,17 +2,33 @@ echo "Install the fingerprint resume hook on existing fingerprint setups"
 
 # omarchy-setup-security-fingerprint gained a system-sleep hook that restarts
 # fprintd on resume, so a verify wedged by suspend cannot leave the reader dead
-# on the lock screen. New setups install it; a machine that enrolled a finger
-# before the hook existed never re-runs setup, so drop it in here.
+# on the lock screen, and a drop-in bounding fprintd's stop timeout so that
+# restart lands within seconds even when the daemon ignores SIGTERM. New setups
+# install both; a machine that enrolled a finger before they existed never
+# re-runs setup, so drop them in here.
 
 hook_src="${OMARCHY_FPRINTD_RESUME_SRC:-$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume}"
 hook_dst="${OMARCHY_FPRINTD_RESUME_DST:-/usr/lib/systemd/system-sleep/fprintd-resume}"
+stop_timeout_src="${OMARCHY_FPRINTD_STOP_TIMEOUT_SRC:-$OMARCHY_PATH/default/systemd/system/fprintd.service.d/10-stop-timeout.conf}"
+stop_timeout_dst="${OMARCHY_FPRINTD_STOP_TIMEOUT_DST:-/etc/systemd/system/fprintd.service.d/10-stop-timeout.conf}"
 lock_pam="${OMARCHY_LOCK_FINGERPRINT_PAM:-/etc/pam.d/omarchy-lock-fingerprint}"
 
-# Only where fingerprint is configured, and only when the hook is absent -- an
-# existing copy may be newer or hand-edited, so leave it alone. install -Dm755
-# sets the executable bit explicitly, which systemd-sleep requires to run it.
-[[ -f $lock_pam && -f $hook_src && ! -e $hook_dst ]] || exit 0
+# Only where fingerprint is configured, and only what is absent -- an existing
+# copy may be newer or hand-edited, so leave it alone. install -Dm755 sets the
+# executable bit explicitly, which systemd-sleep requires to run the hook.
+[[ -f $lock_pam ]] || exit 0
 
-echo "Installing the fprintd resume hook"
-sudo install -Dm755 "$hook_src" "$hook_dst"
+if [[ -f $hook_src && ! -e $hook_dst ]]; then
+  echo "Installing the fprintd resume hook"
+  sudo install -Dm755 "$hook_src" "$hook_dst"
+fi
+
+# An earlier build of this shipped the drop-in without the numeric prefix,
+# where it outranked an administrator's override.conf; replace that copy.
+legacy_stop_timeout="${stop_timeout_dst%/*}/stop-timeout.conf"
+if [[ -f $stop_timeout_src && ( -e $legacy_stop_timeout || ! -e $stop_timeout_dst ) ]]; then
+  echo "Bounding fprintd's stop timeout"
+  sudo rm -f "$legacy_stop_timeout"
+  sudo install -Dm644 "$stop_timeout_src" "$stop_timeout_dst"
+  sudo systemctl daemon-reload
+fi

--- a/shell/plugins/lock/FingerprintModel.js
+++ b/shell/plugins/lock/FingerprintModel.js
@@ -76,6 +76,22 @@ function shouldNudge(nowMs, lastNudgeMs, lastSettleMs, currentIntervalMs) {
   return true
 }
 
+// What a status probe's output means. "yes": an enrolled print exists
+// (fprintd-list prints one " - #N: finger" row per print). "no": definitely
+// not configured -- the probe script's own "no" (PAM file or fprintd-list
+// missing) or fprintd's explicit no-prints answer. Anything else is
+// "unknown": fprintd unreachable or restarting, which is exactly what the
+// resume hook produces, so a probe that could not tell must not overwrite
+// what the lock already knows -- concluding "no" switched off the retry
+// loop, the sleep watch and the notice for the rest of the lock (#9453).
+function classifyProbe(text) {
+  var s = String(text || "").trim()
+  if (s.indexOf(" - #") !== -1) return "yes"
+  if (s === "no") return "no"
+  if (/has no fingers enrolled/i.test(s)) return "no"
+  return "unknown"
+}
+
 // The streak after an attempt: a reached attempt clears it, an unreached one
 // advances it -- unless the machine just woke, in which case the miss is
 // most likely the resume restart landing under the attempt and the streak
@@ -123,6 +139,7 @@ if (typeof module !== "undefined") {
     SLEEP_GAP_MS: SLEEP_GAP_MS,
     RESUME_GRACE_MS: RESUME_GRACE_MS,
     spannedSleep: spannedSleep,
+    classifyProbe: classifyProbe,
     inResumeGrace: inResumeGrace,
     retryDelayMs: retryDelayMs,
     nextStreak: nextStreak,

--- a/shell/plugins/lock/FingerprintModel.js
+++ b/shell/plugins/lock/FingerprintModel.js
@@ -1,0 +1,65 @@
+// Retry pacing and the availability signal for the lock screen's fingerprint
+// loop. The signal is whether an attempt reached the reader at all: pam_fprintd
+// relays a "place your finger" prompt only once the claim has landed and the
+// verify is live, so an attempt that ends without ever prompting never reached
+// the device -- it is wedged (a verify killed by suspend), held by another
+// client, or gone. Those are what the backoff paces and the notice reports. An
+// attempt that did prompt proves the reader works (the user simply has not
+// swiped yet), so it clears the streak and the loop stays responsive.
+//
+// A finger that merely fails to match still prompted, so it resets too and
+// retries fast. Consecutive unreached attempts back off exponentially to a
+// ceiling above fprintd's 30-second idle exit, so a claim wedged without the
+// resume hook clearing it can still recover once the retries let fprintd idle
+// out.
+
+var MATCH_RETRY_MS = 250
+var ERROR_RETRY_BASE_MS = 1000
+var ERROR_RETRY_CAP_MS = 40000
+var UNAVAILABLE_AFTER = 3
+var NUDGE_COOLDOWN_MS = 2000
+var REACH_TIMEOUT_MS = 5000
+
+function retryDelayMs(streak) {
+  if (streak <= 0) return MATCH_RETRY_MS
+  var delay = ERROR_RETRY_BASE_MS * Math.pow(2, streak - 1)
+  return Math.min(delay, ERROR_RETRY_CAP_MS)
+}
+
+// Whether user presence should collapse the current backoff wait to a prompt
+// retry: only when a wait longer than the fast interval is pending, and at most
+// once per cooldown. The cooldown is what stops a moving cursor -- which raises
+// one wake per motion event -- from re-collapsing every fresh wait and spinning
+// the loop back up to the storm the backoff exists to prevent.
+function shouldNudge(nowMs, lastNudgeMs, currentIntervalMs) {
+  if (currentIntervalMs <= MATCH_RETRY_MS) return false
+  return (nowMs - lastNudgeMs) >= NUDGE_COOLDOWN_MS
+}
+
+// The streak after an attempt: a reached attempt clears it, an unreached one
+// advances it.
+function nextStreak(streak, reachedDevice) {
+  return reachedDevice ? 0 : streak + 1
+}
+
+// The reader is reported unavailable once enough consecutive attempts have
+// failed to reach it -- past any single transient claim conflict, but still
+// within a few seconds of a wake.
+function isUnavailable(streak) {
+  return streak >= UNAVAILABLE_AFTER
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    MATCH_RETRY_MS: MATCH_RETRY_MS,
+    ERROR_RETRY_BASE_MS: ERROR_RETRY_BASE_MS,
+    ERROR_RETRY_CAP_MS: ERROR_RETRY_CAP_MS,
+    UNAVAILABLE_AFTER: UNAVAILABLE_AFTER,
+    NUDGE_COOLDOWN_MS: NUDGE_COOLDOWN_MS,
+    REACH_TIMEOUT_MS: REACH_TIMEOUT_MS,
+    retryDelayMs: retryDelayMs,
+    nextStreak: nextStreak,
+    isUnavailable: isUnavailable,
+    shouldNudge: shouldNudge
+  }
+}

--- a/shell/plugins/lock/FingerprintModel.js
+++ b/shell/plugins/lock/FingerprintModel.js
@@ -15,7 +15,14 @@
 
 var MATCH_RETRY_MS = 250
 var ERROR_RETRY_BASE_MS = 1000
+// fprintd exits this long after its last client leaves; a claim wedged by a
+// verify killed under suspend dies with it. The cap sits above it so that,
+// with no hook to restart the daemon, a wait at the cap still clears it.
+var FPRINTD_IDLE_EXIT_MS = 30000
 var ERROR_RETRY_CAP_MS = 40000
+// The idle stretch a nudge must leave fprintd at the cap: its exit plus a
+// margin, so the daemon is gone before the nudged attempt claims.
+var IDLE_CLEAR_MS = FPRINTD_IDLE_EXIT_MS + 2000
 var UNAVAILABLE_AFTER = 3
 var NUDGE_COOLDOWN_MS = 2000
 var REACH_TIMEOUT_MS = 5000
@@ -30,10 +37,28 @@ function retryDelayMs(streak) {
 // retry: only when a wait longer than the fast interval is pending, and at most
 // once per cooldown. The cooldown is what stops a moving cursor -- which raises
 // one wake per motion event -- from re-collapsing every fresh wait and spinning
-// the loop back up to the storm the backoff exists to prevent.
-function shouldNudge(nowMs, lastNudgeMs, currentIntervalMs) {
+// the loop back up to the storm the backoff exists to prevent. It grows with
+// the pending wait: presence collapses each backed-off wait once, but a user
+// who keeps typing at a reader that keeps failing is still paced by the tier.
+//
+// At the cap the wait itself is the cure -- it is what lets fprintd idle out
+// and drop a wedged claim -- so there the idle stretch is measured from the
+// last settle, not the last nudge: a nudged attempt that hung until the reach
+// timeout would otherwise eat most of the window, and under continuous input
+// fprintd would never be left alone long enough to exit.
+function shouldNudge(nowMs, lastNudgeMs, lastSettleMs, currentIntervalMs) {
   if (currentIntervalMs <= MATCH_RETRY_MS) return false
-  return (nowMs - lastNudgeMs) >= NUDGE_COOLDOWN_MS
+  var sinceNudge = nowMs - lastNudgeMs
+  var sinceSettle = nowMs - lastSettleMs
+  // Wall-clock time can step backwards (timesyncd corrects RTC drift right
+  // after resume). A negative nudge gap is stale, not a fresh nudge, so it
+  // does not hold the nudge back. A negative settle gap is unknown idle time:
+  // below the cap that is harmless, but at the cap the idle stretch is the
+  // cure, so it counts as no idle at all rather than as enough.
+  if (sinceNudge >= 0 && sinceNudge < Math.max(NUDGE_COOLDOWN_MS, currentIntervalMs)) return false
+  if (sinceSettle < 0) sinceSettle = 0
+  if (currentIntervalMs >= ERROR_RETRY_CAP_MS && sinceSettle < IDLE_CLEAR_MS) return false
+  return true
 }
 
 // The streak after an attempt: a reached attempt clears it, an unreached one
@@ -54,6 +79,8 @@ if (typeof module !== "undefined") {
     MATCH_RETRY_MS: MATCH_RETRY_MS,
     ERROR_RETRY_BASE_MS: ERROR_RETRY_BASE_MS,
     ERROR_RETRY_CAP_MS: ERROR_RETRY_CAP_MS,
+    FPRINTD_IDLE_EXIT_MS: FPRINTD_IDLE_EXIT_MS,
+    IDLE_CLEAR_MS: IDLE_CLEAR_MS,
     UNAVAILABLE_AFTER: UNAVAILABLE_AFTER,
     NUDGE_COOLDOWN_MS: NUDGE_COOLDOWN_MS,
     REACH_TIMEOUT_MS: REACH_TIMEOUT_MS,

--- a/shell/plugins/lock/FingerprintModel.js
+++ b/shell/plugins/lock/FingerprintModel.js
@@ -25,7 +25,14 @@ var ERROR_RETRY_CAP_MS = 40000
 var IDLE_CLEAR_MS = FPRINTD_IDLE_EXIT_MS + 2000
 var UNAVAILABLE_AFTER = 3
 var NUDGE_COOLDOWN_MS = 2000
-var REACH_TIMEOUT_MS = 5000
+// How long an attempt may go without prompting before it is aborted as stuck.
+// Bounded above by pam_fprintd: its 30s verify timeout ends the attempt with a
+// non-error "Verification timed out" message that would read as reached, and
+// GDBus fails a Claim that never returns at 25s. Bounded below by the reader:
+// aborting kills the PAM child mid-Claim, which fprintd keeps tearing down
+// until the device open completes, so the bound must outlast a slow open --
+// out-of-tree drivers take several seconds, more right after resume.
+var REACH_TIMEOUT_MS = 20000
 
 function retryDelayMs(streak) {
   if (streak <= 0) return MATCH_RETRY_MS

--- a/shell/plugins/lock/FingerprintModel.js
+++ b/shell/plugins/lock/FingerprintModel.js
@@ -33,6 +33,14 @@ var NUDGE_COOLDOWN_MS = 2000
 // until the device open completes, so the bound must outlast a slow open --
 // out-of-tree drivers take several seconds, more right after resume.
 var REACH_TIMEOUT_MS = 20000
+// Monotonic timers pause across suspend, so a wait or an attempt that took
+// this much longer on the wall clock than it should have spanned a sleep.
+var SLEEP_GAP_MS = 2000
+// For this long after a resume the hook is restarting fprintd underneath the
+// loop (a 3s stop cap plus the start), so a miss says nothing about the
+// reader; misses inside it keep retrying at the first tier and never count
+// toward the notice.
+var RESUME_GRACE_MS = 5000
 
 function retryDelayMs(streak) {
   if (streak <= 0) return MATCH_RETRY_MS
@@ -69,9 +77,30 @@ function shouldNudge(nowMs, lastNudgeMs, lastSettleMs, currentIntervalMs) {
 }
 
 // The streak after an attempt: a reached attempt clears it, an unreached one
-// advances it.
-function nextStreak(streak, reachedDevice) {
-  return reachedDevice ? 0 : streak + 1
+// advances it -- unless the machine just woke, in which case the miss is
+// most likely the resume restart landing under the attempt and the streak
+// holds at the first tier instead.
+function nextStreak(streak, reachedDevice, inResumeGrace) {
+  if (reachedDevice) return 0
+  if (inResumeGrace) return 1
+  return streak + 1
+}
+
+// Whether something that should have taken expectedMs of monotonic time took
+// so much longer on the wall clock that the machine must have slept meanwhile.
+// A stalled event loop reads the same way, and a stall over the slack opens a
+// resume grace with no suspend behind it. That is tolerated: the grace only
+// pins the streak at the first tier, so even a loop stalling continuously
+// degrades to one attempt a second, still well under the storm it replaces.
+function spannedSleep(elapsedMs, expectedMs) {
+  return elapsedMs > expectedMs + SLEEP_GAP_MS
+}
+
+// Whether a resume noted at resumedAtMs still covers an attempt settling now.
+function inResumeGrace(nowMs, resumedAtMs) {
+  if (resumedAtMs <= 0) return false
+  var elapsed = nowMs - resumedAtMs
+  return elapsed >= 0 && elapsed < RESUME_GRACE_MS
 }
 
 // The reader is reported unavailable once enough consecutive attempts have
@@ -91,6 +120,10 @@ if (typeof module !== "undefined") {
     UNAVAILABLE_AFTER: UNAVAILABLE_AFTER,
     NUDGE_COOLDOWN_MS: NUDGE_COOLDOWN_MS,
     REACH_TIMEOUT_MS: REACH_TIMEOUT_MS,
+    SLEEP_GAP_MS: SLEEP_GAP_MS,
+    RESUME_GRACE_MS: RESUME_GRACE_MS,
+    spannedSleep: spannedSleep,
+    inResumeGrace: inResumeGrace,
     retryDelayMs: retryDelayMs,
     nextStreak: nextStreak,
     isUnavailable: isUnavailable,

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -9,6 +9,7 @@ Item {
   property string backgroundPath: ""
   property int backgroundVersion: 0
   property bool fingerprintConfigured: false
+  property bool fingerprintUnavailable: false
   property bool authenticatingPassword: false
   property string failureMessage: ""
   property int failedAttempts: 0
@@ -202,20 +203,41 @@ Item {
       // Fingerprint hint pinned inside the field's right edge when a sensor is
       // enrolled, so the user knows they can touch to unlock instead of typing.
       // Matches hyprlock, which draws its fingerprint icon in the same spot.
+      // A reader the shell cannot reach crosses out rather than disappears, so
+      // it stops inviting touches that can never unlock.
       Text {
         id: fingerprintIcon
         objectName: "fingerprintIndicator"
+        textFormat: Text.PlainText
         anchors.right: parent.right
         anchors.rightMargin: inputField.borderRight + 18
         anchors.verticalCenter: parent.verticalCenter
         visible: root.fingerprintConfigured
-        text: "󰈷"
-        color: Color.lock.placeholder
+        text: root.fingerprintUnavailable ? "󰺱" : "󰈷"
+        color: root.fingerprintUnavailable ? Color.lock.textError : Color.lock.placeholder
         font.family: Style.font.family
         font.pixelSize: Math.round(root.fieldFontSize * 1.1)
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
       }
+    }
+
+    // The crossed-out icon has no meaning to a user who has never seen it — it
+    // is not intuitive that it signals a broken reader — so the words carry the
+    // explanation and the icon only reinforces it.
+    Text {
+      objectName: "fingerprintUnavailableNotice"
+      textFormat: Text.PlainText
+      anchors.top: inputField.bottom
+      anchors.topMargin: 18
+      anchors.horizontalCenter: inputField.horizontalCenter
+      visible: root.fingerprintConfigured && root.fingerprintUnavailable
+      text: "Fingerprint reader unavailable"
+      color: Color.lock.textError
+      font.family: Style.font.family
+      font.pixelSize: Style.font.heading
+      font.italic: true
+      horizontalAlignment: Text.AlignHCenter
     }
   }
 }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -28,6 +28,7 @@ Item {
   property double fingerprintLastNudgeMs: 0
   property double fingerprintLastSettleMs: 0
   property double fingerprintResumedAtMs: 0
+  property int fingerprintProbeStreak: 0
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -130,6 +131,35 @@ Item {
     if (!fingerprintCheckProc.running) fingerprintCheckProc.running = true
   }
 
+  // An unreachable fprintd -- restarting under the resume hook, or still
+  // activating -- answers the probe with an error, not with "no prints".
+  // Concluding "not configured" from that stopped the retry loop and the
+  // sleep watch for the rest of the lock (#9453); keep the current state and
+  // ask again instead. Only a definitive answer changes anything.
+  function applyFingerprintProbe(text) {
+    var status = FingerprintModel.classifyProbe(text)
+    if (status === "unknown") {
+      fingerprintProbeStreak += 1
+      if (lockRequested) {
+        fingerprintRecheckTimer.interval = FingerprintModel.retryDelayMs(fingerprintProbeStreak)
+        fingerprintRecheckTimer.restart()
+      }
+      return
+    }
+    fingerprintProbeStreak = 0
+    fingerprintConfigured = status === "yes"
+    if (lockRequested && fingerprintConfigured) {
+      // A pending retry already owns the next attempt.
+      if (!fingerprintRetryTimer.running) startFingerprint()
+    } else if (!fingerprintConfigured) {
+      // abort() delivers no completion signal, so close the attempt here
+      // too; settle returns before arming a retry while unconfigured.
+      if (fingerprintPam.active) fingerprintPam.abort()
+      settleFingerprintAttempt()
+      fingerprintRetryTimer.stop()
+    }
+  }
+
   function logEvent(event) {
     lastEvent = event
     lastEventAt = new Date().toISOString()
@@ -147,6 +177,8 @@ Item {
     fingerprintLastNudgeMs = 0
     fingerprintLastSettleMs = 0
     fingerprintResumedAtMs = 0
+    fingerprintProbeStreak = 0
+    fingerprintRecheckTimer.stop()
     fingerprintRetryTimer.stop()
     fingerprintReachTimer.stop()
     if (passwordPam.active) passwordPam.abort()
@@ -569,28 +601,23 @@ Item {
     }
   }
 
-  // Configured means a print is actually enrolled: fprintd-list prints one
-  // " - #N: finger" line per print, while a user without any gets "has no
-  // fingers enrolled" or a ListEnrolledFingers failure, both of which a looser
-  // match would take as yes and then chase with a reader the account cannot
-  // use.
+  // The probe hands fprintd-list's raw output (errors included) to
+  // classifyProbe, which answers yes, no, or unknown; only a definitive
+  // answer may change fingerprintConfigured. See applyFingerprintProbe.
   Process {
     id: fingerprintCheckProc
-    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$USER\" 2>/dev/null | grep -q ' - #'; then echo yes; else echo no; fi"]
+    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1; then fprintd-list \"$USER\" 2>&1; else echo no; fi"]
     stdout: StdioCollector { id: fingerprintCheckStdout; waitForEnd: true }
-    onExited: {
-      root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"
-      if (root.lockRequested && root.fingerprintConfigured) {
-        // A pending retry already owns the next attempt.
-        if (!fingerprintRetryTimer.running) root.startFingerprint()
-      } else if (!root.fingerprintConfigured) {
-        // abort() delivers no completion signal, so close the attempt here
-        // too; settle returns before arming a retry while unconfigured.
-        if (fingerprintPam.active) fingerprintPam.abort()
-        root.settleFingerprintAttempt()
-        fingerprintRetryTimer.stop()
-      }
-    }
+    onExited: root.applyFingerprintProbe(fingerprintCheckStdout.text)
+  }
+
+  // Retries a probe that could not reach fprintd, paced like the attempt
+  // retries so a daemon that stays unreachable is asked about ever less often.
+  Timer {
+    id: fingerprintRecheckTimer
+    interval: FingerprintModel.ERROR_RETRY_BASE_MS
+    repeat: false
+    onTriggered: root.refreshFingerprintStatus()
   }
 
   Process {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -293,9 +293,11 @@ Item {
       refreshFingerprintStatus()
       return
     }
-    // Bound the wait for the first prompt: a claim that never lands (a daemon
-    // restarted under the verify, e.g. by the resume hook) otherwise hangs
-    // here without ever erroring, and nothing downstream re-arms.
+    // Bound the wait for the first prompt: a claim fprintd accepts but never
+    // completes (a device open stuck behind a wedged claim) otherwise sits here
+    // for GDBus's full call timeout without erroring, and nothing downstream
+    // re-arms. A daemon restarted under the verify is not that case; it fails
+    // the attempt promptly. See REACH_TIMEOUT_MS for the bound's limits.
     fingerprintReachTimer.restart()
   }
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -26,6 +26,7 @@ Item {
   property int fingerprintUnreachedStreak: 0
   property bool fingerprintAttemptReachedDevice: false
   property double fingerprintLastNudgeMs: 0
+  property double fingerprintLastSettleMs: 0
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -143,6 +144,7 @@ Item {
     fingerprintAuthenticating = false
     fingerprintUnreachedStreak = 0
     fingerprintLastNudgeMs = 0
+    fingerprintLastSettleMs = 0
     fingerprintRetryTimer.stop()
     fingerprintReachTimer.stop()
     if (passwordPam.active) passwordPam.abort()
@@ -200,13 +202,14 @@ Item {
   // trying now, so collapse a backed-off wait to a prompt retry rather than
   // ride out the cap. Rate-limited (see shouldNudge): a moving cursor raises a
   // wake per motion event, and without the floor each fresh backoff wait would
-  // be re-collapsed straight back into the storm the backoff exists to prevent.
+  // be re-collapsed straight back into the storm the backoff exists to prevent;
+  // past the floor, the current tier paces repeat nudges.
   function nudgeFingerprint() {
     if (!lockRequested || !fingerprintConfigured) return
     if (fingerprintPam.active || fingerprintAuthenticating) return
     if (!fingerprintRetryTimer.running) return
     var now = Date.now()
-    if (!FingerprintModel.shouldNudge(now, fingerprintLastNudgeMs, fingerprintRetryTimer.interval)) return
+    if (!FingerprintModel.shouldNudge(now, fingerprintLastNudgeMs, fingerprintLastSettleMs, fingerprintRetryTimer.interval)) return
     fingerprintLastNudgeMs = now
     fingerprintRetryTimer.interval = FingerprintModel.MATCH_RETRY_MS
     fingerprintRetryTimer.restart()
@@ -325,6 +328,7 @@ Item {
     if (!lockRequested || !fingerprintConfigured) return
 
     fingerprintUnreachedStreak = FingerprintModel.nextStreak(fingerprintUnreachedStreak, fingerprintAttemptReachedDevice)
+    fingerprintLastSettleMs = Date.now()
     fingerprintRetryTimer.interval = FingerprintModel.retryDelayMs(fingerprintUnreachedStreak)
     fingerprintRetryTimer.restart()
   }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -27,6 +27,7 @@ Item {
   property bool fingerprintAttemptReachedDevice: false
   property double fingerprintLastNudgeMs: 0
   property double fingerprintLastSettleMs: 0
+  property double fingerprintResumedAtMs: 0
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -145,6 +146,7 @@ Item {
     fingerprintUnreachedStreak = 0
     fingerprintLastNudgeMs = 0
     fingerprintLastSettleMs = 0
+    fingerprintResumedAtMs = 0
     fingerprintRetryTimer.stop()
     fingerprintReachTimer.stop()
     if (passwordPam.active) passwordPam.abort()
@@ -211,8 +213,36 @@ Item {
     var now = Date.now()
     if (!FingerprintModel.shouldNudge(now, fingerprintLastNudgeMs, fingerprintLastSettleMs, fingerprintRetryTimer.interval)) return
     fingerprintLastNudgeMs = now
-    fingerprintRetryTimer.interval = FingerprintModel.MATCH_RETRY_MS
+    armFingerprintRetry(FingerprintModel.MATCH_RETRY_MS)
+  }
+
+  function armFingerprintRetry(delayMs) {
+    fingerprintRetryTimer.interval = delayMs
+    fingerprintRetryTimer.armedAt = Date.now()
     fingerprintRetryTimer.restart()
+  }
+
+  // Monotonic timers pause across suspend, so a wait armed before the sleep
+  // picks up mid-count afterwards -- and the streak it was pacing was built
+  // against the reader as it stood before the sleep. The resume hook is
+  // restarting fprintd, so that streak is stale: drop it, and open the grace
+  // window in which the restart landing under an attempt does not count as a
+  // miss either (see RESUME_GRACE_MS). Idempotent within the window, since a
+  // resume can be noticed by more than one timer.
+  function noteFingerprintResumed() {
+    var now = Date.now()
+    if (FingerprintModel.inResumeGrace(now, fingerprintResumedAtMs)) return
+    fingerprintResumedAtMs = now
+    fingerprintUnreachedStreak = 0
+  }
+
+  // A resume noticed while a backed-off wait is pending: retry the fresh
+  // reader now, instead of after the remaining wait or the next keypress.
+  function restartFingerprintAfterSleep() {
+    noteFingerprintResumed()
+    if (fingerprintAuthenticating || fingerprintPam.active) return
+    if (!fingerprintRetryTimer.running) return
+    armFingerprintRetry(FingerprintModel.MATCH_RETRY_MS)
   }
 
   function runBlank() {
@@ -329,10 +359,22 @@ Item {
     fingerprintReachTimer.stop()
     if (!lockRequested || !fingerprintConfigured) return
 
-    fingerprintUnreachedStreak = FingerprintModel.nextStreak(fingerprintUnreachedStreak, fingerprintAttemptReachedDevice)
-    fingerprintLastSettleMs = Date.now()
-    fingerprintRetryTimer.interval = FingerprintModel.retryDelayMs(fingerprintUnreachedStreak)
-    fingerprintRetryTimer.restart()
+    // The sleep watch ticks every second while locked, so a settle that finds
+    // its last tick far in the past is the first thing to run after a resume:
+    // this attempt was in flight across the suspend and was ended by the
+    // restart, not by the reader. Judged from the tick rather than the
+    // attempt's own age so a suspend shorter than the reach bound is caught
+    // too, before the tick itself gets a chance to.
+    var now = Date.now()
+    if (!fingerprintAttemptReachedDevice && fingerprintSleepWatch.running
+        && FingerprintModel.spannedSleep(now - fingerprintSleepWatch.lastTickMs, fingerprintSleepWatch.interval)) {
+      noteFingerprintResumed()
+    }
+
+    var inGrace = FingerprintModel.inResumeGrace(now, fingerprintResumedAtMs)
+    fingerprintUnreachedStreak = FingerprintModel.nextStreak(fingerprintUnreachedStreak, fingerprintAttemptReachedDevice, inGrace)
+    fingerprintLastSettleMs = now
+    armFingerprintRetry(FingerprintModel.retryDelayMs(fingerprintUnreachedStreak))
   }
 
   function handleFingerprintFinished(result) {
@@ -478,7 +520,31 @@ Item {
     id: fingerprintRetryTimer
     interval: FingerprintModel.MATCH_RETRY_MS
     repeat: false
-    onTriggered: root.startFingerprint()
+    property double armedAt: 0
+    onTriggered: {
+      // A wait that took far longer on the wall clock than its interval
+      // spanned a suspend; see noteFingerprintResumed.
+      if (FingerprintModel.spannedSleep(Date.now() - armedAt, interval)) root.noteFingerprintResumed()
+      root.startFingerprint()
+    }
+  }
+
+  // Watches the wall clock for the whole lock, so a resume is noticed within
+  // a tick whatever the loop was doing -- mid-wait, or with an attempt in
+  // flight that the restart is about to end.
+  Timer {
+    id: fingerprintSleepWatch
+    interval: 1000
+    repeat: true
+    running: root.lockRequested && root.fingerprintConfigured
+    property double lastTickMs: 0
+    onRunningChanged: lastTickMs = Date.now()
+    onTriggered: {
+      var now = Date.now()
+      var slept = FingerprintModel.spannedSleep(now - lastTickMs, interval)
+      lastTickMs = now
+      if (slept) root.restartFingerprintAfterSleep()
+    }
   }
 
   Timer {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -271,9 +271,19 @@ Item {
 
   // A resume noticed while a backed-off wait is pending: retry the fresh
   // reader now, instead of after the remaining wait or the next keypress.
+  // An attempt still in flight is worse than a pending wait: the hook has
+  // restarted fprintd under it, so it sits on a dead conversation that
+  // pam_fprintd takes ~25s to give up on (#8747) while the icon invites
+  // touches that cannot work. Abort it and settle -- inside the grace
+  // window, so the kill never counts toward the notice -- and the settle
+  // arms the fast retry itself.
   function restartFingerprintAfterSleep() {
     noteFingerprintResumed()
-    if (fingerprintAuthenticating || fingerprintPam.active) return
+    if (fingerprintAuthenticating || fingerprintPam.active) {
+      if (fingerprintPam.active) fingerprintPam.abort()
+      settleFingerprintAttempt()
+      return
+    }
     if (!fingerprintRetryTimer.running) return
     armFingerprintRetry(FingerprintModel.MATCH_RETRY_MS)
   }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -264,6 +264,7 @@ Item {
   function noteFingerprintResumed() {
     var now = Date.now()
     if (FingerprintModel.inResumeGrace(now, fingerprintResumedAtMs)) return
+    logEvent("fingerprint-resume: streak=" + fingerprintUnreachedStreak)
     fingerprintResumedAtMs = now
     fingerprintUnreachedStreak = 0
   }
@@ -377,6 +378,7 @@ Item {
   // advances the streak (and so the notice) and retries against a daemon that
   // may now be fresh, instead of hanging silently behind a normal icon.
   function timeoutFingerprintReach() {
+    logEvent("fingerprint-reach-timeout")
     if (fingerprintPam.active) fingerprintPam.abort()
     settleFingerprintAttempt()
   }
@@ -403,15 +405,30 @@ Item {
       noteFingerprintResumed()
     }
 
+    // Reached attempts are the steady state (one per swipe window), so only
+    // the misses and the recovery from them leave a trace.
+    var previousStreak = fingerprintUnreachedStreak
     var inGrace = FingerprintModel.inResumeGrace(now, fingerprintResumedAtMs)
-    fingerprintUnreachedStreak = FingerprintModel.nextStreak(fingerprintUnreachedStreak, fingerprintAttemptReachedDevice, inGrace)
+    fingerprintUnreachedStreak = FingerprintModel.nextStreak(previousStreak, fingerprintAttemptReachedDevice, inGrace)
+    if (!fingerprintAttemptReachedDevice) {
+      var crossed = !FingerprintModel.isUnavailable(previousStreak) && FingerprintModel.isUnavailable(fingerprintUnreachedStreak)
+      logEvent((crossed ? "fingerprint-unavailable" : "fingerprint-unreached") + ": streak=" + fingerprintUnreachedStreak)
+    } else if (previousStreak > 0) {
+      logEvent("fingerprint-recovered: streak=" + previousStreak)
+    }
     fingerprintLastSettleMs = now
     armFingerprintRetry(FingerprintModel.retryDelayMs(fingerprintUnreachedStreak))
   }
 
   function handleFingerprintFinished(result) {
-    if (result === PamResult.Success && lockRequested) finishUnlock()
-    else settleFingerprintAttempt()
+    if (result === PamResult.Success && lockRequested) {
+      // A match after a run of misses is the recovery too; the unlock resets
+      // the streak without settling, so log it here or it leaves no trace.
+      if (fingerprintUnreachedStreak > 0) logEvent("fingerprint-recovered: streak=" + fingerprintUnreachedStreak)
+      finishUnlock()
+    } else {
+      settleFingerprintAttempt()
+    }
   }
 
   WlSessionLock {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -282,7 +282,12 @@ Item {
     fingerprintAuthenticating = true
     fingerprintAttemptReachedDevice = false
     if (!fingerprintPam.start()) {
+      // A start that fails before PAM even runs is a configuration problem
+      // (the PAM file removed under the lock), not a reader miss. Settle for
+      // pacing, then re-check: an unconfigured result hides the icon and stops
+      // the retries rather than counting toward "reader unavailable".
       settleFingerprintAttempt()
+      refreshFingerprintStatus()
       return
     }
     // Bound the wait for the first prompt: a claim that never lands (a daemon
@@ -503,8 +508,16 @@ Item {
     stdout: StdioCollector { id: fingerprintCheckStdout; waitForEnd: true }
     onExited: {
       root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"
-      if (root.lockRequested && root.fingerprintConfigured) root.startFingerprint()
-      else if (!root.fingerprintConfigured && fingerprintPam.active) fingerprintPam.abort()
+      if (root.lockRequested && root.fingerprintConfigured) {
+        // A pending retry already owns the next attempt.
+        if (!fingerprintRetryTimer.running) root.startFingerprint()
+      } else if (!root.fingerprintConfigured) {
+        // abort() delivers no completion signal, so close the attempt here
+        // too; settle returns before arming a retry while unconfigured.
+        if (fingerprintPam.active) fingerprintPam.abort()
+        root.settleFingerprintAttempt()
+        fingerprintRetryTimer.stop()
+      }
     }
   }
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -492,9 +492,14 @@ Item {
     }
   }
 
+  // Configured means a print is actually enrolled: fprintd-list prints one
+  // " - #N: finger" line per print, while a user without any gets "has no
+  // fingers enrolled" or a ListEnrolledFingers failure, both of which a looser
+  // match would take as yes and then chase with a reader the account cannot
+  // use.
   Process {
     id: fingerprintCheckProc
-    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$USER\" 2>/dev/null | grep -qi finger; then echo yes; else echo no; fi"]
+    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$USER\" 2>/dev/null | grep -q ' - #'; then echo yes; else echo no; fi"]
     stdout: StdioCollector { id: fingerprintCheckStdout; waitForEnd: true }
     onExited: {
       root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 import Quickshell.Services.Pam
 import Quickshell.Wayland
 import qs.Commons
+import "FingerprintModel.js" as FingerprintModel
 
 Item {
   id: root
@@ -22,6 +23,9 @@ Item {
   property bool fingerprintAuthenticating: false
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
+  property int fingerprintUnreachedStreak: 0
+  property bool fingerprintAttemptReachedDevice: false
+  property double fingerprintLastNudgeMs: 0
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -46,6 +50,13 @@ Item {
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
   readonly property var batteryService: shell && shell.services ? shell.firstPartyServiceFor("omarchy.battery") : null
   readonly property bool powerSaverActive: batteryService ? batteryService.powerSaverOnBattery : false
+  // The reader is unavailable once enough consecutive attempts fail to even
+  // reach it (see FingerprintModel). Distinct from a finger that simply did not
+  // match, which reaches the device and clears the streak. The in-flight reach
+  // clears the notice the moment a prompt arrives, a settle ahead of the streak
+  // reset -- so a recovered reader stops saying "unavailable" at once instead of
+  // waiting out the current attempt.
+  readonly property bool fingerprintUnavailable: fingerprintConfigured && !fingerprintAttemptReachedDevice && FingerprintModel.isUnavailable(fingerprintUnreachedStreak)
 
   function realScreenCount() {
     var screens = Quickshell.screens || []
@@ -130,7 +141,10 @@ Item {
     failedAttempts = 0
     authenticatingPassword = false
     fingerprintAuthenticating = false
+    fingerprintUnreachedStreak = 0
+    fingerprintLastNudgeMs = 0
     fingerprintRetryTimer.stop()
+    fingerprintReachTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
   }
@@ -179,6 +193,23 @@ Item {
     root.monitorDpmsKnown = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
+    nudgeFingerprint()
+  }
+
+  // A keypress, touch, or cursor move is the user saying the reader is worth
+  // trying now, so collapse a backed-off wait to a prompt retry rather than
+  // ride out the cap. Rate-limited (see shouldNudge): a moving cursor raises a
+  // wake per motion event, and without the floor each fresh backoff wait would
+  // be re-collapsed straight back into the storm the backoff exists to prevent.
+  function nudgeFingerprint() {
+    if (!lockRequested || !fingerprintConfigured) return
+    if (fingerprintPam.active || fingerprintAuthenticating) return
+    if (!fingerprintRetryTimer.running) return
+    var now = Date.now()
+    if (!FingerprintModel.shouldNudge(now, fingerprintLastNudgeMs, fingerprintRetryTimer.interval)) return
+    fingerprintLastNudgeMs = now
+    fingerprintRetryTimer.interval = FingerprintModel.MATCH_RETRY_MS
+    fingerprintRetryTimer.restart()
   }
 
   function runBlank() {
@@ -249,20 +280,53 @@ Item {
     if (fingerprintPam.active || fingerprintAuthenticating) return
 
     fingerprintAuthenticating = true
+    fingerprintAttemptReachedDevice = false
     if (!fingerprintPam.start()) {
-      fingerprintAuthenticating = false
+      settleFingerprintAttempt()
+      return
     }
+    // Bound the wait for the first prompt: a claim that never lands (a daemon
+    // restarted under the verify, e.g. by the resume hook) otherwise hangs
+    // here without ever erroring, and nothing downstream re-arms.
+    fingerprintReachTimer.restart()
+  }
+
+  // A verify prompt is the only PAM message pam_fprintd relays, and only once
+  // the claim has landed, so any non-error message means this attempt reached
+  // the reader — the device works, whatever the verify then does. It may now
+  // wait for a finger as long as pam_fprintd allows, so the reach bound stops.
+  function noteFingerprintReachedDevice() {
+    fingerprintAttemptReachedDevice = true
+    fingerprintReachTimer.stop()
+  }
+
+  // An attempt that never reached the reader within the bound is stuck rather
+  // than waiting for a finger — abort it so it settles as unreached, which
+  // advances the streak (and so the notice) and retries against a daemon that
+  // may now be fresh, instead of hanging silently behind a normal icon.
+  function timeoutFingerprintReach() {
+    if (fingerprintPam.active) fingerprintPam.abort()
+    settleFingerprintAttempt()
+  }
+
+  // One PAM attempt can raise both onError and onCompleted, so fold each
+  // attempt into the streak exactly once: fingerprintAuthenticating is the
+  // attempt being open, and the first settle closes it. Reached attempts clear
+  // the streak; unreached ones advance it and stretch the next retry.
+  function settleFingerprintAttempt() {
+    if (!fingerprintAuthenticating) return
+    fingerprintAuthenticating = false
+    fingerprintReachTimer.stop()
+    if (!lockRequested || !fingerprintConfigured) return
+
+    fingerprintUnreachedStreak = FingerprintModel.nextStreak(fingerprintUnreachedStreak, fingerprintAttemptReachedDevice)
+    fingerprintRetryTimer.interval = FingerprintModel.retryDelayMs(fingerprintUnreachedStreak)
+    fingerprintRetryTimer.restart()
   }
 
   function handleFingerprintFinished(result) {
-    fingerprintAuthenticating = false
-
-    if (!lockRequested) return
-    if (result === PamResult.Success) {
-      finishUnlock()
-    } else if (fingerprintConfigured) {
-      fingerprintRetryTimer.restart()
-    }
+    if (result === PamResult.Success && lockRequested) finishUnlock()
+    else settleFingerprintAttempt()
   }
 
   WlSessionLock {
@@ -309,6 +373,7 @@ Item {
         backgroundPath: root.backgroundPath
         backgroundVersion: root.backgroundVersion
         fingerprintConfigured: root.fingerprintConfigured
+        fingerprintUnavailable: root.fingerprintUnavailable
         authenticatingPassword: root.authenticatingPassword
         failureMessage: root.failureMessage
         failedAttempts: root.failedAttempts
@@ -341,6 +406,7 @@ Item {
       backgroundPath: root.backgroundPath
       backgroundVersion: root.backgroundVersion
       fingerprintConfigured: root.fingerprintConfigured
+      fingerprintUnavailable: root.fingerprintUnavailable
       authenticatingPassword: false
       failureMessage: ""
       failedAttempts: 0
@@ -384,21 +450,31 @@ Item {
     config: "omarchy-lock-fingerprint"
     user: root.userName
 
+    onPamMessage: {
+      if (!messageIsError) root.noteFingerprintReachedDevice()
+    }
+
     onCompleted: function(result) {
       root.handleFingerprintFinished(result)
     }
 
     onError: function(error) {
-      root.fingerprintAuthenticating = false
-      if (root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
+      root.settleFingerprintAttempt()
     }
   }
 
   Timer {
     id: fingerprintRetryTimer
-    interval: 250
+    interval: FingerprintModel.MATCH_RETRY_MS
     repeat: false
     onTriggered: root.startFingerprint()
+  }
+
+  Timer {
+    id: fingerprintReachTimer
+    interval: FingerprintModel.REACH_TIMEOUT_MS
+    repeat: false
+    onTriggered: root.timeoutFingerprintReach()
   }
 
   Process {
@@ -600,6 +676,7 @@ Item {
         realScreens: root.realScreenCount(),
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
+        fingerprintUnavailable: root.fingerprintUnavailable,
         authenticating: root.authenticating,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt

--- a/test/shell.d/apply-lock-test.sh
+++ b/test/shell.d/apply-lock-test.sh
@@ -109,7 +109,9 @@ prepare_helper() {
     -v keep_root_path="$keep_root_path" \
     -v use_absolute_fprintd="$use_absolute_fprintd" \
     -v hook_src="$ROOT/default/systemd/system-sleep/fprintd-resume" \
-    -v hook_dst="$test_tmp/system-sleep/fprintd-resume" '
+    -v hook_dst="$test_tmp/system-sleep/fprintd-resume" \
+    -v timeout_src="$ROOT/default/systemd/system/fprintd.service.d/10-stop-timeout.conf" \
+    -v timeout_dst="$test_tmp/fprintd.service.d/10-stop-timeout.conf" '
     {
       line = $0
       gsub("/etc/pam\\.d/omarchy-lock-password", "\"" password_pam "\"", line)
@@ -147,6 +149,18 @@ prepare_helper() {
         print "resume_hook_dst=\"" hook_dst "\""
         next
       }
+      if (line == "stop_timeout_src=\"$OMARCHY_PATH/default/systemd/system/fprintd.service.d/10-stop-timeout.conf\"") {
+        print "stop_timeout_src=\"" timeout_src "\""
+        next
+      }
+      if (line == "stop_timeout_dst=/etc/systemd/system/fprintd.service.d/10-stop-timeout.conf") {
+        print "stop_timeout_dst=\"" timeout_dst "\""
+        next
+      }
+      if (line == "  as_root systemctl daemon-reload" || line == "    as_root systemctl daemon-reload") {
+        print "  :"
+        next
+      }
       if (line == "if omarchy-shell lock status >/dev/null 2>&1; then") {
         print "if false; then"
         next
@@ -167,6 +181,8 @@ for helper in "$patched_helper" "$absolute_only_helper" "$root_path_only_helper"
   if grep -F '/etc/pam.d/' "$helper" >/dev/null ||
     grep -F '/usr/bin/fprintd-list' "$helper" >/dev/null ||
     grep -F '/usr/lib/systemd/system-sleep' "$helper" >/dev/null ||
+    grep -F '/etc/systemd/system/' "$helper" >/dev/null ||
+    grep -F 'systemctl daemon-reload' "$helper" >/dev/null ||
     grep -F 'omarchy-shell lock status' "$helper" >/dev/null; then
     fail "the isolated root fixture redirects every live-system lock-helper target"
   fi
@@ -194,6 +210,8 @@ grep -Fx "$target_user" "$trusted_args" >/dev/null || fail "the trusted fprintd-
   fail "the isolated root lock-helper run writes both scratch PAM fixtures"
 [[ -x $test_tmp/system-sleep/fprintd-resume ]] ||
   fail "the lock helper installs the resume hook beside the fingerprint PAM file"
+[[ -f $test_tmp/fprintd.service.d/10-stop-timeout.conf ]] ||
+  fail "the lock helper installs the stop-timeout drop-in beside the resume hook"
 pass "the hardened root lock helper uses the trusted fingerprint probe"
 
 reset_runtime_files

--- a/test/shell.d/apply-lock-test.sh
+++ b/test/shell.d/apply-lock-test.sh
@@ -85,7 +85,7 @@ cat >"$trusted_fprintd" <<'EOF'
 
 printf '%s\n' "$EUID" >"$TEST_TRUSTED_UID"
 printf '%s\n' "$*" >"$TEST_TRUSTED_ARGS"
-echo "Fingerprints are enrolled"
+echo " - #0: right-index-finger"
 EOF
 
 cat >"$poison_bin/fprintd-list" <<'EOF'
@@ -93,7 +93,7 @@ cat >"$poison_bin/fprintd-list" <<'EOF'
 
 printf '%s\n' "$EUID" >"$TEST_ATTACK_MARKER"
 printf '%s\n' "$*" >"$TEST_ATTACK_ARGS"
-echo "Fingerprints are enrolled"
+echo " - #0: right-index-finger"
 EOF
 
 chmod +x "$trusted_fprintd" "$poison_bin/fprintd-list"
@@ -131,11 +131,11 @@ prepare_helper() {
         }
         next
       }
-      if (line == "  /usr/bin/fprintd-list \"$target_user\" 2>/dev/null | grep -qi finger; then") {
+      if (line == "  /usr/bin/fprintd-list \"$target_user\" 2>/dev/null | grep -q '\'' - #'\''; then") {
         if (use_absolute_fprintd == 1) {
-          print "  \"" trusted_fprintd "\" \"$target_user\" 2>/dev/null | grep -qi finger; then"
+          print "  \"" trusted_fprintd "\" \"$target_user\" 2>/dev/null | grep -q '\'' - #'\''; then"
         } else {
-          print "  fprintd-list \"$target_user\" 2>/dev/null | grep -qi finger; then"
+          print "  fprintd-list \"$target_user\" 2>/dev/null | grep -q '\'' - #'\''; then"
         }
         next
       }

--- a/test/shell.d/apply-lock-test.sh
+++ b/test/shell.d/apply-lock-test.sh
@@ -71,7 +71,7 @@ mkdir -p "$poison_bin" "$trusted_root_bin"
 
 # The runtime copy pins to this isolated root path. It contains every bare
 # command the exercised helper needs, but deliberately no fprintd-list.
-for helper in grep rm tee; do
+for helper in grep rm tee install rmdir dirname; do
   ln -s "/usr/bin/$helper" "$trusted_root_bin/$helper"
 done
 
@@ -107,7 +107,9 @@ prepare_helper() {
     -v trusted_root_bin="$trusted_root_bin" \
     -v trusted_fprintd="$trusted_fprintd" \
     -v keep_root_path="$keep_root_path" \
-    -v use_absolute_fprintd="$use_absolute_fprintd" '
+    -v use_absolute_fprintd="$use_absolute_fprintd" \
+    -v hook_src="$ROOT/default/systemd/system-sleep/fprintd-resume" \
+    -v hook_dst="$test_tmp/system-sleep/fprintd-resume" '
     {
       line = $0
       gsub("/etc/pam\\.d/omarchy-lock-password", "\"" password_pam "\"", line)
@@ -137,6 +139,14 @@ prepare_helper() {
         }
         next
       }
+      if (line == "resume_hook_src=\"$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume\"") {
+        print "resume_hook_src=\"" hook_src "\""
+        next
+      }
+      if (line == "resume_hook_dst=/usr/lib/systemd/system-sleep/fprintd-resume") {
+        print "resume_hook_dst=\"" hook_dst "\""
+        next
+      }
       if (line == "if omarchy-shell lock status >/dev/null 2>&1; then") {
         print "if false; then"
         next
@@ -156,6 +166,7 @@ prepare_helper "$unprotected_helper" 0 0
 for helper in "$patched_helper" "$absolute_only_helper" "$root_path_only_helper" "$unprotected_helper"; do
   if grep -F '/etc/pam.d/' "$helper" >/dev/null ||
     grep -F '/usr/bin/fprintd-list' "$helper" >/dev/null ||
+    grep -F '/usr/lib/systemd/system-sleep' "$helper" >/dev/null ||
     grep -F 'omarchy-shell lock status' "$helper" >/dev/null; then
     fail "the isolated root fixture redirects every live-system lock-helper target"
   fi
@@ -181,6 +192,8 @@ grep -Fx '0' "$trusted_uid" >/dev/null || fail "the trusted fprintd-list probe r
 grep -Fx "$target_user" "$trusted_args" >/dev/null || fail "the trusted fprintd-list probe receives the target user"
 [[ -s $password_pam && -s $fingerprint_pam ]] ||
   fail "the isolated root lock-helper run writes both scratch PAM fixtures"
+[[ -x $test_tmp/system-sleep/fprintd-resume ]] ||
+  fail "the lock helper installs the resume hook beside the fingerprint PAM file"
 pass "the hardened root lock helper uses the trusted fingerprint probe"
 
 reset_runtime_files

--- a/test/shell.d/fixtures/lock-fingerprint-indicator/shell.qml
+++ b/test/shell.d/fixtures/lock-fingerprint-indicator/shell.qml
@@ -84,6 +84,27 @@ ShellRoot {
 
           view.fingerprintConfigured = false
           root.assertTrue(view.fingerprintReserve === 0, "no space is reserved when no sensor is configured")
+
+          // An unreachable reader must announce itself instead of silently
+          // inviting touches that can never unlock.
+          view.fingerprintConfigured = true
+          var notice = findByObjectName(view, "fingerprintUnavailableNotice")
+          root.assertTrue(notice !== null, "unavailable notice exists in the lock view")
+
+          if (notice) {
+            var workingGlyph = indicator.text
+            root.assertTrue(!notice.visible, "notice stays hidden while the reader works")
+
+            view.fingerprintUnavailable = true
+            root.assertTrue(notice.visible, "notice appears when the reader is unavailable")
+            root.assertTrue(indicator.visible, "icon stays visible when the reader is unavailable")
+            root.assertTrue(indicator.text !== workingGlyph, "icon crosses out when the reader is unavailable")
+            root.assertTrue(view.fingerprintReserve > 0, "space stays reserved for the crossed-out icon")
+
+            view.fingerprintUnavailable = false
+            root.assertTrue(!notice.visible, "notice clears when the reader recovers")
+            root.assertTrue(indicator.text === workingGlyph, "icon restores when the reader recovers")
+          }
         }
 
         view.destroy()

--- a/test/shell.d/fprintd-resume-hook-test.sh
+++ b/test/shell.d/fprintd-resume-hook-test.sh
@@ -7,8 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 hook="$ROOT/default/systemd/system-sleep/fprintd-resume"
 
 # systemd execs the files in system-sleep/ directly, so a hook without the
-# executable bit silently never runs. The setup command installs this with
-# `cp -p`, which preserves the repo's mode, so the bit has to be set here.
+# executable bit silently never runs. The installers set the mode explicitly,
+# but the checkout should not ship a hook that cannot run as-is either.
 [[ -x $hook ]] ||
   fail "the resume hook is executable" "mode: $(stat -c '%A' "$hook")"
 pass "the resume hook is executable"

--- a/test/shell.d/fprintd-resume-hook-test.sh
+++ b/test/shell.d/fprintd-resume-hook-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hook="$ROOT/default/systemd/system-sleep/fprintd-resume"
+
+# systemd execs the files in system-sleep/ directly, so a hook without the
+# executable bit silently never runs. The setup command installs this with
+# `cp -p`, which preserves the repo's mode, so the bit has to be set here.
+[[ -x $hook ]] ||
+  fail "the resume hook is executable" "mode: $(stat -c '%A' "$hook")"
+pass "the resume hook is executable"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+call_log="$tmpdir/systemctl-calls"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/systemctl" <<SH
+#!/bin/bash
+printf '%s\n' "\$*" >>"$call_log"
+SH
+chmod +x "$mock_bin/systemctl"
+
+run_hook() {
+  : >"$call_log"
+  PATH="$mock_bin:$PATH" "$hook" "$@"
+}
+
+# Resume ("post") is the only edge that clears a claim wedged across suspend.
+run_hook post suspend
+[[ $(<"$call_log") == "try-restart fprintd.service" ]] ||
+  fail "resume restarts fprintd to clear a wedged claim" "calls: $(<"$call_log")"
+pass "resume restarts fprintd to clear a wedged claim"
+
+# Every resume path lands on "post" regardless of how the machine slept.
+run_hook post hibernate
+[[ $(<"$call_log") == "try-restart fprintd.service" ]] ||
+  fail "resume from hibernate also restarts fprintd" "calls: $(<"$call_log")"
+pass "resume from hibernate also restarts fprintd"
+
+# There is nothing to clear before sleep, and try-restart would needlessly
+# re-activate a fprintd that idle-exited, so "pre" must do nothing.
+run_hook pre suspend
+[[ -z $(<"$call_log") ]] ||
+  fail "pre-suspend leaves fprintd alone" "calls: $(<"$call_log")"
+pass "pre-suspend leaves fprintd alone"

--- a/test/shell.d/fprintd-resume-hook-test.sh
+++ b/test/shell.d/fprintd-resume-hook-test.sh
@@ -32,19 +32,29 @@ run_hook() {
 }
 
 # Resume ("post") is the only edge that clears a claim wedged across suspend.
+# The restart is enqueued, not awaited: user sessions stay frozen until the
+# hook returns, and a wedged fprintd can ride out its whole stop timeout.
 run_hook post suspend
-[[ $(<"$call_log") == "try-restart fprintd.service" ]] ||
-  fail "resume restarts fprintd to clear a wedged claim" "calls: $(<"$call_log")"
-pass "resume restarts fprintd to clear a wedged claim"
+[[ $(<"$call_log") == "--no-block try-restart fprintd.service" ]] ||
+  fail "resume enqueues an fprintd restart to clear a wedged claim" "calls: $(<"$call_log")"
+pass "resume enqueues an fprintd restart to clear a wedged claim"
 
 # Every resume path lands on "post" regardless of how the machine slept.
 run_hook post hibernate
-[[ $(<"$call_log") == "try-restart fprintd.service" ]] ||
+[[ $(<"$call_log") == "--no-block try-restart fprintd.service" ]] ||
   fail "resume from hibernate also restarts fprintd" "calls: $(<"$call_log")"
 pass "resume from hibernate also restarts fprintd"
 
-# There is nothing to clear before sleep, and try-restart would needlessly
-# re-activate a fprintd that idle-exited, so "pre" must do nothing.
+# The drop-in installed beside the hook is what keeps a SIGTERM-ignoring
+# fprintd from turning that restart into a multi-second dead reader.
+dropin="$ROOT/default/systemd/system/fprintd.service.d/10-stop-timeout.conf"
+grep -Eq '^TimeoutStopSec=[0-9]+s?$' "$dropin" ||
+  fail "the stop-timeout drop-in bounds TimeoutStopSec" "content: $(<"$dropin")"
+pass "the stop-timeout drop-in bounds TimeoutStopSec"
+
+# The claim only wedges once the verify dies under suspend, so there is
+# nothing to clear before sleep; a restart there would just take the reader
+# away from the verify the lock screen still has open. "pre" must do nothing.
 run_hook pre suspend
 [[ -z $(<"$call_log") ]] ||
   fail "pre-suspend leaves fprintd alone" "calls: $(<"$call_log")"

--- a/test/shell.d/fprintd-resume-migration-test.sh
+++ b/test/shell.d/fprintd-resume-migration-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Install the fingerprint resume hook on existing fingerprint setups' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "fprintd resume hook migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# The migration installs to a system path via sudo; stub it so the test writes
+# into a temp tree instead of /usr.
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+src="$TMPDIR/fprintd-resume"
+printf '#!/bin/bash\n' >"$src"
+chmod +x "$src"
+dst="$TMPDIR/system-sleep/fprintd-resume"
+lock_pam="$TMPDIR/omarchy-lock-fingerprint"
+
+# omarchy-migrate runs each migration with `bash -euo pipefail`; match it.
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    OMARCHY_FPRINTD_RESUME_SRC="$src" \
+    OMARCHY_FPRINTD_RESUME_DST="$dst" \
+    OMARCHY_LOCK_FINGERPRINT_PAM="$lock_pam" \
+    bash -euo pipefail "$migration" >/dev/null ||
+    fail "migration exits clean"
+}
+
+# A machine with fingerprint configured but no hook yet gets it, executable.
+: >"$lock_pam"
+rm -rf "$TMPDIR/system-sleep"
+run_migration
+[[ -x $dst ]] || fail "migration installs the hook, executable" "dst: $(stat -c '%A' "$dst" 2>/dev/null || echo missing)"
+pass "migration installs the hook, executable"
+
+# Running twice must not fail (the hook now exists) and must not touch it.
+printf 'sentinel\n' >>"$dst"
+run_migration
+grep -q sentinel "$dst" || fail "migration leaves an existing hook alone"
+pass "migration leaves an existing hook alone"
+
+# No fingerprint configured -> nothing to fix, so nothing is installed.
+rm -f "$lock_pam"
+rm -rf "$TMPDIR/system-sleep"
+run_migration
+[[ ! -e $dst ]] || fail "migration skips machines without fingerprint configured"
+pass "migration skips machines without fingerprint configured"

--- a/test/shell.d/fprintd-resume-migration-test.sh
+++ b/test/shell.d/fprintd-resume-migration-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 migration=$(grep -rl 'Install the fingerprint resume hook on existing fingerprint setups' "$ROOT/migrations" | head -n 1 || true)
@@ -33,6 +35,21 @@ run_migration() {
     bash -euo pipefail "$migration" >/dev/null ||
     fail "migration exits clean"
 }
+
+# The migration exits clean when its source is missing, so a hook moved
+# without updating it would silently install nothing and mark itself done.
+# Run once against the real default source under the repo to pin that path.
+rm -rf "$TMPDIR/system-sleep"
+: >"$lock_pam"
+PATH="$stub_bin:$PATH" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_FPRINTD_RESUME_DST="$dst" \
+  OMARCHY_LOCK_FINGERPRINT_PAM="$lock_pam" \
+  bash -euo pipefail "$migration" >/dev/null ||
+  fail "migration exits clean from its default source"
+[[ -x $dst ]] || fail "migration finds the hook at its default source path" "dst: $(stat -c '%A' "$dst" 2>/dev/null || echo missing)"
+cmp -s "$dst" "$ROOT/default/systemd/system-sleep/fprintd-resume" || fail "migration installs the shipped hook from its default source"
+pass "migration installs the shipped hook from its default source"
 
 # A machine with fingerprint configured but no hook yet gets it, executable.
 : >"$lock_pam"

--- a/test/shell.d/fprintd-resume-migration-test.sh
+++ b/test/shell.d/fprintd-resume-migration-test.sh
@@ -19,11 +19,20 @@ cat >"$stub_bin/sudo" <<'STUB'
 exec "$@"
 STUB
 chmod +x "$stub_bin/sudo"
+reload_log="$TMPDIR/systemctl-calls"
+cat >"$stub_bin/systemctl" <<STUB
+#!/bin/bash
+printf '%s\n' "\$*" >>"$reload_log"
+STUB
+chmod +x "$stub_bin/systemctl"
 
 src="$TMPDIR/fprintd-resume"
 printf '#!/bin/bash\n' >"$src"
 chmod +x "$src"
 dst="$TMPDIR/system-sleep/fprintd-resume"
+dropin_src="$TMPDIR/10-stop-timeout.conf"
+printf '[Service]\nTimeoutStopSec=3s\n' >"$dropin_src"
+dropin_dst="$TMPDIR/fprintd.service.d/10-stop-timeout.conf"
 lock_pam="$TMPDIR/omarchy-lock-fingerprint"
 
 # omarchy-migrate runs each migration with `bash -euo pipefail`; match it.
@@ -31,6 +40,8 @@ run_migration() {
   PATH="$stub_bin:$PATH" \
     OMARCHY_FPRINTD_RESUME_SRC="$src" \
     OMARCHY_FPRINTD_RESUME_DST="$dst" \
+    OMARCHY_FPRINTD_STOP_TIMEOUT_SRC="$dropin_src" \
+    OMARCHY_FPRINTD_STOP_TIMEOUT_DST="$dropin_dst" \
     OMARCHY_LOCK_FINGERPRINT_PAM="$lock_pam" \
     bash -euo pipefail "$migration" >/dev/null ||
     fail "migration exits clean"
@@ -39,34 +50,61 @@ run_migration() {
 # The migration exits clean when its source is missing, so a hook moved
 # without updating it would silently install nothing and mark itself done.
 # Run once against the real default source under the repo to pin that path.
-rm -rf "$TMPDIR/system-sleep"
+rm -rf "$TMPDIR/system-sleep" "$TMPDIR/fprintd.service.d"
 : >"$lock_pam"
 PATH="$stub_bin:$PATH" \
   OMARCHY_PATH="$ROOT" \
   OMARCHY_FPRINTD_RESUME_DST="$dst" \
+  OMARCHY_FPRINTD_STOP_TIMEOUT_DST="$dropin_dst" \
   OMARCHY_LOCK_FINGERPRINT_PAM="$lock_pam" \
   bash -euo pipefail "$migration" >/dev/null ||
-  fail "migration exits clean from its default source"
+  fail "migration exits clean from its default sources"
 [[ -x $dst ]] || fail "migration finds the hook at its default source path" "dst: $(stat -c '%A' "$dst" 2>/dev/null || echo missing)"
 cmp -s "$dst" "$ROOT/default/systemd/system-sleep/fprintd-resume" || fail "migration installs the shipped hook from its default source"
-pass "migration installs the shipped hook from its default source"
+cmp -s "$dropin_dst" "$ROOT/default/systemd/system/fprintd.service.d/10-stop-timeout.conf" || fail "migration installs the shipped drop-in from its default source"
+pass "migration installs the shipped hook and drop-in from their default sources"
 
-# A machine with fingerprint configured but no hook yet gets it, executable.
+# A machine with fingerprint configured but no hook yet gets it, executable,
+# plus the stop-timeout drop-in, and systemd is told about the drop-in.
 : >"$lock_pam"
-rm -rf "$TMPDIR/system-sleep"
+rm -rf "$TMPDIR/system-sleep" "$TMPDIR/fprintd.service.d"
+: >"$reload_log"
 run_migration
 [[ -x $dst ]] || fail "migration installs the hook, executable" "dst: $(stat -c '%A' "$dst" 2>/dev/null || echo missing)"
 pass "migration installs the hook, executable"
+[[ $(stat -c '%a' "$dropin_dst" 2>/dev/null) == "644" ]] || fail "migration installs the stop-timeout drop-in" "dst: $(stat -c '%A' "$dropin_dst" 2>/dev/null || echo missing)"
+grep -qx "daemon-reload" "$reload_log" || fail "migration reloads systemd after installing the drop-in" "calls: $(<"$reload_log")"
+pass "migration installs the stop-timeout drop-in and reloads systemd"
 
-# Running twice must not fail (the hook now exists) and must not touch it.
+# Running twice must not fail (both now exist), must not touch them, and has
+# nothing to reload.
 printf 'sentinel\n' >>"$dst"
+printf '# sentinel\n' >>"$dropin_dst"
+: >"$reload_log"
 run_migration
 grep -q sentinel "$dst" || fail "migration leaves an existing hook alone"
-pass "migration leaves an existing hook alone"
+grep -q sentinel "$dropin_dst" || fail "migration leaves an existing drop-in alone"
+[[ ! -s $reload_log ]] || fail "migration does not reload systemd when nothing changed" "calls: $(<"$reload_log")"
+pass "migration leaves existing files alone"
+
+# A copy under the old unprefixed name is replaced by the numbered one.
+legacy="$TMPDIR/fprintd.service.d/stop-timeout.conf"
+rm -f "$dropin_dst"; printf 'old\n' >"$legacy"
+: >"$reload_log"
+run_migration
+[[ ! -e $legacy && -f $dropin_dst ]] || fail "migration replaces the unprefixed drop-in" "legacy: $(ls "$legacy" 2>&1); dst: $(ls "$dropin_dst" 2>&1)"
+grep -qx "daemon-reload" "$reload_log" || fail "migration reloads systemd after replacing the drop-in"
+pass "migration replaces the unprefixed drop-in with the numbered one"
+
+# The drop-in is installed on its own where only the hook is already present.
+rm -rf "$TMPDIR/fprintd.service.d"
+run_migration
+[[ -f $dropin_dst ]] || fail "migration adds the drop-in beside an existing hook"
+pass "migration adds the drop-in beside an existing hook"
 
 # No fingerprint configured -> nothing to fix, so nothing is installed.
 rm -f "$lock_pam"
-rm -rf "$TMPDIR/system-sleep"
+rm -rf "$TMPDIR/system-sleep" "$TMPDIR/fprintd.service.d"
 run_migration
-[[ ! -e $dst ]] || fail "migration skips machines without fingerprint configured"
+[[ ! -e $dst && ! -e $dropin_dst ]] || fail "migration skips machines without fingerprint configured"
 pass "migration skips machines without fingerprint configured"

--- a/test/shell.d/lock-fingerprint-retry-test.sh
+++ b/test/shell.d/lock-fingerprint-retry-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const model = requireFromRoot('shell/plugins/lock/FingerprintModel.js')
+
+// Pacing: a reached attempt (streak 0) retries fast; unreached attempts back
+// off exponentially to a ceiling above fprintd's 30-second idle exit.
+assertEqual(model.retryDelayMs(0), model.MATCH_RETRY_MS, 'a reached attempt retries at the fast interval')
+assertEqual(model.retryDelayMs(1), model.ERROR_RETRY_BASE_MS, 'the first unreached attempt backs off')
+assertEqual(model.retryDelayMs(2), model.ERROR_RETRY_BASE_MS * 2, 'consecutive unreached attempts double the delay')
+assertEqual(model.retryDelayMs(3), model.ERROR_RETRY_BASE_MS * 4, 'the backoff keeps doubling')
+assertEqual(model.retryDelayMs(50), model.ERROR_RETRY_CAP_MS, 'the backoff is capped')
+assert(model.ERROR_RETRY_CAP_MS > 30000, "the cap exceeds fprintd's 30-second idle exit so a wedged claim can clear")
+
+let previous = 0
+let monotonic = true
+for (let streak = 1; streak <= 20; streak++) {
+  const delay = model.retryDelayMs(streak)
+  if (delay < previous) monotonic = false
+  previous = delay
+}
+assert(monotonic, 'the backoff never shrinks while attempts keep failing to reach the reader')
+
+// The signal: reaching the device (a prompt) clears the streak; not reaching it
+// advances it. This is what keeps a healthy-but-untouched reader off the notice
+// while a wedged or held one climbs toward it.
+assertEqual(model.nextStreak(0, true), 0, 'reaching the reader keeps the streak at zero')
+assertEqual(model.nextStreak(5, true), 0, 'reaching the reader clears an accumulated streak')
+assertEqual(model.nextStreak(0, false), 1, 'failing to reach the reader starts the streak')
+assertEqual(model.nextStreak(2, false), 3, 'failing to reach the reader advances the streak')
+
+// Availability: reported unavailable only past a few consecutive misses, so a
+// single transient claim conflict does not flash the notice.
+assert(!model.isUnavailable(0), 'a working reader is not reported unavailable')
+assert(!model.isUnavailable(model.UNAVAILABLE_AFTER - 1), 'a couple of misses do not report unavailable')
+assert(model.isUnavailable(model.UNAVAILABLE_AFTER), 'enough consecutive misses report the reader unavailable')
+
+// End to end: repeatedly failing to reach the reader crosses the threshold, and
+// the first attempt that reaches it clears both the streak and the notice.
+let streak = 0
+for (let i = 0; i < model.UNAVAILABLE_AFTER; i++) streak = model.nextStreak(streak, false)
+assert(model.isUnavailable(streak), 'a run of unreached attempts ends up unavailable')
+streak = model.nextStreak(streak, true)
+assert(!model.isUnavailable(streak), 'one reached attempt clears the unavailable state')
+
+// Presence nudge: it only collapses a backed-off wait, and only once per
+// cooldown, so a moving cursor cannot respin the loop.
+const backedOff = model.retryDelayMs(2)
+assert(!model.shouldNudge(10000, 0, model.MATCH_RETRY_MS), 'no nudge when the wait is already the fast interval')
+assert(model.shouldNudge(10000, 0, backedOff), 'a keypress collapses a backed-off wait')
+assert(!model.shouldNudge(10000, 9000, backedOff), 'a second nudge inside the cooldown is refused')
+assert(model.shouldNudge(10000, 10000 - model.NUDGE_COOLDOWN_MS, backedOff), 'a nudge one cooldown later is allowed')
+
+// A cursor moving at 125 Hz raises a wake every 8 ms; over 10 s the floor caps
+// the collapses at one per cooldown instead of one per event.
+let last = -model.NUDGE_COOLDOWN_MS
+let collapses = 0
+for (let t = 0; t <= 10000; t += 8) {
+  if (model.shouldNudge(t, last, backedOff)) { collapses++; last = t }
+}
+assert(collapses <= 10000 / model.NUDGE_COOLDOWN_MS + 1,
+  'a moving cursor is capped at one collapse per cooldown, got ' + collapses)
+
+assert(model.REACH_TIMEOUT_MS < model.ERROR_RETRY_CAP_MS,
+  'the reach bound is shorter than the backoff cap, so a stuck attempt is caught well before the cap')
+JS

--- a/test/shell.d/lock-fingerprint-retry-test.sh
+++ b/test/shell.d/lock-fingerprint-retry-test.sh
@@ -160,6 +160,14 @@ assert(attempts >= 3, 'the loop keeps retrying through the restart window, got '
 assert(attemptAt - resumedAt < 3300 + model.ERROR_RETRY_BASE_MS + model.MATCH_RETRY_MS,
   'the first attempt after the daemon is back comes within a tier, at ' + (attemptAt - resumedAt) + 'ms')
 
+// Probe classification (#9453): only a definitive answer may change state.
+assertEqual(model.classifyProbe('found 1 devices\nFingerprints for user g on X:\n - #0: right-index-finger'), 'yes', 'an enrolled print row reads yes')
+assertEqual(model.classifyProbe('no'), 'no', "the probe script's own no reads no")
+assertEqual(model.classifyProbe('found 1 devices\nUser bob has no fingers enrolled.'), 'no', "fprintd's explicit no-prints answer reads no")
+assertEqual(model.classifyProbe('Impossible to get devices: GDBus.Error:org.freedesktop.DBus.Error.NameHasNoOwner: Could not activate remote peer'), 'unknown', 'an activation failure reads unknown, not unconfigured')
+assertEqual(model.classifyProbe('ListEnrolledFingers failed: Timeout was reached'), 'unknown', 'a D-Bus timeout reads unknown')
+assertEqual(model.classifyProbe(''), 'unknown', 'empty output reads unknown')
+
 assert(model.REACH_TIMEOUT_MS < model.ERROR_RETRY_CAP_MS,
   'the reach bound is shorter than the backoff cap, so a stuck attempt is caught well before the cap')
 assert(model.REACH_TIMEOUT_MS < 25000,

--- a/test/shell.d/lock-fingerprint-retry-test.sh
+++ b/test/shell.d/lock-fingerprint-retry-test.sh
@@ -122,6 +122,44 @@ assert(minIdle >= model.FPRINTD_IDLE_EXIT_MS,
 assert(minIdle < capped,
   'the nudge still shortens the wait at the cap rather than being dead there, got ' + minIdle + 'ms')
 
+// Resume grace: right after a wake the hook is restarting fprintd under the
+// loop, so a miss there holds the streak at the first tier instead of
+// climbing toward the notice; a reached attempt still clears it.
+assertEqual(model.nextStreak(0, false, true), 1, 'a miss inside the resume grace holds the streak at the first tier')
+assertEqual(model.nextStreak(5, false, true), 1, 'the grace pins any accumulated streak to the first tier')
+assertEqual(model.nextStreak(5, true, true), 0, 'a reached attempt inside the grace clears the streak')
+assertEqual(model.nextStreak(1, false, false), 2, 'outside the grace misses accumulate')
+assert(model.RESUME_GRACE_MS >= 3000 + 1000, "the grace outlasts fprintd's 3s stop cap plus its start")
+assert(model.RESUME_GRACE_MS < model.ERROR_RETRY_CAP_MS, 'the grace is shorter than the cap, so it cannot mask a reader that is really gone')
+assert(!model.inResumeGrace(5000, 0), 'no resume noted means no grace')
+assert(model.inResumeGrace(1000 + model.RESUME_GRACE_MS - 1, 1000), 'an attempt settling inside the window is in grace')
+assert(!model.inResumeGrace(1000 + model.RESUME_GRACE_MS, 1000), 'an attempt settling at the window edge is not')
+assert(!model.inResumeGrace(500, 1000), 'a clock stepped back past the resume is not grace')
+
+// Sleep detection: an unreached attempt cannot outlive the reach bound on the
+// monotonic clock, so one that did on the wall clock spanned a suspend.
+assert(!model.spannedSleep(model.REACH_TIMEOUT_MS + model.SLEEP_GAP_MS, model.REACH_TIMEOUT_MS), 'the bound plus slack is not a sleep')
+assert(model.spannedSleep(model.REACH_TIMEOUT_MS + model.SLEEP_GAP_MS + 1, model.REACH_TIMEOUT_MS), 'longer than the bound plus slack is a sleep')
+assert(model.spannedSleep(1000 + 8 * 3600 * 1000, 1000), 'an eight-hour wait on a one-second timer is a sleep')
+
+// End to end: the async resume hook lands a fresh daemon ~3.3s after wake in
+// the worst case (SIGTERM-ignoring fprintd, 3s stop cap). Every attempt until
+// then misses; none may show the notice, and the loop must still be retrying
+// at the first tier when the daemon comes back.
+const resumedAt = 1000
+let graceStreak = 0
+let attemptAt = resumedAt + model.MATCH_RETRY_MS
+let attempts = 0
+while (attemptAt < resumedAt + 3300) {
+  graceStreak = model.nextStreak(graceStreak, false, model.inResumeGrace(attemptAt, resumedAt))
+  assert(!model.isUnavailable(graceStreak), 'a miss ' + (attemptAt - resumedAt) + 'ms after resume must not show the notice')
+  attemptAt += model.retryDelayMs(graceStreak)
+  attempts++
+}
+assert(attempts >= 3, 'the loop keeps retrying through the restart window, got ' + attempts)
+assert(attemptAt - resumedAt < 3300 + model.ERROR_RETRY_BASE_MS + model.MATCH_RETRY_MS,
+  'the first attempt after the daemon is back comes within a tier, at ' + (attemptAt - resumedAt) + 'ms')
+
 assert(model.REACH_TIMEOUT_MS < model.ERROR_RETRY_CAP_MS,
   'the reach bound is shorter than the backoff cap, so a stuck attempt is caught well before the cap')
 assert(model.REACH_TIMEOUT_MS < 25000,

--- a/test/shell.d/lock-fingerprint-retry-test.sh
+++ b/test/shell.d/lock-fingerprint-retry-test.sh
@@ -14,7 +14,10 @@ assertEqual(model.retryDelayMs(1), model.ERROR_RETRY_BASE_MS, 'the first unreach
 assertEqual(model.retryDelayMs(2), model.ERROR_RETRY_BASE_MS * 2, 'consecutive unreached attempts double the delay')
 assertEqual(model.retryDelayMs(3), model.ERROR_RETRY_BASE_MS * 4, 'the backoff keeps doubling')
 assertEqual(model.retryDelayMs(50), model.ERROR_RETRY_CAP_MS, 'the backoff is capped')
-assert(model.ERROR_RETRY_CAP_MS > 30000, "the cap exceeds fprintd's 30-second idle exit so a wedged claim can clear")
+assertEqual(model.FPRINTD_IDLE_EXIT_MS, 30000, "the model carries fprintd's 30-second idle exit")
+assert(model.ERROR_RETRY_CAP_MS > model.FPRINTD_IDLE_EXIT_MS, "the cap exceeds fprintd's idle exit so a wedged claim can clear")
+assert(model.IDLE_CLEAR_MS > model.FPRINTD_IDLE_EXIT_MS && model.IDLE_CLEAR_MS <= model.ERROR_RETRY_CAP_MS,
+  'the idle stretch a nudge must leave at the cap covers the exit and fits inside the cap')
 
 let previous = 0
 let monotonic = true
@@ -50,20 +53,74 @@ assert(!model.isUnavailable(streak), 'one reached attempt clears the unavailable
 // Presence nudge: it only collapses a backed-off wait, and only once per
 // cooldown, so a moving cursor cannot respin the loop.
 const backedOff = model.retryDelayMs(2)
-assert(!model.shouldNudge(10000, 0, model.MATCH_RETRY_MS), 'no nudge when the wait is already the fast interval')
-assert(model.shouldNudge(10000, 0, backedOff), 'a keypress collapses a backed-off wait')
-assert(!model.shouldNudge(10000, 9000, backedOff), 'a second nudge inside the cooldown is refused')
-assert(model.shouldNudge(10000, 10000 - model.NUDGE_COOLDOWN_MS, backedOff), 'a nudge one cooldown later is allowed')
+assert(!model.shouldNudge(10000, 0, 0, model.MATCH_RETRY_MS), 'no nudge when the wait is already the fast interval')
+assert(model.shouldNudge(10000, 0, 0, backedOff), 'a keypress collapses a backed-off wait')
+assert(!model.shouldNudge(10000, 9000, 0, backedOff), 'a second nudge inside the cooldown is refused')
+assert(model.shouldNudge(10000, 10000 - model.NUDGE_COOLDOWN_MS, 0, backedOff), 'a nudge one cooldown later is allowed')
+assert(model.shouldNudge(10000, 11500, 0, backedOff), 'a clock stepped backwards does not refuse the nudge')
+assert(model.shouldNudge(10000, 0, 11500, backedOff), 'a clock stepped backwards since the settle does not refuse it either')
+assert(model.shouldNudge(10000, 0, 9990, backedOff), 'below the cap a fresh settle does not hold the nudge')
 
 // A cursor moving at 125 Hz raises a wake every 8 ms; over 10 s the floor caps
 // the collapses at one per cooldown instead of one per event.
 let last = -model.NUDGE_COOLDOWN_MS
 let collapses = 0
 for (let t = 0; t <= 10000; t += 8) {
-  if (model.shouldNudge(t, last, backedOff)) { collapses++; last = t }
+  if (model.shouldNudge(t, last, 0, backedOff)) { collapses++; last = t }
 }
 assert(collapses <= 10000 / model.NUDGE_COOLDOWN_MS + 1,
   'a moving cursor is capped at one collapse per cooldown, got ' + collapses)
+
+// Once the wait has backed off past the cooldown, the tier paces the nudges:
+// presence collapses each wait once, but typing at a reader that keeps failing
+// cannot pull the loop under the tier's rate.
+const capped = model.retryDelayMs(50)
+const longAgo = -capped
+assert(model.shouldNudge(capped, 0, longAgo, capped), 'a nudge one tier later is allowed')
+assert(!model.shouldNudge(capped - 1, 0, longAgo, capped), 'a nudge inside the tier is refused')
+last = -capped
+collapses = 0
+for (let t = 0; t <= 4 * capped; t += 8) {
+  if (model.shouldNudge(t, last, longAgo, capped)) { collapses++; last = t }
+}
+assertEqual(collapses, 5, 'continuous input at the cap collapses once per tier')
+
+// At the cap a fresh settle holds the nudge until fprintd has had its idle
+// stretch, then lets it through -- before the cap's own timer would fire.
+assert(!model.shouldNudge(model.IDLE_CLEAR_MS - 1, longAgo, 0, capped), 'a nudge before the idle stretch is refused at the cap')
+assert(model.shouldNudge(model.IDLE_CLEAR_MS, longAgo, 0, capped), 'a nudge after the idle stretch is allowed at the cap')
+// A clock stepped back past the settle says nothing about how long fprintd
+// has been idle, so at the cap it must not stand in for the idle stretch.
+assert(!model.shouldNudge(10000, longAgo, 15000, capped), 'a clock stepped back past the settle does not bypass the idle guard at the cap')
+assert(model.shouldNudge(10000, 15000, longAgo, capped), 'a clock stepped back past the nudge still allows the nudge at the cap once idle')
+
+// At the cap the idle stretch is measured from the settle: a nudged attempt
+// that hangs until the reach timeout must not eat into fprintd's idle exit.
+// Simulate continuous input at 125 Hz against a reader whose every attempt
+// hangs for the full reach bound, and check the gap fprintd is left between
+// one attempt ending and the next claiming.
+let settle = 0
+let nudge = 0
+let attemptStart = model.MATCH_RETRY_MS
+let minIdle = Infinity
+let cycles = 0
+for (let t = attemptStart; cycles < 5; t += 8) {
+  const attemptEnd = attemptStart + model.REACH_TIMEOUT_MS
+  if (t < attemptEnd) continue
+  if (t === attemptEnd || settle < attemptStart) settle = attemptEnd
+  const timerFires = t >= settle + capped
+  if (timerFires || model.shouldNudge(t, nudge, settle, capped)) {
+    if (!timerFires) nudge = t
+    const claimAt = t + model.MATCH_RETRY_MS
+    minIdle = Math.min(minIdle, claimAt - settle)
+    attemptStart = claimAt
+    cycles++
+  }
+}
+assert(minIdle >= model.FPRINTD_IDLE_EXIT_MS,
+  'continuous input against attempts that hang to the reach bound still leaves fprintd its idle exit, got ' + minIdle + 'ms')
+assert(minIdle < capped,
+  'the nudge still shortens the wait at the cap rather than being dead there, got ' + minIdle + 'ms')
 
 assert(model.REACH_TIMEOUT_MS < model.ERROR_RETRY_CAP_MS,
   'the reach bound is shorter than the backoff cap, so a stuck attempt is caught well before the cap')

--- a/test/shell.d/lock-fingerprint-retry-test.sh
+++ b/test/shell.d/lock-fingerprint-retry-test.sh
@@ -124,4 +124,8 @@ assert(minIdle < capped,
 
 assert(model.REACH_TIMEOUT_MS < model.ERROR_RETRY_CAP_MS,
   'the reach bound is shorter than the backoff cap, so a stuck attempt is caught well before the cap')
+assert(model.REACH_TIMEOUT_MS < 25000,
+  "the reach bound lands before GDBus fails a stuck Claim at 25s and pam_fprintd's 30s verify timeout reports as a non-error message")
+assert(model.REACH_TIMEOUT_MS >= 10000,
+  'the reach bound outlasts a slow device open, so a reader that takes seconds to claim is not killed mid-Claim on every attempt')
 JS


### PR DESCRIPTION
### Problem

A fingerprint verify still open when the machine suspends leaves fprintd unable to hand the reader back — the verify dies with `Cannot run while suspended` and the follow-up `ReleaseDevice` fails on the still-busy device:

```
fprintd: Device reported an error during verify: Cannot run while suspended.
pam_fprintd: ReleaseDevice failed: … The device is still busy with another operation
```

The wedged claim then rejects every lock-screen attempt after resume. The lock retried on a flat 250ms timer with no sign to the user, so the reader looked dead behind an icon still inviting touches — ~4 PAM sessions/second that also kept fprintd from reaching the 30-second idle exit that would have cleared the claim on its own.

### Fix — three layers

1. **Remove the wedge at its source.** A `post` system-sleep hook restarts fprintd on resume (installed by `omarchy-setup-security-fingerprint`, with a migration for existing setups). It runs while `user.slice` is frozen, so fprintd is fresh before the lock screen retries, and it's bounded with `timeout` so a wedged restart can't hold the thaw open. `try-restart` is a no-op when fprintd isn't running, so a healthy resume where nothing held the reader pays nothing.
2. **Stop hammering an unreachable reader.** Retries now back off exponentially on the signal of *whether an attempt reached the reader at all* — pam_fprintd relays a finger prompt only once the claim lands, so an attempt that ends without prompting never reached the device (wedged, held by another client, or gone). A finger that merely doesn't match still reaches the reader and retries fast.
3. **Tell the user.** After a few consecutive unreached attempts the icon crosses out and a *"Fingerprint reader unavailable"* notice appears under the field — cleared the instant a prompt shows the reader is reachable again, and a keypress or touch collapses the backoff so a recovered reader is tried at once. This covers *any* cause of an unreachable reader, not just suspend.

### Also clears stale claims across suspend

The restart drops *every* fprintd claim, so a background fingerprint request left waiting across the suspend — a hidden `fprintd-verify`, or an app/polkit prompt you never returned to — no longer survives resume to silently consume your first unlock touch. A *live* verify caught across the suspend (e.g. a `sudo` prompt on a TTY) is likewise dropped and falls back to a password; that's the intended trade. (A background client competing for the reader *without* a suspend is a separate arbitration question, out of scope here.)

### Reproducing

**Deterministically (any machine with an enrolled finger)** — the pacing + notice:

1. Hold the reader from a second process: run `fprintd-verify` and leave it waiting (don't touch the sensor — a touch completes it).
2. Watch: `journalctl -f -t omarchy-shell -t fprintd`
3. `omarchy system lock`.
4. **Before:** ~4 attempts/sec, each a `Starting pam session` (shell) + `Authorization denied … Device was already claimed` (fprintd), behind a normal icon.
5. **After:** a handful of attempts at growing intervals; after the third the icon crosses out with the notice. Kill the holder while still locked and the notice clears within one retry.

**The real trigger (probabilistic)** — the wedge + hook:

1. With the reader idle, close the lid. The pre-suspend lock starts a verify still waiting when the machine sleeps.
2. `journalctl -u fprintd -b` after resume shows the losing rolls: `Cannot run while suspended` + a failed `ReleaseDevice`. The resume hook restarts fprintd so the next touch works regardless.

### Scope / relation to #7179

This paces and reports the *claim-reachability* failure family — a reader that is wedged, held by another client, or gone. It deliberately does **not** touch failures that arrive *after* the claim lands: any error following the finger prompt reads as "reached", so a reader that refuses mid-verify (libfprint's thermal duty-cycle cut-off), disconnects, or whose driver errors gets neither the backoff nor the notice from this PR. The thermal slice of that is #7179's cause and signal. The two overlap only on the retry path in `Service.qml`; the levers are complementary (remove/observe the wedge here, pace the hot verify there).

Of #7176's two reports, the orphaned-claim one (no suspend, fprintd held for days) is this failure family and is resolved here; the thermal one in the title is not, and stays with #7179.

### Testing

`FingerprintModel.js` has a Node test for the backoff and streak logic; the lock-view fixture covers the crossed icon and notice; the hook and migration each have a shell test (including that the hook is installed executable — systemd-sleep won't run it otherwise). `lock status` now reports `fingerprintUnavailable`.

_Screenshots below: the reader available vs. unavailable (Catppuccin, whose `lock.text-error` is red; a few themes like Tokyo Night map it to the foreground, so the notice there matches the icon rather than standing out)._

Fixes #7229
Fixes #7172
Partially addresses #7176 (orphaned-claim case; thermal case is #7179)

