### PR TITLE
Collapse bar widgets listed before the tray into the tray drawer

### DIFF
--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -32,14 +32,14 @@ function pinTrayToInner(entries, section) {
   for (var i = 0; i < values.length; i++) {
     if (entryId(values[i]) === "omarchy.tray") { trayIndex = i; break }
   }
-  if (trayIndex === -1) return values
+  if (trayIndex === -1) return values.slice()
 
   // Entries listed before the tray collapse into it: they render inside the
   // tray's reveal drawer instead of as their own bar slots. Entries after it
   // stay visible beside the tray. Attach the collapsed entries to the tray
   // entry so the tray widget can read them off its injected `settings.widgets`.
   var inner = values.slice(0, trayIndex)
-  var outer = values.slice(trayIndex + 1)
+  var outer = values.slice(trayIndex + 1).filter(function(e) { return entryId(e) !== "omarchy.tray" })
 
   var source = isPlainObject(values[trayIndex]) ? values[trayIndex] : { id: "omarchy.tray" }
   var trayCopy = {}

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -27,16 +27,32 @@ function entryId(entry) {
 }
 
 function pinTrayToInner(entries, section) {
-  var trayEntry = null
-  var result = []
   var values = Array.isArray(entries) ? entries : []
+  var trayIndex = -1
   for (var i = 0; i < values.length; i++) {
-    if (entryId(values[i]) === "omarchy.tray") trayEntry = values[i]
-    else result.push(values[i])
+    if (entryId(values[i]) === "omarchy.tray") { trayIndex = i; break }
   }
-  if (trayEntry) {
-    if (section === "right") result.unshift(trayEntry)
-    else result.push(trayEntry)
+  if (trayIndex === -1) return values
+
+  // Entries listed before the tray collapse into it: they render inside the
+  // tray's reveal drawer instead of as their own bar slots. Entries after it
+  // stay visible beside the tray. Attach the collapsed entries to the tray
+  // entry so the tray widget can read them off its injected `settings.widgets`.
+  var inner = values.slice(0, trayIndex)
+  var outer = values.slice(trayIndex + 1)
+
+  var source = isPlainObject(values[trayIndex]) ? values[trayIndex] : { id: "omarchy.tray" }
+  var trayCopy = {}
+  for (var k in source) trayCopy[k] = source[k]
+  trayCopy.widgets = inner.slice()
+
+  var result = []
+  if (section === "right") {
+    result.push(trayCopy)
+    for (var r = 0; r < outer.length; r++) result.push(outer[r])
+  } else {
+    for (var o = 0; o < outer.length; o++) result.push(outer[o])
+    result.push(trayCopy)
   }
   return result
 }

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -20,6 +20,10 @@ BarWidget {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property var pinnedIds: settings.pinned instanceof Array ? settings.pinned : []
   readonly property var hiddenIds: settings.hidden instanceof Array ? settings.hidden : []
+  // Bar widgets listed before the tray in their section collapse into this
+  // tray: the bar's layout normalization attaches them as `settings.widgets`
+  // and removes them from the section, so the tray owns rendering them.
+  readonly property var widgetEntries: settings.widgets instanceof Array ? settings.widgets : []
   readonly property var pinnedItems: bucket("pinned")
   readonly property var drawerItems: bucket("drawer")
   readonly property var allItems: bucket("all")
@@ -27,11 +31,9 @@ BarWidget {
   readonly property int trayItemExtent: Style.bar.iconSlot
   readonly property int trayItemGap: 0
   readonly property int trayJoinGap: 0
-  readonly property int drawerExtent: drawerCount > 0 ? drawerCount * trayItemExtent + (drawerCount - 1) * trayItemGap : 0
   // Match Waybar's group/tray-expander drawer transition-duration.
   readonly property int animationDuration: 600
   property real revealProgress: expanded ? 1 : 0
-  readonly property real revealExtent: drawerExtent * revealProgress
 
   // Submenu drill-down state. QsMenuEntry.display() renders a *platform* menu,
   // which Quickshell refuses unless the shell root sets `//@ pragma
@@ -210,7 +212,7 @@ BarWidget {
     persistTrayState(p, h)
   }
 
-  visible: pinnedItems.length > 0 || drawerCount > 0
+  visible: pinnedItems.length > 0 || drawerCount > 0 || widgetEntries.length > 0
   clip: false
   implicitWidth: root.vertical ? root.barSize : trayContent.implicitWidth
   implicitHeight: root.vertical ? trayContent.implicitHeight : root.barSize
@@ -231,8 +233,11 @@ BarWidget {
     Item {
       id: horizontalTrayRoot
 
+      readonly property bool hasDrawerContent: root.allItems.length > 0 || root.widgetEntries.length > 0
+      readonly property int drawerExtent: drawerContent ? drawerContent.implicitWidth : 0
+      readonly property int revealExtent: drawerExtent * root.revealProgress
       readonly property int pinnedWidth: pinnedRow.implicitWidth
-      readonly property int drawerBlockWidth: root.allItems.length > 0 ? expandIcon.implicitWidth + root.drawerExtent : 0
+      readonly property int drawerBlockWidth: hasDrawerContent ? expandIcon.implicitWidth + drawerExtent : 0
 
       implicitWidth: pinnedWidth + drawerBlockWidth
       implicitHeight: root.barSize
@@ -244,7 +249,7 @@ BarWidget {
           if (point.y < 0 || point.y > horizontalTrayRoot.height) return false
           // Drawer reveals leftward; chevron sits at the right end when collapsed
           // and slides left as it opens. The visible region starts at the chevron.
-          var chevronX = root.drawerExtent - root.revealExtent
+          var chevronX = horizontalTrayRoot.drawerExtent - horizontalTrayRoot.revealExtent
           if (point.x >= chevronX && point.x <= horizontalTrayRoot.drawerBlockWidth) return true
           // Pinned items, placed to the right of the drawer block.
           var pinnedStart = horizontalTrayRoot.drawerBlockWidth
@@ -257,7 +262,7 @@ BarWidget {
         x: 0
         width: horizontalTrayRoot.drawerBlockWidth
         height: root.barSize
-        visible: root.allItems.length > 0
+        visible: horizontalTrayRoot.hasDrawerContent
 
         HoverHandler {
           onHoveredChanged: root.expanded = hovered
@@ -268,7 +273,7 @@ BarWidget {
           bar: root.bar
           width: implicitWidth
           height: implicitHeight
-          x: root.drawerExtent - root.revealExtent
+          x: horizontalTrayRoot.drawerExtent - horizontalTrayRoot.revealExtent
           text: "\uf053"
           onPressed: function(button) {
             if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
@@ -279,16 +284,21 @@ BarWidget {
           id: trayClip
           x: expandIcon.width
           anchors.verticalCenter: parent.verticalCenter
-          width: root.drawerExtent
+          width: horizontalTrayRoot.drawerExtent
           height: root.barSize
           clip: true
 
           Row {
-            id: trayIcons
-            x: root.drawerExtent - root.revealExtent
+            id: drawerContent
+            x: horizontalTrayRoot.drawerExtent - horizontalTrayRoot.revealExtent
             anchors.verticalCenter: parent.verticalCenter
             spacing: root.trayItemGap
             layer.enabled: true
+
+            Repeater {
+              model: root.widgetEntries
+              NestedBarWidget {}
+            }
 
             Repeater {
               model: root.drawerItems
@@ -318,8 +328,11 @@ BarWidget {
     Item {
       id: verticalTrayRoot
 
+      readonly property bool hasDrawerContent: root.allItems.length > 0 || root.widgetEntries.length > 0
+      readonly property int drawerExtent: drawerContent ? drawerContent.implicitHeight : 0
+      readonly property int revealExtent: drawerExtent * root.revealProgress
       readonly property int pinnedHeight: pinnedCol.implicitHeight
-      readonly property int drawerBlockHeight: root.allItems.length > 0 ? expandIcon.implicitHeight + root.drawerExtent : 0
+      readonly property int drawerBlockHeight: hasDrawerContent ? expandIcon.implicitHeight + drawerExtent : 0
 
       implicitWidth: root.barSize
       implicitHeight: pinnedHeight + drawerBlockHeight
@@ -327,7 +340,7 @@ BarWidget {
       containmentMask: QtObject {
         function contains(point: point): bool {
           if (point.x < 0 || point.x > verticalTrayRoot.width) return false
-          var chevronY = root.drawerExtent - root.revealExtent
+          var chevronY = verticalTrayRoot.drawerExtent - verticalTrayRoot.revealExtent
           if (point.y >= chevronY && point.y <= verticalTrayRoot.drawerBlockHeight) return true
           var pinnedStart = verticalTrayRoot.drawerBlockHeight
           return point.y >= pinnedStart && point.y <= verticalTrayRoot.implicitHeight
@@ -339,7 +352,7 @@ BarWidget {
         y: 0
         width: root.barSize
         height: verticalTrayRoot.drawerBlockHeight
-        visible: root.allItems.length > 0
+        visible: verticalTrayRoot.hasDrawerContent
 
         HoverHandler {
           onHoveredChanged: root.expanded = hovered
@@ -350,7 +363,7 @@ BarWidget {
           bar: root.bar
           width: implicitWidth
           height: implicitHeight
-          y: root.drawerExtent - root.revealExtent
+          y: verticalTrayRoot.drawerExtent - verticalTrayRoot.revealExtent
           text: "\uf053"
           textRotation: 90
           onPressed: function(button) {
@@ -363,15 +376,20 @@ BarWidget {
           y: expandIcon.height
           anchors.horizontalCenter: parent.horizontalCenter
           width: root.barSize
-          height: root.drawerExtent
+          height: verticalTrayRoot.drawerExtent
           clip: true
 
           Column {
-            id: trayIcons
-            y: root.drawerExtent - root.revealExtent
+            id: drawerContent
+            y: verticalTrayRoot.drawerExtent - verticalTrayRoot.revealExtent
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: root.trayItemGap
             layer.enabled: true
+
+            Repeater {
+              model: root.widgetEntries
+              NestedBarWidget {}
+            }
 
             Repeater {
               model: root.drawerItems
@@ -759,6 +777,50 @@ BarWidget {
       }
     }
   }
+
+  // Renders a bar widget that was collapsed into the tray. Mirrors the bar
+  // host's ModuleSlot contract: load the widget's registered component and
+  // inject bar/moduleName/settings so it behaves exactly as it would in a
+  // normal bar slot, just drawn inside the tray's reveal drawer. Loading is
+  // gated on `registryComponent`, which re-evaluates once the host injects
+  // `bar`, so widgets resolve even though the tray itself starts with a null
+  // `bar`.
+  component NestedBarWidget: Loader {
+    id: nested
+    required property var modelData
+
+    readonly property string moduleName: {
+      var e = modelData
+      if (typeof e === "string") return e
+      return e && e.id ? String(e.id) : ""
+    }
+    readonly property var moduleSettings: {
+      var e = modelData
+      var s = ({})
+      if (e && typeof e === "object") {
+        for (var k in e) if (k !== "id") s[k] = e[k]
+      }
+      return s
+    }
+    readonly property var registryComponent: {
+      var widgets = root.bar && root.bar.barWidgetRegistry ? root.bar.barWidgetRegistry.widgets : null
+      if (!widgets) return null
+      var name = root.bar.canonicalWidgetId ? root.bar.canonicalWidgetId(nested.moduleName) : nested.moduleName
+      return widgets[name] ? widgets[name].component : null
+    }
+
+    active: registryComponent !== null
+    sourceComponent: registryComponent
+    onLoaded: injectProps()
+
+    function injectProps() {
+      if (!item) return
+      if ("bar" in item) item.bar = root.bar
+      if ("moduleName" in item) item.moduleName = nested.moduleName
+      if ("settings" in item) item.settings = nested.moduleSettings
+    }
+  }
+
 
   // Renders a tray icon, recoloring symbolic icons to the bar foreground so
   // they stay visible on any theme (a raw symbolic icon keeps its baked-in

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -291,8 +291,18 @@ assertEqual(bar.entryId({ id: 'omarchy.clock' }), 'omarchy.clock', 'bar extracts
 assertEqual(bar.entryId('omarchy.clock'), 'omarchy.clock', 'bar extracts string entry ids')
 
 const entries = [{ id: 'a' }, { id: 'omarchy.tray' }, { id: 'b' }]
-assertDeepEqual(bar.pinTrayToInner(entries, 'left').map(bar.entryId), ['a', 'b', 'omarchy.tray'], 'bar pins tray to left inner edge')
-assertDeepEqual(bar.pinTrayToInner(entries, 'right').map(bar.entryId), ['omarchy.tray', 'a', 'b'], 'bar pins tray to right inner edge')
+const leftSplit = bar.pinTrayToInner(entries, 'left')
+assertDeepEqual(leftSplit.map(bar.entryId), ['b', 'omarchy.tray'], 'bar pins tray to left inner edge')
+assertDeepEqual(leftSplit[1].widgets.map(bar.entryId), ['a'], 'bar nests entries listed before the tray into the left tray')
+const rightSplit = bar.pinTrayToInner(entries, 'right')
+assertDeepEqual(rightSplit.map(bar.entryId), ['omarchy.tray', 'b'], 'bar pins tray to right inner edge')
+assertDeepEqual(rightSplit[0].widgets.map(bar.entryId), ['a'], 'bar nests entries listed before the tray into the right tray')
+const manyInner = bar.pinTrayToInner([{ id: 'a' }, { id: 'c' }, { id: 'omarchy.tray' }, { id: 'b' }], 'right')
+assertDeepEqual(manyInner.map(bar.entryId), ['omarchy.tray', 'b'], 'bar collapses multiple pre-tray entries into the tray')
+assertDeepEqual(manyInner[0].widgets.map(bar.entryId), ['a', 'c'], 'bar preserves inner entry order')
+assertDeepEqual(bar.pinTrayToInner([{ id: 'omarchy.tray' }, { id: 'b' }], 'right')[0].widgets, [], 'bar keeps an empty widget list when the tray is first')
+assertDeepEqual(bar.pinTrayToInner([{ id: 'a' }, { id: 'b' }], 'right'), [{ id: 'a' }, { id: 'b' }], 'bar leaves a tray-less section untouched')
+assertDeepEqual(bar.pinTrayToInner([{ id: 'omarchy.tray', pinned: ['x'] }], 'right')[0].pinned, ['x'], 'bar preserves existing tray settings when nesting')
 
 // A settings-only shell.json write must patch the live bar, not rebuild it:
 // the module Repeaters recreate every widget when their array model changes.

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -303,6 +303,13 @@ assertDeepEqual(manyInner[0].widgets.map(bar.entryId), ['a', 'c'], 'bar preserve
 assertDeepEqual(bar.pinTrayToInner([{ id: 'omarchy.tray' }, { id: 'b' }], 'right')[0].widgets, [], 'bar keeps an empty widget list when the tray is first')
 assertDeepEqual(bar.pinTrayToInner([{ id: 'a' }, { id: 'b' }], 'right'), [{ id: 'a' }, { id: 'b' }], 'bar leaves a tray-less section untouched')
 assertDeepEqual(bar.pinTrayToInner([{ id: 'omarchy.tray', pinned: ['x'] }], 'right')[0].pinned, ['x'], 'bar preserves existing tray settings when nesting')
+assertDeepEqual(
+  bar.pinTrayToInner([{ id: 'a' }, { id: 'omarchy.tray' }, { id: 'omarchy.tray' }, { id: 'b' }], 'right').map(bar.entryId),
+  ['omarchy.tray', 'b'],
+  'bar drops duplicate tray entries instead of rendering them beside the tray'
+)
+const trayLess = [{ id: 'a' }, { id: 'b' }]
+assert(bar.pinTrayToInner(trayLess, 'right') !== trayLess, 'bar returns a fresh array for a tray-less section')
 
 // A settings-only shell.json write must patch the live bar, not rebuild it:
 // the module Repeaters recreate every widget when their array model changes.


### PR DESCRIPTION
## Summary

Bar widgets listed **before** `omarchy.tray` in a section now collapse into the tray's reveal drawer instead of rendering as their own bar slots. Widgets listed **after** it stay visible. Position is the only signal, so the existing drag-to-reorder gesture (and `omarchy bar move`) becomes the "move a widget in/out of the tray" control.

## Why

The system tray only shows StatusNotifier icons from running apps. This lets users tuck less-used bar widgets (custom plugins, secondary status widgets) behind the tray chevron so they stay hidden until hovered, freeing bar space.

## Changes

- `shell/plugins/bar/BarModel.js` — `pinTrayToInner()` splits the section at the tray: pre-tray entries are attached to the tray entry as `widgets` and removed from the section; post-tray entries remain.
- `shell/plugins/bar/widgets/Tray.qml` — renders `settings.widgets` in the reveal drawer through a new `NestedBarWidget` loader that mirrors the bar host's `ModuleSlot` contract (injects `bar` / `moduleName` / `settings`). Drawer extent now accounts for widget width/height on both horizontal and vertical bars.
- `test/shell.d/bar-test.sh` — updates the two `pinTrayToInner` assertions and adds coverage for the nesting behavior.

## Testing

- `bar-test.sh`, `tray-test.sh`, and `bar-widget-contract-test.sh` all pass.
- Live-tested on a running shell: three widgets listed before the tray load inside it with no QML errors.

## Limitation

Only registered bar widgets render inside the tray. Custom `command` / `qml` modules (entries with `type` / `exec` / `source`) aren't in the widget registry and are skipped if placed above the tray.
