### PR TITLE
Fix password field losing autofocus on lock screen

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -14,6 +14,7 @@ Item {
   property int failedAttempts: 0
   property bool inputEnabled: true
   property bool loadBackground: true
+  property bool secure: false
   property string passwordText: ""
   property bool syncingPasswordText: false
 
@@ -70,6 +71,9 @@ Item {
   onPasswordTextChanged: syncPasswordText()
   onInputEnabledChanged: {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
+  }
+  onSecureChanged: {
+    if (secure) Qt.callLater(forcePasswordFocus)
   }
   Component.onCompleted: {
     syncPasswordText()

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -56,6 +56,28 @@ Item {
     passwordInput.forceActiveFocus()
   }
 
+  function retryPasswordFocus() {
+    if (!inputEnabled || authenticatingPassword) return
+    forcePasswordFocus()
+    focusRetryTimer.attemptsLeft = 20
+    focusRetryTimer.restart()
+  }
+
+  Timer {
+    id: focusRetryTimer
+    interval: 150
+    repeat: true
+    property int attemptsLeft: 0
+    onTriggered: {
+      attemptsLeft -= 1
+      if (passwordInput.activeFocus || attemptsLeft <= 0) {
+        stop()
+        return
+      }
+      root.forcePasswordFocus()
+    }
+  }
+
   function clearPassword() {
     passwordTextEdited("")
   }
@@ -69,11 +91,11 @@ Item {
 
   onPasswordTextChanged: syncPasswordText()
   onInputEnabledChanged: {
-    if (inputEnabled) Qt.callLater(forcePasswordFocus)
+    if (inputEnabled) Qt.callLater(retryPasswordFocus)
   }
   Component.onCompleted: {
     syncPasswordText()
-    if (inputEnabled) Qt.callLater(forcePasswordFocus)
+    if (inputEnabled) Qt.callLater(retryPasswordFocus)
   }
 
   // Measures the masked password at full size; passwordDotScale compares this

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -56,28 +56,6 @@ Item {
     passwordInput.forceActiveFocus()
   }
 
-  function retryPasswordFocus() {
-    if (!inputEnabled || authenticatingPassword) return
-    forcePasswordFocus()
-    focusRetryTimer.attemptsLeft = 20
-    focusRetryTimer.restart()
-  }
-
-  Timer {
-    id: focusRetryTimer
-    interval: 150
-    repeat: true
-    property int attemptsLeft: 0
-    onTriggered: {
-      attemptsLeft -= 1
-      if (passwordInput.activeFocus || attemptsLeft <= 0) {
-        stop()
-        return
-      }
-      root.forcePasswordFocus()
-    }
-  }
-
   function clearPassword() {
     passwordTextEdited("")
   }
@@ -91,11 +69,11 @@ Item {
 
   onPasswordTextChanged: syncPasswordText()
   onInputEnabledChanged: {
-    if (inputEnabled) Qt.callLater(retryPasswordFocus)
+    if (inputEnabled) Qt.callLater(forcePasswordFocus)
   }
   Component.onCompleted: {
     syncPasswordText()
-    if (inputEnabled) Qt.callLater(retryPasswordFocus)
+    if (inputEnabled) Qt.callLater(forcePasswordFocus)
   }
 
   // Measures the masked password at full size; passwordDotScale compares this

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -239,6 +239,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
+        Qt.callLater(lockView.forcePasswordFocus)
       }
     }
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -239,7 +239,6 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
-        Qt.callLater(function() { lockView.forcePasswordFocus() })
       }
     }
 
@@ -275,6 +274,7 @@ Item {
         authenticatingPassword: root.authenticatingPassword
         failureMessage: root.failureMessage
         failedAttempts: root.failedAttempts
+        secure: sessionLock.secure
         inputEnabled: root.lockRequested
         loadBackground: root.locked
         passwordText: root.enteredPassword

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -239,7 +239,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
-        Qt.callLater(function() { lockView.retryPasswordFocus() })
+        Qt.callLater(function() { lockView.forcePasswordFocus() })
       }
     }
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -239,7 +239,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
-        Qt.callLater(lockView.forcePasswordFocus)
+        Qt.callLater(function() { lockView.forcePasswordFocus() })
       }
     }
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -239,7 +239,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
-        Qt.callLater(function() { lockView.forcePasswordFocus() })
+        Qt.callLater(function() { lockView.retryPasswordFocus() })
       }
     }
 


### PR DESCRIPTION
I noticed that sometimes on the password screen when I type my input does not go into the password field.

According to Claude:

> forcePasswordFocus() was only triggered by inputEnabled toggling true, which fires before the compositor grants the session lock surface exclusive keyboard focus. Also force focus once WlSessionLock reports secure=true, when focus is actually available.