### PR TITLE
Make hotkeys discoverable: show the shortcut on the rows that have one

### DIFF
--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -10,7 +10,23 @@ if [[ ${1:-} == "--install" ]]; then
   shift
 fi
 
-if (($# == 0)); then
+# The selection is a short name; the command behind it is what actually runs, and
+# only this table knows the difference (chrome is google-chrome-stable). Both are
+# asked for, so keep one table and let the query reach it.
+browser_spec() {
+  case "$1" in
+  chromium) browser="chromium"; command="chromium"; desktop_id="chromium.desktop"; name="Chromium"; glyph= ;;
+  chrome) browser="chrome"; command="google-chrome-stable"; desktop_id="google-chrome.desktop"; name="Chrome"; glyph=󰊯 ;;
+  brave) browser="brave"; command="brave"; desktop_id="brave-browser.desktop"; name="Brave"; glyph=󰖟 ;;
+  brave-origin) browser="brave-origin"; command="brave-origin"; desktop_id="brave-origin.desktop"; name="Brave Origin"; glyph=󰖟 ;;
+  edge) browser="edge"; command="microsoft-edge-stable"; desktop_id="microsoft-edge.desktop"; name="Edge"; glyph=󰇩 ;;
+  firefox) browser="firefox"; command="firefox"; desktop_id="firefox.desktop"; name="Firefox"; glyph=󰈹 ;;
+  zen) browser="zen"; command="zen-browser"; desktop_id="zen.desktop"; name="Zen"; glyph=󰖟 ;;
+  *) return 1 ;;
+  esac
+}
+
+current_browser() {
   case "$(env -u BROWSER xdg-settings get default-web-browser)" in
   chromium.desktop) echo "chromium" ;;
   google-chrome.desktop) echo "chrome" ;;
@@ -21,22 +37,23 @@ if (($# == 0)); then
   zen.desktop) echo "zen" ;;
   *) env -u BROWSER xdg-settings get default-web-browser ;;
   esac
+}
+
+if (($# == 0)); then
+  current_browser
   exit 0
 fi
 
-case "$1" in
-chromium) browser="chromium"; command="chromium"; desktop_id="chromium.desktop"; name="Chromium"; glyph= ;;
-chrome) browser="chrome"; command="google-chrome-stable"; desktop_id="google-chrome.desktop"; name="Chrome"; glyph=󰊯 ;;
-brave) browser="brave"; command="brave"; desktop_id="brave-browser.desktop"; name="Brave"; glyph=󰖟 ;;
-brave-origin) browser="brave-origin"; command="brave-origin"; desktop_id="brave-origin.desktop"; name="Brave Origin"; glyph=󰖟 ;;
-edge) browser="edge"; command="microsoft-edge-stable"; desktop_id="microsoft-edge.desktop"; name="Edge"; glyph=󰇩 ;;
-firefox) browser="firefox"; command="firefox"; desktop_id="firefox.desktop"; name="Firefox"; glyph=󰈹 ;;
-zen) browser="zen"; command="zen-browser"; desktop_id="zen.desktop"; name="Zen"; glyph=󰖟 ;;
-*)
+# What the menu needs to label the Browser keybinding with the app it opens.
+if [[ $1 == "--command" ]]; then
+  browser_spec "$(current_browser)" && echo "$command"
+  exit 0
+fi
+
+if ! browser_spec "$1"; then
   echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
   exit 1
-  ;;
-esac
+fi
 
 if omarchy-cmd-missing "$command"; then
   if [[ $installing == "false" ]]; then

--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -10,6 +10,29 @@ if [[ ${1:-} == "--install" ]]; then
   shift
 fi
 
+# The selection is a short name; the command behind it is what actually runs, and
+# only this table knows the difference (zed is zeditor). Both are asked for, so
+# keep one table and let the query reach it.
+editor_spec() {
+  case "$1" in
+  code) selection="code"; editor="code"; name="VSCode"; glyph= ;;
+  cursor) selection="cursor"; editor="cursor"; name="Cursor"; glyph= ;;
+  zed | zeditor) selection="zed"; editor="zeditor"; name="Zed"; glyph= ;;
+  sublime_text) selection="sublime_text"; editor="sublime_text"; name="Sublime Text"; glyph= ;;
+  helix) selection="helix"; editor="helix"; name="Helix"; glyph= ;;
+  vim) selection="vim"; editor="vim"; name="Vim"; glyph= ;;
+  emacs) selection="emacs"; editor="emacs"; name="Emacs"; glyph= ;;
+  nvim) selection="nvim"; editor="nvim"; name="Neovim"; glyph= ;;
+  *) return 1 ;;
+  esac
+}
+
+# What the menu needs to label the Editor keybinding with the app it opens.
+if [[ ${1:-} == "--command" ]]; then
+  editor_spec "$(omarchy-default-editor)" && echo "$editor"
+  exit 0
+fi
+
 editor_file="$HOME/.local/state/omarchy/defaults/editor"
 
 if (($# == 0)); then
@@ -21,20 +44,10 @@ if (($# == 0)); then
   exit 0
 fi
 
-case "$1" in
-code) selection="code"; editor="code"; name="VSCode"; glyph= ;;
-cursor) selection="cursor"; editor="cursor"; name="Cursor"; glyph= ;;
-zed | zeditor) selection="zed"; editor="zeditor"; name="Zed"; glyph= ;;
-sublime_text) selection="sublime_text"; editor="sublime_text"; name="Sublime Text"; glyph= ;;
-helix) selection="helix"; editor="helix"; name="Helix"; glyph= ;;
-vim) selection="vim"; editor="vim"; name="Vim"; glyph= ;;
-emacs) selection="emacs"; editor="emacs"; name="Emacs"; glyph= ;;
-nvim) selection="nvim"; editor="nvim"; name="Neovim"; glyph= ;;
-*)
+if ! editor_spec "$1"; then
   echo "Usage: omarchy-default-editor <code|cursor|zed|sublime_text|helix|vim|emacs|nvim>"
   exit 1
-  ;;
-esac
+fi
 
 if omarchy-cmd-missing "$editor"; then
   if [[ $installing == "false" ]]; then

--- a/bin/omarchy-default-terminal
+++ b/bin/omarchy-default-terminal
@@ -10,6 +10,18 @@ if [[ ${1:-} == "--install" ]]; then
   shift
 fi
 
+# The selection and the command behind it agree for every terminal here, but the
+# menu asks the same question of every default, so answer it the same way.
+terminal_spec() {
+  case "$1" in
+  alacritty) terminal="alacritty"; desktop_id="Alacritty.desktop"; name="Alacritty"; glyph= ;;
+  foot) terminal="foot"; desktop_id="foot.desktop"; name="Foot"; glyph= ;;
+  ghostty) terminal="ghostty"; desktop_id="com.mitchellh.ghostty.desktop"; name="Ghostty"; glyph= ;;
+  kitty) terminal="kitty"; desktop_id="kitty.desktop"; name="Kitty"; glyph= ;;
+  *) return 1 ;;
+  esac
+}
+
 if (($# == 0)); then
   desktop_id=$(xdg-terminal-exec --print-id 2>/dev/null || true)
   desktop_id=${desktop_id%%:*}
@@ -23,16 +35,16 @@ if (($# == 0)); then
   exit 0
 fi
 
-case "$1" in
-alacritty) terminal="alacritty"; desktop_id="Alacritty.desktop"; name="Alacritty"; glyph= ;;
-foot) terminal="foot"; desktop_id="foot.desktop"; name="Foot"; glyph= ;;
-ghostty) terminal="ghostty"; desktop_id="com.mitchellh.ghostty.desktop"; name="Ghostty"; glyph= ;;
-kitty) terminal="kitty"; desktop_id="kitty.desktop"; name="Kitty"; glyph= ;;
-*)
+# What the menu needs to label the Terminal keybinding with the app it opens.
+if [[ $1 == "--command" ]]; then
+  terminal_spec "$(omarchy-default-terminal)" && echo "$terminal"
+  exit 0
+fi
+
+if ! terminal_spec "$1"; then
   echo "Usage: omarchy-default-terminal <alacritty|foot|ghostty|kitty>"
   exit 1
-  ;;
-esac
+fi
 
 if omarchy-cmd-missing "$terminal"; then
   if [[ $installing == "false" ]]; then

--- a/bin/omarchy-launch-1password
+++ b/bin/omarchy-launch-1password
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Launch 1Password or start its installer when missing.
+# omarchy:launches=1password
 
 set -e
 

--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -2,6 +2,7 @@
 
 # omarchy:summary=Launch the default browser as determined by xdg-settings.
 # omarchy:args=[url]
+# omarchy:launches=default:browser
 
 default_browser=$(env -u BROWSER xdg-settings get default-web-browser)
 if [[ -z $default_browser ]]; then

--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -2,6 +2,7 @@
 
 # omarchy:summary=Launch the default editor selected via Omarchy defaults.
 # omarchy:args=[--inline] <path>
+# omarchy:launches=default:editor
 
 default_editor="$HOME/.local/state/omarchy/defaults/editor"
 

--- a/bin/omarchy-launch-nautilus
+++ b/bin/omarchy-launch-nautilus
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 # omarchy:summary=Launch Files
+# omarchy:launches=nautilus
 
 exec setsid uwsm-app -- nautilus --new-window

--- a/bin/omarchy-launch-signal
+++ b/bin/omarchy-launch-signal
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Launch Signal or start its installer when missing.
+# omarchy:launches=signal-desktop
 
 set -e
 

--- a/bin/omarchy-launch-spotify
+++ b/bin/omarchy-launch-spotify
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Launch Spotify or start its installer when missing.
+# omarchy:launches=spotify
 
 set -e
 

--- a/bin/omarchy-launch-terminal
+++ b/bin/omarchy-launch-terminal
@@ -2,5 +2,6 @@
 
 # omarchy:summary=Launch a terminal in the active terminal's current directory
 # omarchy:args=[command...]
+# omarchy:launches=default:terminal
 
 exec setsid uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" "$@"

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -94,17 +94,32 @@ end
 -- carries the keys and drops the command. Record the pairs while the config
 -- loads and hand them to the shell, which labels menu rows with the shortcut
 -- that reaches them (see docs/menu.md).
-local keybindings_path = (os.getenv("HOME") or "") .. "/.local/state/omarchy/keybindings.tsv"
+local keybindings_dir = (os.getenv("HOME") or "") .. "/.local/state/omarchy"
+local keybindings_path = keybindings_dir .. "/keybindings.tsv"
 local keybindings = {}
 
+local function open_keybindings_file()
+  local file = io.open(keybindings_path .. ".new", "w")
+  if file then
+    return file
+  end
+
+  -- Only reached before the state directory exists, so the fork is a one-off
+  -- rather than part of every config load.
+  os.execute("mkdir -p " .. shell_quote(keybindings_dir))
+  return io.open(keybindings_path .. ".new", "w")
+end
+
 local function write_keybindings()
-  local file = io.open(keybindings_path, "w")
+  local file = open_keybindings_file()
   if not file then
     return
   end
 
   file:write(table.concat(keybindings, "\n"), "\n")
   file:close()
+  -- Renamed into place so a shell reading the file never sees half a snapshot.
+  os.rename(keybindings_path .. ".new", keybindings_path)
 end
 
 -- Both events fire once per config load, and Hyprland drops the handlers a

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -89,6 +89,29 @@ function o.preinstalled_bindings_enabled()
   return not file_exists((os.getenv("HOME") or "") .. "/.local/state/omarchy/preinstalls-removed")
 end
 
+-- o.bind is the only place that sees a key combination and the command it runs
+-- together: Hyprland reports Lua binds as dispatcher `__lua`, so `hyprctl binds`
+-- carries the keys and drops the command. Record the pairs while the config
+-- loads and hand them to the shell, which labels menu rows with the shortcut
+-- that reaches them (see docs/menu.md).
+local keybindings_path = (os.getenv("HOME") or "") .. "/.local/state/omarchy/keybindings.tsv"
+local keybindings = {}
+
+local function write_keybindings()
+  local file = io.open(keybindings_path, "w")
+  if not file then
+    return
+  end
+
+  file:write(table.concat(keybindings, "\n"), "\n")
+  file:close()
+end
+
+-- Both events fire once per config load, and Hyprland drops the handlers a
+-- reload registers again, so this stays one write per load however it started.
+hl.on("hyprland.start", write_keybindings)
+hl.on("config.reloaded", write_keybindings)
+
 function o.bind(keys, description, dispatcher, options)
   local opts = options or {}
 
@@ -99,6 +122,7 @@ function o.bind(keys, description, dispatcher, options)
   dispatcher = command_from(dispatcher, description)
 
   if type(dispatcher) == "string" then
+    keybindings[#keybindings + 1] = keys .. "\t" .. dispatcher
     dispatcher = hl.dsp.exec_cmd(dispatcher)
   end
 

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -60,6 +60,41 @@ The sample extension at `config/omarchy/extensions/omarchy-menu.jsonc`
 (refreshed into `~/.config/`) documents the format in its header and ships
 only comments, so the default state adds nothing.
 
+## Shortcuts
+
+A row that a keybinding also reaches shows that key beside its label — Style >
+Theme reads `⌘⇧⌃ SPACE` — so the menu teaches the shortcut for the thing you
+just came to it for. Nothing declares this: no menu entry names a key and no
+binding names a row.
+
+The pairing comes from `o.bind` in `default/hypr/helpers.lua`, the single funnel
+every Omarchy binding passes through and the only place a key combination and
+the command it runs are both in hand. `hyprctl binds` is not that place:
+Hyprland reports Lua binds as dispatcher `__lua` and keeps the command to
+itself. So `o.bind` records each `<keys>\t<command>` pair as the config loads and
+writes `~/.local/state/omarchy/keybindings.tsv` once it has, on `hyprland.start`
+and `config.reloaded` alike. The shell watches that file the way it watches the
+JSONC, so a reloaded binding relabels the rows without a shell restart, and a
+machine whose config predates the file loses the shortcuts and nothing else.
+
+`resolveShortcuts` in `MenuModel.js` matches a binding to a row two ways, once
+per (re)load rather than per row:
+
+- the binding runs the row's `action` verbatim — `omarchy-system-lock` labels
+  System > Lock, `PRINT` labels Trigger > Capture > Screenshot
+- the binding opens the row by route — `omarchy-menu toggle theme` goes through
+  the same alias resolution `omarchy menu summon` uses, so it finds `style.theme`
+
+An action match wins, since it names one row while a route names whatever
+currently answers to that name. Two keys for one command keep the first, so a
+user file adding a second reads as an alternative rather than a replacement.
+Bindings on a raw `code:34` are dropped: the keycode names nothing a reader
+could press, and resolving one costs a keymap compile the open path will not pay.
+
+Modifiers render as symbols (`⌘⇧⌃⌥`) because the spelled-out form is several
+times wider than the label it sits beside; the key itself stays spelled out so
+the row still reads as a key to press.
+
 ## Guards
 
 `when`, `checked`, and `disabled` are bash conditions. The shell never

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -97,34 +97,43 @@ could press, and resolving one costs a keymap compile the open path will not pay
 
 An app row launches through its desktop entry, a binding through whatever
 `o.bind` was handed, and `launchKeys` reduces both to the same key. Session
-wrappers (`uwsm-app --`, `setsid`) come off, a program is compared by name
+wrappers (`uwsm-app --`, `setsid -f`) come off, a program is compared by name
 rather than by path, and a trailing slash on a URL is ignored, since a desktop
 entry and a binding disagree about one often enough that it cannot be what
-separates them.
+separates them. That is the whole of it for a web app, whose two halves already
+run the same `omarchy-launch-webapp <url>`.
 
-The rest of the distance is Omarchy's own launchers, whose names already say
-what they do, so nothing here knows an application by name:
+Omarchy's own launchers are the rest of the distance, and they say what they
+open rather than being guessed at. A launcher name is not evidence:
+`omarchy-launch-signal` runs `signal-desktop`, and `omarchy-launch-browser` runs
+whichever browser is currently the default. So the launcher declares it, beside
+the `omarchy:summary=` metadata it already carries:
 
-- `omarchy-launch-X` wraps X, and on its own it stands for X
-- unless an `omarchy-default-X` can answer, which makes it a resolver and X
-  whatever that reader currently says — this is how Browser and Terminal land on
-  the browser and terminal actually in use. The values come from the guard
-  batch, which already runs those readers for the ✓ on the Defaults rows and now
-  reports what they printed, so the answer costs an `echo` rather than a fork.
-- the `-or-focus` wrappers take a window pattern first and delegate the rest, so
-  they unwrap to what they delegate to
+```bash
+# omarchy:launches=signal-desktop      # a fixed app
+# omarchy:launches=default:browser     # ask omarchy-default-browser --command
+```
 
-A binding that runs a bare program claims the app that *is* that program, whatever
-arguments the desktop entry adds — Spotify keeps its key off `spotify --uri=%u`.
-A binding carrying arguments of its own has to match in full, so
-`omarchy-launch-browser --private` never claims the browser the plain binding
-does. Where several apps run one program — every Chrome web app runs the browser
-with arguments after it — the entry that runs it plainly owns the name, and a
-name several entries claim alike belongs to none of them.
+`default:X` defers to `omarchy-default-X --command`, which is the only place
+that knows the browser you picked as `chrome` runs `google-chrome-stable`, or
+that `zed` runs `zeditor`. Those scripts keep one table for both questions —
+what is selected, and what that selection runs — so the two cannot drift.
 
-Modifiers render as symbols (`⌘⇧⌃⌥`) because the spelled-out form is several
-times wider than the label it sits beside; the key itself stays spelled out so
-the row still reads as a key to press.
+The shell collects the declarations in one bash pass when the bindings file
+loads, which is to say once per Hyprland config reload, never on the open path.
+A launcher that declares nothing matches nothing.
+
+The `-or-focus` wrappers take a window pattern first and delegate the rest, so
+they unwrap to what they delegate to, and resolution is depth-bounded so a
+launcher declaring itself cannot loop.
+
+A binding that runs a bare program claims the app that *is* that program,
+whatever arguments the desktop entry adds — Spotify keeps its key off
+`spotify --uri=%u`. A binding carrying arguments of its own has to match in
+full, so `omarchy-launch-browser --private` never claims the browser the plain
+binding does. Where several apps run one program — every Chrome web app runs the
+browser with arguments after it — the entry that runs it plainly owns the name,
+and a name several entries claim alike belongs to none of them.
 
 ## Guards
 

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -77,19 +77,50 @@ and `config.reloaded` alike. The shell watches that file the way it watches the
 JSONC, so a reloaded binding relabels the rows without a shell restart, and a
 machine whose config predates the file loses the shortcuts and nothing else.
 
-`resolveShortcuts` in `MenuModel.js` matches a binding to a row two ways, once
+`resolveShortcuts` in `MenuModel.js` matches a binding to a row three ways, once
 per (re)load rather than per row:
 
 - the binding runs the row's `action` verbatim — `omarchy-system-lock` labels
   System > Lock, `PRINT` labels Trigger > Capture > Screenshot
 - the binding opens the row by route — `omarchy-menu toggle theme` goes through
   the same alias resolution `omarchy menu summon` uses, so it finds `style.theme`
+- the binding and an app row launch the same application, which is what puts a
+  key on Chromium and ChatGPT in the Apps list
 
 An action match wins, since it names one row while a route names whatever
 currently answers to that name. Two keys for one command keep the first, so a
 user file adding a second reads as an alternative rather than a replacement.
 Bindings on a raw `code:34` are dropped: the keycode names nothing a reader
 could press, and resolving one costs a keymap compile the open path will not pay.
+
+## Matching an app row
+
+An app row launches through its desktop entry, a binding through whatever
+`o.bind` was handed, and `launchKeys` reduces both to the same key. Session
+wrappers (`uwsm-app --`, `setsid`) come off, a program is compared by name
+rather than by path, and a trailing slash on a URL is ignored, since a desktop
+entry and a binding disagree about one often enough that it cannot be what
+separates them.
+
+The rest of the distance is Omarchy's own launchers, whose names already say
+what they do, so nothing here knows an application by name:
+
+- `omarchy-launch-X` wraps X, and on its own it stands for X
+- unless an `omarchy-default-X` can answer, which makes it a resolver and X
+  whatever that reader currently says — this is how Browser and Terminal land on
+  the browser and terminal actually in use. The values come from the guard
+  batch, which already runs those readers for the ✓ on the Defaults rows and now
+  reports what they printed, so the answer costs an `echo` rather than a fork.
+- the `-or-focus` wrappers take a window pattern first and delegate the rest, so
+  they unwrap to what they delegate to
+
+A binding that runs a bare program claims the app that *is* that program, whatever
+arguments the desktop entry adds — Spotify keeps its key off `spotify --uri=%u`.
+A binding carrying arguments of its own has to match in full, so
+`omarchy-launch-browser --private` never claims the browser the plain binding
+does. Where several apps run one program — every Chrome web app runs the browser
+with arguments after it — the entry that runs it plainly owns the name, and a
+name several entries claim alike belongs to none of them.
 
 Modifiers render as symbols (`⌘⇧⌃⌥`) because the spelled-out form is several
 times wider than the label it sits beside; the key itself stays spelled out so

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -49,8 +49,12 @@ Item {
   // path doesn't have to shell out to bash + jq on every open.
   property string defaultMenuPath: omarchyPath + "/default/omarchy/omarchy-menu.jsonc"
   property string userMenuPath: Quickshell.env("HOME") + "/.config/omarchy/extensions/omarchy-menu.jsonc"
+  // Keys → command pairs recorded by `o.bind` while Hyprland loaded its config.
+  property string keybindingsPath: Quickshell.env("HOME") + "/.local/state/omarchy/keybindings.tsv"
   property var defaultMenuItems: []
   property var userMenuItems: []
+  property var keybindings: null
+  property var shortcutsById: ({})
   property bool opened: false
   property string mode: "menu"
   readonly property bool dmenuActive: mode === "select" || mode === "input"
@@ -250,6 +254,7 @@ Item {
     root.providerQueue = []
     root.items = mergedMenu.items
     root.itemOrder = mergedMenu.itemOrder
+    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings)
     root.rowsLoaded = true
     root.evaluateGuards()
     if (root.opened) {
@@ -259,6 +264,14 @@ Item {
         else root.loadProviderForMenu(root.activeMenu)
       }
     }
+  }
+
+  // The bindings change only when Hyprland reloads its config, so the rows are
+  // re-labelled where they stand rather than rebuilt.
+  function applyKeybindings(raw) {
+    root.keybindings = raw === null ? null : MenuModel.parseKeybindings(raw)
+    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings)
+    if (root.opened) root.rebuildDisplay()
   }
 
   // Each known provider is a tiny bash one-liner that enumerates a list and
@@ -516,7 +529,7 @@ Item {
   }
 
   function displayRow(entry, detail, score, section) {
-    return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults, root.disabledResults, entry, detail, score, section)
+    return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults, root.disabledResults, root.shortcutsById, entry, detail, score, section)
   }
 
   function rowSelectable(index) {
@@ -574,6 +587,7 @@ Item {
       displayModel.append({
         itemId: "dmenu." + i,
         disabled: false,
+        shortcut: "",
         kind: "dmenu",
         icon: icon,
         iconFont: "",
@@ -981,6 +995,18 @@ Item {
     onFileChanged: reload()
   }
 
+  // Written by `o.bind` on every Hyprland config load. Absent on a machine
+  // whose config predates it, which costs the shortcuts and nothing else.
+  FileView {
+    id: keybindingsFile
+    path: root.keybindingsPath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.applyKeybindings(text())
+    onLoadFailed: root.applyKeybindings(null)
+    onFileChanged: reload()
+  }
+
   // ---------------------------------------------------------------- guards
   //
   // `when:` (visibility) and `checked:` (✓ marker) are bash expressions the
@@ -1258,6 +1284,7 @@ Item {
               required property string detail
               required property string path
               required property string action
+              required property string shortcut
               required property int childCount
               required property bool disabled
 
@@ -1321,7 +1348,7 @@ Item {
                 id: contentColumn
                 anchors.left: row.hasIcon ? iconText.right : parent.left
                 anchors.leftMargin: row.hasIcon ? Style.space(6) : root.rowReservedBorderLeft + Style.space(18)
-                anchors.right: trail.left
+                anchors.right: shortcutText.visible ? shortcutText.left : trail.left
                 anchors.rightMargin: Style.space(6)
                 anchors.verticalCenter: parent.verticalCenter
                 spacing: Style.space(3)
@@ -1347,6 +1374,22 @@ Item {
                   font.pixelSize: Style.font.bodySmall
                   elide: Text.ElideRight
                 }
+              }
+
+              // The key that reaches this row without opening the menu. Sits
+              // outside the label column so a long shortcut elides the label
+              // rather than being elided by it.
+              Text {
+                id: shortcutText
+                visible: row.shortcut.length > 0
+                text: row.shortcut
+                color: row.hasCursor ? root.selectedText : root.foreground
+                opacity: 0.4
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.bodySmall
+                anchors.right: trail.left
+                anchors.rightMargin: Style.space(6)
+                y: contentColumn.y + labelText.y + (labelText.height - height) / 2
               }
 
               Row {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -254,7 +254,7 @@ Item {
     root.providerQueue = []
     root.items = mergedMenu.items
     root.itemOrder = mergedMenu.itemOrder
-    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings)
+    root.refreshShortcuts()
     root.rowsLoaded = true
     root.evaluateGuards()
     if (root.opened) {
@@ -266,11 +266,15 @@ Item {
     }
   }
 
+  function refreshShortcuts() {
+    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings, root.readerResults)
+  }
+
   // The bindings change only when Hyprland reloads its config, so the rows are
   // re-labelled where they stand rather than rebuilt.
   function applyKeybindings(raw) {
     root.keybindings = raw === null ? null : MenuModel.parseKeybindings(raw)
-    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings)
+    root.refreshShortcuts()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -311,8 +315,11 @@ Item {
       if (!appId) continue
       var subtext = root.appLibrary.entrySubtext(entry)
       var aliases = subtext ? [subtext] : []
+      var exec = []
       try {
         if (entry.keywords && typeof entry.keywords.join === "function") aliases = aliases.concat(entry.keywords)
+        // The parsed argv, so the field codes (%U and friends) are already gone.
+        if (entry.command && typeof entry.command.slice === "function") exec = entry.command.slice()
       } catch (e) { }
       appRows.push({
         id: "apps." + appId,
@@ -326,6 +333,7 @@ Item {
         target: "",
         description: subtext,
         action: "",
+        exec: exec,
         provider: "",
         aliases: aliases,
         when: "",
@@ -338,6 +346,7 @@ Item {
     var merged = MenuModel.mergeAppRows(root.items, root.itemOrder, appRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
+    root.refreshShortcuts()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -1017,6 +1026,7 @@ Item {
   property var whenResults: ({})       // id → true|false (allow visibility)
   property var checkedResults: ({})    // id → true|false (show ✓)
   property var disabledResults: ({})   // id → true|false (dim, skip cursor)
+  property var readerResults: ({})     // reader command → what it printed
   property bool guardsPending: false
 
   function evaluateGuards() {
@@ -1037,6 +1047,7 @@ Item {
       root.whenResults = ({})
       root.checkedResults = ({})
       root.disabledResults = ({})
+      root.readerResults = ({})
       return
     }
     guardProc.collected = ""
@@ -1063,10 +1074,21 @@ Item {
       var nextWhen = ({})
       var nextChecked = ({})
       var nextDisabled = ({})
+      var nextReaders = ({})
       var lines = guardProc.collected.split("\n")
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i].trim()
         if (!line) continue
+        // `reader:<index>:<value>` before the guard lines: a reader's value is
+        // free text and may carry the colons the guard parse splits on.
+        if (line.indexOf("reader:") === 0) {
+          var readerAt = line.indexOf(":", 7)
+          if (readerAt > 7) {
+            var reader = MenuModel.GUARD_READERS[Number(line.substring(7, readerAt))]
+            if (reader) nextReaders[reader] = line.substring(readerAt + 1)
+          }
+          continue
+        }
         var colon = line.lastIndexOf(":")
         if (colon < 0) continue
         var value = line.substring(colon + 1) === "1"
@@ -1082,6 +1104,12 @@ Item {
       root.whenResults = nextWhen
       root.checkedResults = nextChecked
       root.disabledResults = nextDisabled
+      // Guards run on every open; the defaults they read almost never move, so
+      // the shortcuts are only rebuilt when one actually did.
+      if (JSON.stringify(nextReaders) !== JSON.stringify(root.readerResults)) {
+        root.readerResults = nextReaders
+        root.refreshShortcuts()
+      }
       if (root.opened) root.rebuildDisplay()
       // Run the evaluation that had to stand aside. Deferred by a turn so the
       // process is settled before its command is set again.

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -54,6 +54,7 @@ Item {
   property var defaultMenuItems: []
   property var userMenuItems: []
   property var keybindings: null
+  property var launchTargets: ({})
   property var shortcutsById: ({})
   property bool opened: false
   property string mode: "menu"
@@ -267,7 +268,7 @@ Item {
   }
 
   function refreshShortcuts() {
-    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings, root.readerResults)
+    root.shortcutsById = MenuModel.resolveShortcuts(root.items, root.itemOrder, root.keybindings, root.launchTargets)
   }
 
   // The bindings change only when Hyprland reloads its config, so the rows are
@@ -1011,9 +1012,41 @@ Item {
     path: root.keybindingsPath
     watchChanges: true
     printErrors: false
-    onLoaded: root.applyKeybindings(text())
+    onLoaded: { root.applyKeybindings(text()); resolveProc.running = true }
     onLoadFailed: root.applyKeybindings(null)
     onFileChanged: reload()
+  }
+
+  // What each launcher opens, straight from the `# omarchy:launches=` line in
+  // the launcher itself, so the menu never infers an app from a command name.
+  // `default:X` defers to `omarchy-default-X --command`, the only place that
+  // knows the browser you picked runs google-chrome-stable. Runs once per
+  // bindings load — a config reload — and never on the open path.
+  Process {
+    id: resolveProc
+    property string collected: ""
+    command: ["bash", "-lc",
+      'shopt -s nullglob; for launcher in "${OMARCHY_PATH:-/usr/share/omarchy}"/bin/omarchy-launch-*; do '
+      + 'target=$(sed -n "s/^# omarchy:launches=//p" "$launcher" | head -1); [[ -n $target ]] || continue; '
+      + '[[ $target == default:* ]] && target=$(omarchy-default-"${target#default:}" --command 2>/dev/null); '
+      + '[[ -n $target ]] && printf "%s\t%s\n" "${launcher##*/}" "$target"; done']
+    stdout: SplitParser {
+      onRead: function(data) { resolveProc.collected += data + "\n" }
+    }
+    onRunningChanged: if (resolveProc.running) resolveProc.collected = ""
+    onExited: function(exitCode) {
+      if (exitCode !== 0) return
+      var targets = ({})
+      var lines = resolveProc.collected.split("\n")
+      for (var i = 0; i < lines.length; i++) {
+        var tab = lines[i].indexOf("\t")
+        if (tab <= 0) continue
+        targets[lines[i].substring(0, tab)] = lines[i].substring(tab + 1).trim()
+      }
+      root.launchTargets = targets
+      root.refreshShortcuts()
+      if (root.opened) root.rebuildDisplay()
+    }
   }
 
   // ---------------------------------------------------------------- guards
@@ -1026,7 +1059,6 @@ Item {
   property var whenResults: ({})       // id → true|false (allow visibility)
   property var checkedResults: ({})    // id → true|false (show ✓)
   property var disabledResults: ({})   // id → true|false (dim, skip cursor)
-  property var readerResults: ({})     // reader command → what it printed
   property bool guardsPending: false
 
   function evaluateGuards() {
@@ -1047,7 +1079,6 @@ Item {
       root.whenResults = ({})
       root.checkedResults = ({})
       root.disabledResults = ({})
-      root.readerResults = ({})
       return
     }
     guardProc.collected = ""
@@ -1074,21 +1105,10 @@ Item {
       var nextWhen = ({})
       var nextChecked = ({})
       var nextDisabled = ({})
-      var nextReaders = ({})
       var lines = guardProc.collected.split("\n")
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i].trim()
         if (!line) continue
-        // `reader:<index>:<value>` before the guard lines: a reader's value is
-        // free text and may carry the colons the guard parse splits on.
-        if (line.indexOf("reader:") === 0) {
-          var readerAt = line.indexOf(":", 7)
-          if (readerAt > 7) {
-            var reader = MenuModel.GUARD_READERS[Number(line.substring(7, readerAt))]
-            if (reader) nextReaders[reader] = line.substring(readerAt + 1)
-          }
-          continue
-        }
         var colon = line.lastIndexOf(":")
         if (colon < 0) continue
         var value = line.substring(colon + 1) === "1"
@@ -1104,12 +1124,6 @@ Item {
       root.whenResults = nextWhen
       root.checkedResults = nextChecked
       root.disabledResults = nextDisabled
-      // Guards run on every open; the defaults they read almost never move, so
-      // the shortcuts are only rebuilt when one actually did.
-      if (JSON.stringify(nextReaders) !== JSON.stringify(root.readerResults)) {
-        root.readerResults = nextReaders
-        root.refreshShortcuts()
-      }
       if (root.opened) root.rebuildDisplay()
       // Run the evaluation that had to stand aside. Deferred by a turn so the
       // process is settled before its command is set again.

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -190,6 +190,99 @@ function resolveRoute(items, itemOrder, input) {
   return raw
 }
 
+// ------------------------------------------------------------- shortcuts
+//
+// `o.bind` writes ~/.local/state/omarchy/keybindings.tsv as it registers each
+// binding, one `<keys>\t<command>` line per bind, because Hyprland reports Lua
+// binds as dispatcher `__lua` and keeps the command to itself. A row earns its
+// shortcut two ways: the binding runs the row's own `action`, or it opens the
+// row by route — the `omarchy menu toggle theme` that Style > Theme answers to.
+var MENU_ROUTE_PATTERN = /^omarchy(?:-menu|\s+menu)\s+(?:toggle|summon)\s+(\S+)$/
+
+// A `code:34` key names an XKB keycode, not anything a reader could press, and
+// resolving one costs a keymap compile the open path will not pay.
+function keysArePressable(keys) {
+  return keys.indexOf("code:") < 0 && keys.indexOf("mouse:") < 0
+}
+
+function menuRouteFor(command) {
+  var match = MENU_ROUTE_PATTERN.exec(command)
+  return match ? match[1] : ""
+}
+
+// Keys as authored ("SUPER + SHIFT + CTRL + SPACE") are four times as wide as
+// the label they sit beside. Modifiers become their symbols, which the menu has
+// room for; the key itself stays spelled out so the row still reads as a key to
+// press. Media keys drop the XF86 vendor prefix nobody has printed on a keycap.
+var MODIFIER_SYMBOLS = ({
+  SUPER: "⌘",
+  SHIFT: "⇧",
+  CTRL: "⌃",
+  CONTROL: "⌃",
+  ALT: "⌥"
+})
+
+function shortcutLabel(keys) {
+  var parts = String(keys || "").split("+")
+  var modifiers = ""
+  var key = ""
+
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i].trim().toUpperCase()
+    if (!part) continue
+    if (MODIFIER_SYMBOLS[part]) modifiers += MODIFIER_SYMBOLS[part]
+    else key = part.indexOf("XF86") === 0 ? part.slice(4) : part
+  }
+
+  return modifiers && key ? modifiers + " " + key : modifiers + key
+}
+
+function parseKeybindings(raw) {
+  var byCommand = ({})
+  var byRoute = ({})
+  var lines = String(raw || "").split("\n")
+
+  for (var i = 0; i < lines.length; i++) {
+    var parts = lines[i].split("\t")
+    var keys = String(parts[0] || "").trim()
+    var command = String(parts[1] || "").trim()
+    if (!keys || !command || !keysArePressable(keys)) continue
+
+    var label = shortcutLabel(keys)
+    // First binding wins, so a user file that adds a second key for a command
+    // reads as an alternative rather than a replacement.
+    if (!byCommand[command]) byCommand[command] = label
+    var route = menuRouteFor(command)
+    if (route && !byRoute[route]) byRoute[route] = label
+  }
+
+  return { byCommand: byCommand, byRoute: byRoute }
+}
+
+// id → shortcut label, resolved once per (re)load instead of per row. Routes go
+// through the same alias resolution `omarchy menu summon` uses, so a binding on
+// `theme` finds `style.theme`. An action match wins: it names one row, while a
+// route names whatever currently answers to that name.
+function resolveShortcuts(items, itemOrder, shortcuts) {
+  var byId = ({})
+  if (!shortcuts) return byId
+
+  var order = Array.isArray(itemOrder) ? itemOrder : []
+  for (var i = 0; i < order.length; i++) {
+    var entry = item(items, order[i])
+    if (!entry || !entry.action) continue
+    var keys = shortcuts.byCommand[entry.action]
+    if (keys) byId[entry.id] = keys
+  }
+
+  for (var route in shortcuts.byRoute) {
+    var id = resolveRoute(items, itemOrder, route)
+    if (item(items, id) && !byId[id]) byId[id] = shortcuts.byRoute[route]
+  }
+
+  return byId
+}
+
 function slugify(value) {
   return String(value || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "item"
 }
@@ -362,11 +455,12 @@ function searchScore(items, entry, query) {
   return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
 }
 
-function displayRow(items, itemOrder, checkedResults, disabledResults, entry, detail, score, section) {
+function displayRow(items, itemOrder, checkedResults, disabledResults, shortcutsById, entry, detail, score, section) {
   var target = entry.kind === "link" ? entry.target : entry.id
   return {
     itemId: entry.id,
     disabled: isDisabled(disabledResults, entry),
+    shortcut: (shortcutsById && shortcutsById[entry.id]) || "",
     kind: entry.kind,
     icon: entry.icon,
     iconFont: entry.iconFont || "",
@@ -503,6 +597,9 @@ if (typeof module !== "undefined") {
     swapProviderRows: swapProviderRows,
     item: item,
     resolveRoute: resolveRoute,
+    parseKeybindings: parseKeybindings,
+    shortcutLabel: shortcutLabel,
+    resolveShortcuts: resolveShortcuts,
     slugify: slugify,
     depthFor: depthFor,
     pathFor: pathFor,

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -243,9 +243,11 @@ function parseKeybindings(raw) {
   var lines = String(raw || "").split("\n")
 
   for (var i = 0; i < lines.length; i++) {
-    var parts = lines[i].split("\t")
-    var keys = String(parts[0] || "").trim()
-    var command = String(parts[1] || "").trim()
+    var tab = lines[i].indexOf("\t")
+    if (tab < 0) continue
+    // Split on the first tab only: a command may well contain one of its own.
+    var keys = lines[i].substring(0, tab).trim()
+    var command = lines[i].substring(tab + 1).trim()
     if (!keys || !command || !keysArePressable(keys)) continue
 
     var label = shortcutLabel(keys)
@@ -263,12 +265,13 @@ function parseKeybindings(raw) {
 // row runs the desktop entry's Exec, the binding runs whatever `o.bind` was
 // handed. Both reduce to the same key.
 //
-// Omarchy's launchers are most of the distance between them, and their names
-// already say what they do. `omarchy-launch-X` wraps X, so alone it stands for
-// X — unless an `omarchy-default-X` can answer, which makes it a resolver and X
-// whatever that reader currently says, so Browser lands on the browser in use.
-// The `-or-focus` wrappers take a window pattern first and delegate the rest,
-// so they unwrap to what they delegate to. None of this knows an app by name.
+// Omarchy's launchers are the rest of the distance, and they say what they open
+// rather than being guessed at: `# omarchy:launches=` in the launcher itself,
+// collected into `targets` (see Menu.qml). A launcher that declares nothing
+// matches nothing, because a name is not evidence — `omarchy-launch-signal`
+// runs signal-desktop, and `omarchy-launch-browser` runs whichever browser is
+// currently the default. The `-or-focus` wrappers take a window pattern first
+// and delegate the rest, so they unwrap to what they delegate to.
 var SESSION_WRAPPERS = ["setsid", "uwsm-app", "systemd-cat"]
 var LAUNCHER_PREFIX = "omarchy-launch-"
 
@@ -294,24 +297,29 @@ function commandTokens(command) {
 // (`spotify --uri=%u`). A binding carrying arguments of its own has to match in
 // full, so `omarchy-launch-browser --private` never claims the browser that the
 // plain binding does.
-function launchKeys(command, readers) {
+function launchKeys(command, targets, depth) {
   var tokens = commandTokens(command)
+  var stripped = false
 
-  if (tokens[0] === "uwsm" && tokens[1] === "app") tokens = tokens.slice(2)
-  while (tokens.length && (tokens[0] === "--" || SESSION_WRAPPERS.indexOf(tokens[0]) >= 0)) tokens = tokens.slice(1)
+  if (tokens[0] === "uwsm" && tokens[1] === "app") { tokens = tokens.slice(2); stripped = true }
+  while (tokens.length && (tokens[0] === "--" || SESSION_WRAPPERS.indexOf(tokens[0]) >= 0)) {
+    tokens = tokens.slice(1)
+    stripped = true
+  }
+  // `setsid -f chromium` runs chromium, not -f.
+  while (stripped && tokens.length && tokens[0].charAt(0) === "-") tokens = tokens.slice(1)
   if (!tokens.length) return { command: "", program: "", bare: false }
 
-  if (tokens[0] === LAUNCHER_PREFIX + "or-focus" && tokens.length > 1) return launchKeys(tokens[tokens.length - 1], readers)
+  // Bounded: a launcher that resolves to another launcher cannot loop forever.
+  var next = (depth || 0) + 1
+  if (next > 4) return { command: "", program: "", bare: false }
+
+  if (tokens[0] === LAUNCHER_PREFIX + "or-focus" && tokens.length > 1) return launchKeys(tokens[tokens.length - 1], targets, next)
   if (tokens[0] === LAUNCHER_PREFIX + "or-focus-webapp") tokens = [LAUNCHER_PREFIX + "webapp"].concat(tokens.slice(2))
 
   var program = String(tokens[0] || "").replace(/^.*\//, "")
-  var wrapped = program.indexOf(LAUNCHER_PREFIX) === 0 ? program.slice(LAUNCHER_PREFIX.length) : ""
 
-  if (wrapped && tokens.length === 1) {
-    var resolved = (readers && readers["omarchy-default-" + wrapped]) || ""
-    tokens = commandTokens(resolved || wrapped)
-    program = String(tokens[0] || "").replace(/^.*\//, "")
-  }
+  if (tokens.length === 1 && targets && targets[program]) return launchKeys(targets[program], targets, next)
 
   // A desktop entry and a binding disagree over a trailing slash on the same
   // URL often enough that it cannot be what separates them.
@@ -337,14 +345,14 @@ function programOwner(program) {
 // through the same alias resolution `omarchy menu summon` uses, so a binding on
 // `theme` finds `style.theme`. An action match wins: it names one row, while a
 // route names whatever currently answers to that name.
-function resolveShortcuts(items, itemOrder, shortcuts, readers) {
+function resolveShortcuts(items, itemOrder, shortcuts, targets) {
   var byId = ({})
   if (!shortcuts) return byId
 
   var byLaunch = ({})
   var byProgram = ({})
   for (var command in shortcuts.byCommand) {
-    var launch = launchKeys(command, readers)
+    var launch = launchKeys(command, targets)
     if (launch.command && !byLaunch[launch.command]) byLaunch[launch.command] = shortcuts.byCommand[command]
     if (launch.bare && !byProgram[launch.program]) byProgram[launch.program] = shortcuts.byCommand[command]
   }
@@ -362,7 +370,7 @@ function resolveShortcuts(items, itemOrder, shortcuts, readers) {
     var entry = item(items, order[i])
     if (!entry || !entry.exec) continue
 
-    var launch = launches[entry.id] = launchKeys(entry.exec, readers)
+    var launch = launches[entry.id] = launchKeys(entry.exec, targets)
     if (!launch.program) continue
 
     var program = programs[launch.program] || (programs[launch.program] = { bare: 0, bareId: "", count: 0, id: "" })
@@ -650,11 +658,6 @@ function guardPrelude(guards) {
     // `|| :` so a reader that exits nonzero cannot take the batch down with
     // it under a login shell that turned on errexit.
     prelude += "__omarchy_read_" + i + "=$(" + GUARD_READERS[i] + " 2>/dev/null) || :\n"
-    // Report it too. The default browser and terminal are what the Browser and
-    // Terminal keybindings actually open, and the batch has already paid for
-    // the answer — reading it back costs an echo. Indexed rather than named so
-    // a value carrying colons cannot be mistaken for the guard lines.
-    prelude += "printf 'reader:" + i + ":%s\\n' \"$__omarchy_read_" + i + "\"\n"
   }
 
   return prelude

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -275,18 +275,42 @@ function parseKeybindings(raw) {
 var SESSION_WRAPPERS = ["setsid", "uwsm-app", "systemd-cat"]
 var LAUNCHER_PREFIX = "omarchy-launch-"
 
+// Words the way a shell splits them, because a pattern matching quoted runs on
+// their own gets `'o'\''h'` — what shell_quote writes for an apostrophe — wrong:
+// the fragments around the escape belong to one word, not three.
 function commandTokens(command) {
   if (Array.isArray(command)) return command.slice()
 
+  var text = String(command || "")
   var tokens = []
-  var pattern = /'([^']*)'|"([^"]*)"|(\S+)/g
-  var match
+  var word = ""
+  var open = false
+  var quote = ""
 
-  while ((match = pattern.exec(String(command || "")))) {
-    if (match[1] !== undefined) tokens.push(match[1])
-    else if (match[2] !== undefined) tokens.push(match[2])
-    else tokens.push(match[3])
+  for (var i = 0; i < text.length; i++) {
+    var character = text.charAt(i)
+
+    if (quote) {
+      if (character === quote) quote = ""
+      else if (character === "\\" && quote === "\"") { word += text.charAt(i + 1); i += 1 }
+      else word += character
+      continue
+    }
+
+    if (character === "'" || character === "\"") { quote = character; open = true; continue }
+    if (character === "\\") { word += text.charAt(i + 1); i += 1; open = true; continue }
+    if (character === " " || character === "\t") {
+      if (word || open) tokens.push(word)
+      word = ""
+      open = false
+      continue
+    }
+
+    word += character
+    open = true
   }
+
+  if (word || open) tokens.push(word)
 
   return tokens
 }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -259,20 +259,126 @@ function parseKeybindings(raw) {
   return { byCommand: byCommand, byRoute: byRoute }
 }
 
+// An app row and a binding reach the same application by different routes: the
+// row runs the desktop entry's Exec, the binding runs whatever `o.bind` was
+// handed. Both reduce to the same key.
+//
+// Omarchy's launchers are most of the distance between them, and their names
+// already say what they do. `omarchy-launch-X` wraps X, so alone it stands for
+// X — unless an `omarchy-default-X` can answer, which makes it a resolver and X
+// whatever that reader currently says, so Browser lands on the browser in use.
+// The `-or-focus` wrappers take a window pattern first and delegate the rest,
+// so they unwrap to what they delegate to. None of this knows an app by name.
+var SESSION_WRAPPERS = ["setsid", "uwsm-app", "systemd-cat"]
+var LAUNCHER_PREFIX = "omarchy-launch-"
+
+function commandTokens(command) {
+  if (Array.isArray(command)) return command.slice()
+
+  var tokens = []
+  var pattern = /'([^']*)'|"([^"]*)"|(\S+)/g
+  var match
+
+  while ((match = pattern.exec(String(command || "")))) {
+    if (match[1] !== undefined) tokens.push(match[1])
+    else if (match[2] !== undefined) tokens.push(match[2])
+    else tokens.push(match[3])
+  }
+
+  return tokens
+}
+
+// Two keys come back: the whole command, and the program on its own. Only a
+// binding that runs a bare program is allowed to match on the program — it then
+// claims the app that is that program whatever arguments the desktop entry adds
+// (`spotify --uri=%u`). A binding carrying arguments of its own has to match in
+// full, so `omarchy-launch-browser --private` never claims the browser that the
+// plain binding does.
+function launchKeys(command, readers) {
+  var tokens = commandTokens(command)
+
+  if (tokens[0] === "uwsm" && tokens[1] === "app") tokens = tokens.slice(2)
+  while (tokens.length && (tokens[0] === "--" || SESSION_WRAPPERS.indexOf(tokens[0]) >= 0)) tokens = tokens.slice(1)
+  if (!tokens.length) return { command: "", program: "", bare: false }
+
+  if (tokens[0] === LAUNCHER_PREFIX + "or-focus" && tokens.length > 1) return launchKeys(tokens[tokens.length - 1], readers)
+  if (tokens[0] === LAUNCHER_PREFIX + "or-focus-webapp") tokens = [LAUNCHER_PREFIX + "webapp"].concat(tokens.slice(2))
+
+  var program = String(tokens[0] || "").replace(/^.*\//, "")
+  var wrapped = program.indexOf(LAUNCHER_PREFIX) === 0 ? program.slice(LAUNCHER_PREFIX.length) : ""
+
+  if (wrapped && tokens.length === 1) {
+    var resolved = (readers && readers["omarchy-default-" + wrapped]) || ""
+    tokens = commandTokens(resolved || wrapped)
+    program = String(tokens[0] || "").replace(/^.*\//, "")
+  }
+
+  // A desktop entry and a binding disagree over a trailing slash on the same
+  // URL often enough that it cannot be what separates them.
+  tokens[0] = program
+  var whole = tokens.map(function(token) { return String(token).replace(/\/+$/, "") }).join(" ")
+
+  return { command: whole, program: program, bare: tokens.length === 1 }
+}
+
+// Several apps can run one program: every Chrome web app runs the browser with
+// arguments after it. Only one of them is that program, and it is the one that
+// runs it plainly — so a bare entry owns the name, an argument-carrying entry
+// owns it only when it is the sole claimant, and a name several entries claim
+// alike belongs to none of them. Spotify keeps its key off `spotify --uri=%u`;
+// `chromium --app=...` does not inherit the browser's.
+function programOwner(program) {
+  if (!program) return ""
+  if (program.bare === 1) return program.bareId
+  return program.bare === 0 && program.count === 1 ? program.id : ""
+}
+
 // id → shortcut label, resolved once per (re)load instead of per row. Routes go
 // through the same alias resolution `omarchy menu summon` uses, so a binding on
 // `theme` finds `style.theme`. An action match wins: it names one row, while a
 // route names whatever currently answers to that name.
-function resolveShortcuts(items, itemOrder, shortcuts) {
+function resolveShortcuts(items, itemOrder, shortcuts, readers) {
   var byId = ({})
   if (!shortcuts) return byId
 
+  var byLaunch = ({})
+  var byProgram = ({})
+  for (var command in shortcuts.byCommand) {
+    var launch = launchKeys(command, readers)
+    if (launch.command && !byLaunch[launch.command]) byLaunch[launch.command] = shortcuts.byCommand[command]
+    if (launch.bare && !byProgram[launch.program]) byProgram[launch.program] = shortcuts.byCommand[command]
+  }
+
+  // Several apps can run one program: every Chrome web app runs the browser
+  // with arguments. Only one of them is that program, and it is the one running
+  // it plainly, so a bare entry owns the name outright and an argument-carrying
+  // entry owns it only when nothing else claims it — which is how Spotify keeps
+  // its key while `chromium --app=...` does not inherit the browser's.
   var order = Array.isArray(itemOrder) ? itemOrder : []
+  var launches = ({})
+  var programs = ({})
+
   for (var i = 0; i < order.length; i++) {
     var entry = item(items, order[i])
-    if (!entry || !entry.action) continue
-    var keys = shortcuts.byCommand[entry.action]
-    if (keys) byId[entry.id] = keys
+    if (!entry || !entry.exec) continue
+
+    var launch = launches[entry.id] = launchKeys(entry.exec, readers)
+    if (!launch.program) continue
+
+    var program = programs[launch.program] || (programs[launch.program] = { bare: 0, bareId: "", count: 0, id: "" })
+    program.count += 1
+    program.id = entry.id
+    if (launch.bare) { program.bare += 1; program.bareId = entry.id }
+  }
+
+  for (var j = 0; j < order.length; j++) {
+    var row = item(items, order[j])
+    if (!row) continue
+
+    var keys = row.action ? shortcuts.byCommand[row.action] : ""
+    var rowLaunch = launches[row.id]
+    if (!keys && rowLaunch) keys = byLaunch[rowLaunch.command] || (programOwner(programs[rowLaunch.program]) === row.id ? byProgram[rowLaunch.program] : "") || ""
+    if (keys) byId[row.id] = keys
   }
 
   for (var route in shortcuts.byRoute) {
@@ -544,6 +650,11 @@ function guardPrelude(guards) {
     // `|| :` so a reader that exits nonzero cannot take the batch down with
     // it under a login shell that turned on errexit.
     prelude += "__omarchy_read_" + i + "=$(" + GUARD_READERS[i] + " 2>/dev/null) || :\n"
+    // Report it too. The default browser and terminal are what the Browser and
+    // Terminal keybindings actually open, and the batch has already paid for
+    // the answer — reading it back costs an echo. Indexed rather than named so
+    // a value carrying colons cannot be mistaken for the guard lines.
+    prelude += "printf 'reader:" + i + ":%s\\n' \"$__omarchy_read_" + i + "\"\n"
   }
 
   return prelude
@@ -599,6 +710,7 @@ if (typeof module !== "undefined") {
     resolveRoute: resolveRoute,
     parseKeybindings: parseKeybindings,
     shortcutLabel: shortcutLabel,
+    launchKeys: launchKeys,
     resolveShortcuts: resolveShortcuts,
     slugify: slugify,
     depthFor: depthFor,

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -227,3 +227,56 @@ copy_line=$(awk '/^copy_always_config_defaults$/ { print NR; exit }' "$upgrade_s
 [[ -n $mark_line && -n $copy_line ]] || fail "upgrade-to-quattro preinstall marker and config refresh calls exist"
 (( mark_line < copy_line )) || fail "upgrade-to-quattro detects plain legacy bindings before overwriting Hyprland bindings"
 pass "upgrade-to-quattro preserves preinstall removal before refreshing Hyprland bindings"
+
+# o.bind is the only place a key and the command it runs are both in hand, so
+# what it records is all the menu can label. Register the way Hyprland does,
+# fire the lifecycle callback, and read back the snapshot it wrote.
+snapshot_home="$tmpdir/snapshot-home"
+mkdir -p "$snapshot_home"
+
+snapshot=$(HOME="$snapshot_home" OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local handlers = {}
+
+hl = {
+  dsp = { exec_cmd = function(command) return { kind = "exec", arg = command } end },
+  bind = function() end,
+  on = function(event, handler) handlers[event] = handler end,
+}
+
+require("default.hypr.helpers")
+
+o.bind("SUPER + RETURN", "Terminal", { omarchy = "terminal" })
+o.bind("SUPER + SHIFT + A", "ChatGPT", { webapp = "https://chatgpt.com" })
+o.bind("SUPER + CTRL + N", "Nightlight", function() end)
+
+assert(handlers["config.reloaded"], "o.bind registered no config.reloaded writer")
+assert(handlers["hyprland.start"], "o.bind registered no hyprland.start writer")
+handlers["config.reloaded"]()
+
+local file = assert(io.open(os.getenv("HOME") .. "/.local/state/omarchy/keybindings.tsv", "r"))
+io.write(file:read("*a"))
+file:close()
+LUA
+)
+
+grep -qF "$(printf 'SUPER + RETURN\tomarchy-launch-terminal')" <<<"$snapshot" ||
+  fail "o.bind records the command an omarchy launcher spec expands to" "got: $snapshot"
+pass "o.bind records the command an omarchy launcher spec expands to"
+
+grep -qF "$(printf "SUPER + SHIFT + A\tomarchy-launch-webapp 'https://chatgpt.com'")" <<<"$snapshot" ||
+  fail "o.bind records a web app binding with the command that runs it" "got: $snapshot"
+pass "o.bind records a web app binding with the command that runs it"
+
+grep -q "SUPER + CTRL + N" <<<"$snapshot" &&
+  fail "o.bind records nothing for a dispatcher it cannot name" "got: $snapshot"
+pass "o.bind records nothing for a binding whose dispatcher is a function"
+
+# The snapshot lands whole or not at all, so a shell reading the file never
+# sees half of one, and the state directory is created rather than assumed.
+[[ -f $snapshot_home/.local/state/omarchy/keybindings.tsv ]] ||
+  fail "o.bind creates the state directory it writes into" "no keybindings.tsv"
+[[ ! -e $snapshot_home/.local/state/omarchy/keybindings.tsv.new ]] ||
+  fail "o.bind renames its snapshot into place" "left keybindings.tsv.new behind"
+pass "o.bind creates the state directory and renames its snapshot into place"

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -28,6 +28,7 @@ hl = {
       print(keys .. "\t" .. opts.description)
     end
   end,
+  on = function() end,
 }
 
 require("default.hypr.helpers")

--- a/test/shell.d/menu-guards-test.sh
+++ b/test/shell.d/menu-guards-test.sh
@@ -180,9 +180,20 @@ reader_result=$(bash -c '
 omarchy-dns() { printf "Cloudflare\n"; }
 export -f omarchy-dns
 '"$reader_script")
-[[ $reader_result == $'hit:c:1\nmiss:c:0' ]] ||
+[[ $reader_result == $'reader:5:Cloudflare\nhit:c:1\nmiss:c:0' ]] ||
   fail "guard prelude compares a captured reader as the substitution did" "got: $reader_result"
 pass "guard prelude compares a captured reader exactly as the substitution it replaced"
+
+# The batch also reports what each reader printed, so the menu can label the
+# Browser and Terminal keybindings with the app they currently open. A reader
+# value is free text and may carry the colons the guard lines are split on.
+colon_result=$(bash -c '
+omarchy-dns() { printf "10.0.0.1:53\n"; }
+export -f omarchy-dns
+'"$reader_script")
+[[ $colon_result == $'reader:5:10.0.0.1:53\nhit:c:0\nmiss:c:0' ]] ||
+  fail "guard prelude reports a reader value containing colons intact" "got: $colon_result"
+pass "guard prelude reports what each reader printed, colons and all"
 
 # The batch inherits whatever a login shell left set. A reader that exits
 # nonzero must not take the rest of the menu's rows down with it.
@@ -191,6 +202,6 @@ omarchy-dns() { printf "Cloudflare\n"; return 3; }
 export -f omarchy-dns
 '"$reader_script"'
 printf "survived\n"' 2>/dev/null)
-[[ $errexit_result == $'hit:c:1\nmiss:c:0\nsurvived' ]] ||
+[[ $errexit_result == $'reader:5:Cloudflare\nhit:c:1\nmiss:c:0\nsurvived' ]] ||
   fail "guard batch survives a failing reader under errexit" "got: $errexit_result"
 pass "guard batch survives a reader that exits nonzero under errexit"

--- a/test/shell.d/menu-guards-test.sh
+++ b/test/shell.d/menu-guards-test.sh
@@ -180,20 +180,9 @@ reader_result=$(bash -c '
 omarchy-dns() { printf "Cloudflare\n"; }
 export -f omarchy-dns
 '"$reader_script")
-[[ $reader_result == $'reader:5:Cloudflare\nhit:c:1\nmiss:c:0' ]] ||
+[[ $reader_result == $'hit:c:1\nmiss:c:0' ]] ||
   fail "guard prelude compares a captured reader as the substitution did" "got: $reader_result"
 pass "guard prelude compares a captured reader exactly as the substitution it replaced"
-
-# The batch also reports what each reader printed, so the menu can label the
-# Browser and Terminal keybindings with the app they currently open. A reader
-# value is free text and may carry the colons the guard lines are split on.
-colon_result=$(bash -c '
-omarchy-dns() { printf "10.0.0.1:53\n"; }
-export -f omarchy-dns
-'"$reader_script")
-[[ $colon_result == $'reader:5:10.0.0.1:53\nhit:c:0\nmiss:c:0' ]] ||
-  fail "guard prelude reports a reader value containing colons intact" "got: $colon_result"
-pass "guard prelude reports what each reader printed, colons and all"
 
 # The batch inherits whatever a login shell left set. A reader that exits
 # nonzero must not take the rest of the menu's rows down with it.
@@ -202,6 +191,6 @@ omarchy-dns() { printf "Cloudflare\n"; return 3; }
 export -f omarchy-dns
 '"$reader_script"'
 printf "survived\n"' 2>/dev/null)
-[[ $errexit_result == $'reader:5:Cloudflare\nhit:c:1\nmiss:c:0\nsurvived' ]] ||
+[[ $errexit_result == $'hit:c:1\nmiss:c:0\nsurvived' ]] ||
   fail "guard batch survives a failing reader under errexit" "got: $errexit_result"
 pass "guard batch survives a reader that exits nonzero under errexit"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -148,15 +148,29 @@ assert(
 )
 
 // An app row launches through its desktop entry, a binding through whatever
-// o.bind was handed; both reduce to the same key. The readers are what the
-// guard batch reported, so a wrapper that resolves a default lands on the app
-// that default currently names.
-const readers = { 'omarchy-default-browser': 'chromium', 'omarchy-default-terminal': 'foot' }
-const launchKey = command => menu.launchKeys(command, readers).command
+// o.bind was handed; both reduce to the same key. What a launcher opens is
+// declared by the launcher (`# omarchy:launches=`) and collected into targets,
+// never inferred from its name.
+const targets = {
+  'omarchy-launch-browser': 'chromium',
+  'omarchy-launch-signal': 'signal-desktop',
+  'omarchy-launch-spotify': 'spotify'
+}
+const launchKey = command => menu.launchKeys(command, targets).command
 
-assertEqual(launchKey('omarchy-launch-browser'), 'chromium', 'menu resolves a launcher that wraps a default')
-assertEqual(launchKey('omarchy-launch-spotify'), 'spotify', 'menu reads a launcher with no default as the app it wraps')
+assertEqual(launchKey('omarchy-launch-browser'), 'chromium', 'menu resolves a launcher to the app it declares')
+assertEqual(
+  launchKey('omarchy-launch-signal'),
+  'signal-desktop',
+  'menu takes the declared app over the launcher name, which does not match it'
+)
+assertEqual(
+  launchKey('omarchy-launch-obscure'),
+  'omarchy-launch-obscure',
+  'menu never guesses an app out of an undeclared launcher name'
+)
 assertEqual(launchKey('uwsm-app -- omawrite'), 'omawrite', 'menu looks past the session wrapper')
+assertEqual(launchKey('setsid -f chromium'), 'chromium', 'menu looks past the wrapper flags too')
 assertEqual(launchKey('/usr/bin/chromium'), 'chromium', 'menu compares programs by name, not by path')
 assertEqual(
   launchKey("omarchy-launch-or-focus '^obsidian$' 'uwsm-app -- obsidian'"),
@@ -173,24 +187,40 @@ assertEqual(
   launchKey(['omarchy-launch-webapp', 'https://chatgpt.com/']),
   'menu does not let a trailing slash separate a binding from its desktop entry'
 )
-assert(!menu.launchKeys('omarchy-launch-browser --private', readers).bare, 'menu keeps a binding carrying its own arguments off the program match')
+assert(!menu.launchKeys('omarchy-launch-browser --private', targets).bare, 'menu keeps a binding carrying its own arguments off the program match')
+assertEqual(
+  menu.launchKeys('omarchy-launch-loop', { 'omarchy-launch-loop': 'omarchy-launch-loop' }).command,
+  '',
+  'menu gives up on a launcher declaring itself rather than recursing forever'
+)
+
+// A command may contain a tab; only the first one separates it from the keys.
+const tabbed = menu.parseKeybindings("SUPER + T\tomarchy-launch-webapp 'https://x.test/a\tb'")
+assertEqual(
+  tabbed.byCommand["omarchy-launch-webapp 'https://x.test/a\tb'"],
+  '⌘ T',
+  'menu keeps a command that contains a tab intact'
+)
 
 const appBindings = menu.parseKeybindings([
   'SUPER + SHIFT + B\tomarchy-launch-browser',
   'SUPER + SHIFT + ALT + B\tomarchy-launch-browser --private',
   'SUPER + SHIFT + A\tomarchy-launch-webapp \'https://chatgpt.com\'',
-  'SUPER + SHIFT + M\tomarchy-launch-spotify'
+  'SUPER + SHIFT + M\tomarchy-launch-spotify',
+  'SUPER + SHIFT + G\tomarchy-launch-signal'
 ].join('\n'))
 const appItems = {
   'apps.chromium': { id: 'apps.chromium', parent: 'apps', kind: 'app', label: 'Chromium', action: '', exec: ['/usr/bin/chromium'] },
   'apps.ChatGPT': { id: 'apps.ChatGPT', parent: 'apps', kind: 'app', label: 'ChatGPT', action: '', exec: ['omarchy-launch-webapp', 'https://chatgpt.com/'] },
   'apps.spotify': { id: 'apps.spotify', parent: 'apps', kind: 'app', label: 'Spotify', action: '', exec: ['spotify', '--uri='] },
+  'apps.signal-desktop': { id: 'apps.signal-desktop', parent: 'apps', kind: 'app', label: 'Signal', action: '', exec: ['/usr/bin/signal-desktop'] },
   'apps.firefox': { id: 'apps.firefox', parent: 'apps', kind: 'app', label: 'Firefox', action: '', exec: ['/usr/bin/firefox'] }
 }
-const appShortcuts = menu.resolveShortcuts(appItems, Object.keys(appItems), appBindings, readers)
+const appShortcuts = menu.resolveShortcuts(appItems, Object.keys(appItems), appBindings, targets)
 assertEqual(appShortcuts['apps.chromium'], '⌘⇧ B', 'menu labels the app the default browser currently resolves to')
 assertEqual(appShortcuts['apps.ChatGPT'], '⌘⇧ A', 'menu labels a web app by the launcher its desktop entry runs')
 assertEqual(appShortcuts['apps.spotify'], '⌘⇧ M', 'menu labels an app whose desktop entry adds arguments of its own')
+assertEqual(appShortcuts['apps.signal-desktop'], '⌘⇧ G', 'menu labels an app whose launcher name differs from its executable')
 assert(!appShortcuts['apps.firefox'], 'menu leaves an app alone when no binding reaches it')
 
 // Every Chrome web app runs the browser with arguments after it, and none of
@@ -198,7 +228,7 @@ assert(!appShortcuts['apps.firefox'], 'menu leaves an app alone when no binding 
 const pwaItems = {}
 for (const id in appItems) pwaItems[id] = appItems[id]
 pwaItems['apps.chrome-hey'] = { id: 'apps.chrome-hey', parent: 'apps', kind: 'app', label: 'HEY', action: '', exec: ['/usr/bin/chromium', '--app-id=ipcjik'] }
-const pwaShortcuts = menu.resolveShortcuts(pwaItems, Object.keys(pwaItems), appBindings, readers)
+const pwaShortcuts = menu.resolveShortcuts(pwaItems, Object.keys(pwaItems), appBindings, targets)
 assertEqual(pwaShortcuts['apps.chromium'], '⌘⇧ B', 'menu keeps the browser key on the entry that runs the browser plainly')
 assert(!pwaShortcuts['apps.chrome-hey'], 'menu does not hand the browser key to a web app that runs the browser with arguments')
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -170,6 +170,12 @@ assertEqual(
   'menu never guesses an app out of an undeclared launcher name'
 )
 assertEqual(launchKey('uwsm-app -- omawrite'), 'omawrite', 'menu looks past the session wrapper')
+// o.shell_quote writes an apostrophe as '\'' -- three fragments that are one word.
+assertEqual(
+  launchKey("omarchy-launch-webapp 'https://x.test/o'\\''h'"),
+  launchKey(['omarchy-launch-webapp', "https://x.test/o'h"]),
+  'menu splits a command into words the way a shell does, escapes included'
+)
 assertEqual(launchKey('setsid -f chromium'), 'chromium', 'menu looks past the wrapper flags too')
 assertEqual(launchKey('/usr/bin/chromium'), 'chromium', 'menu compares programs by name, not by path')
 assertEqual(

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -147,6 +147,61 @@ assert(
   'menu drops a binding on a raw keycode, which names nothing a reader could press'
 )
 
+// An app row launches through its desktop entry, a binding through whatever
+// o.bind was handed; both reduce to the same key. The readers are what the
+// guard batch reported, so a wrapper that resolves a default lands on the app
+// that default currently names.
+const readers = { 'omarchy-default-browser': 'chromium', 'omarchy-default-terminal': 'foot' }
+const launchKey = command => menu.launchKeys(command, readers).command
+
+assertEqual(launchKey('omarchy-launch-browser'), 'chromium', 'menu resolves a launcher that wraps a default')
+assertEqual(launchKey('omarchy-launch-spotify'), 'spotify', 'menu reads a launcher with no default as the app it wraps')
+assertEqual(launchKey('uwsm-app -- omawrite'), 'omawrite', 'menu looks past the session wrapper')
+assertEqual(launchKey('/usr/bin/chromium'), 'chromium', 'menu compares programs by name, not by path')
+assertEqual(
+  launchKey("omarchy-launch-or-focus '^obsidian$' 'uwsm-app -- obsidian'"),
+  'obsidian',
+  'menu unwraps a launcher that delegates past its window pattern'
+)
+assertEqual(
+  launchKey("omarchy-launch-or-focus-webapp 'Google Maps' 'https://maps.google.com/'"),
+  launchKey('omarchy-launch-webapp https://maps.google.com'),
+  'menu reads the focusing webapp launcher as the webapp launcher it delegates to'
+)
+assertEqual(
+  launchKey("omarchy-launch-webapp 'https://chatgpt.com'"),
+  launchKey(['omarchy-launch-webapp', 'https://chatgpt.com/']),
+  'menu does not let a trailing slash separate a binding from its desktop entry'
+)
+assert(!menu.launchKeys('omarchy-launch-browser --private', readers).bare, 'menu keeps a binding carrying its own arguments off the program match')
+
+const appBindings = menu.parseKeybindings([
+  'SUPER + SHIFT + B\tomarchy-launch-browser',
+  'SUPER + SHIFT + ALT + B\tomarchy-launch-browser --private',
+  'SUPER + SHIFT + A\tomarchy-launch-webapp \'https://chatgpt.com\'',
+  'SUPER + SHIFT + M\tomarchy-launch-spotify'
+].join('\n'))
+const appItems = {
+  'apps.chromium': { id: 'apps.chromium', parent: 'apps', kind: 'app', label: 'Chromium', action: '', exec: ['/usr/bin/chromium'] },
+  'apps.ChatGPT': { id: 'apps.ChatGPT', parent: 'apps', kind: 'app', label: 'ChatGPT', action: '', exec: ['omarchy-launch-webapp', 'https://chatgpt.com/'] },
+  'apps.spotify': { id: 'apps.spotify', parent: 'apps', kind: 'app', label: 'Spotify', action: '', exec: ['spotify', '--uri='] },
+  'apps.firefox': { id: 'apps.firefox', parent: 'apps', kind: 'app', label: 'Firefox', action: '', exec: ['/usr/bin/firefox'] }
+}
+const appShortcuts = menu.resolveShortcuts(appItems, Object.keys(appItems), appBindings, readers)
+assertEqual(appShortcuts['apps.chromium'], '⌘⇧ B', 'menu labels the app the default browser currently resolves to')
+assertEqual(appShortcuts['apps.ChatGPT'], '⌘⇧ A', 'menu labels a web app by the launcher its desktop entry runs')
+assertEqual(appShortcuts['apps.spotify'], '⌘⇧ M', 'menu labels an app whose desktop entry adds arguments of its own')
+assert(!appShortcuts['apps.firefox'], 'menu leaves an app alone when no binding reaches it')
+
+// Every Chrome web app runs the browser with arguments after it, and none of
+// them is the browser.
+const pwaItems = {}
+for (const id in appItems) pwaItems[id] = appItems[id]
+pwaItems['apps.chrome-hey'] = { id: 'apps.chrome-hey', parent: 'apps', kind: 'app', label: 'HEY', action: '', exec: ['/usr/bin/chromium', '--app-id=ipcjik'] }
+const pwaShortcuts = menu.resolveShortcuts(pwaItems, Object.keys(pwaItems), appBindings, readers)
+assertEqual(pwaShortcuts['apps.chromium'], '⌘⇧ B', 'menu keeps the browser key on the entry that runs the browser plainly')
+assert(!pwaShortcuts['apps.chrome-hey'], 'menu does not hand the browser key to a web app that runs the browser with arguments')
+
 const shortcutBase = menu.mergeMenuSources(menu.parseMenuJsonc(defaultMenuJsonc), [])
 const shortcuts = menu.resolveShortcuts(shortcutBase.items, shortcutBase.itemOrder, keybindings)
 assertEqual(shortcuts['style.theme'], '⌘⇧⌃ SPACE', 'menu resolves a route through the alias it was bound to')

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -89,7 +89,7 @@ assert(menu.isDisabled({ 'install.browser.zen': true }, installed), 'menu disabl
 assert(!menu.isDisabled({ 'install.browser.zen': false }, installed), 'menu leaves a row selectable when its disabled: failed')
 assert(!menu.isDisabled({ 'install.browser.zen': true }, visibilityItems.laptop), 'menu never disables a row that declares no disabled:')
 assert(
-  menu.displayRow({ 'install.browser.zen': installed }, ['install.browser.zen'], {}, { 'install.browser.zen': true }, installed, '', 0).disabled,
+  menu.displayRow({ 'install.browser.zen': installed }, ['install.browser.zen'], {}, { 'install.browser.zen': true }, {}, installed, '', 0).disabled,
   'menu display rows carry their disabled state'
 )
 assert(
@@ -105,10 +105,11 @@ assert(!menu.matchesQuery(entry, 'theme', false), 'menu hides invisible matches'
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
 
 assertDeepEqual(
-  menu.displayRow(merged.items, merged.itemOrder, {}, {}, entry, 'Style', 12, 'search'),
+  menu.displayRow(merged.items, merged.itemOrder, {}, {}, { 'style.theme': '⌘⇧⌃ SPACE' }, entry, 'Style', 12, 'search'),
   {
     itemId: 'style.theme',
     disabled: false,
+    shortcut: '⌘⇧⌃ SPACE',
     kind: 'action',
     icon: '',
     iconFont: '',
@@ -126,6 +127,32 @@ assertDeepEqual(
   },
   'menu builds display rows'
 )
+
+// Shortcuts come from the file `o.bind` writes as Hyprland loads its config,
+// because Hyprland reports Lua binds as dispatcher __lua and drops the command.
+const keybindings = menu.parseKeybindings([
+  'SUPER + SHIFT + CTRL + SPACE\tomarchy-menu toggle theme',
+  'SUPER + ESCAPE\tomarchy-menu toggle system',
+  'SUPER + CTRL + L\tomarchy-system-lock',
+  'SUPER + ALT + code:34\tomarchy-capture-webcam-resize smaller',
+  'SUPER + CTRL + ALT + T\tomarchy-notification-time',
+  'SUPER + SHIFT + ALT + T\tomarchy-notification-time'
+].join('\n'))
+
+assertEqual(keybindings.byRoute['theme'], '⌘⇧⌃ SPACE', 'menu reads the route a binding opens')
+assertEqual(keybindings.byCommand['omarchy-system-lock'], '⌘⌃ L', 'menu reads the command a binding runs')
+assertEqual(keybindings.byCommand['omarchy-notification-time'], '⌘⌃⌥ T', 'menu keeps the first of two keys for one command')
+assert(
+  !keybindings.byCommand['omarchy-capture-webcam-resize smaller'],
+  'menu drops a binding on a raw keycode, which names nothing a reader could press'
+)
+
+const shortcutBase = menu.mergeMenuSources(menu.parseMenuJsonc(defaultMenuJsonc), [])
+const shortcuts = menu.resolveShortcuts(shortcutBase.items, shortcutBase.itemOrder, keybindings)
+assertEqual(shortcuts['style.theme'], '⌘⇧⌃ SPACE', 'menu resolves a route through the alias it was bound to')
+assertEqual(shortcuts['system'], '⌘ ESCAPE', 'menu resolves a route naming an id outright')
+assertEqual(shortcuts['system.lock'], '⌘⌃ L', 'menu labels a row whose own action is bound')
+assertDeepEqual(menu.resolveShortcuts(shortcutBase.items, shortcutBase.itemOrder, null), {}, 'menu carries no shortcuts before the bindings file is read')
 
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))


### PR DESCRIPTION
Opening Style > Theme from the menu works, but the menu never mentions that
`⌘⇧⌃ SPACE` would have got you there without it. The keys exist, and they are
listed under Learn > Keybindings, but that is a separate list you have to go and
read. The menu — the place you are standing when you want the thing — says
nothing, so the fast path stays undiscovered for as long as the slow one keeps
working.

![Menu rows labelled with their keybinding](https://raw.githubusercontent.com/jorgemanrubia/omarchy/pr-assets/menu-shortcuts/menu-shortcuts.png)

Every row a keybinding also reaches now shows that key beside its label, in the
menu and in the Apps list. Nothing declares the pairing: no menu entry names a
key, no binding names a row. Bind something to `omarchy-menu toggle share` and
Trigger > Share labels itself; unbind it and the label goes away.

## Where the pairing comes from

`hyprctl binds` cannot tell you this — it reports Lua binds as dispatcher
`__lua` and keeps the command to itself, which is why `omarchy-menu-keybindings`
re-executes the whole config under a stub `hl` to recover it.

`o.bind` is the one place that already holds both halves. It records each
`<keys>` / `<command>` pair as the config loads and writes them to
`~/.local/state/omarchy/keybindings.tsv`, renamed into place so a reader never
sees half a snapshot. The shell watches that file the way it already watches the
menu JSONC, so reloading Hyprland relabels the rows without restarting the
shell, and a machine without the file loses the shortcuts and nothing else.

A binding then claims a row three ways: it runs the row's `action`, it opens the
row's route (through the same alias resolution `omarchy menu summon` uses), or
it launches the same application an app row does. The id → shortcut map is built
once per load, so an open is a lookup per row.

## Matching an app row

An app row launches through its desktop entry, a binding through whatever
`o.bind` was handed. Both reduce to the same key: session wrappers come off,
programs compare by name rather than path, and a trailing slash on a URL is
ignored — enough on its own for a web app, where the two sides already run the
same `omarchy-launch-webapp <url>`.

Omarchy's launchers are the rest of the distance, and a launcher's name is not
evidence of what it opens: `omarchy-launch-signal` runs `signal-desktop`, and
`omarchy-launch-browser` runs whichever browser is the default. So they say so,
beside the metadata they already carry:

```bash
# omarchy:launches=signal-desktop      # a fixed app
# omarchy:launches=default:browser     # ask omarchy-default-browser --command
```

`default:X` defers to `omarchy-default-X --command`, because the selection name
does not give you the executable either — the browser picked as `chrome` runs
`google-chrome-stable`, the editor picked as `zed` runs `zeditor`. Those scripts
already held that table for setting the default; they now answer both questions
from the one table, so the two cannot drift. Switch your default browser and the
key moves to the row that opens it. A launcher that declares nothing matches
nothing.

<img src="https://raw.githubusercontent.com/jorgemanrubia/omarchy/pr-assets/menu-shortcuts/apps.png" alt="The Apps list, with keys on the apps that have one" width="302">

Two rules keep it honest. A binding that runs a bare program claims the app that
*is* that program whatever arguments its desktop entry adds, so Spotify keeps
its key off `spotify --uri=%u`; a binding carrying arguments of its own must
match in full, so `omarchy-launch-browser --private` never claims the browser
the plain binding does. And where several apps run one program — every Chrome
web app runs the browser with arguments after it — the entry that runs it
plainly owns the name.

## Performance

The open path is a lookup per row, and measures that way. Time from
`omarchy-menu summon` to the menu's surface being up, six trials each:

| | summon → visible |
|---|---|
| before | 26 – 35 ms |
| after | 26 – 36 ms |

Under that, 400 runs of `rebuildDisplay` with the Apps list loaded (387 items):
0.47 – 0.49 ms before and 0.48 – 0.60 ms after on the root menu, 13.4 – 13.7 ms
before and 13.5 – 13.9 ms after on a search. No regression either way; the
spread is run-to-run variance.

The new work is off that path. Parsing the bindings file costs 0.30 ms and
building the map 1.30 ms, once when the file loads or the menu rebuilds —
entering the Apps list the first time is where that lands, since the app rows
arrive then. Reading the launcher declarations is one background bash pass of
65 ms per config reload. On the Hyprland side, recording 132 bindings and
writing the snapshot costs 0.13 – 0.29 ms against a config load that measures
1.6 – 2.0 ms with the change and 1.5 – 1.8 ms without.

## Notes

Shortcuts appear after the next Hyprland config load, so an upgraded machine
picks them up on the next reload or login rather than immediately.

Modifiers render as symbols because spelled out they are wider than the label
beside them: `SUPER SHIFT CTRL SPACE` pushed "Theme" down to "Th…".
