### PR TITLE
fix: filter pre-release tags in omarchy-update-available

### DIFF
--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Get remote tag
 
-latest_tag=$(git -C "$OMARCHY_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | sort -V | tail -n 1)
+latest_tag=$(git -C "$OMARCHY_PATH" ls-remote --tags origin | grep -v "{}" | awk '{print $2}' | sed 's#refs/tags/##' | grep -vE -- '-[A-Za-z]' | sort -V | tail -n 1)
 if [[ -z $latest_tag ]]; then
   echo "Error: Could not retrieve latest tag."
   exit 1


### PR DESCRIPTION
## Summary
- Fixes #7166 — `omarchy-update-available` permanently reports an update is available on a fully up-to-date install because `sort -V` doesn't implement SemVer pre-release ordering, ranking `v4.0.0-beta3` above `v4.0.0`.
- Excludes tags with an alpha suffix (`-beta`, `-rc`, etc.) before taking the version-sorted max, so only real release tags are considered "latest".

## Test plan
- [x] Reproduced the false positive on a `v4.0.0` checkout (`omarchy-update-available` reported `v4.0.0-beta3` as available)
- [x] Applied the fix and confirmed it now reports "Omarchy is up to date (v4.0.0)" with exit code 1
- [x] Confirmed filtered remote tag list still correctly resolves to `v4.0.0` as the highest real release