### PR TITLE
Fix stranded session-lock recovery after plugin reload

### DIFF
--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -24,11 +24,12 @@ fi
 # that holds no lock — sits in that failsafe with no way to authenticate,
 # and a restart plus re-lock is the only way back in without a reboot. So
 # ask the lock service rather than merely pinging the shell: only a locker
-# that reports the lock secure or in progress is worth preserving.
+# that is drawing a surface (sessionLocked) is worth preserving. secure or
+# requested alone is also the wedged "lockscreen app died" state.
 relock=0
 if omarchy-hyprland-session-locked; then
   locking=$(OMARCHY_PATH="$session_omarchy_path" OMARCHY_SHELL_IPC_TIMEOUT=0.5s omarchy-shell lock status 2>/dev/null |
-    jq -r '.secure or .requested' 2>/dev/null)
+    jq -r '(.sessionLocked == true) and (.secure == true or .requested == true)' 2>/dev/null)
   if [[ $locking == "true" ]]; then
     echo "Refusing to restart Omarchy shell while the session is locked." >&2
     exit 1
@@ -47,7 +48,7 @@ relock_session() {
 
   while (( SECONDS < deadline )); do
     state=$(OMARCHY_PATH="$session_omarchy_path" OMARCHY_SHELL_IPC_TIMEOUT=0.5s omarchy-shell lock status 2>/dev/null |
-      jq -r 'if .secure == true then "secure" elif .requested == true then "locking" else "idle" end' 2>/dev/null)
+      jq -r 'if .sessionLocked == true and .secure == true then "secure" elif .sessionLocked == true and .requested == true then "locking" else "idle" end' 2>/dev/null)
 
     case $state in
       secure) return 0 ;;

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -440,7 +440,7 @@ Item {
 
       // A lock taken while this was in flight is this shell's own.
       // Do not use `locked` here: stale sessionLock.secure would hide an orphan.
-      root.strandedLock = exitCode === 0 && !root.sessionLock.locked && !root.lockRequested
+      root.strandedLock = exitCode === 0 && !sessionLock.locked && !root.lockRequested
       if (root.strandedLock) root.recoverStrandedLock()
     }
   }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,8 +33,14 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property bool strandedRestartAttempted: false
 
-  readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
+  // sessionLock.secure is also true for Hyprland's dead-client failsafe and
+  // for a stale Quickshell SessionLockManager after an in-process remount.
+  // A healthy lock is one this client is drawing.
+  readonly property bool lockOwned: sessionLock.locked
+  readonly property bool sessionSecured: sessionLock.secure
+  readonly property bool locked: lockRequested || lockOwned || sessionSecured
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
 
   function realScreenCount() {
@@ -57,17 +63,26 @@ Item {
     pendingSessionLock = true
     if (!sessionLockStabilizeTimer.running) logEvent("lock-pending: screen-stabilizing")
     sessionLockStabilizeTimer.restart()
+    pendingSessionLockTimer.attempts = 0
     if (!pendingSessionLockTimer.running) pendingSessionLockTimer.start()
   }
 
   function requestSessionLock() {
-    if (!lockRequested || sessionLock.locked || sessionLock.secure) return
+    if (!lockRequested || sessionLock.locked) return
     if (sessionLockStabilizeTimer.running) return
 
     if (!hasRealScreen()) {
       if (!pendingSessionLock || lastEvent !== "lock-pending: no-real-screen") logEvent("lock-pending: no-real-screen")
       pendingSessionLock = true
       if (!pendingSessionLockTimer.running) pendingSessionLockTimer.start()
+      return
+    }
+
+    // secure without a surface this client owns is an orphan, not a lock.
+    // Setting sessionLock.locked here qFatal's in Quickshell (no active lock).
+    if (sessionLock.secure && !sessionLock.locked) {
+      logEvent("lock-stranded: compositor-secured-without-surface")
+      recoverStrandedLock()
       return
     }
 
@@ -82,8 +97,9 @@ Item {
   function checkStrandedLock() {
     if (strandedLockResolved || strandedLockCheckProc.running) return
 
-    // A lock this shell took is nobody's orphan.
-    if (locked || lockRequested) {
+    // Only a surface this client owns (or a lock it has already requested)
+    // is ours. sessionLock.secure alone can be an orphan failsafe.
+    if (sessionLock.locked || lockRequested) {
       strandedLockResolved = true
       return
     }
@@ -92,11 +108,20 @@ Item {
   }
 
   function recoverStrandedLock() {
-    if (!strandedLock || locked || !passwordPamConfigured) return
+    if (!passwordPamConfigured) return
+    if (sessionLock.locked) return
+    if (strandedRestartAttempted || restartShellProc.running) return
 
+    // Same-process beginLock() cannot retake the lock: Quickshell's
+    // SessionLockManager::active stays set after the previous WlSessionLock
+    // is destroyed, so lock() fails and updateSurfaces() aborts. A new
+    // process plus omarchy-restart-shell's relock path is the recovery.
+    strandedRestartAttempted = true
     strandedLock = false
+    pendingSessionLockTimer.stop()
+    sessionLockStabilizeTimer.stop()
     logEvent("lock-stranded: recovering")
-    beginLock()
+    restartShellProc.running = true
   }
 
   function refreshBackground() {
@@ -396,8 +421,17 @@ Item {
       root.strandedLockResolved = true
 
       // A lock taken while this was in flight is this shell's own.
-      root.strandedLock = exitCode === 0 && !root.locked && !root.lockRequested
-      root.recoverStrandedLock()
+      // Do not use `locked` here: stale sessionLock.secure would hide an orphan.
+      root.strandedLock = exitCode === 0 && !root.sessionLock.locked && !root.lockRequested
+      if (root.strandedLock) root.recoverStrandedLock()
+    }
+  }
+
+  Process {
+    id: restartShellProc
+    command: ["omarchy-restart-shell"]
+    onExited: function(exitCode) {
+      root.logEvent("lock-stranded: restart-shell=" + exitCode)
     }
   }
 
@@ -442,7 +476,18 @@ Item {
     id: pendingSessionLockTimer
     interval: 100
     repeat: true
-    onTriggered: root.requestSessionLock()
+    property int attempts: 0
+    onTriggered: {
+      attempts += 1
+      if (attempts > 50) {
+        stop()
+        attempts = 0
+        root.logEvent("lock-pending: gave-up")
+        root.recoverStrandedLock()
+        return
+      }
+      root.requestSessionLock()
+    }
   }
 
   Timer {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -40,6 +40,7 @@ Item {
   // A healthy lock is one this client is drawing.
   readonly property bool lockOwned: sessionLock.locked
   readonly property bool sessionSecured: sessionLock.secure
+  readonly property bool lockSurfaceOrphaned: sessionSecured && !lockOwned
   readonly property bool locked: lockRequested || lockOwned || sessionSecured
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
 
@@ -80,9 +81,9 @@ Item {
 
     // secure without a surface this client owns is an orphan, not a lock.
     // Setting sessionLock.locked here qFatal's in Quickshell (no active lock).
-    if (sessionLock.secure && !sessionLock.locked) {
+    if (lockSurfaceOrphaned) {
       logEvent("lock-stranded: compositor-secured-without-surface")
-      recoverStrandedLock()
+      restartForOrphanedLock()
       return
     }
 
@@ -108,8 +109,25 @@ Item {
   }
 
   function recoverStrandedLock() {
-    if (!passwordPamConfigured) return
+    if (!strandedLock || !passwordPamConfigured) return
     if (sessionLock.locked) return
+
+    // A fresh process can take the compositor lock directly. Restarting
+    // here loops: every relaunch sees the same stranded compositor lock
+    // and kills itself again. Restart only the in-process orphan below.
+    if (lockSurfaceOrphaned) {
+      restartForOrphanedLock()
+      return
+    }
+
+    strandedLock = false
+    logEvent("lock-stranded: recovering")
+    beginLock()
+  }
+
+  function restartForOrphanedLock() {
+    if (!passwordPamConfigured) return
+    if (sessionLock.locked || !lockSurfaceOrphaned) return
     if (strandedRestartAttempted || restartShellProc.running) return
 
     // Same-process beginLock() cannot retake the lock: Quickshell's
@@ -120,7 +138,7 @@ Item {
     strandedLock = false
     pendingSessionLockTimer.stop()
     sessionLockStabilizeTimer.stop()
-    logEvent("lock-stranded: recovering")
+    logEvent("lock-stranded: restarting-for-orphan")
     restartShellProc.running = true
   }
 
@@ -483,7 +501,7 @@ Item {
         stop()
         attempts = 0
         root.logEvent("lock-pending: gave-up")
-        root.recoverStrandedLock()
+        if (root.lockSurfaceOrphaned) root.restartForOrphanedLock()
         return
       }
       root.requestSessionLock()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -349,7 +349,7 @@ ShellRoot {
     var lockInst = _services["omarchy.lock"]
     if (!lockInst) return false
     if (lockInst.lockRequested) return true
-    return !!(lockInst.sessionLock && lockInst.sessionLock.locked)
+    return lockInst.lockOwned === true
   }
 
   function unloadPluginServices() {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -345,12 +345,27 @@ ShellRoot {
     }
   }
 
+  function lockServiceOwned() {
+    var lockInst = _services["omarchy.lock"]
+    if (!lockInst) return false
+    if (lockInst.lockRequested) return true
+    return !!(lockInst.sessionLock && lockInst.sessionLock.locked)
+  }
+
   function unloadPluginServices() {
+    // Destroying omarchy.lock while it owns the session lock drops the
+    // lock surface and leaves Hyprland's ext-session-lock failsafe up.
+    // keepLoaded does not protect services; skip that instance instead.
+    var next = ({})
     for (var existingId in _services) {
       var inst = _services[existingId]
+      if (existingId === "omarchy.lock" && lockServiceOwned()) {
+        next[existingId] = inst
+        continue
+      }
       if (inst && typeof inst.destroy === "function") inst.destroy()
     }
-    _services = ({})
+    _services = next
   }
 
   Connections {
@@ -754,7 +769,9 @@ ShellRoot {
       shell.pluginReloadPending = true
       return
     }
-    if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
+    // Clearing the cache while the lock client is still mounted can
+    // invalidate the QML types it is drawing.
+    if (!lockServiceOwned() && typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
     shell.pluginRegistry.rescan()
   }
 

--- a/test/shell.d/lock-stranded-recovery-test.sh
+++ b/test/shell.d/lock-stranded-recovery-test.sh
@@ -66,6 +66,21 @@ assert(
 )
 
 assert(
+  /readonly property bool lockSurfaceOrphaned: sessionSecured && !lockOwned/.test(serviceQml),
+  'an orphan is a compositor-secured session with no surface this client owns'
+)
+
+assert(
+  /function recoverStrandedLock\(\) \{\s*if \(!strandedLock \|\| !passwordPamConfigured\) return/.test(serviceQml),
+  'recovery is skipped unless a stranded lock is waiting and PAM can authenticate it'
+)
+
+assert(
+  /function recoverStrandedLock\(\) \{[\s\S]*if \(lockSurfaceOrphaned\) \{\s*restartForOrphanedLock\(\)/.test(serviceQml),
+  'stranded recovery restarts only when the lock surface is an in-process orphan'
+)
+
+assert(
   /function recoverStrandedLock\(\) \{[\s\S]*if \(sessionLock\.locked\) return/.test(serviceQml),
   'recovery is skipped when this client already owns a lock surface'
 )
@@ -76,8 +91,8 @@ assert(
 )
 
 assert(
-  /sessionLock\.secure && !sessionLock\.locked[\s\S]*recoverStrandedLock\(\)/.test(serviceQml),
-  'a compositor-secured session with no surface recovers instead of setting locked'
+  /lockSurfaceOrphaned[\s\S]*restartForOrphanedLock\(\)/.test(serviceQml),
+  'a compositor-secured session with no surface restarts instead of setting locked'
 )
 
 // The compositor answer and the PAM config land asynchronously, in either
@@ -94,18 +109,28 @@ assert(
 )
 
 assert(
-  /logEvent\("lock-stranded: recovering"\)\s*\n\s*restartShellProc\.running = true/.test(serviceQml),
-  'recovery restarts the shell instead of beginLock in the same process'
+  /logEvent\("lock-stranded: recovering"\)\s*\n\s*beginLock\(\)/.test(serviceQml),
+  'a fresh process takes the stranded compositor lock in-process'
+)
+
+assert(
+  /function restartForOrphanedLock\(\) \{[\s\S]*if \(sessionLock\.locked \|\| !lockSurfaceOrphaned\) return/.test(serviceQml),
+  'a shell restart is reserved for an orphaned lock surface'
+)
+
+assert(
+  /logEvent\("lock-stranded: restarting-for-orphan"\)\s*\n\s*restartShellProc\.running = true/.test(serviceQml),
+  'an in-process orphan restarts the shell instead of beginLock'
 )
 
 assert(
   /id: restartShellProc[\s\S]*omarchy-restart-shell/.test(serviceQml),
-  'recovery goes through omarchy-restart-shell so relock happens in a new process'
+  'orphan recovery goes through omarchy-restart-shell so relock happens in a new process'
 )
 
 assert(
   /property bool strandedRestartAttempted/.test(serviceQml),
-  'recovery attempts a shell restart at most once per process'
+  'orphan recovery attempts a shell restart at most once per process'
 )
 
 assert(

--- a/test/shell.d/lock-stranded-recovery-test.sh
+++ b/test/shell.d/lock-stranded-recovery-test.sh
@@ -33,7 +33,7 @@ assert(
 // omarchy-restart-shell re-locks a fresh shell, possibly mid-question.
 // `locked` includes stale sessionLock.secure and would hide an orphan.
 assert(
-  /root\.strandedLock = exitCode === 0 && !root\.sessionLock\.locked && !root\.lockRequested/.test(serviceQml),
+  /root\.strandedLock = exitCode === 0 && !sessionLock\.locked && !root\.lockRequested/.test(serviceQml),
   'a lock this shell took while the check was in flight is not stranded'
 )
 

--- a/test/shell.d/lock-stranded-recovery-test.sh
+++ b/test/shell.d/lock-stranded-recovery-test.sh
@@ -31,8 +31,9 @@ assert(
 )
 
 // omarchy-restart-shell re-locks a fresh shell, possibly mid-question.
+// `locked` includes stale sessionLock.secure and would hide an orphan.
 assert(
-  /root\.strandedLock = exitCode === 0 && !root\.locked && !root\.lockRequested/.test(serviceQml),
+  /root\.strandedLock = exitCode === 0 && !root\.sessionLock\.locked && !root\.lockRequested/.test(serviceQml),
   'a lock this shell took while the check was in flight is not stranded'
 )
 
@@ -58,15 +59,25 @@ assert(
   're-arming never restarts a check that already has its answer'
 )
 
-// A lock this shell owns ends the search.
+// A lock this shell owns ends the search. sessionLock.secure alone is not ours.
 assert(
-  /function checkStrandedLock\(\) \{\s*if \(strandedLockResolved \|\| strandedLockCheckProc\.running\) return[\s\S]*if \(locked \|\| lockRequested\) \{\s*strandedLockResolved = true/.test(serviceQml),
+  /function checkStrandedLock\(\) \{\s*if \(strandedLockResolved \|\| strandedLockCheckProc\.running\) return[\s\S]*if \(sessionLock\.locked \|\| lockRequested\) \{\s*strandedLockResolved = true/.test(serviceQml),
   'a lock this shell took is not treated as stranded'
 )
 
 assert(
-  /function recoverStrandedLock\(\) \{\s*if \(!strandedLock \|\| locked \|\| !passwordPamConfigured\) return/.test(serviceQml),
-  'recovery is skipped unless a stranded lock is waiting and PAM can authenticate it'
+  /function recoverStrandedLock\(\) \{[\s\S]*if \(sessionLock\.locked\) return/.test(serviceQml),
+  'recovery is skipped when this client already owns a lock surface'
+)
+
+assert(
+  /function requestSessionLock\(\) \{[\s\S]*if \(!lockRequested \|\| sessionLock\.locked\) return/.test(serviceQml),
+  'requesting a lock does not treat sessionLock.secure as proof this client owns it'
+)
+
+assert(
+  /sessionLock\.secure && !sessionLock\.locked[\s\S]*recoverStrandedLock\(\)/.test(serviceQml),
+  'a compositor-secured session with no surface recovers instead of setting locked'
 )
 
 // The compositor answer and the PAM config land asynchronously, in either
@@ -83,7 +94,22 @@ assert(
 )
 
 assert(
-  /strandedLock = false\s*\n\s*logEvent\("lock-stranded: recovering"\)\s*\n\s*beginLock\(\)/.test(serviceQml),
-  'recovery takes the lock once and records it in the journal'
+  /logEvent\("lock-stranded: recovering"\)\s*\n\s*restartShellProc\.running = true/.test(serviceQml),
+  'recovery restarts the shell instead of beginLock in the same process'
+)
+
+assert(
+  /id: restartShellProc[\s\S]*omarchy-restart-shell/.test(serviceQml),
+  'recovery goes through omarchy-restart-shell so relock happens in a new process'
+)
+
+assert(
+  /property bool strandedRestartAttempted/.test(serviceQml),
+  'recovery attempts a shell restart at most once per process'
+)
+
+assert(
+  /id: pendingSessionLockTimer[\s\S]*if \(attempts > 50\)/.test(serviceQml),
+  'a lock that never attaches gives up instead of spinning at 10 Hz'
 )
 JS

--- a/test/shell.d/plugin-reload-lock-test.sh
+++ b/test/shell.d/plugin-reload-lock-test.sh
@@ -13,6 +13,13 @@ assert(
   'plugin reload can tell when the lock service owns the session lock'
 )
 
+// `sessionLock` is an id inside Service.qml, so it is not reachable as a
+// property from here; the service exposes lockOwned for exactly this.
+assert(
+  /function lockServiceOwned\(\) \{[\s\S]*lockInst\.lockOwned/.test(shellQml),
+  'lock ownership is read through the property the service exposes'
+)
+
 assert(
   /function unloadPluginServices\(\) \{[\s\S]*existingId === "omarchy.lock" && lockServiceOwned\(\)/.test(shellQml),
   'plugin reload does not destroy omarchy.lock while it owns the session lock'

--- a/test/shell.d/plugin-reload-lock-test.sh
+++ b/test/shell.d/plugin-reload-lock-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+
+assert(
+  /function lockServiceOwned\(\) \{[\s\S]*_services\["omarchy.lock"\]/.test(shellQml),
+  'plugin reload can tell when the lock service owns the session lock'
+)
+
+assert(
+  /function unloadPluginServices\(\) \{[\s\S]*existingId === "omarchy.lock" && lockServiceOwned\(\)/.test(shellQml),
+  'plugin reload does not destroy omarchy.lock while it owns the session lock'
+)
+
+assert(
+  /function finishPluginReload\(\) \{[\s\S]*!lockServiceOwned\(\) && typeof Qt\.clearComponentCache/.test(shellQml),
+  'plugin reload does not clear the QML cache while the lock client is mounted'
+)
+JS

--- a/test/shell.d/restart-shell-test.sh
+++ b/test/shell.d/restart-shell-test.sh
@@ -98,10 +98,12 @@ case "$*" in
     printf 'ok\n'
     ;;
   *'lock status')
-    if [[ -f $OMARCHY_TEST_QS_STATE.locked ]]; then
-      printf '{"secure": true, "requested": true}\n'
+    if [[ ${OMARCHY_TEST_LOCK_WEDGED:-0} == 1 && ! -f $OMARCHY_TEST_QS_STATE.locked ]]; then
+      printf '{"secure": true, "requested": true, "sessionLocked": false}\n'
+    elif [[ -f $OMARCHY_TEST_QS_STATE.locked ]]; then
+      printf '{"secure": true, "requested": true, "sessionLocked": true}\n'
     else
-      printf '{"secure": false, "requested": false}\n'
+      printf '{"secure": false, "requested": false, "sessionLocked": false}\n'
     fi
     ;;
 esac
@@ -265,3 +267,33 @@ restart_pid_one=""
 grep -F "ipc -n -p $restart_root/shell call -- lock lock" "$ipc_log" >/dev/null || fail "dead-lock recovery re-acquires the session lock"
 grep -F "ipc -n -p $restart_root/shell call -- lock status" "$ipc_log" >/dev/null || fail "dead-lock recovery waits for the lock to become secure"
 pass "restart recovers a locked session whose lock client died"
+
+# A wedged locker reports secure+requested with no surface. That is the
+# "lockscreen app died" wall, not a live lock — restart must recover it.
+sleep 30 &
+restart_pid_one=$!
+printf '%s\n' "$restart_pid_one" >"$restart_state"
+rm -f "$restart_state.locked"
+: >"$restart_log"
+: >"$ipc_log"
+
+PATH="$restart_bin:$PATH" \
+OMARCHY_PATH="$restart_root" \
+XDG_RUNTIME_DIR="$runtime_dir" \
+OMARCHY_TEST_SESSION_LOCKED=1 \
+OMARCHY_TEST_LOCK_WEDGED=1 \
+OMARCHY_TEST_QS_STATE="$restart_state" \
+OMARCHY_TEST_QS_LOG="$restart_log" \
+OMARCHY_TEST_QS_ENV_LOG="$restart_env_log" \
+OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" \
+OMARCHY_TEST_IPC_LOG="$ipc_log" \
+OMARCHY_TEST_SESSION_PATH="$restart_root" \
+  timeout 5 "$ROOT/bin/omarchy-restart-shell" || fail "restart recovers a wedged lock that reports secure without a surface"
+
+if kill -0 "$restart_pid_one" 2>/dev/null; then
+  fail "wedged-lock recovery stops the stale shell instance"
+fi
+wait "$restart_pid_one" 2>/dev/null || true
+restart_pid_one=""
+grep -F "ipc -n -p $restart_root/shell call -- lock lock" "$ipc_log" >/dev/null || fail "wedged-lock recovery re-acquires the session lock"
+pass "restart recovers a wedged lock that reports secure without a surface"


### PR DESCRIPTION
Fixes #6888.

## Problem

Saving any file under `~/.config/omarchy/plugins/` while the session is locked hot-reloads plugins, `destroy()`s `omarchy.lock`, and leaves Hyprland holding `ext-session-lock` with no surface. The lock plugin then logs `lock-stranded: recovering` → `lock-pending: screen-stabilizing` and never draws a prompt. Hyprland's failsafe wall tells the user to `killall -9 hyprlock`, which is not installed on Quattro.

Two outcomes already documented on #6888:

- **Stall:** `requestSessionLock()` returns early on `sessionLock.secure`, which is true for the orphan failsafe and for a stale Quickshell `SessionLockManager::active` after an in-process remount.
- **Crash loop:** dropping that guard and setting `sessionLock.locked = true` in the same process hits Quickshell's `qFatal("Tried to show lockscreen surfaces without active lock")`.

`omarchy-restart-shell` is written to recover a LOCK session with no locker, but it treats `.secure || .requested` as a healthy lock and refuses — the exact JSON a wedged locker reports.

## Approach

Do not remount a live lock client. When an orphan still happens, recover in a **new process**, not by `beginLock()` in the same one.

1. **`shell/shell.qml`** — `unloadPluginServices()` keeps `omarchy.lock` while it owns the session lock (`lockRequested` or `sessionLock.locked`). Skip `Qt.clearComponentCache()` in that case so the mounted lock's types stay valid.
2. **`shell/plugins/lock/Service.qml`** — treat `sessionLock.locked` as the only proof this client has a surface. `secure && !locked` is an orphan: stop the 10 Hz retry and run `omarchy-restart-shell`. Do not set `sessionLock.locked = true` in-process (that is the `qFatal` path).
3. **`bin/omarchy-restart-shell`** — refuse only when `.sessionLocked` is true. `requested`/`secure` without a surface is the wedge and must recover. Relock success is `sessionLocked && secure`.

`hl.clear_crashed_lockscreen()` is intentionally not called first: that would drop the compositor lock before the new process can relock.

## Tests

- Updated `test/shell.d/lock-stranded-recovery-test.sh` for the new recovery contract.
- Updated `test/shell.d/restart-shell-test.sh` so a healthy lock still refuses restart, and a wedged `secure+requested` / `sessionLocked=false` lock is recovered.
- Added `test/shell.d/plugin-reload-lock-test.sh` for the keep-lock reload path.

Focused suites pass. `./test/all` CLI suite is green. Three shell files fail in this environment for missing `omarchy-pkgs` / a non-executable upstream `snapper-test.sh`; they do not touch this change.

## Out of scope

Quickshell still needs to null `SessionLockManager::active` in `~QSWaylandSessionLock` and `return` after a failed `lock()` instead of `updateSurfaces(true)`. Until that lands, same-process retake remains unsafe.