### PR TITLE
Add a manual reader to the Omarchy shell

### DIFF
--- a/bin/omarchy-launch-manual
+++ b/bin/omarchy-launch-manual
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# omarchy:summary=Read the Omarchy manual in a themed reader window
+# omarchy:args=[chapter]
+# omarchy:examples=omarchy launch manual | omarchy launch manual themes | omarchy launch manual 07
+#
+# Pass a chapter to open the reader on it instead of where you left off.
+# Chapters resolve by number, filename, or any fragment of the slug or
+# title — `themes`, `06-themes.md`, and `6` all land on the same page.
+# Unknown chapters are ignored and the reader opens at its usual position.
+
+if (( $# > 0 )) && [[ -n $1 ]]; then
+  payload=$(printf '{"chapter":"%s"}' "${1//\"/}")
+else
+  payload='{}'
+fi
+
+omarchy-shell shell summon omarchy.manual "$payload"

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -10,6 +10,7 @@ o.bind("XF86PowerOff", "Power menu", "omarchy-menu toggle system", { locked = tr
 o.bind("SUPER + K", "Keybindings", "omarchy-menu-keybindings")
 o.bind("SUPER + ALT + K", "Tmux keybindings", "omarchy-menu-tmux-keybindings")
 o.bind("SUPER + CTRL + K", "Herdr keybindings", "omarchy-menu-herdr-keybindings")
+o.bind("SUPER + CTRL + SLASH", "Manual", "omarchy-launch-manual")
 o.bind("SUPER + CTRL + Q", "Calculator", "omacalc")
 o.bind("XF86Calculator", "Calculator", "omacalc")
 

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -37,6 +37,7 @@
   "system.shutdown": {"icon":"󰐥","label":"Shutdown","action":"omarchy-system-shutdown"},
 
   // Learn
+  "learn.manual": {"icon":"󰂺","label":"Manual","action":"omarchy-launch-manual"},
   "learn.keybindings": {"icon":"","label":"Keybindings","action":"omarchy-menu-keybindings"},
   "learn.omarchy": {"icon":"","label":"Omarchy","action":"omarchy-launch-webapp 'https://omarchy.org/manual/'"},
   "learn.hyprland": {"icon":"","label":"Hyprland","action":"omarchy-launch-webapp 'https://wiki.hypr.land/'"},

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -108,6 +108,7 @@ python-poetry-core
 ttfx
 qemu-user-static-binfmt
 qrencode
+qt6-imageformats
 quickshell-git
 ripgrep
 ruby

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -1,6 +1,6 @@
 # Hotkeys
 
-You can see all the main keyboard bindings with `Super + K` (Tmux bindings with `Super + Alt + K` and Herdr bindings with `Super + Ctrl + K`).
+You can see all the main keyboard bindings with `Super + K` (Tmux bindings with `Super + Alt + K` and Herdr bindings with `Super + Ctrl + K`), and open this manual with `Super + Ctrl + /`.
 
 ## Navigating
 

--- a/migrations/1786721707.sh
+++ b/migrations/1786721707.sh
@@ -1,0 +1,3 @@
+echo "Install Qt image format plugins for the manual reader's webp screenshots"
+
+omarchy-pkg-add qt6-imageformats

--- a/shell/plugins/manual/ManualModel.js
+++ b/shell/plugins/manual/ManualModel.js
@@ -1,0 +1,353 @@
+// Pure data helpers for the manual reader. Kept free of QML types so
+// test/shell.d/manual-test.sh can exercise them under node.
+
+// Fallback when a chapter file carries no `# ` heading: derive a readable
+// title from the "NN-some-slug.md" filename.
+function titleFromFilename(name) {
+  var base = String(name || "").replace(/\.md$/, "").replace(/^\d+-/, "")
+  var words = base.split("-").filter(function(w) { return w.length > 0 })
+  return words.map(function(w) {
+    return w.charAt(0).toUpperCase() + w.slice(1)
+  }).join(" ")
+}
+
+// Input: one "filename\ttitle" line per chapter (title may be empty), in
+// whatever order the scanner emitted them. Output: chapters sorted by
+// filename, which the manual numbers deliberately.
+function parseChapterIndex(raw) {
+  var chapters = []
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i]
+    if (!line.trim()) continue
+    var tab = line.indexOf("\t")
+    var file = tab >= 0 ? line.slice(0, tab) : line
+    var title = tab >= 0 ? line.slice(tab + 1).trim() : ""
+    file = file.trim()
+    if (!file.match(/\.md$/)) continue
+    var numberMatch = file.match(/^(\d+)-/)
+    chapters.push({
+      file: file,
+      number: numberMatch ? parseInt(numberMatch[1], 10) : 0,
+      slug: file.replace(/\.md$/, "").replace(/^\d+-/, ""),
+      title: title || titleFromFilename(file)
+    })
+  }
+  chapters.sort(function(a, b) { return a.file < b.file ? -1 : (a.file > b.file ? 1 : 0) })
+  return chapters
+}
+
+// ---------------------------------------------------------------- theming
+
+// Mix #rrggbb (or #aarrggbb) colors: t of a over (1 - t) of b. Used to bake
+// solid chip and panel colors, since Qt's rich text CSS subset takes plain
+// hex but no alpha.
+function mixColors(a, b, t) {
+  function channels(hex) {
+    var h = String(hex || "").replace("#", "")
+    if (h.length === 8) h = h.slice(2)
+    if (h.length !== 6) return null
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+  }
+  var ca = channels(a)
+  var cb = channels(b)
+  if (!ca || !cb) return String(a || b || "")
+  var out = "#"
+  for (var i = 0; i < 3; i++) {
+    var v = Math.round(ca[i] * t + cb[i] * (1 - t))
+    out += (v < 16 ? "0" : "") + v.toString(16)
+  }
+  return out
+}
+
+// The rendering style splitBlocks needs, derived from the four foundational
+// theme colors. Kept here so the derivation is testable and the panel only
+// hands over what it knows.
+function themeFor(accent, foreground, background, muted) {
+  return {
+    link: accent,
+    inlineCodeBg: mixColors(foreground, background, 0.1),
+    comment: muted,
+    string: accent,
+    keyword: foreground,
+    variable: accent
+  }
+}
+
+// ---------------------------------------------------------------- links
+
+// Qt's markdown importer bakes the application palette's link color into the
+// document, so links keep their default blue no matter what the item is told.
+// md4c passes raw inline HTML through, which gives us a working override:
+// rewrite markdown links into anchors styled with the theme accent.
+function rewriteLinkSegment(segment, linkColor) {
+  var re = /\[([^\]]+)\]\(\s*(?:<([^>\s]+)>|((?:[^()\s]|\([^()]*\))+))(\s+"[^"]*")?\s*\)/g
+  return segment.replace(re, function(match, text, angled, bare, title, offset, whole) {
+    if (offset > 0 && whole.charAt(offset - 1) === "!") return match
+    return '<a href="' + (angled || bare || "") + '" style="color:' + linkColor + '">' + text + "</a>"
+  })
+}
+
+// ---------------------------------------------------------------- code
+
+function escapeHtml(text) {
+  return String(text).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+// Inline chips stay inside markdown text, where md4c would still interpret
+// emphasis and bracket syntax between the chip's tags — escape those away.
+function escapeMarkdownSpecials(text) {
+  return String(text).replace(/[\\*_\[\]`~]/g, "\\$&")
+}
+
+function span(color, bold, text) {
+  var style = "color:" + color + (bold ? ";font-weight:bold" : "")
+  return '<span style="' + style + '">' + text + "</span>"
+}
+
+// Line-based token coloring over already HTML-escaped code. One combined
+// alternation per language keeps matches from overlapping: whatever the scan
+// reaches first (a string, a comment opener, a variable) wins the region.
+function highlightLine(line, language, theme) {
+  var rules
+  if (language === "bash" || language === "sh") {
+    rules = /("(?:[^"\\]|\\.)*"|'[^']*')|((?:^|\s)#.*$)|(\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*|\$\d)/g
+  } else if (language === "lua") {
+    rules = /("(?:[^"\\]|\\.)*"|'[^']*')|(--.*$)|(\b(?:local|function|end|if|then|else|elseif|return|for|while|do|in|not|and|or|true|false|nil)\b)/g
+  } else if (language === "json" || language === "jsonc") {
+    rules = /("(?:[^"\\]|\\.)*")|(\/\/.*$)|(\b(?:true|false|null)\b|-?\b\d+(?:\.\d+)?\b)/g
+  } else {
+    // Plain blocks are terminal transcripts: make prompt lines' commands
+    // stand out and leave the output alone.
+    var prompt = line.match(/^(~ ❯|\$)( .*)$/)
+    if (prompt) return span(theme.comment, false, prompt[1]) + span(theme.keyword, true, prompt[2])
+    return line
+  }
+  return line.replace(rules, function(match, string, comment, third, offset, whole) {
+    if (string !== undefined) {
+      // A json key is the string right before a colon; color it like a
+      // variable so structure reads at a glance.
+      if ((language === "json" || language === "jsonc") && /^\s*:/.test(whole.slice(offset + match.length)))
+        return span(theme.variable, false, match)
+      return span(theme.string, false, match)
+    }
+    if (comment !== undefined) return span(theme.comment, false, match)
+    if (language === "bash" || language === "sh") return span(theme.variable, false, match)
+    return span(theme.keyword, true, match)
+  })
+}
+
+function highlightCode(code, language, theme) {
+  var lines = escapeHtml(code).split("\n")
+  for (var i = 0; i < lines.length; i++) lines[i] = highlightLine(lines[i], language, theme)
+  return "<pre>" + lines.join("\n") + "</pre>"
+}
+
+// ---------------------------------------------------------------- lines
+
+// Qt imports markdown with md4c's underline extension, so `_emphasis_`
+// renders underlined instead of italic. Rewrite word-bounded underscore
+// emphasis to the star form, which imports as italic. Intraword underscores
+// (snake_case, URLs) don't sit on word boundaries and stay untouched.
+function normalizeEmphasis(segment) {
+  return String(segment)
+    .replace(/(^|[^A-Za-z0-9_\\])__(?!_)([^_]+)__(?![A-Za-z0-9_])/g, "$1**$2**")
+    .replace(/(^|[^A-Za-z0-9_\\])_(?!_)([^_]+)_(?![A-Za-z0-9_])/g, "$1*$2*")
+}
+
+// Rewrite one markdown line for display: links get accent-colored anchors,
+// inline code spans become tinted chips, underscore emphasis becomes star
+// emphasis. The rewrites ride on md4c's raw-HTML passthrough. Code spans are
+// transformed first so link and emphasis syntax inside them stays literal.
+function styleLine(line, theme) {
+  if (!theme) return line
+  var parts = String(line).split(/(`[^`]+`)/)
+  for (var i = 0; i < parts.length; i++) {
+    if (parts[i].charAt(0) === "`" && parts[i].length > 1) {
+      var code = escapeMarkdownSpecials(escapeHtml(parts[i].slice(1, -1)))
+      parts[i] = '<code style="background-color:' + theme.inlineCodeBg + '">' + code + "</code>"
+    } else {
+      parts[i] = rewriteLinkSegment(normalizeEmphasis(parts[i]), theme.link)
+    }
+  }
+  return parts.join("")
+}
+
+// ---------------------------------------------------------------- blocks
+
+// Split chapter markdown into text, image, and code blocks. Qt markdown
+// quirks drive the shape: images draw at natural size (the manual's
+// screenshots are 1600px wide), so standalone image paragraphs become
+// width-fitted Image blocks; paragraphs get no vertical margins, so each
+// blank-line-separated paragraph becomes its own block and the panel's
+// Column provides the spacing; and fenced code gets neither styling nor
+// horizontal scrolling, so fences become code blocks the panel renders in
+// its own highlighted, scrollable panel. Blank lines followed by a list item
+// or indented continuation don't split, so ordered lists keep their
+// numbering across gaps between items. Without a theme the styling rewrites
+// are skipped and blocks carry raw markdown only.
+function splitBlocks(markdown, theme) {
+  var blocks = []
+  var textLines = []
+  var textStart = 1
+  var textHasContent = false
+  var codeLines = null
+  var codeLanguage = ""
+  var codeStart = 1
+
+  function flushText() {
+    var text = textLines.join("\n")
+    if (text.trim()) blocks.push({ kind: "text", text: text, heading: /^\s*#/.test(text), startLine: textStart })
+    textLines = []
+    textHasContent = false
+  }
+
+  function flushCode() {
+    var code = codeLines.join("\n")
+    blocks.push({
+      kind: "code",
+      language: codeLanguage,
+      text: code,
+      html: theme ? highlightCode(code, codeLanguage, theme) : "",
+      startLine: codeStart
+    })
+    codeLines = null
+    codeLanguage = ""
+  }
+
+  function continuesBlock(lines, from) {
+    for (var i = from; i < lines.length; i++) {
+      if (!lines[i].trim()) continue
+      return lines[i].match(/^\s*([-*+]|\d+[.)])\s/) !== null || lines[i].match(/^ {4,}\S/) !== null
+    }
+    return false
+  }
+
+  var lines = String(markdown || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i]
+    var fence = line.match(/^\s*(```|~~~)\s*([A-Za-z0-9_-]*)\s*$/)
+    if (fence) {
+      if (codeLines === null) {
+        flushText()
+        codeLines = []
+        codeLanguage = fence[2].toLowerCase()
+        codeStart = i + 1
+      } else {
+        flushCode()
+      }
+      continue
+    }
+    if (codeLines !== null) {
+      codeLines.push(line)
+      continue
+    }
+    var image = line.match(/^\s*!\[([^\]]*)\]\(([^)\s]+)\)\s*$/)
+    if (image) {
+      flushText()
+      blocks.push({ kind: "image", alt: image[1], source: image[2], startLine: i + 1 })
+    } else if (!line.trim()) {
+      if (continuesBlock(lines, i + 1)) textLines.push(line)
+      else flushText()
+    } else {
+      if (!textHasContent) {
+        textStart = i + 1
+        textHasContent = true
+      }
+      textLines.push(styleLine(line, theme))
+    }
+  }
+  if (codeLines !== null) flushCode()
+  flushText()
+  return blocks
+}
+
+// The block a 1-based source line landed in — the jump target for a search
+// hit. Lines before the first block clamp to the first.
+function blockIndexForLine(blocks, line) {
+  if (!blocks || blocks.length === 0) return -1
+  var index = 0
+  for (var i = 0; i < blocks.length; i++)
+    if (blocks[i].startLine <= line) index = i
+  return index
+}
+
+// ---------------------------------------------------------------- search
+
+// Parse `grep -rinF` output ("path/NN-file.md:12:matched text") into jump
+// targets ordered the way grep found them, which follows chapter order.
+// Hits in files the chapter index doesn't know are dropped.
+function parseSearchResults(raw, chapters, limit) {
+  var cap = limit || 50
+  var results = []
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length && results.length < cap; i++) {
+    var match = lines[i].match(/^(.*?([^\/:]+\.md)):(\d+):(.*)$/)
+    if (!match) continue
+    var file = match[2]
+    var chapterIndex = -1
+    for (var c = 0; c < chapters.length; c++)
+      if (chapters[c].file === file) { chapterIndex = c; break }
+    if (chapterIndex < 0) continue
+    results.push({
+      chapterIndex: chapterIndex,
+      file: file,
+      title: chapters[chapterIndex].title,
+      line: parseInt(match[3], 10),
+      snippet: match[4].replace(/^[\s#>*-]+/, "").trim()
+    })
+  }
+  return results
+}
+
+// ---------------------------------------------------------------- lookups
+
+// Resolve a user-supplied chapter reference — number, filename, slug, or a
+// case-insensitive fragment of the slug or title — to a chapter index.
+function resolveChapter(chapters, ref) {
+  var wanted = String(ref || "").trim()
+  if (!wanted) return -1
+  var lower = wanted.toLowerCase()
+  var i
+
+  if (wanted.match(/^\d+$/)) {
+    var number = parseInt(wanted, 10)
+    for (i = 0; i < chapters.length; i++)
+      if (chapters[i].number === number) return i
+  }
+  for (i = 0; i < chapters.length; i++)
+    if (chapters[i].file === wanted || chapters[i].slug === lower) return i
+  for (i = 0; i < chapters.length; i++)
+    if (chapters[i].slug.indexOf(lower) !== -1) return i
+  for (i = 0; i < chapters.length; i++)
+    if (chapters[i].title.toLowerCase().indexOf(lower) !== -1) return i
+  return -1
+}
+
+// Classify an activated link: external URLs open a browser, relative .md
+// links navigate between chapters, in-page anchors are ignored.
+function linkTarget(href) {
+  var link = String(href || "").trim()
+  if (!link) return { kind: "none" }
+  if (link.match(/^[a-z][a-z0-9+.-]*:/i)) return { kind: "external", url: link }
+  if (link.charAt(0) === "#") return { kind: "anchor" }
+  var file = link.replace(/^\.\//, "").split("#")[0]
+  if (file.match(/\.md$/)) return { kind: "chapter", file: file }
+  return { kind: "none" }
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    titleFromFilename: titleFromFilename,
+    parseChapterIndex: parseChapterIndex,
+    mixColors: mixColors,
+    themeFor: themeFor,
+    styleLine: styleLine,
+    highlightCode: highlightCode,
+    splitBlocks: splitBlocks,
+    blockIndexForLine: blockIndexForLine,
+    parseSearchResults: parseSearchResults,
+    resolveChapter: resolveChapter,
+    linkTarget: linkTarget
+  }
+}

--- a/shell/plugins/manual/ManualPanel.qml
+++ b/shell/plugins/manual/ManualPanel.qml
@@ -1,0 +1,545 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui as Ui
+import "ManualModel.js" as ManualModel
+
+// Reader window for the manual shipped at $OMARCHY_PATH/manual: chapter list
+// on the left, rendered markdown on the right. Summon with `omarchy launch
+// manual [chapter]`, or directly via:
+//   omarchy-shell shell summon omarchy.manual "{}"
+//
+// Qt renders the markdown itself. Standalone image paragraphs are split out
+// by ManualModel.splitBlocks and drawn as width-fitted Image items, because
+// QTextDocument draws images at their natural size and the manual's
+// screenshots are wider than any comfortable reading column.
+Item {
+  id: root
+
+  // ---- host injections ----------------------------------------------------
+  property var shell: null
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+
+  readonly property string manualDir: omarchyPath + "/manual"
+
+  // ---- plugin lifecycle ---------------------------------------------------
+  property bool closingFromHost: false
+
+  function open(payloadJson) {
+    closingFromHost = false
+
+    var requested = ""
+    if (payloadJson) {
+      try {
+        var parsed = JSON.parse(String(payloadJson))
+        if (parsed && typeof parsed.chapter === "string") requested = parsed.chapter
+      } catch (e) { /* ignore */ }
+    }
+
+    // The chapter list is rescanned on every open so an updated manual shows
+    // up without a shell restart. The requested chapter is resolved once the
+    // scan lands — it may name a chapter the previous scan didn't know.
+    pendingChapterRef = requested
+    scanProcess.running = false
+    scanProcess.running = true
+
+    window.visible = true
+    Qt.callLater(function() { keyScope.forceActiveFocus() })
+  }
+
+  // Host-initiated close (`shell hide`). Visibility flips without notifying
+  // the host back — it already knows.
+  function close() {
+    closingFromHost = true
+    window.visible = false
+    closingFromHost = false
+  }
+
+  // User-initiated close (Esc, window close button). Tell the shell so its
+  // openPanelIds map stays consistent and `toggle` works on the next call.
+  function requestClose() {
+    if (shell && typeof shell.hide === "function") shell.hide("omarchy.manual")
+    else window.visible = false
+  }
+
+  // ---- chapter model ------------------------------------------------------
+  property var chapters: []
+  property int currentIndex: -1
+  property string pendingChapterRef: ""
+  property var blocks: []
+
+  function selectChapter(index) {
+    if (index < 0 || index >= chapters.length) return
+    currentIndex = index
+  }
+
+  function stepChapter(delta) {
+    selectChapter(currentIndex + delta)
+  }
+
+  // One "filename\ttitle" line per chapter, title being the first `# `
+  // heading so the sidebar shows real titles, not slug reconstructions.
+  readonly property string scanScript:
+    "for f in \"$1\"/*.md; do [ -e \"$f\" ] || continue; " +
+    "title=$(awk '/^# /{sub(/^# +/, \"\"); print; exit}' \"$f\"); " +
+    "printf '%s\\t%s\\n' \"${f##*/}\" \"$title\"; done"
+
+  Process {
+    id: scanProcess
+    running: false
+    command: ["bash", "-c", root.scanScript, "--", root.manualDir]
+    stdout: StdioCollector { id: scanStdout; waitForEnd: true }
+    onExited: function(exitCode) {
+      root.chapters = ManualModel.parseChapterIndex(scanStdout.text)
+      var wanted = root.pendingChapterRef
+      root.pendingChapterRef = ""
+      var index = wanted ? ManualModel.resolveChapter(root.chapters, wanted) : -1
+      if (index < 0) index = root.currentIndex
+      root.currentIndex = Math.max(0, Math.min(root.chapters.length - 1, index))
+    }
+  }
+
+  FileView {
+    id: chapterFile
+    path: root.currentIndex >= 0 && root.currentIndex < root.chapters.length
+      ? root.manualDir + "/" + root.chapters[root.currentIndex].file
+      : ""
+    watchChanges: false
+    printErrors: false
+    onLoaded: {
+      root.blocks = ManualModel.splitBlocks(text(), root.markdownTheme())
+      if (root.pendingScrollLine > 0) {
+        var line = root.pendingScrollLine
+        root.pendingScrollLine = 0
+        root.scrollToLine(line)
+      } else {
+        reader.contentY = 0
+      }
+    }
+    onLoadFailed: root.blocks = []
+  }
+
+  function markdownTheme() {
+    return ManualModel.themeFor(String(Color.accent), String(Color.foreground),
+      String(Color.background), String(Color.muted))
+  }
+
+  // Theme colors are baked into each block's anchors, chips, and code
+  // highlights, so a theme switch while the reader is open has to re-derive
+  // the blocks.
+  Connections {
+    target: Color
+    function onAccentChanged() {
+      if (chapterFile.path) root.blocks = ManualModel.splitBlocks(chapterFile.text(), root.markdownTheme())
+    }
+  }
+
+  function openLink(link) {
+    var target = ManualModel.linkTarget(link)
+    if (target.kind === "external") Qt.openUrlExternally(target.url)
+    else if (target.kind === "chapter") {
+      var index = ManualModel.resolveChapter(root.chapters, target.file)
+      if (index >= 0) root.selectChapter(index)
+    }
+  }
+
+  // ---- search -------------------------------------------------------------
+  property var searchResults: []
+  property int searchIndex: 0
+  property int pendingScrollLine: 0
+  property int highlightIndex: -1
+
+  function runSearch() {
+    searchProcess.running = false
+    if (!sidebar.searching) {
+      searchResults = []
+      searchIndex = 0
+      return
+    }
+    searchProcess.command = ["grep", "-rinF", "--include=*.md", "-m", "5", "-e", searchField.text.trim(), manualDir]
+    searchProcess.running = true
+  }
+
+  function jumpToResult(index) {
+    if (index < 0 || index >= searchResults.length) return
+    searchIndex = index
+    var result = searchResults[index]
+    if (currentIndex === result.chapterIndex) {
+      scrollToLine(result.line)
+    } else {
+      pendingScrollLine = result.line
+      currentIndex = result.chapterIndex
+    }
+  }
+
+  // Scroll the reading pane so the block holding the given source line sits
+  // near the top, and flash it. Deferred so the block column has been laid
+  // out when the target's position is read.
+  function scrollToLine(line) {
+    var index = ManualModel.blockIndexForLine(blocks, line)
+    if (index < 0) return
+    highlightIndex = index
+    highlightClear.restart()
+    Qt.callLater(function() {
+      var item = blockRepeater.itemAt(index)
+      if (!item) return
+      var maxY = Math.max(0, reader.contentHeight - reader.height)
+      reader.contentY = Math.max(0, Math.min(maxY, item.y - 32))
+    })
+  }
+
+  Process {
+    id: searchProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: searchStdout; waitForEnd: true }
+    onExited: {
+      root.searchResults = ManualModel.parseSearchResults(searchStdout.text, root.chapters, 50)
+      root.searchIndex = 0
+    }
+  }
+
+  Timer {
+    id: searchTimer
+    interval: 250
+    onTriggered: root.runSearch()
+  }
+
+  Timer {
+    id: highlightClear
+    interval: 1800
+    onTriggered: root.highlightIndex = -1
+  }
+
+  // ---- window -------------------------------------------------------------
+  FloatingWindow {
+    id: window
+    title: "Omarchy Manual"
+    color: Color.background
+    implicitWidth: 1080
+    implicitHeight: 800
+    minimumSize: Qt.size(720, 480)
+
+    onVisibleChanged: {
+      if (!visible && !root.closingFromHost && root.shell && typeof root.shell.hide === "function")
+        root.shell.hide("omarchy.manual")
+    }
+
+    FocusScope {
+      id: keyScope
+      anchors.fill: parent
+      focus: true
+
+      function scrollBy(dy) {
+        if (reader.contentHeight <= reader.height) return
+        reader.contentY = Math.max(0, Math.min(reader.contentHeight - reader.height, reader.contentY + dy))
+      }
+
+      // Keys bubble up here from the read-only text blocks, so scrolling
+      // keeps working after a click into the prose to select something.
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) scrollBy(90)
+        else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) scrollBy(-90)
+        else if (event.key === Qt.Key_D || event.key === Qt.Key_PageDown || event.key === Qt.Key_Space) scrollBy(reader.height * 0.85)
+        else if (event.key === Qt.Key_U || event.key === Qt.Key_PageUp) scrollBy(-reader.height * 0.85)
+        else if (event.key === Qt.Key_Home) reader.contentY = 0
+        else if (event.key === Qt.Key_End) reader.contentY = Math.max(0, reader.contentHeight - reader.height)
+        else if (event.key === Qt.Key_H || event.key === Qt.Key_Left) root.stepChapter(-1)
+        else if (event.key === Qt.Key_L || event.key === Qt.Key_Right) root.stepChapter(1)
+        else if (event.key === Qt.Key_Slash) {
+          searchField.forceActiveFocus()
+          searchField.selectAll()
+        } else if (event.key === Qt.Key_Escape || event.key === Qt.Key_Q) root.requestClose()
+        else return
+        event.accepted = true
+      }
+
+      // ---- sidebar --------------------------------------------------------
+      Rectangle {
+        id: sidebar
+        width: Math.round(250 * Style.fontScale)
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        color: Util.alpha(Color.foreground, 0.04)
+
+        // Two or more characters keeps single keystrokes from grepping the
+        // whole manual for one letter.
+        readonly property bool searching: searchField.text.trim().length >= 2
+
+        Ui.TextField {
+          id: searchField
+          anchors.top: parent.top
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.margins: 10
+          placeholderText: "Search  ( / )"
+          onTextChanged: searchTimer.restart()
+
+          Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Down) {
+              root.searchIndex = Math.min(root.searchIndex + 1, root.searchResults.length - 1)
+            } else if (event.key === Qt.Key_Up) {
+              root.searchIndex = Math.max(root.searchIndex - 1, 0)
+            } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+              root.jumpToResult(root.searchIndex)
+            } else if (event.key === Qt.Key_Escape) {
+              text = ""
+              keyScope.forceActiveFocus()
+            } else {
+              return
+            }
+            event.accepted = true
+          }
+        }
+
+        Text {
+          anchors.top: searchField.bottom
+          anchors.topMargin: 16
+          anchors.horizontalCenter: parent.horizontalCenter
+          visible: sidebar.searching && root.searchResults.length === 0 && !searchProcess.running
+          text: "No matches"
+          color: Color.muted
+          font.family: Style.font.family
+          font.pixelSize: Style.font.bodySmall
+        }
+
+        ListView {
+          id: chapterList
+          anchors.top: searchField.bottom
+          anchors.bottom: parent.bottom
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.topMargin: 10
+          anchors.bottomMargin: 10
+          clip: true
+          model: sidebar.searching ? root.searchResults : root.chapters
+          currentIndex: sidebar.searching ? root.searchIndex : root.currentIndex
+          highlightFollowsCurrentItem: true
+          highlightMoveDuration: 0
+          onCurrentIndexChanged: if (currentIndex >= 0) positionViewAtIndex(currentIndex, ListView.Contain)
+          ScrollBar.vertical: ScrollBar { }
+
+          delegate: Rectangle {
+            required property var modelData
+            required property int index
+
+            readonly property bool current: index === chapterList.currentIndex
+
+            width: chapterList.width
+            height: rowColumn.implicitHeight + 12
+            color: current ? Color.menu.selectedBackground : "transparent"
+
+            Column {
+              id: rowColumn
+              anchors.verticalCenter: parent.verticalCenter
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.leftMargin: 14
+              anchors.rightMargin: 10
+              spacing: 2
+
+              Text {
+                width: parent.width
+                text: modelData.title
+                color: current ? Color.menu.selectedText : Util.alpha(Color.foreground, 0.8)
+                font.family: Style.font.family
+                font.pixelSize: Style.font.bodySmall
+                elide: Text.ElideRight
+              }
+
+              Text {
+                width: parent.width
+                visible: sidebar.searching && (modelData.snippet || "").length > 0
+                text: modelData.snippet || ""
+                color: Util.alpha(Color.foreground, 0.55)
+                font.family: Style.font.family
+                font.pixelSize: Style.font.caption
+                elide: Text.ElideRight
+              }
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              onClicked: sidebar.searching ? root.jumpToResult(parent.index) : root.selectChapter(parent.index)
+            }
+          }
+        }
+      }
+
+      Rectangle {
+        id: divider
+        width: 1
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: sidebar.right
+        color: Util.alpha(Color.foreground, 0.12)
+      }
+
+      // ---- reading pane ---------------------------------------------------
+      Flickable {
+        id: reader
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: divider.right
+        anchors.right: parent.right
+        clip: true
+        contentWidth: width
+        contentHeight: content.height
+        boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar { }
+
+        Column {
+          id: content
+          readonly property int sideMargin: 36
+          // Blocks are paragraphs, so the Column's spacing is the paragraph
+          // gap Qt's markdown rendering doesn't provide on its own.
+          readonly property int paragraphGap: Math.round(Style.font.body * 0.9)
+          readonly property int headingGap: Math.round(Style.font.body * 1.4)
+          width: Math.min(Math.round(700 * Style.fontScale), reader.width - 2 * sideMargin)
+          x: Math.round((reader.width - width) / 2)
+          topPadding: 28
+          bottomPadding: 48
+          spacing: paragraphGap
+
+          Repeater {
+            id: blockRepeater
+            model: root.blocks
+
+            delegate: Loader {
+              required property var modelData
+              required property int index
+
+              width: content.width
+              sourceComponent: modelData.kind === "image" ? imageBlock
+                : modelData.kind === "code" ? codeBlock : textBlock
+
+              // Flash behind the block a search jump landed on.
+              Rectangle {
+                z: -1
+                anchors.fill: parent
+                anchors.margins: -8
+                radius: 6
+                color: Util.alpha(Color.accent, 0.12)
+                opacity: index === root.highlightIndex ? 1 : 0
+
+                Behavior on opacity {
+                  NumberAnimation { duration: 350 }
+                }
+              }
+
+              Component {
+                id: textBlock
+
+                // Headings open a section, so they get extra air above —
+                // except the chapter title at the very top.
+                Item {
+                  readonly property int gapAbove: modelData.heading && index > 0 ? content.headingGap : 0
+                  width: content.width
+                  height: prose.height + gapAbove
+
+                  TextEdit {
+                    id: prose
+                    anchors.bottom: parent.bottom
+                    width: content.width
+                    text: modelData.text
+                    textFormat: TextEdit.MarkdownText
+                    baseUrl: "file://" + root.manualDir + "/"
+                    readOnly: true
+                    selectByMouse: true
+                    wrapMode: TextEdit.Wrap
+                    color: Color.foreground
+                    selectionColor: Util.alpha(Color.accent, 0.45)
+                    selectedTextColor: Color.foreground
+                    font.family: Style.font.family
+                    font.pixelSize: Style.font.body
+                    onLinkActivated: function(link) { root.openLink(link) }
+
+                    HoverHandler {
+                      enabled: prose.hoveredLink !== ""
+                      cursorShape: Qt.PointingHandCursor
+                    }
+                  }
+                }
+              }
+
+              Component {
+                id: codeBlock
+
+                // Fenced code in its own panel: tinted, token-highlighted,
+                // and horizontally scrollable, since terminal transcripts in
+                // the manual run far wider than the reading column.
+                Rectangle {
+                  width: content.width
+                  height: codeFlick.height + 24
+                  radius: 6
+                  color: Util.alpha(Color.foreground, 0.05)
+                  border.color: Util.alpha(Color.foreground, 0.12)
+                  border.width: 1
+
+                  Flickable {
+                    id: codeFlick
+                    x: 14
+                    y: 12
+                    width: parent.width - 28
+                    height: codeText.height
+                    contentWidth: codeText.width
+                    contentHeight: codeText.height
+                    flickableDirection: Flickable.HorizontalFlick
+                    interactive: contentWidth > width
+                    boundsBehavior: Flickable.StopAtBounds
+                    clip: true
+                    ScrollBar.horizontal: ScrollBar { }
+
+                    TextEdit {
+                      id: codeText
+                      text: modelData.html
+                      textFormat: TextEdit.RichText
+                      readOnly: true
+                      selectByMouse: true
+                      color: Color.foreground
+                      selectionColor: Util.alpha(Color.accent, 0.45)
+                      selectedTextColor: Color.foreground
+                      font.family: Style.font.family
+                      font.pixelSize: Style.font.body
+                    }
+                  }
+                }
+              }
+
+              Component {
+                id: imageBlock
+
+                Item {
+                  width: content.width
+                  height: figure.height + content.paragraphGap
+
+                  Image {
+                    id: figure
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    source: "file://" + root.manualDir + "/" + modelData.source
+                    asynchronous: true
+                    fillMode: Image.PreserveAspectFit
+                    width: sourceSize.width > 0 ? Math.min(content.width, sourceSize.width) : content.width
+                    height: sourceSize.width > 0 ? Math.round(width * sourceSize.height / sourceSize.width) : 0
+                  }
+
+                  Rectangle {
+                    anchors.fill: figure
+                    visible: figure.status === Image.Ready
+                    color: "transparent"
+                    border.color: Util.alpha(Color.foreground, 0.15)
+                    border.width: 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/manual/manifest.json
+++ b/shell/plugins/manual/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.manual",
+  "name": "Manual",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Reader window for the Omarchy manual shipped at $OMARCHY_PATH/manual. Summon with: omarchy-shell shell summon omarchy.manual '{}' (or run: omarchy launch manual).",
+  "kinds": [
+    "panel"
+  ],
+  "entryPoints": {
+    "panel": "ManualPanel.qml"
+  }
+}

--- a/test/shell.d/manual-test.sh
+++ b/test/shell.d/manual-test.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The menu advertises the reader; the reader summons the plugin. Both ends of
+# that wiring live in different files, so check they still meet.
+grep -q '"learn.manual".*omarchy-launch-manual' "$ROOT/default/omarchy/omarchy-menu.jsonc" ||
+  fail "menu entry learn.manual does not launch omarchy-launch-manual"
+grep -q 'summon omarchy.manual' "$ROOT/bin/omarchy-launch-manual" ||
+  fail "omarchy-launch-manual does not summon the omarchy.manual plugin"
+pass "menu entry and launcher wiring"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const model = requireFromRoot('shell/plugins/manual/ManualModel.js')
+
+const theme = model.themeFor('#aabbcc', '#cacccc', '#101315', '#707880')
+
+// ---- parseChapterIndex ----------------------------------------------------
+
+const index = model.parseChapterIndex(
+  '02-getting-started.md\tGetting Started\n' +
+  '01-welcome-to-omarchy.md\tWelcome to Omarchy!\n' +
+  '10-notices.md\t\n' +
+  'not-markdown.txt\tIgnored\n' +
+  '\n'
+)
+assertEqual(index.length, 3, 'parseChapterIndex keeps only markdown chapters')
+assertEqual(index[0].file, '01-welcome-to-omarchy.md', 'parseChapterIndex sorts by filename')
+assertEqual(index[0].title, 'Welcome to Omarchy!', 'parseChapterIndex keeps scanned titles')
+assertEqual(index[0].number, 1, 'parseChapterIndex extracts the chapter number')
+assertEqual(index[0].slug, 'welcome-to-omarchy', 'parseChapterIndex extracts the slug')
+assertEqual(index[2].title, 'Notices', 'parseChapterIndex falls back to a filename-derived title')
+
+// ---- theming --------------------------------------------------------------
+
+assertEqual(model.mixColors('#000000', '#ffffff', 0.5), '#808080', 'mixColors blends midpoints')
+assertEqual(model.mixColors('#ff0000', '#000000', 1), '#ff0000', 'mixColors at t=1 returns the first color')
+assertEqual(theme.link, '#aabbcc', 'themeFor wires the accent to links')
+assertEqual(theme.inlineCodeBg, model.mixColors('#cacccc', '#101315', 0.1), 'themeFor tints chips from foreground over background')
+
+// ---- splitBlocks ----------------------------------------------------------
+
+const blocks = model.splitBlocks(
+  '# Title\n' +
+  '\n' +
+  'Some prose with an inline ![icon](images/icon.webp) image.\n' +
+  '\n' +
+  ' ![shot](images/shot.webp)\n' +
+  '\n' +
+  '```bash\n' +
+  '# a comment\n' +
+  'omarchy theme set "nord" $HOME\n' +
+  '```\n' +
+  'Tail prose.\n',
+  theme
+)
+assertDeepEqual(
+  blocks.map(b => b.kind),
+  ['text', 'text', 'image', 'code', 'text'],
+  'splitBlocks separates paragraphs, images, and fenced code'
+)
+assertEqual(blocks[0].heading, true, 'splitBlocks flags heading blocks')
+assertEqual(blocks[1].heading, false, 'splitBlocks leaves prose unflagged')
+assertEqual(blocks[2].source, 'images/shot.webp', 'splitBlocks captures the image source')
+assertEqual(blocks[2].alt, 'shot', 'splitBlocks captures the image alt text')
+assert(blocks[1].text.includes('inline ![icon]'), 'splitBlocks leaves inline images in prose')
+
+const code = blocks[3]
+assertEqual(code.language, 'bash', 'splitBlocks captures the fence language')
+assert(!code.text.includes('```'), 'splitBlocks strips the fence markers')
+assert(code.html.startsWith('<pre>') && code.html.endsWith('</pre>'), 'code html is a pre block')
+assert(code.html.includes('<span style="color:#707880"># a comment</span>'), 'bash comments render muted')
+assert(code.html.includes('<span style="color:#aabbcc">"nord"</span>'), 'bash strings render in the string color')
+assert(code.html.includes('$HOME</span>'), 'bash variables get a span')
+
+const list = model.splitBlocks('Steps:\n\n1. First\n\n2. Second\n\nDone now.', theme)
+assertEqual(list.length, 2, 'splitBlocks splits trailing prose off a list')
+assert(list[0].text.includes('1. First') && list[0].text.includes('2. Second'),
+  'splitBlocks keeps blank-separated list items in one block')
+
+const bare = model.splitBlocks('Some [link](https://x.y) and `code`.\n\n```bash\nls\n```')
+assertEqual(bare[0].text, 'Some [link](https://x.y) and `code`.', 'splitBlocks without a theme leaves markdown raw')
+assertEqual(bare[1].html, '', 'splitBlocks without a theme skips highlighting')
+
+// ---- source line tracking -------------------------------------------------
+
+assertDeepEqual(blocks.map(b => b.startLine), [1, 3, 5, 7, 11], 'blocks remember their source start line')
+assertEqual(model.blockIndexForLine(blocks, 8), 3, 'blockIndexForLine finds the containing block')
+assertEqual(model.blockIndexForLine(blocks, 1), 0, 'blockIndexForLine handles the first line')
+assertEqual(model.blockIndexForLine(blocks, 99), 4, 'blockIndexForLine clamps past the end to the last block')
+assertEqual(model.blockIndexForLine([], 5), -1, 'blockIndexForLine on no blocks misses cleanly')
+
+// ---- parseSearchResults ---------------------------------------------------
+
+const searchChapters = model.parseChapterIndex('06-themes.md\tThemes\n07-hotkeys.md\tHotkeys\n')
+const found = model.parseSearchResults(
+  '/path/to/manual/06-themes.md:12:## Picking a theme\n' +
+  '/path/to/manual/07-hotkeys.md:3:  - Use `Super + K` freely\n' +
+  '/path/to/manual/99-unknown.md:1:not indexed\n' +
+  'garbage line\n',
+  searchChapters, 50
+)
+assertEqual(found.length, 2, 'parseSearchResults keeps hits in indexed chapters only')
+assertEqual(found[0].chapterIndex, 0, 'parseSearchResults maps files to chapter indexes')
+assertEqual(found[0].line, 12, 'parseSearchResults keeps the line number')
+assertEqual(found[0].title, 'Themes', 'parseSearchResults carries the chapter title')
+assertEqual(found[0].snippet, 'Picking a theme', 'parseSearchResults strips heading markers from snippets')
+assertEqual(found[1].snippet, 'Use `Super + K` freely', 'parseSearchResults trims list markers and whitespace')
+assertEqual(model.parseSearchResults(Array(99).fill('/m/06-themes.md:1:x').join('\n'), searchChapters, 10).length, 10, 'parseSearchResults respects the cap')
+
+// ---- highlightCode --------------------------------------------------------
+
+const plain = model.highlightCode('~ ❯ omarchy capture\nplain output line', '', theme)
+assert(plain.includes('<span style="color:#cacccc;font-weight:bold"> omarchy capture</span>'), 'plain prompt commands render bold')
+assert(plain.includes('\nplain output line'), 'plain output lines stay untouched')
+
+const lua = model.highlightCode('local x = "hi" -- note', 'lua', theme)
+assert(lua.includes('font-weight:bold">local</span>'), 'lua keywords render bold')
+assert(lua.includes('<span style="color:#707880">-- note</span>'), 'lua comments render muted')
+
+const jsonc = model.highlightCode('{\n  // note\n  "key": "value",\n}', 'jsonc', theme)
+assert(jsonc.includes('<span style="color:#707880">// note</span>'), 'jsonc comments render muted')
+assert(jsonc.includes('<span style="color:#aabbcc">&quot;key&quot;</span>') === false, 'sanity: quotes are not html-escaped')
+assert(jsonc.includes('<span style="color:#aabbcc">"key"</span>'), 'json keys take the variable color')
+assert(jsonc.includes('<span style="color:#aabbcc">"value"</span>'), 'json string values take the string color')
+
+const escaped = model.highlightCode('a < b && c > d', '', theme)
+assert(escaped.includes('a &lt; b &amp;&amp; c &gt; d'), 'code html escapes angle brackets and ampersands')
+
+// ---- styleLine ------------------------------------------------------------
+
+assertEqual(
+  model.styleLine('see [docs](https://x.y) now', theme),
+  'see <a href="https://x.y" style="color:#aabbcc">docs</a> now',
+  'styleLine rewrites links into accent-colored anchors'
+)
+assertEqual(
+  model.styleLine('run `omarchy theme set <name>` now', theme),
+  'run <code style="background-color:' + theme.inlineCodeBg + '">omarchy theme set &lt;name&gt;</code> now',
+  'styleLine turns inline code into tinted chips with escaped angle brackets'
+)
+assertEqual(
+  model.styleLine('`a_b*c`', theme),
+  '<code style="background-color:' + theme.inlineCodeBg + '">a\\_b\\*c</code>',
+  'styleLine escapes markdown specials inside chips'
+)
+assertEqual(
+  model.styleLine('code `[x](y)` stays', theme),
+  'code <code style="background-color:' + theme.inlineCodeBg + '">\\[x\\](y)</code> stays',
+  'styleLine keeps link syntax inside chips literal'
+)
+assertEqual(
+  model.styleLine('![alt](images/x.webp)', theme),
+  '![alt](images/x.webp)',
+  'styleLine leaves image syntax alone'
+)
+assertEqual(
+  model.styleLine('[vi](<https://en.wikipedia.org/wiki/Vi_(text_editor)>)', theme),
+  '<a href="https://en.wikipedia.org/wiki/Vi_(text_editor)" style="color:#aabbcc">vi</a>',
+  'styleLine unwraps angle-bracketed URLs'
+)
+assertEqual(
+  model.styleLine('[proton](https://en.wikipedia.org/wiki/Proton_(software))', theme),
+  '<a href="https://en.wikipedia.org/wiki/Proton_(software)" style="color:#aabbcc">proton</a>',
+  'styleLine survives URLs with nested parentheses'
+)
+assertEqual(model.styleLine('see [docs](https://x.y)', null), 'see [docs](https://x.y)', 'styleLine without a theme is a no-op')
+
+// Qt imports `_x_` as underline (md4c's underline extension), so underscore
+// emphasis is normalized to the star form, which imports as italic.
+assertEqual(
+  model.styleLine('under _Remove > Security > Fido2_ in the menu', theme),
+  'under *Remove > Security > Fido2* in the menu',
+  'styleLine converts underscore emphasis to italic star emphasis'
+)
+assertEqual(
+  model.styleLine('both __strong__ and _soft_', theme),
+  'both **strong** and *soft*',
+  'styleLine converts double underscores to star bold'
+)
+assertEqual(
+  model.styleLine('intraword snake_case_name stays', theme),
+  'intraword snake_case_name stays',
+  'styleLine leaves intraword underscores alone'
+)
+assertEqual(
+  model.styleLine('`keep _this_ literal`', theme),
+  '<code style="background-color:' + theme.inlineCodeBg + '">keep \\_this\\_ literal</code>',
+  'styleLine leaves emphasis inside chips literal'
+)
+
+// ---- resolveChapter -------------------------------------------------------
+
+const chapters = model.parseChapterIndex(
+  '06-themes.md\tThemes\n' +
+  '07-hotkeys.md\tHotkeys\n' +
+  '45-troubleshooting.md\tTroubleshooting\n'
+)
+assertEqual(model.resolveChapter(chapters, '7'), 1, 'resolveChapter matches a bare number')
+assertEqual(model.resolveChapter(chapters, '07'), 1, 'resolveChapter matches a zero-padded number')
+assertEqual(model.resolveChapter(chapters, '06-themes.md'), 0, 'resolveChapter matches a filename')
+assertEqual(model.resolveChapter(chapters, 'themes'), 0, 'resolveChapter matches a slug')
+assertEqual(model.resolveChapter(chapters, 'Trouble'), 2, 'resolveChapter matches a title fragment case-insensitively')
+assertEqual(model.resolveChapter(chapters, 'nonexistent'), -1, 'resolveChapter misses cleanly')
+
+// ---- linkTarget -----------------------------------------------------------
+
+assertDeepEqual(model.linkTarget('https://omarchy.org'), { kind: 'external', url: 'https://omarchy.org' }, 'linkTarget passes URLs through')
+assertDeepEqual(model.linkTarget('mailto:x@y.z'), { kind: 'external', url: 'mailto:x@y.z' }, 'linkTarget treats mailto as external')
+assertDeepEqual(model.linkTarget('./06-themes.md#making'), { kind: 'chapter', file: '06-themes.md' }, 'linkTarget resolves relative chapter links')
+assertDeepEqual(model.linkTarget('#anchor'), { kind: 'anchor' }, 'linkTarget recognizes in-page anchors')
+assertEqual(model.linkTarget('images/shot.webp').kind, 'none', 'linkTarget ignores non-chapter relative links')
+
+// ---- against the real manual ----------------------------------------------
+
+const manualDir = path.join(root, 'manual')
+const files = fs.readdirSync(manualDir).filter(f => f.endsWith('.md')).sort()
+assert(files.length > 0, 'the repo ships manual chapters')
+
+const scan = files.map(f => {
+  const text = fs.readFileSync(path.join(manualDir, f), 'utf8')
+  const heading = text.split('\n').find(line => line.startsWith('# '))
+  return f + '\t' + (heading ? heading.slice(2) : '')
+}).join('\n')
+
+const real = model.parseChapterIndex(scan)
+assertEqual(real.length, files.length, 'every manual chapter parses into the index')
+assert(real.every(c => c.title.length > 0), 'every chapter gets a title')
+
+const missing = []
+let unhighlighted = 0
+let unclosedFences = 0
+for (const chapter of real) {
+  const text = fs.readFileSync(path.join(manualDir, chapter.file), 'utf8')
+  for (const block of model.splitBlocks(text, theme)) {
+    if (block.kind === 'code') {
+      if (!block.html.startsWith('<pre>')) unhighlighted++
+      if (block.text.includes('```')) unclosedFences++
+    }
+    if (block.kind !== 'image') continue
+    if (!fs.existsSync(path.join(manualDir, block.source))) missing.push(chapter.file + ': ' + block.source)
+  }
+}
+assertDeepEqual(missing, [], 'every standalone manual image resolves to a shipped file')
+assertEqual(unhighlighted, 0, 'every manual code block gets highlighted html')
+assertEqual(unclosedFences, 0, 'no manual code block swallows a fence marker')
+JS


### PR DESCRIPTION
Native reader for the built-in manual: chapter sidebar, full-text search, themed markdown with highlighted code and scaled screenshots. Opens from Learn > Manual, `omarchy launch manual [chapter]`, or `Super + Ctrl + /`.