### PR TITLE
Make Super+J manage scrolling columns

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,7 +1,21 @@
 o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+local window_layout_dispatchers = {
+  dwindle = hl.dsp.layout("togglesplit"),
+  scrolling = hl.dsp.layout("consume_or_expel prev"),
+}
+
+local function toggle_window_layout()
+  local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()
+  local dispatcher = workspace and window_layout_dispatchers[workspace.tiled_layout]
+
+  if dispatcher then
+    hl.dispatch(dispatcher)
+  end
+end
+
+o.bind("SUPER + J", "Toggle window split / consume or expel", toggle_window_layout)
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -36,6 +36,8 @@ But you can also choose to turn a workspace into the scrolling layout where wind
 
  ![navigation-scrolling-layout](images/navigation-scrolling-layout.webp)
 
+On a scrolling workspace, `Super + J` consumes a window that is alone into the previous column. Use it again to expel the focused window from a stacked column into its own column.
+
 The choice is per workspace, and it sticks. So you can keep workspace 1 on dwindle for browsing and workspace 2 on scrolling for code, and they'll come back that way after a restart. (The same toggle is under _Trigger > Toggle > Workspace Layout_ in the Omarchy menu).
 
 If you wish to use the scrolling layout as the default, you can set that in `~/.config/hypr/looknfeel.lua`:

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -36,7 +36,7 @@ But you can also choose to turn a workspace into the scrolling layout where wind
 
  ![navigation-scrolling-layout](images/navigation-scrolling-layout.webp)
 
-On a scrolling workspace, `Super + J` consumes a window that is alone into the previous column. Use it again to expel the focused window from a stacked column into its own column.
+On a scrolling workspace, `Super + J` moves a window that is alone in its column into the previous column. Press `Super + J` again to move the focused window out of a stacked column into its own column.
 
 The choice is per workspace, and it sticks. So you can keep workspace 1 on dwindle for browsing and workspace 2 on scrolling for code, and they'll come back that way after a restart. (The same toggle is under _Trigger > Toggle > Workspace Layout_ in the Omarchy menu).
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -13,7 +13,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + W`               | Close window             |
 | `Ctrl + Alt + Del` | Close all windows |
 | `Super + T`               | Toggle window between tiling/floating             |
-| `Super + J` | Toggle window position (horizontal/vertical) |
+| `Super + J` | Toggle window position in dwindle / consume or expel in scrolling |
 | `Super + O`               | Toggle popping window into sticky'n'floating |
 | `Super + L`               | Toggle between dwindle and scrolling layout |
 | `Super + P`               | Toggle pseudo window style (natural v stretch) |

--- a/test/shell.d/hyprland-layout-binding-test.sh
+++ b/test/shell.d/hyprland-layout-binding-test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+if ! output=$(OMARCHY_PATH="$ROOT" lua 2>&1 <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return {}
+    end,
+  })
+end
+
+local bindings = {}
+local dispatched = {}
+local workspace
+local special_workspace
+local dsp = proxy()
+
+dsp.layout = function(message)
+  return "layout:" .. message
+end
+
+hl = setmetatable({
+  dsp = dsp,
+  bind = function(keys, dispatcher, opts)
+    bindings[keys] = {
+      dispatcher = dispatcher,
+      description = opts and opts.description,
+    }
+  end,
+  dispatch = function(dispatcher)
+    table.insert(dispatched, dispatcher)
+  end,
+  get_active_workspace = function()
+    return workspace
+  end,
+  get_active_special_workspace = function()
+    return special_workspace
+  end,
+}, {
+  __index = function()
+    return function() end
+  end,
+})
+
+require("default.hypr.helpers")
+require("default.hypr.bindings.tiling")
+
+local binding = assert(bindings["SUPER + J"], "SUPER + J binding is missing")
+assert(binding.description == "Toggle window split / consume or expel", "SUPER + J description changed")
+assert(type(binding.dispatcher) == "function", "SUPER + J dispatcher is not layout-aware")
+
+local function assert_dispatch(regular_layout, special_layout, expected)
+  workspace = regular_layout and { tiled_layout = regular_layout } or nil
+  special_workspace = special_layout and { tiled_layout = special_layout } or nil
+
+  local count = #dispatched
+  binding.dispatcher()
+
+  if expected then
+    assert(#dispatched == count + 1, "expected a dispatcher for " .. (special_layout or regular_layout))
+    assert(dispatched[#dispatched] == expected, "dispatched the wrong layout action")
+  else
+    assert(#dispatched == count, "unexpectedly dispatched for an unsupported workspace")
+  end
+end
+
+assert_dispatch("dwindle", nil, "layout:togglesplit")
+assert_dispatch("scrolling", nil, "layout:consume_or_expel prev")
+assert_dispatch("dwindle", "scrolling", "layout:consume_or_expel prev")
+assert_dispatch("scrolling", "dwindle", "layout:togglesplit")
+assert_dispatch("master", nil, nil)
+assert_dispatch(nil, nil, nil)
+LUA
+); then
+  fail "layout-aware binding assertions failed" "$output"
+fi
+
+[[ -z $output ]] || fail "layout-aware binding produces no output" "$output"
+pass "Super+J dispatches the native action for Dwindle and Scrolling layouts"


### PR DESCRIPTION

Make `Super + J` perform the native window-layout action for the active workspace layout:

- Dwindle continues to dispatch `togglesplit`.
- Scrolling dispatches `consume_or_expel prev`.
- Active special workspaces take precedence over regular workspaces.

This lets the same spatial-layout shortcut toggle window positioning in Dwindle and consume or expel windows in scrolling columns.

The hotkey and navigation manuals now document both behaviors, with regression coverage for regular, special, missing, and unsupported workspace layouts.

Alternative to #6924


https://github.com/user-attachments/assets/fafa239c-c000-4fe3-9d5a-b3b8ab32e9d0

