### PR TITLE
Localize clock bar weekday/month names

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -53,7 +53,9 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    // Qt.formatDateTime() always names days/months in English regardless of
+    // the system locale; Qt.locale().toString() is the locale-aware one.
+    return Qt.locale().toString(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -312,7 +312,7 @@ Panel {
               Text {
                 id: heroDate
                 anchors.verticalCenter: parent.verticalCenter
-                text: Qt.formatDate(root.today, "MMMM d")
+                text: Qt.locale().toString(root.today, "MMMM d")
                 color: heroMouse.containsMouse
                   ? Style.hoverStateColor(root.contentForeground, Color.accent)
                   : root.contentForeground
@@ -713,7 +713,7 @@ Panel {
                 // "MAY 2026" and a "SEPTEMBER 2026".
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.formatDate(root.viewDate, "MMMM yyyy").toUpperCase()
+                text: Qt.locale().toString(root.viewDate, "MMMM yyyy").toUpperCase()
                 color: Qt.darker(root.contentForeground, 1.4)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -185,7 +185,7 @@ assert(/function close\(\) \{\s*\n\s*setCenterHoverRevealSuppressed\(false\)/.te
 assert(/width: Math\.max\(calendarScroll\.width, gridColumn\.width\)/.test(panelSource), 'calendar scrolls rather than clipping the grid on a narrow popup')
 assert(/enabled: !root\.viewingCurrentMonth/.test(panelSource) && /onClicked: root\.goToToday\(\)/.test(panelSource), 'calendar hero returns to today once the view has stepped away')
 assert(!/clampMonth/.test(panelSource), 'calendar steps freely into future months')
-assert(/Qt\.formatDate\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+assert(/Qt\.locale\(\)\.toString\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
 assert(/id: yearLabel/.test(panelSource) && /root\.yearDone/.test(panelSource), 'calendar panel shows the year progress bar')
 
 // The memento mori bar is opt-in: double-tapping the year bar asks for an age,


### PR DESCRIPTION
## Summary
- `omarchy.clock`'s bar label formats dates with `Qt.formatDateTime(date, format)`, but that QML function always spells out day/month names (`dddd`, `MMMM`, ...) in English, regardless of the system locale — a known Qt quirk where format-string tokens ignore `QLocale`.
- Switch to `Qt.locale().toString(date, format)`, the locale-aware equivalent, so the bar clock shows day/month names in the user's configured locale (e.g. "domingo" instead of "Sunday" under `pt_BR.UTF-8`).
- The calendar panel (`Panel.qml`) already does the right thing via `Qt.locale().dayName(...)`; this brings the bar label in line with it.

## Test plan
- [x] `bash test/shell.d/clock-test.sh` passes
- [x] Verified locale behavior directly with `qml6`: `Qt.formatDateTime` printed `Sunday` while `Qt.locale().toString` printed `domingo` under `LANG=pt_BR.UTF-8`
- [x] Confirmed on a running Omarchy shell (via a cloned `omarchy.clock` plugin) that the bar now shows the weekday name in Portuguese