### PR TITLE
Mark the T2 Mac internal trackpad as internal

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -35,6 +35,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-t2-touchpad.sh
+++ b/install/hardware/apple/fix-t2-touchpad.sh
@@ -1,0 +1,39 @@
+# Mark the internal trackpad on T2 Macs as internal.
+#
+# The T2 bridge exposes the built-in keyboard and trackpad over a virtual USB
+# host controller (t2bce_vhci), so the trackpad carries ID_BUS=usb and
+# /usr/lib/udev/rules.d/65-integration.rules classifies it as external. libinput
+# makes disable-while-typing unavailable on external touchpads, so a palm
+# resting on the pad moves the cursor while typing.
+#
+# Nothing reports this as broken, which is what makes it hard to find. The
+# compositor option is set and reads back as enabled, while libinput has no such
+# setting to apply:
+#
+#   $ hyprctl getoption input:touchpad:disable_while_typing
+#   int: 1
+#   $ libinput list-devices | grep -A20 Trackpad | grep Disable-w-typing
+#   Disable-w-typing:  n/a
+#
+# 70-touchpad.rules runs after 65-integration.rules precisely so hwdb entries can
+# override the bus-based guess, so this is the supported correction rather than a
+# workaround. Same class of bug as install/hardware/asus/fix-z13-touchpad.sh,
+# where a detachable keyboard's touchpad is also detected as external.
+#
+# Matched on the USB ID the bridged keyboard/trackpad enumerates with, verified
+# on a MacBookPro16,1. Other T2 models may report a different product ID; widen
+# the match as they are reported rather than guessing at the range here.
+
+if lspci -nn | grep "106b:180[12]" >/dev/null; then
+  echo "Detected a T2 Mac; marking its internal trackpad as internal"
+
+  mkdir -p /etc/udev/hwdb.d
+  cat > /etc/udev/hwdb.d/70-omarchy-t2-touchpad.hwdb <<'EOF'
+# Apple internal keyboard/trackpad, bridged over the T2's virtual USB HCI.
+touchpad:usb:v05acp0340:*
+ ID_INPUT_TOUCHPAD_INTEGRATION=internal
+EOF
+
+  # Compiles the text entry into the binary database udev actually reads.
+  systemd-hwdb update
+fi

--- a/migrations/1786910195.sh
+++ b/migrations/1786910195.sh
@@ -1,0 +1,31 @@
+echo "Mark the internal trackpad on T2 Macs as internal so disable-while-typing works"
+
+# The install-time fix only reaches machines set up after it shipped, so an
+# existing T2 install still has palms moving the cursor while typing. See
+# install/hardware/apple/fix-t2-touchpad.sh for the failure and why the hwdb is
+# the right place to correct it.
+hwdb="${OMARCHY_T2_TOUCHPAD_HWDB:-/etc/udev/hwdb.d/70-omarchy-t2-touchpad.hwdb}"
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
+  exit 0
+fi
+
+# Machine-wide repair, so the second user on a T2 Mac finds it already done.
+if [[ -f $hwdb ]] && grep -q '^ ID_INPUT_TOUCHPAD_INTEGRATION=internal$' "$hwdb"; then
+  exit 0
+fi
+
+sudo mkdir -p "$(dirname "$hwdb")"
+sudo tee "$hwdb" >/dev/null <<'EOF'
+# Apple internal keyboard/trackpad, bridged over the T2's virtual USB HCI.
+touchpad:usb:v05acp0340:*
+ ID_INPUT_TOUCHPAD_INTEGRATION=internal
+EOF
+
+sudo systemd-hwdb update
+
+# libinput builds a device's configuration when udev adds the device, so the
+# running session keeps the object it created at login, when the trackpad was
+# still tagged external. Logging out and back in is enough; a reboot is the
+# signal Omarchy has, and it also works.
+omarchy-state set reboot-required

--- a/test/shell.d/t2-touchpad-test.sh
+++ b/test/shell.d/t2-touchpad-test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-t2-touchpad.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1786910195.sh"
+
+grep -q 'apple/fix-t2-touchpad.sh' "$all" ||
+  fail "the trackpad fix runs during hardware setup"
+
+# The property line must keep its leading space: hwdb treats an unindented line
+# as a new match, so losing it turns the property into a match that never fires
+# and the file stops doing anything without failing.
+grep -q '^ ID_INPUT_TOUCHPAD_INTEGRATION=internal$' "$leaf" ||
+  fail "the hwdb property stays indented under its match"
+pass "the trackpad fix is orchestrated and its hwdb entry is well formed"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+hwdb="$test_tmp/etc/udev/hwdb.d/70-omarchy-t2-touchpad.hwdb"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no T2 hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/systemd-hwdb" <<'SH'
+#!/bin/bash
+
+printf 'systemd-hwdb' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+"$@"
+SH
+
+# Stubbed rather than run: the real one would write the running user's state.
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+# The leaf writes to an absolute path, so redirect it into the sandbox. pipefail
+# is on, the context the SIGPIPE gate in #6608 was about.
+run_leaf() {
+  local t2="${1:-0}"
+  rm -rf "$test_tmp/etc"
+  : >"$calls"
+
+  local script="$test_tmp/leaf.sh"
+  sed -e "s|/etc/udev/hwdb.d|$test_tmp/etc/udev/hwdb.d|g" "$leaf" >"$script"
+
+  T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+run_leaf 1 >/dev/null
+grep -q '^touchpad:usb:v05acp0340:\*$' "$hwdb" 2>/dev/null ||
+  fail "a T2 Mac gets the trackpad hwdb entry" "$(ls -R "$test_tmp/etc" 2>&1)"
+grep -Fq $'systemd-hwdb\tupdate' "$calls" ||
+  fail "the hwdb text entry is compiled into the binary database" "$(cat "$calls")"
+pass "a T2 Mac gets the trackpad hwdb entry"
+
+run_leaf 0 >/dev/null
+[[ ! -e $hwdb ]] || fail "non-T2 hardware is left alone" "$(cat "$hwdb")"
+[[ ! -s $calls ]] || fail "non-T2 hardware compiles nothing" "$(cat "$calls")"
+pass "non-T2 hardware is left alone"
+
+# Installs that predate the fix never ran the leaf, so the migration has to
+# reach them.
+run_migration() {
+  local t2="${1:-1}"
+  : >"$calls"
+
+  T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_T2_TOUCHPAD_HWDB="$hwdb" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc"
+run_migration 1
+grep -q '^ ID_INPUT_TOUCHPAD_INTEGRATION=internal$' "$hwdb" 2>/dev/null ||
+  fail "the migration fixes a T2 install that never got the entry" "$(ls -R "$test_tmp/etc" 2>&1)"
+# libinput only rebuilds the device on a udev add, which the running session
+# will not see.
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the session restart that applies it" "$(cat "$calls")"
+pass "the migration fixes a T2 install that never got the entry"
+
+run_migration 1
+[[ ! -s $calls ]] || fail "a repaired install is left untouched" "$(cat "$calls")"
+pass "the migration is machine-idempotent across users"
+
+# A half-written file from an interrupted run is not a repaired install.
+printf 'touchpad:usb:v05acp0340:*\n' >"$hwdb"
+run_migration 1
+grep -q '^ ID_INPUT_TOUCHPAD_INTEGRATION=internal$' "$hwdb" ||
+  fail "a match with no property is rewritten" "$(cat "$hwdb")"
+pass "a match with no property is rewritten"
+
+rm -rf "$test_tmp/etc"
+run_migration 0
+[[ ! -e $hwdb ]] || fail "the migration skips unrelated hardware" "$(cat "$hwdb")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unrelated hardware" "$(cat "$calls")"
+pass "the migration skips unrelated hardware"


### PR DESCRIPTION
On a T2 MacBook, palms resting on the trackpad move the cursor while typing. `input:touchpad:disable_while_typing` is set and reads back as enabled, and it has never done anything.

## Why

The T2 bridge exposes the built-in keyboard and trackpad over a virtual USB host controller (`t2bce_vhci`), so the trackpad carries `ID_BUS=usb` and `/usr/lib/udev/rules.d/65-integration.rules` classifies it as an external touchpad. libinput makes disable-while-typing unavailable on external touchpads, so there is nothing under the compositor option to act on:

```
$ hyprctl getoption input:touchpad:disable_while_typing
int: 1
$ libinput list-devices | grep -A20 Trackpad | grep Disable-w-typing
Disable-w-typing:  n/a
```

Both are true at once, which is what makes this hard to find. Nothing reports an error; the setting simply has no effect.

## Fix

An hwdb entry correcting the classification. `70-touchpad.rules` runs after `65-integration.rules` precisely so hwdb entries can override the bus-based guess, so this is the supported correction rather than a workaround.

This is the same class of bug as `install/hardware/asus/fix-z13-touchpad.sh`, where a detachable keyboard's touchpad is also detected as external.

A migration carries the fix to installs that predate it, since the install leaf only reaches machines set up after it ships. It is a machine-wide repair, so a second user on the same laptop finds it already done.

## Scope

Matched on the USB ID the bridged keyboard/trackpad enumerates with (`05ac:0340`), verified on a MacBookPro16,1. Other T2 models may enumerate a different product ID, so the match is deliberately narrow rather than a guessed range; widening it as models are reported is one line.

I also tested a udev rule matching on `ATTRS{phys}=="usb-t2bce_vhci*"`, which would cover every T2 Mac regardless of product ID. It sets `ID_INPUT_TOUCHPAD_INTEGRATION` correctly and tags no keyboard node, but leaves `ID_INTEGRATION=external` where the hwdb path flips both. I did not confirm that libinput then offers disable-while-typing, so I have not proposed it here. Happy to pursue it if you would prefer the broader match.

## Testing

`test/shell.d/t2-touchpad-test.sh` covers the leaf and the migration with stubbed `lspci`/`systemd-hwdb`, including that the hwdb property keeps its leading space (an unindented line becomes a match that never fires, so the file would silently stop working).

```
$ bash test/shell.d/t2-touchpad-test.sh
ok - the trackpad fix is orchestrated and its hwdb entry is well formed
ok - a T2 Mac gets the trackpad hwdb entry
ok - non-T2 hardware is left alone
ok - the migration fixes a T2 install that never got the entry
ok - the migration is machine-idempotent across users
ok - a match with no property is rewritten
ok - the migration skips unrelated hardware
```

`t2-hardware-test.sh`, `brcmfmac-supplicant-test.sh` and `./test/cli` still pass.

Verified on the machine itself: with the entry installed and after a fresh login, `Disable-w-typing` reports `enabled` and palms resting on the pad no longer move the cursor.

## Not included

Lowering `AttrPalmSizeThreshold` also helps, but the value I measured is specific to this trackpad's geometry and could cause false rejections on models nobody has measured, so it is left out.