### PR TITLE
Stop the lock screen overheating the fingerprint reader

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -31,6 +31,21 @@ Item {
   readonly property int fingerprintRetryMaxMs: 30000
   readonly property int fingerprintFastErrorMs: 2000
   readonly property int fingerprintNudgeCooldownMs: 2000
+  // libfprint models sensor heat as an exponential duty cycle (fpi-device.c):
+  // the ratio rises toward 1 with a 180s constant while the reader is armed and
+  // decays with a 540s one while it is idle, the device is refused above 0.731,
+  // and that refusal latches until the ratio falls back under 0.5. An unswiped
+  // verify holds the reader armed for its whole timeout, so re-arming on
+  // completion is a 100% duty cycle and trips the limit ~3 minutes into a lock.
+  // Track the same ratio and stop short of the latch threshold.
+  readonly property real thermalHeatSeconds: 180
+  readonly property real thermalCoolSeconds: 540
+  readonly property real thermalArmCeiling: 0.5
+  // libfprint assumes a device starts at the top of its COLD band.
+  property real thermalRatio: 0.269
+  property double thermalUpdatedAt: 0
+  property bool thermalArmed: false
+  property bool displayBlanked: false
   property string enteredPassword: ""
   property string pendingPassword: ""
   property string failureMessage: ""
@@ -131,6 +146,10 @@ Item {
     fingerprintErrorStreak = 0
     fingerprintAttemptErrored = false
     fingerprintNudgedAt = 0
+    displayBlanked = false
+    // The heat estimate deliberately survives: it tracks the device, not the
+    // lock session, and unlocking does not cool the sensor.
+    updateThermalRatio(false)
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
@@ -176,9 +195,14 @@ Item {
   }
 
   function runWake() {
+    var wasBlanked = displayBlanked
+    displayBlanked = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
-    nudgeFingerprint()
+    // Unblanking is the user arriving: the reader has been cooling and should
+    // be armed now, not after whatever backoff was pending when we blanked.
+    if (wasBlanked) startFingerprint()
+    else nudgeFingerprint()
   }
 
   // Backing off is right while nobody is there, but it leaves the reader
@@ -198,6 +222,11 @@ Item {
   }
 
   function runBlank() {
+    displayBlanked = true
+    // Nobody is there to swipe, so let the reader sit idle and cool.
+    if (fingerprintPam.active) fingerprintPam.abort()
+    fingerprintRetryTimer.stop()
+    updateThermalRatio(false)
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -234,16 +263,59 @@ Item {
     runWake()
   }
 
+  // Integrates the heat estimate up to now under the previous armed state, then
+  // records the new one. Every arm and disarm has to pass through here or the
+  // estimate drifts away from what libfprint is charging us.
+  function updateThermalRatio(armed) {
+    var now = Date.now()
+
+    if (thermalUpdatedAt > 0) {
+      var passed = (now - thermalUpdatedAt) / 1000
+      if (passed > 0) {
+        if (thermalArmed) {
+          var heat = Math.exp(-passed / thermalHeatSeconds)
+          thermalRatio = heat * thermalRatio + 1 - heat
+        } else {
+          thermalRatio = Math.exp(-passed / thermalCoolSeconds) * thermalRatio
+        }
+      }
+    }
+
+    thermalArmed = armed
+    thermalUpdatedAt = now
+  }
+
+  // Idle time needed to bring the estimate back under the ceiling.
+  function thermalCooldownMs() {
+    if (thermalRatio <= thermalArmCeiling) return 0
+    return Math.ceil(thermalCoolSeconds * Math.log(thermalRatio / thermalArmCeiling) * 1000)
+  }
+
   function startFingerprint() {
     if (!lockRequested || !sessionLock.secure || !fingerprintConfigured) return
     if (fingerprintPam.active || fingerprintAuthenticating) return
+    // A blanked display means nobody is watching, and an armed reader with
+    // nobody to swipe it is pure heat. Waking re-arms it.
+    if (displayBlanked) return
+
+    updateThermalRatio(false)
+    var cooldown = thermalCooldownMs()
+    if (cooldown > 0) {
+      fingerprintRetryTimer.interval = cooldown
+      fingerprintRetryTimer.restart()
+      return
+    }
 
     fingerprintAuthenticating = true
     fingerprintAttemptErrored = false
     fingerprintAttemptStartedAt = Date.now()
     if (!fingerprintPam.start()) {
       fingerprintAuthenticating = false
+      updateThermalRatio(false)
+      return
     }
+
+    updateThermalRatio(true)
   }
 
   function fingerprintRetryDelay(streak) {
@@ -274,7 +346,8 @@ Item {
       fingerprintErrorStreak = 0
     }
 
-    fingerprintRetryTimer.interval = fingerprintRetryDelay(fingerprintErrorStreak)
+    updateThermalRatio(false)
+    fingerprintRetryTimer.interval = Math.max(fingerprintRetryDelay(fingerprintErrorStreak), thermalCooldownMs())
     fingerprintRetryTimer.restart()
   }
 
@@ -282,6 +355,7 @@ Item {
     fingerprintAuthenticating = false
 
     if (!lockRequested) return
+    updateThermalRatio(false)
     if (result === PamResult.Success) {
       fingerprintErrorStreak = 0
       fingerprintAttemptErrored = false

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -223,8 +223,11 @@ Item {
 
   function runBlank() {
     displayBlanked = true
-    // Nobody is there to swipe, so let the reader sit idle and cool.
+    // Nobody is there to swipe, so let the reader sit idle and cool. Aborting
+    // does not raise completed, so the in-flight flag has to be cleared here or
+    // every later arm returns early against an attempt that is already gone.
     if (fingerprintPam.active) fingerprintPam.abort()
+    fingerprintAuthenticating = false
     fingerprintRetryTimer.stop()
     updateThermalRatio(false)
     if (!blankProcess.running) blankProcess.running = true

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -31,17 +31,15 @@ Item {
   readonly property int fingerprintRetryMaxMs: 30000
   readonly property int fingerprintFastErrorMs: 2000
   readonly property int fingerprintNudgeCooldownMs: 2000
-  // libfprint models sensor heat as an exponential duty cycle (fpi-device.c):
-  // the ratio rises toward 1 with a 180s constant while the reader is armed and
-  // decays with a 540s one while it is idle, the device is refused above 0.731,
-  // and that refusal latches until the ratio falls back under 0.5. An unswiped
-  // verify holds the reader armed for its whole timeout, so re-arming on
-  // completion is a 100% duty cycle and trips the limit ~3 minutes into a lock.
-  // Track the same ratio and stop short of the latch threshold.
+  // libfprint charges for time the reader is armed, not time a finger is on it
+  // (fpi-device.c): a ratio rising toward 1 at 180s and decaying at 540s, cut
+  // off above 0.731 until it falls back under 0.5. An unswiped verify stays
+  // armed for its whole timeout, so re-arming on completion is a 100% duty
+  // cycle and trips the cut-off ~3 minutes in. Track the ratio and stop short.
   readonly property real thermalHeatSeconds: 180
   readonly property real thermalCoolSeconds: 540
   readonly property real thermalArmCeiling: 0.5
-  // libfprint assumes a device starts at the top of its COLD band.
+  // Where libfprint starts a device: the top of its COLD band.
   property real thermalRatio: 0.269
   property double thermalUpdatedAt: 0
   property bool thermalArmed: false
@@ -147,8 +145,7 @@ Item {
     fingerprintAttemptErrored = false
     fingerprintNudgedAt = 0
     displayBlanked = false
-    // The heat estimate deliberately survives: it tracks the device, not the
-    // lock session, and unlocking does not cool the sensor.
+    // The estimate tracks the device, not the session; unlocking cools nothing.
     updateThermalRatio(false)
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
@@ -199,17 +196,14 @@ Item {
     displayBlanked = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
-    // Unblanking is the user arriving: the reader has been cooling and should
-    // be armed now, not after whatever backoff was pending when we blanked.
+    // Unblanking is the user arriving, so arm now rather than after a backoff.
     if (wasBlanked) startFingerprint()
     else nudgeFingerprint()
   }
 
-  // Backing off is right while nobody is there, but it leaves the reader
-  // unarmed for up to the ceiling, so someone who walks up and swipes gets
-  // nothing. Any sign of the user is a reason to try again now. The streak
-  // survives, so a still-wedged reader keeps its long gaps, and the cooldown
-  // stops a moving cursor from spinning the loop back up.
+  // Any sign of the user cuts the backoff short. The streak survives so a still
+  // wedged reader keeps its long gaps, and the cooldown stops a moving cursor
+  // from spinning the loop back up.
   function nudgeFingerprint() {
     if (!lockRequested || !fingerprintConfigured) return
     if (fingerprintAuthenticating || fingerprintPam.active) return
@@ -223,9 +217,8 @@ Item {
 
   function runBlank() {
     displayBlanked = true
-    // Nobody is there to swipe, so let the reader sit idle and cool. Aborting
-    // does not raise completed, so the in-flight flag has to be cleared here or
-    // every later arm returns early against an attempt that is already gone.
+    // Let the reader cool while nobody is there. Aborting raises no completed,
+    // so clear the in-flight flag here or every later arm returns early.
     if (fingerprintPam.active) fingerprintPam.abort()
     fingerprintAuthenticating = false
     fingerprintRetryTimer.stop()
@@ -266,9 +259,8 @@ Item {
     runWake()
   }
 
-  // Integrates the heat estimate up to now under the previous armed state, then
-  // records the new one. Every arm and disarm has to pass through here or the
-  // estimate drifts away from what libfprint is charging us.
+  // Integrates up to now under the previous armed state. Every arm and disarm
+  // has to pass through here or the estimate drifts from libfprint's.
   function updateThermalRatio(armed) {
     var now = Date.now()
 
@@ -288,7 +280,6 @@ Item {
     thermalUpdatedAt = now
   }
 
-  // Idle time needed to bring the estimate back under the ceiling.
   function thermalCooldownMs() {
     if (thermalRatio <= thermalArmCeiling) return 0
     return Math.ceil(thermalCoolSeconds * Math.log(thermalRatio / thermalArmCeiling) * 1000)
@@ -297,8 +288,7 @@ Item {
   function startFingerprint() {
     if (!lockRequested || !sessionLock.secure || !fingerprintConfigured) return
     if (fingerprintPam.active || fingerprintAuthenticating) return
-    // A blanked display means nobody is watching, and an armed reader with
-    // nobody to swipe it is pure heat. Waking re-arms it.
+    // An armed reader with nobody to swipe it is pure heat; waking re-arms it.
     if (displayBlanked) return
 
     updateThermalRatio(false)
@@ -326,14 +316,10 @@ Item {
     return Math.min(fingerprintRetryBaseMs * Math.pow(2, streak - 1), fingerprintRetryMaxMs)
   }
 
-  // A device error (fprintd down, reader thermally throttled) returns instantly
-  // and keeps returning instantly, so retrying at the base interval spins as
-  // fast as PAM sessions can be created and never lets the reader recover.
-  // Back those off. A swipe that timed out reports the same PAM code but only
-  // after the full wait, so elapsed time is what separates the two -- backing
-  // off on a timeout would leave the reader unarmed when the user does swipe.
-  // A failed attempt raises both error and completed, so the device error has
-  // to win the attempt no matter which signal arrives first.
+  // A broken reader errors instantly and repeats, so back those off. A swipe
+  // timeout reports the same PAM code after the full wait, so elapsed time is
+  // what separates them. A failed attempt raises both error and completed, so
+  // the device error has to win the attempt whichever arrives first.
   function scheduleFingerprintRetry(isDeviceError) {
     if (!lockRequested || !fingerprintConfigured) return
 
@@ -357,8 +343,8 @@ Item {
   function handleFingerprintFinished(result) {
     fingerprintAuthenticating = false
 
-    if (!lockRequested) return
     updateThermalRatio(false)
+    if (!lockRequested) return
     if (result === PamResult.Success) {
       fingerprintErrorStreak = 0
       fingerprintAttemptErrored = false

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -24,8 +24,11 @@ Item {
   property bool fingerprintConfigured: false
   property bool previewVisible: false
   property int fingerprintErrorStreak: 0
+  property bool fingerprintAttemptErrored: false
+  property double fingerprintAttemptStartedAt: 0
   readonly property int fingerprintRetryBaseMs: 250
   readonly property int fingerprintRetryMaxMs: 30000
+  readonly property int fingerprintFastErrorMs: 2000
   property string enteredPassword: ""
   property string pendingPassword: ""
   property string failureMessage: ""
@@ -124,6 +127,7 @@ Item {
     authenticatingPassword = false
     fingerprintAuthenticating = false
     fingerprintErrorStreak = 0
+    fingerprintAttemptErrored = false
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
@@ -215,6 +219,8 @@ Item {
     if (fingerprintPam.active || fingerprintAuthenticating) return
 
     fingerprintAuthenticating = true
+    fingerprintAttemptErrored = false
+    fingerprintAttemptStartedAt = Date.now()
     if (!fingerprintPam.start()) {
       fingerprintAuthenticating = false
     }
@@ -225,16 +231,28 @@ Item {
     return Math.min(fingerprintRetryBaseMs * Math.pow(2, streak - 1), fingerprintRetryMaxMs)
   }
 
-  // A device error (fprintd down, reader thermally throttled) returns
-  // instantly and keeps returning instantly, so retrying at the base interval
-  // spins as fast as PAM sessions can be created and never lets the reader
-  // recover. Back those off; a swipe that just didn't match is a real attempt
-  // and keeps the responsive base delay.
+  // A device error (fprintd down, reader thermally throttled) returns instantly
+  // and keeps returning instantly, so retrying at the base interval spins as
+  // fast as PAM sessions can be created and never lets the reader recover.
+  // Back those off. A swipe that timed out reports the same PAM code but only
+  // after the full wait, so elapsed time is what separates the two -- backing
+  // off on a timeout would leave the reader unarmed when the user does swipe.
+  // A failed attempt raises both error and completed, so the device error has
+  // to win the attempt no matter which signal arrives first.
   function scheduleFingerprintRetry(isDeviceError) {
     if (!lockRequested || !fingerprintConfigured) return
 
-    if (isDeviceError) fingerprintErrorStreak += 1
-    else fingerprintErrorStreak = 0
+    var fast = Date.now() - fingerprintAttemptStartedAt < fingerprintFastErrorMs
+
+    if (isDeviceError && fast) {
+      if (fingerprintAttemptErrored) return
+      fingerprintAttemptErrored = true
+      fingerprintErrorStreak += 1
+    } else if (fingerprintAttemptErrored) {
+      return
+    } else {
+      fingerprintErrorStreak = 0
+    }
 
     fingerprintRetryTimer.interval = fingerprintRetryDelay(fingerprintErrorStreak)
     fingerprintRetryTimer.restart()
@@ -246,6 +264,7 @@ Item {
     if (!lockRequested) return
     if (result === PamResult.Success) {
       fingerprintErrorStreak = 0
+      fingerprintAttemptErrored = false
       finishUnlock()
     } else if (fingerprintConfigured) {
       scheduleFingerprintRetry(false)

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -23,6 +23,9 @@ Item {
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
   property bool previewVisible: false
+  property int fingerprintErrorStreak: 0
+  readonly property int fingerprintRetryBaseMs: 250
+  readonly property int fingerprintRetryMaxMs: 30000
   property string enteredPassword: ""
   property string pendingPassword: ""
   property string failureMessage: ""
@@ -120,6 +123,7 @@ Item {
     failedAttempts = 0
     authenticatingPassword = false
     fingerprintAuthenticating = false
+    fingerprintErrorStreak = 0
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
@@ -216,14 +220,35 @@ Item {
     }
   }
 
+  function fingerprintRetryDelay(streak) {
+    if (streak <= 0) return fingerprintRetryBaseMs
+    return Math.min(fingerprintRetryBaseMs * Math.pow(2, streak - 1), fingerprintRetryMaxMs)
+  }
+
+  // A device error (fprintd down, reader thermally throttled) returns
+  // instantly and keeps returning instantly, so retrying at the base interval
+  // spins as fast as PAM sessions can be created and never lets the reader
+  // recover. Back those off; a swipe that just didn't match is a real attempt
+  // and keeps the responsive base delay.
+  function scheduleFingerprintRetry(isDeviceError) {
+    if (!lockRequested || !fingerprintConfigured) return
+
+    if (isDeviceError) fingerprintErrorStreak += 1
+    else fingerprintErrorStreak = 0
+
+    fingerprintRetryTimer.interval = fingerprintRetryDelay(fingerprintErrorStreak)
+    fingerprintRetryTimer.restart()
+  }
+
   function handleFingerprintFinished(result) {
     fingerprintAuthenticating = false
 
     if (!lockRequested) return
     if (result === PamResult.Success) {
+      fingerprintErrorStreak = 0
       finishUnlock()
     } else if (fingerprintConfigured) {
-      fingerprintRetryTimer.restart()
+      scheduleFingerprintRetry(false)
     }
   }
 
@@ -349,13 +374,13 @@ Item {
 
     onError: function(error) {
       root.fingerprintAuthenticating = false
-      if (root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
+      root.scheduleFingerprintRetry(true)
     }
   }
 
   Timer {
     id: fingerprintRetryTimer
-    interval: 250
+    interval: root.fingerprintRetryBaseMs
     repeat: false
     onTriggered: root.startFingerprint()
   }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -26,9 +26,11 @@ Item {
   property int fingerprintErrorStreak: 0
   property bool fingerprintAttemptErrored: false
   property double fingerprintAttemptStartedAt: 0
+  property double fingerprintNudgedAt: 0
   readonly property int fingerprintRetryBaseMs: 250
   readonly property int fingerprintRetryMaxMs: 30000
   readonly property int fingerprintFastErrorMs: 2000
+  readonly property int fingerprintNudgeCooldownMs: 2000
   property string enteredPassword: ""
   property string pendingPassword: ""
   property string failureMessage: ""
@@ -128,6 +130,7 @@ Item {
     fingerprintAuthenticating = false
     fingerprintErrorStreak = 0
     fingerprintAttemptErrored = false
+    fingerprintNudgedAt = 0
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
@@ -175,6 +178,23 @@ Item {
   function runWake() {
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
+    nudgeFingerprint()
+  }
+
+  // Backing off is right while nobody is there, but it leaves the reader
+  // unarmed for up to the ceiling, so someone who walks up and swipes gets
+  // nothing. Any sign of the user is a reason to try again now. The streak
+  // survives, so a still-wedged reader keeps its long gaps, and the cooldown
+  // stops a moving cursor from spinning the loop back up.
+  function nudgeFingerprint() {
+    if (!lockRequested || !fingerprintConfigured) return
+    if (fingerprintAuthenticating || fingerprintPam.active) return
+    if (!fingerprintRetryTimer.running) return
+    if (Date.now() - fingerprintNudgedAt < fingerprintNudgeCooldownMs) return
+
+    fingerprintNudgedAt = Date.now()
+    fingerprintRetryTimer.stop()
+    startFingerprint()
   }
 
   function runBlank() {

--- a/test/shell.d/lock-fingerprint-backoff-test.sh
+++ b/test/shell.d/lock-fingerprint-backoff-test.sh
@@ -48,6 +48,10 @@ const makeService = () => {
 
   state.Date = { now: () => state.clock }
   state.Math = Math
+  // The backoff cases all assume a sensor with heat to spare; the thermal cases
+  // below swap these for the real bodies.
+  state.updateThermalRatio = () => {}
+  state.thermalCooldownMs = () => 0
   state.fingerprintRetryDelay = new Function(
     'streak',
     `with (this) { ${delayBody} }`
@@ -199,5 +203,165 @@ assert(
 assert(
   !/interval: 250/.test(serviceQml),
   'the retry timer interval is not hardcoded alongside the backoff'
+)
+
+// libfprint's own model, from fpi-device.c. The lock screen has to stay under
+// this, so the assertions below run the real arming policy against it rather
+// than against a restatement of the policy's own arithmetic.
+const LIBFPRINT = {
+  heatSeconds: 180,
+  coolSeconds: 540,
+  // TEMP_WARM_HOT_THRESH: the device starts refusing here...
+  hotThresh: 1 - 0.26894142136999512075,
+  // ...and TEMP_HOT_WARM_THRESH: the refusal latches until it falls back here.
+  clearThresh: 0.5,
+  startRatio: 0.26894142136999512075,
+}
+
+const reals = {}
+const real = (name) => {
+  if (!(name in reals)) {
+    reals[name] = Number(capture(
+      new RegExp(`readonly property real ${name}: ([\\d.]+)`),
+      `${name} is declared`
+    ))
+  }
+  return reals[name]
+}
+
+assert(
+  real('thermalHeatSeconds') === LIBFPRINT.heatSeconds,
+  'the heating constant tracks libfprint'
+)
+assert(
+  real('thermalCoolSeconds') === LIBFPRINT.coolSeconds,
+  'the cooling constant tracks libfprint'
+)
+assert(
+  real('thermalArmCeiling') <= LIBFPRINT.clearThresh,
+  'the arming ceiling stays at or below the threshold that clears a latched refusal'
+)
+
+const updateBody = capture(
+  /function updateThermalRatio\(armed\) \{([\s\S]*?)\n  \}/,
+  'the heat estimate is integrated by updateThermalRatio()'
+)
+const cooldownBody = capture(
+  /function thermalCooldownMs\(\) \{([\s\S]*?)\n  \}/,
+  'the wait for a cool sensor is computed by thermalCooldownMs()'
+)
+
+// Drives the real policy and an independent libfprint model off one clock. Only
+// `armSeconds` of each cycle is time the reader is actually held open, which is
+// the sole thing either model charges for.
+const simulate = ({ armSeconds, minutes, gated }) => {
+  const service = makeService()
+  service.clock = 1e9
+  service.thermalHeatSeconds = real('thermalHeatSeconds')
+  service.thermalCoolSeconds = real('thermalCoolSeconds')
+  service.thermalArmCeiling = real('thermalArmCeiling')
+  service.thermalRatio = LIBFPRINT.startRatio
+  service.thermalUpdatedAt = 0
+  service.thermalArmed = false
+  service.updateThermalRatio = new Function('armed', `with (this) { ${updateBody} }`).bind(service)
+  service.thermalCooldownMs = new Function(`with (this) { ${cooldownBody} }`).bind(service)
+
+  let fp = LIBFPRINT.startRatio
+  let hot = false
+  let everHot = false
+  let armedMs = 0
+  let maxGapMs = 0
+  let gapMs = 0
+  const advance = (ms, armed) => {
+    if (armed) gapMs = 0
+    else {
+      gapMs += ms
+      if (gapMs > maxGapMs) maxGapMs = gapMs
+    }
+    const seconds = ms / 1000
+    if (armed) {
+      const a = Math.exp(-seconds / LIBFPRINT.heatSeconds)
+      fp = a * fp + 1 - a
+      armedMs += ms
+    } else {
+      fp = Math.exp(-seconds / LIBFPRINT.coolSeconds) * fp
+    }
+    if (fp >= LIBFPRINT.hotThresh) hot = true
+    else if (hot && fp < LIBFPRINT.clearThresh) hot = false
+    if (hot) everHot = true
+    service.clock += ms
+  }
+
+  const deadline = service.clock + minutes * 60000
+  while (service.clock < deadline) {
+    service.updateThermalRatio(false)
+    const wait = gated ? service.thermalCooldownMs() : 0
+    if (wait > 0) {
+      advance(wait, false)
+      continue
+    }
+    service.updateThermalRatio(true)
+    advance(armSeconds * 1000, true)
+    service.updateThermalRatio(false)
+  }
+
+  return { everHot, maxGapMs, duty: armedMs / (minutes * 60000), peak: fp }
+}
+
+// The bug: an unswiped verify holds the reader open for its full timeout and the
+// lock screen re-arms the moment it returns, so the reader is armed essentially
+// all the time and libfprint cuts it off about three minutes into every lock.
+const ungated = simulate({ armSeconds: 30, minutes: 60, gated: false })
+assert(
+  ungated.everHot,
+  're-arming on completion overheats the reader, so the guard has something to prevent'
+)
+
+// The fix, under the worst case the guard has to survive: someone sitting at an
+// unblanked lock screen for an hour who never once touches the reader.
+const gated = simulate({ armSeconds: 30, minutes: 60, gated: true })
+assert(
+  !gated.everHot,
+  `the arming ceiling keeps libfprint below its cutoff, peaked at ${gated.peak.toFixed(3)}`
+)
+assert(
+  gated.duty < 0.475,
+  `the duty cycle stays under what libfprint tolerates, got ${(gated.duty * 100).toFixed(1)}%`
+)
+
+// The ceiling rations total armed time, so the duty cycle settles in the same
+// place whatever the arm length -- what changes is how long a user can be left
+// waiting. Attempts that end quickly have to keep the reader responsive.
+const brief = simulate({ armSeconds: 2, minutes: 60, gated: true })
+assert(!brief.everHot, 'short attempts stay under the cutoff too')
+assert(
+  brief.maxGapMs < 15000,
+  `quick attempts leave the reader responsive, waited ${(brief.maxGapMs / 1000).toFixed(1)}s`
+)
+// The worst gap belongs to the case the nudge and the blanking gate exist to
+// cover: a full unswiped timeout at an unblanked screen.
+assert(
+  gated.maxGapMs < 120000,
+  `a full timeout still re-arms within two minutes, waited ${(gated.maxGapMs / 1000).toFixed(1)}s`
+)
+
+// The cheapest fix is not arming the reader when nobody is in front of it. That
+// is what keeps it cold for the case that actually matters -- the user walking
+// up to a blanked screen.
+assert(
+  /function startFingerprint\(\) \{[\s\S]*?if \(displayBlanked\) return/.test(serviceQml),
+  'a blanked display does not arm the reader'
+)
+assert(
+  /function runBlank\(\) \{[\s\S]*?fingerprintRetryTimer\.stop\(\)/.test(serviceQml),
+  'blanking cancels a pending re-arm instead of letting it fire at a dark screen'
+)
+assert(
+  /function runWake\(\) \{[\s\S]*?wasBlanked[\s\S]*?startFingerprint\(\)/.test(serviceQml),
+  'unblanking arms the reader immediately rather than waiting out a backoff'
+)
+assert(
+  /function scheduleFingerprintRetry\([\s\S]*?Math\.max\(fingerprintRetryDelay\(fingerprintErrorStreak\), thermalCooldownMs\(\)\)/.test(serviceQml),
+  'a scheduled retry never fires earlier than the sensor can take it'
 )
 JS

--- a/test/shell.d/lock-fingerprint-backoff-test.sh
+++ b/test/shell.d/lock-fingerprint-backoff-test.sh
@@ -35,6 +35,7 @@ const makeService = () => {
   const state = {
     lockRequested: true,
     fingerprintConfigured: true,
+    fingerprintAuthenticating: false,
     fingerprintErrorStreak: 0,
     fingerprintAttemptErrored: false,
     fingerprintAttemptStartedAt: 0,
@@ -123,6 +124,66 @@ while (runaway.clock < 60000) {
 
 assert(attempts <= 10, `a wedged reader is retried at most 10 times a minute, got ${attempts}`)
 
+// Backing off must not leave the reader unarmed for someone standing there, so
+// any sign of the user cuts the wait short -- but not so freely that a moving
+// cursor spins the loop back up.
+const nudgeBody = capture(
+  /function nudgeFingerprint\(\) \{([\s\S]*?)\n  \}/,
+  'a present user re-arms the reader through nudgeFingerprint()'
+)
+const cooldownMs = number('fingerprintNudgeCooldownMs')
+
+const makeNudger = () => {
+  const service = makeService()
+  // resetAuthenticationState() zeroes the nudge stamp while the real clock is
+  // far past it, so start the fixture's clock somewhere realistic.
+  service.clock = 1e9
+  service.fingerprintNudgedAt = 0
+  service.fingerprintNudgeCooldownMs = cooldownMs
+  service.fingerprintPam = { active: false }
+  service.starts = 0
+  service.startFingerprint = () => { service.starts++ }
+  service.fingerprintRetryTimer.running = false
+  service.fingerprintRetryTimer.stop = function() { this.running = false }
+  service.nudgeFingerprint = new Function(`with (this) { ${nudgeBody} }`).bind(service)
+  return service
+}
+
+const waiting = makeNudger()
+waiting.fingerprintErrorStreak = 8
+waiting.fingerprintRetryTimer.running = true
+waiting.nudgeFingerprint()
+
+assert(waiting.starts === 1, 'a present user re-arms the reader without waiting out the backoff')
+assert(
+  waiting.fingerprintErrorStreak === 8,
+  `the streak survives a nudge so a wedged reader keeps backing off, got ${waiting.fingerprintErrorStreak}`
+)
+
+waiting.fingerprintRetryTimer.running = true
+waiting.clock += cooldownMs - 1
+waiting.nudgeFingerprint()
+assert(waiting.starts === 1, 'a second nudge inside the cooldown is ignored')
+
+waiting.clock += 2
+waiting.nudgeFingerprint()
+assert(waiting.starts === 2, 'a nudge after the cooldown re-arms again')
+
+const idle = makeNudger()
+idle.fingerprintRetryTimer.running = false
+idle.nudgeFingerprint()
+assert(idle.starts === 0, 'a nudge with no retry pending does not start a second attempt')
+
+const busy = makeNudger()
+busy.fingerprintRetryTimer.running = true
+busy.fingerprintAuthenticating = true
+busy.nudgeFingerprint()
+assert(busy.starts === 0, 'a nudge during an attempt in flight is ignored')
+
+assert(
+  /function runWake\(\) \{[\s\S]*?nudgeFingerprint\(\)/.test(serviceQml),
+  'waking the lock screen nudges the reader'
+)
 assert(
   /onError: function\(error\) \{[\s\S]*?scheduleFingerprintRetry\(true\)/.test(serviceQml),
   'a device error routes through scheduleFingerprintRetry() as a device error'

--- a/test/shell.d/lock-fingerprint-backoff-test.sh
+++ b/test/shell.d/lock-fingerprint-backoff-test.sh
@@ -3,7 +3,6 @@ source "$(dirname "$0")/base-test.sh"
 
 run_node_test <<'JS'
 const fs = require('fs')
-
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
 
 const capture = (pattern, description) => {
@@ -12,52 +11,132 @@ const capture = (pattern, description) => {
   return match[1]
 }
 
-const baseMs = Number(capture(/readonly property int fingerprintRetryBaseMs: (\d+)/, 'the base retry interval is declared'))
-const maxMs = Number(capture(/readonly property int fingerprintRetryMaxMs: (\d+)/, 'the retry ceiling is declared'))
-const body = capture(/function fingerprintRetryDelay\(streak\) \{([\s\S]*?)\n  \}/, 'the retry delay is computed by fingerprintRetryDelay()')
+const number = (name) =>
+  Number(capture(new RegExp(`readonly property int ${name}: (\\d+)`), `${name} is declared`))
 
-const fingerprintRetryDelay = new Function('streak', 'fingerprintRetryBaseMs', 'fingerprintRetryMaxMs', body)
-const delay = (streak) => fingerprintRetryDelay(streak, baseMs, maxMs)
+const baseMs = number('fingerprintRetryBaseMs')
+const maxMs = number('fingerprintRetryMaxMs')
+const fastMs = number('fingerprintFastErrorMs')
+
+const delayBody = capture(
+  /function fingerprintRetryDelay\(streak\) \{([\s\S]*?)\n  \}/,
+  'the retry delay is computed by fingerprintRetryDelay()'
+)
+const scheduleBody = capture(
+  /function scheduleFingerprintRetry\(isDeviceError\) \{([\s\S]*?)\n  \}/,
+  'the retry is scheduled by scheduleFingerprintRetry()'
+)
+
+// Run the real function bodies against a stand-in for the QML root so the test
+// exercises the state machine rather than a paraphrase of it. `with` resolves
+// bare property names against the object the way QML scoping does, and a
+// shadowed Date keeps the elapsed-time branch deterministic.
+const makeService = () => {
+  const state = {
+    lockRequested: true,
+    fingerprintConfigured: true,
+    fingerprintErrorStreak: 0,
+    fingerprintAttemptErrored: false,
+    fingerprintAttemptStartedAt: 0,
+    fingerprintRetryBaseMs: baseMs,
+    fingerprintRetryMaxMs: maxMs,
+    fingerprintFastErrorMs: fastMs,
+    fingerprintRetryTimer: { interval: 0, restarts: 0, restart() { this.restarts++ } },
+    clock: 0,
+  }
+
+  state.Date = { now: () => state.clock }
+  state.Math = Math
+  state.fingerprintRetryDelay = new Function(
+    'streak',
+    `with (this) { ${delayBody} }`
+  ).bind(state)
+  state.scheduleFingerprintRetry = new Function(
+    'isDeviceError',
+    `with (this) { ${scheduleBody} }`
+  ).bind(state)
+
+  // One authentication attempt: the reader is armed, time passes, then PAM
+  // reports back. A failure raises both onError and onCompleted, so replay both.
+  state.attempt = ({ elapsedMs, deviceError }) => {
+    state.fingerprintAttemptErrored = false
+    state.fingerprintAttemptStartedAt = state.clock
+    state.clock += elapsedMs
+    if (deviceError) state.scheduleFingerprintRetry(true)
+    state.scheduleFingerprintRetry(false)
+    return state.fingerprintRetryTimer.interval
+  }
+
+  return state
+}
+
+const delay = (streak) => makeService().fingerprintRetryDelay(streak)
 
 assert(delay(0) === baseMs, 'no error streak retries at the base interval')
 assert(delay(1) === baseMs, 'first device error retries at the base interval')
 assert(delay(2) === baseMs * 2, 'second consecutive device error doubles the delay')
 assert(delay(3) === baseMs * 4, 'third consecutive device error doubles again')
-assert(delay(8) === maxMs, 'the delay saturates at the ceiling')
 assert(delay(80) === maxMs, 'a long error streak never exceeds the ceiling')
 
-// A reader stuck erroring must not be retried more than a handful of times per
-// minute; the unbounded 250ms retry it replaces managed ~240.
-let elapsed = 0
+// The regression that shipped first: onError incremented the streak and the
+// onCompleted for that same attempt reset it, pinning the backoff at one step.
+const wedged = makeService()
+const first = wedged.attempt({ elapsedMs: 0, deviceError: true })
+const second = wedged.attempt({ elapsedMs: 0, deviceError: true })
+const third = wedged.attempt({ elapsedMs: 0, deviceError: true })
+
+assert(first === baseMs, 'a wedged reader first retries at the base interval')
+assert(
+  second === baseMs * 2,
+  `the completed signal for a failed attempt must not reset the streak, got ${second}`
+)
+assert(third === baseMs * 4, `a wedged reader keeps backing off, got ${third}`)
+
+// A reader that waits out the swipe reports the same PAM error code. Backing
+// off there would leave it unarmed when the user finally does swipe.
+const patient = makeService()
+const waits = [0, 1, 2].map(() =>
+  patient.attempt({ elapsedMs: fastMs * 15, deviceError: true })
+)
+
+assert(
+  waits.every((interval) => interval === baseMs),
+  `swipe timeouts stay at the base interval, got ${waits.join(', ')}`
+)
+
+// A wedged reader that recovers should return to being responsive.
+const recovering = makeService()
+recovering.attempt({ elapsedMs: 0, deviceError: true })
+recovering.attempt({ elapsedMs: 0, deviceError: true })
+const recovered = recovering.attempt({ elapsedMs: fastMs * 15, deviceError: false })
+
+assert(recovered === baseMs, `a recovered reader returns to the base interval, got ${recovered}`)
+
+// The point of the change: bound how hard a permanently wedged reader is hit.
+const runaway = makeService()
 let attempts = 0
-for (let streak = 1; elapsed < 60000; streak++) {
-  elapsed += delay(streak)
+while (runaway.clock < 60000) {
+  const interval = runaway.attempt({ elapsedMs: 0, deviceError: true })
+  runaway.clock += interval
   attempts++
 }
-assert(attempts <= 10, 'a persistently failing reader is retried at most 10 times a minute, got ' + attempts)
+
+assert(attempts <= 10, `a wedged reader is retried at most 10 times a minute, got ${attempts}`)
 
 assert(
-  /onError: function\(error\) \{\s*root\.fingerprintAuthenticating = false\s*root\.scheduleFingerprintRetry\(true\)/.test(serviceQml),
-  'a device-level PAM error schedules a backed-off retry'
+  /onError: function\(error\) \{[\s\S]*?scheduleFingerprintRetry\(true\)/.test(serviceQml),
+  'a device error routes through scheduleFingerprintRetry() as a device error'
 )
-
 assert(
-  /\} else if \(fingerprintConfigured\) \{\s*scheduleFingerprintRetry\(false\)/.test(serviceQml),
-  'a failed swipe schedules a retry without counting as a device error'
+  /result === PamResult\.Success[\s\S]*?fingerprintErrorStreak = 0/.test(serviceQml),
+  'a successful fingerprint clears the error streak'
 )
-
 assert(
-  /if \(result === PamResult\.Success\) \{\s*fingerprintErrorStreak = 0/.test(serviceQml),
-  'a successful verify clears the error streak'
+  /fingerprintAttemptStartedAt = Date\.now\(\)/.test(serviceQml),
+  'each attempt records when it started so its duration can be measured'
 )
-
-assert(
-  /fingerprintErrorStreak = 0\s*fingerprintRetryTimer\.stop\(\)/.test(serviceQml),
-  'resetting authentication state clears the error streak'
-)
-
 assert(
   !/interval: 250/.test(serviceQml),
-  'the retry timer takes its interval from the backoff, not a hardcoded literal'
+  'the retry timer interval is not hardcoded alongside the backoff'
 )
 JS

--- a/test/shell.d/lock-fingerprint-backoff-test.sh
+++ b/test/shell.d/lock-fingerprint-backoff-test.sh
@@ -364,4 +364,58 @@ assert(
   /function scheduleFingerprintRetry\([\s\S]*?Math\.max\(fingerprintRetryDelay\(fingerprintErrorStreak\), thermalCooldownMs\(\)\)/.test(serviceQml),
   'a scheduled retry never fires earlier than the sensor can take it'
 )
+
+// Blanking disarms the reader, so waking has to be able to arm it again. PAM's
+// abort() does not raise completed, so anything the completion handler would
+// normally clear has to be cleared by the blank itself -- otherwise the reader
+// is disarmed for the rest of the lock and the user is left swiping a dead
+// sensor, which is worse than the overheating this gate exists to prevent.
+const startBody = capture(
+  /function startFingerprint\(\) \{([\s\S]*?)\n  \}/,
+  'the reader is armed by startFingerprint()'
+)
+const blankBody = capture(
+  /function runBlank\(\) \{([\s\S]*?)\n  \}/,
+  'the display is blanked by runBlank()'
+)
+
+const makeLockScreen = () => {
+  const service = makeService()
+  service.clock = 1e9
+  service.sessionLock = { secure: true }
+  service.displayBlanked = false
+  service.blankProcess = { running: false }
+  service.fingerprintRetryTimer.running = false
+  service.fingerprintRetryTimer.stop = function() { this.running = false }
+  service.fingerprintPam = {
+    active: false,
+    aborted: 0,
+    start() { this.active = true; return true },
+    abort() { this.active = false; this.aborted++ },
+  }
+  service.startFingerprint = new Function(`with (this) { ${startBody} }`).bind(service)
+  service.runBlank = new Function(`with (this) { ${blankBody} }`).bind(service)
+  return service
+}
+
+const cycled = makeLockScreen()
+cycled.startFingerprint()
+assert(cycled.fingerprintPam.active, 'locking arms the reader')
+
+cycled.runBlank()
+assert(cycled.fingerprintPam.aborted === 1, 'blanking releases the reader so it can cool')
+assert(!cycled.fingerprintPam.active, 'the reader is not left armed at a dark screen')
+
+// The wake path clears displayBlanked before arming, so mirror that here.
+cycled.displayBlanked = false
+cycled.startFingerprint()
+assert(
+  cycled.fingerprintPam.active,
+  'waking re-arms the reader after a blank rather than bailing on a stale attempt'
+)
+
+const dark = makeLockScreen()
+dark.runBlank()
+dark.startFingerprint()
+assert(!dark.fingerprintPam.active, 'a blanked screen does not arm the reader')
 JS

--- a/test/shell.d/lock-fingerprint-backoff-test.sh
+++ b/test/shell.d/lock-fingerprint-backoff-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+source "$(dirname "$0")/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+const capture = (pattern, description) => {
+  const match = pattern.exec(serviceQml)
+  assert(match !== null, description)
+  return match[1]
+}
+
+const baseMs = Number(capture(/readonly property int fingerprintRetryBaseMs: (\d+)/, 'the base retry interval is declared'))
+const maxMs = Number(capture(/readonly property int fingerprintRetryMaxMs: (\d+)/, 'the retry ceiling is declared'))
+const body = capture(/function fingerprintRetryDelay\(streak\) \{([\s\S]*?)\n  \}/, 'the retry delay is computed by fingerprintRetryDelay()')
+
+const fingerprintRetryDelay = new Function('streak', 'fingerprintRetryBaseMs', 'fingerprintRetryMaxMs', body)
+const delay = (streak) => fingerprintRetryDelay(streak, baseMs, maxMs)
+
+assert(delay(0) === baseMs, 'no error streak retries at the base interval')
+assert(delay(1) === baseMs, 'first device error retries at the base interval')
+assert(delay(2) === baseMs * 2, 'second consecutive device error doubles the delay')
+assert(delay(3) === baseMs * 4, 'third consecutive device error doubles again')
+assert(delay(8) === maxMs, 'the delay saturates at the ceiling')
+assert(delay(80) === maxMs, 'a long error streak never exceeds the ceiling')
+
+// A reader stuck erroring must not be retried more than a handful of times per
+// minute; the unbounded 250ms retry it replaces managed ~240.
+let elapsed = 0
+let attempts = 0
+for (let streak = 1; elapsed < 60000; streak++) {
+  elapsed += delay(streak)
+  attempts++
+}
+assert(attempts <= 10, 'a persistently failing reader is retried at most 10 times a minute, got ' + attempts)
+
+assert(
+  /onError: function\(error\) \{\s*root\.fingerprintAuthenticating = false\s*root\.scheduleFingerprintRetry\(true\)/.test(serviceQml),
+  'a device-level PAM error schedules a backed-off retry'
+)
+
+assert(
+  /\} else if \(fingerprintConfigured\) \{\s*scheduleFingerprintRetry\(false\)/.test(serviceQml),
+  'a failed swipe schedules a retry without counting as a device error'
+)
+
+assert(
+  /if \(result === PamResult\.Success\) \{\s*fingerprintErrorStreak = 0/.test(serviceQml),
+  'a successful verify clears the error streak'
+)
+
+assert(
+  /fingerprintErrorStreak = 0\s*fingerprintRetryTimer\.stop\(\)/.test(serviceQml),
+  'resetting authentication state clears the error streak'
+)
+
+assert(
+  !/interval: 250/.test(serviceQml),
+  'the retry timer takes its interval from the backoff, not a hardcoded literal'
+)
+JS


### PR DESCRIPTION
The lock screen overheats the fingerprint reader about three minutes after the screen locks, and then never lets it recover.

## What happens

libfprint charges a device for the time it is **armed**, not for the time a finger is on it. From `fpi-device.c`:

```c
if (priv->temp_last_active) {
    alpha = exp (-passed_seconds / priv->temp_hot_seconds);
    priv->temp_current_ratio = alpha * priv->temp_current_ratio + 1 - alpha;
} else {
    alpha = exp (-passed_seconds / priv->temp_cold_seconds);
    priv->temp_current_ratio = alpha * priv->temp_current_ratio;
}
```

| | |
|---|---|
| `DEFAULT_TEMP_HOT_SECONDS` | 180s — time constant while a verify is open |
| `DEFAULT_TEMP_COLD_SECONDS` | 540s — time constant while idle |
| `TEMP_WARM_HOT_THRESH` | 0.731 — device starts refusing here |
| `TEMP_HOT_WARM_THRESH` | 0.5 — the refusal **latches** until the ratio falls back under this |

A verify nobody swipes stays armed for its full ~30s timeout, and `handleFingerprintFinished()` re-arms the moment it returns. So a locked screen holds the reader open essentially 100% of the time. From libfprint's cold start of 0.269 that reaches 0.731 in:

```
-180 * ln((0.731 - 1) / (0.269 - 1)) = 180 seconds
```

Measured here: first arm `18:17:19`, first `Device disabled to prevent overheating` at `18:20:21` — **182 seconds**. Upek Touchstrip (`147e:2016`), which takes libfprint's defaults, as does every driver that doesn't set `temp_hot_seconds` itself. This isn't specific to one sensor.

## Why it doesn't recover

Backing off on errors isn't enough on its own. A refused device returns instantly, so those retries are too cheap to heat it and the ratio drifts down toward 0.5 — at which point the next retry arms *for real*, holds 30s, and pushes it straight back over. It oscillates around the latch threshold indefinitely. The reader here sat refused for **2h20m** and only came back on a `systemctl restart fprintd`.

## The fix

**Don't arm the reader while the display is blanked.** Nobody is there to swipe it, so the entire cost is heat. Waking arms it immediately — which also means the reader is cold and ready when someone walks up, rather than part-way through a backoff.

**Mirror libfprint's ratio and refuse to arm above 0.5.** That's libfprint's own clear-threshold, so the lock screen stops a full band short of the cut-off and never contends with a latched refusal. This bounds the awake-but-not-swiping case that blanking doesn't cover. A scheduled retry waits for whichever is longer, its backoff or the sensor.

The sustainable duty cycle is `3d/(1+2d) < 0.731`, i.e. **d < 47%**. The guard settles at 30%.

## Also here

Three smaller fixes to the same path, each of which stands on its own:

- **Back off on device errors.** A failing verify returned instantly and retried at a flat 250ms, spinning PAM sessions as fast as they could be created — ~2.6 sessions/second for six minutes here. The lock screen was busy enough that a typed password never got checked, so it appeared to reject a correct password. Now exponential, 250ms to a 30s ceiling.
- **Only back off on *fast* errors.** A swipe timeout returns the same PAM code as a broken reader; only elapsed time separates them (~0ms vs ~31s). Backing off on timeouts would leave a healthy reader unarmed. A failed attempt also raises both `onError` and `onCompleted`, so the device error has to win the attempt whichever signal lands first — otherwise the completion resets the streak and the backoff never advances past one step.
- **Re-arm on user presence.** `LockView` already emits `wakeRequested()` on key press, typing, click and cursor movement.

## Testing

`test/shell.d/lock-fingerprint-backoff-test.sh`, 54 assertions. It extracts the real function bodies from `Service.qml` and runs them against a stand-in for the QML root, so it exercises the state machine rather than a paraphrase of it.

The thermal cases drive the real arming policy against an independent implementation of libfprint's model:

```
ok - re-arming on completion overheats the reader, so the guard has something to prevent
ok - the arming ceiling keeps libfprint below its cutoff, peaked at 0.577
ok - the duty cycle stays under what libfprint tolerates, got 30.0%
ok - quick attempts leave the reader responsive, waited 5.9s
ok - a full timeout still re-arms within two minutes, waited 77.1s
ok - blanking releases the reader so it can cool
ok - waking re-arms the reader after a blank rather than bailing on a stale attempt
```

Mutation-tested: raising the ceiling, dropping the cooldown, removing the blanking gate, letting a retry ignore the cooldown, and leaving the in-flight flag set on blank each fail the suite.

Measured on hardware over a five minute lock, before and after:

| | before | after |
|---|---|---|
| reader arms | 767 | 1 |
| `Device disabled to prevent overheating` | 760 | 0 |

Then confirmed end to end across three locks, including one of 3m38s that spans the old 180-second failure point: all three unlocked by fingerprint on first touch, 5 arms total, no overheat events, and the error streak never left 0.

`./test/all`: 2365 assertions pass. The three `omarchy-pkgs` failures are pre-existing on `quattro` and unrelated.

Related: #7176.
