### PR TITLE
Work around Apple BCM4350 suspend failures

### DIFF
--- a/bin/omarchy-hw-brcmfmac-suspend
+++ b/bin/omarchy-hw-brcmfmac-suspend
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# omarchy:hidden=true
+# omarchy:summary=Unbind affected Broadcom Wi-Fi around system sleep
+# omarchy:args=<pre|post>
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+driver_path="${OMARCHY_BRCMFMAC_DRIVER_PATH:-/sys/bus/pci/drivers/brcmfmac}"
+device_root="${OMARCHY_BRCMFMAC_DEVICE_ROOT:-/sys/bus/pci/devices}"
+state_file="${OMARCHY_BRCMFMAC_SUSPEND_STATE:-/run/omarchy-brcmfmac-suspend.devices}"
+
+case "${1:-}" in
+  pre)
+    install -d -m755 "$(dirname "$state_file")"
+    : >"$state_file"
+
+    for bound_device in "$driver_path"/????:??:??.?; do
+      [[ -e $bound_device/vendor && -e $bound_device/device ]] || continue
+      [[ $(<"$bound_device/vendor") == "0x14e4" ]] || continue
+      [[ $(<"$bound_device/device") == "0x43a3" ]] || continue
+
+      pci_address="${bound_device##*/}"
+      if ! printf '%s' "$pci_address" >"$driver_path/unbind"; then
+        rm -f "$state_file"
+        exit 1
+      fi
+      printf '%s\n' "$pci_address" >>"$state_file"
+    done
+
+    if [[ ! -s $state_file ]]; then
+      rm -f "$state_file"
+      echo "No bound Apple BCM4350 Wi-Fi device found" >&2
+      exit 1
+    fi
+    ;;
+  post)
+    [[ -f $state_file ]] || exit 0
+    bind_failed=false
+
+    while IFS= read -r pci_address; do
+      [[ -n $pci_address ]] || continue
+      if [[ ! -e $device_root/$pci_address ]]; then
+        echo "Broadcom Wi-Fi device $pci_address disappeared" >&2
+        bind_failed=true
+        continue
+      fi
+      if [[ ! -L $device_root/$pci_address/driver ]] &&
+        ! printf '%s' "$pci_address" >"$driver_path/bind"; then
+        echo "Failed to rebind Broadcom Wi-Fi device $pci_address" >&2
+        bind_failed=true
+      fi
+    done <"$state_file"
+
+    if [[ $bind_failed == true ]]; then
+      exit 1
+    fi
+
+    rm -f "$state_file"
+    ;;
+  *)
+    echo "Usage: omarchy-hw-brcmfmac-suspend <pre|post>" >&2
+    exit 2
+    ;;
+esac

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-suspend.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-brcmfmac-suspend.sh
+++ b/install/hardware/apple/fix-brcmfmac-suspend.sh
@@ -1,0 +1,18 @@
+# BCM4350 firmware can stop answering after S3 resume on Apple hardware. Once
+# that happens, brcmfmac times out entering D3, NetworkManager cannot initialize
+# its supplicant interface, and every scan fails until the firmware is reloaded.
+#
+# Unbind the device before sleep so its unreliable firmware power transition is
+# bypassed, then bind it after wake so NetworkManager gets a freshly initialized
+# radio. Keep this on the confirmed Apple BCM4350 PCI ID instead of resetting
+# unrelated brcmfmac devices on every suspend.
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+
+if [[ $sys_vendor == Apple* ]] && lspci -nn | grep "14e4:43a3" >/dev/null; then
+  echo "Detected Apple BCM4350 Wi-Fi; resetting its driver around sleep"
+
+  sudo install -Dm644 \
+    "$OMARCHY_PATH/install/hardware/apple/omarchy-brcmfmac-suspend.service" \
+    /etc/systemd/system/omarchy-brcmfmac-suspend.service
+  sudo systemctl enable omarchy-brcmfmac-suspend.service
+fi

--- a/install/hardware/apple/omarchy-brcmfmac-suspend.service
+++ b/install/hardware/apple/omarchy-brcmfmac-suspend.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Reset Broadcom Wi-Fi around sleep on affected Apple hardware
+Before=sleep.target
+StopWhenUnneeded=yes
+ConditionPathExists=/sys/bus/pci/drivers/brcmfmac
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/omarchy-hw-brcmfmac-suspend pre
+ExecStop=/usr/bin/omarchy-hw-brcmfmac-suspend post
+TimeoutStartSec=10s
+TimeoutStopSec=10s
+
+[Install]
+WantedBy=sleep.target

--- a/migrations/1786907783.sh
+++ b/migrations/1786907783.sh
@@ -1,0 +1,22 @@
+echo "Reset Apple BCM4350 Wi-Fi around sleep"
+
+# The installer only reaches new systems. Existing Apple BCM4350 installs can
+# leave the radio firmware unresponsive after resume, which also makes later
+# suspend attempts fail in brcmf_pcie_pm_enter_D3 until the machine reboots.
+dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+service_source="${OMARCHY_BRCMFMAC_SUSPEND_SERVICE_SOURCE:-$OMARCHY_PATH/install/hardware/apple/omarchy-brcmfmac-suspend.service}"
+service_target="${OMARCHY_BRCMFMAC_SUSPEND_SERVICE_TARGET:-/etc/systemd/system/omarchy-brcmfmac-suspend.service}"
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if [[ $sys_vendor != Apple* ]] || ! lspci -nn | grep "14e4:43a3" >/dev/null; then
+  exit 0
+fi
+
+if ! cmp -s "$service_source" "$service_target"; then
+  sudo install -Dm644 "$service_source" "$service_target"
+fi
+
+if ! systemctl is-enabled --quiet omarchy-brcmfmac-suspend.service 2>/dev/null; then
+  sudo systemctl enable omarchy-brcmfmac-suspend.service
+fi

--- a/test/shell.d/brcmfmac-suspend-test.sh
+++ b/test/shell.d/brcmfmac-suspend-test.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-brcmfmac-suspend.sh"
+helper="$ROOT/bin/omarchy-hw-brcmfmac-suspend"
+service="$ROOT/install/hardware/apple/omarchy-brcmfmac-suspend.service"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1786907783.sh"
+
+grep -q 'apple/fix-brcmfmac-suspend.sh' "$all" ||
+  fail "the BCM4350 suspend fix runs during hardware setup"
+grep -Fx 'Before=sleep.target' "$service" >/dev/null ||
+  fail "the BCM4350 service detaches the device before sleep"
+grep -Fx 'StopWhenUnneeded=yes' "$service" >/dev/null ||
+  fail "the BCM4350 service stops after the sleep transaction"
+grep -Fx 'ConditionPathExists=/sys/bus/pci/drivers/brcmfmac' "$service" >/dev/null ||
+  fail "the BCM4350 service only runs when the driver is available"
+grep -Fx 'ExecStart=/usr/bin/omarchy-hw-brcmfmac-suspend pre' "$service" >/dev/null ||
+  fail "the BCM4350 service runs the pre-sleep recovery helper"
+grep -Fx 'ExecStop=/usr/bin/omarchy-hw-brcmfmac-suspend post' "$service" >/dev/null ||
+  fail "the BCM4350 service runs the post-wake recovery helper"
+grep -Fx 'WantedBy=sleep.target' "$service" >/dev/null ||
+  fail "the BCM4350 service joins every sleep transaction"
+pass "the BCM4350 service resets the driver around sleep"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+target="$test_tmp/etc/systemd/system/omarchy-brcmfmac-suspend.service"
+enabled="$test_tmp/enabled"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "02:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '00:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "is-enabled" ]]; then
+  [[ -e $ENABLED_MARKER ]]
+  exit
+fi
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+[[ $1 != "enable" ]] || touch "$ENABLED_MARKER"
+SH
+
+chmod +x "$stub_bin"/*
+
+driver_path="$test_tmp/sys/bus/pci/drivers/brcmfmac"
+device_root="$test_tmp/sys/bus/pci/devices"
+state_file="$test_tmp/run/omarchy-brcmfmac-suspend.devices"
+pci_address="0000:02:00.0"
+mkdir -p "$driver_path" "$device_root/$pci_address"
+printf '0x14e4' >"$device_root/$pci_address/vendor"
+printf '0x43a3' >"$device_root/$pci_address/device"
+ln -s "$device_root/$pci_address" "$driver_path/$pci_address"
+ln -s "$driver_path" "$device_root/$pci_address/driver"
+: >"$driver_path/unbind"
+: >"$driver_path/bind"
+
+OMARCHY_BRCMFMAC_DRIVER_PATH="$driver_path" \
+  OMARCHY_BRCMFMAC_DEVICE_ROOT="$device_root" \
+  OMARCHY_BRCMFMAC_SUSPEND_STATE="$state_file" \
+  "$helper" pre
+[[ $(<"$driver_path/unbind") == "$pci_address" ]] ||
+  fail "the pre-sleep helper unbinds the BCM4350 PCI device"
+[[ $(<"$state_file") == "$pci_address" ]] ||
+  fail "the pre-sleep helper records the device for wake"
+pass "the pre-sleep helper detaches the affected PCI device"
+
+rm "$driver_path/$pci_address" "$device_root/$pci_address/driver"
+OMARCHY_BRCMFMAC_DRIVER_PATH="$driver_path" \
+  OMARCHY_BRCMFMAC_DEVICE_ROOT="$device_root" \
+  OMARCHY_BRCMFMAC_SUSPEND_STATE="$state_file" \
+  "$helper" post
+[[ $(<"$driver_path/bind") == "$pci_address" ]] ||
+  fail "the post-wake helper rebinds the BCM4350 PCI device"
+[[ ! -e $state_file ]] || fail "the post-wake helper clears its device state"
+pass "the post-wake helper reattaches the affected PCI device"
+
+missing_address="0000:04:00.0"
+printf '%s\n' "$missing_address" >"$state_file"
+if OMARCHY_BRCMFMAC_DRIVER_PATH="$driver_path" \
+  OMARCHY_BRCMFMAC_DEVICE_ROOT="$device_root" \
+  OMARCHY_BRCMFMAC_SUSPEND_STATE="$state_file" \
+  "$helper" post 2>/dev/null; then
+  fail "the post-wake helper reports a missing PCI device"
+fi
+[[ -e $state_file ]] || fail "failed recovery keeps its device state for retry"
+rm "$state_file"
+pass "failed recovery remains visible and retryable"
+
+other_address="0000:03:00.0"
+mkdir -p "$device_root/$other_address"
+printf '0x14e4' >"$device_root/$other_address/vendor"
+printf '0x43ba' >"$device_root/$other_address/device"
+ln -s "$device_root/$other_address" "$driver_path/$other_address"
+: >"$driver_path/unbind"
+if OMARCHY_BRCMFMAC_DRIVER_PATH="$driver_path" \
+  OMARCHY_BRCMFMAC_DEVICE_ROOT="$device_root" \
+  OMARCHY_BRCMFMAC_SUSPEND_STATE="$state_file" \
+  "$helper" pre 2>/dev/null; then
+  fail "the pre-sleep helper rejects a different Broadcom PCI device"
+fi
+[[ ! -s $driver_path/unbind ]] || fail "the pre-sleep helper leaves other devices bound"
+pass "the pre-sleep helper only detaches BCM4350 hardware"
+
+run_leaf() {
+  local vendor="$1" wifi_id="${2:-}"
+  local script="$test_tmp/leaf.sh"
+
+  rm -rf "$test_tmp/etc"
+  mkdir -p "$test_tmp/etc"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  sed \
+    -e "s|/sys/class/dmi/id/sys_vendor|$test_tmp/dmi/sys_vendor|g" \
+    -e "s|/etc/systemd/system/omarchy-brcmfmac-suspend.service|$target|g" \
+    "$leaf" >"$script"
+
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" ENABLED_MARKER="$enabled" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+run_leaf "Apple Inc." 43a3 >/dev/null
+cmp -s "$service" "$target" ||
+  fail "Apple BCM4350 setup installs the sleep service"
+grep -Fq $'systemctl\tenable\tomarchy-brcmfmac-suspend.service' "$calls" ||
+  fail "Apple BCM4350 setup enables the sleep service" "$(cat "$calls")"
+pass "Apple BCM4350 setup installs and enables the sleep service"
+
+run_leaf "Apple Inc." 43ba >/dev/null
+[[ ! -e $target ]] || fail "other Apple Broadcom radios are left alone"
+[[ ! -s $calls ]] || fail "other Apple Broadcom radios change no system state" "$(cat "$calls")"
+pass "other Apple Broadcom radios are left alone"
+
+run_leaf "LENOVO" 43a3 >/dev/null
+[[ ! -e $target ]] || fail "non-Apple BCM4350 hardware is left alone"
+[[ ! -s $calls ]] || fail "non-Apple BCM4350 hardware changes no system state" "$(cat "$calls")"
+pass "non-Apple BCM4350 hardware is left alone"
+
+run_migration() {
+  local vendor="$1" wifi_id="${2:-}"
+
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    ENABLED_MARKER="$enabled" OMARCHY_PATH="$ROOT" \
+    OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    OMARCHY_BRCMFMAC_SUSPEND_SERVICE_SOURCE="$service" \
+    OMARCHY_BRCMFMAC_SUSPEND_SERVICE_TARGET="$target" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc"
+rm -f "$enabled"
+run_migration "Apple Inc." 43a3
+cmp -s "$service" "$target" ||
+  fail "the migration installs the service on an existing Apple BCM4350 system"
+[[ -e $enabled ]] || fail "the migration enables the BCM4350 sleep service"
+pass "the migration repairs an existing Apple BCM4350 system"
+
+run_migration "Apple Inc." 43a3
+[[ ! -s $calls ]] || fail "the migration is idempotent" "$(cat "$calls")"
+pass "the migration leaves a repaired system untouched"
+
+rm -rf "$test_tmp/etc"
+rm -f "$enabled"
+run_migration "Apple Inc." 43ba
+[[ ! -e $target ]] || fail "the migration skips other Apple Broadcom radios"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected hardware" "$(cat "$calls")"
+pass "the migration skips unaffected hardware"


### PR DESCRIPTION
## Summary

- Install a sleep service only on Apple systems with the BCM4350 PCI device (`14e4:43a3`).
- Unbind that device from `brcmfmac` before sleep and bind it again after wake, forcing a clean firmware initialization.
- Add an idempotent migration for existing installs and focused coverage for hardware gating, service ordering, recovery state, and installation.

## Failure

This was reproduced twice on a MacBook10,1 with kernel 7.1.8 and the in-tree `brcmfmac` driver.

After a successful S3 suspend, the BCM4350 firmware stopped answering as soon as the machine resumed. The journal then repeated:

```
brcmf_msgbuf_query_dcmd: Timeout on response for query command
Couldn't initialize supplicant interface: Timeout was reached
brcmf_cfg80211_scan: scan error (-5)
```

Toggling Wi-Fi could not recover the device because that only changes NetworkManager/rfkill state. A later suspend attempt also failed when the already-unresponsive firmware did not acknowledge its D3 transition:

```
brcmf_pcie_pm_enter_D3: Timeout on response for entering D3 substate
pci_pm_suspend(): brcmf_pcie_pm_enter_D3 [brcmfmac] returns -5
```

A reboot recovered Wi-Fi by initializing the firmware again.

## Approach

The service keeps this exact PCI device unbound for the sleep transaction. It therefore avoids relying on the unresponsive firmware power transition and binds the device after resume so NetworkManager receives a freshly initialized radio.

The workaround is deliberately limited to Apple hardware with PCI ID `14e4:43a3`; it does not cycle other `brcmfmac` radios.

## Testing

- `bash -n` on the helper, installer, migration, and test
- `test/shell.d/brcmfmac-suspend-test.sh`
- `test/shell.d/brcmfmac-supplicant-test.sh`
- `test/shell.d/unowned-system-paths-test.sh`
- `test/shell.d/systemd-test.sh`
- `test/cli`
- `systemd-analyze verify install/hardware/apple/omarchy-brcmfmac-suspend.service`
- Live PCI unbind/bind: the device stayed detached and NetworkManager reconnected after binding
- Live deep-suspend integration with the actual unit ordering:
  - service started before `sleep.target`
  - S3 suspend ran from 13:10:07 to 13:10:43
  - service stopped and firmware initialization began at 13:10:43
  - Wi-Fi activated at 13:10:47
  - zero `brcmfmac` response timeouts and zero post-resume scan failures

An earlier exploratory module-unload approach was discarded because udev immediately reloaded the module before suspend. That exploratory cycle also coincided with an `snd_hda_codec` kernel oops and a hard lock. The final implementation does not unload modules; both the corrected detached-device cycle and the actual service integration cycle completed cleanly.
