### PR TITLE
Keep UPower's rate when a sysfs power attribute cannot be read

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -45,14 +45,30 @@ power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
 native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
 battery_path="$power_supply_path/$native_path"
 
+# A readable attribute is not a working one. Some ACPI firmware advertises
+# power_now and then fails the read itself with ENODEV, and `[[ -r ]]` only
+# proves the file exists with read permission, so the empty string that comes
+# back becomes 0 and overwrites the rate UPower had computed correctly. Take a
+# sysfs reading only when it parses as a number.
+read_power_attribute() {
+  local value
+
+  [[ -r $1 ]] || return 1
+  value=$(<"$1") || return 1
+  [[ $value =~ ^-?[0-9]+$ ]] || return 1
+
+  printf '%s' "$value"
+}
+
 # UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
 # the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
+if microwatts=$(read_power_attribute "$battery_path/power_now"); then
+  power_rate_raw=$(awk -v microwatts="$microwatts" 'BEGIN { print microwatts / 1000000 }')
+elif microamps=$(read_power_attribute "$battery_path/current_now") &&
+  microvolts=$(read_power_attribute "$battery_path/voltage_now"); then
   power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
+    -v microamps="$microamps" \
+    -v microvolts="$microvolts" \
     'BEGIN { print microamps * microvolts / 1000000000000 }')
 fi
 

--- a/test/shell.d/battery-status-unreadable-rate-test.sh
+++ b/test/shell.d/battery-status-unreadable-rate-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                discharging
+  energy:               28.3 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+# Rebuild BAT0 from scratch per case so a leftover attribute cannot decide the
+# next one. Values arrive as `attribute=contents`; an empty string writes an
+# empty file, which is what bash captures from a read that fails.
+battery_fixture() {
+  local attribute
+
+  rm -rf "$tmp_dir/power"
+  mkdir -p "$tmp_dir/power/BAT0"
+
+  for attribute in "$@"; do
+    printf '%s' "${attribute#*=}" >"$tmp_dir/power/BAT0/${attribute%%=*}"
+  done
+}
+
+battery_rate() {
+  local output
+
+  output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-battery-status" --shell)
+
+  awk -F'\t' '$1 == "rate" { print $2; exit }' <<<"$output"
+}
+
+assert_rate() {
+  local expected="$1"
+  local description="$2"
+  local actual
+
+  actual=$(battery_rate)
+  [[ $actual == "$expected" ]] || fail "$description" "expected: $expected
+actual:   $actual"
+  pass "$description"
+}
+
+# The reported bug: the attribute is present and world-readable, but the read
+# returns ENODEV and hands back an empty string. Reading an empty file gives
+# bash the same empty string, so the fixture reproduces what the script sees.
+battery_fixture "power_now=" "voltage_now=12000000"
+assert_rate "7.3W" "unreadable power_now keeps UPower's energy-rate"
+
+battery_fixture "power_now=No such device" "voltage_now=12000000"
+assert_rate "7.3W" "non-numeric power_now keeps UPower's energy-rate"
+
+# The same hole sits in the current_now/voltage_now fallback, where a failed
+# read would multiply out to 0W just as quietly.
+battery_fixture "current_now=" "voltage_now=12000000"
+assert_rate "7.3W" "unreadable current_now keeps UPower's energy-rate"
+
+# And the reason the sysfs override exists in the first place: where the
+# kernel does answer, its instantaneous reading still wins over UPower's
+# laggier figure.
+battery_fixture "power_now=10800000" "voltage_now=12000000"
+assert_rate "10.8W" "readable power_now still overrides UPower's energy-rate"
+
+battery_fixture "current_now=900000" "voltage_now=12000000"
+assert_rate "10.8W" "readable current_now still overrides UPower's energy-rate"


### PR DESCRIPTION
On an HP Spectre x360 14-ea0 the power panel sits at `0W` while the battery visibly drains. `omarchy-battery-status` reports `rate 0W` at the same moment UPower has the right answer:

```
$ omarchy-battery-status --shell | grep rate
rate	0W
$ upower -i $(upower -e | grep BAT) | grep energy-rate
energy-rate:         11.1458 W
```

The cause is the sysfs override that keeps the open panel live:

```bash
if [[ -r $battery_path/power_now ]]; then
  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
```

`[[ -r ]]` proves the attribute exists with read permission — not that reading it works. This firmware advertises `power_now` and then fails the `read()` itself:

```
$ ls -l /sys/class/power_supply/BAT0/power_now
-r--r--r-- 1 root root 4096 Aug 16 22:04 /sys/class/power_supply/BAT0/power_now
$ cat /sys/class/power_supply/BAT0/power_now
cat: /sys/class/power_supply/BAT0/power_now: No such device
```

So the guard passes, `$(<...)` hands back an empty string, awk computes `"" / 1000000 = 0`, and the correct `energy-rate` read out of UPower ten lines earlier is overwritten with zero. The `current_now`/`voltage_now` fallback has the same hole — a failed read there multiplies out to 0W just as quietly.

**The fix:**

- `read_power_attribute` requires the read to succeed *and* the contents to parse as an integer. When it doesn't, `power_rate_raw` keeps the UPower value it already held, which is the correct figure on this hardware.
- Both branches go through it, so the `current_now`/`voltage_now` path is covered too.
- Where the kernel does answer, its instantaneous reading still wins over UPower's laggier one — that is the reason the override exists, and the new test pins it so this fix cannot quietly become "always use UPower".

**Notes for review:**

- Fixes #6895. That report came from an HP Pavilion 15-dk0xxx (`BAT1`); I hit the identical failure on an HP Spectre x360 14-ea0 (`BAT0`), so it is an ACPI firmware class rather than one machine.
- The regression test uses an empty `power_now` in its fixture. An `ENODEV` read and an empty file hand bash the same empty string, so the fixture reproduces precisely what the script sees without needing the broken firmware — and it covers the non-numeric case as well.
- It's a new test file rather than an addition to `battery-status-test.sh`, to stay out of the way of the two open PRs on this script. #6845 rewrites this same block for multi-battery machines and discards invalid reads as a side effect of its metering loop; if that lands first, only the regression test here is still needed, and #6895 explicitly asks for that coverage. #7138 touches the surrounding lines but not this failure. This change is deliberately four lines of logic so it rebases cleanly behind either.

**Verified:**

| | `rate` |
| --- | --- |
| packaged `omarchy-battery-status` | `0W` |
| this branch | `11.1W` |
| `upower -i` `energy-rate` | `11.1458 W` |

The new test fails on `quattro` (`expected: 7.3W / actual: 0W`) and passes with the fix. `./test/shell` runs 178 of 181 files green; the three failures are pre-existing on a clean checkout and unrelated (`config`, `snapper`, `unowned-system-paths` all want an `omarchy-pkgs` checkout that isn't present here). `./test/cli` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
