### PR TITLE
Report combined dual-battery status in the power panel

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -7,123 +7,275 @@ shell_output=false
 power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
 
 case "${1:-}" in
-  "")
-    ;;
-  --shell)
-    shell_output=true
-    ;;
-  *)
-    echo "Usage: omarchy-battery-status [--shell]" >&2
-    exit 2
-    ;;
+"")
+  ;;
+--shell)
+  shell_output=true
+  ;;
+*)
+  echo "Usage: omarchy-battery-status [--shell]" >&2
+  exit 2
+  ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+format_rate() {
+  awk -v rate="${1:-0}" 'BEGIN {
+    rounded = sprintf("%.1f", rate)
+    sub(/\.0$/, "", rounded)
+    print rounded
+  }'
+}
 
-battery_info=$(upower -i "$battery")
-
-percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
-capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
-time_remaining=$(awk '/time to (empty|full)/ {
-  value = $4
-  unit = $5
-  if (unit ~ /^minute/) {
-    printf "%dm", int(value)
-  } else {
-    hours = int(value)
-    minutes = int((value - hours) * 60)
+format_hours() {
+  awk -v hours="${1:-0}" 'BEGIN {
+    if (hours <= 0) exit
+    whole = int(hours)
+    minutes = int((hours - whole) * 60)
     if (minutes > 0) {
-      printf "%dh %dm", hours, minutes
+      printf "%dh %dm", whole, minutes
     } else {
-      printf "%dh", hours
+      printf "%dh", whole
     }
-  }
-  exit
-}' <<<"$battery_info")
-power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
+  }'
+}
 
-# UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
-# the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
-fi
+live_rate_watts() {
+  local battery_path="$1"
+  local power_rate_raw="$2"
 
-power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
-  rounded = sprintf("%.1f", rate)
-  sub(/\.0$/, "", rounded)
-  print rounded
-}')
-state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  if [[ -r $battery_path/power_now ]]; then
+    awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }'
+  elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
+    awk \
+      -v microamps="$(<"$battery_path/current_now")" \
+      -v microvolts="$(<"$battery_path/voltage_now")" \
+      'BEGIN { print microamps * microvolts / 1000000000000 }'
+  else
+    printf '%s\n' "${power_rate_raw:-0}"
+  fi
+}
 
-[[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
-[[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
+rate_idle() {
+  awk -v rate="${1:-0}" 'BEGIN { exit !(rate <= 0.2) }'
+}
 
 ac_online=false
 for supply in "$power_supply_path"/*; do
-  [[ -r $supply/type ]] || continue
-  [[ $(<"$supply/type") == "Mains" ]] || continue
-  [[ -r $supply/online ]] || continue
-
+  [[ -r $supply/online && -r $supply/type ]] || continue
+  type=$(<"$supply/type")
+  [[ $type == "Mains" || $type == "USB" ]] || continue
   if [[ $(<"$supply/online") == "1" ]]; then
     ac_online=true
     break
   fi
 done
 
-charge_idle=false
-if awk -v rate="${power_rate_raw:-0}" 'BEGIN { exit !(rate <= 0.2) }'; then
-  charge_idle=true
+mapfile -t battery_paths < <(upower -e 2>/dev/null | grep '/battery_' || true)
+if ((${#battery_paths[@]} == 0)); then
+  exit 0
 fi
 
+total_energy=0
+total_full=0
+total_rate=0
+any_charging=false
+any_discharging=false
+any_live_charge=false
+threshold_start=""
+threshold_end=""
+cycles_list=()
+pack_times=()
+declare -a pack_paths pack_percentages pack_states pack_sizes pack_rates pack_cycles
+
+for battery in "${battery_paths[@]}"; do
+  battery_info=$(upower -i "$battery")
+
+  native_path=$(awk '/native-path:/ { print $2; exit }' <<<"$battery_info")
+  energy=$(awk '/^[[:space:]]*energy:/ { print $2; exit }' <<<"$battery_info")
+  energy_full=$(awk '/energy-full:/ { print $2; exit }' <<<"$battery_info")
+  energy_rate=$(awk '/energy-rate:/ { print $2; exit }' <<<"$battery_info")
+  percentage=$(awk '/percentage:/ { print int($2); exit }' <<<"$battery_info")
+  state=$(awk '/state:/ { print $2; exit }' <<<"$battery_info")
+  pack_threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  pack_threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  pack_time=$(awk '/time to (empty|full)/ {
+    value = $4
+    unit = $5
+    if (unit ~ /^minute/) {
+      printf "%dm", int(value)
+    } else {
+      hours = int(value)
+      minutes = int((value - hours) * 60)
+      if (minutes > 0) {
+        printf "%dh %dm", hours, minutes
+      } else {
+        printf "%dh", hours
+      }
+    }
+    exit
+  }' <<<"$battery_info")
+
+  battery_path="$power_supply_path/$native_path"
+  pack_rate_raw=$(live_rate_watts "$battery_path" "${energy_rate:-0}")
+  pack_rate=$(format_rate "$pack_rate_raw")
+  pack_size=$(awk -v full="${energy_full:-0}" 'BEGIN { printf "%d", full }')
+
+  pack_cycle=""
+  if [[ -r $battery_path/cycle_count ]]; then
+    pack_cycle=$(<"$battery_path/cycle_count")
+    pack_cycle=${pack_cycle//$'\n'/}
+    [[ -n $pack_cycle ]] && cycles_list+=("$pack_cycle")
+  fi
+
+  if [[ -z $threshold_end && -n $pack_threshold_end ]]; then
+    threshold_start=$pack_threshold_start
+    threshold_end=$pack_threshold_end
+  fi
+
+  pack_holding=false
+  if [[ $ac_online == "true" && -n $pack_threshold_end ]]; then
+    if [[ $state == "pending-charge" ]]; then
+      pack_holding=true
+    elif [[ $state == "fully-charged" ]] && ((percentage < 99)); then
+      pack_holding=true
+    elif [[ $state == "charging" ]] && rate_idle "$pack_rate_raw" && ((pack_threshold_end < 99 && percentage >= pack_threshold_end)); then
+      pack_holding=true
+    elif [[ $state == "not-charging" || $state == "idle" ]] && ((percentage >= pack_threshold_end)); then
+      pack_holding=true
+    fi
+  fi
+
+  pack_state=$state
+  if [[ $pack_holding == "true" ]]; then
+    pack_state="holding"
+  fi
+
+  if [[ $state == "charging" ]] && ! rate_idle "$pack_rate_raw"; then
+    any_live_charge=true
+    any_charging=true
+  elif [[ $state == "charging" ]]; then
+    any_charging=true
+  elif [[ $state == "discharging" ]]; then
+    any_discharging=true
+  fi
+
+  total_energy=$(awk -v total="$total_energy" -v add="${energy:-0}" 'BEGIN { print total + add }')
+  total_full=$(awk -v total="$total_full" -v add="${energy_full:-0}" 'BEGIN { print total + add }')
+  total_rate=$(awk -v total="$total_rate" -v add="${pack_rate_raw:-0}" 'BEGIN { print total + add }')
+
+  [[ -n $pack_time ]] && pack_times+=("$pack_time")
+
+  pack_paths+=("$native_path")
+  pack_percentages+=("${percentage}%")
+  pack_states+=("$pack_state")
+  pack_sizes+=("${pack_size}Wh")
+  pack_rates+=("${pack_rate}W")
+  pack_cycles+=("$pack_cycle")
+done
+
+if [[ -z $threshold_end ]]; then
+  threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
+  threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
+fi
+
+if ((${#pack_paths[@]} == 1)); then
+  percentage=${pack_percentages[0]%\%}
+else
+  percentage=$(awk -v now="$total_energy" -v full="$total_full" 'BEGIN {
+    if (full <= 0) { print 0; exit }
+    printf "%d", (now / full) * 100
+  }')
+fi
+
+capacity=$(awk -v full="$total_full" 'BEGIN { printf "%d", full }')
+power_rate=$(format_rate "$total_rate")
+
 charge_holding=false
-if [[ $ac_online == "true" && -n $threshold_end ]]; then
-  if [[ $state == "pending-charge" ]]; then
+if [[ $ac_online == "true" && $any_live_charge == "false" ]]; then
+  if [[ -n $threshold_end ]]; then
     charge_holding=true
-  elif [[ $state == "fully-charged" ]] && (( percentage < 99 )); then
-    charge_holding=true
-  elif [[ $state == "charging" && $charge_idle == "true" ]] && (( threshold_end < 99 && percentage >= threshold_end )); then
-    charge_holding=true
+    for pack_state in "${pack_states[@]}"; do
+      if [[ $pack_state != "holding" && $pack_state != "fully-charged" ]]; then
+        # A lone discharging/unknown pack on AC still counts as holding only
+        # when every pack is at rest. Otherwise leave the machine state alone.
+        if [[ $pack_state == "discharging" || $pack_state == "charging" ]]; then
+          charge_holding=false
+          break
+        fi
+      fi
+    done
   fi
 fi
+
+if [[ $charge_holding == "true" ]]; then
+  state="holding"
+elif [[ $any_live_charge == "true" || $any_charging == "true" ]]; then
+  state="charging"
+elif [[ $any_discharging == "true" ]]; then
+  state="discharging"
+else
+  state=${pack_states[0]}
+fi
+
+time_remaining=""
+if ((${#pack_paths[@]} == 1)); then
+  # A single pack keeps UPower's own estimate so the CLI stays stable.
+  time_remaining=${pack_times[0]:-}
+elif [[ $state == "charging" ]] && ! rate_idle "$total_rate"; then
+  remain_hours=$(awk -v now="$total_energy" -v full="$total_full" -v rate="$total_rate" 'BEGIN {
+    if (rate <= 0) exit
+    print (full - now) / rate
+  }')
+  time_remaining=$(format_hours "$remain_hours")
+elif [[ $state == "discharging" ]] && ! rate_idle "$total_rate"; then
+  remain_hours=$(awk -v now="$total_energy" -v rate="$total_rate" 'BEGIN {
+    if (rate <= 0) exit
+    print now / rate
+  }')
+  time_remaining=$(format_hours "$remain_hours")
+elif ((${#pack_times[@]} > 0)); then
+  time_remaining=${pack_times[0]}
+fi
+
+cycles=""
+for cycle in "${cycles_list[@]}"; do
+  if [[ -z $cycles ]]; then
+    cycles=$cycle
+  else
+    cycles+=", $cycle"
+  fi
+done
 
 if [[ $shell_output == "true" ]]; then
   printf 'percentage\t%s\n' "${percentage}%"
-  if [[ $charge_holding == "true" ]]; then
-    printf 'state\tholding\n'
-  else
-    printf 'state\t%s\n' "$state"
-  fi
+  printf 'state\t%s\n' "$state"
   printf 'rate\t%s\n' "${power_rate}W"
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
-
-  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
-
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 
   if [[ -n $threshold_end ]]; then
-    if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
+    if [[ -n $threshold_start && $threshold_start != "$threshold_end" ]]; then
       printf 'threshold\t%s-%s%%\n' "$threshold_start" "$threshold_end"
     else
       printf 'threshold\t%s%%\n' "$threshold_end"
     fi
   fi
 
+  for i in "${!pack_paths[@]}"; do
+    printf 'pack.%s.path\t%s\n' "$i" "${pack_paths[$i]}"
+    printf 'pack.%s.percentage\t%s\n' "$i" "${pack_percentages[$i]}"
+    printf 'pack.%s.state\t%s\n' "$i" "${pack_states[$i]}"
+    printf 'pack.%s.size\t%s\n' "$i" "${pack_sizes[$i]}"
+    printf 'pack.%s.rate\t%s\n' "$i" "${pack_rates[$i]}"
+    [[ -n ${pack_cycles[$i]} ]] && printf 'pack.%s.cycles\t%s\n' "$i" "${pack_cycles[$i]}"
+  done
+
   exit 0
 fi
 
-if [[ $charge_holding == "true" ]]; then
-  if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
+if [[ $state == "holding" ]]; then
+  if [[ -n $threshold_start && $threshold_start != "$threshold_end" ]]; then
     threshold_label="${threshold_start}-${threshold_end}%"
   else
     threshold_label="${threshold_end}%"

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -20,6 +20,78 @@ function parseKeyValue(raw) {
   return next
 }
 
+function parsePacks(info) {
+  var kv = info || {}
+  var packs = []
+  for (var i = 0; i < 16; i++) {
+    var prefix = "pack." + i + "."
+    if (kv[prefix + "path"] === undefined && kv[prefix + "percentage"] === undefined) break
+    packs.push({
+      path: kv[prefix + "path"] || ("BAT" + i),
+      percentage: kv[prefix + "percentage"] || "",
+      state: kv[prefix + "state"] || "",
+      size: kv[prefix + "size"] || "",
+      rate: kv[prefix + "rate"] || "",
+      cycles: kv[prefix + "cycles"] || ""
+    })
+  }
+  return packs
+}
+
+function packSummary(pack) {
+  var parts = []
+  if (pack && pack.percentage) parts.push(pack.percentage)
+  if (pack && pack.state) parts.push(pack.state)
+  if (pack && pack.rate && pack.state === "charging") parts.push(pack.rate)
+  return parts.join(" · ")
+}
+
+function combinedFractionFromStatus(info) {
+  var raw = info && info.percentage
+  if (raw === undefined || raw === "") return -1
+  var value = parseFloat(String(raw).replace("%", ""))
+  if (isNaN(value)) return -1
+  return Math.max(0, Math.min(1, value / 100))
+}
+
+function laptopDevices(devices) {
+  var list = Array.isArray(devices) ? devices : []
+  var packs = []
+  for (var i = 0; i < list.length; i++) {
+    var device = list[i]
+    if (!device || !device.isPresent) continue
+    if (device.isLaptopBattery === false) continue
+    var path = String(device.nativePath || "")
+    if (path === "DisplayDevice") continue
+    packs.push(device)
+  }
+  return packs
+}
+
+function combinedEnergyFraction(devices) {
+  var packs = laptopDevices(devices)
+  if (packs.length === 0) return -1
+
+  var now = 0
+  var full = 0
+  for (var i = 0; i < packs.length; i++) {
+    now += Number(packs[i].energy || 0)
+    full += Number(packs[i].energyCapacity || 0)
+  }
+  if (full > 0) return Math.max(0, Math.min(1, now / full))
+  return batteryFraction(packs[0])
+}
+
+function anyPackCharging(devices, states) {
+  var packs = laptopDevices(devices)
+  var s = states || {}
+  for (var i = 0; i < packs.length; i++) {
+    var device = packs[i]
+    if (device.state === s.Charging && Number(device.changeRate || 0) > 0.2) return true
+  }
+  return false
+}
+
 function parseProfiles(raw, previousIndex) {
   var lines = String(raw || "").split("\n")
   var list = []
@@ -60,17 +132,33 @@ function chargeThresholdActive(device, onBattery, states) {
   if (d.state === s.FullyCharged && fraction < 0.99) return true
   if (d.state !== s.Charging || fraction >= 0.99) return false
 
-  return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
+  // A slow charge into a large or second pack can take well over eight hours.
+  // Only treat the pack as holding when current has actually stalled.
+  return Number(d.changeRate || 0) <= 0.2
 }
 
-function batteryIcon(device, onBattery, states) {
+function chargeThresholdActiveForPacks(devices, onBattery, states, statusInfo) {
+  if (statusInfo && statusInfo.state === "holding") return true
+  if (statusInfo && (statusInfo.state === "charging" || statusInfo.state === "discharging")) return false
+  if (anyPackCharging(devices, states)) return false
+
+  var packs = laptopDevices(devices)
+  if (packs.length === 0) return chargeThresholdActive(null, onBattery, states)
+
+  for (var i = 0; i < packs.length; i++) {
+    if (!chargeThresholdActive(packs[i], onBattery, states)) return false
+  }
+  return true
+}
+
+function batteryIcon(device, onBattery, states, thresholdOverride) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
-  var threshold = chargeThresholdActive(d, onBattery, states)
+  var threshold = thresholdOverride !== undefined ? !!thresholdOverride : chargeThresholdActive(d, onBattery, states)
 
   if (threshold) return defaultIcons[index]
   if (d.state === states.FullyCharged) return "󰂅"
@@ -94,10 +182,17 @@ if (typeof module !== "undefined") {
     clampIndex: clampIndex,
     selectProfileIndex: selectProfileIndex,
     parseKeyValue: parseKeyValue,
+    parsePacks: parsePacks,
+    packSummary: packSummary,
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    combinedFractionFromStatus: combinedFractionFromStatus,
+    laptopDevices: laptopDevices,
+    combinedEnergyFraction: combinedEnergyFraction,
+    anyPackCharging: anyPackCharging,
     chargeThresholdActive: chargeThresholdActive,
+    chargeThresholdActiveForPacks: chargeThresholdActiveForPacks,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel
   }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -20,6 +20,8 @@ Panel {
   property int profileIndex: 0
   property bool cursorActive: false
   readonly property bool showPercentage: setting("showPercentage", false) === true
+  readonly property var powerDevices: UPower.devices ? UPower.devices.values : []
+  readonly property var batteryPacks: Model.parsePacks(root.batteryInfo)
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
@@ -49,7 +51,14 @@ Panel {
 
   function batteryIcon() {
     var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    if (!device || !device.isPresent) return ""
+    return Model.batteryIcon({
+      isPresent: true,
+      percentage: root.batteryFraction,
+      state: device.state,
+      changeRate: device.changeRate,
+      timeToFull: device.timeToFull
+    }, root.discharging, upowerStates(), root.chargeThresholdActive)
   }
 
   function modeLabel() {
@@ -70,19 +79,22 @@ Panel {
     return !!(device && device.isPresent && UPower.onBattery)
   }
   readonly property bool chargeThresholdActive: {
-    var device = UPower.displayDevice
-    return Model.chargeThresholdActive(device, root.discharging, upowerStates())
+    return Model.chargeThresholdActiveForPacks(root.powerDevices, root.discharging, upowerStates(), root.batteryInfo)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
 
   // 0..1 charge level, used by the visual progress bar.
   readonly property real batteryFraction: {
-    var d = UPower.displayDevice
-    return Model.batteryFraction(d)
+    var fromStatus = Model.combinedFractionFromStatus(root.batteryInfo)
+    if (fromStatus >= 0) return fromStatus
+    var fromPacks = Model.combinedEnergyFraction(root.powerDevices)
+    if (fromPacks >= 0) return fromPacks
+    return Model.batteryFraction(UPower.displayDevice)
   }
 
   readonly property bool charging: {
+    if (Model.anyPackCharging(root.powerDevices, upowerStates())) return true
     var d = UPower.displayDevice
     return d && d.isPresent && !UPower.onBattery && !root.batteryFlowIdle
   }
@@ -444,6 +456,31 @@ Panel {
             InfoPair {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
+            }
+          }
+        }
+
+        Column {
+          visible: root.batteryPacks.length > 1
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSeparator {
+            foreground: root.bar.foreground
+          }
+
+          PanelSectionHeader {
+            text: "PACKS"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Repeater {
+            model: root.batteryPacks
+            InfoPair {
+              required property var modelData
+              label: modelData.path || "Battery"
+              value: Model.packSummary(modelData)
             }
           }
         }

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -43,9 +43,132 @@ grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery st
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'pack.0.path\tBAT0' <<<"$shell_output" >/dev/null || fail "battery status reports the single pack path"
+grep -Fx $'pack.0.percentage\t51%' <<<"$shell_output" >/dev/null || fail "battery status reports the single pack percentage"
+
+pass "battery status owns capacity and remaining calculations"
+
+dual_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$dual_dir"' EXIT
+
+mkdir -p "$dual_dir/bin" "$dual_dir/power/BAT0" "$dual_dir/power/BAT1" "$dual_dir/power/AC"
+printf 'Mains\n' >"$dual_dir/power/AC/type"
+printf '1\n' >"$dual_dir/power/AC/online"
+printf '0\n' >"$dual_dir/power/BAT0/power_now"
+printf '7\n' >"$dual_dir/power/BAT0/cycle_count"
+printf '3611000\n' >"$dual_dir/power/BAT1/power_now"
+printf '2\n' >"$dual_dir/power/BAT1/cycle_count"
+cat >"$dual_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT1 ]]; then
+  cat <<'INFO'
+  native-path:          BAT1
+  state:                charging
+  energy:               0.09 Wh
+  energy-full:          71.04 Wh
+  energy-rate:          3.611 W
+  time to full:         19.6 hours
+  percentage:           0%
+  charge-start-threshold:        75%
+  charge-end-threshold:          80%
+INFO
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  energy:               22.54 Wh
+  energy-full:          25.01 Wh
+  energy-rate:          0 W
+  percentage:           90%
+  charge-start-threshold:        75%
+  charge-end-threshold:          80%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$dual_dir/bin/upower"
+
+dual_output=$(OMARCHY_POWER_SUPPLY_PATH="$dual_dir/power" PATH="$dual_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t23%' <<<"$dual_output" >/dev/null || fail "dual battery status uses combined energy percentage" "$dual_output"
+grep -Fx $'state\tcharging' <<<"$dual_output" >/dev/null || fail "dual battery status is charging when any pack is taking current" "$dual_output"
+grep -Fx $'rate\t3.6W' <<<"$dual_output" >/dev/null || fail "dual battery status sums live pack rates" "$dual_output"
+grep -Fx $'size\t96Wh' <<<"$dual_output" >/dev/null || fail "dual battery status sums pack capacities" "$dual_output"
+grep -Fx $'cycles\t7, 2' <<<"$dual_output" >/dev/null || fail "dual battery status lists both pack cycle counts" "$dual_output"
+grep -Fx $'pack.0.state\tholding' <<<"$dual_output" >/dev/null || fail "dual battery status marks the capped pack as holding" "$dual_output"
+grep -Fx $'pack.1.state\tcharging' <<<"$dual_output" >/dev/null || fail "dual battery status marks the charging pack" "$dual_output"
+grep -Fx $'pack.1.percentage\t0%' <<<"$dual_output" >/dev/null || fail "dual battery status reports the empty pack percentage" "$dual_output"
+
+pass "dual battery status aggregates packs and still shows each one"
+
+hold_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$dual_dir" "$hold_dir"' EXIT
+mkdir -p "$hold_dir/bin" "$hold_dir/power/BAT0" "$hold_dir/power/BAT1" "$hold_dir/power/AC"
+printf 'Mains\n' >"$hold_dir/power/AC/type"
+printf '1\n' >"$hold_dir/power/AC/online"
+printf '0\n' >"$hold_dir/power/BAT0/power_now"
+printf '0\n' >"$hold_dir/power/BAT1/power_now"
+cat >"$hold_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT1 ]]; then
+  cat <<'INFO'
+  native-path:          BAT1
+  state:                pending-charge
+  energy:               56.0 Wh
+  energy-full:          71.04 Wh
+  energy-rate:          0 W
+  percentage:           79%
+  charge-start-threshold:        75%
+  charge-end-threshold:          80%
+INFO
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  energy:               22.54 Wh
+  energy-full:          25.01 Wh
+  energy-rate:          0 W
+  percentage:           90%
+  charge-start-threshold:        75%
+  charge-end-threshold:          80%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$hold_dir/bin/upower"
+
+hold_output=$(OMARCHY_POWER_SUPPLY_PATH="$hold_dir/power" PATH="$hold_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'state\tholding' <<<"$hold_output" >/dev/null || fail "dual battery status is holding when every pack is at rest on AC" "$hold_output"
+grep -Fx $'percentage\t81%' <<<"$hold_output" >/dev/null || fail "dual battery holding state still uses combined energy" "$hold_output"
+
+pass "dual battery status holds when both packs are at the charge cap"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"
 fi
 
-pass "battery status owns capacity and remaining calculations"
+pass "removed per-field battery helpers stay gone"

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -15,6 +15,32 @@ assertEqual(power.selectProfileIndex(1, 1, ['balanced', 'performance']), 1, 'pow
 
 assertDeepEqual(power.parseKeyValue('time\t2:00\nenergy\t42\n'), { time: '2:00', energy: '42' }, 'power parses key-value output')
 assertDeepEqual(
+  power.parsePacks({
+    'pack.0.path': 'BAT0',
+    'pack.0.percentage': '90%',
+    'pack.0.state': 'holding',
+    'pack.1.path': 'BAT1',
+    'pack.1.percentage': '0%',
+    'pack.1.state': 'charging',
+    'pack.1.rate': '3.6W'
+  }),
+  [
+    { path: 'BAT0', percentage: '90%', state: 'holding', size: '', rate: '', cycles: '' },
+    { path: 'BAT1', percentage: '0%', state: 'charging', size: '', rate: '3.6W', cycles: '' }
+  ],
+  'power parses pack rows from battery-status'
+)
+assertEqual(power.packSummary({ percentage: '0%', state: 'charging', rate: '3.6W' }), '0% · charging · 3.6W', 'power summarizes a charging pack')
+assertEqual(power.combinedFractionFromStatus({ percentage: '23%' }), 0.23, 'power reads combined percentage from status')
+assertEqual(
+  power.combinedEnergyFraction([
+    { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', energy: 22.54, energyCapacity: 25.01 },
+    { isPresent: true, isLaptopBattery: true, nativePath: 'BAT1', energy: 0.09, energyCapacity: 71.04 }
+  ]).toFixed(4),
+  (22.63 / 96.05).toFixed(4),
+  'power combines pack energy for the bar fill'
+)
+assertDeepEqual(
   power.parseProfiles('power-saver\t0\nbalanced\t1\nperformance\t0\n', 5),
   { profiles: ['power-saver', 'balanced', 'performance'], activeProfile: 'balanced', profileIndex: 2 },
   'power parses profile output and clamps selection'
@@ -26,7 +52,24 @@ assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'pow
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.24, state: states.Charging, changeRate: 3.6, timeToFull: 20 * 60 * 60 }, false, states), 'power does not treat a long charge into a second pack as holding')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
+assert(
+  !power.chargeThresholdActiveForPacks(
+    [
+      { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', percentage: 0.9, state: states.FullyCharged, changeRate: 0 },
+      { isPresent: true, isLaptopBattery: true, nativePath: 'BAT1', percentage: 0.01, state: states.Charging, changeRate: 3.6, timeToFull: 20 * 60 * 60 }
+    ],
+    false,
+    states,
+    { state: 'charging' }
+  ),
+  'power uses the charging pack, not the capped pack, for threshold'
+)
+assert(
+  power.chargeThresholdActiveForPacks([], false, states, { state: 'holding' }),
+  'power trusts battery-status holding state'
+)
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
@@ -48,4 +91,7 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(/batteryPacks\.length > 1/.test(panelSource), 'power lists packs only when more than one battery is present')
+assert(/Model\.parsePacks\(root\.batteryInfo\)/.test(panelSource), 'power reads pack rows from battery-status')
+assert(/chargeThresholdActiveForPacks/.test(panelSource), 'power decides holding from every laptop pack')
 JS


### PR DESCRIPTION
Fixes #6885.

On dual-battery ThinkPads the bar icon and the power panel disagreed: the icon used UPower's composite `DisplayDevice`, while `omarchy-battery-status` (and the panel numbers) took `upower -e | grep BAT | head -n 1` — always BAT0. A long charge into the second pack was also treated as holding because `timeToFull >= 8 hours`.

This keeps one bar icon and makes the numbers match.

- `omarchy-battery-status` aggregates every present `BAT*` pack (combined %, Wh, watts) and emits `pack.N.*` rows.
- The panel hero uses the combined pack. A PACKS section lists each battery when there is more than one.
- Holding only if AC is connected and no pack is taking current. A slow charge no longer counts as a charge limit.
- Notifications that call `omarchy-battery-status` get the same combined line.

Verified on a ThinkPad T480 (BAT0 holding at 90%, BAT1 charging): combined 33% / 96Wh / 26.9W, with both packs listed.

### Tests

- `test/shell.d/battery-status-test.sh` — existing single-pack fixture still passes; added a T480-shaped charging fixture and a both-holding fixture.
- `test/shell.d/power-test.sh` — pack parsing, combined energy fraction, and the 20-hour charge not counting as holding.

`./test/all`: CLI suite green. Shell suite: our files pass. Four other files failed on this machine independently of this change (bar-icon-geometry already fails on clean `quattro` by 0.59px on the monitor glyph; config/snapper/unowned-system-paths need an `omarchy-pkgs` checkout).

### Screenshots

Before/after of the open power panel:

- Before (BAT0 only):
<img width="583" height="393" alt="screenshot-2026-08-16_15-43-55" src="https://github.com/user-attachments/assets/495141df-67bc-422a-b674-045b0fde1f48" />


- After (combined + packs): 
<img width="591" height="532" alt="screenshot-2026-08-16_15-51-45" src="https://github.com/user-attachments/assets/1488cdfc-9da7-4278-bb5e-fd12e4c25c34" />

Filed by Grok 4.6 via Grok Build.