### PR TITLE
Honor OMARCHY_SCREENRECORD_USE_PORTAL when recording fullscreen

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -151,12 +151,12 @@ start_screenrecording() {
   # the portal backend supports and the kms backend doesn't). Default flow uses
   # slurp + the kms backend, which avoids the EGL DMA-BUF modifier import
   # failures the portal path can hit on some configurations.
-  if [[ $FULLSCREEN == "true" ]]; then
-    target="monitor:$(omarchy-hyprland-monitor-focused)"
-    capture_args=(-w "${target#monitor:}" -s "${RESOLUTION:-$(default_resolution)}")
-  elif [[ ${OMARCHY_SCREENRECORD_USE_PORTAL:-false} == "true" ]]; then
+  if [[ ${OMARCHY_SCREENRECORD_USE_PORTAL:-false} == "true" ]]; then
     target="portal"
     capture_args=(-w portal -s "${RESOLUTION:-$(default_resolution)}")
+  elif [[ $FULLSCREEN == "true" ]]; then
+    target="monitor:$(omarchy-hyprland-monitor-focused)"
+    capture_args=(-w "${target#monitor:}" -s "${RESOLUTION:-$(default_resolution)}")
   else
     target=$(select_capture_target) || return 1
 


### PR DESCRIPTION
The header of `omarchy-capture-screenrecording` documents the portal backend as the opt-in path for "HDR-aware capture, support for monitors driven by external GPUs, and window capture", and the comment right above the branch repeats it. But `--fullscreen` is matched first and passes the focused monitor straight to the kms backend, so `OMARCHY_SCREENRECORD_USE_PORTAL=true` never applies on that path.

That matters on hybrid-GPU laptops. The kms backend attaches to one DRM card and only enumerates that card's connectors, so a monitor driven by the other GPU is invisible to it:

```
$ gpu-screen-recorder --list-capture-options
eDP-1|1920x1080     # Intel, card2
region
portal              # no HDMI-A-1 — that's on the NVIDIA card1
```

```
gsr error: display "HDMI-A-1" not found, expected one of:
  "screen"
  "eDP-1"    (1920x1080+1920+0)
```

Since `ALT + PRINT` passes `--fullscreen`, there was no configuration in which it could record that monitor — even with the variable set, and even though the portal backend records it fine.

Checking the variable first makes it apply to every capture path. No change for anyone who doesn't set it.

Reported in #7184.
