### PR TITLE
Report screen recordings that fail to start

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -198,6 +198,10 @@ start_screenrecording() {
   if kill -0 $pid 2>/dev/null; then
     echo "$filename" >"$RECORDING_FILE"
     toggle_screenrecording_indicator
+  else
+    omarchy-notification-send -u critical -t 3000 "Screen recording failed to start" \
+      "Set OMARCHY_SCREENRECORD_DEBUG=true and retry to log why."
+    return 1
   fi
 }
 


### PR DESCRIPTION
`start_screenrecording` already notices when `gpu-screen-recorder` dies before writing the output file — the wait loop breaks on the dead pid and the `kill -0` guard fails — but the failure branch didn't exist. No notification, nothing on screen. A recording that never starts is indistinguishable from a keybinding that does nothing, and the stderr explaining why goes to `/dev/null` unless `OMARCHY_SCREENRECORD_DEBUG=true` is already set, which nobody sets before the first failure.

This adds the missing `else`: notify, and return non-zero, which the caller at the bottom already treats as failure (`start_screenrecording || cleanup_webcam`).

Verified by forcing a start failure — the notification fires with the message pointing at the debug variable.

Independent of #7184 and of the portal-ordering PR; this one is about surfacing *any* start failure, whatever the cause.

One thing I left alone: the script's own exit status still comes from that `|| cleanup_webcam`, so `omarchy capture screenrecording` continues to exit 0 on failure. Happy to change that too if you'd want it.
