### PR TITLE
Make monochrome tray icons readable on any theme

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -782,9 +782,25 @@ BarWidget {
       layer.enabled: trayIconRoot.symbolic
     }
 
+    // Colorization multiplies the target color by the source's luminance, so it
+    // can only reach the foreground from a near-white fill: #333 comes out at
+    // #2b2b2b however it is tinted. Symbolic icons are not required to be light
+    // — Solaar asks for the themed "battery-full", which Yaru draws at #333 —
+    // so flatten the fill to white first and let the second pass land on the
+    // exact foreground. Brightness is applied after colorization within a single
+    // MultiEffect, so this has to be two.
     MultiEffect {
+      id: trayIconWhitened
       anchors.fill: trayIconImage
       source: trayIconImage
+      visible: false
+      layer.enabled: trayIconRoot.symbolic
+      brightness: 1.0
+    }
+
+    MultiEffect {
+      anchors.fill: trayIconImage
+      source: trayIconWhitened
       visible: trayIconRoot.symbolic
       colorization: 1.0
       colorizationColor: root.foreground

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -623,12 +623,12 @@ BarWidget {
             anchors.verticalCenter: parent.verticalCenter
             anchors.right: parent.right
             iconText: "\uf08d"
-            text: rowRoot.isPinned ? "Unpin" : "Pin"
+            tooltipText: rowRoot.isPinned ? "Unpin" : "Pin"
+            selected: rowRoot.isPinned
             foreground: root.foreground
             horizontalPadding: 8
             verticalPadding: 3
             iconSize: Style.font.bodySmall
-            fontSize: Style.font.bodySmall
             onClicked: root.togglePin(rowRoot.itemId)
           }
 
@@ -638,12 +638,12 @@ BarWidget {
             anchors.right: rowPinBtn.left
             anchors.rightMargin: Style.space(6)
             iconText: "\uf06e"
-            text: rowRoot.isHidden ? "Show" : "Hide"
+            tooltipText: rowRoot.isHidden ? "Show" : "Hide"
+            selected: rowRoot.isHidden
             foreground: root.foreground
             horizontalPadding: 8
             verticalPadding: 3
             iconSize: Style.font.bodySmall
-            fontSize: Style.font.bodySmall
             onClicked: root.toggleHide(rowRoot.itemId)
           }
         }

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -20,6 +20,15 @@ BarWidget {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property var pinnedIds: settings.pinned instanceof Array ? settings.pinned : []
   readonly property var hiddenIds: settings.hidden instanceof Array ? settings.hidden : []
+
+  // Measured verdicts, keyed by icon URL. This doubles as the "already done"
+  // flag: a URL present here is never measured again, so the sampler below
+  // touches each distinct icon once no matter how often the tray churns.
+  property var autoRecolorMap: ({})
+  // URLs waiting for the sampler, and the one it currently holds.
+  property var measureQueue: []
+  property string measuringUrl: ""
+  readonly property color barBackground: bar ? bar.background : Color.background
   readonly property var pinnedItems: bucket("pinned")
   readonly property var drawerItems: bucket("drawer")
   readonly property var allItems: bucket("all")
@@ -148,6 +157,75 @@ BarWidget {
     return name.slice(-9) === "-symbolic"
   }
 
+  // Reassign rather than mutate: a binding on autoRecolorMap only re-evaluates
+  // when the property itself changes.
+  function noteAutoRecolor(url, value) {
+    var next = {}
+    for (var key in root.autoRecolorMap) next[key] = root.autoRecolorMap[key]
+    next[url] = value
+    root.autoRecolorMap = next
+  }
+
+  // Called whenever the tray changes. allItems hands back a fresh array on
+  // every evaluation, so this runs constantly — that is fine, because it only
+  // ever appends URLs it has not seen. Crucially it instantiates no QML
+  // object: driving a Repeater from this list instead recreates a Canvas per
+  // icon on every tray update, and those are not released promptly.
+  function enqueueUnmeasured() {
+    var items = root.allItems
+    var queue = root.measureQueue
+    // One pass to build the membership set, so the scan below stays linear in
+    // the number of tray items rather than quadratic against the queue.
+    var known = {}
+    for (var q = 0; q < queue.length; q++) known[queue[q]] = true
+    var pending = []
+    for (var i = 0; i < items.length; i++) {
+      var url = String(items[i].icon || "")
+      if (url === "") continue
+      if (root.autoRecolorMap[url] !== undefined) continue
+      if (url === root.measuringUrl) continue
+      if (known[url]) continue
+      known[url] = true
+      pending.push(url)
+    }
+    if (pending.length > 0) root.measureQueue = queue.concat(pending)
+    startNextMeasurement()
+  }
+
+  function startNextMeasurement() {
+    if (root.measuringUrl !== "") return
+    if (root.measureQueue.length === 0) return
+    var queue = root.measureQueue.slice()
+    var url = queue.shift()
+    root.measureQueue = queue
+    root.measuringUrl = url
+  }
+
+  function finishMeasurement(url, value) {
+    // Ignore anything that is not retiring the measurement currently in flight.
+    // Nothing can interleave here — QML runs onPaint and a Timer on the same
+    // thread — but this keeps a stale completion from ever being attributed to
+    // whichever URL happens to be next.
+    if (url === "" || url !== root.measuringUrl) return
+    root.noteAutoRecolor(url, value)
+    // Drop the decoded image; only one is held at a time.
+    iconProbe.unloadImage(url)
+    measureTimeout.stop()
+    root.measuringUrl = ""
+    startNextMeasurement()
+  }
+
+  // A verdict is relative to the bar, so a theme change invalidates all of them.
+  onBarBackgroundChanged: {
+    root.autoRecolorMap = ({})
+    root.measureQueue = []
+    root.measuringUrl = ""
+    enqueueUnmeasured()
+  }
+
+  onAllItemsChanged: enqueueUnmeasured()
+  Component.onCompleted: enqueueUnmeasured()
+
   function trayTooltip(item) {
     return item.tooltipTitle || item.title || item.id || ""
   }
@@ -208,6 +286,67 @@ BarWidget {
       if (pi !== -1) p.splice(pi, 1)
     }
     persistTrayState(p, h)
+  }
+
+  // Exactly one canvas for the widget's lifetime, working through measureQueue.
+  // Canvas is the only QML element that exposes pixels (Image has no accessor
+  // and grabToImage only offers saveToFile), and sampling through Qt's image
+  // pipeline means an icon delivered as a pixmap over D-Bus is measurable too.
+  //
+  // It stays in the render pass on purpose: a Canvas that is never rendered
+  // never paints, so visible:false silently skips every measurement. opacity 0
+  // still composites.
+  Canvas {
+    id: iconProbe
+    opacity: 0
+    z: -1
+    width: 24
+    height: 24
+    renderStrategy: Canvas.Immediate
+    renderTarget: Canvas.Image
+
+    onImageLoaded: requestPaint()
+    onPaint: {
+      var url = root.measuringUrl
+      if (url === "" || !isImageLoaded(url)) return
+
+      var ctx = getContext("2d")
+      ctx.clearRect(0, 0, width, height)
+      ctx.drawImage(url, 0, 0, width, height)
+
+      // The walk and its thresholds live in TrayModel: a threshold referenced
+      // from here as TrayModel.saturatedPixel reads undefined, because only the
+      // top-level names cross into QML and the camelCase exports are for the
+      // Node tests. Every comparison against it was false, so every icon looked
+      // like a silhouette and full-color icons were being recolored too.
+      var sample = TrayModel.samplePixels(ctx.getImageData(0, 0, width, height).data)
+      if (sample.opaque === 0) {
+        root.finishMeasurement(url, false)
+        return
+      }
+      var background = root.barBackground
+      root.finishMeasurement(url, TrayModel.sampleNeedsRecolor(
+        sample,
+        TrayModel.relativeLuminance(background.r, background.g, background.b)))
+    }
+  }
+
+  // An icon that never loads must not stall the queue behind it.
+  Timer {
+    id: measureTimeout
+    // Armed for one specific URL rather than reading measuringUrl when it fires:
+    // a timeout should only ever retire the measurement it was started for.
+    property string url: ""
+    interval: 2000
+    onTriggered: root.finishMeasurement(measureTimeout.url, false)
+  }
+
+  onMeasuringUrlChanged: {
+    if (root.measuringUrl === "") return
+    measureTimeout.url = root.measuringUrl
+    measureTimeout.restart()
+    iconProbe.loadImage(root.measuringUrl)
+    iconProbe.requestPaint()
   }
 
   visible: pinnedItems.length > 0 || drawerCount > 0
@@ -767,6 +906,7 @@ BarWidget {
     id: trayIconRoot
     required property var icon
     readonly property bool symbolic: root.iconIsSymbolic(icon)
+      || root.autoRecolorMap[String(icon)] === true
 
     Image {
       id: trayIconImage

--- a/shell/plugins/bar/widgets/TrayModel.js
+++ b/shell/plugins/bar/widgets/TrayModel.js
@@ -30,6 +30,82 @@ function layoutHasWidget(layout, id) {
   return false
 }
 
+// Recolor decisions are made from an icon's pixels, not its name: Solaar asks
+// for the themed "battery-full" (Yaru draws it at #333, for a light panel) and
+// Steam publishes "steam_tray_mono", and neither carries anything the
+// StatusNotifierItem protocol defines. Tray.qml walks the pixels, which needs a
+// Canvas; these take the summary and apply the thresholds.
+
+// A pixel counts as colored above this HSV saturation...
+var SATURATED_PIXEL = 0.15
+// ...and an icon counts as a flat silhouette below this share of them.
+// Saturation is what separates a symbolic icon from a saturated single-hue
+// logo: hue spread alone reads Battle.net and btop as monochrome.
+var SILHOUETTE_MAX_COLORED = 0.15
+// WCAG contrast against the bar, so recoloring stops at icons that are
+// genuinely hard to read and a readable flat brand color keeps its own.
+var MIN_READABLE_CONTRAST = 3.0
+
+function channelToLinear(c) {
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+}
+
+function relativeLuminance(r, g, b) {
+  return 0.2126 * channelToLinear(r) + 0.7152 * channelToLinear(g) + 0.0722 * channelToLinear(b)
+}
+
+function contrastRatio(a, b) {
+  var hi = Math.max(a, b)
+  var lo = Math.min(a, b)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+// sample: { opaque, colored, luminance }
+// Below this alpha a pixel is the transparent field around the glyph, and
+// averaging it in would wash out the reading.
+var ALPHA_FLOOR = 40
+
+// data is a flat RGBA byte array, as Canvas getImageData().data hands it over.
+// Returns the summary the decision below needs. Lives here rather than in QML so
+// the thresholds are covered by the tests and never have to be referenced across
+// the QML/JS boundary — TrayModel.saturatedPixel reads as undefined from QML,
+// which silently made every comparison false and every icon a silhouette.
+function samplePixels(data) {
+  var opaque = 0
+  var colored = 0
+  var luminance = 0
+  // Step whole pixels only. A trailing partial group is not a pixel, and reading
+  // past it yields undefined channels: undefined <= ALPHA_FLOOR is false, so the
+  // fragment would count as opaque and its missing channels would poison the
+  // luminance average with NaN.
+  for (var i = 0; i + 3 < data.length; i += 4) {
+    if (data[i + 3] <= ALPHA_FLOOR) continue
+    var r = data[i] / 255
+    var g = data[i + 1] / 255
+    var b = data[i + 2] / 255
+    opaque++
+    var mx = Math.max(r, g, b)
+    var mn = Math.min(r, g, b)
+    if (mx > 0 && (mx - mn) / mx > SATURATED_PIXEL) colored++
+    luminance += relativeLuminance(r, g, b)
+  }
+  return {
+    opaque: opaque,
+    colored: colored,
+    luminance: opaque > 0 ? luminance / opaque : 0
+  }
+}
+
+function sampleIsSilhouette(sample) {
+  if (!sample || !sample.opaque) return false
+  return (sample.colored / sample.opaque) < SILHOUETTE_MAX_COLORED
+}
+
+function sampleNeedsRecolor(sample, backgroundLuminance) {
+  if (!sampleIsSilhouette(sample)) return false
+  return contrastRatio(sample.luminance, backgroundLuminance) < MIN_READABLE_CONTRAST
+}
+
 // LocalSend's item shows no state, offers only Open and Quit, and its primary
 // click is a no-op, so Share > Receive is the whole surface. Hiding it by hand
 // doesn't stick either: LocalSend picks a fresh tray id every launch.
@@ -42,6 +118,11 @@ if (typeof module !== "undefined") {
   module.exports = {
     itemNamed: itemNamed,
     entryId: entryId,
+    relativeLuminance: relativeLuminance,
+    samplePixels: samplePixels,
+    contrastRatio: contrastRatio,
+    sampleIsSilhouette: sampleIsSilhouette,
+    sampleNeedsRecolor: sampleNeedsRecolor,
     layoutHasWidget: layoutHasWidget,
     ownedByOmarchy: ownedByOmarchy
   }

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -8,6 +8,53 @@ run_node_test "tray model helpers" <<'JS'
 const tray = requireFromRoot('shell/plugins/bar/widgets/TrayModel.js')
 
 assert(tray.itemNamed({ id: 'dropbox-client' }, 'dropbox'), 'tray matches item ids')
+
+// Recolor decisions are made from an icon's pixels, not its name. samplePixels
+// walks a flat RGBA array exactly as Canvas getImageData().data hands it over,
+// and owns the thresholds: referencing them from QML instead read undefined,
+// which made every comparison false and every icon look like a silhouette.
+const rgba = (n, r, g, b, a = 255) => {
+  const out = []
+  for (let i = 0; i < n; i++) out.push(r, g, b, a)
+  return out
+}
+const barLum = tray.relativeLuminance(0x2e / 255, 0x34 / 255, 0x40 / 255)
+const lumOf = (v) => tray.relativeLuminance(v / 255, v / 255, v / 255)
+
+const flatDark = tray.samplePixels(rgba(100, 0x33, 0x33, 0x33))
+assert(flatDark.opaque === 100, 'samplePixels counts every opaque pixel')
+assert(flatDark.colored === 0, 'a flat grey fill has no colored pixels')
+
+const teamsPurple = tray.samplePixels(rgba(100, 75, 83, 188))
+assert(teamsPurple.colored === 100, 'a saturated fill is all colored pixels')
+
+assert(tray.samplePixels(rgba(100, 0x33, 0x33, 0x33, 10)).opaque === 0,
+  'samplePixels ignores near-transparent pixels')
+assert(tray.samplePixels([]).opaque === 0, 'an empty buffer yields no pixels')
+
+// A buffer that is not a whole number of pixels must not contribute a partial
+// one: reading past the end gives undefined channels, and undefined <= the alpha
+// floor is false, so the fragment would count as opaque and poison the average.
+assert(tray.samplePixels(rgba(2, 0x33, 0x33, 0x33).slice(0, 5)).opaque === 1,
+  'a trailing partial pixel is ignored')
+assert(!Number.isNaN(tray.samplePixels(rgba(2, 0x33, 0x33, 0x33).slice(0, 6)).luminance),
+  'a truncated buffer does not produce NaN luminance')
+
+assert(tray.sampleIsSilhouette(flatDark), 'a flat grey sample is a silhouette')
+assert(!tray.sampleIsSilhouette(teamsPurple), 'a saturated sample is not a silhouette')
+assert(!tray.sampleIsSilhouette(tray.samplePixels([])), 'an empty sample is not a silhouette')
+
+assert(tray.sampleNeedsRecolor(flatDark, barLum),
+  'tray recolors a dark silhouette that cannot be read on the bar')
+assert(!tray.sampleNeedsRecolor(teamsPurple, barLum),
+  'tray leaves a full-color icon its own colors')
+assert(!tray.sampleNeedsRecolor(tray.samplePixels(rgba(100, 0xde, 0xde, 0xde)), barLum),
+  'tray leaves a light silhouette alone, it already contrasts')
+assert(!tray.sampleNeedsRecolor(flatDark, lumOf(0xf5)),
+  'the same dark silhouette is left alone on a light bar')
+
+assert(Math.abs(tray.contrastRatio(1, 0) - 21) < 0.001, 'contrast of white on black is 21:1')
+assert(Math.abs(tray.contrastRatio(0.5, 0.5) - 1) < 0.001, 'contrast of a color with itself is 1:1')
 assert(tray.itemNamed({ title: 'Dropbox' }, 'dropbox'), 'tray matches item titles')
 assert(tray.itemNamed({ tooltipTitle: 'LocalSend' }, 'localsend'), 'tray matches item tooltips')
 assert(!tray.itemNamed({ id: 'nextcloud' }, 'dropbox'), 'tray ignores items named for something else')


### PR DESCRIPTION
# Make monochrome tray icons readable on any theme

Monochrome tray icons render nearly invisible on a dark bar. Steam and Solaar are the two I hit, but the cause is general and affects any icon whose fill does not contrast with the bar.

## Screenshots

Before (Nord)
<img width="463" height="286" alt="image" src="https://github.com/user-attachments/assets/b3e6a1aa-fe83-4e24-a15d-f3c469a7f478" />

After (Nord)
<img width="492" height="304" alt="image" src="https://github.com/user-attachments/assets/0d4675e1-5675-4c53-a0f5-fa739a611ee2" />

After (Rose Pine)
<img width="492" height="305" alt="image" src="https://github.com/user-attachments/assets/058f819d-9e0e-4a96-9e6c-9ed87bc1ff5d" />

## The recolour was arithmetically unable to work

The tray already recolours symbolic icons to the bar foreground, but `MultiEffect`'s `colorization` multiplies the target colour by the *source's* luminance, so it can only reach the foreground from a near-white fill. Measured on Qt 6.11.1 with `colorizationColor` set to a bar foreground of `(216, 216, 216)`:

| source fill | colorized result |
| --- | --- |
| `#333333` | `(43, 43, 43)` |
| `#808080` | `(108, 108, 108)` |
| `#bebebe` | `(161, 161, 161)` |
| `#ffffff` | `(216, 216, 216)` |

Nothing requires a monochrome icon to be light. Yaru draws both `steam_tray_mono` and the `battery-full` that Solaar asks for at `#333`, for a light panel. Against a dark bar those recoloured to `#2b2b2b` and were effectively invisible.

Flattening the fill to white in a first pass lets the colorization pass land on the exact foreground. `brightness` is applied *after* colorization inside a single `MultiEffect`, so this has to be two passes. Rendering the real icon files at 24px, mean RGB over the non-transparent pixels:

| icon | before | after |
| --- | --- | --- |
| `Yaru/24x24/panel/steam_tray_mono.svg` | 52 | 226 |
| `Yaru/16x16/panel/battery-full.svg` | 52 | 228 |

The lit-pixel counts are identical before and after (826 and 620), so shape and antialiasing are untouched — only the colour changes.

## Names cannot decide which icons need it

Detection matched the freedesktop `-symbolic` suffix, which only catches icons that say what they are. Solaar asks for the themed `battery-full` and Steam publishes `steam_tray_mono` from its own `IconThemePath`; neither carries anything the StatusNotifierItem protocol defines. Widening the suffix list is guesswork that never converges, and asking users to flag icons by hand just moves the guess to them.

What makes an icon unreadable is measurable, so the widget samples its pixels and recolours when both hold:

- **near-greyscale** — under 15% of opaque pixels have HSV saturation above 0.15
- **poor contrast** — WCAG ratio against the bar background below 3:1

Both are required. Saturation is what separates a symbolic icon from a saturated single-hue logo: hue spread alone reads Battle.net and btop as monochrome. Requiring poor contrast as well keeps a flat brand colour that is already readable, and it makes the decision follow the theme — the same dark icons recoloured on a dark bar are left alone on a light one. The verdict is per bar background rather than per theme, so two bars configured with different backgrounds each get their own answer.

The existing name check is left exactly as it was, so icons that already declare themselves keep being recoloured whether or not they contrast. The measurement only adds cases.

To check the false-positive rate I ran the same two thresholds over 51 icon files offline — 40 application icons and 11 symbolic ones — reading them directly rather than through the widget's canvas. 6 were flagged and 45 left alone. Five of the six are genuine symbolic icons; the sixth is Foot's, dominantly `#282828` at contrast 2.2, which is a designed icon rather than a symbolic one but is genuinely hard to read where it sits.

## Two things about the implementation worth reviewing

**The pixel walk lives in `TrayModel`, not in the QML.** Only top-level names cross the QML/JS boundary, so a threshold referenced as `TrayModel.saturatedPixel` from QML comes back `undefined` — and `x > undefined` is quietly `false`, which classified *every* icon as a silhouette and recoloured full-colour icons too. Keeping the walk and its thresholds on the JS side removes that footgun and puts them under test.

**One canvas serves the whole widget, working a queue, with a verdict cached per icon URL.** The obvious shape — a `Repeater` over the icon list with a `Canvas` per delegate — does not hold up: `allItems` hands back a fresh array on every evaluation, so the model changes whenever any tray item updates and the delegates' canvases are destroyed and recreated. A `Canvas` also carries a fixed GPU cost that has nothing to do with how small you make it — a 24x24 RGBA buffer is 2 KB, but the allocation is a minimum render target, and it is not released promptly. Swapping this widget in and out within a single session measured about 1.5 MiB per canvas on one machine (NVIDIA, 4 GB); the figure will vary by driver, but the shape does not: a per-icon canvas turns routine tray churn into unbounded growth, while one canvas per widget is a fixed cost that does not scale with the number of tray icons.

The canvas and its verdicts are session-lived — nothing is written to disk. Each distinct icon is measured once per shell start, and a verdict is dropped when the bar background changes, since that is what it was measured against.

One known limitation: a verdict is keyed on the icon URL, and switching icon theme changes the file behind that URL without changing the URL itself, so cached verdicts go stale until the bar background changes or the shell restarts. It is worth knowing rather than worth guarding against here — an icon theme change is rare, nothing is lost when it happens, and the next shell start re-measures. Invalidating on theme change as well would be the fix if it turns out to matter.

Two smaller notes: the canvas stays in the render pass deliberately, because a `Canvas` that is never rendered never paints and `visible: false` would skip every measurement — it is `opacity: 0` instead. And sampling through Qt's image pipeline means an icon delivered as a pixmap over D-Bus is measurable too, not only one that resolves to a file: Teams arrives here as `image://qspixmap/1/1` with no `IconName` at all, measures at 482 of 576 pixels coloured, and keeps its own colours.

## The manage row

Both row buttons relabelled themselves as their state flipped — Pin became Unpin, Hide became Show. The strings are different widths, so the button resized on click and the row's other controls shifted under the cursor, at exactly the moment the pointer was still there to click again. The labels are gone; the glyphs stay, the wording moved to the tooltip `Ui/Button` already renders for `tooltipText`, and state reads from the selected fill. Nothing about the row's geometry now depends on what is toggled.

## Testing

- `test/shell.d/tray-test.sh` — 14 new assertions, 23 passing. They cover `samplePixels` over synthetic RGBA buffers exactly as `getImageData().data` hands them over (flat grey, saturated fill, near-transparent, empty), the silhouette and contrast thresholds, the light-bar case, and the contrast maths.
- Each of the three commits checked out in isolation: `qmllint` clean, tray tests green. The first predates the new tests and shows the pre-existing 9.
- Verified in the running shell on a dark and a light theme, switching back and forth: Solaar and Steam are recoloured on the dark bar, left alone on the light one, and Teams keeps its colours throughout. GPU memory stayed flat across the session.