### PR TITLE
#7135 - Keep playerctl installed for Voxtype users during Quattro upgrade

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -850,10 +850,18 @@ remove_retired_default_packages() {
     zoom
   )
 
+  # Voxtype's Omarchy-shipped default config enables pause_media, which shells
+  # out to playerctl. Removing playerctl out from under an installed Voxtype
+  # breaks media pause/resume during dictation, so keep it when Voxtype is present.
+  if package_installed_exact voxtype-bin; then
+    retired_packages=("${retired_packages[@]/playerctl}")
+  fi
+
   log "Removing packages retired from the Omarchy quattro default install"
   local pkg
   local installed_retired=()
   for pkg in "${retired_packages[@]}"; do
+    [[ -z $pkg ]] && continue
     if package_installed_exact "$pkg"; then
       installed_retired+=("$pkg")
     fi
@@ -877,9 +885,11 @@ remove_retired_default_packages() {
   local group group_pkg required_by_line
   local group_packages=()
   local installed_group=()
+  local waybar_group="waybar playerctl"
+  package_installed_exact voxtype-bin && waybar_group="waybar"
   local fallback_groups=(
     "omarchy-walker walker elephant-all elephant elephant-bluetooth elephant-calc elephant-clipboard elephant-desktopapplications elephant-files elephant-menus elephant-providerlist elephant-runner elephant-symbols elephant-todo elephant-unicode elephant-websearch"
-    "waybar playerctl"
+    "$waybar_group"
     "impala iwd"
     "blueberry bluetui"
     "wiremix pavucontrol"

--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -8,7 +8,8 @@ set -e
 # Install voxtype and configure it for use.
 
 if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
-  omarchy-pkg-add wtype voxtype-bin
+  # playerctl backs the pause_media option enabled in the default config.
+  omarchy-pkg-add wtype voxtype-bin playerctl
 
   # Setup voxtype
   mkdir -p ~/.config/voxtype

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -177,3 +177,15 @@ reboot_line=$(grep -n 'Rebooting because --reboot was passed' "$upgrade_to_quatt
 [[ -n $unsafe_line && -n $reboot_line ]] || fail "reboot gate and reboot branch exist"
 (( unsafe_line < reboot_line )) || fail "an unverified kernel cmdline blocks the reboot"
 pass "Omarchy 4 upgrade verifies the UKIs and refuses to reboot unverified"
+
+# The default Voxtype config enables pause_media, which shells out to
+# playerctl, so retiring playerctl out from under an installed Voxtype would
+# silently break media pause/resume during dictation.
+remove_retired_body=$(function_body remove_retired_default_packages)
+grep -F 'package_installed_exact voxtype-bin' <<<"$remove_retired_body" >/dev/null ||
+  fail "Omarchy 4 upgrade keeps playerctl installed when Voxtype is present"
+grep -F 'retired_packages=("${retired_packages[@]/playerctl}")' <<<"$remove_retired_body" >/dev/null ||
+  fail "Omarchy 4 upgrade drops playerctl from the retired-package list for Voxtype users"
+grep -F 'waybar_group="waybar"' <<<"$remove_retired_body" >/dev/null ||
+  fail "Omarchy 4 upgrade also spares playerctl from the waybar fallback removal group"
+pass "Omarchy 4 upgrade retains playerctl for installed Voxtype users"


### PR DESCRIPTION
Keep playerctl installed for Voxtype users during Quattro upgrade

Fixes #7135

**Problem**

The Quattro upgrader unconditionally retires playerctl, but Omarchy's shipped Voxtype config enables pause_media = true by default, which shells out to playerctl to pause/resume media during dictation. After upgrading, Voxtype users hit:

`WARN playerctl not found or failed to run: No such file or directory (os error 2)`

and media pause/resume during dictation silently stops working. Fresh Voxtype installs had a related gap: omarchy-voxtype-install never pulled in playerctl either, so a brand-new install with the default config was already broken out of the box.

**Fix**

- bin/omarchy-upgrade-to-quattro: in remove_retired_default_packages, skip removing playerctl when voxtype-bin is installed - both in the main batch removal and in the waybar playerctl fallback removal group used when the batch removal can't run as one transaction.
- bin/omarchy-voxtype-install: install playerctl alongside wtype/voxtype-bin so fresh installs aren't affected either.

This is scoped to only retain playerctl when Voxtype is actually present, so it doesn't change behavior for users who don't have Voxtype installed.

**Testing**

- Added assertions to test/shell.d/upgrade-to-quattro-test.sh covering the new guard in both the batch and fallback removal paths.
- Ran the full suite (./test/all): the changed/new tests pass. 4 unrelated pre-existing failures remain (config-test.sh, manifest-entrypoints-test.sh, snapper-test.sh, unowned-system-paths-test.sh) - confirmed these fail identically on main/stashed-out, due to this environment lacking a local omarchy-pkgs checkout, not caused by this change.

**Note**

Voxtype has since replaced its playerctl subprocess call with direct MPRIS D-Bus access (peteonrails/voxtype#487). Once Omarchy ships a Voxtype version built on that, this playerctl dependency (and this guard) can be dropped.