### PR TITLE
Persist Tmux workspaces with resurrect

### DIFF
--- a/bin/omarchy-tmux-resurrect-save
+++ b/bin/omarchy-tmux-resurrect-save
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# omarchy:summary=Save the current Tmux workspace through tmux-resurrect
+# omarchy:hidden=true
+
+set -euo pipefail
+
+plugin_dir="${TMUX_RESURRECT_PATH:-/usr/share/tmux-resurrect}"
+save_script="$plugin_dir/scripts/save.sh"
+lock_dir="${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/omarchy}/omarchy-tmux"
+
+tmux has-session 2>/dev/null || exit 0
+[[ $(tmux show-options -gqv @omarchy-resurrect-restoring) != "1" ]] || exit 0
+
+if [[ ! -x $save_script ]]; then
+  echo "Tmux resurrection support is not installed." >&2
+  exit 1
+fi
+
+mkdir -p "$lock_dir"
+exec 9>"$lock_dir/resurrect-save.lock"
+flock -n 9 || exit 0
+
+"$save_script" quiet

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -7,6 +7,22 @@ bind -N "Send prefix" C-Space send-prefix
 bind -N "Reload configuration" q source-file ~/.config/tmux/tmux.conf \; display "Configuration reloaded"
 bind -N "Show Tmux keybindings" ? display-popup -E -w 80% -h 70% -T "Tmux keybindings" "omarchy-menu-tmux-keybindings --print | less -R"
 
+# Persistent workspaces
+set -g @resurrect-dir '~/.local/state/omarchy/tmux/resurrect'
+run-shell /usr/share/tmux-resurrect/resurrect.tmux
+set-hook -g session-created[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g session-closed[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g window-linked[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g window-unlinked[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-split-window[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-kill-pane[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-rename-session[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-rename-window[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-select-layout[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g client-detached[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set -g @resurrect-hook-pre-restore-all 'tmux set-option -g @omarchy-resurrect-restoring 1'
+set -g @resurrect-hook-post-restore-all 'tmux set-option -gu @omarchy-resurrect-restoring; /usr/bin/omarchy-tmux-resurrect-save'
+
 # Vi mode for copy
 setw -g mode-keys vi
 bind -N "Begin selection" -T copy-mode-vi v send -X begin-selection

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -123,6 +123,7 @@ tesseract-data-eng
 tldr
 tree-sitter-cli
 tmux
+tmux-resurrect
 tobi-try
 ttf-ia-writer
 ttf-jetbrains-mono-nerd-basic

--- a/manual/15-terminal.md
+++ b/manual/15-terminal.md
@@ -12,6 +12,8 @@ Tmux provides a consistent, programmable interface for panes, windows (aka tabs)
 
 You start a new Tmux session in a fresh terminal using `Super + Alt + Return`, and because Tmux is a persistent process, you can resume your session even if you close that terminal. Just hit `Ctrl + Space` (called the prefix key) then `s` to see all your active sessions.
 
+Omarchy saves Tmux workspaces when their sessions, windows, panes, or layouts change, and when a client detaches. After a restart, press `Ctrl + Space`, then `Ctrl + R`, to restore the most recent workspace: sessions, windows, pane layouts, working directories, and safely supported programs. This is workspace recovery rather than process hibernation: a shell or program that was not safely restorable starts fresh in its original directory.
+
 Omarchy ships with an ergonomically-optimized Tmux configuration, which has a lot of keybindings to learn, so keep [the cheatsheet handy](07-hotkeys.md#tmux).
 
 ## Tmux layout functions

--- a/migrations/1786853363.sh
+++ b/migrations/1786853363.sh
@@ -1,0 +1,26 @@
+echo "Add persistent Tmux workspaces"
+
+omarchy-pkg-add tmux-resurrect
+
+tmux_config="$HOME/.config/tmux/tmux.conf"
+[[ -f $tmux_config ]] || exit 0
+grep -Fq '# Persistent workspaces' "$tmux_config" || cat >>"$tmux_config" <<'EOF'
+
+# Persistent workspaces
+set -g @resurrect-dir '~/.local/state/omarchy/tmux/resurrect'
+run-shell /usr/share/tmux-resurrect/resurrect.tmux
+set-hook -g session-created[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g session-closed[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g window-linked[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g window-unlinked[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-split-window[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-kill-pane[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-rename-session[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-rename-window[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g after-select-layout[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set-hook -g client-detached[100] 'run-shell -b "/usr/bin/omarchy-tmux-resurrect-save"'
+set -g @resurrect-hook-pre-restore-all 'tmux set-option -g @omarchy-resurrect-restoring 1'
+set -g @resurrect-hook-post-restore-all 'tmux set-option -gu @omarchy-resurrect-restoring; /usr/bin/omarchy-tmux-resurrect-save'
+EOF
+
+omarchy-restart-tmux

--- a/test/shell.d/tmux-resurrect-migration-test.sh
+++ b/test/shell.d/tmux-resurrect-migration-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf -- "$test_dir"' EXIT
+
+test_home="$test_dir/home"
+test_bin="$test_dir/bin"
+package_log="$test_dir/packages.log"
+restart_log="$test_dir/restarts.log"
+tmux_config="$test_home/.config/tmux/tmux.conf"
+
+mkdir -p "$test_home/.config/tmux" "$test_bin"
+printf '%s\n' '# Personal tmux config' >"$tmux_config"
+
+cat >"$test_bin/omarchy-pkg-add" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$PACKAGE_LOG"
+EOF
+chmod +x "$test_bin/omarchy-pkg-add"
+
+cat >"$test_bin/omarchy-restart-tmux" <<'EOF'
+#!/bin/bash
+printf 'restart\n' >>"$RESTART_LOG"
+EOF
+chmod +x "$test_bin/omarchy-restart-tmux"
+
+run_migration() {
+  HOME="$test_home" \
+    PATH="$test_bin:$PATH" \
+    PACKAGE_LOG="$package_log" \
+    RESTART_LOG="$restart_log" \
+    bash -euo pipefail "$ROOT/migrations/1786853363.sh"
+}
+
+run_migration
+
+[[ $(<"$package_log") == 'tmux-resurrect' ]] || fail "tmux migration installs the resurrection engine"
+grep -Fx '# Personal tmux config' "$tmux_config" >/dev/null || fail "tmux migration keeps personal configuration"
+grep -Fx '# Persistent workspaces' "$tmux_config" >/dev/null || fail "tmux migration adds the resurrection block"
+[[ $(<"$restart_log") == 'restart' ]] || fail "tmux migration reloads a running server"
+pass "tmux migration installs resurrection without replacing configuration"
+
+run_migration
+[[ $(rg -c '^# Persistent workspaces$' "$tmux_config") == 1 ]] || fail "tmux migration does not duplicate the resurrection block"
+pass "tmux migration is idempotent"

--- a/test/shell.d/tmux-resurrect-test.sh
+++ b/test/shell.d/tmux-resurrect-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+config="$ROOT/config/tmux/tmux.conf"
+save_command='/usr/bin/omarchy-tmux-resurrect-save'
+
+grep -Fx "set -g @resurrect-dir '~/.local/state/omarchy/tmux/resurrect'" "$config" >/dev/null ||
+  fail "tmux resurrect stores snapshots in Omarchy state"
+grep -Fx 'run-shell /usr/share/tmux-resurrect/resurrect.tmux' "$config" >/dev/null ||
+  fail "tmux loads the packaged resurrection plugin"
+grep -F '@resurrect-capture-pane-contents' "$config" >/dev/null &&
+  fail "tmux resurrection does not persist pane contents by default"
+
+for hook in \
+  session-created session-closed window-linked window-unlinked after-split-window \
+  after-kill-pane after-rename-session after-rename-window after-select-layout \
+  client-detached; do
+  grep -Fx "set-hook -g $hook[100] 'run-shell -b \"$save_command\"'" "$config" >/dev/null ||
+    fail "tmux saves after $hook"
+done
+pass "tmux saves workspace changes without continuum"
+
+grep -Fx "set -g @resurrect-hook-pre-restore-all 'tmux set-option -g @omarchy-resurrect-restoring 1'" "$config" >/dev/null ||
+  fail "tmux suppresses snapshots during restoration"
+grep -Fx "set -g @resurrect-hook-post-restore-all 'tmux set-option -gu @omarchy-resurrect-restoring; $save_command'" "$config" >/dev/null ||
+  fail "tmux saves once restoration finishes"
+pass "tmux restoration never snapshots a partial layout"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf -- "$test_dir"' EXIT
+
+test_bin="$test_dir/bin"
+plugin_dir="$test_dir/tmux-resurrect"
+tmux_log="$test_dir/tmux.log"
+plugin_log="$test_dir/plugin.log"
+test_config="$test_dir/tmux.conf"
+socket="$test_dir/tmux.sock"
+
+mkdir -p "$test_bin" "$plugin_dir/scripts"
+
+cat >"$plugin_dir/resurrect.tmux" <<'EOF'
+#!/bin/bash
+EOF
+chmod +x "$plugin_dir/resurrect.tmux"
+
+while IFS= read -r line || [[ -n $line ]]; do
+  printf '%s\n' "${line//\/usr\/share\/tmux-resurrect/$plugin_dir}"
+done <"$config" >"$test_config"
+
+tmux -S "$socket" -f /dev/null new-session -d -s test
+tmux -S "$socket" source-file "$test_config"
+tmux -S "$socket" show-hooks -g session-created | grep -Fq "$save_command" ||
+  fail "tmux accepts the resurrection hook configuration"
+tmux -S "$socket" kill-server
+pass "tmux loads resurrection hooks without replacing other configuration"
+
+cat >"$test_bin/tmux" <<'EOF'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$TMUX_LOG"
+
+case "$1" in
+  has-session)
+    exit 0
+    ;;
+  show-options)
+    [[ ${TMUX_RESTORING:-0} == "1" ]] && printf '1\n'
+    ;;
+esac
+EOF
+chmod +x "$test_bin/tmux"
+
+cat >"$plugin_dir/scripts/save.sh" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TMUX_PLUGIN_LOG"
+EOF
+chmod +x "$plugin_dir/scripts/save.sh"
+
+run_save() {
+  PATH="$test_bin:$PATH" \
+    HOME="$test_dir/home" \
+    XDG_RUNTIME_DIR="$test_dir/runtime" \
+    TMUX_RESURRECT_PATH="$plugin_dir" \
+    TMUX_LOG="$tmux_log" \
+    TMUX_PLUGIN_LOG="$plugin_log" \
+    "$ROOT/bin/omarchy-tmux-resurrect-save"
+}
+
+run_save
+[[ $(<"$plugin_log") == 'quiet' ]] || fail "tmux hook uses upstream quiet save"
+pass "tmux saves through the packaged resurrection engine"
+
+: >"$plugin_log"
+TMUX_RESTORING=1 run_save
+[[ ! -s $plugin_log ]] || fail "tmux skips snapshots while restoration is active"
+pass "tmux does not overwrite a snapshot during restoration"


### PR DESCRIPTION
## Summary
- save Tmux workspace changes through tmux-resurrect lifecycle hooks
- keep restore manual with `Ctrl+Space`, then `Ctrl+R`
- add the existing-user migration, package list entry, documentation, and focused coverage

## Dependency
Requires omacom-io/omarchy-pkgs#159 to publish `tmux-resurrect`.

## Verification
- `bash test/shell.d/tmux-resurrect-test.sh`
- `bash test/shell.d/tmux-resurrect-migration-test.sh`
- `./test/cli`