### PR TITLE
Stop notifications and OSDs from jumping the cursor in fullscreen games

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -955,7 +955,14 @@ Item {
       id: popupWindow
       required property var modelData
       screen: modelData
-      visible: popupModel.count > 0
+      // Stay mapped for the life of the shell. Mapping and unmapping the
+      // layer surface per toast batch makes Hyprland run
+      // simulateMouseMovement() on every unmap, which desyncs the cursor of a
+      // pointer-locked fullscreen client -- seen in games as the aim jumping
+      // on the next click. The surface is transparent and its input region is
+      // empty while popupColumn is empty, so staying mapped is
+      // indistinguishable from being unmapped.
+      visible: true
 
       WlrLayershell.namespace: "omarchy-notifications"
       WlrLayershell.layer: WlrLayer.Overlay

--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -125,7 +125,11 @@ Item {
 
   PanelWindow {
     id: panel
-    visible: root.opened
+    // Stay mapped for the same reason as the notification popup surface: an
+    // unmap makes Hyprland run simulateMouseMovement(), which desyncs the
+    // cursor of a pointer-locked fullscreen client. The input region is empty
+    // and the card fades itself out, so a mapped surface shows nothing.
+    visible: true
     anchors { top: true; bottom: true; left: true; right: true }
     color: "transparent"
     WlrLayershell.namespace: "omarchy-osd"


### PR DESCRIPTION
A notification toast (or a volume/brightness OSD) appearing over a fullscreen game makes the aim jump on the next left click. It stays broken until the window is refocused — switching workspace away and back clears it, which is how I first isolated it. Reproduced on Warframe (`steam_app_230410`, XWayland, `fullscreen: 2`) under Hyprland 0.56.2.

Both surfaces map and unmap per event — `visible: popupModel.count > 0` and `visible: root.opened`. On every layer-surface unmap Hyprland calls `g_pInputManager->simulateMouseMovement()` unconditionally (`LayerSurface.cpp`), and a constraint reactivation warps the cursor to the constraint hint (`CPointerConstraint::activate()` → `warpTo(HINT, true)`). Constraint (de)activation itself only runs on focus change (`FocusState.cpp`), which is why refocusing repairs it.

Keeping both surfaces mapped removes the transition. Nothing else changes: the notification surface is transparent with `mask: Region { item: popupColumn }`, and `popupColumn` collapses to zero size when the model is empty; the OSD has `mask: Region {}` and a card that fades itself to `opacity: 0`. A mapped idle surface therefore paints nothing and accepts no input.

### What this is not

Keyboard-focus stealing is ruled out — both surfaces already set `WlrKeyboardFocus.None`, and Hyprland only grabs focus for `exclusive` layers (unguarded) or `on_demand` (guarded by `!isConstrained()`).

Two other approaches were tried and rejected against the running compositor:

- A `confine_pointer` window rule on the game class made it worse — the aim froze outright rather than jumping.
- Parking the idle surface on `WlrLayer.Top` and raising it to `Overlay` only while a toast is up **reintroduced the bug**. So `set_layer` perturbs the pointer the same way map/unmap does, and the trigger is any layer-surface state transition, not unmapping specifically. That result is what makes a permanently fixed layer the only stable option.

### The trade-off

A permanently mapped overlay surface costs the fullscreen client its solitary candidate, and with it direct scanout and tearing. Measured with a fullscreen game, idle:

```
before:  solitary=5584df2528c0  solitaryBlockedBy=None        tearingBlockedBy=['NOT_TORN','WINDOW']
after:   solitary=0             solitaryBlockedBy=['OVERLAYS'] tearingBlockedBy=['NOT_TORN','CANDIDATE']
```

This is a real regression and I don't want to undersell it. Two things bound it: solitary was already lost for the duration of every toast before this change, and when no window is fullscreen the candidate is blocked by `WINDOWED` anyway, so nothing is lost on the desktop. But between toasts, during gameplay, this does give up scanout where the old code kept it.

The root cause is arguably compositor-side — Omarchy is using the obvious Quickshell pattern, and an unconditional `simulateMouseMovement()` on layer teardown is what turns it into a user-visible bug. Happy to close this in favour of a Hyprland fix if you'd rather not carry the trade.

### Verification

Live in the running shell, with Warframe fullscreen:

- 3 notifications and 3 OSDs, clicking after each: 0/6 aim jumps. Before the change the same run broke on every one.
- Layer address is identical before, during, and after a toast (`0x5584def04090`), confirming the surface persists rather than being recreated by the `Qt::WindowTransparentForInput` flip.
- Toasts still render, stack, auto-dismiss, click-to-invoke, right-click-to-dismiss, and hover-pause; clicks in the top-right land on the window underneath when no toast is up. Volume OSD still appears and fades.

`./test/shell` shows no new failures (`config-test`, `snapper-test` and `unowned-system-paths-test` fail identically on a clean checkout of this branch's base in my environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
