### PR TITLE
Fix audio panel selection for sinks with multiple ports

### DIFF
--- a/bin/omarchy-audio-output-set-default
+++ b/bin/omarchy-audio-output-set-default
@@ -1,15 +1,28 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default audio output and move active streams
-# omarchy:args=<node-id> <sink-name>
-# omarchy:examples=omarchy audio output set default 42 alsa_output.pci-0000_00_1f.3.analog-stereo
+# omarchy:args=<node-id> <sink-name> [port-name]
+# omarchy:examples=omarchy audio output set default 42 alsa_output.pci-0000_00_1f.3.analog-stereo analog-output-headphones
 
 node_id=${1:-}
 sink_name=${2:-}
+port_name=${3:-}
 
 if [[ -z $node_id || -z $sink_name ]]; then
-  echo "Usage: omarchy-audio-output-set-default <node-id> <sink-name>" >&2
+  echo "Usage: omarchy-audio-output-set-default <node-id> <sink-name> [port-name]" >&2
   exit 1
+fi
+
+if [[ -n $port_name ]]; then
+  sink_json=$(timeout 2 pactl --format=json list sinks)
+  if ! jq -e --arg sink "$sink_name" --arg port "$port_name" \
+    'any(.[]; .name == $sink and any(.ports[]?; .name == $port))' \
+    <<<"$sink_json" >/dev/null; then
+    echo "Audio output port disappeared: $sink_name/$port_name" >&2
+    exit 1
+  fi
+
+  timeout 2 pactl set-sink-port "$sink_name" "$port_name"
 fi
 
 timeout 2 wpctl set-default "$node_id" 2>/dev/null || true

--- a/bin/omarchy-audio-output-targets
+++ b/bin/omarchy-audio-output-targets
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# omarchy:summary=List selectable audio output sink ports as JSON
+# omarchy:group=audio
+
+set -euo pipefail
+
+# A speaker tuning is a virtual sink in front of the real speakers. Exposing
+# the fronted physical sink would let the panel bypass the processing chain.
+fronted=$(omarchy-audio-tuning fronted-sink 2>/dev/null || true)
+default_sink=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
+
+timeout 2 pactl --format=json list sinks | jq \
+  --arg fronted "$fronted" \
+  --arg defaultSink "$default_sink" '
+  def text_kind($text):
+    $text | ascii_downcase
+    | if test("headphone|headset|earbud|earphone|airpod") then "headphones"
+      elif test("bluetooth|bluez") then "bluetooth"
+      elif test("hdmi|displayport|display port|display") then "display"
+      else "speaker"
+      end;
+
+  [
+    .[]
+    | select($fronted == "" or .name != $fronted)
+    | . as $sink
+    | (($sink.active_port // "")
+        | if type == "object" then (.name // "") else tostring end) as $activePort
+    | if (($sink.ports // []) | length) == 0 then
+        {
+          sinkName: $sink.name,
+          portName: "",
+          portDescription: "",
+          sinkDescription: ($sink.description // $sink.name),
+          kind: text_kind(
+            ($sink.name // "") + " " +
+            ($sink.description // "") + " " +
+            ($sink.properties["device.product.name"] // "") + " " +
+            ($sink.properties["device.icon_name"] // "")
+          ),
+          active: ($sink.name == $defaultSink)
+        }
+      else
+        $sink.ports[]
+        | select((.availability // "unknown") as $availability
+            | $availability != "no"
+            and $availability != "not available"
+            and $availability != "unavailable")
+        | {
+          sinkName: $sink.name,
+          portName: .name,
+          portDescription: (.description // .name),
+          sinkDescription: ($sink.description // $sink.name),
+          kind: text_kind(
+            (.name // "") + " " +
+            (.description // "") + " " +
+            (.type // "") + " " +
+            ($sink.properties["device.product.name"] // "")
+          ),
+          active: ($sink.name == $defaultSink and .name == $activePort)
+        }
+      end
+  ]
+  | unique_by([.sinkName, .portName])
+  | sort_by([.sinkDescription, .portDescription, .sinkName, .portName])
+'

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -47,6 +47,110 @@ function parseSinkAvailability(raw) {
   return next
 }
 
+function parseOutputTargets(raw) {
+  var parsed
+  try {
+    parsed = JSON.parse(String(raw || ""))
+  } catch (_) {
+    return null
+  }
+  if (!Array.isArray(parsed)) return null
+
+  var targets = []
+  var seen = {}
+  for (var i = 0; i < parsed.length; i++) {
+    var item = parsed[i]
+    if (!item || typeof item !== "object") continue
+
+    var sinkName = String(item.sinkName || "").trim()
+    var portName = String(item.portName || "").trim()
+    if (!sinkName) continue
+
+    var key = sinkName + "|" + portName
+    if (seen[key]) continue
+    seen[key] = true
+    targets.push({
+      sinkName: sinkName,
+      portName: portName,
+      portDescription: String(item.portDescription || "").trim(),
+      sinkDescription: String(item.sinkDescription || sinkName).trim(),
+      kind: String(item.kind || "speaker"),
+      active: item.active === true
+    })
+  }
+  if (parsed.length > 0 && targets.length === 0) return null
+  return targets
+}
+
+function outputTargetLabel(target, targetCountForSink) {
+  if (!target) return "Unknown"
+  var portLabel = friendlyDeviceLabel(target.portDescription)
+  var sinkLabel = friendlyDeviceLabel(target.sinkDescription)
+  if (targetCountForSink > 1 && portLabel) return portLabel
+  if (target.kind === "headphones" && portLabel) return portLabel
+  return sinkLabel || portLabel || target.sinkName || "Unknown"
+}
+
+function joinOutputTargets(targets, sinks) {
+  var values = Array.isArray(targets) ? targets : []
+  var nodes = Array.isArray(sinks) ? sinks : []
+  var counts = {}
+  var joined = []
+
+  for (var i = 0; i < values.length; i++)
+    counts[values[i].sinkName] = (counts[values[i].sinkName] || 0) + 1
+
+  for (var j = 0; j < values.length; j++) {
+    var target = values[j]
+    var node = null
+    for (var k = 0; k < nodes.length; k++) {
+      if (nodes[k] && String(nodes[k].name || "") === target.sinkName) {
+        node = nodes[k]
+        break
+      }
+    }
+    if (!node) continue
+
+    joined.push({
+      sinkName: target.sinkName,
+      portName: target.portName,
+      label: outputTargetLabel(target, counts[target.sinkName]),
+      description: target.sinkDescription,
+      kind: target.kind,
+      active: target.active,
+      node: node
+    })
+  }
+  return joined
+}
+
+function fallbackOutputTargets(sinks, defaultSink) {
+  var nodes = Array.isArray(sinks) ? sinks : []
+  var targets = []
+  for (var i = 0; i < nodes.length; i++) {
+    var node = nodes[i]
+    if (!node) continue
+    targets.push({
+      sinkName: String(node.name || ""),
+      portName: "",
+      label: nodeLabel(node),
+      description: nodeLabel(node),
+      kind: isHeadphones(node) ? "headphones" : "speaker",
+      active: !!defaultSink && (node === defaultSink || node.id === defaultSink.id),
+      node: node
+    })
+  }
+  return targets
+}
+
+function outputTargetGlyph(target) {
+  var kind = String(target && target.kind || "")
+  if (kind === "headphones") return "󰋋"
+  if (kind === "bluetooth") return "󰂯"
+  if (kind === "display") return "󰍹"
+  return "󰓃"
+}
+
 function friendlyDeviceLabel(text) {
   var label = String(text || "").trim()
   label = label.replace(/^sof-soundwire\s+/i, "")
@@ -240,6 +344,11 @@ if (typeof module !== "undefined") {
     listSnapshot: listSnapshot,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
+    parseOutputTargets: parseOutputTargets,
+    outputTargetLabel: outputTargetLabel,
+    joinOutputTargets: joinOutputTargets,
+    fallbackOutputTargets: fallbackOutputTargets,
+    outputTargetGlyph: outputTargetGlyph,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -57,6 +57,8 @@ Panel {
 
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
+  property var outputTargetSnapshot: []
+  property bool outputTargetSnapshotLoaded: false
 
   // Identify true playback streams without reading node.properties here:
   // PwNode.properties is invalid until the node is bound, and reading it while
@@ -106,6 +108,7 @@ Panel {
   // in Quickshell's PipeWire service. The snapshot timer lets that mutation
   // settle first, and closed panels keep their repeaters detached entirely.
   property var displayAudioSinks: []
+  property var displayAudioTargets: []
   property var displayAudioSources: []
   property var displayAudioStreams: []
 
@@ -137,7 +140,10 @@ Panel {
 
   // Re-resolve whenever the selected output changes; the timer below is only a
   // safety net for the tuning being applied or removed underneath us.
-  onSinkChanged: resolveVolumeSink()
+  onSinkChanged: {
+    resolveVolumeSink()
+    refreshOutputTargets()
+  }
 
   function resolveVolumeSink() {
     if (!volumeSinkProc.running) volumeSinkProc.running = true
@@ -184,7 +190,7 @@ Panel {
     : "transparent"
 
   function sectionCount(section) {
-    if (section === "output") return displayAudioSinks.length
+    if (section === "output") return displayAudioTargets.length
     if (section === "input") return displayAudioSources.length
     if (section === "streams") return displayAudioStreams.length
     return 0
@@ -291,8 +297,8 @@ Panel {
     if (focusSection === "header") { toggleAllMuted(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
-      var sink = displayAudioSinks[selectedIndex]
-      if (sink) setDefaultSink(sink)
+      var target = displayAudioTargets[selectedIndex]
+      if (target) setDefaultOutput(target)
       return
     }
     if (focusSection === "input") {
@@ -309,6 +315,7 @@ Panel {
 
   onOpenedChanged: {
     if (opened) {
+      refreshOutputTargets()
       refreshDisplayAudioModels()
       focusSection = "output"
       selectedIndex = -1  // first keyboard cursor reveal starts on the output slider
@@ -320,7 +327,10 @@ Panel {
   }
 
   // Clamp / repair the cursor whenever any list refreshes underneath us.
-  onAudioSinksChanged: scheduleDisplayAudioModelRefresh()
+  onAudioSinksChanged: {
+    scheduleDisplayAudioModelRefresh()
+    refreshOutputTargets()
+  }
   onAudioSourcesChanged: scheduleDisplayAudioModelRefresh()
   onAudioStreamsChanged: scheduleDisplayAudioModelRefresh()
 
@@ -331,6 +341,9 @@ Panel {
   function refreshDisplayAudioModels() {
     if (!opened) return
     displayAudioSinks = listSnapshot(audioSinks)
+    displayAudioTargets = outputTargetSnapshotLoaded
+      ? Model.joinOutputTargets(outputTargetSnapshot, displayAudioSinks)
+      : Model.fallbackOutputTargets(displayAudioSinks, sink)
     displayAudioSources = listSnapshot(audioSources)
     displayAudioStreams = listSnapshot(audioStreams)
     clampCursor()
@@ -344,6 +357,7 @@ Panel {
   function clearDisplayAudioModels() {
     audioModelRefreshTimer.stop()
     displayAudioSinks = []
+    displayAudioTargets = []
     displayAudioSources = []
     displayAudioStreams = []
   }
@@ -460,16 +474,33 @@ Panel {
     if (hasInput) source.audio.muted = mute
   }
 
-  function setDefaultSink(node) {
-    if (!node) return
-    Pipewire.preferredDefaultAudioSink = node
-    if (node.id !== undefined && node.name) {
-      Quickshell.execDetached([
-        "omarchy-audio-output-set-default",
-        String(node.id),
-        String(node.name)
-      ])
+  function setDefaultOutput(target) {
+    if (!target || !target.node || outputSelectionProc.running) return
+    if (target.node.id === undefined || !target.sinkName) return
+
+    outputSelectionProc.command = [
+      "omarchy-audio-output-set-default",
+      String(target.node.id),
+      String(target.sinkName),
+      String(target.portName || "")
+    ]
+    outputSelectionProc.running = true
+  }
+
+  function refreshOutputTargets() {
+    if (opened && !outputTargetsProc.running) outputTargetsProc.running = true
+  }
+
+  function updateOutputTargets(raw) {
+    var parsed = Model.parseOutputTargets(raw)
+    if (parsed === null) {
+      console.warn("Audio output target helper returned invalid JSON")
+      return
     }
+
+    outputTargetSnapshot = parsed
+    outputTargetSnapshotLoaded = true
+    scheduleDisplayAudioModelRefresh()
   }
 
   function setDefaultSource(node) {
@@ -593,6 +624,31 @@ Panel {
   }
 
   Process {
+    id: outputTargetsProc
+    command: ["omarchy-audio-output-targets"]
+    stdout: StdioCollector { id: outputTargetsOutput; waitForEnd: true }
+    stderr: StdioCollector { id: outputTargetsError; waitForEnd: true }
+    onExited: function(exitCode) {
+      if (exitCode === 0) root.updateOutputTargets(outputTargetsOutput.text)
+      else console.warn("Unable to refresh audio output targets: " + String(outputTargetsError.text).trim())
+    }
+  }
+
+  Process {
+    id: outputSelectionProc
+    command: []
+    stderr: StdioCollector { id: outputSelectionError; waitForEnd: true }
+    onExited: function(exitCode) {
+      if (exitCode !== 0)
+        console.warn("Unable to select audio output: " + String(outputSelectionError.text).trim())
+      outputSelectionRefreshTimer.ticks = 0
+      outputSelectionRefreshTimer.restart()
+      root.refreshOutputTargets()
+      root.resolveVolumeSink()
+    }
+  }
+
+  Process {
     id: volumeSinkProc
     command: ["omarchy-audio-output-sink"]
     stdout: StdioCollector {
@@ -606,7 +662,22 @@ Panel {
     running: root.opened
     repeat: true
     triggeredOnStart: true
-    onTriggered: if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+    onTriggered: {
+      if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+      root.refreshOutputTargets()
+    }
+  }
+
+  Timer {
+    id: outputSelectionRefreshTimer
+    property int ticks: 0
+    interval: 250
+    repeat: true
+    onTriggered: {
+      ticks += 1
+      root.refreshOutputTargets()
+      if (ticks >= 4) stop()
+    }
   }
 
   // Runs whether or not the panel is open: the bar shows and scrolls the output
@@ -848,13 +919,13 @@ Panel {
             }
 
             Repeater {
-              model: root.displayAudioSinks
+              model: root.displayAudioTargets
 
-              SinkRow {
+              OutputTargetRow {
                 required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                target: modelData
                 rowIndex: index
               }
             }
@@ -1006,14 +1077,14 @@ Panel {
   // Output device row — cursor target inside the "output" section. Mouse
   // hover updates the panel cursor at the root; visuals come entirely
   // from hasCursor/current via CursorSurface, never from containsMouse.
-  component SinkRow: CursorSurface {
-    id: sinkRow
-    required property var node
+  component OutputTargetRow: CursorSurface {
+    id: outputTargetRow
+    required property var target
     required property int rowIndex
 
-    readonly property bool isActive: root.sink && node && root.sink.id === node.id
+    readonly property bool isActive: target && target.active
     hasCursor: root.cursorActive && root.focusSection === "output" && root.selectedIndex === rowIndex
-    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sinkRow)
+    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(outputTargetRow)
     current: isActive
     foreground: root.bar.foreground
     fill: root.hoverFill
@@ -1030,7 +1101,7 @@ Panel {
       spacing: Style.space(8)
 
       Text {
-        text: root.sinkGlyph(sinkRow.node)
+        text: Model.outputTargetGlyph(outputTargetRow.target)
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.title
@@ -1040,11 +1111,11 @@ Panel {
       }
 
       Text {
-        text: root.nodeLabel(sinkRow.node)
+        text: outputTargetRow.target ? outputTargetRow.target.label : "Unknown"
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
-        font.bold: sinkRow.isActive
+        font.bold: outputTargetRow.isActive
         elide: Text.ElideRight
         width: parent.width - Style.space(22) - Style.space(8)
         anchors.verticalCenter: parent.verticalCenter
@@ -1058,9 +1129,9 @@ Panel {
       onContainsMouseChanged: if (containsMouse) {
         root.cursorActive = true
         root.focusSection = "output"
-        root.selectedIndex = sinkRow.rowIndex
+        root.selectedIndex = outputTargetRow.rowIndex
       }
-      onClicked: root.setDefaultSink(sinkRow.node)
+      onClicked: root.setDefaultOutput(outputTargetRow.target)
     }
   }
 

--- a/test/shell.d/audio-output-targets-test.sh
+++ b/test/shell.d/audio-output-targets-test.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+stub_bin="$test_dir/bin"
+call_log="$test_dir/calls"
+sink_json="$test_dir/sinks.json"
+mkdir -p "$stub_bin"
+touch "$call_log"
+
+cat >"$stub_bin/omarchy-audio-tuning" <<'STUB'
+#!/bin/bash
+[[ $1 == "fronted-sink" ]] && printf '%s\n' "${FRONTED_SINK:-}"
+STUB
+
+cat >"$stub_bin/wpctl" <<'STUB'
+#!/bin/bash
+printf 'wpctl %s\n' "$*" >>"$CALL_LOG"
+STUB
+
+cat >"$stub_bin/pactl" <<'STUB'
+#!/bin/bash
+case "$*" in
+  "get-default-sink")
+    printf '%s\n' "${DEFAULT_SINK:-}"
+    ;;
+  "--format=json list sinks")
+    cat "$SINK_JSON"
+    ;;
+  "list sink-inputs")
+    cat <<'INPUTS'
+Sink Input #10
+    application.name = "Brave"
+Sink Input #11
+    application.name = "EasyEffects"
+Sink Input #12
+    media.name = "DSP output"
+INPUTS
+    ;;
+  *)
+    printf 'pactl %s\n' "$*" >>"$CALL_LOG"
+    ;;
+esac
+STUB
+
+chmod +x "$stub_bin/omarchy-audio-tuning" "$stub_bin/wpctl" "$stub_bin/pactl"
+
+cat >"$sink_json" <<'JSON'
+[
+  {
+    "name": "analog",
+    "description": "Built-in Audio Analog Stereo",
+    "active_port": "lineout",
+    "ports": [
+      {"name": "lineout", "description": "Line Out", "type": "Line", "availability": "available"},
+      {"name": "headphones", "description": "Headphones", "type": "Headphones", "availability": "unknown"}
+    ],
+    "properties": {}
+  },
+  {
+    "name": "usb",
+    "description": "USB Headset",
+    "ports": [],
+    "properties": {"device.product.name": "USB Headset"}
+  },
+  {
+    "name": "hdmi",
+    "description": "Disconnected Display",
+    "active_port": "hdmi-output-0",
+    "ports": [
+      {"name": "hdmi-output-0", "description": "HDMI", "availability": "not available"}
+    ],
+    "properties": {}
+  },
+  {
+    "name": "fronted-physical",
+    "description": "Physical Speakers",
+    "ports": [],
+    "properties": {}
+  },
+  {
+    "name": "tuned-output",
+    "description": "Speaker Tuning",
+    "ports": [],
+    "properties": {}
+  }
+]
+JSON
+
+export CALL_LOG="$call_log"
+export SINK_JSON="$sink_json"
+export DEFAULT_SINK=analog
+export FRONTED_SINK=fronted-physical
+
+targets=$(PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-audio-output-targets")
+jq -e '
+  length == 4
+  and any(.[]; .sinkName == "analog" and .portName == "lineout" and .active == true)
+  and any(.[]; .sinkName == "analog" and .portName == "headphones" and .active == false)
+  and any(.[]; .sinkName == "usb" and .portName == "")
+  and any(.[]; .sinkName == "tuned-output")
+  and all(.[]; .sinkName != "hdmi" and .sinkName != "fronted-physical")
+' <<<"$targets" >/dev/null || fail "audio output targets include usable ports and preserve tuning"
+pass "audio output targets include usable ports and preserve tuning"
+
+: >"$call_log"
+PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-audio-output-set-default" 42 analog headphones
+expected_calls=$'pactl set-sink-port analog headphones\nwpctl set-default 42\npactl set-default-sink analog\npactl move-sink-input 10 analog'
+actual_calls=$(cat "$call_log")
+[[ $actual_calls == "$expected_calls" ]] || fail "audio selects a port before the sink and moves only application streams" "$actual_calls"
+pass "audio selects a port before the sink and moves only application streams"
+
+: >"$call_log"
+PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-audio-output-set-default" 42 analog
+if grep -q 'set-sink-port' "$call_log"; then
+  fail "audio output selection remains compatible with two arguments"
+fi
+grep -qx 'wpctl set-default 42' "$call_log" || fail "audio output selection remains compatible with two arguments"
+pass "audio output selection remains compatible with two arguments"
+
+: >"$call_log"
+if PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-audio-output-set-default" 42 analog vanished 2>/dev/null; then
+  fail "audio rejects a vanished output port"
+fi
+[[ ! -s $call_log ]] || fail "audio rejects a vanished output port" "$(cat "$call_log")"
+pass "audio rejects a vanished output port before changing the default"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -18,6 +18,30 @@ assertEqual(audio.outputVolumeName(0.9, false), 'Party mode', 'audio labels loud
 assertEqual(audio.outputVolumeName(0.5, true), 'Muted', 'audio labels muted output')
 
 assertDeepEqual(audio.parseSinkAvailability('alsa_output\t1\nhdmi_output\t0\n'), { alsa_output: true, hdmi_output: false }, 'audio parses sink availability')
+assertEqual(audio.parseOutputTargets('not json'), null, 'audio rejects malformed output target JSON')
+assertDeepEqual(audio.parseOutputTargets('[]'), [], 'audio accepts an empty output target snapshot')
+assertEqual(audio.parseOutputTargets('[{"portName":"missing-sink"}]'), null, 'audio rejects snapshots containing no valid targets')
+
+const parsedTargets = audio.parseOutputTargets(JSON.stringify([
+  { sinkName: 'analog', portName: 'lineout', portDescription: 'Line Out', sinkDescription: 'Built-in Audio Analog Stereo', kind: 'speaker', active: true },
+  { sinkName: 'analog', portName: 'headphones', portDescription: 'Headphones', sinkDescription: 'Built-in Audio Analog Stereo', kind: 'headphones', active: false },
+  { sinkName: 'analog', portName: 'headphones', portDescription: 'Duplicate' },
+  { portName: 'missing-sink' },
+  null
+]))
+assertEqual(parsedTargets.length, 2, 'audio validates and deduplicates output targets')
+
+const analogSink = { id: 42, name: 'analog', description: 'Analog Stereo' }
+const joinedTargets = audio.joinOutputTargets(parsedTargets, [analogSink])
+assertEqual(joinedTargets.length, 2, 'audio joins output targets to live sinks')
+assertEqual(joinedTargets[0].label, 'Line Out', 'audio labels a multi-port line-out target')
+assertEqual(joinedTargets[1].label, 'Headphones', 'audio labels a headphone target')
+assert(joinedTargets[0].active && !joinedTargets[1].active, 'audio keeps port-specific active state')
+
+const fallbackTargets = audio.fallbackOutputTargets([analogSink], analogSink)
+assertEqual(fallbackTargets.length, 1, 'audio builds a sink-only fallback target')
+assert(fallbackTargets[0].active, 'audio marks the default fallback sink active')
+assert(audio.outputTargetGlyph(joinedTargets[1]).length > 0, 'audio maps output target glyphs')
 assertEqual(audio.friendlyDeviceLabel('Built-in Audio Speakers Output'), 'Speakers', 'audio cleans device labels')
 assertEqual(
   audio.nodeLabel({ ready: true, properties: { 'node.nick': 'Built-in Audio Microphones Input' }, name: 'alsa_input' }),


### PR DESCRIPTION
Expose usable audio sink ports as separate output targets, allowing the audio panel to switch between physical ports while preserving existing default-sink selection and application stream movement.

Previously, hardware exposing multiple analog ports through a single PipeWire sink appeared as only one output option. This made it impossible to select the rear line-out and front headphone jack independently.

With this fix, the audio panel shows both the rear 3.5 mm line-out and front 3.5 mm headphone port when PipeWire reports them as available. Selecting either entry activates the corresponding port and moves active application audio to it.

<img width="846" height="1126" alt="image" src="https://github.com/user-attachments/assets/b41858c4-6f29-40cd-b6cc-d7c4dff4c0ab" />
