### PR TITLE
Restore batch selection in management menus

### DIFF
--- a/bin/omarchy-menu-plugin
+++ b/bin/omarchy-menu-plugin
@@ -30,17 +30,36 @@ rows=$(jq -r --arg icon "$PLUGIN_ICON" \
    | \$icon + \"\\t\" + .name + \"\\t\" + .id" <<<"$plugins")
 [[ -n $rows ]] || { omarchy-notification-send "No plugin to ${1}"; exit 0; }
 
-selection=$(omarchy-menu-select "${1^} plugin" <<<"$rows") || exit 0
-[[ -n $selection ]] || exit 0
+if [[ $1 == "clone" ]]; then
+  selection=$(omarchy-menu-select "${1^} plugin" <<<"$rows") || exit 0
+  [[ -n $selection ]] || exit 0
+  selections=("$selection")
+else
+  mapfile -t selections < <(omarchy-menu-select "${1^} plugins" -- --multi --width 520 --maxheight 520 <<<"$rows")
+  (( ${#selections[@]} > 0 )) || exit 0
+fi
 
-id=$(cut -f2 <<<"$selection")
-[[ -n $id ]] || exit 1
+ids=()
+for selection in "${selections[@]}"; do
+  id=$(cut -f2 <<<"$selection")
+  [[ -n $id ]] && ids+=("$id")
+done
+(( ${#ids[@]} > 0 )) || exit 1
 
 if [[ $1 == "clone" ]]; then
   omarchy-launch-floating-terminal-with-presentation \
-    "omarchy-plugin-clone $(printf '%q' "$id") --edit"
+    "omarchy-plugin-clone $(printf '%q' "${ids[0]}") --edit"
 elif [[ $1 == "remove" ]]; then
-  omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove $(printf '%q' "$id")"
+  remove_command=""
+  for id in "${ids[@]}"; do
+    [[ -z $remove_command ]] || remove_command+="; "
+    remove_command+="omarchy-plugin-remove $(printf '%q' "$id")"
+  done
+  omarchy-launch-floating-terminal-with-presentation "$remove_command"
 else
-  "omarchy-plugin-$1" "$id"
+  status=0
+  for id in "${ids[@]}"; do
+    "omarchy-plugin-$1" "$id" || status=1
+  done
+  exit "$status"
 fi

--- a/bin/omarchy-menu-select
+++ b/bin/omarchy-menu-select
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Pick one option from a menu
+# omarchy:summary=Pick options from a menu
 # omarchy:group=menu
 # omarchy:name=select
 # omarchy:args=prompt [option...] [-- menu args...]
@@ -10,7 +10,8 @@
 # subtext shown under the label, as "<glyph><TAB><label><TAB><subtext>". The
 # menu shows the glyph but never returns it. A plain option returns the label
 # alone; an option with a subtext returns "<label><TAB><subtext>", so callers
-# with same-named rows get the subtext back as the stable key.
+# with same-named rows get the subtext back as the stable key. Pass --multi after
+# the separator to let Tab pin options and Enter return them one per line.
 
 set -euo pipefail
 
@@ -25,12 +26,16 @@ shift
 options=()
 menu_width=""
 menu_maxheight=""
+multi_select=0
 
 while (( $# > 0 )); do
   if [[ $1 == "--" ]]; then
     shift
     while (( $# > 0 )); do
       case "$1" in
+        --multi)
+          multi_select=1
+          ;;
         --width)
           shift
           if (( $# == 0 )); then
@@ -83,8 +88,9 @@ payload=$(perl -MEncode=decode -MJSON::PP=encode_json,decode_json -e '
   };
   $payload->{width} = int($ARGV[4]) if length($ARGV[4] // "");
   $payload->{maxHeight} = int($ARGV[5]) if length($ARGV[5] // "");
+  $payload->{multiSelect} = JSON::PP::true if $ARGV[6] eq "1";
   print encode_json($payload)
-' "$prompt" "$options_json" "$selection_file" "$done_file" "$menu_width" "$menu_maxheight")
+' "$prompt" "$options_json" "$selection_file" "$done_file" "$menu_width" "$menu_maxheight" "$multi_select")
 
 omarchy-shell shell summon omarchy.menu "$payload" >/dev/null
 

--- a/bin/omarchy-theme-remove
+++ b/bin/omarchy-theme-remove
@@ -1,38 +1,45 @@
 #!/bin/bash
 
-# omarchy:summary=Remove a user-installed theme
-# omarchy:args=[theme-name]
+# omarchy:summary=Remove user-installed themes
+# omarchy:args=[theme-name...]
 # omarchy:examples=omarchy theme remove "Tokyo Night"
 
-if [[ -z $1 ]]; then
+if [[ -z ${1-} ]]; then
   mapfile -t extra_themes < <(find ~/.config/omarchy/themes -mindepth 1 -maxdepth 1 -type d ! -xtype l -printf '%f\n')
 
   if (( ${#extra_themes[@]} > 0 )); then
     mapfile -t extra_themes < <(printf '%s\n' "${extra_themes[@]}" | sort)
-    THEME_NAME=$(omarchy-menu-select "Remove extra theme" "${extra_themes[@]}" -- --width 520 --maxheight 520)
+    mapfile -t THEME_NAMES < <(omarchy-menu-select "Remove extra theme" "${extra_themes[@]}" -- --multi --width 520 --maxheight 520)
   else
     echo "No extra themes installed."
     exit 1
   fi
 else
-  THEME_NAME="$1"
+  THEME_NAMES=("$@")
+fi
+
+if (( ${#THEME_NAMES[@]} == 0 )) || [[ -z ${THEME_NAMES[0]} ]]; then
+  exit 1
 fi
 
 THEMES_DIR="$HOME/.config/omarchy/themes"
-THEME_PATH="$THEMES_DIR/$THEME_NAME"
+status=0
 
-# Ensure a theme was set
-if [[ -z $THEME_NAME ]]; then
-  exit 1
-fi
+for THEME_NAME in "${THEME_NAMES[@]}"; do
+  [[ -z $THEME_NAME ]] && continue
+  THEME_PATH="$THEMES_DIR/$THEME_NAME"
 
-# Check if theme exists before attempting removal
-if [[ ! -d $THEME_PATH ]]; then
-  echo "Error: Theme '$THEME_NAME' not found."
-  exit 1
-fi
+  # Check if theme exists before attempting removal
+  if [[ ! -d $THEME_PATH ]]; then
+    echo "Error: Theme '$THEME_NAME' not found."
+    status=1
+    continue
+  fi
 
-# Now remove the theme directory for THEME_NAME
-rm -rf "$THEME_PATH"
-omarchy-notification-send "Theme removed" "$THEME_NAME" || true
-echo "Removed $THEME_NAME"
+  # Now remove the theme directory for THEME_NAME
+  rm -rf "$THEME_PATH"
+  omarchy-notification-send "Theme removed" "$THEME_NAME" || true
+  echo "Removed $THEME_NAME"
+done
+
+exit "$status"

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# omarchy:summary=Remove a terminal UI desktop launcher
-# omarchy:args=[name]
+# omarchy:summary=Remove terminal UI desktop launchers
+# omarchy:args=[name...]
 
 set -e
 
@@ -19,23 +19,28 @@ if (( $# == 0 )); then
 
   if ((${#TUIS[@]})); then
     mapfile -t SORTED_TUIS < <(printf '%s\n' "${TUIS[@]}" | sort)
-    APP_NAME=$(omarchy-menu-select "Select TUI to remove" "${SORTED_TUIS[@]}" -- --width 520 --maxheight 520)
+    mapfile -t APP_NAMES < <(omarchy-menu-select "Select TUI to remove" "${SORTED_TUIS[@]}" -- --multi --width 520 --maxheight 520)
   else
     echo "No TUIs to remove."
     exit 1
   fi
 else
-  APP_NAME="$*"
+  APP_NAMES=("$@")
 fi
 
-if [[ -z $APP_NAME ]]; then
+if (( ${#APP_NAMES[@]} == 0 )) || [[ -z ${APP_NAMES[0]} ]]; then
   echo "You must select a TUI to remove."
   exit 1
 fi
 
-icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
-rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
-if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
-  omarchy-notification-send -g  "TUI removed" "$APP_NAME"
-fi
+for APP_NAME in "${APP_NAMES[@]}"; do
+  [[ -z $APP_NAME ]] && continue
+  icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
+  rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
+  rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
+  if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
+    omarchy-notification-send -g  "TUI removed" "$APP_NAME"
+  fi
+done
+
+update-desktop-database "$DESKTOP_DIR" &>/dev/null

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# omarchy:summary=Remove a web app desktop launcher
-# omarchy:args=[name]
+# omarchy:summary=Remove web app desktop launchers
+# omarchy:args=[name...]
 
 set -e
 
@@ -19,25 +19,29 @@ if (( $# == 0 )); then
 
   if ((${#WEB_APPS[@]})); then
     mapfile -t SORTED_WEB_APPS < <(printf '%s\n' "${WEB_APPS[@]}" | sort)
-    APP_NAME=$(omarchy-menu-select "Select web app to remove" "${SORTED_WEB_APPS[@]}" -- --width 520 --maxheight 520)
+    mapfile -t APP_NAMES < <(omarchy-menu-select "Select web app to remove" "${SORTED_WEB_APPS[@]}" -- --multi --width 520 --maxheight 520)
   else
     echo "No web apps to remove."
     exit 1
   fi
 else
-  APP_NAME="$*"
+  APP_NAMES=("$@")
 fi
 
-if [[ -z $APP_NAME ]]; then
+if (( ${#APP_NAMES[@]} == 0 )) || [[ -z ${APP_NAMES[0]} ]]; then
   echo "You must select a web app to remove."
   exit 1
 fi
 
-icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
-rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
+for APP_NAME in "${APP_NAMES[@]}"; do
+  [[ -z $APP_NAME ]] && continue
+  icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
+  rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
+  rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 
-if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
-  omarchy-notification-send -g  "Web app removed" "$APP_NAME"
-fi
+  if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
+    omarchy-notification-send -g  "Web app removed" "$APP_NAME"
+  fi
+done
+
 update-desktop-database "$DESKTOP_DIR" &>/dev/null

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -60,6 +60,7 @@ Item {
   property string doneFile: ""
   property int dmenuWidth: 300
   property int dmenuMaxHeight: 0
+  property bool multiSelect: false
   property bool requestActive: false
   property bool rowsLoaded: false
   property string activeMenu: "root"
@@ -80,7 +81,9 @@ Item {
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  property var pinnedItems: ({})
+  property int pinnedCount: 0
+  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null; pinnedItems = ({}); pinnedCount = 0 }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -97,7 +100,9 @@ Item {
   readonly property real rowReservedBorderRight: Border.right(selectedBorderSpec)
   readonly property int cornerRadius: Style.cornerRadius
   property int contentMargin: Style.spacing.panelPadding
-  property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
+  property int headerHeight: (root.dmenuActive && root.mode === "select" && root.multiSelect)
+    ? Math.max(Style.space(48), Style.font.title + Style.font.caption + Style.spacing.controlPaddingY * 2)
+    : Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
   property int contentSpacing: Style.spacing.md
   property int baseRowHeight: Math.max(Style.space(50), Style.font.body + Style.spacing.rowPaddingX * 2)
   property int detailRowHeight: Math.max(Style.space(58), Style.font.body + Style.font.caption + Style.spacing.rowPaddingX * 2)
@@ -571,6 +576,7 @@ Item {
       var detail = parts.join("\t")
       if (query && label.toLowerCase().indexOf(query) < 0
           && detail.toLowerCase().indexOf(query) < 0) continue
+      var val = detail ? label + "\t" + detail : label
       displayModel.append({
         itemId: "dmenu." + i,
         disabled: false,
@@ -587,7 +593,8 @@ Item {
         action: "",
         provider: "",
         score: i,
-        section: ""
+        section: "",
+        pinned: !!root.pinnedItems[val]
       })
     }
 
@@ -671,7 +678,11 @@ Item {
       }
     }
 
-    for (var k = 0; k < rows.length; k++) displayModel.append(rows[k])
+    for (var k = 0; k < rows.length; k++) {
+      var r = rows[k]
+      r.pinned = false
+      displayModel.append(r)
+    }
     layoutSerial += 1
 
     root.settleCursor()
@@ -756,6 +767,51 @@ Item {
     return true
   }
 
+  function isOptionPinned(val) {
+    return !!(root.pinnedItems && root.pinnedItems[val])
+  }
+
+  function togglePin(index) {
+    if (!root.multiSelect || root.mode !== "select") return
+    if (index < 0 || index >= displayModel.count) return
+    var row = displayModel.get(index)
+    if (!row) return
+    var val = row.detail ? row.label + "\t" + row.detail : row.label
+    var next = Object.assign({}, root.pinnedItems)
+    if (next[val]) {
+      delete next[val]
+    } else {
+      next[val] = true
+    }
+    root.pinnedItems = next
+    root.pinnedCount = Object.keys(next).length
+    displayModel.setProperty(index, "pinned", !!next[val])
+  }
+
+  function applyDmenuConfirm(index) {
+    if (root.multiSelect && root.pinnedCount > 0) {
+      var selectedValues = []
+      for (var i = 0; i < root.dmenuOptions.length; i++) {
+        var parts = String(root.dmenuOptions[i] || "").split("\t")
+        if (parts.length > 1) parts.shift()
+        var lbl = parts.shift() || ""
+        var dtl = parts.join("\t")
+        var val = dtl ? lbl + "\t" + dtl : lbl
+        if (root.pinnedItems[val]) {
+          selectedValues.push(val)
+        }
+      }
+      if (selectedValues.length === 0) {
+        selectedValues = Object.keys(root.pinnedItems)
+      }
+      root.applyDmenuSelection(selectedValues.join("\n"))
+    } else {
+      if (index < 0 || index >= displayModel.count) return
+      var picked = displayModel.get(index)
+      root.applyDmenuSelection(picked.detail ? picked.label + "\t" + picked.detail : picked.label)
+    }
+  }
+
   function activateIndex(index, fromPointer) {
     if (root.deleteConfirmOpen) return
     if (root.dmenuActive) {
@@ -763,9 +819,7 @@ Item {
         root.applyDmenuSelection(root.filterText)
         return
       }
-      if (index < 0 || index >= displayModel.count) return
-      var picked = displayModel.get(index)
-      root.applyDmenuSelection(picked.detail ? picked.label + "\t" + picked.detail : picked.label)
+      root.applyDmenuConfirm(index)
       return
     }
 
@@ -830,6 +884,8 @@ Item {
 
   function cancel() {
     if (root.dmenuActive) root.finishRequest(null)
+    pinnedItems = ({})
+    pinnedCount = 0
     opened = false
     filterText = ""
   }
@@ -840,6 +896,7 @@ Item {
     requestActive = false
     selectionFile = ""
     doneFile = ""
+    multiSelect = false
     activeMenu = root.item(initialMenu) ? initialMenu : "root"
     navStack = []
     filterText = ""
@@ -861,11 +918,14 @@ Item {
   function openDmenu(payload) {
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
+    multiSelect = mode === "select" && payload.multiSelect === true
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))
     dmenuOptions = Array.isArray(payload.options) ? payload.options : []
     selectionFile = String(payload.selectionFile || "")
     doneFile = String(payload.doneFile || "")
     requestActive = !!doneFile
+    pinnedItems = ({})
+    pinnedCount = 0
     dmenuWidth = Math.max(1, Number(payload.width || 300))
     dmenuMaxHeight = Math.max(0, Number(payload.maxHeight || 0))
     activeMenu = "root"
@@ -1133,6 +1193,12 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
+          } else if (event.key === Qt.Key_Tab && event.modifiers === Qt.NoModifier
+                     && root.dmenuActive && root.mode === "select" && root.multiSelect) {
+            if (displayModel.count > 0 && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count) {
+              root.togglePin(root.selectedIndex)
+            }
+            event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
@@ -1154,7 +1220,7 @@ Item {
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right) {
             if (root.dmenuActive) {
               if (root.mode === "input") root.applyDmenuSelection(root.filterText)
-              else if (displayModel.count > 0) root.activateIndex(root.cursorActive ? root.selectedIndex : 0)
+              else if (displayModel.count > 0 || (root.multiSelect && root.pinnedCount > 0)) root.activateIndex(root.cursorActive ? root.selectedIndex : 0)
             } else if (root.cursorActive) root.activateIndex(root.selectedIndex)
             else root.settleCursor()
             event.accepted = true
@@ -1198,16 +1264,36 @@ Item {
           radius: root.cornerRadius
           color: "transparent"
 
-          Text {
+          Column {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || (root.dmenuActive ? (root.dmenuPrompt + "…") : ((root.item(root.activeMenu) ? (root.item(root.activeMenu).title || root.item(root.activeMenu).label) : "Go") + "…"))
-            color: root.foreground
-            opacity: root.filterText ? 1 : 0.58
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.heading
-            elide: Text.ElideRight
+            spacing: Style.space(2)
+
+            Text {
+              width: parent.width
+              text: root.filterText
+                ? (root.filterText + (root.pinnedCount > 0 ? " (" + root.pinnedCount + " selected)" : ""))
+                : (root.dmenuActive
+                    ? ((root.pinnedCount > 0 ? root.dmenuPrompt + " (" + root.pinnedCount + " selected)" : root.dmenuPrompt) + "…")
+                    : ((root.item(root.activeMenu) ? (root.item(root.activeMenu).title || root.item(root.activeMenu).label) : "Go") + "…"))
+              color: root.foreground
+              opacity: root.filterText ? 1 : 0.58
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.heading
+              elide: Text.ElideRight
+            }
+
+            Text {
+              width: parent.width
+              visible: root.dmenuActive && root.mode === "select" && root.multiSelect
+              text: "Tab to select multiple"
+              color: root.foreground
+              opacity: 0.42
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              elide: Text.ElideRight
+            }
           }
 
         }
@@ -1260,7 +1346,10 @@ Item {
               required property string action
               required property int childCount
               required property bool disabled
+              required property bool pinned
 
+              readonly property string optionValue: row.detail ? row.label + "\t" + row.detail : row.label
+              readonly property bool isPinned: (root.dmenuActive && root.mode === "select" && root.multiSelect && root.isOptionPinned(optionValue)) || row.pinned
               readonly property bool hasCursor: root.cursorActive && row.index === root.selectedIndex
               readonly property bool isApp: row.kind === "app"
               readonly property bool hasIcon: row.icon.length > 0 || row.isApp
@@ -1271,17 +1360,19 @@ Item {
               // installed, not to be picked.
               opacity: row.disabled ? 0.4 : 1
               radius: root.cornerRadius
-              color: row.hasCursor ? root.selectedBackground : "transparent"
+              color: row.hasCursor
+                ? (row.isPinned ? Util.alpha(root.selectedBackground, Math.max(root.selectedBackground.a * 2.25, 0.18)) : root.selectedBackground)
+                : (row.isPinned ? root.selectedBackground : "transparent")
               borderSpec: row.hasCursor ? root.selectedBorderSpec : Border.none()
 
               Rectangle {
-                visible: false
+                visible: row.isPinned
                 width: Style.space(4)
-                height: parent.height - Style.space(18)
-                radius: Math.min(root.cornerRadius, Style.space(4))
-                color: root.selectedBackground
+                height: parent.height - Style.space(16)
+                radius: Math.min(root.cornerRadius, Style.space(2))
+                color: row.hasCursor ? root.selectedText : root.selectedBorder
                 anchors.left: parent.left
-                anchors.leftMargin: root.rowReservedBorderLeft + Style.space(8)
+                anchors.leftMargin: root.rowReservedBorderLeft + Style.space(4)
                 anchors.verticalCenter: parent.verticalCenter
               }
 
@@ -1333,7 +1424,7 @@ Item {
                   color: row.hasCursor ? root.selectedText : root.foreground
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.heading
-                  font.weight: Font.Medium
+                  font.weight: row.isPinned ? Font.DemiBold : Font.Medium
                   elide: Text.ElideRight
                 }
 
@@ -1351,11 +1442,22 @@ Item {
 
               Row {
                 id: trail
-                width: Style.space(14)
+                width: row.isPinned ? Style.space(22) : Style.space(14)
                 anchors.right: parent.right
                 anchors.rightMargin: root.rowReservedBorderRight + Style.space(8)
                 y: contentColumn.y + labelText.y + (labelText.height - height) / 2
-                spacing: 0
+                spacing: Style.space(4)
+
+                Text {
+                  id: pinCheck
+                  visible: row.isPinned
+                  text: "✓"
+                  color: row.hasCursor ? root.selectedText : (row.isPinned ? root.selectedBorder : root.foreground)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.heading
+                  font.weight: Font.Bold
+                  anchors.verticalCenter: parent.verticalCenter
+                }
 
                 Text {
                   visible: false
@@ -1394,6 +1496,10 @@ Item {
                   if (row.disabled) return
                   root.cursorActive = true
                   root.selectedIndex = row.index
+                  if (root.dmenuActive && root.mode === "select" && root.multiSelect && root.pinnedCount > 0) {
+                    root.togglePin(row.index)
+                    return
+                  }
                   root.activateIndex(row.index, true)
                 }
               }

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -94,3 +94,69 @@ pass "launcher remove deletes user-owned desktop files"
 
 (( ${#lines[@]} == 3 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
 pass "launcher remove does not notify for user-owned desktop files"
+
+# Test omarchy-webapp-remove directly with multiple apps
+rm -f "$tmp_dir/bin/omarchy-webapp-remove"
+mkdir -p "$tmp_dir/.local/share/icons/hicolor/256x256/apps" "$tmp_dir/.local/share/applications"
+cat >"$tmp_dir/.local/share/applications/App1.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=App1
+Exec=omarchy-launch-webapp https://app1.com
+DESKTOP
+touch "$tmp_dir/.local/share/icons/hicolor/256x256/apps/app1.png"
+
+cat >"$tmp_dir/.local/share/applications/App2.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=App2
+Exec=omarchy-launch-webapp https://app2.com
+DESKTOP
+touch "$tmp_dir/.local/share/icons/hicolor/256x256/apps/app2.png"
+
+cat >"$tmp_dir/bin/omarchy-menu-select" <<'SCRIPT'
+#!/bin/bash
+[[ " $* " == *" --multi "* ]] || exit 1
+printf '%s\n' "$FAKE_SELECTION"
+SCRIPT
+chmod +x "$tmp_dir/bin/omarchy-menu-select"
+
+FAKE_SELECTION=$'App1\nApp2' HOME="$tmp_dir" OMARCHY_REMOVE_NOTIFY=false "$ROOT/bin/omarchy-webapp-remove"
+
+[[ ! -e "$tmp_dir/.local/share/applications/App1.desktop" ]] || fail "omarchy-webapp-remove removes first pinned app"
+[[ ! -e "$tmp_dir/.local/share/applications/App2.desktop" ]] || fail "omarchy-webapp-remove removes second pinned app"
+[[ ! -e "$tmp_dir/.local/share/icons/hicolor/256x256/apps/app1.png" ]] || fail "omarchy-webapp-remove removes first app icon"
+[[ ! -e "$tmp_dir/.local/share/icons/hicolor/256x256/apps/app2.png" ]] || fail "omarchy-webapp-remove removes second app icon"
+pass "omarchy-webapp-remove removes multiple pinned web apps"
+
+cat >"$tmp_dir/.local/share/applications/Tui1.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Tui1
+Exec=xdg-terminal-exec --app-id=TUI.tile -e lazygit
+DESKTOP
+touch "$tmp_dir/.local/share/icons/hicolor/256x256/apps/tui1.png"
+
+cat >"$tmp_dir/.local/share/applications/Tui2.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Tui2
+Exec=xdg-terminal-exec --app-id=TUI.tile -e btop
+DESKTOP
+touch "$tmp_dir/.local/share/icons/hicolor/256x256/apps/tui2.png"
+
+FAKE_SELECTION=$'Tui1\nTui2' HOME="$tmp_dir" OMARCHY_REMOVE_NOTIFY=false "$ROOT/bin/omarchy-tui-remove"
+
+[[ ! -e "$tmp_dir/.local/share/applications/Tui1.desktop" ]] || fail "omarchy-tui-remove removes first pinned TUI"
+[[ ! -e "$tmp_dir/.local/share/applications/Tui2.desktop" ]] || fail "omarchy-tui-remove removes second pinned TUI"
+[[ ! -e "$tmp_dir/.local/share/icons/hicolor/256x256/apps/tui1.png" ]] || fail "omarchy-tui-remove removes first TUI icon"
+[[ ! -e "$tmp_dir/.local/share/icons/hicolor/256x256/apps/tui2.png" ]] || fail "omarchy-tui-remove removes second TUI icon"
+pass "omarchy-tui-remove removes multiple pinned TUIs"
+
+mkdir -p "$tmp_dir/.config/omarchy/themes/Theme One" "$tmp_dir/.config/omarchy/themes/Theme Two"
+FAKE_SELECTION=$'Theme One\nTheme Two' HOME="$tmp_dir" "$ROOT/bin/omarchy-theme-remove"
+
+[[ ! -d "$tmp_dir/.config/omarchy/themes/Theme One" ]] || fail "omarchy-theme-remove removes first pinned theme"
+[[ ! -d "$tmp_dir/.config/omarchy/themes/Theme Two" ]] || fail "omarchy-theme-remove removes second pinned theme"
+pass "omarchy-theme-remove removes multiple pinned themes"
+
+if HOME="$tmp_dir" "$ROOT/bin/omarchy-theme-remove" definitely-missing >/dev/null 2>&1; then
+  fail "omarchy-theme-remove reports missing themes"
+fi
+pass "omarchy-theme-remove reports missing themes"

--- a/test/shell.d/menu-plugin-test.sh
+++ b/test/shell.d/menu-plugin-test.sh
@@ -30,6 +30,7 @@ done
 # Records the rows it was offered, then answers with the pick under test.
 cat >"$STUB_DIR/omarchy-menu-select" <<'STUB'
 #!/bin/bash
+printf '%s\n' "$*" >"$FAKE_MENU_ARGS"
 cat >"$FAKE_ROWS"
 printf '%s\n' "$FAKE_PICK"
 STUB
@@ -52,17 +53,20 @@ pick() {
   local verb="$1" choice="$2"
 
   : >"$TMPDIR/calls"
+  : >"$TMPDIR/menu-args"
   : >"$TMPDIR/rows"
   HOME="$TMPDIR/home" \
     PATH="$STUB_DIR:$PATH" \
     FAKE_PLUGINS="$TMPDIR/plugins.json" \
     FAKE_CALLS="$TMPDIR/calls" \
+    FAKE_MENU_ARGS="$TMPDIR/menu-args" \
     FAKE_ROWS="$TMPDIR/rows" \
     FAKE_PICK="$choice" \
     "$ROOT/bin/omarchy-menu-plugin" "$verb" >/dev/null 2>&1
 
   ROWS=$(cat "$TMPDIR/rows")
   CALLS=$(cat "$TMPDIR/calls")
+  MENU_ARGS=$(cat "$TMPDIR/menu-args")
 }
 
 # Two plugins can declare the same display name. The id rides along as row
@@ -81,11 +85,42 @@ pass "picker offers the id as subtext on every row"
 [[ $CALLS == *"omarchy-plugin-enable tester.clock"* ]] \
   || fail "picker acts on the row that was picked, not the one that shares its name" "$CALLS"
 pass "picker acts on the row that was picked, not the one that shares its name"
+[[ $MENU_ARGS == *"--multi"* ]] || fail "plugin enable picker opts into multi-select" "$MENU_ARGS"
+pass "plugin enable picker opts into multi-select"
+
+pick enable "$(printf 'Clock\tomarchy.clock\nClock\ttester.clock')"
+[[ $CALLS == $'omarchy-plugin-enable omarchy.clock\nomarchy-plugin-enable tester.clock' ]] \
+  || fail "picker enables every selected plugin" "$CALLS"
+pass "picker enables every selected plugin"
+
+cat >"$TMPDIR/plugins.json" <<'JSON'
+[
+  {"id": "omarchy.clock", "name": "Clock", "kinds": ["bar-widget"], "enabled": true, "active": false, "canDisable": true, "firstParty": true},
+  {"id": "tester.clock", "name": "Clock", "kinds": ["bar-widget"], "enabled": true, "active": false, "canDisable": true, "firstParty": false}
+]
+JSON
+
+pick disable "$(printf 'Clock\tomarchy.clock\nClock\ttester.clock')"
+[[ $CALLS == $'omarchy-plugin-disable omarchy.clock\nomarchy-plugin-disable tester.clock' ]] \
+  || fail "picker disables every selected plugin" "$CALLS"
+pass "picker disables every selected plugin"
 
 pick remove "$(printf 'Clock\ttester.clock')"
 [[ $CALLS == *"omarchy-plugin-remove tester.clock"* ]] \
   || fail "picker removes the plugin whose row was picked" "$CALLS"
 pass "picker removes the plugin whose row was picked"
+
+cat >"$TMPDIR/plugins.json" <<'JSON'
+[
+  {"id": "tester.clock", "name": "Clock", "kinds": ["bar-widget"], "enabled": true, "active": false, "canDisable": true, "firstParty": false},
+  {"id": "acme.weather", "name": "Weather", "kinds": ["bar-widget"], "enabled": false, "active": false, "canDisable": true, "firstParty": false}
+]
+JSON
+
+pick remove "$(printf 'Clock\ttester.clock\nWeather\tacme.weather')"
+[[ $CALLS == "terminal: omarchy-plugin-remove tester.clock; omarchy-plugin-remove acme.weather" ]] \
+  || fail "picker sends every selected plugin through the removal flow" "$CALLS"
+pass "picker sends every selected plugin through the removal flow"
 
 cat >"$TMPDIR/plugins.json" <<'JSON'
 [
@@ -114,6 +149,8 @@ pass "clone picker offers built-in plugins"
 [[ $CALLS == *"terminal: omarchy-plugin-clone omarchy.clock --edit"* ]] ||
   fail "clone picker delegates cloning and editing to the clone command" "$CALLS"
 pass "clone picker clones and opens the personal plugin"
+[[ $MENU_ARGS != *"--multi"* ]] || fail "plugin clone picker stays single-select" "$MENU_ARGS"
+pass "plugin clone picker stays single-select"
 
 # Once a clone pointing back at the source is discovered, whatever it is named,
 # the source no longer belongs in Clone.

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -8,6 +8,7 @@ run_node_test <<'JS'
 const fs = require('fs')
 const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
 const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+const menuSelect = fs.readFileSync(path.join(root, 'bin/omarchy-menu-select'), 'utf8')
 const defaultMenuJsonc = fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8')
 
 const parsed = menu.parseMenuJsonc(`
@@ -376,7 +377,8 @@ assert(
   'menu select mode reads a leading icon and a trailing subtext off an option'
 )
 assert(
-  /omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove/.test(pluginPicker),
+  /remove_command\+="omarchy-plugin-remove/.test(pluginPicker)
+    && /omarchy-launch-floating-terminal-with-presentation "\$remove_command"/.test(pluginPicker),
   'plugin picker removes where the confirmation and backup path are visible'
 )
 
@@ -606,6 +608,33 @@ assert(
   /function activateIndex\(index, fromPointer\)[\s\S]*root\.setActiveMenu\(row\.target \|\| row\.itemId, true, fromPointer\)/.test(menuQml)
     && /onClicked:[\s\S]*root\.activateIndex\(row\.index, true\)/.test(menuQml),
   'mouse activation carries pointer intent into subordinate menus'
+)
+assert(
+  /function togglePin\(index\)\s*\{\s*if \(!root\.multiSelect \|\| root\.mode !== "select"\) return[\s\S]*root\.pinnedItems =[\s\S]*root\.pinnedCount =/.test(menuQml),
+  'menu only pins rows for multi-select requests'
+)
+assert(
+  /function applyDmenuConfirm\(index\)\s*\{[\s\S]*if \(root\.multiSelect && root\.pinnedCount > 0\)[\s\S]*root\.applyDmenuSelection\(selectedValues\.join\("\\n"\)\)/.test(menuQml),
+  'menu select mode returns all pinned items newline-joined when items are pinned'
+)
+assert(
+  /event\.key === Qt\.Key_Tab && event\.modifiers === Qt\.NoModifier[\s\S]*root\.mode === "select" && root\.multiSelect[\s\S]*root\.togglePin\(root\.selectedIndex\)/.test(menuQml)
+    && !/Qt\.Key_Backtab/.test(menuQml),
+  'menu multi-select pins items with plain Tab only'
+)
+assert(
+  /multiSelect = mode === "select" && payload\.multiSelect === true/.test(menuQml)
+    && /visible: root\.dmenuActive && root\.mode === "select" && root\.multiSelect/.test(menuQml),
+  'menu only exposes multi-select controls when the caller opts in'
+)
+assert(
+  /--multi\)\s*multi_select=1/.test(menuSelect)
+    && /\$payload->\{multiSelect\} = JSON::PP::true if \$ARGV\[6\] eq "1"/.test(menuSelect),
+  'menu select only requests multi-selection through its explicit flag'
+)
+assert(
+  /displayModel\.count > 0 \|\| \(root\.multiSelect && root\.pinnedCount > 0\)/.test(menuQml),
+  'menu confirms pinned items even when filtering hides every row'
 )
 JS
 


### PR DESCRIPTION
## Summary

Quattro moved several management flows to the native Omarchy shell selector, which only returned one item at a time. This removed batch removal for web apps and TUIs and required reopening similar management menus for every operation.

This change adds opt-in multi-selection to the native selector.

- Press Tab to pin or unpin the highlighted row.
- Keep pinned rows selected while filtering.
- Show pinned rows with a persistent fill, accent marker, checkmark, and live selected count.
- Return pinned values as newline-delimited output in their original order.
- Preserve single-selection behavior when nothing is pinned.
- Keep multi-selection hidden unless explicitly enabled.

Batch selection is enabled for web app, TUI, and extra-theme removal, plus plugin enablement, disablement, and removal.

Plugin cloning and selectors requiring exactly one value remain single-select. Plugin removal preserves the existing terminal confirmation and backup flow for each selected plugin.

## Screenshot
<img width="495" height="444" alt="screenshot-2026-08-17_02-09-52" src="https://github.com/user-attachments/assets/b2f7f8f6-9cd0-4ec3-8664-6337a45815f5" />
