### PR TITLE
Suspend automatically after idle timeout

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,8 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "suspend": 900
   },
   "bar": {
     "position": "top",

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -13,7 +13,8 @@ $OMARCHY_PATH/config/omarchy/shell.json  # Canonical defaults
 ```
 
 The shell hot-reloads `shell.json` on save — no restart needed for layout
-changes. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+changes. `idle.screensaver`, `idle.lock`, and `idle.suspend` are seconds since
+user idle began.
 
 **Commands:** `omarchy restart shell`, `omarchy refresh shell`
 
@@ -45,8 +46,13 @@ Saving a file anywhere under `~/.config/omarchy/plugins/` reloads plugin code
 automatically. If a change somehow fails to apply, force a reload with
 `omarchy-shell shell rescanPlugins`.
 
-## Idle and Lock
+## Idle, Lock, and Suspend
 
-Set `idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json`,
-in seconds since user idle began. Example: "lock after ten minutes" means
-setting `idle.lock` to `600`.
+Set `idle.screensaver`, `idle.lock`, and `idle.suspend` in
+`~/.config/omarchy/shell.json`, in seconds since user idle began. Example:
+"lock after ten minutes and suspend after thirty" means setting `idle.lock`
+to `600` and `idle.suspend` to `1800`.
+
+Stay Awake (`omarchy toggle idle`) disables all three idle actions. `omarchy
+toggle suspend` only shows or hides the manual Suspend action in the system
+menu; it does not change the automatic idle deadline.

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -136,7 +136,8 @@ string on a miss.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "suspend": 900
   },
   "bar": {
     "id": "omarchy.bar",
@@ -168,12 +169,19 @@ Rules:
 5. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
-7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+7. `idle.screensaver`, `idle.lock`, and `idle.suspend` are seconds since user
+   idle began. The defaults start the screensaver at 150 seconds, lock at 300,
+   and suspend at 900.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user
 customizes, `shell.json` is canonical — there is no deep-merge.
+
+The idle monitor respects application inhibitors. Stay Awake (`omarchy toggle
+idle`) disables the complete idle cycle, including automatic suspend. The
+separate `omarchy toggle suspend` command only controls whether the manual
+Suspend action is shown in the system menu.
 
 `shell.json` is shell configuration; theme tokens live in `shell.toml`
 (next section). Both are current — they answer different questions. A

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -131,4 +131,4 @@ Every widget is one entry in one of the three layout arrays, and its settings si
 
 One rule worth internalizing: **once you have your own `shell.json`, it's canonical**. Until you customize anything, the shell reads Omarchy's default file. The moment you drag a widget, run `omarchy bar`, or edit the file yourself, you own it — there's no deep merge, so new default widgets in future Omarchy releases won't appear on your bar automatically. `omarchy bar defaults` puts the shipped layout back whenever you want a clean slate.
 
-The same file also holds your idle timings at the top level, outside the `bar` key: `idle.screensaver` and `idle.lock`, both in seconds since you went idle. So the default screensaver kicks in at 150 seconds and the lock at 300.
+The same file also holds your idle timings at the top level, outside the `bar` key: `idle.screensaver`, `idle.lock`, and `idle.suspend`, all in seconds since you went idle. The defaults start the screensaver at 150 seconds, lock at 300, and suspend at 900.

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -12,7 +12,7 @@ From the terminal, the same switches are `omarchy toggle <thing>`. Run `omarchy 
 | ------ | ------ | ------- |
 | Night light | `Super + Ctrl + N` | `omarchy toggle nightlight` |
 | Silence notifications | `Super + Ctrl + ,` | `omarchy toggle notification silencing` |
-| Stay awake (no idle lock) | `Super + Ctrl + I` | `omarchy toggle idle` |
+| Stay awake (no idle actions) | `Super + Ctrl + I` | `omarchy toggle idle` |
 | Crash capture | — | `omarchy toggle crash-capture` |
 | Screensaver | — | `omarchy toggle screensaver` |
 | Menu bar | `Super + Shift + Space` | `omarchy toggle bar` |
@@ -31,7 +31,7 @@ Most of these are just a flag file under `~/.local/state/omarchy/toggles/`. If y
 omarchy-toggle-enabled screensaver-off && echo "screensaver is off"
 ```
 
-The flags are named for the off state — `screensaver-off`, `suspend-off`, `bar-off` — so their presence means the feature is disabled.
+The flags are named for the off state — `screensaver-off`, `suspend-off`, `bar-off` — but their scope differs: `screensaver-off` disables the idle screensaver, `bar-off` hides the bar, and `suspend-off` hides the manual Suspend action. Automatic idle suspend is configured separately in `shell.json`.
 
 ### Indicators in the bar
 
@@ -71,18 +71,19 @@ The Omarchy shell owns idle behavior, and the timings are a top-level `idle` blo
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "suspend": 900
   }
 }
 ```
 
-Both numbers are seconds counted from the moment you went idle — not from each other. So with the defaults, the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Save the file and the shell picks up the new timings right away.
+All three numbers are seconds counted from the moment you went idle — not from each other. With the defaults, the screensaver comes up after two and a half minutes, the lock screen takes over at five minutes, and the computer suspends at fifteen minutes. Save the file and the shell picks up the new timings right away.
 
-If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
+If you dismiss the screensaver while the idle cycle is armed, that counts as activity and cancels the pending lock and suspend. You don't get locked out—or suspended—for glancing at your machine.
 
-To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
+To stop all idle actions temporarily, `Super + Ctrl + I` — or `omarchy toggle idle` — flips Stay Awake on, and the coffee cup indicator appears in the bar. That pauses the screensaver, lock, and automatic suspend, so it's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
 
-This is about locking and the screensaver, not power. Suspend and hibernation have their own setup in [system sleep](36-system-sleep.md).
+The idle suspend deadline uses the same system suspend path as the manual action and locks the session before sleep. See [system sleep](36-system-sleep.md) for the manual Suspend action and hibernation setup.
 
 ### The screensaver
 

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -14,7 +14,7 @@ Here's a list of the key files in `~/.config` and what they control:
 | `~/.config/hypr/input.lua` | Controls your keyboard layout, mouse, and trackpad settings. |
 | `~/.config/hypr/looknfeel.lua` | Controls gaps, borders, animations, and the rest of the look. |
 | `~/.config/hypr/autostart.lua` | Controls extra processes started with the session. |
-| `~/.config/omarchy/shell.json` | Controls the Omarchy shell: bar position, layout, and widgets, plus screensaver, lock, and idle timings. |
+| `~/.config/omarchy/shell.json` | Controls the Omarchy shell: bar position, layout, and widgets, plus screensaver, lock, and suspend timings. |
 | `~/.config/foot/foot.ini` | Controls your terminal (foot is the default). |
 | `~/.XCompose` | Defines your quick-access emoji and name/email autocomplete. Make sure to run `omarchy-restart-xcompose` after making changes. |
 

--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -1,6 +1,6 @@
 # System sleep
 
-Omarchy enables suspend and hibernation by default, but if you're having issues with either on your machine, you can toggle them off.
+Omarchy exposes manual suspend by default and can suspend automatically after fifteen minutes of inactivity. Hibernation becomes available after you set it up.
 
 ### Power profiles
 
@@ -8,9 +8,11 @@ On a laptop, Omarchy remembers your power profile separately for plugged in and 
 
 You can see what your machine offers with `omarchy powerprofiles list`, and set the one you want for the state you're currently in with `omarchy powerprofiles set autodetect power-saver`. To set the other state without unplugging anything, name it directly: `omarchy powerprofiles set battery power-saver`. Whatever you pick is what you'll get back the next time you're in that state.
 
-### Toggle suspend
+### Toggle the suspend action
 
-You toggle suspend by running `omarchy toggle suspend` from the terminal. That just reveals/hides the option under _System_ (or `Super + Esc`), and then you can see if it works consistently on your system. If not, you can hide it again with the same command.
+You toggle the manual Suspend action by running `omarchy toggle suspend` from the terminal. That reveals or hides the option under _System_ (or `Super + Esc`); it does not change automatic idle suspend.
+
+Automatic suspend is controlled by `idle.suspend` in `~/.config/omarchy/shell.json`. The value is the number of seconds since your last activity, with a default of `900`. Stay Awake (`Super + Ctrl + I` or `omarchy toggle idle`) temporarily disables the complete idle cycle, including automatic suspend. See [toggles and idle](13-toggles-idle-screensaver.md) for the full configuration.
 
 ### Toggle hibernation
 

--- a/migrations/1786881090.sh
+++ b/migrations/1786881090.sh
@@ -1,0 +1,24 @@
+echo "Add the automatic idle suspend timeout to the shell config"
+
+config_file="$HOME/.config/omarchy/shell.json"
+
+# Customized shell configs are canonical and are not deep-merged with new
+# defaults. Materialize the timeout only when it is absent, so an existing
+# value—including zero or another non-standard choice—remains the user's.
+if [[ -s $config_file ]] && jq -e '
+  type == "object" and
+  ((.idle == null) or ((.idle | type) == "object")) and
+  (((.idle // {}) | has("suspend")) | not)
+' "$config_file" >/dev/null 2>&1; then
+  tmp=$(mktemp)
+
+  if jq '.idle = ((.idle // {}) + { suspend: 900 })' "$config_file" >"$tmp"; then
+    # Write through the path so a shell.json symlinked into a dotfiles repo
+    # stays a symlink.
+    cat "$tmp" >"$config_file"
+  else
+    echo "Could not add idle.suspend to $config_file; add it manually."
+  fi
+
+  rm -f "$tmp"
+fi

--- a/shell/README.md
+++ b/shell/README.md
@@ -232,7 +232,8 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "suspend": 900
   },
   "bar": {
     "id": "omarchy.bar",
@@ -274,9 +275,11 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    `allowMultiple: true`. Each instance is independent — e.g. two clock
    widgets in different timezones are just two `{"id":"omarchy.clock", "timezone": ...}`
    entries with their own values.
-7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
-   are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+7. **Idle timings are top-level.** `idle.screensaver`, `idle.lock`, and
+   `idle.suspend` are seconds since user idle began, so the defaults start the
+   screensaver at 150s, lock at 300s, and suspend at 900s. Stay Awake disables
+   the complete idle cycle; `omarchy toggle suspend` only controls the manual
+   system-menu action.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -16,12 +16,15 @@ Item {
   readonly property string stayAwakeStatePath: stayAwakeStateDir + "/stay-awake"
   readonly property int defaultScreensaverSeconds: 150
   readonly property int defaultLockSeconds: 300
+  readonly property int defaultSuspendSeconds: 900
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
-  readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
+  readonly property int suspendTimeoutSeconds: secondsFromConfig(idleConfig.suspend, defaultSuspendSeconds)
+  readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds, suspendTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
+  readonly property int suspendDelaySeconds: Math.max(0, suspendTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
@@ -73,10 +76,20 @@ Item {
     screensaverTimer.stop()
     lockTimer.stop()
     screensaverLaunchGraceTimer.stop()
-    root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
     runProcess(lockProcess, "lock", "omarchy-system-lock")
+  }
+
+  function suspendSystem() {
+    logEvent("suspend system requested")
+    screensaverTimer.stop()
+    lockTimer.stop()
+    suspendTimer.stop()
+    root.idledThisCycle = false
+    root.screensaverStartedThisCycle = false
+    resetScreensaverWindows()
+    runProcess(suspendProcess, "suspend", "systemctl suspend")
   }
 
   function startIdleCycle() {
@@ -85,7 +98,7 @@ Item {
       return
     }
 
-    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
+    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds + " suspend=" + root.suspendTimeoutSeconds)
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
@@ -95,12 +108,16 @@ Item {
 
     if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
     else lockTimer.restart()
+
+    if (root.suspendTimeoutSeconds === 0) suspendSystem()
+    else suspendTimer.restart()
   }
 
   function cancelIdleCycle(reason) {
     logEvent("idle-cycle-cancel", reason || "requested")
     screensaverTimer.stop()
     lockTimer.stop()
+    suspendTimer.stop()
     screensaverLaunchGraceTimer.stop()
 
     if (root.idledThisCycle) runProcess(wakeProcess, "wake", "omarchy-system-wake")
@@ -188,13 +205,16 @@ Item {
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,
+      suspend: root.suspendTimeoutSeconds,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
+      suspendDelay: root.suspendDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
         screensaver: screensaverTimer.running,
         lock: lockTimer.running,
-        screensaverLaunchGrace: screensaverLaunchGraceTimer.running
+        screensaverLaunchGrace: screensaverLaunchGraceTimer.running,
+        suspend: suspendTimer.running
       },
       processes: {
         screensaver: screensaverProcess.running,
@@ -280,6 +300,13 @@ Item {
     }
   }
 
+  Timer {
+    id: suspendTimer
+    interval: root.suspendDelaySeconds * 1000
+    repeat: false
+    onTriggered: if (root.idleEnabled && root.idledThisCycle) root.suspendSystem()
+  }
+
   Connections {
     target: Hyprland
     function onRawEvent(event) { root.handleHyprlandEvent(event) }
@@ -296,6 +323,10 @@ Item {
   Process {
     id: wakeProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+  Process {
+    id: suspendProcess
+    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "suspend exitCode="+ exitCode + " status=" + exitStatus) }
   }
 
   Process {

--- a/shell/plugins/services/idle/manifest.json
+++ b/shell/plugins/services/idle/manifest.json
@@ -4,7 +4,7 @@
   "name": "Idle",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Quickshell-based idle detection for screensaver, lock, and display wake.",
+  "description": "Quickshell-based idle detection for screensaver, lock, suspend and display wake.",
   "kinds": [
     "service"
   ],

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -37,7 +37,8 @@ ShellRoot {
     version: 1,
     idle: {
       screensaver: 150,
-      lock: 300
+      lock: 300,
+      suspend: 900
     },
     bar: {
       position: "top",

--- a/test/shell.d/idle-suspend-migration-test.sh
+++ b/test/shell.d/idle-suspend-migration-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+
+migration="$ROOT/migrations/1786881090.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+config="$home/.config/omarchy/shell.json"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+write_config() {
+  mkdir -p "$home/.config/omarchy"
+  printf '%s\n' "$1" >"$config"
+}
+
+jq -e '.idle.suspend == 900' "$ROOT/config/omarchy/shell.json" >/dev/null ||
+  fail "shipped config declares the automatic suspend timeout"
+pass "shipped config declares the automatic suspend timeout"
+
+# A customized config from before idle suspend keeps its existing timings and
+# receives only the new default.
+write_config '{"version":1,"idle":{"screensaver":240,"lock":480},"bar":{"position":"bottom"}}'
+run_migration
+
+[[ $(jq -c '.idle' "$config") == '{"screensaver":240,"lock":480,"suspend":900}' ]] ||
+  fail "migration adds idle.suspend without changing existing timings" "$(cat "$config")"
+[[ $(jq -r '.bar.position' "$config") == "bottom" ]] ||
+  fail "migration preserves unrelated shell settings" "$(cat "$config")"
+pass "migration adds only the missing suspend timeout"
+
+before=$(sha256sum "$config")
+run_migration
+[[ $before == $(sha256sum "$config") ]] ||
+  fail "migration is idempotent" "$(cat "$config")"
+pass "migration is idempotent"
+
+# Any value already chosen by the user wins, including zero.
+write_config '{ "version": 1, "idle": { "suspend": 0 } }'
+before=$(sha256sum "$config")
+run_migration
+[[ $before == $(sha256sum "$config") ]] ||
+  fail "migration preserves an existing suspend timeout" "$(cat "$config")"
+pass "migration preserves an existing suspend timeout"
+
+# A config without an idle block still receives the new canonical setting.
+write_config '{"version":1,"bar":{"position":"top"}}'
+run_migration
+[[ $(jq -r '.idle.suspend' "$config") == "900" ]] ||
+  fail "migration creates a missing idle block" "$(cat "$config")"
+pass "migration creates a missing idle block"
+
+# Write through symlinks so dotfile-managed configs remain linked.
+target="$test_dir/dotfiles-shell.json"
+printf '%s\n' '{"version":1,"idle":{"lock":300}}' >"$target"
+mkdir -p "$home/.config/omarchy"
+ln -sfn "$target" "$config"
+run_migration
+[[ -L $config ]] || fail "migration preserves a shell.json symlink"
+[[ $(jq -r '.idle.suspend' "$target") == "900" ]] ||
+  fail "migration updates the symlink target" "$(cat "$target")"
+pass "migration preserves a shell.json symlink"
+
+# Missing and malformed configs are user state the migration must not replace.
+rm -f "$config" "$target"
+run_migration
+[[ ! -e $config ]] || fail "migration does not create a missing user config"
+pass "migration does not create a missing user config"
+
+write_config '{ not json'
+run_migration
+[[ $(cat "$config") == '{ not json' ]] ||
+  fail "migration leaves an unparsable config untouched" "$(cat "$config")"
+pass "migration leaves an unparsable config untouched"


### PR DESCRIPTION
Add a configurable idle suspend deadline, default is 900 seconds.
I have made it myself, the docs are written by AI. I've read them all, they must be correct.

Refers to #6931.