### PR TITLE
Stub OSD calls in power tests

### DIFF
--- a/test/shell.d/system-power-test.sh
+++ b/test/shell.d/system-power-test.sh
@@ -17,7 +17,7 @@ printf 'systemd-run %s\n' "$*" >>"$CALL_LOG"
 exit 0
 SH
 
-for command in omarchy-state omarchy-hyprland-window-close-all sleep; do
+for command in omarchy-osd omarchy-state omarchy-hyprland-window-close-all sleep; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 
@@ -36,10 +36,12 @@ run_power_command() {
 assert_power_calls() {
   local action="$1"
   local systemctl_action="$2"
+  local osd_message="$3"
   local expected_log="$test_tmp/$action-expected.log"
 
   cat >"$expected_log" <<EOF
 systemd-run --user --collect --quiet --on-active=2s --timer-property=AccuracySec=100ms systemctl $systemctl_action --no-wall
+omarchy-osd -i $action -m $osd_message -d 5000
 omarchy-state clear re*-required
 omarchy-hyprland-window-close-all 
 sleep 1
@@ -50,10 +52,10 @@ EOF
 }
 
 run_power_command reboot
-assert_power_calls reboot reboot
+assert_power_calls reboot reboot Rebooting
 
 run_power_command shutdown
-assert_power_calls shutdown poweroff
+assert_power_calls shutdown poweroff "Shutting down"
 
 for action in reboot shutdown; do
   : >"$call_log"

--- a/test/shell.d/system-power-test.sh
+++ b/test/shell.d/system-power-test.sh
@@ -21,7 +21,11 @@ for command in omarchy-osd omarchy-state omarchy-hyprland-window-close-all sleep
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 
-printf '%s %s\n' "$(basename "$0")" "$*" >>"$CALL_LOG"
+printf '%s' "$(basename "$0")" >>"$CALL_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >>"$CALL_LOG"
+done
+printf '\n' >>"$CALL_LOG"
 SH
 done
 chmod +x "$mock_bin"/*
@@ -38,13 +42,14 @@ assert_power_calls() {
   local systemctl_action="$2"
   local osd_message="$3"
   local expected_log="$test_tmp/$action-expected.log"
+  local tab=$'\t'
 
   cat >"$expected_log" <<EOF
 systemd-run --user --collect --quiet --on-active=2s --timer-property=AccuracySec=100ms systemctl $systemctl_action --no-wall
-omarchy-osd -i $action -m $osd_message -d 5000
-omarchy-state clear re*-required
-omarchy-hyprland-window-close-all 
-sleep 1
+omarchy-osd${tab}-i${tab}$action${tab}-m${tab}$osd_message${tab}-d${tab}5000
+omarchy-state${tab}clear${tab}re*-required
+omarchy-hyprland-window-close-all
+sleep${tab}1
 EOF
 
   diff -u "$expected_log" "$call_log" || fail "$action runs after being scheduled outside the terminal scope"


### PR DESCRIPTION
## Summary

- stub `omarchy-osd` in the system power test so it cannot reach the active desktop
- assert the exact reboot and shutdown OSD calls in their production order

## Why

The power test runs the real reboot and shutdown scripts behind command stubs. Because `omarchy-osd` was not stubbed, those scripts could reach the active Omarchy shell and display real OSD messages during a test run.

## Testing

- `bash test/shell.d/system-power-test.sh` in disposable Arch and native Linux gates
- negative control: removing the reboot OSD call fails on the new expected log line
- `./test/all` in the disposable native Linux gate — all 180 test files passed
- Bash 5 syntax check and `git diff --check`

This is a test-only change, so visual verification and graphical acceptance are not applicable.

Fixes #6999