### PR TITLE
Fix keyboard label and Wi-Fi scrollbar alignment

### DIFF
--- a/shell/Ui/WidgetButton.qml
+++ b/shell/Ui/WidgetButton.qml
@@ -16,6 +16,7 @@ Item {
   property real fixedWidth: -1
   property real fixedHeight: -1
   property real textRotation: 0
+  property real labelVerticalOffset: 0
   property bool keepSpace: false
   property bool dimmed: false
   property bool concealed: false
@@ -76,6 +77,7 @@ Item {
     id: label
     visible: root.labelVisible
     anchors.centerIn: parent
+    anchors.verticalCenterOffset: root.labelVerticalOffset
     text: root.text
     color: root.active && root.useActiveColor ? root.activeColor : root.foreground
     font.family: root.fontFamily

--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -211,6 +211,9 @@ BarWidget {
     bar: root.bar
     text: root.layoutLabel
     fontSize: Style.font.caption
+    // Native-rendered caption glyphs sit one visual pixel above the bar's
+    // centre; keep vertical bars symmetric and correct the horizontal label.
+    labelVerticalOffset: root.vertical ? 0 : Style.space(1)
     horizontalMargin: 6
     tooltipText: root.layoutFull
     onPressed: function() { root.cycleLayout() }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1481,7 +1481,10 @@ Panel {
         boundsBehavior: Flickable.StopAtBounds
         interactive: contentHeight > height
 
-        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+        ScrollBar.vertical: ScrollBar {
+          id: networkScrollBar
+          policy: ScrollBar.AsNeeded
+        }
 
         model: root.wifiStationAvailable ? root.wifiNetworks : []
         currentIndex: root.selectedIndex
@@ -1494,7 +1497,7 @@ Panel {
           required property var modelData
           required property int index
           readonly property string sectionTitle: root.wifiSectionTitle(index)
-          width: ListView.view.width
+          width: ListView.view.width - (networkScrollBar.visible ? networkScrollBar.width : 0)
           height: delegateColumn.implicitHeight
 
           Column {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1497,6 +1497,8 @@ Panel {
           required property var modelData
           required property int index
           readonly property string sectionTitle: root.wifiSectionTitle(index)
+          // Keep the list at its full panel width and reserve an internal
+          // gutter for the existing scrollbar by narrowing only the rows.
           width: ListView.view.width - (networkScrollBar.visible ? networkScrollBar.width : 0)
           height: delegateColumn.implicitHeight
 

--- a/test/shell.d/bar-icon-geometry-test.sh
+++ b/test/shell.d/bar-icon-geometry-test.sh
@@ -51,6 +51,14 @@ ShellRoot {
     return true
   }
 
+  function textChild(button) {
+    for (var i = 0; i < button.children.length; i++) {
+      var child = button.children[i]
+      if ("text" in child && child.text === button.text) return child
+    }
+    return null
+  }
+
   Component.onCompleted: Qt.callLater(function() {
     if (!checkIcon(bluetooth, "bluetooth")) return
     if (!checkIcon(network, "network")) return
@@ -95,6 +103,17 @@ ShellRoot {
     if (compactStatusIcon.implicitWidth !== Style.bar.statusSlot
         || compactVerticalStatusIcon.implicitHeight !== Style.bar.statusSlot) {
       fail("compact status icons do not use the shared status slot")
+      return
+    }
+    var keyboardText = textChild(keyboardLabel)
+    if (!keyboardText) {
+      fail("keyboard label text is missing")
+      return
+    }
+    var keyboardInkCenter = keyboardText.y + keyboardText.baselineOffset
+      + keyboardMetrics.tightBoundingRect.y + keyboardMetrics.tightBoundingRect.height / 2
+    if (Math.abs(keyboardInkCenter - keyboardLabel.height / 2) > 0.5) {
+      fail("keyboard label ink is off center by " + (keyboardInkCenter - keyboardLabel.height / 2))
       return
     }
     console.log("RESULT pass")
@@ -142,6 +161,22 @@ ShellRoot {
   BarIconButton { id: verticalIcon; bar: verticalBar; text: "\uf021" }
   BarIconButton { id: compactStatusIcon; bar: testBar; text: "\uf021"; slotSize: Style.bar.statusSlot }
   BarIconButton { id: compactVerticalStatusIcon; bar: verticalBar; text: "\uf021"; slotSize: Style.bar.statusSlot }
+  TextMetrics {
+    id: keyboardMetrics
+    font.family: testBar.fontFamily
+    font.pixelSize: Style.font.caption
+    text: keyboardLabel.text
+  }
+  WidgetButton {
+    id: keyboardLabel
+    bar: testBar
+    text: "EN"
+    fontSize: Style.font.caption
+    horizontalMargin: 6
+    labelVerticalOffset: Style.space(1)
+    width: implicitWidth
+    height: implicitHeight
+  }
   Row {
     id: horizontalIndicatorPair
     BarIndicator { id: horizontalIndicator; bar: testBar; active: true; activeText: "󰅶" }

--- a/test/shell.d/keyboard-layout-test.sh
+++ b/test/shell.d/keyboard-layout-test.sh
@@ -5,7 +5,17 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const model = requireFromRoot('shell/plugins/bar/widgets/KeyboardLayoutModel.js')
+const keyboardSource = fs.readFileSync(root + '/shell/plugins/bar/widgets/KeyboardLayout.qml', 'utf8')
+const widgetButtonSource = fs.readFileSync(root + '/shell/Ui/WidgetButton.qml', 'utf8')
+
+assert(/property real labelVerticalOffset:\s*0/.test(widgetButtonSource), 'bar labels expose a targeted vertical alignment offset')
+assert(/anchors\.verticalCenterOffset:\s*root\.labelVerticalOffset/.test(widgetButtonSource), 'bar labels apply their vertical alignment offset')
+assert(
+  /labelVerticalOffset:\s*root\.vertical\s*\?\s*0\s*:\s*Style\.space\(1\)/.test(keyboardSource),
+  'the horizontal keyboard label corrects its caption-font optical center'
+)
 
 // Trimmed from xkbcli list, keeping the format of every section it prints,
 // including the options nested under an option group: those quote their

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -9,10 +9,18 @@ const fs = require('fs')
 const network = requireFromRoot('shell/plugins/panels/network/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
 
+assert(
+  /ListView\s*\{\s*id:\s*networkList[\s\S]*?width:\s*parent\.width/.test(panelSource),
+  'network keeps the scrollable list at the full panel width'
+)
 assert(/ScrollBar\.vertical:\s*ScrollBar\s*\{\s*id:\s*networkScrollBar/.test(panelSource), 'network gives its attached scrollbar a stable geometry reference')
 assert(
+  /id:\s*networkScrollBar\s*policy:\s*ScrollBar\.AsNeeded/.test(panelSource),
+  'network retains its stock as-needed scrollbar'
+)
+assert(
   /width:\s*ListView\.view\.width\s*-\s*\(networkScrollBar\.visible\s*\?\s*networkScrollBar\.width\s*:\s*0\)/.test(panelSource),
-  'network rows reserve the visible scrollbar width'
+  'network rows reserve an internal gutter for the visible scrollbar'
 )
 
 assert(/IpcHandler[\s\S]*?function toggleNetwork\(\) \{ root\.toggleNetwork\(\) \}/.test(panelSource), 'network exposes the Wi-Fi radio toggle over IPC')

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -9,6 +9,12 @@ const fs = require('fs')
 const network = requireFromRoot('shell/plugins/panels/network/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
 
+assert(/ScrollBar\.vertical:\s*ScrollBar\s*\{\s*id:\s*networkScrollBar/.test(panelSource), 'network gives its attached scrollbar a stable geometry reference')
+assert(
+  /width:\s*ListView\.view\.width\s*-\s*\(networkScrollBar\.visible\s*\?\s*networkScrollBar\.width\s*:\s*0\)/.test(panelSource),
+  'network rows reserve the visible scrollbar width'
+)
+
 assert(/IpcHandler[\s\S]*?function toggleNetwork\(\) \{ root\.toggleNetwork\(\) \}/.test(panelSource), 'network exposes the Wi-Fi radio toggle over IPC')
 assert(/manageIpc: false/.test(panelSource), 'network owns its IPC handler so it can extend the target methods')
 


### PR DESCRIPTION
Align the keyboard layout label and place the existing Wi-Fi scrollbar beside the rows without changing the panel width.

### Keyboard layout

| Before | After |
| --- | --- |
| ![Keyboard layout before](https://github.com/user-attachments/assets/0e84be68-a1db-4b4f-9911-a4304aea5105) | ![Keyboard layout after](https://github.com/user-attachments/assets/d705b7c8-3bf4-4374-96d9-5e1ce3441378) |

### Wi-Fi list

| Before | After |
| --- | --- |
| ![Wi-Fi scrollbar before](https://github.com/user-attachments/assets/0a478929-3445-490d-b2ae-c34caad441b8) | ![Wi-Fi scrollbar after](https://github.com/user-attachments/assets/9219ce01-1467-4a74-9053-ceeadc2e9e5f) |

Tested with `./test/all` (180 files).
