### PR TITLE
Convert sd-encrypt cmdline during Quattro upgrades

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -517,6 +517,19 @@ normalize_limine_config() {
   fi
 }
 
+normalize_encrypt_hook_param() {
+  local param="$1"
+
+  # Omarchy's mkinitcpio drop-in selects the classic encrypt hook. Convert the
+  # equivalent sd-encrypt selector before carrying a pre-Quattro cmdline into
+  # the new UKIs, or the initramfs ignores it and never creates the mapper.
+  if [[ $param =~ ^rd\.luks\.name=([^=]+)=([^=]+)$ ]]; then
+    printf 'cryptdevice=UUID=%s:%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+  else
+    printf '%s\n' "$param"
+  fi
+}
+
 preserve_kernel_cmdline_root() {
   local default_conf=/etc/default/limine
   local cmdline param key root_source root_stack root_uuid subvol uki
@@ -553,7 +566,11 @@ preserve_kernel_cmdline_root() {
         have_mount_mode=1
         boot_params+=("$param")
         ;;
-      cryptdevice | cryptkey | rd.luks.name | rd.luks.uuid | rd.luks.options | rd.luks.key | rd.luks.crypttab | dm-mod.create)
+      rd.luks.name)
+        have_unlock=1
+        boot_params+=("$(normalize_encrypt_hook_param "$param")")
+        ;;
+      cryptdevice | cryptkey | rd.luks.uuid | rd.luks.options | rd.luks.key | rd.luks.crypttab | dm-mod.create)
         have_unlock=1
         boot_params+=("$param")
         ;;

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -151,6 +151,35 @@ grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
 grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 
+# Quattro replaces the effective mkinitcpio hooks with the classic encrypt
+# hook, which reads cryptdevice= rather than systemd's rd.luks.name=. Exercise
+# the conversion directly so a pre-Quattro sd-encrypt cmdline remains bootable.
+hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+grep -Eq '^HOOKS=\([^)]*(^|[[:space:]])udev([[:space:]]|\))' "$hooks_conf" ||
+  fail "Omarchy 4 initramfs uses the udev hook"
+grep -Eq '^HOOKS=\([^)]*(^|[[:space:]])encrypt([[:space:]]|\))' "$hooks_conf" ||
+  fail "Omarchy 4 initramfs uses the encrypt hook"
+if grep -Eq '^HOOKS=\([^)]*(^|[[:space:]])sd-encrypt([[:space:]]|\))' "$hooks_conf"; then
+  fail "Omarchy 4 initramfs does not use the sd-encrypt hook"
+fi
+
+normalize_logic=$(sed -n '/^normalize_encrypt_hook_param() {$/,/^}$/p' "$upgrade_to_quattro")
+grep -Fq 'normalize_encrypt_hook_param() {' <<<"$normalize_logic" ||
+  fail "the encrypted-root parameter conversion is testable"
+grep -Fq 'boot_params+=("$(normalize_encrypt_hook_param "$param")")' "$upgrade_to_quattro" ||
+  fail "the upgrade applies the encrypted-root parameter conversion"
+eval "$normalize_logic"
+
+luks_uuid=11111111-2222-3333-4444-555555555555
+normalized_param=$(normalize_encrypt_hook_param "rd.luks.name=$luks_uuid=root")
+[[ $normalized_param == "cryptdevice=UUID=$luks_uuid:root" ]] ||
+  fail "Omarchy 4 upgrade converts rd.luks.name for the encrypt hook" "$normalized_param"
+[[ $normalized_param != rd.luks.name=* ]] ||
+  fail "Omarchy 4 upgrade removes the incompatible rd.luks.name selector"
+[[ $(normalize_encrypt_hook_param 'cryptdevice=UUID=abc:root') == "cryptdevice=UUID=abc:root" ]] ||
+  fail "Omarchy 4 upgrade preserves an existing encrypt-hook selector"
+pass "Omarchy 4 upgrade writes encrypted-root parameters for its initramfs hooks"
+
 # The += drop-ins make limine-entry-tool ignore /etc/kernel/cmdline and
 # /proc/cmdline, so only the tool's own merge can say whether root= survives.
 # Queried for the default key, so a kernel-specific pin cannot cover for the


### PR DESCRIPTION
## Problem

Upgrading an existing encrypted installation to Quattro can produce a UKI whose command line contains:

```text
rd.luks.name=<uuid>=root root=/dev/mapper/root
```

The initramfs then never creates `/dev/mapper/root`, and boot fails before mounting the real root filesystem.

## Root cause

`omarchy-upgrade-to-quattro` preserves the running kernel's encryption parameters after the Quattro package transaction. It copied `rd.luks.name=` verbatim from installations that booted with systemd/sd-encrypt.

Quattro's effective `/etc/mkinitcpio.conf.d/omarchy_hooks.conf` instead selects the classic `udev` + `encrypt` hooks. The classic hook reads `cryptdevice=` and ignores `rd.luks.name=`:

```text
mkinitcpio encrypt hook   -> cryptdevice=
mkinitcpio sd-encrypt     -> rd.luks.name=
```

Commit [`23f8418e`](https://github.com/basecamp/omarchy/commit/23f8418ed653dcda044cac1b7899faca924a10a9) introduced that package-owned hook configuration. Commit [`9d5c6e25`](https://github.com/basecamp/omarchy/commit/9d5c6e25e7e97db5dd0152650c81d086c465f6da) later added Quattro command-line preservation but copied `rd.luks.name=` verbatim. The regression comes from the interaction between those two changes.

The migration was therefore preserving a selector for a different initramfs architecture than the one used to rebuild the UKI.

## Fix

When harvesting a pre-Quattro `rd.luks.name=<uuid>=<mapper>` parameter, convert it to the equivalent classic-hook selector:

```text
cryptdevice=UUID=<uuid>:<mapper>
```

Existing `cryptdevice=` parameters remain unchanged. This keeps Quattro's current initramfs architecture and limits the change to the incompatible parameter carried through the upgrade.

## Validation

- `bash -n bin/omarchy-upgrade-to-quattro test/shell.d/upgrade-to-quattro-test.sh`
- `bash test/shell.d/upgrade-to-quattro-test.sh`
- Added regression coverage asserting Quattro uses `udev` + `encrypt`, not `sd-encrypt`, and that `rd.luks.name=<uuid>=root` becomes `cryptdevice=UUID=<uuid>:root`
- `git diff --check`
- Ran `./test/shell`; the changed-area tests passed, but the aggregate suite reports its existing environment prerequisite failure because no separate `omarchy-pkgs` checkout is available for PKGBUILD coverage

## Related issues

Fixes #7222.

Related to #6728. PR #6758 independently documents that Omarchy's classic `encrypt` hook ignores `rd.luks.*`, but does not convert the carried selector.
