### PR TITLE
Refresh monitor brightness state promptly

### DIFF
--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -376,8 +376,9 @@ Panel {
   // Only poll while the panel is open; the bar glyph tracks monitor count via
   // Quickshell.screens, and open-time refresh + Component.onCompleted cover the
   // rest. External brightness changes are reflected whenever the panel is open.
+  // Keep this short so brightness keys update the open slider promptly.
   Timer {
-    interval: 5000
+    interval: 250
     running: root.opened
     repeat: true
     onTriggered: root.refresh()


### PR DESCRIPTION
## What changed

Refresh the open monitor panel brightness state every 250 ms instead of every 5 seconds.

## Why

Brightness keys change the display outside the panel, while the panel previously waited for its 5-second poll before updating the slider.

## Impact

The open brightness slider now reflects keyboard brightness changes promptly. Polling remains limited to while the panel is open.

## Validation

`git diff --check` passed.