### PR TITLE
Label the Claude plan from the profile the CLI refreshes

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -589,8 +589,31 @@ def oauth_login(claude_dir: Path) -> tuple[str, int, str]:
   login = data.get("claudeAiOauth")
   if not isinstance(login, dict):
     return "", 0, ""
-  plan = plan_label(str(login.get("rateLimitTier") or ""), str(login.get("subscriptionType") or ""))
+  plan = plan_label(profile_tier(claude_dir), "")
+  if not plan:
+    plan = plan_label(str(login.get("rateLimitTier") or ""), str(login.get("subscriptionType") or ""))
   return str(login.get("accessToken") or ""), number(login.get("expiresAt")), plan
+
+
+# The credentials carry the tier their token was minted with, and an upgrade
+# does not restamp it: a refresh rewrites the file and keeps the old value, so
+# an account moved to Max 20x keeps reading Max 5x. The CLI's own profile is
+# refreshed against the account, so the tier it states there is asked first.
+def profile_tier(claude_dir: Path) -> str:
+  for path in (claude_dir / ".claude.json", claude_dir.with_name(claude_dir.name + ".json")):
+    try:
+      account = json.loads(path.read_text(encoding="utf-8")).get("oauthAccount")
+    except Exception:
+      continue
+    if not isinstance(account, dict):
+      continue
+    # A seat with no tier of its own is limited by its organization, which is
+    # the shape a personal Max subscription takes.
+    for key in ("userRateLimitTier", "organizationRateLimitTier"):
+      tier = str(account.get(key) or "")
+      if tier:
+        return tier
+  return ""
 
 
 def plan_label(tier: str, subscription: str) -> str:

--- a/test/shell.d/agent-usage-claude-plan-test.sh
+++ b/test/shell.d/agent-usage-claude-plan-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command python3
+
+# oauth_login reads two files that only ever exist side by side, so the plan it
+# settles on is exercised over a planted config directory: credentials for the
+# token, the CLI's profile for the account it belongs to. The profile sits
+# beside the directory by default and inside it when CLAUDE_CONFIG_DIR moved
+# the whole config elsewhere, so the caller says which shape to plant.
+read_plan() {
+  local credentials="$1" profile="$2" where="${3:-beside}"
+  local dir plan
+  dir=$(mktemp -d)
+  printf '%s' "$credentials" >"$dir/.credentials.json"
+  if [[ -n $profile ]]; then
+    if [[ $where == "inside" ]]; then
+      printf '%s' "$profile" >"$dir/.claude.json"
+    else
+      printf '%s' "$profile" >"$dir.json"
+    fi
+  fi
+
+  plan=$(COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" CLAUDE_DIR="$dir" python3 - <<'PY'
+import importlib.machinery, importlib.util, os, pathlib
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+print(collector.oauth_login(pathlib.Path(os.environ["CLAUDE_DIR"]))[2])
+PY
+  )
+
+  rm -rf "$dir" "$dir.json"
+  printf '%s' "$plan"
+}
+
+credentials='{"claudeAiOauth":{"accessToken":"token","expiresAt":1,"subscriptionType":"max","rateLimitTier":"default_claude_max_5x"}}'
+upgraded='{"oauthAccount":{"organizationRateLimitTier":"default_claude_max_20x","userRateLimitTier":null}}'
+
+# The tier in the credentials is the one the token was minted with. An upgraded
+# account keeps it there, so the profile the CLI refreshes decides the label.
+plan=$(read_plan "$credentials" "$upgraded")
+[[ $plan == "Max 20x" ]] ||
+  fail "Claude collector labels the plan from the refreshed profile" "$plan"
+pass "Claude collector labels the plan from the refreshed profile"
+
+# CLAUDE_CONFIG_DIR takes the profile along with the rest of the config.
+plan=$(read_plan "$credentials" "$upgraded" inside)
+[[ $plan == "Max 20x" ]] ||
+  fail "Claude collector finds the profile inside a relocated config directory" "$plan"
+pass "Claude collector finds the profile inside a relocated config directory"
+
+# A seat with a tier of its own is limited by that tier, not by its org's.
+plan=$(read_plan "$credentials" '{"oauthAccount":{"organizationRateLimitTier":"default_claude_max_20x","userRateLimitTier":"default_claude_max_5x"}}')
+[[ $plan == "Max 5x" ]] ||
+  fail "Claude collector prefers the seat's own tier over the organization's" "$plan"
+pass "Claude collector prefers the seat's own tier over the organization's"
+
+# Without a profile — or with one that states no tier, or a tier the label
+# cannot read — the credentials are all there is, and they still answer.
+for profile in '' '{}' '{"oauthAccount":{"organizationRateLimitTier":null}}' '{"oauthAccount":{"organizationRateLimitTier":"default_claude_unknown"}}'; do
+  plan=$(read_plan "$credentials" "$profile")
+  [[ $plan == "Max 5x" ]] ||
+    fail "Claude collector falls back to the credentials when the profile names no readable tier" "$profile -> $plan"
+done
+pass "Claude collector falls back to the credentials when the profile names no readable tier"

--- a/test/shell.d/agent-usage-claude-plan-test.sh
+++ b/test/shell.d/agent-usage-claude-plan-test.sh
@@ -9,10 +9,13 @@ require_command python3
 # token, the CLI's profile for the account it belongs to. The profile sits
 # beside the directory by default and inside it when CLAUDE_CONFIG_DIR moved
 # the whole config elsewhere, so the caller says which shape to plant.
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
 read_plan() {
   local credentials="$1" profile="$2" where="${3:-beside}"
   local dir plan
-  dir=$(mktemp -d)
+  dir=$(mktemp -d "$SANDBOX/config.XXXXXX")
   printf '%s' "$credentials" >"$dir/.credentials.json"
   if [[ -n $profile ]]; then
     if [[ $where == "inside" ]]; then
@@ -34,7 +37,6 @@ print(collector.oauth_login(pathlib.Path(os.environ["CLAUDE_DIR"]))[2])
 PY
   )
 
-  rm -rf "$dir" "$dir.json"
   printf '%s' "$plan"
 }
 


### PR DESCRIPTION
Fixes #7221.

The agents panel labeled a Max 20x account as `MAX 5X`. The meters were right — only the plan was wrong.

`plan_label()` read the tier exclusively from `~/.claude/.credentials.json`, which carries the tier the OAuth token was minted with. A plan change does not restamp it: the file is rewritten on every token refresh and keeps the old `default_claude_max_5x`, so the label never catches up. Limits are enforced against the organization tier, which is why the percentages stayed correct.

Claude Code refreshes the account into its own profile, so this asks that first:

`oauthAccount.userRateLimitTier` → `oauthAccount.organizationRateLimitTier` → the credentials, unchanged, whenever the profile names no tier the label can read.

A seat with a tier of its own outranks its organization's; a seat with none is limited by the org, which is the shape a personal Max subscription takes. The profile lives beside the config directory (`~/.claude.json`) and inside it when `CLAUDE_CONFIG_DIR` moved the config elsewhere, so both are tried.

## Verification

- New `test/shell.d/agent-usage-claude-plan-test.sh` covers the upgrade, the relocated config directory, seat-over-org precedence, and every fallback shape. It fails against the current collector and passes with this change.
- `./test/all` on the branch: the same four files fail on unmodified `quattro` in this environment — three want an `omarchy-pkgs` checkout, and `runtime-smoke-test.sh` hits the duplicate-widget registration already tracked in #7128.
- On the affected machine the collector now reports `tierLabel = Max 20x`.
