### PR TITLE
Restore fuzzy matching for menu commands

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -5,6 +5,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "MenuModel.js" as MenuModel
+import "../../services/MenuSearch.js" as MenuSearch
 
 Item {
   id: root
@@ -308,6 +309,7 @@ Item {
         icon: "",
         appIcon: String(entry.icon || ""),
         appId: appId,
+        acronym: root.appLibrary.entryAcronym(entry),
         label: root.appLibrary.entryName(entry),
         title: "",
         target: "",
@@ -478,26 +480,6 @@ Item {
     return MenuModel.labelFor(entry, root.checkedResults, root.disabledResults)
   }
 
-  function searchableToken(value) {
-    return MenuModel.searchableToken(value)
-  }
-
-  function leafIdFor(id) {
-    return MenuModel.leafIdFor(id)
-  }
-
-  function nameSearchText(entry) {
-    return MenuModel.nameSearchText(entry)
-  }
-
-  function termInSearchWords(term, text) {
-    return MenuModel.termInSearchWords(term, text)
-  }
-
-  function descriptionTextMatches(query, text) {
-    return MenuModel.descriptionTextMatches(query, text)
-  }
-
   // Rows whose `disabled:` evaluated truthy stay listed but dimmed, and the
   // cursor steps over them.
   function isDisabled(entry) {
@@ -508,11 +490,11 @@ Item {
   // list around it is the point. Search is a list of what you can do, so it
   // leaves them out.
   function matchesQuery(entry, query) {
-    return MenuModel.matchesQuery(entry, query, root.isVisible(entry) && !root.isDisabled(entry))
+    return MenuSearch.matchesQuery(entry, query, root.isVisible(entry) && !root.isDisabled(entry))
   }
 
-  function searchScore(entry, query) {
-    return MenuModel.searchScore(root.items, entry, query)
+  function searchRank(entry, query) {
+    return MenuSearch.rank(entry, query)
   }
 
   function displayRow(entry, detail, score, section) {
@@ -629,13 +611,20 @@ Item {
         if (!root.matchesQuery(entry, query)) continue
 
         var detail = root.parentPathFor(entry.id)
-        var row = root.displayRow(entry, detail, root.searchScore(entry, query))
+        var rank = root.searchRank(entry, query)
+        var row = root.displayRow(entry, detail, rank.tier)
+        row.searchRank = rank
         if (entry.parent === active) currentRows.push(row)
         else drilldownRows.push(row)
       }
 
       var searchSort = function(a, b) {
-        if (a.score !== b.score) return a.score - b.score
+        var rankOrder = MenuSearch.compareRanks(a.searchRank, b.searchRank)
+        if (rankOrder !== 0) return rankOrder
+        var depthOrder = root.depthFor(a.itemId) - root.depthFor(b.itemId)
+        if (depthOrder !== 0) return depthOrder
+        var itemOrder = root.item(a.itemId).order - root.item(b.itemId).order
+        if (itemOrder !== 0) return itemOrder
         return a.path.localeCompare(b.path)
       }
 

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -287,81 +287,6 @@ function labelFor(entry, checkedResults, disabledResults) {
   return marked ? entry.label + " ✓" : entry.label
 }
 
-function searchableToken(value) {
-  return String(value || "").replace(/[._-]+/g, " ")
-}
-
-function leafIdFor(id) {
-  var parts = String(id || "").split(".")
-  return parts.length > 0 ? parts[parts.length - 1] : id
-}
-
-function nameSearchText(entry) {
-  if (!entry) return ""
-  var aliases = []
-  var values = Array.isArray(entry.aliases) ? entry.aliases : []
-  for (var i = 0; i < values.length; i++) aliases.push(searchableToken(values[i]))
-  return [entry.label, searchableToken(leafIdFor(entry.id)), aliases.join(" ")].join(" ").toLowerCase()
-}
-
-function termInSearchWords(term, text) {
-  var words = String(text || "").toLowerCase().split(/\s+/)
-  for (var i = 0; i < words.length; i++) {
-    if (words[i] === term) return true
-  }
-  return false
-}
-
-function descriptionTextMatches(query, text) {
-  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
-  for (var i = 0; i < terms.length; i++) {
-    if (terms[i] && !termInSearchWords(terms[i], text)) return false
-  }
-  return true
-}
-
-function matchesQuery(entry, query, visible) {
-  if (!entry || entry.id === "root") return false
-  if (!visible) return false
-
-  var nameText = nameSearchText(entry)
-  var descriptionText = String(entry.description || "").toLowerCase()
-  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
-
-  for (var i = 0; i < terms.length; i++) {
-    if (!terms[i]) continue
-    if (nameText.indexOf(terms[i]) >= 0) continue
-    if (termInSearchWords(terms[i], descriptionText)) continue
-    return false
-  }
-
-  return true
-}
-
-function searchScore(items, entry, query) {
-  var needle = String(query || "").toLowerCase().trim()
-  var label = entry.label.toLowerCase()
-  var nameText = nameSearchText(entry)
-  var descriptionText = String(entry.description || "").toLowerCase()
-  var score = 80
-
-  if (label === needle) score = entry.parent === "root" ? 2 : 0
-  // An installed app whose name contains the query as a whole word ("zen"
-  // for Zen Browser) beats exact-labeled menu entries like Install > Zen.
-  else if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) score = 0
-  else if (label.indexOf(needle) === 0) score = 10
-  else if (label.indexOf(needle) >= 0) score = 30
-  else if (nameText.indexOf(needle) >= 0) score = 40
-  else if (descriptionTextMatches(needle, descriptionText)) score = 60
-
-  if (entry.kind === "menu" || entry.kind === "link") score -= 2
-  // App rows sort after all menu items, so they lose the tiebreak below to an
-  // equal match. Outrank those, but stay inside the tier so better ones win.
-  if (entry.kind === "app") score -= 5
-
-  return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
-}
-
 function displayRow(items, itemOrder, checkedResults, disabledResults, entry, detail, score, section) {
   var target = entry.kind === "link" ? entry.target : entry.id
   return {
@@ -512,13 +437,6 @@ if (typeof module !== "undefined") {
     isVisible: isVisible,
     isDisabled: isDisabled,
     labelFor: labelFor,
-    searchableToken: searchableToken,
-    leafIdFor: leafIdFor,
-    nameSearchText: nameSearchText,
-    termInSearchWords: termInSearchWords,
-    descriptionTextMatches: descriptionTextMatches,
-    matchesQuery: matchesQuery,
-    searchScore: searchScore,
     displayRow: displayRow
   }
 }

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -44,6 +44,10 @@ Item {
     return AppSearch.entrySubtext(entry)
   }
 
+  function entryAcronym(entry) {
+    return AppSearch.entryAcronym(entry)
+  }
+
   function isHiddenEntry(entry) {
     var id = String((entry && entry.id) || "")
     return root.configuredHiddenEntryIds[id] === true || root.desktopHiddenEntryIds[id] === true

--- a/shell/services/MenuSearch.js
+++ b/shell/services/MenuSearch.js
@@ -1,0 +1,202 @@
+// Chunk selection follows fuzzel's match_fzf algorithm.
+// Copyright (c) 2019 Daniel Eklöf, SPDX-License-Identifier: MIT.
+// https://codeberg.org/dnkl/fuzzel/src/branch/master/match.c
+
+function searchableToken(value) {
+  return String(value || "").replace(/[._:/\\-]+/g, " ")
+}
+
+function leafIdFor(id) {
+  var parts = String(id || "").split(".")
+  return parts.length > 0 ? parts[parts.length - 1] : id
+}
+
+function nameSearchFields(entry) {
+  if (!entry) return []
+  var fields = [String(entry.label || ""), searchableToken(leafIdFor(entry.id))]
+  var values = Array.isArray(entry.aliases) ? entry.aliases : []
+  for (var i = 0; i < values.length; i++) fields.push(searchableToken(values[i]))
+  return fields
+}
+
+function nameSearchText(entry) {
+  return nameSearchFields(entry).join(" ").toLowerCase()
+}
+
+function termInWords(term, text) {
+  var words = String(text || "").toLowerCase().split(/\s+/)
+  for (var i = 0; i < words.length; i++) {
+    if (words[i] === term) return true
+  }
+  return false
+}
+
+function descriptionMatches(query, text) {
+  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  for (var i = 0; i < terms.length; i++) {
+    if (terms[i] && !termInWords(terms[i], text)) return false
+  }
+  return true
+}
+
+function fzfMatch(text, pattern) {
+  var haystack = String(text || "").toLowerCase()
+  var needle = String(pattern || "").toLowerCase()
+  if (!needle) return null
+
+  var chunks = []
+  var needleStart = 0
+  var searchStart = 0
+
+  while (needleStart < needle.length) {
+    var bestStart = -1
+    var bestLength = 0
+
+    for (var start = searchStart; start < haystack.length; start++) {
+      var length = 0
+      while (needleStart + length < needle.length &&
+             start + length < haystack.length &&
+             needle[needleStart + length] === haystack[start + length]) {
+        length += 1
+      }
+
+      if (length > bestLength) {
+        bestStart = start
+        bestLength = length
+      }
+      if (needleStart + length === needle.length) break
+    }
+
+    if (bestLength === 0) return null
+    chunks.push({ start: bestStart, length: bestLength })
+    needleStart += bestLength
+    searchStart = bestStart + bestLength
+  }
+
+  var longestChunk = 0
+  for (var i = 0; i < chunks.length; i++) longestChunk = Math.max(longestChunk, chunks[i].length)
+  var firstStart = chunks[0].start
+
+  return {
+    longestChunk: longestChunk,
+    wordBoundaries: firstStart === 0 || /\s/.test(haystack[firstStart - 1]) ? 1 : 0,
+    chunkCount: chunks.length,
+    firstStart: firstStart,
+    textLength: haystack.length
+  }
+}
+
+function compareFuzzy(a, b) {
+  if (a.longestChunk !== b.longestChunk) return b.longestChunk - a.longestChunk
+  if (a.wordBoundaries !== b.wordBoundaries) return b.wordBoundaries - a.wordBoundaries
+  if (a.chunkCount !== b.chunkCount) return a.chunkCount - b.chunkCount
+  if (a.firstStart !== b.firstStart) return a.firstStart - b.firstStart
+  return a.textLength - b.textLength
+}
+
+function bestFieldMatch(fields, term) {
+  var best = null
+  for (var i = 0; i < fields.length; i++) {
+    var match = fzfMatch(fields[i], term)
+    if (match && (!best || compareFuzzy(match, best) < 0)) best = match
+  }
+  return best
+}
+
+function fzfFieldsRank(query, fields) {
+  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var rank = { longestChunk: 0, wordBoundaries: 0, chunkCount: 0, firstStart: 0, textLength: 0 }
+
+  for (var i = 0; i < terms.length; i++) {
+    if (!terms[i]) continue
+    var match = bestFieldMatch(fields, terms[i])
+    if (!match) return null
+    rank.longestChunk = Math.max(rank.longestChunk, match.longestChunk)
+    rank.wordBoundaries += match.wordBoundaries
+    rank.chunkCount += match.chunkCount
+    rank.firstStart += match.firstStart
+    rank.textLength += match.textLength
+  }
+
+  return rank
+}
+
+function acronym(entry) {
+  return String((entry && entry.acronym) || "").toLowerCase()
+}
+
+function matchesQuery(entry, query, visible) {
+  if (!entry || entry.id === "root" || !visible) return false
+
+  var nameText = nameSearchText(entry)
+  var nameFields = nameSearchFields(entry)
+  var descriptionText = String(entry.description || "").toLowerCase()
+  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var entryAcronym = entry.kind === "app" ? acronym(entry) : ""
+
+  for (var i = 0; i < terms.length; i++) {
+    var term = terms[i]
+    if (!term) continue
+    if (nameText.indexOf(term) >= 0) continue
+    if (termInWords(term, descriptionText)) continue
+    if (entry.kind === "app") {
+      if (term.length <= 5 && entryAcronym.indexOf(term) >= 0) continue
+    } else if (bestFieldMatch(nameFields, term)) {
+      continue
+    }
+    return false
+  }
+
+  return true
+}
+
+function rank(entry, query) {
+  var needle = String(query || "").toLowerCase().trim()
+  var label = String(entry.label || "").toLowerCase()
+  var nameText = nameSearchText(entry)
+  var nameFields = nameSearchFields(entry)
+  var descriptionText = String(entry.description || "").toLowerCase()
+  var tier = 80
+  var fuzzy = null
+
+  if (label === needle) tier = entry.parent === "root" ? 2 : 0
+  else if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) tier = 0
+  else if (label.indexOf(needle) === 0) tier = 10
+  else if (label.indexOf(needle) >= 0) tier = 30
+  else if (nameText.indexOf(needle) >= 0) tier = 40
+  else if (descriptionMatches(needle, descriptionText)) tier = 60
+  else if (entry.kind === "app") {
+    if (needle.length <= 5 && acronym(entry).indexOf(needle) >= 0) tier = 75
+  } else {
+    fuzzy = fzfFieldsRank(needle, nameFields)
+    if (fuzzy) tier = 70
+  }
+
+  var kindOrder = 0
+  if (entry.kind === "menu" || entry.kind === "link") kindOrder = -2
+  if (entry.kind === "app") kindOrder = -5
+
+  return { tier: tier, fuzzy: fuzzy, kindOrder: kindOrder }
+}
+
+function compareRanks(a, b) {
+  if (a.tier !== b.tier) return a.tier - b.tier
+  if (a.fuzzy && b.fuzzy) {
+    var fuzzyOrder = compareFuzzy(a.fuzzy, b.fuzzy)
+    if (fuzzyOrder !== 0) return fuzzyOrder
+  }
+  return a.kindOrder - b.kindOrder
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    searchableToken: searchableToken,
+    leafIdFor: leafIdFor,
+    nameSearchFields: nameSearchFields,
+    nameSearchText: nameSearchText,
+    fzfMatch: fzfMatch,
+    matchesQuery: matchesQuery,
+    rank: rank,
+    compareRanks: compareRanks
+  }
+}

--- a/test/shell.d/menu-search-test.sh
+++ b/test/shell.d/menu-search-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const search = requireFromRoot('shell/services/MenuSearch.js')
+
+const menuEntry = (id, label) => ({ id, parent: 'system', kind: 'action', label, description: '', aliases: [] })
+const suspend = menuEntry('system.suspend', 'Suspend')
+const screensaver = menuEntry('system.screensaver', 'Screensaver')
+const shutdown = menuEntry('system.shutdown', 'Shutdown')
+
+assert(search.matchesQuery(suspend, 'ss', true), 'menu fzf chunks match separated letters')
+assert(!search.matchesQuery(shutdown, 'ss', true), 'menu fuzzy matching never crosses from a label into its id')
+assertEqual(search.rank(suspend, 'ss').tier, 70, 'menu fuzzy matches stay in their own tier')
+assert(
+  search.compareRanks(search.rank(suspend, 'ss'), search.rank(screensaver, 'ss')) < 0,
+  'menu fzf rank prefers the shorter equivalent chunk match'
+)
+assert(
+  search.compareRanks(
+    search.rank(menuEntry('tools.one', 'Suspend'), 'sud'),
+    search.rank({ ...menuEntry('tools.two', 'Sound'), kind: 'menu' }, 'sud')
+  ) < 0,
+  'menu ranks consecutive chunks before applying the menu-kind tie-breaker'
+)
+
+const boundary = menuEntry('tools.one', 'System Xray')
+const embedded = menuEntry('tools.two', 'Asystem Xray')
+assert(
+  search.compareRanks(search.rank(boundary, 'sx'), search.rank(embedded, 'sx')) < 0,
+  'menu fzf rank prefers matches beginning at a word boundary'
+)
+
+const app = { id: 'apps.google-contacts', parent: 'apps', kind: 'app', label: 'Google Contacts', description: '', aliases: [], acronym: 'gc' }
+assert(search.matchesQuery(app, 'gc', true), 'app rows retain short acronym matching')
+assert(!search.matchesQuery({ ...app, label: 'Calculator', id: 'apps.calculator', acronym: 'c' }, 'cltr', true), 'app rows reject loose subsequences')
+JS

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -7,6 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const search = requireFromRoot('shell/services/MenuSearch.js')
 const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
 const defaultMenuJsonc = fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8')
 
@@ -93,16 +94,20 @@ assert(
   'menu display rows carry their disabled state'
 )
 assert(
-  /function matchesQuery\(entry, query\) \{\s*\n\s*return MenuModel\.matchesQuery\(entry, query, root\.isVisible\(entry\) && !root\.isDisabled\(entry\)\)/.test(menuQml),
+  /function matchesQuery\(entry, query\) \{\s*\n\s*return MenuSearch\.matchesQuery\(entry, query, root\.isVisible\(entry\) && !root\.isDisabled\(entry\)\)/.test(menuQml),
   'menu search skips disabled rows, which belong to the submenu they sit in rather than a list of what you can do'
+)
+assert(
+  /var rankOrder = MenuSearch\.compareRanks\(a\.searchRank, b\.searchRank\)[\s\S]*var depthOrder = root\.depthFor[\s\S]*var itemOrder = root\.item/.test(menuQml),
+  'menu resolves fuzzy rank before applying depth and declaration order tie-breaks'
 )
 
 const entry = merged.items['style.theme']
-assert(menu.matchesQuery(entry, 'theme', true), 'menu matches labels and aliases')
-assert(menu.matchesQuery(entry, 'colors', true), 'menu matches aliases')
-assert(!menu.matchesQuery(entry, 'missing', true), 'menu rejects missing terms')
-assert(!menu.matchesQuery(entry, 'theme', false), 'menu hides invisible matches')
-assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
+assert(search.matchesQuery(entry, 'theme', true), 'menu matches labels and aliases')
+assert(search.matchesQuery(entry, 'colors', true), 'menu matches aliases')
+assert(!search.matchesQuery(entry, 'missing', true), 'menu rejects missing terms')
+assert(!search.matchesQuery(entry, 'theme', false), 'menu hides invisible matches')
+assert(search.compareRanks(search.rank(entry, 'theme'), search.rank(entry, 'appearance')) < 0, 'menu scores name matches above description matches')
 
 assertDeepEqual(
   menu.displayRow(merged.items, merged.itemOrder, {}, {}, entry, 'Style', 12, 'search'),
@@ -138,21 +143,22 @@ const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
   { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] },
   { id: 'apps.zen', parent: 'apps', kind: 'app', label: 'Zen Browser', description: '', aliases: [] }
 ])
-const rankScore = (id, query) => menu.searchScore(ranked.items, ranked.items[id], query)
+const rankScore = (id, query) => search.rank(ranked.items[id], query)
+const ranksBefore = (left, right, query) => search.compareRanks(rankScore(left, query), rankScore(right, query)) < 0
 assert(
   ['install.browser.brave', 'remove.browser.brave', 'setup.default.browser.brave'].every(
-    id => rankScore('apps.brave', 'brave') < rankScore(id, 'brave')
+    id => ranksBefore('apps.brave', id, 'brave')
   ),
   'menu ranks an installed app above menu entries matching the query equally well'
 )
 assert(
   ['install.browser.zen', 'remove.browser.zen', 'setup.default.browser.zen'].every(
-    id => rankScore('apps.zen', 'zen') < rankScore(id, 'zen')
+    id => ranksBefore('apps.zen', id, 'zen')
   ),
   'menu ranks an app matching the query as a whole word above exact-labeled menu entries'
 )
 assert(
-  rankScore('style.font', 'font') < rankScore('apps.fontforge', 'font'),
+  ranksBefore('style.font', 'apps.fontforge', 'font'),
   'menu keeps a better-matching menu entry above a weaker app match'
 )
 
@@ -168,7 +174,7 @@ assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, 'power-menu'), 'sy
 assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, 'power_menu'), 'system', 'menu normalizes underscores in routes')
 assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, ''), 'root', 'menu routes empty input to root')
 assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, 'no-such-route'), 'no-such-route', 'menu falls through to the literal input')
-assert(menu.matchesQuery(routed.items['apps.htop'], 'system', true), 'menu still finds an app by its keywords in search')
+assert(search.matchesQuery(routed.items['apps.htop'], 'system', true), 'menu still finds an app by its keywords in search')
 assert(
   /function resolveRoute\(input\) \{\s*\n\s*return MenuModel\.resolveRoute\(root\.items, root\.itemOrder, input\)\s*\n\s*\}/.test(menuQml),
   'menu delegates route resolution to the shared model'


### PR DESCRIPTION
## Reason
- Quattro migrated the menu from Walker to native Quickshell search.
- This migration dropped fuzzy matching.
- For example, ss no longer matched Suspend.

## What This PR Solves
- Restores abbreviated fuzzy matching for menu commands.
- Keeps exact and substring matches prioritized.
- Does not reintroduce Walker or Elephant.
- Preserves existing app substring/acronym search.
- Prevents matches from crossing label, ID, and alias boundaries.