### PR TITLE
Reap plugin watcher on shell exit

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -24,12 +24,19 @@ QtObject {
   property var installedPlugins: ({})
   property int registryRevision: 0
   property bool scanning: false
+  property bool shuttingDown: false
   property string lastEnableError: ""
 
   signal pluginsChanged()
   signal scanFinished()
   signal pluginLoadFailed(string id, string error)
   signal localPluginChanged(string id)
+
+  Component.onDestruction: {
+    shuttingDown = true
+    localPluginWatcherRestart.stop()
+    localPluginWatcher.running = false
+  }
 
   // ---------------------------------------------------------------- helpers
 
@@ -628,6 +635,7 @@ QtObject {
 
   property Process initProcess: Process {
     onExited: {
+      if (registry.shuttingDown) return
       localPluginWatcher.running = true
       registry.rescan()
     }
@@ -651,12 +659,12 @@ QtObject {
         if (pluginId) registry.localPluginChanged(pluginId)
       }
     }
-    onExited: localPluginWatcherRestart.restart()
+    onExited: if (!registry.shuttingDown) localPluginWatcherRestart.restart()
   }
 
   property Timer localPluginWatcherRestart: Timer {
     interval: 1000
-    onTriggered: localPluginWatcher.running = true
+    onTriggered: if (!registry.shuttingDown) localPluginWatcher.running = true
   }
 
   function rescan() {

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -362,3 +362,24 @@ jq -e 'all(.bar.layout.right[]; (.id // .) != "omarchy.keyboard-layout")' \
   <<<"$(shell_ipc shell listShellConfig)" >/dev/null ||
   fail_with_log "bar put added a second copy of a widget already on the bar"
 pass "bar put leaves a widget already on the bar alone"
+
+watcher_pid=""
+for _ in {1..80}; do
+  watcher_pid=$(pgrep -o -P "$QS_PID" -x inotifywait || true)
+  [[ -n $watcher_pid ]] && break
+  sleep 0.1
+done
+[[ -n $watcher_pid ]] || fail_with_log "plugin watcher did not start under the shell"
+
+kill "$QS_PID" 2>/dev/null || fail_with_log "test shell exited before watcher teardown"
+wait "$QS_PID" 2>/dev/null || true
+QS_PID=""
+
+for _ in {1..80}; do
+  kill -0 "$watcher_pid" 2>/dev/null || break
+  sleep 0.1
+done
+if kill -0 "$watcher_pid" 2>/dev/null; then
+  fail_with_log "plugin watcher did not exit with the shell"
+fi
+pass "plugin watcher exits with the shell"


### PR DESCRIPTION
The plugin registry starts a long-lived `inotifywait`, but teardown does not explicitly stop it and its exit path schedules a restart. Reloaded shells can therefore leave orphaned watchers behind until the user exhausts the inotify instance limit.

Mark the registry as shutting down, stop the restart timer, terminate the watcher through Quickshell's managed `running` property, and gate every callback that could start it again. Normal unexpected-exit recovery stays unchanged.

The runtime smoke test now captures the watcher PID, tears down the shell, and proves the watcher exits with it.

Fixes #7150.
Fixes #7124.

Tested with:
- `bash test/shell.d/launch-shell-test.sh`
- `bash test/shell.d/plugin-registry-contract-test.sh` (skipped without Wayland)
- `bash test/shell.d/runtime-smoke-test.sh` (skipped without Wayland)
- `./bin/omarchy commands --check`