### PR TITLE
Dispatch shell commands without a login shell

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -50,8 +50,14 @@ QtObject {
     return "'" + String(value || "").replace(/'/g, "'\\''") + "'"
   }
 
+  // A non-login shell: the session already carries the environment a login
+  // shell would build. uwsm exports it before omarchy-shell starts, so `-l`
+  // re-sources /etc/profile and the user's profile on every dispatch and
+  // arrives at the same PATH. That is 70ms or more per click, and unbounded:
+  // any package may drop a script into /etc/profile.d that the shell then
+  // pays for on every interaction.
   function execDetached(command) {
-    Quickshell.execDetached(["bash", "-lc", command])
+    Quickshell.execDetached(["bash", "-c", command])
   }
 
   function isPlainObject(value) {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -344,7 +344,7 @@ Item {
     providerProc.providerKey = entry.provider
     providerProc.revision = root.providerRevision
     providerProc.collected = ""
-    providerProc.command = ["bash", "-lc", spec.script]
+    providerProc.command = ["bash", "-c", spec.script]
     providerProc.running = true
   }
 
@@ -1014,7 +1014,7 @@ Item {
       return
     }
     guardProc.collected = ""
-    guardProc.command = ["bash", "-lc", script]
+    guardProc.command = ["bash", "-c", script]
     guardProc.running = true
   }
 


### PR DESCRIPTION
Every menu action, bar click, menu guard batch, and menu provider runs its command through `bash -lc`. The `-l` re-sources `/etc/profile` and the user's profile on each one, and arrives at an environment the shell already has: uwsm exports the session environment before `omarchy-shell` starts.

Refs #7093, which reports the symptom for workspace clicks. This changes the shared dispatch path rather than any one call site.

### Measurements

Omarchy 4.0.0-1, best of five runs:

| | |
|---|---|
| `bash -c true` | **1ms** |
| `bash -lc true` | **73ms** |
| `source /etc/profile` | 69ms |

The cost is also unbounded, because any package may add to `/etc/profile.d`. On this machine one line installed by `vapoursynth` shells out to a Python program and accounts for 69 of those 73ms:

```
/etc/profile.d/vapoursynth.sh:  export VSSCRIPT_PATH=$(vapoursynth get-vsscript)
```

Under load the same `bash -lc true` reached 310ms.

### Why the login shell is not buying anything

A clean login shell's `PATH` here is a strict subset of the one `omarchy-shell` already runs with:

```
$ env -i HOME=$HOME USER=$USER bash -lc 'echo $PATH'   # vs the shell's own environ
< /usr/share/omarchy/bin        # present in the shell, absent from the clean login shell
```

`~/.bashrc` returns early for non-interactive shells, so functions and aliases were never available to dispatched commands either way.

### What changes

`Util.execDetached`, the menu's guard batch, and the menu's provider scripts. The guard batch is the sharpest case: it runs on every menu open, before any row can be drawn.

I left `Bar.qml`'s user-supplied `exec` for custom widgets on `-lc`, since someone writing their own command there may reasonably expect their own profile.

### The one behavioural difference

A profile edit made mid-session stops applying to dispatched commands until the next login. If that matters, the alternative is to snapshot the login environment once at shell start and reuse it — same saving, and edits still apply after a shell restart. Happy to rework it that way.

### Testing

I ran the patched shell tree (`quickshell -n -p <copy>`) alongside the installed one: it starts, the bar and menu draw, and menu rows and guards behave. The only log noise was the expected polkit conflict from running two instances. I have not run it as the session shell across a reboot.
