### PR TITLE
Prepend the Omarchy bin dir in dev-link mode only

### DIFF
--- a/default/hypr/envs.lua
+++ b/default/hypr/envs.lua
@@ -27,13 +27,24 @@ hl.env("XCOMPOSEFILE", paths.home .. "/.XCompose")
 -- hyprctl setenv doesn't reach keybind dispatcher env; use hl.env.
 hl.env("OMARCHY_PATH", paths.omarchy_path)
 
-local bin_dir = paths.omarchy_path .. "/bin"
-local kept = {}
-for entry in (os.getenv("PATH") or "/usr/local/bin:/usr/bin"):gmatch("[^:]+") do
-  if entry ~= bin_dir then table.insert(kept, entry) end
+-- Prepend only in dev-link mode, matching default/bash/env-bootstrap. On a
+-- production install /usr/share/omarchy/bin holds symlinks for the `omarchy`
+-- package's binaries alone, so putting it first shadows the complete /usr/bin
+-- with an incomplete copy -- and the dispatcher scans its own directory, so
+-- every omarchy-* command another package ships to /usr/bin (omarchy-debug,
+-- omarchy-debug-idle, omarchy-upload-log from omarchy-settings;
+-- omarchy-nvim-setup, omarchy-nvim-refresh from omarchy-nvim) loses its route
+-- for the whole graphical session.
+local omarchy_path = paths.omarchy_path:gsub("/+$", "")
+if omarchy_path ~= "/usr/share/omarchy" then
+  local bin_dir = omarchy_path .. "/bin"
+  local kept = {}
+  for entry in (os.getenv("PATH") or "/usr/local/bin:/usr/bin"):gmatch("[^:]+") do
+    if entry ~= bin_dir then table.insert(kept, entry) end
+  end
+  table.insert(kept, 1, bin_dir)
+  hl.env("PATH", table.concat(kept, ":"))
 end
-table.insert(kept, 1, bin_dir)
-hl.env("PATH", table.concat(kept, ":"))
 
 -- Hardware-specific environment.
 require("default.hypr.nvidia")


### PR DESCRIPTION
`default/hypr/envs.lua` puts `$OMARCHY_PATH/bin` first on `PATH` for the whole graphical session unconditionally, and `default/hypr/autostart.lua` imports that into the systemd user manager, so every terminal in the session inherits it. On a production install that directory is `/usr/share/omarchy/bin`, a symlink farm holding only the binaries the `omarchy` package itself ships — so it shadows a complete `/usr/bin` with an incomplete copy. Since `bin/omarchy` resolves subcommands by globbing its own directory with no `PATH` fallback, every `omarchy-*` command another package installs to `/usr/bin` loses its route inside the session while still working from a login shell.

`default/bash/env-bootstrap` already guards the identical prepend with `[ "$OMARCHY_PATH" != /usr/share/omarchy ]`, and `docs/file-layout.md` states that as the intended policy. `envs.lua` is the half that never got the guard. This adds it, and normalizes a trailing slash so a hand-edited path cannot slip past the comparison.

The reported symptom is `omarchy debug`, but the blast radius is wider than the five commands named in the issues: it is every `omarchy-*` route shipped by a package other than `omarchy`. Today that is `omarchy-debug`, `omarchy-debug-idle` and `omarchy-upload-log` from `omarchy-settings`, `omarchy-nvim-setup` and `omarchy-nvim-refresh` from `omarchy-nvim`, plus four from `omarchy-emacs` and one each from `omarchy-fish` and `omarchy-zsh` — eleven routes, growing with every optional package that follows the same pattern.

Fixing it here rather than by adding mirror symlinks keeps the invariant in one place: the alternative is editing six PKGBUILDs to drop files into a directory another package owns, and requiring every future package to remember. Dev-link installs are unaffected — `omarchy-dev-link` writes a canonicalized path that is not `/usr/share/omarchy`, so the prepend still fires there.

Worth noting there is no test harness for `envs.lua`; `test/shell.d/dev-env-path-test.sh` covers the `env-bootstrap` side only and is untouched here.

Fixes #6977