### PR TITLE
Fix invisible VS Code list hover state

### DIFF
--- a/default/themed/vscode-theme.json.tpl
+++ b/default/themed/vscode-theme.json.tpl
@@ -118,7 +118,7 @@
         "list.focusForeground": "{{ foreground }}",
         "list.focusOutline": "{{ accent }}60",
         "list.highlightForeground": "{{ accent }}",
-        "list.hoverBackground": "{{ background }}",
+        "list.hoverBackground": "{{ accent }}20",
         "list.hoverForeground": "{{ foreground }}",
         "list.inactiveSelectionBackground": "{{ muted }}40",
         "list.inactiveSelectionForeground": "{{ foreground }}",


### PR DESCRIPTION
## Bug

The VS Code list hover background currently uses the same color as the list background. This makes the hover state invisible, so it is impossible to visually identify which list item is being hovered.

## Fix

Use the theme accent color at 20% opacity for `list.hoverBackground`, providing a subtle but visible hover indicator.

before:
<img width="281" height="164" alt="pi-clipboard-6d29ae3e-59b2-4c94-bec0-daa0f2ab1f0d" src="https://github.com/user-attachments/assets/bcd14d4b-4dea-479c-b6f0-caf9a86b17f3" />

after:
<img width="285" height="161" alt="pi-clipboard-388249be-98fa-487c-a159-a082a21ce1c8" src="https://github.com/user-attachments/assets/da515253-84ef-4c2d-90ad-214a459f0657" />

