### PR TITLE
Inset BorderSurface strokes a device pixel to survive clip edges

### DIFF
--- a/shell/Ui/BorderSurface.qml
+++ b/shell/Ui/BorderSurface.qml
@@ -1,9 +1,13 @@
 import QtQuick
+import QtQuick.Window
 import qs.Commons
 
-// Rectangle-compatible surface with Omarchy border specs. Uses native
-// Rectangle.border for cheap flat/uniform borders and BorderOverlay for
-// gradients or per-side widths.
+// Rectangle-compatible surface with Omarchy border specs. Flat/uniform
+// borders draw with a cheap nested Rectangle stroke and gradients or
+// per-side widths with BorderOverlay. Both are inset a device pixel so
+// strokes flush against an ancestor's clip edge survive fractionally
+// scaled outputs; setting border.* on this item directly draws an
+// extra un-inset stroke alongside the spec-driven one.
 Rectangle {
   id: root
 
@@ -18,22 +22,35 @@ Rectangle {
   readonly property real borderRight: Border.right(borderSpec)
   readonly property real borderBottom: Border.bottom(borderSpec)
   readonly property real borderLeft: Border.left(borderSpec)
-  readonly property real contentTopInset: borderTop + topPadding
-  readonly property real contentRightInset: borderRight + rightPadding
-  readonly property real contentBottomInset: borderBottom + bottomPadding
-  readonly property real contentLeftInset: borderLeft + leftPadding
+  readonly property real contentTopInset: borderTop + topPadding + contentStrokeInset
+  readonly property real contentRightInset: borderRight + rightPadding + contentStrokeInset
+  readonly property real contentBottomInset: borderBottom + bottomPadding + contentStrokeInset
+  readonly property real contentLeftInset: borderLeft + leftPadding + contentStrokeInset
   readonly property bool usesOverlayBorder: Border.needsOverlay(borderSpec)
+  readonly property bool usesNativeBorder: Border.canUseNative(borderSpec)
 
-  border.color: Border.canUseNative(borderSpec) ? Border.color(borderSpec) : "transparent"
-  border.width: Border.canUseNative(borderSpec) ? Border.uniformWidth(borderSpec) : 0
+  readonly property real strokeInset: 1 / (Screen.devicePixelRatio || 1)
+  readonly property real insetRadius: Math.max(0, radius - strokeInset)
+  readonly property real contentStrokeInset: usesNativeBorder || usesOverlayBorder ? strokeInset : 0
+
+  Rectangle {
+    anchors.fill: parent
+    anchors.margins: root.strokeInset
+    radius: root.insetRadius
+    color: "transparent"
+    visible: root.usesNativeBorder
+    border.color: Border.color(root.borderSpec)
+    border.width: Border.uniformWidth(root.borderSpec)
+  }
 
   Loader {
     anchors.fill: parent
+    anchors.margins: root.strokeInset
     active: root.usesOverlayBorder
 
     sourceComponent: BorderOverlay {
       anchors.fill: parent
-      radius: root.radius
+      radius: root.insetRadius
       borderSpec: root.borderSpec
     }
   }


### PR DESCRIPTION
I was extending the monitor panel to support multi-monitor arrangement:

<img width="721" height="1035" alt="screenshot-2026-08-17_10-08-01" src="https://github.com/user-attachments/assets/9cec460e-cb76-44bf-900f-4d416f2cd617" />

Then I noticed that I have introduced a scroll in the panel and the left edges of the controls have been cut off with a single pixel:

<img width="620" height="372" alt="screenshot-2026-08-16_17-36-41" src="https://github.com/user-attachments/assets/eeeefe5f-7a16-43b7-8660-43f37f99520a" />
<img width="587" height="131" alt="screenshot-2026-08-16_13-24-18" src="https://github.com/user-attachments/assets/0b56f994-2c7a-4537-8106-db94dd318bdd" />

At first I fixed it at my component-level but soon I realized this is a more general edge case. When a stroke flush against an ancestor's clip edge — like a full-width CursorSurface row or the first scale pill at x=0 inside a panel ScrollView — disappears entirely on fractionally scaled outputs, where the shell renders at the ceiled integer scale and the compositor downscales. Drawing every stroke one device pixel inside the surface restores it at full strength, and is imperceptible where the bug cannot occur.

If you think that this is not the right place to fix this, by all means, ignore this change.

---

As an aside, do you think the native monitors panel can benefit by monitor arrangements? I've quickly built it it for myself and it feels like the better place to have it with the quickshell utilities, rather than using TUIs like hyprmon.


https://github.com/user-attachments/assets/70ab7fdd-d68e-40a6-9916-31d8d841e5ff


Here is my initial config, which is a fork of the builtin monitor panel: https://github.com/gsamokovarov/gazarchy/tree/main/.config/omarchy/plugins/genadi.monitor.