### PR TITLE
Switch to the mise-bin package

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -78,7 +78,7 @@ lua51
 luarocks
 man-db
 mariadb-libs
-mise
+mise-bin
 moonlight-qt
 mpv
 mpv-mpris

--- a/migrations/1786952219.sh
+++ b/migrations/1786952219.sh
@@ -1,0 +1,17 @@
+echo "Switch mise to the mise-bin package from the Omarchy repo"
+
+# mise-bin carries mise's own release artifacts -- PGO+BOLT-optimized on x86_64,
+# glibc-native on both arches -- and takes over from Arch's mise, which it both
+# provides and conflicts with.
+#
+# The swap has to happen in one transaction. Removing mise first breaks
+# omarchy-zsh and omarchy-fish, which depend on it; the provides is what keeps
+# them satisfied when mise-bin lands in the same transaction that drops mise.
+#
+# omarchy-pkg-add cannot do that swap: pacman answers its own conflict question
+# with No under --noconfirm and fails the whole transaction ("unresolvable
+# package conflicts detected"). --ask=4 is that one question, answered yes.
+
+omarchy-pkg-missing mise-bin || exit 0
+
+sudo pacman -S --noconfirm --ask=4 mise-bin

--- a/migrations/1786952219.sh
+++ b/migrations/1786952219.sh
@@ -12,6 +12,6 @@ echo "Switch mise to the mise-bin package from the Omarchy repo"
 # with No under --noconfirm and fails the whole transaction ("unresolvable
 # package conflicts detected"). --ask=4 is that one question, answered yes.
 
-omarchy-pkg-missing mise-bin || exit 0
-
-sudo pacman -S --noconfirm --ask=4 mise-bin
+if omarchy-pkg-missing mise-bin; then
+  sudo pacman -S --noconfirm --ask=4 mise-bin
+fi


### PR DESCRIPTION
Switches Omarchy from Arch's `mise` to [`mise-bin`](https://github.com/omacom-io/omarchy-pkgs/pull/156), which ships mise's own release artifacts from the Omarchy repo — PGO+BOLT-optimized on x86_64, glibc-native on both arches — and tracks `jdx/mise` releases directly.

Two parts:

- `install/omarchy-base.packages` names `mise-bin`, so fresh installs get it.
- A migration swaps it on existing installs.

## Why the migration isn't just `omarchy-pkg-add mise-bin`

`mise-bin` both provides and conflicts with `mise`, and pacman answers its own conflict question with **No** under `--noconfirm` — the same behavior `omarchy-update-system-pkgs-when-conflicted` already documents. I verified it rather than assuming:

```
:: pipewire-jack-1:1.6.8-1 and jack2-1.9.22-2 are in conflict (jack). Remove jack2? [y/N]
error: unresolvable package conflicts detected
```

So `omarchy-pkg-add mise-bin` would fail on every machine that has `mise`. `--ask=4` answers exactly that question with yes.

Dropping `mise` first isn't an option either: `omarchy-zsh` and `omarchy-fish` both declare `depends=('mise')`, so `pacman -Rns mise` would refuse. Doing the swap in one transaction keeps them satisfied through `mise-bin`'s `provides`, which I confirmed (`pacman -T jack` comes back clean after the equivalent swap).

## Verification

Built the real `mise-bin` PKGBUILD in an `archlinux:base-devel` container, served it as a local repo, installed Arch's `mise` first, then ran the migration's exact command:

```
--- install Arch's mise (the starting state on existing machines)
mise 2026.8.3-1
--- the migration's command: pacman -S --noconfirm --ask=4 mise-bin
:: mise-bin-2026.8.6-1 and mise-2026.8.3-1 are in conflict. Remove mise? [y/N]
removing mise...
installing mise-bin...
--- after:
mise-bin 2026.8.6-1
mise command still works: 2026.8.6 linux-x64 (2026-08-14)
self-update marker: present
--- rerun is a no-op (idempotency guard)
```

`./test/all` passes (180 test files).

Nothing else in the tree needed changing: every other `mise` reference is the command, not the package name, and `omarchy-zsh`/`omarchy-fish` keep their `depends=('mise')` because `mise-bin` provides it.

🤖 Generated by Opus 5 in [Claude Code](https://claude.com/claude-code).
