### PR TITLE
Make weather and clock panel anchoring configurable

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -171,9 +171,9 @@ Rules:
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
 8. `version: 1` is required.
 9. `omarchy.weather` and `omarchy.clock` accept an optional `centerOnBar`
-   boolean. It defaults to `true` (panel centered on screen, matching the
-   stock look); set it to `false` to anchor the panel under its bar icon
-   instead:
+   boolean. It defaults to `true`: the popup stays centered on screen
+   instead of following its bar icon. Set it to `false` to anchor the
+   popup under the bar icon:
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -170,6 +170,10 @@ Rules:
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
 8. `version: 1` is required.
+9. `omarchy.weather` and `omarchy.clock` accept an optional `centerOnBar`
+   boolean. It defaults to `true` (panel centered on screen, matching the
+   stock look); set it to `false` to anchor the panel under its bar icon
+   instead:
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -21,6 +21,8 @@ Panel {
   manageIpc: false
 
   property var anchorItem: null
+  // Inline shell.json settings (see docs/omarchy-shell.md).
+  property var settings: ({})
 
   // The bar tracks the widget mounted in its slot — BarWidget.qml — not this
   // nested panel. Everything the bar identifies a panel by has to be that
@@ -239,7 +241,9 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    centerOnBar: true
+    // Centered by default; shell.json can set "centerOnBar": false to
+    // anchor the panel under its bar icon instead.
+    centerOnBar: root.settings.centerOnBar !== false
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(560))
     contentHeight: panel.fittedContentHeight(calendarColumn.implicitHeight)

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -12,6 +12,8 @@ Panel {
   manageIpc: false
 
   property var anchorItem: null
+  // Inline shell.json settings (see docs/omarchy-shell.md).
+  property var settings: ({})
   property bool openedFromHotkey: false
 
   // The bar tracks the widget mounted in its slot — BarWidget.qml — not this
@@ -490,7 +492,9 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    centerOnBar: true
+    // Centered by default; shell.json can set "centerOnBar": false to
+    // anchor the panel under its bar icon instead.
+    centerOnBar: root.settings.centerOnBar !== false
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(480))
     contentHeight: panel.fittedContentHeight(weatherColumn.implicitHeight)


### PR DESCRIPTION
## What

The weather and clock panels hard-code `centerOnBar: true`, so their popups always open centered on screen. This PR reads an inline `shell.json` setting so users can anchor them under the bar icon instead:

```json
{ "id": "omarchy.weather", "centerOnBar": false }
```

The default stays `true`, so existing behavior is unchanged.

## Why

On wide or multi-monitor setups, a weather/calendar popup opening far away from the icon it was clicked on is easy to lose track of. Making the placement configurable lets users pick between the stock centered look and an icon-anchored panel without forking the plugin.

## Changes

- `shell/plugins/panels/weather/Panel.qml`: accept `settings`, use `centerOnBar: settings.centerOnBar !== false`
- `shell/plugins/panels/clock/Panel.qml`: same
- `docs/omarchy-shell.md`: document the new option (rule 9)

## Verification

Tested in the running shell (screenshot analysis):

- Default (no setting): panel centered, center x ≈ 958 on a 1920 screen ✓
- `"centerOnBar": false`: panel anchored under the weather icon, center x ≈ 1026, top edge right below the bar ✓

`qmllint` passes on both modified files (weather has a pre-existing lint environment quirk unrelated to this change). `test/acceptance.d/panels-test.sh` asserts panel open/close and content, not placement; default behavior is unchanged so it is unaffected.