### PR TITLE
Install Grok through mise's first-party registry

### DIFF
--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -30,7 +30,7 @@ opencode | open-code) agent="opencode"; name="OpenCode" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
 codex) agent="codex"; name="Codex" ;;
 crush) agent="crush"; name="Crush" ;;
-grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
+grok) agent="grok"; name="Grok" ;;
 gemini | gemini-cli) agent="gemini"; name="Gemini" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
 *)

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -236,7 +236,7 @@
   "install.terminal.kitty": {"icon":"","label":"Kitty","disabled":"omarchy-pkg-present kitty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal kitty'"},
   "install.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","disabled":"omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-chatgpt"},
   "install.ai.dictation": {"icon":"","label":"Dictation","disabled":"omarchy-pkg-present voxtype-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"},
-  "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","disabled":"omarchy-pkg-present grok-bot","action":"omarchy-install-and-launch 'Grok Bot' grok-bot grok-bot"},
+  "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","description":"Desktop chat app, not the Grok CLI","disabled":"omarchy-pkg-present grok-bot","action":"omarchy-install-and-launch 'Grok Bot' grok-bot grok-bot"},
   "install.ai.lm-studio": {"icon":"","iconFont":"omarchy","label":"LM Studio","disabled":"omarchy-pkg-present lmstudio-bin","action":"omarchy-install-app 'LM Studio' lmstudio-bin"},
   "install.ai.ollama": {"icon":"","iconFont":"omarchy","label":"Ollama","disabled":"omarchy-cmd-present ollama","action":"if omarchy-cmd-present nvidia-smi; then ollama_pkg=ollama-cuda; elif omarchy-cmd-present rocminfo; then ollama_pkg=ollama-rocm; else ollama_pkg=ollama; fi; omarchy-install-app Ollama \"$ollama_pkg\""},
   "install.gaming.steam": {"icon":"","label":"Steam","disabled":"omarchy-pkg-present steam","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-steam"},

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -8,6 +8,6 @@ omarchy-mise-install opencode
 omarchy-mise-install npm:playwright playwright
 omarchy-mise-install pi
 omarchy-mise-install github:can1357/oh-my-pi omp
-omarchy-mise-install npm:@xai-official/grok grok
+omarchy-mise-install grok
 omarchy-mise-install npm:@kitlangton/ghui ghui
 omarchy-mise-install aqua:modem-dev/hunk hunk

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -10,11 +10,13 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 | `gemini`   | [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) |
 | `copilot`  | [GitHub Copilot CLI](https://github.com/github/copilot-cli)      |
 | `crush`    | [Crush](https://github.com/charmbracelet/crush)                  |
-| `grok`     | Grok CLI from xAI                                                |
+| `grok`     | [Grok Build](https://x.ai/build) from xAI                        |
 | `pi`       | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)        |
 | `omp`      | [Oh My Pi](https://github.com/can1357/oh-my-pi)                  |
 
 To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`. The stubs are kept current along with everything else mise manages when you run `omarchy update` (or the `mup` alias).
+
+`grok` is installed through [mise](https://mise.jdx.dev/)'s first-party `grok` package, the same way as `claude` and `codex`. Run `grok` or pick it under _Setup > Defaults > Agent_ — skip the `curl | bash` installer on x.ai. That path puts a second copy in `~/.grok/bin`, prepends it on `PATH`, and overwrites Omarchy's wrapper.
 
 ### The default agent
 
@@ -38,7 +40,7 @@ The watching is on by default. Turn it off under _Trigger > Toggle > Crash Captu
 
 ### Desktop apps
 
-The _Install > AI_ menu also carries a couple of graphical AI apps: the ChatGPT desktop app, and Grok Bot for chatting with xAI's models.
+The _Install > AI_ menu also carries a couple of graphical AI apps: the ChatGPT desktop app, and Grok Bot for chatting with xAI's models. Grok Bot is the desktop chat app — the coding agent is the `grok` command above.
 
 ### Local LLMs
 

--- a/migrations/1786956325.sh
+++ b/migrations/1786956325.sh
@@ -1,0 +1,19 @@
+echo "Install Grok through mise's first-party registry"
+
+# mise now ships a first-party `grok` backend (http:grok). The earlier npm
+# package name made `mise use -g grok` fail unless the user added a custom
+# tool definition, and the x.ai curl installer then overwrote the wrapper.
+
+if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  omarchy-mise-install grok
+elif [[ -f $HOME/.local/bin/grok ]] && grep -Fq 'npm:@xai-official/grok' "$HOME/.local/bin/grok"; then
+  rm -f "$HOME/.local/bin/grok"
+fi
+
+# The website installer also drops an `agent` symlink into ~/.local/bin.
+if [[ -L $HOME/.local/bin/agent ]]; then
+  agent_target=$(readlink -f "$HOME/.local/bin/agent" || true)
+  if [[ $agent_target == "$HOME/.grok/"* ]]; then
+    rm -f "$HOME/.local/bin/agent"
+  fi
+fi

--- a/migrations/1786956325.sh
+++ b/migrations/1786956325.sh
@@ -11,9 +11,10 @@ elif [[ -f $HOME/.local/bin/grok ]] && grep -Fq 'npm:@xai-official/grok' "$HOME/
 fi
 
 # The website installer also drops an `agent` symlink into ~/.local/bin.
+# Use the raw target so a dangling link still matches after ~/.grok/bin is gone.
 if [[ -L $HOME/.local/bin/agent ]]; then
-  agent_target=$(readlink -f "$HOME/.local/bin/agent" || true)
-  if [[ $agent_target == "$HOME/.grok/"* ]]; then
+  agent_target=$(readlink "$HOME/.local/bin/agent" || true)
+  if [[ $agent_target == "$HOME/.grok/"* || $agent_target == *'/.grok/'* ]]; then
     rm -f "$HOME/.local/bin/agent"
   fi
 fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -92,7 +92,8 @@ export OMARCHY_TEST_STUB_LOG="$stub_log"
 export OMARCHY_TEST_AGENT_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
 
-grok_package="npm:@xai-official/grok"
+grok_package="grok"
+legacy_grok_package="npm:@xai-official/grok"
 omp_package="github:can1357/oh-my-pi"
 crush_package="crush"
 
@@ -115,7 +116,7 @@ assert_lazy_stub "$crush_package" crush
 pass "custom agent lazy stubs preserve their mise packages"
 
 source "$ROOT/install/user/mise.sh"
-grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
+grep -Fx "$grok_package" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "user setup creates the Oh My Pi lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the Crush lazy stub"
 pass "user setup creates the custom agent lazy stubs"
@@ -127,8 +128,12 @@ grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "Oh My Pi migration c
 : >"$stub_log"
 source "$ROOT/migrations/1785846769.sh" >/dev/null
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "agent migration repairs the Oh My Pi lazy stub"
-grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "agent migration creates the Grok lazy stub"
+grep -Fx "$legacy_grok_package grok" "$stub_log" >/dev/null || fail "agent migration creates the Grok lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "agent migration creates the Crush lazy stub"
+
+: >"$stub_log"
+source "$ROOT/migrations/1786956325.sh" >/dev/null
+grep -Fx "$grok_package" "$stub_log" >/dev/null || fail "registry migration rewrites Grok onto mise's first-party backend"
 
 mkdir -p "$test_home/.local/state/omarchy"
 touch "$test_home/.local/state/omarchy/preinstalls-removed"
@@ -136,6 +141,7 @@ touch "$test_home/.local/state/omarchy/preinstalls-removed"
 : >"$stub_log"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
 source "$ROOT/migrations/1785846769.sh" >/dev/null
+source "$ROOT/migrations/1786956325.sh" >/dev/null
 [[ ! -s $stub_log ]] || fail "agent migrations respect the preinstall opt-out"
 [[ ! -e $test_home/.local/bin/omp ]] || fail "agent migration removes the obsolete Oh My Pi wrapper after opt-out"
 
@@ -155,6 +161,18 @@ source "$ROOT/migrations/1785846769.sh" >/dev/null
 [[ -e $test_home/.local/bin/omp ]] ||
   fail "agent migration keeps a wrapper built on $omp_package"
 rm -f "$test_home/.local/bin/omp"
+
+printf '#!/bin/bash\nmise use -g --quiet "%s" || exit 1\n' "$legacy_grok_package" >"$test_home/.local/bin/grok"
+chmod +x "$test_home/.local/bin/grok"
+mkdir -p "$test_home/.grok/bin"
+: >"$test_home/.grok/bin/agent"
+ln -s "$test_home/.grok/bin/agent" "$test_home/.local/bin/agent"
+: >"$stub_log"
+source "$ROOT/migrations/1786956325.sh" >/dev/null
+[[ ! -s $stub_log ]] || fail "Grok registry migration respects the preinstall opt-out"
+[[ ! -e $test_home/.local/bin/grok ]] || fail "Grok registry migration removes the npm wrapper after opt-out"
+[[ ! -e $test_home/.local/bin/agent ]] || fail "Grok registry migration removes the curl-installer agent symlink"
+rm -f "$test_home/.local/bin/grok" "$test_home/.local/bin/agent"
 
 rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -174,6 +174,13 @@ source "$ROOT/migrations/1786956325.sh" >/dev/null
 [[ ! -e $test_home/.local/bin/agent ]] || fail "Grok registry migration removes the curl-installer agent symlink"
 rm -f "$test_home/.local/bin/grok" "$test_home/.local/bin/agent"
 
+ln -s "$test_home/.grok/bin/agent" "$test_home/.local/bin/agent"
+rm -rf "$test_home/.grok"
+: >"$stub_log"
+source "$ROOT/migrations/1786956325.sh" >/dev/null
+[[ ! -e $test_home/.local/bin/agent ]] || fail "Grok registry migration removes a dangling curl-installer agent symlink"
+rm -f "$test_home/.local/bin/agent"
+
 rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"
 


### PR DESCRIPTION
## Why

Omarchy already treats Grok like Claude and Codex: a lazy mise stub in `~/.local/bin/grok`, plus **Setup → Defaults → Agent → Grok**. First run of `grok` is supposed to download the CLI. That is the install path. There is no Install → AI row for coding-agent CLIs on purpose (Crush was removed from that menu).

This PR is not “add Grok because it was missing.” Typing `grok` is the intended fix for “I want the Grok CLI.”

What *is* wrong:

1. **Wrong mise package name.** The stub and `omarchy-default-agent grok` called `mise use -g npm:@xai-official/grok`. mise now has a first-party `grok` backend (`http:grok`). `mise use -g grok` therefore does not install the same tool Omarchy wired up. Anyone following mise/xAI docs pastes a custom HTTP tool definition, or runs the website installer.

2. **The x.ai `curl | bash` installer fights Omarchy.** It writes `~/.grok/bin`, prepends that on `PATH`, and overwrites `~/.local/bin/grok` (plus an `agent` symlink). After that, mise is no longer what `grok` runs. Easy to hit if you look at x.ai instead of typing `grok`.

3. **Grok Bot is easy to mistake for the CLI.** Install → AI only offers Grok Bot (desktop chat). Someone looking for “install Grok” will pick that, decide it is the wrong thing, and leave the menu for the website. The CLI was never in that list.

Observed sequence on a 4.0 machine (for context, not the bug report): Install → AI → Grok Bot → uninstall → `curl -fsSL https://x.ai/cli/install.sh | bash` → then `grok`. `grok` was never tried first. A failed first `grok` is not what we are fixing.

## What

- Fresh installs: `omarchy-mise-install grok` (first-party mise package, same shape as `claude` / `codex`)
- `omarchy default agent grok` installs `grok`, not `npm:@xai-official/grok`
- Migration rewrites npm wrappers and removes the curl installer's leftover `~/.local/bin/agent` symlink
- Manual: run `grok` or pick the default agent; skip the website installer
- Grok Bot menu row: “desktop chat app, not the Grok CLI”

Coding agents stay out of Install → AI. Deploy path is still `grok` or Setup → Defaults → Agent → Grok.

## Tests

- `test/shell.d/default-agent-test.sh`
- `test/shell.d/menu-test.sh`
- `./test/cli`