### PR TITLE
Stop the audio panel from capturing the microphone

### DIFF
--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -577,12 +577,6 @@ Panel {
   PwObjectTracker { objects: root.candidateSources }
   PwObjectTracker { objects: root.audioStreams }
 
-  PwNodePeakMonitor {
-    id: inputPeakMonitor
-    node: root.source
-    enabled: root.opened && !!root.source
-  }
-
   Process {
     id: sinkAvailabilityProc
     command: ["omarchy-audio-sink-availability"]
@@ -928,20 +922,6 @@ Panel {
 
                   onMoved: function(v) { root.setInputVolume(v) }
                   onRightClicked: root.toggleInputMute()
-                }
-
-                Rectangle {
-                  width: parent.width
-                  height: Math.max(Style.space(5), Style.spacing.xs)
-                  color: Util.alpha(root.bar.foreground, 0.18)
-                  opacity: root.inputMuted ? 0.35 : 1.0
-
-                  Rectangle {
-                    height: parent.height
-                    width: parent.width * Math.max(0, Math.min(1, inputPeakMonitor.peak))
-                    color: root.bar.foreground
-                    Behavior on width { NumberAnimation { duration: 70 } }
-                  }
                 }
               }
 


### PR DESCRIPTION
## Summary

- Remove the audio panel's live input-level monitor.
- Keep input device selection, mute, and volume controls unchanged.

## Why

Opening the panel enabled `PwNodePeakMonitor` for the default input. Quickshell then created a `Stream/Input/Audio` stream named `Quickshell Peak Detect` and connected it to the microphone solely to animate the small level meter.

That implicit capture can disrupt microphones and custom PipeWire setups merely by opening or hovering the volume controls. The panel does not need to capture audio to control input volume, so this removes the monitor and its visual meter.

## Verification

- Before: opening the panel changed the peak-monitor stream count from 0 to 1.
- After: opening and hovering the input control both leave the peak-monitor stream count at 0.
- Confirmed the default input, mute state, and volume remain unchanged.
- `bash test/shell.d/audio-test.sh`
- `git diff --check`
- Visually checked the live panel after the change for layout and clipping.

The complete `./test/all` run passes the relevant audio tests. It retains three unrelated host/baseline failures: a hybrid-GPU timing test that passes alone, the runtime smoke test seeing three shells for two monitors (also on unmodified `quattro`), and the snapper test requiring an unavailable sibling `omarchy-iso` checkout (also on unmodified `quattro`).
