### PR TITLE
Add optional pill containers for bar sections

### DIFF
--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -16,6 +16,17 @@ scale-with-font  = true
 size-horizontal  = 26
 size-vertical    = 28
 
+# Optional per-section pill containers (left/center/right). Leave
+# section-background unset/transparent for the stock single-background
+# bar. Example (waybar-style capsules):
+#   section-background       = "{{ background }}"
+#   section-background-alpha = 0.72
+#   section-border           = "{{ accent }}"
+#   section-border-alpha     = 0.10
+#   section-radius           = 14
+#   section-padding-x        = 5
+#   section-padding-y        = 2
+
 [hyprland]
 # Shared Hyprland-derived border tokens. Surface sections reference these so
 # lock, notifications, popups, and menu-style cards stay aligned with the

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -376,6 +376,27 @@ size-vertical   = 28   # left/right bar width at base-size 12
 
 Set `scale-with-font = false` to keep those bar sizes as fixed pixels.
 
+### Section pills
+
+Optional pill containers behind the left/center/right sections (a
+waybar-style capsule look). All keys default to transparent/zero, so the
+stock single-background bar is unchanged unless a theme opts in:
+
+```toml
+[bar]
+section-background       = "{{ background }}"
+section-background-alpha = 0.72
+section-border           = "{{ accent }}"
+section-border-alpha     = 0.10
+section-radius           = 14
+section-padding-x        = 5
+section-padding-y        = 2
+```
+
+`section-background` / `section-border` are colors (or palette roles)
+with `-alpha` companions; `section-radius` and the paddings scale with
+`scale-with-font` like other bar sizes.
+
 ## Custom bar modules
 
 If a full plugin is overkill, declare a one-off module inline in

--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -74,6 +74,10 @@ QtObject {
     property color background: root.composed("bar.background", "bar.background-alpha", root.background, 1.0)
     property color text: root.pick("bar.text", root.foreground)
     property color active: root.pick("bar.active", root.urgent)
+    // Optional per-section pill containers (left/center/right). Transparent
+    // by default so the stock single-background bar is unchanged.
+    property color sectionBackground: root.composed("bar.section-background", "bar.section-background-alpha", "transparent", 0.0)
+    property color sectionBorder: root.composed("bar.section-border", "bar.section-border-alpha", root.foreground, 0.0)
   }
   readonly property QtObject popups: QtObject {
     property color background: root.composed("popups.background", "popups.background-alpha", root.background, 1.0)

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -405,7 +405,8 @@ QtObject {
       } else if (section === "bar") {
         if (key === "scale-with-font") {
           nextBarScaleWithFont = boolToken(raw, nextBarScaleWithFont)
-        } else if (key === "size-horizontal" || key === "size-vertical") {
+        } else if (key === "size-horizontal" || key === "size-vertical" ||
+                   key === "section-radius" || key === "section-padding-x" || key === "section-padding-y") {
           var b = parseInt(raw, 10)
           if (isFinite(b)) barOut[key] = b
         }

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -41,6 +41,12 @@ Item {
   })
   property var layoutConfig: fallbackBarConfig.layout
   property string centerAnchor: ""
+
+// Optional per-section pill containers. Themed via [bar] tokens in
+// shell.toml; zero/transparent defaults keep the stock bar unchanged.
+readonly property real sectionPillPaddingX: Style.barToken("section-padding-x", 0)
+readonly property real sectionPillPaddingY: Style.barToken("section-padding-y", 0)
+readonly property real sectionPillRadius: Style.barToken("section-radius", 0)
   property bool requestedTransparent: false
   property bool useTransparentForeground: false
   property bool transparent: false
@@ -1109,16 +1115,20 @@ Item {
 
         CenterModules { anchors.fill: parent }
 
-        LeftModules {
+        SectionPill {
           anchors.left: parent.left
           anchors.leftMargin: Style.space(8)
           anchors.verticalCenter: parent.verticalCenter
+
+          LeftModules {}
         }
 
-        RightModules {
+        SectionPill {
           anchors.right: parent.right
           anchors.rightMargin: Style.space(8)
           anchors.verticalCenter: parent.verticalCenter
+
+          RightModules {}
         }
       }
     }
@@ -1131,16 +1141,20 @@ Item {
 
         CenterModules { anchors.fill: parent }
 
-        LeftModules {
+        SectionPill {
           anchors.top: parent.top
           anchors.topMargin: Style.space(8)
           anchors.horizontalCenter: parent.horizontalCenter
+
+          LeftModules {}
         }
 
-        RightModules {
+        SectionPill {
           anchors.bottom: parent.bottom
           anchors.bottomMargin: Style.space(8)
           anchors.horizontalCenter: parent.horizontalCenter
+
+          RightModules {}
         }
       }
     }
@@ -1285,6 +1299,38 @@ Item {
     region: "right"
   }
 
+  // Optional pill container behind a bar section (left/center/right).
+  // Driven by [bar] theme tokens; transparent by default so the stock
+  // single-background bar is unchanged.
+  component SectionPill: Item {
+    id: pill
+
+    default property alias contentChildren: contentHost.data
+
+    readonly property bool pillVisible: Color.bar.sectionBackground.a > 0
+    readonly property real padX: root.sectionPillPaddingX
+    readonly property real padY: root.sectionPillPaddingY
+
+    implicitWidth: contentHost.implicitWidth + padX * 2
+    implicitHeight: contentHost.implicitHeight + padY * 2
+
+    Rectangle {
+      anchors.fill: parent
+      visible: pill.pillVisible
+      radius: root.sectionPillRadius
+      color: Color.bar.sectionBackground
+      border.color: Color.bar.sectionBorder
+      border.width: 1
+    }
+
+    Item {
+      id: contentHost
+      anchors.centerIn: parent
+      implicitWidth: contentHost.childrenRect.width
+      implicitHeight: contentHost.childrenRect.height
+    }
+  }
+
   component CenterModules: Item {
     id: centerRoot
 
@@ -1303,6 +1349,27 @@ Item {
       Item {
         anchors.fill: parent
 
+        // Center pill sized to the anchored content (before + anchor + after).
+        Rectangle {
+          id: centerPill
+          anchors.centerIn: parent
+          visible: Color.bar.sectionBackground.a > 0
+          radius: root.sectionPillRadius
+          color: Color.bar.sectionBackground
+          border.color: Color.bar.sectionBorder
+          border.width: 1
+          width: centerContentWidth + root.sectionPillPaddingX * 2
+          height: centerContentHeight + root.sectionPillPaddingY * 2
+        }
+
+        readonly property real centerContentWidth: centerRoot.hasAnchor
+          ? centerBeforeList.width + centerAnchorModule.width + centerAfterList.width
+          : centerSingleList.width
+        readonly property real centerContentHeight: Math.max(
+          centerRoot.hasAnchor
+            ? Math.max(centerBeforeList.height, centerAnchorModule.height, centerAfterList.height)
+            : centerSingleList.height, 1)
+
         CenterGestureArea { anchors.fill: parent }
 
         HoverHandler {
@@ -1310,6 +1377,7 @@ Item {
         }
 
         ModuleList {
+          id: centerSingleList
           visible: !centerRoot.hasAnchor
           entries: centerRoot.entries
           region: "center"
@@ -1317,6 +1385,7 @@ Item {
         }
 
         ModuleList {
+          id: centerBeforeList
           visible: centerRoot.hasAnchor
           entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
           region: "center"
@@ -1333,6 +1402,7 @@ Item {
         }
 
         ModuleList {
+          id: centerAfterList
           visible: centerRoot.hasAnchor
           entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
           region: "center"
@@ -1348,6 +1418,27 @@ Item {
       Item {
         anchors.fill: parent
 
+        // Center pill sized to the anchored content (before + anchor + after).
+        Rectangle {
+          id: centerPillV
+          anchors.centerIn: parent
+          visible: Color.bar.sectionBackground.a > 0
+          radius: root.sectionPillRadius
+          color: Color.bar.sectionBackground
+          border.color: Color.bar.sectionBorder
+          border.width: 1
+          width: centerContentWidthV + root.sectionPillPaddingX * 2
+          height: centerContentHeightV + root.sectionPillPaddingY * 2
+        }
+
+        readonly property real centerContentWidthV: Math.max(
+          centerRoot.hasAnchor
+            ? Math.max(centerBeforeListV.width, centerAnchorModuleV.width, centerAfterListV.width)
+            : centerSingleListV.width, 1)
+        readonly property real centerContentHeightV: centerRoot.hasAnchor
+          ? centerBeforeListV.height + centerAnchorModuleV.height + centerAfterListV.height
+          : centerSingleListV.height
+
         CenterGestureArea { anchors.fill: parent }
 
         HoverHandler {
@@ -1355,6 +1446,7 @@ Item {
         }
 
         ModuleList {
+          id: centerSingleListV
           visible: !centerRoot.hasAnchor
           entries: centerRoot.entries
           region: "center"
@@ -1362,15 +1454,16 @@ Item {
         }
 
         ModuleList {
+          id: centerBeforeListV
           visible: centerRoot.hasAnchor
           entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
           region: "center"
-          anchors.bottom: centerAnchorModule.top
-          anchors.horizontalCenter: centerAnchorModule.horizontalCenter
+          anchors.bottom: centerAnchorModuleV.top
+          anchors.horizontalCenter: centerAnchorModuleV.horizontalCenter
         }
 
         ModuleSlot {
-          id: centerAnchorModule
+          id: centerAnchorModuleV
           visible: centerRoot.hasAnchor
           entry: centerRoot.anchorEntry
           region: "center"
@@ -1378,11 +1471,12 @@ Item {
         }
 
         ModuleList {
+          id: centerAfterListV
           visible: centerRoot.hasAnchor
           entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
           region: "center"
-          anchors.top: centerAnchorModule.bottom
-          anchors.horizontalCenter: centerAnchorModule.horizontalCenter
+          anchors.top: centerAnchorModuleV.bottom
+          anchors.horizontalCenter: centerAnchorModuleV.horizontalCenter
         }
       }
     }


### PR DESCRIPTION
## What

The bar renders a single background behind all three sections. This PR adds optional theme-driven pill containers behind the left/center/right sections, so themes can opt into a waybar-style capsule look:

```toml
[bar]
section-background       = "{{ background }}"
section-background-alpha = 0.72
section-border           = "{{ accent }}"
section-border-alpha     = 0.10
section-radius           = 14
section-padding-x        = 5
section-padding-y        = 2
```

All keys default to transparent/zero, so the stock single-background bar is unchanged unless a theme opts in.

## Changes

- `shell/plugins/bar/Bar.qml`: new `SectionPill` component wrapping the left/right module lists; the center section gets a pill sized to its anchored content (before + anchor + after module lists). New `section-padding-x/y` and `section-radius` read via `Style.barToken`.
- `shell/Commons/Color.qml`: `bar.sectionBackground` / `bar.sectionBorder` colors (with `-alpha` companions), transparent by default.
- `shell/Commons/Style.qml`: parse the new numeric `[bar]` keys.
- `default/themed/shell.toml.tpl`: document the optional tokens.
- `docs/omarchy-shell.md`: new "Section pills" section.

## Verification

Tested in the running shell with screenshot analysis:

- With the tokens set: three rounded capsules render behind the sections (left x≈0–112, center x≈880–1030, right x≈1500–1911 on a 1920 screen), with borders and semi-transparent backgrounds ✓
- Without the tokens: the bar keeps its single-background look, no pills ✓

`qmllint` passes on all modified QML files. No existing tests assert bar section background behavior, and the default is unchanged.