### PR TITLE
Fix plugin bar loading and its silent failure

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -12,14 +12,14 @@ Item {
   id: root
 
   // The omarchy-shell host injects omarchyPath from OMARCHY_PATH.
-  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  required property string omarchyPath
   // Injected by the host shell so bar slots can resolve enabled widgets.
-  property var barWidgetRegistry: null
+  required property var barWidgetRegistry
   // Injected by the host shell every time shell.json is reloaded. Holds the
   // `bar:` subtree: position, centerAnchor, layout. The host owns file IO;
   // the bar just renders whatever it's handed. The bar font follows the
   // OS-level fontconfig monospace binding — it is not stored in shell.json.
-  property var barConfig: null
+  required property var barConfig
   // Injected by the host shell. Used for shell-wide actions such as opening
   // settings and persisting inline widget state.
   property var shell: null

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -12,14 +12,14 @@ Item {
   id: root
 
   // The omarchy-shell host injects omarchyPath from OMARCHY_PATH.
-  required property string omarchyPath
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   // Injected by the host shell so bar slots can resolve enabled widgets.
-  required property var barWidgetRegistry
+  property var barWidgetRegistry: null
   // Injected by the host shell every time shell.json is reloaded. Holds the
   // `bar:` subtree: position, centerAnchor, layout. The host owns file IO;
   // the bar just renders whatever it's handed. The bar font follows the
   // OS-level fontconfig monospace binding — it is not stored in shell.json.
-  required property var barConfig
+  property var barConfig: null
   // Injected by the host shell. Used for shell-wide actions such as opening
   // settings and persisting inline widget state.
   property var shell: null

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,8 +253,11 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
+        // Loader exposes no errorString; the engine has already logged the
+        // component's own QML errors by the time this runs. Reaching for one
+        // threw a ReferenceError here, which aborted the handler before the
+        // fallback below and left the session with no bar and no explanation.
+        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId)
         shell.failedBarId = shell.activeBarId
       }
     }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -246,20 +246,52 @@ ShellRoot {
   Loader {
     id: pluginBarLoader
 
+    // A bar entry point declares the host-injected properties as required, and
+    // QML refuses to instantiate a component whose required properties are
+    // unset. Binding `source` therefore failed before onLoaded could run, and
+    // configureBar()'s `if (!target) return` made the injection a no-op -- so no
+    // bar plugin could ever load. setSource supplies them at creation instead,
+    // and Qt.binding keeps them live afterwards, the way defaultBarComponent's
+    // declarative bindings do.
+    function loadPluginBar() {
+      if (!active) {
+        setSource("")
+        return
+      }
+
+      setSource(shell.activeBarSourceUrl, {
+        omarchyPath: Qt.binding(function() { return shell.omarchyPath }),
+        barWidgetRegistry: Qt.binding(function() { return shell.barWidgetRegistry }),
+        barConfig: Qt.binding(function() { return shell.barConfig }),
+        shell: shell,
+        manifest: Qt.binding(function() { return shell.activeBarManifest })
+      })
+    }
+
     active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
-    source: shell.activeBarId !== shell.defaultBarId ? shell.activeBarSourceUrl : ""
     asynchronous: true
     onLoaded: shell.configureBar(item, shell.activeBarManifest)
-    onActiveChanged: if (!active) shell.bar = null
+    onActiveChanged: {
+      if (!active) shell.bar = null
+      loadPluginBar()
+    }
     onStatusChanged: {
       if (status === Loader.Error) {
         // Loader exposes no errorString; the engine has already logged the
         // component's own QML errors by the time this runs. Reaching for one
         // threw a ReferenceError here, which aborted the handler before the
         // fallback below and left the session with no bar and no explanation.
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId)
+        console.warn("bar option " + shell.activeBarId + " (" + shell.activeBarSourceUrl + ") failed to load, falling back to " + shell.defaultBarId)
         shell.failedBarId = shell.activeBarId
       }
+    }
+
+    // Switching straight from one bar plugin to another keeps `active` true, so
+    // the url change has to drive the reload by itself.
+    Connections {
+      target: shell
+
+      function onActiveBarSourceUrlChanged() { pluginBarLoader.loadPluginBar() }
     }
   }
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -263,12 +263,19 @@ ShellRoot {
     // and onBarConfigChanged keeps barConfig current from then on. A binding here
     // would be replaced moments after it was made.
     function loadPluginBar() {
-      if (!active) {
+      // `active` already covers activeBarSourceUrl !== "", but a signal handler can
+      // run before that binding is re-evaluated: on the change that empties the
+      // url, onActiveBarSourceUrlChanged fires while `active` is still true, and
+      // setSource("") with a property map is a needless load error. Reading the url
+      // once and checking it here keeps this correct whichever order they arrive in.
+      var url = shell.activeBarSourceUrl
+
+      if (!active || url === "") {
         setSource("")
         return
       }
 
-      setSource(shell.activeBarSourceUrl, {
+      setSource(url, {
         omarchyPath: shell.omarchyPath,
         barWidgetRegistry: shell.barWidgetRegistry,
         barConfig: shell.barConfig,

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -271,6 +271,14 @@ ShellRoot {
     active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
     asynchronous: true
     onLoaded: shell.configureBar(item, shell.activeBarManifest)
+
+    // The load is driven by signals now that `source` is not bound, so a loader
+    // built with `active` already true would never get its initial setSource.
+    // That does not happen today -- the bar config arrives after construction, so
+    // `active` starts false and onActiveChanged does it -- but nothing enforces
+    // that ordering, and the failure mode is a session with no bar.
+    Component.onCompleted: loadPluginBar()
+
     onActiveChanged: {
       if (!active) shell.bar = null
       loadPluginBar()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -178,6 +178,12 @@ ShellRoot {
     return shell.barOptionAvailable(shell.selectedBarId)
   }
   readonly property string activeBarId: selectedBarId !== failedBarId && selectedBarAvailable ? selectedBarId : defaultBarId
+  // configureBar() assigns manifest imperatively at load, which replaces the
+  // binding the bar was created with -- and a manifest can be re-read (a plugin
+  // rescan) without its entry-point url changing, so nothing would reload the
+  // bar or refresh the value. Push it the same way barConfig is pushed above.
+  onActiveBarManifestChanged: if (bar && "manifest" in bar) bar.manifest = shell.activeBarManifest
+
   readonly property var activeBarManifest: {
     var revision = shell.pluginRegistry.registryRevision
     return shell.barManifestFor(shell.activeBarId)

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -250,9 +250,12 @@ ShellRoot {
     // QML refuses to instantiate a component whose required properties are
     // unset. Binding `source` therefore failed before onLoaded could run, and
     // configureBar()'s `if (!target) return` made the injection a no-op -- so no
-    // bar plugin could ever load. setSource supplies them at creation instead,
-    // and Qt.binding keeps them live afterwards, the way defaultBarComponent's
-    // declarative bindings do.
+    // bar plugin could ever load. setSource supplies them at creation instead.
+    //
+    // Plain values, not Qt.binding: onLoaded hands the item straight to
+    // configureBar(), which reassigns all of them from the live shell properties,
+    // and onBarConfigChanged keeps barConfig current from then on. A binding here
+    // would be replaced moments after it was made.
     function loadPluginBar() {
       if (!active) {
         setSource("")
@@ -260,11 +263,11 @@ ShellRoot {
       }
 
       setSource(shell.activeBarSourceUrl, {
-        omarchyPath: Qt.binding(function() { return shell.omarchyPath }),
-        barWidgetRegistry: Qt.binding(function() { return shell.barWidgetRegistry }),
-        barConfig: Qt.binding(function() { return shell.barConfig }),
+        omarchyPath: shell.omarchyPath,
+        barWidgetRegistry: shell.barWidgetRegistry,
+        barConfig: shell.barConfig,
         shell: shell,
-        manifest: Qt.binding(function() { return shell.activeBarManifest })
+        manifest: shell.activeBarManifest
       })
     }
 

--- a/test/shell.d/plugin-bar-loader-test.sh
+++ b/test/shell.d/plugin-bar-loader-test.sh
@@ -11,9 +11,11 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 # the loader omitting the injected properties at creation (so a bar declaring
 # them `required` could not be instantiated at all), and Loader.Error failing to
 # select the fallback (so a broken bar left the session with no bar and no
-# message).
+# message). A third case covers switching straight from one bar plugin to
+# another: `active` stays true across that, so only the url change can drive the
+# reload, and nothing else here would notice if it stopped.
 #
-# Both cases run the real shell rather than a stand-in, because the loader is
+# Every case runs the real shell rather than a stand-in, because the loader is
 # part of shell.qml and a reimplementation in a fixture would only test itself.
 
 TMPDIR=""
@@ -132,6 +134,49 @@ Item {
 QML
 }
 
+# Two of these stand in for two installed bar options. Each reports its own id
+# when it loads, so the result file says *which* bar is up rather than just that
+# some bar is.
+write_named_bar() {
+  local dir="$1" id="$2" name="$3"
+  mkdir -p "$dir"
+  cat >"$dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$id",
+  "name": "$name",
+  "version": "1.0.0",
+  "kinds": ["bar"],
+  "entryPoints": {"bar": "Bar.qml"}
+}
+JSON
+  {
+    printf 'import QtQuick\nimport Quickshell\n\nItem {\n  id: root\n\n'
+    printf '  readonly property string barId: "%s"\n' "$id"
+    cat <<'QML'
+
+  property string omarchyPath: ""
+  property var barWidgetRegistry: null
+  property var barConfig: null
+  property var shell: null
+  property var manifest: null
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\''") + "'"
+  }
+
+  Component.onCompleted: {
+    if (resultPath)
+      Quickshell.execDetached(["bash", "-lc",
+        "printf '%s' " + shellQuote(JSON.stringify({id: root.barId})) + " > " + shellQuote(resultPath)])
+  }
+}
+QML
+  } >"$dir/Bar.qml"
+}
+
 write_shell_json() {
   local home="$1" bar_id="$2"
   mkdir -p "$home/.config/omarchy"
@@ -239,3 +284,66 @@ if ! jq -e "$fallback_took" <<<"$plugins" >/dev/null 2>&1; then
 fi
 
 pass "a bar plugin that cannot load falls back to the built-in bar"
+stop_shell
+
+# ----------------------------------------------------------------- bar switch
+#
+# Both bars are valid and both are plugins, so pluginBarLoader.active is true
+# before and after -- neither onActiveChanged nor Component.onCompleted fires.
+# Only activeBarSourceUrl changes, so the loader reloads solely because the url
+# change drives it. Drop that and this case hangs on bar one.
+home_switch="$TMPDIR/home-switch"
+log_switch="$TMPDIR/switch-bar.log"
+switch_result="$TMPDIR/switch-result.json"
+plugins_dir="$home_switch/.config/omarchy/plugins"
+write_named_bar "$plugins_dir/acme.bar-one" "acme.bar-one" "Bar One"
+write_named_bar "$plugins_dir/acme.bar-two" "acme.bar-two" "Bar Two"
+write_shell_json "$home_switch" "acme.bar-one"
+start_shell "$home_switch" "$log_switch" "$switch_result"
+
+wait_for_bar() {
+  local want="$1" what="$2"
+  for _ in {1..150}; do
+    if [[ -s $switch_result ]] && jq -e --arg id "$want" '.id == $id' "$switch_result" >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! kill -0 "$QS_PID" 2>/dev/null; then
+      sed -n '1,120p' "$log_switch" >&2
+      fail "shell exited before $what"
+    fi
+    sleep 0.1
+  done
+  [[ -s $switch_result ]] && jq . "$switch_result" >&2
+  sed -n '1,120p' "$log_switch" >&2
+  fail "$what"
+}
+
+wait_for_bar "acme.bar-one" "the first bar plugin never loaded"
+
+# Truncated so the poll below cannot pass on bar one's own report.
+: >"$switch_result"
+
+for _ in {1..150}; do
+  shell_ipc_quiet shell ping >/dev/null 2>&1 && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,120p' "$log_switch" >&2
+    fail "shell exited before its IPC became available"
+  fi
+  sleep 0.1
+done
+
+# Switched by enabling the second bar option, which sets bar.id through the
+# in-process config mutator. Rewriting shell.json and reloading it instead would
+# not test this path: the reload empties the config on its way through, so
+# activeBarSourceUrl passes through "", the loader deactivates and reactivates,
+# and onActiveChanged does the work. Mutating in place keeps both plugins
+# installed and the url non-empty throughout, so `active` never drops.
+switched=$(shell_ipc shell enablePlugin acme.bar-two '{}' 2>&1 || true)
+if [[ $switched != *ok* ]]; then
+  sed -n '1,120p' "$log_switch" >&2
+  fail "could not select the second bar plugin: $switched"
+fi
+
+wait_for_bar "acme.bar-two" "switching between two bar plugins did not load the second entry point"
+
+pass "switching straight from one bar plugin to another loads the second entry point"

--- a/test/shell.d/plugin-bar-loader-test.sh
+++ b/test/shell.d/plugin-bar-loader-test.sh
@@ -18,6 +18,15 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 TMPDIR=""
 QS_PID=""
+test_root=""
+
+shell_ipc() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" "$@"
+}
+
+shell_ipc_quiet() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" -q "$@"
+}
 
 cleanup() {
   if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
@@ -194,22 +203,39 @@ write_broken_bar "$home_broken/.config/omarchy/plugins/acme.broken-bar"
 write_shell_json "$home_broken" "acme.broken-bar"
 start_shell "$home_broken" "$log_broken"
 
+# The Loader.Error handler prints its warning before assigning failedBarId, so
+# the log says nothing about whether the fallback actually took. Ask the shell
+# instead: once it has given up on the broken bar, activeBarId is the built-in
+# one, and listPlugins reports that as the active bar option.
+fallback_took='any(.[]; .id == "omarchy.bar" and .active == true)
+  and any(.[]; .id == "acme.broken-bar" and .active == false)'
+
 for _ in {1..150}; do
-  grep -q "failed to load, falling back to" "$log_broken" 2>/dev/null && break
+  shell_ipc_quiet shell ping >/dev/null 2>&1 && break
   if ! kill -0 "$QS_PID" 2>/dev/null; then
-    break
+    sed -n '1,120p' "$log_broken" >&2
+    fail "shell exited before its IPC became available"
   fi
   sleep 0.1
 done
 
-if ! grep -q "failed to load, falling back to omarchy.bar" "$log_broken"; then
+plugins=""
+for _ in {1..150}; do
+  plugins=$(shell_ipc shell listPlugins 2>/dev/null || true)
+  if jq -e "$fallback_took" <<<"$plugins" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,120p' "$log_broken" >&2
+    fail "shell exited before falling back to the built-in bar"
+  fi
+  sleep 0.1
+done
+
+if ! jq -e "$fallback_took" <<<"$plugins" >/dev/null 2>&1; then
+  jq -e 'map(select(.kinds | index("bar")))' <<<"$plugins" >&2 || printf '%s\n' "$plugins" >&2
   sed -n '1,120p' "$log_broken" >&2
   fail "a bar plugin that cannot load did not fall back to the built-in bar"
-fi
-
-if grep -q "ReferenceError" "$log_broken"; then
-  grep -n "ReferenceError" "$log_broken" >&2
-  fail "the Loader.Error handler threw instead of selecting the fallback"
 fi
 
 pass "a bar plugin that cannot load falls back to the built-in bar"

--- a/test/shell.d/plugin-bar-loader-test.sh
+++ b/test/shell.d/plugin-bar-loader-test.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# shell.qml reaches a bar two ways, and only one of them is covered elsewhere.
+# manifest-entrypoints-test.sh instantiates the built-in bar directly, which
+# exercises defaultBarComponent's declarative properties; nothing exercised
+# pluginBarLoader. Both bugs this covers were invisible from the built-in path:
+# the loader omitting the injected properties at creation (so a bar declaring
+# them `required` could not be instantiated at all), and Loader.Error failing to
+# select the fallback (so a broken bar left the session with no bar and no
+# message).
+#
+# Both cases run the real shell rather than a stand-in, because the loader is
+# part of shell.qml and a reimplementation in a fixture would only test itself.
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "plugin bar loader test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping plugin bar loader test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+test_root="$TMPDIR/omarchy"
+mkdir -p "$test_root"
+cp -a "$ROOT/shell" "$test_root/shell"
+ln -s "$ROOT/config" "$test_root/config"
+ln -s "$ROOT/bin" "$test_root/bin"
+
+# A bar plugin whose injected properties are `required`, exactly as the
+# first-party bar declares them. QML refuses to instantiate a component with a
+# required property unset, so this loads only if the loader supplies all three at
+# creation -- and it reports the values back, so a property that arrives as
+# undefined fails the test rather than passing quietly.
+write_required_bar() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/manifest.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "id": "acme.required-bar",
+  "name": "Required Bar",
+  "version": "1.0.0",
+  "kinds": ["bar"],
+  "entryPoints": {"bar": "Bar.qml"}
+}
+JSON
+  cat >"$dir/Bar.qml" <<'QML'
+import QtQuick
+import Quickshell
+
+Item {
+  id: root
+
+  required property string omarchyPath
+  required property var barWidgetRegistry
+  required property var barConfig
+
+  property var shell: null
+  property var manifest: null
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  Component.onCompleted: {
+    var payload = JSON.stringify({
+      ok: true,
+      omarchyPath: String(root.omarchyPath || ""),
+      hasRegistry: root.barWidgetRegistry !== null && root.barWidgetRegistry !== undefined,
+      hasConfig: root.barConfig !== null && root.barConfig !== undefined
+    })
+
+    if (resultPath)
+      Quickshell.execDetached(["bash", "-lc",
+        "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+  }
+}
+QML
+}
+
+# A bar plugin that cannot load, for the fallback path.
+write_broken_bar() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/manifest.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "id": "acme.broken-bar",
+  "name": "Broken Bar",
+  "version": "1.0.0",
+  "kinds": ["bar"],
+  "entryPoints": {"bar": "Bar.qml"}
+}
+JSON
+  cat >"$dir/Bar.qml" <<'QML'
+import QtQuick
+
+Item {
+  ThisTypeDoesNotExist {}
+}
+QML
+}
+
+write_shell_json() {
+  local home="$1" bar_id="$2"
+  mkdir -p "$home/.config/omarchy"
+  cat >"$home/.config/omarchy/shell.json" <<JSON
+{
+  "version": 1,
+  "bar": {"id": "$bar_id", "layout": {"left": [], "center": [], "right": []}}
+}
+JSON
+}
+
+start_shell() {
+  local home="$1" log="$2" result="${3:-}"
+  OMARCHY_PATH="$test_root" \
+  OMARCHY_QML_TEST_RESULT="$result" \
+  HOME="$home" \
+  XDG_CONFIG_HOME="$home/.config" \
+  XDG_CACHE_HOME="$home/.cache" \
+  XDG_STATE_HOME="$home/.local/state" \
+  QML2_IMPORT_PATH="$test_root/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+  QML_IMPORT_PATH="$test_root/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+  PATH="$ROOT/bin:$PATH" \
+    quickshell -p "$test_root/shell" --no-color >"$log" 2>&1 &
+  QS_PID=$!
+}
+
+stop_shell() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  QS_PID=""
+}
+
+# ---------------------------------------------------------------- required bar
+home_ok="$TMPDIR/home-ok"
+log_ok="$TMPDIR/required-bar.log"
+result="$TMPDIR/result.json"
+write_required_bar "$home_ok/.config/omarchy/plugins/acme.required-bar"
+write_shell_json "$home_ok" "acme.required-bar"
+start_shell "$home_ok" "$log_ok" "$result"
+
+for _ in {1..150}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,120p' "$log_ok" >&2
+    fail "shell exited before the plugin bar reported in"
+  fi
+  sleep 0.1
+done
+
+if [[ ! -s $result ]]; then
+  sed -n '1,120p' "$log_ok" >&2
+  fail "a bar plugin with required injected properties never loaded"
+fi
+
+if ! jq -e '.ok == true and .hasRegistry == true and .hasConfig == true and (.omarchyPath | length > 0)' "$result" >/dev/null; then
+  jq . "$result" >&2
+  fail "the plugin bar loaded but its injected properties were not supplied"
+fi
+
+pass "a bar plugin declaring its injected properties required is loaded with them supplied"
+stop_shell
+
+# ------------------------------------------------------------------ broken bar
+home_broken="$TMPDIR/home-broken"
+log_broken="$TMPDIR/broken-bar.log"
+write_broken_bar "$home_broken/.config/omarchy/plugins/acme.broken-bar"
+write_shell_json "$home_broken" "acme.broken-bar"
+start_shell "$home_broken" "$log_broken"
+
+for _ in {1..150}; do
+  grep -q "failed to load, falling back to" "$log_broken" 2>/dev/null && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q "failed to load, falling back to omarchy.bar" "$log_broken"; then
+  sed -n '1,120p' "$log_broken" >&2
+  fail "a bar plugin that cannot load did not fall back to the built-in bar"
+fi
+
+if grep -q "ReferenceError" "$log_broken"; then
+  grep -n "ReferenceError" "$log_broken" >&2
+  fail "the Loader.Error handler threw instead of selecting the fallback"
+fi
+
+pass "a bar plugin that cannot load falls back to the built-in bar"


### PR DESCRIPTION
Fixes #7253.

`omarchy plugin clone omarchy.bar` reports success and switches `bar.id`, then the bar disappears from every monitor with nothing printed and no fallback. Two defects, the second hiding the first.

### 1. A plugin bar's injected properties arrive too late

A bar entry point declares `omarchyPath`, `barWidgetRegistry`, and `barConfig` as `required`, and QML refuses to instantiate a component whose required properties are unset. `shell.qml` reaches a bar two ways:

- `defaultBarComponent` passes them declaratively — the built-in bar is fine.
- `pluginBarLoader` bound `source:` and injected them afterwards, in `onLoaded: shell.configureBar(item, ...)`.

The second can never work: the Loader fails before `onLoaded`, and `configureBar()` opens with `if (!target) return`, making it a no-op. So no bar plugin could load — including a clone of the built-in bar, which is the documented way to customise one.

`setSource` supplies them at creation instead, with `Qt.binding` so they stay live afterwards the way `defaultBarComponent`'s bindings do. That also fixes something that was quietly broken: a plugin bar previously got `barConfig` assigned once in `onLoaded` and never followed a `shell.json` reload. Only the properties `Bar.qml` declares are passed; `configureBar()` still fills in optional ones such as `pluginRegistry` on load.

Since `active` does not change when switching straight from one bar plugin to another, the source url drives the reload itself.

### 2. The `Loader.Error` handler reads `errorString`, which `Loader` does not have

```qml
var detail = errorString && errorString() ? errorString() : ""
console.warn("bar option " + ... + ":", detail)
shell.failedBarId = shell.activeBarId   // never reached
```

The `ReferenceError` aborts the handler before `failedBarId` is set, so the existing fallback to `omarchy.bar` never runs and the warning is never printed. That is why a broken bar option presents as a silently missing bar rather than an error. The warning now also names the url it tried to load, since the engine logs the component's own errors without saying which bar option asked for them.

### Verification

On Omarchy 4.0.0-1, Hyprland 0.56.2, two monitors. Both runs start from a cold `~/.cache/quickshell/qmlcache` — a warm cache serves a previously compiled `Bar.qml` and will happily mask this.

- **Before:** `omarchy plugin clone omarchy.bar` + restart → `hyprctl layers` shows no `omarchy-bar` surface on either monitor; journal shows the three `Required property … was not initialized` warnings plus `ReferenceError: errorString is not defined`.
- **After:** the same untouched clone loads and renders on both monitors, with no warnings beyond one unrelated portal message. `Bar.qml` is not modified, so the clone still declares all three as `required`.

`./test/all` shows the same 4 pre-existing failures with and without this change (they want a sibling `omarchy-pkgs` checkout, snapper config, and a pristine system; the fourth is an IPC-handler count that is off on this machine regardless of branch or active bar id).

### Note on the history

The first two commits relaxed `Bar.qml`'s `required` properties. Review pushed back on weakening the contract, which was fair, and the objection pointed at a better fix: relaxing `Bar.qml` only helps bars descended from a *fixed* `Bar.qml`, so an existing clone or a third-party bar that declares its injected properties required would still fail. The later commits revert that and fix the loader instead. Net diff is `shell/shell.qml` only.
