### PR TITLE
Ensure shift:both_capslock_cancel in kb_options during Quattro migration

### DIFF
--- a/migrations/1781485962.sh
+++ b/migrations/1781485962.sh
@@ -100,12 +100,32 @@ ensure_capslock_cancel_option() {
   local input_file="$1"
   [[ -f $input_file ]] || return 0
 
-  local current_options
-  current_options=$(active_lua_string_value kb_options "$input_file")
+  local tmp_file
+  tmp_file=$(mktemp)
 
-  if [[ -n $current_options && ! "$current_options" == *"shift:both_capslock_cancel"* ]]; then
-    sed -i "s/kb_options = \"$current_options\"/kb_options = \"$current_options,shift:both_capslock_cancel\"/" "$input_file"
-  fi
+  awk -v key="kb_options" -v option="shift:both_capslock_cancel" '
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" && !updated {
+      # Work only on the quoted Lua string so comments or trailing commas stay intact.
+      quote_start = index($0, "\"")
+      if (quote_start) {
+        rest = substr($0, quote_start + 1)
+        quote_end = index(rest, "\"")
+        value = substr(rest, 1, quote_end - 1)
+
+        if (quote_end > 1 && index(value, option) == 0) {
+          # Rebuild the line with the new option before the closing quote.
+          print substr($0, 1, quote_start) value "," option substr(rest, quote_end)
+          updated = 1
+          next
+        }
+      }
+    }
+
+    { print }
+  ' "$input_file" > "$tmp_file"
+
+  cp "$tmp_file" "$input_file"
+  rm -f "$tmp_file"
 }
 
 ensure_capslock_cancel_option "$input_file"

--- a/migrations/1781485962.sh
+++ b/migrations/1781485962.sh
@@ -93,6 +93,23 @@ if [[ -f $input_file ]] && input_is_stock_or_installer_synced "$input_file"; the
   replace_with_packaged_config input.lua
 fi
 
+# Ensure shift:both_capslock_cancel is in kb_options for users who customized
+# their keyboard options before Quattro. Without this, Caps Lock can get stuck
+# ON with no way to toggle it off. See #7255.
+ensure_capslock_cancel_option() {
+  local input_file="$1"
+  [[ -f $input_file ]] || return 0
+
+  local current_options
+  current_options=$(active_lua_string_value kb_options "$input_file")
+
+  if [[ -n $current_options && ! "$current_options" == *"shift:both_capslock_cancel"* ]]; then
+    sed -i "s/kb_options = \"$current_options\"/kb_options = \"$current_options,shift:both_capslock_cancel\"/" "$input_file"
+  fi
+}
+
+ensure_capslock_cancel_option "$input_file"
+
 bindings_file="$HOME/.config/hypr/bindings.lua"
 if [[ -f $bindings_file ]]; then
   case "$(file_sha "$bindings_file")" in


### PR DESCRIPTION
## Summary

This PR fixes a migration bug where users who customized `kb_options` before Quattro would not get the new `shift:both_capslock_cancel` option. Without this option, Caps Lock can get stuck ON with no way to toggle it off.

Fixes #7255

## Problem

The Quattro upgrade changed the default `kb_options` from:
```lua
kb_options = "compose:caps"
```
to:
```lua
kb_options = "compose:caps,shift:both_capslock_cancel"
```

The new `shift:both_capslock_cancel` option allows toggling Caps Lock via both Shifts. However, migration `1781485962.sh` preserves the user's existing `kb_options` value without adding the new option.

This creates two problems:
1. During upgrade: New defaults may be temporarily applied, potentially toggling Caps Lock ON
2. After upgrade: User's local config lacks `shift:both_capslock_cancel`, so there's no way to toggle it back OFF

## Solution

Added `ensure_capslock_cancel_option()` function to migration `1781485962.sh` that:
1. Reads current `kb_options` value from user's `input.lua`
2. If it exists but doesn't include `shift:both_capslock_cancel`, appends it
3. Preserves existing options

## Testing

Verified the fix handles these cases:
- `kb_options = "compose:caps"` → `kb_options = "compose:caps,shift:both_capslock_cancel"` ✓
- `kb_options = "compose:caps,grp:alts_toggle"` → `kb_options = "compose:caps,grp:alts_toggle,shift:both_capslock_cancel"` ✓
- `kb_options = "compose:caps,shift:both_capslock_cancel"` → (unchanged) ✓
- Empty `kb_options` → (unchanged) ✓