### PR TITLE
Restore early Thunderbolt authorization for LUKS unlock

### DIFF
--- a/etc/initcpio/hooks/thunderbolt_autoauth
+++ b/etc/initcpio/hooks/thunderbolt_autoauth
@@ -1,0 +1,38 @@
+#!/usr/bin/ash
+
+run_hook() {
+  local devices_path="${OMARCHY_THUNDERBOLT_DEVICES_PATH:-/sys/bus/thunderbolt/devices}"
+  local device authorized pending=0
+
+  [ -d "$devices_path" ] || return 0
+
+  for device in "$devices_path"/*; do
+    [ -d "$device" ] || continue
+    case "${device##*/}" in
+      domain* | *-0) continue ;;
+    esac
+    [ "$(cat "$device/authorized" 2>/dev/null)" = "0" ] || continue
+    pending=1
+    break
+  done
+
+  [ "$pending" = "1" ] || return 0
+
+  # Let KMS and the Thunderbolt topology settle before authorizing endpoints.
+  sleep 2
+
+  for device in "$devices_path"/*; do
+    [ -d "$device" ] || continue
+
+    # Skip domains and host routers; only attached devices need authorization.
+    case "${device##*/}" in
+      domain* | *-0) continue ;;
+    esac
+
+    authorized="$device/authorized"
+    [ -w "$authorized" ] || continue
+    [ "$(cat "$authorized" 2>/dev/null)" = "0" ] || continue
+
+    echo 1 > "$authorized" 2>/dev/null
+  done
+}

--- a/etc/initcpio/install/thunderbolt_autoauth
+++ b/etc/initcpio/install/thunderbolt_autoauth
@@ -8,5 +8,8 @@ help() {
   cat <<'EOF'
 Authorize Thunderbolt devices already connected at boot so their USB devices
 are available before the encrypted root password prompt.
+
+Security: every Thunderbolt endpoint connected during early boot is trusted.
+Devices connected after this hook runs are not authorized by it.
 EOF
 }

--- a/etc/initcpio/install/thunderbolt_autoauth
+++ b/etc/initcpio/install/thunderbolt_autoauth
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+build() {
+  add_runscript
+}
+
+help() {
+  cat <<'EOF'
+Authorize Thunderbolt devices already connected at boot so their USB devices
+are available before the encrypted root password prompt.
+EOF
+}

--- a/etc/mkinitcpio.conf.d/omarchy_hooks.conf
+++ b/etc/mkinitcpio.conf.d/omarchy_hooks.conf
@@ -1,4 +1,4 @@
-HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
+HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block thunderbolt_autoauth encrypt filesystems fsck btrfs-overlayfs)
 
 # The proprietary NVIDIA driver does early KMS itself: nvidia.conf (written by
 # install/hardware/nvidia.sh, sourced before this file) early-loads nvidia_drm

--- a/migrations/1786961462.sh
+++ b/migrations/1786961462.sh
@@ -1,0 +1,14 @@
+echo "Rebuild the initramfs with early Thunderbolt authorization"
+
+hooks_conf="${OMARCHY_THUNDERBOLT_HOOKS_CONF:-/etc/mkinitcpio.conf.d/omarchy_hooks.conf}"
+install_hook="${OMARCHY_THUNDERBOLT_INSTALL_HOOK:-/etc/initcpio/install/thunderbolt_autoauth}"
+runtime_hook="${OMARCHY_THUNDERBOLT_RUNTIME_HOOK:-/etc/initcpio/hooks/thunderbolt_autoauth}"
+rebuild_marker="${OMARCHY_THUNDERBOLT_REBUILD_MARKER:-/var/lib/omarchy/migrations/1786961462}"
+
+omarchy-cmd-present limine-mkinitcpio || exit 0
+[[ -f $hooks_conf && -f $install_hook && -f $runtime_hook ]] || exit 0
+grep -q ' thunderbolt_autoauth encrypt' "$hooks_conf" || exit 0
+[[ ! -e $rebuild_marker ]] || exit 0
+
+sudo limine-mkinitcpio
+sudo install -Dm644 /dev/null "$rebuild_marker"

--- a/test/shell.d/thunderbolt-autoauth-test.sh
+++ b/test/shell.d/thunderbolt-autoauth-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+install_hook="$ROOT/etc/initcpio/install/thunderbolt_autoauth"
+runtime_hook="$ROOT/etc/initcpio/hooks/thunderbolt_autoauth"
+migration="$ROOT/migrations/1786961462.sh"
+
+resolved_hooks=$(bash -uc "MODULES=(); FILES=(); XKBLAYOUT=us; source '$hooks_conf'; echo \"\${HOOKS[*]}\"")
+[[ $resolved_hooks == *" block thunderbolt_autoauth encrypt "* ]] ||
+  fail "Thunderbolt authorization runs immediately before encrypt" "actual: $resolved_hooks"
+(( $(grep -o 'thunderbolt_autoauth' <<<"$resolved_hooks" | wc -l) == 1 )) ||
+  fail "Thunderbolt authorization appears once in HOOKS" "actual: $resolved_hooks"
+pass "Thunderbolt authorization runs once immediately before encrypt"
+
+[[ $(bash -c 'add_runscript() { echo added; }; source "$1"; build' -- "$install_hook") == "added" ]] ||
+  fail "Thunderbolt install hook adds its runtime script"
+pass "Thunderbolt install hook adds its runtime script"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+devices="$test_tmp/devices"
+stub_bin="$test_tmp/bin"
+mkdir -p "$devices/domain0" "$devices/0-0" "$devices/0-1" "$devices/0-2" "$stub_bin"
+printf '0\n' > "$devices/0-0/authorized"
+printf '0\n' > "$devices/0-1/authorized"
+printf '1\n' > "$devices/0-2/authorized"
+
+cat > "$stub_bin/sleep" <<'EOF'
+#!/bin/bash
+echo sleep >> "$TEST_LOG"
+EOF
+chmod +x "$stub_bin/sleep"
+
+sleep_calls="$test_tmp/sleep.log"
+: > "$sleep_calls"
+PATH="$stub_bin:$PATH" TEST_LOG="$sleep_calls" OMARCHY_THUNDERBOLT_DEVICES_PATH="$devices" \
+  bash -c 'source "$1"; run_hook' -- "$runtime_hook"
+
+[[ $(<"$devices/0-0/authorized") == "0" ]] || fail "runtime hook leaves the host router alone"
+[[ $(<"$devices/0-1/authorized") == "1" ]] || fail "runtime hook authorizes an attached device"
+[[ $(<"$devices/0-2/authorized") == "1" ]] || fail "runtime hook preserves an authorized device"
+pass "runtime hook authorizes only attached unauthorized devices"
+
+empty_devices="$test_tmp/empty-devices"
+mkdir -p "$empty_devices"
+PATH="$stub_bin:$PATH" TEST_LOG="$sleep_calls" OMARCHY_THUNDERBOLT_DEVICES_PATH="$empty_devices" \
+  bash -c 'source "$1"; run_hook' -- "$runtime_hook"
+(( $(grep -c '^sleep$' "$sleep_calls") == 1 )) ||
+  fail "runtime hook adds no delay without a pending device" "$(cat "$sleep_calls")"
+pass "runtime hook adds no delay without a pending device"
+
+calls="$test_tmp/calls.log"
+marker="$test_tmp/rebuild-complete"
+: > "$calls"
+
+cat > "$stub_bin/omarchy-cmd-present" <<'EOF'
+#!/bin/bash
+[[ $1 == "limine-mkinitcpio" ]]
+EOF
+cat > "$stub_bin/limine-mkinitcpio" <<'EOF'
+#!/bin/bash
+echo limine-mkinitcpio >> "$TEST_LOG"
+EOF
+cat > "$stub_bin/sudo" <<'EOF'
+#!/bin/bash
+"$@"
+EOF
+chmod +x "$stub_bin"/*
+
+for _ in 1 2; do
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_THUNDERBOLT_HOOKS_CONF="$hooks_conf" \
+    OMARCHY_THUNDERBOLT_INSTALL_HOOK="$install_hook" \
+    OMARCHY_THUNDERBOLT_RUNTIME_HOOK="$runtime_hook" \
+    OMARCHY_THUNDERBOLT_REBUILD_MARKER="$marker" \
+    bash -euo pipefail "$migration" >/dev/null
+done
+
+(( $(grep -c '^limine-mkinitcpio$' "$calls") == 1 )) ||
+  fail "migration rebuilds the UKI exactly once" "$(cat "$calls")"
+[[ -f $marker ]] || fail "migration records the machine-wide rebuild"
+pass "migration rebuilds the UKI exactly once"


### PR DESCRIPTION
## Summary

Restore early authorization for Thunderbolt devices already connected at boot, allowing keyboards behind Thunderbolt/USB-C displays and docks to work at the LUKS prompt.

Omarchy already includes the Thunderbolt module in its UKI. The missing piece is authorizing the attached endpoint before `encrypt` asks for the disk password. Quattro's packaged `omarchy_hooks.conf` replaces `HOOKS`, so the machine-local hook previously used for this is no longer included.

## Changes

- Ship the small `thunderbolt_autoauth` mkinitcpio install and runtime hooks.
- Run the hook immediately before `encrypt`.
- Authorize only endpoints present during early boot; skip domains and host routers.
- Add no delay on systems without an endpoint awaiting authorization.
- Rebuild existing UKIs once through an idempotent migration.

## Security

This treats every Thunderbolt endpoint already connected during early boot as trusted. It does not authorize devices connected after the hook has run. This is the same trust model discussed in #934: entering the LUKS passphrase is considered implicit trust in the hardware attached at boot.

## Relation to #934

This is the focused early-boot part of #934 and supersedes that proposal.

#934 also changed userspace hotplug authorization, installed `bolt`, and added Hyprland ghost-display handling. None of those changes are included here. Omarchy now already ships the Thunderbolt module, so this PR only restores the missing authorization required for USB keyboards behind a Thunderbolt dock at LUKS unlock.

The hook has also been updated for Quattro: it is part of the packaged hook order instead of editing `/etc/mkinitcpio.conf`, which `omarchy_hooks.conf` now overrides. Related: #6876.

## Testing

- Verifies the hook occurs exactly once immediately before `encrypt`.
- Verifies only attached, unauthorized endpoints are authorized.
- Verifies existing systems rebuild their UKI exactly once.
- Confirmed on hardware with a NuPhy keyboard connected through an Apple Thunderbolt/USB hub: `lsinitcpio` reports `udev plymouth keymap thunderbolt_autoauth encrypt`, and the keyboard works at the LUKS prompt.
