### PR TITLE
Fix plugin reload stale qml

### DIFF
--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -114,7 +114,7 @@ else
   echo "Removed $id. Backup at: $backup"
 fi
 
-omarchy-shell shell rescanPlugins >/dev/null
+omarchy-restart-shell
 
 if [[ -n $cloned_from && $was_enabled == "true" ]]; then
   echo "Restored $cloned_from."

--- a/bin/omarchy-plugin-update
+++ b/bin/omarchy-plugin-update
@@ -128,6 +128,6 @@ for id in "${targets[@]}"; do
 done
 
 if (( UPDATED_ANY )); then
-  omarchy-shell shell rescanPlugins >/dev/null
+  omarchy-restart-shell
 fi
 exit $rc

--- a/test/shell.d/plugin-clone-test.sh
+++ b/test/shell.d/plugin-clone-test.sh
@@ -31,7 +31,7 @@ fi
 exit 0
 SH
 
-for command in omarchy-plugin-enable omarchy-notification-send fake-editor; do
+for command in omarchy-plugin-enable omarchy-notification-send fake-editor omarchy-restart-shell; do
   cat >"$TMPDIR/bin/$command" <<'SH'
 #!/bin/bash
 printf '%s %s\n' "${0##*/}" "$*" >>"$FAKE_CALLS"


### PR DESCRIPTION
refs #6981

### Regarding the issue:

I can confirm the issue is real with my own plugin (plugin-control): also, on a testing machine, I had omarchy running for a couple of days and the shell wasnt restarded during that time

next, after using `omarchy plugin remove <...>` plus `omarchy plugin add <...>`  on my plugin, I couldnt get it updated, and observed the stale behavior; the plugin update did not carry over properly 

### Regarding its solution

Essentially,  this is a question about plugin lifecycle management or so:

user could own the complete removal process as per the documentation, but then every plugin maintainer would have to add more lines to removal code in addition to the simple `omarchy plugin remove ...` a follow up on shell reloads is necessary, which would duplicate to over 300 plugins or so. also many might just forget, and silent bugs being introduced all the time 

integration into existing plugin removal seems (in some form or another) advantegous; not claiming this is the best way here, but its one with fewest lines of code changes I can think of atm. ; alternatives could be to elicit code parts from shell restart into the `omarchy plugin remove ...` but thats kinda duplication

not aware of strong side effects (overkill maybe, a bit heavier than needed; not dangerous in any form) stemming from `omarchy restart shell`; if so, duplication of code in `omarchy plugin remove ...` and change of exact behavior therein could be be better of course

