### PR TITLE
Sync the Midnight Commander skin with the active theme

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -194,6 +194,7 @@ post_theme_commands=(
   omarchy-restart-opencode
   omarchy-restart-helix
   omarchy-theme-set-foot
+  omarchy-theme-set-mc
   omarchy-theme-set-tmux
   omarchy-theme-set-gnome
   omarchy-theme-set-pi

--- a/bin/omarchy-theme-set-mc
+++ b/bin/omarchy-theme-set-mc
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Sync current Omarchy theme into the Midnight Commander skin
+# omarchy:hidden=true
+
+MC_SKIN_SOURCE="$HOME/.local/state/omarchy/current/theme/mc.ini"
+MC_SKIN_LINK="$HOME/.local/share/mc/skins/omarchy.ini"
+MC_INI="$HOME/.config/mc/ini"
+
+omarchy-cmd-present mc || exit 0
+[[ -f $MC_SKIN_SOURCE ]] || exit 0
+
+mkdir -p "$(dirname "$MC_SKIN_LINK")"
+ln -snf "$MC_SKIN_SOURCE" "$MC_SKIN_LINK"
+
+# Point mc at the generated skin without touching any other user setting.
+if [[ -f $MC_INI ]]; then
+  if grep -q '^skin=' "$MC_INI"; then
+    sed -i 's/^skin=.*/skin=omarchy/' "$MC_INI"
+  else
+    printf 'skin=omarchy\n' >>"$MC_INI"
+  fi
+else
+  mkdir -p "$(dirname "$MC_INI")"
+  printf '[Midnight-Commander]\nskin=omarchy\n' >"$MC_INI"
+fi

--- a/default/themed/mc.ini.tpl
+++ b/default/themed/mc.ini.tpl
@@ -1,0 +1,153 @@
+# Midnight Commander skin, rendered from the active Omarchy theme.
+# Applied via bin/omarchy-theme-set-mc.
+
+[skin]
+    description = Omarchy
+    truecolors = true
+
+[Lines]
+    horiz = ─
+    vert = │
+    lefttop = ┌
+    righttop = ┐
+    leftbottom = └
+    rightbottom = ┘
+    topmiddle = ┬
+    bottommiddle = ┴
+    leftmiddle = ├
+    rightmiddle = ┤
+    cross = ┼
+    dhoriz = ═
+    dvert = ║
+    dlefttop = ╔
+    drighttop = ╗
+    dleftbottom = ╚
+    drightbottom = ╝
+    dtopmiddle = ╤
+    dbottommiddle = ╧
+    dleftmiddle = ╟
+    drightmiddle = ╢
+
+[core]
+    _default_ = {{ foreground }};{{ background }}
+    selected = {{ bright_foreground }};{{ selection }}
+    marked = {{ yellow }};;bold
+    markselect = {{ yellow }};{{ selection }};bold
+    gauge = ;{{ accent }}
+    input = {{ foreground }};{{ muted }}
+    inputunchanged = {{ dark_foreground }};{{ muted }}
+    inputmark = {{ background }};{{ accent }}
+    disabled = {{ dark_foreground }};{{ lighter_background }}
+    reverse = {{ background }};{{ accent }}
+    commandlinemark = {{ background }};{{ accent }}
+    header = {{ accent }};;bold
+    shadow = {{ darker_background }};{{ dark_background }}
+
+[dialog]
+    _default_ = {{ foreground }};{{ lighter_background }}
+    dfocus = ;{{ muted }}
+    dhotnormal = {{ accent }};;underline
+    dhotfocus = {{ accent }};{{ muted }};underline
+    dtitle = {{ accent }};;bold
+
+[error]
+    _default_ = {{ bright_foreground }};{{ red }}
+    errdfocus = {{ background }};{{ bright_red }}
+    errdhotnormal = {{ background }};;underline
+    errdhotfocus = {{ background }};{{ bright_red }};underline
+    errdtitle = {{ background }};;bold
+
+[filehighlight]
+    directory = {{ blue }};;bold
+    executable = {{ green }}
+    symlink = {{ cyan }}
+    hardlink =
+    stalelink = {{ red }}
+    device = {{ magenta }}
+    special = {{ orange }}
+    core = {{ red }}
+    temp = {{ dark_foreground }}
+    archive = {{ magenta }}
+    doc = {{ brown }}
+    source = {{ cyan }}
+    media = {{ green }}
+    graph = {{ bright_cyan }}
+    database = {{ bright_red }}
+
+[menu]
+    _default_ = {{ foreground }};{{ lighter_background }}
+    menusel = {{ foreground }};{{ muted }}
+    menuhot = {{ accent }};{{ lighter_background }};underline
+    menuhotsel = {{ accent }};{{ muted }};underline
+    menuinactive = {{ dark_foreground }};{{ lighter_background }}
+
+[popupmenu]
+    _default_ = {{ foreground }};{{ lighter_background }}
+    menusel = {{ foreground }};{{ muted }}
+    menutitle = {{ accent }};;bold
+
+[buttonbar]
+    hotkey = {{ background }};{{ accent }}
+    button = {{ foreground }};{{ lighter_background }}
+
+[statusbar]
+    _default_ = {{ foreground }};{{ lighter_background }}
+
+[help]
+    _default_ = {{ foreground }};{{ lighter_background }}
+    helpbold = {{ accent }};;bold
+    helpitalic = {{ magenta }};;italic
+    helplink = {{ cyan }};;underline
+    helpslink = {{ lighter_background }};{{ cyan }}
+
+[editor]
+    _default_ = {{ foreground }};{{ background }}
+    editbold = {{ bright_yellow }};;bold
+    editmarked = ;{{ selection }}
+    editwhitespace = {{ dark_foreground }};{{ background }}
+    editnonprintable = {{ dark_foreground }};{{ background }}
+    editlinestate = {{ foreground }};{{ lighter_background }}
+    bookmark = {{ background }};{{ yellow }}
+    bookmarkfound = {{ background }};{{ orange }}
+    editrightmargin = {{ muted }};{{ background }}
+    editbg = ;{{ background }}
+    editframe = {{ dark_foreground }}
+    editframeactive = {{ accent }}
+    editframedrag = {{ green }}
+
+[viewer]
+    _default_ = {{ foreground }};{{ background }}
+    viewbold = {{ bright_foreground }};;bold
+    viewunderline = {{ cyan }};;underline
+    viewselected = {{ foreground }};{{ selection }}
+
+[diffviewer]
+    added = {{ background }};{{ green }}
+    changedline = ;{{ selection }}
+    changednew = {{ background }};{{ green }}
+    changed = ;{{ muted }}
+    removed = ;{{ muted }}
+    error = {{ bright_foreground }};{{ red }}
+
+[widget-panel]
+    sort-up-char = ▴
+    sort-down-char = ▾
+    hiddenfiles-show-char = •
+    hiddenfiles-hide-char = ○
+    history-prev-item-char = ◂
+    history-next-item-char = ▸
+    history-show-list-char = ▾
+    filename-scroll-left-char = ◂
+    filename-scroll-right-char = ▸
+
+[widget-scrollbar]
+    first-vert-char = ▴
+    last-vert-char = ▾
+    first-horiz-char = ◂
+    last-horiz-char = ▸
+    current-char = ■
+    background-char = ▒
+
+[widget-editor]
+    window-state-char = ↕
+    window-close-char = ✕


### PR DESCRIPTION
## What

Adds Midnight Commander (`mc`) to the set of apps whose colors follow the active Omarchy theme, using the same mechanism as the other themed apps:

- `default/themed/mc.ini.tpl` — a standard `{{ }}` template rendered automatically by the existing generic templating pipeline (`omarchy-theme-set-templates`), same as `btop.theme.tpl`, `foot.ini.tpl`, etc.
- `bin/omarchy-theme-set-mc` — a small script (mirrors `omarchy-theme-set-foot`/`omarchy-theme-set-tmux`) that symlinks `~/.local/share/mc/skins/omarchy.ini` to the rendered template and seeds `skin=omarchy` into the user's `~/.config/mc/ini` without touching any other setting there. No-ops via `omarchy-cmd-present mc` if mc isn't installed.
- Registered in `omarchy-theme-set`'s `post_theme_commands`, next to `omarchy-theme-set-foot`.

mc isn't in the base package set, same as Helix — this only activates for users who already have it installed (`omarchy-cmd-present mc`), it doesn't add mc to the install menu.

## Why

mc is a long-lived, widely-used TUI file manager (packaged in Arch's `extra` repo) that a fair number of terminal-first Omarchy users already run day to day. Right now it stays on whatever skin colors it started with and never follows the desktop theme.

## Scope note: no live reload

Stock `mc` only re-reads its skin file when it (re)starts, or when a user manually re-selects the same skin from Options > Appearance — it has no equivalent of btop's `SIGUSR2` or Helix's `SIGUSR1` live-reload signal. So `omarchy-theme-set-mc` only keeps the skin *file* in sync (like the config side of any other themed app); it doesn't attempt to force already-open mc windows to redraw, since restarting a user's mc session out from under them isn't something the app supports gracefully today.

I've also opened a companion PR upstream in Midnight Commander itself to add proper file-watching hot-reload support: MidnightCommander/mc#5141. If/when that lands and reaches distro packages, existing mc sessions here would start picking up theme changes live for free, no further change needed on the Omarchy side.

## Testing

- `./test/cli` and `./test/shell` — all pass (one pre-existing, unrelated failure in `config-test.sh` about a systemd service/PKGBUILD mapping; confirmed it fails identically on a clean `quattro` checkout without this change)
- Cross-checked every `{{ }}` key used in `mc.ini.tpl` against `omarchy-theme-color --all` output — all resolve
- Manually replicated `omarchy-theme-set-templates`'s exact substitution logic against `themes/tokyo-night/colors.toml`, rendered the template, pointed a real `mc` install at the result, and confirmed correct colors and box-drawing rendering in a running window