### PR TITLE
Run the shell on the Vulkan backend on primary NVIDIA GPUs

### DIFF
--- a/bin/omarchy-launch-shell
+++ b/bin/omarchy-launch-shell
@@ -14,8 +14,42 @@
 # A package upgrade rewriting $OMARCHY_PATH/shell would otherwise reload it
 # against a half-written tree, and that failed reload leaves a second engine
 # generation behind that turns the next restart's IPC kill into a crash.
+
+# Qt refuses threaded OpenGL rendering on the proprietary NVIDIA driver (the
+# QTBUG-95817 resize-freeze workaround in qtwayland), which drops Qt Quick to
+# the timer-driven basic render loop: every shell animation runs at ~60 fps
+# regardless of monitor refresh rate. The Vulkan scene graph backend is not
+# subject to that workaround and uses the vsync-driven threaded loop by
+# design, so prefer it where that bug actually applies. Forcing
+# QSG_RENDER_LOOP=threaded on GL instead would re-expose the very freeze the
+# vendor check protects against.
+#
+# The workaround only bites when the compositor's EGL stack is NVIDIA's, so
+# gate on the NVIDIA GPU being the primary display adapter: on hybrid laptops
+# with the iGPU driving the display, clients get Mesa's EGL, the threaded
+# loop stays available, and forcing Vulkan would only add cross-GPU risk for
+# no benefit. Turing-or-newer (GSP) limits this to the current driver family
+# with a solid Wayland Vulkan WSI; legacy branches keep today's behavior.
+nvidia_is_primary_gpu() {
+  local card
+
+  for card in /sys/class/drm/card*/device; do
+    [[ -f $card/boot_vga && $(< "$card/boot_vga") == 1 ]] || continue
+    [[ $(< "$card/vendor") == "0x10de" ]] && return 0
+  done
+
+  return 1
+}
+
+shell_render_env=()
+if [[ -f /usr/share/vulkan/icd.d/nvidia_icd.json ]] &&
+  "$OMARCHY_PATH/bin/omarchy-hw-nvidia-gsp" &&
+  nvidia_is_primary_gpu; then
+  shell_render_env=(QSG_RHI_BACKEND=vulkan)
+fi
+
 run_shell() {
-  QS_DISABLE_FILE_WATCHER=1 QS_NO_RELOAD_POPUP=1 \
+  QS_DISABLE_FILE_WATCHER=1 QS_NO_RELOAD_POPUP=1 env "${shell_render_env[@]}" \
     systemd-cat -t omarchy-shell -- quickshell -n -p "$OMARCHY_PATH/shell" &
   shell_pid=$!
 


### PR DESCRIPTION
Fixes #7268

On the proprietary NVIDIA driver, qtwayland reports threaded OpenGL as unsupported (the [QTBUG-95817](https://bugreports.qt.io/browse/QTBUG-95817) resize-freeze workaround), so Qt Quick drops to the timer-driven basic render loop and every shell animation runs at ~60 fps regardless of monitor refresh rate. On a 240 Hz monitor the bar measures 62 fps stock and 240 fps with the Vulkan scene graph backend, which is not subject to that workaround and uses the vsync-driven threaded loop by design (see the issue for videos with a live in-bar fps counter, per-frame analysis of 240 fps captures, and a one-command reproduction).

Why the Vulkan backend rather than forcing `QSG_RENDER_LOOP=threaded` on GL: the forced-threaded route re-exposes the very resize freeze the vendor check protects against, and an analogous setup is known to segfault on AMD iGPUs ([quickshell#720](https://github.com/quickshell-mirror/quickshell/issues/720)). For Vulkan, threaded is Qt's own default on every platform, so no driver workaround gets overridden. The shell's QML carries no raw GL, and quickshell maintains the Vulkan path of its native interop ([quickshell#648](https://github.com/quickshell-mirror/quickshell/issues/648)).

The switch is gated three ways and is a strict no-op everywhere the bug does not apply:

- the NVIDIA Vulkan ICD is installed (rules out nouveau and hardware without the proprietary driver);
- the GPU is Turing or newer, via `omarchy-hw-nvidia-gsp` (limits the change to the current driver family; legacy branches keep today's behavior);
- the NVIDIA GPU is the primary display adapter (on hybrid laptops with the iGPU driving the display, clients get Mesa's EGL, the threaded loop is available anyway, and forcing Vulkan would only add cross-GPU risk).

Testing:

- Reproduced and fixed on RTX 4090 (610.57.04, 4K@240); independently reproduced on RTX 5080. Two Mesa machines (radeonsi hardware, llvmpipe) confirm the default threaded loop and take the no-op path.
- 12+ hours on the Vulkan backend including overnight idle/screensaver cycles, the lock screen (ScreencopyView dmabuf interop on a dual-GPU system), and a full day of regular use.
- Both branches of the gate were exercised end-to-end with the patched launcher and a scrubbed environment: on this machine the gate alone sets the variable; with the hardware detector pointed at an empty sysfs path (`OMARCHY_PCI_DEVICES_PATH`) the shell starts with no QSG variables at all, confirming the no-op path (`env "${arr[@]}"` with an empty array expands to zero words).
- `test/all`: the cli suite passes. In the shell suite, config, snapper, and unowned-system-paths pass with sibling omarchy-pkgs/omarchy-iso checkouts in place; bar-icon-geometry fails identically on an unpatched quattro checkout, on both the GL and Vulkan backends, and at monitor scale 1 and 2 — a constant 0.59 px glyph-centering delta from this machine's font rasterization, unrelated to this change (which touches no rendering code, only the launch environment).





