### PR TITLE
Decode backgrounds at screen size instead of native resolution

### DIFF
--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -225,6 +225,13 @@ Item {
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: true
+        // Decode at the size this screen needs rather than the file's native
+        // resolution. PreserveAspectCrop makes sourceSize a cover bound, not a
+        // fit one, so the wallpaper still fills the panel. Without it an
+        // 7680x4320 background decodes to ~126 MB of RGBA on every machine
+        // regardless of display, and a transition holds three of these at once.
+        sourceSize.width: Math.round(width * Screen.devicePixelRatio)
+        sourceSize.height: Math.round(height * Screen.devicePixelRatio)
         onStatusChanged: {
           if (status === Image.Ready && root.finishingTransition) {
             root.incomingBackground = ""
@@ -243,6 +250,8 @@ Item {
         cache: false
         smooth: true
         mipmap: true
+        sourceSize.width: Math.round(width * Screen.devicePixelRatio)
+        sourceSize.height: Math.round(height * Screen.devicePixelRatio)
         visible: root.oldBackground !== "" && root.revealProgress < 1
         onStatusChanged: panel.maybeStartReveal()
       }
@@ -269,6 +278,8 @@ Item {
           cache: false
           smooth: true
           mipmap: true
+          sourceSize.width: Math.round(width * Screen.devicePixelRatio)
+          sourceSize.height: Math.round(height * Screen.devicePixelRatio)
           onStatusChanged: panel.maybeStartReveal()
         }
       }

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -97,8 +97,8 @@ Item {
       fillMode: Image.PreserveAspectCrop
       asynchronous: true
       cache: false
-      sourceSize.width: width
-      sourceSize.height: height
+      sourceSize.width: Math.round(width * Screen.devicePixelRatio)
+      sourceSize.height: Math.round(height * Screen.devicePixelRatio)
     }
 
     MultiEffect {


### PR DESCRIPTION
The background images set no `sourceSize`, so every wallpaper decodes at whatever resolution the file happens to be — on every machine, regardless of display. `vantablack/1-twisted-stairs` is 7680×4320, which is ~126 MB of RGBA, and a theme transition holds three images at once.

**Measured: peak RSS for an 8K background in a 1080p window drops from 208 MB to 114 MB.**

Screens get exactly what they can display — a 6K panel still decodes at 6K. This trades no resolution for memory; it only stops decoding pixels the display cannot show.

## Why constraining sourceSize is safe here

`sourceSize` normally scales an image to *fit*, which would be wrong under `PreserveAspectCrop` — a wide image on a narrow screen would load too small and get upscaled back to fill.

Qt special-cases this: with `PreserveAspectCrop`, `sourceSize` acts as a **cover** bound. Verified directly against a 3.03:1 source (the widest aspect shipped) in a 16:9 window — it loads at 6545×2160, the cover size, not the 3840×1267 fit size. Same in the other direction for a portrait source.

## Lock screen

`LockView` already constrained `sourceSize`, but in logical pixels. On a scaled display that decodes below the panel's device resolution and upscales the result — a soft lock wallpaper. Multiplying by `devicePixelRatio` matches what `Tray.qml` and `Menu.qml` already do.

## Testing

- `./test/shell` — all 180 files pass
- `qmllint` — no new warnings (32 before, 32 after)
- Offscreen QML harness confirms the image loads, covers the window, and decodes at screen size rather than native

**Not yet verified in the running shell.** Per `agents/skills/visual-verification.md` this needs a look at a live theme transition and lock screen before it leaves draft — I had no session to drive.