### PR TITLE
Switch between subscription accounts

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -26,7 +26,7 @@ declare -A ROUTE_IS_ALIAS
 declare -A BINARY_TO_KEY
 declare -A GROUP_DESCRIPTIONS
 
-GROUP_DESCRIPTIONS[agent]="AI coding agent usage data"
+GROUP_DESCRIPTIONS[agent]="AI coding agents, subscription accounts, and usage data"
 GROUP_DESCRIPTIONS[audio]="Audio input and output controls"
 GROUP_DESCRIPTIONS[bar]="Omarchy shell bar layout and settings"
 GROUP_DESCRIPTIONS[battery]="Battery status helpers"

--- a/bin/omarchy-agent-account
+++ b/bin/omarchy-agent-account
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# omarchy:summary=Print the active account for a subscription provider
+# omarchy:args=[provider]
+# omarchy:examples=omarchy agent account anthropic | omarchy agent account codex
+
+set -euo pipefail
+
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
+usage() {
+  echo "Usage: omarchy agent account [provider]"
+}
+
+if (( $# > 1 )); then
+  usage >&2
+  exit 1
+fi
+
+if (( $# == 1 )) && [[ $1 == "-h" || $1 == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if (( $# == 0 )); then
+  default_agent=$(omarchy-default-agent)
+  if [[ -z $default_agent ]]; then
+    account_found="false"
+    for provider in anthropic openai; do
+      agent_account_provider_load "$provider"
+      active=$(agent_account_active 2>/dev/null || true)
+      if [[ -n $active ]]; then
+        printf '%s: %s\n' "$AGENT_ACCOUNT_PROVIDER_NAME" "$active"
+        account_found="true"
+      fi
+    done
+    if [[ $account_found == "false" ]]; then
+      echo "No agent accounts are set up yet."
+    fi
+    exit 0
+  fi
+fi
+
+agent_account_load_selected_provider "${1:-}"
+agent_account_lock
+trap agent_account_cleanup EXIT
+agent_account_prepare_locked
+agent_account_active || true

--- a/bin/omarchy-agent-account-backends
+++ b/bin/omarchy-agent-account-backends
@@ -1,0 +1,752 @@
+#!/bin/bash
+
+agent_account_provider_load() {
+  local requested="$1"
+
+  case "$requested" in
+  anthropic | claude)
+    AGENT_ACCOUNT_PROVIDER_ID="anthropic"
+    AGENT_ACCOUNT_PROVIDER_NAME="Anthropic"
+    AGENT_ACCOUNT_CONFIG_SLOT="claude"
+    AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT="$HOME/.claude"
+    AGENT_ACCOUNT_SLOTS=(claude pi opencode)
+    ;;
+  openai | codex)
+    AGENT_ACCOUNT_PROVIDER_ID="openai"
+    AGENT_ACCOUNT_PROVIDER_NAME="OpenAI"
+    AGENT_ACCOUNT_CONFIG_SLOT="codex"
+    AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT="$HOME/.codex"
+    AGENT_ACCOUNT_SLOTS=(codex pi opencode)
+    ;;
+  *)
+    echo "Unknown subscription provider: $requested" >&2
+    return 1
+    ;;
+  esac
+
+  AGENT_ACCOUNT_MANAGED_ROOT="$HOME/.local/share/omarchy/agents/$AGENT_ACCOUNT_PROVIDER_ID"
+  AGENT_ACCOUNT_LOCK="$AGENT_ACCOUNT_MANAGED_ROOT/.lock"
+  AGENT_ACCOUNT_ADOPTION_MARKER="$AGENT_ACCOUNT_MANAGED_ROOT/.adopted"
+  AGENT_ACCOUNT_SWITCH_JOURNAL="$AGENT_ACCOUNT_MANAGED_ROOT/.switching.json"
+  AGENT_ACCOUNT_LEDGER_ROOT="$HOME/.local/state/omarchy/agents/switches"
+  AGENT_ACCOUNT_LEDGER="$AGENT_ACCOUNT_LEDGER_ROOT/$AGENT_ACCOUNT_PROVIDER_ID.json"
+}
+
+agent_account_slot_load() {
+  local slot="$1"
+
+  AGENT_ACCOUNT_SLOT_ID="$slot"
+  AGENT_ACCOUNT_SLOT_KIND=""
+  AGENT_ACCOUNT_SLOT_AUTH_FILE=""
+  AGENT_ACCOUNT_SLOT_AUTH_KEY=""
+  AGENT_ACCOUNT_SLOT_CONFIG_ENV=""
+  AGENT_ACCOUNT_SLOT_CREDENTIAL_FILE=""
+  AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=()
+  AGENT_ACCOUNT_SLOT_COMMAND=""
+  AGENT_ACCOUNT_SLOT_LOGIN_NOTE=""
+
+  case "$AGENT_ACCOUNT_PROVIDER_ID:$slot" in
+  anthropic:claude)
+    AGENT_ACCOUNT_SLOT_KIND="config-dir"
+    AGENT_ACCOUNT_SLOT_CONFIG_ENV="CLAUDE_CONFIG_DIR"
+    AGENT_ACCOUNT_SLOT_CREDENTIAL_FILE=".credentials.json"
+    AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=(claude auth login)
+    AGENT_ACCOUNT_SLOT_COMMAND="claude"
+    ;;
+  openai:codex)
+    AGENT_ACCOUNT_SLOT_KIND="config-dir"
+    AGENT_ACCOUNT_SLOT_CONFIG_ENV="CODEX_HOME"
+    AGENT_ACCOUNT_SLOT_CREDENTIAL_FILE="auth.json"
+    AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=(codex login)
+    AGENT_ACCOUNT_SLOT_COMMAND="codex"
+    ;;
+  anthropic:pi)
+    AGENT_ACCOUNT_SLOT_KIND="auth-key"
+    AGENT_ACCOUNT_SLOT_AUTH_FILE="$HOME/.pi/agent/auth.json"
+    AGENT_ACCOUNT_SLOT_AUTH_KEY="anthropic"
+    AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=(pi)
+    AGENT_ACCOUNT_SLOT_COMMAND="pi"
+    AGENT_ACCOUNT_SLOT_LOGIN_NOTE="In Pi, run /login and choose Claude Pro/Max, then exit Pi."
+    ;;
+  openai:pi)
+    AGENT_ACCOUNT_SLOT_KIND="auth-key"
+    AGENT_ACCOUNT_SLOT_AUTH_FILE="$HOME/.pi/agent/auth.json"
+    # Pi separates ChatGPT subscription OAuth from API-billed OpenAI auth.
+    AGENT_ACCOUNT_SLOT_AUTH_KEY="openai-codex"
+    AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=(pi)
+    AGENT_ACCOUNT_SLOT_COMMAND="pi"
+    AGENT_ACCOUNT_SLOT_LOGIN_NOTE="In Pi, run /login and choose ChatGPT Plus/Pro, then exit Pi."
+    ;;
+  anthropic:opencode)
+    AGENT_ACCOUNT_SLOT_KIND="auth-key"
+    AGENT_ACCOUNT_SLOT_AUTH_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json"
+    AGENT_ACCOUNT_SLOT_AUTH_KEY="anthropic"
+    AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=(opencode auth login --provider anthropic)
+    AGENT_ACCOUNT_SLOT_COMMAND="opencode"
+    ;;
+  openai:opencode)
+    AGENT_ACCOUNT_SLOT_KIND="auth-key"
+    AGENT_ACCOUNT_SLOT_AUTH_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json"
+    AGENT_ACCOUNT_SLOT_AUTH_KEY="openai"
+    AGENT_ACCOUNT_SLOT_LOGIN_COMMAND=(opencode auth login --provider openai)
+    AGENT_ACCOUNT_SLOT_COMMAND="opencode"
+    ;;
+  *)
+    echo "$AGENT_ACCOUNT_PROVIDER_NAME has no '$slot' credential slot." >&2
+    return 1
+    ;;
+  esac
+}
+
+agent_account_slot_installed() {
+  agent_account_slot_load "$1"
+  ! omarchy-cmd-missing "$AGENT_ACCOUNT_SLOT_COMMAND"
+}
+
+agent_account_is_known_provider() {
+  case "$1" in
+  anthropic | claude | openai | codex)
+    return 0
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+agent_account_load_selected_provider() {
+  local requested=${1:-}
+
+  if [[ -z $requested ]]; then
+    requested=$(omarchy-default-agent)
+    case "$requested" in
+    claude)
+      requested="anthropic"
+      ;;
+    codex)
+      requested="openai"
+      ;;
+    *)
+      echo "The default agent '$requested' does not select a subscription provider; pass anthropic or openai." >&2
+      return 1
+      ;;
+    esac
+  fi
+
+  agent_account_provider_load "$requested"
+}
+
+agent_account_prepare_managed_root() {
+  install -d -m 700 "$AGENT_ACCOUNT_MANAGED_ROOT"
+  chmod 700 "$AGENT_ACCOUNT_MANAGED_ROOT"
+}
+
+agent_account_lock() {
+  agent_account_prepare_managed_root
+  exec {AGENT_ACCOUNT_LOCK_FD}>"$AGENT_ACCOUNT_LOCK"
+  flock "$AGENT_ACCOUNT_LOCK_FD"
+}
+
+agent_account_unlock() {
+  if [[ -n ${AGENT_ACCOUNT_LOCK_FD:-} ]]; then
+    flock -u "$AGENT_ACCOUNT_LOCK_FD"
+    exec {AGENT_ACCOUNT_LOCK_FD}>&-
+    unset AGENT_ACCOUNT_LOCK_FD
+  fi
+}
+
+agent_account_cleanup() {
+  local status=$?
+
+  trap - EXIT
+  if [[ -n ${AGENT_ACCOUNT_LOCK_FD:-} ]]; then
+    if [[ -e $AGENT_ACCOUNT_SWITCH_JOURNAL ]]; then
+      agent_account_recover_switch_locked || status=1
+    fi
+    agent_account_unlock
+  fi
+  exit "$status"
+}
+
+agent_account_name_is_slug() {
+  [[ $1 =~ ^[a-z0-9][a-z0-9_-]{0,62}$ ]]
+}
+
+agent_account_validate_name() {
+  local name="$1"
+  local managed_root candidate
+
+  case "$name" in
+  . | .. | .lock | .trash)
+    echo "Invalid account name '$name': that name is reserved." >&2
+    return 1
+    ;;
+  esac
+
+  if agent_account_is_known_provider "$name"; then
+    echo "Invalid account name '$name': provider names and aliases are reserved." >&2
+    return 1
+  fi
+
+  if ! agent_account_name_is_slug "$name"; then
+    echo "Invalid account name '$name': use 1-63 lowercase letters, numbers, hyphens, or underscores." >&2
+    return 1
+  fi
+
+  managed_root=$(realpath -m -- "$AGENT_ACCOUNT_MANAGED_ROOT")
+  candidate=$(realpath -m -- "$AGENT_ACCOUNT_MANAGED_ROOT/$name")
+  if [[ $(dirname -- "$candidate") != "$managed_root" ]]; then
+    echo "Invalid account name '$name': its profile would escape the managed account root." >&2
+    return 1
+  fi
+}
+
+agent_account_profile_path() {
+  printf '%s/%s\n' "$AGENT_ACCOUNT_MANAGED_ROOT" "$1"
+}
+
+agent_account_config_path() {
+  printf '%s/%s\n' "$(agent_account_profile_path "$1")" "$AGENT_ACCOUNT_CONFIG_SLOT"
+}
+
+agent_account_slot_path() {
+  printf '%s/slots/%s.json\n' "$(agent_account_profile_path "$1")" "$2"
+}
+
+agent_account_profiles() {
+  [[ -d $AGENT_ACCOUNT_MANAGED_ROOT ]] || return 0
+
+  find "$AGENT_ACCOUNT_MANAGED_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.*' -printf '%f\n' | LC_ALL=C sort
+}
+
+agent_account_profile_exists() {
+  local profile
+
+  profile=$(agent_account_profile_path "$1")
+  [[ -d $profile && ! -L $profile && -d $profile/$AGENT_ACCOUNT_CONFIG_SLOT && ! -L $profile/$AGENT_ACCOUNT_CONFIG_SLOT ]]
+}
+
+agent_account_active() {
+  local target normalized_target normalized_root profile name
+
+  [[ -L $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]] || return 1
+  target=$(readlink -- "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT")
+  if [[ $target != /* ]]; then
+    target="$(dirname -- "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT")/$target"
+  fi
+
+  normalized_target=$(realpath -m -- "$target")
+  normalized_root=$(realpath -m -- "$AGENT_ACCOUNT_MANAGED_ROOT")
+  [[ $(basename -- "$normalized_target") == "$AGENT_ACCOUNT_CONFIG_SLOT" ]] || return 1
+
+  profile=$(dirname -- "$normalized_target")
+  [[ $(dirname -- "$profile") == "$normalized_root" ]] || return 1
+  name=$(basename -- "$profile")
+  agent_account_name_is_slug "$name" || return 1
+  [[ -d $profile && ! -L $profile && -d $normalized_target && ! -L $normalized_target ]] || return 1
+  printf '%s\n' "$name"
+}
+
+agent_account_provision_config_dir() {
+  local config_dir="$1"
+  local skill name
+
+  install -d -m 700 "$config_dir"
+  chmod 700 "$config_dir"
+  mkdir -p "$config_dir/skills"
+
+  for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
+    [[ -d $skill ]] || continue
+    skill=${skill%/}
+    name=${skill##*/}
+    ln -sfn "$skill" "$config_dir/skills/$name"
+  done
+}
+
+agent_account_provision_profile() {
+  local profile="$1"
+
+  install -d -m 700 "$profile"
+  chmod 700 "$profile"
+  agent_account_provision_config_dir "$profile/$AGENT_ACCOUNT_CONFIG_SLOT"
+}
+
+agent_account_provision_managed_profiles() {
+  local name
+
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    agent_account_provision_profile "$(agent_account_profile_path "$name")"
+  done < <(agent_account_profiles)
+}
+
+agent_account_config_roots() {
+  local roots=()
+  local name
+
+  while IFS= read -r name; do
+    [[ -n $name ]] && roots+=("$(agent_account_config_path "$name")")
+  done < <(agent_account_profiles)
+
+  if (( ${#roots[@]} > 0 )); then
+    printf '%s\n' "${roots[@]}"
+  else
+    printf '%s\n' "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT"
+  fi
+}
+
+agent_account_repoint_locked() {
+  local name="$1"
+  local config_dir tmp_link
+
+  agent_account_validate_name "$name" || return 1
+  if ! agent_account_profile_exists "$name"; then
+    echo "$AGENT_ACCOUNT_PROVIDER_NAME account '$name' does not exist." >&2
+    return 1
+  fi
+  config_dir=$(agent_account_config_path "$name")
+
+  if [[ -e $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT && ! -L $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]]; then
+    echo "Cannot switch $AGENT_ACCOUNT_PROVIDER_NAME accounts while $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT is not a managed symlink." >&2
+    return 1
+  fi
+
+  tmp_link="$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT.omarchy-account.tmp"
+  if [[ -e $tmp_link && ! -L $tmp_link ]]; then
+    echo "Cannot replace account link: unexpected path exists at $tmp_link." >&2
+    return 1
+  fi
+
+  rm -f -- "$tmp_link"
+  ln -s -- "$config_dir" "$tmp_link"
+  if ! mv -Tf -- "$tmp_link" "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT"; then
+    rm -f -- "$tmp_link"
+    return 1
+  fi
+}
+
+agent_account_auth_file_validate() {
+  local auth_file="$1"
+
+  if [[ -L $auth_file || -e $auth_file && ! -f $auth_file ]]; then
+    echo "Cannot manage credential keys in $auth_file because it is not a regular file." >&2
+    return 1
+  fi
+  if [[ -f $auth_file ]] && ! jq -e 'type == "object"' "$auth_file" >/dev/null; then
+    echo "Cannot manage credential keys in $auth_file because it is not a JSON object." >&2
+    return 1
+  fi
+}
+
+agent_account_auth_key_write() {
+  local auth_file="$1"
+  local auth_key="$2"
+  local credential_file=${3:-}
+  local auth_dir tmp
+
+  agent_account_auth_file_validate "$auth_file" || return 1
+  auth_dir=$(dirname -- "$auth_file")
+  install -d -m 700 "$auth_dir"
+  tmp=$(mktemp "$auth_dir/.auth.json.omarchy.XXXXXX")
+
+  if [[ -n $credential_file ]]; then
+    if ! jq -e 'type == "object"' "$credential_file" >/dev/null; then
+      rm -f -- "$tmp"
+      echo "Stored $AGENT_ACCOUNT_SLOT_ID credential is not a JSON object." >&2
+      return 1
+    fi
+    if [[ -f $auth_file ]]; then
+      if ! jq --arg key "$auth_key" --slurpfile credential "$credential_file" '.[$key] = $credential[0]' "$auth_file" >"$tmp"; then
+        rm -f -- "$tmp"
+        return 1
+      fi
+    else
+      if ! jq -n --arg key "$auth_key" --slurpfile credential "$credential_file" '{($key): $credential[0]}' >"$tmp"; then
+        rm -f -- "$tmp"
+        return 1
+      fi
+    fi
+  elif [[ -f $auth_file ]]; then
+    if ! jq --arg key "$auth_key" 'del(.[$key])' "$auth_file" >"$tmp"; then
+      rm -f -- "$tmp"
+      return 1
+    fi
+  else
+    printf '{}\n' >"$tmp"
+  fi
+
+  chmod 600 "$tmp"
+  mv -Tf -- "$tmp" "$auth_file"
+  chmod 600 "$auth_file"
+}
+
+agent_account_auth_slot_stash_locked() {
+  local account="$1"
+  local slot="$2"
+  local stored auth_dir tmp
+
+  agent_account_slot_load "$slot"
+  stored=$(agent_account_slot_path "$account" "$slot")
+  agent_account_auth_file_validate "$AGENT_ACCOUNT_SLOT_AUTH_FILE" || return 1
+
+  if [[ -f $AGENT_ACCOUNT_SLOT_AUTH_FILE ]] &&
+    jq -e --arg key "$AGENT_ACCOUNT_SLOT_AUTH_KEY" '.[$key] != null' "$AGENT_ACCOUNT_SLOT_AUTH_FILE" >/dev/null; then
+    if ! jq -e --arg key "$AGENT_ACCOUNT_SLOT_AUTH_KEY" '(.[$key] | type) == "object"' "$AGENT_ACCOUNT_SLOT_AUTH_FILE" >/dev/null; then
+      echo "Cannot stash $slot because its $AGENT_ACCOUNT_SLOT_AUTH_KEY credential is not a JSON object." >&2
+      return 1
+    fi
+
+    auth_dir=$(dirname -- "$stored")
+    install -d -m 700 "$auth_dir"
+    chmod 700 "$auth_dir"
+    tmp=$(mktemp "$auth_dir/.$slot.json.XXXXXX")
+    if ! jq -c --arg key "$AGENT_ACCOUNT_SLOT_AUTH_KEY" '.[$key]' "$AGENT_ACCOUNT_SLOT_AUTH_FILE" >"$tmp"; then
+      rm -f -- "$tmp"
+      return 1
+    fi
+    chmod 600 "$tmp"
+    mv -Tf -- "$tmp" "$stored"
+    chmod 600 "$stored"
+  else
+    rm -f -- "$stored"
+  fi
+}
+
+agent_account_stash_auth_slots_locked() {
+  local account="$1"
+  local slot
+
+  for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
+    if agent_account_slot_installed "$slot" && [[ $AGENT_ACCOUNT_SLOT_KIND == "auth-key" ]]; then
+      agent_account_auth_slot_stash_locked "$account" "$slot"
+    fi
+  done
+}
+
+agent_account_restore_auth_slots_locked() {
+  local account="$1"
+  local slot stored
+
+  for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
+    if agent_account_slot_installed "$slot" && [[ $AGENT_ACCOUNT_SLOT_KIND == "auth-key" ]]; then
+      stored=$(agent_account_slot_path "$account" "$slot")
+      if [[ -f $stored && ! -L $stored ]]; then
+        agent_account_auth_key_write "$AGENT_ACCOUNT_SLOT_AUTH_FILE" "$AGENT_ACCOUNT_SLOT_AUTH_KEY" "$stored"
+      else
+        agent_account_auth_key_write "$AGENT_ACCOUNT_SLOT_AUTH_FILE" "$AGENT_ACCOUNT_SLOT_AUTH_KEY"
+      fi
+    fi
+  done
+}
+
+agent_account_slot_filled() {
+  local account="$1"
+  local slot="$2"
+  local credential
+
+  agent_account_slot_load "$slot"
+  if [[ $AGENT_ACCOUNT_SLOT_KIND == "config-dir" ]]; then
+    credential="$(agent_account_config_path "$account")/$AGENT_ACCOUNT_SLOT_CREDENTIAL_FILE"
+  else
+    credential=$(agent_account_slot_path "$account" "$slot")
+  fi
+
+  [[ -f $credential && ! -L $credential ]] && jq -e 'type == "object" and length > 0' "$credential" >/dev/null
+}
+
+agent_account_missing_slots() {
+  local account="$1"
+  local slot
+
+  for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
+    if agent_account_slot_installed "$slot" && ! agent_account_slot_filled "$account" "$slot"; then
+      printf '%s\n' "$slot"
+    fi
+  done
+}
+
+agent_account_has_filled_slot() {
+  local account="$1"
+  local slot
+
+  for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
+    if agent_account_slot_installed "$slot" && agent_account_slot_filled "$account" "$slot"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+agent_account_report_missing_slots() {
+  local account="$1"
+  shift
+  local slot
+
+  for slot in "$@"; do
+    printf '  %s: omarchy agent account login %s %s %s\n' "$slot" "$AGENT_ACCOUNT_PROVIDER_ID" "$account" "$slot" >&2
+  done
+}
+
+agent_account_check_switch_slots_locked() {
+  local account="$1"
+  local missing=()
+
+  mapfile -t missing < <(agent_account_missing_slots "$account")
+  if ! agent_account_has_filled_slot "$account"; then
+    echo "$AGENT_ACCOUNT_PROVIDER_NAME account '$account' has no filled credential slots." >&2
+    agent_account_report_missing_slots "$account" "${missing[@]}"
+    return 1
+  fi
+  if (( ${#missing[@]} > 0 )); then
+    echo "$AGENT_ACCOUNT_PROVIDER_NAME account '$account' has empty installed credential slots:" >&2
+    agent_account_report_missing_slots "$account" "${missing[@]}"
+  fi
+}
+
+agent_account_atomic_marker_write() {
+  local path="$1"
+  local value="$2"
+  local dir tmp
+
+  dir=$(dirname -- "$path")
+  install -d -m 700 "$dir"
+  tmp=$(mktemp "$dir/.marker.XXXXXX")
+  printf '%s\n' "$value" >"$tmp"
+  chmod 600 "$tmp"
+  mv -Tf -- "$tmp" "$path"
+}
+
+agent_account_record_switch_locked() {
+  local account="$1"
+  local tmp timestamp
+
+  install -d -m 700 "$AGENT_ACCOUNT_LEDGER_ROOT"
+  chmod 700 "$AGENT_ACCOUNT_LEDGER_ROOT"
+  if [[ -L $AGENT_ACCOUNT_LEDGER || -e $AGENT_ACCOUNT_LEDGER && ! -f $AGENT_ACCOUNT_LEDGER ]]; then
+    echo "Cannot write switch ledger because $AGENT_ACCOUNT_LEDGER is not a regular file." >&2
+    return 1
+  fi
+  if [[ -f $AGENT_ACCOUNT_LEDGER ]] && ! jq -e 'type == "array"' "$AGENT_ACCOUNT_LEDGER" >/dev/null; then
+    echo "Cannot write switch ledger because $AGENT_ACCOUNT_LEDGER is not a JSON array." >&2
+    return 1
+  fi
+
+  timestamp=$(date --utc +'%Y-%m-%dT%H:%M:%SZ')
+  tmp=$(mktemp "$AGENT_ACCOUNT_LEDGER_ROOT/.$AGENT_ACCOUNT_PROVIDER_ID.json.XXXXXX")
+  if [[ -f $AGENT_ACCOUNT_LEDGER ]]; then
+    if ! jq \
+      --arg timestamp "$timestamp" \
+      --arg providerId "$AGENT_ACCOUNT_PROVIDER_ID" \
+      --arg accountId "$account" \
+      '. + [{timestamp: $timestamp, providerId: $providerId, accountId: $accountId}]' \
+      "$AGENT_ACCOUNT_LEDGER" >"$tmp"; then
+      rm -f -- "$tmp"
+      return 1
+    fi
+  else
+    jq -n \
+      --arg timestamp "$timestamp" \
+      --arg providerId "$AGENT_ACCOUNT_PROVIDER_ID" \
+      --arg accountId "$account" \
+      '[{timestamp: $timestamp, providerId: $providerId, accountId: $accountId}]' >"$tmp"
+  fi
+  chmod 600 "$tmp"
+  mv -Tf -- "$tmp" "$AGENT_ACCOUNT_LEDGER"
+  chmod 600 "$AGENT_ACCOUNT_LEDGER"
+}
+
+agent_account_begin_switch_locked() {
+  local from="$1"
+  local to="$2"
+  local tmp
+
+  tmp=$(mktemp "$AGENT_ACCOUNT_MANAGED_ROOT/.switching.json.XXXXXX")
+  jq -n --arg from "$from" --arg to "$to" '{from: $from, to: $to}' >"$tmp"
+  chmod 600 "$tmp"
+  mv -Tf -- "$tmp" "$AGENT_ACCOUNT_SWITCH_JOURNAL"
+}
+
+agent_account_recover_switch_locked() {
+  local from
+
+  [[ -e $AGENT_ACCOUNT_SWITCH_JOURNAL ]] || return 0
+  if [[ -L $AGENT_ACCOUNT_SWITCH_JOURNAL || ! -f $AGENT_ACCOUNT_SWITCH_JOURNAL ]] ||
+    ! jq -e 'type == "object" and (.from | type == "string") and (.to | type == "string")' "$AGENT_ACCOUNT_SWITCH_JOURNAL" >/dev/null; then
+    echo "Cannot recover the interrupted $AGENT_ACCOUNT_PROVIDER_NAME switch because $AGENT_ACCOUNT_SWITCH_JOURNAL is invalid." >&2
+    return 1
+  fi
+
+  from=$(jq -r '.from' "$AGENT_ACCOUNT_SWITCH_JOURNAL")
+  if [[ -n $from ]]; then
+    agent_account_validate_name "$from" || return 1
+    if ! agent_account_profile_exists "$from"; then
+      echo "Cannot recover the interrupted $AGENT_ACCOUNT_PROVIDER_NAME switch because account '$from' is missing." >&2
+      return 1
+    fi
+    agent_account_restore_auth_slots_locked "$from"
+    agent_account_repoint_locked "$from"
+    agent_account_record_switch_locked "$from"
+  else
+    agent_account_restore_auth_slots_locked ""
+    if [[ -L $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]]; then
+      rm -f -- "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT"
+    elif [[ -e $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]]; then
+      echo "Cannot recover the interrupted $AGENT_ACCOUNT_PROVIDER_NAME switch because $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT is not a symlink." >&2
+      return 1
+    fi
+  fi
+
+  rm -f -- "$AGENT_ACCOUNT_SWITCH_JOURNAL"
+}
+
+agent_account_adopt_config_locked() {
+  local active=""
+  local target normalized_target normalized_root profile name default_profile default_config
+
+  active=$(agent_account_active 2>/dev/null || true)
+  if [[ -n $active ]]; then
+    agent_account_provision_managed_profiles
+    return 0
+  fi
+
+  if [[ -L $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]]; then
+    target=$(readlink -- "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT")
+    if [[ $target != /* ]]; then
+      target="$(dirname -- "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT")/$target"
+    fi
+    normalized_target=$(realpath -m -- "$target")
+    normalized_root=$(realpath -m -- "$AGENT_ACCOUNT_MANAGED_ROOT")
+    profile=$(dirname -- "$normalized_target")
+
+    if [[ $(basename -- "$normalized_target") != "$AGENT_ACCOUNT_CONFIG_SLOT" || $(dirname -- "$profile") != "$normalized_root" ]]; then
+      echo "Cannot adopt $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT because it is a symlink outside Omarchy's managed account root." >&2
+      return 1
+    fi
+
+    name=$(basename -- "$profile")
+    agent_account_validate_name "$name" || return 1
+    if [[ -e $profile && ! -d $profile || -L $profile ]]; then
+      echo "Cannot repair $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT because its account profile is not a directory." >&2
+      return 1
+    fi
+    if [[ -e $normalized_target && ! -d $normalized_target || -L $normalized_target ]]; then
+      echo "Cannot repair $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT because its config slot is not a directory." >&2
+      return 1
+    fi
+
+    agent_account_provision_profile "$profile"
+    agent_account_provision_managed_profiles
+    return 0
+  fi
+
+  if [[ -e $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT && ! -d $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]]; then
+    echo "Cannot adopt $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT because it is not a directory." >&2
+    return 1
+  fi
+
+  default_profile=$(agent_account_profile_path default)
+  default_config=$(agent_account_config_path default)
+  if [[ -d $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT ]]; then
+    if [[ -L $default_profile || -e $default_profile && ! -d $default_profile ]]; then
+      echo "Cannot adopt $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT because the managed 'default' account is not a directory." >&2
+      return 1
+    fi
+    install -d -m 700 "$default_profile"
+    chmod 700 "$default_profile"
+    if [[ -e $default_config || -L $default_config ]]; then
+      echo "Cannot adopt $AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT because the managed 'default' config slot already exists." >&2
+      return 1
+    fi
+
+    mv -T -- "$AGENT_ACCOUNT_CONFIG_CANONICAL_ROOT" "$default_config"
+    chmod 700 "$default_config"
+    agent_account_repoint_locked default
+  elif [[ -d $default_config && ! -L $default_config ]]; then
+    agent_account_repoint_locked default
+  fi
+
+  agent_account_provision_managed_profiles
+}
+
+agent_account_prepare_locked() {
+  local active
+
+  agent_account_adopt_config_locked
+  agent_account_recover_switch_locked
+  active=$(agent_account_active 2>/dev/null || true)
+  if [[ -n $active && ! -e $AGENT_ACCOUNT_ADOPTION_MARKER ]]; then
+    agent_account_stash_auth_slots_locked "$active"
+    agent_account_record_switch_locked "$active"
+    agent_account_atomic_marker_write "$AGENT_ACCOUNT_ADOPTION_MARKER" "$active"
+  elif [[ -L $AGENT_ACCOUNT_ADOPTION_MARKER || -e $AGENT_ACCOUNT_ADOPTION_MARKER && ! -f $AGENT_ACCOUNT_ADOPTION_MARKER ]]; then
+    echo "Cannot finish $AGENT_ACCOUNT_PROVIDER_NAME adoption because $AGENT_ACCOUNT_ADOPTION_MARKER is invalid." >&2
+    return 1
+  fi
+}
+
+agent_account_create_locked() {
+  local name="$1"
+  local profile
+
+  agent_account_validate_name "$name" || return 1
+  profile=$(agent_account_profile_path "$name")
+  if [[ -e $profile || -L $profile ]]; then
+    if [[ ! -d $profile || -L $profile ]]; then
+      echo "Cannot use $AGENT_ACCOUNT_PROVIDER_NAME account '$name': its managed profile is not a directory." >&2
+      return 1
+    fi
+  else
+    install -d -m 700 "$profile"
+  fi
+
+  agent_account_provision_profile "$profile"
+}
+
+agent_account_switch_locked() {
+  local name="$1"
+  local check_slots=${2:-true}
+  local active
+
+  agent_account_validate_name "$name" || return 1
+  if ! agent_account_profile_exists "$name"; then
+    echo "$AGENT_ACCOUNT_PROVIDER_NAME account '$name' does not exist." >&2
+    return 1
+  fi
+  if [[ $check_slots == "true" ]]; then
+    agent_account_check_switch_slots_locked "$name" || return 1
+  fi
+
+  active=$(agent_account_active 2>/dev/null || true)
+  if [[ -n $active ]]; then
+    agent_account_stash_auth_slots_locked "$active"
+  fi
+
+  agent_account_begin_switch_locked "$active" "$name"
+  agent_account_restore_auth_slots_locked "$name"
+  agent_account_repoint_locked "$name"
+  if [[ $active != "$name" ]]; then
+    agent_account_record_switch_locked "$name"
+  fi
+  if [[ ! -e $AGENT_ACCOUNT_ADOPTION_MARKER ]]; then
+    agent_account_atomic_marker_write "$AGENT_ACCOUNT_ADOPTION_MARKER" "$name"
+  fi
+  rm -f -- "$AGENT_ACCOUNT_SWITCH_JOURNAL"
+}
+
+agent_account_capture_login_slot_locked() {
+  local account="$1"
+  local slot="$2"
+
+  agent_account_slot_load "$slot"
+  if [[ $AGENT_ACCOUNT_SLOT_KIND == "auth-key" ]]; then
+    agent_account_auth_slot_stash_locked "$account" "$slot"
+  fi
+  if ! agent_account_slot_filled "$account" "$slot"; then
+    echo "$AGENT_ACCOUNT_SLOT_ID did not write a $AGENT_ACCOUNT_PROVIDER_NAME credential; the slot is still empty." >&2
+    return 1
+  fi
+}
+
+agent_account_refresh_shell() {
+  omarchy-shell -q omarchy.agents refresh >/dev/null 2>&1 || true
+}

--- a/bin/omarchy-agent-account-list
+++ b/bin/omarchy-agent-account-list
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=List a provider's accounts, slot readiness, and active account
+# omarchy:summary=List subscription accounts, slot readiness, and active accounts
 # omarchy:args=[provider] [--json]
 # omarchy:examples=omarchy agent account list anthropic | omarchy agent account list openai --json
 
@@ -34,64 +34,91 @@ while (( $# > 0 )); do
   shift
 done
 
-agent_account_load_selected_provider "$requested"
-agent_account_lock
 trap agent_account_cleanup EXIT
-agent_account_prepare_locked
 
-active=$(agent_account_active 2>/dev/null || true)
-mapfile -t accounts < <(agent_account_profiles)
+list_provider() {
+  local provider="$1"
+  local active account account_active slot_rows slot filled marker
+  local accounts=()
+
+  agent_account_provider_load "$provider"
+  agent_account_lock
+  agent_account_prepare_locked
+
+  active=$(agent_account_active 2>/dev/null || true)
+  mapfile -t accounts < <(agent_account_profiles)
+
+  if [[ $json == "true" ]]; then
+    for account in "${accounts[@]}"; do
+      if [[ $account == $active ]]; then
+        account_active="true"
+      else
+        account_active="false"
+      fi
+
+      slot_rows=$(
+        for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
+          agent_account_slot_installed "$slot" || continue
+          if agent_account_slot_filled "$account" "$slot"; then
+            filled="true"
+          else
+            filled="false"
+          fi
+          jq -cn \
+            --arg slotId "$slot" \
+            --argjson filled "$filled" \
+            --arg loginCommand "omarchy agent account login $AGENT_ACCOUNT_PROVIDER_ID $account $slot" \
+            '{slotId: $slotId, filled: $filled, loginCommand: $loginCommand}'
+        done | jq -s '.'
+      )
+
+      jq -cn \
+        --arg providerId "$AGENT_ACCOUNT_PROVIDER_ID" \
+        --arg providerName "$AGENT_ACCOUNT_PROVIDER_NAME" \
+        --arg accountId "$account" \
+        --arg accountLabel "$account" \
+        --argjson accountActive "$account_active" \
+        --argjson slotRows "$slot_rows" \
+        '{
+          providerId: $providerId,
+          providerName: $providerName,
+          accountId: $accountId,
+          accountLabel: $accountLabel,
+          accountActive: $accountActive,
+          slots: ($slotRows | map({key: .slotId, value: {filled: .filled, loginCommand: .loginCommand}}) | from_entries),
+          missingSlots: ($slotRows | map(select(.filled | not) | .slotId))
+        }'
+    done
+  else
+    for account in "${accounts[@]}"; do
+      if [[ $account == $active ]]; then
+        marker="*"
+      else
+        marker=" "
+      fi
+      printf '%s %s %s\n' "$marker" "$AGENT_ACCOUNT_PROVIDER_ID" "$account"
+      while IFS= read -r slot; do
+        [[ -n $slot ]] || continue
+        printf '    missing %s: omarchy agent account login %s %s %s\n' "$slot" "$AGENT_ACCOUNT_PROVIDER_ID" "$account" "$slot"
+      done < <(agent_account_missing_slots "$account")
+    done
+  fi
+
+  agent_account_unlock
+}
+
+if [[ -n $requested ]]; then
+  providers=("$requested")
+else
+  providers=(anthropic openai)
+fi
 
 if [[ $json == "true" ]]; then
-  for account in "${accounts[@]}"; do
-    if [[ $account == $active ]]; then
-      account_active="true"
-    else
-      account_active="false"
-    fi
-
-    slot_rows=$(
-      for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
-        agent_account_slot_installed "$slot" || continue
-        if agent_account_slot_filled "$account" "$slot"; then
-          filled="true"
-        else
-          filled="false"
-        fi
-        jq -cn \
-          --arg slotId "$slot" \
-          --argjson filled "$filled" \
-          --arg loginCommand "omarchy agent account login $AGENT_ACCOUNT_PROVIDER_ID $account $slot" \
-          '{slotId: $slotId, filled: $filled, loginCommand: $loginCommand}'
-      done | jq -s '.'
-    )
-
-    jq -cn \
-      --arg providerId "$AGENT_ACCOUNT_PROVIDER_ID" \
-      --arg accountId "$account" \
-      --arg accountLabel "$account" \
-      --argjson accountActive "$account_active" \
-      --argjson slotRows "$slot_rows" \
-      '{
-        providerId: $providerId,
-        accountId: $accountId,
-        accountLabel: $accountLabel,
-        accountActive: $accountActive,
-        slots: ($slotRows | map({key: .slotId, value: {filled: .filled, loginCommand: .loginCommand}}) | from_entries),
-        missingSlots: ($slotRows | map(select(.filled | not) | .slotId))
-      }'
+  for provider in "${providers[@]}"; do
+    list_provider "$provider"
   done | jq -s '.'
 else
-  for account in "${accounts[@]}"; do
-    if [[ $account == $active ]]; then
-      marker="*"
-    else
-      marker=" "
-    fi
-    printf '%s %s %s\n' "$marker" "$AGENT_ACCOUNT_PROVIDER_ID" "$account"
-    while IFS= read -r slot; do
-      [[ -n $slot ]] || continue
-      printf '    missing %s: omarchy agent account login %s %s %s\n' "$slot" "$AGENT_ACCOUNT_PROVIDER_ID" "$account" "$slot"
-    done < <(agent_account_missing_slots "$account")
+  for provider in "${providers[@]}"; do
+    list_provider "$provider"
   done
 fi

--- a/bin/omarchy-agent-account-list
+++ b/bin/omarchy-agent-account-list
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# omarchy:summary=List a provider's accounts, slot readiness, and active account
+# omarchy:args=[provider] [--json]
+# omarchy:examples=omarchy agent account list anthropic | omarchy agent account list openai --json
+
+set -euo pipefail
+
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
+usage() {
+  echo "Usage: omarchy agent account list [provider] [--json]"
+}
+
+json="false"
+requested=""
+while (( $# > 0 )); do
+  case "$1" in
+  --json)
+    json="true"
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    if [[ -n $requested ]]; then
+      usage >&2
+      exit 1
+    fi
+    requested="$1"
+    ;;
+  esac
+  shift
+done
+
+agent_account_load_selected_provider "$requested"
+agent_account_lock
+trap agent_account_cleanup EXIT
+agent_account_prepare_locked
+
+active=$(agent_account_active 2>/dev/null || true)
+mapfile -t accounts < <(agent_account_profiles)
+
+if [[ $json == "true" ]]; then
+  for account in "${accounts[@]}"; do
+    if [[ $account == $active ]]; then
+      account_active="true"
+    else
+      account_active="false"
+    fi
+
+    slot_rows=$(
+      for slot in "${AGENT_ACCOUNT_SLOTS[@]}"; do
+        agent_account_slot_installed "$slot" || continue
+        if agent_account_slot_filled "$account" "$slot"; then
+          filled="true"
+        else
+          filled="false"
+        fi
+        jq -cn \
+          --arg slotId "$slot" \
+          --argjson filled "$filled" \
+          --arg loginCommand "omarchy agent account login $AGENT_ACCOUNT_PROVIDER_ID $account $slot" \
+          '{slotId: $slotId, filled: $filled, loginCommand: $loginCommand}'
+      done | jq -s '.'
+    )
+
+    jq -cn \
+      --arg providerId "$AGENT_ACCOUNT_PROVIDER_ID" \
+      --arg accountId "$account" \
+      --arg accountLabel "$account" \
+      --argjson accountActive "$account_active" \
+      --argjson slotRows "$slot_rows" \
+      '{
+        providerId: $providerId,
+        accountId: $accountId,
+        accountLabel: $accountLabel,
+        accountActive: $accountActive,
+        slots: ($slotRows | map({key: .slotId, value: {filled: .filled, loginCommand: .loginCommand}}) | from_entries),
+        missingSlots: ($slotRows | map(select(.filled | not) | .slotId))
+      }'
+  done | jq -s '.'
+else
+  for account in "${accounts[@]}"; do
+    if [[ $account == $active ]]; then
+      marker="*"
+    else
+      marker=" "
+    fi
+    printf '%s %s %s\n' "$marker" "$AGENT_ACCOUNT_PROVIDER_ID" "$account"
+    while IFS= read -r slot; do
+      [[ -n $slot ]] || continue
+      printf '    missing %s: omarchy agent account login %s %s %s\n' "$slot" "$AGENT_ACCOUNT_PROVIDER_ID" "$account" "$slot"
+    done < <(agent_account_missing_slots "$account")
+  done
+fi

--- a/bin/omarchy-agent-account-login
+++ b/bin/omarchy-agent-account-login
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# omarchy:summary=Fill one harness credential slot for a provider account
+# omarchy:args=[provider] <account> <slot>
+# omarchy:examples=omarchy agent account login anthropic work claude | omarchy agent account login openai personal pi
+
+set -euo pipefail
+
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
+usage() {
+  echo "Usage: omarchy agent account login [provider] <account> <slot>"
+}
+
+run_slot_login() {
+  local provider="$1"
+  local account="$2"
+  local slot="$3"
+  local config_dir status missing=()
+
+  agent_account_provider_load "$provider"
+  agent_account_validate_name "$account"
+  agent_account_slot_load "$slot"
+  if ! agent_account_slot_installed "$slot"; then
+    echo "$slot is not installed, so Omarchy cannot fill its $AGENT_ACCOUNT_PROVIDER_NAME credential slot." >&2
+    return 1
+  fi
+  agent_account_lock
+  trap agent_account_cleanup EXIT
+  agent_account_prepare_locked
+  agent_account_create_locked "$account"
+  agent_account_switch_locked "$account" false
+  agent_account_slot_load "$slot"
+
+  if [[ -n $AGENT_ACCOUNT_SLOT_LOGIN_NOTE ]]; then
+    printf '%s\n\n' "$AGENT_ACCOUNT_SLOT_LOGIN_NOTE"
+  fi
+
+  set +e
+  if [[ $AGENT_ACCOUNT_SLOT_KIND == "config-dir" ]]; then
+    config_dir=$(agent_account_config_path "$account")
+    env "$AGENT_ACCOUNT_SLOT_CONFIG_ENV=$config_dir" "${AGENT_ACCOUNT_SLOT_LOGIN_COMMAND[@]}"
+  else
+    "${AGENT_ACCOUNT_SLOT_LOGIN_COMMAND[@]}"
+  fi
+  status=$?
+  set -e
+
+  agent_account_capture_login_slot_locked "$account" "$slot"
+  mapfile -t missing < <(agent_account_missing_slots "$account")
+  if (( ${#missing[@]} > 0 )); then
+    echo "$AGENT_ACCOUNT_PROVIDER_NAME account '$account' has empty installed credential slots:" >&2
+    agent_account_report_missing_slots "$account" "${missing[@]}"
+  fi
+
+  agent_account_unlock
+  trap - EXIT
+  agent_account_refresh_shell
+  if (( status != 0 )); then
+    return "$status"
+  fi
+}
+
+if (( $# > 0 )) && [[ $1 == "--run-slot-login" ]]; then
+  if (( $# != 4 )); then
+    usage >&2
+    exit 1
+  fi
+  run_slot_login "$2" "$3" "$4"
+  exit
+fi
+
+requested=""
+if (( $# > 0 )) && agent_account_is_known_provider "$1"; then
+  requested="$1"
+  shift
+fi
+
+if (( $# == 1 )) && [[ $1 == "-h" || $1 == "--help" ]]; then
+  usage
+  exit 0
+fi
+if (( $# != 2 )); then
+  usage >&2
+  exit 1
+fi
+
+account="$1"
+slot="$2"
+agent_account_load_selected_provider "$requested"
+agent_account_validate_name "$account"
+if ! agent_account_slot_installed "$slot"; then
+  echo "$slot is not installed, so Omarchy cannot fill its $AGENT_ACCOUNT_PROVIDER_NAME credential slot." >&2
+  exit 1
+fi
+
+printf -v login_command '%q --run-slot-login %q %q %q' "$OMARCHY_PATH/bin/omarchy-agent-account-login" "$AGENT_ACCOUNT_PROVIDER_ID" "$account" "$slot"
+exec omarchy-launch-floating-terminal-with-presentation "$login_command"

--- a/bin/omarchy-agent-account-logout
+++ b/bin/omarchy-agent-account-logout
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# omarchy:summary=Forget a provider account without deleting its credential bundle
+# omarchy:args=[provider] [account]
+# omarchy:examples=omarchy agent account logout work | omarchy agent account logout anthropic work
+
+set -euo pipefail
+
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
+usage() {
+  echo "Usage: omarchy agent account logout [provider] [account]"
+}
+
+requested=""
+if (( $# > 0 )) && agent_account_is_known_provider "$1"; then
+  requested="$1"
+  shift
+fi
+
+if (( $# > 1 )); then
+  usage >&2
+  exit 1
+fi
+if (( $# == 1 )) && [[ $1 == "-h" || $1 == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+agent_account_load_selected_provider "$requested"
+agent_account_lock
+trap agent_account_cleanup EXIT
+agent_account_prepare_locked
+
+active=$(agent_account_active 2>/dev/null || true)
+name=${1:-$active}
+if [[ -z $name ]]; then
+  echo "$AGENT_ACCOUNT_PROVIDER_NAME has no active account to forget." >&2
+  exit 1
+fi
+
+agent_account_validate_name "$name"
+if [[ $name == $active ]]; then
+  echo "Cannot forget active $AGENT_ACCOUNT_PROVIDER_NAME account '$name'; switch to another account first." >&2
+  exit 1
+fi
+
+profile=$(agent_account_profile_path "$name")
+if ! agent_account_profile_exists "$name"; then
+  echo "$AGENT_ACCOUNT_PROVIDER_NAME account '$name' does not exist." >&2
+  exit 1
+fi
+
+trash_root="$AGENT_ACCOUNT_MANAGED_ROOT/.trash"
+install -d -m 700 "$trash_root"
+chmod 700 "$trash_root"
+trash_path="$trash_root/$name.$(date +%s).$$"
+counter=0
+while [[ -e $trash_path || -L $trash_path ]]; do
+  ((counter += 1))
+  trash_path="$trash_root/$name.$(date +%s).$$.$counter"
+done
+
+mv -T -- "$profile" "$trash_path"
+rm -f -- "$HOME/.local/state/omarchy/agents/usage/$AGENT_ACCOUNT_PROVIDER_ID@$name.json"
+agent_account_unlock
+trap - EXIT
+agent_account_refresh_shell
+
+echo "Forgot $AGENT_ACCOUNT_PROVIDER_NAME account '$name'. Its credential bundle can be recovered from $trash_path"

--- a/bin/omarchy-agent-account-switch
+++ b/bin/omarchy-agent-account-switch
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# omarchy:summary=Switch every credential slot for a subscription account
+# omarchy:args=[provider] [account|--next]
+# omarchy:examples=omarchy agent account switch work | omarchy agent account switch anthropic personal | omarchy agent account switch openai --next
+
+set -euo pipefail
+
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
+usage() {
+  echo "Usage: omarchy agent account switch [provider] [account|--next]"
+}
+
+requested=""
+if (( $# > 0 )) && agent_account_is_known_provider "$1"; then
+  requested="$1"
+  shift
+fi
+
+if (( $# > 1 )); then
+  usage >&2
+  exit 1
+fi
+if (( $# == 1 )) && [[ $1 == "-h" || $1 == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+agent_account_load_selected_provider "$requested"
+agent_account_lock
+trap agent_account_cleanup EXIT
+agent_account_prepare_locked
+
+mapfile -t accounts < <(agent_account_profiles)
+if (( ${#accounts[@]} == 0 )); then
+  echo "$AGENT_ACCOUNT_PROVIDER_NAME has no accounts. Fill a first slot with: omarchy agent account login $AGENT_ACCOUNT_PROVIDER_ID <account> <slot>" >&2
+  exit 1
+fi
+
+active=$(agent_account_active 2>/dev/null || true)
+if (( $# == 0 )); then
+  agent_account_unlock
+  trap - EXIT
+  name=$(printf '%s\n' "${accounts[@]}" | gum choose --header "Choose an $AGENT_ACCOUNT_PROVIDER_NAME account")
+  [[ -n $name ]] || exit 1
+  agent_account_lock
+  trap agent_account_cleanup EXIT
+  agent_account_prepare_locked
+  mapfile -t accounts < <(agent_account_profiles)
+  active=$(agent_account_active 2>/dev/null || true)
+elif [[ $1 == "--next" ]]; then
+  next_index=0
+  for index in "${!accounts[@]}"; do
+    if [[ ${accounts[$index]} == "$active" ]]; then
+      next_index=$(((index + 1) % ${#accounts[@]}))
+      break
+    fi
+  done
+  name=${accounts[$next_index]}
+else
+  name="$1"
+fi
+
+agent_account_validate_name "$name"
+agent_account_switch_locked "$name"
+agent_account_unlock
+trap - EXIT
+agent_account_refresh_shell
+echo "Switched $AGENT_ACCOUNT_PROVIDER_NAME to account '$name'."

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -2,7 +2,7 @@
 # omarchy:summary=Print the Claude Code usage record as JSON
 # omarchy:args=[--force] [--limits-only]
 # omarchy:hidden=true
-"""Collect Claude Code usage into one display-ready JSON record.
+"""Collect Anthropic usage into one display-ready account record.
 
 Everything the agents panel shows for Claude comes from this one
 command: local transcript stats from ~/.claude/projects, the stats-cache and
@@ -30,11 +30,17 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-AGENT_ID = "claude"
+PROVIDER_ID = "anthropic"
 AGENT_NAME = "Claude Code"
 AUTH_HELP = "Run `claude auth login` to restore authoritative usage."
 USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage"
 PROBE_MIN_INTERVAL_SECONDS = 15
+
+ACCOUNT_ID = os.environ.get("OMARCHY_AGENT_USAGE_ACCOUNT_ID", "")
+ACCOUNT_LABEL = os.environ.get("OMARCHY_AGENT_USAGE_ACCOUNT_LABEL", ACCOUNT_ID)
+ACCOUNT_ACTIVE = os.environ.get("OMARCHY_AGENT_USAGE_ACCOUNT_ACTIVE", "true").lower() == "true"
+RECORD_ID = PROVIDER_ID + (f"@{ACCOUNT_ID}" if ACCOUNT_ID else "")
+_SWITCH_LEDGER: list[tuple[float, str]] | None | bool = False
 
 
 def config_dir() -> Path:
@@ -49,6 +55,81 @@ def cache_root() -> Path:
   root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omarchy" / "agent-usage"
   root.mkdir(parents=True, exist_ok=True)
   return root
+
+
+def path_digest(*paths: Path) -> str:
+  resolved = "\n".join(str(path.resolve()) for path in paths)
+  return hashlib.sha1(resolved.encode("utf-8")).hexdigest()[:16]
+
+
+def timestamp_seconds(value: Any) -> float | None:
+  if isinstance(value, (int, float)):
+    try:
+      numeric = float(value)
+      return numeric / 1000 if numeric > 10_000_000_000 else numeric
+    except Exception:
+      return None
+
+  raw = str(value or "").strip()
+  if not raw:
+    return None
+  try:
+    parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+      parsed = parsed.astimezone()
+    return parsed.timestamp()
+  except Exception:
+    return None
+
+
+def switch_ledger() -> list[tuple[float, str]] | None:
+  global _SWITCH_LEDGER
+
+  if _SWITCH_LEDGER is not False:
+    return _SWITCH_LEDGER
+
+  path = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local" / "state")) / "omarchy" / "agents" / "switches" / f"{PROVIDER_ID}.json"
+  try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+      raise ValueError("empty switch ledger")
+    entries: list[tuple[float, str]] = []
+    for entry in payload:
+      if not isinstance(entry, dict) or entry.get("providerId") != PROVIDER_ID:
+        raise ValueError("invalid switch ledger entry")
+      timestamp = timestamp_seconds(entry.get("timestamp"))
+      account_id = entry.get("accountId")
+      if timestamp is None or not isinstance(account_id, str) or not account_id:
+        raise ValueError("invalid switch ledger entry")
+      entries.append((timestamp, account_id))
+    _SWITCH_LEDGER = sorted(entries, key=lambda entry: entry[0])
+  except Exception:
+    _SWITCH_LEDGER = None
+  return _SWITCH_LEDGER
+
+
+def shared_message_belongs_to_account(timestamp: Any) -> bool:
+  # An unmanaged provider has one implicit account, preserving the collector's
+  # pre-account behavior byte-for-byte at the stats level.
+  if not ACCOUNT_ID:
+    return True
+
+  ledger = switch_ledger()
+  if ledger is None:
+    return ACCOUNT_ACTIVE
+
+  message_time = timestamp_seconds(timestamp)
+  if message_time is None:
+    return ACCOUNT_ACTIVE
+
+  # The first known account owns earlier history. Equal timestamps retain
+  # append order, so the last switch written in that second wins.
+  owner = ledger[0][1]
+  for switched_at, account_id in ledger:
+    if switched_at > message_time:
+      break
+    owner = account_id
+  return owner == ACCOUNT_ID
 
 
 def date_string(value: dt.date) -> str:
@@ -337,12 +418,12 @@ def today_prompts_from_history(claude_dir: Path) -> tuple[int, int]:
 # provider, model, and token usage on every assistant message.
 
 
-def scan_pi_usage(max_age_seconds: float) -> dict[str, Any] | None:
+def scan_pi_usage(max_age_seconds: float, claude_dir: Path) -> dict[str, Any] | None:
   roots = [
     Path.home() / ".pi" / "agent" / "sessions",
     Path.home() / ".omp" / "agent" / "sessions",
   ]
-  cache_file = cache_root() / "claude-pi-sessions.json"
+  cache_file = cache_root() / f"claude-pi-sessions-{path_digest(claude_dir)}.json"
   cached = read_fresh_json(cache_file, max_age_seconds)
   if cached is not None:
     return cached.get("stats")
@@ -391,8 +472,11 @@ def scan_pi_usage(max_age_seconds: float) -> dict[str, Any] | None:
                 input_tokens = total
               if total <= 0:
                 continue
+              timestamp = entry.get("timestamp") or message.get("timestamp")
+              if not shared_message_belongs_to_account(timestamp):
+                continue
               model = str(message.get("model") or "claude")
-              day = local_date_from_timestamp(entry.get("timestamp") or message.get("timestamp"))
+              day = local_date_from_timestamp(timestamp)
             except Exception:
               continue
 
@@ -441,7 +525,7 @@ def scan_pi_usage(max_age_seconds: float) -> dict[str, Any] | None:
 # messages and merge the result into whatever the transcript scan found.
 
 
-def scan_opencode_usage(max_age_seconds: float) -> dict[str, Any] | None:
+def scan_opencode_usage(max_age_seconds: float, claude_dir: Path) -> dict[str, Any] | None:
   db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
   if not db.is_file():
     return None
@@ -449,7 +533,7 @@ def scan_opencode_usage(max_age_seconds: float) -> dict[str, Any] | None:
   # Same freshness contract as the transcript scan: --limits-only promises to
   # reuse recent local stats, and a big opencode history walked on every panel
   # open would break that promise.
-  cache_file = cache_root() / f"claude-opencode-{hashlib.sha1(str(db).encode('utf-8')).hexdigest()[:16]}.json"
+  cache_file = cache_root() / f"claude-opencode-{path_digest(claude_dir, db)}.json"
   cached = read_fresh_json(cache_file, max_age_seconds)
   if cached is not None:
     return cached.get("stats")
@@ -473,7 +557,7 @@ def scan_opencode_usage(max_age_seconds: float) -> dict[str, Any] | None:
     return None
   try:
     conn.execute("PRAGMA query_only = ON")
-    for session_id, raw in conn.execute("SELECT session_id, data FROM message"):
+    for session_id, row_created, raw in conn.execute("SELECT session_id, time_created, data FROM message"):
       # One malformed row must not abort the scan, so every shape assumption
       # lives inside the try.
       try:
@@ -495,7 +579,9 @@ def scan_opencode_usage(max_age_seconds: float) -> dict[str, Any] | None:
         if total <= 0:
           continue
 
-        created = number((entry.get("time") or {}).get("created"))
+        created = number((entry.get("time") or {}).get("created")) or number(row_created)
+        if not shared_message_belongs_to_account(created):
+          continue
         day = dt.datetime.fromtimestamp(created / 1000).strftime("%Y-%m-%d") if created > 0 else today
         model = str(entry.get("modelID") or "claude").rstrip("/").split("/")[-1]
       except Exception:
@@ -791,13 +877,13 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+def collect_limits(access_token: str, expires_at_ms: int, force: bool, claude_dir: Path) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   # A panel that is opened and shut repeatedly must not turn into a request
   # per flick, so recent probe results are reused for a short window — and
   # kept as the answer of record when a later probe fails.
-  probe_cache = cache_root() / "claude-limits.json"
+  probe_cache = cache_root() / f"claude-limits-{path_digest(claude_dir)}.json"
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
 
@@ -871,20 +957,24 @@ def main() -> int:
       if today_prompts or today_sessions:
         stats = dict(stats, todayPrompts=today_prompts, todaySessions=today_sessions)
 
-  pi_usage = scan_pi_usage(scan_age)
+  pi_usage = scan_pi_usage(scan_age, claude_dir)
   if pi_usage is not None:
     stats = merge_stats(stats, pi_usage)
 
-  opencode = scan_opencode_usage(scan_age)
+  opencode = scan_opencode_usage(scan_age, claude_dir)
   if opencode is not None:
     stats = merge_stats(stats, opencode)
 
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
-  limits = collect_limits(access_token, expires_at_ms, args.force)
+  limits = collect_limits(access_token, expires_at_ms, args.force, claude_dir)
 
   record = {
     "schemaVersion": 1,
-    "id": AGENT_ID,
+    "id": RECORD_ID,
+    "providerId": PROVIDER_ID,
+    "accountId": ACCOUNT_ID,
+    "accountLabel": ACCOUNT_LABEL,
+    "accountActive": ACCOUNT_ACTIVE,
     "name": AGENT_NAME,
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
     "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0,
@@ -893,6 +983,7 @@ def main() -> int:
     "usageStatusText": limits["usageStatusText"],
     "authHelpText": limits["authHelpText"],
     "limits": limits["limits"],
+    "includesSharedSessions": pi_usage is not None or opencode is not None,
   }
   if limits.get("retryAdvised"):
     record["retryAdvised"] = True

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -2,7 +2,7 @@
 # omarchy:summary=Print the Codex usage record as JSON
 # omarchy:args=[--force] [--limits-only]
 # omarchy:hidden=true
-"""Collect Codex usage into one display-ready JSON record.
+"""Collect OpenAI usage into one display-ready account record.
 
 Local stats come from native Codex CLI session files, pi/omp sessions that
 ran through openai-codex, and opencode sessions that ran on an OpenAI
@@ -25,9 +25,15 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-AGENT_ID = "codex"
+PROVIDER_ID = "openai"
 AGENT_NAME = "Codex"
 AUTH_HELP = "Run `codex login` to authenticate."
+
+ACCOUNT_ID = os.environ.get("OMARCHY_AGENT_USAGE_ACCOUNT_ID", "")
+ACCOUNT_LABEL = os.environ.get("OMARCHY_AGENT_USAGE_ACCOUNT_LABEL", ACCOUNT_ID)
+ACCOUNT_ACTIVE = os.environ.get("OMARCHY_AGENT_USAGE_ACCOUNT_ACTIVE", "true").lower() == "true"
+RECORD_ID = PROVIDER_ID + (f"@{ACCOUNT_ID}" if ACCOUNT_ID else "")
+_SWITCH_LEDGER = False
 
 # A scan this recent is only reused to dedup concurrent collector runs (the
 # update command backgrounds one per agent while the panel refreshes on its
@@ -49,14 +55,80 @@ def local_day(value):
   text = str(value)
   try:
     if text.endswith("Z"):
-      dt = datetime.fromisoformat(text[:-1] + "+00:00")
+      parsed = datetime.fromisoformat(text[:-1] + "+00:00")
     else:
-      dt = datetime.fromisoformat(text)
-    if dt.tzinfo is not None:
-      dt = dt.astimezone()
-    return dt.strftime("%Y-%m-%d")
+      parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is not None:
+      parsed = parsed.astimezone()
+    return parsed.strftime("%Y-%m-%d")
   except Exception:
     return datetime.now().strftime("%Y-%m-%d")
+
+
+def timestamp_seconds(value):
+  if isinstance(value, (int, float)):
+    try:
+      numeric = float(value)
+      return numeric / 1000 if numeric > 10_000_000_000 else numeric
+    except Exception:
+      return None
+
+  raw = str(value or "").strip()
+  if not raw:
+    return None
+  try:
+    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+      parsed = parsed.astimezone()
+    return parsed.timestamp()
+  except Exception:
+    return None
+
+
+def switch_ledger():
+  global _SWITCH_LEDGER
+
+  if _SWITCH_LEDGER is not False:
+    return _SWITCH_LEDGER
+
+  path = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local" / "state")) / "omarchy" / "agents" / "switches" / f"{PROVIDER_ID}.json"
+  try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+      raise ValueError("empty switch ledger")
+    entries = []
+    for entry in payload:
+      if not isinstance(entry, dict) or entry.get("providerId") != PROVIDER_ID:
+        raise ValueError("invalid switch ledger entry")
+      timestamp = timestamp_seconds(entry.get("timestamp"))
+      account_id = entry.get("accountId")
+      if timestamp is None or not isinstance(account_id, str) or not account_id:
+        raise ValueError("invalid switch ledger entry")
+      entries.append((timestamp, account_id))
+    _SWITCH_LEDGER = sorted(entries, key=lambda entry: entry[0])
+  except Exception:
+    _SWITCH_LEDGER = None
+  return _SWITCH_LEDGER
+
+
+def shared_message_belongs_to_account(timestamp):
+  if not ACCOUNT_ID:
+    return True
+
+  ledger = switch_ledger()
+  if ledger is None:
+    return ACCOUNT_ACTIVE
+
+  message_time = timestamp_seconds(timestamp)
+  if message_time is None:
+    return ACCOUNT_ACTIVE
+
+  owner = ledger[0][1]
+  for switched_at, account_id in ledger:
+    if switched_at > message_time:
+      break
+    owner = account_id
+  return owner == ACCOUNT_ID
 
 
 def number(value):
@@ -105,14 +177,17 @@ today_total_tokens = 0
 total_prompts = 0
 total_sessions = set()
 seen_pi_messages = set()
+includes_shared_sessions = False
 
 
-def add_usage(day, session_key, model, input_tokens, output_tokens, cache_read, cache_write):
-  global today_prompts, today_total_tokens, total_prompts
+def add_usage(day, session_key, model, input_tokens, output_tokens, cache_read, cache_write, shared=False):
+  global today_prompts, today_total_tokens, total_prompts, includes_shared_sessions
   total = input_tokens + output_tokens + cache_read + cache_write
   total_prompts += 1
   total_sessions.add(session_key)
   active_days.add(day)
+  if shared:
+    includes_shared_sessions = True
 
   bucket = model_usage.setdefault(model, {
     "inputTokens": 0,
@@ -195,9 +270,12 @@ def scan_pi_sessions():
       if not (input_tokens or output_tokens or cache_read or cache_write):
         continue
 
-      day = local_day(entry.get("timestamp") or message.get("timestamp"))
+      timestamp = entry.get("timestamp") or message.get("timestamp")
+      if not shared_message_belongs_to_account(timestamp):
+        continue
+      day = local_day(timestamp)
       session_key = path
-      add_usage(day, session_key, model_name(message.get("model")), input_tokens, output_tokens, cache_read, cache_write)
+      add_usage(day, session_key, model_name(message.get("model")), input_tokens, output_tokens, cache_read, cache_write, shared=True)
 
     try:
       proc.wait(timeout=1)
@@ -243,8 +321,8 @@ def scan_opencode_sessions():
     #     well-formed JSON are skipped here; the per-row try/except below
     #     stays as the final safety net for rows that pass the SQL filter
     #     but fail json.loads.
-    for session_id, raw in conn.execute(
-      "SELECT session_id, data FROM message"
+    for session_id, row_created, raw in conn.execute(
+      "SELECT session_id, time_created, data FROM message"
       " WHERE data LIKE '%\"role\"%:%\"assistant\"%'"
       " AND data LIKE '%\"providerID\"%:%\"openai\"%'"
       " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'"
@@ -269,11 +347,14 @@ def scan_opencode_sessions():
         cache_write = number(cache.get("write"))
         if not (input_tokens or output_tokens or cache_read or cache_write):
           continue
-        day = local_day((entry.get("time") or {}).get("created"))
+        created = (entry.get("time") or {}).get("created") or row_created
+        if not shared_message_belongs_to_account(created):
+          continue
+        day = local_day(created)
         model = model_name(str(entry.get("modelID") or "").rstrip("/").split("/")[-1])
       except Exception:
         continue
-      add_usage(day, "opencode:" + str(session_id), model, input_tokens, output_tokens, cache_read, cache_write)
+      add_usage(day, "opencode:" + str(session_id), model, input_tokens, output_tokens, cache_read, cache_write, shared=True)
   except sqlite3.Error:
     # Transient lock, schema migration, corruption: the numbers stop here,
     # incomplete.
@@ -284,7 +365,7 @@ def scan_opencode_sessions():
 
 
 def scan_native_codex_sessions():
-  codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+  codex_home = resolved_codex_home()
   roots = [codex_home / "sessions", codex_home / "archived_sessions"]
   files = []
   cutoff = time.time() - 30 * 24 * 60 * 60
@@ -343,12 +424,16 @@ def cache_root():
   return root
 
 
+def resolved_codex_home():
+  return Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex")).expanduser().resolve()
+
+
 def scan_cache_paths():
-  codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+  codex_home = resolved_codex_home()
   db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
   # The digest covers every data path the scan reads: the codex session
   # roots, the opencode DB, and (via Path.home()) the pi/omp session roots.
-  digest = hashlib.sha1((str(Path.home()) + "\n" + str(codex_home) + "\n" + str(db)).encode("utf-8")).hexdigest()[:16]
+  digest = hashlib.sha1((str(Path.home().resolve()) + "\n" + str(codex_home) + "\n" + str(db.resolve())).encode("utf-8")).hexdigest()[:16]
   root = cache_root()
   return root / f"codex-scan-{digest}.json", root / f"codex-scan-{digest}.lock"
 
@@ -391,7 +476,7 @@ def write_json(path, payload):
 # of a crash or a garbage record.
 def read_cached_stats(cache_file, max_age_seconds):
   cached = read_fresh_json(cache_file, max_age_seconds)
-  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 2:
     return None
   # today* fields only mean "today" on the day they were scanned. A cache
   # from another local date (midnight passed, or the clock moved) is a miss,
@@ -401,14 +486,14 @@ def read_cached_stats(cache_file, max_age_seconds):
   stats = cached.get("stats")
   if not isinstance(stats, dict):
     return None
-  if not all(key in stats for key in ("todayPrompts", "todayTotalTokens", "recentDays", "activeDates", "modelUsage")):
+  if not all(key in stats for key in ("todayPrompts", "todayTotalTokens", "recentDays", "activeDates", "modelUsage", "includesSharedSessions")):
     return None
   return stats
 
 
 def write_cached_stats(cache_file, stats):
   try:
-    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+    write_json(cache_file, {"schemaVersion": 2, "scanDate": today, "stats": stats})
   except Exception as exc:
     print(f"omarchy-agent-usage-codex: could not write usage cache ({exc})", file=sys.stderr)
 
@@ -429,6 +514,7 @@ def local_stats():
     "activeDays": len(active_days),
     "activeDates": sorted(active_days),
     "modelUsage": model_usage,
+    "includesSharedSessions": includes_shared_sessions,
   }
 
 
@@ -588,7 +674,11 @@ def main():
 
   record = {
     "schemaVersion": 1,
-    "id": AGENT_ID,
+    "id": RECORD_ID,
+    "providerId": PROVIDER_ID,
+    "accountId": ACCOUNT_ID,
+    "accountLabel": ACCOUNT_LABEL,
+    "accountActive": ACCOUNT_ACTIVE,
     "name": AGENT_NAME,
     "updatedAt": datetime.now(timezone.utc).isoformat(),
     "ready": True,

--- a/bin/omarchy-agent-usage-fireworks
+++ b/bin/omarchy-agent-usage-fireworks
@@ -107,6 +107,10 @@ def base_record(**overrides: Any) -> dict[str, Any]:
   record: dict[str, Any] = {
     "schemaVersion": 1,
     "id": AGENT_ID,
+    "providerId": AGENT_ID,
+    "accountId": "",
+    "accountLabel": "",
+    "accountActive": True,
     "name": AGENT_NAME,
     "updatedAt": datetime.now(timezone.utc).isoformat(),
     "ready": False,

--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # omarchy:summary=Regenerate the AI agent usage data files
-# omarchy:args=[--force] [--limits-only] [--except <agent>] [agent...]
-# omarchy:examples=omarchy agent usage-update | omarchy agent usage-update claude | omarchy agent usage-update --except codex
+# omarchy:args=[--force] [--limits-only] [--except <provider>] [provider...]
+# omarchy:examples=omarchy agent usage-update | omarchy agent usage-update anthropic | omarchy agent usage-update --except codex
 
-# Each omarchy-agent-usage-<agent> collector prints one display-ready JSON
-# record; this writes them to ~/.local/state/omarchy/agents/usage/ where the
-# agents panel watches them. Adding an agent is adding a collector — the
-# panel picks up any record that appears here.
+# Account-aware collectors still have one binary per provider. This updater
+# fans those binaries out over the managed subscription accounts and gives
+# each invocation its real config directory, while providers without managed
+# accounts keep one bare record.
 
 USAGE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
 mkdir -p "$USAGE_DIR"
@@ -16,48 +16,252 @@ flags=()
 only=()
 declare -A excluded
 
-while [[ $# -gt 0 ]]; do
+normalize_provider() {
   case "$1" in
-  --force | --limits-only) flags+=("$1") ;;
+  anthropic | claude)
+    printf 'anthropic\n'
+    ;;
+  openai | codex)
+    printf 'openai\n'
+    ;;
+  *)
+    printf '%s\n' "$1"
+    ;;
+  esac
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+  --force | --limits-only)
+    flags+=("$1")
+    ;;
   --except)
-    excluded[$2]=1
+    if (( $# < 2 )); then
+      echo "omarchy-agent-usage-update: --except requires a provider" >&2
+      exit 1
+    fi
+    excluded["$(normalize_provider "$2")"]=1
     shift
     ;;
-  *) only+=("$1") ;;
+  *)
+    only+=("$(normalize_provider "$1")")
+    ;;
   esac
   shift
 done
 
 wanted() {
-  local agent="$1"
-  [[ -n ${excluded[$agent]} ]] && return 1
-  (( ${#only[@]} == 0 )) && return 0
+  local provider="$1"
   local candidate
+
+  [[ -n ${excluded[$provider]} ]] && return 1
+  (( ${#only[@]} == 0 )) && return 0
   for candidate in "${only[@]}"; do
-    [[ $candidate == "$agent" ]] && return 0
+    [[ $candidate == $provider ]] && return 0
   done
   return 1
 }
 
-collect() {
-  local collector="$1" agent="$2"
-  local record tmp
-  if ! record=$("$collector" "${flags[@]}") || [[ -z $record ]] || ! jq -e . >/dev/null 2>&1 <<<"$record"; then
-    echo "omarchy-agent-usage-update: $agent collector failed" >&2
+managed_provider_load() {
+  case "$1" in
+  claude)
+    PROVIDER_ID="anthropic"
+    LEGACY_ID="claude"
+    CONFIG_ENV="CLAUDE_CONFIG_DIR"
+    CONFIG_SLOT="claude"
+    CONFIG_CANONICAL="$HOME/.claude"
+    ;;
+  codex)
+    PROVIDER_ID="openai"
+    LEGACY_ID="codex"
+    CONFIG_ENV="CODEX_HOME"
+    CONFIG_SLOT="codex"
+    CONFIG_CANONICAL="$HOME/.codex"
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+  MANAGED_ROOT="$HOME/.local/share/omarchy/agents/$PROVIDER_ID"
+}
+
+managed_accounts() {
+  local account profile
+
+  [[ -d $MANAGED_ROOT ]] || return 0
+  while IFS= read -r account; do
+    [[ $account =~ ^[a-z0-9][a-z0-9_-]{0,62}$ ]] || continue
+    profile="$MANAGED_ROOT/$account"
+    [[ -d $profile && ! -L $profile && -d $profile/$CONFIG_SLOT && ! -L $profile/$CONFIG_SLOT ]] || continue
+    printf '%s\n' "$account"
+  done < <(find "$MANAGED_ROOT" -mindepth 1 -maxdepth 1 -type d ! -name '.*' -printf '%f\n' | LC_ALL=C sort)
+}
+
+active_account() {
+  local canonical_target account expected
+
+  [[ -L $CONFIG_CANONICAL ]] || return 0
+  canonical_target=$(realpath -m -- "$CONFIG_CANONICAL")
+  for account in "$@"; do
+    expected=$(realpath -m -- "$MANAGED_ROOT/$account/$CONFIG_SLOT")
+    if [[ $canonical_target == $expected ]]; then
+      printf '%s\n' "$account"
+      return 0
+    fi
+  done
+}
+
+collect_record() {
+  local collector="$1"
+  local record_id="$2"
+  local provider_id="$3"
+  local account_id="$4"
+  local account_label="$5"
+  local account_active="$6"
+  local config_env=${7:-}
+  local config_dir=${8:-}
+  local record normalized tmp
+  local -a collector_env=(
+    "OMARCHY_AGENT_USAGE_PROVIDER_ID=$provider_id"
+    "OMARCHY_AGENT_USAGE_ACCOUNT_ID=$account_id"
+    "OMARCHY_AGENT_USAGE_ACCOUNT_LABEL=$account_label"
+    "OMARCHY_AGENT_USAGE_ACCOUNT_ACTIVE=$account_active"
+  )
+
+  if [[ -n $config_env ]]; then
+    collector_env+=("$config_env=$config_dir")
+  fi
+
+  if ! record=$(env "${collector_env[@]}" "$collector" "${flags[@]}") ||
+    [[ -z $record ]] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$record"; then
+    echo "omarchy-agent-usage-update: $record_id collector failed" >&2
     return 1
   fi
-  tmp=$(mktemp "$USAGE_DIR/.$agent.XXXXXX")
-  printf '%s\n' "$record" >"$tmp"
-  mv "$tmp" "$USAGE_DIR/$agent.json"
+
+  if ! normalized=$(jq -c \
+    --arg id "$record_id" \
+    --arg providerId "$provider_id" \
+    --arg accountId "$account_id" \
+    --arg accountLabel "$account_label" \
+    --argjson accountActive "$account_active" \
+    '. + {
+      id: $id,
+      providerId: $providerId,
+      accountId: $accountId,
+      accountLabel: $accountLabel,
+      accountActive: $accountActive
+    }' <<<"$record"); then
+    echo "omarchy-agent-usage-update: $record_id collector returned an invalid record" >&2
+    return 1
+  fi
+
+  tmp=$(mktemp "$USAGE_DIR/.$record_id.XXXXXX")
+  printf '%s\n' "$normalized" >"$tmp"
+  mv -Tf -- "$tmp" "$USAGE_DIR/$record_id.json"
+}
+
+record_expected() {
+  local record="$1"
+  shift
+  local expected
+
+  for expected in "$@"; do
+    [[ $record == ${expected}.json ]] && return 0
+  done
+  return 1
+}
+
+prune_managed_records() {
+  local path record
+  local expected=("$@")
+
+  for path in \
+    "$USAGE_DIR/$PROVIDER_ID.json" \
+    "$USAGE_DIR/$LEGACY_ID.json" \
+    "$USAGE_DIR/$PROVIDER_ID@"*.json \
+    "$USAGE_DIR/$LEGACY_ID@"*.json; do
+    [[ -e $path || -L $path ]] || continue
+    record=${path##*/}
+    record_expected "$record" "${expected[@]}" || rm -f -- "$path"
+  done
+}
+
+collect_managed_provider() {
+  local collector="$1"
+  local collector_id="$2"
+  local account active account_active record_id
+  local lock_fd=""
+  local status=0
+  local accounts=()
+  local expected=()
+
+  managed_provider_load "$collector_id"
+  if [[ -d $MANAGED_ROOT ]]; then
+    if ! exec {lock_fd}>"$MANAGED_ROOT/.lock" || ! flock "$lock_fd"; then
+      echo "omarchy-agent-usage-update: could not lock $PROVIDER_ID accounts" >&2
+      [[ -n $lock_fd ]] && exec {lock_fd}>&-
+      return 1
+    fi
+  fi
+
+  mapfile -t accounts < <(managed_accounts)
+  active=$(active_account "${accounts[@]}")
+
+  if (( ${#accounts[@]} == 0 )); then
+    record_id="$PROVIDER_ID"
+    expected+=("$record_id")
+    collect_record "$collector" "$record_id" "$PROVIDER_ID" "" "" true "$CONFIG_ENV" "$CONFIG_CANONICAL" || status=1
+  else
+    for account in "${accounts[@]}"; do
+      if [[ $account == $active ]]; then
+        account_active=true
+      else
+        account_active=false
+      fi
+      record_id="$PROVIDER_ID@$account"
+      expected+=("$record_id")
+      collect_record \
+        "$collector" "$record_id" "$PROVIDER_ID" "$account" "$account" "$account_active" \
+        "$CONFIG_ENV" "$MANAGED_ROOT/$account/$CONFIG_SLOT" || status=1
+    done
+  fi
+
+  if (( status == 0 )); then
+    prune_managed_records "${expected[@]}"
+  fi
+
+  if [[ -n $lock_fd ]]; then
+    flock -u "$lock_fd"
+    exec {lock_fd}>&-
+  fi
+  return "$status"
+}
+
+collect_bare_provider() {
+  local collector="$1"
+  local provider_id="$2"
+
+  collect_record "$collector" "$provider_id" "$provider_id" "" "" true
 }
 
 pids=()
 for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
   [[ -x $collector ]] || continue
-  agent="${collector##*/omarchy-agent-usage-}"
-  [[ $agent == "update" ]] && continue
-  wanted "$agent" || continue
-  collect "$collector" "$agent" &
+  collector_id=${collector##*/omarchy-agent-usage-}
+  [[ $collector_id == "update" ]] && continue
+
+  if managed_provider_load "$collector_id"; then
+    provider_id="$PROVIDER_ID"
+  else
+    provider_id=$(normalize_provider "$collector_id")
+  fi
+  wanted "$provider_id" || continue
+
+  if managed_provider_load "$collector_id"; then
+    collect_managed_provider "$collector" "$collector_id" &
+  else
+    collect_bare_provider "$collector" "$provider_id" &
+  fi
   pids+=($!)
 done
 
@@ -65,4 +269,4 @@ status=0
 for pid in "${pids[@]}"; do
   wait "$pid" || status=1
 done
-exit $status
+exit "$status"

--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -66,6 +66,8 @@ export OMARCHY_INSTALL="${OMARCHY_INSTALL:-$OMARCHY_PATH/install}"
 export OMARCHY_SETUP_CONTEXT="${OMARCHY_SETUP_CONTEXT:-runtime}"
 export PATH="$OMARCHY_PATH/bin:$PATH"
 
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
 if (( first_install )) && [[ $OMARCHY_SETUP_CONTEXT == "runtime" ]]; then
   # The ISO chroot doesn't set a context; omarchy-provision-owner runs first-install
   # finalization too but with OMARCHY_SETUP_CONTEXT=provision-owner already set.
@@ -83,15 +85,21 @@ fi
 
 # Dev-aware skill symlinks. Cannot live in /etc/skel because OMARCHY_PATH may
 # point at a dev checkout (omarchy dev link) where the target differs.
-# Loops every skill directory, so shipping a new one needs no edit here.
-mkdir -p ~/.agents/skills ~/.claude/skills ~/.codex/skills ~/.pi/agent/skills
+mkdir -p ~/.agents/skills ~/.pi/agent/skills
 for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   skill=${skill%/}
   name=${skill##*/}
   ln -sfn "$skill" ~/.agents/skills/"$name"
-  ln -sfn "$skill" ~/.claude/skills/"$name"
-  ln -sfn "$skill" ~/.codex/skills/"$name"
   ln -sfn "$skill" ~/.pi/agent/skills/"$name"
+done
+
+for provider in anthropic openai; do
+  agent_account_provider_load "$provider"
+  agent_account_lock
+  while IFS= read -r config_dir; do
+    agent_account_provision_config_dir "$config_dir"
+  done < <(agent_account_config_roots)
+  agent_account_unlock
 done
 
 mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0

--- a/bin/omarchy-theme-set-claude
+++ b/bin/omarchy-theme-set-claude
@@ -6,10 +6,10 @@
 
 set -euo pipefail
 
+source "$OMARCHY_PATH/bin/omarchy-agent-account-backends"
+
 CLAUDE_SOURCE_PATH="$HOME/.local/state/omarchy/current/theme/claude.json"
-CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-CLAUDE_THEME_PATH="$CLAUDE_CONFIG_DIR/themes/omarchy.json"
-CLAUDE_SETTINGS_PATH="$CLAUDE_CONFIG_DIR/settings.json"
+CLAUDE_CONFIG_OVERRIDE=${CLAUDE_CONFIG_DIR:-}
 CLAUDE_ACTIVATE=0
 
 usage() {
@@ -42,19 +42,32 @@ if [[ ! -f $CLAUDE_SOURCE_PATH ]]; then
   exit 0
 fi
 
-if (( CLAUDE_ACTIVATE == 0 )) && [[ ! -d $CLAUDE_CONFIG_DIR ]]; then
-  exit 0
-fi
-
-write_setting_theme() {
+write_claude_theme() {
+  local config_dir="$1"
+  local theme_path="$config_dir/themes/omarchy.json"
+  local settings_path="$config_dir/settings.json"
   local tmp
 
-  if [[ -f $CLAUDE_SETTINGS_PATH ]]; then
-    tmp=$(mktemp "$CLAUDE_SETTINGS_PATH.XXXXXX")
-    jq '.theme = "custom:omarchy"' "$CLAUDE_SETTINGS_PATH" >"$tmp"
-    mv "$tmp" "$CLAUDE_SETTINGS_PATH"
+  if (( CLAUDE_ACTIVATE == 0 )) && [[ ! -d $config_dir ]]; then
+    return 0
+  fi
+
+  # Claude Code watches its themes directory and hot-reloads changes.
+  mkdir -p "$(dirname "$theme_path")"
+  tmp=$(mktemp "$theme_path.XXXXXX")
+  cp "$CLAUDE_SOURCE_PATH" "$tmp"
+  mv "$tmp" "$theme_path"
+
+  if (( CLAUDE_ACTIVATE == 0 )); then
+    return 0
+  fi
+
+  if [[ -f $settings_path ]]; then
+    tmp=$(mktemp "$settings_path.XXXXXX")
+    jq '.theme = "custom:omarchy"' "$settings_path" >"$tmp"
+    mv "$tmp" "$settings_path"
   else
-    cat >"$CLAUDE_SETTINGS_PATH" <<EOF
+    cat >"$settings_path" <<EOF
 {
   "theme": "custom:omarchy"
 }
@@ -62,13 +75,16 @@ EOF
   fi
 }
 
-# Claude Code watches ~/.claude/themes and hot-reloads the file on change,
-# so running sessions retint without a restart.
-mkdir -p "$(dirname "$CLAUDE_THEME_PATH")"
-tmp=$(mktemp "$CLAUDE_THEME_PATH.XXXXXX")
-cp "$CLAUDE_SOURCE_PATH" "$tmp"
-mv "$tmp" "$CLAUDE_THEME_PATH"
+agent_account_provider_load anthropic
+agent_account_lock
+trap agent_account_unlock EXIT
 
-if (( CLAUDE_ACTIVATE == 1 )); then
-  write_setting_theme
+if [[ -n $CLAUDE_CONFIG_OVERRIDE ]]; then
+  config_dirs=("$CLAUDE_CONFIG_OVERRIDE")
+else
+  mapfile -t config_dirs < <(agent_account_config_roots)
 fi
+
+for config_dir in "${config_dirs[@]}"; do
+  write_claude_theme "$config_dir"
+done

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -144,6 +144,7 @@
   "setup.default.agent.omp": {"icon":"","iconFont":"omarchy","label":"omp","checked":"[[ \"$(omarchy-default-agent)\" == \"omp\" ]]","action":"omarchy-default-agent omp"},
   "setup.default.agent.opencode": {"icon":"","iconFont":"omarchy","label":"OpenCode","checked":"[[ \"$(omarchy-default-agent)\" == \"opencode\" ]]","action":"omarchy-default-agent opencode"},
   "setup.default.agent.pi": {"icon":"","iconFont":"omarchy","label":"Pi","checked":"[[ \"$(omarchy-default-agent)\" == \"pi\" ]]","action":"omarchy-default-agent pi"},
+  "setup.default.agent.accounts": {"icon":"󰚩","label":"Accounts","title":"Subscription Accounts","provider":"agent-accounts"},
   "setup.default.browser": {"icon":"","label":"Browser","title":"Default Browser"},
   "setup.default.browser.chromium": {"icon":"","label":"Chromium","checked":"[[ \"$(omarchy-default-browser)\" == \"chromium\" ]]","action":"omarchy-default-browser chromium"},
   "setup.default.browser.chrome": {"icon":"󰊯","label":"Chrome","checked":"[[ \"$(omarchy-default-browser)\" == \"chrome\" ]]","action":"omarchy-default-browser chrome"},

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -108,12 +108,18 @@ can point a submenu at an existing provider but cannot declare a new one:
   the launcher. App rows are searchable by their desktop Keywords but never
   routable, so an installed app cannot capture a menu route (htop ships
   `Keywords=system;...`, and SUPER+ESCAPE must still open the system menu).
-- `fonts` and `power-profiles` are bash one-liners in the `providers` map in
+- `fonts`, `power-profiles`, and `agent-accounts` are bash one-liners in the `providers` map in
   `Menu.qml`. The contract is one tab-delimited line per row:
   `label\tvalue\tcurrent`. The row whose value equals `current` gets the ✓
   icon, and selection runs the spec's `actionFor(value)`. Row ids are
   `<menuId>.<slugify(value)>`, with a `-` appended on collision so two values
   that slugify alike cannot silently drop a row.
+
+`agent-accounts` turns `omarchy agent account list --json` into those rows.
+Its value carries the provider and immutable account ids, while the visible
+label shows the provider followed by the account label; selection runs
+`omarchy agent account switch`. It is volatile so a login, logout, or switch
+is reflected on the next entry.
 
 A provider marked `volatile` re-runs every time its submenu is entered — a
 font installed since the shell started shows up without a restart — but not

--- a/manual/14-omarchy-cli.md
+++ b/manual/14-omarchy-cli.md
@@ -25,7 +25,7 @@ Common commands:
   omarchy debug               Print debugging information
 
 Groups:
-  agent          AI coding agent usage data
+  agent          AI coding agents, subscription accounts, and usage data
   audio          Audio input and output controls
   bar            Omarchy shell bar layout and settings
   battery        Battery status helpers

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -24,11 +24,30 @@ Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a d
 
 There are terminal shortcuts too: `a` runs the default agent inline in the current terminal, while `c`, `cx`, and `cy` start OpenCode, Claude Code, and Codex directly (again in their auto-approving modes). Theme changes sync to the agents as well: Claude Code, Pi, and OpenCode all follow along when you switch the Omarchy theme.
 
+### Subscription accounts
+
+Anthropic and OpenAI subscriptions can each hold several named accounts, such as personal and work. An account is a credential bundle: switching Anthropic accounts moves Claude Code, Pi, and OpenCode together, while switching OpenAI moves Codex, Pi, and OpenCode together. This prevents a third-party harness from quietly spending against a different subscription than the native agent.
+
+Use the provider's own login flow to fill each installed harness slot, then list or switch the bundle:
+
+```bash
+omarchy agent account login anthropic work claude
+omarchy agent account login anthropic work pi
+omarchy agent account list anthropic
+omarchy agent account switch anthropic work
+```
+
+`claude` is accepted as an alias for `anthropic`, and `codex` for `openai`. Run `omarchy agent account` to see the active account, use `account list` to list every provider (or `account list <provider>` for just one), add `--json` for structured status, use `account switch <provider> --next` to cycle, and use `account logout <provider> <account>` to forget an inactive account. Logout moves the bundle to a recoverable trash location rather than deleting credentials in place.
+
+You can also switch the current default provider under _Setup > Defaults > Agent > Accounts_ in the Omarchy Menu. In the agents panel, `h`/`l` or a click only changes the account you are inspecting; press `s` or use the hero's **Switch** control to make it active.
+
 ### The agents panel
 
 The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
 
-Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
+Left-click the bar icon for the panel, right-click to launch your default agent. Every subscription account remains visible, including inactive ones, so you can compare their limits before switching. The active account is marked. Usage records are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can merge the same account's token history from your other machines via a synced folder.
+
+When a record includes sessions from Pi, omp, or OpenCode, the panel says so beneath the limits. Those tokens appear in the day and model charts but never move the native plan-limit meters; Pi treats subscription use through a third-party harness as extra usage billed per token. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 
 ### Crash diagnosis
 

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -97,10 +97,14 @@ Item {
 
   function scheduleLimitsRetry() {
     var advising = []
+    var seen = {}
     for (var i = 0; i < agents.length; i++) {
       var record = agents[i] ? agents[i].record : null
-      if (record && record.retryAdvised === true && providerEnabled(String(record.id || "")))
-        advising.push(String(record.id))
+      var providerId = providerIdForRecord(record)
+      if (record && record.retryAdvised === true && providerEnabled(providerId) && !seen[providerId]) {
+        advising.push(providerId)
+        seen[providerId] = true
+      }
     }
     retryAgentIds = advising
     if (advising.length > 0) limitsRetry.restart()
@@ -148,8 +152,12 @@ Item {
     if (kind === "force") command.push("--force")
     if (kind === "limits") command.push("--limits-only")
     var providers = settings && settings.providers ? settings.providers : {}
+    var seen = {}
     for (var id in providers) {
-      if (providers[id] && providers[id].enabled === false) command.push("--except", id)
+      var providerId = canonicalProviderId(id)
+      if (seen[providerId]) continue
+      seen[providerId] = true
+      if (!providerEnabled(providerId)) command.push("--except", providerId)
     }
     if (agentIds) {
       for (var i = 0; i < agentIds.length; i++) command.push(agentIds[i])
@@ -178,6 +186,48 @@ Item {
 
   // ------------------------------------------------------------- providers
 
+  function canonicalProviderId(id) {
+    var value = String(id || "")
+    if (value === "claude") return "anthropic"
+    if (value === "codex") return "openai"
+    return value
+  }
+
+  function legacyProviderId(id) {
+    var value = canonicalProviderId(id)
+    if (value === "anthropic") return "claude"
+    if (value === "openai") return "codex"
+    return value
+  }
+
+  function providerIdForRecord(record) {
+    if (!record) return ""
+    var providerId = String(record.providerId || "")
+    if (providerId === "") providerId = String(record.id || "").split("@")[0]
+    return canonicalProviderId(providerId)
+  }
+
+  function accountIdForRecord(record) {
+    if (!record) return ""
+    if (record.accountId !== undefined && record.accountId !== null)
+      return String(record.accountId)
+    var id = String(record.id || "")
+    var separator = id.indexOf("@")
+    return separator >= 0 ? id.substring(separator + 1) : ""
+  }
+
+  // This deliberately derives identity from the two stable fields rather
+  // than trusting the display record id or the mutable account label.
+  function providerAccountKey(providerId, accountId) {
+    var provider = canonicalProviderId(providerId)
+    var account = String(accountId || "")
+    return account === "" ? provider : provider + "@" + account
+  }
+
+  function recordKey(record) {
+    return providerAccountKey(providerIdForRecord(record), accountIdForRecord(record))
+  }
+
   // An agent earns a place in the bar and the panel by being switched on in
   // settings and having actually produced numbers — locally or on a synced
   // device. With nothing to show, the whole module collapses out of the bar
@@ -186,13 +236,13 @@ Item {
     var rev = dataRevision
     var syncRev = syncRevision
     var result = []
-    var localIds = {}
+    var localKeys = {}
     for (var i = 0; i < agents.length; i++) {
       var record = agents[i] ? agents[i].record : null
-      if (!record || !record.id) continue
-      var id = String(record.id)
-      localIds[id] = true
-      if (!providerEnabled(id)) continue
+      if (!record || providerIdForRecord(record) === "") continue
+      var providerId = providerIdForRecord(record)
+      localKeys[recordKey(record)] = true
+      if (!providerEnabled(providerId)) continue
       var display = displayProvider(record)
       if (providerHasData(display)) result.push(display)
     }
@@ -200,18 +250,28 @@ Item {
     // its synced numbers still deserve a tab. Rate limits stay blank — they
     // are per-account and never travel.
     var syncedProviders = syncConfigured() && aggregateData && aggregateData.providers ? aggregateData.providers : {}
-    for (var syncedId in syncedProviders) {
-      if (localIds[syncedId] || !providerEnabled(syncedId)) continue
-      var stats = syncedProviders[syncedId] || {}
-      var syncedDisplay = displayProvider({ id: syncedId, name: stats.providerName || syncedId })
+    for (var syncedKey in syncedProviders) {
+      var stats = syncedProviders[syncedKey] || {}
+      var key = providerAccountKey(stats.providerId, stats.accountId)
+      if (localKeys[key] || !providerEnabled(stats.providerId)) continue
+      var syncedDisplay = displayProvider({
+        providerId: stats.providerId,
+        accountId: stats.accountId,
+        accountLabel: stats.accountLabel,
+        name: stats.providerName || stats.providerId
+      })
       if (providerHasData(syncedDisplay)) result.push(syncedDisplay)
     }
     return result
   }
 
   function providerEnabled(id) {
-    if (!settings || !settings.providers || !settings.providers[id]) return true
-    return settings.providers[id].enabled !== false
+    if (!settings || !settings.providers) return true
+    var providerId = canonicalProviderId(id)
+    if (settings.providers[providerId]) return settings.providers[providerId].enabled !== false
+    var legacyId = legacyProviderId(providerId)
+    if (settings.providers[legacyId]) return settings.providers[legacyId].enabled !== false
+    return true
   }
 
   // All-time keeps a quiet day from hiding an agent; today's counts admit a
@@ -240,16 +300,23 @@ Item {
   }
 
   function displayProvider(record) {
-    var stats = syncedStatsFor(String(record.id))
+    var providerId = providerIdForRecord(record)
+    var accountId = accountIdForRecord(record)
+    var stats = syncedStatsFor(providerId, accountId)
     var synced = !!stats
     var deviceCount = synced ? Number(stats.deviceCount || aggregateData.deviceCount || 0) : 0
 
     return {
-      providerId: String(record.id),
-      providerName: String(record.name || record.id),
+      recordKey: providerAccountKey(providerId, accountId),
+      providerId: providerId,
+      accountId: accountId,
+      accountLabel: String(record.accountLabel || (stats ? stats.accountLabel : "") || accountId),
+      accountActive: record.accountActive === true,
+      providerName: String(record.name || (stats ? stats.providerName : "") || providerId),
       ready: record.ready === true || synced,
       usageStatusText: String(record.usageStatusText || ""),
       authHelpText: String(record.authHelpText || ""),
+      includesSharedSessions: record.includesSharedSessions === true || (synced && stats.includesSharedSessions === true),
 
       // Rate limits and balances stay per-account and are never merged
       // across devices.
@@ -547,19 +614,35 @@ Item {
     for (var key in source) target[key] = combineNumber(additive, target[key], source[key])
   }
 
+  function snapshotIdentity(mapKey, stats) {
+    var providerId = String(stats.providerId || "")
+    var accountId = String(stats.accountId || "")
+    var key = String(mapKey || "")
+    var source = providerId.indexOf("@") >= 0 ? providerId : key
+    var separator = source.indexOf("@")
+    if (accountId === "" && separator >= 0) accountId = source.substring(separator + 1)
+    if (providerId === "" || providerId.indexOf("@") >= 0)
+      providerId = separator >= 0 ? source.substring(0, separator) : source
+    return { providerId: canonicalProviderId(providerId), accountId: accountId }
+  }
+
   function aggregateSnapshots(snapshots) {
     var dates = recentDateStrings()
     var devices = {}
     var providers = {}
 
-    function providerAcc(id) {
-      if (providers[id]) return providers[id]
+    function providerAcc(providerId, accountId) {
+      var key = providerAccountKey(providerId, accountId)
+      if (providers[key]) return providers[key]
       var recentByDay = {}
       for (var d = 0; d < dates.length; d++) recentByDay[dates[d]] = 0
-      providers[id] = {
-        providerId: id,
+      providers[key] = {
+        providerId: canonicalProviderId(providerId),
+        accountId: String(accountId || ""),
+        accountLabel: "",
         providerName: "",
         ready: false,
+        includesSharedSessions: false,
         hasLocalStats: false,
         hasPromptStats: false,
         todayPrompts: 0,
@@ -574,7 +657,7 @@ Item {
         modelUsage: ({}),
         devices: ({})
       }
-      return providers[id]
+      return providers[key]
     }
 
     for (var i = 0; i < snapshots.length; i++) {
@@ -582,12 +665,15 @@ Item {
       var device = safeDeviceId(snapshot.deviceId || "device")
       devices[device] = true
       var snapshotProviders = snapshot.providers || {}
-      for (var providerId in snapshotProviders) {
-        var stats = snapshotProviders[providerId] || {}
-        var acc = providerAcc(String(providerId))
+      for (var providerKey in snapshotProviders) {
+        var stats = snapshotProviders[providerKey] || {}
+        var identity = snapshotIdentity(providerKey, stats)
+        var acc = providerAcc(identity.providerId, identity.accountId)
         acc.devices[device] = true
         if (stats.providerName && acc.providerName === "") acc.providerName = String(stats.providerName)
+        if (stats.accountLabel && acc.accountLabel === "") acc.accountLabel = String(stats.accountLabel)
         acc.ready = acc.ready || stats.ready === true
+        acc.includesSharedSessions = acc.includesSharedSessions || stats.includesSharedSessions === true
         acc.hasLocalStats = acc.hasLocalStats || stats.hasLocalStats !== false
         // Snapshots from before the field existed only came from agents that
         // count prompts, so a missing value reads as true.
@@ -624,15 +710,18 @@ Item {
     }
 
     var outProviders = {}
-    for (var id in providers) {
-      var acc = providers[id]
+    for (var key in providers) {
+      var acc = providers[key]
       var recentDays = []
       for (var di = 0; di < dates.length; di++) recentDays.push({ date: dates[di], messageCount: acc.recentByDay[dates[di]] || 0 })
       var providerDevices = Object.keys(acc.devices).sort()
-      outProviders[id] = {
+      outProviders[key] = {
         providerId: acc.providerId,
+        accountId: acc.accountId,
+        accountLabel: acc.accountLabel,
         providerName: acc.providerName,
         ready: acc.ready || providerDevices.length > 0,
+        includesSharedSessions: acc.includesSharedSessions,
         hasLocalStats: acc.hasLocalStats,
         hasPromptStats: acc.hasPromptStats,
         todayPrompts: acc.todayPrompts,
@@ -663,9 +752,12 @@ Item {
   // of machines on mixed versions still merges cleanly in both directions.
   function providerSnapshot(record) {
     return {
-      providerId: String(record.id),
-      providerName: String(record.name || record.id),
+      providerId: providerIdForRecord(record),
+      accountId: accountIdForRecord(record),
+      accountLabel: String(record.accountLabel || accountIdForRecord(record)),
+      providerName: String(record.name || providerIdForRecord(record)),
       ready: record.ready === true,
+      includesSharedSessions: record.includesSharedSessions === true,
       hasLocalStats: record.hasLocalStats !== false,
       hasPromptStats: record.hasPromptStats !== false,
       scope: String(record.scope || "device"),
@@ -686,9 +778,10 @@ Item {
     var providerMap = {}
     for (var i = 0; i < agents.length; i++) {
       var record = agents[i] ? agents[i].record : null
-      if (!record || !record.id) continue
-      if (!providerEnabled(String(record.id))) continue
-      providerMap[String(record.id)] = providerSnapshot(record)
+      if (!record || providerIdForRecord(record) === "") continue
+      var providerId = providerIdForRecord(record)
+      if (!providerEnabled(providerId)) continue
+      providerMap[recordKey(record)] = providerSnapshot(record)
     }
     return {
       schemaVersion: 1,
@@ -698,10 +791,10 @@ Item {
     }
   }
 
-  function syncedStatsFor(providerId) {
+  function syncedStatsFor(providerId, accountId) {
     var rev = syncRevision
     if (!syncConfigured() || !aggregateData || !aggregateData.providers) return null
-    return aggregateData.providers[providerId] || null
+    return aggregateData.providers[providerAccountKey(providerId, accountId)] || null
   }
 
   // ---------------------------------------------------------------- format

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -19,13 +19,13 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
   readonly property var providers: usage.enabledProviders
-  // The selection follows the provider, not the slot it happens to sit in: a
-  // provider whose first scan lands while the panel is open would otherwise
-  // shift the list underneath you and swap out what you were reading.
-  property string selectedProviderId: ""
+  // The selection follows the provider/account identity, not the slot it
+  // happens to sit in: a record whose first scan lands while the panel is open
+  // would otherwise shift the list underneath you and swap what you were reading.
+  property string selectedRecordKey: ""
   readonly property int providerIndex: {
     for (var i = 0; i < providers.length; i++)
-      if (providers[i].providerId === selectedProviderId) return i
+      if (providers[i].recordKey === selectedRecordKey) return i
     return 0
   }
   readonly property var provider: providers.length > 0 ? providers[providerIndex] : null
@@ -52,7 +52,7 @@ Panel {
   function selectProvider(index) {
     if (providers.length === 0) return
     var wrapped = ((index % providers.length) + providers.length) % providers.length
-    selectedProviderId = providers[wrapped].providerId
+    selectedRecordKey = providers[wrapped].recordKey
   }
 
   function refreshNow() {
@@ -62,6 +62,35 @@ Panel {
   function launchAgent() {
     if (root.bar) root.bar.run("omarchy-agent --pick")
     root.close()
+  }
+
+  function accountSwitchable(p) {
+    if (!p || String(p.accountId || "") === "") return false
+    return p.providerId === "anthropic" || p.providerId === "openai"
+  }
+
+  function switchAccount() {
+    if (!accountSwitchable(root.provider) || root.provider.accountActive || !root.bar) return
+    root.bar.run("omarchy agent account switch "
+      + Util.shellQuote(root.provider.providerId) + " "
+      + Util.shellQuote(root.provider.accountId))
+    // The account command asks this panel to refresh after the credential
+    // bundle has finished switching, so keep it open for the new active mark.
+  }
+
+  function providerAccountCount(p) {
+    if (!p) return 0
+    var count = 0
+    for (var i = 0; i < providers.length; i++)
+      if (providers[i].providerId === p.providerId) count++
+    return count
+  }
+
+  function chipLabel(p) {
+    if (!p) return ""
+    if (providerAccountCount(p) > 1 && String(p.accountLabel || "") !== "")
+      return p.providerName + " · " + p.accountLabel
+    return p.providerName
   }
 
   // ---------------------------------------------------------------- limits
@@ -283,14 +312,21 @@ Panel {
   }
 
   // Marks resolve by convention, so a new agent's data file needs nothing
-  // from this panel: assets/<id>.svg if it ships one, the module's bar glyph
-  // if it doesn't.
+  // from this panel. The subscription providers retain their established
+  // Claude/Codex asset names even though records carry Anthropic/OpenAI ids.
+  function assetIdForProvider(providerId) {
+    if (providerId === "anthropic") return "claude"
+    if (providerId === "openai") return "codex"
+    return String(providerId || "")
+  }
+
   function iconCandidatesForProvider(p, surfaceColor) {
     if (!p) return []
     var candidates = []
+    var assetId = assetIdForProvider(p.providerId)
     if (colorLuminance(surfaceColor || Color.background) >= 0.5)
-      candidates.push(Qt.resolvedUrl("assets/" + p.providerId + "-light.svg"))
-    candidates.push(Qt.resolvedUrl("assets/" + p.providerId + ".svg"))
+      candidates.push(Qt.resolvedUrl("assets/" + assetId + "-light.svg"))
+    candidates.push(Qt.resolvedUrl("assets/" + assetId + ".svg"))
     return candidates
   }
 
@@ -376,7 +412,10 @@ Panel {
       onActivateRequested: root.refreshNow()
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
-      onTextKey: function(t) { if (t === "r" || t === "R") root.refreshNow() }
+      onTextKey: function(t) {
+        if (t === "r" || t === "R") root.refreshNow()
+        else if (t === "s" || t === "S") root.switchAccount()
+      }
 
       Flickable {
         id: panelFlick
@@ -399,10 +438,32 @@ Panel {
             id: hero
             visible: !!root.provider
             width: parent.width
+            readonly property bool accountCanSwitch: root.accountSwitchable(root.provider)
+            readonly property bool selectedAccountActive: !!root.provider && root.provider.accountActive === true
+            function makeAccountActive() { root.switchAccount() }
+
             title: root.provider ? root.provider.providerName : ""
             meta: root.heroMeta(root.provider)
+            detail: root.provider ? String(root.provider.accountLabel || "") : ""
             foreground: root.foreground
             fontFamily: root.fontFamily
+
+            trailingControl: Component {
+              Button {
+                visible: hero.accountCanSwitch
+                enabled: !hero.selectedAccountActive
+                opacity: enabled ? 1 : 0.65
+                text: hero.selectedAccountActive ? "Active" : "Switch"
+                iconText: hero.selectedAccountActive ? "✓" : ""
+                bordered: true
+                foreground: hero.foreground
+                fontFamily: hero.fontFamily
+                fontSize: Style.font.bodySmall
+                verticalPadding: Style.spacing.controlPaddingY
+                tooltipText: hero.selectedAccountActive ? "Active subscription account" : "Make this the active account (s)"
+                onClicked: hero.makeAccountActive()
+              }
+            }
 
             iconComponent: Component {
               Item {
@@ -458,14 +519,15 @@ Panel {
           }
 
           // ---------- Provider switch ----------
-          Row {
+          Grid {
             id: providerSwitch
             visible: root.providers.length > 1
             width: parent.width
+            columns: Math.min(2, root.providers.length)
             spacing: Style.spacing.md
 
             readonly property real cellWidth: root.providers.length > 0
-              ? (width - spacing * (root.providers.length - 1)) / root.providers.length
+              ? (width - spacing * (columns - 1)) / columns
               : 0
 
             Repeater {
@@ -476,7 +538,8 @@ Panel {
                 required property int index
 
                 width: providerSwitch.cellWidth
-                text: modelData.providerName
+                text: root.chipLabel(modelData)
+                iconText: modelData.accountActive ? "✓" : ""
                 selected: index === root.providerIndex
                 hasCursor: root.cursorActive && index === root.providerIndex
                 bordered: true
@@ -605,6 +668,17 @@ Panel {
                 window: modelData
               }
             }
+          }
+
+          Text {
+            visible: !!root.provider && root.provider.includesSharedSessions === true
+            width: parent.width
+            text: "Shared-harness tokens appear in the charts but never move these plan limits; Pi bills them as extra per-token usage."
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
           }
 
           // ---------- Usage ----------

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-One bar icon and one panel for every AI coding subscription on the machine.
+One bar icon and one panel for every AI coding subscription account on the machine.
 The panel is strictly a display: it watches the usage records that
 `omarchy-agent-usage-update` writes to `~/.local/state/omarchy/agents/usage/`
 and draws whatever appears there. `Panel.qml` owns the bar button and the
@@ -9,10 +9,14 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 
 ## Panel
 
-- **Hero** — the mark, the tool, and the plan it runs on ("Max 20x", "Pro").
-  Auth and endpoint problems replace the plan line and repeat in a card.
-- **Subscription switch** — one chip per enabled agent (`h`/`l` or click).
-  It appears only when more than one agent is enabled.
+- **Hero** — the mark, the provider, the account, and the plan it runs on
+  ("Max 20x", "Pro"). Auth and endpoint problems replace the plan line and
+  repeat in a card. An inactive managed account has an explicit **Switch**
+  control; the active account is marked **Active**.
+- **Account view switch** — one chip per record (`h`/`l` or click). A provider
+  with several accounts labels each chip with both, such as "Claude · work";
+  a sole account keeps the plain provider label. This only changes the record
+  being viewed—it does not change the credentials in use.
 - **Limits** — the percentage of each allowance used, a matching meter, and
   the time until the session or weekly window resets.
 - **Balance** — prepaid agents report a credit ledger instead of limits:
@@ -24,11 +28,15 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
   to the heaviest model,
   the same way the weekly chart scales to its busiest day. Hover for the
   input / output / cache split.
+- **Shared-usage note** — records that include Pi, omp, or OpenCode sessions
+  explain that those tokens appear in the charts but do not move the plan's
+  limit meters. Pi bills subscription use through a third-party harness as
+  extra per-token usage.
 
-A subscription appears only when it is enabled in settings and has actually
-recorded usage — on this machine or on a synced one. With one such agent
-there is no switch row at all; with none, the module leaves the bar entirely
-rather than sitting there with nothing to say. A CLI installed mid-session
+A subscription account appears only when its provider is enabled in settings
+and it has actually recorded usage — on this machine or on a synced one. With
+one such record there is no switch row at all; with none, the module leaves
+the bar entirely rather than sitting there with nothing to say. A CLI installed mid-session
 shows up at the next refresh, so nothing polls the disk waiting for it.
 
 That self-hiding is why the widget ships in the default bar layout: a machine
@@ -38,22 +46,27 @@ its own the first time a scan finds usage. Drop it with
 
 ## Data
 
-Each agent is one JSON record in `~/.local/state/omarchy/agents/usage/`,
-written by `omarchy-agent-usage-update`. That command runs one
-`omarchy-agent-usage-<agent>` collector per agent; the widget invokes it
-on its refresh timer and whenever you ask for a refresh, and picks up any
-record that lands in the directory regardless of who wrote it.
+Each subscription account is one JSON record in
+`~/.local/state/omarchy/agents/usage/`, written by
+`omarchy-agent-usage-update`. Managed records are named
+`<providerId>@<accountId>.json` and carry `providerId`, immutable `accountId`,
+display `accountLabel`, and `accountActive` fields. The command still runs one
+`omarchy-agent-usage-<agent>` collector per provider, fanning it out over the
+managed accounts; the widget invokes it on its refresh timer and whenever you
+ask for a refresh.
 
-Adding an agent therefore never touches this plugin: ship a collector that
+Adding a provider therefore never touches this plugin: ship a collector that
 prints the record contract (see the `claude` and `codex` collectors in
 `bin/`), and the panel gains a tab. An `assets/<id>.svg` mark is optional —
 with an `assets/<id>-light.svg` twin if the mark needs a dark variant for
-light surfaces — and the bar glyph stands in when there is none.
+light surfaces — and the bar glyph stands in when there is none. Anthropic
+and OpenAI records deliberately reuse the established `claude.svg` and
+`codex.svg` asset names.
 
 | Collector | Limits | Local stats |
 |---|---|---|
-| `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
-| `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
+| `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, plus account-attributed Pi, omp, and OpenCode sessions on Anthropic |
+| `codex` | The Codex app-server RPC | native Codex CLI session files, plus account-attributed Pi, omp, and OpenCode sessions on OpenAI |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
@@ -63,6 +76,11 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+Shared harness sessions are attributed by the account-switch ledger. Their
+tokens belong in the token history for the subscription that was active at
+the time, but never in its native limit percentages; this is why a chart can
+grow while the corresponding limit meter does not.
 
 ### Fireworks balance
 
@@ -95,8 +113,11 @@ only adds the meter and the spent-of-funded line under the real figure.
 ## Interactions
 
 - Bar icon: left = panel, right = launch agent, middle = next subscription.
-- Panel: `h`/`l` switch subscription, `j`/`k` scroll, `r` or Enter refresh,
-  Tab moves to the neighboring bar panel, Esc closes.
+- Panel: `h`/`l` change the account record being viewed, `s` makes that
+  account active, `j`/`k` scroll, `r` or Enter refresh, Tab moves to the
+  neighboring bar panel, Esc closes. Switching runs
+  `omarchy agent account switch <providerId> <accountId>` and requests a
+  refresh when the credential swap completes.
 - IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next>`.
 
 ## Settings
@@ -120,21 +141,23 @@ omarchy bar set omarchy.agents refreshIntervalSec 300 --json
 omarchy bar set omarchy.agents syncDir '~/Sync/agent-usage'
 ```
 
-Per-agent enablement is nested, and `set` writes its key literally rather
+Per-provider enablement is nested, and `set` writes its key literally rather
 than walking a dotted path — so pass the whole `providers` object as JSON (or
 edit `shell.json` directly):
 
 ```bash
 omarchy bar set omarchy.agents providers '{
-  "claude": { "enabled": true },
-  "codex": { "enabled": false },
+  "anthropic": { "enabled": true },
+  "openai": { "enabled": false },
   "fireworks": { "enabled": true }
 }' --json
 ```
 
-`enabled` defaults to `true` for every discovered agent; set it to `false` to
-hide a subscription that is installed. Disabled agents are also skipped when
-the records regenerate.
+The canonical keys are `anthropic`, `openai`, and `fireworks` (`claude` and
+`codex` remain accepted for existing `shell.json` files). `enabled` defaults
+to `true` for every discovered provider; set it to `false` to hide all of that
+provider's account records. Disabled providers are also skipped when the
+records regenerate.
 
 With `syncMode` on, every `*.json` snapshot in `syncDir` is merged, so today,
 the last 7 days, and the all-time totals cover every machine you code on —
@@ -142,7 +165,10 @@ active days are unioned by date rather than summed. Rate limits stay
 per-account and are never merged. A record may declare `"scope": "account"`
 when its stats are account-global rather than machine-local (Fireworks'
 billing API); those merge by taking the widest value instead of summing, so
-the same account synced from two machines is not counted twice.
+the same account synced from two machines is not counted twice. Sync identity
+is the pair of `providerId` and immutable `accountId`: two accounts at one
+provider remain separate, while the same account from two machines merges
+even if its label changes.
 
 One caveat on "all-time": the Codex collector only reads native session files
 touched in the last 30 days, and Fireworks requests the last 30 days from its

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -19,8 +19,8 @@
     "allowMultiple": false,
     "defaults": {
       "providers": {
-        "claude": { "enabled": true },
-        "codex": { "enabled": true },
+        "anthropic": { "enabled": true },
+        "openai": { "enabled": true },
         "fireworks": { "enabled": true }
       },
       "refreshIntervalSec": 900,

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -273,6 +273,18 @@ Item {
       volatile: true,
       actionFor: function(value) { return "omarchy-font-set " + Util.shellQuote(value) }
     },
+    "agent-accounts": {
+      script: "omarchy agent account list --json 2>/dev/null | jq -r '.[] | [((.providerName // .providerId) + \" · \" + .accountLabel), (.providerId + \"@\" + .accountId), (if .accountActive then (.providerId + \"@\" + .accountId) else \"\" end)] | @tsv' 2>/dev/null",
+      icon: "󰚩",
+      volatile: true,
+      actionFor: function(value) {
+        var separator = value.indexOf("@")
+        if (separator < 1) return ""
+        var providerId = value.substring(0, separator)
+        var accountId = value.substring(separator + 1)
+        return "omarchy agent account switch " + Util.shellQuote(providerId) + " " + Util.shellQuote(accountId)
+      }
+    },
     "power-profiles": {
       script: "current=$(powerprofilesctl get 2>/dev/null); omarchy-powerprofiles-list 2>/dev/null | while read -r p; do [[ -z $p ]] && continue; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
       icon: "\udb81\udc0b",

--- a/test/cli
+++ b/test/cli
@@ -500,13 +500,13 @@ cp "$NEXT_THEME/claude.json" "$CURRENT_THEME/claude.json"
 
 CLAUDE_TEST_CONFIG="$PI_TMPDIR/.claude-work"
 mkdir -p "$CLAUDE_TEST_CONFIG"
-HOME="$PI_TMPDIR" CLAUDE_CONFIG_DIR="$CLAUDE_TEST_CONFIG" "$ROOT/bin/omarchy-theme-set-claude"
+OMARCHY_PATH="$ROOT" HOME="$PI_TMPDIR" CLAUDE_CONFIG_DIR="$CLAUDE_TEST_CONFIG" "$ROOT/bin/omarchy-theme-set-claude"
 [[ -f $CLAUDE_TEST_CONFIG/themes/omarchy.json ]] || fail "claude theme is synced to the configured directory"
 [[ ! -d $PI_TMPDIR/.claude ]] || fail "claude theme sync avoids the default directory when configured"
 pass "claude theme sync respects CLAUDE_CONFIG_DIR"
 
 echo '{"model":"keep-me"}' >"$CLAUDE_TEST_CONFIG/settings.json"
-HOME="$PI_TMPDIR" CLAUDE_CONFIG_DIR="$CLAUDE_TEST_CONFIG" "$ROOT/bin/omarchy-theme-set-claude" --activate
+OMARCHY_PATH="$ROOT" HOME="$PI_TMPDIR" CLAUDE_CONFIG_DIR="$CLAUDE_TEST_CONFIG" "$ROOT/bin/omarchy-theme-set-claude" --activate
 jq -e '.theme == "custom:omarchy" and .model == "keep-me"' "$CLAUDE_TEST_CONFIG/settings.json" >/dev/null
 pass "claude theme activation preserves configured settings"
 

--- a/test/shell.d/agent-account-test.sh
+++ b/test/shell.d/agent-account-test.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command flock
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+mock_bin="$test_tmp/bin"
+launcher_log="$test_tmp/launcher-log"
+shell_log="$test_tmp/shell-log"
+mkdir -p "$test_home" "$mock_bin"
+
+cat >"$mock_bin/omarchy-default-agent" <<'SH'
+#!/bin/bash
+printf '%s\n' "${OMARCHY_TEST_DEFAULT_AGENT-claude}"
+SH
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+for command in "$@"; do
+  case " ${OMARCHY_TEST_INSTALLED_HARNESSES:-claude codex pi opencode} " in
+  *" $command "*) ;;
+  *) exit 0 ;;
+  esac
+done
+exit 1
+SH
+
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >"$OMARCHY_TEST_LAUNCHER_LOG"
+SH
+
+cat >"$mock_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >>"$OMARCHY_TEST_SHELL_LOG"
+SH
+
+cat >"$mock_bin/gum" <<'SH'
+#!/bin/bash
+first=""
+while IFS= read -r row; do
+  [[ -n $first ]] || first="$row"
+done
+printf '%s\n' "${OMARCHY_TEST_GUM_CHOICE:-$first}"
+SH
+
+cat >"$mock_bin/claude" <<'SH'
+#!/bin/bash
+mkdir -p "$CLAUDE_CONFIG_DIR"
+jq -n --arg token "${OMARCHY_TEST_CLAUDE_TOKEN:-claude-login}" '{oauth: $token}' >"$CLAUDE_CONFIG_DIR/.credentials.json"
+SH
+
+cat >"$mock_bin/codex" <<'SH'
+#!/bin/bash
+mkdir -p "$CODEX_HOME"
+jq -n --arg token "${OMARCHY_TEST_CODEX_TOKEN:-codex-login}" '{tokens: $token}' >"$CODEX_HOME/auth.json"
+SH
+
+cat >"$mock_bin/pi" <<'SH'
+#!/bin/bash
+auth_file="$HOME/.pi/agent/auth.json"
+auth_key=${OMARCHY_TEST_PI_AUTH_KEY:?}
+mkdir -p "$(dirname "$auth_file")"
+if [[ -f $auth_file ]]; then
+  jq --arg key "$auth_key" --arg token "${OMARCHY_TEST_PI_TOKEN:-pi-login}" '.[$key] = {type: "oauth", access: $token}' "$auth_file" >"$auth_file.tmp"
+else
+  jq -n --arg key "$auth_key" --arg token "${OMARCHY_TEST_PI_TOKEN:-pi-login}" '{($key): {type: "oauth", access: $token}}' >"$auth_file.tmp"
+fi
+mv -T "$auth_file.tmp" "$auth_file"
+SH
+
+cat >"$mock_bin/opencode" <<'SH'
+#!/bin/bash
+provider=""
+while (( $# > 0 )); do
+  if [[ $1 == "--provider" ]]; then
+    provider="$2"
+    shift
+  fi
+  shift
+done
+auth_file="${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json"
+mkdir -p "$(dirname "$auth_file")"
+if [[ -f $auth_file ]]; then
+  jq --arg key "$provider" --arg token "${OMARCHY_TEST_OPENCODE_TOKEN:-opencode-login}" '.[$key] = {type: "oauth", refresh: $token, access: $token, expires: 9999999999999}' "$auth_file" >"$auth_file.tmp"
+else
+  jq -n --arg key "$provider" --arg token "${OMARCHY_TEST_OPENCODE_TOKEN:-opencode-login}" '{($key): {type: "oauth", refresh: $token, access: $token, expires: 9999999999999}}' >"$auth_file.tmp"
+fi
+mv -T "$auth_file.tmp" "$auth_file"
+SH
+
+cat >"$mock_bin/omarchy-done" <<'SH'
+#!/bin/bash
+[[ $1 != "check" ]]
+SH
+
+cat >"$mock_bin/omarchy-test-noop" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+for command in omarchy-refresh-applications xdg-mime xdg-settings xdg-user-dirs-update; do
+  ln -s omarchy-test-noop "$mock_bin/$command"
+done
+chmod +x "$mock_bin"/*
+
+export HOME="$test_home"
+export OMARCHY_PATH="$ROOT"
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+export OMARCHY_TEST_LAUNCHER_LOG="$launcher_log"
+export OMARCHY_TEST_SHELL_LOG="$shell_log"
+
+bare_home="$test_tmp/bare-home"
+mkdir -p "$bare_home"
+bare_output=$(HOME="$bare_home" OMARCHY_TEST_DEFAULT_AGENT="" omarchy-agent-account)
+[[ $bare_output == "No agent accounts are set up yet." ]] || fail "bare account command explains that no accounts are configured"
+pass "bare account command succeeds when no default agent is set"
+
+claude_only_home="$test_tmp/claude-only-home"
+mkdir -p "$claude_only_home/.claude"
+printf '{"oauth":"claude-only-default"}\n' >"$claude_only_home/.claude/.credentials.json"
+(
+  export HOME="$claude_only_home"
+  export OMARCHY_TEST_INSTALLED_HARNESSES="claude"
+  [[ $(omarchy-agent-account anthropic) == "default" ]]
+  OMARCHY_TEST_CLAUDE_TOKEN=claude-only-work \
+    omarchy-agent-account-login --run-slot-login anthropic work claude >"$test_tmp/claude-only-login" 2>&1
+  omarchy-agent-account-switch anthropic default >/dev/null
+  omarchy-agent-account-switch anthropic work >"$test_tmp/claude-only-switch" 2>&1
+  [[ $(OMARCHY_TEST_DEFAULT_AGENT="" omarchy-agent-account) == "Anthropic: work" ]]
+  claude_only_list=$(omarchy-agent-account-list anthropic)
+  [[ $claude_only_list != *"missing pi:"* ]]
+  [[ $claude_only_list != *"missing opencode:"* ]]
+  omarchy-agent-account-list anthropic --json |
+    jq -e 'all(.[]; (.slots | keys) == ["claude"] and .missingSlots == [])' >/dev/null
+)
+[[ $(<"$test_tmp/claude-only-switch") == "Switched Anthropic to account 'work'." ]] ||
+  fail "Claude-only switch mentions no uninstalled harnesses"
+[[ ! -e $claude_only_home/.pi ]] || fail "Claude-only account handling does not create a Pi auth directory"
+[[ ! -e $claude_only_home/.local/share/opencode ]] || fail "Claude-only account handling does not create an OpenCode auth directory"
+pass "Claude-only machines switch and list accounts without uninstalled harness slots"
+pass "uninstalled harnesses get no auth files or directories"
+
+(
+  export XDG_DATA_HOME="$test_tmp/xdg-data"
+  source "$ROOT/bin/omarchy-agent-account-backends"
+  agent_account_provider_load anthropic
+  agent_account_slot_load opencode
+  [[ $AGENT_ACCOUNT_SLOT_AUTH_FILE == "$XDG_DATA_HOME/opencode/auth.json" ]]
+) || fail "OpenCode auth-key slots honor XDG_DATA_HOME"
+pass "OpenCode auth-key slots honor XDG_DATA_HOME"
+
+pi_auth="$HOME/.pi/agent/auth.json"
+opencode_auth="$HOME/.local/share/opencode/auth.json"
+anthropic_root="$HOME/.local/share/omarchy/agents/anthropic"
+
+mkdir -p "$HOME/.claude" "$(dirname "$pi_auth")" "$(dirname "$opencode_auth")"
+printf '{"oauth":"legacy-claude"}\n' >"$HOME/.claude/.credentials.json"
+printf '{"anthropic":{"type":"oauth","access":"default-pi"},"openai-codex":{"type":"oauth","access":"openai-sibling"},"google":{"type":"api_key","key":"pi-sibling"}}\n' >"$pi_auth"
+printf '{"anthropic":{"type":"oauth","refresh":"default-opencode","access":"default-opencode","expires":9999999999999},"openai":{"type":"oauth","refresh":"openai-sibling","access":"openai-sibling","expires":9999999999999},"google":{"type":"api","key":"opencode-sibling"}}\n' >"$opencode_auth"
+
+[[ $(omarchy-agent-account claude) == "default" ]] || fail "Claude alias selects the Anthropic provider"
+[[ -L $HOME/.claude ]] || fail "Claude canonical config becomes a symlink"
+[[ $(readlink "$HOME/.claude") == "$anthropic_root/default/claude" ]] ||
+  fail "Claude config points at the adopted provider account slot"
+jq -e '.oauth == "legacy-claude"' "$anthropic_root/default/claude/.credentials.json" >/dev/null ||
+  fail "adoption preserves the existing Claude credential"
+jq -e '.access == "default-pi"' "$anthropic_root/default/slots/pi.json" >/dev/null ||
+  fail "adoption captures the live Pi Anthropic key"
+jq -e '.access == "default-opencode"' "$anthropic_root/default/slots/opencode.json" >/dev/null ||
+  fail "adoption captures the live OpenCode Anthropic key"
+jq -e '.google.key == "pi-sibling" and .["openai-codex"].access == "openai-sibling"' "$pi_auth" >/dev/null ||
+  fail "adoption leaves Pi sibling providers untouched"
+jq -e '.google.key == "opencode-sibling" and .openai.access == "openai-sibling"' "$opencode_auth" >/dev/null ||
+  fail "adoption leaves OpenCode sibling providers untouched"
+[[ $(stat -c '%a' "$anthropic_root") == "700" ]] || fail "managed provider root is private"
+[[ $(stat -c '%a' "$anthropic_root/default") == "700" ]] || fail "account bundle is private"
+[[ $(stat -c '%a' "$anthropic_root/default/claude") == "700" ]] || fail "config-dir slot is private"
+[[ $(stat -c '%a' "$anthropic_root/default/slots/pi.json") == "600" ]] || fail "stored auth-key slot is private"
+pass "existing provider credentials are adopted into private per-harness slots"
+
+list_output=$(omarchy-agent-account-list anthropic)
+[[ $list_output == "* anthropic default" ]] || fail "complete text account list marks the active provider account"
+omarchy-agent-account-list anthropic --json |
+  jq -e 'length == 1 and .[0].providerId == "anthropic" and .[0].accountId == "default" and .[0].accountActive and (.[0].slots | all(.[]; .filled)) and .[0].missingSlots == []' >/dev/null ||
+  fail "JSON account list exposes canonical provider identity and slot readiness"
+pass "account lists report canonical providers and per-slot readiness"
+
+if omarchy-agent-account-login anthropic ../escape claude >"$test_tmp/invalid-output" 2>&1; then
+  fail "account names cannot escape the managed root"
+fi
+grep -Fq "Invalid account name '../escape'" "$test_tmp/invalid-output" ||
+  fail "invalid account errors name the rejected value"
+[[ ! -e $HOME/.local/share/omarchy/agents/escape ]] || fail "invalid account names create no profile"
+
+if omarchy-agent-account-login anthropic openai claude >"$test_tmp/reserved-output" 2>&1; then
+  fail "account IDs cannot collide with provider arguments"
+fi
+grep -Fq "provider names and aliases are reserved" "$test_tmp/reserved-output" ||
+  fail "reserved account errors explain the provider ambiguity"
+pass "account IDs preserve containment and provider argument boundaries"
+
+: >"$launcher_log"
+omarchy-agent-account-login anthropic work claude
+mapfile -d '' -t launcher_args <"$launcher_log"
+expected_login="$ROOT/bin/omarchy-agent-account-login --run-slot-login anthropic work claude"
+[[ ${#launcher_args[@]} == 1 && ${launcher_args[0]} == "$expected_login" ]] ||
+  fail "public login launches the selected harness slot flow"
+[[ $(omarchy-agent-account anthropic) == "default" ]] || fail "launching a login terminal does not mutate the default-agent setting or account state"
+
+OMARCHY_TEST_CLAUDE_TOKEN=work-claude \
+  omarchy-agent-account-login --run-slot-login anthropic work claude 2>"$test_tmp/claude-missing"
+[[ $(omarchy-agent-account anthropic) == "work" ]] || fail "slot login activates its provider account"
+jq -e '.oauth == "work-claude"' "$anthropic_root/work/claude/.credentials.json" >/dev/null ||
+  fail "Claude login writes into the account's config-dir slot"
+grep -Fq "pi: omarchy agent account login anthropic work pi" "$test_tmp/claude-missing" ||
+  fail "login reports the missing Pi slot and its fill command"
+grep -Fq "opencode: omarchy agent account login anthropic work opencode" "$test_tmp/claude-missing" ||
+  fail "login reports the missing OpenCode slot and its fill command"
+jq -e 'has("anthropic") | not' "$pi_auth" >/dev/null || fail "partial login does not leave the outgoing Pi credential live"
+jq -e '.google.key == "pi-sibling" and .["openai-codex"].access == "openai-sibling"' "$pi_auth" >/dev/null ||
+  fail "partial activation preserves unrelated Pi providers"
+pass "login fills one slot and reports every still-empty slot"
+
+omarchy-agent-account-switch anthropic default >/dev/null
+omarchy-agent-account-switch anthropic work >"$test_tmp/missing-switch" 2>&1
+grep -Fq "pi: omarchy agent account login anthropic work pi" "$test_tmp/missing-switch" ||
+  fail "partial switch names the empty Pi slot and fill command"
+grep -Fq "opencode: omarchy agent account login anthropic work opencode" "$test_tmp/missing-switch" ||
+  fail "partial switch names the empty OpenCode slot and fill command"
+[[ $(omarchy-agent-account anthropic) == "work" ]] || fail "empty installed slots do not block a partially filled account"
+jq -e '(has("anthropic") | not) and .google.key == "pi-sibling" and .["openai-codex"].access == "openai-sibling"' "$pi_auth" >/dev/null ||
+  fail "partial switch clears Pi's provider credential and preserves sibling providers"
+jq -e '(has("anthropic") | not) and .google.key == "opencode-sibling" and .openai.access == "openai-sibling"' "$opencode_auth" >/dev/null ||
+  fail "partial switch clears OpenCode's provider credential and preserves sibling providers"
+pass "installed empty slots warn, stay signed out, and do not block switching"
+
+mkdir -p "$anthropic_root/empty/claude"
+if omarchy-agent-account-switch anthropic empty >"$test_tmp/empty-switch" 2>&1; then
+  fail "switching accepts an account with no filled slots"
+fi
+grep -Fq "Anthropic account 'empty' has no filled credential slots." "$test_tmp/empty-switch" ||
+  fail "an entirely empty account explains why switching is refused"
+[[ $(omarchy-agent-account anthropic) == "work" ]] || fail "an entirely empty account leaves the active account unchanged"
+pass "accounts with no filled installed slot are refused"
+
+OMARCHY_TEST_PI_AUTH_KEY=anthropic OMARCHY_TEST_PI_TOKEN=work-pi \
+  omarchy-agent-account-login --run-slot-login anthropic work pi 2>"$test_tmp/pi-missing"
+grep -Fq "opencode: omarchy agent account login anthropic work opencode" "$test_tmp/pi-missing" ||
+  fail "Pi login still reports the empty OpenCode slot"
+OMARCHY_TEST_OPENCODE_TOKEN=work-opencode \
+  omarchy-agent-account-login --run-slot-login anthropic work opencode
+jq -e '.access == "work-pi"' "$anthropic_root/work/slots/pi.json" >/dev/null || fail "Pi provider key is captured into its account slot"
+jq -e '.access == "work-opencode"' "$anthropic_root/work/slots/opencode.json" >/dev/null || fail "OpenCode provider key is captured into its account slot"
+pass "auth-key logins capture only the provider key written by each harness"
+
+jq '.anthropic.access = "work-pi-refreshed"' "$pi_auth" >"$pi_auth.tmp"
+mv -T "$pi_auth.tmp" "$pi_auth"
+jq '.anthropic.access = "work-opencode-refreshed" | .anthropic.refresh = "work-opencode-refreshed"' "$opencode_auth" >"$opencode_auth.tmp"
+mv -T "$opencode_auth.tmp" "$opencode_auth"
+
+omarchy-agent-account-switch anthropic default >/dev/null
+jq -e '.access == "work-pi-refreshed"' "$anthropic_root/work/slots/pi.json" >/dev/null ||
+  fail "switch stashes Pi's refreshed OAuth blob before restoring the incoming account"
+jq -e '.access == "work-opencode-refreshed"' "$anthropic_root/work/slots/opencode.json" >/dev/null ||
+  fail "switch stashes OpenCode's refreshed OAuth blob before restoring the incoming account"
+jq -e '.anthropic.access == "default-pi" and .google.key == "pi-sibling" and .["openai-codex"].access == "openai-sibling"' "$pi_auth" >/dev/null ||
+  fail "Pi restore replaces only Anthropic and preserves sibling providers"
+jq -e '.anthropic.access == "default-opencode" and .google.key == "opencode-sibling" and .openai.access == "openai-sibling"' "$opencode_auth" >/dev/null ||
+  fail "OpenCode restore replaces only Anthropic and preserves sibling providers"
+
+omarchy-agent-account-switch anthropic work >/dev/null
+jq -e '.anthropic.access == "work-pi-refreshed" and .google.key == "pi-sibling" and .["openai-codex"].access == "openai-sibling"' "$pi_auth" >/dev/null ||
+  fail "Pi round trip restores the refreshed account credential and siblings"
+jq -e '.anthropic.access == "work-opencode-refreshed" and .google.key == "opencode-sibling" and .openai.access == "openai-sibling"' "$opencode_auth" >/dev/null ||
+  fail "OpenCode round trip restores the refreshed account credential and siblings"
+[[ $(stat -c '%a' "$pi_auth") == "600" && $(stat -c '%a' "$opencode_auth") == "600" ]] ||
+  fail "auth-key restores keep shared auth files at 0600"
+pass "auth-key slots round-trip refreshed OAuth blobs without touching sibling providers"
+
+ledger="$HOME/.local/state/omarchy/agents/switches/anthropic.json"
+jq -e 'length >= 2 and all(.[]; .providerId == "anthropic" and (.accountId | type == "string") and (.timestamp | fromdateiso8601)) and .[-1].accountId == "work"' "$ledger" >/dev/null ||
+  fail "switch ledger records timestamped canonical provider/account changes"
+[[ $(stat -c '%a' "$ledger") == "600" ]] || fail "switch ledger is private"
+pass "provider switches append an atomic timestamped ledger for later attribution"
+
+omarchy-agent-account-switch anthropic --next >/dev/null
+[[ $(omarchy-agent-account anthropic) == "default" ]] || fail "--next cycles complete provider accounts"
+OMARCHY_TEST_GUM_CHOICE=work omarchy-agent-account-switch anthropic >/dev/null
+[[ $(omarchy-agent-account anthropic) == "work" ]] || fail "account picker switches every provider slot"
+pass "provider account switching supports cycling and interactive selection"
+
+mkdir -p "$anthropic_root/interrupted/claude" "$anthropic_root/interrupted/slots"
+printf '{"oauth":"interrupted-claude"}\n' >"$anthropic_root/interrupted/claude/.credentials.json"
+printf '{"type":"oauth","access":"interrupted-pi"}\n' >"$anthropic_root/interrupted/slots/pi.json"
+printf '{"type":"oauth","refresh":"interrupted-opencode","access":"interrupted-opencode","expires":9999999999999}\n' >"$anthropic_root/interrupted/slots/opencode.json"
+chmod 700 "$anthropic_root/interrupted" "$anthropic_root/interrupted/claude" "$anthropic_root/interrupted/slots"
+chmod 600 "$anthropic_root/interrupted/slots"/*.json
+
+omarchy-agent-account-switch anthropic default >/dev/null
+jq '.anthropic.access = "interrupted-pi"' "$pi_auth" >"$pi_auth.tmp"
+mv -T "$pi_auth.tmp" "$pi_auth"
+ln -s "$anthropic_root/interrupted/claude" "$HOME/.claude.interrupted"
+mv -Tf "$HOME/.claude.interrupted" "$HOME/.claude"
+printf '{"from":"default","to":"interrupted"}\n' >"$anthropic_root/.switching.json"
+chmod 600 "$anthropic_root/.switching.json"
+
+[[ $(omarchy-agent-account anthropic) == "default" ]] || fail "next account command rolls an interrupted switch back to its outgoing account"
+jq -e '.anthropic.access == "default-pi" and .google.key == "pi-sibling"' "$pi_auth" >/dev/null ||
+  fail "interrupted-switch recovery restores the outgoing Pi key and siblings"
+jq -e '.anthropic.access == "default-opencode" and .google.key == "opencode-sibling"' "$opencode_auth" >/dev/null ||
+  fail "interrupted-switch recovery restores the outgoing OpenCode key and siblings"
+[[ ! -e $anthropic_root/.switching.json ]] || fail "interrupted-switch recovery clears its journal"
+pass "an interrupted multi-slot switch recovers as one provider account"
+
+theme_source="$HOME/.local/state/omarchy/current/theme/claude.json"
+mkdir -p "$(dirname "$theme_source")"
+printf '{"name":"Omarchy"}\n' >"$theme_source"
+omarchy-theme-set-claude --activate
+for account in default interrupted work; do
+  [[ -f $anthropic_root/$account/claude/themes/omarchy.json ]] ||
+    fail "Claude theme reaches managed $account config slot"
+  jq -e '.theme == "custom:omarchy"' "$anthropic_root/$account/claude/settings.json" >/dev/null ||
+    fail "Claude theme activation reaches managed $account config slot"
+done
+pass "Claude theming iterates config-dir slots across Anthropic accounts"
+
+omarchy-agent-account-switch anthropic work >/dev/null
+if omarchy-agent-account-logout anthropic work >"$test_tmp/active-logout-output" 2>&1; then
+  fail "logout refuses the active provider account"
+fi
+grep -Fq "switch to another account first" "$test_tmp/active-logout-output" ||
+  fail "active logout explains how to proceed"
+
+omarchy-agent-account-switch anthropic default >/dev/null
+mkdir -p "$HOME/.local/state/omarchy/agents/usage"
+printf '{}\n' >"$HOME/.local/state/omarchy/agents/usage/anthropic@work.json"
+logout_output=$(omarchy-agent-account-logout anthropic work)
+trash_profile=$(find "$anthropic_root/.trash" -mindepth 1 -maxdepth 1 -type d -name 'work.*' -print -quit)
+[[ -n $trash_profile && -f $trash_profile/slots/pi.json ]] || fail "logout keeps the whole credential bundle in recoverable trash"
+[[ $logout_output == *"$trash_profile"* ]] || fail "logout reports where recovery data was moved"
+[[ ! -e $HOME/.local/state/omarchy/agents/usage/anthropic@work.json ]] || fail "logout removes the canonical provider account usage record"
+pass "logout refuses active state and recoverably forgets an inactive provider bundle"
+
+openai_root="$HOME/.local/share/omarchy/agents/openai"
+mkdir -p "$openai_root/default/codex"
+printf '{"tokens":"moved-codex"}\n' >"$openai_root/default/codex/auth.json"
+jq '.["openai-codex"] = {type: "oauth", access: "default-openai-pi"}' "$pi_auth" >"$pi_auth.tmp"
+mv -T "$pi_auth.tmp" "$pi_auth"
+jq '.openai = {type: "oauth", refresh: "default-openai-opencode", access: "default-openai-opencode", expires: 9999999999999}' "$opencode_auth" >"$opencode_auth.tmp"
+mv -T "$opencode_auth.tmp" "$opencode_auth"
+
+[[ $(omarchy-agent-account codex) == "default" ]] || fail "Codex alias selects OpenAI and resumes an already-moved config slot"
+[[ -L $HOME/.codex && $(readlink "$HOME/.codex") == "$openai_root/default/codex" ]] ||
+  fail "resumed OpenAI adoption points Codex at its account config slot"
+jq -e '.access == "default-openai-pi"' "$openai_root/default/slots/pi.json" >/dev/null ||
+  fail "OpenAI adoption maps Pi subscription auth from the openai-codex key"
+jq -e '.access == "default-openai-opencode"' "$openai_root/default/slots/opencode.json" >/dev/null ||
+  fail "OpenAI adoption maps OpenCode subscription auth from the openai key"
+[[ $(omarchy-agent-account openai) == "default" ]] || fail "canonical OpenAI provider ID is accepted"
+
+rm "$HOME/.codex"
+ln -s "$openai_root/recovered/codex" "$HOME/.codex"
+[[ $(omarchy-agent-account openai) == "recovered" ]] || fail "managed dangling config slots are repaired"
+[[ -d $openai_root/recovered/codex ]] || fail "dangling config-slot repair creates a private account profile"
+pass "OpenAI uses the verified harness-specific keys and resumable config adoption"
+
+if (( EUID == 0 )); then
+  pass "running as root; skipping user finalization provisioning check"
+else
+  install_root="$test_tmp/install"
+  mkdir -p "$install_root/user"
+  printf ':\n' >"$install_root/user/all.sh"
+  rm "$anthropic_root/default/claude/skills/omarchy"
+  rm "$anthropic_root/interrupted/claude/skills/omarchy"
+  OMARCHY_INSTALL="$install_root" omarchy-provision-user --force >/dev/null
+  [[ -L $anthropic_root/default/claude/skills/omarchy ]] ||
+    fail "user finalization reprovisions the default Anthropic config slot"
+  [[ -L $anthropic_root/interrupted/claude/skills/omarchy ]] ||
+    fail "user finalization reprovisions the inactive Anthropic config slot"
+  pass "user finalization provisions skills into every managed config-dir slot"
+fi

--- a/test/shell.d/agent-account-test.sh
+++ b/test/shell.d/agent-account-test.sh
@@ -123,6 +123,12 @@ bare_output=$(HOME="$bare_home" OMARCHY_TEST_DEFAULT_AGENT="" omarchy-agent-acco
 [[ $bare_output == "No agent accounts are set up yet." ]] || fail "bare account command explains that no accounts are configured"
 pass "bare account command succeeds when no default agent is set"
 
+if ! bare_list=$(HOME="$bare_home" OMARCHY_TEST_DEFAULT_AGENT="" omarchy-agent-account-list); then
+  fail "bare account list succeeds without a default agent"
+fi
+[[ -z $bare_list ]] || fail "bare account list is empty before accounts exist"
+pass "bare account list succeeds without a default agent"
+
 claude_only_home="$test_tmp/claude-only-home"
 mkdir -p "$claude_only_home/.claude"
 printf '{"oauth":"claude-only-default"}\n' >"$claude_only_home/.claude/.credentials.json"
@@ -371,6 +377,25 @@ ln -s "$openai_root/recovered/codex" "$HOME/.codex"
 [[ $(omarchy-agent-account openai) == "recovered" ]] || fail "managed dangling config slots are repaired"
 [[ -d $openai_root/recovered/codex ]] || fail "dangling config-slot repair creates a private account profile"
 pass "OpenAI uses the verified harness-specific keys and resumable config adoption"
+
+explicit_anthropic=$(omarchy-agent-account-list anthropic --json)
+if ! all_accounts_text=$(OMARCHY_TEST_DEFAULT_AGENT="" omarchy-agent-account-list); then
+  fail "bare text account list succeeds with both providers and no default agent"
+fi
+[[ $all_accounts_text == *"anthropic default"* && $all_accounts_text == *"openai default"* ]] ||
+  fail "bare text account list includes accounts from every provider"
+if ! all_accounts=$(OMARCHY_TEST_DEFAULT_AGENT="" omarchy-agent-account-list --json); then
+  fail "bare account list succeeds with both providers and no default agent"
+fi
+jq -e '
+  any(.[]; .providerId == "anthropic") and
+  any(.[]; .providerId == "openai")
+' <<<"$all_accounts" >/dev/null || fail "bare account list includes accounts from every provider"
+jq -e --argjson explicit "$explicit_anthropic" \
+  '[.[] | select(.providerId == "anthropic")] == $explicit' <<<"$all_accounts" >/dev/null ||
+  fail "explicit provider account list remains scoped and unchanged"
+pass "bare account list returns every provider without consulting the default agent"
+pass "explicit provider account list keeps its provider-scoped output"
 
 if (( EUID == 0 )); then
   pass "running as root; skipping user finalization provisioning check"

--- a/test/shell.d/agent-usage-account-attribution-test.sh
+++ b/test/shell.d/agent-usage-account-attribution-test.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+require_command rg
+
+CLAUDE_HOME=$(mktemp -d)
+CODEX_HOME_FIXTURE=$(mktemp -d)
+trap 'rm -rf "$CLAUDE_HOME" "$CODEX_HOME_FIXTURE"' EXIT
+
+claude_root="$CLAUDE_HOME/.local/share/omarchy/agents/anthropic"
+claude_usage="$CLAUDE_HOME/.local/state/omarchy/agents/usage"
+claude_switches="$CLAUDE_HOME/.local/state/omarchy/agents/switches"
+mkdir -p \
+  "$claude_root/default/claude/projects/default" \
+  "$claude_root/work/claude/projects/work" \
+  "$CLAUDE_HOME/.pi/agent/sessions/project" \
+  "$CLAUDE_HOME/.omp/agent/sessions/project" \
+  "$claude_switches" \
+  "$claude_usage"
+ln -s "$claude_root/work/claude" "$CLAUDE_HOME/.claude"
+
+cat >"$claude_root/default/claude/projects/default/native.jsonl" <<'EOF'
+{"timestamp":"2024-01-03T12:00:00Z","type":"assistant","sessionId":"claude-default","message":{"id":"claude-default-1","role":"assistant","model":"claude-native","usage":{"input_tokens":23}}}
+EOF
+cat >"$claude_root/work/claude/projects/work/native.jsonl" <<'EOF'
+{"timestamp":"2024-01-05T12:00:00Z","type":"assistant","sessionId":"claude-work","message":{"id":"claude-work-1","role":"assistant","model":"claude-native","usage":{"input_tokens":29}}}
+EOF
+cat >"$CLAUDE_HOME/.pi/agent/sessions/project/pi.jsonl" <<'EOF'
+{"type":"message","id":"pi-before","timestamp":"2024-01-01T12:00:00Z","message":{"role":"assistant","provider":"anthropic","model":"claude-pi","usage":{"input":5}}}
+{"type":"message","id":"pi-work","timestamp":"2024-01-05T12:00:00Z","message":{"role":"assistant","provider":"anthropic","model":"claude-pi","usage":{"input":11}}}
+EOF
+cat >"$CLAUDE_HOME/.omp/agent/sessions/project/omp.jsonl" <<'EOF'
+{"type":"message","id":"omp-default","timestamp":"2024-01-03T12:00:00Z","message":{"role":"assistant","provider":"anthropic","model":"claude-omp","usage":{"input":7}}}
+EOF
+cat >"$claude_switches/anthropic.json" <<'EOF'
+[
+  {"timestamp":"2024-01-02T00:00:00Z","providerId":"anthropic","accountId":"default"},
+  {"timestamp":"2024-01-04T00:00:00Z","providerId":"anthropic","accountId":"work"}
+]
+EOF
+
+python3 - "$CLAUDE_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+
+def millis(value):
+  return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
+
+def message(message_id, timestamp, tokens):
+  created = millis(timestamp)
+  data = json.dumps({
+    "role": "assistant",
+    "providerID": "anthropic",
+    "modelID": "claude-opencode",
+    "tokens": {"input": tokens, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+    "time": {"created": created},
+  })
+  return message_id, message_id, created, created, data
+
+conn.executemany("INSERT INTO message VALUES (?, ?, ?, ?, ?)", [
+  message("oc-before", "2024-01-01T12:00:00Z", 13),
+  message("oc-default", "2024-01-03T12:00:00Z", 17),
+  message("oc-work", "2024-01-05T12:00:00Z", 19),
+])
+conn.commit()
+conn.close()
+PY
+
+printf '{"id":"claude"}\n' >"$claude_usage/claude.json"
+printf '{"id":"anthropic@deleted"}\n' >"$claude_usage/anthropic@deleted.json"
+printf '{"id":"codex"}\n' >"$claude_usage/codex.json"
+
+HOME="$CLAUDE_HOME" \
+  XDG_CACHE_HOME="$CLAUDE_HOME/.cache" \
+  XDG_DATA_HOME="$CLAUDE_HOME/.local/share" \
+  XDG_STATE_HOME="$CLAUDE_HOME/.local/state" \
+  OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-agent-usage-update" claude --force
+
+jq -e '
+  .id == "anthropic@default" and
+  .providerId == "anthropic" and
+  .accountId == "default" and
+  .accountLabel == "default" and
+  (.accountActive | not) and
+  .includesSharedSessions and
+  .totalPrompts == 5 and
+  ([.modelUsage[].inputTokens] | add) == 65
+' "$claude_usage/anthropic@default.json" >/dev/null ||
+  fail "Anthropic ledger attributes pre-ledger and default-era shared messages to the first account"
+jq -e '
+  .id == "anthropic@work" and
+  .providerId == "anthropic" and
+  .accountId == "work" and
+  .accountActive and
+  .includesSharedSessions and
+  .totalPrompts == 3 and
+  ([.modelUsage[].inputTokens] | add) == 59
+' "$claude_usage/anthropic@work.json" >/dev/null ||
+  fail "Anthropic ledger attributes later shared messages to the account active at their timestamp"
+[[ ! -e $claude_usage/claude.json && ! -e $claude_usage/anthropic@deleted.json && -e $claude_usage/codex.json ]] ||
+  fail "Anthropic refresh prunes only its stale and legacy records"
+(( $(find "$CLAUDE_HOME/.cache/omarchy/agent-usage" -maxdepth 1 -name 'claude-pi-sessions-*.json' | wc -l) == 2 )) ||
+  fail "Claude pi and omp caches are keyed per config directory"
+(( $(find "$CLAUDE_HOME/.cache/omarchy/agent-usage" -maxdepth 1 -name 'claude-opencode-*.json' | wc -l) == 2 )) ||
+  fail "Claude opencode caches are keyed per config directory"
+pass "Anthropic shared sessions are attributed once across account records"
+
+# A missing ledger cannot justify assigning global sources to every account.
+# The active account gets the conservative fallback; the inactive one keeps
+# only its native transcript usage.
+rm "$claude_switches/anthropic.json"
+HOME="$CLAUDE_HOME" \
+  XDG_CACHE_HOME="$CLAUDE_HOME/.cache" \
+  XDG_DATA_HOME="$CLAUDE_HOME/.local/share" \
+  XDG_STATE_HOME="$CLAUDE_HOME/.local/state" \
+  OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-agent-usage-update" anthropic --force
+
+jq -e '.totalPrompts == 1 and ([.modelUsage[].inputTokens] | add) == 23 and (.includesSharedSessions | not)' \
+  "$claude_usage/anthropic@default.json" >/dev/null ||
+  fail "Missing Anthropic ledger leaves shared usage off inactive accounts"
+jq -e '.totalPrompts == 7 and ([.modelUsage[].inputTokens] | add) == 101 and .includesSharedSessions' \
+  "$claude_usage/anthropic@work.json" >/dev/null ||
+  fail "Missing Anthropic ledger assigns shared usage only to the active account"
+pass "Missing ledgers fall back to the active account without duplication"
+
+# Adoption names a sole account default. Its account record must preserve the
+# exact stats that the old one-record collector produced from the canonical
+# config link and all shared sources.
+rm -rf "$claude_root/work"
+ln -sfnT "$claude_root/default/claude" "$CLAUDE_HOME/.claude"
+cat >"$claude_switches/anthropic.json" <<'EOF'
+[{"timestamp":"2024-01-02T00:00:00Z","providerId":"anthropic","accountId":"default"}]
+EOF
+direct=$(
+  HOME="$CLAUDE_HOME" \
+    CLAUDE_CONFIG_DIR="$CLAUDE_HOME/.claude" \
+    XDG_CACHE_HOME="$CLAUDE_HOME/.cache" \
+    XDG_DATA_HOME="$CLAUDE_HOME/.local/share" \
+    XDG_STATE_HOME="$CLAUDE_HOME/.local/state" \
+    "$ROOT/bin/omarchy-agent-usage-claude" --force
+)
+HOME="$CLAUDE_HOME" \
+  XDG_CACHE_HOME="$CLAUDE_HOME/.cache" \
+  XDG_DATA_HOME="$CLAUDE_HOME/.local/share" \
+  XDG_STATE_HOME="$CLAUDE_HOME/.local/state" \
+  OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-agent-usage-update" claude --force
+
+stats_projection='{todayPrompts,todaySessions,todayTotalTokens,todayTokensByModel,recentDays,modelUsage,totalPrompts,totalSessions,activeDays,activeDates,includesSharedSessions}'
+direct_stats=$(jq -c "$stats_projection" <<<"$direct")
+account_stats=$(jq -c "$stats_projection" "$claude_usage/anthropic@default.json")
+jq -en --argjson direct "$direct_stats" --argjson account "$account_stats" '$direct == $account' >/dev/null ||
+  fail "A sole adopted Anthropic account preserves the old collector totals"
+[[ ! -e $claude_usage/anthropic@work.json ]] ||
+  fail "Removing an account prunes its regenerated usage record"
+pass "A sole default account preserves the pre-account Claude totals"
+
+codex_root="$CODEX_HOME_FIXTURE/.local/share/omarchy/agents/openai"
+codex_usage="$CODEX_HOME_FIXTURE/.local/state/omarchy/agents/usage"
+codex_switches="$CODEX_HOME_FIXTURE/.local/state/omarchy/agents/switches"
+mkdir -p \
+  "$codex_root/default/codex/sessions/2024/01/03" \
+  "$codex_root/work/codex/sessions/2024/01/05" \
+  "$CODEX_HOME_FIXTURE/.pi/agent/sessions/project" \
+  "$CODEX_HOME_FIXTURE/.omp/agent/sessions/project" \
+  "$CODEX_HOME_FIXTURE/bin" \
+  "$codex_switches" \
+  "$codex_usage"
+ln -s "$codex_root/work/codex" "$CODEX_HOME_FIXTURE/.codex"
+
+cat >"$codex_root/default/codex/sessions/2024/01/03/native.jsonl" <<'EOF'
+{"timestamp":"2024-01-03T12:00:00Z","type":"turn_context","payload":{"model":"codex-native"}}
+{"timestamp":"2024-01-03T12:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":31}}}}
+EOF
+cat >"$codex_root/work/codex/sessions/2024/01/05/native.jsonl" <<'EOF'
+{"timestamp":"2024-01-05T12:00:00Z","type":"turn_context","payload":{"model":"codex-native"}}
+{"timestamp":"2024-01-05T12:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":37}}}}
+EOF
+cat >"$CODEX_HOME_FIXTURE/.pi/agent/sessions/project/pi.jsonl" <<'EOF'
+{"type":"message","id":"pi-before","timestamp":"2024-01-01T12:00:00Z","message":{"role":"assistant","provider":"openai-codex","model":"codex-pi","usage":{"input":3}}}
+{"type":"message","id":"pi-work","timestamp":"2024-01-05T12:00:00Z","message":{"role":"assistant","provider":"openai-codex","model":"codex-pi","usage":{"input":7}}}
+EOF
+cat >"$CODEX_HOME_FIXTURE/.omp/agent/sessions/project/omp.jsonl" <<'EOF'
+{"type":"message","id":"omp-default","timestamp":"2024-01-03T12:00:00Z","message":{"role":"assistant","provider":"openai-codex","model":"codex-omp","usage":{"input":5}}}
+EOF
+cat >"$codex_switches/openai.json" <<'EOF'
+[
+  {"timestamp":"2024-01-02T00:00:00Z","providerId":"openai","accountId":"default"},
+  {"timestamp":"2024-01-04T00:00:00Z","providerId":"openai","accountId":"work"}
+]
+EOF
+cat >"$CODEX_HOME_FIXTURE/bin/codex" <<'EOF'
+#!/bin/bash
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  case "$(jq -r '.method // empty' <<<"$request")" in
+  initialize | account/read | account/rateLimits/read)
+    jq -cn --argjson id "$id" '{id: $id, result: {}}'
+    ;;
+  esac
+done
+EOF
+chmod +x "$CODEX_HOME_FIXTURE/bin/codex"
+
+python3 - "$CODEX_HOME_FIXTURE/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+
+def millis(value):
+  return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
+
+def message(message_id, timestamp, tokens):
+  created = millis(timestamp)
+  data = json.dumps({
+    "role": "assistant",
+    "providerID": "openai",
+    "modelID": "codex-opencode",
+    "tokens": {"input": tokens, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+    "time": {"created": created},
+  })
+  return message_id, message_id, created, created, data
+
+conn.executemany("INSERT INTO message VALUES (?, ?, ?, ?, ?)", [
+  message("oc-before", "2024-01-01T12:00:00Z", 11),
+  message("oc-default", "2024-01-03T12:00:00Z", 13),
+  message("oc-work", "2024-01-05T12:00:00Z", 17),
+])
+conn.commit()
+conn.close()
+PY
+
+printf '{"id":"codex"}\n' >"$codex_usage/codex.json"
+printf '{"id":"openai@deleted"}\n' >"$codex_usage/openai@deleted.json"
+
+HOME="$CODEX_HOME_FIXTURE" \
+  PATH="$CODEX_HOME_FIXTURE/bin:$PATH" \
+  XDG_CACHE_HOME="$CODEX_HOME_FIXTURE/.cache" \
+  XDG_DATA_HOME="$CODEX_HOME_FIXTURE/.local/share" \
+  XDG_STATE_HOME="$CODEX_HOME_FIXTURE/.local/state" \
+  OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-agent-usage-update" codex --force
+
+jq -e '
+  .id == "openai@default" and
+  .providerId == "openai" and
+  .accountId == "default" and
+  (.accountActive | not) and
+  .includesSharedSessions and
+  .totalPrompts == 5 and
+  ([.modelUsage[].inputTokens] | add) == 63
+' "$codex_usage/openai@default.json" >/dev/null ||
+  fail "OpenAI ledger attributes pre-ledger and default-era shared messages to the first account"
+jq -e '
+  .id == "openai@work" and
+  .providerId == "openai" and
+  .accountId == "work" and
+  .accountActive and
+  .includesSharedSessions and
+  .totalPrompts == 3 and
+  ([.modelUsage[].inputTokens] | add) == 61
+' "$codex_usage/openai@work.json" >/dev/null ||
+  fail "OpenAI ledger attributes later shared messages to the account active at their timestamp"
+[[ ! -e $codex_usage/codex.json && ! -e $codex_usage/openai@deleted.json ]] ||
+  fail "OpenAI refresh prunes its stale and legacy records"
+(( $(find "$CODEX_HOME_FIXTURE/.cache/omarchy/agent-usage" -maxdepth 1 -name 'codex-scan-*.json' | wc -l) == 2 )) ||
+  fail "Codex aggregate caches are keyed per resolved config directory"
+pass "OpenAI shared sessions are attributed once across account records"
+
+before=$(sha256sum "$codex_usage/openai@work.json")
+HOME="$CODEX_HOME_FIXTURE" \
+  PATH="$CODEX_HOME_FIXTURE/bin:$PATH" \
+  XDG_CACHE_HOME="$CODEX_HOME_FIXTURE/.cache" \
+  XDG_DATA_HOME="$CODEX_HOME_FIXTURE/.local/share" \
+  XDG_STATE_HOME="$CODEX_HOME_FIXTURE/.local/state" \
+  OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-agent-usage-update" --except codex openai
+after=$(sha256sum "$codex_usage/openai@work.json")
+[[ $before == $after ]] ||
+  fail "Legacy --except codex selector excludes the OpenAI provider"
+pass "Provider selection accepts canonical and legacy spellings"

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -79,6 +79,24 @@ pass "Claude collector adds no limit when the payload scopes none"
 CACHE_HOME=$(mktemp -d)
 trap 'rm -rf "$CACHE_HOME"' EXIT
 
+limit_cache_keys=$(COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" python3 - <<'PY'
+import importlib.machinery, importlib.util, os
+from pathlib import Path
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+print(collector.path_digest(Path("/managed/anthropic/personal/claude")))
+print(collector.path_digest(Path("/managed/anthropic/work/claude")))
+PY
+)
+mapfile -t limit_cache_key < <(printf '%s\n' "$limit_cache_keys")
+[[ ${limit_cache_key[0]} != ${limit_cache_key[1]} ]] ||
+  fail "Claude limits cache keys differ between account config directories"
+pass "Claude limits cache is keyed by the resolved account config directory"
+
 collect_limits() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
@@ -89,7 +107,8 @@ spec = importlib.util.spec_from_loader(loader.name, loader)
 collector = importlib.util.module_from_spec(spec)
 loader.exec_module(collector)
 
-cache = collector.cache_root() / "claude-limits.json"
+config_dir = pathlib.Path(os.environ["XDG_CACHE_HOME"]) / "claude-config"
+cache = collector.cache_root() / f"claude-limits-{collector.path_digest(config_dir)}.json"
 cached = os.environ["CACHED"]
 if cached:
   cache.write_text(cached, encoding="utf-8")
@@ -100,7 +119,7 @@ def unreachable(request, timeout=None):
   raise OSError("no route to host")
 
 collector.urllib.request.urlopen = unreachable
-print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False)))
+print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False, config_dir)))
 PY
 }
 
@@ -160,14 +179,15 @@ pass "Claude collector falls back to cache when the probe cannot connect"
 probe_with_cache() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" FORCE="$1" CACHED="$2" PAYLOAD="$3" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
-import importlib.machinery, importlib.util, io, json, os
+import importlib.machinery, importlib.util, io, json, os, pathlib
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
 collector = importlib.util.module_from_spec(spec)
 loader.exec_module(collector)
 
-cache = collector.cache_root() / "claude-limits.json"
+config_dir = pathlib.Path(os.environ["XDG_CACHE_HOME"]) / "claude-config"
+cache = collector.cache_root() / f"claude-limits-{collector.path_digest(config_dir)}.json"
 cache.write_text(os.environ["CACHED"], encoding="utf-8")
 
 probes = []
@@ -177,7 +197,7 @@ def urlopen(request, timeout=None):
   return io.BytesIO(os.environ["PAYLOAD"].encode())
 
 collector.urllib.request.urlopen = urlopen
-result = collector.collect_limits("token", 0, os.environ["FORCE"] == "true")
+result = collector.collect_limits("token", 0, os.environ["FORCE"] == "true", config_dir)
 print(json.dumps({
   "result": result,
   "probes": len(probes),

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -29,7 +29,7 @@ pass "Claude collector counts each API message once"
   fail "Claude collector keeps mutually exclusive token categories" "$result"
 pass "Claude collector keeps mutually exclusive token categories"
 
-[[ $(jq -r '.id + "/" + .usageStatusText' <<<"$result") == "claude/Waiting for auth" ]] ||
+[[ $(jq -r '.id + "/" + .providerId + "/" + .usageStatusText' <<<"$result") == "anthropic/anthropic/Waiting for auth" ]] ||
   fail "Claude collector identifies itself and reports missing auth" "$result"
 pass "Claude collector identifies itself and reports missing auth"
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -51,7 +51,7 @@ pass "Codex collector counts each turn once"
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
 
-[[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
+[[ $(jq -c '.id + "/" + .providerId + "/" + (.limits|tostring)' <<<"$result") == '"openai/openai/[]"' ]] ||
   fail "Codex collector identifies itself with an empty limits list" "$result"
 pass "Codex collector identifies itself with an empty limits list"
 
@@ -175,7 +175,7 @@ cache_file=$(ls "$CACHE_HOME/.cache/omarchy/agent-usage/"/codex-scan-*.json 2>/d
   fail "Codex collector leaves a cache file behind" "$result"
 [[ $(stat -c %a "$cache_file") == "644" ]] ||
   fail "Codex collector keeps cache files readable" "$result"
-[[ $(jq -r '.schemaVersion' "$cache_file") == "1" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
+[[ $(jq -r '.schemaVersion' "$cache_file") == "2" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
   fail "Codex collector writes a versioned cache envelope" "$result"
 pass "Codex collector writes a local-stats cache on first scan"
 
@@ -187,7 +187,7 @@ result=$(HOME="$CACHE_HOME" CODEX_HOME="$CACHE_HOME/.codex" XDG_CACHE_HOME="$CAC
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
   fail "Codex collector recovers from a corrupt cache file" "$result"
-[[ $(jq -r '.schemaVersion' "$cache_file") == "1" ]] ||
+[[ $(jq -r '.schemaVersion' "$cache_file") == "2" ]] ||
   fail "Codex collector rewrites the cache after a corrupt read" "$result"
 pass "Codex collector recovers from a corrupt cache file"
 

--- a/test/shell.d/agent-usage-fireworks-scanner-test.sh
+++ b/test/shell.d/agent-usage-fireworks-scanner-test.sh
@@ -137,6 +137,10 @@ record = scanner.scan("https://example.invalid", auth_path)
 summary["record"] = {
   "schemaVersion": record["schemaVersion"],
   "id": record["id"],
+  "providerId": record["providerId"],
+  "accountId": record["accountId"],
+  "accountLabel": record["accountLabel"],
+  "accountActive": record["accountActive"],
   "ready": record["ready"],
   "hasPromptStats": record["hasPromptStats"],
   "scope": record["scope"],
@@ -211,7 +215,7 @@ pass "Fireworks collector reads firectl credentials"
   fail "Fireworks collector parses Money units and nanos" "$result"
 pass "Fireworks collector parses Money units and nanos"
 
-[[ $(jq -c '.record | {schemaVersion, id, ready, hasPromptStats, scope, tierLabel, limits}' <<<"$result") == '{"schemaVersion":1,"id":"fireworks","ready":true,"hasPromptStats":false,"scope":"account","tierLabel":"Prepaid","limits":[]}' ]] ||
+[[ $(jq -c '.record | {schemaVersion, id, providerId, accountId, accountLabel, accountActive, ready, hasPromptStats, scope, tierLabel, limits}' <<<"$result") == '{"schemaVersion":1,"id":"fireworks","providerId":"fireworks","accountId":"","accountLabel":"","accountActive":true,"ready":true,"hasPromptStats":false,"scope":"account","tierLabel":"Prepaid","limits":[]}' ]] ||
   fail "Fireworks collector prints the display-ready record contract" "$result"
 pass "Fireworks collector prints the display-ready record contract"
 

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -43,6 +43,11 @@ pass "update reports a failing collector"
   fail "update writes each collector's record to the usage directory"
 pass "update writes each collector's record to the usage directory"
 
+jq -e '.id == "good" and .providerId == "good" and .accountId == "" and .accountLabel == "" and .accountActive' \
+  "$usage_dir/good.json" >/dev/null ||
+  fail "update gives a bare provider the account identity contract"
+pass "update gives bare providers the account identity contract"
+
 [[ ! -e $usage_dir/noisy.json ]] ||
   fail "update refuses records that are not valid JSON"
 pass "update refuses records that are not valid JSON"

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -7,6 +7,10 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+const accountSwitchSource = fs.readFileSync(root + '/bin/omarchy-agent-account-switch', 'utf8')
+const accountBackendsSource = fs.readFileSync(root + '/bin/omarchy-agent-account-backends', 'utf8')
+const manifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/agents/manifest.json', 'utf8'))
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
@@ -14,4 +18,26 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(panelSource.includes('omarchy agent account switch '), 'agents panel switches the selected subscription account explicitly')
+assert(/t === "s" \|\| t === "S"/.test(panelSource), 'agents panel binds s to account switching')
+assert(
+  /agent_account_refresh_shell/.test(accountSwitchSource)
+    && /omarchy-shell -q omarchy\.agents refresh/.test(accountBackendsSource),
+  'account switching requests a panel refresh after the credential swap'
+)
+assert(panelSource.includes('p.providerName + " · " + p.accountLabel'), 'agents panel disambiguates multiple accounts from one provider')
+assert(panelSource.includes('iconText: modelData.accountActive ? "✓" : ""'), 'agents panel marks the active account chip')
+assert(panelSource.includes('Shared-harness tokens appear in the charts but never move these plan limits'), 'agents panel explains shared tokens beside the limits and charts')
+assert(/if \(providerId === "anthropic"\) return "claude"/.test(panelSource), 'agents panel maps Anthropic records to the Claude asset')
+assert(/if \(providerId === "openai"\) return "codex"/.test(panelSource), 'agents panel maps OpenAI records to the Codex asset')
+
+assert(/advising\.push\(providerId\)/.test(mainSource), 'agents limits retry passes the provider accepted by the updater')
+assert(/function providerEnabled\(id\)[\s\S]*legacyProviderId\(providerId\)/.test(mainSource), 'agents settings accept legacy Claude and Codex provider keys')
+assert(mainSource.includes('providerAccountKey(providerId, accountId)'), 'agents sync keys records by provider and account identity')
+assert(mainSource.includes('var identity = snapshotIdentity(providerKey, stats)'), 'agents sync reads provider and account identity from each snapshot record')
+assertDeepEqual(
+  Object.keys(manifest.barWidget.defaults.providers),
+  ['anthropic', 'openai', 'fireworks'],
+  'agents manifest defaults use canonical provider ids'
+)
 JS

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -96,10 +96,12 @@ ShellRoot {
     }
     if (entry.id === "omarchy.agents") {
       root.assertTrue(typeof item.iconCandidatesForProvider === "function", entry.id + " resolves provider marks by convention")
-      var darkIcons = item.iconCandidatesForProvider({ providerId: "codex" }, Qt.color("#1a1b26")).join(" ")
-      var lightIcons = item.iconCandidatesForProvider({ providerId: "codex" }, Qt.color("#ffffff")).join(" ")
+      var darkIcons = item.iconCandidatesForProvider({ providerId: "openai" }, Qt.color("#1a1b26")).join(" ")
+      var lightIcons = item.iconCandidatesForProvider({ providerId: "openai" }, Qt.color("#ffffff")).join(" ")
+      var anthropicIcons = item.iconCandidatesForProvider({ providerId: "anthropic" }, Qt.color("#1a1b26")).join(" ")
       root.assertTrue(darkIcons.indexOf("codex.svg") >= 0 && darkIcons.indexOf("codex-light.svg") < 0, entry.id + " uses the dark-theme Codex icon on dark surfaces")
       root.assertTrue(lightIcons.indexOf("codex-light.svg") >= 0, entry.id + " prefers the light-theme Codex icon on light surfaces")
+      root.assertTrue(anthropicIcons.indexOf("claude.svg") >= 0, entry.id + " maps Anthropic records to the Claude icon")
     }
 
     safeCall(item, "refresh", entry)

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -236,7 +236,7 @@ assert(
 )
 assertDeepEqual(
   defaultItems
-    .filter(item => item.parent === 'setup.default.agent')
+    .filter(item => item.parent === 'setup.default.agent' && item.kind === 'action')
     .map(item => item.label),
   ['Claude', 'Codex', 'Copilot', 'Crush', 'Gemini', 'Grok', 'omp', 'OpenCode', 'Pi'],
   'menu sorts coding agents alphabetically'
@@ -385,6 +385,20 @@ const providerBlock = menuQml.match(/readonly property var providers: \(\{[\s\S]
 assert(
   /"fonts": \{[\s\S]*?volatile: true/.test(providerBlock),
   'menu re-enumerates the font list every time it is opened'
+)
+assert(
+  providerBlock.includes('"agent-accounts"')
+    && providerBlock.includes('omarchy agent account list --json')
+    && /"agent-accounts": \{[\s\S]*?volatile: true/.test(providerBlock),
+  'menu re-enumerates subscription accounts every time the submenu is opened'
+)
+assert(
+  providerBlock.includes('omarchy agent account switch '),
+  'menu account rows switch the provider and immutable account ids they carry'
+)
+assert(
+  defaultById['setup.default.agent.accounts'].provider === 'agent-accounts',
+  'menu exposes subscription accounts beneath the existing default-agent entries'
 )
 assert(
   /function setActiveMenu\([\s\S]*?root\.invalidateVolatileProvider\(id\)\s*\n\s*root\.loadProviderForMenu\(id\)/.test(menuQml)
@@ -612,3 +626,54 @@ JS
 font_charset=$(fc-query --format='%{charset}' "$ROOT/default/fonts/omarchy/omarchy.ttf")
 [[ $font_charset == *"e900-e907"* ]] || fail "Omarchy icon font includes every custom menu glyph"
 pass "Omarchy icon font includes the official agent marks"
+
+menu_test_tmp=$(mktemp -d)
+trap 'rm -rf "$menu_test_tmp"' EXIT
+menu_test_home="$menu_test_tmp/home"
+menu_test_bin="$menu_test_tmp/bin"
+mkdir -p \
+  "$menu_test_bin" \
+  "$menu_test_home/.local/share/omarchy/agents/anthropic/personal/claude" \
+  "$menu_test_home/.local/share/omarchy/agents/anthropic/work/claude" \
+  "$menu_test_home/.local/share/omarchy/agents/openai/personal/codex" \
+  "$menu_test_home/.local/share/omarchy/agents/openai/work/codex"
+ln -s "$menu_test_home/.local/share/omarchy/agents/anthropic/personal/claude" "$menu_test_home/.claude"
+ln -s "$menu_test_home/.local/share/omarchy/agents/openai/work/codex" "$menu_test_home/.codex"
+
+cat >"$menu_test_bin/omarchy-default-agent" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$menu_test_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$menu_test_bin"/*
+
+agent_accounts_provider_script=$(
+  node - "$ROOT/shell/plugins/menu/Menu.qml" <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(process.argv[2], 'utf8')
+const match = source.match(/"agent-accounts":\s*\{\s*script:\s*("(?:[^"\\]|\\.)*")/)
+if (!match) process.exit(1)
+process.stdout.write(JSON.parse(match[1]))
+JS
+)
+if ! provider_output=$(
+  HOME="$menu_test_home" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$menu_test_bin:$ROOT/bin:$PATH" \
+    bash -c "$agent_accounts_provider_script"
+); then
+  fail "menu account provider script executes without a default agent"
+fi
+mapfile -t menu_account_rows <<<"$provider_output"
+expected_account_rows=(
+  $'Anthropic · personal\tanthropic@personal\tanthropic@personal'
+  $'Anthropic · work\tanthropic@work\t'
+  $'OpenAI · personal\topenai@personal\t'
+  $'OpenAI · work\topenai@work\topenai@work'
+)
+[[ ${menu_account_rows[*]} == "${expected_account_rows[*]}" ]] ||
+  fail "menu account provider emits labelled rows across providers with active rows marked" "$(printf 'actual:   %q\nexpected: %q' "${menu_account_rows[*]}" "${expected_account_rows[*]}")"
+pass "menu account provider emits labelled rows across providers with active rows marked"


### PR DESCRIPTION
A machine can hold more than one subscription for the same provider — a personal Claude Max and a work one — and Omarchy knew only whichever was signed in. There was no way to remember a second, see it beside the first, or swap which one is live. This adds that, the way `tailscale switch` moves between tailnets.

```
omarchy agent account list
omarchy agent account login anthropic work claude
omarchy agent account switch anthropic work
```

## The unit is the subscription, not the harness

One Anthropic subscription is reachable through Claude Code, pi and opencode, each holding its own credential copy, and `omarchy-agent-usage-claude` already merges all three into a single record. So swapping `~/.claude` alone would have left pi and opencode authenticated as the other account while their tokens kept landing in the same record — account A's limits drawn beside account A+B's usage.

An account is therefore a bundle of per-harness credential slots, and a switch moves every one of them. Two slot kinds, because the harnesses differ:

- **Config dir** (claude, codex) — one provider each, so the whole directory is swapped through an atomic symlink, which also keeps transcripts per account.
- **Auth key** (pi, opencode) — these keep every provider's credential in one `auth.json`, where swapping the file would switch the OpenAI account when you asked for Anthropic. Only that provider's key is stashed and restored.

Credentials are never minted here: a slot is filled by running the harness's own login and capturing what it wrote. Every switch stashes the live values back into the outgoing account first, because OAuth blobs refresh themselves in place and a stored copy goes stale otherwise.

A harness that is not installed is not a slot on this machine. An installed one with no credential for the account is signed out rather than left authenticated as the wrong account — a silent partial switch is the failure this design exists to prevent.

## Usage records

One record per account, named `<provider>@<account>`, collected with that account's config directory. The limits probe previously cached to a fixed `claude-limits.json`, so a second account would have displayed the first one's remaining allowance; every cache is now keyed by the resolved config directory.

Pi, omp and opencode sessions record the provider but not the account, so adding their tokens to every record would count the same spend several times over. A switch ledger settles it: each message is attributed to whichever account was active when it was written, and history older than the ledger goes to the account it first names. Without a readable ledger they fall back to the active account alone, never to all of them.

## Panel and menu

One chip per account with the active one marked, so the work subscription at 92% is visible beside the personal one at 10% — the question you actually have before switching, and one a panel showing only the signed-in account cannot answer. Chips still only change what you are looking at; making an account active is a separate keypress and control, because a click meant to read a number must never move a credential.

Tokens spent through a third-party harness draw from extra usage rather than the plan, so they appear in the charts while the limit meters ignore them. The panel says so, rather than leaving the mismatch looking like a rendering bug.

The menu gains an Accounts submenu over the same list, marking the active account and switching on selection.

## What this does not cover

No real logins have been exercised. The mechanism is tested against fixtures, and the six native flows — claude, codex, pi ×2, opencode ×2 — need actual second accounts before anyone should trust them.

Only claude, codex, pi and opencode have slots. omp should use its own `--profile` rather than a copy of it, crush and grok are unstarted, gemini's credential storage is unverified, and copilot keeps its credential in the OS keyring that Omarchy ships, so it needs a keyring slot kind rather than a swapped directory.
