### PR TITLE
Match the volume OSD icon to the output switcher

### DIFF
--- a/bin/omarchy-audio-output-volume
+++ b/bin/omarchy-audio-output-volume
@@ -79,6 +79,10 @@ fi
 percent=$(volume_percent)
 if volume_muted || ((${percent:-0} == 0)); then
   icon="volume-muted"
+elif ((percent <= 33)); then
+  icon="volume-low"
+elif ((percent <= 66)); then
+  icon="volume-medium"
 else
   icon="volume-high"
 fi

--- a/shell/plugins/osd/OsdModel.js
+++ b/shell/plugins/osd/OsdModel.js
@@ -4,14 +4,14 @@ function clamp(value, min, max) {
 
 // The widest glyph `iconFor` can return. The progress OSD sizes its icon
 // column to it so the bar keeps its place as the icon changes.
-var widestIcon = ""
+var widestIcon = "󰕾"
 
 function iconFor(name, percent) {
   var n = String(name || "").toLowerCase()
-  if (n === "volume-muted" || n === "volume-mute" || n === "muted" || n === "mute") return ""
-  if (n === "volume-low") return ""
-  if (n === "volume-medium") return ""
-  if (n === "volume-high" || n === "volume") return ""
+  if (n === "volume-muted" || n === "volume-mute" || n === "muted" || n === "mute") return "󰖁"
+  if (n === "volume-low") return "󰕿"
+  if (n === "volume-medium") return "󰖀"
+  if (n === "volume-high" || n === "volume") return "󰕾"
   if (n === "microphone-muted" || n === "microphone-off" || n === "mic-muted" || n === "mic-off") return "󰍭"
   if (n === "microphone" || n === "mic") return "󰍬"
   if (n === "keyboard") return "󰌌"
@@ -28,10 +28,10 @@ function iconFor(name, percent) {
   if (n === "media-next" || n === "player-next") return "󰒭"
   if (n === "media-previous" || n === "player-previous") return "󰒮"
   if (n.length > 0) return name
-  if (percent <= 0) return ""
-  if (percent <= 33) return ""
-  if (percent <= 66) return ""
-  return ""
+  if (percent <= 0) return "󰖁"
+  if (percent <= 33) return "󰕿"
+  if (percent <= 66) return "󰖀"
+  return "󰕾"
 }
 
 function stateForShow(iconName, rawMessage, rawValue, rawMax, rawProgressText, rawDuration) {

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -432,10 +432,13 @@ Panel {
 
   function showVolumeOsd(volume) {
     if (!bar || !bar.shell) return
-    bar.shell.summon("omarchy.osd", JSON.stringify({
-      icon: outputIcon(volume),
-      value: Math.round(volume * 100)
-    }))
+    // No icon lets the OSD pick its speaker glyph from the percentage, the
+    // same way the volume keys do. Headphones and mute stay explicit: the
+    // percentage can't express them (scrolling doesn't unmute).
+    var payload = { value: Math.round(volume * 100) }
+    if (sink && sink.audio && isHeadphones(sink)) payload.icon = "󰋋"
+    else if (outputMuted) payload.icon = "volume-muted"
+    bar.shell.summon("omarchy.osd", JSON.stringify(payload))
   }
 
   function setInputVolume(v) {

--- a/test/shell.d/audio-output-volume-test.sh
+++ b/test/shell.d/audio-output-volume-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+log="$test_tmp/calls"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-audio-output-sink" <<'STUB'
+#!/bin/bash
+printf 'stub_sink\n'
+STUB
+chmod +x "$stub_bin/omarchy-audio-output-sink"
+
+# Reports whatever level the case under test asked for, so no real sink is touched.
+cat >"$stub_bin/pactl" <<'STUB'
+#!/bin/bash
+case "$1" in
+  get-sink-volume) printf 'Volume: front-left: 0 / %s%% / 0.00 dB\n' "${STUB_PERCENT:-50}" ;;
+  get-sink-mute) printf 'Mute: %s\n' "${STUB_MUTED:-no}" ;;
+esac
+STUB
+chmod +x "$stub_bin/pactl"
+
+cat >"$stub_bin/omarchy-osd" <<'STUB'
+#!/bin/bash
+printf 'omarchy-osd %s\n' "$*" >>"$TEST_LOG"
+STUB
+chmod +x "$stub_bin/omarchy-osd"
+
+# +0 leaves the level alone, so each case exercises the read-back and the icon
+# choice without moving the volume.
+icon_for_percent() {
+  : >"$log"
+  STUB_PERCENT="$1" \
+    STUB_MUTED="${2:-no}" \
+    TEST_LOG="$log" \
+    PATH="$stub_bin:$PATH" \
+    bash "$ROOT/bin/omarchy-audio-output-volume" +0 >/dev/null
+
+  sed -n 's/.*-i \([^ ]*\).*/\1/p' "$log"
+}
+
+assert_icon() {
+  local percent="$1" expected="$2" muted="${3:-no}" actual
+
+  actual=$(icon_for_percent "$percent" "$muted")
+
+  if [[ $actual == $expected ]]; then
+    pass "volume $percent% muted=$muted shows $expected"
+  else
+    fail "volume $percent% muted=$muted shows $expected" \
+      "expected: $expected
+actual:   $actual"
+  fi
+}
+
+assert_icon 0 volume-muted
+assert_icon 50 volume-muted yes
+
+# Bands come from omarchy-audio-output-switch, which already maps level to icon
+# name. They also equal the 0.34/0.67 cutoffs outputIcon() uses for the bar in
+# shell/plugins/panels/audio/Panel.qml.
+assert_icon 1 volume-low
+assert_icon 33 volume-low
+assert_icon 34 volume-medium
+assert_icon 66 volume-medium
+assert_icon 67 volume-high
+assert_icon 100 volume-high

--- a/test/shell.d/osd-test.sh
+++ b/test/shell.d/osd-test.sh
@@ -9,6 +9,21 @@ const osd = requireFromRoot('shell/plugins/osd/OsdModel.js')
 
 assertEqual(osd.iconFor('', 0), osd.iconFor('muted', 50), 'osd falls back to muted icon at zero percent')
 assertEqual(osd.iconFor('volume-high', 1), osd.iconFor('', 100), 'osd maps high volume aliases')
+
+// Each volume level needs a distinct glyph. These are the Material Design
+// speakers, matching every other icon in iconFor(). The MDI names do not
+// describe wave counts: volume_low draws a bare speaker, volume_medium one
+// wave, volume_high two, and volume_off a slashed speaker.
+assertEqual(osd.iconFor('volume-low', 20), '󰕿', 'osd shows the low volume speaker')
+assertEqual(osd.iconFor('volume-medium', 50), '󰖀', 'osd shows the medium volume speaker')
+assertEqual(osd.iconFor('volume-high', 80), '󰕾', 'osd shows the high volume speaker')
+assertEqual(osd.iconFor('volume-muted', 20), '󰖁', 'osd shows the slashed speaker when muted')
+
+// The audio panel's bar scroll sends no icon at all, so the percentage
+// fallback must land on the same speakers as the named levels.
+assertEqual(osd.iconFor('', 20), osd.iconFor('volume-low', 20), 'osd fallback matches low')
+assertEqual(osd.iconFor('', 50), osd.iconFor('volume-medium', 50), 'osd fallback matches medium')
+assertEqual(osd.iconFor('', 80), osd.iconFor('volume-high', 80), 'osd fallback matches high')
 assertEqual(osd.iconFor('logout', 50), '󰍃', 'osd maps logout icon')
 assertEqual(osd.iconFor('custom-symbol', 50), 'custom-symbol', 'osd preserves unknown explicit icons')
 assertEqual(osd.widestIcon, osd.iconFor('volume-high', 100), 'osd sizes the icon column to a glyph it can show')


### PR DESCRIPTION
omarchy-audio-output-switch already picks its icon from the volume level. Use
the same mapping in omarchy-audio-output-volume so both draw the same speaker
at the same level. The bar's volume scroll sends just the percentage now, so
the OSD lands on those same speakers there too; headphones and mute stay
explicit, since the percentage can't express either.

Move the OSD's volume glyphs to Material Design too, matching every other icon
in iconFor(). Same wave counts either way, but the muted state reads clearer.

## Reproduce

Set the volume to 20%, then compare:

- `SHIFT + XF86AudioMute` (switch output) — shows the low icon
- `XF86AudioLowerVolume` — shows the high icon
- scrolling the bar's volume icon — tracks the level, but with the bar's own glyphs

The volume keys drew the same speaker from 1% to 100%, and each path drew it
from a different set.

## Tests

- `test/shell.d/audio-output-volume-test.sh` (new) stubs `pactl` and `omarchy-osd`, and asserts the icon name at each band boundary
- `test/shell.d/osd-test.sh` gains seven assertions: four pinning the glyphs, three pinning the no-icon percentage fallback the bar scroll relies on

Verified in the running UI at 20/50/80% and muted, via both the volume keys and
the bar scroll.
