### PR TITLE
Add a Kimi usage collector to the agents panel

### DIFF
--- a/bin/omarchy-agent-usage-kimi
+++ b/bin/omarchy-agent-usage-kimi
@@ -1,0 +1,388 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Kimi usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Kimi for Coding quota into one display-ready JSON record.
+
+Quoted limits come from api.kimi.com's usage monitor (the same payload the
+kimi /usage command renders): a weekly quota plus per-window limits such as
+the 5-hour session window. The bearer token comes from KIMI_API_KEY when set,
+otherwise from the kimi-code sign-in at $KIMI_CODE_HOME/credentials/kimi-code.json
+(default ~/.kimi-code/credentials/kimi-code.json), falling back to the legacy
+kimi-cli store at ~/.kimi/credentials/kimi-code.json.
+
+Access tokens expire, so this collector refreshes them the way the CLI does:
+POST the refresh_token to auth.kimi.com/api/oauth/token with the public client
+id, take the flock on kimi-code.lock first (another kimi process may be
+refreshing), and persist the rotated tokens back to the credentials file,
+since the server issues single-use refresh tokens, so the new one must never
+be discarded. Tokens are sent only to hosts under kimi.com over HTTPS
+(redirects are refused; plain HTTP is allowed only for loopback testing
+endpoints) and never written anywhere but the credentials file itself. The
+agents panel only ever reads the JSON this prints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "kimi"
+AGENT_NAME = "Kimi"
+AUTH_HELP = "Set KIMI_API_KEY or sign in to Kimi (run `kimi login`)."
+USAGE_URL = os.environ.get("KIMI_USAGE_URL") or (
+  os.environ.get("KIMI_CODE_BASE_URL", "https://api.kimi.com/coding/v1").rstrip("/") + "/usages"
+)
+OAUTH_HOST = (
+  os.environ.get("KIMI_CODE_OAUTH_HOST") or os.environ.get("KIMI_OAUTH_HOST") or "https://auth.kimi.com"
+)
+TOKEN_URL = OAUTH_HOST.rstrip("/") + "/api/oauth/token"
+OAUTH_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
+# Tokens may only leave this machine for hosts under this domain.
+ALLOWED_DOMAIN = "kimi.com"
+REFRESH_SKEW_S = 60
+
+
+def credentials_dir() -> Path:
+  # kimi-code keeps its OAuth pair under KIMI_CODE_HOME (default ~/.kimi-code);
+  # the legacy kimi-cli used ~/.kimi. Prefer the kimi-code store when both exist.
+  candidates = []
+  if home := os.environ.get("KIMI_CODE_HOME"):
+    candidates.append(Path(home) / "credentials")
+  candidates.append(Path.home() / ".kimi-code" / "credentials")
+  candidates.append(Path.home() / ".kimi" / "credentials")
+  for candidate in candidates:
+    if (candidate / "kimi-code.json").is_file():
+      return candidate
+  return candidates[0]
+
+
+CREDENTIALS_DIR = credentials_dir()
+CREDENTIALS_PATH = CREDENTIALS_DIR / "kimi-code.json"
+CREDENTIALS_LOCK = CREDENTIALS_DIR / "kimi-code.lock"
+
+
+class KimiError(Exception):
+  pass
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+  # urllib would copy every header (including the bearer token) onto the
+  # redirect target, potentially leaking it cross-host. Never follow.
+  def redirect_request(self, req, fp, code, msg, headers, newurl):
+    return None
+
+
+def trusted_url(url: str) -> tuple[str, bool]:
+  """Require HTTPS (plain HTTP only for loopback); report credential trust."""
+  try:
+    parts = urllib.parse.urlsplit(url)
+  except ValueError as error:
+    raise KimiError("Kimi endpoint URL is invalid") from error
+  host = (parts.hostname or "").lower()
+  loopback = host in ("localhost", "127.0.0.1", "::1")
+  if parts.scheme != "https" and not (loopback and parts.scheme == "http"):
+    raise KimiError("Kimi endpoint must use HTTPS")
+  return url, host == ALLOWED_DOMAIN or host.endswith("." + ALLOWED_DOMAIN)
+
+
+def empty_stats() -> dict[str, Any]:
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [],
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+  }
+
+
+def base_record(**overrides: Any) -> dict[str, Any]:
+  record: dict[str, Any] = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": False,
+    "hasLocalStats": False,
+    # Quota numbers are account-global, not machine-local: every synced device
+    # reports the same truth, so aggregation must not sum them.
+    "scope": "account",
+    "hasPromptStats": False,
+    "tierLabel": "",
+    "usageStatusText": "",
+    "authHelpText": "",
+    "limits": [],
+  }
+  record.update(empty_stats())
+  record.update(overrides)
+  return record
+
+
+# --------------------------------------------------------------- kimi auth
+
+
+def read_credentials() -> dict[str, Any]:
+  try:
+    credentials = json.loads(CREDENTIALS_PATH.read_text())
+  except (OSError, json.JSONDecodeError):
+    return {}
+  return credentials if isinstance(credentials, dict) else {}
+
+
+def write_credentials(credentials: dict[str, Any]) -> None:
+  CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+  temporary = CREDENTIALS_PATH.with_suffix(".json.tmp")
+  temporary.write_text(json.dumps(credentials))
+  os.chmod(temporary, 0o600)
+  os.replace(temporary, CREDENTIALS_PATH)
+
+
+def token_fresh(credentials: dict[str, Any]) -> bool:
+  try:
+    return float(credentials.get("expires_at") or 0) - REFRESH_SKEW_S > time.time()
+  except (TypeError, ValueError):
+    return False
+
+
+def request_refresh(refresh_token: str) -> dict[str, Any]:
+  url, _ = trusted_url(TOKEN_URL)
+  form = urllib.parse.urlencode(
+    {
+      "client_id": OAUTH_CLIENT_ID,
+      "grant_type": "refresh_token",
+      "refresh_token": refresh_token,
+    }
+  ).encode()
+  headers = {"Content-Type": "application/x-www-form-urlencoded"}
+  request = urllib.request.Request(url, data=form, headers=headers)
+  try:
+    with urllib.request.build_opener(NoRedirectHandler()).open(request, timeout=15) as response:
+      decoded = json.load(response)
+  except urllib.error.HTTPError as error:
+    body = {}
+    try:
+      body = json.load(error)
+    except Exception:
+      body = {}
+    description = body.get("error_description") or f"HTTP {error.code}"
+    if error.code in (400, 401, 403):
+      raise KimiError(f"Kimi rejected the sign-in ({description}); sign in again with `kimi login`") from error
+    raise KimiError(f"Kimi token refresh failed ({description})") from error
+  except urllib.error.URLError as error:
+    raise KimiError("Could not reach the Kimi login service") from error
+  except (json.JSONDecodeError, TimeoutError) as error:
+    raise KimiError("Kimi returned an invalid token response") from error
+  if not isinstance(decoded, dict) or not decoded.get("access_token"):
+    raise KimiError("Kimi returned an invalid token response")
+  return decoded
+
+
+def refresh_credentials() -> dict[str, Any]:
+  """Refresh under the CLI's lock, persisting the rotated refresh token."""
+  lock_fd = None
+  try:
+    CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+    lock_fd = os.open(str(CREDENTIALS_LOCK), os.O_CREAT | os.O_RDWR, 0o600)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+  except OSError:
+    # Lock unavailable: the CLI also falls back to an unlocked refresh.
+    if lock_fd is not None:
+      os.close(lock_fd)
+      lock_fd = None
+  try:
+    # The lock holder may have just refreshed; never reuse a stale read.
+    credentials = read_credentials()
+    if token_fresh(credentials):
+      return credentials
+    refresh_token = str(credentials.get("refresh_token") or "")
+    if not refresh_token:
+      raise KimiError("Kimi sign-in is missing; sign in with `kimi login`")
+    granted = request_refresh(refresh_token)
+    credentials.update(
+      {
+        "access_token": str(granted["access_token"]),
+        "refresh_token": str(granted.get("refresh_token") or refresh_token),
+        "expires_at": time.time() + float(granted.get("expires_in") or 0),
+        "expires_in": float(granted.get("expires_in") or 0),
+        "scope": str(granted.get("scope") or credentials.get("scope") or ""),
+        "token_type": str(granted.get("token_type") or "Bearer"),
+      }
+    )
+    write_credentials(credentials)
+    return credentials
+  finally:
+    if lock_fd is not None:
+      fcntl.flock(lock_fd, fcntl.LOCK_UN)
+      os.close(lock_fd)
+
+
+def api_key() -> str:
+  key = os.environ.get("KIMI_API_KEY", "").strip()
+  if key:
+    return key
+  credentials = read_credentials()
+  if not token_fresh(credentials):
+    credentials = refresh_credentials()
+  return str(credentials.get("access_token") or "")
+
+
+# -------------------------------------------------------------------- quota
+
+
+def quota(key: str) -> dict[str, Any]:
+  url, trusted = trusted_url(USAGE_URL)
+  headers = {"Accept": "application/json"}
+  if trusted:
+    headers["Authorization"] = "Bearer " + key
+  request = urllib.request.Request(url, headers=headers)
+  try:
+    with urllib.request.build_opener(NoRedirectHandler()).open(request, timeout=15) as response:
+      decoded = json.load(response)
+  except urllib.error.HTTPError as error:
+    if error.code in (401, 403):
+      raise KimiError("Kimi rejected the credentials; sign in again with `kimi login`") from error
+    if error.code == 404:
+      raise KimiError("Kimi usage endpoint not available. Try Kimi for Coding.") from error
+    raise KimiError(f"Kimi API returned HTTP {error.code}") from error
+  except urllib.error.URLError as error:
+    raise KimiError("Could not reach the Kimi API") from error
+  except (json.JSONDecodeError, TimeoutError) as error:
+    raise KimiError("Kimi returned an invalid usage response") from error
+  if not isinstance(decoded, dict):
+    raise KimiError("Kimi returned an empty usage response")
+  return decoded
+
+
+def to_int(value: Any) -> int | None:
+  try:
+    return int(value)
+  except (OverflowError, TypeError, ValueError):
+    return None
+
+
+def reset_at(detail: dict[str, Any]) -> str:
+  for key in ("reset_at", "resetAt", "reset_time", "resetTime"):
+    raw = str(detail.get(key) or "").strip()
+    if not raw:
+      continue
+    if raw.isdigit():
+      stamp = int(raw)
+      if stamp < 1_000_000_000_000:
+        stamp *= 1000
+      try:
+        return datetime.fromtimestamp(stamp / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+      except (OverflowError, OSError, ValueError):
+        return raw
+    # Kimi stamps carry nanosecond fractions Python cannot parse; trim them.
+    normalized = raw.replace("Z", "+00:00")
+    if "." in normalized:
+      head, tail = normalized.split(".", 1)
+      digits = ""
+      for character in tail:
+        if not character.isdigit():
+          break
+        digits += character
+      tail = digits[:6] + tail[len(digits) :]
+      normalized = head + "." + tail
+    try:
+      return datetime.fromisoformat(normalized).isoformat().replace("+00:00", "Z")
+    except ValueError:
+      return raw
+  return ""
+
+
+def window_label(item: dict[str, Any], detail: dict[str, Any], window: dict[str, Any], index: int) -> str:
+  for key in ("name", "title", "scope"):
+    value = item.get(key) or detail.get(key)
+    if value:
+      return str(value)
+  duration = to_int(window.get("duration") or item.get("duration") or detail.get("duration"))
+  unit = str(window.get("timeUnit") or item.get("timeUnit") or detail.get("timeUnit") or "")
+  if duration:
+    if "MINUTE" in unit.upper():
+      return "Session (5-hour)" if duration == 300 else f"{duration}m limit"
+    if "HOUR" in unit.upper():
+      return f"{duration}h limit"
+    if "DAY" in unit.upper():
+      return "Weekly (7-day)" if duration == 7 else f"{duration}d limit"
+    return f"{duration} limit"
+  return f"Limit #{index + 1}"
+
+
+def limit_row(detail: dict[str, Any], default_label: str) -> dict[str, Any] | None:
+  limit = to_int(detail.get("limit"))
+  used = to_int(detail.get("used"))
+  if used is None and limit is not None:
+    remaining = to_int(detail.get("remaining"))
+    if remaining is not None:
+      used = limit - remaining
+  if not limit or limit <= 0 or used is None:
+    return None
+  label = str(detail.get("name") or detail.get("title") or default_label)
+  percent = min(1.0, max(0.0, used / limit))
+  return {"label": label, "percent": percent, "resetsAt": reset_at(detail)}
+
+
+def to_limits(data: dict[str, Any]) -> list[dict[str, Any]]:
+  limits = []
+  usage = data.get("usage")
+  if isinstance(usage, dict):
+    row = limit_row(usage, "Weekly limit")
+    if row:
+      limits.append(row)
+  entries = data.get("limits")
+  if isinstance(entries, list):
+    for index, entry in enumerate(entries):
+      if not isinstance(entry, dict):
+        continue
+      detail = entry.get("detail") if isinstance(entry.get("detail"), dict) else entry
+      window = entry.get("window") if isinstance(entry.get("window"), dict) else {}
+      row = limit_row(detail, window_label(entry, detail, window, index))
+      if row:
+        limits.append(row)
+  return limits
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Print the Kimi usage record as JSON")
+  # Flags accepted so the collector answers the same invocation as the others.
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  parser.parse_args()
+
+  try:
+    key = api_key()
+    if not key:
+      record = base_record(usageStatusText="Kimi unavailable", authHelpText=AUTH_HELP)
+    else:
+      data = quota(key)
+      record = base_record(
+        ready=True,
+        hasLocalStats=True,
+        limits=to_limits(data),
+      )
+  except KimiError as error:
+    record = base_record(usageStatusText="Kimi unavailable", authHelpText=str(error))
+  except Exception:
+    record = base_record(usageStatusText="Kimi unavailable", authHelpText="Kimi usage scan failed")
+  print(json.dumps(record, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -26,7 +26,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, Fireworks, and Kimi are covered out of the box.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `kimi` | api.kimi.com's usage monitor (weekly quota + per-window limits such as the 5-hour session) | none; quota only |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -63,6 +64,15 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+Kimi reads `KIMI_API_KEY` first, then the kimi-code sign-in at
+`$KIMI_CODE_HOME/credentials/kimi-code.json` (default
+`~/.kimi-code/credentials/kimi-code.json`), then the legacy kimi-cli store at
+`~/.kimi/credentials/kimi-code.json`. Expired access tokens are refreshed the
+way the CLI does, under a `flock` on the sibling `kimi-code.lock`; the rotated
+single-use refresh token is always persisted back, so the CLI keeps working
+from the same file. When the refresh token itself expires, sign in again with
+`kimi login`.
 
 ### Fireworks balance
 

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Fireworks, and Kimi usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "kimi": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-kimi-test.sh
+++ b/test/shell.d/agent-usage-kimi-test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# Without credentials the collector must still print a full, hidden-by-default
+# record: the update runner writes whatever valid JSON appears on stdout.
+no_key=$(HOME="$TEST_HOME" KIMI_CODE_HOME="$TEST_HOME/kimi-code" KIMI_API_KEY="" \
+  "$ROOT/bin/omarchy-agent-usage-kimi")
+
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.scope)' <<<"$no_key") == "kimi:false:account" ]] ||
+  fail "Kimi collector prints a valid record without credentials" "$no_key"
+pass "Kimi collector prints a valid record without credentials"
+
+result=$(TEST_HOME="$TEST_HOME" python3 - "$ROOT/bin/omarchy-agent-usage-kimi" <<'PY'
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+from contextlib import redirect_stdout
+from pathlib import Path
+
+collector_path = str(Path(sys.argv[1]))
+test_home = Path(os.environ["TEST_HOME"])
+
+os.environ["HOME"] = str(test_home / "home")
+os.environ["KIMI_CODE_HOME"] = str(test_home / "kimi-code")
+
+loader = importlib.machinery.SourceFileLoader("kimi_collector", collector_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+scanner = importlib.util.module_from_spec(spec)
+loader.exec_module(scanner)
+
+summary = {}
+
+# The env key wins without touching any credentials file.
+os.environ["KIMI_API_KEY"] = "kimi_env"
+summary["envKeyWins"] = scanner.api_key() == "kimi_env"
+del os.environ["KIMI_API_KEY"]
+
+# The kimi-code store wins over the legacy kimi-cli one; legacy is the fallback.
+code_dir = test_home / "kimi-code" / "credentials"
+legacy_dir = test_home / "home" / ".kimi" / "credentials"
+code_dir.mkdir(parents=True, exist_ok=True)
+legacy_dir.mkdir(parents=True, exist_ok=True)
+(legacy_dir / "kimi-code.json").write_text("{}")
+summary["legacyFallback"] = scanner.credentials_dir() == legacy_dir
+(code_dir / "kimi-code.json").write_text("{}")
+summary["codeStorePreferred"] = scanner.credentials_dir() == code_dir
+
+# A fresh token is used as-is; an expired one is refreshed under the lock and
+# the rotated single-use refresh token is persisted back.
+scanner.CREDENTIALS_DIR = code_dir
+scanner.CREDENTIALS_PATH = code_dir / "kimi-code.json"
+scanner.CREDENTIALS_LOCK = code_dir / "kimi-code.lock"
+
+fresh = {"access_token": "at_fresh", "refresh_token": "rt_1", "expires_at": time.time() + 3600}
+scanner.CREDENTIALS_PATH.write_text(json.dumps(fresh))
+summary["freshTokenUsed"] = scanner.api_key() == "at_fresh"
+
+expired = {"access_token": "at_old", "refresh_token": "rt_1", "expires_at": time.time() - 10}
+scanner.CREDENTIALS_PATH.write_text(json.dumps(expired))
+scanner.request_refresh = lambda token: {
+  "access_token": "at_new",
+  "refresh_token": "rt_2",
+  "expires_in": 3600,
+}
+granted = scanner.refresh_credentials()
+persisted = json.loads(scanner.CREDENTIALS_PATH.read_text())
+summary["refreshRotates"] = (
+  granted["access_token"] == "at_new"
+  and persisted["refresh_token"] == "rt_2"
+  and persisted["access_token"] == "at_new"
+)
+
+# Endpoint trust: plain HTTP is refused off-loopback; tokens only go to kimi.com.
+try:
+  scanner.trusted_url("http://evil.example.com/usages")
+  summary["httpRefused"] = False
+except scanner.KimiError:
+  summary["httpRefused"] = True
+summary["loopbackAllowed"] = scanner.trusted_url("http://127.0.0.1:9000/usages")[1] is False
+summary["kimiTrusted"] = scanner.trusted_url("https://api.kimi.com/coding/v1/usages")[1] is True
+
+# The usage payload renders into display rows: the weekly quota, the 5-hour
+# session window, used derived from remaining, and nanosecond stamps trimmed.
+payload = {
+  "usage": {"limit": 100, "used": 33, "reset_at": "2026-08-23T11:52:13.042087123Z"},
+  "limits": [
+    {
+      "window": {"duration": 300, "timeUnit": "MINUTES"},
+      "detail": {"limit": 50, "remaining": 17, "reset_at": "2026-08-17T16:52:13Z"},
+    },
+    {
+      "window": {"duration": 7, "timeUnit": "DAYS"},
+      "detail": {"name": "Weekly quota", "limit": 200, "used": 50},
+    },
+    {"window": {"duration": 0}, "detail": {"limit": 0, "used": 0}},
+  ],
+}
+limits = scanner.to_limits(payload)
+summary["limits"] = limits
+
+os.environ["KIMI_API_KEY"] = "kimi_env"
+scanner.quota = lambda key: payload
+sys.argv = ["omarchy-agent-usage-kimi", "--limits-only"]
+out = io.StringIO()
+with redirect_stdout(out):
+  scanner.main()
+summary["record"] = json.loads(out.getvalue())
+
+print(json.dumps(summary, separators=(",", ":")))
+PY
+)
+
+[[ $(jq -r '.envKeyWins' <<<"$result") == "true" ]] ||
+  fail "Kimi collector prefers KIMI_API_KEY over stored credentials" "$result"
+pass "Kimi collector prefers KIMI_API_KEY over stored credentials"
+
+[[ $(jq -r '"\(.codeStorePreferred):\(.legacyFallback)"' <<<"$result") == "true:true" ]] ||
+  fail "Kimi collector prefers the kimi-code store and falls back to legacy kimi-cli" "$result"
+pass "Kimi collector prefers the kimi-code store and falls back to legacy kimi-cli"
+
+[[ $(jq -r '"\(.freshTokenUsed):\(.refreshRotates)"' <<<"$result") == "true:true" ]] ||
+  fail "Kimi collector refreshes expired tokens and persists the rotated pair" "$result"
+pass "Kimi collector refreshes expired tokens and persists the rotated pair"
+
+[[ $(jq -r '"\(.httpRefused):\(.loopbackAllowed):\(.kimiTrusted)"' <<<"$result") == "true:true:true" ]] ||
+  fail "Kimi collector only sends tokens to kimi.com over HTTPS" "$result"
+pass "Kimi collector only sends tokens to kimi.com over HTTPS"
+
+[[ $(jq -c '.limits' <<<"$result") == '[{"label":"Weekly limit","percent":0.33,"resetsAt":"2026-08-23T11:52:13.042087Z"},{"label":"Session (5-hour)","percent":0.66,"resetsAt":"2026-08-17T16:52:13Z"},{"label":"Weekly quota","percent":0.25,"resetsAt":""}]' ]] ||
+  fail "Kimi collector renders usage windows into display rows" "$result"
+pass "Kimi collector renders usage windows into display rows"
+
+[[ $(jq -r '.record.ready | tostring' <<<"$result") == "true" && $(jq -r '.record.id' <<<"$result") == "kimi" ]] ||
+  fail "Kimi collector prints the display-ready record contract" "$result"
+pass "Kimi collector prints the display-ready record contract"


### PR DESCRIPTION
## Summary

Follow-up to #7261 (which makes Kimi selectable as the default coding agent): this adds `bin/omarchy-agent-usage-kimi`, so the agents panel gains a Kimi tab through the existing collector discovery — no plugin changes needed beyond enabling the provider in the manifest.

The collector prints the standard usage record:

- **Limits**: the weekly quota and per-window limits (e.g. the 5-hour session) from `api.kimi.com/coding/v1/usages` — the same payload the CLI's `/usage` command renders
- **Auth**: `KIMI_API_KEY` when set, otherwise the kimi-code sign-in at `$KIMI_CODE_HOME/credentials/kimi-code.json` (default `~/.kimi-code/...`), falling back to the legacy kimi-cli store at `~/.kimi/...`
- **Token refresh**: expired access tokens are refreshed the way the CLI does — form POST to `auth.kimi.com/api/oauth/token` under a `flock` on the sibling lock file, with a re-read after acquiring the lock. The server issues single-use refresh tokens, so the rotated pair is always persisted back (atomic replace, mode 0600); both the collector and the CLI keep working from the same file
- **Token safety**: tokens are sent only to hosts under `kimi.com` over HTTPS, redirects are refused (urllib would otherwise forward the Authorization header cross-host), and tokens never touch disk, logs, or the published record. Plain HTTP is allowed only for loopback hosts so tests can mock the endpoint via `KIMI_USAGE_URL`

Also updates the agents plugin manifest (Kimi enabled by default), the plugin README's collector table, and the manual.

No local token stats: kimi-code does not persist per-session token counts to disk, so the record is quota-only (`hasLocalStats` carries no prompt history). If a local stats source appears, the collector can grow one later.

## Test plan

- [x] `./test/all` — all 181 test files pass, including the new `agent-usage-kimi-test.sh` (no-credentials record, env-key precedence, kimi-code vs legacy store preference, refresh rotation persistence, endpoint trust, payload parsing, record contract)
- [x] Live run against `api.kimi.com` with a real kimi-code sign-in: returns the weekly and session limits with correct percentages and reset timestamps
- [ ] Panel shows the Kimi tab after `omarchy agent usage update` on a signed-in machine