### PR TITLE
Fix universal clipboard shortcuts on non-Latin layouts

### DIFF
--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -8,12 +8,12 @@
 --
 -- Letter keysyms in send_key_state are resolved against the active layout, so
 -- SUPER+C/V/X fail with "key not found" while a non-Latin layout is active.
--- Use Hyprland's `code:` key identifiers here so these shortcuts do not depend
--- on active-layout keysym resolution.
-local KEY_X = "code:53"
-local KEY_C = "code:54"
-local KEY_V = "code:55"
-local KEY_INSERT = "code:118"
+-- Use Hyprland's `code:` key identifiers with evdev scancodes so these
+-- shortcuts work regardless of the active keyboard layout.
+local KEY_X      = "code:53"   -- KEY_X      (linux/input-event-codes.h)
+local KEY_C      = "code:54"   -- KEY_C
+local KEY_V      = "code:55"   -- KEY_V
+local KEY_INSERT = "code:118"  -- KEY_INSERT
 
 local function send_shortcut_once(mods, key)
   return function()

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -5,6 +5,15 @@
 -- The down/up split works around Hyprland send_shortcut sometimes leaving
 -- synthetic key state stuck/repeating.
 -- https://github.com/hyprwm/Hyprland/discussions/14099
+--
+-- Letter keysyms in send_key_state are resolved against the active layout, so
+-- SUPER+C/V/X fail with "key not found" while a non-Latin layout is active.
+-- Physical keycodes keep the shortcuts working on every layout.
+local KEY_X = "code:53"
+local KEY_C = "code:54"
+local KEY_V = "code:55"
+local KEY_INSERT = "code:118"
+
 local function send_shortcut_once(mods, key)
   return function()
     hl.dispatch(hl.dsp.send_key_state({ mods = mods, key = key, state = "down" }))
@@ -42,7 +51,7 @@ local function universal_clipboard_shortcut(default_mods, default_key, terminal_
   end
 end
 
-o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
-o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
+o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", KEY_C, "CTRL", KEY_INSERT))
+o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", KEY_V, "SHIFT", KEY_INSERT))
+o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", KEY_X))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -8,7 +8,8 @@
 --
 -- Letter keysyms in send_key_state are resolved against the active layout, so
 -- SUPER+C/V/X fail with "key not found" while a non-Latin layout is active.
--- Physical keycodes keep the shortcuts working on every layout.
+-- Use Hyprland's `code:` key identifiers here so these shortcuts do not depend
+-- on active-layout keysym resolution.
 local KEY_X = "code:53"
 local KEY_C = "code:54"
 local KEY_V = "code:55"


### PR DESCRIPTION
## Summary
- Issue #7371
- Use physical keycodes for the `SUPER+C/V/X` universal clipboard shortcuts instead of letter keysyms
- Fixes `send_key_state: key not found` when a non-Latin keyboard layout (e.g. Russian) is active

## Problem

`default/hypr/bindings/clipboard.lua` injects copy/paste/cut via `hl.dsp.send_key_state` with keys like `"C"` and `"V"`. Hyprland resolves those keysyms against the **active** layout, so they are missing while `ru` (or any non-Latin layout) is selected.

Reproduction:

1. Configure multiple layouts, e.g. `kb_layout = "us,ru"`
2. Switch to Russian
3. Press `Super+C` or `Super+V` in a normal app (not a terminal)

Expected: copy/paste works.

Actual: Hyprland reports `send_key_state: key not found`.

On English layout the same shortcuts work.

## Fix

Send the physical keycodes for the US QWERTY positions instead:

- `code:54` (C)
- `code:55` (V)
- `code:53` (X)
- `code:118` (Insert, for terminal copy/paste)

This matches how other Omarchy Hyprland bindings already use `code:` keys.

## Test plan

- [x] `./test/cli` passes
- [x] `./test/shell` runs; unrelated failures in this environment (`omarchy-pkgs checkout` missing)
- [x] Manual: on Russian layout, `hyprctl dispatch 'hl.dsp.send_key_state({mods="CTRL", key="C", state="down"})'` fails; `key="code:54"` succeeds
- [x] Manual: `Super+C` / `Super+V` work on Russian layout in browser and terminal


Made with [Cursor](https://cursor.com)