### PR TITLE
Prefer footclient when Foot is the default terminal

### DIFF
--- a/applications/footclient.desktop
+++ b/applications/footclient.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Type=Application
+TryExec=footclient
+Exec=omarchy-launch-foot
+Icon=foot
+Terminal=false
+Categories=System;TerminalEmulator;
+Name=Foot Client
+GenericName=Terminal
+Comment=A fast, lightweight and minimalistic Wayland terminal emulator (client)
+StartupNotify=true
+NoDisplay=true
+X-TerminalArgExec=-e
+X-TerminalArgAppId=--app-id=
+X-TerminalArgTitle=--title=
+X-TerminalArgDir=--working-directory=

--- a/bin/omarchy-default-terminal
+++ b/bin/omarchy-default-terminal
@@ -15,7 +15,7 @@ if (($# == 0)); then
   desktop_id=${desktop_id%%:*}
   case "$desktop_id" in
   Alacritty.desktop) echo "alacritty" ;;
-  foot.desktop) echo "foot" ;;
+  foot.desktop|footclient.desktop) echo "foot" ;;
   com.mitchellh.ghostty.desktop) echo "ghostty" ;;
   kitty.desktop) echo "kitty" ;;
   *) echo "$desktop_id" ;;
@@ -25,7 +25,7 @@ fi
 
 case "$1" in
 alacritty) terminal="alacritty"; desktop_id="Alacritty.desktop"; name="Alacritty"; glyph= ;;
-foot) terminal="foot"; desktop_id="foot.desktop"; name="Foot"; glyph= ;;
+foot) terminal="foot"; desktop_id="footclient.desktop"; name="Foot"; glyph= ;;
 ghostty) terminal="ghostty"; desktop_id="com.mitchellh.ghostty.desktop"; name="Ghostty"; glyph= ;;
 kitty) terminal="kitty"; desktop_id="kitty.desktop"; name="Kitty"; glyph= ;;
 *)
@@ -40,6 +40,13 @@ if omarchy-cmd-missing "$terminal"; then
   else
     omarchy-install-terminal "$terminal" || exit 1
   fi
+fi
+
+if [[ $terminal == "foot" ]]; then
+  mkdir -p ~/.local/share/applications
+  cp "$OMARCHY_PATH/applications/foot.desktop" ~/.local/share/applications/
+  cp "$OMARCHY_PATH/applications/footclient.desktop" ~/.local/share/applications/
+  systemctl --user enable --now foot-server.socket || true
 fi
 
 cat >~/.config/xdg-terminals.list <<EOF

--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -14,7 +14,7 @@ package="$1"
 # Map package name to desktop entry ID
 case "$package" in
 alacritty) desktop_id="Alacritty.desktop" ;;
-foot) desktop_id="foot.desktop" ;;
+foot) desktop_id="footclient.desktop" ;;
 ghostty) desktop_id="com.mitchellh.ghostty.desktop" ;;
 kitty) desktop_id="kitty.desktop" ;;
 *)
@@ -33,7 +33,9 @@ if omarchy-pkg-add $package; then
     cp "$OMARCHY_PATH/default/alacritty/$desktop_id" ~/.local/share/applications/
   elif [[ $package == "foot" ]]; then
     mkdir -p ~/.local/share/applications
-    cp "$OMARCHY_PATH/applications/$desktop_id" ~/.local/share/applications/
+    cp "$OMARCHY_PATH/applications/foot.desktop" ~/.local/share/applications/
+    cp "$OMARCHY_PATH/applications/footclient.desktop" ~/.local/share/applications/
+    systemctl --user enable --now foot-server.socket || true
   fi
 
   # Copy default config for optional terminals when missing

--- a/bin/omarchy-launch-foot
+++ b/bin/omarchy-launch-foot
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Launch Foot via footclient when the server socket is up
+# omarchy:hidden=true
+
+# New clients inherit the server's startup config. Re-apply the live theme
+# include and font so a theme or font change reaches the next Super+Return.
+runtime=${XDG_RUNTIME_DIR:-/run/user/$UID}
+
+if [[ -n $WAYLAND_DISPLAY && -S $runtime/foot-$WAYLAND_DISPLAY.sock ]] || [[ -S $runtime/foot.sock ]]; then
+  overrides=()
+  theme_ini=$HOME/.local/state/omarchy/current/theme/foot.ini
+  [[ -f $theme_ini ]] && overrides+=(--override=include="$theme_ini")
+  if [[ -f $HOME/.config/foot/foot.ini ]]; then
+    font=$(grep -m1 '^font=' "$HOME/.config/foot/foot.ini" || true)
+    [[ -n $font ]] && overrides+=(--override=font="${font#font=}")
+  fi
+  exec footclient "${overrides[@]}" "$@"
+else
+  exec foot "$@"
+fi

--- a/default/hypr/apps/terminals.lua
+++ b/default/hypr/apps/terminals.lua
@@ -1,8 +1,8 @@
 -- Define terminal tag so themes and bindings can single terminals out. Omarchy
 -- launches TUIs and its own terminal windows under dedicated app-ids
 -- (org.omarchy.btop, org.omarchy.terminal, TUI.float, ...), so match those too.
--- The class is matched in full, so foot's other app-id needs spelling out.
+-- The class is matched in full, so foot's other app-ids need spelling out.
 o.window(
-  "(Alacritty|kitty|com.mitchellh.ghostty|foot|org\\.codeberg\\.dnkl\\.foot|wezterm|org\\.omarchy\\..*|TUI\\..*)",
+  "(Alacritty|kitty|com.mitchellh.ghostty|foot|footclient|org\\.codeberg\\.dnkl\\.foot|wezterm|org\\.omarchy\\..*|TUI\\..*)",
   { tag = "+terminal" }
 )

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -75,5 +75,5 @@ hl.config({
 })
 
 -- Scroll nicely in the terminal.
-o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
+o.window("(Alacritty|kitty|foot|footclient)", { scroll_touchpad = 1.5 })
 o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })

--- a/default/xdg-terminal-exec/hyprland-xdg-terminals.list
+++ b/default/xdg-terminal-exec/hyprland-xdg-terminals.list
@@ -1,3 +1,3 @@
 # Terminal emulator preference order for xdg-terminal-exec
 # The first found and valid terminal will be used
-foot.desktop
+footclient.desktop

--- a/manual/15-terminal.md
+++ b/manual/15-terminal.md
@@ -1,6 +1,6 @@
 # Terminal
 
-[Foot](https://codeberg.org/dnkl/foot) is the default terminal for Omarchy. It's fast, lightweight, and compatible with even old computers. It does not, however, support native tabs or splits.
+[Foot](https://codeberg.org/dnkl/foot) is the default terminal for Omarchy. It's fast, lightweight, and compatible with even old computers. Extra windows attach through `footclient` when the Foot server is running. It does not, however, support native tabs or splits.
 
 If you use Tmux, you may not mind, but if not, we fully support _Alacritty_, _Ghostty_, and _Kitty_ as options as well. Pick your preference under _Install > Terminal_ in the Omarchy menu.
 

--- a/migrations/1786966072.sh
+++ b/migrations/1786966072.sh
@@ -1,0 +1,27 @@
+echo "Prefer footclient when Foot is the default terminal"
+
+# Stock footclient.desktop drops X-TerminalArgAppId. Do not create a user
+# xdg-terminals.list when none exists; quattro retired that file.
+
+omarchy-cmd-present footclient || exit 0
+
+list="$HOME/.config/xdg-terminals.list"
+first=""
+if [[ -f $list ]]; then
+  first=$(grep -Ev '^\s*(#|$)' "$list" | head -n 1 || true)
+fi
+
+[[ -z $first || $first == "foot.desktop" || $first == "footclient.desktop" ]] || exit 0
+
+mkdir -p "$HOME/.local/share/applications"
+cp -f "$OMARCHY_PATH/applications/footclient.desktop" "$HOME/.local/share/applications/footclient.desktop"
+
+if [[ $first == "foot.desktop" ]]; then
+  cat >"$list" <<EOF
+# Terminal emulator preference order for xdg-terminal-exec
+# The first found and valid terminal will be used
+footclient.desktop
+EOF
+fi
+
+systemctl --user enable --now foot-server.socket || true

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -44,6 +44,11 @@ printf 'sudo:%s\n' "$*" >>"$OMARCHY_TEST_SETUP_LOG"
 [[ ${OMARCHY_TEST_SETUP_FAIL:-} != "sudo" ]]
 SH
 
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
 cat >"$mock_bin/xdg-settings" <<'SH'
 #!/bin/bash
 case $1 in
@@ -157,7 +162,7 @@ browser_cases=(
 
 terminal_cases=(
   'alacritty Alacritty.desktop'
-  'foot foot.desktop'
+  'foot footclient.desktop'
   'ghostty com.mitchellh.ghostty.desktop'
   'kitty kitty.desktop'
 )

--- a/test/shell.d/footclient-test.sh
+++ b/test/shell.d/footclient-test.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command xdg-terminal-exec
+require_command python3
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+systemctl_log="$test_tmp/systemctl.log"
+host_path=$PATH
+mkdir -p "$mock_bin" "$test_home/.config"
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_SYSTEMCTL_LOG"
+exit 0
+SH
+
+cat >"$mock_bin/xdg-terminal-exec" <<'SH'
+#!/bin/bash
+if [[ $1 == "--print-id" ]]; then
+  printf '%s\n' "${OMARCHY_TEST_PRINT_ID:-footclient.desktop}"
+  exit 0
+fi
+exit 1
+SH
+
+chmod +x "$mock_bin"/*
+
+export HOME="$test_home"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_TEST_SYSTEMCTL_LOG="$systemctl_log"
+export PATH="$mock_bin:$ROOT/bin:$host_path"
+
+OMARCHY_TEST_PRINT_ID=footclient.desktop
+[[ $(omarchy-default-terminal) == "foot" ]] || fail "footclient.desktop reports as foot"
+OMARCHY_TEST_PRINT_ID=foot.desktop
+[[ $(omarchy-default-terminal) == "foot" ]] || fail "foot.desktop still reports as foot"
+pass "omarchy-default-terminal treats footclient as foot"
+
+: >"$systemctl_log"
+omarchy-default-terminal foot >/dev/null
+[[ -f $test_home/.local/share/applications/footclient.desktop ]] ||
+  fail "setting foot installs the Omarchy footclient desktop file"
+[[ $(grep -Ev '^\s*(#|$)' "$test_home/.config/xdg-terminals.list") == "footclient.desktop" ]] ||
+  fail "setting foot prefers footclient" "$(cat "$test_home/.config/xdg-terminals.list")"
+grep -Fq 'enable --now foot-server.socket' "$systemctl_log" ||
+  fail "setting foot enables the foot server socket" "$(cat "$systemctl_log")"
+pass "setting foot prefers footclient and starts the server"
+
+printf '%s\n' "kitty.desktop" >"$test_home/.config/xdg-terminals.list"
+rm -f "$test_home/.local/share/applications/footclient.desktop"
+: >"$systemctl_log"
+omarchy-default-terminal foot >/dev/null
+[[ -f $test_home/.local/share/applications/footclient.desktop ]] ||
+  fail "switching back to foot installs the Omarchy footclient desktop file"
+[[ $(grep -Ev '^\s*(#|$)' "$test_home/.config/xdg-terminals.list") == "footclient.desktop" ]] ||
+  fail "switching back to foot prefers footclient"
+pass "switching back to foot from Kitty installs the Omarchy desktop"
+
+data_home="$test_tmp/xdg-data"
+config_home="$test_tmp/xdg-config"
+mkdir -p "$data_home/applications" "$config_home"
+cp "$ROOT/applications/footclient.desktop" "$data_home/applications/"
+printf '%s\n' "footclient.desktop" >"$config_home/xdg-terminals.list"
+cmd=$(
+  PATH="$ROOT/bin:$host_path" \
+    XDG_DATA_HOME="$data_home" \
+    XDG_CONFIG_HOME="$config_home" \
+    XDG_DATA_DIRS=/usr/share \
+    xdg-terminal-exec --print-cmd --app-id=org.omarchy.btop --title=btop -e btop
+)
+[[ $cmd == *"--app-id=org.omarchy.btop"* ]] || fail "Omarchy footclient desktop passes --app-id" "$cmd"
+[[ $cmd == *"omarchy-launch-foot"* ]] || fail "resolved command is the Foot wrapper" "$cmd"
+pass "xdg-terminal-exec keeps org.omarchy app-ids through footclient"
+
+wrapper_bin="$test_tmp/wrapper-bin"
+mkdir -p "$wrapper_bin"
+cat >"$wrapper_bin/footclient" <<'SH'
+#!/bin/bash
+printf 'footclient:%s\n' "$*"
+SH
+cat >"$wrapper_bin/foot" <<'SH'
+#!/bin/bash
+printf 'foot:%s\n' "$*"
+SH
+chmod +x "$wrapper_bin/footclient" "$wrapper_bin/foot"
+
+got=$(
+  PATH="$wrapper_bin:$mock_bin:$ROOT/bin:$host_path" \
+    HOME="$test_tmp/bare-home" \
+    XDG_RUNTIME_DIR="$test_tmp/empty-runtime" \
+    WAYLAND_DISPLAY=wayland-test \
+    omarchy-launch-foot --app-id=org.omarchy.btop -e btop
+)
+[[ $got == "foot:--app-id=org.omarchy.btop -e btop" ]] ||
+  fail "wrapper falls back to standalone foot without a server socket" "$got"
+pass "wrapper falls back to standalone foot without a server socket"
+
+socket_runtime="$test_tmp/socket-runtime"
+mkdir -p "$socket_runtime"
+python3 - "$socket_runtime/foot-wayland-test.sock" <<'PY'
+import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind(sys.argv[1])
+s.listen(1)
+PY
+got=$(
+  PATH="$wrapper_bin:$mock_bin:$ROOT/bin:$host_path" \
+    HOME="$test_tmp/bare-home" \
+    XDG_RUNTIME_DIR="$socket_runtime" \
+    WAYLAND_DISPLAY=wayland-test \
+    omarchy-launch-foot --app-id=org.omarchy.btop -e btop
+)
+[[ $got == "footclient:--app-id=org.omarchy.btop -e btop" ]] ||
+  fail "wrapper uses footclient when the server socket exists" "$got"
+pass "wrapper uses footclient when the server socket exists"
+
+theme_home="$test_tmp/theme-home"
+mkdir -p "$theme_home/.config/foot" "$theme_home/.local/state/omarchy/current/theme"
+printf '%s\n' "font=TestFont:size=12" >"$theme_home/.config/foot/foot.ini"
+printf '%s\n' "[colors-dark]" "background=000000" >"$theme_home/.local/state/omarchy/current/theme/foot.ini"
+got=$(
+  PATH="$wrapper_bin:$mock_bin:$ROOT/bin:$host_path" \
+    HOME="$theme_home" \
+    XDG_RUNTIME_DIR="$socket_runtime" \
+    WAYLAND_DISPLAY=wayland-test \
+    omarchy-launch-foot --app-id=org.omarchy.btop -e btop
+)
+[[ $got == "footclient:--override=include=$theme_home/.local/state/omarchy/current/theme/foot.ini --override=font=TestFont:size=12 --app-id=org.omarchy.btop -e btop" ]] ||
+  fail "wrapper re-applies the live theme include and font" "$got"
+pass "wrapper re-applies the live theme include and font"
+
+migration="$ROOT/migrations/1786966072.sh"
+run_migration() {
+  HOME="$1" PATH="$mock_bin:$host_path" OMARCHY_PATH="$ROOT" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+mig_home="$test_tmp/mig-home"
+mkdir -p "$mig_home/.config" "$mig_home/.local/share/applications"
+printf '%s\n' "foot.desktop" >"$mig_home/.config/xdg-terminals.list"
+: >"$systemctl_log"
+run_migration "$mig_home"
+[[ -f $mig_home/.local/share/applications/footclient.desktop ]] ||
+  fail "migration installs the Omarchy footclient desktop file"
+[[ $(grep -Ev '^\s*(#|$)' "$mig_home/.config/xdg-terminals.list") == "footclient.desktop" ]] ||
+  fail "migration rewrites a stock foot list" "$(cat "$mig_home/.config/xdg-terminals.list")"
+grep -Fq 'enable --now foot-server.socket' "$systemctl_log" ||
+  fail "migration enables the foot server socket"
+pass "migration upgrades a stock Foot install"
+
+empty_home="$test_tmp/empty-home"
+mkdir -p "$empty_home/.local/share/applications"
+: >"$systemctl_log"
+run_migration "$empty_home"
+[[ ! -e $empty_home/.config/xdg-terminals.list ]] ||
+  fail "migration does not create a user terminal list"
+grep -Fq 'enable --now foot-server.socket' "$systemctl_log" ||
+  fail "migration enables the foot server socket when there is no user list"
+pass "migration leaves a missing user list to the packaged default"
+
+kitty_home="$test_tmp/kitty-home"
+mkdir -p "$kitty_home/.config"
+printf '%s\n' "kitty.desktop" >"$kitty_home/.config/xdg-terminals.list"
+: >"$systemctl_log"
+run_migration "$kitty_home"
+[[ $(<"$kitty_home/.config/xdg-terminals.list") == "kitty.desktop" ]] ||
+  fail "migration leaves a non-Foot default alone"
+[[ ! -e $kitty_home/.local/share/applications/footclient.desktop ]] ||
+  fail "migration does not install a Foot desktop for Kitty"
+[[ ! -s $systemctl_log ]] || fail "migration does not start the foot server for Kitty"
+pass "migration leaves a non-Foot default alone"


### PR DESCRIPTION
closes #6123

Foot is the default terminal, but Super+Return always started a standalone `foot`. A background `foot --server` plus `footclient` is the cheap path for extra windows. There was no official support, and the stock `footclient.desktop` does not advertise `X-TerminalArgAppId`, so pointing the terminal list at it drops `--app-id=org.omarchy.btop`. TUIs come up as class `footclient` and stop floating.

Selecting Foot now prefers an Omarchy `footclient.desktop` that carries the xdg-terminal-exec keys. `TryExec` is `footclient`, matching `foot.desktop` / Alacritty, so a missing wrapper cannot make `xdg-terminal-exec` skip Foot entirely. Exec goes through `omarchy-launch-foot` because `xdg-terminal-exec` will not try the next entry after the first valid one, and because a live `foot --server` does not re-read `foot.ini`. The wrapper attaches when a socket exists under `$XDG_RUNTIME_DIR`, re-applies the live theme include and font, and otherwise starts standalone `foot`. Open windows keep getting OSC from `omarchy-theme-set-foot`. The server is not restarted on theme set, so existing terminals stay up.

The visible Foot launcher stays `Exec=foot`. Super+Return is the client path. `omarchy default terminal` still prints `foot` when the active desktop file is `footclient.desktop`, and copies the Omarchy desktop into `~/.local/share/applications` so a Kitty user who switches back to Foot does not fall through to stock `footclient.desktop` and lose app-ids again. Existing Foot-first lists are rewritten to the same one-entry default. Stock quattro installs have no user list; they pick up the packaged default and are not given a user override. The socket is enabled when Foot is selected or when the migration sees a Foot default, not from first-run (that file is for units Omarchy ships).

## Verification

- `bash test/shell.d/footclient-test.sh`
- `./test/cli`
- live: `xdg-terminal-exec --app-id=org.omarchy.btop --title=btop -e btop`

Live compositor after that command: class `org.omarchy.btop`, title `btop`, floating `875x600`.

Before (stock desktop): class `footclient`, tiled 1896x1056, title `foot`.

![before](https://files.catbox.moe/zqqhrx.png)

After: class `org.omarchy.btop`, floating 875x600, title `btop`.

![after](https://files.catbox.moe/akb326.png)

Final tree, live after `xdg-terminal-exec --app-id=org.omarchy.btop --title=btop -e btop` (class `org.omarchy.btop`, title `btop`, floating `875x600`). CPU header only, process list cropped out:

![after-final](https://files.catbox.moe/owsbtr.png)
