### PR TITLE
capture: exclude media-controller nodes from the webcam list

### DIFF
--- a/bin/omarchy-capture-webcam-list
+++ b/bin/omarchy-capture-webcam-list
@@ -3,13 +3,17 @@
 # omarchy:summary=List webcam devices that support video capture
 # omarchy:hidden=true
 
+# Raw sensor nodes (Intel IPU6/IPU7 ISYS) advertise Video Capture but also set
+# I/O MC, meaning their media-controller pipeline must be configured before they
+# can stream. mpv opens devices directly, so those nodes always fail on it.
 capture_capable() {
   local device="$1"
 
   v4l2-ctl --device "$device" --info 2>/dev/null | awk '
     /^[[:space:]]*Device Caps[[:space:]]*:/ { inspect = 1; next }
     inspect && /^[[:space:]]*Video Capture/ { found = 1 }
-    END { exit !found }
+    inspect && /^[[:space:]]*I\/O MC/ { media_controller = 1 }
+    END { exit !(found && !media_controller) }
   '
 }
 


### PR DESCRIPTION
Fixes #7277.

### Problem

`capture_capable()` accepts Intel IPU6/IPU7 ISYS nodes. They advertise `Video Capture`, but they also set `I/O MC` — their media-controller pipeline has to be configured with `media-ctl` before they can stream. `mpv av://v4l2:` opens the device directly, so these nodes can never work with the webcam overlay.

The `Device Caps` check added for #5722 does not catch this on IPU7 with the mainline `isys` driver, because unlike the IPU6 + `v4l2-relayd` case in that report, this node *does* report `Video Capture`:

```
$ v4l2-ctl -d /dev/video0 --info
Driver name      : isys
Card type        : ipu7
Device Caps      : 0x24200001
        Video Capture
        I/O MC
        Streaming
        Extended Pix Format
```

The result is a black overlay with no error: `/dev/video0` sorts first, so it wins the `--with-webcam` auto-detect, and `omarchy hw webcam` returns a false positive on machines with no V4L2-usable camera at all.

Streaming from it fails exactly as the capability predicts:

```
$ ffmpeg -f v4l2 -input_format yuyv422 -i /dev/video0 -frames:v 1 -f null -
ioctl(VIDIOC_STREAMON): Broken pipe
```

### Fix

Reject devices that set `I/O MC`. UVC webcams and `v4l2loopback` nodes never set it, so they are unaffected.

Filtering on pixel formats does *not* work here, in case it looks like the more obvious fix: this node advertises `UYVY`, `YUYV`, `RGBP` and `BGR3` alongside its Bayer formats even though the attached OV02C10 can only produce Bayer. `I/O MC` is the property that actually distinguishes "needs pipeline setup" from "openable directly".

### Verification

Tested on the hardware from #7277 — Core Ultra 7 258V (Lunar Lake), IPU7, OV02C10, mainline `intel_ipu7` + libcamera software ISP, with a `v4l2loopback` node at `/dev/video40` fed from `libcamerasrc`.

Before:

```
$ omarchy-capture-webcam-list
/dev/video0   ipu7 (PCI:0000:00:05.0):
/dev/video40  Camara integrada (platform:v4l2loopback-040):
```

After, with the loopback bridge running:

```
$ omarchy-capture-webcam-list
/dev/video40  Camara integrada (platform:v4l2loopback-040):
```

After, with no bridge running — an empty list, which is the honest answer and lets `omarchy hw webcam` correctly report no webcam:

```
$ omarchy-capture-webcam-list
$
```

`./test/cli` passes (116 assertions). `./test/shell` has 3 pre-existing failures on this machine, all from a missing `omarchy-pkgs` sibling checkout (`set OMARCHY_PKGS_PATH to the omarchy-pkgs checkout`) and unrelated to this change.

I don't have an IPU6 + `v4l2-relayd` machine to confirm #5722's setup still behaves, but that path is unaffected by construction: its raw node was already rejected for lacking `Video Capture`, and its `v4l2loopback` device does not set `I/O MC`.

