### PR TITLE
Trust sysfs over stale upower state for battery charge status

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -62,6 +62,18 @@ power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   print rounded
 }')
 state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
+
+# UPower's state lags the kernel the same way its energy-rate does: a pack held
+# at a charge threshold keeps reporting pending-charge for tens of seconds after
+# it starts drawing again. Use sysfs when it is available.
+if [[ -r $battery_path/status ]]; then
+  case "$(<"$battery_path/status")" in
+    "Charging") state=charging ;;
+    "Discharging") state=discharging ;;
+    "Not charging") state=pending-charge ;;
+    "Full") state=fully-charged ;;
+  esac
+fi
 threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
 threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
 
@@ -85,13 +97,16 @@ if awk -v rate="${power_rate_raw:-0}" 'BEGIN { exit !(rate <= 0.2) }'; then
   charge_idle=true
 fi
 
+# Holding means no power is moving, so an idle rate is a precondition for every
+# branch below: a stale state label must not report holding while the battery is
+# drawing watts.
 charge_holding=false
-if [[ $ac_online == "true" && -n $threshold_end ]]; then
+if [[ $ac_online == "true" && -n $threshold_end && $charge_idle == "true" ]]; then
   if [[ $state == "pending-charge" ]]; then
     charge_holding=true
   elif [[ $state == "fully-charged" ]] && (( percentage < 99 )); then
     charge_holding=true
-  elif [[ $state == "charging" && $charge_idle == "true" ]] && (( threshold_end < 99 && percentage >= threshold_end )); then
+  elif [[ $state == "charging" ]] && (( threshold_end < 99 && percentage >= threshold_end )); then
     charge_holding=true
   fi
 fi

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -44,6 +44,55 @@ grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status re
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
 
+# A pack held at a charge threshold keeps reporting pending-charge with a 0W
+# rate for tens of seconds after it starts charging again, so a stale label must
+# not win over sysfs and report holding mid-charge.
+stale_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$stale_dir"' EXIT
+
+mkdir -p "$stale_dir/bin" "$stale_dir/power/BAT0" "$stale_dir/power/AC"
+printf '29000000\n' >"$stale_dir/power/BAT0/power_now"
+printf 'Charging\n' >"$stale_dir/power/BAT0/status"
+printf '80\n' >"$stale_dir/power/BAT0/charge_control_end_threshold"
+printf 'Mains\n' >"$stale_dir/power/AC/type"
+printf '1\n' >"$stale_dir/power/AC/online"
+cat >"$stale_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                pending-charge
+  energy:               42.5 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          0 W
+  percentage:           75%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$stale_dir/bin/upower"
+
+stale_output=$(OMARCHY_POWER_SUPPLY_PATH="$stale_dir/power" PATH="$stale_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'state\tcharging' <<<"$stale_output" >/dev/null || fail "battery status trusts sysfs over a stale upower state" "$stale_output"
+grep -Fx $'rate\t29W' <<<"$stale_output" >/dev/null || fail "battery status reports the live charge rate" "$stale_output"
+
+# The same battery parked at its threshold, drawing nothing, is genuinely holding.
+printf '0\n' >"$stale_dir/power/BAT0/power_now"
+printf 'Not charging\n' >"$stale_dir/power/BAT0/status"
+
+holding_output=$(OMARCHY_POWER_SUPPLY_PATH="$stale_dir/power" PATH="$stale_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'state\tholding' <<<"$holding_output" >/dev/null || fail "battery status reports holding once the battery stops drawing" "$holding_output"
+
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"
 fi


### PR DESCRIPTION
`omarchy-battery-status` reports "Holding" while the battery is actively charging on a ThinkPad with a charge threshold set.

UPower's `state` lags the kernel by tens of seconds, the same way its `energy-rate` does. The script already works around that lag for the rate, reading `power_now` from sysfs, but still takes `state` from UPower. On a T480 charging at 29W:

```
$ upower -i /org/freedesktop/UPower/devices/battery_BAT1
    state:               pending-charge
    energy-rate:         0 W
$ cat /sys/class/power_supply/BAT1/status /sys/class/power_supply/BAT1/power_now
Charging
29207000
```

The `pending-charge` branch has no rate guard, so the panel shows `Battery 75% · Holding at 75-80% · 28.7W / 87Wh` mid-charge — holding and 28.7W at the same time.

Two changes:

- Prefer `$battery_path/status` over UPower's `state` when it is readable.
- Require an idle rate for every `charge_holding` branch. Holding means no power is moving, so a stale label must not claim it while watts are flowing. The `charging` branch's now-redundant `charge_idle` check folds into that precondition.

Covered by two cases in `battery-status-test.sh`: sysfs reporting charging against a stale `pending-charge` label, and the same fixture at 0W confirming genuine holding still reports.
