### PR TITLE
Aggregate battery status across multiple batteries

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -62,6 +62,18 @@ power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   print rounded
 }')
 state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
+
+# UPower's state lags the kernel the same way its energy-rate does: a pack held
+# at a charge threshold keeps reporting pending-charge for tens of seconds after
+# it starts drawing again. Use sysfs when it is available.
+if [[ -r $battery_path/status ]]; then
+  case "$(<"$battery_path/status")" in
+    "Charging") state=charging ;;
+    "Discharging") state=discharging ;;
+    "Not charging") state=pending-charge ;;
+    "Full") state=fully-charged ;;
+  esac
+fi
 threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
 threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
 
@@ -85,13 +97,16 @@ if awk -v rate="${power_rate_raw:-0}" 'BEGIN { exit !(rate <= 0.2) }'; then
   charge_idle=true
 fi
 
+# Holding means no power is moving, so an idle rate is a precondition for every
+# branch below: a stale state label must not report holding while the battery is
+# drawing watts.
 charge_holding=false
-if [[ $ac_online == "true" && -n $threshold_end ]]; then
+if [[ $ac_online == "true" && -n $threshold_end && $charge_idle == "true" ]]; then
   if [[ $state == "pending-charge" ]]; then
     charge_holding=true
   elif [[ $state == "fully-charged" ]] && (( percentage < 99 )); then
     charge_holding=true
-  elif [[ $state == "charging" && $charge_idle == "true" ]] && (( threshold_end < 99 && percentage >= threshold_end )); then
+  elif [[ $state == "charging" ]] && (( threshold_end < 99 && percentage >= threshold_end )); then
     charge_holding=true
   fi
 fi

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,67 +18,135 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+mapfile -t batteries < <(upower -e 2>/dev/null | grep BAT)
+((${#batteries[@]} == 0)) && exit 0
 
-battery_info=$(upower -i "$battery")
+# Machines like the ThinkPad T480 carry more than one pack, so every reading is
+# aggregated across all of them: energies sum, the rate sums, and the reported
+# percentage is the combined charge rather than whichever battery upower lists
+# first.
+energy_total=0
+capacity_total=0
+rate_total=0
+percentage_weighted=0
+states=()
+cycles_list=()
+pack_labels=()
+threshold_starts=()
+threshold_ends=()
 
-percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
-capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
-time_remaining=$(awk '/time to (empty|full)/ {
-  value = $4
-  unit = $5
-  if (unit ~ /^minute/) {
-    printf "%dm", int(value)
-  } else {
-    hours = int(value)
-    minutes = int((value - hours) * 60)
-    if (minutes > 0) {
-      printf "%dh %dm", hours, minutes
-    } else {
-      printf "%dh", hours
-    }
-  }
-  exit
-}' <<<"$battery_info")
-power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
+for battery in "${batteries[@]}"; do
+  battery_info=$(upower -i "$battery")
 
-# UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
-# the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
-fi
+  present=$(awk '/present:/ { print $2; exit }' <<<"$battery_info")
+  [[ $present == "no" ]] && continue
 
+  energy=$(awk '/^ *energy: / { print $2; exit }' <<<"$battery_info")
+  capacity=$(awk '/energy-full:/ { print $2; exit }' <<<"$battery_info")
+  rate=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
+  native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
+  battery_path="$power_supply_path/$native_path"
+
+  # UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
+  # the instantaneous sysfs reading when available so the open panel stays live.
+  if [[ -r $battery_path/power_now ]]; then
+    rate=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
+  elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
+    rate=$(awk \
+      -v microamps="$(<"$battery_path/current_now")" \
+      -v microvolts="$(<"$battery_path/voltage_now")" \
+      'BEGIN { print (microamps < 0 ? -microamps : microamps) * microvolts / 1000000000000 }')
+  fi
+
+  energy_total=$(awk -v a="$energy_total" -v b="${energy:-0}" 'BEGIN { print a + b }')
+  capacity_total=$(awk -v a="$capacity_total" -v b="${capacity:-0}" 'BEGIN { print a + b }')
+  rate_total=$(awk -v a="$rate_total" -v b="${rate:-0}" 'BEGIN { print a + b }')
+
+  share=$(awk '/^ *percentage:/ { gsub(/%/, "", $2); print $2; exit }' <<<"$battery_info")
+  percentage_weighted=$(awk -v a="$percentage_weighted" -v p="${share:-0}" -v c="${capacity:-0}" 'BEGIN { print a + p * c }')
+
+  # UPower's state label lags the kernel the same way its energy-rate does, and
+  # on a threshold-limited pack it can still read pending-charge while the pack
+  # is drawing 30W. Prefer sysfs when it's readable.
+  state=$(awk '/^ *state:/ { print $2; exit }' <<<"$battery_info")
+  if [[ -r $battery_path/status ]]; then
+    case "$(<"$battery_path/status")" in
+      "Charging") state=charging ;;
+      "Discharging") state=discharging ;;
+      "Not charging") state=pending-charge ;;
+      "Full") state=fully-charged ;;
+    esac
+  fi
+  states+=("$state")
+
+  pack_labels+=("$(awk -v c="${capacity:-0}" -v p="${share:-0}" 'BEGIN { printf "%dWh · %d%%", c, p + 0.5 }')")
+
+  cycles=$(awk '/charge-cycles:/ { print $2; exit }' <<<"$battery_info")
+  [[ -n $cycles && $cycles != "N/A" ]] && cycles_list+=("$cycles")
+
+  start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  [[ -n $start ]] && threshold_starts+=("$start")
+  [[ -n $end ]] && threshold_ends+=("$end")
+done
+
+((${#states[@]} == 0)) && exit 0
+
+# Each pack's own percentage, weighted by how much of the total capacity it
+# holds, so a small auxiliary pack can't skew the number the panel shows.
+percentage=$(awk -v w="$percentage_weighted" -v c="$capacity_total" -v e="$energy_total" 'BEGIN {
+  if (c > 0 && w > 0) print int(w / c + 0.5)
+  else if (c > 0) print int(e / c * 100 + 0.5)
+  else print 0
+}')
+capacity=$(awk -v c="$capacity_total" 'BEGIN { printf "%d", c }')
+power_rate_raw=$rate_total
 power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   rounded = sprintf("%.1f", rate)
   sub(/\.0$/, "", rounded)
   print rounded
 }')
-state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
 
-# UPower's state lags the kernel the same way its energy-rate does: a pack held
-# at a charge threshold keeps reporting pending-charge for tens of seconds after
-# it starts drawing again. Use sysfs when it is available.
-if [[ -r $battery_path/status ]]; then
-  case "$(<"$battery_path/status")" in
-    "Charging") state=charging ;;
-    "Discharging") state=discharging ;;
-    "Not charging") state=pending-charge ;;
-    "Full") state=fully-charged ;;
-  esac
+# The system is charging if any pack is taking charge, discharging if any pack
+# is feeding the system, and otherwise reports whatever the packs agree on.
+state=${states[0]}
+for candidate in "${states[@]}"; do
+  [[ $candidate == "discharging" ]] && state="discharging" && break
+done
+if [[ $state != "discharging" ]]; then
+  for candidate in "${states[@]}"; do
+    [[ $candidate == "charging" ]] && state="charging" && break
+  done
 fi
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
 
-[[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
-[[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
+# Time remaining is derived from the combined energy and draw so a second pack
+# extends the estimate instead of being ignored.
+if [[ $state == "charging" ]]; then
+  remaining_energy=$(awk -v e="$energy_total" -v c="$capacity_total" 'BEGIN { print (c > e) ? c - e : 0 }')
+else
+  remaining_energy=$energy_total
+fi
+
+time_remaining=$(awk -v energy="$remaining_energy" -v rate="${power_rate_raw:-0}" 'BEGIN {
+  if (rate <= 0.2 || energy <= 0) exit
+  hours_total = energy / rate
+  hours = int(hours_total)
+  minutes = int((hours_total - hours) * 60 + 0.5)
+  if (minutes == 60) { hours += 1; minutes = 0 }
+  if (hours == 0) printf "%dm", minutes
+  else if (minutes > 0) printf "%dh %dm", hours, minutes
+  else printf "%dh", hours
+}')
+
+dedupe_min() { printf '%s\n' "$@" | sort -n | head -1; }
+
+threshold_start=""
+threshold_end=""
+((${#threshold_starts[@]})) && threshold_start=$(dedupe_min "${threshold_starts[@]}")
+((${#threshold_ends[@]})) && threshold_end=$(dedupe_min "${threshold_ends[@]}")
+
+[[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | sort -n | head -1)
+[[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | sort -n | head -1)
 
 ac_online=false
 for supply in "$power_supply_path"/*; do
@@ -97,10 +165,10 @@ if awk -v rate="${power_rate_raw:-0}" 'BEGIN { exit !(rate <= 0.2) }'; then
   charge_idle=true
 fi
 
-# Holding means no power is moving, so an idle rate is a precondition for every
-# branch below: a stale state label must not report holding while the battery is
-# drawing watts.
 charge_holding=false
+# Holding means no power is moving. With more than one pack a single pack can
+# sit parked at its threshold while another still charges, so the combined rate
+# decides: any real draw means we are charging, whatever the labels say.
 if [[ $ac_online == "true" && -n $threshold_end && $charge_idle == "true" ]]; then
   if [[ $state == "pending-charge" ]]; then
     charge_holding=true
@@ -121,10 +189,22 @@ if [[ $shell_output == "true" ]]; then
   printf 'rate\t%s\n' "${power_rate}W"
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
+  # Single-battery machines already say everything in the totals above, so the
+  # per-pack breakdown only shows up when there is more than one pack.
+  if ((${#pack_labels[@]} > 1)); then
+    printf 'batteries\t%s\n' "${#pack_labels[@]}"
+    for index in "${!pack_labels[@]}"; do
+      printf 'battery%d\t%s\n' "$((index + 1))" "${pack_labels[index]}"
+    done
+  fi
 
-  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
-
-  [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
+  if ((${#cycles_list[@]})); then
+    cycles_label=${cycles_list[0]}
+    for cycles in "${cycles_list[@]:1}"; do
+      cycles_label+=" / $cycles"
+    done
+    printf 'cycles\t%s\n' "$cycles_label"
+  fi
 
   if [[ -n $threshold_end ]]; then
     if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
@@ -146,7 +226,7 @@ if [[ $charge_holding == "true" ]]; then
 
   echo "Battery ${percentage}%  ·  Holding at ${threshold_label}  ·  ${power_rate}W / ${capacity}Wh"
 elif [[ $state == "charging" ]]; then
-  echo "Battery ${percentage}%  ·  ${time_remaining} to full  ·   ${power_rate}W / ${capacity}Wh"
+  echo "Battery ${percentage}%  ·  ${time_remaining} to full  ·   ${power_rate}W / ${capacity}Wh"
 else
-  echo "Battery ${percentage}%  ·  ${time_remaining} left  ·   ${power_rate}W / ${capacity}Wh"
+  echo "Battery ${percentage}%  ·  ${time_remaining} left  ·   ${power_rate}W / ${capacity}Wh"
 fi

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -20,6 +20,23 @@ function parseKeyValue(raw) {
   return next
 }
 
+// Machines with more than one pack (ThinkPad T480 and friends) get a row per
+// pack under the totals. omarchy-battery-status only emits these keys when a
+// second pack exists, so single-battery hardware keeps the panel as it was.
+function batteryPacks(info) {
+  var data = info || {}
+  var count = parseInt(data.batteries, 10)
+  if (!(count > 1)) return []
+
+  var packs = []
+  for (var i = 1; i <= count; i++) {
+    var value = data["battery" + i]
+    if (!value) continue
+    packs.push({ label: "Battery " + i, value: value })
+  }
+  return packs
+}
+
 function parseProfiles(raw, previousIndex) {
   var lines = String(raw || "").split("\n")
   var list = []
@@ -94,6 +111,7 @@ if (typeof module !== "undefined") {
     clampIndex: clampIndex,
     selectProfileIndex: selectProfileIndex,
     parseKeyValue: parseKeyValue,
+    batteryPacks: batteryPacks,
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -24,6 +24,7 @@ Panel {
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
   readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  readonly property var batteryPacks: Model.batteryPacks(batteryInfo)
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -444,6 +445,33 @@ Panel {
             InfoPair {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
+            }
+          }
+        }
+
+        // ---------- Per-pack breakdown (multi-battery machines only) ----------
+        Row {
+          visible: root.batteryPacks.length > 1
+          width: parent.width
+          spacing: Style.space(20)
+
+          Column {
+            width: (parent.width - parent.spacing) / 2
+            spacing: Style.spacing.labelGap
+
+            Repeater {
+              model: root.batteryPacks.filter(function (pack, index) { return index % 2 === 0 })
+              InfoPair { label: modelData.label; value: modelData.value }
+            }
+          }
+
+          Column {
+            width: (parent.width - parent.spacing) / 2
+            spacing: Style.spacing.labelGap
+
+            Repeater {
+              model: root.batteryPacks.filter(function (pack, index) { return index % 2 === 1 })
+              InfoPair { label: modelData.label; value: modelData.value }
             }
           }
         }

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -44,6 +44,55 @@ grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status re
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
 
+# A pack held at a charge threshold keeps reporting pending-charge with a 0W
+# rate for tens of seconds after it starts charging again, so a stale label must
+# not win over sysfs and report holding mid-charge.
+stale_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$stale_dir"' EXIT
+
+mkdir -p "$stale_dir/bin" "$stale_dir/power/BAT0" "$stale_dir/power/AC"
+printf '29000000\n' >"$stale_dir/power/BAT0/power_now"
+printf 'Charging\n' >"$stale_dir/power/BAT0/status"
+printf '80\n' >"$stale_dir/power/BAT0/charge_control_end_threshold"
+printf 'Mains\n' >"$stale_dir/power/AC/type"
+printf '1\n' >"$stale_dir/power/AC/online"
+cat >"$stale_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                pending-charge
+  energy:               42.5 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          0 W
+  percentage:           75%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$stale_dir/bin/upower"
+
+stale_output=$(OMARCHY_POWER_SUPPLY_PATH="$stale_dir/power" PATH="$stale_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'state\tcharging' <<<"$stale_output" >/dev/null || fail "battery status trusts sysfs over a stale upower state" "$stale_output"
+grep -Fx $'rate\t29W' <<<"$stale_output" >/dev/null || fail "battery status reports the live charge rate" "$stale_output"
+
+# The same battery parked at its threshold, drawing nothing, is genuinely holding.
+printf '0\n' >"$stale_dir/power/BAT0/power_now"
+printf 'Not charging\n' >"$stale_dir/power/BAT0/status"
+
+holding_output=$(OMARCHY_POWER_SUPPLY_PATH="$stale_dir/power" PATH="$stale_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'state\tholding' <<<"$holding_output" >/dev/null || fail "battery status reports holding once the battery stops drawing" "$holding_output"
+
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"
 fi

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -42,7 +42,7 @@ grep -Fx $'percentage\t51%' <<<"$shell_output" >/dev/null || fail "battery statu
 grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery status reports state"
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
-grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'time\t2h 37m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
 
 # A pack held at a charge threshold keeps reporting pending-charge with a 0W
 # rate for tens of seconds after it starts charging again, so a stale label must
@@ -92,6 +92,83 @@ printf 'Not charging\n' >"$stale_dir/power/BAT0/status"
 holding_output=$(OMARCHY_POWER_SUPPLY_PATH="$stale_dir/power" PATH="$stale_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
 
 grep -Fx $'state\tholding' <<<"$holding_output" >/dev/null || fail "battery status reports holding once the battery stops drawing" "$holding_output"
+
+# Multi-battery laptops (ThinkPad T480 and friends) expose one BAT device per
+# pack; every reading has to combine them instead of following upower's first.
+dual_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$stale_dir" "$dual_dir"' EXIT
+
+mkdir -p "$dual_dir/bin" "$dual_dir/power/BAT0" "$dual_dir/power/BAT1"
+printf '0\n' >"$dual_dir/power/BAT0/power_now"
+printf '8000000\n' >"$dual_dir/power/BAT1/power_now"
+cat >"$dual_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT0 ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  present:              yes
+  state:                discharging
+  energy:               13.3 Wh
+  energy-full:          16.7 Wh
+  energy-rate:          0 W
+  charge-cycles:        348
+  percentage:           80%
+INFO
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT1 ]]; then
+  cat <<'INFO'
+  native-path:          BAT1
+  present:              yes
+  state:                discharging
+  energy:               57.4 Wh
+  energy-full:          71.0 Wh
+  energy-rate:          8 W
+  charge-cycles:        82
+  percentage:           81%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$dual_dir/bin/upower"
+
+dual_output=$(OMARCHY_POWER_SUPPLY_PATH="$dual_dir/power" PATH="$dual_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t81%' <<<"$dual_output" >/dev/null || fail "battery status blends both packs into one percentage" "$dual_output"
+grep -Fx $'size\t87Wh' <<<"$dual_output" >/dev/null || fail "battery status sums capacity across packs" "$dual_output"
+grep -Fx $'rate\t8W' <<<"$dual_output" >/dev/null || fail "battery status sums power draw across packs" "$dual_output"
+grep -Fx $'time\t8h 50m' <<<"$dual_output" >/dev/null || fail "battery status spends both packs before empty" "$dual_output"
+grep -Fx $'cycles\t348 / 82' <<<"$dual_output" >/dev/null || fail "battery status lists cycles per pack" "$dual_output"
+grep -Fx $'batteries\t2' <<<"$dual_output" >/dev/null || fail "battery status reports the pack count" "$dual_output"
+grep -Fx $'battery1\t16Wh · 80%' <<<"$dual_output" >/dev/null || fail "battery status breaks out the first pack" "$dual_output"
+grep -Fx $'battery2\t71Wh · 81%' <<<"$dual_output" >/dev/null || fail "battery status breaks out the second pack" "$dual_output"
+
+grep -q '^battery1' <<<"$shell_output" && fail "battery status omits the breakdown on single-battery machines" "$shell_output"
+
+# One pack parked at its threshold while the other still charges is charging,
+# not holding: the combined rate decides, not the parked pack's label.
+printf 'Not charging\n' >"$dual_dir/power/BAT0/status"
+printf 'Charging\n' >"$dual_dir/power/BAT1/status"
+printf '29000000\n' >"$dual_dir/power/BAT1/power_now"
+printf '80\n' >"$dual_dir/power/BAT0/charge_control_end_threshold"
+mkdir -p "$dual_dir/power/AC"
+printf 'Mains\n' >"$dual_dir/power/AC/type"
+printf '1\n' >"$dual_dir/power/AC/online"
+
+mixed_output=$(OMARCHY_POWER_SUPPLY_PATH="$dual_dir/power" PATH="$dual_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'state\tcharging' <<<"$mixed_output" >/dev/null || fail "battery status charges while one pack sits at its threshold" "$mixed_output"
+grep -Fx $'rate\t29W' <<<"$mixed_output" >/dev/null || fail "battery status reports the charging pack's rate" "$mixed_output"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -20,6 +20,14 @@ assertDeepEqual(
   'power parses profile output and clamps selection'
 )
 
+assertDeepEqual(
+  power.batteryPacks({ batteries: '2', battery1: '16Wh · 80%', battery2: '71Wh · 74%' }),
+  [{ label: 'Battery 1', value: '16Wh · 80%' }, { label: 'Battery 2', value: '71Wh · 74%' }],
+  'power lists a row per pack on multi-battery machines'
+)
+assertDeepEqual(power.batteryPacks({ size: '56Wh' }), [], 'power lists no packs on single-battery machines')
+assertDeepEqual(power.batteryPacks({}), [], 'power tolerates an empty battery payload')
+
 assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
 


### PR DESCRIPTION
Stacked on #7293 — take that one first; this branch contains it.

Laptops with two packs (ThinkPad T480 and friends, internal + hot-swappable) expose one `BAT*` device each. `omarchy-battery-status` takes `upower -e | grep BAT | head -n 1`, so the panel describes one pack and ignores the rest. On a T480 the bar reads:

```
Battery 80%  ·   left  ·   0W / 16Wh
```

That is the idle 16Wh internal pack, with no time estimate, while the 71Wh pack does all the work.

Every reading now combines all packs:

- **percentage** — each pack's own percentage weighted by its share of total capacity, so a small auxiliary pack cannot skew the number
- **size / rate** — summed, still preferring the live sysfs rate per pack
- **time** — derived from combined remaining energy divided by combined draw
- **state** — discharging wins, then charging, else what the packs agree on
- **cycles** — listed per pack (`348 / 82`); thresholds take the lowest across packs

The panel gains a `Battery 1` / `Battery 2` row showing each pack's size and charge, emitted only when a second pack exists — single-battery machines see the panel exactly as before, and there are tests on both sides asserting that.

One expectation moves: `battery status reports remaining time` goes `2h 30m` → `2h 37m`. Time no longer comes from UPower's `time to empty` (per-pack, and wrong once there are two) and is derived instead, which is consistent with the sysfs rate the script already prefers.

Verified on a T480 across both directions:

```
Battery 76%  ·  7h 53m left  ·   8.4W / 87Wh
Battery 78%  ·  38m to full  ·   29.8W / 87Wh   (one pack parked at its threshold, the other charging)
```

`./test/shell` passes apart from four failures that reproduce unchanged on a pristine `quattro` checkout of this machine (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`).
