### PR TITLE
feat: wrap the overflowing text in the menu

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -179,7 +179,7 @@ Item {
   }
 
   function rowListHeight(_serial, _count, _filter, _divider) {
-    if (displayModel.count === 0) return root.baseRowHeight
+    if (displayModel.count === 0) return root.mode === "input" ? root.baseRowHeight : emptyColumn.height
 
     var totals = []
     var total = 0
@@ -199,7 +199,7 @@ Item {
 
   function dmenuRowListHeight(_serial, _count, _filter) {
     if (root.mode === "input") return 0
-    if (displayModel.count === 0) return root.baseRowHeight
+    if (displayModel.count === 0) return emptyColumn.height
 
     var available = availableRowsHeight()
     if (root.dmenuMaxHeight > 0) available = Math.min(available, Style.space(root.dmenuMaxHeight))
@@ -1437,7 +1437,9 @@ Item {
           }
 
           Column {
+            id: emptyColumn
             anchors.centerIn: parent
+            width: parent.width
             spacing: Style.space(8)
             visible: displayModel.count === 0 && root.mode !== "input"
 
@@ -1448,7 +1450,7 @@ Item {
               font.family: root.fontFamily
               font.pixelSize: Style.font.displayLarge
               horizontalAlignment: Text.AlignHCenter
-              width: Style.space(320)
+              width: parent.width
             }
 
             Text {
@@ -1458,7 +1460,10 @@ Item {
               font.family: root.fontFamily
               font.pixelSize: Style.font.title
               horizontalAlignment: Text.AlignHCenter
-              width: Style.space(320)
+              width: parent.width
+              wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+              maximumLineCount: 5
+              elide: Text.ElideRight
             }
           }
         }


### PR DESCRIPTION
Fixes the overflowing search text in the menu body when the search text is too long.

- before
 
<img width="1848" height="424" alt="image" src="https://github.com/user-attachments/assets/29b2b65b-ac53-4950-a661-fb18360fdc8d" />

- after
<img width="756" height="464" alt="image" src="https://github.com/user-attachments/assets/fcc4857a-a5f3-42f3-ad8f-1d1fc79fbaf7" />
