### PR TITLE
Correctly name grok and add docs link

### DIFF
--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -10,7 +10,7 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 | `gemini`   | [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) |
 | `copilot`  | [GitHub Copilot CLI](https://github.com/github/copilot-cli)      |
 | `crush`    | [Crush](https://github.com/charmbracelet/crush)                  |
-| `grok`     | Grok CLI from xAI                                                |
+| `grok`     | [Grok Build](https://x.ai/build)                        |
 | `pi`       | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)        |
 | `omp`      | [Oh My Pi](https://github.com/can1357/oh-my-pi)                  |
 


### PR DESCRIPTION
Its "Grok Build" not "Grok CLI from xAI". I also added the Link to the docs.