### PR TITLE
Stop the agents panel scrolling by a few pixels

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -356,9 +356,10 @@ Panel {
     open: root.opened
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(380))
-    // Taller than the control panels on purpose: this one is a dashboard, and
-    // the whole point is reading limits and history without scrolling.
-    contentHeight: panel.fittedContentHeight(column.implicitHeight, Style.space(640))
+    // No fixed cap: this one is a dashboard, and the whole point is reading
+    // limits and history without scrolling. The panel grows to fit its
+    // content; fittedContentHeight still bounds it to the screen.
+    contentHeight: panel.fittedContentHeight(column.implicitHeight)
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -386,8 +387,15 @@ Panel {
         clip: true
         boundsBehavior: Flickable.StopAtBounds
         flickableDirection: Flickable.VerticalFlick
-        interactive: contentHeight > height
-        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+        // Sub-pixel slop: fittedContentHeight rounds the card height, so on a
+        // fractional-scale display the viewport can land a fraction of a pixel
+        // short of the content. That is not overflow worth a scrollbar or a
+        // wheel that nudges the content around.
+        readonly property bool overflows: contentHeight > height + 1
+        interactive: overflows
+        ScrollBar.vertical: ScrollBar {
+          policy: panelFlick.overflows ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+        }
 
         Column {
           id: column


### PR DESCRIPTION
Stylistic annoyance fix, no functional change. The agents panel caps its height at `Style.space(640)`, but its content can run a few pixels taller — three limit windows plus the day and model tables land just over the cap. The result: a scrollbar sits on the panel's right edge and covers the limit percentages (see the "44%" in the capture below), and every wheel tick jiggles the whole dashboard a few pixels down and back up. On fractional-scale displays, rounding in `fittedContentHeight` can leave the viewport a fraction of a pixel shorter than the content, producing the same phantom scroll even under the cap.

- Drop the fixed cap: the panel grows to fit its content; `fittedContentHeight` still bounds it to the screen. This matches the panel's stated intent — a dashboard read without scrolling.
- Give the overflow check 1px of slop so sub-pixel rounding never enables scrolling. Real overflow (screen shorter than content) still scrolls with a scrollbar, as before.

| Before | After |
| --- | --- |
| <img width="488" height="842" alt="pr-before" src="https://github.com/user-attachments/assets/5146d3df-f287-47c4-ae36-1b3c579eb707" /> | <img width="488" height="842" alt="pr-after" src="https://github.com/user-attachments/assets/21a314f0-423e-4d8a-8e2e-1d80a9a93089" /> |

Before: the scrollbar overlaps the percentage values and one wheel step jiggles the content. After: the same wheel step moves nothing — the frames are pixel-identical.

Tested with `./test/all` (180 files; 4 failures are environment-dependent and identical on a pristine checkout).
