### PR TITLE
Note that voxtype push-to-talk can't be rebound to a bare modifier key

### DIFF
--- a/default/hypr/bindings/voxtype.lua
+++ b/default/hypr/bindings/voxtype.lua
@@ -1,3 +1,8 @@
+-- Want push-to-talk on a bare modifier key (e.g. Right Cmd/Super) instead of
+-- F9? Hyprland can't fire a release-bind for a lone modifier key
+-- (https://github.com/hyprwm/Hyprland/issues/6946), so o.bind can't do this.
+-- Use voxtype's own built-in evdev hotkey instead:
+-- ~/.config/voxtype/config.toml -> [hotkey] enabled = true, key = "RIGHTMETA"
 if o.cmd_present("voxtype") then
   o.bind("SUPER + CTRL + X", "Toggle dictation", "voxtype record toggle")
   o.bind("F9", "Start dictation (push-to-talk)", "voxtype record start")


### PR DESCRIPTION
## Summary
- Right Cmd/Super (or any bare modifier key, either side) can't do hold/release push-to-talk via a Hyprland `o.bind`/`bindr` pair — Hyprland never fires the release-bind for a lone modifier key ([hyprwm/Hyprland#6946](https://github.com/hyprwm/Hyprland/issues/6946), still open as of Hyprland 0.56.2).
- Confirmed by testing plain keysym binds, the documented "modifier tap" pattern, and raw keycode binds — all fire on press, none fire on release.
- voxtype has its own built-in evdev hotkey listener that grabs the key directly and isn't affected, so this adds a short comment pointing users who want this at that instead of leading them into the same dead end.

## Test plan
- [x] `./test/all` — 3 pre-existing unrelated failures (need a separate `omarchy-pkgs` checkout), reproduced identically with this change stashed out
- [x] Comment-only change to `default/hypr/bindings/voxtype.lua`, no behavior change