### PR TITLE
Fix 1Password window matching regex

### DIFF
--- a/default/hypr/apps/1password.lua
+++ b/default/hypr/apps/1password.lua
@@ -1,1 +1,1 @@
-o.window("^(1[p|P]assword)$", { no_screen_share = true, tag = "+floating-window" })
+o.window("^(1[pP]assword)$", { no_screen_share = true, tag = "+floating-window" })


### PR DESCRIPTION
The 1Password window matching regex currently uses `[p|P]`.

Because this is a regex character class, `|` is treated as a literal character rather than an alternation operator. This means the current pattern also matches `1|assword`.

Change `[p|P]` to `[pP]` so only the intended lowercase and uppercase forms are matched.