### PR TITLE
Add plugin-provided audio output icons

### DIFF
--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -100,13 +100,20 @@ for kind_entry_point in \
   "menu:menu" \
   "overlay:overlay" \
   "panel:panel" \
-  "service:service"; do
+  "service:service" \
+  "audio-output-icon:audioOutputIcon"; do
   kind="${kind_entry_point%%:*}"
   entry_point="${kind_entry_point##*:}"
   jq -e --arg kind "$kind" '(.kinds | index($kind)) != null' "$MANIFEST" >/dev/null 2>&1 || continue
   jq -e --arg ep "$entry_point" '.entryPoints | has($ep)' "$MANIFEST" >/dev/null 2>&1 \
     || fail "kind '$kind' requires an 'entryPoints.$entry_point' to load"
 done
+
+if jq -e '(.kinds | index("audio-output-icon")) != null' "$MANIFEST" >/dev/null 2>&1; then
+  provider=$(jq -r '.entryPoints.audioOutputIcon // ""' "$MANIFEST")
+  [[ -x "$PLUGIN_DIR/$provider" ]] \
+    || fail "audio output icon entry point must be executable: '$provider'"
+fi
 
 # Refuse any symlink anywhere inside the plugin folder. Symlinks could point a
 # copied plugin back at arbitrary files on disk after it lands in the trusted

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -34,6 +34,7 @@ wait).
 | `overlay`    | Fullscreen overlay (e.g. background picker)    |
 | `menu`       | Summoned menu surface                          |
 | `service`    | Headless singleton, no UI                      |
+| `audio-output-icon` | Executable that may override the stock audio output glyph |
 
 Only one full bar option is active at a time. The built-in `omarchy.bar` is
 used when `bar.id` is omitted or when a selected third-party bar cannot load.
@@ -41,7 +42,28 @@ Panels, overlays, and menus are loaded when summoned. Plugins can set the
 top-level manifest key `keepLoaded: true` to survive between summons.
 First-party services are loaded at startup.
 
-Entry points are QML `Item`s. Panel, overlay, and menu entry points expose
+### Audio output icon providers
+
+An enabled plugin can replace only the audio output glyph without cloning the built-in audio widget. Declare the `audio-output-icon` kind and point `entryPoints.audioOutputIcon` at an executable file in the plugin:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "my.org.audio-device",
+  "name": "My audio device",
+  "version": "1.0.0",
+  "kinds": ["audio-output-icon"],
+  "entryPoints": { "audioOutputIcon": "bin/output-icon" }
+}
+```
+
+Omarchy invokes the provider with the stock glyph, PipeWire sink name, sink description, volume percentage, and mute state as positional arguments. Print one glyph to stdout to override the icon, or print nothing to keep the stock icon. The provider is polled every two seconds while enabled so it can reflect device state that PipeWire does not expose. It must finish quickly and must not change device state.
+
+The arguments are `$1` stock glyph, `$2` sink name, `$3` sink description, `$4` integer volume percentage, and `$5` mute state (`true` or `false`).
+
+If multiple providers are enabled, the plugin with the lexicographically first id wins. Plugins run as unsandboxed code, and this executable follows the same trust model as QML entry points.
+
+QML entry points are `Item`s. Panel, overlay, and menu entry points expose
 `open(payloadJson)` and `close()` for summon/hide; on load the host injects
 `omarchyPath`, `shell`, `manifest`, and the registries (`pluginRegistry` /
 `barWidgetRegistry`) as properties.

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -35,6 +35,10 @@ function outputVolumeName(volume, muted) {
   return "Whisper"
 }
 
+function parseOutputIcon(raw) {
+  return String(raw || "").split(/\r?\n/, 1)[0].trim()
+}
+
 function parseSinkAvailability(raw) {
   var next = {}
   var lines = String(raw || "").split("\n")
@@ -239,6 +243,7 @@ if (typeof module !== "undefined") {
     isAudioSource: isAudioSource,
     listSnapshot: listSnapshot,
     outputVolumeName: outputVolumeName,
+    parseOutputIcon: parseOutputIcon,
     parseSinkAvailability: parseSinkAvailability,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -137,7 +137,10 @@ Panel {
 
   // Re-resolve whenever the selected output changes; the timer below is only a
   // safety net for the tuning being applied or removed underneath us.
-  onSinkChanged: resolveVolumeSink()
+  onSinkChanged: {
+    resolveVolumeSink()
+    scheduleOutputIconRefresh()
+  }
 
   function resolveVolumeSink() {
     if (!volumeSinkProc.running) volumeSinkProc.running = true
@@ -147,6 +150,21 @@ Panel {
   readonly property bool outputMuted: volumeSink && volumeSink.audio ? volumeSink.audio.muted : false
   readonly property real inputVolume: source && source.audio ? source.audio.volume : 0
   readonly property bool inputMuted: source && source.audio ? source.audio.muted : false
+
+  readonly property string outputIconProvider: {
+    var registry = bar?.shell?.pluginRegistry
+    if (!registry) return ""
+    var revision = registry.registryRevision
+    return registry.firstEnabledEntryPointPath("audio-output-icon", "audioOutputIcon")
+  }
+  property string customOutputIcon: ""
+
+  onOutputVolumeChanged: scheduleOutputIconRefresh()
+  onOutputMutedChanged: scheduleOutputIconRefresh()
+  onOutputIconProviderChanged: {
+    customOutputIcon = ""
+    scheduleOutputIconRefresh()
+  }
 
   onRawAudioSinksChanged: if (rawAudioSinks.length > 0) cachedAudioSinks = rawAudioSinks
   onRawAudioSourcesChanged: if (rawAudioSources.length > 0) cachedAudioSources = rawAudioSources
@@ -398,7 +416,7 @@ Panel {
     if (selectedIndex < floor) selectedIndex = floor
   }
 
-  function outputIcon(volume) {
+  function stockOutputIcon(volume) {
     // Match the old Waybar pulseaudio glyph set. The Material Design speaker
     // icons render visually smaller in JetBrainsMono Nerd Font.
     if (!sink || !sink.audio) return ""
@@ -409,6 +427,27 @@ Panel {
     if (v >= 0.34) return ""
     if (v > 0) return ""
     return ""
+  }
+
+  function outputIcon(volume) {
+    return customOutputIcon || stockOutputIcon(volume)
+  }
+
+  function scheduleOutputIconRefresh() {
+    if (!outputIconProvider) return
+    outputIconRefreshTimer.restart()
+  }
+
+  function refreshOutputIcon() {
+    if (!outputIconProvider) {
+      customOutputIcon = ""
+      return
+    }
+    if (!outputIconProc.running) outputIconProc.running = true
+  }
+
+  function updateOutputIcon(raw) {
+    customOutputIcon = outputIconProvider ? Model.parseOutputIcon(raw) : ""
   }
 
   function inputIcon() {
@@ -599,6 +638,40 @@ Panel {
       waitForEnd: true
       onStreamFinished: root.volumeSinkName = String(text).trim()
     }
+  }
+
+  Process {
+    id: outputIconProc
+    command: [
+      root.outputIconProvider,
+      root.stockOutputIcon(),
+      root.sink ? String(root.sink.name || "") : "",
+      root.sink ? String(root.sink.description || "") : "",
+      String(Math.round(root.outputVolume * 100)),
+      root.outputMuted ? "true" : "false"
+    ]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateOutputIcon(text)
+    }
+  }
+
+  Timer {
+    id: outputIconRefreshTimer
+    interval: 100
+    repeat: false
+    onTriggered: root.refreshOutputIcon()
+  }
+
+  // Provider logic may reflect hardware state that PipeWire cannot see. Poll
+  // only while such a plugin is enabled; the stock widget starts no extra
+  // process when it has no provider.
+  Timer {
+    interval: 2000
+    running: root.outputIconProvider !== ""
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.refreshOutputIcon()
   }
 
   Timer {

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -90,7 +90,7 @@ QtObject {
     return manifest
   }
 
-  function entryPointUrl(manifest, kind) {
+  function entryPointPath(manifest, kind) {
     if (!Util.isPlainObject(manifest)) return ""
     var ep = manifest.entryPoints ? manifest.entryPoints[kind] : null
     if (!ep) return ""
@@ -104,7 +104,27 @@ QtObject {
       console.warn("PluginRegistry: entry point escapes sourceDir: " + resolved)
       return ""
     }
-    return Util.fileUrl(resolved)
+    return resolved
+  }
+
+  function entryPointUrl(manifest, kind) {
+    var resolved = entryPointPath(manifest, kind)
+    return resolved ? Util.fileUrl(resolved) : ""
+  }
+
+  // Non-QML extension points use executable files rather than Components.
+  // Pick deterministically so enabling two providers never depends on scan
+  // order; users can disable the provider they do not want.
+  function firstEnabledEntryPointPath(kind, entryPoint) {
+    var ids = Object.keys(installedPlugins).sort()
+    for (var i = 0; i < ids.length; i++) {
+      var manifest = installedPlugins[ids[i]]
+      if (!manifest || !Array.isArray(manifest.kinds) || manifest.kinds.indexOf(kind) === -1) continue
+      if (!isEnabled(ids[i])) continue
+      var path = entryPointPath(manifest, entryPoint)
+      if (path) return path
+    }
+    return ""
   }
 
   // Enabled = the plugin id is referenced somewhere in shell.json. That can

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -16,6 +16,8 @@ assert(audio.isAudioSource({ type: 'Audio/Source' }), 'audio detects typed sourc
 assertEqual(audio.outputVolumeName(0, false), 'Silenced', 'audio labels silent output')
 assertEqual(audio.outputVolumeName(0.9, false), 'Party mode', 'audio labels loud output')
 assertEqual(audio.outputVolumeName(0.5, true), 'Muted', 'audio labels muted output')
+assertEqual(audio.parseOutputIcon('󰃋\nignored'), '󰃋', 'audio accepts the first provider output line')
+assertEqual(audio.parseOutputIcon('  \n'), '', 'audio falls back when a provider returns no icon')
 
 assertDeepEqual(audio.parseSinkAvailability('alsa_output\t1\nhdmi_output\t0\n'), { alsa_output: true, hdmi_output: false }, 'audio parses sink availability')
 assertEqual(audio.friendlyDeviceLabel('Built-in Audio Speakers Output'), 'Speakers', 'audio cleans device labels')
@@ -47,3 +49,14 @@ assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spo
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
 JS
+
+panel_source=$(<"$ROOT/shell/plugins/panels/audio/Panel.qml")
+registry_source=$(<"$ROOT/shell/services/PluginRegistry.qml")
+
+[[ $panel_source == *'firstEnabledEntryPointPath("audio-output-icon", "audioOutputIcon")'* ]] \
+  || fail "audio discovers the enabled output icon provider"
+[[ $panel_source == *'running: root.outputIconProvider !== ""'* ]] \
+  || fail "audio polls only when an output icon provider is enabled"
+[[ $registry_source == *'var ids = Object.keys(installedPlugins).sort()'* ]] \
+  || fail "plugin entry point selection is deterministic"
+pass "audio supports plugin-provided output icons"

--- a/test/shell.d/fixtures/manifest-entrypoints/shell.qml
+++ b/test/shell.d/fixtures/manifest-entrypoints/shell.qml
@@ -102,6 +102,23 @@ ShellRoot {
     createdIds.push(entry.id + ":" + entry.kind)
   }
 
+  function verifyCreatedEntries(entries) {
+    root.assertTrue(root.createdIds.length === entries.length, "all manifest entrypoints instantiate")
+    var audio = null
+    for (var i = 0; i < root.createdObjects.length; i++) {
+      var item = root.createdObjects[i]
+      if (item && item.moduleName === "omarchy.audio") audio = item
+    }
+    root.assertTrue(audio !== null, "audio entrypoint instantiates")
+    if (audio) root.assertTrue(audio.customOutputIcon === "󰃋", "audio entrypoint reads its executable icon provider")
+
+    for (var j = 0; j < root.createdObjects.length; j++) {
+      var created = root.createdObjects[j]
+      if (created && typeof created.destroy === "function") created.destroy()
+    }
+    root.writeResult()
+  }
+
   Item { id: host }
 
   QtObject {
@@ -132,7 +149,12 @@ ShellRoot {
   QtObject {
     id: mockPluginRegistry
     property var installedPlugins: ({})
+    property int registryRevision: 0
     function isEnabled(id) { return true }
+    function firstEnabledEntryPointPath(kind, entryPoint) {
+      return kind === "audio-output-icon" && entryPoint === "audioOutputIcon"
+        ? Quickshell.env("OMARCHY_QML_AUDIO_ICON_PROVIDER") : ""
+    }
     function entryPointUrl(manifest, kind) { return "" }
     function rescan() {}
   }
@@ -140,6 +162,7 @@ ShellRoot {
   QtObject {
     id: mockShell
     property var bar: fakeBar
+    property var pluginRegistry: mockPluginRegistry
     property var barConfig: ({ position: "top" })
     property var shellConfig: ({ version: 1, idle: {}, plugins: [], bar: { layout: { left: [], center: [], right: [] } } })
     function firstPartyServiceFor(id) { return null }
@@ -172,6 +195,14 @@ ShellRoot {
   }
 
   Timer {
+    id: verificationTimer
+    interval: 500
+    repeat: false
+    property var entries: []
+    onTriggered: root.verifyCreatedEntries(entries)
+  }
+
+  Timer {
     interval: 1
     running: true
     repeat: false
@@ -179,15 +210,8 @@ ShellRoot {
       var entries = manifests()
       root.assertTrue(entries.length > 0, "manifest entry list is not empty")
       for (var i = 0; i < entries.length; i++) root.loadEntry(entries[i])
-
-      Qt.callLater(function() {
-        root.assertTrue(root.createdIds.length === entries.length, "all manifest entrypoints instantiate")
-        for (var j = 0; j < root.createdObjects.length; j++) {
-          var item = root.createdObjects[j]
-          if (item && typeof item.destroy === "function") item.destroy()
-        }
-        root.writeResult()
-      })
+      verificationTimer.entries = entries
+      verificationTimer.start()
     }
   }
 }

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -87,6 +87,8 @@ ShellRoot {
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
     scan += block("thirdparty", "/third/center-widget", manifest("third.center-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/right-widget", manifest("third.right-widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "right" }))
+    scan += block("thirdparty", "/third/audio-a", manifest("third.audio-a", ["audio-output-icon"], { audioOutputIcon: "output-icon" }))
+    scan += block("thirdparty", "/third/audio-z", manifest("third.audio-z", ["audio-output-icon"], { audioOutputIcon: "output-icon" }))
     var localWidget = manifest("local.first-widget", ["bar-widget"], { barWidget: "Widget.qml" })
     localWidget.omarchy = { clonedFrom: "omarchy.first-widget" }
     scan += block("thirdparty", "/third/local-widget", localWidget)
@@ -123,6 +125,8 @@ ShellRoot {
       "omarchy.first-widget",
       "omarchy.grouped-panel",
       "omarchy.hybrid",
+      "third.audio-a",
+      "third.audio-z",
       "third.bar",
       "third.center-widget",
       "third.panel",
@@ -135,6 +139,7 @@ ShellRoot {
     root.assertEqual(registry.installedPlugins["omarchy.grouped-panel"].__sourceDir, "/first/panels/grouped", "grouped plugin source paths are preserved")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel"), "file:///third/panel/Panel.qml", "entryPointUrl resolves plugin-relative paths")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.widget"], "barWidget"), "file:///third/widget/Widget.qml", "entryPointUrl resolves bar widget paths")
+    root.assertEqual(registry.entryPointPath(registry.installedPlugins["third.audio-a"], "audioOutputIcon"), "/third/audio-a/output-icon", "entryPointPath resolves executable plugin paths")
 
     root.assertTrue(!has("omarchy.reserved"), "third-party omarchy namespace ids are rejected")
     root.assertTrue(!has("third.unsafe"), "unsafe entry points are rejected")
@@ -147,6 +152,24 @@ ShellRoot {
     root.assertTrue(!registry.isEnabled("third.bar"), "third-party bar options start inactive")
     root.assertTrue(!registry.isEnabled("third.panel"), "third-party plugins start disabled")
     root.assertEqual(registry.resolveEnabledId("omarchy.first-widget"), "omarchy.first-widget", "inactive clones do not replace their source id")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: [{ id: "third.audio-z" }, { id: "third.audio-a" }]
+    }
+    root.assertEqual(
+      registry.firstEnabledEntryPointPath("audio-output-icon", "audioOutputIcon"),
+      "/third/audio-a/output-icon",
+      "executable extension points select the enabled provider deterministically"
+    )
+    root.config.plugins = [{ id: "third.audio-z" }]
+    root.assertEqual(
+      registry.firstEnabledEntryPointPath("audio-output-icon", "audioOutputIcon"),
+      "/third/audio-z/output-icon",
+      "executable extension points ignore disabled providers"
+    )
+    root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
 
     registry.setEnabled("third.bar", true)
     root.assertEqual(root.config.bar.id, "third.bar", "enabling third-party bar options writes bar id")

--- a/test/shell.d/manifest-entrypoints-test.sh
+++ b/test/shell.d/manifest-entrypoints-test.sh
@@ -71,6 +71,13 @@ result="$TMPDIR/result.json"
 log="$TMPDIR/quickshell.log"
 config_dir="$TMPDIR/manifest-entrypoints"
 mkdir -p "$config_dir" "$TMPDIR/home"
+audio_icon_provider="$TMPDIR/audio-output-icon"
+cat >"$audio_icon_provider" <<'PROVIDER'
+#!/bin/bash
+(( $# == 5 )) || exit 1
+printf '󰃋\n'
+PROVIDER
+chmod +x "$audio_icon_provider"
 cp "$SHELL_TEST_DIR/fixtures/manifest-entrypoints/shell.qml" "$config_dir/shell.qml"
 ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
 ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
@@ -78,6 +85,7 @@ ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
 OMARCHY_PATH="$ROOT" \
 OMARCHY_QML_TEST_RESULT="$result" \
 OMARCHY_QML_MANIFESTS="$manifest_entries" \
+OMARCHY_QML_AUDIO_ICON_PROVIDER="$audio_icon_provider" \
 HOME="$TMPDIR/home" \
 XDG_CONFIG_HOME="$TMPDIR/home/.config" \
 XDG_CACHE_HOME="$TMPDIR/home/.cache" \

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -33,6 +33,7 @@ JSON
   while IFS= read -r entry; do
     [[ -n $entry ]] || continue
     touch "$dir/$entry"
+    chmod +x "$dir/$entry"
   done < <(jq -r '.[]' <<<"$entry_points")
 
   printf '%s\n' "$dir"
@@ -65,7 +66,15 @@ menu:menu
 overlay:overlay
 panel:panel
 service:service
+audio-output-icon:audioOutputIcon
 KINDS
+
+dir=$(write_plugin "non-executable-audio-icon" '["audio-output-icon"]' '{"audioOutputIcon": "icon-provider"}')
+chmod -x "$dir/icon-provider"
+output=$(validate "$dir") && fail "validate refuses a non-executable audio output icon provider" "$output"
+grep -qF "audio output icon entry point must be executable" <<<"$output" \
+  || fail "validate explains that the audio output icon provider must be executable" "$output"
+pass "validate refuses a non-executable audio output icon provider"
 
 # A plugin that is both a bar and a widget owes an entry point for each.
 dir=$(write_plugin "both" '["bar","bar-widget"]' '{"bar": "Bar.qml", "barWidget": "Widget.qml"}')

--- a/test/shell.d/plugins-test.sh
+++ b/test/shell.d/plugins-test.sh
@@ -14,7 +14,8 @@ const kindEntryPoints = {
   'menu': 'menu',
   'overlay': 'overlay',
   'panel': 'panel',
-  'service': 'service'
+  'service': 'service',
+  'audio-output-icon': 'audioOutputIcon'
 }
 
 function isPlainObject(value) {
@@ -54,6 +55,10 @@ function assertSafeEntryPoint(manifest, manifestPath, key, value) {
   check(!path.isAbsolute(value), `${label} must be relative`)
   check(!String(value).split(/[\\/]+/).includes('..'), `${label} must stay inside plugin source`)
   check(fs.existsSync(path.join(sourceDirForManifest(manifestPath), String(value))), `${label} file must exist`)
+  if (key === 'audioOutputIcon') {
+    const mode = fs.statSync(path.join(sourceDirForManifest(manifestPath), String(value))).mode
+    check((mode & 0o111) !== 0, `${label} must be executable`)
+  }
 }
 
 const manifests = walk(pluginsDir)


### PR DESCRIPTION
## Summary

- Add an `audio-output-icon` plugin kind backed by an executable `entryPoints.audioOutputIcon`.
- Allow enabled plugins to override only the built-in audio output glyph while preserving the stock fallback.
- Validate and document the provider contract.
- Cover provider discovery, manifest validation, and executable invocation with shell and Quickshell runtime tests.

## Motivation

Some USB DACs and sound cards can switch between speakers and headphones internally without changing the PipeWire sink.

Third-party integrations currently have to clone the complete `omarchy.audio` widget just to reflect that hardware state. Those clones stop receiving upstream audio widget fixes and can break volume, microphone, or device selection after shell changes.

This extension keeps the built-in widget owned by Omarchy while moving device-specific detection into a small external provider.

## Provider contract

An enabled plugin declares:

- kind: `audio-output-icon`
- entry point: `entryPoints.audioOutputIcon`
- an executable provider file

The provider receives the stock glyph, sink name, sink description, volume percentage, and mute state. It prints one glyph to override the icon or nothing to retain the stock icon.

No additional process runs when no provider is enabled. Enabled providers are polled every two seconds so they can reflect hardware state unavailable through PipeWire.

## Testing

- `bash test/shell.d/audio-test.sh`
- `bash test/shell.d/plugin-validate-test.sh`
- `bash test/shell.d/plugins-test.sh`
- `bash test/shell.d/plugin-registry-contract-test.sh`
- `bash test/shell.d/manifest-entrypoints-test.sh`
- `bash test/shell.d/bar-widget-contract-test.sh`
- `git diff --check`
- `git fsck --full`

`./test/all` passes the changed and related areas. The existing `network-qr-test.sh` interface auto-detection failure reproduces unchanged on the clean upstream parent `f32ebbdb`.