### PR TITLE
Keep jack names on multi-port audio devices

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -64,9 +64,19 @@ function nodeProps(node) {
 function nodeLabel(node) {
   if (!node) return "Unknown"
   var p = nodeProps(node)
-  var nickname = friendlyDeviceLabel(node.nickname || node.nick || p["node.nick"] || p["device.profile.description"] || "")
-  if (nickname) return nickname
-  return friendlyDeviceLabel(node.description || p["node.description"] || node.name || "Unknown")
+  var nick = String(node.nickname || node.nick || p["node.nick"] || "").trim()
+  var profile = String(p["device.profile.description"] || "").trim()
+  var desc = String(node.description || p["node.description"] || "").trim()
+
+  // Multi-jack cards (Focusrite, onboard USB audio) share one node.nick
+  // and put the port in node.description / device.profile.description.
+  // Prefer that longer description when it is just nick + port.
+  if (desc && nick && desc.length > nick.length && desc.toLowerCase().indexOf(nick.toLowerCase()) === 0)
+    return friendlyDeviceLabel(desc)
+
+  if (nick) return friendlyDeviceLabel(nick)
+  if (profile) return friendlyDeviceLabel(profile)
+  return friendlyDeviceLabel(desc || node.name || "Unknown")
 }
 
 function isHeadphones(node) {

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -24,6 +24,42 @@ assertEqual(
   'Microphone',
   'audio chooses friendly node labels'
 )
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
+    properties: {
+      'node.nick': 'Scarlett 18i20 USB',
+      'node.description': 'Scarlett 18i20 USB Line Output 1+2',
+      'device.profile.description': 'Line Output 1+2'
+    }
+  }),
+  'Scarlett 18i20 USB Line Output 1+2',
+  'audio keeps the jack on a shared-nick output'
+)
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
+    properties: {
+      'node.nick': 'Scarlett 18i20 USB',
+      'node.description': 'Scarlett 18i20 USB Input 1 (Mic)',
+      'device.profile.description': 'Input 1 (Mic)'
+    }
+  }),
+  'Scarlett 18i20 USB Input 1 (Mic)',
+  'audio keeps the jack on a shared-nick input'
+)
+assertEqual(
+  audio.nodeLabel({
+    ready: true,
+    properties: {
+      'node.nick': 'Odyssey G8',
+      'node.description': 'AD102 High Definition Audio Controller Digital Stereo (HDMI)',
+      'device.profile.description': 'Digital Stereo (HDMI)'
+    }
+  }),
+  'Odyssey G8',
+  'audio keeps a unique nick when the description is a different product string'
+)
 
 const headphones = { ready: true, name: 'bluez_output.airpods', properties: { 'device.product.name': 'AirPods Headphones' } }
 assert(audio.isHeadphones(headphones), 'audio detects headphone devices')


### PR DESCRIPTION
The audio panel prefers `node.nick` for device rows. Multi-jack cards such as the Focusrite Scarlett 18i20 share that nick across every port (`Scarlett 18i20 USB`) and put the actual jack in `node.description` (`Scarlett 18i20 USB Line Output 1+2`, `Input 1 (Mic)`, `Headphones 1`). The picker therefore showed a stack of identical names, so the right speakers and mic were guesswork.

Use the longer description when it is just nick + port. HDMI and other devices whose description is a different product string keep their short nick (`Odyssey G8`).

Verified on a Scarlett 18i20: outputs now read `Line Output 1+2`, `Headphones 1`, `S/PDIF`, etc.; inputs now read `Input 1 (Mic)`, `Input 3`, `S/PDIF Input 1`, etc.

`./test/all`: CLI suite passed; audio-test.sh passed including the new shared-nick cases. Three other shell files fail looking for an `omarchy-pkgs` checkout and fail the same way on pristine `quattro`.