### PR TITLE
fix: always use sed -i --follow-symlinks to preserve symlinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,14 @@ Commands installed by Omarchy's default package set are runtime invariants. Invo
 
 Exceptions are allowed for migration and package-helper scripts where the helper may not be available yet, where the helper itself is being implemented, or where direct package-manager behavior is required.
 
+# Symlink-safe file editing
+
+User config files under the home directory may be symlinks managed by dotfile tools (GNU Stow, chezmoi, yadm, bare git repos). Any in-place edit must preserve the symlink rather than replacing it with a regular file.
+
+- **`sed -i`**: always use `sed -i --follow-symlinks`. Without it, GNU sed writes a temporary file and renames it over the target, replacing a symlink with a regular file. This is critical for user files and harmless everywhere else — there is no reason to omit it.
+- Alternatives like `awk '...' file > tmp && mv tmp file` have the same problem — they replace the symlink. Prefer `sed -i --follow-symlinks` or write through the symlink explicitly with `cat > "$file"` patterns that follow symlinks.
+- The architectural test `test/shell.d/sed-follow-symlinks-test.sh` enforces this rule in CI for `bin/` and `migrations/`. If you must use bare `sed -i` on a non-user path (staging dir, build dir), add the file to the test's allowlist with a comment.
+
 # Menu
 
 - The menu definition lives in `default/omarchy/omarchy-menu.jsonc`;

--- a/agents/skills/migrations.md
+++ b/agents/skills/migrations.md
@@ -135,6 +135,9 @@ New migration format:
   hot-reloads `shell.json` edits.
 - Raw `pacman`, `command -v`, and direct config edits are acceptable when
   needed for one-off repair work.
+- Always use `sed -i --follow-symlinks` when editing user config files.
+  Bare `sed -i` replaces symlinks with regular files, breaking dotfile
+  setups. The test `test/shell.d/sed-follow-symlinks-test.sh` enforces this.
 
 Example:
 

--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -137,7 +137,7 @@ set_terminal_size() {
   local pt="$1"
 
   if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-    sed -i -E "s/^size[[:space:]]*=.*/size = $pt/" ~/.config/alacritty/alacritty.toml
+    sed -i --follow-symlinks -E "s/^size[[:space:]]*=.*/size = $pt/" ~/.config/alacritty/alacritty.toml
   fi
 
   if [[ -f ~/.config/kitty/kitty.conf ]] || omarchy-cmd-present kitty; then
@@ -151,12 +151,12 @@ set_terminal_size() {
   fi
 
   if [[ -f ~/.config/ghostty/config ]]; then
-    sed -i -E "s/^font-size = .*/font-size = $pt/" ~/.config/ghostty/config
+    sed -i --follow-symlinks -E "s/^font-size = .*/font-size = $pt/" ~/.config/ghostty/config
     pkill -SIGUSR2 ghostty 2>/dev/null || true
   fi
 
   if [[ -f ~/.config/foot/foot.ini ]]; then
-    sed -i -E "s/(:size=)[0-9.]+/\1$pt/" ~/.config/foot/foot.ini
+    sed -i --follow-symlinks -E "s/(:size=)[0-9.]+/\1$pt/" ~/.config/foot/foot.ini
     # Foot has no config-reload signal, so a running instance keeps its startup
     # size until relaunched (new windows pick up the change). Nudge the user —
     # but reuse the same notification id (freedesktop replaces_id) so dragging

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -27,7 +27,7 @@ if ! fc-list | grep -Fqi -- "$font_name"; then
 fi
 
 if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-  sed -i "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
+  sed -i --follow-symlinks "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
 fi
 
 if [[ -f ~/.config/kitty/kitty.conf ]] || omarchy-cmd-present kitty; then
@@ -42,12 +42,12 @@ if [[ -f ~/.config/kitty/kitty.conf ]] || omarchy-cmd-present kitty; then
 fi
 
 if [[ -f ~/.config/ghostty/config ]]; then
-  sed -i "s/font-family = \".*\"/font-family = \"$font_name\"/g" ~/.config/ghostty/config
+  sed -i --follow-symlinks "s/font-family = \".*\"/font-family = \"$font_name\"/g" ~/.config/ghostty/config
   pkill -SIGUSR2 ghostty
 fi
 
 if [[ -f ~/.config/foot/foot.ini ]]; then
-  sed -i "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
+  sed -i --follow-symlinks "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,

--- a/bin/omarchy-hibernation-remove
+++ b/bin/omarchy-hibernation-remove
@@ -40,8 +40,8 @@ fi
 if grep -Fq "$SWAP_FILE" /etc/fstab; then
   echo "Removing swapfile from /etc/fstab"
   sudo cp -a /etc/fstab "/etc/fstab.$(date +%Y%m%d%H%M%S).back"
-  sudo sed -i "\|$SWAP_FILE|d" /etc/fstab
-  sudo sed -i '/^# Btrfs swapfile for system hibernation$/d' /etc/fstab
+  sudo sed -i --follow-symlinks "\|$SWAP_FILE|d" /etc/fstab
+  sudo sed -i --follow-symlinks '/^# Btrfs swapfile for system hibernation$/d' /etc/fstab
 fi
 
 # Remove mkinitcpio resume hook

--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -66,7 +66,7 @@ if [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; 
     RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE" 2>/dev/null)
     if [[ -n $RESUME_OFFSET ]]; then
       echo "Fixing empty resume_offset ($RESUME_OFFSET)"
-      sudo sed -i "s/resume_offset=\"$/resume_offset=$RESUME_OFFSET\"/" "$RESUME_DROP_IN"
+      sudo sed -i --follow-symlinks "s/resume_offset=\"$/resume_offset=$RESUME_OFFSET\"/" "$RESUME_DROP_IN"
       if ! $NO_REBUILD; then
         sudo limine-mkinitcpio
       fi

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -100,12 +100,12 @@ set_scale() {
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.
   if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
-    sed -i -E \
+    sed -i --follow-symlinks -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
       "$monitor_lua"
   elif [[ -f $monitor_lua ]] && grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
-    sed -i -E \
+    sed -i --follow-symlinks -E \
       -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
       -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
       "$monitor_lua"

--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -35,13 +35,13 @@ install_php() {
   )
 
   # Enable Xdebug
-  sudo sed -i \
+  sudo sed -i --follow-symlinks \
     -e 's/^;zend_extension=xdebug.so/zend_extension=xdebug.so/' \
     -e 's/^;xdebug.mode=debug/xdebug.mode=debug/' \
     /etc/php/conf.d/xdebug.ini
 
   for ext in "${extensions_to_enable[@]}"; do
-    sudo sed -i "s/^;extension=${ext}/extension=${ext}/" "$php_ini_path"
+    sudo sed -i --follow-symlinks "s/^;extension=${ext}/extension=${ext}/" "$php_ini_path"
   done
 }
 

--- a/bin/omarchy-install-gaming-lutris
+++ b/bin/omarchy-install-gaming-lutris
@@ -11,7 +11,7 @@ omarchy-install-gaming-gpu-lib32
 
 # Lutris ships with `#!/usr/bin/env python3`, which resolves to mise's Python and
 # fails to import the lutris module. Pin the shebang to the system Python.
-sudo sed -i '/env python3/ c\#!/bin/python3' /usr/bin/lutris
+sudo sed -i --follow-symlinks '/env python3/ c\#!/bin/python3' /usr/bin/lutris
 
 cat <<'EOF'
 

--- a/bin/omarchy-install-gaming-retroarch
+++ b/bin/omarchy-install-gaming-retroarch
@@ -38,7 +38,7 @@ touch "$CFG"
 set_cfg() {
   local key=$1 value=$2
   if grep -q "^$key = " "$CFG"; then
-    sed -i "s|^$key = .*|$key = \"$value\"|" "$CFG"
+    sed -i --follow-symlinks "s|^$key = .*|$key = \"$value\"|" "$CFG"
   else
     echo "$key = \"$value\"" >>"$CFG"
   fi

--- a/bin/omarchy-plugin-clone
+++ b/bin/omarchy-plugin-clone
@@ -39,7 +39,7 @@ copy_plugin() {
     if [[ $source != "$target" ]]; then
       source_pattern=${source//./\\.}
       while IFS= read -r -d '' file; do
-        sed -i "s|$source_pattern|$target|g" "$file"
+        sed -i --follow-symlinks "s|$source_pattern|$target|g" "$file"
       done < <(rg --files-with-matches --null --fixed-strings "$source" "$target_dir")
     fi
   done < <(jq -r '

--- a/bin/omarchy-remove-security-fido2
+++ b/bin/omarchy-remove-security-fido2
@@ -10,13 +10,13 @@ remove_pam_config() {
   # Remove from sudo
   if grep -q pam_u2f.so /etc/pam.d/sudo; then
     echo "Removing FIDO2 authentication from sudo..."
-    sudo sed -i '/pam_u2f\.so/d' /etc/pam.d/sudo
+    sudo sed -i --follow-symlinks '/pam_u2f\.so/d' /etc/pam.d/sudo
   fi
 
   # Remove from polkit
   if [[ -f /etc/pam.d/polkit-1 ]] && grep -Fq 'pam_u2f.so' /etc/pam.d/polkit-1; then
     echo "Removing FIDO2 authentication from polkit..."
-    sudo sed -i '/pam_u2f\.so/d' /etc/pam.d/polkit-1
+    sudo sed -i --follow-symlinks '/pam_u2f\.so/d' /etc/pam.d/polkit-1
   fi
 }
 

--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -10,13 +10,13 @@ remove_pam_config() {
   # Remove from sudo (both the fingerprint module and its clamshell gate)
   if grep -Eq 'pam_fprintd\.so|omarchy-hw-laptop-closed' /etc/pam.d/sudo; then
     echo "Removing fingerprint authentication from sudo..."
-    sudo sed -i -e '/pam_fprintd\.so/d' -e '/omarchy-hw-laptop-closed/d' /etc/pam.d/sudo
+    sudo sed -i --follow-symlinks -e '/pam_fprintd\.so/d' -e '/omarchy-hw-laptop-closed/d' /etc/pam.d/sudo
   fi
 
   # Remove from polkit (both the fingerprint module and its clamshell gate)
   if [[ -f /etc/pam.d/polkit-1 ]] && grep -Eq 'pam_fprintd\.so|omarchy-hw-laptop-closed' /etc/pam.d/polkit-1; then
     echo "Removing fingerprint authentication from polkit..."
-    sudo sed -i -e '/pam_fprintd\.so/d' -e '/omarchy-hw-laptop-closed/d' /etc/pam.d/polkit-1
+    sudo sed -i --follow-symlinks -e '/pam_fprintd\.so/d' -e '/omarchy-hw-laptop-closed/d' /etc/pam.d/polkit-1
   fi
 }
 

--- a/bin/omarchy-remove-service-sunshine
+++ b/bin/omarchy-remove-service-sunshine
@@ -55,7 +55,7 @@ close_ufw_ports() {
 
 disable_hyprland_autostart() {
   if [[ -f $HYPR_AUTOSTART_FILE ]]; then
-    sed -i "\|^$HYPR_AUTOSTART_ENTRY$|d" "$HYPR_AUTOSTART_FILE"
+    sed -i --follow-symlinks "\|^$HYPR_AUTOSTART_ENTRY$|d" "$HYPR_AUTOSTART_FILE"
   fi
 }
 

--- a/bin/omarchy-restart-audio
+++ b/bin/omarchy-restart-audio
@@ -98,7 +98,7 @@ clear_usb_audio_defaults() {
 
   if [[ -f $state_dir/default-nodes ]]; then
     cp "$state_dir/default-nodes" "$state_dir/default-nodes.bak.$(date +%s)" 2>/dev/null || true
-    sed -i \
+    sed -i --follow-symlinks \
       -e '/^default\.configured\.audio\.sink=alsa_output\.usb-/d' \
       -e '/^default\.configured\.audio\.sink\.[0-9]\+=alsa_output\.usb-/d' \
       "$state_dir/default-nodes" 2>/dev/null || true
@@ -106,7 +106,7 @@ clear_usb_audio_defaults() {
 
   if [[ -f $state_dir/default-routes ]]; then
     cp "$state_dir/default-routes" "$state_dir/default-routes.bak.$(date +%s)" 2>/dev/null || true
-    sed -i '/^alsa_card\.usb-/d' "$state_dir/default-routes" 2>/dev/null || true
+    sed -i --follow-symlinks '/^alsa_card\.usb-/d' "$state_dir/default-routes" 2>/dev/null || true
   fi
 }
 

--- a/bin/omarchy-setup-security-fido2
+++ b/bin/omarchy-setup-security-fido2
@@ -20,13 +20,13 @@ setup_pam_config() {
   # Configure sudo
   if ! grep -q pam_u2f.so /etc/pam.d/sudo; then
     echo "Configuring sudo for FIDO2 authentication..."
-    sudo sed -i '1i auth    sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/sudo
+    sudo sed -i --follow-symlinks '1i auth    sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/sudo
   fi
 
   # Configure polkit
   if [[ -f /etc/pam.d/polkit-1 ]] && ! grep -q 'pam_u2f.so' /etc/pam.d/polkit-1; then
     echo "Configuring polkit for FIDO2 authentication..."
-    sudo sed -i '1i auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/polkit-1
+    sudo sed -i --follow-symlinks '1i auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/polkit-1
   elif [[ ! -f /etc/pam.d/polkit-1 ]]; then
     echo "Creating polkit configuration with FIDO2 authentication..."
     sudo tee /etc/pam.d/polkit-1 >/dev/null <<'EOF'

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -21,23 +21,23 @@ setup_pam_config() {
   # Configure sudo
   if ! grep -q pam_fprintd.so /etc/pam.d/sudo; then
     echo "Configuring sudo for fingerprint authentication..."
-    sudo sed -i '1i auth      sufficient pam_fprintd.so' /etc/pam.d/sudo
+    sudo sed -i --follow-symlinks '1i auth      sufficient pam_fprintd.so' /etc/pam.d/sudo
   fi
   if ! grep -q 'omarchy-hw-laptop-closed' /etc/pam.d/sudo; then
     echo "Adding clamshell gate to sudo..."
     # Insert immediately before pam_fprintd so success=1 skips exactly it.
-    sudo sed -i "/pam_fprintd\.so/i $fprintd_gate" /etc/pam.d/sudo
+    sudo sed -i --follow-symlinks "/pam_fprintd\.so/i $fprintd_gate" /etc/pam.d/sudo
   fi
 
   # Configure polkit
   if [[ -f /etc/pam.d/polkit-1 ]]; then
     if ! grep -q 'pam_fprintd.so' /etc/pam.d/polkit-1; then
       echo "Configuring polkit for fingerprint authentication..."
-      sudo sed -i '1i auth      sufficient pam_fprintd.so' /etc/pam.d/polkit-1
+      sudo sed -i --follow-symlinks '1i auth      sufficient pam_fprintd.so' /etc/pam.d/polkit-1
     fi
     if ! grep -q 'omarchy-hw-laptop-closed' /etc/pam.d/polkit-1; then
       echo "Adding clamshell gate to polkit..."
-      sudo sed -i "/pam_fprintd\.so/i $fprintd_gate" /etc/pam.d/polkit-1
+      sudo sed -i --follow-symlinks "/pam_fprintd\.so/i $fprintd_gate" /etc/pam.d/polkit-1
     fi
   else
     echo "Creating polkit configuration with fingerprint authentication..."

--- a/bin/omarchy-toggle-hybrid-gpu
+++ b/bin/omarchy-toggle-hybrid-gpu
@@ -70,7 +70,7 @@ case "$gpu_mode" in
 "Integrated")
   if gum confirm "Enable dedicated GPU and reboot?"; then
     # Switch to hybrid mode
-    sudo sed -i "s/\"mode\": \".*\"/\"mode\": \"Hybrid\"/" /etc/supergfxd.conf
+    sudo sed -i --follow-symlinks "s/\"mode\": \".*\"/\"mode\": \"Hybrid\"/" /etc/supergfxd.conf
 
     # Let hybrid mode be the default after system sleep
     sudo rm -rf /usr/lib/systemd/system-sleep/force-igpu

--- a/migrations/1780057136.sh
+++ b/migrations/1780057136.sh
@@ -11,12 +11,12 @@ ensure_alacritty_shift_return() {
   [[ -f $config ]] || return 0
 
   if grep -q 'key = "Return", mods = "Shift", chars = "\\u001B\\r"' "$config"; then
-    sed -i 's/{ key = "Return", mods = "Shift", chars = "\\u001B\\r" }/{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" }/' "$config"
+    sed -i --follow-symlinks 's/{ key = "Return", mods = "Shift", chars = "\\u001B\\r" }/{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" }/' "$config"
   elif ! grep -q 'key = "Return", mods = "Shift", chars = "\\u001B\[13;2u"' "$config"; then
     if grep -qxF '{ key = "Return", mods = "Alt|Shift", chars = "\u001B[13;4u" }' "$config"; then
-      sed -i '/^{ key = "Return", mods = "Alt|Shift", chars = "\\u001B\[13;4u" }$/i # Send Shift+Return as CSI-u so TUIs can distinguish it from Return without treating it as Alt+Return.\n{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" },' "$config"
+      sed -i --follow-symlinks '/^{ key = "Return", mods = "Alt|Shift", chars = "\\u001B\[13;4u" }$/i # Send Shift+Return as CSI-u so TUIs can distinguish it from Return without treating it as Alt+Return.\n{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" },' "$config"
     elif grep -qxF '{ key = "Insert", mods = "Control", action = "Copy" },' "$config"; then
-      sed -i '/^{ key = "Insert", mods = "Control", action = "Copy" },$/a # Send Shift+Return as CSI-u so TUIs can distinguish it from Return without treating it as Alt+Return.\n{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" },' "$config"
+      sed -i --follow-symlinks '/^{ key = "Insert", mods = "Control", action = "Copy" },$/a # Send Shift+Return as CSI-u so TUIs can distinguish it from Return without treating it as Alt+Return.\n{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" },' "$config"
     else
       printf '\n# Send Shift+Return as CSI-u so TUIs can distinguish it from Return without treating it as Alt+Return.\n{ key = "Return", mods = "Shift", chars = "\\u001B[13;2u" }\n' >>"$config"
     fi
@@ -35,10 +35,10 @@ ensure_ghostty_binding() {
   key_regex=$(printf '%s\n' "$key" | sed 's/[][\\.^$*+?{}|()\/]/\\&/g')
 
   if grep -Eq "^keybind = $key_regex=.*13;[24]u" "$config"; then
-    sed -i "s/^keybind = $key_regex=.*/keybind = $key=$binding/" "$config"
+    sed -i --follow-symlinks "s/^keybind = $key_regex=.*/keybind = $key=$binding/" "$config"
   elif ! grep -qF "keybind = $key=" "$config"; then
     if grep -qxF 'keybind = control+insert=copy_to_clipboard' "$config"; then
-      sed -i "/^keybind = control+insert=copy_to_clipboard$/a $comment\nkeybind = $key=$binding" "$config"
+      sed -i --follow-symlinks "/^keybind = control+insert=copy_to_clipboard$/a $comment\nkeybind = $key=$binding" "$config"
     else
       printf '\n%s\nkeybind = %s=%s\n' "$comment" "$key" "$binding" >>"$config"
     fi

--- a/migrations/1784401744.sh
+++ b/migrations/1784401744.sh
@@ -2,10 +2,10 @@ echo "Backfill hardware support and tmux settings added before Omarchy quattro"
 
 tmux_config="$HOME/.config/tmux/tmux.conf"
 if [[ -f $tmux_config ]]; then
-  sed -i 's/^set -g terminal-features\[3\] "xterm-kitty:extkeys"$/set -ag terminal-features "xterm-kitty:extkeys"/' "$tmux_config"
+  sed -i --follow-symlinks 's/^set -g terminal-features\[3\] "xterm-kitty:extkeys"$/set -ag terminal-features "xterm-kitty:extkeys"/' "$tmux_config"
 
   if ! grep -q 'M-S-Enter' "$tmux_config"; then
-    sed -i '/^# Pane Controls$/a\bind -n M-Enter split-window -v -c "#{pane_current_path}"\nbind -n M-S-Enter split-window -h -c "#{pane_current_path}"\nbind -n M-Escape kill-pane\n' "$tmux_config"
+    sed -i --follow-symlinks '/^# Pane Controls$/a\bind -n M-Enter split-window -v -c "#{pane_current_path}"\nbind -n M-S-Enter split-window -h -c "#{pane_current_path}"\nbind -n M-Escape kill-pane\n' "$tmux_config"
   fi
 
   omarchy-restart-tmux

--- a/migrations/1784476564.sh
+++ b/migrations/1784476564.sh
@@ -18,7 +18,7 @@ layout="${layout%%,*}"
 
 if [[ $layout =~ ^(af|am|ara|bd|bg|by|et|ge|gr|il|in|iq|ir|kg|kh|kz|la|lk|mk|mm|mn|mv|np|rs|ru|sy|th|tj|ua)$ ]] &&
   [[ -f $hooks_conf ]] && grep -qx 'FILES+=(/etc/vconsole.conf)' "$hooks_conf"; then
-  sudo sed -i '\|^FILES+=(/etc/vconsole.conf)$|d' "$hooks_conf"
+  sudo sed -i --follow-symlinks '\|^FILES+=(/etc/vconsole.conf)$|d' "$hooks_conf"
 
   if omarchy-cmd-present limine-mkinitcpio; then
     sudo limine-mkinitcpio

--- a/migrations/1784818437.sh
+++ b/migrations/1784818437.sh
@@ -18,6 +18,6 @@ for pam in /etc/pam.d/sudo /etc/pam.d/polkit-1; do
   if [[ -f $pam ]] &&
     grep -q 'pam_fprintd\.so' "$pam" &&
     ! grep -q 'omarchy-hw-laptop-closed' "$pam"; then
-    sudo sed -i "/pam_fprintd\.so/i $gate" "$pam"
+    sudo sed -i --follow-symlinks "/pam_fprintd\.so/i $gate" "$pam"
   fi
 done

--- a/migrations/1785273276.sh
+++ b/migrations/1785273276.sh
@@ -15,10 +15,10 @@ conf="${OMARCHY_T2_MKINITCPIO_CONF:-/etc/mkinitcpio.conf.d/apple-t2.conf}"
 modules_conf="${OMARCHY_T2_MODULES_CONF:-/etc/modules-load.d/t2.conf}"
 
 if [[ -f $conf ]] && grep -q 'apple-bce ' "$conf"; then
-  sudo sed -i 's/apple-bce /apple-bce? t2bce_vhci? /' "$conf"
+  sudo sed -i --follow-symlinks 's/apple-bce /apple-bce? t2bce_vhci? /' "$conf"
 
   if [[ -f $modules_conf ]]; then
-    sudo sed -i 's/^apple-bce$/t2bce_vhci/' "$modules_conf"
+    sudo sed -i --follow-symlinks 's/^apple-bce$/t2bce_vhci/' "$modules_conf"
   fi
 
   # Rebuild what the failed hook skipped so the ESP matches the installed kernel.

--- a/migrations/1785944594.sh
+++ b/migrations/1785944594.sh
@@ -11,7 +11,7 @@ repair_marker="${OMARCHY_T2_REPAIR_MARKER:-/var/lib/omarchy/migrations/178594459
 needs_limine_rebuild=0
 
 if [[ -f $limine_conf ]] && grep -q 'pcie_ports=compat' "$limine_conf"; then
-  sudo sed -i \
+  sudo sed -i --follow-symlinks \
     's/pcie_ports=compat/pm_async=off mem_sleep_default=deep/' \
     "$limine_conf"
   needs_limine_rebuild=1

--- a/migrations/1786380259.sh
+++ b/migrations/1786380259.sh
@@ -30,7 +30,7 @@ fi
 # powering the adapter up when the block above is lifted. Only the exact line
 # Omarchy wrote is reverted, so a hand-edited opt-out survives.
 if [[ -f $main_conf ]]; then
-  sudo sed -i 's/^AutoEnable=false$/#AutoEnable=true/' "$main_conf"
+  sudo sed -i --follow-symlinks 's/^AutoEnable=false$/#AutoEnable=true/' "$main_conf"
 fi
 
 sudo install -Dm644 /dev/null "$marker"

--- a/migrations/1786782461.sh
+++ b/migrations/1786782461.sh
@@ -14,5 +14,5 @@ echo "Remove the literal \\n[text-bindings] line an earlier migration wrote into
 foot_config="$HOME/.config/foot/foot.ini"
 
 if [[ -f $foot_config ]] && grep -qxF '\n[text-bindings]' "$foot_config"; then
-  sed -i '/^\\n\[text-bindings\]$/d' "$foot_config"
+  sed -i --follow-symlinks '/^\\n\[text-bindings\]$/d' "$foot_config"
 fi

--- a/test/shell.d/sed-follow-symlinks-test.sh
+++ b/test/shell.d/sed-follow-symlinks-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+# sed -i without --follow-symlinks replaces symlinks with regular files,
+# breaking dotfile setups that symlink configs from a version-controlled
+# repository. Always use sed -i --follow-symlinks — it is critical for
+# user files and harmless everywhere else.
+#
+# Allowlisted files operate on temporary/staging directories where
+# symlink preservation is irrelevant.
+
+ALLOWLIST=(
+  bin/omarchy-dev-pkg-test
+  bin/omarchy-plymouth-set
+  bin/omarchy-upgrade-to-quattro
+)
+
+violations=()
+
+is_allowlisted() {
+  local rel="${1#$ROOT/}"
+  local entry
+  for entry in "${ALLOWLIST[@]}"; do
+    [[ $rel == "$entry" ]] && return 0
+  done
+  return 1
+}
+
+while IFS=: read -r file lineno line; do
+  local_line="${line#"${line%%[![:space:]]*}"}"
+  [[ $local_line == \#* ]] && continue
+  is_allowlisted "$file" && continue
+  violations+=("${file#$ROOT/}:$lineno")
+done < <(grep -rEn 'sed[[:space:]]+-i([[:space:]]|$)' "$ROOT/bin" "$ROOT/migrations" | grep -v -- '--follow-symlinks' || true)
+
+if (( ${#violations[@]} > 0 )); then
+  printf 'Found sed -i without --follow-symlinks on user-space files:\n' >&2
+  printf '  %s\n' "${violations[@]}" >&2
+  fail "all sed -i calls on user files use --follow-symlinks"
+fi
+
+pass "all sed -i calls on user files use --follow-symlinks"


### PR DESCRIPTION
Without --follow-symlinks, GNU sed writes a temp file and renames it over the target, replacing any symlink with a regular file. This silently breaks dotfile setups that symlink configs from a version-controlled repository (GNU Stow, chezmoi, yadm, etc.).

Every sed -i call across bin/ and migrations/ now includes --follow-symlinks. The flag is harmless on regular files and critical on symlinks, so there is no reason to omit it.

An architectural test (test/shell.d/sed-follow-symlinks-test.sh) enforces the rule in CI — any new bare sed -i in bin/ or migrations/ will fail the build. Agent instructions in AGENTS.md and agents/skills/migrations.md are updated with the guidance.


Thanks!