### PR TITLE
Disable Chromium WaylandPerSurfaceScale on mixed-scale Hyprland

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -2,4 +2,5 @@
 --ozone-platform-hint=wayland
 --password-store=gnome-libsecret
 --enable-features=TouchpadOverscrollHistoryNavigation
+--disable-features=WaylandPerSurfaceScale
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp,/usr/share/omarchy/default/chromium/extensions/whatsapp-slim

--- a/test/shell.d/chromium-flags-test.sh
+++ b/test/shell.d/chromium-flags-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# The packaged flags file is what `omarchy refresh` / first-run copy to
+# ~/.config/chromium-flags.conf (and what the Brave Origin migration copies).
+# WaylandPerSurfaceScale makes Chromium report the scale of a sibling
+# output (e.g. eDP at 2) on a scale-1 HDMI window, so sites like x.com
+# layout at ~half width and their virtual lists jump on scroll.
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+flags="$ROOT/config/chromium-flags.conf"
+
+[[ -f $flags ]] || fail "packaged chromium-flags.conf exists" "missing: $flags"
+pass "packaged chromium-flags.conf exists"
+
+grep -qx -- '--disable-features=WaylandPerSurfaceScale' "$flags" ||
+  fail "packaged flags disable WaylandPerSurfaceScale" "$(cat "$flags")"
+pass "packaged flags disable WaylandPerSurfaceScale"
+
+grep -qx -- '--ozone-platform=wayland' "$flags" ||
+  fail "packaged flags keep ozone wayland" "$(cat "$flags")"
+pass "packaged flags keep ozone wayland"
+
+grep -q -- 'WaylandLinuxDrmSyncobj\|force-device-scale-factor\|disable-gpu-compositing' "$flags" &&
+  fail "packaged flags stay free of discarded GPU/scale workarounds" "$(cat "$flags")"
+pass "packaged flags stay free of discarded GPU/scale workarounds"


### PR DESCRIPTION
## Why

On Hyprland laptops with mixed **integer** scales (eDP scale 2 + HDMI scale 1), Chromium's `WaylandPerSurfaceScale` reports the laptop scale on the HDMI window. Sites like x.com then layout at ~960 CSS px (collapsed nav, large empty gutter) and their virtualized timeline **jumps back to the top** while scrolling.

This is not Hyprland `debug:damage_tracking` and not missing `WaylandLinuxDrmSyncobj`. Those were tried on Omarchy 4 / Hyprland 0.56.2 / Chromium 151 (Intel UHD + NVIDIA-wired HDMI); they do not change the reported viewport.

`--disable-features=WaylandPerSurfaceScale` in `chromium-flags.conf` fixes tabbed Chromium.

See https://github.com/hyprwm/Hyprland/discussions/11627

Related follow-up (separate PR): the X **webapp** (`--app=https://x.com/`) still needs extra flags; those must not go in this file (`force-device-scale-factor=1` blacks out tabbed Chromium).

## Change

Add `--disable-features=WaylandPerSurfaceScale` to packaged `config/chromium-flags.conf`.

Existing installs that already have a user flags file need the same line added (or a follow-up migration).

## Risk

This is a global Chromium flag. Fractional-scale-only setups may want per-surface scale; review if this should be conditional later.

## Test

`test/shell.d/chromium-flags-test.sh` reads the shipped flags file and asserts the disable line is present (fails if it is removed).