### PR TITLE
X webapp: inject hybrid-safe Chromium flags in the launcher

### DIFF
--- a/applications/X.desktop
+++ b/applications/X.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=X
-Exec=omarchy-launch-webapp https://x.com/
+Exec=omarchy-launch-webapp https://x.com/ --force-device-scale-factor=1 --disable-accelerated-video-decode
 Terminal=false
 Type=Application
 Icon=x

--- a/applications/X.desktop
+++ b/applications/X.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=X
-Exec=omarchy-launch-webapp https://x.com/ --force-device-scale-factor=1 --disable-accelerated-video-decode
+Exec=omarchy-launch-webapp https://x.com/
 Terminal=false
 Type=Application
 Icon=x

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -10,4 +10,27 @@ google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+# Super+Shift+X (and compose/post) call this script with only the URL.
+# Chromium --app skips chromium-flags.conf, so hybrid Intel+NVIDIA
+# machines with mixed monitor scales need these flags here: --app
+# otherwise inherits the eDP scale on HDMI, VA-API points at NVIDIA
+# while the GPU process renders on Intel, and dma-buf overlays play
+# audio with a black frame. Do not add force-device-scale-factor to
+# chromium-flags.conf — it blacks out tabbed Chromium.
+url=$1
+extra=()
+host=${url#*://}
+host=${host%%/*}
+host=${host%%:*}
+host=${host#www.}
+case $host in
+x.com | twitter.com | *.x.com | *.twitter.com)
+  extra=(
+    --force-device-scale-factor=1
+    --disable-accelerated-video-decode
+    --disable-gpu-memory-buffer-video-frames
+  )
+  ;;
+esac
+
+exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${extra[@]}" "${@:2}"

--- a/test/shell.d/x-webapp-flags-test.sh
+++ b/test/shell.d/x-webapp-flags-test.sh
@@ -1,32 +1,114 @@
 #!/bin/bash
 
-# The packaged X webapp is what users launch for x.com. On hybrid
-# Intel+NVIDIA laptops with mixed monitor scales, Chromium --app
-# reports the eDP scale on HDMI and VA-API points at NVIDIA while
-# the GPU process renders on Intel: videos stay on the poster.
-# These flags are webapp-only; they must not go in chromium-flags.conf
+# Super+Shift+X and the packaged X.desktop both call
+# omarchy-launch-webapp with only the URL. Hybrid Intel+NVIDIA
+# laptops with mixed monitor scales need extra Chromium --app
+# flags injected there — not in chromium-flags.conf
 # (force-device-scale-factor=1 blacks out tabbed Chromium).
 
 source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 desktop="$ROOT/applications/X.desktop"
 flags="$ROOT/config/chromium-flags.conf"
+launcher="$ROOT/bin/omarchy-launch-webapp"
+bindings="$ROOT/default/hypr/bindings/applications.lua"
 
 [[ -f $desktop ]] || fail "packaged X.desktop exists" "missing: $desktop"
 pass "packaged X.desktop exists"
 
-grep -E '^Exec=omarchy-launch-webapp https://x.com/' "$desktop" | grep -q -- '--force-device-scale-factor=1' ||
-  fail "X webapp forces CSS scale 1" "$(grep '^Exec=' "$desktop")"
-pass "X webapp forces CSS scale 1"
+grep -E '^Exec=omarchy-launch-webapp https://x.com/' "$desktop" >/dev/null ||
+  fail "X.desktop launches through omarchy-launch-webapp" "$(grep '^Exec=' "$desktop")"
+pass "X.desktop launches through omarchy-launch-webapp"
 
-grep -E '^Exec=omarchy-launch-webapp https://x.com/' "$desktop" | grep -q -- '--disable-accelerated-video-decode' ||
-  fail "X webapp disables broken VAAPI decode" "$(grep '^Exec=' "$desktop")"
-pass "X webapp disables broken VAAPI decode"
+grep -q 'webapp = "https://x.com/"' "$bindings" ||
+  fail "Super+Shift+X launches https://x.com/ through omarchy-launch-webapp" "$(grep -n 'SHIFT + X' "$bindings")"
+pass "Super+Shift+X launches https://x.com/ through omarchy-launch-webapp"
 
 if [[ -f $flags ]]; then
   grep -q -- 'force-device-scale-factor' "$flags" &&
     fail "global chromium-flags.conf stays free of force-device-scale-factor" "$(cat "$flags")"
   grep -q -- 'disable-accelerated-video-decode' "$flags" &&
     fail "global chromium-flags.conf stays free of disable-accelerated-video-decode" "$(cat "$flags")"
+  grep -q -- 'disable-gpu-memory-buffer-video-frames' "$flags" &&
+    fail "global chromium-flags.conf stays free of disable-gpu-memory-buffer-video-frames" "$(cat "$flags")"
   pass "global chromium-flags.conf stays free of X-only flags"
 fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications"
+
+cat >"$test_home/.local/share/applications/chromium.desktop" <<'EOF'
+[Desktop Entry]
+Exec=chromium %U
+EOF
+
+cat >"$mock_bin/xdg-settings" <<'EOF'
+#!/bin/bash
+echo chromium.desktop
+EOF
+
+cat >"$mock_bin/setsid" <<'EOF'
+#!/bin/bash
+exec "$@"
+EOF
+
+cat >"$mock_bin/uwsm-app" <<'EOF'
+#!/bin/bash
+[[ $1 == -- ]] && shift
+printf '%s\n' "$@"
+EOF
+
+chmod +x "$mock_bin"/*
+
+run_launch() {
+  HOME="$test_home" PATH="$mock_bin:$PATH" bash "$launcher" "$@"
+}
+
+assert_has_flag() {
+  local out=$1
+  local flag=$2
+  local label=$3
+
+  printf '%s\n' "$out" | grep -Fxq -- "$flag" ||
+    fail "$label" "$out"
+}
+
+assert_missing_flag() {
+  local out=$1
+  local flag=$2
+  local label=$3
+
+  printf '%s\n' "$out" | grep -Fxq -- "$flag" &&
+    fail "$label" "$out"
+}
+
+x_out=$(run_launch "https://x.com/")
+[[ $x_out == *$'\n'--app=https://x.com/$'\n'* ]] ||
+  fail "x.com launch keeps --app URL" "$x_out"
+assert_has_flag "$x_out" "--force-device-scale-factor=1" "x.com launch forces CSS scale 1"
+assert_has_flag "$x_out" "--disable-accelerated-video-decode" "x.com launch disables broken VAAPI decode"
+assert_has_flag "$x_out" "--disable-gpu-memory-buffer-video-frames" "x.com launch disables dma-buf video overlay"
+pass "x.com launch injects hybrid-safe Chromium flags"
+
+compose_out=$(run_launch "https://x.com/compose/post")
+assert_has_flag "$compose_out" "--force-device-scale-factor=1" "compose/post launch forces CSS scale 1"
+pass "x.com/compose/post launch injects the same flags"
+
+twitter_out=$(run_launch "https://twitter.com/")
+assert_has_flag "$twitter_out" "--disable-accelerated-video-decode" "twitter.com launch disables broken VAAPI decode"
+pass "twitter.com launch injects the same flags"
+
+yt_out=$(run_launch "https://youtube.com/")
+assert_missing_flag "$yt_out" "--force-device-scale-factor=1" "YouTube launch must not force CSS scale 1"
+assert_missing_flag "$yt_out" "--disable-accelerated-video-decode" "YouTube launch must not disable VAAPI"
+assert_missing_flag "$yt_out" "--disable-gpu-memory-buffer-video-frames" "YouTube launch must not disable dma-buf frames"
+pass "other webapps do not get the X-only flags"
+
+passthru_out=$(run_launch "https://x.com/" --user-data-dir=/tmp/x-profile)
+assert_has_flag "$passthru_out" "--user-data-dir=/tmp/x-profile" "extra args still pass through"
+assert_has_flag "$passthru_out" "--force-device-scale-factor=1" "injected flags still present with extra args"
+pass "extra args still pass through after injected flags"

--- a/test/shell.d/x-webapp-flags-test.sh
+++ b/test/shell.d/x-webapp-flags-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# The packaged X webapp is what users launch for x.com. On hybrid
+# Intel+NVIDIA laptops with mixed monitor scales, Chromium --app
+# reports the eDP scale on HDMI and VA-API points at NVIDIA while
+# the GPU process renders on Intel: videos stay on the poster.
+# These flags are webapp-only; they must not go in chromium-flags.conf
+# (force-device-scale-factor=1 blacks out tabbed Chromium).
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+desktop="$ROOT/applications/X.desktop"
+flags="$ROOT/config/chromium-flags.conf"
+
+[[ -f $desktop ]] || fail "packaged X.desktop exists" "missing: $desktop"
+pass "packaged X.desktop exists"
+
+grep -E '^Exec=omarchy-launch-webapp https://x.com/' "$desktop" | grep -q -- '--force-device-scale-factor=1' ||
+  fail "X webapp forces CSS scale 1" "$(grep '^Exec=' "$desktop")"
+pass "X webapp forces CSS scale 1"
+
+grep -E '^Exec=omarchy-launch-webapp https://x.com/' "$desktop" | grep -q -- '--disable-accelerated-video-decode' ||
+  fail "X webapp disables broken VAAPI decode" "$(grep '^Exec=' "$desktop")"
+pass "X webapp disables broken VAAPI decode"
+
+if [[ -f $flags ]]; then
+  grep -q -- 'force-device-scale-factor' "$flags" &&
+    fail "global chromium-flags.conf stays free of force-device-scale-factor" "$(cat "$flags")"
+  grep -q -- 'disable-accelerated-video-decode' "$flags" &&
+    fail "global chromium-flags.conf stays free of disable-accelerated-video-decode" "$(cat "$flags")"
+  pass "global chromium-flags.conf stays free of X-only flags"
+fi


### PR DESCRIPTION
## Why

The packaged X webapp still misbehaves on hybrid Intel+NVIDIA laptops with mixed monitor scales, even with `WaylandPerSurfaceScale` disabled in `chromium-flags.conf`:

1. `--app` Chromium still reports the eDP scale (2) on an HDMI window at scale 1, so x.com layouts as a narrow viewport.
2. The GPU process renders on Intel (`renderD129`) while the session has `LIBVA_DRIVER_NAME=nvidia`. In-feed videos stay on the poster: click play, the timestamp never advances.
3. After software decode, dma-buf video overlays play **audio with a black frame** unless `--disable-gpu-memory-buffer-video-frames` is set.

Putting those flags only on `applications/X.desktop` is not enough. Super+Shift+X (and Super+Shift+Alt+X compose/post) call `omarchy-launch-webapp https://x.com/…` with **just the URL** — they never read the desktop file.

These flags must **not** go in `config/chromium-flags.conf`. `force-device-scale-factor=1` globally left tabbed Chromium as a black window.

Companion: WaylandPerSurfaceScale for tabbed Chromium (separate PR).

## Change

`omarchy-launch-webapp` injects, only when the URL host is `x.com` / `twitter.com`:

```
--force-device-scale-factor=1
--disable-accelerated-video-decode
--disable-gpu-memory-buffer-video-frames
```

That covers Super+Shift+X, compose/post, and the `.desktop` menu entry. Other webapps are unchanged.

## Test

`test/shell.d/x-webapp-flags-test.sh` mock-runs the launcher (fake `xdg-settings` / `uwsm-app`) and asserts:

- x.com, compose/post, and twitter.com get all three flags
- youtube.com does not
- extra args still pass through
- `chromium-flags.conf` stays free of the X-only flags