### PR TITLE
Warn about shrinking partitions during install

### DIFF
--- a/manual/50-dual-boot-install.md
+++ b/manual/50-dual-boot-install.md
@@ -26,6 +26,8 @@ When you're finished, you should see something like this where the 50GB section 
 
 The install process for Omarchy is effectively the same as normal. After you select your disk, you'll be given the option of **Free space install**. Select that option to prevent wiping the full disk.
 
+> **Warning:** Only use **Free space install** when the disk already contains unallocated space. If the installer offers to shrink an existing partition, do not continue unless you have a verified backup and have first resized the filesystem using a tool that supports that filesystem. Shrinking the partition alone can corrupt the existing filesystem and cause data loss.
+
  ![dual-boot-5](images/dual-boot-5.webp)
 
 Confirm that everything looks good and wait for the install to finish like normal. This is also where you could elect to install unencrypted (not recommended) just like on a full-drive install.


### PR DESCRIPTION
Adds a prominent warning to the dual-boot installation guide for the Free space install path.

The warning clarifies that:
- Free space install should be used with already-unallocated space.
- Shrinking an existing partition is destructive unless the filesystem is resized with a filesystem-aware tool first.
- Partition-only shrinking can corrupt the existing filesystem and cause data loss.

Related discussion: https://github.com/basecamp/omarchy/discussions/7262

Validation:
- git diff --check