### PR TITLE
Give empty menu file searches real feedback instead of a usage error

### DIFF
--- a/bin/omarchy-games-retro-install
+++ b/bin/omarchy-games-retro-install
@@ -19,7 +19,14 @@ if (( $# == 0 )); then
   core="${core##*(}"
   core="${core%)}"
 
-  game_path=$(omarchy-menu-file "Retro game" "$HOME/Games/roms" "7z bin ccd chd cue dmg elf fds gb gba gbc iso lha m3u md n64 nds nes pbp sfc smc swc zip z64") || exit 0
+  game_status=0
+  game_path=$(omarchy-menu-file "Retro game" "$HOME/Games/roms" "7z bin ccd chd cue dmg elf fds gb gba gbc iso lha m3u md n64 nds nes pbp sfc smc swc zip z64") || game_status=$?
+
+  if (( game_status == 2 )); then
+    omarchy-notification-send -g 󰯉 "No retro games found" "$HOME/Games/roms"
+    exit 1
+  fi
+
   [[ -n $game_path ]] || exit 0
 elif (( $# == 2 )); then
   core="$1"

--- a/bin/omarchy-menu-file
+++ b/bin/omarchy-menu-file
@@ -44,5 +44,11 @@ for format in "${formats[@]}"; do
 done
 find_args+=(")" -printf '%T@\t%p\n')
 
-find "${find_args[@]}" 2>/dev/null | sort -rn | cut -f2- |
-  omarchy-menu-select "$label" -- --width 800 --maxheight 500 "$@"
+files=$(find "${find_args[@]}" 2>/dev/null | sort -rn | cut -f2-)
+
+if [[ -z $files ]]; then
+  echo "No matching files under ${paths_arg//:/ }" >&2
+  exit 2
+fi
+
+omarchy-menu-select "$label" -- --width 800 --maxheight 500 "$@" <<<"$files"

--- a/bin/omarchy-menu-select
+++ b/bin/omarchy-menu-select
@@ -11,6 +11,9 @@
 # menu shows the glyph but never returns it. A plain option returns the label
 # alone; an option with a subtext returns "<label><TAB><subtext>", so callers
 # with same-named rows get the subtext back as the stable key.
+#
+# An empty option list piped on stdin exits 2 with no menu and no output, so
+# pipe-callers can tell "nothing to offer" apart from a usage mistake.
 
 set -euo pipefail
 
@@ -60,6 +63,12 @@ done
 
 if (( ${#options[@]} == 0 )) && [[ ! -t 0 ]]; then
   mapfile -t options
+
+  # An empty piped list is the caller's "nothing to offer", not a usage
+  # mistake; exit distinctly and quietly so callers can report it themselves.
+  if (( ${#options[@]} == 0 )); then
+    exit 2
+  fi
 fi
 
 if (( ${#options[@]} == 0 )); then

--- a/bin/omarchy-transcode
+++ b/bin/omarchy-transcode
@@ -130,7 +130,7 @@ copy_to_clipboard() {
 
 main() {
   local input="" format="" resolution="" search_path=""
-  local type output positional=()
+  local type output positional=() menu_status=0
 
   while (( $# > 0 )); do
     case "$1" in
@@ -166,7 +166,14 @@ main() {
   search_path="${search_path:-$HOME/Pictures:$HOME/Videos}"
 
   if [[ -z $input ]]; then
-    input=$(omarchy-menu-file "Transcode picture or video" "$search_path" "jpg jpeg png webp gif heic avif mp4 mov m4v mkv webm avi")
+    input=$(omarchy-menu-file "Transcode picture or video" "$search_path" "jpg jpeg png webp gif heic avif mp4 mov m4v mkv webm avi") || menu_status=$?
+
+    # The menu entry has no terminal, so an empty search needs a notification
+    # rather than the stderr line omarchy-menu-file already printed.
+    if (( menu_status == 2 )); then
+      omarchy-notification-send -g  "Nothing to transcode" "No pictures or videos under ${search_path//:/ }"
+      return 1
+    fi
   fi
 
   [[ -n $input ]] || return 1

--- a/test/cli
+++ b/test/cli
@@ -807,3 +807,42 @@ assert_output_contains "a --help behind -- belongs to the command and still forw
 
 output=$("$TMPDIR/omarchy" parenthelp --helpme x--help)
 assert_output_contains "help lookalike tokens do not trigger help" "$output" "parenthelp-parent-ran args=[--helpme x--help]"
+
+# An empty option list piped into menu-select is the caller's "nothing to
+# offer", not a usage mistake: it must exit 2 quietly instead of leaking the
+# usage string, and callers must report what came up empty.
+status=0
+output=$(printf '' | "$ROOT/bin/omarchy-menu-select" "Pick" 2>&1) || status=$?
+(( status == 2 )) || fail "menu-select exits 2 on an empty piped option list (got $status)"
+[[ -z $output ]] || fail "menu-select is quiet on an empty piped option list"
+pass "menu-select exits 2 quietly on an empty piped option list"
+
+status=0
+output=$("$ROOT/bin/omarchy-menu-select" </dev/null 2>&1) || status=$?
+(( status == 1 )) || fail "menu-select without a prompt exits 1 (got $status)"
+assert_output_contains "menu-select without a prompt still prints usage" "$output" "Usage: omarchy-menu-select"
+
+make_tmpdir EMPTY_MEDIA_TMPDIR
+status=0
+output=$("$ROOT/bin/omarchy-menu-file" "Pick media" "$EMPTY_MEDIA_TMPDIR" "jpg png" 2>&1) || status=$?
+(( status == 2 )) || fail "menu-file exits 2 when no files match (got $status)"
+assert_output_contains "menu-file reports an empty search instead of usage" "$output" "No matching files"
+
+make_tmpdir NOTIFY_TMPDIR
+NOTIFY_FAKE_BIN="$NOTIFY_TMPDIR/fake-bin"
+mkdir -p "$NOTIFY_FAKE_BIN"
+
+cat >"$NOTIFY_FAKE_BIN/omarchy-notification-send" <<'EOF'
+#!/bin/bash
+echo "$*" >>"${NOTIFY_LOG:-/dev/null}"
+EOF
+chmod +x "$NOTIFY_FAKE_BIN/omarchy-notification-send"
+
+status=0
+output=$(NOTIFY_LOG="$NOTIFY_TMPDIR/notify.log" PATH="$NOTIFY_FAKE_BIN:$PATH" "$ROOT/bin/omarchy-transcode" --path "$EMPTY_MEDIA_TMPDIR" 2>&1) || status=$?
+(( status == 1 )) || fail "transcode exits 1 when nothing matches (got $status)"
+grep -q "Nothing to transcode" "$NOTIFY_TMPDIR/notify.log" || fail "transcode notifies when nothing matches"
+if [[ $output == *"Usage: omarchy-menu-select"* ]]; then
+  fail "transcode does not leak the menu-select usage string"
+fi
+pass "transcode notifies instead of leaking usage when nothing matches"


### PR DESCRIPTION
Fixes #7114.

Picking Transcode from the menu with empty `~/Pictures` and `~/Videos` was a silent no-op, and running `omarchy transcode` from a terminal printed an internal usage string for a command the user never typed. `omarchy-menu-select` couldn't tell an empty option list piped on stdin apart from a caller passing no options at all, so it treated both as a usage mistake.

- `omarchy-menu-select`: an empty piped list now exits 2 with no output — it's the caller's "nothing to offer", not a usage error. Argument errors keep the usage string and exit 1, and cancelling a menu still exits 1, so existing callers are unaffected. This also stops the usage leak for the other pipe-callers (`omarchy-menu-plugin`, `omarchy-menu-timezone`, `omarchy-menu-keybindings`).
- `omarchy-menu-file`: an empty `find` result reports `No matching files under <paths>` on stderr and exits 2 instead of summoning the menu.
- `omarchy-transcode`: on an empty search it sends a "Nothing to transcode" notification (the menu's `trigger.transcode` has no terminal, so a notification is the only feedback channel) and exits 1.
- `omarchy-games-retro-install`: an empty `~/Games/roms` now mirrors the script's existing "No RetroArch cores found" notification instead of exiting silently.

Regression tests in `test/cli` cover the quiet exit-2, the preserved usage error, the menu-file message, and an end-to-end transcode run with a stubbed `omarchy-notification-send`. Full `./test/cli` passes, and the populated-search path was verified end-to-end against a stubbed `omarchy-shell` summon.