### PR TITLE
Install patched PTL kernel on ASUS ExpertBook B9406

### DIFF
--- a/install/hardware/intel/ptl-kernel.sh
+++ b/install/hardware/intel/ptl-kernel.sh
@@ -1,8 +1,9 @@
-# Install Panther Lake kernel for Dell XPS Panther Lake systems
-# The linux-ptl kernel includes audio driver patches not yet in mainline.
+# Install the patched Panther Lake kernel on systems that still need it.
+# Dell XPS models need the display patches. The ASUS ExpertBook B9406 needs
+# the SoundWire quirk that ignores its firmware's phantom RT722 codec.
 
-if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
-  echo "Detected Dell XPS Panther Lake, installing PTL kernel..."
+if { omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; } || omarchy-hw-asus-expertbook-b9406; then
+  echo "Detected hardware requiring the patched Panther Lake kernel..."
 
   omarchy-pkg-add linux-ptl linux-ptl-headers
   pacman -Rdd --noconfirm linux linux-headers || true
@@ -14,12 +15,15 @@ if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
     pacman -Qi linux | grep -i "required by"
   fi
 
-  mkdir -p /etc/limine-entry-tool.d
+  boot_order_conf="${OMARCHY_PTL_BOOT_ORDER_CONF:-/etc/limine-entry-tool.d/zz-panther-lake-kernel.conf}"
+  old_boot_order_conf="${OMARCHY_PTL_OLD_BOOT_ORDER_CONF:-/etc/limine-entry-tool.d/dell-xps-panther-lake.conf}"
+  legacy_boot_order_conf="${OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF:-/etc/limine-entry-tool.d/zz-dell-xps-panther-lake.conf}"
+  mkdir -p "$(dirname "$boot_order_conf")"
   # Named to sort after omarchy-defaults.conf: drop-ins are read in order and
   # the last BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.
-  rm -f /etc/limine-entry-tool.d/dell-xps-panther-lake.conf
-  cat > /etc/limine-entry-tool.d/zz-dell-xps-panther-lake.conf <<'EOF'
-# Only show Panther Lake kernel in boot menu on Dell XPS Panther Lake
+  rm -f "$old_boot_order_conf" "$legacy_boot_order_conf"
+  cat > "$boot_order_conf" <<'EOF'
+# Prefer Omarchy's patched kernel on supported Panther Lake systems
 BOOT_ORDER="linux-ptl*, *fallback, Snapshots"
 EOF
 fi

--- a/install/hardware/intel/ptl-kernel.sh
+++ b/install/hardware/intel/ptl-kernel.sh
@@ -2,7 +2,14 @@
 # Dell XPS models need the display patches. The ASUS ExpertBook B9406 needs
 # the SoundWire quirk that ignores its firmware's phantom RT722 codec.
 
-if { omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; } || omarchy-hw-asus-expertbook-b9406; then
+needs_ptl_kernel=false
+if omarchy-hw-asus-expertbook-b9406; then
+  needs_ptl_kernel=true
+elif omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
+  needs_ptl_kernel=true
+fi
+
+if [[ $needs_ptl_kernel == "true" ]]; then
   echo "Detected hardware requiring the patched Panther Lake kernel..."
 
   omarchy-pkg-add linux-ptl linux-ptl-headers
@@ -15,9 +22,15 @@ if { omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; } || omarchy-hw-asus-expert
     pacman -Qi linux | grep -i "required by"
   fi
 
-  boot_order_conf="${OMARCHY_PTL_BOOT_ORDER_CONF:-/etc/limine-entry-tool.d/zz-panther-lake-kernel.conf}"
-  old_boot_order_conf="${OMARCHY_PTL_OLD_BOOT_ORDER_CONF:-/etc/limine-entry-tool.d/dell-xps-panther-lake.conf}"
-  legacy_boot_order_conf="${OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF:-/etc/limine-entry-tool.d/zz-dell-xps-panther-lake.conf}"
+  if [[ ${OMARCHY_TESTING:-0} == "1" ]] && (( EUID != 0 )); then
+    boot_order_conf="${OMARCHY_PTL_BOOT_ORDER_CONF:?missing test boot-order path}"
+    old_boot_order_conf="${OMARCHY_PTL_OLD_BOOT_ORDER_CONF:?missing test old boot-order path}"
+    legacy_boot_order_conf="${OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF:?missing test legacy boot-order path}"
+  else
+    boot_order_conf="/etc/limine-entry-tool.d/zz-panther-lake-kernel.conf"
+    old_boot_order_conf="/etc/limine-entry-tool.d/dell-xps-panther-lake.conf"
+    legacy_boot_order_conf="/etc/limine-entry-tool.d/zz-dell-xps-panther-lake.conf"
+  fi
   mkdir -p "$(dirname "$boot_order_conf")"
   # Named to sort after omarchy-defaults.conf: drop-ins are read in order and
   # the last BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.

--- a/install/hardware/intel/ptl-kernel.sh
+++ b/install/hardware/intel/ptl-kernel.sh
@@ -22,7 +22,7 @@ if [[ $needs_ptl_kernel == "true" ]]; then
     pacman -Qi linux | grep -i "required by"
   fi
 
-  if [[ ${OMARCHY_TESTING:-0} == "1" ]] && (( EUID != 0 )); then
+  if [[ ${OMARCHY_TESTING:-0} == "1" ]]; then
     boot_order_conf="${OMARCHY_PTL_BOOT_ORDER_CONF:?missing test boot-order path}"
     old_boot_order_conf="${OMARCHY_PTL_OLD_BOOT_ORDER_CONF:?missing test old boot-order path}"
     legacy_boot_order_conf="${OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF:?missing test legacy boot-order path}"

--- a/migrations/1786961462.sh
+++ b/migrations/1786961462.sh
@@ -1,0 +1,8 @@
+echo "Install the audio-capable kernel on ASUS ExpertBook B9406 systems"
+
+omarchy-hw-asus-expertbook-b9406 || exit 0
+
+sudo env OMARCHY_PATH="$OMARCHY_PATH" PATH="$OMARCHY_PATH/bin:$PATH" \
+  bash -euo pipefail "$OMARCHY_PATH/install/hardware/intel/ptl-kernel.sh"
+
+omarchy-state set reboot-required

--- a/test/shell.d/ptl-kernel-test.sh
+++ b/test/shell.d/ptl-kernel-test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/intel/ptl-kernel.sh"
+migration="$ROOT/migrations/1786961462.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+boot_order_conf="$test_tmp/zz-panther-lake-kernel.conf"
+old_boot_order_conf="$test_tmp/dell-xps-panther-lake.conf"
+legacy_boot_order_conf="$test_tmp/zz-dell-xps-panther-lake.conf"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+
+[[ $1 == "XPS" ]] && (( ${XPS_MATCH:-0} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-hw-intel-ptl" <<'SH'
+#!/bin/bash
+
+(( ${PTL_MATCH:-0} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-hw-asus-expertbook-b9406" <<'SH'
+#!/bin/bash
+
+(( ${B9406_MATCH:-0} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/pacman" <<'SH'
+#!/bin/bash
+
+printf 'pacman' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+if [[ $1 == "-Qq" && $2 == "linux" ]]; then
+  exit 1
+fi
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local xps="$1" ptl="$2" b9406="$3"
+  : >"$calls"
+  rm -f "$boot_order_conf"
+  touch "$legacy_boot_order_conf"
+
+  XPS_MATCH="$xps" PTL_MATCH="$ptl" B9406_MATCH="$b9406" \
+    TEST_LOG="$calls" PATH="$stub_bin:$PATH" \
+    OMARCHY_PTL_BOOT_ORDER_CONF="$boot_order_conf" \
+    OMARCHY_PTL_OLD_BOOT_ORDER_CONF="$old_boot_order_conf" \
+    OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF="$legacy_boot_order_conf" \
+    bash -euo pipefail "$leaf" >/dev/null
+}
+
+run_leaf 0 1 1
+grep -Fxq $'omarchy-pkg-add\tlinux-ptl\tlinux-ptl-headers' "$calls" ||
+  fail "the B9406 installs the patched kernel" "$(cat "$calls")"
+grep -Fxq $'pacman\t-Rdd\t--noconfirm\tlinux\tlinux-headers' "$calls" ||
+  fail "the B9406 removes the superseded stock kernel" "$(cat "$calls")"
+grep -Fq 'BOOT_ORDER="linux-ptl*, *fallback, Snapshots"' "$boot_order_conf" ||
+  fail "the B9406 boots the patched kernel by default"
+[[ ! -e $legacy_boot_order_conf ]] || fail "the legacy Dell boot-order drop-in is removed"
+pass "the B9406 selects the audio-capable Panther Lake kernel"
+
+run_leaf 1 1 0
+grep -Fxq $'omarchy-pkg-add\tlinux-ptl\tlinux-ptl-headers' "$calls" ||
+  fail "a Panther Lake XPS keeps the patched kernel" "$(cat "$calls")"
+pass "the existing Dell XPS kernel path is preserved"
+
+run_leaf 1 0 0
+[[ ! -s $calls ]] || fail "a non-Panther-Lake XPS is left alone" "$(cat "$calls")"
+[[ ! -e $boot_order_conf ]] || fail "a non-Panther-Lake XPS gets no boot override"
+
+run_leaf 0 1 0
+[[ ! -s $calls ]] || fail "an unrelated Panther Lake system is left alone" "$(cat "$calls")"
+[[ ! -e $boot_order_conf ]] || fail "an unrelated Panther Lake system gets no boot override"
+pass "unrelated hardware does not install the custom kernel"
+
+: >"$calls"
+rm -f "$boot_order_conf"
+
+B9406_MATCH=1 XPS_MATCH=0 PTL_MATCH=1 TEST_LOG="$calls" \
+  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  OMARCHY_PTL_BOOT_ORDER_CONF="$boot_order_conf" \
+  OMARCHY_PTL_OLD_BOOT_ORDER_CONF="$old_boot_order_conf" \
+  OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF="$legacy_boot_order_conf" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -Fxq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the B9406 migration requests the reboot needed for the new kernel" "$(cat "$calls")"
+grep -Fq 'BOOT_ORDER="linux-ptl*, *fallback, Snapshots"' "$boot_order_conf" ||
+  fail "the B9406 migration installs the kernel boot override"
+pass "existing B9406 installs receive the patched kernel"
+
+: >"$calls"
+rm -f "$boot_order_conf"
+
+B9406_MATCH=0 XPS_MATCH=0 PTL_MATCH=1 TEST_LOG="$calls" \
+  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  OMARCHY_PTL_BOOT_ORDER_CONF="$boot_order_conf" \
+  OMARCHY_PTL_OLD_BOOT_ORDER_CONF="$old_boot_order_conf" \
+  OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF="$legacy_boot_order_conf" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ ! -s $calls ]] || fail "the B9406 migration skips unrelated hardware" "$(cat "$calls")"
+[[ ! -e $boot_order_conf ]] || fail "the migration adds no unrelated boot override"
+pass "the B9406 migration is hardware-scoped"

--- a/test/shell.d/ptl-kernel-test.sh
+++ b/test/shell.d/ptl-kernel-test.sh
@@ -82,7 +82,7 @@ run_leaf() {
   touch "$legacy_boot_order_conf"
 
   XPS_MATCH="$xps" PTL_MATCH="$ptl" B9406_MATCH="$b9406" \
-    TEST_LOG="$calls" PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" PATH="$stub_bin:$PATH" OMARCHY_TESTING=1 \
     OMARCHY_PTL_BOOT_ORDER_CONF="$boot_order_conf" \
     OMARCHY_PTL_OLD_BOOT_ORDER_CONF="$old_boot_order_conf" \
     OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF="$legacy_boot_order_conf" \
@@ -117,7 +117,7 @@ pass "unrelated hardware does not install the custom kernel"
 rm -f "$boot_order_conf"
 
 B9406_MATCH=1 XPS_MATCH=0 PTL_MATCH=1 TEST_LOG="$calls" \
-  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" OMARCHY_TESTING=1 \
   OMARCHY_PTL_BOOT_ORDER_CONF="$boot_order_conf" \
   OMARCHY_PTL_OLD_BOOT_ORDER_CONF="$old_boot_order_conf" \
   OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF="$legacy_boot_order_conf" \
@@ -133,7 +133,7 @@ pass "existing B9406 installs receive the patched kernel"
 rm -f "$boot_order_conf"
 
 B9406_MATCH=0 XPS_MATCH=0 PTL_MATCH=1 TEST_LOG="$calls" \
-  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" OMARCHY_TESTING=1 \
   OMARCHY_PTL_BOOT_ORDER_CONF="$boot_order_conf" \
   OMARCHY_PTL_OLD_BOOT_ORDER_CONF="$old_boot_order_conf" \
   OMARCHY_PTL_LEGACY_BOOT_ORDER_CONF="$legacy_boot_order_conf" \


### PR DESCRIPTION
## What

Extend the existing `linux-ptl` hardware path to the ASUS ExpertBook B9406CAA, whose firmware exposes a phantom RT722 SoundWire codec that prevents Linux 7.1 from registering an ALSA card.

This PR:

- keeps the existing Dell XPS Panther Lake detection unchanged;
- adds the exact B9406 hardware detector already used by its display and touchpad fixes;
- uses a generic Panther Lake boot-order drop-in and cleans up both earlier Dell-specific names;
- migrates existing B9406 installs and marks them reboot-required;
- adds focused coverage for B9406, XPS, unrelated PTL hardware, migration, and reboot state.

Depends on omacom-io/omarchy-pkgs#163, which adds the tested B9406 SoundWire DMI quirk to `linux-ptl`.

## Why the kernel fix is narrow

On the live B9406, Linux 7.1 creates duplicate `SDW3-Playback-SimpleJack` links for an unattached RT722 and the real CS42L43, then fails `sof_sdw` with `-12`. The equivalent DMI remap is running successfully today as a DKMS backport: the ALSA card registers, both CS35L56 amplifiers load calibrated firmware, and PipeWire exposes the HiFi Speaker sink.

Current Arch packages already ship the required Cirrus firmware and combined-codec UCM. This intentionally adds no firmware blobs, ALSA overrides, or PipeWire profile hacks.

## Validation

- `bash test/shell.d/ptl-kernel-test.sh` passes all five focused cases.
- `./test/all` runs the new test successfully and passes 180/181 test files. The sole failure is the unrelated pre-existing `snapper-test.sh` checkout prerequisite (`omarchy-iso` sibling checkout is unavailable in this workspace).
- The coordinated package patch completes `makepkg` preparation and the targeted SoundWire driver compilation.
