### PR TITLE
Require explicit approval for upstream agent work

### DIFF
--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -46,7 +46,7 @@ matching guide before starting:
 - [`theming.md`](theming.md) - themes, backgrounds, and fonts
 - [`hooks.md`](hooks.md) - automation hooks that run on system events
 - [`capture.md`](capture.md) - screenshots, screen recordings, OCR text capture, and file sharing
-- [`contributing.md`](contributing.md) - reporting Omarchy bugs and submitting fixes upstream
+- [`contributing.md`](contributing.md) - reporting Omarchy bugs and, when explicitly requested, submitting fixes upstream
 
 ## Critical Safety Rules
 

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -46,7 +46,7 @@ matching guide before starting:
 - [`theming.md`](theming.md) - themes, backgrounds, and fonts
 - [`hooks.md`](hooks.md) - automation hooks that run on system events
 - [`capture.md`](capture.md) - screenshots, screen recordings, OCR text capture, and file sharing
-- [`contributing.md`](contributing.md) - reporting Omarchy bugs and, when explicitly requested, submitting fixes upstream
+- [`contributing.md`](contributing.md) - diagnosing or reporting Omarchy bugs and, when explicitly requested, submitting fixes upstream
 
 ## Critical Safety Rules
 

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -1,7 +1,18 @@
 # Reporting Issues and Submitting PRs
 
-Read this when the user wants to report an Omarchy bug, suggest a feature, or
-contribute a fix upstream.
+Read this when the user explicitly wants to report an Omarchy bug, suggest a
+feature, or contribute a fix upstream.
+
+## Keep Upstream Work Explicit
+
+Reporting or diagnosing a bug does not authorize implementing a fix. Do not
+leave the current project or clone, fork, branch, or modify an Omarchy source
+checkout unless the user explicitly asks to work on an upstream Omarchy fix.
+
+If upstream work is explicitly requested but the current project is not an
+Omarchy source checkout, tell the user that the work requires a separate
+checkout and get confirmation before creating one. Once working in an Omarchy
+source checkout, follow its repository instructions.
 
 Omarchy lives at https://github.com/basecamp/omarchy. Route requests to the
 right place:
@@ -51,7 +62,10 @@ the debug log URL (or attached log), and the capture.
 
 ## Submitting a PR
 
-Never develop against `/usr/share/omarchy`. Clone a working copy instead:
+Only follow this workflow when the user explicitly asks to implement or prepare
+an upstream Omarchy fix. Never develop against `/usr/share/omarchy`. Use an
+existing Omarchy source checkout when one is available. If a new checkout is
+needed, explain that to the user and get confirmation before creating it:
 
 ```bash
 gh repo fork basecamp/omarchy --clone
@@ -59,7 +73,8 @@ cd omarchy
 ```
 
 Follow the repository's own `AGENTS.md` for style, testing, and commit
-conventions — it is the authority on contributions. Keep commits atomic, run
-`./test/all` before pushing, and open the PR with `gh pr create`. A PR that
-fixes a visual problem should include before/after captures (again, see
-[`capture.md`](capture.md)).
+conventions — it is the authority on contributions. Keep commits atomic and run
+`./test/all` before pushing. Preparing a fix does not authorize publishing it;
+get the user's explicit approval before pushing or opening the PR with
+`gh pr create`. A PR that fixes a visual problem should include before/after
+captures (again, see [`capture.md`](capture.md)).

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -1,7 +1,7 @@
 # Reporting Issues and Submitting PRs
 
-Read this when the user explicitly wants to report an Omarchy bug, suggest a
-feature, or contribute a fix upstream.
+Read this when the user wants to diagnose or report an Omarchy bug, suggest a
+feature, or explicitly contribute a fix upstream.
 
 ## Keep Upstream Work Explicit
 


### PR DESCRIPTION
## Problem

The globally installed Omarchy skill says source development is out of scope, but its contribution workflow can still be read as permission to leave an unrelated project, create an Omarchy checkout, and begin implementing a fix after diagnosing or reporting a bug.

A request to diagnose or report an Omarchy bug should not imply permission to implement it upstream. Likewise, preparing a fix should not imply permission to push it or open a PR.

## Change

Preserve the existing reporting and PR guidance while adding explicit scope gates:

- Route diagnosis, reporting, suggestion, and explicit upstream-fix requests through the contribution guide.
- State that diagnosis and bug reporting do not authorize implementation.
- Prevent agents from leaving the current project or creating/modifying an Omarchy checkout without an explicit upstream-fix request.
- Require the agent to explain the need for a separate checkout and get confirmation before creating one.
- Preserve the fork, test, capture, and PR workflow.
- Require explicit approval before pushing or opening a PR.

## Validation

- `git diff --check`
- Targeted assertions confirm that diagnosis routes through the guide, the scope and approval guards are present, and the original fork/PR workflow remains documented.
- `./test/all` was started but not completed because the full suite was too resource-intensive for the active system. Before it was stopped, it reached an environment-dependent, unrelated failure requiring a separate `omarchy-pkgs` checkout. This change only touches Markdown agent guidance.
