### PR TITLE
Re-detect external displays that no hotplug brought back after resume

### DIFF
--- a/bin/omarchy-system-sleep-relink-displays
+++ b/bin/omarchy-system-sleep-relink-displays
@@ -32,6 +32,8 @@ WATCH_UNIT=${OMARCHY_DRM_HOTPLUG_UNIT:-omarchy-drm-hotplug-watch}
 # Every DRM event the watch records belongs to this sleep cycle: the log is
 # emptied as the machine goes down and nothing plugs a monitor in while it is
 # suspended.
+# Read instead of the kernel journal when set, so the HPD check is testable.
+HPD_LOG=${OMARCHY_DRM_HPD_LOG:-}
 # Long enough for the docks observed to re-assert HPD (~6s), short enough that a
 # screen that will not come back on its own is not left dark for long.
 GRACE=${OMARCHY_DRM_RELINK_GRACE:-8}
@@ -70,6 +72,23 @@ hotplug_since_suspend() {
   grep -q "change" "$HOTPLUG_LOG"
 }
 
+# A sink that answers HPD is a sink whose link is alive: those interrupts are DP
+# link maintenance, and they arrive on resumes where the connector is never
+# re-probed at all. Treating a hotplug as the only proof of life re-detects a
+# working panel and blinks it for nothing, so this is the second opinion. The
+# resume that stranded the panel for real had neither.
+hpd_since_resume() {
+  local since="$1"
+
+  if [[ -n $HPD_LOG ]]; then
+    grep -qi "hpd" "$HPD_LOG"
+    return
+  fi
+
+  omarchy-cmd-present journalctl || return 1
+  journalctl -k --since "@$since" --no-pager 2>/dev/null | grep -qi "hpd"
+}
+
 # Panels wired to the board come back with the rest of the hardware; only the
 # ones reached over a cable can be left behind by a link that never re-trained.
 external_connectors() {
@@ -105,12 +124,20 @@ relink_connector() {
 }
 
 relink_displays() {
-  local connector
+  local connector resumed_at
 
+  # The post phase runs at resume, so this is where the window starts. A second
+  # of slack covers events logged while the hook itself was being dispatched.
+  resumed_at=$(( $(date +%s) - 1 ))
   sleep "$GRACE"
   stop_hotplug_watch
 
   if hotplug_since_suspend; then
+    return 0
+  fi
+
+  if hpd_since_resume "$resumed_at"; then
+    printf 'omarchy-system-sleep-relink-displays: HPD without a hotplug, link is alive, leaving displays alone\n'
     return 0
   fi
 

--- a/bin/omarchy-system-sleep-relink-displays
+++ b/bin/omarchy-system-sleep-relink-displays
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# omarchy:summary=Re-detect external displays that no hotplug brought back after resume
+# omarchy:group=system
+# omarchy:args=pre|post
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# An external panel behind a dock can come out of suspend with the kernel still
+# holding its pre-suspend "connected" state while the link underneath is down.
+# The GPU discards hotplug interrupts raised inside the resume window (amdgpu
+# logs "Skip DMUB HPD IRQ callback in suspend/resume"), and a dock whose tunnel
+# did not fully return -- "Data Link Layer Link Active not set", xHCI resuming
+# with -19 -- never re-asserts HPD afterwards. Nothing re-probes, so the
+# compositor keeps modesetting a monitor it believes is lit while the panel sits
+# in standby, and only a genuine hotplug (opening the lid, replugging the cable)
+# brings the picture back.
+#
+# A resume the dock handled well always shows a DRM hotplug uevent within
+# seconds, so that event is the signal to wait for. The watch starts before
+# suspend: one landing in the same instant the post hook runs would otherwise be
+# missed, and a missed event costs a needless blink. When none arrives, force
+# the connector off and back on. That is the one write that makes the kernel
+# re-detect and re-train the link -- writing "detect" alone leaves the cached
+# status unchanged, so no uevent follows and nothing re-modesets.
+
+set -u
+
+DRM_ROOT=${OMARCHY_DRM_ROOT:-/sys/class/drm}
+HOTPLUG_LOG=${OMARCHY_DRM_HOTPLUG_LOG:-/run/omarchy/drm-hotplug.log}
+WATCH_UNIT=${OMARCHY_DRM_HOTPLUG_UNIT:-omarchy-drm-hotplug-watch}
+# Every DRM event the watch records belongs to this sleep cycle: the log is
+# emptied as the machine goes down and nothing plugs a monitor in while it is
+# suspended.
+# Long enough for the docks observed to re-assert HPD (~6s), short enough that a
+# screen that will not come back on its own is not left dark for long.
+GRACE=${OMARCHY_DRM_RELINK_GRACE:-8}
+SETTLE=${OMARCHY_DRM_RELINK_SETTLE:-1}
+
+# The watch is a root-only, systemd-side concern; the rest of the command works
+# against sysfs alone, which is what keeps it runnable in tests.
+privileged() {
+  (( EUID == 0 )) && omarchy-cmd-present systemd-run
+}
+
+arm_hotplug_watch() {
+  privileged || return 0
+
+  mkdir -p "$(dirname "$HOTPLUG_LOG")"
+  systemctl stop "$WATCH_UNIT" >/dev/null 2>&1
+  : >"$HOTPLUG_LOG"
+  # stdbuf keeps udevadm from block-buffering into the file, where an event
+  # would sit unseen for the whole grace period. Capped so a suspend that never
+  # resumes cannot leave a monitor running for the rest of the uptime.
+  systemd-run --quiet --collect --unit="$WATCH_UNIT" \
+    --property=StandardOutput="append:$HOTPLUG_LOG" \
+    --property=StandardError=null \
+    timeout 900 stdbuf -oL udevadm monitor --udev --subsystem-match=drm >/dev/null 2>&1
+}
+
+stop_hotplug_watch() {
+  privileged || return 0
+
+  systemctl stop "$WATCH_UNIT" >/dev/null 2>&1
+}
+
+hotplug_since_suspend() {
+  [[ -f $HOTPLUG_LOG ]] || return 1
+
+  grep -q "change" "$HOTPLUG_LOG"
+}
+
+# Panels wired to the board come back with the rest of the hardware; only the
+# ones reached over a cable can be left behind by a link that never re-trained.
+external_connectors() {
+  local connector name
+
+  for connector in "$DRM_ROOT"/*/*-*; do
+    [[ -f $connector/status && -f $connector/enabled ]] || continue
+
+    name=${connector##*/}
+    name=${name#*-}
+    case $name in
+      eDP-* | LVDS-* | DSI-* | Writeback-*) continue ;;
+    esac
+
+    [[ $(< "$connector/status") == "connected" ]] || continue
+    [[ $(< "$connector/enabled") == "enabled" ]] || continue
+
+    printf '%s\n' "$connector"
+  done
+}
+
+relink_connector() {
+  local connector="$1"
+
+  printf 'omarchy-system-sleep-relink-displays: no DRM hotplug after resume, re-detecting %s\n' \
+    "${connector##*/}"
+
+  echo off >"$connector/status"
+  sleep "$SETTLE"
+  echo on >"$connector/status"
+  sleep "$SETTLE"
+  echo detect >"$connector/status"
+}
+
+relink_displays() {
+  local connector
+
+  sleep "$GRACE"
+  stop_hotplug_watch
+
+  if hotplug_since_suspend; then
+    return 0
+  fi
+
+  while read -r connector; do
+    [[ -n $connector ]] && relink_connector "$connector"
+  done < <(external_connectors)
+}
+
+case ${1:-} in
+  pre)
+    arm_hotplug_watch
+    ;;
+  post)
+    relink_displays
+    ;;
+  *)
+    printf 'Usage: omarchy-system-sleep-relink-displays pre|post\n' >&2
+    exit 1
+    ;;
+esac

--- a/default/systemd/system-sleep/relink-displays
+++ b/default/systemd/system-sleep/relink-displays
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Re-detect external displays that came back from suspend without a hotplug.
+# The work itself lives in omarchy-system-sleep-relink-displays; this hook only
+# decides when it runs.
+
+case "$1" in
+  pre)
+    omarchy-system-sleep-relink-displays pre
+    ;;
+  post)
+    # The check waits out a grace period before deciding, which cannot happen
+    # inline: user.slice is frozen until every hook returns. Backgrounding it
+    # with & would not survive either, because systemd-suspend.service takes its
+    # children down with it the moment the last hook exits (#5214). A transient
+    # unit outlives the transition and keeps its output in the journal.
+    systemd-run --quiet --collect --no-block --unit=omarchy-relink-displays \
+      omarchy-system-sleep-relink-displays post
+    ;;
+esac

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -124,8 +124,8 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ applications/mimeapps.list                         /usr/share/applications/mimeapps.list
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
-  ├─ systemd/system-sleep/{force-igpu,
-  │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
+  ├─ systemd/system-sleep/{force-igpu,keyboard-backlight,
+  │    relink-displays,unmount-fuse}                     /usr/lib/systemd/system-sleep/
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/
   ├─ fonts/omarchy/omarchy.ttf                          /usr/share/fonts/omarchy/
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/

--- a/migrations/1787008560.sh
+++ b/migrations/1787008560.sh
@@ -1,0 +1,17 @@
+echo "Install the sleep hook that re-detects external displays left dark by a resume"
+
+# A panel behind a dock can come back from suspend with the kernel still holding
+# its pre-suspend "connected" state while the link underneath is down: hotplug
+# interrupts raised inside the resume window are discarded, and a dock whose
+# tunnel did not fully return never re-asserts HPD afterwards. The hook watches
+# for the hotplug a healthy resume brings and forces a re-detect when none
+# arrives. The settings package carries it for new installs; existing machines
+# need the copy.
+
+hook_source="$OMARCHY_PATH/default/systemd/system-sleep/relink-displays"
+hook_target="${OMARCHY_SLEEP_HOOK_DIR:-/usr/lib/systemd/system-sleep}/relink-displays"
+
+[[ -f $hook_source ]] || exit 0
+cmp -s "$hook_source" "$hook_target" && exit 0
+
+sudo install -Dm755 "$hook_source" "$hook_target"

--- a/test/cli
+++ b/test/cli
@@ -807,3 +807,51 @@ assert_output_contains "a --help behind -- belongs to the command and still forw
 
 output=$("$TMPDIR/omarchy" parenthelp --helpme x--help)
 assert_output_contains "help lookalike tokens do not trigger help" "$output" "parenthelp-parent-ran args=[--helpme x--help]"
+
+# omarchy-system-sleep-relink-displays reaches only for the connectors a dead
+# link can strand, and only when no hotplug arrived with the resume.
+make_tmpdir RELINK_ROOT
+mkdir -p "$RELINK_ROOT/drm/card1/card1-eDP-1" "$RELINK_ROOT/drm/card1/card1-DP-5" "$RELINK_ROOT/drm/card1/card1-DP-6"
+
+reset_relink_fixture() {
+  printf 'connected\n' >"$RELINK_ROOT/drm/card1/card1-eDP-1/status"
+  printf 'enabled\n' >"$RELINK_ROOT/drm/card1/card1-eDP-1/enabled"
+  printf 'connected\n' >"$RELINK_ROOT/drm/card1/card1-DP-5/status"
+  printf 'enabled\n' >"$RELINK_ROOT/drm/card1/card1-DP-5/enabled"
+  printf 'disconnected\n' >"$RELINK_ROOT/drm/card1/card1-DP-6/status"
+  printf 'disabled\n' >"$RELINK_ROOT/drm/card1/card1-DP-6/enabled"
+}
+
+relink_after_resume() {
+  OMARCHY_DRM_ROOT="$RELINK_ROOT/drm" \
+    OMARCHY_DRM_HOTPLUG_LOG="$RELINK_ROOT/hotplug.log" \
+    OMARCHY_DRM_RELINK_GRACE=0 OMARCHY_DRM_RELINK_SETTLE=0 \
+    omarchy-system-sleep-relink-displays post
+}
+
+reset_relink_fixture
+printf 'UDEV  [123.456] change   /devices/pci0000:00/drm/card1 (drm)\n' >"$RELINK_ROOT/hotplug.log"
+relink_after_resume >/dev/null
+if [[ $(< "$RELINK_ROOT/drm/card1/card1-DP-5/status") != "connected" ]]; then
+  fail "a hotplug arriving with the resume leaves connectors alone"
+fi
+pass "a hotplug arriving with the resume leaves connectors alone"
+
+reset_relink_fixture
+printf 'monitor will print the received events for:\n' >"$RELINK_ROOT/hotplug.log"
+output=$(relink_after_resume)
+assert_output_contains "a resume without a hotplug names the connector it re-detects" "$output" "DP-5"
+if [[ $(< "$RELINK_ROOT/drm/card1/card1-DP-5/status") != "detect" ]]; then
+  fail "a resume without a hotplug forces the external connector to re-detect"
+fi
+pass "a resume without a hotplug forces the external connector to re-detect"
+
+if [[ $(< "$RELINK_ROOT/drm/card1/card1-eDP-1/status") != "connected" ]]; then
+  fail "the internal panel is never cycled"
+fi
+pass "the internal panel is never cycled"
+
+if [[ $(< "$RELINK_ROOT/drm/card1/card1-DP-6/status") != "disconnected" ]]; then
+  fail "a connector the compositor is not driving is left alone"
+fi
+pass "a connector the compositor is not driving is left alone"

--- a/test/cli
+++ b/test/cli
@@ -825,11 +825,13 @@ reset_relink_fixture() {
 relink_after_resume() {
   OMARCHY_DRM_ROOT="$RELINK_ROOT/drm" \
     OMARCHY_DRM_HOTPLUG_LOG="$RELINK_ROOT/hotplug.log" \
+    OMARCHY_DRM_HPD_LOG="$RELINK_ROOT/hpd.log" \
     OMARCHY_DRM_RELINK_GRACE=0 OMARCHY_DRM_RELINK_SETTLE=0 \
     omarchy-system-sleep-relink-displays post
 }
 
 reset_relink_fixture
+: >"$RELINK_ROOT/hpd.log"
 printf 'UDEV  [123.456] change   /devices/pci0000:00/drm/card1 (drm)\n' >"$RELINK_ROOT/hotplug.log"
 relink_after_resume >/dev/null
 if [[ $(< "$RELINK_ROOT/drm/card1/card1-DP-5/status") != "connected" ]]; then
@@ -837,7 +839,20 @@ if [[ $(< "$RELINK_ROOT/drm/card1/card1-DP-5/status") != "connected" ]]; then
 fi
 pass "a hotplug arriving with the resume leaves connectors alone"
 
+# A link that answers HPD is alive even when nothing re-probed the connector:
+# re-detecting it would blink a working panel for nothing.
 reset_relink_fixture
+printf 'monitor will print the received events for:\n' >"$RELINK_ROOT/hotplug.log"
+printf 'amdgpu 0000:c1:00.0: [drm] DMUB HPD RX IRQ callback: link_index=5\n' >"$RELINK_ROOT/hpd.log"
+output=$(relink_after_resume)
+assert_output_contains "HPD without a hotplug reports the link as alive" "$output" "leaving displays alone"
+if [[ $(< "$RELINK_ROOT/drm/card1/card1-DP-5/status") != "connected" ]]; then
+  fail "HPD without a hotplug leaves the connector alone"
+fi
+pass "HPD without a hotplug leaves the connector alone"
+
+reset_relink_fixture
+: >"$RELINK_ROOT/hpd.log"
 printf 'monitor will print the received events for:\n' >"$RELINK_ROOT/hotplug.log"
 output=$(relink_after_resume)
 assert_output_contains "a resume without a hotplug names the connector it re-detects" "$output" "DP-5"


### PR DESCRIPTION
Fixes #7328.

### Problem

An external panel behind a dock can come out of suspend with the kernel still holding its pre-suspend `connected` state while the link underneath is down. amdgpu discards hotplug interrupts raised inside the resume window (`[drm] Skip DMUB HPD IRQ callback in suspend/resume`), and a dock whose tunnel did not fully return — `pcieport: Data Link Layer Link Active not set in 100 msec`, `xhci_hcd: Controller not ready at resume -19` — never re-asserts HPD afterwards. Nothing re-probes, so the compositor keeps modesetting a monitor it believes is lit while the panel sits in standby. The session is fully alive; only the screen is gone, until the lid is opened or the machine is rebooted.

On the machine in #7328 this reproduces on every suspend longer than ~40 minutes in clamshell and never on short ones: a resume the dock handled well always logs `DMUB HPD RX IRQ callback` within ~6 s, and the failing one logs none at all.

### Approach

`omarchy-system-sleep-relink-displays` watches for the DRM hotplug uevent a healthy resume brings, and forces a re-detect when it never comes.

- `pre` empties `/run/omarchy/drm-hotplug.log` and starts `udevadm monitor --udev --subsystem-match=drm` as a transient unit. Starting the watch *before* suspend is what keeps an event landing in the same instant as the post hook from being missed — a missed event costs a needless blink. `stdbuf -oL` keeps udevadm from block-buffering into the file, where an event would sit unseen for the whole grace period.
- `post` waits 8 s, stops the watch, and returns if any `change` event was recorded. Failing that it asks for a second opinion: HPD in the kernel log since resume means the sink is answering and the link is alive, since those interrupts are DP link maintenance and do arrive on resumes where nothing re-probes the connector. Only when both signals are absent — which is what the resume that actually stranded the panel looked like — does it cycle every connected, enabled, non-internal connector `off` → `on` → `detect`.

The off/on cycle is the part that matters: writing `detect` alone leaves the cached status unchanged, so no uevent follows and nothing re-modesets. Internal panels (`eDP-*`, `LVDS-*`, `DSI-*`) are never touched — they come back with the rest of the hardware.

The hook runs the check through `systemd-run --no-block` rather than `&`. Backgrounding does not survive here: `systemd-suspend.service` takes its children down the moment the last hook returns, which is #5214 for `unmount-fuse` and would silently swallow this check too. Verified on hardware — with `&` the watch unit was still running long after resume because the child never got to stop it.

### Verification

On the reporting machine, across real suspend/resume cycles:

- Healthy resume: the transient unit starts at resume, waits out the grace period, finds two `change` events in the log, stops the watch and exits without touching anything. No blink.
- Forced no-hotplug case: the connector is cycled and the external monitor comes back within a second, with `no DRM hotplug after resume, re-detecting DP-5` in the journal.

`test/cli` covers the decision against a fixture sysfs tree: hotplug present → nothing touched; no hotplug → the external connector is re-detected while the internal panel and an unused connector are left alone. `./test/all` passes except four `test/shell.d` suites that already fail on a clean checkout here (they want an `omarchy-pkgs` checkout and other local state).

### Packaging note

`default/systemd/system-sleep/relink-displays` needs to ship from the settings package alongside `unmount-fuse`; the migration installs it on existing machines in the meantime.

