### PR TITLE
Scroll the Tailscale machine list independently of the panel

### DIFF
--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -265,24 +265,34 @@ Panel {
     if (region) chooseExitNode(region)
   }
 
-  function scrollItemIntoView(item) {
-    if (!panelFlick || !item) return
+  // `flick` defaults to the whole-panel scroller. The machine list has its own
+  // Flickable, so rows in that section pass it explicitly — scrolling the outer
+  // one to reveal a peer would move the panel rather than the list, and the row
+  // would stay hidden inside a list that never scrolled.
+  function scrollItemIntoView(item, flick) {
+    var view = flick || panelFlick
+    if (!view || !item) return
     Qt.callLater(function() {
       if (!item) return
       var margin = Style.space(6)
-      var point = item.mapToItem(panelFlick.contentItem, 0, 0)
+      var point = item.mapToItem(view.contentItem, 0, 0)
       var top = point.y
       var bottom = top + item.height
-      var viewTop = panelFlick.contentY
-      var viewBottom = viewTop + panelFlick.height
-      var maxY = Math.max(0, panelFlick.contentHeight - panelFlick.height)
-      if (top < viewTop + margin) panelFlick.contentY = Math.max(0, top - margin)
-      else if (bottom > viewBottom - margin) panelFlick.contentY = Math.min(maxY, bottom + margin - panelFlick.height)
+      var viewTop = view.contentY
+      var viewBottom = viewTop + view.height
+      var maxY = Math.max(0, view.contentHeight - view.height)
+      if (top < viewTop + margin) view.contentY = Math.max(0, top - margin)
+      else if (bottom > viewBottom - margin) view.contentY = Math.min(maxY, bottom + margin - view.height)
     })
   }
 
   function scrollCursorIntoView() {
-    if (focusSection === "peers" && peerColumn && peerIndex >= 0 && peerIndex < peerColumn.children.length) scrollItemIntoView(peerColumn.children[peerIndex])
+    if (focusSection === "peers" && peerColumn && peerIndex >= 0 && peerIndex < peerColumn.children.length) {
+      // Bring the machine list itself into view first, then the row within it —
+      // otherwise the row scrolls inside a list that is still off-screen.
+      scrollItemIntoView(peerFlick)
+      scrollItemIntoView(peerColumn.children[peerIndex], peerFlick)
+    }
     else if (focusSection === "exitNodes" && exitNodeColumn && exitNodeIndex >= 0 && exitNodeIndex < exitNodeColumn.children.length) scrollItemIntoView(exitNodeColumn.children[exitNodeIndex])
   }
 
@@ -690,20 +700,42 @@ Panel {
               horizontalAlignment: Text.AlignHCenter
             }
 
-            Column {
-              id: peerColumn
+            // The machine list scrolls on its own rather than pushing the
+            // sections above it off the top of the panel. Its height is the
+            // content height until that passes maxPeerListHeight, after which
+            // it stops growing and scrolls internally — so a tailnet with three
+            // machines still renders as a short panel, and one with thirty
+            // keeps the header, CONNECTIONS and EXIT NODES in view while the
+            // machines move under them.
+            Flickable {
+              id: peerFlick
               visible: root.showPeers
               width: parent.width
-              spacing: Style.space(6)
+              readonly property real maxPeerListHeight: Style.space(260)
+              implicitHeight: Math.min(peerColumn.implicitHeight, maxPeerListHeight)
+              height: implicitHeight
+              contentWidth: width
+              contentHeight: peerColumn.implicitHeight
+              clip: true
+              boundsBehavior: Flickable.StopAtBounds
+              flickableDirection: Flickable.VerticalFlick
+              interactive: contentHeight > height
+              ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
 
-              Repeater {
-                model: tailscale.peers
-                PeerRow {
-                  required property var modelData
-                  required property int index
-                  width: peerColumn.width
-                  peer: modelData
-                  rowIndex: index
+              Column {
+                id: peerColumn
+                width: peerFlick.width
+                spacing: Style.space(6)
+
+                Repeater {
+                  model: tailscale.peers
+                  PeerRow {
+                    required property var modelData
+                    required property int index
+                    width: peerColumn.width
+                    peer: modelData
+                    rowIndex: index
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Problem

On a tailnet with more than a handful of machines, the Tailscale panel scrolls as one piece. Reaching a machine near the bottom pushes the hero — and with it the on/off switch — plus the CONNECTIONS and EXIT NODES sections off the top of the panel.

So the two things you are most likely to want while looking at a machine (toggling Tailscale, switching account) are exactly the things that scroll away. On the tailnet I tested with (14 online peers) the hero is gone before the fifth machine.

## Change

Give the machine list its own `Flickable`, capped at `Style.space(260)` — about five rows — so the sections above it stay put while only the machines move.

Two details worth calling out:

**The cap applies only when it is needed.** `implicitHeight` is `min(peerColumn.implicitHeight, maxPeerListHeight)`, so a tailnet with three machines still renders as a short panel rather than reserving five rows of empty space. The list also keeps `interactive: contentHeight > height`, matching 51075ce ("Make sure we never get in-panel scrolling when we shouldn't") — it stays inert when everything fits.

**Keyboard navigation needed the scroller passed explicitly.** `scrollItemIntoView()` addressed `panelFlick` directly. Left as it was, `j`/`k` through the peers would scroll the panel rather than the list, leaving the highlighted row hidden inside a list that never moved. It now takes the target scroller and defaults to the panel, and peer navigation brings the list into view first, then the row within it.

The outer panel scroller is untouched and still handles the panel as a whole outgrowing the screen.

## Verification

- `test/shell` — 815 pass. The single failure is `omarchy-pkgs checkout found for PKGBUILD coverage`, which is a missing sibling checkout in my environment and unrelated to this change.
- Ran in the live shell as a third-party plugin built from this branch, on a 14-peer tailnet across three monitors: the machine list scrolls on its own, the sections above stay fixed, and `j`/`k` past the fifth machine keeps the highlighted row visible.
- No drift: `shell/plugins/panels/tailscale/Panel.qml` is identical between the commit I developed against and current `quattro`.

## Open question

`Style.space(260)` is a chosen number rather than a derived one. Five rows felt right against the rest of the panel's proportions, but it is a design call and I have no attachment to it — happy to change the value, derive it from the panel height, or expose it through the plugin's existing `schema` block alongside `refreshIntervalSec` if you would rather it be configurable.
