### PR TITLE
Reset Apple BCM4350/BCM43602 Wi-Fi around sleep

### DIFF
--- a/bin/omarchy-hw-brcmfmac-suspend
+++ b/bin/omarchy-hw-brcmfmac-suspend
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# omarchy:hidden=true
+# omarchy:summary=Unbind affected Broadcom Wi-Fi around system sleep
+# omarchy:args=<pre|post>
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+# Apple BCM4350 (43a3) and BCM43602 (43ba/43bb/43bc) firmware often stops
+# answering after S3. NetworkManager still shows the radio as on, but scans
+# fail and the supplicant times out until the device is rebound. Do not add
+# T2-era parts: BCM4364 (4464) must stay bound for PCI PM, and
+# BCM4377/4378/4387 have their own T2 recovery path.
+affected_ids="${OMARCHY_BRCMFMAC_SUSPEND_IDS:-0x43a3 0x43ba 0x43bb 0x43bc}"
+driver_path="${OMARCHY_BRCMFMAC_DRIVER_PATH:-/sys/bus/pci/drivers/brcmfmac}"
+device_root="${OMARCHY_BRCMFMAC_DEVICE_ROOT:-/sys/bus/pci/devices}"
+state_file="${OMARCHY_BRCMFMAC_SUSPEND_STATE:-/run/omarchy-brcmfmac-suspend.devices}"
+
+is_affected_id() {
+  local device_id="$1" candidate
+  for candidate in $affected_ids; do
+    [[ $device_id == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+driver_name() {
+  local pci_address="$1"
+  local link="$device_root/$pci_address/driver"
+
+  [[ -L $link ]] || return 0
+  basename "$(readlink -f "$link")"
+}
+
+case "${1:-}" in
+  pre)
+    install -d -m755 "$(dirname "$state_file")"
+    : >"$state_file"
+
+    for device in "$device_root"/????:??:??.?; do
+      [[ -e $device/vendor && -e $device/device ]] || continue
+      [[ $(<"$device/vendor") == "0x14e4" ]] || continue
+      is_affected_id "$(<"$device/device")" || continue
+
+      pci_address="${device##*/}"
+      if [[ $(driver_name "$pci_address") == "brcmfmac" ]]; then
+        if ! printf '%s' "$pci_address" >"$driver_path/unbind"; then
+          rm -f "$state_file"
+          exit 1
+        fi
+      fi
+      printf '%s\n' "$pci_address" >>"$state_file"
+    done
+
+    if [[ ! -s $state_file ]]; then
+      rm -f "$state_file"
+      echo "No Apple BCM4350/BCM43602 Wi-Fi device found" >&2
+      exit 1
+    fi
+    ;;
+  post)
+    [[ -f $state_file ]] || exit 0
+    bind_failed=false
+
+    while IFS= read -r pci_address; do
+      [[ -n $pci_address ]] || continue
+      if [[ ! -e $device_root/$pci_address ]]; then
+        echo "Broadcom Wi-Fi device $pci_address disappeared" >&2
+        bind_failed=true
+        continue
+      fi
+      if [[ $(driver_name "$pci_address") != "brcmfmac" ]] &&
+        ! printf '%s' "$pci_address" >"$driver_path/bind"; then
+        echo "Failed to rebind Broadcom Wi-Fi device $pci_address" >&2
+        bind_failed=true
+      fi
+    done <"$state_file"
+
+    if [[ $bind_failed == true ]]; then
+      exit 1
+    fi
+
+    rm -f "$state_file"
+    ;;
+  *)
+    echo "Usage: omarchy-hw-brcmfmac-suspend <pre|post>" >&2
+    exit 2
+    ;;
+esac

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-suspend.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-brcmfmac-suspend.sh
+++ b/install/hardware/apple/fix-brcmfmac-suspend.sh
@@ -1,0 +1,20 @@
+# BCM4350 and BCM43602 firmware can stop answering after S3 resume on Apple
+# hardware. Once that happens, brcmfmac times out on ioctls, NetworkManager
+# cannot initialize its supplicant interface, and every scan fails until the
+# firmware is reinitialized.
+#
+# Unbind the device before sleep so its unreliable firmware power transition is
+# bypassed, then bind it after wake so NetworkManager gets a freshly initialized
+# radio. Keep this on the confirmed Apple BCM4350/BCM43602 PCI IDs instead of
+# resetting T2-era brcmfmac devices, which need the opposite treatment.
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+
+if [[ $sys_vendor == Apple* ]] &&
+  lspci -nn | grep -E "14e4:(43a3|43ba|43bb|43bc)" >/dev/null; then
+  echo "Detected Apple BCM4350/BCM43602 Wi-Fi; resetting its driver around sleep"
+
+  sudo install -Dm644 \
+    "$OMARCHY_PATH/install/hardware/apple/omarchy-brcmfmac-suspend.service" \
+    /etc/systemd/system/omarchy-brcmfmac-suspend.service
+  sudo systemctl enable omarchy-brcmfmac-suspend.service
+fi

--- a/install/hardware/apple/omarchy-brcmfmac-suspend.service
+++ b/install/hardware/apple/omarchy-brcmfmac-suspend.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Reset Broadcom Wi-Fi around sleep on affected Apple hardware
+Before=sleep.target
+StopWhenUnneeded=yes
+ConditionPathExists=/sys/bus/pci/drivers/brcmfmac
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/omarchy-hw-brcmfmac-suspend pre
+ExecStop=/usr/bin/omarchy-hw-brcmfmac-suspend post
+TimeoutStartSec=10s
+TimeoutStopSec=10s
+
+[Install]
+WantedBy=sleep.target

--- a/migrations/1787013338.sh
+++ b/migrations/1787013338.sh
@@ -1,0 +1,23 @@
+echo "Reset Apple BCM4350/BCM43602 Wi-Fi around sleep"
+
+# The installer only reaches new systems. Existing Apple BCM4350 and BCM43602
+# installs can leave the radio firmware unresponsive after resume, which also
+# makes later suspend attempts fail in brcmf_pcie_pm_enter_D3 until reboot.
+dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+service_source="${OMARCHY_BRCMFMAC_SUSPEND_SERVICE_SOURCE:-$OMARCHY_PATH/install/hardware/apple/omarchy-brcmfmac-suspend.service}"
+service_target="${OMARCHY_BRCMFMAC_SUSPEND_SERVICE_TARGET:-/etc/systemd/system/omarchy-brcmfmac-suspend.service}"
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if [[ $sys_vendor != Apple* ]] ||
+  ! lspci -nn | grep -E "14e4:(43a3|43ba|43bb|43bc)" >/dev/null; then
+  exit 0
+fi
+
+if ! cmp -s "$service_source" "$service_target"; then
+  sudo install -Dm644 "$service_source" "$service_target"
+fi
+
+if ! systemctl is-enabled --quiet omarchy-brcmfmac-suspend.service 2>/dev/null; then
+  sudo systemctl enable omarchy-brcmfmac-suspend.service
+fi

--- a/test/shell.d/brcmfmac-suspend-test.sh
+++ b/test/shell.d/brcmfmac-suspend-test.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-brcmfmac-suspend.sh"
+helper="$ROOT/bin/omarchy-hw-brcmfmac-suspend"
+service="$ROOT/install/hardware/apple/omarchy-brcmfmac-suspend.service"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1787013338.sh"
+
+grep -q 'apple/fix-brcmfmac-suspend.sh' "$all" ||
+  fail "the Broadcom suspend fix runs during hardware setup"
+grep -Fx 'Before=sleep.target' "$service" >/dev/null ||
+  fail "the Broadcom service detaches the device before sleep"
+grep -Fx 'StopWhenUnneeded=yes' "$service" >/dev/null ||
+  fail "the Broadcom service stops after the sleep transaction"
+grep -Fx 'ConditionPathExists=/sys/bus/pci/drivers/brcmfmac' "$service" >/dev/null ||
+  fail "the Broadcom service only runs when the driver is available"
+grep -Fx 'ExecStart=/usr/bin/omarchy-hw-brcmfmac-suspend pre' "$service" >/dev/null ||
+  fail "the Broadcom service runs the pre-sleep recovery helper"
+grep -Fx 'ExecStop=/usr/bin/omarchy-hw-brcmfmac-suspend post' "$service" >/dev/null ||
+  fail "the Broadcom service runs the post-wake recovery helper"
+grep -Fx 'WantedBy=sleep.target' "$service" >/dev/null ||
+  fail "the Broadcom service joins every sleep transaction"
+pass "the Broadcom service resets the driver around sleep"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+target="$test_tmp/etc/systemd/system/omarchy-brcmfmac-suspend.service"
+enabled="$test_tmp/enabled"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "03:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '00:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "is-enabled" ]]; then
+  [[ -e $ENABLED_MARKER ]]
+  exit
+fi
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+[[ $1 != "enable" ]] || touch "$ENABLED_MARKER"
+SH
+
+chmod +x "$stub_bin"/*
+
+driver_path="$test_tmp/sys/bus/pci/drivers/brcmfmac"
+device_root="$test_tmp/sys/bus/pci/devices"
+state_file="$test_tmp/run/omarchy-brcmfmac-suspend.devices"
+pci_address="0000:03:00.0"
+
+reset_pci() {
+  rm -rf "$device_root" "$driver_path" "$state_file"
+  mkdir -p "$device_root" "$driver_path"
+  : >"$driver_path/unbind"
+  : >"$driver_path/bind"
+}
+
+setup_device() {
+  local address="$1" device_id="$2"
+  mkdir -p "$device_root/$address" "$driver_path"
+  printf '0x14e4' >"$device_root/$address/vendor"
+  printf '%s' "$device_id" >"$device_root/$address/device"
+  ln -sfn "$device_root/$address" "$driver_path/$address"
+  ln -sfn "$driver_path" "$device_root/$address/driver"
+  : >"$driver_path/unbind"
+  : >"$driver_path/bind"
+}
+
+run_helper() {
+  OMARCHY_BRCMFMAC_DRIVER_PATH="$driver_path" \
+    OMARCHY_BRCMFMAC_DEVICE_ROOT="$device_root" \
+    OMARCHY_BRCMFMAC_SUSPEND_STATE="$state_file" \
+    "$helper" "$@"
+}
+
+reset_pci
+setup_device "$pci_address" "0x43ba"
+run_helper pre
+[[ $(<"$driver_path/unbind") == "$pci_address" ]] ||
+  fail "the pre-sleep helper unbinds the BCM43602 PCI device"
+[[ $(<"$state_file") == "$pci_address" ]] ||
+  fail "the pre-sleep helper records the device for wake"
+pass "the pre-sleep helper detaches the affected PCI device"
+
+rm -f "$driver_path/$pci_address" "$device_root/$pci_address/driver"
+run_helper post
+[[ $(<"$driver_path/bind") == "$pci_address" ]] ||
+  fail "the post-wake helper rebinds the BCM43602 PCI device"
+[[ ! -e $state_file ]] || fail "the post-wake helper clears its device state"
+pass "the post-wake helper reattaches the affected PCI device"
+
+missing_address="0000:04:00.0"
+printf '%s\n' "$missing_address" >"$state_file"
+if run_helper post 2>/dev/null; then
+  fail "the post-wake helper reports a missing PCI device"
+fi
+[[ -e $state_file ]] || fail "failed recovery keeps its device state for retry"
+rm -f "$state_file"
+pass "failed recovery remains visible and retryable"
+
+other_address="0000:02:00.0"
+reset_pci
+setup_device "$other_address" "0x4464"
+: >"$driver_path/unbind"
+if run_helper pre 2>/dev/null; then
+  fail "the pre-sleep helper rejects a T2-era Broadcom PCI device"
+fi
+[[ ! -s $driver_path/unbind ]] || fail "the pre-sleep helper leaves other devices bound"
+pass "the pre-sleep helper only detaches confirmed S3-dead chips"
+
+reset_pci
+setup_device "$pci_address" "0x43a3"
+run_helper pre
+[[ $(<"$driver_path/unbind") == "$pci_address" ]] ||
+  fail "the pre-sleep helper also detaches BCM4350"
+pass "the pre-sleep helper also detaches BCM4350"
+
+run_leaf() {
+  local vendor="$1" wifi_id="${2:-}"
+  local script="$test_tmp/leaf.sh"
+
+  rm -rf "$test_tmp/etc"
+  mkdir -p "$test_tmp/etc"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  sed \
+    -e "s|/sys/class/dmi/id/sys_vendor|$test_tmp/dmi/sys_vendor|g" \
+    -e "s|/etc/systemd/system/omarchy-brcmfmac-suspend.service|$target|g" \
+    "$leaf" >"$script"
+
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" ENABLED_MARKER="$enabled" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+for wifi_id in 43ba 43bb 43bc 43a3; do
+  run_leaf "Apple Inc." "$wifi_id" >/dev/null
+  cmp -s "$service" "$target" ||
+    fail "Apple setup installs the sleep service" "14e4:$wifi_id"
+  grep -Fq $'systemctl\tenable\tomarchy-brcmfmac-suspend.service' "$calls" ||
+    fail "Apple setup enables the sleep service" "$(cat "$calls")"
+done
+pass "Apple BCM4350/BCM43602 setup installs and enables the sleep service"
+
+run_leaf "Apple Inc." 4464 >/dev/null
+[[ ! -e $target ]] || fail "T2-era Apple Broadcom radios are left alone"
+[[ ! -s $calls ]] || fail "T2-era Apple Broadcom radios change no system state" "$(cat "$calls")"
+pass "T2-era Apple Broadcom radios are left alone"
+
+run_leaf "LENOVO" 43ba >/dev/null
+[[ ! -e $target ]] || fail "non-Apple BCM43602 hardware is left alone"
+[[ ! -s $calls ]] || fail "non-Apple BCM43602 hardware changes no system state" "$(cat "$calls")"
+pass "non-Apple BCM43602 hardware is left alone"
+
+run_migration() {
+  local vendor="$1" wifi_id="${2:-}"
+
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    ENABLED_MARKER="$enabled" OMARCHY_PATH="$ROOT" \
+    OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    OMARCHY_BRCMFMAC_SUSPEND_SERVICE_SOURCE="$service" \
+    OMARCHY_BRCMFMAC_SUSPEND_SERVICE_TARGET="$target" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc"
+rm -f "$enabled"
+run_migration "Apple Inc." 43ba
+cmp -s "$service" "$target" ||
+  fail "the migration installs the service on an existing Apple BCM43602 system"
+[[ -e $enabled ]] || fail "the migration enables the Broadcom sleep service"
+pass "the migration repairs an existing Apple BCM43602 system"
+
+run_migration "Apple Inc." 43ba
+[[ ! -s $calls ]] || fail "the migration is idempotent" "$(cat "$calls")"
+pass "the migration leaves a repaired system untouched"
+
+rm -rf "$test_tmp/etc"
+rm -f "$enabled"
+run_migration "Apple Inc." 4464
+[[ ! -e $target ]] || fail "the migration skips T2-era Apple Broadcom radios"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected hardware" "$(cat "$calls")"
+pass "the migration skips unaffected hardware"


### PR DESCRIPTION
## Summary

- Install a sleep service only on Apple systems with BCM4350 (`14e4:43a3`) or BCM43602 (`14e4:43ba` / `43bb` / `43bc`).
- Unbind that device from `brcmfmac` before sleep and bind it again after wake, forcing a clean firmware initialization.
- Add an idempotent migration for existing installs and tests for hardware gating, helper recovery, and installation.

This generalizes the approach in #7180, which already proved the unbind/bind cycle on BCM4350, so one service can cover both confirmed S3-dead chips. T2-era parts stay out of the allowlist: BCM4364 must remain bound, and BCM4377/4378/4387 have their own recovery path.

## Failure

Reproduced on a MacBookPro12,1 (Early 2015 13") running Omarchy 4.0.0-1, kernel 7.1.8, in-tree `brcmfmac` for BCM43602 (`14e4:43ba`, firmware `7.35.177.61`).

Closing the lid suspends (`deep` S3). After resume, the Wi-Fi toggle stays on and the network panel only shows DNS. The radio is enabled, but the firmware is dead:

```
platform-linux: do-change-link[2]: failure 5 (Input/output error)
device (wlp3s0): set-hw-addr: failed to set MAC address ... (scanning) (NME_UNSPEC)
device (wlp3s0): Couldn't initialize supplicant interface: Timeout was reached
ieee80211 phy0: brcmf_msgbuf_tx_ioctl: Failed to reserve space in commonring
ieee80211 phy0: brcmf_cfg80211_scan: scan error (-12)
```

Toggling the slider only flips rfkill/NetworkManager state. A reboot reinitializes the firmware and Wi-Fi works again. Same machine, same failure, on Omarchy 3 — this is not leftover Quattro UI.

#7180 recorded the same class of failure on MacBook10,1 / BCM4350, including a later suspend that then timed out in `brcmf_pcie_pm_enter_D3`.

## Approach

A `sleep.target` oneshot keeps the matching PCI device unbound for the sleep transaction, then binds it after wake so NetworkManager sees a freshly initialized radio. The helper also records an already-unbound matching device so a leftover cycle cannot block the next suspend.

Module unload was discarded in #7180 because udev immediately reloaded `brcmfmac` and an exploratory cycle coincided with a hard lock. This PR uses that same unbind/bind path.

The installer and migration no-op unless the machine is Apple and `lspci` shows one of the confirmed IDs.

## Testing

- `bash -n` on the helper, installer, migration, and test
- `test/shell.d/brcmfmac-suspend-test.sh`
- `test/shell.d/brcmfmac-supplicant-test.sh`
- `test/cli` (including command metadata for the new helper)

Live lid-close/resume of this service still needs a run on the MacBookPro12,1 that produced the logs. #7180 already completed that cycle on BCM4350 with the same unit ordering.

If this should land after #7180 instead of beside it, the BCM43602 IDs can be added there and this closed.