### PR TITLE
Inhibit idle for fullscreen Steam games

### DIFF
--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,4 +1,6 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
+o.window("steam_app_.*", { idle_inhibit = "fullscreen" })
+o.window("steam.app.*", { idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })

--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,6 +1,6 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
 o.window("steam_app_.*", { idle_inhibit = "fullscreen" })
-o.window("steam.app.*", { idle_inhibit = "fullscreen" })
+o.window("steam\\.app\\..*", { idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })


### PR DESCRIPTION
## Problem

Omarchy already sets `idle_inhibit = "fullscreen"` on the Steam **client**, RetroArch, Moonlight, and GeForce Now. Games launched from Steam are a different window class (`steam_app_<id>` on XWayland/Proton, `steam.app.<id>` on native Wayland Proton), so they never inhibit idle.

The idle monitor only counts keyboard and mouse. After the default 150s screensaver timeout, a controller-only session starts the screensaver (and later the lock) in the middle of a game. Any later input that Hyprland sees (DS4 touchpad-as-mouse, a translated button) dismisses it again.

Reproduced on Omarchy 4 with Dark Souls II (`steam_app_335300`) in exclusive fullscreen using a DualShock 4.

## Change

Add the same `idle_inhibit = "fullscreen"` rule for:

- `steam_app_.*` (Proton / most Steam games)
- `steam.app.*` (Proton with native Wayland)

Desktop Steam windows are unchanged. Windowed games do not hold the session awake.

## Test plan

- [x] `bash test/shell.d/hyprland-default-config-test.sh`
- [x] Launch a Steam game fullscreen, leave keyboard/mouse untouched, use only a gamepad for >150s — screensaver should not start
- [x] Quit the game — idle/screensaver should work again as before