### PR TITLE
Re-detect Apple display when cached hiddev node stops responding

### DIFF
--- a/bin/omarchy-brightness-display-apple
+++ b/bin/omarchy-brightness-display-apple
@@ -86,9 +86,13 @@ if [[ $step =~ ^([0-9]+)%-$ ]]; then
   step="-${BASH_REMATCH[1]}%"
 fi
 
-if ! sudo asdcontrol "$device" -- "$step" >/dev/null; then
+# asdcontrol exits 0 against a hiddev node that is no longer the display
+# (interfaces renumber when the display replugs), so a brightness read is the
+# only reliable check that the cached device still works.
+if ! sudo asdcontrol "$device" -- "$step" >/dev/null || ! brightness="$(current_brightness "$device")"; then
   retry_with_fresh_device
   sudo asdcontrol "$device" -- "$step" >/dev/null
+  brightness="$(current_brightness "$device")"
 fi
 
-(( no_osd )) || omarchy-osd -i brightness -p "$(current_brightness "$device")"
+(( no_osd )) || omarchy-osd -i brightness -p "$brightness"


### PR DESCRIPTION
## Description

`omarchy-brightness-display-apple` caches the display's hiddev node in `$XDG_RUNTIME_DIR` but only validates that the cached path still exists. When the display replugs mid-session, its USB interfaces renumber and the old node gets backfilled by one of the display's other HID interfaces. `asdcontrol` exits 0 against that node without doing anything, so the existing retry never fires and every brightness key press silently no-ops until reboot.

This verifies the write with a brightness read and falls back to fresh detection when the read fails. The OSD path already performed this read after every adjustment — it now happens before the OSD call so its exit status gets checked, adding no extra `asdcontrol` calls there. `--no-osd` gains one read.

## Reproduction

Hit organically on a Studio Display (2022, 27") after a Thunderbolt replug — the journal showed key presses driving `asdcontrol /dev/usb/hiddev3` while the display had moved to `hiddev2`. To reproduce directly, point the cache at any hiddev node that is not the display:

```
echo /dev/usb/hiddev0 > "$XDG_RUNTIME_DIR/omarchy-brightness-display-apple.device"
omarchy-brightness-display-apple --no-osd 50%
```

Before: exits 0, brightness unchanged, cache still stale. After: re-detects, repairs the cache, brightness changes.

## Verification

- Reproduced as above; patched script self-heals, stock script stays wedged.
- `./test/all` shows the same 3 pre-existing local-environment failures on clean master and this branch — no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)