### PR TITLE
Remove redundant tmux escape-time setting

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -69,7 +69,6 @@ set -g base-index 1
 setw -g pane-base-index 1
 set -g renumber-windows on
 set -g history-limit 50000
-set -g escape-time 0
 set -g focus-events on
 set -g set-clipboard on
 set -g allow-passthrough on


### PR DESCRIPTION
### Why
`config/tmux/tmux.conf` sets `escape-time` twice: first to `0`, then to `10` later in the same file. The second assignment takes precedence, so the earlier setting has no effect and leaves conflicting values in the configuration.

### What
Remove the redundant assignment and keep `set -sg escape-time 10` as the single setting.

### Verified
Verified by loading the config with tmux 3.6a and confirming `show-options -s escape-time` reports `escape-time 10`. 