### PR TITLE
Stop forcing hid_apple fnmode=2 on Apple keyboards

### DIFF
--- a/install/hardware/fix-fkeys.sh
+++ b/install/hardware/fix-fkeys.sh
@@ -1,5 +1,21 @@
-# Ensure that F-keys on Apple-like keyboards (such as Lofree Flow84) are always F-keys
-if [[ ! -f /etc/modprobe.d/hid_apple.conf ]]; then
-  sudo mkdir -p /etc/modprobe.d
-  echo "options hid_apple fnmode=2" | sudo tee /etc/modprobe.d/hid_apple.conf >/dev/null
+# hid_apple fnmode=3 (auto) already uses fkeysfirst for boards the kernel flags
+# APPLE_IS_NON_APPLE (Keychron, SONiX, and similar). Lofree Flow84 is not on
+# that list: in Mac mode it binds hid_apple and otherwise keeps media keys on
+# the top row, so non-Apple machines still need fnmode=2.
+#
+# Do not write that globally. On genuine Apple/T2 hardware it switches MacBook
+# internals and Magic Keyboard from fkeyslast (media/brightness without Fn) to
+# fkeysfirst, which contradicts the Mac docs.
+
+dmi_vendor="${OMARCHY_HID_APPLE_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+conf="${OMARCHY_HID_APPLE_CONF:-/etc/modprobe.d/hid_apple.conf}"
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if [[ $sys_vendor == Apple* ]]; then
+  if [[ -f $conf && $(<"$conf") == "options hid_apple fnmode=2" ]]; then
+    sudo rm -f "$conf"
+  fi
+elif [[ ! -f $conf ]]; then
+  sudo mkdir -p "$(dirname "$conf")"
+  echo "options hid_apple fnmode=2" | sudo tee "$conf" >/dev/null
 fi

--- a/migrations/1787019665.sh
+++ b/migrations/1787019665.sh
@@ -1,0 +1,27 @@
+echo "Stop forcing hid_apple fnmode=2 on genuine Apple keyboards"
+
+# install/hardware/fix-fkeys.sh used to write this on every machine. Auto
+# (fnmode=3) already gives APPLE_IS_NON_APPLE boards fkeysfirst, but Lofree
+# Flow84 is not on that list, so non-Apple installs keep the drop-in. Apple/T2
+# hardware must go back to the kernel default so media keys work without Fn.
+
+dmi_vendor="${OMARCHY_HID_APPLE_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+conf="${OMARCHY_HID_APPLE_CONF:-/etc/modprobe.d/hid_apple.conf}"
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+[[ $sys_vendor == Apple* ]] || exit 0
+[[ -f $conf ]] || exit 0
+[[ $(<"$conf") == "options hid_apple fnmode=2" ]] || exit 0
+
+sudo rm -f "$conf"
+
+# T2 bakes hid_apple into the initramfs, so deleting the live drop-in is not
+# enough until that image is rebuilt. Other Apple machines load hid_apple later
+# and only need a reboot.
+if lspci -nn | grep "106b:180[12]" >/dev/null; then
+  if omarchy-cmd-present limine-mkinitcpio; then
+    sudo limine-mkinitcpio
+  fi
+fi
+
+omarchy-state set reboot-required

--- a/test/shell.d/fix-fkeys-test.sh
+++ b/test/shell.d/fix-fkeys-test.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/fix-fkeys.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1787019665.sh"
+
+grep -q 'hardware/fix-fkeys.sh' "$all" ||
+  fail "F-key hid_apple setup still runs during hardware setup"
+! grep -q 'fnmode=2' "$ROOT/install/hardware/apple/fix-t2.sh" ||
+  fail "T2 setup does not own hid_apple fnmode"
+pass "F-key hid_apple setup has a single owner and runs during setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+conf="$test_tmp/etc/modprobe.d/hid_apple.conf"
+dmi_vendor="$test_tmp/dmi/sys_vendor"
+mkdir -p "$stub_bin" "$test_tmp/dmi" "$(dirname "$conf")"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+[[ $1 == limine-mkinitcpio ]] && (( ${LIMINE_MKINITCPIO:-1} == 1 ))
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local vendor="$1"
+  local existing="${2-}"
+  rm -rf "$test_tmp/etc"
+  mkdir -p "$(dirname "$conf")"
+  printf '%s' "$vendor" >"$dmi_vendor"
+  if [[ -n $existing ]]; then
+    printf '%s' "$existing" >"$conf"
+  fi
+
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_HID_APPLE_DMI_VENDOR="$dmi_vendor" \
+    OMARCHY_HID_APPLE_CONF="$conf" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf" </dev/null
+}
+
+run_migration() {
+  local vendor="$1"
+  printf '%s' "$vendor" >"$dmi_vendor"
+  : >"$calls"
+
+  T2_HARDWARE="${T2_HARDWARE:-0}" LIMINE_MKINITCPIO="${LIMINE_MKINITCPIO:-1}" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_HID_APPLE_DMI_VENDOR="$dmi_vendor" \
+    OMARCHY_HID_APPLE_CONF="$conf" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_leaf "LENOVO"
+[[ -f $conf ]] || fail "a non-Apple machine still gets the Lofree drop-in"
+grep -qx 'options hid_apple fnmode=2' "$conf" ||
+  fail "the non-Apple drop-in is the hid_apple fnmode=2 line" "$(cat "$conf")"
+pass "a non-Apple machine still gets the Lofree drop-in"
+
+run_leaf "QEMU"
+[[ -f $conf ]] || fail "a VM without Apple DMI still gets the drop-in"
+pass "a VM without Apple DMI still gets the drop-in"
+
+run_leaf "Apple Inc."
+[[ ! -f $conf ]] || fail "an Apple machine is left on kernel default" "$(cat "$conf")"
+pass "an Apple machine is left on kernel default"
+
+run_leaf "Apple Computer, Inc."
+[[ ! -f $conf ]] || fail "the older Apple vendor string is recognized"
+pass "the older Apple vendor string is recognized"
+
+run_leaf "Apple Inc." $'options hid_apple fnmode=2\n'
+[[ ! -e $conf ]] || fail "apply-hardware removes the stock Apple drop-in" "$(cat "$conf")"
+pass "apply-hardware removes the stock Apple drop-in"
+
+run_leaf "Apple Inc." $'options hid_apple fnmode=2\noptions hid_apple iso_layout=1\n'
+grep -qx 'options hid_apple fnmode=2' "$conf" ||
+  fail "a customized hid_apple.conf is left alone" "$(cat "$conf")"
+pass "a customized hid_apple.conf is left alone"
+
+run_leaf "LENOVO" $'options hid_apple swap_opt_cmd=1\n'
+grep -qx 'options hid_apple swap_opt_cmd=1' "$conf" ||
+  fail "an existing non-Apple hid_apple.conf is not overwritten" "$(cat "$conf")"
+! grep -q 'fnmode=2' "$conf" ||
+  fail "an existing non-Apple hid_apple.conf is not appended to" "$(cat "$conf")"
+pass "an existing non-Apple hid_apple.conf is left untouched"
+
+# Installs that predate the gate already have the drop-in.
+printf 'options hid_apple fnmode=2\n' >"$conf"
+T2_HARDWARE=0 run_migration "Apple Inc."
+[[ ! -e $conf ]] || fail "the migration removes the stock Apple drop-in" "$(cat "$conf")"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the reboot that applies it" "$(cat "$calls")"
+! grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "a non-T2 Apple machine does not rebuild the boot image" "$(cat "$calls")"
+pass "the migration removes the stock drop-in on Apple hardware"
+
+printf 'options hid_apple fnmode=2\n' >"$conf"
+T2_HARDWARE=1 run_migration "Apple Inc."
+[[ ! -e $conf ]] || fail "the migration removes the stock T2 drop-in" "$(cat "$conf")"
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "a T2 Mac rebuilds the initramfs that bakes in hid_apple" "$(cat "$calls")"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "a T2 Mac still asks for a reboot" "$(cat "$calls")"
+pass "the migration rebuilds the T2 initramfs after removing the drop-in"
+
+printf 'options hid_apple fnmode=2\n' >"$conf"
+T2_HARDWARE=1 LIMINE_MKINITCPIO=0 run_migration "Apple Inc."
+[[ ! -e $conf ]] || fail "the migration still removes the drop-in without limine-mkinitcpio"
+! grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "a missing limine-mkinitcpio is not invoked" "$(cat "$calls")"
+pass "the T2 rebuild is skipped when limine-mkinitcpio is absent"
+
+printf 'options hid_apple fnmode=2\n' >"$conf"
+: >"$calls"
+T2_HARDWARE=0 run_migration "Apple Inc."
+T2_HARDWARE=0 run_migration "Apple Inc."
+[[ ! -e $conf ]] || fail "a second migration run keeps the file gone"
+[[ ! -s $calls ]] || fail "an already repaired Apple install is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+printf 'options hid_apple fnmode=2\noptions hid_apple iso_layout=1\n' >"$conf"
+T2_HARDWARE=0 run_migration "Apple Inc."
+grep -qx 'options hid_apple fnmode=2' "$conf" ||
+  fail "the migration keeps a customized Apple hid_apple.conf" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "a customized Apple config escalates nothing" "$(cat "$calls")"
+pass "the migration leaves a customized Apple hid_apple.conf alone"
+
+printf 'options hid_apple fnmode=2\n' >"$conf"
+T2_HARDWARE=0 run_migration "LENOVO"
+grep -qx 'options hid_apple fnmode=2' "$conf" ||
+  fail "the migration keeps the Lofree drop-in on non-Apple hardware" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "non-Apple hardware escalates nothing" "$(cat "$calls")"
+pass "the migration leaves non-Apple hardware on fnmode=2"

--- a/test/shell.d/fix-fkeys-test.sh
+++ b/test/shell.d/fix-fkeys-test.sh
@@ -5,13 +5,16 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 leaf="$ROOT/install/hardware/fix-fkeys.sh"
+fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
 all="$ROOT/install/hardware/all.sh"
 migration="$ROOT/migrations/1787019665.sh"
 
 grep -q 'hardware/fix-fkeys.sh' "$all" ||
   fail "F-key hid_apple setup still runs during hardware setup"
-! grep -q 'fnmode=2' "$ROOT/install/hardware/apple/fix-t2.sh" ||
+[[ -f $fix_t2 ]] || fail "T2 setup script is present"
+if grep -q 'fnmode=2' "$fix_t2"; then
   fail "T2 setup does not own hid_apple fnmode"
+fi
 pass "F-key hid_apple setup has a single owner and runs during setup"
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
Fixes https://github.com/basecamp/omarchy/issues/7110

`install/hardware/fix-fkeys.sh` wrote `options hid_apple fnmode=2` on every install. That flips genuine Apple/T2 keyboards from the kernel default (`fnmode=3` / auto → fkeyslast: media, brightness, and volume on the top row) to fkeysfirst, so those keys need Fn. That contradicts the Mac docs.

The issue hypothesized that the drop-in is a no-op for the keyboards it names (Lofree Flow84) because auto already maps `APPLE_IS_NON_APPLE` to mode 2. The kernel source says otherwise: `drivers/hid/hid-apple.c`'s `non_apple_keyboards[]` includes Keychron, SONiX, GANSS, Hailuck, and similar clones, but not Lofree. In Mac mode, Flow84 binds `hid_apple` and otherwise keeps media keys on the top row, which is why community Lofree fixes still set `fnmode=2`. Removing the drop-in globally would regress those boards.

This keeps the drop-in on non-Apple machines and skips (and, for the stock one-line file, removes) it when DMI vendor is Apple, including T2 Macs.

## Changes
- Gate `install/hardware/fix-fkeys.sh` on `sys_vendor == Apple*`
- Migration `1787019665.sh` removes the stock drop-in on existing Apple/T2 installs, rebuilds the T2 initramfs (it bakes in `hid_apple`), and sets reboot-required
- Custom `hid_apple.conf` files are left alone
- Shell tests cover the leaf and the migration

## Done when
- Genuine Apple/T2 keyboards keep media keys without holding Fn
- Third-party Apple-like boards that still need fkeysfirst (Lofree Flow84) still get `fnmode=2` on non-Apple machines