### PR TITLE
Add the task manager shell plugin

### DIFF
--- a/default/hypr/apps/omarchy-shell.lua
+++ b/default/hypr/apps/omarchy-shell.lua
@@ -12,3 +12,12 @@ hl.layer_rule({ match = { namespace = "^(omarchy-menu|omarchy-image-selector|oma
 -- Dev gallery is the main shell workbench; open it maximized like
 -- SUPER+ALT+F so component previews have the whole workspace.
 o.window({ class = "^org.quickshell$", title = "^Omarchy shell – dev gallery$" }, { maximize = true })
+
+-- Task manager is a real toplevel so it can be dragged and stacked like any
+-- other window, but it is a tool you summon over your work rather than a pane
+-- you live in, so it floats centred instead of claiming a tile.
+o.window({ class = "^org.quickshell$", title = "^Task Manager$" }, {
+  float = true,
+  center = true,
+  size = { 1180, 820 },
+})

--- a/shell/plugins/omatask/BarWidget.qml
+++ b/shell/plugins/omatask/BarWidget.qml
@@ -24,7 +24,10 @@ Panel {
   }
 
   moduleName: "omarchy.omatask"
-  ipcTarget: "omarchy.omatask"
+  // Written once and bound everywhere else. Three copies of this string is how
+  // a rename gets partially applied — which already happened once here, leaving
+  // ipcTarget naming a target no handler answered on.
+  ipcTarget: moduleName
   // The base Panel would register its own handler for that target; this widget
   // owns the single allowed one so it can add expand() alongside the standard
   // open/close/toggle.
@@ -197,7 +200,7 @@ Panel {
   }
 
   IpcHandler {
-    target: "omarchy.omatask"
+    target: root.ipcTarget
 
     function open(): void { root.open() }
     function close(): void { root.close() }

--- a/shell/plugins/omatask/BarWidget.qml
+++ b/shell/plugins/omatask/BarWidget.qml
@@ -1,0 +1,545 @@
+import QtQuick
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+import "Model.js" as Model
+
+// Bar widget plus its under-bar panel. The widget paints a live CPU history
+// graph in the bar itself; clicking drops the panel below it with per-core
+// meters, memory, I/O, and the busiest processes. The full process table lives
+// in the overlay, one click further in.
+Panel {
+  id: root
+
+  // Dimming has to know what it is dimming *against*. dim() only reads as
+  // "less prominent" on a dark ground; on a light theme it makes secondary text
+  // darker — and therefore louder — than the primary text it sits behind. This
+  // moves toward the background either way.
+  readonly property bool groundIsDark: {
+    var g = (root.bar ? root.bar.background : Color.popups.background)
+    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
+  }
+  function dim(c, amount) {
+    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
+  }
+
+  moduleName: "omarchy.omatask"
+  ipcTarget: "omatask"
+  // The base Panel would register its own handler for that target; this widget
+  // owns the single allowed one so it can add expand() alongside the standard
+  // open/close/toggle.
+  manageIpc: false
+
+  readonly property var service: bar && bar.shell ? bar.shell.serviceFor(moduleName) : null
+
+  readonly property int intervalSec: Math.max(1, Number(setting("intervalSec", 2)) || 2)
+  readonly property int historyPoints: Math.max(10, Number(setting("historyPoints", 60)) || 60)
+  readonly property int processLimit: Math.max(10, Number(setting("processLimit", 60)) || 60)
+  readonly property bool showPercent: setting("showPercent", true) === true
+  readonly property bool alerts: setting("alerts", false) === true
+  readonly property bool groupApps: setting("groupApps", true) === true
+  readonly property string listMode: String(setting("listMode", "processes"))
+  readonly property string sortBy: String(setting("sortBy", "cpu"))
+  readonly property bool sortDescending: setting("sortDescending", true) === true
+  readonly property string barGraph: String(setting("barGraph", "sparkline"))
+
+  // How many samples the in-bar graph shows. Deliberately shorter than the
+  // panel's history: at 30px wide, sixty points is noise.
+  readonly property int barPoints: 24
+  readonly property int panelProcessCount: 8
+
+  property int cursorIndex: -1
+  property bool cursorActive: false
+
+  readonly property real cpuPercent: service ? service.cpuPercent : 0
+  readonly property var panelProcesses: {
+    if (!service) return []
+    var rows = service.processes || []
+    return rows.slice(0, root.panelProcessCount)
+  }
+
+  // Push settings down into the shared sampler. The widget owns the shell.json
+  // entry, so it is the only surface that knows what the user configured.
+  function syncService() {
+    if (!service) return
+    service.intervalSec = intervalSec
+    service.historyPoints = historyPoints
+    service.processLimit = processLimit
+    service.alertsEnabled = alerts
+    service.groupApps = groupApps
+    service.listMode = listMode
+    service.sortBy = sortBy
+    service.sortDescending = sortDescending
+    // Hand over the whole entry so the service can merge into it when a
+    // preference changes from the overlay, which has no access to shell.json.
+    service.widgetSettings = settings || ({})
+  }
+
+  onServiceChanged: syncService()
+  onIntervalSecChanged: syncService()
+  onHistoryPointsChanged: syncService()
+  onProcessLimitChanged: syncService()
+  onAlertsChanged: syncService()
+  onGroupAppsChanged: syncService()
+  onListModeChanged: syncService()
+  onSortByChanged: syncService()
+  onSortDescendingChanged: syncService()
+  // The bar host injects `settings` after construction, so a preference read
+  // at Component.onCompleted would still be the default. Re-sync whenever the
+  // entry itself changes — including when this widget writes back to it.
+  onSettingsChanged: syncService()
+  Component.onCompleted: syncService()
+
+  // The sampler skips the process walk unless something is showing it.
+  onOpenedChanged: {
+    if (!service) return
+    if (opened) {
+      service.retainProcesses()
+      service.retainGpu()
+      cursorIndex = -1
+      cursorActive = false
+    } else {
+      service.releaseProcesses()
+      service.releaseGpu()
+    }
+  }
+
+    Component.onDestruction: {
+    if (!service || !opened) return
+    service.releaseProcesses()
+    service.releaseGpu()
+  }
+
+  function expand() {
+    close()
+    if (bar && bar.shell) bar.shell.summon(moduleName, "{}")
+  }
+
+  function moveCursor(delta) {
+    var count = panelProcesses.length
+    if (count === 0) return
+    if (!cursorActive) {
+      cursorActive = true
+      cursorIndex = 0
+      return
+    }
+    cursorIndex = Math.max(0, Math.min(count - 1, cursorIndex + delta))
+  }
+
+  function killCursor(signalName) {
+    if (!service || cursorIndex < 0 || cursorIndex >= panelProcesses.length) return
+    service.killProcess(panelProcesses[cursorIndex].pid, signalName)
+  }
+
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  // ------------------------------------------------------------ bar button
+
+  WidgetButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    labelVisible: false
+    hasVisualContent: true
+    tooltipText: root.service && root.service.ready
+      ? "CPU " + Model.formatPercent(root.cpuPercent) + " · MEM " + Model.formatPercent(root.service.memPercent)
+      : "Task Manager"
+
+    // Vertical bars have no room for a history graph, so they fall back to the
+    // percentage alone — the same compromise the media widget makes.
+    readonly property bool graphVisible: !vertical && root.barGraph !== "none"
+    readonly property real graphWidth: graphVisible ? Style.space(34) : 0
+
+    fixedWidth: vertical ? -1 : graphWidth + (root.showPercent ? percentLabel.implicitWidth + Style.space(5) : 0) + Style.space(10)
+    fixedHeight: vertical ? Style.bar.iconSlot : -1
+
+    onPressed: function(mouseButton) {
+      if (mouseButton === Qt.RightButton) root.expand()
+      else root.toggle()
+    }
+
+    Row {
+      anchors.centerIn: parent
+      spacing: Style.space(5)
+
+      Sparkline {
+        id: barGraphCanvas
+        visible: button.graphVisible
+        width: button.graphWidth
+        height: Math.max(Style.space(9), button.barSize - Style.space(14))
+        anchors.verticalCenter: parent.verticalCenter
+        values: root.service ? root.service.cpuHistory.slice(-root.barPoints) : []
+        capacity: root.barPoints
+        maxValue: 100
+        bars: root.barGraph === "bars"
+        stroke: root.cpuPercent >= 85 ? button.activeColor : button.foreground
+        lineWidth: 1
+        fillOpacity: 0.22
+        barGap: 1
+      }
+
+      Text {
+        id: percentLabel
+        visible: root.showPercent || button.vertical
+        anchors.verticalCenter: parent.verticalCenter
+        text: Math.round(root.cpuPercent) + (button.vertical ? "" : "%")
+        color: root.cpuPercent >= 85 ? button.activeColor : button.foreground
+        font.family: button.fontFamily
+        font.pixelSize: Style.bar.iconFont
+        renderType: Text.NativeRendering
+      }
+    }
+  }
+
+  IpcHandler {
+    target: "omarchy.omatask"
+
+    function open(): void { root.open() }
+    function close(): void { root.close() }
+    function toggle(): void { root.toggle() }
+    function expand(): void { root.expand() }
+  }
+
+  // ----------------------------------------------------------- under-bar panel
+
+  KeyboardPanel {
+    id: panel
+    anchorItem: button
+    owner: root
+    bar: root.bar
+    open: root.opened
+    focusTarget: keys
+    contentWidth: panel.fittedContentWidth(Style.space(440))
+    contentHeight: panel.fittedContentHeight(column.implicitHeight)
+
+    PanelKeyCatcher {
+      id: keys
+      anchors.fill: parent
+      onMoveRequested: function(dx, dy) { if (dy !== 0) root.moveCursor(dy) }
+      onActivateRequested: root.expand()
+      onDeleteRequested: root.killCursor("TERM")
+      onCloseRequested: root.close()
+      onTabRequested: function(direction) { root.switchPanel(direction) }
+
+      Column {
+        id: column
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        spacing: Style.space(12)
+
+        // ---------- CPU ----------
+        Item {
+          width: parent.width
+          implicitHeight: Math.max(cpuLabels.implicitHeight, cpuValue.implicitHeight)
+
+          Column {
+            id: cpuLabels
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(1)
+
+            Text {
+              text: "CPU"
+              color: root.bar.foreground
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.title
+              font.bold: true
+            }
+
+            Text {
+              text: {
+                var service = root.service
+                if (!service || !service.ready) return "SAMPLING…"
+                var load = service.loadAverage
+                var parts = [service.coreCount + " THREADS"]
+                if (service.hasCpuTemp) parts.push(Math.round(service.cpuTemp) + "°C")
+                parts.push("LOAD " + Number(load[0]).toFixed(2) + " " + Number(load[1]).toFixed(2))
+                return parts.join(" · ")
+              }
+              color: dim(root.bar.foreground, 1.4)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+              font.bold: true
+              font.letterSpacing: 1.0
+            }
+          }
+
+          Text {
+            id: cpuValue
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            text: root.cpuPercent.toFixed(1) + "%"
+            color: root.cpuPercent >= 85 ? root.bar.urgent : root.bar.foreground
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.displayLarge
+            font.bold: true
+
+            Behavior on color { ColorAnimation { duration: 200 } }
+          }
+        }
+
+        Sparkline {
+          width: parent.width
+          height: Style.space(52)
+          values: root.service ? root.service.cpuHistory : []
+          capacity: root.historyPoints
+          maxValue: 100
+          stroke: root.bar.foreground
+          showBaseline: true
+        }
+
+        CoreGrid {
+          ground: root.bar.background
+          width: parent.width
+          cores: root.service ? root.service.cores : []
+          foreground: root.bar.foreground
+          fill: root.bar.foreground
+          hotColor: root.bar.urgent
+          rowHeight: Style.space(22)
+        }
+
+        // ---------- Memory ----------
+        PanelSeparator { foreground: root.bar.foreground }
+
+        Meter {
+          ground: root.bar.background
+          width: parent.width
+          label: "MEMORY"
+          value: root.service
+            ? Model.formatBytes(root.service.memUsed) + " / " + Model.formatBytes(root.service.memTotal)
+            : ""
+          fraction: root.service ? root.service.memPercent / 100 : 0
+          foreground: root.bar.foreground
+          fill: root.service && root.service.memPercent >= 90 ? root.bar.urgent : root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Meter {
+          ground: root.bar.background
+          width: parent.width
+          // Plenty of Omarchy machines run zram or no swap at all; an empty
+          // meter would just be a permanently dead row.
+          visible: root.service && root.service.swapTotal > 0
+          label: "SWAP"
+          value: root.service
+            ? Model.formatBytes(root.service.swapUsed) + " / " + Model.formatBytes(root.service.swapTotal)
+            : ""
+          fraction: root.service ? root.service.swapPercent / 100 : 0
+          foreground: root.bar.foreground
+          fill: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          compact: true
+        }
+
+        // ---------- GPU ----------
+        // Hidden outright when nothing readable is present, so machines with
+        // no discrete GPU don't carry a dead row.
+        PanelSeparator {
+          foreground: root.bar.foreground
+          visible: root.service && root.service.hasGpu
+        }
+
+        Meter {
+          ground: root.bar.background
+          width: parent.width
+          visible: root.service && root.service.hasGpu
+          label: "GPU"
+          value: root.service && root.service.hasGpu
+            ? Math.round(root.service.gpuPercent) + "% · "
+              + Model.formatBytes(root.service.gpuMemUsed) + " / "
+              + Model.formatBytes(root.service.gpuMemTotal)
+            : ""
+          fraction: root.service ? root.service.gpuPercent / 100 : 0
+          foreground: root.bar.foreground
+          fill: root.service && root.service.gpuPercent >= 85 ? root.bar.urgent : root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Meter {
+          ground: root.bar.background
+          width: parent.width
+          visible: root.service && root.service.hasGpu
+          label: "VRAM"
+          value: {
+            if (!root.service || !root.service.hasGpu) return ""
+            var device = root.service.primaryGpu
+            var parts = [Math.round(root.service.gpuMemPercent) + "%"]
+            if (device.temp !== null && device.temp !== undefined) parts.push(device.temp + "°C")
+            if (device.power !== null && device.power !== undefined) parts.push(device.power + "W")
+            return parts.join(" · ")
+          }
+          fraction: root.service ? root.service.gpuMemPercent / 100 : 0
+          foreground: root.bar.foreground
+          fill: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          compact: true
+        }
+
+        // ---------- I/O ----------
+        PanelSeparator { foreground: root.bar.foreground }
+
+        Row {
+          width: parent.width
+          spacing: Style.space(16)
+
+          IoReadout {
+            width: (parent.width - parent.spacing) / 2
+            label: "NETWORK"
+            down: root.service ? Model.formatRate(root.service.net.rx) : "—"
+            up: root.service ? Model.formatRate(root.service.net.tx) : "—"
+          }
+
+          IoReadout {
+            width: (parent.width - parent.spacing) / 2
+            label: "DISK"
+            down: root.service ? Model.formatRate(root.service.disk.read) : "—"
+            up: root.service ? Model.formatRate(root.service.disk.write) : "—"
+          }
+        }
+
+        // ---------- Processes ----------
+        PanelSeparator { foreground: root.bar.foreground }
+
+        Item {
+          width: parent.width
+          implicitHeight: processHeader.implicitHeight
+
+          PanelSectionHeader {
+            id: processHeader
+            anchors.left: parent.left
+            text: "TOP PROCESSES"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Text {
+            anchors.right: parent.right
+            anchors.baseline: processHeader.baseline
+            text: root.service && root.service.ready
+              ? root.service.processCount + " PROCS · " + root.service.threadCount + " THREADS"
+              : ""
+            color: dim(root.bar.foreground, 1.6)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+            font.letterSpacing: 0.8
+          }
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(1)
+
+          Repeater {
+            model: root.panelProcesses
+
+            ProcessRow {
+              ground: root.bar.background
+              required property var modelData
+              required property int index
+
+              process: modelData
+              machineCapacity: root.service ? Math.max(1, root.service.coreCount) * 100 : 100
+              selected: root.cursorActive && root.cursorIndex === index
+              foreground: root.bar.foreground
+              accent: root.bar.foreground
+              urgent: root.bar.urgent
+              fontFamily: root.bar.fontFamily
+              onActivated: {
+                root.cursorActive = true
+                root.cursorIndex = index
+              }
+              onKillRequested: function(signalName) {
+                if (root.service) root.service.killProcess(modelData.pid, signalName)
+              }
+            }
+          }
+
+          Text {
+            visible: root.panelProcesses.length === 0
+            width: parent.width
+            height: Style.spacing.popupRowHeight
+            verticalAlignment: Text.AlignVCenter
+            text: "Waiting for the first sample…"
+            color: dim(root.bar.foreground, 1.6)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.bodySmall
+          }
+        }
+
+        // ---------- Footer ----------
+        PanelSeparator { foreground: root.bar.foreground }
+
+        Item {
+          width: parent.width
+          implicitHeight: expandButton.implicitHeight
+
+          Text {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            // The panel is the glance surface, so it carries a fact rather
+            // than an instruction list; the ✕ appears on hover and the full
+            // key legend lives behind `?` in the overlay.
+            text: root.service && root.service.ready
+              ? "UP " + Model.formatUptime(root.service.uptime)
+              : ""
+            color: dim(root.bar.foreground, 1.7)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            font.letterSpacing: 0.6
+            elide: Text.ElideRight
+            width: parent.width - expandButton.width - Style.space(10)
+          }
+
+          Button {
+            id: expandButton
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            text: "Expand"
+            iconText: "⤢"
+            iconSize: Style.font.body
+            fontSize: Style.font.bodySmall
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            horizontalPadding: Style.spacing.controlPaddingX
+            verticalPadding: Style.spacing.controlPaddingY
+            bordered: true
+            onClicked: root.expand()
+          }
+        }
+      }
+    }
+  }
+
+  // Two-line down/up readout, used for both network and disk so the pair reads
+  // as one unit rather than two differently-shaped blocks.
+  component IoReadout: Column {
+    property string label: ""
+    property string down: ""
+    property string up: ""
+
+    spacing: Style.spacing.labelGap
+
+    PanelSectionHeader {
+      text: parent.label
+      foreground: root.bar.foreground
+      fontFamily: root.bar.fontFamily
+    }
+
+    Text {
+      text: "↓ " + parent.down
+      color: root.bar.foreground
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.bodySmall
+    }
+
+    Text {
+      text: "↑ " + parent.up
+      color: dim(root.bar.foreground, 1.3)
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.bodySmall
+    }
+  }
+}

--- a/shell/plugins/omatask/BarWidget.qml
+++ b/shell/plugins/omatask/BarWidget.qml
@@ -15,13 +15,8 @@ Panel {
   // "less prominent" on a dark ground; on a light theme it makes secondary text
   // darker — and therefore louder — than the primary text it sits behind. This
   // moves toward the background either way.
-  readonly property bool groundIsDark: {
-    var g = (root.bar ? root.bar.background : Color.popups.background)
-    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
-  }
-  function dim(c, amount) {
-    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
-  }
+  readonly property bool groundIsDark: Model.groundIsDark((root.bar ? root.bar.background : Color.popups.background))
+  function dim(c, amount) { return Model.dim((root.bar ? root.bar.background : Color.popups.background), c, amount) }
 
   moduleName: "omarchy.omatask"
   // Written once and bound everywhere else. Three copies of this string is how

--- a/shell/plugins/omatask/BarWidget.qml
+++ b/shell/plugins/omatask/BarWidget.qml
@@ -44,6 +44,14 @@ Panel {
   readonly property string sortBy: String(setting("sortBy", "cpu"))
   readonly property bool sortDescending: setting("sortDescending", true) === true
   readonly property string barGraph: String(setting("barGraph", "sparkline"))
+  // Checked here rather than trusted: `omarchy bar set` writes whatever value
+  // it is handed straight into shell.json without consulting the manifest
+  // schema, so a typo arrives intact. An unrecognised metric reads as off,
+  // instead of falling through to memory and captioning it wrongly.
+  readonly property string secondaryMetric: {
+    var value = String(setting("secondaryMetric", "none"))
+    return ["mem", "swap", "gpu"].indexOf(value) >= 0 ? value : "none"
+  }
 
   // How many samples the in-bar graph shows. Deliberately shorter than the
   // panel's history: at 30px wide, sixty points is noise.
@@ -54,6 +62,56 @@ Panel {
   property bool cursorActive: false
 
   readonly property real cpuPercent: service ? service.cpuPercent : 0
+
+  // A second metric alongside CPU, so both are readable without opening
+  // anything. Every candidate is already in the sample the shared service
+  // receives each tick, so this costs a second strip of bar and nothing else —
+  // with one exception, noted at syncSecondaryGpu().
+  readonly property bool secondaryVisible: {
+    if (!service || secondaryMetric === "none") return false
+    // Plenty of Omarchy machines run zram or no swap, and a discrete GPU is
+    // hardly universal; either would otherwise sit in the bar as a strip that
+    // never moves. Same reason the panel hides those rows outright.
+    if (secondaryMetric === "swap") return service.swapTotal > 0
+    if (secondaryMetric === "gpu") return service.hasGpu
+    return true
+  }
+  readonly property real secondaryPercent: {
+    if (!service) return 0
+    if (secondaryMetric === "swap") return service.swapPercent
+    if (secondaryMetric === "gpu") return service.gpuPercent
+    return service.memPercent
+  }
+  readonly property var secondaryHistory: {
+    if (!service) return []
+    var series = secondaryMetric === "swap" ? service.swapUsedHistory
+      : secondaryMetric === "gpu" ? service.gpuHistory
+      : service.memHistory
+    return series.slice(-barPoints)
+  }
+  // Swap history is kept in bytes rather than percent, so its graph scales to
+  // the partition instead of to 100.
+  readonly property real secondaryCeiling: secondaryMetric === "swap" && service ? service.swapTotal : 100
+  // Memory and GPU turn urgent where the panel's meters do. Swap does not:
+  // a half-full swap file is ordinary on a machine that has been up a while,
+  // and the panel leaves that meter in the foreground colour for the same
+  // reason.
+  readonly property bool secondaryHot: secondaryMetric !== "swap" && secondaryPercent >= 90
+  readonly property string secondaryLabel: secondaryMetric === "swap" ? "SWAP"
+    : secondaryMetric === "gpu" ? "GPU" : "MEM"
+  // Nerd font glyphs, the same vocabulary the bar's indicators already speak.
+  // They caption the pair and only the pair: one percentage beside a graph on a
+  // system monitor needs no caption, and adding one would widen the widget for
+  // everyone who never asked for a second metric.
+  //
+  // Chosen by silhouette at 13px rather than by name. Material's md-memory is a
+  // chip, indistinguishable from a CPU at this size and the whole reason the
+  // caption exists; fa-memory is a DIMM stick and shares no outline with the
+  // processor. oct-cpu rasterises cleaner than md-cpu_64_bit here.
+  readonly property string cpuIcon: ""          // oct-cpu
+  readonly property string secondaryIcon: secondaryMetric === "swap" ? "󰓡"   // md-swap_horizontal
+    : secondaryMetric === "gpu" ? "󰾲"   // md-expansion_card_variant
+    : ""  // fa-memory
   readonly property var panelProcesses: {
     if (!service) return []
     var rows = service.processes || []
@@ -77,7 +135,10 @@ Panel {
     service.widgetSettings = settings || ({})
   }
 
-  onServiceChanged: syncService()
+  onServiceChanged: {
+    syncService()
+    syncSecondaryGpu()
+  }
   onIntervalSecChanged: syncService()
   onHistoryPointsChanged: syncService()
   onProcessLimitChanged: syncService()
@@ -90,7 +151,10 @@ Panel {
   // at Component.onCompleted would still be the default. Re-sync whenever the
   // entry itself changes — including when this widget writes back to it.
   onSettingsChanged: syncService()
-  Component.onCompleted: syncService()
+  Component.onCompleted: {
+    syncService()
+    syncSecondaryGpu()
+  }
 
   // The sampler skips the process walk unless something is showing it.
   onOpenedChanged: {
@@ -106,11 +170,42 @@ Panel {
     }
   }
 
-    Component.onDestruction: {
-    if (!service || !opened) return
-    service.releaseProcesses()
-    service.releaseGpu()
+  Component.onDestruction: {
+    if (!service) return
+    if (opened) {
+      service.releaseProcesses()
+      service.releaseGpu()
+    }
+    if (_gpuHeldOn) {
+      _gpuHeldOn.releaseGpu()
+      _gpuHeldOn = null
+    }
   }
+
+  // The service the retain below was taken against, rather than a bare held
+  // flag: the setting and the service arrive in either order, and a flag
+  // cleared on the way past takes a second retain without giving one back.
+  property var _gpuHeldOn: null
+
+  // Memory and swap ride along in a sample the service already receives every
+  // tick, so putting either in the bar starts nothing. GPU is the exception —
+  // it costs a driver query per tick, so the sampler leaves it off until some
+  // view asks for it. Choosing it here holds that reference for the life of the
+  // widget rather than for the life of an open panel, which is the price of an
+  // always-visible metric and is what the settings copy warns about.
+  //
+  // Keyed on the setting and not on secondaryVisible: hasGpu only becomes true
+  // *after* sampling starts, so gating the retain on it would leave the strip
+  // permanently hidden and the GPU permanently unpolled.
+  function syncSecondaryGpu() {
+    var wanted = secondaryMetric === "gpu" ? service : null
+    if (_gpuHeldOn === wanted) return
+    if (_gpuHeldOn) _gpuHeldOn.releaseGpu()
+    if (wanted) wanted.retainGpu()
+    _gpuHeldOn = wanted
+  }
+
+  onSecondaryMetricChanged: syncSecondaryGpu()
 
   function expand() {
     close()
@@ -144,52 +239,124 @@ Panel {
     bar: root.bar
     labelVisible: false
     hasVisualContent: true
-    tooltipText: root.service && root.service.ready
-      ? "CPU " + Model.formatPercent(root.cpuPercent) + " · MEM " + Model.formatPercent(root.service.memPercent)
-      : "Task Manager"
+    // The glyphs caption the pair on a horizontal bar; the tooltip spells the
+    // same thing out in words, and is the only identity a vertical bar carries.
+    tooltipText: {
+      if (!root.service || !root.service.ready) return "Task Manager"
+      var parts = ["CPU " + Model.formatPercent(root.cpuPercent),
+                   "MEM " + Model.formatPercent(root.service.memPercent)]
+      if (root.secondaryVisible && root.secondaryMetric !== "mem") {
+        parts.push(root.secondaryLabel + " " + Model.formatPercent(root.secondaryPercent))
+      }
+      return parts.join(" · ")
+    }
 
     // Vertical bars have no room for a history graph, so they fall back to the
     // percentage alone — the same compromise the media widget makes.
     readonly property bool graphVisible: !vertical && root.barGraph !== "none"
-    readonly property real graphWidth: graphVisible ? Style.space(34) : 0
+    // Two strips at the single-metric width would very nearly double what the
+    // widget takes out of the bar. Narrowing them means the pair costs about
+    // half again as much as CPU alone, which is what makes this wearable on a
+    // laptop panel that is already carrying a workspace list and a clock.
+    readonly property real graphWidth: graphVisible ? Style.space(root.secondaryVisible ? 22 : 34) : 0
 
-    fixedWidth: vertical ? -1 : graphWidth + (root.showPercent ? percentLabel.implicitWidth + Style.space(5) : 0) + Style.space(10)
-    fixedHeight: vertical ? Style.bar.iconSlot : -1
+    // Measured from the content rather than recomputed: with a second strip
+    // that arithmetic has to know about spacing, visibility and orientation
+    // all at once, and the positioner already does.
+    fixedWidth: vertical ? -1 : metrics.implicitWidth + Style.space(10)
+    // One slot is sized for a single row of glyphs; stacked percentages need
+    // the second row's worth of bar.
+    fixedHeight: vertical
+      ? (root.secondaryVisible ? metrics.implicitHeight + Style.space(6) : Style.bar.iconSlot)
+      : -1
 
     onPressed: function(mouseButton) {
       if (mouseButton === Qt.RightButton) root.expand()
       else root.toggle()
     }
 
-    Row {
-      anchors.centerIn: parent
+    // Captions are for telling two otherwise identical strips apart, so they
+    // arrive with the second metric and leave with it. A vertical bar has room
+    // for neither — it is already down to bare stacked numbers.
+    readonly property bool iconsVisible: root.secondaryVisible && !vertical
+
+    // One metric's caption, graph and percentage.
+    component MetricStrip: Row {
+      id: metric
+
+      property string icon: ""
+      property var series: []
+      property real percent: 0
+      property real ceiling: 100
+      property bool hot: false
+
       spacing: Style.space(5)
 
       Sparkline {
-        id: barGraphCanvas
         visible: button.graphVisible
         width: button.graphWidth
         height: Math.max(Style.space(9), button.barSize - Style.space(14))
         anchors.verticalCenter: parent.verticalCenter
-        values: root.service ? root.service.cpuHistory.slice(-root.barPoints) : []
+        values: metric.series
         capacity: root.barPoints
-        maxValue: 100
+        maxValue: metric.ceiling
         bars: root.barGraph === "bars"
-        stroke: root.cpuPercent >= 85 ? button.activeColor : button.foreground
+        stroke: metric.hot ? button.activeColor : button.foreground
         lineWidth: 1
         fillOpacity: 0.22
         barGap: 1
       }
 
       Text {
-        id: percentLabel
-        visible: root.showPercent || button.vertical
+        visible: button.iconsVisible && metric.icon !== ""
         anchors.verticalCenter: parent.verticalCenter
-        text: Math.round(root.cpuPercent) + (button.vertical ? "" : "%")
-        color: root.cpuPercent >= 85 ? button.activeColor : button.foreground
+        text: metric.icon
+        // The caption runs hot with the reading it names, so a spike colours the
+        // whole strip rather than leaving the glyph behind in the plain colour.
+        color: metric.hot ? button.activeColor : button.foreground
         font.family: button.fontFamily
         font.pixelSize: Style.bar.iconFont
         renderType: Text.NativeRendering
+      }
+
+      Text {
+        visible: root.showPercent || button.vertical
+        anchors.verticalCenter: parent.verticalCenter
+        text: Math.round(metric.percent) + (button.vertical ? "" : "%")
+        color: metric.hot ? button.activeColor : button.foreground
+        font.family: button.fontFamily
+        font.pixelSize: Style.bar.iconFont
+        renderType: Text.NativeRendering
+      }
+    }
+
+    // CPU always leads and the second metric always follows, on every monitor
+    // and in both orientations: a pair that swapped places by context would be
+    // unreadable at this size.
+    Grid {
+      id: metrics
+      anchors.centerIn: parent
+      // Side by side along a horizontal bar. Stacked on a vertical one, which
+      // has width for two digits and never for two strips — the same place the
+      // graph itself already drops out.
+      columns: button.vertical ? 1 : 2
+      columnSpacing: Style.space(7)
+      rowSpacing: Style.space(1)
+
+      MetricStrip {
+        icon: root.cpuIcon
+        series: root.service ? root.service.cpuHistory.slice(-root.barPoints) : []
+        percent: root.cpuPercent
+        hot: root.cpuPercent >= 85
+      }
+
+      MetricStrip {
+        visible: root.secondaryVisible
+        icon: root.secondaryIcon
+        series: root.secondaryHistory
+        percent: root.secondaryPercent
+        ceiling: root.secondaryCeiling
+        hot: root.secondaryHot
       }
     }
   }

--- a/shell/plugins/omatask/BarWidget.qml
+++ b/shell/plugins/omatask/BarWidget.qml
@@ -24,13 +24,17 @@ Panel {
   }
 
   moduleName: "omarchy.omatask"
-  ipcTarget: "omatask"
+  ipcTarget: "omarchy.omatask"
   // The base Panel would register its own handler for that target; this widget
   // owns the single allowed one so it can add expand() alongside the standard
   // open/close/toggle.
   manageIpc: false
 
-  readonly property var service: bar && bar.shell ? bar.shell.serviceFor(moduleName) : null
+  // Bound, not readonly: the shell's own manifest-entrypoint test instantiates
+  // every entry point and assigns `service` to check the contract, and a
+  // readonly property makes that assignment throw — which aborts the harness
+  // mid-load rather than failing one plugin.
+  property var service: bar && bar.shell ? bar.shell.serviceFor(moduleName) : null
 
   readonly property int intervalSec: Math.max(1, Number(setting("intervalSec", 2)) || 2)
   readonly property int historyPoints: Math.max(10, Number(setting("historyPoints", 60)) || 60)

--- a/shell/plugins/omatask/CoreGraphGrid.qml
+++ b/shell/plugins/omatask/CoreGraphGrid.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Commons
+import "Model.js" as Model
 
 // One history graph per logical core — the "logical processors" view. Cells lay
 // out on a grid sized to the available width, and the whole grid scrolls, so a
@@ -12,13 +13,8 @@ Flickable {
   // "less prominent" on a dark ground; on a light theme it makes secondary text
   // darker — and therefore louder — than the primary text it sits behind. This
   // moves toward the background either way.
-  readonly property bool groundIsDark: {
-    var g = root.ground
-    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
-  }
-  function dim(c, amount) {
-    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
-  }
+  readonly property bool groundIsDark: Model.groundIsDark(root.ground)
+  function dim(c, amount) { return Model.dim(root.ground, c, amount) }
 
   // The surface this sits on, so dim() knows which way to move.
   property color ground: Color.popups.background

--- a/shell/plugins/omatask/CoreGraphGrid.qml
+++ b/shell/plugins/omatask/CoreGraphGrid.qml
@@ -1,0 +1,132 @@
+import QtQuick
+import qs.Commons
+
+// One history graph per logical core — the "logical processors" view. Cells lay
+// out on a grid sized to the available width, and the whole grid scrolls, so a
+// 16-thread laptop and a 256-thread workstation both render honestly instead of
+// one of them being truncated or squeezed into slivers.
+Flickable {
+  id: root
+
+  // Dimming has to know what it is dimming *against*. dim() only reads as
+  // "less prominent" on a dark ground; on a light theme it makes secondary text
+  // darker — and therefore louder — than the primary text it sits behind. This
+  // moves toward the background either way.
+  readonly property bool groundIsDark: {
+    var g = root.ground
+    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
+  }
+  function dim(c, amount) {
+    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
+  }
+
+  // The surface this sits on, so dim() knows which way to move.
+  property color ground: Color.popups.background
+
+  property var histories: []
+  property var cores: []
+  property int capacity: 60
+  property color foreground: Color.foreground
+  property color hotColor: Color.urgent
+  property real hotThreshold: 85
+  property string fontFamily: Style.font.family
+  property real minCellWidth: Style.space(84)
+  property real maxCellHeight: Style.space(52)
+  property real minCellHeight: Style.space(26)
+  property real gap: Style.space(6)
+
+  readonly property int count: (cores || []).length
+  readonly property int columns: {
+    if (count === 0 || width <= 0) return 1
+    var fits = Math.floor((width + gap) / (minCellWidth + gap))
+    return Math.max(1, Math.min(count, fits))
+  }
+  readonly property real cellWidth: columns > 0 ? (width - gap * (columns - 1)) / columns : 0
+  readonly property int rowCount: count > 0 ? Math.ceil(count / columns) : 0
+
+  // Shrink the cells to fit every core in view before resorting to scrolling.
+  // A core grid you have to scroll is a core grid that failed at its one job,
+  // so height is only conceded once the cells hit their legibility floor.
+  readonly property real cellHeight: {
+    if (rowCount === 0 || height <= 0) return maxCellHeight
+    var available = (height - gap * (rowCount - 1)) / rowCount
+    return Math.max(minCellHeight, Math.min(maxCellHeight, available))
+  }
+
+  // Keyboard scrolling for the case where even the floor does not fit.
+  readonly property bool scrollable: contentHeight > height + 1
+
+  function scrollBy(delta) {
+    if (!scrollable) return
+    contentY = Math.max(0, Math.min(contentHeight - height, contentY + delta))
+  }
+
+  contentWidth: width
+  contentHeight: grid.height
+  clip: true
+  boundsBehavior: Flickable.StopAtBounds
+  flickableDirection: Flickable.VerticalFlick
+
+  Grid {
+    id: grid
+    width: root.width
+    columns: root.columns
+    columnSpacing: root.gap
+    rowSpacing: root.gap
+
+    Repeater {
+      model: root.count
+
+      Item {
+        required property int index
+        readonly property real usage: Number(root.cores[index]) || 0
+        readonly property bool hot: usage >= root.hotThreshold
+
+        width: root.cellWidth
+        height: root.cellHeight
+
+        Rectangle {
+          anchors.fill: parent
+          radius: Style.space(3)
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+        }
+
+        Sparkline {
+          anchors.fill: parent
+          anchors.margins: Style.space(3)
+          // Each cell keeps its own ring, so switching into this view shows
+          // history that was already being collected rather than starting flat.
+          values: (root.histories || [])[index] || []
+          capacity: root.capacity
+          maxValue: 100
+          stroke: parent.hot ? root.hotColor : root.foreground
+          lineWidth: 1
+          fillOpacity: 0.2
+        }
+
+        // Labels sit on top of the graph: at this cell size, giving them their
+        // own row would leave the graph too short to read.
+        Text {
+          anchors.left: parent.left
+          anchors.top: parent.top
+          anchors.margins: Style.space(4)
+          text: index
+          color: dim(root.foreground, 1.7)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+        }
+
+        Text {
+          anchors.right: parent.right
+          anchors.top: parent.top
+          anchors.margins: Style.space(4)
+          text: Math.round(parent.usage) + "%"
+          color: parent.hot ? root.hotColor : dim(root.foreground, 1.3)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: parent.hot
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/omatask/CoreGrid.qml
+++ b/shell/plugins/omatask/CoreGrid.qml
@@ -1,0 +1,105 @@
+import QtQuick
+import qs.Commons
+
+// One vertical fill bar per logical core. Wraps into as many rows as it takes
+// to keep each bar wide enough to read — a 32-thread desktop gets two rows of
+// sixteen rather than thirty-two two-pixel slivers.
+Item {
+  id: root
+
+  // Dimming has to know what it is dimming *against*. dim() only reads as
+  // "less prominent" on a dark ground; on a light theme it makes secondary text
+  // darker — and therefore louder — than the primary text it sits behind. This
+  // moves toward the background either way.
+  readonly property bool groundIsDark: {
+    var g = root.ground
+    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
+  }
+  function dim(c, amount) {
+    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
+  }
+
+  // The surface this sits on, so dim() knows which way to move.
+  property color ground: Color.popups.background
+
+  property var cores: []
+  property color foreground: Color.foreground
+  property color fill: foreground
+  // Cores at or above this are tinted urgent, so a pegged thread is findable
+  // at a glance without reading any number.
+  property real hotThreshold: 85
+  property color hotColor: Color.urgent
+  property real minBarWidth: Style.space(7)
+  property real gap: Style.space(2)
+  property real rowHeight: Style.space(26)
+
+  readonly property int count: (cores || []).length
+  readonly property int columns: {
+    if (count === 0 || width <= 0) return 1
+    var fits = Math.floor((width + gap) / (minBarWidth + gap))
+    return Math.max(1, Math.min(count, fits))
+  }
+  readonly property int rows: count > 0 ? Math.ceil(count / columns) : 0
+
+  implicitHeight: rows > 0 ? rows * rowHeight + (rows - 1) * gap : 0
+
+  Column {
+    anchors.fill: parent
+    spacing: root.gap
+
+    Repeater {
+      model: root.rows
+
+      Row {
+        id: coreRow
+        required property int index
+        width: parent.width
+        height: root.rowHeight
+        spacing: root.gap
+
+        readonly property int firstCore: index * root.columns
+        readonly property real barWidth: root.columns > 0
+          ? (width - root.gap * (root.columns - 1)) / root.columns
+          : 0
+
+        Repeater {
+          model: root.columns
+
+          Item {
+            required property int index
+            readonly property int coreIndex: coreRow.firstCore + index
+            readonly property real usage: coreIndex < root.count
+              ? Math.min(100, Math.max(0, Number(root.cores[coreIndex]) || 0))
+              : -1
+
+            width: coreRow.barWidth
+            height: coreRow.height
+            // The last row is usually short; empty slots keep the remaining
+            // bars aligned under the row above instead of stretching.
+            visible: usage >= 0
+
+            // Faint enough that a mostly-idle machine reads as a row of quiet
+            // marks rather than a row of empty tanks demanding to be filled.
+            Rectangle {
+              anchors.fill: parent
+              radius: Style.space(2)
+              color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06)
+            }
+
+            Rectangle {
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.bottom: parent.bottom
+              radius: Style.space(2)
+              height: Math.max(Style.space(2), parent.height * (parent.usage / 100))
+              color: parent.usage >= root.hotThreshold ? root.hotColor : root.fill
+
+              Behavior on height { NumberAnimation { duration: 240; easing.type: Easing.OutCubic } }
+              Behavior on color { ColorAnimation { duration: 200 } }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/omatask/CoreGrid.qml
+++ b/shell/plugins/omatask/CoreGrid.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Commons
+import "Model.js" as Model
 
 // One vertical fill bar per logical core. Wraps into as many rows as it takes
 // to keep each bar wide enough to read — a 32-thread desktop gets two rows of
@@ -11,13 +12,8 @@ Item {
   // "less prominent" on a dark ground; on a light theme it makes secondary text
   // darker — and therefore louder — than the primary text it sits behind. This
   // moves toward the background either way.
-  readonly property bool groundIsDark: {
-    var g = root.ground
-    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
-  }
-  function dim(c, amount) {
-    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
-  }
+  readonly property bool groundIsDark: Model.groundIsDark(root.ground)
+  function dim(c, amount) { return Model.dim(root.ground, c, amount) }
 
   // The surface this sits on, so dim() knows which way to move.
   property color ground: Color.popups.background

--- a/shell/plugins/omatask/Meter.qml
+++ b/shell/plugins/omatask/Meter.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import qs.Commons
+
+// Labelled horizontal fill bar: caption on the left, reading on the right,
+// track underneath. Used for memory, swap, and the CPU summary so all three
+// read as one family.
+Column {
+  id: root
+
+  // Dimming has to know what it is dimming *against*. dim() only reads as
+  // "less prominent" on a dark ground; on a light theme it makes secondary text
+  // darker — and therefore louder — than the primary text it sits behind. This
+  // moves toward the background either way.
+  readonly property bool groundIsDark: {
+    var g = root.ground
+    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
+  }
+  function dim(c, amount) {
+    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
+  }
+
+  // The surface this sits on, so dim() knows which way to move.
+  property color ground: Color.popups.background
+
+  property string label: ""
+  property string value: ""
+  property real fraction: 0
+  property color foreground: Color.foreground
+  property color fill: foreground
+  property string fontFamily: Style.font.family
+  property real trackHeight: Style.space(6)
+  property bool compact: false
+
+  spacing: Style.spacing.labelGap
+  width: parent ? parent.width : implicitWidth
+
+  Item {
+    width: parent.width
+    height: caption.implicitHeight
+    visible: root.label !== "" || root.value !== ""
+
+    Text {
+      id: caption
+      anchors.left: parent.left
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.label
+      color: dim(root.foreground, 1.4)
+      font.family: root.fontFamily
+      font.pixelSize: root.compact ? Style.font.caption : Style.font.bodySmall
+      font.bold: true
+      font.letterSpacing: 0.8
+    }
+
+    Text {
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.value
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.compact ? Style.font.caption : Style.font.bodySmall
+    }
+  }
+
+  Rectangle {
+    id: track
+    width: parent.width
+    height: root.trackHeight
+    radius: height / 2
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+
+    Rectangle {
+      height: parent.height
+      radius: parent.radius
+      color: root.fill
+      // Clamp rather than trusting the caller: a rate-derived fraction can
+      // briefly exceed 1 between samples and would otherwise overhang the
+      // track. A true zero paints nothing — the rounded minimum width would
+      // otherwise leave a permanent dot on an unused swap meter.
+      width: root.fraction <= 0
+        ? 0
+        : Math.max(height, parent.width * Math.min(1, root.fraction))
+
+      Behavior on width { NumberAnimation { duration: 260; easing.type: Easing.OutCubic } }
+      Behavior on color { ColorAnimation { duration: 200 } }
+    }
+  }
+}

--- a/shell/plugins/omatask/Meter.qml
+++ b/shell/plugins/omatask/Meter.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Commons
+import "Model.js" as Model
 
 // Labelled horizontal fill bar: caption on the left, reading on the right,
 // track underneath. Used for memory, swap, and the CPU summary so all three
@@ -11,13 +12,8 @@ Column {
   // "less prominent" on a dark ground; on a light theme it makes secondary text
   // darker — and therefore louder — than the primary text it sits behind. This
   // moves toward the background either way.
-  readonly property bool groundIsDark: {
-    var g = root.ground
-    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
-  }
-  function dim(c, amount) {
-    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
-  }
+  readonly property bool groundIsDark: Model.groundIsDark(root.ground)
+  function dim(c, amount) { return Model.dim(root.ground, c, amount) }
 
   // The surface this sits on, so dim() knows which way to move.
   property color ground: Color.popups.background

--- a/shell/plugins/omatask/Model.js
+++ b/shell/plugins/omatask/Model.js
@@ -174,7 +174,12 @@ function sortApps(apps, sortId, descending) {
     var left = sort.key(a), right = sort.key(b)
     if (left < right) return -direction
     if (left > right) return direction
-    return String(a.unit) < String(b.unit) ? -1 : 1
+    // The tie-break has to be a total order, equality included: a comparator
+    // that never returns 0 lets two identical rows swap places between renders.
+    var leftUnit = String(a.unit), rightUnit = String(b.unit)
+    if (leftUnit < rightUnit) return -1
+    if (leftUnit > rightUnit) return 1
+    return 0
   })
   return rows
 }

--- a/shell/plugins/omatask/Model.js
+++ b/shell/plugins/omatask/Model.js
@@ -1,0 +1,228 @@
+.pragma library
+
+// Formatting and small data transforms for the task manager. Kept out of the
+// QML so the panel and the overlay format identically and neither has to
+// re-derive the rules.
+
+var KIB = 1024
+
+function formatBytes(bytes, digits) {
+  var value = Number(bytes) || 0
+  if (value < KIB) return Math.round(value) + " B"
+  var units = ["KB", "MB", "GB", "TB", "PB"]
+  var index = -1
+  do {
+    value /= KIB
+    index++
+  } while (value >= KIB && index < units.length - 1)
+  var places = digits === undefined ? (value < 10 ? 1 : 0) : digits
+  return value.toFixed(places) + " " + units[index]
+}
+
+function formatRate(bytesPerSecond) {
+  return formatBytes(bytesPerSecond) + "/s"
+}
+
+// Uptime as the coarsest two units that still carry information — "3d 4h"
+// rather than "3d 4h 12m 7s", which nobody reads past the first field.
+function formatUptime(seconds) {
+  var total = Math.max(0, Math.floor(Number(seconds) || 0))
+  var days = Math.floor(total / 86400)
+  var hours = Math.floor((total % 86400) / 3600)
+  var minutes = Math.floor((total % 3600) / 60)
+  if (days > 0) return days + "d " + hours + "h"
+  if (hours > 0) return hours + "h " + minutes + "m"
+  return minutes + "m " + (total % 60) + "s"
+}
+
+function formatPercent(value, digits) {
+  var n = Number(value) || 0
+  return n.toFixed(digits === undefined ? 1 : digits) + "%"
+}
+
+// Process state letters from /proc/<pid>/stat, spelled out for the detail row.
+var STATE_NAMES = {
+  "R": "Running",
+  "S": "Sleeping",
+  "D": "Waiting on I/O",
+  "Z": "Zombie",
+  "T": "Stopped",
+  "t": "Traced",
+  "X": "Dead",
+  "I": "Idle"
+}
+
+function stateName(letter) {
+  return STATE_NAMES[String(letter)] || String(letter || "")
+}
+
+// Push onto a fixed-length ring, returning a new array. QML property bindings
+// only re-evaluate on assignment, so mutating in place would leave the graphs
+// showing stale data.
+function pushHistory(history, value, limit) {
+  var next = (history || []).slice()
+  next.push(Number(value) || 0)
+  var max = Math.max(2, Number(limit) || 60)
+  if (next.length > max) next = next.slice(next.length - max)
+  return next
+}
+
+// Largest value in a series, for pinning two graphs to one scale. Overlaying
+// series that each autoscale independently draws a picture that is worse than
+// no picture — the lines imply a relationship their axes do not share.
+function peak(values) {
+  var highest = 0
+  var list = values || []
+  for (var i = 0; i < list.length; i++) {
+    var value = Number(list[i]) || 0
+    if (value > highest) highest = value
+  }
+  return highest
+}
+
+// Same as pushHistory, once per core. Returns a fresh outer array so a QML
+// binding on it actually re-evaluates; core count can change under us on a
+// machine that hotplugs CPUs, so the ring set is resized rather than assumed.
+function pushCoreHistories(histories, cores, limit) {
+  var values = cores || []
+  var next = []
+  for (var i = 0; i < values.length; i++) {
+    next.push(pushHistory((histories || [])[i], values[i], limit))
+  }
+  return next
+}
+
+// The commands a process list can be sorted by. `key` reads the field off a
+// row; every one sorts descending first, because "what is using the most" is
+// the question being asked.
+var SORTS = [
+  { id: "cpu", label: "CPU", key: function(p) { return p.cpu } },
+  { id: "rss", label: "Memory", key: function(p) { return p.rss } },
+  { id: "threads", label: "Threads", key: function(p) { return p.threads } },
+  { id: "pid", label: "PID", key: function(p) { return p.pid } },
+  { id: "name", label: "Name", key: function(p) { return String(p.name).toLowerCase() } }
+]
+
+function sortById(id) {
+  for (var i = 0; i < SORTS.length; i++) {
+    if (SORTS[i].id === id) return SORTS[i]
+  }
+  return SORTS[0]
+}
+
+function sortProcesses(processes, sortId, descending) {
+  var sort = sortById(sortId)
+  var rows = (processes || []).slice()
+  var direction = descending ? -1 : 1
+  rows.sort(function(a, b) {
+    var left = sort.key(a)
+    var right = sort.key(b)
+    if (left < right) return -direction
+    if (left > right) return direction
+    return a.pid - b.pid  // stable tiebreak so equal rows stop swapping places
+  })
+  return rows
+}
+
+// Case-insensitive match against the process name, its full command line, the
+// owning user, and the pid — so "1234", "chrome", and "root" all work.
+function filterProcesses(processes, query) {
+  var needle = String(query || "").trim().toLowerCase()
+  if (needle === "") return processes || []
+  return (processes || []).filter(function(p) {
+    return String(p.name).toLowerCase().indexOf(needle) !== -1
+      || String(p.cmd).toLowerCase().indexOf(needle) !== -1
+      || String(p.user).toLowerCase().indexOf(needle) !== -1
+      || String(p.pid).indexOf(needle) !== -1
+  })
+}
+
+// Strip the interpreter and path noise so a row reads as the thing the user
+// launched: "/usr/lib/chromium/chromium --type=renderer …" becomes
+// "chromium --type=renderer …".
+function shortCommand(cmd, name) {
+  var text = String(cmd || "").trim()
+  if (text === "") return String(name || "")
+  var space = text.indexOf(" ")
+  var head = space === -1 ? text : text.substring(0, space)
+  var tail = space === -1 ? "" : text.substring(space)
+  var slash = head.lastIndexOf("/")
+  if (slash !== -1) head = head.substring(slash + 1)
+  return head + tail
+}
+
+// ---------------------------------------------------------------- applications
+
+var APP_SORTS = [
+  { id: "cpu", key: function(a) { return a.cpu } },
+  { id: "mem", key: function(a) { return a.mem } },
+  { id: "rss", key: function(a) { return a.mem } },
+  { id: "ioStall", key: function(a) { return a.ioStall } },
+  { id: "procs", key: function(a) { return a.procs } },
+  { id: "pid", key: function(a) { return a.procs } },
+  { id: "name", key: function(a) { return String(a.name).toLowerCase() } }
+]
+
+function sortApps(apps, sortId, descending) {
+  var sort = APP_SORTS[0]
+  for (var i = 0; i < APP_SORTS.length; i++) {
+    if (APP_SORTS[i].id === sortId) sort = APP_SORTS[i]
+  }
+  var rows = (apps || []).slice()
+  var direction = descending ? -1 : 1
+  rows.sort(function(a, b) {
+    var left = sort.key(a), right = sort.key(b)
+    if (left < right) return -direction
+    if (left > right) return direction
+    return String(a.unit) < String(b.unit) ? -1 : 1
+  })
+  return rows
+}
+
+function filterApps(apps, query) {
+  var needle = String(query || "").trim().toLowerCase()
+  if (needle === "") return apps || []
+  return (apps || []).filter(function(a) {
+    return String(a.name).toLowerCase().indexOf(needle) !== -1
+      || String(a.unit).toLowerCase().indexOf(needle) !== -1
+  })
+}
+
+// ---------------------------------------------------------------- process tree
+//
+// Flatten parent/child structure back into a list, because a ListView wants a
+// flat model. Each row carries its `depth`, and the order is a depth-first walk
+// of the forest — so the list reads as a tree while staying cheap to render.
+function buildTree(rows) {
+  var byPid = {}
+  var children = {}
+  var i
+  for (i = 0; i < rows.length; i++) {
+    byPid[rows[i].pid] = rows[i]
+  }
+  for (i = 0; i < rows.length; i++) {
+    var parent = rows[i].ppid
+    // A process whose parent is outside the set (or is itself) is a root.
+    var key = (byPid[parent] !== undefined && parent !== rows[i].pid) ? parent : "roots"
+    if (!children[key]) children[key] = []
+    children[key].push(rows[i])
+  }
+
+  var out = []
+  var guard = 0
+  function walk(list, depth) {
+    if (!list || depth > 24) return
+    for (var j = 0; j < list.length; j++) {
+      if (++guard > 5000) return          // cycle guard; /proc can lie briefly
+      var row = list[j]
+      var copy = {}
+      for (var k in row) copy[k] = row[k]
+      copy.depth = depth
+      copy.hasChildren = !!children[row.pid]
+      out.push(copy)
+      walk(children[row.pid], depth + 1)
+    }
+  }
+  walk(children["roots"], 0)
+  return out
+}

--- a/shell/plugins/omatask/Model.js
+++ b/shell/plugins/omatask/Model.js
@@ -4,6 +4,18 @@
 // QML so the panel and the overlay format identically and neither has to
 // re-derive the rules.
 
+// Dimming has to know what it is dimming *against*. "Less prominent" means
+// darker on a dark ground and lighter on a light one; picking the wrong
+// direction makes secondary text louder than the text it sits behind. Six
+// components needed this, and six copies were six chances to diverge.
+function groundIsDark(ground) {
+  return (ground.r * 0.2126 + ground.g * 0.7152 + ground.b * 0.0722) < 0.5
+}
+
+function dim(ground, color, amount) {
+  return groundIsDark(ground) ? Qt.darker(color, amount) : Qt.lighter(color, amount)
+}
+
 var KIB = 1024
 
 function formatBytes(bytes, digits) {

--- a/shell/plugins/omatask/Overlay.qml
+++ b/shell/plugins/omatask/Overlay.qml
@@ -15,13 +15,8 @@ Item {
   // "less prominent" on a dark ground; on a light theme it makes secondary text
   // darker — and therefore louder — than the primary text it sits behind. This
   // moves toward the background either way.
-  readonly property bool groundIsDark: {
-    var g = root.background
-    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
-  }
-  function dim(c, amount) {
-    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
-  }
+  readonly property bool groundIsDark: Model.groundIsDark(root.background)
+  function dim(c, amount) { return Model.dim(root.background, c, amount) }
 
   // Injected by the shell's panel loader.
   property var shell: null

--- a/shell/plugins/omatask/Overlay.qml
+++ b/shell/plugins/omatask/Overlay.qml
@@ -1,0 +1,2757 @@
+import QtQuick
+import Quickshell
+import qs.Commons
+import qs.Ui
+import "Model.js" as Model
+
+// The expanded view: everything the under-bar panel shows, plus the full
+// process table with filtering, sorting, and signals. Summoned from the panel's
+// Expand button, from `omarchy-shell shell toggle omarchy.omatask`, or
+// from a Hyprland binding.
+Item {
+  id: root
+
+  // Dimming has to know what it is dimming *against*. dim() only reads as
+  // "less prominent" on a dark ground; on a light theme it makes secondary text
+  // darker — and therefore louder — than the primary text it sits behind. This
+  // moves toward the background either way.
+  readonly property bool groundIsDark: {
+    var g = root.background
+    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
+  }
+  function dim(c, amount) {
+    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
+  }
+
+  // Injected by the shell's panel loader.
+  property var shell: null
+  property var service: null
+  property var manifest: ({})
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+
+  property bool opened: false
+  property string filterText: ""
+  property int selectedPid: -1
+  // Applications have no pid to key selection on, so they key on their scope.
+  property string selectedUnit: ""
+  // "processes" is the flat table; "apps" groups by systemd scope so one
+  // Chromium replaces forty-seven chromium rows; "tree" keeps the flat data but
+  // draws parent/child structure.
+  readonly property string listMode: service ? service.listMode : "processes"
+  readonly property bool appsMode: listMode === "apps"
+  readonly property bool treeMode: listMode === "tree"
+  // Whether rows carry a thread-disclosure chevron. An application row has no
+  // threads to disclose, so the column disappears — and the table header has to
+  // agree, which is why this is one property both of them read.
+  readonly property bool rowsExpandable: !appsMode
+
+  function cycleListMode(direction) {
+    if (!service) return
+    var modes = ["processes", "apps", "tree"]
+    var at = modes.indexOf(listMode)
+    service.listMode = modes[(at + (direction || 1) + modes.length) % modes.length]
+  }
+
+  // Reconcile every sampler gate with what is currently on screen. Called on
+  // open as well as on change: a preference restored from shell.json means the
+  // mode is already correct when the overlay is built, so a change handler
+  // alone never fires and the view opens empty.
+  function syncDetailGates() {
+    if (!service) return
+    service.appsDetail = appsMode && opened
+    service.gpuDetail = gpuExpanded && opened
+    service.netDetail = netExpanded && opened
+    service.diskDetail = diskExpanded && opened
+    service.sensorDetail = (cpuExpanded || memExpanded || diskExpanded) && opened
+  }
+
+  onAppsModeChanged: syncDetailGates()
+
+  readonly property string sortId: service ? service.sortBy : "cpu"
+  readonly property bool sortDescending: service ? service.sortDescending : true
+  // The CPU card swaps between one aggregate graph and a per-core grid; the
+  // grid needs the whole row, so the other cards stand down while it is up.
+  // Only one card can hold the row at a time, so these are kept exclusive
+  // rather than letting two full-width cards fight over it.
+  property bool cpuExpanded: false
+  property bool gpuExpanded: false
+  property bool memExpanded: false
+  property bool netExpanded: false
+  property bool diskExpanded: false
+  property int expandedPid: -1
+  // The full key list is a reference, not a status bar. It lives behind `?`
+  // so the persistent chrome can stay down to the one thing worth saying.
+  property bool keysVisible: false
+
+  readonly property var keyHelp: [
+    { keys: "type", action: "Filter by name, command, user, or pid" },
+    { keys: "↑ ↓", action: "Select a process" },
+    { keys: "PgUp PgDn · Home End", action: "Jump through the list" },
+    { keys: "Enter · →", action: "Expand the process into its threads" },
+    { keys: "←", action: "Collapse the expanded process" },
+    { keys: "Del", action: "Terminate (SIGTERM)" },
+    { keys: "Shift+Del", action: "Kill (SIGKILL)" },
+    { keys: "Tab · Shift+Tab", action: "Cycle the sort column" },
+    { keys: "Ctrl+R", action: "Reverse the sort direction" },
+    { keys: "Ctrl+L", action: "Toggle the per-core view" },
+    { keys: "Ctrl+G", action: "Toggle the GPU engine view" },
+    { keys: "Ctrl+M", action: "Toggle the memory breakdown" },
+    { keys: "Ctrl+N", action: "Toggle the network breakdown" },
+    { keys: "Ctrl+D", action: "Toggle the disk breakdown" },
+    { keys: "Ctrl+A", action: "Cycle processes / applications / tree" },
+    { keys: "g", action: "Group an app's scopes into one row (Applications view)" },
+    { keys: "Ctrl+O", action: "Show the selected process's open files" },
+    { keys: "s", action: "Suspend the selected process (SIGSTOP)" },
+    { keys: "c", action: "Resume the selected process (SIGCONT)" },
+    { keys: "[ / ]", action: "Lower / raise priority of the selected process" },
+    { keys: "Ctrl+↑ Ctrl+↓", action: "Scroll the expanded card" },
+    { keys: "Backspace · Ctrl+U", action: "Edit or clear the filter" },
+    { keys: "Esc", action: "Clear the filter, then close" }
+  ]
+
+  // Live ScrollColumns, so Ctrl+arrow can drive whichever ones are on screen.
+  property var scrollables: []
+
+  function registerScrollable(item) {
+    var next = scrollables.slice()
+    next.push(item)
+    scrollables = next
+  }
+
+  function unregisterScrollable(item) {
+    var next = []
+    for (var i = 0; i < scrollables.length; i++) {
+      if (scrollables[i] !== item) next.push(scrollables[i])
+    }
+    scrollables = next
+  }
+
+  function scrollExpanded(delta) {
+    var moved = false
+    for (var i = 0; i < scrollables.length; i++) {
+      var target = scrollables[i]
+      if (target && target.visible && target.overflowing) {
+        target.scrollBy(delta)
+        moved = true
+      }
+    }
+    return moved
+  }
+
+  readonly property bool anyCardExpanded: cpuExpanded || gpuExpanded || memExpanded || netExpanded || diskExpanded
+
+  function toggleCpuExpanded() {
+    diskExpanded = false
+    netExpanded = false
+    gpuExpanded = false
+    memExpanded = false
+    cpuExpanded = !cpuExpanded
+  }
+
+  function toggleGpuExpanded() {
+    diskExpanded = false
+    netExpanded = false
+    if (!service || !service.hasGpu) return
+    cpuExpanded = false
+    memExpanded = false
+    gpuExpanded = !gpuExpanded
+  }
+
+  function toggleDiskExpanded() {
+    cpuExpanded = false
+    gpuExpanded = false
+    memExpanded = false
+    netExpanded = false
+    diskExpanded = !diskExpanded
+  }
+
+  function toggleNetExpanded() {
+    diskExpanded = false
+    cpuExpanded = false
+    gpuExpanded = false
+    memExpanded = false
+    netExpanded = !netExpanded
+  }
+
+  function toggleMemExpanded() {
+    diskExpanded = false
+    netExpanded = false
+    cpuExpanded = false
+    gpuExpanded = false
+    memExpanded = !memExpanded
+  }
+
+  // The expensive GPU readings are collected only while the card showing them
+  // is open — and never once the overlay itself is gone.
+  onGpuExpandedChanged: if (service) service.gpuDetail = gpuExpanded && opened
+  // Both expansions show hwmon readings — CPU the full strip, memory the DIMM
+  // sensors — so either one opens the expensive sensor gate.
+  function syncSensorDetail() {
+    if (service) service.sensorDetail = (cpuExpanded || memExpanded || diskExpanded) && opened
+  }
+  onCpuExpandedChanged: syncSensorDetail()
+  onMemExpandedChanged: syncSensorDetail()
+  onNetExpandedChanged: if (service) service.netDetail = netExpanded && opened
+  onDiskExpandedChanged: {
+    if (!service) return
+    service.diskDetail = diskExpanded && opened
+    // Drive temperatures come from the same hwmon tier as the DIMM sensors.
+    syncSensorDetail()
+  }
+  onOpenedChanged: {
+    if (service && !opened) {
+      service.gpuDetail = false
+      service.sensorDetail = false
+    }
+  }
+
+  // True only for processes worth expanding. Keeping the keyboard and the
+  // chevron on the same rule means Enter never opens a disclosure the row
+  // showed no arrow for.
+  function hasThreads(pid) {
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].pid === pid) return Number(rows[i].threads) > 1
+    }
+    return false
+  }
+
+  function toggleThreads(pid) {
+    var target = Number(pid) || -1
+    if (expandedPid === target) {
+      expandedPid = -1
+      if (service) service.unwatchThreads(target)
+      return
+    }
+    if (!hasThreads(target)) return
+    expandedPid = target
+    if (service) service.watchThreads(target)
+  }
+
+  // Shares the [menu] surface tokens, so a theme that restyles the menu
+  // restyles this too rather than needing its own entry.
+  readonly property color background: Color.menu.background
+  readonly property color foreground: Color.menu.text
+  readonly property color accent: Color.accent
+  readonly property color urgent: Color.urgent
+  readonly property var borderSpec: Border.surfaceSpec("menu", "border", Color.menu.border, Math.max(1, Style.space(2)))
+  readonly property string fontFamily: Style.font.menuFamily
+
+  readonly property var rows: {
+    if (!service) return []
+    if (appsMode) {
+      return Model.sortApps(Model.filterApps(service.apps, filterText), sortId, sortDescending)
+    }
+    var flat = Model.sortProcesses(
+      Model.filterProcesses(service.processes, filterText), sortId, sortDescending)
+    // The tree only makes sense over the whole set; once a filter has cut it
+    // down, the surviving rows have no shared ancestry to draw.
+    return treeMode && filterText === "" ? Model.buildTree(flat) : flat
+  }
+  readonly property int selectedIndex: {
+    for (var i = 0; i < rows.length; i++) {
+      if (appsMode ? rows[i].unit === selectedUnit : rows[i].pid === selectedPid) return i
+    }
+    return -1
+  }
+
+  function open(payloadJson) {
+    if (opened) return
+    opened = true
+    filterText = ""
+    selectedPid = -1
+    if (service) {
+      service.retainProcesses()
+      service.retainGpu()
+    }
+    syncDetailGates()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function close() {
+    if (!opened) return
+    opened = false
+    gpuExpanded = false
+    cpuExpanded = false
+    memExpanded = false
+    netExpanded = false
+    diskExpanded = false
+    if (expandedPid > 0 && service) service.unwatchThreads(expandedPid)
+    expandedPid = -1
+    if (service) {
+      service.gpuDetail = false
+      service.sensorDetail = false
+      service.netDetail = false
+      service.diskDetail = false
+      service.appsDetail = false
+      service.socketDetail = false
+      service.openFilesPid = 0
+      service.releaseProcesses()
+      service.releaseGpu()
+    }
+  }
+
+  function toggle() {
+    if (opened) close()
+    else open("{}")
+  }
+
+  Component.onDestruction: {
+    if (!opened || !service) return
+    if (expandedPid > 0) service.unwatchThreads(expandedPid)
+    service.gpuDetail = false
+    service.sensorDetail = false
+    service.netDetail = false
+    service.diskDetail = false
+    service.appsDetail = false
+    service.socketDetail = false
+    service.openFilesPid = 0
+    service.releaseProcesses()
+    service.releaseGpu()
+  }
+
+  // Selection follows the pid, not the row number: the table re-sorts on every
+  // sample, and an index-based cursor would slide onto whatever process
+  // happened to overtake the one you were aiming at.
+  function select(delta) {
+    if (rows.length === 0) return
+    var next = selectedIndex < 0
+      ? (delta > 0 ? 0 : rows.length - 1)
+      : Math.max(0, Math.min(rows.length - 1, selectedIndex + delta))
+    if (appsMode) selectedUnit = rows[next].unit
+    else selectedPid = rows[next].pid
+    list.positionViewAtIndex(next, ListView.Contain)
+  }
+
+  function selectAbsolute(index) {
+    if (rows.length === 0) return
+    var clamped = Math.max(0, Math.min(rows.length - 1, index))
+    if (appsMode) selectedUnit = rows[clamped].unit
+    else selectedPid = rows[clamped].pid
+    list.positionViewAtIndex(clamped, ListView.Contain)
+  }
+
+  property bool filesVisible: false
+
+  function toggleOpenFiles() {
+    if (appsMode || selectedPid <= 0) return
+    filesVisible = !filesVisible
+    if (service) service.openFilesPid = filesVisible ? selectedPid : 0
+  }
+
+  onSelectedPidChanged: {
+    if (filesVisible && service) service.openFilesPid = selectedPid
+    // A priority nudge applies to whatever is selected, so the accumulated
+    // offset resets when the selection moves.
+    pendingNice = 0
+  }
+
+  // Priority moves in preset-sized steps rather than one nice unit at a time,
+  // so a keypress produces a change a person can feel.
+  property int pendingNice: 0
+
+  function nudgePriority(delta) {
+    if (!service || selectedPid <= 0) return
+    pendingNice = Math.max(-19, Math.min(19, pendingNice + delta))
+    service.setPriority(selectedPid, pendingNice)
+  }
+
+  function killSelected(signalName) {
+    if (!service || selectedIndex < 0) return
+    service.killProcess(rows[selectedIndex].pid, signalName)
+  }
+
+  function applySort(id) {
+    if (!service) return
+    // Clicking the column you are already sorted by flips direction; picking a
+    // new one starts descending, because "most first" is always the question.
+    if (sortId === id) service.sortDescending = !sortDescending
+    else {
+      service.sortBy = id
+      service.sortDescending = true
+    }
+  }
+
+  // A real toplevel window, not a layer-shell surface. Layer-shell is what made
+  // this hover above the desktop without being part of it: it could not be
+  // dragged, windows dragged around it passed underneath, and SUPER+W closed
+  // whatever was behind it because the compositor resolves keybindings before a
+  // layer surface ever sees them. As a window it drags, stacks, tiles and
+  // closes like everything else the window manager owns.
+  FloatingWindow {
+    id: window
+    visible: root.opened
+    // The window manager shows this in alt-tab and matches window rules against
+    // it, so it is the public name rather than the internal one.
+    title: "Task Manager"
+    color: "transparent"
+    implicitWidth: Style.space(1180)
+    implicitHeight: Style.space(820)
+    // Below this the stat cards stop being readable and the table loses its
+    // right-hand columns, so refuse rather than degrade.
+    minimumSize: Qt.size(Style.space(720), Style.space(420))
+
+    // The compositor's close — a window rule, SUPER+W, a close button — arrives
+    // here. Without this the shell would keep thinking the view is open.
+    onClosed: root.close()
+
+    BorderSurface {
+      id: card
+      anchors.fill: parent
+      radius: Style.cornerRadius
+      color: root.background
+      borderSpec: root.borderSpec
+      padding: Style.spacing.panelPadding
+
+      Item {
+        id: keyCatcher
+        // BorderSurface exposes padding as insets rather than applying them,
+        // so content has to honour them explicitly.
+        anchors.fill: parent
+        anchors.topMargin: card.contentTopInset
+        anchors.rightMargin: card.contentRightInset
+        anchors.bottomMargin: card.contentBottomInset
+        anchors.leftMargin: card.contentLeftInset
+        focus: true
+        // Nothing inside should ever paint over the card border; a layout slip
+        // in an unclipped layer-shell surface bleeds onto the desktop itself.
+        clip: true
+
+        Keys.priority: Keys.BeforeItem
+        Keys.onPressed: function(event) {
+          // The legend swallows everything while it is up, so no shortcut can
+          // act on a list the user cannot currently see.
+          if (root.keysVisible) {
+            if (event.key === Qt.Key_Escape || event.text === "?") root.keysVisible = false
+            event.accepted = true
+            return
+          }
+          // `?` is a printable character, so it only opens the legend when
+          // there is no filter to append it to.
+          if (event.text === "?" && root.filterText === "") {
+            root.keysVisible = true
+            event.accepted = true
+            return
+          }
+
+          if (event.key === Qt.Key_Escape) {
+            if (root.filterText !== "") root.filterText = ""
+            else root.close()
+            event.accepted = true
+          } else if (Util.editsFilter(event, root.filterText)) {
+            root.filterText = Util.editedFilter(event, root.filterText)
+            event.accepted = true
+          } else if (root.anyCardExpanded && (event.modifiers & Qt.ControlModifier)
+                     && (event.key === Qt.Key_Up || event.key === Qt.Key_Down)) {
+            // Scrolls whatever the expanded card is showing: the per-core
+            // grid, the VRAM list, or any detail column that overflowed. Each
+            // call is a no-op when its target already fits.
+            var step = event.key === Qt.Key_Down ? Style.space(58) : -Style.space(58)
+            if (root.cpuExpanded) coreGraphs.scrollBy(step)
+            if (root.gpuExpanded) vramList.scrollBy(step)
+            root.scrollExpanded(step)
+            event.accepted = true
+          } else if (event.key === Qt.Key_R && (event.modifiers & Qt.ControlModifier)) {
+            if (root.service) root.service.sortDescending = !root.sortDescending
+            event.accepted = true
+          } else if (event.key === Qt.Key_Up) {
+            root.select(-1); event.accepted = true
+          } else if (event.key === Qt.Key_Down) {
+            root.select(1); event.accepted = true
+          } else if (event.key === Qt.Key_PageUp) {
+            root.select(-12); event.accepted = true
+          } else if (event.key === Qt.Key_PageDown) {
+            root.select(12); event.accepted = true
+          } else if (event.key === Qt.Key_Home) {
+            root.selectAbsolute(0); event.accepted = true
+          } else if (event.key === Qt.Key_End) {
+            root.selectAbsolute(root.rows.length - 1); event.accepted = true
+          } else if (event.text === "g" && root.filterText === "" && root.appsMode) {
+            if (root.service) root.service.groupApps = !root.service.groupApps
+            event.accepted = true
+          } else if (event.text === "s" && root.filterText === "" && root.selectedPid > 0) {
+            // Suspending is the humane alternative to killing something you
+            // actually want back.
+            if (root.service) root.service.killProcess(root.selectedPid, "STOP")
+            event.accepted = true
+          } else if (event.text === "c" && root.filterText === "" && root.selectedPid > 0) {
+            if (root.service) root.service.killProcess(root.selectedPid, "CONT")
+            event.accepted = true
+          } else if ((event.text === "[" || event.text === "]") && root.selectedPid > 0) {
+            root.nudgePriority(event.text === "]" ? 5 : -5)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Delete) {
+            root.killSelected(event.modifiers & Qt.ShiftModifier ? "KILL" : "TERM")
+            event.accepted = true
+          } else if (event.key === Qt.Key_L && (event.modifiers & Qt.ControlModifier)) {
+            // Ctrl+L for "logical processors", the same view the CPU card
+            // toggles on click. Ctrl-modified keys never reach the filter.
+            root.toggleCpuExpanded()
+            event.accepted = true
+          } else if (event.key === Qt.Key_G && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleGpuExpanded()
+            event.accepted = true
+          } else if (event.key === Qt.Key_M && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleMemExpanded()
+            event.accepted = true
+          } else if (event.key === Qt.Key_N && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleNetExpanded()
+            event.accepted = true
+          } else if (event.key === Qt.Key_D && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleDiskExpanded()
+            event.accepted = true
+          } else if (event.key === Qt.Key_A && (event.modifiers & Qt.ControlModifier)) {
+            root.cycleListMode((event.modifiers & Qt.ShiftModifier) ? -1 : 1)
+            event.accepted = true
+          } else if (event.key === Qt.Key_O && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleOpenFiles()
+            event.accepted = true
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            if (root.selectedPid > 0) root.toggleThreads(root.selectedPid)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Right && root.selectedPid > 0 && root.expandedPid !== root.selectedPid) {
+            root.toggleThreads(root.selectedPid)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Left && root.expandedPid > 0) {
+            root.toggleThreads(root.expandedPid)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+            // Tab walks the sort columns rather than moving focus; there is
+            // only one focusable surface here.
+            var order = Model.SORTS
+            var at = 0
+            for (var i = 0; i < order.length; i++) {
+              if (order[i].id === root.sortId) at = i
+            }
+            var step = (event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab ? -1 : 1
+            if (root.service) {
+              root.service.sortBy = order[(at + step + order.length) % order.length].id
+              root.service.sortDescending = true
+            }
+            event.accepted = true
+          } else if (event.text && event.text.length === 1 && event.text >= " "
+                     && !(event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier))) {
+            root.filterText += event.text
+            event.accepted = true
+          }
+        }
+
+        // ------------------------------------------------------ key legend
+        //
+        // Sits above the content rather than inside the layout, so opening it
+        // never reflows the table behind it.
+        BorderSurface {
+          id: legend
+          visible: root.keysVisible
+          z: 30
+          anchors.centerIn: parent
+          width: Math.min(Style.space(520), parent.width - Style.space(40))
+          height: Math.min(legendColumn.implicitHeight + Style.space(36), parent.height - Style.space(20))
+          radius: Style.cornerRadius
+          color: Color.menu.background
+          borderSpec: root.borderSpec
+
+          MouseArea {
+            anchors.fill: parent
+            onClicked: root.keysVisible = false
+          }
+
+          Column {
+            id: legendColumn
+            anchors.centerIn: parent
+            width: parent.width - Style.space(36)
+            spacing: Style.space(6)
+
+            Text {
+              text: "KEYS"
+              bottomPadding: Style.space(4)
+              color: dim(root.foreground, 1.4)
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              font.bold: true
+              font.letterSpacing: 1.2
+            }
+
+            Repeater {
+              model: root.keyHelp
+
+              Item {
+                required property var modelData
+                width: legendColumn.width
+                height: Style.space(19)
+
+                Text {
+                  anchors.left: parent.left
+                  width: Style.space(160)
+                  text: modelData.keys
+                  elide: Text.ElideRight
+                  color: root.accent
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.caption
+                }
+
+                Text {
+                  anchors.left: parent.left
+                  anchors.leftMargin: Style.space(168)
+                  anchors.right: parent.right
+                  text: modelData.action
+                  elide: Text.ElideRight
+                  color: root.foreground
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.caption
+                }
+              }
+            }
+
+            Text {
+              topPadding: Style.space(6)
+              text: "? or Esc to close"
+              color: dim(root.foreground, 1.8)
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+            }
+          }
+        }
+
+        Column {
+          anchors.fill: parent
+          spacing: Style.space(14)
+
+          // ------------------------------------------------------- header
+          Item {
+            width: parent.width
+            implicitHeight: Math.max(title.implicitHeight, summary.implicitHeight)
+
+            Text {
+              id: title
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+              text: "Task Manager"
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.heading
+              font.bold: true
+            }
+
+            Text {
+              id: summary
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              text: {
+                if (!root.service || !root.service.ready) return "SAMPLING…"
+                var s = root.service
+                return s.processCount + " PROCESSES · " + s.runningCount + " RUNNING · "
+                  + s.threadCount + " THREADS · UP " + Model.formatUptime(s.uptime)
+              }
+              color: dim(root.foreground, 1.5)
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              font.bold: true
+              font.letterSpacing: 1.0
+            }
+          }
+
+          // -------------------------------------------------- stat cards
+          Row {
+            id: cards
+            width: parent.width
+            // Taller while expanded so a normal core count lands in full
+            // instead of making the user scroll a grid to see half their CPU.
+            height: root.anyCardExpanded ? Style.space(384) : Style.space(196)
+            spacing: Style.space(12)
+
+            Behavior on height { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+
+            // CPU takes two parts, every other card one. Counting parts rather
+            // than cards is what keeps the row exactly `width` wide whether or
+            // not the GPU card is present.
+            readonly property bool gpuVisible: root.service && root.service.hasGpu
+            readonly property int cardCount: gpuVisible ? 5 : 4
+            readonly property real unit: (width - spacing * (cardCount - 1)) / (cardCount + 1)
+
+            // CPU is the widest card because the per-core grid needs the room;
+            // the others split what is left evenly. Expanded, it takes the lot.
+            StatCard {
+              visible: !root.gpuExpanded && !root.memExpanded && !root.netExpanded && !root.diskExpanded
+              width: root.cpuExpanded ? cards.width : cards.unit * 2
+              height: cards.height
+              heading: "CPU"
+              reading: root.service ? root.service.cpuPercent.toFixed(1) + "%" : "—"
+              readingHot: root.service && root.service.cpuPercent >= 85
+              detail: {
+                if (!root.service || !root.service.ready) return ""
+                var load = root.service.loadAverage
+                var parts = [root.service.coreCount + " threads"]
+                if (root.service.hasCpuTemp) parts.push(root.service.cpuTemp.toFixed(1) + "°C")
+                parts.push("load " + Number(load[0]).toFixed(2) + " "
+                  + Number(load[1]).toFixed(2) + " " + Number(load[2]).toFixed(2))
+                parts.push(root.cpuExpanded ? "click to collapse" : "click for all cores")
+                return parts.join(" · ")
+              }
+              interactive: true
+              onCardClicked: root.toggleCpuExpanded()
+
+              Behavior on width { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+
+              Sparkline {
+                width: parent.width
+                height: Style.space(60)
+                visible: !root.cpuExpanded
+                values: root.service ? root.service.cpuHistory : []
+                capacity: root.service ? root.service.historyPoints : 60
+                maxValue: 100
+                stroke: root.foreground
+                showBaseline: true
+              }
+
+              CoreGrid {
+                ground: root.background
+                width: parent.width
+                visible: !root.cpuExpanded
+                cores: root.service ? root.service.cores : []
+                foreground: root.foreground
+                fill: root.foreground
+                hotColor: root.urgent
+                rowHeight: Style.space(18)
+              }
+
+              CoreGraphGrid {
+                ground: root.background
+                id: coreGraphs
+                width: parent.width
+                // Whatever the card has left below the heading block, minus the
+                // sensor strip that shares the expanded view with it.
+                height: root.cpuExpanded
+                  ? Math.max(Style.space(60), cards.height - Style.space(84) - sensorStrip.height - Style.space(10))
+                  : 0
+                visible: root.cpuExpanded
+                histories: root.service ? root.service.coreHistories : []
+                cores: root.service ? root.service.cores : []
+                capacity: root.service ? root.service.historyPoints : 60
+                foreground: root.foreground
+                hotColor: root.urgent
+                fontFamily: root.fontFamily
+              }
+
+              // Temperatures and fans. Which of these exist is decided entirely
+              // by what hwmon drivers are loaded, so the strip reports what the
+              // kernel offers and says plainly when it offers nothing.
+              Column {
+                id: sensorStrip
+                width: parent.width
+                visible: root.cpuExpanded
+                spacing: Style.space(6)
+
+                PanelSeparator { width: parent.width; foreground: root.foreground }
+
+                // The two temperatures worth watching over time rather than
+                // reading once. Both ride the free sampling path, so these open
+                // populated; the other ten stay as text below, because graphing
+                // them would mean paying their bus cost on every sample.
+                Row {
+                  id: tempGraphs
+                  width: parent.width
+                  height: Style.space(62)
+                  spacing: Style.space(12)
+
+                  readonly property bool cpuShown: root.service && root.service.hasCpuTemp
+                  readonly property bool gpuShown: root.service && root.service.hasGpu
+                    && root.service.gpuTempHistory.length > 0
+                  readonly property real cell: cpuShown && gpuShown ? (width - spacing) / 2 : width
+
+                  TempGraph {
+                    width: tempGraphs.cell
+                    height: tempGraphs.height
+                    visible: tempGraphs.cpuShown
+                    label: "CPU TEMP"
+                    value: root.service ? root.service.cpuTemp : 0
+                    history: root.service ? root.service.cpuTempHistory : []
+                  }
+
+                  TempGraph {
+                    width: tempGraphs.cell
+                    height: tempGraphs.height
+                    visible: tempGraphs.gpuShown
+                    label: "GPU TEMP"
+                    value: root.service && root.service.hasGpu
+                      ? (Number(root.service.primaryGpu.temp) || 0) : 0
+                    history: root.service ? root.service.gpuTempHistory : []
+                  }
+                }
+
+                Flow {
+                  width: parent.width
+                  spacing: Style.space(18)
+
+                  PanelSectionHeader {
+                    text: "SENSORS"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  Repeater {
+                    model: root.service ? root.service.sensors : []
+
+                    Text {
+                      required property var modelData
+                      // 80°C is the point past which a reading stops being
+                      // trivia and starts being something to look at.
+                      readonly property bool hot: Number(modelData.temp) >= 80
+
+                      text: modelData.name + " " + Number(modelData.temp).toFixed(0) + "°C"
+                      color: hot ? root.urgent : root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.bold: hot
+                    }
+                  }
+                }
+
+                Flow {
+                  width: parent.width
+                  spacing: Style.space(18)
+
+                  PanelSectionHeader {
+                    text: "FANS"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  Text {
+                    visible: root.service && !root.service.fansAvailable
+                    text: "no tachometer exposed by this board"
+                    color: dim(root.foreground, 1.8)
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+
+                  Repeater {
+                    model: root.service ? root.service.fans : []
+
+                    Text {
+                      required property var modelData
+                      text: modelData.name + " " + modelData.rpm + " RPM"
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+
+                  Text {
+                    // The GPU fan comes from NVML rather than hwmon, so it is
+                    // listed here alongside the board's fans instead of being
+                    // stranded in the GPU card.
+                    visible: root.service && root.service.hasGpu
+                      && root.service.primaryGpu.fan !== null
+                      && root.service.primaryGpu.fan !== undefined
+                    text: "GPU " + (root.service ? root.service.primaryGpu.fan : 0) + "%"
+                    color: root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+              }
+            }
+
+            StatCard {
+              visible: !root.cpuExpanded && !root.gpuExpanded && !root.netExpanded && !root.diskExpanded
+              width: root.memExpanded ? cards.width : cards.unit
+              height: cards.height
+              heading: "MEMORY"
+              reading: root.service ? root.service.memPercent.toFixed(0) + "%" : "—"
+              readingHot: root.service && root.service.memPercent >= 90
+              interactive: true
+              onCardClicked: root.toggleMemExpanded()
+              detail: {
+                if (!root.service) return ""
+                var text = Model.formatBytes(root.service.memUsed) + " / " + Model.formatBytes(root.service.memTotal)
+                return text + " · " + (root.memExpanded ? "click to collapse" : "click for breakdown")
+              }
+
+              Behavior on width { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+
+              // ---------- collapsed ----------
+              Sparkline {
+                width: parent.width
+                height: Style.space(52)
+                visible: !root.memExpanded
+                values: root.service ? root.service.memHistory : []
+                capacity: root.service ? root.service.historyPoints : 60
+                maxValue: 100
+                stroke: root.foreground
+                showBaseline: true
+              }
+
+              Meter {
+                ground: root.background
+                width: parent.width
+                visible: !root.memExpanded && root.service && root.service.swapTotal > 0
+                label: "SWAP"
+                value: root.service ? Model.formatBytes(root.service.swapUsed) : ""
+                fraction: root.service ? root.service.swapPercent / 100 : 0
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                compact: true
+              }
+
+              // ---------- expanded ----------
+              //
+              // What the headline percentage hides: where "used" actually went,
+              // whether anything is stalling on memory, and what swap is really
+              // holding once zram's compression is accounted for.
+              Item {
+                width: parent.width
+                visible: root.memExpanded
+                height: visible ? Math.max(Style.space(60), cards.height - Style.space(84)) : 0
+
+                // Graphs first: composition tells you where memory is now,
+                // but only a trace tells you whether it is going somewhere.
+                Row {
+                  id: memGraphs
+                  anchors.top: parent.top
+                  width: parent.width
+                  height: Style.space(74)
+                  spacing: Style.space(12)
+
+                  readonly property bool swapShown: root.service && root.service.swapTotal > 0
+                  readonly property int count: swapShown ? 3 : 2
+                  readonly property real cell: (width - spacing * (count - 1)) / count
+
+                  MemGraph {
+                    width: memGraphs.cell
+                    height: memGraphs.height
+                    label: "USED"
+                    reading: root.service ? Model.formatBytes(root.service.memUsed) : ""
+                    values: root.service ? root.service.memHistory : []
+                    scaleMax: 100
+                  }
+
+                  // Processes against page cache on one shared scale. Anonymous
+                  // memory climbing while cache is squeezed out is the shape of
+                  // a machine running out of room, and it is only visible when
+                  // the two are plotted against each other.
+                  MemGraph {
+                    width: memGraphs.cell
+                    height: memGraphs.height
+                    label: "PROCESSES vs CACHE"
+                    reading: root.service
+                      ? Model.formatBytes(root.service.mem.anon) + " / " + Model.formatBytes(root.service.mem.cached)
+                      : ""
+                    values: root.service ? root.service.memAnonHistory : []
+                    secondaryValues: root.service ? root.service.memCacheHistory : []
+                    scaleMax: root.service
+                      ? Math.max(Model.peak(root.service.memAnonHistory),
+                                 Model.peak(root.service.memCacheHistory)) * 1.05
+                      : 0
+                  }
+
+                  MemGraph {
+                    width: memGraphs.cell
+                    height: memGraphs.height
+                    visible: memGraphs.swapShown
+                    label: "SWAP USED"
+                    reading: root.service ? Model.formatBytes(root.service.swapUsed) : ""
+                    values: root.service ? root.service.swapUsedHistory : []
+                    // Autoscaled rather than pinned to swap size: on a 63 GB
+                    // zram device a real 200 MB of swapping would be an
+                    // invisible sliver against the total.
+                    scaleMax: 0
+                    hot: root.service && root.service.swapUsed > 0
+                  }
+                }
+
+                Row {
+                  id: memColumns
+                  anchors.top: memGraphs.bottom
+                  anchors.topMargin: Style.space(12)
+                  anchors.bottom: parent.bottom
+                  width: parent.width
+                  spacing: Style.space(20)
+
+                  readonly property real cell: (width - spacing * 2) / 3
+
+                  // --- composition ---
+                  ScrollColumn {
+                    width: memColumns.cell
+                    height: memColumns.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "WHERE IT WENT"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.memBreakdown : []
+
+                      Item {
+                        required property var modelData
+                        width: parent.width
+                        height: Style.space(19)
+
+                        Text {
+                          anchors.left: parent.left
+                          anchors.right: breakdownValue.left
+                          anchors.rightMargin: Style.space(8)
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: modelData.label
+                          elide: Text.ElideRight
+                          color: dim(root.foreground, 1.4)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          id: breakdownValue
+                          anchors.right: parent.right
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: Model.formatBytes(modelData.value)
+                          color: root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+
+                    // Page cache is not "used" in any sense worth alarming
+                    // about — the kernel hands it back on demand — so it sits
+                    // apart from the breakdown above rather than inside it.
+                    Item {
+                      width: parent.width
+                      height: Style.space(19)
+
+                      Text {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: "Cache (reclaimable)"
+                        color: dim(root.foreground, 1.7)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                      }
+
+                      Text {
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: root.service ? Model.formatBytes(root.service.mem.cached) : ""
+                        color: dim(root.foreground, 1.4)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                      }
+                    }
+                  }
+
+                  // --- pressure ---
+                  ScrollColumn {
+                    width: memColumns.cell
+                    height: memColumns.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "PRESSURE"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Text {
+                      width: parent.width
+                      wrapMode: Text.WordWrap
+                      text: root.service && root.service.memStall > 0
+                        ? "Tasks are stalling on memory."
+                        : "No task has stalled on memory."
+                      color: root.service && root.service.memStall > 0
+                        ? root.urgent : dim(root.foreground, 1.6)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Sparkline {
+                      width: parent.width
+                      height: Style.space(44)
+                      values: root.service ? root.service.memStallHistory : []
+                      capacity: root.service ? root.service.historyPoints : 60
+                      // Autoscaled: stall percentages live near zero, and the
+                      // shape of a spike matters more than its absolute height.
+                      maxValue: 0
+                      stroke: root.service && root.service.memStall > 0 ? root.urgent : root.foreground
+                      showBaseline: true
+                    }
+
+                    Repeater {
+                      model: [
+                        { label: "memory", key: "memPressure" },
+                        { label: "cpu", key: "cpuPressure" },
+                        { label: "io", key: "ioPressure" }
+                      ]
+
+                      Item {
+                        required property var modelData
+                        width: parent.width
+                        height: Style.space(17)
+
+                        readonly property var stats: root.service ? root.service[modelData.key] : ({})
+
+                        Text {
+                          anchors.left: parent.left
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: modelData.label
+                          color: dim(root.foreground, 1.6)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          anchors.right: parent.right
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: "some " + Number(parent.stats.some10 || 0).toFixed(2)
+                            + " / " + Number(parent.stats.some60 || 0).toFixed(2)
+                            + " / " + Number(parent.stats.some300 || 0).toFixed(2)
+                          color: Number(parent.stats.some10 || 0) > 0 ? root.urgent : root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+                  }
+
+                  // --- swap + commit ---
+                  ScrollColumn {
+                    width: memColumns.cell
+                    height: memColumns.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "SWAP"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Text {
+                      visible: root.service && root.service.swaps.length === 0
+                      text: "no swap configured"
+                      color: dim(root.foreground, 1.7)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.swaps : []
+
+                      Column {
+                        required property var modelData
+                        width: parent.width
+                        spacing: Style.space(2)
+
+                        Item {
+                          width: parent.width
+                          height: Style.space(17)
+
+                          Text {
+                            anchors.left: parent.left
+                            text: modelData.name
+                            elide: Text.ElideRight
+                            color: root.foreground
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+
+                          Text {
+                            anchors.right: parent.right
+                            text: Model.formatBytes(modelData.used) + " / " + Model.formatBytes(modelData.size)
+                            color: dim(root.foreground, 1.3)
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+                        }
+
+                        // Only meaningful once zram is actually holding
+                        // something; on an empty device the ratio is noise.
+                        Text {
+                          visible: modelData.zramRatio !== undefined && modelData.zramOriginal > 1048576
+                          width: parent.width
+                          text: "  " + (modelData.zramAlgorithm || "zram") + " · "
+                            + Model.formatBytes(modelData.zramOriginal) + " in "
+                            + Model.formatBytes(modelData.zramUsed) + " · "
+                            + Number(modelData.zramRatio).toFixed(1) + "× · saves "
+                            + Model.formatBytes(modelData.zramSaved)
+                          elide: Text.ElideRight
+                          color: dim(root.foreground, 1.6)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          visible: modelData.zramRatio !== undefined && !(modelData.zramOriginal > 1048576)
+                          text: "  " + (modelData.zramAlgorithm || "zram") + " · idle"
+                          color: dim(root.foreground, 1.8)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+
+                    PanelSectionHeader {
+                      text: "DIMM TEMPERATURE"
+                      topPadding: Style.space(6)
+                      visible: root.service && root.service.dimmSensors.length > 0
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.dimmSensors : []
+
+                      Item {
+                        required property var modelData
+                        width: parent.width
+                        height: Style.space(17)
+                        // 85°C is the point where DIMMs start refreshing twice
+                        // as often, which is the first thing you would notice.
+                        readonly property bool hot: Number(modelData.temp) >= 85
+
+                        Text {
+                          anchors.left: parent.left
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: modelData.name
+                          color: dim(root.foreground, 1.6)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          anchors.right: parent.right
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: Number(modelData.temp).toFixed(0) + "°C"
+                          color: parent.hot ? root.urgent : root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                          font.bold: parent.hot
+                        }
+                      }
+                    }
+
+                    Text {
+                      visible: root.service && root.service.dimmSensors.length === 0
+                      text: "no DIMM sensor exposed"
+                      color: dim(root.foreground, 1.8)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    PanelSectionHeader {
+                      text: "COMMIT"
+                      topPadding: Style.space(6)
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Item {
+                      width: parent.width
+                      height: Style.space(17)
+
+                      Text {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        // Overcommit is normal on Linux and not by itself a
+                        // fault, so it is stated rather than alarmed about.
+                        text: root.service && root.service.overcommitted ? "overcommitted" : "within limit"
+                        color: dim(root.foreground, 1.6)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                      }
+
+                      Text {
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: root.service
+                          ? Model.formatBytes(root.service.committed) + " / " + Model.formatBytes(root.service.commitLimit)
+                          : ""
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            // Absent entirely on a machine with no readable GPU, rather than
+            // showing a card full of dashes.
+            StatCard {
+              visible: cards.gpuVisible && !root.cpuExpanded && !root.memExpanded && !root.netExpanded && !root.diskExpanded
+              width: root.gpuExpanded ? cards.width : cards.unit
+              height: cards.height
+              interactive: true
+              onCardClicked: root.toggleGpuExpanded()
+
+              Behavior on width { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+
+              heading: "GPU"
+              reading: root.service ? Math.round(root.service.gpuPercent) + "%" : "—"
+              readingHot: root.service && root.service.gpuPercent >= 85
+              // Temperature and power only; the VRAM figures go on the meter
+              // below, where they have a bar to sit against. Cramming all four
+              // onto one line just elided the last two away.
+              detail: {
+                if (!root.service || !root.service.hasGpu) return ""
+                var device = root.service.primaryGpu
+                var parts = []
+                if (device.temp !== null && device.temp !== undefined) parts.push(device.temp + "°C")
+                if (device.power !== null && device.power !== undefined) parts.push(device.power + " W")
+                parts.push(root.gpuExpanded ? "click to collapse" : "click for engines")
+                return parts.join(" · ")
+              }
+
+              // ---------- collapsed ----------
+              Sparkline {
+                width: parent.width
+                height: Style.space(52)
+                visible: !root.gpuExpanded
+                values: root.service ? root.service.gpuHistory : []
+                capacity: root.service ? root.service.historyPoints : 60
+                maxValue: 100
+                stroke: root.foreground
+                showBaseline: true
+              }
+
+              Meter {
+                ground: root.background
+                width: parent.width
+                visible: !root.gpuExpanded
+                label: "VRAM"
+                value: root.service
+                  ? Model.formatBytes(root.service.gpuMemUsed) + " / " + Model.formatBytes(root.service.gpuMemTotal)
+                  : ""
+                fraction: root.service ? root.service.gpuMemPercent / 100 : 0
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                compact: true
+              }
+
+              Text {
+                width: parent.width
+                visible: !root.gpuExpanded
+                text: root.service && root.service.hasGpu ? String(root.service.primaryGpu.name) : ""
+                elide: Text.ElideRight
+                color: dim(root.foreground, 1.7)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+              }
+
+              // ---------- expanded ----------
+              //
+              // Where CPU expands into its cores, the GPU expands into its
+              // engines and its clients: three utilisation graphs, the hardware
+              // readouts, and the answer to "what is holding my VRAM".
+              Item {
+                width: parent.width
+                visible: root.gpuExpanded
+                height: visible ? Math.max(Style.space(60), cards.height - Style.space(84)) : 0
+
+                readonly property var device: root.service ? root.service.primaryGpu : ({})
+
+                Row {
+                  id: engineRow
+                  width: parent.width
+                  height: Style.space(96)
+                  spacing: Style.space(12)
+
+                  readonly property real cell: (width - spacing * 2) / 3
+
+                  EngineGraph {
+                    width: engineRow.cell
+                    height: engineRow.height
+                    label: "GRAPHICS"
+                    value: root.service ? root.service.gpuPercent : 0
+                    history: root.service ? root.service.gpuHistory : []
+                  }
+
+                  EngineGraph {
+                    width: engineRow.cell
+                    height: engineRow.height
+                    label: "ENCODE"
+                    supported: root.service && root.service.hasGpuEngines
+                    value: parent.parent.device.encode || 0
+                    history: root.service ? root.service.gpuEncodeHistory : []
+                  }
+
+                  EngineGraph {
+                    width: engineRow.cell
+                    height: engineRow.height
+                    label: "DECODE"
+                    supported: root.service && root.service.hasGpuEngines
+                    value: parent.parent.device.decode || 0
+                    history: root.service ? root.service.gpuDecodeHistory : []
+                  }
+                }
+
+                // Hardware readouts. Each cell hides itself when the driver
+                // returns null for that counter, so an unsupported reading is
+                // absent rather than a confident zero.
+                Row {
+                  id: readoutRow
+                  anchors.top: engineRow.bottom
+                  anchors.topMargin: Style.space(10)
+                  width: parent.width
+                  spacing: Style.space(20)
+
+                  readonly property var device: parent.device
+
+                  Readout { label: "VRAM"; value: root.service
+                    ? Model.formatBytes(root.service.gpuMemUsed) + " / " + Model.formatBytes(root.service.gpuMemTotal)
+                    : "" }
+                  Readout { label: "SM CLOCK"; value: readoutRow.device.smClock ? readoutRow.device.smClock + " MHz" : "" }
+                  Readout { label: "MEM CLOCK"; value: readoutRow.device.memClock ? readoutRow.device.memClock + " MHz" : "" }
+                  Readout {
+                    label: "FAN"
+                    value: readoutRow.device.fan === null || readoutRow.device.fan === undefined
+                      ? "" : readoutRow.device.fan + "%"
+                  }
+                  Readout {
+                    label: "POWER"
+                    value: readoutRow.device.power === null || readoutRow.device.power === undefined
+                      ? ""
+                      : readoutRow.device.power + " / " + (readoutRow.device.powerLimit || "?") + " W"
+                  }
+                  Readout {
+                    label: "PCIE"
+                    value: readoutRow.device.pcieRx === null || readoutRow.device.pcieRx === undefined
+                      ? ""
+                      : "↓" + Model.formatRate(readoutRow.device.pcieRx) + "  ↑" + Model.formatRate(readoutRow.device.pcieTx)
+                  }
+                }
+
+                PanelSeparator {
+                  id: gpuRule
+                  anchors.top: readoutRow.bottom
+                  anchors.topMargin: Style.space(10)
+                  width: parent.width
+                  foreground: root.foreground
+                }
+
+                PanelSectionHeader {
+                  id: vramHeader
+                  anchors.top: gpuRule.bottom
+                  anchors.topMargin: Style.space(8)
+                  text: "VRAM BY PROCESS"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                }
+
+                ListView {
+                  id: vramList
+                  anchors.top: vramHeader.bottom
+                  anchors.topMargin: Style.space(4)
+                  anchors.bottom: parent.bottom
+                  width: parent.width
+                  clip: true
+                  boundsBehavior: Flickable.StopAtBounds
+                  model: root.service ? root.service.gpuProcesses : []
+
+                  // Driven by the same Ctrl+↑/↓ that scrolls the per-core grid,
+                  // so those keys mean "scroll whatever is expanded" rather
+                  // than one thing here and something else there.
+                  function scrollBy(delta) {
+                    if (contentHeight <= height) return
+                    contentY = Math.max(0, Math.min(contentHeight - height, contentY + delta))
+                  }
+
+                  delegate: Item {
+                    required property var modelData
+                    width: ListView.view.width
+                    height: Style.space(20)
+
+                    Text {
+                      anchors.left: parent.left
+                      width: Style.space(72)
+                      text: modelData.pid
+                      horizontalAlignment: Text.AlignRight
+                      color: dim(root.foreground, 1.6)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Text {
+                      anchors.left: parent.left
+                      anchors.leftMargin: Style.space(84)
+                      anchors.right: vramValue.left
+                      anchors.rightMargin: Style.space(10)
+                      text: modelData.name
+                      elide: Text.ElideRight
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Text {
+                      id: vramValue
+                      anchors.right: parent.right
+                      anchors.rightMargin: Style.space(8)
+                      width: Style.space(80)
+                      horizontalAlignment: Text.AlignRight
+                      text: Model.formatBytes(modelData.mem)
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+
+                  Text {
+                    anchors.centerIn: parent
+                    visible: parent.count === 0
+                    text: "No process is holding VRAM"
+                    color: dim(root.foreground, 1.7)
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+              }
+            }
+
+            StatCard {
+              visible: !root.cpuExpanded && !root.gpuExpanded && !root.memExpanded && !root.diskExpanded
+              width: root.netExpanded ? cards.width : cards.unit
+              height: cards.height
+              interactive: true
+              onCardClicked: root.toggleNetExpanded()
+              heading: "NETWORK"
+              reading: root.service ? Model.formatRate(root.service.net.rx) : "—"
+              detail: root.service
+                ? "↑ " + Model.formatRate(root.service.net.tx)
+                  + (root.service.net.ifaces && root.service.net.ifaces.length > 0
+                     ? " · " + root.service.net.ifaces.map(function(i) { return i.name }).join(", ")
+                     : "")
+                : ""
+
+              Sparkline {
+                width: parent.width
+                height: Style.space(52)
+                visible: !root.netExpanded
+                values: root.service ? root.service.netRxHistory : []
+                capacity: root.service ? root.service.historyPoints : 60
+                maxValue: 0  // byte rates have no ceiling; scale to what is in view
+                stroke: root.foreground
+                showBaseline: true
+              }
+
+              Sparkline {
+                width: parent.width
+                height: Style.space(30)
+                visible: !root.netExpanded
+                values: root.service ? root.service.netTxHistory : []
+                capacity: root.service ? root.service.historyPoints : 60
+                maxValue: 0
+                stroke: dim(root.foreground, 1.4)
+                fillOpacity: 0.10
+                showBaseline: true
+              }
+
+              // ---------- expanded ----------
+              Item {
+                width: parent.width
+                visible: root.netExpanded
+                height: visible ? Math.max(Style.space(60), cards.height - Style.space(84)) : 0
+
+                Row {
+                  id: netGraphs
+                  anchors.top: parent.top
+                  width: parent.width
+                  height: Style.space(74)
+                  spacing: Style.space(12)
+
+                  readonly property bool wifiShown: root.service && root.service.hasWifi
+                  readonly property int count: wifiShown ? 3 : 2
+                  readonly property real cell: (width - spacing * (count - 1)) / count
+
+                  MemGraph {
+                    width: netGraphs.cell
+                    height: netGraphs.height
+                    label: "DOWN"
+                    reading: root.service ? Model.formatRate(root.service.net.rx) : ""
+                    values: root.service ? root.service.netRxHistory : []
+                    scaleMax: 0
+                  }
+
+                  MemGraph {
+                    width: netGraphs.cell
+                    height: netGraphs.height
+                    label: "UP"
+                    reading: root.service ? Model.formatRate(root.service.net.tx) : ""
+                    values: root.service ? root.service.netTxHistory : []
+                    scaleMax: 0
+                  }
+
+                  // Signal is the one network reading that is a condition
+                  // rather than a rate: throughput can be zero because nothing
+                  // is being asked for, but a sagging dBm is always a fact
+                  // about the link.
+                  TempGraph {
+                    width: netGraphs.cell
+                    height: netGraphs.height
+                    visible: netGraphs.wifiShown
+                    label: "WIFI SIGNAL"
+                    value: root.service ? root.service.wifiSignal : 0
+                    history: root.service ? root.service.wifiSignalHistory : []
+                    unit: " dBm"
+                    floor: -90
+                    ceiling: -30
+                    throttlePoint: -70
+                    invertHot: true
+                  }
+                }
+
+                Row {
+                  anchors.top: netGraphs.bottom
+                  anchors.topMargin: Style.space(12)
+                  anchors.bottom: parent.bottom
+                  width: parent.width
+                  spacing: Style.space(20)
+
+                  readonly property real cell: (width - spacing * 2) / 3
+
+                  // --- links ---
+                  ScrollColumn {
+                    width: parent.cell
+                    height: parent.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "LINKS"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.netLinks : []
+
+                      Column {
+                        required property var modelData
+                        width: parent.width
+                        spacing: Style.space(1)
+
+                        readonly property var rate: root.service ? root.service.rateFor(modelData.name) : ({})
+
+                        Item {
+                          width: parent.width
+                          height: Style.space(17)
+
+                          Text {
+                            anchors.left: parent.left
+                            text: modelData.name
+                            color: root.foreground
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+
+                          Text {
+                            anchors.right: parent.right
+                            text: "↓" + Model.formatRate(parent.parent.rate.rx || 0)
+                              + "  ↑" + Model.formatRate(parent.parent.rate.tx || 0)
+                            color: dim(root.foreground, 1.3)
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+                        }
+
+                        Text {
+                          width: parent.width
+                          text: {
+                            var bits = [modelData.state]
+                            if (modelData.speed) bits.push(modelData.speed + " Mb/s")
+                            if (modelData.duplex && modelData.duplex !== "unknown") bits.push(modelData.duplex)
+                            bits.push("mtu " + modelData.mtu)
+                            if (modelData.wireless) bits.push("q " + Math.round(modelData.wireless.quality))
+                            return "  " + bits.join(" · ")
+                          }
+                          elide: Text.ElideRight
+                          color: dim(root.foreground, 1.7)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+                  }
+
+                  // --- errors ---
+                  ScrollColumn {
+                    width: parent.cell
+                    height: parent.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "ERRORS & DROPS"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.netLinks : []
+
+                      Item {
+                        required property var modelData
+                        width: parent.width
+                        height: Style.space(17)
+
+                        readonly property real bad: (Number(modelData.rx_errors) || 0)
+                          + (Number(modelData.tx_errors) || 0)
+                          + (Number(modelData.rx_dropped) || 0)
+                          + (Number(modelData.tx_dropped) || 0)
+
+                        Text {
+                          anchors.left: parent.left
+                          text: modelData.name
+                          color: dim(root.foreground, 1.6)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          anchors.right: parent.right
+                          text: "err " + ((Number(modelData.rx_errors) || 0) + (Number(modelData.tx_errors) || 0))
+                            + " · drop " + ((Number(modelData.rx_dropped) || 0) + (Number(modelData.tx_dropped) || 0))
+                          color: parent.bad > 0 ? root.urgent : root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+
+                    Text {
+                      width: parent.width
+                      wrapMode: Text.WordWrap
+                      topPadding: Style.space(4)
+                      text: "Counters are since boot, not rates."
+                      color: dim(root.foreground, 1.8)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+
+                  // --- sockets ---
+                  ScrollColumn {
+                    width: parent.cell
+                    height: parent.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "TCP SOCKETS"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: [
+                        { label: "established", key: "established" },
+                        { label: "listening", key: "listen" },
+                        { label: "time-wait", key: "timeWait" },
+                        { label: "close-wait", key: "closeWait" },
+                        { label: "total", key: "total" }
+                      ]
+
+                      Item {
+                        required property var modelData
+                        width: parent.width
+                        height: Style.space(17)
+
+                        Text {
+                          anchors.left: parent.left
+                          text: modelData.label
+                          color: dim(root.foreground, 1.6)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          anchors.right: parent.right
+                          text: root.service ? (root.service.sockets[modelData.key] || 0) : "0"
+                          color: root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+
+                    // Stated rather than left as a puzzle: people expect a task
+                    // manager to name the process using the bandwidth, and the
+                    // kernel simply does not account for it anywhere in /proc.
+                    Text {
+                      width: parent.width
+                      wrapMode: Text.WordWrap
+                      topPadding: Style.space(6)
+                      text: "Per-process bandwidth needs eBPF; /proc does not account for it."
+                      color: dim(root.foreground, 1.8)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+                }
+              }
+            }
+
+            StatCard {
+              visible: !root.cpuExpanded && !root.gpuExpanded && !root.memExpanded && !root.netExpanded
+              width: root.diskExpanded ? cards.width : cards.unit
+              height: cards.height
+              interactive: true
+              onCardClicked: root.toggleDiskExpanded()
+              heading: "DISK"
+              reading: root.service ? Model.formatRate(root.service.disk.read) : "—"
+              detail: root.service
+                ? "write " + Model.formatRate(root.service.disk.write)
+                : ""
+
+              Column {
+                width: parent.width
+                visible: !root.diskExpanded
+                spacing: Style.spacing.labelGap
+
+                Repeater {
+                  model: root.service && root.service.diskDevices ? root.service.diskDevices.slice(0, 4) : []
+
+                  Item {
+                    required property var modelData
+                    width: parent.width
+                    height: Style.space(16)
+
+                    Text {
+                      anchors.left: parent.left
+                      anchors.verticalCenter: parent.verticalCenter
+                      text: modelData.name
+                      color: dim(root.foreground, 1.5)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Text {
+                      anchors.right: parent.right
+                      anchors.verticalCenter: parent.verticalCenter
+                      text: "↓" + Model.formatRate(modelData.read) + "  ↑" + Model.formatRate(modelData.write)
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+                }
+              }
+
+              // ---------- expanded ----------
+              Item {
+                width: parent.width
+                visible: root.diskExpanded
+                height: visible ? Math.max(Style.space(60), cards.height - Style.space(84)) : 0
+
+                Row {
+                  id: diskGraphs
+                  anchors.top: parent.top
+                  width: parent.width
+                  height: Style.space(74)
+                  spacing: Style.space(12)
+
+                  readonly property real cell: (width - spacing * 2) / 3
+
+                  MemGraph {
+                    width: diskGraphs.cell
+                    height: diskGraphs.height
+                    label: "READ"
+                    reading: root.service ? Model.formatRate(root.service.disk.read) : ""
+                    values: root.service ? root.service.diskReadHistory : []
+                    scaleMax: 0
+                  }
+
+                  MemGraph {
+                    width: diskGraphs.cell
+                    height: diskGraphs.height
+                    label: "WRITE"
+                    reading: root.service ? Model.formatRate(root.service.disk.write) : ""
+                    values: root.service ? root.service.diskWriteHistory : []
+                    scaleMax: 0
+                  }
+
+                  // Throughput says how much is moving; utilisation says how
+                  // hard the device is working to move it. A drive can be at
+                  // 100% util shifting very little, which is the interesting
+                  // case and the one a byte-rate graph alone hides.
+                  MemGraph {
+                    width: diskGraphs.cell
+                    height: diskGraphs.height
+                    label: "BUSIEST DEVICE"
+                    reading: root.service ? Math.round(root.service.diskUtil) + "% util" : ""
+                    values: root.service ? root.service.diskUtilHistory : []
+                    scaleMax: 100
+                    hot: root.service && root.service.diskUtil >= 90
+                  }
+                }
+
+                Row {
+                  anchors.top: diskGraphs.bottom
+                  anchors.topMargin: Style.space(12)
+                  anchors.bottom: parent.bottom
+                  width: parent.width
+                  spacing: Style.space(20)
+
+                  readonly property real cell: (width - spacing * 2) / 3
+
+                  // --- devices ---
+                  ScrollColumn {
+                    width: parent.cell
+                    height: parent.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "DEVICES"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.diskDevices : []
+
+                      Column {
+                        required property var modelData
+                        width: parent.width
+                        spacing: Style.space(1)
+
+                        Item {
+                          width: parent.width
+                          height: Style.space(17)
+
+                          Text {
+                            anchors.left: parent.left
+                            text: modelData.name
+                            color: root.foreground
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+
+                          Text {
+                            anchors.right: parent.right
+                            text: "↓" + Model.formatRate(modelData.read) + "  ↑" + Model.formatRate(modelData.write)
+                            color: dim(root.foreground, 1.3)
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+                        }
+
+                        // The iostat figures: how hard the queue is working and
+                        // how long a request is taking, which is what tells a
+                        // busy device from a struggling one.
+                        Text {
+                          width: parent.width
+                          text: "  " + Number(modelData.iops).toFixed(0) + " iops · "
+                            + Number(modelData.util).toFixed(0) + "% util · q "
+                            + modelData.queue + " · " + Number(modelData.latency).toFixed(2) + " ms"
+                          elide: Text.ElideRight
+                          color: Number(modelData.util) >= 90
+                            ? root.urgent : dim(root.foreground, 1.7)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+                  }
+
+                  // --- filesystems ---
+                  ScrollColumn {
+                    width: parent.cell
+                    height: parent.height
+                    spacing: Style.space(5)
+
+                    PanelSectionHeader {
+                      text: "FILESYSTEMS"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.filesystems : []
+
+                      Column {
+                        required property var modelData
+                        width: parent.width
+                        spacing: Style.space(1)
+
+                        // Matches df's Use%, so the number is comparable with
+                        // what the terminal says.
+                        readonly property bool nearlyFull: Number(modelData.percent) >= 90
+
+                        Item {
+                          width: parent.width
+                          height: Style.space(16)
+
+                          Text {
+                            anchors.left: parent.left
+                            anchors.right: fsPercent.left
+                            anchors.rightMargin: Style.space(8)
+                            text: modelData.mounts.join(", ")
+                            elide: Text.ElideRight
+                            color: parent.parent.nearlyFull ? root.urgent : root.foreground
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                          }
+
+                          Text {
+                            id: fsPercent
+                            anchors.right: parent.right
+                            text: Number(modelData.percent).toFixed(0) + "%"
+                            color: parent.parent.nearlyFull ? root.urgent : root.foreground
+                            font.family: root.fontFamily
+                            font.pixelSize: Style.font.caption
+                            font.bold: parent.parent.nearlyFull
+                          }
+                        }
+
+                        Meter {
+                          ground: root.background
+                          width: parent.width
+                          fraction: Number(modelData.percent) / 100
+                          foreground: root.foreground
+                          fill: parent.nearlyFull ? root.urgent : root.foreground
+                          fontFamily: root.fontFamily
+                          trackHeight: Style.space(3)
+                          compact: true
+                        }
+
+                        Text {
+                          width: parent.width
+                          text: "  " + modelData.fstype + " · "
+                            + Model.formatBytes(modelData.avail) + " free"
+                          elide: Text.ElideRight
+                          color: dim(root.foreground, 1.7)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+                  }
+
+                  // --- I/O by process ---
+                  ScrollColumn {
+                    width: parent.cell
+                    height: parent.height
+                    spacing: Style.space(6)
+
+                    PanelSectionHeader {
+                      text: "I/O BY PROCESS"
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                    }
+
+                    Text {
+                      visible: root.service && root.service.ioProcesses.length === 0
+                      text: "no block I/O this interval"
+                      color: dim(root.foreground, 1.8)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Repeater {
+                      model: root.service ? root.service.ioProcesses.slice(0, 8) : []
+
+                      Item {
+                        required property var modelData
+                        width: parent.width
+                        height: Style.space(17)
+
+                        Text {
+                          anchors.left: parent.left
+                          anchors.right: ioRate.left
+                          anchors.rightMargin: Style.space(8)
+                          text: modelData.name
+                          elide: Text.ElideRight
+                          color: root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+
+                        Text {
+                          id: ioRate
+                          anchors.right: parent.right
+                          text: "↓" + Model.formatRate(modelData.read) + "  ↑" + Model.formatRate(modelData.write)
+                          color: dim(root.foreground, 1.3)
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+                    }
+
+                    // Unlike network, the kernel does account for this per
+                    // process — but only to the owner, so the list is partial
+                    // by design and says how partial.
+                    Text {
+                      width: parent.width
+                      wrapMode: Text.WordWrap
+                      topPadding: Style.space(6)
+                      text: root.service && root.service.ioTotal > 0
+                        ? "Readable for " + root.service.ioReadable + " of "
+                          + root.service.ioTotal + " processes; the rest are other users'."
+                        : ""
+                      color: dim(root.foreground, 1.8)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          PanelSeparator { foreground: root.foreground }
+
+          // ------------------------------------------------ filter + sort
+          Item {
+            width: parent.width
+            implicitHeight: Style.space(22)
+
+            Text {
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+              text: {
+                if (root.filterText !== "") return "filter: " + root.filterText + "▏"
+                if (root.appsMode) {
+                  var grouped = root.service && root.service.groupApps
+                  return "Applications  ·  " + (grouped ? "grouped" : "by scope")
+                    + " (g)  ·  Ctrl+A to switch  ·  ? for keys"
+                }
+                return (root.treeMode ? "Process tree" : "Processes")
+                  + "  ·  Ctrl+A to switch  ·  ? for keys"
+              }
+              elide: Text.ElideRight
+              width: parent.width - Style.space(90)
+              color: root.filterText === "" ? dim(root.foreground, 1.8) : root.accent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+            }
+
+            Text {
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              text: root.rows.length + " shown"
+              color: dim(root.foreground, 1.6)
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+            }
+          }
+
+          // -------------------------------------------------- table header
+          //
+          // The header has to reproduce ProcessRow's geometry exactly: same
+          // insets, same conditional columns, same gap count. Two things had
+          // drifted. ProcessRow insets its Row a few pixels each side and the
+          // header did not, so every heading sat slightly right of the values
+          // it labels, in every view. And Row drops the spacing of an invisible
+          // child along with its width, so the chevron the header always
+          // reserved but an application row never has left the PROCESS heading
+          // a whole column-and-gap right of the names underneath it.
+          Row {
+            id: header
+            width: parent.width
+            height: Style.space(20)
+            spacing: Style.space(8)
+            // Matches ProcessRow's Row margins, which are otherwise a constant
+            // few pixels of skew between every heading and its column.
+            leftPadding: Style.space(6)
+            rightPadding: Style.space(4)
+
+            // Name, CPU, memory and the kill column are always present (three
+            // gaps); pid and wait are always on in the overlay (two more); the
+            // chevron is the only one that comes and goes.
+            readonly property int gapCount: 5 + (root.rowsExpandable ? 1 : 0)
+            readonly property real fixedWidth: leftPadding + rightPadding
+              + spacing * gapCount
+              + (root.rowsExpandable ? Style.space(16) : 0)
+              + Style.space(56) + Style.space(64) + Style.space(60)
+              + Style.space(72) + Style.space(22)
+
+            Item {
+              visible: root.rowsExpandable                    // chevron column
+              width: visible ? Style.space(16) : 0
+              height: 1
+            }
+            SortHeader {
+              width: Style.space(56)
+              label: root.appsMode ? "PROCS" : "PID"
+              sort: root.appsMode ? "procs" : "pid"
+              alignment: Text.AlignRight
+            }
+            SortHeader {
+              width: header.width - header.fixedWidth
+              label: "PROCESS"
+              sort: "name"
+            }
+            SortHeader {
+              width: Style.space(64)
+              label: root.appsMode ? "STALL" : (root.listMode === "processes" ? "WAIT" : "USER")
+              sort: root.appsMode ? "ioStall" : (root.listMode === "processes" ? "wait" : "")
+              alignment: root.appsMode || root.listMode === "processes" ? Text.AlignRight : Text.AlignLeft
+            }
+            SortHeader { width: Style.space(60); label: "CPU"; sort: "cpu"; alignment: Text.AlignRight }
+            SortHeader {
+              width: Style.space(72)
+              label: "MEMORY"
+              sort: root.appsMode ? "mem" : "rss"
+              alignment: Text.AlignRight
+            }
+            Item { width: Style.space(22); height: 1 }
+          }
+
+          // --------------------------------------------------- the table
+          ListView {
+            id: list
+            width: parent.width
+            // Fill whatever the cards and chrome above did not take.
+            height: parent.height - y
+            clip: true
+            model: root.rows
+            boundsBehavior: Flickable.StopAtBounds
+            spacing: Style.space(1)
+            currentIndex: root.selectedIndex
+            cacheBuffer: Style.space(400)
+
+            // A row plus, when expanded, that process's threads underneath it.
+            // The delegate is a Column so the ListView measures the pair as one
+            // variable-height item and scrolling stays correct.
+            delegate: Column {
+              id: rowGroup
+              required property var modelData
+              required property int index
+
+              readonly property bool expanded: root.expandedPid === modelData.pid
+
+              width: list.width
+
+              ProcessRow {
+                ground: root.background
+                width: parent.width
+                height: Style.space(34)
+                process: rowGroup.modelData
+                detailed: true
+                machineCapacity: root.service ? Math.max(1, root.service.coreCount) * 100 : 100
+                appMode: root.appsMode
+                depth: Number(rowGroup.modelData.depth) || 0
+                showWait: root.listMode === "processes"
+                expandable: root.rowsExpandable
+                expanded: rowGroup.expanded
+                selected: root.appsMode
+                  ? rowGroup.modelData.unit === root.selectedUnit
+                  : rowGroup.modelData.pid === root.selectedPid
+                foreground: root.foreground
+                accent: root.accent
+                urgent: root.urgent
+                fontFamily: root.fontFamily
+
+                onActivated: {
+                  if (root.appsMode) root.selectedUnit = rowGroup.modelData.unit
+                  else root.selectedPid = rowGroup.modelData.pid
+                }
+                onExpandToggled: {
+                  root.selectedPid = rowGroup.modelData.pid
+                  root.toggleThreads(rowGroup.modelData.pid)
+                }
+                onKillRequested: function(signalName) {
+                  if (root.service) root.service.killProcess(rowGroup.modelData.pid, signalName)
+                }
+              }
+
+              Loader {
+                width: parent.width
+                active: rowGroup.expanded
+                visible: active
+                sourceComponent: threadList
+              }
+            }
+
+            // Threads of the expanded process. Its own component so the
+            // delegate stays legible and the rows cost nothing when collapsed.
+            Component {
+              id: threadList
+
+              Column {
+                readonly property var threads: root.service ? root.service.threads : []
+
+                spacing: 0
+                bottomPadding: Style.space(6)
+
+                Text {
+                  visible: parent.threads.length === 0
+                  leftPadding: Style.space(78)
+                  height: Style.space(22)
+                  verticalAlignment: Text.AlignVCenter
+                  text: "Reading threads…"
+                  color: dim(root.foreground, 1.7)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.caption
+                }
+
+                Repeater {
+                  model: parent.threads
+
+                  Item {
+                    required property var modelData
+                    width: list.width
+                    height: Style.space(20)
+
+                    readonly property real cpuValue: Number(modelData.cpu) || 0
+                    readonly property bool hot: cpuValue >= 50
+
+                    // Indented under the process name column, so the threads
+                    // read as belonging to the row above rather than as peers.
+                    Text {
+                      anchors.left: parent.left
+                      anchors.leftMargin: Style.space(78)
+                      anchors.verticalCenter: parent.verticalCenter
+                      text: "└ " + modelData.tid
+                      color: dim(root.foreground, 1.8)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Text {
+                      anchors.left: parent.left
+                      anchors.leftMargin: Style.space(148)
+                      anchors.right: threadCpu.left
+                      anchors.rightMargin: Style.space(8)
+                      anchors.verticalCenter: parent.verticalCenter
+                      text: modelData.name + "  ·  " + Model.stateName(modelData.state)
+                      elide: Text.ElideRight
+                      color: dim(root.foreground, 1.4)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Text {
+                      id: threadCpu
+                      anchors.right: parent.right
+                      // Lands on ProcessRow's CPU column: its Row's right
+                      // margin, the kill column, the memory column, and the
+                      // gap either side of memory. Counted out rather than
+                      // written as one number so it stays checkable against
+                      // the row — it was two gaps short, which pushed every
+                      // thread's percentage right of the process above it.
+                      anchors.rightMargin: Style.space(4 + 22 + 8 + 72 + 8)
+                      anchors.verticalCenter: parent.verticalCenter
+                      width: Style.space(60)
+                      horizontalAlignment: Text.AlignRight
+                      text: parent.cpuValue.toFixed(1) + "%"
+                      color: parent.hot ? root.urgent : dim(root.foreground, 1.2)
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+                }
+              }
+            }
+
+            Text {
+              anchors.centerIn: parent
+              visible: root.rows.length === 0
+              text: {
+                if (!root.service || !root.service.ready) return "Waiting for the first sample…"
+                var noun = root.appsMode ? "application" : "process"
+                if (root.filterText !== "") return "No " + noun + " matches “" + root.filterText + "”"
+                return "Collecting " + noun + " data…"
+              }
+              color: dim(root.foreground, 1.6)
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // A bordered panel with a heading, a big reading, a caption, and whatever
+  // graphs the caller nests inside it.
+  component StatCard: BorderSurface {
+    id: statCard
+    default property alias cardContent: cardColumn.children
+
+    property string heading: ""
+    property string reading: ""
+    property string detail: ""
+    property bool readingHot: false
+    property bool interactive: false
+
+    signal cardClicked()
+
+    radius: Style.cornerRadius
+    color: cardMouse.containsMouse
+      ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+    borderSpec: Border.none()
+
+    Behavior on color { ColorAnimation { duration: 120 } }
+
+    MouseArea {
+      id: cardMouse
+      anchors.fill: parent
+      enabled: statCard.interactive
+      hoverEnabled: statCard.interactive
+      cursorShape: statCard.interactive ? Qt.PointingHandCursor : Qt.ArrowCursor
+      onClicked: statCard.cardClicked()
+    }
+
+    Column {
+      anchors.fill: parent
+      anchors.margins: Style.space(12)
+      spacing: Style.space(8)
+
+      Item {
+        width: parent.width
+        implicitHeight: cardReading.implicitHeight
+
+        Text {
+          anchors.left: parent.left
+          // Stop where the reading starts. A wide reading ("385 KB/s") would
+          // otherwise be painted straight through the heading.
+          anchors.right: cardReading.left
+          anchors.rightMargin: Style.space(6)
+          anchors.bottom: cardReading.baseline
+          anchors.bottomMargin: -Style.space(1)
+          text: statCard.heading
+          elide: Text.ElideRight
+          color: dim(root.foreground, 1.4)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          font.letterSpacing: 1.2
+        }
+
+        Text {
+          id: cardReading
+          anchors.right: parent.right
+          text: statCard.reading
+          color: statCard.readingHot ? root.urgent : root.foreground
+          font.family: root.fontFamily
+          // Rates run far longer than percentages; stepping the size down
+          // keeps a five-card row from having to choose between the number
+          // and the label that says what it is.
+          font.pixelSize: statCard.reading.length > 6 ? Style.font.heading : Style.font.display
+          font.bold: true
+
+          Behavior on color { ColorAnimation { duration: 200 } }
+        }
+      }
+
+      Text {
+        width: parent.width
+        text: statCard.detail
+        elide: Text.ElideRight
+        color: dim(root.foreground, 1.6)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+      }
+
+      Column {
+        id: cardColumn
+        width: parent.width
+        spacing: Style.space(8)
+      }
+    }
+  }
+
+  // A temperature over time, plotted on a fixed 30–100°C scale with a dashed
+  // line at the point where a part is usually throttling. Fixed rather than
+  // autoscaled on purpose: autoscale would turn a degree of idle jitter into a
+  // dramatic mountain range, and the question being asked is "how close is this
+  // to its limit", which only a stable scale can answer at a glance.
+  // A detail column that scrolls when its content outgrows the card, with a
+  // scrollbar that only appears when there is something to scroll to. Without
+  // this a long list — six filesystems, a dozen interfaces — simply ran past
+  // the bottom of the card and was silently cut off.
+  component ScrollColumn: Item {
+    id: scrollRoot
+
+    default property alias content: inner.children
+    property real spacing: Style.space(6)
+
+    readonly property bool overflowing: flick.contentHeight > flick.height + 1
+
+    function scrollBy(delta) {
+      if (!overflowing) return
+      flick.contentY = Math.max(0, Math.min(flick.contentHeight - flick.height, flick.contentY + delta))
+    }
+
+    // Registered so the keyboard can reach it; whichever card is expanded is
+    // the only one with live columns, so Ctrl+arrow never has to guess.
+    Component.onCompleted: root.registerScrollable(scrollRoot)
+    Component.onDestruction: root.unregisterScrollable(scrollRoot)
+
+    Flickable {
+      id: flick
+      anchors.fill: parent
+      // Give the bar its own gutter rather than letting it sit over the text.
+      anchors.rightMargin: scrollRoot.overflowing ? Style.space(9) : 0
+      clip: true
+      contentWidth: width
+      contentHeight: inner.implicitHeight
+      boundsBehavior: Flickable.StopAtBounds
+      flickableDirection: Flickable.VerticalFlick
+
+      Column {
+        id: inner
+        width: flick.width
+        spacing: scrollRoot.spacing
+      }
+    }
+
+    Rectangle {
+      visible: scrollRoot.overflowing
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.bottom: parent.bottom
+      width: Style.space(3)
+      radius: width / 2
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+
+      Rectangle {
+        width: parent.width
+        radius: parent.radius
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.35)
+        height: Math.max(Style.space(16), parent.height * (flick.height / Math.max(1, flick.contentHeight)))
+        y: {
+          var scrollable = Math.max(1, flick.contentHeight - flick.height)
+          return (parent.height - height) * Math.min(1, Math.max(0, flick.contentY / scrollable))
+        }
+      }
+    }
+  }
+
+  // A labelled memory trace, optionally with a second series overlaid on the
+  // same scale (drawn fainter, so the pair reads as foreground against
+  // background rather than as two equal claims).
+  component MemGraph: Item {
+    property string label: ""
+    property string reading: ""
+    property var values: []
+    property var secondaryValues: []
+    property real scaleMax: 0
+    property bool hot: false
+
+    Rectangle {
+      anchors.fill: parent
+      radius: Style.space(3)
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+    }
+
+    Text {
+      id: memGraphLabel
+      anchors.left: parent.left
+      anchors.top: parent.top
+      anchors.margins: Style.space(6)
+      text: parent.label
+      color: dim(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: true
+      font.letterSpacing: 1.0
+    }
+
+    Text {
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.margins: Style.space(6)
+      text: parent.reading
+      color: parent.hot ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: true
+    }
+
+    // Background series first so the primary one draws over it.
+    Sparkline {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      anchors.top: memGraphLabel.bottom
+      anchors.margins: Style.space(6)
+      visible: parent.secondaryValues.length > 0
+      values: parent.secondaryValues
+      capacity: root.service ? root.service.historyPoints : 60
+      maxValue: parent.scaleMax
+      stroke: dim(root.foreground, 1.7)
+      lineWidth: 1
+      fillOpacity: 0.06
+    }
+
+    Sparkline {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      anchors.top: memGraphLabel.bottom
+      anchors.margins: Style.space(6)
+      values: parent.values
+      capacity: root.service ? root.service.historyPoints : 60
+      maxValue: parent.scaleMax
+      stroke: parent.hot ? root.urgent : root.foreground
+      lineWidth: 1
+      fillOpacity: 0.18
+      showBaseline: true
+    }
+  }
+
+  component TempGraph: Item {
+    property string label: ""
+    property real value: 0
+    property var history: []
+    property real floor: 30
+    property real ceiling: 100
+    property real throttlePoint: 90
+    property string unit: "°C"
+    // Temperature is bad when high; signal strength is bad when low. Same
+    // graph, opposite sense of "past the line".
+    property bool invertHot: false
+
+    readonly property bool hot: invertHot ? value <= throttlePoint : value >= throttlePoint
+
+    Rectangle {
+      anchors.fill: parent
+      radius: Style.space(3)
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+    }
+
+    Text {
+      id: tempLabel
+      anchors.left: parent.left
+      anchors.top: parent.top
+      anchors.margins: Style.space(5)
+      text: parent.label
+      color: dim(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: true
+      font.letterSpacing: 1.0
+    }
+
+    Text {
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.margins: Style.space(5)
+      text: Math.round(parent.value) + parent.unit
+      color: parent.hot ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      font.bold: true
+    }
+
+    Sparkline {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      anchors.top: tempLabel.bottom
+      anchors.margins: Style.space(5)
+      values: parent.history
+      capacity: root.service ? root.service.historyPoints : 60
+      minValue: parent.floor
+      maxValue: parent.ceiling
+      thresholdValue: parent.throttlePoint
+      thresholdColor: root.urgent
+      stroke: parent.hot ? root.urgent : root.foreground
+      lineWidth: 1
+      fillOpacity: 0.18
+    }
+  }
+
+  // One engine's utilisation: title, current percentage, and its history.
+  // `supported: false` greys the cell out rather than drawing a flat zero line
+  // that would read as "idle" when it actually means "not reported".
+  component EngineGraph: Item {
+    property string label: ""
+    property real value: 0
+    property var history: []
+    property bool supported: true
+
+    Rectangle {
+      anchors.fill: parent
+      radius: Style.space(3)
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+    }
+
+    Text {
+      id: engineLabel
+      anchors.left: parent.left
+      anchors.top: parent.top
+      anchors.margins: Style.space(6)
+      text: parent.label
+      color: dim(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: true
+      font.letterSpacing: 1.0
+    }
+
+    Text {
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.margins: Style.space(6)
+      text: parent.supported ? Math.round(parent.value) + "%" : "n/a"
+      color: parent.supported && parent.value >= 85 ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      font.bold: true
+    }
+
+    Sparkline {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      anchors.top: engineLabel.bottom
+      anchors.margins: Style.space(6)
+      visible: parent.supported
+      values: parent.history
+      capacity: root.service ? root.service.historyPoints : 60
+      maxValue: 100
+      stroke: root.foreground
+      showBaseline: true
+    }
+  }
+
+  // Stacked label-over-value pair for the GPU hardware readouts.
+  component Readout: Column {
+    property string label: ""
+    property string value: ""
+
+    visible: value !== ""
+    spacing: Style.spacing.labelGap
+
+    PanelSectionHeader {
+      text: parent.label
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+
+    Text {
+      text: parent.value
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+    }
+  }
+
+  // Column label that sorts on click and marks the active column's direction.
+  component SortHeader: Text {
+    property string label: ""
+    property string sort: ""
+    property int alignment: Text.AlignLeft
+
+    readonly property bool active: sort !== "" && root.sortId === sort
+
+    height: parent ? parent.height : implicitHeight
+    verticalAlignment: Text.AlignVCenter
+    horizontalAlignment: alignment
+    text: label + (active ? (root.sortDescending ? " ▼" : " ▲") : "")
+    elide: Text.ElideRight
+    color: active ? root.accent : dim(root.foreground, 1.6)
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.caption
+    font.bold: true
+    font.letterSpacing: 0.8
+
+    MouseArea {
+      anchors.fill: parent
+      enabled: parent.sort !== ""
+      cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+      onClicked: root.applySort(parent.sort)
+    }
+  }
+}

--- a/shell/plugins/omatask/ProcessRow.qml
+++ b/shell/plugins/omatask/ProcessRow.qml
@@ -11,13 +11,8 @@ Rectangle {
   // "less prominent" on a dark ground; on a light theme it makes secondary text
   // darker — and therefore louder — than the primary text it sits behind. This
   // moves toward the background either way.
-  readonly property bool groundIsDark: {
-    var g = root.ground
-    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
-  }
-  function dim(c, amount) {
-    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
-  }
+  readonly property bool groundIsDark: Model.groundIsDark(root.ground)
+  function dim(c, amount) { return Model.dim(root.ground, c, amount) }
 
   // The surface this sits on, so dim() knows which way to move.
   property color ground: Color.popups.background

--- a/shell/plugins/omatask/ProcessRow.qml
+++ b/shell/plugins/omatask/ProcessRow.qml
@@ -1,0 +1,264 @@
+import QtQuick
+import qs.Commons
+import "Model.js" as Model
+
+// One process. The compact form (bar panel) shows name, CPU, and memory; the
+// detailed form (overlay) adds pid, user, thread count, and the full command.
+Rectangle {
+  id: root
+
+  // Dimming has to know what it is dimming *against*. dim() only reads as
+  // "less prominent" on a dark ground; on a light theme it makes secondary text
+  // darker — and therefore louder — than the primary text it sits behind. This
+  // moves toward the background either way.
+  readonly property bool groundIsDark: {
+    var g = root.ground
+    return (g.r * 0.2126 + g.g * 0.7152 + g.b * 0.0722) < 0.5
+  }
+  function dim(c, amount) {
+    return groundIsDark ? Qt.darker(c, amount) : Qt.lighter(c, amount)
+  }
+
+  // The surface this sits on, so dim() knows which way to move.
+  property color ground: Color.popups.background
+
+  property var process: ({})
+  property bool detailed: false
+  property bool selected: false
+  property color foreground: Color.foreground
+  property color accent: Color.accent
+  property color urgent: Color.urgent
+  property string fontFamily: Style.font.family
+  // "Eating the machine" has to be measured against the machine. CPU here is
+  // on the per-core scale — 100% is one core, so the ceiling is coreCount×100 —
+  // and a fixed threshold on that scale means wildly different things on
+  // different hardware: 50% is an eighth of a 4-core laptop but a sixtieth of a
+  // 32-thread desktop, where a browser sits above it permanently and the tint
+  // stops meaning anything. So the test is a share of total capacity.
+  property real machineCapacity: 100      // coreCount × 100; 100 until told
+  property real hotShare: 0.2             // a fifth of the machine
+
+  property bool expandable: false
+  property bool expanded: false
+  // An application row aggregates a whole systemd scope, so it counts member
+  // processes where a process row shows a pid, and reports I/O stall where a
+  // process reports its own runqueue wait.
+  property bool appMode: false
+  // Depth in the process tree; 0 in the flat and application views.
+  property int depth: 0
+  // Flat process view shows runqueue wait here; the tree shows the user,
+  // because indentation already costs the row horizontal space.
+  property bool showWait: false
+
+  signal activated()
+  signal expandToggled()
+  signal killRequested(string signalName)
+
+  readonly property real cpuValue: Number(process.cpu) || 0
+  readonly property real cpuShare: machineCapacity > 0 ? cpuValue / machineCapacity : 0
+  readonly property bool hot: cpuShare >= hotShare
+  // Name, CPU, memory, and the kill button are always present (three gaps);
+  // the chevron adds one more and the detailed pid/user columns add two.
+  readonly property int gapCount: 3 + (expandable ? 1 : 0) + (detailed ? 2 : 0)
+
+  width: parent ? parent.width : implicitWidth
+  height: Style.spacing.popupRowHeight
+  radius: Style.space(4)
+  color: selected ? Style.selectedFillFor(foreground, accent, urgent)
+    : (hover.hovered ? Style.hoverFillFor(foreground, accent, urgent) : "transparent")
+
+  Behavior on color { ColorAnimation { duration: 120 } }
+
+  HoverHandler { id: hover }
+
+  MouseArea {
+    anchors.fill: parent
+    acceptedButtons: Qt.LeftButton
+    onClicked: root.activated()
+  }
+
+  Row {
+    anchors.fill: parent
+    anchors.leftMargin: Style.space(6)
+    anchors.rightMargin: Style.space(4)
+    spacing: Style.space(8)
+
+    // Disclosure for the thread list. Only meaningful on a process with more
+    // than one thread, so single-threaded rows get the space but not the arrow.
+    Item {
+      id: chevron
+      visible: root.expandable
+      width: visible ? Style.space(16) : 0
+      height: parent.height
+
+      Text {
+        anchors.centerIn: parent
+        visible: Number(root.process.threads) > 1
+        text: root.expanded ? "▾" : "▸"
+        color: root.expanded ? root.accent : dim(root.foreground, 1.6)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        enabled: Number(root.process.threads) > 1
+        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: root.expandToggled()
+      }
+    }
+
+    Text {
+      id: pidText
+      visible: root.detailed
+      width: visible ? Style.space(56) : 0
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.appMode ? String(root.process.procs || "") : String(root.process.pid || "")
+      horizontalAlignment: Text.AlignRight
+      color: dim(root.foreground, 1.5)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+    }
+
+    // Name and command share one column: the name is what you scan for, the
+    // command is what tells two identical names apart. It takes whatever the
+    // fixed columns leave — Row only puts spacing between *visible* children,
+    // so the gap count tracks which optional columns are on.
+    Column {
+      id: nameColumn
+      // Tree rows step their text right by depth. The indent is applied inside
+      // this column, never to its geometry: a Row positions its children in
+      // sequence, so it owns their x and an `x:` binding here is ignored while
+      // a width shrunk by the indent still pulls USER, CPU and MEMORY left by
+      // that much. Every nested row then drifts further out of line with the
+      // header than the one above it.
+      readonly property real indent: root.depth * Style.space(13)
+      width: parent.width - parent.spacing * root.gapCount
+        - chevron.width - pidText.width - userText.width
+        - Style.space(60) - Style.space(72) - killButton.width
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: 0
+
+      Text {
+        width: parent.width
+        leftPadding: nameColumn.indent
+        text: String(root.process.name || "")
+        elide: Text.ElideRight
+        color: root.hot ? root.urgent : root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        font.bold: root.hot
+      }
+
+      Text {
+        visible: root.detailed
+        width: parent.width
+        leftPadding: nameColumn.indent
+        height: visible ? implicitHeight : 0
+        // An application's second line names the systemd scope it came from,
+        // which is what distinguishes two scopes that resolve to the same
+        // binary — the Hyprland-launched Chromium from the XDG-activated one.
+        text: {
+          if (!root.appMode) return Model.shortCommand(root.process.cmd, root.process.name)
+          // A merged row's unit name is no longer the whole truth, so it says
+          // how many scopes it covers instead.
+          var scopes = Number(root.process.scopes) || 1
+          return scopes > 1 ? scopes + " scopes merged" : String(root.process.unit || "")
+        }
+        elide: Text.ElideRight
+        color: dim(root.foreground, 1.7)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
+
+    Text {
+      id: userText
+      visible: root.detailed
+      width: visible ? Style.space(64) : 0
+      anchors.verticalCenter: parent.verticalCenter
+      // Stall and wait are the "why is this slow" numbers, so they earn the
+      // urgent tint; the owning user is just context.
+      readonly property real stall: root.appMode
+        ? (Number(root.process.ioStall) || 0)
+        : (Number(root.process.wait) || 0)
+      readonly property bool stalling: stall >= 20
+      text: {
+        if (root.appMode) return stall > 0 ? stall.toFixed(1) + "%" : "—"
+        if (root.depth > 0 || !root.showWait) return String(root.process.user || "")
+        return stall > 0 ? stall.toFixed(1) + "%" : "—"
+      }
+      horizontalAlignment: (root.appMode || root.showWait) && root.depth === 0
+        ? Text.AlignRight : Text.AlignLeft
+      elide: Text.ElideRight
+      color: stalling ? root.urgent : dim(root.foreground, 1.5)
+      font.bold: stalling
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+    }
+
+    Text {
+      width: Style.space(60)
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.cpuValue.toFixed(1) + "%"
+      horizontalAlignment: Text.AlignRight
+      color: root.hot ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      font.bold: root.hot
+    }
+
+    Text {
+      width: Style.space(72)
+      anchors.verticalCenter: parent.verticalCenter
+      text: Model.formatBytes(root.appMode ? root.process.mem : root.process.rss)
+      horizontalAlignment: Text.AlignRight
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+    }
+
+    // Kill affordance stays hidden until the row is hovered or selected, so a
+    // list at rest is a readout rather than a wall of destructive buttons.
+    Item {
+      id: killButton
+      width: Style.space(22)
+      height: parent.height
+      opacity: (hover.hovered || root.selected) && !root.appMode ? 1 : 0
+
+      Behavior on opacity { NumberAnimation { duration: 120 } }
+
+      Rectangle {
+        anchors.centerIn: parent
+        width: Style.space(18)
+        height: Style.space(18)
+        radius: Style.space(3)
+        color: killArea.containsMouse
+          ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.22)
+          : "transparent"
+
+        Text {
+          anchors.centerIn: parent
+          text: "✕"
+          color: killArea.containsMouse ? root.urgent : dim(root.foreground, 1.4)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+        }
+      }
+
+      MouseArea {
+        id: killArea
+        anchors.fill: parent
+        enabled: hover.hovered || root.selected
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        // Left asks the process to exit, right insists. Same split as
+        // htop's SIGTERM/SIGKILL, without a modal in the way.
+        onClicked: function(mouse) {
+          root.killRequested(mouse.button === Qt.RightButton ? "KILL" : "TERM")
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/omatask/README.md
+++ b/shell/plugins/omatask/README.md
@@ -1,0 +1,390 @@
+# Task Manager
+
+A system monitor for Omarchy Quattro. One plugin inside the long-running
+`omarchy-shell` process, three surfaces sharing one sampler, themed off the
+shell palette so it follows `omarchy theme set` without a hard-coded colour
+anywhere.
+
+It takes its shape from btop and htop — per-core meters, live rates, a process
+table you can sort and signal — and its layout from Dave Plummer's Windows Task
+Manager: a graph you read at a glance, a compact mode that stays out of the way,
+and a full mode for when you actually need to find something.
+
+## Why
+
+On 17 August 2026 Dave Plummer — who wrote the original Windows Task Manager —
+[installed Omarchy for the first time](https://x.com/davepl1968/status/2089409079630606803):
+
+> I installed @dhh's Omarchy - and then realized I'd never touched Arch before,
+> let alone Hyprland. […] This is first light on Arch, so there will be a few
+> rough edges to sort out, but it works :-)
+
+[Tobi Lütke replied](https://x.com/tobi/status/2089433491171623008):
+
+> We definitely need omatasks
+
+Internally it is **omatask**: plugin id `omarchy.omatask`, IPC target `omatask`,
+state in `~/.local/state/omarchy/omatask/`, matching Quattro's Omawrite /
+Omacut / Omacalc family. Everything a person reads says "Task Manager".
+
+---
+
+## Surfaces
+
+| Surface | Reached by | Shows |
+|---|---|---|
+| **Bar widget** | always visible | CPU history graph and current percentage |
+| **Panel** | click the widget | CPU graph, per-core grid, memory, swap, GPU, network and disk rates, busiest eight processes |
+| **Window** | `Expand` in the panel · right-click the widget | Five stat cards that each expand, plus the full process table with filter, sort, threads and signals |
+
+Neither surface claims a keybinding. To bind them, add to
+`~/.config/hypr/bindings.lua` — `CTRL+SHIFT+ESCAPE` is the shortcut every other
+desktop uses for a task manager, and `SUPER+ESCAPE` is already Omarchy's system
+menu:
+
+```lua
+o.bind("CTRL + SHIFT + ESCAPE", "Task manager", "omarchy-shell shell toggle omarchy.omatask")
+o.bind("SUPER + CTRL + ESCAPE", "Task manager panel", "omarchy-shell omarchy.omatask toggle")
+```
+
+## Keys
+
+Everything is reachable from the keyboard alone; the mouse is an alternative,
+never the only route. The overlay carries one line of chrome and keeps the full
+list behind `?` — which opens the legend only when the filter is empty, since
+otherwise it is just a character.
+
+**Panel**
+
+| Key | Does |
+|---|---|
+| `↑` `↓` / `j` `k` | Move through the rows |
+| `x` | Terminate the selected process |
+| `Enter` / `Space` | Expand to the overlay |
+| `Tab` | Move to the next bar panel |
+| `Esc` | Close |
+
+**Overlay**
+
+| Key | Does |
+|---|---|
+| any character | Filter by name, command, user or pid |
+| `Backspace` / `Ctrl+U` | Edit / clear the filter |
+| `↑` `↓` · `PgUp` `PgDn` · `Home` `End` | Move the selection |
+| `Enter` / `→` | Expand the process into its threads |
+| `←` | Collapse it |
+| `Del` / `Shift+Del` | Terminate / kill |
+| `s` / `c` | Suspend / resume |
+| `[` / `]` | Lower / raise priority |
+| `Ctrl+O` | Open files and sockets |
+| `Tab` / `Shift+Tab` | Cycle the sort column |
+| `Ctrl+R` | Reverse the sort |
+| `Ctrl+A` | Cycle processes / applications / tree |
+| `g` | Group an app's scopes (Applications view) |
+| `Ctrl+L` `Ctrl+G` `Ctrl+M` `Ctrl+N` `Ctrl+D` | Expand the CPU / GPU / memory / network / disk card |
+| `Ctrl+↑` `Ctrl+↓` | Scroll the expanded card |
+| `?` | Key legend |
+| `Esc` | Clear the filter, then close |
+
+With the mouse: a row's `✕` terminates on left-click and kills on right-click,
+the `▸` chevron expands threads, any card toggles its expanded view, and column
+headers sort — clicking the active column flips direction.
+
+---
+
+## The three lists
+
+`Ctrl+A` cycles between them.
+
+**Processes** — the flat table, covering every process on the machine. Its
+**wait** column is time spent runnable but not running, from `schedstat`: the
+number that explains a machine feeling slow while CPU% reads calm. Under 2×
+oversubscription a process here shows 38% CPU against 63% waiting.
+
+**Applications** — grouped by systemd scope. Omarchy launches every app into
+its own scope, so the kernel has already grouped processes the way people think
+about them; this is the view other Linux monitors struggle with, because it
+depends on the desktop registering a cgroup per app. Rows show member count,
+aggregate CPU, honest `memory.current` rather than a sum of double-counted RSS,
+and **I/O stall** — the share of the interval the app spent blocked on disk.
+That last column exists even where per-app I/O *bytes* do not, because PSI is
+exposed per cgroup whether or not the io controller is delegated.
+
+**Tree** — the same data with parent/child structure, so forty-seven chromium
+processes read as one family.
+
+### How an application is identified
+
+Grouping pulls two ways. One app can own several scopes — Chromium launched
+from the menu and Chromium activated through XDG. But different apps can share
+a process name: `podcast-worker.service` and `hermes-gateway.service` are both
+`python`, and merging on `comm` would fuse two unrelated programs.
+
+So identity comes from the unit, which systemd already made unique:
+
+| Scope | Identity | Example |
+|---|---|---|
+| `*.service` | the unit name | `podcast-worker` |
+| `app-….scope` | the desktop id, minus compositor tag and hash | `org.chromium.Chromium` → `chromium` |
+| `docker-…`, `libpod-`, `machine-` | the container id, labelled from inside | `mongod (1111aaaa)` |
+| launcher or tmux scope | the heaviest process inside | `app-Hyprland-gtk-launch-…` → `slack` |
+
+Two `mongo:7` containers are two databases, so they stay two rows. Press `g` to
+see the raw scopes instead.
+
+---
+
+## Expandable cards
+
+Each stat card opens into what that resource actually decomposes into, which is
+different for each. They are mutually exclusive. Detail columns clip and scroll,
+growing a scrollbar only when there is something to scroll to.
+
+### CPU — `Ctrl+L`
+
+One history graph per logical core. Each core keeps its own ring whether or not
+the view is open, so it opens showing the last two minutes. Cells shrink to fit
+the core count before resorting to scrolling; 32 threads land in three rows.
+
+Below: CPU and GPU temperature graphs, every hwmon sensor the kernel exposes,
+and fans. Sensor names are translated from driver names to hardware — `k10temp`
+→ CPU, `spd5118` → DIMM, `mt7921_phy0` → WiFi — and where two devices report
+the same sensor the *device* is numbered, so a pair of drives reads
+`NVMe 1 Composite` / `NVMe 2 Composite`.
+
+Temperature graphs use a fixed 30–100 °C scale with a dashed line at 90 °C
+rather than autoscaling, which would turn a degree of idle jitter into a
+mountain range. Crossing the line turns the trace urgent.
+
+### Memory — `Ctrl+M`
+
+- **Graphs** — used, swap used, and *processes against page cache on one shared
+  scale*. Anonymous memory climbing while cache is squeezed out is the shape of
+  a machine running out of room, and only visible when the two are plotted
+  together.
+- **Where it went** — process memory, shared/tmpfs, slab (reclaimable vs
+  locked), page tables, kernel stacks. "22 GB used" hides that ~4 GB of it is
+  kernel slab. Reclaimable page cache is listed apart, because it is not "used"
+  in any sense worth alarming about.
+- **Pressure** — PSI stall percentages for memory, CPU and I/O. A memory bar at
+  90% may be healthy page cache; `some avg10` above zero means tasks *actually
+  stalled waiting*.
+- **Swap, DIMM temperature, commit** — swap areas with priority; for zram the
+  algorithm, what it holds, the ratio and the RAM saved. `Committed_AS` against
+  `CommitLimit`, stated rather than alarmed about, since overcommit is normal.
+
+### GPU — `Ctrl+G`
+
+A graph per engine (graphics, encode, decode), the hardware readouts — VRAM, SM
+and memory clocks, fan, power against its enforced limit, PCIe throughput — and
+**VRAM by process**. Any counter the driver declines to report is omitted
+rather than drawn as a confident zero.
+
+| Vendor | Source |
+|---|---|
+| NVIDIA | NVML through `ctypes`; ~0.15 ms per sample, no `nvidia-smi` fork |
+| AMD | `amdgpu` sysfs — no engine or per-client queries exist there, so those rows are absent |
+
+### Network — `Ctrl+N`
+
+- **Graphs** — down, up, and **wifi signal in dBm**, on an inverted temperature
+  graph with the line at −70. Signal is the one network reading that is a
+  *condition* rather than a rate: throughput can be zero because nothing is
+  being asked for, but a sagging dBm is always a fact about the link.
+- **Links** — state, negotiated speed and duplex, MTU, wifi quality, and each
+  interface's own throughput rather than only the total.
+- **Errors and drops** — since-boot counters, urgent when non-zero, labelled as
+  counters so a large lifetime number is not read as a live problem.
+- **TCP sockets** — counts by state.
+
+Interfaces are filtered twice: container plumbing (`veth*`, `br-*`, `docker*`)
+double-counts the physical link beneath it, and a link with no carrier is
+excluded — an unplugged NIC still appears in `/proc/net/dev` with frozen
+counters, and listing it as active is a small lie.
+
+### Disk — `Ctrl+D`
+
+- **Graphs** — read, write, and *busiest device utilisation*. Throughput says
+  how much is moving; utilisation says how hard the device is working to move
+  it. A drive can sit at 100% util shifting very little.
+- **Devices** — throughput, IOPS, %util, queue depth and mean request latency,
+  from the extended `/proc/diskstats` fields. This is iostat's data.
+- **Filesystems** — usage per *filesystem*, not per mount: a btrfs pool with
+  subvolumes at `/`, `/home` and `/var/log` is one thing to run out of. The
+  percentage matches `df`'s Use%, measured against spendable space so ext4's
+  root reserve is not counted as free.
+- **I/O by process** — which processes are touching the block device.
+
+---
+
+## Threads, files and actions
+
+Expanding a process lists its threads with per-thread CPU, busiest first, from
+`/proc/<pid>/task/`. One process is expanded at a time and the sampler only
+walks task directories while one is. Single-threaded processes show no
+disclosure.
+
+`Ctrl+O` lists a process's open files and sockets — "what is holding this port",
+"why can't I unmount this" — resolved by joining socket inodes against
+`/proc/net/tcp`.
+
+Beyond signals, a process can be renice'd (`[` `]`), suspended and resumed
+(`s` `c`), and pinned to a CPU set. Priority changes try unprivileged first and
+escalate through `pkexec` only when the kernel refuses, so lowering priority —
+which needs no privilege — never raises a dialog.
+
+**CPU percentages are per-core**: 100% is one core saturated, so the ceiling is
+core count × 100. A row is drawn urgent by its *share of the machine* rather
+than a fixed number, because a fixed threshold means a sixtieth of a 32-thread
+desktop and an eighth of a 4-core laptop.
+
+---
+
+## Alerts — off until you ask
+
+Disabled by default. A monitor that starts pushing notifications the moment it
+is installed is making a decision that belongs to the person running it, and a
+disk you filled on purpose does not need telling you about.
+
+Enable in `Setup > Plugins`, or:
+
+```json
+{ "id": "omarchy.omatask", "alerts": true }
+```
+
+Once on, alerts go to the shell's own notification daemon: a filesystem past
+95%, sustained memory stall, a CPU at its thermal limit, btrfs metadata
+exhaustion or device errors, and failed systemd units. Each latches on the way
+up and clears on the way down, so a value flapping around a threshold cannot
+spam.
+
+## Settings
+
+Per bar-widget entry in `~/.config/omarchy/shell.json`, or through
+`Setup > Plugins`.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `intervalSec` | `2` | Seconds between samples |
+| `historyPoints` | `60` | Samples kept for the graphs — 60 × 2s is two minutes |
+| `processLimit` | `60` | How many command lines are resolved (not how many processes are listed) |
+| `showPercent` | `true` | CPU percentage beside the bar graph |
+| `barGraph` | `"sparkline"` | `sparkline`, `bars`, or `none` |
+| `alerts` | `false` | Desktop notifications |
+| `groupApps` | `true` | Fold an app's scopes into one row |
+| `listMode` | `"processes"` | Which list the overlay opens on |
+| `sortBy` | `"cpu"` | Sort column |
+| `sortDescending` | `true` | Largest first |
+
+## What is remembered
+
+A preference is how you like the tool; transient state is what you happen to be
+doing. The first survives a shell restart, the second does not — a filter that
+came back after an `omarchy update` would be a bug.
+
+| Remembered | Deliberately not |
+|---|---|
+| List mode, grouping, sort column and direction | Filter text, selected row |
+| Everything in the settings table | Expanded process, expanded card |
+| Recorded history | The key legend |
+
+Preferences write back to the widget's `shell.json` entry, so the keyboard and
+`Setup > Plugins` never disagree. Values equal to the default are omitted, so
+the config records only actual choices.
+
+---
+
+## How it works
+
+```
+sampler.py ──JSON lines──> Service.qml ──┬──> BarWidget.qml  (bar + panel)
+ (one python3; /proc, /sys,   history,   └──> Overlay.qml    (full table)
+  cgroups, NVML)              rates, gates
+```
+
+`Service.qml` is the plugin's `service` entry point, so the shell mounts exactly
+one and hands the same instance to both surfaces. History lives there, which is
+why graphs are populated the moment a surface opens.
+
+`sampler.py` runs for the life of the shell and emits one JSON object per
+interval, holding the previous `/proc` snapshot in memory so every CPU figure is
+a true delta rather than the since-boot average `ps` reports. Commands arrive on
+stdin (`interval`, `procs`, `apps`, `gpu`, `sensors`, `netdetail`, `diskdetail`,
+`sockets`, `openfiles`, `threads`, `history`, `quit`), so changing a setting or
+opening a view never restarts it and never interrupts the history.
+
+### Paying only for what is on screen
+
+Every expensive reading is collected only while something displays it.
+
+| Reading | Cost | Collected when |
+|---|---|---|
+| Everything always-on | **1.5 ms** | always |
+| Process table | ~14 ms | the panel or overlay is open |
+| Application cgroups | ~10 ms | the Applications view is open |
+| Off-CPU hwmon sensors | ~23 ms — NVMe admin commands, DIMM I²C, wifi firmware | the CPU, memory or disk card is expanded |
+| GPU PCIe + per-client VRAM | ~41 ms — NVML samples PCIe over a fixed window | the GPU card is expanded |
+| NIC errors + socket table | ~4 ms | the network card is expanded |
+| Per-process block I/O | ~1.3 ms per 60 processes | the disk card is expanded |
+| Thread list | one `task/` walk | a process is expanded |
+
+The NVIDIA driver is not mapped at all until a GPU surface opens, which costs
+~31 MB of RSS and 0.8 ms per sample. At rest the sampler measures **0.00% CPU
+and about 6.6 MB RSS**.
+
+### Flight recorder
+
+History is appended to `~/.local/state/omarchy/omatask/history.jsonl`, roughly
+400 KB per day at a 30 s tick, and replayed at startup — so the graphs survive
+`omarchy update` and can answer "what happened at 3am".
+
+This is fixed-tick sampling, the model zenith uses. It is deliberately not
+atop's: atop hooks BSD process accounting and can attribute a process that both
+started and exited between two samples. Nothing here sees such a process.
+
+---
+
+## Limits
+
+Things a monitor might reasonably want that this machine will not give up.
+
+| Wanted | Blocker |
+|---|---|
+| Per-process network bytes | No per-process network accounting exists in `/proc`. Needs eBPF or packet capture, as `nethogs` does. Per-process *connections* are shown instead |
+| Per-process PSS | `smaps_rollup` costs ~0.39 ms per process; RSS double-counts shared pages, so the memory column overstates a browser |
+| CPU package watts | `energy_uj` is root-only — the PLATYPUS mitigation |
+| NVMe SMART / wear | Needs `NVME_IOCTL_ADMIN_CMD` and `CAP_SYS_ADMIN` |
+| Fan RPM | Needs a super-I/O driver; MSI B650 boards want the out-of-tree `nct6687d`. The GPU fan comes from NVML and is unaffected |
+| Per-app I/O bytes | `io.stat` needs `Delegate=…io` on `user@.service`. Docker already delegates it, so containers have it today |
+
+Two of these are stated in the UI rather than left to be discovered:
+per-process disk I/O reports how many processes it could read (`/proc/<pid>/io`
+is owner-only — typically a few hundred of several hundred), and the network card says outright that
+per-process bandwidth is unavailable.
+
+## Tests
+
+```bash
+python3 test_sampler.py
+```
+
+Fifty-seven checks over the parsers and derivations, on fixture strings rather
+than live `/proc`, so the suite is deterministic. The parsers are what deserve
+testing: a sampler bug is silent by nature — a mis-parsed field surfaces as a
+plausible-looking wrong number, not a crash. Mutation-checked; breaking the
+latency divisor or making PSI read `full` instead of `some` both fail it.
+
+## Development
+
+Run `omarchy-restart-shell` after editing any QML here. Saving can appear to
+hot-reload, but both that and `omarchy-shell shell rescanPlugins` may still
+serve a **cached compiled QML type** for a file whose contents changed — if an
+edit stubbornly refuses to take effect, restart the shell before assuming the
+edit is wrong.
+
+```bash
+journalctl --user -f | grep omatask                      # errors
+omarchy-shell omarchy.omatask open|close|toggle|expand   # the bar panel
+omarchy-shell shell toggle omarchy.omatask               # the window
+./test/shell                                             # includes the sampler suite
+```

--- a/shell/plugins/omatask/README.md
+++ b/shell/plugins/omatask/README.md
@@ -33,7 +33,7 @@ Omacut / Omacalc family. Everything a person reads says "Task Manager".
 
 | Surface | Reached by | Shows |
 |---|---|---|
-| **Bar widget** | always visible | CPU history graph and current percentage |
+| **Bar widget** | always visible | CPU history graph and current percentage, and optionally a second metric — memory, swap or GPU — beside it |
 | **Panel** | click the widget | CPU graph, per-core grid, memory, swap, GPU, network and disk rates, busiest eight processes |
 | **Window** | `Expand` in the panel · right-click the widget | Five stat cards that each expand, plus the full process table with filter, sort, threads and signals |
 
@@ -268,8 +268,9 @@ Per bar-widget entry in `~/.config/omarchy/shell.json`, or through
 | `intervalSec` | `2` | Seconds between samples |
 | `historyPoints` | `60` | Samples kept for the graphs — 60 × 2s is two minutes |
 | `processLimit` | `60` | How many command lines are resolved (not how many processes are listed) |
-| `showPercent` | `true` | CPU percentage beside the bar graph |
+| `showPercent` | `true` | Percentage beside each bar graph |
 | `barGraph` | `"sparkline"` | `sparkline`, `bars`, or `none` |
+| `secondaryMetric` | `"none"` | A second reading in the bar beside CPU: `mem`, `swap`, `gpu`, or `none` |
 | `alerts` | `false` | Desktop notifications |
 | `groupApps` | `true` | Fold an app's scopes into one row |
 | `listMode` | `"processes"` | Which list the overlay opens on |

--- a/shell/plugins/omatask/Service.qml
+++ b/shell/plugins/omatask/Service.qml
@@ -1,0 +1,710 @@
+import QtQuick
+import Quickshell.Io
+import "Model.js" as Model
+
+// Shared telemetry singleton for the task manager. The shell mounts one of
+// these per session and hands the same instance to the bar widget (via
+// `bar.shell.serviceFor`) and to the summoned overlay (injected as `service`),
+// so both surfaces read one sampler and one history rather than starting a
+// second /proc walk each.
+Item {
+  id: root
+
+  // The plugin's internal id. Public labels say "Task Manager"; everything the
+  // machine reads — this id, the IPC target, the layer-shell namespace, the
+  // state directory — says omatask, matching Quattro's Omawrite/Omacut family.
+  readonly property string pluginId: "omarchy.omatask"
+
+  // Injected by the shell's service loader.
+  property var shell: null
+  property var manifest: ({})
+  property string omarchyPath: ""
+
+  // Tunables. The bar widget owns the shell.json entry, so it pushes these in
+  // rather than the service re-reading config the widget already parsed.
+  property int intervalSec: 2
+  property int historyPoints: 60
+  property int processLimit: 60
+
+  readonly property string sourceDir: (manifest && manifest.__sourceDir) ? String(manifest.__sourceDir) : ""
+  readonly property bool samplerAvailable: sourceDir !== ""
+
+  // ------------------------------------------------------------- live state
+
+  property var latest: ({})
+  property bool ready: false
+  property string lastError: ""
+
+  property var cpuHistory: []
+  property var memHistory: []
+  property var netRxHistory: []
+  property var netTxHistory: []
+  property var gpuHistory: []
+  property var gpuEncodeHistory: []
+  property var gpuDecodeHistory: []
+  // Temperature rings are filled on every sample, not just while a thermal
+  // view is open, because both readings are on the free path — a CPU die
+  // register and an NVML query. That is what lets the graphs open showing the
+  // last two minutes instead of starting flat.
+  property var cpuTempHistory: []
+  property var gpuTempHistory: []
+  property var memStallHistory: []
+  // All three come out of the meminfo parse we already do, so they cost
+  // nothing and can be collected always — which is what lets the memory
+  // breakdown open with real history instead of an empty canvas.
+  property var memAnonHistory: []
+  property var memCacheHistory: []
+  property var swapUsedHistory: []
+  // /proc/net/wireless costs 0.012ms, so signal strength is collected always
+  // and its graph opens populated like the temperature ones.
+  property var wifiSignalHistory: []
+  property var diskUtilHistory: []
+  property var diskReadHistory: []
+  property var diskWriteHistory: []
+  // One history ring per logical core, for the expanded per-core view. Kept
+  // unconditionally: the alternative is starting every expand from an empty
+  // graph, and 32 rings of 60 floats costs nothing worth measuring.
+  property var coreHistories: []
+
+  readonly property var cpu: latest.cpu || ({})
+  readonly property var mem: latest.mem || ({})
+  readonly property var net: latest.net || ({})
+  readonly property var disk: latest.disk || ({})
+  readonly property var gpu: latest.gpu || ({})
+
+  readonly property var gpuDevices: gpu.devices || []
+  readonly property bool hasGpu: gpuDevices.length > 0
+  readonly property var primaryGpu: hasGpu ? gpuDevices[0] : ({})
+  readonly property real gpuPercent: Number(primaryGpu.util) || 0
+  readonly property real gpuMemUsed: Number(primaryGpu.memUsed) || 0
+  readonly property real gpuMemTotal: Number(primaryGpu.memTotal) || 0
+  readonly property real gpuMemPercent: gpuMemTotal > 0 ? (gpuMemUsed / gpuMemTotal) * 100 : 0
+  readonly property var gpuProcesses: primaryGpu.procs || []
+  // Engine counters are null on a driver or card that cannot report them, and
+  // the UI hides those rows rather than drawing a permanent zero.
+  readonly property bool hasGpuEngines: primaryGpu.encode !== undefined && primaryGpu.encode !== null
+
+  // Threads for the one expanded process, empty when nothing is expanded.
+  readonly property int threadsOf: Number(latest.threadsOf) || 0
+  readonly property var threads: latest.threads || []
+
+  readonly property real cpuPercent: Number(cpu.total) || 0
+  readonly property var cores: cpu.cores || []
+  readonly property int coreCount: Number(cpu.count) || 0
+  readonly property var loadAverage: cpu.load || [0, 0, 0]
+
+  readonly property real memTotal: Number(mem.total) || 0
+  readonly property real memUsed: Number(mem.used) || 0
+  readonly property real memPercent: memTotal > 0 ? (memUsed / memTotal) * 100 : 0
+  readonly property real swapTotal: Number(mem.swapTotal) || 0
+  readonly property real swapUsed: Number(mem.swapUsed) || 0
+  readonly property real swapPercent: swapTotal > 0 ? (swapUsed / swapTotal) * 100 : 0
+
+  // ---------------------------------------------------------- memory detail
+  readonly property var pressure: latest.pressure || ({})
+  readonly property var memPressure: pressure.memory || ({})
+  readonly property var cpuPressure: pressure.cpu || ({})
+  readonly property var ioPressure: pressure.io || ({})
+  readonly property bool hasPressure: pressure.memory !== undefined
+  // `some avg10`: the share of the last ten seconds in which at least one task
+  // stalled waiting for memory. Unlike a usage percentage, anything above zero
+  // is a real symptom.
+  readonly property real memStall: Number(memPressure.some10) || 0
+
+  readonly property var swaps: latest.swaps || []
+
+  // ------------------------------------------------------ preferences
+  //
+  // A preference is a choice about how you like the tool; transient state is
+  // what you happen to be doing right now. The first should survive a shell
+  // restart, the second should not — a filter or a selection that came back
+  // after an update would be a bug, not a feature.
+  //
+  // shell.json is the store, so preferences live in the same place as every
+  // other Omarchy setting and remain editable by hand or through
+  // Setup > Plugins. The bar widget owns that entry and hands its contents
+  // here, because the overlay has no route to it.
+
+  property var widgetSettings: ({})
+
+  // Writing a value that equals the shipped default only adds noise to
+  // shell.json — every fresh install would immediately gain keys nobody set.
+  // These must match manifest.json's defaults.
+  readonly property var preferenceDefaults: ({
+    "groupApps": true,
+    "listMode": "processes",
+    "sortBy": "cpu",
+    "sortDescending": true
+  })
+
+  function persist(key, value) {
+    if (!shell || typeof shell.updateEntryInline !== "function") return
+    if (widgetSettings[key] === value) return      // nothing to write
+    var isDefault = preferenceDefaults[key] === value
+    if (isDefault && widgetSettings[key] === undefined) return   // never set
+    var next = {}
+    for (var k in widgetSettings) next[k] = widgetSettings[k]
+    if (isDefault) delete next[key]      // back at the default: drop the key
+    else next[key] = value
+    widgetSettings = next
+    shell.updateEntryInline(pluginId, next)
+  }
+
+  // ---------------------------------------------------- applications
+  //
+  // Omarchy launches every app into its own systemd scope, so the kernel is
+  // already grouping processes the way a person thinks about them. These are
+  // whole applications — one Chromium, not forty-seven chromium processes —
+  // and `mem` is the honest figure rather than a sum of double-counted RSS.
+  readonly property var apps: latest.apps || []
+  readonly property bool ioDelegated: latest.ioDelegated === true
+  readonly property var userApps: apps.filter(function(a) { return !a.system })
+  readonly property var systemApps: apps.filter(function(a) { return a.system })
+
+  property bool appsDetail: false
+  onAppsDetailChanged: send("apps " + (appsDetail ? "on" : "off"))
+
+  // One row per application, or one row per systemd scope. Grouping is right
+  // nearly always; turning it off is how you see that Chromium is actually two
+  // scopes, or check what a merged row is made of.
+  property bool groupApps: true
+  onGroupAppsChanged: {
+    send("groupapps " + (groupApps ? "on" : "off"))
+    persist("groupApps", groupApps)
+  }
+
+  // Which list the overlay opens on, and how it is ordered. Held by the
+  // service rather than the overlay because the overlay is destroyed every
+  // time it closes, and a preference that dies with the window is not one.
+  property string listMode: "processes"
+  onListModeChanged: persist("listMode", listMode)
+
+  property string sortBy: "cpu"
+  onSortByChanged: persist("sortBy", sortBy)
+
+  property bool sortDescending: true
+  onSortDescendingChanged: persist("sortDescending", sortDescending)
+
+  // ---------------------------------------------------- health & hardware
+  readonly property var cpuFreq: latest.cpufreq || ({})
+  readonly property var coreFreqs: cpuFreq.cores || []
+  readonly property real peakFreq: {
+    var peak = 0
+    for (var i = 0; i < coreFreqs.length; i++) peak = Math.max(peak, coreFreqs[i])
+    return peak
+  }
+  readonly property var irq: latest.irq || ({})
+  readonly property var btrfs: latest.btrfs || []
+  readonly property var failedUnits: latest.failedUnits || []
+
+  // Softirq skew worth reporting. A handful of times is normal scheduling; a
+  // hundred-fold means one core is carrying an interrupt line alone.
+  readonly property var irqWarnings: {
+    var out = []
+    for (var key in irq) {
+      var entry = irq[key]
+      if (entry && entry.imbalance && entry.imbalance >= 20) {
+        out.push({ name: key, imbalance: entry.imbalance, core: entry.busiestCore })
+      }
+    }
+    return out
+  }
+
+  // ---------------------------------------------------- sockets & files
+  readonly property var socketCounts: latest.socketCounts || ({})
+  readonly property var openFiles: latest.openFiles || null
+
+  property bool socketDetail: false
+  onSocketDetailChanged: send("sockets " + (socketDetail ? "on" : "off"))
+
+  property int openFilesPid: 0
+  onOpenFilesPidChanged: send("openfiles " + (openFilesPid > 0 ? openFilesPid : "off"))
+
+  // ---------------------------------------------------- recorded history
+  //
+  // Replayed from disk once per session so the graphs open with whatever was
+  // recorded before this shell started, rather than from an empty canvas.
+  property var recorded: []
+  readonly property bool hasRecorded: recorded.length > 0
+
+  function requestHistory() { send("history") }
+
+  // ------------------------------------------------------------ network
+  readonly property var netLinks: net.links || []
+  readonly property var netInterfaces: net.ifaces || []
+  readonly property var sockets: latest.sockets || ({})
+  readonly property var wifiLink: {
+    for (var i = 0; i < netLinks.length; i++) {
+      if (netLinks[i].wireless) return netLinks[i]
+    }
+    return null
+  }
+  readonly property bool hasWifi: wifiLink !== null
+  // Rounded dBm. -30 is next to the router, -90 is unusable.
+  readonly property real wifiSignal: hasWifi ? Number(wifiLink.wireless.signal) || 0 : 0
+
+  // Rate for one interface, so the link rows can show their own throughput
+  // rather than only the machine-wide total.
+  function rateFor(name) {
+    for (var i = 0; i < netInterfaces.length; i++) {
+      if (netInterfaces[i].name === name) return netInterfaces[i]
+    }
+    return { rx: 0, tx: 0 }
+  }
+
+  // ------------------------------------------------------------- disk
+  readonly property var diskDevices: disk.devices || []
+  readonly property var filesystems: disk.filesystems || []
+  readonly property var ioProcesses: latest.ioProcs || []
+  readonly property int ioReadable: Number(latest.ioReadable) || 0
+  readonly property int ioTotal: Number(latest.ioTotal) || 0
+  // Busiest device's utilisation, for the headline graph.
+  readonly property real diskUtil: {
+    var peak = 0
+    for (var i = 0; i < diskDevices.length; i++) {
+      peak = Math.max(peak, Number(diskDevices[i].util) || 0)
+    }
+    return peak
+  }
+  // Drive temperatures arrive through hwmon, tagged by kind, so they can be
+  // matched back to the block devices they belong to by name.
+  function tempForDevice(name) {
+    var list = driveSensors
+    for (var i = 0; i < list.length; i++) {
+      if (String(list[i].name).toLowerCase().indexOf("composite") !== -1) return list[i].temp
+    }
+    return null
+  }
+
+  property bool diskDetail: false
+  onDiskDetailChanged: send("diskdetail " + (diskDetail ? "on" : "off"))
+
+  property bool netDetail: false
+  onNetDetailChanged: send("netdetail " + (netDetail ? "on" : "off"))
+  readonly property real committed: Number(mem.committed) || 0
+  readonly property real commitLimit: Number(mem.commitLimit) || 0
+  readonly property bool overcommitted: commitLimit > 0 && committed > commitLimit
+
+  // The breakdown behind "used", largest first. Page cache is deliberately
+  // excluded: it is not used memory in any sense a user cares about.
+  readonly property var memBreakdown: {
+    if (!mem.total) return []
+    var parts = [
+      { label: "Processes", key: "anon", value: Number(mem.anon) || 0 },
+      { label: "Shared / tmpfs", key: "shmem", value: Number(mem.shmem) || 0 },
+      { label: "Kernel slab (reclaimable)", key: "slabRecl", value: Number(mem.slabReclaimable) || 0 },
+      { label: "Kernel slab (locked)", key: "slabUnrecl", value: Number(mem.slabUnreclaimable) || 0 },
+      { label: "Page tables", key: "pageTables", value: Number(mem.pageTables) || 0 },
+      { label: "Kernel stacks", key: "kernelStack", value: Number(mem.kernelStack) || 0 }
+    ]
+    return parts.filter(function(p) { return p.value > 0 })
+  }
+
+  // --------------------------------------------------------------- thermals
+  readonly property var thermal: latest.thermal || ({})
+  readonly property var sensors: thermal.sensors || []
+  readonly property var fans: thermal.fans || []
+  // False means the board exposes no tachometer at all — a different thing
+  // from fans that are genuinely stopped, and worth saying out loud.
+  readonly property bool fansAvailable: thermal.fansAvailable === true
+  readonly property bool hasCpuTemp: thermal.cpu !== undefined && thermal.cpu !== null
+  readonly property real cpuTemp: Number(thermal.cpu) || 0
+
+  // The sampler tags each sensor with a coarse kind, so a surface can ask for
+  // the DIMM sensors without re-deriving which hwmon chip names mean memory.
+  function sensorsOfKind(kind) {
+    return (sensors || []).filter(function(s) { return s.kind === kind })
+  }
+  readonly property var dimmSensors: sensorsOfKind("dimm")
+  readonly property var driveSensors: sensorsOfKind("drive")
+
+  // The off-CPU sensors each cost a bus transaction, so they follow the same
+  // rule as PCIe: measured only while a view is listing them.
+  property bool sensorDetail: false
+  onSensorDetailChanged: send("sensors " + (sensorDetail ? "on" : "off"))
+
+  readonly property real uptime: Number(latest.uptime) || 0
+  readonly property var processes: latest.procs || []
+  readonly property int processCount: Number(latest.procCount) || 0
+  readonly property int runningCount: Number(latest.procRunning) || 0
+  readonly property int threadCount: Number(latest.threadCount) || 0
+
+  // ------------------------------------------- process-table subscriptions
+  //
+  // Walking every /proc/<pid> is the expensive half of a sample, and it is
+  // wasted while the only thing on screen is a bar sparkline. Surfaces that
+  // show processes retain the table for as long as they are open; the sampler
+  // stops building it when the last one lets go.
+
+  property int _processHolders: 0
+  readonly property bool processesActive: _processHolders > 0
+
+  function retainProcesses() {
+    _processHolders = _processHolders + 1
+  }
+
+  function releaseProcesses() {
+    _processHolders = Math.max(0, _processHolders - 1)
+  }
+
+  onProcessesActiveChanged: {
+    send("procs " + (processesActive ? "on" : "off"))
+    // The table is stale the moment we stop collecting it. Clearing avoids a
+    // reopened panel showing whatever the CPU ordering was minutes ago.
+    if (!processesActive && latest.procs) {
+      var next = {}
+      for (var key in latest) next[key] = latest[key]
+      delete next.procs
+      latest = next
+    }
+  }
+
+  onIntervalSecChanged: send("interval " + intervalSec)
+  onProcessLimitChanged: send("limit " + processLimit)
+
+  // ------------------------------------------------- thread subscription
+  //
+  // Only one process can be expanded at a time, so this is a plain pid rather
+  // than a refcount: whoever expands last owns the thread view.
+
+  // PCIe throughput and per-client VRAM are only rendered in the expanded GPU
+  // card, and NVML charges ~20ms per PCIe counter, so they follow the same
+  // "measure it while something shows it" rule as the process table.
+  // Nothing displays GPU data at idle, and mapping the NVIDIA driver costs
+  // ~31MB of RSS, so the sampler only loads it while a GPU-showing surface is
+  // open. Retained rather than a plain flag: both the panel and the overlay
+  // can want it at once.
+  property int _gpuHolders: 0
+  readonly property bool gpuWanted: _gpuHolders > 0
+  function retainGpu() { _gpuHolders = _gpuHolders + 1 }
+  function releaseGpu() { _gpuHolders = Math.max(0, _gpuHolders - 1) }
+  onGpuWantedChanged: send("gpu " + (gpuWanted ? "on" : "off"))
+
+  property bool gpuDetail: false
+
+  onGpuDetailChanged: send("gpudetail " + (gpuDetail ? "on" : "off"))
+
+  property int threadPid: 0
+
+  function watchThreads(pid) {
+    threadPid = Number(pid) || 0
+  }
+
+  function unwatchThreads(pid) {
+    // Ignore a stale collapse from a row that is no longer the expanded one.
+    if (pid === undefined || Number(pid) === threadPid) threadPid = 0
+  }
+
+  onThreadPidChanged: {
+    send("threads " + (threadPid > 0 ? threadPid : "off"))
+    if (threadPid <= 0 && latest.threads) {
+      var next = {}
+      for (var key in latest) next[key] = latest[key]
+      delete next.threads
+      delete next.threadsOf
+      latest = next
+    }
+  }
+
+  onHistoryPointsChanged: {
+    cpuHistory = Model.pushHistory(cpuHistory, cpuPercent, historyPoints)
+    memHistory = Model.pushHistory(memHistory, memPercent, historyPoints)
+  }
+
+  // ------------------------------------------------------------- ingestion
+
+  function ingest(line) {
+    var text = String(line || "").trim()
+    if (text === "") return
+
+    var data
+    try {
+      data = JSON.parse(text)
+    } catch (error) {
+      lastError = "unparseable sample: " + error
+      return
+    }
+
+    // The history replay is a one-shot answer on the same stream, not a sample.
+    if (data.history !== undefined) {
+      recorded = data.history || []
+      return
+    }
+
+    latest = data
+    ready = true
+    lastError = ""
+
+    var sampledMem = data.mem || {}
+    var memTotalBytes = Number(sampledMem.total) || 0
+    cpuHistory = Model.pushHistory(cpuHistory, data.cpu ? data.cpu.total : 0, historyPoints)
+    memHistory = Model.pushHistory(memHistory,
+      memTotalBytes > 0 ? (Number(sampledMem.used) / memTotalBytes) * 100 : 0, historyPoints)
+    netRxHistory = Model.pushHistory(netRxHistory, data.net ? data.net.rx : 0, historyPoints)
+    netTxHistory = Model.pushHistory(netTxHistory, data.net ? data.net.tx : 0, historyPoints)
+
+    var devices = data.gpu ? (data.gpu.devices || []) : []
+    if (devices.length > 0) {
+      gpuHistory = Model.pushHistory(gpuHistory, devices[0].util, historyPoints)
+      gpuEncodeHistory = Model.pushHistory(gpuEncodeHistory, devices[0].encode || 0, historyPoints)
+      gpuDecodeHistory = Model.pushHistory(gpuDecodeHistory, devices[0].decode || 0, historyPoints)
+      if (devices[0].temp !== null && devices[0].temp !== undefined) {
+        gpuTempHistory = Model.pushHistory(gpuTempHistory, devices[0].temp, historyPoints)
+      }
+    }
+
+    // Only pushed when a reading actually arrived: a gap would otherwise be
+    // recorded as 0°C and draw a cliff to the floor of the graph.
+    var thermal = data.thermal || {}
+    if (thermal.cpu !== null && thermal.cpu !== undefined) {
+      cpuTempHistory = Model.pushHistory(cpuTempHistory, thermal.cpu, historyPoints)
+    }
+
+    memAnonHistory = Model.pushHistory(memAnonHistory, Number(sampledMem.anon) || 0, historyPoints)
+    memCacheHistory = Model.pushHistory(memCacheHistory, Number(sampledMem.cached) || 0, historyPoints)
+    swapUsedHistory = Model.pushHistory(swapUsedHistory, Number(sampledMem.swapUsed) || 0, historyPoints)
+
+    var devices = (data.disk || {}).devices || []
+    var busiest = 0
+    for (var di = 0; di < devices.length; di++) {
+      busiest = Math.max(busiest, Number(devices[di].util) || 0)
+    }
+    diskUtilHistory = Model.pushHistory(diskUtilHistory, busiest, historyPoints)
+    diskReadHistory = Model.pushHistory(diskReadHistory, (data.disk || {}).read || 0, historyPoints)
+    diskWriteHistory = Model.pushHistory(diskWriteHistory, (data.disk || {}).write || 0, historyPoints)
+
+    var links = (data.net || {}).links || []
+    for (var li = 0; li < links.length; li++) {
+      if (links[li].wireless) {
+        wifiSignalHistory = Model.pushHistory(wifiSignalHistory, links[li].wireless.signal, historyPoints)
+        break
+      }
+    }
+
+    var memoryPressure = (data.pressure || {}).memory
+    if (memoryPressure) {
+      memStallHistory = Model.pushHistory(memStallHistory, memoryPressure.some10 || 0, historyPoints)
+    }
+
+    evaluateAlerts()
+
+    coreHistories = Model.pushCoreHistories(coreHistories,
+      data.cpu ? data.cpu.cores : [], historyPoints)
+  }
+
+  function send(command) {
+    if (!sampler.running) return
+    sampler.write(command + "\n")
+  }
+
+  // ------------------------------------------------------------- processes
+
+  // SIGTERM asks; SIGKILL insists. The panel offers TERM on click and KILL
+  // only behind a confirm, matching what every other task manager does.
+  function killProcess(pid, signal) {
+    var target = Number(pid)
+    if (!(target > 0)) return
+    var name = String(signal || "TERM").toUpperCase()
+    if (["TERM", "KILL", "INT", "HUP", "STOP", "CONT", "USR1", "USR2"].indexOf(name) === -1) return
+    killer.command = ["kill", "-" + name, String(target)]
+    killer.running = true
+  }
+
+  // Nice presets, matching the vocabulary a person uses rather than the
+  // kernel's -20..19 scale. Values follow the convention Resources settled on.
+  readonly property var nicePresets: [
+    { label: "Very high", nice: -19 },
+    { label: "High",      nice: -5 },
+    { label: "Normal",    nice: 0 },
+    { label: "Low",       nice: 5 },
+    { label: "Very low",  nice: 19 }
+  ]
+
+  function niceLabel(value) {
+    var n = Number(value)
+    if (n <= -8) return "Very high"
+    if (n <= -3) return "High"
+    if (n <= 2) return "Normal"
+    if (n <= 6) return "Low"
+    return "Very low"
+  }
+
+  // Lowering niceness needs privilege; raising it does not. Try unprivileged
+  // first and only escalate when the kernel actually refuses, so the common
+  // case never shows an authentication dialog.
+  function setPriority(pid, nice) {
+    var target = Number(pid)
+    if (!(target > 0)) return
+    var value = Math.max(-20, Math.min(19, Math.round(Number(nice) || 0)))
+    priorityAction.command = ["sh", "-c",
+      "renice -n " + value + " -p " + target + " >/dev/null 2>&1 || " +
+      "pkexec renice -n " + value + " -p " + target]
+    priorityAction.running = true
+  }
+
+  // A comma-separated CPU list, e.g. "0-7,16". taskset applies to the whole
+  // process; threads created afterwards inherit it.
+  function setAffinity(pid, cpuList) {
+    var target = Number(pid)
+    if (!(target > 0)) return
+    var list = String(cpuList || "").replace(/[^0-9,\-]/g, "")
+    if (list === "") return
+    affinityAction.command = ["taskset", "-a", "-pc", list, String(target)]
+    affinityAction.running = true
+  }
+
+  Process {
+    id: priorityAction
+    stderr: SplitParser { onRead: function(line) { root.lastError = String(line) } }
+  }
+
+  Process {
+    id: affinityAction
+    stderr: SplitParser { onRead: function(line) { root.lastError = String(line) } }
+  }
+
+  // ------------------------------------------------------------- alerts
+  //
+  // A monitor you have to be looking at is a monitor that misses things, and
+  // the shell hosting this plugin already owns a notification daemon.
+
+  // Off until asked for. A monitor that starts pushing desktop notifications
+  // the moment it is installed is making a decision that belongs to the person
+  // running it — and the conditions it alarms on (a full disk, a hot CPU) are
+  // often already known and deliberate.
+  property bool alertsEnabled: false
+  property var _alerted: ({})
+
+  function alert(key, summary, body, urgent) {
+    if (!alertsEnabled || _alerted[key]) return
+    // Latch per condition: a disk that is full stays full, and a notification
+    // every two seconds would be worse than none.
+    var next = {}
+    for (var k in _alerted) next[k] = _alerted[k]
+    next[key] = true
+    _alerted = next
+
+    notifier.command = ["notify-send", "-a", "Task Manager",
+                        "-u", urgent ? "critical" : "normal",
+                        summary, body]
+    notifier.running = true
+  }
+
+  function clearAlert(key) {
+    if (!_alerted[key]) return
+    var next = {}
+    for (var k in _alerted) if (k !== key) next[k] = _alerted[k]
+    _alerted = next
+  }
+
+  Process { id: notifier }
+
+  // Conditions worth interrupting someone for. Each latches on the way up and
+  // clears on the way down, so a flapping value does not spam.
+  function evaluateAlerts() {
+    if (!ready) return
+
+    for (var i = 0; i < filesystems.length; i++) {
+      var fs = filesystems[i]
+      var key = "fs:" + fs.device
+      if (Number(fs.percent) >= 95) {
+        alert(key, "Filesystem almost full",
+              fs.mounts.join(", ") + " is " + Math.round(fs.percent) + "% full — "
+              + Model.formatBytes(fs.avail) + " left", true)
+      } else if (Number(fs.percent) < 90) {
+        clearAlert(key)
+      }
+    }
+
+    if (memStall >= 10) {
+      alert("mem-stall", "Memory pressure",
+            "Tasks are stalling on memory (" + memStall.toFixed(1) + "% of the last 10s)", true)
+    } else if (memStall < 2) {
+      clearAlert("mem-stall")
+    }
+
+    if (hasCpuTemp && cpuTemp >= 95) {
+      alert("cpu-temp", "CPU at thermal limit",
+            Math.round(cpuTemp) + "°C — the CPU is likely throttling", true)
+    } else if (hasCpuTemp && cpuTemp < 88) {
+      clearAlert("cpu-temp")
+    }
+
+    for (var d = 0; d < btrfs.length; d++) {
+      var meta = (btrfs[d].allocation || {}).metadata
+      if (meta && Number(meta.percent) >= 95) {
+        alert("btrfs-meta:" + btrfs[d].label, "btrfs metadata nearly full",
+              btrfs[d].label + " metadata is " + Math.round(meta.percent)
+              + "% used — this is how btrfs runs out of space", true)
+      }
+      if (Number(btrfs[d].errors) > 0) {
+        alert("btrfs-err:" + btrfs[d].label, "btrfs device errors",
+              btrfs[d].label + " has logged " + btrfs[d].errors + " device error(s)", true)
+      }
+    }
+
+    if (failedUnits.length > 0) {
+      alert("units:" + failedUnits.length, "systemd units failed",
+            failedUnits.map(function(u) { return u.unit }).join(", "), false)
+    } else {
+      // Keys carry the count, so clear every latch once nothing is failing.
+      for (var k in _alerted) {
+        if (k.indexOf("units:") === 0) clearAlert(k)
+      }
+    }
+  }
+
+  Process {
+    id: killer
+    // A kill that fails (already exited, not ours) is normal and not worth a
+    // dialog — the row simply disappears or does not, on the next sample.
+    stderr: SplitParser { onRead: function(line) { root.lastError = String(line) } }
+  }
+
+  // --------------------------------------------------------------- sampler
+
+  Process {
+    id: sampler
+    running: root.samplerAvailable
+    // No tunables in argv: interval, limit, and the process toggle all change
+    // over stdin, so adjusting a setting never restarts the sampler and never
+    // interrupts the history.
+    command: ["python3", root.sourceDir + "/sampler.py"]
+    stdinEnabled: true
+
+    onStarted: {
+      root.send("interval " + root.intervalSec)
+      root.send("limit " + root.processLimit)
+      root.send("procs " + (root.processesActive ? "on" : "off"))
+      root.send("gpudetail " + (root.gpuDetail ? "on" : "off"))
+      root.send("sensors " + (root.sensorDetail ? "on" : "off"))
+      root.send("netdetail " + (root.netDetail ? "on" : "off"))
+      root.send("diskdetail " + (root.diskDetail ? "on" : "off"))
+      root.send("apps " + (root.appsDetail ? "on" : "off"))
+      root.send("groupapps " + (root.groupApps ? "on" : "off"))
+      root.send("sockets " + (root.socketDetail ? "on" : "off"))
+      root.send("gpu " + (root.gpuWanted ? "on" : "off"))
+      root.requestHistory()
+      if (root.threadPid > 0) root.send("threads " + root.threadPid)
+    }
+
+    stdout: SplitParser { onRead: function(line) { root.ingest(line) } }
+    stderr: SplitParser { onRead: function(line) { root.lastError = String(line) } }
+
+    // A sampler that dies (python upgrade mid-session, OOM kill) would
+    // otherwise leave every surface frozen on its last frame with no hint why.
+    onExited: function(exitCode) {
+      root.ready = false
+      if (root.samplerAvailable) {
+        if (exitCode !== 0) root.lastError = "sampler exited with code " + exitCode
+        restart.restart()
+      }
+    }
+  }
+
+  Timer {
+    id: restart
+    interval: 3000
+    onTriggered: if (root.samplerAvailable && !sampler.running) sampler.running = true
+  }
+}

--- a/shell/plugins/omatask/Service.qml
+++ b/shell/plugins/omatask/Service.qml
@@ -431,7 +431,11 @@ Item {
     try {
       data = JSON.parse(text)
     } catch (error) {
-      lastError = "unparseable sample: " + error
+      // Without a piece of the offending line this says only that parsing
+      // failed, which is the one thing already obvious from the error.
+      var snippet = String(text).slice(0, 120)
+      if (String(text).length > 120) snippet += "…"
+      lastError = "unparseable sample: " + error + " — " + snippet
       return
     }
 

--- a/shell/plugins/omatask/Service.qml
+++ b/shell/plugins/omatask/Service.qml
@@ -266,14 +266,24 @@ Item {
     }
     return peak
   }
-  // Drive temperatures arrive through hwmon, tagged by kind, so they can be
-  // matched back to the block devices they belong to by name.
+  // Drive temperatures arrive through hwmon, which knows nothing about block
+  // devices, so the sampler resolves each chip to the devices it speaks for and
+  // sends them along. Matching on that, rather than on the first sensor that
+  // happens to say "composite", is what stops a second drive from reporting the
+  // first one's temperature.
   function tempForDevice(name) {
-    var list = driveSensors
-    for (var i = 0; i < list.length; i++) {
-      if (String(list[i].name).toLowerCase().indexOf("composite") !== -1) return list[i].temp
+    var wanted = String(name)
+    var fallback = null
+    for (var i = 0; i < driveSensors.length; i++) {
+      var sensor = driveSensors[i]
+      var owned = sensor.devices || []
+      if (owned.indexOf(wanted) === -1) continue
+      // An NVMe chip reports Composite alongside per-die sensors; Composite is
+      // the one that means "this drive". The others run hotter and are parts.
+      if (String(sensor.label).toLowerCase().indexOf("composite") !== -1) return sensor.temp
+      if (fallback === null) fallback = sensor.temp
     }
-    return null
+    return fallback
   }
 
   property bool diskDetail: false
@@ -443,13 +453,13 @@ Item {
     netRxHistory = Model.pushHistory(netRxHistory, data.net ? data.net.rx : 0, historyPoints)
     netTxHistory = Model.pushHistory(netTxHistory, data.net ? data.net.tx : 0, historyPoints)
 
-    var devices = data.gpu ? (data.gpu.devices || []) : []
-    if (devices.length > 0) {
-      gpuHistory = Model.pushHistory(gpuHistory, devices[0].util, historyPoints)
-      gpuEncodeHistory = Model.pushHistory(gpuEncodeHistory, devices[0].encode || 0, historyPoints)
-      gpuDecodeHistory = Model.pushHistory(gpuDecodeHistory, devices[0].decode || 0, historyPoints)
-      if (devices[0].temp !== null && devices[0].temp !== undefined) {
-        gpuTempHistory = Model.pushHistory(gpuTempHistory, devices[0].temp, historyPoints)
+    var sampledGpus = data.gpu ? (data.gpu.devices || []) : []
+    if (sampledGpus.length > 0) {
+      gpuHistory = Model.pushHistory(gpuHistory, sampledGpus[0].util, historyPoints)
+      gpuEncodeHistory = Model.pushHistory(gpuEncodeHistory, sampledGpus[0].encode || 0, historyPoints)
+      gpuDecodeHistory = Model.pushHistory(gpuDecodeHistory, sampledGpus[0].decode || 0, historyPoints)
+      if (sampledGpus[0].temp !== null && sampledGpus[0].temp !== undefined) {
+        gpuTempHistory = Model.pushHistory(gpuTempHistory, sampledGpus[0].temp, historyPoints)
       }
     }
 
@@ -464,10 +474,10 @@ Item {
     memCacheHistory = Model.pushHistory(memCacheHistory, Number(sampledMem.cached) || 0, historyPoints)
     swapUsedHistory = Model.pushHistory(swapUsedHistory, Number(sampledMem.swapUsed) || 0, historyPoints)
 
-    var devices = (data.disk || {}).devices || []
+    var sampledDisks = (data.disk || {}).devices || []
     var busiest = 0
-    for (var di = 0; di < devices.length; di++) {
-      busiest = Math.max(busiest, Number(devices[di].util) || 0)
+    for (var di = 0; di < sampledDisks.length; di++) {
+      busiest = Math.max(busiest, Number(sampledDisks[di].util) || 0)
     }
     diskUtilHistory = Model.pushHistory(diskUtilHistory, busiest, historyPoints)
     diskReadHistory = Model.pushHistory(diskReadHistory, (data.disk || {}).read || 0, historyPoints)

--- a/shell/plugins/omatask/Sparkline.qml
+++ b/shell/plugins/omatask/Sparkline.qml
@@ -1,0 +1,132 @@
+import QtQuick
+
+// History graph for a fixed-capacity series. Newest sample sits at the right
+// edge and older ones march left, so a half-full series scrolls in from the
+// right instead of stretching to fill and then visibly compressing once the
+// buffer wraps.
+Canvas {
+  id: root
+
+  property var values: []
+  // 0 autoscales to the peak in view — right for byte rates, wrong for
+  // percentages, where a flat 3% line should sit near the floor rather than
+  // being stretched to the ceiling.
+  property real maxValue: 100
+  // Floor of the plotted range. Percentages start at zero, but a temperature
+  // does not — a CPU that idles near 40°C and throttles near 95°C would waste
+  // the bottom of the canvas and make idle jitter look dramatic. A floor puts
+  // the band that matters across the full height.
+  property real minValue: 0
+  // Optional reference line, e.g. a thermal limit. 0 draws nothing.
+  property real thresholdValue: 0
+  property color thresholdColor: stroke
+  property int capacity: 0
+  property color stroke: "white"
+  property real fillOpacity: 0.16
+  property real lineWidth: 1.5
+  property bool bars: false
+  property real barGap: 1
+  property bool showBaseline: false
+
+  readonly property int pointCount: (values || []).length
+  readonly property int slots: Math.max(2, capacity > 0 ? capacity : pointCount)
+
+  readonly property real scaleMax: {
+    if (maxValue > 0) return maxValue
+    var peak = 0
+    for (var i = 0; i < pointCount; i++) peak = Math.max(peak, Number(values[i]) || 0)
+    // A flat-zero series still needs a non-zero divisor.
+    return peak > 0 ? peak : 1
+  }
+
+  onValuesChanged: requestPaint()
+  onStrokeChanged: requestPaint()
+  onBarsChanged: requestPaint()
+  onMaxValueChanged: requestPaint()
+  onWidthChanged: requestPaint()
+  onHeightChanged: requestPaint()
+
+  onPaint: {
+    var ctx = getContext("2d")
+    ctx.reset()
+    if (width <= 0 || height <= 0 || pointCount === 0) return
+
+    var step = width / (slots - 1)
+    var offset = slots - pointCount  // right-align a partially filled series
+
+    function yFor(value) {
+      var span = Math.max(1e-6, scaleMax - minValue)
+      var normalized = Math.min(1, Math.max(0, ((Number(value) || 0) - minValue) / span))
+      // Inset by the stroke so a pegged 100% sample is not clipped in half by
+      // the top edge of the canvas.
+      var inset = lineWidth / 2
+      return inset + (1 - normalized) * Math.max(0, height - lineWidth)
+    }
+
+    if (bars) {
+      var barWidth = Math.max(1, step - barGap)
+      ctx.fillStyle = stroke
+      for (var b = 0; b < pointCount; b++) {
+        var top = yFor(values[b])
+        var x = (offset + b) * step - barWidth / 2
+        ctx.fillRect(x, top, barWidth, Math.max(1, height - top))
+      }
+      return
+    }
+
+    ctx.beginPath()
+    for (var i = 0; i < pointCount; i++) {
+      var px = (offset + i) * step
+      var py = yFor(values[i])
+      if (i === 0) ctx.moveTo(px, py)
+      else ctx.lineTo(px, py)
+    }
+
+    if (fillOpacity > 0 && pointCount > 1) {
+      ctx.save()
+      ctx.lineTo((offset + pointCount - 1) * step, height)
+      ctx.lineTo(offset * step, height)
+      ctx.closePath()
+      ctx.globalAlpha = fillOpacity
+      ctx.fillStyle = stroke
+      ctx.fill()
+      ctx.restore()
+
+      // The fill consumed the path; lay the line down again to stroke it.
+      ctx.beginPath()
+      for (var j = 0; j < pointCount; j++) {
+        var lx = (offset + j) * step
+        var ly = yFor(values[j])
+        if (j === 0) ctx.moveTo(lx, ly)
+        else ctx.lineTo(lx, ly)
+      }
+    }
+
+    ctx.strokeStyle = stroke
+    ctx.lineWidth = lineWidth
+    ctx.lineJoin = "round"
+    ctx.stroke()
+
+    if (showBaseline) {
+      ctx.beginPath()
+      ctx.moveTo(0, height - 0.5)
+      ctx.lineTo(width, height - 0.5)
+      ctx.globalAlpha = 0.25
+      ctx.stroke()
+    }
+
+    // Reference line last, so it reads on top of the fill.
+    if (thresholdValue > minValue && thresholdValue < scaleMax) {
+      var ty = Math.round(yFor(thresholdValue)) + 0.5
+      ctx.beginPath()
+      ctx.setLineDash([3, 3])
+      ctx.moveTo(0, ty)
+      ctx.lineTo(width, ty)
+      ctx.globalAlpha = 0.45
+      ctx.lineWidth = 1
+      ctx.strokeStyle = thresholdColor
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
+  }
+}

--- a/shell/plugins/omatask/Sparkline.qml
+++ b/shell/plugins/omatask/Sparkline.qml
@@ -45,6 +45,16 @@ Canvas {
   onMaxValueChanged: requestPaint()
   onWidthChanged: requestPaint()
   onHeightChanged: requestPaint()
+  // Everything else the paint reads. A rendering input without one of these
+  // leaves the last frame on screen after the value behind it has changed.
+  onMinValueChanged: requestPaint()
+  onThresholdValueChanged: requestPaint()
+  onThresholdColorChanged: requestPaint()
+  onCapacityChanged: requestPaint()
+  onFillOpacityChanged: requestPaint()
+  onLineWidthChanged: requestPaint()
+  onBarGapChanged: requestPaint()
+  onShowBaselineChanged: requestPaint()
 
   onPaint: {
     var ctx = getContext("2d")
@@ -64,12 +74,15 @@ Canvas {
     }
 
     if (bars) {
-      var barWidth = Math.max(1, step - barGap)
+      // A bar occupies a slot; a line plot marks the points between them. Using
+      // the line's spacing for bars centres the first and last on the canvas
+      // edges, so each loses half its width off the side.
+      var barStep = width / slots
+      var barWidth = Math.max(1, barStep - barGap)
       ctx.fillStyle = stroke
       for (var b = 0; b < pointCount; b++) {
         var top = yFor(values[b])
-        var x = (offset + b) * step - barWidth / 2
-        ctx.fillRect(x, top, barWidth, Math.max(1, height - top))
+        ctx.fillRect((offset + b) * barStep, top, barWidth, Math.max(1, height - top))
       }
       return
     }

--- a/shell/plugins/omatask/manifest.json
+++ b/shell/plugins/omatask/manifest.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.omatask",
+  "name": "Task Manager",
+  "version": "1.0.0",
+  "author": "Stephen Taylor",
+  "license": "MIT",
+  "description": "Live CPU, memory, GPU, network, disk, and process monitor as a bar widget, an under-bar panel, and a window.",
+  "kinds": [
+    "service",
+    "bar-widget",
+    "overlay"
+  ],
+  "entryPoints": {
+    "service": "Service.qml",
+    "barWidget": "BarWidget.qml",
+    "overlay": "Overlay.qml"
+  },
+  "barWidget": {
+    "displayName": "Task Manager",
+    "description": "Live CPU, memory, GPU, network, disk, and process monitor as a bar widget, an under-bar panel, and a window.",
+    "category": "System",
+    "allowMultiple": false,
+    "defaultSection": "right",
+    "defaults": {
+      "intervalSec": 2,
+      "historyPoints": 60,
+      "processLimit": 60,
+      "showPercent": true,
+      "barGraph": "sparkline",
+      "alerts": false,
+      "groupApps": true,
+      "listMode": "processes",
+      "sortBy": "cpu",
+      "sortDescending": true
+    },
+    "schema": [
+      {
+        "key": "intervalSec",
+        "type": "integer",
+        "label": "Sample interval (seconds)",
+        "description": "How often /proc is sampled. Lower is more responsive and costs more CPU.",
+        "min": 1,
+        "max": 30,
+        "step": 1,
+        "defaultValue": 2
+      },
+      {
+        "key": "historyPoints",
+        "type": "integer",
+        "label": "History points",
+        "description": "How many samples the CPU and memory graphs keep. At the default interval, 60 points is two minutes.",
+        "min": 10,
+        "max": 300,
+        "step": 10,
+        "defaultValue": 60
+      },
+      {
+        "key": "processLimit",
+        "type": "integer",
+        "label": "Processes tracked",
+        "description": "How many processes the sampler reports, ordered by CPU.",
+        "min": 10,
+        "max": 500,
+        "step": 10,
+        "defaultValue": 60
+      },
+      {
+        "key": "showPercent",
+        "type": "boolean",
+        "label": "Show CPU percent",
+        "description": "Print the CPU percentage next to the bar graph.",
+        "defaultValue": true
+      },
+      {
+        "key": "barGraph",
+        "type": "enum",
+        "label": "Bar graph style",
+        "description": "How CPU history is drawn in the bar itself.",
+        "options": [
+          "sparkline",
+          "bars",
+          "none"
+        ],
+        "defaultValue": "sparkline"
+      },
+      {
+        "key": "alerts",
+        "type": "boolean",
+        "label": "Desktop notifications",
+        "description": "Notify when a filesystem passes 95%, memory stalls, the CPU reaches its thermal limit, btrfs metadata fills or logs device errors, or a systemd unit fails. Off by default.",
+        "defaultValue": false
+      },
+      {
+        "key": "groupApps",
+        "type": "boolean",
+        "label": "Group applications",
+        "description": "In the Applications view, fold an app's several systemd scopes into one row \u2014 Chromium launched from the menu and Chromium activated through XDG read as one application. Off shows one row per scope.",
+        "defaultValue": true
+      },
+      {
+        "key": "listMode",
+        "type": "enum",
+        "label": "Default list",
+        "description": "Which list the overlay opens on. Changing it with Ctrl+A is remembered.",
+        "options": [
+          "processes",
+          "apps",
+          "tree"
+        ],
+        "defaultValue": "processes"
+      },
+      {
+        "key": "sortBy",
+        "type": "enum",
+        "label": "Sort column",
+        "description": "Remembered when you change it with Tab or by clicking a header.",
+        "options": [
+          "cpu",
+          "rss",
+          "mem",
+          "wait",
+          "ioStall",
+          "threads",
+          "pid",
+          "name"
+        ],
+        "defaultValue": "cpu"
+      },
+      {
+        "key": "sortDescending",
+        "type": "boolean",
+        "label": "Sort descending",
+        "description": "Largest first. Remembered when you flip it with Ctrl+R.",
+        "defaultValue": true
+      }
+    ]
+  }
+}

--- a/shell/plugins/omatask/manifest.json
+++ b/shell/plugins/omatask/manifest.json
@@ -58,8 +58,8 @@
       {
         "key": "processLimit",
         "type": "integer",
-        "label": "Processes tracked",
-        "description": "How many processes the sampler reports, ordered by CPU.",
+        "label": "Command lines resolved",
+        "description": "Every process is always reported; this is how many of them, busiest by CPU and by memory, get their full command line read from /proc. Reading command lines is the part that scales badly.",
         "min": 10,
         "max": 500,
         "step": 10,

--- a/shell/plugins/omatask/manifest.json
+++ b/shell/plugins/omatask/manifest.json
@@ -28,6 +28,7 @@
       "processLimit": 60,
       "showPercent": true,
       "barGraph": "sparkline",
+      "secondaryMetric": "none",
       "alerts": false,
       "groupApps": true,
       "listMode": "processes",
@@ -68,21 +69,34 @@
       {
         "key": "showPercent",
         "type": "boolean",
-        "label": "Show CPU percent",
-        "description": "Print the CPU percentage next to the bar graph.",
+        "label": "Show percentages",
+        "description": "Print the percentage next to each bar graph.",
         "defaultValue": true
       },
       {
         "key": "barGraph",
         "type": "enum",
         "label": "Bar graph style",
-        "description": "How CPU history is drawn in the bar itself.",
+        "description": "How history is drawn in the bar itself.",
         "options": [
           "sparkline",
           "bars",
           "none"
         ],
         "defaultValue": "sparkline"
+      },
+      {
+        "key": "secondaryMetric",
+        "type": "enum",
+        "label": "Second bar metric",
+        "description": "Show a second reading beside CPU in the bar itself, so both are readable without opening the panel. Memory and swap come out of the sample already being taken. GPU is different \u2014 choosing it keeps the GPU polled for as long as the widget is on the bar. Swap and GPU hide themselves on a machine that has neither.",
+        "options": [
+          "none",
+          "mem",
+          "swap",
+          "gpu"
+        ],
+        "defaultValue": "none"
       },
       {
         "key": "alerts",

--- a/shell/plugins/omatask/sampler.py
+++ b/shell/plugins/omatask/sampler.py
@@ -309,14 +309,18 @@ def read_links(ifaces, detailed=False):
     out = []
     for iface in sorted(ifaces):
         speed = read_sysfs_net(iface, "speed")
+        # Parsed once, then judged: -1 is the kernel's "not applicable" (wifi,
+        # tunnels) and 0 is "not negotiated". Both mean there is no speed to show.
+        link_speed = int(speed) if speed and speed.lstrip("-").isdigit() else None
+        if link_speed is not None and link_speed <= 0:
+            link_speed = None
         entry = {
             "name": iface,
             "state": read_sysfs_net(iface, "operstate") or "unknown",
             "carrier": read_sysfs_net(iface, "carrier") == "1",
             "mtu": int(read_sysfs_net(iface, "mtu") or 0),
             "duplex": read_sysfs_net(iface, "duplex"),
-            # -1 is the kernel's "not applicable", e.g. wifi and tunnels.
-            "speed": int(speed) if speed and speed.lstrip("-").isdigit() and int(speed) > 0 else None,
+            "speed": link_speed,
         }
         if iface in wireless:
             entry["wireless"] = wireless[iface]

--- a/shell/plugins/omatask/sampler.py
+++ b/shell/plugins/omatask/sampler.py
@@ -2223,6 +2223,11 @@ class Sampler:
             if want == self.want_procs:
                 return False
             self.want_procs = want
+            if not want:
+                # Closing a view needs no baseline; re-priming for it would
+                # reset every other one and cost an off-cadence sample.
+                self.prev_procs = {}
+                return False
             return True
         if command == "interval":
             try:
@@ -2288,6 +2293,9 @@ class Sampler:
             if want == self.disk_detail:
                 return False
             self.disk_detail = want
+            if not want:
+                self.prev_proc_io = {}
+                return False
             return True
         if command == "netdetail":
             # Error counters and the socket table, for the expanded network card.
@@ -2321,6 +2329,9 @@ class Sampler:
             if pid == self.thread_pid:
                 return False
             self.thread_pid = max(0, pid)
+            if not self.thread_pid:
+                self.prev_threads = {}
+                return False
             return True
         return False
 

--- a/shell/plugins/omatask/sampler.py
+++ b/shell/plugins/omatask/sampler.py
@@ -1448,13 +1448,26 @@ class AmdGpu:
         except (OSError, ValueError):
             return None
 
+    @staticmethod
+    def _hwmon_dir(device_dir):
+        """The card's hwmon node, whatever number the kernel gave it.
+
+        hwmon indices are global allocation order, not per-device: on a machine
+        whose NVMe drives claim hwmon0 and hwmon1, an amdgpu card is hwmon2 or
+        later. Assuming hwmon0 left temperature, power and clocks permanently
+        null on any machine with another hwmon device enumerated first.
+        """
+        nodes = sorted(glob.glob(os.path.join(device_dir, "hwmon", "hwmon*")))
+        return nodes[0] if nodes else None
+
     def sample(self, detailed=False):
         out = []
         for device_dir, label in self.devices:
             used = self._read_number(os.path.join(device_dir, "mem_info_vram_used"))
             total = self._read_number(os.path.join(device_dir, "mem_info_vram_total"))
-            temp = self._read_number(os.path.join(device_dir, "hwmon/hwmon0/temp1_input"))
-            power = self._read_number(os.path.join(device_dir, "hwmon/hwmon0/power1_average"))
+            hwmon = self._hwmon_dir(device_dir)
+            temp = self._read_number(os.path.join(hwmon, "temp1_input")) if hwmon else None
+            power = self._read_number(os.path.join(hwmon, "power1_average")) if hwmon else None
             out.append({
                 "name": label,
                 "util": self._read_number(os.path.join(device_dir, "gpu_busy_percent")) or 0,
@@ -1470,8 +1483,8 @@ class AmdGpu:
                 "powerLimit": None,
                 "encode": None,
                 "decode": None,
-                "smClock": self._read_number(os.path.join(device_dir, "hwmon/hwmon0/freq1_input")),
-                "memClock": self._read_number(os.path.join(device_dir, "hwmon/hwmon0/freq2_input")),
+                "smClock": self._read_number(os.path.join(hwmon, "freq1_input")) if hwmon else None,
+                "memClock": self._read_number(os.path.join(hwmon, "freq2_input")) if hwmon else None,
                 "fan": None,
                 "pcieTx": None,
                 "pcieRx": None,

--- a/shell/plugins/omatask/sampler.py
+++ b/shell/plugins/omatask/sampler.py
@@ -884,9 +884,11 @@ def read_btrfs():
 def read_failed_units():
     """systemd units in a failed state, system and user.
 
-    Read from the cgroup-adjacent file systemd maintains rather than by forking
-    `systemctl`, which costs orders of magnitude more than everything else in
-    this sampler combined.
+    There is no file to read this from: failure is derived state, so the answer
+    has to come from systemd itself. Forking `systemctl` twice costs several
+    milliseconds — more than everything else in a sample combined — which is why
+    the caller polls this on its own slow timer and carries the last answer
+    between polls rather than asking every tick.
     """
     failed = []
     for scope, command in (("system", ["systemctl", "--failed", "--no-legend", "--plain"]),
@@ -1564,6 +1566,34 @@ CHIP_DISPLAY_NAMES = (
 GENERIC_LABEL_PREFIXES = ("temp", "fan", "in")
 
 
+NVME_NAMESPACE = re.compile(r"^nvme\d+n\d+$")
+
+
+def block_devices_for(chip_dir):
+    """Block devices an hwmon chip reports temperatures for.
+
+    An NVMe controller's hwmon node carries its namespaces (`nvme0n1`) directly
+    under `device/`; a SATA drive's `drivetemp` node carries them under
+    `device/block/`. Without this association a surface asking for one drive's
+    temperature can only guess, and on a two-drive machine it guesses the first
+    one for both — a plausible wrong number, which is the failure mode a monitor
+    must never have.
+    """
+    names = []
+    device_dir = os.path.join(chip_dir, "device")
+    try:
+        for entry in os.listdir(device_dir):
+            if NVME_NAMESPACE.match(entry):
+                names.append(entry)
+    except OSError:
+        pass
+    try:
+        names.extend(os.listdir(os.path.join(device_dir, "block")))
+    except OSError:
+        pass
+    return sorted(set(names))
+
+
 def display_chip(chip):
     for prefix, name, _ in CHIP_DISPLAY_NAMES:
         if chip.startswith(prefix):
@@ -1652,7 +1682,7 @@ class Thermals:
                     name = pretty  # "temp1" says nothing the chip name doesn't
                 else:
                     name = label if pretty == label else "%s %s" % (pretty, label)
-                entry_list[index] = (path, chip, label, name)
+                entry_list[index] = (path, chip, label, name, block_devices_for(chip_dir))
 
     @staticmethod
     def _read_text(path):
@@ -1694,17 +1724,20 @@ class Thermals:
         }
 
         sources = self.cpu_temps + self.other_temps if detailed else self.cpu_temps
-        for path, chip, label, name in sources:
+        for path, chip, label, name, block_devices in sources:
             millidegrees = self._read_number(path)
             if millidegrees is None:
                 continue
             celsius = round(millidegrees / 1000.0, 1)
             if path == self.cpu_path:
                 out["cpu"] = celsius
-            out["sensors"].append({"chip": chip, "kind": chip_kind(chip), "label": label,
-                                   "name": name, "temp": celsius})
+            sensor = {"chip": chip, "kind": chip_kind(chip), "label": label,
+                      "name": name, "temp": celsius}
+            if block_devices:
+                sensor["devices"] = block_devices
+            out["sensors"].append(sensor)
 
-        for path, chip, label, name in self.fans:
+        for path, chip, label, name, _ in self.fans:
             rpm = self._read_number(path)
             if rpm is None:
                 continue

--- a/shell/plugins/omatask/sampler.py
+++ b/shell/plugins/omatask/sampler.py
@@ -1,0 +1,2366 @@
+#!/usr/bin/env python3
+"""Stream system and process telemetry as JSON lines for the Omarchy task manager.
+
+One JSON object per line on stdout, one per sample interval. Everything comes
+from /proc, and the previous snapshot is held in memory so CPU figures are true
+deltas over the interval rather than the since-boot averages `ps` reports.
+
+Commands on stdin, one per line:
+
+  procs on | off      include or omit the process table
+  threads <pid>|off   include per-thread CPU for one process
+  gpudetail on | off  include PCIe throughput and per-client VRAM
+  sensors on | off    include the off-CPU hwmon sensors (NVMe, DIMM, wifi)
+  netdetail on | off  include NIC error counters and the socket table
+  diskdetail on | off include per-process block I/O
+  apps on | off       include per-application cgroup accounting
+  groupapps on | off  fold multiple scopes of one app into a single row
+  gpu on | off        map the GPU driver (off by default; costs ~31MB RSS)
+  sockets on | off    include per-process socket counts
+  openfiles <pid>|off list one process's open files and sockets
+  history             replay the recorded history as one JSON line
+  interval <secs>     change the sample rate
+  limit <n>           how many processes to emit (sorted by CPU)
+  quit                exit
+
+Everything optional is off by default and switched on by whichever surface
+needs it, because the optional readings are the expensive ones: the process
+table is three /proc reads per pid, and NVML's PCIe counters block for ~20ms
+each. A bar sparkline only needs the cheap aggregate lines, and pays for
+nothing else.
+"""
+
+import ctypes
+import glob
+import subprocess
+import json
+import os
+import pwd
+import re
+import select
+import sys
+import time
+
+PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
+SECTOR_BYTES = 512
+
+# Software threads of one expanded process (/proc/<pid>/task/*), NOT CPU
+# hardware threads — those come from /proc/stat's cpuN lines and are never
+# capped, so a 256-thread Threadripper reports 256 cores. This is only a
+# backstop against a pathological process turning one sample into megabytes of
+# JSON; a JVM or browser in the low thousands still lists in full.
+THREAD_LIMIT = 2000
+
+# How many VRAM-holding clients NVML is asked about per device.
+GPU_PROCESS_LIMIT = 64
+
+# How often to fork systemctl for failed-unit status. Units fail rarely and the
+# fork is the most expensive single thing this sampler can do.
+FAILED_UNIT_POLL_SEC = 30
+
+# Interfaces and block devices that would only add noise to a machine-wide
+# throughput readout: loopback is local traffic, container/bridge/virtual links
+# double-count the physical interface underneath them, and loop/ram/zram
+# devices are not disks anyone is trying to see the I/O of. Device-mapper
+# nodes (LUKS, LVM) are skipped for the same reason as bridges — their traffic
+# lands on the physical device below and is already counted there.
+SKIP_IFACE_PREFIXES = ("veth", "docker", "br-", "virbr", "vnet", "tap")
+SKIP_DISK_PREFIXES = ("loop", "ram", "zram", "dm-", "md")
+
+_uid_names = {}
+
+
+def username(uid):
+    name = _uid_names.get(uid)
+    if name is None:
+        try:
+            name = pwd.getpwuid(uid).pw_name
+        except KeyError:
+            name = str(uid)
+        _uid_names[uid] = name
+    return name
+
+
+def read_cpu():
+    """[(busy, total)] jiffie counters: index 0 is the aggregate, 1.. are cores."""
+    out = []
+    with open("/proc/stat") as f:
+        for line in f:
+            if not line.startswith("cpu"):
+                break
+            values = [int(v) for v in line.split()[1:]]
+            # idle + iowait both count as "not doing work" the way top does it.
+            idle = values[3] + (values[4] if len(values) > 4 else 0)
+            out.append((sum(values) - idle, sum(values)))
+    return out
+
+
+MEMINFO_FIELDS = (
+    "MemTotal", "MemFree", "MemAvailable", "Buffers", "Cached",
+    "SReclaimable", "SUnreclaim", "Slab", "SwapTotal", "SwapFree",
+    "AnonPages", "Mapped", "Shmem", "KernelStack", "PageTables",
+    "Dirty", "Writeback", "Committed_AS", "CommitLimit",
+    "Active(file)", "Inactive(file)", "Active(anon)", "Inactive(anon)",
+)
+
+
+def read_mem():
+    """Composition as well as totals — one parse of a file we read anyway.
+
+    "22 GB used" hides that several of those gigabytes are kernel slab rather
+    than anything a process allocated, so the breakdown comes along for free
+    with the summary.
+    """
+    wanted = set(MEMINFO_FIELDS)
+    raw = {}
+    with open("/proc/meminfo") as f:
+        for line in f:
+            key, _, rest = line.partition(":")
+            if key in wanted:
+                raw[key] = int(rest.split()[0]) * 1024
+
+    total = raw.get("MemTotal", 0)
+    # MemAvailable is the kernel's own estimate of what a new allocation could
+    # get, which is what "used" should be measured against — subtracting only
+    # MemFree would count reclaimable page cache as used.
+    available = raw.get("MemAvailable", raw.get("MemFree", 0))
+    swap_total = raw.get("SwapTotal", 0)
+    return {
+        "total": total,
+        "used": total - available,
+        "avail": available,
+        "free": raw.get("MemFree", 0),
+        "cached": raw.get("Cached", 0) + raw.get("SReclaimable", 0),
+        "buffers": raw.get("Buffers", 0),
+        "swapTotal": swap_total,
+        "swapUsed": swap_total - raw.get("SwapFree", 0),
+        # Composition. `anon` is what processes actually hold; `slab` is the
+        # kernel's own allocator, split into the part it can hand back under
+        # pressure and the part it cannot.
+        "anon": raw.get("AnonPages", 0),
+        "mapped": raw.get("Mapped", 0),
+        "shmem": raw.get("Shmem", 0),
+        "slab": raw.get("Slab", 0),
+        "slabReclaimable": raw.get("SReclaimable", 0),
+        "slabUnreclaimable": raw.get("SUnreclaim", 0),
+        "kernelStack": raw.get("KernelStack", 0),
+        "pageTables": raw.get("PageTables", 0),
+        "dirty": raw.get("Dirty", 0),
+        "writeback": raw.get("Writeback", 0),
+        "committed": raw.get("Committed_AS", 0),
+        "commitLimit": raw.get("CommitLimit", 0),
+        "activeFile": raw.get("Active(file)", 0),
+        "inactiveFile": raw.get("Inactive(file)", 0),
+    }
+
+
+def read_pressure():
+    """PSI stall percentages — the honest "is this machine struggling" signal.
+
+    A memory bar at 90% may be perfectly healthy page cache; `some avg10` above
+    zero means tasks actually stalled waiting for memory. That is the number
+    worth alarming on, so it is collected for all three resources.
+    """
+    out = {}
+    for resource in ("cpu", "memory", "io"):
+        try:
+            with open("/proc/pressure/" + resource) as f:
+                text = f.read()
+        except OSError:
+            continue  # kernel built without PSI, or cgroup restrictions
+        entry = {}
+        for line in text.splitlines():
+            parts = line.split()
+            if not parts:
+                continue
+            scope = parts[0]  # "some" or "full"
+            for field in parts[1:]:
+                key, _, value = field.partition("=")
+                if key.startswith("avg"):
+                    try:
+                        entry[scope + key[3:]] = float(value)
+                    except ValueError:
+                        pass
+        if entry:
+            out[resource] = entry
+    return out
+
+
+def read_swaps():
+    """Every swap area, with zram compression folded in where it applies."""
+    out = []
+    try:
+        with open("/proc/swaps") as f:
+            lines = f.readlines()[1:]
+    except OSError:
+        return out
+
+    for line in lines:
+        fields = line.split()
+        if len(fields) < 5:
+            continue
+        name = fields[0]
+        entry = {
+            "name": name,
+            "type": fields[1],
+            # /proc/swaps counts in kibibytes regardless of page size.
+            "size": int(fields[2]) * 1024,
+            "used": int(fields[3]) * 1024,
+            "priority": int(fields[4]),
+        }
+
+        device = os.path.basename(name)
+        if device.startswith("zram"):
+            entry.update(read_zram(device))
+        out.append(entry)
+    return out
+
+
+def read_zram(device):
+    """Compression figures for one zram device.
+
+    mm_stat is a single line: orig_data_size compr_data_size mem_used_total
+    mem_limit mem_used_max same_pages pages_compacted huge_pages.
+    """
+    try:
+        with open("/sys/block/%s/mm_stat" % device) as f:
+            fields = [int(v) for v in f.read().split()]
+    except (OSError, ValueError):
+        return {}
+    if len(fields) < 3:
+        return {}
+
+    original, compressed, used_total = fields[0], fields[1], fields[2]
+    out = {
+        "zramOriginal": original,
+        "zramCompressed": compressed,
+        "zramUsed": used_total,
+        # What the compression actually bought: the pages' uncompressed size
+        # minus the RAM zram is really holding, allocator overhead included.
+        "zramSaved": max(0, original - used_total),
+        # Ratio is compression, so it divides by the compressed size — dividing
+        # by mem_used_total would fold in allocator overhead and report a
+        # nonsensical sub-1x "ratio" on an idle device holding a single page.
+        "zramRatio": round(original / compressed, 2) if compressed > 0 else 0,
+    }
+    try:
+        with open("/sys/block/%s/comp_algorithm" % device) as f:
+            text = f.read()
+        # The active algorithm is the bracketed one in the list.
+        for token in text.split():
+            if token.startswith("["):
+                out["zramAlgorithm"] = token.strip("[]")
+                break
+    except OSError:
+        pass
+    return out
+
+
+def read_sysfs_net(iface, name):
+    try:
+        with open("/sys/class/net/%s/%s" % (iface, name)) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def interface_is_live(iface):
+    """Whether a link is actually carrying traffic.
+
+    An unplugged NIC still appears in /proc/net/dev with its counters frozen at
+    zero, and listing it as an active interface is a small lie. TUN devices like
+    tailscale0 report operstate "unknown" forever, so carrier is the signal that
+    works for both.
+    """
+    if read_sysfs_net(iface, "carrier") == "1":
+        return True
+    return read_sysfs_net(iface, "operstate") == "up"
+
+
+def read_net():
+    """{iface: (rx_bytes, tx_bytes)} cumulative counters, live links only."""
+    out = {}
+    with open("/proc/net/dev") as f:
+        lines = f.readlines()[2:]
+    for line in lines:
+        name, _, rest = line.partition(":")
+        name = name.strip()
+        if name == "lo" or name.startswith(SKIP_IFACE_PREFIXES):
+            continue
+        fields = rest.split()
+        if len(fields) < 9:
+            continue
+        if not interface_is_live(name):
+            continue
+        out[name] = (int(fields[0]), int(fields[8]))
+    return out
+
+
+NET_ERROR_COUNTERS = ("rx_errors", "tx_errors", "rx_dropped", "tx_dropped")
+
+
+def read_links(ifaces, detailed=False):
+    """Per-interface link state, and on request its error counters.
+
+    Link state is cheap enough to read every sample; the error counters are
+    another six file reads per interface and only appear in the expanded view.
+    """
+    wireless = read_wireless()
+    out = []
+    for iface in sorted(ifaces):
+        speed = read_sysfs_net(iface, "speed")
+        entry = {
+            "name": iface,
+            "state": read_sysfs_net(iface, "operstate") or "unknown",
+            "carrier": read_sysfs_net(iface, "carrier") == "1",
+            "mtu": int(read_sysfs_net(iface, "mtu") or 0),
+            "duplex": read_sysfs_net(iface, "duplex"),
+            # -1 is the kernel's "not applicable", e.g. wifi and tunnels.
+            "speed": int(speed) if speed and speed.lstrip("-").isdigit() and int(speed) > 0 else None,
+        }
+        if iface in wireless:
+            entry["wireless"] = wireless[iface]
+        if detailed:
+            for counter in NET_ERROR_COUNTERS:
+                value = read_sysfs_net(iface, "statistics/" + counter)
+                entry[counter] = int(value) if value and value.isdigit() else 0
+        out.append(entry)
+    return out
+
+
+def read_wireless():
+    """{iface: {quality, signal}} from /proc/net/wireless.
+
+    Values carry a trailing '.' in the kernel's fixed-width formatting. `noise`
+    is reported as -256 when the driver has nothing, so it is dropped rather
+    than shown as a real floor.
+    """
+    out = {}
+    try:
+        with open("/proc/net/wireless") as f:
+            lines = f.readlines()[2:]
+    except OSError:
+        return out
+
+    for line in lines:
+        name, _, rest = line.partition(":")
+        fields = rest.split()
+        if len(fields) < 4:
+            continue
+        try:
+            quality = float(fields[1].rstrip("."))
+            signal = float(fields[2].rstrip("."))
+        except ValueError:
+            continue
+        entry = {"quality": quality, "signal": signal}
+        try:
+            noise = float(fields[3].rstrip("."))
+            if noise > -256:
+                entry["noise"] = noise
+        except ValueError:
+            pass
+        out[name.strip()] = entry
+    return out
+
+
+# /proc/net/tcp state codes worth naming; the rest are transient handshake
+# states that would only add noise to a summary.
+TCP_STATES = {"01": "established", "06": "timeWait", "08": "closeWait", "0A": "listen"}
+
+
+def read_sockets():
+    """Counts of TCP sockets by state, v4 and v6 together."""
+    counts = {}
+    total = 0
+    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(path) as f:
+                lines = f.readlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 4:
+                continue
+            total += 1
+            name = TCP_STATES.get(fields[3])
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+    counts["total"] = total
+    return counts
+
+
+def read_disk():
+    """{device: (read_bytes, written_bytes)} cumulative counters, whole disks only."""
+    out = {}
+    for name, fields in iter_diskstats():
+        out[name] = (int(fields[5]) * SECTOR_BYTES, int(fields[9]) * SECTOR_BYTES)
+    return out
+
+
+def iter_diskstats():
+    """(name, fields) for every whole block device worth reporting."""
+    with open("/proc/diskstats") as f:
+        for line in f:
+            fields = line.split()
+            if len(fields) < 14:
+                continue
+            name = fields[2]
+            if name.startswith(SKIP_DISK_PREFIXES):
+                continue
+            # Partitions have a parent in /sys/block; only whole devices appear
+            # there directly, which keeps sda1 from double-counting sda.
+            if not os.path.exists("/sys/block/" + name):
+                continue
+            yield name, fields
+
+
+def read_disk_stats():
+    """Raw counters per device for the iostat-style derived figures.
+
+    Field order after major/minor/name: reads, reads merged, sectors read, ms
+    reading, writes, writes merged, sectors written, ms writing, I/Os in
+    flight, ms doing I/O, weighted ms doing I/O.
+    """
+    out = {}
+    for name, fields in iter_diskstats():
+        out[name] = {
+            "reads": int(fields[3]),
+            "readBytes": int(fields[5]) * SECTOR_BYTES,
+            "msReading": int(fields[6]),
+            "writes": int(fields[7]),
+            "writeBytes": int(fields[9]) * SECTOR_BYTES,
+            "msWriting": int(fields[10]),
+            "inFlight": int(fields[11]),
+            "msDoingIO": int(fields[12]),
+        }
+    return out
+
+
+def derive_disk(current, previous, elapsed):
+    """Throughput, IOPS, utilisation, queue depth and latency per device.
+
+    Utilisation is the share of wall-clock the device spent with any request
+    outstanding — iostat's %util. On an NVMe drive that serves many requests in
+    parallel it saturates long before the device does, so it reads as "busy",
+    not "full".
+    """
+    out = []
+    for name in sorted(current):
+        now = current[name]
+        before = previous.get(name)
+        if before is None:
+            continue
+
+        reads = max(0, now["reads"] - before["reads"])
+        writes = max(0, now["writes"] - before["writes"])
+        operations = reads + writes
+        busy_ms = max(0, now["msDoingIO"] - before["msDoingIO"])
+        service_ms = max(0, (now["msReading"] - before["msReading"])
+                         + (now["msWriting"] - before["msWriting"]))
+
+        out.append({
+            "name": name,
+            "read": round(max(0, now["readBytes"] - before["readBytes"]) / elapsed),
+            "write": round(max(0, now["writeBytes"] - before["writeBytes"]) / elapsed),
+            "iops": round(operations / elapsed, 1),
+            "util": round(min(100.0, busy_ms / (elapsed * 1000.0) * 100.0), 1),
+            "queue": now["inFlight"],
+            # Mean time a request spent in the driver, over the interval. Only
+            # meaningful when something actually happened.
+            "latency": round(service_ms / operations, 2) if operations > 0 else 0,
+        })
+    return out
+
+
+def read_filesystems():
+    """Usage per real filesystem, one entry per device rather than per mount.
+
+    A btrfs pool with subvolumes at /, /home and /var/log is one filesystem
+    reported four times by /proc/mounts; listing it four times would imply four
+    separate things to run out of.
+    """
+    seen = {}
+    order = []
+    try:
+        with open("/proc/mounts") as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+
+    for line in lines:
+        fields = line.split()
+        if len(fields) < 3:
+            continue
+        device, mount, fstype = fields[0], fields[1], fields[2]
+        if not device.startswith("/dev/"):
+            continue
+        try:
+            stats = os.statvfs(mount)
+        except OSError:
+            continue
+        total = stats.f_blocks * stats.f_frsize
+        if total <= 0:
+            continue
+        # Available-to-unprivileged, matching what df reports as the usable
+        # figure — f_bfree includes root's reserve, which nothing can spend.
+        available = stats.f_bavail * stats.f_frsize
+        used = total - stats.f_bfree * stats.f_frsize
+
+        if device in seen:
+            seen[device]["mounts"].append(mount)
+            continue
+        seen[device] = {
+            "device": device,
+            "mounts": [mount],
+            "fstype": fstype,
+            "total": total,
+            "used": used,
+            "avail": available,
+            # df's Use%: measured against what is actually spendable, so the
+            # root reserve on an ext4 volume does not read as usable free
+            # space. This is the number to compare against `df`.
+            "percent": round(used / (used + available) * 100, 1) if (used + available) > 0 else 0,
+        }
+        order.append(device)
+
+    return [seen[d] for d in order]
+
+
+def read_socket_inodes():
+    """{inode: (proto, state, local, remote)} for every TCP and UDP socket.
+
+    The kernel does not record which process owns a socket, so the standard
+    join is inode -> /proc/<pid>/fd. Every tool that does per-process network
+    on Linux — nethogs, procs, psutil — uses exactly this, and inherits the
+    same ceiling: you see your own processes' sockets, not other users'.
+    """
+    TCP_STATES = {"01": "ESTABLISHED", "02": "SYN_SENT", "06": "TIME_WAIT", "0A": "LISTEN"}
+
+    def parse_addr(raw):
+        host, _, port = raw.partition(":")
+        try:
+            port = int(port, 16)
+        except ValueError:
+            return raw
+        if len(host) == 8:                      # IPv4, little-endian hex
+            octets = [int(host[i:i + 2], 16) for i in (6, 4, 2, 0)]
+            return "%d.%d.%d.%d:%d" % (*octets, port)
+        return "[v6]:%d" % port
+
+    out = {}
+    for path, proto in (("/proc/net/tcp", "tcp"), ("/proc/net/tcp6", "tcp6"),
+                        ("/proc/net/udp", "udp"), ("/proc/net/udp6", "udp6")):
+        try:
+            with open(path) as f:
+                lines = f.readlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 10:
+                continue
+            out[fields[9]] = (
+                proto,
+                TCP_STATES.get(fields[3], fields[3]) if proto.startswith("tcp") else "",
+                parse_addr(fields[1]),
+                parse_addr(fields[2]),
+            )
+    return out
+
+
+def read_open_files(pid):
+    """Files, sockets and pipes held by one process.
+
+    Answers "what is holding this port" and "why can't I unmount that" — the
+    two questions that otherwise send people to lsof. On demand only: a browser
+    can hold nine hundred descriptors.
+    """
+    sockets_by_inode = None
+    files, sockets, pipes = [], [], 0
+    try:
+        entries = list(os.scandir("/proc/%d/fd" % pid))
+    except OSError:
+        return None                              # not ours, or already gone
+
+    for entry in entries:
+        try:
+            target = os.readlink(entry.path)
+        except OSError:
+            continue
+        if target.startswith("socket:["):
+            if sockets_by_inode is None:
+                sockets_by_inode = read_socket_inodes()
+            info = sockets_by_inode.get(target[8:-1])
+            if info:
+                sockets.append({"proto": info[0], "state": info[1],
+                                "local": info[2], "remote": info[3]})
+            else:
+                sockets.append({"proto": "unix", "state": "", "local": "", "remote": ""})
+        elif target.startswith(("pipe:", "anon_inode:")):
+            pipes += 1
+        elif target.startswith("/"):
+            files.append(target)
+
+    files.sort()
+    return {
+        "pid": pid,
+        "total": len(entries),
+        "files": files[:200],
+        "sockets": sockets[:200],
+        "pipes": pipes,
+    }
+
+
+def count_process_sockets(pids):
+    """{pid: (listening, established)} — cheap enough for the whole table.
+
+    Counts only; the addresses come from read_open_files when a row is opened.
+    """
+    sockets_by_inode = read_socket_inodes()
+    out = {}
+    for pid in pids:
+        listening = established = 0
+        try:
+            for entry in os.scandir("/proc/%d/fd" % pid):
+                try:
+                    target = os.readlink(entry.path)
+                except OSError:
+                    continue
+                if not target.startswith("socket:["):
+                    continue
+                info = sockets_by_inode.get(target[8:-1])
+                if not info:
+                    continue
+                if info[1] == "LISTEN":
+                    listening += 1
+                elif info[1] == "ESTABLISHED":
+                    established += 1
+        except OSError:
+            continue
+        if listening or established:
+            out[pid] = (listening, established)
+    return out
+
+
+def read_process_io(pids):
+    """{pid: (read_bytes, write_bytes)} of real block I/O, where permitted.
+
+    /proc/<pid>/io is readable only for processes the caller owns, so on a
+    normal session this covers your own processes and silently omits root's.
+    The count of what was readable is reported so the UI can say so.
+    """
+    out = {}
+    for pid in pids:
+        try:
+            with open("/proc/%d/io" % pid) as f:
+                text = f.read()
+        except OSError:
+            continue  # not ours, or exited
+        read_bytes = write_bytes = 0
+        for line in text.splitlines():
+            key, _, value = line.partition(":")
+            if key == "read_bytes":
+                read_bytes = int(value)
+            elif key == "write_bytes":
+                write_bytes = int(value)
+        out[pid] = (read_bytes, write_bytes)
+    return out
+
+
+# ---------------------------------------------------------- flight recorder
+#
+# Every history ring in the UI lives in the shell process, so an `omarchy
+# update` — which restarts the shell — erases all of it. That reduces the tool
+# to answering "what is happening now", never "what happened while I was
+# asleep". A small append-only log on disk fixes that.
+#
+# This is fixed-tick sampling, the same model zenith uses. It is deliberately
+# not atop's model: atop hooks BSD process accounting and can therefore
+# attribute a process that both started and exited between two samples.
+# Nothing here can see such a process, and the recorder does not pretend to.
+
+RECORDER_DIR = os.path.join(
+    os.environ.get("XDG_STATE_HOME", os.path.expanduser("~/.local/state")),
+    "omarchy", "omatask")
+RECORDER_FILE = os.path.join(RECORDER_DIR, "history.jsonl")
+# One week at a 30s tick is ~20k rows, comfortably under 4MB.
+RECORDER_TICK_SEC = 30
+RECORDER_MAX_ROWS = 20160
+
+
+class FlightRecorder:
+    """Appends one downsampled row per tick, and prunes when it reads back.
+
+    Keys are single letters on purpose: this file is appended to forever, and
+    spelled-out names would be most of its bytes.
+    """
+
+    def __init__(self, tick=RECORDER_TICK_SEC):
+        self.tick = tick
+        self.last_write = 0.0
+        self.enabled = True
+        try:
+            os.makedirs(RECORDER_DIR, exist_ok=True)
+        except OSError:
+            self.enabled = False
+
+    def load(self, limit=RECORDER_MAX_ROWS):
+        """Recorded rows, oldest first. Prunes the file only when overlong."""
+        if not self.enabled:
+            return []
+        try:
+            with open(RECORDER_FILE) as f:
+                lines = f.readlines()
+        except OSError:
+            return []
+
+        rows = []
+        for line in lines[-limit:]:
+            try:
+                rows.append(json.loads(line))
+            except ValueError:
+                continue          # a torn final line after an unclean exit
+        if len(lines) > limit * 1.25:
+            try:
+                with open(RECORDER_FILE, "w") as f:
+                    for row in rows:
+                        f.write(json.dumps(row, separators=(",", ":")) + "\n")
+            except OSError:
+                pass
+        return rows
+
+    def record(self, sample, now):
+        if not self.enabled or now - self.last_write < self.tick:
+            return
+        self.last_write = now
+
+        cpu = sample.get("cpu") or {}
+        mem = sample.get("mem") or {}
+        net = sample.get("net") or {}
+        disk = sample.get("disk") or {}
+        thermal = sample.get("thermal") or {}
+        devices = (sample.get("gpu") or {}).get("devices") or [{}]
+        pressure = (sample.get("pressure") or {}).get("memory") or {}
+        total = mem.get("total") or 1
+
+        row = {
+            "t": int(time.time()),
+            "c": round(cpu.get("total", 0), 1),
+            "m": round(mem.get("used", 0) / total * 100, 1),
+            "s": round(mem.get("swapUsed", 0) / 1e6),
+            "nr": net.get("rx", 0),
+            "nt": net.get("tx", 0),
+            "dr": disk.get("read", 0),
+            "dw": disk.get("write", 0),
+            "g": devices[0].get("util"),
+            "ct": thermal.get("cpu"),
+            "gt": devices[0].get("temp"),
+            "p": round(pressure.get("some10", 0), 2),
+        }
+        try:
+            with open(RECORDER_FILE, "a") as f:
+                f.write(json.dumps(row, separators=(",", ":")) + "\n")
+        except OSError:
+            self.enabled = False
+
+
+# ---------------------------------------------------------------- hardware
+#
+# Readings that no generic monitor surfaces, all unprivileged, all from files
+# the kernel already maintains.
+
+
+def read_cpufreq():
+    """Per-core delivered frequency, plus the policy that governs it.
+
+    `cpuinfo_avg_freq` is amd-pstate's APERF/MPERF-derived *actual* average —
+    what the core really ran at. `scaling_cur_freq` is the requested operating
+    point, which lags under this driver rather than being wrong. Prefer the
+    former where it exists and fall back where it does not.
+    """
+    freqs = []
+    index = 0
+    while True:
+        base = "/sys/devices/system/cpu/cpu%d/cpufreq" % index
+        if not os.path.isdir(base):
+            break
+        value = _cg_int(os.path.join(base, "cpuinfo_avg_freq"))
+        if value is None:
+            value = _cg_int(os.path.join(base, "scaling_cur_freq"))
+        freqs.append(round((value or 0) / 1000.0))   # kHz -> MHz
+        index += 1
+
+    if not freqs:
+        return {}
+
+    policy = "/sys/devices/system/cpu/cpu0/cpufreq"
+    out = {
+        "cores": freqs,
+        "min": round((_cg_int(policy + "/scaling_min_freq") or 0) / 1000.0),
+        "max": round((_cg_int(policy + "/cpuinfo_max_freq") or 0) / 1000.0),
+        "governor": (_cg_read(policy + "/scaling_governor") or "").strip() or None,
+        "driver": (_cg_read(policy + "/scaling_driver") or "").strip() or None,
+    }
+    boost = _cg_read("/sys/devices/system/cpu/cpufreq/boost")
+    if boost is not None:
+        out["boost"] = boost.strip() == "1"
+    return out
+
+
+def read_interrupts():
+    """Softirq distribution across cores, to catch a pinned interrupt load.
+
+    /proc/interrupts is the richer file but costs ~240us to read — the most
+    expensive in /proc — because it is O(irqs x cpus). /proc/softirqs is a
+    tenth of that and carries the line that actually matters on a desktop:
+    NET_RX, which lands entirely on one core when a NIC's affinity is wrong.
+    """
+    out = {}
+    try:
+        with open("/proc/softirqs") as f:
+            lines = f.readlines()[1:]
+    except OSError:
+        return out
+
+    for line in lines:
+        name, _, rest = line.partition(":")
+        name = name.strip()
+        if name not in ("NET_RX", "NET_TX", "BLOCK", "TIMER", "SCHED"):
+            continue
+        try:
+            counts = [int(v) for v in rest.split()]
+        except ValueError:
+            continue
+        if not counts:
+            continue
+        busiest = max(counts)
+        quietest = min(counts)
+        out[name] = {
+            "counts": counts,
+            "busiestCore": counts.index(busiest),
+            # A ratio, not a difference: on an idle core the absolute numbers
+            # are meaningless but a 300x skew is a misconfiguration.
+            "imbalance": round(busiest / quietest, 1) if quietest > 0 else None,
+        }
+    return out
+
+
+def read_btrfs():
+    """Commit stalls, allocation headroom and device errors.
+
+    Three things `df` cannot tell you: that a commit blocked the filesystem for
+    two seconds, that metadata is nearly full while data looks fine (which is
+    how btrfs actually runs out of space), and that a device has logged errors.
+    """
+    out = []
+    for fsdir in sorted(glob.glob("/sys/fs/btrfs/*")):
+        stats = _cg_keyed(_cg_read(os.path.join(fsdir, "commit_stats")))
+        if not stats:
+            continue
+        entry = {
+            "label": (_cg_read(os.path.join(fsdir, "label")) or "").strip() or os.path.basename(fsdir)[:8],
+            "commits": stats.get("commits", 0),
+            "lastCommitMs": stats.get("last_commit_ms", 0),
+            "maxCommitMs": stats.get("max_commit_ms", 0),
+            "allocation": {},
+            "errors": 0,
+        }
+        for kind in ("data", "metadata", "system"):
+            total = _cg_int(os.path.join(fsdir, "allocation", kind, "total_bytes"))
+            used = _cg_int(os.path.join(fsdir, "allocation", kind, "bytes_used"))
+            if total:
+                entry["allocation"][kind] = {
+                    "total": total, "used": used or 0,
+                    "percent": round((used or 0) / total * 100, 1),
+                }
+        for devdir in glob.glob(os.path.join(fsdir, "devinfo", "*")):
+            errors = _cg_keyed(_cg_read(os.path.join(devdir, "error_stats")))
+            entry["errors"] += sum(errors.values())
+        out.append(entry)
+    return out
+
+
+def read_failed_units():
+    """systemd units in a failed state, system and user.
+
+    Read from the cgroup-adjacent file systemd maintains rather than by forking
+    `systemctl`, which costs orders of magnitude more than everything else in
+    this sampler combined.
+    """
+    failed = []
+    for scope, command in (("system", ["systemctl", "--failed", "--no-legend", "--plain"]),
+                           ("user", ["systemctl", "--user", "--failed", "--no-legend", "--plain"])):
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=4)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if parts and parts[0].endswith((".service", ".timer", ".mount", ".socket")):
+                failed.append({"unit": parts[0], "scope": scope})
+    return failed
+
+
+# ------------------------------------------------------------- cgroups v2
+#
+# Omarchy Quattro launches every application into its own systemd scope, which
+# means the kernel is already grouping processes the way a person thinks about
+# them. Reading those groups gives true per-application accounting — one
+# "Chromium" row instead of forty-seven chromium processes — and `memory.current`
+# is the honest figure, without the shared-page double counting that makes a
+# sum of RSS meaningless.
+
+CGROUP_ROOT = "/sys/fs/cgroup"
+
+# Where user applications and system services live. Both are world-readable.
+CGROUP_SCAN_ROOTS = (
+    "user.slice/user-%d.slice/user@%d.service" % (os.getuid(), os.getuid()),
+    "system.slice",
+)
+
+def _cg_read(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def _cg_int(path):
+    text = _cg_read(path)
+    try:
+        return int(text.strip())
+    except (AttributeError, ValueError):
+        return None
+
+
+def _cg_keyed(text):
+    """Parse the `key value` format used by cpu.stat, memory.stat, memory.events."""
+    out = {}
+    for line in (text or "").splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            try:
+                out[parts[0]] = int(parts[1])
+            except ValueError:
+                pass
+    return out
+
+
+def _cg_pressure_total(text):
+    """Microseconds of `some` stall, cumulative.
+
+    PSI is exposed per cgroup even when the matching controller is not
+    delegated — which is why io *stall* can be attributed per application on a
+    system where io *bytes* cannot.
+    """
+    for line in (text or "").splitlines():
+        if not line.startswith("some"):
+            continue
+        for field in line.split():
+            if field.startswith("total="):
+                try:
+                    return int(field.split("=", 1)[1])
+                except ValueError:
+                    return None
+    return None
+
+
+# Deriving an application's identity is the hard part of grouping by cgroup,
+# and getting it wrong is worse than not grouping at all.
+#
+# Two failure modes pull in opposite directions:
+#
+#   * The same app can own several scopes. Chromium launched from the Omarchy
+#     menu and Chromium activated through XDG land in different scopes and
+#     should read as one application.
+#   * Different apps can share a process name. `podcast-worker.service` and
+#     `hermes-gateway.service` are both `python`; collapsing them because their
+#     comm matches would merge two unrelated programs into a meaningless row.
+#
+# So identity comes from the *unit*, which systemd already made unique, and
+# only falls back to the process name where the unit name carries nothing —
+# an anonymous `tmux-spawn-<uuid>.scope` says nothing about what is inside it.
+
+# systemd escapes characters it cannot put in a unit name.
+UNIT_UNESCAPE = (("\\x2d", "-"), ("\\x40", "@"), ("\\x5f", "_"))
+
+# `app-<launcher>-<something>-<hash>.scope`. The launcher is not the app —
+# `app-Hyprland-gtk-launch-<hash>.scope` contains Slack — so a scope whose
+# middle section is a known launcher has to be identified from its processes.
+LAUNCHERS = ("gtk-launch", "uwsm-app", "systemd-run", "flatpak", "sh", "bash", "env")
+
+# Scopes whose name is a session identifier rather than an application.
+ANONYMOUS_SCOPE_PREFIXES = ("tmux-spawn-", "session-", "vte-spawn-")
+
+# Container runtimes name a scope after the container instance. Two containers
+# from the same image run the same binary, so identifying them by process name
+# would merge two separate databases into one row — the container id is the
+# identity, even though it is unreadable and the name has to come from inside.
+CONTAINER_SCOPE_PREFIXES = ("docker-", "libpod-", "podman-", "crio-", "machine-")
+
+
+def _unescape_unit(name):
+    for escaped, plain in UNIT_UNESCAPE:
+        name = name.replace(escaped, plain)
+    return name
+
+
+def app_identity(dirname, pids):
+    """(key, display) for one cgroup.
+
+    `key` is what rows are merged on; `display` is what a person reads.
+    """
+    name = _unescape_unit(dirname)
+
+    if name.endswith(".service"):
+        # A service unit name is already a unique, human-meaningful identity.
+        # This is what keeps podcast-worker and hermes-gateway apart.
+        stem = name[:-len(".service")]
+        stem = stem.split("@", 1)[0]          # template instances share an app
+        if stem.startswith("app-"):
+            stem = stem[len("app-"):]
+        return stem, stem
+
+    if name.endswith(".scope"):
+        stem = name[:-len(".scope")]
+
+        if stem.startswith(CONTAINER_SCOPE_PREFIXES):
+            # Unique key, but no readable name: the container's name lives in
+            # the runtime's daemon, not anywhere on this side of the API. The
+            # caller labels it from its processes and appends a short id so two
+            # containers of the same image stay tellable apart.
+            return stem, None
+
+        if stem.startswith(ANONYMOUS_SCOPE_PREFIXES):
+            # A terminal pane. What matters is the program running in it.
+            return None, None
+
+        if stem.startswith("app-"):
+            parts = stem[len("app-"):].split("-")
+            # Drop the trailing hash or pid systemd appends.
+            if len(parts) > 1 and re.fullmatch(r"[0-9a-f]{6,}|\d+", parts[-1]):
+                parts = parts[:-1]
+            # Drop a leading desktop/compositor tag.
+            if parts and parts[0] in ("Hyprland", "gnome", "KDE", "uwsm"):
+                parts = parts[1:]
+            candidate = "-".join(parts)
+            if candidate and not candidate.startswith(LAUNCHERS):
+                # A reverse-DNS desktop id reduces to its last component:
+                # org.chromium.Chromium -> chromium.
+                leaf = candidate.split(".")[-1] if "." in candidate else candidate
+                return leaf.lower(), leaf.lower()
+
+    return None, None
+
+
+# Resolving a scope's name from its processes means reading two files per
+# candidate, which dominates a cgroup sweep. Names change only when membership
+# does, so cache on the leading pid and re-resolve when that moves.
+_scope_names = {}
+
+
+def scope_display_name(dirname, pids):
+    """The heaviest member's name, for scopes whose own name says nothing.
+
+    Heaviest rather than first: a scope's first pid is often a launcher or a
+    crash handler that outlives its purpose — Chromium's is `chrome_crashpad`.
+    """
+    cache_key = (dirname, pids[0] if pids else "")
+    cached = _scope_names.get(cache_key)
+    if cached is not None:
+        return cached
+
+    best = None
+    best_rss = -1
+    for pid in pids[:24]:
+        try:
+            with open("/proc/%s/statm" % pid) as f:
+                rss = int(f.read().split()[1]) * PAGE_SIZE
+            with open("/proc/%s/comm" % pid) as f:
+                comm = f.read().strip()
+        except (OSError, ValueError, IndexError):
+            continue
+        if rss > best_rss:
+            best_rss, best = rss, comm
+
+    resolved = best or _unescape_unit(dirname).split(".")[0]
+    _scope_names[cache_key] = resolved
+    if len(_scope_names) > 512:               # bounded; scopes come and go
+        _scope_names.pop(next(iter(_scope_names)))
+    return resolved
+
+
+def merge_apps(apps):
+    """Fold scopes that are the same application into one row.
+
+    Rates and totals add; peaks and stalls take the worst member, because "this
+    application stalled 12% of the interval" is answered by its worst scope,
+    not by an average that dilutes it.
+    """
+    merged = {}
+    order = []
+    for app in apps:
+        key = app.get("key") or app["unit"]
+        existing = merged.get(key)
+        if existing is None:
+            entry = dict(app)
+            entry["scopes"] = 1
+            merged[key] = entry
+            order.append(key)
+            continue
+        existing["mem"] += app["mem"]
+        existing["memPeak"] += app["memPeak"]
+        existing["cpu"] = round(existing["cpu"] + app["cpu"], 1)
+        existing["procs"] += app["procs"]
+        existing["oomKills"] += app["oomKills"]
+        existing["ioStall"] = max(existing["ioStall"], app["ioStall"])
+        existing["memStall"] = max(existing["memStall"], app["memStall"])
+        existing["scopes"] += 1
+        if "ioBytes" in app and "ioBytes" in existing:
+            existing["ioBytes"] = (existing["ioBytes"][0] + app["ioBytes"][0],
+                                   existing["ioBytes"][1] + app["ioBytes"][1])
+        # Once several scopes are folded together the individual unit name is
+        # no longer the whole truth, so say how many there were instead.
+        existing["unit"] = "%d scopes" % existing["scopes"]
+    return [merged[k] for k in order]
+
+
+def read_cgroups(previous, elapsed):
+    """Per-application CPU, memory, stall and I/O.
+
+    `previous` is the last sample's raw counters, keyed by cgroup path, so CPU
+    and stall arrive as rates rather than since-boot totals.
+    """
+    apps = []
+    counters = {}
+
+    for root in CGROUP_SCAN_ROOTS:
+        base = os.path.join(CGROUP_ROOT, root)
+        if not os.path.isdir(base):
+            continue
+        for dirpath, _, _ in os.walk(base):
+            # A slice is a container for scopes; counting both would double.
+            # The scan root itself is skipped even though it is a `.service`:
+            # `user@1000.service` is the parent of every app scope, and
+            # treating it as a leaf would both double-count and — since an
+            # earlier version pruned the walk here — hide every application
+            # underneath it.
+            if dirpath == base or not dirpath.endswith((".scope", ".service")):
+                continue
+
+            memory = _cg_int(os.path.join(dirpath, "memory.current"))
+            cpu = _cg_keyed(_cg_read(os.path.join(dirpath, "cpu.stat")))
+            if memory is None or "usage_usec" not in cpu:
+                continue
+
+            pids = (_cg_read(os.path.join(dirpath, "cgroup.procs")) or "").split()
+            if not pids:
+                continue  # an empty scope is on its way out
+
+            usage = cpu["usage_usec"]
+            io_stall = _cg_pressure_total(_cg_read(os.path.join(dirpath, "io.pressure")))
+            mem_stall = _cg_pressure_total(_cg_read(os.path.join(dirpath, "memory.pressure")))
+            counters[dirpath] = (usage, io_stall, mem_stall)
+            before = previous.get(dirpath)
+
+            def rate(now, was, scale):
+                if was is None or now is None:
+                    return 0.0
+                return max(0.0, (now - was) / elapsed * scale)
+
+            events = _cg_keyed(_cg_read(os.path.join(dirpath, "memory.events")))
+            basename = os.path.basename(dirpath)
+            key, display = app_identity(basename, pids)
+            if display is None:
+                # A launcher, container or anonymous scope says nothing about
+                # its contents, so the label comes from what is running inside.
+                display = scope_display_name(basename, pids)
+                if key is None:
+                    # No identity of its own: the bare name becomes the key, so
+                    # a scope named after an app and a scope named after the
+                    # launcher that started it still fold together.
+                    key = display.lower()
+                else:
+                    # It has a unique identity but an unreadable one. Keep the
+                    # key and disambiguate the label, or two containers of the
+                    # same image become two rows with identical names.
+                    short = key.split("-")[-1][:8]
+                    display = "%s (%s)" % (display, short)
+            entry = {
+                "name": display,
+                "key": key,
+                "unit": _unescape_unit(basename),
+                "system": root == "system.slice",
+                "procs": len(pids),
+                "mem": memory,
+                # Retroactive facts /proc cannot give: the high-water mark, and
+                # whether the kernel has ever had to kill something in here.
+                "memPeak": _cg_int(os.path.join(dirpath, "memory.peak")) or memory,
+                "oomKills": events.get("oom_kill", 0),
+                # usage_usec is microseconds of CPU; /elapsed gives a fraction
+                # of one core, ×100 a percentage in the same units as a process.
+                "cpu": round(rate(usage, before[0] if before else None, 100.0 / 1e6), 1),
+                # Stall totals are microseconds too; as a percentage of the
+                # interval this reads "how much of the last two seconds did
+                # this app spend waiting rather than working".
+                "ioStall": round(min(100.0, rate(io_stall, before[1] if before else None, 100.0 / 1e6)), 1),
+                "memStall": round(min(100.0, rate(mem_stall, before[2] if before else None, 100.0 / 1e6)), 1),
+            }
+
+            # io.stat only exists where the controller is delegated. Docker
+            # delegates it; systemd's user@.service does not by default, which
+            # is why per-app bytes need a drop-in but per-app stall does not.
+            io = _cg_read(os.path.join(dirpath, "io.stat"))
+            if io:
+                read_bytes = write_bytes = 0
+                for line in io.splitlines():
+                    for field in line.split()[1:]:
+                        key, _, value = field.partition("=")
+                        if key == "rbytes":
+                            read_bytes += int(value)
+                        elif key == "wbytes":
+                            write_bytes += int(value)
+                entry["ioBytes"] = (read_bytes, write_bytes)
+
+            apps.append(entry)
+
+    apps.sort(key=lambda a: -a["mem"])
+    return apps, counters
+
+
+def io_delegation_enabled():
+    """Whether per-app io.stat is available, for the UI to explain its absence."""
+    controllers = _cg_read(os.path.join(
+        CGROUP_ROOT, CGROUP_SCAN_ROOTS[0], "cgroup.controllers")) or ""
+    return "io" in controllers.split()
+
+
+# ----------------------------------------------------------------- GPU
+#
+# There is no /proc for GPUs, so each vendor gets its own reader. Both are
+# polled inline with everything else and must stay cheap; a backend that
+# cannot answer in well under a millisecond does not belong here.
+
+
+class NvidiaGpu:
+    """NVIDIA via NVML, bound through ctypes.
+
+    nvidia-smi would mean spawning a process per sample; the library it wraps
+    answers the same questions in about 0.15ms with no fork at all. Only the
+    handful of entry points used here are declared.
+    """
+
+    class _Utilization(ctypes.Structure):
+        _fields_ = [("gpu", ctypes.c_uint), ("memory", ctypes.c_uint)]
+
+    class _Memory(ctypes.Structure):
+        _fields_ = [
+            ("total", ctypes.c_ulonglong),
+            ("free", ctypes.c_ulonglong),
+            ("used", ctypes.c_ulonglong),
+        ]
+
+    class _ProcessInfo(ctypes.Structure):
+        _fields_ = [
+            ("pid", ctypes.c_uint),
+            ("usedGpuMemory", ctypes.c_ulonglong),
+            ("gpuInstanceId", ctypes.c_uint),
+            ("computeInstanceId", ctypes.c_uint),
+        ]
+
+    # nvmlClockType_t
+    CLOCK_SM = 1
+    CLOCK_MEM = 2
+    # nvmlPcieUtilCounter_t
+    PCIE_TX = 0
+    PCIE_RX = 1
+
+    def __init__(self):
+        self.lib = ctypes.CDLL("libnvidia-ml.so.1")
+        if self.lib.nvmlInit_v2() != 0:
+            raise OSError("nvmlInit failed")
+
+        count = ctypes.c_uint()
+        if self.lib.nvmlDeviceGetCount_v2(ctypes.byref(count)) != 0:
+            raise OSError("nvmlDeviceGetCount failed")
+
+        self.devices = []
+        for index in range(count.value):
+            handle = ctypes.c_void_p()
+            if self.lib.nvmlDeviceGetHandleByIndex_v2(index, ctypes.byref(handle)) != 0:
+                continue
+            name = ctypes.create_string_buffer(96)
+            label = "GPU %d" % index
+            if self.lib.nvmlDeviceGetName(handle, name, 96) == 0:
+                label = name.value.decode("utf-8", "replace")
+            self.devices.append((handle, label))
+
+        if not self.devices:
+            raise OSError("no NVML devices")
+
+    def shutdown(self):
+        try:
+            self.lib.nvmlShutdown()
+        except Exception:
+            pass
+
+    def _optional(self, function_name, handle, *args):
+        """Read one unsigned value, or None if the driver won't answer.
+
+        Fan speed on a passively cooled card, encoder utilisation on a part
+        without NVENC, PCIe counters on some laptop GPUs — all legitimately
+        unsupported, and none of them worth failing a sample over.
+        """
+        function = getattr(self.lib, function_name, None)
+        if function is None:
+            return None
+        value = ctypes.c_uint()
+        if function(handle, *(list(args) + [ctypes.byref(value)])) != 0:
+            return None
+        return value.value
+
+    def _engine(self, function_name, handle):
+        function = getattr(self.lib, function_name, None)
+        if function is None:
+            return None
+        value = ctypes.c_uint()
+        sampling_period = ctypes.c_uint()
+        if function(handle, ctypes.byref(value), ctypes.byref(sampling_period)) != 0:
+            return None
+        return value.value
+
+    def _processes(self, handle):
+        """[{pid, name, mem}] for everything holding VRAM on this device.
+
+        Graphics and compute clients are separate NVML lists and a process can
+        be on both, so they are merged on pid rather than concatenated.
+        """
+        merged = {}
+        for function_name in ("nvmlDeviceGetGraphicsRunningProcesses_v3",
+                              "nvmlDeviceGetComputeRunningProcesses_v3",
+                              "nvmlDeviceGetGraphicsRunningProcesses_v2",
+                              "nvmlDeviceGetComputeRunningProcesses_v2"):
+            function = getattr(self.lib, function_name, None)
+            if function is None:
+                continue
+            count = ctypes.c_uint(GPU_PROCESS_LIMIT)
+            infos = (self._ProcessInfo * GPU_PROCESS_LIMIT)()
+            if function(handle, ctypes.byref(count), infos) != 0:
+                continue
+            for index in range(min(count.value, GPU_PROCESS_LIMIT)):
+                info = infos[index]
+                # NVML reports "not supported" as an all-ones sentinel rather
+                # than an error, which would otherwise render as 18 exabytes.
+                used = info.usedGpuMemory
+                if used >= 0xFFFFFFFFFFFFFFFF:
+                    used = 0
+                previous = merged.get(info.pid)
+                if previous is None or used > previous:
+                    merged[info.pid] = used
+
+        rows = []
+        for pid, used in merged.items():
+            try:
+                with open("/proc/%d/comm" % pid) as f:
+                    name = f.read().strip()
+            except OSError:
+                continue  # exited since NVML listed it
+            rows.append({"pid": pid, "name": name, "mem": used})
+
+        rows.sort(key=lambda row: -row["mem"])
+        return rows
+
+    def sample(self, detailed=False):
+        out = []
+        for handle, label in self.devices:
+            utilization = self._Utilization()
+            memory = self._Memory()
+
+            ok = self.lib.nvmlDeviceGetUtilizationRates(handle, ctypes.byref(utilization)) == 0
+            self.lib.nvmlDeviceGetMemoryInfo(handle, ctypes.byref(memory))
+
+            power = self._optional("nvmlDeviceGetPowerUsage", handle)
+            power_limit = self._optional("nvmlDeviceGetEnforcedPowerLimit", handle)
+
+            # nvmlDeviceGetPcieThroughput samples over a fixed internal window
+            # and blocks for ~20ms per counter — two of them cost more than
+            # every other reading in this file combined. It and the per-client
+            # VRAM list are only ever rendered in the expanded GPU card, so
+            # they are only measured while that card is open.
+            pcie_tx = pcie_rx = None
+            processes = []
+            if detailed:
+                pcie_tx = self._optional("nvmlDeviceGetPcieThroughput", handle, self.PCIE_TX)
+                pcie_rx = self._optional("nvmlDeviceGetPcieThroughput", handle, self.PCIE_RX)
+                processes = self._processes(handle)
+
+            out.append({
+                "name": label,
+                "util": utilization.gpu if ok else 0,
+                "memUtil": utilization.memory if ok else 0,
+                "memUsed": memory.used,
+                "memTotal": memory.total,
+                "temp": self._optional("nvmlDeviceGetTemperature", handle, 0),
+                "power": round(power / 1000.0, 1) if power is not None else None,
+                "powerLimit": round(power_limit / 1000.0) if power_limit is not None else None,
+                "encode": self._engine("nvmlDeviceGetEncoderUtilization", handle),
+                "decode": self._engine("nvmlDeviceGetDecoderUtilization", handle),
+                "smClock": self._optional("nvmlDeviceGetClockInfo", handle, self.CLOCK_SM),
+                "memClock": self._optional("nvmlDeviceGetClockInfo", handle, self.CLOCK_MEM),
+                "fan": self._optional("nvmlDeviceGetFanSpeed", handle),
+                # NVML reports PCIe throughput in KB/s; everything else in this
+                # payload is bytes per second.
+                "pcieTx": pcie_tx * 1024 if pcie_tx is not None else None,
+                "pcieRx": pcie_rx * 1024 if pcie_rx is not None else None,
+                "procs": processes,
+            })
+        return out
+
+
+class AmdGpu:
+    """AMD via amdgpu's sysfs counters, which need no library at all."""
+
+    def __init__(self):
+        self.devices = []
+        for busy in sorted(glob.glob("/sys/class/drm/card*/device/gpu_busy_percent")):
+            device_dir = os.path.dirname(busy)
+            label = "GPU"
+            try:
+                with open(os.path.join(device_dir, "uevent")) as f:
+                    for line in f:
+                        if line.startswith("DRIVER="):
+                            label = line.strip().split("=", 1)[1]
+            except OSError:
+                pass
+            self.devices.append((device_dir, label))
+        if not self.devices:
+            raise OSError("no amdgpu devices")
+
+    @staticmethod
+    def _read_number(path):
+        try:
+            with open(path) as f:
+                return int(f.read().strip())
+        except (OSError, ValueError):
+            return None
+
+    def sample(self, detailed=False):
+        out = []
+        for device_dir, label in self.devices:
+            used = self._read_number(os.path.join(device_dir, "mem_info_vram_used"))
+            total = self._read_number(os.path.join(device_dir, "mem_info_vram_total"))
+            temp = self._read_number(os.path.join(device_dir, "hwmon/hwmon0/temp1_input"))
+            power = self._read_number(os.path.join(device_dir, "hwmon/hwmon0/power1_average"))
+            out.append({
+                "name": label,
+                "util": self._read_number(os.path.join(device_dir, "gpu_busy_percent")) or 0,
+                "memUtil": round(used / total * 100) if used and total else 0,
+                "memUsed": used or 0,
+                "memTotal": total or 0,
+                # sysfs reports millidegrees and microwatts.
+                "temp": round(temp / 1000) if temp else None,
+                "power": round(power / 1000000.0, 1) if power else None,
+                # amdgpu exposes no equivalent of NVML's engine, clock, and
+                # per-client VRAM queries here. Present-but-null keeps the UI's
+                # "hide what the driver can't answer" path identical for both.
+                "powerLimit": None,
+                "encode": None,
+                "decode": None,
+                "smClock": self._read_number(os.path.join(device_dir, "hwmon/hwmon0/freq1_input")),
+                "memClock": self._read_number(os.path.join(device_dir, "hwmon/hwmon0/freq2_input")),
+                "fan": None,
+                "pcieTx": None,
+                "pcieRx": None,
+                "procs": [],
+            })
+        return out
+
+
+def detect_gpu():
+    """First backend that initialises wins; no GPU is a normal outcome."""
+    for backend in (NvidiaGpu, AmdGpu):
+        try:
+            return backend()
+        except Exception:
+            continue
+    return None
+
+
+class LazyGpu:
+    """Defers GPU initialisation until something actually displays GPU data.
+
+    `nvmlInit_v2` maps the driver and costs ~31MB of RSS plus 0.8ms of every
+    sample — more than half the entire always-on budget — and at idle the bar
+    widget shows no GPU data at all. So the backend is created on first use and
+    released when the last GPU surface closes.
+    """
+
+    def __init__(self):
+        self._backend = None
+        self._tried = False
+        self._wanted = False
+
+    def set_wanted(self, wanted):
+        if wanted == self._wanted:
+            return
+        self._wanted = wanted
+        if not wanted:
+            self.release()
+
+    def release(self):
+        backend = self._backend
+        self._backend = None
+        self._tried = False
+        if backend is not None and hasattr(backend, "shutdown"):
+            try:
+                backend.shutdown()
+            except Exception:
+                pass
+
+    def sample(self, detailed=False):
+        if not self._wanted:
+            return None
+        if not self._tried:
+            self._tried = True
+            self._backend = detect_gpu()
+        if self._backend is None:
+            return None
+        try:
+            return self._backend.sample(detailed)
+        except Exception:
+            self.release()
+            raise
+
+
+# ------------------------------------------------------------- thermals
+#
+# Everything the kernel exposes under /sys/class/hwmon: CPU package and die
+# temperatures, drive and RAM sensors, and fan tachometers. Which of those
+# exist is entirely a function of what drivers are loaded — a board whose
+# super-I/O chip has no in-tree driver reports no fans at all, and that is a
+# fact to surface rather than a bug to work around.
+
+# hwmon chip names that report CPU temperature, and the labels each uses for
+# the package-level reading, best first.
+CPU_CHIPS = ("k10temp", "zenpower", "coretemp")
+CPU_PACKAGE_LABELS = ("Tdie", "Package id 0", "Tctl", "CPU Temperature")
+
+# hwmon chip names say what driver is bound, not what the thing is. A strip
+# reading "temp1 36°C" four times is useless; these turn the driver name into
+# the hardware a person would recognise. Matched by prefix, first hit wins.
+CHIP_DISPLAY_NAMES = (
+    ("k10temp", "CPU", "cpu"), ("zenpower", "CPU", "cpu"), ("coretemp", "CPU", "cpu"),
+    ("nvme", "NVMe", "drive"),
+    ("spd5118", "DIMM", "dimm"), ("jc42", "DIMM", "dimm"),
+    ("mt7921", "WiFi", "net"), ("iwlwifi", "WiFi", "net"), ("ath1", "WiFi", "net"),
+    ("r8169", "Ethernet", "net"), ("igb", "Ethernet", "net"), ("e1000", "Ethernet", "net"),
+    ("amdgpu", "GPU", "gpu"), ("nouveau", "GPU", "gpu"),
+    ("acpitz", "Board", "board"), ("nct", "Board", "board"), ("it87", "Board", "board"),
+)
+
+# Labels that carry no information beyond "this is a sensor".
+GENERIC_LABEL_PREFIXES = ("temp", "fan", "in")
+
+
+def display_chip(chip):
+    for prefix, name, _ in CHIP_DISPLAY_NAMES:
+        if chip.startswith(prefix):
+            return name
+    return chip
+
+
+def chip_kind(chip):
+    """Coarse category, so a surface can ask for "the DIMM sensors" without
+    re-deriving the chip-name knowledge that lives in this file."""
+    for prefix, _, kind in CHIP_DISPLAY_NAMES:
+        if chip.startswith(prefix):
+            return kind
+    return "other"
+
+
+class Thermals:
+    """Reads hwmon sensors, with the directory walk done once.
+
+    Discovery — which chips exist, what each sensor is called — cannot change
+    without a module load, but the readings change every sample. Doing the walk
+    at startup and only reading the `*_input` files afterwards keeps a sample
+    to a handful of small reads.
+    """
+
+    def __init__(self):
+        # Split by cost, not by importance. A CPU die sensor is a register read
+        # (~0.02ms); an NVMe sensor is an admin command, a DIMM sensor is an
+        # I²C transaction, and a wifi sensor is a firmware round-trip — 0.6 to
+        # 3ms each, which together dwarf every other reading in this file. The
+        # cheap ones are always sampled; the rest wait until something asks.
+        self.cpu_temps = []    # (path, chip, label)
+        self.other_temps = []  # (path, chip, label)
+        self.fans = []         # (path, chip, label)
+        self.cpu_path = None
+
+        # hwmon numbering is allocation order, not a stable identity, so sort to
+        # keep the device indices below consistent across boots on one machine.
+        for chip_dir in sorted(glob.glob("/sys/class/hwmon/hwmon*")):
+            chip = self._read_text(os.path.join(chip_dir, "name")) or "hwmon"
+            is_cpu_chip = chip in CPU_CHIPS
+            for input_path in sorted(glob.glob(os.path.join(chip_dir, "temp*_input"))):
+                prefix = input_path[:-len("_input")]
+                label = self._read_text(prefix + "_label") or os.path.basename(prefix)
+                entry = (input_path, chip, label, chip_dir)
+                (self.cpu_temps if is_cpu_chip else self.other_temps).append(entry)
+            # Fan tachometers are port or register reads wherever they exist at
+            # all, so they stay on the cheap path.
+            for input_path in sorted(glob.glob(os.path.join(chip_dir, "fan*_input"))):
+                prefix = input_path[:-len("_input")]
+                label = self._read_text(prefix + "_label") or os.path.basename(prefix)
+                self.fans.append((input_path, chip, label, chip_dir))
+
+        self.cpu_path = self._find_cpu_package()
+        self._assign_names()
+
+    def _assign_names(self):
+        """Give every sensor a name a person can act on.
+
+        A driver name plus its own label is usually enough ("CPU Tccd1"), but
+        two NVMe drives present the same chip *and* the same label, and a
+        board's DIMM sensors are all just `temp1`. Anything still ambiguous
+        after that is numbered in discovery order — the order `nvme list` and
+        `sensors` use, so the numbers line up with other tools.
+        """
+        lists = (self.cpu_temps, self.other_temps, self.fans)
+
+        # The index belongs to the *device*, not the sensor: two NVMe drives
+        # each reporting "Composite" and "Sensor 2" want to read
+        # "NVMe 1 Composite" / "NVMe 2 Composite", not "NVMe Composite 1" and
+        # a nonsensical "NVMe Sensor 2 2".
+        devices = {}  # pretty name -> [chip_dir, ...] in discovery order
+        for entry_list in lists:
+            for _, chip, _, chip_dir in entry_list:
+                seen_dirs = devices.setdefault(display_chip(chip), [])
+                if chip_dir not in seen_dirs:
+                    seen_dirs.append(chip_dir)
+
+        for entry_list in lists:
+            for index, (path, chip, label, chip_dir) in enumerate(entry_list):
+                pretty = display_chip(chip)
+                seen_dirs = devices[pretty]
+                if len(seen_dirs) > 1:
+                    pretty = "%s %d" % (pretty, seen_dirs.index(chip_dir) + 1)
+                if label.lower().startswith(GENERIC_LABEL_PREFIXES):
+                    name = pretty  # "temp1" says nothing the chip name doesn't
+                else:
+                    name = label if pretty == label else "%s %s" % (pretty, label)
+                entry_list[index] = (path, chip, label, name)
+
+    @staticmethod
+    def _read_text(path):
+        try:
+            with open(path) as f:
+                return f.read().strip()
+        except OSError:
+            return None
+
+    @staticmethod
+    def _read_number(path):
+        try:
+            with open(path) as f:
+                return int(f.read().strip())
+        except (OSError, ValueError):
+            return None
+
+    def _find_cpu_package(self):
+        """The one temperature that means "the CPU", by chip then by label."""
+        for chip_name in CPU_CHIPS:
+            candidates = [t for t in self.cpu_temps if t[1] == chip_name]
+            if not candidates:
+                continue
+            for label in CPU_PACKAGE_LABELS:
+                for entry in candidates:
+                    if entry[2] == label:  # (path, chip, label, chip_dir)
+                        return entry[0]
+            return candidates[0][0]  # unlabelled CPU chip: take its first sensor
+        return None
+
+    def sample(self, detailed=False):
+        out = {
+            "cpu": None,
+            "sensors": [],
+            "fans": [],
+            # Distinguishes "this board reports no fans" from "the fans are at
+            # zero RPM", which are very different things to show a user.
+            "fansAvailable": len(self.fans) > 0,
+        }
+
+        sources = self.cpu_temps + self.other_temps if detailed else self.cpu_temps
+        for path, chip, label, name in sources:
+            millidegrees = self._read_number(path)
+            if millidegrees is None:
+                continue
+            celsius = round(millidegrees / 1000.0, 1)
+            if path == self.cpu_path:
+                out["cpu"] = celsius
+            out["sensors"].append({"chip": chip, "kind": chip_kind(chip), "label": label,
+                                   "name": name, "temp": celsius})
+
+        for path, chip, label, name in self.fans:
+            rpm = self._read_number(path)
+            if rpm is None:
+                continue
+            out["fans"].append({"chip": chip, "kind": chip_kind(chip), "label": label,
+                                "name": name, "rpm": rpm})
+
+        return out
+
+
+def read_threads(pid):
+    """{tid: {...}} for one process. Only ever called for an expanded row."""
+    out = {}
+    try:
+        entries = os.scandir("/proc/%d/task" % pid)
+    except OSError:
+        return out
+
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            with open(entry.path + "/stat", "rb") as f:
+                raw = f.read()
+        except OSError:
+            continue
+        close = raw.rfind(b")")
+        if close < 0:
+            continue
+        fields = raw[close + 2:].split()
+        if len(fields) < 13:
+            continue
+        try:
+            out[int(entry.name)] = {
+                "name": raw[raw.find(b"(") + 1:close].decode("utf-8", "replace"),
+                "state": fields[0].decode("ascii", "replace"),
+                "jiffies": int(fields[11]) + int(fields[12]),
+            }
+        except (ValueError, IndexError):
+            continue
+    return out
+
+
+def read_procs():
+    """{pid: {...}} one entry per live process, cheap fields only."""
+    out = {}
+    for entry in os.scandir("/proc"):
+        if not entry.name.isdigit():
+            continue
+        try:
+            with open(entry.path + "/stat", "rb") as f:
+                raw = f.read()
+        except OSError:
+            continue  # exited between scandir and open
+
+        # comm is parenthesised and may itself contain spaces or parens, so the
+        # numeric fields start after the *last* ')', not the first space.
+        close = raw.rfind(b")")
+        if close < 0:
+            continue
+        fields = raw[close + 2:].split()
+        if len(fields) < 22:
+            continue
+
+        try:
+            pid = int(entry.name)
+            state = fields[0].decode("ascii", "replace")
+            record = {
+                "name": raw[raw.find(b"(") + 1:close].decode("utf-8", "replace"),
+                "state": state,
+                "ppid": int(fields[1]),
+                "jiffies": int(fields[11]) + int(fields[12]),  # utime + stime
+                "threads": int(fields[17]),
+                "rss": int(fields[21]) * PAGE_SIZE,
+                "uid": entry.stat().st_uid,
+            }
+        except (ValueError, IndexError, OSError):
+            continue
+
+        # Time spent runnable but not running — pure CPU contention, and the
+        # reason a machine can feel slow while every CPU% column reads calm.
+        # schedstat field 2; absent only if CONFIG_SCHEDSTATS is off.
+        try:
+            with open(entry.path + "/schedstat") as f:
+                sched = f.read().split()
+            if len(sched) >= 2:
+                record["runqueue"] = int(sched[1])
+        except (OSError, ValueError):
+            pass
+
+        # Uninterruptible sleep is the state where signals do nothing, so the
+        # only useful thing to show is what the kernel is blocked in. Read for
+        # those processes alone — one extra file for a handful of pids.
+        if state == "D":
+            try:
+                with open(entry.path + "/wchan") as f:
+                    blocked_in = f.read().strip()
+                if blocked_in and blocked_in != "0":
+                    record["wchan"] = blocked_in
+            except OSError:
+                pass
+
+        out[pid] = record
+    return out
+
+
+# Command lines are elided in every surface that shows them, so carrying the
+# full 4KB of a browser's argv only inflates the payload.
+CMDLINE_CHARS = 220
+
+
+def read_cmdline(pid, fallback):
+    try:
+        with open("/proc/%d/cmdline" % pid, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return fallback
+    if not raw:
+        return fallback  # kernel threads have an empty cmdline
+    text = raw.replace(b"\x00", b" ").strip().decode("utf-8", "replace")
+    return text if len(text) <= CMDLINE_CHARS else text[:CMDLINE_CHARS] + "…"
+
+
+def busy_percent(current, previous):
+    delta_total = current[1] - previous[1]
+    if delta_total <= 0:
+        return 0.0
+    pct = (current[0] - previous[0]) / delta_total * 100.0
+    return round(min(100.0, max(0.0, pct)), 1)
+
+
+def rates(current, previous, elapsed):
+    """Per-second deltas for a {key: (a, b)} counter map."""
+    out = {}
+    for key, (a, b) in current.items():
+        prev = previous.get(key)
+        if prev is None:
+            continue
+        # Counters only go backwards when a device is re-created, in which case
+        # the delta is meaningless rather than negative.
+        out[key] = (
+            max(0.0, (a - prev[0]) / elapsed),
+            max(0.0, (b - prev[1]) / elapsed),
+        )
+    return out
+
+
+class Sampler:
+    def __init__(self, interval, want_procs, limit):
+        self.interval = interval
+        self.want_procs = want_procs
+        self.limit = limit
+        self.thread_pid = 0
+        self.gpu_detail = False
+        self.gpu = LazyGpu()
+        self.sensor_detail = False
+        self.net_detail = False
+        self.disk_detail = False
+        self.apps_detail = False
+        self.group_apps = True
+        self.prev_cgroups = {}
+        # Forking systemctl costs ~5ms, which is more than the entire rest of a
+        # sample. Failed units change rarely, so poll on a slow timer and carry
+        # the last answer between polls.
+        self.failed_units = []
+        self.failed_units_at = 0.0
+        self.thermals = Thermals()
+        self.recorder = FlightRecorder()
+        self.socket_detail = False
+        self.open_files_pid = 0
+        self.prime()
+
+    def prime(self):
+        """Reset every baseline to now, so the next sample measures from here."""
+        self.prev_cpu = read_cpu()
+        self.prev_net = read_net()
+        self.prev_disk = read_disk()
+        self.prev_disk_stats = read_disk_stats()
+        self.prev_proc_io = {}
+        self.prev_procs = read_procs() if self.want_procs else {}
+        self.prev_threads = read_threads(self.thread_pid) if self.thread_pid else {}
+        # cpu.stat is cumulative and outlives the applications gate, so a
+        # baseline taken before the overlay last closed makes the next sample
+        # divide however long it was shut by a single interval. Twelve seconds
+        # closed is enough to show a browser at several hundred percent for one
+        # frame; a minute reads in the thousands. The discarded first return is
+        # the rates against an empty baseline — all zero — and the counters are
+        # what we actually want.
+        self.prev_cgroups = read_cgroups({}, 1.0)[1] if self.apps_detail else {}
+        self.prev_time = time.monotonic()
+
+    def sample(self):
+        now = time.monotonic()
+        elapsed = max(1e-6, now - self.prev_time)
+
+        cpu = read_cpu()
+        cores = [
+            busy_percent(cpu[i], self.prev_cpu[i])
+            for i in range(1, min(len(cpu), len(self.prev_cpu)))
+        ]
+        # Total jiffies burned across every core this interval. Per-process
+        # shares are measured against this, so a process pegging one core of
+        # sixteen reads as 100% (of a core) rather than 6% (of the machine) —
+        # the htop/btop convention.
+        cpu_jiffies = cpu[0][1] - self.prev_cpu[0][1] if self.prev_cpu else 0
+
+        net = read_net()
+        disk = read_disk()
+        disk_stats = read_disk_stats()
+        net_rates = rates(net, self.prev_net, elapsed)
+        disk_rates = rates(disk, self.prev_disk, elapsed)
+
+        with open("/proc/loadavg") as f:
+            load = [float(v) for v in f.read().split()[:3]]
+        with open("/proc/uptime") as f:
+            uptime = float(f.read().split()[0])
+
+        out = {
+            "interval": round(elapsed, 3),
+            "uptime": uptime,
+            "cpu": {
+                "total": busy_percent(cpu[0], self.prev_cpu[0]) if self.prev_cpu else 0.0,
+                "cores": cores,
+                "count": len(cores),
+                "load": load,
+            },
+            "mem": read_mem(),
+            "pressure": read_pressure(),
+            "swaps": read_swaps(),
+            "thermal": self.thermals.sample(self.sensor_detail),
+            "cpufreq": read_cpufreq(),
+            "irq": read_interrupts(),
+            "btrfs": read_btrfs(),
+            "failedUnits": self.poll_failed_units(),
+            "net": {
+                "rx": round(sum(r[0] for r in net_rates.values())),
+                "tx": round(sum(r[1] for r in net_rates.values())),
+                "ifaces": [
+                    {"name": name, "rx": round(r[0]), "tx": round(r[1])}
+                    for name, r in sorted(net_rates.items())
+                ],
+                "links": read_links(net.keys(), self.net_detail),
+            },
+            "disk": {
+                "read": round(sum(r[0] for r in disk_rates.values())),
+                "write": round(sum(r[1] for r in disk_rates.values())),
+                "devices": derive_disk(disk_stats, self.prev_disk_stats, elapsed),
+                "filesystems": read_filesystems(),
+            },
+        }
+
+        if self.net_detail:
+            out["sockets"] = read_sockets()
+
+        if self.disk_detail:
+            out.update(self.io_table(elapsed))
+
+        if self.socket_detail:
+            pids = [int(e.name) for e in os.scandir("/proc") if e.name.isdigit()]
+            out["socketCounts"] = {str(k): v for k, v in count_process_sockets(pids).items()}
+
+        if self.open_files_pid:
+            details = read_open_files(self.open_files_pid)
+            if details is not None:
+                out["openFiles"] = details
+
+        if self.apps_detail:
+            apps, self.prev_cgroups = read_cgroups(self.prev_cgroups, elapsed)
+            if self.group_apps:
+                apps = merge_apps(apps)
+                apps.sort(key=lambda a: -a["mem"])
+            out["apps"] = apps
+            out["ioDelegated"] = io_delegation_enabled()
+
+        try:
+            devices = self.gpu.sample(self.gpu_detail)
+            if devices is not None:
+                out["gpu"] = {"devices": devices}
+        except Exception as error:
+            if True:
+                # A GPU that falls off the bus mid-session (driver reload, eGPU
+                # unplug) should cost the panel its GPU card, not its samples.
+                out["gpu"] = {"devices": [], "error": str(error)}
+
+        if self.want_procs:
+            out.update(self.process_table(cpu_jiffies, elapsed, len(cores)))
+
+        if self.thread_pid:
+            out["threadsOf"] = self.thread_pid
+            out["threads"] = self.thread_table(cpu_jiffies, len(cores))
+
+        self.prev_cpu = cpu
+        self.prev_net = net
+        self.prev_disk = disk
+        self.prev_disk_stats = disk_stats
+        self.prev_time = now
+        self.recorder.record(out, now)
+        return out
+
+    def process_table(self, cpu_jiffies, elapsed, ncpu):
+        """Every process, not a top-N slice.
+
+        The previous version emitted only the busiest `limit` processes, which
+        meant the UI could not find — let alone sort by — anything that was not
+        already CPU-busy. Searching for a sleeping daemon returned nothing and
+        "sort by memory" silently ranked within the CPU top 60. A full scan of
+        ~700 processes costs about 14ms, which the process table's own gate
+        already covers, so there is no reason to truncate.
+
+        `limit` now governs only how many command lines are resolved, since
+        that is the part that scales badly and matters least for the long tail.
+        """
+        procs = read_procs()
+        ncpu = ncpu or os.cpu_count() or 1
+        scale = (100.0 * ncpu / cpu_jiffies) if cpu_jiffies > 0 else 0.0
+        elapsed_ms = max(1e-6, elapsed) * 1000.0
+
+        rows = []
+        running = 0
+        blocked = 0
+        threads = 0
+        for pid, cur in procs.items():
+            threads += cur["threads"]
+            if cur["state"] == "R":
+                running += 1
+            elif cur["state"] == "D":
+                blocked += 1
+
+            previous = self.prev_procs.get(pid)
+            # A recycled pid looks like a huge negative jump; comparing comm
+            # catches the common case and costs one string compare.
+            delta = 0
+            wait_ms = 0.0
+            if previous is not None and previous["name"] == cur["name"]:
+                delta = max(0, cur["jiffies"] - previous["jiffies"])
+                if "runqueue" in cur and "runqueue" in previous:
+                    # Nanoseconds of runnable-but-not-running this interval,
+                    # as a share of the interval: 100% means it spent the whole
+                    # time waiting for a CPU.
+                    waited = max(0, cur["runqueue"] - previous["runqueue"])
+                    wait_ms = waited / 1e6
+
+            row = {
+                "pid": pid,
+                "ppid": cur["ppid"],
+                "name": cur["name"],
+                "user": username(cur["uid"]),
+                "cpu": round(delta * scale, 1),
+                "rss": cur["rss"],
+                "threads": cur["threads"],
+                "state": cur["state"],
+                "wait": round(min(100.0, wait_ms / elapsed_ms * 100.0), 1),
+            }
+            if "wchan" in cur:
+                row["wchan"] = cur["wchan"]
+            rows.append(row)
+
+        self.prev_procs = procs
+        # Emitted busiest-first. The sampler no longer truncates, but callers
+        # that show only the first few rows — the bar panel's "top processes" —
+        # need that to mean the busiest few rather than whichever pids scandir
+        # happened to return first.
+        rows.sort(key=lambda r: (-r["cpu"], -r["rss"]))
+
+        # Command lines only for the rows most likely to be looked at. Sorting
+        # by CPU and by memory separately means a memory hog that never uses
+        # the CPU still gets one.
+        detailed = set()
+        for key in ("cpu", "rss"):
+            ranked = sorted(rows, key=lambda r: -r[key])
+            detailed.update(r["pid"] for r in ranked[:self.limit])
+        for row in rows:
+            if row["pid"] in detailed:
+                row["cmd"] = read_cmdline(row["pid"], row["name"])
+
+        return {
+            "procs": rows,
+            "procCount": len(procs),
+            "procRunning": running,
+            "procBlocked": blocked,
+            "threadCount": threads,
+            "cmdResolved": len(detailed),
+        }
+
+    def poll_failed_units(self):
+        now = time.monotonic()
+        if now - self.failed_units_at > FAILED_UNIT_POLL_SEC:
+            self.failed_units = read_failed_units()
+            self.failed_units_at = now
+        return self.failed_units
+
+    def io_table(self, elapsed):
+        """Processes ranked by block I/O over the interval.
+
+        Unlike network, the kernel does account for this per process — but only
+        to the process's owner, so a normal session sees its own processes and
+        not root's. The readable/total counts go along so the UI can say which
+        it is showing rather than implying the list is complete.
+        """
+        pids = [int(e.name) for e in os.scandir("/proc") if e.name.isdigit()]
+        current = read_process_io(pids)
+
+        rows = []
+        for pid, (read_bytes, write_bytes) in current.items():
+            before = self.prev_proc_io.get(pid)
+            if before is None:
+                continue
+            read_rate = max(0, read_bytes - before[0]) / elapsed
+            write_rate = max(0, write_bytes - before[1]) / elapsed
+            if read_rate <= 0 and write_rate <= 0:
+                continue
+            try:
+                with open("/proc/%d/comm" % pid) as f:
+                    name = f.read().strip()
+            except OSError:
+                continue
+            rows.append({
+                "pid": pid,
+                "name": name,
+                "read": round(read_rate),
+                "write": round(write_rate),
+            })
+
+        self.prev_proc_io = current
+        rows.sort(key=lambda row: -(row["read"] + row["write"]))
+        return {
+            "ioProcs": rows[:20],
+            "ioReadable": len(current),
+            "ioTotal": len(pids),
+        }
+
+    def thread_table(self, cpu_jiffies, ncpu):
+        """Per-thread CPU for the one expanded process, busiest first."""
+        threads = read_threads(self.thread_pid)
+        ncpu = ncpu or os.cpu_count() or 1
+        scale = (100.0 * ncpu / cpu_jiffies) if cpu_jiffies > 0 else 0.0
+
+        rows = []
+        for tid, cur in threads.items():
+            previous = self.prev_threads.get(tid)
+            delta = 0
+            if previous is not None and previous["name"] == cur["name"]:
+                delta = max(0, cur["jiffies"] - previous["jiffies"])
+            rows.append({
+                "tid": tid,
+                "name": cur["name"],
+                "state": cur["state"],
+                "cpu": round(delta * scale, 1),
+            })
+
+        self.prev_threads = threads
+        rows.sort(key=lambda row: (-row["cpu"], row["tid"]))
+        # Deliberately not `limit`: that setting bounds a list of every process
+        # on the machine, and a user who trimmed it to ten still wants to see
+        # more than ten of a browser's threads.
+        return rows[:THREAD_LIMIT]
+
+    def handle(self, line):
+        """Apply one stdin command. Returns True if baselines need re-priming."""
+        parts = line.split()
+        if not parts:
+            return False
+        command = parts[0]
+        argument = parts[1] if len(parts) > 1 else ""
+
+        if command == "quit":
+            raise SystemExit(0)
+        if command == "procs":
+            want = argument == "on"
+            if want == self.want_procs:
+                return False
+            self.want_procs = want
+            return True
+        if command == "interval":
+            try:
+                self.interval = min(60.0, max(0.25, float(argument)))
+            except ValueError:
+                pass
+            return False
+        if command == "limit":
+            try:
+                self.limit = min(2000, max(1, int(argument)))
+            except ValueError:
+                pass
+            return False
+        if command == "history":
+            # Its own line, so the shell can seed its graphs with everything
+            # recorded before this session started.
+            print(json.dumps({"history": self.recorder.load()},
+                             separators=(",", ":")), flush=True)
+            return False
+        if command == "gpu":
+            # Nothing shows GPU data at idle, so the driver is not mapped until
+            # a surface that displays it opens.
+            self.gpu.set_wanted(argument == "on")
+            return False
+        if command == "sockets":
+            want = argument == "on"
+            if want == self.socket_detail:
+                return False
+            self.socket_detail = want
+            return False
+        if command == "openfiles":
+            try:
+                pid = 0 if argument in ("", "off") else int(argument)
+            except ValueError:
+                return False
+            if pid == self.open_files_pid:
+                return False
+            self.open_files_pid = max(0, pid)
+            return False
+        if command == "groupapps":
+            # Off shows one row per systemd scope instead of one per application.
+            self.group_apps = argument != "off"
+            return False
+        if command == "apps":
+            # Per-application accounting from cgroups, for the Applications view.
+            want = argument == "on"
+            if want == self.apps_detail:
+                return False
+            self.apps_detail = want
+            if not want:
+                # Nothing reads these again until the view reopens, and by then
+                # they describe a window that has already closed. A missing
+                # baseline reads as 0% for one sample; a stale one reads as
+                # hundreds or thousands of percent.
+                self.prev_cgroups = {}
+                return False
+            # Unlike the other detail gates, this one is measured as a rate, so
+            # it needs the same re-prime the process table asks for.
+            return True
+        if command == "diskdetail":
+            # Per-process block I/O, for the expanded disk card.
+            want = argument == "on"
+            if want == self.disk_detail:
+                return False
+            self.disk_detail = want
+            return True
+        if command == "netdetail":
+            # Error counters and the socket table, for the expanded network card.
+            want = argument == "on"
+            if want == self.net_detail:
+                return False
+            self.net_detail = want
+            return False
+        if command == "sensors":
+            # Turns on the off-CPU hwmon sensors (NVMe, DIMM, wifi), each of
+            # which costs a bus transaction, while a view is listing them.
+            want = argument == "on"
+            if want == self.sensor_detail:
+                return False
+            self.sensor_detail = want
+            return False
+        if command == "gpudetail":
+            # Turns on the expensive GPU readings (PCIe throughput, per-client
+            # VRAM) while the expanded GPU card is showing them.
+            want = argument == "on"
+            if want == self.gpu_detail:
+                return False
+            self.gpu_detail = want
+            return False
+        if command == "threads":
+            # `threads <pid>` expands one process; `threads off` (or 0) collapses.
+            try:
+                pid = 0 if argument in ("", "off") else int(argument)
+            except ValueError:
+                return False
+            if pid == self.thread_pid:
+                return False
+            self.thread_pid = max(0, pid)
+            return True
+        return False
+
+
+class StdinLines:
+    """Line reader that never leaves data in a Python-level buffer.
+
+    select() reports on the file descriptor, but sys.stdin.readline() reads
+    through an object buffer on top of it. When two commands arrive in the same
+    chunk — which is exactly what happens when a surface closes and another
+    opens in the same frame, sending `procs off` then `procs on` — readline()
+    hands back the first and keeps the second, while select() correctly reports
+    that the fd has nothing new. The second command then sits unread until
+    something else happens to arrive. Reading the fd directly keeps the
+    readiness check and the reader talking about the same bytes.
+    """
+
+    def __init__(self, fd):
+        self.fd = fd
+        self.buffer = b""
+        self.closed = False
+
+    def read_available(self):
+        try:
+            chunk = os.read(self.fd, 65536)
+        except OSError:
+            self.closed = True
+            return []
+        if not chunk:
+            self.closed = True
+            return []
+        self.buffer += chunk
+        lines = self.buffer.split(b"\n")
+        self.buffer = lines.pop()  # trailing partial line waits for more bytes
+        return [line.decode("utf-8", "replace") for line in lines]
+
+
+def main():
+    interval = 2.0
+    want_procs = False
+    limit = 60
+
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        value = args[i + 1] if i + 1 < len(args) else ""
+        if arg == "--interval":
+            interval = min(60.0, max(0.25, float(value)))
+        elif arg == "--limit":
+            limit = min(2000, max(1, int(value)))
+        elif arg == "--procs":
+            want_procs = value == "on"
+
+    sampler = Sampler(interval, want_procs, limit)
+    stdin = StdinLines(sys.stdin.fileno())
+    # Re-priming after `procs on` throws away the interval already elapsed, so
+    # emit the first table sooner than a full period to keep panel-open snappy.
+    deadline = time.monotonic() + sampler.interval
+
+    while True:
+        while True:
+            timeout = deadline - time.monotonic()
+            if timeout <= 0:
+                break
+            readable, _, _ = select.select([stdin.fd], [], [], timeout)
+            if not readable:
+                break
+            lines = stdin.read_available()
+            if stdin.closed:
+                return  # the shell went away; so do we
+            # Every command in this chunk is applied before the next readiness
+            # check, so a batch re-primes once rather than once per line. The
+            # list is built eagerly: any() over a generator would stop at the
+            # first command that changed state and drop the rest of the batch.
+            changed = [sampler.handle(line) for line in lines]
+            if any(changed):
+                sampler.prime()
+                deadline = time.monotonic() + min(sampler.interval, 0.6)
+
+        try:
+            print(json.dumps(sampler.sample(), separators=(",", ":")), flush=True)
+        except BrokenPipeError:
+            return
+        deadline = time.monotonic() + sampler.interval
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (KeyboardInterrupt, BrokenPipeError):
+        pass

--- a/shell/plugins/omatask/sampler.py
+++ b/shell/plugins/omatask/sampler.py
@@ -1113,7 +1113,9 @@ def merge_apps(apps):
             order.append(key)
             continue
         existing["mem"] += app["mem"]
-        existing["memPeak"] += app["memPeak"]
+        # A high-water mark is not additive: two scopes that peaked at
+        # different moments never held the sum of their peaks at once.
+        existing["memPeak"] = max(existing["memPeak"], app["memPeak"])
         existing["cpu"] = round(existing["cpu"] + app["cpu"], 1)
         existing["procs"] += app["procs"]
         existing["oomKills"] += app["oomKills"]
@@ -2029,10 +2031,9 @@ class Sampler:
             if devices is not None:
                 out["gpu"] = {"devices": devices}
         except Exception as error:
-            if True:
-                # A GPU that falls off the bus mid-session (driver reload, eGPU
-                # unplug) should cost the panel its GPU card, not its samples.
-                out["gpu"] = {"devices": [], "error": str(error)}
+            # A GPU that falls off the bus mid-session (driver reload, eGPU
+            # unplug) should cost the panel its GPU card, not its samples.
+            out["gpu"] = {"devices": [], "error": str(error)}
 
         if self.want_procs:
             out.update(self.process_table(cpu_jiffies, elapsed, len(cores)))
@@ -2362,15 +2363,21 @@ def main():
     want_procs = False
     limit = 60
 
+    # A malformed invocation should not take the sampler down: the stdin
+    # handlers already ignore values they cannot parse, and argv gets the same
+    # treatment, including a trailing flag with no value at all.
     args = sys.argv[1:]
     for i, arg in enumerate(args):
         value = args[i + 1] if i + 1 < len(args) else ""
-        if arg == "--interval":
-            interval = min(60.0, max(0.25, float(value)))
-        elif arg == "--limit":
-            limit = min(2000, max(1, int(value)))
-        elif arg == "--procs":
-            want_procs = value == "on"
+        try:
+            if arg == "--interval":
+                interval = min(60.0, max(0.25, float(value)))
+            elif arg == "--limit":
+                limit = min(2000, max(1, int(value)))
+            elif arg == "--procs":
+                want_procs = value == "on"
+        except ValueError:
+            pass
 
     sampler = Sampler(interval, want_procs, limit)
     stdin = StdinLines(sys.stdin.fileno())

--- a/shell/plugins/omatask/test_sampler.py
+++ b/shell/plugins/omatask/test_sampler.py
@@ -245,12 +245,16 @@ def app(key, name, mem, cpu, procs, stall=0.0, peak=None, oom=0):
             "oomKills": oom}
 
 rows = sampler.merge_apps([
-    app("chromium", "chromium", 10_000, 5.0, 90, stall=2.0),
-    app("chromium", "chromium", 2_000, 1.0, 5, stall=7.5),
+    app("chromium", "chromium", 10_000, 5.0, 90, stall=2.0, peak=11_000),
+    app("chromium", "chromium", 2_000, 1.0, 5, stall=7.5, peak=9_000),
     app("podcast-worker", "podcast-worker", 500, 0.1, 1),
 ])
 check("merging folds one app's scopes into a single row", len(rows), 2)
 check("merged memory adds", rows[0]["mem"], 12_000)
+# A high-water mark is not additive: these two scopes never together held
+# 20,000, because each reached its own peak at its own moment.
+check("merged peak takes the worst scope rather than summing",
+      rows[0]["memPeak"], 11_000)
 close("merged cpu adds", rows[0]["cpu"], 6.0)
 check("merged process counts add", rows[0]["procs"], 95)
 check("merged rows record how many scopes they cover", rows[0]["scopes"], 2)

--- a/shell/plugins/omatask/test_sampler.py
+++ b/shell/plugins/omatask/test_sampler.py
@@ -89,7 +89,6 @@ check("_cg_pressure_total on irq-style input with only a `full` line",
 
 # ---------------------------------------------------------------- disk
 
-DISKSTATS_FIELDS = ("8 0 sda 100 0 2000 50 200 0 4000 80 0 300 130 0 0 0 0 0 0").split()
 now = {"sda": {"reads": 100, "readBytes": 1024000, "msReading": 50,
                "writes": 200, "writeBytes": 2048000, "msWriting": 80,
                "inFlight": 2, "msDoingIO": 500}}
@@ -134,9 +133,13 @@ def fake_open(path, *args, **kwargs):
     return _orig_open(path, *args, **kwargs)
 
 
+# Restored in a finally: if read_wireless() raises, a leaked fake_open would
+# answer every later check and make those failures point anywhere but here.
 sampler.open = fake_open
-wireless = sampler.read_wireless()
-del sampler.open
+try:
+    wireless = sampler.read_wireless()
+finally:
+    del sampler.open
 check("wireless: strips the kernel's trailing dots", wireless["wlp13s0"]["signal"], -56.0)
 check("wireless: link quality", wireless["wlp13s0"]["quality"], 54.0)
 check("wireless: a -256 noise floor means 'unknown' and is dropped",

--- a/shell/plugins/omatask/test_sampler.py
+++ b/shell/plugins/omatask/test_sampler.py
@@ -27,7 +27,12 @@ import tempfile
 sys.dont_write_bytecode = True
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-spec = importlib.util.spec_from_file_location("sampler", os.path.join(HERE, "sampler.py"))
+SAMPLER = os.path.join(HERE, "sampler.py")
+spec = importlib.util.spec_from_file_location("sampler", SAMPLER)
+if spec is None or spec.loader is None:
+    # Otherwise this dies with an AttributeError on None, which says nothing
+    # about the file that is actually missing or unreadable.
+    sys.exit("cannot load the sampler under test: %s" % SAMPLER)
 sampler = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(sampler)
 

--- a/shell/plugins/omatask/test_sampler.py
+++ b/shell/plugins/omatask/test_sampler.py
@@ -6,8 +6,14 @@ has to be runnable on a fresh Omarchy install with nothing added.
 
 The parsers are the part worth testing: a sampler bug is silent by nature, and
 a mis-parsed field shows up as a plausible-looking wrong number rather than a
-crash. Everything here works on fixture strings, so the suite is deterministic
-and does not depend on what the machine happens to be doing.
+crash. Most of what follows works on fixture strings and is deterministic
+regardless of what the machine is doing.
+
+The exception is the baseline group at the end, which builds a real Sampler and
+therefore reads this host's /proc, /sys and cgroup files. That is deliberate —
+it is the only way to check that priming actually takes a baseline — and it is
+written to assert against what the host exposes rather than assuming any of it
+is present, so a container without cgroup v2 passes rather than failing.
 """
 
 import importlib.util

--- a/shell/plugins/omatask/test_sampler.py
+++ b/shell/plugins/omatask/test_sampler.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Tests for the sampler's parsers and derivations.
+
+Run with `python3 test_sampler.py`. No test framework, no dependencies — this
+has to be runnable on a fresh Omarchy install with nothing added.
+
+The parsers are the part worth testing: a sampler bug is silent by nature, and
+a mis-parsed field shows up as a plausible-looking wrong number rather than a
+crash. Everything here works on fixture strings, so the suite is deterministic
+and does not depend on what the machine happens to be doing.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+
+# Load from source every run. A stale __pycache__ entry can otherwise shadow an
+# edit made within the same second as the previous compile — which silently
+# turns this suite into a test of the last version rather than this one.
+sys.dont_write_bytecode = True
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("sampler", os.path.join(HERE, "sampler.py"))
+sampler = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sampler)
+
+failures = []
+checks = 0
+
+
+def check(name, got, want):
+    global checks
+    checks += 1
+    if got != want:
+        failures.append("%s\n      got:  %r\n      want: %r" % (name, got, want))
+
+
+def close(name, got, want, tolerance=0.05):
+    global checks
+    checks += 1
+    if got is None or abs(got - want) > tolerance:
+        failures.append("%s\n      got:  %r\n      want: ~%r" % (name, got, want))
+
+
+# ---------------------------------------------------------------- formatting
+
+check("busy_percent: half busy",
+      sampler.busy_percent((50, 100), (0, 0)), 50.0)
+check("busy_percent: idle interval yields 0, not a divide error",
+      sampler.busy_percent((10, 100), (10, 100)), 0.0)
+check("busy_percent: counter reset clamps at 0",
+      sampler.busy_percent((0, 100), (50, 200)), 0.0)
+check("busy_percent: clamps above 100",
+      sampler.busy_percent((300, 100), (0, 0)), 100.0)
+
+check("rates: per-second from a delta",
+      sampler.rates({"a": (200, 400)}, {"a": (100, 200)}, 2.0), {"a": (50.0, 100.0)})
+check("rates: unknown key is skipped rather than counted from zero",
+      sampler.rates({"new": (10, 10)}, {}, 1.0), {})
+check("rates: a counter that went backwards reads 0, not negative",
+      sampler.rates({"a": (5, 5)}, {"a": (100, 100)}, 1.0), {"a": (0.0, 0.0)})
+
+# ---------------------------------------------------------------- cgroups
+
+check("_cg_keyed parses the kernel's `key value` format",
+      sampler._cg_keyed("usage_usec 123\nuser_usec 45\n"),
+      {"usage_usec": 123, "user_usec": 45})
+check("_cg_keyed ignores non-numeric values instead of raising",
+      sampler._cg_keyed("good 1\nbad notanumber\n"), {"good": 1})
+
+PSI = ("some avg10=1.50 avg60=0.20 avg300=0.00 total=12345\n"
+       "full avg10=0.00 avg60=0.00 avg300=0.00 total=678\n")
+check("_cg_pressure_total reads the `some` total, not `full`",
+      sampler._cg_pressure_total(PSI), 12345)
+check("_cg_pressure_total on irq-style input with only a `full` line",
+      sampler._cg_pressure_total("full avg10=0.00 total=99\n"), None)
+
+# ---------------------------------------------------------------- disk
+
+DISKSTATS_FIELDS = ("8 0 sda 100 0 2000 50 200 0 4000 80 0 300 130 0 0 0 0 0 0").split()
+now = {"sda": {"reads": 100, "readBytes": 1024000, "msReading": 50,
+               "writes": 200, "writeBytes": 2048000, "msWriting": 80,
+               "inFlight": 2, "msDoingIO": 500}}
+before = {"sda": {"reads": 50, "readBytes": 512000, "msReading": 30,
+                  "writes": 100, "writeBytes": 1024000, "msWriting": 40,
+                  "inFlight": 0, "msDoingIO": 300}}
+derived = sampler.derive_disk(now, before, 2.0)[0]
+check("derive_disk: read throughput", derived["read"], 256000)
+check("derive_disk: write throughput", derived["write"], 512000)
+close("derive_disk: iops is completed ops per second", derived["iops"], 75.0)
+close("derive_disk: util is busy time over wall time", derived["util"], 10.0)
+check("derive_disk: queue depth is instantaneous", derived["queue"], 2)
+close("derive_disk: latency is service time per op", derived["latency"], 0.4)
+check("derive_disk: a device with no previous sample is skipped",
+      sampler.derive_disk(now, {}, 1.0), [])
+
+zero = sampler.derive_disk({"sda": dict(now["sda"])}, {"sda": dict(now["sda"])}, 1.0)[0]
+check("derive_disk: an idle device reports 0 latency, not a divide error",
+      zero["latency"], 0)
+
+# ---------------------------------------------------------------- network
+
+check("interface names that double-count the physical link are skipped",
+      [n for n in ("veth123", "br-abc", "docker0", "virbr0", "wlp13s0", "enp1s0")
+       if not n.startswith(sampler.SKIP_IFACE_PREFIXES)],
+      ["wlp13s0", "enp1s0"])
+check("block devices that are not disks are skipped",
+      [n for n in ("loop0", "ram1", "zram0", "dm-0", "md0", "nvme0n1", "sda")
+       if not n.startswith(sampler.SKIP_DISK_PREFIXES)],
+      ["nvme0n1", "sda"])
+
+WIRELESS = ("Inter-| sta-|   Quality        |   Discarded packets\n"
+            " face | tus | link level noise |  nwid  crypt\n"
+            "wlp13s0: 0000   54.  -56.  -256        0      0\n")
+import io as _io
+_orig_open = open
+
+
+def fake_open(path, *args, **kwargs):
+    if path == "/proc/net/wireless":
+        return _io.StringIO(WIRELESS)
+    return _orig_open(path, *args, **kwargs)
+
+
+sampler.open = fake_open
+wireless = sampler.read_wireless()
+del sampler.open
+check("wireless: strips the kernel's trailing dots", wireless["wlp13s0"]["signal"], -56.0)
+check("wireless: link quality", wireless["wlp13s0"]["quality"], 54.0)
+check("wireless: a -256 noise floor means 'unknown' and is dropped",
+      "noise" in wireless["wlp13s0"], False)
+
+# ---------------------------------------------------------------- thermals
+
+check("chip_kind maps a driver name to hardware a person recognises",
+      [sampler.chip_kind(c) for c in ("k10temp", "nvme", "spd5118", "mt7921_phy0", "r8169_0")],
+      ["cpu", "drive", "dimm", "net", "net"])
+check("display_chip falls through to the raw name when unknown",
+      sampler.display_chip("some_new_driver"), "some_new_driver")
+
+# ---------------------------------------------------------------- zram
+
+check("zram ratio divides by the compressed size, not allocator overhead",
+      sampler.read_zram("definitely-not-a-device"), {})
+
+# ---------------------------------------------------------------- recorder
+
+with tempfile.TemporaryDirectory() as tmp:
+    sampler.RECORDER_DIR = tmp
+    sampler.RECORDER_FILE = os.path.join(tmp, "history.jsonl")
+    recorder = sampler.FlightRecorder(tick=0)
+    sample = {"cpu": {"total": 12.5}, "mem": {"total": 100, "used": 40, "swapUsed": 0},
+              "net": {"rx": 1, "tx": 2}, "disk": {"read": 3, "write": 4},
+              "thermal": {"cpu": 55.0}, "pressure": {"memory": {"some10": 0.5}}}
+    recorder.record(sample, 100.0)
+    recorder.record(sample, 200.0)
+    rows = recorder.load()
+    check("recorder: writes one row per tick", len(rows), 2)
+    check("recorder: cpu is carried through", rows[0]["c"], 12.5)
+    check("recorder: memory is stored as a percentage", rows[0]["m"], 40.0)
+    check("recorder: temperature is carried through", rows[0]["ct"], 55.0)
+
+    with _orig_open(sampler.RECORDER_FILE, "a") as f:
+        f.write('{"t":1,"c":  \n')       # a torn line, as after an unclean exit
+    check("recorder: survives a torn final line", len(recorder.load()), 2)
+
+    recorder.tick = 3600
+    recorder.record(sample, 200.5)
+    check("recorder: respects its tick", len(recorder.load()), 2)
+
+# ---------------------------------------------------------------- stdin
+
+lines = sampler.StdinLines(0)
+lines.buffer = b"procs on\ngpu on\npartial"
+consumed = lines.buffer.split(b"\n")
+lines.buffer = consumed.pop()
+check("stdin reader holds back an incomplete trailing line", lines.buffer, b"partial")
+check("stdin reader yields both complete commands",
+      [c.decode() for c in consumed], ["procs on", "gpu on"])
+
+
+# ------------------------------------------------------- application identity
+
+# A service unit name IS the identity. Two Python services must not collapse
+# into one "python" row just because their process names match.
+check("service units identify by unit name, not process name",
+      [sampler.app_identity(u, [])[0]
+       for u in ("podcast-worker.service", "hermes-gateway.service")],
+      ["podcast-worker", "hermes-gateway"])
+check("template instances of one unit share an identity",
+      sampler.app_identity("getty@tty1.service", [])[0], "getty")
+check("a launcher-added app- prefix is stripped from services",
+      sampler.app_identity("app-dropbox@autostart.service", [])[0], "dropbox")
+check("portal services stay distinct despite a shared prefix",
+      [sampler.app_identity(u, [])[0]
+       for u in ("xdg-desktop-portal.service", "xdg-desktop-portal-gtk.service")],
+      ["xdg-desktop-portal", "xdg-desktop-portal-gtk"])
+
+# App scopes: the desktop id reduces to its leaf, and the trailing hash or pid
+# systemd appends is not part of the identity.
+check("a reverse-DNS desktop id reduces to its leaf",
+      sampler.app_identity("app-org.chromium.Chromium-1000.scope", [])[0], "chromium")
+check("a compositor tag is not part of the identity",
+      sampler.app_identity("app-Hyprland-chromium-deadbeef.scope", [])[0], "chromium")
+check("both Chromium scopes therefore share one key",
+      sampler.app_identity("app-org.chromium.Chromium-1000.scope", [])[0]
+      == sampler.app_identity("app-Hyprland-chromium-deadbeef.scope", [])[0], True)
+
+# A scope named after the launcher, or after a terminal session, says nothing
+# about its contents — those defer to the processes inside.
+check("a launcher scope defers to its processes",
+      sampler.app_identity("app-Hyprland-gtk-launch-cafe1234.scope", [])[0], None)
+check("an anonymous session scope defers to its processes",
+      sampler.app_identity("tmux-spawn-00000000-0000.scope", [])[0], None)
+
+
+# Container scopes carry a unique id but no readable name. Identifying them by
+# process name would merge two containers of the same image — two separate
+# databases showing as one row.
+check("a container scope keeps its own identity",
+      sampler.app_identity("docker-1111aaaa2222.scope", [])[0], "docker-1111aaaa2222")
+check("...but has no readable name of its own",
+      sampler.app_identity("docker-1111aaaa2222.scope", [])[1], None)
+check("two containers of one image get different keys",
+      sampler.app_identity("docker-aaaa1111.scope", [])[0]
+      != sampler.app_identity("docker-bbbb2222.scope", [])[0], True)
+check("podman and nspawn scopes are treated the same way",
+      [sampler.app_identity(u, [])[0] is not None
+       for u in ("libpod-abc.scope", "podman-abc.scope", "machine-vm.scope")],
+      [True, True, True])
+
+# ------------------------------------------------------- application merging
+
+def app(key, name, mem, cpu, procs, stall=0.0, peak=None, oom=0):
+    return {"key": key, "name": name, "unit": key, "system": False,
+            "mem": mem, "memPeak": peak if peak is not None else mem,
+            "cpu": cpu, "procs": procs, "ioStall": stall, "memStall": 0.0,
+            "oomKills": oom}
+
+rows = sampler.merge_apps([
+    app("chromium", "chromium", 10_000, 5.0, 90, stall=2.0),
+    app("chromium", "chromium", 2_000, 1.0, 5, stall=7.5),
+    app("podcast-worker", "podcast-worker", 500, 0.1, 1),
+])
+check("merging folds one app's scopes into a single row", len(rows), 2)
+check("merged memory adds", rows[0]["mem"], 12_000)
+close("merged cpu adds", rows[0]["cpu"], 6.0)
+check("merged process counts add", rows[0]["procs"], 95)
+check("merged rows record how many scopes they cover", rows[0]["scopes"], 2)
+close("stall takes the worst scope, not an average", rows[0]["ioStall"], 7.5)
+check("an app with one scope is left alone", rows[1]["scopes"], 1)
+check("distinct services survive merging", rows[1]["name"], "podcast-worker")
+
+# The failure this whole identity model exists to prevent.
+same_name = sampler.merge_apps([
+    app("podcast-worker", "python", 500, 0.1, 1),
+    app("hermes-gateway", "python", 90, 0.2, 1),
+])
+check("two services that merely share a process name do NOT merge",
+      len(same_name), 2)
+
+# ------------------------------------------------- rate baselines on re-open
+#
+# cgroup counters are cumulative. If the applications gate reopens against a
+# baseline taken before it last closed, the next sample divides the whole
+# closed period by one interval and every application reads in the hundreds or
+# thousands of percent for a frame. Two things have to hold to prevent it.
+
+gates = sampler.Sampler(2.0, False, 10)
+
+gates.apps_detail = True
+gates.prev_cgroups = {"/stale": (123456789, 0, 0)}
+gates.handle("apps off")
+check("turning applications off drops the stale baseline",
+      gates.prev_cgroups, {})
+
+check("turning applications on asks for a re-prime",
+      gates.handle("apps on"), True)
+
+# The other detail gates read instantaneous values, so they must NOT pay for a
+# full re-prime — that would discard every other baseline mid-interval.
+for gate, attr in (("sensors", "sensor_detail"), ("gpudetail", "gpu_detail"),
+                   ("netdetail", "net_detail")):
+    setattr(gates, attr, False)
+    check("%s does not force a re-prime" % gate, gates.handle(gate + " on"), False)
+
+# And prime() has to actually take the baseline it is now relied on for.
+# A host without cgroup v2 delegated (a CI container, say) has nothing to
+# read, and the point of the check is that prime() tries — not that this
+# particular machine has cgroups.
+cgroups_readable = len(sampler.read_cgroups({}, 1.0)[1]) > 0
+gates.apps_detail = True
+gates.prev_cgroups = {}
+gates.prime()
+check("prime takes a cgroup baseline when applications are on",
+      len(gates.prev_cgroups) > 0, cgroups_readable)
+
+gates.apps_detail = False
+gates.prime()
+check("prime skips the cgroup walk when applications are off",
+      gates.prev_cgroups, {})
+
+# ---------------------------------------------------------------- report
+
+print("ran %d checks" % checks)
+if failures:
+    print("\n%d FAILED:\n" % len(failures))
+    for f in failures:
+        print("  - " + f)
+    sys.exit(1)
+print("all passed")

--- a/test/shell.d/fixtures/omatask-bar-metrics/shell.qml
+++ b/test/shell.d/fixtures/omatask-bar-metrics/shell.qml
@@ -1,0 +1,253 @@
+import QtQuick
+import Quickshell
+import qs.Commons
+
+// The Task Manager bar widget, driven against a stub service, checking the
+// always-visible metric pair: that a second reading actually reaches the bar
+// without opening anything, that it comes out of the one shared sampler rather
+// than a second one, that a widget on every monitor still shares that sampler,
+// and that swap and GPU stay out of the bar on machines that have neither.
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
+  readonly property string widgetUrl: Quickshell.env("OMARCHY_OMATASK_WIDGET_URL")
+  readonly property string moduleName: "omarchy.omatask"
+
+  property var failures: []
+  property int checks: 0
+
+  function fail(message) { failures.push(String(message)) }
+
+  function check(condition, message) {
+    checks = checks + 1
+    if (!condition) fail(message)
+  }
+
+  function checkEqual(actual, expected, message) {
+    checks = checks + 1
+    if (actual !== expected) fail(message + " expected=" + expected + " actual=" + actual)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({ ok: failures.length === 0, failures: failures, checks: checks })
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  property var component: null
+
+  function widget(secondaryMetric) {
+    var item = component.createObject(host, {
+      bar: fakeBar,
+      moduleName: root.moduleName,
+      settings: { secondaryMetric: secondaryMetric, showPercent: true, barGraph: "sparkline" }
+    })
+    if (!item) fail("bar widget failed to instantiate for secondaryMetric=" + secondaryMetric)
+    return item
+  }
+
+  Item { id: host }
+
+  // One sampler, one service, however many bars ask for it — the shell caches
+  // service instances per plugin id, and this stands in for that cache.
+  QtObject {
+    id: stubService
+
+    property bool ready: true
+
+    property real cpuPercent: 41
+    property var cpuHistory: [10, 20, 30, 41]
+    property int coreCount: 8
+    property var cores: []
+    property var loadAverage: [0.4, 0.3, 0.2]
+    property bool hasCpuTemp: false
+    property real cpuTemp: 0
+
+    property real memPercent: 63
+    property var memHistory: [50, 55, 60, 63]
+    property real memTotal: 16 * 1024 * 1024 * 1024
+    property real memUsed: 10 * 1024 * 1024 * 1024
+
+    // Starts at zero the way a zram-only machine reports it.
+    property real swapTotal: 0
+    property real swapUsed: 0
+    property real swapPercent: 0
+    property var swapUsedHistory: [0, 0, 0, 0]
+
+    // Starts absent the way a machine with no discrete GPU reports it, and the
+    // way a hybrid machine reports it before anything asks for GPU sampling.
+    property bool hasGpu: false
+    property real gpuPercent: 0
+    property var gpuHistory: [0, 0, 0, 0]
+    property var primaryGpu: ({})
+    property real gpuMemPercent: 0
+    property real gpuMemTotal: 0
+    property real gpuMemUsed: 0
+
+    property var net: ({})
+    property var disk: ({})
+    property var processes: []
+    property int processCount: 0
+    property int threadCount: 0
+    property real uptime: 0
+
+    // Written by the widget's syncService(); present so those assignments land
+    // somewhere instead of throwing.
+    property int intervalSec: 2
+    property int historyPoints: 60
+    property int processLimit: 60
+    property bool alertsEnabled: false
+    property bool groupApps: true
+    property string listMode: "processes"
+    property string sortBy: "cpu"
+    property bool sortDescending: true
+    property var widgetSettings: ({})
+
+    // GPU is refcounted because polling it costs a driver query per tick. The
+    // counter is the point of the GPU half of this test.
+    property int gpuHolders: 0
+    property int processHolders: 0
+
+    function retainGpu() { gpuHolders = gpuHolders + 1 }
+    function releaseGpu() { gpuHolders = Math.max(0, gpuHolders - 1) }
+    function retainProcesses() { processHolders = processHolders + 1 }
+    function releaseProcesses() { processHolders = Math.max(0, processHolders - 1) }
+    function killProcess(pid, signalName) {}
+  }
+
+  QtObject {
+    id: mockShell
+    property var bar: fakeBar
+    property var barConfig: ({ position: "top" })
+    property var shellConfig: ({ version: 1, idle: {}, plugins: [], bar: { layout: { left: [], center: [], right: [] } } })
+    function firstPartyServiceFor(id) { return serviceFor(id) }
+    function serviceFor(id) { return id === root.moduleName ? stubService : null }
+    function summon(id, payloadJson) { return true }
+    function hide(id) { return true }
+    function toggle(id, payloadJson) { return true }
+    function updateEntryInline(moduleName, settings) { return true }
+  }
+
+  QtObject {
+    id: fakeBar
+    property bool vertical: false
+    property int barSize: 26
+    property string omarchyPath: root.rootPath
+    property string fontFamily: "monospace"
+    property color foreground: "white"
+    property color background: "black"
+    property color urgent: "red"
+    property var shell: mockShell
+    function run(command) {}
+    function showTooltip(target, text) {}
+    function hideTooltip(target) {}
+    function requestPopout(owner) {}
+    function releasePopout(owner) {}
+    function registerClickTarget(target) {}
+    function unregisterClickTarget(target) {}
+  }
+
+  Timer {
+    interval: 1
+    running: true
+    repeat: false
+    onTriggered: {
+      root.component = Qt.createComponent(root.widgetUrl, Component.PreferSynchronous)
+      if (root.component.status !== Component.Ready) {
+        root.fail("bar widget failed to load: " + root.component.errorString())
+        root.writeResult()
+        return
+      }
+
+      var cpuOnly = root.widget("none")
+      var withMemory = root.widget("mem")
+      var withSwap = root.widget("swap")
+      var withGpu = root.widget("gpu")
+
+      // ---- both readings reach the bar, with nothing opened ----
+      root.check(!cpuOnly.opened && !withMemory.opened, "the pair is readable without opening the panel")
+      root.checkEqual(cpuOnly.secondaryVisible, false, "CPU alone stays the default")
+      root.checkEqual(withMemory.secondaryVisible, true, "memory reaches the bar beside CPU")
+      root.checkEqual(withMemory.secondaryPercent, stubService.memPercent, "the bar reads memory off the shared sample")
+      root.checkEqual(withMemory.cpuPercent, stubService.cpuPercent, "CPU is still read off the same sample")
+      root.checkEqual(withMemory.secondaryLabel, "MEM", "the tooltip names the second metric")
+
+      // ---- the pair is captioned, and captions follow the metric ----
+      root.checkEqual(cpuOnly.cpuIcon, "", "CPU wears the processor glyph")
+      root.checkEqual(withMemory.secondaryIcon, "", "memory wears the memory glyph")
+      root.checkEqual(withSwap.secondaryIcon, "󰓡", "swap wears its own glyph")
+      root.checkEqual(withGpu.secondaryIcon, "󰾲", "GPU wears its own glyph")
+
+      // ---- the second metric starts nothing ----
+      root.checkEqual(stubService.gpuHolders, 1, "only the GPU metric asks for GPU polling")
+      root.checkEqual(stubService.processHolders, 0, "a closed widget never asks for the process walk")
+      root.checkEqual(withMemory.service, stubService, "the widget reads the shared service")
+
+      // ---- a value nothing recognises reads as off ----
+      var misspelled = root.widget("memm")
+      root.checkEqual(misspelled.secondaryMetric, "none", "an unrecognised metric falls back to off")
+      root.checkEqual(misspelled.secondaryVisible, false, "an unrecognised metric shows no second strip")
+      misspelled.destroy()
+
+      // ---- swap and GPU hide where they do not exist ----
+      root.checkEqual(withSwap.secondaryVisible, false, "swap stays out of the bar with no swap configured")
+      root.checkEqual(withGpu.secondaryVisible, false, "GPU stays out of the bar until a device is seen")
+
+      stubService.swapTotal = 8 * 1024 * 1024 * 1024
+      stubService.swapUsed = 2 * 1024 * 1024 * 1024
+      stubService.swapPercent = 25
+      stubService.hasGpu = true
+      stubService.gpuPercent = 77
+
+      root.checkEqual(withSwap.secondaryVisible, true, "swap appears once a swap device exists")
+      root.checkEqual(withSwap.secondaryCeiling, stubService.swapTotal, "the swap graph scales to the partition, not to 100")
+      root.checkEqual(withGpu.secondaryVisible, true, "GPU appears once sampling reports a device")
+      root.checkEqual(withGpu.secondaryPercent, stubService.gpuPercent, "the bar reads GPU off the shared sample")
+
+      Qt.callLater(function() {
+        // ---- the pair costs bar width, but not double ----
+        var single = cpuOnly.implicitWidth
+        var pair = withMemory.implicitWidth
+        root.check(isFinite(single) && single > 0, "the CPU-only widget has a finite width")
+        root.check(pair > single, "a second metric takes more bar than one single=" + single + " pair=" + pair)
+        root.check(pair < single * 2, "the pair stays compact rather than doubling the widget single=" + single + " pair=" + pair)
+
+        // ---- a widget per monitor still shares one sampler ----
+        var secondMonitor = root.widget("mem")
+        Qt.callLater(function() {
+          root.checkEqual(secondMonitor.service, cpuOnly.service, "every monitor's widget resolves the same service")
+          root.checkEqual(secondMonitor.implicitWidth, withMemory.implicitWidth, "the compact pair measures the same on a second monitor")
+          root.checkEqual(stubService.gpuHolders, 1, "a second monitor does not double the GPU hold")
+
+          // ---- vertical bars stack rather than overflow ----
+          fakeBar.vertical = true
+          fakeBar.barSize = Style.bar.sizeVertical
+
+          Qt.callLater(function() {
+            root.checkEqual(cpuOnly.implicitHeight, Style.bar.iconSlot, "one metric still uses one slot on a vertical bar")
+            root.check(withMemory.implicitHeight > Style.bar.iconSlot, "two metrics take a second line on a vertical bar")
+            root.check(isFinite(withMemory.implicitHeight), "the stacked pair has a finite height")
+
+            // ---- the GPU hold is given back ----
+            withGpu.destroy()
+            Qt.callLater(function() {
+              root.checkEqual(stubService.gpuHolders, 0, "the GPU hold is released with the widget")
+              cpuOnly.destroy()
+              withMemory.destroy()
+              withSwap.destroy()
+              secondMonitor.destroy()
+              root.writeResult()
+            })
+          })
+        })
+      })
+    }
+  }
+}

--- a/test/shell.d/omatask-bar-metrics-test.sh
+++ b/test/shell.d/omatask-bar-metrics-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "omatask bar metrics test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping omatask bar metrics test"
+  exit 0
+fi
+
+require_command jq
+
+widget="$ROOT/shell/plugins/omatask/BarWidget.qml"
+[[ -f $widget ]] || fail "omatask bar widget exists: $widget"
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/omatask-bar-metrics"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/omatask-bar-metrics/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+OMARCHY_OMATASK_WIDGET_URL="file://$widget" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "omatask bar metrics quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "omatask bar metrics test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Bar metrics result:\n' >&2
+  jq . "$result" >&2
+  printf 'Bar metrics log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "omatask bar metrics hold"
+fi
+
+pass "omatask bar metrics: ran $(jq -r '.checks' "$result") checks"

--- a/test/shell.d/omatask-sampler-test.sh
+++ b/test/shell.d/omatask-sampler-test.sh
@@ -6,7 +6,7 @@ require_command python3
 
 plugin_dir="$ROOT/shell/plugins/omatask"
 
-[[ -f "$plugin_dir/test_sampler.py" ]] || fail "omatask sampler suite is present"
+[[ -f "$plugin_dir/test_sampler.py" ]] || fail "omatask sampler suite exists: $plugin_dir/test_sampler.py"
 
 # The suite parses this machine's own /proc, /sys and cgroup files rather than
 # fixtures, so it also checks that the sampler still agrees with the kernel it

--- a/test/shell.d/omatask-sampler-test.sh
+++ b/test/shell.d/omatask-sampler-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command python3
+
+plugin_dir="$ROOT/shell/plugins/omatask"
+
+[[ -f "$plugin_dir/test_sampler.py" ]] || fail "omatask sampler suite is present"
+
+# The suite parses this machine's own /proc, /sys and cgroup files rather than
+# fixtures, so it also checks that the sampler still agrees with the kernel it
+# is running on. It skips what the host does not expose.
+if output=$(cd "$plugin_dir" && python3 test_sampler.py 2>&1); then
+  pass "omatask sampler: $(tail -n 2 <<<"$output" | head -n 1)"
+else
+  fail "omatask sampler suite passes" "$output"
+fi


### PR DESCRIPTION
A system monitor for the Omarchy shell, built as three surfaces sharing one sampler.

| Surface | Reached by | Shows |
|---|---|---|
| Bar widget | always visible | CPU sparkline and current percentage, and optionally a second metric — memory, swap or GPU — beside it |
| Panel | click the widget | CPU graph, per-core grid, memory, swap, GPU, network and disk rates, busiest eight processes |
| Window | `Expand` in the panel, right-click the widget | Five expandable stat cards plus the full process table with filter, sort, threads and signals |

**Bar widget** — CPU and memory, both readable without opening anything.

<img width="700" alt="Task Manager bar widget showing CPU and memory" src="https://github.com/user-attachments/assets/886dce2f-fc68-47b1-ac73-fef41e5be40f" />

**Panel** — one click down: per-core CPU, memory, swap, GPU, network, disk, and the busiest processes.

<img width="520" alt="Task Manager panel" src="https://github.com/user-attachments/assets/8884a061-cc19-4e51-a2e8-234916b0dbbe" />

**Window** — the full process table, filterable and sortable.

<img width="900" alt="Task Manager window with the full process table" src="https://github.com/user-attachments/assets/6d84ecdc-81b0-4427-96fe-978771db7514" />

## How it works

One long-running Python process reads `/proc`, `/sys` and cgroup v2 and emits JSON lines. Everything expensive is gated on a visible surface asking for it: the full process table, per-process I/O, the socket table, the off-CPU hwmon sensors, and NVML all stay off until something is showing them. Idle RSS is about 6.6 MB; NVML alone costs 31 MB, so it is loaded lazily rather than at startup.

Applications are grouped by systemd scope, so one Chromium row replaces forty-seven `chromium` rows. Per-core CPU follows the htop convention where 100% is one core, so a busy multi-threaded process reads above 100% rather than being normalised away.

Processes can be filtered, sorted, signalled, reniced and pinned to cores. Everything is reachable from the keyboard; the mouse is an alternative, never the only route.

## Notes for review

- **The expanded view is a real toplevel**, not a layer-shell overlay, so it drags, stacks and closes like any other window. The accompanying rule in `default/hypr/apps/omarchy-shell.lua` floats it centred rather than letting it claim a tile — following the existing dev-gallery rule in that file.
- **It is not added to the default bar layout** in `config/omarchy/shell.json`, and **it ships no keybinding**. Both felt like product decisions rather than mine; the README documents the bindings a user can add.
- The plugin declares `service`, `bar-widget` and `overlay` kinds and lives at `shell/plugins/omatask/`, alongside the other overlay-carrying plugins.

## Testing

`test/shell.d/omatask-sampler-test.sh` runs the sampler's own suite (64 checks) so `./test/shell` picks it up. The suite parses this machine's real `/proc`, `/sys` and cgroup files rather than fixtures, and skips what a host does not expose, so it also serves as a check that the parsers still agree with the running kernel.

Focused suites run locally, all passing: `manifest-entrypoints`, `plugin-validate`, `plugins`, `bar-widget-contract`, `runtime-smoke`, `omatask-sampler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)