### PR TITLE
Install PipeWire ALSA support on T2 Macs

### DIFF
--- a/install/hardware/apple/fix-t2.sh
+++ b/install/hardware/apple/fix-t2.sh
@@ -3,12 +3,17 @@
 if lspci -nn | grep "106b:180[12]" >/dev/null; then
   echo "Detected MacBook with T2 chip. Installing support items..."
 
+  # apple-t2-audio-config only tunes cards. WirePlumber still needs PipeWire's
+  # ALSA SPA plugin or there is no speaker sink (#7347).
   omarchy-pkg-add \
     linux-t2 \
     linux-t2-headers \
     apple-t2-audio-config \
     apple-bcm-firmware \
-    t2fanrd
+    t2fanrd \
+    pipewire-audio \
+    pipewire-alsa \
+    pipewire-pulse
 
   # Enable T2 fan control
   systemctl enable t2fanrd.service

--- a/migrations/1787023543.sh
+++ b/migrations/1787023543.sh
@@ -1,0 +1,14 @@
+echo "Install PipeWire ALSA support on T2 Macs"
+
+# Overlay installs that already ran the old fix-t2.sh have apple-t2-audio-config
+# but not PipeWire's ALSA SPA plugin, so WirePlumber never sees the speakers
+# (#7347). omarchy-pkg-add is a no-op when the packages are already present.
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
+  exit 0
+fi
+
+omarchy-pkg-add \
+  pipewire-audio \
+  pipewire-alsa \
+  pipewire-pulse

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -227,3 +227,75 @@ grep -Fxq 'limine-mkinitcpio' "$calls" ||
   fail "T2 rerun migration rebuilds the boot image"
 [[ -f $repair_marker ]] || fail "T2 rerun migration records the machine-wide repair"
 pass "T2 rerun migration repairs installs the broken hardware check skipped"
+
+pipewire_migration="$ROOT/migrations/1787023543.sh"
+
+grep -Fq 'lspci -nn | grep "106b:180[12]"' "$pipewire_migration" ||
+  fail "T2 PipeWire migration uses the same PCI check as fix-t2.sh"
+! grep -q 'pacman' "$pipewire_migration" ||
+  fail "T2 PipeWire migration installs with omarchy-pkg-add, not pacman"
+for pkg in pipewire-audio pipewire-alsa pipewire-pulse; do
+  grep -Fq "$pkg" "$pipewire_migration" ||
+    fail "T2 PipeWire migration installs $pkg"
+done
+pass "T2 PipeWire migration matches the leaf's package set"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+chmod +x "$stub_bin/omarchy-pkg-add"
+
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=1 \
+  bash -euo pipefail "$pipewire_migration" >/dev/null
+
+grep -Fq $'omarchy-pkg-add\tpipewire-audio\tpipewire-alsa\tpipewire-pulse' "$calls" ||
+  fail "T2 PipeWire migration omarchy-pkg-adds the ALSA SPA plugin" "$(cat "$calls")"
+pass "T2 PipeWire migration installs the ALSA SPA plugin on T2 hardware"
+
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=0 \
+  bash -euo pipefail "$pipewire_migration" >/dev/null
+
+[[ ! -s $calls ]] || fail "non-T2 systems skip the PipeWire migration" "$(cat "$calls")"
+pass "T2 PipeWire migration skips unrelated hardware"
+
+# Already-present packages are omarchy-pkg-add's no-op: missing-check fails,
+# so pacman never gets -S, and the post-check's pacman -Q is allowed.
+cat >"$stub_bin/omarchy-pkg-missing" <<'SH'
+#!/bin/bash
+
+exit 1
+SH
+cat >"$stub_bin/pacman" <<'SH'
+#!/bin/bash
+
+printf 'pacman' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+[[ $1 == -Q ]] && exit 0
+exit 1
+SH
+ln -sfn "$ROOT/bin/omarchy-pkg-add" "$stub_bin/omarchy-pkg-add"
+chmod +x "$stub_bin/omarchy-pkg-missing" "$stub_bin/pacman"
+
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=1 \
+  bash -euo pipefail "$pipewire_migration" >/dev/null
+
+! grep -E $'^pacman\t-S' "$calls" ||
+  fail "already-present PipeWire packages are a no-op" "$(cat "$calls")"
+pass "already-present PipeWire packages are a no-op"

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -23,19 +23,21 @@ grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sl
 pass "fresh T2 setup uses t2bce-compatible suspend, fan, and Touch Bar defaults"
 
 # Overlay installs can run this leaf without omarchy-other.packages, so T2
-# audio support has to install the SPA plugin here (#7347).
+# audio support has to install the full PipeWire audio stack here (#7347).
 pkg_add_block=$(awk '
   $0 ~ /omarchy-pkg-add/ { grab=1 }
   grab {
     print
-    if ($0 !~ /\\$/) exit
+    line = $0
+    sub(/[[:space:]]+$/, "", line)
+    if (line !~ /\\$/) exit
   }
 ' "$fix_t2")
 for pkg in pipewire-audio pipewire-alsa pipewire-pulse; do
   grep -Fq "$pkg" <<<"$pkg_add_block" ||
-    fail "T2 setup omarchy-pkg-adds $pkg so WirePlumber can load sound cards"
+    fail "T2 setup omarchy-pkg-adds $pkg as part of the PipeWire audio stack"
 done
-pass "T2 setup installs the PipeWire ALSA SPA plugin"
+pass "T2 setup installs the full PipeWire audio stack"
 
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
@@ -256,9 +258,17 @@ PATH="$stub_bin:$PATH" \
   T2_HARDWARE=1 \
   bash -euo pipefail "$pipewire_migration" >/dev/null
 
-grep -Fq $'omarchy-pkg-add\tpipewire-audio\tpipewire-alsa\tpipewire-pulse' "$calls" ||
-  fail "T2 PipeWire migration omarchy-pkg-adds the ALSA SPA plugin" "$(cat "$calls")"
-pass "T2 PipeWire migration installs the ALSA SPA plugin on T2 hardware"
+pkg_add_call=$(awk '/^omarchy-pkg-add(\t| |$)/ { print; exit }' "$calls")
+[[ -n $pkg_add_call ]] ||
+  fail "T2 PipeWire migration calls omarchy-pkg-add" "$(cat "$calls")"
+for pkg in pipewire-audio pipewire-alsa pipewire-pulse; do
+  awk -F '[\t ]+' -v pkg="$pkg" '{
+    for (i = 1; i <= NF; i++) if ($i == pkg) found = 1
+  }
+  END { exit !found }' <<<"$pkg_add_call" ||
+    fail "T2 PipeWire migration omarchy-pkg-adds $pkg as part of the PipeWire audio stack" "$(cat "$calls")"
+done
+pass "T2 PipeWire migration installs the full PipeWire audio stack on T2 hardware"
 
 : >"$calls"
 

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -22,6 +22,21 @@ grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sl
   fail "the ISO no longer caches tiny-dfr"
 pass "fresh T2 setup uses t2bce-compatible suspend, fan, and Touch Bar defaults"
 
+# Overlay installs can run this leaf without omarchy-other.packages, so T2
+# audio support has to install the SPA plugin here (#7347).
+pkg_add_block=$(awk '
+  $0 ~ /omarchy-pkg-add/ { grab=1 }
+  grab {
+    print
+    if ($0 !~ /\\$/) exit
+  }
+' "$fix_t2")
+for pkg in pipewire-audio pipewire-alsa pipewire-pulse; do
+  grep -Fq "$pkg" <<<"$pkg_add_block" ||
+    fail "T2 setup omarchy-pkg-adds $pkg so WirePlumber can load sound cards"
+done
+pass "T2 setup installs the PipeWire ALSA SPA plugin"
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 


### PR DESCRIPTION
Section 3 of https://github.com/basecamp/omarchy/issues/7347 only. Does not close the issue (Limine / ESP / enroll remain separate).

`install/hardware/apple/fix-t2.sh` installs `apple-t2-audio-config`, `linux-t2`, firmware, and `t2fanrd`. It does not install PipeWire's ALSA SPA plugin. On a MacBookPro16,3 that came up through t2archinstall + `curl -fsSL https://omarchy.org/install`, WirePlumber logged:

```
wp-device: SPA handle 'api.alsa.enum.udev' could not be loaded; is it installed?
s-monitors: PipeWire's ALSA SPA plugin is missing or broken. Sound cards will not be supported
```

No speaker sink, volume keys dead, Spotify silent, even though T2 audio hardware `106b:1803` and `apple-t2-audio-config` were present. pacman first installed the missing pieces at `2026-08-17T21:43:44-0400`:

```
pacman -S --needed pipewire-audio pipewire-pulse pipewire-alsa
```

After that: `alsa_output.pci-0000_02_00.3.HiFi__Speaker__sink`.

`install/omarchy-other.packages` already lists `pipewire-alsa` and `pipewire-pulse`, but the overlay path (and any install that runs this leaf without that full package set) still ships a silent T2 machine. T2 audio config without the SPA plugin is not audio support.

## Changes
- `fix-t2.sh` also `omarchy-pkg-add`s `pipewire-audio`, `pipewire-alsa`, and `pipewire-pulse` (names from quattro's existing package lists and the pacman line that restored sound)
- `migrations/1787023543.sh` is T2-gated on the same `lspci -nn` / `106b:180[12]` check, so existing overlay installs that already ran the old leaf get those packages on `omarchy update`. Non-T2 exits 0 and installs nothing; already-present packages are `omarchy-pkg-add`'s no-op
- `test/shell.d/t2-hardware-test.sh` pins the leaf package set and the migration's T2 / non-T2 / already-present behavior

Does not touch Limine, ESP_PATH, enroll hooks, or hid_apple / fnmode (#7110 / #7343).