### PR TITLE
Fix emoji picker inserting into the wrong window on split layouts (#7350)

### DIFF
--- a/bin/omarchy-menu-emoji-insert
+++ b/bin/omarchy-menu-emoji-insert
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# omarchy:summary=Insert an emoji into the focused application
+# omarchy:summary=Insert an emoji into the window that had focus when the picker opened
 # omarchy:group=menu
-# omarchy:args=<emoji>
+# omarchy:args=<emoji> [focus-address]
 # omarchy:hidden=true
 
 emoji="${1:-}"
+focus="${2:-}"
 copy_pid=""
 
 [[ -n $emoji ]] || exit
@@ -14,6 +15,16 @@ printf '%s' "$emoji" | wl-copy --type text/plain --sensitive --foreground &
 copy_pid=$!
 
 sleep 0.15
+# The picker overlay is gone by the time this script runs, and the compositor
+# refocuses whichever window sits under the clicked cell. When the picker card
+# spans two windows (split layout, multi-monitor), that is not the window the
+# user was typing in. Restore the focus captured when the picker opened so the
+# paste lands where the user expects.
+if [[ -n $focus ]]; then
+  hyprctl dispatch "hl.dsp.focus({ window = \"address:${focus}\" })" >/dev/null 2>&1 \
+    || hyprctl dispatch focuswindow "address:${focus}" >/dev/null 2>&1 || true
+  sleep 0.1
+fi
 wtype -M shift -k Insert -m shift 2>/dev/null || true
 sleep 0.2
 

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -13,6 +13,12 @@ Item {
   property var shell: null
   property var manifest: null
 
+  // Address of the window that had focus when the picker opened. The insert
+  // helper refocuses it before typing, so the emoji lands in the app the user
+  // was in — not whichever window sits under the clicked cell when the card
+  // spans two windows (split layouts, multi-monitor).
+  property string focusAddress: ""
+
   property bool opened: false
   property string filterText: ""
   property int selectedIndex: 0
@@ -43,12 +49,23 @@ Item {
   property int columns: Math.floor((cardWidth - contentMargin * 2) / cellWidth)
 
   function open(payloadJson) {
+    // Capture focus before the overlay maps: the layer grabs keyboard focus
+    // exclusively once visible, so the probe must run first to deterministically
+    // read the window the user was in.
+    root.captureFocus()
     root.opened = true
     root.filterText = ""
     root.selectedIndex = 0
     root.cursorActive = true
     root.rebuildDisplay()
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function captureFocus() {
+    // hyprctl is a runtime invariant invoked via PATH, like the rest of the
+    // shell (e.g. Workspaces.qml).
+    focusProbe.command = ["hyprctl", "-j", "activewindow"]
+    focusProbe.running = true
   }
 
   function close() {
@@ -148,10 +165,34 @@ Item {
   function applySelected(emoji) {
     if (!emoji) return
     root.dismiss()
-    Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-menu-emoji-insert", emoji])
+    Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-menu-emoji-insert", emoji, root.focusAddress])
   }
 
   ListModel { id: displayModel }
+
+  // One-shot probe: reads `hyprctl -j activewindow` when the picker opens so
+  // the emoji can be typed back into the window the user was actually using.
+  Process {
+    id: focusProbe
+    stdout: StdioCollector {
+      id: focusStdout
+      waitForEnd: true
+    }
+    onExited: function(code) {
+      var text = String(focusStdout.text || "").trim()
+      var address = ""
+      if (text) {
+        try {
+          var data = JSON.parse(text)
+          if (data && data.address && data.address !== "0x0")
+            address = String(data.address)
+        } catch (e) {
+          address = ""
+        }
+      }
+      root.focusAddress = address
+    }
+  }
 
   FileView {
     path: root.omarchyPath + "/shell/plugins/emojis/emojis.json"

--- a/test/shell.d/emojis-test.sh
+++ b/test/shell.d/emojis-test.sh
@@ -68,14 +68,20 @@ cat >"$TMPDIR/bin/wtype" <<'SH'
 printf '%s\n' "$*" >"$WTYPE_OUT"
 SH
 
+cat >"$TMPDIR/bin/hyprctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_OUT"
+SH
+
 cat >"$TMPDIR/bin/sleep" <<'SH'
 #!/bin/bash
 exit 0
 SH
 
-chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wtype" "$TMPDIR/bin/sleep"
+chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wtype" "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/sleep"
 
-WL_COPY_OUT="$TMPDIR/copy" WL_COPY_EMOJI_OUT="$TMPDIR/emoji" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
+WL_COPY_OUT="$TMPDIR/copy" WL_COPY_EMOJI_OUT="$TMPDIR/emoji" WTYPE_OUT="$TMPDIR/wtype" \
+  HYPRCTL_OUT="$TMPDIR/hyprctl" PATH="$TMPDIR/bin:$PATH" \
   "$ROOT/bin/omarchy-menu-emoji-insert" "😀"
 
 [[ $(<"$TMPDIR/emoji") == "😀" ]] || fail "emoji insert helper copies emoji transiently"
@@ -86,3 +92,16 @@ pass "emoji insert helper serves transient clipboard in foreground"
 
 [[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "emoji insert helper pastes with shift insert"
 pass "emoji insert helper pastes with shift insert"
+
+# With a focus address, the helper restores that window's focus before pasting.
+# No hyprctl call is expected without one, so the stub stays empty here.
+[[ ! -s "$TMPDIR/hyprctl" ]] || fail "emoji insert helper skips focus restore without a focus address"
+pass "emoji insert helper skips focus restore without a focus address"
+
+WL_COPY_OUT="$TMPDIR/copy" WL_COPY_EMOJI_OUT="$TMPDIR/emoji2" WTYPE_OUT="$TMPDIR/wtype2" \
+  HYPRCTL_OUT="$TMPDIR/hyprctl" PATH="$TMPDIR/bin:$PATH" \
+  "$ROOT/bin/omarchy-menu-emoji-insert" "😀" "0x1234abcd"
+
+[[ $(<"$TMPDIR/hyprctl") == 'dispatch hl.dsp.focus({ window = "address:0x1234abcd" })' ]] \
+  || fail "emoji insert helper restores the focus captured at picker open"
+pass "emoji insert helper restores the focus captured at picker open"


### PR DESCRIPTION
## Summary

Fixes #7350 — the emoji picker types the picked emoji into the **wrong window** whenever the picker card visually spans two windows (split layouts, side-by-side monitors).

**Root cause:** `Emojis.qml`'s `applySelected()` dismisses the overlay and then runs `bin/omarchy-menu-emoji-insert`, which pastes with `wtype Shift+Insert` into whatever window is focused *at that moment*. Once the overlay closes, the compositor refocuses whichever window sits under the clicked cell — so clicking an emoji on the half of the card over the other window pastes it there (e.g. into a browser's address bar) instead of in the window the user was typing in.

**Fix:**
- `shell/plugins/emojis/Emojis.qml` — when the picker opens, capture the address of the active window (`hyprctl -j activewindow`, via a one-shot `Process`), and pass it to the insert helper alongside the emoji.
- `bin/omarchy-menu-emoji-insert` — accept an optional second argument (focus address) and dispatch focus back to that window (`hl.dsp.focus({ window = "address:…" })`, the same form already used in `Workspaces.qml`) before pasting. With no address given, behavior is unchanged, so the command stays usable standalone.
- `test/shell.d/emojis-test.sh` — new coverage: the helper skips the focus restore when called without an address, and issues the correct dispatch when given one.

## Related

I did **not** touch the clipboard lifecycle (the `wl-copy --foreground` + `kill` dance). That is deliberate: git history shows the transient clipboard is intentional (`Insert emojis without persisting clipboard entries`, `Keep sensitive clipboard contents out of history`), even though it confuses users who expect the emoji to remain pasteable after insert (#7233). Happy to address that separately if the maintainers want to reconsider.

## Test plan

- `test/all` — all emoji tests pass; the only failures (`config-test`, `snapper-test`, `unowned-system-paths-test`) also fail on a clean `quattro` checkout on this machine (environment-specific, unrelated).
- Live verification on the reporter's machine: user plugin clone of the emojis plugin running the exact patched files. Clicking emojis on the half of the card over the *other* window now inserts into the window that was focused when the picker opened (verified with the reporter on two layouts: tiled side-by-side windows and the same card geometry on a split).
