### PR TITLE
Detect the tailscale CLI without the which package

### DIFF
--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -152,7 +152,7 @@ Item {
     }
     if (!whichProcess.running) {
       refreshing = true
-      whichProcess.command = ["which", "tailscale"]
+      whichProcess.command = ["bash", "-c", "command -v tailscale"]
       whichProcess.running = true
     }
   }

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -8,8 +8,10 @@ run_node_test <<'JS'
 const fs = require('fs')
 const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
+const serviceSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Service.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
+assert(!/\["which",/.test(serviceSource), 'tailscale CLI detection does not depend on the optional which package')
 
 assertDeepEqual(
   tailscale.filterIPv4(['100.64.0.1', 'fd7a:115c:a1e0::1', '192.168.1.2']),


### PR DESCRIPTION
Fixes #7354

## Problem

The Tailscale panel detects the CLI by running the external `which` utility:

```qml
whichProcess.command = ["which", "tailscale"]
```

On Arch, `which` is a standalone package (`core/which`) that base installs don't include, and it isn't in Omarchy's package lists. Without it, the check exits 127, `installed` stays false, and the panel permanently reports **"Tailscale CLI is not installed or not on PATH"** — while `tailscaled` runs and the machine is connected to the tailnet.

## Fix

Detect the CLI through the POSIX `command -v` shell builtin using `sh`, avoiding the optional `which` package without introducing a Bash-specific dependency:

```qml
whichProcess.command = ["sh", "-c", "command -v tailscale"]
```

The shell test verifies the intended portable command and exercises the Tailscale model and panel behavior.

## Verification

```bash
bash test/shell.d/tailscale-test.sh
```

All focused Tailscale shell tests pass.

| Before | After |
| --------- | ------ |
| <img width="350" height="160" alt="image" src="https://github.com/user-attachments/assets/e91f75c0-41ef-4dcf-badb-32a632b5a25d" /> | <img width="350" height="160" alt="image" src="https://github.com/user-attachments/assets/8dba4462-1121-4fac-aa20-aec862316d07" /> |
