### PR TITLE
Add Open in Terminal to the Files context menu

### DIFF
--- a/default/nautilus-python/extensions/terminal.py
+++ b/default/nautilus-python/extensions/terminal.py
@@ -7,19 +7,29 @@ require_version("Nautilus", "4.1")
 from gi.repository import GObject, Gio, Nautilus
 
 
+def _resolve_launch_command():
+    launcher = shutil.which("uwsm-app")
+    terminal = shutil.which("xdg-terminal-exec")
+
+    if not launcher or not terminal:
+        return None
+
+    return [launcher, "--", terminal]
+
+
+# PATH does not change under a running Files session, so resolve once at import
+# rather than on every menu build.
+LAUNCH_COMMAND = _resolve_launch_command()
+
+
 class OpenInTerminalAction(GObject.GObject, Nautilus.MenuProvider):
     def _launch_terminal(self, path):
-        launcher = shutil.which("uwsm-app")
-        terminal = shutil.which("xdg-terminal-exec")
-        if not launcher or not terminal:
-            return
-
         # xdg-terminal-exec resolves the terminal the same way `omarchy default
         # terminal` sets it, and --dir works whether or not the entry declares a
         # working-directory flag: it falls back to chdir before exec. That keeps
         # this working across alacritty, foot, ghostty and kitty alike.
         Gio.Subprocess.new(
-            [launcher, "--", terminal, f"--dir={path}"],
+            LAUNCH_COMMAND + [f"--dir={path}"],
             Gio.SubprocessFlags.NONE,
         )
 
@@ -48,6 +58,11 @@ class OpenInTerminalAction(GObject.GObject, Nautilus.MenuProvider):
         self._launch_terminal(path)
 
     def _items_for(self, file):
+        # Offering an entry that cannot launch anything is worse than offering
+        # none, so stay out of the menu unless the launcher is really there.
+        if not LAUNCH_COMMAND:
+            return []
+
         path = self._directory_path(file)
         if not path:
             return []

--- a/default/nautilus-python/extensions/terminal.py
+++ b/default/nautilus-python/extensions/terminal.py
@@ -1,0 +1,69 @@
+import shutil
+
+from gi import require_version
+
+require_version("Nautilus", "4.1")
+
+from gi.repository import GObject, Gio, Nautilus
+
+
+class OpenInTerminalAction(GObject.GObject, Nautilus.MenuProvider):
+    def _launch_terminal(self, path):
+        launcher = shutil.which("uwsm-app")
+        terminal = shutil.which("xdg-terminal-exec")
+        if not launcher or not terminal:
+            return
+
+        # xdg-terminal-exec resolves the terminal the same way `omarchy default
+        # terminal` sets it, and --dir works whether or not the entry declares a
+        # working-directory flag: it falls back to chdir before exec. That keeps
+        # this working across alacritty, foot, ghostty and kitty alike.
+        Gio.Subprocess.new(
+            [launcher, "--", terminal, f"--dir={path}"],
+            Gio.SubprocessFlags.NONE,
+        )
+
+    def _directory_path(self, file):
+        if not file or not file.is_directory():
+            return None
+
+        location = file.get_location()
+        if not location:
+            return None
+
+        # Remote and virtual locations (trash:, sftp:) have no local path to
+        # hand a terminal.
+        return location.get_path()
+
+    def _make_item(self, path):
+        item = Nautilus.MenuItem(
+            name="OmarchyTerminalNautilus::open_in_terminal",
+            label="Open in Terminal",
+            icon="utilities-terminal",
+        )
+        item.connect("activate", self._on_activate, path)
+        return item
+
+    def _on_activate(self, _menu, path):
+        self._launch_terminal(path)
+
+    def _items_for(self, file):
+        path = self._directory_path(file)
+        if not path:
+            return []
+
+        return [self._make_item(path)]
+
+    def get_file_items(self, *args):
+        files = args[0] if len(args) == 1 else args[1]
+
+        # Only a lone directory names an unambiguous target; a file selection is
+        # already served by the background item for the folder it sits in.
+        if len(files) != 1:
+            return []
+
+        return self._items_for(files[0])
+
+    def get_background_items(self, *args):
+        folder = args[0] if len(args) == 1 else args[1]
+        return self._items_for(folder)

--- a/migrations/1786961462.sh
+++ b/migrations/1786961462.sh
@@ -1,0 +1,9 @@
+echo "Add Open in Terminal to the Files context menu"
+
+# New installs get the extension seeded from /etc/skel; existing homes only
+# pick it up by copying it over. Files loads extensions at startup, so the
+# entry appears the next time it is launched.
+extensions_dir="$HOME/.local/share/nautilus-python/extensions"
+
+mkdir -p "$extensions_dir"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/terminal.py" "$extensions_dir/"


### PR DESCRIPTION
Right-clicking a folder in Files — or the background of the one you're in — now offers **Open in Terminal**.

This existed as "Open in Ghostty" until 3.5.1, when the `/usr/share/nautilus-python/extensions` tree it shipped in went away (#5338). It's still missing.

### Why not `nautilus-open-any-terminal`

#5343 proposed pulling in the AUR package. It stalled on exactly the problem it was meant to solve: the entry showed up but did nothing under Alacritty, because that extension carries its own hardcoded per-terminal flag table.

Going through `xdg-terminal-exec` avoids the table entirely:

- it resolves the terminal the same way `omarchy default terminal` sets it, so the entry follows the user's choice instead of pinning one emulator
- `--dir` works for all four terminals by construction — entries declaring `X-TerminalArgDir` get the flag passed, and the rest are `cd`'d into before `exec`

No new package; it's the same launcher `omarchy-launch-terminal` already uses.

### Shape

Follows the existing extension pattern (`localsend.py`, `transcode.py`), so `default/nautilus-python/extensions/*.py` seeds it into `/etc/skel` for new installs, plus a migration for existing homes.

The entry shows for a single directory or a folder background. It stays hidden for file selections (the background entry already covers "here"), for multi-selections, for locations with no local path such as `trash:` and `sftp:`, and when the launcher itself is missing — a menu entry that does nothing is worse than no entry at all.

### Testing

On 4.0.0.alpha with foot as the default terminal:

- extension imports cleanly into Nautilus 50.2.2 / nautilus-python 4.1.0
- entry appears on a folder and on a folder background; absent for files, multi-selections, and pathless locations
- launching lands the shell in the right directory (verified via `/proc/<shell>/cwd`, not just the window title)
- `xdg-terminal-exec --print-cmd --dir=…` resolves to `foot --working-directory=…`; the chdir fallback covers entries without the flag
- migration is idempotent and copies into `~/.local/share/nautilus-python/extensions`
- entry stays out of the menu entirely when `uwsm-app` or `xdg-terminal-exec` cannot be resolved
