### PR TITLE
Stop cloning plugins into the reserved omarchy.* namespace

### DIFF
--- a/bin/omarchy-plugin-clone
+++ b/bin/omarchy-plugin-clone
@@ -87,7 +87,9 @@ Copies a built-in plugin into ~/.config/omarchy/plugins/<username>.<id>/ so you
 can edit it freely. The clone keeps all of the source plugin's files and kinds
 and uses "My <name>" as its display name, then replaces the built-in with the
 clone. The username prefix keeps the id yours, so a shared clone does not
-collide with anyone else's. --edit opens the clone in \$EDITOR afterwards.
+collide with anyone else's. If that id would start with omarchy., the reserved
+first-party namespace, it is stored as user.<username>.<id> instead. --edit
+opens the clone in \$EDITOR afterwards.
 
 USAGE
 }
@@ -129,6 +131,12 @@ source_info=$(omarchy-plugin-catalog | jq -r --arg id "$source_id" '
 IFS=$'\t' read -r source_dir source_manifest source_name <<<"$source_info"
 
 new_id="${USER:-$(id -un)}.${source_id#omarchy.}"
+# PluginRegistry and omarchy-plugin-validate reserve omarchy.* for built-ins.
+# A unix user named omarchy would otherwise clone to omarchy.clock: the CLI
+# matches the built-in, reports success, and the copy is never loaded.
+if [[ $new_id == omarchy.* ]]; then
+  new_id="user.$new_id"
+fi
 display_name="My $source_name"
 target_dir="$PLUGINS_DIR/$new_id"
 [[ ! -e $target_dir && ! -L $target_dir ]] || fail "$target_dir already exists"

--- a/test/shell.d/plugin-clone-test.sh
+++ b/test/shell.d/plugin-clone-test.sh
@@ -191,3 +191,23 @@ fi
 [[ ! -e $TMPDIR/home/.config/omarchy/plugins/tester.osd ]] ||
   fail "failed clone discovery leaves a partial clone behind"
 pass "clone removes a partial clone when switching fails"
+
+# USER=omarchy produces omarchy.clock, which PluginRegistry rejects as reserved
+# while discovery still matches the built-in and the CLI reports success.
+omarchy_user_calls="$TMPDIR/calls-omarchy"
+HOME="$TMPDIR/home" USER=omarchy OMARCHY_PATH="$ROOT" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  FAKE_CALLS="$omarchy_user_calls" OMARCHY_TEST_ROOT="$ROOT" \
+  omarchy-plugin-clone omarchy.clock >/dev/null
+omarchy_clock="$TMPDIR/home/.config/omarchy/plugins/user.omarchy.clock"
+[[ ! -e $TMPDIR/home/.config/omarchy/plugins/omarchy.clock ]] ||
+  fail "clone for user omarchy lands in the reserved omarchy.* path"
+[[ -f $omarchy_clock/manifest.json ]] ||
+  fail "clone for user omarchy did not write user.omarchy.clock"
+jq -e '
+  .id == "user.omarchy.clock" and
+  .omarchy.clonedFrom == "omarchy.clock"
+' "$omarchy_clock/manifest.json" >/dev/null ||
+  fail "clone for user omarchy kept a reserved manifest id"
+grep -qx 'omarchy-plugin-enable user.omarchy.clock' "$omarchy_user_calls" ||
+  fail "clone does not enable the reserved-safe id"
+pass "clone keeps USER=omarchy out of the reserved omarchy.* namespace"


### PR DESCRIPTION
Fixes #7118

`omarchy plugin clone` builds the new id as `$USER.` plus the source without the `omarchy.` prefix. When the unix user is named `omarchy`, that is `omarchy.clock`. PluginRegistry and `omarchy-plugin-validate` reserve `omarchy.*` for built-ins, but discovery still matches the first-party plugin, so the CLI reports success and the copy on disk is never loaded.

If the derived id starts with `omarchy.`, prefix it with `user.` (`omarchy.clock` becomes `user.omarchy.clock`). Other usernames are unchanged.

Verified:

```
./test/shell.d/plugin-clone-test.sh
# 21 pass, including "clone keeps USER=omarchy out of the reserved omarchy.* namespace"
```

Same file on the omarchy-test VM (unix user `omarchy`, Omarchy 4.0.0-1): 21 pass.

Not runtime-tested against a live `omarchy-shell` session. The guest is at the SDDM greeter, so there is no shell to rescan; the clone test stubs `omarchy-shell` the same way the rest of that file does. `./test/cli` still dies on this Ubuntu host at `python: command not found` (only `python3` is installed) — pre-existing, unrelated.
