### PR TITLE
Add a notifications.position setting for centered toasts

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -4,6 +4,9 @@
     "screensaver": 150,
     "lock": 300
   },
+  "notifications": {
+    "position": "right"
+  },
   "bar": {
     "position": "top",
     "transparent": false,

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,7 @@ hosts a Quickshell `NotificationServer` that claims `org.freedesktop.Notificatio
 on the session bus. There is no dunst or mako — anything that speaks the
 freedesktop notification protocol (notify-send, libnotify apps, Chromium web
 apps) lands in the shell, which renders it as a toast card stacked in the
-top-right corner. The pure decision logic lives in `NotificationLogic.js`,
+top-right corner, or top-center when configured to (see [Placement](#placement)). The pure decision logic lives in `NotificationLogic.js`,
 which is also loadable from Node so `test/shell.d/` can exercise it without
 a compositor.
 
@@ -36,6 +36,22 @@ in place, under the popup's original file identity. Restored rows carry ids
 from a dead server generation (ids restart from 1 each shell process), so
 they are keyed by timestamp+id and never matched against live objects — a
 fresh notification reusing an old id must not dismiss or replace them.
+
+## Placement
+
+Toasts stack down from the top edge, anchored right by default. On a wide or
+multi-monitor desk that corner is a long way from where the eyes are, so the
+column can be centered instead:
+
+```json
+{ "notifications": { "position": "center" } }
+```
+
+in `~/.config/omarchy/shell.json`. The value is `right` (default) or `center`;
+anything else falls back to `right`. `NotificationLogic.popupPlacement()` turns
+it into anchors and margins, and drops the right-bar clearance when centered,
+since a centered column is not held off any side edge. There is one popup
+window per screen, so the choice applies to every monitor.
 
 ## Silencing
 

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -286,20 +286,30 @@ function popupExpired(entry, duration, now) {
   return (Number(now) - Number((entry || {}).timestamp || 0)) >= lifetime
 }
 
-function popupPlacement(barPosition, barClearance, gapsOut) {
+function popupPlacement(barPosition, barClearance, gapsOut, alignment) {
   var position = String(barPosition || "top")
   var clearance = Number(barClearance)
   var gap = Number(gapsOut)
   if (!isFinite(clearance)) clearance = 0
   if (!isFinite(gap)) gap = 0
 
+  var centered = String(alignment || "right") === "center"
+
   return {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: {
+      top: true,
+      bottom: false,
+      left: false,
+      right: !centered,
+      horizontalCenter: centered
+    },
     margins: {
       top: position === "top" ? clearance : gap,
       bottom: gap,
       left: gap,
-      right: position === "right" ? clearance : gap
+      // A centered column is not held off any side edge, so a right bar has
+      // nothing to clear.
+      right: position === "right" && !centered ? clearance : gap
     }
   }
 }

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -46,6 +46,9 @@ Item {
   // Falls back to the bar's default size (26 horizontal / 28 vertical) when
   // shell.bar isn't reachable so the popup never lands on top of the bar.
   readonly property string barPosition: shell && shell.barConfig ? String(shell.barConfig.position || "top") : "top"
+  // Where toasts line up horizontally: "right" (the default) or "center".
+  readonly property string popupAlignment: shell && shell.notificationsConfig
+    ? String(shell.notificationsConfig.position || "right") : "right"
   readonly property bool barVertical: barPosition === "left" || barPosition === "right"
   readonly property int defaultBarSize: barVertical ? Style.bar.sizeVertical : Style.bar.sizeHorizontal
   readonly property int liveBarSize: shell && shell.bar && !shell.bar.barHidden ? Math.max(0, shell.bar.barSize) : defaultBarSize
@@ -964,7 +967,7 @@ Item {
       color: "transparent"
 
       readonly property var popupPlacement: NotificationLogic.popupPlacement(
-        service.barPosition, service.barClearance, Style.gapsOut)
+        service.barPosition, service.barClearance, Style.gapsOut, service.popupAlignment)
 
       // Full-screen, fixed-size surface (like the OSD overlay). Adding or
       // removing a toast changes only the content inside; the Wayland surface
@@ -978,10 +981,14 @@ Item {
 
       ColumnLayout {
         id: popupColumn
-        anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: popupWindow.popupPlacement.margins.top
+        // Only one of these two is ever set; the other resolves to undefined,
+        // which leaves that edge unanchored.
+        anchors.right: popupWindow.popupPlacement.anchors.right ? parent.right : undefined
         anchors.rightMargin: popupWindow.popupPlacement.margins.right
+        anchors.horizontalCenter: popupWindow.popupPlacement.anchors.horizontalCenter
+          ? parent.horizontalCenter : undefined
         spacing: Style.space(8)
 
         Repeater {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -113,6 +113,7 @@ ShellRoot {
   }
 
   readonly property var barConfig: shellConfig && Util.isPlainObject(shellConfig.bar) ? shellConfig.bar : builtinShellConfig.bar
+  readonly property var notificationsConfig: shellConfig && Util.isPlainObject(shellConfig.notifications) ? shellConfig.notifications : builtinShellConfig.notifications
   onBarConfigChanged: if (bar && "barConfig" in bar) bar.barConfig = shell.barConfig
   FileView {
     id: defaultsFile

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -52,7 +52,7 @@ assert(!notifications.isEphemeralApp('omarchy-menu-keybindings'), 'notifications
 assertDeepEqual(
   notifications.popupPlacement('top', 32, 6),
   {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: { top: true, bottom: false, left: false, right: true, horizontalCenter: false },
     margins: { top: 32, bottom: 6, left: 6, right: 6 }
   },
   'notifications clear a top bar while staying anchored top-right'
@@ -60,7 +60,7 @@ assertDeepEqual(
 assertDeepEqual(
   notifications.popupPlacement('right', 32, 6),
   {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: { top: true, bottom: false, left: false, right: true, horizontalCenter: false },
     margins: { top: 6, bottom: 6, left: 6, right: 32 }
   },
   'notifications clear a right bar while staying anchored top-right'
@@ -68,7 +68,7 @@ assertDeepEqual(
 assertDeepEqual(
   notifications.popupPlacement('bottom', 32, 6),
   {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: { top: true, bottom: false, left: false, right: true, horizontalCenter: false },
     margins: { top: 6, bottom: 6, left: 6, right: 6 }
   },
   'notifications ignore a bottom bar for popup placement'
@@ -76,10 +76,31 @@ assertDeepEqual(
 assertDeepEqual(
   notifications.popupPlacement('left', 32, 6),
   {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: { top: true, bottom: false, left: false, right: true, horizontalCenter: false },
     margins: { top: 6, bottom: 6, left: 6, right: 6 }
   },
   'notifications ignore a left bar for popup placement'
+)
+assertDeepEqual(
+  notifications.popupPlacement('top', 32, 6, 'center'),
+  {
+    anchors: { top: true, bottom: false, left: false, right: false, horizontalCenter: true },
+    margins: { top: 32, bottom: 6, left: 6, right: 6 }
+  },
+  'centered notifications clear a top bar and drop the right anchor'
+)
+assertDeepEqual(
+  notifications.popupPlacement('right', 32, 6, 'center'),
+  {
+    anchors: { top: true, bottom: false, left: false, right: false, horizontalCenter: true },
+    margins: { top: 6, bottom: 6, left: 6, right: 6 }
+  },
+  'centered notifications need no clearance for a right bar'
+)
+assertDeepEqual(
+  notifications.popupPlacement('top', 32, 6, 'right'),
+  notifications.popupPlacement('top', 32, 6),
+  'an explicit right alignment matches the default'
 )
 
 const notification = {


### PR DESCRIPTION
Toasts are anchored to the top-right corner, which is hardcoded. On a wide screen that corner is far outside where you are actually looking: I run a 6016px display and kept missing notifications entirely, including ones I had set up myself and was waiting for.

This adds `notifications.position` to `shell.json`, accepting `right` (the default, unchanged) or `center`:

```json
{ "notifications": { "position": "center" } }
```

`popupPlacement()` gains an `alignment` argument and returns a `horizontalCenter` anchor instead of `right` when centered. It also drops the right-bar clearance in that case, since a centered column is not held off any side edge. Anyone who does not set it sees no change.

**Before** — right-aligned, on a 6016px screen

<img width="2400" height="1350" alt="before-right-aligned" src="https://github.com/user-attachments/assets/97e729f4-2511-4ff5-a97a-431da832b6f2" />


**After** — `"position": "center"`

<img width="2400" height="1350" alt="after-centered" src="https://github.com/user-attachments/assets/99d13e82-c8b3-45aa-9cda-30d0c5ba7802" />


<!-- sleep hier after-centered.png -->

## Testing

`test/shell.d/notifications-test.sh` passes (111 checks). The four existing placement assertions were updated for the new anchors field, and three were added: centered with a top bar, centered with a right bar, and an explicit `right` matching the default.
