### PR TITLE
Fire the restart-terminal toast after a font change

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -68,11 +68,11 @@ XML
 omarchy-restart-shell
 
 if pgrep -x ghostty; then
-  omarchy-notification-send -g  "You must restart Ghostty to see font change"
+  omarchy-notification-send "You must restart Ghostty to see font change"
 fi
 
 if pgrep -x foot; then
-  omarchy-notification-send -g  "You must restart Foot to see font change"
+  omarchy-notification-send "You must restart Foot to see font change"
 fi
 
 omarchy-hook font-set "$font_name"

--- a/test/shell.d/font-set-test.sh
+++ b/test/shell.d/font-set-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/home" "$TMPDIR/bin"
+CALLS="$TMPDIR/calls"
+
+cat >"$TMPDIR/bin/fc-list" <<'SH'
+#!/bin/bash
+printf '%s\n' "CaskaydiaMono Nerd Font"
+SH
+
+cat >"$TMPDIR/bin/pgrep" <<'SH'
+#!/bin/bash
+# Pretend Ghostty and Foot are running so font-set should notify.
+[[ $1 == -x && ( $2 == ghostty || $2 == foot ) ]]
+SH
+
+for command in omarchy-notification-send omarchy-restart-shell omarchy-hook; do
+  cat >"$TMPDIR/bin/$command" <<'SH'
+#!/bin/bash
+printf '%s %s\n' "${0##*/}" "$*" >>"$FAKE_CALLS"
+SH
+done
+chmod +x "$TMPDIR/bin/"*
+
+HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" FAKE_CALLS="$CALLS" \
+  omarchy-font-set "CaskaydiaMono Nerd Font"
+
+grep -q 'You must restart Ghostty to see font change' "$CALLS" ||
+  fail "font-set does not notify when Ghostty is running"
+grep -q 'You must restart Foot to see font change' "$CALLS" ||
+  fail "font-set does not notify when Foot is running"
+if grep -q -- '-g You must restart Ghostty' "$CALLS" ||
+  grep -q -- '-g You must restart Foot' "$CALLS"; then
+  fail "font-set passes the restart message as a glyph"
+fi
+pass "font-set notifies a restart without consuming the message as a glyph"


### PR DESCRIPTION
Fixes #7183

`omarchy font set` is supposed to toast "You must restart Ghostty/Foot to see font change" when those terminals are running. Both calls were written as `omarchy-notification-send -g  "You must restart…"`. `-g` consumes the next argument as the glyph, so the sentence never became the headline: `notification-send` printed its usage and exited 1. `font-set` has no `set -e`, so the command still exited 0 and the user just never saw the toast.

Drop the empty `-g`. The sentence is the headline, matching every other caller that does not have a glyph.

Verified:

```
./test/shell.d/font-set-test.sh
# ok - font-set notifies a restart without consuming the message as a glyph

omarchy-notification-send -g  "You must restart Ghostty to see font change"
# usage, rc=1 (the old call)

omarchy-notification-send "You must restart Ghostty to see font change"
# rc=0
```

Same test file on the omarchy-test VM: pass. Did not change a live Ghostty/Foot font in a graphical session (guest is at the SDDM greeter).
