### PR TITLE
Add searched menu selection event

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -772,18 +772,16 @@ Item {
     if (!root.rowSelectable(index)) return
 
     var row = displayModel.get(index)
+    var selection = MenuModel.selectionAfterSearch(root.items, row, root.filterText)
+    if (selection && root.shell
+        && typeof root.shell.publishMenuSelectionAfterSearch === "function") {
+      root.shell.publishMenuSelectionAfterSearch(root.manifest ? root.manifest.id : "", selection)
+    }
     if (row.kind === "menu" || row.kind === "link") {
       root.setActiveMenu(row.target || row.itemId, true, fromPointer)
     } else if (row.kind === "app") {
       var appId = row.appId
       var label = row.label
-      if (root.filterText.trim() && root.shell
-          && typeof root.shell.publishAppSelectedAfterSearch === "function") {
-        root.shell.publishAppSelectedAfterSearch(
-          root.manifest ? root.manifest.id : "",
-          { schemaVersion: 1, desktopId: appId, name: label }
-        )
-      }
       applySerial = requestSerial
       opened = false
       filterText = ""

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -777,6 +777,13 @@ Item {
     } else if (row.kind === "app") {
       var appId = row.appId
       var label = row.label
+      if (root.filterText.trim() && root.shell
+          && typeof root.shell.publishAppSelectedAfterSearch === "function") {
+        root.shell.publishAppSelectedAfterSearch(
+          root.manifest ? root.manifest.id : "",
+          { schemaVersion: 1, desktopId: appId, name: label }
+        )
+      }
       applySerial = requestSerial
       opened = false
       filterText = ""

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -384,6 +384,25 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
   }
 }
 
+function selectionAfterSearch(items, row, filterText) {
+  if (!String(filterText || "").trim() || !row || row.disabled) return null
+  var entry = item(items, row.itemId)
+  if (!entry || entry.providerMenu) return null
+  var allowedKinds = ["action", "app", "link", "menu"]
+  if (allowedKinds.indexOf(entry.kind) === -1) return null
+
+  var desktopId = entry.kind === "app" ? String(entry.appId || "").trim() : ""
+  if (entry.kind === "app" && !desktopId) return null
+  return {
+    schemaVersion: 1,
+    itemId: String(entry.id || ""),
+    kind: String(entry.kind || ""),
+    label: String(entry.label || ""),
+    path: pathFor(items, entry.id),
+    desktopId: desktopId
+  }
+}
+
 // Commands a `checked:` expression reads a value out of. Every sibling row
 // asks the same one -- Defaults > Browser has seven rows all comparing
 // against `omarchy-default-browser` -- so the batch runs it once and the rows
@@ -519,6 +538,7 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    selectionAfterSearch: selectionAfterSearch
   }
 }

--- a/shell/plugins/menu/manifest.json
+++ b/shell/plugins/menu/manifest.json
@@ -11,7 +11,7 @@
   ],
   "keepLoaded": true,
   "capabilities": {
-    "app-selected-after-search": 1
+    "menu-selection-after-search": 1
   },
   "entryPoints": {
     "menu": "Menu.qml",

--- a/shell/plugins/menu/manifest.json
+++ b/shell/plugins/menu/manifest.json
@@ -10,6 +10,9 @@
     "bar-widget"
   ],
   "keepLoaded": true,
+  "capabilities": {
+    "app-selected-after-search": 1
+  },
   "entryPoints": {
     "menu": "Menu.qml",
     "barWidget": "BarWidget.qml"

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -69,6 +69,19 @@ QtObject {
       console.warn("PluginRegistry: entryPoints must be an object at " + sourcePath)
       return null
     }
+    if (manifest.capabilities !== undefined) {
+      if (!Util.isPlainObject(manifest.capabilities)) {
+        console.warn("PluginRegistry: capabilities must be an object at " + sourcePath)
+        return null
+      }
+      for (var capability in manifest.capabilities) {
+        var capabilityVersion = Number(manifest.capabilities[capability])
+        if (!capability || !Number.isInteger(capabilityVersion) || capabilityVersion < 1) {
+          console.warn("PluginRegistry: capability versions must be positive integers at " + sourcePath)
+          return null
+        }
+      }
+    }
     if (manifest.barWidget !== undefined && Util.isPlainObject(manifest.barWidget)
         && manifest.barWidget.defaultSection !== undefined) {
       var defaultSection = String(manifest.barWidget.defaultSection)
@@ -154,6 +167,19 @@ QtObject {
         return candidate
     }
     return key
+  }
+
+  // -1 means the registry is still scanning, 0 means unsupported, and a
+  // positive integer is the declared capability contract version.
+  function capabilityVersion(id, capability) {
+    if (scanning) return -1
+    var resolvedId = resolveEnabledId(id)
+    var manifest = installedPlugins[resolvedId]
+    var capabilities = manifest && Util.isPlainObject(manifest.capabilities)
+      ? manifest.capabilities : null
+    if (!capabilities) return 0
+    var version = Number(capabilities[String(capability || "")])
+    return Number.isInteger(version) && version > 0 ? version : 0
   }
 
   // A bar widget is on when it sits in the bar, whoever shipped it. That is a

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -74,7 +74,9 @@ QtObject {
         console.warn("PluginRegistry: capabilities must be an object at " + sourcePath)
         return null
       }
-      for (var capability in manifest.capabilities) {
+      var capabilityNames = Object.keys(manifest.capabilities)
+      for (var capabilityIndex = 0; capabilityIndex < capabilityNames.length; capabilityIndex++) {
+        var capability = capabilityNames[capabilityIndex]
         var capabilityVersion = Number(manifest.capabilities[capability])
         if (!capability || !Number.isInteger(capabilityVersion) || capabilityVersion < 1) {
           console.warn("PluginRegistry: capability versions must be positive integers at " + sourcePath)
@@ -173,7 +175,10 @@ QtObject {
   // positive integer is the declared capability contract version.
   function capabilityVersion(id, capability) {
     if (scanning) return -1
-    var resolvedId = resolveEnabledId(id)
+    return capabilityVersionForResolvedId(resolveEnabledId(id), capability)
+  }
+
+  function capabilityVersionForResolvedId(resolvedId, capability) {
     var manifest = installedPlugins[resolvedId]
     var capabilities = manifest && Util.isPlainObject(manifest.capabilities)
       ? manifest.capabilities : null

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -77,9 +77,13 @@ QtObject {
       var capabilityNames = Object.keys(manifest.capabilities)
       for (var capabilityIndex = 0; capabilityIndex < capabilityNames.length; capabilityIndex++) {
         var capability = capabilityNames[capabilityIndex]
+        var normalizedCapability = capability.trim()
+        var reservedCapabilityNames = ["__proto__", "constructor", "prototype"]
         var capabilityVersion = Number(manifest.capabilities[capability])
-        if (!capability || !Number.isInteger(capabilityVersion) || capabilityVersion < 1) {
-          console.warn("PluginRegistry: capability versions must be positive integers at " + sourcePath)
+        if (!normalizedCapability || normalizedCapability !== capability
+            || reservedCapabilityNames.indexOf(capability) !== -1
+            || !Number.isInteger(capabilityVersion) || capabilityVersion < 1) {
+          console.warn("PluginRegistry: capabilities require trimmed non-reserved names and positive integer versions at " + sourcePath)
           return null
         }
       }
@@ -183,7 +187,7 @@ QtObject {
     var capabilities = manifest && Util.isPlainObject(manifest.capabilities)
       ? manifest.capabilities : null
     if (!capabilities) return 0
-    var version = Number(capabilities[String(capability || "")])
+    var version = Number(capabilities[String(capability || "").trim()])
     return Number.isInteger(version) && version > 0 ? version : 0
   }
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -57,6 +57,8 @@ ShellRoot {
   property bool pluginReloading: false
   property bool pluginReloadPending: false
 
+  signal appSelectedAfterSearch(var event)
+
   Timer {
     id: localPluginReloadTimer
     interval: 150
@@ -110,6 +112,31 @@ ShellRoot {
     payload.version = 1
     shellConfig = payload
     userConfigFile.setText(JSON.stringify(payload, null, 2) + "\n")
+  }
+
+  function pluginSupportStatus(pluginId, capability, minimumVersion) {
+    var version = shell.pluginRegistry.capabilityVersion(pluginId, capability)
+    if (version < 0) return "checking"
+    return version >= Math.max(1, Number(minimumVersion) || 1) ? "supported" : "unsupported"
+  }
+
+  function publishAppSelectedAfterSearch(sourceId, event) {
+    var activeMenuId = shell.pluginRegistry.resolveEnabledId("omarchy.menu")
+    if (String(sourceId || "") !== activeMenuId) return false
+    if (shell.pluginSupportStatus("omarchy.menu", "app-selected-after-search", 1) !== "supported") return false
+    if (!Util.isPlainObject(event) || Number(event.schemaVersion) !== 1) return false
+
+    var desktopId = String(event.desktopId || "").trim()
+    var name = String(event.name || "").trim()
+    if (!desktopId || !name) return false
+
+    shell.appSelectedAfterSearch({
+      schemaVersion: 1,
+      sourceId: activeMenuId,
+      desktopId: desktopId,
+      name: name
+    })
+    return true
   }
 
   readonly property var barConfig: shellConfig && Util.isPlainObject(shellConfig.bar) ? shellConfig.bar : builtinShellConfig.bar
@@ -894,6 +921,10 @@ ShellRoot {
     function reloadConfig(): string {
       userConfigFile.reload()
       return "ok"
+    }
+
+    function pluginSupports(id: string, capability: string, minimumVersion: string): string {
+      return shell.pluginSupportStatus(id, capability, Number(minimumVersion) || 1)
     }
 
     function toggleBarTransparency(): string {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -123,7 +123,7 @@ ShellRoot {
   function publishAppSelectedAfterSearch(sourceId, event) {
     var activeMenuId = shell.pluginRegistry.resolveEnabledId("omarchy.menu")
     if (String(sourceId || "") !== activeMenuId) return false
-    if (shell.pluginSupportStatus("omarchy.menu", "app-selected-after-search", 1) !== "supported") return false
+    if (shell.pluginRegistry.capabilityVersionForResolvedId(activeMenuId, "app-selected-after-search") < 1) return false
     if (!Util.isPlainObject(event) || Number(event.schemaVersion) !== 1) return false
 
     var desktopId = String(event.desktopId || "").trim()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -117,7 +117,9 @@ ShellRoot {
   function pluginSupportStatus(pluginId, capability, minimumVersion) {
     var version = shell.pluginRegistry.capabilityVersion(pluginId, capability)
     if (version < 0) return "checking"
-    return version >= Math.max(1, Number(minimumVersion) || 1) ? "supported" : "unsupported"
+    var minimum = Number(minimumVersion)
+    if (!Number.isInteger(minimum) || minimum < 1) minimum = 1
+    return version >= minimum ? "supported" : "unsupported"
   }
 
   function publishAppSelectedAfterSearch(sourceId, event) {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -57,7 +57,7 @@ ShellRoot {
   property bool pluginReloading: false
   property bool pluginReloadPending: false
 
-  signal appSelectedAfterSearch(var event)
+  signal menuSelectionAfterSearch(var event)
 
   Timer {
     id: localPluginReloadTimer
@@ -122,21 +122,31 @@ ShellRoot {
     return version >= minimum ? "supported" : "unsupported"
   }
 
-  function publishAppSelectedAfterSearch(sourceId, event) {
+  function publishMenuSelectionAfterSearch(sourceId, event) {
     var activeMenuId = shell.pluginRegistry.resolveEnabledId("omarchy.menu")
     if (String(sourceId || "") !== activeMenuId) return false
-    if (shell.pluginRegistry.capabilityVersionForResolvedId(activeMenuId, "app-selected-after-search") < 1) return false
+    if (shell.pluginRegistry.capabilityVersionForResolvedId(activeMenuId, "menu-selection-after-search") < 1) return false
     if (!Util.isPlainObject(event) || Number(event.schemaVersion) !== 1) return false
 
+    var itemId = String(event.itemId || "").trim()
+    var kind = String(event.kind || "").trim()
+    var allowedKinds = ["action", "app", "link", "menu"]
+    var label = String(event.label || "").trim()
+    var path = String(event.path || "").trim()
     var desktopId = String(event.desktopId || "").trim()
-    var name = String(event.name || "").trim()
-    if (!desktopId || !name) return false
+    if (!itemId || allowedKinds.indexOf(kind) === -1 || !label || !path) return false
+    if (kind === "app" && !desktopId) return false
+    if (kind !== "app") desktopId = ""
+    if (itemId.length > 256 || label.length > 256 || path.length > 1024 || desktopId.length > 256) return false
 
-    shell.appSelectedAfterSearch({
+    shell.menuSelectionAfterSearch({
       schemaVersion: 1,
       sourceId: activeMenuId,
+      itemId: itemId,
+      kind: kind,
+      label: label,
+      path: path,
       desktopId: desktopId,
-      name: name
     })
     return true
   }

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -116,6 +116,8 @@ ShellRoot {
     scan += block("thirdparty", "/third/missing", { schemaVersion: 1, id: "third.missing", name: "missing", version: "1.0.0", kinds: ["panel"] })
     scan += block("thirdparty", "/third/bad-section", manifest("third.bad-section", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "bottom" }))
     scan += block("thirdparty", "/third/bad-capability", manifest("third.bad-capability", ["panel"], { panel: "Panel.qml" }, null, { broken: 0 }))
+    scan += block("thirdparty", "/third/padded-capability", manifest("third.padded-capability", ["panel"], { panel: "Panel.qml" }, null, { " padded ": 1 }))
+    scan += block("thirdparty", "/third/reserved-capability", manifest("third.reserved-capability", ["panel"], { panel: "Panel.qml" }, null, { constructor: 1 }))
     scan += block("thirdparty", "/third/schema", { schemaVersion: 2, id: "third.schema", name: "schema", version: "1.0.0", kinds: ["panel"], entryPoints: { panel: "Panel.qml" } })
     scan += block("thirdparty", "/third/bad-json", "{")
 
@@ -149,6 +151,8 @@ ShellRoot {
     root.assertTrue(!has("third.missing"), "incomplete manifests are rejected")
     root.assertTrue(!has("third.bad-section"), "invalid default bar widget sections are rejected")
     root.assertTrue(!has("third.bad-capability"), "invalid capability versions are rejected")
+    root.assertTrue(!has("third.padded-capability"), "padded capability names are rejected")
+    root.assertTrue(!has("third.reserved-capability"), "reserved capability names are rejected")
     root.assertTrue(!has("third.schema"), "unsupported schema versions are rejected")
 
     root.assertTrue(registry.isEnabled("omarchy.first-widget"), "first-party plugins are implicitly enabled")
@@ -157,6 +161,7 @@ ShellRoot {
     root.assertTrue(!registry.isEnabled("third.panel"), "third-party plugins start disabled")
     root.assertEqual(registry.resolveEnabledId("omarchy.first-widget"), "omarchy.first-widget", "inactive clones do not replace their source id")
     root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 1, "registry reads versioned plugin capabilities")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", " app-selected-after-search "), 1, "capability lookup trims caller input")
     root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "missing"), 0, "registry reports unsupported capabilities")
 
     registry.setEnabled("third.bar", true)

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -50,7 +50,7 @@ ShellRoot {
     }
   }
 
-  function manifest(id, kinds, entryPoints, barWidget) {
+  function manifest(id, kinds, entryPoints, barWidget, capabilities) {
     var value = {
       schemaVersion: 1,
       id: id,
@@ -60,6 +60,7 @@ ShellRoot {
       entryPoints: entryPoints
     }
     if (barWidget) value.barWidget = barWidget
+    if (capabilities) value.capabilities = capabilities
     return value
   }
 
@@ -82,7 +83,13 @@ ShellRoot {
     scan += block("firstparty", "/first/widgets/clock", manifest("omarchy.first-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
     scan += block("firstparty", "/first/bar", manifest("omarchy.bar", ["bar"], { bar: "Bar.qml" }))
     scan += block("firstparty", "/first/panels/grouped", manifest("omarchy.grouped-panel", ["panel"], { panel: "Panel.qml" }))
-    scan += block("firstparty", "/first/hybrid", manifest("omarchy.hybrid", ["menu", "bar-widget"], { menu: "Menu.qml", barWidget: "Widget.qml" }))
+    scan += block("firstparty", "/first/hybrid", manifest(
+      "omarchy.hybrid",
+      ["menu", "bar-widget"],
+      { menu: "Menu.qml", barWidget: "Widget.qml" },
+      null,
+      { "app-selected-after-search": 1 }
+    ))
     scan += block("thirdparty", "/third/panel", manifest("third.panel", ["panel"], { panel: "Panel.qml" }))
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
     scan += block("thirdparty", "/third/center-widget", manifest("third.center-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
@@ -108,6 +115,7 @@ ShellRoot {
     scan += block("thirdparty", "/third/unsafe", manifest("third.unsafe", ["panel"], { panel: "../Panel.qml" }))
     scan += block("thirdparty", "/third/missing", { schemaVersion: 1, id: "third.missing", name: "missing", version: "1.0.0", kinds: ["panel"] })
     scan += block("thirdparty", "/third/bad-section", manifest("third.bad-section", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "bottom" }))
+    scan += block("thirdparty", "/third/bad-capability", manifest("third.bad-capability", ["panel"], { panel: "Panel.qml" }, null, { broken: 0 }))
     scan += block("thirdparty", "/third/schema", { schemaVersion: 2, id: "third.schema", name: "schema", version: "1.0.0", kinds: ["panel"], entryPoints: { panel: "Panel.qml" } })
     scan += block("thirdparty", "/third/bad-json", "{")
 
@@ -140,6 +148,7 @@ ShellRoot {
     root.assertTrue(!has("third.unsafe"), "unsafe entry points are rejected")
     root.assertTrue(!has("third.missing"), "incomplete manifests are rejected")
     root.assertTrue(!has("third.bad-section"), "invalid default bar widget sections are rejected")
+    root.assertTrue(!has("third.bad-capability"), "invalid capability versions are rejected")
     root.assertTrue(!has("third.schema"), "unsupported schema versions are rejected")
 
     root.assertTrue(registry.isEnabled("omarchy.first-widget"), "first-party plugins are implicitly enabled")
@@ -147,6 +156,8 @@ ShellRoot {
     root.assertTrue(!registry.isEnabled("third.bar"), "third-party bar options start inactive")
     root.assertTrue(!registry.isEnabled("third.panel"), "third-party plugins start disabled")
     root.assertEqual(registry.resolveEnabledId("omarchy.first-widget"), "omarchy.first-widget", "inactive clones do not replace their source id")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 1, "registry reads versioned plugin capabilities")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "missing"), 0, "registry reports unsupported capabilities")
 
     registry.setEnabled("third.bar", true)
     root.assertEqual(root.config.bar.id, "third.bar", "enabling third-party bar options writes bar id")
@@ -306,6 +317,7 @@ ShellRoot {
     // Refusing an id the scan has not reached would fail the migration.
     root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
     registry.scanning = true
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), -1, "capability checks wait for registry scans")
     root.assertEqual(registry.putBarWidget("third.absent", {}), "not ready", "put waits for a scan that has not reached its widget")
     root.assertDeepEqual(root.config.bar.layout.center, [], "put places nothing while it is still waiting")
     root.assertEqual(registry.putBarWidget("third.center-widget", {}), "", "put places a widget the scan has already read")
@@ -355,9 +367,11 @@ ShellRoot {
     registry.setEnabled("local.hybrid", true)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "local.hybrid" }], "enabling a multi-kind clone replaces its widget")
     root.assertDeepEqual(root.config.disabledPlugins, ["omarchy.hybrid"], "enabling a multi-kind clone disables the source")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 0, "an active clone without the capability reports unsupported")
     registry.setEnabled("local.hybrid", false)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "omarchy.hybrid" }], "disabling a multi-kind clone restores its widget")
     root.assertTrue(root.config.disabledPlugins === undefined, "disabling a multi-kind clone enables the source")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 1, "restoring the source restores its capabilities")
 
     root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
     registry.setEnabled("local.grouped-panel", true)

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -88,7 +88,7 @@ ShellRoot {
       ["menu", "bar-widget"],
       { menu: "Menu.qml", barWidget: "Widget.qml" },
       null,
-      { "app-selected-after-search": 1 }
+      { "menu-selection-after-search": 1 }
     ))
     scan += block("thirdparty", "/third/panel", manifest("third.panel", ["panel"], { panel: "Panel.qml" }))
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
@@ -160,8 +160,8 @@ ShellRoot {
     root.assertTrue(!registry.isEnabled("third.bar"), "third-party bar options start inactive")
     root.assertTrue(!registry.isEnabled("third.panel"), "third-party plugins start disabled")
     root.assertEqual(registry.resolveEnabledId("omarchy.first-widget"), "omarchy.first-widget", "inactive clones do not replace their source id")
-    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 1, "registry reads versioned plugin capabilities")
-    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", " app-selected-after-search "), 1, "capability lookup trims caller input")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "menu-selection-after-search"), 1, "registry reads versioned plugin capabilities")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", " menu-selection-after-search "), 1, "capability lookup trims caller input")
     root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "missing"), 0, "registry reports unsupported capabilities")
 
     registry.setEnabled("third.bar", true)
@@ -322,7 +322,7 @@ ShellRoot {
     // Refusing an id the scan has not reached would fail the migration.
     root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
     registry.scanning = true
-    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), -1, "capability checks wait for registry scans")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "menu-selection-after-search"), -1, "capability checks wait for registry scans")
     root.assertEqual(registry.putBarWidget("third.absent", {}), "not ready", "put waits for a scan that has not reached its widget")
     root.assertDeepEqual(root.config.bar.layout.center, [], "put places nothing while it is still waiting")
     root.assertEqual(registry.putBarWidget("third.center-widget", {}), "", "put places a widget the scan has already read")
@@ -372,11 +372,11 @@ ShellRoot {
     registry.setEnabled("local.hybrid", true)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "local.hybrid" }], "enabling a multi-kind clone replaces its widget")
     root.assertDeepEqual(root.config.disabledPlugins, ["omarchy.hybrid"], "enabling a multi-kind clone disables the source")
-    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 0, "an active clone without the capability reports unsupported")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "menu-selection-after-search"), 0, "an active clone without the capability reports unsupported")
     registry.setEnabled("local.hybrid", false)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "omarchy.hybrid" }], "disabling a multi-kind clone restores its widget")
     root.assertTrue(root.config.disabledPlugins === undefined, "disabling a multi-kind clone enables the source")
-    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "app-selected-after-search"), 1, "restoring the source restores its capabilities")
+    root.assertEqual(registry.capabilityVersion("omarchy.hybrid", "menu-selection-after-search"), 1, "restoring the source restores its capabilities")
 
     root.config = { version: 1, bar: { layout: { left: [], center: [], right: [] } }, plugins: [] }
     registry.setEnabled("local.grouped-panel", true)

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -13,16 +13,15 @@ const menuManifest = JSON.parse(fs.readFileSync(path.join(root, 'shell/plugins/m
 const defaultMenuJsonc = fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8')
 
 assertEqual(
-  menuManifest.capabilities['app-selected-after-search'],
+  menuManifest.capabilities['menu-selection-after-search'],
   1,
-  'menu declares the searched-app selection event contract'
+  'menu declares the searched-menu selection event contract'
 )
 const publishedSelection = menuQml.match(
-  /publishAppSelectedAfterSearch\s*\([\s\S]*?\{\s*schemaVersion\s*:\s*1\s*,\s*desktopId\s*:\s*appId\s*,\s*name\s*:\s*label\s*\}[\s\S]*?\)[\s\S]*?filterText\s*=\s*""/
+  /selectionAfterSearch\s*\([\s\S]*?publishMenuSelectionAfterSearch\s*\(/
 )
-assert(publishedSelection, 'menu publishes explicit app selections before clearing its search state')
-assert(!publishedSelection[0].includes('query:'), 'menu does not publish the search query')
-assert(/signal\s+appSelectedAfterSearch\s*\(\s*var\s+event\s*\)/.test(shellQml), 'shell exposes a semantic searched-app event')
+assert(publishedSelection, 'menu publishes explicit normal-menu selections through the shared activation path')
+assert(/signal\s+menuSelectionAfterSearch\s*\(\s*var\s+event\s*\)/.test(shellQml), 'shell exposes a semantic searched-menu event')
 assert(/String\s*\(\s*sourceId\s*\|\|\s*""\s*\)\s*!==\s*activeMenuId/.test(shellQml), 'shell rejects publications from inactive menu implementations')
 assert(/function\s+pluginSupports\s*\(\s*id\s*:\s*string\s*,\s*capability\s*:\s*string\s*,\s*minimumVersion\s*:\s*string\s*\)/.test(shellQml), 'shell IPC exposes capability detection')
 
@@ -73,6 +72,33 @@ const merged = menu.mergeMenuSources(parsed, user)
 assertEqual(merged.items['style.theme'].label, 'Theme picker', 'menu user entries override default entries')
 assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order on override')
 assert(merged.items.root, 'menu injects root when merging sources')
+
+const selectionItems = menu.mergeMenuSources([
+  menu.normalizeItem('style', { label: 'Style' }),
+  menu.normalizeItem('style.theme', { label: 'Theme', action: 'omarchy-theme-switcher' }),
+  menu.normalizeItem('learn', { label: 'Learn' }),
+  menu.normalizeItem('learn.keybindings', { label: 'Keybindings', action: 'omarchy-menu-keybindings' }),
+  { ...menu.normalizeItem('apps.firefox', { label: 'Firefox' }), kind: 'app', appId: 'firefox.desktop' }
+], []).items
+assertDeepEqual(
+  menu.selectionAfterSearch(selectionItems, { itemId: 'style.theme', disabled: false }, 'theme'),
+  { schemaVersion: 1, itemId: 'style.theme', kind: 'action', label: 'Theme', path: 'Style › Theme', desktopId: '' },
+  'menu creates a query-free static-action selection event'
+)
+assertDeepEqual(
+  menu.selectionAfterSearch(selectionItems, { itemId: 'learn', disabled: false }, 'learn'),
+  { schemaVersion: 1, itemId: 'learn', kind: 'menu', label: 'Learn', path: 'Learn', desktopId: '' },
+  'menu creates a submenu selection event'
+)
+assertDeepEqual(
+  menu.selectionAfterSearch(selectionItems, { itemId: 'apps.firefox', disabled: false }, 'firefox'),
+  { schemaVersion: 1, itemId: 'apps.firefox', kind: 'app', label: 'Firefox', path: 'Firefox', desktopId: 'firefox.desktop' },
+  'menu creates an app selection event with stable desktop identity'
+)
+assertEqual(menu.selectionAfterSearch(selectionItems, { itemId: 'style.theme', disabled: false }, ''), null, 'menu skips empty-search selections')
+const providerSelection = { ...menu.normalizeItem('style.font.fira-code', { label: 'Fira Code', action: 'set-font' }), providerMenu: 'style.font' }
+selectionItems[providerSelection.id] = providerSelection
+assertEqual(menu.selectionAfterSearch(selectionItems, { itemId: providerSelection.id, disabled: false }, 'fira'), null, 'menu skips dynamic provider rows without a stable selection contract')
 
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -17,16 +17,14 @@ assertEqual(
   1,
   'menu declares the searched-app selection event contract'
 )
-const publishIndex = menuQml.indexOf('root.shell.publishAppSelectedAfterSearch(')
-const clearFilterIndex = menuQml.indexOf('filterText = ""', publishIndex)
-assert(publishIndex >= 0, 'menu publishes explicit app selections made after search')
-assert(clearFilterIndex > publishIndex, 'menu publishes before clearing its search state')
-const publishedEvent = menuQml.slice(publishIndex, clearFilterIndex)
-assert(publishedEvent.includes('desktopId: appId') && publishedEvent.includes('name: label'), 'menu publishes stable app identity and display name')
-assert(!publishedEvent.includes('filterText') && !publishedEvent.includes('query:'), 'menu does not publish the search query')
-assert(shellQml.includes('signal appSelectedAfterSearch(var event)'), 'shell exposes a semantic searched-app event')
-assert(shellQml.includes('String(sourceId || "") !== activeMenuId'), 'shell rejects publications from inactive menu implementations')
-assert(shellQml.includes('function pluginSupports(id: string, capability: string, minimumVersion: string)'), 'shell IPC exposes capability detection')
+const publishedSelection = menuQml.match(
+  /publishAppSelectedAfterSearch\s*\([\s\S]*?\{\s*schemaVersion\s*:\s*1\s*,\s*desktopId\s*:\s*appId\s*,\s*name\s*:\s*label\s*\}[\s\S]*?\)[\s\S]*?filterText\s*=\s*""/
+)
+assert(publishedSelection, 'menu publishes explicit app selections before clearing its search state')
+assert(!publishedSelection[0].includes('query:'), 'menu does not publish the search query')
+assert(/signal\s+appSelectedAfterSearch\s*\(\s*var\s+event\s*\)/.test(shellQml), 'shell exposes a semantic searched-app event')
+assert(/String\s*\(\s*sourceId\s*\|\|\s*""\s*\)\s*!==\s*activeMenuId/.test(shellQml), 'shell rejects publications from inactive menu implementations')
+assert(/function\s+pluginSupports\s*\(\s*id\s*:\s*string\s*,\s*capability\s*:\s*string\s*,\s*minimumVersion\s*:\s*string\s*\)/.test(shellQml), 'shell IPC exposes capability detection')
 
 const parsed = menu.parseMenuJsonc(`
 {

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -8,7 +8,25 @@ run_node_test <<'JS'
 const fs = require('fs')
 const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
 const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+const menuManifest = JSON.parse(fs.readFileSync(path.join(root, 'shell/plugins/menu/manifest.json'), 'utf8'))
 const defaultMenuJsonc = fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8')
+
+assertEqual(
+  menuManifest.capabilities['app-selected-after-search'],
+  1,
+  'menu declares the searched-app selection event contract'
+)
+const publishIndex = menuQml.indexOf('root.shell.publishAppSelectedAfterSearch(')
+const clearFilterIndex = menuQml.indexOf('filterText = ""', publishIndex)
+assert(publishIndex >= 0, 'menu publishes explicit app selections made after search')
+assert(clearFilterIndex > publishIndex, 'menu publishes before clearing its search state')
+const publishedEvent = menuQml.slice(publishIndex, clearFilterIndex)
+assert(publishedEvent.includes('desktopId: appId') && publishedEvent.includes('name: label'), 'menu publishes stable app identity and display name')
+assert(!publishedEvent.includes('filterText') && !publishedEvent.includes('query:'), 'menu does not publish the search query')
+assert(shellQml.includes('signal appSelectedAfterSearch(var event)'), 'shell exposes a semantic searched-app event')
+assert(shellQml.includes('String(sourceId || "") !== activeMenuId'), 'shell rejects publications from inactive menu implementations')
+assert(shellQml.includes('function pluginSupports(id: string, capability: string, minimumVersion: string)'), 'shell IPC exposes capability detection')
 
 const parsed = menu.parseMenuJsonc(`
 {


### PR DESCRIPTION
## Summary

- publish a semantic shell event when a normal menu row is explicitly selected after a non-empty search
- cover static actions, apps, menus, and links through the shared keyboard/pointer activation path
- declare and validate a versioned menu capability with clone-aware support detection
- reject events from inactive menu implementations and omit queries, commands, dmenu values, and unsafe dynamic-provider identities
- cover manifest validation, clone routing, scan state, payload construction, and exclusion behavior

## Motivation

Third-party coaching plugins need to observe menu discovery without patching the launcher or collecting search text. The event contains only stable item identity, canonical kind/label/path, and desktop-entry ID for apps. It represents explicit selection intent, not confirmed command success.

Related design and consumer tracking: https://github.com/FilipHarald/omacoach/issues/17

## Tests

- `bash test/shell.d/menu-test.sh`
- `bash test/shell.d/plugin-registry-contract-test.sh`
- `qmllint -I shell shell/shell.qml shell/services/PluginRegistry.qml shell/plugins/menu/Menu.qml`
- `jq empty shell/plugins/menu/manifest.json`