### PR TITLE
update battery lookup

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,7 +18,7 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
+battery=$(upower -e 2>/dev/null | grep -i BAT | head -n 1)
 [[ -z $battery ]] && exit 0
 
 battery_info=$(upower -i "$battery")


### PR DESCRIPTION
omarchy-battery-lookup used uppercase "BAT" for battery info lookup in upower but some machines have lowercase "battery" as the key..