### PR TITLE
Keep universal clipboard shortcuts working on non-Latin layouts

### DIFF
--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -42,7 +42,15 @@ local function universal_clipboard_shortcut(default_mods, default_key, terminal_
   end
 end
 
-o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
-o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
+-- Inject letters by keycode, not keysym: Hyprland resolves keysyms against the
+-- active layout, so on a non-Latin layout (Cyrillic, Greek, ...) no key produces
+-- "C"/"V"/"X" and the injection silently does nothing. Hyprland's code: prefix
+-- takes XKB keycodes (evdev scancode + 8), verifiable with `wev`.
+local KEYCODE_C = "code:54"
+local KEYCODE_V = "code:55"
+local KEYCODE_X = "code:53"
+
+o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", KEYCODE_C, "CTRL", "Insert"))
+o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", KEYCODE_V, "SHIFT", "Insert"))
+o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", KEYCODE_X))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")


### PR DESCRIPTION
Fixes #7371

mise ~/.config/mise/config.toml tools: gh@2.97.0
### Problem

With multiple keyboard layouts where the secondary one is non-Latin (e.g. `kb_layout = "us,ua"`), the universal clipboard shortcuts (Super+C / Super+V / Super+X) silently do nothing while the non-Latin layout is active.

The Super+C trigger itself still fires (Hyprland resolves binds against the first layout), but `send_key_state` injects the shortcut by key *symbol*, and Hyprland resolves that symbol against the *active* keymap. On a Cyrillic layout no key produces the Latin `C`/`V`/`X` keysym, so the resolution fails and nothing is sent. Same story for Greek, Hebrew, and any other non-Latin layout.

### Fix

Inject the letters by keycode (`code:54`/`code:55`/`code:53`) instead of by symbol. Keycodes are layout-independent, so the injection works regardless of the active layout. The terminal branch (`Insert`) is unaffected — that keysym exists in every layout.

The receiving app then sees the same event a physical Ctrl+C press produces (e.g. Ctrl+с on a Cyrillic layout), which toolkits already match to Copy via their standard Latin fallback.

### Testing

- Verified locally on `us,ua` (Omarchy 4.0.0, Hyprland 0.56.2): before the change Super+C/V/X work only on `us`; after the change they work on both layouts, in browsers and terminals.
- `./test/cli` passes. The four `./test/shell` failures on this machine reproduce identically on a clean master checkout (live-session/environment interference), so they are unrelated.
