### PR TITLE
fix: sanitize clipboard and notification HTML to prevent Qt6 StyledText crash

### DIFF
--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -1,13 +1,38 @@
+// Strip HTML tags and decode common entities to prevent StyledText crashes.
+// Clipboard entries from browsers/messaging apps often contain raw HTML that
+// triggers Qt6 bugs in StyledText rendering. Converting to plain text avoids
+// the crash while keeping the content readable.
+function sanitizeText(text) {
+  var s = String(text || "")
+
+  // Decode HTML entities first
+  s = s
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&nbsp;/gi, " ")
+
+  // Strip HTML tags (including self-closing and malformed)
+  s = s.replace(/<[^>]+>/g, "")
+
+  // Collapse whitespace
+  s = s.replace(/\s+/g, " ").trim()
+
+  return s
+}
+
 function normalizeEntry(value) {
   if (typeof value === "string")
-    return value.trim().length > 0 ? { type: "text", text: value } : null
+    return value.trim().length > 0 ? { type: "text", text: sanitizeText(value) } : null
 
   if (!value || typeof value !== "object") return null
 
   var type = String(value.type || value.kind || "")
   if (type === "text") {
-    var text = String(value.text || "")
-    return text.trim().length > 0 ? { type: "text", text: text } : null
+    var text = sanitizeText(value.text)
+    return text.length > 0 ? { type: "text", text: text } : null
   }
 
   if (type === "image") {

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -6,7 +6,22 @@ function isChromiumDerived(app, appIcon) {
 }
 
 function sanitizeBody(body, app, appIcon) {
-  var text = String(body || "").replace(/<img[^>]*>/gi, "")
+  var text = String(body || "")
+
+  // Decode HTML entities first so we can catch encoded img tags
+  // e.g. &lt;img src="..."&gt; -> <img src="...">
+  text = text
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+
+  // Strip all img tags aggressively (handles multiline, malformed, etc.)
+  // This catches: <img ...>, <IMG ...>, <img/>, <img ... />, and any variation
+  // The \b word boundary ensures we match "img" but not "image" or other tags
+  text = text.replace(/<img\b[^>]*>/gi, "")
+
   if (!isChromiumDerived(app, appIcon)) return text
 
   return text


### PR DESCRIPTION
## Problem

Clipboard entries from browsers/messaging apps (WhatsApp, etc.) often contain raw HTML that triggers a Qt6 bug in `QQuickTextPrivate::updateLayout()` when rendered with `Text.StyledText`. The crash occurs because the `nbImages` counter gets out of sync when invalid `<img>` tags are deleted.

## Root Cause

Upstream Qt6 bug in `qquickstyledtext.cpp`: when an `<img>` tag has an invalid URL, the code deletes the image object but does not increment `nbImages`. This causes the counter to desynchronize, leading to invalid memory access when subsequent `<img>` tags are processed.

## Fix

This PR adds sanitization at two layers:

1. **Clipboard**: Strip HTML tags and decode entities before storing entries. Existing entries are sanitized on load via `parseHistory()`.

2. **Notifications**: Improve `sanitizeBody()` to decode HTML entities before stripping `<img>` tags, catching encoded variants like `&lt;img&gt;`.

## Testing

- [ ] Copy HTML content from WhatsApp/browser and verify clipboard stores plain text
- [ ] Send notification with HTML body and verify no crash
- [ ] Verify existing clipboard history is sanitized on load

## Upstream

A separate PR will be submitted to Qt6 to fix the root cause (`nbImages++` missing in `qquickstyledtext.cpp`).