### PR TITLE
Make the lock screen blank delay configurable

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,8 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "lockBlank": 5
   },
   "bar": {
     "position": "top",

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -16,6 +16,14 @@ Item {
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
 
+  readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
+  // Seconds the unlock screen stays lit without input before the display
+  // blanks, validated the same way the idle service reads its timeouts.
+  readonly property int blankTimeoutSeconds: {
+    var seconds = Number(idleConfig.lockBlank)
+    return isFinite(seconds) && seconds >= 0 ? Math.floor(seconds) : 5
+  }
+
   property bool lockRequested: false
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
@@ -413,7 +421,7 @@ Item {
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    interval: root.blankTimeoutSeconds * 1000
     repeat: false
     property double armedAt: 0
     onTriggered: {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -17,11 +17,12 @@ Item {
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
 
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
+  readonly property int defaultBlankSeconds: 5
   // Seconds the unlock screen stays lit without input before the display
   // blanks, validated the same way the idle service reads its timeouts.
   readonly property int blankTimeoutSeconds: {
     var seconds = Number(idleConfig.lockBlank)
-    return isFinite(seconds) && seconds >= 0 ? Math.floor(seconds) : 5
+    return isFinite(seconds) && seconds >= 0 ? Math.floor(seconds) : defaultBlankSeconds
   }
 
   property bool lockRequested: false

--- a/test/shell.d/lock-blank-timeout-test.sh
+++ b/test/shell.d/lock-blank-timeout-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const shellDefaults = JSON.parse(fs.readFileSync(path.join(root, 'config/omarchy/shell.json'), 'utf8'))
+
+assert(
+  /idleConfig\.lockBlank/.test(serviceQml),
+  'the blank delay reads idle.lockBlank from the shell config'
+)
+
+assert(
+  /interval: root\.blankTimeoutSeconds \* 1000/.test(serviceQml),
+  'the blank timer takes its interval from the configured seconds'
+)
+
+assert(
+  /isFinite\(seconds\) && seconds >= 0 \? Math\.floor\(seconds\) : 5/.test(serviceQml),
+  'invalid or missing config falls back to the 5-second default'
+)
+
+assertEqual(shellDefaults.idle.lockBlank, 5, 'the shipped default keeps the 5-second blank')
+JS

--- a/test/shell.d/lock-blank-timeout-test.sh
+++ b/test/shell.d/lock-blank-timeout-test.sh
@@ -15,13 +15,13 @@ assert(
 )
 
 assert(
-  /interval: root\.blankTimeoutSeconds \* 1000/.test(serviceQml),
+  /interval:\s*root\.blankTimeoutSeconds\s*\*\s*1000/.test(serviceQml),
   'the blank timer takes its interval from the configured seconds'
 )
 
 assert(
-  /isFinite\(seconds\) && seconds >= 0 \? Math\.floor\(seconds\) : 5/.test(serviceQml),
-  'invalid or missing config falls back to the 5-second default'
+  /defaultBlankSeconds:\s*5\b/.test(serviceQml),
+  'the QML fallback keeps the 5-second default'
 )
 
 assertEqual(shellDefaults.idle.lockBlank, 5, 'the shipped default keeps the 5-second blank')


### PR DESCRIPTION
## Summary

- read `idle.lockBlank` from shell.json for the seconds the unlock screen stays lit without input before the display blanks
- keep the current 5-second behavior as the default and validate the value the same way the idle service reads its timeouts
- document the default in the shipped shell.json

Opening the lid on a machine that locks before suspend gives you exactly 5 seconds of password prompt before the backlight drops. That is the right default, but on a desk with an external keyboard it can feel abrupt; this makes it a one-line config change instead of a fork of the lock service.

## Verification

- `bash test/shell.d/lock-blank-timeout-test.sh`
- `bash test/shell.d/lock-blank-fingerprint-test.sh`
- `git diff --check`