### PR TITLE
plugin cli: force LC_ALL=C so plugin ids validate under any locale

### DIFF
--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+# Plugin ids are ASCII, and the range expressions below say so. POSIX resolves
+# ranges through the collation, not ASCII, so a locale whose alphabet omits a
+# Latin letter drops it from A-Z: tr_TR has no dotted i, lv_LV no q/w/x/y, etc.
+export LC_ALL=C
+
 PLUGINS_DIR="$HOME/.config/omarchy/plugins"
 ASSUME_YES=0
 

--- a/bin/omarchy-plugin-update
+++ b/bin/omarchy-plugin-update
@@ -6,6 +6,11 @@
 
 set -euo pipefail
 
+# Plugin ids are ASCII, and the range expressions below say so. POSIX resolves
+# ranges through the collation, not ASCII, so a locale whose alphabet omits a
+# Latin letter drops it from A-Z: tr_TR has no dotted i, lv_LV no q/w/x/y, etc.
+export LC_ALL=C
+
 export GIT_TERMINAL_PROMPT=0
 export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
 

--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -11,6 +11,11 @@
 
 set -o pipefail
 
+# Plugin ids are ASCII, and the range expressions below say so. POSIX resolves
+# ranges through the collation, not ASCII, so a locale whose alphabet omits a
+# Latin letter drops it from A-Z: tr_TR has no dotted i, lv_LV no q/w/x/y, etc.
+export LC_ALL=C
+
 fail() {
   echo "omarchy-plugin-validate: $*" >&2
   exit 1

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -115,3 +115,28 @@ output=$(validate "$dir") && fail "validate refuses an entry point file that is 
 grep -qF "entry point file not found" <<<"$output" \
   || fail "validate reports a missing file as a missing file" "$output"
 pass "validate refuses an entry point file that is not there"
+
+# Ids are checked with range expressions, and POSIX resolves ranges through
+# the collation rather than ASCII: tr_TR drops the dotted i, lv_LV has no
+# q/w/x/y. The scripts force LC_ALL=C so the answer is the same everywhere.
+# Exported here to prove the script overrides an inherited locale, not merely
+# that it works under the one the suite happens to run in.
+dir=$(write_plugin "locale-id" '["bar-widget"]' '{"barWidget":"Panel.qml"}')
+jq '.id = "io.github.woogy7.vitals"' "$dir/manifest.json" >"$dir/manifest.tmp"
+mv "$dir/manifest.tmp" "$dir/manifest.json"
+
+for locale in tr_TR.UTF-8 lv_LV.UTF-8; do
+  installed=$(locale -a 2>/dev/null | grep -ixF -e "$locale" -e "${locale/UTF-8/utf8}" | head -n1) || true
+  [[ -n $installed ]] || continue
+  LC_ALL="$installed" validate "$dir" >/dev/null \
+    || fail "validate rejects an ASCII id under $installed"
+  pass "validate accepts an ASCII id under $installed"
+done
+
+# Forcing C is what keeps the id set identical everywhere, so a non-ASCII id
+# stays rejected even where the locale would call it alphanumeric.
+jq '.id = "acme.\u0131d"' "$dir/manifest.json" >"$dir/manifest.tmp"
+mv "$dir/manifest.tmp" "$dir/manifest.json"
+validate "$dir" >/dev/null \
+  && fail "validate rejects a non-ASCII id regardless of locale"
+pass "validate rejects a non-ASCII id regardless of locale"


### PR DESCRIPTION
**Base branch:** `quattro`

### Title

```
plugin cli: force LC_ALL=C so plugin ids validate under any locale
```

### Body

---

Closes #6973, which reported this for Turkish. I hit the same bug under
Latvian, and found two more call sites.

## The bug

`omarchy plugin add` refuses valid plugins under `lv_LV.UTF-8`:

```
$ omarchy plugin add https://github.com/Woogy7/omarchy-vitals.git --enable
Cloning into '/home/jj/.config/omarchy/plugins/.add.tmp.40312'...
omarchy-plugin-validate: invalid plugin id 'io.github.woogy7.vitals'
omarchy-plugin-add: refusing to add: validation failed
```

The id is 23 clean ASCII bytes, no BOM, no CR, LF endings:

```
$ jq -r .id /tmp/vt/manifest.json | od -c
0000000   i   o   .   g   i   t   h   u   b   .   w   o   o   g   y   7
0000020   .   v   i   t   a   l   s  \n
```

`[A-Za-z0-9]` is a POSIX range expression, resolved through the current collation rather than ASCII. The Latvian alphabet is `a ā b c č d e ē f g ģ h i ī j k ķ l ļ m n ņ o p r s š t u ū v z ž` — no
**q, w, x, y** — so those letters fall outside `a-z`:

```
$ bash -c 'ID="io.github.woogy7.vitals"
[[ $ID =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] && echo "range OK" || echo "range FAIL"'
range FAIL

$ LC_ALL=C omarchy plugin validate /tmp/vt   # exit 0
```

Turkish fails on `i` for the analogous reason (dotted `İ` / dotless `ı`).

## Scope beyond the reported issue

#6973 names `omarchy-plugin-validate` only. The same expression guards two more commands, so an affected plugin installed under a different locale can also not be updated or removed:

- `bin/omarchy-plugin-validate:51`
- `bin/omarchy-plugin-remove:33`
- `bin/omarchy-plugin-update:36`

This PR fixes all three. 

## Why `LC_ALL=C` and not `[[:alnum:]]`

`[[:alnum:]]` fixes Turkish and Latvian but keeps the rule locale-dependent,
now in the permissive direction.

## Verification

Under `LANG=lv_LV.UTF-8`, after the change:

```
$ bash bin/omarchy-plugin-validate /tmp/vt; and echo PASS; or echo FAIL
PASS

$ for id in "a..b" "omarchy.x" "acme.ıd"; ...
omarchy-plugin-validate: invalid plugin id 'a..b'
a..b rejected-ok
omarchy-plugin-validate: plugin id 'omarchy.x' uses the reserved omarchy.* namespace
omarchy.x rejected-ok
omarchy-plugin-validate: invalid plugin id 'acme.ıd'
acme.ıd rejected-ok
```

Test suite:

```
$ bash test/shell.d/plugin-validate-test.sh | tail -4
ok - validate leaves a kind it does not know alone
ok - validate refuses an entry point file that is not there
ok - validate accepts an ASCII id under lv_LV.UTF-8
ok - validate rejects a non-ASCII id regardless of locale
```

The first of those two new cases fails without this change; the second is what
pins `LC_ALL=C` over `[[:alnum:]]` so it can't be quietly reverted.

`bash test/shell` passes in full.

**On CI:** the locale cases are guarded by `locale -a`, so on an image with only `C`/`C.UTF-8` they skip and the meaningful coverage is the non-ASCII rejection. If you want the regression genuinely enforced, the test image needs `locale-gen tr_TR.UTF-8 lv_LV.UTF-8`.

**Environment:** Omarchy `4.0.0.alpha`, bash 5.3.15(1), jq 1.8.2,
`LANG=lv_LV.UTF-8`.