### PR TITLE
Protect qt6-wayland from orphan cleanup

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -726,6 +726,7 @@ install_omarchy_quattro_packages() {
     "$omarchy_package"
     fakeroot
     pacman-contrib
+    qt6-wayland
   )
   local base_packages=()
 

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -28,6 +28,13 @@ grep -F 'omarchy-update-mise' "$upgrade_to_quattro" >/dev/null
 grep -F 'run_final_system_package_upgrade' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade completes package update checks"
 
+core_packages_body=$(sed -n '/  local core_packages=(/,/  )/p' "$upgrade_to_quattro")
+grep -Fx '    qt6-wayland' <<<"$core_packages_body" >/dev/null ||
+  fail "Omarchy 4 upgrade installs qt6-wayland as an explicit core package"
+grep -F 'mark_packages_explicit "${core_packages[@]}"' "$upgrade_to_quattro" >/dev/null ||
+  fail "Omarchy 4 upgrade marks core packages explicit"
+pass "Omarchy 4 upgrade protects qt6-wayland from orphan cleanup"
+
 grep -F 'run_post_upgrade_migrations' "$upgrade_to_quattro" >/dev/null
 grep -F 'omarchy-migrate' "$upgrade_to_quattro" >/dev/null
 grep -F 'dust' "$upgrade_to_quattro" >/dev/null

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -28,8 +28,8 @@ grep -F 'omarchy-update-mise' "$upgrade_to_quattro" >/dev/null
 grep -F 'run_final_system_package_upgrade' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade completes package update checks"
 
-core_packages_body=$(sed -n '/  local core_packages=(/,/  )/p' "$upgrade_to_quattro")
-grep -Fx '    qt6-wayland' <<<"$core_packages_body" >/dev/null ||
+core_packages_body=$(sed -n '/^[[:space:]]*local core_packages=(/,/^[[:space:]]*)$/p' "$upgrade_to_quattro")
+printf '%s\n' "$core_packages_body" | grep -Eq '^[[:space:]]*qt6-wayland$' ||
   fail "Omarchy 4 upgrade installs qt6-wayland as an explicit core package"
 grep -F 'mark_packages_explicit "${core_packages[@]}"' "$upgrade_to_quattro" >/dev/null ||
   fail "Omarchy 4 upgrade marks core packages explicit"


### PR DESCRIPTION
Fixes #7327.

`qt6-wayland` could remain dependency-marked after upgrading an existing installation to Quattro. This caused it to appear in `pacman -Qdtq`, allowing orphan cleanup to remove the Wayland platform plugin required by Quickshell and Qt6 applications.

This adds `qt6-wayland` to the upgrade's `core_packages` list. The existing installation and `mark_packages_explicit` steps now ensure the package is explicitly installed, matching fresh-install behavior.

A regression test verifies that `qt6-wayland` remains in the explicitly marked core package set.

Tested with:

- `bash test/shell.d/upgrade-to-quattro-test.sh`
- `git diff --check`