### PR TITLE
Resolve package-backed OMARCHY_PATH symlinks

### DIFF
--- a/bin/omarchy-channel-current
+++ b/bin/omarchy-channel-current
@@ -4,10 +4,15 @@
 
 set -euo pipefail
 
+resolved_omarchy_path=${OMARCHY_PATH%/}
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
+  resolved_omarchy_path=$(readlink -f "$resolved_omarchy_path" 2>/dev/null || printf '%s\n' "$resolved_omarchy_path")
+fi
+
 # Dev is a linked source checkout: OMARCHY_PATH points somewhere other than
 # the package-backed install at /usr/share/omarchy. This takes precedence over
 # the package channels, since the checkout overrides whatever is installed.
-if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
   echo dev
   exit 0
 fi

--- a/bin/omarchy-channel-set
+++ b/bin/omarchy-channel-set
@@ -44,6 +44,10 @@ link_dev_checkout() {
 dev_checkout=""
 channel="$1"
 leaving_dev=0
+resolved_omarchy_path=${OMARCHY_PATH%/}
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
+  resolved_omarchy_path=$(readlink -f "$resolved_omarchy_path" 2>/dev/null || printf '%s\n' "$resolved_omarchy_path")
+fi
 
 case "$channel" in
   stable)
@@ -72,7 +76,7 @@ case "$channel" in
     ;;
 esac
 
-if [[ -z $dev_checkout && $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
+if [[ -z $dev_checkout && $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
   leaving_dev=1
 fi
 

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -5,8 +5,12 @@
 set -euo pipefail
 
 updates=()
+resolved_omarchy_path=${OMARCHY_PATH%/}
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
+  resolved_omarchy_path=$(readlink -f "$resolved_omarchy_path" 2>/dev/null || printf '%s\n' "$resolved_omarchy_path")
+fi
 
-if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
   upstream=$(git -C "$OMARCHY_PATH" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
   if [[ -n $upstream ]]; then
     GIT_TERMINAL_PROMPT=0 timeout 10 git -C "$OMARCHY_PATH" fetch --quiet 2>/dev/null || true

--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -4,7 +4,12 @@
 
 set -euo pipefail
 
-[[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
+resolved_omarchy_path=${OMARCHY_PATH%/}
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
+  resolved_omarchy_path=$(readlink -f "$resolved_omarchy_path" 2>/dev/null || printf '%s\n' "$resolved_omarchy_path")
+fi
+
+[[ $resolved_omarchy_path != "/usr/share/omarchy" ]] || exit 0
 
 if ! git -C "$OMARCHY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Error: OMARCHY_PATH is not a git checkout: $OMARCHY_PATH" >&2

--- a/bin/omarchy-version
+++ b/bin/omarchy-version
@@ -4,8 +4,12 @@
 
 omarchy_path=${OMARCHY_PATH:-/usr/share/omarchy}
 omarchy_path=${omarchy_path%/}
-
+resolved_omarchy_path=$omarchy_path
 if [[ $omarchy_path != "/usr/share/omarchy" ]]; then
+  resolved_omarchy_path=$(readlink -f "$omarchy_path" 2>/dev/null || printf '%s\n' "$omarchy_path")
+fi
+
+if [[ $resolved_omarchy_path != "/usr/share/omarchy" ]]; then
   hash=$(git -C "$omarchy_path" rev-parse --short HEAD 2>/dev/null || true)
 
   if [[ -n $hash ]]; then

--- a/bin/omarchy-version-branch
+++ b/bin/omarchy-version-branch
@@ -5,8 +5,12 @@
 
 omarchy_path=${OMARCHY_PATH:-/usr/share/omarchy}
 omarchy_path=${omarchy_path%/}
+resolved_omarchy_path=$omarchy_path
+if [[ $omarchy_path != "/usr/share/omarchy" ]]; then
+  resolved_omarchy_path=$(readlink -f "$omarchy_path" 2>/dev/null || printf '%s\n' "$omarchy_path")
+fi
 
-[[ $omarchy_path != "/usr/share/omarchy" ]] || exit 1
+[[ $resolved_omarchy_path != "/usr/share/omarchy" ]] || exit 1
 
 branch=$(git -C "$omarchy_path" branch --show-current 2>/dev/null || true)
 if [[ -z $branch ]]; then

--- a/test/shell.d/channel-test.sh
+++ b/test/shell.d/channel-test.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 log_file="$test_tmp/channel.log"
-mkdir -p "$stub_bin" "$test_tmp/home"
+mkdir -p "$stub_bin" "$test_tmp/home" "$test_tmp/dev-checkout"
 
 write_stub() {
   local name="$1"
@@ -87,6 +87,14 @@ case "${OMARCHY_TEST_PACKAGES:-}" in
 esac
 '
 
+write_stub readlink '#!/bin/bash
+if [[ -n ${OMARCHY_TEST_RESOLVED_PATH:-} ]]; then
+  echo "$OMARCHY_TEST_RESOLVED_PATH"
+else
+  /usr/bin/readlink "$@"
+fi
+'
+
 run_channel() {
   : >"$log_file"
   OMARCHY_CHANNEL_TEST_LOG="$log_file" \
@@ -113,6 +121,13 @@ if grep -q $'^state\tset\treboot-required$' "$log_file"; then
   fail "stable does not require reboot when already package-backed" "$(cat "$log_file")"
 fi
 pass "stable does not require reboot when already package-backed"
+
+OMARCHY_TEST_PATH="$test_tmp/legacy-omarchy-link" OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy run_channel stable
+unset OMARCHY_TEST_RESOLVED_PATH
+if grep -q $'^state\tset\treboot-required$' "$log_file"; then
+  fail "stable does not require reboot through the legacy Omarchy path symlink" "$(cat "$log_file")"
+fi
+pass "channel changes recognize the legacy Omarchy path symlink"
 
 run_channel rc
 assert_log_line $'refresh\trc' "rc refreshes the rc pacman channel"
@@ -182,6 +197,11 @@ pass "current channel detects rc"
 
 [[ $(current_channel edge dev /usr/share/omarchy) == "edge" ]] || fail "current channel detects package-backed edge"
 pass "current channel detects package-backed edge"
+
+[[ $(OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy current_channel stable stable "$test_tmp/legacy-omarchy-link") == "stable" ]] ||
+  fail "current channel recognizes the legacy Omarchy path symlink"
+unset OMARCHY_TEST_RESOLVED_PATH
+pass "current channel recognizes the legacy Omarchy path symlink"
 
 [[ $(current_channel edge dev "$test_tmp/dev-checkout") == "dev" ]] || fail "current channel detects dev from OMARCHY_PATH"
 pass "current channel honors a dev link outside ~/omarchy"

--- a/test/shell.d/channel-test.sh
+++ b/test/shell.d/channel-test.sh
@@ -91,7 +91,7 @@ write_stub readlink '#!/bin/bash
 if [[ -n ${OMARCHY_TEST_RESOLVED_PATH:-} ]]; then
   echo "$OMARCHY_TEST_RESOLVED_PATH"
 else
-  /usr/bin/readlink "$@"
+  command -p readlink "$@"
 fi
 '
 
@@ -123,7 +123,6 @@ fi
 pass "stable does not require reboot when already package-backed"
 
 OMARCHY_TEST_PATH="$test_tmp/legacy-omarchy-link" OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy run_channel stable
-unset OMARCHY_TEST_RESOLVED_PATH
 if grep -q $'^state\tset\treboot-required$' "$log_file"; then
   fail "stable does not require reboot through the legacy Omarchy path symlink" "$(cat "$log_file")"
 fi
@@ -200,7 +199,6 @@ pass "current channel detects package-backed edge"
 
 [[ $(OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy current_channel stable stable "$test_tmp/legacy-omarchy-link") == "stable" ]] ||
   fail "current channel recognizes the legacy Omarchy path symlink"
-unset OMARCHY_TEST_RESOLVED_PATH
 pass "current channel recognizes the legacy Omarchy path symlink"
 
 [[ $(current_channel edge dev "$test_tmp/dev-checkout") == "dev" ]] || fail "current channel detects dev from OMARCHY_PATH"

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 git_log="$test_tmp/git.log"
-mkdir -p "$stub_bin"
+mkdir -p "$stub_bin" "$test_tmp/checkout"
 
 cat >"$stub_bin/checkupdates" <<'SH'
 #!/bin/bash
@@ -90,6 +90,16 @@ esac
 SH
 chmod +x "$stub_bin/git"
 
+cat >"$stub_bin/readlink" <<'SH'
+#!/bin/bash
+if [[ -n ${TEST_RESOLVED_OMARCHY_PATH:-} ]]; then
+  echo "$TEST_RESOLVED_OMARCHY_PATH"
+else
+  /usr/bin/readlink "$@"
+fi
+SH
+chmod +x "$stub_bin/readlink"
+
 run_checker() {
   OMARCHY_PATH="${TEST_OMARCHY_PATH:-/usr/share/omarchy}" \
     TEST_GIT_LOG="$git_log" \
@@ -147,6 +157,18 @@ fi
 grep -q '^omarchy-dev ' "$stdout" || fail "update checker prints omarchy-dev when both packages are installed"
 ! grep -q '^omarchy ' "$stdout" || fail "update checker ignores omarchy when omarchy-dev is installed"
 pass "update checker prefers omarchy-dev over omarchy"
+
+: >"$git_log"
+if TEST_OMARCHY_PATH="$test_tmp/legacy-omarchy-link" TEST_RESOLVED_OMARCHY_PATH=/usr/share/omarchy \
+  capture_checker "$stdout" "$stderr" TEST_CHECKUPDATES=updates TEST_INSTALLED_PACKAGE=omarchy; then
+  status=0
+else
+  status=$?
+fi
+unset TEST_RESOLVED_OMARCHY_PATH
+[[ $status -eq 0 ]] || fail "update checker handles the legacy Omarchy path symlink"
+[[ ! -s $git_log ]] || fail "update checker does not inspect the legacy Omarchy path symlink as git" "$(cat "$git_log")"
+pass "update checker recognizes the legacy Omarchy path symlink"
 
 if capture_checker "$stdout" "$stderr" TEST_CHECKUPDATES=updates TEST_INSTALLED_PACKAGE=none; then
   status=0

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -95,7 +95,7 @@ cat >"$stub_bin/readlink" <<'SH'
 if [[ -n ${TEST_RESOLVED_OMARCHY_PATH:-} ]]; then
   echo "$TEST_RESOLVED_OMARCHY_PATH"
 else
-  /usr/bin/readlink "$@"
+  command -p readlink "$@"
 fi
 SH
 chmod +x "$stub_bin/readlink"
@@ -165,7 +165,6 @@ if TEST_OMARCHY_PATH="$test_tmp/legacy-omarchy-link" TEST_RESOLVED_OMARCHY_PATH=
 else
   status=$?
 fi
-unset TEST_RESOLVED_OMARCHY_PATH
 [[ $status -eq 0 ]] || fail "update checker handles the legacy Omarchy path symlink"
 [[ ! -s $git_log ]] || fail "update checker does not inspect the legacy Omarchy path symlink as git" "$(cat "$git_log")"
 pass "update checker recognizes the legacy Omarchy path symlink"

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -51,7 +51,7 @@ cat >"$stub_bin/readlink" <<'SH'
 if [[ -n ${TEST_RESOLVED_OMARCHY_PATH:-} ]]; then
   echo "$TEST_RESOLVED_OMARCHY_PATH"
 else
-  /usr/bin/readlink "$@"
+  command -p readlink "$@"
 fi
 SH
 chmod +x "$stub_bin/readlink"

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -46,6 +46,16 @@ esac
 SH
 chmod +x "$stub_bin/git"
 
+cat >"$stub_bin/readlink" <<'SH'
+#!/bin/bash
+if [[ -n ${TEST_RESOLVED_OMARCHY_PATH:-} ]]; then
+  echo "$TEST_RESOLVED_OMARCHY_PATH"
+else
+  /usr/bin/readlink "$@"
+fi
+SH
+chmod +x "$stub_bin/readlink"
+
 run_dev_update() {
   OMARCHY_PATH="$1" \
     TEST_GIT_LOG="$git_log" \
@@ -57,6 +67,11 @@ run_dev_update() {
 run_dev_update /usr/share/omarchy
 [[ ! -s $git_log ]] || fail "package-backed updates do not invoke git" "$(cat "$git_log")"
 pass "package-backed updates skip the dev checkout step"
+
+: >"$git_log"
+TEST_RESOLVED_OMARCHY_PATH=/usr/share/omarchy run_dev_update "$test_tmp/legacy-omarchy-link"
+[[ ! -s $git_log ]] || fail "resolved package-backed updates do not invoke git" "$(cat "$git_log")"
+pass "package-backed updates recognize the legacy Omarchy path symlink"
 
 : >"$git_log"
 run_dev_update "$checkout"

--- a/test/shell.d/version-test.sh
+++ b/test/shell.d/version-test.sh
@@ -29,6 +29,16 @@ exit 1
 STUB
 chmod +x "$stub_bin/pacman"
 
+cat >"$stub_bin/readlink" <<'STUB'
+#!/bin/bash
+if [[ -n ${OMARCHY_TEST_RESOLVED_PATH:-} ]]; then
+  echo "$OMARCHY_TEST_RESOLVED_PATH"
+else
+  /usr/bin/readlink "$@"
+fi
+STUB
+chmod +x "$stub_bin/readlink"
+
 version() {
   OMARCHY_TEST_PACKAGES="$1" \
     OMARCHY_PATH="${2:-/usr/share/omarchy}" \
@@ -41,6 +51,14 @@ pass "version reports the stable package"
 
 [[ $(version omarchy-dev) == "4.0.0-1" ]] || fail "version reports the edge package"
 pass "version reports the edge package"
+
+[[ $(OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy version omarchy "$test_tmp/legacy-omarchy-link") == "4.0.0-1" ]] ||
+  fail "version recognizes the legacy Omarchy path symlink"
+if OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy OMARCHY_PATH="$test_tmp/legacy-omarchy-link" \
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-version-branch" >/dev/null 2>&1; then
+  fail "version branch rejects the legacy Omarchy path symlink"
+fi
+pass "version commands recognize the legacy Omarchy path symlink"
 
 # A checkout reports its hash instead, so packages are irrelevant there.
 [[ $(version "" "$test_tmp/checkout") == "dev" ]] || fail "version reports a dev checkout"

--- a/test/shell.d/version-test.sh
+++ b/test/shell.d/version-test.sh
@@ -34,7 +34,7 @@ cat >"$stub_bin/readlink" <<'STUB'
 if [[ -n ${OMARCHY_TEST_RESOLVED_PATH:-} ]]; then
   echo "$OMARCHY_TEST_RESOLVED_PATH"
 else
-  /usr/bin/readlink "$@"
+  command -p readlink "$@"
 fi
 STUB
 chmod +x "$stub_bin/readlink"

--- a/test/shell.d/version-test.sh
+++ b/test/shell.d/version-test.sh
@@ -8,6 +8,7 @@ test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
+git_log="$test_tmp/git.log"
 mkdir -p "$stub_bin"
 
 # The edge channel installs omarchy-dev. Older builds did not declare
@@ -29,6 +30,15 @@ exit 1
 STUB
 chmod +x "$stub_bin/pacman"
 
+# Fails the way a non-checkout does, so only the log distinguishes a package-backed
+# path that skipped git from one that asked git and got nothing.
+cat >"$stub_bin/git" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_GIT_LOG"
+exit 1
+STUB
+chmod +x "$stub_bin/git"
+
 cat >"$stub_bin/readlink" <<'STUB'
 #!/bin/bash
 if [[ -n ${OMARCHY_TEST_RESOLVED_PATH:-} ]]; then
@@ -42,6 +52,7 @@ chmod +x "$stub_bin/readlink"
 version() {
   OMARCHY_TEST_PACKAGES="$1" \
     OMARCHY_PATH="${2:-/usr/share/omarchy}" \
+    TEST_GIT_LOG="$git_log" \
     PATH="$stub_bin:$PATH" \
     "$ROOT/bin/omarchy-version"
 }
@@ -54,10 +65,13 @@ pass "version reports the edge package"
 
 [[ $(OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy version omarchy "$test_tmp/legacy-omarchy-link") == "4.0.0-1" ]] ||
   fail "version recognizes the legacy Omarchy path symlink"
+: >"$git_log"
 if OMARCHY_TEST_RESOLVED_PATH=/usr/share/omarchy OMARCHY_PATH="$test_tmp/legacy-omarchy-link" \
-  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-version-branch" >/dev/null 2>&1; then
+  TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-version-branch" >/dev/null 2>&1; then
   fail "version branch rejects the legacy Omarchy path symlink"
 fi
+[[ ! -s $git_log ]] ||
+  fail "version branch does not inspect the legacy Omarchy path symlink as git" "$(cat "$git_log")"
 pass "version commands recognize the legacy Omarchy path symlink"
 
 # A checkout reports its hash instead, so packages are irrelevant there.


### PR DESCRIPTION
Fixes #7390.

After upgrading to Quattro, existing terminals can retain the legacy
`OMARCHY_PATH=$HOME/.local/share/omarchy` value. The upgrader keeps this path
working as a symlink to `/usr/share/omarchy`, but six commands compared the
unresolved string directly and incorrectly treated it as a dev checkout.

This resolves `OMARCHY_PATH` before classifying the installation while keeping
the original configured path for actual git operations. If path resolution
fails, the existing behavior is preserved.

Regression coverage verifies the legacy package-backed symlink behavior for:

- dev checkout updates
- version and branch reporting
- channel detection and switching
- update availability checks

Tested with:

- `bash test/shell.d/update-dev-test.sh`
- `bash test/shell.d/version-test.sh`
- `bash test/shell.d/channel-test.sh`
- `bash test/shell.d/bin-style-test.sh`
- Bash syntax checks for all changed scripts and tests
- `git diff --check`

The `update-available` regression case passes; the remainder of that test file
requires GNU `timeout`, which is unavailable in the macOS test environment.