### PR TITLE
Prevent duplicate agents widget during migration

### DIFF
--- a/migrations/1785344985.sh
+++ b/migrations/1785344985.sh
@@ -38,7 +38,7 @@ if [[ -s $config_file ]]; then
 
     # Respect a bar the user already curated: only place the widget when it is
     # absent from every section, never a second copy.
-    if has_widget("omarchy.agents") then
+    if has_widget("omarchy.agents") or has_widget("omarchy.model-usage") then
       .
     else
       .bar.layout.right |= insert_after("omarchy.tray"; { id: "omarchy.agents" })

--- a/test/shell.d/agents-default-migration-test.sh
+++ b/test/shell.d/agents-default-migration-test.sh
@@ -7,6 +7,7 @@ source "$(dirname "$0")/base-test.sh"
 require_command jq
 
 migration="$ROOT/migrations/1785344985.sh"
+rename_migration="$ROOT/migrations/1786099804.sh"
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
 
@@ -16,6 +17,10 @@ cat >"$test_dir/bin/omarchy-restart-shell" <<'STUB'
 #!/bin/bash
 
 echo restart >>"$SHELL_RESTARTS"
+STUB
+
+cat >"$test_dir/bin/omarchy-agent-usage-update" <<'STUB'
+#!/bin/bash
 STUB
 
 chmod +x "$test_dir/bin/"*
@@ -77,6 +82,18 @@ run_migration
 [[ $(ids center) == *'"omarchy.agents"'* ]] || fail "migration leaves a user-placed widget alone" "$(ids center)"
 [[ $(ids right) != *'"omarchy.agents"'* ]] || fail "migration does not add a second copy" "$(ids right)"
 pass "migration respects a widget the user already placed"
+
+# A user who placed the widget under its former id before the rename migration
+# must not get a new agents entry that the later migration turns into a duplicate.
+write_config "$without_widget | .bar.layout.center += [{ id: \"omarchy.model-usage\" }]"
+run_migration
+
+[[ $(ids center) == *'"omarchy.model-usage"'* ]] || fail "migration leaves the former widget id alone" "$(ids center)"
+[[ $(ids right) != *'"omarchy.agents"'* ]] || fail "migration does not add an agents copy beside the former widget id" "$(ids right)"
+HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$rename_migration" >/dev/null
+[[ $(jq '[.bar.layout[][]? | if type == "object" then .id else . end] | map(select(. == "omarchy.agents")) | length' "$config") == 1 ]] ||
+  fail "migration sequence leaves exactly one agents widget" "$(jq -c '.bar.layout' "$config")"
+pass "migration sequence recognizes and renames the former model usage widget once"
 
 # Layouts written before entries grew options are bare id strings.
 write_config "$without_widget | .bar.layout.right = [\"omarchy.tray\", \"omarchy.agents\", \"omarchy.power\"]"

--- a/test/shell.d/agents-default-migration-test.sh
+++ b/test/shell.d/agents-default-migration-test.sh
@@ -31,8 +31,10 @@ home="$test_dir/home"
 config="$home/.config/omarchy/shell.json"
 
 run_migration() {
+  local migration_path="${1:-$migration}"
+
   : >"$SHELL_RESTARTS"
-  HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+  HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$migration_path" >/dev/null
 }
 
 # The shipped default minus the widget is what every machine installed before
@@ -90,7 +92,7 @@ run_migration
 
 [[ $(ids center) == *'"omarchy.model-usage"'* ]] || fail "migration leaves the former widget id alone" "$(ids center)"
 [[ $(ids right) != *'"omarchy.agents"'* ]] || fail "migration does not add an agents copy beside the former widget id" "$(ids right)"
-HOME="$home" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$rename_migration" >/dev/null
+run_migration "$rename_migration"
 [[ $(jq '[.bar.layout[][]? | if type == "object" then .id else . end] | map(select(. == "omarchy.agents")) | length' "$config") == 1 ]] ||
   fail "migration sequence leaves exactly one agents widget" "$(jq -c '.bar.layout' "$config")"
 pass "migration sequence recognizes and renames the former model usage widget once"


### PR DESCRIPTION
Fixes #7128.

An unmarked installation can already contain the former
`omarchy.model-usage` widget when the agents-widget migration runs. That
migration only checked for `omarchy.agents`, so it added a new entry. The later
rename migration then converted the former entry to the same id, leaving two
`omarchy.agents` widgets.

This makes the placement migration recognize both the current and former widget
ids before adding anything.

The regression test runs the placement and rename migrations in sequence and
verifies that exactly one `omarchy.agents` widget remains.

Tested with:

- `bash test/shell.d/agents-default-migration-test.sh`
- `bash test/shell.d/agents-rename-migration-test.sh`
- Bash syntax checks for the changed migration and test
- `git diff --check`