### PR TITLE
Make stateful regression tests self-contained

### DIFF
--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -59,8 +59,10 @@ grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "mo
 pass "monitor scaling down recovers 3x to 2x"
 
 write_monitor_config
+: >"$eval_out"
 OMARCHY_TEST_MONITOR_SCALE=3.0000000000000004 run_scaling down
-grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down snaps floating point 3x to 2x"
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "2880x1800@120.0", position = "auto", scale = 2 })' "$eval_out" >/dev/null ||
+  fail "monitor scaling down snaps floating point 3x to 2x"
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling down persists 2x from floating point 3x"
 pass "monitor scaling down snaps floating point 3x to 2x"
 

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -59,9 +59,10 @@ grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "mo
 pass "monitor scaling down recovers 3x to 2x"
 
 write_monitor_config
-: >"$eval_out"
+: >|"$eval_out"
 OMARCHY_TEST_MONITOR_SCALE=3.0000000000000004 run_scaling down
-grep -Fx 'hl.monitor({ output = "eDP-1", mode = "2880x1800@120.0", position = "auto", scale = 2 })' "$eval_out" >/dev/null ||
+(( $(wc -l <"$eval_out") == 1 )) || fail "monitor scaling down emits exactly one monitor command"
+grep -Eq 'output[[:space:]]*=[[:space:]]*"eDP-1".*scale[[:space:]]*=[[:space:]]*2[[:space:]]*}' "$eval_out" ||
   fail "monitor scaling down snaps floating point 3x to 2x"
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling down persists 2x from floating point 3x"
 pass "monitor scaling down snaps floating point 3x to 2x"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -62,7 +62,7 @@ write_monitor_config
 : >|"$eval_out"
 OMARCHY_TEST_MONITOR_SCALE=3.0000000000000004 run_scaling down
 (( $(wc -l <"$eval_out") == 1 )) || fail "monitor scaling down emits exactly one monitor command"
-grep -Eq 'output[[:space:]]*=[[:space:]]*"eDP-1".*scale[[:space:]]*=[[:space:]]*2[[:space:]]*}' "$eval_out" ||
+grep -Eq 'scale[[:space:]]*=[[:space:]]*2([[:space:],}]|$)' "$eval_out" ||
   fail "monitor scaling down snaps floating point 3x to 2x"
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling down persists 2x from floating point 3x"
 pass "monitor scaling down snaps floating point 3x to 2x"

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -43,12 +43,12 @@ reset_calls_log() {
 reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-set" ac balanced
 [[ $(<"$tmp_dir/state/ac") == "balanced" ]] || fail "power profile stores AC preference"
-[[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile applies selected AC preference"
+[[ $(tail -n 1 "$POWERPROFILES_LOG") == "balanced" ]] || fail "power profile applies selected AC preference"
 pass "power profile stores and applies AC preference"
 
 reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-set" ac
-[[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile restores AC preference"
+[[ $(tail -n 1 "$POWERPROFILES_LOG") == "balanced" ]] || fail "power profile restores AC preference"
 pass "power profile restores AC preference"
 
 if POWERPROFILES_SET_FAIL=1 "$ROOT/bin/omarchy-powerprofiles-set" ac performance; then
@@ -63,24 +63,24 @@ pass "power profile stores battery preference separately"
 
 reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-set" ac
-[[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "battery preference does not replace AC preference"
+[[ $(tail -n 1 "$POWERPROFILES_LOG") == "balanced" ]] || fail "battery preference does not replace AC preference"
 pass "power profile keeps AC and battery preferences separate"
 
 reset_calls_log
 ON_BATTERY=1 "$ROOT/bin/omarchy-powerprofiles-set"
-[[ $(tail -n 1 "$tmp_dir/calls") == "performance" ]] || fail "autodetect restores battery preference"
+[[ $(tail -n 1 "$POWERPROFILES_LOG") == "performance" ]] || fail "autodetect restores battery preference"
 pass "power profile autodetect restores battery preference"
 
 rm "$tmp_dir/state/ac"
 reset_calls_log
 ON_BATTERY=0 "$ROOT/bin/omarchy-powerprofiles-set"
-[[ $(tail -n 1 "$tmp_dir/calls") == "performance" ]] || fail "power profile uses performance as AC default"
+[[ $(tail -n 1 "$POWERPROFILES_LOG") == "performance" ]] || fail "power profile uses performance as AC default"
 pass "power profile retains performance as AC default"
 
 "$ROOT/bin/omarchy-powerprofiles-set" ac power-saver
 reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-init"
-[[ $(tail -n 1 "$tmp_dir/calls") == "power-saver" ]] || fail "init restores the autodetected preference"
+[[ $(tail -n 1 "$POWERPROFILES_LOG") == "power-saver" ]] || fail "init restores the autodetected preference"
 pass "power profile init restores the autodetected preference"
 
 rg -F '["omarchy-powerprofiles-set", pendingPowerSource]' "$ROOT/shell/plugins/services/battery/Service.qml" >/dev/null ||

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -36,13 +36,17 @@ export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
 export POWERPROFILES_LOG="$tmp_dir/calls"
 export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
 
-: >"$POWERPROFILES_LOG"
+reset_calls_log() {
+  : >|"$POWERPROFILES_LOG"
+}
+
+reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-set" ac balanced
 [[ $(<"$tmp_dir/state/ac") == "balanced" ]] || fail "power profile stores AC preference"
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile applies selected AC preference"
 pass "power profile stores and applies AC preference"
 
-: >"$POWERPROFILES_LOG"
+reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-set" ac
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile restores AC preference"
 pass "power profile restores AC preference"
@@ -57,24 +61,24 @@ pass "power profile persists only successful selections"
 [[ $(<"$tmp_dir/state/battery") == "performance" ]] || fail "power profile stores battery preference"
 pass "power profile stores battery preference separately"
 
-: >"$POWERPROFILES_LOG"
+reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-set" ac
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "battery preference does not replace AC preference"
 pass "power profile keeps AC and battery preferences separate"
 
-: >"$POWERPROFILES_LOG"
+reset_calls_log
 ON_BATTERY=1 "$ROOT/bin/omarchy-powerprofiles-set"
 [[ $(tail -n 1 "$tmp_dir/calls") == "performance" ]] || fail "autodetect restores battery preference"
 pass "power profile autodetect restores battery preference"
 
 rm "$tmp_dir/state/ac"
-: >"$POWERPROFILES_LOG"
+reset_calls_log
 ON_BATTERY=0 "$ROOT/bin/omarchy-powerprofiles-set"
 [[ $(tail -n 1 "$tmp_dir/calls") == "performance" ]] || fail "power profile uses performance as AC default"
 pass "power profile retains performance as AC default"
 
 "$ROOT/bin/omarchy-powerprofiles-set" ac power-saver
-: >"$POWERPROFILES_LOG"
+reset_calls_log
 "$ROOT/bin/omarchy-powerprofiles-init"
 [[ $(tail -n 1 "$tmp_dir/calls") == "power-saver" ]] || fail "init restores the autodetected preference"
 pass "power profile init restores the autodetected preference"

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -36,11 +36,13 @@ export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
 export POWERPROFILES_LOG="$tmp_dir/calls"
 export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
 
+: >"$POWERPROFILES_LOG"
 "$ROOT/bin/omarchy-powerprofiles-set" ac balanced
 [[ $(<"$tmp_dir/state/ac") == "balanced" ]] || fail "power profile stores AC preference"
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile applies selected AC preference"
 pass "power profile stores and applies AC preference"
 
+: >"$POWERPROFILES_LOG"
 "$ROOT/bin/omarchy-powerprofiles-set" ac
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile restores AC preference"
 pass "power profile restores AC preference"
@@ -55,20 +57,24 @@ pass "power profile persists only successful selections"
 [[ $(<"$tmp_dir/state/battery") == "performance" ]] || fail "power profile stores battery preference"
 pass "power profile stores battery preference separately"
 
+: >"$POWERPROFILES_LOG"
 "$ROOT/bin/omarchy-powerprofiles-set" ac
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "battery preference does not replace AC preference"
 pass "power profile keeps AC and battery preferences separate"
 
+: >"$POWERPROFILES_LOG"
 ON_BATTERY=1 "$ROOT/bin/omarchy-powerprofiles-set"
 [[ $(tail -n 1 "$tmp_dir/calls") == "performance" ]] || fail "autodetect restores battery preference"
 pass "power profile autodetect restores battery preference"
 
 rm "$tmp_dir/state/ac"
+: >"$POWERPROFILES_LOG"
 ON_BATTERY=0 "$ROOT/bin/omarchy-powerprofiles-set"
 [[ $(tail -n 1 "$tmp_dir/calls") == "performance" ]] || fail "power profile uses performance as AC default"
 pass "power profile retains performance as AC default"
 
 "$ROOT/bin/omarchy-powerprofiles-set" ac power-saver
+: >"$POWERPROFILES_LOG"
 "$ROOT/bin/omarchy-powerprofiles-init"
 [[ $(tail -n 1 "$tmp_dir/calls") == "power-saver" ]] || fail "init restores the autodetected preference"
 pass "power profile init restores the autodetected preference"


### PR DESCRIPTION
Fixes #7121.

Two stateful regression checks could pass using output produced by an earlier test case.

The monitor scaling test now clears the previous Hyprland evaluation output, verifies that exactly one command was emitted, and checks the relevant output and scale fields without depending on exact formatting.

The power profile tests now reset their call log through a shared helper before each command under test, ensuring every assertion observes a call produced by that specific scenario.

Tested with:

- `bash test/shell.d/monitor-scaling-test.sh`
- Bash syntax checks for both changed tests
- `git diff --check`

The power profile test requires the project's Bash 5/GNU environment and cannot run fully under macOS's system Bash 3.2.