### PR TITLE
Make snapshot recovery and boot setup work on non-Btrfs roots

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Create or restore system snapshots with snapper
+# omarchy:summary=Create or restore system snapshots
 # omarchy:args=<create|restore>
 # omarchy:requires-sudo=true
 
@@ -13,37 +13,72 @@ if [[ -z $COMMAND ]]; then
   exit 1
 fi
 
-if omarchy-cmd-missing snapper; then
-  exit 127 # omarchy-update can use this to just ignore if snapper is not available
-fi
+# Recovery snapshots are filesystem-specific: Snapper drives Btrfs subvolumes,
+# and Timeshift (rsync mode) is the fallback for non-Btrfs roots. Which tool a
+# machine needs depends on findmnt, so its absence is only a problem when the
+# active path actually requires it. Tests pin the detection explicitly.
+root_fstype="${OMARCHY_SNAPSHOT_FSTYPE:-$(findmnt -no FSTYPE / 2>/dev/null || true)}"
 
 case "$COMMAND" in
 create)
   # The description is just a label, so never let it abort the snapshot.
   DESC="$(omarchy-version 2>/dev/null || echo unknown)"
 
-  # Get existing snapper config names from CSV output
-  mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
+  if [[ $root_fstype == "btrfs" ]]; then
+    if omarchy-cmd-missing snapper; then
+      exit 127 # omarchy-update can use this to just ignore if snapper is not available
+    fi
 
-  # Snapper installed but unconfigured snapshots nothing. Staying quiet here
-  # reads as a successful snapshot, so the next update looks recoverable when
-  # nothing has ever been captured.
-  if (( ${#CONFIGS[@]} == 0 )); then
-    echo -e "\e[33mNo Snapper configs found, so no snapshot was created.\e[0m" >&2
-    echo "Configure Snapper with: sudo bash -euo pipefail \"$OMARCHY_PATH/install/config/snapper.sh\"" >&2
-    exit 1
+    # Get existing snapper config names from CSV output
+    mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
+
+    # Snapper installed but unconfigured snapshots nothing. Staying quiet here
+    # reads as a successful snapshot, so the next update looks recoverable when
+    # nothing has ever been captured.
+    if (( ${#CONFIGS[@]} == 0 )); then
+      echo -e "\e[33mNo Snapper configs found, so no snapshot was created.\e[0m" >&2
+      echo "Configure Snapper with: sudo bash -euo pipefail \"$OMARCHY_PATH/install/config/snapper.sh\"" >&2
+      exit 1
+    fi
+
+    echo -e "\e[32mCreate system snapshot\e[0m"
+
+    for config in "${CONFIGS[@]}"; do
+      sudo snapper -c "$config" create -c number -d "$DESC"
+      sudo snapper -c "$config" cleanup number
+    done
+
+    echo "Snapshots can be selected during boot."
+  else
+    if omarchy-cmd-missing timeshift; then
+      exit 127 # omarchy-update can use this to just ignore if timeshift is not available
+    fi
+
+    # Timeshift refuses to create a snapshot when no snapshot location has been
+    # configured yet, so present the normal setup step instead of failing.
+    if ! sudo test -f "${OMARCHY_TIMESHIFT_CONFIG:-/etc/timeshift/timeshift.json}"; then
+      echo -e "\e[33mTimeshift is not configured; run 'sudo timeshift-wizard' once to pick a snapshot location.\e[0m" >&2
+      exit 1
+    fi
+
+    echo -e "\e[32mCreate system snapshot\e[0m"
+    sudo timeshift --create --comments "pre-update $DESC"
+
+    echo "Snapshots can be restored from Timeshift. Btrfs boot-menu restore is not available on $root_fstype."
   fi
-
-  echo -e "\e[32mCreate system snapshot\e[0m"
-
-  for config in "${CONFIGS[@]}"; do
-    sudo snapper -c "$config" create -c number -d "$DESC"
-    sudo snapper -c "$config" cleanup number
-  done
-
-  echo "Snapshots can be selected during boot."
   ;;
 restore)
-  sudo limine-snapper-restore
+  if [[ $root_fstype == "btrfs" ]]; then
+    if omarchy-cmd-missing limine-snapper-restore; then
+      exit 127
+    fi
+    sudo limine-snapper-restore
+  else
+    if omarchy-cmd-missing timeshift; then
+      exit 127
+    fi
+    echo "Launching Timeshift to restore a snapshot (no Btrfs boot-menu restore on $root_fstype)." >&2
+    sudo timeshift --restore
+  fi
   ;;
 esac

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -21,6 +21,7 @@ Options:
   --dev                     Use dev packages [omarchy-dev / omarchy-settings-dev] (uses edge channel)
   --channel stable|rc|edge  Override the default stable Omarchy package channel
   --user USER               User account to refresh after package install
+  --no-recovery-check       Skip the pre-upgrade recovery snapshot requirement on non-Btrfs roots
   -h, --help                Show this help
 USAGE
 }
@@ -75,6 +76,7 @@ yes=0
 auto_reboot=0
 boot_cmdline_unsafe=0
 use_dev_packages=${OMARCHY_UPGRADE_DEV:-0}
+skip_recovery_check=0
 
 while (($#)); do
   case "$1" in
@@ -88,6 +90,10 @@ while (($#)); do
       ;;
     --dev)
       use_dev_packages=1
+      shift
+      ;;
+    --no-recovery-check)
+      skip_recovery_check=1
       shift
       ;;
     --channel)
@@ -639,6 +645,35 @@ configure_snapper_policy() {
 
   log "Configuring Omarchy snapshot retention"
   as_root env OMARCHY_PATH=/usr/share/omarchy bash -euo pipefail "$snapper_config_script"
+
+  # On non-Btrfs roots the configured recovery mechanism is Timeshift (rsync),
+  # not Snapper. Omarchy would rather hold a one-way upgrade than run without
+  # any pre-update recovery snapshot, so offer to install Timeshift when it is
+  # missing and abort if the user declines.
+  local root_fstype
+  root_fstype="$(as_root findmnt -no FSTYPE / 2>/dev/null || true)"
+  if [[ $root_fstype == "btrfs" || $root_fstype == "" ]]; then
+    return 0
+  fi
+
+  if as_root command -v timeshift >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if (( skip_recovery_check )); then
+    warn "Skipping the non-Btrfs recovery snapshot requirement because --no-recovery-check was passed; no pre-update recovery snapshot will be available."
+    return 0
+  fi
+
+  warn "This system's root filesystem ($root_fstype) cannot use Btrfs snapshots, so Omarchy relies on Timeshift for pre-update recovery."
+  if (( yes )) || gum confirm </dev/tty "Install Timeshift so the upgrade can create a recovery snapshot before it starts?"; then
+    log "Installing Timeshift"
+    if ! as_root pacman -S --noconfirm timeshift; then
+      fail "Timeshift could not be installed. Install it manually and re-run the upgrade, or re-run with --no-recovery-check to proceed without a recovery snapshot."
+    fi
+  else
+    fail "Timeshift is required to capture a pre-update recovery snapshot on a non-Btrfs root. Install it and re-run the upgrade, or re-run with --no-recovery-check to proceed without one."
+  fi
 }
 
 configure_lock_authentication() {

--- a/etc/mkinitcpio.conf.d/omarchy_hooks.conf
+++ b/etc/mkinitcpio.conf.d/omarchy_hooks.conf
@@ -1,4 +1,33 @@
-HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
+# Be filesystem and storage-layout aware. The initramfs can only assemble the
+# root device if the hooks it needs are present: lvm2 when the root lives on an
+# LVM volume group, encrypt when it sits on dm-crypt, and btrfs-overlayfs only
+# for btrfs roots. Scheme: [early] block <storage hooks> filesystems fsck.
+# mkinitcpio sources this file in the same shell as the other drop-ins, so the
+# values computed here are carried into final HOOKS.
+HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block)
+
+root_device="$(findmnt -no SOURCE / 2>/dev/null || true)"
+root_fstype="$(findmnt -no FSTYPE / 2>/dev/null || true)"
+
+# Resolve the full device stack so LVM-on-LUKS, LUKS inside LVM, and a plain
+# LUKS or LVM root all flip the right hooks on.
+root_stack="$(lsblk -rno TYPE "$root_device" 2>/dev/null || true)"
+
+case "$root_stack" in
+  *lvm*)
+    HOOKS+=(lvm2) ;;
+esac
+
+case "$root_stack" in
+  *crypt*)
+    HOOKS+=(encrypt) ;;
+esac
+
+if [[ $root_fstype == "btrfs" ]]; then
+  HOOKS+=(btrfs-overlayfs)
+fi
+
+HOOKS+=(filesystems fsck)
 
 # The proprietary NVIDIA driver does early KMS itself: nvidia.conf (written by
 # install/hardware/nvidia.sh, sourced before this file) early-loads nvidia_drm

--- a/install/config/snapper.sh
+++ b/install/config/snapper.sh
@@ -2,23 +2,50 @@ SNAPPER_CONFIG_PATH="${OMARCHY_SNAPPER_CONFIG_PATH:-/etc/snapper/configs/root}"
 SNAPPER_CONF_PATH="${OMARCHY_SNAPPER_CONF_PATH:-/etc/conf.d/snapper}"
 template="${OMARCHY_SNAPPER_TEMPLATE:-${OMARCHY_PATH:-/usr/share/omarchy}/default/snapper/root}"
 
-echo "Configuring Omarchy Snapper snapshot retention"
+# Recovery snapshots are filesystem-specific. Btrfs has native subvolumes, so
+# Snapper and Limine snapshot boot entries work; any other filesystem falls
+# back to rsync snapshots through Timeshift and keeps Snapper disabled. Allow
+# tests to pin the detection.
+root_fstype="${OMARCHY_SNAPPER_FSTYPE:-$(findmnt -no FSTYPE / 2>/dev/null || true)}"
 
-if [[ ! -f $SNAPPER_CONFIG_PATH ]]; then
-  mkdir -p "$(dirname "$SNAPPER_CONFIG_PATH")"
+if [[ $root_fstype == "btrfs" ]]; then
+  echo "Configuring Omarchy Snapper snapshot retention"
 
-  if [[ ${OMARCHY_SNAPPER_CONFIGURE_TEST:-0} == "1" ]]; then
-    : >"$SNAPPER_CONFIG_PATH"
-  else
-    snapper --no-dbus -c root create-config / >/dev/null 2>&1 || snapper -c root create-config / >/dev/null
+  if [[ ! -f $SNAPPER_CONFIG_PATH ]]; then
+    mkdir -p "$(dirname "$SNAPPER_CONFIG_PATH")"
+
+    if [[ ${OMARCHY_SNAPPER_CONFIGURE_TEST:-0} == "1" ]]; then
+      : >"$SNAPPER_CONFIG_PATH"
+    else
+      snapper --no-dbus -c root create-config / >/dev/null 2>&1 || snapper -c root create-config / >/dev/null
+    fi
   fi
+
+  install -m 0644 "$template" "$SNAPPER_CONFIG_PATH"
+
+  mkdir -p "$(dirname "$SNAPPER_CONF_PATH")"
+  printf '%s\n' 'SNAPPER_CONFIGS="root"' >"$SNAPPER_CONF_PATH"
+  chmod 0644 "$SNAPPER_CONF_PATH"
+
+  systemctl disable --now snapper-timeline.timer >/dev/null 2>&1 || true
+  systemctl enable --now snapper-cleanup.timer limine-snapper-sync.service >/dev/null 2>&1 || true
+else
+  echo "Root is $root_fstype, not Btrfs: skipping Snapper and Limine snapshot sync"
+
+  # Snapper and limine-snapper-sync only understand Btrfs subvolumes. Earlier
+  # setup wrote an impossible FSTYPE="btrfs" root config on non-Btrfs roots,
+  # making snapper-cleanup fail every night and the pre-update snapshot abort
+  # (#6683). Remove the phantom config and its SNAPPER_CONFIGS entry.
+  if [[ -f $SNAPPER_CONFIG_PATH ]] &&
+    grep -qFx 'FSTYPE="btrfs"' "$SNAPPER_CONFIG_PATH"; then
+    rm -f "$SNAPPER_CONFIG_PATH"
+  fi
+
+  mkdir -p "$(dirname "$SNAPPER_CONF_PATH")"
+  printf '%s\n' 'SNAPPER_CONFIGS=""' >"$SNAPPER_CONF_PATH"
+  chmod 0644 "$SNAPPER_CONF_PATH"
+
+  # Nothing to clean or sync without Btrfs; keep the units from failing daily.
+  systemctl disable --now snapper-cleanup.timer >/dev/null 2>&1 || true
+  systemctl disable --now limine-snapper-sync.service >/dev/null 2>&1 || true
 fi
-
-install -m 0644 "$template" "$SNAPPER_CONFIG_PATH"
-
-mkdir -p "$(dirname "$SNAPPER_CONF_PATH")"
-printf '%s\n' 'SNAPPER_CONFIGS="root"' >"$SNAPPER_CONF_PATH"
-chmod 0644 "$SNAPPER_CONF_PATH"
-
-systemctl disable --now snapper-timeline.timer >/dev/null 2>&1 || true
-systemctl enable --now snapper-cleanup.timer limine-snapper-sync.service >/dev/null 2>&1 || true

--- a/manual/47-system-snapshots.md
+++ b/manual/47-system-snapshots.md
@@ -2,6 +2,8 @@
 
 We create snapshots automatically on every Omarchy update, but should you want to create your own, you can use `omarchy-snapshot create`.
 
+## Btrfs roots (Limine boot-menu restore)
+
 To boot and restore a snapshot, you select it from the Limine boot loader. (If you're currently booting straight into the Omarchy decryption screen, you'll need to select Limine as a boot option via the BIOS first).
 
 From that screen, choose the snapshot you'd like to boot into based on the date and version. The version of Omarchy at the time of the snapshot can be seen at the bottom left corner.
@@ -23,3 +25,15 @@ _Note: This feature is only available on installations using the Limine boot loa
 If you never touch the boot menu and just want the machine to go straight to the decryption screen, run _Setup > Direct Boot_ in the Omarchy menu. That adds an EFI entry pointing directly at Omarchy, so the firmware boots it without stopping at Limine.
 
 The trade-off is the one mentioned at the top: with direct boot on, getting to a snapshot means picking Limine from your BIOS boot menu first. Run _Setup > Direct Boot_ again to remove the entry and go back to booting through Limine. Some firmware doesn't take kindly to custom EFI entries, so the setup refuses to run on American Megatrends and Apple firmware.
+
+## Non-Btrfs roots (Timeshift)
+
+On installs whose root filesystem is not Btrfs (for example ext4, including over LVM or LUKS), there is no bootable subvolume for Limine to select. Snapshot creation still happens automatically before every update, but it uses Timeshift (in rsync mode) instead of Snapper, and restoring is done from Timeshift rather than the Limine boot menu.
+
+- `omarchy-snapshot create` on a non-Btrfs root creates a Timeshift snapshot. The first time you run it, Timeshift asks you to pick a snapshot location with `sudo timeshift-wizard`.
+- `omarchy-snapshot restore` opens Timeshift's restore dialog, which restores the root filesystem from the snapshot you choose.
+- `omarchy update` refuses to run a one-way upgrade without a usable recovery mechanism: if Timeshift is missing it offers to install it, and aborts if you decline. Pass `--no-recovery-check` to proceed without a recovery snapshot instead.
+
+The Limine boot loader itself stays in use as your bootloader on every filesystem; only snapshot boot entries are Btrfs-only.
+
+_Note: On Btrfs roots this feature is only available on installations using the Limine boot loader, which has been the default since Omarchy 2.0, and is not available if you're on GRUB or systemd-boot._

--- a/migrations/1787070563.sh
+++ b/migrations/1787070563.sh
@@ -1,0 +1,24 @@
+echo "Prepare non-Btrfs roots for Omarchy snapshot recovery via Timeshift"
+
+# Snapper and limine-snapper-sync only understand Btrfs subvolumes. Setup used
+# to write an impossible FSTYPE="btrfs" root config on every filesystem, which
+# made snapper-cleanup fail nightly and aborted the pre-update snapshot on
+# non-Btrfs roots (#6683). Machine-wide repairs happen once per user, so check
+# the actual root filesystem before touching anything and no-op elsewhere.
+
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+snapper_config_script="$OMARCHY_PATH/install/config/snapper.sh"
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+root_fstype=$(findmnt -no FSTYPE / 2>/dev/null || true)
+
+if [[ $root_fstype != "btrfs" ]] && [[ -f "$snapper_config_script" ]]; then
+  as_root env OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$snapper_config_script"
+fi

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -60,6 +60,7 @@ pass "Limine Snapper warning notifier migration disables existing user autostart
 TEST_LOG="$test_tmp/calls.log" \
 PATH="$fake_bin:$PATH" \
 OMARCHY_SNAPPER_CONFIGURE_TEST=1 \
+OMARCHY_SNAPPER_FSTYPE=btrfs \
 OMARCHY_PATH="$ROOT" \
 OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/etc/snapper/configs/root" \
 OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
@@ -70,6 +71,28 @@ grep -Fx 'SNAPPER_CONFIGS="root"' "$test_tmp/etc/conf.d/snapper" >/dev/null || f
 grep -Fx 'systemctl disable --now snapper-timeline.timer' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure disables timeline snapshots"
 grep -Fx 'systemctl enable --now snapper-cleanup.timer limine-snapper-sync.service' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure enables cleanup and Limine snapshot sync"
 pass "snapshot configure normalizes Snapper policy and services"
+
+: >"$test_tmp/calls.log"
+mkdir -p "$test_tmp/etc/snapper/configs"
+cat >"$test_tmp/etc/snapper/configs/root" <<'CONFIG'
+SUBVOLUME="/"
+FSTYPE="btrfs"
+CONFIG
+
+TEST_LOG="$test_tmp/calls.log" \
+PATH="$fake_bin:$PATH" \
+OMARCHY_SNAPPER_CONFIGURE_TEST=1 \
+OMARCHY_SNAPPER_FSTYPE=ext4 \
+OMARCHY_PATH="$ROOT" \
+OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/etc/snapper/configs/root" \
+OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
+  bash -euo pipefail "$ROOT/install/config/snapper.sh" >/dev/null
+
+[[ ! -e "$test_tmp/etc/snapper/configs/root" ]] || fail "non-Btrfs snapshot configure removes the phantom Btrfs root config"
+grep -Fx 'SNAPPER_CONFIGS=""' "$test_tmp/etc/conf.d/snapper" >/dev/null || fail "non-Btrfs snapshot configure clears SNAPPER_CONFIGS"
+grep -F 'systemctl disable --now snapper-cleanup.timer' "$test_tmp/calls.log" >/dev/null || fail "non-Btrfs snapshot configure disables cleanup"
+grep -F 'systemctl disable --now limine-snapper-sync.service' "$test_tmp/calls.log" >/dev/null || fail "non-Btrfs snapshot configure disables Limine snapshot sync"
+pass "non-Btrfs snapshot configure keeps Snapper and Limine snapshot sync off"
 
 setup_system="$ROOT/bin/omarchy-apply-system"
 grep -F 'config/all.sh' "$setup_system" >/dev/null ||
@@ -86,6 +109,14 @@ grep -F 'sudo "$@"' "$migration" >/dev/null
 grep -F 'as_root env OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$snapper_config_script"' "$migration" >/dev/null
 ! grep -F 'NUMBER_LIMIT="5"' "$migration" >/dev/null || fail "Snapper service migration does not overwrite working custom retention"
 pass "Snapper service migration only repairs broken services idempotently"
+
+non_btrfs_migration=$(grep -rl 'Prepare non-Btrfs roots for Omarchy snapshot recovery via Timeshift' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $non_btrfs_migration ]] || fail "non-Btrfs snapshot recovery migration exists"
+grep -qx 'echo "Prepare non-Btrfs roots for Omarchy snapshot recovery via Timeshift"' "$non_btrfs_migration" >/dev/null || fail "non-Btrfs migration starts with its description"
+grep -F 'findmnt -no FSTYPE /' "$non_btrfs_migration" >/dev/null || fail "non-Btrfs migration detects the root filesystem"
+grep -F 'root_fstype != "btrfs"' "$non_btrfs_migration" >/dev/null || fail "non-Btrfs migration only runs off Btrfs"
+grep -F 'snapper_config_script' "$non_btrfs_migration" >/dev/null || fail "non-Btrfs migration calls the packaged snapshot script"
+pass "non-Btrfs migration repairs already-upgraded installs idempotently"
 
 # Checkouts differ per machine, so allow an explicit pointer at the sibling repo.
 # Accepts either the omarchy-pkgs checkout or its pkgbuilds/ directory.

--- a/test/shell.d/snapshot-create-test.sh
+++ b/test/shell.d/snapshot-create-test.sh
@@ -44,7 +44,7 @@ chmod +x "$fake_bin/snapper"
 # an unconfigured Snapper has to fail loudly instead of passing for a backup.
 : >"$test_tmp/calls.log"
 set +e
-stderr=$(TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+stderr=$(OMARCHY_SNAPSHOT_FSTYPE=btrfs TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
   bash "$snapshot" create 2>&1 >/dev/null)
 status=$?
 set -e
@@ -67,7 +67,7 @@ STUB
 chmod +x "$fake_bin/snapper"
 
 : >"$test_tmp/calls.log"
-TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+OMARCHY_SNAPSHOT_FSTYPE=btrfs TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
   bash "$snapshot" create >/dev/null
 
 grep -qFx 'snapper -c root create -c number -d 4.0.0' "$test_tmp/calls.log" ||
@@ -85,7 +85,7 @@ STUB
 chmod +x "$fake_bin/omarchy-cmd-missing"
 
 set +e
-TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+OMARCHY_SNAPSHOT_FSTYPE=btrfs TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
   bash "$snapshot" create >/dev/null 2>&1
 status=$?
 set -e
@@ -94,6 +94,51 @@ set -e
 grep -qF 'omarchy-snapshot create || (($? == 127))' "$ROOT/bin/omarchy-update" ||
   fail "update ignores only the missing-snapper exit code"
 pass "snapshot create keeps the quiet 127 path for systems without snapper"
+
+# A non-Btrfs root uses Timeshift instead of Snapper. Snapshot create has to
+# route there, refusing to run when unconfigured and calling into it when a
+# snapshot location exists.
+cat >"$fake_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+# The first argument is the command whose presence is being checked. In this
+# block every dependency is treated as present.
+exit 1
+STUB
+chmod +x "$fake_bin/omarchy-cmd-missing"
+
+cat >"$fake_bin/timeshift" <<'STUB'
+#!/bin/bash
+printf 'timeshift %s\n' "$*" >>"$TEST_LOG"
+STUB
+chmod +x "$fake_bin/timeshift"
+
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(OMARCHY_SNAPSHOT_FSTYPE=ext4 OMARCHY_TIMESHIFT_CONFIG="$test_tmp/no-config.json" \
+  TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot" create 2>&1 >/dev/null)
+status=$?
+set -e
+
+(( status != 0 )) || fail "snapshot create fails on non-Btrfs roots without a configured Timeshift"
+grep -qF "run 'sudo timeshift-wizard' once" <<<"$stderr" ||
+  fail "snapshot create tells the user to configure Timeshift" "$stderr"
+! grep -q '^timeshift ' "$test_tmp/calls.log" ||
+  fail "snapshot create does not run Timeshift before it is configured"
+pass "snapshot create fails loudly on non-Btrfs roots without Timeshift configured"
+
+cat >"$test_tmp/timeshift.json" <<'JSON'
+{}
+JSON
+
+: >"$test_tmp/calls.log"
+OMARCHY_SNAPSHOT_FSTYPE=ext4 OMARCHY_TIMESHIFT_CONFIG="$test_tmp/timeshift.json" \
+  TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot" create >/dev/null
+
+grep -qF 'timeshift --create --comments pre-update 4.0.0' "$test_tmp/calls.log" ||
+  fail "snapshot create runs Timeshift on non-Btrfs roots" "$(cat "$test_tmp/calls.log")"
+pass "snapshot create uses Timeshift for non-Btrfs roots"
 
 # The quattro upgrade runs under set -e, so a failed snapshot has to be warned
 # past there too or it aborts the whole upgrade at the snapshot step.

--- a/test/shell.d/storage-hooks-test.sh
+++ b/test/shell.d/storage-hooks-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+
+# Stub findmnt and lsblk so the storage detection is deterministic regardless
+# of the filesystem the test runner lives on. The stubs are installed into a
+# directory put at the front of PATH, and the hook config is sourced with the
+# vconsole block pinned to a Latin layout.
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/findmnt" <<'STUB'
+#!/bin/bash
+# args used: findmnt -no SOURCE /   and   findmnt -no FSTYPE /
+if [[ $1 == "-no" && $2 == "SOURCE" ]]; then
+  printf '%s\n' "$OMARCHY_TEST_ROOT_DEVICE"
+elif [[ $1 == "-no" && $2 == "FSTYPE" ]]; then
+  printf '%s\n' "$OMARCHY_TEST_ROOT_FSTYPE"
+else
+  exit 0
+fi
+STUB
+chmod +x "$fake_bin/findmnt"
+
+cat >"$fake_bin/lsblk" <<'STUB'
+#!/bin/bash
+# lsblk -rno TYPE <device>
+printf '%s\n' "$OMARCHY_TEST_ROOT_STACK"
+STUB
+chmod +x "$fake_bin/lsblk"
+
+resolved_hooks() {
+  OMARCHY_PCI_DEVICES_PATH="$tmp_dir/devices" \
+  FAKE_BIN_OVERRIDE=1 \
+  PATH="$fake_bin:$PATH" \
+  bash -uc "
+    FILES=()
+    XKBLAYOUT=us
+    source '$hooks_conf'
+    echo \"\${HOOKS[*]}\"
+  "
+}
+
+required_hooks() {
+  local description="$1" device="$2" fstype="$3" stack="$4"
+  local expected="base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block"
+  local actual
+
+  case "$stack" in
+    *lvm*) expected+=" lvm2" ;;
+  esac
+  case "$stack" in
+    *crypt*) expected+=" encrypt" ;;
+  esac
+  [[ $fstype == "btrfs" ]] && expected+=" btrfs-overlayfs"
+  expected+=" filesystems fsck"
+
+  actual=$(FAKE_OMARCHY_ROOT_STACK="$stack" FAKE_OMARCHY_ROOT="$device" OMARCHY_TEST_ROOT_DEVICE="$device" OMARCHY_TEST_ROOT_FSTYPE="$fstype" OMARCHY_TEST_ROOT_STACK="$stack" resolved_hooks)
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+  pass "$description"
+}
+
+mkdir -p "$tmp_dir/devices"
+
+required_hooks "plain btrfs root keeps only btrfs-overlayfs" \
+  "/dev/nvme0n1p2" "btrfs" "part"
+
+required_hooks "LVM root gains the lvm2 hook" \
+  "/dev/mapper/vg0-root" "ext4" "lvm"
+
+required_hooks "LUKS root gains the encrypt hook" \
+  "/dev/mapper/cryptroot" "ext4" "crypt"
+
+required_hooks "LVM-on-LUKS root gains lvm2 and encrypt hooks" \
+  "/dev/mapper/vg0-root" "ext4" $'lvm\ncrypt'
+
+required_hooks "LVM root on btrfs gains lvm2 and btrfs-overlayfs" \
+  "/dev/mapper/vg0-root" "btrfs" "lvm"
+
+required_hooks "plain ext4 root adds neither storage hook" \
+  "/dev/sda2" "ext4" "part"


### PR DESCRIPTION
## Summary

Omarchy's snapshot and boot setup assumed a Btrfs root. On non-Btrfs filesystems this caused two real problems:

1. **Snapshot recovery silently broke.** `install/config/snapper.sh` wrote an impossible `FSTYPE="btrfs"` root config on every filesystem and enabled Snapper's cleanup timer plus Limine snapshot sync. On non-Btrfs roots `snapper-cleanup` failed every night, `limine-snapper-watcher` warned on every boot, and the pre-update recovery snapshot aborted (see #6683).
2. **Non-Btrfs installs could not boot after the Quattro upgrade.** `omarchy_hooks.conf` carried a fixed hook list with `btrfs-overlayfs` and no `lvm2`/`encrypt` detection, so an LVM-over-LUKS ext4 root — with no `lvm2` hook in the initramfs — dropped to an emergency shell because the initramfs could not assemble the volume group (reproduced on ext4 + LVM + LUKS).

This PR makes snapshot *recovery* and the *boot image* depend on the actual root filesystem, giving non-Btrfs systems the same pre-update recovery promise via **Timeshift (rsync mode)**.

## What changes

**Filesystem-aware snapshot recovery**

- `install/config/snapper.sh` now dispatches on `findmnt -no FSTYPE /`:
  - **Btrfs** roots keep the current behavior (Snapper config, `snapper-cleanup.timer`, `limine-snapper-sync.service`).
  - **Non-Btrfs** roots have the phantom `FSTYPE="btrfs"` root config and `SNAPPER_CONFIGS="root"` entry removed, the Btrfs-only units disabled, and recovery handed to Timeshift.
- `omarchy-upgrade-to-quattro` detects a non-Btrfs root and, when Timeshift is missing, offers to install it and **aborts the one-way upgrade if the user declines** — a one-way upgrade must not run without a recovery net. `--no-recovery-check` is the escape hatch.
- `omarchy-snapshot` is now filesystem-aware: `create`/`restore` use snapper + Limine on Btrfs and Timeshift (rsync) on other filesystems.
- A new idempotent migration repairs installs already running on non-Btrfs roots.

**Storage-layout-aware boot**
- `etc/mkinitcpio.conf.d/omarchy_hooks.conf` now builds HOOKS from the live device stack: it adds `lvm2` when the root is on an LVM volume group, `encrypt` when it sits on dm-crypt, and `btrfs-overlayfs` only on Btrfs roots. LVM-on-LUKS ext4 installs get an initramfs that can actually assemble the root device, so they boot instead of dropping to an emergency shell.

**Docs**
- `manual/47-system-snapshots.md` documents the two flows: Limine boot-menu restore on Btrfs, Timeshift restore on non-Btrfs.

**Tests**
- `storage-hooks-test.sh` (new): hooks selected for plain Btrfs, LVM, LUKS, LVM-on-LUKS, LVM+Btrfs, and plain ext4.
- `snapper-test.sh`: non-Btrfs cleanup + migration coverage.
- `snapshot-create-test.sh`: Timeshift path (`create` fails until configured, then runs Timeshift) plus the existing Snapper paths.

## Related

- Fixes #6683 partially (the Snapper-on-non-Btrfs root config and daily cleanup failure).
- Incorporates the gating approach from #6730 (`Keep Snapper off non-Btrfs roots`) and extends it with the Timeshift recovery flow and the mkinitcpio/limine boot fix so non-Btrfs installs have a complete, bootable recovery story.

## How I verified

- `bash -n` on every edited script.
- Focused suites pass: `snapper-test.sh`, `snapshot-create-test.sh`, `storage-hooks-test.sh`, `nvidia-kms-hook-test.sh`, `upgrade-to-quattro-test.sh`, `limine-cmdline-migration-test.sh`.
- The full `./test/shell` run reports only the same pre-existing environment-dependent failures (`omarchy-pkgs` sibling checkout, a network-dependent Fireworks collector) that already fail on `quattro` untouched.
