### PR TITLE
Accept theme-set display names in theme remove

### DIFF
--- a/bin/omarchy-theme-remove
+++ b/bin/omarchy-theme-remove
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Remove a user-installed theme
 # omarchy:args=[theme-name]
-# omarchy:examples=omarchy theme remove "Tokyo Night"
+# omarchy:examples=omarchy theme remove "My Theme"
 
 if [[ -z $1 ]]; then
   mapfile -t extra_themes < <(find ~/.config/omarchy/themes -mindepth 1 -maxdepth 1 -type d ! -xtype l -printf '%f\n')
@@ -15,7 +15,8 @@ if [[ -z $1 ]]; then
     exit 1
   fi
 else
-  THEME_NAME="$1"
+  # Same slug as omarchy-theme-set, so the documented display name works.
+  THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 fi
 
 THEMES_DIR="$HOME/.config/omarchy/themes"

--- a/test/shell.d/theme-remove-test.sh
+++ b/test/shell.d/theme-remove-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/home/.config/omarchy/themes/my-cool-theme" "$TMPDIR/bin"
+printf 'ok\n' >"$TMPDIR/home/.config/omarchy/themes/my-cool-theme/marker"
+
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$TMPDIR/bin/omarchy-notification-send"
+
+HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  omarchy-theme-remove "My Cool Theme" ||
+  fail "theme remove does not accept the display name theme set already normalises"
+[[ ! -e $TMPDIR/home/.config/omarchy/themes/my-cool-theme ]] ||
+  fail "theme remove left the display-name theme on disk"
+pass "theme remove accepts a quoted display name"
+
+mkdir -p "$TMPDIR/home/.config/omarchy/themes/already-slug"
+HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  omarchy-theme-remove already-slug
+[[ ! -e $TMPDIR/home/.config/omarchy/themes/already-slug ]] ||
+  fail "theme remove rejects a directory slug"
+pass "theme remove still accepts a directory slug"


### PR DESCRIPTION
Fixes #7127

`omarchy theme set` slugs a display name (`My Theme` → `my-theme`). `omarchy theme remove` used `$1` as a directory name, so the form its own example advertised always failed. The interactive picker already passed directory names from `find`, so only the explicit argument path was wrong.

Apply the same `sed`/`tr` slug theme-set uses. Change the example from `"Tokyo Night"` (a bundled theme, which this command will not delete) to `"My Theme"`.

Verified:

```
./test/shell.d/theme-remove-test.sh
# ok - theme remove accepts a quoted display name
# ok - theme remove still accepts a directory slug
```
