### PR TITLE
Fail shell and CLI tests when ripgrep is missing

### DIFF
--- a/test/cli
+++ b/test/cli
@@ -51,6 +51,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+command -v rg >/dev/null || fail "required command is available: rg"
+
 output=$("$CLI" --help)
 assert_output_contains "main help renders" "$output" "Omarchy command center"
 assert_output_contains "main help includes hardware group" "$output" "hw"

--- a/test/shell.d/base-test.sh
+++ b/test/shell.d/base-test.sh
@@ -29,6 +29,10 @@ require_command() {
   command -v "$command" >/dev/null || fail "required command is available: $command"
 }
 
+# Negative `rg` guards treat a missing binary as "no match" and print ok.
+# Fail the file instead. Ripgrep is part of Omarchy's default package set.
+require_command rg
+
 # WAYLAND_DISPLAY proves the variable was inherited, not that the compositor
 # answers. Sandboxes pass the environment through while blocking
 # $XDG_RUNTIME_DIR, so Quickshell clears a bare variable check and then aborts

--- a/test/shell.d/require-rg-test.sh
+++ b/test/shell.d/require-rg-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+empty=$(mktemp -d)
+trap 'rm -rf "$empty"' EXIT
+# Keep dirname so the child can source base-test.sh; omit rg.
+ln -s "$(command -v dirname)" "$empty/dirname"
+
+output=$(PATH="$empty" /bin/bash "$ROOT/test/shell.d/panel-command-path-test.sh" 2>&1) &&
+  fail "panel-command-path reports ok when rg is missing" "$output"
+grep -q 'required command is available: rg' <<<"$output" ||
+  fail "missing rg does not fail as a required command" "$output"
+pass "missing rg fails the suite instead of skipping negative guards"


### PR DESCRIPTION
Fixes #7122

Several shell tests (and two `test/cli` guards) use `rg` in negative form. A missing binary is exit 127, `if rg` treats that as "no match", and the file prints `ok`. `require_command` already exists for `jq` / `python3` / `node`; nothing asked for `rg`.

Require it when `test/shell.d/base-test.sh` is sourced and at the start of `test/cli`. Ripgrep is in Omarchy's default package set; this only bites a stripped PATH or a broken install.

Verified:

```
./test/shell.d/require-rg-test.sh
# ok - missing rg fails the suite instead of skipping negative guards

./test/shell.d/panel-command-path-test.sh
./test/shell.d/bin-style-test.sh
```
