### PR TITLE
Say when acceptance screenshots fail to capture

### DIFF
--- a/test/acceptance.d/base-test.sh
+++ b/test/acceptance.d/base-test.sh
@@ -29,7 +29,10 @@ fail() {
 }
 
 screenshot() {
-  timeout 10 grim "$ARTIFACTS/$1.png" 2>/dev/null || true
+  if ! timeout 10 grim "$ARTIFACTS/$1.png" 2>/dev/null; then
+    printf 'could not capture screenshot %s.png\n' "$1" >&2
+    return 1
+  fi
 }
 
 screen_contains() {
@@ -38,6 +41,7 @@ screen_contains() {
 
   if ! timeout 10 grim "$snapshot" 2>/dev/null; then
     rm -f "$snapshot"
+    echo "screen_contains: grim failed to capture" >&2
     return 1
   fi
   tesseract "$snapshot" stdout --psm 11 2>/dev/null | grep -Fi -- "$text" >/dev/null

--- a/test/shell.d/acceptance-helpers-test.sh
+++ b/test/shell.d/acceptance-helpers-test.sh
@@ -51,3 +51,20 @@ assert_layer_on_screen "visible-negative-offset" "visible layer is found on a ne
 assert_layer_off_screen "parked-negative-offset" "left-parked layer stays off a negatively offset monitor"
 assert_layer_on_screen "visible-rotated" "visible layer uses the transformed monitor height"
 assert_layer_off_screen "parked-rotated" "parked layer uses the transformed monitor width"
+
+grim_fail=$(mktemp -d)
+trap 'rm -rf "$test_tmp" "$grim_fail"' EXIT
+printf '%s\n' '#!/bin/bash' 'exit 1' >"$grim_fail/grim"
+chmod +x "$grim_fail/grim"
+
+screenshot_out=$(PATH="$grim_fail:$PATH" screenshot "probe" 2>&1) &&
+  fail "screenshot reports success when grim fails" "$screenshot_out"
+grep -q 'could not capture' <<<"$screenshot_out" ||
+  fail "screenshot swallows a grim failure" "$screenshot_out"
+pass "screenshot reports when grim cannot capture"
+
+contains_out=$(PATH="$grim_fail:$PATH" screen_contains "Hello" 2>&1) &&
+  fail "screen_contains reports the text missing when grim fails" "$contains_out"
+grep -q 'grim failed' <<<"$contains_out" ||
+  fail "screen_contains does not name a capture failure" "$contains_out"
+pass "screen_contains names a grim failure instead of missing text"


### PR DESCRIPTION
Fixes #7126

`screen_contains` returned 1 both when the text was absent and when `grim` failed, so `wait_until` reported "root menu content is visible" (etc.) for a capture outage. `screenshot` used `|| true`, so `fail()` pointed at PNGs that were never written.

On grim failure, print that the capture failed. `screen_contains` still returns 1 so `wait_until` can retry a transient miss; the timeout path then has the grim error on stderr instead of looking like missing OCR text.

Verified:

```
./test/shell.d/acceptance-helpers-test.sh
# ok - screenshot reports when grim cannot capture
# ok - screen_contains names a grim failure instead of missing text
```
