### PR TITLE
Refactor monitor_rules for better rule processing

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -63,8 +63,13 @@ lua_scalar() {
 monitor_rules() {
   [[ -f $MONITOR_LUA ]] || return 0
 
-  sed -E -e 's/--\[\[[^]]*\]\]//g' -e 's/--.*$//' "$MONITOR_LUA"
+  # Strip comments, flatten multi-line table formats into a single string, 
+  # and isolate each rule onto its own line for the regex parser.
+  sed -E -e 's/--\[\[[^]]*\]\]//g' -e 's/--.*$//' "$MONITOR_LUA" | \
+    tr '\n' ' ' | \
+    sed 's/hl\.monitor/\n&/g'
 }
+
 
 monitor_rule_regex() {
   printf '^[[:space:]]*hl\\.monitor\\(\\{.*output[[:space:]]*=[[:space:]]*"%s"' "$1"


### PR DESCRIPTION
Fixes #7326 

### **What's wrong?**
`nwg-displays` generate multi-line formatted Lua monitor configs (where `hl.monitor({`, `output`, and `scale` sit on separate lines). 

Because `omarchy-hyprland-monitor-clamshell` pipes `monitors.lua` line-by-line into `sed`, `configured_monitor_value()` fails to match the regular expression, which expects the entire `hl.monitor({ ... })` declaration to reside on a single line. This parsing failure causes `read_monitor_scale()` to fall back to the default `scale = 2`, continuously reverting fractional scale configurations.

### What does this PR do?
* Updates `monitor_rules()` to flatten multi-line table declarations into a single stream using `tr '\n' ' '`.
* Injects a newline before each `hl.monitor` declaration using `sed 's/hl\.monitor/\n&/g'`.
* Ensures each monitor definition is isolated onto its own line so the existing downstream regex parser can reliably extract keys without modifying the underlying extraction logic.