### PR TITLE
Give scratchpad a Quake-style console presentation

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -26,6 +26,8 @@ end
 
 o.bind("SUPER + S", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
 o.bind("SUPER + ALT + S", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
+o.bind("SUPER + grave", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
+o.bind("SUPER + SHIFT + grave", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
 
 o.bind("SUPER + TAB", "Next workspace", hl.dsp.focus({ workspace = "e+1" }))
 o.bind("SUPER + SHIFT + TAB", "Previous workspace", hl.dsp.focus({ workspace = "e-1" }))

--- a/default/hypr/looknfeel.lua
+++ b/default/hypr/looknfeel.lua
@@ -20,14 +20,24 @@ hl.config({
   },
 
   decoration = {
-    rounding = 0,
+    rounding = 5,
+    dim_special = 0.6,
 
     shadow = {
-      enabled = false,
+      enabled = true,
+      range = 8,
+      render_power = 2,
+      color = "rgba(50, 50, 50, 0.35)",
     },
 
     blur = {
-      enabled = false,
+      enabled = true,
+      size = 1,
+      passes = 1,
+      new_optimizations = true,
+      xray = true,
+      brightness = 0.5,
+      special = true,
     },
   },
 
@@ -64,6 +74,17 @@ hl.config({
   },
 })
 
+-- Give the scratchpad a floating Quake-console presentation.
+hl.workspace_rule({
+  workspace = "special:scratchpad",
+  gaps_out = 80,
+  gaps_in = 40,
+  no_border = false,
+  no_rounding = false,
+  no_shadow = false,
+  decorate = true,
+})
+
 -- Default animations, see https://wiki.hypr.land/Configuring/Advanced-and-Cool/Animations/
 hl.curve("easeOutQuint", { type = "bezier", points = { { 0.23, 1 }, { 0.32, 1 } } })
 hl.curve("easeInOutCubic", { type = "bezier", points = { { 0.65, 0.05 }, { 0.36, 1 } } })
@@ -86,7 +107,8 @@ hl.animation({ leaf = "layersOut", enabled = true, speed = 1.5, bezier = "linear
 hl.animation({ leaf = "fadeLayersIn", enabled = true, speed = 1.79, bezier = "almostLinear" })
 hl.animation({ leaf = "fadeLayersOut", enabled = true, speed = 1.39, bezier = "almostLinear" })
 hl.animation({ leaf = "workspaces", enabled = false })
-hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 3, bezier = "easeOutQuint", style = "slidevert" })
+hl.animation({ leaf = "specialWorkspaceIn", enabled = true, speed = 3, bezier = "easeOutQuint", style = "slide top" })
+hl.animation({ leaf = "specialWorkspaceOut", enabled = true, speed = 2, bezier = "easeInOutCubic", style = "slide bottom" })
 
 hl.config({
   dwindle = {

--- a/default/hypr/looknfeel.lua
+++ b/default/hypr/looknfeel.lua
@@ -20,24 +20,19 @@ hl.config({
   },
 
   decoration = {
-    rounding = 5,
+    rounding = 0,
+
+    -- Dimming only kicks in while a special workspace is open, so the
+    -- scratchpad gets its overlay separation without costing anything the
+    -- rest of the time.
     dim_special = 0.6,
 
     shadow = {
-      enabled = true,
-      range = 8,
-      render_power = 2,
-      color = "rgba(50, 50, 50, 0.35)",
+      enabled = false,
     },
 
     blur = {
-      enabled = true,
-      size = 1,
-      passes = 1,
-      new_optimizations = true,
-      xray = true,
-      brightness = 0.5,
-      special = true,
+      enabled = false,
     },
   },
 
@@ -74,16 +69,18 @@ hl.config({
   },
 })
 
--- Give the scratchpad a floating Quake-console presentation.
+-- Give the scratchpad a floating Quake-console presentation. Shadow and blur
+-- stay off globally (they cost GPU on every frame for almost no visual gain,
+-- and windows are near-opaque anyway), so the inset, the dimming, and the
+-- slide carry the effect.
 hl.workspace_rule({
   workspace = "special:scratchpad",
   gaps_out = 80,
   gaps_in = 40,
-  no_border = false,
-  no_rounding = false,
-  no_shadow = false,
-  decorate = true,
 })
+
+-- Round just the scratchpad, so the global default can stay square.
+hl.window_rule({ match = { workspace = "special:scratchpad" }, rounding = 8 })
 
 -- Default animations, see https://wiki.hypr.land/Configuring/Advanced-and-Cool/Animations/
 hl.curve("easeOutQuint", { type = "bezier", points = { { 0.23, 1 }, { 0.32, 1 } } })
@@ -107,6 +104,9 @@ hl.animation({ leaf = "layersOut", enabled = true, speed = 1.5, bezier = "linear
 hl.animation({ leaf = "fadeLayersIn", enabled = true, speed = 1.79, bezier = "almostLinear" })
 hl.animation({ leaf = "fadeLayersOut", enabled = true, speed = 1.39, bezier = "almostLinear" })
 hl.animation({ leaf = "workspaces", enabled = false })
+-- The direction names the edge the offset is measured from, not where the
+-- workspace goes: "slide top" drops it down into view, and "slide bottom"
+-- retracts it back up the way a Quake console does.
 hl.animation({ leaf = "specialWorkspaceIn", enabled = true, speed = 3, bezier = "easeOutQuint", style = "slide top" })
 hl.animation({ leaf = "specialWorkspaceOut", enabled = true, speed = 2, bezier = "easeInOutCubic", style = "slide bottom" })
 

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -62,9 +62,9 @@ You can pop a window out of its workspace allocation with `Super + O`. That'll p
 
 ### Scratchpad workspace
 
-Finally, there's a special scratchpad workspace that overlays on whatever workspace you're currently on. You access what's on that using `Super + S` and you place windows there using `Super + Alt + S`.
+Finally, there's a special scratchpad workspace that drops down over whatever workspace you're currently on, much like a Quake console. Toggle it with `Super + Grave` or `Super + S`, and place a window there using `Super + Shift + Grave` or `Super + Alt + S`.
 
-It works well for controls or perhaps a terminal that you quickly want to interact with in an overlay without leaving the current workspace. If you want to move a window off the scratchpad, you just move it directly to another workspace with something like `Super + Shift + 1` to move it to workspace 1.
+It works especially well for a terminal running an agent, or for controls you want to interact with quickly without leaving the current workspace. To move a window off the scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
 
 ### It takes some getting used to!
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -26,6 +26,8 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Ctrl + Tab` | Jump to former workspace |
 | `Super + Shift + 1/2/3/4` | Move window to workspace |
 | `Super + Shift + Alt + 1/2/3/4` | Move window to workspace without following |
+| `Super + S` / `Super + Grave` | Toggle scratchpad |
+| `Super + Alt + S` / `Super + Shift + Grave` | Move window to scratchpad |
 | `Super + Shift + Alt + Arrows` | Move workspaces to directional monitor |
 | `Super + Arrow`  | Move focus to window in direction of arrow              |
 | `Super + Shift + Arrow`  | Swap window with another in direction of arrow     |

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -49,8 +49,6 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Alt + 1/2/3/4/5`               | Jump to specific window in grouping      |
 | `Super + Alt + Arrow`  | Move window into grouping in direction of arrow  |
 | `Super + Ctrl + Left/Right`  | Move between windows inside a tiling group |
-| `Super + S` | Show scratchpad workspace overlay |
-| `Super + Alt + S` | Move window to scratchpad workspace |
 | `Super + Ctrl + Z` | Zoom in on screen (repeat for more zoom) |
 | `Super + Ctrl + Alt + Z` | Zoom fully out from screen |
 | `Super + /` | Step forward through monitor scaling options |

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -175,22 +175,27 @@ if grep -Fq $'SUPER + CTRL + X	Toggle dictation' <<<"$missing_voxtype_output"; t
 fi
 pass "missing Voxtype skips dictation bindings"
 
+# The Grave shortcuts are aliases, so the original SUPER + S pair has to keep
+# working alongside them.
+scratchpad_home="$tmpdir/scratchpad-home"
+mkdir -p "$scratchpad_home"
+scratchpad_output=$(run_omarchy_bindings "$scratchpad_home")
+grep -Fqx $'SUPER + S	Toggle scratchpad' <<<"$scratchpad_output" ||
+  fail "scratchpad keeps its existing toggle binding"
+grep -Fqx $'SUPER + grave	Toggle scratchpad' <<<"$scratchpad_output" ||
+  fail "scratchpad supports a Quake-style toggle binding"
+grep -Fqx $'SUPER + ALT + S	Move window to scratchpad' <<<"$scratchpad_output" ||
+  fail "scratchpad keeps its existing move binding"
+grep -Fqx $'SUPER + SHIFT + grave	Move window to scratchpad' <<<"$scratchpad_output" ||
+  fail "scratchpad supports a Quake-style move binding"
+pass "scratchpad retains existing bindings and adds Grave shortcuts"
+
 # The panel hotkeys claim a row of keys that workspace switching already uses
 # under other modifiers, so the count matters as much as the bindings: a tenth
 # claim on SUPER + CTRL + a number is a collision with one of these.
 panels_home="$tmpdir/panels-home"
 mkdir -p "$panels_home"
 panels_output=$(run_omarchy_bindings "$panels_home")
-grep -Fqx $'SUPER + S	Toggle scratchpad' <<<"$panels_output" ||
-  fail "scratchpad keeps its existing toggle binding"
-grep -Fqx $'SUPER + grave	Toggle scratchpad' <<<"$panels_output" ||
-  fail "scratchpad supports a Quake-style toggle binding"
-grep -Fqx $'SUPER + ALT + S	Move window to scratchpad' <<<"$panels_output" ||
-  fail "scratchpad keeps its existing move binding"
-grep -Fqx $'SUPER + SHIFT + grave	Move window to scratchpad' <<<"$panels_output" ||
-  fail "scratchpad supports a Quake-style move binding"
-pass "scratchpad retains existing bindings and adds Grave shortcuts"
-
 for panel in 1 2 3 4 5 6 7 8 9; do
   grep -Fqx "SUPER + CTRL + code:$((panel + 9))"$'\t'"Bar panel $panel" <<<"$panels_output" ||
     fail "bar panel hotkeys count the right section" "$panel"

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -181,6 +181,16 @@ pass "missing Voxtype skips dictation bindings"
 panels_home="$tmpdir/panels-home"
 mkdir -p "$panels_home"
 panels_output=$(run_omarchy_bindings "$panels_home")
+grep -Fqx $'SUPER + S	Toggle scratchpad' <<<"$panels_output" ||
+  fail "scratchpad keeps its existing toggle binding"
+grep -Fqx $'SUPER + grave	Toggle scratchpad' <<<"$panels_output" ||
+  fail "scratchpad supports a Quake-style toggle binding"
+grep -Fqx $'SUPER + ALT + S	Move window to scratchpad' <<<"$panels_output" ||
+  fail "scratchpad keeps its existing move binding"
+grep -Fqx $'SUPER + SHIFT + grave	Move window to scratchpad' <<<"$panels_output" ||
+  fail "scratchpad supports a Quake-style move binding"
+pass "scratchpad retains existing bindings and adds Grave shortcuts"
+
 for panel in 1 2 3 4 5 6 7 8 9; do
   grep -Fqx "SUPER + CTRL + code:$((panel + 9))"$'\t'"Bar panel $panel" <<<"$panels_output" ||
     fail "bar panel hotkeys count the right section" "$panel"


### PR DESCRIPTION
## Summary

- present the special scratchpad as an inset, dimmed overlay with rounding, shadow, blur, and directional slide animations
- add `Super + Grave` and `Super + Shift + Grave` shortcuts while retaining the existing `Super + S` and `Super + Alt + S` bindings
- document the scratchpad as a quick home for terminal agents and cover all four bindings in the default-config test

## Verification

- `bash test/shell.d/hyprland-default-config-test.sh`
- `test/shell.d/hyprland-binding-conflicts-test.sh`
- `luac -p default/hypr/looknfeel.lua default/hypr/bindings/tiling.lua`
- loaded `default/hypr/looknfeel.lua` into the live compositor; `hyprctl configerrors` remained empty
- exercised a terminal probe in the scratchpad and visually inspected the inset layout, dimming, and hide/show transition

`./test/all` reached two unrelated failures: the Fireworks collector's local-midnight assertion and missing local `omarchy-iso` checkout coverage. The changed Hyprland tests pass.