### PR TITLE
Point T2 overlay Limine at /boot/efi and write linux-t2

### DIFF
--- a/migrations/1787076745.sh
+++ b/migrations/1787076745.sh
@@ -1,0 +1,114 @@
+echo "Point T2 overlay Limine at /boot/efi and write a linux-t2 entry"
+
+# Overlay installs from t2archinstall keep the ESP at /boot/efi and leave /boot
+# as a directory on btrfs. Omarchy Limine still has ESP_PATH=/boot, so
+# limine-update writes the branding-only template where Apple firmware never
+# looks and toasts "Target OS name 'Omarchy' not found" (#7347 sections 1–2).
+# Official installs already use /boot as the ESP and are left alone.
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
+  exit 0
+fi
+
+boot_mount="${OMARCHY_T2_BOOT:-/boot}"
+esp_mount="${OMARCHY_T2_ESP:-/boot/efi}"
+limine_default="${OMARCHY_T2_LIMINE_DEFAULT:-/etc/default/limine}"
+reset_enroll="${OMARCHY_T2_RESET_ENROLL:-/etc/boot/hooks/pre.d/10-limine-reset-enroll}"
+cmdline_file="${OMARCHY_T2_RUNNING_CMDLINE:-/proc/cmdline}"
+
+if [[ ${OMARCHY_T2_BOOT_FSTYPE+set} == set ]]; then
+  boot_fstype=$OMARCHY_T2_BOOT_FSTYPE
+else
+  boot_fstype=$(findmnt -no FSTYPE "$boot_mount" 2>/dev/null || true)
+fi
+
+if [[ ${OMARCHY_T2_ESP_FSTYPE+set} == set ]]; then
+  esp_fstype=$OMARCHY_T2_ESP_FSTYPE
+else
+  esp_fstype=$(findmnt -no FSTYPE "$esp_mount" 2>/dev/null || true)
+fi
+
+if [[ $boot_fstype == "vfat" ]]; then
+  exit 0
+fi
+
+if [[ $esp_fstype != "vfat" ]]; then
+  exit 0
+fi
+
+if [[ ! -f $limine_default ]] || ! grep -Eq '^ESP_PATH=["'\'']?/boot/efi["'\'']?$' "$limine_default"; then
+  if [[ -f $limine_default ]] && grep -q '^ESP_PATH=' "$limine_default"; then
+    sudo sed -i 's|^ESP_PATH=.*|ESP_PATH="/boot/efi"|' "$limine_default"
+  else
+    printf 'ESP_PATH="/boot/efi"\n' | sudo tee -a "$limine_default" >/dev/null
+  fi
+fi
+
+copy_kernel_to_esp() {
+  local src=$1
+  local dest=$2
+
+  if [[ ! -f $src ]]; then
+    return 0
+  fi
+
+  if [[ -f $dest ]] && cmp -s "$src" "$dest"; then
+    return 0
+  fi
+
+  sudo install -Dm644 "$src" "$dest"
+}
+
+copy_kernel_to_esp "$boot_mount/vmlinuz-linux-t2" "$esp_mount/vmlinuz-linux-t2"
+copy_kernel_to_esp "$boot_mount/initramfs-linux-t2.img" "$esp_mount/initramfs-linux-t2.img"
+
+cmdline=""
+if [[ -r $cmdline_file ]]; then
+  cmdline=$(<"$cmdline_file")
+  cmdline=${cmdline%%$'\n'}
+fi
+
+write_linux_t2_entry() {
+  local conf=$1
+
+  if [[ -f $conf ]] && grep -qx '/Omarchy' "$conf" && grep -qx '//linux-t2' "$conf"; then
+    return 0
+  fi
+
+  if [[ ! -f $conf ]]; then
+    local template="$OMARCHY_PATH/default/limine/limine.conf"
+    if [[ -f $template ]]; then
+      sudo install -Dm644 "$template" "$conf"
+    else
+      sudo install -Dm644 /dev/null "$conf"
+    fi
+  fi
+
+  sudo tee -a "$conf" >/dev/null <<EOF
+
+/Omarchy
+//linux-t2
+    protocol: linux
+    path: boot():/vmlinuz-linux-t2
+    cmdline: $cmdline
+    module_path: boot():/initramfs-linux-t2.img
+EOF
+}
+
+if [[ -f $esp_mount/vmlinuz-linux-t2 ]]; then
+  write_linux_t2_entry "$esp_mount/limine.conf"
+
+  if [[ -d $esp_mount/EFI/BOOT ]]; then
+    write_linux_t2_entry "$esp_mount/EFI/BOOT/limine.conf"
+  fi
+
+  if [[ -d $esp_mount/EFI/limine ]]; then
+    write_linux_t2_entry "$esp_mount/EFI/limine/limine.conf"
+  fi
+fi
+
+# The reset hook rewrites the enrolled Limine config and can put branding-only
+# back on this ESP. Disable it the way limine-entry-tool documents.
+if [[ -e $reset_enroll ]]; then
+  sudo mv "$reset_enroll" "${reset_enroll}.disabled"
+fi

--- a/migrations/1787076745.sh
+++ b/migrations/1787076745.sh
@@ -68,15 +68,38 @@ if [[ -r $cmdline_file ]]; then
   cmdline=${cmdline%%$'\n'}
 fi
 
+has_linux_t2_entry() {
+  local conf=$1
+
+  [[ -f $conf ]] || return 1
+
+  awk '
+    $0 == "/Omarchy" { expect_kernel = 1; next }
+    expect_kernel {
+      expect_kernel = 0
+      if ($0 == "//linux-t2") {
+        in_kernel = 1
+        next
+      }
+    }
+    in_kernel && /^[[:space:]]*protocol:[[:space:]]*linux[[:space:]]*$/ {
+      found = 1
+      exit
+    }
+    in_kernel && /^\// { in_kernel = 0 }
+    END { exit !found }
+  ' "$conf"
+}
+
 write_linux_t2_entry() {
   local conf=$1
 
-  if [[ -f $conf ]] && grep -qx '/Omarchy' "$conf" && grep -qx '//linux-t2' "$conf"; then
+  if has_linux_t2_entry "$conf"; then
     return 0
   fi
 
   if [[ ! -f $conf ]]; then
-    local template="$OMARCHY_PATH/default/limine/limine.conf"
+    local template="${OMARCHY_PATH:-/usr/share/omarchy}/default/limine/limine.conf"
     if [[ -f $template ]]; then
       sudo install -Dm644 "$template" "$conf"
     else

--- a/test/shell.d/t2-esp-migration-test.sh
+++ b/test/shell.d/t2-esp-migration-test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787076745.sh"
+
+[[ -f $migration ]] || fail "T2 ESP migration exists"
+! grep -q '^#!' "$migration" || fail "T2 ESP migration has no shebang"
+grep -Fq 'echo "Point T2 overlay Limine at /boot/efi and write a linux-t2 entry"' "$migration" ||
+  fail "T2 ESP migration starts with an echo"
+grep -Fq 'lspci -nn | grep "106b:180[12]" >/dev/null' "$migration" ||
+  fail "T2 ESP migration uses the same PCI check as fix-t2.sh"
+! grep -E 'lspci[^[:space:]]*[[:space:]].*grep -q' "$migration" >/dev/null ||
+  fail "T2 ESP migration does not grep -q a chatty lspci"
+pass "T2 ESP migration is a T2-gated quattro migration"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the T2
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no T2 hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+chmod +x "$stub_bin"/*
+
+boot="$test_tmp/boot"
+esp="$test_tmp/boot/efi"
+limine_default="$test_tmp/etc/default/limine"
+reset_enroll="$test_tmp/hooks/10-limine-reset-enroll"
+cmdline_file="$test_tmp/cmdline"
+
+mkdir -p "$boot" "$esp/EFI/BOOT" "$esp/EFI/limine" "$(dirname "$limine_default")" "$(dirname "$reset_enroll")"
+
+cp "$ROOT/default/limine/default.conf" "$limine_default"
+cp "$ROOT/default/limine/limine.conf" "$esp/limine.conf"
+cp "$ROOT/default/limine/limine.conf" "$esp/EFI/BOOT/limine.conf"
+cp "$ROOT/default/limine/limine.conf" "$esp/EFI/limine/limine.conf"
+printf 'vmlinuz-linux-t2\n' >"$boot/vmlinuz-linux-t2"
+printf 'initramfs-linux-t2\n' >"$boot/initramfs-linux-t2.img"
+printf 'limine-reset-enroll\n' >"$reset_enroll"
+printf 'root=/dev/mapper/root rw rootflags=subvol=@ intel_iommu=on iommu=pt\n' >"$cmdline_file"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_BOOT="$boot" \
+    OMARCHY_T2_ESP="$esp" \
+    OMARCHY_T2_BOOT_FSTYPE="$boot_fstype" \
+    OMARCHY_T2_ESP_FSTYPE="$esp_fstype" \
+    OMARCHY_T2_LIMINE_DEFAULT="$limine_default" \
+    OMARCHY_T2_RESET_ENROLL="$reset_enroll" \
+    OMARCHY_T2_RUNNING_CMDLINE="$cmdline_file" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+assert_linux_t2_entry() {
+  local conf=$1
+  local label=$2
+
+  grep -qx '/Omarchy' "$conf" || fail "$label writes /Omarchy"
+  grep -qx '//linux-t2' "$conf" || fail "$label writes //linux-t2"
+  grep -Fq 'protocol: linux' "$conf" || fail "$label writes a protocol: linux stanza"
+  grep -Fq 'path: boot():/vmlinuz-linux-t2' "$conf" || fail "$label points at vmlinuz-linux-t2 on the ESP"
+  grep -Fq 'module_path: boot():/initramfs-linux-t2.img' "$conf" ||
+    fail "$label points at initramfs-linux-t2.img on the ESP"
+  grep -Fq 'cmdline: root=/dev/mapper/root rw rootflags=subvol=@ intel_iommu=on iommu=pt' "$conf" ||
+    fail "$label uses the running kernel command line"
+  grep -Fq 'interface_branding: Omarchy Bootloader' "$conf" ||
+    fail "$label keeps the Omarchy branding template"
+}
+
+boot_fstype=btrfs
+esp_fstype=vfat
+T2_HARDWARE=1 run_migration
+
+grep -Eq '^ESP_PATH=["'\'']?/boot/efi["'\'']?$' "$limine_default" ||
+  fail "overlay T2 migration sets ESP_PATH=/boot/efi"
+! grep -Eq '^ESP_PATH=["'\'']?/boot["'\'']?$' "$limine_default" ||
+  fail "overlay T2 migration replaces ESP_PATH=/boot"
+assert_linux_t2_entry "$esp/limine.conf" "ESP limine.conf"
+assert_linux_t2_entry "$esp/EFI/BOOT/limine.conf" "EFI fallback limine.conf"
+assert_linux_t2_entry "$esp/EFI/limine/limine.conf" "EFI/limine limine.conf"
+cmp -s "$boot/vmlinuz-linux-t2" "$esp/vmlinuz-linux-t2" ||
+  fail "overlay T2 migration copies vmlinuz-linux-t2 onto the ESP"
+cmp -s "$boot/initramfs-linux-t2.img" "$esp/initramfs-linux-t2.img" ||
+  fail "overlay T2 migration copies initramfs-linux-t2.img onto the ESP"
+[[ -e ${reset_enroll}.disabled ]] || fail "overlay T2 migration disables the Limine enroll reset hook"
+[[ ! -e $reset_enroll ]] || fail "the enroll reset hook is renamed, not left in place"
+pass "T2 overlay ESP at /boot/efi gets /Omarchy, //linux-t2, and ESP_PATH"
+
+: >"$calls"
+T2_HARDWARE=1 run_migration
+
+[[ ! -s $calls ]] || fail "an already repaired T2 overlay is left unchanged" "$(cat "$calls")"
+(( $(grep -c '^/Omarchy$' "$esp/limine.conf") == 1 )) ||
+  fail "a second run does not duplicate /Omarchy"
+(( $(grep -c '^//linux-t2$' "$esp/limine.conf") == 1 )) ||
+  fail "a second run does not duplicate //linux-t2"
+pass "T2 overlay ESP migration is idempotent"
+
+cp "$ROOT/default/limine/default.conf" "$limine_default"
+cp "$ROOT/default/limine/limine.conf" "$boot/limine.conf"
+printf 'limine-reset-enroll\n' >"$reset_enroll"
+rm -f "${reset_enroll}.disabled"
+: >"$calls"
+
+boot_fstype=vfat
+esp_fstype=vfat
+T2_HARDWARE=1 run_migration
+
+grep -Eq '^ESP_PATH=["'\'']?/boot["'\'']?$' "$limine_default" ||
+  fail "official /boot-as-ESP keeps ESP_PATH=/boot"
+! grep -q '^/Omarchy$' "$boot/limine.conf" ||
+  fail "official /boot-as-ESP does not write /Omarchy"
+! grep -q '^//linux-t2$' "$boot/limine.conf" ||
+  fail "official /boot-as-ESP does not write //linux-t2"
+[[ -e $reset_enroll ]] || fail "official /boot-as-ESP leaves the enroll reset hook enabled"
+[[ ! -e ${reset_enroll}.disabled ]] || fail "official /boot-as-ESP does not disable the enroll reset hook"
+[[ ! -s $calls ]] || fail "official /boot-as-ESP is a no-op" "$(cat "$calls")"
+pass "official /boot-as-ESP path is a no-op"
+
+cp "$ROOT/default/limine/default.conf" "$limine_default"
+cp "$ROOT/default/limine/limine.conf" "$esp/limine.conf"
+printf 'limine-reset-enroll\n' >"$reset_enroll"
+rm -f "${reset_enroll}.disabled" "$esp/vmlinuz-linux-t2" "$esp/initramfs-linux-t2.img"
+: >"$calls"
+
+boot_fstype=btrfs
+esp_fstype=vfat
+T2_HARDWARE=0 run_migration
+
+grep -Eq '^ESP_PATH=["'\'']?/boot["'\'']?$' "$limine_default" ||
+  fail "non-T2 Limine configuration is unchanged"
+! grep -q '^//linux-t2$' "$esp/limine.conf" || fail "non-T2 ESP limine.conf is unchanged"
+[[ -e $reset_enroll ]] || fail "non-T2 enroll reset hook is unchanged"
+[[ ! -s $calls ]] || fail "non-T2 systems skip the ESP repair" "$(cat "$calls")"
+pass "T2 ESP migration skips unrelated hardware"

--- a/test/shell.d/t2-esp-migration-test.sh
+++ b/test/shell.d/t2-esp-migration-test.sh
@@ -14,6 +14,8 @@ grep -Fq 'lspci -nn | grep "106b:180[12]" >/dev/null' "$migration" ||
   fail "T2 ESP migration uses the same PCI check as fix-t2.sh"
 ! grep -E 'lspci[^[:space:]]*[[:space:]].*grep -q' "$migration" >/dev/null ||
   fail "T2 ESP migration does not grep -q a chatty lspci"
+grep -Fq '${OMARCHY_PATH:-/usr/share/omarchy}' "$migration" ||
+  fail "T2 ESP migration defaults OMARCHY_PATH the same way as other migrations"
 pass "T2 ESP migration is a T2-gated quattro migration"
 
 test_tmp=$(mktemp -d)
@@ -67,33 +69,60 @@ printf 'limine-reset-enroll\n' >"$reset_enroll"
 printf 'root=/dev/mapper/root rw rootflags=subvol=@ intel_iommu=on iommu=pt\n' >"$cmdline_file"
 
 run_migration() {
-  PATH="$stub_bin:$PATH" \
-    TEST_LOG="$calls" \
-    OMARCHY_PATH="$ROOT" \
-    OMARCHY_T2_BOOT="$boot" \
-    OMARCHY_T2_ESP="$esp" \
-    OMARCHY_T2_BOOT_FSTYPE="$boot_fstype" \
-    OMARCHY_T2_ESP_FSTYPE="$esp_fstype" \
-    OMARCHY_T2_LIMINE_DEFAULT="$limine_default" \
-    OMARCHY_T2_RESET_ENROLL="$reset_enroll" \
-    OMARCHY_T2_RUNNING_CMDLINE="$cmdline_file" \
-    bash -euo pipefail "$migration" >/dev/null
+  local -a env=(
+    PATH="$stub_bin:$PATH"
+    TEST_LOG="$calls"
+    OMARCHY_T2_BOOT="$boot"
+    OMARCHY_T2_ESP="$esp"
+    OMARCHY_T2_BOOT_FSTYPE="$boot_fstype"
+    OMARCHY_T2_ESP_FSTYPE="$esp_fstype"
+    OMARCHY_T2_LIMINE_DEFAULT="$limine_default"
+    OMARCHY_T2_RESET_ENROLL="$reset_enroll"
+    OMARCHY_T2_RUNNING_CMDLINE="$cmdline_file"
+  )
+
+  if [[ ${SET_OMARCHY_PATH:-1} == 1 ]]; then
+    env+=(OMARCHY_PATH="$ROOT")
+    env "${env[@]}" bash -euo pipefail "$migration" >/dev/null
+  else
+    env -u OMARCHY_PATH "${env[@]}" bash -euo pipefail "$migration" >/dev/null
+  fi
+}
+
+has_contiguous_linux_t2_entry() {
+  local conf=$1
+
+  [[ -f $conf ]] || return 1
+
+  awk '
+    $0 == "/Omarchy" { expect_kernel = 1; next }
+    expect_kernel {
+      expect_kernel = 0
+      if ($0 == "//linux-t2") {
+        in_kernel = 1
+        next
+      }
+    }
+    in_kernel && /^[[:space:]]*protocol:[[:space:]]*linux[[:space:]]*$/ {
+      found = 1
+      exit
+    }
+    in_kernel && /^\// { in_kernel = 0 }
+    END { exit !found }
+  ' "$conf"
 }
 
 assert_linux_t2_entry() {
   local conf=$1
   local label=$2
 
-  grep -qx '/Omarchy' "$conf" || fail "$label writes /Omarchy"
-  grep -qx '//linux-t2' "$conf" || fail "$label writes //linux-t2"
-  grep -Fq 'protocol: linux' "$conf" || fail "$label writes a protocol: linux stanza"
+  has_contiguous_linux_t2_entry "$conf" ||
+    fail "$label writes contiguous /Omarchy, //linux-t2, protocol: linux"
   grep -Fq 'path: boot():/vmlinuz-linux-t2' "$conf" || fail "$label points at vmlinuz-linux-t2 on the ESP"
   grep -Fq 'module_path: boot():/initramfs-linux-t2.img' "$conf" ||
     fail "$label points at initramfs-linux-t2.img on the ESP"
   grep -Fq 'cmdline: root=/dev/mapper/root rw rootflags=subvol=@ intel_iommu=on iommu=pt' "$conf" ||
     fail "$label uses the running kernel command line"
-  grep -Fq 'interface_branding: Omarchy Bootloader' "$conf" ||
-    fail "$label keeps the Omarchy branding template"
 }
 
 boot_fstype=btrfs
@@ -107,6 +136,8 @@ grep -Eq '^ESP_PATH=["'\'']?/boot/efi["'\'']?$' "$limine_default" ||
 assert_linux_t2_entry "$esp/limine.conf" "ESP limine.conf"
 assert_linux_t2_entry "$esp/EFI/BOOT/limine.conf" "EFI fallback limine.conf"
 assert_linux_t2_entry "$esp/EFI/limine/limine.conf" "EFI/limine limine.conf"
+grep -Fq 'interface_branding: Omarchy Bootloader' "$esp/limine.conf" ||
+  fail "ESP limine.conf keeps the Omarchy branding template"
 cmp -s "$boot/vmlinuz-linux-t2" "$esp/vmlinuz-linux-t2" ||
   fail "overlay T2 migration copies vmlinuz-linux-t2 onto the ESP"
 cmp -s "$boot/initramfs-linux-t2.img" "$esp/initramfs-linux-t2.img" ||
@@ -123,7 +154,60 @@ T2_HARDWARE=1 run_migration
   fail "a second run does not duplicate /Omarchy"
 (( $(grep -c '^//linux-t2$' "$esp/limine.conf") == 1 )) ||
   fail "a second run does not duplicate //linux-t2"
+(( $(grep -c 'path: boot():/vmlinuz-linux-t2' "$esp/limine.conf") == 1 )) ||
+  fail "a second run does not duplicate the linux-t2 path"
 pass "T2 overlay ESP migration is idempotent"
+
+# The old grep -qx pair treated these leftover strings as a finished entry.
+write_scattered_limine_conf() {
+  {
+    cat "$ROOT/default/limine/limine.conf"
+    cat <<'EOF'
+
+/Other
+//linux-t2
+    protocol: efi
+    path: boot():/EFI/BOOT/BOOTX64.EFI
+
+/Omarchy
+    protocol: efi
+    path: boot():/EFI/Linux/omarchy_linux.efi
+EOF
+  } >"$1"
+}
+
+write_scattered_limine_conf "$esp/limine.conf"
+write_scattered_limine_conf "$esp/EFI/BOOT/limine.conf"
+write_scattered_limine_conf "$esp/EFI/limine/limine.conf"
+has_contiguous_linux_t2_entry "$esp/limine.conf" &&
+  fail "the scattered-stanza fixture must not already look like a linux-t2 entry"
+: >"$calls"
+
+T2_HARDWARE=1 run_migration
+
+assert_linux_t2_entry "$esp/limine.conf" "scattered ESP limine.conf"
+assert_linux_t2_entry "$esp/EFI/BOOT/limine.conf" "scattered EFI fallback limine.conf"
+assert_linux_t2_entry "$esp/EFI/limine/limine.conf" "scattered EFI/limine limine.conf"
+(( $(grep -c 'path: boot():/vmlinuz-linux-t2' "$esp/limine.conf") == 1 )) ||
+  fail "scattered leftover strings still get exactly one linux-t2 path"
+pass "split /Omarchy and //linux-t2 strings still get the real entry"
+
+: >"$calls"
+T2_HARDWARE=1 run_migration
+
+[[ ! -s $calls ]] || fail "a repaired scattered config is left unchanged" "$(cat "$calls")"
+(( $(grep -c 'path: boot():/vmlinuz-linux-t2' "$esp/limine.conf") == 1 )) ||
+  fail "a second run does not duplicate the linux-t2 path on a scattered config"
+(( $(grep -c '^/Omarchy$' "$esp/limine.conf") == 2 )) ||
+  fail "the leftover /Omarchy stanza is kept and not rewritten"
+pass "scattered-stanza repair is idempotent"
+
+rm -f "$esp/EFI/limine/limine.conf"
+: >"$calls"
+SET_OMARCHY_PATH=0 T2_HARDWARE=1 run_migration
+
+assert_linux_t2_entry "$esp/EFI/limine/limine.conf" "unset OMARCHY_PATH ESP limine.conf"
+pass "unset OMARCHY_PATH does not abort the template copy"
 
 cp "$ROOT/default/limine/default.conf" "$limine_default"
 cp "$ROOT/default/limine/limine.conf" "$boot/limine.conf"


### PR DESCRIPTION
Sections 1–2 of https://github.com/basecamp/omarchy/issues/7347 only. Does not close the issue (PipeWire ALSA remains #7348; hid_apple fnmode is #7110 / #7343).

On a MacBookPro16,3 that came up through t2archinstall + `curl -fsSL https://omarchy.org/install`, the ESP is vfat at `/boot/efi` and `/boot` is a directory on btrfs. Omarchy Limine still has `ESP_PATH="/boot"`. `limine-update` then writes the branding-only template where Apple firmware never looks, toasts `Target OS name 'Omarchy' not found`, and leaves no `protocol: linux` entry. The gold EFI fallback black-screens; the machine only boots the leftover Arch entry.

The official installer path, where `/boot` itself is the ESP, is unchanged.

## Changes
- `migrations/1787076745.sh` is T2-gated on the same `lspci -nn` / `106b:180[12]` check (`grep >/dev/null`, not `grep -q`, so a chatty lspci cannot SIGPIPE into a false skip)
- When `/boot` is already vfat, the migration exits 0 and writes nothing
- When `/boot` is not vfat and `/boot/efi` is, it sets `ESP_PATH=/boot/efi`, copies `vmlinuz-linux-t2` and `initramfs-linux-t2.img` onto that ESP, and writes `/Omarchy` plus `//linux-t2` (`protocol: linux`) on the ESP `limine.conf` files firmware and limine-entry-tool actually read
- The enroll reset hook `10-limine-reset-enroll` is renamed `10-limine-reset-enroll.disabled` so a later limine/pacman run cannot wipe the working ESP entry (section 2)
- `test/shell.d/t2-esp-migration-test.sh` covers overlay repair, idempotence, official `/boot`-as-ESP no-op, and non-T2 skip, in the same stub style as `t2-hardware-test.sh`

Does not touch PipeWire, hid_apple / fnmode, or `omarchy-refresh-limine`.