### PR TITLE
Keep background refreshes from scrolling an open select menu

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -252,12 +252,13 @@ Item {
     root.itemOrder = mergedMenu.itemOrder
     root.rowsLoaded = true
     root.evaluateGuards()
-    if (root.opened) {
+    // Dmenu rows come solely from dmenuOptions, so item changes never redraw
+    // an open dmenu: clearing the model would reset its scroll under the
+    // reader for rows that cannot have changed.
+    if (root.opened && !root.dmenuActive) {
       root.rebuildDisplay()
-      if (!root.dmenuActive) {
-        if (root.filterText.trim()) root.loadProvidersForSearch()
-        else root.loadProviderForMenu(root.activeMenu)
-      }
+      if (root.filterText.trim()) root.loadProvidersForSearch()
+      else root.loadProviderForMenu(root.activeMenu)
     }
   }
 
@@ -325,7 +326,7 @@ Item {
     var merged = MenuModel.mergeAppRows(root.items, root.itemOrder, appRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
-    if (root.opened) root.rebuildDisplay()
+    if (root.opened && !root.dmenuActive) root.rebuildDisplay()
   }
 
   function startProviderForMenu(id) {
@@ -390,7 +391,7 @@ Item {
     var merged = MenuModel.swapProviderRows(root.items, root.itemOrder, menuId, providerRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
-    if (root.opened) root.rebuildDisplay()
+    if (root.opened && !root.dmenuActive) root.rebuildDisplay()
   }
 
   function startNextProvider() {
@@ -1056,7 +1057,7 @@ Item {
       root.whenResults = nextWhen
       root.checkedResults = nextChecked
       root.disabledResults = nextDisabled
-      if (root.opened) root.rebuildDisplay()
+      if (root.opened && !root.dmenuActive) root.rebuildDisplay()
       // Run the evaluation that had to stand aside. Deferred by a turn so the
       // process is settled before its command is set again.
       if (root.guardsPending) Qt.callLater(function() { root.evaluateGuards() })

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -581,6 +581,21 @@ assert(
   'menu never writes into the item map held by the var property'
 )
 
+// Dmenu rows come solely from dmenuOptions, so a background refresh landing
+// mid-read — a desktop-entry rescan, a provider exit, a guard batch, a menu
+// source reload — must not rebuild an open dmenu: clearing the model resets
+// the scroll position under the reader for rows that cannot have changed.
+const backgroundRebuilds = menuQml.match(/if \(root\.opened[^\n]*\)(?: \{)?\s*\n?\s*root\.rebuildDisplay\(\)/g) || []
+assertEqual(
+  backgroundRebuilds.length,
+  4,
+  'menu rebuilds the open display from app, provider, guard, and source refreshes'
+)
+assert(
+  backgroundRebuilds.every(function(site) { return site.includes('!root.dmenuActive') }),
+  'menu background refreshes leave an open dmenu untouched'
+)
+
 for (const functionName of ['openExistingMenu', 'openDmenu']) {
   const openMatch = menuQml.match(new RegExp(`function ${functionName}\\([^)]*\\) \\{([\\s\\S]*?)\\n  \\}`))
   assert(openMatch, `menu ${functionName} function exists`)


### PR DESCRIPTION
Leave the Shortcuts menu (Super+K) open for a few seconds and it snaps back to the top while you're reading. Anything that wakes the desktop-entry watcher triggers it — mise stamps `~/.local/share` on every shell activation, so on a machine with mise the menu resets every few seconds.

The chain: `DesktopEntries` rescans → `AppLibrary` fires `appsChanged` → the menu plugin's `mergeAppRows()` ends with `rebuildDisplay()` on the open menu (armed once the apps provider has loaded during the shell's lifetime). In dmenu mode the rows come solely from `dmenuOptions`, so the rebuild clears and re-appends an identical model, resetting the ListView's scroll; `revealCursor()` then scrolls back to the cursor, which wheel scrolling never moved off row 0. Provider exits, guard batches, and menu source reloads hit the same path.

Fix: skip the display rebuild in the four async completion paths when a dmenu is active. Menu mode is unchanged — those rebuilds still run there, where rows genuinely depend on the refreshed data.

Testing:
- `test/shell.d/menu-test.sh` now asserts all four `root.opened`-guarded `rebuildDisplay()` sites carry `!root.dmenuActive`; `./test/shell` passes.
- Reproduced and verified in a QEMU VM via omarchy-iso: open the Shortcuts menu, wheel-scroll down, drop a new `.desktop` file to force a rescan. Stock 4.0.0 and pre-fix HEAD snap back to the top (after-trigger frame pixel-identical to the opening frame); with this change the scrolled position holds (pixel-identical to the scrolled frame).