### PR TITLE
Capture open plugin panels in screenshots

### DIFF
--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -49,13 +49,36 @@ window_rects() {
     '[.[] | select(.workspace.id == ($ws | tonumber) and .hidden != true) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"] | unique[]'
 }
 
+open_plugin_rects() {
+  local geometry
+
+  # Plugin panels are commonly full-screen transparent layer-shell surfaces.
+  # Ask the shell for their visible card geometry, rather than selecting their
+  # bar icon or the invisible full-screen surface.
+  geometry=$(omarchy-shell shell listCaptureTargets 2>/dev/null) || return 0
+
+  jq -r '
+    .[] |
+    select(.visible == true and .width > 0 and .height > 0) |
+    "\(.x),\(.y) \(.width)x\(.height)"
+  ' <<<"$geometry" 2>/dev/null
+}
+
+capture_target_rects() {
+  open_plugin_rects
+  window_rects
+}
+
 monitor_rects() {
-  hyprctl monitors -j | jq -r --arg ws "$(active_workspace)" "${JQ_MONITOR_GEO} .[] | select(.activeWorkspace.id == (\$ws | tonumber)) | format_geo"
+  # A monitor can show a workspace other than the focused one. It remains a
+  # valid capture target even when it has no windows, so do not limit these
+  # rectangles to active_workspace().
+  hyprctl monitors -j | jq -r "${JQ_MONITOR_GEO} .[] | select(.disabled != true) | format_geo"
 }
 
 get_rectangles() {
   monitor_rects
-  window_rects
+  capture_target_rects
 }
 
 focused_monitor_geo() {
@@ -64,9 +87,10 @@ focused_monitor_geo() {
 
 # slurp highlights the smallest box containing the point and keeps the first
 # one on a tie, so overlapping rectangles resolve the same way here (e.g.
-# floating over tiled). Reads candidates on stdin and leaves the answer in
-# RESOLVED_RECT; returns 1 when no candidate contains the point. Assigning to
-# a global rather than printing keeps the probing in warp_point_in fork-free.
+# a plugin card over its monitor). Reads candidates on stdin and leaves the
+# answer in RESOLVED_RECT; returns 1 when no candidate contains the point.
+# Assigning to a global rather than printing keeps the probing in
+# warp_point_in fork-free.
 resolve_rect_at() {
   local x=$1 y=$2
   local rect area
@@ -116,15 +140,15 @@ warp_point_in() {
   return 1
 }
 
-# Whatever slurp is highlighting under the cursor. It is fed monitor rects as
-# well as window rects, so a cursor in a gap or over the bar highlights the
-# monitor rather than any window.
+# Whatever slurp is highlighting under the cursor. It is fed monitor,
+# application-window, and open-plugin-panel rects, so a cursor in a gap
+# highlights the monitor while a cursor over an open plugin selects its card.
 geo_at_cursor() {
   local pos=$(hyprctl cursorpos)
   local x=${pos%,*}
   local y=${pos#*, }
 
-  if resolve_rect_at "$x" "$y" < <(window_rects) || resolve_rect_at "$x" "$y" < <(monitor_rects); then
+  if resolve_rect_at "$x" "$y" < <(capture_target_rects) || resolve_rect_at "$x" "$y" < <(monitor_rects); then
     echo "$RESOLVED_RECT"
   else
     focused_monitor_geo
@@ -148,7 +172,7 @@ if [[ ${1:-} == "--take-window" ]]; then
   exit 0
 fi
 
-# Warps the cursor to another window's center, so slurp's own hover
+# Warps the cursor to another capture target's center, so slurp's own hover
 # highlight tracks the selection.
 if [[ ${1:-} == "--select-window" ]]; then
   pgrep -x slurp >/dev/null || exit 0
@@ -158,7 +182,7 @@ if [[ ${1:-} == "--select-window" ]]; then
   origin_x=${pos%,*}
   origin_y=${pos#*, }
 
-  candidates=$(window_rects)
+  candidates=$(capture_target_rects)
 
   # Eighth fractions of a rectangle's width and height, ordered by distance
   # from its center so warp_point_in prefers the most central point it can use.
@@ -321,8 +345,9 @@ region)
   SELECTION=$(pick)
   ;;
 windows)
+  RECTS=$(get_rectangles)
   freeze_screen
-  SELECTION=$(get_rectangles | pick -r)
+  SELECTION=$(pick -r <<<"$RECTS")
   ;;
 fullscreen)
   SELECTION=$(focused_monitor_geo)

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -54,15 +54,15 @@ hl.on("layer.opened", function(layer)
     selection_layers = selection_layers + 1
     if selection_layers == 1 then
       selection_binds = {
-        hl.bind("RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), { description = "Capture highlighted window" }),
+        hl.bind("RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), { description = "Capture highlighted target" }),
         hl.bind("CTRL + RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen"), { description = "Capture entire screen" }),
-        hl.bind("TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window next"), { description = "Select next window to capture" }),
-        hl.bind("CTRL + TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window prev"), { description = "Select previous window to capture" }),
+        hl.bind("TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window next"), { description = "Select next capture target" }),
+        hl.bind("CTRL + TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window prev"), { description = "Select previous capture target" }),
       }
       for _, direction in ipairs({ "left", "right", "up", "down" }) do
         table.insert(
           selection_binds,
-          hl.bind(direction:upper(), hl.dsp.exec_cmd("omarchy-capture-region --select-window " .. direction), { description = "Select window to capture" })
+          hl.bind(direction:upper(), hl.dsp.exec_cmd("omarchy-capture-region --select-window " .. direction), { description = "Select capture target" })
         )
       end
     end

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -13,13 +13,13 @@ Everything you can grab off the screen hangs off the Print Screen key. One key o
 
 ## Screenshots
 
-Hit `Print Screen` and the screen freezes so nothing shifts under you while you aim. Drag a box for a freeform region, or just click once and the shot snaps to whatever rectangle you clicked in — a window if you landed on one, the whole monitor if you landed on the bar or in a gap. Changed your mind? Hit `Print Screen` again to dismiss the picker.
+Hit `Print Screen` and the screen freezes so nothing shifts under you while you aim. Drag a box for a freeform region, or just click once and the shot snaps to whatever rectangle you clicked in — a window, the visible panel of an open plugin, or the whole monitor if you landed on the bar or in a gap. Changed your mind? Hit `Print Screen` again to dismiss the picker.
 
 The result goes two places at once: a PNG in your pictures directory, and the clipboard, so you can paste it straight into a chat window with `Super + V`. A notification pops up with a thumbnail. Click it (or hit `Super + Alt + ,` to invoke the last notification) and the shot opens in Tensaku, the annotation editor, where you can draw arrows and boxes on it before you send it.
 
 Files land in `~/Pictures` by default, named `screenshot-2026-08-13_14-22-05.png`. If you'd rather keep them in their own folder, set `OMARCHY_SCREENSHOT_DIR` — see [the FAQ](46-faq.md) for where to put session environment variables. Omarchy creates the directory for you if it isn't there. You can swap the editor too with `OMARCHY_SCREENSHOT_EDITOR`.
 
-From the terminal, `omarchy screenshot` takes the same shot, and you can be explicit about it: `omarchy capture screenshot region` for freeform only, `windows` to snap to window and monitor rectangles, or `fullscreen` to skip the picker entirely and grab the focused monitor. A second argument of `copy` puts the shot only on the clipboard, and `save` only on disk.
+From the terminal, `omarchy screenshot` takes the same shot, and you can be explicit about it: `omarchy capture screenshot region` for freeform only, `windows` to snap to windows, open plugin panels, and monitors, or `fullscreen` to skip the picker entirely and grab the focused monitor. A second argument of `copy` puts the shot only on the clipboard, and `save` only on disk.
 
 ### Driving the picker from the keyboard
 
@@ -27,16 +27,16 @@ While the selection is up, you don't have to use the mouse at all:
 
 | Key | Function |
 | --- | -------- |
-| `Return` | Capture the highlighted window |
+| `Return` | Capture the highlighted target |
 | `Ctrl + Return` | Capture the whole screen |
-| `Tab` / `Ctrl + Tab` | Highlight the next / previous window |
-| Arrow keys | Highlight the window in that direction |
+| `Tab` / `Ctrl + Tab` | Highlight the next / previous target |
+| Arrow keys | Highlight the target in that direction |
 
-The arrows and Tab move the cursor to the window they pick, so the highlight follows along and you can see what you're about to capture. These bindings only exist while a selection is on screen, so they can't collide with anything in your own config.
+The arrows and Tab move the cursor to the target they pick, so the highlight follows along and you can see what you're about to capture. These bindings only exist while a selection is on screen, so they can't collide with anything in your own config.
 
 ## Screen recording
 
-`Alt + Print Screen` opens _Trigger > Capture > Screenrecord_, which asks what you want on the soundtrack: no audio, desktop audio, desktop plus microphone, or desktop plus microphone plus webcam. That last one only shows up if you actually have a camera plugged in. Pick one and you get the same picker as a screenshot: drag a region, or click a window or monitor.
+`Alt + Print Screen` opens _Trigger > Capture > Screenrecord_, which asks what you want on the soundtrack: no audio, desktop audio, desktop plus microphone, or desktop plus microphone plus webcam. That last one only shows up if you actually have a camera plugged in. Pick one and you get the same picker as a screenshot: drag a region, or click a window, an open plugin panel, or a monitor.
 
 Recording runs on gpu-screen-recorder, which encodes on the GPU at 60fps and falls back to the CPU if it has to. The result is an MP4 in `~/Videos`, named `screenrecording-2026-08-13_14-22-05.mp4`. Set `OMARCHY_SCREENRECORD_DIR` to change that — but note that unlike the screenshot directory, this one has to exist already, or the recording refuses to start.
 

--- a/shell/Ui/CaptureTarget.qml
+++ b/shell/Ui/CaptureTarget.qml
@@ -1,0 +1,60 @@
+import QtQuick
+
+// Registers the painted portion of a plugin panel as a capture target.
+// Layer-shell panels often span the full output with a transparent backdrop,
+// so compositor window geometry cannot describe the card the user sees.
+QtObject {
+  id: root
+
+  required property var shell
+  required property var window
+  required property Item item
+  required property string targetId
+  property bool active: true
+  property var registeredShell: null
+
+  function syncRegistration() {
+    if (registeredShell === shell) return
+    if (registeredShell && registeredShell.unregisterCaptureTarget)
+      registeredShell.unregisterCaptureTarget(root)
+    registeredShell = shell
+    if (registeredShell && registeredShell.registerCaptureTarget)
+      registeredShell.registerCaptureTarget(root)
+  }
+
+  function captureGeometry() {
+    if (!active || !window || !window.screen || !item || !item.visible || item.width <= 0 || item.height <= 0) return null
+    var points = [
+      item.mapToItem(null, 0, 0),
+      item.mapToItem(null, item.width, 0),
+      item.mapToItem(null, 0, item.height),
+      item.mapToItem(null, item.width, item.height)
+    ]
+    var left = points[0].x
+    var top = points[0].y
+    var right = points[0].x
+    var bottom = points[0].y
+    for (var i = 1; i < points.length; i++) {
+      left = Math.min(left, points[i].x)
+      top = Math.min(top, points[i].y)
+      right = Math.max(right, points[i].x)
+      bottom = Math.max(bottom, points[i].y)
+    }
+    return {
+      id: targetId,
+      screen: String(window.screen.name || ""),
+      x: Math.round(window.screen.x + left),
+      y: Math.round(window.screen.y + top),
+      width: Math.round(right - left),
+      height: Math.round(bottom - top),
+      visible: true
+    }
+  }
+
+  onShellChanged: syncRegistration()
+  Component.onCompleted: syncRegistration()
+  Component.onDestruction: {
+    if (registeredShell && registeredShell.unregisterCaptureTarget)
+      registeredShell.unregisterCaptureTarget(root)
+  }
+}

--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -415,4 +415,12 @@ PanelWindow {
       }
     }
   }
+
+  CaptureTarget {
+    shell: root.bar && root.bar.shell ? root.bar.shell : null
+    window: root
+    item: card
+    targetId: root.owner && root.owner.moduleName ? String(root.owner.moduleName) : "plugin-panel"
+    active: root.open
+  }
 }

--- a/shell/Ui/qmldir
+++ b/shell/Ui/qmldir
@@ -8,6 +8,7 @@ BorderSurface 1.0 BorderSurface.qml
 Button 1.0 Button.qml
 ButtonGroup 1.0 ButtonGroup.qml
 ConfirmDialog 1.0 ConfirmDialog.qml
+CaptureTarget 1.0 CaptureTarget.qml
 CursorSurface 1.0 CursorSurface.qml
 Dropdown 1.0 Dropdown.qml
 KeyboardPanel 1.0 KeyboardPanel.qml

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -10,7 +10,9 @@ Item {
   id: root
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  property var shell: null
   property bool opened: false
+
   property string filterText: ""
   property int selectedIndex: 0
   property bool cursorActive: false
@@ -605,5 +607,13 @@ Item {
         }
       }
     }
+  }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.clipboard"
+    active: panel.visible
   }
 }

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -339,4 +339,12 @@ Item {
       }
     }
   }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.emojis"
+    active: panel.visible
+  }
 }

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -5,6 +5,7 @@ import QtQuick
 import QtQuick.Effects
 import QtQuick.Shapes
 import qs.Commons
+import qs.Ui
 import "ImagePickerModel.js" as ImagePickerModel
 
 Item {
@@ -12,6 +13,7 @@ Item {
 
   // Injected by omarchy-shell; defaults to the session OMARCHY_PATH.
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  property var shell: null
   property string stateHome: Quickshell.env("HOME") + "/.local/state"
   property string imageDirs: Quickshell.env("OMARCHY_IMAGE_SELECTOR_DIRS") || Quickshell.env("OMARCHY_IMAGE_SELECTOR_DIR") || Quickshell.env("OMARCHY_STOCK_BACKGROUNDS_DIR") || (stateHome + "/omarchy/current/theme/backgrounds")
   property string imageRows: ""
@@ -21,6 +23,7 @@ Item {
   property int selectedIndex: 0
   property bool imagesLoaded: false
   property bool opened: false
+
   property bool showLabels: false
   property bool filterable: false
   property bool layoutSettled: false
@@ -576,5 +579,13 @@ Item {
           elide: Text.ElideRight
         }
     }
+  }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.image-picker"
+    active: panel.visible && card.visible
   }
 }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1470,4 +1470,12 @@ Item {
       }
     }
   }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.menu"
+    active: panel.visible
+  }
 }

--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -9,6 +9,7 @@ import "OsdModel.js" as OsdModel
 Item {
   id: root
 
+  property var shell: null
   property bool opened: false
   property string icon: ""
   property string message: ""
@@ -200,5 +201,13 @@ Item {
         }
       }
     }
+  }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.osd"
+    active: panel.visible
   }
 }

--- a/shell/plugins/panels/wifiqr/Panel.qml
+++ b/shell/plugins/panels/wifiqr/Panel.qml
@@ -211,6 +211,7 @@ Item {
   }
 
   PanelWindow {
+    id: panel
     visible: root.opened
     anchors { top: true; bottom: true; left: true; right: true }
     color: "transparent"
@@ -239,6 +240,7 @@ Item {
       Keys.onEscapePressed: root.dismiss()
 
       Item {
+        id: card
         anchors.centerIn: parent
         width: content.implicitWidth
         height: content.implicitHeight
@@ -362,5 +364,13 @@ Item {
         }
       }
     }
+  }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.wifiqr"
+    active: panel.visible
   }
 }

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -169,4 +169,12 @@ Item {
       }
     }
   }
+
+  CaptureTarget {
+    shell: root.shell
+    window: panel
+    item: card
+    targetId: "omarchy.reminders"
+    active: panel.visible
+  }
 }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -412,6 +412,36 @@ ShellRoot {
   // QML to notice the change.
   property var openPanelIds: ({})
 
+  // Visible plugin panels are often full-screen transparent layer-shell
+  // windows. Keep their inner-card geometry separately so tools such as the
+  // screenshot picker can target what the user actually sees.
+  property var captureTargets: []
+
+  function registerCaptureTarget(target) {
+    if (!target || captureTargets.indexOf(target) !== -1) return
+    captureTargets = captureTargets.concat([target])
+  }
+
+  function unregisterCaptureTarget(target) {
+    captureTargets = captureTargets.filter(function(item) { return item !== target })
+  }
+
+  function captureTargetGeometry() {
+    var out = []
+    function append(target) {
+      if (!target || typeof target.captureGeometry !== "function") return
+      var geometry = null
+      try { geometry = target.captureGeometry() } catch (e) {
+        console.warn("capture geometry failed for", target.targetId || "unknown target", e)
+        return
+      }
+      if (!geometry || !geometry.visible || geometry.width <= 0 || geometry.height <= 0) return
+      out.push(geometry)
+    }
+    for (var i = 0; i < captureTargets.length; i++) append(captureTargets[i])
+    return out
+  }
+
   // Pending payloads to deliver to a plugin's open() once its loader resolves.
   // Keyed by plugin id; the value is an array so two summon() calls before
   // the Loader resolves both reach the plugin in arrival order rather than
@@ -997,6 +1027,10 @@ ShellRoot {
 
     function debugBarGeometry(): string {
       return JSON.stringify(shell.bar && shell.bar.debugBarGeometry ? shell.bar.debugBarGeometry() : [])
+    }
+
+    function listCaptureTargets(): string {
+      return JSON.stringify(shell.captureTargetGeometry())
     }
 
     function summon(id: string, payloadJson: string): string {

--- a/test/shell.d/capture-region-test.sh
+++ b/test/shell.d/capture-region-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+cleanup() {
+  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+TMPDIR=$(mktemp -d)
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+case "$*" in
+  "monitors -j")
+    printf '%s\n' '[{"name":"focused","x":0,"y":0,"width":1920,"height":1080,"scale":1,"transform":0,"focused":true,"activeWorkspace":{"id":1}},{"name":"empty","x":1920,"y":0,"width":1920,"height":1080,"scale":1,"transform":0,"focused":false,"activeWorkspace":{"id":2}}]'
+    ;;
+  "clients -j")
+    printf '%s\n' '[{"at":[0,26],"size":[1920,1054],"workspace":{"id":1},"hidden":false}]'
+    ;;
+  "cursorpos")
+    printf '%s\n' '110,10'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$stub_bin/hyprctl"
+
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+[[ $* == "shell listCaptureTargets" ]] || exit 1
+printf '%s\n' '[{"id":"omarchy.clock","screen":"focused","x":100,"y":32,"width":360,"height":420,"visible":true},{"id":"omarchy.network","screen":"empty","x":2020,"y":32,"width":420,"height":530,"visible":true}]'
+SH
+chmod +x "$stub_bin/omarchy-shell"
+
+cat >"$stub_bin/hyprpicker" <<'SH'
+#!/bin/bash
+while :; do sleep 1; done
+SH
+chmod +x "$stub_bin/hyprpicker"
+
+cat >"$stub_bin/slurp" <<'SH'
+#!/bin/bash
+cat >"$CAPTURE_CANDIDATES"
+printf '%s\n' '100,32 360x420'
+SH
+chmod +x "$stub_bin/slurp"
+
+CAPTURE_CANDIDATES="$TMPDIR/candidates"
+selection=$(
+  OMARCHY_PATH="$ROOT" \
+  CAPTURE_CANDIDATES="$CAPTURE_CANDIDATES" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-capture-region" smart
+)
+
+grep -Fx '100,32 360x420' "$CAPTURE_CANDIDATES" >/dev/null \
+  || fail "smart picker receives open-plugin panel geometry"
+grep -Fx '2020,32 420x530' "$CAPTURE_CANDIDATES" >/dev/null \
+  || fail "smart picker receives secondary-monitor open-plugin panel geometry"
+grep -Fx '0,0 1920x1080' "$CAPTURE_CANDIDATES" >/dev/null \
+  || fail "smart picker keeps monitor geometry"
+grep -Fx '1920,0 1920x1080' "$CAPTURE_CANDIDATES" >/dev/null \
+  || fail "smart picker keeps an empty secondary monitor"
+grep -Fx '0,26 1920x1054' "$CAPTURE_CANDIDATES" >/dev/null \
+  || fail "smart picker keeps application-window geometry"
+[[ $selection == '100,32 360x420' ]] \
+  || fail "smart picker captures the plugin-sized selection" "got: $selection"
+
+pass "smart screenshot picker includes open-plugin panel geometry"


### PR DESCRIPTION
## Summary

- add visible plugin panels as screenshot and screen-recording capture targets
- provide a reusable  component for built-in and third-party panels
- keep every enabled monitor selectable, including an empty secondary monitor
- update picker labels, documentation, and focused test coverage

## Why

Most plugin panels are full-screen transparent layer-shell surfaces, so compositor window geometry describes the entire monitor instead of the card the user can actually see. The picker now asks the shell for each registered card's global geometry and offers it alongside application windows and monitors.

Monitor targets were also limited to the focused workspace. Listing every enabled monitor keeps an empty secondary display selectable.

## Verification

- ok - smart screenshot picker includes open-plugin panel geometry
- ok - bin commands use command helpers
ok - bin commands use the notification helper
- ok - fullscreen screenshot shows a nonblank bar band
- ok - main help renders
ok - main help includes hardware group
ok - main help includes package group
ok - main help does not show group counts
ok - commands lists documented commands
ok - commands --json is valid JSON with full bin coverage
ok - all included commands have summaries
ok - JSON uses binary/routes and omits legacy/usage/extra metadata
ok - commands --check passes
ok - commands --all does not crash
ok - fallback commands are inferred and documented
ok - benchmark command is discoverable in all commands
ok - JSON exposes direct pkg add route
ok - Xbox Cloud installer keeps hyphenated canonical route
ok - Xbox controller installer keeps hyphenated canonical route
ok - Xbox controller remover keeps hyphenated canonical route
ok - GeForce NOW installer keeps hyphenated canonical route
ok - GeForce NOW remover keeps hyphenated canonical route
ok - GPU lib32 installer keeps hyphenated canonical route
ok - sudo metadata marks sudo commands
ok - group help renders
ok - install group help renders
ok - install group includes browser route
ok - bare group renders help instead of picker
ok - bare group includes browser route
ok - bare root command with children renders help
ok - bare toggle help includes child route
ok - package group includes pkg add fallback route
ok - restart group includes inferred commands
ok - restart group includes all restart commands
ok - hardware group help renders
ok - hardware group includes touchpad
ok - partial hardware prefix renders matching commands
ok - partial hardware prefix includes nested match
ok - menu group includes share fallback route
ok - bare required-arg alias renders CLI help
ok - bare share help uses canonical route
ok - bare required-arg filename route renders CLI help
ok - every filename-derived group help represents its bins
ok - command help renders without executing
ok - theme set help names binary
ok - mutating command help does not execute target
ok - hidden update perform compatibility wrapper is not shown
ok - a group whose commands are all hidden stays out of the top-level listing
ok - install-time setup plumbing is hidden from the setup wizards
ok - hidden setup plumbing still routes
ok - root alias resolves to command help
ok - aliases are included in JSON metadata
ok - pkg add help resolves
ok - pkg add help shows direct route
ok - system command help is safe
ok - benchmark command runs
ok - safe dispatch works for theme list
ok - safe dispatch works for theme current
ok - safe dispatch works for font list
ok - safe dispatch works for font current
ok - theme template color mix helpers work
ok - theme template semantic aliases expose legacy palette helpers
ok - legacy short palette resolves every canonical neutral color
ok - legacy short palette renders the complete generated theme
ok - theme OSC aliases semantic colors to ANSI palette
ok - theme preview shows background to bright_foreground gradient
ok - theme preview orders light mode ramp light to dark
ok - theme preview includes dark background slots
ok - theme preview shows selected text sample
ok - theme preview shows practical terminal samples
ok - theme preview shows ANSI palette strips
ok - tokyo night foreground ramp stays ordered
ok - built-in colors.toml files omit cursor token
ok - theme template gradient helpers work
ok - theme shell section override is merged
ok - pi theme template is generated from standard themed templates
ok - theme-specific pi.json overrides the default template
ok - pi theme sync skips missing Pi agent when not activating
ok - pi theme file is synced
ok - pi settings file is generated
ok - pi synced theme JSON is valid
ok - pi generated theme is activated
ok - pi theme activation preserves existing settings
ok - claude theme template is generated from standard themed templates
ok - claude theme sync respects CLAUDE_CONFIG_DIR
ok - claude theme activation preserves configured settings
ok - headless theme set creates current background symlink
ok - current theme migration moves state and rewrites shipped references
ok - nvim theme migration relinks current theme
ok - nvim theme repair migration relinks every legacy spelling
ok - hyprland bootstrap migration updates stale user entrypoint
ok - tmux sync reads mode from colors.toml
ok - gnome sync reads mode from colors.toml
ok - vscode generated light theme uses VS Code light uiTheme
ok - vscode generated theme references current theme file
ok - vscode generated theme clears obsolete extension marker
ok - vscode generated theme registers local extension
ok - binary is executable: omarchy-update
ok - binary is executable: omarchy-theme-set
ok - binary is executable: omarchy-capture-screenshot
ok - binary is executable: omarchy-system-reboot
ok - binary is executable: omarchy-pkg-add
ok - all executable bins have slim self-documenting metadata
ok - unknown metadata values are non-fatal
ok - partial metadata keeps inferred fallback route
ok - metadata-looking comments after script body are ignored
ok - temporary metadata command dispatches
ok - partial metadata command dispatches
ok - body metadata command dispatches by filename
ok - trailing --help after an unresolved word renders help
ok - partial resolution help lists related commands
ok - trailing --help after an unresolved word does not execute the command
ok - trailing -h after an unresolved word renders help
ok - trailing --help after an unresolved word renders help via alias route
ok - trailing --help on an alias route does not execute the command
ok - --json with --help renders JSON help
ok - a --json embedded inside one argument does not switch help to JSON
ok - leftover args without a help flag still forward
ok - a --help behind -- belongs to the command and still forwards
ok - help lookalike tokens do not trigger help
- 
- live-verified menu, network, and OSD card geometry in a two-monitor session
- live-verified all 38 configured bar slots reload across both monitors

🤖 Implemented and validated with OpenAI Codex in collaboration with @ArthurWillers.