### PR TITLE
Let Chromium size and position PiP windows (Fixes #7391)

### DIFF
--- a/default/hypr/apps/pip.lua
+++ b/default/hypr/apps/pip.lua
@@ -4,11 +4,8 @@ o.window({ tag = "pip" }, {
   tag = "-default-opacity",
   float = true,
   pin = true,
-  size = { 600, 338 },
-  keep_aspect_ratio = true,
   border_size = 0,
   opacity = "1 1",
-  move = { "(monitor_w-window_w-40)", "(monitor_h*0.04)" },
 })
 
 -- Google Meet PiP uses the meeting title instead of "Picture-in-Picture".
@@ -16,9 +13,6 @@ o.window({ tag = "chromium-based-browser", title = "^Meet - .+" }, {
   tag = "-default-opacity",
   float = true,
   pin = true,
-  size = { 600, 338 },
-  keep_aspect_ratio = true,
   border_size = 0,
   opacity = "1 1",
-  move = { "(monitor_w-window_w-40)", "(monitor_h-window_h-40)" },
 })


### PR DESCRIPTION
Fixes #7391

Chromium PiP windows were always forced to 600x338 (16:9) and could open partially off-screen.

**Cause:** the rules in `default/hypr/apps/pip.lua` set `size = { 600, 338 }` and `keep_aspect_ratio = true`, overriding Chromium's AR-correct PiP sizing; and `move = (monitor_w-window_w-40) ...` is evaluated by Hyprland against the window's client-requested (pre-rule) size, so for videos wider than `monitor_w - 40` the x coordinate underflows and the window opens off-screen. The Google Meet rule had the same trio.

**Change:** drop `size`, `keep_aspect_ratio`, and `move` from both rules. Chromium sizes the PiP to the video's aspect ratio and Hyprland centers it — always fully on-screen. `float`/`pin`/borderless overlay behavior is unchanged.

**Verified:** live repro before/after on a Hyprland 0.56.2 session — before: 21:9 video opened at 600x338 positioned from the client's 374x160 request; after: on-screen, aspect ratio follows the video (tested with 21:9 and vertical videos).
