### PR TITLE
Support pasting Omarchy screenshots into terminals

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -60,11 +60,46 @@ set_no_hw_cursors 0
 FILENAME="screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png"
 FILEPATH="$OUTPUT_DIR/$FILENAME"
 
+publish_image() {
+  local path="$1" copied_path
+
+  setsid -f omarchy-clipboard-publish-image image/png "$path" >/dev/null 2>&1
+  for _ in {1..50}; do
+    if wl-paste --list-types 2>/dev/null | grep -qx 'application/x-omarchy-file-backed-image'; then
+      copied_path=$(wl-paste --type text/plain --no-newline 2>/dev/null || true)
+      [[ $copied_path == "$path" ]] && return 0
+    fi
+    sleep 0.01
+  done
+
+  return 1
+}
+
+capture_to_cache() {
+  local tmp hash path
+  local image_dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/clipboard-images"
+
+  mkdir -p "$image_dir"
+  tmp=$(mktemp --tmpdir="$image_dir" clipboard.XXXXXX)
+  if ! grim -g "$SELECTION" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  hash=$(sha256sum "$tmp" | cut -d' ' -f1)
+  path="$image_dir/$hash.png"
+  if [[ -e $path ]]; then
+    rm -f "$tmp"
+  else
+    mv "$tmp" "$path"
+  fi
+  printf '%s\n' "$path"
+}
+
 case "$PROCESSING" in
   slurp)
     grim -g "$SELECTION" "$FILEPATH" || exit 1
     echo "$FILEPATH"
-    wl-copy --type image/png <"$FILEPATH"
+    publish_image "$FILEPATH" || exit 1
 
     # Best-effort: the screenshot is already saved and on the clipboard, so a
     # notification outage must not report the capture itself as failed.
@@ -73,7 +108,8 @@ case "$PROCESSING" in
       --exec "$(printf '%q %q' "$SCREENSHOT_EDITOR" "$FILEPATH")" || true
     ;;
   copy)
-    grim -g "$SELECTION" - | wl-copy --type image/png
+    FILEPATH=$(capture_to_cache) || exit 1
+    publish_image "$FILEPATH" || exit 1
     ;;
   save)
     grim -g "$SELECTION" "$FILEPATH" || exit 1

--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -60,21 +60,6 @@ set_no_hw_cursors 0
 FILENAME="screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png"
 FILEPATH="$OUTPUT_DIR/$FILENAME"
 
-publish_image() {
-  local path="$1" copied_path
-
-  setsid -f omarchy-clipboard-publish-image image/png "$path" >/dev/null 2>&1
-  for _ in {1..50}; do
-    if wl-paste --list-types 2>/dev/null | grep -qx 'application/x-omarchy-file-backed-image'; then
-      copied_path=$(wl-paste --type text/plain --no-newline 2>/dev/null || true)
-      [[ $copied_path == "$path" ]] && return 0
-    fi
-    sleep 0.01
-  done
-
-  return 1
-}
-
 capture_to_cache() {
   local tmp hash path
   local image_dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/clipboard-images"
@@ -99,7 +84,7 @@ case "$PROCESSING" in
   slurp)
     grim -g "$SELECTION" "$FILEPATH" || exit 1
     echo "$FILEPATH"
-    publish_image "$FILEPATH" || exit 1
+    omarchy-clipboard-publish-image image/png "$FILEPATH" || exit 1
 
     # Best-effort: the screenshot is already saved and on the clipboard, so a
     # notification outage must not report the capture itself as failed.
@@ -109,7 +94,7 @@ case "$PROCESSING" in
     ;;
   copy)
     FILEPATH=$(capture_to_cache) || exit 1
-    publish_image "$FILEPATH" || exit 1
+    omarchy-clipboard-publish-image image/png "$FILEPATH" || exit 1
     ;;
   save)
     grim -g "$SELECTION" "$FILEPATH" || exit 1

--- a/bin/omarchy-clipboard-paste-file
+++ b/bin/omarchy-clipboard-paste-file
@@ -2,28 +2,37 @@
 
 # omarchy:summary=Copy a file to the clipboard and paste it
 # omarchy:group=clipboard
-# omarchy:args=[--copy-only] <mime-type> <path>
+# omarchy:args=[--copy-only] [--file-backed] <mime-type> <path>
 # omarchy:examples=omarchy clipboard paste file image/png /tmp/screenshot.png
 # omarchy:hidden=true
 
 copy_only=false
+file_backed=false
 
-if [[ ${1:-} == "--copy-only" ]]; then
-  copy_only=true
+while [[ ${1:-} == --* ]]; do
+  case "$1" in
+  --copy-only) copy_only=true ;;
+  --file-backed) file_backed=true ;;
+  *) echo "Usage: omarchy-clipboard-paste-file [--copy-only] [--file-backed] <mime-type> <path>" >&2; exit 1 ;;
+  esac
   shift
-fi
+done
 
 mime=${1:-}
 path=${2:-}
 
 if [[ -z $mime || -z $path ]]; then
-  echo "Usage: omarchy-clipboard-paste-file [--copy-only] <mime-type> <path>" >&2
+  echo "Usage: omarchy-clipboard-paste-file [--copy-only] [--file-backed] <mime-type> <path>" >&2
   exit 1
 fi
 
 [[ -r $path ]] || exit 1
 
-wl-copy --type "$mime" < "$path"
+if [[ $file_backed == "true" ]]; then
+  omarchy-clipboard-publish-image "$mime" "$path" || exit 1
+else
+  wl-copy --type "$mime" < "$path"
+fi
 
 if [[ $copy_only == "true" ]]; then
   exit

--- a/bin/omarchy-clipboard-publish-image
+++ b/bin/omarchy-clipboard-publish-image
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Publish an image with file-backed clipboard representations
+# omarchy:group=clipboard
+# omarchy:args=<mime-type> <path>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+mime=${1:-}
+path=${2:-}
+
+if [[ -z $mime || -z $path ]]; then
+  echo "Usage: omarchy-clipboard-publish-image <mime-type> <path>" >&2
+  exit 1
+fi
+
+[[ $mime == image/* && -r $path ]] || exit 1
+
+exec "$OMARCHY_PATH/shell/plugins/clipboard/publish-image.py" "$mime" "$path"

--- a/bin/omarchy-clipboard-publish-image
+++ b/bin/omarchy-clipboard-publish-image
@@ -10,11 +10,21 @@ set -euo pipefail
 mime=${1:-}
 path=${2:-}
 
-if [[ -z $mime || -z $path ]]; then
+if (( $# != 2 )) || [[ -z $mime || -z $path ]]; then
   echo "Usage: omarchy-clipboard-publish-image <mime-type> <path>" >&2
   exit 1
 fi
 
 [[ $mime == image/* && -r $path ]] || exit 1
+path=$(realpath "$path")
 
-exec "$OMARCHY_PATH/shell/plugins/clipboard/publish-image.py" "$mime" "$path"
+setsid -f "$OMARCHY_PATH/shell/plugins/clipboard/publish-image.py" "$mime" "$path" >/dev/null 2>&1
+for _ in {1..50}; do
+  if wl-paste --list-types 2>/dev/null | grep -qx 'application/x-omarchy-file-backed-image' &&
+    [[ $(wl-paste --type text/plain --no-newline 2>/dev/null || true) == "$path" ]]; then
+    exit 0
+  fi
+  sleep 0.01
+done
+
+exit 1

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -143,6 +143,7 @@ Item {
         previewImage: row.previewImage ? Util.fileUrl(row.previewImage) : "",
         path: row.path,
         mime: row.mime,
+        fileBacked: row.fileBacked === true,
         historyIndex: row.index
       })
     }
@@ -216,7 +217,7 @@ Item {
     if (!row) return
     root.opened = false
     if (row.entryType === "image") {
-      Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-file", row.mime, row.path])
+      root.pasteFile(row, false)
     } else if (row.fullText) {
       Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-text", "--shift-insert", "--history-index", String(row.historyIndex)])
     }
@@ -226,10 +227,18 @@ Item {
     if (!row) return
     root.opened = false
     if (row.entryType === "image") {
-      Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-file", "--copy-only", row.mime, row.path])
+      root.pasteFile(row, true)
     } else if (row.fullText) {
       Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-text", "--copy-only", "--history-index", String(row.historyIndex)])
     }
+  }
+
+  function pasteFile(row, copyOnly) {
+    var args = [root.omarchyPath + "/bin/omarchy-clipboard-paste-file"]
+    if (copyOnly) args.push("--copy-only")
+    if (row.fileBacked) args.push("--file-backed")
+    args.push(row.mime, row.path)
+    Quickshell.execDetached(args)
   }
 
   function openSelected(row) {

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -20,6 +20,7 @@ function normalizeEntry(value) {
     }
     if (value.capturedAt !== undefined && value.capturedAt !== null)
       entry.capturedAt = String(value.capturedAt)
+    if (value.fileBacked === true) entry.fileBacked = true
     return entry
   }
 
@@ -190,7 +191,7 @@ function displayRows(history, query, limit) {
     var isFile = paths.length > 0
     var isImage = entry.type === "image"
     var previewPath = isImage ? String(entry.path || "") : (isFile && paths.length === 1 && isImagePath(paths[0]) ? paths[0] : "")
-    rows.push({
+    var row = {
       entryType: isFile ? "file" : entry.type,
       fullText: isImage ? "" : fullText(entry),
       previewText: previewText(entry),
@@ -198,7 +199,9 @@ function displayRows(history, query, limit) {
       path: isImage ? String(entry.path || "") : (isFile && paths.length === 1 ? paths[0] : ""),
       mime: isImage ? String(entry.mime || "image/png") : "text/plain",
       index: i
-    })
+    }
+    if (isImage && entry.fileBacked === true) row.fileBacked = true
+    rows.push(row)
     if (rows.length >= max) break
   }
 

--- a/shell/plugins/clipboard/capture.sh
+++ b/shell/plugins/clipboard/capture.sh
@@ -18,7 +18,7 @@ fi
 
 emit_image() {
   local mime="$1"
-  local ext tmp hash file
+  local ext tmp hash file file_backed=false
 
   ext=${mime#image/}
   [[ $ext == jpeg ]] && ext=jpg
@@ -38,8 +38,9 @@ emit_image() {
     mv "$tmp" "$file"
   fi
 
-  jq -cn --arg mime "$mime" --arg path "$file" --arg captured_at "$(date +'%A %H:%M')" \
-    '{type:"image", mime:$mime, path:$path, capturedAt:$captured_at}'
+  grep -qx 'application/x-omarchy-file-backed-image' <<<"$types" && file_backed=true
+  jq -cn --arg mime "$mime" --arg path "$file" --arg captured_at "$(date +'%A %H:%M')" --argjson file_backed "$file_backed" \
+    '{type:"image", mime:$mime, path:$path, capturedAt:$captured_at} + if $file_backed then {fileBacked:true} else {} end'
 }
 
 emit_text() {

--- a/shell/plugins/clipboard/capture.sh
+++ b/shell/plugins/clipboard/capture.sh
@@ -65,7 +65,12 @@ emit_text() {
 }
 
 case "${1:-}" in
-text) emit_text; exit 0 ;;
+text)
+  # File-backed screenshots expose their path for terminal paste. The image
+  # watcher records the same selection, so do not add a duplicate text entry.
+  grep -qx 'application/x-omarchy-file-backed-image' <<<"$types" || emit_text
+  exit 0
+  ;;
 image/*) emit_image "$1"; exit 0 ;;
 esac
 

--- a/shell/plugins/clipboard/publish-image.py
+++ b/shell/plugins/clipboard/publish-image.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+
+import pathlib
+import sys
+
+import gi
+
+gi.require_version("Gdk", "4.0")
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gdk, GLib, Gtk
+
+
+MARKER_MIME = "application/x-omarchy-file-backed-image"
+
+
+class ClipboardOwnerProvider(Gdk.ContentProvider):
+    __gtype_name__ = "OmarchyClipboardOwnerProvider"
+
+    def __init__(self, provider, on_detach):
+        super().__init__()
+        self.provider = provider
+        self.on_detach = on_detach
+
+    def do_ref_formats(self):
+        return self.provider.ref_formats()
+
+    def do_write_mime_type_async(self, mime, stream, priority, cancellable, callback, user_data):
+        self.provider.write_mime_type_async(mime, stream, priority, cancellable, callback, user_data)
+
+    def do_write_mime_type_finish(self, result):
+        return self.provider.write_mime_type_finish(result)
+
+    def do_detach_clipboard(self, _clipboard):
+        self.on_detach()
+
+
+def clipboard_payloads(mime: str, path: pathlib.Path, image: bytes):
+    path_text = str(path).encode()
+    return [
+        (mime, image),
+        ("text/plain;charset=utf-8", path_text),
+        ("text/plain", path_text),
+        ("text/uri-list", (path.as_uri() + "\r\n").encode()),
+        (MARKER_MIME, b"1"),
+    ]
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: publish-image.py <mime-type> <path>", file=sys.stderr)
+        return 1
+
+    mime, raw_path = sys.argv[1:]
+    path = pathlib.Path(raw_path).resolve()
+    if not mime.startswith("image/") or not path.is_file():
+        return 1
+    Gtk.init()
+    display = Gdk.Display.get_default()
+    if display is None:
+        return 1
+
+    clipboard = display.get_clipboard()
+    loop = GLib.MainLoop()
+    result = 1
+    image = path.read_bytes()
+    providers = [
+        Gdk.ContentProvider.new_for_bytes(payload_mime, GLib.Bytes.new(data))
+        for payload_mime, data in clipboard_payloads(mime, path, image)
+    ]
+    provider = ClipboardOwnerProvider(Gdk.ContentProvider.new_union(providers), loop.quit)
+
+    def claim_clipboard():
+        nonlocal result
+        if clipboard.set_content(provider):
+            result = 0
+        else:
+            print("Unable to take ownership of the clipboard image", file=sys.stderr)
+            loop.quit()
+        return GLib.SOURCE_REMOVE
+
+    # Claim from inside the loop so replacement notifications cannot arrive
+    # in the gap between taking ownership and starting lifecycle processing.
+    GLib.idle_add(claim_clipboard)
+    loop.run()
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/acceptance.d/screenshot-clipboard-test.sh
+++ b/test/acceptance.d/screenshot-clipboard-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+provider_pattern="$OMARCHY_PATH/shell/plugins/clipboard/publish-image.py"
+previous_providers=$(pgrep -f "$provider_pattern" || true)
+
+omarchy capture screenshot fullscreen copy
+
+wait_until "screenshot clipboard advertises image data" 15 bash -c \
+  "wl-paste --list-types | grep -qx image/png"
+wait_until "screenshot clipboard advertises a terminal path" 15 bash -c \
+  "wl-paste --list-types | grep -qx text/plain"
+wait_until "screenshot clipboard advertises a file URI" 15 bash -c \
+  "wl-paste --list-types | grep -qx text/uri-list"
+wait_until "screenshot clipboard advertises its file-backed marker" 15 bash -c \
+  "wl-paste --list-types | grep -qx application/x-omarchy-file-backed-image"
+
+path=$(wl-paste --type text/plain --no-newline)
+uri=$(wl-paste --type text/uri-list --no-newline)
+
+[[ -f $path ]] || fail "screenshot clipboard path exists" "$path"
+[[ $path == "$HOME/.local/state/omarchy/clipboard-images/"*.png ]] || fail "copy-only screenshot uses clipboard state" "$path"
+[[ $uri == "file://$path"$'\r' ]] || fail "screenshot clipboard URI identifies its backing file" "$uri"
+cmp -s "$path" <(wl-paste --type image/png) || fail "screenshot clipboard image matches its backing file"
+pass "screenshot clipboard representations describe the same image"
+
+provider_pid=""
+while read -r candidate; do
+  if ! grep -qx "$candidate" <<<"$previous_providers"; then
+    provider_pid=$candidate
+    break
+  fi
+done < <(pgrep -f "$provider_pattern" || true)
+[[ -n $provider_pid ]] || fail "screenshot clipboard provider remains alive"
+pass "screenshot clipboard provider remains alive while it owns the selection"
+
+first_provider_pid=$provider_pid
+omarchy capture screenshot fullscreen copy
+wait_until "a consecutive screenshot replaces its previous provider" 15 bash -c \
+  '! kill -0 "$1" 2>/dev/null' _ "$first_provider_pid"
+
+provider_pid=""
+provider_count=0
+while read -r candidate; do
+  if [[ $candidate != "$first_provider_pid" ]] && ! grep -qx "$candidate" <<<"$previous_providers"; then
+    provider_pid=$candidate
+    ((provider_count += 1))
+  fi
+done < <(pgrep -f "$provider_pattern" || true)
+[[ -n $provider_pid ]] || fail "consecutive screenshot starts a replacement provider"
+((provider_count == 1)) || fail "consecutive screenshot leaves exactly one replacement provider" "$provider_count providers"
+pass "consecutive screenshots retain exactly the current clipboard owner"
+
+printf 'clipboard replacement' | wl-copy >/dev/null 2>&1
+wait_until "screenshot clipboard provider exits after replacement" 15 bash -c \
+  '! kill -0 "$1" 2>/dev/null' _ "$provider_pid"

--- a/test/shell.d/clipboard-publish-image-test.sh
+++ b/test/shell.d/clipboard-publish-image-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+ROOT="$ROOT" python <<'PY'
+import importlib.util
+import os
+import pathlib
+
+root = pathlib.Path(os.environ["ROOT"])
+spec = importlib.util.spec_from_file_location(
+    "publish_image", root / "shell/plugins/clipboard/publish-image.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+image = b"\x89PNG\r\n\x1a\nclipboard-image"
+path = pathlib.Path("/tmp/clipboard image.png")
+payloads = dict(module.clipboard_payloads("image/png", path, image))
+assert payloads["image/png"] == image
+assert payloads["text/plain;charset=utf-8"] == str(path).encode()
+assert payloads["text/plain"] == str(path).encode()
+assert payloads["text/uri-list"] == (path.resolve().as_uri() + "\r\n").encode()
+assert payloads[module.MARKER_MIME] == b"1"
+PY
+pass "image publisher builds image, path, URI, and marker payloads"
+
+if OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-clipboard-publish-image" unexpected >/dev/null 2>&1; then
+  fail "image publisher rejects arguments"
+fi
+pass "image publisher rejects arguments"
+
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+mkdir -p "$TEST_TMPDIR/bin"
+cat >"$TEST_TMPDIR/bin/python" <<'SH'
+#!/bin/bash
+touch "$PYTHON_CALLED"
+SH
+chmod +x "$TEST_TMPDIR/bin/python"
+printf 'image' >"$TEST_TMPDIR/image.png"
+
+if GDK_BACKEND=wayland WAYLAND_DISPLAY=missing XDG_RUNTIME_DIR="$TEST_TMPDIR" PYTHON_CALLED="$TEST_TMPDIR/python-called" PATH="$TEST_TMPDIR/bin:$PATH" OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-clipboard-publish-image" image/png "$TEST_TMPDIR/image.png" 2>/dev/null; then
+  fail "image publisher uses the system Python runtime"
+fi
+[[ ! -e $TEST_TMPDIR/python-called ]] || fail "image publisher uses the system Python runtime"
+pass "image publisher uses the system Python runtime"

--- a/test/shell.d/clipboard-publish-image-test.sh
+++ b/test/shell.d/clipboard-publish-image-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
-ROOT="$ROOT" python <<'PY'
+ROOT="$ROOT" /usr/bin/python3 <<'PY'
 import importlib.util
 import os
 import pathlib
@@ -35,15 +35,29 @@ pass "image publisher rejects arguments"
 TEST_TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 mkdir -p "$TEST_TMPDIR/bin"
-cat >"$TEST_TMPDIR/bin/python" <<'SH'
+cat >"$TEST_TMPDIR/bin/setsid" <<'SH'
 #!/bin/bash
-touch "$PYTHON_CALLED"
+[[ $1 == "-f" ]] && shift
+printf '%s\n' "$*" >"$PUBLISH_LOG"
+printf '%s' "${*: -1}" >"$PUBLISHED_PATH"
 SH
-chmod +x "$TEST_TMPDIR/bin/python"
+
+cat >"$TEST_TMPDIR/bin/wl-paste" <<'SH'
+#!/bin/bash
+if [[ $1 == "--list-types" ]]; then
+  printf 'image/png\ntext/plain\napplication/x-omarchy-file-backed-image\n'
+elif [[ $1 == "--type" && $2 == "text/plain" ]]; then
+  cat "$PUBLISHED_PATH"
+fi
+SH
+chmod +x "$TEST_TMPDIR/bin/setsid" "$TEST_TMPDIR/bin/wl-paste"
 printf 'image' >"$TEST_TMPDIR/image.png"
 
-if GDK_BACKEND=wayland WAYLAND_DISPLAY=missing XDG_RUNTIME_DIR="$TEST_TMPDIR" PYTHON_CALLED="$TEST_TMPDIR/python-called" PATH="$TEST_TMPDIR/bin:$PATH" OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-clipboard-publish-image" image/png "$TEST_TMPDIR/image.png" 2>/dev/null; then
-  fail "image publisher uses the system Python runtime"
-fi
-[[ ! -e $TEST_TMPDIR/python-called ]] || fail "image publisher uses the system Python runtime"
+PUBLISH_LOG="$TEST_TMPDIR/publish" PUBLISHED_PATH="$TEST_TMPDIR/published-path" PATH="$TEST_TMPDIR/bin:$PATH" OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-clipboard-publish-image" image/png "$TEST_TMPDIR/image.png"
+[[ $(<"$TEST_TMPDIR/publish") == "$ROOT/shell/plugins/clipboard/publish-image.py image/png $TEST_TMPDIR/image.png" ]] || fail "image publisher detaches its clipboard provider"
+pass "image publisher detaches and waits for its clipboard provider"
+
+IFS= read -r publisher_shebang <"$ROOT/shell/plugins/clipboard/publish-image.py"
+[[ $publisher_shebang == "#!/usr/bin/python3" ]] || fail "image publisher uses the system Python runtime"
 pass "image publisher uses the system Python runtime"

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -28,6 +28,12 @@ assertDeepEqual(
 )
 
 assertDeepEqual(
+  clipboard.normalizeEntry({ type: 'image', path: '/tmp/a.png', mime: 'image/png', fileBacked: true }),
+  { type: 'image', path: '/tmp/a.png', mime: 'image/png', fileBacked: true },
+  'clipboard keeps file-backed image metadata'
+)
+
+assertDeepEqual(
   clipboard.parseHistory(JSON.stringify(['one', '', { type: 'text', text: 'two' }, { type: 'image', path: '/tmp/a.jpg', mime: 'image/jpeg' }])),
   [
     { type: 'text', text: 'one' },
@@ -89,6 +95,12 @@ assertDeepEqual(
   clipboard.displayRows(history, 'image', 50).map(row => row.index),
   [2],
   'clipboard display rows preserve original history indexes'
+)
+
+assertEqual(
+  clipboard.displayRows([{ type: 'image', path: '/tmp/a.png', mime: 'image/png', fileBacked: true }], '', 50)[0].fileBacked,
+  true,
+  'clipboard display rows preserve file-backed image metadata'
 )
 
 assertDeepEqual(
@@ -161,6 +173,10 @@ assert(
 assert(
   !/onContainsMouseChanged:[\s\S]*root\.selectedIndex/.test(clipboardQml),
   'clipboard does not select rows from containsMouse'
+)
+assert(
+  clipboardQml.includes('if (row.fileBacked) args.push("--file-backed")'),
+  'clipboard restores file-backed image history with multiple representations'
 )
 assert(
   clipboardQml.includes('command: ["setpriv", "--pdeathsig", "TERM", "wl-paste", "--type", "text", "--watch", root.captureScript, "text"]'),
@@ -339,6 +355,10 @@ jq -e '.type == "image" and .mime == "image/png" and (.capturedAt | type == "str
 [[ -s $image_path && $(<"$image_path") == "png-data" ]] || fail "clipboard capture stores watched png image data"
 pass "clipboard capture records watched png images"
 
+capture_output=$(printf 'file-backed-png' | WL_PASTE_TYPES="image/png\napplication/x-omarchy-file-backed-image\ntext/plain\n" XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh" image/png)
+jq -e '.type == "image" and .fileBacked == true' <<<"$capture_output" >/dev/null || fail "clipboard capture marks file-backed screenshot images"
+pass "clipboard capture marks file-backed screenshot images"
+
 capture_output=$(printf 'jpg-data' | XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh" image/jpeg)
 image_path=$(jq -r '.path' <<<"$capture_output")
 jq -e '.mime == "image/jpeg"' <<<"$capture_output" >/dev/null && [[ $image_path == *.jpg ]] || fail "clipboard capture stores watched jpeg images with jpg extension"
@@ -442,6 +462,12 @@ pass "clipboard paste helper copy-only copies history entry text"
 [[ ! -e "$TMPDIR/wtype" ]] || fail "clipboard paste helper copy-only skips typing"
 pass "clipboard paste helper copy-only skips typing"
 
+cat >"$TMPDIR/bin/omarchy-clipboard-publish-image" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$PUBLISH_LOG"
+SH
+chmod +x "$TMPDIR/bin/omarchy-clipboard-publish-image"
+
 printf 'image-data' >"$TMPDIR/image.png"
 rm -f "$TMPDIR/wtype"
 WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
@@ -452,6 +478,21 @@ pass "clipboard file paste helper copy-only copies file content"
 
 [[ ! -e "$TMPDIR/wtype" ]] || fail "clipboard file paste helper copy-only skips paste keystroke"
 pass "clipboard file paste helper copy-only skips paste keystroke"
+
+rm -f "$TMPDIR/copied" "$TMPDIR/wtype"
+PUBLISH_LOG="$TMPDIR/publish" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
+  "$ROOT/bin/omarchy-clipboard-paste-file" --file-backed image/png "$TMPDIR/image.png"
+
+[[ $(<"$TMPDIR/publish") == "image/png $TMPDIR/image.png" ]] || fail "clipboard file paste helper restores file-backed images"
+[[ ! -e $TMPDIR/copied ]] || fail "clipboard file paste helper avoids image-only copy for file-backed images"
+[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "clipboard file paste helper pastes restored file-backed image paths"
+pass "clipboard file paste helper restores file-backed image representations"
+
+rm -f "$TMPDIR/wtype"
+PUBLISH_LOG="$TMPDIR/publish" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
+  "$ROOT/bin/omarchy-clipboard-paste-file" --copy-only --file-backed image/png "$TMPDIR/image.png"
+[[ ! -e $TMPDIR/wtype ]] || fail "clipboard file paste helper copy-only skips typing for file-backed images"
+pass "clipboard file paste helper copy-only restores file-backed image representations"
 
 jq -n --arg url 'https://example.com/docs' --arg text "$(printf 'plain text\nsecond line')" --arg image "$TMPDIR/image.png" \
   '[{type:"text", text:$url}, {type:"text", text:$text}, {type:"image", mime:"image/png", path:$image}]' >"$TMPDIR/home/.local/state/omarchy/clipboard-history.json"

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -348,6 +348,10 @@ capture_output=$(printf 'secret' | CLIPBOARD_STATE=sensitive XDG_RUNTIME_DIR="$T
 [[ -z $capture_output ]] || fail "clipboard capture ignores sensitive watched text"
 pass "clipboard capture ignores sensitive watched text"
 
+capture_output=$(printf 'generated screenshot path' | WL_PASTE_TYPES="image/png\napplication/x-omarchy-file-backed-image\ntext/plain\n" XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh" text)
+[[ -z $capture_output ]] || fail "clipboard capture hides file-backed screenshot paths"
+pass "clipboard capture hides file-backed screenshot paths"
+
 capture_output=$(CLIPBOARD_STATE=sensitive XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh")
 [[ -z $capture_output ]] || fail "clipboard capture ignores sensitive clipboard events"
 pass "clipboard capture ignores sensitive clipboard events"

--- a/test/shell.d/screenshot-clipboard-test.sh
+++ b/test/shell.d/screenshot-clipboard-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/bin" "$TMPDIR/home" "$TMPDIR/screenshots" "$TMPDIR/state"
+
+cat >"$TMPDIR/bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "getoption" ]]; then
+  printf '{"int":0}\n'
+fi
+SH
+
+cat >"$TMPDIR/bin/omarchy-capture-region" <<'SH'
+#!/bin/bash
+printf '\n10,20 300x200\n'
+SH
+
+cat >"$TMPDIR/bin/grim" <<'SH'
+#!/bin/bash
+[[ ${GRIM_FAIL:-0} == "1" ]] && exit 1
+printf '\211PNG\r\n\032\nscreenshot-data' >"${*: -1}"
+SH
+
+cat >"$TMPDIR/bin/setsid" <<'SH'
+#!/bin/bash
+[[ $1 == "-f" ]] && shift
+printf '%s\n' "$*" >"$PUBLISH_LOG"
+printf '%s' "${*: -1}" >"$PUBLISHED_PATH"
+SH
+
+cat >"$TMPDIR/bin/wl-paste" <<'SH'
+#!/bin/bash
+if [[ $1 == "--list-types" ]]; then
+  printf 'image/png\ntext/plain\napplication/x-omarchy-file-backed-image\n'
+elif [[ $1 == "--type" && $2 == "text/plain" ]]; then
+  cat "$PUBLISHED_PATH"
+fi
+SH
+
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$TMPDIR/bin/"*
+
+run_screenshot() {
+  local processing="$1"
+  PUBLISH_LOG="$TMPDIR/publish" \
+    PUBLISHED_PATH="$TMPDIR/published-path" \
+    HOME="$TMPDIR/home" \
+    XDG_STATE_HOME="$TMPDIR/state" \
+    OMARCHY_SCREENSHOT_DIR="$TMPDIR/screenshots" \
+    PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-capture-screenshot" region "$processing"
+}
+
+slurp_path=$(run_screenshot slurp)
+[[ -f $slurp_path ]] || fail "screenshot slurp saves its image"
+[[ $(<"$TMPDIR/published-path") == "$slurp_path" ]] || fail "screenshot slurp publishes its saved file"
+grep -Fq "omarchy-clipboard-publish-image image/png $slurp_path" "$TMPDIR/publish" || fail "screenshot slurp uses the file-backed publisher"
+pass "screenshot slurp publishes its saved image with file-backed representations"
+
+rm -f "$TMPDIR/publish" "$TMPDIR/published-path"
+run_screenshot copy
+copy_path=$(<"$TMPDIR/published-path")
+[[ $copy_path == "$TMPDIR/state/omarchy/clipboard-images/"*.png ]] || fail "screenshot copy stores its backing file in clipboard state"
+[[ -f $copy_path && $(<"$copy_path") == $'\x89PNG\r\n\x1a\nscreenshot-data' ]] || fail "screenshot copy preserves captured image bytes"
+grep -Fq "omarchy-clipboard-publish-image image/png $copy_path" "$TMPDIR/publish" || fail "screenshot copy uses the file-backed publisher"
+pass "screenshot copy publishes a state-backed image"
+
+rm -f "$TMPDIR/publish" "$TMPDIR/published-path"
+save_path=$(run_screenshot save)
+[[ -f $save_path ]] || fail "screenshot save writes its image"
+[[ ! -e $TMPDIR/publish && ! -e $TMPDIR/published-path ]] || fail "screenshot save leaves the clipboard untouched"
+pass "screenshot save leaves the clipboard untouched"
+
+if GRIM_FAIL=1 run_screenshot copy; then
+  fail "failed screenshot copy removes its temporary image"
+fi
+shopt -s nullglob
+temporary_images=("$TMPDIR/state/omarchy/clipboard-images"/clipboard.*)
+(( ${#temporary_images[@]} == 0 )) || fail "failed screenshot copy removes its temporary image"
+pass "failed screenshot copy removes its temporary image"

--- a/test/shell.d/screenshot-clipboard-test.sh
+++ b/test/shell.d/screenshot-clipboard-test.sh
@@ -63,7 +63,7 @@ run_screenshot() {
 slurp_path=$(run_screenshot slurp)
 [[ -f $slurp_path ]] || fail "screenshot slurp saves its image"
 [[ $(<"$TMPDIR/published-path") == "$slurp_path" ]] || fail "screenshot slurp publishes its saved file"
-grep -Fq "omarchy-clipboard-publish-image image/png $slurp_path" "$TMPDIR/publish" || fail "screenshot slurp uses the file-backed publisher"
+grep -Fq "publish-image.py image/png $slurp_path" "$TMPDIR/publish" || fail "screenshot slurp uses the file-backed publisher"
 pass "screenshot slurp publishes its saved image with file-backed representations"
 
 rm -f "$TMPDIR/publish" "$TMPDIR/published-path"
@@ -71,7 +71,7 @@ run_screenshot copy
 copy_path=$(<"$TMPDIR/published-path")
 [[ $copy_path == "$TMPDIR/state/omarchy/clipboard-images/"*.png ]] || fail "screenshot copy stores its backing file in clipboard state"
 [[ -f $copy_path && $(<"$copy_path") == $'\x89PNG\r\n\x1a\nscreenshot-data' ]] || fail "screenshot copy preserves captured image bytes"
-grep -Fq "omarchy-clipboard-publish-image image/png $copy_path" "$TMPDIR/publish" || fail "screenshot copy uses the file-backed publisher"
+grep -Fq "publish-image.py image/png $copy_path" "$TMPDIR/publish" || fail "screenshot copy uses the file-backed publisher"
 pass "screenshot copy publishes a state-backed image"
 
 rm -f "$TMPDIR/publish" "$TMPDIR/published-path"


### PR DESCRIPTION
Omarchy screenshots currently place only `image/png` on the clipboard. Graphical applications can paste the image, but terminals cannot request a usable file path.

This mirrors the user-facing behavior of CleanShot X on macOS: a captured screenshot pastes as an image into graphical applications and as its backing file path into terminals.

Screenshots are now published as one clipboard selection with multiple representations:

- `image/png` for graphical applications
- `text/plain` for terminals
- `text/uri-list` for file-aware applications
- an internal marker used by clipboard history

Copy-only screenshots are stored in a content-addressed cache under `$XDG_STATE_HOME/omarchy/clipboard-images`. Saved screenshots use their existing file directly.

The clipboard provider remains alive only while it owns the selection and exits through GDK native detach lifecycle when another application or screenshot replaces it. Clipboard history records the image while suppressing the duplicate generated path entry.

## Why this approach

Related to #7187, but this keeps the existing `Super+V` binding unchanged and limits the change to screenshots created by Omarchy.

Rather than inspecting the clipboard during paste and synthesizing a different shortcut, each receiving application selects the representation it already understands:

- terminals receive the backing file path
- graphical applications receive the PNG
- file-aware applications receive the file URI

This avoids focus and synthetic-key timing concerns while preserving normal text paste behavior.

## Scope and limitations

This applies only to screenshots created by Omarchy because their backing files are known at capture time.

Images copied from browsers or other applications are not converted into file-backed clipboard entries. They still require `Ctrl+V` in terminals that support direct image paste.

Making `Super+V` handle arbitrary copied images would require the broader clipboard interception or conditional key-dispatch behavior discussed in #7187. That is intentionally outside this change.

## Tests

- `./test/cli`
- `test/shell.d/clipboard-publish-image-test.sh`
- `test/shell.d/screenshot-clipboard-test.sh`
- `test/shell.d/clipboard-test.sh`
- Bash syntax checks
- Python compilation
- `git diff --check`
- Real Wayland verification of advertised MIME types, exact PNG bytes, consecutive screenshot replacement, and provider exit after clipboard replacement
- Dev-linked desktop test using the normal screenshot hotkey:
  - `Super+V` pasted the backing path into a terminal
  - `Ctrl+V` pasted the screenshot into a graphical application

The full `./test/shell` run completed with four unrelated local-environment failures: one bar geometry check and three checks requiring an `omarchy-pkgs` checkout.