### PR TITLE
Tick the clock per second when its format shows seconds

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -111,7 +111,10 @@ BarWidget {
 
   SystemClock {
     id: clock
-    precision: SystemClock.Minutes
+    // Follow the label: a format carrying seconds needs a tick a second, and
+    // one without it should not wake the shell 60 times a minute to redraw
+    // the same string.
+    precision: Model.formatHasSeconds(root.activeFormat) ? SystemClock.Seconds : SystemClock.Minutes
     onDateChanged: root.displayDate = date
   }
 

--- a/shell/plugins/panels/clock/Model.js
+++ b/shell/plugins/panels/clock/Model.js
@@ -67,6 +67,23 @@ function nextClockFormat(ring, current) {
   return ring[(index + 1) % ring.length]
 }
 
+// Whether a label format asks for seconds, so the widget can tick once a
+// second only when the label would otherwise sit frozen between minutes.
+// Qt reads single quotes as literal text ("'W'ww"), so an 's' inside them is
+// a letter rather than the seconds token.
+function formatHasSeconds(format) {
+  var text = String(format === undefined || format === null ? "" : format)
+  var quoted = false
+  for (var i = 0; i < text.length; i++) {
+    if (text[i] === "'") {
+      quoted = !quoted
+    } else if (!quoted && text[i] === "s") {
+      return true
+    }
+  }
+  return false
+}
+
 // Two-digit ISO week, substituted into a format's 'ww' token before Qt
 // formats it -- Qt has no ISO week specifier of its own.
 function isoWeekLiteral(year, month, day) {
@@ -291,6 +308,7 @@ if (typeof module !== "undefined") {
     clockFormats: clockFormats,
     clockFormatRing: clockFormatRing,
     nextClockFormat: nextClockFormat,
+    formatHasSeconds: formatHasSeconds,
     isoWeekLiteral: isoWeekLiteral
   }
 }

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -187,7 +187,7 @@ assert(calendar.clockFormats(false).every(format => !calendar.formatHasSeconds(f
 
 // ---- widget wiring
 assert(/precision: Model\.formatHasSeconds\(root\.activeFormat\) \? SystemClock\.Seconds : SystemClock\.Minutes/.test(widgetSource), 'clock ticks per second only when the label shows seconds')
-assert(/precision: SystemClock\.Minutes/.test(panelSource), 'calendar panel keeps a minute tick, since it only watches for the day to roll over')
+assert(/precision\s*:\s*SystemClock\.Minutes/.test(panelSource), 'calendar panel keeps a minute tick, since it only watches for the day to roll over')
 assert(/moduleName: "omarchy\.clock"/.test(panelSource), 'calendar panel declares its module name')
 assert(/ipcTarget: "omarchy\.clock"/.test(panelSource), 'calendar panel registers its IPC target')
 assert(/manageIpc: false/.test(panelSource), 'calendar panel leaves the IPC target to the bar widget')

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -166,7 +166,28 @@ assertEqual(
 )
 assertEqual(calendar.isoWeekLiteral(2026, 0, 5), '02', 'clock zero-pads the ISO week token')
 
+// ---- seconds in the label
+// The widget ticks once a minute unless the format asks for seconds, so a
+// hand-written 'ss' would otherwise sit frozen until the minute rolled over.
+assert(calendar.formatHasSeconds('HH:mm:ss'), 'clock sees seconds in a 24-hour format')
+assert(calendar.formatHasSeconds('ddd d MMM h:mm:ss AP'), 'clock sees seconds in a dated AM/PM format')
+assert(calendar.formatHasSeconds('HH\nmm\nss'), 'clock sees seconds in a stacked format')
+assert(calendar.formatHasSeconds('h:mm:s AP'), 'clock sees a single-digit seconds token')
+assert(!calendar.formatHasSeconds('HH:mm'), 'clock sees no seconds in the default format')
+assert(!calendar.formatHasSeconds('dddd h:mm AP'), 'clock reads the AM/PM twin as secondless')
+assert(!calendar.formatHasSeconds(''), 'clock reads an empty format as secondless')
+assert(!calendar.formatHasSeconds(null), 'clock reads a missing format as secondless')
+// Qt reads single quotes as literal text, so letters inside them are not tokens.
+assert(!calendar.formatHasSeconds("d MMMM 'W'ww yyyy"), 'clock ignores the quoted week literal')
+assert(!calendar.formatHasSeconds("'seconds' HH:mm"), 'clock ignores an s inside a quoted literal')
+assert(calendar.formatHasSeconds("'W'ww HH:mm:ss"), 'clock still sees seconds after a quoted literal')
+assert(!calendar.formatHasSeconds("dd\nMMM\n'W'ww\n''yy"), 'clock reads the stacked week preset as secondless')
+assert(calendar.clockFormats(false).every(format => !calendar.formatHasSeconds(format)), 'clock ships no seconds preset, so the default tick stays at a minute')
+
+
 // ---- widget wiring
+assert(/precision: Model\.formatHasSeconds\(root\.activeFormat\) \? SystemClock\.Seconds : SystemClock\.Minutes/.test(widgetSource), 'clock ticks per second only when the label shows seconds')
+assert(/precision: SystemClock\.Minutes/.test(panelSource), 'calendar panel keeps a minute tick, since it only watches for the day to roll over')
 assert(/moduleName: "omarchy\.clock"/.test(panelSource), 'calendar panel declares its module name')
 assert(/ipcTarget: "omarchy\.clock"/.test(panelSource), 'calendar panel registers its IPC target')
 assert(/manageIpc: false/.test(panelSource), 'calendar panel leaves the IPC target to the bar widget')


### PR DESCRIPTION
 The bar clock runs its SystemClock at precision: SystemClock.Minutes, so the label only
  repaints when the minute changes. A format carrying an s token therefore renders the seconds
  it was given and then holds them until the minute rolls over: setting "format": "HH:mm:ss" in
  shell.json today produces a clock that reads :00 for a minute at a time.

<img width="698" height="132" alt="clock-seconds" src="https://github.com/user-attachments/assets/50b1363f-0fd3-474d-ba88-3cbbbe426128" />

  Hand-written formats are already a supported way to configure the clock — clockFormatRing
  keeps one that isn't a preset, and clock-test.sh uses HH:mm:ss as its example of exactly that.
  Seconds are the one token the widget can't honor.

 ## Summary

  - derive the clock's tick from its active format instead of hardcoding a minute
  - add Model.formatHasSeconds(), which reads Qt's single-quoted literals as text so the 'W' in
  d MMMM 'W'ww yyyy isn't mistaken for a seconds token
  - leave the calendar panel on its minute tick, since it only watches for the day to roll over
  - cover the helper and the widget binding in clock-test.sh

  Formats without seconds keep the minute tick, so this doesn't wake the shell 60 times a minute
  to redraw a string that hasn't changed. The binding is reactive: right-clicking from a
  seconds format back to a plain one drops the tick rate on the spot, with no restart.

  No default changes. clockFormats() is untouched, and a test asserts no stock preset carries
  seconds, so the ring still walks the same eight formats and a fresh install ticks once a
  minute exactly as it does now. Adding a seconds preset to the ring would be a separate change,
  and one worth deciding on its own merits.

  ## Enabling seconds

  Nothing changes until a clock is given a format with a seconds token:

  omarchy bar set omarchy.clock format "ddd d MMM h:mm:ss AP"

  or in ~/.config/omarchy/shell.json:

  { "id": "omarchy.clock", "format": "ddd d MMM h:mm:ss AP" }

  Vertical bars read verticalFormat under the same rule. The preset ring is unchanged, so a
  right click still walks the stock formats and cycles out of a seconds format rather than back
  into it.

  ## Verification

  - ./test/shell.d/clock-test.sh — 156 pass
  - reverted the one-line precision binding and confirmed the new widget-wiring test fails, so
  it isn't a test that can't fail
  - ./test/all — 3 pre-existing failures unrelated to this change (config-test.sh,
  snapper-test.sh, unowned-system-paths-test.sh); all three fail identically on a clean checkout
  of this branch
  - ran the shell from this checkout against the live bar: with ddd d MMM h:mm:ss AP the label
  advanced every second; with ddd d MMM h:mm AP successive screenshots were byte-identical
  - switched the format on the running shell and watched the tick rate follow it without a
  restart