### PR TITLE
Let a clicked day in the clock's calendar go somewhere

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -127,6 +127,14 @@ All of it is stored in `~/.config/omarchy/shell.json`, under the `bar` key. Here
 
 Every widget is one entry in one of the three layout arrays, and its settings sit inline on that entry — there's no separate settings file and no `config` sub-object. The clock's `format`, `formatAlt` (what right-click cycles to), and `verticalFormat` all live right there on `{ "id": "omarchy.clock" }`.
 
+The clock takes one more: `onDayClick`, a command to run when you click a day in its calendar. Unset, the grid stays the read-out it has always been. Set it and the day you clicked goes somewhere:
+
+```json
+{ "id": "omarchy.clock", "onDayClick": "uwsm-app -- gnome-calendar" }
+```
+
+`{date}` anywhere in the command is replaced with the day you clicked as `2026-08-22`, so a calendar that can open on a date gets handed one. Pressing `o` with the calendar open does the same for today, so the command isn't mouse-only.
+
 `centerAnchor` names the one center widget that gets pinned to the exact center of the screen, with the others flanking it. That's how the clock stays dead center even as the weather and update badge come and go. Set it to an empty string and the center list is just centered as a group instead.
 
 One rule worth internalizing: **once you have your own `shell.json`, it's canonical**. Until you customize anything, the shell reads Omarchy's default file. The moment you drag a widget, run `omarchy bar`, or edit the file yourself, you own it — there's no deep merge, so new default widgets in future Omarchy releases won't appear on your bar automatically. `omarchy bar defaults` puts the shipped layout back whenever you want a clean slate.

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -56,7 +56,7 @@ Example `shell.json` (bar subtree only shown):
 |---|---|---|
 | `omarchy.menu` | Omarchy menu launcher | left = menu · right = terminal |
 | `omarchy.workspaces` | Hyprland workspace switcher | left = focus workspace |
-| `omarchy.clock` | Date/time label + popup with a month grid, ISO week numbers, and month stepping | left = popup · right = cycle label format · middle = timezone selector |
+| `omarchy.clock` | Date/time label + popup with a month grid, ISO week numbers, and month stepping | left = popup · right = cycle label format · middle = timezone selector · click a day (or `o`) = run `onDayClick` |
 | `omarchy.media` | MPRIS now-playing — scrolling track + artist, cover-art popup | left = play/pause · middle = next · scroll = prev/next · right = popup |
 | `omarchy.indicators` | Manual state indicators | left = indicator action |
 | `omarchy.system-update` | Available update indicator | left = update |

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -59,6 +59,14 @@ Panel {
   readonly property int lifeDonePercent: Model.lifeProgressPercent(age, lifeExpectancy)
   property bool editingLife: false
 
+  // A day in the grid is a read-out with nowhere to go, which is the one
+  // thing a calendar popup can't answer: "and then what?". Given a command,
+  // clicking a day runs it and gets out of the way. Empty — the default —
+  // leaves the grid exactly as it has always been, so this costs nothing
+  // until someone asks for it.
+  readonly property string dayCommand: setting("onDayClick", "")
+  readonly property bool daysClickable: dayCommand !== "" && root.bar !== null
+
   // Unset falls through to the locale's own first day, so a fresh install
   // starts out matching the rest of the desktop rather than a hardcoded
   // convention. Clicking the grid's "W" heading writes the choice back to
@@ -131,6 +139,19 @@ Panel {
   function goToToday() {
     root.viewYear = today.getFullYear()
     root.viewMonth = today.getMonth()
+  }
+
+  // {date} is substituted with the day as yyyy-MM-dd, so a calendar that can
+  // open on a date gets one and everything else ignores it. It takes the key
+  // rather than the grid cell, because the keyboard can ask for a day the
+  // grid isn't currently drawing.
+  function openDay(dayKey) {
+    if (!root.daysClickable) return
+    var command = root.dayCommand.indexOf("{date}") >= 0
+      ? root.dayCommand.split("{date}").join(root.bar.shellQuote(dayKey))
+      : root.dayCommand
+    root.bar.run(command)
+    root.close()
   }
 
   function moveMonth(delta) {
@@ -262,6 +283,11 @@ Panel {
         else if (t === "}") root.moveYear(1)
         else if (t === "t" || t === "T") root.goToToday()
         else if (t === "w" || t === "W") root.toggleWeekStart()
+        // Arrows already belong to the month and the year, so the grid has no
+        // day cursor for a key to move. It opens today instead — the one day
+        // the calendar names without being asked, and the one you want on the
+        // way past.
+        else if (t === "o" || t === "O") root.openDay(root.todayKey)
       }
 
       Flickable {
@@ -656,8 +682,12 @@ Panel {
                       height: root.cellHeight
                       radius: Style.cornerRadius
                       // Today is outlined, not filled: a lit-up block shouts
-                      // over a grid this quiet.
-                      color: "transparent"
+                      // over a grid this quiet. Hover fills the same way
+                      // round — under the pointer only, so the grid at rest
+                      // still marks one day and one day only.
+                      color: dayHover.containsMouse
+                        ? Qt.rgba(root.contentForeground.r, root.contentForeground.g, root.contentForeground.b, 0.12)
+                        : "transparent"
                       border.width: modelData.today ? Style.spacing.hairline : 0
                       border.color: Style.normalBorderFor(root.contentForeground, Color.accent)
 
@@ -670,6 +700,15 @@ Panel {
                         font.family: root.contentFontFamily
                         font.pixelSize: Style.font.body
                         font.bold: modelData.today
+                      }
+
+                      MouseArea {
+                        id: dayHover
+                        anchors.fill: parent
+                        enabled: root.daysClickable
+                        hoverEnabled: root.daysClickable
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.openDay(modelData.key)
                       }
                     }
                   }

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -178,7 +178,17 @@ assert(/updateEntryInline/.test(panelSource), 'calendar panel persists the week 
 assert(/function moveMonth\(delta\)/.test(panelSource), 'calendar panel steps between months')
 assert(!/property bool onToday/.test(panelSource) && !/root\.onToday/.test(panelSource), 'calendar panel avoids the on-prefixed property name QML reads as a signal handler')
 assert(/readonly property bool viewingCurrentMonth:/.test(panelSource), 'calendar panel tracks whether the current month is on screen')
-assert(!/MouseArea/.test(panelSource.slice(panelSource.indexOf('model: modelData.days'), panelSource.indexOf('// Hairline'))), 'calendar day cells are not selectable')
+// Day cells took a MouseArea when onDayClick arrived, but they stay inert
+// without one: both enabled and hoverEnabled hang off daysClickable, so an
+// unconfigured grid still has nothing to click and nothing to light up.
+const dayCells = panelSource.slice(panelSource.indexOf('model: modelData.days'), panelSource.indexOf('// Hairline'))
+assert(/enabled: root\.daysClickable/.test(dayCells) && /hoverEnabled: root\.daysClickable/.test(dayCells), 'calendar day cells stay inert until onDayClick is set')
+assert(/onClicked: root\.openDay\(modelData\.key\)/.test(dayCells), 'calendar day cells hand the clicked day to openDay')
+assert(!/selected|currentIndex/.test(dayCells), 'calendar day cells still carry no selection state')
+assert(/readonly property string dayCommand: setting\("onDayClick", ""\)/.test(panelSource), 'calendar reads the day command from onDayClick')
+assert(/dayCommand !== "" && root\.bar !== null/.test(panelSource), 'calendar leaves days unclickable without a command or a bar')
+assert(/root\.bar\.shellQuote\(dayKey\)/.test(panelSource), 'calendar quotes the date before it reaches the shell')
+assert(/root\.openDay\(root\.todayKey\)/.test(panelSource), 'calendar opens today from the keyboard, so the command is not mouse-only')
 assert(/yearDone: Model\.yearProgress\(today\./.test(panelSource), 'calendar year bar stays pinned to today while months are stepped')
 assert(/Qt\.callLater\(function\(\) \{\s*\n\s*if \(root\.opened\) setCenterHoverRevealSuppressed\(true\)/.test(panelSource), 'calendar claims the shared hover-reveal flag after the popout handoff, so the panel taking over wins')
 assert(/function close\(\) \{\s*\n\s*setCenterHoverRevealSuppressed\(false\)/.test(panelSource), 'calendar always releases the shared hover-reveal flag on close')


### PR DESCRIPTION
The clock popup answers "what is the date?" beautifully and then stops. Clicking a day does nothing, because the grid is a read-out — but a read-out is exactly the moment you have decided you want to look at that day properly.

This adds one optional setting on the clock entry in `shell.json`:

```json
{ "id": "omarchy.clock", "onDayClick": "uwsm-app -- gnome-calendar" }
```

Unset — the default — **nothing changes at all**: no hover, no pointer cursor, the `MouseArea` disabled, the grid the same read-out it has always been. Set it, and clicking a day runs the command through `bar.run` and closes the popup.

`{date}` anywhere in the command is replaced with the clicked day as `2026-08-22`, shell-quoted, so a calendar that can open on a date gets handed one and one that cannot just opens:

```json
{ "id": "omarchy.clock", "onDayClick": "uwsm-app -- gnome-calendar {date}" }
```

Notes on the shape of it:

- Only the day cells take the click. The chevrons, the week-start `W` heading, and the year rail keep the behaviour they have.
- Hover fills the day cell rather than outlining it, so the grid at rest still marks exactly one day — today — the way it does now.
- 34 lines in `Panel.qml`, nothing removed.

Docs updated in `manual/05-the-top-bar.md` (where the clock's inline settings are introduced) and the widget catalogue row in `shell/plugins/bar/README.md`.

Running it here against a local calendar app, cold and with the app already open.