### PR TITLE
Read login_background/login_foreground from colors.toml with fallback

### DIFF
--- a/bin/omarchy-plymouth-set-by-theme
+++ b/bin/omarchy-plymouth-set-by-theme
@@ -47,7 +47,7 @@ theme_color() {
   ' "$theme_dir/colors.toml"
 }
 
-bg=$(theme_color background)
-text=$(theme_color foreground)
+bg=$(theme_color login_background background)
+text=$(theme_color login_foreground foreground)
 
 exec omarchy-plymouth-set "$bg" "$text" "$theme_dir/unlock.png"


### PR DESCRIPTION
## What

Allow themes to set separate colors for the login screen (SDDM + Plymouth) by defining `login_background` and `login_foreground` in `colors.toml`.

## Why

Currently `omarchy-plymouth-set-by-theme` reads `background` and `foreground` and applies them to both Plymouth and SDDM. This means the login screen always matches the terminal palette. Some themes want a different look for the login screen without changing their terminal colors or simply the default color is visually incompatible.

## How

Reads `login_background` first, falls back to `background` if not set. Same for `login_foreground` → `foreground`. The existing `theme_color()` awk function already supports a fallback key via its second argument, so this is a 2-line change.

I can also move where the new variables are stored in something like login.toml similar to how shell.lock.toml is used and expand this behavior to the base themes.
