### PR TITLE
Persist monitor scaling to explicit per-monitor entries

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -89,9 +89,19 @@ set_scale() {
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
-  # Persist to monitors.lua if the user still has Omarchy's generic catch-all
-  # defaults, so the scale survives reboots.
-  if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
+  # Persist to monitors.lua so the scale survives reboots. An explicit
+  # hl.monitor entry for the active monitor (the per-monitor form this file's
+  # own comments suggest) overrides the catch-all, so it must be updated in
+  # place — editing only the catch-all would leave the entry stale, and the
+  # config reload this write triggers would revert the scale that was just
+  # applied. Without an explicit numeric entry, fall back to Omarchy's
+  # generic catch-all defaults.
+  if [[ -f $monitor_lua ]] && update_explicit_monitor_scale "$active_monitor" "$new_scale" "$monitor_lua"; then
+    sed -i -E \
+      -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
+      -e 's|^hl\.env\("GDK_SCALE", "[0-9]+"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
+      "$monitor_lua"
+  elif [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
     sed -i -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
@@ -101,6 +111,44 @@ set_scale() {
       -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
       -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
       "$monitor_lua"
+  fi
+}
+
+# Rewrite `scale = <number>` inside the hl.monitor entry naming this output,
+# whether the entry is single-line or spread over multiple lines. Succeeds only
+# when an entry with an explicit numeric scale was found and updated; entries
+# that reference a variable (e.g. `scale = omarchy_monitor_scale`) are left
+# alone so the catch-all fallback keeps owning them.
+update_explicit_monitor_scale() {
+  local monitor="$1"
+  local scale="$2"
+  local file="$3"
+  local tmp
+
+  tmp=$(mktemp) || return 1
+
+  if awk -v monitor="$monitor" -v scale="$scale" '
+    {
+      buffer = buffer $0 "\n"
+      depth += gsub(/\{/, "{")
+      depth -= gsub(/\}/, "}")
+      if (depth > 0) next
+      if (buffer !~ /^[[:space:]]*--/ && buffer ~ /hl\.monitor\(/ && index(buffer, "output = \"" monitor "\"")) {
+        if (sub(/scale = [0-9][0-9.]*/, "scale = " scale, buffer)) changed = 1
+      }
+      printf "%s", buffer
+      buffer = ""
+    }
+    END {
+      printf "%s", buffer
+      exit changed ? 0 : 1
+    }
+  ' "$file" >"$tmp"; then
+    mv "$tmp" "$file"
+    return 0
+  else
+    rm -f "$tmp"
+    return 1
   fi
 }
 

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -129,3 +129,78 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+# An explicit hl.monitor entry for the active monitor overrides the catch-all,
+# so the entry itself must be updated — otherwise the config reload triggered
+# by the write reverts the scale that was just applied.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+hl.monitor({
+  output = "eDP-1",
+  mode = "2880x1800@120.00",
+  position = "0x0",
+  scale = 2
+})
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling up
+grep -F '  scale = 3' "$monitor_lua" >/dev/null || fail "monitor scaling up updates explicit multi-line entry"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the catch-all alone when an explicit entry is updated"
+grep -Fx 'local omarchy_gdk_scale = 3' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists GDK scale alongside an explicit entry"
+pass "monitor scaling up updates explicit multi-line entry"
+
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({ output = "eDP-1", mode = "2880x1800@120", position = "0x0", scale = 2 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -F 'position = "0x0", scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling updates explicit single-line entry"
+grep -Fx 'local omarchy_gdk_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists integer GDK scale alongside a single-line entry"
+pass "monitor scaling updates explicit single-line entry"
+
+# An entry that references the catch-all variable is not an explicit scale;
+# the variable keeps owning it.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({
+  output = "eDP-1",
+  mode = "2880x1800@120.00",
+  position = "0x0",
+  scale = omarchy_monitor_scale
+})
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling up
+grep -F 'scale = omarchy_monitor_scale' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves variable-referencing entries alone"
+grep -Fx 'local omarchy_monitor_scale = 3' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists to the catch-all for variable-referencing entries"
+pass "monitor scaling leaves variable-referencing entries to the catch-all"
+
+# Entries for other monitors are not the active monitor's; fall back to the
+# catch-all and leave them untouched.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({
+  output = "DP-9",
+  mode = "2560x1440@144.00",
+  position = "2880x0",
+  scale = 1
+})
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling up
+grep -F '  scale = 1' "$monitor_lua" >/dev/null || fail "monitor scaling leaves other monitors' entries alone"
+grep -Fx 'local omarchy_monitor_scale = 3' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists to the catch-all when only other monitors are pinned"
+pass "monitor scaling leaves other monitors' entries alone"


### PR DESCRIPTION
## Problem

`omarchy-hyprland-monitor-scaling` (SUPER+SLASH, and the shell's Monitor panel) persists scale by editing the `omarchy_monitor_scale` catch-all in `monitors.lua`. But when the file contains an explicit `hl.monitor` entry for the focused monitor — the per-monitor form the file's own shipped comments suggest:

```lua
-- Configure a specific monitor.
-- hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "0x0", scale = 1 })
```

— that entry overrides the catch-all. Each adjustment then applies live via `hyprctl eval`, the script's own write to `monitors.lua` triggers Hyprland's config reload, and the reload re-asserts the entry's stale scale, reverting the change a moment later. The keybinding appears dead; the audit log shows every press starting over from the same scale.

This bites anyone with per-monitor entries, which is the only way to run different scales on different monitors (e.g. a 4K at 1x next to a 1440p at 1.333x) — a state the single catch-all variable cannot express.

## Fix

Teach `set_scale` to update the explicit entry in place, before falling back to the existing catch-all forms. A new `update_explicit_monitor_scale` helper rewrites `scale = <number>` inside the `hl.monitor` entry naming the active output, handling both single-line entries (the form in the file's comments) and multi-line entries. The integer GDK scale is persisted alongside, as before.

Deliberately left to existing behavior:

- entries that reference a variable (`scale = omarchy_monitor_scale`) — not an explicit scale, the catch-all keeps owning them
- entries for other monitors
- commented-out entries

## Testing

- 4 new cases in `test/shell.d/monitor-scaling-test.sh` (explicit multi-line entry, explicit single-line entry, variable-referencing entry falls through, other-monitor entry falls through); all 18 pass
- `./test/all`: no new failures (4 `test/shell.d` files fail identically on clean master in my environment — config/snapper/runtime-smoke/unowned-system-paths — all unrelated)
- Smoke-tested on a live Omarchy 4.0.0 machine with divergent per-monitor scales: stepping the focused monitor now updates its entry, survives `hyprctl reload` (previously the revert point), `hyprctl configerrors` clean, catch-all variable and commented examples untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)