### PR TITLE
tailscale: detect CLI via command -v instead of the optional which package

### DIFF
--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -152,7 +152,7 @@ Item {
     }
     if (!whichProcess.running) {
       refreshing = true
-      whichProcess.command = ["which", "tailscale"]
+      whichProcess.command = ["bash", "-c", "command -v tailscale"]
       whichProcess.running = true
     }
   }

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -8,8 +8,10 @@ run_node_test <<'JS'
 const fs = require('fs')
 const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
+const serviceSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Service.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
+assert(/command -v tailscale/.test(serviceSource) && !/["']which["']/.test(serviceSource), 'tailscale detects the CLI via `command -v` rather than the optional `which` package')
 
 assertDeepEqual(
   tailscale.filterIPv4(['100.64.0.1', 'fd7a:115c:a1e0::1', '192.168.1.2']),


### PR DESCRIPTION
Fixes #7354

The Tailscale panel `Service.qml` shelled out to the external `which` utility to detect the `tailscale` CLI. The standalone `core/which` package is not part of the Arch base install, not in `omarchy-base.packages` or `omarchy-other.packages`, so on systems without it the panel permanently reports "Tailscale CLI is not installed or not on PATH" even when Tailscale is running and connected.

`command -v` is a bash builtin (already used by `omarchy-cmd-present` on the bash side) and works in any shell. The plugin already shells out through `bash -c` elsewhere (`copyToClipboard`), so this matches the existing pattern.

```diff
- whichProcess.command = ["which", "tailscale"]
+ whichProcess.command = ["bash", "-c", "command -v tailscale"]
```

Exit-code behavior is unchanged (0 when found, non-zero when not), so the `onExited` handler keeps working as-is.

Added a regression assertion in `tailscale-test.sh` that reads `Service.qml` and verifies the detection uses `command -v` rather than `which`.