### PR TITLE
zen: write preferences to the path Zen reads and merge with package policies

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -30,11 +30,38 @@ setup_firefox_preferences() {
   sudo cp -f "$OMARCHY_PATH/default/firefox/policies.json" "$distribution_dir/policies.json"
 }
 
+# Zen's AUR package (zen-browser-bin) installs to /opt/zen-browser-bin and
+# ships its own /opt/zen-browser-bin/distribution/policies.json with package
+# policies like DisableAppUpdate. Merge Omarchy's Preferences on top of the
+# package's policies instead of overwriting them, so a Zen upgrade can still
+# refresh its own entries and Omarchy's preferences survive the upgrade.
+#
+# The distribution dir is overridable for tests; the real install path is the
+# one Zen actually reads from.
+setup_zen_preferences() {
+  local distribution_dir="${1:-/opt/zen-browser-bin/distribution}"
+  local omarchy_policies="$OMARCHY_PATH/default/firefox/policies.json"
+  local merged_policies
+
+  setup_policy_directory "$distribution_dir"
+
+  if [[ -f $distribution_dir/policies.json ]] && omarchy-cmd-present jq; then
+    merged_policies=$(jq -S --slurpfile omarchy "$omarchy_policies" '
+      .policies + $omarchy[0].policies as $merged
+      | {policies: $merged}
+    ' "$distribution_dir/policies.json")
+    printf '%s' "$merged_policies" | sudo tee "$distribution_dir/policies.json" >/dev/null
+  else
+    sudo cp -f "$omarchy_policies" "$distribution_dir/policies.json"
+  fi
+}
+
 setup_firefox_wayland() {
   mkdir -p ~/.config/environment.d
   echo "MOZ_ENABLE_WAYLAND=1" > ~/.config/environment.d/omarchy-firefox-wayland.conf
 }
 
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
 case $1 in
 chromium)
   echo "Installing Chromium..."
@@ -93,7 +120,7 @@ zen)
   echo "Installing Zen..."
   omarchy-pkg-aur-add zen-browser-bin || exit 1
 
-  setup_firefox_preferences /opt/zen-browser/distribution
+  setup_zen_preferences
   setup_firefox_wayland
   announce_browser_installed "Zen"
   ;;
@@ -102,3 +129,4 @@ zen)
   exit 1
   ;;
 esac
+fi

--- a/test/shell.d/zen-browser-policies-test.sh
+++ b/test/shell.d/zen-browser-policies-test.sh
@@ -78,7 +78,7 @@ pass "zen preferences fall back to a plain copy without package policies"
 # /opt/zen-browser path from the original report.
 grep -q "zen-browser-bin/distribution" "$ROOT/bin/omarchy-install-browser" ||
   fail "zen installer targets the zen-browser-bin install path"
-grep -q "zen-browser/distribution" "$ROOT/bin/omarchy-install-browser" &&
-  fail "zen installer still references the unused zen-browser path" ||
-  true
+if grep -q "zen-browser/distribution" "$ROOT/bin/omarchy-install-browser"; then
+  fail "zen installer still references the unused zen-browser path"
+fi
 pass "zen installer targets the path Zen reads from"

--- a/test/shell.d/zen-browser-policies-test.sh
+++ b/test/shell.d/zen-browser-policies-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+export PATH="$ROOT/bin:$PATH"
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Stub sudo so the installer can write into our temp tree without privilege,
+# and omarchy-cmd-present so setup_zen_preferences sees jq as available.
+mock_bin="$TMPDIR/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ ${1:-} == "jq" ]]
+SH
+
+chmod +x "$mock_bin"/*
+
+distribution="$TMPDIR/zen-browser-bin/distribution"
+
+# Simulate the policies the zen-browser-bin AUR package ships: DisableAppUpdate
+# and DefaultSerialGuardSetting. The fix must merge Omarchy's Preferences on
+# top of these, not overwrite them.
+mkdir -p "$distribution"
+cat >"$distribution/policies.json" <<'JSON'
+{
+  "policies": {
+    "DisableAppUpdate": true,
+    "DefaultSerialGuardSetting": 3
+  }
+}
+JSON
+
+PATH="$mock_bin:$PATH" OMARCHY_PATH="$ROOT" bash -c '
+  source "$1/bin/omarchy-install-browser"
+  setup_zen_preferences "$2"
+' bash "$ROOT" "$distribution"
+
+[[ -f $distribution/policies.json ]] || fail "zen preferences wrote policies.json"
+
+jq -e '
+  .policies.DisableAppUpdate == true and
+  .policies.DefaultSerialGuardSetting == 3 and
+  (.policies.Preferences."apz.overscroll.enabled".Value == true) and
+  (.policies.Preferences."media.ffmpeg.vaapi.enabled".Value == true) and
+  (.policies.Preferences."widget.wayland.fractional-scale.enabled".Value == true)
+' "$distribution/policies.json" >/dev/null ||
+  fail "zen preferences preserve package policies and add Omarchy Preferences" \
+    "$(jq -c . "$distribution/policies.json")"
+pass "zen preferences preserve package policies and add Omarchy Preferences"
+
+# Without a pre-existing package policies.json, the installer falls back to a
+# plain copy of Omarchy's policies.
+fresh_distribution="$TMPDIR/zen-browser-bin-fresh/distribution"
+PATH="$mock_bin:$PATH" OMARCHY_PATH="$ROOT" bash -c '
+  source "$1/bin/omarchy-install-browser"
+  setup_zen_preferences "$2"
+' bash "$ROOT" "$fresh_distribution"
+
+jq -e '.policies.Preferences."apz.overscroll.enabled".Value == true' \
+  "$fresh_distribution/policies.json" >/dev/null ||
+  fail "zen preferences fall back to a plain copy without package policies"
+pass "zen preferences fall back to a plain copy without package policies"
+
+# The installer must target the path Zen actually reads from, not the
+# /opt/zen-browser path from the original report.
+grep -q "zen-browser-bin/distribution" "$ROOT/bin/omarchy-install-browser" ||
+  fail "zen installer targets the zen-browser-bin install path"
+grep -q "zen-browser/distribution" "$ROOT/bin/omarchy-install-browser" &&
+  fail "zen installer still references the unused zen-browser path" ||
+  true
+pass "zen installer targets the path Zen reads from"


### PR DESCRIPTION
Fixes #7411

`omarchy install browser zen` wrote Omarchy's Firefox-derived preferences to `/opt/zen-browser/distribution`, but the `zen-browser-bin` AUR package installs and launches Zen from `/opt/zen-browser-bin` (`exec /opt/zen-browser-bin/zen-bin "$@"`). Zen reads `distribution/policies.json` relative to its actual install dir, so the preferences were silently ignored.

This PR:

- Targets `/opt/zen-browser-bin/distribution`, the path Zen actually reads from.
- Merges Omarchy's `Preferences` on top of the package's own `policies.json` (which ships `DisableAppUpdate` and `DefaultSerialGuardSetting`) using `jq`, instead of `cp -f` overwriting them — so a Zen upgrade can still refresh its own entries and Omarchy's preferences survive the upgrade.
- Falls back to a plain copy when the package policies file is absent or `jq` is unavailable.
- Guards the dispatch `case` with `if [[ ${BASH_SOURCE[0]} == "$0" ]]` so the installer can be sourced by tests (matching the pattern in `omarchy-chromium-copy-url-host`).
- Adds `test/shell.d/zen-browser-policies-test.sh` covering the merge, the fallback, and the path.