### PR TITLE
shell: close menu-spawned panels on toggle re-press instead of re-running the action

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -509,7 +509,28 @@ ShellRoot {
 
   function toggle(pluginId, payloadJson) {
     var id = shell.pluginRegistry.resolveEnabledId(pluginId)
-    return isPluginOpen(id) ? hide(id) : summon(id, payloadJson)
+    if (isPluginOpen(id)) return hide(id)
+    // A menu action (e.g. style.background, style.theme) self-closes the menu
+    // and then spawns a separate panel (image-picker) via shell.summon. The
+    // menu's own openPanelIds entry stays true from the original summon because
+    // the menu sets `opened = false` directly without calling shell.hide, so
+    // isPluginOpen above reports false even though the entry is stale. When
+    // that stale entry exists, close any panel the action left open instead of
+    // re-running the action on the next key press. Clean up the stale entry
+    // either way so a normal menu action (which spawns nothing) reopens the
+    // menu on the next press instead of no-op'ing.
+    if (openPanelIds[id]) {
+      var closedAny = false
+      for (var openId in openPanelIds) {
+        if (openId !== id && isPluginOpen(openId)) {
+          hide(openId)
+          closedAny = true
+        }
+      }
+      hide(id)
+      if (closedAny) return true
+    }
+    return summon(id, payloadJson)
   }
 
   // Map of pluginId -> Loader, populated by the Instantiator delegate below.

--- a/test/shell.d/menu-toggle-close-test.sh
+++ b/test/shell.d/menu-toggle-close-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const shellSource = fs.readFileSync(root + '/shell/shell.qml', 'utf8')
+
+// shell.toggle must close a panel that a menu action left open instead of
+// re-running the action on the next key press. The menu self-closes by setting
+// `opened = false` without calling shell.hide, which leaves a stale
+// openPanelIds entry; toggle uses that stale entry as the signal to tear down
+// whatever the action spawned (e.g. the image-picker behind Background/Theme).
+const toggleBody = shellSource.match(/function toggle\(pluginId, payloadJson\) \{([\s\S]*?)\n  \}/)
+assert(toggleBody, 'shell.qml defines a toggle(pluginId, payloadJson) function')
+
+assert(/openPanelIds\[id\]/.test(toggleBody[1]), 'toggle checks the stale openPanelIds entry for the requested plugin')
+assert(/isPluginOpen\(openId\)/.test(toggleBody[1]), 'toggle checks whether a spawned panel is still open before closing it')
+assert(/hide\(openId\)/.test(toggleBody[1]), 'toggle hides a panel the menu action left open')
+assert(/hide\(id\)/.test(toggleBody[1]), 'toggle cleans up the stale openPanelIds entry for the requested plugin')
+assert(/if \(closedAny\) return true/.test(toggleBody[1]), 'toggle stops after closing a spawned panel instead of re-running the action')
+assert(/return summon\(id, payloadJson\)/.test(toggleBody[1]), 'toggle still summons when no spawned panel needs closing')
+
+pass('shell.toggle closes a menu-spawned panel on re-press instead of re-running the action')
+JS


### PR DESCRIPTION
Fixes #7389

### The problem

Pressing the keybind for Background Switcher (SUPER+CTRL+SPACE) or Theme Switcher (SUPER+SHIFT+CTRL+SPACE) opens the switcher, but pressing it again does not close it — it re-runs the action instead.

### Root cause

These menu entries (`style.background`, `style.theme`) are **actions**, not submenus. The flow:

1. `omarchy-menu toggle background` → `shell.toggle("omarchy.menu", {menu:"background"})`
2. The menu is not open, so `toggle` calls `summon("omarchy.menu", ...)`.
3. The menu's `openRoute("background")` sees the route resolves to an action, calls `cancel()` (sets `opened = false`) and runs the action detached. The action spawns the **image-picker** panel via `shell.summon("omarchy.image-picker")`.
4. The menu self-closed by setting `opened = false` directly — it never called `shell.hide("omarchy.menu")`, so `openPanelIds["omarchy.menu"]` stays `true` (stale) while `isPluginOpen("omarchy.menu")` reports `false`.
5. On the second press, `toggle` sees `isPluginOpen` is false and calls `summon` again, which re-runs the action instead of closing the image-picker that the first press opened.

### The fix

`shell.toggle` now checks for the stale `openPanelIds` entry when the plugin is not actually open. When it finds one, it closes any panel the action left open (e.g. the image-picker) and cleans up the stale entry, instead of re-running the action. A normal menu action that spawns nothing just cleans up the stale entry and reopens the menu on the next press.

```javascript
function toggle(pluginId, payloadJson) {
  var id = shell.pluginRegistry.resolveEnabledId(pluginId)
  if (isPluginOpen(id)) return hide(id)
  if (openPanelIds[id]) {
    var closedAny = false
    for (var openId in openPanelIds) {
      if (openId !== id && isPluginOpen(openId)) {
        hide(openId)
        closedAny = true
      }
    }
    hide(id)
    if (closedAny) return true
  }
  return summon(id, payloadJson)
}
```

### Verification

- Added `test/shell.d/menu-toggle-close-test.sh` (source-level assertions over `shell.qml`).
- All existing shell/cli tests pass.
- **Recommended visual verification** in a running session (requires `omarchy dev link` + reboot): press SUPER+CTRL+SPACE to open the background switcher, press it again to confirm it closes rather than re-opening.