### PR TITLE
default-editor: sync XDG MIME defaults so Nautilus respects the menu selection

### DIFF
--- a/applications/omarchy-launch-editor.desktop
+++ b/applications/omarchy-launch-editor.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Editor
+Comment=Open files in the Omarchy default editor
+Exec=omarchy-launch-editor %f
+Icon=text-editor
+Type=Application
+MimeType=text/plain;text/english;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;application/xml;text/xml;
+Terminal=false
+Categories=Utility;TextEditor;
+NoDisplay=true

--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -56,4 +56,18 @@ fi
 mkdir -p "$(dirname "$editor_file")"
 printf '%s\n' "$editor" >"$editor_file"
 
+# Nautilus and other XDG-aware file managers pick the app for text files from
+# mimeapps.list, not from Omarchy's internal default. Point every text MIME
+# type at the omarchy-launch-editor handler, which delegates to the editor
+# recorded above — so changing the default editor from the menu also changes
+# what double-clicking a text file opens in Nautilus.
+if command -v xdg-mime >/dev/null 2>&1; then
+  xdg-mime default omarchy-launch-editor.desktop \
+    text/plain text/english text/x-makefile \
+    text/x-c++hdr text/x-c++src text/x-chdr text/x-csrc \
+    text/x-java text/x-moc text/x-pascal text/x-tcl text/x-tex \
+    application/x-shellscript text/x-c text/x-c++ \
+    application/xml text/xml
+fi
+
 omarchy-notification-send -g $glyph "$name is now the default editor"

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -52,6 +52,22 @@ set) printf '%s\n' "$3" >"$OMARCHY_TEST_BROWSER_FILE" ;;
 esac
 SH
 
+mime_defaults_file="$test_tmp/mime-defaults"
+cat >"$mock_bin/xdg-mime" <<'SH'
+#!/bin/bash
+case "$1" in
+default)
+  shift
+  desktop_id=$1
+  shift
+  for mime in "$@"; do
+    printf '%s=%s\n' "$mime" "$desktop_id" >>"$OMARCHY_TEST_MIME_DEFAULTS_FILE"
+  done
+  ;;
+query) ;;
+esac
+SH
+
 cat >"$mock_bin/omarchy-test-installer" <<'SH'
 #!/bin/bash
 installer=${0##*/}
@@ -133,6 +149,7 @@ export OMARCHY_TEST_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_NOTIFICATION_LOG="$notification_log"
 export OMARCHY_TEST_SETUP_LOG="$setup_log"
 export OMARCHY_TEST_BROWSER_FILE="$browser_file"
+export OMARCHY_TEST_MIME_DEFAULTS_FILE="$mime_defaults_file"
 
 assert_missing_opens_installer() {
   local type=$1
@@ -264,6 +281,19 @@ omarchy-default-terminal kitty
 omarchy-default-editor nvim
 [[ ! -s $install_log && ! -s $terminal_log ]] || fail "installed defaults skip installation"
 pass "installed defaults are selected immediately"
+
+# Setting the default editor must also update XDG MIME defaults so Nautilus
+# opens text files in the selected editor, not just the hardcoded nvim.desktop.
+: >"$mime_defaults_file"
+omarchy-default-editor vim
+[[ -s $mime_defaults_file ]] || fail "setting the default editor updates XDG MIME defaults"
+grep -Fxq "text/plain=omarchy-launch-editor.desktop" "$mime_defaults_file" ||
+  fail "default editor points text/plain at the omarchy-launch-editor handler"
+grep -Fxq "application/xml=omarchy-launch-editor.desktop" "$mime_defaults_file" ||
+  fail "default editor points application/xml at the omarchy-launch-editor handler"
+grep -Fxq "application/x-shellscript=omarchy-launch-editor.desktop" "$mime_defaults_file" ||
+  fail "default editor points application/x-shellscript at the omarchy-launch-editor handler"
+pass "setting the default editor updates XDG MIME defaults for text types"
 
 previous_editor=$(omarchy-default-editor)
 rm -f "$installed_dir/vim"


### PR DESCRIPTION
Fixes #7441

### The problem

Selecting "Vim" as the default editor from SUPER+SPACE > Setup > Defaults > Editor updates Omarchy's internal default (`~/.local/state/omarchy/defaults/editor`), but Nautilus keeps opening text files in Neovim. The Omarchy menu selection has no effect on what Nautilus uses.

### Root cause

`omarchy-default-editor` only writes Omarchy's internal file. Nautilus (and other XDG-aware file managers) pick the app for text files from `mimeapps.list`, which ships `text/plain=nvim.desktop` from `default/applications/mimeapps.list` and is never updated when the user changes their default editor. `omarchy-default-browser` already handles this correctly by calling `xdg-settings set default-web-browser`; the editor path was missing the equivalent `xdg-mime default` call.

### The fix

1. **Ship `applications/omarchy-launch-editor.desktop`** — a NoDisplay handler that delegates to `omarchy-launch-editor %f`, which already knows how to launch the configured editor (wrapping TUI editors in a terminal via `omarchy-launch-tui`). It is installed by `omarchy-refresh-applications` alongside the other shipped `.desktop` files.

2. **`omarchy-default-editor` now calls `xdg-mime default omarchy-launch-editor.desktop`** for every text MIME type listed in the shipped `mimeapps.list` after writing the internal default. Because the handler delegates to `omarchy-launch-editor`, changing the editor from the menu takes effect for Nautilus immediately without re-running `xdg-mime default`.

### Verification

- Extended `test/shell.d/default-apps-test.sh` with an `xdg-mime` stub and assertions that setting the default editor writes the expected MIME defaults.
- All existing shell/cli tests pass.
- **Recommended visual verification**: run `omarchy default editor vim`, then double-click a `.txt` file in Nautilus and confirm it opens in Vim (in a terminal), not Neovim.