### PR TITLE
sleep-monitor: resolve dbus-monitor by absolute path to avoid PATH shadowing

### DIFF
--- a/bin/omarchy-system-sleep-monitor
+++ b/bin/omarchy-system-sleep-monitor
@@ -4,6 +4,13 @@
 # omarchy:group=system
 # omarchy:hidden=true
 
+# Resolve dbus-monitor by absolute path so a shadowing PATH entry (e.g.
+# Homebrew's relocatable dbus build, which looks for a system bus socket
+# under $HOMEBREW_PREFIX) cannot redirect the monitor to the wrong bus and
+# leave omarchy-sleep-lock.service restart-looping silently. Tests override
+# DBUS_MONITOR with a mock.
+DBUS_MONITOR="${DBUS_MONITOR:-/usr/bin/dbus-monitor}"
+
 consume_sleep_events() {
   local line sleep_lock
   sleep_lock="$OMARCHY_PATH/bin/omarchy-system-sleep-lock"
@@ -20,7 +27,7 @@ monitor_sleep_events() {
   local monitor_fd monitor_pid status
 
   coproc SLEEP_EVENTS {
-    exec dbus-monitor --system \
+    exec "$DBUS_MONITOR" --system \
       "type='signal',sender='org.freedesktop.login1',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"
   }
   monitor_fd=${SLEEP_EVENTS[0]}

--- a/test/shell.d/sleep-monitor-test.sh
+++ b/test/shell.d/sleep-monitor-test.sh
@@ -112,7 +112,7 @@ pass "sleep monitor cleans up its producer when terminated"
 # system bus and leave omarchy-sleep-lock.service restart-looping silently.
 grep -q 'DBUS_MONITOR="${DBUS_MONITOR:-/usr/bin/dbus-monitor}"' "$sleep_monitor" ||
   fail "sleep monitor resolves dbus-monitor by absolute path by default"
-grep -Eq 'exec[[:space:]]+dbus-monitor[[:space:]]' "$sleep_monitor" &&
-  fail "sleep monitor still invokes bare dbus-monitor from PATH" ||
-  true
+if grep -Eq 'exec[[:space:]]+dbus-monitor[[:space:]]' "$sleep_monitor"; then
+  fail "sleep monitor still invokes bare dbus-monitor from PATH"
+fi
 pass "sleep monitor resolves dbus-monitor by absolute path by default"

--- a/test/shell.d/sleep-monitor-test.sh
+++ b/test/shell.d/sleep-monitor-test.sh
@@ -46,6 +46,7 @@ ln -s "$sleep_monitor" "$mock_omarchy/bin/omarchy-system-sleep-monitor"
 
 start_us=${EPOCHREALTIME//[!0-9]/}
 OMARCHY_PATH="$mock_omarchy" \
+  DBUS_MONITOR="$mock_bin/dbus-monitor" \
   PATH="$mock_bin:$PATH" \
   PRODUCER_PID_FILE="$producer_pid_file" \
   LOCK_LOG="$lock_log" \
@@ -79,6 +80,7 @@ chmod +x "$mock_bin/dbus-monitor"
 rm -f "$producer_pid_file"
 
 OMARCHY_PATH="$mock_omarchy" \
+  DBUS_MONITOR="$mock_bin/dbus-monitor" \
   PATH="$mock_bin:$PATH" \
   PRODUCER_PID_FILE="$producer_pid_file" \
   LOCK_LOG="$lock_log" \
@@ -104,3 +106,13 @@ if kill -0 "$producer_pid" 2>/dev/null; then
   fail "sleep monitor cleans up its producer when terminated" "producer still running: $producer_pid"
 fi
 pass "sleep monitor cleans up its producer when terminated"
+
+# The monitor must not resolve dbus-monitor by bare PATH lookup — a shadowing
+# PATH entry (Homebrew's relocatable dbus build) would redirect it to the wrong
+# system bus and leave omarchy-sleep-lock.service restart-looping silently.
+grep -q 'DBUS_MONITOR="${DBUS_MONITOR:-/usr/bin/dbus-monitor}"' "$sleep_monitor" ||
+  fail "sleep monitor resolves dbus-monitor by absolute path by default"
+grep -Eq 'exec[[:space:]]+dbus-monitor[[:space:]]' "$sleep_monitor" &&
+  fail "sleep monitor still invokes bare dbus-monitor from PATH" ||
+  true
+pass "sleep monitor resolves dbus-monitor by absolute path by default"


### PR DESCRIPTION
Fixes #7412

### The problem

`omarchy-system-sleep-monitor` invoked `dbus-monitor` by bare name. On systems with Homebrew (linuxbrew) installed, Homebrew's `bin` directory sits ahead of `/usr/bin` on `$PATH` (its documented `shellenv` behavior), and Homebrew ships its own `dbus-monitor` built with a relocatable system-bus address (`$HOMEBREW_PREFIX/var/run/dbus/system_bus_socket`) instead of the real OS socket (`/run/dbus/system_bus_socket`).

The Homebrew `dbus-monitor` fails to connect and exits immediately. Because `omarchy-sleep-lock.service` is `Type=simple` with `Restart=always`/`RestartSec=2` and the `--inhibited` branch ends with `exit 0` regardless of `dbus-monitor`'s outcome, systemd restart-loops the unit every 2 seconds forever — over 10,000 restarts in a ~6 hour session — and the pre-suspend lock never fires.

### The fix

Resolve `dbus-monitor` by absolute path (`/usr/bin/dbus-monitor`) by default, with a `DBUS_MONITOR` env-var override so tests can substitute a mock:

```bash
DBUS_MONITOR="${DBUS_MONITOR:-/usr/bin/dbus-monitor}"
```

`dbus` is a base Arch package, so `/usr/bin/dbus-monitor` is a runtime invariant.

### Verification

- Updated `test/shell.d/sleep-monitor-test.sh` to pass `DBUS_MONITOR` pointing at the mock, and added assertions that the script defaults to the absolute path and no longer invokes bare `dbus-monitor`.
- All existing shell/cli tests pass.