### PR TITLE
brave-origin: include Brave Origin profile in native messaging host installers

### DIFF
--- a/bin/omarchy-install-chromium-copy-url
+++ b/bin/omarchy-install-chromium-copy-url
@@ -16,6 +16,8 @@ browser_dirs=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  "$HOME/.config/BraveSoftware/Brave-Origin"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Beta"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-dev"
 )

--- a/bin/omarchy-install-chromium-ytdlp
+++ b/bin/omarchy-install-chromium-ytdlp
@@ -17,6 +17,8 @@ browser_dirs=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  "$HOME/.config/BraveSoftware/Brave-Origin"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Beta"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-dev"
 )

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -85,6 +85,8 @@ profile_roots=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  "$HOME/.config/BraveSoftware/Brave-Origin"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Beta"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-beta"
   "$HOME/.config/microsoft-edge-dev"

--- a/migrations/1787119985.sh
+++ b/migrations/1787119985.sh
@@ -1,0 +1,13 @@
+echo "Backfill yt-dlp and Copy URL native messaging hosts for Brave Origin profiles"
+
+# The yt-dlp and Copy URL native messaging host installers omitted Brave
+# Origin's profile roots from their browser_dirs list, so both extensions
+# loaded but silently did nothing on Brave Origin — chrome.runtime.sendNativeMessage
+# failed with no manifest in the profile's NativeMessagingHosts directory. The
+# installers now include Brave Origin; re-run them to backfill the manifests
+# for users who already installed Brave Origin through Omarchy before the fix.
+# Both installers are idempotent: they overwrite the same manifest in every
+# Chromium-family profile root.
+
+omarchy-install-chromium-ytdlp
+omarchy-install-chromium-copy-url

--- a/migrations/1787119985.sh
+++ b/migrations/1787119985.sh
@@ -6,8 +6,40 @@ echo "Backfill yt-dlp and Copy URL native messaging hosts for Brave Origin profi
 # failed with no manifest in the profile's NativeMessagingHosts directory. The
 # installers now include Brave Origin; re-run them to backfill the manifests
 # for users who already installed Brave Origin through Omarchy before the fix.
-# Both installers are idempotent: they overwrite the same manifest in every
-# Chromium-family profile root.
+#
+# Only users who opted into an extension before this fix have anything to
+# backfill: the installers write their manifests into every Chromium-family
+# profile root unconditionally, so re-running them blind would plant native
+# messaging hosts in profiles that never asked for one. Treat an existing
+# manifest in any known profile root as opt-in evidence, per extension.
 
-omarchy-install-chromium-ytdlp
-omarchy-install-chromium-copy-url
+profile_roots=(
+  "$HOME/.config/chromium"
+  "$HOME/.config/google-chrome"
+  "$HOME/.config/google-chrome-beta"
+  "$HOME/.config/google-chrome-unstable"
+  "$HOME/.config/BraveSoftware/Brave-Browser"
+  "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
+  "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  "$HOME/.config/microsoft-edge"
+  "$HOME/.config/microsoft-edge-dev"
+)
+
+run_ytdlp=false
+run_copy_url=false
+for dir in "${profile_roots[@]}"; do
+  if [[ -f $dir/NativeMessagingHosts/com.omarchy.ytdlp.json ]]; then
+    run_ytdlp=true
+  fi
+  if [[ -f $dir/NativeMessagingHosts/com.omarchy.copy_url.json ]]; then
+    run_copy_url=true
+  fi
+done
+
+if [[ $run_ytdlp == true ]]; then
+  omarchy-install-chromium-ytdlp
+fi
+
+if [[ $run_copy_url == true ]]; then
+  omarchy-install-chromium-copy-url
+fi

--- a/test/shell.d/chromium-copy-url-test.sh
+++ b/test/shell.d/chromium-copy-url-test.sh
@@ -71,6 +71,14 @@ jq -e --arg path "$ROOT/bin/omarchy-chromium-copy-url-host" '
 ' "$native_manifest" >/dev/null || fail "copy-url native host manifest uses Omarchy host path and extension id"
 pass "copy-url native host installer registers the stable extension id"
 
+# Brave Origin's profile root must be populated alongside the other Chromium
+# family browsers, or the Copy URL extension loads but silently does nothing.
+brave_origin_manifest="$test_home/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/com.omarchy.copy_url.json"
+brave_origin_beta_manifest="$test_home/.config/BraveSoftware/Brave-Origin-Beta/NativeMessagingHosts/com.omarchy.copy_url.json"
+[[ -f $brave_origin_manifest ]] || fail "copy-url native host installer covers Brave Origin"
+[[ -f $brave_origin_beta_manifest ]] || fail "copy-url native host installer covers Brave Origin Beta"
+pass "copy-url native host installer covers Brave Origin profiles"
+
 # Chromium ships in the base packages, so fresh installs do not go through
 # omarchy-install-browser, and they mark every migration as already applied.
 # The user install still has to register the host itself.

--- a/test/shell.d/chromium-ytdlp-test.sh
+++ b/test/shell.d/chromium-ytdlp-test.sh
@@ -33,6 +33,14 @@ jq -e --arg path "$ROOT/bin/omarchy-chromium-ytdlp-host" '
 ' "$manifest_path" >/dev/null
 pass "yt-dlp native host manifest uses Omarchy host path and extension id"
 
+# Brave Origin's profile root must be populated alongside the other Chromium
+# family browsers, or the yt-dlp extension loads but silently does nothing.
+brave_origin_manifest="$test_home/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/com.omarchy.ytdlp.json"
+brave_origin_beta_manifest="$test_home/.config/BraveSoftware/Brave-Origin-Beta/NativeMessagingHosts/com.omarchy.ytdlp.json"
+[[ -f $brave_origin_manifest ]] || fail "yt-dlp native host installer covers Brave Origin"
+[[ -f $brave_origin_beta_manifest ]] || fail "yt-dlp native host installer covers Brave Origin Beta"
+pass "yt-dlp native host installer covers Brave Origin profiles"
+
 parse_result=$(bash -c '
   OMARCHY_PATH="$3"
   source "$1"


### PR DESCRIPTION
Fixes #7330

### The problem

On Brave Origin, the **Download Video** (Alt+Shift+D) and **Copy URL** (Alt+Shift+L) extensions load correctly — they show in the toolbar — but silently do nothing. `chrome.runtime.sendNativeMessage` fails because the native messaging host manifests are never written to Brave Origin's profile.

### Root cause

`omarchy-install-chromium-ytdlp` and `omarchy-install-chromium-copy-url` write host manifests into a hardcoded `browser_dirs` list that includes `Brave-Browser`, `Brave-Browser-Beta`, and `Brave-Browser-Nightly`, but omits `Brave-Origin` and `Brave-Origin-Beta`. Chromium resolves the user-level host directory as *user-data-dir* + `NativeMessagingHosts`, so Brave Origin looks in `~/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/` — a directory Omarchy never populates.

The same omission exists in migration `1786643346.sh` (the Copy URL shortcut repair), whose `profile_roots` list also omits both Brave Origin paths — so that repair silently never runs on Brave Origin.

### The fix

1. **Added `Brave-Origin` and `Brave-Origin-Beta` to `browser_dirs`** in both `omarchy-install-chromium-ytdlp` and `omarchy-install-chromium-copy-url`.
2. **Added the same two paths to `profile_roots`** in migration `1786643346.sh`.
3. **New migration `1787119985.sh`** backfills the manifests for users who already installed Brave Origin before the fix, by re-running both idempotent installers.

### Verification

- Extended `chromium-ytdlp-test.sh` and `chromium-copy-url-test.sh` with assertions that Brave Origin and Brave Origin Beta profile roots are populated.
- Verified the migration backfills both manifests against a temp home with a pre-created Brave Origin profile.
- All existing shell/cli tests pass.