### PR TITLE
emoji-insert: persist clipboard instead of clearing it after 0.35s

### DIFF
--- a/bin/omarchy-menu-emoji-insert
+++ b/bin/omarchy-menu-emoji-insert
@@ -6,15 +6,18 @@
 # omarchy:hidden=true
 
 emoji="${1:-}"
-copy_pid=""
 
 [[ -n $emoji ]] || exit
 
-printf '%s' "$emoji" | wl-copy --type text/plain --sensitive --foreground &
-copy_pid=$!
+# Copy the emoji to the clipboard. Without --foreground, wl-copy daemonizes
+# and the content persists — the previous --foreground + kill pattern cleared
+# the clipboard after 0.35s, leaving neither a paste nor a manual copy working.
+printf '%s' "$emoji" | wl-copy --type text/plain
 
+# Give the layer-shell surface time to release keyboard focus before typing.
 sleep 0.15
-wtype -M shift -k Insert -m shift 2>/dev/null || true
-sleep 0.2
 
-kill "$copy_pid" 2>/dev/null || true
+# Best-effort auto-paste into the focused window. Some apps don't bind
+# Shift+Insert to paste, but the clipboard content persists regardless so
+# the user can paste manually.
+wtype -M shift -k Insert -m shift 2>/dev/null || true

--- a/test/shell.d/emojis-test.sh
+++ b/test/shell.d/emojis-test.sh
@@ -53,14 +53,8 @@ mkdir -p "$TMPDIR/bin"
 
 cat >"$TMPDIR/bin/wl-copy" <<'SH'
 #!/bin/bash
-args="$*"
-target="$WL_COPY_OUT"
-if [[ $args == "--type text/plain --sensitive --foreground" ]]; then
-  target="$WL_COPY_EMOJI_OUT"
-fi
-
-printf '%s\n' "$args" >"$target.args"
-cat >"$target"
+printf '%s\n' "$*" >"$WL_COPY_ARGS_OUT"
+cat >"$WL_COPY_OUT"
 SH
 
 cat >"$TMPDIR/bin/wtype" <<'SH'
@@ -75,14 +69,19 @@ SH
 
 chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wtype" "$TMPDIR/bin/sleep"
 
-WL_COPY_OUT="$TMPDIR/copy" WL_COPY_EMOJI_OUT="$TMPDIR/emoji" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
+WL_COPY_OUT="$TMPDIR/copy" WL_COPY_ARGS_OUT="$TMPDIR/copy.args" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
   "$ROOT/bin/omarchy-menu-emoji-insert" "😀"
 
-[[ $(<"$TMPDIR/emoji") == "😀" ]] || fail "emoji insert helper copies emoji transiently"
-pass "emoji insert helper copies emoji transiently"
+[[ $(<"$TMPDIR/copy") == "😀" ]] || fail "emoji insert helper copies emoji to clipboard"
+pass "emoji insert helper copies emoji to clipboard"
 
-[[ $(<"$TMPDIR/emoji.args") == "--type text/plain --sensitive --foreground" ]] || fail "emoji insert helper serves sensitive transient clipboard in foreground"
-pass "emoji insert helper serves transient clipboard in foreground"
+# Without --foreground, wl-copy daemonizes and the content persists instead of
+# being cleared after 0.35s by a kill — the root cause of both #7378 (keyboard)
+# and #7379 (mouse) where the emoji ended up in neither the clipboard nor the
+# target window.
+[[ $(<"$TMPDIR/copy.args") == "--type text/plain" ]] ||
+  fail "emoji insert helper copies persistently without --foreground" "args: $(<"$TMPDIR/copy.args")"
+pass "emoji insert helper copies persistently without --foreground"
 
 [[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "emoji insert helper pastes with shift insert"
 pass "emoji insert helper pastes with shift insert"


### PR DESCRIPTION
Fixes #7378
Fixes #7379

### The problem

Selecting an emoji from the Emoji Picker (by keyboard or mouse) results in nothing — the emoji is neither inserted into the focused window nor placed in the clipboard. Both keyboard (#7378) and mouse (#7379) selection are broken.

### Root cause

Both paths converge on `omarchy-menu-emoji-insert`, which used `wl-copy --foreground &` to copy the emoji, then killed the `wl-copy` process after 0.35s:

```bash
printf %s'%s\ "$emoji" | wl-copy --type text/plain --sensitive --foreground &
copy_pid=$!
sleep 0.15
wtype -M shift -k Insert -m shift 2>/dev/null || true
sleep 0.2
kill "$copy_pid" 2>/dev/null || true
```

With `--foreground`, `wl-copy` owns the clipboard only while running. Killing it after 0.35s clears the clipboard. If the paste (`wtype Shift+Insert`) didn't reach the target window in time — which happens when the layer-shell surface hasn't released keyboard focus yet — the emoji is gone from both the clipboard and the target window.

### The fix

Copy the emoji to the clipboard without `--foreground`, so `wl-copy` daemonizes and the content persists. The best-effort auto-paste (`wtype Shift+Insert`) still runs, but even if it fails the emoji stays in the clipboard and the user can paste manually.

```bash
printf %s'%s\ "$emoji" | wl-copy --type text/plain
sleep 0.15
wtype -M shift -k Insert -m shift 2>/dev/null || true
```

Also removed `--sensitive`, which is intended for passwords/secrets and has no benefit for emoji.

### Verification

- Updated `emojis-test.sh` to assert persistent clipboard copy (no `--foreground`, no `--sensitive`) and the retained paste attempt.
- All existing shell/cli tests pass.
- **Recommended visual verification**: open the emoji picker (SUPER+E or menu), select an emoji by keyboard, confirm it appears in the clipboard (paste anywhere). Repeat with mouse click.