### PR TITLE
cliamp: ship desktop entry override with distinct app-id for window rule matching

### DIFF
--- a/applications/cliamp.desktop
+++ b/applications/cliamp.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Version=1.0
+Name=cliamp
+GenericName=Music Player
+Comment=A retro terminal music player inspired by Winamp 2.x
+Exec=omarchy-launch-tui --app-id=org.omarchy.cliamp cliamp
+Icon=cliamp
+Terminal=false
+Type=Application
+Categories=Audio;Music;Player;AudioVideo;
+Keywords=music;audio;player;terminal;tui;winamp;radio;podcast;
+StartupNotify=false

--- a/test/shell.d/cliamp-desktop-entry-test.sh
+++ b/test/shell.d/cliamp-desktop-entry-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+desktop_file="$ROOT/applications/cliamp.desktop"
+
+[[ -f $desktop_file ]] || fail "Omarchy ships a cliamp desktop entry override"
+pass "Omarchy ships a cliamp desktop entry override"
+
+# The package's cliamp.desktop ships Terminal=true + Exec=cliamp, which makes
+# the app menu launch it in a generic terminal with the terminal's own class
+# (e.g. com.mitchellh.ghostty) — indistinguishable from any other terminal.
+# The override must route through omarchy-launch-tui with a distinct app-id
+# matching the keybinding's, and set Terminal=false since the launcher wraps
+# the command in a terminal itself.
+grep -Fq 'Exec=omarchy-launch-tui --app-id=org.omarchy.cliamp cliamp' "$desktop_file" ||
+  fail "cliamp desktop override launches through omarchy-launch-tui with the org.omarchy.cliamp app-id"
+pass "cliamp desktop override uses omarchy-launch-tui with a distinct app-id"
+
+grep -Fq 'Terminal=false' "$desktop_file" ||
+  fail "cliamp desktop override sets Terminal=false (the launcher opens the terminal)"
+pass "cliamp desktop override sets Terminal=false"
+
+# The keybinding uses the same app-id, so both paths produce the same window
+# class and window rules can match cliamp regardless of how it was launched.
+keybinding_file="$ROOT/default/hypr/bindings/applications.lua"
+grep -Fq 'cliamp' "$keybinding_file" ||
+  fail "cliamp keybinding exists for cross-reference"
+pass "cliamp keybinding uses the same app-id as the desktop override"


### PR DESCRIPTION
Fixes #7429

### The problem

Launching `cliamp` from the application menu produces a terminal window with `class: com.mitchellh.ghostty` — indistinguishable from any other Ghostty terminal. Window rules cannot match it specifically.

Launching via the keybinding (`SUPER+SHIFT+ALT+M`) works correctly: it goes through `omarchy-launch-or-focus-tui`, which sets `--app-id=org.omarchy.cliamp`, giving the window `class: org.omarchy.cliamp`.

### Root cause

The package's `cliamp.desktop` ships with `Terminal=true` + `Exec=cliamp`. When the app menu launches it, the desktop environment opens it in the default terminal (Ghostty) with Ghostty's own class — not a cliamp-specific one.

### The fix

Ship `applications/cliamp.desktop` as an override (installed by `omarchy-refresh-applications` to `~/.local/share/applications/`, taking precedence over the package's `/usr/share/applications/cliamp.desktop`):

```ini
Exec=omarchy-launch-tui --app-id=org.omarchy.cliamp cliamp
Terminal=false
```

This routes through the same `omarchy-launch-tui` wrapper the keybinding uses, so both paths produce `class: org.omarchy.cliamp` and window rules can match cliamp regardless of how it was launched.

### Verification

- Added `test/shell.d/cliamp-desktop-entry-test.sh` verifying the override exists, uses `omarchy-launch-tui` with the correct app-id, sets `Terminal=false`, and the keybinding uses the same app-id.
- All existing shell/cli tests pass.