### PR TITLE
menu: scale wheel events 3x for faster touchpad scrolling on long lists

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1224,6 +1224,19 @@ Item {
             spacing: root.rowSpacing
             boundsBehavior: Flickable.StopAtBounds
 
+            // Qt's default Flickable touchpad scrolling is too slow on long
+            // lists (e.g. keybindings). Scale the wheel delta so each gesture
+            // moves the list meaningfully instead of a few pixels at a time.
+            WheelHandler {
+              onWheel: function(event) {
+                var step = event.angleDelta.y * 3
+                var minY = resultList.originY
+                var maxY = resultList.originY + resultList.contentHeight - resultList.height
+                if (maxY <= minY) return
+                resultList.contentY = Math.max(minY, Math.min(resultList.contentY - step, maxY))
+              }
+            }
+
             section.property: "section"
             section.criteria: ViewSection.FullString
             section.delegate: Item {

--- a/test/shell.d/menu-scroll-speed-test.sh
+++ b/test/shell.d/menu-scroll-speed-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const menuSource = fs.readFileSync(root + '/shell/plugins/menu/Menu.qml', 'utf8')
+
+// The menu ListView must carry a WheelHandler that scales the wheel delta so
+// touchpad scrolling on long lists (e.g. keybindings) feels responsive. Qt's
+// default Flickable scroll on touchpads translates the small per-event
+// angleDelta into tiny contentY steps, making the menu feel sluggish.
+const listMatch = menuSource.match(/ListView \{[\s\S]*?id: resultList[\s\S]*?\n            \}/)
+assert(listMatch, 'menu ListView with id resultList exists')
+assert(/WheelHandler\s*\{/.test(listMatch[0]), 'menu ListView has a WheelHandler for scroll speed')
+assert(/event\.angleDelta\.y\s*\*\s*3/.test(listMatch[0]), 'menu WheelHandler scales the wheel delta by 3x')
+assert(/resultList\.contentY/.test(listMatch[0]), 'menu WheelHandler adjusts contentY directly')
+assert(/resultList\.originY/.test(listMatch[0]), 'menu WheelHandler clamps to originY bounds')
+pass('menu ListView scales wheel events for faster touchpad scrolling')
+JS


### PR DESCRIPTION
Fixes #7361

### The problem

The Omarchy menu scrolls very slowly with touchpad on long lists like the keybindings menu. Navigating requires many scroll gestures to move through the list.

### Root cause

The menu's `ListView` uses Qt's default `Flickable` scroll behavior, which translates the small per-event `angleDelta` from touchpad scroll events into tiny `contentY` steps. On high-precision touchpads each event carries only 10-20 units of angleDelta, so the list barely moves per gesture.

### The fix

Added a `WheelHandler` to the menu's `ListView` that scales the wheel delta by 3x and adjusts `contentY` directly, clamped to the list's bounds:

```qml
WheelHandler {
    onWheel: function(event) {
        var step = event.angleDelta.y * 3
        var minY = resultList.originY
        var maxY = resultList.originY + resultList.contentHeight - resultList.height
        if (maxY <= minY) return
        resultList.contentY = Math.max(minY, Math.min(resultList.contentY - step, maxY))
    }
}
```

This makes both touchpad and mouse wheel scrolling 3x faster without being uncontrollable.

### Verification

- Added `test/shell.d/menu-scroll-speed-test.sh` (source-level assertions over `Menu.qml`).
- All existing shell/cli tests pass.
- **Recommended visual verification**: open the keybindings menu (SUPER+K), scroll with touchpad, and confirm the list moves at a responsive speed.