### PR TITLE
Clipboard manager: OCR search, configurable history and paste behavior

### DIFF
--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -19,6 +19,7 @@ Item {
 
   property string historyPath: Quickshell.env("HOME") + "/.local/state/omarchy/clipboard-history.json"
   property string captureScript: root.omarchyPath + "/shell/plugins/clipboard/capture.sh"
+  property string gcScript: root.omarchyPath + "/shell/plugins/clipboard/gc.sh"
   // Shares the [menu] surface tokens — themes that style the menu also
   // style the clipboard. Selected-row colors composed in the
   // singleton so consumers drop them straight into Rectangle bindings.
@@ -74,6 +75,10 @@ Item {
 
   function saveHistory() {
     historyFile.setText(JSON.stringify(root.history.slice(0, root.historyLimit), null, 2) + "\n")
+    // Deleted, evicted, and cleared image entries would otherwise leave
+    // their captured files on disk forever. Delayed so gc.sh reads the
+    // freshly written history file.
+    gcTimer.restart()
   }
 
   function addClipboardEntry(entry) {
@@ -239,6 +244,13 @@ Item {
   }
 
   Component.onCompleted: initProc.running = true
+
+  Timer {
+    id: gcTimer
+    interval: 1000
+    repeat: false
+    onTriggered: Quickshell.execDetached([root.gcScript])
+  }
 
   ListModel { id: displayModel }
 
@@ -436,6 +448,7 @@ Item {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             text: root.filterText || "Search clipboard…"
+            textFormat: Text.PlainText
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
@@ -503,6 +516,9 @@ Item {
                       width: parent.width - (parent.parent.previewImage.length > 0 ? parent.height + parent.spacing : 0)
                       height: parent.height
                       text: parent.parent.previewText
+                      // Clipboard content is untrusted: AutoText would parse
+                      // copied HTML markup and load remote images from it.
+                      textFormat: Text.PlainText
                       color: parent.parent.hasCursor ? root.selectedText : root.foreground
                       font.family: root.fontFamily
                       font.pixelSize: Style.font.title
@@ -553,6 +569,7 @@ Item {
                 anchors.topMargin: 0
                 anchors.bottomMargin: 0
                 text: parent.activeRow ? parent.activeRow.fullText : ""
+                textFormat: Text.PlainText
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.title
@@ -594,6 +611,7 @@ Item {
 
             Text {
               text: root.history.length === 0 ? "Clipboard is empty" : "No matches for “" + root.filterText + "”"
+              textFormat: Text.PlainText
               color: root.foreground
               opacity: 0.7
               font.family: root.fontFamily

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -10,8 +10,12 @@ Item {
   id: root
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  // Injected by the shell's panel loader (see shell.qml onLoaded).
+  property var shell: null
+  property var manifest: null
   property bool opened: false
   property string filterText: ""
+  property bool imagesOnly: false
   property int selectedIndex: 0
   property bool cursorActive: false
   property bool clearConfirmOpen: false
@@ -38,11 +42,29 @@ Item {
   property int cardWidth: Math.min(Style.space(875), panel.width - Style.gapsOut * 2)
   property int cardHeight: Math.min(Style.space(600), panel.height - Style.gapsOut * 2)
   property int rowHeight: Math.max(Style.space(50), Style.font.body + Style.font.caption + Style.spacing.rowPaddingX * 2)
-  property int historyLimit: 300
+  // Optional settings on this plugin's entry in shell.json, e.g.
+  //   "plugins": [{ "id": "omarchy.clipboard", "historyLimit": 500, "ocr": true }]
+  // Defaults preserve the previous fixed behavior. shell.shellConfig
+  // re-parses when shell.json is saved, so these are live.
+  readonly property var pluginSettings: {
+    var cfg = root.shell ? root.shell.shellConfig : null
+    var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
+    var id = root.manifest && root.manifest.id ? String(root.manifest.id) : "omarchy.clipboard"
+    for (var i = 0; i < list.length; i++)
+      if (list[i] && list[i].id === id) return list[i]
+    return ({})
+  }
+  property int historyLimit: Number(root.pluginSettings.historyLimit) > 0 ? Math.floor(Number(root.pluginSettings.historyLimit)) : 300
+  property int maxRows: Number(root.pluginSettings.maxRows) > 0 ? Math.floor(Number(root.pluginSettings.maxRows)) : 50
+  // false = Enter/click only copies to the clipboard (paste manually);
+  // true keeps the default copy-and-auto-paste. Shift+Enter always does
+  // the other action.
+  property bool autoPaste: root.pluginSettings.autoPaste !== false
 
   function open(payloadJson) {
     root.opened = true
     root.filterText = ""
+    root.imagesOnly = false
     root.selectedIndex = 0
     root.cursorActive = true
     root.disarmPointer()
@@ -136,7 +158,7 @@ Item {
   }
 
   function rebuildDisplay() {
-    var rows = ClipboardHistory.displayRows(root.history, root.filterText, 50)
+    var rows = ClipboardHistory.displayRows(root.history, root.filterText, root.maxRows, root.imagesOnly ? "image" : "")
 
     displayModel.clear()
     for (var i = 0; i < rows.length; i++) {
@@ -189,6 +211,14 @@ Item {
     root.rebuildDisplay()
   }
 
+  function toggleImagesOnly() {
+    root.imagesOnly = !root.imagesOnly
+    root.selectedIndex = 0
+    root.cursorActive = true
+    root.disarmPointer()
+    root.rebuildDisplay()
+  }
+
   function disarmPointer() {
     pointerGate.reset()
   }
@@ -215,6 +245,16 @@ Item {
     if (index < 0 || index >= displayModel.count) return
     var row = displayModel.get(index)
     root.openSelected(row)
+  }
+
+  function primaryIndex(index) {
+    if (root.autoPaste) root.activateIndex(index)
+    else root.copyIndex(index)
+  }
+
+  function secondaryIndex(index) {
+    if (root.autoPaste) root.copyIndex(index)
+    else root.activateIndex(index)
   }
 
   function applySelected(row) {
@@ -370,7 +410,11 @@ Item {
 
           if (event.key === Qt.Key_Escape) {
             if (root.filterText) root.setFilter("")
+            else if (root.imagesOnly) root.toggleImagesOnly()
             else root.close()
+            event.accepted = true
+          } else if (event.key === Qt.Key_I && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleImagesOnly()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
@@ -399,8 +443,8 @@ Item {
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             if (root.cursorActive && (event.modifiers & Qt.AltModifier)) root.openIndex(root.selectedIndex)
-            else if (root.cursorActive && (event.modifiers & Qt.ShiftModifier)) root.copyIndex(root.selectedIndex)
-            else if (root.cursorActive) root.activateIndex(root.selectedIndex)
+            else if (root.cursorActive && (event.modifiers & Qt.ShiftModifier)) root.secondaryIndex(root.selectedIndex)
+            else if (root.cursorActive) root.primaryIndex(root.selectedIndex)
             else if (displayModel.count > 0) root.cursorActive = true
             event.accepted = true
           } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127) {
@@ -447,7 +491,7 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || "Search clipboard…"
+            text: (root.imagesOnly ? "[images] " : "") + (root.filterText || (root.imagesOnly ? "Search image text…" : "Search clipboard…"))
             textFormat: Text.PlainText
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
@@ -539,7 +583,7 @@ Item {
                     onClicked: {
                       root.cursorActive = true
                       root.selectedIndex = row.index
-                      root.activateIndex(row.index)
+                      root.primaryIndex(row.index)
                     }
                   }
                 }
@@ -610,7 +654,9 @@ Item {
             }
 
             Text {
-              text: root.history.length === 0 ? "Clipboard is empty" : "No matches for “" + root.filterText + "”"
+              text: root.history.length === 0 ? "Clipboard is empty"
+                : (root.imagesOnly && !root.filterText ? "No images in history"
+                : "No matches for “" + root.filterText + "”")
               textFormat: Text.PlainText
               color: root.foreground
               opacity: 0.7

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -1,3 +1,8 @@
+// The history file is user-editable, so cap ocrText on load: searchableText
+// scans it on every keystroke and an oversized value would lag the picker.
+// Matches OCR_MAX_CHARS in capture.sh.
+var ocrTextLimit = 4000
+
 function normalizeEntry(value) {
   if (typeof value === "string")
     return value.trim().length > 0 ? { type: "text", text: value } : null
@@ -21,7 +26,7 @@ function normalizeEntry(value) {
     if (value.capturedAt !== undefined && value.capturedAt !== null)
       entry.capturedAt = String(value.capturedAt)
     if (value.ocrText !== undefined && value.ocrText !== null && String(value.ocrText).length > 0)
-      entry.ocrText = String(value.ocrText)
+      entry.ocrText = String(value.ocrText).slice(0, ocrTextLimit)
     return entry
   }
 

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -20,6 +20,8 @@ function normalizeEntry(value) {
     }
     if (value.capturedAt !== undefined && value.capturedAt !== null)
       entry.capturedAt = String(value.capturedAt)
+    if (value.ocrText !== undefined && value.ocrText !== null && String(value.ocrText).length > 0)
+      entry.ocrText = String(value.ocrText)
     return entry
   }
 
@@ -91,7 +93,7 @@ function parseEntryJson(line) {
 
 function searchableText(entry) {
   if (!entry) return ""
-  if (entry.type === "image") return "image screenshot " + String(entry.mime || "") + " " + String(entry.capturedAt || "")
+  if (entry.type === "image") return "image screenshot " + String(entry.mime || "") + " " + String(entry.capturedAt || "") + " " + String(entry.ocrText || "")
   return String(entry.text || "") + " " + fileEntryText(entry)
 }
 
@@ -171,9 +173,10 @@ function cappedEntry(entry) {
   return { type: "text", text: entry.text.slice(0, cut > 0 ? cut : displayTextLimit) }
 }
 
-function displayRows(history, query, limit) {
+function displayRows(history, query, limit, typeFilter) {
   var values = Array.isArray(history) ? history : []
   var needle = String(query || "").trim().toLowerCase()
+  var wantType = String(typeFilter || "")
   var max = limit === undefined || limit === null ? 50 : Number(limit)
   if (isNaN(max)) max = 50
   max = Math.max(0, max)
@@ -184,6 +187,7 @@ function displayRows(history, query, limit) {
   for (var i = 0; i < values.length; i++) {
     var entry = cappedEntry(normalizeEntry(values[i]))
     if (!entry) continue
+    if (wantType && entry.type !== wantType) continue
     if (needle && searchableText(entry).toLowerCase().indexOf(needle) < 0) continue
 
     var paths = filePaths(entry)

--- a/shell/plugins/clipboard/capture.sh
+++ b/shell/plugins/clipboard/capture.sh
@@ -16,9 +16,34 @@ if [[ ${CLIPBOARD_STATE:-} == "sensitive" ]] || grep -qx 'x-kde-passwordManagerH
   exit 0
 fi
 
+# OCR capped so one text-dense screenshot can't bloat the history JSON.
+OCR_MAX_CHARS=4000
+SHELL_JSON="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/shell.json"
+
+# Settings on the plugin's entry in shell.json plugins[]:
+#   "ocr": true           enables OCR of captured images (default off)
+#   "ocrLang": "eng+deu"  tesseract language(s), default eng
+plugin_setting() {
+  [[ -f $SHELL_JSON ]] || { printf '%s' "$2"; return; }
+  jq -r --arg key "$1" --arg default "$2" \
+    '(.plugins // []) | map(select(.id == "omarchy.clipboard")) | first | .[$key] // $default' \
+    "$SHELL_JSON" 2>/dev/null || printf '%s' "$2"
+}
+
+ocr_image() {
+  local file="$1" text="" lang
+  [[ $(plugin_setting ocr false) == "true" ]] || return 0
+  command -v tesseract >/dev/null 2>&1 || return 0
+  lang=$(plugin_setting ocrLang eng)
+  text=$(timeout 15s tesseract -l "$lang" "$file" - 2>/dev/null | tr -s '[:space:]' ' ') || true
+  text="${text# }"
+  text="${text% }"
+  printf '%s' "${text:0:OCR_MAX_CHARS}"
+}
+
 emit_image() {
   local mime="$1"
-  local ext tmp hash file
+  local ext tmp hash file ocr
 
   ext=${mime#image/}
   [[ $ext == jpeg ]] && ext=jpg
@@ -38,8 +63,11 @@ emit_image() {
     mv "$tmp" "$file"
   fi
 
-  jq -cn --arg mime "$mime" --arg path "$file" --arg captured_at "$(date +'%A %H:%M')" \
-    '{type:"image", mime:$mime, path:$path, capturedAt:$captured_at}'
+  ocr=$(ocr_image "$file")
+
+  jq -cn --arg mime "$mime" --arg path "$file" --arg captured_at "$(date +'%A %H:%M')" --arg ocr "$ocr" \
+    '{type:"image", mime:$mime, path:$path, capturedAt:$captured_at}
+     + (if ($ocr | length) > 0 then {ocrText:$ocr} else {} end)'
 }
 
 emit_text() {

--- a/shell/plugins/clipboard/gc.sh
+++ b/shell/plugins/clipboard/gc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Deletes captured clipboard images that no history entry references anymore
+# (deleted, evicted, or cleared entries would otherwise leave their files on
+# disk forever). Invoked by the plugin after every history save.
+
+set -o pipefail
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+IMAGE_DIR="$STATE_DIR/clipboard-images"
+HISTORY="$STATE_DIR/clipboard-history.json"
+
+[[ -d $IMAGE_DIR ]] || exit 0
+
+referenced=""
+if [[ -f $HISTORY ]]; then
+  referenced=$(jq -r '.[]? | select(.type == "image") | .path // empty' "$HISTORY" 2>/dev/null || true)
+fi
+
+# Only touch files older than 10 minutes: capture.sh writes the image before
+# its history entry lands (OCR runs in between), so a fresh file can be
+# unreferenced while its entry is still in flight.
+while IFS= read -r -d '' file; do
+  grep -qxF -- "$file" <<<"$referenced" && continue
+  rm -f -- "$file"
+done < <(find "$IMAGE_DIR" -maxdepth 1 -type f -mmin +10 -print0)

--- a/shell/plugins/clipboard/gc.sh
+++ b/shell/plugins/clipboard/gc.sh
@@ -12,15 +12,17 @@ HISTORY="$STATE_DIR/clipboard-history.json"
 
 [[ -d $IMAGE_DIR ]] || exit 0
 
-referenced=""
+declare -A referenced=()
 if [[ -f $HISTORY ]]; then
-  referenced=$(jq -r '.[]? | select(.type == "image") | .path // empty' "$HISTORY" 2>/dev/null || true)
+  while IFS= read -r path; do
+    [[ -n $path ]] && referenced["$path"]=1
+  done < <(jq -r '.[]? | select(.type == "image") | .path // empty' "$HISTORY" 2>/dev/null || true)
 fi
 
 # Only touch files older than 10 minutes: capture.sh writes the image before
 # its history entry lands (OCR runs in between), so a fresh file can be
 # unreferenced while its entry is still in flight.
 while IFS= read -r -d '' file; do
-  grep -qxF -- "$file" <<<"$referenced" && continue
+  [[ ${referenced["$file"]+x} ]] && continue
   rm -f -- "$file"
 done < <(find "$IMAGE_DIR" -maxdepth 1 -type f -mmin +10 -print0)


### PR DESCRIPTION
This improves the Clipboard manager by adding OCR, a configurable history item, and security hardening. It's basically my initial plugin https://github.com/sspaeti/omarchy-clipboard-plugin pushed upstream with the same configuration as of now with Omarchy, while direct pasting and OCR can be toggled:

```
{
  "id": "omarchy.clipboard",
  "historyLimit": 500,
  "maxRows": 50,
  "ocr": true,
  "ocrLang": "eng+deu",
  "autoPaste": false
}
```

- `historyLimit` (default 300) and `maxRows` (default 50) — current fixed values become configurable.
- `ocr` (default off) — runs tesseract on captured images and stores the text on the entry, so the picker's search finds text *inside* screenshots. tesseract is an optional dependency: not installed → OCR silently skipped, nothing else needed. `Ctrl+I` in the picker toggles an images-only view.
- `autoPaste` (default true, current behavior) — set to `false` and Enter/click only copies to the clipboard, so you paste manually and never paste into the wrong window by accident (Shift+Enter still auto-pastes). Personally I run with `false`, but the PR doesn't change the default.

If this OCR is not wanted to add for clipboard, we can also just have it as plugin here: https://github.com/HANCORE-linux/omarchy-plugin-marketplace/issues/679.

The first commit (44b24af5) is a standalone security hardening fix (see https://github.com/HANCORE-linux/omarchy-plugin-marketplace/issues/679#issuecomment-5336028249) (plain-text rendering of clipboard content + cleanup of orphaned image files) and is also available as its own branch, clipboard-security-fixes, if you'd prefer to take it separately. If you'd like only the security fix, this would be a dedicated branch: https://github.com/sspaeti/omarchy/commits/clipboard-security-fixes/