### PR TITLE
Read Fireworks credentials from pi's auth.json

### DIFF
--- a/bin/omarchy-agent-usage-fireworks
+++ b/bin/omarchy-agent-usage-fireworks
@@ -29,7 +29,7 @@ from typing import Any
 
 AGENT_ID = "fireworks"
 AGENT_NAME = "Fireworks"
-AUTH_HELP = "Set FIREWORKS_API_KEY, run `firectl set-api-key`, or sign in to Fireworks in opencode."
+AUTH_HELP = "Set FIREWORKS_API_KEY, run `firectl set-api-key`, or sign in to Fireworks in pi or opencode."
 API_BASE_URL = "https://api.fireworks.ai"
 
 
@@ -196,9 +196,55 @@ def read_auth_file(path: Path) -> tuple[str, str]:
   return api_key, account_id
 
 
+def pi_auth_path() -> Path:
+  agent_dir = Path(os.environ.get("PI_CODING_AGENT_DIR") or (Path.home() / ".pi" / "agent"))
+  return agent_dir / "auth.json"
+
+
 def opencode_auth_path() -> Path:
   data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
   return data_home / "opencode" / "auth.json"
+
+
+PI_ENV_REFERENCE = re.compile(r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))")
+
+
+def resolve_pi_key(raw: Any) -> str:
+  # pi credential keys are literals, $ENV_VAR/${ENV_VAR} references, or
+  # !command shell lookups. The collector resolves the first two; command
+  # lookups stay pi-only and are skipped rather than sent to the API verbatim.
+  key = str(raw or "").strip()
+  if not key or key.startswith("!"):
+    return ""
+  # Escapes survive interpolation as sentinels, then restore.
+  key = key.replace("$$", "\x00").replace("$!", "\x01")
+
+  unresolved = False
+
+  def substitute(match: re.Match[str]) -> str:
+    nonlocal unresolved
+    value = os.environ.get(match.group(1) or match.group(2), "")
+    if not value:
+      unresolved = True
+    return value
+
+  key = PI_ENV_REFERENCE.sub(substitute, key)
+  if unresolved:
+    return ""
+  return key.replace("\x00", "$").replace("\x01", "!")
+
+
+def read_pi_key(path: Path) -> str:
+  try:
+    parsed = json.loads(path.read_text())
+  except (OSError, json.JSONDecodeError):
+    return ""
+  entry = parsed.get("fireworks") if isinstance(parsed, dict) else None
+  if not isinstance(entry, dict):
+    return ""
+  if entry.get("type") not in (None, "api_key"):
+    return ""
+  return resolve_pi_key(entry.get("key"))
 
 
 def read_opencode_key(path: Path) -> str:
@@ -227,11 +273,12 @@ def read_config() -> dict[str, Any]:
 
 def credentials(auth_path: Path, config: dict[str, Any]) -> tuple[str, str]:
   file_key, file_account = read_auth_file(auth_path)
-  # opencode is the last resort: an explicit key or a firectl login should
-  # win over whatever another tool happens to be signed in with.
+  # Agent logins are the fallback ladder below an explicit key or a firectl
+  # login: pi first as Omarchy's default agent, opencode as the last resort.
   api_key = (
     str(os.environ.get("FIREWORKS_API_KEY", "")).strip()
     or file_key
+    or read_pi_key(pi_auth_path())
     or read_opencode_key(opencode_auth_path())
   )
   account_id = (

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -61,8 +61,9 @@ falls back to local stats only. A non-default Claude directory is honored via
 `CLAUDE_CONFIG_DIR`, Codex via `CODEX_HOME`. Fireworks reads
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
-opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
-signed in there.
+pi stores in `~/.pi/agent/auth.json` when Fireworks is signed in there
+(honoring `PI_CODING_AGENT_DIR`, and pi's literal and `$ENV_VAR` key forms),
+and finally the key opencode stores in `~/.local/share/opencode/auth.json`.
 
 ### Fireworks balance
 

--- a/test/shell.d/agent-usage-fireworks-scanner-test.sh
+++ b/test/shell.d/agent-usage-fireworks-scanner-test.sh
@@ -27,13 +27,13 @@ EOF
 # Without credentials the collector must still print a full, hidden-by-default
 # record: the update runner writes whatever valid JSON appears on stdout.
 no_key=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_DATA_HOME="$TEST_HOME/.local/share" \
-  FIREWORKS_API_KEY="" FIREWORKS_AUTH_PATH="$TEST_HOME/missing.ini" "$ROOT/bin/omarchy-agent-usage-fireworks")
+  PI_CODING_AGENT_DIR="$TEST_HOME/.pi/agent" FIREWORKS_API_KEY="" FIREWORKS_AUTH_PATH="$TEST_HOME/missing.ini" "$ROOT/bin/omarchy-agent-usage-fireworks")
 
 [[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasPromptStats | tostring)' <<<"$no_key") == "fireworks:false:false" ]] ||
   fail "Fireworks collector prints a valid record without credentials" "$no_key"
 pass "Fireworks collector prints a valid record without credentials"
 
-result=$(python3 - "$ROOT/bin/omarchy-agent-usage-fireworks" "$auth_file" "$TEST_HOME/.config" "$TEST_HOME/.local/share" <<'PY'
+result=$(python3 - "$ROOT/bin/omarchy-agent-usage-fireworks" "$auth_file" "$TEST_HOME/.config" "$TEST_HOME/.local/share" "$TEST_HOME/.pi/agent" <<'PY'
 import importlib.machinery
 import importlib.util
 import json
@@ -95,7 +95,11 @@ summary["apiKey"] = api_key
 summary["accountId"] = account_id
 summary["money"] = float(scanner.money_value({"units": "12", "nanos": 430000000}))
 
-# The opencode key only wins when no explicit key or firectl login exists.
+# The opencode key only wins when no explicit key, firectl login, or pi
+# login exists. Pin the pi dir first so a developer's real ~/.pi/agent
+# credentials cannot leak into the fixture run.
+pi_dir = Path(sys.argv[5])
+os.environ["PI_CODING_AGENT_DIR"] = str(pi_dir)
 data_home = Path(os.environ["XDG_DATA_HOME"])
 opencode_auth = data_home / "opencode" / "auth.json"
 opencode_auth.parent.mkdir(parents=True, exist_ok=True)
@@ -104,6 +108,22 @@ os.environ.pop("FIREWORKS_API_KEY", None)
 opencode_key, _ = scanner.credentials(Path("/nonexistent/auth.ini"), {})
 firectl_key, _ = scanner.credentials(auth_path, {})
 summary["opencodeFallback"] = opencode_key == "fw_opencode" and firectl_key == "fw_test"
+
+# A pi login is the next rung below firectl, above opencode.
+pi_dir.mkdir(parents=True, exist_ok=True)
+(pi_dir / "auth.json").write_text(json.dumps({"fireworks": {"type": "api_key", "key": "fw_pi"}}))
+pi_key, _ = scanner.credentials(Path("/nonexistent/auth.ini"), {})
+firectl_still_wins, _ = scanner.credentials(auth_path, {})
+summary["piFallback"] = pi_key == "fw_pi" and firectl_still_wins == "fw_test"
+
+# pi key syntax: $ENV references resolve, missing ones stay unresolved, and
+# !command lookups are skipped and fall through to opencode.
+os.environ["FW_TEST_ENV_KEY"] = "fw_from_env"
+summary["piEnvKey"] = scanner.resolve_pi_key("$FW_TEST_ENV_KEY") == "fw_from_env"
+summary["piMissingEnvKey"] = scanner.resolve_pi_key("$FW_DEFINITELY_MISSING") == ""
+(pi_dir / "auth.json").write_text(json.dumps({"fireworks": {"type": "api_key", "key": "!secret-tool lookup fw"}}))
+command_key, _ = scanner.credentials(Path("/nonexistent/auth.ini"), {})
+summary["piCommandKeySkipped"] = command_key == "fw_opencode"
 
 class WorkingClient:
   def __init__(self, api_key, base_url):
@@ -242,3 +262,19 @@ pass "Fireworks collector dates buckets by local day east of Greenwich"
 [[ $(jq -r '.opencodeFallback' <<<"$result") == "true" ]] ||
   fail "Fireworks collector falls back to the opencode key last" "$result"
 pass "Fireworks collector falls back to the opencode key last"
+
+[[ $(jq -r '.piFallback' <<<"$result") == "true" ]] ||
+  fail "Fireworks collector falls back to the pi login before opencode" "$result"
+pass "Fireworks collector falls back to the pi login before opencode"
+
+[[ $(jq -r '.piEnvKey' <<<"$result") == "true" ]] ||
+  fail "Fireworks collector resolves env-var pi keys" "$result"
+pass "Fireworks collector resolves env-var pi keys"
+
+[[ $(jq -r '.piMissingEnvKey' <<<"$result") == "true" ]] ||
+  fail "Fireworks collector treats missing env references as unresolved" "$result"
+pass "Fireworks collector treats missing env references as unresolved"
+
+[[ $(jq -r '.piCommandKeySkipped' <<<"$result") == "true" ]] ||
+  fail "Fireworks collector skips command-lookup pi keys and falls through" "$result"
+pass "Fireworks collector skips command-lookup pi keys and falls through"


### PR DESCRIPTION
## Problem

The Fireworks collector in `omarchy.agents` never sees a Fireworks login made through pi — Omarchy's default agent. A machine signed in only via `/login fireworks` in pi gets a permanently hidden Fireworks tab, even though the same machine's Claude and Codex collectors already treat pi as a first-class session source.

## Change

Insert pi's credential store into the collector's fallback ladder, between the `firectl` `auth.ini` and the opencode fallback:

1. `FIREWORKS_API_KEY` / `FIREWORKS_ACCOUNT_ID` (unchanged)
2. `~/.fireworks/auth.ini` from `firectl set-api-key` (unchanged)
3. **`fireworks.key` in `$PI_CODING_AGENT_DIR/auth.json`** (default `~/.pi/agent/auth.json`) — new
4. opencode's `~/.local/share/opencode/auth.json` (unchanged, still last)

pi's documented key forms are honored: literals and `$ENV_VAR`/`${ENV_VAR}` references resolve (a missing variable leaves the key unresolved and falls through), while `!command` shell lookups stay pi-only and are skipped rather than sent to the Fireworks API verbatim. `PI_CODING_AGENT_DIR` is respected for non-default pi setups.

The auth help text and plugin README now mention pi alongside the other sources.

## Tests

Four new assertions in `test/shell.d/agent-usage-fireworks-scanner-test.sh`:

- pi login wins over opencode but loses to firectl
- `$ENV_VAR` keys resolve; missing env vars stay unresolved
- `!command` keys are skipped and fall through to opencode

The pi dir is pinned via `PI_CODING_AGENT_DIR` in both the shell-level and inline-python fixtures, mirroring the existing `XDG_DATA_HOME` pinning that keeps real developer credentials out of fixture runs.

`bash test/shell.d/agent-usage-fireworks-scanner-test.sh` — all 19 pass. `./test/all` — the only failures are 4 pre-existing/environmental ones that also fail on a clean checkout (`omarchy-pkgs` sibling checkout missing; bar icon geometry on this machine).