### PR TITLE
Fix Zen policy installation

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -30,6 +30,23 @@ setup_firefox_preferences() {
   sudo cp -f "$OMARCHY_PATH/default/firefox/policies.json" "$distribution_dir/policies.json"
 }
 
+setup_zen_preferences() (
+  local distribution_dir="${1:-/opt/zen-browser-bin/distribution}"
+  local zen_policies="$distribution_dir/policies.json"
+  local merged_policies
+
+  if [[ ! -f $zen_policies ]]; then
+    setup_firefox_preferences "$distribution_dir"
+    return
+  fi
+
+  merged_policies=$(mktemp)
+  trap 'rm -f "$merged_policies"' EXIT
+
+  jq -s '.[0] * .[1]' "$OMARCHY_PATH/default/firefox/policies.json" "$zen_policies" >"$merged_policies"
+  sudo install -m644 "$merged_policies" "$zen_policies"
+)
+
 setup_firefox_wayland() {
   mkdir -p ~/.config/environment.d
   echo "MOZ_ENABLE_WAYLAND=1" > ~/.config/environment.d/omarchy-firefox-wayland.conf
@@ -93,7 +110,7 @@ zen)
   echo "Installing Zen..."
   omarchy-pkg-aur-add zen-browser-bin || exit 1
 
-  setup_firefox_preferences /opt/zen-browser/distribution
+  setup_zen_preferences
   setup_firefox_wayland
   announce_browser_installed "Zen"
   ;;

--- a/test/shell.d/install-browser-test.sh
+++ b/test/shell.d/install-browser-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command jq
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+distribution_dir="$test_dir/distribution"
+mkdir -p "$distribution_dir"
+
+sudo() {
+  "$@"
+}
+
+# Load the real helper without running the installer.
+source <(sed '/^case \$1 in/,$d' "$ROOT/bin/omarchy-install-browser")
+
+cat >"$distribution_dir/policies.json" <<'JSON'
+{
+  "policies": {
+    "DisableAppUpdate": true,
+    "Preferences": {
+      "existing.preference": {
+        "Value": true
+      },
+      "media.ffmpeg.vaapi.enabled": {
+        "Value": false
+      }
+    }
+  }
+}
+JSON
+
+OMARCHY_PATH="$ROOT" setup_zen_preferences "$distribution_dir"
+
+jq -e '
+  .policies.DisableAppUpdate == true and
+  .policies.Preferences["existing.preference"].Value == true and
+  .policies.Preferences["media.ffmpeg.vaapi.enabled"].Value == false and
+  .policies.Preferences["media.hardware-video-decoding.force-enabled"].Value == true
+' "$distribution_dir/policies.json" >/dev/null || fail "Zen setup preserves existing policies and adds Omarchy policies"
+
+grep -Fq '/opt/zen-browser-bin/distribution' "$ROOT/bin/omarchy-install-browser" ||
+  fail "Zen policies use the browser installation directory"
+grep -Fqx '  setup_zen_preferences' "$ROOT/bin/omarchy-install-browser" ||
+  fail "Zen install sets up browser policies"
+
+pass "Zen setup merges policies in the browser installation directory"


### PR DESCRIPTION
Zen installs under `/opt/zen-browser-bin`, but Omarchy wrote its policies to `/opt/zen-browser`, where Zen never reads them. This uses Zen's actual distribution directory and merges Omarchy's defaults with the policies from `zen-browser-bin` while preserving package-owned values.

Verified with `zen-browser-bin 1.21.14b-1`: the packaged policies and Omarchy preferences were active in `about:policies`. Merge precedence is covered by the shell test, and all 181 test files pass.

This is intentionally limited to installation; a later package upgrade may replace the merged policy file.

Addresses #7411
