### PR TITLE
Let the Lua assertions in shell tests fail

### DIFF
--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -189,7 +189,7 @@ grep -F 'package.path = home' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
 grep -F '/.local/state/?.lua;' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
 pass "Hyprland user entrypoint keeps package and state path bootstrap in defaults"
 
-OMARCHY_PATH="$ROOT" lua <<'LUA'
+OMARCHY_PATH="$ROOT" lua - <<'LUA' || fail "Hyprland bootstrap reloads cached Omarchy config modules"
 package.loaded["default.hypr.omarchy"] = true
 package.loaded["default.hypr.require_optional"] = true
 package.loaded["hypr.looknfeel"] = true

--- a/test/shell.d/hyprland-binding-conflicts-test.sh
+++ b/test/shell.d/hyprland-binding-conflicts-test.sh
@@ -12,7 +12,7 @@ list_bindings() {
   local home="$1"
   local epilogue="${2:-}"
 
-  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_EPILOGUE="$epilogue" lua <<'LUA'
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_EPILOGUE="$epilogue" lua - <<'LUA'
 package.path = os.getenv("HOME") .. "/.config/?.lua;" .. os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local function proxy()

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -8,7 +8,7 @@ run_application_bindings() {
   local home="$1"
   local prelude="${2:-}"
 
-  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua <<'LUA'
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua - <<'LUA'
 package.path = os.getenv("HOME") .. "/.config/?.lua;" .. os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local prelude = os.getenv("OMARCHY_BINDING_PRELUDE") or ""
@@ -39,7 +39,7 @@ run_omarchy_bindings() {
   local home="$1"
   local prelude="${2:-}"
 
-  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua <<'LUA'
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua - <<'LUA'
 package.path = os.getenv("HOME") .. "/.config/?.lua;" .. os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local function proxy()

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 require_command lua
 
 resolved_input() {
-  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua - <<'LUA'
 package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local vconsole = os.getenv("OMARCHY_VCONSOLE")

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -50,7 +50,7 @@ fi
   fail "workspace layout toggle does not persist a rule without a workspace id"
 pass "workspace layout toggle ignores broken hyprctl output"
 
-HOME="$home_dir" OMARCHY_PATH="$ROOT" lua <<'LUA'
+HOME="$home_dir" OMARCHY_PATH="$ROOT" lua - <<'LUA' || fail "saved workspace layouts load into Hyprland configuration"
 local rules = {}
 
 hl = {

--- a/test/shell.d/shell-test-style-test.sh
+++ b/test/shell.d/shell-test-style-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Handing a heredoc to lua with no script argument runs it as a REPL: an error
+# is printed and the interpreter still exits 0, so assertions written inside one
+# cannot fail their test. Passing an explicit - reads the same heredoc as a
+# script, where an error is an error.
+repl_lua=$(rg -l -P 'lua[[:space:]]+<<' "$SHELL_TEST_DIR" || true)
+[[ -z $repl_lua ]] || fail "shell tests read Lua as a script rather than a REPL" "$repl_lua"
+pass "shell tests read Lua as a script rather than a REPL"


### PR DESCRIPTION
Handing a heredoc to `lua` with no script argument runs it as a **REPL**. An error prints a traceback and the interpreter still exits **0**:

```
$ lua <<'L'
assert(false, "boom")
L
lua: stdin:1: boom
$ echo $?
0
```

So assertions written that way cannot fail their test. Eight of them were in that position:

| File | Assertions | What they check |
|---|---|---|
| `config-test.sh` | 5 | the Hyprland bootstrap clears cached Omarchy modules |
| `hyprland-workspace-layout-test.sh` | 3 | saved workspace layouts load into Hyprland config |

**All eight pass on their own merits** — I checked before changing anything, so this is not a bug fix, it is coverage that was never armed.

## The fix

`lua -` reads the same heredoc as a script and exits nonzero on error.

That alone is not enough. `base-test.sh` does not `set -e`, so a nonzero exit would still leave the `pass` on the following line to run. Where the Lua assertions are the only assertions, the block now checks its own exit status:

```bash
OMARCHY_PATH="$ROOT" lua - <<'LUA' || fail "Hyprland bootstrap reloads cached Omarchy config modules"
```

The other four call sites hand their output back for the shell to grep, so their failures already bit — a Lua error there surfaces as a failing grep with the traceback on stderr. Switched them to `lua -` anyway, so the next assertion written inside one is not born dead.

## Guarding it

Nothing about the working form advertises why the `-` matters, and the broken form looks completely ordinary. Added a style test in the shape of `bin-style-test.sh`:

```bash
repl_lua=$(rg -l -P 'lua[[:space:]]+<<' "$SHELL_TEST_DIR" || true)
[[ -z $repl_lua ]] || fail "shell tests read Lua as a script rather than a REPL" "$repl_lua"
```

The pattern does not match itself, so the guard needs no exemption for its own source.

## Verification

- `./test/shell` — **182 files, 2251 assertions, all pass**
- the guard was checked against a deliberately reintroduced bare heredoc, and fails on it
- each of the five touched files was run individually after the change

Found while writing tests for #7420, where a new test passed against code I had deliberately broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
