### PR TITLE
Fix Obsidian focus pattern for its current app id

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -15,7 +15,7 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "lazydocker" })
   o.bind("SUPER + SHIFT + G", "Signal", { omarchy = "signal" })
-  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^obsidian$" })
+  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^md\\.obsidian\\.Obsidian$" })
   o.bind("SUPER + SHIFT + W", "Omawrite", { launch = "omawrite" })
   o.bind("SUPER + SHIFT + SLASH", "Passwords", { omarchy = "1password" })
 


### PR DESCRIPTION
Fixes #7464.

Obsidian changed its Wayland app_id from `obsidian` to `md.obsidian.Obsidian`, so the pattern anchored in #1838 can no longer match and the binding never focuses a running window. It launches Obsidian when closed and does nothing when Obsidian is already open.

This anchors on the current app id, keeping the anti-hijack property #1838 added.

Tested on Omarchy 4.0.0-1 with obsidian 1.13.7-1. With Obsidian open on another workspace the binding switches to it and focuses it without spawning a second process. With Obsidian closed it still launches normally.

`./test/all` passes apart from four failures that also occur on an unmodified `quattro`: three need an `omarchy-pkgs` checkout, one is the graphical `bar-icon-geometry` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
