### PR TITLE
Prime the Settings portal before changing color scheme

### DIFF
--- a/bin/omarchy-theme-set-gnome
+++ b/bin/omarchy-theme-set-gnome
@@ -17,6 +17,14 @@ COLORS_FILE="$THEME_DIR/colors.toml"
 # legacy light.mode marker beside it, or background luminance for user themes.
 mode=$(omarchy-theme-color --file "$COLORS_FILE" mode)
 
+# Prime the selected Settings portal before changing color-scheme so it can
+# forward the resulting signal to already-running clients.
+gdbus call --session --timeout 2 \
+  --dest org.freedesktop.portal.Desktop \
+  --object-path /org/freedesktop/portal/desktop \
+  --method org.freedesktop.portal.Settings.ReadOne \
+  org.freedesktop.appearance color-scheme >/dev/null 2>&1 || true
+
 if [[ $mode == "light" ]]; then
   gsettings set org.gnome.desktop.interface color-scheme "prefer-light"
   gsettings set org.gnome.desktop.interface gtk-theme "Adwaita"

--- a/test/cli
+++ b/test/cli
@@ -645,15 +645,29 @@ TMUX_LOG="$PI_TMPDIR/tmux.log" PATH="$FAKE_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR
 grep -q 'set-environment -g COLORFGBG 0;15' "$PI_TMPDIR/tmux.log" || fail "tmux sync reads mode from colors.toml"
 pass "tmux sync reads mode from colors.toml"
 
+cat >"$FAKE_BIN/gdbus" <<'EOF'
+#!/bin/bash
+echo "gdbus $*" >>"${GNOME_SYNC_LOG:-/dev/null}"
+exit "${GDBUS_EXIT_CODE:-0}"
+EOF
+chmod +x "$FAKE_BIN/gdbus"
+
 cat >"$FAKE_BIN/gsettings" <<'EOF'
 #!/bin/bash
-echo "$*" >>"${GSETTINGS_LOG:-/dev/null}"
+echo "gsettings $*" >>"${GNOME_SYNC_LOG:-/dev/null}"
 EOF
 chmod +x "$FAKE_BIN/gsettings"
 
-GSETTINGS_LOG="$PI_TMPDIR/gsettings.log" DBUS_SESSION_BUS_ADDRESS="unix:path=$PI_TMPDIR/bus" PATH="$FAKE_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-gnome"
-grep -q 'org.gnome.desktop.interface color-scheme prefer-light' "$PI_TMPDIR/gsettings.log" || fail "gnome sync reads mode from colors.toml"
+GNOME_SYNC_LOG="$PI_TMPDIR/gnome-sync.log" DBUS_SESSION_BUS_ADDRESS="unix:path=$PI_TMPDIR/bus" PATH="$FAKE_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-gnome"
+[[ $(sed -n '1p' "$PI_TMPDIR/gnome-sync.log") == "gdbus call --session --timeout 2 --dest org.freedesktop.portal.Desktop --object-path /org/freedesktop/portal/desktop --method org.freedesktop.portal.Settings.ReadOne org.freedesktop.appearance color-scheme" ]] || fail "gnome sync primes the Settings portal before changing color scheme"
+pass "gnome sync primes the Settings portal before changing color scheme"
+grep -q 'gsettings set org.gnome.desktop.interface color-scheme prefer-light' "$PI_TMPDIR/gnome-sync.log" || fail "gnome sync reads mode from colors.toml"
 pass "gnome sync reads mode from colors.toml"
+
+: >"$PI_TMPDIR/gnome-sync.log"
+GNOME_SYNC_LOG="$PI_TMPDIR/gnome-sync.log" GDBUS_EXIT_CODE=1 DBUS_SESSION_BUS_ADDRESS="unix:path=$PI_TMPDIR/bus" PATH="$FAKE_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-gnome"
+grep -q 'gsettings set org.gnome.desktop.interface color-scheme prefer-light' "$PI_TMPDIR/gnome-sync.log" || fail "gnome sync continues when the Settings portal is unavailable"
+pass "gnome sync tolerates an unavailable Settings portal"
 
 cat >"$FAKE_BIN/omarchy-cmd-present" <<'EOF'
 #!/bin/bash


### PR DESCRIPTION
## Summary

- prime the selected desktop Settings portal before writing GNOME's color scheme
- keep theme changes fail-open when the portal is unavailable
- cover call ordering and failure behavior in the CLI suite

## Root cause

Chromium reads `org.freedesktop.appearance/color-scheme` through the desktop portal, caches it, and then relies on `SettingChanged`. The GTK Settings backend observes the GNOME GSettings key and forwards changes through the portal frontend.

If the selected Settings backend is absent while Omarchy writes `gsettings`, that transition is missed. Starting the backend afterward exposes the new value to fresh reads, but does not replay the missed signal to already-running clients. Those clients can therefore retain the previous appearance until restarted.

This does not claim that Omarchy stopped the backend; it hardens the theme transition against that failure/restart window.

Relevant implementations:

- [Chromium's Linux dark-mode manager](https://chromium.googlesource.com/chromium/src/+/refs/tags/151.0.7922.137/chrome/browser/ui/views/dark_mode_manager_linux.cc#81)
- [xdg-desktop-portal-gtk Settings backend](https://github.com/flatpak/xdg-desktop-portal-gtk/blob/main/src/settings.c#L266-L286)
- [xdg-desktop-portal Settings frontend](https://github.com/flatpak/xdg-desktop-portal/blob/main/desktop-portal/settings.c#L222-L231)

## Fix

Call `Settings.ReadOne` through `org.freedesktop.portal.Desktop` immediately before the GSettings mutation. This respects configured portal routing, activates the selected backend when needed, and primes its color-scheme observer before the transition.

The D-Bus call has a two-second timeout and is deliberately nonfatal, so theme application continues even when no usable portal is available.

This prevents missed changed-value transitions. It intentionally does not force a same-value resync, which would require publishing a false opposite transition and could produce visible flicker.

## Live A/B verification

Tested on Omarchy 4.0.0-1 / Hyprland 0.56.2 using the same running Chrome process and the same loaded document with `matchMedia` listeners:

| Sequence | Backend before write | Public portal signal | Existing page |
| --- | --- | --- | --- |
| Control: active backend, set dark | active | `uint32 1` | changed to dark |
| Unpatched: stop backend, set light | inactive | none | remained dark |
| Patched: stop backend, `ReadOne`, set light | inactive → active | `uint32 2` | changed to light without reload or restart |

In the patched sequence, `ReadOne` returned the prior dark value (`uint32 1`) and activated the backend before the light write. The public portal then emitted `uint32 2`, and the already-running page updated immediately.

Final device state was restored to `prefer-light`, portal value `uint32 2`, with the GTK portal backend active.

## Tests

- `./test/all` — all 181 test files passed
- `bash -n bin/omarchy-theme-set-gnome test/cli`
- `git diff --check`
- independent xhigh review — no blockers; exact call, ordering, timeout, fail-open behavior, and test scope verified
