### PR TITLE
Wake the blanked lock screen from the keyboard

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -72,15 +72,23 @@ Item {
   onInputEnabledChanged: {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
   }
-  // DPMS takes this surface's keyboard focus with it, and lighting the panel
-  // back up does not hand it back. Re-take it as the display returns, or the
-  // field stays deaf to everything but the click that focused it.
-  onDisplayBlankedChanged: {
-    if (!displayBlanked && inputEnabled) Qt.callLater(forcePasswordFocus)
-  }
   Component.onCompleted: {
     syncPasswordText()
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
+  }
+
+  // DPMS takes this surface's keyboard focus with it, and lighting the panel
+  // back up does not hand it back, so the field stays deaf to everything but
+  // the click that focused it. The blanked flag clears when the wake is
+  // dispatched rather than when the compositor has handed focus back, so a
+  // single call lands too early on hardware slow to return it -- ask until it
+  // takes. Idle while blanked: there is no focus to win with the output down,
+  // and a lock can sit blanked all night.
+  Timer {
+    interval: 100
+    repeat: true
+    running: root.inputEnabled && !root.authenticatingPassword && !root.displayBlanked && !passwordInput.activeFocus
+    onTriggered: root.forcePasswordFocus()
   }
 
   // Measures the masked password at full size; passwordDotScale compares this

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -14,6 +14,7 @@ Item {
   property int failedAttempts: 0
   property bool inputEnabled: true
   property bool loadBackground: true
+  property bool displayBlanked: false
   property string passwordText: ""
   property bool syncingPasswordText: false
 
@@ -70,6 +71,12 @@ Item {
   onPasswordTextChanged: syncPasswordText()
   onInputEnabledChanged: {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
+  }
+  // DPMS takes this surface's keyboard focus with it, and lighting the panel
+  // back up does not hand it back. Re-take it as the display returns, or the
+  // field stays deaf to everything but the click that focused it.
+  onDisplayBlankedChanged: {
+    if (!displayBlanked && inputEnabled) Qt.callLater(forcePasswordFocus)
   }
   Component.onCompleted: {
     syncPasswordText()

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -363,11 +363,15 @@ Item {
   // by pointer alone — the field cannot hear the key that would light the panel
   // it needs to be lit to hear. The compositor still reports input as activity no
   // matter who holds focus, so watch that instead and let any key wake the screen.
+  // Armed for the whole lock rather than only while blanked: the notification
+  // starts active and reports idle a second later, and typing restarts that
+  // second, so one armed at blank time never primes under a user who wakes the
+  // screen by typing their password straight in.
   IdleMonitor {
-    enabled: root.lockRequested && root.displayBlanked
+    enabled: root.lockRequested
     timeout: 1
     respectInhibitors: false
-    onIsIdleChanged: if (!isIdle) root.runWake()
+    onIsIdleChanged: if (!isIdle && root.displayBlanked) root.runWake()
   }
 
   Timer {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -167,7 +167,11 @@ Item {
 
   function runWake() {
     displayBlanked = false
-    if (!wakeProcess.running) wakeProcess.running = true
+    // A wake dispatched while the blank is still running finds the display lit,
+    // skips its DPMS enable, and is then taken down by the very blank it meant
+    // to undo: dark panel, blanked flag false, monitor disarmed. Let the blank
+    // land and undo it on the way out instead.
+    if (!blankProcess.running && !wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
@@ -430,6 +434,9 @@ Item {
   Process {
     id: blankProcess
     command: ["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"]
+    // Any wake that arrived mid-blank was held back above, so run it here,
+    // where the DPMS off it has to undo has actually landed.
+    onExited: if (!root.displayBlanked && !wakeProcess.running) wakeProcess.running = true
   }
 
   Timer {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,6 +33,7 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property bool displayBlanked: false
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
@@ -165,11 +166,13 @@ Item {
   }
 
   function runWake() {
+    displayBlanked = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
+    displayBlanked = true
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -277,6 +280,7 @@ Item {
         inputEnabled: root.lockRequested
         loadBackground: root.locked
         passwordText: root.enteredPassword
+        displayBlanked: root.displayBlanked
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
@@ -351,6 +355,19 @@ Item {
       root.fingerprintAuthenticating = false
       if (root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
     }
+  }
+
+  // Hyprland drops the lock surface's keyboard focus when the display goes
+  // DPMS-off, which severs the only route a keystroke has to runWake(): the
+  // password field's Keys handler. That leaves the blanked lock screen wakeable
+  // by pointer alone — the field cannot hear the key that would light the panel
+  // it needs to be lit to hear. The compositor still reports input as activity no
+  // matter who holds focus, so watch that instead and let any key wake the screen.
+  IdleMonitor {
+    enabled: root.lockRequested && root.displayBlanked
+    timeout: 1
+    respectInhibitors: false
+    onIsIdleChanged: if (!isIdle) root.runWake()
   }
 
   Timer {

--- a/test/shell.d/lock-blank-wake-test.sh
+++ b/test/shell.d/lock-blank-wake-test.sh
@@ -7,6 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const lockViewQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
 
 // `omarchy-brightness-display on` skips its dispatch when the display still
 // looks lit, so a wake that overtakes an in-flight blank does nothing and the
@@ -20,5 +21,17 @@ assert(
 assert(
   /id: blankProcess[\s\S]*?onExited: if \(!root\.displayBlanked && !wakeProcess\.running\) wakeProcess\.running = true/.test(serviceQml),
   'the blank runs the wake it held back once its own DPMS off has landed'
+)
+
+// The blanked flag clears when the wake is dispatched, not when the compositor
+// has handed the surface its keyboard focus back, so one call can land early.
+assert(
+  !/onDisplayBlankedChanged:/.test(lockViewQml),
+  'the refocus no longer fires once off the blanked flag'
+)
+
+assert(
+  /running: root\.inputEnabled && !root\.authenticatingPassword && !root\.displayBlanked && !passwordInput\.activeFocus\s*\n\s*onTriggered: root\.forcePasswordFocus\(\)/.test(lockViewQml),
+  'the refocus retries until the field holds focus, and idles while blanked'
 )
 JS

--- a/test/shell.d/lock-blank-wake-test.sh
+++ b/test/shell.d/lock-blank-wake-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// `omarchy-brightness-display on` skips its dispatch when the display still
+// looks lit, so a wake that overtakes an in-flight blank does nothing and the
+// blank then takes the panel down behind it, with the blanked flag already
+// false and the keyboard monitor disarmed.
+assert(
+  /if \(!blankProcess\.running && !wakeProcess\.running\) wakeProcess\.running = true/.test(serviceQml),
+  'a wake waits for an in-flight blank instead of racing its DPMS off'
+)
+
+assert(
+  /id: blankProcess[\s\S]*?onExited: if \(!root\.displayBlanked && !wakeProcess\.running\) wakeProcess\.running = true/.test(serviceQml),
+  'the blank runs the wake it held back once its own DPMS off has landed'
+)
+JS


### PR DESCRIPTION
Fixes #7467

all this so i don't have to reach for my mouse and do a click.

### Root cause

The lock screen blanks the display five seconds in, and `omarchy-brightness-display off` dispatches a real DPMS off:

```bash
hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'
```

Hyprland takes the lock surface's keyboard focus along with the output, and lighting the panel back up does not hand it back.

That leaves the blanked lock screen wakeable by pointer alone. Waking runs from `wakeRequested`, and the keyboard's only route to it is the password field's `Keys` handler — which needs the focus DPMS just took. The field cannot hear the key that would light the panel it needs lit to hear. `MouseArea` escapes the deadlock because pointer events arrive no matter who holds keyboard focus, which is why clicking the screen — or, as in the issue, connecting a mouse to do it — is what brings the field back.

Suspending on an idle timeout and resuming into a blanked lock screen lands in the same state, which is why the report is specific to the automatic lock rather than a lock taken by hand.

### The fix

Two halves, because the deadlock has two: light the panel back up, and get the focus back.

**Wake it.** `shell/plugins/lock/Service.qml` watches input at the compositor, where focus does not matter:

```qml
IdleMonitor {
  enabled: root.lockRequested
  timeout: 1
  respectInhibitors: false
  onIsIdleChanged: if (!isIdle && root.displayBlanked) root.runWake()
}
```

Armed for the whole lock rather than only while blanked. The idle notification starts *active* and reports idle a second later, and any input restarts that second, so one armed at blank time is deaf to precisely the user this is for: someone who looks back at a just-blanked screen and types their password straight in never leaves the gap it needs to prime. Measured with every other route to `runWake()` severed: 47 keystrokes over 15 seconds, no wake; then a three-second pause and one key, wake. Arming it for the whole lock leaves it already idle when the blank lands, so the first key wakes the screen; the wake is gated on `displayBlanked` instead, which keeps every other moment of the lock behaving as before.

**Focus it.** `shell/plugins/lock/LockView.qml` asks for focus on a short timer bound to the field's own `activeFocus`, so it stops itself the moment focus lands, and idles while the display is blanked — there is no focus to win with the output down, and a lock can sit blanked all night.

### Two findings from review, both fixed

**A wake could race the blank it was undoing.** `runBlank()` sets `displayBlanked` and starts a process that turns the keyboard backlight down *before* dispatching the DPMS off. A key arriving in that window reached `runWake()`, which cleared the flag and ran `omarchy-system-wake` against a display that was still lit — and `omarchy-brightness-display on` deliberately skips its dispatch when every active display already reports DPMS on, to keep a redundant modeset from flashing the panel after resume. So the wake did nothing, the blank took the display down behind it, and the lock was left dark with `displayBlanked` false: the monitor is gated on that flag, so it was disarmed against exactly the screen it exists to wake. The blank timer healed it five seconds and another keypress later.

A wake arriving while the blank runs is now held back and dispatched from the blank's own exit, where the off it has to undo has actually happened. (7d6cb900)

**The refocus fired once, and too early.** It ran from `Qt.callLater` on the blanked flag going false — but that flag clears the moment `runWake()` is called, before `omarchy-system-wake` has started, let alone before Hyprland has re-enabled DPMS and handed the surface its focus back. It landed on a display that was still off, and nothing tried again. It happened to take on this machine; on hardware slower to return focus, the wake lights the panel and the field stays deaf anyway.

It now retries until the field holds focus. (e5b5567f)

### Sequencing against the other open PRs

**#7673 conflicts, and should probably go first.** It replaces `blankProcess` and `wakeProcess` with `Quickshell.execDetached` to stop a wedged child latching `running` forever. The serialization above is built on `blankProcess.running` and its `onExited`, neither of which survives a detached spawn. If #7673 lands first this half needs re-expressing, and the closest equivalent is a settle timer in the spirit of its own `wakeCoalesceTimer` — worse, because it guesses a duration instead of hearing the exit.

Worth stating the reverse, since it rules out the obvious alternative: this could have been a blocking `flock` across the `off` and `on` branches of `omarchy-brightness-display`, which would have survived #7673 and covered every caller. It does not work. The blank is delayed by `omarchy-brightness-keyboard off` — a glob plus a `brightnessctl` spawn — so the wake reaches the lock *first*, still sees a lit display, skips, and releases; the blank then takes the lock and turns the panel off behind it. Mutual exclusion orders by arrival, and arrival here is the reverse of intent. Holding the lock across the whole blank instead would order it correctly, and would then let one wedged blank hold every wake on the system behind it — the exact failure #7673 exists to fix.

**On the wake arriving from outside this plugin.** `cancelIdleCycle()` in `shell/plugins/services/idle/Service.qml` runs `omarchy-system-wake` too, on the same user input, with no knowledge of this blank. Nothing here can hold that one back and it will no-op against a lit display. The outcome is still covered, because the monitor above fires on that same input and its wake goes through the guarded path.

**#7592 overlaps** on the focus half: same shape of timer from the resume side, minus the blanked gate. If it lands first, the timer here should go and only the `Service.qml` half of this PR is needed.

**#7164** refocuses when `WlSessionLock` reports secure, which is before the blank, so it cannot reach this. As noted in its own thread, `secure` also does not re-fire when the lock surfaces are rebuilt on an output change, which is the case #7592's timer does cover.

**#6642** avoids this whole class by not blanking the display at all, for an unrelated reason: DPMS-off drops the connector on some monitors and kills the shell mid-lock. Only this PR restores the display.

### On the previous version of this PR

This branch previously added `focus: true` to the password field. That was wrong twice over: `forceActiveFocus()` already sets `focus`, so the line was a no-op, and focus at construction was never the failure. Tracing the live lock screen shows the field holding `activeFocus` with the window active before the lock reports secure, and losing it only when the blank timer runs.

### Verification

Traced on a machine reproducing the issue, with temporary logging around the blank/wake path. The lock screen was blanked and then woken from the keyboard alone, no pointer input:

```
17:32:49.300  blanked
17:32:50.301  blank-idle-monitor: isIdle=true
17:39:47.152  blank-idle-monitor: isIdle=false   <- keypress, no focus held
17:39:47.152  wake-from-blank
              lock-focus: forced -> activeFocus=true
17:39:56.644  unlocked
```

`./test/shell`: 182 files, the same three pre-existing environment failures with and without the change (`config`, `snapper`, `unowned-system-paths`). `test/shell.d/lock-blank-wake-test.sh` covers both fixes above and fails without them.

The two fixes in this section have not yet been re-traced on the affected machine — the shell there runs from the packaged tree. They are reasoned from the source and covered by that test; a live re-trace is worth having before merge if the timing is in doubt.
