### PR TITLE
Preserve XCompose customizations on setup rerun

### DIFF
--- a/install/user/xcompose.sh
+++ b/install/user/xcompose.sh
@@ -1,5 +1,6 @@
 # Set default XCompose that is triggered with CapsLock
-tee ~/.XCompose >/dev/null <<EOF
+if [[ ! -f $HOME/.XCompose ]]; then
+  cat >"$HOME/.XCompose" <<EOF
 # Run omarchy-restart-xcompose to apply changes
 
 # Include fast emoji access
@@ -9,3 +10,4 @@ include "/usr/share/omarchy/default/xcompose"
 <Multi_key> <space> <n> : "$OMARCHY_USER_NAME"
 <Multi_key> <space> <e> : "$OMARCHY_USER_EMAIL"
 EOF
+fi

--- a/test/shell.d/xcompose-install-test.sh
+++ b/test/shell.d/xcompose-install-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+xcompose_install="$ROOT/install/user/xcompose.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+mkdir -p "$home"
+
+OMARCHY_USER_NAME="Example User" \
+OMARCHY_USER_EMAIL="user@example.com" \
+HOME="$home" \
+  bash -eE "$xcompose_install"
+
+grep -qFx '<Multi_key> <space> <n> : "Example User"' "$home/.XCompose" ||
+  fail "XCompose install writes the user's name"
+grep -qFx '<Multi_key> <space> <e> : "user@example.com"' "$home/.XCompose" ||
+  fail "XCompose install writes the user's email"
+pass "XCompose install creates the default file with the user's identity"
+
+printf '\n<Multi_key> <space> <x> : "custom"\n' >>"$home/.XCompose"
+before=$(sha256sum "$home/.XCompose")
+
+HOME="$home" bash -euo pipefail "$xcompose_install"
+
+[[ $(sha256sum "$home/.XCompose") == "$before" ]] ||
+  fail "XCompose install preserves an existing user file" "$(cat "$home/.XCompose")"
+pass "XCompose install preserves user customizations on rerun"


### PR DESCRIPTION
 `omarchy-finalize-user --force` can run `install/user/xcompose.sh` more than once, but the script
  currently recreates `~/.XCompose` on every pass. That removes user-defined Compose sequences and,
  when the identity variables are absent, replaces the name and email macros with empty strings.

  Only seed the default file when `~/.XCompose` does not already exist. This matches the non-
  destructive guard already used by the Quattro upgrade path.

  The regression test covers initial identity creation, adds a custom sequence, reruns without the
  identity variables, and verifies the file is unchanged byte-for-byte.

  ## Testing

  - `./test/all` - all 182 test files passed

  Closes #7104
 