### PR TITLE
Repair fcitx5 restart loops from user autostarts

### DIFF
--- a/migrations/1787085233.sh
+++ b/migrations/1787085233.sh
@@ -1,0 +1,66 @@
+echo "Disable user autostarts that compete with the supervised fcitx5 service"
+
+# XDG autostart entries only mask another entry with the same filename. A user
+# may therefore have an older, differently named entry that still launches
+# fcitx5 alongside omarchy-fcitx5.service. The stray instance wins the D-Bus
+# name race and leaves the Restart=always unit looping forever.
+autostart_dir="$HOME/.config/autostart"
+[[ -d $autostart_dir ]] || exit 0
+
+affected=false
+
+for desktop_file in "$autostart_dir"/*.desktop; do
+  [[ -f $desktop_file ]] || continue
+  grep -qxF '[Desktop Entry]' "$desktop_file" || continue
+
+  in_desktop_entry=false
+  exec_line=""
+  hidden_present=false
+  hidden_value=""
+  while IFS= read -r line; do
+    if [[ $line == "[Desktop Entry]" ]]; then
+      in_desktop_entry=true
+      continue
+    elif [[ $line == \[*\] ]]; then
+      $in_desktop_entry && break
+      continue
+    fi
+
+    $in_desktop_entry || continue
+
+    if [[ $line =~ ^[[:space:]]*Exec[[:space:]]*=(.*)$ ]]; then
+      exec_line=${BASH_REMATCH[1]}
+    elif [[ $line =~ ^[[:space:]]*Hidden[[:space:]]*=(.*)$ ]]; then
+      hidden_present=true
+      hidden_value=${BASH_REMATCH[1]}
+    fi
+  done <"$desktop_file"
+
+  exec_line=${exec_line#"${exec_line%%[![:space:]]*}"}
+  hidden_value=${hidden_value#"${hidden_value%%[![:space:]]*}"}
+  hidden_value=${hidden_value%"${hidden_value##*[![:space:]]}"}
+
+  if [[ $exec_line == \"* ]]; then
+    executable=${exec_line#\"}
+    executable=${executable%%\"*}
+  else
+    executable=${exec_line%%[[:space:]]*}
+  fi
+
+  [[ ${executable##*/} == "fcitx5" ]] || continue
+  affected=true
+  [[ $hidden_value == "true" ]] && continue
+
+  if $hidden_present; then
+    sed -i -E '/^\[Desktop Entry\][[:space:]]*$/,/^\[[^]]+\][[:space:]]*$/{s/^[[:space:]]*Hidden[[:space:]]*=.*$/Hidden=true/}' "$desktop_file"
+  else
+    sed -i '/^[[:space:]]*\[Desktop Entry\][[:space:]]*$/aHidden=true' "$desktop_file"
+  fi
+done
+
+# Outside a graphical session the next login starts the sole remaining fcitx5
+# through systemd. Inside one, replace the competing process immediately so the
+# service stops flooding the journal and keeps the Compose table supervised.
+if $affected && systemctl --user is-active --quiet graphical-session.target; then
+  omarchy-restart-xcompose
+fi

--- a/test/shell.d/fcitx5-autostart-migration-test.sh
+++ b/test/shell.d/fcitx5-autostart-migration-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787085233.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+test_home="$test_dir/home"
+autostart_dir="$test_home/.config/autostart"
+fake_bin="$test_dir/bin"
+calls="$test_dir/calls"
+mkdir -p "$autostart_dir" "$fake_bin"
+
+cat >"$fake_bin/systemctl" <<'STUB'
+#!/bin/bash
+
+printf 'systemctl %s\n' "$*" >>"$CALLS"
+[[ $* == "--user is-active --quiet graphical-session.target" && ${ACTIVE_SESSION:-no} == "yes" ]]
+STUB
+
+cat >"$fake_bin/omarchy-restart-xcompose" <<'STUB'
+#!/bin/bash
+
+printf 'omarchy-restart-xcompose\n' >>"$CALLS"
+[[ ${RESTART_FAIL:-no} != "yes" ]]
+STUB
+
+chmod +x "$fake_bin/"*
+
+run_migration() {
+  : >"$calls"
+  ACTIVE_SESSION="${1:-no}" \
+    RESTART_FAIL="${2:-no}" \
+    CALLS="$calls" \
+    HOME="$test_home" \
+    PATH="$fake_bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+cat >"$autostart_dir/fcitx5.desktop" <<'EOF'
+[Desktop Entry]
+Name=Custom input method
+Exec=fcitx5 -d
+X-Custom=preserve-me
+EOF
+
+cat >"$autostart_dir/input-method.desktop" <<'EOF'
+[Desktop Entry]
+Name=Absolute input method
+Exec="/usr/bin/fcitx5" --replace
+Hidden=false
+EOF
+
+cat >"$autostart_dir/empty-hidden.desktop" <<'EOF'
+[Desktop Entry]
+Name=Input method with an empty hidden key
+Exec=fcitx5
+Hidden=
+EOF
+
+cat >"$autostart_dir/org.fcitx.Fcitx5.desktop" <<'EOF'
+[Desktop Entry]
+Hidden=true
+EOF
+stock_mask_before=$(sha256sum "$autostart_dir/org.fcitx.Fcitx5.desktop")
+
+cat >"$autostart_dir/fcitx5-config.desktop" <<'EOF'
+[Desktop Entry]
+Name=Fcitx configuration
+Exec=fcitx5-configtool
+EOF
+config_entry_before=$(sha256sum "$autostart_dir/fcitx5-config.desktop")
+
+cat >"$autostart_dir/action-only.desktop" <<'EOF'
+[Desktop Entry]
+Name=Input method helper
+Exec=input-method-helper
+
+[Desktop Action Restart]
+Name=Restart fcitx5
+Exec=fcitx5 --replace
+EOF
+action_entry_before=$(sha256sum "$autostart_dir/action-only.desktop")
+
+run_migration no
+
+grep -qxF 'Hidden=true' "$autostart_dir/fcitx5.desktop" ||
+  fail "migration disables a differently named fcitx5 autostart"
+grep -qxF 'X-Custom=preserve-me' "$autostart_dir/fcitx5.desktop" ||
+  fail "migration preserves custom desktop entry fields"
+grep -qxF 'Hidden=true' "$autostart_dir/input-method.desktop" ||
+  fail "migration disables an absolute fcitx5 launch and replaces Hidden=false"
+[[ $(grep -c '^Hidden=' "$autostart_dir/empty-hidden.desktop") == 1 ]] &&
+  grep -qxF 'Hidden=true' "$autostart_dir/empty-hidden.desktop" ||
+  fail "migration replaces an empty Hidden key without duplicating it"
+pass "migration disables competing fcitx5 autostarts without deleting them"
+
+[[ $(sha256sum "$autostart_dir/org.fcitx.Fcitx5.desktop") == "$stock_mask_before" ]] ||
+  fail "migration leaves the packaged fcitx5 mask alone"
+[[ $(sha256sum "$autostart_dir/fcitx5-config.desktop") == "$config_entry_before" ]] ||
+  fail "migration leaves related fcitx5 tools alone"
+[[ $(sha256sum "$autostart_dir/action-only.desktop") == "$action_entry_before" ]] ||
+  fail "migration ignores fcitx5 commands outside the main desktop entry"
+pass "migration only changes desktop entries that launch fcitx5"
+
+if grep -qFx 'omarchy-restart-xcompose' "$calls"; then
+  fail "migration restarts fcitx5 outside a graphical session"
+fi
+pass "migration defers service repair outside a graphical session"
+
+sed -i '/^Hidden=true$/d' "$autostart_dir/fcitx5.desktop"
+run_migration yes
+
+grep -qFx 'omarchy-restart-xcompose' "$calls" ||
+  fail "migration repairs the running service after disabling a competing autostart" "$(cat "$calls")"
+pass "migration repairs fcitx5 in an active graphical session"
+
+before=$(find "$autostart_dir" -type f -print0 | sort -z | xargs -0 sha256sum)
+run_migration yes
+after=$(find "$autostart_dir" -type f -print0 | sort -z | xargs -0 sha256sum)
+
+[[ $before == "$after" ]] || fail "fcitx5 autostart migration is idempotent"
+grep -qFx 'omarchy-restart-xcompose' "$calls" ||
+  fail "migration keeps repairing the service when its prior restart may have failed" "$(cat "$calls")"
+pass "fcitx5 autostart migration is idempotent and retryable"
+
+if run_migration yes yes; then
+  fail "migration reports success when the fcitx5 service repair fails"
+fi
+
+run_migration yes
+grep -qFx 'omarchy-restart-xcompose' "$calls" ||
+  fail "migration retries the service repair after a failure" "$(cat "$calls")"
+pass "migration keeps a failed service repair retryable"


### PR DESCRIPTION
The Quattro handover moved fcitx5 into `omarchy-fcitx5.service`, but the original migration only
kills the process that is running at update time. A differently named user autostart entry, such
as `~/.config/autostart/fcitx5.desktop`, survives and starts again at the next login.

That instance can claim `org.fcitx.Fcitx5` before the service does. fcitx5 then exits cleanly, and
`Restart=always` turns the service into a permanent two-second restart loop.

This follow-up migration finds user desktop entries whose main `Exec=` directly launches fcitx5
and marks them `Hidden=true`, preserving the file and its custom fields. In a graphical session it
hands the running instance back to the supervised service through `omarchy-restart-xcompose`. A
failed handover remains retryable.

This is a new migration rather than a change to the original handover because existing 4.0 users
may already have recorded that migration as complete.

## Testing

- `./test/all` - all 182 test files passed

Closes #7461