### PR TITLE
Keep the Bluetooth device list where it was left while scanning

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -99,6 +99,122 @@ function deviceRow(d) {
   }
 }
 
+// Roles of one row in the device list model, in one place: the projection
+// below writes them, the snapshot reads them back off the ListModel, and the
+// delegate declares them as required properties.
+var SCROLL_ROLES = [
+  "key", "section", "sectionTitle", "indexInSection",
+  "address", "name", "deviceName",
+  "connected", "devState", "batteryAvailable", "battery", "pairing"
+]
+
+// A role that is not a finite number is worse than a wrong one: NaN compares
+// unequal to itself, so a row carrying one would be rewritten on every rebuild
+// for as long as the panel lives, and nothing would say why.
+function finiteNumber(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback
+  var number = Number(value)
+  return isFinite(number) ? number : fallback
+}
+
+// Rows are identified by section and address, so the same device showing up
+// in a different section is a different row rather than an in-place edit.
+function scrollRowKey(row) {
+  if (!row) return ""
+  return (row.section || "") + "/" + (row.dev && row.dev.address ? row.dev.address : "")
+}
+
+// A row opens a section when it is the first of its kind in the flat list.
+function scrollSectionTitle(rows, index) {
+  if (!rows || index < 0 || index >= rows.length) return ""
+  if (index > 0 && rows[index - 1].section === rows[index].section) return ""
+  return rows[index].section === "known" ? "PAIRED" : "AVAILABLE"
+}
+
+// Flat, primitives-only projection of a row for the list model. ListModel
+// roles hold no nested objects, and `state` is already taken on the
+// delegate's Item, so the device's connection state travels as devState.
+function scrollEntry(rows, index) {
+  var row = rows[index] || {}
+  var device = row.dev || {}
+  return {
+    key: scrollRowKey(row),
+    section: row.section || "",
+    sectionTitle: scrollSectionTitle(rows, index),
+    indexInSection: row.indexInSection !== undefined ? row.indexInSection : 0,
+    address: device.address || "",
+    name: device.name || "",
+    deviceName: device.deviceName || "",
+    connected: !!device.connected,
+    devState: finiteNumber(device.state, -1),
+    batteryAvailable: !!device.batteryAvailable,
+    battery: finiteNumber(device.battery, 0),
+    pairing: !!device.pairing
+  }
+}
+
+function scrollEntries(rows) {
+  var entries = []
+  for (var i = 0; i < (rows || []).length; i++) entries.push(scrollEntry(rows, i))
+  return entries
+}
+
+// Plain-object copy of a row read back off the ListModel, so the diff compares
+// values rather than model handles and cannot be surprised by what a handle
+// tracks once the ops start landing.
+function scrollEntrySnapshot(item) {
+  var copy = ({})
+  for (var i = 0; i < SCROLL_ROLES.length; i++) copy[SCROLL_ROLES[i]] = item ? item[SCROLL_ROLES[i]] : undefined
+  return copy
+}
+
+function sameScrollEntry(a, b) {
+  if (!a || !b) return false
+  for (var i = 0; i < SCROLL_ROLES.length; i++)
+    if (a[SCROLL_ROLES[i]] !== b[SCROLL_ROLES[i]]) return false
+  return true
+}
+
+// Edit script turning the entries a ListModel already holds into the ones a
+// rebuild wants, applied in order. Handing a ListView a whole new model is a
+// reset that drops the viewport back to the top, and discovery rebuilds the
+// rows every time a device appears or times out; patching only what actually
+// moved keeps the delegates, and with them the scroll position.
+function scrollModelOps(current, entries) {
+  var rows = (current || []).slice()
+  var wanted = entries || []
+  var ops = []
+
+  for (var i = 0; i < wanted.length; i++) {
+    var entry = wanted[i]
+    var at = -1
+    for (var j = i; j < rows.length; j++) {
+      if (rows[j] && rows[j].key === entry.key) { at = j; break }
+    }
+
+    if (at === -1) {
+      ops.push({ op: "insert", index: i, entry: entry })
+      rows.splice(i, 0, entry)
+      continue
+    }
+
+    if (at !== i) {
+      ops.push({ op: "move", from: at, to: i })
+      rows.splice(i, 0, rows.splice(at, 1)[0])
+    }
+
+    if (!sameScrollEntry(rows[i], entry)) {
+      ops.push({ op: "set", index: i, entry: entry })
+      rows[i] = entry
+    }
+  }
+
+  if (rows.length > wanted.length)
+    ops.push({ op: "remove", index: wanted.length, count: rows.length - wanted.length })
+
+  return ops
+}
+
 function deviceLists(devices) {
   var values = toArray(devices)
   var connected = []
@@ -168,6 +284,13 @@ if (typeof module !== "undefined") {
     sortedByLabel: sortedByLabel,
     deviceRow: deviceRow,
     deviceLists: deviceLists,
+    finiteNumber: finiteNumber,
+    scrollRowKey: scrollRowKey,
+    scrollSectionTitle: scrollSectionTitle,
+    scrollEntries: scrollEntries,
+    scrollEntrySnapshot: scrollEntrySnapshot,
+    sameScrollEntry: sameScrollEntry,
+    scrollModelOps: scrollModelOps,
     cloneMap: cloneMap,
     pendingAction: pendingAction,
     withPendingAction: withPendingAction,

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -146,6 +146,33 @@ Panel {
     return rows
   }
 
+  // Same rows as ListModel entries, kept in place instead of handed to the
+  // ListView as a fresh array: assigning a model is a reset, and scrollRows is
+  // rebuilt every time discovery turns up a device or drops a stale one, which
+  // dropped the viewport back to the top under a mid-list read. Syncing only
+  // the rows that moved keeps the delegates, and with them the scroll offset.
+  readonly property var scrollEntries: Model.scrollEntries(scrollRows)
+
+  ListModel { id: scrollModel }
+
+  function syncScrollModel() {
+    var current = []
+    for (var i = 0; i < scrollModel.count; i++)
+      current.push(Model.scrollEntrySnapshot(scrollModel.get(i)))
+
+    var ops = Model.scrollModelOps(current, scrollEntries)
+    for (var o = 0; o < ops.length; o++) {
+      var op = ops[o]
+      if (op.op === "insert") scrollModel.insert(op.index, op.entry)
+      else if (op.op === "move") scrollModel.move(op.from, op.to, 1)
+      else if (op.op === "set") scrollModel.set(op.index, op.entry)
+      else if (op.op === "remove") scrollModel.remove(op.index, op.count)
+    }
+  }
+
+  onScrollEntriesChanged: syncScrollModel()
+  Component.onCompleted: syncScrollModel()
+
   // Connected devices render above the scroll area; same primitives-only
   // projection so those delegates never hold Device QObject wrappers either.
   readonly property var connectedRows: {
@@ -176,14 +203,6 @@ Panel {
     for (var i = 0; i < scrollRows.length; i++)
       if (scrollRows[i].section === focusSection && scrollRows[i].indexInSection === selectedIndex) return i
     return -1
-  }
-
-  // A row opens a section when it is the first of its kind in the flat list.
-  function scrollSectionTitle(index) {
-    var rows = scrollRows
-    if (index < 0 || index >= rows.length) return ""
-    if (index > 0 && rows[index - 1].section === rows[index].section) return ""
-    return rows[index].section === "known" ? "PAIRED" : "AVAILABLE"
   }
 
   function audioSinks() {
@@ -812,22 +831,55 @@ Panel {
 
           ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
 
-          model: root.scrollRows
-          currentIndex: root.scrollRowIndex
-          // Deferred by a turn. Called straight out of the signal the position
-          // does not take — verified with the cursor six rows down and
-          // contentY still 0 — because scrollRows is rebuilt every time
-          // discovery reports, and swapping the model resets the view out from
-          // under the call. Network's list is stable enough not to need this.
-          onCurrentIndexChanged: if (currentIndex >= 0) Qt.callLater(keepCurrentVisible)
+          model: scrollModel
+
+          // Follows the panel's cursor, never the view's currentIndex: a view
+          // bumps that itself for every row inserted at or before it, and the
+          // write does not re-run the binding that fed it — so an index taken
+          // off the view walks away from the cursor, a row per discovered
+          // device, and scrolls to a row nobody is on.
+          Connections {
+            target: root
+            // Deferred by a turn. Called straight out of the signal the
+            // position does not take — verified with the cursor six rows down
+            // and contentY still 0 — because the row a discovery report
+            // inserts is still being laid out when the cursor moves with it.
+            function onScrollRowIndexChanged() { Qt.callLater(deviceListView.keepCurrentVisible) }
+          }
+
           function keepCurrentVisible() {
-            if (currentIndex >= 0) positionViewAtIndex(currentIndex, ListView.Contain)
+            if (root.scrollRowIndex >= 0)
+              positionViewAtIndex(root.scrollRowIndex, ListView.Contain)
           }
 
           delegate: Item {
-            required property var modelData
+            id: rowDelegate
             required property int index
-            readonly property string sectionTitle: root.scrollSectionTitle(index)
+            required property string section
+            required property string sectionTitle
+            required property int indexInSection
+            required property string address
+            required property string name
+            required property string deviceName
+            required property bool connected
+            required property int devState
+            required property bool batteryAvailable
+            required property real battery
+            required property bool pairing
+
+            // Rebuilt from roles rather than carried in the model: rows hold
+            // primitives only, so no delegate ever holds a Device wrapper that
+            // BlueZ can destroy mid-incubation.
+            readonly property var dev: ({
+              address: address,
+              name: name,
+              deviceName: deviceName,
+              connected: connected,
+              state: devState,
+              batteryAvailable: batteryAvailable,
+              battery: battery,
+              pairing: pairing
+            })
 
             width: ListView.view.width
             height: delegateColumn.implicitHeight
@@ -838,25 +890,25 @@ Panel {
               spacing: Style.space(10)
 
               PanelSeparator {
-                visible: index > 0 && sectionTitle !== ""
+                visible: rowDelegate.index > 0 && rowDelegate.sectionTitle !== ""
                 height: visible ? implicitHeight : 0
                 foreground: root.bar.foreground
               }
 
               PanelSectionHeader {
-                visible: sectionTitle !== ""
+                visible: rowDelegate.sectionTitle !== ""
                 height: visible ? implicitHeight : 0
-                text: sectionTitle
+                text: rowDelegate.sectionTitle
                 foreground: root.bar.foreground
                 fontFamily: root.bar.fontFamily
               }
 
               DeviceRow {
                 width: parent.width
-                dev: modelData.dev
-                rowIndex: modelData.indexInSection
-                sectionName: modelData.section
-                isDiscovered: modelData.section === "discovered"
+                dev: rowDelegate.dev
+                rowIndex: rowDelegate.indexInSection
+                sectionName: rowDelegate.section
+                isDiscovered: rowDelegate.section === "discovered"
               }
             }
           }

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -103,6 +103,198 @@ assertEqual(
   'bluetooth keeps deviceName in row projections so labels survive QObject-free rows'
 )
 
+// The device list is a ListModel the panel patches in place. Rebuilding it --
+// or handing a ListView a fresh JS array, which is the same reset -- puts the
+// viewport back at the top, and discovery rebuilds the rows every few seconds,
+// so a list being read mid-scroll kept jumping away under the pointer.
+assert(/model: scrollModel/.test(panelSource), 'bluetooth backs the device list with a ListModel it owns')
+assert(!/model: root\.scrollRows/.test(panelSource), 'bluetooth never assigns the rebuilt rows to the view as a whole model')
+assert(/onScrollEntriesChanged: syncScrollModel\(\)/.test(panelSource), 'bluetooth patches the device list when the rows are rebuilt')
+
+// A view bumps its own currentIndex for every row inserted at or before it,
+// and that write does not re-run the binding that fed it, so an index read
+// back off the view drifts one row further from the cursor per discovered
+// device -- and the scroll-into-view lands on a row nobody is on.
+assert(
+  /function keepCurrentVisible\(\) \{\s*\n\s*if \(root\.scrollRowIndex >= 0\)\s*\n\s*positionViewAtIndex\(root\.scrollRowIndex, ListView\.Contain\)/.test(panelSource),
+  'bluetooth scrolls to the cursor the panel owns, not to the index the view keeps'
+)
+assert(!/currentIndex: root\.scrollRowIndex/.test(panelSource), 'bluetooth never feeds the cursor through the view\'s own current index')
+
+const scrollRows = (addresses, section) => addresses.map((address, index) => ({
+  dev: bluetooth.deviceRow({ name: 'dev' + address, address: address }),
+  section: section || 'known',
+  indexInSection: index
+}))
+
+const knownThenDiscovered = scrollRows(['1', '2'], 'known').concat(scrollRows(['3'], 'discovered'))
+assertDeepEqual(
+  bluetooth.scrollEntries(knownThenDiscovered).map(entry => entry.sectionTitle),
+  ['PAIRED', '', 'AVAILABLE'],
+  'bluetooth titles the first row of each section only'
+)
+assertDeepEqual(
+  bluetooth.scrollEntries(knownThenDiscovered).map(entry => entry.key),
+  ['known/1', 'known/2', 'discovered/3'],
+  'bluetooth keys rows by section and address so a device changing section is a new row'
+)
+
+const settled = bluetooth.scrollEntries(scrollRows(['1', '2', '3']))
+assertDeepEqual(
+  bluetooth.scrollModelOps(settled, settled),
+  [],
+  'bluetooth touches nothing when a rebuild turns up the same devices'
+)
+
+const withNewDevice = bluetooth.scrollEntries(scrollRows(['1', '4', '2', '3']))
+assertDeepEqual(
+  bluetooth.scrollModelOps(settled, withNewDevice).filter(op => op.op !== 'set').map(op => op.op + ':' + op.index),
+  ['insert:1'],
+  'bluetooth inserts a discovered device without rebuilding the rows around it'
+)
+
+assertDeepEqual(
+  bluetooth.scrollModelOps(settled, bluetooth.scrollEntries(scrollRows(['1']))).map(op => `${op.op}:${op.index}:${op.count}`),
+  ['remove:1:2'],
+  'bluetooth drops timed-out devices off the end of the list'
+)
+
+const reordered = bluetooth.scrollModelOps(settled, bluetooth.scrollEntries(scrollRows(['3', '1', '2'])))
+assertDeepEqual(
+  reordered.filter(op => op.op === 'move').map(op => `${op.from}->${op.to}`),
+  ['2->0'],
+  'bluetooth moves a re-sorted device instead of replacing the list'
+)
+
+const charged = bluetooth.scrollEntries(scrollRows(['1', '2', '3']))
+charged[1].battery = 0.75
+assertDeepEqual(
+  bluetooth.scrollModelOps(settled, charged).map(op => `${op.op}:${op.index}`),
+  ['set:1'],
+  'bluetooth updates only the row whose device changed'
+)
+
+assertDeepEqual(
+  bluetooth.scrollEntrySnapshot({ key: 'known/1', extra: 'ignored' }).key,
+  'known/1',
+  'bluetooth snapshots list rows by role and ignores anything else on the object'
+)
+assertEqual(
+  bluetooth.scrollEntrySnapshot({}).battery,
+  undefined,
+  'bluetooth snapshots a role the model never set as undefined rather than inventing a value'
+)
+
+// ListModel.insert/move/set/remove, in JS. Asserting on the op list alone
+// lets a diff that emits plausible-looking ops pass; replaying them is what
+// proves the list the panel ends up showing is the list it wanted.
+const applyOps = (current, ops) => {
+  const rows = current.slice()
+  for (const op of ops) {
+    if (op.op === 'insert') rows.splice(op.index, 0, op.entry)
+    else if (op.op === 'move') rows.splice(op.to, 0, rows.splice(op.from, 1)[0])
+    else if (op.op === 'set') rows[op.index] = op.entry
+    else if (op.op === 'remove') rows.splice(op.index, op.count)
+    else fail(`bluetooth emits only list model operations (got ${op.op})`)
+  }
+  return rows
+}
+
+const replays = [
+  ['an unchanged list', ['1', '2', '3'], ['1', '2', '3']],
+  ['a device appearing', ['1', '2'], ['1', '3', '2']],
+  ['a device timing out', ['1', '2', '3'], ['1', '3']],
+  ['every device timing out at once', ['1', '2', '3'], []],
+  ['the first devices of a scan', [], ['1', '2', '3']],
+  ['a re-sort', ['1', '2', '3'], ['3', '2', '1']],
+  ['a re-sort that also gains and loses devices', ['1', '2', '3', '4'], ['5', '3', '1', '6']],
+  ['a list replaced wholesale', ['1', '2', '3'], ['7', '8', '9']]
+]
+
+for (const [description, before, after] of replays) {
+  const from = bluetooth.scrollEntries(scrollRows(before))
+  const to = bluetooth.scrollEntries(scrollRows(after))
+  assertDeepEqual(
+    applyOps(from, bluetooth.scrollModelOps(from, to)),
+    to,
+    `bluetooth patches the list to exactly what it wants through ${description}`
+  )
+}
+
+// Producing the right list is not enough: an insert plus a remove lands the
+// same rows as a move while destroying and rebuilding that row's delegate,
+// which is the thing this list model exists to avoid. BlueZ reports a device
+// before its alias often enough that a late label re-sorts it the length of
+// the list.
+const beforeResort = bluetooth.scrollEntries(scrollRows(['b', 'c', 'd', 'e', 'f', 'g', 'a']))
+const afterResort = bluetooth.scrollEntries(scrollRows(['a', 'b', 'c', 'd', 'e', 'f', 'g']))
+const resortOps = bluetooth.scrollModelOps(beforeResort, afterResort)
+assertDeepEqual(
+  applyOps(beforeResort, resortOps),
+  afterResort,
+  'bluetooth patches the list to exactly what it wants when a late alias re-sorts a device'
+)
+assertDeepEqual(
+  resortOps.filter(op => op.op !== 'set').map(op => `${op.op}:${op.from}->${op.to}`),
+  ['move:6->0'],
+  'bluetooth moves a re-sorted device the length of the list rather than rebuilding its row'
+)
+assertEqual(
+  bluetooth.scrollModelOps(beforeResort, afterResort).filter(op => op.op === 'insert' || op.op === 'remove').length,
+  0,
+  'bluetooth never inserts or removes a row when the same devices are merely re-sorted'
+)
+
+// A role that is not a finite number would make a row compare unequal to
+// itself, and the diff would rewrite it on every rebuild forever.
+const unreadable = bluetooth.scrollEntries([{
+  dev: { address: '1', name: 'Speaker', state: NaN, battery: 'unknown' },
+  section: 'known',
+  indexInSection: 0
+}])
+assertEqual(unreadable[0].devState, -1, 'bluetooth falls back to no connection state when the state does not read as a number')
+assertEqual(unreadable[0].battery, 0, 'bluetooth falls back to an empty battery when the reading does not read as a number')
+assert(bluetooth.sameScrollEntry(unreadable[0], unreadable[0]), 'bluetooth never builds a row that compares unequal to itself')
+assertDeepEqual(
+  bluetooth.scrollModelOps(unreadable, unreadable),
+  [],
+  'bluetooth stops rewriting a row whose device reports something unreadable'
+)
+assertEqual(bluetooth.finiteNumber('', -1), -1, 'bluetooth reads an empty string as no value rather than as zero')
+assertEqual(bluetooth.finiteNumber(0.8, 0), 0.8, 'bluetooth keeps a real battery reading')
+
+// A device can carry a human name and no address at all, which keys two rows
+// alike. The diff has to land on the list it was handed anyway rather than let
+// a later row match a twin that is already placed.
+const twins = [
+  { name: 'Speaker', address: '' },
+  { name: 'Mouse', address: 'a' },
+  { name: 'Keyboard', address: '' }
+].map((device, index) => ({ dev: bluetooth.deviceRow(device), section: 'known', indexInSection: index }))
+const scanned = bluetooth.scrollEntries(twins)
+assertDeepEqual(
+  applyOps([], bluetooth.scrollModelOps([], scanned)),
+  scanned,
+  'bluetooth patches the list to exactly what it wants when rows key alike'
+)
+assertDeepEqual(
+  applyOps(scanned, bluetooth.scrollModelOps(scanned, bluetooth.scrollEntries(twins.slice(1)))),
+  bluetooth.scrollEntries(twins.slice(1)),
+  'bluetooth drops the right one of two rows that key alike'
+)
+
+// Sections are the other half of the key: a device connecting leaves the
+// paired list for the connected one, and the row it left has to go.
+const paired = bluetooth.scrollEntries(scrollRows(['1', '2'], 'known'))
+const scanning = bluetooth.scrollEntries(
+  scrollRows(['2'], 'known').concat(scrollRows(['1'], 'discovered'))
+)
+assertDeepEqual(
+  applyOps(paired, bluetooth.scrollModelOps(paired, scanning)),
+  scanning,
+  'bluetooth patches the list to exactly what it wants when a device changes section'
+)
+
 assertDeepEqual(
   bluetooth.withPendingAction({ a: 'connecting' }, 'b', 'forgetting'),
   { a: 'connecting', b: 'forgetting' },


### PR DESCRIPTION
The scrollable half of the Bluetooth panel drops back to the top while a scan is running, every few seconds, under whoever is reading the list.

## Cause

`ListView.model` was `root.scrollRows` — a JS array rebuilt whenever discovery turns up a device or drops a stale one. Handing a ListView a fresh array is a full model reset, so every discovery report reset the viewport.

## Fix

Project the rows into a `ListModel` and patch it row by row — insert / move / set / remove, keyed by section and address — so only what actually changed moves, and the scroll offset survives. The diff itself is a pure function in `Model.js`, testable from node like the rest of the panel's model code.

Once the model stops resetting, the view starts reporting incremental changes, and that exposed a second defect: `currentIndex` was bound to `root.scrollRowIndex`, but a view bumps `currentIndex` itself for every row inserted at or before it, and that write does not re-run the binding that fed it. `keepCurrentVisible` then scrolls to a row that is not the cursor. `reselectFocusedDevice` re-points the cursor by address on the next rebuild, so the usual symptom is one spurious scroll and a residual off-by-one — but a device with no address leaves the cursor positional and nothing corrects it. The panel now takes the row to scroll to from its own cursor, and the view keeps no index of its own.

## Verification

- `test/shell.d/bluetooth-test.sh` covers the new code: the ops are replayed through a reference applier and the resulting list asserted equal to the wanted list, across unchanged / gained / lost / re-sorted / wholesale-replaced lists, a device changing section, and rows that key alike (a device with a human name and no address). Op shape is pinned too, so a diff that rebuilds a re-sorted row with insert+remove instead of moving it fails.
- Five deliberately broken diffs — never clearing the list, matching an already-placed row, dropping moves, a bounded lookahead, and dropping the finite-number guard — each fail the suite; the shipped one passes.
- `qmllint -I shell shell/plugins/panels/bluetooth/Panel.qml`: 134 warnings / 0 errors, unchanged from the base revision.
- Run on a live 4.0.0.alpha desktop: the list holds its position through a full scan.

## Known residual

Delegates now survive a rebuild, so a device appearing inside the visible range above the pointer can slide a different row under a stationary cursor and leave the highlight briefly stale until the pointer moves. `reselectFocusedDevice` re-points it on the next rebuild, and actions are unaffected — `onClicked` resolves the device off the row's own MouseArea, not off the highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
