### PR TITLE
feat: Pause and resume a screen recording mid-capture

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Start or stop screen recording
 # omarchy:group=capture
-# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording]
+# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording] [--pause-recording]
 # omarchy:examples=omarchy screenrecord | omarchy capture screenrecording --with-desktop-audio
 # omarchy:aliases=omarchy screenrecord
 #
@@ -34,7 +34,9 @@ WEBCAM_SIZE="medium"
 RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
+PAUSE_RECORDING="false"
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
+PAUSED_FILE="/tmp/omarchy-screenrecord-paused"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
 LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
 
@@ -48,6 +50,7 @@ for arg in "$@"; do
   --resolution=*) RESOLUTION="${arg#*=}" ;;
   --fullscreen) FULLSCREEN="true" ;;
   --stop-recording) STOP_RECORDING="true" ;;
+  --pause-recording) PAUSE_RECORDING="true" ;;
   esac
 done
 
@@ -147,6 +150,10 @@ start_screenrecording() {
   local capture_args=()
   local target
 
+  # A paused marker left by a recording that never reached stop (crash, logout)
+  # would invert the first pause toggle of this new session, so drop it.
+  rm -f "$PAUSED_FILE"
+
   # Opt-in path for HDR, external-GPU monitors, and window capture (all things
   # the portal backend supports and the kms backend doesn't). Default flow uses
   # slurp + the kms backend, which avoids the EGL DMA-BUF modifier import
@@ -239,7 +246,7 @@ stop_screenrecording() {
     ) &
   fi
 
-  rm -f "$RECORDING_FILE"
+  rm -f "$RECORDING_FILE" "$PAUSED_FILE"
 }
 
 toggle_screenrecording_indicator() {
@@ -248,6 +255,27 @@ toggle_screenrecording_indicator() {
 
 screenrecording_active() {
   pgrep -f "^gpu-screen-recorder" >/dev/null
+}
+
+screenrecording_paused() {
+  [[ -f $PAUSED_FILE ]]
+}
+
+# SIGUSR1 toggles capture pause in gpu-screen-recorder. The process won't report
+# its paused state back, so the marker file is the source of truth — every
+# pause/resume goes through here, which keeps it in lockstep with the process.
+pause_screenrecording() {
+  pkill -SIGUSR1 -f "^gpu-screen-recorder"
+
+  if screenrecording_paused; then
+    rm -f "$PAUSED_FILE"
+    omarchy-notification-send -t 1500 "Recording resumed"
+  else
+    touch "$PAUSED_FILE"
+    omarchy-notification-send -t 1500 "Recording paused"
+  fi
+
+  toggle_screenrecording_indicator
 }
 
 finalize_recording() {
@@ -279,7 +307,13 @@ finalize_recording() {
   fi
 }
 
-if screenrecording_active; then
+if [[ $PAUSE_RECORDING == "true" ]]; then
+  if screenrecording_active; then
+    pause_screenrecording
+  else
+    exit 1
+  fi
+elif screenrecording_active; then
   stop_screenrecording
 elif [[ $STOP_RECORDING == "true" ]]; then
   exit 1

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Start or stop screen recording
 # omarchy:group=capture
-# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording] [--pause-recording]
+# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording] [--pause-recording] [--prompt]
 # omarchy:examples=omarchy screenrecord | omarchy capture screenrecording --with-desktop-audio
 # omarchy:aliases=omarchy screenrecord
 #
@@ -35,6 +35,7 @@ RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
 PAUSE_RECORDING="false"
+PROMPT="false"
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
 PAUSED_FILE="/tmp/omarchy-screenrecord-paused"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
@@ -51,6 +52,7 @@ for arg in "$@"; do
   --fullscreen) FULLSCREEN="true" ;;
   --stop-recording) STOP_RECORDING="true" ;;
   --pause-recording) PAUSE_RECORDING="true" ;;
+  --prompt) PROMPT="true" ;;
   esac
 done
 
@@ -278,6 +280,28 @@ pause_screenrecording() {
   toggle_screenrecording_indicator
 }
 
+# Present a focused stop/pause (or stop/resume) picker for an active capture.
+# Called by the bar indicator so a mid-recording click asks before destroying
+# the take, instead of stopping on the first click. omarchy-menu-select returns
+# the label without the glyph; cancel exits nonzero and nothing runs.
+prompt_screenrecording_action() {
+  local pause_label=$'\uf04c\tPause recording'
+  local resume_label=$'\uf04b\tResume recording'
+  local stop_label=$'\uf04d\tStop recording'
+  local choice
+
+  if screenrecording_paused; then
+    choice=$(omarchy-menu-select "Screen recording" "$resume_label" "$stop_label") || return 1
+  else
+    choice=$(omarchy-menu-select "Screen recording" "$pause_label" "$stop_label") || return 1
+  fi
+
+  case "$choice" in
+    "Pause recording" | "Resume recording") pause_screenrecording ;;
+    "Stop recording") stop_screenrecording ;;
+  esac
+}
+
 finalize_recording() {
   local latest
   latest=$(cat "$RECORDING_FILE" 2>/dev/null)
@@ -312,6 +336,12 @@ if [[ $PAUSE_RECORDING == "true" ]]; then
     pause_screenrecording
   else
     exit 1
+  fi
+elif [[ $PROMPT == "true" ]]; then
+  if screenrecording_active; then
+    prompt_screenrecording_action
+  else
+    omarchy-menu toggle trigger.capture.screenrecord
   fi
 elif screenrecording_active; then
   stop_screenrecording

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -263,11 +263,12 @@ screenrecording_paused() {
   [[ -f $PAUSED_FILE ]]
 }
 
-# SIGUSR1 toggles capture pause in gpu-screen-recorder. The process won't report
-# its paused state back, so the marker file is the source of truth — every
-# pause/resume goes through here, which keeps it in lockstep with the process.
+# SIGUSR2 toggles capture pause in gpu-screen-recorder (SIGUSR1 saves a replay
+# instead). The process won't report its paused state back, so the marker file
+# is the source of truth — every pause/resume goes through here, which keeps it
+# in lockstep with the process.
 pause_screenrecording() {
-  pkill -SIGUSR1 -f "^gpu-screen-recorder"
+  pkill -SIGUSR2 -f "^gpu-screen-recorder"
 
   if screenrecording_paused; then
     rm -f "$PAUSED_FILE"

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -58,6 +58,8 @@
   "trigger.capture": {"icon":"","label":"Capture","aliases":["capture","screenshot","screenrecord","screen-record","screenrecording"]},
   "trigger.capture.screenshot": {"icon":"","label":"Screenshot","action":"omarchy-capture-screenshot"},
   "trigger.capture.screenrecord.stop": {"icon":"","label":"Stop Screenrecording","when":"pgrep -f '^gpu-screen-recorder'","action":"omarchy-capture-screenrecording --stop-recording"},
+  "trigger.capture.screenrecord.pause": {"icon":"","label":"Pause Recording","when":"pgrep -f '^gpu-screen-recorder' && [[ ! -f /tmp/omarchy-screenrecord-paused ]]","action":"omarchy-capture-screenrecording --pause-recording"},
+  "trigger.capture.screenrecord.resume": {"icon":"","label":"Resume Recording","when":"pgrep -f '^gpu-screen-recorder' && [[ -f /tmp/omarchy-screenrecord-paused ]]","action":"omarchy-capture-screenrecording --pause-recording"},
   "trigger.capture.screenrecord": {"icon":"","label":"Screenrecord"},
   "trigger.capture.text": {"icon":"󰴑","label":"Text","action":"omarchy-capture-text"},
   "trigger.capture.qr": {"icon":"󰐲","label":"QR Code","action":"omarchy-capture-qr"},

--- a/shell/plugins/bar/indicators/ScreenRecording.qml
+++ b/shell/plugins/bar/indicators/ScreenRecording.qml
@@ -6,16 +6,17 @@ BarIndicator {
   id: root
 
   property bool recording: false
+  property bool paused: false
 
   active: recording
-  activeText: "󰻂"
+  activeText: paused ? "" : "󰻂"
   inactiveText: "󰻂"
-  activeTooltipText: "Stop recording"
+  activeTooltipText: paused ? "Resume recording" : "Stop recording"
   inactiveTooltipText: "Screen Recording"
 
   function refresh() {
     if (!root.bar || statusProc.running) return
-    statusProc.command = ["pgrep", "--quiet", "-f", "^gpu-screen-recorder"]
+    statusProc.command = ["bash", "-c", "if pgrep -qf '^gpu-screen-recorder'; then [[ -f /tmp/omarchy-screenrecord-paused ]] && echo paused || echo recording; else echo idle; fi"]
     statusProc.running = true
   }
 
@@ -30,14 +31,31 @@ BarIndicator {
 
   Process {
     id: statusProc
-    onExited: function(exitCode) {
-      root.recording = exitCode === 0
+    stdout: SplitParser {
+      onRead: function(data) {
+        var state = String(data).trim()
+        if (state === "paused") {
+          root.recording = true
+          root.paused = true
+        } else if (state === "recording") {
+          root.recording = true
+          root.paused = false
+        } else {
+          root.recording = false
+          root.paused = false
+        }
+      }
     }
   }
 
   onPressed: function() {
-    if (root.bar) {
-      root.bar.run(root.recording ? "omarchy-capture-screenrecording --stop-recording" : "omarchy-menu toggle trigger.capture.screenrecord")
+    if (!root.bar) return
+    if (!root.recording) {
+      root.bar.run("omarchy-menu toggle trigger.capture.screenrecord")
+    } else if (root.paused) {
+      root.bar.run("omarchy-capture-screenrecording --pause-recording")
+    } else {
+      root.bar.run("omarchy-capture-screenrecording --stop-recording")
     }
   }
 }

--- a/shell/plugins/bar/indicators/ScreenRecording.qml
+++ b/shell/plugins/bar/indicators/ScreenRecording.qml
@@ -16,7 +16,7 @@ BarIndicator {
 
   function refresh() {
     if (!root.bar || statusProc.running) return
-    statusProc.command = ["bash", "-c", "if pgrep -qf '^gpu-screen-recorder'; then [[ -f /tmp/omarchy-screenrecord-paused ]] && echo paused || echo recording; else echo idle; fi"]
+    statusProc.command = ["bash", "-c", "if pgrep -f '^gpu-screen-recorder' >/dev/null 2>&1; then [[ -f /tmp/omarchy-screenrecord-paused ]] && echo paused || echo recording; else echo idle; fi"]
     statusProc.running = true
   }
 
@@ -27,6 +27,17 @@ BarIndicator {
     target: root.indicatorHost
     ignoreUnknownSignals: true
     function onRefreshRequested() { root.refresh() }
+  }
+
+  // The script pokes the indicator on start/pause/stop, but that IPC can lose
+  // a race right after a shell restart and leave the indicator stuck on idle
+  // (so a mid-capture click opens the start menu instead of the chooser). A 2s
+  // tick lets the indicator catch up on its own from the marker file + pgrep.
+  Timer {
+    interval: 2000
+    running: root.bar !== null
+    repeat: true
+    onTriggered: root.refresh()
   }
 
   Process {
@@ -52,6 +63,8 @@ BarIndicator {
     if (!root.bar) return
     if (!root.recording) {
       root.bar.run("omarchy-menu toggle trigger.capture.screenrecord")
+    } else if (root.paused) {
+      root.bar.run("omarchy-capture-screenrecording --pause-recording")
     } else {
       root.bar.run("omarchy-capture-screenrecording --prompt")
     }

--- a/shell/plugins/bar/indicators/ScreenRecording.qml
+++ b/shell/plugins/bar/indicators/ScreenRecording.qml
@@ -52,10 +52,8 @@ BarIndicator {
     if (!root.bar) return
     if (!root.recording) {
       root.bar.run("omarchy-menu toggle trigger.capture.screenrecord")
-    } else if (root.paused) {
-      root.bar.run("omarchy-capture-screenrecording --pause-recording")
     } else {
-      root.bar.run("omarchy-capture-screenrecording --stop-recording")
+      root.bar.run("omarchy-capture-screenrecording --prompt")
     }
   }
 }

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -196,6 +196,10 @@ ShellRoot {
         screenRecording.recording = true
         screenRecording.triggerPress(Qt.LeftButton)
         root.assertTrue(root.commandCount("omarchy-capture-screenrecording --stop-recording") === 1, "Screen Recording left click stops active recording")
+        screenRecording.paused = true
+        screenRecording.triggerPress(Qt.LeftButton)
+        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --pause-recording") === 1, "Screen Recording left click resumes a paused recording")
+        screenRecording.paused = false
       }
 
       var dictation = root.createIndicator("Dictation")

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -198,7 +198,7 @@ ShellRoot {
         root.assertTrue(root.commandCount("omarchy-capture-screenrecording --prompt") === 1, "Screen Recording mid-capture click prompts for stop or pause")
         screenRecording.paused = true
         screenRecording.triggerPress(Qt.LeftButton)
-        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --prompt") === 2, "Screen Recording paused click prompts for stop or resume")
+        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --pause-recording") === 1, "Screen Recording paused click resumes the capture")
         screenRecording.paused = false
       }
 

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -195,10 +195,10 @@ ShellRoot {
         root.assertTrue(root.commandCount("omarchy-menu toggle trigger.capture.screenrecord") === 1, "Screen Recording left click opens capture menu when idle")
         screenRecording.recording = true
         screenRecording.triggerPress(Qt.LeftButton)
-        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --stop-recording") === 1, "Screen Recording left click stops active recording")
+        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --prompt") === 1, "Screen Recording mid-capture click prompts for stop or pause")
         screenRecording.paused = true
         screenRecording.triggerPress(Qt.LeftButton)
-        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --pause-recording") === 1, "Screen Recording left click resumes a paused recording")
+        root.assertTrue(root.commandCount("omarchy-capture-screenrecording --prompt") === 2, "Screen Recording paused click prompts for stop or resume")
         screenRecording.paused = false
       }
 

--- a/test/shell.d/screenrecording-pause-test.sh
+++ b/test/shell.d/screenrecording-pause-test.sh
@@ -49,14 +49,14 @@ export OMARCHY_TEST_NOTIF_ARGS="$tmp_dir/notif.log"
 : >"$OMARCHY_TEST_PKILL_LOG"
 : >"$OMARCHY_TEST_NOTIF_ARGS"
 
-# Active recording -> pause creates the marker, sends SIGUSR1, and notifies.
+# Active recording -> pause creates the marker, sends SIGUSR2, and notifies.
 OMARCHY_TEST_REC_ACTIVE=true "$ROOT/bin/omarchy-capture-screenrecording" --pause-recording
 [[ -f $PAUSED_FILE ]] || fail "pause creates the paused marker file"
-grep -qx -- '-SIGUSR1 -f ^gpu-screen-recorder' "$OMARCHY_TEST_PKILL_LOG" || \
-  fail "pause signals SIGUSR1 to gpu-screen-recorder" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
+grep -qx -- '-SIGUSR2 -f ^gpu-screen-recorder' "$OMARCHY_TEST_PKILL_LOG" || \
+  fail "pause signals SIGUSR2 to gpu-screen-recorder" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
 grep -Fx -- 'Recording paused' "$OMARCHY_TEST_NOTIF_ARGS" || \
   fail "pause notifies that recording paused" "$(cat "$OMARCHY_TEST_NOTIF_ARGS")"
-pass "pause signals SIGUSR1, sets the marker, and notifies"
+pass "pause signals SIGUSR2, sets the marker, and notifies"
 
 # Second toggle -> resume removes the marker and notifies.
 OMARCHY_TEST_REC_ACTIVE=true "$ROOT/bin/omarchy-capture-screenrecording" --pause-recording
@@ -65,12 +65,12 @@ grep -Fx -- 'Recording resumed' "$OMARCHY_TEST_NOTIF_ARGS" || \
   fail "resume notifies that recording resumed" "$(cat "$OMARCHY_TEST_NOTIF_ARGS")"
 pass "resume clears the marker and notifies"
 
-# Toggling twice sent SIGUSR1 both times (pause then resume), never SIGINT.
-[[ $(grep -c -- '-SIGUSR1' "$OMARCHY_TEST_PKILL_LOG") -eq 2 ]] || \
-  fail "pause/resume only ever sends SIGUSR1" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
+# Toggling twice sent SIGUSR2 both times (pause then resume), never SIGINT.
+[[ $(grep -c -- '-SIGUSR2' "$OMARCHY_TEST_PKILL_LOG") -eq 2 ]] || \
+  fail "pause/resume only ever sends SIGUSR2" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
 ! grep -q -- '-SIGINT' "$OMARCHY_TEST_PKILL_LOG" || \
   fail "pause/resume never sends the stop signal" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
-pass "pause/resume toggles only SIGUSR1"
+pass "pause/resume toggles only SIGUSR2"
 
 # No active recording -> --pause-recording is a no-op that exits nonzero.
 : >"$OMARCHY_TEST_PKILL_LOG"

--- a/test/shell.d/screenrecording-pause-test.sh
+++ b/test/shell.d/screenrecording-pause-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$PAUSED_FILE"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+# The dispatch under test hardcodes /tmp/omarchy-screenrecord-paused (matching
+# the existing /tmp/omarchy-screenrecord-filename convention), so the test has
+# to own that path directly rather than isolate it under $tmp_dir.
+PAUSED_FILE="/tmp/omarchy-screenrecord-paused"
+rm -f "$PAUSED_FILE"
+
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+[[ ${OMARCHY_TEST_REC_ACTIVE:-true} == "true" ]]
+SH
+
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_PKILL_LOG"
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >>"$OMARCHY_TEST_NOTIF_ARGS"
+SH
+
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+mkdir -p "$tmp_dir/videos"
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export HOME="$tmp_dir/home"
+mkdir -p "$HOME"
+export XDG_VIDEOS_DIR="$tmp_dir/videos"
+export OMARCHY_TEST_PKILL_LOG="$tmp_dir/pkill.log"
+export OMARCHY_TEST_NOTIF_ARGS="$tmp_dir/notif.log"
+: >"$OMARCHY_TEST_PKILL_LOG"
+: >"$OMARCHY_TEST_NOTIF_ARGS"
+
+# Active recording -> pause creates the marker, sends SIGUSR1, and notifies.
+OMARCHY_TEST_REC_ACTIVE=true "$ROOT/bin/omarchy-capture-screenrecording" --pause-recording
+[[ -f $PAUSED_FILE ]] || fail "pause creates the paused marker file"
+grep -qx -- '-SIGUSR1 -f ^gpu-screen-recorder' "$OMARCHY_TEST_PKILL_LOG" || \
+  fail "pause signals SIGUSR1 to gpu-screen-recorder" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
+grep -Fx -- 'Recording paused' "$OMARCHY_TEST_NOTIF_ARGS" || \
+  fail "pause notifies that recording paused" "$(cat "$OMARCHY_TEST_NOTIF_ARGS")"
+pass "pause signals SIGUSR1, sets the marker, and notifies"
+
+# Second toggle -> resume removes the marker and notifies.
+OMARCHY_TEST_REC_ACTIVE=true "$ROOT/bin/omarchy-capture-screenrecording" --pause-recording
+[[ ! -f $PAUSED_FILE ]] || fail "resume clears the paused marker file"
+grep -Fx -- 'Recording resumed' "$OMARCHY_TEST_NOTIF_ARGS" || \
+  fail "resume notifies that recording resumed" "$(cat "$OMARCHY_TEST_NOTIF_ARGS")"
+pass "resume clears the marker and notifies"
+
+# Toggling twice sent SIGUSR1 both times (pause then resume), never SIGINT.
+[[ $(grep -c -- '-SIGUSR1' "$OMARCHY_TEST_PKILL_LOG") -eq 2 ]] || \
+  fail "pause/resume only ever sends SIGUSR1" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
+! grep -q -- '-SIGINT' "$OMARCHY_TEST_PKILL_LOG" || \
+  fail "pause/resume never sends the stop signal" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
+pass "pause/resume toggles only SIGUSR1"
+
+# No active recording -> --pause-recording is a no-op that exits nonzero.
+: >"$OMARCHY_TEST_PKILL_LOG"
+if OMARCHY_TEST_REC_ACTIVE=false "$ROOT/bin/omarchy-capture-screenrecording" --pause-recording; then
+  fail "pause with no active recording exits nonzero"
+fi
+[[ ! -f $PAUSED_FILE ]] || fail "pause with no active recording leaves no marker"
+[[ ! -s $OMARCHY_TEST_PKILL_LOG ]] || fail "pause with no active recording sends no signal" "$(cat "$OMARCHY_TEST_PKILL_LOG")"
+pass "pause with no active recording is a non-signaling no-op"

--- a/test/shell.d/screenrecording-prompt-test.sh
+++ b/test/shell.d/screenrecording-prompt-test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$PAUSED_FILE" "$RECORDING_FILE"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+PAUSED_FILE="/tmp/omarchy-screenrecord-paused"
+RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
+PGREP_STATE="$tmp_dir/pgrep-state"
+PKILL_LOG="$tmp_dir/pkill.log"
+SELECT_LOG="$tmp_dir/select.log"
+MENU_LOG="$tmp_dir/menu.log"
+NOTIF_LOG="$tmp_dir/notif.log"
+
+rm -f "$PAUSED_FILE" "$RECORDING_FILE"
+echo active >"$PGREP_STATE"
+
+# First call returns active and flips to inactive so stop_screenrecording's wait
+# loop exits without a 5s spin. Tests reset the state file per case.
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+state=$(cat "$OMARCHY_TEST_PGREP_STATE" 2>/dev/null || echo active)
+if [[ $state == active ]]; then
+  echo inactive >"$OMARCHY_TEST_PGREP_STATE"
+  exit 0
+else
+  exit 1
+fi
+SH
+
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_PKILL_LOG"
+exit 0
+SH
+
+# omarchy-menu-select returns the choice the test pinned, or exits 1 for cancel.
+cat >"$stub_bin/omarchy-menu-select" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >>"$OMARCHY_TEST_SELECT_LOG"
+if [[ ${OMARCHY_TEST_SELECT_CANCEL:-false} == "true" ]]; then exit 1; fi
+printf '%s\n' "${OMARCHY_TEST_SELECT_CHOICE:-}"
+SH
+
+cat >"$stub_bin/omarchy-menu" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_MENU_LOG"
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >>"$OMARCHY_TEST_NOTIF_LOG"
+SH
+
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+# stop_screenrecording calls ffmpeg/ffprobe for finalize + preview; stub them so
+# the path completes without the real binaries. ffmpeg touches .mp4 outputs so
+# finalize's `mv` finds the processed file and doesn't noise up stderr.
+cat >"$stub_bin/ffmpeg" <<'SH'
+#!/bin/bash
+for a in "$@"; do [[ $a == *.mp4 ]] && touch -- "$a"; done
+exit 0
+SH
+cat >"$stub_bin/ffprobe" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+mkdir -p "$tmp_dir/videos"
+# stop_screenrecording reads the in-progress filename from $RECORDING_FILE and
+# builds a preview path from it; give it a real file so that path is valid.
+fake_recording="$tmp_dir/fake-recording.mp4"
+: >"$fake_recording"
+echo "$fake_recording" >"$RECORDING_FILE"
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export HOME="$tmp_dir/home"
+mkdir -p "$HOME"
+export XDG_VIDEOS_DIR="$tmp_dir/videos"
+export OMARCHY_TEST_PGREP_STATE="$PGREP_STATE"
+export OMARCHY_TEST_PKILL_LOG="$PKILL_LOG"
+export OMARCHY_TEST_SELECT_LOG="$SELECT_LOG"
+export OMARCHY_TEST_MENU_LOG="$MENU_LOG"
+export OMARCHY_TEST_NOTIF_LOG="$NOTIF_LOG"
+export OMARCHY_TEST_SELECT_CANCEL=false
+export OMARCHY_TEST_SELECT_CHOICE=""
+
+run_prompt() {
+  echo active >"$PGREP_STATE"
+  rm -f "$PAUSED_FILE"
+  : >"$PKILL_LOG"
+  "$ROOT/bin/omarchy-capture-screenrecording" --prompt
+}
+
+# Pause choice -> SIGUSR1, marker set, no SIGINT.
+OMARCHY_TEST_SELECT_CHOICE="Pause recording" run_prompt
+[[ -f $PAUSED_FILE ]] || fail "pause choice creates the paused marker"
+grep -qx -- '-SIGUSR1 -f ^gpu-screen-recorder' "$PKILL_LOG" || \
+  fail "pause choice sends SIGUSR1" "$(cat "$PKILL_LOG")"
+! grep -q -- '-SIGINT' "$PKILL_LOG" || fail "pause choice does not send SIGINT"
+pass "pause choice pauses the capture without stopping"
+
+# Resume choice (marker pre-set) -> SIGUSR1, marker cleared.
+echo active >"$PGREP_STATE"
+touch "$PAUSED_FILE"
+: >"$PKILL_LOG"
+OMARCHY_TEST_SELECT_CHOICE="Resume recording" "$ROOT/bin/omarchy-capture-screenrecording" --prompt
+[[ ! -f $PAUSED_FILE ]] || fail "resume choice clears the paused marker"
+grep -qx -- '-SIGUSR1 -f ^gpu-screen-recorder' "$PKILL_LOG" || \
+  fail "resume choice sends SIGUSR1" "$(cat "$PKILL_LOG")"
+pass "resume choice resumes the capture"
+
+# Stop choice -> SIGINT, never SIGUSR1.
+echo active >"$PGREP_STATE"
+rm -f "$PAUSED_FILE"
+: >"$PKILL_LOG"
+OMARCHY_TEST_SELECT_CHOICE="Stop recording" "$ROOT/bin/omarchy-capture-screenrecording" --prompt
+grep -qx -- '-SIGINT -f ^gpu-screen-recorder' "$PKILL_LOG" || \
+  fail "stop choice sends SIGINT" "$(cat "$PKILL_LOG")"
+! grep -q -- '-SIGUSR1' "$PKILL_LOG" || fail "stop choice does not send SIGUSR1"
+pass "stop choice stops the capture"
+
+# The picker gets the right options per state: pause option when recording,
+# resume option when paused.
+echo active >"$PGREP_STATE"
+rm -f "$PAUSED_FILE"
+: >"$SELECT_LOG"
+OMARCHY_TEST_SELECT_CHOICE="Pause recording" "$ROOT/bin/omarchy-capture-screenrecording" --prompt >/dev/null
+grep -Fx -- 'Screen recording' "$SELECT_LOG" >/dev/null || fail "picker prompt is 'Screen recording'" "$(cat "$SELECT_LOG")"
+grep -Fq -- $'\uf04c\tPause recording' "$SELECT_LOG" || fail "recording state offers Pause" "$(cat "$SELECT_LOG")"
+grep -Fq -- $'\uf04d\tStop recording' "$SELECT_LOG" || fail "recording state offers Stop" "$(cat "$SELECT_LOG")"
+! grep -Fq -- $'\uf04b\tResume recording' "$SELECT_LOG" || fail "recording state does not offer Resume" "$(cat "$SELECT_LOG")"
+
+echo active >"$PGREP_STATE"
+touch "$PAUSED_FILE"
+: >"$SELECT_LOG"
+OMARCHY_TEST_SELECT_CHOICE="Resume recording" "$ROOT/bin/omarchy-capture-screenrecording" --prompt >/dev/null
+grep -Fq -- $'\uf04b\tResume recording' "$SELECT_LOG" || fail "paused state offers Resume" "$(cat "$SELECT_LOG")"
+grep -Fq -- $'\uf04d\tStop recording' "$SELECT_LOG" || fail "paused state offers Stop" "$(cat "$SELECT_LOG")"
+! grep -Fq -- $'\uf04c\tPause recording' "$SELECT_LOG" || fail "paused state does not offer Pause" "$(cat "$SELECT_LOG")"
+pass "picker offers the two actions valid for the current state"
+
+# Cancel -> nothing runs, exits nonzero, no signal.
+echo active >"$PGREP_STATE"
+: >"$PKILL_LOG"
+if OMARCHY_TEST_SELECT_CANCEL=true "$ROOT/bin/omarchy-capture-screenrecording" --prompt; then
+  fail "cancel exits nonzero"
+fi
+[[ ! -s $PKILL_LOG ]] || fail "cancel sends no signal" "$(cat "$PKILL_LOG")"
+pass "cancel sends no signal and exits nonzero"
+
+# No active recording -> --prompt opens the start menu, sends no signal.
+echo inactive >"$PGREP_STATE"
+: >"$MENU_LOG"
+: >"$PKILL_LOG"
+"$ROOT/bin/omarchy-capture-screenrecording" --prompt
+grep -Fx -- 'toggle trigger.capture.screenrecord' "$MENU_LOG" >/dev/null || \
+  fail "idle prompt opens the screenrecord menu" "$(cat "$MENU_LOG")"
+[[ ! -s $PKILL_LOG ]] || fail "idle prompt sends no signal" "$(cat "$PKILL_LOG")"
+pass "idle prompt opens the start menu instead of signaling"

--- a/test/shell.d/screenrecording-prompt-test.sh
+++ b/test/shell.d/screenrecording-prompt-test.sh
@@ -104,32 +104,32 @@ run_prompt() {
   "$ROOT/bin/omarchy-capture-screenrecording" --prompt
 }
 
-# Pause choice -> SIGUSR1, marker set, no SIGINT.
+# Pause choice -> SIGUSR2, marker set, no SIGINT.
 OMARCHY_TEST_SELECT_CHOICE="Pause recording" run_prompt
 [[ -f $PAUSED_FILE ]] || fail "pause choice creates the paused marker"
-grep -qx -- '-SIGUSR1 -f ^gpu-screen-recorder' "$PKILL_LOG" || \
-  fail "pause choice sends SIGUSR1" "$(cat "$PKILL_LOG")"
+grep -qx -- '-SIGUSR2 -f ^gpu-screen-recorder' "$PKILL_LOG" || \
+  fail "pause choice sends SIGUSR2" "$(cat "$PKILL_LOG")"
 ! grep -q -- '-SIGINT' "$PKILL_LOG" || fail "pause choice does not send SIGINT"
 pass "pause choice pauses the capture without stopping"
 
-# Resume choice (marker pre-set) -> SIGUSR1, marker cleared.
+# Resume choice (marker pre-set) -> SIGUSR2, marker cleared.
 echo active >"$PGREP_STATE"
 touch "$PAUSED_FILE"
 : >"$PKILL_LOG"
 OMARCHY_TEST_SELECT_CHOICE="Resume recording" "$ROOT/bin/omarchy-capture-screenrecording" --prompt
 [[ ! -f $PAUSED_FILE ]] || fail "resume choice clears the paused marker"
-grep -qx -- '-SIGUSR1 -f ^gpu-screen-recorder' "$PKILL_LOG" || \
-  fail "resume choice sends SIGUSR1" "$(cat "$PKILL_LOG")"
+grep -qx -- '-SIGUSR2 -f ^gpu-screen-recorder' "$PKILL_LOG" || \
+  fail "resume choice sends SIGUSR2" "$(cat "$PKILL_LOG")"
 pass "resume choice resumes the capture"
 
-# Stop choice -> SIGINT, never SIGUSR1.
+# Stop choice -> SIGINT, never SIGUSR2.
 echo active >"$PGREP_STATE"
 rm -f "$PAUSED_FILE"
 : >"$PKILL_LOG"
 OMARCHY_TEST_SELECT_CHOICE="Stop recording" "$ROOT/bin/omarchy-capture-screenrecording" --prompt
 grep -qx -- '-SIGINT -f ^gpu-screen-recorder' "$PKILL_LOG" || \
   fail "stop choice sends SIGINT" "$(cat "$PKILL_LOG")"
-! grep -q -- '-SIGUSR1' "$PKILL_LOG" || fail "stop choice does not send SIGUSR1"
+! grep -q -- '-SIGUSR2' "$PKILL_LOG" || fail "stop choice does not send SIGUSR2"
 pass "stop choice stops the capture"
 
 # The picker gets the right options per state: pause option when recording,


### PR DESCRIPTION
Closes #7479.

## What

`gpu-screen-recorder` already supports pause, but Omarchy only ever stopped a recording (SIGINT). This adds pause/resume so a capture can be held and continued on the same file, plus a focused chooser so a mid-recording click no longer destroys the take on the first click.

### Behavior

- **Idle** — clicking the bar indicator opens the capture menu (start options), unchanged.
- **Recording** — the indicator shows the record icon. Clicking it opens a small menu with **only Pause and Stop** (not the full start menu).
  - **Pause** — the capture pauses (indicator switches to the pause icon).
  - **Stop** — stops and saves like before.
- **Paused** — clicking the pause icon **resumes** directly (one click to continue).
- The Capture menu (Super+Ctrl+C → Screenrecord) gains **Stop / Pause / Resume** rows that appear/disappear based on state (Pause hides when paused; Resume appears instead).

## How

- **`omarchy-capture-screenrecording --pause-recording`** — toggles pause by sending `SIGUSR2` to the running process and flips a `/tmp/omarchy-screenrecord-paused` marker file (the process won't report paused state back, so the marker is the source of truth). `start` and `stop` both clear the marker so a crashed session can't invert the next recording's first toggle.
- **`omarchy-capture-screenrecording --prompt`** — presents the Pause/Stop chooser via `omarchy-menu-select` (the picker offers exactly the actions valid for the current state).
- **Indicator (`ScreenRecording.qml`)** — polls every 2s (`pgrep -f ... >/dev/null` + the marker file) so it reflects state on its own, rather than relying solely on the script's IPC poke (which races the shell right after a restart). Uses `pgrep -f ... >/dev/null` rather than `pgrep -qf` because this build's `pgrep` has no short `-q` flag.
- **Menu** — `trigger.capture.screenrecord.pause` / `.resume` entries gated on `pgrep` active ± the marker file.

## Why SIGUSR2

`SIGUSR1` is "save replay" — a no-op for regular recording, so the marker flipped and the icon changed but the capture kept going. The gsr 6.0 man page lists `SIGUSR2` as the pause/unpause signal for regular recording.

## Tests

- `screenrecording-pause-test.sh` — pause creates the marker + sends SIGUSR2; resume clears it; only SIGUSR2 is ever sent (never SIGINT); pause with no active recording is a non-signaling no-op.
- `screenrecording-prompt-test.sh` — the chooser dispatches pause/resume/stop correctly, offers the right two options per state, cancel sends nothing, idle opens the start menu.
- `indicator-contract` — idle/recording/paused indicator clicks dispatch to the right command.
- `menu-test`, `menu-guards`, `bin-style`, and the CLI metadata suite all pass.

## Notes for review

- Verified live on a Hyprland desktop: indicator reflects recording/paused state, the Pause/Stop chooser appears on a mid-capture click, Pause switches to the pause icon and actually pauses the capture, and a paused click resumes.
- All changes are package-owned files (`/usr/bin/omarchy-capture-screenrecording`, `/usr/share/omarchy/shell/.../ScreenRecording.qml`, `/usr/share/omarchy/default/omarchy/omarchy-menu.jsonc`) — no new dependencies, no font change, no user config migration, so this ships cleanly in a package update.