### PR TITLE
Add wallpaper portal backend so Files' Set as Background works

### DIFF
--- a/bin/omarchy-portal-wallpaper
+++ b/bin/omarchy-portal-wallpaper
@@ -1,0 +1,126 @@
+#!/usr/bin/python3
+# omarchy:summary=xdg-desktop-portal wallpaper backend for Omarchy
+# omarchy:hidden=true
+"""D-Bus backend for org.freedesktop.impl.portal.Wallpaper.
+
+Lets portal-aware apps (Nautilus "Set as Background", browsers, GNOME apps)
+set the Omarchy desktop background. Requests are forwarded to
+omarchy-theme-bg-set, which adopts the image into the current theme's user
+background collection and updates the live shell background.
+
+Activated on demand by D-Bus via /usr/share/dbus-1/services/.
+"""
+
+import subprocess
+from urllib.parse import unquote, urlparse
+
+from gi.repository import Gio, GLib
+
+BUS_NAME = "org.freedesktop.impl.portal.desktop.omarchy"
+OBJECT_PATH = "/org/freedesktop/portal/desktop"
+
+RESPONSE_SUCCESS = 0
+RESPONSE_ERROR = 2
+
+WALLPAPER_XML = """
+<node>
+  <interface name="org.freedesktop.impl.portal.Wallpaper">
+    <method name="SetWallpaperURI">
+      <arg type="o" name="handle" direction="in"/>
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="s" name="parent_window" direction="in"/>
+      <arg type="s" name="uri" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="u" name="response" direction="out"/>
+    </method>
+  </interface>
+</node>
+"""
+
+REQUEST_XML = """
+<node>
+  <interface name="org.freedesktop.impl.portal.Request">
+    <method name="Close"/>
+    <signal name="Response">
+      <arg type="u" name="response"/>
+      <arg type="a{sv}" name="results"/>
+    </signal>
+  </interface>
+</node>
+"""
+
+request_node = Gio.DBusNodeInfo.new_for_xml(REQUEST_XML)
+request_registrations = {}
+
+
+def uri_to_path(uri):
+    parsed = urlparse(uri or "")
+    if parsed.scheme != "file":
+        return None
+    return unquote(parsed.path)
+
+
+def apply_wallpaper(uri, options):
+    set_on = options.get("set-on", "background")
+    if set_on not in ("background", "both"):
+        # The Omarchy lock screen takes its background from the theme.
+        # Accept the request so apps don't treat it as an error.
+        return RESPONSE_SUCCESS
+
+    path = uri_to_path(uri)
+    if not path:
+        return RESPONSE_ERROR
+
+    result = subprocess.run(
+        ["omarchy-theme-bg-set", path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return RESPONSE_SUCCESS if result.returncode == 0 else RESPONSE_ERROR
+
+
+def on_request_close(connection, sender, path, interface, method, parameters, invocation):
+    registration = request_registrations.pop(path, None)
+    if registration is not None:
+        connection.unregister_object(registration)
+    invocation.return_value(None)
+
+
+def on_set_wallpaper_uri(connection, sender, path, interface, method, parameters, invocation):
+    handle, _app_id, _parent_window, uri, options = parameters.unpack()
+    response = apply_wallpaper(uri, options)
+
+    # The frontend reads the result from this method's return value, but the
+    # request object must exist so it can forward a client Close call.
+    registration = connection.register_object(
+        handle, request_node.interfaces[0], on_request_close, None, None
+    )
+    request_registrations[handle] = registration
+
+    invocation.return_value(GLib.Variant("(u)", (response,)))
+
+
+def on_bus_acquired(connection, name):
+    # Register before the name is visible on the bus, so calls queued behind
+    # D-Bus activation never race the object registration.
+    node = Gio.DBusNodeInfo.new_for_xml(WALLPAPER_XML)
+    connection.register_object(
+        OBJECT_PATH, node.interfaces[0], on_set_wallpaper_uri, None, None
+    )
+
+
+def on_name_lost(connection, name):
+    loop.quit()
+
+
+loop = GLib.MainLoop()
+Gio.bus_own_name(
+    Gio.BusType.SESSION,
+    BUS_NAME,
+    Gio.BusNameOwnerFlags.NONE,
+    on_bus_acquired,
+    None,
+    on_name_lost,
+)
+loop.run()

--- a/bin/omarchy-theme-bg-set
+++ b/bin/omarchy-theme-bg-set
@@ -11,10 +11,32 @@ fi
 
 BACKGROUND="$(realpath "$1")"
 CURRENT_BACKGROUND_LINK="$HOME/.local/state/omarchy/current/background"
+THEME_NAME=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null)
+THEME_BACKGROUNDS_PATH=$(realpath "$HOME/.local/state/omarchy/current/theme/backgrounds" 2>/dev/null)
+USER_BACKGROUNDS_PATH="$HOME/.config/omarchy/backgrounds/$THEME_NAME"
 
 if [[ ! -f $BACKGROUND ]]; then
   echo "File does not exist: $BACKGROUND" >&2
   exit 1
+fi
+
+# Adopt images from outside the theme's background collections into the user's
+# per-theme collection, so they show up in the background switcher and keep
+# working even if the original file is moved or deleted.
+if [[ -n $THEME_NAME && $BACKGROUND != "$THEME_BACKGROUNDS_PATH"/* && $BACKGROUND != "$USER_BACKGROUNDS_PATH"/* ]]; then
+  case ${BACKGROUND,,} in
+    *.jpg | *.jpeg | *.png | *.gif | *.bmp | *.webp)
+      mkdir -p "$USER_BACKGROUNDS_PATH"
+      target="$USER_BACKGROUNDS_PATH/$(basename "$BACKGROUND")"
+      if [[ -e $target ]] && ! cmp -s "$BACKGROUND" "$target"; then
+        target="$USER_BACKGROUNDS_PATH/$(date +%s)-$(basename "$BACKGROUND")"
+      fi
+      if [[ ! -e $target ]]; then
+        cp "$BACKGROUND" "$target"
+      fi
+      BACKGROUND="$target"
+      ;;
+  esac
 fi
 
 # Create symlink to the new background

--- a/default/dbus-1/services/org.freedesktop.impl.portal.desktop.omarchy.service
+++ b/default/dbus-1/services/org.freedesktop.impl.portal.desktop.omarchy.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.impl.portal.desktop.omarchy
+Exec=/usr/bin/omarchy-portal-wallpaper

--- a/default/xdg-desktop-portal/portals/omarchy.portal
+++ b/default/xdg-desktop-portal/portals/omarchy.portal
@@ -1,0 +1,4 @@
+[portal]
+DBusName=org.freedesktop.impl.portal.desktop.omarchy
+Interfaces=org.freedesktop.impl.portal.Wallpaper;
+UseIn=Hyprland;

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -115,6 +115,8 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ hypr/toggles/*.lua (flags,
   │    single-window-aspect-ratio, window-no-gaps)      /etc/skel/.local/state/omarchy/toggles/hypr/
   ├─ nautilus-python/extensions/*.py                    /etc/skel/.local/share/nautilus-python/extensions/
+  ├─ xdg-desktop-portal/portals/omarchy.portal           /usr/share/xdg-desktop-portal/portals/
+  ├─ dbus-1/services/*.service                          /usr/share/dbus-1/services/
   ├─ tensaku/state.toml                                 /etc/skel/.local/state/tensaku/state.toml
   ├─ uwsm/env.d/10-omarchy                              /usr/share/uwsm/env.d/
   ├─ environment.d/*.conf                               /usr/lib/environment.d/

--- a/etc/xdg/xdg-desktop-portal/hyprland-portals.conf
+++ b/etc/xdg/xdg-desktop-portal/hyprland-portals.conf
@@ -1,0 +1,5 @@
+[preferred]
+# Mirrors /usr/share/xdg-desktop-portal/hyprland-portals.conf from
+# xdg-desktop-portal-hyprland, plus the Omarchy wallpaper backend.
+default=hyprland;gtk
+org.freedesktop.impl.portal.Wallpaper=omarchy;

--- a/manual/39-backgrounds.md
+++ b/manual/39-backgrounds.md
@@ -5,3 +5,5 @@ Every theme ships with its own set of backgrounds, and you can add extras of you
 You can do this most easily by going to _Install > Style > Background_ in the Omarchy Menu. That'll bring up the folder where the backgrounds for that theme is stored. Hit `Super + Shift + F` to start another file manager, find your background, copy it over.  Now it'll be included in the choices of backgrounds you can select between using `Super + Ctrl + Space`.
 
 You can find a huge collection of cool curated backgrounds on https://github.com/dharmx/walls.
+
+You can also right-click any image in Files and pick _Set as Background_. That sets it right away and adds a copy to the current theme's backgrounds, so it shows up in the background switcher too.

--- a/migrations/1787139516.sh
+++ b/migrations/1787139516.sh
@@ -1,0 +1,21 @@
+echo "Enable the Omarchy wallpaper portal backend for this user"
+
+# Ships the backend definition, D-Bus activation entry, and portal config into
+# user-level XDG paths so "Set as Background" in Files works without waiting
+# for the omarchy-settings package to place the system-wide copies.
+
+portal="$OMARCHY_PATH/default/xdg-desktop-portal/portals/omarchy.portal"
+service="$OMARCHY_PATH/default/dbus-1/services/org.freedesktop.impl.portal.desktop.omarchy.service"
+config="$OMARCHY_PATH/etc/xdg/xdg-desktop-portal/hyprland-portals.conf"
+
+[[ -f $portal && -f $service && -f $config ]] || exit 0
+
+mkdir -p "$HOME/.local/share/xdg-desktop-portal/portals" "$HOME/.local/share/dbus-1/services" "$HOME/.config/xdg-desktop-portal"
+cp "$portal" "$HOME/.local/share/xdg-desktop-portal/portals/"
+cp "$service" "$HOME/.local/share/dbus-1/services/"
+cp "$config" "$HOME/.config/xdg-desktop-portal/"
+
+# The session bus caches the activation service list, and xdg-desktop-portal
+# only reads portal backends and config at startup.
+gdbus call --session --dest org.freedesktop.DBus --object-path /org/freedesktop/DBus --method org.freedesktop.DBus.ReloadConfig >/dev/null || true
+systemctl --user try-restart xdg-desktop-portal.service || true


### PR DESCRIPTION
![Nautilus context menu with Set as Background](https://gist.githubusercontent.com/bitbonsai/37e768a59e5093fc022b64ffd579fce0/raw/nautilus-set-background.png)

Right-click → **Set as Background** in Nautilus does nothing on Omarchy: the `org.freedesktop.impl.portal.Wallpaper` interface has no backend on Hyprland.

This PR adds a D-Bus-activated wallpaper portal backend that forwards to `omarchy theme bg set`, and makes that command adopt external images into `~/.config/omarchy/backgrounds/<theme>/` so they show up in the background switcher and survive the original file being moved.

A migration seeds the new files for existing installs without touching the user's portal routing config. `omarchy-pkgs` needs the two new path mappings in docs/file-layout.md. Tested on Omarchy 4 / Nautilus 50.2.2, plus a user test on 4.0.3.
