### PR TITLE
Detect Apple Silicon trackpads in omarchy-hw-touchpad

### DIFF
--- a/bin/omarchy-hw-touchpad
+++ b/bin/omarchy-hw-touchpad
@@ -2,5 +2,7 @@
 
 # omarchy:summary=Print the detected Hyprland touchpad or trackpad device name
 
-device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')
+# "multi-touch" matches Apple Silicon internal trackpads, which Hyprland
+# names after the MTP HID interface (e.g. "apple-mtp-multi-touch").
+device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad|multi-touch"; "i"))] | first // empty')
 [[ -n $device ]] && echo "$device"


### PR DESCRIPTION
Hyprland names the Apple MTP trackpad after its HID interface (`apple-mtp-multi-touch`). The `touchpad|trackpad` pattern misses it, so every touchpad-guarded menu entry is hidden on Asahi Linux. This adds `multi-touch` to the pattern.

Tested on a MacBook Air M2 (J413) on Asahi Alarm: `omarchy-hw-touchpad` now prints `apple-mtp-multi-touch` and the touchpad menu entries appear. `./test/cli` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)