### PR TITLE
Show when Tailscale is routing through an exit node

### DIFF
--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -53,7 +53,33 @@ Panel {
   readonly property bool headerHasCursor: cursorActive && focusSection === "header" && tailscale.installed
   readonly property color iconColor: tailscale.active ? foreground : dim
   readonly property string toggleHint: tailscale.active ? "Turn Tailscale off" : (tailscale.needsLogin ? "Authorize this device" : "Turn Tailscale on")
+  // An active exit node routes every packet through another machine, while the
+  // link itself still looks perfectly healthy. Fills in the mark's faded dots.
+  readonly property bool routedViaExitNode: {
+    // Read both dependencies unconditionally — an early return would leave
+    // QML unaware that this binding depends on exitNodes.
+    var nodes = tailscale.exitNodes || []
+    var routed = false
+    for (var i = 0; i < nodes.length; i++) {
+      if (nodes[i] && nodes[i].ExitNode === true) routed = true
+    }
+    return routed && tailscale.active
+  }
   readonly property color barIconColor: tailscale.active ? barForeground : Qt.darker(barForeground, 1.55)
+
+  // Inline exit-node label, toggled by right-click and persisted per-widget.
+  readonly property bool showNodeName: setting("showNodeName", false) === true
+  readonly property string exitNodeName: {
+    // Same unconditional-read rule as routedViaExitNode above.
+    var nodes = tailscale.exitNodes || []
+    var name = ""
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i]
+      if (n && n.ExitNode === true && name === "") name = String(n.DisplayName || n.HostName || "")
+    }
+    return tailscale.active ? name : ""
+  }
+  readonly property bool nodeNameVisible: showNodeName && exitNodeName !== "" && !button.vertical
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
 
@@ -363,6 +389,11 @@ Panel {
     function onAccountsAccessDeniedChanged() { root.ensureCursor() }
   }
 
+  function toggleNodeName() {
+    root.settings = Object.assign({}, root.settings, { showNodeName: !root.showNodeName })
+    if (root.bar && root.bar.shell) root.bar.shell.updateEntryInline(root.moduleName, root.settings)
+  }
+
   IpcHandler {
     target: root.ipcTarget
     function open(): void { root.open() }
@@ -374,28 +405,54 @@ Panel {
     function up(): string { tailscale.loginOrUp(); return "ok" }
     function down(): string { tailscale.down(); return "ok" }
     function toggleTailscale(): string { tailscale.toggleTailscale(); return "ok" }
+    function toggleNodeName(): string { root.toggleNodeName(); return "ok" }
     function status(): string { return tailscale.statusText }
+  }
+
+  TextMetrics {
+    id: nodeLabelMetrics
+    font.family: root.fontFamily
+    font.pixelSize: Style.bar.iconFont
+    text: root.exitNodeName
   }
 
   BarIconButton {
     id: button
     anchors.fill: parent
     bar: root.bar
+    // The icon slot only fits the mark; widen it by the measured label so the
+    // Row stays centred instead of overhanging into the neighbouring widget.
+    slotSize: Style.bar.iconSlot + (root.nodeNameVisible ? nodeLabelMetrics.width + Style.space(5) : 0)
     iconComponent: Component {
       Item {
-        TailscaleIcon {
+        Row {
           anchors.centerIn: parent
-          iconSize: Style.space(11)
-          color: root.barIconColor
-          badgeColor: root.urgent
-          crossed: !tailscale.active && !tailscale.needsLogin
-          warning: tailscale.needsLogin
+          spacing: Style.space(5)
+
+          TailscaleIcon {
+            anchors.verticalCenter: parent.verticalCenter
+            iconSize: Style.space(11)
+            color: root.barIconColor
+            badgeColor: root.urgent
+            crossed: !tailscale.active && !tailscale.needsLogin
+            warning: tailscale.needsLogin
+            routed: root.routedViaExitNode
+          }
+
+          Text {
+            visible: root.nodeNameVisible
+            anchors.verticalCenter: parent.verticalCenter
+            text: root.exitNodeName
+            color: root.barIconColor
+            font.family: root.fontFamily
+            font.pixelSize: Style.bar.iconFont
+          }
         }
       }
     }
     onPressed: function(buttonCode) {
-      if (buttonCode === Qt.RightButton) tailscale.toggleTailscale()
-      else if (buttonCode === Qt.MiddleButton) tailscale.refresh()
+      if (buttonCode === Qt.RightButton) root.toggleNodeName()
+      else if (buttonCode === Qt.MiddleButton) tailscale.toggleTailscale()
       else root.toggle()
     }
   }

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -5,8 +5,10 @@ Native Omarchy bar widget for Tailscale.
 ## Features
 
 - Shows Tailscale connection state in the bar
+- Fills in the mark's faded dots while an exit node is routing traffic
 - Left click opens a keyboard-friendly panel
-- Right click toggles Tailscale on/off
+- Right click toggles the exit node name shown inline in the bar
+- Middle click toggles Tailscale on/off
 - Switch between available Tailscale connections when multiple are available
 - Browse machines from `tailscale status --json`
 - Copy a machine's Tailscale IP, host name, or DNS name
@@ -43,6 +45,12 @@ runs the same loop by hand.
 ## Icon
 
 Renders the Tailscale mark natively as a theme-colored 3×3 dot grid, matching the official SVG silhouette while avoiding tiny-SVG rendering quirks in the bar.
+
+With an exit node active the grid's faded dots come up to full opacity, so a
+tunnelled connection reads differently from a healthy direct one at a glance.
+The signal is carried by shape rather than color: on a light-on-dark bar the
+resting mark is already near-white, so any tint would *lower* contrast and read
+as dimmed rather than lit.
 
 ## Add to the bar
 

--- a/shell/plugins/panels/tailscale/TailscaleIcon.qml
+++ b/shell/plugins/panels/tailscale/TailscaleIcon.qml
@@ -10,6 +10,7 @@ Item {
   property color badgeColor: Color.urgent
   property bool crossed: false
   property bool warning: false
+  property bool routed: false
 
   width: iconSize
   height: iconSize
@@ -23,15 +24,15 @@ Item {
   // Native rendering of the Tailscale mark from the SVG: a 3×3 dot grid
   // with the inactive dots faded. This avoids Qt SVG/effect rendering quirks
   // in tiny bar slots while keeping the official silhouette.
-  Dot { x: 0; y: 0; opacity: 0.24 }
-  Dot { x: root.mid; y: 0; opacity: 0.24 }
-  Dot { x: root.end; y: 0; opacity: 0.24 }
+  Dot { x: 0; y: 0; opacity: root.routed ? 1.0 : 0.24 }
+  Dot { x: root.mid; y: 0; opacity: root.routed ? 1.0 : 0.24 }
+  Dot { x: root.end; y: 0; opacity: root.routed ? 1.0 : 0.24 }
   Dot { x: 0; y: root.mid; opacity: 1.0 }
   Dot { x: root.mid; y: root.mid; opacity: 1.0 }
   Dot { x: root.end; y: root.mid; opacity: 1.0 }
-  Dot { x: 0; y: root.end; opacity: 0.24 }
+  Dot { x: 0; y: root.end; opacity: root.routed ? 1.0 : 0.24 }
   Dot { x: root.mid; y: root.end; opacity: 1.0 }
-  Dot { x: root.end; y: root.end; opacity: 0.24 }
+  Dot { x: root.end; y: root.end; opacity: root.routed ? 1.0 : 0.24 }
 
   Rectangle {
     visible: root.crossed

--- a/shell/plugins/panels/tailscale/manifest.json
+++ b/shell/plugins/panels/tailscale/manifest.json
@@ -19,7 +19,8 @@
     "allowMultiple": false,
     "defaultSection": "right",
     "defaults": {
-      "refreshIntervalSec": 30
+      "refreshIntervalSec": 30,
+      "showNodeName": false
     },
     "schema": [
       {
@@ -30,6 +31,12 @@
         "max": 3600,
         "step": 5,
         "defaultValue": 30
+      },
+      {
+        "key": "showNodeName",
+        "type": "boolean",
+        "label": "Show exit node name in bar",
+        "defaultValue": false
       }
     ]
   }


### PR DESCRIPTION
## The problem

The bar widget renders an exit-node connection identically to a direct one. Both states are just the lit Tailscale mark, so traffic can be tunnelled through a machine on another continent with nothing in the bar to say so.

That failure mode is quiet and expensive. Diagnosing it on my laptop today, the Wi-Fi link itself looked flawless — 6 GHz, -39 dBm, 2402/1201 Mbit PHY, zero retries — while actual throughput sat at a fraction of the line rate:

| | via exit node | direct |
|---|---|---|
| Latency to 1.1.1.1 | 114 ms | 3.3 ms |
| Bulk download (25 MB) | 90–117 Mbit/s | 590–730 Mbit/s |
| Short transfer (3 MB) | 20 Mbit/s | 175 Mbit/s |

Every layer reports healthy. The only clue is a widget that looks exactly the same either way.

## The change

**Fill in the mark's faded dots while an exit node is active.** The mark is already a 3×3 grid with five dots at 24% opacity, so this is free geometry — crisp at bar scale, and the silhouette stays recognisably Tailscale.

**Optional inline node name**, off by default, right click to toggle. Persisted per-widget via `updateEntryInline`, the same mechanism as the power widget's `showPercentage`, and exposed in the manifest schema plus over IPC as `toggleNodeName`.

## Two notes for review

**Shape rather than color, on purpose.** I tried tinting the icon with `Color.accent` first and it backfires: on a light-on-dark bar the resting mark is already near-white, so any tint *lowers* contrast. Measured against the bar background, `#F6F4EC` → `#6b7fbe` drops 16.8:1 to 4.8:1. The icon got quieter exactly when it needed to get louder, and read as disabled. I also tried an overlaid arrow badge — at the icon's 22 physical px a badge glyph gets ~12 px, which is why the existing `!` warning badge works (single stroke) and why anything more detailed turns to mush.

**This changes an existing binding, which is the part worth arguing about.** Right click currently toggles Tailscale on/off; it now toggles the label, and on/off moves to middle click (refresh stays on `r` in the panel). My reasoning is that right-clicking a tray icon is a lot of destructive power for an accidental gesture — it drops your whole tailnet — and the battery widget already establishes right-click-toggles-inline-detail as the convention. Happy to put the label on middle click and leave right click alone if you'd rather not move it.

`BarIconButton` renders either `text` or `iconComponent`, never both, so unlike the power widget the label had to go in a `Row` inside the icon component, with the slot widened by a `TextMetrics` measurement rather than power's fixed `iconSlot * 2` (hostnames vary in length).

## Testing

Verified against a live exit node on my own tailnet, both states captured from the real bar. The right-click handler calls `toggleNodeName()`, which I exercised end-to-end over IPC and confirmed round-trips `showNodeName` into `shell.json` and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)