### PR TITLE
Show the hourglass while dictation is transcribing

### DIFF
--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -8,7 +8,7 @@ BarIndicator {
   property string state: "idle"
   property string icon: ""
 
-  active: state === "recording"
+  active: state === "recording" || state === "transcribing"
   activeText: icon
   inactiveText: "󰍬"
   activeTooltipText: state

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -206,6 +206,14 @@ ShellRoot {
         dictation.triggerPress(Qt.RightButton)
         root.assertTrue(root.commandCount("omarchy-voxtype-config") === 2, "Dictation clicks run config command")
         root.assertTrue(root.commandCount("omarchy-voxtype-model") === 0, "Dictation clicks do not run model command")
+        dictation.update('{"class":"transcribing"}')
+        root.assertTrue(dictation.effectiveActive === true, "Dictation indicator is active while transcribing")
+        root.assertTrue(dictation.icon === "󰔟", "Dictation transcribing icon is the hourglass")
+        root.assertTrue(dictation.text === dictation.icon, "Dictation indicator shows the transcribing icon while active")
+        dictation.update('{"class":"idle"}')
+        root.assertTrue(dictation.effectiveActive === false, "Dictation indicator is inactive when idle")
+        dictation.update('{"class":"recording"}')
+        root.assertTrue(dictation.effectiveActive === true, "Dictation indicator is active while recording")
       }
 
       var stayAwake = root.createIndicator("StayAwake")


### PR DESCRIPTION
## Problem

The Dictation indicator sets the hourglass icon for the `transcribing` state, but `active` was only true during `recording`. As a result, `BarIndicator` rendered the inactive microphone instead of the hourglass while Voxtype was transcribing.

## Fix

Treat both `recording` and `transcribing` as active states.

## Test plan

- Extended the indicator contract test for recording, transcribing, and idle states.
- Confirmed the test fails with the old implementation.
- Confirmed `./test/shell.d/indicator-contract-test.sh` passes with the fix.
- Verified visually that the hourglass appears in the top bar during transcription.

Visual Verification: 

https://github.com/user-attachments/assets/dd2ef11c-6e4e-49bb-9149-10bd82898292

