### PR TITLE
Fall back to polkit when the DNS sudoers grant is missing

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -33,45 +33,28 @@ provider_from_arg() {
 # where $OMARCHY_PATH points at a checkout.
 PACKAGED_PATH=/usr/bin/omarchy-dns
 
-# True when etc/sudoers.d/omarchy-dns covers this invocation. Both halves of the
-# rule have to hold -- one of the three providers, and %wheel -- or sudo asks
-# for a password like any other command.
-grant_covers() {
-  local provider="${1:-}"
-  local group
-
-  case "$provider" in
-  Cloudflare | Google | DHCP) ;;
-  *) return 1 ;;
-  esac
-
-  for group in $(id -nG 2>/dev/null); do
-    [[ $group == wheel ]] && return 0
-  done
-
-  return 1
+# True when sudo would run this exact command without stopping for a password.
+# `sudo -l` on its own reports whether a command is permitted, which the blanket
+# %wheel rule answers yes to for everything; the long listing prints the matched
+# entry's tags, so !authenticate is the grant in etc/sudoers.d/omarchy-dns and
+# nothing else. Listing runs nothing and, under -n, prompts for nothing, so a
+# machine whose omarchy-settings predates that file falls through to polkit
+# instead of dying on a password prompt it has no terminal to show.
+sudo_grants_passwordless() {
+  sudo -n -l -l "$PACKAGED_PATH" "$@" 2>/dev/null | grep -q '!authenticate'
 }
 
 require_root() {
   if (( EUID == 0 )); then
     return
-  fi
-
-  # A terminal can carry sudo's own password prompt. Without one, sudo is still
-  # right when etc/sudoers.d/omarchy-dns covers this invocation: that grant is
-  # what keeps the panel's one-click provider switch from raising a polkit
-  # prompt. Custom and a caller outside %wheel still go through polkit, which
-  # can at least offer to authenticate as someone else.
-  #
-  # Do not swap this for a `sudo -n -l` probe. That reports whether a command is
-  # permitted, not whether it is passwordless, so the blanket %wheel rule
-  # answers yes for every argument and Custom dies on `sudo -n` instead of
-  # falling through to pkexec.
-  if [[ -t 0 ]] || grant_covers "${1:-}"; then
+  elif [[ -t 0 ]] || sudo_grants_passwordless "$@"; then
+    # A terminal can carry sudo's own password prompt. Without one, sudo is
+    # right only where the grant reaches; polkit can at least put a prompt on
+    # screen, and offer to authenticate as someone else.
     exec sudo "$PACKAGED_PATH" "$@"
+  else
+    exec pkexec "$PACKAGED_PATH" "$@"
   fi
-
-  exec pkexec "$PACKAGED_PATH" "$@"
 }
 
 networkmanager_global_dns() {

--- a/test/shell.d/dns-sudoers-test.sh
+++ b/test/shell.d/dns-sudoers-test.sh
@@ -22,12 +22,11 @@ fi
 grep -Fx 'PACKAGED_PATH=/usr/bin/omarchy-dns' "$dns" >/dev/null ||
   fail "omarchy-dns elevates the path the sudoers rule names"
 
-# sudo -l answers whether a command is permitted, not whether it is
-# passwordless, and Omarchy ships a blanket %wheel rule that permits
-# everything. A probe built on it sends Custom into `sudo -n`, which fails
-# outright instead of falling through to pkexec.
-! grep -E '^[[:space:]]*[^#[:space:]].*sudo -n -l' "$dns" >/dev/null ||
-  fail "omarchy-dns does not decide elevation with a sudo -l probe"
+# `sudo -l` on its own answers whether a command is permitted, not whether it
+# is passwordless, and Omarchy ships a blanket %wheel rule that permits
+# everything. Only the long listing prints the matched entry's tags.
+grep -E 'sudo -n -l -l' "$dns" >/dev/null ||
+  fail "omarchy-dns reads the grant from the long sudo listing"
 
 pass "dns sudoers rule is scoped to the stock providers"
 
@@ -44,25 +43,32 @@ trap 'rm -rf "$test_tmp"' EXIT
 stub_bin="$test_tmp/bin"
 mkdir -p "$stub_bin"
 
-# Both stubs stand in for the exec at the end of require_root, so the DNS writes
-# below it never run, and neither real sudo nor real pkexec is reached.
-for command in sudo pkexec; do
-  cat >"$stub_bin/$command" <<SH
+# pkexec stands in for the exec at the end of require_root, so the DNS writes
+# below it never run and real pkexec is never reached.
+cat >"$stub_bin/pkexec" <<'SH'
 #!/bin/bash
-printf '$command %s\n' "\$*" >"\$ELEVATION_LOG"
+printf 'pkexec %s\n' "$*" >"$ELEVATION_LOG"
 SH
-  chmod +x "$stub_bin/$command"
-done
+chmod +x "$stub_bin/pkexec"
 
-# The rule is %wheel-scoped, so group membership decides the route as much as
-# the provider does. Stub id rather than reading the real groups: the suite has
-# to give the same answer on a build user outside wheel.
-cat >"$stub_bin/id" <<'SH'
+# The sudo stub plays both parts: it answers the passwordless probe from
+# STUB_GRANTED, the providers etc/sudoers.d/omarchy-dns covers on this machine,
+# and logs the elevation otherwise. STUB_GRANTED empty stands for an install
+# whose omarchy-settings predates the file.
+cat >"$stub_bin/sudo" <<'SH'
 #!/bin/bash
-[[ ${1:-} == -nG ]] || exec /usr/bin/id "$@"
-printf '%s\n' "${STUB_GROUPS-users wheel}"
+if [[ $1 == -n && $2 == -l ]]; then
+  for granted in ${STUB_GRANTED-Cloudflare Google DHCP}; do
+    [[ ${!#} == "$granted" ]] || continue
+    echo "    Options: !authenticate"
+    exit 0
+  done
+  echo "    Matched: ${!#}"
+  exit 0
+fi
+printf 'sudo %s\n' "$*" >"$ELEVATION_LOG"
 SH
-chmod +x "$stub_bin/id"
+chmod +x "$stub_bin/sudo"
 
 elevation_for() {
   : >"$test_tmp/elevation"
@@ -90,8 +96,12 @@ custom=$(elevation_for Custom)
 [[ $custom == "pkexec /usr/bin/omarchy-dns Custom" ]] ||
   fail "omarchy-dns leaves Custom on the polkit path, since no sudoers rule covers it" "got: $custom"
 
-non_wheel=$(STUB_GROUPS="users" elevation_for Cloudflare)
-[[ $non_wheel == "pkexec /usr/bin/omarchy-dns Cloudflare" ]] ||
-  fail "omarchy-dns leaves a user outside %wheel on the polkit path, since the rule cannot match them" "got: $non_wheel"
+# The grant is what makes sudo passwordless, so its absence -- an install still
+# on an older omarchy-settings, or a user outside %wheel the rule cannot match
+# -- has to route to polkit. Betting on sudo here leaves the panel's one-click
+# toggle execing into a password prompt it has no terminal to show.
+ungranted=$(STUB_GRANTED="" elevation_for Cloudflare)
+[[ $ungranted == "pkexec /usr/bin/omarchy-dns Cloudflare" ]] ||
+  fail "omarchy-dns falls back to polkit where the sudoers grant is not installed" "got: $ungranted"
 
 pass "omarchy-dns falls back to polkit wherever the grant does not reach"


### PR DESCRIPTION
Follow-up to #7472. Switching DNS providers from the network panel still does nothing on any machine that has not yet picked up the `omarchy-settings` build carrying `etc/sudoers.d/omarchy-dns` — no password prompt, no DNS change.

`grant_covers` re-implemented the sudoers rule in bash: one of the three stock providers, and `%wheel`. Both halves can hold on a machine where the rule is not installed at all. The file ships in the `etc/` tree that `omarchy-settings` copies, so it arrives on a package upgrade rather than with `bin/`, and until then every `wheel` user answers yes to a grant they do not have. `require_root` then `exec`s into sudo with nothing to fall back to:

```
sudo: a terminal is required to read the password
```

The panel runs `bash -c omarchy-dns Cloudflare` with no tty, so that is where it ends.

Ask sudo instead of predicting it. `sudo -l` on its own reports whether a command is *permitted*, which the blanket `%wheel` rule answers yes to for every argument — that objection from #7472 stands. But the long listing prints the matched entry's tags, and `!authenticate` is the grant and nothing else:

```
$ sudo -n -l -l /usr/bin/omarchy-dns Cloudflare
Sudoers entry: /etc/sudoers.d/03_dhh
    RunAsUsers: ALL
    Commands:
	ALL
    Matched: /usr/bin/omarchy-dns Cloudflare

$ sudo -n -l -l /usr/bin/timedatectl set-timezone Europe/Oslo
Sudoers entry: /etc/sudoers.d/omarchy-tzupdate
    RunAsUsers: root
    Options: !authenticate
    ...
```

Listing runs nothing, and under `-n` it prompts for nothing, so a machine without the rule falls through to polkit and gets a prompt on screen instead of dying silently. Both strings come from sudo's own listing formatter in `sudoers.so`, not from a locale-dependent message.

The provider list and the wheel check go away with it. Sudo owns that policy now, so the script stays correct if the rule is ever edited, removed, or scoped differently — the class of drift that caused this.

The test's stubbed `id` and group logic go too, replaced by a case that pins the regression: grant absent, provider granted, no terminal → polkit rather than a dead sudo.

Note for anyone hitting this today: no migration is needed or wanted. Writing the file from one would leave it unowned, and pacman would then refuse the eventual `omarchy-settings` upgrade with "exists in filesystem" — the trap that forced the `--overwrite` list in `omarchy-upgrade-to-quattro`. It lands on its own with the next settings build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)