### PR TITLE
Only follow an opened link when an argument is a URL

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -23,7 +23,7 @@ systemd-run --user --quiet --collect --unit="omarchy-browser-$(date +%s%N)" \
 
 url=""
 for argument in "$@"; do
-  if [[ $argument != "--private" ]]; then
+  if [[ $argument != -* ]]; then
     url=$argument
     break
   fi

--- a/test/shell.d/launch-browser-test.sh
+++ b/test/shell.d/launch-browser-test.sh
@@ -58,6 +58,12 @@ HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
 
 HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
   OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
+  bash "$ROOT/bin/omarchy-launch-browser" "--profile-directory=Profile 1"
+
+[[ ! -e $focus_log ]] || fail "flagged browser launcher leaves a new window on the current workspace"
+
+HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+  OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
   bash "$ROOT/bin/omarchy-launch-browser" "https://example.test/authorize"
 
 grep -F 'https://example.test/authorize' "$launch_log" >/dev/null || fail "browser launcher passes through the URL"


### PR DESCRIPTION
## What this script does

When something opens a link, it runs `omarchy-launch-browser <url>`. Chromium does not make a new window for that link. It adds a tab to a window you already have open, and that window can be on another workspace. So you click a link and nothing seems to happen.

To fix that, the script moves you to the browser window whenever it is given a link. When it is given no link, it opens a new window and leaves you where you are.

## What is broken

The script has to tell a link from an option. It does that by taking the first thing you passed it that is not `--private`:

```bash
for argument in "$@"; do
  if [[ $argument != "--private" ]]; then
    url=$argument
    break
  fi
done
```

Options are not links, but every option other than `--private` passes that test. So the script thinks you gave it a link, and moves you to a browser window on some other workspace. Your new window then opens over there.

You see this if a keybinding passes an option, like picking a Chromium profile:

```lua
o.bind("SUPER + SHIFT + RETURN", "Browser", "omarchy-launch-browser --profile-directory='Profile 1'")
```

Press it on workspace 3, land on workspace 4. Same with `--new-window`, `--incognito` and `--ozone-platform=...`.

Default bindings pass nothing or `--private`, so a stock install is not affected.

## The fix

Links do not start with a dash. Options do. So only count something as a link if it does not start with a dash:

```bash
if [[ $argument != -* ]]; then
```

`--private` starts with a dash, so it is covered and the special case goes away.

## Testing

- `bash test/shell.d/launch-browser-test.sh` — new case passes an option and checks that nothing gets focused. It fails on the current script.
- `./test/all` — `bar-icon-geometry-test.sh` and `snapper-test.sh` fail before and after, from a local node that rejects `-G`.