### PR TITLE
Keep the monitor layout when changing scale

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -86,7 +86,9 @@ set_scale() {
   local new_gdk_scale="$(awk -v scale="$new_scale" 'BEGIN { printf "%d", int(scale + 0.5) }')"
   local monitor_lua="$HOME/.config/hypr/monitors.lua"
 
-  hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
+  # Omit position: omitted fields inherit the monitor's existing declaration,
+  # while asserting "auto" re-places the monitor and discards a configured layout.
+  hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -129,3 +129,11 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+# Asserting a position on scale change re-places the monitor (#7326).
+write_monitor_config
+run_scaling 1.25
+if grep -F 'position' "$eval_out" >/dev/null; then
+  fail "monitor scaling must not assert a position"
+fi
+pass "monitor scaling leaves position to the existing declaration"


### PR DESCRIPTION
## Summary

- Changing scale from the Display panel or `SUPER+/` re-declared the focused monitor with `position = "auto"`, re-placing it and discarding any configured multi-monitor layout (root cause 2 of #7326).
- Omit `position` from the runtime re-declaration instead: omitted fields inherit the monitor's existing declaration, so an explicitly placed monitor stays put and an auto-arranged one keeps following its neighbors. Passing the current coordinates was considered and rejected — it pins auto-arranged monitors, detaching them from neighbors whose logical size later changes.
- Add a regression test asserting the re-declaration carries no `position`.

## Testing

- `bash test/shell.d/monitor-scaling-test.sh` — 15 ok, including the new case.
- Live on Omarchy 4.0.0-1 / Hyprland 0.56.2, ultrawide DP-3 (3440x1440, explicit `0x0`) + rotated DP-1 (`auto-right`, `transform = 1`): scaling DP-3 through 1 → 1.25 → 1.6 keeps it at `0x0` with DP-1 re-flowing to the correct edge each time; scaling DP-1 keeps its rotation and placement. The stock script re-places the scaled monitor on every invocation.
- Full `test/shell` suite: same 5 pre-existing environment-dependent failures with and without this change; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)