### PR TITLE
Stop monitor scaling from persisting a scale the reload will undo

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -71,6 +71,38 @@ normalize_scale() {
   awk 'NR == 1 { printf "%g\n", $0 }'
 }
 
+# monitors.lua with its comments cut away, so a commented-out example can pose
+# neither as a rule nor as one of its keys. The file ships with several.
+monitor_rules() {
+  local monitor_lua="$1"
+
+  [[ -f $monitor_lua ]] || return 0
+  sed -E -e 's/--\[\[[^]]*\]\]//g' -e 's/--.*$//' "$monitor_lua"
+}
+
+# The scale set by a monitor's own hl.monitor rule, if it has one. Empty when
+# the monitor has no rule of its own or its rule names no scale, which is when
+# the catch-all rule governs it instead. A key is preceded by a table separator
+# so a longer key cannot stand in for it.
+monitor_rule_scale() {
+  local monitor_lua="$1" output="$2"
+
+  monitor_rules "$monitor_lua" |
+    sed -nE '/^[[:space:]]*hl\.monitor\(\{.*output[[:space:]]*=[[:space:]]*"'"$output"'"/ {
+      s/.*[{,;[:space:]]scale[[:space:]]*=[[:space:]]*("[^"]*"|[^,;}[:space:]]+).*/\1/p
+    }' | head -1
+}
+
+# Whether writing the shipped locals and catch-all reaches this monitor at all.
+# A rule of its own overrides them, unless that rule defers to the local by
+# name, as the shipped `scale = omarchy_monitor_scale` does.
+persisting_governs_monitor() {
+  local monitor_lua="$1" output="$2" rule_scale
+
+  rule_scale=$(monitor_rule_scale "$monitor_lua" "$output")
+  [[ -z $rule_scale || $rule_scale == "omarchy_monitor_scale" ]]
+}
+
 set_scale() {
   local requested_scale="$1"
   local requested="${2:-$requested_scale}"
@@ -88,6 +120,15 @@ set_scale() {
 
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
+
+  # Hyprland reloads monitors.lua when it changes, and the reload re-applies
+  # whichever rule governs this monitor. Persisting somewhere that rule does not
+  # read back is therefore worse than not persisting at all: the reload undoes
+  # the scale just set, and the display snaps back a moment after it moved.
+  if [[ -f $monitor_lua ]] && ! persisting_governs_monitor "$monitor_lua" "$active_monitor"; then
+    echo "Not persisting scale: $active_monitor has its own rule in $monitor_lua that overrides the shared scale." >&2
+    return 0
+  fi
 
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -129,3 +129,88 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+# ---- Persisting must not undo the scale it just set ----
+#
+# Hyprland reloads monitors.lua when it changes, and the reload re-applies
+# whichever rule governs the monitor. A per-output rule overrides the shared
+# locals, so writing the locals for a monitor that has its own rule reverts the
+# scale a moment after it moved: the flicker-and-snap-back this guards against.
+
+write_own_rule_config() {
+  cat >"$monitor_lua" <<LUA
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = $1, transform = 3 })
+LUA
+}
+
+write_own_rule_config '"auto"'
+before=$(cat "$monitor_lua")
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6 2>/dev/null
+grep -F 'scale = 1.6' "$eval_out" >/dev/null ||
+  fail "monitor scaling still applies when it cannot persist"
+[[ $(cat "$monitor_lua") == "$before" ]] ||
+  fail "monitor scaling leaves monitors.lua alone when its write would be overridden" \
+    "$(diff <(printf '%s\n' "$before") "$monitor_lua" || true)"
+pass "monitor scaling leaves monitors.lua alone when its write would be overridden"
+
+# The same rule shape, but deferring to the local by name: writing the local is
+# what the rule reads back, so persisting reaches the monitor and is safe.
+write_own_rule_config 'omarchy_monitor_scale'
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -F 'scale = 1.6' "$eval_out" >/dev/null || fail "monitor scaling applies through a deferring rule"
+grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists through a rule that defers to the local"
+pass "monitor scaling persists through a rule that defers to the local"
+
+# A literal scale on the monitor's own rule overrides the local just as "auto"
+# does, so it is equally unsafe to write.
+write_own_rule_config '1'
+before=$(cat "$monitor_lua")
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6 2>/dev/null
+[[ $(cat "$monitor_lua") == "$before" ]] ||
+  fail "monitor scaling leaves a literal per-output scale alone"
+pass "monitor scaling leaves a literal per-output scale alone"
+
+# A rule for some other output does not govern this monitor, so the catch-all
+# still does and persisting is safe.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({ output = "DP-2", mode = "preferred", position = "auto", scale = 1 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists when only another output has a rule"
+pass "monitor scaling persists when only another output has a rule"
+
+# The file ships with commented-out example rules, including one for a rotated
+# monitor. A comment is not a rule and must not block persisting.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+-- hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 1, transform = 1 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling ignores a commented-out rule"
+pass "monitor scaling ignores a commented-out rule"
+
+# A rule naming no scale at all leaves the catch-all governing the scale.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", transform = 3 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists when the monitor's rule names no scale"
+pass "monitor scaling persists when the monitor's rule names no scale"


### PR DESCRIPTION
Changing the scale from the Display panel (or `omarchy display`/`Super + /`) could apply and then immediately revert — a visible flicker and a snap back to the old size, with nothing logged anywhere to explain it.

## What happens

`set_scale` applies the scale, then persists it by rewriting `local omarchy_monitor_scale` (or the catch-all `hl.monitor` rule) in `monitors.lua`. Hyprland reloads that file when it changes, and the reload re-applies whichever rule governs the monitor.

Persistence never checked that what it wrote reaches the monitor being scaled. A per-output rule overrides the shared locals, so on a config that has one, the sequence is:

1. `hyprctl eval` applies the new scale — this works
2. the script rewrites `monitors.lua`
3. Hyprland reloads on the write
4. the reload re-applies the per-output rule, reverting the scale just set

Caught at 250ms resolution on a display whose own rule carries `scale = "auto"`:

```
08:34:34.59  scale=1.6      ← before
             script sets 1.25, writes monitors.lua at .65
08:34:34.85  scale=2        ← reload re-applied "auto", undoing it
```

The requested value never survived a single sample. `touch monitors.lua`, changing nothing at all, reproduces the revert on its own — the write is the trigger, not the content.

It fails silently in a way that's actively misleading. The eval succeeds, so there's no error; and the audit log records the change *after* applying it, so a second attempt reads back the reverted scale and logs an identical line:

```
requested=1.6  current=2  new=1.6
requested=1.6  current=2  new=1.6   ← 5s later, still 2
```

## The fix

Check what governs the monitor before writing. A rule of its own overrides the locals — unless it defers to one by name, as the shipped `scale = omarchy_monitor_scale` does — so in that case writing them is worse than not persisting at all, and the script now says so on stderr rather than silently doing nothing.

The scale still applies; it just no longer gets undone by a reload the script provoked itself.

Comments are stripped before matching, since `monitors.lua` ships with commented-out example rules and one of them names a scale.

## Who hits this

Rotated displays, mostly. Giving a monitor a `transform` means giving it a rule of its own, and the shipped example for exactly that is:

```lua
-- hl.monitor({ output = "DP-2", mode = "preferred", position = "auto", scale = 1, transform = 1 })
```

Follow that pattern and scale changes stop sticking. The machine this was found on is a convertible whose panel needs `transform = 3`.

## Scope

This stops the clobber; it does not make the scale persist in that configuration — it never did, since the value was being written somewhere the config doesn't read back. Making it persist would mean rewriting the scale on the user's own rule line, which is a bigger policy call about editing hand-written config. Happy to add that if you'd want it.

## Testing

`./test/shell` passes. Six new cases in `monitor-scaling-test.sh` cover a per-output rule with `"auto"` and with a literal, a rule deferring to the local (still persists), a rule for a different output (still persists), a rule naming no scale (still persists), and a commented-out rule (not a rule).

Verified live on the affected config: 1.6 applies and holds, where before it reverted within 250ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QDMrgifw4mGevBCEAtA3A
