### PR TITLE
Fix horizontal resize in scrolling layout

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -51,18 +51,34 @@ o.bind("ALT + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.bring_t
 o.bind("CTRL + ALT + TAB", "Focus on next monitor", hl.dsp.focus({ monitor = "+1" }))
 o.bind("CTRL + ALT + SHIFT + TAB", "Focus on previous monitor", hl.dsp.focus({ monitor = "-1" }))
 
-o.bind("SUPER + code:20", "Expand window left", hl.dsp.window.resize({ x = -100, y = 0, relative = true }))
-o.bind("SUPER + code:21", "Shrink window left", hl.dsp.window.resize({ x = 100, y = 0, relative = true }))
+local function resize_width(column_delta, window_delta)
+  local column_resize = hl.dsp.layout("colresize " .. column_delta)
+  local window_resize = hl.dsp.window.resize({ x = window_delta, y = 0, relative = true })
+
+  return function()
+    local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()
+    local window = hl.get_active_window()
+    local tiled_scrolling =
+      workspace and workspace.tiled_layout == "scrolling"
+      and window and not window.floating
+      and window.fullscreen == 0
+
+    hl.dispatch(tiled_scrolling and column_resize or window_resize)
+  end
+end
+
+o.bind("SUPER + code:20", "Shrink window horizontally", resize_width("-0.05", -100))
+o.bind("SUPER + code:21", "Grow window horizontally", resize_width("+0.05", 100))
 o.bind("SUPER + SHIFT + code:20", "Shrink window up", hl.dsp.window.resize({ x = 0, y = -100, relative = true }))
 o.bind("SUPER + SHIFT + code:21", "Expand window down", hl.dsp.window.resize({ x = 0, y = 100, relative = true }))
 
-o.bind("SUPER + ALT + code:20", "Expand window left a little", hl.dsp.window.resize({ x = -25, y = 0, relative = true }))
-o.bind("SUPER + ALT + code:21", "Shrink window left a little", hl.dsp.window.resize({ x = 25, y = 0, relative = true }))
+o.bind("SUPER + ALT + code:20", "Shrink window horizontally a little", resize_width("-0.0125", -25))
+o.bind("SUPER + ALT + code:21", "Grow window horizontally a little", resize_width("+0.0125", 25))
 o.bind("SUPER + SHIFT + ALT + code:20", "Shrink window up a little", hl.dsp.window.resize({ x = 0, y = -25, relative = true }))
 o.bind("SUPER + SHIFT + ALT + code:21", "Expand window down a little", hl.dsp.window.resize({ x = 0, y = 25, relative = true }))
 
-o.bind("SUPER + CTRL + code:20", "Expand window left a lot", hl.dsp.window.resize({ x = -300, y = 0, relative = true }))
-o.bind("SUPER + CTRL + code:21", "Shrink window left a lot", hl.dsp.window.resize({ x = 300, y = 0, relative = true }))
+o.bind("SUPER + CTRL + code:20", "Shrink window horizontally a lot", resize_width("-0.15", -300))
+o.bind("SUPER + CTRL + code:21", "Grow window horizontally a lot", resize_width("+0.15", 300))
 o.bind("SUPER + CTRL + SHIFT + code:20", "Shrink window up a lot", hl.dsp.window.resize({ x = 0, y = -300, relative = true }))
 o.bind("SUPER + CTRL + SHIFT + code:21", "Expand window down a lot", hl.dsp.window.resize({ x = 0, y = 300, relative = true }))
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -31,8 +31,8 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Shift + Alt + Arrows` | Move workspaces to directional monitor |
 | `Super + Arrow`  | Move focus to window in direction of arrow              |
 | `Super + Shift + Arrow`  | Swap window with another in direction of arrow     |
-| `Super + Minus` | Expand window left |
-| `Super + Equal` | Shrink window left |
+| `Super + Minus` | Shrink window horizontally |
+| `Super + Equal` | Grow window horizontally |
 | `Super + Shift + Minus` | Shrink window up |
 | `Super + Shift + Equal` | Expand window down |
 | `Super + Alt + Minus/Equal` | Same resizing in smaller steps |

--- a/test/shell.d/hyprland-window-resize-binding-test.sh
+++ b/test/shell.d/hyprland-window-resize-binding-test.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+if ! output=$(OMARCHY_PATH="$ROOT" lua 2>&1 <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return {}
+    end,
+  })
+end
+
+local bindings = {}
+local dispatched = {}
+local workspace
+local special_workspace
+local window
+local dsp = proxy()
+
+dsp.layout = function(message)
+  return "layout:" .. message
+end
+
+dsp.window.resize = function(options)
+  if not options then
+    return { kind = "resize", interactive = true }
+  end
+
+  return {
+    kind = "resize",
+    x = options.x,
+    y = options.y,
+    relative = options.relative,
+  }
+end
+
+local function describe(dispatcher)
+  if type(dispatcher) == "table" and dispatcher.kind == "resize" then
+    if dispatcher.interactive then
+      return "resize:interactive"
+    end
+
+    return string.format("resize:%s:%s:%s", dispatcher.x, dispatcher.y, tostring(dispatcher.relative))
+  end
+
+  return dispatcher
+end
+
+hl = setmetatable({
+  dsp = dsp,
+  bind = function(keys, dispatcher, opts)
+    bindings[keys] = {
+      dispatcher = dispatcher,
+      description = opts and opts.description,
+    }
+  end,
+  dispatch = function(dispatcher)
+    table.insert(dispatched, describe(dispatcher))
+  end,
+  get_active_workspace = function()
+    return workspace
+  end,
+  get_active_special_workspace = function()
+    return special_workspace
+  end,
+  get_active_window = function()
+    return window
+  end,
+}, {
+  __index = function()
+    return function() end
+  end,
+})
+
+require("default.hypr.helpers")
+require("default.hypr.bindings.tiling")
+
+local horizontal_bindings = {
+  {
+    keys = "SUPER + code:20",
+    description = "Shrink window horizontally",
+    column = "layout:colresize -0.05",
+    window = "resize:-100:0:true",
+  },
+  {
+    keys = "SUPER + code:21",
+    description = "Grow window horizontally",
+    column = "layout:colresize +0.05",
+    window = "resize:100:0:true",
+  },
+  {
+    keys = "SUPER + ALT + code:20",
+    description = "Shrink window horizontally a little",
+    column = "layout:colresize -0.0125",
+    window = "resize:-25:0:true",
+  },
+  {
+    keys = "SUPER + ALT + code:21",
+    description = "Grow window horizontally a little",
+    column = "layout:colresize +0.0125",
+    window = "resize:25:0:true",
+  },
+  {
+    keys = "SUPER + CTRL + code:20",
+    description = "Shrink window horizontally a lot",
+    column = "layout:colresize -0.15",
+    window = "resize:-300:0:true",
+  },
+  {
+    keys = "SUPER + CTRL + code:21",
+    description = "Grow window horizontally a lot",
+    column = "layout:colresize +0.15",
+    window = "resize:300:0:true",
+  },
+}
+
+local function assert_dispatch(binding, regular_layout, special_layout, active_window, expected)
+  workspace = regular_layout and { tiled_layout = regular_layout } or nil
+  special_workspace = special_layout and { tiled_layout = special_layout } or nil
+  window = active_window
+
+  local count = #dispatched
+  binding.dispatcher()
+
+  assert(#dispatched == count + 1, "resize binding did not dispatch")
+  assert(dispatched[#dispatched] == expected, "resize binding dispatched " .. tostring(dispatched[#dispatched]) .. " instead of " .. expected)
+end
+
+for _, expected in ipairs(horizontal_bindings) do
+  local binding = assert(bindings[expected.keys], expected.keys .. " binding is missing")
+  assert(binding.description == expected.description, expected.keys .. " description changed")
+  assert(type(binding.dispatcher) == "function", expected.keys .. " is not layout-aware")
+
+  local tiled = { floating = false, fullscreen = 0 }
+  assert_dispatch(binding, "scrolling", nil, tiled, expected.column)
+  assert_dispatch(binding, "dwindle", nil, tiled, expected.window)
+  assert_dispatch(binding, "master", nil, tiled, expected.window)
+  assert_dispatch(binding, "monocle", nil, tiled, expected.window)
+  assert_dispatch(binding, "dwindle", "scrolling", tiled, expected.column)
+  assert_dispatch(binding, "scrolling", "dwindle", tiled, expected.window)
+  assert_dispatch(binding, "scrolling", nil, { floating = true, fullscreen = 0 }, expected.window)
+  assert_dispatch(binding, "scrolling", nil, { floating = false, fullscreen = 1 }, expected.window)
+  assert_dispatch(binding, "scrolling", nil, nil, expected.window)
+  assert_dispatch(binding, nil, nil, tiled, expected.window)
+end
+
+local vertical_bindings = {
+  ["SUPER + SHIFT + code:20"] = "resize:0:-100:true",
+  ["SUPER + SHIFT + code:21"] = "resize:0:100:true",
+  ["SUPER + SHIFT + ALT + code:20"] = "resize:0:-25:true",
+  ["SUPER + SHIFT + ALT + code:21"] = "resize:0:25:true",
+  ["SUPER + CTRL + SHIFT + code:20"] = "resize:0:-300:true",
+  ["SUPER + CTRL + SHIFT + code:21"] = "resize:0:300:true",
+}
+
+for keys, expected in pairs(vertical_bindings) do
+  local binding = assert(bindings[keys], keys .. " binding is missing")
+  assert(type(binding.dispatcher) ~= "function", keys .. " unexpectedly became layout-aware")
+  assert(describe(binding.dispatcher) == expected, keys .. " vertical resize changed to " .. tostring(describe(binding.dispatcher)))
+end
+LUA
+); then
+  fail "layout-aware resize binding assertions failed" "$output"
+fi
+
+[[ -z $output ]] || fail "layout-aware resize bindings produce no output" "$output"
+pass "horizontal resize bindings use native scrolling columns with safe fallbacks"
+
+grep -Fq '| `Super + Minus` | Shrink window horizontally |' "$ROOT/manual/07-hotkeys.md" || fail "manual documents horizontal shrinking on Super + Minus"
+grep -Fq '| `Super + Equal` | Grow window horizontally |' "$ROOT/manual/07-hotkeys.md" || fail "manual documents horizontal growth on Super + Equal"
+pass "manual documents the horizontal resize directions"


### PR DESCRIPTION
## Summary

- use Hyprland's native `colresize` dispatcher for horizontal resizing of tiled scrolling-layout columns
- preserve the existing relative window resize behavior for dwindle, master, monocle, floating, fullscreen, and incomplete compositor state
- correct the key descriptions and manual so `Super + Minus` shrinks and `Super + Equal` grows
- add regression coverage for all horizontal step sizes, special workspaces, fallbacks, and unchanged vertical bindings

## Root cause

The generic relative window resize dispatcher changes a client edge. In the scrolling layout, the last column's right edge is already at the viewport boundary, so that resize is clamped and cannot extend the column. The layout-native `colresize` dispatcher changes the column width instead and lets the scrolling layout reposition the viewport correctly.

This revisits the resize portion of #4870 using Omarchy's current Quattro Lua binding architecture.

## Validation

- `./test/shell.d/hyprland-window-resize-binding-test.sh`
- `luac -p default/hypr/bindings/tiling.lua`
- `bash -n test/shell.d/hyprland-window-resize-binding-test.sh`
- `./test/all` — all 184 test files passed
- fresh local ISO build: `387082e8e79c8597f3a0001a0964e4865ae47cfd1b353ec3177041d0b0fdf4c4`
- clean KVM guest with QMP keyboard input: last, middle, first, and pseudo scrolling columns grew with `Super + Equal`; fine/coarse steps, reverse shrinking, fullscreen protection, floating fallback, and dwindle fallback all passed

Fixes #5101
