### PR TITLE
Keep OpenCode sessions alive during theme changes

### DIFF
--- a/bin/omarchy-restart-opencode
+++ b/bin/omarchy-restart-opencode
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Reload opencode configuration (used by the Omarchy theme switching).
+# omarchy:summary=Reload opencode configuration
 
 if pgrep -x opencode >/dev/null; then
   killall -SIGUSR2 opencode

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -191,10 +191,10 @@ post_theme_commands=(
   omarchy-restart-terminal
   omarchy-restart-hyprctl
   omarchy-restart-btop
-  omarchy-restart-opencode
   omarchy-restart-helix
   omarchy-theme-set-foot
   omarchy-theme-set-tmux
+  omarchy-theme-set-opencode
   omarchy-theme-set-gnome
   omarchy-theme-set-pi
   omarchy-theme-set-browser

--- a/bin/omarchy-theme-set-opencode
+++ b/bin/omarchy-theme-set-opencode
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Apply the current Omarchy theme to running OpenCode TUIs
+# omarchy:hidden=true
+
+COLORS_TOML="$HOME/.local/state/omarchy/current/theme/colors.toml"
+
+[[ -f $COLORS_TOML ]] || exit 0
+
+theme_osc=$(omarchy-theme-osc "$COLORS_TOML")
+[[ -n $theme_osc ]] || exit 0
+
+declare -A seen_ttys
+for pid in $(pgrep -x opencode 2>/dev/null || true); do
+  tty=$(readlink "/proc/$pid/fd/1" 2>/dev/null)
+  [[ $tty == /dev/pts/* ]] || continue
+  [[ ${seen_ttys[$tty]:-} ]] && continue
+  seen_ttys[$tty]=1
+
+  printf '%b\033[?996n' "$theme_osc" >"$tty" 2>/dev/null || true
+done

--- a/bin/omarchy-theme-set-opencode
+++ b/bin/omarchy-theme-set-opencode
@@ -17,5 +17,5 @@ for pid in $(pgrep -x opencode 2>/dev/null || true); do
   [[ ${seen_ttys[$tty]:-} ]] && continue
   seen_ttys[$tty]=1
 
-  printf '%b\033[?996n' "$theme_osc" >"$tty" 2>/dev/null || true
+  printf '%b\033[?996n' "$theme_osc" 2>/dev/null >"$tty" || true
 done


### PR DESCRIPTION
## Why

Omarchy sends `SIGUSR2` to every running OpenCode process after a theme change. OpenCode uses this signal to reload its configuration. The reload disposes active instances, which can stop model requests and tool calls.

## What changed

- Stop calling `omarchy-restart-opencode` during theme changes.
- Add `omarchy-theme-set-opencode`.
- Send the current Omarchy terminal colors to each running OpenCode TTY.
- Send the terminal theme query that lets OpenCode refresh its `system` theme without reloading its worker.
- Keep `omarchy-restart-opencode` available for manual configuration reloads.

Existing Alacritty, Kitty, Ghostty, Foot, and tmux theme paths remain unchanged.

## Tests

- `./test/cli`
- `bash -n bin/omarchy-theme-set bin/omarchy-theme-set-opencode bin/omarchy-theme-osc bin/omarchy-theme-set-foot`