### PR TITLE
Deregister the OSD IPC handler before its QML context dies

### DIFF
--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -114,6 +114,12 @@ Item {
 
   IpcHandler {
     target: "osd"
+    // quickshell 0.3.0's IpcHandler destructor cannot resolve its engine
+    // generation and silently skips deregistration, leaving a dangling
+    // registry pointer that later segfaults the shell (quickshell#898).
+    // Deregistering here runs while the QML context is still alive. Remove
+    // once quickshell deregisters correctly on destruction.
+    Component.onDestruction: enabled = false
     function show(payloadJson: string): string {
       root.open(payloadJson)
       return "ok"


### PR DESCRIPTION
## What this fixes

Every local-plugin hot reload strands a freed `IpcHandler` in Quickshell's IPC registry under target `osd`. A later IPC call dispatches through that dangling pointer and takes the whole shell down with SIGSEGV.

Root cause is upstream in Quickshell 0.3.0, not in Omarchy: `IpcHandler::~IpcHandler()` calls `updateRegistration(true)`, which resolves the engine generation via `findObjectGeneration(this)` to reach the registry. During QML destruction that lookup returns null, so the deregistration is skipped — and the `destroying` flag deliberately silences the warning that would otherwise report it. Filed as [quickshell-mirror/quickshell#898](https://github.com/quickshell-mirror/quickshell/issues/898) (root-cause analysis and a 30-line reproduction are in the comments there).

The OSD panel is the one entry point that always feels it, because it is `keepLoaded`: its handler is destroyed and recreated on every reload, so the registry accumulates one dead entry per reload. `Component.onDestruction: enabled = false` runs while the QML context is still alive, so `updateRegistration()` resolves the generation and deregisters cleanly.

## Why it is worth carrying in Omarchy

The one-line guard removes a shell-killing crash class without waiting on an upstream release. The comment states the removal condition, so it can be dropped when Quickshell deregisters correctly on destruction.

This is very likely the mechanism behind #7362 (Quickshell heap corruption after local-plugin hot reload). That report's cores prove jemalloc state was already invalid but could not identify the earlier corrupting write. `IpcHandlerRegistry::deregisterHandler` supplies one: it promotes `knownHandlers.first()` into the active map and then executes `handler->registeredState = RegistrationState(false)` — a write through the stored pointer. Once a freed handler is stranded, that write lands in freed memory, which corrupts allocator metadata and surfaces later in unrelated code (glib teardown, QV4 GC) exactly as that issue describes.

## Verification

On a live Omarchy 4.0 session (Quickshell 0.3.0-2, Qt 6.11.1):

- Before: 28 `Handler was registered but will not be used ... target osd` warnings over two days, one per hot reload, plus SIGSEGVs whose faulting frame is a `QHash` bucket walk reached from `IpcServerConnection` socket dispatch.
- After: three consecutive hot reloads produce **zero** duplicate-handler warnings, `quickshell ipc show` lists all 19 targets exactly once with full function lists and no empty-name entries, and `omarchy-shell osd ping` / `osd state` answer normally.
- `bash test/shell.d/osd-test.sh` passes on this branch.

One note for anyone grepping their own logs: ten other `omarchy.*` bar and panel targets also emit that warning, but in a different shape — all of them in the same second, in one-off bursts during a synchronized bar rebuild, where the new widgets register before the old ones deregister. Those recover on their own and need no guard. Only `osd` warns again on every reload, which is the accumulation signature this patch addresses.

Authored by Claude Fable 5 via Claude Code, on behalf of @Skeptomenos.
