### PR TITLE
Fix frozen media marquee showing only leading characters

### DIFF
--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -61,9 +61,30 @@ BarWidget {
 
         property bool needsScroll: implicitWidth > scrollClip.width
 
+        // NumberAnimation latches `from`/`to` at the instant it starts, and
+        // `scrollClip.width` (the source of `from`) is still 0 on the frame
+        // where a new title lands. Starting then latches a degenerate 0 -> 0
+        // animation that loops forever: `running` and `needsScroll` both stay
+        // true, the corrected bindings arrive a frame late, and changing
+        // from/to on a running animation does not restart it -- so the label
+        // sits motionless showing only its first maxLabelWidth px. Arm one
+        // tick later so the width bindings have settled, and re-arm on every
+        // text change so a frozen animation cannot be inherited.
+        property bool scrollArmed: false
+        function rearmScroll() { scrollArmed = false; Qt.callLater(armScroll) }
+        function armScroll() { scrollArmed = true }
+        onImplicitWidthChanged: rearmScroll()
+        Component.onCompleted: rearmScroll()
+
+        // A value source owns `x` and leaves it wherever it stopped, which
+        // parks the label outside scrollClip once scrolling is no longer
+        // needed. Keyed on needsScroll rather than running so opening the
+        // popup pauses in place instead of snapping back to the start.
+        onNeedsScrollChanged: if (!needsScroll) x = 0
+
         NumberAnimation on x {
           id: scrollAnim
-          running: labelText.needsScroll && !root.popupOpen && !root.bar.vertical
+          running: labelText.scrollArmed && labelText.needsScroll && !root.popupOpen && !root.bar.vertical
           loops: Animation.Infinite
           duration: Math.max(6000, labelText.implicitWidth * 25)
           from: scrollClip.width


### PR DESCRIPTION
Fixes #7054.

The now-playing label in the media bar widget frequently stops mid-scroll, showing only the first few characters of the title — or nothing at all.

## Cause

`NumberAnimation` latches `from`/`to` at the instant it starts. `running` is driven by `needsScroll` (derived from `labelText.implicitWidth`), while `from` comes from `scrollClip.width`, and those bindings do not settle in the same evaluation pass.

On the frame a new title lands, `scrollClip.width` is still `0`, so the animation starts as a degenerate `0 → 0` and loops that forever. The corrected bindings arrive a frame later, but changing `from`/`to` on an already-running animation does not restart it — so the label sits motionless showing only its first `maxLabelWidth` px, for the lifetime of that track.

The tell is that in this state `running` and `needsScroll` are **both still true**, so a reset keyed on either going false never fires. And because a degenerate animation never restarts on its own, every subsequent track change inherits the frozen animation — which matches the "sometimes for the lifetime of the shell process" reports.

## Change

- Arm the animation a tick later via `Qt.callLater`, so it only ever starts once the width bindings have settled, and re-arm on every `implicitWidth` change so a frozen animation cannot be inherited across track changes.
- Reset `x` when scrolling is no longer needed. `NumberAnimation on x` is a property value source: it owns `x` and leaves it wherever it stopped, which parks a now-shorter label outside `scrollClip`. Keyed on `needsScroll` rather than `running` so opening the popup pauses the marquee in place instead of snapping it back to the start.

## Credit

The root-cause analysis and the shape of this fix are @y4nder's, from the instrumented investigation in #7054 — including the isolated QtQuick reproduction and the scenario matrix showing that a `running`-keyed reset alone leaves the `"" → long`, `long → "" → long` and `long → long` transitions frozen. This PR is that fix, submitted so the issue has a patch attached.

## Verification

Applied to a local clone of the plugin (`omarchy plugin clone omarchy.media`) on Omarchy 4.0.0-1 / Quickshell 0.3.0 / Hyprland, with a Spotify player and Japanese track titles (the symptom is easiest to hit with CJK titles, which exceed `maxLabelWidth` at few characters).

- Before: label parked mid-string, frozen across 8 samples over 6.4s — screenshots showed the pause glyph followed by a gap and only the first 3 characters of a 5-character title; on other tracks, no text at all.
- After, short title that fits: renders in full at `x = 0`, flush after the glyph.
- After, forced scroll path (temporarily lowered `maxLabelWidth`): 8/8 sampled frames unique, with the label visibly advancing through the clip.