### PR TITLE
Add ctrl-n and ctrl-p menu navigation

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1139,10 +1139,10 @@ Item {
           } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
             root.goBack()
             event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
+          } else if (event.key === Qt.Key_Up || (event.key === Qt.Key_P && (event.modifiers & Qt.ControlModifier))) {
             root.select(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Down) {
+          } else if (event.key === Qt.Key_Down || (event.key === Qt.Key_N && (event.modifiers & Qt.ControlModifier))) {
             root.select(1)
             event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {


### PR DESCRIPTION
Use:
Adds vim-style navigation shortcuts to the Omarchy menu:

- Ctrl+N selects the next item, matching Down
- Ctrl+P selects the previous item, matching Up