### PR TITLE
Show today's high and low in the weather panel

### DIFF
--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -153,6 +153,45 @@ function openMeteoForecastDays(dailyForecastReport, todayString) {
   return result
 }
 
+// Today's own daily entry. The forecast strip shows only future days (see
+// isFutureForecastDate), so today's high/low is resolved separately for the
+// hero read-out. Matches on date rather than trusting index 0.
+function openMeteoTodayForecast(dailyForecastReport, todayString) {
+  var daily = dailyForecastReport && dailyForecastReport.daily ? dailyForecastReport.daily : null
+  if (!daily || !daily.time) return null
+
+  var today = String(todayString || "")
+  for (var i = 0; i < daily.time.length; ++i) {
+    if (String(daily.time[i]).slice(0, 10) !== today) continue
+
+    var maxC = daily.temperature_2m_max ? daily.temperature_2m_max[i] : ""
+    var minC = daily.temperature_2m_min ? daily.temperature_2m_min[i] : ""
+    return {
+      date: daily.time[i],
+      maxtempC: roundedTemp(maxC),
+      mintempC: roundedTemp(minC),
+      maxtempF: roundedTemp(celsiusToFahrenheit(maxC)),
+      mintempF: roundedTemp(celsiusToFahrenheit(minC)),
+      openMeteoWeatherCode: daily.weather_code ? daily.weather_code[i] : null
+    }
+  }
+  return null
+}
+
+function wttrTodayForecast(report, todayString) {
+  var days = report && report.weather ? report.weather : []
+  var today = String(todayString || "")
+  for (var i = 0; i < days.length; ++i) {
+    if (String(days[i].date || "").slice(0, 10) === today) return days[i]
+  }
+  return null
+}
+
+function buildTodayForecast(report, dailyForecastReport, todayString) {
+  return openMeteoTodayForecast(dailyForecastReport, todayString)
+    || wttrTodayForecast(report, todayString)
+}
+
 // Open-Meteo bundles current conditions with the daily forecast request and
 // answers far faster than wttr.in. Normalize them to wttr's
 // current_condition shape so the panel can use either source
@@ -281,6 +320,9 @@ if (typeof module !== "undefined") {
     shouldUseImperial: shouldUseImperial,
     dayName: dayName,
     openMeteoForecastDays: openMeteoForecastDays,
+    openMeteoTodayForecast: openMeteoTodayForecast,
+    wttrTodayForecast: wttrTodayForecast,
+    buildTodayForecast: buildTodayForecast,
     openMeteoCurrentCondition: openMeteoCurrentCondition,
     currentIcon: currentIcon,
     provisionalCurrentIcon: provisionalCurrentIcon,

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -133,6 +133,7 @@ Panel {
   readonly property var current: (hasConfiguredCoordinates && openMeteoCurrent) ? openMeteoCurrent : ((report && report.current_condition && report.current_condition[0]) ? report.current_condition[0] : openMeteoCurrent)
   readonly property var areaInfo: report && report.nearest_area && report.nearest_area[0] ? report.nearest_area[0] : null
   readonly property var forecastDays: buildForecastDays()
+  readonly property var todayForecast: buildTodayForecast()
   readonly property string reportCountry: areaInfo && areaInfo.country && areaInfo.country[0] ? areaInfo.country[0].value : ""
 
   readonly property bool useImperial: Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, reportCountry)
@@ -146,6 +147,8 @@ Panel {
   readonly property string reportFeels:     current ? formatTemp(useImperial ? current.FeelsLikeF : current.FeelsLikeC) : ""
   readonly property string reportWind:      current ? (useImperial ? (current.windspeedMiles + " mph") : (current.windspeedKmph + " km/h")) : ""
   readonly property string reportHumidity:  current ? (current.humidity + "%") : ""
+  readonly property string todayHigh:       bareTempForDay(todayForecast, "max")
+  readonly property string todayLow:        bareTempForDay(todayForecast, "min")
 
   function refresh() {
     // Each full refresh cycle gets a fresh retry budget, so an earlier
@@ -279,6 +282,10 @@ Panel {
 
   function buildForecastDays() {
     return Model.buildForecastDays(report, dailyForecastReport, Qt.formatDate(new Date(), "yyyy-MM-dd"))
+  }
+
+  function buildTodayForecast() {
+    return Model.buildTodayForecast(report, dailyForecastReport, Qt.formatDate(new Date(), "yyyy-MM-dd"))
   }
 
   function openMeteoForecastDays() {
@@ -541,27 +548,51 @@ Panel {
             font.pixelSize: 64
           }
 
-          Row {
+          Column {
             anchors.verticalCenter: parent.verticalCenter
             spacing: Style.space(2)
 
-            Text {
-              id: tempBig
-              text: root.reportTempNum || "—"
-              color: root.bar.foreground
-              font.family: root.bar.fontFamily
-              // Hero temperature read-out; deliberately oversized, outside
-              // the Style.font.* scale.
-              font.pixelSize: 56
-              font.bold: true
+            Row {
+              spacing: Style.space(2)
+
+              Text {
+                id: tempBig
+                text: root.reportTempNum || "—"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                // Hero temperature read-out; deliberately oversized, outside
+                // the Style.font.* scale.
+                font.pixelSize: 56
+                font.bold: true
+              }
+              Text {
+                text: root.current ? root.tempUnit : ""
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.display
+                anchors.top: tempBig.top
+                anchors.topMargin: Style.space(10)
+              }
             }
-            Text {
-              text: root.current ? root.tempUnit : ""
-              color: root.bar.foreground
-              font.family: root.bar.fontFamily
-              font.pixelSize: Style.font.display
-              anchors.top: tempBig.top
-              anchors.topMargin: Style.space(10)
+
+            // ---- Today's high/low. The forecast strip starts at tomorrow,
+            //      so today's range only appears here.
+            Row {
+              visible: root.todayHigh !== "" || root.todayLow !== ""
+              spacing: Style.space(8)
+
+              Text {
+                text: root.todayHigh === "" ? "" : "H:" + root.todayHigh
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+              }
+              Text {
+                text: root.todayLow === "" ? "" : "L:" + root.todayLow
+                color: Qt.darker(root.bar.foreground, 1.5)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+              }
             }
           }
         }

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -86,6 +86,19 @@ assertDeepEqual(
 )
 
 assertDeepEqual(
+  weather.openMeteoTodayForecast(openMeteo, '2026-05-25'),
+  { date: '2026-05-25', maxtempC: '20', mintempC: '12', maxtempF: '68', mintempF: '54', openMeteoWeatherCode: 0 },
+  'weather resolves today from the Open-Meteo daily forecast'
+)
+assertDeepEqual(
+  weather.openMeteoTodayForecast(openMeteo, '2026-05-27'),
+  { date: '2026-05-27', maxtempC: '18', mintempC: '11', maxtempF: '65', mintempF: '51', openMeteoWeatherCode: 95 },
+  'weather matches today by date rather than trusting the first daily entry'
+)
+assertEqual(weather.openMeteoTodayForecast(openMeteo, '2026-06-01'), null, 'weather returns no today forecast when the day is absent')
+assertEqual(weather.openMeteoTodayForecast({}, '2026-05-25'), null, 'weather returns no today forecast without Open-Meteo data')
+
+assertDeepEqual(
   weather.openMeteoCurrentCondition({ current: { temperature_2m: 21.4, apparent_temperature: 19.8, wind_speed_10m: 14.3, relative_humidity_2m: 63 } }),
   { temp_C: '21', temp_F: '71', FeelsLikeC: '20', FeelsLikeF: '68', windspeedKmph: '14', windspeedMiles: '9', humidity: '63' },
   'weather normalizes open-meteo current conditions to the wttr shape'
@@ -100,6 +113,12 @@ const wttr = {
   ]
 }
 assertEqual(weather.buildForecastDays(wttr, {}, '2026-05-25')[0].date, '2026-05-26', 'weather falls back to wttr forecast')
+assertEqual(weather.wttrTodayForecast(wttr, '2026-05-25').maxtempC, '20', 'weather resolves today from the wttr forecast')
+assertEqual(weather.wttrTodayForecast(wttr, '2026-06-01'), null, 'weather returns no wttr today forecast when the day is absent')
+
+assertEqual(weather.buildTodayForecast(wttr, openMeteo, '2026-05-25').maxtempF, '68', 'weather prefers Open-Meteo for today')
+assertEqual(weather.buildTodayForecast(wttr, {}, '2026-05-25').maxtempC, '20', 'weather falls back to wttr for today')
+assertEqual(weather.buildTodayForecast({}, {}, '2026-05-25'), null, 'weather returns no today forecast without either source')
 assertEqual(weather.bareTempForDay({ maxtempC: '22', mintempC: '13', maxtempF: '72', mintempF: '55' }, 'max', false), '22°', 'weather formats forecast metric highs')
 assertEqual(weather.bareTempForDay({ maxtempC: '22', mintempC: '13', maxtempF: '72', mintempF: '55' }, 'min', true), '55°', 'weather formats forecast imperial lows')
 
@@ -136,6 +155,18 @@ assert(
 assert(
   panelSource.includes('text: root.label || "—"'),
   'weather hero and bar use the same resolved icon'
+)
+
+// The forecast strip starts at tomorrow, so today's range is only ever
+// reachable from the hero block.
+assert(
+  panelSource.includes('bareTempForDay(todayForecast, "max")') &&
+    panelSource.includes('bareTempForDay(todayForecast, "min")'),
+  'weather derives today high and low through the shared forecast formatter'
+)
+assert(
+  /visible: root\.todayHigh !== "" \|\| root\.todayLow !== ""/.test(panelSource),
+  'weather hides the today high-low row when neither value resolved'
 )
 assert(
   panelSource.includes('onReturnRequested: root.startEditingLocation()'),


### PR DESCRIPTION
### The gap

The weather panel never shows today's high and low.

The forecast strip is built from `openMeteoForecastDays` / `wttrForecastDays`, both of which filter through `isFutureForecastDate` (`Model.js:72`), so the strip starts at **tomorrow**. The hero block above it renders only the current temperature. Between the two, today's range is unreachable from the panel — arguably the most-wanted number after the current temp.

### The change

Show today's `H:` / `L:` under the hero temperature.

Both providers already return this data in responses we're making anyway; it was only ever being filtered out. No new network calls, no new settings.

**`Model.js`**
- `openMeteoTodayForecast(dailyForecastReport, todayString)` — scans `daily.time` for today and normalizes to the shape `buildForecastDays` already produces. It matches on date rather than trusting index `0`, since the daily window isn't guaranteed to start today.
- `wttrTodayForecast(report, todayString)` — same for the wttr.in path.
- `buildTodayForecast(...)` — prefers Open-Meteo, falls back to wttr, mirroring how `buildForecastDays` already picks a source.

**`Panel.qml`**
- A `todayForecast` property plus `todayHigh` / `todayLow`, derived through the existing `bareTempForDay(day, kind)` helper (`Panel.qml:313`) so unit selection and formatting stay shared with the forecast strip — `useImperial` and the Open-Meteo→wttr normalization come along for free.
- The hero `Row` is wrapped in a `Column` with a second row for the H/L texts, hidden when neither value resolves (no-data and wttr-only-without-today paths degrade to exactly the current UI).

### Tests

Added to `test/shell.d/weather-test.sh`, following the existing fixtures:

- today resolved from Open-Meteo, including a case where today is **not** the first daily entry
- `null` when the day is absent, and when there's no Open-Meteo data at all
- the wttr path, and `buildTodayForecast` source preference plus fallback
- `Panel.qml` derives H/L through the shared formatter, and hides the row when both are empty

`./test/shell.d/weather-test.sh` passes.

### Verification notes, in the interest of being upfront

- I ran the weather test file, not the full `./test/shell` aggregate, and not the graphical acceptance suite (which per `agents/skills/acceptance-tests.md` wants a disposable VM).
- For the visual side: I've been running this as a cloned widget on 4.0.0 for a bit against both providers, including the wttr fallback, rather than through the formal `visual-verification` flow. Happy to put it through that properly if you'd like — likewise happy to attach a screenshot.

### Open question

Styling of the new row is the part I'd most want a second opinion on. I used `Style.font.body` with the low dimmed via `Qt.darker(foreground, 1.5)`. That may under- or over-weight it against the deliberately oversized hero temperature; easy to change to whatever fits the design.
