### PR TITLE
Fix style inconsistencies in bin/

### DIFF
--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -16,7 +16,7 @@ flags=()
 only=()
 declare -A excluded
 
-while [[ $# -gt 0 ]]; do
+while (( $# > 0 )); do
   case "$1" in
   --force | --limits-only) flags+=("$1") ;;
   --except)

--- a/bin/omarchy-chromium-ytdlp-host
+++ b/bin/omarchy-chromium-ytdlp-host
@@ -116,7 +116,7 @@ main() {
   local length payload url
 
   # Detached worker: this is what actually runs yt-dlp and fires notifications.
-  if [[ "${1:-}" == "--download" ]]; then
+  if [[ ${1:-} == "--download" ]]; then
     download_url "$2"
   fi
 

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -2,10 +2,6 @@
 
 # omarchy:summary=Launch the Omarchy screensaver in the default terminal on the system with the correct font configuration.
 
-if omarchy-cmd-missing ttfx; then
-  exit 1
-fi
-
 # Exit early if screensaver is already running
 pgrep -f '[o]rg.omarchy.screensaver' && exit 0
 

--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -34,23 +34,18 @@ print_status() {
     return
   fi
 
-  if omarchy-cmd-present nmcli; then
-    nm=$(nmcli -t -f GENERAL.STATE,GENERAL.CONNECTION dev show "$device" 2>/dev/null)
-    state=$(awk -F: '$1 == "GENERAL.STATE" { print $2; exit }' <<<"$nm")
-    ssid=$(awk -F: '$1 == "GENERAL.CONNECTION" { print $2; exit }' <<<"$nm")
-    signal=$(nmcli -t -f IN-USE,SIGNAL dev wifi list ifname "$device" --rescan no 2>/dev/null | awk -F: '$1 == "*" { print $2; exit }')
-    freq=$(iw dev "$device" link 2>/dev/null | awk '/freq:/ { print $2; exit }')
+  nm=$(nmcli -t -f GENERAL.STATE,GENERAL.CONNECTION dev show "$device" 2>/dev/null)
+  state=$(awk -F: '$1 == "GENERAL.STATE" { print $2; exit }' <<<"$nm")
+  ssid=$(awk -F: '$1 == "GENERAL.CONNECTION" { print $2; exit }' <<<"$nm")
+  signal=$(nmcli -t -f IN-USE,SIGNAL dev wifi list ifname "$device" --rescan no 2>/dev/null | awk -F: '$1 == "*" { print $2; exit }')
+  freq=$(iw dev "$device" link 2>/dev/null | awk '/freq:/ { print $2; exit }')
 
-    if [[ $state != 100* ]]; then
-      printf 'disconnected\t\t\t\n'
-      return
-    fi
-
-    printf 'wifi\t%s\t%s\t%s\n' "${ssid:-$device}" "$signal" "$freq"
+  if [[ $state != 100* ]]; then
+    printf 'disconnected\t\t\t\n'
     return
   fi
 
-  printf 'wifi\t%s\t\t\n' "$device"
+  printf 'wifi\t%s\t%s\t%s\n' "${ssid:-$device}" "$signal" "$freq"
 }
 
 ping_latency_ms() {

--- a/bin/omarchy-remove-dev-env
+++ b/bin/omarchy-remove-dev-env
@@ -10,7 +10,7 @@ if [[ -z $1 ]]; then
 fi
 
 remove_php() {
-  sudo pacman -Rns --noconfirm php composer php-sqlite xdebug 2>/dev/null || true
+  omarchy-pkg-drop php composer php-sqlite xdebug
 }
 
 case "$1" in
@@ -50,7 +50,7 @@ laravel)
   ;;
 symfony)
   echo -e "Removing Symfony CLI...\n"
-  sudo pacman -Rns --noconfirm symfony-cli 2>/dev/null || true
+  omarchy-pkg-drop symfony-cli
   ;;
 python)
   echo -e "Removing Python...\n"

--- a/bin/omarchy-transcode-ascii
+++ b/bin/omarchy-transcode-ascii
@@ -101,11 +101,6 @@ if [[ ! -f $image_path ]]; then
   exit 1
 fi
 
-if omarchy-cmd-missing magick; then
-  echo "ImageMagick is required to convert logo images" >&2
-  exit 1
-fi
-
 if [[ $mode == "braille" ]]; then
   pixel_width=$((width * 2))
   pixel_height=$((height * 4))


### PR DESCRIPTION
A consistency sweep of `bin/` against the conventions in `AGENTS.md` turned up a handful of stragglers:

- `omarchy-agent-usage-update` used `[[ $# -gt 0 ]]`, the only numeric operator inside `[[ ]]` in all of `bin/`; now `(( $# > 0 ))` like everywhere else.
- `omarchy-chromium-ytdlp-host` quoted a variable inside `[[ ]]`, the only such instance.
- `omarchy-remove-dev-env` called raw `sudo pacman -Rns --noconfirm ... 2>/dev/null || true` for the php and symfony cases; `omarchy-pkg-drop` does exactly this (and already filters to installed packages, making the error suppression unnecessary).
- `omarchy-launch-screensaver`, `omarchy-transcode-ascii`, and `omarchy-network-status` wrapped `ttfx`, `magick`, and `nmcli` in `omarchy-cmd-present`/`omarchy-cmd-missing` guards. All three are in the default package set, so they're runtime invariants that should be invoked directly. Dropping the nmcli guard also drops the degraded wifi fallthrough that could only run when nmcli was missing.

`omarchy-bar-text-color` also guards base-set commands, but those checks feed its deliberate `fallback` path, so they're left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)