### PR TITLE
Persist monitor scaling per monitor instead of via the catch-all

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -89,19 +89,32 @@ set_scale() {
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
-  # Persist to monitors.lua if the user still has Omarchy's generic catch-all
-  # defaults, so the scale survives reboots.
-  if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
-    sed -i -E \
-      -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
-      -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
-      "$monitor_lua"
-  elif [[ -f $monitor_lua ]] && grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
-    sed -i -E \
-      -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
-      -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
-      "$monitor_lua"
+  # Persist the change for THIS monitor only, so it survives reboots without
+  # rescaling other monitors: update the monitor's own hl.monitor rule when the
+  # config has one, otherwise append one. Name-specific rules take precedence
+  # over the catch-all defaults regardless of their order in the file.
+  if [[ ! -f $monitor_lua ]]; then
+    return 0
   fi
+
+  local rule_pattern="^hl\.monitor\(\{ output = \"${active_monitor}\","
+  if grep -Eq "${rule_pattern}.* scale = [0-9.]+" "$monitor_lua"; then
+    sed -i -E "s|(${rule_pattern}.* scale = )[0-9.]+|\\1${new_scale}|" "$monitor_lua"
+  elif ! grep -Eq "$rule_pattern" "$monitor_lua"; then
+    printf 'hl.monitor({ output = "%s", mode = "preferred", position = "auto", scale = %s })\n' \
+      "$active_monitor" "$new_scale" >>"$monitor_lua"
+  else
+    # The monitor has a rule but its scale is not a numeric literal, so the
+    # user is managing this file by hand. Leave the file alone: any write
+    # trips Hyprland's config auto-reload, which would revert the runtime
+    # change just applied above.
+    return 0
+  fi
+
+  sed -i -E \
+    -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
+    -e 's|^hl\.env\("GDK_SCALE", "[0-9]+"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
+    "$monitor_lua"
 }
 
 scale_from_current() {

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -33,7 +33,24 @@ write_monitor_config() {
   cat >"$monitor_lua" <<'LUA'
 local omarchy_gdk_scale = 2
 local omarchy_monitor_scale = 2
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
 LUA
+}
+
+# Persistence is per-monitor: the focused monitor gets its own rule while the
+# catch-all defaults that govern every other monitor stay untouched.
+assert_persisted_rule() {
+  local description="$1"
+  local scale="$2"
+
+  grep -Fx "hl.monitor({ output = \"eDP-1\", mode = \"preferred\", position = \"auto\", scale = $scale })" \
+    "$monitor_lua" >/dev/null || fail "$description"
+  grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+    fail "$description leaves the catch-all scale variable untouched"
+  grep -Fx 'hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })' \
+    "$monitor_lua" >/dev/null || fail "$description leaves the catch-all rule untouched"
 }
 
 run_scaling() {
@@ -48,26 +65,26 @@ run_scaling() {
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling up
 grep -F 'scale = 3' "$eval_out" >/dev/null || fail "monitor scaling up reaches 3x"
-grep -Fx 'local omarchy_monitor_scale = 3' "$monitor_lua" >/dev/null || fail "monitor scaling up persists 3x"
+assert_persisted_rule "monitor scaling up persists 3x for the focused monitor" 3
 grep -F $'requested=up\tcurrent=2\tnew=3\tmonitor=eDP-1' "$scale_log" >/dev/null || fail "monitor scaling up writes audit log"
 pass "monitor scaling up reaches 3x"
 
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=3 run_scaling down
 grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down recovers 3x to 2x"
-grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling down persists 2x from 3x"
+assert_persisted_rule "monitor scaling down persists 2x from 3x for the focused monitor" 2
 pass "monitor scaling down recovers 3x to 2x"
 
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=3.0000000000000004 run_scaling down
 grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down snaps floating point 3x to 2x"
-grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling down persists 2x from floating point 3x"
+assert_persisted_rule "monitor scaling down persists 2x from floating point 3x" 2
 pass "monitor scaling down snaps floating point 3x to 2x"
 
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 3
 grep -F 'scale = 3' "$eval_out" >/dev/null || fail "monitor scaling explicit 3x remains available"
-grep -Fx 'local omarchy_monitor_scale = 3' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 3x persists"
+assert_persisted_rule "monitor scaling explicit 3x persists for the focused monitor" 3
 grep -Fx 'local omarchy_gdk_scale = 3' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 3x persists GDK scale"
 pass "monitor scaling explicit 3x remains available"
 
@@ -76,13 +93,13 @@ pass "monitor scaling explicit 3x remains available"
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
 grep -F 'scale = 1.6' "$eval_out" >/dev/null || fail "monitor scaling explicit 1.6x remains available"
-grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 1.6x persists"
+assert_persisted_rule "monitor scaling explicit 1.6x persists for the focused monitor" 1.6
 grep -Fx 'local omarchy_gdk_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling 1.6x persists integer GDK scale 2"
 pass "monitor scaling 1.6x persists integer GDK scale 2"
 
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.25
-grep -Fx 'local omarchy_monitor_scale = 1.25' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 1.25x persists"
+assert_persisted_rule "monitor scaling explicit 1.25x persists for the focused monitor" 1.25
 grep -Fx 'local omarchy_gdk_scale = 1' "$monitor_lua" >/dev/null || fail "monitor scaling 1.25x persists integer GDK scale 1"
 pass "monitor scaling 1.25x persists integer GDK scale 1"
 
@@ -98,8 +115,7 @@ pass "monitor scaling reports the actual non-preset scale"
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 OMARCHY_TEST_MONITOR_WIDTH=1280 OMARCHY_TEST_MONITOR_HEIGHT=800 run_scaling 3
 grep -F 'scale = 3.2' "$eval_out" >/dev/null || fail "monitor scaling approximates explicit 3x as 3.2x"
-grep -Fx 'local omarchy_monitor_scale = 3.2' "$monitor_lua" >/dev/null ||
-  fail "monitor scaling persists approximated 3.2x"
+assert_persisted_rule "monitor scaling persists approximated 3.2x" 3.2
 pass "monitor scaling approximates explicit 3x as 3.2x"
 
 write_monitor_config
@@ -126,6 +142,39 @@ pass "monitor scaling accepts displayed approximate values"
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=4 OMARCHY_TEST_MONITOR_WIDTH=1280 OMARCHY_TEST_MONITOR_HEIGHT=804 run_scaling down
 grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips duplicate 4x approximation"
-grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
-  fail "monitor scaling down persists 2x after skipping duplicate approximation"
+assert_persisted_rule "monitor scaling down persists 2x after skipping duplicate approximation" 2
 pass "monitor scaling down skips duplicate approximation"
+
+# A config with an explicit rule for the focused monitor gets that rule updated
+# in place — no appended duplicate, and the catch-all stays untouched, so the
+# config auto-reload re-applies the NEW value instead of reverting it.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 1.6
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+hl.monitor({ output = "eDP-1", mode = "2560x1440@165", position = "1920x0", scale = 1 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=1 run_scaling 1.25
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "2560x1440@165", position = "1920x0", scale = 1.25 })' \
+  "$monitor_lua" >/dev/null || fail "monitor scaling updates an existing per-monitor rule in place"
+grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling with an existing rule leaves the catch-all scale variable untouched"
+rule_count=$(grep -Ec '^hl\.monitor\(\{ output = "eDP-1",' "$monitor_lua")
+(( rule_count == 1 )) || fail "monitor scaling does not append a duplicate rule" "actual: $rule_count"
+pass "monitor scaling updates an existing per-monitor rule in place"
+
+# A hand-managed rule (scale is a variable, not a numeric literal) is left
+# entirely alone — no write means no config auto-reload to revert the runtime
+# change that was just applied.
+cat >"$monitor_lua" <<'LUA'
+local laptop_scale = 1.25
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = laptop_scale })
+LUA
+before=$(cat "$monitor_lua")
+OMARCHY_TEST_MONITOR_SCALE=1.25 run_scaling 2
+grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling still applies at runtime on a hand-managed config"
+[[ $(cat "$monitor_lua") == "$before" ]] ||
+  fail "monitor scaling leaves a hand-managed config file untouched"
+pass "monitor scaling leaves a hand-managed config file untouched"


### PR DESCRIPTION
## Problem

`omarchy-hyprland-monitor-scaling` (also driving the Display panel's scale buttons and the SUPER+SLASH bindings) applies the new scale to the **focused monitor** at runtime via `hyprctl eval`, but persists it by rewriting the **global** `omarchy_monitor_scale` / catch-all rule in `~/.config/hypr/monitors.lua`. Both persistence branches write the catch-all; there is no per-monitor path.

Since writing the file trips Hyprland's config auto-reload (~30 ms later), this is not just a persistence bug:

- On multi-monitor setups, scaling one monitor rescales **all the others** within a second, in the same session (#6673).
- On configs that already carry an explicit `hl.monitor({ output = ... })` rule for the focused monitor, that rule overrides the rewritten catch-all on reload, so the tool's own runtime change is **instantly reverted** — the scale can never be changed at all (#7242).

On a single-monitor stock config the two writes happen to agree, which is why this is invisible in the default setup.

## Fix

Persist to the focused monitor's own rule instead of the catch-all:

- If `monitors.lua` has an `hl.monitor({ output = "<focused>" ... })` rule with a numeric scale, update that rule's scale in place — the auto-reload then re-applies the *new* value instead of reverting it.
- If the monitor has no rule, append one (`mode = "preferred", position = "auto"`, matching the catch-all defaults that governed it until now). Name-specific rules take precedence over the catch-all regardless of order, and the catch-all keeps governing every monitor that has no rule of its own.
- If the monitor's rule exists but its scale is **not** a numeric literal (the user manages the file by hand, e.g. `scale = laptop_scale`), leave the file completely untouched — any write would trigger the self-reverting reload described in #7242. The runtime change still applies for the session.

`omarchy_monitor_scale` and the catch-all rule are never rewritten anymore. GDK_SCALE persistence is unchanged.

## Tests

Reworked `test/shell.d/monitor-scaling-test.sh` for the new behavior: the stock fixture now includes the catch-all rule, and every persistence assertion checks that the focused monitor's rule carries the new scale **and** that the catch-all variable and rule are untouched. Two new regression cases: in-place update of an existing explicit rule with no duplicate appended (#7242's config shape), and a hand-managed config left byte-identical while the runtime change still applies.

`./test/cli` and `./test/shell` pass (the 3 failures in `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` pre-exist on clean HEAD in my environment).

Fixes #6673
Fixes #7242

🤖 Generated with [Claude Code](https://claude.com/claude-code)