### PR TITLE
Move Herdr to the herdr-git package

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -50,7 +50,7 @@ gum
 gvfs-mtp
 gvfs-nfs
 gvfs-smb
-herdr
+herdr-git
 hyprland
 hyprland-guiutils
 hyprland-preview-share-picker

--- a/migrations/1787155435.sh
+++ b/migrations/1787155435.sh
@@ -1,0 +1,19 @@
+echo "Switch to the herdr-git package that follows upstream Herdr"
+
+# herdr was built from an Omarchy fork whose only divergence was replaying an
+# agent's CLI options on resume, work upstream declined twice. herdr-git drops
+# the fork and follows upstream master, which renames the package.
+
+if omarchy-pkg-present herdr-git; then
+  exit 0
+fi
+
+# One transaction rather than a drop and an add: the session is usually running
+# inside herdr, and an install that failed between the two would leave it with
+# no terminal. --noconfirm answers "no" to the conflict herdr-git raises against
+# the installed herdr, so --ask 4 preselects removing it.
+sudo pacman -S --noconfirm --ask 4 --needed herdr-git
+
+# pacman does not always exit non-zero when a package fails to install, and a
+# migration that marked itself done would leave this machine on the fork for good.
+omarchy-pkg-present herdr-git


### PR DESCRIPTION
The `herdr` package was built from an Omarchy fork of Herdr whose only divergence was three commits replaying an agent's CLI options when a session resumed. Upstream declined that work twice — from a contributor in herdrdev/herdr#2036, and from us in herdrdev/herdr#2614, closed in favour of an agent resume manifest meant to supersede it — so the fork bought one feature at the price of rebasing it onto upstream forever. omacom-io/omarchy-pkgs#170 drops the fork and builds from upstream master instead, which renames the package to `herdr-git`.

Packaging upstream's v0.8.0 release rather than master was the other way out, and it regresses more than the fork gained: configurable outer pane borders, direct pane resize keybindings, move tab keybind actions, centered tab labels and outer terminal window title sync all merged upstream *after* that tag, so the release predates five features Omarchy contributed.

The rename means the package list has to name the new package, and existing installs need a nudge. `herdr-git` declares `replaces`, but pacman honours that only during a full sysupgrade, so anyone who updates another way keeps the old name.

The migration installs `herdr-git` in one transaction rather than dropping `herdr` and adding it back, because the session is usually running inside Herdr and an install that failed between the two would leave the machine with no terminal. That needs `--ask 4`: `--noconfirm` answers "no" to the conflict `herdr-git` raises against the installed `herdr`, which is the same reason `omarchy-upgrade-to-quattro` passes it. It ends by asserting the package is really present, because pacman does not always exit non-zero when an install fails, and a migration that marked itself done would leave the machine on the fork for good.

Draft on purpose: nothing here can merge before `herdr-git` is published to the package mirrors. Until then the migration fails, stays pending and retries — safe, but noisy. Two steps outside this repo have to land first: publish `herdr-git` for every architecture, then `repo-remove` the old `herdr` from each mirror's database, which deleting its PKGBUILD does not do on its own. `omarchy-herdr` is still published today for exactly that reason, orphaned by the previous rename.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
