### PR TITLE
Show limits for OpenCode's OpenAI account

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -6,8 +6,9 @@
 
 Local stats come from native Codex CLI session files, pi/omp sessions that
 ran through openai-codex, and opencode sessions that ran on an OpenAI
-provider; rate limits and the plan come from the Codex app-server RPC. The agents
-panel only ever reads the JSON this prints.
+provider. Rate limits come from the native Codex login and, when it belongs
+to a different account, OpenCode's OpenAI OAuth login. The agents panel only
+ever reads the JSON this prints.
 """
 
 import argparse
@@ -495,7 +496,7 @@ def rpc_request(proc, request_id, method, params=None, timeout=8):
   raise TimeoutError(method)
 
 
-def limit_window(window):
+def limit_window(window, prefix=""):
   if not isinstance(window, dict):
     return None
   used = window.get("usedPercent")
@@ -510,12 +511,118 @@ def limit_window(window):
     label = f"{mins}m window"
   else:
     label = "Limit"
+  if prefix:
+    label = f"{prefix} · {label}"
   reset = window.get("resetsAt")
   return {
     "label": label,
     "percent": float(used) / 100.0,
     "resetsAt": datetime.fromtimestamp(number(reset), timezone.utc).isoformat() if reset else "",
   }
+
+
+def read_json(path):
+  try:
+    with path.open() as handle:
+      data = json.load(handle)
+    return data if isinstance(data, dict) else {}
+  except Exception:
+    return {}
+
+
+def codex_account_id():
+  codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+  auth = read_json(codex_home / "auth.json")
+  tokens = auth.get("tokens") or {}
+  return str(tokens.get("account_id") or "") if isinstance(tokens, dict) else ""
+
+
+def opencode_openai_auth():
+  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+  auth = read_json(data_home / "opencode" / "auth.json").get("openai") or {}
+  if not isinstance(auth, dict) or auth.get("type") != "oauth":
+    return None
+  access_token = str(auth.get("access") or "")
+  account_id = str(auth.get("accountId") or "")
+  if not access_token or not account_id:
+    return None
+  return {"accessToken": access_token, "accountId": account_id}
+
+
+def stop_process(proc):
+  try:
+    proc.terminate()
+    proc.wait(timeout=1)
+  except Exception:
+    try:
+      proc.kill()
+    except Exception:
+      pass
+
+
+def start_codex_app_server(codex, env):
+  return subprocess.Popen(
+    [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    env=env,
+  )
+
+
+def initialize_app_server(proc, experimental=False):
+  params = {"clientInfo": {"name": "omarchy-agent-usage", "version": "1"}}
+  if experimental:
+    params["capabilities"] = {"experimentalApi": True}
+  rpc_request(proc, 1, "initialize", params, timeout=8)
+  proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
+  proc.stdin.flush()
+
+
+def fetch_opencode_rpc(codex, native_account):
+  auth = opencode_openai_auth()
+  if not auth:
+    return None
+
+  native_id = codex_account_id()
+  if native_id and native_id == auth["accountId"]:
+    return None
+
+  try:
+    with tempfile.TemporaryDirectory(prefix="omarchy-opencode-openai-") as temp_codex_home:
+      env = ENV.copy()
+      env["CODEX_HOME"] = temp_codex_home
+      env.pop("OPENAI_API_KEY", None)
+      proc = start_codex_app_server(codex, env)
+      try:
+        initialize_app_server(proc, experimental=True)
+        login_msg = rpc_request(proc, 2, "account/login/start", {
+          "type": "chatgptAuthTokens",
+          "accessToken": auth["accessToken"],
+          "chatgptAccountId": auth["accountId"],
+        }, timeout=4)
+        if login_msg.get("error"):
+          return None
+        account_msg = rpc_request(proc, 3, "account/read", {"refreshToken": False}, timeout=4)
+        limits_msg = rpc_request(proc, 4, "account/rateLimits/read", timeout=4)
+      finally:
+        stop_process(proc)
+  except Exception:
+    return None
+
+  account = (account_msg.get("result") or {}).get("account") or {}
+  # File-backed Codex auth gives an exact account-id comparison. If Codex
+  # stores credentials elsewhere, use the account email as a conservative
+  # fallback rather than drawing duplicate meters for the same subscription.
+  if not native_id and native_account.get("type") == "chatgpt":
+    native_email = str(native_account.get("email") or "")
+    opencode_email = str(account.get("email") or "")
+    if not native_email or not opencode_email or native_email == opencode_email:
+      return None
+
+  limits = (limits_msg.get("result") or {}).get("rateLimits") or {}
+  return {"account": account, "limits": limits}
 
 
 def fetch_codex_rpc():
@@ -527,23 +634,14 @@ def fetch_codex_rpc():
     return result
 
   try:
-    proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
-      stdin=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.DEVNULL,
-      text=True,
-      env=ENV,
-    )
+    proc = start_codex_app_server(codex, ENV)
   except Exception as exc:
     result["usageStatusText"] = "Codex unavailable"
     result["authHelpText"] = str(exc)
     return result
 
   try:
-    rpc_request(proc, 1, "initialize", {"clientInfo": {"name": "omarchy-agent-usage", "version": "1"}}, timeout=8)
-    proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
-    proc.stdin.flush()
+    initialize_app_server(proc)
     account_msg = rpc_request(proc, 2, "account/read", timeout=4)
     limits_msg = rpc_request(proc, 3, "account/rateLimits/read", timeout=4)
 
@@ -556,18 +654,22 @@ def fetch_codex_rpc():
       entry = limit_window(window)
       if entry:
         result["limits"].append(entry)
+
+    opencode = fetch_opencode_rpc(codex, account)
+    if opencode:
+      for window in (opencode["limits"].get("primary"), opencode["limits"].get("secondary")):
+        entry = limit_window(window, "OpenCode")
+        if entry:
+          result["limits"].append(entry)
+      if not result["tierLabel"]:
+        opencode_account = opencode["account"]
+        plan = opencode["limits"].get("planType") or opencode_account.get("planType") or ""
+        result["tierLabel"] = str(plan) if plan else ""
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
     result["authHelpText"] = str(exc)
   finally:
-    try:
-      proc.terminate()
-      proc.wait(timeout=1)
-    except Exception:
-      try:
-        proc.kill()
-      except Exception:
-        pass
+    stop_process(proc)
   return result
 
 

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -26,7 +26,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box. If OpenCode uses a different OpenAI subscription from the native Codex CLI, its limits appear separately without asking you to sign in again.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -53,7 +53,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | Collector | Limits | Local stats |
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
-| `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
+| `codex` | The Codex app-server RPC, including a distinct OpenCode OpenAI OAuth account | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
@@ -63,6 +63,8 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+When OpenCode has an OAuth login for its `openai` provider, the Codex collector compares its ChatGPT account id with the native Codex login. A different account gets separately labelled `OpenCode` limit meters through an isolated Codex app-server external-token session; the same account is skipped so its meters do not appear twice. This reuses the login already stored by OpenCode and never changes either tool's saved credentials. If account identity cannot be established or the OpenCode token no longer works, the native limits and combined local stats remain available.
 
 ### Fireworks balance
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -590,3 +590,83 @@ result=$(HOME="$INTERRUPTED_HOME" CODEX_HOME="$INTERRUPTED_HOME/.codex" XDG_CACH
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "9" ]] ||
   fail "Codex collector does not reuse a snapshot from an interrupted scan" "$result"
 pass "Codex collector does not cache an interrupted opencode scan"
+
+# OpenCode can hold a different ChatGPT subscription from the native Codex
+# CLI. Its OAuth token should be handed to an isolated app-server process,
+# and its limits should only be added when the stable account ids differ.
+LIMITS_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$LIMITS_HOME"' EXIT
+mkdir -p "$LIMITS_HOME/bin" "$LIMITS_HOME/.codex" "$LIMITS_HOME/.local/share/opencode"
+
+cat >"$LIMITS_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+
+external=false
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  method=$(jq -r '.method // empty' <<<"$request")
+
+  case "$method" in
+    initialize)
+      experimental=$(jq -r '.params.capabilities.experimentalApi // false' <<<"$request")
+      printf 'initialize:%s\n' "$experimental" >>"$RPC_LOG"
+      jq -cn --argjson id "$id" '{id: $id, result: {}}'
+      ;;
+    account/login/start)
+      external=true
+      type=$(jq -r '.params.type // empty' <<<"$request")
+      has_access=$(jq -r '(.params.accessToken // "") != ""' <<<"$request")
+      has_account=$(jq -r '(.params.chatgptAccountId // "") != ""' <<<"$request")
+      printf 'login:%s:%s:%s\n' "$type" "$has_access" "$has_account" >>"$RPC_LOG"
+      jq -cn --argjson id "$id" '{id: $id, result: {type: "chatgptAuthTokens"}}'
+      ;;
+    account/read)
+      if [[ $external == "true" ]]; then
+        jq -cn --argjson id "$id" '{id: $id, result: {account: {type: "chatgpt", email: "opencode@example.com", planType: "plus"}}}'
+      else
+        jq -cn --argjson id "$id" '{id: $id, result: {account: {type: "chatgpt", email: "codex@example.com", planType: "pro"}}}'
+      fi
+      ;;
+    account/rateLimits/read)
+      if [[ $external == "true" ]]; then
+        jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {primary: {usedPercent: 25, windowDurationMins: 300, resetsAt: 1780000000}}}}'
+      else
+        jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {primary: {usedPercent: 10, windowDurationMins: 10080, resetsAt: 1780000000}}}}'
+      fi
+      ;;
+  esac
+done
+EOF
+chmod +x "$LIMITS_HOME/bin/codex"
+
+printf '%s\n' '{"tokens":{"account_id":"native-account"}}' >"$LIMITS_HOME/.codex/auth.json"
+printf '%s\n' '{"openai":{"type":"oauth","access":"secret-opencode-token","accountId":"opencode-account"}}' >"$LIMITS_HOME/.local/share/opencode/auth.json"
+
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["Weekly (7-day)",0.1],["OpenCode · 5h window",0.25]]' ]] ||
+  fail "Codex collector adds separately labelled OpenCode limits" "$result"
+[[ $(jq -r '.tierLabel' <<<"$result") == "pro" ]] ||
+  fail "Codex collector keeps the native subscription as the hero plan" "$result"
+[[ $(grep -c '^login:chatgptAuthTokens:true:true$' "$LIMITS_HOME/rpc.log") == "1" ]] ||
+  fail "Codex collector supplies OpenCode OAuth through external-token auth" "$(<"$LIMITS_HOME/rpc.log")"
+[[ $(grep -c '^initialize:true$' "$LIMITS_HOME/rpc.log") == "1" ]] ||
+  fail "Codex collector enables the experimental external-token API only for OpenCode" "$(<"$LIMITS_HOME/rpc.log")"
+[[ $result != *"secret-opencode-token"* && $result != *"native-account"* && $result != *"opencode-account"* ]] ||
+  fail "Codex collector keeps account credentials out of its record" "$result"
+pass "Codex collector adds limits from a different OpenCode account"
+
+# The same ChatGPT account in both tools must not produce duplicate meters or
+# even start a second app-server authentication flow.
+printf '%s\n' '{"openai":{"type":"oauth","access":"secret-opencode-token","accountId":"native-account"}}' >"$LIMITS_HOME/.local/share/opencode/auth.json"
+: >"$LIMITS_HOME/rpc.log"
+
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["Weekly (7-day)",0.1]]' ]] ||
+  fail "Codex collector deduplicates matching native and OpenCode accounts" "$result"
+[[ $(grep -c '^login:' "$LIMITS_HOME/rpc.log") == "0" ]] ||
+  fail "Codex collector skips external auth for a matching account" "$(<"$LIMITS_HOME/rpc.log")"
+pass "Codex collector deduplicates matching native and OpenCode accounts"


### PR DESCRIPTION
## Use case

A user can sign native Codex into one ChatGPT subscription while OpenCode’s `openai` provider uses another. The Codex collector already combines local token usage from native Codex, T3 Code, pi/omp, and OpenCode, but it only reports rate limits for the native Codex account. That leaves the second subscription’s actual limit windows invisible.

## What changed

- add an explicit `providers.codex.openCodeOpenAiLimits` opt-in, disabled by default
- when enabled, reuse OpenCode’s existing OpenAI OAuth login through an isolated Codex app-server `chatgptAuthTokens` session
- compare stable ChatGPT account IDs and skip the extra session when both tools use the same account
- label both accounts’ limit meters with their emails when they differ, falling back to `Codex` and `OpenCode` when an email is unavailable
- preserve native limits when OpenCode authentication fails or returns no usable windows
- never initiate a login or change either tool’s saved credentials

Token aggregation is unchanged. Native Codex, T3 Code, pi/omp, and OpenCode OpenAI usage continue to feed the same Codex daily/model totals; this option only adds rate-limit tracking for a distinct OpenCode account.

The external-token and rate-limit RPCs are documented in the Codex app-server guide: https://developers.openai.com/codex/app-server/

## Validation

- `python3` syntax compilation for the Codex collector
- Bash syntax validation for the updater and changed shell tests
- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- `bash test/shell.d/agent-usage-claude-limits-test.sh` for the shared panel title path
- `bash test/shell.d/agent-usage-update-test.sh`
- `bash test/shell.d/agents-panel-test.sh`
- `./test/cli`
- live sanitized collector check with two distinct OpenAI subscriptions: two limit windows, two explicit display titles, two email-labelled titles, and no error status
- temporary cloned agents plugin wired to the checkout with isolated usage state: clone activated successfully and produced the same two email-labelled live limits
- `./test/all`: 180 of 184 test files passed; the remaining four are environment-dependent failures (three require an `omarchy-pkgs` checkout and one is the existing live Quickshell runtime-smoke check)