### PR TITLE
Dismiss the screensaver on touch and pointer input, bluetooth mice included

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -43,10 +43,20 @@ function screensaverWindowsAfter(windows, address, visible) {
   }
 }
 
+// A second idle monitor watches for input while the screensaver is displayed.
+// It only counts as input once the monitor has gone quiet since the screensaver
+// appeared, because launching the screensaver registers as activity itself.
+function dismissStateAfter(settled, isIdle, visible) {
+  if (!visible) return { settled: false, dismiss: false }
+  if (isIdle) return { settled: true, dismiss: false }
+  return { settled: false, dismiss: !!settled }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
-    screensaverWindowsAfter: screensaverWindowsAfter
+    screensaverWindowsAfter: screensaverWindowsAfter,
+    dismissStateAfter: dismissStateAfter
   }
 }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -24,6 +24,7 @@ Item {
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
+  readonly property bool screensaverVisible: screensaverWindowCount > 0
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
@@ -79,6 +80,20 @@ Item {
     runProcess(lockProcess, "lock", "omarchy-system-lock")
   }
 
+  function dismissScreensaver(reason) {
+    logEvent("screensaver-dismiss", reason || "input")
+    // Signal the script, not its terminal: exit_screensaver stops ttfx before the
+    // terminal closes, and closing it first takes ttfx's pty with it. The terminal
+    // also ends in "omarchy-screensaver", hence the bash prefix.
+    runProcess(dismissProcess, "dismiss", "pkill -f 'bash .*bin/omarchy-screensaver$'")
+  }
+
+  function handleDismissMonitorChanged() {
+    var next = IdleModel.dismissStateAfter(dismissMonitor.settled, dismissMonitor.isIdle, root.screensaverVisible)
+    dismissMonitor.settled = next.settled
+    if (next.dismiss) dismissScreensaver("input-while-screensaver-visible")
+  }
+
   function startIdleCycle() {
     if (root.idledThisCycle) {
       logEvent("idle-cycle-already-running")
@@ -88,7 +103,9 @@ Item {
     logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
-    resetScreensaverWindows()
+    // Screensaver windows outlive idle cycles: one launched from the menu is
+    // still on screen when the idle timeout arrives, and Hyprland sends no
+    // second openwindow for it. Clearing here would lose it for good.
 
     if (root.screensaverDelaySeconds === 0) launchScreensaver()
     else screensaverTimer.restart()
@@ -255,6 +272,20 @@ Item {
     onIsIdleChanged: root.handleIdleChanged()
   }
 
+  // Launching the screensaver counts as activity, so the main monitor sits at
+  // active for as long as it is displayed and never signals again. This one is
+  // armed only while the screensaver is up, and catches the input its read-loop
+  // cannot see: touch and pointer motion never reach the screensaver's stdin.
+  IdleMonitor {
+    id: dismissMonitor
+    property bool settled: false
+    enabled: root.screensaverVisible
+    timeout: 1
+    respectInhibitors: false
+    onEnabledChanged: settled = false
+    onIsIdleChanged: root.handleDismissMonitorChanged()
+  }
+
   Timer {
     id: screensaverTimer
     interval: root.screensaverDelaySeconds * 1000
@@ -292,6 +323,10 @@ Item {
   Process {
     id: lockProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "lock exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+  Process {
+    id: dismissProcess
+    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "dismiss exitCode=" + exitCode + " status=" + exitStatus) }
   }
   Process {
     id: wakeProcess

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,27 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assertDeepEqual(
+  idle.dismissStateAfter(false, true, true),
+  { settled: true, dismiss: false },
+  'idle settles the dismiss monitor once the screensaver goes quiet'
+)
+assertDeepEqual(
+  idle.dismissStateAfter(true, false, true),
+  { settled: false, dismiss: true },
+  'idle dismisses the screensaver on input after it has settled'
+)
+assertDeepEqual(
+  idle.dismissStateAfter(false, false, true),
+  { settled: false, dismiss: false },
+  'idle ignores the activity caused by launching the screensaver'
+)
+assertDeepEqual(
+  idle.dismissStateAfter(true, false, false),
+  { settled: false, dismiss: false },
+  'idle never dismisses without a screensaver on screen'
+)
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
# Dismiss the screensaver on touch and pointer input, bluetooth mice included

`bin/omarchy-screensaver` can only be dismissed by a **keypress**. Touch, pointer motion and mouse clicks are all ignored. On a convertible in tablet mode there is no way to dismiss it at all — and touch is delivered *into* the screensaver terminal, so you can tap, scroll and select text in it while it is displayed.

The dismiss loop has exactly two exits (`bin/omarchy-screensaver:43-47`):

```bash
if read -n1 -t 1 || ! screensaver_in_focus; then
```

`read -n1 -t 1` needs a byte on **stdin** — a keypress. `! screensaver_in_focus` needs the focused window **class** to change. A click on a fullscreen screensaver that already has focus produces neither, and pointer motion produces neither since the mouse-tracking escapes were removed in d2ea6ad1.

## The fix

Arm a second `IdleMonitor` for as long as a screensaver is on screen. It settles once the launch activity passes, and the next seat input dismisses.

`ext-idle-notify` is compositor-side and device-agnostic, so one path covers keyboard, touch, touchpad, clicks and bluetooth mice — the terminal and per-device escape sequences are not involved at all. The state machine lives in `IdleModel.js` as a pure function alongside the existing helpers, so `test/shell.d/idle-test.sh` covers it.

No change to `bin/omarchy-screensaver`: its `trap` already tears down in the right order, and the existing `closewindow` → `handleScreensaverWindowClosed()` path already cancels the pending lock and runs wake.

## On the d2ea6ad1 revert

The revert reason was *"Could not get it to stop existing with a Logitech MX4 when connected via bluetooth."* That failure was specific to the approach: #3723 made the **terminal** watch for mouse reports (`\e[?1000h\e[?1003h`), which is client-side and device-dependent. This never involves the terminal, and is verified here with a **Logitech MX Master 3S over bluetooth**.

## Caveats

- Dismissing by touch can segfault `foot` when the finger is **still down** as the window tears down — a use-after-free in foot, not in this change, though this change makes it reachable. Root-caused and fixed upstream: [dnkl/foot#2436](https://codeberg.org/dnkl/foot/pulls/2436). Details below.
- The `pkill` in `dismissScreensaver()` overlaps with #6813, which reworks screensaver teardown into per-supervisor ownership. The detection half (the second monitor) is what is missing today and composes with whatever lands there.
- Tested with **foot** only; alacritty/ghostty/kitty untested.

<details>
<summary><b>Why this cannot be fixed in <code>handleActiveSignal()</code>, or by polling the pointer</b></summary>

The main `IdleMonitor` is already `active` for the whole time the screensaver is displayed and never signals again. Launching the screensaver focuses the new window, which the compositor reports as activity. Every cycle, from the shell's own log:

```
21:12:39.087  idle-monitor: idle
21:12:39.087  process-start: screensaver
21:12:39.424  idle-monitor: active                          <- +337ms, self-inflicted
21:12:39.424  idle-monitor-active: screensaver cycle remains armed
      ... no further idle-monitor events for the whole display ...
21:15:09.093  lock-system: lock-timeout
```

That blip is what the `screensaverLaunchGraceTimer` guard already absorbs. The control case confirms the cause: when the session is already locked, `omarchy-launch-screensaver` is skipped by the `isLocked` guard and no `idle-monitor: active` follows.

So `isIdle` is `false` before the user touches anything and stays `false`; a new branch there would be unreachable.

Polling the pointer does not work either. Touch never moves it: across 1248 touchscreen events over 5.5s, `hyprctl cursorpos` did not change once, while a touchpad drag tracked it sample-for-sample. `cursor:hide_on_touch` defaults to true and Hyprland routes touch through `wl_touch`, separate from the pointer.

</details>

<details>
<summary><b>Testing</b></summary>

`./test/shell` — 4 new assertions in `test/shell.d/idle-test.sh`; 181/184 files pass. The 3 failures (`config`, `snapper`, `unowned-system-paths`) reproduce identically on a clean checkout here and are environment-specific.

Verified in the running UI per `agents/skills/visual-verification.md`, running the checkout via `omarchy dev link`. Raw evdev correlated against the shell's own journal:

| input | dismissed | notes |
|---|---|---|
| keyboard | yes | unchanged path |
| touchscreen, quick tap | yes | finger held 0.05s |
| touchpad | yes | |
| bluetooth mouse (Logitech MX Master 3S) | yes | the device class that caused d2ea6ad1 |
| touchscreen, held ~3s | yes | dismisses, but trips the foot bug |

270ms from finger to dismissal:

```
114.82  SHELL        idle-monitor: active          (launch blip)
117.67  TOUCHSCREEN  BTN_TOUCH DOWN
117.83  TOUCHSCREEN  BTN_TOUCH UP
117.94  SHELL        screensaver-dismiss: input-while-screensaver-visible
117.94  SHELL        idle-cycle-cancel: screensaver-dismissed
118.32  SHELL        process-exit: wake exitCode=0
```

Also covered:

- **Screensaver launched from the menu** (`system.screensaver` → `omarchy-launch-screensaver force`), i.e. outside any idle cycle — dismissal works, which is why `screensaverVisible` keys off `screensaverWindowCount` rather than the idle-cycle flags.
- **Multi-monitor** — with a second output added via `hyprctl output create headless`, `omarchy-launch-screensaver` starts one instance per output and dismissal tears down both.

Environment: Acer Spin SP313-51N (Wacom HID 49AF Finger touchscreen), Hyprland 0.56.2, foot 1.27.0.

Known limitation, inherited rather than introduced: the service learns about screensaver windows from `openwindow` events, so a screensaver already on screen when the shell restarts is not tracked and will not arm the dismiss monitor.

</details>

<details>
<summary><b>The foot use-after-free, in detail</b></summary>

Symbolized, and identical across three independent crashes:

```
#0   wl_touch_up (serial=1193, time=921788) at ../input.c:3587
#10  wl_display_roundtrip_queue (wayland-client.c:1479)
#12  wayl_roundtrip   (../wayland.c:2416)
#13  wayl_win_destroy (../wayland.c:2297)
```

`wayl_win_destroy()` does a `wl_display_roundtrip()`, which dispatches still-queued Wayland events — and a pending `wl_touch.up` then runs `wl_touch_up()` against the window being freed.

| touch | trials | crashes |
|---|---|---|
| quick tap (lifted before teardown) | 4 | 0 |
| held through teardown | 3 | 3 |

In one run the two crashes land 1.4s and 0.9s after the two held-touch dismissals and nowhere else, while a tap held 0.05s dismissed cleanly in the same run.

Dismissal is issued about 270ms after finger-down, so a normal tap is already clear of the window and only a held touch hits it. It is a race rather than a certainty — it depends on whether a `wl_touch.up` happens to be queued when the roundtrip runs — but a held touch loses it reliably in practice.

`wl_touch` has no `leave` event, so the unmap in `wayl_win_destroy()` cannot drop touch focus the way it drops keyboard and pointer focus — `seat->touch.surface` keeps pointing at the window being destroyed. Fixed upstream in [dnkl/foot#2436](https://codeberg.org/dnkl/foot/pulls/2436) (17 lines, tested: 3/3 crashes before, 0/7 after).

Not worked around here, because a timing delay would only narrow the race rather than close it. Note also that #7193 replaces the foot-based screensaver with a native Wayland client, which would remove this exposure entirely.

</details>

<details>
<summary><b>Teardown ordering, and why the pkill pattern looks like that</b></summary>

`dismissScreensaver()` signals the screensaver script, not its terminal, so the script's `trap` runs `exit_screensaver` and stops `ttfx` before the terminal closes. Closing the terminal first takes `ttfx`'s pty with it and `ttfx` aborts — the same failure as #6762 / #6764.

The terminal's own command line also ends in `omarchy-screensaver` (`foot … -e omarchy-screensaver`), so the pattern requires the `bash` prefix to avoid matching both and killing them simultaneously.

#7193 is unaffected by this change: it execs an externally packaged binary and does not alter dismissal logic in this repo. A fix at the idle-service level is implementation-independent, though the stop command would need to cover the native client too.

</details>

---

Diagnosis and patch developed with AI assistance (Claude), verified on hardware.
