### PR TITLE
Add ttl to base packages

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -128,6 +128,7 @@ tmux
 tobi-try
 ttf-ia-writer
 ttf-jetbrains-mono-nerd
+ttl-bin
 typora
 tzupdate
 ufw


### PR DESCRIPTION
`ttl` is a modern traceroute/mtr-style TUI: real-time per-hop latency, loss,
and jitter, with optional ASN/geo/IX enrichment. Think `mtr` with a live view.

![demo](https://raw.githubusercontent.com/lance0/ttl/master/docs/demo.gif)

Why it fits base:
- Base already leans on TUI-first tools (`btop`, `impala`, `bluetui`,
  `lazygit`) — `ttl` is the network-path equivalent. Today the only traceroute
  in base is classic `inetutils`.
- **Runs without sudo.** The `ttl-bin` package sets `cap_net_raw+ep` on
  install, so `ttl <host>` just works for a normal user — no root, no manual
  setcap.
- Prebuilt release binary (`ttl-bin`), so no Rust compile at install time.
  Single static binary, ships bash/zsh/fish completions.
- MIT/Apache-2.0, actively maintained, ~1.4k stars.

Heads up on the name: `ttl` reads like the TTL concept, but that's the upstream
binary/package name (github.com/lance0/ttl).

No hard feelings if a traceroute TUI isn't core enough for base — figured it
was worth offering given how well it matches the existing TUI lineup.
