### PR TITLE
Fall back to the portal backend when kms can't capture the monitor

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -198,7 +198,33 @@ start_screenrecording() {
   if kill -0 $pid 2>/dev/null; then
     echo "$filename" >"$RECORDING_FILE"
     toggle_screenrecording_indicator
+    return 0
   fi
+
+  # gsr exited without writing the file. On a hybrid laptop the kms backend
+  # connects to the iGPU's DRM card, so it can't see an external monitor wired
+  # to the dGPU — gsr logs "failed to find monitor by name" and exits. gsr has
+  # no capture-time card selector, so fall back to the portal backend, the
+  # documented path for external-GPU monitors. The portal pops the
+  # xdg-desktop-portal picker, which is the only way to capture a dGPU-driven
+  # display; skip it when the user already opted into portal above.
+  if [[ $target != portal ]]; then
+    omarchy-notification-send -t 4000 "Retrying screen recording via the portal backend" \
+      "The kms backend couldn't capture this monitor — the portal picker will ask you to confirm the source"
+    capture_args=(-w portal -s "${RESOLUTION:-0x0}")
+    gpu-screen-recorder "${capture_args[@]}" -k auto -f 60 -fm cfr -fallback-cpu-encoding yes -o "$filename" "${audio_args[@]}" 2>>"$LOG_FILE" &
+    pid=$!
+    while kill -0 $pid 2>/dev/null && [[ ! -f $filename ]]; do
+      sleep 0.2
+    done
+    if kill -0 $pid 2>/dev/null; then
+      echo "$filename" >"$RECORDING_FILE"
+      toggle_screenrecording_indicator
+      return 0
+    fi
+  fi
+
+  return 1
 }
 
 stop_screenrecording() {

--- a/test/shell.d/screenrecording-portal-fallback-test.sh
+++ b/test/shell.d/screenrecording-portal-fallback-test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$RECORDING_FILE"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
+GSR_LOG="$tmp_dir/gsr.log"
+NOTIF_LOG="$tmp_dir/notif.log"
+rm -f "$RECORDING_FILE"
+: >"$GSR_LOG"
+: >"$NOTIF_LOG"
+
+# gpu-screen-recorder stub: the kms launch (-w <monitor>) exits without writing
+# the file (the "failed to find monitor by name" failure on a dGPU-driven
+# external monitor); the portal retry (-w portal) touches the output file and
+# stays alive so the script's wait loop sees it succeed. OMARCHY_TEST_PORTAL_FAILS
+# flips the portal branch to fail too, for the no-retry case.
+cat >"$stub_bin/gpu-screen-recorder" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_GSR_LOG"
+w=""; out=""; prev=""
+for a in "$@"; do
+  [[ $prev == -w ]] && w="$a"
+  [[ $prev == -o ]] && out="$a"
+  prev="$a"
+done
+if [[ $w == portal && ${OMARCHY_TEST_PORTAL_FAILS:-false} != true ]]; then
+  [[ -n $out ]] && touch -- "$out"
+  sleep 5
+else
+  exit 1
+fi
+SH
+
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >>"$OMARCHY_TEST_NOTIF_LOG"
+SH
+
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-hyprland-monitor-focused" <<'SH'
+#!/bin/bash
+echo "eDP-2"
+SH
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+case "$1" in
+monitors) printf '[{"focused":true,"width":1920,"height":1080}]' ;;
+*) printf '{}' ;;
+esac
+SH
+
+chmod +x "$stub_bin"/*
+
+mkdir -p "$tmp_dir/videos"
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export HOME="$tmp_dir/home"
+mkdir -p "$HOME"
+export XDG_VIDEOS_DIR="$tmp_dir/videos"
+export OMARCHY_TEST_GSR_LOG="$GSR_LOG"
+export OMARCHY_TEST_NOTIF_LOG="$NOTIF_LOG"
+
+# kms fails -> portal retry succeeds.
+"$ROOT/bin/omarchy-capture-screenrecording" --fullscreen --resolution=0x0
+filename=$(cat "$RECORDING_FILE")
+[[ -n $filename ]] || fail "portal fallback wrote the recording file" "$(cat "$RECORDING_FILE")"
+[[ -f $filename ]] || fail "portal fallback created the recording file on disk"
+
+# Two gsr invocations: first the kms monitor target, then the portal retry.
+calls=$(grep -c . "$GSR_LOG") || true
+(( calls == 2 )) || fail "kms failure retried exactly once via portal" "got $calls calls:$(cat "$GSR_LOG")"
+grep -q -- '-w eDP-2' "$GSR_LOG" || fail "first attempt targets the focused monitor via kms" "$(cat "$GSR_LOG")"
+grep -q -- '-w portal' "$GSR_LOG" || fail "retry targets the portal backend" "$(cat "$GSR_LOG")"
+grep -Fx -- 'Retrying screen recording via the portal backend' "$NOTIF_LOG" >/dev/null || \
+  fail "fallback notifies the user" "$(cat "$NOTIF_LOG")"
+pass "kms failure falls back to the portal backend and records"
+
+# When the user already opted into the portal and it also fails, do not retry again.
+rm -f "$RECORDING_FILE" "$filename" 2>/dev/null
+: >"$GSR_LOG"
+OMARCHY_TEST_PORTAL_FAILS=true OMARCHY_SCREENRECORD_USE_PORTAL=true \
+  "$ROOT/bin/omarchy-capture-screenrecording" --resolution=0x0 || true
+calls=$(grep -c . "$GSR_LOG") || true
+(( calls == 1 )) || fail "portal failure is not retried again" "got $calls calls:$(cat "$GSR_LOG")"
+grep -q -- '-w portal' "$GSR_LOG" || fail "the single attempt used portal" "$(cat "$GSR_LOG")"
+[[ ! -f $RECORDING_FILE ]] || fail "no recording file when both backends fail"
+pass "portal failure is not retried again"


### PR DESCRIPTION
Closes #7530.

## What

On hybrid-GPU laptops (Intel iGPU + NVIDIA dGPU), `omarchy capture screenrecording` silently fails when the target is an external monitor wired to the dGPU — only the laptop panel records. Reported by @Mohamedkrms in #7479; same root cause as the closed #4804 / #4834.

## Root cause

`gpu-screen-recorder`'s kms backend connects to one DRM card (the iGPU driving the internal panel). A dGPU-driven external monitor's connector isn't visible to that card, so gsr logs `failed to find monitor by name "DP-1"` and exits without producing the output file. The script's wait loop then sees the process dead and silently gives up — no recording, no message. gsr exposes no capture-time card selector (only `--list-capture-options [card]`), so the kms backend can't be pointed at the dGPU card.

## Fix

When the kms launch dies without producing the output file, retry **once** via the portal backend (`-w portal`) — the documented path for external-GPU monitors (the script already exposes it as the `OMARCHY_SCREENRECORD_USE_PORTAL` opt-in). A notification tells the user the portal picker will appear, since the portal backend (xdg-desktop-portal ScreenCast) requires the user to confirm the source.

- Keeps the fast kms path for the laptop panel (the common case) — the portal is only invoked when kms can't see the target.
- Skips the retry when the user already opted into portal (`target == portal`), so a portal failure isn't retried with portal again.
- Returns nonzero on total failure so `start_screenrecording || cleanup_webcam` cleans up the webcam overlay (previously `start` always returned 0, so the overlay was never cleaned up on failure).

## Tests

New `test/shell.d/screenrecording-portal-fallback-test.sh` stubs `gpu-screen-recorder` to fail the kms launch and succeed the portal retry, and asserts:
- the kms monitor target is tried first, then `-w portal`;
- the recording file is written;
- the user is notified about the retry;
- when the user already opted into portal and it also fails, it is **not** retried again.

Existing `screenrecording-test.sh`, `bin-style-test.sh`, and the CLI metadata suite still pass.

## Notes for review

- The portal backend pops the xdg-desktop-portal picker, so `--fullscreen` on an external monitor changes UX slightly (a picker appears instead of auto-record). That's unavoidable — there's no auto-focused-monitor mode for the portal, and kms can't see the dGPU display at all. The notification explains it.
- **Needs verification on a hybrid + external-monitor setup.** I couldn't reproduce the external-monitor case locally (no external display attached). If @Mohamedkrms or anyone with a hybrid + dGPU-driven external monitor can test this branch, that would confirm the fallback lands on the portal and records.
- **Immediate workaround** (no code needed): set \`OMARCHY_SCREENRECORD_USE_PORTAL=true\` in \`~/.config/uwsm/env.d/capture\` and re-login.