### PR TITLE
Treat Ctrl+[ as panel escape

### DIFF
--- a/shell/Ui/PanelKeyCatcher.qml
+++ b/shell/Ui/PanelKeyCatcher.qml
@@ -48,7 +48,8 @@ Item {
   Keys.onPressed: function(event) {
     if (blocked) return
 
-    if (event.key === Qt.Key_Escape) {
+    if (event.key === Qt.Key_Escape
+        || (event.key === Qt.Key_BracketLeft && event.modifiers === Qt.ControlModifier)) {
       closeRequested(); event.accepted = true; return
     }
     if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {

--- a/test/acceptance.d/control-bracket-panel-test.sh
+++ b/test/acceptance.d/control-bracket-panel-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hide_panel() {
+  omarchy-shell shell hide omarchy.audio >/dev/null 2>&1 || true
+}
+
+trap hide_panel EXIT
+
+# Ctrl+[ is the terminal-style equivalent of Escape for keyboard-driven panels.
+omarchy-shell notifications dismissAll >/dev/null
+wait_until "notification popups close" 15 layer_absent "omarchy-notifications"
+omarchy-shell shell summon omarchy.audio >/dev/null
+wait_until "Ctrl+[ panel opens" 15 layer_present "omarchy-keyboard-panel"
+wait_until "Ctrl+[ panel content is visible" 15 screen_contains "Audio"
+screenshot "success-panel-control-bracket-open"
+wtype -M ctrl -k bracketleft -m ctrl
+wait_until "Ctrl+[ closes a panel" 15 layer_absent "omarchy-keyboard-panel"
+screenshot "success-panel-control-bracket-closed"
+
+trap - EXIT

--- a/test/shell.d/panel-key-catcher-test.sh
+++ b/test/shell.d/panel-key-catcher-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const panelKeyCatcher = fs.readFileSync(path.join(root, 'shell/Ui/PanelKeyCatcher.qml'), 'utf8')
+
+assert(
+  /event\.key === Qt\.Key_Escape\s*\|\| \(event\.key === Qt\.Key_BracketLeft && event\.modifiers === Qt\.ControlModifier\)/.test(panelKeyCatcher),
+  'panel key catcher treats Ctrl+[ as Escape'
+)
+JS


### PR DESCRIPTION
## Summary

- treat an exact `Ctrl+[` keypress as Escape in `PanelKeyCatcher`
- preserve the existing Escape behavior and avoid matching extra modifiers
- add focused shell and graphical acceptance coverage

## Testing

- `./test/shell.d/panel-key-catcher-test.sh`
- `bash -n test/acceptance.d/control-bracket-panel-test.sh`
- Omarchy 4.0.0 disposable VM acceptance run: opened the Audio panel, sent `Ctrl+[`, and verified the panel layer closed

