### PR TITLE
Show limits for OpenCode's OpenAI account

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -209,7 +209,10 @@ def scan_pi_sessions():
 def scan_opencode_sessions():
   # A subscription burned entirely through opencode leaves no native session
   # files, but opencode records per-message provider, model, and token usage
-  # in its own database. Read-only: opencode may be writing right now.
+  # in its own database. Newer releases migrate that history from message to
+  # session_message; once the new table exists it is authoritative, so reading
+  # both would double-count the migrated rows. Read-only: opencode may be
+  # writing right now.
   # Returns whether the scan ran to completion: a scan cut short by a
   # database error still contributes what it read, but must not be cached
   # as if it were the whole story.
@@ -222,13 +225,40 @@ def scan_opencode_sessions():
     return False
   try:
     conn.execute("PRAGMA query_only = ON")
+    tables = {
+      str(row[0])
+      for row in conn.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type = 'table' AND name IN ('session_message', 'message')"
+      )
+    }
+    if "session_message" in tables:
+      rows = conn.execute(
+        "SELECT session_id, time_created, data FROM session_message"
+        " WHERE type = 'assistant'"
+        " AND data LIKE '%\"providerID\"%:%\"openai\"%'"
+        " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.model.providerID') END = 'openai'"
+      )
+      current_schema = True
+    elif "message" in tables:
+      rows = conn.execute(
+        "SELECT session_id, time_created, data FROM message"
+        " WHERE data LIKE '%\"role\"%:%\"assistant\"%'"
+        " AND data LIKE '%\"providerID\"%:%\"openai\"%'"
+        " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'"
+        " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.providerID') END = 'openai'"
+      )
+      current_schema = False
+    else:
+      return False
+
     # OpenCode DBs grow huge (every historical message, JSON included), and
     # Python-side json.loads of every row wasted ~600 MB of RSS on machines
     # whose subscription never ran on OpenAI. The json_extract conditions are
-    # the authority for the rows that reach them: role == "assistant" and
+    # the authority for the rows that reach them: an assistant message from
     # providerID == "openai", the same exact-match values the Python filter
-    # below checks. The guards in front are pure acceleration, not a perfect
-    # proxy for the Python filter:
+    # below checks. The LIKE guards are pure acceleration, not a perfect proxy
+    # for the Python filter:
     #   - The LIKE gates skip rows whose JSON cannot contain the two
     #     key/value pairs, avoiding the JSON parse of tens-of-MB blobs. They
     #     can differ from json.loads on duplicate keys (Python keeps the
@@ -244,25 +274,31 @@ def scan_opencode_sessions():
     #     well-formed JSON are skipped here; the per-row try/except below
     #     stays as the final safety net for rows that pass the SQL filter
     #     but fail json.loads.
-    for session_id, raw in conn.execute(
-      "SELECT session_id, data FROM message"
-      " WHERE data LIKE '%\"role\"%:%\"assistant\"%'"
-      " AND data LIKE '%\"providerID\"%:%\"openai\"%'"
-      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'"
-      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.providerID') END = 'openai'"
-    ):
+    for session_id, row_created, raw in rows:
       # One malformed row must not abort the scan, so every shape assumption
       # lives inside the try.
       try:
         entry = json.loads(raw)
-        # Exact match: opencode provider ids are free-form, and a custom
-        # "openai-local" gateway is not this subscription.
-        if not isinstance(entry, dict) or entry.get("role") != "assistant":
+        if not isinstance(entry, dict):
           continue
-        if str(entry.get("providerID") or "") != "openai":
-          continue
+        if current_schema:
+          model = entry.get("model") or {}
+          if not isinstance(model, dict) or str(model.get("providerID") or "") != "openai":
+            continue
+          model_id = model.get("id")
+        else:
+          # Exact match: opencode provider ids are free-form, and a custom
+          # "openai-local" gateway is not this subscription.
+          if entry.get("role") != "assistant" or str(entry.get("providerID") or "") != "openai":
+            continue
+          model_id = entry.get("modelID")
+
         tokens = entry.get("tokens") or {}
+        if not isinstance(tokens, dict):
+          continue
         cache = tokens.get("cache") or {}
+        if not isinstance(cache, dict):
+          cache = {}
         input_tokens = number(tokens.get("input"))
         # opencode keeps thinking tokens out of output; both are generated.
         output_tokens = number(tokens.get("output")) + number(tokens.get("reasoning"))
@@ -270,8 +306,11 @@ def scan_opencode_sessions():
         cache_write = number(cache.get("write"))
         if not (input_tokens or output_tokens or cache_read or cache_write):
           continue
-        day = local_day((entry.get("time") or {}).get("created"))
-        model = model_name(str(entry.get("modelID") or "").rstrip("/").split("/")[-1])
+        entry_time = entry.get("time") or {}
+        if not isinstance(entry_time, dict):
+          entry_time = {}
+        day = local_day(entry_time.get("created") or row_created)
+        model = model_name(str(model_id or "").rstrip("/").split("/")[-1])
       except Exception:
         continue
       add_usage(day, "opencode:" + str(session_id), model, input_tokens, output_tokens, cache_read, cache_write)

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -548,16 +548,48 @@ def codex_account_id():
   return str(tokens.get("account_id") or "") if isinstance(tokens, dict) else ""
 
 
-def opencode_openai_auth():
-  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
-  auth = read_json(data_home / "opencode" / "auth.json").get("openai") or {}
+def normalize_opencode_openai_auth(auth):
   if not isinstance(auth, dict) or auth.get("type") != "oauth":
     return None
+  metadata = auth.get("metadata") or {}
+  if not isinstance(metadata, dict):
+    metadata = {}
   access_token = str(auth.get("access") or "")
-  account_id = str(auth.get("accountId") or "")
+  account_id = str(auth.get("accountId") or metadata.get("accountID") or metadata.get("accountId") or "")
   if not access_token or not account_id:
     return None
   return {"accessToken": access_token, "accountId": account_id}
+
+
+def opencode_database_auth(database):
+  if not database.is_file():
+    return None
+  try:
+    connection = sqlite3.connect(f"{database.resolve().as_uri()}?mode=ro", uri=True, timeout=0.25)
+    try:
+      row = connection.execute(
+        "SELECT value FROM credential WHERE integration_id = ? ORDER BY time_updated DESC LIMIT 1",
+        ("openai",),
+      ).fetchone()
+    finally:
+      connection.close()
+    auth = json.loads(row[0]) if row and row[0] else {}
+  except Exception:
+    return None
+  return normalize_opencode_openai_auth(auth)
+
+
+def opencode_openai_auth():
+  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+  opencode_data = data_home / "opencode"
+  # Newer OpenCode builds keep provider credentials in their database. Read
+  # that current record first, then retain auth.json compatibility for older
+  # installations and upstream OpenCode releases that still use the file.
+  database_auth = opencode_database_auth(opencode_data / "opencode.db")
+  if database_auth:
+    return database_auth
+  file_auth = read_json(opencode_data / "auth.json").get("openai") or {}
+  return normalize_opencode_openai_auth(file_auth)
 
 
 def stop_process(proc):

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -1,13 +1,14 @@
 #!/usr/bin/python3
 # omarchy:summary=Print the Codex usage record as JSON
-# omarchy:args=[--force] [--limits-only]
+# omarchy:args=[--force] [--limits-only] [--opencode-openai-limits]
 # omarchy:hidden=true
 """Collect Codex usage into one display-ready JSON record.
 
 Local stats come from native Codex CLI session files, pi/omp sessions that
 ran through openai-codex, and opencode sessions that ran on an OpenAI
-provider; rate limits and the plan come from the Codex app-server RPC. The agents
-panel only ever reads the JSON this prints.
+provider. Rate limits come from the native Codex login and, when it belongs
+to a different account, OpenCode's OpenAI OAuth login. The agents panel only
+ever reads the JSON this prints.
 """
 
 import argparse
@@ -495,7 +496,7 @@ def rpc_request(proc, request_id, method, params=None, timeout=8):
   raise TimeoutError(method)
 
 
-def limit_window(window):
+def limit_window(window, prefix=""):
   if not isinstance(window, dict):
     return None
   used = window.get("usedPercent")
@@ -504,21 +505,138 @@ def limit_window(window):
   mins = number(window.get("windowDurationMins"))
   if mins == 10080:
     label = "Weekly (7-day)"
+    title = "Weekly"
+  elif mins == 43200:
+    label = "Monthly (30-day)"
+    title = "Monthly"
   elif mins and mins % 60 == 0:
     label = f"{mins // 60}h window"
+    title = "Session"
   elif mins:
     label = f"{mins}m window"
+    title = "Session"
   else:
     label = "Limit"
+    title = "Limit"
+  if prefix:
+    label = f"{prefix} · {label}"
+    title = f"{prefix} · {title}"
   reset = window.get("resetsAt")
-  return {
+  entry = {
     "label": label,
     "percent": float(used) / 100.0,
     "resetsAt": datetime.fromtimestamp(number(reset), timezone.utc).isoformat() if reset else "",
   }
+  if prefix:
+    entry["title"] = title
+  return entry
 
 
-def fetch_codex_rpc():
+def read_json(path):
+  try:
+    with path.open() as handle:
+      data = json.load(handle)
+    return data if isinstance(data, dict) else {}
+  except Exception:
+    return {}
+
+
+def codex_account_id():
+  codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+  auth = read_json(codex_home / "auth.json")
+  tokens = auth.get("tokens") or {}
+  return str(tokens.get("account_id") or "") if isinstance(tokens, dict) else ""
+
+
+def opencode_openai_auth():
+  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+  auth = read_json(data_home / "opencode" / "auth.json").get("openai") or {}
+  if not isinstance(auth, dict) or auth.get("type") != "oauth":
+    return None
+  access_token = str(auth.get("access") or "")
+  account_id = str(auth.get("accountId") or "")
+  if not access_token or not account_id:
+    return None
+  return {"accessToken": access_token, "accountId": account_id}
+
+
+def stop_process(proc):
+  try:
+    proc.terminate()
+    proc.wait(timeout=1)
+  except Exception:
+    try:
+      proc.kill()
+    except Exception:
+      pass
+
+
+def start_codex_app_server(codex, env):
+  return subprocess.Popen(
+    [codex, "-s", "read-only", "-a", "on-request", "app-server"],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    env=env,
+  )
+
+
+def initialize_app_server(proc, experimental=False):
+  params = {"clientInfo": {"name": "omarchy-agent-usage", "version": "1"}}
+  if experimental:
+    params["capabilities"] = {"experimentalApi": True}
+  rpc_request(proc, 1, "initialize", params, timeout=8)
+  proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
+  proc.stdin.flush()
+
+
+def fetch_opencode_rpc(codex, native_account):
+  auth = opencode_openai_auth()
+  if not auth:
+    return None
+
+  native_id = codex_account_id()
+  if native_id and native_id == auth["accountId"]:
+    return None
+
+  try:
+    with tempfile.TemporaryDirectory(prefix="omarchy-opencode-openai-") as temp_codex_home:
+      env = ENV.copy()
+      env["CODEX_HOME"] = temp_codex_home
+      env.pop("OPENAI_API_KEY", None)
+      proc = start_codex_app_server(codex, env)
+      try:
+        initialize_app_server(proc, experimental=True)
+        login_msg = rpc_request(proc, 2, "account/login/start", {
+          "type": "chatgptAuthTokens",
+          "accessToken": auth["accessToken"],
+          "chatgptAccountId": auth["accountId"],
+        }, timeout=4)
+        if login_msg.get("error"):
+          return None
+        account_msg = rpc_request(proc, 3, "account/read", {"refreshToken": False}, timeout=4)
+        limits_msg = rpc_request(proc, 4, "account/rateLimits/read", timeout=4)
+      finally:
+        stop_process(proc)
+  except Exception:
+    return None
+
+  account = (account_msg.get("result") or {}).get("account") or {}
+  # File-backed Codex auth gives an exact account-id comparison. If Codex
+  # stores credentials elsewhere, use the account email as a conservative
+  # fallback rather than drawing duplicate meters for the same subscription.
+  if not native_id and native_account.get("type") == "chatgpt":
+    native_email = str(native_account.get("email") or "")
+    opencode_email = str(account.get("email") or "")
+    if not native_email or not opencode_email or native_email == opencode_email:
+      return None
+
+  limits = (limits_msg.get("result") or {}).get("rateLimits") or {}
+  return {"account": account, "limits": limits}
+
+
+def fetch_codex_rpc(include_opencode=False):
   result = {"limits": [], "tierLabel": "", "usageStatusText": "", "authHelpText": AUTH_HELP}
   codex = find_command("codex")
   if not codex:
@@ -527,23 +645,14 @@ def fetch_codex_rpc():
     return result
 
   try:
-    proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "on-request", "app-server"],
-      stdin=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.DEVNULL,
-      text=True,
-      env=ENV,
-    )
+    proc = start_codex_app_server(codex, ENV)
   except Exception as exc:
     result["usageStatusText"] = "Codex unavailable"
     result["authHelpText"] = str(exc)
     return result
 
   try:
-    rpc_request(proc, 1, "initialize", {"clientInfo": {"name": "omarchy-agent-usage", "version": "1"}}, timeout=8)
-    proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
-    proc.stdin.flush()
+    initialize_app_server(proc)
     account_msg = rpc_request(proc, 2, "account/read", timeout=4)
     limits_msg = rpc_request(proc, 3, "account/rateLimits/read", timeout=4)
 
@@ -556,18 +665,32 @@ def fetch_codex_rpc():
       entry = limit_window(window)
       if entry:
         result["limits"].append(entry)
+
+    opencode = fetch_opencode_rpc(codex, account) if include_opencode else None
+    if opencode:
+      opencode_email = str(opencode["account"].get("email") or "OpenCode")
+      opencode_entries = []
+      for window in (opencode["limits"].get("primary"), opencode["limits"].get("secondary")):
+        entry = limit_window(window, opencode_email)
+        if entry:
+          opencode_entries.append(entry)
+      if opencode_entries:
+        native_email = str(account.get("email") or "Codex")
+        native_entries = []
+        for window in (limits.get("primary"), limits.get("secondary")):
+          entry = limit_window(window, native_email)
+          if entry:
+            native_entries.append(entry)
+        result["limits"] = native_entries + opencode_entries
+      if opencode_entries and not result["tierLabel"]:
+        opencode_account = opencode["account"]
+        plan = opencode["limits"].get("planType") or opencode_account.get("planType") or ""
+        result["tierLabel"] = str(plan) if plan else ""
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
     result["authHelpText"] = str(exc)
   finally:
-    try:
-      proc.terminate()
-      proc.wait(timeout=1)
-    except Exception:
-      try:
-        proc.kill()
-      except Exception:
-        pass
+    stop_process(proc)
   return result
 
 
@@ -580,11 +703,12 @@ def main():
   # collector runs.
   parser.add_argument("--force", action="store_true")
   parser.add_argument("--limits-only", action="store_true")
+  parser.add_argument("--opencode-openai-limits", action="store_true")
   args = parser.parse_args()
 
   max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
   stats = cached_local_stats(max_age)
-  rpc = fetch_codex_rpc()
+  rpc = fetch_codex_rpc(args.opencode_openai_limits)
 
   record = {
     "schemaVersion": 1,

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -606,8 +606,10 @@ def opencode_database_auth(database):
   try:
     connection = sqlite3.connect(f"{database.resolve().as_uri()}?mode=ro", uri=True, timeout=0.25)
     try:
+      columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(credential)")}
+      order = "COALESCE(active, 0) DESC, time_updated DESC" if "active" in columns else "time_updated DESC"
       row = connection.execute(
-        "SELECT value FROM credential WHERE integration_id = ? ORDER BY time_updated DESC LIMIT 1",
+        f"SELECT value FROM credential WHERE integration_id = ? ORDER BY {order} LIMIT 1",
         ("openai",),
       ).fetchone()
     finally:

--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Regenerate the AI agent usage data files
-# omarchy:args=[--force] [--limits-only] [--except <agent>] [agent...]
+# omarchy:args=[--force] [--limits-only] [--opencode-openai-limits] [--except <agent>] [agent...]
 # omarchy:examples=omarchy agent usage-update | omarchy agent usage-update claude | omarchy agent usage-update --except codex
 
 # Each omarchy-agent-usage-<agent> collector prints one display-ready JSON
@@ -13,12 +13,14 @@ USAGE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
 mkdir -p "$USAGE_DIR"
 
 flags=()
+codex_flags=()
 only=()
 declare -A excluded
 
 while (( $# > 0 )); do
   case "$1" in
   --force | --limits-only) flags+=("$1") ;;
+  --opencode-openai-limits) codex_flags+=("$1") ;;
   --except)
     excluded[$2]=1
     shift
@@ -42,7 +44,9 @@ wanted() {
 collect() {
   local collector="$1" agent="$2"
   local record tmp
-  if ! record=$("$collector" "${flags[@]}") || [[ -z $record ]] || ! jq -e . >/dev/null 2>&1 <<<"$record"; then
+  local -a collector_flags=("${flags[@]}")
+  [[ $agent == "codex" ]] && collector_flags+=("${codex_flags[@]}")
+  if ! record=$("$collector" "${collector_flags[@]}") || [[ -z $record ]] || ! jq -e . >/dev/null 2>&1 <<<"$record"; then
     echo "omarchy-agent-usage-update: $agent collector failed" >&2
     return 1
   fi

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -29,7 +29,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box. If OpenCode uses a different OpenAI subscription from the native Codex CLI, you can opt in to showing its limits separately without signing in again; see the agents plugin README for the setting.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -148,6 +148,8 @@ Item {
     if (kind === "force") command.push("--force")
     if (kind === "limits") command.push("--limits-only")
     var providers = settings && settings.providers ? settings.providers : {}
+    if (providers.codex && providers.codex.openCodeOpenAiLimits === true)
+      command.push("--opencode-openai-limits")
     for (var id in providers) {
       if (providers[id] && providers[id].enabled === false) command.push("--except", id)
     }

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -53,7 +53,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | Collector | Limits | Local stats |
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
-| `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
+| `codex` | The Codex app-server RPC, including a distinct OpenCode OpenAI OAuth account | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
@@ -63,6 +63,8 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+OpenCode OpenAI limits are opt-in. Set `providers.codex.openCodeOpenAiLimits` to `true` to reuse the OpenAI OAuth login already stored by OpenCode without changing either tool's saved credentials. The Codex collector then compares its ChatGPT account id with the native Codex login. When they differ, both accounts' limit meters are labelled with their account emails through an isolated Codex app-server external-token session; the same account is skipped so its meters do not appear twice. An unavailable email falls back to a `Codex` or `OpenCode` label. If account identity cannot be established or the OpenCode token no longer works, the native limits and combined local stats remain available.
 
 ### Fireworks balance
 
@@ -126,15 +128,15 @@ edit `shell.json` directly):
 
 ```bash
 omarchy bar set omarchy.agents providers '{
-  "claude": { "enabled": true },
-  "codex": { "enabled": false },
+  "claude": { "enabled": false },
+  "codex": { "enabled": true, "openCodeOpenAiLimits": true },
   "fireworks": { "enabled": true }
 }' --json
 ```
 
 `enabled` defaults to `true` for every discovered agent; set it to `false` to
 hide a subscription that is installed. Disabled agents are also skipped when
-the records regenerate.
+the records regenerate. `providers.codex.openCodeOpenAiLimits` defaults to `false`; set it to `true` to include limits from a distinct OpenCode OpenAI account.
 
 With `syncMode` on, every `*.json` snapshot in `syncDir` is merged, so today,
 the last 7 days, and the all-time totals cover every machine you code on —

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -20,7 +20,7 @@
     "defaults": {
       "providers": {
         "claude": { "enabled": true },
-        "codex": { "enabled": true },
+        "codex": { "enabled": true, "openCodeOpenAiLimits": false },
         "fireworks": { "enabled": true }
       },
       "refreshIntervalSec": 900,

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -226,11 +226,13 @@ eval(source.slice(start, end))
 assertDeepEqual(
   limitWindows({ limits: [
     { label: 'Session (5-hour)', percent: 0.78, resetsAt: '' },
-    { label: 'Opus 5 (1M context) Weekly', title: 'Opus 5 (1M context) Weekly', percent: 0.42, resetsAt: '' }
+    { label: 'Opus 5 (1M context) Weekly', title: 'Opus 5 (1M context) Weekly', percent: 0.42, resetsAt: '' },
+    { label: 'account@example.com · Weekly (7-day)', title: 'account@example.com · Weekly', percent: 0.12, resetsAt: '' }
   ] }),
   [
     { title: 'Session', percent: 0.78, resetAt: '' },
-    { title: 'Opus 5 (1M context) Weekly', percent: 0.42, resetAt: '' }
+    { title: 'Opus 5 (1M context) Weekly', percent: 0.42, resetAt: '' },
+    { title: 'account@example.com · Weekly', percent: 0.12, resetAt: '' }
   ],
   'agents panel titles a limit off the collector when it states one'
 )

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -142,6 +142,47 @@ pass "Codex collector counts OpenAI usage, reasoning included, from opencode ses
   fail "Codex collector ignores prefix-colliding providers, user messages, and malformed rows" "$result"
 pass "Codex collector ignores prefix-colliding providers, user messages, and malformed rows"
 
+# Newer opencode releases migrate messages into session_message. When both
+# tables exist, the migrated table is authoritative: falling through to the
+# legacy table as well would count the same history twice.
+python3 - "$OPENCODE_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+
+db = sys.argv[1]
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE session_message (id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, seq integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+
+def message(id, provider, model, type="assistant", input=0, output=0, reasoning=0, read=0, write=0):
+  return (id, "ses_2", type, 1, now_ms, now_ms, json.dumps({
+    "model": {"providerID": provider, "id": model},
+    "tokens": {"input": input, "output": output, "reasoning": reasoning, "cache": {"read": read, "write": write}},
+    "time": {"created": now_ms},
+  }))
+
+conn.executemany("INSERT INTO session_message VALUES (?, ?, ?, ?, ?, ?, ?)", [
+  message("v2_1", "openai", "openai/gpt-new", input=12, output=8, reasoning=3, read=4, write=2),
+  message("v2_2", "anthropic", "claude-opus-5", input=999, output=999),
+  message("v2_3", "openai", "gpt-new", type="user", input=999, output=999),
+  message("v2_4", "openai-local", "gpt-new", input=999, output=999),
+])
+conn.execute("INSERT INTO session_message VALUES ('v2_5', 'ses_2', 'assistant', 2, ?, ?, 'not json')", (now_ms, now_ms))
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$OPENCODE_HOME" CODEX_HOME="$OPENCODE_HOME/.codex" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+  PATH="$OPENCODE_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --force)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "29" ]] ||
+  fail "Codex collector prefers migrated opencode messages over the legacy table" "$result"
+[[ $(jq -c '.modelUsage' <<<"$result") == '{"gpt-new":{"inputTokens":12,"outputTokens":11,"cacheReadInputTokens":4,"cacheCreationInputTokens":2}}' ]] ||
+  fail "Codex collector parses OpenAI usage from the migrated opencode schema" "$result"
+pass "Codex collector reads the authoritative migrated opencode schema"
+
 # A warm cache makes --limits-only cheap: local stats come from the last scan
 # instead of another walk over the opencode database, and --force bypasses it.
 CACHE_HOME=$(mktemp -d)

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -631,6 +631,9 @@ while read -r request; do
       has_access=$(jq -r '(.params.accessToken // "") != ""' <<<"$request")
       has_account=$(jq -r '(.params.chatgptAccountId // "") != ""' <<<"$request")
       printf 'login:%s:%s:%s\n' "$type" "$has_access" "$has_account" >>"$RPC_LOG"
+      if [[ $(jq -r '.params.accessToken == "secret-database-token" and .params.chatgptAccountId == "database-account"' <<<"$request") == "true" ]]; then
+        printf 'credential:database\n' >>"$RPC_LOG"
+      fi
       if [[ ${FAIL_EXTERNAL_LOGIN:-false} == "true" ]]; then
         jq -cn --argjson id "$id" '{id: $id, error: {message: "login failed"}}'
       else
@@ -736,3 +739,49 @@ RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_
 [[ $(grep -c '^login:' "$LIMITS_HOME/rpc.log") == "0" ]] ||
   fail "Codex collector skips external auth for a matching account" "$(<"$LIMITS_HOME/rpc.log")"
 pass "Codex collector deduplicates matching native and OpenCode accounts"
+
+# Newer OpenCode builds migrate provider credentials into opencode.db. That
+# current database record must take precedence over a stale legacy auth.json,
+# while the file-based cases above retain backwards compatibility.
+python3 - "$LIMITS_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+conn.execute("CREATE TABLE credential (id text PRIMARY KEY, integration_id text, label text NOT NULL, value text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL)")
+now_ms = int(time.time() * 1000)
+conn.execute("INSERT INTO credential VALUES (?, ?, ?, ?, ?, ?)", (
+  "cred_openai",
+  "openai",
+  "OAuth",
+  json.dumps({
+    "type": "oauth",
+    "access": "secret-database-token",
+    "refresh": "secret-database-refresh",
+    "expires": now_ms + 3_600_000,
+    "metadata": {"accountID": "database-account"},
+  }),
+  now_ms,
+  now_ms,
+))
+conn.commit()
+conn.close()
+PY
+printf '%s\n' '{"openai":{"type":"oauth","access":"secret-stale-token","accountId":"native-account"}}' >"$LIMITS_HOME/.local/share/opencode/auth.json"
+: >"$LIMITS_HOME/rpc.log"
+
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+
+[[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["codex@example.com · Weekly (7-day)",0.1],["opencode@example.com · 5h window",0.25]]' ]] ||
+  fail "Codex collector reads current OpenCode database credentials" "$result"
+[[ $(grep -c '^credential:database$' "$LIMITS_HOME/rpc.log") == "1" ]] ||
+  fail "Codex collector prefers OpenCode database credentials over stale auth.json" "$(<"$LIMITS_HOME/rpc.log")"
+[[ $result != *"secret-database-token"* && $result != *"secret-database-refresh"* && $result != *"database-account"* ]] ||
+  fail "Codex collector keeps database-backed OpenCode credentials out of its record" "$result"
+pass "Codex collector reads database-backed OpenCode credentials"

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -603,3 +603,136 @@ result=$(HOME="$INTERRUPTED_HOME" CODEX_HOME="$INTERRUPTED_HOME/.codex" XDG_CACH
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "9" ]] ||
   fail "Codex collector does not reuse a snapshot from an interrupted scan" "$result"
 pass "Codex collector does not cache an interrupted opencode scan"
+
+# OpenCode can hold a different ChatGPT subscription from the native Codex
+# CLI. Its OAuth token should be handed to an isolated app-server process,
+# and its limits should only be added when the stable account ids differ.
+LIMITS_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$LIMITS_HOME"' EXIT
+mkdir -p "$LIMITS_HOME/bin" "$LIMITS_HOME/.codex" "$LIMITS_HOME/.local/share/opencode"
+
+cat >"$LIMITS_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+
+external=false
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  method=$(jq -r '.method // empty' <<<"$request")
+
+  case "$method" in
+    initialize)
+      experimental=$(jq -r '.params.capabilities.experimentalApi // false' <<<"$request")
+      printf 'initialize:%s\n' "$experimental" >>"$RPC_LOG"
+      jq -cn --argjson id "$id" '{id: $id, result: {}}'
+      ;;
+    account/login/start)
+      external=true
+      type=$(jq -r '.params.type // empty' <<<"$request")
+      has_access=$(jq -r '(.params.accessToken // "") != ""' <<<"$request")
+      has_account=$(jq -r '(.params.chatgptAccountId // "") != ""' <<<"$request")
+      printf 'login:%s:%s:%s\n' "$type" "$has_access" "$has_account" >>"$RPC_LOG"
+      if [[ ${FAIL_EXTERNAL_LOGIN:-false} == "true" ]]; then
+        jq -cn --argjson id "$id" '{id: $id, error: {message: "login failed"}}'
+      else
+        jq -cn --argjson id "$id" '{id: $id, result: {type: "chatgptAuthTokens"}}'
+      fi
+      ;;
+    account/read)
+      if [[ $external == "true" ]]; then
+        jq -cn --argjson id "$id" --arg email "${OPENCODE_TEST_EMAIL-opencode@example.com}" \
+          '{id: $id, result: {account: {type: "chatgpt", email: $email, planType: "plus"}}}'
+      else
+        jq -cn --argjson id "$id" --arg email "${NATIVE_TEST_EMAIL-codex@example.com}" \
+          '{id: $id, result: {account: {type: "chatgpt", email: $email, planType: "pro"}}}'
+      fi
+      ;;
+    account/rateLimits/read)
+      if [[ $external == "true" ]]; then
+        if [[ ${NO_EXTERNAL_LIMITS:-false} == "true" ]]; then
+          jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {}}}'
+        else
+          jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {primary: {usedPercent: 25, windowDurationMins: 300, resetsAt: 1780000000}}}}'
+        fi
+      else
+        jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {primary: {usedPercent: 10, windowDurationMins: 10080, resetsAt: 1780000000}}}}'
+      fi
+      ;;
+  esac
+done
+EOF
+chmod +x "$LIMITS_HOME/bin/codex"
+
+printf '%s\n' '{"tokens":{"account_id":"native-account"}}' >"$LIMITS_HOME/.codex/auth.json"
+printf '%s\n' '{"openai":{"type":"oauth","access":"secret-opencode-token","accountId":"opencode-account"}}' >"$LIMITS_HOME/.local/share/opencode/auth.json"
+
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["Weekly (7-day)",0.1]]' ]] ||
+  fail "Codex collector leaves OpenCode limits disabled by default" "$result"
+[[ $(grep -c '^login:' "$LIMITS_HOME/rpc.log") == "0" ]] ||
+  fail "Codex collector does not use OpenCode OAuth without opt-in" "$(<"$LIMITS_HOME/rpc.log")"
+pass "Codex collector requires opt-in for OpenCode limits"
+
+: >"$LIMITS_HOME/rpc.log"
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+
+[[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["codex@example.com · Weekly (7-day)",0.1],["opencode@example.com · 5h window",0.25]]' ]] ||
+  fail "Codex collector labels distinct account limits with their emails" "$result"
+[[ $(jq -c '[.limits[].title]' <<<"$result") == '["codex@example.com · Weekly","opencode@example.com · Session"]' ]] ||
+  fail "Codex collector supplies display titles that preserve account emails" "$result"
+[[ $(jq -r '.tierLabel' <<<"$result") == "pro" ]] ||
+  fail "Codex collector keeps the native subscription as the hero plan" "$result"
+[[ $(grep -c '^login:chatgptAuthTokens:true:true$' "$LIMITS_HOME/rpc.log") == "1" ]] ||
+  fail "Codex collector supplies OpenCode OAuth through external-token auth" "$(<"$LIMITS_HOME/rpc.log")"
+[[ $(grep -c '^initialize:true$' "$LIMITS_HOME/rpc.log") == "1" ]] ||
+  fail "Codex collector enables the experimental external-token API only for OpenCode" "$(<"$LIMITS_HOME/rpc.log")"
+[[ $result != *"secret-opencode-token"* && $result != *"native-account"* && $result != *"opencode-account"* ]] ||
+  fail "Codex collector keeps account credentials out of its record" "$result"
+pass "Codex collector labels distinct account limits with their emails"
+
+# Empty external windows and a failed external login are both best-effort
+# outcomes. Neither should relabel or otherwise disturb native Codex limits.
+for failure_mode in empty login; do
+  : >"$LIMITS_HOME/rpc.log"
+  if [[ $failure_mode == "empty" ]]; then
+    result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+      RPC_LOG="$LIMITS_HOME/rpc.log" NO_EXTERNAL_LIMITS=true PATH="$LIMITS_HOME/bin:$PATH" \
+      "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+  else
+    result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+      RPC_LOG="$LIMITS_HOME/rpc.log" FAIL_EXTERNAL_LOGIN=true PATH="$LIMITS_HOME/bin:$PATH" \
+      "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+  fi
+  [[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["Weekly (7-day)",0.1]]' ]] ||
+    fail "Codex collector preserves native limits after an OpenCode $failure_mode result" "$result"
+  [[ $(jq -r '.usageStatusText' <<<"$result") == "" ]] ||
+    fail "Codex collector keeps an OpenCode $failure_mode result best-effort" "$result"
+done
+pass "Codex collector preserves native limits when optional OpenCode limits are unavailable"
+
+# App-server account emails are nullable. Both meters still need distinct,
+# stable source labels when neither account supplies one.
+: >"$LIMITS_HOME/rpc.log"
+result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" NATIVE_TEST_EMAIL="" OPENCODE_TEST_EMAIL="" PATH="$LIMITS_HOME/bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+
+[[ $(jq -c '[.limits[].title]' <<<"$result") == '["Codex · Weekly","OpenCode · Session"]' ]] ||
+  fail "Codex collector falls back to source names when account emails are unavailable" "$result"
+pass "Codex collector falls back when account emails are unavailable"
+
+# The same ChatGPT account in both tools must not produce duplicate meters or
+# even start a second app-server authentication flow.
+printf '%s\n' '{"openai":{"type":"oauth","access":"secret-opencode-token","accountId":"native-account"}}' >"$LIMITS_HOME/.local/share/opencode/auth.json"
+: >"$LIMITS_HOME/rpc.log"
+
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+
+[[ $(jq -c '[.limits[] | [.label, .percent]]' <<<"$result") == '[["Weekly (7-day)",0.1]]' ]] ||
+  fail "Codex collector deduplicates matching native and OpenCode accounts" "$result"
+[[ $(grep -c '^login:' "$LIMITS_HOME/rpc.log") == "0" ]] ||
+  fail "Codex collector skips external auth for a matching account" "$(<"$LIMITS_HOME/rpc.log")"
+pass "Codex collector deduplicates matching native and OpenCode accounts"

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -675,6 +675,9 @@ while read -r request; do
       if [[ $(jq -r '.params.accessToken == "secret-database-token" and .params.chatgptAccountId == "database-account"' <<<"$request") == "true" ]]; then
         printf 'credential:database\n' >>"$RPC_LOG"
       fi
+      if [[ $(jq -r '.params.accessToken == "secret-active-token" and .params.chatgptAccountId == "active-account"' <<<"$request") == "true" ]]; then
+        printf 'credential:active\n' >>"$RPC_LOG"
+      fi
       if [[ ${FAIL_EXTERNAL_LOGIN:-false} == "true" ]]; then
         jq -cn --argjson id "$id" '{id: $id, error: {message: "login failed"}}'
       else
@@ -826,3 +829,46 @@ RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_
 [[ $result != *"secret-database-token"* && $result != *"secret-database-refresh"* && $result != *"database-account"* ]] ||
   fail "Codex collector keeps database-backed OpenCode credentials out of its record" "$result"
 pass "Codex collector reads database-backed OpenCode credentials"
+
+# OpenCode can retain an inactive credential beside its replacement. Prefer
+# the active row even when both carry the same update timestamp, while the
+# preceding fixture proves compatibility with schemas that lack active.
+python3 - "$LIMITS_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+
+db = sys.argv[1]
+conn = sqlite3.connect(db)
+conn.execute("ALTER TABLE credential ADD COLUMN active integer")
+updated = conn.execute("SELECT time_updated FROM credential WHERE id = 'cred_openai'").fetchone()[0]
+conn.execute("UPDATE credential SET active = 0 WHERE id = 'cred_openai'")
+conn.execute("INSERT INTO credential VALUES (?, ?, ?, ?, ?, ?, ?)", (
+  "cred_active",
+  "openai",
+  "OpenAI",
+  json.dumps({
+    "type": "oauth",
+    "access": "secret-active-token",
+    "refresh": "secret-active-refresh",
+    "metadata": {"accountID": "active-account"},
+  }),
+  updated,
+  updated,
+  1,
+))
+conn.commit()
+conn.close()
+PY
+: >"$LIMITS_HOME/rpc.log"
+
+RPC_LOG="$LIMITS_HOME/rpc.log" result=$(HOME="$LIMITS_HOME" CODEX_HOME="$LIMITS_HOME/.codex" XDG_DATA_HOME="$LIMITS_HOME/.local/share" \
+  RPC_LOG="$LIMITS_HOME/rpc.log" PATH="$LIMITS_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --opencode-openai-limits)
+
+[[ $(grep -c '^credential:active$' "$LIMITS_HOME/rpc.log") == "1" ]] ||
+  fail "Codex collector selects the active OpenCode credential" "$(<$LIMITS_HOME/rpc.log)"
+[[ $(grep -c '^credential:database$' "$LIMITS_HOME/rpc.log") == "0" ]] ||
+  fail "Codex collector ignores inactive OpenCode credentials" "$(<$LIMITS_HOME/rpc.log)"
+[[ $result != *"secret-active-token"* && $result != *"secret-active-refresh"* && $result != *"active-account"* ]] ||
+  fail "Codex collector keeps the active OpenCode credential out of its record" "$result"
+pass "Codex collector prefers the active OpenCode credential"

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -25,6 +25,12 @@ cat >"$FAKE_OMARCHY/bin/omarchy-agent-usage-skipped" <<'EOF'
 echo '{"id":"skipped"}'
 EOF
 
+cat >"$FAKE_OMARCHY/bin/omarchy-agent-usage-codex" <<'EOF'
+#!/bin/bash
+[[ -n ${ARG_LOG:-} ]] && printf '%s\n' "$*" >"$ARG_LOG"
+echo '{"schemaVersion":1,"id":"codex","name":"Codex","totalPrompts":3}'
+EOF
+
 # The updater itself lives in the same namespace as the collectors it globs.
 cat >"$FAKE_OMARCHY/bin/omarchy-agent-usage-update" <<'EOF'
 #!/bin/bash
@@ -63,3 +69,10 @@ pass "update succeeds when the requested collectors all pass"
 [[ -e $usage_dir/skipped.json && ! -e $usage_dir/noisy.json ]] ||
   fail "update with agent arguments only runs the named collectors"
 pass "update with agent arguments only runs the named collectors"
+
+ARG_LOG="$TEST_HOME/codex-args" HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" --opencode-openai-limits codex 2>/dev/null ||
+  fail "update forwards opted-in OpenCode limits to Codex"
+[[ $(<"$TEST_HOME/codex-args") == "--opencode-openai-limits" ]] ||
+  fail "update forwards the OpenCode limits flag only to Codex" "$(<"$TEST_HOME/codex-args")"
+pass "update forwards opted-in OpenCode limits to Codex"

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -7,6 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+const manifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/agents/manifest.json', 'utf8'))
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
@@ -14,4 +16,7 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(manifest.barWidget.defaults.providers.codex.openCodeOpenAiLimits === false, 'OpenCode OpenAI limits default to opt-in')
+assert(/providers\.codex\.openCodeOpenAiLimits === true/.test(mainSource), 'agents panel reads the OpenCode OpenAI limits opt-in')
+assert(/command\.push\("--opencode-openai-limits"\)/.test(mainSource), 'agents panel forwards the OpenCode OpenAI limits opt-in')
 JS


### PR DESCRIPTION
## Why

Codex and OpenCode can use different ChatGPT subscriptions. Token usage from both is already aggregated, but the panel only shows rate limits for the native Codex account.

## What changed

- Add an opt-in `providers.codex.openCodeOpenAiLimits` setting, disabled by default.
- Read OpenCode's active database-backed OpenAI credential, with legacy `auth.json` support.
- Show both accounts' limits, labelled by email, when the accounts differ.
- Avoid duplicate limits when Codex and OpenCode use the same account.
- Preserve native limits if the OpenCode credential is unavailable or invalid.
- Never initiate a login or modify saved credentials.

Token aggregation is unchanged; this only adds rate-limit tracking.

## Testing

- Relevant collector, updater, panel, and CLI tests pass.
- Verified with two distinct ChatGPT subscriptions through OpenCode2.
- Verified through a temporary cloned agents plugin using isolated state.
- Full suite: 180/184 test files passed; the remaining four require unavailable environment dependencies or the existing Quickshell runtime.

<img width="1716" height="917" alt="image" src="https://github.com/user-attachments/assets/272198d2-a76a-4bcb-91e8-be25908efe5a" />
