### PR TITLE
Fix terminal image paste from universal shortcut

### DIFF
--- a/bin/omarchy-cmd-terminal-paste
+++ b/bin/omarchy-cmd-terminal-paste
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# omarchy:summary=Paste clipboard content into the active terminal
+# omarchy:hidden=true
+
+export LC_ALL=C
+
+mime_types=""
+mime_probe=""
+
+if mime_probe=$(
+  set -o pipefail
+  timeout --signal=TERM --kill-after=0.05s 0.20s wl-paste --list-types 2>/dev/null | head -c 16385
+  probe_status=$?
+  (( probe_status == 0 )) || exit "$probe_status"
+  printf x
+); then
+  # The suffix prevents command substitution from stripping trailing newlines,
+  # so the byte limit can reliably detect a truncated MIME list.
+  mime_types=${mime_probe%?}
+fi
+
+# A truncated list cannot prove that the clipboard has no text representation.
+(( ${#mime_types} < 16385 )) || mime_types=""
+
+has_image=0
+has_text=0
+
+while IFS= read -r mime_type; do
+  case "$mime_type" in
+    UTF8_STRING | STRING | TEXT | COMPOUND_TEXT)
+      has_text=1
+      ;;
+    *)
+      case "${mime_type,,}" in
+        image/*)
+          has_image=1
+          ;;
+        text/*)
+          has_text=1
+          ;;
+      esac
+      ;;
+  esac
+done <<<"$mime_types"
+
+mods="SHIFT"
+key="Insert"
+
+if (( has_image && !has_text )); then
+  mods="CTRL"
+  key="V"
+fi
+
+send_key_state() {
+  local state="$1"
+
+  hyprctl dispatch "hl.dsp.send_key_state({ mods = \"$mods\", key = \"$key\", state = \"$state\" })" >/dev/null 2>&1
+}
+
+key_is_down=false
+
+release_key() {
+  if [[ $key_is_down == "true" ]]; then
+    key_is_down=false
+    send_key_state "up" || true
+  fi
+}
+
+trap release_key EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+key_is_down=true
+if send_key_state "down"; then
+  sleep 0.05
+fi
+release_key

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -42,7 +42,17 @@ local function universal_clipboard_shortcut(default_mods, default_key, terminal_
   end
 end
 
+local function universal_paste()
+  return function()
+    if active_window_is_terminal() then
+      hl.dispatch(hl.dsp.exec_cmd("omarchy-cmd-terminal-paste"))
+    else
+      send_shortcut_once("CTRL", "V")()
+    end
+  end
+end
+
 o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
+o.bind("SUPER + V", "Universal paste", universal_paste())
 o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")

--- a/test/shell.d/terminal-paste-test.sh
+++ b/test/shell.d/terminal-paste-test.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+helper="$ROOT/bin/omarchy-cmd-terminal-paste"
+[[ -x $helper ]] || fail "terminal paste helper is executable"
+grep -Fqx '# omarchy:hidden=true' "$helper" || fail "terminal paste helper is hidden from command listings"
+grep -Fqx '# omarchy:summary=Paste clipboard content into the active terminal' "$helper" ||
+  fail "terminal paste helper has command metadata"
+pass "terminal paste helper has hidden command metadata"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bin="$tmpdir/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/wl-paste" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$WL_PASTE_LOG"
+
+case "$WL_PASTE_MODE" in
+  image)
+    printf '%s\n' 'image/png'
+    ;;
+  mixed-case-image)
+    printf '%s\n' 'Image/PNG'
+    ;;
+  text)
+    printf '%s\n' 'text/plain;charset=utf-8'
+    ;;
+  text-atom)
+    printf '%s\n' 'UTF8_STRING'
+    ;;
+  mixed)
+    printf '%s\n' 'image/png' 'text/plain'
+    ;;
+  mixed-case-text)
+    printf '%s\n' 'image/png' 'Text/Plain;Charset=UTF-8'
+    ;;
+  empty)
+    ;;
+  unknown)
+    printf '%s\n' 'application/octet-stream'
+    ;;
+  oversized)
+    printf '%s\n' 'image/png'
+    while :; do
+      printf '%s\n' 'application/octet-stream'
+    done
+    ;;
+  failure)
+    exit 1
+    ;;
+  timeout)
+    sleep 2
+    printf '%s\n' 'image/png'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$fake_bin/wl-paste"
+
+cat >"$fake_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+
+if [[ ${HYPRCTL_SIGNAL_DOWN:-false} == "true" && $* == *'state = "down"'* ]]; then
+  kill -TERM "$PPID"
+fi
+SH
+chmod +x "$fake_bin/hyprctl"
+
+assert_terminal_paste() {
+  local mode="$1"
+  local expected_mods="$2"
+  local expected_key="$3"
+  local description="$4"
+  local hyprctl_log="$tmpdir/hyprctl-$mode.log"
+  local wl_paste_log="$tmpdir/wl-paste-$mode.log"
+
+  : >"$hyprctl_log"
+  : >"$wl_paste_log"
+
+  PATH="$fake_bin:$PATH" \
+    HYPRCTL_LOG="$hyprctl_log" \
+    WL_PASTE_LOG="$wl_paste_log" \
+    WL_PASTE_MODE="$mode" \
+    "$helper"
+
+  [[ $(<"$wl_paste_log") == "--list-types" ]] ||
+    fail "$description queries MIME names only" "$(<"$wl_paste_log")"
+
+  mapfile -t dispatches <"$hyprctl_log"
+  (( ${#dispatches[@]} == 2 )) ||
+    fail "$description sends one key down and one key up" "$(<"$hyprctl_log")"
+
+  [[ ${dispatches[0]} == "dispatch hl.dsp.send_key_state({ mods = \"$expected_mods\", key = \"$expected_key\", state = \"down\" })" ]] ||
+    fail "$description sends the expected key down" "${dispatches[0]}"
+  [[ ${dispatches[1]} == "dispatch hl.dsp.send_key_state({ mods = \"$expected_mods\", key = \"$expected_key\", state = \"up\" })" ]] ||
+    fail "$description sends the expected key up" "${dispatches[1]}"
+
+  if grep -Fq 'window =' "$hyprctl_log"; then
+    fail "$description sends to the focused surface without a window target"
+  fi
+
+  pass "$description"
+}
+
+assert_terminal_paste image CTRL V "image-only clipboard uses raw Ctrl+V"
+assert_terminal_paste mixed-case-image CTRL V "mixed-case image MIME uses raw Ctrl+V"
+assert_terminal_paste text SHIFT Insert "text clipboard uses terminal paste"
+assert_terminal_paste text-atom SHIFT Insert "standard text atoms use terminal paste"
+assert_terminal_paste mixed SHIFT Insert "mixed clipboard uses terminal paste"
+assert_terminal_paste mixed-case-text SHIFT Insert "mixed-case text MIME keeps mixed clipboard on terminal paste"
+assert_terminal_paste empty SHIFT Insert "empty clipboard falls back to terminal paste"
+assert_terminal_paste unknown SHIFT Insert "unknown clipboard falls back to terminal paste"
+assert_terminal_paste oversized SHIFT Insert "oversized MIME output falls back to terminal paste"
+assert_terminal_paste failure SHIFT Insert "clipboard query failure falls back to terminal paste"
+assert_terminal_paste timeout SHIFT Insert "clipboard query timeout falls back to terminal paste"
+
+interrupt_log="$tmpdir/hyprctl-interrupt.log"
+: >"$interrupt_log"
+set +e
+PATH="$fake_bin:$PATH" \
+  HYPRCTL_LOG="$interrupt_log" \
+  HYPRCTL_SIGNAL_DOWN=true \
+  WL_PASTE_LOG="$tmpdir/wl-paste-interrupt.log" \
+  WL_PASTE_MODE=image \
+  "$helper"
+interrupt_status=$?
+set -e
+(( interrupt_status == 143 )) || fail "interrupted paste reports termination" "$interrupt_status"
+mapfile -t interrupt_dispatches <"$interrupt_log"
+(( ${#interrupt_dispatches[@]} == 2 )) ||
+  fail "interrupted paste releases the synthetic key" "$(<"$interrupt_log")"
+[[ ${interrupt_dispatches[1]} == *'state = "up" })' ]] ||
+  fail "interrupted paste sends key up during cleanup" "${interrupt_dispatches[1]}"
+pass "interrupted paste releases the synthetic key"
+
+run_clipboard_binding() {
+  local window_kind="$1"
+
+  OMARCHY_PATH="$ROOT" WINDOW_KIND="$window_kind" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local paste_handler
+
+o = {
+  bind = function(_, description, handler)
+    if description == "Universal paste" then
+      paste_handler = handler
+    end
+  end,
+}
+
+hl = {
+  dsp = {
+    exec_cmd = function(command)
+      return { kind = "exec", command = command }
+    end,
+    send_key_state = function(args)
+      return { kind = "key", args = args }
+    end,
+  },
+  dispatch = function(dispatcher)
+    if dispatcher.kind == "exec" then
+      print("exec\t" .. dispatcher.command)
+    elseif dispatcher.kind == "key" then
+      print(table.concat({ "key", dispatcher.args.mods, dispatcher.args.key, dispatcher.args.state }, "\t"))
+    end
+  end,
+  get_active_window = function()
+    if os.getenv("WINDOW_KIND") == "terminal" then
+      return { tags = { "terminal*" } }
+    end
+
+    return { tags = {} }
+  end,
+  timer = function(callback)
+    callback()
+  end,
+}
+
+require("default.hypr.bindings.clipboard")
+assert(type(paste_handler) == "function")
+paste_handler()
+LUA
+}
+
+terminal_binding_output=$(run_clipboard_binding terminal)
+[[ $terminal_binding_output == $'exec\tomarchy-cmd-terminal-paste' ]] ||
+  fail "terminal Super+V launches the MIME-aware helper asynchronously" "$terminal_binding_output"
+pass "terminal Super+V launches the MIME-aware helper asynchronously"
+
+gui_binding_output=$(run_clipboard_binding gui)
+[[ $gui_binding_output == $'key\tCTRL\tV\tdown\nkey\tCTRL\tV\tup' ]] ||
+  fail "GUI Super+V keeps explicit Ctrl+V injection" "$gui_binding_output"
+pass "GUI Super+V keeps explicit Ctrl+V injection"


### PR DESCRIPTION
## Summary

- Route terminal `SUPER+V` through a hidden MIME-aware helper.
- Use raw `CTRL+V` only for image-only clipboard offers.
- Keep `SHIFT+Insert` for text, mixed, empty, unknown, failed, timed-out, or truncated MIME probes.
- Keep GUI paste and the existing copy and cut bindings unchanged.

## Root cause

The universal terminal paste path always injected `SHIFT+Insert`. That is correct for terminal text paste, but it does not deliver an image-only clipboard to terminal applications such as Codex that handle raw `CTRL+V` as an image-paste action.

The new helper queries MIME names outside the Hyprland Lua event loop. The query has a 200 ms deadline, a 50 ms kill grace, and a 16 KiB output cap. Uncertain results fall back to the existing text-safe behavior. Synthetic key-down state is paired with key-up cleanup on normal exit and termination.

## Validation

- `test/shell.d/terminal-paste-test.sh`: 15 checks passed.
- `./test/cli`: passed.
- `bin/omarchy commands --check`: 429 commands passed.
- Bash syntax, Lua parse, and `git diff --check`: passed.
- `./test/all`: CLI passed; shell reported four environment-only failures because `omarchy-pkgs` and sandbox netlink access were unavailable. The new test passed inside the aggregate run.
- Live on Hyprland 0.56.1: reload passed and `hyprctl configerrors` was empty.
- Real bounded probes returned the expected text MIME offers and an image-only `image/png` offer.
- Live `SUPER+V` image paste passed in Herdr/Codex and Kitty/Codex. Normal terminal text paste also passed.

## Delivery note

The same generic commit is temporarily backported to the Apple Silicon fork. No ARM-specific behavior is included in this change.
