### PR TITLE
Add source, state, and kinds filters to omarchy-plugin-list

### DIFF
--- a/bin/omarchy-plugin-list
+++ b/bin/omarchy-plugin-list
@@ -2,19 +2,31 @@
 
 # omarchy:summary=List discovered shell plugins
 # omarchy:group=plugin
-# omarchy:args=[--json]
+# omarchy:args=[--json] [--source=<first-party|third-party>] [--state=<enabled|disabled>] [--kinds=<kind[,kind...]>]
 
 set -euo pipefail
 
 json="false"
+source_filter=""
+state_filter=""
+kinds_filter=""
 
 while (( $# > 0 )); do
   case "$1" in
   --json)
     json="true"
     ;;
+  --source=*)
+    source_filter="${1#*=}"
+    ;;
+  --state=*)
+    state_filter="${1#*=}"
+    ;;
+  --kinds=*)
+    kinds_filter="${1#*=}"
+    ;;
   -h | --help)
-    echo "Usage: omarchy plugin list [--json]"
+    echo "Usage: omarchy plugin list [--json] [--source=<first-party|third-party>] [--state=<enabled|disabled>] [--kinds=<kind[,kind...]>]"
     exit 0
     ;;
   *)
@@ -25,10 +37,34 @@ while (( $# > 0 )); do
   shift
 done
 
+if [[ -n $source_filter && $source_filter != "first-party" && $source_filter != "third-party" ]]; then
+  echo "omarchy-plugin-list: --source must be first-party or third-party" >&2
+  exit 1
+fi
+
+if [[ -n $state_filter && $state_filter != "enabled" && $state_filter != "disabled" ]]; then
+  echo "omarchy-plugin-list: --state must be enabled or disabled" >&2
+  exit 1
+fi
+
 plugins=$(omarchy-shell shell listPlugins)
 
+filtered=$(jq -r \
+  --arg source "$source_filter" \
+  --arg state "$state_filter" \
+  --arg kind "$kinds_filter" '
+    [ .[] | select(
+        ($source == "" or (if $source == "first-party" then .firstParty else (.firstParty | not) end))
+      ) | select(
+        ($state == "" or (if $state == "enabled" then .enabled else (.enabled | not) end))
+      ) | select(
+        ($kind == "" or ((.kinds // []) as $kinds | all($kind | split(",")[]; . as $wanted | $kinds | index($wanted) != null)))
+      )
+    ]
+  ' <<<"$plugins")
+
 if [[ $json == "true" ]]; then
-  printf '%s\n' "$plugins"
+  printf '%s\n' "$filtered"
   exit 0
 fi
 
@@ -40,7 +76,7 @@ jq -r '
     ((.kinds // []) | join(",")),
     (.name // "")
   ] | @tsv
-' <<<"$plugins" | awk -F '\t' '
+' <<<"$filtered" | awk -F '\t' '
   BEGIN { printf "%-32s %-9s %-11s %-18s %s\n", "ID", "STATE", "SOURCE", "KINDS", "NAME" }
   { printf "%-32s %-9s %-11s %-18s %s\n", $1, $2, $3, $4, $5 }
 '

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -12,7 +12,7 @@ The first-party plugins ship with Omarchy and live in `$OMARCHY_PATH/shell/plugi
 omarchy plugin list
 ```
 
-That prints every discovered plugin with its id, whether it's enabled, whether it's first-party or third-party, its kinds, and its display name. Add `--json` if you're feeding it to something else.
+That prints every discovered plugin with its id, whether it's enabled, whether it's first-party or third-party, its kinds, and its display name. Add `--json` if you're feeding it to something else. If the list is long, you can narrow it down — for example `omarchy plugin list --source=third-party --state=enabled` shows only the third-party plugins that are on.
 
 Plugin ids are namespaced. The built-ins all start with `omarchy.` — `omarchy.clock`, `omarchy.network`, `omarchy.notifications` — and that namespace is reserved, so a third-party plugin can never claim it.
 

--- a/test/shell.d/plugin-list-test.sh
+++ b/test/shell.d/plugin-list-test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/bin"
+
+cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' '[
+  {"id": "omarchy.clock", "name": "Clock", "enabled": true, "firstParty": true, "kinds": ["bar-widget"]},
+  {"id": "acme.weather", "name": "Weather", "enabled": false, "firstParty": false, "kinds": ["bar-widget", "service"]},
+  {"id": "tester.bar", "name": "Tester Bar", "enabled": true, "firstParty": false, "kinds": ["bar"]}
+]'
+SH
+chmod +x "$TMPDIR/bin/omarchy-shell"
+
+list_plugins() {
+  PATH="$TMPDIR/bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-plugin-list" "$@"
+}
+
+list_plugins --json --source=third-party | jq -e 'length == 2 and all(.[]; .firstParty == false)' >/dev/null ||
+  fail "--source=third-party --json lists only third-party plugins"
+pass "--source=third-party --json lists only third-party plugins"
+
+list_plugins --json --source=first-party | jq -e 'length == 1 and .[0].id == "omarchy.clock"' >/dev/null ||
+  fail "--source=first-party --json lists only first-party plugins"
+pass "--source=first-party --json lists only first-party plugins"
+
+list_plugins --json --state=enabled | jq -e 'length == 2 and all(.[]; .enabled)' >/dev/null ||
+  fail "--state=enabled --json lists only enabled plugins"
+pass "--state=enabled --json lists only enabled plugins"
+
+list_plugins --json --state=disabled | jq -e 'length == 1 and .[0].id == "acme.weather"' >/dev/null ||
+  fail "--state=disabled --json lists only disabled plugins"
+pass "--state=disabled --json lists only disabled plugins"
+
+list_plugins --json --kinds=service | jq -e 'length == 1 and .[0].id == "acme.weather"' >/dev/null ||
+  fail "--kinds=service --json matches a plugin that has service among its kinds"
+pass "--kinds=service --json matches a plugin that has service among its kinds"
+
+list_plugins --json --kinds=bar-widget | jq -e 'length == 2 and all(.[]; .kinds | index("bar-widget") != null)' >/dev/null ||
+  fail "--kinds=bar-widget --json matches every plugin carrying that kind"
+pass "--kinds=bar-widget --json matches every plugin carrying that kind"
+
+list_plugins --json --kinds=bar-widget,service | jq -e 'length == 1 and .[0].id == "acme.weather"' >/dev/null ||
+  fail "--kinds=bar-widget,service --json matches a plugin that carries every listed kind"
+pass "--kinds=bar-widget,service --json matches a plugin that carries every listed kind"
+
+list_plugins --json --kinds=service,bar | jq -e 'length == 0' >/dev/null ||
+  fail "--kinds=service,bar --json skips plugins missing any listed kind"
+pass "--kinds=service,bar --json skips plugins missing any listed kind"
+
+list_plugins --json | jq -e 'length == 3' >/dev/null ||
+  fail "plain --json still lists every plugin"
+pass "plain --json still lists every plugin"
+
+output=$(list_plugins --source=third-party)
+grep -q '^acme.weather' <<<"$output" || fail "--source=third-party table lists third-party plugins" "$output"
+grep -q '^tester.bar' <<<"$output" || fail "--source=third-party table lists third-party plugins" "$output"
+if grep -q '^omarchy.clock' <<<"$output"; then
+  fail "--source=third-party table omits first-party plugins"
+fi
+pass "--source=third-party table lists only third-party plugins"
+
+if list_plugins --source=bogus >/dev/null 2>&1; then
+  fail "an unknown --source value is rejected"
+fi
+pass "an unknown --source value is rejected"
+
+if list_plugins --state=bogus >/dev/null 2>&1; then
+  fail "an unknown --state value is rejected"
+fi
+pass "an unknown --state value is rejected"
+
+output=$(list_plugins --help)
+grep -q -- '--source=<first-party|third-party>' <<<"$output" || fail "help shows --source" "$output"
+grep -q -- '--state=<enabled|disabled>' <<<"$output" || fail "help shows --state" "$output"
+grep -Fq -- '--kinds=<kind[,kind...]>' <<<"$output" || fail "help shows --kinds" "$output"
+pass "help shows all filter options"


### PR DESCRIPTION
Adds some optional arguments to filter the output from `omarchy plugin list`:
- source: first-party/third-party
- state: enabled/disabled
- kinds: free-text, matching one or more kinds

A hint option more options is added to the manual page.

Also adds a new test for the plugin list command, including the added argument handling:

```bash
$ bash test/shell.d/plugin-list-test.sh 
ok - --source=third-party --json lists only third-party plugins
ok - --source=first-party --json lists only first-party plugins
ok - --state=enabled --json lists only enabled plugins
ok - --state=disabled --json lists only disabled plugins
ok - --kinds=service --json matches a plugin that has service among its kinds
ok - --kinds=bar-widget --json matches every plugin carrying that kind
ok - --kinds=bar-widget,service --json matches a plugin that carries every listed kind
ok - --kinds=service,bar --json skips plugins missing any listed kind
ok - plain --json still lists every plugin
ok - --source=third-party table lists only third-party plugins
ok - an unknown --source value is rejected
ok - an unknown --state value is rejected
ok - help shows all filter options
```