### PR TITLE
Apply the theme accent color to Zen

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -199,6 +199,7 @@ post_theme_commands=(
   omarchy-theme-set-pi
   omarchy-theme-set-claude
   omarchy-theme-set-browser
+  omarchy-theme-set-zen
   omarchy-theme-set-vscode
   omarchy-theme-set-obsidian
   omarchy-theme-set-keyboard

--- a/bin/omarchy-theme-set-zen
+++ b/bin/omarchy-theme-set-zen
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# omarchy:summary=Sync the generated Omarchy theme to Zen
+# omarchy:hidden=true
+
+ZEN_SOURCE_PATH="$HOME/.local/state/omarchy/current/theme/zen.js"
+ZEN_PROFILES_DIR="$HOME/.config/zen"
+
+[[ -f $ZEN_SOURCE_PATH ]] || exit 0
+[[ -d $ZEN_PROFILES_DIR ]] || exit 0
+
+# Zen reads its accent from a preference rather than a Chromium-style policy,
+# and policies live under a root-owned distribution directory that a theme
+# change cannot write to. So the generated prefs go into each profile's
+# user.js, which the user also owns: replace only the lines the theme file
+# declares and leave the rest of the file alone.
+merge_theme_prefs() {
+  local user_js="$1"
+  local managed updated
+
+  managed=$(mktemp)
+  updated=$(mktemp)
+
+  sed -n 's/^\(user_pref("[^"]*"\).*/\1/p' "$ZEN_SOURCE_PATH" >"$managed"
+
+  if [[ -f $user_js && -s $managed ]]; then
+    grep -vF -f "$managed" "$user_js" >"$updated"
+  elif [[ -f $user_js ]]; then
+    cat "$user_js" >"$updated"
+  fi
+
+  cat "$ZEN_SOURCE_PATH" >>"$updated"
+
+  mv "$updated" "$user_js"
+  rm -f "$managed"
+}
+
+for profile in "$ZEN_PROFILES_DIR"/*/; do
+  [[ -f $profile/prefs.js ]] || continue
+
+  merge_theme_prefs "$profile/user.js"
+done

--- a/default/themed/zen.js.tpl
+++ b/default/themed/zen.js.tpl
@@ -1,0 +1,1 @@
+user_pref("zen.theme.accent-color", "{{ accent }}");

--- a/test/shell.d/theme-set-zen-test.sh
+++ b/test/shell.d/theme-set-zen-test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export PATH="$ROOT/bin:$PATH"
+
+theme_dir="$TMPDIR/.local/state/omarchy/current/theme"
+profile="$TMPDIR/.config/zen/abcd1234.Default"
+mkdir -p "$theme_dir" "$profile"
+touch "$profile/prefs.js"
+
+echo 'user_pref("zen.theme.accent-color", "#7aa2f7");' >"$theme_dir/zen.js"
+
+HOME="$TMPDIR" omarchy-theme-set-zen
+
+expected='user_pref("zen.theme.accent-color", "#7aa2f7");'
+[[ $(<"$profile/user.js") == "$expected" ]] ||
+  fail "the generated theme file lands in a Zen profile" "expected $expected, got $(<"$profile/user.js")"
+pass "the generated theme file lands in a Zen profile"
+
+cat >"$profile/user.js" <<'PREFS'
+user_pref("zen.welcome-screen.seen", true);
+user_pref("zen.theme.accent-color", "#00ff00");
+user_pref("browser.tabs.closeWindowWithLastTab", true);
+PREFS
+
+HOME="$TMPDIR" omarchy-theme-set-zen
+
+grep -q '^user_pref("zen.welcome-screen.seen", true);$' "$profile/user.js" &&
+  grep -q '^user_pref("browser.tabs.closeWindowWithLastTab", true);$' "$profile/user.js" ||
+  fail "preferences the user owns survive a theme change" "user.js lost user-owned entries"
+pass "preferences the user owns survive a theme change"
+
+(( $(grep -c "zen.theme.accent-color" "$profile/user.js") == 1 )) &&
+  grep -q "$expected" "$profile/user.js" ||
+  fail "a stale accent is replaced rather than appended" "got $(grep -c "zen.theme.accent-color" "$profile/user.js") accent lines"
+pass "a stale accent is replaced rather than appended"
+
+# The script drops whatever the theme file declares, so a second pref needs no
+# code change -- only a longer template.
+cat >"$theme_dir/zen.js" <<'GENERATED'
+user_pref("zen.theme.accent-color", "#bb9af7");
+user_pref("zen.theme.border-radius", 4);
+GENERATED
+
+HOME="$TMPDIR" omarchy-theme-set-zen
+HOME="$TMPDIR" omarchy-theme-set-zen
+
+(( $(grep -c "zen.theme.accent-color" "$profile/user.js") == 1 )) &&
+  (( $(grep -c "zen.theme.border-radius" "$profile/user.js") == 1 )) &&
+  grep -q '^user_pref("zen.welcome-screen.seen", true);$' "$profile/user.js" ||
+  fail "every pref the theme declares is managed, and repeated runs stay idempotent" "$(cat "$profile/user.js")"
+pass "every pref the theme declares is managed, and repeated runs stay idempotent"
+
+not_a_profile="$TMPDIR/.config/zen/Profile Groups"
+mkdir -p "$not_a_profile"
+
+HOME="$TMPDIR" omarchy-theme-set-zen
+
+[[ ! -f $not_a_profile/user.js ]] ||
+  fail "directories without prefs.js are skipped" "wrote user.js into $not_a_profile"
+pass "directories without prefs.js are skipped"
+
+rm "$theme_dir/zen.js"
+cp "$profile/user.js" "$TMPDIR/user.js.before"
+
+HOME="$TMPDIR" omarchy-theme-set-zen
+
+diff -q "$TMPDIR/user.js.before" "$profile/user.js" >/dev/null ||
+  fail "a theme without a zen.js leaves profiles untouched" "user.js changed with no generated theme file"
+pass "a theme without a zen.js leaves profiles untouched"
+
+no_zen=$(mktemp -d)
+mkdir -p "$no_zen/.local/state/omarchy/current/theme"
+echo 'user_pref("zen.theme.accent-color", "#7aa2f7");' >"$no_zen/.local/state/omarchy/current/theme/zen.js"
+
+HOME="$no_zen" omarchy-theme-set-zen ||
+  fail "a machine without Zen is a no-op" "command failed when ~/.config/zen is missing"
+pass "a machine without Zen is a no-op"
+
+rm -rf "$no_zen"
+
+# End to end: the template is what actually produces zen.js at theme-set time.
+render=$(mktemp -d)
+mkdir -p "$render/.local/state/omarchy/current/next-theme"
+cp "$ROOT/themes/tokyo-night/colors.toml" "$render/.local/state/omarchy/current/next-theme/"
+
+HOME="$render" OMARCHY_PATH="$ROOT" omarchy-theme-set-templates
+
+rendered="$render/.local/state/omarchy/current/next-theme/zen.js"
+[[ -f $rendered ]] ||
+  fail "the template renders zen.js for a theme that does not ship one" "no zen.js generated"
+[[ $(<"$rendered") == 'user_pref("zen.theme.accent-color", "#7aa2f7");' ]] ||
+  fail "the template renders zen.js for a theme that does not ship one" "got $(<"$rendered")"
+pass "the template renders zen.js for a theme that does not ship one"
+
+rm -rf "$render"


### PR DESCRIPTION
## Summary

Add Zen as a theme target, the way VS Code, Obsidian, Pi, and Claude already are.

## Problem

Omarchy installs Zen, offers it under `Setup > Defaults > Browser`, and ships it the same Firefox preferences as Firefox itself — but a theme change never reaches it. `omarchy-theme-set-browser` writes `BrowserThemeColor` into Chromium-style managed policies, which Zen does not read.

Zen already exposes the hook. `zen.theme.accent-color` is a preference that Zen applies to its chrome as `--zen-primary-color`:

```js
// zenThemeModifier.js
updateAccentColor() {
  const accentColor = Services.prefs.getStringPref("zen.theme.accent-color");
  document.documentElement.style.setProperty("--zen-primary-color", accentColor);
}
```

It takes a hex value directly (`ZenGradientGenerator.mjs` falls back to `hexToRgb` when the value is not `AccentColor`), so the theme's `accent` goes in verbatim.

## How

`default/themed/zen.js.tpl` renders `zen.js` alongside the rest of the generated theme, so a theme can ship its own and a user can override it from `~/.config/omarchy/themed`. `omarchy-theme-set-zen` only delivers what was generated, the same shape as `omarchy-theme-set-obsidian`.

Zen's policies live under a root-owned `distribution/` directory that a theme change cannot write to without `sudo`, so the generated prefs go into each profile's `user.js`. That file belongs to the user, so the script replaces only the lines the theme file declares and preserves everything else — including whatever the user put there themselves.

Two things worth flagging:

- The accent lands on Zen's next start. The pref observer in `zenThemeModifier.js` only fires for in-process changes, so live updating would need a native messaging host — not worth the machinery.
- On Linux the `AccentColor` default does **not** resolve from `org.gnome.desktop.interface accent-color`. I checked by flipping that between `blue` and `orange` with Zen open and diffing screenshots: no change. Worth knowing for anyone who assumes the system-colors route works here.

## Testing

`test/shell.d/theme-set-zen-test.sh` covers eight cases, including that user-owned prefs survive, that a stale accent is replaced rather than appended, that repeated runs are idempotent, that every pref the theme file declares is managed (so a longer template needs no code change), and an end-to-end one that runs `omarchy-theme-set-templates` against `tokyo-night` and asserts the rendered `zen.js`.

`./test/cli` passes. `./test/shell` passes except for four failures that reproduce identically on a clean checkout without this patch: three `omarchy-pkgs checkout` ones that need that repo alongside, and `bar icons share slot and baseline geometry`.

Also verified in a running session, on `zen-browser-bin 1.21.14b`: switching the generated accent between themes rewrites the profile without duplicating the line, and unrelated prefs in the same `user.js` stay put. Setting a deliberately unmistakable `#00ff00` while the GNOME accent stayed `blue` turned every accent surface in `about:preferences` green — checkboxes, buttons, the search field border, the active section marker.

## Note on #6058

#6058 targets the same gap through generated `userChrome.css`, and it reaches the sidebar and vertical tabs background, which no preference exposes. This one is narrower and stops at the accent.

Happy to close this if you would rather take that route — I left a note there about the paths it guards on, which have moved since it was opened.
