### PR TITLE
Show all Codex usage pools

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -495,7 +495,7 @@ def rpc_request(proc, request_id, method, params=None, timeout=8):
   raise TimeoutError(method)
 
 
-def limit_window(window):
+def limit_window(window, limit_name=""):
   if not isinstance(window, dict):
     return None
   used = window.get("usedPercent")
@@ -512,7 +512,7 @@ def limit_window(window):
     label = "Limit"
   reset = window.get("resetsAt")
   return {
-    "label": label,
+    "label": f"{limit_name} · {label}" if limit_name else label,
     "percent": float(used) / 100.0,
     "resetsAt": datetime.fromtimestamp(number(reset), timezone.utc).isoformat() if reset else "",
   }
@@ -548,14 +548,32 @@ def fetch_codex_rpc():
     limits_msg = rpc_request(proc, 3, "account/rateLimits/read", timeout=4)
 
     account = (account_msg.get("result") or {}).get("account") or {}
-    limits = (limits_msg.get("result") or {}).get("rateLimits") or {}
+    limits_result = limits_msg.get("result") or {}
+    limits = limits_result.get("rateLimits") or {}
     plan = limits.get("planType") or account.get("planType") or account.get("type") or ""
     result["tierLabel"] = str(plan) if plan else ""
 
-    for window in (limits.get("primary"), limits.get("secondary")):
-      entry = limit_window(window)
-      if entry:
-        result["limits"].append(entry)
+    limits_by_id = limits_result.get("rateLimitsByLimitId") or {}
+    if isinstance(limits_by_id, dict) and limits_by_id:
+      default_limit_id = limits.get("limitId")
+      ordered_limit_ids = list(limits_by_id)
+      if default_limit_id in limits_by_id:
+        ordered_limit_ids.remove(default_limit_id)
+        ordered_limit_ids.insert(0, default_limit_id)
+      for limit_id in ordered_limit_ids:
+        grouped_limits = limits_by_id.get(limit_id)
+        if not isinstance(grouped_limits, dict):
+          continue
+        limit_name = str(grouped_limits.get("limitName") or "")
+        for window in (grouped_limits.get("primary"), grouped_limits.get("secondary")):
+          entry = limit_window(window, limit_name)
+          if entry:
+            result["limits"].append(entry)
+    if not result["limits"]:
+      for window in (limits.get("primary"), limits.get("secondary")):
+        entry = limit_window(window)
+        if entry:
+          result["limits"].append(entry)
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
     result["authHelpText"] = str(exc)

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -510,14 +510,16 @@ def limit_window(window, limit_name=""):
     label = f"{mins}m window"
   else:
     label = "Limit"
+  title = "Weekly limit" if mins == 10080 else label
+  if limit_name:
+    title = f"{limit_name} {title}"
   reset = window.get("resetsAt")
   result = {
     "label": f"{limit_name} · {label}" if limit_name else label,
     "percent": float(used) / 100.0,
     "resetsAt": datetime.fromtimestamp(number(reset), timezone.utc).isoformat() if reset else "",
+    "title": title,
   }
-  if limit_name:
-    result["title"] = limit_name
   return result
 
 

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -533,7 +533,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -511,11 +511,14 @@ def limit_window(window, limit_name=""):
   else:
     label = "Limit"
   reset = window.get("resetsAt")
-  return {
+  result = {
     "label": f"{limit_name} · {label}" if limit_name else label,
     "percent": float(used) / 100.0,
     "resetsAt": datetime.fromtimestamp(number(reset), timezone.utc).isoformat() if reset else "",
   }
+  if limit_name:
+    result["title"] = limit_name
+  return result
 
 
 def fetch_codex_rpc():

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -116,7 +116,11 @@ Panel {
     for (var i = 0; i < list.length; i++) {
       var entry = list[i] || {}
       var percent = Number(entry.percent)
-      if (percent >= 0) out.push(limitWindow(entry.label, percent, entry.resetsAt, entry.title))
+      // An untouched five-hour allowance is just noise beside the longer and
+      // model-specific pools. Reveal it as soon as any of it has been used.
+      var isUnusedFiveHour = windowSpanMs(entry.label) === 5 * 3600 * 1000 && percent === 0
+      if (percent >= 0 && !isUnusedFiveHour)
+        out.push(limitWindow(entry.label, percent, entry.resetsAt, entry.title))
     }
     return out
   }

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -116,9 +116,10 @@ Panel {
     for (var i = 0; i < list.length; i++) {
       var entry = list[i] || {}
       var percent = Number(entry.percent)
-      // An untouched five-hour allowance is just noise beside the longer and
-      // model-specific pools. Reveal it as soon as any of it has been used.
-      var isUnusedFiveHour = windowSpanMs(entry.label) === 5 * 3600 * 1000 && percent === 0
+      // Codex can advertise additional model pools before they have been
+      // touched. Keep those five-hour meters quiet until usage begins.
+      var isUnusedFiveHour = p.providerId === "codex"
+        && windowSpanMs(entry.label) === 5 * 3600 * 1000 && percent === 0
       if (percent >= 0 && !isUnusedFiveHour)
         out.push(limitWindow(entry.label, percent, entry.resetsAt, entry.title))
     }

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -240,4 +240,17 @@ assertDeepEqual(
   [{ title: 'Weekly', percent: 0.12, resetAt: '' }],
   'agents panel still reads a window out of a label that carries no title'
 )
+
+assertDeepEqual(
+  limitWindows({ limits: [
+    { label: '5h window', percent: 0, resetsAt: '' },
+    { label: 'Weekly (7-day)', percent: 0, resetsAt: '' },
+    { label: 'Session (5-hour)', percent: 0.01, resetsAt: '' }
+  ] }),
+  [
+    { title: 'Weekly', percent: 0, resetAt: '' },
+    { title: 'Session', percent: 0.01, resetAt: '' }
+  ],
+  'agents panel hides only untouched five-hour windows'
+)
 JS

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -241,16 +241,4 @@ assertDeepEqual(
   'agents panel still reads a window out of a label that carries no title'
 )
 
-assertDeepEqual(
-  limitWindows({ limits: [
-    { label: '5h window', percent: 0, resetsAt: '' },
-    { label: 'Weekly (7-day)', percent: 0, resetsAt: '' },
-    { label: 'Session (5-hour)', percent: 0.01, resetsAt: '' }
-  ] }),
-  [
-    { title: 'Weekly', percent: 0, resetAt: '' },
-    { title: 'Session', percent: 0.01, resetAt: '' }
-  ],
-  'agents panel hides only untouched five-hour windows'
-)
 JS

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,8 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+[[ $* == "-s read-only -a never app-server" ]] || exit 64
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -69,7 +69,7 @@ pass "Codex collector counts each turn once"
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
 
-[[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00"},{"label":"GPT-5.3-Codex-Spark · Weekly (7-day)","percent":0.12,"resetsAt":"2026-08-22T00:18:05+00:00","title":"GPT-5.3-Codex-Spark"}]}' ]] ||
+[[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00","title":"Weekly limit"},{"label":"GPT-5.3-Codex-Spark · Weekly (7-day)","percent":0.12,"resetsAt":"2026-08-22T00:18:05+00:00","title":"GPT-5.3-Codex-Spark Weekly limit"}]}' ]] ||
   fail "Codex collector includes every named usage pool without duplicating the default pool" "$result"
 pass "Codex collector includes every named usage pool without duplicating the default pool"
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -22,10 +22,28 @@ while read -r request; do
       jq -cn --argjson id "$id" '{id: $id, result: {}}'
       ;;
     account/read)
-      jq -cn --argjson id "$id" '{id: $id, result: {account: {}}}'
+      jq -cn --argjson id "$id" '{id: $id, result: {account: {planType: "pro"}}}'
       ;;
     account/rateLimits/read)
-      jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {}}}'
+      jq -cn --argjson id "$id" '{id: $id, result: {
+        rateLimits: {
+          limitId: "codex",
+          planType: "pro",
+          primary: {usedPercent: 94, windowDurationMins: 10080, resetsAt: 1787196799}
+        },
+        rateLimitsByLimitId: {
+          codex: {
+            limitId: "codex",
+            limitName: null,
+            primary: {usedPercent: 94, windowDurationMins: 10080, resetsAt: 1787196799}
+          },
+          codex_bengalfox: {
+            limitId: "codex_bengalfox",
+            limitName: "GPT-5.3-Codex-Spark",
+            primary: {usedPercent: 12, windowDurationMins: 10080, resetsAt: 1787357885}
+          }
+        }
+      }}'
       ;;
   esac
 done
@@ -51,9 +69,9 @@ pass "Codex collector counts each turn once"
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
 
-[[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
-  fail "Codex collector identifies itself with an empty limits list" "$result"
-pass "Codex collector identifies itself with an empty limits list"
+[[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00"},{"label":"GPT-5.3-Codex-Spark · Weekly (7-day)","percent":0.12,"resetsAt":"2026-08-22T00:18:05+00:00"}]}' ]] ||
+  fail "Codex collector includes every named usage pool without duplicating the default pool" "$result"
+pass "Codex collector includes every named usage pool without duplicating the default pool"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -25,7 +25,14 @@ while read -r request; do
       jq -cn --argjson id "$id" '{id: $id, result: {account: {planType: "pro"}}}'
       ;;
     account/rateLimits/read)
-      jq -cn --argjson id "$id" '{id: $id, result: {
+      if [[ ${LEGACY_LIMITS:-false} == "true" ]]; then
+        jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {
+          limitId: "codex",
+          planType: "pro",
+          primary: {usedPercent: 94, windowDurationMins: 10080, resetsAt: 1787196799}
+        }}}'
+      else
+        jq -cn --argjson id "$id" '{id: $id, result: {
         rateLimits: {
           limitId: "codex",
           planType: "pro",
@@ -44,6 +51,7 @@ while read -r request; do
           }
         }
       }}'
+      fi
       ;;
   esac
 done
@@ -72,6 +80,13 @@ pass "Codex collector does not double-count cache or reasoning tokens"
 [[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00","title":"Weekly limit"},{"label":"GPT-5.3-Codex-Spark · Weekly (7-day)","percent":0.12,"resetsAt":"2026-08-22T00:18:05+00:00","title":"GPT-5.3-Codex-Spark Weekly limit"}]}' ]] ||
   fail "Codex collector includes every named usage pool without duplicating the default pool" "$result"
 pass "Codex collector includes every named usage pool without duplicating the default pool"
+
+legacy_result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  LEGACY_LIMITS=true PATH="$TEST_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --force)
+
+[[ $(jq -c '.limits' <<<"$legacy_result") == '[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00","title":"Weekly limit"}]' ]] ||
+  fail "Codex collector supports legacy top-level rate limits" "$legacy_result"
+pass "Codex collector supports legacy top-level rate limits"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -69,7 +69,7 @@ pass "Codex collector counts each turn once"
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
 
-[[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00"},{"label":"GPT-5.3-Codex-Spark · Weekly (7-day)","percent":0.12,"resetsAt":"2026-08-22T00:18:05+00:00"}]}' ]] ||
+[[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"Weekly (7-day)","percent":0.94,"resetsAt":"2026-08-20T03:33:19+00:00"},{"label":"GPT-5.3-Codex-Spark · Weekly (7-day)","percent":0.12,"resetsAt":"2026-08-22T00:18:05+00:00","title":"GPT-5.3-Codex-Spark"}]}' ]] ||
   fail "Codex collector includes every named usage pool without duplicating the default pool" "$result"
 pass "Codex collector includes every named usage pool without duplicating the default pool"
 

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,28 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+
+const start = panelSource.indexOf('function windowIsLong')
+const end = panelSource.indexOf('// The window that decides')
+assert(start > 0 && end > start, 'agents panel exposes its limit-window helpers')
+eval(panelSource.slice(start, end))
+
+const untouchedFiveHour = { label: '5h window', percent: 0, resetsAt: '' }
+assertDeepEqual(
+  limitWindows({ providerId: 'codex', limits: [
+    untouchedFiveHour,
+    { label: 'Weekly (7-day)', percent: 0, resetsAt: '' },
+    { label: 'Session (5-hour)', percent: 0.01, resetsAt: '' }
+  ] }),
+  [
+    { title: 'Weekly', percent: 0, resetAt: '' },
+    { title: 'Session', percent: 0.01, resetAt: '' }
+  ],
+  'agents panel hides only untouched Codex five-hour windows'
+)
+assertDeepEqual(
+  limitWindows({ providerId: 'claude', limits: [untouchedFiveHour] }),
+  [{ title: 'Session', percent: 0, resetAt: '' }],
+  'agents panel leaves other providers unchanged'
+)
 JS


### PR DESCRIPTION
## Why

Codex can return multiple usage pools in `rateLimitsByLimitId`, such as the main Codex allowance and a separate GPT-5.3-Codex-Spark allowance. The collector currently reads only the top-level `rateLimits` object, leaving additional pools invisible in the agents panel.

## What changed

- read all entries from `rateLimitsByLimitId` when available
- label named pools using the name supplied by Codex
- keep the default Codex pool first
- avoid duplicating the default pool
- fall back to the existing top-level response for older Codex versions
- use the current non-interactive Codex approval policy when starting app-server
- hide untouched Codex five-hour meters until usage begins, while leaving other providers unchanged

## Validation

- verified live against Codex CLI 0.149.0 with main Codex and GPT-5.3-Codex-Spark pools
- verified that an untouched Codex five-hour meter disappears after restarting the shell
- focused agents panel, Claude limits, and Codex scanner tests passed
- collector test verifies the supported -a never app-server invocation
- full shell suite passed except three packaging checks requiring a separate `omarchy-pkgs` checkout
- legacy top-level Codex response fallback is covered
- `git diff --check`

Fixes #7873.
