### PR TITLE
Fix shell restart race through launcher ownership

### DIFF
--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -61,10 +61,52 @@ relock_session() {
   return 1
 }
 
-# Each kill stops the oldest matching instance and only returns once it has
-# fully exited, so the no-duplicate launch below can't race a dying shell.
-# Requires our quickshell-git build; 0.3.0's kill returns immediately.
-while timeout 5 quickshell kill -p "$CONFIG_DIR" --any-display >/dev/null 2>&1; do :; done
+shell_launcher_pid_matches() {
+  local pid="$1"
+  local -a command=()
+
+  [[ -r /proc/$pid/cmdline ]] || return 1
+  mapfile -d '' -t command <"/proc/$pid/cmdline" 2>/dev/null || return 1
+
+  [[ ${command[0]##*/} == "bash" &&
+    ${command[1]:-} == "$session_omarchy_path/bin/omarchy-launch-shell" &&
+    ${#command[@]} == 2 ]]
+}
+
+shell_launcher_pids() {
+  local proc pid
+
+  for proc in /proc/[0-9]*; do
+    pid=${proc##*/}
+    shell_launcher_pid_matches "$pid" && printf '%s\n' "$pid"
+  done
+}
+
+# The launcher owns Quickshell and forwards TERM to it. Stop every launcher and
+# wait for its child to exit before starting a replacement. This avoids
+# Quickshell's version-specific IPC kill behavior and cannot stack instances
+# when a child crashes during shutdown.
+mapfile -t shell_launchers < <(shell_launcher_pids)
+if ((${#shell_launchers[@]})); then
+  for pid in "${shell_launchers[@]}"; do
+    shell_launcher_pid_matches "$pid" && kill -TERM "$pid" 2>/dev/null
+  done
+
+  deadline=$((SECONDS + 5))
+  while (( SECONDS < deadline )); do
+    for pid in "${shell_launchers[@]}"; do
+      shell_launcher_pid_matches "$pid" && { sleep 0.05; continue 2; }
+    done
+    break
+  done
+
+  for pid in "${shell_launchers[@]}"; do
+    if shell_launcher_pid_matches "$pid"; then
+      echo "Could not stop all Omarchy shell instances." >&2
+      exit 1
+    fi
+  done
+fi
 
 # Spawn from Hyprland so the shell inherits the canonical session environment,
 # not transient variables from a terminal, SSH connection, or development tool.

--- a/test/shell.d/restart-shell-test.sh
+++ b/test/shell.d/restart-shell-test.sh
@@ -11,6 +11,8 @@ restart_pid_two=""
 cleanup() {
   [[ -n $restart_pid_one ]] && kill "$restart_pid_one" 2>/dev/null || true
   [[ -n $restart_pid_two ]] && kill "$restart_pid_two" 2>/dev/null || true
+  [[ -n $restart_pid_one ]] && wait "$restart_pid_one" 2>/dev/null || true
+  [[ -n $restart_pid_two ]] && wait "$restart_pid_two" 2>/dev/null || true
   rm -rf "$test_tmp"
 }
 trap cleanup EXIT
@@ -116,13 +118,30 @@ case " $* " in
   *' kill -p '*)
     pid=$(head -n 1 "$OMARCHY_TEST_QS_STATE")
     [[ $pid =~ ^[0-9]+$ ]] || exit 1
-    kill "$pid" 2>/dev/null
-    while kill -0 "$pid" 2>/dev/null; do sleep 0.01; done
-    awk 'NR > 1' "$OMARCHY_TEST_QS_STATE" >"$OMARCHY_TEST_QS_STATE.next"
-    mv "$OMARCHY_TEST_QS_STATE.next" "$OMARCHY_TEST_QS_STATE"
+
+    # Stock Quickshell 0.3.0 returns before the instance exits. A second kill
+    # during that shutdown is the update-time crash reproduced by this test.
+    if [[ -f $OMARCHY_TEST_QS_STATE.pending.$pid ]]; then
+      touch "$OMARCHY_TEST_QS_STATE.crashed"
+      exit 134
+    fi
+
+    touch "$OMARCHY_TEST_QS_STATE.pending.$pid"
+    (sleep 0.1; kill "$pid" 2>/dev/null) &
     ;;
   *' -n -p '*)
     printf '%s\n' "${OMARCHY_TEST_TRANSIENT_ENV-unset}" >"$OMARCHY_TEST_QS_ENV_LOG"
+
+    if [[ ${OMARCHY_TEST_QS_LONG_RUNNING:-0} == 1 ]]; then
+      stop_shell() {
+        awk -v pid="$PPID" '$0 != pid' "$OMARCHY_TEST_QS_STATE" >"$OMARCHY_TEST_QS_STATE.$$.next"
+        mv "$OMARCHY_TEST_QS_STATE.$$.next" "$OMARCHY_TEST_QS_STATE"
+        exit 0
+      }
+      trap stop_shell TERM INT
+      while true; do sleep 1; done
+    fi
+
     printf '303\n' >"$OMARCHY_TEST_QS_STATE"
     ;;
 esac
@@ -142,7 +161,7 @@ if [[ ${1:-} == "-j" && ${2:-} == "monitors" ]]; then
 elif [[ ${1:-} == "dispatch" && ${2:-} == hl.dsp.exec_cmd* ]]; then
   printf '%s\n' "${2:-}" >>"$OMARCHY_TEST_DISPATCH_LOG"
   OMARCHY_PATH="$OMARCHY_TEST_SESSION_PATH" \
-    env -u OMARCHY_TEST_TRANSIENT_ENV omarchy-launch-shell
+    env -u OMARCHY_TEST_TRANSIENT_ENV -u OMARCHY_TEST_QS_LONG_RUNNING omarchy-launch-shell
   printf 'ok\n'
 elif [[ ${1:-} == "dispatch" ]]; then
   exit 1
@@ -174,11 +193,25 @@ SH
 
 chmod +x "$restart_bin/qs" "$restart_bin/quickshell" "$restart_bin/hyprctl" "$restart_bin/systemd-cat" "$restart_bin/systemctl"
 
-sleep 30 &
+PATH="$restart_bin:$PATH" \
+OMARCHY_PATH="$restart_root" \
+OMARCHY_TEST_QS_LONG_RUNNING=1 \
+OMARCHY_TEST_QS_STATE="$restart_state" \
+OMARCHY_TEST_QS_LOG="$restart_log" \
+OMARCHY_TEST_QS_ENV_LOG="$restart_env_log" \
+  /bin/bash "$restart_bin/omarchy-launch-shell" &
 restart_pid_one=$!
-sleep 30 &
+PATH="$restart_bin:$PATH" \
+OMARCHY_PATH="$restart_root" \
+OMARCHY_TEST_QS_LONG_RUNNING=1 \
+OMARCHY_TEST_QS_STATE="$restart_state" \
+OMARCHY_TEST_QS_LOG="$restart_log" \
+OMARCHY_TEST_QS_ENV_LOG="$restart_env_log" \
+  /bin/bash "$restart_bin/omarchy-launch-shell" &
 restart_pid_two=$!
 printf '%s\n%s\n' "$restart_pid_one" "$restart_pid_two" >"$restart_state"
+sleep 0.1
+: >"$restart_log"
 
 caller_root="$test_tmp/caller-root"
 mkdir -p "$caller_root/shell"
@@ -208,7 +241,10 @@ restart_pid_one=""
 restart_pid_two=""
 [[ $(<"$restart_state") == 303 ]] || fail "restart leaves exactly one fresh shell instance"
 [[ $(grep -c '^-n -p ' "$restart_log") == 1 ]] || fail "restart launches one fresh shell process"
-grep -F "kill -p $restart_root/shell --any-display" "$restart_log" >/dev/null || fail "restart stops the shell from the session checkout"
+[[ ! -f $restart_state.crashed ]] || fail "restart does not send a second stop request while stock Quickshell is shutting down"
+if grep -F "kill -p $restart_root/shell --any-display" "$restart_log" >/dev/null; then
+  fail "restart does not depend on Quickshell's version-specific kill command"
+fi
 [[ $(<"$restart_env_log") == "unset" ]] || fail "restart uses the Hyprland session environment for the fresh shell"
 grep -F 'hl.dsp.exec_cmd("omarchy-launch-shell")' "$dispatch_log" >/dev/null || fail "restart launches the fresh shell through Hyprland"
 grep -F "ipc -n -p $restart_root/shell call -- shell ping" "$ipc_log" >/dev/null || fail "restart checks readiness in the session checkout"
@@ -237,9 +273,16 @@ pass "restart preserves the shell while its lock is active"
 # A LOCK session without an active locker — dead shell or a crash-handler
 # relaunch holding no lock — is the failsafe: restart must proceed,
 # re-acquire the session lock, and wait for it to report secure.
-sleep 30 &
+PATH="$restart_bin:$PATH" \
+OMARCHY_PATH="$restart_root" \
+OMARCHY_TEST_QS_LONG_RUNNING=1 \
+OMARCHY_TEST_QS_STATE="$restart_state" \
+OMARCHY_TEST_QS_LOG="$restart_log" \
+OMARCHY_TEST_QS_ENV_LOG="$restart_env_log" \
+  /bin/bash "$restart_bin/omarchy-launch-shell" &
 restart_pid_one=$!
 printf '%s\n' "$restart_pid_one" >"$restart_state"
+sleep 0.1
 rm -f "$restart_state.locked"
 : >"$restart_log"
 : >"$ipc_log"


### PR DESCRIPTION
## Summary

- stop every matching `omarchy-launch-shell` supervisor before launching a replacement
- wait for each supervisor and its Quickshell child to exit
- remove the restart path's dependency on version-specific `quickshell kill` behavior
- cover asynchronous Quickshell shutdown and duplicate launcher replacement in the restart regression test

## Root cause

`omarchy-restart-shell` repeatedly called `quickshell kill` until no instance matched. Stock Quickshell 0.3 returns before QML teardown is complete. Its development fix waits for IPC disconnect, but disconnect is still not a process-ownership boundary.

A second stop request or replacement launch can therefore overlap teardown. On an ARM system this produced a Quickshell `SIGSEGV` during `omarchy update`. The surviving supervisor relaunched its child while the update launched another supervisor, which left two shells and two bars.

The launcher already owns the child lifecycle and waits for the child it terminates. This change uses that ownership boundary directly.

This addresses the restart race described in #7076. It does not claim to fix the separate cold QML compilation and readiness concerns in that issue.

## Validation

- focused restart suite: 7/7 passed
- `./test/all`: all 184 current test files passed
- `bin/omarchy commands --check`: 428 commands passed
- shell and Python syntax checks passed
- live ARM verification after deployment: one launcher, one Quickshell process, and no new core dump
