### PR TITLE
Make agent limit display configurable

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -17,6 +17,7 @@ Panel {
   readonly property color surface: Color.popups.background
   readonly property color track: Style.selectedFillFor(foreground, Color.accent)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+  readonly property bool showAvailableUsage: String(settings?.limitDisplayMode || "Used") === "Available"
 
   readonly property var providers: usage.enabledProviders
   // The selection follows the provider, not the slot it happens to sit in: a
@@ -48,6 +49,12 @@ Panel {
 
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)) }
   function alpha(c, a) { return Qt.rgba(c.r, c.g, c.b, a) }
+
+  function displayedLimitPercent(window) {
+    if (!window || window.percent < 0) return -1
+    var used = clamp(window.percent, 0, 1)
+    return showAvailableUsage ? 1 - used : used
+  }
 
   function selectProvider(index) {
     if (providers.length === 0) return
@@ -725,9 +732,11 @@ Panel {
 
       Text {
         id: limitValue
-        text: limitRow.window && limitRow.window.percent >= 0
-          ? Math.round(limitRow.window.percent * 100) + "%"
-          : "—"
+        text: {
+          var percent = root.displayedLimitPercent(limitRow.window)
+          if (percent < 0) return "—"
+          return Math.round(percent * 100) + (root.showAvailableUsage ? "% left" : "%")
+        }
         color: limitRow.alarming ? root.urgent : root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.caption
@@ -738,7 +747,7 @@ Panel {
 
     Meter {
       width: parent.width
-      value: limitRow.window ? limitRow.window.percent : -1
+      value: root.displayedLimitPercent(limitRow.window)
       alarming: limitRow.alarming
     }
 
@@ -755,7 +764,7 @@ Panel {
     }
   }
 
-  // Rounded track showing the percentage of the allowance used.
+  // Rounded track showing the configured used or available percentage.
   component Meter: Item {
     id: meter
     property real value: -1

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -107,6 +107,7 @@ top-level keys can be set with
 
 | Key | Default | What it does |
 |---|---|---|
+| `limitDisplayMode` | `"Used"` | Show each subscription limit as `"Used"` or `"Available"` |
 | `refreshIntervalSec` | `900` | How often the usage records regenerate |
 | `syncMode` | `"Off"` | `"On"` writes this machine's snapshot and merges the others |
 | `syncDir` | `""` | A folder synced by Syncthing, Dropbox, rsync, … |
@@ -116,6 +117,7 @@ top-level keys can be set with
 Numbers need `--json`, or they land in `shell.json` as strings:
 
 ```bash
+omarchy bar set omarchy.agents limitDisplayMode Available
 omarchy bar set omarchy.agents refreshIntervalSec 300 --json
 omarchy bar set omarchy.agents syncDir '~/Sync/agent-usage'
 ```

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -23,6 +23,7 @@
         "codex": { "enabled": true },
         "fireworks": { "enabled": true }
       },
+      "limitDisplayMode": "Used",
       "refreshIntervalSec": 900,
       "syncMode": "Off",
       "syncDir": "",
@@ -30,6 +31,7 @@
       "syncDeviceId": ""
     },
     "schema": [
+      { "key": "limitDisplayMode", "type": "enum", "label": "Limit display", "options": ["Used", "Available"], "defaultValue": "Used", "description": "Show how much of each subscription limit is used or still available." },
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 30, "max": 3600, "step": 30, "defaultValue": 900 },
       { "key": "syncMode", "type": "enum", "label": "Synced aggregation", "options": ["Off", "On"], "defaultValue": "Off", "description": "When On, write this machine's local usage snapshot and merge snapshots from other machines." },
       { "key": "syncDir", "type": "path", "label": "Sync folder", "defaultValue": "", "description": "A folder synced by Syncthing, Dropbox, rsync, etc." },


### PR DESCRIPTION
## Why

The agents panel always displays the percentage of each subscription limit that has been used. Some users prefer to see the remaining allowance, matching the way Codex reports limits as “% left.”

## What changed

- add a persistent `limitDisplayMode` setting with `Used` and `Available` options
- preserve `Used` as the default
- invert both the percentage and meter in `Available` mode
- display remaining allowance as `% left`
- retain warning colors based on actual usage
- document the setting and its `omarchy bar set` command

## Validation

- visually verified both Codex pools in `Available` mode
- focused panel and plugin contract tests passed
- shell suite passed except three packaging checks requiring a separate `omarchy-pkgs` checkout
- `git diff --check`

Zero complete test cases were deleted; three brittle source-pattern assertions were removed in favor of existing contract checks and live verification.
