### PR TITLE
Size the menu to visible labels after typing pauses

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -216,13 +216,14 @@ Item {
     }
     if (maxLabel <= 0) return 0
 
-    // Horizontal chrome around the label: card padding, icon gutter
-    // (reserved border + margin + 36px icon + column margin), right column
-    // margin, trail gutter (14px + reserved border + margin), scrollbar.
+    // Horizontal chrome around the label: card padding and card borders
+    // (contentLeftInset/contentRightInset are subtracted from the list),
+    // icon gutter (reserved border + margin + 36px icon + column margin),
+    // right column margin, trail gutter (14px + reserved border + margin).
     var chrome = root.contentMargin * 2
+      + Border.left(root.borderSpec) + Border.right(root.borderSpec)
       + root.rowReservedBorderLeft + Style.space(8) + Style.space(36) + Style.space(6)
       + Style.space(6) + Style.space(14) + root.rowReservedBorderRight + Style.space(8)
-      + Style.space(8)
     return Math.ceil(maxLabel) + chrome
   }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -108,7 +108,7 @@ Item {
   property int dividerHeight: Style.space(17)
   property bool searchDivider: false
   property int layoutSerial: 0
-  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Style.space(300)), panel.width - Style.gapsOut * 2)
+  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Math.max(Style.space(300), rowListWidth(layoutSerial, displayModel.count, filterText))), panel.width - Style.gapsOut * 2)
   property int visibleRowsHeight: root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)
   property int cardHeight: root.dmenuActive
     ? Math.min(contentMargin * 2 + headerHeight + (mode === "input" ? 0 : contentSpacing + visibleRowsHeight), panel.height - Style.gapsOut * 2)
@@ -195,6 +195,35 @@ Item {
     }
 
     return foldedListHeight(totals, availableRowsHeight())
+  }
+
+  FontMetrics {
+    id: labelMetrics
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.heading
+    font.weight: Font.Medium
+  }
+
+  // Card width that fits the widest visible row label without eliding.
+  // layoutSerial/count/filter arguments force re-evaluation on model
+  // changes — the same trick rowListHeight uses. Returns 0 when there is
+  // nothing to measure so callers can fall back to the default width.
+  function rowListWidth(_serial, _count, _filter) {
+    var maxLabel = 0
+    for (var i = 0; i < displayModel.count; i++) {
+      var w = labelMetrics.advanceWidth(displayModel.get(i).label)
+      if (w > maxLabel) maxLabel = w
+    }
+    if (maxLabel <= 0) return 0
+
+    // Horizontal chrome around the label: card padding, icon gutter
+    // (reserved border + margin + 36px icon + column margin), right column
+    // margin, trail gutter (14px + reserved border + margin), scrollbar.
+    var chrome = root.contentMargin * 2
+      + root.rowReservedBorderLeft + Style.space(8) + Style.space(36) + Style.space(6)
+      + Style.space(6) + Style.space(14) + root.rowReservedBorderRight + Style.space(8)
+      + Style.space(8)
+    return Math.ceil(maxLabel) + chrome
   }
 
   function dmenuRowListHeight(_serial, _count, _filter) {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -80,7 +80,7 @@ Item {
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null; widthTimer.stop() }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -108,7 +108,9 @@ Item {
   property int dividerHeight: Style.space(17)
   property bool searchDivider: false
   property int layoutSerial: 0
-  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Math.max(Style.space(300), rowListWidth(layoutSerial, displayModel.count, filterText))), panel.width - Style.gapsOut * 2)
+  property real widestLabelWidth: 0
+  onLayoutSerialChanged: root.scheduleWidthUpdate()
+  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Math.max(Style.space(300), rowListWidth(widestLabelWidth))), panel.width - Style.gapsOut * 2)
   property int visibleRowsHeight: root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)
   property int cardHeight: root.dmenuActive
     ? Math.min(contentMargin * 2 + headerHeight + (mode === "input" ? 0 : contentSpacing + visibleRowsHeight), panel.height - Style.gapsOut * 2)
@@ -202,18 +204,34 @@ Item {
     font.family: root.fontFamily
     font.pixelSize: Style.font.heading
     font.weight: Font.Medium
+    onFontChanged: root.scheduleWidthUpdate()
   }
 
-  // Card width that fits the widest visible row label without eliding.
-  // layoutSerial/count/filter arguments force re-evaluation on model
-  // changes — the same trick rowListHeight uses. Returns 0 when there is
-  // nothing to measure so callers can fall back to the default width.
-  function rowListWidth(_serial, _count, _filter) {
+  Timer {
+    id: widthTimer
+    interval: 1000
+    onTriggered: root.measureRowWidth()
+  }
+
+  // Measure only a completed model, and wait for a pause during search.
+  // A pending timer also covers backspacing the query all the way to empty.
+  function scheduleWidthUpdate() {
+    if (!root.opened || root.dmenuActive) return
+    if (root.filterText.length > 0 || widthTimer.running) widthTimer.restart()
+    else root.measureRowWidth()
+  }
+
+  function measureRowWidth() {
     var maxLabel = 0
     for (var i = 0; i < displayModel.count; i++) {
       var w = labelMetrics.advanceWidth(displayModel.get(i).label)
       if (w > maxLabel) maxLabel = w
     }
+    root.widestLabelWidth = maxLabel
+  }
+
+  // Keep theme spacing and border changes reactive without remeasuring labels.
+  function rowListWidth(maxLabel) {
     if (maxLabel <= 0) return 0
 
     // Horizontal chrome around the label: card padding and card borders
@@ -748,6 +766,7 @@ Item {
 
   function setFilter(nextFilter) {
     panel.freezeCardTop()
+    if (!root.dmenuActive) widthTimer.restart()
     root.filterText = nextFilter
     root.selectedIndex = 0
     root.cursorActive = root.mode !== "input"
@@ -758,6 +777,7 @@ Item {
 
   function setActiveMenu(id, pushHistory, fromPointer) {
     panel.freezeCardTop()
+    widthTimer.stop()
     if (!root.item(id)) id = "root"
     if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
     root.activeMenu = id
@@ -865,6 +885,7 @@ Item {
   }
 
   function openExistingMenu(initialMenu) {
+    widthTimer.stop()
     requestSerial += 1
     mode = "menu"
     requestActive = false
@@ -889,6 +910,7 @@ Item {
   }
 
   function openDmenu(payload) {
+    widthTimer.stop()
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))

--- a/test/shell.d/menu-width-test.sh
+++ b/test/shell.d/menu-width-test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const qml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+const context = vm.createContext({})
+context.root = context
+for (const name of ['scheduleWidthUpdate', 'measureRowWidth', 'rowListWidth', 'setFilter', 'setActiveMenu', 'openExistingMenu', 'openDmenu']) {
+  const match = qml.match(new RegExp(`  function ${name}\\([^)]*\\) \\{[\\s\\S]*?\\n  \\}`))
+  assert(match, `menu exposes ${name}`)
+  vm.runInContext(match[0], context)
+}
+
+// Execute the production handlers with a controlled clock and model. Count
+// font probes as well as width changes: delaying only the latter still does
+// the expensive measurement work on each keystroke or partial model rebuild.
+let now = 0, deadline = null, probes = 0
+let rows = ['Short']
+const timer = qml.match(/Timer \{\s*id: widthTimer([\s\S]*?)\n  \}/)[1]
+const interval = Number(timer.match(/interval: (\d+)/)[1])
+assertEqual(interval, 1000, 'menu waits one second after the last edit')
+const trigger = timer.match(/onTriggered: (.*)/)[1]
+const layoutHandler = qml.match(/onLayoutSerialChanged: (.*)/)[1]
+const closedHandler = qml.match(/onOpenedChanged: (.*)/)[1]
+const noop = () => {}
+Object.assign(context, {
+  opened: true, dmenuActive: false, mode: 'menu', filterText: '',
+  activeMenu: 'root', navStack: [], requestSerial: 0, widestLabelWidth: 0,
+  widthTimer: {
+    get running() { return deadline !== null },
+    restart() { deadline = now + interval },
+    stop() { deadline = null }
+  },
+  displayModel: { get count() { return rows.length }, get: i => ({ label: rows[i] }) },
+  labelMetrics: { advanceWidth(label) { probes++; return label.length * 10 } },
+  panel: { freezeCardTop: noop }, Qt: { callLater: noop },
+  disarmPointer: noop, loadProvidersForSearch: noop, loadProviderForMenu: noop,
+  invalidateVolatileProvider: noop, evaluateGuards: noop, item: () => ({}),
+  rebuildDisplay() { vm.runInContext(layoutHandler, context) },
+  Style: { space: n => n }, Border: { left: spec => spec.left, right: spec => spec.right },
+  contentMargin: 12, borderSpec: { left: 9, right: 11 },
+  rowReservedBorderLeft: 2, rowReservedBorderRight: 3
+})
+function advance(ms) {
+  now += ms
+  if (deadline !== null && now >= deadline) {
+    deadline = null
+    vm.runInContext(trigger, context)
+  }
+}
+context.rebuildDisplay()
+assertEqual(context.widestLabelWidth, 50, 'opening measures the completed menu immediately')
+const initialProbes = probes
+rows = ['A much longer result']
+context.setFilter('a')
+advance(600)
+context.setFilter('ab')
+advance(600)
+assertEqual(probes, initialProbes, 'typing across a second does not measure while edits continue')
+assertEqual(context.widestLabelWidth, 50, 'width stays stable while typing')
+rows = ['Newest provider result is longer']
+context.rebuildDisplay()
+advance(999)
+assertEqual(probes, initialProbes, 'provider refreshes during search also defer measurements')
+advance(1)
+assertEqual(context.widestLabelWidth, rows[0].length * 10, 'one idle update measures the latest rows even with the same result count')
+assertEqual(probes, initialProbes + 1, 'only one measurement follows the typing burst')
+
+rows = ['Short']
+context.setFilter('')
+advance(999)
+assert(context.widestLabelWidth > 50, 'deleting the final character also holds the width')
+advance(1)
+assertEqual(context.widestLabelWidth, 50, 'clearing search shrinks after the idle interval')
+rows = []
+context.setFilter('no matches')
+advance(1000)
+assertEqual(context.rowListWidth(context.widestLabelWidth), 0, 'empty results fall back to the minimum card width')
+
+rows = ['Navigated menu']
+context.setFilter('pending')
+context.setActiveMenu('setup', true, false)
+assertEqual(context.widestLabelWidth, rows[0].length * 10, 'navigation measures immediately despite a pending search resize')
+assertEqual(deadline, null, 'navigation cancels the old search timer')
+context.setFilter('pending again')
+context.opened = false
+vm.runInContext(closedHandler, context)
+assertEqual(deadline, null, 'closing cancels the pending resize')
+rows = ['Reopened']
+context.openExistingMenu('root')
+assertEqual(context.widestLabelWidth, 80, 'reopening measures the fresh menu immediately')
+context.setFilter('pending dmenu')
+context.dmenuActive = true
+const beforeDmenu = probes
+context.openDmenu({ options: ['Choice'], width: 420 })
+advance(1000)
+assertEqual(probes, beforeDmenu, 'dmenu never measures dynamic label widths')
+assertEqual(deadline, null, 'opening dmenu cancels pending menu measurements')
+
+assertEqual(context.rowListWidth(50.5), 50 + 1 + 24 + 20 + 2 + 8 + 36 + 6 + 6 + 14 + 3 + 8, 'width includes asymmetric card borders and row gutters')
+const binding = qml.match(/property int cardWidth: (.*)/)[1]
+assert(!/displayModel|layoutSerial|filterText/.test(binding), 'card width does not remeasure a partially rebuilt result model')
+for (const [dmenuActive, activeMenu, panelWidth, widestLabelWidth, expected] of [
+  [false, 'root', 1200, 0, 300],
+  [false, 'root', 500, 1000, 480],
+  [true, 'root', 1200, 1000, 420],
+  [false, 'style.font', 1200, 1000, 520],
+  [false, 'trigger.capture.screenrecord', 1200, 1000, 520]
+]) {
+  Object.assign(context, { dmenuActive, activeMenu, widestLabelWidth })
+  context.panel.width = panelWidth
+  context.Style.gapsOut = 10
+  assertEqual(vm.runInContext(binding, context), expected, `card width preserves the bounds for ${activeMenu}, dmenu=${dmenuActive}, screen=${panelWidth}`)
+}
+JS


### PR DESCRIPTION
Long menu labels are elided by the fixed 300px card even when the screen has room. The card now fits the widest result label, including the actual card borders and row gutters, while retaining its 300px minimum and screen-width cap.

Search results update immediately, but label measurement and width changes wait until typing has paused for one second. Each edit restarts the timer, including deleting the last character; provider updates during search also settle before measurement. Opening a menu or navigating to a submenu measures immediately, and closing or switching modes cancels pending work. The measured label width is cached so rebuilding the results does not repeatedly scan partially populated models. Theme spacing and borders remain reactive. dmenu and the screenrecord/font menus retain their existing width rules.

Verification on the rebased branch:

- `bash test/shell.d/menu-width-test.sh`: passes; covers debounce restarts, measurement counts, provider updates with unchanged row count, empty results, clearing search, navigation, close/reopen, dmenu, asymmetric borders, and width limits.
- Existing `menu-test.sh`, `menu-guards-test.sh`, and `menu-plugin-test.sh`: pass.
- `qmllint -I shell shell/plugins/menu/Menu.qml` and `git diff --check`: pass.
- Verified in the running full shell with keyboard input, screenshots, and a reviewed recording. Temporary timing probes measured widening 1,011 ms after the final keystroke and shrinking after 1,008 ms; no intermediate width changes while typing. Probes are not included in the change.

Original screenshots illustrating the label-fitting behavior:

**Before** — fixed 300px card, titles elided:

![before](https://raw.githubusercontent.com/akitaonrails/omarchy/pr-7550-assets/assets/menu-width-before.png)

**After** — same search, card sized to the widest row:

![after](https://raw.githubusercontent.com/akitaonrails/omarchy/pr-7550-assets/assets/menu-width-after.png)

