### PR TITLE
Measure speedtest on the interface the transfer uses

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -28,13 +28,6 @@ format_mbps() {
   }'
 }
 
-iface=$(ip route get "$probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
-
-if [[ -z $iface || ! -r /sys/class/net/$iface/statistics/rx_bytes || ! -r /sys/class/net/$iface/statistics/tx_bytes ]]; then
-  echo "No active network interface" >&2
-  exit 1
-fi
-
 if ! omarchy-cmd-present curl; then
   echo "curl is required" >&2
   exit 1
@@ -47,6 +40,32 @@ fast_urls=$(curl -fsS "$fast_api_url" 2>/dev/null | jq -r '.targets[]?.url // em
 
 if [[ -z $fast_urls ]]; then
   echo "Failed to fetch speed test endpoints" >&2
+  exit 1
+fi
+
+# The fast.com targets are frequently IPv6-only. On a machine with more than one link up, the
+# IPv4 default route can point at a different interface than the one the transfer actually
+# uses, and we would then sample the byte counters of an idle NIC. Ask curl which local
+# address it ends up using for the target, and map that back to its interface.
+iface_for_address() {
+  ip -o addr show 2>/dev/null | awk -v addr="$1" '{ split($4, parts, "/"); if (parts[1] == addr) { print $2; exit } }'
+}
+
+first_url=${fast_urls%%$'\n'*}
+local_ip=$(curl -fsS -o /dev/null -r 0-0 --max-time 10 -w '%{local_ip}' "$first_url" 2>/dev/null || true)
+
+iface=""
+if [[ -n $local_ip ]]; then
+  iface=$(iface_for_address "$local_ip")
+fi
+
+# Fall back to the default route if the target could not be probed.
+if [[ -z $iface ]]; then
+  iface=$(ip route get "$probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+fi
+
+if [[ -z $iface || ! -r /sys/class/net/$iface/statistics/rx_bytes || ! -r /sys/class/net/$iface/statistics/tx_bytes ]]; then
+  echo "No active network interface" >&2
   exit 1
 fi
 


### PR DESCRIPTION
### The problem

`omarchy-network-speedtest` reports ~0 Mbps on machines that have more than one link up.

It picks the interface to sample with an IPv4 route lookup:

```bash
iface=$(ip route get "$probe" ...)   # probe=1.1.1.1
```

But the targets that come back from the fast.com API are frequently IPv6-only
(`ipv6-...oca.nflxvideo.net`). With both wifi and ethernet connected, those two can resolve to
different links:

```
v4: 1.1.1.1 via 192.168.1.1 dev wlp8s0      <- sampled
v6: ...     via fe80::...   dev enp9s0f1    <- where the transfer actually goes
```

So the loop reads `rx_bytes`/`tx_bytes` from an idle NIC. Measured across a single 26 MB
download on my laptop: `wlp8s0` +28 KB, `enp9s0f1` +27205 KB. The panel sat at 0.0-0.8 Mbps
the whole time while the link was doing ~99 Mbps.

### The fix

Probe the actual target with a one-byte range request, ask curl for the local address it ended
up using, and map that address back to its interface. The probe costs a single request
(HTTP 206, 1 byte, ~28 ms here) and runs once, before the workers start.

If the probe fails for any reason, it falls back to the existing default-route lookup, so
single-link machines behave exactly as before.

### Testing

On the affected laptop (wifi + ethernet both up):

| | before | after |
|---|---|---|
| `down` | `0.1 0.0 0.8 0.0 0.4 ...` | `96 99 99 99 99 ...` |
| `up` | `0.0 0.1 0.0 ...` | `78 97 97 100 102 ...` |

Also verified: the fallback path still works under `set -e` (pointed `first_url` at an
unreachable host - the script degrades to the old behaviour instead of exiting), bad arguments
still exit 2, and `bash -n` is clean.
