### PR TITLE
Fix weather panel hero overlapping location at triple-digit temps

### DIFF
--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -143,6 +143,11 @@ Panel {
   readonly property string reportLocation:  configuredLocation || wttrLocation || (areaInfo && areaInfo.areaName && areaInfo.areaName[0] ? areaInfo.areaName[0].value : "")
   readonly property string reportTempNum:   current ? String(useImperial ? current.temp_F : current.temp_C) : ""
   readonly property string tempUnit:        "°" + (useImperial ? "F" : "C")
+  // Triple-digit (or negative) readings are 3+ chars and would push the hero
+  // cluster into the location/stats column on the right, which has a fixed
+  // width — step the hero icon and temperature down a size when wide.
+  // reportTempNum is always a rounded integer, so length is a stable proxy.
+  readonly property bool wideHeroTemp: reportTempNum.length > 2
   readonly property string reportFeels:     current ? formatTemp(useImperial ? current.FeelsLikeF : current.FeelsLikeC) : ""
   readonly property string reportWind:      current ? (useImperial ? (current.windspeedMiles + " mph") : (current.windspeedKmph + " km/h")) : ""
   readonly property string reportHumidity:  current ? (current.humidity + "%") : ""
@@ -538,7 +543,7 @@ Panel {
             font.family: root.bar.fontFamily
             // Decorative condition emoji; intentionally larger than the
             // Style.font.* scale's displayLarge (28).
-            font.pixelSize: 64
+            font.pixelSize: root.wideHeroTemp ? 56 : 64
           }
 
           Row {
@@ -551,8 +556,9 @@ Panel {
               color: root.bar.foreground
               font.family: root.bar.fontFamily
               // Hero temperature read-out; deliberately oversized, outside
-              // the Style.font.* scale.
-              font.pixelSize: 56
+              // the Style.font.* scale. Steps down for wide readings so the
+              // left cluster never overlaps the location/stats column.
+              font.pixelSize: root.wideHeroTemp ? 44 : 56
               font.bold: true
             }
             Text {

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -137,6 +137,17 @@ assert(
   panelSource.includes('text: root.label || "—"'),
   'weather hero and bar use the same resolved icon'
 )
+// Triple-digit (or negative) readings widen the hero cluster past the fixed
+// panel width, overlapping the location/stats column (#6991).
+assert(
+  panelSource.includes('readonly property bool wideHeroTemp: reportTempNum.length > 2'),
+  'weather flags triple-digit (or negative) hero readings as wide'
+)
+assert(
+  panelSource.includes('font.pixelSize: root.wideHeroTemp ? 56 : 64') &&
+  panelSource.includes('font.pixelSize: root.wideHeroTemp ? 44 : 56'),
+  'weather steps the hero icon and temperature down a size for wide readings'
+)
 assert(
   panelSource.includes('onReturnRequested: root.startEditingLocation()'),
   'weather focuses city input when Return is pressed'


### PR DESCRIPTION
The hero row anchors the icon+temperature cluster to the left edge and the location/stats column to the right edge of a fixed-width card with no collision guard, so a three-digit (or negative) reading widens the left cluster past the right column and the unit ends up drawn over the location label (#6991).

Step the hero icon (64 -> 56) and temperature (56 -> 44) down a size whenever the rounded reading is 3+ characters, which keeps the two sides separated for any temperature the providers can return.

Before:
<img width="968" height="370" alt="screenshot-2026-08-19_15-54-52" src="https://github.com/user-attachments/assets/66ed86a0-f38c-470a-b460-42ed04c7918c" />


After:
<img width="976" height="346" alt="screenshot-2026-08-19_16-23-18" src="https://github.com/user-attachments/assets/2bf3130d-724b-4ab7-822e-0f3da52f628d" />
