### PR TITLE
Add dynamic bar transparency mode

### DIFF
--- a/bin/omarchy-bar
+++ b/bin/omarchy-bar
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Configure the bar and its widget layout
 # omarchy:group=bar
-# omarchy:args=use <id> | reset | defaults | position <top|bottom|left|right> | transparent <true|false|toggle> | put <id> [placement] | move <id> [placement] | set <id> <key> <value> [--json] [placement]
+# omarchy:args=use <id> | reset | defaults | position <top|bottom|left|right> | transparent <true|false|dynamic|toggle> | put <id> [placement] | move <id> [placement] | set <id> <key> <value> [--json] [placement]
 # omarchy:examples=omarchy bar use local.neon-bar | omarchy bar put omarchy.keyboard-layout --after omarchy.clock | omarchy bar move omarchy.clock --section center --index 0 | omarchy bar set omarchy.clock format HH:mm
 
 set -euo pipefail
@@ -17,7 +17,8 @@ Usage: omarchy bar <command> [args...]
   reset                                Return to the built-in Omarchy bar
   defaults                             Restore the default bar and service widgets
   position <top|bottom|left|right>     Bar position
-  transparent <true|false|toggle>      Bar transparency
+  transparent <true|false|dynamic|toggle>
+                                       Bar transparency
   put <id> [placement]                 Put a widget on the bar, leaving one
                                        that is already there where it is
   move <id> [placement]                Move a widget within or between sections
@@ -208,10 +209,13 @@ cmd_transparent() {
   local transparent="${1:-}"
   [[ -n $transparent ]] || fail "transparent is required"
   (( $# == 1 )) || fail "transparent takes a single value"
-  [[ $transparent =~ ^(true|false|toggle)$ ]] || fail "transparent must be true, false, or toggle"
+  [[ $transparent =~ ^(true|false|dynamic|toggle)$ ]] || fail "transparent must be true, false, dynamic, or toggle"
   if [[ $transparent == "toggle" ]]; then
-    commit "$NORMALIZE | .bar.transparent = (.bar.transparent != true)"
+    commit "$NORMALIZE | .bar.transparent = (if .bar.transparent == true or .bar.transparent == \"dynamic\" then false else true end)"
     echo "Bar transparency toggled"
+  elif [[ $transparent == "dynamic" ]]; then
+    commit "$NORMALIZE | .bar.transparent = \"dynamic\""
+    echo "Bar transparency set to dynamic"
   else
     commit "$NORMALIZE | .bar.transparent = \$transparent" --argjson transparent "$transparent"
     echo "Bar transparency set to $transparent"

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -160,16 +160,19 @@ Rules:
 1. The active bar option is `bar.id`. Omit it or set it to `omarchy.bar` for
    the built-in bar; set it to a plugin whose manifest declares `kind: "bar"`
    to replace the full bar.
-2. Every plugin instance is one entry — `bar.layout.<section>` for
+2. Set `bar.transparent` to `false` for solid, `true` for transparent, or
+   `"dynamic"` to stay transparent on an empty or floating-only focused
+   workspace and turn solid for a visible tiled client.
+3. Every plugin instance is one entry — `bar.layout.<section>` for
    bar widgets, `plugins[]` for everything else.
-3. Settings are inline on the entry. No `config:` sub-object, no
+4. Settings are inline on the entry. No `config:` sub-object, no
    merge layers.
-4. Built-in bar widget ids are namespaced (`omarchy.clock`, `omarchy.audio`, …).
-5. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
+5. Built-in bar widget ids are namespaced (`omarchy.clock`, `omarchy.audio`, …).
+6. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
-6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
-7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
-8. `version: 1` is required.
+7. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
+8. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+9. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -160,9 +160,7 @@ Rules:
 1. The active bar option is `bar.id`. Omit it or set it to `omarchy.bar` for
    the built-in bar; set it to a plugin whose manifest declares `kind: "bar"`
    to replace the full bar.
-2. Set `bar.transparent` to `false` for solid, `true` for transparent, or
-   `"dynamic"` to stay transparent on an empty or floating-only focused
-   workspace and turn solid for a visible tiled client.
+2. Set `bar.transparent` to `false` for solid, `true` for transparent, or `"dynamic"` to stay transparent on an empty or floating-only focused workspace and turn solid for a visible tiled client.
 3. Every plugin instance is one entry — `bar.layout.<section>` for
    bar widgets, `plugins[]` for everything else.
 4. Settings are inline on the entry. No `config:` sub-object, no

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -89,10 +89,13 @@ The same things have commands, which is what you want for a [dotfiles](31-dotfil
 ```bash
 omarchy bar position bottom
 omarchy bar transparent toggle
+omarchy bar transparent dynamic
 omarchy bar move omarchy.clock --section center --index 0
 omarchy bar set omarchy.clock format "HH:mm"
 omarchy bar defaults          # back to the shipped layout
 ```
+
+Transparency can be `true` (always transparent), `false` (always solid), or `dynamic`. Dynamic transparency keeps the bar transparent while the focused workspace is empty or contains only floating windows, then makes it solid as soon as a visible tiled window appears. Double-clicking the bar or running `omarchy bar transparent toggle` exits dynamic mode and makes the bar solid.
 
 To add or remove a widget entirely, use the plugin commands. `omarchy plugin list` prints every widget the shell knows about with its id, and then:
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -256,28 +256,32 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
 1. **The active bar option is `bar.id`.** Omit it or set it to `omarchy.bar`
    to use the built-in bar. Set it to another plugin id whose manifest declares
    `kind: "bar"` to replace the full bar.
-2. **Every plugin instance is one entry.** Either in `bar.layout.<section>`
+2. **Bar transparency supports three modes.** Set `bar.transparent` to `false`
+   for solid, `true` for transparent, or `"dynamic"` to stay transparent on an
+   empty or floating-only focused workspace and turn solid for a visible tiled
+   client.
+3. **Every plugin instance is one entry.** Either in `bar.layout.<section>`
    for bar widgets, or in `plugins[]` for panels, overlays, services,
    menus, and anything else non-bar.
-3. **Settings are inline on the entry.** No `config:` sub-object, no
+4. **Settings are inline on the entry.** No `config:` sub-object, no
    separate per-plugin settings file, no merge layers. The fields on each
    entry are the values the plugin sees.
-4. **Built-in widget ids are namespaced.** Use ids such as `omarchy.clock`,
+5. **Built-in widget ids are namespaced.** Use ids such as `omarchy.clock`,
    `omarchy.audio`, and `omarchy.network`. The migration rewrites older ids
    like `Clock` and `AudioPanel` forward.
-5. **Third-party enabled ⇔ present.** A third-party plugin is enabled iff
+6. **Third-party enabled ⇔ present.** A third-party plugin is enabled iff
    its id appears somewhere in shell.json. For full bar options, that means
    `bar.id`; for bar widgets, plugin enable/disable adds/removes layout entries;
    other plugin kinds are enabled the same way. First-party non-bar plugins
    are enabled unless listed in `disabledPlugins[]`.
-6. **Multiple instances** are allowed when a manifest sets
+7. **Multiple instances** are allowed when a manifest sets
    `allowMultiple: true`. Each instance is independent — e.g. two clock
    widgets in different timezones are just two `{"id":"omarchy.clock", "timezone": ...}`
    entries with their own values.
-7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
+8. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
    even if the 150s screensaver starts first.
-8. **`version: 1` is required** at the top level. The shell will fall back
+9. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 
 ## Implementation history

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -41,6 +41,9 @@ Item {
   })
   property var layoutConfig: fallbackBarConfig.layout
   property string centerAnchor: ""
+  property string transparencyMode: "solid"
+  property bool focusedWorkspaceHasTiled: true
+  property bool clientRefreshPending: false
   property bool requestedTransparent: false
   property bool useTransparentForeground: false
   property bool transparent: false
@@ -356,7 +359,10 @@ Item {
     var config = Util.isPlainObject(barConfig) ? barConfig : fallbackBarConfig
 
     position = normalizePosition(config.position)
-    setRequestedTransparency(config.transparent === true)
+    transparencyMode = BarModel.normalizeTransparencyMode(config.transparent)
+    setRequestedTransparency(effectiveTransparency)
+    if (transparencyMode === "dynamic") automaticTransparencyRefreshTimer.restart()
+    else automaticTransparencyRefreshTimer.stop()
     centerAnchor = Util.canonicalWidgetId(config.centerAnchor || "")
 
     // layoutEntries feeds plain JS arrays to the module Repeaters, and QML
@@ -615,13 +621,14 @@ Item {
   }
 
   function toggleTransparency() {
-    var nextTransparent = !(root.requestedTransparent === true)
+    var nextTransparent = BarModel.toggledTransparencyValue(root.transparencyMode)
     if (root.shell && typeof root.shell.mutateShellConfig === "function") {
       root.shell.mutateShellConfig(function(config) {
         if (!Util.isPlainObject(config.bar)) config.bar = {}
         config.bar.transparent = nextTransparent
       })
     } else {
+      root.transparencyMode = BarModel.normalizeTransparencyMode(nextTransparent)
       root.setRequestedTransparency(nextTransparent)
     }
   }
@@ -799,6 +806,78 @@ Item {
     return "#" + hexChannel(c.r) + hexChannel(c.g) + hexChannel(c.b)
   }
 
+  readonly property bool effectiveTransparency: transparencyMode === "transparent"
+    || (transparencyMode === "dynamic" && !focusedWorkspaceHasTiled)
+  onEffectiveTransparencyChanged: setRequestedTransparency(effectiveTransparency)
+
+  function applyClientSnapshot(output) {
+    if (transparencyMode !== "dynamic") return
+
+    var workspace = Hyprland.focusedWorkspace
+    if (!workspace) {
+      focusedWorkspaceHasTiled = false
+      return
+    }
+
+    var clients = []
+    try {
+      clients = JSON.parse(String(output || "[]"))
+    } catch (e) {
+      console.warn("dynamic bar transparency: invalid hyprctl clients output:", e)
+      return
+    }
+    focusedWorkspaceHasTiled = BarModel.workspaceHasTiledClient(clients, workspace.id)
+  }
+
+  function refreshClientSnapshot() {
+    if (automaticTransparencyClientProc.running) {
+      clientRefreshPending = true
+      return
+    }
+    automaticTransparencyClientProc.running = true
+  }
+
+  Timer {
+    id: automaticTransparencyRefreshTimer
+    interval: 16
+    repeat: false
+    onTriggered: root.refreshClientSnapshot()
+  }
+
+  Process {
+    id: automaticTransparencyClientProc
+    command: ["hyprctl", "-j", "clients"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.applyClientSnapshot(text)
+    }
+    onExited: function() {
+      if (!root.clientRefreshPending) return
+      root.clientRefreshPending = false
+      if (root.transparencyMode === "dynamic") automaticTransparencyRefreshTimer.restart()
+    }
+  }
+
+  Connections {
+    target: Hyprland
+
+    function onFocusedWorkspaceChanged() {
+      if (root.transparencyMode === "dynamic") automaticTransparencyRefreshTimer.restart()
+    }
+
+    function onRawEvent(event) {
+      if (root.transparencyMode !== "dynamic") return
+
+      var name = String(event.name || "")
+      var relevant = [
+        "openwindow", "closewindow", "movewindow", "movewindowv2",
+        "workspace", "workspacev2", "focusedmon", "changefloatingmode",
+        "fullscreen"
+      ]
+      if (relevant.indexOf(name) !== -1) automaticTransparencyRefreshTimer.restart()
+    }
+  }
+
   function setRequestedTransparency(value) {
     var nextTransparent = value === true
     requestedTransparent = nextTransparent
@@ -806,10 +885,16 @@ Item {
       foregroundAnimationEnabled = false
       useTransparentForeground = false
       transparent = false
-      transparentForeground = themeForeground
       restoreForegroundAnimation()
       return
     }
+
+    // Change opacity immediately. Wallpaper sampling only refines the text
+    // color and must not delay the surface transition.
+    foregroundAnimationEnabled = false
+    useTransparentForeground = true
+    transparent = true
+    restoreForegroundAnimation()
     scheduleTransparentForegroundRefresh()
   }
 
@@ -820,10 +905,7 @@ Item {
   }
 
   function scheduleTransparentForegroundRefresh() {
-    if (!requestedTransparent) {
-      transparentForeground = themeForeground
-      return
-    }
+    if (!requestedTransparent) return
     transparentForegroundTimer.restart()
   }
 
@@ -842,7 +924,10 @@ Item {
 
   onRequestedTransparentChanged: scheduleTransparentForegroundRefresh()
   onPositionChanged: scheduleTransparentForegroundRefresh()
-  onThemeForegroundChanged: scheduleTransparentForegroundRefresh()
+  onThemeForegroundChanged: {
+    if (!requestedTransparent) transparentForeground = themeForeground
+    scheduleTransparentForegroundRefresh()
+  }
   onThemeContrastForegroundChanged: scheduleTransparentForegroundRefresh()
 
   Timer {

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -7,6 +7,30 @@ function normalizePosition(value) {
   return /^(top|bottom|left|right)$/.test(next) ? next : "top"
 }
 
+function normalizeTransparencyMode(value) {
+  if (value === true) return "transparent"
+  if (value === "dynamic") return "dynamic"
+  return "solid"
+}
+
+function toggledTransparencyValue(value) {
+  return normalizeTransparencyMode(value) === "solid"
+}
+
+function workspaceHasTiledClient(clients, workspaceId) {
+  var values = Array.isArray(clients) ? clients : []
+  var targetId = Number(workspaceId)
+  if (!isFinite(targetId)) return false
+
+  for (var i = 0; i < values.length; i++) {
+    var client = values[i]
+    if (!client || client.mapped === false || client.hidden === true || client.visible === false) continue
+    if (!client.workspace || Number(client.workspace.id) !== targetId) continue
+    if (client.floating !== true) return true
+  }
+  return false
+}
+
 function entrySettings(entry) {
   if (!isPlainObject(entry)) return {}
   var copy = {}
@@ -215,6 +239,9 @@ if (typeof module !== "undefined") {
     pickPanelSlot: pickPanelSlot,
     nearestDropTarget: nearestDropTarget,
     normalizePosition: normalizePosition,
+    normalizeTransparencyMode: normalizeTransparencyMode,
+    toggledTransparencyValue: toggledTransparencyValue,
+    workspaceHasTiledClient: workspaceHasTiledClient,
     entrySettings: entrySettings,
     entryId: entryId,
     pinTrayToInner: pinTrayToInner,

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -18,6 +18,8 @@ The bar config lives under the `bar:` key of [`~/.config/omarchy/shell.json`](..
 
 The bar is configured directly on the bar itself: drag empty bar space (or click-and-hold) to move the bar to another screen edge, double-left-click empty center-bar space to toggle transparency, and drag widgets to reorder them. The `omarchy bar position`, `omarchy bar transparent`, `omarchy bar move`, and `omarchy bar set` commands do the same from scripts. Enable or disable widgets with `omarchy plugin enable` and `omarchy plugin disable` (widget ids come from `omarchy plugin list`).
 
+`bar.transparent` accepts `false` for an always-solid bar, `true` for an always-transparent bar, or `"dynamic"`. Dynamic mode keeps the bar transparent while the focused workspace is empty or floating-only and makes it solid when the workspace contains a visible tiled window. Set it with `omarchy bar transparent dynamic`; the regular transparency toggle exits dynamic mode to solid.
+
 Example `shell.json` (bar subtree only shown):
 
 ```json

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -38,6 +38,38 @@ const shellSource = fs.readFileSync(root + '/shell/shell.qml', 'utf8')
 
 assert(/function toggleBarTransparency\(\): string \{[\s\S]*?shell\.bar\.toggleTransparency\(\)/.test(shellSource), 'shell exposes the bar transparency toggle over IPC')
 
+assertEqual(bar.normalizeTransparencyMode(false), 'solid', 'false keeps the bar solid')
+assertEqual(bar.normalizeTransparencyMode(true), 'transparent', 'true keeps the bar transparent')
+assertEqual(bar.normalizeTransparencyMode('dynamic'), 'dynamic', 'dynamic enables workspace-aware transparency')
+assertEqual(bar.normalizeTransparencyMode('unknown'), 'solid', 'unknown transparency modes fall back to solid')
+assertEqual(bar.toggledTransparencyValue(false), true, 'transparency toggle enables transparency from solid')
+assertEqual(bar.toggledTransparencyValue(true), false, 'transparency toggle disables forced transparency')
+assertEqual(bar.toggledTransparencyValue('dynamic'), false, 'transparency toggle exits dynamic mode to solid')
+
+const tiledClient = {
+  mapped: true,
+  hidden: false,
+  visible: true,
+  floating: false,
+  workspace: { id: 2 }
+}
+const floatingClient = { ...tiledClient, floating: true }
+assertEqual(bar.workspaceHasTiledClient([tiledClient], 2), true, 'dynamic transparency finds a tiled client on the workspace')
+assertEqual(bar.workspaceHasTiledClient([floatingClient], 2), false, 'dynamic transparency ignores floating clients')
+assertEqual(bar.workspaceHasTiledClient([{ ...tiledClient, hidden: true }], 2), false, 'dynamic transparency ignores hidden clients')
+assertEqual(bar.workspaceHasTiledClient([{ ...tiledClient, workspace: { id: 3 } }], 2), false, 'dynamic transparency ignores other workspaces')
+assertEqual(bar.workspaceHasTiledClient([], 2), false, 'dynamic transparency handles an empty workspace')
+assertEqual(bar.workspaceHasTiledClient(null, 2), false, 'dynamic transparency tolerates a missing client list')
+
+assert(
+  /command: \["hyprctl", "-j", "clients"\]/.test(barSource),
+  'dynamic transparency reads authoritative Hyprland client state'
+)
+assert(
+  /transparent = true[\s\S]*?scheduleTransparentForegroundRefresh\(\)/.test(barSource),
+  'transparent surfaces do not wait for wallpaper color sampling'
+)
+
 // put tolerates a placement target the bar does not carry, so the IPC call
 // must reach the registry's put rather than route back through enable.
 assert(

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -298,6 +298,19 @@ HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent toggle
 jq -e '.bar.transparent == false' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
 pass "shell config toggles bar transparency"
 
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent dynamic
+jq -e '.bar.transparent == "dynamic"' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+pass "shell config sets dynamic bar transparency"
+
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent toggle
+jq -e '.bar.transparent == false' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+pass "bar transparency toggle exits dynamic mode"
+
+if HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent sometimes 2>/dev/null; then
+  fail "bar transparency accepted an unknown mode"
+fi
+pass "bar transparency rejects unknown modes"
+
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.bluetooth enabled false --json
 grep -Fqx 'shell setBarWidget omarchy.bluetooth enabled false {}' \
   "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"


### PR DESCRIPTION
## Summary

- add `dynamic` as a third `bar.transparent` mode alongside the existing boolean values
- keep the bar transparent on empty or floating-only focused workspaces and make it solid when a visible tiled client appears
- query Hyprland client state after relevant compositor events and apply opacity immediately, without waiting for wallpaper text-color sampling
- expose the mode as `omarchy bar transparent dynamic` and document toggle behavior

Existing `true` and `false` configurations retain their current behavior. Toggling transparency while dynamic is active returns the bar to solid mode.

## Testing

- `./test/cli`
- `bash test/shell.d/bar-test.sh`
- `OMARCHY_PKGS_PATH=<omarchy-pkgs>/pkgbuilds bash test/shell.d/config-test.sh`
- `qmllint -I shell shell/plugins/bar/Bar.qml`
- `bash -n bin/omarchy-bar test/shell.d/config-test.sh test/shell.d/bar-test.sh`
- `git diff --check`

## Visual verification

![Dynamic bar transparency switching between an empty workspace and a tiled window](https://raw.githubusercontent.com/Naresh1318/omarchy/refs/heads/pr-assets/7568/dynamic-transparency.gif)

| Empty or floating-only workspace | Visible tiled client |
| --- | --- |
| ![Transparent bar on an empty workspace](https://raw.githubusercontent.com/Naresh1318/omarchy/refs/heads/pr-assets/7568/dynamic-transparent-empty.png) | ![Solid bar with a tiled client](https://raw.githubusercontent.com/Naresh1318/omarchy/refs/heads/pr-assets/7568/dynamic-solid-tiled.png) |

Live verification against this checkout confirmed both states as well as floating-only behavior. Pixel sampling measured the solid transition 33 ms after Hyprland reported the mapped client and the transparent transition 52 ms after the client disappeared.
