### PR TITLE
Spare the session-lock owner in the _syncServices teardown

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -37,6 +37,14 @@ Item {
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
 
+  // Whether this service owns the live session lock, for callers that must not
+  // destroy it. Deliberately narrower than `locked`: lockRequested is the
+  // shell's own state and sessionLock.locked is the instance-local
+  // SessionLockManager::mLock, so both are deterministic on a rebuilt service.
+  // sessionLock.secure is excluded because it resolves through the process-wide
+  // session-lock manager, which an earlier teardown can leave dangling.
+  readonly property bool sessionLockOwned: lockRequested || sessionLock.locked
+
   function realScreenCount() {
     var screens = Quickshell.screens || []
     var count = 0

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -347,6 +347,19 @@ ShellRoot {
       var stillEnabled = stillThere && pluginRegistry.isEnabled(existingId)
       if (stillService && stillEnabled) continue
       var inst = _services[existingId]
+      // unloadPluginServices() spares a keepLoaded service, but this loop
+      // destroys one the moment the registry stops listing it as installed,
+      // enabled and service-declaring -- reached from pluginsChanged, so
+      // `omarchy plugin disable omarchy.lock` gets here without a reload, as
+      // does a local lock clone whose manifest is unreadable during the write
+      // that triggered the rescan. Destroying the service that holds the live
+      // ext-session-lock abandons the compositor-side lock and drops Hyprland
+      // into its lockscreen-died failsafe, so keep it until the lock is gone.
+      // Retention is indefinite: nothing re-runs this on unlock, and the
+      // instance is collected by whichever pluginsChanged lands next.
+      // Duck-typed rather than keyed on "omarchy.lock" so a cloned lock plugin
+      // is covered too.
+      if (inst && inst.sessionLockOwned === true) continue
       if (inst && typeof inst.destroy === "function") inst.destroy()
       var next = ({})
       for (var k in _services) if (k !== existingId) next[k] = _services[k]

--- a/test/shell.d/lock-service-teardown-test.sh
+++ b/test/shell.d/lock-service-teardown-test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+const lockQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// An adjacency regex (`anchor[\s\S]*?anchor`) only proves that one occurrence
+// follows another. It cannot prove that a destructive call does not *precede*
+// the guard meant to stop it, which is the only thing that matters here: a
+// destroy hoisted above the guard leaves the guard reading as present and doing
+// nothing. Every ordering claim below is therefore made against a brace-matched
+// function body, comparing the index of the guard against the index of the
+// first destroy in that body.
+function bodyOf(src, name, label) {
+  const start = src.indexOf(`function ${name}(`)
+  if (start === -1) fail(`${label}: source defines ${name}()`)
+  const open = src.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth += 1
+    else if (src[i] === '}') {
+      depth -= 1
+      if (depth === 0) return src.slice(open + 1, i)
+    }
+  }
+  fail(`${label}: ${name}() has balanced braces`)
+}
+
+// ------------------------------------------------------------- _syncServices()
+// unloadPluginServices() spares a keepLoaded service, so a plugin hot-reload no
+// longer destroys the lock. _syncServices destroys services inline on its own,
+// without going through unloadPluginServices() and without consulting
+// keepLoaded, whenever the registry stops listing a plugin as installed,
+// enabled and service-declaring. It is reached straight from pluginsChanged, so
+// `omarchy plugin disable omarchy.lock` gets there with no reload at all.
+const sync = bodyOf(shellQml, '_syncServices', 'sync guard')
+const syncDestroy = sync.indexOf('.destroy()')
+
+// Finding the property name is not enough: `inst.sessionLockOwned !== true`
+// reads as present, sits before the destroy, and continues on exactly the
+// services this guard exists for. Compare the whole condition.
+const syncGuardMatch = sync.match(/if \((.+?)\) continue\s*\n\s*if \(inst && typeof inst\.destroy/)
+assert(syncGuardMatch, '_syncServices guards the destroy with a skip that continues')
+assertEqual(
+  syncGuardMatch[1].trim(),
+  'inst && inst.sessionLockOwned === true',
+  'the skip fires when the instance owns the session lock -- not negated, not widened'
+)
+const syncGuard = syncGuardMatch.index
+
+assert(syncDestroy !== -1, '_syncServices still destroys services for plugins that went away')
+assert(
+  syncGuard < syncDestroy,
+  'no destroy in _syncServices runs before the ownership skip',
+  `skip at ${syncGuard}, first destroy at ${syncDestroy}`
+)
+
+// Duck-typed, not keyed on the first-party plugin id, so a cloned lock plugin
+// is covered as well. Comments are stripped so the prose above the guard, which
+// names the id as an example, does not answer for the code.
+const syncCode = sync.replace(/\/\/[^\n]*/g, '')
+assert(
+  !/omarchy\.lock/.test(syncCode),
+  '_syncServices does not key the skip on the first-party lock id'
+)
+
+// ------------------------------------------------- lock service: sessionLockOwned
+// The signal the shell reads must be deterministic on a rebuilt service.
+// sessionLock.secure resolves through the process-wide session-lock manager,
+// which an earlier teardown can leave dangling, so the ownership property must
+// not depend on it -- unlike `locked`, which deliberately still does.
+const decl = lockQml.match(/readonly property bool sessionLockOwned:([^\n]*)/)
+assert(decl, 'the lock service exposes sessionLockOwned for the shell to read')
+
+const expr = decl[1].replace(/\/\/.*$/, '').replace(/\s+/g, ' ').trim()
+const operands = expr.split('||').map((s) => s.trim()).sort()
+
+// Token presence is not enough. `lockRequested && sessionLock.locked` contains
+// both names and means the opposite; a `secure` term laundered through a helper
+// property keeps the word off this line entirely. Compare the operand set.
+assertEqual(
+  JSON.stringify(operands),
+  JSON.stringify(['lockRequested', 'sessionLock.locked']),
+  'sessionLockOwned is exactly lockRequested OR sessionLock.locked -- no extra term, no conjunction'
+)
+assert(!/\bsecure\b/.test(expr), 'sessionLockOwned does not read sessionLock.secure')
+JS


### PR DESCRIPTION
Closes the teardown path that #9485 left uncovered, for #7106.

## The gap

#9485 made `unloadPluginServices()` spare a `keepLoaded` service, so a plugin hot-reload no longer destroys `omarchy.lock` while Hyprland still holds the session lock. `_syncServices()` destroys services inline on its own, without going through `unloadPluginServices()` and without consulting `keepLoaded`, whenever the registry stops listing a plugin as installed, enabled and service-declaring.

It is reached straight from `pluginsChanged`, so nothing about that path needs a reload:

```
omarchy plugin disable omarchy.lock       (while the screen is locked)
  -> PluginRegistry.setEnabled            PluginRegistry.qml:540  pluginsChanged()
  -> onPluginsChanged                     shell.qml:381           pluginReloading is false
  -> _syncServices                        shell.qml:348           stillEnabled false
  -> inst.destroy()                       shell.qml:350           on the live WlSessionLock
```

`omarchy plugin remove` reaches the same line through its own `setPluginEnabled <id> false` step (`bin/omarchy-plugin-remove:96`), which runs before it touches the directory. Its closing `rescanPlugins` (`:117`) goes the long way round — that IPC calls `reloadPlugins()`, which holds `pluginReloading`, so the destroy lands in `onScanFinished`'s `_syncServices` at `shell.qml:798` instead — and the same skip catches it there. So does a local lock clone whose `manifest.json` is unreadable at the moment the rescan reads it — `parseScanOutput` catches the bad manifest per block and drops that one plugin from the registry, and `_syncServices` then destroys its service. That is the "local lock-plugin clone" shape reported in #7106.

The outcome is the one `keepLoaded` was added to prevent: the compositor-side `ext-session-lock` is abandoned without an unlock, Hyprland shows its lockscreen-died failsafe, and the process-global lock manager is left dangling so in-process recovery cannot retake the lock.

## The change

Skip that one service in the `_syncServices` teardown for as long as it owns the lock.

The signal is a new `sessionLockOwned` on the lock service rather than the existing `locked`. `locked` carries `sessionLock.secure`, which resolves through the process-wide session-lock manager; an earlier teardown can leave it dangling, so a guard reading it would suppress every teardown for the life of a poisoned process while protecting nothing. `lockRequested` is the shell's own state and `sessionLock.locked` is the instance-local `SessionLockManager::mLock`, both deterministic on a rebuilt service.

The skip is duck-typed rather than keyed on the `omarchy.lock` id, so a cloned lock plugin gets the same protection.

## What this does not do

Retention is indefinite. Nothing re-runs `_syncServices` on unlock, so a lock service that was disabled or removed mid-lock stays mounted — still in `_services`, still answering the `lock` IPC target — until whichever `pluginsChanged` lands next. The comment in the code says so. Wiring unlock to a re-sync is a separate change and this one does not need it: a mounted service the user asked to disable is the cheaper end of the trade.

It is also not a fix for the underlying defect. That is quickshell-mirror/quickshell#962 — `~QSWaylandSessionLock()` releases the Wayland object without clearing the process-global `QSWaylandSessionLockManager::active`, so the pointer dangles for the life of the process. This keeps Omarchy from reaching it.

## Testing

`test/shell.d/lock-service-teardown-test.sh`, 8 assertions. They assert against a brace-matched function body and compare whole conditions and operand sets, because token-presence matching cannot tell a guard that works from one that reads as present and does nothing. Each of these breakages makes the file fail:

| Tampering | Caught by |
|---|---|
| the skip deleted | guard match |
| the skip negated (`!== true`) | whole-condition comparison |
| the skip widened (`!== false`) | whole-condition comparison |
| `inst.destroy()` hoisted above the skip | index comparison in the brace-matched body |
| `inst.destroy()` removed entirely | the "still destroys" assertion |
| `sessionLockOwned` changed from OR to AND | operand-set comparison |
| `sessionLock.secure` added to `sessionLockOwned` | operand-set comparison |
| `sessionLock.secure` laundered in through a helper property | operand-set comparison |

Also green on this branch: `./test/cli` at 116, and `plugins`, `plugin-add`, `plugin-clone`, `plugin-enable`, `plugin-registry-contract`, `lock-stranded-recovery`, `system-lock`, `sleep-lock`, `menu-plugin`, `bin-style`. `runtime-smoke`'s `keepLoaded service instance survives plugin rescan` still passes. `qmllint` clean on both changed files.

Four files in `./test/shell` fail on this machine — `config`, `unowned-system-paths` and `snapper` want a local `omarchy-pkgs` checkout, and `runtime-smoke` fails one screen-count assertion against a live desktop. All four fail identically on `quattro` with this branch stashed, so none of them are this change.

Not verified against a live locked session: this machine has no disposable VM, and reproducing the trigger against the running desktop is the failure this PR is about.

## History

This PR previously carried a second mechanism — deferring the whole reload until unlock, with a slow poll during the lock, plus a refusal in `omarchy plugin add` and `omarchy plugin clone` for the window where discovery was deferred. #9485 landing made the deferral redundant for the reload path it protected, and the CLI refusal existed only to cover the discovery gap the deferral opened, so both are gone. What is left is the part the merge does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhPK6AtHo1fHNQBBNfKkpk
