### PR TITLE
Fix per-monitor scale not persisting with dedicated output blocks

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -89,14 +89,27 @@ set_scale() {
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
+  [[ -f $monitor_lua ]] || return 0
+
+  # Prefer updating a dedicated block for this output (e.g. a user-added
+  # `hl.monitor({ output = "DP-3", ... })` line) so each monitor keeps its
+  # own scale independently, instead of falling through to the shared
+  # catch-all default below and clobbering every other monitor's scale.
+  if grep -Eq "^hl\.monitor\(\{ output = \"${active_monitor}\"," "$monitor_lua"; then
+    sed -i -E \
+      "s|^(hl\.monitor\(\{ output = \"${active_monitor}\".*scale = )[^}]+(\}\))|\\1${new_scale} \\2|" \
+      "$monitor_lua"
+    return 0
+  fi
+
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.
-  if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
+  if grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
     sed -i -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
       "$monitor_lua"
-  elif [[ -f $monitor_lua ]] && grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
+  elif grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
     sed -i -E \
       -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
       -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \


### PR DESCRIPTION
## Summary
- `omarchy-hyprland-monitor-scaling` already applies the live scale change to the correct (focused) monitor, but the step that *saves* it to `monitors.lua` only recognized two shapes: the shared `omarchy_monitor_scale` variable, or the generic wildcard `output = ""` block.
- Once a user gives each display its own dedicated block (e.g. `hl.monitor({ output = "DP-3", ... })`), which is exactly what the shipped template's commented-out example suggests doing, neither branch matches. The script then falls back to rewriting the shared `omarchy_monitor_scale` variable — silently changing the scale of every other monitor still wired to it.
- Concretely: with two monitors each given their own named block, using the scale widget/CLI on one monitor would overwrite the other monitor's persisted scale on next reload/reboot.

## Fix
Add a persistence branch that, when a dedicated `hl.monitor({ output = "<name>", ... })` block already exists for the focused monitor, updates just that block's `scale` field in place — so each display's scale is saved independently. Falls back to the existing two behaviors unchanged when no dedicated block exists yet.

## Test plan
- [x] `bash -n` syntax check passes
- [x] Manually reproduced on a two-monitor (4K + 1080p) setup with dedicated `hl.monitor` blocks for each output:
  - Before fix: changing scale on monitor A also silently changed monitor B's persisted scale in `monitors.lua`.
  - After fix: changing scale on monitor A only updates monitor A's block; monitor B's block and live scale are untouched.
  - Verified both directions (A→B and B→A) and confirmed with `hyprctl monitors` that live scales matched the persisted file after `hyprctl reload`.
- [x] Confirmed the existing generic catch-all persistence paths (shared variable, wildcard block) are unchanged for users who haven't customized `monitors.lua`.