### PR TITLE
Stop the Broadcom Wi-Fi quirk breaking Apple Silicon Macs

### DIFF
--- a/install/hardware/apple/fix-brcmfmac-supplicant.sh
+++ b/install/hardware/apple/fix-brcmfmac-supplicant.sh
@@ -18,11 +18,22 @@
 # machines including the T2-less iMac19,1 and iMac19,2, and BCM4377/4378/4387
 # from the T2 era on. The BCM4360 in 2013-2015 Macs is deliberately absent: it
 # runs the out-of-tree wl driver, which never reads a brcmfmac option.
+#
+# Intel Macs only, hence the architecture gate. Two of the IDs below are Apple
+# Silicon parts as well, BCM4378 (4425) and BCM4387 (4433), and there the
+# offload is the half that works: disable FWSUP and FWAUTH on a BCM4387 and it
+# never gets past authentication, then the firmware wedges in
+# brcmf_msgbuf_query_dcmd timeouts (#7439).
+#
+# Testing the architecture rather than pruning those two IDs keeps this list
+# brcmfmac's own, so the next ID copied out of brcm_hw_ids.h cannot bring the
+# breakage back.
 sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
 
-if lspci -nn | grep "106b:180[12]" >/dev/null ||
-  { [[ $sys_vendor == Apple* ]] &&
-    lspci -nn | grep -E "14e4:(43ba|43bb|43bc|43a3|43dc|4464|4488|4425|4433)" >/dev/null; }; then
+if [[ $(uname -m) == "x86_64" ]] &&
+  { lspci -nn | grep "106b:180[12]" >/dev/null ||
+    { [[ $sys_vendor == Apple* ]] &&
+      lspci -nn | grep -E "14e4:(43ba|43bb|43bc|43a3|43dc|4464|4488|4425|4433)" >/dev/null; }; }; then
   echo "Detected a Mac with Broadcom Wi-Fi; running the WPA handshake in software"
 
   mkdir -p /etc/modprobe.d

--- a/migrations/1786391100.sh
+++ b/migrations/1786391100.sh
@@ -8,6 +8,12 @@ echo "Run the WPA handshake in software on Macs with Broadcom Wi-Fi"
 dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
 conf="${OMARCHY_BRCMFMAC_CONF:-/etc/modprobe.d/brcmfmac.conf}"
 
+# Intel Macs only. Apple Silicon Macs report the same vendor and carry two of
+# the same PCI IDs, and there this option leaves the machine with no Wi-Fi at
+# all (#7439). migrations/1787163407.sh takes it back off the machines this one
+# already reached.
+[[ $(uname -m) == "x86_64" ]] || exit 0
+
 sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
 
 if ! lspci -nn | grep "106b:180[12]" >/dev/null &&

--- a/migrations/1787163407.sh
+++ b/migrations/1787163407.sh
@@ -8,7 +8,7 @@ echo "Stop disabling the Broadcom Wi-Fi offload on Apple Silicon Macs"
 # including any that ran migrations/1786391100.sh.
 conf="${OMARCHY_BRCMFMAC_CONF:-/etc/modprobe.d/brcmfmac.conf}"
 
-[[ $(uname -m) == "x86_64" ]] && exit 0
+[[ $(uname -m) == "aarch64" ]] || exit 0
 [[ -f $conf ]] || exit 0
 
 # Only the two parts that gate could have matched. brcmfmac drives plenty of

--- a/migrations/1787163407.sh
+++ b/migrations/1787163407.sh
@@ -1,0 +1,59 @@
+echo "Stop disabling the Broadcom Wi-Fi offload on Apple Silicon Macs"
+
+# The gate in install/hardware/apple/fix-brcmfmac-supplicant.sh matched an Apple
+# machine carrying a brcmfmac PCI ID, and two of those IDs are Apple Silicon
+# parts: BCM4378 (14e4:4425) and BCM4387 (14e4:4433). See that leaf for what the
+# option does and why those two cannot have it (#7439). Intel Macs keep the
+# quirk. This takes it back off the Apple Silicon machines the gate reached,
+# including any that ran migrations/1786391100.sh.
+conf="${OMARCHY_BRCMFMAC_CONF:-/etc/modprobe.d/brcmfmac.conf}"
+
+[[ $(uname -m) == "x86_64" ]] && exit 0
+[[ -f $conf ]] || exit 0
+
+# Only the two parts that gate could have matched. brcmfmac drives plenty of
+# other hardware, and a config Omarchy never wrote is not this migration's to
+# remove. grep -q would close the pipe on lspci and pipefail would read that
+# SIGPIPE as "no such hardware" (#6608), so let lspci finish writing.
+lspci -nn | grep -E "14e4:(4425|4433)" >/dev/null || exit 0
+
+# Read through sudo so a root-only file fails the migration loudly and gets
+# retried, rather than reading as empty and burning the once-per-user marker.
+content="$(sudo cat "$conf")"
+
+# Byte for byte what the leaf wrote, and what migrations/1786391100.sh appended
+# after a blank line. Matching the whole block is the ownership test: a line
+# the user merged other options onto, a commented-out copy, or any hand-written
+# variant no longer matches, and a file like that is not this migration's to
+# edit. Those keep the option and its owner removes it by hand.
+block="# Broadcom's firmware supplicant and authenticator fail the WPA four-way
+# handshake on Apple hardware, which surfaces as a rejected password. Disable
+# both so wpa_supplicant performs the handshake instead.
+options brcmfmac feature_disable=0x82000"
+
+[[ $content == "$block" || $content == *$'\n'"$block" ]] || exit 0
+
+# Flag the reboot before touching the file: interrupted here, the worst case is
+# a spare reboot prompt rather than an edited config nothing asks to apply.
+# modprobe only reads this when brcmfmac next loads, and reloading it now would
+# drop the Wi-Fi this update arrived over. An affected machine may also carry
+# its own override setting feature_disable=0, which is the driver default and
+# redundant once this lands, but removing that file is its owner's call.
+omarchy-state set reboot-required
+
+rest=${content%"$block"}
+while [[ $rest == *$'\n' ]]; do rest=${rest%$'\n'}; done
+
+if [[ -z $rest ]]; then
+  # The file held nothing but Omarchy's block. A symlinked config is emptied
+  # through the link rather than removed, so the link its owner set up stays.
+  if [[ -L $conf ]]; then
+    : | sudo tee "$conf" >/dev/null
+  else
+    sudo rm -f "$conf"
+  fi
+else
+  # Anything the user kept above the appended block survives. tee writes
+  # through a symlink where sed -i would replace it with a regular file.
+  printf '%s\n' "$rest" | sudo tee "$conf" >/dev/null
+fi

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -320,3 +320,13 @@ write_quirk_conf
 run_cleanup 4425
 [[ ! -e $conf ]] || fail "the cleanup covers BCM4378 too" "$(cat "$conf")"
 pass "the cleanup covers BCM4378 too"
+
+# Naming the architecture the repair is for keeps every other one out, rather
+# than treating everything that is not an Intel Mac as an Apple Silicon one.
+rm -rf "$test_tmp/etc"
+write_quirk_conf
+run_cleanup 4433 riscv64
+grep -qx 'options brcmfmac feature_disable=0x82000' "$conf" ||
+  fail "an unrelated architecture is left alone" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the cleanup escalates nothing on an unrelated architecture" "$(cat "$calls")"
+pass "the cleanup leaves unrelated architectures alone"

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -8,6 +8,7 @@ leaf="$ROOT/install/hardware/apple/fix-brcmfmac-supplicant.sh"
 fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
 all="$ROOT/install/hardware/all.sh"
 migration="$ROOT/migrations/1786391100.sh"
+cleanup="$ROOT/migrations/1787163407.sh"
 
 grep -q 'apple/fix-brcmfmac-supplicant.sh' "$all" ||
   fail "the brcmfmac quirk runs during hardware setup"
@@ -205,3 +206,117 @@ run_migration "Apple Inc." 4433 0 aarch64
 [[ ! -e $conf ]] || fail "the migration skips an Apple Silicon Mac" "$(cat "$conf")"
 [[ ! -s $calls ]] || fail "the migration escalates nothing on an Apple Silicon Mac" "$(cat "$calls")"
 pass "the migration skips an Apple Silicon Mac"
+
+# An Apple Silicon Mac that already ran either of those is carrying the option
+# that breaks its Wi-Fi, so a second migration takes it off.
+run_cleanup() {
+  local wifi_id="${1:-}" arch="${2:-aarch64}"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" T2_HARDWARE=0 ARCH="$arch" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_BRCMFMAC_CONF="$conf" \
+    bash -euo pipefail "$cleanup" >/dev/null
+}
+
+# Byte for byte what the leaf writes, which is also the ownership test the
+# cleanup applies: only content ending in exactly this block is Omarchy's.
+write_quirk_conf() {
+  mkdir -p "$(dirname "$conf")"
+  cat >"$conf" <<'EOF'
+# Broadcom's firmware supplicant and authenticator fail the WPA four-way
+# handshake on Apple hardware, which surfaces as a rejected password. Disable
+# both so wpa_supplicant performs the handshake instead.
+options brcmfmac feature_disable=0x82000
+EOF
+}
+
+rm -rf "$test_tmp/etc"
+write_quirk_conf
+run_cleanup 4433
+[[ ! -e $conf ]] || fail "the cleanup retires a config that held only the quirk" "$(cat "$conf")"
+pass "the cleanup retires a config that held only the quirk"
+
+# The reboot request has to land before the edit: interrupted between the two,
+# a spare reboot prompt beats an edited config nothing asks to apply.
+state_line=$(grep -Fn $'omarchy-state\tset\treboot-required' "$calls" | cut -d: -f1 | head -1 || true)
+edit_line=$(grep -En $'sudo\t(rm|tee)' "$calls" | cut -d: -f1 | head -1 || true)
+[[ -n $state_line && -n $edit_line ]] ||
+  fail "the cleanup asks for the reboot that applies it" "$(cat "$calls")"
+(( state_line < edit_line )) ||
+  fail "the reboot request lands before the file is touched" "$(cat "$calls")"
+pass "the reboot request lands before the file is touched"
+
+run_cleanup 4433
+[[ ! -s $calls ]] || fail "a machine already cleaned up is left untouched" "$(cat "$calls")"
+pass "the cleanup is idempotent"
+
+# migrations/1786391100.sh appended the block after a blank line, below whatever
+# the user already kept there. That part survives, the block does not.
+write_quirk_conf
+mv "$conf" "$conf.block"
+printf 'options brcmfmac roamoff=1\n' >"$conf"
+printf '\n' >>"$conf"
+cat "$conf.block" >>"$conf"
+rm -f "$conf.block"
+run_cleanup 4433
+grep -qx 'options brcmfmac roamoff=1' "$conf" ||
+  fail "the cleanup keeps what the user had above the appended block" "$(cat "$conf")"
+! grep -q 'feature_disable=0x82000' "$conf" ||
+  fail "the cleanup removes the appended block" "$(cat "$conf")"
+! grep -q '^# Broadcom' "$conf" ||
+  fail "the cleanup takes its own comments with the block" "$(cat "$conf")"
+pass "the cleanup strips the appended block and keeps the rest"
+
+# A line the user merged another option onto is no longer the line Omarchy
+# wrote, and deleting it would take roamoff=1 with it. Not ours to edit.
+printf 'options brcmfmac feature_disable=0x82000 roamoff=1\n' >"$conf"
+run_cleanup 4433
+grep -qx 'options brcmfmac feature_disable=0x82000 roamoff=1' "$conf" ||
+  fail "a merged options line is left alone" "$(cat "$conf")"
+pass "a merged options line is left alone"
+
+# Same for a hand-written file that happens to set the same option: without
+# Omarchy's comment block above it, nothing proves Omarchy wrote it.
+printf '# my notes\noptions brcmfmac feature_disable=0x82000\n' >"$conf"
+run_cleanup 4433
+grep -qx '# my notes' "$conf" ||
+  fail "a hand-written config is left alone" "$(cat "$conf")"
+pass "a hand-written config is left alone"
+
+# A symlinked config keeps its link: tee writes through it where sed -i would
+# have replaced the link with a regular file and left the target still broken.
+rm -rf "$test_tmp/etc"
+mkdir -p "$test_tmp/etc/modprobe.d" "$test_tmp/real"
+write_quirk_conf
+mv "$conf" "$test_tmp/real/brcmfmac.conf"
+ln -s "$test_tmp/real/brcmfmac.conf" "$conf"
+run_cleanup 4433
+[[ -L $conf ]] || fail "a symlinked config keeps its link"
+! grep -q 'feature_disable=0x82000' "$test_tmp/real/brcmfmac.conf" ||
+  fail "the cleanup empties a symlinked config through the link" "$(cat "$test_tmp/real/brcmfmac.conf")"
+pass "the cleanup writes through a symlinked config"
+
+# The Intel Macs the quirk was written for still need it.
+rm -rf "$test_tmp/etc"
+write_quirk_conf
+run_cleanup 4488 x86_64
+grep -qx 'options brcmfmac feature_disable=0x82000' "$conf" ||
+  fail "an Intel Mac keeps the quirk" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the cleanup escalates nothing on an Intel Mac" "$(cat "$calls")"
+pass "the cleanup leaves Intel Macs alone"
+
+# brcmfmac drives plenty of hardware Omarchy never wrote this option on, and a
+# hand-written config there is not this migration's to remove.
+rm -rf "$test_tmp/etc"
+write_quirk_conf
+run_cleanup ""
+grep -qx 'options brcmfmac feature_disable=0x82000' "$conf" ||
+  fail "a config on other brcmfmac hardware is left alone" "$(cat "$conf")"
+pass "the cleanup only touches the parts the gate matched"
+
+# BCM4378 sits behind the same gate as BCM4387.
+rm -rf "$test_tmp/etc"
+write_quirk_conf
+run_cleanup 4425
+[[ ! -e $conf ]] || fail "the cleanup covers BCM4378 too" "$(cat "$conf")"
+pass "the cleanup covers BCM4378 too"

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -43,6 +43,18 @@ for _ in {1..4096}; do
 done
 SH
 
+# The quirk is for Intel Macs, so every case has to say which architecture it
+# runs on rather than inherit whichever machine the suite is running on.
+cat >"$stub_bin/uname" <<'SH'
+#!/bin/bash
+
+if [[ ${1:-} == "-m" ]]; then
+  echo "${ARCH:-x86_64}"
+else
+  exec /usr/bin/uname "$@"
+fi
+SH
+
 cat >"$stub_bin/sudo" <<'SH'
 #!/bin/bash
 
@@ -67,7 +79,7 @@ chmod +x "$stub_bin"/*
 # running with a fake root on PATH-independent state. pipefail is on, so a
 # grep -q gate would go silent here the way #6608 did.
 run_leaf() {
-  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}"
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" arch="${4:-x86_64}"
   rm -rf "$test_tmp/etc"
   mkdir -p "$test_tmp/etc"
   printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
@@ -78,7 +90,7 @@ run_leaf() {
       -e "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
       "$leaf" >"$script"
 
-  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" \
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" ARCH="$arch" PATH="$stub_bin:$PATH" \
     bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
 }
 
@@ -89,13 +101,24 @@ grep -q 'feature_disable=0x82000' "$conf" 2>/dev/null ||
   fail "a T2 Mac still gets the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
 pass "a T2 Mac still gets the quirk"
 
-# Every Broadcom part brcmfmac drives, on a Mac with no T2 to detect: BCM43602
-# and its single-band variants, BCM4350, BCM4355, BCM4364, BCM4378, BCM4387.
+# Every Broadcom part brcmfmac drives, on an Intel Mac with no T2 to detect:
+# BCM43602 and its single-band variants, BCM4350, BCM4355, BCM4364, BCM4378,
+# BCM4387.
 for wifi_id in 43ba 43bb 43bc 43a3 43dc 4464 4425 4433; do
   run_leaf "Apple Inc." "$wifi_id" 0 >/dev/null
   [[ -f $conf ]] || fail "a Mac without a T2 gets the quirk" "14e4:$wifi_id"
 done
 pass "every brcmfmac part on a Mac without a T2 gets the quirk"
+
+# BCM4378 and BCM4387 are Apple Silicon parts too, and there the offload is the
+# half that works: with it disabled a BCM4387 cannot associate at all (#7439).
+# Same vendor string and the same PCI IDs, so only the architecture tells them
+# apart.
+for wifi_id in 4425 4433; do
+  run_leaf "Apple Inc." "$wifi_id" 0 aarch64 >/dev/null
+  [[ ! -f $conf ]] || fail "an Apple Silicon Mac is left alone" "14e4:$wifi_id"
+done
+pass "an Apple Silicon Mac is left alone"
 
 # Older Macs report the vendor differently.
 run_leaf "Apple Computer, Inc." 43ba 0 >/dev/null

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -143,11 +143,11 @@ pass "a Mac with no wireless device is left alone"
 # Installs that predate the quirk never ran the leaf, so the migration has to
 # reach them. It runs as the user under pipefail, the context #6608 was about.
 run_migration() {
-  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}"
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" arch="${4:-x86_64}"
   printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
   : >"$calls"
 
-  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" ARCH="$arch" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
     OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
     OMARCHY_BRCMFMAC_CONF="$conf" \
     bash -euo pipefail "$migration" >/dev/null
@@ -199,3 +199,9 @@ run_migration "Apple Inc." 43a0 0
 [[ ! -e $conf ]] || fail "the migration skips a Mac brcmfmac does not drive" "$(cat "$conf")"
 [[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected Macs" "$(cat "$calls")"
 pass "the migration skips hardware brcmfmac does not drive"
+
+rm -rf "$test_tmp/etc"
+run_migration "Apple Inc." 4433 0 aarch64
+[[ ! -e $conf ]] || fail "the migration skips an Apple Silicon Mac" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on an Apple Silicon Mac" "$(cat "$calls")"
+pass "the migration skips an Apple Silicon Mac"


### PR DESCRIPTION
`install/hardware/apple/fix-brcmfmac-supplicant.sh` writes `options brcmfmac feature_disable=0x82000` for any Apple machine whose Wi-Fi PCI ID appears in the list taken from `brcm_hw_ids.h`. Two of those nine IDs are Apple Silicon parts: `4425` (BCM4378) and `4433` (BCM4387).

On a BCM4387 the option does the reverse of its job. The machine cannot associate with a WPA2/WPA3 transition-mode AP at all. wpa_supplicant reports `FT: Invalid key management type (2)`, authentication times out, and the firmware then wedges in `brcmf_msgbuf_query_dcmd` timeouts until the driver is reloaded. Without the option the same machine joins the same AP normally.

#6652 named this risk when it derived the list: "The chip-ID list is derived, not tested." Asahi reports `Apple Inc.` through DMI like any other Mac, so both halves of the gate matched.

## What changes

The leaf names `x86_64` rather than pruning the two IDs. That keeps the list brcmfmac's own, so the next ID copied out of `brcm_hw_ids.h` cannot bring this back. `BRCM_PCIE_4388_DEVICE_ID` is already sitting in that header.

`migrations/1786391100.sh` repeats the same gate, so it gets the same guard.

`migrations/1787163407.sh` takes the option off machines that already have it, which neither guard can help. Ownership is the comment-plus-option block both writers produce, matched byte for byte, so a merged options line or a hand-edited config is left alone. The rewrite goes through `tee`, which writes through a symlinked config where `sed -i` would replace the link. The reboot request lands before the edit. It names `aarch64`, so no other architecture is in scope.

## Verification

`test/shell.d/brcmfmac-supplicant-test.sh` grew to 26 assertions, with `uname` stubbed per case alongside the existing `lspci` and `sudo` stubs. Reverting either guard fails the suite. `./test/shell` shows no new failures.

Reproduced on a MacBookPro18,2 (M1 Max, `14e4:4433`, Asahi, `linux-asahi 7.1.6`) against a UniFi mesh in WPA2/WPA3 transition mode, under NetworkManager, iwd and a standalone wpa_supplicant.

BCM4378 is untested: I have no M1 to check it on. It sits behind the guard because shipping an untested flag on untested hardware is the thing worth avoiding. Say the word and I will narrow it to `4433` alone.

Fixes #7439
