### PR TITLE
Clamp idle timeouts to the int32 millisecond timer ceiling

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,7 +1,16 @@
+// Timer.interval and IdleMonitor.timeout are signed 32-bit millisecond
+// properties. A timeout past this ceiling wraps to a negative interval, which
+// Qt clamps to 1ms and re-arms for the whole idle cycle, flooding the instance
+// log. Clamp here rather than fall back to the default: someone writing a huge
+// number means "as good as never", and a silent drop to 5 minutes locks them
+// out of their session. Every derived delay is at most the timeout it came
+// from, so this one ceiling keeps the delay timers in range too.
+var MAX_TIMEOUT_SECONDS = Math.floor(2147483647 / 1000)
+
 function secondsFromConfig(value, fallback) {
   var n = Number(value)
   if (!isFinite(n) || n < 0) return fallback
-  return Math.floor(n)
+  return Math.min(Math.floor(n), MAX_TIMEOUT_SECONDS)
 }
 
 function eventParts(event, count) {
@@ -45,6 +54,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    MAX_TIMEOUT_SECONDS: MAX_TIMEOUT_SECONDS,
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,10 +1,7 @@
-// Timer.interval and IdleMonitor.timeout are signed 32-bit millisecond
-// properties. A timeout past this ceiling wraps to a negative interval, which
-// Qt clamps to 1ms and re-arms for the whole idle cycle, flooding the instance
-// log. Clamp here rather than fall back to the default: someone writing a huge
-// number means "as good as never", and a silent drop to 5 minutes locks them
-// out of their session. Every derived delay is at most the timeout it came
-// from, so this one ceiling keeps the delay timers in range too.
+// Timer.interval is int32 milliseconds, and a larger timeout wraps negative:
+// Qt then re-arms it at 1ms for the whole idle cycle. Clamp instead of falling
+// back, since a huge number means "never" and the 5 minute default would lock
+// the user out. Delays never exceed their timeout, so one ceiling covers both.
 var MAX_TIMEOUT_SECONDS = Math.floor(2147483647 / 1000)
 
 function secondsFromConfig(value, fallback) {

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -10,6 +10,20 @@ const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+assertEqual(
+  idle.secondsFromConfig('999999999', 10),
+  idle.MAX_TIMEOUT_SECONDS,
+  'idle clamps a timeout whose milliseconds overflow the int32 timer'
+)
+assertEqual(
+  idle.secondsFromConfig(idle.MAX_TIMEOUT_SECONDS, 10),
+  idle.MAX_TIMEOUT_SECONDS,
+  'idle keeps the largest timeout that still fits the int32 timer'
+)
+assert(
+  idle.MAX_TIMEOUT_SECONDS * 1000 <= 2147483647,
+  'idle timeout ceiling stays inside a signed 32-bit millisecond interval'
+)
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(
@@ -52,3 +66,15 @@ if rg -q 'omarchy-shell' "$ROOT/bin/omarchy-toggle-idle"; then
 fi
 
 pass "Stay Awake toggle persists state without reentrant shell IPC"
+
+# The int32 ceiling is enforced once, inside secondsFromConfig. Reading a
+# timeout straight off idleConfig would walk around it and bring the 1ms timer
+# storm back, so keep both timeouts wired through the model.
+idle_service="$ROOT/shell/plugins/services/idle/Service.qml"
+
+for timeout in screensaver lock; do
+  rg -q "readonly property int ${timeout}TimeoutSeconds: secondsFromConfig\(idleConfig\.${timeout}," "$idle_service" ||
+    fail "idle ${timeout} timeout is clamped through secondsFromConfig"
+done
+
+pass "idle timeouts reach the timers through the clamping model"


### PR DESCRIPTION
Addresses #7506.

`idle.lock` values past ~24.8 days overflow the int32 millisecond `Timer.interval`, wrapping negative so Qt clamps to 1ms and re-arms for the whole idle cycle. This clamps both idle timeouts to `Math.floor(2147483647 / 1000)` seconds inside `secondsFromConfig`, enforcing the ceiling once at the config boundary — every derived delay is at most the timeout it came from, so the delay timers stay in range without separate handling. I clamped rather than falling back to the default because someone typing `999999999` means "as good as never", and silently dropping to 5 minutes would lock them out instead.

With the reported config the lock delay goes from `999999849 s → -727530968 ms` to `2147333 s → 2147333000 ms`, and `omarchy-shell idle status` reports the effective clamped value so the change stays visible. I also checked this in Qt 6.11.1 with an offscreen harness importing the real `IdleModel.js`: on `quattro` the resulting `Timer.interval` is negative, and with this change it lands in range. `test/shell.d/idle-test.sh` passes, with three new assertions on the ceiling and one guarding that both timeouts still reach the timers through `secondsFromConfig`.

Happy to adjust. -MB
