### PR TITLE
Keep scratchpad separate from Quake console

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -26,8 +26,8 @@ end
 
 o.bind("SUPER + S", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
 o.bind("SUPER + ALT + S", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
-o.bind("SUPER + grave", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
-o.bind("SUPER + SHIFT + grave", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
+o.bind("SUPER + grave", "Toggle Quake console", hl.dsp.workspace.toggle_special("qconsole"))
+o.bind("SUPER + SHIFT + grave", "Move window to Quake console", hl.dsp.window.move({ workspace = "special:qconsole", follow = false }))
 
 o.bind("SUPER + TAB", "Next workspace", hl.dsp.focus({ workspace = "e+1" }))
 o.bind("SUPER + SHIFT + TAB", "Previous workspace", hl.dsp.focus({ workspace = "e-1" }))

--- a/default/hypr/qconsole.lua
+++ b/default/hypr/qconsole.lua
@@ -12,7 +12,7 @@ local share = 0.5
 -- Omarchy ships without a default agent, and omarchy-agent exits without
 -- opening anything when none is set, so until one is picked this just opens an
 -- empty console.
-local seed = "[workspace special:scratchpad silent] omarchy-agent"
+local seed = "[workspace special:qconsole silent] omarchy-agent"
 
 -- Dimming only applies while a special workspace is open, so the console gets
 -- its separation from the workspace underneath without costing anything the
@@ -36,7 +36,7 @@ local function cover(bottom)
   covering = bottom
 
   hl.workspace_rule({
-    workspace = "special:scratchpad",
+    workspace = "special:qconsole",
     gaps_in = 0,
     gaps_out = { top = 0, right = 0, bottom = bottom, left = 0 },
 

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -60,11 +60,17 @@ You can pop a window out of its workspace allocation with `Super + O`. That'll p
 
  ![navigation-popped-window](images/navigation-popped-window.webp)
 
-### Scratchpad workspaces
+### Scratchpad workspace
 
-Finally, there are two special scratchpad workspaces that open over whatever workspace you're currently on. `Super + S` toggles a full-size scratchpad styled like a regular workspace, and `Super + Alt + S` places a window there.
+There's a special full-size scratchpad workspace that overlays whatever workspace you're currently on. You access what's on it using `Super + S`, and you place windows there using `Super + Alt + S`.
 
-`Super + Grave` drops down a half-height Quake console seeded with your default agent, and `Super + Shift + Grave` places a window there. To move a window off either scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
+It works well for controls or a terminal you want to interact with quickly without leaving the current workspace.
+
+### Quake console
+
+Finally, there's a half-height Quake console that drops down over whatever workspace you're currently on. Toggle it with `Super + Grave`, and place a window there using `Super + Shift + Grave`.
+
+It opens with your default agent ready to go. To move a window off either scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
 
 ### It takes some getting used to!
 

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -60,11 +60,11 @@ You can pop a window out of its workspace allocation with `Super + O`. That'll p
 
  ![navigation-popped-window](images/navigation-popped-window.webp)
 
-### Scratchpad workspace
+### Scratchpad workspaces
 
-Finally, there's a special scratchpad workspace that drops down over whatever workspace you're currently on, much like a Quake console. Toggle it with `Super + Grave` or `Super + S`, and place a window there using `Super + Shift + Grave` or `Super + Alt + S`.
+Finally, there are two special scratchpad workspaces that open over whatever workspace you're currently on. `Super + S` toggles a full-size scratchpad styled like a regular workspace, and `Super + Alt + S` places a window there.
 
-It works especially well for a terminal running an agent, or for controls you want to interact with quickly without leaving the current workspace. To move a window off the scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
+`Super + Grave` drops down a half-height Quake console seeded with your default agent, and `Super + Shift + Grave` places a window there. To move a window off either scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
 
 ### It takes some getting used to!
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -26,8 +26,10 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Ctrl + Tab` | Jump to former workspace |
 | `Super + Shift + 1/2/3/4` | Move window to workspace |
 | `Super + Shift + Alt + 1/2/3/4` | Move window to workspace without following |
-| `Super + S` / `Super + Grave` | Toggle scratchpad |
-| `Super + Alt + S` / `Super + Shift + Grave` | Move window to scratchpad |
+| `Super + S` | Toggle full scratchpad |
+| `Super + Alt + S` | Move window to full scratchpad |
+| `Super + Grave` | Toggle Quake console |
+| `Super + Shift + Grave` | Move window to Quake console |
 | `Super + Shift + Alt + Arrows` | Move workspaces to directional monitor |
 | `Super + Arrow`  | Move focus to window in direction of arrow              |
 | `Super + Shift + Arrow`  | Swap window with another in direction of arrow     |

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -175,20 +175,19 @@ if grep -Fq $'SUPER + CTRL + X	Toggle dictation' <<<"$missing_voxtype_output"; t
 fi
 pass "missing Voxtype skips dictation bindings"
 
-# The Grave shortcuts are aliases, so the original SUPER + S pair has to keep
-# working alongside them.
+# The original scratchpad stays separate from the Quake console.
 scratchpad_home="$tmpdir/scratchpad-home"
 mkdir -p "$scratchpad_home"
 scratchpad_output=$(run_omarchy_bindings "$scratchpad_home")
 grep -Fqx $'SUPER + S	Toggle scratchpad' <<<"$scratchpad_output" ||
   fail "scratchpad keeps its existing toggle binding"
-grep -Fqx $'SUPER + grave	Toggle scratchpad' <<<"$scratchpad_output" ||
-  fail "scratchpad supports a Quake-style toggle binding"
+grep -Fqx $'SUPER + grave	Toggle Quake console' <<<"$scratchpad_output" ||
+  fail "Quake console has its own toggle binding"
 grep -Fqx $'SUPER + ALT + S	Move window to scratchpad' <<<"$scratchpad_output" ||
   fail "scratchpad keeps its existing move binding"
-grep -Fqx $'SUPER + SHIFT + grave	Move window to scratchpad' <<<"$scratchpad_output" ||
-  fail "scratchpad supports a Quake-style move binding"
-pass "scratchpad retains existing bindings and adds Grave shortcuts"
+grep -Fqx $'SUPER + SHIFT + grave	Move window to Quake console' <<<"$scratchpad_output" ||
+  fail "Quake console has its own move binding"
+pass "scratchpad and Quake console have separate bindings"
 
 # The panel hotkeys claim a row of keys that workspace switching already uses
 # under other modifiers, so the count matters as much as the bindings: a tenth

--- a/test/shell.d/hyprland-qconsole-test.sh
+++ b/test/shell.d/hyprland-qconsole-test.sh
@@ -33,9 +33,9 @@ end
 -- read. It still has to leave a rule behind, or the console would open unseeded.
 assert(#rules > 0, "console is ruled even before a monitor can be read")
 assert(current().on_created_empty:find("omarchy%-agent"), "console is seeded with the default agent")
-assert(current().on_created_empty:find("^%[workspace special:scratchpad silent%]"),
+assert(current().on_created_empty:find("^%[workspace special:qconsole silent%]"),
   "the seed is pinned to the console rather than trusting the spawn to inherit it")
-assert(current().workspace == "special:scratchpad")
+assert(current().workspace == "special:qconsole")
 
 local function rescale(height, scale, bar)
   monitor = { height = height, scale = scale, reserved = { top = bar, bottom = 0, left = 0, right = 0 } }


### PR DESCRIPTION
This keeps the original full-size scratchpad and the Quake console as two separate named special workspaces, rather than having both shortcuts open the same one.

- `scratchpad` remains the original full-size scratchpad on `SUPER + S`.
- `qconsole` is the half-height Quake console on `SUPER + grave`, named after `qconsole.lua`.

This keeps the Quake styling and default agent seed scoped to the Quake console, while the original scratchpad retains its existing windows and standard workspace styling.

The tests pass locally.