### PR TITLE
Leave an auto-scaled internal panel alone in clamshell recovery

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -118,9 +118,17 @@ remember_internal_scale() {
   store_internal_scale "$scale"
 }
 
+# $1 is the configured scale when the caller has already read it, so one sync
+# does not parse the config twice.
 read_monitor_scale() {
   local scale
-  scale=$(configured_monitor_scale)
+
+  if (( $# )); then
+    scale="$1"
+  else
+    scale=$(configured_monitor_scale)
+  fi
+
   if valid_scale "$scale"; then
     echo "$scale"
     return
@@ -159,11 +167,25 @@ enable_internal_output() {
 
 sync_internal_scale() {
   [[ -n $INTERNAL ]] || return 0
+  local configured_scale
   local desired_scale
   local active_scale
 
-  desired_scale=$(read_monitor_scale)
+  configured_scale=$(configured_monitor_scale)
   active_scale=$(current_internal_scale)
+
+  # A config without a usable number -- the default "auto", or an expression
+  # only Hyprland's Lua can evaluate -- delegates the scale to the compositor,
+  # so whatever it resolved for the enabled panel IS the configured scale.
+  # There is no number to correct it toward: substituting one makes the scale
+  # flap between that number and the compositor's own value on every idle-wake.
+  # Only a panel that is off altogether still gets a hand below, from the
+  # remembered scale.
+  if ! valid_scale "$configured_scale" && valid_scale "$active_scale"; then
+    return 0
+  fi
+
+  desired_scale=$(read_monitor_scale "$configured_scale")
   scales_match "$active_scale" "$desired_scale" && return 0
 
   enable_internal_output "$desired_scale"

--- a/test/shell.d/monitor-clamshell-scale-test.sh
+++ b/test/shell.d/monitor-clamshell-scale-test.sh
@@ -70,6 +70,18 @@ local omarchy_monitor_scale = "auto"
 LUA
 }
 
+# The shipped default's own shape: the catch-all rule hands the panel a
+# bare-word reference to the "auto" local.
+write_default_auto_config() {
+  cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = "auto"
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+LUA
+}
+
 write_internal_monitor_config() {
   cat >"$monitor_lua" <<'LUA'
 hl.monitor({ output = "eDP-1", mode = "preferred", position = "0x0", scale = 1.25 })
@@ -213,19 +225,38 @@ run_clamshell() {
     "$ROOT/bin/omarchy-hyprland-monitor-clamshell"
 }
 
+# Regression (#7265, #7301): with scale = "auto" the compositor's resolution of
+# it IS the configured scale, not a transient to correct. Forcing a number here
+# made the scale flap: every idle-wake applied the fallback 2, every config
+# reload resolved auto back to the panel's own value.
 write_auto_monitor_config
 : >"$eval_log"
 OMARCHY_TEST_INTERNAL_SCALE=3 run_clamshell
-grep -F 'scale = 2' "$eval_log" >/dev/null || fail "clamshell recovery ignores transient auto scale"
-! grep -F 'scale = "auto"' "$eval_log" >/dev/null || fail "clamshell recovery does not apply auto scale"
+! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell recovery leaves an auto-scaled panel alone"
 [[ ! -f $scale_state ]] || fail "clamshell recovery does not remember transient scale"
-pass "clamshell recovery ignores transient auto scale"
+pass "clamshell recovery leaves an auto-scaled panel alone"
 
-write_auto_monitor_config
+# The same delegation through the shipped default config, where "auto" reaches
+# the panel via the catch-all rule's bare-word reference to the local.
+write_default_auto_config
 : >"$eval_log"
-OMARCHY_TEST_INTERNAL_SCALE=2 run_clamshell
+OMARCHY_TEST_INTERNAL_SCALE=3 run_clamshell
+! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell recovery leaves the shipped auto default alone"
+pass "clamshell recovery leaves the shipped auto default alone"
+
+# A numeric config keeps both sync behaviors: a matching active scale is not
+# reapplied, and a drifted one is corrected back to the configured value.
+write_internal_monitor_config
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_SCALE=1.25 run_clamshell
 ! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell recovery does not reapply matching scale"
 pass "clamshell recovery avoids redundant scale apply"
+
+write_internal_monitor_config
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_SCALE=3 run_clamshell
+grep -F 'scale = 1.25' "$eval_log" >/dev/null || fail "clamshell recovery corrects a drifted numeric scale"
+pass "clamshell recovery corrects a drifted numeric scale"
 
 write_auto_monitor_config
 : >"$eval_log"
@@ -239,6 +270,15 @@ OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
 grep -F 'scale = 1.6' "$eval_log" >/dev/null || fail "clamshell recovery uses remembered internal scale"
 ! grep -F 'scale = "auto"' "$eval_log" >/dev/null || fail "clamshell recovery avoids auto after disabled internal display"
 pass "clamshell recovery uses remembered internal scale"
+
+# Recovery of a panel that is off, under an auto config with nothing
+# remembered, still needs a number: the historical default 2.
+write_auto_monitor_config
+rm -f "$scale_state"
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
+grep -F 'scale = 2' "$eval_log" >/dev/null || fail "clamshell recovery falls back to the default scale"
+pass "clamshell recovery falls back to the default scale"
 
 write_internal_monitor_config
 : >"$eval_log"
@@ -312,6 +352,15 @@ OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
 grep -F 'scale = 1.75' "$eval_log" >/dev/null || fail "clamshell recovery leaves an expression scale unresolved"
 pass "clamshell recovery leaves an expression scale unresolved"
 
+# An expression is Hyprland's to evaluate, not this parser's: like "auto", it
+# names no number to correct an enabled panel toward.
+write_expression_scale_config
+remember_scale 1.75
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_SCALE=3 run_clamshell
+! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell recovery leaves an expression-scaled panel alone"
+pass "clamshell recovery leaves an expression-scaled panel alone"
+
 # A quoted value is a string, not a reference to a local of the same name.
 write_shadowed_auto_config
 remember_scale 1.75
@@ -319,6 +368,15 @@ remember_scale 1.75
 OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
 grep -F 'scale = 1.75' "$eval_log" >/dev/null || fail "clamshell recovery does not resolve a quoted scale against a local"
 pass "clamshell recovery does not resolve a quoted scale against a local"
+
+# An explicit "auto" on the internal rule delegates just the same: while the
+# panel is enabled, it is not corrected toward the remembered scale.
+write_shadowed_auto_config
+remember_scale 1.75
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_SCALE=3 run_clamshell
+! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell recovery leaves an explicitly auto panel alone"
+pass "clamshell recovery leaves an explicitly auto panel alone"
 
 # Half of `3 / 2` is no better inside the rule than inside a local.
 write_expression_rule_config


### PR DESCRIPTION
## Symptom

With the stock `monitors.lua` (`omarchy_monitor_scale = "auto"`), the internal panel's scale flaps: every idle-wake it jumps to 2, every config reload it returns to whatever Hyprland's auto actually resolves (1.5666667 on my 2256x1504 @ 198 DPI panel, 1.5 on the reporter's 143 DPI panel in #7265). #7301 is the same loop seen from the screensaver side: dismissing the screensaver runs `omarchy-system-wake`, which snaps the scale back to 2.

## Root cause

`omarchy-hyprland-monitor-clamshell` runs from `omarchy-system-wake` after every idle cycle. Its `sync_internal_scale` reads the configured scale, and for `"auto"`:

1. `valid_scale` accepts only numbers, so `auto` is rejected,
2. the `$SCALE_STATE` fallback usually doesn't exist (it is only written when clamshell disables the panel),
3. `read_monitor_scale` lands on the hardcoded fallback `echo 2`,
4. `sync_internal_scale` sees 2 != auto's resolution and force-applies 2.

Deterministic repro on a live system with `scale = "auto"`:

```
$ hyprctl monitors -j | jq '.[0].scale'    # 1.5666667 (auto, after any reload)
$ omarchy-hyprland-monitor-clamshell
$ hyprctl monitors -j | jq '.[0].scale'    # 2
$ hyprctl reload && sleep 1
$ hyprctl monitors -j | jq '.[0].scale'    # 1.5666667 again
```

For what it's worth, the EDID-timing guess in #7265 doesn't reproduce: DPMS off/on cycles and a full `monitor eDP-1, disable` → re-enable cycle all keep auto's value stable. Only this script flips it.

## Fix

A config without a usable number — the default `"auto"`, or an expression only Hyprland's Lua can evaluate (`scale = 3 / 2`) — delegates the scale to the compositor: whatever it resolved for the *enabled* panel is the configured scale, so `sync_internal_scale` now leaves it alone instead of substituting a number. The guard tests `valid_scale` on the configured value rather than special-casing the `"auto"` string, so expression scales stop flapping too, and the configured scale is read once per sync instead of twice (`read_monitor_scale` accepts the already-read value).

Recovery of a *disabled* panel is unchanged: it still re-enables with the remembered scale (falling back to the historical default 2), and clamshell disable still records the active scale first — so the remembered value under auto is auto's own resolution, not the fallback.

This deliberately flips one existing assertion: the previous test required auto's resolution to be "corrected" to 2 (`clamshell recovery ignores transient auto scale`). That assumption — that auto's resolution is transient noise and 2 is the real value — is precisely what #7265/#7301 report as a bug, so the test now asserts the panel is left alone.

## Tests

`monitor-clamshell-scale-test.sh` grows from 20 to 25 cases:

- enabled panel left alone under: the bare auto local, the shipped default's catch-all-rule shape, an explicit `scale = "auto"` on the internal rule, and an expression scale (each fails against the unpatched script),
- numeric configs keep both sync behaviors: matching active scale not reapplied, drifted active scale corrected back,
- disabled-panel recovery under auto with no remembered state still applies the `echo 2` fallback.

All 25 pass; `./test/all` shows no new failures against the baseline on my machine.

Known bounded residual: if `hyprctl monitors` is transiently unreadable right after the lid-open reload, sync can still pin a number over auto until the next reload; the pre-existing code had the same window with a worse outcome, so it is left out of scope here.

Live verification: with the patch, running the script under `scale = "auto"` no longer changes the active scale; idle-wake cycles keep 1.5666667.

Fixes #7265. Fixes the scale-revert half of #7301 (the "sub-1080p should default to 1x" suggestion there is a separate question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
