### PR TITLE
Order the Omarchy repository above Arch's

### DIFF
--- a/default/pacman/pacman-edge.conf
+++ b/default/pacman/pacman-edge.conf
@@ -15,19 +15,22 @@ DownloadUser = alpm
 SigLevel = Required DatabaseOptional
 LocalFileSigLevel = Optional
 
-# pacman searches repositories in the order defined here
+# pacman searches repositories in the order defined here, and it stops at the first one carrying a name
+# instead of comparing versions across the rest. [omarchy] therefore precedes [extra] and [multilib] so
+# Omarchy can ship a package sooner than Arch does -- and so a package Omarchy ships has to stay ahead of
+# Arch's, because an older build here is what everyone gets. [core] stays first: Arch owns the base system.
 [core]
 Include = /etc/pacman.d/mirrorlist
+
+[omarchy]
+SigLevel = Optional TrustAll
+Server = https://pkgs.omarchy.org/edge/$arch
 
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
 [multilib]
 Include = /etc/pacman.d/mirrorlist
-
-[omarchy]
-SigLevel = Optional TrustAll
-Server = https://pkgs.omarchy.org/edge/$arch
 
 # Repositories for debug symbol packages.
 #

--- a/default/pacman/pacman-rc.conf
+++ b/default/pacman/pacman-rc.conf
@@ -15,16 +15,19 @@ DownloadUser = alpm
 SigLevel = Required DatabaseOptional
 LocalFileSigLevel = Optional
 
-# pacman searches repositories in the order defined here
+# pacman searches repositories in the order defined here, and it stops at the first one carrying a name
+# instead of comparing versions across the rest. [omarchy] therefore precedes [extra] and [multilib] so
+# Omarchy can ship a package sooner than Arch does -- and so a package Omarchy ships has to stay ahead of
+# Arch's, because an older build here is what everyone gets. [core] stays first: Arch owns the base system.
 [core]
 Include = /etc/pacman.d/mirrorlist
+
+[omarchy]
+SigLevel = Optional TrustAll
+Server = https://pkgs.omarchy.org/edge/$arch
 
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
 [multilib]
 Include = /etc/pacman.d/mirrorlist
-
-[omarchy]
-SigLevel = Optional TrustAll
-Server = https://pkgs.omarchy.org/edge/$arch

--- a/default/pacman/pacman-stable.conf
+++ b/default/pacman/pacman-stable.conf
@@ -15,16 +15,19 @@ DownloadUser = alpm
 SigLevel = Required DatabaseOptional
 LocalFileSigLevel = Optional
 
-# pacman searches repositories in the order defined here
+# pacman searches repositories in the order defined here, and it stops at the first one carrying a name
+# instead of comparing versions across the rest. [omarchy] therefore precedes [extra] and [multilib] so
+# Omarchy can ship a package sooner than Arch does -- and so a package Omarchy ships has to stay ahead of
+# Arch's, because an older build here is what everyone gets. [core] stays first: Arch owns the base system.
 [core]
 Include = /etc/pacman.d/mirrorlist
+
+[omarchy]
+SigLevel = Optional TrustAll
+Server = https://pkgs.omarchy.org/stable/$arch
 
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
 [multilib]
 Include = /etc/pacman.d/mirrorlist
-
-[omarchy]
-SigLevel = Optional TrustAll
-Server = https://pkgs.omarchy.org/stable/$arch

--- a/migrations/1787210567.sh
+++ b/migrations/1787210567.sh
@@ -1,0 +1,60 @@
+echo "Let the Omarchy repository outrank Arch's so its packages can ship ahead of extra"
+
+# Ordering is the whole mechanism. pacman stops at the first repository carrying
+# a name and never compares versions across the rest, so with [omarchy] below
+# [extra] an Omarchy build of a package Arch also ships is simply unreachable:
+# -Syu reports nothing to do and -S installs Arch's.
+#
+# The section is moved in place rather than by copying the shipped template over
+# the file, because omarchy-refresh-pacman does that and it also resets the
+# channel and discards whatever the user added to /etc/pacman.conf.
+
+conf="${OMARCHY_PACMAN_CONF:-/etc/pacman.conf}"
+marker="${OMARCHY_PACMAN_ORDER_MARKER:-/var/lib/omarchy/migrations/1787210567}"
+
+# Machine-wide work recorded per user, so a second account would run it again and
+# undo an administrator who deliberately put the ordering back.
+[[ -e $marker ]] && exit 0
+[[ -f $conf ]] || exit 0
+
+# awk rather than grep, which reports no match as a failure and would take the
+# whole migration run down with it under the runner's errexit.
+omarchy_line=$(awk '/^\[omarchy\]/ { print NR; exit }' "$conf")
+extra_line=$(awk '/^\[extra\]/ { print NR; exit }' "$conf")
+
+# Nothing to do for a config that predates the Omarchy repository, and nothing to
+# do once the section already leads.
+if [[ -z $omarchy_line || -z $extra_line ]] || ((omarchy_line < extra_line)); then
+  sudo install -Dm644 /dev/null "$marker"
+  exit 0
+fi
+
+# The section runs to the next header, a blank line, or the end of the file.
+block=$(awk '
+  /^\[omarchy\]/ { collecting = 1; print; next }
+  collecting && (/^\[/ || /^[[:space:]]*$/) { collecting = 0 }
+  collecting { print }
+' "$conf")
+
+reordered=$(awk -v block="$block" '
+  /^\[omarchy\]/ { dropping = 1; next }
+  dropping && /^\[/ { dropping = 0 }
+  dropping && /^[[:space:]]*$/ { dropping = 0; next }
+  dropping { next }
+  /^\[extra\]/ && !inserted { print block; print ""; inserted = 1 }
+  { print }
+' "$conf")
+
+# A reorder moves lines and changes nothing else, so the two files have to hold
+# the same content. Anything else means the awk above misread this config, and a
+# mangled pacman.conf is not worth the ordering.
+if ! diff -q <(grep -v '^[[:space:]]*$' "$conf" | sort) \
+             <(grep -v '^[[:space:]]*$' <<<"$reordered" | sort) >/dev/null; then
+  echo "Leaving $conf alone: reordering it would have changed more than the order"
+  exit 0
+fi
+
+sudo cp -f "$conf" "$conf.bak-repo-order"
+printf '%s\n' "$reordered" | sudo tee "$conf" >/dev/null
+sudo chmod 644 "$conf"
+sudo install -Dm644 /dev/null "$marker"


### PR DESCRIPTION
## Why

pacman stops at the **first** repository carrying a name and never compares versions across the rest. With `[omarchy]` listed last, an Omarchy build of anything Arch also ships is unreachable — `pacman -S` installs Arch's and `pacman -Syu` reports nothing to do.

That is why packaging something Arch is slow with cannot work today. yt-dlp is the case in hand: `extra` is six weeks behind upstream, and six weeks of missing extractor fixes means downloads that simply fail. omacom-io/omarchy-pkgs#178 packages it, but nothing installs it until the repository outranks `extra`.

`[core]` deliberately stays first. Arch keeps the base system; Omarchy takes precedence only over `extra` and `multilib`.

## The migration

Existing installs have `/etc/pacman.conf` written once at install time, so the templates alone change nothing for anyone who already runs Omarchy. The migration moves the section in place rather than copying the template over the file — that is what `omarchy-refresh-pacman` does, and it also resets the channel and discards whatever the user added.

It reorders only when the section trails `[extra]`, and it verifies its own result: a reorder moves lines and changes nothing else, so the file is compared against itself afterwards and left untouched if anything but the order changed. Tested against this machine's live config, the shipped edge/stable/rc templates, a config with no `[omarchy]` section, one with an extra `Usage = All` directive, and one with a trailing comment — content preserved in every case, byte-identical where there was nothing to do, and stable across repeated runs.

## What this costs, and the sequencing that matters

Ordering above Arch means a package Omarchy publishes **must stay ahead of Arch's**. An older build no longer sits unused:

| command | with an Omarchy build older than Arch's |
| --- | --- |
| `pacman -S <pkg>` | installs **ours** |
| `pacman -Syu` | **"nothing to do"** — the newer official build is never offered |
| `pacman -Syyuu` | **downgrades** to ours, and that is what `omarchy-refresh-pacman` runs |

Four packages are in that state right now: `gpu-screen-recorder` (5.12.3 vs extra's 6.0.0), `intel-lpmd`, `pinta` and `umu-launcher` (1.1.3 vs multilib's 1.4.4). They are harmless only because the current ordering hides them.

**So this must not merge until both are done:**

1. omacom-io/omarchy-pkgs#177 removes the three checked-in PKGBUILDs, and omacom-io/omarchy-pkgs#179 adds a check that fails when a package here falls behind Arch.
2. The already-published artifacts are removed from the mirror itself with `bin/repo remove-package` on the repository host, for **edge and stable both** — including `gpu-screen-recorder`, whose PKGBUILD is already gone but whose package is still in the repository database. Deleting the PKGBUILD stops rebuilds; it does not unpublish what is already there.

Marked draft for that reason.