### PR TITLE
Drop the Windows VM start notification

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -287,9 +287,6 @@ launch_windows() {
   if [[ $CONTAINER_STATUS != "running" ]]; then
     echo "Starting Windows VM..."
 
-    # Send desktop notification
-    omarchy-notification-send -g  "Starting Windows VM" "This can take 15-30 seconds" -t 15000
-
     if ! docker-compose -f "$COMPOSE_FILE" up -d 2>&1; then
       echo "❌ Failed to start Windows VM!"
       echo "   Try checking: omarchy-windows-vm status"


### PR DESCRIPTION
Launching the Windows VM fired a desktop notification saying "Starting Windows VM — this can take 15-30 seconds". That notification predates the launch OSD: the shell now shows "Launching Windows…" from the moment the desktop entry is activated until the RDP window appears, so the notification was a second copy of feedback already on screen, and it outlived the wait it described.

The failure notification stays. Nothing else tells you the VM never came up, and a launch started from the app menu has no terminal to print into.