### PR TITLE
Route cloned services through enabled plugin ids

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -277,7 +277,8 @@ ShellRoot {
   }
 
   function firstPartyServiceFor(pluginId) {
-    return serviceFor(pluginId)
+    var id = pluginRegistry ? pluginRegistry.resolveEnabledId(pluginId) : pluginId
+    return serviceFor(id)
   }
 
   function ensureService(pluginId) {

--- a/test/shell.d/plugin-registry-contract-test.sh
+++ b/test/shell.d/plugin-registry-contract-test.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+service_lookup=$(sed -n '/function firstPartyServiceFor(pluginId)/,/^  }/p' "$ROOT/shell/shell.qml")
+grep -F 'pluginRegistry.resolveEnabledId(pluginId)' <<<"$service_lookup" >/dev/null || \
+  fail "first-party service lookup routes cloned source ids"
+pass "first-party service lookup routes cloned source ids"
+
 TMPDIR=""
 QS_PID=""
 


### PR DESCRIPTION
Fixes #7355.

Cloning a service plugin now routes its service lookup to the enabled clone. This keeps cloned media widgets and the audio panel connected to the active media service.
<img width="2164" height="726" alt="omarchy-7587-media-clone-bar" src="https://github.com/user-attachments/assets/626d881f-2199-4651-84c1-10e2b743aa55" />
Tested with `test/shell.d/plugin-registry-contract-test.sh`.