### PR TITLE
Fix Mac suspend loop after the first resume from sleep

### DIFF
--- a/default/systemd/system-sleep/brcmfmac-suspend
+++ b/default/systemd/system-sleep/brcmfmac-suspend
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# The brcmfmac firmware in Apple's Broadcom BCM43602 Wi-Fi wedges on the first
+# resume from S3. Every suspend after that fails when brcmf_pcie_pm_enter_D3
+# returns -EIO, and systemd-logind keeps retrying: the machine wakes, its panel
+# lights up, and the cycle repeats until the lid is opened and the driver is
+# restarted.
+#
+# rmmod cannot pull the module out cleanly (its refcount never reaches zero),
+# so detach the PCI device from the driver before sleep and bind it again on
+# wake, which reloads the firmware. The driver check makes this a no-op on
+# machines whose Wi-Fi at this address is not brcmfmac.
+
+pci="/sys/bus/pci/devices/0000:03:00.0"
+driver="/sys/bus/pci/drivers/brcmfmac"
+
+bound() {
+  readlink "$pci/driver" 2>/dev/null | grep -q brcmfmac
+}
+
+if [[ -d $pci ]]; then
+  if [[ $1 == "pre" ]] && bound; then
+    echo "0000:03:00.0" > "$driver/unbind"
+  fi
+
+  if [[ $1 == "post" ]] && ! bound; then
+    # Bind again until the driver returns, or give up after 40 seconds. The
+    # kernel can re-enumerate the card itself through brcmfmac's rfkill, in
+    # which case the device races the loop back onto the bus and the retries
+    # all fail harmlessly.
+    for attempt in {1..20}; do
+      echo "0000:03:00.0" > "$driver/bind" 2>/dev/null
+      if bound; then
+        break
+      fi
+      (( attempt < 20 )) && sleep 2
+    done
+  fi
+fi

--- a/default/systemd/system-sleep/brcmfmac-suspend
+++ b/default/systemd/system-sleep/brcmfmac-suspend
@@ -9,31 +9,35 @@
 # rmmod cannot pull the module out cleanly (its refcount never reaches zero),
 # so detach the PCI device from the driver before sleep and bind it again on
 # wake, which reloads the firmware. The driver check makes this a no-op on
-# machines whose Wi-Fi at this address is not brcmfmac.
+# machines whose Wi-Fi at this address is not brcmfmac, and the marker keeps
+# post a no-op unless pre actually unbound the device, so a Wi-Fi that was
+# switched off intentionally stays off.
 
 pci="/sys/bus/pci/devices/0000:03:00.0"
 driver="/sys/bus/pci/drivers/brcmfmac"
+marker="/run/omarchy-brcmfmac-suspend"
 
 bound() {
   readlink "$pci/driver" 2>/dev/null | grep -q brcmfmac
 }
 
-if [[ -d $pci ]]; then
-  if [[ $1 == "pre" ]] && bound; then
-    echo "0000:03:00.0" > "$driver/unbind"
+if [[ -d $pci ]] && [[ $1 == "pre" ]] && bound; then
+  if echo "0000:03:00.0" > "$driver/unbind"; then
+    : > "$marker"
   fi
+fi
 
-  if [[ $1 == "post" ]] && ! bound; then
-    # Bind again until the driver returns, or give up after 40 seconds. The
-    # kernel can re-enumerate the card itself through brcmfmac's rfkill, in
-    # which case the device races the loop back onto the bus and the retries
-    # all fail harmlessly.
-    for attempt in {1..20}; do
-      echo "0000:03:00.0" > "$driver/bind" 2>/dev/null
-      if bound; then
-        break
-      fi
-      (( attempt < 20 )) && sleep 2
-    done
-  fi
+if [[ $1 == "post" ]] && [[ -f $marker ]]; then
+  # Bind again until the driver returns, or give up after 40 seconds. The
+  # kernel can re-enumerate the card itself through brcmfmac's rfkill, in
+  # which case the device races the loop back onto the bus and the retries
+  # all fail harmlessly.
+  for attempt in {1..20}; do
+    echo "0000:03:00.0" > "$driver/bind" 2>/dev/null
+    if bound; then
+      break
+    fi
+    (( attempt < 20 )) && sleep 2
+  done
+  rm -f "$marker"
 fi

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -125,7 +125,8 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
   ├─ systemd/system-sleep/{force-igpu,
-  │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
+  │    keyboard-backlight, brcmfmac-suspend,
+  │    unmount-fuse}                                    /usr/lib/systemd/system-sleep/
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/
   ├─ fonts/omarchy/omarchy.ttf                          /usr/share/fonts/omarchy/
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-suspend.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-brcmfmac-suspend.sh
+++ b/install/hardware/apple/fix-brcmfmac-suspend.sh
@@ -5,9 +5,13 @@
 # loop, lighting the panel each time.
 #
 # Install a sleep hook that detaches the PCI device from brcmfmac before sleep
-# and rebinds it on wake, forcing a clean firmware load. The T2 Macs from 2018
-# on are deliberately out of scope: their Wi-Fi sits on a different PCI bus.
-if lspci -nn -s 03:00.0 | grep -q "14e4:43ba"; then
+# and rebinds it on wake, forcing a clean firmware load. Non-Apple systems run
+# brcmfmac too without sharing the firmware bug, so the install is gated on the
+# DMI vendor like the WPA handshake quirk beside this file. The T2 Macs from
+# 2018 on are also out of scope: their Wi-Fi sits on a different PCI bus.
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+
+if [[ $sys_vendor == Apple* ]] && lspci -nn -s 03:00.0 | grep "14e4:43ba" >/dev/null; then
   echo "Detected BCM43602 Wi-Fi; installing a suspend workaround"
   sudo mkdir -p /usr/lib/systemd/system-sleep
   sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/brcmfmac-suspend" /usr/lib/systemd/system-sleep/

--- a/install/hardware/apple/fix-brcmfmac-suspend.sh
+++ b/install/hardware/apple/fix-brcmfmac-suspend.sh
@@ -1,0 +1,14 @@
+# Macs with Broadcom BCM43602 Wi-Fi (MacBook Pro 2015-2017, MacBook 2016+,
+# and same-era iMacs) wedge the brcmfmac firmware on the first resume from S3.
+# The driver can no longer put the card into D3, so every suspend after that
+# fails with pci_pm_suspend returning -EIO and systemd-logind retries it in a
+# loop, lighting the panel each time.
+#
+# Install a sleep hook that detaches the PCI device from brcmfmac before sleep
+# and rebinds it on wake, forcing a clean firmware load. The T2 Macs from 2018
+# on are deliberately out of scope: their Wi-Fi sits on a different PCI bus.
+if lspci -nn -s 03:00.0 | grep -q "14e4:43ba"; then
+  echo "Detected BCM43602 Wi-Fi; installing a suspend workaround"
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/brcmfmac-suspend" /usr/lib/systemd/system-sleep/
+fi

--- a/test/shell.d/brcmfmac-suspend-test.sh
+++ b/test/shell.d/brcmfmac-suspend-test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-brcmfmac-suspend.sh"
+hook="$ROOT/default/systemd/system-sleep/brcmfmac-suspend"
+all="$ROOT/install/hardware/all.sh"
+
+grep -q 'apple/fix-brcmfmac-suspend.sh' "$all" ||
+  fail "the brcmfmac suspend workaround runs during hardware setup"
+pass "the brcmfmac suspend workaround runs during setup"
+
+[[ -x $hook ]] || fail "the sleep hook ships executable"
+pass "the sleep hook ships executable"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "03:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+chmod +x "$stub_bin"/*
+
+# The leaf reads the vendor from an absolute path, so point it at a fixture by
+# running with a fake root on PATH-independent state. Its destination under
+# /usr is sed-rewritten into the sandbox, and pipefail is on, so a grep -q
+# gate would go silent here the way #6608 did.
+run_leaf() {
+  local vendor="$1" wifi_id="${2:-}"
+  rm -rf "$test_tmp/dmi/sys_vendor" "$test_tmp/system-sleep"
+  mkdir -p "$test_tmp/dmi" "$test_tmp/system-sleep"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+
+  local script="$test_tmp/leaf.sh"
+  sed -e "s|/sys/class/dmi/id/sys_vendor|$test_tmp/dmi/sys_vendor|g" \
+      -e "s|/usr/lib/systemd/system-sleep|$test_tmp/system-sleep|g" \
+      "$leaf" >"$script"
+
+  : >"$calls"
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" OMARCHY_PATH="$ROOT" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+run_leaf "Apple Inc." 43ba >/dev/null
+[[ -f $test_tmp/system-sleep/brcmfmac-suspend ]] ||
+  fail "a Mac with BCM43602 Wi-Fi at 03:00.0 gets the hook" "$(ls -R "$test_tmp/system-sleep" 2>&1)"
+pass "a Mac with BCM43602 Wi-Fi at 03:00.0 gets the hook"
+
+run_leaf "Apple Computer, Inc." 43ba >/dev/null
+[[ -f $test_tmp/system-sleep/brcmfmac-suspend ]] ||
+  fail "the older Apple vendor string is recognized" "$(ls -R "$test_tmp/system-sleep" 2>&1)"
+pass "the older Apple vendor string is recognized"
+
+run_leaf "LENOVO" 43ba >/dev/null
+[[ ! -e $test_tmp/system-sleep/brcmfmac-suspend ]] ||
+  fail "non-Apple hardware with the same Wi-Fi part is left alone"
+pass "non-Apple hardware with the same Wi-Fi part is left alone"
+
+run_leaf "Apple Inc." 43a0 >/dev/null
+[[ ! -e $test_tmp/system-sleep/brcmfmac-suspend ]] ||
+  fail "a Mac whose Wi-Fi runs the out-of-tree wl driver is left alone"
+pass "a Mac whose Wi-Fi runs the out-of-tree wl driver is left alone"
+
+run_leaf "Apple Inc." "" >/dev/null
+[[ ! -e $test_tmp/system-sleep/brcmfmac-suspend ]] ||
+  fail "a Mac with no wireless device is left alone"
+pass "a Mac with no wireless device is left alone"
+
+# The hook itself, against a sandbox sysfs. sysfs attributes are write-only
+# files, so a stub cannot sit inside them: instead the two sysfs writes in the
+# hook are sed-rewritten into stub invocations that maintain the device's
+# driver symlink the way the PCI core does.
+pci_dir="$test_tmp/sys/bus/pci/devices/0000:03:00.0"
+drv_dir="$test_tmp/sys/bus/pci/drivers/brcmfmac"
+marker="$test_tmp/marker"
+bind_calls="$test_tmp/bind_calls.log"
+mkdir -p "$pci_dir" "$drv_dir"
+
+cat >"$drv_dir/unbind" <<SH
+#!/bin/bash
+rm -f "$pci_dir/driver"
+SH
+cat >"$drv_dir/bind" <<SH
+#!/bin/bash
+printf '%s\n' bind >>"$bind_calls"
+ln -sfn ../../../../bus/pci/drivers/brcmfmac "$pci_dir/driver"
+SH
+chmod +x "$drv_dir/unbind" "$drv_dir/bind"
+
+run_hook() {
+  local script="$test_tmp/hook.sh"
+  # Path rewrites first; the sysfs writes are rewritten last because their
+  # replacement text carries the sandbox path, which the path patterns would
+  # otherwise match a second time.
+  sed -e "s|/sys/bus/pci/devices/0000:03:00.0|$pci_dir|g" \
+      -e "s|/sys/bus/pci/drivers/brcmfmac|$drv_dir|g" \
+      -e "s|/run/omarchy-brcmfmac-suspend|$marker|g" \
+      -e "s|echo \"0000:03:00.0\" > \"\\\$driver/unbind\"|\"$drv_dir/unbind\"|" \
+      -e "s|echo \"0000:03:00.0\" > \"\\\$driver/bind\" 2>/dev/null|\"$drv_dir/bind\"|" \
+      "$hook" >"$script"
+  : >"$bind_calls"
+  bash "$script" "$@"
+}
+
+ln -sfn ../../../../bus/pci/drivers/brcmfmac "$pci_dir/driver"
+run_hook pre suspend
+[[ ! -L $pci_dir/driver ]] || fail "pre unbinds a brcmfmac device"
+[[ -f $marker ]] || fail "pre records that it unbound the device"
+pass "pre unbinds a brcmfmac device and records it"
+
+run_hook post suspend
+[[ -L $pci_dir/driver ]] || fail "post binds the device again"
+[[ ! -e $marker ]] || fail "post clears the marker"
+pass "post binds the device again and clears the marker"
+
+rm -f "$pci_dir/driver"
+run_hook pre suspend
+[[ ! -e $marker ]] || fail "pre leaves a device that is not brcmfmac alone"
+pass "pre leaves a device that is not brcmfmac alone"
+
+run_hook post suspend
+[[ ! -s $bind_calls ]] || fail "post leaves alone a device pre did not unbind" "$(cat "$bind_calls")"
+pass "post leaves alone a device pre did not unbind"


### PR DESCRIPTION
## Problem

On Macs with Broadcom BCM43602 Wi-Fi driven by brcmfmac (MacBook Pro 2015–2017, MacBook 2016+, same-era iMacs), the firmware wedges on the first resume from S3:
`brcmf_msgbuf_query_dcmd` times out forever, and wpa_supplicant blocks in D state.

From then on every suspend fails when `brcmf_pcie_pm_enter_D3` returns `-EIO` (`PM: failed to suspend async: error -5`). systemd-logind retries the suspend every ~30 seconds indefinitely — 338 failed attempts were logged over a two-hour lid-closed window on the machine that motivated this change. Each retry powers the panel back up, so a closed laptop visibly "wakes" in a loop.

`rmmod` cannot cleanly unload `brcmfmac` (its refcount never returns to zero while the driver is bound), so the reliable workaround is to detach the PCI device itself.

## Change

- `default/systemd/system-sleep/brcmfmac-suspend` — sleep hook that unbinds `0000:03:00.0` from `brcmfmac` in `pre` and rebinds it in `post` (with a retry loop for the rfkill re-enumeration race), forcing a clean firmware load on every wake. It is a strict no-op unless it did the work itself: `pre` only acts when the device is bound to `brcmfmac` and records the unbind in a `/run` marker, and `post` only rebinds when that marker exists — an intentionally disabled Wi-Fi stays off.
- `install/hardware/apple/fix-brcmfmac-suspend.sh` — installs the hook at install time, gated on the DMI vendor (`Apple*`) and `lspci` finding a BCM43602 (`14e4:43ba`) at `03:00.0`, mirroring the WPA-handshake quirk beside it. T2 Macs (2018+) are out of scope: their Wi-Fi sits on a different PCI bus.
- `install/hardware/all.sh` — runs the new leaf as part of hardware setup.
- `docs/file-layout.md` — documents the new hook.
- `test/shell.d/brcmfmac-suspend-test.sh` — new tests covering the installer gate (Apple/BCM43602, older Apple vendor string, non-Apple same part, wl-driven part, no Wi-Fi), the hook's executable bit, and all four hook paths (bound pre, marker-gated post, non-brcmfmac device, post without a prior unbind) against a sandbox sysfs.

## Verification

- Hook exercised end-to-end on a MacBookPro13,2 (pre → unbind confirmed via `/sys/bus/pci/devices/0000:03:00.0/driver`, post → device re-bound and NetworkManager reconnected within seconds).
- `./test/all` passes except four pre-existing environment-dependent test files that also fail on a clean tree (`config-test`, `snapper-test`, `unowned-system-paths-test` need the private omarchy-pkgs checkout; `bar-icon-geometry-test` fails in test rendering).
- The new install script writes `/usr/lib/systemd/system-sleep`, which is the recorded hardware-conditional-hooks exception in `unowned-system-paths-test`.

## Notes

- The underlying firmware hang is a brcmfmac/kernel issue; this is a distro-side mitigation in the spirit of the existing `force-igpu` and `keyboard-backlight` hooks.
- For already-installed systems the hook can be applied manually:
  `sudo cp -p /usr/share/omarchy/default/systemd/system-sleep/brcmfmac-suspend /usr/lib/systemd/system-sleep/ && sudo chmod +x /usr/lib/systemd/system-sleep/brcmfmac-suspend`
  (after the next `omarchy update` that ships this file).
