### PR TITLE
Keep mise upgrades from pruning versions still in use

### DIFF
--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -1,3 +1,7 @@
+# Upgrades must not delete the version a running process is executing from:
+# mise up would prune the old install dir out from under a live session.
+mise settings set upgrade.auto_prune false
+
 omarchy-mise-install codex
 omarchy-mise-install claude
 omarchy-mise-install crush

--- a/migrations/1787215483.sh
+++ b/migrations/1787215483.sh
@@ -1,0 +1,3 @@
+echo "Stop mise upgrades from pruning versions still in use"
+
+mise settings set upgrade.auto_prune false


### PR DESCRIPTION
`upgrade.auto_prune` is on by default in mise, so `mise up` deletes the old install directory the moment a tool upgrades. Anything long-running is still executing out of that directory, and some tools re-exec themselves by absolute path — so `omarchy update` or `mup` breaks them mid-session.

Claude Code is how this surfaced. It records its own binary path at startup and dispatches its bundled `ugrep`/`bfs` through it via `exec -a`. Once the upgrade pruned that path, its `grep` and `find` wrappers fell back to the mise wrapper in `~/.local/bin`, which can't stand in for the real binary: **a shebang script never sees the argv[0] it was invoked under** — the kernel hands the interpreter the script path instead. So the dispatch collapsed to a plain `claude -G`:

```
$ grep -rn 'foo' .
mise ~/.config/mise/config.toml tools: claude@2.1.237
error: unknown option '-G'
```

Silent, too — `grep` and `find` returned empty rather than erroring visibly, so results looked merely absent.

Worth noting the wrapper itself isn't fixable here. Preserving argv[0] would need `~/.local/bin/<tool>` to be a symlink to the real binary, which gives up the install-and-upgrade-on-first-run behaviour the wrapper exists for. Not pruning the in-use version is the cheaper fix and keeps that intact.

## Changes

- `install/user/mise.sh` — set `upgrade.auto_prune false` before any tool installs
- `migrations/1787215483.sh` — same for existing installs

## Testing

Ran the migration on a live machine: `upgrade.auto_prune` flips `true` → `false`, writes `[settings.upgrade]` to `~/.config/mise/config.toml`, and is idempotent across re-runs. Confirmed the real binary honours argv[0] dispatch while the wrapper doesn't, which is what pinned down the cause.

## Trade-off

Old versions now accumulate until something prunes them deliberately. Costs disk, and leaves stale directories around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)