### PR TITLE
Refocus the lock password field after resume

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -76,6 +76,16 @@ Item {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
   }
 
+  // Suspend leaves this surface mapped, so onCompleted never runs again.
+  // Resume also rebuilds the keymap and drops Qt activeFocus; a click already
+  // calls forcePasswordFocus, and this recovers the same path without one.
+  Timer {
+    interval: 100
+    repeat: true
+    running: root.inputEnabled && !root.authenticatingPassword && !passwordInput.activeFocus
+    onTriggered: root.forcePasswordFocus()
+  }
+
   // Measures the masked password at full size; passwordDotScale compares this
   // against the field width to decide how far the dots must shrink to fit.
   TextMetrics {


### PR DESCRIPTION
## Problem
After suspend, the lock screen shows the password field but keystrokes do nothing until any mouse click. The keyboard is alive; Qt activeFocus on the field is not.
## Reproduce
1. Lock, then suspend (or suspend, which locks first).
2. Wake.
3. Type immediately, without clicking.
4. No dots. Click anywhere, then the same keys appear.
## Why v3 worked
Omarchy 3 locked with hyprlock, which reads raw Wayland keys. Quattro (7ea4e1ab Switch hyprlock to QS) replaced that with a Quickshell TextInput. Focus is set on Component.onCompleted, inputEnabled, and click. The lock stays mapped across suspend, so onCompleted never runs again. Click already called forcePasswordFocus(); nothing else did.
## Fix
While the lock is up, idle, and the field has no activeFocus, a short timer calls the same forcePasswordFocus() path as a click. Stops once the field is focused; does not run during PAM.
Verified: suspend → wake → type with no click.