### PR TITLE
Prevent idle hard-freeze on 2011 MacBook Airs (intel_idle.max_cstate=1)

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-sandy-bridge-idle.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-sandy-bridge-idle.sh
+++ b/install/hardware/apple/fix-sandy-bridge-idle.sh
@@ -1,0 +1,15 @@
+# Idle-state freeze fix for 2011 MacBook Airs (MacBookAir4,1 / MacBookAir4,2).
+#
+# The Sandy Bridge CPUs in these machines hard-lock when dropping into deep
+# C-states after load: the whole machine freezes (no TTY switch, no SysRq,
+# nothing reaches the journal) within seconds-to-minutes of reaching an idle
+# desktop. Capping intel_idle at C1 prevents the lockup, at some idle power
+# cost on hardware that is otherwise unusable.
+
+if omarchy-hw-match "MacBookAir4,"; then
+  mkdir -p /etc/limine-entry-tool.d
+  cat > /etc/limine-entry-tool.d/apple-sandy-bridge-idle.conf <<'EOF'
+# 2011 MacBook Air (Sandy Bridge) hard-locks when idling into deep C-states
+KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"
+EOF
+fi

--- a/migrations/1787217354.sh
+++ b/migrations/1787217354.sh
@@ -1,0 +1,41 @@
+echo "Cap intel_idle C-states on 2011 MacBook Airs to prevent idle hard-freeze"
+
+limine_conf="${OMARCHY_SANDY_IDLE_LIMINE_CONF:-/etc/limine-entry-tool.d/apple-sandy-bridge-idle.conf}"
+running_cmdline="${OMARCHY_RUNNING_CMDLINE:-/proc/cmdline}"
+repair_marker="${OMARCHY_SANDY_IDLE_REPAIR_MARKER:-/var/lib/omarchy/migrations/1787217354}"
+
+omarchy-hw-match "MacBookAir4," || exit 0
+
+needs_rebuild=0
+
+# Installs that predate install/hardware/apple/fix-sandy-bridge-idle.sh never
+# got the drop-in from hardware setup.
+if [[ ! -f $limine_conf ]]; then
+  sudo install -Dm644 /dev/stdin "$limine_conf" <<'EOF'
+# 2011 MacBook Air (Sandy Bridge) hard-locks when idling into deep C-states
+KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"
+EOF
+  needs_rebuild=1
+fi
+
+# The running kernel keeps its old command line until reboot, so a marker
+# records the machine-wide rebuild instead: another user's migration must not
+# repeat it before then, while a missing marker still retries an interrupted
+# rebuild.
+if [[ ! -e $repair_marker ]] &&
+  { [[ ! -r $running_cmdline ]] ||
+    ! grep -Eq '(^| )intel_idle\.max_cstate=1( |$)' "$running_cmdline"; }; then
+  needs_rebuild=1
+fi
+
+if (( needs_rebuild )); then
+  sudo limine-mkinitcpio
+  sudo install -Dm644 /dev/null "$repair_marker"
+
+  # Someone who already added the cap by hand (e.g. straight into
+  # /etc/default/limine) is running fixed and only needed the drop-in baked in.
+  if [[ ! -r $running_cmdline ]] ||
+    ! grep -Eq '(^| )intel_idle\.max_cstate=1( |$)' "$running_cmdline"; then
+    omarchy-state set reboot-required
+  fi
+fi

--- a/migrations/1787217354.sh
+++ b/migrations/1787217354.sh
@@ -9,8 +9,12 @@ omarchy-hw-match "MacBookAir4," || exit 0
 needs_rebuild=0
 
 # Installs that predate install/hardware/apple/fix-sandy-bridge-idle.sh never
-# got the drop-in from hardware setup.
-if [[ ! -f $limine_conf ]]; then
+# got the drop-in from hardware setup. Check for the active setting rather
+# than the file: an interrupted first run can leave the drop-in truncated, and
+# a hand-edited one can hold the parameter commented out — either way a later
+# rebuild would bake nothing and still look repaired. This drop-in exists only
+# to carry this parameter, so reinstalling it whole is safe.
+if ! grep -Fxq 'KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"' "$limine_conf" 2>/dev/null; then
   sudo install -Dm644 /dev/stdin "$limine_conf" <<'EOF'
 # 2011 MacBook Air (Sandy Bridge) hard-locks when idling into deep C-states
 KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"

--- a/migrations/1787217354.sh
+++ b/migrations/1787217354.sh
@@ -31,11 +31,14 @@ fi
 if (( needs_rebuild )); then
   sudo limine-mkinitcpio
   sudo install -Dm644 /dev/null "$repair_marker"
+fi
 
-  # Someone who already added the cap by hand (e.g. straight into
-  # /etc/default/limine) is running fixed and only needed the drop-in baked in.
-  if [[ ! -r $running_cmdline ]] ||
-    ! grep -Eq '(^| )intel_idle\.max_cstate=1( |$)' "$running_cmdline"; then
-    omarchy-state set reboot-required
-  fi
+# The reboot state is per-user while the rebuild is machine-wide, so this runs
+# independently of who rebuilt: a second user whose migration skips the rebuild
+# still boots an uncapped kernel and still needs the prompt. Someone who
+# already added the cap by hand (e.g. straight into /etc/default/limine) is
+# running fixed and only needed the drop-in baked in.
+if [[ ! -r $running_cmdline ]] ||
+  ! grep -Eq '(^| )intel_idle\.max_cstate=1( |$)' "$running_cmdline"; then
+  omarchy-state set reboot-required
 fi

--- a/test/shell.d/sandy-bridge-idle-test.sh
+++ b/test/shell.d/sandy-bridge-idle-test.sh
@@ -139,6 +139,27 @@ grep -Fq 'limine-mkinitcpio' "$calls" ||
   fail "a hand-fixed install is not asked to reboot" "$(cat "$calls")"
 pass "a hand-fixed install gets the drop-in without a reboot prompt"
 
+# A run interrupted mid-install can leave the drop-in truncated; the rerun
+# must not trust the file's existence and rebuild an empty config into the
+# boot image.
+rm -rf "$test_tmp/etc" "$test_tmp/var"
+mkdir -p "$(dirname "$conf")"
+: >"$conf"
+run_migration "MacBookAir4,1" "quiet splash"
+grep -Fq 'KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"' "$conf" ||
+  fail "a truncated drop-in is reinstalled" "$(cat "$conf")"
+grep -Fq 'limine-mkinitcpio' "$calls" ||
+  fail "a reinstalled drop-in is baked into the boot image" "$(cat "$calls")"
+pass "a truncated drop-in is reinstalled and baked in"
+
+# Someone who commented the line out is still on the freezing default.
+printf '#KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"\n' >"$conf"
+rm -rf "$test_tmp/var"
+run_migration "MacBookAir4,1" "quiet splash"
+grep -Fxq 'KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"' "$conf" ||
+  fail "a commented-out parameter does not count as applied" "$(cat "$conf")"
+pass "a commented-out parameter does not count as applied"
+
 # An interrupted rebuild leaves the drop-in without a marker; the rerun must
 # retry rather than trust the config.
 rm -rf "$test_tmp/var"

--- a/test/shell.d/sandy-bridge-idle-test.sh
+++ b/test/shell.d/sandy-bridge-idle-test.sh
@@ -113,9 +113,21 @@ grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
 [[ -e $marker ]] || fail "the migration records the machine-wide rebuild"
 pass "the migration fixes an install that never got the cap"
 
+# A second user on the same machine: the drop-in and marker exist, so the
+# machine-wide rebuild must not repeat, but this user's kernel is still
+# uncapped and their per-user state still needs the reboot prompt.
 run_migration "MacBookAir4,1" "quiet splash"
-[[ ! -s $calls ]] || fail "a repaired install is left untouched" "$(cat "$calls")"
-pass "the migration is idempotent"
+! grep -Fq 'limine-mkinitcpio' "$calls" ||
+  fail "a recorded rebuild is not repeated" "$(cat "$calls")"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "a second user is still asked for the pending reboot" "$(cat "$calls")"
+pass "a second user skips the rebuild but still gets the reboot prompt"
+
+# After the reboot the cap is live, and a later user's migration has nothing
+# left to do at all.
+run_migration "MacBookAir4,1" "quiet splash intel_idle.max_cstate=1"
+[[ ! -s $calls ]] || fail "a fully applied install is left untouched" "$(cat "$calls")"
+pass "a fully applied install is left untouched"
 
 # Someone who already added the cap by hand boots fixed and only needs the
 # drop-in baked in, not another reboot.

--- a/test/shell.d/sandy-bridge-idle-test.sh
+++ b/test/shell.d/sandy-bridge-idle-test.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-sandy-bridge-idle.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1787217354.sh"
+
+grep -q 'apple/fix-sandy-bridge-idle.sh' "$all" ||
+  fail "the Sandy Bridge idle fix runs during hardware setup"
+grep -Fq 'KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"' "$leaf" ||
+  fail "the leaf installs the C-state cap kernel parameter"
+pass "the Sandy Bridge idle fix installs the C-state cap during setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+conf="$test_tmp/etc/limine-entry-tool.d/apple-sandy-bridge-idle.conf"
+marker="$test_tmp/var/lib/omarchy/migrations/1787217354"
+cmdline="$test_tmp/proc-cmdline"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+# Real matching logic against a fixture, so the model gate itself is exercised.
+cat >"$stub_bin/omarchy-hw-match" <<SH
+#!/bin/bash
+
+grep -qi "\$1" "$test_tmp/dmi/product_name"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+printf 'limine-mkinitcpio\n' >>"$TEST_LOG"
+SH
+
+# Stubbed rather than run: the real one would write the running user's state.
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local model="$1"
+  rm -rf "$test_tmp/etc"
+  printf '%s' "$model" >"$test_tmp/dmi/product_name"
+
+  # Redirect the absolute path the leaf writes into the sandbox.
+  local script="$test_tmp/leaf.sh"
+  sed "s|/etc/limine-entry-tool.d|$test_tmp/etc/limine-entry-tool.d|g" \
+    "$leaf" >"$script"
+
+  PATH="$stub_bin:$PATH" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+for model in "MacBookAir4,1" "MacBookAir4,2"; do
+  run_leaf "$model"
+  grep -Fq 'KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"' "$conf" 2>/dev/null ||
+    fail "an affected Air gets the C-state cap" "$model"
+done
+pass "both 2011 Air models get the C-state cap"
+
+# Sandy Bridge relatives that do not share the verified freeze, and a model
+# whose name would match a sloppier pattern than "MacBookAir4,".
+for model in "MacBookPro8,1" "Macmini6,1" "MacBookAir41"; do
+  run_leaf "$model"
+  [[ ! -e $conf ]] || fail "other Macs are left alone" "$model"
+done
+pass "other Macs are left alone"
+
+# Installs that predate the leaf never ran hardware setup again, so the
+# migration has to reach them.
+run_migration() {
+  local model="$1" booted="$2"
+  printf '%s' "$model" >"$test_tmp/dmi/product_name"
+  printf '%s' "$booted" >"$cmdline"
+  : >"$calls"
+
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_SANDY_IDLE_LIMINE_CONF="$conf" \
+    OMARCHY_SANDY_IDLE_REPAIR_MARKER="$marker" \
+    OMARCHY_RUNNING_CMDLINE="$cmdline" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc" "$test_tmp/var"
+run_migration "MacBookAir4,1" "quiet splash"
+grep -Fq 'KERNEL_CMDLINE[default]+=" intel_idle.max_cstate=1"' "$conf" 2>/dev/null ||
+  fail "the migration installs the drop-in on an affected Air" "$(ls -R "$test_tmp/etc" 2>&1)"
+grep -Fq 'limine-mkinitcpio' "$calls" ||
+  fail "the migration rebuilds the boot image" "$(cat "$calls")"
+# The cap only reaches the kernel on the next boot.
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the reboot that applies it" "$(cat "$calls")"
+[[ -e $marker ]] || fail "the migration records the machine-wide rebuild"
+pass "the migration fixes an install that never got the cap"
+
+run_migration "MacBookAir4,1" "quiet splash"
+[[ ! -s $calls ]] || fail "a repaired install is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+# Someone who already added the cap by hand boots fixed and only needs the
+# drop-in baked in, not another reboot.
+rm -rf "$test_tmp/etc" "$test_tmp/var"
+run_migration "MacBookAir4,1" "quiet splash intel_idle.max_cstate=1"
+grep -Fq 'limine-mkinitcpio' "$calls" ||
+  fail "a hand-fixed install still gets the drop-in baked in" "$(cat "$calls")"
+! grep -Fq 'reboot-required' "$calls" ||
+  fail "a hand-fixed install is not asked to reboot" "$(cat "$calls")"
+pass "a hand-fixed install gets the drop-in without a reboot prompt"
+
+# An interrupted rebuild leaves the drop-in without a marker; the rerun must
+# retry rather than trust the config.
+rm -rf "$test_tmp/var"
+run_migration "MacBookAir4,1" "quiet splash"
+grep -Fq 'limine-mkinitcpio' "$calls" ||
+  fail "an interrupted rebuild is retried" "$(cat "$calls")"
+pass "an interrupted rebuild is retried"
+
+rm -rf "$test_tmp/etc" "$test_tmp/var"
+run_migration "Macmini6,1" "quiet splash"
+[[ ! -e $conf && ! -s $calls ]] ||
+  fail "the migration skips unaffected Macs" "$(cat "$calls")"
+pass "the migration skips unaffected Macs"


### PR DESCRIPTION
## What

Adds `install/hardware/apple/fix-sandy-bridge-idle.sh`, which appends `intel_idle.max_cstate=1` to the kernel cmdline (via the existing `/etc/limine-entry-tool.d/` drop-in pattern) on 2011 MacBook Airs (`MacBookAir4,1` / `MacBookAir4,2`).

## Why

The Sandy Bridge CPUs in these machines hard-lock when the CPU drops into deep C-states after load. The symptom is brutal to diagnose: the machine freezes completely (no TTY switch, no SysRq, nothing in the journal) within seconds-to-minutes of reaching an idle desktop, which reads as a graphics or compositor problem when it isn't one — it reproduces at a plain `multi-user.target` console too. This is a long-known quirk of these models under Linux, and capping intel_idle at C1 is the established fix.

## Verification

- Reproduced and fixed on a MacBookAir4,1 (i5-2467M) running Omarchy: froze reliably within moments of the desktop appearing; with `intel_idle.max_cstate=1` it has been stable since 2026-08-19, including load-then-idle cycles and lid-close suspend/resume.
- Being transparent about scope: verified on one 4,1 machine. The 4,2 (13" 2011 Air) shares the same board family and CPU generation and the same freeze is widely reported for it, but I don't own one to test. Happy to narrow the match to `MacBookAir4,1` if preferred.
- Detection tested: `omarchy-hw-match "MacBookAir4,"` matches both models and does not match other Macs (e.g. `Macmini6,1`).
- `./test/all`: the CLI suite passes; the shell suite shows 3 environment-dependent failures on my machine (config, snapper, unowned-system-paths) that are identical on a clean checkout of `quattro`, so nothing introduced by this change.

The param costs some idle battery, but on affected machines the alternative is a computer that locks up within a minute of logging in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
