### PR TITLE
Let the Dropbox widget be told the account's real quota

### DIFF
--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -32,6 +32,10 @@ Item {
   property string lastError: ""
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 60, 10, 3600)
+  // 0 leaves the plan lookup in charge. Accounts carrying bonus space have a
+  // real quota the plan name cannot describe, so they set this to correct it.
+  // Megabytes, not bytes: a quota in bytes overflows a QML int.
+  readonly property int quotaOverrideMB: intSetting("quotaOverrideMB", 0, 0, 2000000000)
   readonly property bool busy: statusProcess.running || loginProcess.running || controlProcess.running
   readonly property string helperPath: (omarchyPath || "") + "/shell/plugins/panels/dropbox/status.py"
 
@@ -61,7 +65,7 @@ Item {
     _statusOutput = ""
     _statusError = ""
     refreshing = true
-    statusProcess.command = ["python3", helperPath, "25"]
+    statusProcess.command = ["python3", helperPath, "25", String(quotaOverrideMB)]
     statusProcess.running = true
   }
 

--- a/shell/plugins/panels/dropbox/manifest.json
+++ b/shell/plugins/panels/dropbox/manifest.json
@@ -19,7 +19,8 @@
     "allowMultiple": false,
     "defaultSection": "right",
     "defaults": {
-      "refreshIntervalSec": 60
+      "refreshIntervalSec": 60,
+      "quotaOverrideMB": 0
     },
     "schema": [
       {
@@ -30,6 +31,15 @@
         "max": 3600,
         "step": 5,
         "defaultValue": 60
+      },
+      {
+        "key": "quotaOverrideMB",
+        "type": "integer",
+        "label": "Storage quota override (MB, 0 for plan default)",
+        "min": 0,
+        "max": 2000000000,
+        "step": 100,
+        "defaultValue": 0
       }
     ]
   }

--- a/shell/plugins/panels/dropbox/status.py
+++ b/shell/plugins/panels/dropbox/status.py
@@ -7,6 +7,11 @@ import heapq
 from pathlib import Path
 
 
+# What a plan ships with, which is not always what an account has. Bonus space
+# — referral bonuses on Basic, storage add-ons on the paid tiers — raises the
+# real quota permanently, and `subscription_type` still reads "Basic". Nothing
+# the local daemon exposes reveals the true figure, so these are a starting
+# point that `quota_override_bytes` can correct.
 PLAN_QUOTAS = {
   "basic": 2_000_000_000,
   "plus": 2_000_000_000_000,
@@ -80,6 +85,18 @@ def scan_dropbox(path, limit):
   return total, rows
 
 
+def quota_override_bytes(raw):
+  """Megabytes from the widget's quotaOverrideMB setting, as a byte count.
+
+  Returns 0 for anything unusable, which leaves PLAN_QUOTAS in charge.
+  """
+  try:
+    megabytes = int(raw)
+  except (TypeError, ValueError):
+    return 0
+  return megabytes * 1_000_000 if megabytes > 0 else 0
+
+
 def main():
   limit = 25
   if len(sys.argv) > 1:
@@ -93,7 +110,8 @@ def main():
   account = dropbox_account(info)
   account_path = account.get("path") if isinstance(account.get("path"), str) else ""
   plan = account.get("subscription_type") if isinstance(account.get("subscription_type"), str) else ""
-  quota = PLAN_QUOTAS.get(plan.lower(), 0)
+  override = quota_override_bytes(sys.argv[2] if len(sys.argv) > 2 else 0)
+  quota = override or PLAN_QUOTAS.get(plan.lower(), 0)
   authenticated = account_path != "" and Path(account_path).exists()
 
   running = False

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -32,3 +32,36 @@ assertEqual(
   'dropbox file metadata includes relative time and folder'
 )
 JS
+
+require_command python3
+
+# The plan table describes what a plan ships with, so an account carrying bonus
+# space needs the override to win. Everything unusable has to defer to the
+# table instead, since a broken setting must not blank out the quota.
+read_override() {
+  HELPER="$ROOT/shell/plugins/panels/dropbox/status.py" RAW="$1" python3 - <<'PY'
+import importlib.machinery, importlib.util, os
+
+loader = importlib.machinery.SourceFileLoader("status", os.environ["HELPER"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+status = importlib.util.module_from_spec(spec)
+loader.exec_module(status)
+
+print(status.quota_override_bytes(os.environ["RAW"]))
+PY
+}
+
+assert_override() {
+  local raw=$1 expected=$2 description=$3
+  local actual
+
+  actual=$(read_override "$raw")
+  [[ $actual == "$expected" ]] || fail "$description" "expected $expected, got $actual"
+  pass "$description"
+}
+
+assert_override 21380 21380000000 "dropbox override reads megabytes as bytes"
+assert_override 0 0 "dropbox override of zero defers to the plan table"
+assert_override -5 0 "dropbox override refuses negative megabytes"
+assert_override "" 0 "dropbox override ignores a blank setting"
+assert_override "lots" 0 "dropbox override ignores a non-numeric setting"


### PR DESCRIPTION
Fixes #7597.

`PLAN_QUOTAS` in the Dropbox widget's `status.py` maps `subscription_type` to the space a plan ships with, but that is only where an account *starts*. Referral bonuses on Basic (500 MB each, up to 16 GB, permanent) and storage add-ons on the paid tiers raise the real quota while `subscription_type` still reads `"Basic"`. My own account is 1.53 GB of 21.38 GB and the widget rendered it as `1.64 GB of 2 GB` — ~82% full instead of ~7%.

The authoritative number lives behind the Dropbox API (`/2/users/get_space_usage`), which needs an OAuth token the widget has no way to ask for, and neither `dropbox-cli` nor `~/.dropbox/info.json` exposes it. So rather than guess better, this lets the affected account state the figure:

- `manifest.json` gains a `quotaOverrideMB` integer setting, defaulting to `0`.
- `Service.qml` reads it and passes it to the helper.
- `status.py` gains `quota_override_bytes()`; the override wins when usable, and anything else — zero, negative, blank, non-numeric — falls back to `PLAN_QUOTAS` untouched.

Megabytes rather than bytes because a real quota in bytes overflows a QML `int`.

Default behavior is unchanged: with the setting absent or `0`, the plan lookup runs exactly as before.

## Before / after

Same account, before and after setting `quotaOverrideMB` to `21380`:

| | |
|---|---|
| Before | `1.64 GB of 2 GB` |
| After | `1.64 GB of 21.4 GB` |

(Screenshots attached below.)

## Tests

Extended `test/shell.d/dropbox-test.sh` with coverage for the override reader — megabyte conversion plus each way a setting can be unusable. `./test/shell` passes; the three failures in `./test/all` on my machine are all `omarchy-pkgs checkout not found` and unrelated to this change.

Verified in the running UI on Omarchy 4.0.0-1 via a cloned copy of the plugin.

## Notes

Two things I deliberately left out, happy to fold in either if you'd rather:

- **Manual docs.** `manual/24-commercial-apps-services.md` covers Dropbox setup but no widget settings, so I left it alone rather than start that section here.
- **`usedBytes` accuracy.** `scan_dropbox()` walks the sync folder rather than reading Dropbox, so it understates usage under selective sync (and slightly overstates here by counting `.dropbox.cache`). Same root cause — no API access — but a separate change.
