### PR TITLE
Keep first-party services alive during local plugin reloads

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -56,11 +56,12 @@ ShellRoot {
   property var shellConfig: builtinShellConfig
   property bool pluginReloading: false
   property bool pluginReloadPending: false
+  property bool pendingReloadKeepsFirstParty: true
 
   Timer {
     id: localPluginReloadTimer
     interval: 150
-    onTriggered: shell.reloadPlugins()
+    onTriggered: shell.reloadLocalPlugins()
   }
 
   onShellConfigChanged: {
@@ -345,12 +346,27 @@ ShellRoot {
     }
   }
 
-  function unloadPluginServices() {
+  function unloadPluginServices(keepFirstParty) {
+    var retained = ({})
     for (var existingId in _services) {
       var inst = _services[existingId]
+      var manifest = pluginRegistry && pluginRegistry.installedPlugins
+        ? pluginRegistry.installedPlugins[existingId] : null
+
+      // A local plugin edit must not tear down first-party infrastructure.
+      // In particular, destroying omarchy.lock while it owns ext-session-lock
+      // strands the compositor lock and can make Quickshell abort while the
+      // replacement service races to create lock surfaces. First-party code is
+      // package-owned and cannot have changed through the local plugin watcher,
+      // so keep those services alive across the rescan.
+      if (keepFirstParty && manifest && manifest.__isFirstParty) {
+        retained[existingId] = inst
+        continue
+      }
+
       if (inst && typeof inst.destroy === "function") inst.destroy()
     }
-    _services = ({})
+    _services = retained
   }
 
   Connections {
@@ -736,14 +752,20 @@ ShellRoot {
     pluginWidgetComponents = ({})
   }
 
-  function reloadPlugins() {
+  function reloadLocalPlugins() {
+    reloadPlugins(true)
+  }
+
+  function reloadPlugins(keepFirstParty) {
     if (shell.pluginReloading || shell.pluginRegistry.scanning) {
       shell.pluginReloadPending = true
+      shell.pendingReloadKeepsFirstParty = shell.pendingReloadKeepsFirstParty
+        && keepFirstParty === true
       return
     }
     shell.pluginReloading = true
     shell.unloadPanels()
-    shell.unloadPluginServices()
+    shell.unloadPluginServices(keepFirstParty === true)
     shell.unloadPluginWidgets()
     Qt.callLater(shell.finishPluginReload)
   }
@@ -766,9 +788,15 @@ ShellRoot {
     }
     function onScanFinished() {
       if (shell.pluginReloadPending) {
+        var keepFirstParty = shell.pendingReloadKeepsFirstParty
         shell.pluginReloadPending = false
+        shell.pendingReloadKeepsFirstParty = true
         shell.pluginReloading = false
-        Qt.callLater(shell.reloadPlugins)
+        if (keepFirstParty) {
+          Qt.callLater(shell.reloadLocalPlugins)
+        } else {
+          Qt.callLater(shell.reloadPlugins)
+        }
         return
       }
       shell.pluginReloading = false

--- a/test/shell.d/plugin-reload-test.sh
+++ b/test/shell.d/plugin-reload-test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const shellSource = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+
+function functionBody(source, name) {
+  const marker = `function ${name}(`
+  const start = source.indexOf(marker)
+  if (start === -1) throw new Error(`missing ${name}`)
+
+  const open = source.indexOf('{', start)
+  let depth = 0
+  let quote = ''
+  let escaped = false
+  let lineComment = false
+  let blockComment = false
+  for (let index = open; index < source.length; index += 1) {
+    const char = source[index]
+    const next = source[index + 1]
+
+    if (lineComment) {
+      if (char === '\n') lineComment = false
+      continue
+    }
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false
+        index += 1
+      }
+      continue
+    }
+    if (quote) {
+      if (escaped) escaped = false
+      else if (char === '\\') escaped = true
+      else if (char === quote) quote = ''
+      continue
+    }
+    if (char === '/' && next === '/') {
+      lineComment = true
+      index += 1
+      continue
+    }
+    if (char === '/' && next === '*') {
+      blockComment = true
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '{') depth += 1
+    if (char === '}') depth -= 1
+    if (depth === 0) return source.slice(open + 1, index)
+  }
+
+  throw new Error(`unterminated ${name}`)
+}
+
+const destroyed = []
+const firstPartyLock = { destroy: () => destroyed.push('omarchy.lock') }
+const firstPartyIdle = { destroy: () => destroyed.push('omarchy.idle') }
+const localService = { destroy: () => destroyed.push('local.service') }
+let _services = {
+  'omarchy.lock': firstPartyLock,
+  'omarchy.idle': firstPartyIdle,
+  'local.service': localService
+}
+const pluginRegistry = {
+  installedPlugins: {
+    'omarchy.lock': { __isFirstParty: true },
+    'omarchy.idle': { __isFirstParty: true },
+    'local.service': { __isFirstParty: false }
+  }
+}
+
+function unloadServices(keepFirstParty) {
+  new Function(
+    'pluginRegistry',
+    'services',
+    'setServices',
+    'keepFirstParty',
+    `let _services = services\n${functionBody(shellSource, 'unloadPluginServices')}\nsetServices(_services)`
+  )(pluginRegistry, _services, value => { _services = value }, keepFirstParty)
+}
+
+unloadServices(true)
+
+assertDeepEqual(destroyed, ['local.service'], 'local plugin reload destroys only third-party services')
+assertDeepEqual(Object.keys(_services).sort(), ['omarchy.idle', 'omarchy.lock'], 'local plugin reload retains first-party infrastructure services')
+assert(_services['omarchy.lock'] === firstPartyLock, 'local plugin reload preserves the active lock service instance')
+
+destroyed.length = 0
+_services['local.service'] = localService
+unloadServices(false)
+
+assertDeepEqual(destroyed.sort(), ['local.service', 'omarchy.idle', 'omarchy.lock'], 'explicit plugin rescan destroys every service')
+assertDeepEqual(Object.keys(_services), [], 'explicit plugin rescan retains no stale service instances')
+JS


### PR DESCRIPTION
Fixes #7106.

Alternative to #7572; overlaps the lock-preservation part of #7169.

## Problem

A practical trigger is **phone vibe coding through T3 Code**: the computer idle-locks while the user continues editing an Omarchy plugin from their phone. Saving plugin changes updates `~/.config/omarchy/plugins/`, whose watcher starts a full plugin reload even though only local plugin code changed.

`reloadPlugins()` currently destroys every plugin service, including the package-owned `omarchy.lock` service and its live `WlSessionLock`. Destroying that service while it owns `ext-session-lock` strands the compositor lock. The replacement service can then race while recreating lock surfaces and make Quickshell abort with:

```
FATAL: Tried to show lockscreen surfaces without active lock
```

This was observed in two `SIGABRT` coredumps. One crash coincided exactly with a local plugin manifest edit; the stack reached `WlSessionLock::updateSurfaces()` from the QML reload lifecycle.

## Fix

Treat automatic local-plugin changes differently from an explicit full rescan:

- `reloadLocalPlugins()` retains package-owned first-party service instances, including `omarchy.lock`, idle, notifications, polkit, and media.
- Third-party services are still destroyed and recreated, so the plugin being edited reloads immediately.
- Explicit `rescanPlugins` calls keep the existing full-reload behavior and unload every service.

The first-party boundary is intentional: files changed by the local plugin watcher cannot modify package-owned plugin sources, so retaining those instances cannot leave the edited third-party plugin stale.

Unlike #7572, this does not defer the edit until the session unlocks. Phone-driven/T3 Code plugin development remains live while the lock infrastructure stays intact, and no polling is introduced.

## Testing

- Added `test/shell.d/plugin-reload-test.sh` covering first-party retention, third-party teardown, lock-service identity, and explicit full rescans.
- Focused regression test passes: 5/5 assertions.
- `git diff --check` and QML parsing pass.
- Two manual local-plugin edits reloaded without changing the Quickshell PID or producing a fatal error.
- `./test/all`: all relevant tests pass. The three packaging-coverage files fail because this machine does not have the separate `omarchy-pkgs` checkout (`config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`); this is unrelated to the patch.
