### PR TITLE
Suppress keyring "reinstalling" warning in any locale

### DIFF
--- a/bin/omarchy-update-keyring
+++ b/bin/omarchy-update-keyring
@@ -18,5 +18,7 @@ fi
 # Ensure we have the latest archlinux-keyring, maintainer keys might have changed
 # Always reinstall, as the keyring can be updated without a package version bump.
 echo -e "\e[32m\nUpdate Arch signing keys\e[0m"
-sudo pacman -Sy --noconfirm archlinux-keyring >/dev/null 2> >(grep -vE '^warning: archlinux-keyring-[^ ]+ is up to date -- reinstalling$' >&2)
+# LC_ALL=C keeps pacman's messages English, so the "reinstalling" filter below
+# matches regardless of the user's locale (the filter is English-only).
+sudo env LC_ALL=C pacman -Sy --noconfirm archlinux-keyring >/dev/null 2> >(grep -vE '^warning: archlinux-keyring-[^ ]+ is up to date -- reinstalling$' >&2)
 echo "Keys are correct"


### PR DESCRIPTION
## Summary

This fixes a minor update annoyance of mine. :D

`omarchy-update-keyring` re-installs `archlinux-keyring` on every update and pipes the output through a `grep -vE` filter that hides pacman's *"up to date -- reinstalling"* warning.

That filter only matches the **English** string, but pacman prints the message in the user's locale. On a Swedish system (`LANG=sv_SE.UTF-8`) the warning leaked through on every update, producing noise even on a clean, successful run.

## Fix

Force `LC_ALL=C` on the `archlinux-keyring` install so pacman's messages are always English and the existing filter reliably suppresses the warning, regardless of the user's locale.

```diff
-sudo pacman -Sy --noconfirm archlinux-keyring >/dev/null 2> >(grep -vE '^warning: archlinux-keyring-[^ ]+ is up to date -- reinstalling$' >&2)
+sudo env LC_ALL=C pacman -Sy --noconfirm archlinux-keyring >/dev/null 2> >(grep -vE '^warning: archlinux-keyring-[^ ]+ is up to date -- reinstalling$' >&2)

Changes:
bin/omarchy-update-keyring — one-line change plus a comment explaining why LC_ALL=C is set.

Verification:
Ran omarchy-update-keyring on a system with LANG=sv_SE.UTF-8; the "reinstalling" warning is no longer emitted.
Confirmed output remains clean on an English-locale system as well.