### PR TITLE
Add Alfred-style quick-select to the menu

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -153,6 +153,14 @@ link is followed to its target. The default Hyprland bindings in
 `default/hypr/bindings/utilities.lua` all go through this surface
 (SUPER+SPACE toggles root, SUPER+ESCAPE the system menu, and so on).
 
+## Quick-select
+
+Holding Alt labels the first nine selectable rows `Alt 1` through `Alt 9`, and Alt+N activates the row carrying that label. The row under the cursor shows `↵` in place of its number, since Enter already opens it; its Alt+N still works, there is just no label spelling it out. The numbering counts selectable rows, so it skips `disabled` rows exactly as the cursor does and every label a user can see is a label that works. Rows past the ninth get none.
+
+The digit reads Alt off its own key event rather than off the tracked hold, so a menu summoned by a binding that already carries Alt still quick-selects; the tracked hold only drives the labels, and it clears when the menu closes or loses focus, since a release that lands elsewhere never reaches the menu.
+
+Alt rather than Super because Hyprland's workspace bindings claim Super+number before the menu ever sees it. Quick-select is inactive in select and input modes, where digits belong to the prompt.
+
 ## Select and input modes
 
 The same plugin doubles as the system's dmenu. `omarchy-menu-select` and

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -58,6 +58,22 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Ctrl + Alt + Tab`| Cycle focus forward through monitors |
 | `Ctrl + Alt + Shift + Tab`| Cycle focus backwards through monitors |
 
+## Inside the Omarchy menu
+
+Once the menu is open (`Super + Space`), it takes the keyboard for itself.
+
+| Hotkey                  | Function              |
+| ----------------------- | --------------------- |
+| `Type anything` | Filter the list |
+| `Arrow Up/Down` | Move the cursor |
+| `Return` / `Arrow Right` | Open the highlighted row |
+| `Backspace` / `Arrow Left` | Go back a level (or delete a character while filtering) |
+| `Alt` (hold) | Number the first nine rows |
+| `Alt + 1-9` | Open the numbered row directly |
+| `Escape` | Clear the filter, then close the menu |
+
+Holding `Alt` labels the rows it can reach, so you can see the number before you commit to it. The highlighted row shows `↵` instead of a number, since `Return` already opens it. Rows that are dimmed — software you already have installed, say — are skipped in the numbering, so every number you can see is a number that works.
+
 ## System controls
 
 | Hotkey                  | Function              |

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1150,8 +1150,12 @@ Item {
             event.accepted = true
           } else if (!root.dmenuActive && (event.modifiers & Qt.AltModifier)
                      && event.key >= Qt.Key_1 && event.key <= Qt.Key_9) {
-            var target = root.quickSelectIndexForOrdinal(event.key - Qt.Key_1 + 1)
-            if (target >= 0) root.activateIndex(target)
+            // A held digit auto-repeats, and the first press may have opened a
+            // submenu — a repeat would then activate a row the user never chose.
+            if (!event.isAutoRepeat) {
+              var target = root.quickSelectIndexForOrdinal(event.key - Qt.Key_1 + 1)
+              if (target >= 0) root.activateIndex(target)
+            }
             event.accepted = true
           } else if (event.key === Qt.Key_Delete) {
             root.requestDeleteSelected()

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -80,7 +80,9 @@ Item {
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  // Holding Alt reveals direct-selection labels for the first nine selectable rows.
+  property bool quickSelectHeld: false
+  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null; quickSelectHeld = false }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -548,6 +550,20 @@ Item {
     var target = root.nextSelectable(root.selectedIndex, 1)
     root.selectedIndex = target >= 0 ? target : 0
     root.cursorActive = target >= 0
+  }
+
+  // displayModel index for the Nth selectable row, for Alt+N activation.
+  function quickSelectIndexForOrdinal(ordinal) {
+    var rows = []
+    for (var i = 0; i < displayModel.count; i++) rows.push(displayModel.get(i))
+    return MenuModel.quickSelectIndexForOrdinal(rows, ordinal)
+  }
+
+  // Inverse of quickSelectIndexForOrdinal, for labeling a row with its number.
+  function quickSelectOrdinalForIndex(index) {
+    var rows = []
+    for (var i = 0; i <= index && i < displayModel.count; i++) rows.push(displayModel.get(i))
+    return MenuModel.quickSelectOrdinalForIndex(rows, index)
   }
 
   function rebuildDmenuDisplay() {
@@ -1126,7 +1142,18 @@ Item {
             return
           }
 
-          if (event.key === Qt.Key_Delete) {
+          // The digit reads the modifier off its own event rather than the held
+          // flag: a menu summoned by an Alt-bearing binding never sees the Alt
+          // press, and Alt+N has to work there too.
+          if (event.key === Qt.Key_Alt) {
+            root.quickSelectHeld = true
+            event.accepted = true
+          } else if (!root.dmenuActive && (event.modifiers & Qt.AltModifier)
+                     && event.key >= Qt.Key_1 && event.key <= Qt.Key_9) {
+            var target = root.quickSelectIndexForOrdinal(event.key - Qt.Key_1 + 1)
+            if (target >= 0) root.activateIndex(target)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Delete) {
             root.requestDeleteSelected()
             event.accepted = true
           } else if (event.key === Qt.Key_Escape) {
@@ -1163,6 +1190,14 @@ Item {
             event.accepted = true
           }
         }
+
+        Keys.onReleased: function(event) {
+          if (event.key === Qt.Key_Alt) root.quickSelectHeld = false
+        }
+
+        // Alt can go up while something else holds focus, and that release
+        // never arrives here — without this the labels stay lit until close.
+        onActiveFocusChanged: if (!activeFocus) root.quickSelectHeld = false
 
         ConfirmDialog {
           id: deleteConfirm
@@ -1355,7 +1390,7 @@ Item {
 
               Row {
                 id: trail
-                width: Style.space(14)
+                width: root.quickSelectHeld && !root.dmenuActive ? Style.space(46) : Style.space(14)
                 anchors.right: parent.right
                 anchors.rightMargin: root.rowReservedBorderRight + Style.space(8)
                 y: contentColumn.y + labelText.y + (labelText.height - height) / 2
@@ -1373,13 +1408,31 @@ Item {
                 }
 
                 Text {
+                  readonly property int quickSelectOrdinal: root.quickSelectOrdinalForIndex(row.index)
+
                   textFormat: Text.PlainText
-                  text: row.kind === "menu" || row.kind === "link" ? "›" : ""
+                  visible: root.quickSelectHeld && !root.dmenuActive && quickSelectOrdinal > 0 && !row.hasCursor
+                  text: "Alt " + quickSelectOrdinal
                   color: row.hasCursor ? root.selectedText : root.foreground
-                  opacity: row.kind === "menu" || row.kind === "link" ? 0.36 : 0
+                  opacity: 0.72
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.heading
-                  font.weight: Font.Normal
+                  font.pixelSize: Style.font.bodySmall
+                  font.weight: Font.Bold
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Text {
+                  textFormat: Text.PlainText
+                  text: root.quickSelectHeld && !root.dmenuActive
+                    ? (row.hasCursor ? "↵" : "")
+                    : (row.kind === "menu" || row.kind === "link" ? "›" : "")
+                  color: row.hasCursor ? root.selectedText : root.foreground
+                  opacity: root.quickSelectHeld && !root.dmenuActive
+                    ? (row.hasCursor ? 0.8 : 0)
+                    : (row.kind === "menu" || row.kind === "link" ? 0.36 : 0)
+                  font.family: root.fontFamily
+                  font.pixelSize: root.quickSelectHeld && !root.dmenuActive ? Style.font.bodySmall : Style.font.heading
+                  font.weight: root.quickSelectHeld && !root.dmenuActive ? Font.Bold : Font.Normal
                   anchors.verticalCenter: parent.verticalCenter
                 }
               }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -362,6 +362,35 @@ function searchScore(items, entry, query) {
   return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
 }
 
+// Alt+N addresses the Nth selectable row, so its numbering skips disabled
+// rows the same way the cursor does via rowSelectable/nextSelectable.
+function quickSelectIndexForOrdinal(rows, ordinal) {
+  var list = Array.isArray(rows) ? rows : []
+  if (ordinal < 1 || ordinal > 9) return -1
+
+  var seen = 0
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] && list[i].disabled) continue
+    seen += 1
+    if (seen === ordinal) return i
+  }
+
+  return -1
+}
+
+function quickSelectOrdinalForIndex(rows, index) {
+  var list = Array.isArray(rows) ? rows : []
+  if (index < 0 || index >= list.length) return -1
+  if (list[index] && list[index].disabled) return -1
+
+  var seen = 0
+  for (var i = 0; i <= index; i++) {
+    if (!(list[i] && list[i].disabled)) seen += 1
+  }
+
+  return seen <= 9 ? seen : -1
+}
+
 function displayRow(items, itemOrder, checkedResults, disabledResults, entry, detail, score, section) {
   var target = entry.kind === "link" ? entry.target : entry.id
   return {
@@ -519,6 +548,8 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    quickSelectIndexForOrdinal: quickSelectIndexForOrdinal,
+    quickSelectOrdinalForIndex: quickSelectOrdinalForIndex
   }
 }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -638,6 +638,57 @@ assert(
     && /onClicked:[\s\S]*root\.activateIndex\(row\.index, true\)/.test(menuQml),
   'mouse activation carries pointer intent into subordinate menus'
 )
+
+// Alt+N addresses the Nth selectable row: disabled rows are skipped in the
+// numbering, the same way the cursor skips them via nextSelectable.
+const quickSelectRows = [
+  { disabled: false },
+  { disabled: true },
+  { disabled: false },
+  { disabled: false },
+  { disabled: true }
+]
+assertEqual(menu.quickSelectIndexForOrdinal(quickSelectRows, 1), 0, 'quick-select ordinal 1 maps to the first selectable row')
+assertEqual(menu.quickSelectIndexForOrdinal(quickSelectRows, 2), 2, 'quick-select ordinal 2 skips a disabled row')
+assertEqual(menu.quickSelectIndexForOrdinal(quickSelectRows, 3), 3, 'quick-select ordinal 3 maps to the correct index')
+assertEqual(menu.quickSelectIndexForOrdinal(quickSelectRows, 4), -1, 'quick-select has no fourth selectable row here')
+assertEqual(menu.quickSelectOrdinalForIndex(quickSelectRows, 0), 1, 'quick-select labels the first selectable row 1')
+assertEqual(menu.quickSelectOrdinalForIndex(quickSelectRows, 1), -1, 'quick-select gives a disabled row no ordinal')
+assertEqual(menu.quickSelectOrdinalForIndex(quickSelectRows, 3), 3, 'quick-select labels indexes past a disabled row correctly')
+
+const manySelectableRows = Array.from({ length: 12 }, () => ({ disabled: false }))
+assertEqual(menu.quickSelectIndexForOrdinal(manySelectableRows, 9), 8, 'quick-select labels up through the ninth selectable row')
+assertEqual(menu.quickSelectIndexForOrdinal(manySelectableRows, 10), -1, 'quick-select stops labeling past the ninth selectable row')
+assertEqual(menu.quickSelectOrdinalForIndex(manySelectableRows, 9), -1, 'quick-select gives the tenth selectable row no ordinal')
+
+assert(
+  /property bool quickSelectHeld: false/.test(menuQml),
+  'menu tracks whether Alt is held for quick-select'
+)
+assert(
+  /onOpenedChanged: if \(!opened\) \{[\s\S]*quickSelectHeld = false \}/.test(menuQml),
+  'menu clears quick-select state when it closes'
+)
+assert(
+  /if \(event\.key === Qt\.Key_Alt\) \{\s*\n\s*root\.quickSelectHeld = true/.test(menuQml),
+  'menu arms quick-select while Alt is held'
+)
+assert(
+  /Keys\.onReleased: function\(event\) \{\s*\n\s*if \(event\.key === Qt\.Key_Alt\) root\.quickSelectHeld = false/.test(menuQml),
+  'menu disarms quick-select when Alt is released'
+)
+assert(
+  /onActiveFocusChanged: if \(!activeFocus\) root\.quickSelectHeld = false/.test(menuQml),
+  'menu disarms quick-select when focus leaves, since the Alt release never arrives'
+)
+assert(
+  /!root\.dmenuActive && \(event\.modifiers & Qt\.AltModifier\)\s*\n\s*&& event\.key >= Qt\.Key_1 && event\.key <= Qt\.Key_9/.test(menuQml),
+  'menu reads Alt+digit off the event modifier, so a menu summoned with Alt held still quick-selects'
+)
+assert(
+  /root\.quickSelectIndexForOrdinal\(event\.key - Qt\.Key_1 \+ 1\)/.test(menuQml),
+  'menu activates a row by its quick-select ordinal, not its raw digit'
+)
 JS
 
 font_charset=$(fc-query --format='%{charset}' "$ROOT/default/fonts/omarchy/omarchy.ttf")

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -689,6 +689,10 @@ assert(
   /root\.quickSelectIndexForOrdinal\(event\.key - Qt\.Key_1 \+ 1\)/.test(menuQml),
   'menu activates a row by its quick-select ordinal, not its raw digit'
 )
+assert(
+  /if \(!event\.isAutoRepeat\) \{\s*\n\s*var target = root\.quickSelectIndexForOrdinal/.test(menuQml),
+  'menu ignores auto-repeat digits, so a held Alt+N cannot drill into a submenu'
+)
 JS
 
 font_charset=$(fc-query --format='%{charset}' "$ROOT/default/fonts/omarchy/omarchy.ttf")


### PR DESCRIPTION
## Summary

The menu is fast to open but arrow-key travel to the row you want is the slow part. This improves the ergonomics of the whole surface: hold `Alt` and the first nine selectable rows reveal quick-select labels — press the number and you're there. Frequent destinations stop being "open, arrow, arrow, arrow, Enter" and become a single chord you learn once, while the labels stay invisible until you ask, so the menu looks exactly as it does today.

<img src="https://raw.githubusercontent.com/vormwald/omarchy/pr-assets-menu-quick-select/omarchy-quick-select.png" width="360" alt="Omarchy menu with Alt held, showing quick-select labels" />


<details><summary>Video Demo</summary>

https://github.com/user-attachments/assets/0b97c9de-0791-4c8b-8eda-5a67ddeab53d

</details>

The inspiration is Alfred's `⌘N` result hotkeys — the thing I've missed most since moving over:
<img width="1000" height="698" alt="image" src="https://github.com/user-attachments/assets/9dc97483-639a-47f4-8031-345136668448" />


- Numbering counts selectable rows, skipping disabled ones the same way the cursor does — every label a user can see is a label that works. The row under the cursor shows `↵` instead, since Enter already opens it
- The digit reads Alt off its own key event rather than a tracked hold, so a menu summoned by a binding that already carries Alt still quick-selects; the tracked hold only drives the labels and clears on close or focus loss
- Alt rather than Super because Hyprland's workspace bindings claim Super+number before the menu ever sees it; inactive in select and input modes, where digits belong to the prompt
- `docs/menu.md` gets the mechanism; the manual gets a new "Inside the Omarchy menu" hotkey section covering quick-select alongside the arrows, Enter, and Escape that weren't written down either

## Verification

- `./test/shell` passes, including new `test/shell.d/menu-test.sh` coverage for the ordinal mapping (disabled-row skipping, nine-row cap) and the key-handling wiring
- Exercised in the running shell (video above): labels appear on Alt hold and clear on release/close/focus loss, Alt+N opens the right row past disabled entries, and quick-select stays out of dmenu prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
