### PR TITLE
Restore global workspace layouts

### DIFF
--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -1,21 +1,28 @@
 #!/bin/bash
 
-# omarchy:summary=Toggle the layout on the current active workspace between dwindle and scrolling
+# omarchy:summary=Toggle the current workspace layout and restore its global default
 
 ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
 [[ $ACTIVE_WORKSPACE =~ ^-?[0-9]+$ ]] || exit 1
-CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
 LAYOUTS_DIR="$HOME/.local/state/omarchy/workspace-layouts"
 LAYOUT_FILE="$LAYOUTS_DIR/$ACTIVE_WORKSPACE.lua"
 
-case "$CURRENT_LAYOUT" in
-  dwindle) NEW_LAYOUT=scrolling ;;
-  *) NEW_LAYOUT=dwindle ;;
-esac
+if [[ -f $LAYOUT_FILE ]]; then
+  rm -- "$LAYOUT_FILE"
+  hyprctl reload
+  omarchy-notification-send -g 󱂬 "Workspace layout restored to the global default"
+else
+  CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
 
-mkdir -p "$LAYOUTS_DIR"
-printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ACTIVE_WORKSPACE" "$NEW_LAYOUT" >"$LAYOUT_FILE"
+  case "$CURRENT_LAYOUT" in
+    dwindle) NEW_LAYOUT=scrolling ;;
+    *) NEW_LAYOUT=dwindle ;;
+  esac
 
-hyprctl eval "hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 || \
-  hyprctl keyword workspace "$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT"
-omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_LAYOUT"
+  mkdir -p "$LAYOUTS_DIR"
+  printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ACTIVE_WORKSPACE" "$NEW_LAYOUT" >"$LAYOUT_FILE"
+
+  hyprctl eval "hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 || \
+    hyprctl keyword workspace "$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT"
+  omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_LAYOUT"
+fi

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -18,7 +18,7 @@ cat >"$stub_dir/hyprctl" <<'EOF'
 if [[ $1 == "activeworkspace" && -n $HYPRCTL_BROKEN ]]; then
   printf '{}\n'
 elif [[ $1 == "activeworkspace" ]]; then
-  printf '{"id":3,"tiledLayout":"dwindle"}\n'
+  printf '{"id":3,"tiledLayout":"%s"}\n' "${HYPRCTL_LAYOUT:-dwindle}"
 else
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
 fi
@@ -42,6 +42,20 @@ grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling" })' "$l
   fail "workspace layout toggle applies the selected layout immediately"
 pass "workspace layout toggle persists and applies the selected layout"
 
+HOME="$home_dir" HYPRCTL_LAYOUT=scrolling HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
+
+[[ ! -f $layout_file ]] || fail "workspace layout toggle clears its persisted workspace rule"
+grep -Fx 'reload' "$log_file" >/dev/null ||
+  fail "workspace layout toggle reloads Hyprland after clearing a workspace rule"
+pass "workspace layout toggle restores the global layout after a workspace override"
+
+HOME="$home_dir" HYPRCTL_LAYOUT=master HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
+grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "dwindle" })' "$layout_file" >/dev/null ||
+  fail "workspace layout toggle can override a custom global layout"
+pass "workspace layout toggle preserves a path back to a custom global layout"
+
 if HOME="$home_dir" HYPRCTL_LOG="$log_file" HYPRCTL_BROKEN=1 PATH="$stub_dir:$PATH" \
   "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle" 2>/dev/null; then
   fail "workspace layout toggle exits nonzero without a workspace id"
@@ -64,6 +78,6 @@ require("default.hypr.workspace-layouts")
 
 assert(#rules == 1)
 assert(rules[1].workspace == "3")
-assert(rules[1].layout == "scrolling")
+assert(rules[1].layout == "dwindle")
 LUA
 pass "saved workspace layouts load into Hyprland configuration"


### PR DESCRIPTION
## Problem

`omarchy-hyprland-workspace-layout-toggle` persists a per-workspace layout rule in `~/.local/state/omarchy/workspace-layouts/`. That rule overrides `general.layout` after every Hyprland reload. For users with a global layout other than dwindle or scrolling, pressing Super+L once leaves no supported way to return the workspace to the configured global layout.

## Change

Treat the saved workspace rule as the toggle state:

- When no saved rule exists, retain the current behavior of applying the alternate dwindle/scrolling layout and persist it.
- When a saved rule exists, remove only that workspace rule and reload Hyprland so the workspace returns to the user-configured global layout.

This keeps per-workspace layout toggling persistent across reloads while making the override reversible.

Closes #7612