### PR TITLE
Add an omarchy:// link handler for installing plugins from a web page

### DIFF
--- a/applications/omarchy-url-handler.desktop
+++ b/applications/omarchy-url-handler.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Omarchy URL Handler
+Comment=Handle omarchy:// links, such as installing a plugin from a web page
+Exec=omarchy-url-handler %u
+Terminal=false
+Type=Application
+NoDisplay=true
+MimeType=x-scheme-handler/omarchy;

--- a/bin/omarchy-url-handler
+++ b/bin/omarchy-url-handler
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# omarchy:summary=Handle omarchy:// links, such as installing a plugin from a web page
+# omarchy:group=cmd
+# omarchy:name=url-handler
+# omarchy:args=<omarchy://plugin/add?url=<https-git-url>[&enable=1]>
+# omarchy:hidden=true
+
+# Registered as the x-scheme-handler for omarchy:// so a web page can offer an
+# "Install in Omarchy" link for a shell plugin:
+#
+#   omarchy://plugin/add?url=<https-git-url>[&enable=1]
+#
+# The link comes from an untrusted page, so this only ever turns it into an
+# interactive `omarchy plugin add` in a floating terminal: the user still sees
+# the plugin trust warning and confirms before anything is cloned. Only https://
+# repo URLs are accepted; other git transports (ssh, file, ext::, local paths,
+# `-`-prefixed strings) are rejected.
+
+set -euo pipefail
+
+fail() {
+  echo "omarchy-url-handler: $*" >&2
+  omarchy-notification-send -u critical "Omarchy link rejected" "$*" || true
+  exit 1
+}
+
+urldecode() {
+  local encoded="${1//+/ }"
+  printf '%b' "${encoded//%/\\x}"
+}
+
+truthy() {
+  case "${1,,}" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" || -z ${1:-} ]]; then
+  echo "Usage: omarchy-url-handler <omarchy://plugin/add?url=<https-git-url>[&enable=1]>"
+  exit 0
+fi
+
+uri="$1"
+
+# omarchy://<path>?<query>, with or without the slashes after the scheme.
+[[ $uri =~ ^[Oo][Mm][Aa][Rr][Cc][Hh][Yy]:(//)?([^?#]*)(\?([^#]*))?(#.*)?$ ]] ||
+  fail "not an omarchy:// link: $uri"
+path="${BASH_REMATCH[2]}"
+query="${BASH_REMATCH[4]}"
+path="${path#/}"
+path="${path%/}"
+
+declare -A params=()
+IFS='&' read -ra pairs <<<"$query"
+for pair in "${pairs[@]}"; do
+  [[ -n $pair ]] || continue
+  key="${pair%%=*}"
+  value=""
+  [[ $pair == *=* ]] && value="${pair#*=}"
+  params["$(urldecode "$key")"]="$(urldecode "$value")"
+done
+
+case "$path" in
+  plugin/add | plugin/install)
+    repo="${params[url]:-}"
+    [[ -n $repo ]] || fail "missing url= parameter"
+    [[ $repo =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?(/[^[:space:][:cntrl:]]*)?$ ]] ||
+      fail "only https:// git URLs are allowed: $repo"
+
+    cmd=(omarchy-plugin-add "$repo")
+    if truthy "${params[enable]:-}"; then
+      cmd+=(--enable)
+    fi
+    ;;
+  *)
+    fail "unsupported omarchy:// action: ${path:-(none)}"
+    ;;
+esac
+
+printf -v quoted '%q ' "${cmd[@]}"
+exec omarchy-launch-floating-terminal-with-presentation "${quoted% }"

--- a/default/applications/mimeapps.list
+++ b/default/applications/mimeapps.list
@@ -13,6 +13,7 @@ application/pdf=org.gnome.Evince.desktop
 x-scheme-handler/http=chromium.desktop
 x-scheme-handler/https=chromium.desktop
 x-scheme-handler/mailto=HEY.desktop
+x-scheme-handler/omarchy=omarchy-url-handler.desktop
 
 video/mp4=mpv.desktop
 video/x-msvideo=mpv.desktop

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -100,3 +100,12 @@ For the full picture, the source is the documentation: `shell/README.md` in the 
 Once you've made something you like, put it in a public git repo. That's the whole distribution mechanism — anyone can then run `omarchy plugin add` against your URL and have it running in seconds.
 
 To help people actually find it, list it at [omarchyplugins.com](https://omarchyplugins.com). That's the community directory of Omarchy shell plugins, and it's the first place to look when you're wondering whether someone has already built the widget you're about to write. Browse it before you start!
+
+If you have a web page for your plugin, you can give it an install link. Omarchy registers itself as the handler for `omarchy://` links, so this opens a terminal running `omarchy plugin add` with the URL already filled in:
+
+```html
+<a href="omarchy://plugin/add?url=https%3A%2F%2Fgithub.com%2Facme%2Fomarchy-weather.git&enable=1">Install in Omarchy</a>
+```
+
+The `url` parameter is the https URL of your git repo, percent-encoded; add `enable=1` to enable the plugin right after it's added. The link only pre-fills the command — the same trust warning and confirmation apply, and only `https://` repos are accepted, so a page can't point the handler at anything else.
+

--- a/migrations/1787219051.sh
+++ b/migrations/1787219051.sh
@@ -1,0 +1,6 @@
+echo "Register the omarchy:// link handler so plugins can be installed from a web page"
+
+app_dir="$HOME/.local/share/applications"
+mkdir -p "$app_dir"
+cp "$OMARCHY_PATH/applications/omarchy-url-handler.desktop" "$app_dir/"
+update-desktop-database "$app_dir"

--- a/test/acceptance.d/url-handler-test.sh
+++ b/test/acceptance.d/url-handler-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# End-to-end check of the omarchy:// link handler on an installed system: the
+# scheme must resolve to our desktop entry the way a browser resolves it, and
+# opening a link must land the user in the interactive plugin trust prompt —
+# never straight into a clone.
+
+terminal_class='^org\.omarchy\.terminal$'
+repo_url='https://github.com/acme/omarchy-weather.git'
+
+if window_present "$terminal_class" >/dev/null 2>&1; then
+  fail "url handler starts with no pre-existing terminal" "an Omarchy terminal is already open"
+fi
+
+desktop_entry="$HOME/.local/share/applications/omarchy-url-handler.desktop"
+[[ -f $desktop_entry ]] ||
+  fail "url handler desktop entry is installed for the user" "missing $desktop_entry"
+pass "url handler desktop entry is installed for the user"
+
+handler=$(xdg-mime query default x-scheme-handler/omarchy || true)
+[[ $handler == "omarchy-url-handler.desktop" ]] ||
+  fail "omarchy:// scheme resolves to the url handler" "xdg-mime returned '${handler:-(nothing)}'"
+pass "omarchy:// scheme resolves to the url handler"
+
+command -v omarchy-url-handler >/dev/null ||
+  fail "omarchy-url-handler is on PATH"
+pass "omarchy-url-handler is on PATH"
+
+# Open the link the way a browser hands it off, then expect the plugin trust
+# prompt in a floating terminal rather than any git activity.
+launch_app "xdg-open 'omarchy://plugin/add?url=${repo_url//\//%2F}'"
+wait_until "omarchy:// link opens a terminal" 45 window_present "$terminal_class"
+wait_until "terminal shows the plugin trust prompt" 30 screen_contains "Clone and add this plugin"
+screenshot "success-url-handler-prompt"
+
+[[ ! -d $HOME/.config/omarchy/plugins/omarchy-weather ]] ||
+  fail "link does not clone before confirmation" "plugin directory appeared without confirmation"
+pass "link does not clone before confirmation"
+
+close_windows "$terminal_class"
+wait_until "url handler terminal closes" 30 window_absent "$terminal_class"
+
+# A rejected link must not open a terminal at all.
+launch_app "xdg-open 'omarchy://plugin/add?url=ssh%3A%2F%2Fgit%40example.test%2Facme%2Fplugin.git'"
+sleep 5
+window_absent "$terminal_class" >/dev/null 2>&1 ||
+  fail "rejected ssh link opens no terminal"
+pass "rejected ssh link opens no terminal"

--- a/test/shell.d/url-handler-test.sh
+++ b/test/shell.d/url-handler-test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_URL_HANDLER_LAUNCH"
+SH
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_URL_HANDLER_NOTIFY"
+SH
+chmod +x "$mock_bin"/*
+
+launch_log="$test_tmp/launch"
+notify_log="$test_tmp/notify"
+
+run_handler() {
+  rm -f "$launch_log" "$notify_log"
+  PATH="$mock_bin:$PATH" \
+    OMARCHY_TEST_URL_HANDLER_LAUNCH="$launch_log" OMARCHY_TEST_URL_HANDLER_NOTIFY="$notify_log" \
+    bash "$ROOT/bin/omarchy-url-handler" "$@" 2>/dev/null
+}
+
+assert_launches() {
+  local description="$1" uri="$2" expected="$3"
+
+  run_handler "$uri" || fail "$description: handler exited non-zero"
+  [[ -e $launch_log ]] || fail "$description: handler did not open a terminal"
+  [[ $(<"$launch_log") == "$expected" ]] ||
+    fail "$description: expected '$expected', got '$(<"$launch_log")'"
+  pass "$description"
+}
+
+assert_rejects() {
+  local description="$1" uri="$2"
+
+  if run_handler "$uri"; then
+    fail "$description: handler accepted the link"
+  fi
+  [[ ! -e $launch_log ]] || fail "$description: handler opened a terminal for a rejected link"
+  [[ -e $notify_log ]] || fail "$description: handler did not notify about the rejection"
+  pass "$description"
+}
+
+assert_launches "url handler runs plugin add for an encoded https repo" \
+  'omarchy://plugin/add?url=https%3A%2F%2Fgithub.com%2Facme%2Fomarchy-weather.git' \
+  'omarchy-plugin-add https://github.com/acme/omarchy-weather.git'
+
+assert_launches "url handler passes --enable when enable=1" \
+  'omarchy://plugin/add?url=https%3A%2F%2Fgithub.com%2Facme%2Fomarchy-weather.git&enable=1' \
+  'omarchy-plugin-add https://github.com/acme/omarchy-weather.git --enable'
+
+assert_launches "url handler accepts the plugin/install alias and unencoded URLs" \
+  'omarchy://plugin/install?url=https://github.com/acme/omarchy-weather&enable=0' \
+  'omarchy-plugin-add https://github.com/acme/omarchy-weather'
+
+assert_launches "url handler accepts omarchy: without slashes" \
+  'omarchy:plugin/add?url=https%3A%2F%2Fgithub.com%2Facme%2Fomarchy-weather.git' \
+  'omarchy-plugin-add https://github.com/acme/omarchy-weather.git'
+
+assert_rejects "url handler rejects ssh repo URLs" \
+  'omarchy://plugin/add?url=ssh%3A%2F%2Fgit%40example.test%2Facme%2Fplugin.git'
+assert_rejects "url handler rejects git ext:: transports" \
+  'omarchy://plugin/add?url=ext%3A%3Ash%20-c%20id'
+assert_rejects "url handler rejects option-looking repo URLs" \
+  'omarchy://plugin/add?url=--upload-pack%3Did'
+assert_rejects "url handler rejects local paths" \
+  'omarchy://plugin/add?url=%2Ftmp%2Fplugin'
+assert_rejects "url handler rejects repo URLs with whitespace" \
+  'omarchy://plugin/add?url=https%3A%2F%2Fgithub.com%2Fa%20b'
+assert_rejects "url handler rejects a missing url parameter" \
+  'omarchy://plugin/add'
+assert_rejects "url handler rejects unknown actions" \
+  'omarchy://theme/install?url=https%3A%2F%2Fgithub.com%2Facme%2Ftheme.git'
+assert_rejects "url handler rejects non-omarchy schemes" \
+  'https://github.com/acme/omarchy-weather.git'


### PR DESCRIPTION
A plugin's web page (or a directory like omarchyplugins.com) can now offer an **Install in Omarchy** link:

```html
<a href="omarchy://plugin/add?url=https%3A%2F%2Fgithub.com%2Facme%2Fomarchy-weather.git&enable=1">Install in Omarchy</a>
```

Clicking it opens the floating presentation terminal running `omarchy plugin add <url> [--enable]` — the same flow as _Setup > Plugins > Add Plugin_, so the trust warning and confirmation still stand between the click and the clone. The link only pre-fills the command; nothing is installed silently and `--yes` is never passed.

## How it's wired

- `bin/omarchy-url-handler` (hidden, `omarchy cmd url-handler`) parses the link and execs `omarchy-launch-floating-terminal-with-presentation`.
- `applications/omarchy-url-handler.desktop` is a `NoDisplay` entry with `MimeType=x-scheme-handler/omarchy;`, shipped like `HEY.desktop`.
- `default/applications/mimeapps.list` gets `x-scheme-handler/omarchy=omarchy-url-handler.desktop`, the same mechanism that routes `mailto:` to HEY, so it works system-wide without per-user `xdg-mime` calls.
- A migration copies the desktop entry into existing users' `~/.local/share/applications/`; new users get it from `/etc/skel` and `omarchy-refresh-applications`.
- `manual/32-shell-plugins.md` shows plugin authors how to build the link in the "Sharing yours with the world" section.

## Safety

Links come from untrusted pages, so the handler only accepts `https://` repository URLs. `ssh://`, `file://`, `ext::` transports, local paths, option-looking strings (`--upload-pack=…`), URLs with whitespace, unknown actions, and missing parameters are all rejected with a desktop notification saying why. The URL path is namespaced (`plugin/add`), leaving room for other actions later without changing the scheme.

## Testing

- `test/shell.d/url-handler-test.sh` covers the accepted forms (encoded/unencoded URL, `enable=1`, `plugin/install` alias, `omarchy:` without slashes) and every rejection above, using the suite's mock-bin pattern.
- `./test/cli` passes; `./test/shell` passes apart from the three omarchy-pkgs coverage checks, which need a sibling `omarchy-pkgs` checkout and fail the same way on `quattro` here.
- Migration run against a scratch `$HOME` installs the entry and is idempotent; `desktop-file-validate` passes.
- Verified end to end on a running Omarchy install: `xdg-open 'omarchy://plugin/add?url=…&enable=1'` from the browser opens the presentation terminal at the "Clone and add this plugin?" prompt with the decoded URL shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHgeZuuzTBV7kEeEXJrtTE
