### PR TITLE
tailscale: virtualize the machine list so huge tailnets don't melt the shell

### DIFF
--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -57,9 +57,84 @@ Panel {
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
 
+  // Large tailnets: the machine list renders through a virtualized
+  // ListView over this filtered view instead of one eager row per peer.
+  property string peerQuery: ""
+  readonly property var filteredPeers: {
+    var query = peerQuery.trim().toLowerCase()
+    if (query === "") return tailscale.peers
+    var result = []
+    for (var i = 0; i < tailscale.peers.length; i++) {
+      var p = tailscale.peers[i]
+      var ip = p.TailscaleIPs && p.TailscaleIPs.length > 0 ? String(p.TailscaleIPs[0]) : ""
+      var hay = (String(p.DisplayName || "") + " " + String(p.DNSName || "") + " " + ip).toLowerCase()
+      if (hay.indexOf(query) !== -1) result.push(p)
+    }
+    return result
+  }
+
+  // One shared copy menu for whichever row summoned it, instead of a Popup
+  // instantiated inside every machine row.
+  property var copyPeer: null
+  property int copyIndex: 0
+  readonly property var copyOptions: copyOptionsFor(copyPeer)
+
+  function copyOptionsFor(peer) {
+    var options = []
+    if (!peer) return options
+    var name = String(peer.DisplayName || peer.HostName || "")
+    var dns = String(peer.DNSName || "")
+    var ipv6 = peer.TailscaleIPv6 && peer.TailscaleIPv6.length > 0 ? String(peer.TailscaleIPv6[0] || "") : ""
+    var ip = peer.TailscaleIPs && peer.TailscaleIPs.length > 0 ? String(peer.TailscaleIPs[0]) : ""
+    if (name !== "") options.push({ kind: "name", label: name })
+    if (dns !== "") options.push({ kind: "dns", label: dns })
+    if (ipv6 !== "") options.push({ kind: "ipv6", label: ipv6 })
+    if (ip !== "") options.push({ kind: "ip", label: ip })
+    return options
+  }
+
+  function clampCopyIndex() {
+    copyIndex = Math.max(0, Math.min(copyIndex, copyOptions.length - 1))
+  }
+
+  function moveCopyCursor(delta) {
+    if (copyOptions.length === 0) return
+    copyIndex = Math.max(0, Math.min(copyOptions.length - 1, copyIndex + delta))
+  }
+
+  function copyOption(kind) {
+    var peer = copyPeer
+    if (peer) {
+      if (kind === "name") tailscale.copyPeerName(peer)
+      else if (kind === "dns") tailscale.copyPeerDnsName(peer)
+      else if (kind === "ipv6") {
+        var ipv6 = peer.TailscaleIPv6 && peer.TailscaleIPv6.length > 0 ? String(peer.TailscaleIPv6[0] || "") : ""
+        tailscale.copyToClipboard(ipv6, String(peer.DisplayName || peer.HostName || "") + " IPv6")
+      } else if (kind === "ip") tailscale.copyPeerIp(peer)
+    }
+    sharedCopyPopup.close()
+  }
+
+  function copyCurrentOption() {
+    clampCopyIndex()
+    if (copyOptions.length === 0) return
+    copyOption(copyOptions[copyIndex].kind)
+  }
+
+  function openCopyMenuFor(peer, row) {
+    if (!peer || copyOptionsFor(peer).length === 0) return
+    copyPeer = peer
+    clampCopyIndex()
+    var anchor = row || peerList
+    var point = anchor.mapToItem(peerList, 0, anchor.height)
+    sharedCopyPopup.x = Math.max(0, Math.min(peerList.width - sharedCopyPopup.width, point.x + anchor.width - sharedCopyPopup.width))
+    sharedCopyPopup.y = point.y + Style.space(4)
+    sharedCopyPopup.open()
+  }
+
   function selectedPeer() {
-    if (tailscale.peers.length === 0) return null
-    return tailscale.peers[Math.max(0, Math.min(peerIndex, tailscale.peers.length - 1))]
+    if (filteredPeers.length === 0) return null
+    return filteredPeers[Math.max(0, Math.min(peerIndex, filteredPeers.length - 1))]
   }
 
   function selectedExitNode() {
@@ -181,7 +256,7 @@ Panel {
     if (headerIndex < 0) headerIndex = 0
     if (headerIndex > 0) headerIndex = 0
     if (accountIndex >= tailscale.accounts.length) accountIndex = Math.max(0, tailscale.accounts.length - 1)
-    if (peerIndex >= tailscale.peers.length) peerIndex = Math.max(0, tailscale.peers.length - 1)
+    if (peerIndex >= filteredPeers.length) peerIndex = Math.max(0, filteredPeers.length - 1)
     if (exitNodeIndex >= exitNodes.length) exitNodeIndex = Math.max(0, exitNodes.length - 1)
     if (mullvadRegionIndex >= filteredMullvadRegions.length) mullvadRegionIndex = Math.max(0, filteredMullvadRegions.length - 1)
     if (focusSection === "auth" && !tailscale.accountsAccessDenied) focusSection = tailscale.accounts.length > 1 ? "accounts" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
@@ -219,7 +294,7 @@ Panel {
         if (dy < 0) {
           if (peerIndex <= 0) focusSection = showExitNodes ? "exitNodes" : (tailscale.accounts.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header"))
           else peerIndex--
-        } else if (peerIndex < tailscale.peers.length - 1) {
+        } else if (peerIndex < filteredPeers.length - 1) {
           peerIndex++
         }
       } else if (focusSection === "exitNodes") {
@@ -282,8 +357,10 @@ Panel {
   }
 
   function scrollCursorIntoView() {
-    if (focusSection === "peers" && peerColumn && peerIndex >= 0 && peerIndex < peerColumn.children.length) scrollItemIntoView(peerColumn.children[peerIndex])
-    else if (focusSection === "exitNodes" && exitNodeColumn && exitNodeIndex >= 0 && exitNodeIndex < exitNodeColumn.children.length) scrollItemIntoView(exitNodeColumn.children[exitNodeIndex])
+    if (focusSection === "peers" && peerList && filteredPeers.length > 0) {
+      peerList.positionViewAtIndex(Math.max(0, Math.min(peerIndex, filteredPeers.length - 1)), ListView.Contain)
+      scrollItemIntoView(peerList)
+    } else if (focusSection === "exitNodes" && exitNodeColumn && exitNodeIndex >= 0 && exitNodeIndex < exitNodeColumn.children.length) scrollItemIntoView(exitNodeColumn.children[exitNodeIndex])
   }
 
   function scrollMullvadRegionCursorIntoView() {
@@ -305,9 +382,10 @@ Panel {
   }
 
   function openSelectedPeerCopyMenu() {
-    if (!peerColumn || peerIndex < 0 || peerIndex >= peerColumn.children.length) return
-    var item = peerColumn.children[peerIndex]
-    if (item && item.openCopyMenu) item.openCopyMenu()
+    if (filteredPeers.length === 0) return
+    ensureCursor()
+    peerList.positionViewAtIndex(peerIndex, ListView.Contain)
+    openCopyMenuFor(selectedPeer(), peerList.itemAtIndex(peerIndex))
   }
 
   function setExitNodeCursor(index) {
@@ -340,7 +418,7 @@ Panel {
   onOpenedChanged: if (opened) {
     cursorActive = false
     if (panelFlick) panelFlick.contentY = 0
-    tailscale.refresh()
+    tailscale.refresh(false, true)
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
   onPeerIndexChanged: scrollCursorIntoView()
@@ -348,12 +426,14 @@ Panel {
   onMullvadRegionIndexChanged: if (mullvadPickerOpen) scrollMullvadRegionCursorIntoView()
   onShowConnectionsChanged: ensureCursor()
   onShowPeersChanged: ensureCursor()
+  onFilteredPeersChanged: ensureCursor()
   onShowExitNodesChanged: ensureCursor()
   onFilteredMullvadRegionsChanged: ensureCursor()
 
   Service {
     id: tailscale
     settings: root.settings
+    peersWanted: root.opened
   }
 
   Connections {
@@ -370,7 +450,7 @@ Panel {
     function show(): void { root.open() }
     function hide(): void { root.close() }
     function toggle(): void { root.toggle() }
-    function refresh(): string { tailscale.refresh(); return "ok" }
+    function refresh(): string { tailscale.refresh(false, true); return "ok" }
     function up(): string { tailscale.loginOrUp(); return "ok" }
     function down(): string { tailscale.down(); return "ok" }
     function toggleTailscale(): string { tailscale.toggleTailscale(); return "ok" }
@@ -395,7 +475,7 @@ Panel {
     }
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) tailscale.toggleTailscale()
-      else if (buttonCode === Qt.MiddleButton) tailscale.refresh()
+      else if (buttonCode === Qt.MiddleButton) tailscale.refresh(false, true)
       else root.toggle()
     }
   }
@@ -427,6 +507,7 @@ Panel {
         else if (t === "n" || t === "N") tailscale.copyPeerName(root.selectedPeer())
         else if (t === "d" || t === "D") tailscale.copyPeerDnsName(root.selectedPeer())
         else if (t === "s" || t === "S") root.sendPeerFile(root.selectedPeer())
+        else if (t === "/" && peerSearch.visible) peerSearch.forceActiveFocus()
       }
 
       Flickable {
@@ -675,9 +756,42 @@ Panel {
             spacing: Style.space(10)
 
             PanelSectionHeader {
-              text: "MACHINES"
+              text: {
+                if (tailscale.peers.length === 0) return "MACHINES"
+                if (root.peerQuery.trim() !== "") return "MACHINES · " + root.filteredPeers.length + " OF " + tailscale.peers.length
+                return "MACHINES · " + tailscale.peers.length
+              }
               foreground: root.foreground
               fontFamily: root.fontFamily
+            }
+
+            TextField {
+              id: peerSearch
+              visible: tailscale.peers.length > 8
+              width: parent.width
+              foreground: root.foreground
+              placeholderText: "Search machines  ( / )"
+              onTextChanged: {
+                root.peerQuery = text
+                root.peerIndex = 0
+              }
+              onAccepted: {
+                root.setPeerCursor(0)
+                keyCatcher.forceActiveFocus()
+              }
+              Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Down) {
+                  root.setPeerCursor(0)
+                  keyCatcher.forceActiveFocus()
+                  event.accepted = true
+                  return
+                }
+                if (event.key === Qt.Key_Escape) {
+                  if (peerSearch.text !== "") peerSearch.text = ""
+                  else keyCatcher.forceActiveFocus()
+                  event.accepted = true
+                }
+              }
             }
 
             Text {
@@ -690,20 +804,103 @@ Panel {
               horizontalAlignment: Text.AlignHCenter
             }
 
-            Column {
-              id: peerColumn
-              visible: root.showPeers
+            Text {
+              visible: tailscale.peers.length > 0 && root.filteredPeers.length === 0
               width: parent.width
-              spacing: Style.space(6)
+              text: "No machines match."
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              horizontalAlignment: Text.AlignHCenter
+            }
 
-              Repeater {
-                model: tailscale.peers
-                PeerRow {
-                  required property var modelData
-                  required property int index
-                  width: peerColumn.width
-                  peer: modelData
-                  rowIndex: index
+            // Virtualized: only the visible slice of the tailnet exists as
+            // delegates, and rows are pooled instead of destroyed on refresh.
+            ListView {
+              id: peerList
+              visible: root.showPeers && root.filteredPeers.length > 0
+              width: parent.width
+              height: Math.min(contentHeight, Style.space(300))
+              clip: true
+              spacing: Style.space(6)
+              model: root.filteredPeers
+              reuseItems: true
+              boundsBehavior: Flickable.StopAtBounds
+              flickableDirection: Flickable.VerticalFlick
+              interactive: contentHeight > height
+              ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+              delegate: PeerRow {
+                required property var modelData
+                required property int index
+                width: peerList.width
+                peer: modelData
+                rowIndex: index
+              }
+            }
+
+            Popup {
+              id: sharedCopyPopup
+              parent: peerList
+              width: Style.space(280)
+              padding: 0
+              modal: false
+              focus: true
+              closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+              function handleKey(event) {
+                if (event.key === Qt.Key_Escape) {
+                  close()
+                  event.accepted = true
+                  return
+                }
+                if (event.key === Qt.Key_Down || event.text === "j") {
+                  root.moveCopyCursor(1)
+                  event.accepted = true
+                  return
+                }
+                if (event.key === Qt.Key_Up || event.text === "k") {
+                  root.moveCopyCursor(-1)
+                  event.accepted = true
+                  return
+                }
+                if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
+                  root.copyCurrentOption()
+                  event.accepted = true
+                }
+              }
+              onOpenedChanged: {
+                root.copyMenuOpen = opened
+                if (opened) {
+                  root.clampCopyIndex()
+                  Qt.callLater(function() { sharedCopyContent.forceActiveFocus() })
+                } else if (root.opened) {
+                  Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+                }
+              }
+              background: BorderSurface {
+                color: Color.background
+                borderSpec: Border.flat(root.dim, 1)
+                radius: Style.cornerRadius
+              }
+
+              contentItem: Column {
+                id: sharedCopyContent
+                width: parent.width
+                focus: true
+                Keys.priority: Keys.BeforeItem
+                Keys.onPressed: function(event) { sharedCopyPopup.handleKey(event) }
+
+                Repeater {
+                  model: root.copyOptions
+                  CopyChoice {
+                    required property var modelData
+                    required property int index
+                    width: parent.width
+                    label: String(modelData.label || "")
+                    selected: root.copyIndex === index
+                    onHovered: root.copyIndex = index
+                    onChosen: root.copyOption(String(modelData.kind || ""))
+                  }
                 }
               }
             }
@@ -872,48 +1069,13 @@ Panel {
       return String(peer.TailscaleIPv6[0] || "")
     }
     readonly property string peerDns: peer ? String(peer.DNSName || "") : ""
-    readonly property var copyOptions: {
-      var options = []
-      if (peerName !== "") options.push({ kind: "name", label: peerName })
-      if (peerDns !== "") options.push({ kind: "dns", label: peerDns })
-      if (peerIpv6 !== "") options.push({ kind: "ipv6", label: peerIpv6 })
-      if (peerIp !== "") options.push({ kind: "ip", label: peerIp })
-      return options
-    }
-    property int copyIndex: 0
-
     hasCursor: root.cursorActive && root.focusSection === "peers" && root.peerIndex === rowIndex
     foreground: root.foreground
 
     implicitHeight: Math.max(peerContent.implicitHeight, copyButton.implicitHeight) + Style.spacing.rowPaddingX
 
-    function clampCopyIndex() {
-      copyIndex = Math.max(0, Math.min(copyIndex, copyOptions.length - 1))
-    }
-
     function openCopyMenu() {
-      if (copyOptions.length === 0) return
-      clampCopyIndex()
-      copyPopup.open()
-    }
-
-    function moveCopyCursor(delta) {
-      if (copyOptions.length === 0) return
-      copyIndex = Math.max(0, Math.min(copyOptions.length - 1, copyIndex + delta))
-    }
-
-    function copyOption(kind) {
-      if (kind === "name") tailscale.copyPeerName(peer)
-      else if (kind === "dns") tailscale.copyPeerDnsName(peer)
-      else if (kind === "ipv6") tailscale.copyToClipboard(peerIpv6, peerName + " IPv6")
-      else if (kind === "ip") tailscale.copyPeerIp(peer)
-      copyPopup.close()
-    }
-
-    function copyCurrentOption() {
-      clampCopyIndex()
-      if (copyOptions.length === 0) return
-      copyOption(copyOptions[copyIndex].kind)
+      root.openCopyMenuFor(peer, peerRow)
     }
 
     MouseArea {
@@ -988,73 +1150,6 @@ Panel {
         enabled: peerRow.peerIp !== "" || peerRow.peerName !== "" || peerRow.peerDns !== "" || peerRow.peerIpv6 !== ""
         Layout.alignment: Qt.AlignVCenter
         onClicked: peerRow.openCopyMenu()
-      }
-
-      Popup {
-        id: copyPopup
-        x: copyButton.x + copyButton.width - width
-        y: copyButton.y + copyButton.height + Style.space(4)
-        width: Style.space(280)
-        padding: 0
-        modal: false
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-        function handleKey(event) {
-          if (event.key === Qt.Key_Escape) {
-            close()
-            event.accepted = true
-            return
-          }
-          if (event.key === Qt.Key_Down || event.text === "j") {
-            peerRow.moveCopyCursor(1)
-            event.accepted = true
-            return
-          }
-          if (event.key === Qt.Key_Up || event.text === "k") {
-            peerRow.moveCopyCursor(-1)
-            event.accepted = true
-            return
-          }
-          if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space) {
-            peerRow.copyCurrentOption()
-            event.accepted = true
-          }
-        }
-        onOpenedChanged: {
-          root.copyMenuOpen = opened
-          if (opened) {
-            peerRow.clampCopyIndex()
-            Qt.callLater(function() { copyPopupContent.forceActiveFocus() })
-          } else if (root.opened) {
-            Qt.callLater(function() { keyCatcher.forceActiveFocus() })
-          }
-        }
-        background: BorderSurface {
-          color: Color.background
-          borderSpec: Border.flat(root.dim, 1)
-          radius: Style.cornerRadius
-        }
-
-        contentItem: Column {
-          id: copyPopupContent
-          width: parent.width
-          focus: true
-          Keys.priority: Keys.BeforeItem
-          Keys.onPressed: function(event) { copyPopup.handleKey(event) }
-
-          Repeater {
-            model: peerRow.copyOptions
-            CopyChoice {
-              required property var modelData
-              required property int index
-              width: parent.width
-              label: String(modelData.label || "")
-              selected: peerRow.copyIndex === index
-              onHovered: peerRow.copyIndex = index
-              onChosen: peerRow.copyOption(String(modelData.kind || ""))
-            }
-          }
-        }
       }
     }
   }

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -42,7 +42,7 @@ Panel {
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
-  readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
+  readonly property bool showPeers: tailscale.active && filteredPeers.length > 0
   readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
   readonly property var exitNodes: displayExitNodes()
@@ -362,6 +362,7 @@ Panel {
   function scrollCursorIntoView() {
     if (focusSection === "peers" && peerList && filteredPeers.length > 0) {
       peerList.positionViewAtIndex(Math.max(0, Math.min(peerIndex, filteredPeers.length - 1)), ListView.Contain)
+      peerList.rememberPosition()
       scrollItemIntoView(peerList)
     } else if (focusSection === "exitNodes" && exitNodeColumn && exitNodeIndex >= 0 && exitNodeIndex < exitNodeColumn.children.length) scrollItemIntoView(exitNodeColumn.children[exitNodeIndex])
   }
@@ -388,6 +389,7 @@ Panel {
     if (filteredPeers.length === 0) return
     ensureCursor()
     peerList.positionViewAtIndex(peerIndex, ListView.Contain)
+    peerList.rememberPosition()
     openCopyMenuFor(selectedPeer(), peerList.itemAtIndex(peerIndex))
   }
 
@@ -421,8 +423,14 @@ Panel {
   onOpenedChanged: if (opened) {
     cursorActive = false
     if (panelFlick) panelFlick.contentY = 0
+    peerList.rememberedY = 0
+    peerList.positionViewAtBeginning()
     tailscale.refresh(false, true)
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  } else if (peerSearch.text !== "") {
+    // A query must not survive the panel: reopening to a silently filtered
+    // list looks like machines are missing.
+    peerSearch.text = ""
   }
   onPeerIndexChanged: scrollCursorIntoView()
   onExitNodeIndexChanged: scrollCursorIntoView()
@@ -774,9 +782,15 @@ Panel {
               width: parent.width
               foreground: root.foreground
               placeholderText: "Search machines  ( / )"
+              // The field can disappear (account switch to a small tailnet)
+              // while a query is typed; a filter with no visible box and no
+              // `/` shortcut to clear it would look like missing machines.
+              onVisibleChanged: if (!visible && text !== "") text = ""
               onTextChanged: {
                 root.peerQuery = text
                 root.peerIndex = 0
+                peerList.rememberedY = 0
+                peerList.positionViewAtBeginning()
               }
               onAccepted: {
                 root.setPeerCursor(0)
@@ -785,6 +799,13 @@ Panel {
               Keys.onPressed: function(event) {
                 if (event.key === Qt.Key_Down) {
                   root.setPeerCursor(0)
+                  keyCatcher.forceActiveFocus()
+                  event.accepted = true
+                  return
+                }
+                if (event.key === Qt.Key_Up) {
+                  // Unhandled Up propagates past the field and moves the
+                  // panel's section cursor out from under the query.
                   keyCatcher.forceActiveFocus()
                   event.accepted = true
                   return
@@ -798,9 +819,21 @@ Panel {
             }
 
             Text {
-              visible: tailscale.installed && tailscale.active && tailscale.peers.length === 0
+              // Only claim an empty tailnet once a full peer fetch has
+              // answered; before that the panel is simply still loading.
+              visible: tailscale.installed && tailscale.active && tailscale.peersLoaded && tailscale.peers.length === 0
               width: parent.width
               text: "No machines found on this tailnet."
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+              horizontalAlignment: Text.AlignHCenter
+            }
+
+            Text {
+              visible: tailscale.installed && tailscale.active && !tailscale.peersLoaded && tailscale.peers.length === 0
+              width: parent.width
+              text: "Loading machines…"
               color: root.dim
               font.family: root.fontFamily
               font.pixelSize: Style.font.body
@@ -821,7 +854,7 @@ Panel {
             // delegates, and rows are pooled instead of destroyed on refresh.
             ListView {
               id: peerList
-              visible: root.showPeers && root.filteredPeers.length > 0
+              visible: root.showPeers
               width: parent.width
               height: Math.min(contentHeight, Style.space(300))
               clip: true
@@ -831,7 +864,20 @@ Panel {
               boundsBehavior: Flickable.StopAtBounds
               flickableDirection: Flickable.VerticalFlick
               interactive: contentHeight > height
-              ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+              // Qt resets contentY whenever a JS-array model is reassigned,
+              // and any poll where a peer changed publishes a new array — so
+              // without this a background refresh scrolls the list to the top
+              // under the user's finger. Remember the position the user (or
+              // keyboard cursor) chose and put it back; filter changes and
+              // panel opens reset it explicitly instead.
+              property real rememberedY: 0
+              function rememberPosition() { rememberedY = contentY }
+              onContentYChanged: if (moving || dragging) rememberedY = contentY
+              onModelChanged: contentY = Math.max(0, Math.min(rememberedY, Math.max(0, contentHeight - height)))
+              ScrollBar.vertical: ScrollBar {
+                policy: ScrollBar.AsNeeded
+                onPressedChanged: if (!pressed) peerList.rememberPosition()
+              }
 
               delegate: PeerRow {
                 required property var modelData

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -452,6 +452,14 @@ Panel {
     function onPeersChanged() { root.ensureCursor() }
     function onAccountsChanged() { root.ensureCursor() }
     function onAccountsAccessDeniedChanged() { root.ensureCursor() }
+    function onSelectedAccountIdChanged() {
+      // A remembered scroll position belongs to the tailnet it was scrolled
+      // in; restoring it midway into another account's machine list would
+      // land the user somewhere they have never been.
+      root.peerIndex = 0
+      peerList.rememberedY = 0
+      peerList.positionViewAtBeginning()
+    }
   }
 
   IpcHandler {

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -123,6 +123,9 @@ Panel {
 
   function openCopyMenuFor(peer, row) {
     if (!peer || copyOptionsFor(peer).length === 0) return
+    // The popup is shared across rows, so a cursor position left over from
+    // another machine's menu must not carry into this one.
+    if (!copyPeer || String(copyPeer.id || "") !== String(peer.id || "")) copyIndex = 0
     copyPeer = peer
     clampCopyIndex()
     var anchor = row || peerList

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -448,7 +448,9 @@ Panel {
   }
 
   Connections {
+    id: serviceEvents
     target: tailscale
+    property string lastAccountId: ""
     function onPeersChanged() { root.ensureCursor() }
     function onAccountsChanged() { root.ensureCursor() }
     function onAccountsAccessDeniedChanged() { root.ensureCursor() }
@@ -456,6 +458,11 @@ Panel {
       // A remembered scroll position belongs to the tailnet it was scrolled
       // in; restoring it midway into another account's machine list would
       // land the user somewhere they have never been.
+      var next = tailscale.selectedAccountId
+      // A failed account poll publishes an empty id for the tailnet the user
+      // is still on, so compare against the last one actually seen.
+      if (next === "" || next === serviceEvents.lastAccountId) return
+      serviceEvents.lastAccountId = next
       root.peerIndex = 0
       peerList.rememberedY = 0
       peerList.positionViewAtBeginning()

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -80,6 +80,9 @@ Item {
   property bool peersWanted: false
   property bool _statusFullPeers: false
   property bool _pendingFullPeers: false
+  // False until a full peer fetch has answered, so the panel can tell
+  // "still loading" apart from "this tailnet has no machines".
+  property bool peersLoaded: false
 
   function publishPeers(next) {
     var sig = JSON.stringify(next)
@@ -256,6 +259,7 @@ Item {
     authUrl = ""
     publishPeers([])
     publishTailnetExitNodes([])
+    peersLoaded = false
     syncExitNodes()
     mullvadExitNodes = []
     mullvadRegions = []
@@ -298,6 +302,7 @@ Item {
     if (_statusFullPeers) {
       publishPeers(parsed.running ? parsed.peers : [])
       publishTailnetExitNodes(parsed.running ? parsed.exitNodes : [])
+      peersLoaded = true
     } else if (!parsed.running) {
       publishPeers([])
       publishTailnetExitNodes([])
@@ -328,12 +333,13 @@ Item {
   }
 
   function parseMullvadExitNodes(raw) {
-    var nextExitNodes = Model.parseExitNodeList(raw)
-    var nextRegions = Model.mullvadRegionOptions(nextExitNodes)
+    // The raw node list is small and nothing hot binds to it, so publish it
+    // unconditionally; only the derived regions need the churn guard.
+    mullvadExitNodes = Model.parseExitNodeList(raw)
+    var nextRegions = Model.mullvadRegionOptions(mullvadExitNodes)
     var sig = JSON.stringify(nextRegions)
     if (sig !== _mullvadRegionsSig) {
       _mullvadRegionsSig = sig
-      mullvadExitNodes = nextExitNodes
       mullvadRegions = nextRegions
     }
     syncExitNodes()

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -302,10 +302,13 @@ Item {
     if (_statusFullPeers) {
       publishPeers(parsed.running ? parsed.peers : [])
       publishTailnetExitNodes(parsed.running ? parsed.exitNodes : [])
-      peersLoaded = true
+      // A stopped tailnet publishes no peers, so a later light poll finding it
+      // running again must not read as "fetched, and this tailnet is empty".
+      peersLoaded = parsed.running
     } else if (!parsed.running) {
       publishPeers([])
       publishTailnetExitNodes([])
+      peersLoaded = false
     }
     syncExitNodes()
 

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -79,6 +79,7 @@ Item {
   // is closed; the panel binds peersWanted and forces a full fetch on open.
   property bool peersWanted: false
   property bool _statusFullPeers: false
+  property bool _pendingFullPeers: false
 
   function publishPeers(next) {
     var sig = JSON.stringify(next)
@@ -200,12 +201,17 @@ Item {
       _statusOutput = ""
       _statusError = ""
       refreshing = true
-      _statusFullPeers = fullPeers === true || peersWanted
+      _statusFullPeers = fullPeers === true || peersWanted || _pendingFullPeers
+      if (_statusFullPeers) _pendingFullPeers = false
       statusProcess.command = _statusFullPeers
         ? ["tailscale", "status", "--json"]
         : ["tailscale", "status", "--json", "--peers=false"]
       statusProcess.running = true
       launched = true
+    } else if ((fullPeers === true || peersWanted) && !_statusFullPeers) {
+      // A full-peer request arrived while a light poll is in flight; remember
+      // it so the panel is not left stale until the next periodic refresh.
+      _pendingFullPeers = true
     }
     if (!mullvadExitNodesProcess.running) {
       _mullvadExitNodesOutput = ""
@@ -535,6 +541,10 @@ Item {
       else {
         root.resetUnavailable("Disconnected")
         root.lastError = stderr.trim()
+      }
+      if (root._pendingFullPeers) {
+        root._pendingFullPeers = false
+        root.refreshStatusAndAccounts(false, true)
       }
     }
   }

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -65,6 +65,42 @@ Item {
   property string _exitNodeError: ""
   property string _operatorOutput: ""
   property string _operatorError: ""
+  // Change signatures for the big arrays. A 4k-machine tailnet makes every
+  // status poll rebuild thousands of delegate rows if the arrays are
+  // reassigned unconditionally, so only publish an array whose content
+  // actually changed.
+  property string _peersSig: "[]"
+  property string _tailnetExitNodesSig: "[]"
+  property string _exitNodesSig: "[]"
+  property string _mullvadRegionsSig: "[]"
+
+  // The full status JSON is ~4.6MB on a 4k-machine tailnet, and the bar icon
+  // only needs Self/BackendState. Poll light (--peers=false) while the panel
+  // is closed; the panel binds peersWanted and forces a full fetch on open.
+  property bool peersWanted: false
+  property bool _statusFullPeers: false
+
+  function publishPeers(next) {
+    var sig = JSON.stringify(next)
+    if (sig === _peersSig) return
+    _peersSig = sig
+    peers = next
+  }
+
+  function publishTailnetExitNodes(next) {
+    var sig = JSON.stringify(next)
+    if (sig === _tailnetExitNodesSig) return
+    _tailnetExitNodesSig = sig
+    tailnetExitNodes = next
+  }
+
+  function syncExitNodes() {
+    var next = running ? tailnetExitNodes.concat(mullvadRegions) : []
+    var sig = JSON.stringify(next)
+    if (sig === _exitNodesSig) return
+    _exitNodesSig = sig
+    exitNodes = next
+  }
 
   function setting(name, fallback) {
     var value = settings ? settings[name] : undefined
@@ -145,9 +181,9 @@ Item {
     Quickshell.execDetached(["omarchy-tailscale-send", target])
   }
 
-  function refresh(forceAccounts) {
+  function refresh(forceAccounts, fullPeers) {
     if (installed) {
-      refreshStatusAndAccounts(forceAccounts === true)
+      refreshStatusAndAccounts(forceAccounts === true, fullPeers === true)
       return
     }
     if (!whichProcess.running) {
@@ -157,14 +193,17 @@ Item {
     }
   }
 
-  function refreshStatusAndAccounts(forceAccounts) {
+  function refreshStatusAndAccounts(forceAccounts, fullPeers) {
     if (!installed) return
     var launched = false
     if (!statusProcess.running) {
       _statusOutput = ""
       _statusError = ""
       refreshing = true
-      statusProcess.command = ["tailscale", "status", "--json"]
+      _statusFullPeers = fullPeers === true || peersWanted
+      statusProcess.command = _statusFullPeers
+        ? ["tailscale", "status", "--json"]
+        : ["tailscale", "status", "--json", "--peers=false"]
       statusProcess.running = true
       launched = true
     }
@@ -209,11 +248,12 @@ Item {
     selfUserId = ""
     fileSharing = false
     authUrl = ""
-    peers = []
-    exitNodes = []
-    tailnetExitNodes = []
+    publishPeers([])
+    publishTailnetExitNodes([])
+    syncExitNodes()
     mullvadExitNodes = []
     mullvadRegions = []
+    _mullvadRegionsSig = "[]"
     accounts = []
     selectedAccountId = ""
     selectedAccountLabel = ""
@@ -247,9 +287,16 @@ Item {
     selfIp = parsed.selfIp
     selfUserId = parsed.selfUserId
     fileSharing = parsed.fileSharing
-    peers = parsed.running ? parsed.peers : []
-    tailnetExitNodes = parsed.running ? parsed.exitNodes : []
-    exitNodes = parsed.running ? tailnetExitNodes.concat(mullvadRegions) : []
+    // A light poll carries no peer data — keep the last full machine list
+    // while running, and only clear it when tailscale actually went down.
+    if (_statusFullPeers) {
+      publishPeers(parsed.running ? parsed.peers : [])
+      publishTailnetExitNodes(parsed.running ? parsed.exitNodes : [])
+    } else if (!parsed.running) {
+      publishPeers([])
+      publishTailnetExitNodes([])
+    }
+    syncExitNodes()
 
     if (needsLogin) statusText = "Needs login"
     else if (running) {
@@ -275,9 +322,15 @@ Item {
   }
 
   function parseMullvadExitNodes(raw) {
-    mullvadExitNodes = Model.parseExitNodeList(raw)
-    mullvadRegions = Model.mullvadRegionOptions(mullvadExitNodes)
-    exitNodes = running ? tailnetExitNodes.concat(mullvadRegions) : []
+    var nextExitNodes = Model.parseExitNodeList(raw)
+    var nextRegions = Model.mullvadRegionOptions(nextExitNodes)
+    var sig = JSON.stringify(nextRegions)
+    if (sig !== _mullvadRegionsSig) {
+      _mullvadRegionsSig = sig
+      mullvadExitNodes = nextExitNodes
+      mullvadRegions = nextRegions
+    }
+    syncExitNodes()
   }
 
   function toggleTailscale() {


### PR DESCRIPTION
## Problem

On a corporate tailnet with ~3,900 machines, the tailscale widget makes the shell unusable. `tailscale status --json` is ~4.6 MB there, and every 30-second poll reassigns `peers`, which rebuilds one eager row per peer — each row carrying its own copy-menu `Popup` — on every bar. Traced with the QML profiler, that is **~500k QML object creations per refresh**. On my machine (3,933 peers, two monitors) it meant:

- ~4.6 s of shell CPU per poll (main thread stalls, visible desktop jank)
- ~15% average quickshell CPU
- delegate trees accumulating until the shell passed **7 GB RSS** over a workday

## Changes

- **Virtualized machine list** — the peers `Repeater`+`Column` becomes a clipped `ListView` with `reuseItems`; only the visible rows exist, and pooled rows are reused across refreshes.
- **Machine search** — filter field above the list (`/` focuses it, Escape clears), match count in the section header. A 4,000-row list isn't navigable by scrolling alone.
- **One shared copy menu** — a single `Popup` positioned at whichever row summoned it, instead of one instantiated per peer.
- **Change-detected refreshes** — the service only reassigns `peers`/`exitNodes`/`mullvadRegions` when the parsed content actually changed, so an unchanged poll rebuilds nothing.
- **Light polling while closed** — the periodic poll uses `tailscale status --json --peers=false` (~3 KB); the full peer list is fetched when the panel opens or on explicit refresh.

Keyboard navigation (j/k cursor, Enter → copy menu, taildrop send, panel tabbing) is preserved; the cursor and copy actions operate on the filtered list. Small tailnets look and behave exactly as before.

## Numbers (3,933-peer tailnet, two bars)

| | before | after |
|---|---|---|
| full refresh, shell CPU | ~4.6 s | ~0.17 s |
| steady-state average CPU | ~15% | <1% |
| shell RSS after hours of uptime | 7+ GB and climbing | ~520 MB, stable |

## Screenshot

Panel against a **synthetic 4,000-machine tailnet** (fake `tailscale` CLI used for the capture, so no real hostnames appear):

![tailscale panel with 4,000 machines: virtualized list and search field](https://raw.githubusercontent.com/iskakaushik/omarchy/tailscale-demo-assets/tailscale-panel-4k-tailnet.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)