### PR TITLE
Fix bitwarden floating window config on other chromium browsers

### DIFF
--- a/default/hypr/apps/bitwarden.lua
+++ b/default/hypr/apps/bitwarden.lua
@@ -1,6 +1,6 @@
 o.window("^(Bitwarden)$", { no_screen_share = true, tag = "+floating-window" })
 
-o.window("chrome-nngceckbapebfimnlniiiahkandclblb-Default", {
+o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)-nngceckbapebfimnlniiiahkandclblb-Default", {
   no_screen_share = true,
   tag = "+floating-window",
 })

--- a/default/hypr/apps/bitwarden.lua
+++ b/default/hypr/apps/bitwarden.lua
@@ -1,6 +1,6 @@
 o.window("^(Bitwarden)$", { no_screen_share = true, tag = "+floating-window" })
 
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)-nngceckbapebfimnlniiiahkandclblb-Default", {
+o.window("((google-)?[cC]hrom(e|ium)|[bB]rave(-browser)?|[mM]icrosoft-edge|Vivaldi-stable|helium)-nngceckbapebfimnlniiiahkandclblb-Default", {
   no_screen_share = true,
   tag = "+floating-window",
 })

--- a/default/hypr/apps/bitwarden.lua
+++ b/default/hypr/apps/bitwarden.lua
@@ -1,6 +1,8 @@
 o.window("^(Bitwarden)$", { no_screen_share = true, tag = "+floating-window" })
 
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave(-browser)?|[mM]icrosoft-edge|Vivaldi-stable|helium)-nngceckbapebfimnlniiiahkandclblb-Default", {
+o.window("(([cC]hrome|[bB]rave|Vivaldi-stable|helium)-nngceckbapebfimnlniiiahkandclblb-Default)|([mM]sedge-_jbkfoedolllekgbhcbcoahefnbanhhlh-Default)", {
   no_screen_share = true,
-  tag = "+floating-window",
+  float = true,
+  no_blur = true,
+  max_size = "480 650",
 })

--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -1,5 +1,5 @@
 -- Browser tags and styling.
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+o.window("((google-)?[cC]hrom(e|ium)|[bB]rave(-browser)?|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
 o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
 o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
 o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })


### PR DESCRIPTION
This config will make the floating window configuration work on other non-default chrome browsers.

Tested on all chromium based browsers (including ms edge)

## Before

<img width="2558" height="1548" alt="screenshot-2026-08-20_12-" src="https://github.com/user-attachments/assets/3bdafacd-b0a4-4bfd-8a82-e8d733b5a6e0" />


## After

(Screenshot tool intentionally redacted the contents, but it is working)

<img width="2532" height="1510" alt="screenshot-2026-08-26_16-43-59" src="https://github.com/user-attachments/assets/f8a184f2-6485-4f73-a35c-6566334da2c1" />



## Note

This only fixes it for chromium based browsers. The Firefox selector doesn't work because the class is just "firefox". Will leave as an opportunity for someone else to fix.

