### PR TITLE
Fix positional hotkeys for multi-surface bar widgets

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -529,6 +529,14 @@ Item {
     return true
   }
 
+  function toggleBarWidget(pluginId) {
+    var item = findPanelWidget(pluginId)
+    if (!item) return false
+    if (item.opened === true) item.close()
+    else item.open()
+    return true
+  }
+
   function isBarWidgetOpen(pluginId) {
     var item = findPanelWidget(pluginId)
     return !!item && item.opened === true

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -1020,8 +1020,8 @@ ShellRoot {
         ? shell.bar.panelWidgetIdAt(section, index)
         : ""
       if (!id) return "unknown"
-      shell.toggle(id, "{}")
-      return id
+      return shell.bar && typeof shell.bar.toggleBarWidget === "function"
+        && shell.bar.toggleBarWidget(id) ? id : "unknown"
     }
 
     function call(id: string, method: string, arg: string): string {

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -212,8 +212,12 @@ assert(
   'positional panels are one-based, and anything off the end lands on no slot'
 )
 assert(
-  /function togglePanelAt\(section: string, index: string\): string \{[\s\S]*?shell\.bar\.panelWidgetIdAt\(section, index\)[\s\S]*?shell\.toggle\(id, "\{\}"\)/.test(shellSource),
-  'shell toggles a bar panel by its position over IPC'
+  /function toggleBarWidget\(pluginId\) \{[\s\S]*?findPanelWidget\(pluginId\)[\s\S]*?item\.opened === true[\s\S]*?item\.close\(\)[\s\S]*?item\.open\(\)/.test(barSource),
+  'bar toggles the resolved live panel widget directly'
+)
+assert(
+  /function togglePanelAt\(section: string, index: string\): string \{[\s\S]*?shell\.bar\.panelWidgetIdAt\(section, index\)[\s\S]*?shell\.bar\.toggleBarWidget\(id\)/.test(shellSource),
+  'shell toggles a positional panel through its bar widget even when the plugin also has another surface'
 )
 
 const clockSlot = { id: 'clock' }


### PR DESCRIPTION
`togglePanelAt` resolved a bar widget ID, then routed it through generic `shell.toggle()`. For plugins with both `bar-widget` and `overlay`, such as Home Assistant, this opened the settings overlay instead of the bar panel.

Toggle the resolved live bar widget directly and cover it with a regression test.

Reported in https://github.com/konradk/hass/issues/11

Test: `bash test/shell.d/bar-test.sh`