### PR TITLE
Opt-in: keep AMD xHCI controllers awake to avoid dead USB after resume

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -211,7 +211,7 @@ show_share_menu() {
 }
 
 show_toggle_menu() {
-  local options="󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰂛  Notifications\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n  Direct Boot\n󰟵  Passwordless Sudo"
+  local options="󱄄  Screensaver\n󰔎  Nightlight\n󱫖  Idle Lock\n󰂛  Notifications\n󰍜  Top Bar\n󱂬  Workspace Layout\n  Window Gaps\n  1-Window Ratio\n󰍹  Monitor Scaling\n  Direct Boot\n󰟵  Passwordless Sudo\n󰾅  AMD xHCI Wake"
 
   case $(menu "Toggle" "$options") in
   *Screensaver*) omarchy-toggle-screensaver ;;
@@ -225,6 +225,7 @@ show_toggle_menu() {
   *Scaling*) omarchy-hyprland-monitor-scaling-cycle ;;
   *"Direct Boot"*) present_terminal omarchy-config-direct-boot ;;
   *"Passwordless Sudo"*) present_terminal omarchy-sudo-passwordless ;;
+  *"AMD xHCI Wake"*) present_terminal omarchy-toggle-amd-xhci-wakeup ;;
   *) back_to show_trigger_menu ;;
   esac
 }

--- a/bin/omarchy-toggle-amd-xhci-wakeup
+++ b/bin/omarchy-toggle-amd-xhci-wakeup
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Keep AMD xHCI controllers awake to avoid the resume dead-USB bug
+# omarchy:requires-sudo=true
+
+omarchy-toggle \
+  --enabled-notification "󰾅  AMD xHCI wake fix enabled" \
+  --disabled-notification "󰾅  AMD xHCI wake fix disabled" \
+  amd-xhci-wakeup
+
+source "$OMARCHY_PATH/install/config/hardware/amd/fix-xhci-resume.sh"

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -67,6 +67,8 @@ run_logged $OMARCHY_INSTALL/config/hardware/apple/fix-t2.sh
 
 run_logged $OMARCHY_INSTALL/config/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh
 
+run_logged $OMARCHY_INSTALL/config/hardware/amd/fix-xhci-resume.sh
+
 run_logged $OMARCHY_INSTALL/config/hardware/fix-bcm43xx.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-surface-keyboard.sh
 run_logged $OMARCHY_INSTALL/config/hardware/fix-yt6801-ethernet-adapter.sh

--- a/install/config/hardware/amd/fix-xhci-resume.sh
+++ b/install/config/hardware/amd/fix-xhci-resume.sh
@@ -1,12 +1,21 @@
 # Opt-in: keep AMD xHCI controllers awake to avoid the broken resume path.
 # Off by default to preserve laptop power draw (see basecamp/omarchy#6671).
 # Enable with: omarchy toggle amd-xhci-wakeup
-omarchy-toggle-enabled amd-xhci-wakeup || exit 0
+RULE=/etc/udev/rules.d/99-omarchy-amd-xhci-wakeup.rules
+
+if ! omarchy-toggle-enabled amd-xhci-wakeup; then
+  if [[ -f $RULE ]]; then
+    echo "AMD xHCI wake fix disabled. Removing rule..."
+    sudo rm -f "$RULE"
+    sudo udevadm control --reload-rules
+  fi
+  exit 0
+fi
 
 if lspci -nn | grep -qE "1022:(1587|15b6|15b7|15e0|15e1|15e5|1639|148c)"; then
   echo "AMD xHCI detected (resume bug). Keeping controllers awake..."
 
-  cat <<'EOF' | sudo tee /etc/udev/rules.d/99-omarchy-amd-xhci-wakeup.rules >/dev/null
+  cat <<'EOF' | sudo tee "$RULE" >/dev/null
 # AMD xHCI controllers die on resume (Bugzilla 221073, Ubuntu 2158539). Keep
 # them awake so the broken suspend->resume cycle never runs. Class-based match
 # (PCI class 0x0c0330) covers all current and future AMD xHCI device IDs.

--- a/install/config/hardware/amd/fix-xhci-resume.sh
+++ b/install/config/hardware/amd/fix-xhci-resume.sh
@@ -1,0 +1,18 @@
+# Opt-in: keep AMD xHCI controllers awake to avoid the broken resume path.
+# Off by default to preserve laptop power draw (see basecamp/omarchy#6671).
+# Enable with: omarchy toggle amd-xhci-wakeup
+omarchy-toggle-enabled amd-xhci-wakeup || exit 0
+
+if lspci -nn | grep -qE "1022:(1587|15b6|15b7|15e0|15e1|15e5|1639|148c)"; then
+  echo "AMD xHCI detected (resume bug). Keeping controllers awake..."
+
+  cat <<'EOF' | sudo tee /etc/udev/rules.d/99-omarchy-amd-xhci-wakeup.rules >/dev/null
+# AMD xHCI controllers die on resume (Bugzilla 221073, Ubuntu 2158539). Keep
+# them awake so the broken suspend->resume cycle never runs. Class-based match
+# (PCI class 0x0c0330) covers all current and future AMD xHCI device IDs.
+SUBSYSTEM=="pci", ATTR{vendor}=="0x1022", ATTR{class}=="0x0c0330", ATTR{power/control}="on", ATTR{d3cold_allowed}="0"
+EOF
+
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=pci --attr-match=vendor=0x1022
+fi

--- a/migrations/1787260348.sh
+++ b/migrations/1787260348.sh
@@ -1,0 +1,4 @@
+echo "Opt-in: keep AMD xHCI controllers awake on resume"
+
+# shellcheck source=install/config/hardware/amd/fix-xhci-resume.sh
+source "$OMARCHY_PATH/install/config/hardware/amd/fix-xhci-resume.sh"


### PR DESCRIPTION
Opt-in udev rule behind `omarchy toggle amd-xhci-wakeup`; keeps AMD xHCI controllers awake so the broken suspend→resume path (Bugzilla 221073, Ubuntu 2158539) never runs; off by default honoring #6671 (dhh: default-on raises laptop power draw; he asked to document instead — docs side lives in #7631); class-based match (0x0c0330 + vendor 0x1022) avoids device-ID whack-a-mole; sibling of #7044 (same power/control=on + d3cold_allowed=0 for the Intel TB3 xHCI).