### PR TITLE
Make the lock screen blank timeout configurable

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,8 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "blank": 5
   },
   "bar": {
     "position": "top",

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -13,7 +13,9 @@ $OMARCHY_PATH/config/omarchy/shell.json  # Canonical defaults
 ```
 
 The shell hot-reloads `shell.json` on save — no restart needed for layout
-changes. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+changes. `idle.screensaver` and `idle.lock` are seconds since user idle began,
+and `idle.blank` is seconds of inactivity on the lock screen before the
+backlight goes off.
 
 **Commands:** `omarchy restart shell`, `omarchy refresh shell`
 
@@ -50,3 +52,8 @@ automatically. If a change somehow fails to apply, force a reload with
 Set `idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json`,
 in seconds since user idle began. Example: "lock after ten minutes" means
 setting `idle.lock` to `600`.
+
+`idle.blank` is the third timing: seconds of inactivity on the lock screen
+before the display backlight goes off (default `5`). It counts from the last
+key or mouse input on the lock screen, not from when idle began. Example:
+"stop the lock screen going dark so fast" means raising `idle.blank`.

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -136,7 +136,8 @@ string on a miss.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "blank": 5
   },
   "bar": {
     "id": "omarchy.bar",
@@ -168,7 +169,7 @@ Rules:
 5. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
-7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+7. `idle.screensaver` and `idle.lock` are seconds since user idle began. `idle.blank` is seconds of inactivity on the lock screen before the backlight goes off, counted from the last input there rather than from when idle began.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -98,4 +98,19 @@ The logo it draws is yours to change, under _Style > Screensaver_. Upload a png 
 
 `Super + Ctrl + L` locks the machine. That runs the lock screen from the Omarchy shell, blanks the display, resets your keyboard layout to the first one so you're not typing your password in the wrong alphabet, and — if you have it running — locks 1Password on the way out.
 
+The display does not stay lit behind it. Five seconds after your last key or mouse input on the lock screen, the backlight goes off — the session is still locked, and the next touch brings the screen right back. Typing your password holds the light on while it is checked. Five seconds is short on purpose, and `idle.blank` is where you change it:
+
+```json
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 150,
+    "lock": 300,
+    "blank": 5
+  }
+}
+```
+
+Unlike the other two timings, that one counts from your last input on the lock screen rather than from the moment you went idle, so it applies to a lock you asked for with `Super + Ctrl + L` just as much as to one you idled into.
+
 The lock screen takes a password, and it'll take a fingerprint too once you've set one up. That, and the other ways to authenticate, are covered in [hardware authentication](37-hardware-authentication.md).

--- a/shell/plugins/lock/LockModel.js
+++ b/shell/plugins/lock/LockModel.js
@@ -1,0 +1,11 @@
+function secondsFromConfig(value, fallback) {
+  var n = Number(value)
+  if (!isFinite(n) || n < 0) return fallback
+  return Math.floor(n)
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    secondsFromConfig: secondsFromConfig
+  }
+}

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -540,6 +540,7 @@ Item {
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
         authenticating: root.authenticating,
+        blank: root.blankTimeoutSeconds,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt
       })

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -420,6 +420,11 @@ Item {
     interval: root.blankTimeoutSeconds * 1000
     repeat: false
     property double armedAt: 0
+    // A hot-reloaded timeout restarts the countdown from zero, so the arming
+    // timestamp has to move with it. Left behind, it reads to the guard below
+    // as a suspend gap, and the lock screen stays lit for another full
+    // interval after the edit.
+    onIntervalChanged: if (running) root.armBlankTimer()
     onTriggered: {
       // A countdown frozen by suspend fires right after resume, which would
       // blank the freshly woken unlock screen under the user. Wall-clock time

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 import Quickshell.Services.Pam
 import Quickshell.Wayland
 import qs.Commons
+import "LockModel.js" as LockModel
 
 Item {
   id: root
@@ -15,6 +16,9 @@ Item {
   readonly property string stateHome: home + "/.local/state"
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
+  readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
+  readonly property int defaultBlankSeconds: 5
+  readonly property int blankTimeoutSeconds: LockModel.secondsFromConfig(idleConfig.blank, defaultBlankSeconds)
 
   property bool lockRequested: false
   property bool pendingSessionLock: false
@@ -413,7 +417,7 @@ Item {
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    interval: root.blankTimeoutSeconds * 1000
     repeat: false
     property double armedAt: 0
     onTriggered: {

--- a/test/shell.d/lock-blank-runtime-test.sh
+++ b/test/shell.d/lock-blank-runtime-test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  # Qt can still be flushing its cache as the process dies, so a first pass can
+  # walk a tree that grows behind it. A second one clears what landed late.
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR" 2>/dev/null || rm -rf "$TMPDIR" 2>/dev/null || true
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+require_compositor "lock blank timeout runtime test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping lock blank timeout runtime test"
+  exit 0
+fi
+
+require_command jq
+
+shell_ipc() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" "$@"
+}
+
+shell_ipc_quiet() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" -q "$@"
+}
+
+fail_with_log() {
+  local description="$1"
+  sed -n '1,240p' "$log" >&2
+  fail "$description"
+}
+
+TMPDIR=$(mktemp -d)
+test_root="$TMPDIR/omarchy"
+test_home="$TMPDIR/home"
+stub_bin="$TMPDIR/bin"
+log="$TMPDIR/quickshell.log"
+shell_config="$test_home/.config/omarchy/shell.json"
+mkdir -p "$test_root" "$test_home/.config/omarchy" "$stub_bin"
+cp -a "$ROOT/shell" "$test_root/shell"
+ln -s "$ROOT/config" "$test_root/config"
+ln -s "$ROOT/bin" "$test_root/bin"
+
+# The test shell shares the session's idle notifications, so keep its own idle
+# deadlines out of reach and stub what an idle cycle would reach for. Nothing
+# here should dim or lock the desktop running the suite.
+for stubbed in omarchy-system-lock omarchy-launch-screensaver omarchy-brightness-display omarchy-brightness-keyboard; do
+  cat >"$stub_bin/$stubbed" <<'SH_STUB'
+#!/bin/bash
+exit 0
+SH_STUB
+  chmod +x "$stub_bin/$stubbed"
+done
+
+write_shell_config() {
+  local blank_entry="$1"
+
+  cat >"$shell_config" <<JSON
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 36000,
+    "lock": 36000$blank_entry
+  },
+  "bar": {
+    "layout": {
+      "left": [],
+      "center": [{ "id": "omarchy.clock" }],
+      "right": []
+    }
+  },
+  "plugins": []
+}
+JSON
+}
+
+blank_timeout() {
+  shell_ipc lock status 2>/dev/null | jq -r '.blank // "missing"'
+}
+
+await_blank_timeout() {
+  local expected="$1"
+  local seen=""
+
+  for _ in {1..80}; do
+    seen=$(blank_timeout)
+    [[ $seen == "$expected" ]] && return 0
+    sleep 0.1
+  done
+
+  printf 'expected: %s\nactual:   %s\n' "$expected" "$seen" >&2
+  return 1
+}
+
+write_shell_config ',
+    "blank": 42'
+
+OMARCHY_PATH="$test_root" \
+HOME="$test_home" \
+XDG_CONFIG_HOME="$test_home/.config" \
+XDG_CACHE_HOME="$test_home/.cache" \
+XDG_STATE_HOME="$test_home/.local/state" \
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  quickshell -p "$test_root/shell" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  shell_ipc_quiet shell ping >/dev/null 2>&1 && break
+  kill -0 "$QS_PID" 2>/dev/null || fail_with_log "test shell exited before IPC became available"
+  sleep 0.1
+done
+
+shell_ipc_quiet shell ping >/dev/null 2>&1 || fail_with_log "test shell answers IPC"
+
+await_blank_timeout 42 || fail_with_log "lock screen adopts the configured blank timeout"
+pass "lock screen adopts the configured blank timeout"
+
+write_shell_config ',
+    "blank": 9'
+await_blank_timeout 9 || fail_with_log "lock screen picks up an edited blank timeout without a restart"
+pass "lock screen picks up an edited blank timeout without a restart"
+
+write_shell_config ''
+await_blank_timeout 5 || fail_with_log "lock screen falls back to the five second default"
+pass "lock screen falls back to the five second default"
+
+write_shell_config ',
+    "blank": "nonsense"'
+await_blank_timeout 5 || fail_with_log "lock screen ignores a nonsense blank timeout"
+pass "lock screen ignores a nonsense blank timeout"
+
+# The blank timeout is read from a plugin that can lock the desktop running the
+# suite. Prove the checks above never asked it to.
+if grep -qE 'omarchy (lock|idle) [^ ]+ (lock-requested|lock-system)' "$log"; then
+  fail_with_log "the runtime check leaves the session unlocked"
+fi
+pass "the runtime check leaves the session unlocked"

--- a/test/shell.d/lock-blank-timeout-test.sh
+++ b/test/shell.d/lock-blank-timeout-test.sh
@@ -31,6 +31,13 @@ assert(
   /id: idleBlankTimer\s*interval: root\.blankTimeoutSeconds \* 1000/.test(serviceQml),
   'the blank timer takes its interval from the configured timeout'
 )
+
+// Qt restarts a running timer's countdown when the interval changes. Leaving
+// `armedAt` behind makes the next trigger read the edit as a suspend gap.
+assert(
+  /onIntervalChanged: if \(running\) root\.armBlankTimer\(\)/.test(serviceQml),
+  'an edited timeout re-arms the blank timer instead of tripping the suspend guard'
+)
 JS
 
 jq -e '.idle.blank == 5' "$ROOT/config/omarchy/shell.json" >/dev/null

--- a/test/shell.d/lock-blank-timeout-test.sh
+++ b/test/shell.d/lock-blank-timeout-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const lock = requireFromRoot('shell/plugins/lock/LockModel.js')
+
+assertEqual(lock.secondsFromConfig(30, 5), 30, 'lock blank takes the configured seconds')
+assertEqual(lock.secondsFromConfig('30.9', 5), 30, 'lock blank floors configured seconds')
+assertEqual(lock.secondsFromConfig(0, 5), 0, 'lock blank allows blanking immediately')
+assertEqual(lock.secondsFromConfig(-1, 5), 5, 'lock blank rejects negative seconds')
+assertEqual(lock.secondsFromConfig('nope', 5), 5, 'lock blank rejects invalid seconds')
+assertEqual(lock.secondsFromConfig(undefined, 5), 5, 'lock blank falls back when unset')
+
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+assert(
+  /readonly property int defaultBlankSeconds: 5/.test(serviceQml),
+  'an unconfigured lock screen still blanks after five seconds'
+)
+
+assert(
+  /readonly property int blankTimeoutSeconds: LockModel\.secondsFromConfig\(idleConfig\.blank, defaultBlankSeconds\)/.test(serviceQml),
+  'the blank timeout comes from idle.blank in shell.json'
+)
+
+assert(
+  /id: idleBlankTimer\s*interval: root\.blankTimeoutSeconds \* 1000/.test(serviceQml),
+  'the blank timer takes its interval from the configured timeout'
+)
+JS
+
+jq -e '.idle.blank == 5' "$ROOT/config/omarchy/shell.json" >/dev/null
+pass "default shell.json ships the lock blank timeout"


### PR DESCRIPTION
The lock screen blanks the display five seconds after your last key or mouse input, and that five was hardcoded as `interval: 5000` on the blank timer in `shell/plugins/lock/Service.qml`. It is a good default, but it is the one lock screen timing with no way out: the screensaver and lock deadlines are already in `shell.json`, so a user who finds the blank too eager — hunting for keys on a long passphrase, reading what is on the lock screen, waiting on a fingerprint prompt — has to clone the whole lock plugin to change one number, and then owns the PAM code forever.

This reads the interval from `idle.blank`, next to the two timings the shell already takes from that block:

```json
{
  "version": 1,
  "idle": {
    "screensaver": 150,
    "lock": 300,
    "blank": 5
  }
}
```

It defaults to `5`, so an unconfigured machine behaves exactly as before, and it hot-reloads with the rest of `shell.json`. Everything else about the blank stays as it is: password entry still holds the display up, the passive fingerprint wait still does not, and the post-resume wall-clock guard still measures against the configured interval.

The clamp lives in a plugin-local `LockModel.js` rather than reusing the idle plugin's identical `secondsFromConfig`. `omarchy-plugin-clone` copies a plugin's own directory, so a cross-plugin import would resolve in the tree and break inside a clone.

Docs: `docs/omarchy-shell.md` rule 7, the shell.json samples, the shipped `plugins.md` skill, and the lock screen section of `manual/13-toggles-idle-screensaver.md`, which never documented the blank at all.

### Verification

- `test/shell.d/lock-blank-runtime-test.sh` launches a shell against a temporary `shell.json` and reads the timeout back over `lock status`: configured (42), edited to 9 with no restart, unset (5), nonsense (5). `lock status` gained a `blank` field to report it, alongside the timeouts `idle status` already exposes, so the value also shows up in `omarchy debug idle`. The test keeps the desktop running it out of the way — idle deadlines hours out, lock and brightness commands stubbed, and a final assertion that neither plugin logged a lock request.
- `test/shell.d/lock-blank-timeout-test.sh` covers the clamp (floor, negative, non-numeric, unset, `0`), the five-second default, the timer binding, and the re-arm on an edited interval.
- `test/shell.d/lock-blank-fingerprint-test.sh` still passes — its regexes describe the gating, which this does not touch.
- `./test/all`: 183 of 187 shell test files pass. The four failures are environmental in my session, not from this change — `config`, `snapper` and `unowned-system-paths` want an `omarchy-pkgs` checkout I do not have, and `runtime-smoke` fails identically on the base commit because a real shell is already registered on this desktop.
- Not covered: driving a real session lock and watching the backlight actually drop at the configured second. That wants `test/acceptance.d/` in the disposable VM rather than a developer's live desktop; say the word and I will add it here.
