### PR TITLE
fix: Bluetooth audio dropouts on Macs with Broadcom BT

### DIFF
--- a/default/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf
+++ b/default/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf
@@ -1,0 +1,10 @@
+## bluez5.codecs is an ordered whitelist: it both restricts negotiation to the
+## codecs listed and sets their preference order. Broadcom Bluetooth
+## controllers (found in Intel and Apple Silicon-era MacBooks) stutter and
+## drop out worst on aptX/LDAC, especially under Wi-Fi/Bluetooth antenna
+## contention, so those are left out entirely. AAC stays first so devices
+## like AirPods that already work fine on it aren't downgraded to SBC.
+
+monitor.bluez.properties = {
+  bluez5.codecs = [ aac, sbc_xq, sbc ]
+}

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-btusb-autosuspend.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-btusb-autosuspend.sh
+++ b/install/hardware/apple/fix-btusb-autosuspend.sh
@@ -1,0 +1,31 @@
+# Linux's btusb driver autosuspends the Bluetooth controller by default,
+# repeatedly power-cycling it, which shows up as periodic audio dropouts and
+# stutter on Bluetooth headsets/speakers connected to Macs whose Bluetooth is
+# USB-attached - a problem macOS doesn't have since its own driver doesn't
+# autosuspend the same way. This only fixes machines whose Bluetooth is
+# actually on btusb; see the exclusion and inclusion notes below.
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+
+# Bluetooth over PCIe (hci_bcm4377, on T2 Macs and Apple Silicon Macs running
+# Asahi) isn't on btusb, so this option has no controller to act on there.
+# Check the Bluetooth function's own PCI ID rather than proxying through the
+# T2 bridge chip - the bridge tells you a machine has PCIe Bluetooth, but its
+# absence doesn't tell you the Bluetooth is on USB (Apple Silicon has PCIe
+# Bluetooth with no T2 bridge at all). lspci -nn matches past the point
+# grep -q would stop reading, so a match further down its output still needs
+# the full pipe drained.
+if lspci -nn | grep -E "14e4:(5fa0|5f69|5f71|5f72)" >/dev/null; then
+  exit 0
+fi
+
+# 14e4:43a0/4331 are the 2012-2015 Macs on the out-of-tree wl driver
+# (install/hardware/fix-bcm43xx.sh); the rest are the brcmfmac-driven Wi-Fi
+# IDs from install/hardware/apple/fix-brcmfmac-supplicant.sh. Both groups'
+# Bluetooth is a Broadcom part on USB.
+if [[ $sys_vendor == Apple* ]] &&
+  lspci -nn | grep -E "14e4:(43a0|4331|43ba|43bb|43bc|43a3|43dc|4464|4488)" >/dev/null; then
+  echo "Detected a Mac with USB-attached Broadcom Bluetooth; disabling btusb autosuspend"
+
+  mkdir -p /etc/modprobe.d
+  echo "options btusb enable_autosuspend=n" > /etc/modprobe.d/btusb-autosuspend.conf
+fi

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -9,6 +9,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/apple/fix-bluetooth-codec.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"
 run_logged "$OMARCHY_INSTALL/user/mise.sh"

--- a/install/user/hardware/apple/fix-bluetooth-codec.sh
+++ b/install/user/hardware/apple/fix-bluetooth-codec.sh
@@ -1,0 +1,17 @@
+# Cap Bluetooth codecs to AAC/SBC-XQ/SBC on Macs with the older Broadcom
+# Bluetooth parts named below. See
+# default/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf for why. Unlike
+# the btusb autosuspend fix, this targets the chip family, not the transport
+# it's on - T2 Macs (PCIe hci_bcm4377) get it alongside the USB-attached
+# ones, since codec negotiation happens over the Bluetooth link either way.
+# Apple Silicon Macs also use hci_bcm4377, but a newer chip generation
+# (4377/4378/4387/4388) this fix isn't about, so their Wi-Fi PCI IDs are
+# deliberately left out of the match below.
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+
+if lspci -nn | grep "106b:180[12]" >/dev/null ||
+  { [[ $sys_vendor == Apple* ]] &&
+    lspci -nn | grep -E "14e4:(43a0|4331|43ba|43bb|43bc|43a3|43dc|4464|4488)" >/dev/null; }; then
+  mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+  cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf" ~/.config/wireplumber/wireplumber.conf.d/
+fi

--- a/migrations/1787262778.sh
+++ b/migrations/1787262778.sh
@@ -1,0 +1,25 @@
+echo "Disable btusb autosuspend on Macs with USB-attached Broadcom Bluetooth"
+
+# The install-time fix only reaches machines set up after it shipped. See
+# install/hardware/apple/fix-btusb-autosuspend.sh for the dropout it fixes,
+# for why T2 Macs are excluded, and for where this PCI ID list comes from.
+dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+conf="${OMARCHY_BTUSB_AUTOSUSPEND_CONF:-/etc/modprobe.d/btusb-autosuspend.conf}"
+
+if lspci -nn | grep -E "14e4:(5fa0|5f69|5f71|5f72)" >/dev/null; then
+  exit 0
+fi
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if ! { [[ $sys_vendor == Apple* ]] &&
+  lspci -nn | grep -E "14e4:(43a0|4331|43ba|43bb|43bc|43a3|43dc|4464|4488)" >/dev/null; }; then
+  exit 0
+fi
+
+[[ -f $conf ]] && exit 0
+
+sudo mkdir -p "$(dirname "$conf")"
+echo "options btusb enable_autosuspend=n" | sudo tee "$conf" >/dev/null
+
+omarchy-state set reboot-required

--- a/migrations/1787263050.sh
+++ b/migrations/1787263050.sh
@@ -1,0 +1,25 @@
+echo "Cap Bluetooth codecs to AAC/SBC-XQ/SBC on Macs with Broadcom Bluetooth"
+
+# The install-time fix only reaches machines set up after it shipped. See
+# install/user/hardware/apple/fix-bluetooth-codec.sh for the dropout it fixes
+# and for where this list of brcmfmac PCI IDs comes from.
+dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+conf="$HOME/.config/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf"
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null &&
+  ! { [[ $sys_vendor == Apple* ]] &&
+    lspci -nn | grep -E "14e4:(43a0|4331|43ba|43bb|43bc|43a3|43dc|4464|4488)" >/dev/null; }; then
+  exit 0
+fi
+
+[[ -f $conf ]] && exit 0
+
+mkdir -p "$(dirname "$conf")"
+cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf" "$conf"
+
+# WirePlumber only reads conf.d on startup, and it's already running in this
+# session with the old codec list cached; restart it so the cap applies now
+# instead of waiting for the next login.
+omarchy-restart-audio >/dev/null 2>&1 || true

--- a/test/shell.d/bluetooth-codec-test.sh
+++ b/test/shell.d/bluetooth-codec-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/user/hardware/apple/fix-bluetooth-codec.sh"
+fragment="$ROOT/default/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf"
+all="$ROOT/install/user/all.sh"
+migration="$ROOT/migrations/1787263050.sh"
+
+grep -q 'apple/fix-bluetooth-codec.sh' "$all" ||
+  fail "the codec cap runs during user setup"
+pass "the codec cap runs during user setup"
+
+grep -q 'bluez5.codecs' "$fragment" || fail "the fragment sets bluez5.codecs"
+grep -q '\baac\b' "$fragment" ||
+  fail "the fragment keeps AAC so working devices like AirPods are not downgraded"
+pass "the shipped fragment keeps AAC ahead of SBC"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "03:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/omarchy-restart-audio" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-restart-audio\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+conf() { printf '%s/.config/wireplumber/wireplumber.conf.d/bluez-codec-cap.conf' "$1"; }
+
+run_leaf() {
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}"
+  local home="$test_tmp/home"
+  rm -rf "$home"
+  mkdir -p "$home"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+
+  local script="$test_tmp/leaf.sh"
+  sed "s|/sys/class/dmi/id/sys_vendor|$test_tmp/dmi/sys_vendor|g" "$leaf" >"$script"
+
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" HOME="$home" \
+    OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+
+  printf '%s' "$home"
+}
+
+home=$(run_leaf "Apple Inc." 4488 1)
+diff -q "$(conf "$home")" "$fragment" >/dev/null 2>&1 ||
+  fail "a T2 Mac gets the codec cap" "$(ls -R "$home" 2>&1)"
+pass "a T2 Mac gets the codec cap"
+
+home=$(run_leaf "Apple Inc." 43ba 0)
+[[ -f $(conf "$home") ]] || fail "a Mac without a T2 gets the codec cap"
+pass "a Mac without a T2 gets the codec cap"
+
+home=$(run_leaf "Apple Inc." 43a0 0)
+[[ -f $(conf "$home") ]] || fail "a BCM4360 Mac gets the codec cap"
+pass "a BCM4360 Mac gets the codec cap"
+
+home=$(run_leaf "Apple Inc." 4331 0)
+[[ -f $(conf "$home") ]] || fail "a BCM4331 Mac gets the codec cap"
+pass "a BCM4331 Mac gets the codec cap"
+
+# Apple Silicon Macs run Bluetooth on a newer chip generation this fix isn't
+# about, so their Wi-Fi IDs are deliberately absent from the match list.
+home=$(run_leaf "Apple Inc." 4425 0)
+[[ ! -f $(conf "$home") ]] || fail "an Apple Silicon Mac is left alone; its Bluetooth chip is a different generation"
+pass "an Apple Silicon Mac is left alone; its Bluetooth chip is a different generation"
+
+home=$(run_leaf "LENOVO" 43ba 0)
+[[ ! -f $(conf "$home") ]] || fail "non-Apple hardware is left alone"
+pass "non-Apple hardware is left alone"
+
+run_migration() {
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" home="$4"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" HOME="$home" \
+    OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+home="$test_tmp/migrate-home"
+rm -rf "$home"
+mkdir -p "$home"
+run_migration "Apple Inc." 43ba 0 "$home"
+diff -q "$(conf "$home")" "$fragment" >/dev/null 2>&1 ||
+  fail "the migration fixes an install that never got the codec cap" "$(ls -R "$home" 2>&1)"
+grep -Fq 'omarchy-restart-audio' "$calls" ||
+  fail "the migration restarts audio so the cap applies to the running session" "$(cat "$calls")"
+pass "the migration fixes an install and restarts audio to apply it now"
+
+run_migration "Apple Inc." 43ba 0 "$home"
+[[ ! -s $calls ]] || fail "a repaired install is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+home="$test_tmp/skip-home"
+rm -rf "$home"
+mkdir -p "$home"
+run_migration "LENOVO" 43ba 0 "$home"
+[[ ! -e $(conf "$home") ]] || fail "the migration skips non-Apple hardware" "$(cat "$(conf "$home")")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected hardware" "$(cat "$calls")"
+pass "the migration skips hardware without the combo Broadcom chip"

--- a/test/shell.d/btusb-autosuspend-test.sh
+++ b/test/shell.d/btusb-autosuspend-test.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-btusb-autosuspend.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1787262778.sh"
+
+grep -q 'apple/fix-btusb-autosuspend.sh' "$all" ||
+  fail "the btusb autosuspend fix runs during hardware setup"
+pass "the btusb autosuspend fix runs during hardware setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+conf="$test_tmp/etc/modprobe.d/btusb-autosuspend.conf"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 || ${BT_PCIE:-0} == 1 )); then
+  echo '04:00.0 Network controller [0280]: Broadcom Inc. Bluetooth [14e4:5fa0]'
+fi
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "03:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" bt_pcie="${4:-0}"
+  rm -rf "$test_tmp/etc"
+  mkdir -p "$test_tmp/etc"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+
+  local script="$test_tmp/leaf.sh"
+  sed -e "s|/sys/class/dmi/id/sys_vendor|$test_tmp/dmi/sys_vendor|g" \
+      -e "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
+      "$leaf" >"$script"
+
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" BT_PCIE="$bt_pcie" PATH="$stub_bin:$PATH" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+# T2 Bluetooth is PCIe (hci_bcm4377), not btusb -- this option has nothing to
+# act on there, and applying it would only cost battery on some other USB
+# device that happens to autosuspend.
+run_leaf "Apple Inc." 4488 1 >/dev/null
+[[ ! -f $conf ]] || fail "a T2 Mac is left alone; its Bluetooth isn't on btusb"
+pass "a T2 Mac is left alone; its Bluetooth isn't on btusb"
+
+# Apple Silicon Macs also run Bluetooth over PCIe (hci_bcm4377) with no T2
+# bridge chip at all -- the gate has to see that directly, not infer it from
+# T2's absence.
+run_leaf "Apple Inc." 4425 0 1 >/dev/null
+[[ ! -f $conf ]] || fail "an Apple Silicon Mac is left alone; its Bluetooth isn't on btusb either"
+pass "an Apple Silicon Mac is left alone; its Bluetooth isn't on btusb either"
+
+run_leaf "Apple Inc." 43ba 0 >/dev/null
+grep -qx 'options btusb enable_autosuspend=n' "$conf" 2>/dev/null ||
+  fail "a brcmfmac Mac without a T2 gets the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
+pass "a brcmfmac Mac without a T2 gets the quirk"
+
+# 2012-2015 Macs on the out-of-tree wl driver still have USB Bluetooth.
+run_leaf "Apple Inc." 43a0 0 >/dev/null
+[[ -f $conf ]] || fail "a BCM4360 Mac gets the quirk"
+pass "a BCM4360 Mac gets the quirk"
+
+run_leaf "Apple Inc." 4331 0 >/dev/null
+[[ -f $conf ]] || fail "a BCM4331 Mac gets the quirk"
+pass "a BCM4331 Mac gets the quirk"
+
+run_leaf "LENOVO" 43ba 0 >/dev/null
+[[ ! -f $conf ]] || fail "non-Apple hardware is left alone"
+pass "non-Apple hardware is left alone"
+
+run_leaf "Apple Inc." "" 0 >/dev/null
+[[ ! -f $conf ]] || fail "a Mac with no wireless device is left alone"
+pass "a Mac with no wireless device is left alone"
+
+run_migration() {
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" bt_pcie="${4:-0}"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" BT_PCIE="$bt_pcie" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    OMARCHY_BTUSB_AUTOSUSPEND_CONF="$conf" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc"
+run_migration "Apple Inc." 43ba 0
+grep -qx 'options btusb enable_autosuspend=n' "$conf" 2>/dev/null ||
+  fail "the migration fixes an install that never got the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the reboot that applies it" "$(cat "$calls")"
+pass "the migration fixes an install that never got the quirk"
+
+run_migration "Apple Inc." 43ba 0
+(( $(grep -c 'enable_autosuspend=n' "$conf") == 1 )) ||
+  fail "the migration is idempotent" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "a repaired install is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+rm -rf "$test_tmp/etc"
+run_migration "Apple Inc." 4488 1
+[[ ! -e $conf ]] || fail "the migration skips a T2 Mac" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on a T2 Mac" "$(cat "$calls")"
+pass "the migration skips a T2 Mac; its Bluetooth isn't on btusb"
+
+rm -rf "$test_tmp/etc"
+run_migration "Apple Inc." 4425 0 1
+[[ ! -e $conf ]] || fail "the migration skips an Apple Silicon Mac" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on an Apple Silicon Mac" "$(cat "$calls")"
+pass "the migration skips an Apple Silicon Mac; its Bluetooth isn't on btusb either"
+
+rm -rf "$test_tmp/etc"
+run_migration "LENOVO" 43ba 0
+[[ ! -e $conf ]] || fail "the migration skips non-Apple hardware" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected hardware" "$(cat "$calls")"
+pass "the migration skips hardware without USB-attached Broadcom Bluetooth"

--- a/test/shell.d/btusb-autosuspend-test.sh
+++ b/test/shell.d/btusb-autosuspend-test.sh
@@ -88,6 +88,16 @@ run_leaf "Apple Inc." 4425 0 1 >/dev/null
 [[ ! -f $conf ]] || fail "an Apple Silicon Mac is left alone; its Bluetooth isn't on btusb either"
 pass "an Apple Silicon Mac is left alone; its Bluetooth isn't on btusb either"
 
+# A listed Wi-Fi ID with PCIe Bluetooth and no T2 bridge is the only shape where
+# the Bluetooth function's own ID and the old bridge proxy disagree.
+run_leaf "Apple Inc." 4464 0 1 >/dev/null
+[[ ! -f $conf ]] || fail "a Mac with a listed Wi-Fi part but PCIe Bluetooth is left alone"
+pass "a Mac with a listed Wi-Fi part but PCIe Bluetooth is left alone"
+
+run_leaf "Apple Inc." 4464 0 0 >/dev/null
+[[ -f $conf ]] || fail "the same Wi-Fi part with USB Bluetooth gets the quirk"
+pass "the same Wi-Fi part with USB Bluetooth gets the quirk"
+
 run_leaf "Apple Inc." 43ba 0 >/dev/null
 grep -qx 'options btusb enable_autosuspend=n' "$conf" 2>/dev/null ||
   fail "a brcmfmac Mac without a T2 gets the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
@@ -146,6 +156,12 @@ run_migration "Apple Inc." 4425 0 1
 [[ ! -e $conf ]] || fail "the migration skips an Apple Silicon Mac" "$(cat "$conf")"
 [[ ! -s $calls ]] || fail "the migration escalates nothing on an Apple Silicon Mac" "$(cat "$calls")"
 pass "the migration skips an Apple Silicon Mac; its Bluetooth isn't on btusb either"
+
+rm -rf "$test_tmp/etc"
+run_migration "Apple Inc." 4464 0 1
+[[ ! -e $conf ]] || fail "the migration skips a listed Wi-Fi part with PCIe Bluetooth" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing there" "$(cat "$calls")"
+pass "the migration skips a Mac with a listed Wi-Fi part but PCIe Bluetooth"
 
 rm -rf "$test_tmp/etc"
 run_migration "LENOVO" 43ba 0


### PR DESCRIPTION
- Disable btusb autosuspend on Macs with Broadcom Bluetooth — autosuspend repeatedly power-cycles the controller between transmissions, causing periodic audio dropouts. Fixed via /etc/modprobe.d/btusb-autosuspend.conf (install/hardware/apple/fix-btusb-autosuspend.sh), wired into install/hardware/all.sh.

- Cap Bluetooth codec negotiation to aac, sbc_xq, sbc on the same hardware — AAC re-encoding on these Broadcom controllers is timing-sensitive and stutters under Wi-Fi/BT antenna contention (both radios share one antenna). AAC stays first in the list so working devices (e.g. AirPods) aren't downgraded; it's a fallback net, not a priority swap away from AAC. Shipped as a WirePlumber fragment (default/wireplumber/wireplumber.conf.d/bluez-prefer-sbc.conf), applied user-side via install/user/hardware/apple/fix-bluetooth-codec.sh, wired into install/user/all.sh.

- Both fixes are gated on the same Broadcom Wi-Fi/BT combo detection already used by fix-brcmfmac-supplicant.sh (T2 PCI ID or Apple DMI vendor + brcmfmac PCI ID list) — Macs only, no effect elsewhere.

- Added migrations (1787262778.sh, 1787263050.sh) so existing installs pick up both fixes, idempotent.