### PR TITLE
Fix Codex usage collection on 0.149

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "on-request", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -14,7 +14,7 @@ cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
 if [[ -n ${CODEX_ARGS_FILE:-} ]]; then
-  printf '%s\n' "$*" >"$CODEX_ARGS_FILE"
+  printf '%s\0' "$@" >"$CODEX_ARGS_FILE"
 fi
 
 while read -r request; do
@@ -47,8 +47,13 @@ EOF
 result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" CODEX_ARGS_FILE="$TEST_HOME/codex-args" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
 
-[[ $(<"$TEST_HOME/codex-args") == "-s read-only -a on-request app-server" ]] ||
-  fail "Codex collector uses the supported approval policy" "$(<"$TEST_HOME/codex-args")"
+# NUL-separated, so the assertion sees argument boundaries: a single "-a on-request"
+# would flatten to the same text as two arguments but is not a policy codex accepts.
+expected_args=(-s read-only -a on-request app-server)
+mapfile -d '' -t codex_args <"$TEST_HOME/codex-args"
+
+[[ ${codex_args[*]@Q} == "${expected_args[*]@Q}" ]] ||
+  fail "Codex collector uses the supported approval policy" "${codex_args[*]@Q}"
 pass "Codex collector uses the supported approval policy"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,10 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+if [[ -n ${CODEX_ARGS_FILE:-} ]]; then
+  printf '%s\n' "$*" >"$CODEX_ARGS_FILE"
+fi
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -40,8 +44,12 @@ cat >"$session" <<EOF
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}}}}
 EOF
 
-result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" CODEX_ARGS_FILE="$TEST_HOME/codex-args" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(<"$TEST_HOME/codex-args") == "-s read-only -a on-request app-server" ]] ||
+  fail "Codex collector uses the supported approval policy" "$(<"$TEST_HOME/codex-args")"
+pass "Codex collector uses the supported approval policy"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"


### PR DESCRIPTION
## Changes

- replace Codex's removed `untrusted` approval policy with `on-request`
- retain the existing `read-only` app-server sandbox
- assert the collector's exact app-server launch arguments in its regression test

`on-request` is supported by Codex 0.148 and restores authenticated limits on 0.149.

Fixes #7648

## Tests

- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- `./test/cli`
- live `bin/omarchy-agent-usage-codex --limits-only` against Codex 0.149.0
