### PR TITLE
Give session.slice CPU weight over app.slice so builds cannot stall input

### DIFF
--- a/default/systemd/user/session.slice.d/10-cpuweight.conf
+++ b/default/systemd/user/session.slice.d/10-cpuweight.conf
@@ -1,0 +1,24 @@
+# Keep the compositor responsive while apps saturate the CPU.
+#
+# Hyprland runs in session.slice, as wayland-wm@hyprland.desktop.service, next
+# to the shell, PipeWire, the portals and D-Bus. Everything the user launches
+# lands in app.slice/app-*.scope: browsers, terminals, and whatever those
+# terminals start -- cargo, make, ninja, qmlls, language servers, an agent or
+# three in worktrees. Both slices ship with cpu.weight=100, so when a couple
+# of builds pin every core the compositor's input loop waits its turn like any
+# compiler thread. libinput then logs "event processing lagging behind by
+# N ms, your system is too slow", the pointer stutters, and key events queue
+# up until the scheduler comes back around.
+#
+# Raising session.slice to 1000 gives the session a 10:1 share over app.slice
+# (background.slice is already 30). CPU weight only arbitrates under
+# contention, so an idle machine behaves exactly as before and builds still
+# get every core the compositor is not using at that instant -- which is
+# almost all of them. The compositor just stops losing the argument.
+#
+# Nice or realtime on Hyprland alone would not do this: nice is per thread and
+# autogroup flattens it across sessions, and SCHED_FIFO on a compositor that
+# ever spins is a hard input lock. The slice is where the whole interactive
+# tier already lives, so weight it as one.
+[Slice]
+CPUWeight=1000

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -124,6 +124,7 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ applications/mimeapps.list                         /usr/share/applications/mimeapps.list
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
+  ├─ systemd/user/session.slice.d/10-cpuweight.conf     /usr/lib/systemd/user/session.slice.d/
   ├─ systemd/system-sleep/{force-igpu,
   │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/

--- a/migrations/1785424256.sh
+++ b/migrations/1785424256.sh
@@ -26,6 +26,6 @@ fi
 # Pick up /usr/lib/systemd/user/app.slice.d/10-oomd.conf without waiting for
 # the next login. That drop-in is what marks app.slice as a kill candidate;
 # until the user manager reloads and reports it, oomd is running with nothing
-# to act on. An `omarchy update` over SSH or from a TTY has no user manager to
-# reload, and there the next graphical login picks it up on its own.
+# to act on. There is one user manager per user, not per session, so this also
+# reaches the graphical session when `omarchy update` runs over SSH or a TTY.
 systemctl --user daemon-reload >/dev/null 2>&1 || true

--- a/migrations/1787276689.sh
+++ b/migrations/1787276689.sh
@@ -3,14 +3,17 @@ echo "Give the session slice CPU priority over apps so builds cannot stall input
 # New installs get /usr/lib/systemd/user/session.slice.d/10-cpuweight.conf
 # with omarchy-settings. Existing sessions only apply a slice drop-in when the
 # user manager reloads, and the weight takes effect live -- no relogin needed.
-# An `omarchy update` from SSH or a TTY has no user manager to reload; there
-# the next graphical login picks it up on its own.
+# There is one user manager per user, not per session, so this also reaches
+# the graphical session when `omarchy update` runs from SSH or a TTY.
 systemctl --user daemon-reload >/dev/null 2>&1 || true
 
 # Migrations run once. If this one lands before the package that ships the
-# drop-in, apply the same weight for the running session only (--runtime
-# writes under /run, nothing persists), so the user gets it now and the
-# packaged file takes over at the next login without a second migration.
+# drop-in, apply the same weight for the running user manager only. --runtime
+# writes /run/user/$UID/systemd/user.control/session.slice.d/50-CPUWeight.conf,
+# which outlives nothing but the manager itself (it is gone once the user has
+# fully logged out), so the packaged file takes over from the next login on
+# without a second migration. Until then the runtime drop-in sorts after and
+# outranks the packaged one; both say 1000, so nothing differs.
 if [[ ! -f /usr/lib/systemd/user/session.slice.d/10-cpuweight.conf ]]; then
   systemctl --user set-property --runtime session.slice CPUWeight=1000 >/dev/null 2>&1 || true
 fi

--- a/migrations/1787276689.sh
+++ b/migrations/1787276689.sh
@@ -1,8 +1,16 @@
 echo "Give the session slice CPU priority over apps so builds cannot stall input"
 
 # New installs get /usr/lib/systemd/user/session.slice.d/10-cpuweight.conf
-# with the package. Existing sessions only apply a slice drop-in when the user
-# manager reloads, and the weight takes effect live -- no relogin needed.
+# with omarchy-settings. Existing sessions only apply a slice drop-in when the
+# user manager reloads, and the weight takes effect live -- no relogin needed.
 # An `omarchy update` from SSH or a TTY has no user manager to reload; there
 # the next graphical login picks it up on its own.
 systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# Migrations run once. If this one lands before the package that ships the
+# drop-in, apply the same weight for the running session only (--runtime
+# writes under /run, nothing persists), so the user gets it now and the
+# packaged file takes over at the next login without a second migration.
+if [[ ! -f /usr/lib/systemd/user/session.slice.d/10-cpuweight.conf ]]; then
+  systemctl --user set-property --runtime session.slice CPUWeight=1000 >/dev/null 2>&1 || true
+fi

--- a/migrations/1787276689.sh
+++ b/migrations/1787276689.sh
@@ -1,0 +1,8 @@
+echo "Give the session slice CPU priority over apps so builds cannot stall input"
+
+# New installs get /usr/lib/systemd/user/session.slice.d/10-cpuweight.conf
+# with the package. Existing sessions only apply a slice drop-in when the user
+# manager reloads, and the weight takes effect live -- no relogin needed.
+# An `omarchy update` from SSH or a TTY has no user manager to reload; there
+# the next graphical login picks it up on its own.
+systemctl --user daemon-reload >/dev/null 2>&1 || true

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -141,6 +141,7 @@ package_defaults = [
   ("default/systemd/user/omarchy-tailscale-receive.service", "/usr/lib/systemd/user/omarchy-tailscale-receive.service", "systemd/user/omarchy-tailscale-receive.service"),
   ("default/systemd/user/omarchy-fcitx5.service", "/usr/lib/systemd/user/omarchy-fcitx5.service", "systemd/user/omarchy-fcitx5.service"),
   ("default/systemd/user/omarchy-crash-watch.service", "/usr/lib/systemd/user/omarchy-crash-watch.service", "systemd/user/omarchy-crash-watch.service"),
+  ("default/systemd/user/session.slice.d/10-cpuweight.conf", "/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf", "systemd/user/session.slice.d/10-cpuweight.conf"),
   ("default/systemd/zram-generator.conf.d/90-omarchy.conf", "/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf", "systemd/zram-generator.conf.d/90-omarchy.conf"),
   ("default/fonts/omarchy/omarchy.ttf", "/usr/share/fonts/omarchy/omarchy.ttf", "omarchy.ttf"),
   ("default/snapper/root", "/etc/snapper/config-templates/omarchy", "snapper/root"),

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -102,6 +102,22 @@ candidates=$(grep -rlE '^ManagedOOM(MemoryPressure|Swap)=kill' "$ROOT/default/sy
   fail "systemd-oomd kill candidacy is set outside app.slice, which can select the compositor: $candidates"
 pass "only user app scopes are systemd-oomd kill candidates"
 
+# The compositor shares cpu.weight=100 with app.slice by default, so a couple
+# of builds in terminals stall its input loop: libinput logs "event processing
+# lagging behind by N ms", the pointer stutters, keys queue. Weighting the
+# interactive tier above apps is what keeps the desktop usable while compiling.
+cpu_slice="$ROOT/default/systemd/user/session.slice.d/10-cpuweight.conf"
+grep -Fx 'CPUWeight=1000' "$cpu_slice" >/dev/null ||
+  fail "session.slice has no CPU weight over app.slice, so saturating builds stall compositor input"
+grep -rlE '^CPUWeight=' "$ROOT/default/systemd/user" 2>/dev/null | grep -vFx "$cpu_slice" | grep -q . &&
+  fail "CPU weight is set on something other than session.slice; app scopes must stay at the default so the compositor out-ranks them"
+cpuweight_migration=$(grep -rl 'session.slice.d/10-cpuweight.conf' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $cpuweight_migration ]] ||
+  fail "existing installs never reload the user manager, so the session weight waits for the next login"
+grep -F 'systemctl --user daemon-reload' "$cpuweight_migration" >/dev/null ||
+  fail "migration does not reload the user manager, so the session weight waits for the next login"
+pass "the session slice out-ranks app scopes for CPU, live on existing installs"
+
 oomd_conf="$ROOT/etc/systemd/oomd.conf.d/10-omarchy.conf"
 grep -Fx 'DefaultMemoryPressureLimit=50%' "$oomd_conf" >/dev/null ||
   fail "no pressure limit; the 60% default rides thrashing longer than a desktop stays usable"

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -107,16 +107,22 @@ pass "only user app scopes are systemd-oomd kill candidates"
 # lagging behind by N ms", the pointer stutters, keys queue. Weighting the
 # interactive tier above apps is what keeps the desktop usable while compiling.
 cpu_slice="$ROOT/default/systemd/user/session.slice.d/10-cpuweight.conf"
-grep -Fx 'CPUWeight=1000' "$cpu_slice" >/dev/null ||
+# systemd takes the last assignment in a unit file, so assert the effective
+# value rather than that 1000 appears somewhere: a later CPUWeight= line would
+# quietly win while a match-anywhere grep still passed.
+[[ $(grep -E '^CPUWeight=' "$cpu_slice" | tail -n 1) == "CPUWeight=1000" ]] ||
   fail "session.slice has no CPU weight over app.slice, so saturating builds stall compositor input"
-grep -rlE '^CPUWeight=' "$ROOT/default/systemd/user" 2>/dev/null | grep -vFx "$cpu_slice" | grep -q . &&
-  fail "CPU weight is set on something other than session.slice; app scopes must stay at the default so the compositor out-ranks them"
+stray_cpuweight=$(grep -rlE '^CPUWeight=' "$ROOT/default/systemd/user" 2>/dev/null | grep -vFx "$cpu_slice" || true)
+[[ -z $stray_cpuweight ]] ||
+  fail "CPU weight is set on something other than session.slice; app scopes must stay at the default so the compositor out-ranks them: $stray_cpuweight"
 cpuweight_migration=$(grep -rl 'session.slice.d/10-cpuweight.conf' "$ROOT/migrations" | head -n 1 || true)
 [[ -n $cpuweight_migration ]] ||
   fail "existing installs never reload the user manager, so the session weight waits for the next login"
-grep -F 'systemctl --user daemon-reload' "$cpuweight_migration" >/dev/null ||
+# Anchored to the start of a line so a commented-out command cannot satisfy
+# these: a migration whose body is entirely comments does nothing at all.
+grep -qE '^[[:space:]]*systemctl --user daemon-reload' "$cpuweight_migration" ||
   fail "migration does not reload the user manager, so the session weight waits for the next login"
-grep -F 'set-property --runtime session.slice CPUWeight=1000' "$cpuweight_migration" >/dev/null ||
+grep -qE '^[[:space:]]*systemctl --user set-property --runtime session\.slice CPUWeight=1000' "$cpuweight_migration" ||
   fail "migration runs once; without a runtime fallback a session updated before the package ships the drop-in never gets the weight until relogin"
 pass "the session slice out-ranks app scopes for CPU, live on existing installs"
 

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -107,10 +107,10 @@ pass "only user app scopes are systemd-oomd kill candidates"
 # lagging behind by N ms", the pointer stutters, keys queue. Weighting the
 # interactive tier above apps is what keeps the desktop usable while compiling.
 cpu_slice="$ROOT/default/systemd/user/session.slice.d/10-cpuweight.conf"
-# systemd takes the last assignment in a unit file, so assert the effective
-# value rather than that 1000 appears somewhere: a later CPUWeight= line would
-# quietly win while a match-anywhere grep still passed.
-[[ $(grep -E '^CPUWeight=' "$cpu_slice" | tail -n 1) == "CPUWeight=1000" ]] ||
+# Read the value the way systemd does: the last CPUWeight= under [Slice]. A
+# line grep also matches a decoy in another section, and CPUWeight=1000 under
+# [Unit] is discarded while the slice keeps running at 100.
+[[ $(awk -F= '/^\[/ { s = $0 } s == "[Slice]" && /^CPUWeight=/ { w = $2 } END { print w }' "$cpu_slice") == "1000" ]] ||
   fail "session.slice has no CPU weight over app.slice, so saturating builds stall compositor input"
 stray_cpuweight=$(grep -rlE '^CPUWeight=' "$ROOT/default/systemd/user" 2>/dev/null | grep -vFx "$cpu_slice" || true)
 [[ -z $stray_cpuweight ]] ||
@@ -118,11 +118,11 @@ stray_cpuweight=$(grep -rlE '^CPUWeight=' "$ROOT/default/systemd/user" 2>/dev/nu
 cpuweight_migration=$(grep -rl 'session.slice.d/10-cpuweight.conf' "$ROOT/migrations" | head -n 1 || true)
 [[ -n $cpuweight_migration ]] ||
   fail "existing installs never reload the user manager, so the session weight waits for the next login"
-# Anchored to the start of a line so a commented-out command cannot satisfy
-# these: a migration whose body is entirely comments does nothing at all.
-grep -qE '^[[:space:]]*systemctl --user daemon-reload' "$cpuweight_migration" ||
+# Anchored at both ends: the left stops a commented-out command satisfying
+# these, the right stops CPUWeight=10000 passing while the drop-in says 1000.
+grep -qE '^[[:space:]]*systemctl --user daemon-reload([[:space:]]|$)' "$cpuweight_migration" ||
   fail "migration does not reload the user manager, so the session weight waits for the next login"
-grep -qE '^[[:space:]]*systemctl --user set-property --runtime session\.slice CPUWeight=1000' "$cpuweight_migration" ||
+grep -qE '^[[:space:]]*systemctl --user set-property --runtime session\.slice CPUWeight=1000([[:space:]]|$)' "$cpuweight_migration" ||
   fail "migration runs once; without a runtime fallback a session updated before the package ships the drop-in never gets the weight until relogin"
 pass "the session slice out-ranks app scopes for CPU, live on existing installs"
 

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -116,6 +116,8 @@ cpuweight_migration=$(grep -rl 'session.slice.d/10-cpuweight.conf' "$ROOT/migrat
   fail "existing installs never reload the user manager, so the session weight waits for the next login"
 grep -F 'systemctl --user daemon-reload' "$cpuweight_migration" >/dev/null ||
   fail "migration does not reload the user manager, so the session weight waits for the next login"
+grep -F 'set-property --runtime session.slice CPUWeight=1000' "$cpuweight_migration" >/dev/null ||
+  fail "migration runs once; without a runtime fallback a session updated before the package ships the drop-in never gets the weight until relogin"
 pass "the session slice out-ranks app scopes for CPU, live on existing installs"
 
 oomd_conf="$ROOT/etc/systemd/oomd.conf.d/10-omarchy.conf"


### PR DESCRIPTION
## Problem

When a few things compile at once — which happens by accident all the time now: a Qt/QML app, a Rust rewrite, a couple of agents in worktrees behind a terminal multiplexer — the mouse starts stuttering and keys arrive late or in bursts. It feels like a hardware problem. It isn't.

Hyprland, the shell, PipeWire, the portals and D-Bus run in **`session.slice`**. Everything the user launches — browsers, terminals, and every `cargo`/`ninja`/`cc1plus`/`rustc` those terminals spawn — runs in **`app.slice`**. Both slices ship at systemd's default `cpu.weight=100`. Under saturation the compositor's input loop is just another runnable thread waiting for a CFS slot, and libinput says so:

```
ERR from aquamarine ]: [libinput] event10 - Keychron Keychron M3 4K: client bug: event processing lagging behind by 364ms, your system is too slow
ERR from aquamarine ]: [libinput] event10 - Keychron Keychron M3 4K: client bug: event processing lagging behind by 168ms, your system is too slow
ERR from aquamarine ]: [libinput] client bug: timer button-debounce-debounce-event7: scheduled expiry is in the past (-104ms), your system is too slow
DEBUG from aquamarine ]: [libinput] event7  - Keychron Keychron M3 4K: SYN_DROPPED event - some input events have been lost.
```

Anyone can check their own session for this signature (no root needed):

```bash
command grep -hoE 'lagging behind by [0-9]+ms|SYN_DROPPED|scheduled expiry is in the past' /run/user/$UID/hypr/*/hyprland.log | sed -E 's/[0-9]+ms/Nms/' | sort | uniq -c
```

Binned, from a ~36 h Hyprland session on a Dell XPS 14 / Panther Lake driving a 5K display while doing normal dev work (Hyprland C++ build, cargo builds, 40 Chrome renderers):

```
    92  <50ms
    62  50-99ms
    41  100-249ms
    10  250-499ms
   max  385ms
    33  SYN_DROPPED
   125  scheduled expiry is in the past
```

Every 250 ms+ entry and every `SYN_DROPPED` lines up with a load spike of 15–30 on 16 cores from builds in terminals. Memory, swap and GPU were healthy at those moments — this is CPU arbitration, and it's happening in the one cgroup that must never lose it.

## Change

Ship `/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf`:

```ini
[Slice]
CPUWeight=1000
```

That gives the interactive tier a 10:1 share over `app.slice` (`background.slice` is already 30, so the ordering becomes session ≫ app > background, which is what GNOME/KDE sessions effectively do). CPU weight is **work-conserving**: it only arbitrates under contention. An idle machine is unchanged, and builds still get every core the compositor is not using at that instant — which is almost all of them. The compositor just stops losing the argument. Memory and IO are untouched; this is orthogonal to the oomd tiering in `app.slice.d/10-oomd.conf` and follows the same packaging pattern.

Why not the alternatives:
- `Nice=` on Hyprland alone: per-thread, doesn't cover the shell/PipeWire/portals, and `sched_autogroup` flattens nice across sessions anyway.
- `SCHED_FIFO/RR` on the compositor: a compositor that ever spins becomes a hard input lock; Hyprland upstream deliberately elevates only specific threads.
- `nice -n 19` on builds: opt-in, forgotten, doesn't cover Chrome.

## Evidence (anecdotal, stated as such)

Applied live with `systemctl --user set-property session.slice CPUWeight=1000` during a bad episode (load 31, CPU PSI `some` 60 %, Hyprland + cargo builds running). Subjectively: immediate. Mouse stopped stuttering, typing stopped hanging, while the builds kept going. "Huh, this really fixed things."

A short synthetic A/B (48 burners in `app.slice`, real uinput mouse at 400 Hz, 60 s each) measured Hyprland's cgroup CPU stall (`cpu.pressure some`) at **+314 ms** with weight 1000 vs **+1150 ms** at the default 100, and +540 ms vs +764 ms with a malloc/memset churn load. Synthetic load did not reproduce the 300 ms+ libinput stalls that real compiles cause in either configuration, so I'm not claiming this eliminates them — only that the compositor waits for CPU several times less, and that in daily use the difference is obvious.

## Included

- `default/systemd/user/session.slice.d/10-cpuweight.conf` (commented)
- migration: `systemctl --user daemon-reload` so existing sessions pick it up live (same shape as the oomd migration; a TTY/SSH `omarchy update` gets it at next login)
- `test/shell.d/systemd-test.sh`: asserts the drop-in, that nothing else under `default/systemd/user` carries a `CPUWeight=` (app scopes must stay default so the compositor out-ranks them), and that the migration reloads
- `docs/file-layout.md` entry

Companion (after this lands): one `install -Dm644 default/systemd/user/session.slice.d/10-cpuweight.conf "$pkgdir/usr/lib/systemd/user/session.slice.d/10-cpuweight.conf"` in `omarchy-settings`' PKGBUILD in omarchy-pkgs, next to the oomd line. Happy to open that too.

Verified live: `cat /sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/session.slice/cpu.weight` → `1000`, `hyprctl configerrors` clean, Hyprland/Quickshell/PipeWire all still in `session.slice`, apps in `app-*.scope`.
