### PR TITLE
Keep menu empty-state text inside the card

### DIFF
--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -579,6 +579,7 @@ Item {
 
           Column {
             anchors.centerIn: parent
+            width: parent.width
             spacing: Style.space(8)
             visible: displayModel.count === 0
 
@@ -600,6 +601,7 @@ Item {
               font.pixelSize: Style.font.title
               horizontalAlignment: Text.AlignHCenter
               width: parent.width
+              elide: Text.ElideRight
             }
           }
         }

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -312,6 +312,7 @@ Item {
 
           Column {
             anchors.centerIn: parent
+            width: parent.width
             spacing: Style.space(8)
             visible: displayModel.count === 0
 
@@ -333,6 +334,7 @@ Item {
               font.pixelSize: Style.font.title
               horizontalAlignment: Text.AlignHCenter
               width: parent.width
+              elide: Text.ElideRight
             }
           }
         }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1438,6 +1438,7 @@ Item {
 
           Column {
             anchors.centerIn: parent
+            width: parent.width
             spacing: Style.space(8)
             visible: displayModel.count === 0 && root.mode !== "input"
 
@@ -1448,7 +1449,7 @@ Item {
               font.family: root.fontFamily
               font.pixelSize: Style.font.displayLarge
               horizontalAlignment: Text.AlignHCenter
-              width: Style.space(320)
+              width: parent.width
             }
 
             Text {
@@ -1458,7 +1459,8 @@ Item {
               font.family: root.fontFamily
               font.pixelSize: Style.font.title
               horizontalAlignment: Text.AlignHCenter
-              width: Style.space(320)
+              width: parent.width
+              elide: Text.ElideRight
             }
           }
         }


### PR DESCRIPTION
This is my first PR here so please let me know if there is anything I can improve upon or do better to make reviewing easier. I'm looking to learn and get better and will be happy to make changes moving forward.
Thanks!

Ben

## Summary

- Constrain the menu empty-state column to the card width so a long unmatched query cannot paint past the rounded edges.
- Elide the "No matches for …" line, matching the search field.
- Apply the same empty-state constraint and elide to the clipboard and emoji pickers so they cannot overflow the same way.

The empty-state `Column` only had `anchors.centerIn`. Its message `Text` used a fixed `width: Style.space(320)` with no `elide`, so once the query was wider than 320px the line was centered on that box and painted outside the card. Giving the column `width: parent.width` (the already-sized list item) and eliding the message keeps it inside.

Fixes #7510

## Testing

- Super+Space, typed a long unmatched query (`holas como esatas cjaksjdwdawdjwdj`): the message stays inside the card, elided, still centered.
- Short unmatched query still reads in full inside the card.
- `./test/all` — CLI suite passed. Shell suite had three environment-only failures (`omarchy-pkgs` checkout not present); nothing related to this QML change.

## Before / after

**Before** — empty-state text paints past the rounded card:
<img width="552" height="358" alt="7510-before" src="https://github.com/user-attachments/assets/91f6db3b-b404-4d3a-a53c-247692faa332" />



**After** — same query stays inside, with an ellipsis:
<img width="687" height="449" alt="7510-after" src="https://github.com/user-attachments/assets/cab26231-813f-479f-b97b-8966fb3ab1ec" />

**Clipboard picker/Emoji**
<img width="3440" height="1440" alt="7510-emojis-after" src="https://github.com/user-attachments/assets/a26aa2c6-464e-4bd4-a934-6353106d37c6" />
<img width="3440" height="1440" alt="7510-clipboard-after" src="https://github.com/user-attachments/assets/3d7ffd02-4296-42ca-9a52-ddfb3e925f57" />

