### PR TITLE
docs: how to customize the lock screen

### DIFF
--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -99,3 +99,28 @@ The logo it draws is yours to change, under _Style > Screensaver_. Upload a png 
 `Super + Ctrl + L` locks the machine. That runs the lock screen from the Omarchy shell, blanks the display, resets your keyboard layout to the first one so you're not typing your password in the wrong alphabet, and — if you have it running — locks 1Password on the way out.
 
 The lock screen takes a password, and it'll take a fingerprint too once you've set one up. That, and the other ways to authenticate, are covered in [hardware authentication](37-hardware-authentication.md).
+
+#### Customizing the lock screen
+
+The lock screen is a shell plugin, so you change it by cloning it:
+
+```
+omarchy plugin clone omarchy.lock
+```
+
+`Service.qml` owns the session lock and the PAM flows. Leave it alone. `LockView.qml` is the part you see — the blurred wallpaper, the password field, and whatever you add.
+
+Preview your work without locking the machine:
+
+```
+omarchy-shell lock preview
+omarchy-shell lock hidePreview
+```
+
+That draws the same view in an ordinary window, so a broken layout costs you nothing. Clicking it closes it.
+
+Edits to the lock plugin don't land on save the way bar widgets do. Run `omarchy restart shell` to see them.
+
+Take colors from `Color.lock.text`, `Color.lock.placeholder` and `Color.accent`, and type from `Style.font`. Hardcode them instead and your lock screen stops following theme switches.
+
+Lock for real with `Super + Ctrl + L` before you trust it. If it ever comes up broken, `Ctrl + Alt + F2` gets you a TTY, and `omarchy plugin remove <username>.lock` puts the built-in back.

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -108,7 +108,16 @@ The lock screen is a shell plugin, so you change it by cloning it:
 omarchy plugin clone omarchy.lock
 ```
 
-`Service.qml` owns the session lock and the PAM flows. Leave it alone. `LockView.qml` is the part you see — the blurred wallpaper, the password field, and whatever you add.
+`Service.qml` owns the session lock and the PAM flows. `LockView.qml` is the part you see — the blurred wallpaper, the password field, and whatever you add. Edit the view, leave the service alone.
+
+Cloning copies the whole plugin, so your `Service.qml` is frozen at the moment you cloned it. `omarchy plugin update` only tracks git-managed plugins, and a clone isn't one, so later fixes to the built-in lock screen — including authentication ones — never reach your copy. After an Omarchy update, diff the two and carry anything you're missing across:
+
+```
+diff ~/.config/omarchy/plugins/<username>.lock/Service.qml \
+     /usr/share/omarchy/shell/plugins/lock/Service.qml
+```
+
+The clone rewrites the plugin id, so that shows up in the diff every time. Ignore it and read the rest.
 
 Preview your work without locking the machine:
 

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -68,7 +68,7 @@ That copies the whole plugin into `~/.config/omarchy/plugins/dhh.clock` (your us
 
 The username prefix keeps your clone's id yours, so sharing it doesn't collide with anyone else's. Calls made to the original built-in id get routed to your clone, so nothing that referred to `omarchy.clock` needs updating. And if you make a mess of it, `omarchy plugin remove dhh.clock` puts the built-in back.
 
-Saving a file anywhere under `~/.config/omarchy/plugins/` reloads the plugin code automatically, so you can leave the editor open and watch your changes land.
+Saving a file anywhere under `~/.config/omarchy/plugins/` reloads the plugin code automatically, so you can leave the editor open and watch your changes land. Some plugins are the exception — the lock screen among them — and need `omarchy restart shell` before an edit shows up.
 
 ## Writing your own
 


### PR DESCRIPTION
The manual documents lock **timing** (`idle.lock`, `Super + Ctrl + L`) and authentication, but never says the lock screen is a clonable plugin, and never mentions `omarchy-shell lock preview`.

That preview IPC is the part that matters. Without it, the only way to see a lock screen change is to lock the machine — a bad way to discover you broke it. It exists in `plugins/lock/Service.qml` and nothing points a user at it.

**`manual/13-toggles-idle-screensaver.md`** — new "Customizing the lock screen" subsection under the existing heading: the clone command, the `Service.qml` / `LockView.qml` split (own the view, leave PAM alone), the preview/hidePreview pair, the theme tokens to use so a customized lock still follows theme switches, and the `Ctrl + Alt + F2` / `omarchy plugin remove` recovery path.

**`manual/32-shell-plugins.md`** — one-line correction. It currently says saving a file under `~/.config/omarchy/plugins/` reloads plugin code automatically. That isn't true for the lock screen; edits to `LockView.qml` don't appear until `omarchy restart shell`. Verified by editing it and previewing before and after.

Docs only. Every command in it was run on Omarchy 4.0.0.alpha before writing it down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)