### PR TITLE
Rebuild quickshell from source when Qt ABI breaks after update

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -45,6 +45,7 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
   # them, so everything below waits on this finishing. An upgrade that stopped
   # takes the update with it rather than migrating against what is still on disk.
   omarchy-update-system-pkgs
+  omarchy-update-fix-quickshell-abi
   omarchy-migrate
   omarchy-hook post-update
   omarchy-update-aur-pkgs

--- a/bin/omarchy-update-fix-quickshell-abi
+++ b/bin/omarchy-update-fix-quickshell-abi
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# omarchy:summary=Rebuild quickshell from source if it broke after a Qt upgrade
+
+# The prebuilt quickshell-git in the omarchy repo links Qt private symbols.
+# When qt6-base is upgraded, those symbols change and quickshell fails to load
+# with a symbol lookup error, leaving a dark desktop. This step detects the
+# mismatch and rebuilds quickshell from AUR source against the installed Qt.
+#
+# Runs after system packages are updated but before the shell restart, so the
+# restart picks up a working binary.
+
+if ! quickshell --version >/dev/null 2>&1; then
+  echo -e "\e[33mQuickshell ABI mismatch detected — rebuilding from source...\e[0m"
+
+  if ! omarchy-cmd-present yay; then
+    echo -e "\e[31mCannot rebuild: yay is not installed.\e[0m" >&2
+    echo "Run manually: sudo pacman -U /var/cache/pacman/pkg/quickshell-git-*.pkg.tar.zst" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+
+  builddir=$(mktemp -d)
+  trap 'rm -rf "$builddir"' EXIT
+
+  if yay -S --noconfirm --aur --rebuild --redownload --builddir "$builddir" quickshell-git; then
+    if quickshell --version >/dev/null 2>&1; then
+      echo -e "\e[32mQuickshell rebuilt successfully.\e[0m"
+    else
+      echo -e "\e[31mRebuild succeeded but quickshell still fails to load.\e[0m" >&2
+      echo "Run manually: sudo pacman -U /var/cache/pacman/pkg/quickshell-git-*.pkg.tar.zst" >&2
+      return 1 2>/dev/null || exit 1
+    fi
+  else
+    echo -e "\e[31mRebuild failed. Run manually:\e[0m" >&2
+    echo "  sudo pacman -U /var/cache/pacman/pkg/quickshell-git-*.pkg.tar.zst" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

When `qt6-base` is upgraded, the prebuilt `quickshell-git` in the omarchy repo fails to load (private Qt symbols change). This adds an automatic rebuild step so the system self-heals instead of leaving a dark desktop.

## Root cause

The omarchy repo ships a prebuilt `quickshell-git` binary that links Qt private ABI symbols. When `qt6-base` is upgraded, those symbols change and quickshell fails with `symbol lookup error: QUntypedPropertyBinding, version Qt_6`. The omarchy rebuild of quickshell-git may ship before the channels Qt snapshot advances, or lag behind it, causing a mismatch.

## Fix

**`bin/omarchy-update-fix-quickshell-abi`** (new) — runs after system packages are updated and before the shell restart. If `quickshell --version` fails (ABI break detected), rebuilds quickshell from AUR source against the installed Qt using `yay --aur --rebuild --redownload`. Falls back to printing the manual downgrade command if yay is unavailable or the build fails.

**`bin/omarchy-update`** — calls the new script after `omarchy-update-system-pkgs`.

## Testing

- `./test/cli` passes
- `./test/shell` failures are all pre-existing (missing `omarchy-pkgs` checkout + the quickshell ABI bug itself)

## Ref

- Issue: #7596