### PR TITLE
Restore the selected menu row when going back

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -787,8 +787,14 @@ Item {
       return true
     }
 
-    var active = root.item(root.activeMenu)
+    var childId = root.activeMenu
+    var active = root.item(childId)
     root.setActiveMenu((active && active.parent) ? active.parent : "root", false)
+    var parentRow = root.indexOfItemId(childId)
+    if (parentRow >= 0) {
+      root.selectedIndex = parentRow
+      root.settleCursor()
+    }
     return true
   }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -787,8 +787,19 @@ Item {
       return true
     }
 
-    var active = root.item(root.activeMenu)
+    // navStack is empty when the menu was opened directly at a route
+    // (`omarchy menu summon system`) rather than reached by drilling down,
+    // so there is no remembered row to pop. Restore the cursor onto the
+    // menu being left instead, the same way the navStack branch above
+    // restores onto the row that led into it.
+    var childId = root.activeMenu
+    var active = root.item(childId)
     root.setActiveMenu((active && active.parent) ? active.parent : "root", false)
+    var restored = root.indexOfItemId(childId)
+    if (restored >= 0) {
+      root.selectedIndex = restored
+      root.settleCursor()
+    }
     return true
   }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -726,13 +726,18 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoreIndex) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
+    // Remember where the cursor sat in the menu being left, keyed to it on
+    // the stack, so goBack() can restore it instead of always landing on the
+    // first row. settleCursor() still runs via rebuildDisplay(), so a stale
+    // index (rows changed underneath) lands on the nearest selectable row.
+    if (pushHistory && id !== root.activeMenu)
+      root.navStack = root.navStack.concat([{ id: root.activeMenu, selectedIndex: root.selectedIndex }])
     root.activeMenu = id
     root.filterText = ""
-    root.selectedIndex = 0
+    root.selectedIndex = restoreIndex >= 0 ? restoreIndex : 0
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
     else root.disarmPointer()
@@ -747,7 +752,7 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous, false)
+      root.setActiveMenu(previous.id, false, false, previous.selectedIndex)
       return true
     }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -777,8 +777,12 @@ Item {
       root.setActiveMenu(previous.id, false, false, previous.filterText)
       var restored = root.indexOfItemId(previous.selectedItemId)
       if (restored >= 0) {
+        // Re-settle rather than force the cursor onto `restored`: if that row
+        // went disabled while its submenu was open, settleCursor() walks
+        // forward to the nearest selectable row instead of parking the
+        // cursor somewhere Enter won't run.
         root.selectedIndex = restored
-        root.cursorActive = true
+        root.settleCursor()
       }
       return true
     }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -787,19 +787,8 @@ Item {
       return true
     }
 
-    // navStack is empty when the menu was opened directly at a route
-    // (`omarchy menu summon system`) rather than reached by drilling down,
-    // so there is no remembered row to pop. Restore the cursor onto the
-    // menu being left instead, the same way the navStack branch above
-    // restores onto the row that led into it.
-    var childId = root.activeMenu
-    var active = root.item(childId)
+    var active = root.item(root.activeMenu)
     root.setActiveMenu((active && active.parent) ? active.parent : "root", false)
-    var restored = root.indexOfItemId(childId)
-    if (restored >= 0) {
-      root.selectedIndex = restored
-      root.settleCursor()
-    }
     return true
   }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -726,21 +726,43 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer, restoreIndex) {
+  // Index of the row currently showing `itemId`, or -1 if it isn't in the
+  // current (possibly filtered) displayModel at all.
+  function indexOfItemId(itemId) {
+    if (!itemId) return -1
+    for (var i = 0; i < displayModel.count; i++) {
+      if (displayModel.get(i).itemId === itemId) return i
+    }
+    return -1
+  }
+
+  function setActiveMenu(id, pushHistory, fromPointer, restoreFilterText) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    // Remember where the cursor sat in the menu being left, keyed to it on
-    // the stack, so goBack() can restore it instead of always landing on the
-    // first row. settleCursor() still runs via rebuildDisplay(), so a stale
-    // index (rows changed underneath) lands on the nearest selectable row.
-    if (pushHistory && id !== root.activeMenu)
-      root.navStack = root.navStack.concat([{ id: root.activeMenu, selectedIndex: root.selectedIndex }])
+    // Remember which row was selected -- and what search filter was active,
+    // if any -- in the menu being left, so goBack() can restore the exact
+    // view instead of always landing on the first row of the unfiltered
+    // menu. The row is keyed by itemId rather than index: the parent may
+    // have been filtered when this row was activated (search results), and
+    // a raw index would land on whatever unrelated row now occupies that
+    // position once the filter is restored (or cleared).
+    if (pushHistory && id !== root.activeMenu) {
+      var currentRow = (root.cursorActive && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count)
+        ? displayModel.get(root.selectedIndex)
+        : null
+      root.navStack = root.navStack.concat([{
+        id: root.activeMenu,
+        filterText: root.filterText,
+        selectedItemId: currentRow ? currentRow.itemId : ""
+      }])
+    }
     root.activeMenu = id
-    root.filterText = ""
-    root.selectedIndex = restoreIndex >= 0 ? restoreIndex : 0
+    root.filterText = restoreFilterText || ""
+    root.selectedIndex = 0
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
     else root.disarmPointer()
+    if (!root.dmenuActive && root.filterText.trim()) root.loadProvidersForSearch()
     root.rebuildDisplay()
     root.invalidateVolatileProvider(id)
     root.loadProviderForMenu(id)
@@ -752,7 +774,12 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous.id, false, false, previous.selectedIndex)
+      root.setActiveMenu(previous.id, false, false, previous.filterText)
+      var restored = root.indexOfItemId(previous.selectedItemId)
+      if (restored >= 0) {
+        root.selectedIndex = restored
+        root.cursorActive = true
+      }
       return true
     }
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -510,20 +510,6 @@ assert(
   /function indexOfItemId\(itemId\)[\s\S]*?displayModel\.get\(i\)\.itemId === itemId\) return i/.test(menuQml),
   'menu can find a row by id in the current, possibly filtered, display model'
 )
-// navStack is empty when a menu is opened directly at a route (e.g.
-// `omarchy menu summon system`) rather than reached by drilling down, so
-// goBack() falls through to walking up to the parent without a remembered
-// row to pop. That fallback should still land the cursor back on the menu
-// being left, the same way the navStack branch above restores onto the row
-// that led into it.
-assert(
-  /var childId = root\.activeMenu\s*\n\s*var active = root\.item\(childId\)\s*\n\s*root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)/.test(menuQml),
-  'menu remembers the menu being left before walking up to its parent with no navStack entry'
-)
-assert(
-  /root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)\s*\n\s*var restored = root\.indexOfItemId\(childId\)\s*\n\s*if \(restored >= 0\) \{\s*\n\s*root\.selectedIndex = restored\s*\n\s*root\.settleCursor\(\)\s*\n\s*\}/.test(menuQml),
-  'menu restores the cursor onto the left menu when going back with no navStack entry'
-)
 assert(
   /function setActiveMenu\([\s\S]*?root\.filterText = restoreFilterText \|\| ""[\s\S]*?if \(!root\.dmenuActive && root\.filterText\.trim\(\)\) root\.loadProvidersForSearch\(\)/.test(menuQml),
   'menu reloads volatile search providers when a remembered filter is restored'

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -515,6 +515,10 @@ assert(
   'menu reloads volatile search providers when a remembered filter is restored'
 )
 assert(
+  /var childId = root\.activeMenu[\s\S]*?root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)[\s\S]*?var parentRow = root\.indexOfItemId\(childId\)[\s\S]*?root\.selectedIndex = parentRow[\s\S]*?root\.settleCursor\(\)/.test(menuQml),
+  'menu restores the child row when backing out of a directly opened route'
+)
+assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
   'menu Left key follows empty-filter Backspace navigation'
 )

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -497,6 +497,15 @@ assert(
   /function goBack\(\)[\s\S]*?root\.setActiveMenu\(previous\.id, false, false, previous\.filterText\)\s*\n\s*var restored = root\.indexOfItemId\(previous\.selectedItemId\)/.test(menuQml),
   'menu restores the remembered search filter, then looks up the remembered row by id'
 )
+// The lookup by itself proves nothing if its result is never applied --
+// assert the found index actually drives the cursor, and that it goes
+// through settleCursor() rather than a bare cursorActive flip, so a row that
+// went disabled while its submenu was open still resolves to the nearest
+// selectable one instead of parking the cursor where Enter won't run.
+assert(
+  /if \(restored >= 0\) \{[\s\S]*?root\.selectedIndex = restored\s*\n\s*root\.settleCursor\(\)\s*\n\s*\}/.test(menuQml),
+  'menu applies the restored row index and re-settles the cursor onto it'
+)
 assert(
   /function indexOfItemId\(itemId\)[\s\S]*?displayModel\.get\(i\)\.itemId === itemId\) return i/.test(menuQml),
   'menu can find a row by id in the current, possibly filtered, display model'

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -480,8 +480,18 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoreIndex\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
+)
+// Going back should return the cursor to the row that was highlighted before
+// descending, not reset it to the top of the parent menu.
+assert(
+  /root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, selectedIndex: root\.selectedIndex \}\]\)/.test(menuQml),
+  'menu remembers the selected row alongside the menu id when descending'
+)
+assert(
+  /function goBack\(\)[\s\S]*?root\.setActiveMenu\(previous\.id, false, false, previous\.selectedIndex\)/.test(menuQml),
+  'menu restores the remembered selected row when going back'
 )
 assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -515,7 +515,7 @@ assert(
   'menu reloads volatile search providers when a remembered filter is restored'
 )
 assert(
-  /var childId = root\.activeMenu[\s\S]*?root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)[\s\S]*?var parentRow = root\.indexOfItemId\(childId\)[\s\S]*?root\.selectedIndex = parentRow[\s\S]*?root\.settleCursor\(\)/.test(menuQml),
+  /var childId = root\.activeMenu[\s\S]*?root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)[\s\S]*?var parentRow = root\.indexOfItemId\(childId\)\s*\n\s*if \(parentRow >= 0\) \{\s*\n\s*root\.selectedIndex = parentRow\s*\n\s*root\.settleCursor\(\)\s*\n\s*\}/.test(menuQml),
   'menu restores the child row when backing out of a directly opened route'
 )
 assert(

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -510,6 +510,20 @@ assert(
   /function indexOfItemId\(itemId\)[\s\S]*?displayModel\.get\(i\)\.itemId === itemId\) return i/.test(menuQml),
   'menu can find a row by id in the current, possibly filtered, display model'
 )
+// navStack is empty when a menu is opened directly at a route (e.g.
+// `omarchy menu summon system`) rather than reached by drilling down, so
+// goBack() falls through to walking up to the parent without a remembered
+// row to pop. That fallback should still land the cursor back on the menu
+// being left, the same way the navStack branch above restores onto the row
+// that led into it.
+assert(
+  /var childId = root\.activeMenu\s*\n\s*var active = root\.item\(childId\)\s*\n\s*root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)/.test(menuQml),
+  'menu remembers the menu being left before walking up to its parent with no navStack entry'
+)
+assert(
+  /root\.setActiveMenu\(\(active && active\.parent\) \? active\.parent : "root", false\)\s*\n\s*var restored = root\.indexOfItemId\(childId\)\s*\n\s*if \(restored >= 0\) \{\s*\n\s*root\.selectedIndex = restored\s*\n\s*root\.settleCursor\(\)\s*\n\s*\}/.test(menuQml),
+  'menu restores the cursor onto the left menu when going back with no navStack entry'
+)
 assert(
   /function setActiveMenu\([\s\S]*?root\.filterText = restoreFilterText \|\| ""[\s\S]*?if \(!root\.dmenuActive && root\.filterText\.trim\(\)\) root\.loadProvidersForSearch\(\)/.test(menuQml),
   'menu reloads volatile search providers when a remembered filter is restored'

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -480,18 +480,30 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer, restoreIndex\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoreFilterText\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 // Going back should return the cursor to the row that was highlighted before
-// descending, not reset it to the top of the parent menu.
+// descending, not reset it to the top of the parent menu -- and if that row
+// was reached through a search, the search itself should come back too. The
+// row is looked up by itemId rather than reused as a raw index, since a raw
+// index would point at an unrelated row once the filter is restored (or
+// cleared, if there wasn't one).
 assert(
-  /root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, selectedIndex: root\.selectedIndex \}\]\)/.test(menuQml),
-  'menu remembers the selected row alongside the menu id when descending'
+  /root\.navStack = root\.navStack\.concat\(\[\{\s*id: root\.activeMenu,\s*filterText: root\.filterText,\s*selectedItemId: currentRow \? currentRow\.itemId : ""\s*\}\]\)/.test(menuQml),
+  'menu remembers the selected row\'s id and the active search filter when descending'
 )
 assert(
-  /function goBack\(\)[\s\S]*?root\.setActiveMenu\(previous\.id, false, false, previous\.selectedIndex\)/.test(menuQml),
-  'menu restores the remembered selected row when going back'
+  /function goBack\(\)[\s\S]*?root\.setActiveMenu\(previous\.id, false, false, previous\.filterText\)\s*\n\s*var restored = root\.indexOfItemId\(previous\.selectedItemId\)/.test(menuQml),
+  'menu restores the remembered search filter, then looks up the remembered row by id'
+)
+assert(
+  /function indexOfItemId\(itemId\)[\s\S]*?displayModel\.get\(i\)\.itemId === itemId\) return i/.test(menuQml),
+  'menu can find a row by id in the current, possibly filtered, display model'
+)
+assert(
+  /function setActiveMenu\([\s\S]*?root\.filterText = restoreFilterText \|\| ""[\s\S]*?if \(!root\.dmenuActive && root\.filterText\.trim\(\)\) root\.loadProvidersForSearch\(\)/.test(menuQml),
+  'menu reloads volatile search providers when a remembered filter is restored'
 )
 assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),


### PR DESCRIPTION
## Summary
- `setActiveMenu()` always reset `selectedIndex` to `0`, so pressing Left (or Backspace with an empty filter) to go back up a level in the Omarchy menu always landed on the first row instead of the item you'd drilled in from.
- `navStack` now remembers `{ id, filterText, selectedItemId }` for the menu being left when descending. `goBack()` restores that filter (reloading volatile search providers if needed) so `rebuildDisplay()` regenerates the same view, then looks the remembered row up by `itemId` via a new `indexOfItemId()` and re-runs `settleCursor()` on it. The row is keyed by id rather than a raw index because the parent may have been filtered (search results) when the row was activated, and a raw index would land on an unrelated row once that filter is restored or cleared. Re-settling rather than forcing the cursor onto the found index means a row that went disabled while its submenu was open still resolves to the nearest selectable row instead of parking the cursor somewhere Enter won't run.
- `navStack` is only populated by drilling down, so menus opened directly at a route (`omarchy menu summon system`) started with an empty stack and `goBack()`'s no-history fallback landed back on row 0 instead of the menu that was left. That fallback now remembers the menu being left before walking up to its parent, then restores the cursor onto it the same way, via `indexOfItemId()` + `settleCursor()`.

## Test plan
- [x] `./test/shell.d/menu-test.sh` passes, including regression assertions covering the remembered row/filter, the identity-based lookup, that the restored index is actually applied through `settleCursor()` (not just looked up), and the no-navStack-entry fallback restoring onto the left menu
- [x] `./test/all` — no new failures (pre-existing failures on this machine are environment-only: missing `omarchy-pkgs` checkout, file permissions, and flaky screen-capture/smoke tests unrelated to this change)
- [x] Manually verified in the running shell: Right into a submenu from a non-first row, then Left back out re-highlights the original row; two levels down and back twice restores both levels; searching, descending into a drilldown result, and going back restores both the search text and the selected row; closing and re-summoning the menu starts fresh at root (navStack is cleared on open, so nothing leaks across sessions); `omarchy menu summon system` followed by Left now re-highlights `System` instead of jumping to the top of the root menu