### PR TITLE
fix(menu): accept plus in search input

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1158,7 +1158,7 @@ Item {
             } else if (root.cursorActive) root.activateIndex(root.selectedIndex)
             else root.settleCursor()
             event.accepted = true
-          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
+          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && !(event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier))) {
             root.setFilter(root.filterText + event.text)
             event.accepted = true
           }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -488,6 +488,10 @@ assert(
   'menu Left key follows empty-filter Backspace navigation'
 )
 assert(
+  /!\(event\.modifiers & \(Qt\.ControlModifier \| Qt\.AltModifier \| Qt\.MetaModifier\)\)/.test(menuQml),
+  'menu accepts printable text carrying Shift plus keypad or layout modifiers'
+)
+assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),
   'menu uses shared pointer movement gate in card coordinates'
 )


### PR DESCRIPTION
## What changed

- allow printable menu input carrying Shift plus keypad or keyboard-layout modifiers
- continue rejecting Ctrl, Alt, and Meta shortcuts
- add regression coverage for the modifier guard

This fixes `+` being dropped from menu searches on affected keyboard layouts while preserving shortcut handling.

Closes #7629

## Testing

- `git diff --check`
- focused Node assertion for the printable-modifier guard

Full shell test runner was unavailable because this Windows host has no Bash/WSL. CI provides the Linux shell suite.
