### PR TITLE
fix(keybindings): print Lua-compatible combos

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -335,7 +335,9 @@ parse_binding_records() {
   awk -F, '
 {
     # Combine the modifier and key (first two fields)
-    key_combo = $1 " + " $2;
+    modifiers = $1;
+    gsub(/[ \t]+/, " + ", modifiers);
+    key_combo = modifiers " + " $2;
 
     # Clean up: strip leading "+" if present, trim spaces
     gsub(/^[ \t]*\+?[ \t]*/, "", key_combo);


### PR DESCRIPTION
## What changed

Format every modifier separator in `keybindings --print` with ` + `.

Printed bindings such as `SUPER + SHIFT + S` can now be copied directly into `hl.unbind(...)` or `o.bind(...)`.

Closes #7627

## Testing

- exercised `parse_binding_records` with `SUPER SHIFT,S` and `SHIFT ALT,D`
- `git diff --check`
