### PR TITLE
fix(menu): rank apps above destructive actions

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -355,6 +355,9 @@ function searchScore(items, entry, query) {
   else if (descriptionTextMatches(needle, descriptionText)) score = 60
 
   if (entry.kind === "menu" || entry.kind === "link") score -= 2
+  // Global search should not put destructive package actions above apps that
+  // begin with the query (for example, Remove > Rust above RustDesk).
+  if (entry.id.indexOf("install.") === 0 || entry.id.indexOf("remove.") === 0) score += 20
   // App rows sort after all menu items, so they lose the tiebreak below to an
   // equal match. Outrank those, but stay inside the tier so better ones win.
   if (entry.kind === "app") score -= 5

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -136,6 +136,7 @@ const rankBase = menu.mergeMenuSources(defaultItems, [])
 const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
   { id: 'apps.brave', parent: 'apps', kind: 'app', label: 'Brave', description: '', aliases: [] },
   { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] },
+  { id: 'apps.rustdesk', parent: 'apps', kind: 'app', label: 'RustDesk', description: '', aliases: [] },
   { id: 'apps.zen', parent: 'apps', kind: 'app', label: 'Zen Browser', description: '', aliases: [] }
 ])
 const rankScore = (id, query) => menu.searchScore(ranked.items, ranked.items[id], query)
@@ -154,6 +155,10 @@ assert(
 assert(
   rankScore('style.font', 'font') < rankScore('apps.fontforge', 'font'),
   'menu keeps a better-matching menu entry above a weaker app match'
+)
+assert(
+  rankScore('apps.rustdesk', 'rust') < rankScore('remove.development.rust', 'rust'),
+  'menu keeps a destructive exact match below an app prefix match'
 )
 
 // Routing: htop ships `Keywords=system;...`, which app rows carry as aliases.


### PR DESCRIPTION
## What changed

- lower global-search rank of install/remove actions
- keep destructive exact matches below app prefix matches
- add RustDesk versus Remove Rust regression coverage

Closes #7630

## Testing

- `test/shell.d/menu-test.sh` passed all menu search/ranking assertions, then stopped at unrelated missing host command `fc-query`
- `git diff --check`
