### PR TITLE
Dismiss low battery warning on AC

### DIFF
--- a/bin/omarchy-battery-low
+++ b/bin/omarchy-battery-low
@@ -13,5 +13,5 @@ fi
 
 level=$1
 
-omarchy-notification-send -g 󱐋 -u critical "Time to recharge!" "Battery is down to ${level}%" -i battery-caution -t 30000
+omarchy-notification-send --app-name omarchy-battery -g 󱐋 -u critical "Time to recharge!" "Battery is down to ${level}%" -i battery-caution -t 30000
 omarchy-hook battery-low "$level"

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -46,14 +46,11 @@ Do-not-disturb is a single boolean, persisted as the `dnd` key in
 bar's `omarchy.indicators` widget, whose Dnd indicator binds directly to the
 service's `doNotDisturb` property.
 
-Two kinds of notification punch through DND, chosen to be intentional and
-rare:
+Three kinds of notification punch through DND, chosen to be intentional and rare:
 
-- `app_name` = `omarchy-action` — Omarchy's own user-action confirmation
-  toasts ("Theme changed"). The user just did something; their feedback shows.
-- urgency critical *and* `app_name` = `notify-send` — bare-CLI emergency
-  alerts. Critical alone is not enough, because chat apps abuse it to force
-  visibility; they set `app_name` to their brand, which fails this rule.
+- `app_name` = `omarchy-action` — Omarchy's own user-action confirmation toasts ("Theme changed"). The user just did something; their feedback shows.
+- urgency critical *and* `app_name` = `notify-send` — bare-CLI emergency alerts. Critical alone is not enough, because chat apps abuse it to force visibility; they set `app_name` to their brand, which fails this rule.
+- urgency critical *and* `app_name` = `omarchy-battery` — the low-battery warning, which must surface even while notifications are silenced.
 
 A silenced notification that anyone might look back at is written straight
 into history — "what did I miss while silenced" is what history is for.
@@ -110,8 +107,7 @@ variants map to the IPC methods `dismissOne`, `dismissAll`, `invokeLast`,
 
 Everything goes through the same sender contract, so the pieces are small:
 
-- **Low battery** — `omarchy-battery-low` sends a critical toast and runs the
-  `battery-low` hook.
+- **Low battery** — `omarchy-battery-low` sends a critical `omarchy-battery` toast and runs the `battery-low` hook. The battery service dismisses active warnings when UPower reports that the machine is back on AC.
 - **Crash capture** — `omarchy-crash-watch` follows the systemd-coredump
   journal stream and announces each crashed program (deduped per minute) as a
   critical toast whose `--exec` runs `omarchy-agent-crash`. It waits for the

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -34,7 +34,15 @@ function summaryStartsWithGlyph(summary) {
 function shouldBypassDnd(notification, criticalUrgency) {
   var appName = String((notification && notification.appName) || "")
   if (appName === "omarchy-action") return true
-  return appName === "notify-send" && notification && notification.urgency === criticalUrgency
+  return (appName === "notify-send" || appName === "omarchy-battery")
+    && notification && notification.urgency === criticalUrgency
+}
+
+function popupMatchesApp(row, appName, summary) {
+  var name = String(appName || "")
+  if (!row || !name || String(row.app || "") !== name) return false
+  if (summary === undefined || summary === null) return true
+  return String(row.summary || "") === String(summary)
 }
 
 function isEphemeralApp(appName) {
@@ -343,6 +351,7 @@ if (typeof module !== "undefined") {
     sanitizeBody: sanitizeBody,
     summaryStartsWithGlyph: summaryStartsWithGlyph,
     shouldBypassDnd: shouldBypassDnd,
+    popupMatchesApp: popupMatchesApp,
     isEphemeralApp: isEphemeralApp,
     stringHint: stringHint,
     glyphFromHints: glyphFromHints,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -17,6 +17,10 @@ Item {
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
 
+  // Emitted only for new and startup-restored active popups. History replay
+  // does not announce an archived row as newly active.
+  signal popupAdded(string appName, string summary)
+
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   readonly property string home: Quickshell.env("HOME")
   // History + DND live under XDG_STATE_HOME: they're persistent user state
@@ -127,6 +131,7 @@ Item {
   //     Trusted because it's almost always omarchy or system shell scripts —
   //     chat apps set app_name to their brand (Discord/Slack/Vesktop), which
   //     falls outside this rule.
+  //   - urgency=critical AND app_name=omarchy-battery: the low-battery warning.
   function shouldBypassDnd(notification) {
     return NotificationLogic.shouldBypassDnd(notification, NotificationUrgency.Critical)
   }
@@ -194,6 +199,8 @@ Item {
       // write to, and a property that already changed will not change again.
       // Reading the object once the row exists catches up on it.
       service.refreshPopup(notification, snapshot.originalId, snapshot.timestamp)
+      var inserted = popupModel.get(0)
+      if (inserted) service.popupAdded(inserted.app, inserted.summary)
     })
   }
 
@@ -350,6 +357,20 @@ Item {
 
   function clearPopups() {
     while (popupModel.count > 0) dismissPopup(0)
+  }
+
+  // Dismiss every popup from an exact app identity. Supplying a summary
+  // narrows the match to that exact headline, which supports callers
+  // transitioning away from a previously shared app name.
+  function dismissByApp(appName, summary) {
+    var hit = false
+    for (var i = popupModel.count - 1; i >= 0; i--) {
+      var row = popupModel.get(i)
+      if (!NotificationLogic.popupMatchesApp(row, appName, summary)) continue
+      dismissPopup(i)
+      hit = true
+    }
+    return hit
   }
 
   // Run the popup's click action, then dismiss. Omarchy's own toasts carry the
@@ -771,6 +792,7 @@ Item {
         // old shell — so dismissal and action fallbacks degrade gracefully.
         service.restoredPopups[NotificationLogic.popupFileName(restored)] = true
         popupModel.append(restored)
+        service.popupAdded(restored.app, restored.summary)
       }
     })
   }

--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -7,7 +7,14 @@ function isDischarging(device, onBattery, dischargingState) {
   return !!(device && device.isPresent && onBattery && device.state === dischargingState)
 }
 
+function shouldDismissLowBatteryWarning(device, onBattery) {
+  return !!(device && device.ready && !onBattery)
+}
+
 function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
+  if (!device || device.ready === false)
+    return { level: -1, notify: false, notifiedLowBattery: !!alreadyNotified }
+
   var level = batteryPercentage(device)
   if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
 
@@ -23,6 +30,7 @@ if (typeof module !== "undefined") {
   module.exports = {
     batteryPercentage: batteryPercentage,
     isDischarging: isDischarging,
+    shouldDismissLowBatteryWarning: shouldDismissLowBatteryWarning,
     shouldWarnLowBattery: shouldWarnLowBattery
   }
 }

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -11,7 +11,14 @@ Item {
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
 
   readonly property int batteryThreshold: 10
+  readonly property string lowBatteryNotificationApp: "omarchy-battery"
+  readonly property string legacyLowBatteryNotificationApp: "omarchy-action"
+  readonly property string lowBatteryNotificationSummary: "Time to recharge!"
+  readonly property var batteryDevice: UPower.displayDevice
+  readonly property var notificationService: shell ? shell.firstPartyServiceFor("omarchy.notifications") : null
   property string pendingPowerSource: ""
+
+  onNotificationServiceChanged: dismissLowBatteryWarning()
 
   PersistentProperties {
     id: persisted
@@ -40,6 +47,16 @@ Item {
       String(level)
     ]
     warningProcess.running = true
+  }
+
+  function dismissLowBatteryWarning() {
+    if (!BatteryModel.shouldDismissLowBatteryWarning(batteryDevice, UPower.onBattery)) return
+    if (!notificationService) return
+
+    notificationService.dismissByApp(lowBatteryNotificationApp)
+    // Warnings persisted before the dedicated app identity was introduced
+    // used omarchy-action, so match their exact headline during the upgrade.
+    notificationService.dismissByApp(legacyLowBatteryNotificationApp, lowBatteryNotificationSummary)
   }
 
   function applyPowerProfile() {
@@ -72,7 +89,30 @@ Item {
     target: UPower
     function onOnBatteryChanged() {
       root.checkBattery()
+      root.dismissLowBatteryWarning()
       root.applyPowerProfile()
+    }
+  }
+
+  Connections {
+    target: root.batteryDevice
+    function onReadyChanged() {
+      // On AC, clear a warning latch preserved while UPower was unready.
+      // On battery, the regular timer avoids racing popup restoration with
+      // a duplicate warning during shell startup.
+      if (!UPower.onBattery) root.checkBattery()
+      root.dismissLowBatteryWarning()
+    }
+  }
+
+  Connections {
+    target: root.notificationService
+    function onPopupAdded(appName, summary) {
+      if (appName === root.lowBatteryNotificationApp
+          || (appName === root.legacyLowBatteryNotificationApp
+              && summary === root.lowBatteryNotificationSummary)) {
+        root.dismissLowBatteryWarning()
+      }
     }
   }
 }

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -12,6 +12,14 @@ assertEqual(battery.batteryPercentage({ isPresent: true, percentage: 0.126 }), 1
 assertEqual(battery.batteryPercentage({ isPresent: false, percentage: 0.5 }), -1, 'battery reports missing battery')
 assert(battery.isDischarging({ isPresent: true, state: discharging }, true, discharging), 'battery detects discharging state')
 assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, discharging), 'battery requires on-battery state')
+assert(!battery.shouldDismissLowBatteryWarning({ ready: false }, false), 'battery keeps warnings until UPower is ready')
+assert(battery.shouldDismissLowBatteryWarning({ ready: true }, false), 'battery dismisses warnings on AC')
+assert(!battery.shouldDismissLowBatteryWarning({ ready: true }, true), 'battery keeps warnings while on battery')
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ ready: false }, false, discharging, 10, true),
+  { level: -1, notify: false, notifiedLowBattery: true },
+  'battery preserves warning state until UPower is ready'
+)
 
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
@@ -29,3 +37,25 @@ assertDeepEqual(
   'battery clears notified state after recovery'
 )
 JS
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+cat >"$tmp_dir/bin/omarchy-notification-send" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_BATTERY_NOTIFICATION"
+STUB
+cat >"$tmp_dir/bin/omarchy-hook" <<'STUB'
+#!/bin/bash
+:
+STUB
+chmod +x "$tmp_dir/bin/omarchy-notification-send" "$tmp_dir/bin/omarchy-hook"
+
+OMARCHY_TEST_BATTERY_NOTIFICATION="$tmp_dir/notification" PATH="$tmp_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-battery-low" 8
+
+mapfile -t notification_args <"$tmp_dir/notification"
+[[ ${notification_args[0]} == "--app-name" ]] || fail "low battery warning passes app-name flag"
+[[ ${notification_args[1]} == "omarchy-battery" ]] || fail "low battery warning uses a stable app identity"
+pass "low battery warning uses a stable app identity"

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -44,10 +44,17 @@ assert(!notifications.shouldRenderCompactGlyph('K', 'file:///tmp/image.png', tru
 
 assert(notifications.shouldBypassDnd({ appName: 'omarchy-action', urgency: 1 }, 2), 'omarchy action toasts bypass DND')
 assert(notifications.shouldBypassDnd({ appName: 'notify-send', urgency: 2 }, 2), 'critical notify-send bypasses DND')
+assert(notifications.shouldBypassDnd({ appName: 'omarchy-battery', urgency: 2 }, 2), 'critical battery warnings bypass DND')
+assert(!notifications.shouldBypassDnd({ appName: 'omarchy-battery', urgency: 1 }, 2), 'non-critical battery notifications respect DND')
 assert(!notifications.shouldBypassDnd({ appName: 'notify-send', urgency: 1 }, 2), 'normal notify-send does not bypass DND')
 assert(!notifications.shouldBypassDnd({ appName: 'Slack', urgency: 2 }, 2), 'critical app notifications do not bypass DND')
 assert(!notifications.shouldBypassDnd({ appName: 'omarchy-menu-keybindings', urgency: 1 }, 2), 'omarchy command app names do not bypass DND')
 assert(!notifications.isEphemeralApp('omarchy-menu-keybindings'), 'notifications treat omarchy command app names as normal apps')
+
+assert(notifications.popupMatchesApp({ app: 'omarchy-battery', summary: 'Low' }, 'omarchy-battery'), 'notifications match an exact app identity')
+assert(!notifications.popupMatchesApp({ app: 'omarchy-battery-helper', summary: 'Low' }, 'omarchy-battery'), 'notifications reject an app identity prefix')
+assert(notifications.popupMatchesApp({ app: 'omarchy-action', summary: 'Time to recharge!' }, 'omarchy-action', 'Time to recharge!'), 'notifications can narrow an app match by exact summary')
+assert(!notifications.popupMatchesApp({ app: 'omarchy-action', summary: 'Theme changed' }, 'omarchy-action', 'Time to recharge!'), 'notifications reject a different summary when narrowed')
 
 assertDeepEqual(
   notifications.popupPlacement('top', 32, 6),
@@ -386,6 +393,56 @@ assertEqual(
 )
 
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+assert(
+  /signal popupAdded\(string appName, string summary\)/.test(serviceQml),
+  'notifications service announces active popup insertion'
+)
+assert(
+  /function dismissByApp\(appName, summary\)/.test(serviceQml),
+  'notifications service can dismiss popups by exact app identity'
+)
+const liveHandler = serviceQml.slice(
+  serviceQml.indexOf('function handleNotification(notification)'),
+  serviceQml.indexOf('function writeSilenced(notification, written)')
+)
+const liveInsertIndex = liveHandler.indexOf('popupModel.insert(0, snapshot)')
+const liveAnnounceIndex = liveHandler.indexOf('service.popupAdded(inserted.app, inserted.summary)')
+assert(
+  liveInsertIndex >= 0 && liveAnnounceIndex > liveInsertIndex,
+  'notifications announce a live popup after insertion'
+)
+const replayHandler = serviceQml.slice(
+  serviceQml.indexOf('function replayHistory(raw)'),
+  serviceQml.indexOf('id: restorePopupsProc')
+)
+assert(!replayHandler.includes('popupAdded('), 'notifications do not announce explicit history replay')
+const restoreHandler = serviceQml.slice(
+  serviceQml.indexOf('function restorePopups(raw)'),
+  serviceQml.indexOf('// ---------------------------------------------------- settings persistence')
+)
+const restoreInsertIndex = restoreHandler.indexOf('popupModel.append(restored)')
+const restoreAnnounceIndex = restoreHandler.indexOf('service.popupAdded(restored.app, restored.summary)')
+assert(
+  restoreInsertIndex >= 0 && restoreAnnounceIndex > restoreInsertIndex,
+  'notifications announce a startup-restored popup after insertion'
+)
+const batteryServiceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/battery/Service.qml'), 'utf8')
+const batteryReadyHandler = batteryServiceQml.slice(
+  batteryServiceQml.indexOf('function onReadyChanged()'),
+  batteryServiceQml.indexOf('target: root.notificationService')
+)
+assert(
+  batteryReadyHandler.includes('root.dismissLowBatteryWarning()'),
+  'battery retries dismissal after UPower becomes ready'
+)
+const batteryPopupHandler = batteryServiceQml.slice(
+  batteryServiceQml.indexOf('function onPopupAdded(appName, summary)'),
+  batteryServiceQml.lastIndexOf('\n  }')
+)
+assert(
+  batteryPopupHandler.includes('root.dismissLowBatteryWarning()'),
+  'battery reconciles warnings inserted after an earlier dismissal'
+)
 assert(
   /readonly property int historyLimit: 10/.test(serviceQml),
   'notifications service keeps the last ten notifications in history'


### PR DESCRIPTION
## What

- Give low-battery warnings a dedicated `omarchy-battery` app identity.
- Dismiss active and startup-restored warnings once UPower has positively resolved the machine as running on AC.
- Reconcile after power changes, UPower readiness, notification-service availability, and popup insertion so charger, delivery, and restore ordering cannot strand the critical toast.
- Preserve critical DND bypass behavior and narrowly clean up warnings persisted under the former shared `omarchy-action` identity.

## Why

The critical low-battery toast currently remains on screen indefinitely after power is connected.

This follows the behavior proposed by @defer in #6700, while adding popup-insertion and UPower-readiness reconciliation to address the [startup restore race identified in review](https://github.com/basecamp/omarchy/pull/6700#discussion_r3756751993).

## Testing

- `bash test/shell.d/battery-test.sh`
- `bash test/shell.d/notifications-test.sh`
- `bash test/shell.d/notification-send-test.sh`
- `/usr/lib/qt6/bin/qmllint -I shell shell/plugins/services/battery/Service.qml shell/plugins/notifications/Service.qml`
- Isolated Quickshell runtime check against real UPower state on AC, covering dedicated, legacy, and unrelated popup identities
- `./test/all`: CLI passed and 180/185 shell test files passed. The two desktop-runtime failures reproduce at the unmodified upstream commit; the other three require unavailable `omarchy-pkgs`/`omarchy-iso` sibling checkouts.
