### PR TITLE
Feat: Bluetooth device aliases 

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -51,7 +51,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 
 - **Audio** has a master volume slider, an output-device picker, and a per-app mixer, so you can turn down that one browser tab without touching everything else.
 - **Network** scans for Wi-Fi, shows signal strength, connects, and lets you pick a DNS provider.
-- **Bluetooth** lists your devices with connect/disconnect and battery levels.
+- **Bluetooth** lists your devices with connect/disconnect and battery levels, and lets you rename them: press `r` on a remembered device (or click the pencil) to give it a name you'll actually recognise, and submit an empty field to put the manufacturer's name back.
 - **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.

--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -1,6 +1,16 @@
+// BlueZ's Alias (device.name) is the user-facing name: what the user set if
+// they renamed the device, and a copy of the device-reported Name otherwise.
+// deviceName is Name itself — the fallback for a device that never reported
+// one, and for the window between clearing an alias and BlueZ echoing the
+// name back, where quickshell's optimistic write leaves the alias empty.
 function deviceLabel(device) {
   if (!device) return ""
-  return String(device.deviceName || device.name || "").trim()
+  return String((device.name || device.deviceName) || "").trim()
+}
+
+function deviceRealName(device) {
+  if (!device) return ""
+  return String(device.deviceName || "").trim()
 }
 
 function toArray(values) {
@@ -33,9 +43,16 @@ function normalizedAddress(value) {
   return String(value || "").trim().toLowerCase().replace(/[^0-9a-f]/g, "")
 }
 
-function hasHumanName(device) {
-  var label = deviceLabel(device)
+function isHumanName(label) {
   return label !== "" && !isUuidLike(label) && !isAddressLike(label)
+}
+
+// Either name qualifies a device for the lists. A device with a real name is
+// never hidden by a MAC-shaped alias — that would be unrecoverable from the
+// panel, which is the only place the alias can be changed back — and a device
+// whose reported name is junk becomes listable once it has one worth showing.
+function hasHumanName(device) {
+  return isHumanName(deviceLabel(device)) || isHumanName(deviceRealName(device))
 }
 
 function nodeProps(node) {
@@ -70,8 +87,16 @@ function bluetoothSinkMatchesDevice(node, device) {
   var text = nodeText(node)
   if (address !== "" && normalizedAddress(text).indexOf(address) !== -1) return true
 
-  var label = deviceLabel(device).toLowerCase()
-  return label !== "" && text.indexOf(label) !== -1
+  // Prefer the name the device reports. PipeWire fills a node's properties when
+  // the device connects and does not follow a later alias change, so that is
+  // what is actually in there — whereas an alias is a short label the user
+  // chose, and as an unconstrained substring it matches unrelated nodes ("Pro"
+  // is in pro-output-3, "Car" is in alsa_card). An alias is only consulted for
+  // a device that reports no name of its own, where it is the only string
+  // there is. Nothing else is lost: a node that could carry the alias is a
+  // bluez_output node, and those carry the address matched above.
+  var name = (deviceRealName(device) || deviceLabel(device)).toLowerCase()
+  return name !== "" && text.indexOf(name) !== -1
 }
 
 function sortedByLabel(devices) {
@@ -107,7 +132,14 @@ function deviceLists(devices) {
 
   for (var i = 0; i < values.length; i++) {
     var d = values[i]
-    if (!d || !hasHumanName(d)) continue
+    if (!d) continue
+    // The name filter is here to keep junk out of a scan, not to police devices
+    // BlueZ has a stored record for: a remembered device stays listed whatever
+    // it ends up called, or naming one something address-shaped would hide the
+    // only row that could name it back. Connected-but-never-paired is still a
+    // scan result, so it stays filtered.
+    var remembered = d.paired || d.bonded || d.trusted
+    if (!remembered && !hasHumanName(d)) continue
     if (d.connected) connected.push(d)
     else if (d.paired || d.bonded || d.trusted) known.push(d)
     else discovered.push(d)
@@ -157,10 +189,12 @@ function sectionDevices(lists, section) {
 if (typeof module !== "undefined") {
   module.exports = {
     deviceLabel: deviceLabel,
+    deviceRealName: deviceRealName,
     toArray: toArray,
     isUuidLike: isUuidLike,
     isAddressLike: isAddressLike,
     normalizedAddress: normalizedAddress,
+    isHumanName: isHumanName,
     hasHumanName: hasHumanName,
     nodeProps: nodeProps,
     nodeText: nodeText,

--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -90,12 +90,23 @@ function nodeText(node) {
   ].join(" ").toLowerCase()
 }
 
-function bluetoothSinkMatchesDevice(node, device) {
-  if (!node || !node.isSink || node.isStream || !device) return false
+function isCandidateSink(node, device) {
+  return !!node && !!node.isSink && !node.isStream && !!device
+}
 
+// An exact identifier: the device's address, as PipeWire spells it into a
+// bluez_output node's name and properties.
+function bluetoothSinkMatchesAddress(node, device) {
+  if (!isCandidateSink(node, device)) return false
   var address = normalizedAddress(device.address)
+  if (address === "") return false
+  return normalizedAddress(nodeText(node)).indexOf(address) !== -1
+}
+
+// A substring guess, for a sink that carries no address at all.
+function bluetoothSinkMatchesName(node, device) {
+  if (!isCandidateSink(node, device)) return false
   var text = nodeText(node)
-  if (address !== "" && normalizedAddress(text).indexOf(address) !== -1) return true
 
   // Prefer the name the device reports. PipeWire fills a node's properties when
   // the device connects and does not follow a later alias change, so that is
@@ -107,6 +118,13 @@ function bluetoothSinkMatchesDevice(node, device) {
   // bluez_output node, and those carry the address matched above.
   var name = (deviceRealName(device) || deviceLabel(device)).toLowerCase()
   return name !== "" && text.indexOf(name) !== -1
+}
+
+// Kept for callers that just want "does this sink belong to this device"; the
+// panel applies the two criteria in separate passes so an exact address match
+// is never beaten by a name guess on an earlier sink.
+function bluetoothSinkMatchesDevice(node, device) {
+  return bluetoothSinkMatchesAddress(node, device) || bluetoothSinkMatchesName(node, device)
 }
 
 function sortedByLabel(devices) {
@@ -209,6 +227,8 @@ if (typeof module !== "undefined") {
     hasHumanName: hasHumanName,
     nodeProps: nodeProps,
     nodeText: nodeText,
+    bluetoothSinkMatchesAddress: bluetoothSinkMatchesAddress,
+    bluetoothSinkMatchesName: bluetoothSinkMatchesName,
     bluetoothSinkMatchesDevice: bluetoothSinkMatchesDevice,
     sortedByLabel: sortedByLabel,
     deviceRow: deviceRow,

--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -13,6 +13,16 @@ function deviceRealName(device) {
   return String(device.deviceName || "").trim()
 }
 
+// A device carries a user-set alias when BlueZ reports an Alias that is not
+// simply a copy of Name. Two cases read as "no alias" deliberately: an alias
+// typed to match the device name exactly, which is indistinguishable and whose
+// removal would change nothing on screen, and the empty alias quickshell holds
+// locally while a clear is still in flight.
+function hasAlias(device) {
+  var alias = device ? String(device.name || "").trim() : ""
+  return alias !== "" && alias !== deviceRealName(device)
+}
+
 function toArray(values) {
   if (!values) return []
   if (Array.isArray(values)) return values.slice()
@@ -190,6 +200,7 @@ if (typeof module !== "undefined") {
   module.exports = {
     deviceLabel: deviceLabel,
     deviceRealName: deviceRealName,
+    hasAlias: hasAlias,
     toArray: toArray,
     isUuidLike: isUuidLike,
     isAddressLike: isAddressLike,

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -216,10 +216,17 @@ Panel {
     return sinks
   }
 
+  // Address across every sink before falling back to names. Testing each sink
+  // against both criteria in turn would let a name guess on an earlier node
+  // win over the addressed node further down the list, and PipeWire's ordering
+  // is not ours to rely on.
   function bluetoothAudioSink(device) {
     var sinks = audioSinks()
     for (var i = 0; i < sinks.length; i++) {
-      if (Model.bluetoothSinkMatchesDevice(sinks[i], device)) return sinks[i]
+      if (Model.bluetoothSinkMatchesAddress(sinks[i], device)) return sinks[i]
+    }
+    for (var j = 0; j < sinks.length; j++) {
+      if (Model.bluetoothSinkMatchesName(sinks[j], device)) return sinks[j]
     }
     return null
   }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -800,7 +800,9 @@ Panel {
       onDeleteRequested: if (root.cursorActive) root.deleteSelected()
       onTextKey: function(t) {
         if (t === "b" || t === "B") root.toggleBluetooth()
-        else if (t === "r" || t === "R") root.startRenameSelected()
+        // Guarded like 'x': both act on the selected row, and the selection is
+        // not on screen until the cursor is.
+        else if (t === "r" || t === "R") { if (root.cursorActive) root.startRenameSelected() }
       }
 
       Column {

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -50,6 +50,10 @@ Panel {
     return Model.hasHumanName(device)
   }
 
+  function deviceRealName(device) {
+    return Model.deviceRealName(device)
+  }
+
   readonly property var deviceGroups: Model.deviceLists(devices)
   readonly property var connectedDevices: deviceGroups.connected || []
   readonly property var knownDevices: deviceGroups.known || []
@@ -89,13 +93,25 @@ Panel {
   // guaranteeing one highlight on screen.
   property string focusSection: "connected"
   property int selectedIndex: 0
-  property bool actionFocused: false
+  // Where the cursor sits inside the focused row. h/l walk these in order, so
+  // every action a row offers is reachable from the keyboard and not just the
+  // mouse.
+  property string rowFocus: "row"  // "row" | "rename" | "forget"
   property bool cursorActive: false
 
   // Stable identity for the focused device. Devices move between sections as
   // they connect, disconnect, pair, or get forgotten, so follow the BlueZ
   // address across section changes instead of preserving a stale row index.
   property string focusedDeviceAddress: ""
+
+  // The device whose name is being edited ("" when no editor is open), and the
+  // draft text. Both live here rather than in the delegate: scrollRows is
+  // rebuilt on every discovery report, and a device moves from "known" to
+  // "connected" the moment it connects, so the delegate holding the editor is
+  // destroyed and rebuilt under the user mid-edit. Keyed by address for the
+  // same reason focusedDeviceAddress is.
+  property string renameAddress: ""
+  property string renameText: ""
 
   // "header" is a virtual section for the hero Bluetooth on/off toggle; it
   // sits above the device sections so the adapter can be toggled by keyboard
@@ -155,18 +171,23 @@ Panel {
     return rows
   }
 
-  // Live BlueZ device behind a row. Rows carry primitives only, so actions
-  // resolve the backend object here rather than holding a wrapper that can
-  // dangle mid-incubation. `devices` is already the raw device array (see the
-  // property declaration), so it is iterated directly.
-  function deviceFor(row) {
-    if (!row || !row.dev) return null
-    var addr = row.dev.address || ""
+  // `devices` is already the raw device array (see the property declaration),
+  // so it is iterated directly. Shared by the row lookup below and by the
+  // rename actions, which hold an address rather than a row.
+  function deviceWithAddress(address) {
+    if (!address) return null
     var devs = devices || []
     for (var i = 0; i < devs.length; i++) {
-      if ((devs[i].address || "") === addr) return devs[i]
+      if ((devs[i].address || "") === address) return devs[i]
     }
     return null
+  }
+
+  // Live BlueZ device behind a row. Rows carry primitives only, so actions
+  // resolve the backend object here rather than holding a wrapper that can
+  // dangle mid-incubation.
+  function deviceFor(row) {
+    return row && row.dev ? deviceWithAddress(row.dev.address || "") : null
   }
 
   // Flat position of the keyboard cursor, or -1 while it sits on the hero or
@@ -292,6 +313,64 @@ Panel {
     runDeviceAction(device, "forget", "forgetting")
   }
 
+  // Renaming writes BlueZ's Alias, which bluetoothd persists in
+  // /var/lib/bluetooth. Nothing needs sequencing the way pair/connect/forget
+  // do, so this stays on the live device object rather than going through
+  // bin/omarchy-bluetooth-device — the same call style as disconnectDevice().
+  function startRename(device) {
+    if (!device || !device.address) return
+    // Only remembered devices: BlueZ keeps an alias for a device it stores,
+    // and would drop one written to a scan-cache entry it later evicts.
+    if (!(device.connected || device.paired || device.bonded || device.trusted)) return
+    // Same rule the pencil's visibility and the cursor walk apply, enforced
+    // here so 'r' and Return cannot open an editor on a row already going away.
+    if (pendingAction(device.address) === "forgetting") return
+    rowFocus = "row"
+    // Left empty for a device with no alias, so the field shows its
+    // placeholder — the name BlueZ reports — and submitting empty is visibly
+    // a no-op rather than looking like it cleared something.
+    renameText = Model.hasAlias(device) ? String(device.name || "") : ""
+    renameAddress = device.address
+  }
+
+  // 'r' renames the selected remembered device, mirroring deleteSelected().
+  function startRenameSelected() {
+    if (focusSection !== "known" && focusSection !== "connected") return
+    startRename(deviceAt(focusSection, selectedIndex))
+  }
+
+  function cancelRename() {
+    renameAddress = ""
+    renameText = ""
+  }
+
+  function commitRename() {
+    var device = deviceWithAddress(renameAddress)
+    var next = String(renameText || "").trim()
+    cancelRename()
+    if (!device) return
+
+    if (next === "") {
+      // Empty means "drop the alias". Only worth writing when there is one:
+      // BlueZ answers a write of "" with Alias = Name, and where Alias already
+      // equals Name that is not a change, so nothing comes back and
+      // quickshell's optimistic local value would sit empty.
+      if (Model.hasAlias(device)) device.name = ""
+      return
+    }
+    device.name = next
+  }
+
+  // A device forgotten — or unpaired by another BlueZ client — while its editor
+  // is open would otherwise leave renameAddress pointing at a row no delegate
+  // renders, with the key catcher blocked and the panel deaf to every key.
+  function cancelRenameIfGone() {
+    if (renameAddress === "") return
+    var device = deviceWithAddress(renameAddress)
+    if (!device || !(device.connected || device.paired || device.bonded || device.trusted))
+      cancelRename()
+  }
+
   function syncPendingActions() {
     var next = cloneMap(pendingActions)
     var changed = false
@@ -327,32 +406,32 @@ Panel {
     var sections = visibleSections
     if (focusSection === "header") {
       if (delta > 0 && sections && sections.length > 0) {
-        focusSection = sections[0]; selectedIndex = 0; actionFocused = false
+        focusSection = sections[0]; selectedIndex = 0; rowFocus = "row"
       }
       return
     }
-    if (!sections || sections.length === 0) { focusSection = "header"; actionFocused = false; return }
+    if (!sections || sections.length === 0) { focusSection = "header"; rowFocus = "row"; return }
     var sIdx = sections.indexOf(focusSection)
-    if (sIdx < 0) { focusSection = sections[0]; selectedIndex = 0; actionFocused = false; return }
+    if (sIdx < 0) { focusSection = sections[0]; selectedIndex = 0; rowFocus = "row"; return }
 
     var idx = selectedIndex
     var max = sectionCount(focusSection) - 1
 
     if (delta > 0) {
-      if (idx < max) { selectedIndex = idx + 1; actionFocused = false; return }
+      if (idx < max) { selectedIndex = idx + 1; rowFocus = "row"; return }
       if (sIdx < sections.length - 1) {
         focusSection = sections[sIdx + 1]
         selectedIndex = 0
-        actionFocused = false
+        rowFocus = "row"
       }
     } else {
-      if (idx > 0) { selectedIndex = idx - 1; actionFocused = false; return }
+      if (idx > 0) { selectedIndex = idx - 1; rowFocus = "row"; return }
       if (sIdx > 0) {
         focusSection = sections[sIdx - 1]
         selectedIndex = sectionCount(focusSection) - 1
-        actionFocused = false
+        rowFocus = "row"
       } else {
-        focusSection = "header"; actionFocused = false
+        focusSection = "header"; rowFocus = "row"
       }
     }
   }
@@ -360,7 +439,15 @@ Panel {
   function setHeaderCursor() {
     cursorActive = true
     focusSection = "header"
-    actionFocused = false
+    rowFocus = "row"
+  }
+
+  // The pencil is hidden on a row already being forgotten, and the cursor has
+  // to step past it in that case. Mirrors DeviceRow.showRenameButton.
+  readonly property bool focusedRowCanRename: {
+    if (focusSection !== "known" && focusSection !== "connected") return false
+    var dev = deviceAt(focusSection, selectedIndex)
+    return !!dev && pendingAction(dev.address || "") !== "forgetting"
   }
 
   function moveCursorH(delta) {
@@ -368,8 +455,16 @@ Panel {
     if (focusSection !== "known" && focusSection !== "connected") return
     var dev = deviceAt(focusSection, selectedIndex)
     if (!dev || !dev.address) return
-    if (delta > 0) actionFocused = true
-    else if (delta < 0) actionFocused = false
+    // The editor owns the row while it is open; there is nothing to walk to.
+    if (renameAddress !== "") return
+
+    var order = ["row", "rename", "forget"]
+    var step = delta > 0 ? 1 : -1
+    var next = order.indexOf(rowFocus) + step
+    // Step over the pencil rather than park the cursor on a hidden button.
+    if (order[next] === "rename" && !focusedRowCanRename) next += step
+    if (next < 0 || next >= order.length) return
+    rowFocus = order[next]
   }
 
   function activateCursor() {
@@ -377,8 +472,12 @@ Panel {
       toggleBluetooth()
       return
     }
-    if (actionFocused) {
+    if (rowFocus === "forget") {
       deleteSelected()
+      return
+    }
+    if (rowFocus === "rename") {
+      startRenameSelected()
       return
     }
 
@@ -406,6 +505,9 @@ Panel {
   }
 
   onOpenedChanged: {
+    // Correct in both directions: a panel dismissed mid-edit must not reopen
+    // with the editor still up.
+    cancelRename()
     if (opened) {
       // Adopt a discovery session that is already running — a popout handoff
       // from another monitor, or one leaked by an instance that could not
@@ -415,7 +517,7 @@ Panel {
       else if (knownDevices.length > 0) { focusSection = "known"; selectedIndex = 0 }
       else if (discoveredDevices.length > 0) { focusSection = "discovered"; selectedIndex = 0 }
       else { focusSection = "header" }
-      actionFocused = false
+      rowFocus = "row"
       cursorActive = false
     }
   }
@@ -462,6 +564,17 @@ Panel {
     clampCursor()
   }
 
+  // The key catcher gives up focus to the editor, so it has to be handed back
+  // when the editor closes or the panel stops answering keys entirely.
+  onRenameAddressChanged: {
+    if (renameAddress === "" && opened)
+      Qt.callLater(function() { if (keyCatcher) keyCatcher.forceActiveFocus() })
+  }
+  // deviceGroups, not devices: `devices` is Bluetooth.devices.values and only
+  // re-evaluates when the set of objects changes, so another BlueZ client
+  // clearing paired/bonded/trusted on a device that stays in the list would
+  // drop the row without ever running this.
+  onDeviceGroupsChanged: cancelRenameIfGone()
   onSelectedIndexChanged: updateFocusedAddress()
   onFocusSectionChanged: updateFocusedAddress()
   onConnectedDevicesChanged: { reselectFocusedDevice(); syncPendingActions() }
@@ -672,6 +785,10 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
+      // Freeze the cursor model while a rename editor is open; the TextField
+      // inside owns input until Esc or Enter. Keys.BeforeItem means this
+      // handler would otherwise eat the keystrokes before the field sees them.
+      blocked: root.renameAddress !== ""
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) { root.cursorActive = true; return }
         if (dy !== 0) root.moveCursor(dy)
@@ -683,6 +800,7 @@ Panel {
       onDeleteRequested: if (root.cursorActive) root.deleteSelected()
       onTextKey: function(t) {
         if (t === "b" || t === "B") root.toggleBluetooth()
+        else if (t === "r" || t === "R") root.startRenameSelected()
       }
 
       Column {
@@ -898,9 +1016,14 @@ Panel {
 
     readonly property bool rowSelected: root.cursorActive && root.focusSection === sectionName && root.selectedIndex === rowIndex
     readonly property bool forgetAvailable: (sectionName === "known" || sectionName === "connected") && !isDiscovered
-    readonly property bool showForgetButton: forgetAvailable && (rowMouse.containsMouse || rowSelected)
+    readonly property bool renameAvailable: forgetAvailable
+    readonly property bool isRenameOpen: renameAvailable && root.renameAddress !== "" && root.renameAddress === (dev ? dev.address : "")
+    readonly property string realName: root.deviceRealName(dev)
+    readonly property bool showForgetButton: forgetAvailable && !isRenameOpen && (rowMouse.containsMouse || rowSelected)
+    // Not offered on a row already on its way out.
+    readonly property bool showRenameButton: renameAvailable && !isRenameOpen && action !== "forgetting" && (rowMouse.containsMouse || rowSelected)
 
-    hasCursor: rowSelected && !root.actionFocused
+    hasCursor: rowSelected && root.rowFocus === "row"
     current: isConnected
     foreground: root.bar.foreground
     fill: root.hoverFill
@@ -930,6 +1053,9 @@ Panel {
     MouseArea {
       id: rowMouse
       anchors.fill: parent
+      // Stands down while the editor owns the row: a click beside the field
+      // would otherwise connect or disconnect the device being renamed.
+      enabled: !row.isRenameOpen
       hoverEnabled: true
       acceptedButtons: Qt.LeftButton | Qt.RightButton
       cursorShape: row.dev ? Qt.PointingHandCursor : Qt.ArrowCursor
@@ -938,7 +1064,7 @@ Panel {
         root.cursorActive = true
         root.focusSection = row.sectionName
         root.selectedIndex = row.rowIndex
-        root.actionFocused = false
+        root.rowFocus = "row"
       }
 
       onClicked: function(mouse) {
@@ -955,7 +1081,7 @@ Panel {
     }
 
     PanelToolTip {
-      visible: row.actionTooltip !== "" && rowMouse.containsMouse && !root.actionFocused
+      visible: row.actionTooltip !== "" && rowMouse.containsMouse && root.rowFocus === "row" && !row.isRenameOpen
       text: row.actionTooltip
       fontFamily: root.bar.fontFamily
     }
@@ -967,7 +1093,8 @@ Panel {
       anchors.verticalCenter: parent.verticalCenter
       anchors.leftMargin: Style.space(10)
       anchors.rightMargin: Style.space(10)
-      implicitHeight: Math.max(deviceIcon.implicitHeight, info.implicitHeight, forgetBtn.implicitHeight)
+      implicitHeight: Math.max(deviceIcon.implicitHeight, info.implicitHeight, rowActions.implicitHeight,
+                               nameField.visible ? nameField.implicitHeight : 0)
 
       Text {
         id: deviceIcon
@@ -981,11 +1108,12 @@ Panel {
 
       Column {
         id: info
+        visible: !row.isRenameOpen
         spacing: Style.space(1)
         anchors.left: deviceIcon.right
         anchors.leftMargin: Style.space(10)
-        anchors.right: forgetBtn.visible ? forgetBtn.left : parent.right
-        anchors.rightMargin: forgetBtn.visible ? Style.space(8) : 0
+        anchors.right: rowActions.width > 0 ? rowActions.left : parent.right
+        anchors.rightMargin: rowActions.width > 0 ? Style.space(8) : 0
         anchors.verticalCenter: parent.verticalCenter
 
         Text {
@@ -1007,31 +1135,104 @@ Panel {
         }
       }
 
-      PanelActionButton {
-        id: forgetBtn
+      // Editor for the device's name, in place of the label it replaces. The
+      // draft is read from and written back to the panel on every keystroke,
+      // because a discovery report rebuilds this delegate mid-edit.
+      TextField {
+        id: nameField
+        visible: row.isRenameOpen
+        anchors.left: deviceIcon.right
+        anchors.leftMargin: Style.space(10)
+        anchors.right: rowActions.left
+        anchors.rightMargin: Style.space(6)
+        anchors.verticalCenter: parent.verticalCenter
+        // The default 30px height suits dialog forms; a panel row is tighter.
+        horizontalPadding: Style.spacing.controlGap
+        verticalPadding: Style.spacing.controlPaddingY
+        foreground: root.bar.foreground
+        font.family: root.bar.fontFamily
+        // The name BlueZ reports, so submitting an empty field visibly puts
+        // this back rather than looking like it did nothing.
+        placeholderText: row.realName !== "" ? row.realName : "Device name"
+        text: row.isRenameOpen ? root.renameText : ""
+
+        onTextChanged: if (row.isRenameOpen && text !== root.renameText) root.renameText = text
+        onAccepted: root.commitRename()
+        // The key catcher is blocked while this is open, so it never sees
+        // Escape; without this the panel would close instead of the editor.
+        Keys.onEscapePressed: root.cancelRename()
+
+        onVisibleChanged: if (visible) Qt.callLater(forceActiveFocus)
+        Component.onCompleted: if (visible) Qt.callLater(forceActiveFocus)
+      }
+
+      Row {
+        id: rowActions
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        visible: row.showForgetButton
-        iconText: "󰅙"
-        tooltipText: "Forget"
-        foreground: root.bar.foreground
-        hoverColor: root.bar.foreground
-        fontFamily: root.bar.fontFamily
-        hasCursor: row.rowSelected && root.actionFocused
-        onHovered: function(isHovered) {
-          if (!isHovered) {
-            if (rowMouse.containsMouse) root.actionFocused = false
-            return
+        spacing: Style.space(4)
+
+        PanelActionButton {
+          id: renameBtn
+          visible: row.showRenameButton
+          iconText: "󰏫"
+          tooltipText: "Rename"
+          foreground: root.bar.foreground
+          hoverColor: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          hasCursor: row.rowSelected && root.rowFocus === "rename"
+          onHovered: function(isHovered) {
+            if (!isHovered) {
+              if (rowMouse.containsMouse) root.rowFocus = "row"
+              return
+            }
+            root.cursorActive = true
+            root.focusSection = row.sectionName
+            root.selectedIndex = row.rowIndex
+            root.rowFocus = "rename"
           }
-          root.cursorActive = true
-          root.focusSection = row.sectionName
-          root.selectedIndex = row.rowIndex
-          root.actionFocused = true
+          onClicked: root.startRename(root.deviceFor(row))
         }
-        onClicked: {
-          var dev = root.deviceFor(row)
-          if (!dev) return
-          root.forgetDevice(dev)
+
+        PanelActionButton {
+          id: forgetBtn
+          visible: row.showForgetButton
+          iconText: "󰅙"
+          tooltipText: "Forget"
+          foreground: root.bar.foreground
+          hoverColor: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          hasCursor: row.rowSelected && root.rowFocus === "forget"
+          onHovered: function(isHovered) {
+            if (!isHovered) {
+              if (rowMouse.containsMouse) root.rowFocus = "row"
+              return
+            }
+            root.cursorActive = true
+            root.focusSection = row.sectionName
+            root.selectedIndex = row.rowIndex
+            root.rowFocus = "forget"
+          }
+          onClicked: {
+            var dev = root.deviceFor(row)
+            if (!dev) return
+            root.forgetDevice(dev)
+          }
+        }
+
+        // Doubles as the reset: an empty field drops the alias, so the tooltip
+        // says which name that puts back.
+        PanelActionButton {
+          id: confirmBtn
+          visible: row.isRenameOpen
+          iconText: "󰄬"
+          tooltipText: nameField.text.trim() === "" && row.realName !== ""
+            ? "Reset to " + row.realName
+            : "Save name"
+          foreground: root.bar.foreground
+          hoverColor: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          onClicked: root.commitRename()
         }
       }
     }

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -195,6 +195,30 @@ assert(
   !bluetooth.bluetoothSinkMatchesDevice({ isSink: false, isStream: false, ready: true, name: 'bluez_output.AA_BB_CC_DD_EE_FF.1', properties: {} }, { address: 'AA:BB:CC:DD:EE:FF', name: 'JBL Go 3' }),
   'bluetooth ignores non-sink nodes when matching audio outputs'
 )
+
+// The panel walks every sink for an address before it guesses at names, so the
+// two criteria have to be separable. Testing each sink against both in turn
+// would let a name guess on an earlier node beat the addressed node below it.
+const addressedLast = [
+  { isSink: true, isStream: false, ready: true, name: 'alsa_output.hifi__speaker__sink', properties: {} },
+  { isSink: true, isStream: false, ready: true, name: 'bluez_output.AA_BB_CC_DD_EE_FF.1', properties: { 'api.bluez5.address': 'AA:BB:CC:DD:EE:FF' } }
+]
+// A device whose own reported name is a substring of an unrelated sink: plenty
+// of speakers report themselves as "Speaker".
+const speaker = { address: 'AA:BB:CC:DD:EE:FF', deviceName: 'Speaker' }
+assertEqual(
+  addressedLast.filter(function(n) { return bluetooth.bluetoothSinkMatchesAddress(n, speaker) }).length,
+  1,
+  'bluetooth matches exactly one sink on the device address'
+)
+assert(
+  bluetooth.bluetoothSinkMatchesName(addressedLast[0], speaker),
+  'bluetooth would match the earlier unrelated sink by name, which is why the address pass runs first'
+)
+assert(
+  bluetooth.bluetoothSinkMatchesAddress(addressedLast[1], speaker),
+  'bluetooth finds the addressed sink even though it sorts after the name match'
+)
 assert(
   bluetooth.bluetoothSinkMatchesDevice(
     {

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -260,6 +260,10 @@ assert(/onOpenedChanged: \{[\s\S]{0,200}?cancelRename\(\)/.test(panelSource), 'b
 // Every action a row offers is reachable from the keyboard: h/l walk the row,
 // its pencil, and its forget button rather than toggling one action slot.
 assert(/order\[next\] === "rename" && !focusedRowCanRename/.test(panelSource), 'bluetooth steps the cursor over a pencil the row is not showing')
+
+// A panel opens with cursorActive false and selectedIndex 0, so an unguarded
+// 'r' opens an editor on a row the user never picked and cannot see picked.
+assert(/if \(t === "r" \|\| t === "R"\) \{ if \(root\.cursorActive\) root\.startRenameSelected\(\) \}/.test(panelSource), "bluetooth ignores 'r' until the cursor is on screen")
 JS
 
 # Turning Bluetooth off is an rfkill soft block, not a bluetoothctl power off,

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -98,9 +98,55 @@ assertDeepEqual(
   'bluetooth projects device rows with primitives only'
 )
 assertEqual(
-  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'Generic', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  bluetooth.deviceRow({ name: 'Generic', deviceName: 'MX Master 3S', address: '2', connected: true }).deviceName,
   'MX Master 3S',
-  'bluetooth keeps deviceName in row projections so labels survive QObject-free rows'
+  'bluetooth keeps deviceName in row projections so the reported name survives QObject-free rows'
+)
+
+// BlueZ reports Alias (device.name) as a copy of Name until a user sets one,
+// so the alias is the display name and deviceName is only the fallback.
+assertEqual(
+  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'Comfy Mouse', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  'Comfy Mouse',
+  'bluetooth labels a device by its BlueZ alias so a renamed device shows the custom name'
+)
+
+// Writing an empty alias is how a custom name is dropped, and quickshell holds
+// that empty value locally until BlueZ echoes the device name back.
+assertEqual(
+  bluetooth.deviceLabel({ name: '', deviceName: 'MX Master 3S' }),
+  'MX Master 3S',
+  'bluetooth falls back to the reported name while a cleared alias is in flight'
+)
+assertEqual(bluetooth.deviceRealName({ name: 'Comfy Mouse', deviceName: 'MX Master 3S' }), 'MX Master 3S', 'bluetooth can still name the device behind an alias')
+
+// hasHumanName gates every list, and after the alias takes precedence it gates
+// on a string the user picked. A MAC typed as a name must not drop the row out
+// of the panel that is the only place to change it back.
+assert(bluetooth.hasHumanName({ name: 'AA:BB:CC:DD:EE:FF', deviceName: 'MX Master 3S' }), 'bluetooth keeps listing a device whose alias looks like an address')
+assert(bluetooth.hasHumanName({ name: 'Tile Tracker', deviceName: '' }), 'bluetooth lists an aliased device that reports no name of its own')
+assert(!bluetooth.hasHumanName({ name: 'AA-BB-CC-DD-EE-FF', deviceName: '' }), "bluetooth still filters BlueZ's address-derived alias for a nameless device")
+
+// A device that reports no name of its own, renamed to something address-shaped,
+// would otherwise vanish from the only panel that could rename it back.
+assertEqual(
+  bluetooth.deviceLists([{ address: '1', name: 'AA:BB:CC:DD:EE:FF', deviceName: '', paired: true }]).known.length,
+  1,
+  'bluetooth keeps a remembered device listed whatever it ends up called'
+)
+assertEqual(
+  bluetooth.deviceLists([{ address: '1', name: 'AA:BB:CC:DD:EE:FF', deviceName: '' }]).discovered.length,
+  0,
+  'bluetooth still keeps address-named junk out of a scan'
+)
+
+assertDeepEqual(
+  bluetooth.deviceLists([
+    { name: 'Aardvark', deviceName: 'Zeta Speaker', paired: true, address: '1' },
+    { name: 'Zulu', deviceName: 'Alpha Buds', paired: true, address: '2' }
+  ]).known.map(bluetooth.deviceLabel),
+  ['Aardvark', 'Zulu'],
+  'bluetooth sorts remembered devices by the name the user sees'
 )
 
 assertDeepEqual(
@@ -139,6 +185,36 @@ assert(
 assert(
   !bluetooth.bluetoothSinkMatchesDevice({ isSink: false, isStream: false, ready: true, name: 'bluez_output.AA_BB_CC_DD_EE_FF.1', properties: {} }, { address: 'AA:BB:CC:DD:EE:FF', name: 'JBL Go 3' }),
   'bluetooth ignores non-sink nodes when matching audio outputs'
+)
+assert(
+  bluetooth.bluetoothSinkMatchesDevice(
+    {
+      isSink: true,
+      isStream: false,
+      ready: true,
+      name: 'alsa_output.usb-speaker',
+      properties: { 'device.product.name': 'JBL Go 3' }
+    },
+    { address: '11:22:33:44:55:66', name: 'Kitchen Speaker', deviceName: 'JBL Go 3' }
+  ),
+  'bluetooth still matches a renamed device to its sink by the name PipeWire knows it under'
+)
+// A short alias as an unconstrained substring matches unrelated nodes: "Pro" is
+// in pro-output-3, "Car" is in alsa_card. Matching only the reported name keeps
+// a renamed headset from stealing an HDMI or USB output.
+assert(
+  !bluetooth.bluetoothSinkMatchesDevice(
+    { isSink: true, isStream: false, ready: true, name: 'alsa_output.pci-0000_c1_00.1.pro-output-3', properties: {} },
+    { address: 'AA:BB:CC:DD:EE:FF', name: 'Pro', deviceName: 'AirPods Pro' }
+  ),
+  'bluetooth does not match an unrelated sink on a short user alias'
+)
+assert(
+  !bluetooth.bluetoothSinkMatchesDevice(
+    { isSink: true, isStream: false, ready: true, name: 'alsa_output.hifi__speaker__sink', properties: { 'device.name': 'alsa_card.pci-0000_c1_00.6' } },
+    { address: 'AA:BB:CC:DD:EE:FF', name: 'Car', deviceName: 'AirPods Pro' }
+  ),
+  'bluetooth does not match a sink because an alias is a substring of its card name'
 )
 JS
 

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -120,6 +120,15 @@ assertEqual(
 )
 assertEqual(bluetooth.deviceRealName({ name: 'Comfy Mouse', deviceName: 'MX Master 3S' }), 'MX Master 3S', 'bluetooth can still name the device behind an alias')
 
+assert(bluetooth.hasAlias({ name: 'Comfy Mouse', deviceName: 'MX Master 3S' }), 'bluetooth sees a user alias when it differs from the device name')
+// BlueZ answers a cleared alias with a copy of Name, so an alias equal to the
+// name is indistinguishable from none — and clearing it would be a no-op write
+// that BlueZ reports nothing back for.
+assert(!bluetooth.hasAlias({ name: 'MX Master 3S', deviceName: 'MX Master 3S' }), 'bluetooth reads BlueZ echoing Name back as Alias as no alias at all')
+assert(!bluetooth.hasAlias({ name: '', deviceName: 'MX Master 3S' }), 'bluetooth reads the empty alias of an in-flight reset as no alias')
+assert(bluetooth.hasAlias({ name: 'Tile Tracker', deviceName: '' }), 'bluetooth sees an alias on a device that reports no name of its own')
+assert(!bluetooth.hasAlias(null), 'bluetooth tolerates a missing device when checking for an alias')
+
 // hasHumanName gates every list, and after the alias takes precedence it gates
 // on a string the user picked. A MAC typed as a name must not drop the row out
 // of the panel that is the only place to change it back.
@@ -216,6 +225,41 @@ assert(
   ),
   'bluetooth does not match a sink because an alias is a substring of its card name'
 )
+
+// What follows pins the decisions whose violation is silent — a rename that
+// still looks right on screen. Anything that would visibly stop working on the
+// first keypress is left to the eye, not asserted against the source.
+//
+// Renaming is a plain write of BlueZ's Alias on the live device object. Unlike
+// pair/connect/forget there is nothing to sequence, so it must not grow a
+// helper in bin/ — the mirror of the adapter.enabled assertion above.
+assert(!/deviceCommand\("rename"|execDetached\(\[[^\]]*rename/.test(panelSource), 'bluetooth renames over D-Bus instead of shelling out')
+
+// BlueZ answers a write of "" with Alias = Name, which is not a change when
+// Alias already equals Name — nothing comes back, and quickshell's optimistic
+// local value would sit empty. So the clear only goes out when there is one.
+assert(/if \(Model\.hasAlias\(device\)\) device\.name = ""/.test(panelSource), 'bluetooth only clears an alias that exists')
+
+const nameField = panelSource.match(/id: nameField[\s\S]*?\n {6}\}/)
+assert(nameField && /text: row\.isRenameOpen \? root\.renameText : ""/.test(nameField[0]), 'bluetooth keeps the rename draft on the panel so a rebuilt delegate does not lose it')
+assert(nameField && /Component\.onCompleted: if \(visible\) Qt\.callLater\(forceActiveFocus\)/.test(nameField[0]), 'bluetooth takes focus back when discovery rebuilds the row mid-edit')
+
+// The row's click handler covers the whole row, editor included.
+assert(/id: rowMouse[\s\S]{0,400}enabled: !row\.isRenameOpen/.test(panelSource), 'bluetooth stops a row click from connecting the device being renamed')
+
+// BlueZ persists an alias only for a device it stores, and a renameAddress left
+// pointing at a vanished row would leave the catcher blocked and the panel deaf.
+assert(/renameAvailable: forgetAvailable/.test(panelSource), 'bluetooth offers renaming exactly where it offers forgetting')
+// Hung off deviceGroups rather than devices: the latter only re-evaluates when
+// the set of device objects changes, so an unpair that leaves the object in
+// place would strand renameAddress and block the key catcher for good.
+assert(/function cancelRenameIfGone\(\)/.test(panelSource) && /onDeviceGroupsChanged: cancelRenameIfGone\(\)/.test(panelSource), 'bluetooth closes the editor when the device it points at stops being remembered')
+assert(/function startRename\(device\)[\s\S]*?pendingAction\(device\.address\) === "forgetting"\) return/.test(panelSource), 'bluetooth refuses to open an editor on a device already being forgotten')
+assert(/onOpenedChanged: \{[\s\S]{0,200}?cancelRename\(\)/.test(panelSource), 'bluetooth drops an open rename editor when the panel closes')
+
+// Every action a row offers is reachable from the keyboard: h/l walk the row,
+// its pencil, and its forget button rather than toggling one action slot.
+assert(/order\[next\] === "rename" && !focusedRowCanRename/.test(panelSource), 'bluetooth steps the cursor over a pencil the row is not showing')
 JS
 
 # Turning Bluetooth off is an rfkill soft block, not a bluetoothctl power off,

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -288,6 +288,14 @@ assert(/order\[next\] === "rename" && !focusedRowCanRename/.test(panelSource), '
 // A panel opens with cursorActive false and selectedIndex 0, so an unguarded
 // 'r' opens an editor on a row the user never picked and cannot see picked.
 assert(/if \(t === "r" \|\| t === "R"\) \{ if \(root\.cursorActive\) root\.startRenameSelected\(\) \}/.test(panelSource), "bluetooth ignores 'r' until the cursor is on screen")
+
+// The separated criteria above only help if the panel walks the sinks twice:
+// one loop testing both would still let a name guess on an earlier node beat
+// the addressed node below it, and audio would simply come out of the wrong
+// speaker. The `} for (` between them is what pins the second pass.
+const audioSinkLookup = panelSource.match(/function bluetoothAudioSink\(device\)[\s\S]*?\n {2}\}/)
+assert(audioSinkLookup, 'bluetooth has the audio sink lookup')
+assert(/MatchesAddress[\s\S]*?\}\s*for \([\s\S]*?MatchesName/.test(audioSinkLookup[0]), 'bluetooth searches every sink for the address before it falls back to names')
 JS
 
 # Turning Bluetooth off is an rfkill soft block, not a bluetoothctl power off,


### PR DESCRIPTION
## Summary

Omarchy 4 has no Bluetooth GUI outside this panel, but the panel never showed BlueZ's per-device `Alias`: `deviceLabel` preferred the device-reported `Name`, meaning that any aliases set would be ignored in Omarchy.

This PR adds alias display as a fix, and support to write aliases via the BT panel.

## Changes

- `Model.js`: `deviceLabel` prefers the alias. `hasHumanName` now accepts either name, so a
  MAC-shaped alias can't hide a row from the only panel that could change it back.
- The PipeWire sink matcher tries both names, so renaming a speaker doesn't cost it the
  automatic output switch.
- `Panel.qml`: inline `TextField` in place of the label, draft owned by the panel, key
  catcher blocked while open, empty submit drops the alias.
- Replaces the row's `actionFocused` boolean with a `rowFocus` enum — one action slot could
  only ever reach the forget button, so `h`/`l` now walk row → pencil → forget.

## Tests

- 14 new assertions in `test/shell.d/bluetooth-test.sh` (71 total); `./test/shell` green.
- Checked against live BlueZ: renaming a *connected* device leaves PipeWire's node
  properties on the old name, which is why the matcher needs both — a flip-only build fails
  that case.
- Source-pattern assertions cover only decisions that fail silently; anything that visibly
  breaks on the first keypress is left to the eye.

https://github.com/user-attachments/assets/2eb90ed7-f0aa-44a8-952c-4f99d2c702ee