### PR TITLE
Hint at the ELAN 04f3:0c4b generic-driver matching bug in fingerprint setup

### DIFF
--- a/bin/omarchy-hw-fingerprint-generic-driver-risk
+++ b/bin/omarchy-hw-fingerprint-generic-driver-risk
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Prints the connected reader's USB id and exits 0 if it is known to fail matching under the generic driver
+# omarchy:hidden=true
+
+# A handful of Elan match-on-chip-shaped readers enroll fine under the
+# generic libfprint elan.c driver but never produce a working software
+# match — fprintd-verify fails every time, with no indication that the
+# driver is the problem rather than technique. Confirmed on 04f3:0c4b
+# (ThinkPad E15 Gen3 AMD): consistently 0-score matches across 25+ verify
+# attempts under elan.c, resolved by switching to Lenovo's proprietary ELAN
+# MOH driver via libfprint-tod instead — see
+# https://github.com/jcperdomoybarra/thinkpad-elan-04f3-0c4b-fingerprint-fix
+known_generic_matching_failure_ids=" 04f3:0c4b "
+usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
+
+for dev in "$usb_devices_path"/*; do
+  [[ -r $dev/idVendor && -r $dev/idProduct ]] || continue
+  id="$(<"$dev/idVendor"):$(<"$dev/idProduct")"
+  if [[ $known_generic_matching_failure_ids == *" $id "* ]]; then
+    echo "$id"
+    exit 0
+  fi
+done
+
+exit 1

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -71,6 +71,12 @@ if ! omarchy-hw-fingerprint; then
   exit 1
 fi
 
+# Some readers are known to enroll fine but never produce a working software
+# match under the generic driver (see omarchy-hw-fingerprint-generic-driver-risk).
+# Checked here — not blocked on — so normal setup still runs first; only used
+# below to give a more useful failure message than "try again".
+generic_matching_failure_device=$(omarchy-hw-fingerprint-generic-driver-risk || true)
+
 # Install required packages
 echo "Installing required packages..."
 
@@ -104,6 +110,9 @@ if sudo fprintd-enroll "$USER"; then
     echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
   else
     echo -e "\e[31m\nVerification failed. You may want to try enrolling again.\e[0m"
+    if [[ -n $generic_matching_failure_device ]]; then
+      echo -e "\e[33mNote: reader $generic_matching_failure_device is known to enroll but never verify under the generic driver — see https://github.com/jcperdomoybarra/thinkpad-elan-04f3-0c4b-fingerprint-fix for a workaround.\e[0m"
+    fi
   fi
 else
   echo -e "\e[31m\nEnrollment failed. Please try again.\e[0m"

--- a/test/shell.d/hw-fingerprint-generic-driver-risk-test.sh
+++ b/test/shell.d/hw-fingerprint-generic-driver-risk-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+write_usb_devices() {
+  rm -rf "$tmp_dir/devices"
+  mkdir -p "$tmp_dir/devices"
+
+  local index=0
+  local spec
+  for spec in "$@"; do
+    local vendor=${spec%%:*}
+    local product_id=${spec#*:}
+    local dev="$tmp_dir/devices/1-$index"
+
+    mkdir -p "$dev"
+    printf '%s\n' "$vendor" >"$dev/idVendor"
+    printf '%s\n' "$product_id" >"$dev/idProduct"
+    index=$((index + 1))
+  done
+}
+
+hw_fingerprint_generic_driver_risk() {
+  OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-fingerprint-generic-driver-risk"
+}
+
+write_usb_devices '04f3:0c4b'
+output=$(hw_fingerprint_generic_driver_risk) || fail "a known-risk reader (04f3:0c4b) is flagged"
+[[ $output == "04f3:0c4b" ]] || fail "a known-risk reader (04f3:0c4b) is flagged" "expected id '04f3:0c4b', got '$output'"
+pass "a known-risk reader (04f3:0c4b) is flagged"
+
+write_usb_devices '27c6:5385'
+if hw_fingerprint_generic_driver_risk >/dev/null; then
+  fail "an unrelated reader is not flagged"
+fi
+pass "an unrelated reader is not flagged"
+
+write_usb_devices
+if hw_fingerprint_generic_driver_risk >/dev/null; then
+  fail "no connected devices is not flagged"
+fi
+pass "no connected devices is not flagged"


### PR DESCRIPTION
## What

Hardware: ELAN `04f3:0c4b` fingerprint reader (confirmed on a ThinkPad E15 Gen3 AMD, likely present on other E14/E15 Gen3/Gen4 units — see #7483).

Under the generic `libfprint` `elan.c` driver, this reader enrolls fine (`fprintd-enroll` completes normally) but `fprintd-verify` never produces a working match — the score is consistently `0` regardless of technique, across 25+ verify attempts in my own testing. `omarchy-setup-security-fingerprint` currently reports this as a generic "Verification failed. You may want to try enrolling again." with no way to tell a driver limitation from a bad enrollment.

Lenovo ships a proprietary "ELAN MOH" driver for this exact PID, usable on Linux via `libfprint-tod` + the `libfprint-2-tod1-elan` AUR package. Switching to it fixed the reader completely (10/10 clean `verify-match`, `sudo`/polkit/lock screen all working) — full writeup, evidence, and a reproducible procedure at https://github.com/jcperdomoybarra/thinkpad-elan-04f3-0c4b-fingerprint-fix. I filed #7483 with this same summary a couple of days ago; this PR is the actual code half of that.

## Why this shape

This does **not** bundle or install the proprietary driver — it's a closed-source binary from Lenovo, not something to pull into Omarchy directly. It only adds:

1. `bin/omarchy-hw-fingerprint-generic-driver-risk` — a small helper (mirrors `omarchy-hw-fingerprint`'s shape and `OMARCHY_USB_DEVICES_PATH` override for testability) that detects a known-risk reader by USB id and prints it.
2. A one-line hook into `omarchy-setup-security-fingerprint`'s existing verify-failure branch, pointing at the workaround instead of just "try again" — only shown for the exact confirmed-affected id, not a general driver-quality guess.

Kept the known-id list to just `04f3:0c4b` (the one I've actually verified end to end) rather than guessing at siblings — easy to extend later if others confirm the same failure mode on a different PID.

## Testing

- `test/shell.d/hw-fingerprint-generic-driver-risk-test.sh` (new), same fixture pattern as `hw-fingerprint-test.sh`.
- Ran the full `test/shell` suite locally — all passing, including the pre-existing fingerprint tests.
- Verified the actual failure/workaround on real hardware (the ThinkPad in #7483).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
