### PR TITLE
Stop a wedged blank or wake child from silently disabling the lock screen's display control

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -156,7 +156,7 @@ Item {
     idleBlankTimer.stop()
     sessionLock.locked = false
     logEvent("unlocked")
-    runWake()
+    forceWake()
   }
 
   function armBlankTimer() {
@@ -164,13 +164,23 @@ Item {
     idleBlankTimer.restart()
   }
 
+  // Pointer motion calls this at input rate, so coalesce. The reused Process
+  // this replaced coalesced too, until a child that never exited pinned it.
   function runWake() {
-    if (!wakeProcess.running) wakeProcess.running = true
+    if (!wakeCoalesceTimer.running) forceWake()
     if (lockRequested) armBlankTimer()
   }
 
+  // Unlock gets no second chance: the surface is gone, so no later input can
+  // ask again for a wake the coalescing window swallowed.
+  function forceWake() {
+    wakeCoalesceTimer.restart()
+    Quickshell.execDetached(["bash", "-c", "omarchy-system-wake"])
+  }
+
   function runBlank() {
-    if (!blankProcess.running) blankProcess.running = true
+    logEvent("blank-requested")
+    Quickshell.execDetached(["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"])
   }
 
   function submitPassword(value) {
@@ -257,7 +267,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.resetAuthenticationState()
-        root.runWake()
+        root.forceWake()
       }
     }
 
@@ -401,14 +411,10 @@ Item {
     }
   }
 
-  Process {
-    id: wakeProcess
-    command: ["bash", "-c", "omarchy-system-wake"]
-  }
-
-  Process {
-    id: blankProcess
-    command: ["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"]
+  Timer {
+    id: wakeCoalesceTimer
+    interval: 1000
+    repeat: false
   }
 
   Timer {

--- a/test/shell.d/lock-blank-spawn-test.sh
+++ b/test/shell.d/lock-blank-spawn-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// A Quickshell Process is `running` while its child exists, so reusing one for
+// blank and wake turns a single child that never exits into a display that
+// never blanks -- or, through runWake(), never comes back -- until the shell
+// restarts. Nothing times it out, and the lock IPC cannot see it happen.
+assert(
+  !/id: (blank|wake)Process/.test(serviceQml),
+  'blank and wake do not run through a Process reused across invocations'
+)
+
+assert(
+  /function runBlank\(\) \{[\s\S]*?Quickshell\.execDetached\(\["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"\]\)/.test(serviceQml),
+  'the blank spawns statelessly'
+)
+
+assert(
+  /function forceWake\(\) \{[\s\S]*?Quickshell\.execDetached\(\["bash", "-c", "omarchy-system-wake"\]\)/.test(serviceQml),
+  'the wake spawns statelessly'
+)
+
+// Pointer motion calls runWake() at input rate, so dropping the old Process
+// guard without a replacement forks a shell per motion event. A Timer rather
+// than wall-clock arithmetic, so a clock stepping backwards cannot suppress it.
+assert(
+  /function runWake\(\) \{\s*if \(!wakeCoalesceTimer\.running\) forceWake\(\)/.test(serviceQml),
+  'the wake coalesces on a timer instead of on a process it can no longer see'
+)
+
+assert(
+  /function forceWake\(\) \{\s*wakeCoalesceTimer\.restart\(\)/.test(serviceQml),
+  'every wake opens the coalescing window'
+)
+
+// The lock surface is gone by the time these run, so nothing is left to ask
+// again for a wake the coalescing window swallowed.
+assert(
+  /function finishUnlock\(\)[\s\S]*?logEvent\("unlocked"\)\s*forceWake\(\)/.test(serviceQml),
+  'unlock always wakes'
+)
+
+assert(
+  /if \(!locked && root\.lockRequested\) \{[\s\S]*?root\.forceWake\(\)/.test(serviceQml),
+  'losing the session lock always wakes'
+)
+
+// The silence is half the bug: nothing in the journal said the blank was skipped.
+assert(
+  /function runBlank\(\) \{\s*logEvent\("blank-requested"\)/.test(serviceQml),
+  'every blank is recorded'
+)
+JS


### PR DESCRIPTION
After locking, the display never powers off, and once it starts the shell never blanks again until `omarchy restart shell`.

`runBlank()` and `runWake()` each drove a single `Process` object created once and reused for the life of the shell. Quickshell's `Process` is `running` while its `QProcess` exists and clears only on `QProcess::finished`, so one child that never exits pins the object true forever — `startProcessIfReady()` returns while a process exists, and the `if (!process.running)` guard in front of it drops the request outright rather than deferring it to an exit that never arrives. Every blank and every wake after that is discarded with no timeout, no reset, no log line, and nothing in the service's IPC `status()` to see it by.

The blank half leaves the panel lit behind the lock surface. The wake half is worse and was latent in the same code: `runWake()` is what unlock, a failed password, a lost session lock, and every key and pointer event call to bring the display back, so a wedged wake leaves a black screen that does not answer input.

Both spawns are now stateless, which removes the state that could latch. `runWake()` still coalesces, because `LockView`'s full-surface `MouseArea` sets `hoverEnabled` and calls it from `onPositionChanged` — so without a replacement, moving the mouse on the lock screen would fork a `bash` plus two `hyprctl` round trips per motion event. It coalesces on a `Timer` rather than on wall-clock arithmetic a backwards clock step could suppress, and unlock and a lost session lock bypass the window entirely, since the surface is gone by then and no later input can ask again. `runBlank()` logs `blank-requested`, so the next blank that goes missing says so in the journal and in `lastEvent`.

What made one child stop exiting after roughly a day is not established, and this does not claim to fix it — it makes it survivable. The likeliest candidate is an unbounded `hyprctl` call: `omarchy-brightness-display` resolves the focused monitor through `hyprctl monitors -j | jq` before it reaches the `off` branch that never uses the answer, and neither that call nor the DPMS dispatch after it has a timeout. Hoisting that query below the `off`/`on` branches would remove one such call from every blank and every wake, and is worth doing separately.

Note for sequencing: #7179 rewrites both `runWake()` and `runBlank()` for fingerprint thermal backoff and will conflict textually, and #6538 and #6642 both edit `blankProcess`'s command line, which is gone here. None of them change the spawn semantics, so all three resolve by reapplying their own change to the new bodies.

Fixes #7652
