### PR TITLE
Add a reveal toggle to the lock screen password field

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -16,6 +16,7 @@ Item {
   property bool loadBackground: true
   property string passwordText: ""
   property bool syncingPasswordText: false
+  property bool passwordRevealed: false
 
   readonly property string placeholderText: "Enter Password"
   readonly property int fieldWidth: 381
@@ -27,10 +28,16 @@ Item {
   // Space to keep clear on each side of the field for the fingerprint icon
   // (icon width plus a gap) so the centered dots never run under it.
   readonly property real fingerprintReserve: fingerprintConfigured ? Math.round(fingerprintIcon.implicitWidth + 12) : 0
+  // Same idea, for the always-on reveal toggle.
+  readonly property real eyeReserve: Math.round(eyeButton.width + 4)
   // Shrink the dots to fit once the password outgrows the field, so every
   // keystroke stays visible — otherwise long passwords clip with no feedback.
   readonly property real passwordDotScale: dotMetrics.advanceWidth > 0
     ? Math.min(1, (passwordInput.width - 4) / dotMetrics.advanceWidth)
+    : 1
+  // Same idea as passwordDotScale, but for the revealed plain-text password.
+  readonly property real revealedTextScale: revealedMetrics.advanceWidth > 0
+    ? Math.min(1, (passwordInput.width - 4) / revealedMetrics.advanceWidth)
     : 1
   readonly property bool showPasswordCursor: inputEnabled && !authenticatingPassword && failureMessage.length === 0
   readonly property bool errorState: failureMessage.length > 0
@@ -86,6 +93,15 @@ Item {
     text: "●".repeat(passwordInput.text.length)
   }
 
+  // Measures the revealed plain-text password; revealedTextScale compares
+  // this against the field width to decide how far it must shrink to fit.
+  TextMetrics {
+    id: revealedMetrics
+    font.family: Style.font.family
+    font.pixelSize: root.fieldFontSize
+    text: passwordInput.text
+  }
+
   Rectangle {
     anchors.fill: parent
     color: Color.background
@@ -133,26 +149,31 @@ Item {
         id: passwordInput
         anchors.fill: parent
         anchors.topMargin: inputField.borderTop
-        // Reserve the fingerprint icon's width on both sides so the centered
-        // dots stay symmetric and never slide under the icon as they grow.
-        anchors.rightMargin: inputField.borderRight + 18 + root.fingerprintReserve
+        // Reserve the icons' width on both sides so the centered dots stay
+        // symmetric and never slide under them as the password grows.
+        anchors.rightMargin: inputField.borderRight + 18 + root.fingerprintReserve + root.eyeReserve
         anchors.bottomMargin: inputField.borderBottom
-        anchors.leftMargin: inputField.borderLeft + 18 + root.fingerprintReserve
+        anchors.leftMargin: inputField.borderLeft + 18 + root.fingerprintReserve + root.eyeReserve
         verticalAlignment: TextInput.AlignVCenter
         horizontalAlignment: TextInput.AlignHCenter
         activeFocusOnPress: true
         clip: true
         enabled: root.inputEnabled && !root.authenticatingPassword
         readOnly: root.authenticatingPassword
-        echoMode: TextInput.Password
+        echoMode: root.passwordRevealed ? TextInput.Normal : TextInput.Password
         passwordCharacter: "\u25CF"
         passwordMaskDelay: 0
         color: Color.lock.text
         selectionColor: Color.lock.selection
         selectedTextColor: Color.lock.text
         font.family: Style.font.family
-        font.pixelSize: text.length > 0 ? Math.max(1, Math.floor(root.passwordDotFontSize * root.passwordDotScale)) : root.fieldFontSize
-        font.letterSpacing: text.length > 0 ? root.passwordDotLetterSpacing * root.passwordDotScale : 0
+        font.pixelSize: {
+          if (text.length === 0) return root.fieldFontSize
+          return root.passwordRevealed
+            ? Math.max(1, Math.floor(root.fieldFontSize * root.revealedTextScale))
+            : Math.max(1, Math.floor(root.passwordDotFontSize * root.passwordDotScale))
+        }
+        font.letterSpacing: text.length > 0 && !root.passwordRevealed ? root.passwordDotLetterSpacing * root.passwordDotScale : 0
         cursorVisible: activeFocus && root.showPasswordCursor && text.length > 0
         cursorDelegate: Rectangle {
           width: 2
@@ -164,6 +185,9 @@ Item {
           if (!root.syncingPasswordText) root.passwordTextEdited(text)
           if (text.length > 0) {
             root.wakeRequested()
+          } else {
+            // Don't leave the field armed to reveal next time someone starts typing.
+            root.passwordRevealed = false
           }
           if (text.length > 0 && root.failureMessage.length > 0) root.clearFailureRequested()
         }
@@ -178,6 +202,12 @@ Item {
           root.wakeRequested()
           if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
+            event.accepted = true
+          } else if (event.modifiers === Qt.ControlModifier && event.key === Qt.Key_Space) {
+            // Ctrl+Space (not Alt-based, so it won't collide with AltGr
+            // composition on non-US keyboard layouts) reveals the password
+            // without touching the mouse.
+            root.passwordRevealed = !root.passwordRevealed
             event.accepted = true
           }
         }
@@ -212,6 +242,45 @@ Item {
         font.pixelSize: Math.round(root.fieldFontSize * 1.1)
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
+      }
+
+      // Eye toggle: click-and-hold-free reveal of the password. Sits just
+      // inside the fingerprint icon (or in its spot, when no sensor is
+      // enrolled) and never steals focus from the text field. Always shown
+      // (dimmed while empty) so it's easy to spot before you start typing.
+      Rectangle {
+        id: eyeButton
+        objectName: "passwordRevealToggle"
+        width: eyeIcon.implicitWidth + 16
+        height: eyeIcon.implicitHeight + 12
+        radius: height / 2
+        anchors.right: root.fingerprintConfigured ? fingerprintIcon.left : parent.right
+        anchors.rightMargin: root.fingerprintConfigured ? 12 : inputField.borderRight + 12
+        anchors.verticalCenter: parent.verticalCenter
+        color: eyeArea.containsMouse ? Util.alpha(Color.lock.text, 0.12) : "transparent"
+
+        Text {
+          id: eyeIcon
+          anchors.centerIn: parent
+          text: root.passwordRevealed ? "󰈉" : "󰈈"
+          color: passwordInput.text.length > 0
+            ? (root.passwordRevealed ? Color.lock.text : Util.alpha(Color.lock.text, 0.8))
+            : Util.alpha(Color.lock.text, 0.35)
+          font.family: Style.font.family
+          font.pixelSize: Math.round(root.fieldFontSize * 1.1)
+        }
+
+        MouseArea {
+          id: eyeArea
+          anchors.fill: parent
+          hoverEnabled: true
+          cursorShape: passwordInput.text.length > 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
+          enabled: passwordInput.text.length > 0
+          onClicked: {
+            root.passwordRevealed = !root.passwordRevealed
+            root.forcePasswordFocus()
+          }
+        }
       }
     }
   }

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -296,6 +296,11 @@ Item {
             root.forcePasswordFocus()
           }
         }
+
+        PanelToolTip {
+          visible: eyeArea.containsMouse
+          text: (root.passwordRevealed ? "Hide password" : "Show password") + "  ·  Ctrl+Space"
+        }
       }
     }
   }

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -67,6 +67,14 @@ Item {
     passwordTextEdited("")
   }
 
+  // Shared by the mouse toggle and the Ctrl+Space shortcut. Guarded on
+  // non-empty input so neither path can arm a reveal that then applies to
+  // the next attempt's first keystrokes once the field re-fills.
+  function toggleReveal() {
+    if (passwordInput.text.length === 0) return
+    passwordRevealed = !passwordRevealed
+  }
+
   function syncPasswordText() {
     if (passwordInput.text === passwordText) return
     syncingPasswordText = true
@@ -207,7 +215,7 @@ Item {
             // Ctrl+Space (not Alt-based, so it won't collide with AltGr
             // composition on non-US keyboard layouts) reveals the password
             // without touching the mouse.
-            root.passwordRevealed = !root.passwordRevealed
+            root.toggleReveal()
             event.accepted = true
           }
         }
@@ -259,6 +267,12 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         color: eyeArea.containsMouse ? Util.alpha(Color.lock.text, 0.12) : "transparent"
 
+        Accessible.role: Accessible.Button
+        Accessible.name: root.passwordRevealed ? "Hide password" : "Show password"
+        Accessible.description: "Toggle whether the typed password is shown in plain text"
+        Accessible.focusable: passwordInput.text.length > 0
+        Accessible.onPressAction: root.toggleReveal()
+
         Text {
           id: eyeIcon
           anchors.centerIn: parent
@@ -272,12 +286,13 @@ Item {
 
         MouseArea {
           id: eyeArea
+          objectName: "passwordRevealMouseArea"
           anchors.fill: parent
           hoverEnabled: true
           cursorShape: passwordInput.text.length > 0 ? Qt.PointingHandCursor : Qt.ArrowCursor
           enabled: passwordInput.text.length > 0
           onClicked: {
-            root.passwordRevealed = !root.passwordRevealed
+            root.toggleReveal()
             root.forcePasswordFocus()
           }
         }

--- a/test/shell.d/fixtures/lock-password-reveal/shell.qml
+++ b/test/shell.d/fixtures/lock-password-reveal/shell.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import Quickshell
+import qs.Commons
+
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
+  property var failures: []
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures
+    })
+
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  Item { id: host; width: 800; height: 600 }
+
+  TextMetrics {
+    id: probe
+    font.family: Style.font.family
+  }
+
+  Timer {
+    interval: 1
+    running: true
+    repeat: false
+    onTriggered: {
+      try {
+        var component = Qt.createComponent("file://" + root.rootPath + "/shell/plugins/lock/LockView.qml", Component.PreferSynchronous)
+        if (component.status !== Component.Ready) {
+          root.fail("LockView failed to load: " + component.errorString())
+          return
+        }
+
+        var view = component.createObject(host, { width: 800, height: 600, loadBackground: false })
+        if (!view) {
+          root.fail("LockView failed to instantiate: " + component.errorString())
+          return
+        }
+
+        var toggle = findByObjectName(view, "passwordRevealMouseArea")
+        root.assertTrue(toggle !== null, "reveal toggle mouse area exists in the lock view")
+
+        // Empty-field no-op: neither entry point can arm a reveal with
+        // nothing typed yet.
+        root.assertTrue(!view.passwordRevealed, "starts hidden")
+        root.assertTrue(toggle && !toggle.enabled, "reveal toggle is disabled while the field is empty")
+        view.toggleReveal()
+        root.assertTrue(!view.passwordRevealed, "toggling on an empty field is a no-op, mirroring the disabled mouse button")
+
+        // Both toggle paths (the mouse handler and the Ctrl+Space shortcut)
+        // call the same root.toggleReveal(), so exercising it here covers
+        // both call sites' shared logic.
+        view.passwordText = "hunter2"
+        root.assertTrue(toggle && toggle.enabled, "reveal toggle is enabled once there is text")
+        view.toggleReveal()
+        root.assertTrue(view.passwordRevealed, "toggling with text present reveals the password")
+        view.toggleReveal()
+        root.assertTrue(!view.passwordRevealed, "toggling again re-hides the password")
+
+        // Reset on clear/submit: both the clear shortcuts (Escape, Ctrl+U)
+        // and a submit funnel through passwordTextEdited("") externally,
+        // which round-trips back into passwordText -- exactly what this
+        // reproduces directly.
+        view.toggleReveal()
+        root.assertTrue(view.passwordRevealed, "revealed before the field is cleared")
+        view.passwordText = ""
+        root.assertTrue(!view.passwordRevealed, "clearing the field resets reveal state, so the next attempt starts masked")
+
+        // Revealed-text overflow: a long revealed password must still be
+        // clamped to fit the field, the same guarantee already covered for
+        // masked dots by the lock-password-overflow test.
+        view.passwordText = "x".repeat(80)
+        view.passwordRevealed = true
+        probe.font.pixelSize = Math.max(1, Math.floor(view.fieldFontSize * view.revealedTextScale))
+        probe.font.letterSpacing = 0
+        probe.text = view.passwordText
+        root.assertTrue(probe.advanceWidth <= view.fieldWidth,
+          "revealed text fits inside the field, need " + probe.advanceWidth + "px of " + view.fieldWidth)
+        root.assertTrue(view.revealedTextScale < 1, "an 80-char revealed password shrinks to fit, got scale " + view.revealedTextScale)
+
+        view.destroy()
+      } catch (error) {
+        root.fail("lock password reveal fixture threw: " + error)
+      } finally {
+        root.writeResult()
+      }
+    }
+  }
+
+  function findByObjectName(node, name) {
+    if (!node) return null
+    if (node.objectName === name) return node
+    var kids = node.children || []
+    for (var i = 0; i < kids.length; i++) {
+      var found = findByObjectName(kids[i], name)
+      if (found) return found
+    }
+    return null
+  }
+}

--- a/test/shell.d/lock-password-reveal-test.sh
+++ b/test/shell.d/lock-password-reveal-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "lock password reveal test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping lock password reveal test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/lock-password-reveal"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/lock-password-reveal/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "lock password reveal quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "lock password reveal test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Lock password reveal result:\n' >&2
+  jq . "$result" >&2
+  printf 'Lock password reveal log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "password reveal toggle behaves correctly"
+fi
+
+pass "password reveal toggle behaves correctly"


### PR DESCRIPTION
## Problem
The lock screen password field only ever shows dots. There's no way to check what you typed before submitting, so a single typo means guessing again -- more annoying the longer/more complex the password is.

## Solution
- Add an eye button pinned inside the field (to the left of the fingerprint icon, when one is configured) that toggles the field between masked and plain text.
- Add `Ctrl+Space` as a mouse-free equivalent.
- The toggle stays visible but dimmed while the field is empty (nothing to reveal yet), and brightens once you start typing.
- Revealing resets to masked whenever the field is cleared (Escape, Ctrl+U, or a submit attempt), so it never carries over into the next attempt.
- The fingerprint-icon reserved-space math is untouched (`fingerprintReserve`); the eye toggle gets its own `eyeReserve`, and both are summed for the field's margins.

## Why `Ctrl+Space`
There's no established convention here -- no OS, browser, or password manager agrees on one shortcut for this. I deliberately avoided an Alt-based chord: Alt (and AltGr specifically) composes special characters on many non-US keyboard layouts, French AZERTY among them, so an Alt combo risked colliding with that.

## Screenshots

Masked (default) | Revealed (toggled)
:---:|:---:
![masked](https://raw.githubusercontent.com/thooams/omarchy/pr-assets/7680/lock-password-masked.png) | ![revealed](https://raw.githubusercontent.com/thooams/omarchy/pr-assets/7680/lock-password-revealed.png)

## Testing
- `qmllint shell/plugins/lock/LockView.qml`
- `test/shell.d/lock-fingerprint-indicator-test.sh` and `test/shell.d/lock-password-overflow-test.sh` (both exercise the reserved-space math this change also touches)
- Full `test/shell` (185 files) and `test/cli` (116 files) suites -- the only 3 shell-suite failures need a sibling `omarchy-pkgs` checkout and are unrelated to this change
- Manually verified with `omarchy-shell lock preview` and a real `omarchy system lock` session