### PR TITLE
Show hours since battery was plugged in

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -1,16 +1,23 @@
 #!/bin/bash
 
 # omarchy:summary=Returns a formatted battery status string with percentage and power draw/charge.
-# omarchy:args=[--shell]
+# omarchy:args=[--shell|--record-plugged-at <online> <timestamp>]
 
 shell_output=false
 power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+plugged_state="${OMARCHY_BATTERY_PLUGGED_STATE:-$HOME/.local/state/omarchy/battery-plugged-at}"
 
 case "${1:-}" in
   "")
     ;;
   --shell)
     shell_output=true
+    ;;
+  --record-plugged-at)
+    [[ ${2:-} == "1" && ${3:-} =~ ^[0-9]+$ ]] || exit 2
+    mkdir -p "$(dirname "$plugged_state")"
+    printf 'online=1\ntimestamp=%s\n' "$3" >"$plugged_state"
+    exit 0
     ;;
   *)
     echo "Usage: omarchy-battery-status [--shell]" >&2
@@ -106,6 +113,12 @@ if [[ $shell_output == "true" ]]; then
   printf 'rate\t%s\n' "${power_rate}W"
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
+
+  plugged_at=""
+  if [[ -r $plugged_state ]]; then
+    plugged_at=$(awk -F= '$1 == "timestamp" && $2 ~ /^[0-9]+$/ { print $2; exit }' "$plugged_state")
+  fi
+  printf 'plugged-at\t%s\n' "$plugged_at"
 
   cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
 

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -20,6 +20,17 @@ function parseKeyValue(raw) {
   return next
 }
 
+function hoursSincePluggedAt(value, now) {
+  var seconds = Number(value)
+  if (!Number.isFinite(seconds) || seconds <= 0) return "—"
+
+  var elapsed = Math.max(0, Number(now === undefined ? Date.now() : now) - seconds * 1000)
+  var hours = Math.floor(elapsed / (60 * 60 * 1000))
+  var minutes = Math.floor((elapsed % (60 * 60 * 1000)) / (60 * 1000))
+  if (hours === 0 && minutes === 0) return "less than 1 minute"
+  return hours + "h " + minutes + "m"
+}
+
 function parseProfiles(raw, previousIndex) {
   var lines = String(raw || "").split("\n")
   var list = []
@@ -94,6 +105,7 @@ if (typeof module !== "undefined") {
     clampIndex: clampIndex,
     selectProfileIndex: selectProfileIndex,
     parseKeyValue: parseKeyValue,
+    hoursSincePluggedAt: hoursSincePluggedAt,
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -432,6 +432,7 @@ Panel {
             spacing: Style.spacing.labelGap
             InfoPair { label: "Battery size"; value: root.batteryInfo.size || "" }
             InfoPair { label: "Charge cycles"; value: root.batteryInfo.cycles || "—" }
+            InfoPair { label: "Since last plugged"; value: Model.hoursSincePluggedAt(root.batteryInfo["plugged-at"]) }
           }
 
           Column {

--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -19,10 +19,27 @@ function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, al
   }
 }
 
+function observePowerSource(powerSourceInitialized, wasOnBattery, onBattery) {
+  if (!powerSourceInitialized) {
+    return {
+      recordPluggedAt: false,
+      powerSourceInitialized: true,
+      wasOnBattery: onBattery
+    }
+  }
+
+  return {
+    recordPluggedAt: wasOnBattery && !onBattery,
+    powerSourceInitialized: true,
+    wasOnBattery: onBattery
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     batteryPercentage: batteryPercentage,
     isDischarging: isDischarging,
-    shouldWarnLowBattery: shouldWarnLowBattery
+    shouldWarnLowBattery: shouldWarnLowBattery,
+    observePowerSource: observePowerSource
   }
 }

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -51,17 +51,14 @@ Item {
 
   function observePowerSource() {
     var onBattery = UPower.onBattery
-    if (!persisted.powerSourceInitialized) {
-      persisted.powerSourceInitialized = true
-      persisted.wasOnBattery = onBattery
-      return
-    }
+    var state = BatteryModel.observePowerSource(persisted.powerSourceInitialized, persisted.wasOnBattery, onBattery)
+    persisted.powerSourceInitialized = state.powerSourceInitialized
+    persisted.wasOnBattery = state.wasOnBattery
 
-    if (persisted.wasOnBattery && !onBattery) {
+    if (state.recordPluggedAt) {
       pluggedAtProcess.command = ["omarchy-battery-status", "--record-plugged-at", "1", String(Math.floor(Date.now() / 1000))]
       pluggedAtProcess.running = true
     }
-    persisted.wasOnBattery = onBattery
   }
 
   function runPendingPowerProfile() {

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -17,6 +17,8 @@ Item {
     id: persisted
     reloadableId: "omarchy-battery"
     property bool notifiedLowBattery: false
+    property bool powerSourceInitialized: false
+    property bool wasOnBattery: true
   }
 
   function batteryPercentage() {
@@ -47,6 +49,21 @@ Item {
     if (!powerProfileProcess.running) runPendingPowerProfile()
   }
 
+  function observePowerSource() {
+    var onBattery = UPower.onBattery
+    if (!persisted.powerSourceInitialized) {
+      persisted.powerSourceInitialized = true
+      persisted.wasOnBattery = onBattery
+      return
+    }
+
+    if (persisted.wasOnBattery && !onBattery) {
+      pluggedAtProcess.command = ["omarchy-battery-status", "--record-plugged-at", "1", String(Math.floor(Date.now() / 1000))]
+      pluggedAtProcess.running = true
+    }
+    persisted.wasOnBattery = onBattery
+  }
+
   function runPendingPowerProfile() {
     powerProfileProcess.command = ["omarchy-powerprofiles-set", pendingPowerSource]
     pendingPowerSource = ""
@@ -54,6 +71,7 @@ Item {
   }
 
   Process { id: warningProcess }
+  Process { id: pluggedAtProcess }
 
   Process {
     id: powerProfileProcess
@@ -73,6 +91,9 @@ Item {
     function onOnBatteryChanged() {
       root.checkBattery()
       root.applyPowerProfile()
+      root.observePowerSource()
     }
   }
+
+  Component.onCompleted: root.observePowerSource()
 }

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -36,13 +36,19 @@ exit 1
 STUB
 chmod +x "$tmp_dir/bin/upower"
 
-shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+state_file="$tmp_dir/battery-plugged-at"
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" OMARCHY_BATTERY_PLUGGED_STATE="$state_file" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
 
 grep -Fx $'percentage\t51%' <<<"$shell_output" >/dev/null || fail "battery status reports percentage"
 grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery status reports state"
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'plugged-at\t' <<<"$shell_output" >/dev/null || fail "battery status reports empty last plugged time"
+
+OMARCHY_BATTERY_PLUGGED_STATE="$state_file" "$ROOT/bin/omarchy-battery-status" --record-plugged-at 1 1700000000
+recorded_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" OMARCHY_BATTERY_PLUGGED_STATE="$state_file" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'plugged-at\t1700000000' <<<"$recorded_output" >/dev/null || fail "battery status reports persisted last plugged time"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -28,4 +28,22 @@ assertDeepEqual(
   { level: 40, notify: false, notifiedLowBattery: false },
   'battery clears notified state after recovery'
 )
+
+assertDeepEqual(
+  battery.observePowerSource(false, true, false),
+  { recordPluggedAt: false, powerSourceInitialized: true, wasOnBattery: false },
+  'battery initializes power-source state without recording'
+)
+assertDeepEqual(
+  battery.observePowerSource(true, true, false),
+  { recordPluggedAt: true, powerSourceInitialized: true, wasOnBattery: false },
+  'battery records battery-to-AC transition'
+)
+assertDeepEqual(
+  battery.observePowerSource(true, false, true),
+  { recordPluggedAt: false, powerSourceInitialized: true, wasOnBattery: true },
+  'battery does not record AC-to-battery transition'
+)
+assert(!battery.observePowerSource(true, true, true).recordPluggedAt, 'battery ignores unchanged battery state')
+assert(!battery.observePowerSource(true, false, false).recordPluggedAt, 'battery ignores unchanged AC state')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -14,6 +14,11 @@ assertEqual(power.selectProfileIndex(0, 1, ['balanced', 'performance']), 1, 'pow
 assertEqual(power.selectProfileIndex(1, 1, ['balanced', 'performance']), 1, 'power clamps profile selection')
 
 assertDeepEqual(power.parseKeyValue('time\t2:00\nenergy\t42\n'), { time: '2:00', energy: '42' }, 'power parses key-value output')
+assertEqual(power.hoursSincePluggedAt('', 1700000000000), '—', 'power formats missing last plugged time')
+assertEqual(power.hoursSincePluggedAt('1699991900', 1700000000000), '2h 15m', 'power formats elapsed plugged time')
+assertEqual(power.hoursSincePluggedAt('1699996400', 1700000000000), '1h 0m', 'power formats a whole elapsed hour')
+assertEqual(power.hoursSincePluggedAt('1699999940', 1700000000000), '0h 1m', 'power formats elapsed minutes')
+assertEqual(power.hoursSincePluggedAt('1699999999', 1700000000000), 'less than 1 minute', 'power formats very recent plugged time')
 assertDeepEqual(
   power.parseProfiles('power-saver\t0\nbalanced\t1\nperformance\t0\n', 5),
   { profiles: ['power-saver', 'balanced', 'performance'], activeProfile: 'balanced', profileIndex: 2 },


### PR DESCRIPTION
Summary

Adds persisted battery plug-in tracking and displays elapsed time in the power panel, such as 2h
  15m.

  ## Testing

  - bash test/shell.d/battery-status-test.sh
  - bash test/shell.d/power-test.sh
  - ./test/all
[<img width="401" height="275" alt="screenshot-2026-08-21_11-10-01" src="https://github.com/user-attachments/assets/a82126e3-a8f3-44fb-88da-6f52767b6d02" />
](url)