### PR TITLE
Improve menu search with acronym, prefix-sequence, and fuzzy matching

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -296,6 +296,89 @@ function leafIdFor(id) {
   return parts.length > 0 ? parts[parts.length - 1] : id
 }
 
+function getWords(text) {
+  if (!text) return []
+  var clean = String(text)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .trim()
+    .toLowerCase()
+  return clean ? clean.split(/\s+/) : []
+}
+
+function getInitials(text) {
+  var words = getWords(text)
+  var initials = ""
+  for (var i = 0; i < words.length; i++) {
+    if (words[i].length > 0) initials += words[i][0]
+  }
+  return initials
+}
+
+function matchesWordPrefixes(query, words) {
+  if (!query || !words || words.length === 0) return false
+  var q = String(query).toLowerCase()
+
+  function check(wIdx, qIdx, matchedAnyWord) {
+    if (qIdx === q.length) return matchedAnyWord
+    if (wIdx >= words.length) return false
+
+    var word = words[wIdx]
+    var maxLen = Math.min(word.length, q.length - qIdx)
+    for (var len = maxLen; len >= 1; len--) {
+      if (word.substring(0, len) === q.substring(qIdx, qIdx + len)) {
+        if (check(wIdx + 1, qIdx + len, true)) return true
+      }
+    }
+
+    if (check(wIdx + 1, qIdx, matchedAnyWord)) return true
+    return false
+  }
+
+  return check(0, 0, false)
+}
+
+function entryWordSources(entry) {
+  if (!entry) return []
+  var sources = [getWords(entry.label), getWords(leafIdFor(entry.id))]
+  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+  for (var i = 0; i < aliases.length; i++) {
+    sources.push(getWords(aliases[i]))
+  }
+  return sources
+}
+
+function entryMatchesAnyWordPrefix(entry, term) {
+  var sources = entryWordSources(entry)
+  for (var s = 0; s < sources.length; s++) {
+    if (matchesWordPrefixes(term, sources[s])) return true
+  }
+  return false
+}
+
+function isFuzzySubsequence(needle, text) {
+  if (!needle || !text) return false
+  var n = String(needle).toLowerCase()
+  var t = String(text).toLowerCase()
+  if (n.length > t.length) return false
+  var nIdx = 0
+  for (var i = 0; i < t.length && nIdx < n.length; i++) {
+    if (t[i] === n[nIdx]) nIdx++
+  }
+  return nIdx === n.length
+}
+
+function entryMatchesFuzzy(entry, term) {
+  if (!term || term.length < 2) return false
+  if (isFuzzySubsequence(term, entry.label)) return true
+  if (isFuzzySubsequence(term, leafIdFor(entry.id))) return true
+  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+  for (var i = 0; i < aliases.length; i++) {
+    if (isFuzzySubsequence(term, aliases[i])) return true
+  }
+  return false
+}
+
 function nameSearchText(entry) {
   if (!entry) return ""
   var aliases = []
@@ -329,9 +412,12 @@ function matchesQuery(entry, query, visible) {
   var terms = String(query || "").toLowerCase().trim().split(/\s+/)
 
   for (var i = 0; i < terms.length; i++) {
-    if (!terms[i]) continue
-    if (nameText.indexOf(terms[i]) >= 0) continue
-    if (termInSearchWords(terms[i], descriptionText)) continue
+    var term = terms[i]
+    if (!term) continue
+    if (nameText.indexOf(term) >= 0) continue
+    if (termInSearchWords(term, descriptionText)) continue
+    if (term.length >= 2 && entryMatchesAnyWordPrefix(entry, term)) continue
+    if (term.length >= 2 && entryMatchesFuzzy(entry, term)) continue
     return false
   }
 
@@ -339,25 +425,45 @@ function matchesQuery(entry, query, visible) {
 }
 
 function searchScore(items, entry, query) {
+  if (!entry || !entry.label) return 1000000
   var needle = String(query || "").toLowerCase().trim()
   var label = entry.label.toLowerCase()
   var nameText = nameSearchText(entry)
   var descriptionText = String(entry.description || "").toLowerCase()
+  var isApp = entry.kind === "app"
   var score = 80
 
-  if (label === needle) score = entry.parent === "root" ? 2 : 0
-  // An installed app whose name contains the query as a whole word ("zen"
-  // for Zen Browser) beats exact-labeled menu entries like Install > Zen.
-  else if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) score = 0
-  else if (label.indexOf(needle) === 0) score = 10
-  else if (label.indexOf(needle) >= 0) score = 30
-  else if (nameText.indexOf(needle) >= 0) score = 40
-  else if (descriptionTextMatches(needle, descriptionText)) score = 60
+  var labelWords = getWords(entry.label)
+  var labelInitials = getInitials(entry.label)
 
-  if (entry.kind === "menu" || entry.kind === "link") score -= 2
-  // App rows sort after all menu items, so they lose the tiebreak below to an
-  // equal match. Outrank those, but stay inside the tier so better ones win.
-  if (entry.kind === "app") score -= 5
+  // 1. Exact match on app or word match in app name (e.g. "zen" in "Zen Browser")
+  if (isApp && (label === needle || label.split(/\s+/).indexOf(needle) >= 0)) score = 0
+  // 2. Exact match on submenu / link (e.g. "Font" under style)
+  else if ((entry.kind === "menu" || entry.kind === "link") && label === needle) score = entry.parent === "root" ? 2 : 1
+  // 3. Exact match on non-app action (e.g. "Zen" under Defaults > Browser)
+  else if (label === needle) score = 3
+  // 4. Exact acronym match on app name (e.g. "gc" for "Google Chrome")
+  else if (isApp && labelInitials === needle) score = 3
+  // 5. Prefix match
+  else if (label.indexOf(needle) === 0) score = isApp ? 4 : 25
+  // 6. Word-prefix sequence match on label (e.g. "vs" for "Visual Studio Code", "gch" for "Google Chrome")
+  else if (needle.length >= 2 && matchesWordPrefixes(needle, labelWords)) score = isApp ? 6 : 28
+  // 7. Substring in label
+  else if (label.indexOf(needle) >= 0) score = isApp ? 10 : 35
+  // 8. Exact acronym match on non-app label
+  else if (!isApp && labelInitials === needle) score = 26
+  // 9. Substring or acronym in aliases / executable name
+  else if (nameText.indexOf(needle) >= 0 || (needle.length >= 2 && entryMatchesAnyWordPrefix(entry, needle))) score = isApp ? 15 : 45
+  // 10. Fuzzy subsequence match in label or aliases (e.g. "cf" in "Config" / "Voxtype Configuration")
+  else if (needle.length >= 2 && entryMatchesFuzzy(entry, needle)) score = isApp ? 18 : 38
+  // 11. Match in description / keywords
+  else if (descriptionTextMatches(needle, descriptionText)) score = isApp ? 25 : 60
+
+  var entryId = String(entry.id || "").toLowerCase()
+  if (!isApp) {
+    if (entryId.indexOf("install.") === 0 || entryId.indexOf("remove.") === 0 || entryId.indexOf("install") >= 0) score += 15
+    if (entryId.indexOf("system") >= 0 || entry.id === "logout") score += 20
+  }
 
   return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
 }
@@ -515,6 +621,12 @@ if (typeof module !== "undefined") {
     searchableToken: searchableToken,
     leafIdFor: leafIdFor,
     nameSearchText: nameSearchText,
+    getWords: getWords,
+    getInitials: getInitials,
+    matchesWordPrefixes: matchesWordPrefixes,
+    entryMatchesAnyWordPrefix: entryMatchesAnyWordPrefix,
+    isFuzzySubsequence: isFuzzySubsequence,
+    entryMatchesFuzzy: entryMatchesFuzzy,
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -135,7 +135,11 @@ const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item])
 const rankBase = menu.mergeMenuSources(defaultItems, [])
 const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
   { id: 'apps.brave', parent: 'apps', kind: 'app', label: 'Brave', description: '', aliases: [] },
+  { id: 'apps.chrome', parent: 'apps', kind: 'app', label: 'Google Chrome', description: 'Web Browser', aliases: ['google-chrome', 'chrome'] },
   { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] },
+  { id: 'apps.rustdesk', parent: 'apps', kind: 'app', label: 'RustDesk', description: 'Remote Desktop', aliases: ['rustdesk'] },
+  { id: 'apps.thunderbird', parent: 'apps', kind: 'app', label: 'Thunderbird', description: 'Email Client', aliases: ['email', 'mail'] },
+  { id: 'apps.vscode', parent: 'apps', kind: 'app', label: 'Visual Studio Code', description: 'Code Editor', aliases: ['code', 'vsc'] },
   { id: 'apps.zen', parent: 'apps', kind: 'app', label: 'Zen Browser', description: '', aliases: [] }
 ])
 const rankScore = (id, query) => menu.searchScore(ranked.items, ranked.items[id], query)
@@ -155,6 +159,33 @@ assert(
   rankScore('style.font', 'font') < rankScore('apps.fontforge', 'font'),
   'menu keeps a better-matching menu entry above a weaker app match'
 )
+assert(
+  rankScore('apps.rustdesk', 'rust') < rankScore('remove.development.rust', 'rust'),
+  'menu keeps a destructive exact match below an app prefix match'
+)
+assert(
+  rankScore('apps.rustdesk', 'rust') < rankScore('install.development.rust', 'rust'),
+  'menu keeps an installer match below an app prefix match'
+)
+
+// Acronym & initialism search
+assert(menu.matchesQuery(ranked.items['apps.chrome'], 'gc', true), 'menu matches app acronym (gc -> Google Chrome)')
+assert(menu.matchesQuery(ranked.items['apps.vscode'], 'vsc', true), 'menu matches app acronym (vsc -> Visual Studio Code)')
+assert(menu.matchesQuery(ranked.items['apps.thunderbird'], 'tb', true), 'menu matches app acronym (tb -> Thunderbird)')
+assert(menu.matchesQuery(ranked.items['apps.chrome'], 'gch', true), 'menu matches app prefix sequence (gch -> Google Chrome)')
+assert(menu.matchesQuery(ranked.items['apps.vscode'], 'vs', true), 'menu matches app prefix sequence (vs -> Visual Studio Code)')
+assert(
+  rankScore('apps.chrome', 'gc') < rankScore('setup.default.browser', 'gc'),
+  'menu ranks acronym app match above menu items'
+)
+assert(
+  rankScore('apps.vscode', 'vsc') < rankScore('setup.default.editor', 'vsc'),
+  'menu ranks acronym app match above menu items'
+)
+
+// Fuzzy subsequence search
+assert(menu.matchesQuery({ id: 'config', label: 'Config', aliases: [] }, 'cf', true), 'menu matches fuzzy subsequence (cf -> Config)')
+assert(menu.matchesQuery({ id: 'voxtype', label: 'Voxtype Configuration', aliases: [] }, 'cfg', true), 'menu matches fuzzy subsequence (cfg -> Configuration)')
 
 // Routing: htop ships `Keywords=system;...`, which app rows carry as aliases.
 // An installed app must never capture a menu route (SUPER+ESCAPE opens the


### PR DESCRIPTION
## What changed

- **Acronym & Initialism Matching**: Quickly find applications and menu items using initials (e.g. `gc` → Google Chrome, `vsc` → Visual Studio Code, `tb` → Thunderbird).
- **Word-Prefix Sequence Matching**: Match multi-word initial sequences (e.g. `gch` → Google Chrome, `vs` → Visual Studio Code).
- **Fuzzy Subsequence Matching**: Match abbreviated subsequences (e.g. `cf`/`cfg` → Config / Configuration).
- **App Priority Search Scoring**: Installed applications consistently rank ahead of installer scripts (`install.*`) and destructive/system actions on shared keywords.
- **Unit & Regression Test Coverage**: Added test assertions to `test/shell.d/menu-test.sh` covering acronyms, prefix sequences, fuzzy matching, and ranking tiers.

## Testing

- `test/shell.d/menu-test.sh` (all 100+ assertions passed)
- `git diff --check`