### PR TITLE
Add Cursor agent usage to the agents bar panel

### DIFF
--- a/bin/omarchy-agent-usage-cursor
+++ b/bin/omarchy-agent-usage-cursor
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# omarchy:summary=Print the Cursor agent usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Cursor agent usage into one display-ready JSON record.
+
+Billing limits and per-model totals come from Cursor's dashboard API
+(api2.cursor.sh). Local prompt/session stats come from agent CLI
+transcripts under ~/.cursor/projects/*/agent-transcripts/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "cursor"
+AGENT_NAME = "Cursor"
+AUTH_HELP = "Sign in to Cursor (IDE or `agent`) to restore usage data."
+API_BASE = os.environ.get("CURSOR_API_ENDPOINT", "https://api2.cursor.sh").rstrip("/")
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+TIMESTAMP_RE = re.compile(
+  r"<timestamp>\s*([A-Za-z]+,\s+[A-Za-z]+\s+\d{1,2},\s+\d{4},\s+\d{1,2}:\d{2}\s+[AP]M\s+\([^)]+\))\s*</timestamp>"
+)
+
+
+def number(value: Any) -> int:
+  try:
+    n = float(value or 0)
+    return round(n) if n == n else 0
+  except Exception:
+    return 0
+
+
+def cents_to_dollars(value: Any) -> float:
+  return round(number(value) / 100.0, 2)
+
+
+def date_string(value: dt.date) -> str:
+  return value.strftime("%Y-%m-%d")
+
+
+def recent_date_strings() -> list[str]:
+  today = dt.datetime.now().date()
+  return [date_string(today - dt.timedelta(days=offset)) for offset in range(6, -1, -1)]
+
+
+def local_date_string() -> str:
+  return date_string(dt.datetime.now().date())
+
+
+def cache_root() -> Path:
+  root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def auth_paths() -> list[Path]:
+  paths: list[Path] = []
+  if os.environ.get("CURSOR_AUTH_PATH"):
+    paths.append(Path(os.path.expanduser(os.environ["CURSOR_AUTH_PATH"])))
+  if os.environ.get("CURSOR_CONFIG_DIR"):
+    paths.append(Path(os.path.expanduser(os.environ["CURSOR_CONFIG_DIR"])) / "auth.json")
+  home = Path.home()
+  paths.extend(
+    [
+      home / ".config" / "cursor" / "auth.json",
+      home / ".config" / "Cursor" / "auth.json",
+    ]
+  )
+  return paths
+
+
+def load_access_token() -> str | None:
+  for path in auth_paths():
+    if not path.is_file():
+      continue
+    try:
+      payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+      continue
+    token = payload.get("accessToken") or payload.get("refreshToken")
+    if token:
+      return str(token)
+  return None
+
+
+def agent_transcript_root() -> Path:
+  if os.environ.get("CURSOR_PROJECTS_DIR"):
+    return Path(os.path.expanduser(os.environ["CURSOR_PROJECTS_DIR"]))
+  return Path.home() / ".cursor" / "projects"
+
+
+def parse_transcript_day(text: str, fallback_mtime: float) -> str:
+  match = TIMESTAMP_RE.search(text)
+  if match:
+    raw = match.group(1)
+    for fmt in ("%A, %B %d, %Y, %I:%M %p (UTC)", "%A, %b %d, %Y, %I:%M %p (UTC)"):
+      try:
+        parsed = dt.datetime.strptime(raw, fmt).replace(tzinfo=dt.timezone.utc)
+        return date_string(parsed.date())
+      except Exception:
+        continue
+  return date_string(dt.datetime.fromtimestamp(fallback_mtime).date())
+
+
+def empty_stats() -> dict[str, Any]:
+  recent = {day: {"date": day, "messageCount": 0} for day in recent_date_strings()}
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": list(recent.values()),
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+  }
+
+
+def scan_transcripts() -> dict[str, Any]:
+  root = agent_transcript_root()
+  stats = empty_stats()
+  if not root.is_dir():
+    return stats
+
+  today = local_date_string()
+  recent_map = {entry["date"]: entry for entry in stats["recentDays"]}
+  active_dates: set[str] = set()
+  sessions: set[str] = set()
+  today_sessions: set[str] = set()
+  prompts = 0
+  today_prompts = 0
+
+  for path in root.glob("*/agent-transcripts/*/*.jsonl"):
+    try:
+      mtime = path.stat().st_mtime
+      session_key = str(path)
+      sessions.add(session_key)
+      with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+          if '"role":"user"' not in line and '"role": "user"' not in line:
+            continue
+          try:
+            entry = json.loads(line)
+          except Exception:
+            continue
+          if entry.get("role") != "user":
+            continue
+          day = parse_transcript_day(line, mtime)
+          active_dates.add(day)
+          prompts += 1
+          if day == today:
+            today_prompts += 1
+            today_sessions.add(session_key)
+          if day in recent_map:
+            recent_map[day]["messageCount"] += 1
+    except Exception:
+      continue
+
+  stats["todayPrompts"] = today_prompts
+  stats["todaySessions"] = len(today_sessions)
+  stats["totalPrompts"] = prompts
+  stats["totalSessions"] = len(sessions)
+  stats["activeDays"] = len(active_dates)
+  stats["activeDates"] = sorted(active_dates)
+  stats["recentDays"] = [recent_map[day] for day in recent_date_strings()]
+  return stats
+
+
+def cache_key(prefix: str, *parts: str) -> Path:
+  digest = hashlib.sha256("|".join(parts).encode()).hexdigest()[:16]
+  return cache_root() / f"{prefix}-{digest}.json"
+
+
+def cached_scan(max_age_seconds: float) -> dict[str, Any]:
+  key = cache_key("cursor-scan", str(agent_transcript_root()))
+  if max_age_seconds > 0 and key.is_file():
+    age = time.time() - key.stat().st_mtime
+    if age <= max_age_seconds:
+      try:
+        return json.loads(key.read_text(encoding="utf-8"))
+      except Exception:
+        pass
+  stats = scan_transcripts()
+  tmp = key.with_suffix(".tmp")
+  tmp.write_text(json.dumps(stats, separators=(",", ":")), encoding="utf-8")
+  tmp.replace(key)
+  return stats
+
+
+def dashboard_request(token: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+  payload = json.dumps(body or {}).encode("utf-8")
+  request = urllib.request.Request(
+    f"{API_BASE}{path}",
+    data=payload,
+    headers={
+      "Authorization": f"Bearer {token}",
+      "Content-Type": "application/json",
+      "Connect-Protocol-Version": "1",
+    },
+    method="POST",
+  )
+  with urllib.request.urlopen(request, timeout=12) as response:
+    return json.loads(response.read().decode("utf-8"))
+
+
+def ms_to_iso(value: Any) -> str:
+  if value in (None, ""):
+    return ""
+  try:
+    ms = int(str(value))
+  except Exception:
+    return ""
+  return dt.datetime.fromtimestamp(ms / 1000, tz=dt.timezone.utc).isoformat()
+
+
+def collect_limits(token: str) -> dict[str, Any]:
+  result = {
+    "limits": [],
+    "tierLabel": "",
+    "usageStatusText": "",
+    "authHelpText": AUTH_HELP,
+    "scope": "account",
+  }
+  try:
+    usage = dashboard_request(token, "/aiserver.v1.DashboardService/GetCurrentPeriodUsage")
+    plan = dashboard_request(token, "/aiserver.v1.DashboardService/GetPlanInfo")
+  except urllib.error.HTTPError as error:
+    if error.code in (401, 403):
+      result["usageStatusText"] = "Sign-in expired"
+      result["authHelpText"] = "Open Cursor and sign in again, or run `agent about` to verify your session."
+    else:
+      result["usageStatusText"] = "Cursor limits unavailable"
+      result["authHelpText"] = f"HTTP {error.code}"
+    result["retryAdvised"] = True
+    return result
+  except Exception as error:
+    result["usageStatusText"] = "Cursor limits unavailable"
+    result["authHelpText"] = str(error)
+    result["retryAdvised"] = True
+    return result
+
+  plan_info = (plan.get("planInfo") or {}) if isinstance(plan, dict) else {}
+  plan_usage = (usage.get("planUsage") or {}) if isinstance(usage, dict) else {}
+  tier = str(plan_info.get("planName") or "").strip()
+  price = str(plan_info.get("price") or "").strip()
+  if tier and price:
+    result["tierLabel"] = f"{tier} ({price})"
+  elif tier:
+    result["tierLabel"] = tier
+  elif price:
+    result["tierLabel"] = price
+
+  reset_at = ms_to_iso(usage.get("billingCycleEnd"))
+  # usageStatusText makes the panel's status card visible and that card shows
+  # authHelpText — reserve both fields for auth problems, not billing copy.
+  result["usageStatusText"] = ""
+  result["authHelpText"] = ""
+
+  total_percent = float(plan_usage.get("totalPercentUsed") or 0) / 100.0
+  auto_percent = float(plan_usage.get("autoPercentUsed") or 0) / 100.0
+  api_percent = float(plan_usage.get("apiPercentUsed") or 0) / 100.0
+
+  if total_percent >= 0:
+    result["limits"].append(
+      {
+        "label": "Billing cycle",
+        "percent": min(max(total_percent, 0.0), 1.0),
+        "resetsAt": reset_at,
+      }
+    )
+  if auto_percent > 0:
+    result["limits"].append(
+      {
+        "label": "Auto models",
+        "title": "Auto models",
+        "percent": min(max(auto_percent, 0.0), 1.0),
+        "resetsAt": reset_at,
+      }
+    )
+  if api_percent > 0:
+    result["limits"].append(
+      {
+        "label": "API models",
+        "title": "API models",
+        "percent": min(max(api_percent, 0.0), 1.0),
+        "resetsAt": reset_at,
+      }
+    )
+
+  limit_cents = number(plan_usage.get("limit"))
+  remaining_cents = number(plan_usage.get("remaining"))
+  spent_cents = number(plan_usage.get("totalSpend") or plan_usage.get("includedSpend"))
+  if limit_cents > 0:
+    result["balance"] = {
+      "remaining": cents_to_dollars(remaining_cents),
+      "funded": cents_to_dollars(limit_cents),
+      "spent": cents_to_dollars(spent_cents),
+      "currency": "USD",
+      "estimated": False,
+    }
+
+  return result
+
+
+def collect_model_usage(token: str) -> dict[str, dict[str, int]]:
+  try:
+    payload = dashboard_request(token, "/aiserver.v1.DashboardService/GetAggregatedUsageEvents")
+  except Exception:
+    return {}
+
+  usage: dict[str, dict[str, int]] = {}
+  for row in payload.get("aggregations") or []:
+    model = str(row.get("modelIntent") or "cursor").strip() or "cursor"
+    bucket = usage.setdefault(
+      model,
+      {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "cacheReadInputTokens": 0,
+        "cacheCreationInputTokens": 0,
+      },
+    )
+    bucket["inputTokens"] += number(row.get("inputTokens"))
+    bucket["outputTokens"] += number(row.get("outputTokens"))
+    bucket["cacheReadInputTokens"] += number(row.get("cacheReadTokens"))
+    bucket["cacheCreationInputTokens"] += number(row.get("cacheWriteTokens"))
+  return usage
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
+  stats = cached_scan(max_age)
+
+  token = load_access_token()
+  limits = {
+    "limits": [],
+    "tierLabel": "",
+    "usageStatusText": "Not signed in",
+    "authHelpText": AUTH_HELP,
+    "retryAdvised": True,
+  }
+  model_usage: dict[str, dict[str, int]] = {}
+
+  if token:
+    limits = collect_limits(token)
+    if not args.limits_only:
+      model_usage = collect_model_usage(token)
+
+  if model_usage:
+    stats["modelUsage"] = model_usage
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "ready": number(stats.get("totalPrompts")) > 0 or len(limits.get("limits") or []) > 0,
+    "hasLocalStats": True,
+    "hasPromptStats": True,
+  }
+  record.update(stats)
+  record.update(limits)
+  print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `cursor` | Cursor dashboard billing cycle (included spend, auto/API pools) | `~/.config/cursor/auth.json` session token + dashboard API; agent CLI transcripts under `~/.cursor/projects/*/agent-transcripts/` |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -62,7 +63,9 @@ falls back to local stats only. A non-default Claude directory is honored via
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
-signed in there.
+signed in there. Cursor reads `~/.config/cursor/auth.json` (written by the
+IDE or `agent` CLI). Override with `CURSOR_AUTH_PATH`, `CURSOR_CONFIG_DIR`,
+or `CURSOR_PROJECTS_DIR` for the transcript scan root.
 
 ### Fireworks balance
 
@@ -128,7 +131,8 @@ edit `shell.json` directly):
 omarchy bar set omarchy.agents providers '{
   "claude": { "enabled": true },
   "codex": { "enabled": false },
-  "fireworks": { "enabled": true }
+  "fireworks": { "enabled": true },
+  "cursor": { "enabled": true }
 }' --json
 ```
 

--- a/shell/plugins/agents/assets/cursor-light.svg
+++ b/shell/plugins/agents/assets/cursor-light.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Cursor">
+  <path fill="#14120B" d="M32 32h192v192H32z"/>
+  <path fill="#EDECEC" d="M56 56h144v144H56z"/>
+  <path fill="#F54E00" d="M72 72h48v48H72z"/>
+  <path fill="#14120B" d="M136 72h48v48h-48z"/>
+  <path fill="#F54E00" d="M72 136h48v48H72z"/>
+  <path fill="#14120B" d="M136 136h48v48h-48z"/>
+</svg>

--- a/shell/plugins/agents/assets/cursor.svg
+++ b/shell/plugins/agents/assets/cursor.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Cursor">
+  <path fill="#EDECEC" d="M32 32h192v192H32z"/>
+  <path fill="#14120B" d="M56 56h144v144H56z"/>
+  <path fill="#F54E00" d="M72 72h48v48H72z"/>
+  <path fill="#EDECEC" d="M136 72h48v48h-48z"/>
+  <path fill="#14120B" d="M72 136h48v48H72z"/>
+  <path fill="#F54E00" d="M136 136h48v48h-48z"/>
+</svg>

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Cursor, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "cursor": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-cursor-scanner-test.sh
+++ b/test/shell.d/agent-usage-cursor-scanner-test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.config/cursor"
+cat >"$TEST_HOME/.config/cursor/auth.json" <<'EOF'
+{"accessToken":"test-token"}
+EOF
+
+mkdir -p "$TEST_HOME/projects/demo/agent-transcripts/session-1"
+cat >"$TEST_HOME/projects/demo/agent-transcripts/session-1/session-1.jsonl" <<'EOF'
+{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Friday, Aug 21, 2026, 2:00 PM (UTC)</timestamp>\nhello"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}
+EOF
+
+COLLECTOR="$ROOT/bin/omarchy-agent-usage-cursor"
+
+signed_in=$(HOME="$TEST_HOME" CURSOR_CONFIG_DIR="$TEST_HOME/.config/cursor" CURSOR_PROJECTS_DIR="$TEST_HOME/projects" \
+  COLLECTOR="$COLLECTOR" python3 - <<'PY'
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import urllib.error
+
+loader = importlib.machinery.SourceFileLoader("cursor_collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+def urlopen(request, timeout=None):
+  path = request.full_url.rsplit("/", 1)[-1]
+  if path == "GetCurrentPeriodUsage":
+    return io.BytesIO(json.dumps({
+      "billingCycleEnd": "1789577156000",
+      "displayMessage": "You have used 41% of your included usage",
+      "planUsage": {
+        "totalPercentUsed": 41.0,
+        "autoPercentUsed": 8.0,
+        "apiPercentUsed": 0,
+        "limit": 40000,
+        "remaining": 23600,
+        "totalSpend": 16400
+      }
+    }).encode())
+  if path == "GetPlanInfo":
+    return io.BytesIO(json.dumps({"planInfo": {"planName": "Ultra", "price": "$200/mo"}}).encode())
+  raise AssertionError(request.full_url)
+
+collector.urllib.request.urlopen = urlopen
+print(json.dumps(collector.collect_limits("token")))
+PY
+)
+
+[[ $(jq -r '.tierLabel' <<<"$signed_in") == "Ultra (\$200/mo)" ]] ||
+  fail "Cursor collector reads plan tier from dashboard API" "$signed_in"
+[[ $(jq -r '.usageStatusText + "|" + .authHelpText' <<<"$signed_in") == "|" ]] ||
+  fail "Cursor collector leaves status fields empty when signed in" "$signed_in"
+[[ $(jq -c '.limits[0]' <<<"$signed_in") == '{"label":"Billing cycle","percent":0.41,"resetsAt":"2026-09-16T16:45:56+00:00"}' ]] ||
+  fail "Cursor collector maps billing cycle usage to limits" "$signed_in"
+[[ $(jq -c '.balance' <<<"$signed_in") == '{"remaining":236.0,"funded":400.0,"spent":164.0,"currency":"USD","estimated":false}' ]] ||
+  fail "Cursor collector maps included spend to balance" "$signed_in"
+pass "Cursor collector maps signed-in dashboard usage"
+
+expired=$(HOME="$TEST_HOME" COLLECTOR="$COLLECTOR" python3 - <<'PY'
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import urllib.error
+
+loader = importlib.machinery.SourceFileLoader("cursor_collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+def urlopen(request, timeout=None):
+  raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", hdrs=None, fp=io.BytesIO(b""))
+
+collector.urllib.request.urlopen = urlopen
+print(json.dumps(collector.collect_limits("token")))
+PY
+)
+
+[[ $(jq -r '.usageStatusText' <<<"$expired") == "Sign-in expired" ]] ||
+  fail "Cursor collector reports expired auth" "$expired"
+pass "Cursor collector reports expired auth"
+
+record=$(HOME="$TEST_HOME" CURSOR_CONFIG_DIR="$TEST_HOME/.config/cursor" CURSOR_PROJECTS_DIR="$TEST_HOME/projects" \
+  XDG_CACHE_HOME="$TEST_HOME/.cache" COLLECTOR="$COLLECTOR" python3 - <<'PY'
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import sys
+import urllib.error
+
+loader = importlib.machinery.SourceFileLoader("cursor_collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+def urlopen(request, timeout=None):
+  path = request.full_url.rsplit("/", 1)[-1]
+  if path == "GetCurrentPeriodUsage":
+    return io.BytesIO(json.dumps({
+      "billingCycleEnd": "1789577156000",
+      "planUsage": {"totalPercentUsed": 10, "autoPercentUsed": 0, "apiPercentUsed": 0, "limit": 0}
+    }).encode())
+  if path == "GetPlanInfo":
+    return io.BytesIO(json.dumps({"planInfo": {"planName": "Pro", "price": "$20/mo"}}).encode())
+  if path == "GetAggregatedUsageEvents":
+    return io.BytesIO(json.dumps({
+      "aggregations": [{
+        "modelIntent": "composer-2.5",
+        "inputTokens": "100",
+        "outputTokens": "20",
+        "cacheReadTokens": "5"
+      }]
+    }).encode())
+  raise AssertionError(request.full_url)
+
+collector.urllib.request.urlopen = urlopen
+sys.argv = ["omarchy-agent-usage-cursor", "--force"]
+raise SystemExit(collector.main())
+PY
+)
+
+[[ $(jq -r '.totalPrompts' <<<"$record") == "1" ]] ||
+  fail "Cursor collector counts agent CLI user prompts" "$record"
+[[ $(jq -r '.modelUsage["composer-2.5"].inputTokens' <<<"$record") == "100" ]] ||
+  fail "Cursor collector reads per-model usage from dashboard API" "$record"
+pass "Cursor collector merges local transcripts with dashboard model usage"
+
+no_auth_home=$(mktemp -d)
+no_auth=$(HOME="$no_auth_home" XDG_CACHE_HOME="$no_auth_home/.cache" "$COLLECTOR" --force)
+rm -rf "$no_auth_home"
+
+[[ $(jq -r '.usageStatusText' <<<"$no_auth") == "Not signed in" ]] ||
+  fail "Cursor collector reports missing auth" "$no_auth"
+pass "Cursor collector reports missing auth"


### PR DESCRIPTION
## Summary
- Add `omarchy-agent-usage-cursor` to collect billing-cycle limits, included spend, and per-model token totals from Cursor's dashboard API
- Scan local agent CLI transcripts under `~/.cursor/projects/*/agent-transcripts/` for prompt/session stats
- Enable Cursor in the stock `omarchy.agents` plugin defaults, with bar icons and README docs

## Notes
- Auth comes from `~/.config/cursor/auth.json` (written by the Cursor IDE or `agent` CLI)
- On successful sign-in, `usageStatusText` and `authHelpText` stay empty so the panel does not show a false sign-in banner
- Account-scoped usage (`scope: account`) merges cleanly when sync aggregation is enabled

## Test plan
- [x] `./test/shell.d/agent-usage-cursor-scanner-test.sh`
- [x] `./test/all` (4 pre-existing environment failures unrelated to this change: `config-test`, `runtime-smoke-test`, `snapper-test`, `unowned-system-paths-test`)
- [ ] Manual: `omarchy agent usage-update cursor` on a signed-in machine
- [ ] Manual: open the agents bar panel and confirm Cursor shows plan tier, billing meters, and model breakdown


Made with [Cursor](https://cursor.com)