### PR TITLE
Dismiss low battery warning when AC connects

### DIFF
--- a/bin/omarchy-battery-low
+++ b/bin/omarchy-battery-low
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-# omarchy:summary=Send the low battery warning notification and run battery-low hooks.
-# omarchy:args=<percentage>
+# omarchy:summary=Send the low battery warning with hooks, or dismiss it.
+# omarchy:args=<percentage|--dismiss>
 # omarchy:hidden=true
 
 set -euo pipefail
 
 if (($# != 1)); then
-  echo "Usage: omarchy-battery-low <percentage>" >&2
+  echo "Usage: omarchy-battery-low <percentage|--dismiss>" >&2
   exit 1
 fi
 
-level=$1
+notification_summary="Time to recharge!"
 
-omarchy-notification-send -g 󱐋 -u critical "Time to recharge!" "Battery is down to ${level}%" -i battery-caution -t 30000
-omarchy-hook battery-low "$level"
+if [[ $1 == "--dismiss" ]]; then
+  omarchy-notification-dismiss "$notification_summary"
+else
+  level=$1
+  omarchy-notification-send -g 󱐋 -u critical "$notification_summary" "Battery is down to ${level}%" -i battery-caution -t 30000
+  omarchy-hook battery-low "$level"
+fi

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -42,6 +42,11 @@ Item {
     warningProcess.running = true
   }
 
+  function dismissLowBatteryWarningOnAc() {
+    if (UPower.onBattery) return
+    Quickshell.execDetached(["omarchy-battery-low", "--dismiss"])
+  }
+
   function applyPowerProfile() {
     pendingPowerSource = UPower.onBattery ? "battery" : "ac"
     if (!powerProfileProcess.running) runPendingPowerProfile()
@@ -53,7 +58,11 @@ Item {
     powerProfileProcess.running = true
   }
 
-  Process { id: warningProcess }
+  Process {
+    id: warningProcess
+    // Retry if AC connects before the popup is inserted.
+    onExited: Qt.callLater(root.dismissLowBatteryWarningOnAc)
+  }
 
   Process {
     id: powerProfileProcess
@@ -72,6 +81,7 @@ Item {
     target: UPower
     function onOnBatteryChanged() {
       root.checkBattery()
+      root.dismissLowBatteryWarningOnAc()
       root.applyPowerProfile()
     }
   }


### PR DESCRIPTION
Dismiss the low-battery popup when UPower switches to AC.

Add a `--dismiss` mode to `omarchy-battery-low` and retry the dismissal after an in-flight warning exits if AC connects before the popup is inserted.

## Testing

- Manually verified at 10% that connecting AC dismisses the warning
- `./test/all`
