### PR TITLE
Add Neovim interactive REPL documentation and menu keybinding search

### DIFF
--- a/bin/omarchy-menu-neovim-repl-keybindings
+++ b/bin/omarchy-menu-neovim-repl-keybindings
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# omarchy:summary=Display annotated Neovim REPL keybindings using an interactive search menu.
+# omarchy:args=[--print|-p]
+
+print_only=false
+
+while (($#)); do
+  case "$1" in
+    --print|-p)
+      print_only=true
+      ;;
+  esac
+  shift
+done
+
+output_keybindings() {
+  cat <<'BINDINGS'
+SPACE + r + r                    → Toggle REPL
+SPACE + r + R                    → Restart REPL
+SPACE + r + f                    → Focus REPL
+SPACE + r + h                    → Hide REPL
+SPACE + r + s + l                → Send Line
+SPACE + r + s + f                → Send File
+SPACE + r + s + p                → Send Paragraph
+SPACE + r + s + u                → Send Until Cursor
+SPACE + r + s + b                → Send Code Block (delimited by # %%)
+SPACE + r + s + n                → Send Code Block & Move to Next
+SPACE + r + s + m                → Send Motion
+SPACE + r + s (VISUAL)           → Send Visual Selection
+SPACE + r + m + m                → Mark Motion
+SPACE + r + m + v (VISUAL)       → Mark Visual Selection
+SPACE + r + m + d                → Remove Last Mark
+SPACE + r + m + r                → Send Marked Block
+SPACE + r + q                    → Interrupt REPL (Ctrl+C)
+SPACE + r + x                    → Exit / Close REPL
+SPACE + r + c + c                → Clear REPL Screen
+SPACE + r + c + l                → Clear Mark Highlights
+ESC (TERMINAL MODE)              → Exit Terminal Mode to Normal Mode
+BINDINGS
+}
+
+if [[ $print_only == "true" ]]; then
+  output_keybindings
+  exit 0
+fi
+
+records=$(output_keybindings)
+
+monitor_height=$(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | .height' 2>/dev/null)
+
+if [[ ! $monitor_height =~ ^[0-9]+$ ]] || ((monitor_height <= 0)); then
+  monitor_height=900
+fi
+
+menu_height=$((monitor_height * 40 / 100))
+printf '%s\n' "$records" | omarchy-menu-select 'Neovim REPL keybindings' -- --width 800 --height "$menu_height" >/dev/null || true

--- a/bin/omarchy-menu-neovim-repl-keybindings
+++ b/bin/omarchy-menu-neovim-repl-keybindings
@@ -36,7 +36,7 @@ SPACE + r + q                    → Interrupt REPL (Ctrl+C)
 SPACE + r + x                    → Exit / Close REPL
 SPACE + r + c + c                → Clear REPL Screen
 SPACE + r + c + l                → Clear Mark Highlights
-ESC (TERMINAL MODE)              → Exit Terminal Mode to Normal Mode
+ESC (REPL TERMINAL)              → Exit Terminal Mode to Normal Mode
 BINDINGS
 }
 

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -47,6 +47,7 @@
   "learn.hyprland": {"icon":"","label":"Hyprland","action":"omarchy-launch-webapp 'https://wiki.hypr.land/'"},
   "learn.arch": {"icon":"󰣇","label":"Arch","action":"omarchy-launch-webapp 'https://wiki.archlinux.org/title/Main_page'"},
   "learn.neovim": {"icon":"","label":"Neovim","action":"omarchy-launch-webapp 'https://www.lazyvim.org/keymaps'"},
+  "learn.neovim-repl": {"icon":"","label":"Neovim REPL","action":"omarchy-menu-neovim-repl-keybindings"},
   "learn.bash": {"icon":"󱆃","label":"Bash","action":"omarchy-launch-webapp 'https://devhints.io/bash'"},
   "learn.tmux-keybindings": {"icon":"","label":"Tmux","action":"omarchy-menu-tmux-keybindings"},
   "learn.herdr-keybindings": {"icon":"","label":"Herdr","action":"omarchy-menu-herdr-keybindings"},

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -320,7 +320,7 @@ Ghostty terminal is installed using _Install > Terminal_ via the Omarchy menu.
 | `Space B D`                | Close file tab                  |
 
 ### While in sidebar
-
+ 
 | Hotkey                   | Function                        |
 | ------------------------ | ------------------------------- |
 | `A`                        | Add new file in parent dir      |
@@ -329,6 +329,26 @@ Ghostty terminal is installed using _Install > Terminal_ via the Omarchy menu.
 | `M`                        | Move highlighted file/dir       |
 | `R`                        | Rename highlighted file/dir     |
 | `?`                        | Show help for all commands      |
+
+### Interactive REPL (iron.nvim)
+
+| Hotkey                   | Function                        |
+| ------------------------ | ------------------------------- |
+| `Space R R`              | Toggle / open REPL              |
+| `Space R Shift + R`      | Restart REPL                    |
+| `Space R F`              | Focus REPL                      |
+| `Space R H`              | Hide REPL                       |
+| `Space R S L`            | Send line to REPL               |
+| `Space R S F`            | Send entire file to REPL        |
+| `Space R S P`            | Send paragraph to REPL          |
+| `Space R S U`            | Send until cursor to REPL       |
+| `Space R S B`            | Send code block (delimited by `# %%`) |
+| `Space R S N`            | Send code block & jump to next  |
+| `Space R S` (Visual)     | Send selected lines             |
+| `Space R Q`              | Interrupt REPL (`Ctrl + C`)     |
+| `Space R X`              | Exit / close REPL               |
+| `Space R C C`            | Clear REPL screen               |
+| `Escape` (Terminal mode) | Exit terminal mode to normal    |
 
 [See all the Neovim hotkeys configured by LazyVim](https://www.lazyvim.org/keymaps).
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -348,7 +348,7 @@ Ghostty terminal is installed using _Install > Terminal_ via the Omarchy menu.
 | `Space R Q`              | Interrupt REPL (`Ctrl + C`)     |
 | `Space R X`              | Exit / close REPL               |
 | `Space R C C`            | Clear REPL screen               |
-| `Escape` (Terminal mode) | Exit terminal mode to normal    |
+| `Escape` (REPL terminal) | Exit terminal mode to normal    |
 
 [See all the Neovim hotkeys configured by LazyVim](https://www.lazyvim.org/keymaps).
 

--- a/manual/16-neovim.md
+++ b/manual/16-neovim.md
@@ -33,6 +33,33 @@ If you want to pickup the basic vim language, I've written about [the three-part
 
 You can see all the possible commands on [the LazyVim Keymaps page](https://www.lazyvim.org/keymaps).
 
+## Interactive REPL
+
+Omarchy's Neovim setup includes [iron.nvim](https://github.com/Vigemus/iron.nvim) for an interactive Read-Eval-Print Loop (REPL). It gives you a notebook-like interactive workflow directly inside Neovim without leaving your editor.
+
+### Opening and Managing the REPL
+
+- `Space R R` - Open or toggle the REPL split (defaults to Python/IPython or Shell based on filetype).
+- `Space R Shift+R` - Restart the active REPL.
+- `Space R F` - Focus the cursor into the REPL window.
+- `Space R H` - Hide the REPL window.
+- `Space R Q` - Interrupt the running REPL (`Ctrl + C`).
+- `Space R X` - Exit and close the REPL session.
+- `Space R C C` - Clear the REPL screen.
+- `Escape` (while in REPL terminal mode) - Return to normal vim mode.
+
+### Sending Code to the REPL
+
+You can evaluate lines, paragraphs, entire files, or code blocks:
+
+- `Space R S L` - Send the current line.
+- `Space R S F` - Send the entire file.
+- `Space R S P` - Send the current paragraph / block of code.
+- `Space R S U` - Send everything from the start of the file up to the cursor.
+- `Space R S B` - Send the current code block (delimited by `# %%`).
+- `Space R S N` - Send the current code block and advance cursor to the next block.
+- `Space R S` (in Visual mode) - Send the selected lines.
+
 ## Starting Neovim
 
 You can start Neovim using `Super + Shift + N` (the binding launches your default editor, which is Neovim out of the box), but it's usually easier to drive it from the terminal by navigating to the directory you wish to work in and typing `n`. The `n` is the alias for `nvim`, which will use the the present directory to open by default. You can open a single file with `n myfile.txt`.

--- a/migrations/1787498986.sh
+++ b/migrations/1787498986.sh
@@ -1,0 +1,10 @@
+echo "Add iron.nvim REPL configuration to Neovim"
+
+nvim_config_dir="$HOME/.config/nvim"
+iron_target="$nvim_config_dir/lua/plugins/iron.lua"
+iron_source="/usr/share/omarchy-nvim/config/lua/plugins/iron.lua"
+
+if [[ -d $nvim_config_dir && -f $iron_source ]]; then
+  mkdir -p "$(dirname "$iron_target")"
+  install -m 0644 "$iron_source" "$iron_target"
+fi

--- a/migrations/1787498986.sh
+++ b/migrations/1787498986.sh
@@ -4,7 +4,10 @@ nvim_config_dir="$HOME/.config/nvim"
 iron_target="$nvim_config_dir/lua/plugins/iron.lua"
 iron_source="/usr/share/omarchy-nvim/config/lua/plugins/iron.lua"
 
-if [[ -d $nvim_config_dir && -f $iron_source ]]; then
+# Skip if the user already has their own iron.lua. If the packaged source is
+# not installed yet, let install fail so the migration retries next run
+# instead of being marked done.
+if [[ -d $nvim_config_dir && ! -f $iron_target ]]; then
   mkdir -p "$(dirname "$iron_target")"
   install -m 0644 "$iron_source" "$iron_target"
 fi


### PR DESCRIPTION
### Summary

This PR adds documentation and desktop menu discovery for the interactive Neovim REPL workflow (powered by `iron.nvim`).

### Changes
* **`bin/omarchy-menu-neovim-repl-keybindings`**: Added interactive keybinding search modal with `omarchy-menu-select` and `--print` support.
* **`default/omarchy/omarchy-menu.jsonc`**: Added `learn.neovim-repl` to the **Learn** menu (`Super + Space` -> Learn -> Neovim REPL).
* **`manual/16-neovim.md`**: Documented interactive REPL concepts, keybindings (`<space>r...`), cell execution with `# %%`, and terminal mode navigation.
* **`manual/07-hotkeys.md`**: Added REPL shortcut reference table to the hotkeys cheatsheet.

### Companion PR
* `omacom-io/omarchy-pkgs`: Adds the LazyVim plugin specification (`pkgbuilds/omarchy-nvim/lua/plugins/iron.lua`).