### PR TITLE
Reconnect trusted Bluetooth keyboards and mice at login

### DIFF
--- a/bin/omarchy-bluetooth-reconnect
+++ b/bin/omarchy-bluetooth-reconnect
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# omarchy:summary=Reconnect trusted Bluetooth keyboards and mice
+# omarchy:group=bluetooth
+
+# BlueZ never connects a paired HID peripheral on its own initiative. Its policy
+# plugin reconnects only the profiles in ReconnectUUIDs, whose stock list is the
+# four audio ones -- HID (0x1124) is deliberately absent -- and even that path
+# covers a link that dropped, not an adapter that has only just come up. So a
+# keyboard or mouse that was connected before a reboot sits paired and idle until
+# something asks BlueZ for it, which is why reconnecting one meant opening the
+# Bluetooth panel and clicking it by hand after every boot. This asks, once, when
+# the session starts.
+#
+# Trusted rather than merely paired: trust is the standing "connect this without
+# asking" flag, and omarchy-bluetooth-device sets it on every pair and every
+# connect, so anything adopted through the Bluetooth panel already qualifies.
+#
+# Keyboards and mice only. Audio has both halves covered already -- ReconnectUUIDs
+# for a dropped link, wireplumber's a2dp autoconnect for the rest -- and pulling a
+# headset in at login would move audio off the speakers uninvited.
+
+HID_UUID="00001124-0000-1000-8000-00805f9b34fb"
+
+POWER_WAIT_SECONDS=${OMARCHY_BLUETOOTH_RECONNECT_WAIT_SECONDS:-10}
+CONNECT_ATTEMPTS=${OMARCHY_BLUETOOTH_RECONNECT_ATTEMPTS:-3}
+CONNECT_RETRY_SECONDS=${OMARCHY_BLUETOOTH_RECONNECT_RETRY_SECONDS:-2}
+
+powered() {
+  [[ $(timeout 2s bluetoothctl show 2>/dev/null) == *"Powered: yes"* ]]
+}
+
+# One deadline around the whole wait rather than a fixed number of probes, for the
+# same reason omarchy-bluetooth-power uses one: every probe can sit on its own
+# timeout when D-Bus is wedged, and counting probes then stretches the wait far
+# past what was asked for.
+wait_powered() {
+  local deadline=$((SECONDS + POWER_WAIT_SECONDS))
+
+  while :; do
+    powered && return 0
+    ((SECONDS < deadline)) || return 1
+    sleep 0.5
+  done
+}
+
+connect() {
+  local address=$1 attempt
+
+  for ((attempt = 1; attempt <= CONNECT_ATTEMPTS; attempt++)); do
+    timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 && return 0
+
+    # The peripheral has to be awake to answer. One woken by the same power-on as
+    # the machine can miss the first attempt while its own radio is still coming
+    # up, so leave it room to arrive rather than reporting it missing.
+    ((attempt < CONNECT_ATTEMPTS)) && sleep "$CONNECT_RETRY_SECONDS"
+  done
+
+  return 1
+}
+
+# Bluetooth being off is a decision -- held in the rfkill soft block, which
+# survives reboots -- so an adapter that never powers up means there is nothing to
+# do here, not that this command should power it on.
+if wait_powered; then
+  while read -r _ address _; do
+    # One info call per device, not one per question: each is a D-Bus round trip.
+    info=$(timeout 5s bluetoothctl info "$address" 2>/dev/null)
+
+    if [[ $info == *"$HID_UUID"* && $info != *"Connected: yes"* ]]; then
+      connect "$address" ||
+        echo "omarchy-bluetooth-reconnect: $address did not connect" >&2
+    fi
+  done < <(timeout 5s bluetoothctl devices Trusted 2>/dev/null)
+fi

--- a/default/systemd/user/omarchy-bluetooth-reconnect.service
+++ b/default/systemd/user/omarchy-bluetooth-reconnect.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Reconnect trusted Bluetooth keyboards and mice
+Documentation=man:bluetoothctl(1)
+ConditionPathIsDirectory=/sys/class/bluetooth
+# bluez must be reachable on the system bus before bluetoothctl can ask it for
+# anything.
+After=dbus.socket
+Requires=dbus.socket
+# The peripherals this connects are the ones the user is about to type on, so it
+# belongs to the login rather than to boot. Running after the target means the
+# oneshot cannot hold it open while it waits for the adapter.
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+# If bluetoothd is unavailable (for example in VMs or machines without a usable
+# adapter), skip cleanly rather than spending the adapter wait on nothing.
+ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
+ExecStart=/usr/bin/omarchy-bluetooth-reconnect
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 systemctl --user daemon-reload
 systemctl --user enable --now \
   bt-agent.service \
+  omarchy-bluetooth-reconnect.service \
   omarchy-recover-internal-monitor.service \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \

--- a/migrations/1787330669.sh
+++ b/migrations/1787330669.sh
@@ -2,8 +2,24 @@ echo "Reconnect trusted Bluetooth keyboards and mice at login"
 
 systemctl --user daemon-reload >/dev/null 2>&1 || true
 
-# Report what systemctl actually said; "could not enable" on its own gives
-# nothing to act on.
-if ! error=$(systemctl --user enable --now omarchy-bluetooth-reconnect.service 2>&1); then
-  echo "Could not enable omarchy-bluetooth-reconnect.service: $error"
+# Enable without --now, and start by hand further down only when there is a
+# session to start into. `systemctl enable` needs a live user manager, which an
+# `omarchy update` from a TTY or over SSH does not have, so fall back to writing
+# exactly the symlink it would have written rather than printing an error and
+# marking the migration complete with the unit still unenabled.
+if ! systemctl --user enable omarchy-bluetooth-reconnect.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-bluetooth-reconnect.service \
+    "$wants_dir/omarchy-bluetooth-reconnect.service"
+fi
+
+# This unit belongs to the login: the peripherals it asks for are the ones
+# someone is about to type on. Starting it from an update over SSH would reach
+# for the keyboard and mouse of whoever is sitting at the machine, mid-update,
+# so leave it to the next graphical login.
+if systemctl --user is-active --quiet graphical-session.target; then
+  # A failed start only leaves the peripherals where they already were, one
+  # click away in the Bluetooth panel, until the next login picks them up.
+  systemctl --user start omarchy-bluetooth-reconnect.service >/dev/null 2>&1 || true
 fi

--- a/migrations/1787330669.sh
+++ b/migrations/1787330669.sh
@@ -1,0 +1,9 @@
+echo "Reconnect trusted Bluetooth keyboards and mice at login"
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# Report what systemctl actually said; "could not enable" on its own gives
+# nothing to act on.
+if ! error=$(systemctl --user enable --now omarchy-bluetooth-reconnect.service 2>&1); then
+  echo "Could not enable omarchy-bluetooth-reconnect.service: $error"
+fi

--- a/test/shell.d/bluetooth-reconnect-test.sh
+++ b/test/shell.d/bluetooth-reconnect-test.sh
@@ -155,6 +155,29 @@ run_reconnect
   fail "reconnect reports a device it could not connect" "actual: $(<"$tmp/err")"
 pass "reconnect reports a device it could not connect"
 
+service="$ROOT/default/systemd/user/omarchy-bluetooth-reconnect.service"
+grep -Fx 'ExecStart=/usr/bin/omarchy-bluetooth-reconnect' "$service" >/dev/null
+grep -Fx 'ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service' "$service" >/dev/null ||
+  fail "reconnect spends the adapter wait on machines where bluetoothd never runs"
+grep -Fx 'WantedBy=graphical-session.target' "$service" >/dev/null ||
+  fail "reconnect is never pulled in at login without a WantedBy"
+grep -Fx 'After=graphical-session.target' "$service" >/dev/null ||
+  fail "a oneshot that waits for the adapter can hold graphical-session.target open"
+pass "reconnect runs once per login after the graphical session is ready"
+
+first_run_units="$ROOT/install/user/first-run/enable-user-units.sh"
+grep -F 'omarchy-bluetooth-reconnect.service' "$first_run_units" >/dev/null ||
+  fail "first-run does not enable the reconnect unit, so new installs never get it"
+pass "first-run enables the reconnect unit"
+
+# The unit has to be installed by the package before anything can enable it by
+# name: first-run enables every unit in one command under `set -e`, so a unit
+# missing from /usr/lib/systemd/user takes bt-agent and the sleep lock down with
+# it. config-test.sh holds the PKGBUILD mapping that keeps that honest.
+grep -F 'default/systemd/user/omarchy-bluetooth-reconnect.service' "$ROOT/test/shell.d/config-test.sh" >/dev/null ||
+  fail "reconnect unit is enabled by name with no PKGBUILD coverage asserting the package installs it"
+pass "reconnect unit is covered by the PKGBUILD mapping"
+
 migration="$ROOT/migrations/1787330669.sh"
 grep -F 'systemctl --user enable omarchy-bluetooth-reconnect.service' "$migration" >/dev/null ||
   fail "migration must enable without --now; --now starts the unit before the session-gate check"

--- a/test/shell.d/bluetooth-reconnect-test.sh
+++ b/test/shell.d/bluetooth-reconnect-test.sh
@@ -154,3 +154,12 @@ run_reconnect
 [[ $(<"$tmp/err") == *"$keyboard did not connect"* ]] ||
   fail "reconnect reports a device it could not connect" "actual: $(<"$tmp/err")"
 pass "reconnect reports a device it could not connect"
+
+migration="$ROOT/migrations/1787330669.sh"
+grep -F 'systemctl --user enable omarchy-bluetooth-reconnect.service' "$migration" >/dev/null ||
+  fail "migration must enable without --now; --now starts the unit before the session-gate check"
+grep -F 'graphical-session.target.wants' "$migration" >/dev/null ||
+  fail "an update over SSH has no user manager to enable into, so the migration completes with the unit unenabled and no second chance"
+grep -F 'is-active --quiet graphical-session.target' "$migration" >/dev/null ||
+  fail "migration reaches for the peripherals of whoever is at the machine during an update from a TTY"
+pass "migration enables for existing installs with or without a live user manager"

--- a/test/shell.d/bluetooth-reconnect-test.sh
+++ b/test/shell.d/bluetooth-reconnect-test.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+command="$ROOT/bin/omarchy-bluetooth-reconnect"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mouse="AA:AA:AA:AA:AA:AA"
+keyboard="BB:BB:BB:BB:BB:BB"
+headset="CC:CC:CC:CC:CC:CC"
+hid_uuid="00001124-0000-1000-8000-00805f9b34fb"
+a2dp_uuid="0000110b-0000-1000-8000-00805f9b34fb"
+
+mkdir -p "$tmp/bin"
+cat >"$tmp/bin/bluetoothctl" <<'EOF'
+#!/bin/bash
+
+state=$BLUETOOTHCTL_STATE
+
+case "$1" in
+  show)
+    echo "Controller 00:00:00:00:00:00 (public)"
+    echo "  Powered: $(<"$state/powered")"
+    ;;
+  devices)
+    cat "$state/devices"
+    ;;
+  info)
+    cat "$state/info/$2"
+    ;;
+  connect)
+    echo "$2" >>"$state/connect-log"
+
+    if [[ -f $state/fail-$2 ]]; then
+      remaining=$(<"$state/fail-$2")
+      if ((remaining > 0)); then
+        echo $((remaining - 1)) >"$state/fail-$2"
+        exit 1
+      fi
+    fi
+
+    echo "Connection successful"
+    ;;
+esac
+EOF
+chmod +x "$tmp/bin/bluetoothctl"
+
+# A trusted device as bluetoothctl describes it: the UUID lines are what
+# separates a keyboard from a headset, and Connected is what makes it a
+# candidate.
+describe_device() {
+  local address=$1 name=$2 uuid=$3 connected=$4
+
+  mkdir -p "$tmp/state/info"
+  cat >"$tmp/state/info/$address" <<EOF
+Device $address ($name)
+	Name: $name
+	Paired: yes
+	Trusted: yes
+	Connected: $connected
+	UUID: Vendor specific           ($uuid)
+EOF
+}
+
+reset_state() {
+  rm -rf "$tmp/state"
+  mkdir -p "$tmp/state/info"
+  echo yes >"$tmp/state/powered"
+  : >"$tmp/state/devices"
+  : >"$tmp/state/connect-log"
+}
+
+trust_device() {
+  echo "Device $1 $2" >>"$tmp/state/devices"
+}
+
+run_reconnect() {
+  BLUETOOTHCTL_STATE="$tmp/state" \
+    OMARCHY_BLUETOOTH_RECONNECT_WAIT_SECONDS=0 \
+    OMARCHY_BLUETOOTH_RECONNECT_RETRY_SECONDS=0 \
+    PATH="$tmp/bin:$ROOT/bin:$PATH" \
+    "$command" 2>"$tmp/err"
+}
+
+connect_log() {
+  tr '\n' ' ' <"$tmp/state/connect-log" | sed 's/ $//'
+}
+
+# A trusted keyboard and mouse left disconnected are exactly what BlueZ will not
+# pick up on its own, so both must be asked for.
+reset_state
+describe_device "$mouse" "Magic Mouse" "$hid_uuid" no
+describe_device "$keyboard" "Magic Keyboard" "$hid_uuid" no
+trust_device "$mouse" "Magic Mouse"
+trust_device "$keyboard" "Magic Keyboard"
+run_reconnect
+[[ $(connect_log) == "$mouse $keyboard" ]] ||
+  fail "reconnect connects trusted keyboards and mice" "actual: $(connect_log)"
+pass "reconnect connects trusted keyboards and mice"
+
+# Audio is already covered by ReconnectUUIDs and wireplumber, and grabbing a
+# headset at login would move audio off the speakers uninvited.
+reset_state
+describe_device "$headset" "Headset" "$a2dp_uuid" no
+trust_device "$headset" "Headset"
+run_reconnect
+[[ -z $(connect_log) ]] ||
+  fail "reconnect leaves non-HID devices alone" "actual: $(connect_log)"
+pass "reconnect leaves non-HID devices alone"
+
+# Asking for a device that is already connected would be a no-op at best, and
+# BlueZ has been known to drop and re-establish the link at worst.
+reset_state
+describe_device "$mouse" "Magic Mouse" "$hid_uuid" yes
+trust_device "$mouse" "Magic Mouse"
+run_reconnect
+[[ -z $(connect_log) ]] ||
+  fail "reconnect skips devices already connected" "actual: $(connect_log)"
+pass "reconnect skips devices already connected"
+
+# Bluetooth being off is a decision the rfkill soft block carries across reboots.
+# Reconnecting must not be what turns it back on.
+reset_state
+echo no >"$tmp/state/powered"
+describe_device "$mouse" "Magic Mouse" "$hid_uuid" no
+trust_device "$mouse" "Magic Mouse"
+run_reconnect
+[[ -z $(connect_log) ]] ||
+  fail "reconnect does nothing while the adapter is unpowered" "actual: $(connect_log)"
+pass "reconnect does nothing while the adapter is unpowered"
+
+# A peripheral woken by the same power-on as the machine can miss the first
+# attempt while its own radio is still coming up.
+reset_state
+describe_device "$mouse" "Magic Mouse" "$hid_uuid" no
+trust_device "$mouse" "Magic Mouse"
+echo 2 >"$tmp/state/fail-$mouse"
+run_reconnect
+[[ $(connect_log) == "$mouse $mouse $mouse" ]] ||
+  fail "reconnect retries a device that does not answer at once" "actual: $(connect_log)"
+[[ -z $(<"$tmp/err") ]] ||
+  fail "reconnect stays quiet once a retry succeeds" "actual: $(<"$tmp/err")"
+pass "reconnect retries a device that does not answer at once"
+
+# Giving up silently would leave nothing to explain a dead keyboard.
+reset_state
+describe_device "$keyboard" "Magic Keyboard" "$hid_uuid" no
+trust_device "$keyboard" "Magic Keyboard"
+echo 99 >"$tmp/state/fail-$keyboard"
+run_reconnect
+[[ $(<"$tmp/err") == *"$keyboard did not connect"* ]] ||
+  fail "reconnect reports a device it could not connect" "actual: $(<"$tmp/err")"
+pass "reconnect reports a device it could not connect"

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -141,6 +141,7 @@ package_defaults = [
   ("default/systemd/user/omarchy-tailscale-receive.service", "/usr/lib/systemd/user/omarchy-tailscale-receive.service", "systemd/user/omarchy-tailscale-receive.service"),
   ("default/systemd/user/omarchy-fcitx5.service", "/usr/lib/systemd/user/omarchy-fcitx5.service", "systemd/user/omarchy-fcitx5.service"),
   ("default/systemd/user/omarchy-crash-watch.service", "/usr/lib/systemd/user/omarchy-crash-watch.service", "systemd/user/omarchy-crash-watch.service"),
+  ("default/systemd/user/omarchy-bluetooth-reconnect.service", "/usr/lib/systemd/user/omarchy-bluetooth-reconnect.service", "systemd/user/omarchy-bluetooth-reconnect.service"),
   ("default/systemd/zram-generator.conf.d/90-omarchy.conf", "/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf", "systemd/zram-generator.conf.d/90-omarchy.conf"),
   ("default/fonts/omarchy/omarchy.ttf", "/usr/share/fonts/omarchy/omarchy.ttf", "omarchy.ttf"),
   ("default/snapper/root", "/etc/snapper/config-templates/omarchy", "snapper/root"),


### PR DESCRIPTION
A paired Bluetooth keyboard or mouse does not come back on its own after a reboot. It stays paired and idle until someone opens the Bluetooth panel and clicks it — a hard first move to make when the keyboard you would use to get there is the thing that did not connect.

### Why it happens

BlueZ's policy plugin reconnects only the profiles listed in `ReconnectUUIDs`, and the stock list is the four audio ones:

```
#ReconnectUUIDs=00001112-...,0000111f-...,0000110a-...,0000110b-...
                Headset AG    Handsfree AG  AudioSource  AudioSink
```

HID (`0x1124`) is deliberately absent. And adding it would not be the fix either: that path covers a link that *dropped*, not an adapter that has only just come up. Nothing in the stock configuration ever asks for the peripheral at session start, so `bt-agent` gets you paired and then nothing keeps you connected.

### What this adds

`omarchy-bluetooth-reconnect` asks once, when the session starts, from a oneshot user unit alongside the other units in `install/user/first-run/enable-user-units.sh`. It waits for the adapter, then connects every trusted device advertising HID that is not already connected, retrying a few times because a peripheral woken by the same power-on as the machine can miss the first attempt while its own radio is still coming up. It is also reachable by hand as `omarchy bluetooth reconnect`.

Three deliberate limits:

- **Trusted, not merely paired.** Trust is the standing "connect this without asking" flag, and `omarchy-bluetooth-device` already sets it on every pair and every connect, so anything adopted through the Bluetooth panel qualifies.
- **Keyboards and mice only.** Audio already has both halves covered — `ReconnectUUIDs` for a dropped link, wireplumber's a2dp autoconnect for the rest — and pulling a headset in at login would move audio off the speakers uninvited.
- **Never powers the adapter on.** Bluetooth being off is a decision the rfkill soft block carries across reboots, so an adapter that never powers up means there is nothing to do, not that this command should undo it.

### Testing

`test/shell.d/bluetooth-reconnect-test.sh` stubs `bluetoothctl` and covers the selection rules and the retry path:

```
ok - reconnect connects trusted keyboards and mice
ok - reconnect leaves non-HID devices alone
ok - reconnect skips devices already connected
ok - reconnect does nothing while the adapter is unpowered
ok - reconnect retries a device that does not answer at once
ok - reconnect reports a device it could not connect
```

Verified on hardware too, with a Magic Mouse, an Apple keyboard and a set of AirPods all trusted on the same adapter:

- With everything connected it is a no-op — the AirPods short-circuit on the HID test, the mouse and keyboard skip as already connected, and no `connect` is issued.
- Disconnecting the mouse and running it reconnected the mouse in 0.8s, exit 0, leaving the AirPods alone.
- The unit itself runs clean under systemd (`Result=success`, `ExecMainStatus=0`), and `systemd-analyze verify` is quiet.

`./test/cli` passes. In `./test/shell`, the new file passes; the five failures on this machine (`bar-icon-geometry`, `config`, `runtime-smoke`, `snapper`, `unowned-system-paths`) reproduce identically on a pristine `quattro` checkout at the same commit — three want an `omarchy-pkgs` checkout, and `runtime-smoke` collides with the session's running Quickshell.

A migration enables the unit for existing installs, since `enable-user-units.sh` only runs at first-run.
