### PR TITLE
Match Spotify and Signal launcher windows by class only

### DIFF
--- a/bin/omarchy-launch-signal
+++ b/bin/omarchy-launch-signal
@@ -4,7 +4,7 @@
 
 set -e
 
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select((.class|test("\\bsignal\\b";"i")) or (.title|test("\\bsignal\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select(.class|test("\\bsignal\\b";"i"))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/bin/omarchy-launch-spotify
+++ b/bin/omarchy-launch-spotify
@@ -4,7 +4,7 @@
 
 set -e
 
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select((.class|test("\\bspotify\\b";"i")) or (.title|test("\\bspotify\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select(.class|test("\\bspotify\\b";"i"))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"


### PR DESCRIPTION
Fixes #7154.

`omarchy-launch-spotify` picks the window to focus with a jq filter that matches `\bspotify\b` against the window **class or title**. Any window whose title happens to contain the word — a browser tab, a terminal running a session named "Diagnosing Spotify issue" — wins the match, so `SUPER+SHIFT+M` focuses that window instead of launching or focusing Spotify. From the user's side the shortcut just "does nothing", and nothing in the config explains why.

`omarchy-launch-signal` has the identical filter for `\bsignal\b`, so it has the same problem.

## Fix

Match on the window class only. The class is the canonical app identifier, and Spotify reports it as `Spotify` under XWayland or `spotify` as a native Wayland app_id — both still match the case-insensitive `\bspotify\b`. Same for Signal.

`omarchy-launch-or-focus` has the same class-or-title match; #4928 already proposes the same change there, so this PR leaves it alone.

## Verification

Ran both jq filters against a fake `hyprctl clients -j` payload:

```json
[{"class":"Alacritty","title":"OC | Diagnosing Spotify issue"},
 {"class":"chromium","title":"Spotify Wrapped - YouTube"},
 {"class":"Spotify","title":"Spotify Premium"},
 {"class":"spotify","title":"Daft Punk - Spotify"},
 {"class":"signal","title":"Signal"}]
```

- Old Spotify filter, first match: the Alacritty window (the reported hijack).
- New Spotify filter: only the two Spotify windows, XWayland and native class spellings both matched.
- New Signal filter: only the Signal window.

`bash -n` on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdrqXrL4pbdS9CjdHxfCYF
