### PR TITLE
Add Google Antigravity CLI as a default coding agent option

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -78,6 +78,10 @@ claude)
   command=(claude --permission-mode auto)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
+agy)
+  command=(agy --dangerously-skip-permissions)
+  [[ -n ${prompt:-} ]] && command+=(--prompt-interactive "$prompt")
+  ;;
 grok)
   command=(grok --permission-mode bypassPermissions)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|claude|codex|grok|gemini|copilot|crush]
+# omarchy:args=[pi|omp|opencode|claude|antigravity|codex|grok|gemini|copilot|crush]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -28,13 +28,14 @@ pi) agent="pi"; name="Pi" ;;
 omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-my-pi" ;;
 opencode | open-code) agent="opencode"; name="OpenCode" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
+antigravity | agy) agent="agy"; name="Antigravity"; agent_package="aqua:google-antigravity/antigravity-cli" ;;
 codex) agent="codex"; name="Codex" ;;
 crush) agent="crush"; name="Crush" ;;
 grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
 gemini | gemini-cli) agent="gemini"; name="Gemini" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|claude|codex|grok|gemini|copilot|crush>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|claude|antigravity|codex|grok|gemini|copilot|crush>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -15,7 +15,7 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
   # Remove mise stubs
   rm -f ~/.local/bin/codex ~/.local/bin/claude ~/.local/bin/gemini ~/.local/bin/copilot \
        ~/.local/bin/gh ~/.local/bin/opencode ~/.local/bin/playwright ~/.local/bin/playwright-cli ~/.local/bin/pi \
-       ~/.local/bin/omp ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk
+       ~/.local/bin/omp ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk ~/.local/bin/agy
 
   omarchy-pkg-drop \
     aether \

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -135,6 +135,7 @@
   "setup.network.qr": {"icon":"󰐲","label":"QR Code","aliases":["wifi-qr"],"when":"[[ $(omarchy-network-status) == wifi* ]]","action":"omarchy-shell shell summon omarchy.wifiqr"},
   "setup.default": {"icon":"","label":"Defaults","aliases":["default","defaults"]},
   "setup.default.agent": {"icon":"󰚩","label":"Agent","title":"Default Agent"},
+  "setup.default.agent.agy": {"icon":"󱓞","label":"Antigravity","checked":"[[ \"$(omarchy-default-agent)\" == \"agy\" ]]","action":"omarchy-default-agent agy"},
   "setup.default.agent.claude": {"icon":"󰛄","label":"Claude","checked":"[[ \"$(omarchy-default-agent)\" == \"claude\" ]]","action":"omarchy-default-agent claude"},
   "setup.default.agent.codex": {"icon":"","iconFont":"omarchy","label":"Codex","checked":"[[ \"$(omarchy-default-agent)\" == \"codex\" ]]","action":"omarchy-default-agent codex"},
   "setup.default.agent.copilot": {"icon":"","label":"Copilot","checked":"[[ \"$(omarchy-default-agent)\" == \"copilot\" ]]","action":"omarchy-default-agent copilot"},

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -1,5 +1,6 @@
 omarchy-mise-install codex
 omarchy-mise-install claude
+omarchy-mise-install aqua:google-antigravity/antigravity-cli agy
 omarchy-mise-install crush
 omarchy-mise-install gemini
 omarchy-mise-install gh

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -2,17 +2,18 @@
 
 Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a favorite for you. Instead, every major coding-agent CLI comes pre-wired as a lazy-loaded launcher. The launchers are tiny [mise](https://mise.jdx.dev/)-managed stubs in `~/.local/bin/`, so nothing is downloaded until the first time you actually run one. Invoke any of these and authenticate when prompted:
 
-| Command    | Agent                                                            |
-|------------|------------------------------------------------------------------|
-| `claude`   | [Claude Code](https://code.claude.com/docs/en/overview)          |
-| `codex`    | [OpenAI Codex](https://github.com/openai/codex)                  |
-| `opencode` | [OpenCode](https://opencode.ai/)                                 |
-| `gemini`   | [Google Gemini CLI](https://github.com/google-gemini/gemini-cli) |
-| `copilot`  | [GitHub Copilot CLI](https://github.com/github/copilot-cli)      |
-| `crush`    | [Crush](https://github.com/charmbracelet/crush)                  |
-| `grok`     | Grok CLI from xAI                                                |
-| `pi`       | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)        |
-| `omp`      | [Oh My Pi](https://github.com/can1357/oh-my-pi)                  |
+| Command    | Agent                                                                            |
+|------------|-----------------------------------------------------------------------------------|
+| `claude`   | [Claude Code](https://code.claude.com/docs/en/overview)                         |
+| `agy`      | [Google Antigravity CLI](https://github.com/google-antigravity/antigravity-cli) |
+| `codex`    | [OpenAI Codex](https://github.com/openai/codex)                                 |
+| `opencode` | [OpenCode](https://opencode.ai/)                                                |
+| `gemini`   | [Google Gemini CLI](https://github.com/google-gemini/gemini-cli)                |
+| `copilot`  | [GitHub Copilot CLI](https://github.com/github/copilot-cli)                     |
+| `crush`    | [Crush](https://github.com/charmbracelet/crush)                                 |
+| `grok`     | Grok CLI from xAI                                                                |
+| `pi`       | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)                       |
+| `omp`      | [Oh My Pi](https://github.com/can1357/oh-my-pi)                                 |
 
 To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`. The stubs are kept current along with everything else mise manages when you run `omarchy update` (or the `mup` alias).
 

--- a/migrations/1787242932.sh
+++ b/migrations/1787242932.sh
@@ -1,0 +1,5 @@
+echo "Install Antigravity (agy) via mise wrapper"
+
+if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  omarchy-mise-install aqua:google-antigravity/antigravity-cli agy
+fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -95,6 +95,7 @@ export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
 grok_package="npm:@xai-official/grok"
 omp_package="github:can1357/oh-my-pi"
 crush_package="crush"
+antigravity_package="aqua:google-antigravity/antigravity-cli"
 
 assert_lazy_stub() {
   local package=$1
@@ -112,17 +113,23 @@ assert_lazy_stub() {
 assert_lazy_stub "$grok_package" grok
 assert_lazy_stub "$omp_package" omp
 assert_lazy_stub "$crush_package" crush
+assert_lazy_stub "$antigravity_package" agy
 pass "custom agent lazy stubs preserve their mise packages"
 
 source "$ROOT/install/user/mise.sh"
 grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "user setup creates the Oh My Pi lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the Crush lazy stub"
+grep -Fx "$antigravity_package agy" "$stub_log" >/dev/null || fail "user setup creates the Antigravity lazy stub"
 pass "user setup creates the custom agent lazy stubs"
 
 : >"$stub_log"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "Oh My Pi migration creates a working lazy stub"
+
+: >"$stub_log"
+source "$ROOT/migrations/1787242932.sh" >/dev/null
+grep -Fx "$antigravity_package agy" "$stub_log" >/dev/null || fail "Antigravity migration creates a working lazy stub"
 
 : >"$stub_log"
 source "$ROOT/migrations/1785846769.sh" >/dev/null
@@ -136,6 +143,7 @@ touch "$test_home/.local/state/omarchy/preinstalls-removed"
 : >"$stub_log"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
 source "$ROOT/migrations/1785846769.sh" >/dev/null
+source "$ROOT/migrations/1787242932.sh" >/dev/null
 [[ ! -s $stub_log ]] || fail "agent migrations respect the preinstall opt-out"
 [[ ! -e $test_home/.local/bin/omp ]] || fail "agent migration removes the obsolete Oh My Pi wrapper after opt-out"
 
@@ -160,7 +168,7 @@ rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"
 
 omarchy-remove-preinstalls >/dev/null
-for command in omp grok crush; do
+for command in omp grok crush agy; do
   [[ ! -e $test_home/.local/bin/$command ]] || fail "Remove Preinstalls deletes the $command lazy stub"
 done
 pass "Remove Preinstalls deletes every optional agent lazy stub"
@@ -213,6 +221,8 @@ declare -A expected_agents=(
   [open-code]="opencode"
   [claude]="claude"
   [claude-code]="claude"
+  [antigravity]="agy"
+  [agy]="agy"
   [codex]="codex"
   [crush]="crush"
   [grok]="grok"
@@ -227,6 +237,7 @@ declare -A expected_packages=(
   [omp]="$omp_package"
   [opencode]="opencode"
   [claude]="claude"
+  [agy]="$antigravity_package"
   [codex]="codex"
   [crush]="$crush_package"
   [grok]="$grok_package"
@@ -370,6 +381,7 @@ assert_launch pi pi "Review this project"
 assert_launch omp omp --auto-approve -- "Review this project"
 assert_launch opencode opencode --auto --prompt "Review this project"
 assert_launch claude claude --permission-mode auto -- "Review this project"
+assert_launch agy agy --dangerously-skip-permissions --prompt-interactive "Review this project"
 assert_launch codex codex --approve-for-me -- "Review this project"
 assert_launch crush crush run "Review this project"
 assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
@@ -381,6 +393,7 @@ assert_bypass pi pi
 assert_bypass omp omp --auto-approve
 assert_bypass opencode opencode --auto
 assert_bypass claude claude --permission-mode auto
+assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass codex codex --approve-for-me
 assert_bypass crush crush --yolo
 assert_bypass grok grok --permission-mode bypassPermissions

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -215,6 +215,7 @@ const expectedAgents = {
   omp: { icon: '\ue903', iconFont: 'omarchy', label: 'omp' },
   opencode: { icon: '\ue902', iconFont: 'omarchy', label: 'OpenCode' },
   claude: { icon: '󰛄', label: 'Claude' },
+  agy: { icon: '󱓞', label: 'Antigravity' },
   codex: { icon: '\ue905', iconFont: 'omarchy', label: 'Codex' },
   grok: { icon: '\ue904', iconFont: 'omarchy', label: 'Grok' },
   gemini: { icon: '󰫢', label: 'Gemini' },
@@ -238,7 +239,7 @@ assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Claude', 'Codex', 'Copilot', 'Crush', 'Gemini', 'Grok', 'omp', 'OpenCode', 'Pi'],
+  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Gemini', 'Grok', 'omp', 'OpenCode', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {


### PR DESCRIPTION
## Summary

Adds Google Antigravity CLI (`agy`) as another default-agent option, alongside the existing ones — nothing is replaced or changed for existing agents.

- `bin/omarchy-default-agent` — new `antigravity | agy` case, installed via mise as `aqua:google-antigravity/antigravity-cli`
- `bin/omarchy-agent` — launches it as `agy --dangerously-skip-permissions`, with `--prompt-interactive` when given a starting prompt (same pattern as the Gemini launch)
- `default/omarchy/omarchy-menu.jsonc` — new "Antigravity" entry under Setup → Defaults → Agent
- `install/user/mise.sh` + new migration — pre-wires `agy` as a lazy stub on both fresh and existing installs, matching every other bundled agent
- `bin/omarchy-remove-preinstalls` — cleans up the `agy` stub too
- `manual/17-ai.md` — added to the agent table
- Test coverage added to `test/shell.d/default-agent-test.sh` and `test/shell.d/menu-test.sh`

## Test plan

- [x] `./test/cli` passes
- [x] `./test/shell` passes (only pre-existing, unrelated failures in this environment: `bar-icon-geometry-test`, `config-test`, `runtime-smoke-test`, `snapper-test`, `unowned-system-paths-test` — same failures on unmodified `quattro`)
- [x] Live end-to-end on a real Omarchy machine: `omarchy default agent antigravity` installs and launches Antigravity in a terminal window
- [x] Live crash-diagnosis integration: `omarchy agent crash <pid>` correctly resolves to `agy` and launches it with the diagnose-crash prompt, matching the existing pattern for other agents
