### PR TITLE
Show the weather status notification in the panel's unit

### DIFF
--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -10,15 +10,76 @@ if [[ -z $place ]]; then
 fi
 
 query=$(jq -rn --arg place "$place" '$place | @uri')
-weather=$(curl -fsS --max-time 4 "https://wttr.in/${query}?format=%t|%w" 2>/dev/null | tr -d '\n')
+report=$(curl -fsS --max-time 6 "https://wttr.in/${query}?format=j1" 2>/dev/null)
 
-if [[ -z $weather ]]; then
+if [[ -z $report ]]; then
   echo "Weather unavailable"
   exit 1
 fi
 
-IFS='|' read -r temperature wind <<< "$weather"
-place=${place^}
-temperature=${temperature#+}
+country=$(jq -r '.nearest_area[0].country[0].value // ""' <<<"$report")
+temperature_c=$(jq -r '.current_condition[0].temp_C // ""' <<<"$report")
+temperature_f=$(jq -r '.current_condition[0].temp_F // ""' <<<"$report")
+wind_kmh=$(jq -r '.current_condition[0].windspeedKmph // ""' <<<"$report")
+wind_mph=$(jq -r '.current_condition[0].windspeedMiles // ""' <<<"$report")
 
-echo "$place  ·  Temp $temperature  ·  Wind $wind"
+if [[ -z $temperature_c ]]; then
+  echo "Weather unavailable"
+  exit 1
+fi
+
+# Mirror the panel's unit decision (Model.js shouldUseImperial): an explicit
+# shell.json unit override wins, then wttr's reported country, then the
+# session locale — so this notification always agrees with what the widget's
+# popup shows.
+shell_config=$HOME/.config/omarchy/shell.json
+[[ -s $shell_config ]] || shell_config=$OMARCHY_PATH/config/omarchy/shell.json
+unit_override=$(jq -r '
+  [(.bar.layout.left // [])[], (.bar.layout.center // [])[], (.bar.layout.right // [])[]]
+  | map(select(type == "object" and .id == "omarchy.weather") | .unit // empty)
+  | first // ""
+' "$shell_config" 2>/dev/null || echo "")
+
+country=${country//./ }
+country=${country//-/ }
+country=${country//_/ }
+country=${country,,}
+
+use_imperial=
+case ${unit_override,,} in
+  imperial) use_imperial=true ;;
+  metric) use_imperial=false ;;
+esac
+
+if [[ -z $use_imperial ]]; then
+  case $country in
+    us | usa | "united states" | "united states of america" | liberia | myanmar | burma) use_imperial=true ;;
+    "") ;;
+    *) use_imperial=false ;;
+  esac
+fi
+
+if [[ -z $use_imperial ]]; then
+  locale=${LANG:-}
+  locale=${locale%%.*}
+  locale=${locale//-/_}
+  if [[ $locale =~ ^(en_US|en_LR|my)($|_) ]]; then
+    use_imperial=true
+  else
+    use_imperial=false
+  fi
+fi
+
+if [[ $use_imperial == true ]]; then
+  temperature=$temperature_f
+  unit=F
+  wind="$wind_mph mph"
+else
+  temperature=$temperature_c
+  unit=C
+  wind="$wind_kmh km/h"
+fi
+
+place=${place^}
+
+echo "$place  ·  Temp $temperature°$unit  ·  Wind $wind"

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -182,3 +182,123 @@ pass "weather location rejects malformed coordinates"
 weather_location --clear
 [[ ! -e "$test_tmp/.local/state/omarchy/settings/weather.json" ]] || fail "weather location clear removes the state file"
 pass "weather location clear removes the state file"
+
+# ---- omarchy-weather-status: unit parity with the panel --------------------
+
+status_dir="$test_tmp/status"
+status_home="$status_dir/home"
+mkdir -p "$status_dir/bin" "$status_home/.config/omarchy"
+
+# Serves the canned j1 report and records the requested URL so tests can pin
+# both the query contract and the units the notification comes out with.
+cat >"$status_dir/bin/curl" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$status_dir/last-url"
+if [[ -f $status_dir/report.json ]]; then
+  cat "$status_dir/report.json"
+fi
+EOF
+
+cat >"$status_dir/bin/omarchy-weather-location" <<'STUB'
+#!/bin/bash
+echo "malibu"
+STUB
+chmod +x "$status_dir/bin/curl" "$status_dir/bin/omarchy-weather-location"
+
+weather_status() {
+  HOME="$status_home" OMARCHY_PATH="$ROOT" PATH="$status_dir/bin:$PATH" LANG=${1:-} \
+    "$ROOT/bin/omarchy-weather-status"
+}
+
+serve_report() {
+  cat >"$status_dir/report.json"
+}
+
+set_weather_unit() {
+  jq --arg unit "$1" '.bar.layout.center |= map(if .id == "omarchy.weather" then . + {unit: $unit} else . end)' \
+    "$ROOT/config/omarchy/shell.json" >"$status_home/.config/omarchy/shell.json"
+}
+
+clear_weather_unit() {
+  rm -f "$status_home/.config/omarchy/shell.json"
+}
+
+serve_report <<'JSON'
+{
+  "current_condition": [
+    { "temp_C": "21", "temp_F": "70", "windspeedKmph": "14", "windspeedMiles": "9" }
+  ],
+  "nearest_area": [
+    { "country": [ { "value": "Denmark" } ] }
+  ]
+}
+JSON
+
+output=$(weather_status en_US.UTF-8) || fail "weather status succeeds for a metric country"
+[[ $output == "Malibu  ·  Temp 21°C  ·  Wind 14 km/h" ]] || fail "weather status prefers the reported metric country over a US locale" "$output"
+pass "weather status prefers the reported metric country over a US locale"
+
+[[ $(<"$status_dir/last-url") == *"https://wttr.in/malibu?format=j1"* ]] || fail "weather status fetches the wttr j1 report for the configured place" "$(<"$status_dir/last-url")"
+pass "weather status fetches the wttr j1 report for the configured place"
+
+serve_report <<'JSON'
+{
+  "current_condition": [
+    { "temp_C": "21", "temp_F": "70", "windspeedKmph": "14", "windspeedMiles": "9" }
+  ],
+  "nearest_area": [
+    { "country": [ { "value": "United States of America" } ] }
+  ]
+}
+JSON
+
+output=$(weather_status da_DK.UTF-8) || fail "weather status succeeds for an imperial country"
+[[ $output == "Malibu  ·  Temp 70°F  ·  Wind 9 mph" ]] || fail "weather status prefers the reported imperial country over a metric locale" "$output"
+pass "weather status prefers the reported imperial country over a metric locale"
+
+serve_report <<'JSON'
+{
+  "current_condition": [
+    { "temp_C": "21", "temp_F": "70", "windspeedKmph": "14", "windspeedMiles": "9" }
+  ]
+}
+JSON
+
+output=$(weather_status en_US.UTF-8) || fail "weather status succeeds without a reported country"
+[[ $output == "Malibu  ·  Temp 70°F  ·  Wind 9 mph" ]] || fail "weather status falls back to the session locale without a reported country" "$output"
+pass "weather status falls back to the session locale without a reported country"
+
+serve_report <<'JSON'
+{
+  "current_condition": [
+    { "temp_C": "21", "temp_F": "70", "windspeedKmph": "14", "windspeedMiles": "9" }
+  ],
+  "nearest_area": [
+    { "country": [ { "value": "Denmark" } ] }
+  ]
+}
+JSON
+
+set_weather_unit imperial
+output=$(weather_status da_DK.UTF-8) || fail "weather status succeeds with an imperial override"
+[[ $output == "Malibu  ·  Temp 70°F  ·  Wind 9 mph" ]] || fail "weather status honors an imperial unit override over country and locale" "$output"
+pass "weather status honors an imperial unit override over country and locale"
+
+set_weather_unit metric
+output=$(weather_status en_US.UTF-8) || fail "weather status succeeds with a metric override"
+[[ $output == "Malibu  ·  Temp 21°C  ·  Wind 14 km/h" ]] || fail "weather status honors a metric unit override over country and locale" "$output"
+pass "weather status honors a metric unit override over country and locale"
+clear_weather_unit
+
+rm -f "$status_dir/report.json"
+output=$(weather_status en_US.UTF-8) && fail "weather status fails when wttr answers nothing"
+[[ $output == "Weather unavailable" ]] || fail "weather status reports unavailability when wttr answers nothing" "$output"
+pass "weather status reports unavailability when wttr answers nothing"
+
+serve_report <<'JSON'
+{ "current_condition": [] }
+JSON
+
+output=$(weather_status en_US.UTF-8) && fail "weather status fails without current conditions"
+[[ $output == "Weather unavailable" ]] || fail "weather status reports unavailability without current conditions" "$output"
+pass "weather status reports unavailability without current conditions"


### PR DESCRIPTION
Fixes #7706

## Problem

Left-clicking the weather widget opens a panel whose units follow `Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, reportCountry)` — an explicit shell.json `unit` override first, then wttr's reported country (US/Liberia/Myanmar), then the session locale. Right-clicking the same widget runs `omarchy-weather-status`, which fetched `wttr.in/<place>?format=%t|%w` with no unit flag and let wttr pick its own units from location heuristics.

With no explicit override — or whenever wttr's country-based choice disagrees with the locale fallback the panel ends up on, e.g. with pinned coordinates where Open-Meteo supplies current conditions and no `reportCountry` is known yet — the two surfaces show different units. That is exactly the mismatch in the issue: a Celsius panel next to a Fahrenheit notification.

## Fix

`omarchy-weather-status` now fetches the same `format=j1` report the panel uses and applies the identical precedence:

1. explicit `unit` override read from the `omarchy.weather` bar entry in shell.json (user config falling back to the defaults file)
2. wttr-reported country (`nearest_area[0].country`)
3. session locale from `$LANG`

Temperature, wind value, and wind unit are all taken from the j1 response, so the notification always agrees with what the widget's popup shows. Output format and the "Weather unavailable" failure path are unchanged; the boot hook sample benefits automatically since it calls the same command.

## Tests

Extended `test/shell.d/weather-test.sh` with end-to-end cases for the status script (stubbed curl + `omarchy-weather-location`):

- metric country beats a US locale (panel parity both ways)
- imperial country beats a metric locale
- locale fallback when no `nearest_area` country is present
- `unit: imperial` / `unit: metric` overrides win over both country and locale
- the j1 URL contract for the configured place
- "Weather unavailable" when wttr answers nothing or returns no current conditions

`./test/shell.d/weather-test.sh` and `./test/cli` pass.