### PR TITLE
Display keybindings in menu on demand via "?"

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -153,6 +153,18 @@ link is followed to its target. The default Hyprland bindings in
 `default/hypr/bindings/utilities.lua` all go through this surface
 (SUPER+SPACE toggles root, SUPER+ESCAPE the system menu, and so on).
 
+## Keybindings
+
+The menu resolves shortcuts from Hyprland's keybinding records asynchronously on demand. Pressing `?` while browsing or filtering toggles keybinding visibility on the right edge of each row. Default visibility can be set in `~/.config/omarchy/shell.json`:
+
+```json
+{
+  "menu": {
+    "keybindings": true
+  }
+}
+```
+
 ## Select and input modes
 
 The same plugin doubles as the system's dmenu. `omarchy-menu-select` and

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -1,6 +1,6 @@
 # Hotkeys
 
-You can see all the main keyboard bindings with `Super + K` (Tmux bindings with `Super + Alt + K` and Herdr bindings with `Super + Ctrl + K`).
+You can see all the main keyboard bindings with `Super + K` (Tmux bindings with `Super + Alt + K` and Herdr bindings with `Super + Ctrl + K`). You can also press `?` inside the Omarchy menu (`Super + Space`) to peek at shortcuts for menu entries.
 
 ## Navigating
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -36,6 +36,7 @@ Item {
   }
 
   function refresh() {
+    if (root.keybindingsLoaded) root.loadKeybindings()
     defaultMenuFile.reload()
     userMenuFile.reload()
     return "ok"
@@ -74,13 +75,39 @@ Item {
   property var providersLoaded: ({})
   property var providerQueue: []
   property int providerRevision: 0
+  property var keybindings: []
+  property bool keybindingsLoaded: false
+  readonly property bool defaultShowKeybindings: Boolean(root.shell && root.shell.shellConfig && root.shell.shellConfig.menu && root.shell.shellConfig.menu.keybindings)
+  property bool showKeybindings: false
+
+  function applyKeybindings() {
+    MenuModel.applyKeybindings(root.items, root.itemOrder, root.keybindings)
+  }
+
+  function loadKeybindings() {
+    if (keybindingsProc.running) return
+    keybindingsProc.collected = ""
+    keybindingsProc.command = ["bash", "-c", "/usr/bin/omarchy-menu-keybindings -p >/dev/null 2>&1; cache_file=$(ls -t \"${XDG_CACHE_HOME:-$HOME/.cache}/omarchy\"/keybindings-*.records 2>/dev/null | head -n1); [[ -s \"$cache_file\" ]] && cat \"$cache_file\""]
+    keybindingsProc.running = true
+  }
 
   // Shared application engine (entries, hidden filters, icons, launch,
   // removal), owned by the shell and also used by the standalone launcher.
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  onOpenedChanged: {
+    if (!opened) {
+      deleteConfirmOpen = false
+      deleteTarget = null
+      showKeybindings = false
+    } else {
+      showKeybindings = root.defaultShowKeybindings
+      if (root.showKeybindings && !root.keybindingsLoaded) {
+        root.loadKeybindings()
+      }
+    }
+  }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -108,7 +135,8 @@ Item {
   property int dividerHeight: Style.space(17)
   property bool searchDivider: false
   property int layoutSerial: 0
-  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Style.space(300)), panel.width - Style.gapsOut * 2)
+  property int baseCardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Style.space(300)), panel.width - Style.gapsOut * 2)
+  property int cardWidth: Math.min(root.baseCardWidth + (root.showKeybindings ? Style.space(130) : 0), panel.width - Style.gapsOut * 2)
   property int visibleRowsHeight: root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)
   property int cardHeight: root.dmenuActive
     ? Math.min(contentMargin * 2 + headerHeight + (mode === "input" ? 0 : contentSpacing + visibleRowsHeight), panel.height - Style.gapsOut * 2)
@@ -250,6 +278,7 @@ Item {
     root.providerQueue = []
     root.items = mergedMenu.items
     root.itemOrder = mergedMenu.itemOrder
+    root.applyKeybindings()
     root.rowsLoaded = true
     root.evaluateGuards()
     if (root.opened) {
@@ -325,6 +354,7 @@ Item {
     var merged = MenuModel.mergeAppRows(root.items, root.itemOrder, appRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
+    root.applyKeybindings()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -582,6 +612,7 @@ Item {
         label: label,
         target: "",
         detail: detail,
+        keybinding: "",
         path: "",
         childCount: 0,
         action: "",
@@ -947,6 +978,22 @@ Item {
     }
   }
 
+  Process {
+    id: keybindingsProc
+    property string collected: ""
+    stdout: SplitParser {
+      onRead: function(data) { keybindingsProc.collected += data + "\n" }
+    }
+    onExited: function(exitCode, exitStatus) {
+      if (exitCode === 0) {
+        root.keybindings = MenuModel.parseKeybindingRecords(keybindingsProc.collected)
+        root.keybindingsLoaded = true
+        root.applyKeybindings()
+        if (root.opened) root.rebuildDisplay()
+      }
+    }
+  }
+
   PointerMoveGate {
     id: pointerGate
     referenceItem: card
@@ -1105,7 +1152,7 @@ Item {
       width: root.cardWidth
       height: Math.min(root.cardHeight, panel.height - Style.gapsOut - panel.effectiveCardTop)
       radius: root.cornerRadius
-      anchors.horizontalCenter: parent.horizontalCenter
+      x: Math.max(Style.gapsOut, Math.round((panel.width - root.baseCardWidth) / 2))
       y: panel.effectiveCardTop
       color: root.background
       borderSpec: root.borderSpec
@@ -1132,6 +1179,10 @@ Item {
           } else if (event.key === Qt.Key_Escape) {
             if (root.filterText) root.setFilter("")
             else root.cancel()
+            event.accepted = true
+          } else if (event.text === "?" || event.key === Qt.Key_Question) {
+            if (!root.keybindingsLoaded) root.loadKeybindings()
+            root.showKeybindings = !root.showKeybindings
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
@@ -1256,6 +1307,7 @@ Item {
               required property string label
               required property string target
               required property string detail
+              required property string keybinding
               required property string path
               required property string action
               required property int childCount
@@ -1326,23 +1378,44 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 spacing: Style.space(3)
 
-                Text {
-                  id: labelText
+                Item {
+                  id: labelRow
                   width: parent.width
-                  text: row.label
-                  color: row.hasCursor ? root.selectedText : root.foreground
-                  font.family: root.fontFamily
-                  font.pixelSize: Style.font.heading
-                  font.weight: Font.Medium
-                  elide: Text.ElideRight
+                  height: labelText.implicitHeight
+
+                  Text {
+                    id: labelText
+                    anchors.left: parent.left
+                    anchors.right: keybindingText.visible ? keybindingText.left : parent.right
+                    anchors.rightMargin: keybindingText.visible ? Style.space(8) : 0
+                    anchors.top: parent.top
+                    text: row.label
+                    color: row.hasCursor ? root.selectedText : root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.heading
+                    font.weight: Font.Medium
+                    elide: Text.ElideRight
+                  }
+
+                  Text {
+                    id: keybindingText
+                    anchors.right: parent.right
+                    anchors.baseline: labelText.baseline
+                    text: row.keybinding
+                    visible: root.showKeybindings && row.keybinding.length > 0
+                    color: row.hasCursor ? root.selectedText : root.foreground
+                    opacity: row.hasCursor ? 0.75 : 0.52
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.bodySmall
+                  }
                 }
 
                 Text {
                   width: parent.width
                   text: row.detail
                   visible: (root.filterText || row.kind === "dmenu") && row.detail.length > 0
-                  color: root.foreground
-                  opacity: 0.52
+                  color: row.hasCursor ? root.selectedText : root.foreground
+                  opacity: row.hasCursor ? 0.75 : 0.52
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
                   elide: Text.ElideRight

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -36,6 +36,7 @@ Item {
   }
 
   function refresh() {
+    root.showKeybindings = root.defaultShowKeybindings
     if (root.keybindingsLoaded) root.loadKeybindings()
     defaultMenuFile.reload()
     userMenuFile.reload()
@@ -78,7 +79,8 @@ Item {
   property var keybindings: []
   property bool keybindingsLoaded: false
   readonly property bool defaultShowKeybindings: Boolean(root.shell && root.shell.shellConfig && root.shell.shellConfig.menu && root.shell.shellConfig.menu.keybindings)
-  property bool showKeybindings: false
+  property bool showKeybindings: defaultShowKeybindings
+  onDefaultShowKeybindingsChanged: showKeybindings = defaultShowKeybindings
 
   function applyKeybindings() {
     MenuModel.applyKeybindings(root.items, root.itemOrder, root.keybindings)
@@ -100,9 +102,7 @@ Item {
     if (!opened) {
       deleteConfirmOpen = false
       deleteTarget = null
-      showKeybindings = false
     } else {
-      showKeybindings = root.defaultShowKeybindings
       if (root.showKeybindings && !root.keybindingsLoaded) {
         root.loadKeybindings()
       }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -37,6 +37,8 @@ function normalizeItem(id, raw) {
     checked: value.checked || "",
     disabled: value.disabled || ""
   }
+  if (value.keybinding) item.keybinding = value.keybinding
+  return item
 }
 
 function parseMenuJsonc(raw) {
@@ -296,12 +298,106 @@ function leafIdFor(id) {
   return parts.length > 0 ? parts[parts.length - 1] : id
 }
 
+function parseKeybindingRecords(raw) {
+  var lines = String(raw || "").split("\n")
+  var bindings = []
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim()
+    if (!line) continue
+    var parts = line.split("\t")
+    var left = parts[0] || ""
+    var dispatcher = parts[1] || ""
+    var arg = parts.slice(2).join("\t") || ""
+    var arrowIdx = left.indexOf("→")
+    if (arrowIdx < 0) continue
+    var combo = left.substring(0, arrowIdx).trim()
+    var desc = left.substring(arrowIdx + 1).trim()
+    bindings.push({
+      combo: combo,
+      desc: desc,
+      dispatcher: dispatcher,
+      arg: arg
+    })
+  }
+  return bindings
+}
+
+function findKeybinding(bindings, entry) {
+  if (!bindings || !Array.isArray(bindings) || bindings.length === 0 || !entry) return ""
+
+  var action = String(entry.action || "").trim()
+  var id = String(entry.id || "").trim()
+  var label = String(entry.label || "").trim().toLowerCase()
+  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+  var kind = entry.kind || "menu"
+
+  // 1. Direct Action Match
+  if (action) {
+    for (var i = 0; i < bindings.length; i++) {
+      var bArg = String(bindings[i].arg || "").trim()
+      if (!bArg) continue
+      if (bArg === action) return bindings[i].combo
+      if (action.indexOf(bArg + " ") === 0 || bArg.indexOf(action + " ") === 0) return bindings[i].combo
+    }
+  }
+
+  // 2. Menu Route / Alias / Toggle Match
+  var routeCandidates = [id].concat(aliases)
+  for (var j = 0; j < bindings.length; j++) {
+    var bArg2 = String(bindings[j].arg || "").trim()
+    if (!bArg2) continue
+    var prefixes = ["omarchy-menu toggle ", "omarchy-menu summon "]
+    for (var p = 0; p < prefixes.length; p++) {
+      var prefix = prefixes[p]
+      if (bArg2.indexOf(prefix) === 0) {
+        var route = bArg2.substring(prefix.length).trim()
+        if (route) {
+          for (var r = 0; r < routeCandidates.length; r++) {
+            if (routeCandidates[r] === route) return bindings[j].combo
+          }
+        }
+      }
+    }
+  }
+
+  // 3. App Match (for desktop apps / AppLibrary rows)
+  if (kind === "app") {
+    var appId = String(entry.appId || "").toLowerCase()
+    for (var k = 0; k < bindings.length; k++) {
+      var bDesc = String(bindings[k].desc || "").toLowerCase()
+      var bArgApp = String(bindings[k].arg || "").toLowerCase()
+      if (bDesc && (bDesc === label || label.indexOf(bDesc) >= 0 || bDesc.indexOf(label) >= 0)) {
+        return bindings[k].combo
+      }
+      if (appId && bArgApp && bArgApp.indexOf(appId) >= 0) {
+        return bindings[k].combo
+      }
+    }
+  }
+
+  return ""
+}
+
+function applyKeybindings(items, itemOrder, bindings) {
+  if (!items || !itemOrder || !bindings) return items
+  for (var i = 0; i < itemOrder.length; i++) {
+    var id = itemOrder[i]
+    var entry = items[id]
+    if (entry) {
+      entry.keybinding = findKeybinding(bindings, entry)
+    }
+  }
+  return items
+}
+
 function nameSearchText(entry) {
   if (!entry) return ""
   var aliases = []
   var values = Array.isArray(entry.aliases) ? entry.aliases : []
   for (var i = 0; i < values.length; i++) aliases.push(searchableToken(values[i]))
-  return [entry.label, searchableToken(leafIdFor(entry.id)), aliases.join(" ")].join(" ").toLowerCase()
+  var parts = [entry.label, searchableToken(leafIdFor(entry.id)), aliases.join(" ")]
+  if (entry.keybinding) parts.push(searchableToken(entry.keybinding))
+  return parts.join(" ").toLowerCase()
 }
 
 function termInSearchWords(term, text) {
@@ -329,8 +425,9 @@ function matchesQuery(entry, query, visible) {
   var terms = String(query || "").toLowerCase().trim().split(/\s+/)
 
   for (var i = 0; i < terms.length; i++) {
-    if (!terms[i]) continue
-    if (nameText.indexOf(terms[i]) >= 0) continue
+    var term = terms[i]
+    if (!term) continue
+    if (nameText.indexOf(term) >= 0) continue
     if (termInSearchWords(terms[i], descriptionText)) continue
     return false
   }
@@ -375,6 +472,7 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
     label: labelFor(entry, checkedResults, disabledResults),
     target: target,
     detail: detail || "",
+    keybinding: entry.keybinding || "",
     path: pathFor(items, entry.id),
     childCount: (entry.kind === "menu" || entry.kind === "link") ? childCount(items, itemOrder, target) : 0,
     action: entry.action || "",
@@ -519,6 +617,9 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    parseKeybindingRecords: parseKeybindingRecords,
+    findKeybinding: findKeybinding,
+    applyKeybindings: applyKeybindings
   }
 }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -117,6 +117,7 @@ assertDeepEqual(
     label: 'Theme picker',
     target: 'style.theme',
     detail: 'Style',
+    keybinding: '',
     path: 'Style › Theme picker',
     childCount: 0,
     action: 'custom-theme',
@@ -126,6 +127,31 @@ assertDeepEqual(
   },
   'menu builds display rows'
 )
+
+const sampleRecords = [
+  "SUPER + K                           → Keybindings\texec\tomarchy-menu-keybindings",
+  "SUPER + ESCAPE                      → System menu\texec\tomarchy-menu toggle system",
+  "SUPER CTRL + L                      → Lock screen\texec\tomarchy-system-lock",
+  "SUPER + RETURN                      → Terminal\texec\tomarchy-launch-terminal",
+  "SUPER CTRL + R                      → Set reminder\texec\tomarchy-menu toggle reminder-set"
+].join("\n")
+
+const parsedBindings = menu.parseKeybindingRecords(sampleRecords)
+assert(parsedBindings.length === 5, 'menu parses keybinding records')
+assert(parsedBindings[0].combo === 'SUPER + K' && parsedBindings[0].desc === 'Keybindings', 'menu extracts combo and description')
+assert(menu.findKeybinding(parsedBindings, { id: 'system.lock', action: 'omarchy-system-lock' }) === 'SUPER CTRL + L', 'menu matches direct action keybinding')
+assert(menu.findKeybinding(parsedBindings, { id: 'system', kind: 'menu' }) === 'SUPER + ESCAPE', 'menu matches route keybinding')
+assert(menu.findKeybinding(parsedBindings, { id: 'trigger.reminder.set', kind: 'action', action: 'omarchy-reminder -i', aliases: ['reminder-set'] }) === 'SUPER CTRL + R', 'menu matches action alias route keybinding')
+assert(menu.findKeybinding(parsedBindings, { id: 'apps.terminal', kind: 'app', label: 'Terminal' }) === 'SUPER + RETURN', 'menu matches app keybinding')
+assert(menu.findKeybinding(parsedBindings, { id: 'unknown', action: 'something-else' }) === '', 'menu returns empty string when no binding matches')
+
+const testItems = {
+  'system.lock': { id: 'system.lock', action: 'omarchy-system-lock' },
+  'apps.term': { id: 'apps.term', kind: 'app', label: 'Terminal' }
+}
+menu.applyKeybindings(testItems, ['system.lock', 'apps.term'], parsedBindings)
+assert(testItems['system.lock'].keybinding === 'SUPER CTRL + L', 'applyKeybindings attaches keybinding to items')
+assert(testItems['apps.term'].keybinding === 'SUPER + RETURN', 'applyKeybindings attaches keybinding to app items')
 
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))


### PR DESCRIPTION
The menu is the natural fallback when you don't remember a shortcut, making it the best place to learn them. This PR lets you peek at keybindings alongside menu entries so you can build muscle memory as you go.

This leverages the keybinding records already parsed by `omarchy-menu-keybindings`.

### How It Works
- **On-Demand Peek (`?`)**: By default, the menu maintains its standard compact width with shortcuts hidden. Tapping `?` expands the menu to the right and reveals the shortcuts right-aligned next to each entry.
- **Fixed Left Alignment**: When expanded, the card extends solely to the right, keeping all existing icons and titles in place without shifting on screen.
- **Sticky State**: The toggle is sticky across menu summons during your active session.
- **Configurable Default**: Users who prefer having keybindings visible by default can set `"menu": { "keybindings": true }` in `~/.config/omarchy/shell.json`.

### Matching Heuristics
It makes a best-effort attempt at matching menu entries with keybindings using 3 tiers:
1. **Direct Action Commands**: Matches exact or prefixed commands executed by Hyprland (e.g. `omarchy-system-lock` → SUPER CTRL + L, `omarchy-capture-screenshot` → PRINT, `hyprpicker -a` → SUPER + PRINT).
2. **Menu Routes & Aliases**: Matches submenus and action leaf shortcuts triggered via `omarchy-menu toggle <route>` (e.g. `Apps` → SUPER ALT + SPACE, `Reminder › Set one` via `reminder-set` alias → SUPER CTRL + R, `Theme` → SUPER SHIFT CTRL + SPACE).
3. **Desktop Applications**: Matches desktop applications provided by `AppLibrary` (e.g. `Terminal` → SUPER + RETURN, `Browser` → SUPER SHIFT + RETURN).

### Implementation & Performance
- **Lazy On-Demand Loading**: If a user never presses `?` and doesn't configure them on by default, zero subprocesses are spawned and zero parsing is performed on startup or menu open.
- **Instant In-Memory Filtering**: When requested, keybindings are loaded and mapped to items in memory, keeping live search filtering instantaneous (<1ms).

### Search
Finally, I extended search filtering so typing shortcut names (e.g. `print`, `super`) also surfaces the corresponding actions.

Includes unit test coverage in `test/shell.d/menu-test.sh` and documentation in `docs/menu.md` and `manual/07-hotkeys.md`.


[[Toggling the hotkey visibility via "?"]](https://github.com/user-attachments/assets/ff8dd201-d5f3-46c6-8fee-f4ce46ccbf7e)

[[Searching actions by name as usual]](https://github.com/user-attachments/assets/6ca58228-69e3-4c37-bdd8-c942efdea761)

[[Searching by keybinding tokens]](https://github.com/user-attachments/assets/76ea2ec7-ca80-42a0-8fc0-8c33f0724851)

