### PR TITLE
Include dual-width fonts in font picker

### DIFF
--- a/bin/omarchy-font-list
+++ b/bin/omarchy-font-list
@@ -3,4 +3,7 @@
 # omarchy:summary=List available monospace fonts
 # omarchy:examples=omarchy font list | omarchy font set "CaskaydiaMono Nerd Font"
 
-fc-list :spacing=100 -f "%{family[0]}\n" | grep -v -i -E 'emoji|signwriting|omarchy' | sort -u
+{
+  fc-list :spacing=90 -f "%{family[0]}\n"
+  fc-list :spacing=100 -f "%{family[0]}\n"
+} | grep -v -i -E 'emoji|signwriting|omarchy' | sort -u

--- a/test/shell.d/font-list-test.sh
+++ b/test/shell.d/font-list-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/fc-list-calls"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/fc-list" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$1" >>"$FC_LIST_CALL_LOG"
+
+case "$1" in
+  ":spacing=90")
+    printf '%s\n' "Dual Width" "Shared Family" "Omarchy Dual"
+    ;;
+  ":spacing=100")
+    printf '%s\n' "Mono Width" "Shared Family" "Emoji Mono"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$mock_bin/fc-list"
+
+actual=$(FC_LIST_CALL_LOG="$call_log" PATH="$mock_bin:$PATH" "$ROOT/bin/omarchy-font-list")
+expected=$'Dual Width\nMono Width\nShared Family'
+
+[[ $actual == "$expected" ]] || fail "font list includes fixed-grid font families" "expected:\n$expected\nactual:\n$actual"
+pass "font list includes fixed-grid font families"
+
+calls=$(<"$call_log")
+expected_calls=$':spacing=90\n:spacing=100'
+[[ $calls == "$expected_calls" ]] || fail "font list queries mono and dual spacing" "expected:\n$expected_calls\nactual:\n$calls"
+pass "font list queries mono and dual spacing"


### PR DESCRIPTION
## Problem

`omarchy font list` only queries Fontconfig's `FC_MONO` class (`spacing=100`). That excludes `FC_DUAL` fonts (`spacing=90`), even though they use a fixed terminal-compatible grid with one-cell and two-cell glyph widths.

As a result, installed families such as `Lekton Nerd Font` can be applied with `omarchy font set` but are missing from both `omarchy font list` and the Style → Font picker.

Fixes #7698.

## Change

- query both `FC_DUAL` and `FC_MONO` font families
- merge the results through the existing exclusion, sorting, and deduplication pipeline
- add focused coverage for discovery, filtering, ordering, and deduplication across both spacing classes

## Visual verification

Searching the font picker for the installed dual-width `Lekton Nerd Font` family:

![Before: only the FC_MONO variant is listed. After: FC_DUAL and FC_MONO variants are both listed.](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets/pr-assets/7713-font-picker-controlled.png)

Captured from the same shell instance and geometry. Only the font-list implementation changed between captures.

## Validation

- `bash test/shell.d/font-list-test.sh`
- `bash -n bin/omarchy-font-list test/shell.d/font-list-test.sh`
- `shellcheck -e SC1091 bin/omarchy-font-list test/shell.d/font-list-test.sh`
- `./test/cli`

<details>
<summary>Full shell-suite result</summary>

`./test/shell` ran the new test successfully. The aggregate remained red on five unrelated environment/runtime checks: three require a sibling `omarchy-pkgs` checkout, one migration timing case was intermittent, and the live graphical session caused duplicate Quickshell IPC-handler counts.

</details>
