### PR TITLE
Add per-channel mute toggles to the audio panel

### DIFF
--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -787,14 +787,29 @@ Panel {
 
             Item {
               width: parent.width
-              implicitHeight: Math.max(outputHeader.implicitHeight, outputPercent.implicitHeight)
+              implicitHeight: Math.max(outputHeader.implicitHeight, outputPercent.implicitHeight, outputMuteSwitch.implicitHeight)
+
+              Text {
+                id: outputMuteGlyph
+                text: root.outputMuted ? "" : "󰓃"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.title
+                // Reserve the same glyph overshoot the section headers do
+                // (PanelSectionHeader), so this glyph's painted outline lines
+                // up with the header text beside it.
+                topPadding: Math.ceil(Style.font.title * 0.15)
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+              }
 
               PanelSectionHeader {
                 id: outputHeader
                 text: "OUTPUT"
                 foreground: root.bar.foreground
                 fontFamily: root.bar.fontFamily
-                anchors.left: parent.left
+                anchors.left: outputMuteGlyph.right
+                anchors.leftMargin: Style.space(8)
                 anchors.verticalCenter: parent.verticalCenter
               }
 
@@ -805,10 +820,28 @@ Panel {
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
+                anchors.right: outputMuteSwitch.left
+                anchors.rightMargin: Style.space(8)
+                anchors.verticalCenter: parent.verticalCenter
+                opacity: root.outputMuted ? 0.5 : 1.0
+              }
+
+              // Visible output mute toggle — scoped to the output channel only,
+              // unlike the hero switch which mutes both channels at once.
+              ToggleSwitch {
+                id: outputMuteSwitch
+                checked: root.hasOutput && !root.outputMuted
+                foreground: root.bar.foreground
                 anchors.right: parent.right
                 anchors.rightMargin: Style.space(6)
                 anchors.verticalCenter: parent.verticalCenter
-                opacity: root.outputMuted ? 0.5 : 1.0
+                onToggled: root.toggleOutputMute()
+
+                PanelToolTip {
+                  visible: outputMuteSwitch.containsMouse
+                  text: root.outputMuted ? "Unmute output" : "Mute output"
+                  fontFamily: root.bar.fontFamily
+                }
               }
             }
 
@@ -873,14 +906,29 @@ Panel {
 
             Item {
               width: parent.width
-              implicitHeight: Math.max(microphoneHeader.implicitHeight, microphonePercent.implicitHeight)
+              implicitHeight: Math.max(microphoneHeader.implicitHeight, microphonePercent.implicitHeight, inputMuteSwitch.implicitHeight)
+
+              Text {
+                id: inputMuteGlyph
+                text: root.inputMuted ? "󰍭" : "󰍬"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.title
+                // Reserve the same glyph overshoot the section headers do
+                // (PanelSectionHeader), so this glyph's painted outline lines
+                // up with the header text beside it.
+                topPadding: Math.ceil(Style.font.title * 0.15)
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+              }
 
               PanelSectionHeader {
                 id: microphoneHeader
                 text: "INPUT"
                 foreground: root.bar.foreground
                 fontFamily: root.bar.fontFamily
-                anchors.left: parent.left
+                anchors.left: inputMuteGlyph.right
+                anchors.leftMargin: Style.space(8)
                 anchors.verticalCenter: parent.verticalCenter
               }
 
@@ -891,10 +939,29 @@ Panel {
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
+                anchors.right: inputMuteSwitch.left
+                anchors.rightMargin: Style.space(8)
+                anchors.verticalCenter: parent.verticalCenter
+                opacity: root.inputMuted ? 0.5 : 1.0
+              }
+
+              // Visible input mute toggle — the microphone previously had no
+              // on-screen mute control (only right-click on the slider and the
+              // 'm' key). Mirrors the hero output switch: checked = audible.
+              ToggleSwitch {
+                id: inputMuteSwitch
+                checked: root.hasInput && !root.inputMuted
+                foreground: root.bar.foreground
                 anchors.right: parent.right
                 anchors.rightMargin: Style.space(6)
                 anchors.verticalCenter: parent.verticalCenter
-                opacity: root.inputMuted ? 0.5 : 1.0
+                onToggled: root.toggleInputMute()
+
+                PanelToolTip {
+                  visible: inputMuteSwitch.containsMouse
+                  text: root.inputMuted ? "Unmute microphone" : "Mute microphone"
+                  fontFamily: root.bar.fontFamily
+                }
               }
             }
 

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -791,7 +791,7 @@ Panel {
 
               Text {
                 id: outputMuteGlyph
-                text: root.outputMuted ? "" : "󰓃"
+                text: root.hasOutput && !root.outputMuted ? "󰓃" : ""
                 color: root.bar.foreground
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.title
@@ -820,7 +820,7 @@ Panel {
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
-                anchors.right: outputMuteSwitch.left
+                anchors.right: root.hasOutput ? outputMuteSwitch.left : parent.right
                 anchors.rightMargin: Style.space(8)
                 anchors.verticalCenter: parent.verticalCenter
                 opacity: root.outputMuted ? 0.5 : 1.0
@@ -831,6 +831,7 @@ Panel {
               ToggleSwitch {
                 id: outputMuteSwitch
                 checked: root.hasOutput && !root.outputMuted
+                visible: root.hasOutput
                 foreground: root.bar.foreground
                 anchors.right: parent.right
                 anchors.rightMargin: Style.space(6)
@@ -910,7 +911,7 @@ Panel {
 
               Text {
                 id: inputMuteGlyph
-                text: root.inputMuted ? "󰍭" : "󰍬"
+                text: root.hasInput && !root.inputMuted ? "󰍬" : "󰍭"
                 color: root.bar.foreground
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.title
@@ -939,7 +940,7 @@ Panel {
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
-                anchors.right: inputMuteSwitch.left
+                anchors.right: root.hasInput ? inputMuteSwitch.left : parent.right
                 anchors.rightMargin: Style.space(8)
                 anchors.verticalCenter: parent.verticalCenter
                 opacity: root.inputMuted ? 0.5 : 1.0
@@ -951,6 +952,7 @@ Panel {
               ToggleSwitch {
                 id: inputMuteSwitch
                 checked: root.hasInput && !root.inputMuted
+                visible: root.hasInput
                 foreground: root.bar.foreground
                 anchors.right: parent.right
                 anchors.rightMargin: Style.space(6)

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -168,13 +168,8 @@ Panel {
   // "header" is a virtual section for the hero output mute toggle; it sits
   // above the output section so the speaker can be muted from the keyboard.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
-  // Only channels that actually exist get a vote. A box with no default source
-  // would otherwise report "input unmuted" forever, leaving the hero switch
-  // able to mute but never to unmute.
   readonly property bool hasOutput: !!(volumeSink && volumeSink.audio)
   readonly property bool hasInput: !!(source && source.audio)
-  readonly property bool anyAudible: (hasOutput && !outputMuted) || (hasInput && !inputMuted)
-  readonly property string toggleHint: anyAudible ? "Mute" : "Unmute"
 
   readonly property color hoverFill: bar
     ? Style.hoverFillFor(bar.foreground, Color.accent)
@@ -288,7 +283,7 @@ Panel {
 
   // Enter/Space: activate whatever the cursor is on.
   function activateCursor() {
-    if (focusSection === "header") { toggleAllMuted(); return }
+    if (focusSection === "header") { toggleOutputMute(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
       var sink = displayAudioSinks[selectedIndex]
@@ -449,15 +444,6 @@ Panel {
 
   function toggleInputMute() {
     if (source && source.audio) source.audio.muted = !source.audio.muted
-  }
-
-  // The hero switch is the whole panel's on/off, so it carries both channels
-  // at once. It reads as on while anything is still audible, which keeps
-  // muting a single channel from the row below flipping the master switch.
-  function toggleAllMuted() {
-    var mute = anyAudible
-    if (hasOutput) volumeSink.audio.muted = mute
-    if (hasInput) source.audio.muted = mute
   }
 
   function setDefaultSink(node) {
@@ -633,7 +619,7 @@ Panel {
     bar: root.bar
     text: root.outputIcon()
     onPressed: function(b) {
-      if (b === Qt.RightButton) root.toggleAllMuted()
+      if (b === Qt.RightButton) root.toggleOutputMute()
       else root.toggle()
     }
 
@@ -720,22 +706,21 @@ Panel {
               anchors.verticalCenter: parent.verticalCenter
             }
 
-            // Compact on/off switch on the trailing edge of the hero, and the
-            // header's only cursor target. Checked means something is still
-            // audible, so muting everything reads as switching audio off.
+            // Compact output switch on the trailing edge of the hero, and the
+            // header's only cursor target. Checked means output is audible.
             ToggleSwitch {
               id: powerSwitch
-              checked: root.anyAudible
+              checked: root.hasOutput && !root.outputMuted
               hasCursor: root.headerHasCursor
               foreground: root.bar.foreground
               anchors.right: parent.right
               anchors.verticalCenter: parent.verticalCenter
               onHovered: function(on) { if (on) root.setHeaderCursor() }
-              onToggled: root.toggleAllMuted()
+              onToggled: root.toggleOutputMute()
 
               PanelToolTip {
                 visible: powerSwitch.containsMouse
-                text: root.toggleHint
+                text: root.outputMuted ? "Unmute output" : "Mute output"
                 fontFamily: root.bar.fontFamily
               }
             }
@@ -826,8 +811,7 @@ Panel {
                 opacity: root.outputMuted ? 0.5 : 1.0
               }
 
-              // Visible output mute toggle — scoped to the output channel only,
-              // unlike the hero switch which mutes both channels at once.
+              // Visible output mute toggle, matching the hero switch above.
               ToggleSwitch {
                 id: outputMuteSwitch
                 checked: root.hasOutput && !root.outputMuted

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -5,7 +5,24 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const audio = requireFromRoot('shell/plugins/panels/audio/Model.js')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/audio/Panel.qml', 'utf8')
+
+function qmlObject(source, type, id) {
+  const startPattern = new RegExp(type + ' \\{\\s*id: ' + id + '\\b')
+  const match = startPattern.exec(source)
+  if (!match) fail(`audio panel contains ${id}`)
+
+  const start = match.index
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    if (source[i] === '}' && --depth === 0) return source.slice(start, i + 1)
+  }
+  fail(`audio panel closes ${id}`)
+}
 
 assert(audio.isPlaybackStream({ isStream: true, isSink: true }), 'audio detects sink-backed playback streams')
 assert(audio.isPlaybackStream({ isStream: true, type: 'Stream/Output/Audio' }), 'audio detects typed playback streams')
@@ -16,6 +33,20 @@ assert(audio.isAudioSource({ type: 'Audio/Source' }), 'audio detects typed sourc
 assertEqual(audio.outputVolumeName(0, false), 'Silenced', 'audio labels silent output')
 assertEqual(audio.outputVolumeName(0.9, false), 'Party mode', 'audio labels loud output')
 assertEqual(audio.outputVolumeName(0.5, true), 'Muted', 'audio labels muted output')
+
+assert(/if \(focusSection === "header"\) \{ toggleOutputMute\(\); return \}/.test(panelSource), 'audio hero keyboard activation toggles output')
+assert(/onPressed: function\(b\) \{\s*if \(b === Qt\.RightButton\) root\.toggleOutputMute\(\)/.test(panelSource), 'audio bar right-click toggles output')
+const heroSwitch = qmlObject(panelSource, 'ToggleSwitch', 'powerSwitch')
+const heroCheckedExpression = heroSwitch.match(/checked: (.+)/)[1]
+const heroChecked = new Function('root', `return ${heroCheckedExpression}`)
+assert(!heroChecked({ hasOutput: true, outputMuted: true, inputMuted: false }), 'audio hero stays off when output is muted and input is audible')
+assert(heroChecked({ hasOutput: true, outputMuted: false, inputMuted: true }), 'audio hero turns on when output is audible')
+assert(!heroChecked({ hasOutput: false, outputMuted: false, inputMuted: false }), 'audio hero stays off without an output')
+assert(/onToggled: root\.toggleOutputMute\(\)/.test(heroSwitch), 'audio hero switch controls output')
+assert(/text: root\.outputMuted \? "Unmute output" : "Mute output"/.test(heroSwitch), 'audio hero tooltip describes output mute')
+const inputSwitch = qmlObject(panelSource, 'ToggleSwitch', 'inputMuteSwitch')
+assert(/text: root\.inputMuted \? "Unmute microphone" : "Mute microphone"/.test(inputSwitch), 'audio microphone tooltip stays shortcut-neutral')
+assert(!/toggleAllMuted|anyAudible|toggleHint/.test(panelSource), 'audio panel removes global mute state')
 
 assertDeepEqual(audio.parseSinkAvailability('alsa_output\t1\nhdmi_output\t0\n'), { alsa_output: true, hdmi_output: false }, 'audio parses sink availability')
 assertEqual(audio.friendlyDeviceLabel('Built-in Audio Speakers Output'), 'Speakers', 'audio cleans device labels')


### PR DESCRIPTION
The audio panel now has separate output and microphone mute toggles, with state glyphs and tooltips. The speaker hero, header keyboard activation, and bar-icon right-click control output only: muting output and then unmuting the microphone leaves the hero off.

## Controls and state

- The hero and OUTPUT toggle both track output mute state and call `toggleOutputMute()`.
- The INPUT toggle independently controls the microphone through `toggleInputMute()`.
- Output and input glyphs reflect whether their channel exists and is unmuted. Section toggles are hidden when their channel is absent.
- Hero and output tooltips say “Mute output” / “Unmute output.” The microphone tooltip says “Mute microphone” / “Unmute microphone,” without a hard-coded shortcut because bindings can vary.
- Section keyboard `m` and slider right-click behavior remain unchanged.

## Validation

- Focused audio regression test passes, including evaluation of the hero's actual QML checked expression for mixed mute states and checks of action/tooltip wiring.
- Standards and spec code reviews found no implementation issues.
- The full shell suite did not complete: packaging checks require an unavailable `omarchy-pkgs` checkout, and the run stalled in `update-lock-test.sh`.
