### PR TITLE
Gate calculator keybindings with preinstalls

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -11,6 +11,8 @@ if o.preinstalled_bindings_enabled() then
   -- Bindings for preinstalled Omarchy applications, TUIs, and web apps.
   o.bind("SUPER + ALT + RETURN", "Tmux", { omarchy = "terminal-tmux" })
   o.bind("SUPER + CTRL + RETURN", "Herdr", { omarchy = "terminal-herdr" })
+  o.bind("SUPER + CTRL + Q", "Calculator", "omacalc")
+  o.bind("XF86Calculator", "Calculator", "omacalc")
   o.bind("SUPER + SHIFT + M", "Music", { omarchy = "spotify" })
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "lazydocker" })

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -10,9 +10,6 @@ o.bind("XF86PowerOff", "Power menu", "omarchy-menu toggle system", { locked = tr
 o.bind("SUPER + K", "Keybindings", "omarchy-menu-keybindings")
 o.bind("SUPER + ALT + K", "Tmux keybindings", "omarchy-menu-tmux-keybindings")
 o.bind("SUPER + CTRL + K", "Herdr keybindings", "omarchy-menu-herdr-keybindings")
-o.bind("SUPER + CTRL + Q", "Calculator", "omacalc")
-o.bind("XF86Calculator", "Calculator", "omacalc")
-
 o.bind_toggle("SUPER + SHIFT + SPACE", "Toggle top bar", "bar")
 o.bind("SUPER + CTRL + SPACE", "Background switcher", "omarchy-menu toggle background")
 o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme")

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -103,6 +103,8 @@ mkdir -p "$fresh_home"
 fresh_output=$(run_application_bindings "$fresh_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default application bindings include essentials"
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
+grep -Fq $'SUPER + CTRL + Q	Calculator' <<<"$fresh_output" || fail "default application bindings include the preinstalled calculator"
+grep -Fq $'XF86Calculator	Calculator' <<<"$fresh_output" || fail "default application bindings include the calculator hardware key"
 pass "default application bindings load from package defaults"
 
 grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
@@ -122,19 +124,25 @@ pass "universal clipboard shortcuts avoid virtual keyboard modifier merging"
 removed_home="$tmpdir/removed-home"
 mkdir -p "$removed_home/.local/state/omarchy"
 touch "$removed_home/.local/state/omarchy/preinstalls-removed"
-removed_output=$(run_application_bindings "$removed_home")
+removed_output=$(run_omarchy_bindings "$removed_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$removed_output" || fail "preinstall removal keeps essential bindings"
 if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$removed_output"; then
   fail "preinstall removal skips preinstalled web app bindings"
+fi
+if grep -Fq $'	Calculator' <<<"$removed_output"; then
+  fail "preinstall removal skips calculator bindings"
 fi
 pass "preinstall removal flag skips optional application bindings"
 
 variable_home="$tmpdir/variable-home"
 mkdir -p "$variable_home"
-variable_output=$(run_application_bindings "$variable_home" 'omarchy_preinstalled_bindings = false')
+variable_output=$(run_omarchy_bindings "$variable_home" 'omarchy_preinstalled_bindings = false')
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$variable_output" || fail "preinstalled binding variable keeps essential bindings"
 if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$variable_output"; then
   fail "preinstalled binding variable skips optional application bindings"
+fi
+if grep -Fq $'	Calculator' <<<"$variable_output"; then
+  fail "preinstalled binding variable skips calculator bindings"
 fi
 pass "preinstalled binding variable skips optional application bindings"
 


### PR DESCRIPTION
## Problem

`omarchy-remove-preinstalls` removes `omacalc`, records the `preinstalls-removed` state, and reloads Hyprland. The Calculator bindings currently live in the unconditional utility binding set, so both shortcuts remain registered and point to a command that no longer exists:

- `SUPER + CTRL + Q`
- `XF86Calculator`

The same stale bindings remain when users explicitly set `omarchy_preinstalled_bindings = false`.

Fixes #7565.

## Change

Move the existing Calculator declarations into the established `o.preinstalled_bindings_enabled()` block in `applications.lua`. Their keys and command are unchanged; they now follow the same lifecycle as the other preinstalled applications and TUIs.

## Behavioral verification

This changes whether global bindings are registered rather than a rendered surface, so a screenshot would not add meaningful evidence. The Lua binding harness evaluates the real default modules under isolated homes and verifies:

| State | Calculator bindings | Essential bindings |
| --- | --- | --- |
| Default install | Both registered | Preserved |
| `preinstalls-removed` marker | Not registered | Preserved |
| `omarchy_preinstalled_bindings = false` | Not registered | Preserved |

The conflict test also confirms the relocation introduces no duplicate chord.

## Validation

- `bash test/shell.d/hyprland-default-config-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- `luac -p default/hypr/bindings/applications.lua default/hypr/bindings/utilities.lua`
- `shellcheck -e SC1091,SC2016 test/shell.d/hyprland-default-config-test.sh`
- `./test/cli`