### PR TITLE
Fix which system-sleep hooks omarchy-settings ships

### DIFF
--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -125,7 +125,8 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
   ├─ systemd/system-sleep/unmount-fuse                  /usr/lib/systemd/system-sleep/
-  │                                                       (keyboard-backlight and force-igpu only ship under /usr/share/omarchy/default/; omarchy-hibernation-setup and omarchy-toggle-hybrid-gpu install them on demand)
+  │                                                       (keyboard-backlight and force-igpu only ship under /usr/share/omarchy/default/;
+  │                                                        omarchy-hibernation-setup and omarchy-toggle-hybrid-gpu install them on demand)
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/
   ├─ fonts/omarchy/omarchy.ttf                          /usr/share/fonts/omarchy/
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -124,8 +124,8 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ applications/mimeapps.list                         /usr/share/applications/mimeapps.list
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
-  ├─ systemd/system-sleep/{force-igpu,
-  │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
+  ├─ systemd/system-sleep/unmount-fuse                  /usr/lib/systemd/system-sleep/
+  │                                                       (keyboard-backlight and force-igpu only ship under /usr/share/omarchy/default/; omarchy-hibernation-setup and omarchy-toggle-hybrid-gpu install them on demand)
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/
   ├─ fonts/omarchy/omarchy.ttf                          /usr/share/fonts/omarchy/
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/


### PR DESCRIPTION
`docs/file-layout.md` lists `default/systemd/system-sleep/{force-igpu,keyboard-backlight,unmount-fuse}` as shipped by `omarchy-settings` into `/usr/lib/systemd/system-sleep/`. Only `unmount-fuse` is. The line grew the other two names in f4189398; before that it listed `unmount-fuse` alone, which was and still is correct.

Checked against the built packages on `pkgs.omarchy.org/edge/x86_64` (`omarchy-settings-4.0.0-1` and `omarchy-settings-dev-4.0.0.r1791.ged7bae4-1`): `/usr/lib/systemd/system-sleep/` contains `unmount-fuse` only; `keyboard-backlight` and `force-igpu` appear solely as 644 sources under `/usr/share/omarchy/default/systemd/system-sleep/`. `test/shell.d/unowned-system-paths-test.sh` describes the same split (hardware-conditional hooks installed only where they apply), and `bin/omarchy-hibernation-setup` / `bin/omarchy-toggle-hybrid-gpu` are the installers.

The wrong entry has already misled a review: Codex flagged #7699 on the premise that the package activates `force-igpu` on Hybrid-mode machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdrqXrL4pbdS9CjdHxfCYF
