### PR TITLE
Codex collector: plan label and model-scoped limit windows

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -495,7 +495,7 @@ def rpc_request(proc, request_id, method, params=None, timeout=8):
   raise TimeoutError(method)
 
 
-def limit_window(window):
+def limit_window(window, title=None):
   if not isinstance(window, dict):
     return None
   used = window.get("usedPercent")
@@ -504,18 +504,47 @@ def limit_window(window):
   mins = number(window.get("windowDurationMins"))
   if mins == 10080:
     label = "Weekly (7-day)"
+  elif mins == 300:
+    label = "Session (5-hour)"
   elif mins and mins % 60 == 0:
-    label = f"{mins // 60}h window"
+    label = f"Session ({mins // 60}-hour)"
   elif mins:
     label = f"{mins}m window"
   else:
     label = "Limit"
   reset = window.get("resetsAt")
-  return {
+  entry = {
     "label": label,
     "percent": float(used) / 100.0,
     "resetsAt": datetime.fromtimestamp(number(reset), timezone.utc).isoformat() if reset else "",
   }
+  if title:
+    # A model-scoped window, like Claude's "Fable Weekly": the panel shows
+    # the title verbatim instead of parsing a window out of the label.
+    short = "Weekly" if mins == 10080 else ("Session" if mins else "Limit")
+    entry["title"] = f"{title} {short}"
+    entry["label"] = f"{title} {label}"
+  return entry
+
+
+PLAN_LABELS = {
+  "free": "Free",
+  "go": "Go",
+  "plus": "Plus",
+  "pro": "Pro",
+  "prolite": "Pro Lite",
+  "team": "Team",
+  "business": "Business",
+  "edu": "Edu",
+  "enterprise": "Enterprise",
+}
+
+
+def plan_label(plan):
+  raw = str(plan or "").strip()
+  if not raw:
+    return ""
+  return PLAN_LABELS.get(raw.lower(), raw.replace("_", " ").title())
 
 
 def fetch_codex_rpc():
@@ -550,12 +579,28 @@ def fetch_codex_rpc():
     account = (account_msg.get("result") or {}).get("account") or {}
     limits = (limits_msg.get("result") or {}).get("rateLimits") or {}
     plan = limits.get("planType") or account.get("planType") or account.get("type") or ""
-    result["tierLabel"] = str(plan) if plan else ""
+    result["tierLabel"] = plan_label(plan)
 
     for window in (limits.get("primary"), limits.get("secondary")):
       entry = limit_window(window)
       if entry:
         result["limits"].append(entry)
+
+    # Model-scoped allowances (e.g. "GPT-5.3-Codex-Spark") ride alongside the
+    # account-wide ones, the way the Claude collector reports "Fable Weekly".
+    by_id = (limits_msg.get("result") or {}).get("rateLimitsByLimitId") or {}
+    main_id = limits.get("limitId")
+    for limit_id, scoped in by_id.items():
+      if not isinstance(scoped, dict) or limit_id == main_id:
+        continue
+      title = str(scoped.get("limitName") or limit_id)
+      for window in (scoped.get("primary"), scoped.get("secondary")):
+        entry = limit_window(window, title=title)
+        if entry:
+          result["limits"].append(entry)
+
+    if limits.get("spendControlReached"):
+      result["usageStatusText"] = "Codex spend control reached"
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
     result["authHelpText"] = str(exc)

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,8 +13,10 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
-if [[ -n ${CODEX_ARGS_FILE:-} ]]; then
-  printf '%s\0' "$@" >"$CODEX_ARGS_FILE"
+# Fail if the collector regresses to `-a untrusted` (Codex 0.149 / #7648).
+if [[ $1 != "-s" || $2 != "read-only" || $3 != "-a" || $4 != "on-request" || ${5:-} != "app-server" ]]; then
+  echo "unexpected codex invocation: $*" >&2
+  exit 1
 fi
 
 while read -r request; do
@@ -29,7 +31,7 @@ while read -r request; do
       jq -cn --argjson id "$id" '{id: $id, result: {account: {}}}'
       ;;
     account/rateLimits/read)
-      jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {}}}'
+      jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {limitId: "codex", planType: "prolite", primary: {usedPercent: 6, windowDurationMins: 10080, resetsAt: 1787887121}, secondary: null}, rateLimitsByLimitId: {codex: {limitId: "codex", planType: "prolite", primary: {usedPercent: 6, windowDurationMins: 10080, resetsAt: 1787887121}}, codex_bengalfox: {limitId: "codex_bengalfox", limitName: "GPT-5.3-Codex-Spark", primary: {usedPercent: 0, windowDurationMins: 300, resetsAt: 1787379264}, secondary: {usedPercent: 12, windowDurationMins: 10080, resetsAt: 1787966064}}}}}'
       ;;
   esac
 done
@@ -44,17 +46,16 @@ cat >"$session" <<EOF
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}}}}
 EOF
 
-result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" CODEX_ARGS_FILE="$TEST_HOME/codex-args" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
 
-# NUL-separated, so the assertion sees argument boundaries: a single "-a on-request"
-# would flatten to the same text as two arguments but is not a policy codex accepts.
-expected_args=(-s read-only -a on-request app-server)
-mapfile -d '' -t codex_args <"$TEST_HOME/codex-args"
+[[ $(jq -r '.tierLabel' <<<"$result") == "Pro Lite" ]] ||
+  fail "Codex collector labels the plan" "$result"
+pass "Codex collector labels the plan"
 
-[[ ${codex_args[*]@Q} == "${expected_args[*]@Q}" ]] ||
-  fail "Codex collector uses the supported approval policy" "${codex_args[*]@Q}"
-pass "Codex collector uses the supported approval policy"
+[[ $(jq -c '[.limits[] | [.label, (.percent * 100 | round), .title // ""]]' <<<"$result") == '[["Weekly (7-day)",6,""],["GPT-5.3-Codex-Spark Session (5-hour)",0,"GPT-5.3-Codex-Spark Session"],["GPT-5.3-Codex-Spark Weekly (7-day)",12,"GPT-5.3-Codex-Spark Weekly"]]' ]] ||
+  fail "Codex collector reports account and model-scoped limit windows" "$result"
+pass "Codex collector reports account and model-scoped limit windows"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"
@@ -64,9 +65,9 @@ pass "Codex collector counts each turn once"
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
 
-[[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
-  fail "Codex collector identifies itself with an empty limits list" "$result"
-pass "Codex collector identifies itself with an empty limits list"
+[[ $(jq -c '.id + "/" + (.limits|length|tostring)' <<<"$result") == '"codex/3"' ]] ||
+  fail "Codex collector identifies itself and keeps every limit window" "$result"
+pass "Codex collector identifies itself and keeps every limit window"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.


### PR DESCRIPTION
## Changes

Brings the Codex tab of the Agents panel up to parity with the Claude tab. `account/rateLimits/read` already returns more than the collector showed, so this only surfaces what Codex reports:

- `tierLabel` becomes a human plan name (`prolite` → "Pro Lite", `plus` → "Plus") instead of the raw API token, matching Claude's "Max 20x" / "Pro".
- Window labels follow the Claude collector's wording ("Session (5-hour)", "Weekly (7-day)") so the LIMITS section reads the same on both tabs.
- Model-scoped allowances under `rateLimitsByLimitId` (e.g. "GPT-5.3-Codex-Spark", each with its own 5-hour and weekly window) are emitted with a `title`, the way Claude reports "Fable Weekly", so the panel renders them as their own rows instead of dropping them.
- `spendControlReached` surfaces as the usage status text.
- Launches app-server with `-a on-request`, same as #7649 (Codex 0.149 retired `untrusted`, #7648). Happy to rebase on #7649 once it lands — this is meant to stack on it, not compete with it.

Before (Codex 0.149.0, Pro Lite): no plan, `limits: []`.
After:

```
tierLabel: "Pro Lite"
Weekly (7-day)                          6%
GPT-5.3-Codex-Spark Session (5-hour)    0%
GPT-5.3-Codex-Spark Weekly (7-day)      0%
```

## Tests

- `bash test/shell.d/agent-usage-codex-scanner-test.sh` — mock app-server now answers with a realistic `rateLimits` / `rateLimitsByLimitId` payload; asserts the plan label and every limit row.
- `./test/cli`
- live `bin/omarchy-agent-usage-codex --limits-only` against Codex CLI 0.149.0 on Omarchy 4.0.0-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDPn6hVmawjV1sSRLedsUD