### PR TITLE
Detect fingerprint readers by USB interface name

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -31,6 +31,17 @@ has_kernel_driver() {
   return 1
 }
 
+has_fingerprint_interface() {
+  local intf name
+  for intf in "$1"/*:*; do
+    [[ -r $intf/interface ]] || continue
+    name=$(<"$intf/interface")
+    name=${name,,}
+    [[ $name == *fingerprint* || $name == *biometric* ]] && return 0
+  done
+  return 1
+}
+
 for dev in "$usb_devices_path"/*; do
   # The device's own product descriptor usually names it, e.g. "Goodix
   # Fingerprint USB Device" — driver-independent and vendor-agnostic.
@@ -45,6 +56,10 @@ for dev in "$usb_devices_path"/*; do
     # three letters are little to match on, so require the prefix.
     [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* || $product == "fpc "* ]] && exit 0
   fi
+
+  # Composite devices can expose a generic product name while identifying the
+  # fingerprint reader only on one USB interface.
+  has_fingerprint_interface "$dev" && exit 0
 
   if [[ -r $dev/idVendor ]]; then
     vendor=$(<"$dev/idVendor")

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -34,6 +34,14 @@ write_usb_devices() {
   done
 }
 
+write_interface_name() {
+  local dev="$1" number="$2" name="$3"
+  local intf="$tmp_dir/devices/$dev/$dev:$number"
+
+  mkdir -p "$intf"
+  printf '%s\n' "$name" >"$intf/interface"
+}
+
 hw_fingerprint() {
   OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-fingerprint"
 }
@@ -70,6 +78,15 @@ assert_rejects "an FPC token mid-string is not detected"
 
 write_usb_devices '1234:5678:Goodix Fingerprint USB Device'
 assert_detects "a reader is detected by an existing product-name match"
+
+write_usb_devices '0a5c:5865:58200'
+write_interface_name '1-0' '1.0' 'Broadcom ControlVault 3+ SmartCard'
+write_interface_name '1-0' '1.1' 'Broadcom ControlVault 3+ w/FingerPrint'
+assert_detects "a reader named only by one composite USB interface is detected"
+
+write_usb_devices '0a5c:5865:58200'
+write_interface_name '1-0' '1.0' 'Broadcom ControlVault 3+ SmartCard'
+assert_rejects "a generic USB interface is not detected"
 
 write_usb_devices '27c6:1234'
 assert_detects "a reader is detected by an existing vendor match"


### PR DESCRIPTION
## Problem

Some composite USB fingerprint readers expose only a generic device-level product name. The useful description appears on one of the device's USB interfaces instead.

For example, the Broadcom ControlVault 3+ (`0a5c:5865`) reports `58200` as its product while an interface reports `Broadcom ControlVault 3+ w/FingerPrint`. `omarchy-hw-fingerprint` currently reads only the product descriptor and therefore reports that no reader is present.

Fixes #7424.

## Change

Inspect each device's immediate USB interface descriptors for the same explicit `fingerprint`/`biometric` identity used by the existing product-name detection. Explicit interface names are trusted before the broader vendor heuristic; generic interfaces remain rejected.

## Scope

This fixes hardware detection only. Broadcom ControlVault readers may still require an out-of-tree TOD libfprint driver before enrollment can succeed, as noted in the issue. The setup flow already avoids modifying PAM unless enrollment and verification succeed.

## Regression coverage

The test fixture models a composite ControlVault device with:

- a generic `58200` product descriptor
- a SmartCard interface at `1.0`
- a fingerprint interface at `1.1`

It verifies that every interface is searched and also confirms that the generic SmartCard interface alone does not produce a false positive.

## Validation

- `bash test/shell.d/hw-fingerprint-test.sh`
- `bash test/shell.d/fingerprint-invitation-test.sh`
- `bash -n bin/omarchy-hw-fingerprint test/shell.d/hw-fingerprint-test.sh`
- `shellcheck -e SC1091 bin/omarchy-hw-fingerprint test/shell.d/hw-fingerprint-test.sh`
- `./test/cli`
- `git diff --check`