### PR TITLE
Add omarchy-hyprland-workspace-compact to collapse workspaces to the lowest numbers

### DIFF
--- a/bin/omarchy-hyprland-workspace-compact
+++ b/bin/omarchy-hyprland-workspace-compact
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# omarchy:summary=Collapse occupied workspaces down to the lowest numbers (3,4,7 -> 1,2,3).
+# omarchy:args=[--dry-run]
+
+# Hyprland can't renumber a workspace, so move every window from each occupied
+# workspace into the lowest free slot, ascending per monitor. The target is
+# always empty by construction. Special workspaces (id < 1) are left alone and
+# focus follows the active workspace to its new number.
+
+dry_run=false
+[[ ${1:-} == "-n" || ${1:-} == "--dry-run" ]] && dry_run=true
+
+hypr_dispatch() {
+  local lua="$1"
+  shift
+
+  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
+}
+
+active=$(hyprctl activeworkspace -j | jq -r '.id')
+[[ $active =~ ^-?[0-9]+$ ]] || exit 1
+clients=$(hyprctl clients -j)
+workspaces=$(hyprctl workspaces -j)
+new_active=$active
+
+while IFS= read -r monitor; do
+  target=1
+  while IFS= read -r ws; do
+    if ((ws != target)); then
+      if $dry_run; then
+        echo "workspace $ws -> $target ($monitor)"
+      else
+        while IFS= read -r addr; do
+          hypr_dispatch "hl.dsp.window.move({ window = \"address:$addr\", workspace = \"$target\", follow = false })" \
+            movetoworkspacesilent "$target,address:$addr"
+        done < <(jq -r --argjson w "$ws" '.[] | select(.workspace.id == $w) | .address' <<<"$clients")
+      fi
+      ((ws == active)) && new_active=$target
+    fi
+    target=$((target + 1))
+  done < <(jq -r --arg m "$monitor" '.[] | select(.monitor == $m and .id > 0 and .windows > 0 and ((.name // "") | test("^[0-9]+$"))) | .id' <<<"$workspaces" | sort -n)
+done < <(hyprctl monitors -j | jq -r '.[].name')
+
+if ! $dry_run && ((new_active != active)); then
+  hypr_dispatch "hl.dsp.focus({ workspace = \"$new_active\" })" workspace "$new_active"
+fi

--- a/test/shell.d/hyprland-workspace-compact-test.sh
+++ b/test/shell.d/hyprland-workspace-compact-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command jq
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_dir="$tmpdir/bin"
+log_file="$tmpdir/hyprctl.log"
+mkdir -p "$stub_dir"
+
+# Workspaces 3, 4 and 7 are occupied on one monitor; 1, 2, 5 and 6 are holes.
+cat >"$stub_dir/hyprctl" <<'EOF2'
+#!/bin/bash
+
+case "$1" in
+  activeworkspace) printf '{"id":7}\n' ;;
+  monitors) printf '[{"name":"eDP-1"}]\n' ;;
+  workspaces)
+    printf '[{"id":7,"name":"7","monitor":"eDP-1","windows":1},{"id":3,"name":"3","monitor":"eDP-1","windows":2},{"id":4,"name":"4","monitor":"eDP-1","windows":1},{"id":-99,"monitor":"eDP-1","windows":1},{"id":9,"name":"mail","monitor":"eDP-1","windows":1}]\n'
+    ;;
+  clients)
+    printf '[{"address":"0xa","workspace":{"id":3}},{"address":"0xb","workspace":{"id":3}},{"address":"0xc","workspace":{"id":4}},{"address":"0xd","workspace":{"id":7}},{"address":"0xe","workspace":{"id":-99}},{"address":"0xf","workspace":{"id":9}}]\n'
+    ;;
+  dispatch) printf '%s\n' "$*" >>"$HYPRCTL_LOG" ;;
+esac
+EOF2
+chmod +x "$stub_dir/hyprctl"
+
+HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" "$ROOT/bin/omarchy-hyprland-workspace-compact"
+
+grep -Fx 'dispatch hl.dsp.window.move({ window = "address:0xa", workspace = "1", follow = false })' "$log_file" >/dev/null ||
+  fail "workspace compact moves the first occupied workspace to 1"
+grep -Fx 'dispatch hl.dsp.window.move({ window = "address:0xb", workspace = "1", follow = false })' "$log_file" >/dev/null ||
+  fail "workspace compact moves every window on a workspace"
+grep -Fx 'dispatch hl.dsp.window.move({ window = "address:0xc", workspace = "2", follow = false })' "$log_file" >/dev/null ||
+  fail "workspace compact fills the next free slot"
+grep -Fx 'dispatch hl.dsp.window.move({ window = "address:0xd", workspace = "3", follow = false })' "$log_file" >/dev/null ||
+  fail "workspace compact collapses across gaps"
+grep -F '0xe' "$log_file" >/dev/null &&
+  fail "workspace compact leaves special workspaces alone"
+grep -F '0xf' "$log_file" >/dev/null &&
+  fail "workspace compact leaves named workspaces alone"
+grep -Fx 'dispatch hl.dsp.focus({ workspace = "3" })' "$log_file" >/dev/null ||
+  fail "workspace compact refocuses the active workspace at its new number"
+pass "workspace compact collapses occupied workspaces to the lowest numbers"
+
+: >"$log_file"
+output=$(HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" "$ROOT/bin/omarchy-hyprland-workspace-compact" --dry-run)
+[[ -s $log_file ]] && fail "workspace compact dry run does not dispatch"
+grep -Fx 'workspace 7 -> 3 (eDP-1)' <<<"$output" >/dev/null || fail "workspace compact dry run prints the plan"
+pass "workspace compact dry run only prints the plan"


### PR DESCRIPTION
## What

A small `bin/` helper in the `omarchy-hyprland-*` family: **collapse occupied workspaces down to the lowest numbers.**

Open windows on 1–11, close a few, and you're left with 3, 4, 5, 7, 8, 9, 10, 11 occupied and holes at 1, 2, 6. Hyprland has no "renumber workspace" dispatcher, so this moves every window from each occupied workspace into the lowest free slot (ascending, per monitor — the target is always empty by construction), skips special workspaces, and refocuses the active workspace at its new number.

```
$ omarchy-hyprland-workspace-compact --dry-run
workspace 3 -> 1 (eDP-1)
workspace 4 -> 2 (eDP-1)
workspace 7 -> 3 (eDP-1)
$ omarchy-hyprland-workspace-compact
```

## How

- Same shape as `omarchy-hyprland-window-pop`: `hypr_dispatch` tries the Lua dispatcher (`hl.dsp.window.move({ follow = false })`, `hl.dsp.focus`) and falls back to legacy syntax.
- `omarchy:summary=` / `omarchy:args=` headers for the menu.
- Idempotent; `--dry-run` prints the plan and dispatches nothing.
- Test: `test/shell.d/hyprland-workspace-compact-test.sh` (stub `hyprctl`, checks moves, gap collapsing, special-workspace skip, refocus, dry run).

## Keybinding

Deliberately **no default binding** added — your call. `SUPER + MINUS` is unbound in the current defaults if you want one:

```lua
o.bind("SUPER + MINUS", "Compact workspaces", "omarchy-hyprland-workspace-compact")
```

Tested live on Omarchy 4.x / Hyprland 0.56.2 (single monitor; multi-monitor path is covered by per-monitor iteration but not exercised on real hardware).