### PR TITLE
Show Windows PCs and admin shares in Files

### DIFF
--- a/bin/omarchy-setup-windows-share
+++ b/bin/omarchy-setup-windows-share
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# omarchy:summary=Sign in to a Windows PC with a username and password
+# omarchy:args=[host]
+
+set -euo pipefail
+
+discover_hosts() {
+  timeout 8 gio list network:// 2>/dev/null | awk '!/^urn:uuid/ && NF { print $1 }' | sort -u
+}
+
+domain_for() {
+  local host=$1
+  local name
+
+  if [[ $host =~ ^[0-9.]+$ ]]; then
+    name=$(nmblookup -A "$host" 2>/dev/null | awk '/<00> -/ && !/<GROUP>/ { print $1; exit }')
+    if [[ -n $name ]]; then
+      printf '%s\n' "$name"
+      return
+    fi
+  fi
+
+  printf '%s\n' "$host"
+}
+
+pick_host() {
+  local host=${1:-${OMARCHY_SMB_HOST:-}}
+  local -a hosts=()
+
+  if [[ -n $host ]]; then
+    printf '%s\n' "$host"
+    return
+  fi
+
+  mapfile -t hosts < <(discover_hosts)
+
+  if ((${#hosts[@]} == 0)); then
+    gum input --placeholder "Windows PC name or IP"
+    return
+  fi
+
+  if ((${#hosts[@]} == 1)); then
+    printf '%s\n' "${hosts[0]}"
+    return
+  fi
+
+  printf '%s\n' "${hosts[@]}" | gum choose --header "Windows PC"
+}
+
+prompt_user() {
+  if [[ -n ${OMARCHY_SMB_USER:-} ]]; then
+    printf '%s\n' "$OMARCHY_SMB_USER"
+    return
+  fi
+
+  gum input --placeholder "Windows username"
+}
+
+prompt_password() {
+  if [[ -n ${OMARCHY_SMB_PASSWORD:-} ]]; then
+    printf '%s\n' "$OMARCHY_SMB_PASSWORD"
+    return
+  fi
+
+  gum input --password --placeholder "Password"
+}
+
+list_disk_shares() {
+  local host=$1 user=$2 pass=$3 domain=$4
+
+  smbclient -L "//$host" -U "$user%$pass" -W "$domain" 2>/dev/null |
+    awk '/Disk/ { print $1 }' |
+    grep -v '^IPC$' || true
+}
+
+mount_share() {
+  local host=$1 user=$2 pass=$3 domain=$4 share=$5
+
+  printf '%s\n%s\n%s\n' "$user" "$domain" "$pass" |
+    timeout 20 gio mount "smb://$host/$share"
+}
+
+host=$(pick_host "${1:-}")
+[[ -n $host ]] || exit 1
+
+user=$(prompt_user)
+pass=$(prompt_password)
+[[ -n $user && -n $pass ]] || exit 1
+
+domain=$(domain_for "$host")
+
+if ! smbclient -L "//$host" -U "$user%$pass" -W "$domain" >/dev/null 2>&1; then
+  omarchy-notification-send -u critical -g  "Could not sign in to $host" "Use a local admin username and password on that Windows PC."
+  exit 1
+fi
+
+mounted=
+for share in 'C$' $(list_disk_shares "$host" "$user" "$pass" "$domain"); do
+  [[ -n $share ]] || continue
+  if mount_share "$host" "$user" "$pass" "$domain" "$share"; then
+    mounted=$share
+    break
+  fi
+done
+
+if [[ -z $mounted ]]; then
+  omarchy-notification-send -u critical -g  "Signed in to $host" "No share could be opened."
+  exit 1
+fi
+
+gio open "smb://$host/$mounted"
+omarchy-notification-send -g  "Connected to $host"

--- a/bin/omarchy-setup-windows-share
+++ b/bin/omarchy-setup-windows-share
@@ -66,19 +66,16 @@ prompt_password() {
   gum input --password --placeholder "Password"
 }
 
-list_disk_shares() {
-  local host=$1 user=$2 pass=$3 domain=$4
-
-  smbclient -L "//$host" -U "$user%$pass" -W "$domain" 2>/dev/null |
-    awk '/Disk/ { print $1 }' |
-    grep -v '^IPC$' || true
-}
-
 mount_share() {
   local host=$1 user=$2 pass=$3 domain=$4 share=$5
+  local uri="smb://$host/"
+
+  if [[ -n $share ]]; then
+    uri="smb://$host/$share"
+  fi
 
   printf '%s\n%s\n%s\n' "$user" "$domain" "$pass" |
-    timeout 20 gio mount "smb://$host/$share"
+    timeout 20 gio mount "$uri"
 }
 
 host=$(pick_host "${1:-}")
@@ -95,19 +92,10 @@ if ! smbclient -L "//$host" -U "$user%$pass" -W "$domain" >/dev/null 2>&1; then
   exit 1
 fi
 
-mounted=
-for share in 'C$' $(list_disk_shares "$host" "$user" "$pass" "$domain"); do
-  [[ -n $share ]] || continue
-  if mount_share "$host" "$user" "$pass" "$domain" "$share"; then
-    mounted=$share
-    break
-  fi
-done
-
-if [[ -z $mounted ]]; then
-  omarchy-notification-send -u critical -g  "Signed in to $host" "No share could be opened."
+if ! mount_share "$host" "$user" "$pass" "$domain" ""; then
+  omarchy-notification-send -u critical -g  "Signed in to $host" "Could not open the share list."
   exit 1
 fi
 
-gio open "smb://$host/$mounted"
+gio open "smb://$host/"
 omarchy-notification-send -g  "Connected to $host"

--- a/bin/omarchy-toggle-windows-admin-shares
+++ b/bin/omarchy-toggle-windows-admin-shares
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# omarchy:summary=Show Windows admin shares (C$, ADMIN$) in Files
+# omarchy:args=[toggle|on|off]
+
+SCHEMA=org.gnome.nautilus.preferences
+KEY=show-hidden-files
+
+is_on() {
+  [[ $(gsettings get "$SCHEMA" "$KEY" 2>/dev/null) == "true" ]]
+}
+
+set_hidden_files() {
+  gsettings set "$SCHEMA" "$KEY" "$1"
+}
+
+ACTION=${1:-toggle}
+
+case $ACTION in
+  on)
+    set_hidden_files true
+    ;;
+  off)
+    set_hidden_files false
+    ;;
+  toggle)
+    if is_on; then
+      set_hidden_files false
+    else
+      set_hidden_files true
+    fi
+    ;;
+  *)
+    echo "Usage: omarchy toggle windows-admin-shares [toggle|on|off]" >&2
+    exit 1
+    ;;
+esac
+
+if is_on; then
+  omarchy-notification-send -g  "Windows admin shares visible"
+else
+  omarchy-notification-send -g  "Windows admin shares hidden"
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -97,6 +97,7 @@
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},
   "trigger.toggle.window-gaps": {"icon":"","label":"Window Gaps","action":"omarchy-hyprland-window-gaps-toggle"},
   "trigger.toggle.one-window-ratio": {"icon":"","label":"1-Window Ratio","action":"omarchy-hyprland-window-single-square-aspect-toggle"},
+  "trigger.toggle.windows-admin-shares": {"icon":"","label":"Windows Admin Shares","description":"Show C$ and other hidden SMB admin shares in Files","checked":"gsettings get org.gnome.nautilus.preferences show-hidden-files | grep -qx true","action":"omarchy-toggle-windows-admin-shares"},
   "trigger.tests.network-speedtest": {"icon":"󰓅","label":"Network Speed Test","action":"omarchy-shell shell summon omarchy.speedtest"},
   "trigger.tests.disk-speedtest": {"icon":"󰋊","label":"Disk Speed Test","action":"omarchy-shell shell summon omarchy.disk-speedtest"},
 

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -68,6 +68,7 @@
   "trigger.capture.screenrecord.webcam": {"icon":"","label":"With desktop + microphone audio + webcam","when":"omarchy-hw-webcam","action":"omarchy-capture-screenrecording-with-webcam"},
   "trigger.transcode": {"icon":"󰧸","label":"Transcode","action":"omarchy-transcode"},
   "trigger.share": {"icon":"","label":"Share","aliases":["share"]},
+  "trigger.windows-pc": {"icon":"","label":"Windows PC","description":"Sign in to a Windows computer on the network","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-windows-share"},
   "trigger.toggle": {"icon":"󰔎","label":"Toggle","aliases":["toggle","toggles"]},
   "trigger.hardware": {"icon":"","label":"Hardware","aliases":["hardware","hw"]},
   "trigger.tests": {"icon":"󰓅","label":"Speed Test"},

--- a/install/config/firewall.sh
+++ b/install/config/firewall.sh
@@ -6,6 +6,13 @@ ufw default allow outgoing
 ufw allow 53317/udp
 ufw allow 53317/tcp
 
+# Windows PCs answer WS-Discovery from UDP/3702. Without this, Files' Other
+# Locations stays empty because the default deny-incoming policy drops replies.
+ufw allow in proto udp from 10.0.0.0/8 port 3702 comment 'ws-discovery'
+ufw allow in proto udp from 172.16.0.0/12 port 3702 comment 'ws-discovery'
+ufw allow in proto udp from 192.168.0.0/16 port 3702 comment 'ws-discovery'
+ufw allow in proto udp from fe80::/10 port 3702 comment 'ws-discovery-ipv6'
+
 # Allow Docker containers to use DNS on host.
 ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment 'allow-docker-dns'
 ufw allow in proto udp from 192.168.0.0/16 to 172.17.0.1 port 53 comment 'allow-docker-dns'

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -50,6 +50,7 @@ gum
 gvfs-mtp
 gvfs-nfs
 gvfs-smb
+gvfs-wsdd
 herdr
 hyprland
 hyprland-guiutils

--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -32,7 +32,7 @@ Windows folks: your Win + V clipboard history lives on `Super + Ctrl + V`, and i
 | ------------- | ---------- |
 | Spotlight / Raycast / Start menu | `Super + Space` — the Omarchy menu |
 | AirDrop | LocalSend, via `Super + Ctrl + S` — see [GUIs](22-guis.md) |
-| Network / `\\PC\Share` | Files, Other Locations, or `Ctrl + L` then `smb://PC/Share` — see [GUIs](22-guis.md) |
+| Network / `\\PC\Share` | _Trigger > Windows PC_, then the Windows username and password — see [GUIs](22-guis.md) |
 | Cmd + Shift + 4 / Win + Shift + S | `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
 | Notification Center | Notification history on `Super + Shift + Alt + ,` |
 | Time Machine (for the system) | Automatic [system snapshots](47-system-snapshots.md) on every update |

--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -32,6 +32,7 @@ Windows folks: your Win + V clipboard history lives on `Super + Ctrl + V`, and i
 | ------------- | ---------- |
 | Spotlight / Raycast / Start menu | `Super + Space` — the Omarchy menu |
 | AirDrop | LocalSend, via `Super + Ctrl + S` — see [GUIs](22-guis.md) |
+| Network / `\\PC\Share` | Files, Other Locations, or `Ctrl + L` then `smb://PC/Share` — see [GUIs](22-guis.md) |
 | Cmd + Shift + 4 / Win + Shift + S | `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
 | Notification Center | Notification history on `Super + Shift + Alt + ,` |
 | Time Machine (for the system) | Automatic [system snapshots](47-system-snapshots.md) on every update |

--- a/manual/22-guis.md
+++ b/manual/22-guis.md
@@ -6,7 +6,7 @@ Files (Nautilus) is the graphical file manager. `Super + Shift + F` opens it, an
 
 Plug in a USB stick or an SD card and it's mounted automatically, so it just shows up in the sidebar. For anything more involved — formatting a drive, checking SMART health, creating partitions — launch _Disks_ from the app launcher (`Super + Space`).
 
-Windows PCs on the same network show up under Other Locations. Click one and sign in with the Windows account. Admin shares like `C$` stay hidden until you turn them on with `Ctrl + H` in Files, or _Trigger > Toggle > Windows Admin Shares_. You can also type a path with `Ctrl + L`, the same idea as `\\HOST\C$` in Explorer:
+Windows PCs on the same network show up under Other Locations. Click one and sign in with the Windows account. Check _Remember forever_ so you only do that once. Admin shares like `C$` stay hidden until you turn them on with `Ctrl + H` in Files, or _Trigger > Toggle > Windows Admin Shares_. You can also type a path with `Ctrl + L`, the same idea as `\\HOST\C$` in Explorer:
 
 `smb://HOST/C$`
 

--- a/manual/22-guis.md
+++ b/manual/22-guis.md
@@ -6,6 +6,11 @@ Files (Nautilus) is the graphical file manager. `Super + Shift + F` opens it, an
 
 Plug in a USB stick or an SD card and it's mounted automatically, so it just shows up in the sidebar. For anything more involved — formatting a drive, checking SMART health, creating partitions — launch _Disks_ from the app launcher (`Super + Space`).
 
+Windows PCs on the same network show up under Other Locations. Click one and sign in with the Windows account. Admin shares like `C$` stay hidden until you turn them on with `Ctrl + H` in Files, or _Trigger > Toggle > Windows Admin Shares_. You can also type a path with `Ctrl + L`, the same idea as `\\HOST\C$` in Explorer:
+
+`smb://HOST/C$`
+
+
 Double-clicking follows sensible defaults: images open in imv, video in mpv, PDFs in Document Viewer, and plain text in Neovim.
 
 ## Obsidian

--- a/manual/22-guis.md
+++ b/manual/22-guis.md
@@ -6,9 +6,7 @@ Files (Nautilus) is the graphical file manager. `Super + Shift + F` opens it, an
 
 Plug in a USB stick or an SD card and it's mounted automatically, so it just shows up in the sidebar. For anything more involved — formatting a drive, checking SMART health, creating partitions — launch _Disks_ from the app launcher (`Super + Space`).
 
-Windows PCs on the same network show up under Other Locations. Click one and sign in with the Windows account. Check _Remember forever_ so you only do that once. Admin shares like `C$` stay hidden until you turn them on with `Ctrl + H` in Files, or _Trigger > Toggle > Windows Admin Shares_. You can also type a path with `Ctrl + L`, the same idea as `\\HOST\C$` in Explorer:
-
-`smb://HOST/C$`
+Windows PCs on the same network show up under Other Locations. The reliable way in is _Trigger > Windows PC_ (or search “Windows PC” in the menu): pick the computer, then the Windows username and password. That’s a local admin on that PC — not your Linux user. Admin shares like `C$` stay hidden in Files until you turn them on with `Ctrl + H`, or _Trigger > Toggle > Windows Admin Shares_.
 
 
 Double-clicking follows sensible defaults: images open in imv, video in mpv, PDFs in Document Viewer, and plain text in Neovim.

--- a/migrations/1787366183.sh
+++ b/migrations/1787366183.sh
@@ -2,6 +2,16 @@ echo "Discover Windows PCs in Files"
 
 omarchy-pkg-add gvfs-wsdd
 
+if [[ ! -f /etc/samba/smb.conf ]]; then
+  sudo mkdir -p /etc/samba
+  sudo tee /etc/samba/smb.conf >/dev/null <<'EOF'
+[global]
+   client min protocol = SMB2_02
+   client max protocol = SMB3
+   client use kerberos = off
+EOF
+fi
+
 sudo ufw allow in proto udp from 10.0.0.0/8 port 3702 comment 'ws-discovery'
 sudo ufw allow in proto udp from 172.16.0.0/12 port 3702 comment 'ws-discovery'
 sudo ufw allow in proto udp from 192.168.0.0/16 port 3702 comment 'ws-discovery'

--- a/migrations/1787366183.sh
+++ b/migrations/1787366183.sh
@@ -1,0 +1,3 @@
+echo "Discover Windows PCs in Files"
+
+omarchy-pkg-add gvfs-wsdd

--- a/migrations/1787366183.sh
+++ b/migrations/1787366183.sh
@@ -1,3 +1,8 @@
 echo "Discover Windows PCs in Files"
 
 omarchy-pkg-add gvfs-wsdd
+
+sudo ufw allow in proto udp from 10.0.0.0/8 port 3702 comment 'ws-discovery'
+sudo ufw allow in proto udp from 172.16.0.0/12 port 3702 comment 'ws-discovery'
+sudo ufw allow in proto udp from 192.168.0.0/16 port 3702 comment 'ws-discovery'
+sudo ufw allow in proto udp from fe80::/10 port 3702 comment 'ws-discovery-ipv6'

--- a/test/shell.d/windows-admin-shares-test.sh
+++ b/test/shell.d/windows-admin-shares-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+STATE="$TMPDIR/show-hidden"
+
+cat >"$TMPDIR/bin/gsettings" <<'SH'
+#!/bin/bash
+state_file=${GSETTINGS_STATE:?}
+case "$1 $2 $3" in
+  "get org.gnome.nautilus.preferences show-hidden-files")
+    if [[ -f $state_file ]]; then
+      cat "$state_file"
+    else
+      echo false
+    fi
+    ;;
+  "set org.gnome.nautilus.preferences show-hidden-files")
+    printf '%s\n' "$4" >"$state_file"
+    ;;
+  *)
+    echo "unexpected gsettings: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$TMPDIR/bin/gsettings" "$TMPDIR/bin/omarchy-notification-send"
+
+run_toggle() {
+  PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+    GSETTINGS_STATE="$STATE" \
+    "$ROOT/bin/omarchy-toggle-windows-admin-shares" "$@"
+}
+
+hidden_value() {
+  PATH="$TMPDIR/bin:$PATH" GSETTINGS_STATE="$STATE" gsettings get org.gnome.nautilus.preferences show-hidden-files
+}
+
+[[ $(hidden_value) == false ]] || fail "admin shares start hidden"
+run_toggle
+[[ $(hidden_value) == true ]] || fail "toggle shows admin shares"
+run_toggle off
+[[ $(hidden_value) == false ]] || fail "off hides admin shares"
+run_toggle on
+[[ $(hidden_value) == true ]] || fail "on shows admin shares"
+pass "windows admin shares toggle drives Files hidden-files setting"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const items = menu.parseMenuJsonc(fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8'))
+const byId = Object.fromEntries(items.map(item => [item.id, item]))
+
+assertEqual(
+  byId['trigger.toggle.windows-admin-shares'].action,
+  'omarchy-toggle-windows-admin-shares',
+  'menu toggles Windows admin shares from Trigger > Toggle'
+)
+JS

--- a/test/shell.d/windows-share-connect-test.sh
+++ b/test/shell.d/windows-share-connect-test.sh
@@ -75,7 +75,7 @@ run_connect() {
 run_connect GLENN-PC
 grep -Fq -- '-W GLENN-PC' "$LOG" || fail "domain is the Windows PC hostname, not WORKGROUP"
 grep -Fq -- '-U glenn%secret' "$LOG" || fail "signs in as the Windows username"
-grep -Fq -- 'smb://GLENN-PC/C$' "$TMPDIR/mounted.log" || fail "local admin opens C$ first"
+grep -Fq -- 'smb://GLENN-PC/' "$TMPDIR/mounted.log" || fail "opens the PC so shared folders are listed"
 ! grep -Fq har0x "$LOG" || fail "does not use the Linux username"
 pass "local admin username and password open the Windows PC"
 

--- a/test/shell.d/windows-share-connect-test.sh
+++ b/test/shell.d/windows-share-connect-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+LOG="$TMPDIR/commands.log"
+
+cat >"$TMPDIR/bin/gio" <<'SH'
+#!/bin/bash
+printf 'gio %s\n' "$*" >>"$COMMAND_LOG"
+if [[ $1 == list ]]; then
+  printf '%s\n' GLENN-PC PLAYON-DEV-NODE
+  exit 0
+fi
+if [[ $1 == mount ]]; then
+  cat >/dev/null
+  printf '%s\n' "$2" >>"$MOUNTED_LOG"
+  exit 0
+fi
+exit 0
+SH
+
+cat >"$TMPDIR/bin/smbclient" <<'SH'
+#!/bin/bash
+printf 'smbclient %s\n' "$*" >>"$COMMAND_LOG"
+cat <<'OUT'
+Sharename       Type      Comment
+---------       ----      -------
+Users           Disk
+C$              Disk      Default share
+IPC$            IPC       IPC Service
+OUT
+exit 0
+SH
+
+cat >"$TMPDIR/bin/gum" <<'SH'
+#!/bin/bash
+echo "gum should not run when host/user/password are provided" >&2
+exit 1
+SH
+
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$TMPDIR/bin/timeout" <<'SH'
+#!/bin/bash
+shift
+exec "$@"
+SH
+
+cat >"$TMPDIR/bin/nmblookup" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+chmod +x "$TMPDIR/bin"/*
+
+run_connect() {
+  PATH="$TMPDIR/bin:$PATH" \
+    COMMAND_LOG="$LOG" \
+    MOUNTED_LOG="$TMPDIR/mounted.log" \
+    OMARCHY_SMB_USER=glenn \
+    OMARCHY_SMB_PASSWORD=secret \
+    "$ROOT/bin/omarchy-setup-windows-share" "$@"
+}
+
+: >"$LOG"
+run_connect GLENN-PC
+grep -Fq -- '-W GLENN-PC' "$LOG" || fail "domain is the Windows PC hostname, not WORKGROUP"
+grep -Fq -- '-U glenn%secret' "$LOG" || fail "signs in as the Windows username"
+grep -Fq -- 'smb://GLENN-PC/C$' "$TMPDIR/mounted.log" || fail "local admin opens C$ first"
+! grep -Fq har0x "$LOG" || fail "does not use the Linux username"
+pass "local admin username and password open the Windows PC"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const items = menu.parseMenuJsonc(fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8'))
+const byId = Object.fromEntries(items.map(item => [item.id, item]))
+
+assertEqual(
+  byId['trigger.windows-pc'].action,
+  'omarchy-launch-floating-terminal-with-presentation omarchy-setup-windows-share',
+  'menu signs in to a Windows PC from Trigger'
+)
+JS


### PR DESCRIPTION
## What

Omarchy already ships `gvfs-smb`, so Files can *open* Windows shares, but it does not ship `gvfs-wsdd`. Windows 10/11 advertise themselves with WS-Discovery, not the old NetBIOS browse list, so Other Locations stays empty and people have to type `smb://IP/Share`.

This adds the missing discovery backend as a default, plus a toggle for hidden SMB admin shares (`C$`, `ADMIN$`).

## Why not a plugin or panel

Files is already the network panel. `gvfs-wsdd` is how GNOME discovers modern Windows PCs (Ubuntu has shipped this since 24.10). Admin shares are already marked hidden by gvfs; Files already has a hidden-files setting (`Ctrl+H`). The toggle just exposes that setting in Trigger > Toggle so it is findable.

## Changes

- Install `gvfs-wsdd` on new systems (`omarchy-base.packages`)
- Migration for existing installs: `omarchy-pkg-add gvfs-wsdd`
- `omarchy toggle windows-admin-shares` (also in Trigger > Toggle)
- Manual notes for Files and Coming from Windows

## After this lands

1. Open Files (`Super+Shift+F`)
2. Other Locations should list Windows PCs on the LAN
3. Sign in with the Windows account
4. Toggle Windows Admin Shares (or `Ctrl+H`) to see `C$`

Typing `smb://HOST/C$` still works, same as `\\HOST\C$` in Explorer.

Windows may still deny `C$` for a filtered local admin token (`LocalAccountTokenFilterPolicy`). That is a Windows restriction, not Omarchy.