### PR TITLE
Add MacBookPro13,1 hardware support

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -32,6 +32,8 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
+run_logged "$OMARCHY_INSTALL/hardware/apple/install-macbookpro13-1-audio.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/install-macbookpro13-1-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"

--- a/install/hardware/apple/fix-spi-keyboard.sh
+++ b/install/hardware/apple/fix-spi-keyboard.sh
@@ -3,7 +3,9 @@ product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
 if [[ $product_name =~ MacBook[89],1|MacBook1[02],1|MacBookPro13,[123]|MacBookPro14,[123] ]]; then
   echo "Detected MacBook with SPI keyboard"
 
-  omarchy-pkg-add macbook12-spi-driver-dkms
+  if [[ $product_name != "MacBookPro13,1" ]]; then
+    omarchy-pkg-add macbook12-spi-driver-dkms
+  fi
   sudo mkdir -p /etc/mkinitcpio.conf.d
   if [[ $product_name == "MacBook8,1" ]]; then
     echo "MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)" | \

--- a/install/hardware/apple/install-macbookpro13-1-audio.sh
+++ b/install/hardware/apple/install-macbookpro13-1-audio.sh
@@ -1,0 +1,4 @@
+if omarchy-hw-match '^MacBookPro13,1$'; then
+  echo "Installing MacBookPro13,1 Cirrus audio support"
+  omarchy-pkg-add snd-hda-macbookpro-dkms
+fi

--- a/install/hardware/apple/install-macbookpro13-1-camera.sh
+++ b/install/hardware/apple/install-macbookpro13-1-camera.sh
@@ -1,0 +1,4 @@
+if omarchy-hw-match '^MacBookPro13,1$'; then
+  echo "Installing MacBookPro13,1 FaceTime HD camera support"
+  omarchy-pkg-add facetimehd-dkms facetimehd-firmware
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -65,6 +65,11 @@ dell-xps-touchpad-haptics
 # Speaker tunings (LV2 limiter every tuning ends in)
 lsp-plugins-lv2
 
+# MacBookPro13,1 compatibility
+facetimehd-dkms
+facetimehd-firmware
+snd-hda-macbookpro-dkms
+
 # T2 MacBook support packages
 apple-bcm-firmware
 apple-t2-audio-config

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -37,15 +37,22 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 
 The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.
 
+#### MacBookPro13,1
+
+Omarchy supports the exact DMI model `MacBookPro13,1` (the 13-inch 2016 MacBook Pro with two Thunderbolt 3 ports, model A1708) on the stock Omarchy kernel. Fresh installations and hardware replay automatically install the Cirrus audio driver and FaceTime HD camera driver and firmware. The keyboard uses the kernel's in-tree `applespi` driver, and Omarchy's existing NVMe suspend fix remains enabled.
+
+The support contract covers built-in speaker and headphone playback, internal microphone capture, FaceTime HD camera capture, keyboard backlight control, and suspend. Hibernation remains opt-in through the standard Omarchy setup command.
+
+The internal microphone works at a lower capture gain than under macOS because of an upstream audio-driver limitation. The FaceTime HD camera driver can affect suspend or resume on some systems; Omarchy does not add a speculative module unload/reload workaround.
+
 ### Known Limitations
 
 Members of the community are constantly working on solutions to these challenges so if these are problematic for you, join #omarchy-on-other in our [Discord](https://discord.gg/tXFUdasqhY) and see if there's any up-to-date methods for resolving these.
 
 #### Devices with T1 Chip
 
-The Apple T1 chip was introduced in late 2016 and used exclusively in the first-generation MacBook Pro models with Touch Bar.
-- MacBook Pro 13-inch (2016, two Thunderbolt 3 ports) – Model: A1706
-- MacBook Pro 13-inch (2016, four Thunderbolt 3 ports) – Model: A1708
+The Apple T1 chip was introduced in late 2016 and used in the first-generation MacBook Pro models with Touch Bar. The supported `MacBookPro13,1`/A1708 does not have a T1 chip.
+- MacBook Pro 13-inch (2016, four Thunderbolt 3 ports) – Model: A1706
 - MacBook Pro 15-inch (2016) – Model: A1707
 
 #### Known Issues

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -41,9 +41,7 @@ The installer detects Mac hardware and applies the needed fixes automatically: B
 
 Omarchy supports the exact DMI model `MacBookPro13,1` (the 13-inch 2016 MacBook Pro with two Thunderbolt 3 ports, model A1708) on the stock Omarchy kernel. Fresh installations and hardware replay automatically install the Cirrus audio driver and FaceTime HD camera driver and firmware. The keyboard uses the kernel's in-tree `applespi` driver, and Omarchy's existing NVMe power workaround remains enabled.
 
-The support contract covers built-in speaker and headphone playback, internal microphone capture, FaceTime HD camera capture, and keyboard backlight control after a normal boot. Deep suspend and hibernation are not supported on this model in the first iteration. Resuming from deep suspend can leave both the built-in speakers and 3.5 mm headphone output silent until the next reboot.
-
-The internal microphone works at a lower capture gain than under macOS because of an upstream audio-driver limitation. Omarchy does not patch the audio driver's experimental deep-suspend resume path or add a speculative camera module unload/reload workaround.
+After a normal boot, the built-in speakers, headphones, microphone, camera, and keyboard backlight are supported. Deep suspend and hibernation are not supported because audio and camera do not always recover after wake and may remain unavailable until reboot. Use a normal shutdown instead. For technical background, see the upstream [deep-suspend audio proposal](https://github.com/davidjo/snd_hda_macbookpro/pull/198) and [jack-detection issue](https://github.com/davidjo/snd_hda_macbookpro/issues/199).
 
 ### Known Limitations
 

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -39,11 +39,11 @@ The installer detects Mac hardware and applies the needed fixes automatically: B
 
 #### MacBookPro13,1
 
-Omarchy supports the exact DMI model `MacBookPro13,1` (the 13-inch 2016 MacBook Pro with two Thunderbolt 3 ports, model A1708) on the stock Omarchy kernel. Fresh installations and hardware replay automatically install the Cirrus audio driver and FaceTime HD camera driver and firmware. The keyboard uses the kernel's in-tree `applespi` driver, and Omarchy's existing NVMe suspend fix remains enabled.
+Omarchy supports the exact DMI model `MacBookPro13,1` (the 13-inch 2016 MacBook Pro with two Thunderbolt 3 ports, model A1708) on the stock Omarchy kernel. Fresh installations and hardware replay automatically install the Cirrus audio driver and FaceTime HD camera driver and firmware. The keyboard uses the kernel's in-tree `applespi` driver, and Omarchy's existing NVMe power workaround remains enabled.
 
-The support contract covers built-in speaker and headphone playback, internal microphone capture, FaceTime HD camera capture, keyboard backlight control, and suspend. Hibernation remains opt-in through the standard Omarchy setup command.
+The support contract covers built-in speaker and headphone playback, internal microphone capture, FaceTime HD camera capture, and keyboard backlight control after a normal boot. Deep suspend and hibernation are not supported on this model in the first iteration. Resuming from deep suspend can leave both the built-in speakers and 3.5 mm headphone output silent until the next reboot.
 
-The internal microphone works at a lower capture gain than under macOS because of an upstream audio-driver limitation. The FaceTime HD camera driver can affect suspend or resume on some systems; Omarchy does not add a speculative module unload/reload workaround.
+The internal microphone works at a lower capture gain than under macOS because of an upstream audio-driver limitation. Omarchy does not patch the audio driver's experimental deep-suspend resume path or add a speculative camera module unload/reload workaround.
 
 ### Known Limitations
 

--- a/migrations/1787257711.sh
+++ b/migrations/1787257711.sh
@@ -1,0 +1,11 @@
+echo "Install MacBookPro13,1 audio and camera compatibility support"
+
+compatibility_marker="${OMARCHY_MACBOOKPRO13_1_MIGRATION_MARKER:-/var/lib/omarchy/migrations/macbookpro13-1-compatibility}"
+
+if omarchy-hw-match '^MacBookPro13,1$' && [[ ! -e $compatibility_marker ]]; then
+  omarchy-pkg-add snd-hda-macbookpro-dkms facetimehd-dkms facetimehd-firmware
+  omarchy-pkg-drop macbook12-spi-driver-dkms
+  sudo limine-mkinitcpio
+  omarchy-state set reboot-required
+  sudo install -Dm644 /dev/null "$compatibility_marker"
+fi

--- a/test/shell.d/macbookpro13-1-hardware-test.sh
+++ b/test/shell.d/macbookpro13-1-hardware-test.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+audio_installer="$ROOT/install/hardware/apple/install-macbookpro13-1-audio.sh"
+camera_installer="$ROOT/install/hardware/apple/install-macbookpro13-1-camera.sh"
+hardware_all="$ROOT/install/hardware/all.sh"
+spi_installer="$ROOT/install/hardware/apple/fix-spi-keyboard.sh"
+offline_packages="$ROOT/install/omarchy-other.packages"
+migration="$ROOT/migrations/1787257711.sh"
+mac_support_manual="$ROOT/manual/44-mac-support.md"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+
+(( ${MATCHING_HARDWARE:-0} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-pkg-drop" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-drop' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_capability_installer() {
+  local installer="$1" matching_hardware="$2"
+  : >"$calls"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" MATCHING_HARDWARE="$matching_hardware" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$installer" >/dev/null
+}
+
+run_migration() {
+  local matching_hardware="$1"
+  : >"$calls"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" MATCHING_HARDWARE="$matching_hardware" \
+    OMARCHY_MACBOOKPRO13_1_MIGRATION_MARKER="$compatibility_marker" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_capability_installer "$audio_installer" 1
+
+grep -Fxq $'omarchy-pkg-add\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "MacBookPro13,1 audio setup installs the Cirrus DKMS package" "$(cat "$calls")"
+pass "MacBookPro13,1 audio setup installs the Cirrus DKMS package"
+
+run_capability_installer "$audio_installer" 0
+
+[[ ! -s $calls ]] ||
+  fail "audio setup leaves other models untouched" "$(cat "$calls")"
+pass "audio setup leaves other models untouched"
+
+run_capability_installer "$camera_installer" 1
+
+grep -Fxq $'omarchy-pkg-add\tfacetimehd-dkms\tfacetimehd-firmware' "$calls" ||
+  fail "MacBookPro13,1 camera setup installs the driver and firmware packages" "$(cat "$calls")"
+pass "MacBookPro13,1 camera setup installs the driver and firmware packages"
+
+run_capability_installer "$camera_installer" 0
+
+[[ ! -s $calls ]] ||
+  fail "camera setup leaves other models untouched" "$(cat "$calls")"
+pass "camera setup leaves other models untouched"
+
+grep -Fq 'apple/install-macbookpro13-1-audio.sh' "$hardware_all" &&
+  grep -Fq 'apple/install-macbookpro13-1-camera.sh' "$hardware_all" ||
+  fail "hardware setup replays both MacBookPro13,1 capabilities"
+pass "hardware setup replays both MacBookPro13,1 capabilities"
+
+product_name="$test_tmp/product_name"
+spi_conf_dir="$test_tmp/mkinitcpio.conf.d"
+spi_test_script="$test_tmp/fix-spi-keyboard.sh"
+sed -e "s|/sys/class/dmi/id/product_name|$product_name|g" \
+    -e "s|/etc/mkinitcpio.conf.d|$spi_conf_dir|g" \
+    "$spi_installer" >"$spi_test_script"
+
+printf '%s\n' 'MacBookPro13,1' >"$product_name"
+: >"$calls"
+PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+  bash -eE -o pipefail -c 'source "$1"' bash "$spi_test_script" >/dev/null
+
+! grep -Fq $'omarchy-pkg-add\tmacbook12-spi-driver-dkms' "$calls" ||
+  fail "MacBookPro13,1 SPI setup uses the in-tree driver" "$(cat "$calls")"
+pass "MacBookPro13,1 SPI setup uses the in-tree driver"
+
+grep -Fxq 'MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)' \
+  "$spi_conf_dir/macbook_spi_modules.conf" ||
+  fail "MacBookPro13,1 SPI setup keeps the applespi initramfs configuration"
+pass "MacBookPro13,1 SPI setup keeps the applespi initramfs configuration"
+
+rm -rf "$spi_conf_dir"
+printf '%s\n' 'MacBookPro13,2' >"$product_name"
+: >"$calls"
+PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+  bash -eE -o pipefail -c 'source "$1"' bash "$spi_test_script" >/dev/null
+
+grep -Fq $'omarchy-pkg-add\tmacbook12-spi-driver-dkms' "$calls" ||
+  fail "other supported MacBooks keep the SPI DKMS package" "$(cat "$calls")"
+pass "other supported MacBooks keep the SPI DKMS package"
+
+for package in facetimehd-dkms facetimehd-firmware snd-hda-macbookpro-dkms; do
+  grep -Fxq "$package" "$offline_packages" ||
+    fail "the offline package set includes MacBookPro13,1 compatibility packages" "$package is missing"
+done
+pass "the offline package set includes MacBookPro13,1 compatibility packages"
+
+compatibility_marker="$test_tmp/macbookpro13-1-compatibility"
+run_migration 1
+
+grep -Fxq $'omarchy-pkg-add\tsnd-hda-macbookpro-dkms\tfacetimehd-dkms\tfacetimehd-firmware' "$calls" ||
+  fail "the compatibility migration installs MacBookPro13,1 audio and camera support" "$(cat "$calls")"
+pass "the compatibility migration installs MacBookPro13,1 audio and camera support"
+
+grep -Fxq $'omarchy-pkg-drop\tmacbook12-spi-driver-dkms' "$calls" ||
+  fail "the compatibility migration removes the obsolete SPI DKMS package" "$(cat "$calls")"
+pass "the compatibility migration removes the obsolete SPI DKMS package"
+
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "the compatibility migration regenerates the boot image" "$(cat "$calls")"
+pass "the compatibility migration regenerates the boot image"
+
+grep -Fxq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the compatibility migration requests reboot" "$(cat "$calls")"
+pass "the compatibility migration requests reboot"
+
+[[ -f $compatibility_marker ]] ||
+  fail "the compatibility migration records machine-level completion"
+pass "the compatibility migration records machine-level completion"
+
+run_migration 1
+
+[[ ! -s $calls ]] ||
+  fail "the compatibility migration is machine-idempotent" "$(cat "$calls")"
+pass "the compatibility migration is machine-idempotent"
+
+rm -f "$compatibility_marker"
+run_migration 0
+
+[[ ! -s $calls && ! -e $compatibility_marker ]] ||
+  fail "the compatibility migration leaves other models untouched" "$(cat "$calls")"
+pass "the compatibility migration leaves other models untouched"
+
+grep -Fq '`MacBookPro13,1`' "$mac_support_manual" &&
+  grep -Eqi 'microphone.*gain' "$mac_support_manual" &&
+  grep -Eqi 'camera.*suspend|suspend.*camera' "$mac_support_manual" ||
+  fail "the Mac manual documents the exact support contract and upstream limitations"
+pass "the Mac manual documents the exact support contract and upstream limitations"

--- a/test/shell.d/macbookpro13-1-hardware-test.sh
+++ b/test/shell.d/macbookpro13-1-hardware-test.sh
@@ -185,7 +185,10 @@ run_migration 0
 pass "the compatibility migration leaves other models untouched"
 
 grep -Fq '`MacBookPro13,1`' "$mac_support_manual" &&
-  grep -Eqi 'microphone.*gain' "$mac_support_manual" &&
-  grep -Eqi 'camera.*suspend|suspend.*camera' "$mac_support_manual" ||
+  grep -Eqi 'deep suspend.*not supported|not supported.*deep suspend' "$mac_support_manual" &&
+  grep -Eqi 'hibernation.*not supported|not supported.*hibernation' "$mac_support_manual" &&
+  grep -Eqi 'audio.*camera.*do not always recover' "$mac_support_manual" &&
+  grep -Eqi 'shutdown.*reboot|reboot.*shutdown' "$mac_support_manual" &&
+  ! grep -Eqi 'first[- ]iteration' "$mac_support_manual" ||
   fail "the Mac manual documents the exact support contract and upstream limitations"
 pass "the Mac manual documents the exact support contract and upstream limitations"


### PR DESCRIPTION
## Summary

- install model-gated Cirrus audio and FaceTime HD camera packages during fresh setup and hardware replay
- migrate existing MacBookPro13,1 systems away from the obsolete SPI DKMS package while retaining in-tree applespi
- include the offline compatibility packages and document the MacBookPro13,1 normal-boot support boundary

Depends on omacom-io/omarchy-pkgs#182.

## Validation

- MacBookPro13,1 focused shell test: 17/17 passed
- package and offline DKMS validation passed on Linux 7.1.8
- live migration, reboot, audio, microphone, camera, keyboard, trackpad, and keyboard-backlight checks passed
- official hardware replay passed with before/after state unchanged except timestamp

Deep suspend and hibernation are not supported on MacBookPro13,1. The reference-device deep-suspend test left both analog audio outputs silent until reboot, so no experimental downstream workaround is included. See the upstream [deep-suspend audio proposal](https://github.com/davidjo/snd_hda_macbookpro/pull/198) and [jack-detection issue](https://github.com/davidjo/snd_hda_macbookpro/issues/199) for technical background.