### PR TITLE
Match LocalSend's current Wayland app ID

### DIFF
--- a/default/hypr/apps/localsend.lua
+++ b/default/hypr/apps/localsend.lua
@@ -1,3 +1,3 @@
 -- Float LocalSend and fzf file picker.
-o.window("(Share|localsend)", { float = true, center = true })
-o.window("localsend", { size = { 1100, 700 } })
+o.window("^(Share|localsend|org\\.localsend\\.localsend_app)$", { float = true, center = true })
+o.window("^(localsend|org\\.localsend\\.localsend_app)$", { size = { 1100, 700 } })

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -105,6 +105,27 @@ grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default applicat
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
 
+OMARCHY_PATH="$ROOT" lua <<'LUA' || fail "LocalSend rules match its current Wayland app ID"
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local rules = {}
+hl = {
+  window_rule = function(rule)
+    table.insert(rules, rule)
+  end,
+}
+
+require("default.hypr.helpers")
+require("default.hypr.apps.localsend")
+
+assert(#rules == 2)
+assert(rules[1].match.class == "^(Share|localsend|org\\.localsend\\.localsend_app)$")
+assert(rules[1].float == true and rules[1].center == true)
+assert(rules[2].match.class == "^(localsend|org\\.localsend\\.localsend_app)$")
+assert(rules[2].size[1] == 1100 and rules[2].size[2] == 700)
+LUA
+pass "LocalSend rules match its current Wayland app ID"
+
 grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
   fail "universal clipboard shortcuts send explicit mods to the focused surface"
 pass "universal clipboard shortcuts send explicit mods to the focused surface"


### PR DESCRIPTION
## Problem

LocalSend 1.18.1 uses the Wayland class `org.localsend.localsend_app`, but Omarchy only matches `localsend`. The window therefore opens tiled instead of floating, centered, and sized to 1100×700. On this release, buttons in a tiled LocalSend window may also stop accepting clicks.

Fixes #7482.

## Change

Add the current app ID to both LocalSend rules. Keep the legacy `localsend` class and the `Share` file-picker rule. Anchor both expressions and escape the app ID's dots for Hyprland's RE2 matcher.

## Live verification

Tested with `localsend 1.18.1-2` in a running Hyprland 0.56 session on DP-2, workspace 8:

![LocalSend tiled with the packaged rules and floating with the candidate rules](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets/pr-assets/7736-localsend-window-rule.png)

| Rules | Class | Floating | Size |
| --- | --- | --- | --- |
| Current packaged rules | `org.localsend.localsend_app` | `false` | `1866×1000` |
| Candidate rules | `org.localsend.localsend_app` | `true` | `1100×700` |

I loaded the candidate file through Hyprland's Lua evaluator, launched LocalSend, and checked it with `hyprctl clients -j`. I then closed LocalSend and reloaded the normal configuration. `hyprctl configerrors` remained empty.

## Tests

The default-config test now checks the current and legacy app IDs, regex escaping, the existing `Share` behavior, and both LocalSend rules.

- `bash test/shell.d/hyprland-default-config-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- `luac -p default/hypr/apps/localsend.lua`
- `bash -n test/shell.d/hyprland-default-config-test.sh`
- `shellcheck -e SC1091,SC2016 test/shell.d/hyprland-default-config-test.sh`
- `./test/cli`
- `git diff --check`
