### PR TITLE
Make the menu's navigation keys configurable

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -138,6 +138,12 @@ string on a miss.
     "screensaver": 150,
     "lock": 300
   },
+  "keys": {
+    "menu": {
+      "down": ["Down", "Ctrl+N", "Ctrl+J"],
+      "up": ["Up", "Ctrl+P", "Ctrl+K"]
+    }
+  },
   "bar": {
     "id": "omarchy.bar",
     "position": "top",
@@ -169,7 +175,8 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
-8. `version: 1` is required.
+8. `keys.menu.<action>` is a list of binding specs (`"Ctrl+N"`, `"Down"`). Actions are resolved against the menu's own defaults one action at a time, so naming one action does not unbind the rest. `[]` unbinds an action. Parsing lives in `shell/Commons/Keymap.js`; only the menu reads `keys` today, other panels may adopt the same layout later.
+9. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -66,6 +66,43 @@ Finally, there's a special scratchpad workspace that drops down over whatever wo
 
 It works especially well for a terminal running an agent, or for controls you want to interact with quickly without leaving the current workspace. To move a window off the scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
 
+### Moving around the Omarchy menu
+
+The menu moves on the arrow keys, and on `Ctrl + N`/`Ctrl + P` and `Ctrl + J`/`Ctrl + K` too, so it reads the same way as Neovim or any readline prompt. `Ctrl + H` steps back a level like `Left`, and `Ctrl + L` opens the highlighted entry like `Return`. Every one of those is on by default — nothing to turn on.
+
+If you want different keys, each action takes a list of them under a `keys` block in `~/.config/omarchy/shell.json`, alongside whatever is already in there:
+
+```json
+{
+  "version": 1,
+  "keys": {
+    "menu": {
+      "down": ["Down", "Ctrl+N", "Ctrl+J"],
+      "up": ["Up", "Ctrl+P", "Ctrl+K"]
+    }
+  }
+}
+```
+
+That's a complete file if you don't have a `shell.json` yet. If you do — and you will the moment you've moved a bar widget — add just the `keys` block to it rather than pasting over the file. There's no deep merge, so a `shell.json` containing only the above would take your bar layout with it; see [the top bar](05-the-top-bar.md) for that rule in full.
+
+The actions are `up`, `down`, `pageUp`, `pageDown`, `back`, `activate`, and `remove`. Escape always closes the menu and can't be rebound, so a typo here never locks you in. Anything you leave out keeps its default, so a block naming only `down` changes just that. Write bindings as `Ctrl+N`, `Shift+Tab` or `Down` — `Ctrl`, `Shift`, `Alt` and `Super` are the modifiers. Setting an action to `[]` unbinds it.
+
+Paging is a good example of something you can add for yourself. Vim's half-page keys aren't bound by default, but nothing stops you:
+
+```json
+"keys": {
+  "menu": {
+    "pageDown": ["PageDown", "Ctrl+D"],
+    "pageUp": ["PageUp", "Ctrl+U"]
+  }
+}
+```
+
+Note that `PageDown` and `PageUp` are listed again alongside them. Naming an action replaces its whole list rather than adding to it, so leaving them out would unbind them.
+
+`Ctrl + U` is a partial case worth knowing about. While there's text in the search field it clears the field, the way it does at a shell prompt, so it only pages once the field is empty. `Ctrl + D` has no such conflict and pages either way.
+
 ### It takes some getting used to!
 
 It takes a little while to get used to navigating your desktop like this, but once you do, it'll be hard to go back to a traditional mouse-driven desktop experience!

--- a/shell/Commons/Keymap.js
+++ b/shell/Commons/Keymap.js
@@ -1,0 +1,135 @@
+.pragma library
+
+// Keybindings for panels that navigate a list.
+//
+// Bindings are written as human-readable specs ("Down", "Ctrl+N", "Shift+Tab")
+// so they can live in shell.json, and every action takes a LIST of them, so
+// several keys can drive the same action without the panel knowing which.
+//
+// Qt's key and modifier codes are stable public constants, repeated here so
+// this file stays plain JS: it is imported by QML and by the Node test suite,
+// which has no Qt available. keymap-test.sh pins the two codes that were
+// verified against live key events.
+
+var MODIFIER_CODES = {
+  shift: 0x02000000,
+  ctrl: 0x04000000,
+  control: 0x04000000,
+  alt: 0x08000000,
+  meta: 0x10000000,
+  super: 0x10000000
+}
+
+// Flags Qt adds to an event on its own (keypad keys, keyboard layout groups).
+// No spec can name them, so they are ignored when matching.
+var INTRINSIC_MODIFIERS = 0x20000000 | 0x40000000
+
+var NAMED_KEY_CODES = {
+  escape: 0x01000000,
+  esc: 0x01000000,
+  tab: 0x01000001,
+  backtab: 0x01000002,
+  backspace: 0x01000003,
+  return: 0x01000004,
+  enter: 0x01000005,
+  insert: 0x01000006,
+  delete: 0x01000007,
+  del: 0x01000007,
+  home: 0x01000010,
+  end: 0x01000011,
+  left: 0x01000012,
+  up: 0x01000013,
+  right: 0x01000014,
+  down: 0x01000015,
+  pageup: 0x01000016,
+  pagedown: 0x01000017,
+  space: 0x20
+}
+
+// Qt uses the ASCII code for letters and digits, so Key_N === 78. Anything
+// else has to be a name from the table above; unknown names return -1 so a
+// typo in shell.json disables that one binding instead of throwing.
+function keyCode(name) {
+  var token = String(name === undefined || name === null ? "" : name).trim()
+  if (!token) return -1
+  var named = NAMED_KEY_CODES[token.toLowerCase()]
+  if (named !== undefined) return named
+  if (token.length === 1) {
+    var code = token.toUpperCase().charCodeAt(0)
+    if ((code >= 48 && code <= 57) || (code >= 65 && code <= 90)) return code
+  }
+  return -1
+}
+
+// "Ctrl+Shift+N" -> { key: 78, modifiers: 0x06000000 }. Returns null when the
+// key is unknown, so callers can treat a bad spec as simply not bound.
+function parse(spec) {
+  var text = String(spec === undefined || spec === null ? "" : spec).trim()
+  if (!text) return null
+
+  var parts = text.split("+")
+  var keyToken = parts.pop()
+  var modifiers = 0
+  for (var i = 0; i < parts.length; i++) {
+    var modifier = MODIFIER_CODES[parts[i].trim().toLowerCase()]
+    if (modifier === undefined) return null
+    modifiers |= modifier
+  }
+
+  var key = keyCode(keyToken)
+  if (key < 0) return null
+  return { key: key, modifiers: modifiers }
+}
+
+// True when the event matches any spec in bindings. Nameable modifiers must
+// match exactly, so Ctrl+Shift+N never fires a Ctrl+N binding and bare letters
+// keep falling through to the filter.
+function matches(event, bindings) {
+  if (!event || !bindings) return false
+  var specs = typeof bindings === "string" ? [bindings] : bindings
+  if (!Array.isArray(specs)) return false
+
+  var key = event.key
+  var modifiers = event.modifiers & ~INTRINSIC_MODIFIERS
+  // Shift+Tab arrives as Key_Backtab. Fold it back to Tab+Shift so the spec
+  // people naturally write matches; "Backtab" is normalised the same way.
+  if (key === NAMED_KEY_CODES.backtab) {
+    key = NAMED_KEY_CODES.tab
+    modifiers |= MODIFIER_CODES.shift
+  }
+
+  for (var i = 0; i < specs.length; i++) {
+    var binding = parse(specs[i])
+    if (!binding) continue
+    if (binding.key === NAMED_KEY_CODES.backtab) {
+      binding.key = NAMED_KEY_CODES.tab
+      binding.modifiers |= MODIFIER_CODES.shift
+    }
+    if (binding.key === key && binding.modifiers === modifiers) return true
+  }
+  return false
+}
+
+// Overlay a user's shell.json block onto a panel's defaults, one action at a
+// time, so overriding "down" does not silently drop "up". A bare string is
+// accepted wherever a list is, since binding one key is the common case.
+function resolve(userConfig, defaults) {
+  var out = {}
+  var action
+
+  for (action in defaults) {
+    if (defaults.hasOwnProperty(action)) out[action] = defaults[action].slice()
+  }
+  if (!userConfig || typeof userConfig !== "object" || Array.isArray(userConfig)) return out
+
+  for (action in userConfig) {
+    if (!userConfig.hasOwnProperty(action)) continue
+    var value = userConfig[action]
+    if (typeof value === "string") {
+      out[action] = value ? [value] : []
+    } else if (Array.isArray(value)) {
+      out[action] = value.filter(function(spec) { return typeof spec === "string" && spec })
+    }
+  }
+  return out
+}

--- a/shell/Commons/qmldir
+++ b/shell/Commons/qmldir
@@ -3,3 +3,4 @@ singleton Border 1.0 Border.qml
 singleton Color 1.0 Color.qml
 singleton Style 1.0 Style.qml
 singleton Util 1.0 Util.qml
+Keymap 1.0 Keymap.js

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -78,6 +78,24 @@ Item {
   // Shared application engine (entries, hidden filters, icons, launch,
   // removal), owned by the shell and also used by the standalone launcher.
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
+
+  // Navigation keys. Arrows and Enter are the baseline; Ctrl+N/P and Ctrl+H/J/K/L
+  // are here so the menu reads the same way as a modal editor. Override any
+  // single action under "keys": { "menu": { ... } } in shell.json — actions left
+  // out keep these defaults. Escape is deliberately not here: it is checked
+  // ahead of every binding so no configuration can shadow the way out.
+  readonly property var defaultKeymap: ({
+    "up": ["Up", "Ctrl+P", "Ctrl+K"],
+    "down": ["Down", "Ctrl+N", "Ctrl+J"],
+    "pageUp": ["PageUp"],
+    "pageDown": ["PageDown"],
+    "back": ["Left", "Backspace", "Ctrl+H"],
+    "activate": ["Return", "Enter", "Right", "Ctrl+L"],
+    "remove": ["Delete"]
+  })
+  readonly property var shellKeymaps: root.shell && root.shell.shellConfig && root.shell.shellConfig.keys
+    ? root.shell.shellConfig.keys : null
+  readonly property var keymap: Keymap.resolve(root.shellKeymaps ? root.shellKeymaps.menu : null, root.defaultKeymap)
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
   onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
@@ -1126,32 +1144,35 @@ Item {
             return
           }
 
-          if (event.key === Qt.Key_Delete) {
-            root.requestDeleteSelected()
-            event.accepted = true
-          } else if (event.key === Qt.Key_Escape) {
+          // Escape and editsFilter come before the keymap: Escape always gets
+          // out whatever the bindings say, and a non-empty filter always owns
+          // Backspace and Ctrl+U; "back" only claims Backspace once it's empty.
+          if (event.key === Qt.Key_Escape) {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
+          } else if (Keymap.matches(event, root.keymap.remove)) {
+            root.requestDeleteSelected()
+            event.accepted = true
+          } else if (Keymap.matches(event, root.keymap.back) && !root.filterText) {
             root.goBack()
             event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
+          } else if (Keymap.matches(event, root.keymap.up)) {
             root.select(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Down) {
+          } else if (Keymap.matches(event, root.keymap.down)) {
             root.select(1)
             event.accepted = true
-          } else if (event.key === Qt.Key_PageUp) {
+          } else if (Keymap.matches(event, root.keymap.pageUp)) {
             root.select(-6)
             event.accepted = true
-          } else if (event.key === Qt.Key_PageDown) {
+          } else if (Keymap.matches(event, root.keymap.pageDown)) {
             root.select(6)
             event.accepted = true
-          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right) {
+          } else if (Keymap.matches(event, root.keymap.activate)) {
             if (root.dmenuActive) {
               if (root.mode === "input") root.applyDmenuSelection(root.filterText)
               else if (displayModel.count > 0) root.activateIndex(root.cursorActive ? root.selectedIndex : 0)

--- a/test/shell.d/keymap-test.sh
+++ b/test/shell.d/keymap-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+source "$(dirname "$0")/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+
+const source = fs.readFileSync(path.join(root, 'shell/Commons/Keymap.js'), 'utf8').replace(/^\.pragma library\n/, '')
+const keymap = {}
+vm.createContext(keymap)
+vm.runInContext(source, keymap)
+
+// Pinned against key events captured from a running menu, so a wrong constant
+// in the table fails here rather than silently unbinding a key in the UI.
+assertDeepEqual(
+  keymap.parse('Ctrl+N'),
+  { key: 78, modifiers: 0x04000000 },
+  'Ctrl+N parses to the Qt codes a live event carries'
+)
+assertDeepEqual(
+  keymap.parse('Down'),
+  { key: 0x01000015, modifiers: 0 },
+  'a bare named key parses with no modifiers'
+)
+assertDeepEqual(
+  keymap.parse('Ctrl+Shift+Tab'),
+  { key: 0x01000001, modifiers: 0x04000000 | 0x02000000 },
+  'modifiers combine into one mask'
+)
+
+assert(keymap.parse('Ctrl+n').key === 78, 'key names are case-insensitive')
+assert(keymap.parse('CTRL+N').modifiers === 0x04000000, 'modifier names are case-insensitive')
+assert(keymap.parse('Super+K').modifiers === 0x10000000, 'Super is an alias for Meta')
+
+// A typo should cost one binding, not throw inside a key handler.
+assertEqual(keymap.parse('Ctrl+Nope'), null, 'an unknown key name parses to null')
+assertEqual(keymap.parse('Hyper+N'), null, 'an unknown modifier parses to null')
+assertEqual(keymap.parse(''), null, 'an empty spec parses to null')
+assertEqual(keymap.parse('Ctrl+'), null, 'a spec with no key parses to null')
+assertEqual(keymap.parse('Ctrl++'), null, 'punctuation keys are not bindable')
+assertEqual(keymap.parse(null), null, 'a null spec parses to null')
+
+const down = ['Down', 'Ctrl+N', 'Ctrl+J']
+assert(keymap.matches({ key: 0x01000015, modifiers: 0 }, down), 'Down matches the down action')
+assert(keymap.matches({ key: 78, modifiers: 0x04000000 }, down), 'Ctrl+N matches the same action')
+assert(keymap.matches({ key: 74, modifiers: 0x04000000 }, down), 'Ctrl+J matches the same action')
+assert(!keymap.matches({ key: 80, modifiers: 0x04000000 }, down), 'Ctrl+P does not match the down action')
+
+// Exact modifier equality keeps bare letters falling through to the filter and
+// stops Ctrl+Shift+N stealing a Ctrl+N binding.
+assert(!keymap.matches({ key: 78, modifiers: 0 }, down), 'a bare letter does not match a Ctrl binding')
+assert(
+  !keymap.matches({ key: 78, modifiers: 0x04000000 | 0x02000000 }, down),
+  'an extra modifier does not match'
+)
+// Qt tags keypad keys with KeypadModifier and layout-group keys with
+// GroupSwitchModifier. Neither is something a user can write in a spec, so
+// they must not stop numpad Enter or keypad arrows matching their plain names.
+assert(
+  keymap.matches({ key: 0x01000005, modifiers: 0x20000000 }, ['Enter']),
+  'numpad Enter matches a plain Enter binding'
+)
+assert(
+  keymap.matches({ key: 0x01000013, modifiers: 0x20000000 }, ['Up']),
+  'a keypad arrow matches a plain arrow binding'
+)
+assert(
+  keymap.matches({ key: 78, modifiers: 0x04000000 | 0x40000000 }, down),
+  'a layout-group flag does not stop Ctrl+N matching'
+)
+assert(
+  !keymap.matches({ key: 0x01000005, modifiers: 0x20000000 | 0x04000000 }, ['Enter']),
+  'a keypad key with a real modifier still needs that modifier in the spec'
+)
+// Shift+Tab reaches Qt as Key_Backtab rather than Key_Tab, so the spec people
+// naturally write has to match the event they actually get.
+assert(
+  keymap.matches({ key: 0x01000002, modifiers: 0x02000000 }, ['Shift+Tab']),
+  'Shift+Tab matches the Backtab event Qt delivers for it'
+)
+assert(
+  keymap.matches({ key: 0x01000002, modifiers: 0x02000000 }, ['Backtab']),
+  'a bare Backtab spec matches the same event'
+)
+assert(
+  !keymap.matches({ key: 0x01000001, modifiers: 0 }, ['Shift+Tab']),
+  'plain Tab does not match Shift+Tab'
+)
+assert(keymap.matches({ key: 78, modifiers: 0x04000000 }, 'Ctrl+N'), 'a bare string is accepted as one binding')
+assert(!keymap.matches({ key: 78, modifiers: 0x04000000 }, null), 'no bindings never matches')
+
+const defaults = { up: ['Up'], down: ['Down'], close: ['Escape'] }
+
+assertDeepEqual(keymap.resolve(null, defaults), defaults, 'no user config returns the defaults')
+assertDeepEqual(
+  keymap.resolve({ down: ['Down', 'Ctrl+N'] }, defaults),
+  { up: ['Up'], down: ['Down', 'Ctrl+N'], close: ['Escape'] },
+  'overriding one action leaves the others intact'
+)
+assertDeepEqual(
+  keymap.resolve({ up: 'Ctrl+P' }, defaults),
+  { up: ['Ctrl+P'], down: ['Down'], close: ['Escape'] },
+  'a bare string overrides as a single binding'
+)
+assertDeepEqual(
+  keymap.resolve({ close: [] }, defaults),
+  { up: ['Up'], down: ['Down'], close: [] },
+  'an empty list unbinds an action'
+)
+assertDeepEqual(
+  keymap.resolve({ down: [null, 'Ctrl+N', ''] }, defaults),
+  { up: ['Up'], down: ['Ctrl+N'], close: ['Escape'] },
+  'non-string entries are dropped'
+)
+
+const frozen = { up: ['Up'] }
+keymap.resolve({}, frozen).up.push('Ctrl+P')
+assertDeepEqual(frozen, { up: ['Up'] }, 'resolve copies the defaults instead of aliasing them')
+JS

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -484,8 +484,28 @@ assert(
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
-  /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
-  'menu Left key follows empty-filter Backspace navigation'
+  /Keymap\.matches\(event, root\.keymap\.back\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
+  'menu back navigation is still gated on an empty filter'
+)
+assert(
+  /event\.key === Qt\.Key_Escape/.test(menuQml) && !/"close":/.test(menuQml) && !/keymap\.close/.test(menuQml),
+  'menu keeps Escape hardcoded so no binding can shadow the way out'
+)
+assert(
+  menuQml.indexOf('event.key === Qt.Key_Escape') < menuQml.indexOf('Keymap.matches(event, root.keymap.'),
+  'menu checks Escape before any rebindable action'
+)
+assert(
+  menuQml.indexOf('Util.editsFilter(event, root.filterText)') < menuQml.indexOf('Keymap.matches(event, root.keymap.'),
+  'menu lets a non-empty filter edit before any rebindable action can claim the key'
+)
+assert(
+  /"back":\s*\[[^\]]*"Left"[^\]]*"Backspace"/.test(menuQml),
+  'menu keeps Left and Backspace bound to back by default'
+)
+assert(
+  /"down":\s*\[[^\]]*"Down"/.test(menuQml) && /"up":\s*\[[^\]]*"Up"/.test(menuQml),
+  'menu keeps the arrow keys bound to list movement by default'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),

--- a/test/shell.d/plugin-clone-test.sh
+++ b/test/shell.d/plugin-clone-test.sh
@@ -191,3 +191,16 @@ fi
 [[ ! -e $TMPDIR/home/.config/omarchy/plugins/tester.osd ]] ||
   fail "failed clone discovery leaves a partial clone behind"
 pass "clone removes a partial clone when switching fails"
+
+# A clone copies only the plugin's own directory, so a relative import that
+# climbs out of it (import "../../Commons/X.js") has nothing to resolve against
+# once cloned. Shared code has to come through a qs.* module instead.
+escaping=""
+while IFS=: read -r file _ target; do
+  plugin_root=$(realpath --relative-to="$ROOT/shell/plugins" "$file" | cut -d/ -f1)
+  resolved=$(realpath -m "$(dirname "$file")/$target")
+  [[ $resolved == "$ROOT/shell/plugins/$plugin_root/"* ]] ||
+    escaping+="$file imports $target"$'\n'
+done < <(rg -on --no-heading 'import\s+"(\.\./[^"]+)"' -r '$1' "$ROOT/shell/plugins" -g '*.qml' -g '*.js' || true)
+[[ -z $escaping ]] || fail "plugin files import outside their plugin directory:"$'\n'"$escaping"
+pass "plugins only import shared code through qs.* modules"


### PR DESCRIPTION
**TLDR:**

This PR makes Omarchy menu navigation keymaps configurable via a config file.
In addition to the default arrow keys, it also adds vim-style `Ctrl-n`/`Ctrl+p` for down/up (so you can navigate while search can still be typed into).
It also adds Ctrl+h/j/k/l (includes back and forward) as some people prefer that.

Not all keyboards have arrow keys, and while the mouse _does_ work in the Omarchy menu, needing to use the mouse is a bit of a pain point.

---

**Claude Description:**

The menu has a typable search field, so the established convention is that Ctrl+N/Ctrl+P also move the selection — readline-style, as in shells, fzf, and editor completion popups — since your hands are already on the home row (and not every keyboard has easy arrows). This PR adds those, plus Ctrl+J/Ctrl+K for down/up and Ctrl+H/Ctrl+L for back/activate as a nod to vim-style pickers (LazyVim's completion menus use Ctrl+J/Ctrl+K, for example). The arrows and every other existing key still work exactly as before.

Rather than growing the hardcoded `else if (event.key === Qt.Key_Up)` chain in `Menu.qml`, the chain is replaced with a small keymap layer: each action takes a list of bindings, and the list can be overridden from `shell.json`. Adding another binding is now a config line, not a code change.

## Defaults

| Action | Bindings |
|---|---|
| `up` | Up, Ctrl+P, Ctrl+K |
| `down` | Down, Ctrl+N, Ctrl+J |
| `pageUp` / `pageDown` | PageUp / PageDown |
| `back` | Left, Backspace, Ctrl+H |
| `activate` | Return, Enter, Right, Ctrl+L |
| `remove` | Delete |

## Configuration

```json
"keys": {
  "menu": {
    "down": ["Down", "Ctrl+N", "Ctrl+J"],
    "up": ["Up", "Ctrl+P", "Ctrl+K"]
  }
}
```

Resolution is per action against the panel's defaults, so naming one action doesn't unbind the others. `[]` unbinds an action; modifiers are Ctrl/Shift/Alt/Super. Escape always closes the menu and isn't rebindable. The seven existing actions can be rebound freely — inventing a new action still needs code.

## Implementation notes

- `shell/Commons/Keymap.js` (~120 lines, `.pragma library`): `keyCode`, `parse`, `matches`, `resolve`. Plain JS follows the shell's existing convention (27 `.js` logic files already, e.g. `Commons/BorderGeometry.js`) and lets `run_node_test` exercise it directly in Node.

- Modifiers match exactly, so Ctrl+Shift+N never fires a Ctrl+N binding and bare letters still fall through to the filter.
- An unknown key name in `shell.json` disables that one binding rather than throwing.
- `Util.editsFilter` still runs before the keymap: typing filters, and Backspace edits a non-empty filter — `back` only claims it once the filter is empty.

## Backwards compatibility

No behaviour change for anyone who changes nothing: the shipped `config/omarchy/shell.json` is untouched (defaults live in `Menu.qml`), all pre-existing bindings work identically, and the Ctrl bindings are purely additive.

## Testing

- New `test/shell.d/keymap-test.sh`: 33 assertions covering parsing, exact-modifier matching, keypad and Shift+Tab (Backtab) events, per-action merge, bare-string specs, `[]` unbinding, and unknown names. Qt key/modifier codes are pinned to values captured from live key events.
- `test/shell.d/menu-test.sh` updated for the removed hardcoded chain, plus assertions that the defaults keep Left/Backspace and the arrows.
- `test/shell.d/plugin-clone-test.sh` now fails on any plugin import that escapes its plugin directory, since a clone copies only that directory.

Docs: `docs/omarchy-shell.md` gains the `keys` rule and example. `manual/04-navigation.md` gains a "Moving around the Omarchy menu" section covering the default keys, how to override an action, and — since `shell.json` doesn't deep-merge — that the block goes into an existing file rather than replacing it. A second example adds vim's `Ctrl+D`/`Ctrl+U` paging, which isn't bound by default, to show the mechanism doing something the defaults don't.

Only the menu is wired up here. The clipboard, emoji, tailscale and weather panels and the shared `Ui/` dropdown/multi-select have the same hardcoded chains; `Keymap.js` lives in `Commons/` so they can adopt it later, but this PR deliberately leaves them alone.

