### PR TITLE
Notifications: clicking a toast focuses the exact sending window when focus_on_activate is off

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
+import Quickshell.Hyprland
 import Quickshell.Services.Notifications
 import qs.Commons
 
@@ -392,8 +393,45 @@ Item {
     // libnotify action — they just expect clicking the notification to
     // focus their window. Fall back to focusing the sending app by class so
     // that click-to-jump actually works.
-    if (!invoked) focusApp(entry)
+    //
+    // When the sender does have a default action it usually answers with an
+    // xdg-activation request. With misc:focus_on_activate=false Hyprland
+    // denies that request but still emits `urgent>>ADDR` for the exact window
+    // that asked. Catch that for a moment after the click and focus by address
+    // — precise even when the app owns many windows (terminals, editors). If
+    // no urgent event arrives, fall back to the class match as before.
+    if (invoked) armUrgentFocus(entry)
+    else focusApp(entry)
     dismissPopup(index)
+  }
+
+  property var urgentFocusEntry: null
+  function armUrgentFocus(entry) {
+    // Plain copy: dismissPopup() deletes the model row right after this and
+    // QML nulls `var` references to destroyed objects.
+    urgentFocusEntry = { app: String(entry && entry.app ? entry.app : "") }
+    urgentFocusTimer.restart()
+  }
+  Timer {
+    id: urgentFocusTimer
+    interval: 1000
+    repeat: false
+    onTriggered: {
+      var entry = service.urgentFocusEntry
+      service.urgentFocusEntry = null
+      if (entry) service.focusApp(entry)
+    }
+  }
+  Connections {
+    target: Hyprland
+    function onRawEvent(event) {
+      if (!service.urgentFocusEntry || !event || String(event.name) !== "urgent") return
+      var addr = String(event.data || "").trim()
+      if (!addr) return
+      service.urgentFocusEntry = null
+      urgentFocusTimer.stop()
+      Hyprland.dispatch('hl.dsp.focus({ window = "address:0x' + addr.replace(/^0x/, "") + '" })')
+    }
   }
 
   // Try to focus an existing Hyprland window matching the notification's

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -406,6 +406,39 @@ Item {
   }
 
   property var urgentFocusEntry: null
+
+  // Same match omarchy-hyprland-focus-app uses: class, then agent-terminal title.
+  function ipcClassMatches(toplevel, app) {
+    if (!toplevel || !app) return false
+    var ipc = toplevel.lastIpcObject || {}
+    var pattern = String(app)
+    var re
+    try { re = new RegExp(pattern, "i") } catch (e) { re = null }
+    function matches(value) {
+      var text = String(value || "")
+      if (re) return re.test(text)
+      return text.toLowerCase().indexOf(pattern.toLowerCase()) !== -1
+    }
+    if (matches(ipc["class"])) return true
+    if (ipc["initialClass"] === "org.omarchy.agent" && matches(ipc["initialTitle"])) return true
+    return false
+  }
+
+  function toplevelByAddress(addr) {
+    var want = String(addr || "").replace(/^0x/i, "").toLowerCase()
+    if (!want || !Hyprland.toplevels) return null
+    var values = Hyprland.toplevels.values
+    for (var i = 0; i < values.length; i++) {
+      var have = String(values[i].address || "").replace(/^0x/i, "").toLowerCase()
+      if (have === want) return values[i]
+    }
+    return null
+  }
+
+  function senderAlreadyFocused(entry) {
+    return !!(entry && ipcClassMatches(Hyprland.activeToplevel, entry.app))
+  }
+
   function armUrgentFocus(entry) {
     // Plain copy: dismissPopup() deletes the model row right after this and
     // QML nulls `var` references to destroyed objects.
@@ -419,7 +452,9 @@ Item {
     onTriggered: {
       var entry = service.urgentFocusEntry
       service.urgentFocusEntry = null
-      if (entry) service.focusApp(entry)
+      // Hyprland 0.56 skips the urgent event when the requested window is
+      // already focused. Do not then class-match onto a sibling window.
+      if (entry && !service.senderAlreadyFocused(entry)) service.focusApp(entry)
     }
   }
   Connections {
@@ -428,9 +463,11 @@ Item {
       if (!service.urgentFocusEntry || !event || String(event.name) !== "urgent") return
       var addr = String(event.data || "").trim()
       if (!addr) return
+      var win = service.toplevelByAddress(addr)
+      if (!win || !service.ipcClassMatches(win, service.urgentFocusEntry.app)) return
       service.urgentFocusEntry = null
       urgentFocusTimer.stop()
-      Hyprland.dispatch('hl.dsp.focus({ window = "address:0x' + addr.replace(/^0x/, "") + '" })')
+      Hyprland.dispatch('hl.dsp.focus({ window = "address:0x' + addr.replace(/^0x/i, "") + '" })')
     }
   }
 


### PR DESCRIPTION
## Problem

With `misc:focus_on_activate = false` (common for people who hate focus stealing), clicking a notification toast often does nothing: the sender's default action fires an xdg-activation request, Hyprland denies it, and the existing class-match fallback never runs because `invoked` is true. For apps with many windows (kitty running several agents, editors) nothing moves.

## Fix

Hyprland still emits `urgent>>ADDR` for the exact window that asked for activation. On click, arm a 1 s listener on `Hyprland.rawEvent`; when the urgent event lands, focus that window by address with `hl.dsp.focus({ window = "address:0x…" })` (same dispatcher `omarchy-hyprland-focus-app` uses). If no urgent event arrives (app never requested activation), fall back to the class match exactly as before.

39 lines, one file (`shell/plugins/notifications/Service.qml`), no new dependencies beyond `Quickshell.Hyprland`.

## Tested

Omarchy 4.0.0 / Hyprland 0.56 with `focus_on_activate=false`: notifications from kitty (multiple windows), Chromium web apps and libnotify now jump to the precise window on click; with `focus_on_activate=true` behaviour is unchanged (activation wins, listener is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D411mB4n7uBWNSvTJkpmJa