### PR TITLE
Keep Spotify volume across track changes

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -233,6 +233,41 @@ function streamRepresentsPlayer(node, player, players, streams) {
   return streamRepresentsMprisPlayer(streamLabel(node, players, streams), playerLabel)
 }
 
+function mprisPlayerForStream(node, players, streams) {
+  var values = Array.isArray(players) ? players : []
+  var candidate = null
+  var proxyCandidate = null
+
+  for (var i = 0; i < values.length; i++) {
+    var player = values[i]
+    if (!streamRepresentsPlayer(node, player, values, streams)) continue
+
+    if (mprisPlayerIsProxy(player)) {
+      if (!proxyCandidate || player.isPlaying) proxyCandidate = player
+    } else if (!candidate || player.isPlaying) {
+      candidate = player
+    }
+  }
+
+  return candidate || proxyCandidate
+}
+
+function playerControlsVolume(player) {
+  return !!(player && player.canControl && player.volumeSupported)
+}
+
+function streamVolume(node, player) {
+  if (playerControlsVolume(player) && typeof player.volume === "number") return player.volume
+  return node && node.audio && typeof node.audio.volume === "number" ? node.audio.volume : 0
+}
+
+function setStreamVolume(node, player, volume) {
+  var nextVolume = Math.max(0, Math.min(1.5, volume))
+  if (playerControlsVolume(player)) player.volume = nextVolume
+  if (node && node.audio) node.audio.volume = nextVolume
+  return nextVolume
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isPlaybackStream: isPlaybackStream,
@@ -257,6 +292,10 @@ if (typeof module !== "undefined") {
     matchingMprisStreamLabel: matchingMprisStreamLabel,
     unmatchedMprisStreamLabel: unmatchedMprisStreamLabel,
     streamLabel: streamLabel,
-    streamRepresentsPlayer: streamRepresentsPlayer
+    streamRepresentsPlayer: streamRepresentsPlayer,
+    mprisPlayerForStream: mprisPlayerForStream,
+    playerControlsVolume: playerControlsVolume,
+    streamVolume: streamVolume,
+    setStreamVolume: setStreamVolume
   }
 }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -282,7 +282,7 @@ Panel {
     }
     if (focusSection === "streams" && selectedIndex >= 0 && selectedIndex < displayAudioStreams.length) {
       var s = displayAudioStreams[selectedIndex]
-      if (s && s.audio) s.audio.volume = Math.max(0, Math.min(1.5, s.audio.volume + delta))
+      if (s && s.audio) setStreamVolume(s, streamVolume(s) + delta)
     }
   }
 
@@ -568,6 +568,18 @@ Panel {
 
   function streamRepresentsPlayer(node, player) {
     return Model.streamRepresentsPlayer(node, player, mprisPlayers, displayAudioStreams)
+  }
+
+  function mprisPlayerForStream(node) {
+    return Model.mprisPlayerForStream(node, mprisPlayers, displayAudioStreams)
+  }
+
+  function streamVolume(node) {
+    return Model.streamVolume(node, mprisPlayerForStream(node))
+  }
+
+  function setStreamVolume(node, volume) {
+    return Model.setStreamVolume(node, mprisPlayerForStream(node), volume)
   }
 
   implicitWidth: button.implicitWidth
@@ -1132,7 +1144,8 @@ Panel {
     required property var node
     required property int rowIndex
 
-    readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
+    readonly property var mediaPlayer: root.mprisPlayerForStream(node)
+    readonly property real streamVolume: Model.streamVolume(node, mediaPlayer)
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
     readonly property bool isActive: root.streamRepresentsPlayer(node, root.activeMediaPlayer)
 
@@ -1213,7 +1226,7 @@ Panel {
         opacity: streamRow.streamMuted ? 0.5 : 1.0
 
         onMoved: function(v) {
-          if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
+          root.setStreamVolume(streamRow.node, v)
         }
         onRightClicked: {
           if (streamRow.node && streamRow.node.audio)

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -46,4 +46,21 @@ assertEqual(audio.matchingMprisStreamLabel('Chromium', players), 'Chromium', 'au
 assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spotify', 'audio uses unmatched MPRIS player for generic streams')
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
+
+players[0].canControl = true
+players[0].volumeSupported = true
+players[0].volume = 0.39
+streams[1].audio = { volume: 0.8 }
+
+assertEqual(audio.mprisPlayerForStream(streams[1], players, streams), players[0], 'audio finds the MPRIS player for a stream')
+assertEqual(audio.streamVolume(streams[1], players[0]), 0.39, 'audio reads persistent player volume when available')
+assertEqual(audio.setStreamVolume(streams[1], players[0], 0.65), 0.65, 'audio returns the updated stream volume')
+assertEqual(players[0].volume, 0.65, 'audio updates persistent player volume')
+assertEqual(streams[1].audio.volume, 0.65, 'audio updates live stream volume')
+
+const unsupportedPlayer = { canControl: true, volumeSupported: false, volume: 0.2 }
+assertEqual(audio.streamVolume(streams[1], unsupportedPlayer), 0.65, 'audio falls back to live stream volume')
+audio.setStreamVolume(streams[1], unsupportedPlayer, 0.5)
+assertEqual(unsupportedPlayer.volume, 0.2, 'audio leaves unsupported player volume unchanged')
+assertEqual(streams[1].audio.volume, 0.5, 'audio still updates streams without player volume support')
 JS


### PR DESCRIPTION
## What changed

- Update both the media player volume and its live audio stream.
- Keep the current behavior for apps that do not support player volume.
- Cover mouse and keyboard volume changes with tests.

## Why

Spotify keeps its own volume. The audio panel changed only the current stream, so Spotify restored the old value when the next track started.

Fixes #7741

## Tests

- `bash test/shell.d/audio-test.sh` passes.
- The audio and runtime checks in `./test/all` pass. The full suite still reports four unrelated local setup checks: display geometry and a missing `omarchy-pkgs` checkout.