### PR TITLE
Keep Spotify volume across track changes

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -19,7 +19,12 @@ function isAudioSource(node) {
 }
 
 function listSnapshot(list) {
-  return list && list.slice ? list.slice() : []
+  if (!list) return []
+  if (list.slice) return list.slice()
+
+  var values = []
+  for (var i = 0; i < Number(list.length || 0); i++) values.push(list[i])
+  return values
 }
 
 function outputVolumeName(volume, muted) {
@@ -163,7 +168,7 @@ function streamRepresentsMprisPlayer(streamLabel, playerLabel) {
 }
 
 function mprisLabelsFor(players, predicate) {
-  var values = Array.isArray(players) ? players : []
+  var values = listSnapshot(players)
   var playingCandidates = []
   var candidates = []
   var playingProxyCandidates = []
@@ -204,7 +209,7 @@ function unmatchedMprisStreamLabel(label, players, streams) {
   if (!streamLabelIsGeneric(label)) return ""
 
   return mprisLabelsFor(players, function(playerLabel) {
-    var values = Array.isArray(streams) ? streams : []
+    var values = listSnapshot(streams)
     for (var i = 0; i < values.length; i++) {
       var stream = values[i]
       var streamLabel = rawStreamLabel(stream)
@@ -233,6 +238,41 @@ function streamRepresentsPlayer(node, player, players, streams) {
   return streamRepresentsMprisPlayer(streamLabel(node, players, streams), playerLabel)
 }
 
+function mprisPlayerForStream(node, players, streams) {
+  var values = listSnapshot(players)
+  var candidate = null
+  var proxyCandidate = null
+
+  for (var i = 0; i < values.length; i++) {
+    var player = values[i]
+    if (!streamRepresentsPlayer(node, player, values, streams)) continue
+
+    if (mprisPlayerIsProxy(player)) {
+      if (!proxyCandidate || player.isPlaying) proxyCandidate = player
+    } else if (!candidate || player.isPlaying) {
+      candidate = player
+    }
+  }
+
+  return candidate || proxyCandidate
+}
+
+function playerControlsVolume(player) {
+  return !!(player && player.canControl && player.volumeSupported)
+}
+
+function streamVolume(node, player) {
+  if (playerControlsVolume(player) && typeof player.volume === "number") return player.volume
+  return node && node.audio && typeof node.audio.volume === "number" ? node.audio.volume : 0
+}
+
+function setStreamVolume(node, player, volume) {
+  var nextVolume = Math.max(0, Math.min(1.5, volume))
+  if (playerControlsVolume(player)) player.volume = nextVolume
+  if (node && node.audio) node.audio.volume = nextVolume
+  return nextVolume
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isPlaybackStream: isPlaybackStream,
@@ -257,6 +297,10 @@ if (typeof module !== "undefined") {
     matchingMprisStreamLabel: matchingMprisStreamLabel,
     unmatchedMprisStreamLabel: unmatchedMprisStreamLabel,
     streamLabel: streamLabel,
-    streamRepresentsPlayer: streamRepresentsPlayer
+    streamRepresentsPlayer: streamRepresentsPlayer,
+    mprisPlayerForStream: mprisPlayerForStream,
+    playerControlsVolume: playerControlsVolume,
+    streamVolume: streamVolume,
+    setStreamVolume: setStreamVolume
   }
 }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -282,7 +282,7 @@ Panel {
     }
     if (focusSection === "streams" && selectedIndex >= 0 && selectedIndex < displayAudioStreams.length) {
       var s = displayAudioStreams[selectedIndex]
-      if (s && s.audio) s.audio.volume = Math.max(0, Math.min(1.5, s.audio.volume + delta))
+      if (s && s.audio) setStreamVolume(s, streamVolume(s) + delta)
     }
   }
 
@@ -568,6 +568,18 @@ Panel {
 
   function streamRepresentsPlayer(node, player) {
     return Model.streamRepresentsPlayer(node, player, mprisPlayers, displayAudioStreams)
+  }
+
+  function mprisPlayerForStream(node) {
+    return Model.mprisPlayerForStream(node, mprisPlayers, displayAudioStreams)
+  }
+
+  function streamVolume(node) {
+    return Model.streamVolume(node, mprisPlayerForStream(node))
+  }
+
+  function setStreamVolume(node, volume) {
+    return Model.setStreamVolume(node, mprisPlayerForStream(node), volume)
   }
 
   implicitWidth: button.implicitWidth
@@ -1132,7 +1144,8 @@ Panel {
     required property var node
     required property int rowIndex
 
-    readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
+    readonly property var mediaPlayer: root.mprisPlayerForStream(node)
+    readonly property real streamVolume: Model.streamVolume(node, mediaPlayer)
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
     readonly property bool isActive: root.streamRepresentsPlayer(node, root.activeMediaPlayer)
 
@@ -1213,7 +1226,7 @@ Panel {
         opacity: streamRow.streamMuted ? 0.5 : 1.0
 
         onMoved: function(v) {
-          if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
+          root.setStreamVolume(streamRow.node, v)
         }
         onRightClicked: {
           if (streamRow.node && streamRow.node.audio)

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -46,4 +46,23 @@ assertEqual(audio.matchingMprisStreamLabel('Chromium', players), 'Chromium', 'au
 assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spotify', 'audio uses unmatched MPRIS player for generic streams')
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
+
+players[0].canControl = true
+players[0].volumeSupported = true
+players[0].volume = 0.39
+streams[1].audio = { volume: 0.8 }
+
+assertEqual(audio.mprisPlayerForStream(streams[1], players, streams), players[0], 'audio finds the MPRIS player for a stream')
+const qmlPlayerList = { 0: players[0], length: 1 }
+assertEqual(audio.mprisPlayerForStream(streams[1], qmlPlayerList, streams), players[0], 'audio reads Quickshell array-like player lists')
+assertEqual(audio.streamVolume(streams[1], players[0]), 0.39, 'audio reads persistent player volume when available')
+assertEqual(audio.setStreamVolume(streams[1], players[0], 0.65), 0.65, 'audio returns the updated stream volume')
+assertEqual(players[0].volume, 0.65, 'audio updates persistent player volume')
+assertEqual(streams[1].audio.volume, 0.65, 'audio updates live stream volume')
+
+const unsupportedPlayer = { canControl: true, volumeSupported: false, volume: 0.2 }
+assertEqual(audio.streamVolume(streams[1], unsupportedPlayer), 0.65, 'audio falls back to live stream volume')
+audio.setStreamVolume(streams[1], unsupportedPlayer, 0.5)
+assertEqual(unsupportedPlayer.volume, 0.2, 'audio leaves unsupported player volume unchanged')
+assertEqual(streams[1].audio.volume, 0.5, 'audio still updates streams without player volume support')
 JS

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -55,6 +55,7 @@ streams[1].audio = { volume: 0.8 }
 assertEqual(audio.mprisPlayerForStream(streams[1], players, streams), players[0], 'audio finds the MPRIS player for a stream')
 const qmlPlayerList = { 0: players[0], length: 1 }
 assertEqual(audio.mprisPlayerForStream(streams[1], qmlPlayerList, streams), players[0], 'audio reads Quickshell array-like player lists')
+assertEqual(audio.streamLabel(streams[1], qmlPlayerList, streams), 'Spotify', 'audio labels generic streams from array-like player lists')
 assertEqual(audio.streamVolume(streams[1], players[0]), 0.39, 'audio reads persistent player volume when available')
 assertEqual(audio.setStreamVolume(streams[1], players[0], 0.65), 0.65, 'audio returns the updated stream volume')
 assertEqual(players[0].volume, 0.65, 'audio updates persistent player volume')


### PR DESCRIPTION
## Problem

Changing Spotify’s volume in the audio panel worked only for the current song. When the next song started, the volume returned to Spotify’s previous value.

## Cause

The panel updated the temporary PipeWire audio stream, but Spotify also keeps its own saved player volume. Spotify restored that saved value when the track changed.

## Fix

When an audio stream belongs to a media player, the panel now updates both values:

- the player’s saved volume
- the current PipeWire stream volume

Apps that do not provide their own volume control continue to work as before.

Fixes #7741

## Verified

- The focused audio tests pass, including Quickshell’s array-like player list.
- Live Spotify test: changed volume from 60% to 65% in the panel, skipped to a different track, and both values stayed at 65%.

Test command: `bash test/shell.d/audio-test.sh`