### PR TITLE
Add themed Voxtype dictation OSD (On-Screen Display)

### DIFF
--- a/default/voxtype/config.toml
+++ b/default/voxtype/config.toml
@@ -90,6 +90,10 @@ on_recording_stop = false
 # Show notification with transcribed text after transcription completes
 on_transcription = false
 
+[osd]
+# Omarchy Shell provides a themed dictation OSD from the same state stream.
+enabled = false
+
 # [text]
 # Text processing options (word replacements, spoken punctuation)
 #

--- a/migrations/1787257711.sh
+++ b/migrations/1787257711.sh
@@ -1,0 +1,64 @@
+echo "Use Omarchy Shell for the Voxtype dictation OSD"
+
+config="$HOME/.config/voxtype/config.toml"
+
+[[ -f $config ]] || exit 0
+
+changed=$(python3 - "$config" <<'PY'
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    text = path.read_text(encoding="utf-8")
+    data = tomllib.loads(text)
+except (OSError, tomllib.TOMLDecodeError):
+    sys.exit(0)
+
+osd = data.get("osd")
+if isinstance(osd, dict) and "enabled" in osd:
+    sys.exit(0)
+if osd is not None and not isinstance(osd, dict):
+    sys.exit(0)
+
+
+def disables_osd(candidate):
+    try:
+        migrated_osd = tomllib.loads(candidate).get("osd")
+        return isinstance(migrated_osd, dict) and migrated_osd.get("enabled") is False
+    except tomllib.TOMLDecodeError:
+        return False
+
+
+header = re.search(r'''(?m)^[ \t]*\[[ \t]*(?:osd|"osd"|'osd')[ \t]*\][ \t]*(?:#.*)?$''', text)
+if header:
+    candidate = text[:header.end()] + "\nenabled = false" + text[header.end():]
+elif "osd" not in data:
+    candidate = text.rstrip("\n") + "\n\n[osd]\nenabled = false\n"
+else:
+    first_table = re.search(r'''(?m)^[ \t]*\[''', text)
+    root_end = first_table.start() if first_table else len(text)
+    inline = re.search(r'''(?m)^[ \t]*(?:osd|"osd"|'osd')[ \t]*=[ \t]*\{''', text[:root_end])
+
+    if inline:
+        value_start = inline.end() + len(re.match(r'''[ \t]*''', text[inline.end():]).group())
+        separator = "" if text[value_start:value_start + 1] == "}" else ", "
+        candidate = text[:value_start] + "enabled = false" + separator + text[value_start:]
+    elif first_table:
+        candidate = text[:root_end] + "osd.enabled = false\n" + text[root_end:]
+    else:
+        candidate = text.rstrip("\n") + "\nosd.enabled = false\n"
+
+if not disables_osd(candidate):
+    sys.exit(0)
+
+path.write_text(candidate, encoding="utf-8")
+print("yes")
+PY
+)
+
+[[ $changed == "yes" ]] || exit 0
+
+systemctl --user try-restart voxtype.service 2>/dev/null || true

--- a/shell/plugins/README.md
+++ b/shell/plugins/README.md
@@ -33,6 +33,7 @@ User-installed plugins live alongside these conceptually but on disk under
 | Battery       | `omarchy.battery`         | `service`               | `services/battery/Service.qml`        |
 | Idle          | `omarchy.idle`            | `service`               | `services/idle/Service.qml`           |
 | Night light   | `omarchy.nightlight`      | `service`               | `services/nightlight/Service.qml`     |
+| Voxtype       | `omarchy.voxtype`         | `service`               | `services/voxtype/Service.qml`        |
 | Lock screen   | `omarchy.lock`            | `service`               | `lock/Service.qml`                    |
 | OSD           | `omarchy.osd`             | `panel`                 | `osd/Osd.qml`                         |
 | Polkit agent  | `omarchy.polkit`          | `service`               | `polkit/PolkitAgent.qml`              |

--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -1,35 +1,18 @@
 import QtQuick
-import Quickshell.Io
 import qs.Ui
 
 BarIndicator {
   id: root
 
-  property string state: "idle"
-  property string icon: ""
+  readonly property var dictationService: bar?.shell?.firstPartyServiceFor("omarchy.voxtype")
+  readonly property string state: dictationService ? dictationService.state : "idle"
+  readonly property string icon: state === "transcribing" ? "󰔟" : "󰍬"
 
-  active: state === "recording"
+  active: dictationService ? dictationService.busy : false
   activeText: icon
   inactiveText: "󰍬"
   activeTooltipText: state
   inactiveTooltipText: "Dictate"
-
-  function update(raw) {
-    var data = extractData(raw)
-
-    state = String(data.alt || data.class || "idle")
-    if (state === "recording") icon = "󰍬"
-    else if (state === "transcribing") icon = "󰔟"
-    else icon = ""
-  }
-
-  Process {
-    command: ["bash", "-c", "omarchy-voxtype-status"]
-    running: true
-    stdout: SplitParser {
-      onRead: function(data) { root.update(data) }
-    }
-  }
 
   onPressed: function() {
     if (!root.bar) return

--- a/shell/plugins/osd/DictationCard.qml
+++ b/shell/plugins/osd/DictationCard.qml
@@ -1,0 +1,149 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+BorderSurface {
+  id: root
+
+  property var dictation: null
+  property bool opened: false
+
+  readonly property bool transcribing: dictation && dictation.transcribing
+  readonly property int gap: Style.spacing.xl
+
+  width: Style.space(320)
+  height: Style.space(54)
+  radius: Style.cornerRadius
+  color: Util.alpha(Color.background, 0.97)
+  borderSpec: Border.surfaceSpec("popups", "border", Color.popups.border, Math.max(1, Style.space(2)))
+  opacity: opened ? 1 : 0
+  scale: opened ? 1 : 0.98
+
+  Behavior on opacity {
+    NumberAnimation { duration: 180; easing.type: Easing.OutQuad }
+  }
+
+  Behavior on scale {
+    NumberAnimation { duration: 180; easing.type: Easing.OutQuad }
+  }
+
+  Row {
+    anchors.centerIn: parent
+    spacing: root.gap
+
+    Text {
+      width: Style.space(18)
+      anchors.verticalCenter: parent.verticalCenter
+      horizontalAlignment: Text.AlignHCenter
+      text: root.transcribing ? "󰔟" : "󰍬"
+      color: root.transcribing ? Color.accent : Color.urgent
+      font.family: Style.font.family
+      font.pixelSize: Style.font.title
+    }
+
+    Text {
+      width: Style.space(84)
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.transcribing ? "Transcribing" : "Listening"
+      color: root.transcribing ? Util.alpha(Color.popups.text, 0.7) : Color.popups.text
+      font.family: Style.font.family
+      font.pixelSize: Style.font.bodySmall
+    }
+
+    Item {
+      width: root.transcribing ? Style.space(156) : Style.space(112)
+      height: Style.space(22)
+      anchors.verticalCenter: parent.verticalCenter
+
+      Behavior on width {
+        NumberAnimation { duration: 180; easing.type: Easing.OutQuad }
+      }
+
+      Canvas {
+        id: bars
+
+        anchors.fill: parent
+        visible: !root.transcribing
+
+        onPaint: {
+          var ctx = getContext("2d")
+          ctx.clearRect(0, 0, width, height)
+
+          var levels = root.dictation ? root.dictation.levels : []
+          var count = levels.length
+          if (count === 0) return
+
+          var barWidth = Style.spaceReal(3)
+          var gap = (width - count * barWidth) / (count - 1)
+          for (var i = 0; i < count; i++) {
+            var level = levels[i]
+            var barHeight = Math.max(Style.spaceReal(2), level * (height - Style.spaceReal(2)))
+            ctx.fillStyle = level > 0.85 ? Color.urgent : Color.accent
+            ctx.globalAlpha = 0.35 + level * 0.65
+            ctx.beginPath()
+            ctx.roundedRect(i * (barWidth + gap), height - barHeight, barWidth, barHeight, barWidth / 2, barWidth / 2)
+            ctx.fill()
+          }
+          ctx.globalAlpha = 1
+        }
+
+        Connections {
+          target: root.dictation
+          function onLevelsChanged() { bars.requestPaint() }
+        }
+
+        Connections {
+          target: Color
+          function onAccentChanged() { bars.requestPaint() }
+          function onUrgentChanged() { bars.requestPaint() }
+        }
+      }
+
+      Rectangle {
+        id: sweepTrack
+
+        width: parent.width
+        height: Style.space(3)
+        anchors.verticalCenter: parent.verticalCenter
+        radius: height / 2
+        color: Util.alpha(Color.popups.text, 0.09)
+        visible: root.transcribing
+        clip: true
+
+        Rectangle {
+          id: sweep
+
+          width: sweepTrack.width * 0.38
+          height: sweepTrack.height
+          radius: sweepTrack.radius
+          color: Color.accent
+
+          XAnimator on x {
+            running: root.transcribing
+            loops: Animation.Infinite
+            from: -sweep.width
+            to: sweepTrack.width
+            duration: 1150
+            easing.type: Easing.InOutQuad
+          }
+        }
+      }
+    }
+
+    Text {
+      visible: !root.transcribing
+      width: visible ? Style.space(34) : 0
+      anchors.verticalCenter: parent.verticalCenter
+      text: {
+        var elapsed = root.dictation ? root.dictation.elapsed : 0
+        var minutes = Math.floor(elapsed / 60)
+        var seconds = elapsed % 60
+        return minutes + ":" + (seconds < 10 ? "0" : "") + seconds
+      }
+      color: Util.alpha(Color.popups.text, 0.7)
+      font.family: Style.font.family
+      font.pixelSize: Style.font.bodySmall
+      horizontalAlignment: Text.AlignRight
+    }
+  }
+}

--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -9,6 +9,7 @@ import "OsdModel.js" as OsdModel
 Item {
   id: root
 
+  property var shell: null
   property bool opened: false
   property string icon: ""
   property string message: ""
@@ -17,6 +18,9 @@ Item {
   property int maxValue: 100
   property bool hasProgress: true
   property int duration: 1200
+
+  readonly property var dictation: shell ? shell.firstPartyServiceFor("omarchy.voxtype") : null
+  readonly property bool dictationOpened: dictation ? dictation.busy : false
 
   readonly property bool mediaOsd: iconKey.indexOf("media") === 0 || iconKey.indexOf("player") === 0
 
@@ -125,7 +129,7 @@ Item {
 
   PanelWindow {
     id: panel
-    visible: root.opened
+    visible: root.opened || root.dictationOpened
     anchors { top: true; bottom: true; left: true; right: true }
     color: "transparent"
     WlrLayershell.namespace: "omarchy-osd"
@@ -138,6 +142,7 @@ Item {
 
     BorderSurface {
       id: card
+      visible: root.opened
       width: card.borderLeft + root.pad + root.contentWidth + root.pad + card.borderRight
       height: card.borderTop + root.pad + Style.font.displayLarge + root.pad + card.borderBottom
       anchors.horizontalCenter: parent.horizontalCenter
@@ -199,6 +204,15 @@ Item {
           maximumLineCount: 1
         }
       }
+    }
+
+    DictationCard {
+      dictation: root.dictation
+      opened: root.dictationOpened && !root.opened
+      visible: opened
+      anchors.horizontalCenter: parent.horizontalCenter
+      anchors.bottom: parent.bottom
+      anchors.bottomMargin: Style.space(67)
     }
   }
 }

--- a/shell/plugins/services/voxtype/Service.qml
+++ b/shell/plugins/services/voxtype/Service.qml
@@ -1,0 +1,112 @@
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+
+  property string state: "idle"
+  readonly property bool capturing: state === "recording" || state === "streaming"
+  readonly property bool transcribing: state === "transcribing"
+  readonly property bool busy: capturing || transcribing
+
+  property int levelSlots: 22
+  property var levels: []
+  property real pendingPeak: 0
+  property double startedAt: 0
+  property int elapsed: 0
+
+  function resetLevels() {
+    var empty = []
+    for (var i = 0; i < levelSlots; i++) empty.push(0)
+    levels = empty
+    pendingPeak = 0
+  }
+
+  function updateStatus(raw) {
+    try {
+      var data = JSON.parse(String(raw || "").trim())
+      state = String(data.alt || data.class || "idle")
+    } catch (e) {
+    }
+  }
+
+  function updateAudio(raw) {
+    try {
+      var frame = JSON.parse(String(raw || "").trim())
+      if (typeof frame.peak === "number") pendingPeak = Math.max(pendingPeak, frame.peak)
+    } catch (e) {
+    }
+  }
+
+  Component.onCompleted: {
+    resetLevels()
+    statusProc.running = true
+  }
+
+  onCapturingChanged: {
+    if (capturing) {
+      startedAt = Date.now()
+      elapsed = 0
+      bridgeProc.running = true
+    } else {
+      bridgeRestart.stop()
+      bridgeProc.running = false
+      resetLevels()
+    }
+  }
+
+  Process {
+    id: statusProc
+    command: ["bash", "-c", "if omarchy-cmd-present voxtype; then exec omarchy-voxtype-status; else exit 127; fi"]
+    stdout: SplitParser {
+      onRead: function(data) { root.updateStatus(data) }
+    }
+    onExited: function(exitCode) {
+      root.state = "idle"
+      root.resetLevels()
+      if (exitCode !== 127) statusRestart.restart()
+    }
+  }
+
+  Timer {
+    id: statusRestart
+    interval: 1000
+    onTriggered: statusProc.running = true
+  }
+
+  Process {
+    id: bridgeProc
+    command: ["bash", "-c", "if omarchy-cmd-present voxtype-audio-bridge; then exec voxtype-audio-bridge; else exit 127; fi"]
+    stdout: SplitParser {
+      onRead: function(data) { root.updateAudio(data) }
+    }
+    onExited: function(exitCode) {
+      if (root.capturing && exitCode !== 127) bridgeRestart.restart()
+    }
+  }
+
+  Timer {
+    id: bridgeRestart
+    interval: 500
+    onTriggered: if (root.capturing) bridgeProc.running = true
+  }
+
+  Timer {
+    running: root.capturing
+    interval: 55
+    repeat: true
+    onTriggered: {
+      var next = root.levels.slice(1)
+      next.push(Math.max(0, Math.min(1, root.pendingPeak)))
+      root.levels = next
+      root.pendingPeak = 0
+    }
+  }
+
+  Timer {
+    running: root.capturing
+    interval: 250
+    repeat: true
+    onTriggered: root.elapsed = Math.floor((Date.now() - root.startedAt) / 1000)
+  }
+}

--- a/shell/plugins/services/voxtype/manifest.json
+++ b/shell/plugins/services/voxtype/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.voxtype",
+  "name": "Voxtype",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Voxtype dictation state and microphone levels.",
+  "kinds": [
+    "service"
+  ],
+  "entryPoints": {
+    "service": "Service.qml"
+  }
+}

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -42,11 +42,18 @@ ShellRoot {
   }
 
   QtObject {
+    id: dictationService
+    property string state: "idle"
+    readonly property bool busy: state === "recording" || state === "streaming" || state === "transcribing"
+  }
+
+  QtObject {
     id: mockShell
     function firstPartyServiceFor(id) {
       if (id === "omarchy.notifications") return notificationService
       if (id === "omarchy.idle") return idleService
       if (id === "omarchy.nightlight") return nightlightService
+      if (id === "omarchy.voxtype") return dictationService
       return null
     }
   }
@@ -202,6 +209,12 @@ ShellRoot {
       if (dictation) {
         dictation.moduleName = "Dictation"
         root.injectBar(dictation)
+        dictationService.state = "recording"
+        root.assertTrue(dictation.active === true, "Dictation activates while recording")
+        dictationService.state = "transcribing"
+        root.assertTrue(dictation.active === true && dictation.icon === "󰔟", "Dictation stays active while transcribing")
+        dictationService.state = "idle"
+        root.assertTrue(dictation.active === false, "Dictation deactivates when idle")
         dictation.triggerPress(Qt.LeftButton)
         dictation.triggerPress(Qt.RightButton)
         root.assertTrue(root.commandCount("omarchy-voxtype-config") === 2, "Dictation clicks run config command")

--- a/test/shell.d/fixtures/voxtype-service/shell.qml
+++ b/test/shell.d/fixtures/voxtype-service/shell.qml
@@ -1,0 +1,108 @@
+import QtQuick
+import Quickshell
+
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
+  property var service: null
+  property var failures: []
+  property var states: []
+  property real maxLevel: 0
+  property bool levelsReset: false
+  property bool resultWritten: false
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function allLevelsReset() {
+    if (!service || service.levels.length !== service.levelSlots) return false
+    for (var i = 0; i < service.levels.length; i++) {
+      if (service.levels[i] !== 0) return false
+    }
+    return true
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    if (resultWritten) return
+    resultWritten = true
+
+    assertTrue(states.join(",") === "recording,idle,transcribing", "status stream ignores malformed input and recovers")
+    assertTrue(maxLevel >= 0.79, "audio JSON accumulates peak levels")
+    assertTrue(levelsReset, "levels reset when capture ends")
+    assertTrue(service && service.transcribing && service.busy, "transcribing state remains busy")
+
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures,
+      states: states,
+      maxLevel: maxLevel,
+      levelsReset: levelsReset
+    })
+    Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+  }
+
+  Item { id: host }
+
+  Connections {
+    target: root.service
+
+    function onStateChanged() {
+      root.states.push(root.service.state)
+      if (root.service.state === "idle" && root.states.indexOf("recording") !== -1) resetCheck.restart()
+      if (root.service.state === "transcribing") finishCheck.restart()
+    }
+
+    function onLevelsChanged() {
+      for (var i = 0; i < root.service.levels.length; i++) {
+        root.maxLevel = Math.max(root.maxLevel, root.service.levels[i])
+      }
+    }
+  }
+
+  Timer {
+    id: resetCheck
+    interval: 1
+    onTriggered: root.levelsReset = root.allLevelsReset()
+  }
+
+  Timer {
+    id: finishCheck
+    interval: 100
+    onTriggered: root.writeResult()
+  }
+
+  Timer {
+    interval: 6000
+    running: true
+    onTriggered: {
+      root.fail("Voxtype service test timed out")
+      root.writeResult()
+    }
+  }
+
+  Component.onCompleted: {
+    var component = Qt.createComponent("file://" + rootPath + "/shell/plugins/services/voxtype/Service.qml", Component.PreferSynchronous)
+    if (component.status !== Component.Ready) {
+      fail("Voxtype service failed to load: " + component.errorString())
+      writeResult()
+      return
+    }
+
+    service = component.createObject(host)
+    if (!service) {
+      fail("Voxtype service failed to instantiate: " + component.errorString())
+      writeResult()
+    }
+  }
+}

--- a/test/shell.d/voxtype-osd-migration-test.sh
+++ b/test/shell.d/voxtype-osd-migration-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787257711.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$stub_bin/systemctl"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" HOME="$1" bash -euo pipefail "$migration" >/dev/null
+}
+
+missing_section_home="$tmpdir/missing-section"
+mkdir -p "$missing_section_home/.config/voxtype"
+printf 'state_file = "auto"\n' >"$missing_section_home/.config/voxtype/config.toml"
+run_migration "$missing_section_home"
+run_migration "$missing_section_home"
+(( $(grep -c '^\[osd\]$' "$missing_section_home/.config/voxtype/config.toml") == 1 )) ||
+  fail "voxtype OSD migration is idempotent"
+grep -A1 '^\[osd\]$' "$missing_section_home/.config/voxtype/config.toml" | grep -qx 'enabled = false' ||
+  fail "voxtype OSD migration appends a disabled OSD section"
+pass "voxtype OSD migration appends a disabled OSD section once"
+
+empty_section_home="$tmpdir/empty-section"
+mkdir -p "$empty_section_home/.config/voxtype"
+printf '[osd]\n\n[text]\nspoken_punctuation = false\n' >"$empty_section_home/.config/voxtype/config.toml"
+run_migration "$empty_section_home"
+sed -n '/^\[osd\]$/,/^\[text\]$/p' "$empty_section_home/.config/voxtype/config.toml" | grep -qx 'enabled = false' ||
+  fail "voxtype OSD migration fills an existing OSD section"
+pass "voxtype OSD migration fills an existing OSD section"
+
+implicit_forms=(
+  $'osd.position = "bottom"\n[text]\nspoken_punctuation = false\n'
+  $'osd = { position = "bottom" }\n'
+)
+
+for index in "${!implicit_forms[@]}"; do
+  implicit_home="$tmpdir/implicit-$index"
+  mkdir -p "$implicit_home/.config/voxtype"
+  config="$implicit_home/.config/voxtype/config.toml"
+  printf '%s' "${implicit_forms[$index]}" >"$config"
+  run_migration "$implicit_home"
+  python3 -c 'import sys, tomllib; data = tomllib.load(open(sys.argv[1], "rb")); assert data["osd"] == {"position": "bottom", "enabled": False}' "$config" ||
+    fail "voxtype OSD migration disables implicit TOML form $index"
+done
+pass "voxtype OSD migration disables dotted and inline TOML preferences"
+
+explicit_forms=(
+  $'[osd]\nenabled = true\n'
+  $'["osd"]\n"enabled" = true\n'
+  $'osd.enabled = true\n'
+  $'osd = { enabled = true }\n'
+)
+
+for index in "${!explicit_forms[@]}"; do
+  explicit_home="$tmpdir/explicit-$index"
+  mkdir -p "$explicit_home/.config/voxtype"
+  config="$explicit_home/.config/voxtype/config.toml"
+  printf '%s' "${explicit_forms[$index]}" >"$config"
+  cp "$config" "$config.expected"
+  run_migration "$explicit_home"
+  cmp -s "$config.expected" "$config" ||
+    fail "voxtype OSD migration preserves explicit TOML form $index"
+done
+pass "voxtype OSD migration preserves explicit TOML preferences"

--- a/test/shell.d/voxtype-service-test.sh
+++ b/test/shell.d/voxtype-service-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "Voxtype service test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping Voxtype service test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+status_runs="$TMPDIR/status-runs"
+bridge_runs="$TMPDIR/bridge-runs"
+stub_bin="$TMPDIR/bin"
+config_dir="$TMPDIR/voxtype-service"
+mkdir -p "$stub_bin" "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/voxtype-service/shell.qml" "$config_dir/shell.qml"
+
+cat >"$stub_bin/voxtype" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-voxtype-status" <<'SH'
+#!/bin/bash
+set -euo pipefail
+
+count=0
+[[ -f $OMARCHY_VOXTYPE_STATUS_RUNS ]] && read -r count <"$OMARCHY_VOXTYPE_STATUS_RUNS"
+count=$((count + 1))
+printf '%s\n' "$count" >"$OMARCHY_VOXTYPE_STATUS_RUNS"
+printf 'malformed status\n'
+
+if (( count == 1 )); then
+  printf '{"alt":"recording"}\n'
+  sleep 1.3
+  exit 1
+fi
+
+printf '{"class":"transcribing"}\n'
+sleep 1
+SH
+
+cat >"$stub_bin/voxtype-audio-bridge" <<'SH'
+#!/bin/bash
+set -euo pipefail
+
+count=0
+[[ -f $OMARCHY_VOXTYPE_BRIDGE_RUNS ]] && read -r count <"$OMARCHY_VOXTYPE_BRIDGE_RUNS"
+printf '%s\n' "$((count + 1))" >"$OMARCHY_VOXTYPE_BRIDGE_RUNS"
+printf 'malformed audio\n'
+printf '{"peak":0.8}\n'
+sleep 0.1
+exit 1
+SH
+
+chmod +x "$stub_bin/voxtype" "$stub_bin/omarchy-voxtype-status" "$stub_bin/voxtype-audio-bridge"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+OMARCHY_VOXTYPE_STATUS_RUNS="$status_runs" \
+OMARCHY_VOXTYPE_BRIDGE_RUNS="$bridge_runs" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,180p' "$log" >&2
+    fail "Voxtype service quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,180p' "$log" >&2
+  fail "Voxtype service test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Voxtype service result:\n' >&2
+  jq . "$result" >&2
+  printf 'Voxtype service log:\n' >&2
+  sed -n '1,180p' "$log" >&2
+  fail "Voxtype service behavior"
+fi
+
+(( $(<"$status_runs") >= 2 )) || fail "Voxtype status follower restarts after exit"
+(( $(<"$bridge_runs") >= 2 )) || fail "Voxtype audio bridge restarts during capture"
+bridge_count=$(<"$bridge_runs")
+sleep 0.6
+(( $(<"$bridge_runs") == bridge_count )) || fail "Voxtype audio bridge stops retrying after capture"
+pass "Voxtype service parses streams, resets state, and recovers followers"


### PR DESCRIPTION
## Summary

Omarchy already exposes Voxtype status in the bar, but dictation feedback is rendered by Voxtype's separate OSD.

This change integrates that feedback into Omarchy Shell:

- add a shared service for Voxtype state and microphone levels
- show a theme-aware listening meter and transcribing animation in the existing OSD
- reuse the shared service for the dictation bar indicator
- disable Voxtype's separate OSD for new installations
- migrate existing configurations while preserving explicit OSD preferences

Existing volume, brightness, media, and status OSD behavior remains unchanged.

## Testing

- QML lint passes for all changed components
- plugin manifest validation passes
- OSD and migration tests pass
- compositor-backed indicator contract checks pass
- manifest entry-point loading passes
- listening and transcribing states were visually verified in a live Hyprland session