### PR TITLE
Add gradient fills for menu surfaces

### DIFF
--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -172,7 +172,10 @@ selected-border-alpha     = 0.25
 [menu]
 # Cards, rows, and selected-row treatment. Alpha companions (where present)
 # go from 0 (invisible) to 1 (opaque). scrim is the full-screen dim layer
-# behind the card. Clipboard and emojis inherit these tokens.
+# behind the card. Clipboard, emojis, and reminders inherit these tokens.
+# background and selected-background accept either a solid color or a
+# space-separated 2–10 stop gradient followed by an optional angle, using the
+# same syntax as shell borders: "#111111 #333333 45deg".
 background                = "{{ background }}"
 background-alpha          = 1.0
 text                      = "{{ foreground }}"

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -200,20 +200,12 @@ text/background palette, exposed to QML as `Color.foreground` and
 The shell exposes these tokens to QML via three singletons in
 `qs.Commons`:
 
-- `Color` — palette (`foreground`, `background`, `accent`, `urgent`)
-  and per-surface roles (`Color.bar.*`, `Color.popups.*`,
-  `Color.tooltip.*`, `Color.notifications.*`, `Color.menu.*`,
-  `Color.polkit.*`, `Color.lock.*`, `Color.imagePicker.*`). Clipboard
-  and emojis share `Color.menu.*`; the `[launcher]` section is consumed
-  by the launcher outside shell QML.
+- `Color` — palette (`foreground`, `background`, `accent`, `urgent`) and per-surface roles (`Color.bar.*`, `Color.popups.*`, `Color.tooltip.*`, `Color.notifications.*`, `Color.menu.*`, `Color.polkit.*`, `Color.lock.*`, `Color.imagePicker.*`). `Color.menu.backgroundSpec` and `selectedBackgroundSpec` preserve gradient fill data while the corresponding color properties expose the first stop. Clipboard, emojis, and reminders share `Color.menu.*`; the `[launcher]` section is consumed by the launcher outside shell QML.
 - `Style` — structural tokens (`cornerRadius`), shared interactive
   state tokens/helpers, spacing (`Style.spacing.*` / `Style.space(px)`),
   the type scale (`Style.font.*`), and bar dimensions
   (`Style.bar.sizeHorizontal` / `Style.bar.sizeVertical`).
-- `Border` — border-spec helpers for QML surfaces. Use with
-  `BorderSurface` from `qs.Ui` when a border should honor shell theme
-  gradients or per-side widths. `Color.<section>.border` is only the
-  flat-color fallback for code that cannot render a real border.
+- `Border` — border-spec helpers for QML surfaces. Use with `BorderSurface` from `qs.Ui` when a border should honor shell theme gradients or per-side widths. `BorderSurface.fillSpec` similarly renders surface-fill specs such as the menu gradients, with `fillColor` providing the solid fallback. `Color.<section>.border` is only the flat-color fallback for code that cannot render a real border.
 
 ### Interactive states
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -177,6 +177,22 @@ The running shell reads `shell.toml` into two QML singletons:
 - `Color` for palette and surface roles like `Color.menu.border`.
 - `Style` for controls, spacing, font scale, corner radius, and bar sizing.
 
+### Surface fills
+
+The `[menu]` `background` and `selected-background` tokens accept either a solid color or a 2–10 stop gradient in the same space-separated syntax as shell borders:
+
+```toml
+[menu]
+background = "#111827 #312e81 25deg"
+background-alpha = 0.95
+selected-background = "#7c3aed #2563eb 0deg"
+selected-background-alpha = 0.35
+```
+
+Stops are distributed evenly. `0deg` runs left to right and `90deg` runs top to bottom. For gradient values, the alpha companion multiplies every stop's own alpha; solid values retain the shell's existing alpha behavior. Menu, Clipboard, Emojis, and Reminders share the menu card fill; Menu, Clipboard, and Emojis also share the selected-item fill. Color-only consumers use the first stop as a compatibility fallback.
+
+Do not add separate `background-gradient` or `selected-background-gradient` keys. The canonical token itself holds either the solid color or gradient.
+
 ### Borders
 
 Shell border tokens accept either a solid color or a gradient in the same key:

--- a/shell/Commons/BorderGeometry.js
+++ b/shell/Commons/BorderGeometry.js
@@ -371,3 +371,37 @@ function stopPosition(colors, index) {
   if (index >= count) return 1
   return index / (count - 1)
 }
+
+// Shapes require a static GradientStop list. Sample an arbitrary evenly-spaced
+// source palette across that fixed list instead of piling unused stops at 1.0,
+// which makes the CurveRenderer collapse the fill to the final color.
+function sampledStopColor(colors, index, sampleCount) {
+  var count = colors ? colors.length : 0
+  var samples = Math.max(2, Number(sampleCount) || 2)
+  if (count === 0) return "transparent"
+  if (count === 1) return colors[0]
+
+  var position = clamp(index / (samples - 1), 0, 1)
+  var scaled = position * (count - 1)
+  var leftIndex = Math.min(count - 1, Math.floor(scaled))
+  var rightIndex = Math.min(count - 1, leftIndex + 1)
+  var amount = scaled - leftIndex
+  if (amount <= 0 || leftIndex === rightIndex) return colors[leftIndex]
+
+  if (typeof Qt === "undefined" || !Qt.color || !Qt.rgba) return colors[leftIndex]
+  var left = typeof colors[leftIndex] === "string" ? Qt.color(colors[leftIndex]) : colors[leftIndex]
+  var right = typeof colors[rightIndex] === "string" ? Qt.color(colors[rightIndex]) : colors[rightIndex]
+  if (!left || !right || left.r === undefined || right.r === undefined) return colors[leftIndex]
+
+  return Qt.rgba(
+    left.r + (right.r - left.r) * amount,
+    left.g + (right.g - left.g) * amount,
+    left.b + (right.b - left.b) * amount,
+    (left.a === undefined ? 1 : left.a) + ((right.a === undefined ? 1 : right.a) - (left.a === undefined ? 1 : left.a)) * amount
+  )
+}
+
+function sampledStopPosition(index, sampleCount) {
+  var samples = Math.max(2, Number(sampleCount) || 2)
+  return clamp(index / (samples - 1), 0, 1)
+}

--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -48,10 +48,15 @@ QtObject {
     return value
   }
 
-  function flatColor(value, fallback) {
+  function flatColor(value, fallback, seen) {
     var token = firstColorToken(value)
     var role = String(token || "").replace(/^\s+|\s+$/g, "").toLowerCase()
-    if (root.shellValues[role] && root.shellValues[role] !== token) return flatColor(root.shellValues[role], fallback)
+    var visited = seen || ({})
+    if (root.shellValues[role] && root.shellValues[role] !== token) {
+      if (visited[role]) return fallback
+      visited[role] = true
+      return flatColor(root.shellValues[role], fallback, visited)
+    }
     if (role === "foreground" || role === "text") return root.foreground
     if (role === "accent") return root.accent
     if (role === "urgent") return root.urgent
@@ -68,6 +73,47 @@ QtObject {
   // base token is a gradient, color-only consumers use the first stop.
   function composed(colorKey, alphaKey, colorFallback, alphaFallback) {
     return Util.alpha(flatColor(pick(colorKey, colorFallback), colorFallback), pickAlpha(alphaKey, alphaFallback))
+  }
+
+  // Resolve a surface fill that may be either a solid color or the same
+  // space-separated gradient syntax used by shell borders. The companion
+  // alpha multiplies every stop's own alpha. Color-only consumers keep using
+  // the first stop through the existing typed color properties below.
+  function resolveShellRef(raw) {
+    var value = String(raw || "").replace(/^\s+|\s+$/g, "")
+    var seen = {}
+    while (value.match(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/) && !seen[value]) {
+      seen[value] = true
+      var next = shellValues[value]
+      if (next === undefined || next === null || String(next).length === 0) break
+      value = String(next).replace(/^\s+|\s+$/g, "")
+    }
+    return value
+  }
+
+  function multipliedAlpha(color, alpha) {
+    if (color && typeof color === "object" && color.r !== undefined)
+      return Qt.rgba(color.r, color.g, color.b, (color.a === undefined ? 1 : color.a) * Util.clampAlpha(alpha))
+    return Util.alpha(color, alpha)
+  }
+
+  function fillSpec(colorKey, alphaKey, colorFallback, alphaFallback) {
+    var raw = resolveShellRef(pick(colorKey, colorFallback))
+    var alpha = pickAlpha(alphaKey, alphaFallback)
+    var parts = String(raw || "").split(/\s+/)
+    var colors = []
+    var angle = 0
+    for (var i = 0; i < parts.length; i++) {
+      if (!parts[i]) continue
+      var angleMatch = parts[i].match(/^(-?\d+(?:\.\d+)?)deg$/)
+      if (angleMatch) angle = Number(angleMatch[1])
+      else if (colors.length < 10) colors.push(multipliedAlpha(flatColor(parts[i], colorFallback), alpha))
+    }
+    if (colors.length === 0) colors.push(multipliedAlpha(flatColor(colorFallback, colorFallback), alpha))
+    return {
+      color: colors[0],
+      gradient: { colors: colors, angle: angle, enabled: colors.length > 1 }
+    }
   }
 
   readonly property QtObject bar: QtObject {
@@ -93,10 +139,12 @@ QtObject {
   }
   readonly property QtObject menu: QtObject {
     property color background: root.composed("menu.background", "menu.background-alpha", root.background, 1.0)
+    property var backgroundSpec: root.fillSpec("menu.background", "menu.background-alpha", root.background, 1.0)
     property color text: root.pick("menu.text", root.foreground)
     property color border: root.composed("menu.border", "menu.border-alpha", root.foreground, 1.0)
     property color scrim: root.composed("menu.scrim", "menu.scrim-alpha", root.background, 0.5)
     property color selectedBackground: root.composed("menu.selected-background", "menu.selected-background-alpha", root.foreground, 0.08)
+    property var selectedBackgroundSpec: root.fillSpec("menu.selected-background", "menu.selected-background-alpha", root.foreground, 0.08)
     property color selectedText: root.pick("menu.selected-text", root.accent)
     property color selectedBorder: root.composed("menu.selected-border", "menu.selected-border-alpha", root.foreground, 0.0)
   }

--- a/shell/Ui/BorderSurface.qml
+++ b/shell/Ui/BorderSurface.qml
@@ -8,6 +8,8 @@ Rectangle {
   id: root
 
   property var borderSpec: Border.none()
+  property var fillSpec: null
+  property color fillColor: "transparent"
   property real padding: 0
   property real topPadding: padding
   property real rightPadding: padding
@@ -22,10 +24,24 @@ Rectangle {
   readonly property real contentRightInset: borderRight + rightPadding
   readonly property real contentBottomInset: borderBottom + bottomPadding
   readonly property real contentLeftInset: borderLeft + leftPadding
+  readonly property bool usesGradientFill: !!(fillSpec && fillSpec.gradient && fillSpec.gradient.enabled)
   readonly property bool usesOverlayBorder: Border.needsOverlay(borderSpec)
+    || (usesGradientFill && !Border.isNone(borderSpec))
 
-  border.color: Border.canUseNative(borderSpec) ? Border.color(borderSpec) : "transparent"
-  border.width: Border.canUseNative(borderSpec) ? Border.uniformWidth(borderSpec) : 0
+  color: usesGradientFill ? "transparent" : fillColor
+  border.color: Border.canUseNative(borderSpec) && !usesGradientFill ? Border.color(borderSpec) : "transparent"
+  border.width: Border.canUseNative(borderSpec) && !usesGradientFill ? Border.uniformWidth(borderSpec) : 0
+
+  Loader {
+    anchors.fill: parent
+    active: root.usesGradientFill
+
+    sourceComponent: FillOverlay {
+      anchors.fill: parent
+      radius: root.radius
+      fillSpec: root.fillSpec
+    }
+  }
 
   Loader {
     anchors.fill: parent

--- a/shell/Ui/FillOverlay.qml
+++ b/shell/Ui/FillOverlay.qml
@@ -1,0 +1,55 @@
+import QtQuick
+import QtQuick.Shapes
+import qs.Commons
+import "../Commons/BorderGeometry.js" as Geometry
+
+// Visual-only rounded surface fill for shell color specs containing gradients.
+// Solid fills stay on Rectangle.color; this Shape exists only for 2+ stops.
+Item {
+  id: root
+
+  property var fillSpec: null
+  property real radius: 0
+
+  readonly property var _gradient: fillSpec && fillSpec.gradient
+    ? fillSpec.gradient
+    : ({ colors: [], angle: 0, enabled: false })
+  readonly property var _colors: _gradient.colors || []
+  readonly property var _endpoints: Geometry.gradientEndpoints(width, height, _gradient.angle || 0)
+  readonly property string _path: Geometry.roundedRectPath(0, 0, width, height, {
+    tlrx: radius, tlry: radius,
+    trrx: radius, trry: radius,
+    brrx: radius, brry: radius,
+    blrx: radius, blry: radius,
+  })
+
+  visible: _gradient.enabled && width > 0 && height > 0
+
+  Shape {
+    anchors.fill: parent
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+      strokeWidth: 0
+      fillGradient: LinearGradient {
+        x1: root._endpoints.x1
+        y1: root._endpoints.y1
+        x2: root._endpoints.x2
+        y2: root._endpoints.y2
+
+        GradientStop { position: Geometry.sampledStopPosition(0, 10); color: Geometry.sampledStopColor(root._colors, 0, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(1, 10); color: Geometry.sampledStopColor(root._colors, 1, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(2, 10); color: Geometry.sampledStopColor(root._colors, 2, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(3, 10); color: Geometry.sampledStopColor(root._colors, 3, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(4, 10); color: Geometry.sampledStopColor(root._colors, 4, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(5, 10); color: Geometry.sampledStopColor(root._colors, 5, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(6, 10); color: Geometry.sampledStopColor(root._colors, 6, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(7, 10); color: Geometry.sampledStopColor(root._colors, 7, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(8, 10); color: Geometry.sampledStopColor(root._colors, 8, 10) }
+        GradientStop { position: Geometry.sampledStopPosition(9, 10); color: Geometry.sampledStopColor(root._colors, 9, 10) }
+      }
+
+      PathSvg { path: root._path }
+    }
+  }
+}

--- a/shell/Ui/qmldir
+++ b/shell/Ui/qmldir
@@ -10,6 +10,7 @@ ButtonGroup 1.0 ButtonGroup.qml
 ConfirmDialog 1.0 ConfirmDialog.qml
 CursorSurface 1.0 CursorSurface.qml
 Dropdown 1.0 Dropdown.qml
+FillOverlay 1.0 FillOverlay.qml
 KeyboardPanel 1.0 KeyboardPanel.qml
 MultiSelect 1.0 MultiSelect.qml
 NumberField 1.0 NumberField.qml

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -23,11 +23,13 @@ Item {
   // style the clipboard. Selected-row colors composed in the
   // singleton so consumers drop them straight into Rectangle bindings.
   property color background: Color.menu.background
+  property var backgroundSpec: Color.menu.backgroundSpec
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
   property color scrim: Color.menu.scrim
   property color selectedBackground: Color.menu.selectedBackground
+  property var selectedBackgroundSpec: Color.menu.selectedBackgroundSpec
   property color selectedText: Color.menu.selectedText
   readonly property int cornerRadius: Style.cornerRadius
   property string fontFamily: Style.font.menuFamily
@@ -337,7 +339,8 @@ Item {
       height: root.cardHeight
       radius: root.cornerRadius
       anchors.centerIn: parent
-      color: root.background
+      fillColor: root.background
+      fillSpec: root.backgroundSpec
       borderSpec: root.borderSpec
       padding: root.contentMargin
 
@@ -466,7 +469,7 @@ Item {
                 spacing: Style.space(4)
                 boundsBehavior: Flickable.StopAtBounds
 
-                delegate: Rectangle {
+                delegate: BorderSurface {
                   id: row
                   required property int index
                   required property string entryType
@@ -479,7 +482,8 @@ Item {
                   width: ListView.view.width
                   height: root.rowHeight
                   radius: root.cornerRadius
-                  color: hasCursor ? root.selectedBackground : "transparent"
+                  fillColor: hasCursor ? root.selectedBackground : "transparent"
+                  fillSpec: hasCursor ? root.selectedBackgroundSpec : null
 
                   Row {
                     anchors.fill: parent

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -24,11 +24,13 @@ Item {
   // style emojis. Selected-cell colors composed in the
   // singleton so consumers drop them straight into Rectangle bindings.
   property color background: Color.menu.background
+  property var backgroundSpec: Color.menu.backgroundSpec
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
   property color scrim: Color.menu.scrim
   property color selectedBackground: Color.menu.selectedBackground
+  property var selectedBackgroundSpec: Color.menu.selectedBackgroundSpec
   property color selectedText: Color.menu.selectedText
   readonly property int cornerRadius: Style.cornerRadius
   property string fontFamily: Style.font.menuFamily
@@ -183,7 +185,8 @@ Item {
       height: root.cardHeight
       radius: root.cornerRadius
       anchors.centerIn: parent
-      color: root.background
+      fillColor: root.background
+      fillSpec: root.backgroundSpec
       borderSpec: root.borderSpec
       padding: root.contentMargin
 
@@ -272,7 +275,7 @@ Item {
             cellHeight: root.cellHeight
             boundsBehavior: Flickable.StopAtBounds
 
-            delegate: Rectangle {
+            delegate: BorderSurface {
               required property int index
               required property string emoji
 
@@ -281,7 +284,8 @@ Item {
               width: root.cellWidth
               height: root.cellHeight
               radius: root.cornerRadius
-              color: hasCursor ? root.selectedBackground : "transparent"
+              fillColor: hasCursor ? root.selectedBackground : "transparent"
+              fillSpec: hasCursor ? root.selectedBackgroundSpec : null
 
               Text {
                 text: parent.emoji

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -85,11 +85,13 @@ Item {
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
   property color background: Color.menu.background
+  property var backgroundSpec: Color.menu.backgroundSpec
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
   property color scrim: Color.menu.scrim
   property color selectedBackground: Color.menu.selectedBackground
+  property var selectedBackgroundSpec: Color.menu.selectedBackgroundSpec
   property color selectedText: Color.menu.selectedText
   property color selectedBorder: Color.menu.selectedBorder
   property var selectedBorderSpec: Border.surfaceSpec("menu", "selected-border", selectedBorder, 0)
@@ -1107,7 +1109,8 @@ Item {
       radius: root.cornerRadius
       anchors.horizontalCenter: parent.horizontalCenter
       y: panel.effectiveCardTop
-      color: root.background
+      fillColor: root.background
+      fillSpec: root.backgroundSpec
       borderSpec: root.borderSpec
       padding: root.contentMargin
 
@@ -1271,7 +1274,8 @@ Item {
               // installed, not to be picked.
               opacity: row.disabled ? 0.4 : 1
               radius: root.cornerRadius
-              color: row.hasCursor ? root.selectedBackground : "transparent"
+              fillColor: row.hasCursor ? root.selectedBackground : "transparent"
+              fillSpec: row.hasCursor ? root.selectedBackgroundSpec : null
               borderSpec: row.hasCursor ? root.selectedBorderSpec : Border.none()
 
               Rectangle {
@@ -1411,7 +1415,7 @@ Item {
             anchors.right: parent.right
             anchors.top: parent.top
             height: Math.min(Style.space(28), parent.height / 2)
-            visible: opacity > 0
+            visible: opacity > 0 && !root.backgroundSpec.gradient.enabled
             opacity: resultList.contentHeight > resultList.height
               ? Math.max(0, Math.min(1, (resultList.contentY - resultList.originY) / height))
               : 0
@@ -1426,7 +1430,7 @@ Item {
             anchors.right: parent.right
             anchors.bottom: parent.bottom
             height: Math.min(Style.space(28), parent.height / 2)
-            visible: opacity > 0
+            visible: opacity > 0 && !root.backgroundSpec.gradient.enabled
             opacity: resultList.contentHeight > resultList.height
               ? Math.max(0, Math.min(1, (resultList.originY + resultList.contentHeight - resultList.height - resultList.contentY) / height))
               : 0

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -19,6 +19,7 @@ Item {
   property string fontFamily: Style.font.menuFamily
 
   property color background: Color.menu.background
+  property var backgroundSpec: Color.menu.backgroundSpec
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
@@ -118,7 +119,8 @@ Item {
       height: root.cardHeight
       radius: root.cornerRadius
       anchors.centerIn: parent
-      color: root.background
+      fillColor: root.background
+      fillSpec: root.backgroundSpec
       borderSpec: root.borderSpec
       padding: root.contentMargin
 

--- a/test/shell.d/menu-gradient-test.sh
+++ b/test/shell.d/menu-gradient-test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const template = fs.readFileSync(path.join(root, 'default/themed/shell.toml.tpl'), 'utf8')
+const color = fs.readFileSync(path.join(root, 'shell/Commons/Color.qml'), 'utf8')
+const surface = fs.readFileSync(path.join(root, 'shell/Ui/BorderSurface.qml'), 'utf8')
+const fillOverlay = fs.readFileSync(path.join(root, 'shell/Ui/FillOverlay.qml'), 'utf8')
+const qmldir = fs.readFileSync(path.join(root, 'shell/Ui/qmldir'), 'utf8')
+const menu = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+const clipboard = fs.readFileSync(path.join(root, 'shell/plugins/clipboard/Clipboard.qml'), 'utf8')
+const emojis = fs.readFileSync(path.join(root, 'shell/plugins/emojis/Emojis.qml'), 'utf8')
+const reminders = fs.readFileSync(path.join(root, 'shell/plugins/reminders/ReminderFlow.qml'), 'utf8')
+
+assert(!/^background-gradient\s*=/m.test(template), 'menu fill gradients reuse the canonical background token')
+assert(!/^selected-background-gradient\s*=/m.test(template), 'selected fill gradients reuse the canonical selected-background token')
+assert(/property var backgroundSpec: root\.fillSpec\("menu\.background"/.test(color), 'Color exposes the menu card fill spec')
+assert(/property var selectedBackgroundSpec: root\.fillSpec\("menu\.selected-background"/.test(color), 'Color exposes the selected-item fill spec')
+assert(/property var fillSpec: null/.test(surface) && /usesGradientFill/.test(surface), 'BorderSurface supports lazy gradient fills')
+assert(/property color fillColor: "transparent"/.test(surface) && /color: usesGradientFill \? "transparent" : fillColor/.test(surface), 'gradient fills replace rather than stack over solid fallbacks')
+assert(/FillOverlay 1\.0 FillOverlay\.qml/.test(qmldir), 'FillOverlay is registered in qs.Ui')
+assert(/sampledStopPosition/.test(fillOverlay) && /sampledStopColor/.test(fillOverlay), 'FillOverlay samples its fixed stop list without collapsing to the final color')
+assert(/fillSpec: root\.backgroundSpec/.test(menu) && /fillSpec: row\.hasCursor \? root\.selectedBackgroundSpec : null/.test(menu), 'Menu renders card and selected-row gradients')
+assert(/!root\.backgroundSpec\.gradient\.enabled/.test(menu), 'Menu suppresses flat scroll fades over a gradient card')
+assert(/fillSpec: root\.backgroundSpec/.test(clipboard) && /fillSpec: hasCursor \? root\.selectedBackgroundSpec : null/.test(clipboard), 'Clipboard inherits menu card and selected-row gradients')
+assert(/fillSpec: root\.backgroundSpec/.test(emojis) && /fillSpec: hasCursor \? root\.selectedBackgroundSpec : null/.test(emojis), 'Emojis inherit menu card and selected-cell gradients')
+assert(/fillSpec: root\.backgroundSpec/.test(reminders), 'Reminders inherit the menu card gradient')
+JS
+
+require_compositor "menu gradient runtime test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping menu gradient runtime test"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+ln -s "$ROOT/shell/Ui" "$test_tmp/Ui"
+ln -s "$ROOT/shell/Commons" "$test_tmp/Commons"
+
+cat >"$test_tmp/shell.qml" <<'QML'
+import QtQuick
+import Quickshell
+import qs.Commons
+import qs.Ui
+
+ShellRoot {
+  id: root
+
+  function fail(message) {
+    console.log("RESULT fail " + message)
+    Qt.quit()
+  }
+
+  function runChecks() {
+    Color.loadUserShell(`
+[menu]
+background = "#11223380 #445566 25deg"
+background-alpha = 0.5
+selected-background = "accent foreground 0deg"
+selected-background-alpha = 0.35
+`)
+
+    Qt.callLater(function() {
+      var background = Color.menu.backgroundSpec
+      var selected = Color.menu.selectedBackgroundSpec
+      if (!background.gradient.enabled || background.gradient.colors.length !== 2 || background.gradient.angle !== 25) {
+        fail("menu background gradient spec was not resolved")
+        return
+      }
+      if (Math.abs(background.gradient.colors[0].a - 0.25) > 0.01) {
+        fail("menu background alpha did not multiply the stop alpha")
+        return
+      }
+      if (!selected.gradient.enabled || selected.gradient.colors.length !== 2) {
+        fail("selected background gradient spec was not resolved")
+        return
+      }
+      if (!card.usesGradientFill || !card.usesOverlayBorder || !selection.usesGradientFill) {
+        fail("gradient surfaces did not select the overlay renderers")
+        return
+      }
+      if (card.color.a > 0.01 || selection.color.a > 0.01) {
+        fail("gradient fills were composited over their solid fallbacks")
+        return
+      }
+
+      Color.loadUserShell(`
+[menu]
+background = "#11223380"
+background-alpha = 0.5
+selected-background = "#445566"
+selected-background-alpha = 0.35
+`)
+      Qt.callLater(function() {
+        if (card.usesGradientFill || selection.usesGradientFill) {
+          fail("solid menu values selected a gradient renderer")
+          return
+        }
+        if (Math.abs(card.color.a - 0.5) > 0.01) {
+          fail("solid menu alpha compatibility changed")
+          return
+        }
+
+        Color.loadUserShell(`
+[menu]
+background = "fill.alias"
+[fill]
+alias = "menu.background"
+`)
+        Qt.callLater(function() {
+          if (Math.abs(Color.menu.background.r - Color.background.r) > 0.01
+              || Math.abs(Color.menu.background.g - Color.background.g) > 0.01
+              || Math.abs(Color.menu.background.b - Color.background.b) > 0.01) {
+            fail("cyclic fill references did not fall back safely")
+            return
+          }
+          console.log("RESULT pass")
+          Qt.quit()
+        })
+      })
+    })
+  }
+
+  Timer {
+    interval: 100
+    running: true
+    onTriggered: root.runChecks()
+  }
+
+  BorderSurface {
+    id: card
+    width: 160
+    height: 100
+    radius: 12
+    fillColor: Color.menu.background
+    fillSpec: Color.menu.backgroundSpec
+    borderSpec: Border.flat("white", 1)
+  }
+
+  BorderSurface {
+    id: selection
+    width: 120
+    height: 40
+    radius: 8
+    fillColor: Color.menu.selectedBackground
+    fillSpec: Color.menu.selectedBackgroundSpec
+  }
+}
+QML
+
+output=$(timeout 15 env \
+  QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+  QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+  quickshell -p "$test_tmp" --no-color 2>&1) || {
+  printf '%s\n' "$output" >&2
+  fail "menu gradient runtime fixture exits cleanly"
+}
+
+if ! grep -q 'RESULT pass' <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail "menu gradient specs render through gradient surfaces"
+fi
+
+pass "menu gradient specs render through gradient surfaces"


### PR DESCRIPTION
## Summary

`[menu]` background tokens now accept solid colors or Hyprland-style gradients.

Menu, Clipboard, Emojis, and Reminders use the background gradient. Menu, Clipboard, and Emojis also use the selected-item gradient.

## Example

```toml
[menu]
background = "#020a14 #061221 #0b2a3d 120deg"
background-alpha = 0.96

selected-background = "#0b2a3d #17475a #13c1dc 0deg"
selected-background-alpha = 0.46
```

Gradients support 2–10 evenly distributed stops with an optional angle. Companion alpha values multiply each stop's intrinsic alpha.

## Implementation

- Add reusable rounded gradient fill rendering
- Extend `BorderSurface` to accept fill specifications
- Preserve the native rectangle path for solid themes
- Prevent translucent gradients from stacking over fallback fills
- Resolve dotted color references safely, including cycles
- Disable flat Menu scroll fades over gradient backgrounds
- Document gradient syntax and update the default template
- Add coverage for parsing, alpha composition, renderer selection, references, and consumers

## Verification

- `bash test/shell.d/menu-gradient-test.sh`
- Focused Menu, Clipboard, Emojis, Reminders, and border geometry tests
- `./test/cli`
- `qmllint`
- `git diff --check`
- Live visual verification of all four surfaces

The focused tests pass. `./test/shell` still has existing environment and configuration failures outside this patch.

## Visual evidence

Captured on empty workspace 8. Clipboard is filtered to an empty result, so no clipboard contents are shown.

![Menu, Clipboard, Emojis, and Reminders using Frost Sentinel navy and cyan gradients](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-7748-visual-evidence/visual-evidence/menu-gradient-evidence.png)
