### PR TITLE
Fix Codex limits collector approval policy

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,10 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+if [[ -n ${CODEX_ARGS_LOG:-} ]]; then
+  printf '%s\n' "$*" >"$CODEX_ARGS_LOG"
+fi
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -40,8 +44,12 @@ cat >"$session" <<EOF
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}}}}
 EOF
 
-result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" CODEX_ARGS_LOG="$TEST_HOME/codex-args" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(<"$TEST_HOME/codex-args") == "-s read-only -a never app-server" ]] ||
+  fail "Codex collector uses the current non-interactive approval policy" "$(<"$TEST_HOME/codex-args")"
+pass "Codex collector uses the current non-interactive approval policy"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"


### PR DESCRIPTION
# Codex limits unavailable because collector uses removed `untrusted` approval policy

## What happened

On Omarchy 4.0.0-1 with Codex CLI 0.149.0, the Agents toolbar panel shows `Codex limits unavailable` and a red `initialize` error even though `codex login status` reports `Logged in using ChatGPT`.

The panel still shows historical local usage, but the plan and rate-limit windows are absent.

## Root cause

`bin/omarchy-agent-usage-codex` launches the app server with:

```text
codex -s read-only -a untrusted app-server
```

Codex CLI 0.149.0 rejects `untrusted`:

```text
error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'
  [possible values: on-request, never]
```

Because stderr is discarded, the collector waits for the `initialize` RPC until it times out. It then exposes the exception method name as `authHelpText`, producing the misleading red `initialize` message.

## Expected behavior

The collector should start the current Codex app server non-interactively and return the authenticated account's plan and rate-limit windows.

## Proposed fix

Replace `-a untrusted` with `-a never` and add a regression assertion covering the exact app-server launch arguments.

With this change, the collector returned the authenticated plan and a populated 7-day limit window on the affected machine, with an empty `usageStatusText`.

## Reproduction

1. Install Omarchy 4.0.0-1 and Codex CLI 0.149.0.
2. Authenticate using `codex login`.
3. Run `omarchy agent usage-update --force codex`.
4. Open the Agents toolbar panel.

## Verification

- `bash test/shell.d/agent-usage-codex-scanner-test.sh` passes.
- `git diff --check` passes.
- Live authenticated collector probe returns the plan and limit window.
- The broader `./test/shell` suite reaches the changed test successfully; four unrelated environment/checkout-dependent tests fail because the separate `omarchy-pkgs` checkout is unavailable (plus its dependent coverage checks).
