### PR TITLE
Avoid full plugin reload when discovering new plugins

### DIFF
--- a/bin/omarchy-plugin-add
+++ b/bin/omarchy-plugin-add
@@ -139,7 +139,7 @@ fi
 mv "$stage" "$target"
 echo "Added $id into $target"
 
-omarchy-shell shell rescanPlugins >/dev/null
+omarchy-shell shell discoverPlugins "$id" >/dev/null
 
 if [[ -z $enable_after ]]; then
   if (( ASSUME_YES )) || ! interactive; then

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -56,6 +56,14 @@ ShellRoot {
   property var shellConfig: builtinShellConfig
   property bool pluginReloading: false
   property bool pluginReloadPending: false
+  // IDs observed by this shell process remain here after removal. Re-adding
+  // one must use code-reload semantics because Qt may still cache its QML URL.
+  property var knownLocalPluginIds: ({})
+  // These two sets make plugin-add's explicit discovery and the filesystem
+  // watcher idempotent regardless of which reaches the shell first.
+  property var requestedPluginDiscoveries: ({})
+  property var watcherPluginDiscoveries: ({})
+  property bool initialPluginScanFinished: false
 
   Timer {
     id: localPluginReloadTimer
@@ -748,6 +756,20 @@ ShellRoot {
     Qt.callLater(shell.finishPluginReload)
   }
 
+  function rememberLocalPlugin(pluginId) {
+    var next = ({})
+    for (var id in shell.knownLocalPluginIds) next[id] = true
+    next[String(pluginId)] = true
+    shell.knownLocalPluginIds = next
+  }
+
+  function forgetDiscovery(setName, pluginId) {
+    var current = shell[setName]
+    var next = ({})
+    for (var id in current) if (id !== String(pluginId)) next[id] = true
+    shell[setName] = next
+  }
+
   function finishPluginReload() {
     if (!shell.pluginReloading) return
     if (shell.pluginRegistry.scanning) {
@@ -761,10 +783,35 @@ ShellRoot {
   Connections {
     target: shell.pluginRegistry
     function onLocalPluginChanged(pluginId) {
+      // A plugin unseen by this shell session has no live objects to tear
+      // down. Discover its completed manifest without rebuilding unrelated
+      // plugins. Session-known IDs include removed plugins, whose QML URLs may
+      // still be cached and therefore require the code-reload path below.
+      if (!shell.knownLocalPluginIds[pluginId]) {
+        shell.rememberLocalPlugin(pluginId)
+        if (shell.requestedPluginDiscoveries[pluginId])
+          shell.forgetDiscovery("requestedPluginDiscoveries", pluginId)
+        else {
+          var acknowledged = ({})
+          for (var id in shell.watcherPluginDiscoveries) acknowledged[id] = true
+          acknowledged[pluginId] = true
+          shell.watcherPluginDiscoveries = acknowledged
+        }
+        console.log("Local plugin added, discovering:", pluginId)
+        shell.pluginRegistry.rescan()
+        return
+      }
       console.log("Local plugin changed, reloading:", pluginId)
       localPluginReloadTimer.restart()
     }
     function onScanFinished() {
+      if (!shell.initialPluginScanFinished) {
+        for (var id in shell.pluginRegistry.installedPlugins) {
+          var manifest = shell.pluginRegistry.installedPlugins[id]
+          if (manifest && !manifest.__isFirstParty) shell.rememberLocalPlugin(id)
+        }
+        shell.initialPluginScanFinished = true
+      }
       if (shell.pluginReloadPending) {
         shell.pluginReloadPending = false
         shell.pluginReloading = false
@@ -889,6 +936,25 @@ ShellRoot {
 
     function rescanPlugins(): void {
       shell.reloadPlugins()
+    }
+
+    // Synchronize newly installed plugin metadata without destroying loaded
+    // components. A same-ID reinstallation in this shell session deliberately
+    // retains rescanPlugins' existing full code-refresh semantics.
+    function discoverPlugins(id: string): void {
+      var pluginId = String(id || "")
+      if (shell.watcherPluginDiscoveries[pluginId]) {
+        shell.forgetDiscovery("watcherPluginDiscoveries", pluginId)
+        shell.pluginRegistry.rescan()
+      } else if (shell.knownLocalPluginIds[pluginId]) {
+        shell.reloadPlugins()
+      } else {
+        var requested = ({})
+        for (var key in shell.requestedPluginDiscoveries) requested[key] = true
+        requested[pluginId] = true
+        shell.requestedPluginDiscoveries = requested
+        shell.pluginRegistry.rescan()
+      }
     }
 
     function reloadConfig(): string {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -63,6 +63,9 @@ ShellRoot {
   // watcher idempotent regardless of which reaches the shell first.
   property var requestedPluginDiscoveries: ({})
   property var watcherPluginDiscoveries: ({})
+  // Values are true when a request arrived during a scan and therefore needs
+  // one follow-up scan if that scan did not discover the plugin.
+  property var pendingPluginDiscoveries: ({})
   property bool initialPluginScanFinished: false
 
   Timer {
@@ -770,6 +773,35 @@ ShellRoot {
     shell[setName] = next
   }
 
+  function requestPluginDiscovery(pluginId) {
+    var key = String(pluginId)
+    var pending = ({})
+    for (var id in shell.pendingPluginDiscoveries) pending[id] = shell.pendingPluginDiscoveries[id]
+    pending[key] = Boolean(pending[key]) || shell.pluginRegistry.scanning
+    shell.pendingPluginDiscoveries = pending
+    if (!shell.pluginRegistry.scanning) shell.pluginRegistry.rescan()
+  }
+
+  function finishPluginDiscoveries() {
+    var pending = ({})
+    var followUp = false
+    for (var id in shell.pendingPluginDiscoveries) {
+      if (shell.pluginRegistry.installedPlugins[id]) {
+        shell.rememberLocalPlugin(id)
+        shell.forgetDiscovery("requestedPluginDiscoveries", id)
+        shell.forgetDiscovery("watcherPluginDiscoveries", id)
+      } else if (shell.pendingPluginDiscoveries[id]) {
+        pending[id] = false
+        followUp = true
+      } else {
+        shell.forgetDiscovery("requestedPluginDiscoveries", id)
+        shell.forgetDiscovery("watcherPluginDiscoveries", id)
+      }
+    }
+    shell.pendingPluginDiscoveries = pending
+    if (followUp) Qt.callLater(shell.pluginRegistry.rescan)
+  }
+
   function finishPluginReload() {
     if (!shell.pluginReloading) return
     if (shell.pluginRegistry.scanning) {
@@ -788,7 +820,6 @@ ShellRoot {
       // plugins. Session-known IDs include removed plugins, whose QML URLs may
       // still be cached and therefore require the code-reload path below.
       if (!shell.knownLocalPluginIds[pluginId]) {
-        shell.rememberLocalPlugin(pluginId)
         if (shell.requestedPluginDiscoveries[pluginId])
           shell.forgetDiscovery("requestedPluginDiscoveries", pluginId)
         else {
@@ -798,13 +829,14 @@ ShellRoot {
           shell.watcherPluginDiscoveries = acknowledged
         }
         console.log("Local plugin added, discovering:", pluginId)
-        shell.pluginRegistry.rescan()
+        shell.requestPluginDiscovery(pluginId)
         return
       }
       console.log("Local plugin changed, reloading:", pluginId)
       localPluginReloadTimer.restart()
     }
     function onScanFinished() {
+      shell.finishPluginDiscoveries()
       if (!shell.initialPluginScanFinished) {
         for (var id in shell.pluginRegistry.installedPlugins) {
           var manifest = shell.pluginRegistry.installedPlugins[id]
@@ -945,7 +977,7 @@ ShellRoot {
       var pluginId = String(id || "")
       if (shell.watcherPluginDiscoveries[pluginId]) {
         shell.forgetDiscovery("watcherPluginDiscoveries", pluginId)
-        shell.pluginRegistry.rescan()
+        shell.requestPluginDiscovery(pluginId)
       } else if (shell.knownLocalPluginIds[pluginId]) {
         shell.reloadPlugins()
       } else {
@@ -953,7 +985,7 @@ ShellRoot {
         for (var key in shell.requestedPluginDiscoveries) requested[key] = true
         requested[pluginId] = true
         shell.requestedPluginDiscoveries = requested
-        shell.pluginRegistry.rescan()
+        shell.requestPluginDiscovery(pluginId)
       }
     }
 

--- a/test/shell.d/plugin-add-test.sh
+++ b/test/shell.d/plugin-add-test.sh
@@ -6,6 +6,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
+calls="$TMPDIR/calls"
 
 write_plugin() {
   local dir="$1"
@@ -35,6 +36,14 @@ stub_dir="$TMPDIR/stubs"
 mkdir -p "$stub_dir"
 cat >"$stub_dir/omarchy-shell" <<'STUB'
 #!/bin/bash
+[[ -n ${OMARCHY_TEST_CALLS:-} ]] && printf '%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+if [[ ${1:-} == shell && ${2:-} == listPlugins ]]; then
+  find "$HOME/.config/omarchy/plugins" -mindepth 2 -maxdepth 2 -name manifest.json -type f -print0 2>/dev/null |
+    xargs -0 -r jq '{id: .id, name: .name, version: .version, kinds: .kinds, enabled: false, canDisable: true, firstParty: false, clonedFrom: ""}' |
+    jq -s .
+elif [[ ${1:-} == shell && ${2:-} == enablePlugin ]]; then
+  printf 'ok\n'
+fi
 exit 0
 STUB
 chmod +x "$stub_dir/omarchy-shell"
@@ -56,3 +65,81 @@ grep -qF "plugin id 'acme.same' is already used by" <<<"$output" ||
 [[ ! -e $test_home/.config/omarchy/plugins/acme.same ]] ||
   fail "plugin add leaves a target behind after refusing a duplicate id"
 pass "plugin add refuses an installed manifest id regardless of directory name"
+
+new_home() {
+  test_home="$TMPDIR/home-$1"
+  mkdir -p "$test_home"
+}
+
+run_add() {
+  HOME="$test_home" OMARCHY_PATH="$ROOT" OMARCHY_TEST_CALLS="$calls" \
+    PATH="$stub_dir:$ROOT/bin:$PATH" omarchy-plugin-add "$@"
+}
+
+assert_no_stage() {
+  local stage
+  stage=$(find "$test_home/.config/omarchy/plugins" -maxdepth 1 -name '.add.tmp.*' -print -quit 2>/dev/null || true)
+  [[ -z $stage ]] || fail "plugin add leaves a staging directory after failure"
+}
+
+valid_source="$TMPDIR/valid-source"
+write_plugin "$valid_source" acme.local "Local source"
+git -C "$valid_source" init -q
+git -C "$valid_source" add .
+git -C "$valid_source" -c user.name=Test -c user.email=test@example.com commit -qm Initial
+
+new_home failed-clone
+if run_add "$TMPDIR/does-not-exist" --yes >/dev/null 2>&1; then
+  fail "plugin add accepts a failed clone"
+fi
+assert_no_stage
+[[ ! -e $test_home/.config/omarchy/plugins/acme.local ]] || fail "failed clone installs a plugin"
+pass "failed clones leave no installed plugin or staging directory"
+
+invalid_source="$TMPDIR/invalid-source"
+mkdir -p "$invalid_source"
+printf '{invalid\n' >"$invalid_source/manifest.json"
+git -C "$invalid_source" init -q
+git -C "$invalid_source" add .
+git -C "$invalid_source" -c user.name=Test -c user.email=test@example.com commit -qm Initial
+new_home invalid
+if run_add "$invalid_source" --yes >/dev/null 2>&1; then
+  fail "plugin add accepts an invalid manifest"
+fi
+assert_no_stage
+[[ -z $(find "$test_home/.config/omarchy/plugins" -mindepth 1 -maxdepth 1 ! -name '.*' -print -quit 2>/dev/null) ]] ||
+  fail "invalid manifest leaves a visible installed plugin"
+pass "invalid manifests leave no installed plugin or registry-visible directory"
+
+new_home existing-destination
+mkdir -p "$test_home/.config/omarchy/plugins/acme.local"
+printf 'keep\n' >"$test_home/.config/omarchy/plugins/acme.local/sentinel"
+if run_add "$valid_source" --yes >/dev/null 2>&1; then
+  fail "plugin add overwrites an existing destination"
+fi
+grep -q '^keep$' "$test_home/.config/omarchy/plugins/acme.local/sentinel" ||
+  fail "plugin add modifies an existing destination"
+assert_no_stage
+pass "existing destinations are rejected without modification"
+
+new_home local-path
+: >"$calls"
+run_add "$valid_source" --yes >/dev/null
+[[ -f $test_home/.config/omarchy/plugins/acme.local/manifest.json ]] ||
+  fail "local path plugin is not installed"
+grep -Fqx 'shell discoverPlugins acme.local' "$calls" ||
+  fail "local path add does not request targeted discovery"
+pass "local repository paths install through targeted discovery"
+
+new_home remote-url
+: >"$calls"
+run_add "file://$valid_source" --yes --enable >/dev/null
+[[ -f $test_home/.config/omarchy/plugins/acme.local/manifest.json ]] ||
+  fail "URL plugin is not installed"
+grep -Fqx 'shell discoverPlugins acme.local' "$calls" ||
+  fail "URL add does not request targeted discovery"
+grep -Fq 'shell enablePlugin acme.local {}' "$calls" ||
+  fail "add --enable does not enable the discovered plugin"
+[[ $(grep -Fc 'shell discoverPlugins acme.local' "$calls") -eq 1 ]] ||
+  fail "add --enable requests explicit discovery more than once"
+pass "URL add --enable discovers once and then enables the new plugin"

--- a/test/shell.d/plugin-add-test.sh
+++ b/test/shell.d/plugin-add-test.sh
@@ -140,6 +140,6 @@ grep -Fqx 'shell discoverPlugins acme.local' "$calls" ||
   fail "URL add does not request targeted discovery"
 grep -Fq 'shell enablePlugin acme.local {}' "$calls" ||
   fail "add --enable does not enable the discovered plugin"
-[[ $(grep -Fc 'shell discoverPlugins acme.local' "$calls") -eq 1 ]] ||
+(( $(grep -Fc 'shell discoverPlugins acme.local' "$calls") == 1 )) ||
   fail "add --enable requests explicit discovery more than once"
 pass "URL add --enable discovers once and then enables the new plugin"

--- a/test/shell.d/plugin-discovery-runtime-test.sh
+++ b/test/shell.d/plugin-discovery-runtime-test.sh
@@ -28,10 +28,28 @@ test_root="$TMPDIR/omarchy"
 test_home="$TMPDIR/home"
 plugins_dir="$test_home/.config/omarchy/plugins"
 log="$TMPDIR/quickshell.log"
-mkdir -p "$test_root" "$plugins_dir"
+stub_dir="$TMPDIR/bin"
+scan_arm="$TMPDIR/scan-arm"
+scan_reached="$TMPDIR/scan-reached"
+scan_release="$TMPDIR/scan-release"
+mkdir -p "$test_root" "$plugins_dir" "$stub_dir"
 cp -a "$ROOT/shell" "$test_root/shell"
 ln -s "$ROOT/config" "$test_root/config"
 ln -s "$ROOT/bin" "$test_root/bin"
+
+cat >"$stub_dir/bash" <<'SH'
+#!/bin/bash
+if [[ -e $OMARCHY_TEST_SCAN_ARM && ${2:-} == *scan_firstparty* ]]; then
+  rm "$OMARCHY_TEST_SCAN_ARM"
+  output=$(/bin/bash "$@")
+  : >"$OMARCHY_TEST_SCAN_REACHED"
+  while [[ ! -e $OMARCHY_TEST_SCAN_RELEASE ]]; do sleep 0.01; done
+  printf '%s\n' "$output"
+else
+  exec /bin/bash "$@"
+fi
+SH
+chmod +x "$stub_dir/bash"
 
 write_service() {
   local dir="$1"
@@ -82,7 +100,7 @@ wait_for_count() {
   local version="$2"
   local expected="$3"
   for _ in {1..80}; do
-    [[ $(instance_count "$id" "$version") -ge $expected ]] && return 0
+    (( $(instance_count "$id" "$version") >= expected )) && return 0
     kill -0 "$QS_PID" 2>/dev/null || return 1
     sleep 0.1
   done
@@ -96,11 +114,39 @@ wait_for_plugin() {
     local present=0
     shell_ipc shell listPlugins 2>/dev/null |
       jq -e --arg id "$id" 'any(.[]; .id == $id)' >/dev/null && present=1
-    [[ $present -eq $expected ]] && return 0
+    (( present == expected )) && return 0
     kill -0 "$QS_PID" 2>/dev/null || return 1
     sleep 0.1
   done
   return 1
+}
+
+wait_for_log() {
+  local pattern="$1"
+  for _ in {1..80}; do
+    grep -qF "$pattern" "$log" 2>/dev/null && return 0
+    kill -0 "$QS_PID" 2>/dev/null || return 1
+    sleep 0.1
+  done
+  return 1
+}
+
+start_blocked_scan() {
+  local name="$1"
+  rm -f "$scan_reached" "$scan_release"
+  : >"$scan_arm"
+  write_service "$plugins_dir/.add.block-$name" "test.scan-block-$name" 1
+  mv "$plugins_dir/.add.block-$name" "$plugins_dir/test.scan-block-$name"
+  for _ in {1..80}; do
+    [[ -e $scan_reached ]] && return 0
+    kill -0 "$QS_PID" 2>/dev/null || return 1
+    sleep 0.1
+  done
+  return 1
+}
+
+release_blocked_scan() {
+  : >"$scan_release"
 }
 
 OMARCHY_PATH="$test_root" \
@@ -108,7 +154,10 @@ HOME="$test_home" \
 XDG_CONFIG_HOME="$test_home/.config" \
 XDG_CACHE_HOME="$test_home/.cache" \
 XDG_STATE_HOME="$test_home/.local/state" \
-PATH="$ROOT/bin:$PATH" \
+OMARCHY_TEST_SCAN_ARM="$scan_arm" \
+OMARCHY_TEST_SCAN_REACHED="$scan_reached" \
+OMARCHY_TEST_SCAN_RELEASE="$scan_release" \
+PATH="$stub_dir:$ROOT/bin:$PATH" \
   quickshell -p "$test_root/shell" --no-color >"$log" 2>&1 &
 QS_PID=$!
 
@@ -126,20 +175,63 @@ write_service "$plugins_dir/.add.test" test.service-c 1
 mv "$plugins_dir/.add.test" "$plugins_dir/test.service-c"
 shell_ipc shell discoverPlugins test.service-c >/dev/null
 wait_for_plugin test.service-c 1 || fail_with_log "new service is discovered"
-[[ $(instance_count test.service-a 1) -eq 1 && $(instance_count test.service-b 1) -eq 1 ]] ||
+(( $(instance_count test.service-a 1) == 1 && $(instance_count test.service-b 1) == 1 )) ||
   fail_with_log "discovering a new plugin does not recreate existing services"
-[[ $(instance_count test.service-c 1) -eq 0 ]] ||
+(( $(instance_count test.service-c 1) == 0 )) ||
   fail_with_log "a newly discovered disabled service is not instantiated"
 pass "new disabled plugins are discovered without recreating existing services"
 
 [[ $(shell_ipc shell setPluginEnabled test.service-c true) == ok ]] ||
   fail_with_log "new service can be enabled after discovery"
 wait_for_count test.service-c 1 1 || fail_with_log "new service is instantiated after enable"
-[[ $(instance_count test.service-a 1) -eq 1 && $(instance_count test.service-b 1) -eq 1 ]] ||
+(( $(instance_count test.service-a 1) == 1 && $(instance_count test.service-b 1) == 1 )) ||
   fail_with_log "enabling the new service does not recreate existing services"
-[[ $(instance_count test.service-c 1) -eq 1 ]] ||
+(( $(instance_count test.service-c 1) == 1 )) ||
   fail_with_log "new service is instantiated exactly once"
 pass "enabling a discovered service creates only that service once"
+
+# Block a scan after its third-party directory glob has been expanded. Plugins
+# moved into place now cannot be part of that scan, so only a queued follow-up
+# can discover them.
+start_blocked_scan watcher-first || fail_with_log "watcher-first scan reaches its deterministic hold point"
+write_service "$plugins_dir/.add.test" test.service-watcher-first 1
+mv "$plugins_dir/.add.test" "$plugins_dir/test.service-watcher-first"
+wait_for_log "Local plugin added, discovering: test.service-watcher-first" ||
+  fail_with_log "watcher requests discovery while the registry is scanning"
+shell_ipc shell discoverPlugins test.service-watcher-first >/dev/null
+if shell_ipc shell listPlugins | jq -e 'any(.[]; .id == "test.service-watcher-first")' >/dev/null; then
+  fail_with_log "blocked initial scan discovers a plugin added after enumeration"
+fi
+release_blocked_scan watcher-first
+wait_for_plugin test.service-watcher-first 1 || fail_with_log "watcher-first pending discovery is processed"
+[[ $(shell_ipc shell setPluginEnabled test.service-watcher-first true) == ok ]] ||
+  fail_with_log "watcher-first service can be enabled"
+wait_for_count test.service-watcher-first 1 1 || fail_with_log "watcher-first service is instantiated"
+(( $(instance_count test.service-watcher-first 1) == 1 )) ||
+  fail_with_log "watcher-first service is instantiated exactly once"
+(( $(instance_count test.service-a 1) == 1 && $(instance_count test.service-b 1) == 1 )) ||
+  fail_with_log "watcher-first queued discovery does not recreate existing services"
+pass "watcher-first discovery queued during a scan is not lost"
+
+start_blocked_scan ipc-first || fail_with_log "IPC-first scan reaches its deterministic hold point"
+shell_ipc shell discoverPlugins test.service-ipc-first >/dev/null
+write_service "$plugins_dir/.add.test" test.service-ipc-first 1
+mv "$plugins_dir/.add.test" "$plugins_dir/test.service-ipc-first"
+wait_for_log "Local plugin added, discovering: test.service-ipc-first" ||
+  fail_with_log "watcher acknowledges IPC-first discovery while the registry is scanning"
+if shell_ipc shell listPlugins | jq -e 'any(.[]; .id == "test.service-ipc-first")' >/dev/null; then
+  fail_with_log "blocked initial scan discovers the IPC-first plugin added after enumeration"
+fi
+release_blocked_scan ipc-first
+wait_for_plugin test.service-ipc-first 1 || fail_with_log "IPC-first pending discovery is processed"
+[[ $(shell_ipc shell setPluginEnabled test.service-ipc-first true) == ok ]] ||
+  fail_with_log "IPC-first service can be enabled"
+wait_for_count test.service-ipc-first 1 1 || fail_with_log "IPC-first service is instantiated"
+(( $(instance_count test.service-ipc-first 1) == 1 )) ||
+  fail_with_log "IPC-first service is instantiated exactly once"
+(( $(instance_count test.service-a 1) == 1 && $(instance_count test.service-b 1) == 1 )) ||
+  fail_with_log "IPC-first queued discovery does not recreate existing services"
+pass "IPC-first discovery queued during a scan is not lost"
 
 shell_ipc shell rescanPlugins >/dev/null
 wait_for_count test.service-a 1 2 || fail_with_log "explicit rescan recreates service A"

--- a/test/shell.d/plugin-discovery-runtime-test.sh
+++ b/test/shell.d/plugin-discovery-runtime-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+require_compositor "plugin discovery runtime test"
+command -v quickshell >/dev/null 2>&1 || {
+  pass "quickshell not installed; skipping plugin discovery runtime test"
+  exit 0
+}
+require_command jq
+
+TMPDIR=$(mktemp -d)
+test_root="$TMPDIR/omarchy"
+test_home="$TMPDIR/home"
+plugins_dir="$test_home/.config/omarchy/plugins"
+log="$TMPDIR/quickshell.log"
+mkdir -p "$test_root" "$plugins_dir"
+cp -a "$ROOT/shell" "$test_root/shell"
+ln -s "$ROOT/config" "$test_root/config"
+ln -s "$ROOT/bin" "$test_root/bin"
+
+write_service() {
+  local dir="$1"
+  local id="$2"
+  local version="$3"
+  mkdir -p "$dir"
+  jq -n --arg id "$id" --arg version "$version" '{
+    schemaVersion: 1,
+    id: $id,
+    name: $id,
+    version: $version,
+    kinds: ["service"],
+    entryPoints: {service: "Service.qml"}
+  }' >"$dir/manifest.json"
+  cat >"$dir/Service.qml" <<QML
+import QtQuick
+
+Item {
+  property var shell: null
+  property var manifest: null
+  Component.onCompleted: console.log("PLUGIN_DISCOVERY_TEST_INSTANCE", "$id", "$version")
+}
+QML
+}
+
+write_service "$plugins_dir/test.service-a" test.service-a 1
+write_service "$plugins_dir/test.service-b" test.service-b 1
+mkdir -p "$test_home/.config/omarchy"
+jq '.plugins = [{id: "test.service-a"}, {id: "test.service-b"}]' \
+  "$ROOT/config/omarchy/shell.json" >"$test_home/.config/omarchy/shell.json"
+
+shell_ipc() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" "$@"
+}
+
+fail_with_log() {
+  local description="$1"
+  sed -n '1,240p' "$log" >&2
+  fail "$description"
+}
+
+instance_count() {
+  grep -c "PLUGIN_DISCOVERY_TEST_INSTANCE $1 $2" "$log" 2>/dev/null || true
+}
+
+wait_for_count() {
+  local id="$1"
+  local version="$2"
+  local expected="$3"
+  for _ in {1..80}; do
+    [[ $(instance_count "$id" "$version") -ge $expected ]] && return 0
+    kill -0 "$QS_PID" 2>/dev/null || return 1
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_plugin() {
+  local id="$1"
+  local expected="$2"
+  for _ in {1..80}; do
+    local present=0
+    shell_ipc shell listPlugins 2>/dev/null |
+      jq -e --arg id "$id" 'any(.[]; .id == $id)' >/dev/null && present=1
+    [[ $present -eq $expected ]] && return 0
+    kill -0 "$QS_PID" 2>/dev/null || return 1
+    sleep 0.1
+  done
+  return 1
+}
+
+OMARCHY_PATH="$test_root" \
+HOME="$test_home" \
+XDG_CONFIG_HOME="$test_home/.config" \
+XDG_CACHE_HOME="$test_home/.cache" \
+XDG_STATE_HOME="$test_home/.local/state" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$test_root/shell" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  shell_ipc shell ping >/dev/null 2>&1 && break
+  kill -0 "$QS_PID" 2>/dev/null || fail_with_log "test shell exited before IPC became available"
+  sleep 0.1
+done
+wait_for_count test.service-a 1 1 || fail_with_log "existing service A starts once"
+wait_for_count test.service-b 1 1 || fail_with_log "existing service B starts once"
+
+# Installation uses a hidden completed staging directory followed by one final
+# rename, matching omarchy-plugin-add. Explicit discovery may race the watcher.
+write_service "$plugins_dir/.add.test" test.service-c 1
+mv "$plugins_dir/.add.test" "$plugins_dir/test.service-c"
+shell_ipc shell discoverPlugins test.service-c >/dev/null
+wait_for_plugin test.service-c 1 || fail_with_log "new service is discovered"
+[[ $(instance_count test.service-a 1) -eq 1 && $(instance_count test.service-b 1) -eq 1 ]] ||
+  fail_with_log "discovering a new plugin does not recreate existing services"
+[[ $(instance_count test.service-c 1) -eq 0 ]] ||
+  fail_with_log "a newly discovered disabled service is not instantiated"
+pass "new disabled plugins are discovered without recreating existing services"
+
+[[ $(shell_ipc shell setPluginEnabled test.service-c true) == ok ]] ||
+  fail_with_log "new service can be enabled after discovery"
+wait_for_count test.service-c 1 1 || fail_with_log "new service is instantiated after enable"
+[[ $(instance_count test.service-a 1) -eq 1 && $(instance_count test.service-b 1) -eq 1 ]] ||
+  fail_with_log "enabling the new service does not recreate existing services"
+[[ $(instance_count test.service-c 1) -eq 1 ]] ||
+  fail_with_log "new service is instantiated exactly once"
+pass "enabling a discovered service creates only that service once"
+
+shell_ipc shell rescanPlugins >/dev/null
+wait_for_count test.service-a 1 2 || fail_with_log "explicit rescan recreates service A"
+wait_for_count test.service-b 1 2 || fail_with_log "explicit rescan recreates service B"
+wait_for_count test.service-c 1 2 || fail_with_log "explicit rescan recreates service C"
+pass "explicit rescanPlugins retains full code-reload semantics"
+
+jq '.name = "Edited service B"' "$plugins_dir/test.service-b/manifest.json" >"$TMPDIR/manifest.json"
+mv "$TMPDIR/manifest.json" "$plugins_dir/test.service-b/manifest.json"
+wait_for_count test.service-b 1 3 || fail_with_log "known plugin edit triggers full reload"
+grep -q "Local plugin changed, reloading: test.service-b" "$log" ||
+  fail_with_log "known plugin edit is classified as a reload"
+pass "editing an installed plugin retains live code reload"
+
+shell_ipc shell setPluginEnabled test.service-c false >/dev/null
+rm -rf "$plugins_dir/test.service-c"
+shell_ipc shell rescanPlugins >/dev/null
+wait_for_plugin test.service-c 0 || fail_with_log "removed plugin leaves the registry"
+write_service "$plugins_dir/.add.test" test.service-c 2
+mv "$plugins_dir/.add.test" "$plugins_dir/test.service-c"
+shell_ipc shell discoverPlugins test.service-c >/dev/null
+wait_for_plugin test.service-c 1 || fail_with_log "same-id plugin is rediscovered"
+sleep 0.3
+[[ $(instance_count test.service-a 1) -ge 4 && $(instance_count test.service-b 1) -ge 4 ]] ||
+  fail_with_log "same-id reinstallation takes the full reload path"
+pass "remove and re-add of a session-known id uses full reload semantics"

--- a/test/shell.d/plugin-discovery-runtime-test.sh
+++ b/test/shell.d/plugin-discovery-runtime-test.sh
@@ -158,11 +158,12 @@ shell_ipc shell setPluginEnabled test.service-c false >/dev/null
 rm -rf "$plugins_dir/test.service-c"
 shell_ipc shell rescanPlugins >/dev/null
 wait_for_plugin test.service-c 0 || fail_with_log "removed plugin leaves the registry"
+before_a=$(instance_count test.service-a 1)
+before_b=$(instance_count test.service-b 1)
 write_service "$plugins_dir/.add.test" test.service-c 2
 mv "$plugins_dir/.add.test" "$plugins_dir/test.service-c"
 shell_ipc shell discoverPlugins test.service-c >/dev/null
 wait_for_plugin test.service-c 1 || fail_with_log "same-id plugin is rediscovered"
-sleep 0.3
-[[ $(instance_count test.service-a 1) -ge 4 && $(instance_count test.service-b 1) -ge 4 ]] ||
-  fail_with_log "same-id reinstallation takes the full reload path"
+wait_for_count test.service-a 1 "$((before_a + 1))" || fail_with_log "same-id reinstallation reloads service A"
+wait_for_count test.service-b 1 "$((before_b + 1))" || fail_with_log "same-id reinstallation reloads service B"
 pass "remove and re-add of a session-known id uses full reload semantics"

--- a/test/shell.d/plugin-lifecycle-test.sh
+++ b/test/shell.d/plugin-lifecycle-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+test_home="$TMPDIR/home"
+stub_dir="$TMPDIR/bin"
+calls="$TMPDIR/calls"
+mkdir -p "$test_home/.config/omarchy/plugins" "$stub_dir"
+
+cat >"$stub_dir/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+if [[ ${1:-} == shell && ${2:-} == listPlugins ]]; then
+  printf '%s\n' "${OMARCHY_TEST_PLUGINS:-[]}"
+elif [[ ${1:-} == shell && ${2:-} == setPluginEnabled ]]; then
+  printf 'ok\n'
+fi
+SH
+chmod +x "$stub_dir/omarchy-shell"
+
+write_version() {
+  local dir="$1"
+  local version="$2"
+  jq -n --arg version "$version" '{
+    schemaVersion: 1,
+    id: "acme.lifecycle",
+    name: "Lifecycle",
+    version: $version,
+    kinds: ["service"],
+    entryPoints: {service: "Service.qml"}
+  }' >"$dir/manifest.json"
+  printf 'import QtQuick\nItem { property string version: "%s" }\n' "$version" >"$dir/Service.qml"
+}
+
+upstream="$TMPDIR/upstream"
+mkdir -p "$upstream"
+git -C "$upstream" init -q
+write_version "$upstream" 1
+git -C "$upstream" add .
+git -C "$upstream" -c user.name=Test -c user.email=test@example.com commit -qm v1
+git clone -q "$upstream" "$test_home/.config/omarchy/plugins/acme.lifecycle"
+write_version "$upstream" 2
+git -C "$upstream" add .
+git -C "$upstream" -c user.name=Test -c user.email=test@example.com commit -qm v2
+
+HOME="$test_home" OMARCHY_PATH="$ROOT" OMARCHY_TEST_CALLS="$calls" \
+  PATH="$stub_dir:$ROOT/bin:$PATH" omarchy-plugin-update acme.lifecycle --yes >/dev/null
+[[ $(jq -r .version "$test_home/.config/omarchy/plugins/acme.lifecycle/manifest.json") == 2 ]] ||
+  fail "plugin update does not install changed plugin contents"
+grep -Fqx 'shell rescanPlugins' "$calls" ||
+  fail "plugin update does not request full reload semantics"
+! grep -q 'discoverPlugins' "$calls" ||
+  fail "plugin update is mistaken for new-plugin discovery"
+pass "plugin update retains full reload semantics for changed contents"
+
+: >"$calls"
+plugins='[{"id":"acme.lifecycle","enabled":true}]'
+HOME="$test_home" OMARCHY_PATH="$ROOT" OMARCHY_TEST_CALLS="$calls" \
+  OMARCHY_TEST_PLUGINS="$plugins" PATH="$stub_dir:$ROOT/bin:$PATH" \
+  omarchy-plugin-remove acme.lifecycle --yes >/dev/null
+[[ ! -e $test_home/.config/omarchy/plugins/acme.lifecycle ]] ||
+  fail "plugin remove leaves its git checkout installed"
+grep -Fqx 'shell setPluginEnabled acme.lifecycle false' "$calls" ||
+  fail "plugin remove does not disable a loaded plugin first"
+grep -Fqx 'shell rescanPlugins' "$calls" ||
+  fail "plugin remove does not retain full reload semantics"
+pass "plugin remove disables its plugin and retains the existing full reload path"

--- a/test/shell.d/plugin-reload-test.sh
+++ b/test/shell.d/plugin-reload-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const shell = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+const rescan = shell.match(/function rescanPlugins\(\): void \{([\s\S]*?)\n    \}/)
+const discover = shell.match(/function discoverPlugins\(id: string\): void \{([\s\S]*?)\n    \}/)
+
+assert(rescan, 'shell exposes plugin code reload over IPC')
+assert(
+  /shell\.reloadPlugins\(\)/.test(rescan[1]),
+  'explicit code reloads retain the full plugin teardown path'
+)
+assert(discover, 'shell exposes plugin discovery over IPC')
+assert(
+  /watcherPluginDiscoveries/.test(discover[1])
+    && /knownLocalPluginIds/.test(discover[1])
+    && /shell\.reloadPlugins\(\)/.test(discover[1])
+    && /shell\.pluginRegistry\.rescan\(\)/.test(discover[1]),
+  'plugin discovery is idempotent and same-id reinstalls use code reload semantics'
+)
+
+const localChange = shell.match(/function onLocalPluginChanged\(pluginId\) \{([\s\S]*?)\n    \}/)
+assert(localChange, 'shell handles local plugin filesystem changes')
+assert(
+  /!shell\.knownLocalPluginIds\[pluginId\]/.test(localChange[1])
+    && /rememberLocalPlugin\(pluginId\)/.test(localChange[1])
+    && /shell\.pluginRegistry\.rescan\(\)/.test(localChange[1]),
+  'new plugin directories use discovery without global teardown'
+)
+assert(
+  /localPluginReloadTimer\.restart\(\)/.test(localChange[1]),
+  'changes to installed plugins retain debounced code reload'
+)
+
+const add = fs.readFileSync(path.join(root, 'bin/omarchy-plugin-add'), 'utf8')
+assert(
+  /omarchy-shell shell discoverPlugins "\$id"/.test(add),
+  'plugin add requests targeted metadata discovery for its installed id'
+)
+JS

--- a/test/shell.d/plugin-reload-test.sh
+++ b/test/shell.d/plugin-reload-test.sh
@@ -21,7 +21,7 @@ assert(
   /watcherPluginDiscoveries/.test(discover[1])
     && /knownLocalPluginIds/.test(discover[1])
     && /shell\.reloadPlugins\(\)/.test(discover[1])
-    && /shell\.pluginRegistry\.rescan\(\)/.test(discover[1]),
+    && /requestPluginDiscovery\(pluginId\)/.test(discover[1]),
   'plugin discovery is idempotent and same-id reinstalls use code reload semantics'
 )
 
@@ -29,13 +29,22 @@ const localChange = shell.match(/function onLocalPluginChanged\(pluginId\) \{([\
 assert(localChange, 'shell handles local plugin filesystem changes')
 assert(
   /!shell\.knownLocalPluginIds\[pluginId\]/.test(localChange[1])
-    && /rememberLocalPlugin\(pluginId\)/.test(localChange[1])
-    && /shell\.pluginRegistry\.rescan\(\)/.test(localChange[1]),
+    && /requestPluginDiscovery\(pluginId\)/.test(localChange[1]),
   'new plugin directories use discovery without global teardown'
 )
 assert(
   /localPluginReloadTimer\.restart\(\)/.test(localChange[1]),
   'changes to installed plugins retain debounced code reload'
+)
+
+assert(
+  /function requestPluginDiscovery\(pluginId\)[\s\S]*?pluginRegistry\.scanning[\s\S]*?pluginRegistry\.rescan\(\)/.test(shell),
+  'targeted discovery queues requests that arrive during a registry scan'
+)
+assert(
+  /function onScanFinished\(\)[\s\S]*?finishPluginDiscoveries\(\)/.test(shell)
+    && /function finishPluginDiscoveries\(\)[\s\S]*?Qt\.callLater\(shell\.pluginRegistry\.rescan\)/.test(shell),
+  'scan completion drains queued targeted discovery with a metadata-only follow-up'
 )
 
 const add = fs.readFileSync(path.join(root, 'bin/omarchy-plugin-add'), 'utf8')


### PR DESCRIPTION
## Why

Adding a new plugin currently triggers a full plugin reload, which unloads and recreates unrelated plugin panels, services, and widgets.

In physical testing, even installing an inert no-op plugin caused visible desktop jitter. Reducing the process from two full reloads to one still reproduced the problem.

A newly installed plugin only needs to be discovered and registered; existing plugin instances do not need to be recreated.

## What changed

- Added a targeted `discoverPlugins` path for newly installed plugins.
- Newly discovered plugins are registered without unloading or recreating existing plugin components.
- `omarchy plugin add --enable` now discovers the new plugin before enabling it.
- Filesystem-watcher discovery and explicit discovery are idempotent regardless of which happens first.
- Changes to already-known plugins continue using the existing full reload path.
- Explicit `rescanPlugins`, plugin updates, removals, and same-ID reinstalls retain their existing full reload semantics.

With targeted discovery:

- global plugin recreation cycles: `0`
- invalid QML-context warnings: `0`
- existing services recreated: `0`
- visible installation jitter: none

## Testing

Passed: 

- `test/shell.d/plugin-add-test.sh`
- `test/shell.d/plugin-reload-test.sh`
- `test/shell.d/plugin-lifecycle-test.sh`
- `test/shell.d/plugin-discovery-runtime-test.sh`
- `test/shell.d/runtime-smoke-test.sh`
- `./test/cli`
- `git diff --check`

Regression coverage includes:

- plugin add
- plugin add with `--enable`
- local and remote repositories
- failed clone and invalid manifest cleanup
- duplicate IDs and existing destinations
- watcher/IPC discovery ordering
- service instance stability
- plugin updates and removals
- same-ID reinstall
- explicit `rescanPlugins`
- edits to already-installed plugin QML

A runtime test verifies that two existing enabled services remain at one instance each while a third plugin is discovered, and that enabling the new service creates exactly one instance.

Physical testing also confirmed:

- inert plugin install: no visible jitter
- inert service install with `--enable`: no visible jitter
- real service plugin install: no visible jitter
- real service plugin enable: no visible jitter
- editing an already-installed plugin still invokes the existing full hot-reload path

`./test/all` still reports four failures that also reproduce on the tested base commit `ed7bae4ac5a570e9df307486e0202fdafcc6ee24`:

- Bluetooth bar-icon geometry tolerance
- three tests requiring an unavailable `omarchy-pkgs` checkout

These are pre-existing/environmental and are not introduced by this patch.

## Scope

This change only optimizes discovery of genuinely new plugins.

Existing plugin edits, updates, removals, same-ID reinstalls, and explicit `rescanPlugins` calls continue using the current full reload behavior.

This does not attempt to solve the broader QML component-cache or Quickshell hot-reload issues.

Related to #6981, #7362, and #7076.