### PR TITLE
Stop building a theme signature nothing reads

### DIFF
--- a/bin/omarchy-theme-switcher
+++ b/bin/omarchy-theme-switcher
@@ -13,7 +13,6 @@ USER_THEMES_PATH="$HOME/.config/omarchy/themes"
 OMARCHY_THEMES_PATH="$OMARCHY_PATH/themes"
 CACHE_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/omarchy/theme-selector"
 preview_dir="$CACHE_PATH/previews"
-signature_file="$CACHE_PATH/signature"
 fast_signature_file="$CACHE_PATH/fast-signature"
 
 mkdir -p "$preview_dir"
@@ -60,24 +59,6 @@ for theme_dir in "$USER_THEMES_PATH" "$OMARCHY_THEMES_PATH"; do
 done
 
 if [[ ! -f $fast_signature_file ]] || ! cmp -s "$fast_signature_file" <(printf '%s' "$fast_signature"); then
-  theme_signature=""
-  for theme_dir in "$USER_THEMES_PATH" "$OMARCHY_THEMES_PATH"; do
-    if [[ -d $theme_dir ]]; then
-      theme_signature+="$theme_dir:$(stat -Lc '%Y' "$theme_dir")"$'\n'
-
-      while IFS= read -r -d '' theme_path; do
-        preview=$(find_preview "$theme_path")
-        theme_signature+="$theme_path:$(stat -Lc '%Y' "$theme_path")"$'\n'
-
-        if [[ -n $preview ]]; then
-          theme_signature+="$preview:$(stat -Lc '%s:%Y' "$preview")"$'\n'
-        fi
-      done < <(find -L "$theme_dir" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print0 2>/dev/null | sort -z)
-    fi
-  done
-fi
-
-if [[ ! -f $fast_signature_file ]] || ! cmp -s "$fast_signature_file" <(printf '%s' "$fast_signature"); then
   rm -rf "$preview_dir"
   mkdir -p "$preview_dir"
 
@@ -98,7 +79,6 @@ if [[ ! -f $fast_signature_file ]] || ! cmp -s "$fast_signature_file" <(printf '
     add_theme_preview "$theme_name" "$preview"
   done < <(find -L "$OMARCHY_THEMES_PATH" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | sort)
 
-  printf '%s' "$theme_signature" >"$signature_file"
   printf '%s' "$fast_signature" >"$fast_signature_file"
 fi
 


### PR DESCRIPTION
`omarchy-theme-switcher` builds two signatures for the preview cache. One is the fast signature based on directory times. The other is a fuller one that runs `find_preview` on every theme.

Commit 523803e9 added the fast signature and pointed the cache check at it. It moved the older signature code inside the new check rather than removing it. So both checks now test the same fast signature, and `$CACHE_PATH/signature` gets written at the end but is never read again by anything in the repo.

What is left is a full pass over every theme, calling `find_preview` on each one, only to write a file nothing opens.

This removes that pass, the variable, and the write.

Measured on a cold rebuild against the 22 themes in the repo, with a counting wrapper around `find` and a stub in place of `omarchy-menu-images`:

- `find` calls drop from 48 to 25.
- The previews directory comes out with the same 22 entries, and each symlink points at the same file as before.
- The only other difference in the cache directory is that the dead `signature` file is no longer created.

`./test/cli` passes on this branch, 116 tests, no failures. `./test/all` comes out the same on this
branch as on `quattro`, 2343 passing with the same 11 failures either way. Those 11 are tools missing
from my environment, `lua` and `magick` and an `omarchy-pkgs` checkout, and not anything this touches.

One leftover worth knowing about: anyone who has run the old version still has a stale `$CACHE_PATH/signature` file in their cache. It is a few KB and nothing reads it, so I left it there rather than adding cleanup code for one dead file.

Tested on Ubuntu, bash 5.2.21.
