### PR TITLE
Read the tmux session list once per theme change

### DIFF
--- a/bin/omarchy-theme-set-tmux
+++ b/bin/omarchy-theme-set-tmux
@@ -11,6 +11,10 @@ if ! tmux list-sessions >/dev/null 2>&1; then
   exit 0
 fi
 
+# The theme has well over a hundred environment keys, and the session list is
+# the same for all of them, so read it once here rather than once per key.
+mapfile -t tmux_sessions < <(tmux list-sessions -F "#{session_id}" 2>/dev/null)
+
 set_tmux_environment() {
   local key="$1"
   local value="$2"
@@ -18,10 +22,10 @@ set_tmux_environment() {
 
   tmux set-environment -g "$key" "$value" 2>/dev/null || return 0
 
-  while IFS= read -r session; do
+  for session in "${tmux_sessions[@]}"; do
     [[ -n $session ]] || continue
     tmux set-environment -t "$session" "$key" "$value" 2>/dev/null || true
-  done < <(tmux list-sessions -F "#{session_id}" 2>/dev/null)
+  done
 }
 
 sync_theme_environment() {

--- a/test/shell.d/theme-set-tmux-test.sh
+++ b/test/shell.d/theme-set-tmux-test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+log_file="$test_tmp/tmux.log"
+theme_dir="$test_tmp/home/.local/state/omarchy/current/theme"
+mkdir -p "$stub_bin" "$theme_dir"
+
+# Two sessions, no panes or clients: enough to count the calls that matter
+# without dragging the pane and client loops into the numbers.
+cat >"$stub_bin/tmux" <<'SH'
+#!/bin/bash
+
+printf 'tmux' >>"$OMARCHY_TMUX_TEST_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >>"$OMARCHY_TMUX_TEST_LOG"
+done
+printf '\n' >>"$OMARCHY_TMUX_TEST_LOG"
+
+case "$1" in
+  list-sessions)
+    printf '$0\n$1\n'
+    ;;
+esac
+SH
+chmod +x "$stub_bin/tmux"
+
+cat >"$stub_bin/omarchy-theme-color" <<'SH'
+#!/bin/bash
+
+case "${!#}" in
+  mode) echo dark ;;
+  *) echo '#000000' ;;
+esac
+SH
+chmod +x "$stub_bin/omarchy-theme-color"
+
+cat >"$stub_bin/omarchy-theme-osc" <<'SH'
+#!/bin/bash
+SH
+chmod +x "$stub_bin/omarchy-theme-osc"
+
+cat >"$theme_dir/gum_env.lua" <<'LUA'
+hl.env("GUM_ONE", "1")
+hl.env("GUM_TWO", "2")
+hl.env("GUM_THREE", "3")
+LUA
+: >"$theme_dir/colors.toml"
+
+: >"$log_file"
+HOME="$test_tmp/home" \
+  OMARCHY_TMUX_TEST_LOG="$log_file" \
+  PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-theme-set-tmux"
+
+count_lines() {
+  grep -c -- "$1" "$log_file" || true
+}
+
+# One call is the guard at the top, one reads the list for the loop. Every key
+# used to add another, so this is the number that proves the list is read once.
+list_calls=$(count_lines $'^tmux\tlist-sessions')
+(( list_calls == 2 )) ||
+  fail "theme-set-tmux reads the session list once for all keys" "list-sessions calls: $list_calls"
+pass "theme-set-tmux reads the session list once for all keys"
+
+# Three keys from gum_env plus COLORFGBG, each set globally and in both sessions.
+global_sets=$(count_lines $'^tmux\tset-environment\t-g\t')
+(( global_sets == 4 )) ||
+  fail "theme-set-tmux sets every key globally" "global set-environment calls: $global_sets"
+pass "theme-set-tmux sets every key globally"
+
+for session in '$0' '$1'; do
+  for key in GUM_ONE GUM_TWO GUM_THREE COLORFGBG; do
+    grep -qF -- $'tmux\tset-environment\t-t\t'"$session"$'\t'"$key"$'\t' "$log_file" ||
+      fail "theme-set-tmux sets $key in session $session" "$(cat "$log_file")"
+  done
+done
+pass "theme-set-tmux sets every key in every session"
+
+session_sets=$(count_lines $'^tmux\tset-environment\t-t\t')
+(( session_sets == 8 )) ||
+  fail "theme-set-tmux sets each key once per session" "per-session set-environment calls: $session_sets"
+pass "theme-set-tmux sets each key once per session"


### PR DESCRIPTION
`set_tmux_environment` calls `tmux list-sessions` every time it runs, and it runs once for every theme environment key. There are 116 of those keys, counted from `default/themed/gum_env.lua.tpl` with the same awk filter the script itself uses. The session list does not change while the script is running, so all of those calls ask the same question and get the same answer.

This reads the list once up front and loops over it instead.

Measured against real tmux with two sessions open:

- `tmux show-environment` afterwards is identical, globally and for both sessions, 392 lines each way.
- This script goes from 1.02s to 0.78s, averaged over 5 runs each, with every run checked to have actually populated the session environment.
- The number of `list-sessions` calls goes from 118 to 2.

Worth being clear about what that 0.24s does and does not buy. This script runs in the `run_parallel` fan out in `omarchy-theme-set`, which waits on all 14 commands, so it only shortens the whole thing if this is the slowest of the 14, and I have not checked whether it is. That block also runs after the `flock -u 9` release, once the theme is applied and the shell has accepted it, so nothing the user is looking at happens sooner. What actually improves is that tmux panes pick up the new colors about 0.24s earlier, and only for people with a tmux server running at all. Everyone else exits at the guard on line 11 either way.

So this is a small win on its own. The better reason to take it is that asking tmux the same question 116 times in a row is simply wrong, and the fix is four lines.

Tests: new `test/shell.d/theme-set-tmux-test.sh` runs the script against a stubbed `tmux` that reports two sessions and logs every call. It checks that `list-sessions` is called exactly twice (the guard and the one read), that every key from a three-key `gum_env.lua` plus `COLORFGBG` is set globally and in both sessions, and that each key is set once per session. Against the old script the first check fails with five calls. The existing `./test/cli` tmux case only checks that `COLORFGBG` lands, so it passes on both versions and would not have caught a slide back to per-key listing.

One behavior note: a session created while the script is running will no longer pick up the keys that are left. Before this change it would have picked up whatever had not been set yet. A theme sync takes well under a second, and the functions that touch panes already read their list once and work from that, so this seemed like the right trade.

There is more that could be done here. The calls that remain are one `set-environment` per key per session, and tmux can take several commands in a single call. I left that out because `COLORFGBG` is set to a value with a semicolon in it, and tmux reads a bare semicolon as a command separator, and because the current code ignores a failure on any single key on purpose, which one combined call would give up. I have not tested that version, so it is not part of this change.

Tested on Ubuntu, bash 5.2.21, tmux 3.4.
