### PR TITLE
Add Quick Settings to Setup menu

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -123,6 +123,12 @@
   "style.screensaver.default": {"icon":"","label":"Restore Default","action":"omarchy-branding-screensaver reset"},
 
   // Setup
+  "setup.quick-settings": {"icon":"󰒓","label":"Quick Settings"},
+  "setup.quick-settings.wifi": {"icon":"󰖩","label":"Wi-Fi","action":"omarchy-shell shell summon omarchy.network"},
+  "setup.quick-settings.bluetooth": {"icon":"󰂯","label":"Bluetooth","action":"omarchy-shell shell summon omarchy.bluetooth"},
+  "setup.quick-settings.audio": {"icon":"󰕾","label":"Audio","action":"omarchy-shell shell summon omarchy.audio"},
+  "setup.quick-settings.display": {"icon":"󰍹","label":"Display","action":"omarchy-shell shell summon omarchy.monitor"},
+  "setup.quick-settings.power": {"icon":"󰐥","label":"Power","action":"omarchy-shell shell summon omarchy.power"},
   "setup.monitors": {"icon":"󰍹","label":"Monitors","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/monitors.lua\""},
   "setup.keybindings": {"icon":"","label":"Keybindings","when":"[[ -f ~/.config/hypr/bindings.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/bindings.lua\""},
   "setup.input": {"icon":"","label":"Input","when":"[[ -f ~/.config/hypr/input.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/input.lua\""},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -128,7 +128,6 @@
   "setup.quick-settings.bluetooth": {"icon":"󰂯","label":"Bluetooth","action":"omarchy-shell shell summon omarchy.bluetooth"},
   "setup.quick-settings.audio": {"icon":"󰕾","label":"Audio","action":"omarchy-shell shell summon omarchy.audio"},
   "setup.quick-settings.display": {"icon":"󰍹","label":"Display","action":"omarchy-shell shell summon omarchy.monitor"},
-  "setup.quick-settings.power": {"icon":"󰐥","label":"Power","action":"omarchy-shell shell summon omarchy.power"},
   "setup.monitors": {"icon":"󰍹","label":"Monitors","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/monitors.lua\""},
   "setup.keybindings": {"icon":"","label":"Keybindings","when":"[[ -f ~/.config/hypr/bindings.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/bindings.lua\""},
   "setup.input": {"icon":"","label":"Input","when":"[[ -f ~/.config/hypr/input.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/input.lua\""},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -128,6 +128,7 @@
   "setup.quick-settings.bluetooth": {"icon":"󰂯","label":"Bluetooth","action":"omarchy-shell shell summon omarchy.bluetooth"},
   "setup.quick-settings.audio": {"icon":"󰕾","label":"Audio","action":"omarchy-shell shell summon omarchy.audio"},
   "setup.quick-settings.display": {"icon":"󰍹","label":"Display","action":"omarchy-shell shell summon omarchy.monitor"},
+  "setup.quick-settings.power": {"icon":"󰐥","label":"Power","when":"omarchy-hw-laptop","action":"omarchy-shell shell summon omarchy.power"},
   "setup.monitors": {"icon":"󰍹","label":"Monitors","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/monitors.lua\""},
   "setup.keybindings": {"icon":"","label":"Keybindings","when":"[[ -f ~/.config/hypr/bindings.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/bindings.lua\""},
   "setup.input": {"icon":"","label":"Input","when":"[[ -f ~/.config/hypr/input.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/input.lua\""},

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -196,6 +196,24 @@ assert(
   defaultById['setup.input'].action.includes('input.lua'),
   'menu keeps Input as a direct config action'
 )
+const quickSettingsPanels = {
+  wifi: 'omarchy.network',
+  bluetooth: 'omarchy.bluetooth',
+  audio: 'omarchy.audio',
+  display: 'omarchy.monitor',
+  power: 'omarchy.power'
+}
+assertEqual(
+  defaultById['setup.quick-settings'].kind,
+  'menu',
+  'menu exposes Quick Settings under Setup'
+)
+assert(
+  Object.entries(quickSettingsPanels).every(([entry, panel]) =>
+    defaultById[`setup.quick-settings.${entry}`].action === `omarchy-shell shell summon ${panel}`
+  ),
+  'menu opens every Quick Settings panel from Setup'
+)
 assert(
   defaultById['setup.direct-boot'].action.includes('omarchy-setup-direct-boot'),
   'menu places Direct Boot directly under Setup'

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -200,8 +200,7 @@ const quickSettingsPanels = {
   wifi: 'omarchy.network',
   bluetooth: 'omarchy.bluetooth',
   audio: 'omarchy.audio',
-  display: 'omarchy.monitor',
-  power: 'omarchy.power'
+  display: 'omarchy.monitor'
 }
 assertEqual(
   defaultById['setup.quick-settings'].kind,

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -200,7 +200,8 @@ const quickSettingsPanels = {
   wifi: 'omarchy.network',
   bluetooth: 'omarchy.bluetooth',
   audio: 'omarchy.audio',
-  display: 'omarchy.monitor'
+  display: 'omarchy.monitor',
+  power: 'omarchy.power'
 }
 assertEqual(
   defaultById['setup.quick-settings'].kind,
@@ -212,6 +213,11 @@ assert(
     defaultById[`setup.quick-settings.${entry}`].action === `omarchy-shell shell summon ${panel}`
   ),
   'menu opens every Quick Settings panel from Setup'
+)
+assertEqual(
+  defaultById['setup.quick-settings.power'].when,
+  'omarchy-hw-laptop',
+  'menu only offers the battery-dependent Power panel on laptops'
 )
 assert(
   defaultById['setup.direct-boot'].action.includes('omarchy-setup-direct-boot'),


### PR DESCRIPTION
## Summary

- add a **Setup > Quick Settings** submenu to the Omarchy menu
- expose the Wi-Fi, Bluetooth, Audio, Display, and laptop-only Power shell panels there
- cover the menu hierarchy and panel targets in the menu test

## Why

I bought a brand-new Beelink computer following the DHH/Omarchy recommendation. On a fresh start, it does not automatically reconnect either my Bluetooth mouse or Wi-Fi.

That is exactly when discoverability matters most: without Wi-Fi I cannot even ask Codex how to recover, and without a connected mouse it is difficult to explore the bar. The panel keyboard shortcuts exist, but they are hard to discover when searching through the Omarchy menu for Bluetooth or Wi-Fi.

Putting the existing shell panels under **Setup > Quick Settings** provides a keyboard-searchable recovery path without duplicating their behavior or introducing a second settings implementation.

## Verification

- `bash test/shell.d/menu-test.sh` passes
- the same menu extension was verified in the running Omarchy UI
- `./test/all`: CLI suite passed; the shell suite had five environment-only failures because the private `omarchy-pkgs` checkout and writable live Quickshell runtime were unavailable
