### PR TITLE
Switch back to the packaged quickshell now that 0.3.1 kills synchronously

### DIFF
--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -63,7 +63,6 @@ relock_session() {
 
 # Each kill stops the oldest matching instance and only returns once it has
 # fully exited, so the no-duplicate launch below can't race a dying shell.
-# Requires quickshell 0.3.1 or newer; 0.3.0's kill returned immediately.
 while timeout 5 quickshell kill -p "$CONFIG_DIR" --any-display >/dev/null 2>&1; do :; done
 
 # Spawn from Hyprland so the shell inherits the canonical session environment,

--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -63,7 +63,7 @@ relock_session() {
 
 # Each kill stops the oldest matching instance and only returns once it has
 # fully exited, so the no-duplicate launch below can't race a dying shell.
-# Requires our quickshell-git build; 0.3.0's kill returns immediately.
+# Requires quickshell 0.3.1 or newer; 0.3.0's kill returned immediately.
 while timeout 5 quickshell kill -p "$CONFIG_DIR" --any-display >/dev/null 2>&1; do :; done
 
 # Spawn from Hyprland so the shell inherits the canonical session environment,

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -109,7 +109,7 @@ ttfx
 qemu-user-static-binfmt
 qrencode
 qt6-imageformats
-quickshell-git
+quickshell
 ripgrep
 ruby
 tensaku

--- a/migrations/1787399318.sh
+++ b/migrations/1787399318.sh
@@ -1,0 +1,9 @@
+echo "Switch back to the packaged quickshell now that 0.3.1 kills synchronously"
+
+# 0.3.1 fixes `kill` returning before the instance has exited, which is the only
+# reason Omarchy shipped the git build.
+if omarchy-pkg-present quickshell-git; then
+  # One transaction with --ask 4 so pacman accepts replacing the conflicting
+  # quickshell-git in place; packages depending on quickshell stay satisfied.
+  sudo pacman -S --noconfirm --ask 4 quickshell
+fi


### PR DESCRIPTION
Omarchy ships the `quickshell-git` build for exactly one reason: 0.3.0's `kill` returned before the instance had exited, so the kill loop in `omarchy-restart-shell` could launch a new shell while the old one was still dying. Upstream [0.3.1](https://quickshell.org/changelog) fixes that — "Fixed `qs kill` not waiting for the process to exit" — and Arch published it to `extra` on 2026-08-21.

That makes the git build the worse package to be on. `extra/quickshell` is signed, versioned, and pinned to a release, where the git build is rebuilt from a moving branch and currently sits at `0.3.0.r20.g28771c7`.

The migration swaps unconditionally rather than first checking which version the mirror is offering. A machine left holding `quickshell-git` while the shipped package list names `quickshell` has no way to reconcile the two: `omarchy-reinstall-pkgs` installs that list with `--needed`, which does not skip a name that is not installed, and the conflict it then walks into has no answer under `--noconfirm`. A mirror that is briefly behind installs 0.3.0 instead and the next upgrade carries it to 0.3.1, which is much the cheaper way to be wrong.

`--ask 4` is `ALPM_QUESTION_CONFLICT_PKG`, so pacman replaces the conflicting `quickshell-git` in one transaction; `omarchy-dev` depends on the virtual `quickshell` and stays satisfied across the swap. Fresh installs need no migration — they already own the correctly named package, and an ordinary `pacman -Syu` carries them from 0.3.0 to 0.3.1.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
