### PR TITLE
Launch Codex app-server with an approval policy the CLI accepts

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "on-request", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-limits-test.sh
+++ b/test/shell.d/agent-usage-codex-limits-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+# Codex 0.149 retired the "untrusted" approval policy, and the CLI rejects an
+# unknown one before app-server starts. The collector discards app-server's
+# stderr and waits for an RPC reply, so that immediate exit surfaced as the
+# pending method name — "initialize" — and the panel lost its limits with no
+# hint of why. This stub answers the way the CLI does: it validates the policy
+# first, and only then speaks the protocol.
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.codex" "$TEST_HOME/bin"
+
+cat >"$TEST_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+
+policy=""
+while (( $# )); do
+  case "$1" in
+    -a | --ask-for-approval)
+      policy="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+case "$policy" in
+  on-request | never) ;;
+  *)
+    echo "error: invalid value '$policy' for '--ask-for-approval <APPROVAL_POLICY>'" >&2
+    exit 2
+    ;;
+esac
+
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  method=$(jq -r '.method // empty' <<<"$request")
+
+  case "$method" in
+    initialize)
+      jq -cn --argjson id "$id" '{id: $id, result: {}}'
+      ;;
+    account/read)
+      jq -cn --argjson id "$id" '{id: $id, result: {account: {planType: "team"}}}'
+      ;;
+    account/rateLimits/read)
+      jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {planType: "team", primary: {usedPercent: 53, windowDurationMins: 10080}}}}'
+      ;;
+  esac
+done
+EOF
+chmod +x "$TEST_HOME/bin/codex"
+
+result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -c '[.limits[] | {label, percent}]' <<<"$result") == '[{"label":"Weekly (7-day)","percent":0.53}]' ]] ||
+  fail "Codex collector reads the window app-server reports" "$result"
+pass "Codex collector reads the window app-server reports"
+
+[[ $(jq -r '.tierLabel' <<<"$result") == "team" ]] ||
+  fail "Codex collector names the plan app-server reports" "$result"
+pass "Codex collector names the plan app-server reports"
+
+# The regression this file exists for: a rejected policy left the panel showing
+# "Codex limits unavailable" over the RPC method that never got an answer.
+[[ -z $(jq -r '.usageStatusText' <<<"$result") ]] ||
+  fail "Codex collector launches app-server with an approval policy the CLI accepts" "$result"
+pass "Codex collector launches app-server with an approval policy the CLI accepts"

--- a/test/shell.d/agent-usage-codex-limits-test.sh
+++ b/test/shell.d/agent-usage-codex-limits-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/base-test.sh"
 
 require_command jq


### PR DESCRIPTION
Fixes #7648.

Codex 0.149 retired the `untrusted` approval policy ([openai/codex#39630](https://github.com/openai/codex/pull/39630)), so the collector's launch never reaches app-server:

```console
$ codex -s read-only -a untrusted app-server
error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'
  [possible values: on-request, never]
```

`fetch_codex_rpc` discards app-server's stderr and waits on the `initialize` reply, so the immediate exit surfaces as `TimeoutError("initialize")`. The panel then shows `Codex limits unavailable` over the bare method name — the symptom several people reported in the issue. Local token and session stats keep working, since they come off the session files.

Asking for `on-request` restores the limits. It is the closest surviving policy to the original intent: nothing is auto-approved, `-s read-only` still bounds the sandbox, and the app-server is only ever read from (`account/read`, `account/rateLimits/read`).

## Test

`test/shell.d/agent-usage-codex-limits-test.sh` stubs `codex` the way the real CLI behaves: it validates `--ask-for-approval` before speaking the protocol, and rejects a retired value. The test fails on `quattro` with the reported `authHelpText: "initialize"` and passes with the fix.

```
ok - Codex collector reads the window app-server reports
ok - Codex collector names the plan app-server reports
ok - Codex collector launches app-server with an approval policy the CLI accepts
```

Verified against a live Codex 0.149.0 sign-in too: the collector returns `tierLabel: "team"`, an empty `usageStatusText`, and the weekly window.

`./test/all` is otherwise unchanged — the 4 failures on this machine (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`) reproduce on a clean `quattro` checkout.

## Not in this PR

The issue also notes that an early app-server exit should not be reported as the pending RPC method name. That is a separate change to the error handling and I left it out to keep this atomic — happy to follow up if you want it.
