### PR TITLE
Gate the IPU7 camera stack on the controller, not the sensor

### DIFF
--- a/install/hardware/intel/ipu7-camera.sh
+++ b/install/hardware/intel/ipu7-camera.sh
@@ -1,5 +1,11 @@
 # Install MIPI camera support for Intel IPU7 hardware
 
-if grep -q "OVTI08F4" /sys/bus/acpi/devices/*/hid 2>/dev/null; then
+# The ov08x40 sensor (OVTI08F4) sits behind IPU6 on Meteor Lake as much as behind IPU7 on
+# Panther Lake, so the controller decides; intel-ipu7-camera builds the ipu75xa HAL alone.
+acpi_devices="${OMARCHY_ACPI_DEVICES_PATH:-/sys/bus/acpi/devices}"
+
+if pci_devices=$(lspci -nn) &&
+  grep -q "OVTI08F4" "$acpi_devices"/*/hid 2>/dev/null &&
+  grep -qi '\[8086:b05d\]' <<<"$pci_devices"; then
   omarchy-pkg-add intel-ipu7-camera
 fi

--- a/test/shell.d/ipu7-camera-test.sh
+++ b/test/shell.d/ipu7-camera-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+install_script="$ROOT/install/hardware/intel/ipu7-camera.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+acpi_devices="$test_tmp/acpi"
+mkdir -p "$stub_bin" "$acpi_devices/device:00" "$acpi_devices/device:01"
+
+echo 'INTC1059' >"$acpi_devices/device:00/hid"
+
+# Chatty past the pipe buffer after the match, so a gate that piped lspci into a
+# grep that stops reading would die of SIGPIPE and read as "no IPU7" (#6608).
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+(( ${LSPCI_STATUS:-0} == 0 )) || exit "$LSPCI_STATUS"
+[[ -n ${IPU_PCI_ID:-} ]] &&
+  printf '00:05.0 Multimedia controller [0480]: Intel Corporation Image Processing Unit [8086:%s]\n' "$IPU_PCI_ID"
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add\t%s\n' "$*" >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_install() {
+  : >"$calls"
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    IPU_PCI_ID="${1:-}" \
+    LSPCI_STATUS="${2:-0}" \
+    OMARCHY_ACPI_DEVICES_PATH="$acpi_devices" \
+    bash -euo pipefail -c 'source "$1"' bash "$install_script"
+}
+
+echo 'OVTI08F4' >"$acpi_devices/device:01/hid"
+
+run_install b05d
+grep -Fxq $'omarchy-pkg-add\tintel-ipu7-camera' "$calls" ||
+  fail "Panther Lake installs the IPU7 camera stack" "$(cat "$calls")"
+pass "Panther Lake with an ov08x40 sensor installs the IPU7 camera stack"
+
+# The sensor spans generations, and the package builds only the ipu75xa HAL: every
+# other controller gets a camera stack that cannot drive it (#7697).
+run_install 7d19
+[[ ! -s $calls ]] ||
+  fail "Meteor Lake IPU6 skips the IPU7 camera stack" "$(cat "$calls")"
+
+run_install a75d
+[[ ! -s $calls ]] ||
+  fail "Raptor Lake IPU6 skips the IPU7 camera stack" "$(cat "$calls")"
+
+run_install 645d
+[[ ! -s $calls ]] ||
+  fail "Lunar Lake, which the ipu75xa HAL does not cover, is skipped" "$(cat "$calls")"
+pass "the same sensor behind another controller installs nothing"
+
+run_install "" 1
+[[ ! -s $calls ]] ||
+  fail "an unreadable PCI bus skips the IPU7 camera stack" "$(cat "$calls")"
+pass "an unreadable PCI bus installs nothing"
+
+echo 'OVTI2680' >"$acpi_devices/device:01/hid"
+
+run_install b05d
+[[ ! -s $calls ]] ||
+  fail "a machine without an ov08x40 sensor installs nothing" "$(cat "$calls")"
+pass "hardware without an ov08x40 sensor installs nothing"


### PR DESCRIPTION
`install/hardware/intel/ipu7-camera.sh` decided whether a machine needs Intel's IPU7 camera stack by looking for the ov08x40 sensor's ACPI HID and nothing else. That sensor sits behind IPU6 on Meteor Lake — Core Ultra 100-series, `8086:7d19`, `ipu6epmtl_fw.bin` — as much as it sits behind IPU7 on Panther Lake, so Meteor Lake laptops installed `intel-ipu7-camera`. The kernel treats the HID as generation-agnostic by construction: `OVTI08F4` is in the shared `ipu-bridge` sensor table, which both `intel_ipu6` and `intel_ipu7` import.

Landing there is worse than landing nothing. The package blacklists `ov08x40` behind `intel_cvs`, disables wireplumber's libcamera monitor outright, hides the raw V4L2 nodes and publishes a v4l2loopback device labelled "Hardware ISP Camera" fed by `icamerasrc device-name=ov08x40-uf`, with a HAL the machine cannot load. The webcam then appears in every application and shows a black frame, which is what #7697 reports.

So the gate now asks the controller, and asks positively: `8086:b05d`, the Panther Lake IPU7.5. That is the only platform the package builds a HAL for — it configures CamHAL with `-DIPU_VERSIONS="ipu75xa"` and installs only `config/linux/ipu75xa` — so Lunar Lake's `645d`, whose HAL variant upstream calls `ipu7x`, is left out too. Excluding the known IPU6 ids instead would have failed open, and unknown hardware getting a stack pinned to one platform is the bug being fixed. `lspci` output is captured before it is matched, so an unreadable PCI bus skips rather than installs, and the gate stays off the `lspci | grep -q` pipeline b85ae70e went through the tree to remove.

`test/shell.d/ipu7-camera-test.sh` runs the script against a stubbed PCI bus and ACPI tree: Panther Lake installs, Meteor Lake and Raptor Lake and Lunar Lake do not, an `lspci` failure does not, and a machine without the sensor does not. With the old gate the Meteor Lake case installs the stack.

Two things this deliberately does not do, both of them yours to decide. It does not add an IPU6 camera stack — that means adopting `intel-ipu6-camera-hal-git` and `icamerasrc-git`, which the reporter says needs a local patch to build under GCC 16, and #5676 already asks for it. And it does not remove the package from machines that already have it; there is no migration here, so an affected user needs `omarchy-pkg-drop intel-ipu7-camera` by hand.

Fixes #7697