### PR TITLE
Remove GeForce NOW launcher leftovers on uninstall

### DIFF
--- a/bin/omarchy-remove-gaming-geforce-now
+++ b/bin/omarchy-remove-gaming-geforce-now
@@ -10,5 +10,15 @@ if omarchy-cmd-present flatpak && flatpak info com.nvidia.geforcenow &>/dev/null
   flatpak uninstall -y --delete-data com.nvidia.geforcenow
 fi
 
+# The NVIDIA installer drops a launcher script, desktop entry, and icon outside
+# the Flatpak exports, so they survive the uninstall above.
+rm -f "$HOME/.local/share/applications/com.nvidia.geforcenow.desktop"
+rm -f "$HOME/.local/share/applications/NVIDIA GeForce NOW"
+rm -f "$HOME"/.local/share/icons/hicolor/*/apps/com.nvidia.geforcenow.png
+rm -rf "$HOME/.local/state/NVIDIA/GeForceNOW"
+rmdir --ignore-fail-on-non-empty "$HOME/.local/state/NVIDIA" 2>/dev/null || true
+
+update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+
 echo ""
 echo "GeForce NOW removed."


### PR DESCRIPTION
Fixes #7761.

`omarchy remove gaming geforce-now` only uninstalled the Flatpak. The NVIDIA installer run by `omarchy install gaming geforce-now` also writes a launcher script, desktop entry, icon, and state directory into `~/.local/share` / `~/.local/state`, outside the Flatpak exports, so those survived the uninstall and GeForce NOW stayed in the application menu pointing at a launcher that could no longer work.

The remove command now deletes those leftovers and refreshes the desktop database, following the same pattern as `omarchy-remove-gaming-battlenet`.

## Verified on an affected machine

Ran the old command:

```
$ omarchy remove gaming geforce-now
Uninstall complete.
GeForce NOW removed.

$ ls ~/.local/share/applications | grep -i nvidia
com.nvidia.geforcenow.desktop
NVIDIA GeForce NOW
$ ls ~/.local/share/icons/hicolor/512x512/apps | grep -i nvidia
com.nvidia.geforcenow.png
$ ls -d ~/.local/state/NVIDIA/GeForceNOW
/home/.../.local/state/NVIDIA/GeForceNOW
```

Then ran the patched command against the same leftovers: all four are gone and the entry no longer shows in the launcher.

`./test/cli` passes. In `./test/shell`, `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` fail on my machine because there is no local `omarchy-pkgs` checkout; unrelated to this change.
