### PR TITLE
Hide Hibernate when the kernel will not accept the request

### DIFF
--- a/bin/omarchy-hibernation-available
+++ b/bin/omarchy-hibernation-available
@@ -2,17 +2,35 @@
 
 # omarchy:summary=Check if hibernation is supported
 
-if [[ ! -f /sys/power/image_size ]]; then
+SYS_POWER_PATH="${OMARCHY_SYS_POWER_PATH:-/sys/power}"
+SWAPS_PATH="${OMARCHY_SWAPS_PATH:-/proc/swaps}"
+RESUME_CONF_PATH="${OMARCHY_RESUME_CONF_PATH:-/etc/mkinitcpio.conf.d/omarchy_resume.conf}"
+
+if [[ ! -r $SYS_POWER_PATH/state || ! -r $SYS_POWER_PATH/image_size ]]; then
+  exit 1
+fi
+
+# The kernel drops "disk" from the sleep states whenever it will refuse the
+# request outright: lockdown, nohibernate, secretmem or an active CXL device.
+SLEEP_STATES=" $(<"$SYS_POWER_PATH/state") "
+
+if [[ $SLEEP_STATES != *" disk "* ]]; then
   exit 1
 fi
 
 # Sum all swap sizes (excluding zram)
-SWAPSIZE_KB=$(awk '!/Filename|zram/ {sum += $3} END {print sum+0}' /proc/swaps)
+SWAPSIZE_KB=$(awk '!/Filename|zram/ {sum += $3} END {print sum+0}' "$SWAPS_PATH")
 SWAPSIZE=$(( 1024 * ${SWAPSIZE_KB:-0} ))
 
-HIBERNATION_IMAGE_SIZE=$(cat /sys/power/image_size)
+HIBERNATION_IMAGE_SIZE=$(<"$SYS_POWER_PATH/image_size")
 
-if (( SWAPSIZE > HIBERNATION_IMAGE_SIZE )) && [[ -f /etc/mkinitcpio.conf.d/omarchy_resume.conf ]]; then
+# A size that did not read is worth zero to the comparison below, and any swap
+# at all beats zero.
+if [[ ! $HIBERNATION_IMAGE_SIZE =~ ^[0-9]+$ ]]; then
+  exit 1
+fi
+
+if (( SWAPSIZE > HIBERNATION_IMAGE_SIZE )) && [[ -f $RESUME_CONF_PATH ]]; then
   exit 0
 else
   exit 1

--- a/test/shell.d/hibernation-available-test.sh
+++ b/test/shell.d/hibernation-available-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+sys_power="$tmp_dir/power"
+swaps="$tmp_dir/swaps"
+resume_conf="$tmp_dir/omarchy_resume.conf"
+
+mkdir -p "$sys_power"
+
+write_sleep_states() {
+  printf '%s\n' "$1" >"$sys_power/state"
+}
+
+write_swaps() {
+  {
+    printf 'Filename\t\t\t\tType\t\tSize\t\tUsed\t\tPriority\n'
+    printf '%s\n' "$@"
+  } >"$swaps"
+}
+
+hibernation_available() {
+  OMARCHY_SYS_POWER_PATH="$sys_power" \
+    OMARCHY_SWAPS_PATH="$swaps" \
+    OMARCHY_RESUME_CONF_PATH="$resume_conf" \
+    "$ROOT/bin/omarchy-hibernation-available"
+}
+
+printf '%s\n' '6871947673' >"$sys_power/image_size"
+write_sleep_states 'freeze mem disk'
+write_swaps '/swap/swapfile                          file            62914556        0       0' \
+  '/dev/zram0                              partition       8388604         0       100'
+: >"$resume_conf"
+
+hibernation_available || fail "hibernation is available with a resume config and swap the kernel will accept"
+pass "hibernation is available with a resume config and swap the kernel will accept"
+
+# The kernel lists "disk" only while it will accept a hibernation request, so a
+# probe that ignores it offers a Hibernate entry that does nothing (#7730).
+write_sleep_states 'freeze mem'
+
+if hibernation_available; then
+  fail "hibernation is unavailable when the kernel offers no disk sleep state"
+fi
+pass "hibernation is unavailable when the kernel offers no disk sleep state"
+
+write_sleep_states 'freeze mem diskette'
+
+if hibernation_available; then
+  fail "hibernation is unavailable when only a longer state name contains disk"
+fi
+pass "hibernation is unavailable when only a longer state name contains disk"
+
+rm "$sys_power/state"
+
+if hibernation_available; then
+  fail "hibernation is unavailable when the kernel has no sleep states at all"
+fi
+pass "hibernation is unavailable when the kernel has no sleep states at all"
+
+# A kernel built without suspend offers hibernation and nothing else.
+write_sleep_states 'disk'
+
+hibernation_available || fail "hibernation is available when the kernel offers no other sleep state"
+pass "hibernation is available when the kernel offers no other sleep state"
+
+: >"$sys_power/image_size"
+
+if hibernation_available; then
+  fail "hibernation is unavailable when the hibernation image size does not read"
+fi
+pass "hibernation is unavailable when the hibernation image size does not read"
+
+printf '%s\n' '6871947673' >"$sys_power/image_size"
+write_sleep_states 'freeze mem disk'
+write_swaps '/dev/zram0                              partition       8388604         0       100'
+
+if hibernation_available; then
+  fail "hibernation is unavailable when only zram swap is active"
+fi
+pass "hibernation is unavailable when only zram swap is active"
+
+write_swaps '/swap/swapfile                          file            1024            0       0'
+
+if hibernation_available; then
+  fail "hibernation is unavailable when swap is smaller than the hibernation image"
+fi
+pass "hibernation is unavailable when swap is smaller than the hibernation image"
+
+write_swaps '/swap/swapfile                          file            62914556        0       0'
+rm "$resume_conf"
+
+if hibernation_available; then
+  fail "hibernation is unavailable without the resume config"
+fi
+pass "hibernation is unavailable without the resume config"


### PR DESCRIPTION
`omarchy-hibernation-available` checked that `/sys/power/image_size` exists, that non-zram swap exceeds the hibernation image size, and that `/etc/mkinitcpio.conf.d/omarchy_resume.conf` exists — everything except whether the kernel will take a hibernation request. All three hold on a machine where hibernation is disabled, so the `system.hibernate` row was shown, `systemctl hibernate` ran detached with its output on `/dev/null`, and from the user's side clicking Hibernate did nothing at all.

The kernel lists `disk` in `/sys/power/state` exactly while `hibernation_available()` holds — no `nohibernate`, no lockdown, no secretmem, no active CXL memory — and that same predicate is what makes `/sys/power/disk` read `[disabled]` and rejects every write to it with `-EPERM`. The probe now requires that token, which is also what logind asks before answering `CanHibernate`.

Reproduced on a disposable VM without simulating anything: raising the running kernel's lockdown to `integrity` turned `/sys/power/state` from `freeze mem disk` into `freeze mem`, `/sys/power/disk` into `[disabled]`, and `CanHibernate` from `challenge` into `na`, while the old probe still exited 0. On that machine before the change — 8 GiB swapfile at priority 0, zram at 100, resume config in place — old and new both exit 0.

A second way to say yes goes with it: an `image_size` that exists but does not read is worth zero to the arithmetic comparison, and any swap at all beats zero.

The sysfs, swaps and resume-config paths take an `OMARCHY_*_PATH` override the way `omarchy-power-present` does, which is what lets the new `test/shell.d/hibernation-available-test.sh` build a kernel that refuses.

Two wider gaps are deliberately left: the probe trusts that `omarchy_resume.conf` exists rather than that `resume=` reached the running kernel, so the row appears between `omarchy hibernation setup` and the reboot it asks for; and it sums every disk swap while the kernel writes its image to one. Both deserve their own change.

Fixes #7730.
