### PR TITLE
Dismiss the screensaver on any input, not just a keypress

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -43,10 +43,21 @@ function screensaverWindowsAfter(windows, address, visible) {
   }
 }
 
+// The screensaver's own window mapping registers as input, so a dismissal
+// monitor cannot treat its first activity as the user. It arms only once input
+// has gone quiet while the screensaver is on screen; the next activity after
+// that is a real keypress, click, or pointer move and dismisses the screensaver.
+function screensaverDismissAction(armed, isIdle, screensaverVisible) {
+  if (!screensaverVisible) return "ignore"
+  if (isIdle) return armed ? "ignore" : "arm"
+  return armed ? "dismiss" : "ignore"
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
-    screensaverWindowsAfter: screensaverWindowsAfter
+    screensaverWindowsAfter: screensaverWindowsAfter,
+    screensaverDismissAction: screensaverDismissAction
   }
 }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -24,6 +24,7 @@ Item {
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
+  readonly property int screensaverDismissSettleSeconds: 1
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
@@ -35,6 +36,7 @@ Item {
   property string lastEventAt: ""
   property var screensaverWindows: ({})
   property int screensaverWindowCount: 0
+  property bool screensaverDismissArmed: false
 
   function secondsFromConfig(value, fallback) {
     return IdleModel.secondsFromConfig(value, fallback)
@@ -113,6 +115,29 @@ Item {
   function resetScreensaverWindows() {
     root.screensaverWindows = ({})
     root.screensaverWindowCount = 0
+    root.screensaverDismissArmed = false
+  }
+
+  function dismissScreensaver(reason) {
+    logEvent("screensaver-dismiss", reason || "input")
+    root.screensaverDismissArmed = false
+    runProcess(dismissProcess, "dismiss", "pkill -f '[o]rg.omarchy.screensaver'")
+  }
+
+  // The main idle monitor reports activity once while the screensaver maps its
+  // window and then stays active for as long as it is up, so it never sees the
+  // input that should dismiss it. A second monitor, armed only while the
+  // screensaver is on screen, supplies that signal for every input device the
+  // compositor knows about.
+  function handleScreensaverDismissSignal() {
+    var action = IdleModel.screensaverDismissAction(root.screensaverDismissArmed, screensaverDismissMonitor.isIdle, root.screensaverWindowCount > 0)
+
+    if (action === "arm") {
+      root.screensaverDismissArmed = true
+      logEvent("screensaver-dismiss-armed")
+    } else if (action === "dismiss") {
+      dismissScreensaver("input")
+    }
   }
 
   function setScreensaverWindow(address, visible) {
@@ -128,6 +153,7 @@ Item {
 
   function handleScreensaverWindowClosed(address) {
     setScreensaverWindow(address, false)
+    if (root.screensaverWindowCount === 0) root.screensaverDismissArmed = false
 
     if (!root.idleEnabled || !root.idledThisCycle || !root.screensaverStartedThisCycle) return
     if (root.screensaverWindowCount > 0) return
@@ -191,6 +217,7 @@ Item {
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,
+      screensaverDismissArmed: root.screensaverDismissArmed,
       timers: {
         screensaver: screensaverTimer.running,
         lock: lockTimer.running,
@@ -199,7 +226,8 @@ Item {
       processes: {
         screensaver: screensaverProcess.running,
         lock: lockProcess.running,
-        wake: wakeProcess.running
+        wake: wakeProcess.running,
+        dismiss: dismissProcess.running
       },
       lastEvent: root.lastEvent,
       lastEventAt: root.lastEventAt
@@ -255,6 +283,14 @@ Item {
     onIsIdleChanged: root.handleIdleChanged()
   }
 
+  IdleMonitor {
+    id: screensaverDismissMonitor
+    enabled: root.idleEnabled && root.screensaverWindowCount > 0
+    timeout: root.screensaverDismissSettleSeconds
+    respectInhibitors: false
+    onIsIdleChanged: root.handleScreensaverDismissSignal()
+  }
+
   Timer {
     id: screensaverTimer
     interval: root.screensaverDelaySeconds * 1000
@@ -296,6 +332,11 @@ Item {
   Process {
     id: wakeProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+
+  Process {
+    id: dismissProcess
+    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "dismiss exitCode=" + exitCode + " status=" + exitStatus) }
   }
 
   Process {

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,26 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+assertEqual(
+  idle.screensaverDismissAction(false, true, true),
+  'arm',
+  'idle arms screensaver dismissal once input goes quiet'
+)
+assertEqual(
+  idle.screensaverDismissAction(false, false, true),
+  'ignore',
+  'idle ignores the screensaver launching itself as input'
+)
+assertEqual(
+  idle.screensaverDismissAction(true, false, true),
+  'dismiss',
+  'idle dismisses the screensaver on input once armed'
+)
+assertEqual(
+  idle.screensaverDismissAction(true, false, false),
+  'ignore',
+  'idle ignores input when no screensaver is on screen'
+)
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
Fixes #7762.

Once the screensaver is up, moving the mouse does nothing — it only goes away on a keypress delivered to its own terminal. Pre-Quattro, hypridle's `on-resume` dismissed it on any global input.

## Why the main idle monitor cannot see the input

The screensaver focusing its own window registers as activity, so `IdleMonitor.isIdle` flips back to `false` a fraction of a second after launch and then never changes for the rest of the display. `onIsIdleChanged` never fires again, so `handleActiveSignal()` is never reached, and the `screensaverWindowCount > 0` guard inside it is not what suppresses the dismissal — the signal simply never arrives.

Traced on an affected machine (polling the idle service's own IPC status; the key includes `lastEventAt`, so a repeated event would still show):

```
17:48:28.948 | isIdle=true  inCycle=true ssWindows=0 | process-start: screensaver
17:48:29.240 | isIdle=false inCycle=true ssWindows=1 | process-exit: screensaver
   ... ~12s of continuous mouse movement: no events at all ...
17:48:41.211 | isIdle=false inCycle=false ssWindows=0 | process-exit: wake
```

Two cycles in the same run, with the self-inflicted flip landing at 292ms and 295ms after launch. So narrowing that guard would edit unreachable code.

`cancelIdleCycle()` is also not a teardown: it stops timers and runs `omarchy-system-wake`, leaving the screensaver window on screen.

## The fix

A second `IdleMonitor`, enabled only while a screensaver window exists. It arms once input has gone quiet — which absorbs the launch activity without needing a grace timer — and the next activity dismisses the screensaver with the same `pkill` that `omarchy-system-lock` already uses. The existing `closewindow` → `handleScreensaverWindowClosed()` path then cancels the pending lock and wakes the display, unchanged.

Because `ext-idle-notify` is compositor-side, this covers keyboard, pointer motion, clicks, touch, and bluetooth devices without the terminal being involved. Manually launched screensavers (`omarchy-launch-screensaver force`) become dismissable the same way, since window tracking is driven by Hyprland events rather than the idle cycle.

The arm/dismiss decision is a pure function in `IdleModel.js`, covered by `test/shell.d/idle-test.sh`.

## Verified in the running UI

Same machine, patched service loaded via `omarchy plugin clone omarchy.idle`, three cycles:

```
17:53:00.555 | isIdle=true  ssWindows=0 armed=false | process-start: screensaver
17:53:00.850 | isIdle=false ssWindows=1 armed=false | process-exit: screensaver     <- 295ms blip, ignored
17:53:01.712 | isIdle=false ssWindows=1 armed=true  | screensaver-dismiss-armed
17:53:06.283 | isIdle=false ssWindows=1 armed=false | process-start: dismiss pkill -f '[o]rg.omarchy.screensaver'
17:53:06.574 | isIdle=false ssWindows=0 armed=false | process-exit: wake
```

Mouse movement dismisses it immediately; teardown measured at 172ms window-close latency in a 50ms-resolution trace. Lock timing is unaffected — the dismissal monitor is disabled whenever no screensaver window is on screen, and `lockSystem()` resets it.

Terminal: foot. Hardware: Intel UHD 630 + RTX 2080 Mobile, wired mouse.

## Related

- #7528 diagnoses the same root cause and also reaches for a second `IdleMonitor`; its state machine and arming differ from this one, and it carries touch-specific findings (including an upstream foot crash) that this PR does not. Reviewers may prefer to land one and close the other.
- #6813 reworks screensaver teardown into per-supervisor ownership; the `pkill` here is the same call `omarchy-system-lock` makes today and should be swapped for whatever lands there.
- #7102 and #7193 touch adjacent screensaver behavior.

## Tests

`./test/shell` — 2301 assertions pass, 4 of them new; 182 of 185 test files pass. The 3 failing files (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`) all fail on the same missing `omarchy-pkgs` sibling checkout on my machine (`omarchy-pkgs checkout found/available for ...`) and reproduce identically on a clean tree. `./test/cli` passes.
