### PR TITLE
Fix Codex usage widget: -a untrusted is no longer a valid approval policy

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary

- `omarchy-agent-usage-codex` starts `codex app-server` with `-a untrusted`, but current `codex-cli` (0.149.0+) only accepts `on-request` or `never` for `--ask-for-approval`. The subprocess now exits immediately on this invalid flag instead of speaking the RPC protocol, so the script's `initialize` request times out after 8s and the Codex tab shows "Codex limits unavailable" with the raw `TimeoutError` text (`initialize`) as the help line. Local token stats are unaffected since they come from a separate file-scan path.
- Switches the flag to `-a never`. Verified this is semantically correct, not just a value that happens to work: this process only calls the read-only `account/read` and `account/rateLimits/read` RPCs and never asks the model to run anything, so paired with `-s read-only` it makes the intent explicit — a fully non-interactive, read-only probe that can never block on an approval prompt.

Fixes #7781

## Test plan

- [x] Reproduced the bug directly: `codex -s read-only -a untrusted app-server` fails with `error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'`
- [x] Verified the fix end-to-end: patched script run with `-a never` (and separately with `-a on-request`, for comparison) returns real rate limits (`plan: plus`, weekly window populated) instead of timing out
- [x] `./test/all` — only pre-existing, environment-caused failures unrelated to this change (missing `omarchy-pkgs` checkout for `config-test.sh`/`unowned-system-paths-test.sh`, a permission bit on `snapper-test.sh`); confirmed these three also fail identically on `quattro` before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)