### PR TITLE
Document memory gating for plugin file reads

### DIFF
--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -45,6 +45,22 @@ Saving a file anywhere under `~/.config/omarchy/plugins/` reloads plugin code
 automatically. If a change somehow fails to apply, force a reload with
 `omarchy-shell shell rescanPlugins`.
 
+## Plugin Safety: Bound Every File Read
+
+`omarchy-shell` is a single long-running process. Never read a file into it
+without a size bound — an oversized or corrupted file (a plugin's state or
+config file grown by a bug, or written by another process) forces unbounded
+allocation in a process the user cannot afford to have balloon.
+
+- `FileView` (`Quickshell.Io`) reads the *entire* file before any code can
+  validate or reject it. Do not use it for user-writable files.
+- Read such files with a stat-gated `Process` instead: `stat -c%s` reads only
+  metadata (no content), so check it first and `cat` only when the size is
+  under a hard cap (e.g. 64 KiB).
+- Bound the in-memory model too. A file under the byte cap can still hold a
+  huge array — cap collection counts (dice lists, side lists, rows) to a sane
+  maximum while parsing.
+
 ## Idle and Lock
 
 Set `idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json`,

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -54,9 +54,10 @@ allocation in a process the user cannot afford to have balloon.
 
 - `FileView` (`Quickshell.Io`) reads the *entire* file before any code can
   validate or reject it. Do not use it for user-writable files.
-- Read such files with a stat-gated `Process` instead: `stat -c%s` reads only
-  metadata (no content), so check it first and `cat` only when the size is
-  under a hard cap (e.g. 64 KiB).
+- Read such files with a bounded `Process` instead: read at most one byte over
+  the hard cap (e.g. `timeout 5 head -c 65537 -- "$path"` for a 64 KiB cap)
+  and reject output over the cap. A preliminary `stat -c%s` can fast-reject an
+  oversized file, but cannot enforce the bound because the file may change.
 - Bound the in-memory model too. A file under the byte cap can still hold a
   huge array — cap collection counts (dice lists, side lists, rows) to a sane
   maximum while parsing.


### PR DESCRIPTION
## Summary

Adds a **Plugin Safety: Bound Every File Read** section to the `omarchy` skill's `plugins.md`, warning that the shell is a single long-running process and that unbounded file reads can force unbounded allocation.

## The problem

`FileView` (`Quickshell.Io`) loads the *entire* file into the shell before any code can validate or reject it. A plugin that reads a user-writable state/config file this way lets an oversized or corrupted file balloon the shell's memory.

## The change

Three guidance bullets in `plugins.md`:

- Never use `FileView` for user-writable files — it reads the whole file first.
- Use a stat-gated `Process` instead (`stat -c%s` reads metadata only) and `cat` only under a hard size cap.
- Bound the in-memory model too (cap collection counts), since a file under the byte cap can still hold a huge array.

## Notes

- Complements #7002 (`omarchy-plugin-dev` skill), which covers authoring but not this memory-gating caveat.
- Documentation-only change; no tests.
