### PR TITLE
docs(agents): add plugin UI safety baseline

### DIFF
--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -42,7 +42,7 @@ Deeper instructions for common areas live next to this file. Read the
 matching guide before starting:
 
 - [`hyprland.md`](hyprland.md) - keybindings, monitors, window rules, and other Hyprland config
-- [`plugins.md`](plugins.md) - the Omarchy shell: bar layout, widgets, plugins, idle behavior, and safe plugin UI data
+- [`plugins.md`](plugins.md) - the Omarchy shell: bar layout, widgets, plugins, idle behavior
 - [`theming.md`](theming.md) - themes, backgrounds, and fonts
 - [`hooks.md`](hooks.md) - automation hooks that run on system events
 - [`capture.md`](capture.md) - screenshots, screen recordings, OCR text capture, and file sharing

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -42,7 +42,7 @@ Deeper instructions for common areas live next to this file. Read the
 matching guide before starting:
 
 - [`hyprland.md`](hyprland.md) - keybindings, monitors, window rules, and other Hyprland config
-- [`plugins.md`](plugins.md) - the Omarchy shell: bar layout, widgets, plugins, idle behavior
+- [`plugins.md`](plugins.md) - the Omarchy shell: bar layout, widgets, plugins, idle behavior, and safe plugin UI data
 - [`theming.md`](theming.md) - themes, backgrounds, and fonts
 - [`hooks.md`](hooks.md) - automation hooks that run on system events
 - [`capture.md`](capture.md) - screenshots, screen recordings, OCR text capture, and file sharing

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -17,6 +17,25 @@ changes. `idle.screensaver` and `idle.lock` are seconds since user idle began.
 
 **Commands:** `omarchy restart shell`, `omarchy refresh shell`
 
+## Plugin UI Safety
+
+Plugins run inside Omarchy's long-lived, unsandboxed shell. Treat text from network responses, files, IPC, settings, environment variables, and command output as untrusted.
+
+- QML `Text` defaults to `Text.AutoText`. Do not bind untrusted data to an AutoText sink: markup-shaped input such as `<img src="https://example.invalid/tracker">` can be interpreted as rich text and load a resource.
+- For display text owned by the plugin, set `textFormat: Text.PlainText`. Prefer a local `PlainText` component when the plugin has multiple text elements.
+
+```qml
+Text {
+  textFormat: Text.PlainText
+  text: modelData.name
+}
+```
+
+- When passing dynamic text to an Omarchy-owned component whose internal `Text` format cannot be controlled, use a documented markup-neutralizing helper and add a regression test. Prefer extending the shared component with a plain-text property when that is feasible.
+- Bound and validate downloaded data before displaying or saving it: limit response and collection sizes, string lengths, identifiers, and timestamps.
+- Keep network access explicit and user-initiated. Use fixed HTTPS sources, timeouts, response-size limits, and validation. Never execute downloaded content or interpolate untrusted values into shell commands.
+- Add regression coverage for markup-shaped input and every shared tooltip or notification sink that receives dynamic text.
+
 ## Bar Layout
 
 Use the `omarchy bar` group to move and manage widgets:

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -33,7 +33,7 @@ Text {
 
 - When passing dynamic text to an Omarchy-owned component whose internal `Text` format cannot be controlled, use a documented markup-neutralizing helper and add a regression test. Prefer extending the shared component with a plain-text property when that is feasible.
 - Bound and validate downloaded data before displaying or saving it: limit response and collection sizes, string lengths, identifiers, and timestamps.
-- Keep network access explicit and user-initiated. Use fixed HTTPS sources, timeouts, response-size limits, and validation. Never execute downloaded content or interpolate untrusted values into shell commands.
+- Keep network access explicit. Use fixed HTTPS sources, timeouts, response-size limits, and validation. For periodic background refreshes, disclose the behavior and let users enable or disable it. Never execute downloaded content or interpolate untrusted values into shell commands.
 - Add regression coverage for markup-shaped input and every shared tooltip or notification sink that receives dynamic text.
 
 ## Bar Layout


### PR DESCRIPTION
## Summary

- Add an agent-facing safety baseline for plugin UI strings.
- Explain `Text.AutoText` and require `Text.PlainText` for untrusted display data.
- Cover component boundaries, bounded data, explicit networking, and regression coverage.

## Why

This guidance comes from a third-party plugin marketplace review: https://github.com/HANCORE-linux/omarchy-plugin-marketplace/issues/1498

A schedule API field rendered through QML AutoText could be treated as rich text and load a referenced resource. The affected plugin has been fixed and released; this PR makes the review lesson available to future Omarchy plugin authors and agents.

## Testing

- Documentation-only: `git diff --check`