### PR TITLE
Fix broken manual links in README and Neovim chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,18 @@ its screenshots are also hosted.
 - [Prompt](manual/40-prompt.md)
 - [Branding](manual/41-branding.md)
 - [Common tweaks](manual/42-common-tweaks.md)
-- [Extra themes](manual/43-extra-themes.md)
-- [Making your own theme](manual/44-making-your-own-theme.md)
+- [Making your own theme](manual/43-making-your-own-theme.md)
 
 **The Rest**
 
-- [Mac support](manual/45-mac-support.md)
-- [Troubleshooting](manual/46-troubleshooting.md)
-- [FAQ](manual/47-faq.md)
-- [System snapshots](manual/48-system-snapshots.md)
-- [Security](manual/49-security.md)
-- [Omarchy on...](manual/50-omarchy-on.md)
-- [Dual Boot Install](manual/51-dual-boot-install.md)
-- [Unattended Installs](manual/52-unattended-installs.md)
+- [Mac support](manual/44-mac-support.md)
+- [Troubleshooting](manual/45-troubleshooting.md)
+- [FAQ](manual/46-faq.md)
+- [System snapshots](manual/47-system-snapshots.md)
+- [Security](manual/48-security.md)
+- [Omarchy on...](manual/49-omarchy-on.md)
+- [Dual Boot Install](manual/50-dual-boot-install.md)
+- [Unattended Installs](manual/51-unattended-installs.md)
 
 ## License
 

--- a/manual/16-neovim.md
+++ b/manual/16-neovim.md
@@ -1,6 +1,6 @@
 # Neovim
 
-[Neovim](https://neovim.io/) is a modern implementation of [the vi editor](<https://en.wikipedia.org/wiki/Vi_(text_editor)>) created by Bill Joy all the way back in 1976. It's a modal editor where insert mode and command mode are separated, and it's a bit of a superpower once you learn even just a subset of the incredibly deep key command set. But it's also quite the learning curve!
+[Neovim](https://neovim.io/) is a modern implementation of [the vi editor](https://en.wikipedia.org/wiki/Vi_(text_editor)) created by Bill Joy all the way back in 1976. It's a modal editor where insert mode and command mode are separated, and it's a bit of a superpower once you learn even just a subset of the incredibly deep key command set. But it's also quite the learning curve!
 
 If you're totally new to vim-style editing, I recommend you checkout [ThePrimeagen's Vim As Your Editor series](https://www.youtube.com/watch?v=X6AR2RMB5tE&list=PLm323Lc7iSW_wuxqmKx_xxNtJC_hJbQ7R) on YouTube. That'll teach you the basics. Just know that unlike more similar mainstream editors, it's going to take you longer to get basic proficiency with vim. But once you do, the payoff is also larger.
 


### PR DESCRIPTION
### Summary
Fixes 10 broken (404) links in `README.md`'s Table of Contents caused by an off-by-one shift in chapter numbers, and corrects link formatting in `manual/16-neovim.md`.

### Details
1. **README.md Table of Contents**:
   - Due to earlier consolidation/removal of `43-extra-themes.md`, the actual markdown files in `manual/` run from `43-making-your-own-theme.md` to `51-unattended-installs.md`.
   - `README.md` was still referencing `manual/43-extra-themes.md` through `manual/52-unattended-installs.md`, causing links 43–52 to 404 on GitHub.
   - Updated the links in `README.md` to point to the correct files (`43-` to `51-`).

2. **manual/16-neovim.md**:
   - Removed extraneous angle brackets from `[the vi editor](<https://en.wikipedia.org/wiki/Vi_(text_editor)>)` so the markdown link parses standardly.

### Verification
- Validated all relative markdown links across `README.md` and `manual/` with 0 broken links remaining.
