### PR TITLE
Add Remove > 1Password to the shell menu

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -295,6 +295,7 @@
   "remove.browser.brave-origin": {"icon":"","label":"Brave Origin","when":"omarchy-pkg-present brave-origin-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser brave-origin'"},
   "remove.browser.firefox": {"icon":"","label":"Firefox","when":"omarchy-pkg-present firefox","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser firefox'"},
   "remove.browser.zen": {"icon":"","label":"Zen","when":"omarchy-pkg-present zen-browser-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser zen'"},
+  "remove.service.1password": {"icon":"󰢁","label":"1Password","when":"omarchy-pkg-present 1password","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-service-1password"},
   "remove.service.dropbox": {"icon":"","label":"Dropbox","when":"omarchy-pkg-present dropbox","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-service-dropbox"},
   "remove.service.tailscale": {"icon":"","label":"Tailscale","when":"omarchy-pkg-present tailscale","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-service-tailscale"},
   "remove.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","when":"omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-chatgpt"},


### PR DESCRIPTION
### Summary
The removal script `omarchy-remove-service-1password` is already implemented and functional in `bin/`, and `install.service.1password` exists under the **Install** menu. However, `1password` was missing under the **Remove > Services** submenu in `default/omarchy/omarchy-menu.jsonc`.

### Changes
- Added `"remove.service.1password"` entry to `default/omarchy/omarchy-menu.jsonc` under `remove.service`.
- Configured it with `"when": "omarchy-pkg-present 1password"` to launch `omarchy-remove-service-1password` when installed.

### Verification
- Verified against `./test/shell.d/menu-test.sh` (all assertions passed).
- Confirmed menu schema and formatting match existing service entries (`dropbox`, `tailscale`).