### PR TITLE
Show banked rate limit resets on the Codex tab

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -22,6 +22,8 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -36,6 +38,12 @@ AUTH_HELP = "Run `codex login` to authenticate."
 # may reuse a scan for up to 15 minutes.
 SCAN_REUSE_SECONDS = 20
 LIMITS_ONLY_REUSE_SECONDS = 900
+
+# Banked rate limit resets ("reset credits") are granted per account and spend
+# down a rate limit window early. The app-server RPC does not report them, so
+# they come straight from the same backend the Codex CLI authenticates against.
+RESET_CREDITS_ENDPOINT = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
+RESET_CREDITS_TIMEOUT = 10
 
 
 def local_day(value):
@@ -571,6 +579,74 @@ def fetch_codex_rpc():
   return result
 
 
+def codex_credentials():
+  """The bearer token and account the Codex CLI stores after `codex login`."""
+  auth_path = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex")) / "auth.json"
+  with open(auth_path, "r", encoding="utf-8") as handle:
+    auth = json.load(handle)
+  tokens = auth.get("tokens") or {}
+  token = str(tokens.get("access_token") or auth.get("OPENAI_API_KEY") or "").strip()
+  return token, str(tokens.get("account_id") or "").strip()
+
+
+def available_reset_credits(payload):
+  """How many banked resets are still spendable.
+
+  The response carries its own tally; the credit list is only consulted when a
+  response omits it, and then a credit counts when it is available and has not
+  passed its expiry.
+  """
+  count = payload.get("availableCount", payload.get("available_count"))
+  if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+    return count
+
+  now = datetime.now(timezone.utc)
+  total = 0
+  for credit in payload.get("credits") or []:
+    if not isinstance(credit, dict) or credit.get("status") != "available":
+      continue
+    expires = str(credit.get("expires_at") or "")
+    if expires:
+      try:
+        if datetime.fromisoformat(expires.replace("Z", "+00:00")) <= now:
+          continue
+      except ValueError:
+        pass
+    total += 1
+  return total
+
+
+def fetch_reset_credits():
+  """Banked resets for the signed-in account, or None when unknown.
+
+  Advisory: every failure returns None so a record that is otherwise complete
+  still reaches the panel. None means "not read", which the panel shows as
+  nothing at all — distinct from a read that reports zero banked resets.
+  """
+  try:
+    token, account_id = codex_credentials()
+  except Exception:
+    return None
+  if not token:
+    return None
+
+  headers = {
+    "Authorization": f"Bearer {token}",
+    "Accept": "application/json",
+    "User-Agent": "omarchy-agent-usage-codex",
+  }
+  if account_id:
+    headers["ChatGPT-Account-Id"] = account_id
+
+  request = urllib.request.Request(RESET_CREDITS_ENDPOINT, headers=headers)
+  try:
+    with urllib.request.urlopen(request, timeout=RESET_CREDITS_TIMEOUT) as response:
+      payload = json.loads(response.read().decode("utf-8"))
+  except Exception:
+    return None
+  return available_reset_credits(payload) if isinstance(payload, dict) else None
+
+
 def main():
   parser = argparse.ArgumentParser()
   # --force rescans everything and rewrites the cache. --limits-only is kept
@@ -596,6 +672,11 @@ def main():
   }
   record.update(stats)
   record.update(rpc)
+
+  reset_credits = fetch_reset_credits()
+  if reset_credits is not None:
+    record["resetCreditsAvailable"] = reset_credits
+
   print(json.dumps(record, separators=(",", ":")))
 
 

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -256,6 +256,7 @@ Item {
       limits: Array.isArray(record.limits) ? record.limits : [],
       tierLabel: String(record.tierLabel || ""),
       balance: balanceValue(record.balance),
+      resetCreditsAvailable: bankedResetsValue(record.resetCreditsAvailable),
 
       todayPrompts: synced ? numberValue(stats.todayPrompts) : numberValue(record.todayPrompts),
       todaySessions: synced ? numberValue(stats.todaySessions) : numberValue(record.todaySessions),
@@ -511,6 +512,15 @@ Item {
   function numberValue(value) {
     var n = Number(value || 0)
     return isFinite(n) ? Math.round(n) : 0
+  }
+
+  // Banked resets, normalized to -1 when the collector did not report them.
+  // A provider with none left says 0, which is an answer; a collector that
+  // never read them says nothing, and 0 would put words in its mouth.
+  function bankedResetsValue(value) {
+    if (value === undefined || value === null) return -1
+    var n = Number(value)
+    return isFinite(n) && n >= 0 ? Math.floor(n) : -1
   }
 
   function dateString(date) {

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -40,6 +40,11 @@ Panel {
   readonly property var models: modelRows(provider)
   readonly property var headline: bindingWindow(provider)
   readonly property var balance: provider ? (provider.balance || null) : null
+  // Banked resets a provider grants for clearing a rate limit window early.
+  // -1 is a collector that never read them, held apart from a read that
+  // reports none -- though both stay off the panel, since a standing
+  // "0 resets banked" line is noise on an account that never has any.
+  readonly property int bankedResets: provider ? Number(provider.resetCreditsAvailable) : -1
   // A prepaid account runs low the way a subscription window fills up: the
   // last 10% of the funded credits lights the same alarm.
   readonly property bool balanceAlarming: !!balance && balance.funded > 0
@@ -604,6 +609,15 @@ Panel {
                 width: limitsSection.width
                 window: modelData
               }
+            }
+
+            Text {
+              visible: root.bankedResets > 0
+              width: parent.width
+              text: root.bankedResets === 1 ? "1 reset banked" : root.bankedResets + " resets banked"
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
             }
           }
 

--- a/test/shell.d/agent-usage-codex-reset-credits-test.sh
+++ b/test/shell.d/agent-usage-codex-reset-credits-test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+# fetch_reset_credits reaches ChatGPT, so the reader that interprets its answer
+# is exercised on its own: the collector loads as a module, and a recorded
+# payload stands in for the response.
+read_credits() {
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-codex" PAYLOAD="$1" python3 - <<'PY'
+import importlib.machinery, importlib.util, json, os
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+print(json.dumps(collector.available_reset_credits(json.loads(os.environ["PAYLOAD"]))))
+PY
+}
+
+# The tally the endpoint reports is the answer, however many credits it lists.
+[[ $(read_credits '{"credits": [{"status": "available"}], "available_count": 2}') == "2" ]] ||
+  fail "Codex collector reads the banked reset tally the endpoint reports" "$(read_credits '{"credits": [{"status": "available"}], "available_count": 2}')"
+pass "Codex collector reads the banked reset tally the endpoint reports"
+
+# A read that reports no banked resets is an answer, not a missing one.
+[[ $(read_credits '{"credits": [], "available_count": 0}') == "0" ]] ||
+  fail "Codex collector reports zero banked resets as zero" "$(read_credits '{"credits": [], "available_count": 0}')"
+pass "Codex collector reports zero banked resets as zero"
+
+# Without a tally the credits are counted: spent, expired, and unspendable ones
+# do not count, and a credit with no expiry is still good.
+counted=$(read_credits '{"credits": [
+  {"status": "available", "expires_at": "2999-01-01T00:00:00Z"},
+  {"status": "available"},
+  {"status": "available", "expires_at": "2000-01-01T00:00:00Z"},
+  {"status": "redeemed", "expires_at": "2999-01-01T00:00:00Z"},
+  {"status": "available", "expires_at": "not-a-date"}
+]}')
+[[ $counted == "3" ]] ||
+  fail "Codex collector counts only banked resets it can still spend" "$counted"
+pass "Codex collector counts only banked resets it can still spend"
+
+# A record that reaches the panel without the count is better than no record:
+# an unreachable endpoint reports nothing rather than raising.
+unreachable=$(COLLECTOR="$ROOT/bin/omarchy-agent-usage-codex" python3 - <<'PY'
+import importlib.machinery, importlib.util, json, os
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+collector.codex_credentials = lambda: ("token", "account")
+
+
+def unreachable(request, timeout=None):
+  raise OSError("no route to host")
+
+
+collector.urllib.request.urlopen = unreachable
+print(json.dumps(collector.fetch_reset_credits()))
+PY
+)
+[[ $unreachable == "null" ]] ||
+  fail "Codex collector reports unknown banked resets when the endpoint is unreachable" "$unreachable"
+pass "Codex collector reports unknown banked resets when the endpoint is unreachable"
+
+# Signed out is the same unknown: no auth file, no count, no traceback.
+signed_out=$(COLLECTOR="$ROOT/bin/omarchy-agent-usage-codex" CODEX_HOME="$(mktemp -d)" python3 - <<'PY'
+import importlib.machinery, importlib.util, json, os
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+print(json.dumps(collector.fetch_reset_credits()))
+PY
+)
+[[ $signed_out == "null" ]] ||
+  fail "Codex collector reports unknown banked resets when signed out" "$signed_out"
+pass "Codex collector reports unknown banked resets when signed out"


### PR DESCRIPTION
## Why

Codex grants accounts "reset credits" — banked resets that clear a rate limit window before it runs out. An account holding one has no way to learn that from Omarchy: `account/rateLimits/read`, which the collector already speaks, does not report them, so nothing ever reached the agents panel.

I went looking for this after hitting a weekly window at 63% and finding out from the ChatGPT web UI, not from the bar, that I had a free reset sitting unused.

## What changed

- `bin/omarchy-agent-usage-codex` reads `GET /backend-api/wham/rate-limit-reset-credits` from the same backend the Codex CLI authenticates against, reusing the token `codex login` already wrote to `auth.json`, and reports it as `resetCreditsAvailable`.
- `shell/plugins/agents/Main.qml` carries the count into the provider view model, normalized to `-1` when a collector never read it.
- `shell/plugins/agents/Panel.qml` prints it under LIMITS: "1 reset banked".

## Notes

- **The fetch is advisory.** Signed out, offline, an HTTP error, or a changed response shape all report nothing, and the record still reaches the panel intact. It cannot take the rest of the Codex tab down with it.
- **A zero is held apart from a silence.** A read that reports no banked resets stays distinct from a read that never happened — neither prints, since a standing "0 resets banked" line is noise on an account that never has any, but the distinction is there for a surface that wants it.
- **The count is per-account**, so it stays out of `providerSnapshot()` the way limits and balances already do, rather than merging across devices.
- This adds a field rather than reusing `title` on a limit entry, since `title` already means the window's name (Claude emits "Fable Weekly", and #7725 extends that).
- Only Codex is wired up here. Grok has the same concept, so `resetCreditsAvailable` is deliberately provider-neutral — a Grok collector can fill it in with no panel change.

## Testing

`test/shell.d/agent-usage-codex-reset-credits-test.sh` covers the reported tally, a zero, the fallback that counts credits when a response omits the tally (skipping spent, expired, and unparseable ones), an unreachable endpoint, and being signed out. It follows `agent-usage-claude-limits-test.sh`: the collector loads as a module and a recorded payload stands in for the response, so the suite makes no network call.

Verified in the running shell against a real account holding one banked reset:

```
LIMITS
Weekly                                    63%
Resets in 4d 10h
1 reset banked
```
