### PR TITLE
Stage and syntax-check /etc/omarchy.conf before installing it

### DIFF
--- a/bin/omarchy-dev-link
+++ b/bin/omarchy-dev-link
@@ -89,7 +89,8 @@ done
 # read takes every rule after it down with it, including the %wheel grant, and
 # the password prompt needed to undo that is on the other side of the breakage.
 staged_sudoers=$(mktemp)
-trap 'rm -f "$staged_sudoers"' EXIT
+staged_conf=$(mktemp)
+trap 'rm -f "$staged_sudoers" "$staged_conf"' EXIT
 
 {
   printf 'Defaults secure_path='
@@ -106,7 +107,17 @@ fi
   printf 'export OMARCHY_PATH='
   omarchy_conf_quote "$target"
   printf '\n'
-} | sudo tee /etc/omarchy.conf >/dev/null
+} >"$staged_conf"
+
+# Same stage-and-parse rule as the sudoers drop-in: every login shell sources
+# /etc/omarchy.conf, so a file bash cannot parse would break each login until
+# root fixes it by hand. Check it parses before it lands.
+if ! bash -n "$staged_conf"; then
+  echo "Error: refusing to install an unparsable /etc/omarchy.conf for $target" >&2
+  exit 1
+fi
+
+sudo tee /etc/omarchy.conf <"$staged_conf" >/dev/null
 
 sudo install -Dm440 -o root -g root "$staged_sudoers" "$sudoers_file"
 

--- a/test/shell.d/dev-link-test.sh
+++ b/test/shell.d/dev-link-test.sh
@@ -122,3 +122,36 @@ if grep -q 'sudo' "$log_file"; then
   fail "dev link touches nothing when the path does not exist" "$(cat "$log_file")"
 fi
 pass "dev link rejects a path that does not exist"
+
+# The conf is staged and checked with `bash -n` before sudo installs it. The
+# quoting keeps every real path parsable, so this stubs the checker to fail and
+# confirms a failed check leaves the system untouched: no sudo call, and the
+# conf that was already installed stays as it was.
+broken_bin="$test_tmp/broken-bin"
+mkdir -p "$broken_bin"
+cat >"$broken_bin/bash" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "-n" ]]; then
+  exit 1
+fi
+exec /bin/bash "$@"
+SH
+chmod +x "$broken_bin/bash"
+
+: >"$log_file"
+: >"$sudoers_file"
+printf 'export OMARCHY_PATH="/usr/share/omarchy"\n' >"$conf_file"
+if PATH="$broken_bin:$PATH" run_link "$checkout" --no-reboot >/dev/null 2>"$test_tmp/syntax.err"; then
+  fail "dev link stops when the staged conf fails the syntax check"
+fi
+grep -F "Error: refusing to install an unparsable /etc/omarchy.conf for $checkout" "$test_tmp/syntax.err" >/dev/null ||
+  fail "dev link explains a staged conf that fails the syntax check" "$(cat "$test_tmp/syntax.err")"
+if grep -q 'sudo' "$log_file"; then
+  fail "dev link runs no privileged command when the staged conf fails the syntax check" "$(cat "$log_file")"
+fi
+[[ $(<"$conf_file") == 'export OMARCHY_PATH="/usr/share/omarchy"' ]] ||
+  fail "dev link keeps the installed conf when the staged conf fails the syntax check" "$(<"$conf_file")"
+[[ ! -s $sudoers_file ]] ||
+  fail "dev link installs no sudoers drop-in when the staged conf fails the syntax check" "$(<"$sudoers_file")"
+pass "dev link installs nothing when the staged conf fails the syntax check"


### PR DESCRIPTION
`omarchy dev link` piped `/etc/omarchy.conf` straight into `sudo tee` with no check. Every login shell sources that file through `/etc/profile.d/omarchy.sh`, so a conf bash cannot parse would break each login until root fixed it by hand.

This change builds the conf in a temp file, checks it with `bash -n`, and only then installs it with `sudo tee`. It is the same stage-and-check rule the sudoers drop-in a few lines below already follows.

Today `omarchy_conf_quote` keeps every real path parsable, so this does not fix a bug that can be hit now. It guards against a future change to how the conf is written landing a broken file on the system.

Tests: added a case to `test/shell.d/dev-link-test.sh`. It stubs `bash` so the `-n` check fails, then confirms dev link exits with an error, runs no `sudo` command, leaves the conf that was already installed as it was, and installs no sudoers drop-in. The same test fails against the script on the base branch, which has no check. All 9 dev-link tests and the 4 dev-unlink tests pass.

Earlier versions of this PR claimed a newline in the checkout path could inject commands into the conf. That was wrong: a newline inside double quotes stays part of the string, and the quoting already escapes `"`. The path rejection and its test are gone.
