### PR TITLE
Let a KeyboardPanel owner opt out of dismissal

### DIFF
--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -47,6 +47,19 @@ PanelWindow {
   property var borderSpec: Border.surfaceSpec("popups", "border", Color.popups.border, Math.max(1, Style.space(2)))
   property bool centerOnBar: false
   property bool open: false
+  // Whether a click outside the card dismisses the panel. An owner that keeps
+  // the panel up regardless — a pinned dashboard, say — sets this false, and
+  // the surface then stops claiming input it has no intention of acting on:
+  // the mask narrows to the card, the dismissal MouseArea goes idle, and the
+  // per-output twins below are never created.
+  //
+  // Overriding `close()` on the owner is not enough on its own. The click is
+  // still delivered here and swallowed, so the window behind the panel cannot
+  // be clicked, and — because the compositor is never asked to move focus to a
+  // toplevel that was never clicked — cannot be typed into either. That reads
+  // as the panel holding the keyboard hostage when in fact it is holding the
+  // pointer.
+  property bool dismissable: true
   property int gap: Style.gapsOut  // distance between bar edge and panel
   property bool popoutSwitching: false
   property bool popoutSwitchClosing: false
@@ -113,17 +126,25 @@ PanelWindow {
     right: true
   }
 
-  // Clickable region is the whole screen. Clicks in the bar strip are
-  // forwarded to registered bar buttons so switching between panel icons
+  // Clickable region is the whole screen while the panel is dismissable, so
+  // there is somewhere for an outside click to land. Clicks in the bar strip
+  // are forwarded to registered bar buttons so switching between panel icons
   // works in one click even when the overlay surface is above the bar.
+  //
+  // A non-dismissable panel narrows the region to the card instead. It has no
+  // outside click to catch, the bar is no longer covered so it needs no
+  // forwarding, and the rest of the screen goes back to belonging to whatever
+  // is underneath it.
   readonly property real _barStripSize: {
     if (!bar) return 0
     var actual = (root.barPos === "top" || root.barPos === "bottom") ? root.barH : root.barW
     return Math.max(bar.barSize, actual) + root.gap
   }
   mask: Region {
-    width: root.screenW
-    height: root.screenH
+    x: root.dismissable ? 0 : root.cardOrigin.x
+    y: root.dismissable ? 0 : root.cardOrigin.y
+    width: root.dismissable ? root.screenW : root.contentWidth
+    height: root.dismissable ? root.screenH : root.contentHeight
   }
 
   // Track every layout change between the bar's contentItem and the
@@ -280,7 +301,7 @@ PanelWindow {
   MouseArea {
     id: dismissArea
     anchors.fill: parent
-    enabled: root.open
+    enabled: root.open && root.dismissable
     acceptedButtons: Qt.AllButtons
     hoverEnabled: true
     property bool hoveringBar: false
@@ -336,12 +357,15 @@ PanelWindow {
   // hit-tests pointer input per output, so `dismissArea` above can never see
   // a click on another monitor. Give every other output a transparent twin
   // whose only job is to catch that click. They exist only while the panel is
-  // logically open (not during the fade-out, matching `dismissArea.enabled`).
+  // logically open and dismissable (not during the fade-out, matching
+  // `dismissArea.enabled`) — a panel that will not dismiss must not blanket
+  // other outputs with a surface whose only job is to dismiss it, or windows
+  // there cannot be clicked for as long as it is up.
   //
   // Keyboard focus is None: these must catch the pointer without taking focus
   // from the panel when the cursor merely crosses onto their output.
   Variants {
-    model: root.open ? Quickshell.screens : []
+    model: root.open && root.dismissable ? Quickshell.screens : []
 
     delegate: Component {
       PanelWindow {


### PR DESCRIPTION
## What

Adds a `dismissable` property to `qs.Ui.KeyboardPanel`, default `true`. When an owner sets it `false`, the panel stops claiming screen-wide pointer input it has no intention of acting on.

## Why

`KeyboardPanel.close()` already delegates to the owner:

```qml
function close() {
  if (owner && "close" in owner) owner.close()
  else root.open = false
}
```

So an owner can override `close()` to keep the panel up — that part works. What does not work is everything after it. The panel keeps a full-screen input region:

```qml
mask: Region {
  width: root.screenW
  height: root.screenH
}
```

and gives every *other* output a full-screen twin whose only job is to catch a click and dismiss. Both are correct for a dismissable panel — an outside click needs somewhere to land — but for one that will not dismiss, they only swallow clicks meant for other windows.

The second-order effect is the one that is hard to diagnose. A pinned panel appears to hold the **keyboard** hostage: you cannot type into any other window. The layer's steady state is `WlrKeyboardFocus.OnDemand`, and Hyprland *does* move keyboard focus off an OnDemand surface when a toplevel is clicked — but no toplevel is ever reached to be clicked, so the compositor is never asked to move anything. It reads as a focus bug and is a pointer bug.

I hit this building a third-party bar widget with a pin control. Two earlier attempts at it read the symptom as a keyboard-focus problem and rewrote the panel onto a `FloatingWindow` to get "normal focus semantics"; that passed a full headless test suite and was broken in real use. Narrowing the input region fixes it with no host change at all.

## What changes

With `dismissable: false`:

- `mask` narrows to the card rect (`cardOrigin` + `contentWidth`/`contentHeight`)
- `dismissArea.enabled` becomes false
- the per-output `Variants` model is empty, so no twins are created

Default `true` keeps every existing caller byte-for-byte identical — nothing in `shell/` sets the property.

## Testing

`./test/shell` — 183/188 pass. The 5 failures (`config`, `runtime-smoke`, `screenshot-sanity`, `snapper`, `unowned-system-paths`) fail identically on a clean checkout in this environment; they are not affected by this change.

Verified in the running UI on a two-monitor Hyprland session (eDP-1 + DP-1), with a panel plugin setting `dismissable: !pinned`:

| Case | Before | After |
|---|---|---|
| Pinned, click a window on the panel's output | swallowed | window focuses, panel stays open |
| Pinned, type into that window | nothing arrives | every character arrives |
| Pinned, click a window on the *other* output | swallowed | window focuses, panel stays open |
| Pinned, `hyprctl layers` | dismiss twin present on other output | twin absent |
| Unpin | — | twin returns, outside click dismisses again |
| Never pinned | — | unchanged |

The keyboard check used characters that are also panel keybindings (`c`, `h`, `t`, `o`, `p`, `r`); their arriving in the other window is what distinguishes "the panel is not receiving these" from "the panel is ignoring these".

## Note for reviewers

If you would rather not add API surface, the alternative is for owners to override `mask` on the instance — that works for the panel's own output and is what the widget ships today. It cannot reach the per-output twins, which are created inside `Variants` with no `id` or alias, and are gated only on `open`. That is the part only this repo can fix.
