### PR TITLE
fix(shell): ensure audio volume and mute reliably update via wpctl

### DIFF
--- a/shell/plugins/bar/widgets/Microphone.qml
+++ b/shell/plugins/bar/widgets/Microphone.qml
@@ -29,7 +29,10 @@ BarWidget {
   implicitHeight: button.implicitHeight
 
   function toggleMute() {
-    if (source && source.audio) source.audio.muted = !source.audio.muted
+    var nextMute = !muted
+    if (source && source.audio) source.audio.muted = nextMute
+    var target = (source && source.id !== undefined) ? String(source.id) : "@DEFAULT_AUDIO_SOURCE@"
+    Quickshell.execDetached(["wpctl", "set-mute", target, nextMute ? "1" : "0"])
   }
 
   PwObjectTracker { objects: root.source ? [root.source] : [] }
@@ -48,7 +51,10 @@ BarWidget {
     onWheelMoved: function(delta) {
       if (!root.source || !root.source.audio) return
       var step = 0.05
-      root.source.audio.volume = Math.max(0, Math.min(1, root.volume + (delta > 0 ? step : -step)))
+      var nextVol = Math.max(0, Math.min(1, root.volume + (delta > 0 ? step : -step)))
+      root.source.audio.volume = nextVol
+      var target = (root.source && root.source.id !== undefined) ? String(root.source.id) : "@DEFAULT_AUDIO_SOURCE@"
+      Quickshell.execDetached(["wpctl", "set-volume", target, nextVol.toFixed(3)])
     }
   }
 }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -282,7 +282,7 @@ Panel {
     }
     if (focusSection === "streams" && selectedIndex >= 0 && selectedIndex < displayAudioStreams.length) {
       var s = displayAudioStreams[selectedIndex]
-      if (s && s.audio) s.audio.volume = Math.max(0, Math.min(1.5, s.audio.volume + delta))
+      if (s && s.audio) setNodeVolume(s, s.audio.volume + delta)
     }
   }
 
@@ -303,7 +303,7 @@ Panel {
     }
     if (focusSection === "streams" && selectedIndex >= 0) {
       var st = displayAudioStreams[selectedIndex]
-      if (st && st.audio) st.audio.muted = !st.audio.muted
+      if (st) setNodeMute(st)
     }
   }
 
@@ -423,10 +423,34 @@ Panel {
     return Model.outputVolumeName(volume, muted)
   }
 
+  function setNodeVolume(node, v) {
+    var volume = Math.max(0, Math.min(1.5, v))
+    if (node && node.audio) node.audio.volume = volume
+    var target = (node && node.id !== undefined) ? String(node.id) : ""
+    if (target) {
+      Quickshell.execDetached(["wpctl", "set-volume", target, volume.toFixed(3)])
+    }
+    return volume
+  }
+
+  function setNodeMute(node, mute) {
+    if (node && node.audio) {
+      if (mute === undefined) node.audio.muted = !node.audio.muted
+      else node.audio.muted = mute
+    }
+    var target = (node && node.id !== undefined) ? String(node.id) : ""
+    if (target) {
+      var val = mute === undefined ? "toggle" : (mute ? "1" : "0")
+      Quickshell.execDetached(["wpctl", "set-mute", target, val])
+    }
+  }
+
   function setOutputVolume(v) {
-    if (!volumeSink || !volumeSink.audio) return outputVolume
+    var targetNode = volumeSink || sink
     var volume = Math.max(0, Math.min(1, v))
-    volumeSink.audio.volume = volume
+    if (targetNode && targetNode.audio) targetNode.audio.volume = volume
+    var target = (targetNode && targetNode.id !== undefined) ? String(targetNode.id) : (volumeSinkName || "@DEFAULT_AUDIO_SINK@")
+    Quickshell.execDetached(["wpctl", "set-volume", target, volume.toFixed(3)])
     return volume
   }
 
@@ -439,16 +463,25 @@ Panel {
   }
 
   function setInputVolume(v) {
-    if (!source || !source.audio) return
-    source.audio.volume = Math.max(0, Math.min(1, v))
+    var volume = Math.max(0, Math.min(1, v))
+    if (source && source.audio) source.audio.volume = volume
+    var target = (source && source.id !== undefined) ? String(source.id) : "@DEFAULT_AUDIO_SOURCE@"
+    Quickshell.execDetached(["wpctl", "set-volume", target, volume.toFixed(3)])
   }
 
   function toggleOutputMute() {
-    if (volumeSink && volumeSink.audio) volumeSink.audio.muted = !volumeSink.audio.muted
+    var targetNode = volumeSink || sink
+    var nextMute = !outputMuted
+    if (targetNode && targetNode.audio) targetNode.audio.muted = nextMute
+    var target = (targetNode && targetNode.id !== undefined) ? String(targetNode.id) : (volumeSinkName || "@DEFAULT_AUDIO_SINK@")
+    Quickshell.execDetached(["wpctl", "set-mute", target, nextMute ? "1" : "0"])
   }
 
   function toggleInputMute() {
-    if (source && source.audio) source.audio.muted = !source.audio.muted
+    var nextMute = !inputMuted
+    if (source && source.audio) source.audio.muted = nextMute
+    var target = (source && source.id !== undefined) ? String(source.id) : "@DEFAULT_AUDIO_SOURCE@"
+    Quickshell.execDetached(["wpctl", "set-mute", target, nextMute ? "1" : "0"])
   }
 
   // The hero switch is the whole panel's on/off, so it carries both channels
@@ -456,8 +489,17 @@ Panel {
   // muting a single channel from the row below flipping the master switch.
   function toggleAllMuted() {
     var mute = anyAudible
-    if (hasOutput) volumeSink.audio.muted = mute
-    if (hasInput) source.audio.muted = mute
+    if (hasOutput) {
+      var targetNode = volumeSink || sink
+      if (targetNode && targetNode.audio) targetNode.audio.muted = mute
+      var target = (targetNode && targetNode.id !== undefined) ? String(targetNode.id) : (volumeSinkName || "@DEFAULT_AUDIO_SINK@")
+      Quickshell.execDetached(["wpctl", "set-mute", target, mute ? "1" : "0"])
+    }
+    if (hasInput) {
+      if (source && source.audio) source.audio.muted = mute
+      var targetSrc = (source && source.id !== undefined) ? String(source.id) : "@DEFAULT_AUDIO_SOURCE@"
+      Quickshell.execDetached(["wpctl", "set-mute", targetSrc, mute ? "1" : "0"])
+    }
   }
 
   function setDefaultSink(node) {
@@ -676,7 +718,7 @@ Panel {
           if (root.focusSection === "streams" && root.selectedIndex >= 0
               && root.selectedIndex < root.displayAudioStreams.length) {
             var s = root.displayAudioStreams[root.selectedIndex]
-            if (s && s.audio) s.audio.muted = !s.audio.muted
+            if (s) root.setNodeMute(s)
           } else if (root.focusSection === "input") {
             root.toggleInputMute()
           } else {
@@ -1172,8 +1214,7 @@ Panel {
             anchors.fill: parent
             cursorShape: Qt.PointingHandCursor
             onClicked: {
-              if (streamRow.node && streamRow.node.audio)
-                streamRow.node.audio.muted = !streamRow.node.audio.muted
+              root.setNodeMute(streamRow.node)
             }
           }
         }
@@ -1213,11 +1254,10 @@ Panel {
         opacity: streamRow.streamMuted ? 0.5 : 1.0
 
         onMoved: function(v) {
-          if (streamRow.node && streamRow.node.audio) streamRow.node.audio.volume = v
+          root.setNodeVolume(streamRow.node, v)
         }
         onRightClicked: {
-          if (streamRow.node && streamRow.node.audio)
-            streamRow.node.audio.muted = !streamRow.node.audio.muted
+          root.setNodeMute(streamRow.node)
         }
       }
     }


### PR DESCRIPTION
### Problem
In Quickshell's PipeWire integration (`PwNodeBoundAudio::setVolumes`), device volume modifications are only dispatched if `this->volumeStep != -1`. For devices that do not expose a discrete hardware volume step property in their PipeWire SPA params (e.g. certain Bluetooth headsets like MM40, USB audio interfaces, or ALSA sinks/sources), `volumeStep` remains `-1`. As a result, volume adjustments (from the audio panel slider, mouse wheel scrolling on the bar icon, or keyboard hotkeys) are silently dropped.

### Solution
- When adjusting sink, source, or stream volume and mute states in `Panel.qml` and `Microphone.qml`, dispatch the corresponding `wpctl set-volume` and `wpctl set-mute` commands via `Quickshell.execDetached`.
- This guarantees volume and mute changes are immediately and reliably applied across WirePlumber/PipeWire for all audio device types.