### PR TITLE
Add encrypted, versioned, off-site backups

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -28,6 +28,7 @@ declare -A GROUP_DESCRIPTIONS
 
 GROUP_DESCRIPTIONS[agent]="AI coding agent usage data"
 GROUP_DESCRIPTIONS[audio]="Audio input and output controls"
+GROUP_DESCRIPTIONS[backup]="Off-site encrypted backups"
 GROUP_DESCRIPTIONS[bar]="Omarchy shell bar layout and settings"
 GROUP_DESCRIPTIONS[battery]="Battery status helpers"
 GROUP_DESCRIPTIONS[bluetooth]="Bluetooth device controls"

--- a/bin/omarchy-backup-browse
+++ b/bin/omarchy-backup-browse
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# omarchy:summary=Browse every backup as dated folders and copy files out
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+if ! backup_configured; then
+  echo "Backups are not set up. Run: omarchy setup backup" >&2
+  exit 1
+fi
+
+if omarchy-cmd-missing fusermount; then
+  echo "Browsing needs fuse2. Install it with: omarchy-pkg-add fuse2" >&2
+  exit 1
+fi
+
+unmount() {
+  fusermount -u "$BACKUP_MOUNT_DIR" 2>/dev/null
+  rmdir "$BACKUP_MOUNT_DIR" 2>/dev/null
+}
+
+# A browse session that was killed rather than closed leaves the mountpoint
+# behind, and restic refuses to mount over it.
+unmount
+mkdir -p "$BACKUP_MOUNT_DIR"
+trap unmount EXIT
+
+backup_load_credentials
+
+echo -e "\e[32mMounting your backups at $BACKUP_MOUNT_DIR\e[0m"
+echo "Every backup appears as a dated folder. Copy out what you need."
+echo "Close this window or press Ctrl-C when you are done."
+echo
+
+backup_restic mount "$BACKUP_MOUNT_DIR" &
+mount_pid=$!
+
+for attempt in {1..30}; do
+  if mountpoint -q "$BACKUP_MOUNT_DIR"; then
+    xdg-open "$BACKUP_MOUNT_DIR" >/dev/null 2>&1 &
+    break
+  fi
+  sleep 0.5
+done
+
+wait "$mount_pid"

--- a/bin/omarchy-backup-env
+++ b/bin/omarchy-backup-env
@@ -1,0 +1,210 @@
+#!/bin/bash
+
+# omarchy:summary=Load backup paths, settings, and credentials for the other backup commands
+# omarchy:hidden=true
+
+# Sourced rather than run: every other backup command starts with
+# `source omarchy-backup-env`. Keeping the layout in one place is what keeps a
+# delete-capable credential out of ~/.config, where the dots repo would sync it.
+
+BACKUP_SECRETS_DIR="$HOME/.local/share/omarchy/backup"
+BACKUP_ENV_FILE="$BACKUP_SECRETS_DIR/env"
+BACKUP_PASSPHRASE_FILE="$BACKUP_SECRETS_DIR/passphrase"
+
+BACKUP_CONFIG_DIR="$HOME/.config/omarchy/backup"
+BACKUP_SETTINGS_FILE="$BACKUP_CONFIG_DIR/settings"
+BACKUP_USER_EXCLUDE_FILE="$BACKUP_CONFIG_DIR/excludes"
+
+BACKUP_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/backup"
+BACKUP_STATUS_FILE="$BACKUP_STATE_DIR/status.json"
+BACKUP_LOG_FILE="$BACKUP_STATE_DIR/backup.log"
+BACKUP_PAUSE_FILE="$BACKUP_STATE_DIR/pause"
+BACKUP_LOCK_FILE="$BACKUP_STATE_DIR/lock"
+BACKUP_EXCLUDE_FILE="$BACKUP_STATE_DIR/excludes"
+BACKUP_MAINTENANCE_FILE="$BACKUP_STATE_DIR/maintenance"
+BACKUP_SETUP_PHASE_FILE="$BACKUP_STATE_DIR/setup-phase"
+BACKUP_MOUNT_DIR="${XDG_RUNTIME_DIR:-/tmp}/omarchy-backup-browse"
+
+BACKUP_UNIT_DIR="$HOME/.config/systemd/user"
+BACKUP_SHIPPED_UNIT_DIR="$OMARCHY_PATH/default/systemd/user"
+BACKUP_DEFAULT_EXCLUDE_FILE="$OMARCHY_PATH/default/backup/excludes"
+
+# Overridable in the settings file, which the wizard writes and the user may edit.
+BACKUP_DESTINATION_LABEL=""
+BACKUP_DESTINATION_KIND="s3"
+BACKUP_DESTINATION_UUID=""
+BACKUP_KEEP_HOURLY=24
+BACKUP_KEEP_DAILY=7
+BACKUP_KEEP_WEEKLY=5
+BACKUP_KEEP_MONTHLY=12
+BACKUP_MAINTENANCE_HOST=""
+BACKUP_BATTERY_FLOOR=20
+
+if [[ -f $BACKUP_SETTINGS_FILE ]]; then
+  source "$BACKUP_SETTINGS_FILE"
+fi
+
+backup_configured() {
+  [[ -s $BACKUP_ENV_FILE && -s $BACKUP_PASSPHRASE_FILE ]]
+}
+
+# Credentials reach restic through the environment and a password file, never
+# through argv, where every other process on the machine could read them.
+backup_load_credentials() {
+  if ! backup_configured; then
+    return 1
+  fi
+
+  set -a
+  source "$BACKUP_ENV_FILE"
+  set +a
+  export RESTIC_PASSWORD_FILE="$BACKUP_PASSPHRASE_FILE"
+}
+
+# restic defaults to zero lock retries, which turns a second machine backing up
+# at the same minute into a failure rather than a wait.
+backup_restic() {
+  restic --retry-lock 5m "$@"
+}
+
+backup_destination_offsite() {
+  [[ $BACKUP_DESTINATION_KIND != "local" ]]
+}
+
+# A local destination whose disk is absent must skip the run: restic would
+# otherwise happily create a fresh repository in the empty mountpoint sitting on
+# the root filesystem, and report success for a backup that protects nothing.
+backup_local_destination_present() {
+  if [[ $BACKUP_DESTINATION_KIND != "local" || -z $BACKUP_DESTINATION_UUID ]]; then
+    return 0
+  fi
+
+  local path="${RESTIC_REPOSITORY#local:}"
+  [[ $(findmnt -no UUID --target "$path" 2>/dev/null) == "$BACKUP_DESTINATION_UUID" ]]
+}
+
+backup_write_settings() {
+  mkdir -p "$BACKUP_CONFIG_DIR"
+
+  cat >"$BACKUP_SETTINGS_FILE" <<SETTINGS
+# Omarchy backup settings. Credentials live in $BACKUP_SECRETS_DIR, not here.
+BACKUP_DESTINATION_LABEL="$BACKUP_DESTINATION_LABEL"
+BACKUP_DESTINATION_KIND="$BACKUP_DESTINATION_KIND"
+BACKUP_DESTINATION_UUID="$BACKUP_DESTINATION_UUID"
+BACKUP_KEEP_HOURLY=$BACKUP_KEEP_HOURLY
+BACKUP_KEEP_DAILY=$BACKUP_KEEP_DAILY
+BACKUP_KEEP_WEEKLY=$BACKUP_KEEP_WEEKLY
+BACKUP_KEEP_MONTHLY=$BACKUP_KEEP_MONTHLY
+BACKUP_MAINTENANCE_HOST="$BACKUP_MAINTENANCE_HOST"
+BACKUP_BATTERY_FLOOR=$BACKUP_BATTERY_FLOOR
+SETTINGS
+}
+
+# restic reads exclude patterns literally: a `~/` pattern excludes a directory
+# actually named "~", so patterns are expanded here instead of being trusted to
+# mean what they look like.
+backup_write_exclude_file() {
+  local line=""
+  local patterns=""
+
+  mkdir -p "$BACKUP_STATE_DIR"
+
+  {
+    # The repository must never contain the credentials that unlock it, and
+    # restic's own cache is regenerable by definition.
+    printf '%s\n' "$BACKUP_SECRETS_DIR"
+    printf '%s\n' "$HOME/.cache"
+    printf '%s\n' "$HOME/.local/share/Trash"
+
+    for patterns in "$BACKUP_DEFAULT_EXCLUDE_FILE" "$BACKUP_USER_EXCLUDE_FILE"; do
+      [[ -f $patterns ]] || continue
+
+      while IFS= read -r line; do
+        [[ -z $line || $line == \#* ]] && continue
+        if [[ $line == /* ]]; then
+          printf '%s\n' "$line"
+        else
+          printf '%s/%s\n' "$HOME" "${line#./}"
+        fi
+      done <"$patterns"
+    done
+  } >"$BACKUP_EXCLUDE_FILE"
+}
+
+backup_status_document() {
+  if [[ -s $BACKUP_STATUS_FILE ]] && jq -e . "$BACKUP_STATUS_FILE" >/dev/null 2>&1; then
+    cat "$BACKUP_STATUS_FILE"
+  else
+    backup_status_skeleton
+  fi
+}
+
+backup_status_skeleton() {
+  jq -n '{
+    phase: "unconfigured",
+    run_id: "",
+    pid: 0,
+    started_at: 0,
+    updated_at: 0,
+    progress: {percent: 0, bytes_done: 0, bytes_total: 0, files_done: 0},
+    last_backup: {time: 0, snapshot: "", result: "", error: "", unreadable: []},
+    last_complete: {time: 0, snapshot: ""},
+    last_maintenance: {time: 0, result: "", error: ""},
+    last_skip: {time: 0, reason: ""},
+    last_warning: 0,
+    snapshots: [],
+    destination: {label: "", kind: "", offsite: true},
+    repository: {size_bytes: 0, snapshot_count: 0},
+    pause: {until: 0, reason: ""}
+  }'
+}
+
+# Written by rename so the panel never reads half a document, and so a crash
+# mid-write leaves the previous status intact rather than an empty file.
+backup_status_update() {
+  local program="$1"
+  shift
+  local temporary="$BACKUP_STATUS_FILE.$$"
+
+  mkdir -p "$BACKUP_STATE_DIR"
+
+  if backup_status_document |
+    jq --argjson now "$(date +%s)" "$@" "$program | .updated_at = \$now" >"$temporary"; then
+    mv -f "$temporary" "$BACKUP_STATUS_FILE"
+  else
+    rm -f "$temporary"
+    return 1
+  fi
+}
+
+backup_log() {
+  mkdir -p "$BACKUP_STATE_DIR"
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >>"$BACKUP_LOG_FILE"
+
+  # A log that grows for years is its own bug report; keep the tail that a
+  # support question actually needs.
+  if (( $(wc -l <"$BACKUP_LOG_FILE") > 2000 )); then
+    tail -n 1000 "$BACKUP_LOG_FILE" >"$BACKUP_LOG_FILE.trimmed"
+    mv -f "$BACKUP_LOG_FILE.trimmed" "$BACKUP_LOG_FILE"
+  fi
+}
+
+backup_pause_active() {
+  local until=""
+
+  [[ -f $BACKUP_PAUSE_FILE ]] || return 1
+
+  until=$(<"$BACKUP_PAUSE_FILE")
+  if [[ $until == "manual" ]]; then
+    return 0
+  fi
+
+  if [[ $until =~ ^[0-9]+$ ]] && (( until > $(date +%s) )); then
+    return 0
+  fi
+
+  # An expired pause is cleared by whoever notices it first, so the timer can
+  # resume on its own rather than waiting for someone to press Resume.
+  rm -f "$BACKUP_PAUSE_FILE"
+  return 1
+}

--- a/bin/omarchy-backup-log
+++ b/bin/omarchy-backup-log
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Show what the backups have been doing
+# omarchy:args=[--follow]
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+if [[ ! -f $BACKUP_LOG_FILE ]]; then
+  echo "No backup log yet."
+  exit 0
+fi
+
+case "${1:-}" in
+"")
+  tail -n 50 "$BACKUP_LOG_FILE"
+  ;;
+--follow | -f)
+  tail -n 50 -f "$BACKUP_LOG_FILE"
+  ;;
+*)
+  echo "Usage: omarchy backup log [--follow]" >&2
+  exit 2
+  ;;
+esac

--- a/bin/omarchy-backup-now
+++ b/bin/omarchy-backup-now
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# omarchy:summary=Back up now instead of waiting for the next scheduled run
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+if ! backup_configured; then
+  echo "Backups are not set up. Run: omarchy setup backup" >&2
+  exit 1
+fi
+
+if backup_pause_active; then
+  echo "Backups are paused. Run 'omarchy backup resume' first." >&2
+  exit 1
+fi
+
+# Started through the unit rather than directly so a manual run and a scheduled
+# one are the same run, with the same journal and the same restart behavior.
+systemctl --user start --no-block omarchy-backup.service
+echo "Backing up in the background. Watch it with: omarchy backup status"

--- a/bin/omarchy-backup-pause
+++ b/bin/omarchy-backup-pause
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# omarchy:summary=Pause scheduled backups for a while, or until resumed
+# omarchy:args=[1h|today|until-resumed]
+# omarchy:examples=omarchy backup pause 1h | omarchy backup pause until-resumed
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+duration="${1:-until-resumed}"
+
+case "$duration" in
+1h)
+  pause_until=$(date -d "+1 hour" +%s)
+  message="Paused until $(date -d "@$pause_until" '+%H:%M')"
+  ;;
+today)
+  pause_until=$(date -d "tomorrow 00:00" +%s)
+  message="Paused until tomorrow"
+  ;;
+until-resumed)
+  pause_until="manual"
+  message="Paused until resumed"
+  ;;
+-h | --help)
+  echo "Usage: omarchy backup pause [1h|today|until-resumed]"
+  exit 0
+  ;;
+*)
+  echo "omarchy-backup-pause: pause for 1h, today, or until-resumed." >&2
+  exit 2
+  ;;
+esac
+
+mkdir -p "$BACKUP_STATE_DIR"
+printf '%s\n' "$pause_until" >"$BACKUP_PAUSE_FILE"
+
+if [[ $pause_until == "manual" ]]; then
+  backup_status_update '.phase = "paused" | .pause = {until: 0, reason: "paused"}'
+else
+  backup_status_update '.phase = "paused" | .pause = {until: $until, reason: "paused"}' --argjson until "$pause_until"
+fi
+
+backup_log "$message"
+echo "$message"

--- a/bin/omarchy-backup-restore
+++ b/bin/omarchy-backup-restore
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# omarchy:summary=Restore files or folders from a backup
+# omarchy:args=<path> [--at <snapshot|time>] [--in-place]
+# omarchy:examples=omarchy backup restore ~/Documents/taxes.pdf | omarchy backup restore ~/Pictures --at 2026-01-15 | omarchy backup restore ~/Notes --in-place
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+TARGET_PATH=""
+AT=""
+IN_PLACE="false"
+
+while (( $# > 0 )); do
+  case "$1" in
+  --at)
+    shift
+    AT="${1:-}"
+    if [[ -z $AT ]]; then
+      echo "omarchy-backup-restore: --at needs a snapshot id or a date." >&2
+      exit 2
+    fi
+    ;;
+  --at=*)
+    AT="${1#--at=}"
+    ;;
+  --in-place)
+    IN_PLACE="true"
+    ;;
+  -h | --help)
+    echo "Usage: omarchy backup restore <path> [--at <snapshot|time>] [--in-place]"
+    echo
+    echo "Restores into ~/Restored/<timestamp>/ by default, so nothing you still"
+    echo "have is overwritten. --in-place puts the files back where they came"
+    echo "from, after copying the current version aside first."
+    exit 0
+    ;;
+  -*)
+    echo "omarchy-backup-restore: unknown option '$1'. Try --help." >&2
+    exit 2
+    ;;
+  *)
+    if [[ -n $TARGET_PATH ]]; then
+      echo "omarchy-backup-restore: restore one path at a time." >&2
+      exit 2
+    fi
+    TARGET_PATH="$1"
+    ;;
+  esac
+  shift
+done
+
+if [[ -z $TARGET_PATH ]]; then
+  echo "Usage: omarchy backup restore <path> [--at <snapshot|time>] [--in-place]" >&2
+  exit 2
+fi
+
+if ! backup_configured; then
+  echo "Backups are not set up. Run: omarchy setup backup" >&2
+  exit 1
+fi
+
+# The path is turned into an absolute one here and handed to restic as a literal
+# include argument, never through a shell, so spaces and globs in a filename
+# restore the file rather than something else.
+if [[ $TARGET_PATH != /* ]]; then
+  TARGET_PATH="$(pwd)/$TARGET_PATH"
+fi
+TARGET_PATH="${TARGET_PATH%/}"
+
+backup_load_credentials
+
+# Defaults to the last snapshot known to be complete: a partial one is missing
+# files by definition, and quietly restoring from it is how you find that out
+# too late.
+resolve_snapshot() {
+  local candidate=""
+  local at_epoch=""
+  local id=""
+  local timestamp=""
+  local snapshot_epoch=0
+
+  if [[ -z $AT ]]; then
+    candidate=$(jq -r '.last_complete.snapshot // ""' "$BACKUP_STATUS_FILE" 2>/dev/null)
+    printf '%s' "${candidate:-latest}"
+    return
+  fi
+
+  if [[ $AT =~ ^[0-9a-f]{8,}$ ]]; then
+    printf '%s' "$AT"
+    return
+  fi
+
+  at_epoch=$(date -d "$AT" +%s 2>/dev/null)
+  if [[ -z $at_epoch ]]; then
+    echo "omarchy-backup-restore: could not read '$AT' as a date or a snapshot id." >&2
+    return
+  fi
+
+  # restic has no "the snapshot as of this time" selector, so the newest one
+  # taken before that time is picked here.
+  candidate=$(backup_restic snapshots --json --host "$(hostname)" 2>/dev/null |
+    jq -r 'sort_by(.time) | .[] | [(.short_id // .id), .time] | @tsv' |
+    while IFS=$'\t' read -r id timestamp; do
+      snapshot_epoch=$(date -d "$timestamp" +%s 2>/dev/null || echo 0)
+      (( snapshot_epoch <= at_epoch )) && printf '%s\n' "$id"
+    done | tail -n 1)
+
+  if [[ -z $candidate ]]; then
+    echo "omarchy-backup-restore: no backup from before $AT." >&2
+    return
+  fi
+
+  printf '%s' "$candidate"
+}
+
+snapshot=$(resolve_snapshot)
+if [[ -z $snapshot ]]; then
+  exit 1
+fi
+
+stamp=$(date '+%Y-%m-%d-%H%M%S')
+staging="$HOME/Restored/$stamp"
+
+if [[ $IN_PLACE == "true" ]]; then
+  echo -e "\e[33mRestoring $TARGET_PATH in place from snapshot $snapshot.\e[0m"
+  echo "The version you have now is copied to $staging first."
+  read -rp "Type 'restore' to continue: " confirmation
+  if [[ $confirmation != "restore" ]]; then
+    echo "Nothing restored."
+    exit 1
+  fi
+
+  if [[ -e $TARGET_PATH ]]; then
+    mkdir -p "$staging$(dirname "$TARGET_PATH")"
+    cp -a "$TARGET_PATH" "$staging$(dirname "$TARGET_PATH")/"
+  fi
+
+  backup_restic restore "$snapshot" --target / --include "$TARGET_PATH"
+  echo -e "\e[32mRestored $TARGET_PATH from $snapshot.\e[0m"
+  echo "The version it replaced is in $staging."
+else
+  mkdir -p "$staging"
+  backup_restic restore "$snapshot" --target "$staging" --include "$TARGET_PATH"
+  echo -e "\e[32mRestored $TARGET_PATH from $snapshot into:\e[0m"
+  echo "  $staging$TARGET_PATH"
+fi

--- a/bin/omarchy-backup-resume
+++ b/bin/omarchy-backup-resume
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Resume scheduled backups after a pause
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+rm -f "$BACKUP_PAUSE_FILE"
+backup_status_update '.phase = (if .phase == "paused" then "idle" else .phase end) | .pause = {until: 0, reason: ""}'
+backup_log "Resumed"
+echo "Backups resumed. The next scheduled run picks up from here."

--- a/bin/omarchy-backup-run
+++ b/bin/omarchy-backup-run
@@ -1,0 +1,325 @@
+#!/bin/bash
+
+# omarchy:summary=Run one backup pass, honoring pauses, power, locks, and maintenance
+# omarchy:hidden=true
+
+# The unit target of omarchy-backup.timer, and what "Back Up Now" ultimately
+# starts. Every decision it makes — ran, skipped, failed — lands in status.json,
+# because the panel and the CLI both read that file and never restic itself.
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+RUN_OUTPUT_DIR="$BACKUP_STATE_DIR/run"
+SUMMARY_FILE="$RUN_OUTPUT_DIR/summary.json"
+ERRORS_FILE="$RUN_OUTPUT_DIR/unreadable"
+EXIT_FILE="$RUN_OUTPUT_DIR/exit"
+STDERR_FILE="$RUN_OUTPUT_DIR/stderr"
+
+MAINTENANCE_INTERVAL_DAYS=30
+WARNING_AFTER_HOURS=24
+WARNING_REPEAT_DAYS=7
+READ_DATA_SUBSETS=12
+
+now() {
+  date +%s
+}
+
+skip() {
+  local reason="$1"
+
+  backup_log "Skipped: $reason"
+  backup_status_update '.phase = (if .phase == "running" then "idle" else .phase end) |
+    .last_skip = {time: $now, reason: $reason}' --arg reason "$reason"
+  exit 0
+}
+
+# A run recorded as `running` by a process that no longer exists is a crash or a
+# reboot mid-backup. Left alone the panel shows an eternal upload, so the next
+# run rewrites it as the failure it was.
+reconcile_stale_run() {
+  local phase=""
+  local pid=""
+
+  [[ -s $BACKUP_STATUS_FILE ]] || return 0
+
+  phase=$(jq -r '.phase // ""' "$BACKUP_STATUS_FILE" 2>/dev/null)
+  pid=$(jq -r '.pid // 0' "$BACKUP_STATUS_FILE" 2>/dev/null)
+
+  [[ $phase == "running" ]] || return 0
+  [[ $pid =~ ^[0-9]+$ ]] && (( pid > 0 )) && kill -0 "$pid" 2>/dev/null && return 0
+
+  backup_log "Reconciled a run that died without reporting (pid ${pid:-unknown})"
+  backup_status_update '.phase = "error" | .pid = 0 |
+    .last_backup = (.last_backup + {time: $now, result: "failed", error: "The backup process stopped without finishing"})'
+}
+
+destination_json() {
+  jq -n --arg label "$BACKUP_DESTINATION_LABEL" \
+    --arg kind "$BACKUP_DESTINATION_KIND" \
+    --argjson offsite "$(backup_destination_offsite && echo true || echo false)" \
+    '{label: $label, kind: $kind, offsite: $offsite}'
+}
+
+run_backup() {
+  local run_id="$1"
+  local exit_code=0
+
+  rm -rf "$RUN_OUTPUT_DIR"
+  mkdir -p "$RUN_OUTPUT_DIR"
+
+  backup_write_exclude_file
+  backup_status_update '.phase = "running" | .run_id = $run | .pid = $pid | .started_at = $now |
+    .progress = {percent: 0, bytes_done: 0, bytes_total: 0, files_done: 0} |
+    .destination = $destination' \
+    --arg run "$run_id" --argjson pid "$$" --argjson destination "$(destination_json)"
+
+  {
+    backup_restic backup --json --one-file-system \
+      --exclude-file "$BACKUP_EXCLUDE_FILE" \
+      --tag omarchy "$HOME" 2>"$STDERR_FILE"
+    printf '%s\n' "$?" >"$EXIT_FILE"
+  } | consume_backup_output
+
+  if [[ -s $EXIT_FILE ]]; then
+    exit_code=$(<"$EXIT_FILE")
+  else
+    exit_code=1
+  fi
+
+  return "$exit_code"
+}
+
+# restic reports progress several times a second. Matching on the raw line keeps
+# the common case out of jq, and the throttle keeps status.json from being
+# rewritten faster than anyone can read it.
+consume_backup_output() {
+  local line=""
+  local last_progress=0
+
+  while IFS= read -r line; do
+    if [[ $line == *'"message_type":"status"'* ]]; then
+      if (( SECONDS - last_progress >= 3 )); then
+        last_progress=$SECONDS
+        record_progress "$line"
+      fi
+    elif [[ $line == *'"message_type":"summary"'* ]]; then
+      printf '%s\n' "$line" >"$SUMMARY_FILE"
+    elif [[ $line == *'"message_type":"error"'* ]]; then
+      jq -r '.item // empty' <<<"$line" >>"$ERRORS_FILE"
+    fi
+  done
+}
+
+record_progress() {
+  backup_status_update '.progress = {
+      percent: (($status.percent_done // 0) * 100 | floor),
+      bytes_done: ($status.bytes_done // 0),
+      bytes_total: ($status.total_bytes // 0),
+      files_done: ($status.files_done // 0)
+    }' --argjson status "$1"
+}
+
+unreadable_json() {
+  if [[ -s $ERRORS_FILE ]]; then
+    jq -R -s 'split("\n") | map(select(length > 0)) | unique | .[0:20]' "$ERRORS_FILE"
+  else
+    echo '[]'
+  fi
+}
+
+# Exit 3 means restic wrote a snapshot but could not read everything in it. That
+# is a real backup and worth keeping, but it must never become the snapshot a
+# restore silently defaults to.
+record_result() {
+  local exit_code="$1"
+  local snapshot=""
+  local error=""
+
+  [[ -s $SUMMARY_FILE ]] && snapshot=$(jq -r '.snapshot_id // ""' "$SUMMARY_FILE")
+
+  case "$exit_code" in
+  0)
+    backup_status_update '.phase = "idle" | .pid = 0 |
+      .last_backup = {time: $now, snapshot: $snapshot, result: "complete", error: "", unreadable: []} |
+      .last_complete = {time: $now, snapshot: $snapshot}' --arg snapshot "$snapshot"
+    backup_log "Backed up as ${snapshot:-unknown}"
+    ;;
+  3)
+    backup_status_update '.phase = "idle" | .pid = 0 |
+      .last_backup = {time: $now, snapshot: $snapshot, result: "partial", error: "Some files could not be read", unreadable: $unreadable}' \
+      --arg snapshot "$snapshot" --argjson unreadable "$(unreadable_json)"
+    backup_log "Backed up as ${snapshot:-unknown} with unreadable files"
+    ;;
+  *)
+    error=$(tail -n 3 "$STDERR_FILE" 2>/dev/null | tr '\n' ' ' | cut -c1-300)
+    [[ -n $error ]] || error="restic exited with code $exit_code"
+    backup_status_update '.phase = "error" | .pid = 0 |
+      .last_backup = {time: $now, snapshot: "", result: "failed", error: $error, unreadable: []}' \
+      --arg error "$error"
+    backup_log "Backup failed: $error"
+    ;;
+  esac
+}
+
+# restic timestamps carry an offset (+01:00), which jq's strptime cannot read,
+# so the conversion to epoch seconds — what everything downstream displays —
+# happens here rather than inside a jq program that would silently return zero.
+snapshot_records() {
+  local raw="$1"
+  local records="[]"
+  local id=""
+  local timestamp=""
+  local host=""
+
+  while IFS=$'\t' read -r id timestamp host; do
+    [[ -n $id ]] || continue
+    records=$(jq -c --arg id "$id" --arg host "$host" \
+      --argjson time "$(date -d "$timestamp" +%s 2>/dev/null || echo 0)" \
+      '. + [{id: $id, time: $time, hostname: $host}]' <<<"$records")
+  done < <(jq -r 'sort_by(.time) | reverse | .[0:10] | .[] |
+    [(.short_id // .id // ""), .time, (.hostname // "")] | @tsv' <<<"$raw")
+
+  printf '%s' "$records"
+}
+
+refresh_repository_facts() {
+  local snapshots=""
+  local stats=""
+
+  snapshots=$(backup_restic snapshots --json --host "$(hostname)" 2>/dev/null) || return 0
+  [[ -n $snapshots ]] || return 0
+  stats=$(backup_restic stats --json --mode raw-data 2>/dev/null) || stats='{}'
+
+  backup_status_update '.snapshots = $snapshots |
+    .repository = {size_bytes: ($stats.total_size // 0), snapshot_count: $count}' \
+    --argjson snapshots "$(snapshot_records "$snapshots")" \
+    --argjson stats "$stats" \
+    --argjson count "$(jq 'length' <<<"$snapshots")"
+}
+
+maintenance_due() {
+  local last=0
+
+  # Exactly one machine prunes and checks: the expensive, lock-contending half
+  # of the work has no reason to run on every laptop sharing the repository.
+  if [[ -n $BACKUP_MAINTENANCE_HOST && $BACKUP_MAINTENANCE_HOST != "$(hostname)" ]]; then
+    return 1
+  fi
+
+  [[ -s $BACKUP_MAINTENANCE_FILE ]] && last=$(cut -d' ' -f1 "$BACKUP_MAINTENANCE_FILE")
+  [[ $last =~ ^[0-9]+$ ]] || last=0
+
+  (( $(now) - last > MAINTENANCE_INTERVAL_DAYS * 86400 ))
+}
+
+# prune re-uploads packs it rewrites, so this is bandwidth and API spend, not
+# housekeeping — monthly, and read-data one slice at a time so the whole
+# repository is eventually read without paying for it all at once.
+run_maintenance() {
+  local subset=0
+  local result="ok"
+  local error=""
+
+  [[ -s $BACKUP_MAINTENANCE_FILE ]] && subset=$(cut -d' ' -f2 "$BACKUP_MAINTENANCE_FILE")
+  [[ $subset =~ ^[0-9]+$ ]] || subset=0
+  subset=$(( subset % READ_DATA_SUBSETS + 1 ))
+
+  backup_log "Running maintenance (forget --prune, check, read-data subset $subset/$READ_DATA_SUBSETS)"
+
+  if ! backup_restic forget --prune \
+    --group-by host,paths \
+    --keep-hourly "$BACKUP_KEEP_HOURLY" \
+    --keep-daily "$BACKUP_KEEP_DAILY" \
+    --keep-weekly "$BACKUP_KEEP_WEEKLY" \
+    --keep-monthly "$BACKUP_KEEP_MONTHLY" >>"$BACKUP_LOG_FILE" 2>&1; then
+    result="failed"
+    error="Could not forget and prune old snapshots"
+  elif ! backup_restic check --read-data-subset="$subset/$READ_DATA_SUBSETS" >>"$BACKUP_LOG_FILE" 2>&1; then
+    result="failed"
+    error="Repository check reported a problem"
+  fi
+
+  printf '%s %s\n' "$(now)" "$subset" >"$BACKUP_MAINTENANCE_FILE"
+  backup_status_update '.last_maintenance = {time: $now, result: $result, error: $error}' \
+    --arg result "$result" --arg error "$error"
+
+  if [[ $result == "failed" ]]; then
+    backup_log "Maintenance failed: $error"
+  fi
+}
+
+# One failed run is a café's wifi, not a broken backup. A day without a complete
+# one is worth saying out loud, and worth repeating weekly — a single warning
+# would let a dead credential rot silently for months.
+warn_if_stale() {
+  local last_complete=0
+  local last_warning=0
+
+  last_complete=$(jq -r '.last_complete.time // 0' "$BACKUP_STATUS_FILE" 2>/dev/null)
+  last_warning=$(jq -r '.last_warning // 0' "$BACKUP_STATUS_FILE" 2>/dev/null)
+
+  (( $(now) - last_complete > WARNING_AFTER_HOURS * 3600 )) || return 0
+  (( $(now) - last_warning > WARNING_REPEAT_DAYS * 86400 )) || return 0
+
+  backup_status_update '.last_warning = $now'
+  omarchy-notification-send \
+    --exec "omarchy-shell omarchy.backup toggle" \
+    -u normal -g "󰁯" \
+    "Backups are behind" \
+    "No complete backup in over ${WARNING_AFTER_HOURS} hours."
+}
+
+if omarchy-cmd-missing restic; then
+  exit 127
+fi
+
+if ! backup_configured; then
+  backup_status_update '.phase = "unconfigured"'
+  exit 0
+fi
+
+reconcile_stale_run
+
+if backup_pause_active; then
+  pause_until=$(<"$BACKUP_PAUSE_FILE")
+  [[ $pause_until =~ ^[0-9]+$ ]] || pause_until=0
+  backup_status_update '.phase = "paused" | .pause = {until: $until, reason: "paused"}' \
+    --argjson until "$pause_until"
+  skip "backups are paused"
+fi
+
+backup_status_update '.pause = {until: 0, reason: ""}'
+
+exec 9>"$BACKUP_LOCK_FILE"
+if ! flock -n 9; then
+  skip "another backup is already running on this machine"
+fi
+
+backup_load_credentials
+
+if omarchy-battery-below "$BACKUP_BATTERY_FLOOR"; then
+  skip "running on battery below ${BACKUP_BATTERY_FLOOR}%"
+fi
+
+if ! backup_local_destination_present; then
+  skip "the backup disk is not mounted"
+fi
+
+run_id="$(now)-$$"
+run_backup "$run_id"
+exit_code=$?
+
+if (( exit_code == 11 )); then
+  skip "another machine is using the repository"
+fi
+
+record_result "$exit_code"
+refresh_repository_facts
+
+if maintenance_due; then
+  run_maintenance
+fi
+
+warn_if_stale

--- a/bin/omarchy-backup-snapshots
+++ b/bin/omarchy-backup-snapshots
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# omarchy:summary=List the backups you can restore from
+# omarchy:args=[--all-hosts] [--json]
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+if ! backup_configured; then
+  echo "Backups are not set up. Run: omarchy setup backup" >&2
+  exit 1
+fi
+
+args=(--host "$(hostname)")
+
+while (( $# > 0 )); do
+  case "$1" in
+  --all-hosts)
+    args=()
+    ;;
+  --json)
+    args+=(--json)
+    ;;
+  -h | --help)
+    echo "Usage: omarchy backup snapshots [--all-hosts] [--json]"
+    exit 0
+    ;;
+  *)
+    echo "omarchy-backup-snapshots: unknown option '$1'. Try --help." >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+backup_load_credentials
+backup_restic snapshots "${args[@]}"

--- a/bin/omarchy-backup-status
+++ b/bin/omarchy-backup-status
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# omarchy:summary=Show what the backups are doing right now
+# omarchy:args=[--json]
+
+set -uo pipefail
+
+source omarchy-backup-env
+
+if [[ ${1:-} == "--json" ]]; then
+  backup_status_document
+  exit 0
+fi
+
+if [[ -n ${1:-} ]]; then
+  echo "Usage: omarchy backup status [--json]" >&2
+  exit 2
+fi
+
+status=$(backup_status_document)
+
+field() {
+  jq -r "$1" <<<"$status"
+}
+
+ago() {
+  local timestamp="$1"
+  local seconds=0
+
+  [[ $timestamp =~ ^[0-9]+$ ]] && (( timestamp > 0 )) || { echo "never"; return; }
+
+  seconds=$(( $(date +%s) - timestamp ))
+  if (( seconds < 60 )); then
+    echo "just now"
+  elif (( seconds < 3600 )); then
+    echo "$(( seconds / 60 )) minutes ago"
+  elif (( seconds < 172800 )); then
+    echo "$(( seconds / 3600 )) hours ago"
+  else
+    echo "$(( seconds / 86400 )) days ago"
+  fi
+}
+
+size() {
+  numfmt --to=iec --suffix=B --format='%.1f' "${1:-0}" 2>/dev/null || echo "${1:-0} B"
+}
+
+phase=$(field '.phase')
+destination=$(field '.destination.label')
+
+case "$phase" in
+unconfigured)
+  echo "Backups are not set up. Run: omarchy setup backup"
+  exit 0
+  ;;
+running)
+  echo "Backing up to ${destination:-the repository} — $(field '.progress.percent')% of $(size "$(field '.progress.bytes_total')")"
+  ;;
+paused)
+  pause_until=$(field '.pause.until')
+  if [[ $pause_until =~ ^[0-9]+$ ]] && (( pause_until > 0 )); then
+    echo "Paused until $(date -d "@$pause_until" '+%H:%M on %-d %B')"
+  else
+    echo "Paused until resumed"
+  fi
+  ;;
+*)
+  echo "Last backup $(ago "$(field '.last_backup.time')") to ${destination:-the repository}"
+  ;;
+esac
+
+result=$(field '.last_backup.result')
+if [[ $result == "failed" ]]; then
+  echo "Last run failed: $(field '.last_backup.error')"
+elif [[ $result == "partial" ]]; then
+  echo "Last run could not read: $(field '.last_backup.unreadable | join(", ")')"
+fi
+
+skip_reason=$(field '.last_skip.reason')
+if [[ -n $skip_reason ]] && (( $(field '.last_skip.time') > $(field '.last_backup.time') )); then
+  echo "Last run skipped: $skip_reason"
+fi
+
+echo "Repository: $(size "$(field '.repository.size_bytes')") in $(field '.repository.snapshot_count') snapshots"
+
+if [[ $(field '.destination.offsite') == "false" ]]; then
+  echo "This destination is local, so it dies with the machine it is plugged into."
+fi
+
+maintenance_result=$(field '.last_maintenance.result')
+if [[ $maintenance_result == "failed" ]]; then
+  echo "Last maintenance failed: $(field '.last_maintenance.error')"
+fi

--- a/bin/omarchy-battery-below
+++ b/bin/omarchy-battery-below
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when running on battery below the given percentage
+# omarchy:args=<percent>
+# omarchy:examples=omarchy battery below 20
+
+# A quiet predicate for scheduled work that should wait for power, unlike
+# omarchy-battery-low, which exists to notify.
+
+threshold="${1:-}"
+power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+
+if [[ ! $threshold =~ ^[0-9]+$ ]]; then
+  echo "Usage: omarchy-battery-below <percent>" >&2
+  exit 2
+fi
+
+for supply in "$power_supply_path"/*; do
+  [[ -r $supply/type && $(<"$supply/type") == "Battery" ]] || continue
+  [[ -r $supply/status && $(<"$supply/status") == "Discharging" ]] || continue
+  [[ -r $supply/capacity ]] || continue
+
+  (( $(<"$supply/capacity") < threshold )) && exit 0
+done
+
+exit 1

--- a/bin/omarchy-setup-backup
+++ b/bin/omarchy-setup-backup
@@ -1,0 +1,444 @@
+#!/bin/bash
+
+# omarchy:summary=Set up encrypted, versioned, off-site backups of your home folder
+# omarchy:args=[--repository <url>] [--access-key-id <id>] [--secret-access-key <key>] [--passphrase-file <path>] [--no-first-backup] [--remove]
+# omarchy:examples=omarchy setup backup | omarchy setup backup --remove
+
+set -eo pipefail
+
+source omarchy-backup-env
+
+REPOSITORY=""
+ACCESS_KEY_ID=""
+SECRET_ACCESS_KEY=""
+REGION=""
+PASSPHRASE_FILE=""
+FIRST_BACKUP="true"
+REMOVE="false"
+RECOVERY_CARD="$HOME/Omarchy Backup Recovery.txt"
+
+while (( $# > 0 )); do
+  case "$1" in
+  --repository) shift; REPOSITORY="${1:-}" ;;
+  --repository=*) REPOSITORY="${1#--repository=}" ;;
+  --access-key-id) shift; ACCESS_KEY_ID="${1:-}" ;;
+  --access-key-id=*) ACCESS_KEY_ID="${1#--access-key-id=}" ;;
+  --secret-access-key) shift; SECRET_ACCESS_KEY="${1:-}" ;;
+  --secret-access-key=*) SECRET_ACCESS_KEY="${1#--secret-access-key=}" ;;
+  --region) shift; REGION="${1:-}" ;;
+  --region=*) REGION="${1#--region=}" ;;
+  --passphrase-file) shift; PASSPHRASE_FILE="${1:-}" ;;
+  --passphrase-file=*) PASSPHRASE_FILE="${1#--passphrase-file=}" ;;
+  --no-first-backup) FIRST_BACKUP="false" ;;
+  --remove) REMOVE="true" ;;
+  -h | --help)
+    echo "Usage: omarchy setup backup [--repository <url>] [--access-key-id <id>]"
+    echo "                            [--secret-access-key <key>] [--region <region>]"
+    echo "                            [--passphrase-file <path>] [--no-first-backup]"
+    echo "                            [--remove]"
+    echo
+    echo "Sets up hourly, encrypted, versioned backups of your home folder to an"
+    echo "S3-compatible bucket, a local disk, or any restic repository URL."
+    echo
+    echo "Passing --repository and its credentials skips the prompts, so the setup"
+    echo "can run unattended from a script or an unattended install."
+    exit 0
+    ;;
+  *)
+    echo "omarchy-setup-backup: unknown option '$1'. Try --help." >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+record_phase() {
+  mkdir -p "$BACKUP_STATE_DIR"
+  printf '%s\n' "$1" >"$BACKUP_SETUP_PHASE_FILE"
+}
+
+abort() {
+  echo -e "\e[31m$1\e[0m" >&2
+  exit 1
+}
+
+teardown() {
+  echo -e "\e[32mRemoving the backup setup.\e[0m\n"
+
+  echo "Stopping any running backup..."
+  systemctl --user stop omarchy-backup.timer omarchy-backup.service 2>/dev/null || true
+  systemctl --user disable omarchy-backup.timer 2>/dev/null || true
+
+  fusermount -u "$BACKUP_MOUNT_DIR" 2>/dev/null || true
+
+  echo "Removing the bar widget..."
+  omarchy-plugin-disable omarchy.backup 2>/dev/null || true
+
+  echo "Deleting local credentials and state..."
+  rm -f "$BACKUP_UNIT_DIR/omarchy-backup.service" "$BACKUP_UNIT_DIR/omarchy-backup.timer"
+  systemctl --user daemon-reload
+  rm -rf "$BACKUP_SECRETS_DIR" "$BACKUP_STATE_DIR"
+  rm -f "$BACKUP_SETTINGS_FILE"
+
+  echo -e "\n\e[32mDone.\e[0m"
+  echo "Your repository and every snapshot in it are untouched — this only forgot"
+  echo "how to reach them. Keep the passphrase and recovery card: they are still"
+  echo "the only way to read those backups. restic stays installed."
+}
+
+install_dependencies() {
+  echo -e "\e[32mInstalling restic\e[0m"
+  omarchy-pkg-add restic fuse2
+}
+
+prompt_destination() {
+  local choice=""
+  local endpoint=""
+  local bucket=""
+  local path=""
+
+  choice=$(gum choose \
+    "S3-compatible bucket" \
+    "Local disk or NAS folder" \
+    "Any restic repository URL" \
+    --header "Where should your backups live?")
+
+  case "$choice" in
+  "S3-compatible bucket")
+    endpoint=$(gum input --prompt "Endpoint> " --placeholder "https://s3.us-west-002.backblazeb2.com")
+    bucket=$(gum input --prompt "Bucket (and optional /prefix)> " --placeholder "my-backups/laptop")
+    REGION=$(gum input --prompt "Region (optional)> " --placeholder "us-west-002")
+    ACCESS_KEY_ID=$(gum input --prompt "Access key ID> ")
+    SECRET_ACCESS_KEY=$(gum input --password --prompt "Secret access key> ")
+
+    [[ -n $endpoint && -n $bucket ]] || abort "An endpoint and a bucket are both needed."
+    REPOSITORY="s3:${endpoint%/}/${bucket#/}"
+    BACKUP_DESTINATION_KIND="s3"
+    BACKUP_DESTINATION_LABEL="${bucket%%/*} at ${endpoint#https://}"
+    ;;
+  "Local disk or NAS folder")
+    path=$(gum input --prompt "Folder> " --placeholder "/run/media/$USER/backup-disk/omarchy")
+    [[ -n $path ]] || abort "A folder is needed."
+    mkdir -p "$path"
+    REPOSITORY="$path"
+    BACKUP_DESTINATION_KIND="local"
+    BACKUP_DESTINATION_LABEL="$path"
+    # Recorded so a run can tell the disk being missing from the disk being
+    # empty, and skip rather than write a backup onto the root filesystem.
+    BACKUP_DESTINATION_UUID=$(findmnt -no UUID --target "$path" 2>/dev/null || true)
+    echo -e "\e[33mA local destination dies with the machine it is plugged into.\e[0m"
+    ;;
+  "Any restic repository URL")
+    REPOSITORY=$(gum input --prompt "Repository> " --placeholder "sftp:user@host:/srv/backups")
+    [[ -n $REPOSITORY ]] || abort "A repository URL is needed."
+    BACKUP_DESTINATION_KIND="other"
+    BACKUP_DESTINATION_LABEL="$REPOSITORY"
+    ;;
+  *)
+    exit 1
+    ;;
+  esac
+}
+
+label_for_repository() {
+  case "$REPOSITORY" in
+  s3:*)
+    BACKUP_DESTINATION_KIND="s3"
+    BACKUP_DESTINATION_LABEL="${REPOSITORY##*/} at ${REPOSITORY#s3:https://}"
+    ;;
+  /*)
+    BACKUP_DESTINATION_KIND="local"
+    BACKUP_DESTINATION_LABEL="$REPOSITORY"
+    BACKUP_DESTINATION_UUID=$(findmnt -no UUID --target "$REPOSITORY" 2>/dev/null || true)
+    ;;
+  *)
+    BACKUP_DESTINATION_KIND="other"
+    BACKUP_DESTINATION_LABEL="$REPOSITORY"
+    ;;
+  esac
+}
+
+generate_passphrase() {
+  local group=""
+  local groups=()
+
+  for _ in 1 2 3 4 5 6; do
+    group=$(LC_ALL=C tr -dc 'a-z2-9' </dev/urandom | head -c 5)
+    groups+=("$group")
+  done
+
+  printf '%s' "$(IFS=-; printf '%s' "${groups[*]}")"
+}
+
+prompt_passphrase() {
+  local choice=""
+
+  if [[ -n $PASSPHRASE_FILE ]]; then
+    [[ -s $PASSPHRASE_FILE ]] || abort "No passphrase in $PASSPHRASE_FILE."
+    PASSPHRASE=$(<"$PASSPHRASE_FILE")
+    return
+  fi
+
+  choice=$(gum choose \
+    "Generate a strong passphrase" \
+    "Enter an existing passphrase" \
+    --header "This passphrase encrypts every backup. Nobody can recover it for you.")
+
+  case "$choice" in
+  "Generate a strong passphrase")
+    PASSPHRASE=$(generate_passphrase)
+    ;;
+  "Enter an existing passphrase")
+    PASSPHRASE=$(gum input --password --prompt "Passphrase> ")
+    [[ -n $PASSPHRASE ]] || abort "An empty passphrase is not a passphrase."
+    ;;
+  *)
+    exit 1
+    ;;
+  esac
+}
+
+write_secrets() {
+  mkdir -p "$BACKUP_SECRETS_DIR"
+  chmod 700 "$BACKUP_SECRETS_DIR"
+
+  # Mode-restricted files rather than the keyring: Omarchy's keyring is
+  # passwordless anyway, and a locked one at 3am would mean no backup.
+  umask 077
+  {
+    printf 'RESTIC_REPOSITORY=%s\n' "$REPOSITORY"
+    if [[ -n $ACCESS_KEY_ID ]]; then
+      printf 'AWS_ACCESS_KEY_ID=%s\n' "$ACCESS_KEY_ID"
+    fi
+    if [[ -n $SECRET_ACCESS_KEY ]]; then
+      printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$SECRET_ACCESS_KEY"
+    fi
+    if [[ -n $REGION ]]; then
+      printf 'AWS_DEFAULT_REGION=%s\n' "$REGION"
+    fi
+  } >"$BACKUP_ENV_FILE"
+  printf '%s\n' "$PASSPHRASE" >"$BACKUP_PASSPHRASE_FILE"
+  chmod 600 "$BACKUP_ENV_FILE" "$BACKUP_PASSPHRASE_FILE"
+}
+
+# An apparently empty bucket is not proof that a repository is safe to create
+# there, so the probe distinguishes absent (10) from wrong passphrase (12) from
+# "we could not even reach the storage", and only the first one initializes.
+probe_repository() {
+  local status=0
+
+  backup_load_credentials
+  set +e
+  restic cat config >/dev/null 2>"$BACKUP_STATE_DIR/probe.log"
+  status=$?
+  set -e
+
+  case "$status" in
+  0)
+    EXISTING_REPOSITORY="true"
+    echo "Found an existing repository, and the passphrase opens it."
+    ;;
+  10)
+    echo "Creating a new repository..."
+    restic init
+    ;;
+  12)
+    abort "That passphrase does not open the repository. Nothing was changed."
+    ;;
+  *)
+    echo "$(tail -n 3 "$BACKUP_STATE_DIR/probe.log")" >&2
+    abort "Could not reach the repository. Check the endpoint and credentials; nothing was created."
+    ;;
+  esac
+}
+
+# The payoff of the whole feature: a fresh machine pointed at the old bucket
+# gets its home folder back before anything else happens.
+offer_disaster_recovery() {
+  local hosts=()
+  local source_host=""
+  local source_home=""
+
+  [[ ${EXISTING_REPOSITORY:-false} == "true" ]] || return 0
+
+  mapfile -t hosts < <(restic snapshots --json 2>/dev/null |
+    jq -r --arg host "$(hostname)" '[.[] | select(.hostname != $host) | .hostname] | unique | .[]')
+  (( ${#hosts[@]} > 0 )) || return 0
+
+  echo
+  echo "This repository already holds backups from: ${hosts[*]}"
+  if ! gum confirm "Restore a home folder from one of them into $HOME first?"; then
+    return 0
+  fi
+
+  source_host=$(gum choose "${hosts[@]}" --header "Restore from which machine?")
+  [[ -n $source_host ]] || return 0
+
+  # The other machine's home folder is not necessarily at this machine's path,
+  # so the snapshot's own home directory is restored *as* this one rather than
+  # landing in ~/home/someone-else.
+  source_home=$(restic snapshots --json --host "$source_host" |
+    jq -r 'sort_by(.time) | last | .paths[0]')
+
+  echo -e "\e[33mRestoring $source_host:$source_home into $HOME.\e[0m"
+  echo "Files that already exist here under the same name are overwritten."
+  if ! gum confirm "Continue?"; then
+    return 0
+  fi
+
+  restic restore "latest:$source_home" --host "$source_host" --target "$HOME"
+  echo -e "\e[32mRestored. Look around $HOME before carrying on.\e[0m"
+}
+
+write_recovery_card() {
+  cat >"$RECOVERY_CARD" <<CARD
+Omarchy backup recovery card
+============================
+
+Destination : $BACKUP_DESTINATION_LABEL
+Repository  : $REPOSITORY
+Created     : $(date '+%Y-%m-%d')
+Machine     : $(hostname)
+
+Passphrase  : ______________________________________________
+              (write it here by hand, then keep this off the machine)
+
+To recover on any machine, with restic installed:
+
+  export RESTIC_REPOSITORY='$REPOSITORY'
+  export AWS_ACCESS_KEY_ID=...        # if the destination is a bucket
+  export AWS_SECRET_ACCESS_KEY=...
+  restic snapshots
+  restic restore latest --target ~/Restored
+
+On a fresh Omarchy install, run "omarchy setup backup", point it at this
+repository, and it offers to restore your home folder.
+
+Without the passphrase these backups cannot be read. Not by you, not by
+Omarchy, not by whoever stores the bytes.
+CARD
+
+  chmod 600 "$RECOVERY_CARD"
+
+  echo
+  gum style --border normal --padding "1 2" "$(cat "$RECOVERY_CARD")"
+  echo
+  echo -e "\e[33mSaved to: $RECOVERY_CARD\e[0m"
+
+  if [[ -z $PASSPHRASE_FILE ]]; then
+    echo -e "\e[33mYour passphrase is: $PASSPHRASE\e[0m"
+    echo "Write it onto the card and store the card somewhere that is not this machine."
+    local confirmation=""
+    confirmation=$(gum input --prompt "Type SAVED once the passphrase is somewhere safe> ")
+    [[ $confirmation == "SAVED" ]] || abort "Nothing enabled. Run the setup again when the passphrase is safe."
+  fi
+}
+
+install_units() {
+  mkdir -p "$BACKUP_UNIT_DIR"
+  ln -sf "$BACKUP_SHIPPED_UNIT_DIR/omarchy-backup.service" "$BACKUP_UNIT_DIR/omarchy-backup.service"
+  ln -sf "$BACKUP_SHIPPED_UNIT_DIR/omarchy-backup.timer" "$BACKUP_UNIT_DIR/omarchy-backup.timer"
+  systemctl --user daemon-reload
+}
+
+run_first_backup() {
+  local pid=""
+  local percent=0
+  local result=""
+
+  echo -e "\n\e[32mBacking up for the first time. Later runs only send what changed.\e[0m"
+  echo -n "Measuring your home folder... "
+  # Source size, not an upload estimate: deduplication and compression usually
+  # shrink it a lot, and saying otherwise would make the first run look broken.
+  echo "$(du -sh --exclude=.cache "$HOME" 2>/dev/null | cut -f1) of files to consider."
+  echo
+
+  systemctl --user start omarchy-backup.service &
+  pid=$!
+
+  while kill -0 "$pid" 2>/dev/null; do
+    percent=$(jq -r '.progress.percent // 0' "$BACKUP_STATUS_FILE" 2>/dev/null || echo 0)
+    printf '\rBacking up... %s%%' "$percent"
+    sleep 2
+  done
+  wait "$pid" || true
+  printf '\r                    \r'
+
+  result=$(jq -r '.last_backup.result // ""' "$BACKUP_STATUS_FILE" 2>/dev/null || echo "")
+  case "$result" in
+  complete)
+    echo -e "\e[32mFirst backup done.\e[0m"
+    ;;
+  partial)
+    echo -e "\e[33mFirst backup done, but some files could not be read:\e[0m"
+    jq -r '.last_backup.unreadable[]?' "$BACKUP_STATUS_FILE"
+    ;;
+  *)
+    abort "The first backup failed: $(jq -r '.last_backup.error // "unknown error"' "$BACKUP_STATUS_FILE")"
+    ;;
+  esac
+}
+
+enable_schedule() {
+  systemctl --user enable --now omarchy-backup.timer
+  omarchy-plugin-enable omarchy.backup >/dev/null 2>&1 || true
+}
+
+if [[ $REMOVE == "true" ]]; then
+  teardown
+  exit 0
+fi
+
+echo -e "\e[32mSetting up encrypted, versioned, off-site backups of your home folder.\n\e[0m"
+
+install_dependencies
+
+if [[ -n $REPOSITORY ]]; then
+  label_for_repository
+elif backup_configured && gum confirm "Reuse the destination this machine is already set up for?"; then
+  backup_load_credentials
+  REPOSITORY="$RESTIC_REPOSITORY"
+  PASSPHRASE=$(<"$BACKUP_PASSPHRASE_FILE")
+  PASSPHRASE_FILE="$BACKUP_PASSPHRASE_FILE"
+else
+  prompt_destination
+fi
+record_phase "destination"
+
+if [[ -z ${PASSPHRASE:-} ]]; then
+  prompt_passphrase
+fi
+record_phase "passphrase"
+
+write_secrets
+probe_repository
+record_phase "repository"
+
+offer_disaster_recovery
+
+if [[ -z $BACKUP_MAINTENANCE_HOST ]]; then
+  # Whoever sets the repository up first owns pruning and checking it, so the
+  # expensive half of the work does not run on every machine sharing it.
+  BACKUP_MAINTENANCE_HOST="$(hostname)"
+fi
+backup_write_settings
+backup_write_exclude_file
+
+write_recovery_card
+record_phase "card"
+
+install_units
+
+if [[ $FIRST_BACKUP == "true" ]]; then
+  run_first_backup
+fi
+record_phase "first-backup"
+
+enable_schedule
+record_phase "done"
+
+echo
+echo -e "\e[32mBackups are on. Every hour, only what changed, encrypted before it leaves.\e[0m"
+echo "Status:  omarchy backup status"
+echo "Restore: omarchy backup restore ~/some/file"
+echo "Browse:  omarchy backup browse"

--- a/default/backup/excludes
+++ b/default/backup/excludes
@@ -1,0 +1,44 @@
+# Default backup excludes. Patterns are relative to $HOME and expanded to
+# absolute paths before restic sees them. Regenerable bytes only — when in
+# doubt, include: a backup that skipped something you needed is worse than a
+# backup that carried something you did not.
+#
+# Extend this list in ~/.config/omarchy/backup/excludes rather than editing
+# here, so an Omarchy update does not overwrite your patterns.
+
+.cache
+.local/share/Trash
+.local/state/omarchy/backup
+
+# Browser caches and profile scratch
+.config/*/Cache
+.config/*/Code Cache
+.config/*/GPUCache
+.config/*/Service Worker/CacheStorage
+.mozilla/firefox/*/cache2
+.mozilla/firefox/*/startupCache
+
+# Package and toolchain caches
+.npm/_cacache
+.bun/install/cache
+.cargo/registry/cache
+.gradle/caches
+.local/share/mise/downloads
+.local/share/pnpm/store
+.local/share/uv/cache
+.m2/repository
+.rustup/toolchains
+.yarn/cache
+go/pkg/mod/cache
+
+# Build output that the source rebuilds
+**/node_modules
+**/.next/cache
+**/target/debug
+**/vendor/bundle
+
+# Thumbnails and desktop scratch
+.local/share/thumbnails
+.thumbnails
+.steam
+.local/share/Steam

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -172,6 +172,7 @@
   "setup.plugin.add": {"icon":"󰖟","label":"Add Plugin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-plugin-add'"},
   "setup.plugin.clone": {"icon":"󰆏","label":"Clone Plugin","action":"omarchy-menu-plugin clone"},
   "setup.plugin.remove": {"icon":"󰭌","label":"Remove Plugin","when":"compgen -G \"$HOME/.config/omarchy/plugins/*/manifest.json\"","action":"omarchy-menu-plugin remove"},
+  "setup.backup": {"icon":"󰁯","label":"Backup","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-backup"},
   "setup.security": {"icon":"","label":"Security"},
   "setup.config": {"icon":"","label":"Config"},
   "setup.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-hw-fingerprint","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"},

--- a/default/systemd/user/omarchy-backup.service
+++ b/default/systemd/user/omarchy-backup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Back up the home folder off-site with restic
+# Unconfigured means inert. Pause is deliberately not a condition here: a unit
+# that never runs while paused could never notice the pause expiring, so the
+# runner starts and decides for itself.
+ConditionPathExists=%h/.local/share/omarchy/backup/env
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/omarchy-backup-run
+Nice=10
+IOSchedulingClass=idle

--- a/default/systemd/user/omarchy-backup.timer
+++ b/default/systemd/user/omarchy-backup.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Back up the home folder every hour
+
+[Timer]
+OnCalendar=hourly
+# Spread the load so every Omarchy machine does not hit its bucket on the hour.
+RandomizedDelaySec=15m
+# Catch up after sleep or shutdown; only calendar timers can.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,80 @@
+# Backups
+
+Reference for the backup feature: what writes what, where state lives, and which decisions belong to which component. The user-facing guide is [`manual/52-backups.md`](../manual/52-backups.md); the design and the reasoning behind the engine choice are in [`plans/backup.md`](../plans/backup.md).
+
+## Shape
+
+restic is the engine. Omarchy owns the schedule, the state file, the panel, and the wizard; restic owns chunking, encryption, deduplication, retention, and the repository format. Nothing in the panel or the CLI status path talks to restic — they read a JSON file that the runner maintains, so an open panel costs nothing and never touches the repository.
+
+```
+omarchy-backup.timer  →  omarchy-backup.service  →  omarchy-backup-run  →  restic
+                                                          │
+                                                          ↓
+                                              ~/.local/state/omarchy/backup/status.json
+                                                          │
+                                     ┌────────────────────┴────────────────────┐
+                             omarchy backup status                    omarchy.backup panel
+```
+
+## Files
+
+| Path | Contents |
+|---|---|
+| `~/.local/share/omarchy/backup/env` | `RESTIC_REPOSITORY` and the destination's credentials, mode 600 |
+| `~/.local/share/omarchy/backup/passphrase` | The repository passphrase, mode 600, passed as `RESTIC_PASSWORD_FILE` |
+| `~/.config/omarchy/backup/settings` | Non-secret settings: destination label and kind, retention, maintenance host, battery floor |
+| `~/.config/omarchy/backup/excludes` | User exclude patterns, `$HOME`-relative |
+| `$OMARCHY_PATH/default/backup/excludes` | Shipped exclude patterns, `$HOME`-relative |
+| `~/.local/state/omarchy/backup/status.json` | The state file every reader watches |
+| `~/.local/state/omarchy/backup/excludes` | Effective exclude file, absolute paths, regenerated each run |
+| `~/.local/state/omarchy/backup/pause` | An epoch second, or `manual` |
+| `~/.local/state/omarchy/backup/lock` | `flock` target for the per-machine run lock |
+| `~/.local/state/omarchy/backup/backup.log` | Human-readable run log, trimmed at 2000 lines |
+| `~/.local/state/omarchy/backup/maintenance` | `<epoch> <read-data subset index>` |
+
+Credentials deliberately live under `~/.local/share`, not `~/.config`: `~/.config/omarchy` is documented user-intent config that people version and that the dots workflow syncs, and a delete-capable credential must not travel that way. `omarchy-backup-env` is the one place that knows this layout; every other command sources it.
+
+## status.json
+
+Written by `omarchy-backup-run` through a temporary file and `mv`, so a reader never sees a partial document. All times are epoch seconds.
+
+| Field | Meaning |
+|---|---|
+| `phase` | `unconfigured`, `idle`, `running`, `paused`, `error` |
+| `run_id`, `pid`, `started_at`, `updated_at` | Current or last run identity |
+| `progress` | `percent`, `bytes_done`, `bytes_total`, `files_done`, throttled to one write per 3s |
+| `last_backup` | `time`, `snapshot`, `result` (`complete`/`partial`/`failed`), `error`, `unreadable[]` |
+| `last_complete` | The last snapshot known to hold everything; what restores default to |
+| `last_maintenance` | Tracked apart from backup health, so a failed prune is not a failed backup |
+| `last_skip` | `time` and `reason` — skips are recorded distinctly from failures |
+| `last_warning` | When the stale-backup notification last fired |
+| `snapshots` | Up to 10 recent snapshots for this host: `id`, `time`, `hostname` |
+| `destination` | Redacted label, kind (`s3`/`local`/`other`), and whether it counts as off-site |
+| `repository` | `size_bytes` and `snapshot_count` |
+| `pause` | `until` (0 when open-ended) and `reason` |
+
+A `running` record whose pid is gone is rewritten as `failed` at the start of the next run: a crash or a reboot mid-backup would otherwise leave the panel showing an upload forever.
+
+## The run
+
+`omarchy-backup-run` is the timer's target and the only thing that writes `status.json`. In order: exit 127 if restic is absent; mark `unconfigured` and stop if there are no credentials; reconcile a stale run; skip if paused (clearing an expired pause on the way); take the per-machine `flock`; skip if discharging below `BACKUP_BATTERY_FLOOR`; skip if a local destination's filesystem UUID does not match; write the effective exclude file; run `restic backup --json --one-file-system`; record the result; refresh snapshots and repository size; run maintenance if due; warn if backups have gone stale.
+
+Exit codes are treated as distinct outcomes rather than pass/fail: `3` is a real snapshot that is missing unreadable files and is recorded as `partial` without advancing `last_complete`, and `11` is lock contention with another machine, which is a skip rather than a failure. Every skip is logged as a skip.
+
+Pause is state, not a unit condition. A `ConditionPathExists` on the pause file would keep the unit from ever running while paused — including the run that would have noticed the pause had expired.
+
+## Maintenance and multi-machine
+
+`forget --prune` and `check` run monthly, not weekly: prune rewrites and re-uploads packs, which is bandwidth and API spend. `check` is paired with a rotating `--read-data-subset=<n>/12` so the whole repository is eventually read, since a plain `check` verifies structure and not content.
+
+Only one machine does this. The wizard records the first machine to set the repository up as `BACKUP_MAINTENANCE_HOST`, and other machines skip maintenance entirely — keeping the lock-contending, expensive half of the work in one place. Backups themselves run everywhere and pass `--retry-lock 5m`.
+
+Retention defaults to `--keep-hourly 24 --keep-daily 7 --keep-weekly 5 --keep-monthly 12`, grouped by `host,paths`, and is overridable per machine in the settings file.
+
+## Units
+
+`default/systemd/user/omarchy-backup.{service,timer}` are symlinked into `~/.config/systemd/user/` by the wizard and enabled there, rather than being enabled for everyone: backups are opt-in, and nothing about them should exist on a machine that never ran the setup. The service is `ConditionPathExists=%h/.local/share/omarchy/backup/env`, so removing the credentials makes it inert without leaving a broken unit behind. The timer is `OnCalendar=hourly` with `RandomizedDelaySec=15m` and `Persistent=true`, which catches up after sleep or shutdown.
+
+## Panel
+
+`shell/plugins/panels/backup/` is a first-party bar widget. `Service.qml` watches `status.json` with a `FileView`, plus a second `FileView` on the containing directory — the runner replaces the file by rename, and a `FileView` loses a file that is replaced rather than modified. `Model.js` is pure JavaScript that both the panel and `test/shell.d/backup-model-test.sh` load, so the display logic is tested without a compositor. Actions shell out to the same CLI a person would use, with an optimistic pause flag so the button reacts before the state file catches up.

--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -35,6 +35,7 @@ Windows folks: your Win + V clipboard history lives on `Super + Ctrl + V`, and i
 | Cmd + Shift + 4 / Win + Shift + S | `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
 | Notification Center | Notification history on `Super + Shift + Alt + ,` |
 | Time Machine (for the system) | Automatic [system snapshots](47-system-snapshots.md) on every update |
+| Time Machine (for your files) | Hourly, versioned, encrypted [backups](52-backups.md) to a bucket or a disk |
 | App Store / downloading an installer | _Install_ in the menu, or `omarchy pkg add` — see [other packages](29-other-packages.md) |
 | System Settings / Control Panel | _Setup_ in the menu, which edits plain config files — see [dotfiles](31-dotfiles.md) |
 

--- a/manual/24-commercial-apps-services.md
+++ b/manual/24-commercial-apps-services.md
@@ -20,7 +20,7 @@ You start Spotify using `Super + Shift + M`. Like 1Password, the hotkey kicks of
 
 ## Dropbox
 
-[Dropbox](https://www.dropbox.com/) is a great way to sync files between machines while keeping a backup in the cloud. To set it up, select _Install > Service > Dropbox_ from the Omarchy menu. Once it's running, hover the tray in the top right of the bar and right-click the Dropbox icon to finish the setup.
+[Dropbox](https://www.dropbox.com/) is a great way to sync files between machines. Sync is not backup, though — it copies your deletions too, and only keeps old versions for a while — so pair it with [backups](52-backups.md) rather than relying on it for one. To set it up, select _Install > Service > Dropbox_ from the Omarchy menu. Once it's running, hover the tray in the top right of the bar and right-click the Dropbox icon to finish the setup.
 
 ## Tailscale
 

--- a/manual/47-system-snapshots.md
+++ b/manual/47-system-snapshots.md
@@ -14,6 +14,8 @@ When you arrive inside, a notification will popup notifying you that you're in a
 
 This will restore your root filesystem, but not your `/home`. So it works for reverting a broken system update, but not for recovering lost personal files.
 
+For personal files, that's what [backups](52-backups.md) are for: they run hourly, keep old versions, and live somewhere other than this disk.
+
 This also means that your `~/.config` directory is kept as-is. So if you're rolling back to an earlier version of a library or application that stores configuration files in a new format, you'll have to sort that out manually.
 
 _Note: This feature is only available on installations using the Limine boot loader, which has been the default since Omarchy 2.0. It's not available if you're on GRUB or systemd-boot._

--- a/manual/52-backups.md
+++ b/manual/52-backups.md
@@ -1,0 +1,99 @@
+# Backups
+
+Snapshots roll the system back. Backups get your files back. They are different jobs: [system snapshots](47-system-snapshots.md) live on the same disk and skip your home folder entirely, so a dead disk, a stolen laptop, or a folder you deleted last month needs something else.
+
+Run _Setup > Backup_ from the Omarchy menu (or `omarchy setup backup`). Paste the credentials for a storage bucket, save the passphrase, and from then on Omarchy backs up your home folder every hour: only what changed, encrypted before it leaves the machine, and versioned so you can go back to how a file looked last Tuesday.
+
+## Setting it up
+
+The wizard asks for three things:
+
+1. **Where the backups go.** An S3-compatible bucket (Backblaze B2, Cloudflare R2, AWS, Hetzner, Wasabi, MinIO — anything that speaks the protocol), a local disk or NAS folder, or any [restic](https://restic.net) repository URL if you know what you want.
+2. **A passphrase.** It encrypts everything before upload. Generate one or bring your own.
+3. **Confirmation that you saved the passphrase.** Omarchy writes a recovery card to `~/Omarchy Backup Recovery.txt` with your destination and the restore commands, leaving a blank line for the passphrase to be written in by hand.
+
+Then it runs the first backup while you watch, and only turns on the hourly schedule once that has worked. A backup icon appears in the bar.
+
+**Lose the passphrase and the backups are gone.** Not delayed, not recoverable by support — gone. Nobody but you can read those files, which is the point, and the price. Keep the passphrase somewhere that is not this machine.
+
+## What gets backed up
+
+Your home folder, minus caches and other bytes that regenerate themselves — browser caches, `node_modules`, package manager downloads, thumbnails, the trash. The shipped list is in `$OMARCHY_PATH/default/backup/excludes` and errs towards including things: a backup that skipped what you needed is worse than one that carried something you didn't.
+
+Add your own patterns, one per line, in `~/.config/omarchy/backup/excludes`:
+
+```
+Videos/raw-footage
+**/*.iso
+.local/share/containers
+```
+
+Mounted network shares and removable disks are never followed, so a NAS mount in your home folder does not get uploaded to your bucket.
+
+System files are not backed up. Omarchy reinstalls from the ISO in a few minutes, and the things you configured are in your home folder.
+
+## Getting files back
+
+Three ways, depending on what you know:
+
+```bash
+omarchy backup restore ~/Documents/taxes.pdf            # into ~/Restored/<timestamp>/
+omarchy backup restore ~/Pictures --at 2026-01-15       # as it was on that date
+omarchy backup restore ~/Notes --in-place               # put it back where it was
+omarchy backup browse                                   # every backup as dated folders
+```
+
+Restores land in `~/Restored/<timestamp>/` by default, so a restore never overwrites something you still have. `--in-place` does overwrite, after asking, and copies the current version into `~/Restored/` first — so even an in-place restore you regret is recoverable.
+
+`omarchy backup browse` mounts every backup as a folder tree and opens the file manager on it. Browse to a date, drag out what you want, close the window. Nothing to learn.
+
+## Day to day
+
+The bar icon is the whole interface most of the time: quiet when things are fine, animated while a backup runs, dimmed when paused, and coloured when something needs you. Click it for the panel: when the last backup happened, how big the repository is, a **Back up now** button, **Pause for an hour**, and a way into browsing older versions.
+
+From the terminal:
+
+```bash
+omarchy backup status          # what happened, and when
+omarchy backup now             # do not wait for the top of the hour
+omarchy backup pause 1h        # or: today, until-resumed
+omarchy backup resume
+omarchy backup snapshots       # every backup this machine has made
+omarchy backup log             # what the scheduled runs have been doing
+```
+
+Backups skip themselves when they should: while paused, when the laptop is on battery below 20%, when another backup is still running, and — for a local destination — when the disk is not plugged in. A single failed run stays quiet, because café wifi is not news. A full day without a complete backup gets you a notification, repeated weekly until it is fixed.
+
+Old backups are thinned out monthly: 24 hourly, 7 daily, 5 weekly, and 12 monthly are kept. Change those numbers in `~/.config/omarchy/backup/settings` if you want a different shape.
+
+## More than one machine
+
+Point the second machine at the same bucket and it just works: each machine's backups are kept separately, restores default to your own machine's, and nothing is ever merged or synced between them. Give your machines distinct hostnames — that name is how backups are told apart.
+
+The machine you set up first owns the monthly cleanup, so the expensive part of the job does not run on every laptop at once.
+
+Worth knowing: every machine sharing a repository can read all of it. That is what makes the next section possible, and it means one compromised machine exposes the rest. If you want machines isolated from each other, give them separate buckets or prefixes.
+
+## Starting over on a new machine
+
+This is the part that pays for the whole feature. Install Omarchy, run _Setup > Backup_, point it at the same bucket, and give it the passphrase. It finds the backups from your old machine and offers to restore that home folder into this one before anything else happens.
+
+Your files, your configs, your keys, your projects — back where they were, on a machine that is an hour old.
+
+## What this does and does not protect you from
+
+**It protects you from**: a dead disk, a stolen or lost laptop, a folder deleted three weeks ago and missed today, a migration that ate something. Anything where you still have your storage account and your passphrase.
+
+**It does not protect you from** malware running as you, right now. The machine has to hold credentials that can write to — and, to make room, delete from — the repository. Ransomware with your privileges can reach the backups too. Object versioning or object lock on the bucket helps, and is worth setting up if your provider supports it, but it is a per-provider job with its own recovery procedure rather than a checkbox here.
+
+**Running databases, virtual machine disks, and containers** are copied while they are live, so what lands in the backup is a crash-consistent state at best. Stop them, or dump them somewhere in your home folder, if you need better than that.
+
+**Do not put the bucket on a cold-storage or archival tier.** Backups need to read small objects at any moment; archival tiers make that slow, expensive, or impossible, and restic will not tell you until you need a restore.
+
+## Turning it off
+
+```bash
+omarchy setup backup --remove
+```
+
+That stops the schedule, removes the widget, and deletes the local credentials. Your backups stay in the bucket — this only forgets how to reach them. Delete them at the provider if that is what you meant, and keep the passphrase until you have.

--- a/shell/plugins/panels/backup/Model.js
+++ b/shell/plugins/panels/backup/Model.js
@@ -97,8 +97,6 @@ function attention(status, staleAfterHours, nowMs) {
 }
 
 function heroMeta(status, staleAfterHours, nowMs) {
-  var destination = String(status.destination.label || "")
-
   switch (status.phase) {
   case "unconfigured":
     return "Not set up"
@@ -111,8 +109,9 @@ function heroMeta(status, staleAfterHours, nowMs) {
   if (status.last_backup.result === "failed") return "Last run failed"
   if (Number(status.last_backup.time || 0) <= 0) return "No backup yet"
 
-  var when = relativeTime(status.last_backup.time, nowMs)
-  return destination === "" ? "Backed up " + when : "Backed up " + when + " to " + destination
+  // The destination has its own line below. Naming it here too only made the
+  // hero long enough to elide.
+  return "Backed up " + relativeTime(status.last_backup.time, nowMs)
 }
 
 function pauseText(status, nowMs) {

--- a/shell/plugins/panels/backup/Model.js
+++ b/shell/plugins/panels/backup/Model.js
@@ -1,0 +1,178 @@
+// Pure display logic for the backup panel. omarchy-backup-run owns the truth in
+// status.json; nothing here ever asks restic anything, which is what keeps the
+// panel instant and the repository untouched by an open panel.
+
+function defaultStatus() {
+  return {
+    phase: "unconfigured",
+    progress: {percent: 0, bytes_done: 0, bytes_total: 0, files_done: 0},
+    last_backup: {time: 0, snapshot: "", result: "", error: "", unreadable: []},
+    last_complete: {time: 0, snapshot: ""},
+    last_maintenance: {time: 0, result: "", error: ""},
+    last_skip: {time: 0, reason: ""},
+    snapshots: [],
+    destination: {label: "", kind: "", offsite: true},
+    repository: {size_bytes: 0, snapshot_count: 0},
+    pause: {until: 0, reason: ""}
+  }
+}
+
+function parseStatus(raw) {
+  var text = String(raw || "").trim()
+  if (text === "") return defaultStatus()
+
+  try {
+    var parsed = JSON.parse(text)
+    if (!parsed || typeof parsed !== "object") return defaultStatus()
+    return merge(defaultStatus(), parsed)
+  } catch (e) {
+    return defaultStatus()
+  }
+}
+
+function merge(base, overlay) {
+  for (var key in overlay) {
+    var value = overlay[key]
+    if (value && typeof value === "object" && !Array.isArray(value) && base[key]) {
+      base[key] = merge(base[key], value)
+    } else if (value !== null && value !== undefined) {
+      base[key] = value
+    }
+  }
+  return base
+}
+
+function formatBytes(bytes) {
+  var value = Number(bytes || 0)
+  if (!isFinite(value) || value <= 0) return "0 B"
+
+  var units = ["B", "KB", "MB", "GB", "TB"]
+  var index = 0
+  while (value >= 1000 && index < units.length - 1) {
+    value = value / 1000
+    index++
+  }
+
+  var decimals = value >= 100 || index === 0 ? 0 : 1
+  return value.toFixed(decimals).replace(/\.0$/, "") + " " + units[index]
+}
+
+function relativeTime(timestampSec, nowMs) {
+  var timestamp = Number(timestampSec || 0)
+  if (!isFinite(timestamp) || timestamp <= 0) return "never"
+
+  var now = nowMs === undefined ? Date.now() : Number(nowMs)
+  var diff = Math.max(0, Math.floor((now - timestamp * 1000) / 1000))
+
+  if (diff < 60) return "just now"
+  var minutes = Math.floor(diff / 60)
+  if (minutes < 60) return minutes + " minute" + (minutes === 1 ? "" : "s") + " ago"
+  var hours = Math.floor(minutes / 60)
+  if (hours < 24) return hours + " hour" + (hours === 1 ? "" : "s") + " ago"
+  var days = Math.floor(hours / 24)
+  if (days < 30) return days + " day" + (days === 1 ? "" : "s") + " ago"
+  var months = Math.floor(days / 30)
+  if (months < 12) return months + " month" + (months === 1 ? "" : "s") + " ago"
+  return Math.floor(days / 365) + "y ago"
+}
+
+function stale(status, staleAfterHours, nowMs) {
+  var last = Number(status.last_complete.time || 0)
+  var now = nowMs === undefined ? Date.now() : Number(nowMs)
+  var limit = Number(staleAfterHours || 24) * 3600 * 1000
+
+  if (status.phase === "unconfigured") return false
+  if (last <= 0) return status.last_backup.time > 0
+  return (now - last * 1000) > limit
+}
+
+// The bar earns attention only for things a person has to act on: a failed run,
+// a snapshot that is missing files, or a backup that has quietly stopped
+// happening. A paused backup is a choice, not a problem.
+function attention(status, staleAfterHours, nowMs) {
+  if (status.phase === "paused" || status.phase === "unconfigured") return false
+  if (status.last_backup.result === "failed") return true
+  if (status.last_backup.result === "partial") return true
+  return stale(status, staleAfterHours, nowMs)
+}
+
+function heroMeta(status, staleAfterHours, nowMs) {
+  var destination = String(status.destination.label || "")
+
+  switch (status.phase) {
+  case "unconfigured":
+    return "Not set up"
+  case "running":
+    return "Backing up " + Number(status.progress.percent || 0) + "%"
+  case "paused":
+    return pauseText(status, nowMs)
+  }
+
+  if (status.last_backup.result === "failed") return "Last run failed"
+  if (Number(status.last_backup.time || 0) <= 0) return "No backup yet"
+
+  var when = relativeTime(status.last_backup.time, nowMs)
+  return destination === "" ? "Backed up " + when : "Backed up " + when + " to " + destination
+}
+
+function pauseText(status, nowMs) {
+  var until = Number(status.pause.until || 0)
+  if (until <= 0) return "Paused until resumed"
+
+  var now = nowMs === undefined ? Date.now() : Number(nowMs)
+  var minutes = Math.round((until * 1000 - now) / 60000)
+  if (minutes <= 0) return "Resuming"
+  if (minutes < 60) return "Paused for " + minutes + " more minutes"
+  return "Paused for " + Math.round(minutes / 60) + " more hours"
+}
+
+function repositoryText(status) {
+  var count = Number(status.repository.snapshot_count || 0)
+  if (count <= 0) return "No snapshots yet"
+  return formatBytes(status.repository.size_bytes) + " in " + count + " backup" + (count === 1 ? "" : "s")
+}
+
+function progressText(status) {
+  var done = formatBytes(status.progress.bytes_done)
+  var total = Number(status.progress.bytes_total || 0)
+  if (total <= 0) return done
+  return done + " of " + formatBytes(total)
+}
+
+function snapshotLabel(snapshot, nowMs) {
+  if (!snapshot) return ""
+  var when = relativeTime(snapshot.time, nowMs)
+  return when.charAt(0).toUpperCase() + when.slice(1)
+}
+
+function problem(status) {
+  if (status.phase === "unconfigured") return ""
+  if (status.last_backup.result === "failed") return String(status.last_backup.error || "The last backup failed")
+  if (status.last_backup.result === "partial") {
+    var paths = status.last_backup.unreadable || []
+    return paths.length > 0
+      ? "Could not read " + paths.length + " path" + (paths.length === 1 ? "" : "s") + ", starting with " + paths[0]
+      : "Some files could not be read"
+  }
+  if (Number(status.last_skip.time || 0) > Number(status.last_backup.time || 0) && status.last_skip.reason) {
+    return "Last run skipped: " + status.last_skip.reason
+  }
+  return ""
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    defaultStatus: defaultStatus,
+    parseStatus: parseStatus,
+    formatBytes: formatBytes,
+    relativeTime: relativeTime,
+    stale: stale,
+    attention: attention,
+    heroMeta: heroMeta,
+    pauseText: pauseText,
+    repositoryText: repositoryText,
+    progressText: progressText,
+    snapshotLabel: snapshotLabel,
+    problem: problem
+  }
+}

--- a/shell/plugins/panels/backup/Panel.qml
+++ b/shell/plugins/panels/backup/Panel.qml
@@ -418,9 +418,15 @@ Panel {
     width: parent.width
     spacing: Style.space(8)
 
-    InfoLabel { text: label }
-    Item { width: Math.max(0, parent.width - parent.children[0].implicitWidth - parent.children[2].implicitWidth - parent.spacing * 2); height: 1 }
-    InfoValue { text: value }
+    InfoLabel { id: pairLabel; text: label }
+
+    // Bounded rather than implicit, so a long bucket name elides at the panel
+    // edge instead of running under it.
+    InfoValue {
+      text: value
+      width: Math.max(0, parent.width - pairLabel.implicitWidth - parent.spacing)
+      horizontalAlignment: Text.AlignRight
+    }
   }
 
   component InfoLabel: Text {

--- a/shell/plugins/panels/backup/Panel.qml
+++ b/shell/plugins/panels/backup/Panel.qml
@@ -1,0 +1,439 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+import "Model.js" as Model
+
+Panel {
+  id: root
+  moduleName: "omarchy.backup"
+  ipcTarget: "omarchy.backup"
+  manageIpc: false
+
+  property string focusSection: "actions"
+  property int actionIndex: 0
+  property int snapshotIndex: 0
+  property bool cursorActive: false
+
+  readonly property color foreground: bar ? bar.foreground : Color.foreground
+  readonly property color urgent: bar ? bar.urgent : Color.urgent
+  readonly property color dim: Qt.darker(foreground, 1.55)
+  readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+  readonly property string glyph: "󰁯"
+  readonly property string problemText: backup.problem
+
+  readonly property color barIconColor: backup.attention
+    ? (bar ? bar.urgent : Color.urgent)
+    : (backup.paused || !backup.configured ? Qt.darker(barForeground, 1.55) : barForeground)
+
+  readonly property var actions: {
+    if (!backup.configured) return [{id: "setup", glyph: "󰒓", label: "Set up backups", detail: "Encrypted, hourly, off-site"}]
+
+    var rows = [{
+      id: "now",
+      glyph: "󰑓",
+      label: backup.running ? "Backing up now" : "Back up now",
+      detail: backup.running ? Model.progressText(backup.status) : "Send what has changed since the last run"
+    }]
+
+    if (backup.paused) {
+      rows.push({id: "resume", glyph: "󰐊", label: "Resume backups", detail: Model.pauseText(backup.status, backup.nowMs)})
+    } else {
+      rows.push({id: "pause", glyph: "󰏤", label: "Pause for an hour", detail: "Scheduled runs wait until then"})
+    }
+
+    rows.push({id: "browse", glyph: "󰉋", label: "Browse older versions", detail: "Every backup as a dated folder"})
+    return rows
+  }
+
+  function ensureCursor() {
+    if (focusSection === "snapshots" && backup.snapshots.length === 0) focusSection = "actions"
+    actionIndex = Math.max(0, Math.min(actions.length - 1, actionIndex))
+    snapshotIndex = Math.max(0, Math.min(Math.max(0, backup.snapshots.length - 1), snapshotIndex))
+  }
+
+  function moveCursor(dx, dy) {
+    cursorActive = true
+    ensureCursor()
+    if (dy === 0) return
+
+    if (focusSection === "actions") {
+      if (dy > 0 && actionIndex === actions.length - 1 && backup.snapshots.length > 0) {
+        focusSection = "snapshots"
+        snapshotIndex = 0
+        return
+      }
+      actionIndex = Math.max(0, Math.min(actions.length - 1, actionIndex + dy))
+      return
+    }
+
+    if (dy < 0 && snapshotIndex === 0) {
+      focusSection = "actions"
+      actionIndex = actions.length - 1
+      return
+    }
+    snapshotIndex = Math.max(0, Math.min(backup.snapshots.length - 1, snapshotIndex + dy))
+  }
+
+  function runAction(id) {
+    switch (id) {
+    case "setup": backup.setUp(); break
+    case "now": backup.backUpNow(); break
+    case "pause": backup.pause("1h"); break
+    case "resume": backup.resume(); break
+    case "browse": backup.browse(); break
+    }
+  }
+
+  function activateCursor() {
+    ensureCursor()
+    if (focusSection === "actions") runAction(actions[actionIndex].id)
+    else backup.browse()
+  }
+
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  onOpenedChanged: if (opened) {
+    cursorActive = false
+    focusSection = "actions"
+    actionIndex = 0
+    backup.nowMs = Date.now()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  Service {
+    id: backup
+    settings: root.settings
+  }
+
+  IpcHandler {
+    target: root.ipcTarget
+    function open(): void { root.open() }
+    function close(): void { root.close() }
+    function show(): void { root.open() }
+    function hide(): void { root.close() }
+    function toggle(): void { root.toggle() }
+    function run(): string { backup.backUpNow(); return "ok" }
+    function status(): string { return backup.heroMeta }
+  }
+
+  BarIconButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    text: root.glyph
+    foreground: root.barIconColor
+    dimmed: backup.paused && !backup.attention
+    tooltipText: backup.heroMeta
+    onPressed: function(buttonCode) {
+      if (buttonCode === Qt.MiddleButton) backup.backUpNow()
+      else root.toggle()
+    }
+  }
+
+  KeyboardPanel {
+    id: panel
+    anchorItem: button
+    owner: root
+    bar: root.bar
+    open: root.opened
+    focusTarget: keyCatcher
+    contentWidth: panel.fittedContentWidth(Style.space(360))
+    contentHeight: panel.fittedContentHeight(column.implicitHeight, Style.space(560))
+
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+      onMoveRequested: function(dx, dy) {
+        if (!root.cursorActive) { root.cursorActive = true; return }
+        root.moveCursor(dx, dy)
+      }
+      onActivateRequested: if (root.cursorActive) root.activateCursor()
+      onCloseRequested: root.close()
+      onTabRequested: function(direction) { root.switchPanel(direction) }
+      onTextKey: function(key) {
+        if (key === "b" || key === "B") backup.backUpNow()
+        else if (key === "p" || key === "P") backup.paused ? backup.resume() : backup.pause("1h")
+        else if (key === "o" || key === "O") backup.browse()
+      }
+
+      Flickable {
+        id: panelFlick
+        anchors.fill: parent
+        contentWidth: width
+        contentHeight: column.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        flickableDirection: Flickable.VerticalFlick
+        interactive: contentHeight > height
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        Column {
+          id: column
+          width: panelFlick.width
+          spacing: Style.space(12)
+
+          PanelHero {
+            id: hero
+            width: parent.width
+            title: "Backups"
+            meta: backup.heroMeta
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            iconOpacity: backup.paused ? 0.5 : 1.0
+            iconComponent: Component {
+              Text {
+                text: root.glyph
+                color: backup.attention ? root.urgent : root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.display
+              }
+            }
+          }
+
+          Item {
+            visible: backup.running
+            width: parent.width
+            implicitHeight: Style.space(6)
+
+            Rectangle {
+              anchors.fill: parent
+              radius: height / 2
+              color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+            }
+
+            Rectangle {
+              height: parent.height
+              width: parent.width * Math.max(0, Math.min(100, backup.percent)) / 100
+              radius: height / 2
+              color: root.foreground
+              Behavior on width { NumberAnimation { duration: 240; easing.type: Easing.OutQuad } }
+            }
+          }
+
+          Text {
+            visible: root.problemText !== ""
+            width: parent.width
+            text: root.problemText
+            color: backup.attention ? root.urgent : root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            wrapMode: Text.WordWrap
+          }
+
+          Column {
+            visible: backup.configured
+            width: parent.width
+            spacing: Style.spacing.labelGap
+
+            InfoPair { label: "Destination"; value: backup.status.destination.label || "Unknown" }
+            InfoPair { label: "Repository"; value: backup.repositoryText }
+            InfoPair {
+              visible: !backup.offsite
+              label: "Warning"
+              value: "Local disk, not off-site"
+            }
+          }
+
+          PanelSeparator { foreground: root.foreground }
+
+          Column {
+            id: actionColumn
+            width: parent.width
+            spacing: Style.space(6)
+
+            Repeater {
+              model: root.actions
+              ActionRow {
+                required property var modelData
+                required property int index
+                width: actionColumn.width
+                action: modelData
+                rowIndex: index
+              }
+            }
+          }
+
+          Column {
+            visible: backup.snapshots.length > 0
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSeparator { foreground: root.foreground }
+
+            PanelSectionHeader {
+              text: "RECENT BACKUPS"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            Column {
+              id: snapshotColumn
+              width: parent.width
+              spacing: Style.space(6)
+
+              Repeater {
+                model: backup.snapshots
+                SnapshotRow {
+                  required property var modelData
+                  required property int index
+                  width: snapshotColumn.width
+                  snapshot: modelData
+                  rowIndex: index
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  component ActionRow: CursorSurface {
+    id: actionRow
+    property var action: null
+    property int rowIndex: 0
+
+    hasCursor: root.cursorActive && root.focusSection === "actions" && root.actionIndex === rowIndex
+    foreground: root.foreground
+    implicitHeight: actionContent.implicitHeight + Style.spacing.rowPaddingX
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onEntered: {
+        root.cursorActive = true
+        root.focusSection = "actions"
+        root.actionIndex = actionRow.rowIndex
+      }
+      onClicked: root.runAction(actionRow.action.id)
+    }
+
+    RowLayout {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      spacing: Style.space(8)
+
+      Text {
+        text: actionRow.action ? actionRow.action.glyph : ""
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.icon
+        Layout.alignment: Qt.AlignVCenter
+      }
+
+      ColumnLayout {
+        id: actionContent
+        Layout.fillWidth: true
+        spacing: Style.space(1)
+
+        Text {
+          Layout.fillWidth: true
+          text: actionRow.action ? actionRow.action.label : ""
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+        }
+
+        Text {
+          Layout.fillWidth: true
+          text: actionRow.action ? actionRow.action.detail : ""
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+      }
+    }
+  }
+
+  component SnapshotRow: CursorSurface {
+    id: snapshotRow
+    property var snapshot: null
+    property int rowIndex: 0
+
+    hasCursor: root.cursorActive && root.focusSection === "snapshots" && root.snapshotIndex === rowIndex
+    foreground: root.foreground
+    implicitHeight: snapshotContent.implicitHeight + Style.spacing.rowPaddingX
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onEntered: {
+        root.cursorActive = true
+        root.focusSection = "snapshots"
+        root.snapshotIndex = snapshotRow.rowIndex
+      }
+      onClicked: backup.browse()
+    }
+
+    RowLayout {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      spacing: Style.space(8)
+
+      ColumnLayout {
+        id: snapshotContent
+        Layout.fillWidth: true
+        spacing: Style.space(1)
+
+        Text {
+          Layout.fillWidth: true
+          text: Model.snapshotLabel(snapshotRow.snapshot, backup.nowMs)
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+        }
+
+        Text {
+          Layout.fillWidth: true
+          text: snapshotRow.snapshot ? String(snapshotRow.snapshot.id || "") : ""
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+      }
+    }
+  }
+
+  component InfoPair: Row {
+    property string label: ""
+    property string value: ""
+
+    width: parent.width
+    spacing: Style.space(8)
+
+    InfoLabel { text: label }
+    Item { width: Math.max(0, parent.width - parent.children[0].implicitWidth - parent.children[2].implicitWidth - parent.spacing * 2); height: 1 }
+    InfoValue { text: value }
+  }
+
+  component InfoLabel: Text {
+    color: root.foreground
+    opacity: 0.6
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.bodySmall
+  }
+
+  component InfoValue: Text {
+    color: root.foreground
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.bodySmall
+    elide: Text.ElideRight
+  }
+}

--- a/shell/plugins/panels/backup/Service.qml
+++ b/shell/plugins/panels/backup/Service.qml
@@ -1,0 +1,111 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import "Model.js" as Model
+
+// Display state for the backup panel, read from the file omarchy-backup-run
+// maintains. Nothing here shells out to restic: a panel that queried the
+// repository would be slow to open, and would touch the repository every time
+// someone glanced at the bar.
+Item {
+  id: root
+
+  property var settings: ({})
+  readonly property string home: Quickshell.env("HOME")
+  readonly property string stateDir: (Quickshell.env("XDG_STATE_HOME") || home + "/.local/state") + "/omarchy/backup"
+  readonly property string statusPath: stateDir + "/status.json"
+
+  property var status: Model.defaultStatus()
+  property double nowMs: Date.now()
+
+  // Optimistic pause state, so the button reacts on the click rather than after
+  // the CLI has written the file back. -1 follows reality; 0/1 override it.
+  property int _desiredPause: -1
+
+  readonly property string phase: String(status.phase || "unconfigured")
+  readonly property bool configured: phase !== "unconfigured"
+  readonly property bool running: phase === "running"
+  readonly property bool paused: _desiredPause === -1 ? phase === "paused" : _desiredPause === 1
+  readonly property int staleAfterHours: intSetting("staleAfterHours", 24, 2, 168)
+  readonly property bool attention: Model.attention(status, staleAfterHours, nowMs)
+  readonly property string heroMeta: Model.heroMeta(status, staleAfterHours, nowMs)
+  readonly property string repositoryText: Model.repositoryText(status)
+  readonly property string progressText: Model.progressText(status)
+  readonly property string problem: Model.problem(status)
+  readonly property int percent: Number(status.progress.percent || 0)
+  readonly property var snapshots: status.snapshots || []
+  readonly property bool offsite: status.destination.offsite !== false
+
+  function setting(name, fallback) {
+    var value = settings ? settings[name] : undefined
+    return value === undefined || value === null ? fallback : value
+  }
+
+  function intSetting(name, fallback, min, max) {
+    var parsed = parseInt(String(setting(name, fallback)), 10)
+    if (!isFinite(parsed)) parsed = fallback
+    return Math.max(min, Math.min(max, parsed))
+  }
+
+  function apply(text) {
+    status = Model.parseStatus(text)
+    if (_desiredPause !== -1 && (phase === "paused") === (_desiredPause === 1)) _desiredPause = -1
+  }
+
+  function backUpNow() {
+    if (!configured || running) return
+    Quickshell.execDetached(["omarchy-backup-now"])
+  }
+
+  function pause(duration) {
+    if (!configured) return
+    _desiredPause = 1
+    Quickshell.execDetached(["omarchy-backup-pause", duration])
+  }
+
+  function resume() {
+    if (!configured) return
+    _desiredPause = 0
+    Quickshell.execDetached(["omarchy-backup-resume"])
+  }
+
+  // Restores and browsing print, confirm, and can take a while, so they belong
+  // in a terminal rather than behind a panel button that shows nothing.
+  function browse() {
+    Quickshell.execDetached(["omarchy-launch-floating-terminal-with-presentation", "omarchy-backup-browse"])
+  }
+
+  function setUp() {
+    Quickshell.execDetached(["omarchy-launch-floating-terminal-with-presentation", "omarchy-setup-backup"])
+  }
+
+  FileView {
+    id: statusFile
+    path: root.statusPath
+    watchChanges: true
+    printErrors: false
+    onFileChanged: reload()
+    onLoaded: root.apply(text())
+    onLoadFailed: root.status = Model.defaultStatus()
+  }
+
+  // The runner replaces status.json by rename rather than writing into it, and
+  // FileView loses a file that is replaced. Watching the directory it lives in
+  // is what makes the panel notice the new one.
+  FileView {
+    path: root.stateDir
+    watchChanges: true
+    printErrors: false
+    onFileChanged: statusFile.reload()
+  }
+
+  // Relative times ("12 minutes ago") and the pause countdown go stale on their
+  // own, with no file change to trigger a repaint.
+  Timer {
+    interval: 30000
+    repeat: true
+    running: true
+    onTriggered: root.nowMs = Date.now()
+  }
+}

--- a/shell/plugins/panels/backup/manifest.json
+++ b/shell/plugins/panels/backup/manifest.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.backup",
+  "name": "Backup",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "license": "MIT",
+  "description": "Backup status, progress, pausing, and restores in the Omarchy bar.",
+  "kinds": [
+    "bar-widget"
+  ],
+  "entryPoints": {
+    "barWidget": "Panel.qml"
+  },
+  "barWidget": {
+    "displayName": "Backup",
+    "description": "See when your files were last backed up, back up now, pause, and browse older versions.",
+    "category": "Files",
+    "allowMultiple": false,
+    "defaultSection": "right",
+    "defaults": {
+      "staleAfterHours": 24
+    },
+    "schema": [
+      {
+        "key": "staleAfterHours",
+        "type": "integer",
+        "label": "Warn after hours without a backup",
+        "min": 2,
+        "max": 168,
+        "step": 1,
+        "defaultValue": 24
+      }
+    ]
+  }
+}

--- a/test/shell.d/backup-model-test.sh
+++ b/test/shell.d/backup-model-test.sh
@@ -25,8 +25,8 @@ assertEqual(Model.parseStatus('{oh no').phase, 'unconfigured', 'a corrupt status
 
 assertEqual(
   Model.heroMeta(status({}), 24, now),
-  'Backed up 1 hour ago to photos at s3.example.com',
-  'the hero says when and where'
+  'Backed up 1 hour ago',
+  'the hero says when the last backup was'
 )
 assertEqual(
   Model.heroMeta(status({phase: 'running', progress: {percent: 42}}), 24, now),

--- a/test/shell.d/backup-model-test.sh
+++ b/test/shell.d/backup-model-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const Model = requireFromRoot('shell/plugins/panels/backup/Model.js')
+
+const now = Date.parse('2026-08-22T12:00:00Z')
+const hourAgo = now / 1000 - 3600
+
+function status(overrides) {
+  return Model.parseStatus(JSON.stringify(Object.assign({
+    phase: 'idle',
+    last_backup: {time: hourAgo, snapshot: 'abcd1234', result: 'complete', error: '', unreadable: []},
+    last_complete: {time: hourAgo, snapshot: 'abcd1234'},
+    destination: {label: 'photos at s3.example.com', kind: 's3', offsite: true},
+    repository: {size_bytes: 2500000000, snapshot_count: 42}
+  }, overrides)))
+}
+
+assertEqual(Model.parseStatus('').phase, 'unconfigured', 'an absent status file reads as unconfigured')
+assertEqual(Model.parseStatus('{oh no').phase, 'unconfigured', 'a corrupt status file does not throw')
+
+assertEqual(
+  Model.heroMeta(status({}), 24, now),
+  'Backed up 1 hour ago to photos at s3.example.com',
+  'the hero says when and where'
+)
+assertEqual(
+  Model.heroMeta(status({phase: 'running', progress: {percent: 42}}), 24, now),
+  'Backing up 42%',
+  'a running backup shows its progress'
+)
+assertEqual(
+  Model.heroMeta(status({phase: 'paused', pause: {until: now / 1000 + 1800}}), 24, now),
+  'Paused for 30 more minutes',
+  'a timed pause counts down'
+)
+assertEqual(
+  Model.heroMeta(status({phase: 'paused', pause: {until: 0}}), 24, now),
+  'Paused until resumed',
+  'an open-ended pause says so'
+)
+
+assertEqual(Model.repositoryText(status({})), '2.5 GB in 42 backups', 'the repository line is sizes, not bytes')
+
+// A failed run, a partial one, and a backup that quietly stopped happening are
+// the three things worth colouring the bar for. A pause is a choice.
+assert(!Model.attention(status({}), 24, now), 'a healthy backup does not ask for attention')
+assert(
+  Model.attention(status({last_backup: {time: hourAgo, result: 'failed', error: 'no route to host'}}), 24, now),
+  'a failed run asks for attention'
+)
+assert(
+  Model.attention(status({last_backup: {time: hourAgo, result: 'partial', unreadable: ['/home/x/vault']}}), 24, now),
+  'a partial run asks for attention'
+)
+assert(
+  Model.attention(status({last_complete: {time: now / 1000 - 90000}}), 24, now),
+  'a day without a complete backup asks for attention'
+)
+assert(
+  !Model.attention(status({phase: 'paused', last_complete: {time: now / 1000 - 90000}}), 24, now),
+  'a pause is not a problem, however old the last backup is'
+)
+assert(!Model.attention(Model.parseStatus(''), 24, now), 'an unconfigured machine is not nagged')
+
+assertEqual(
+  Model.problem(status({last_backup: {time: hourAgo, result: 'partial', unreadable: ['/home/x/vault', '/home/x/db']}})),
+  'Could not read 2 paths, starting with /home/x/vault',
+  'a partial backup names what it could not read'
+)
+assertEqual(
+  Model.problem(status({last_skip: {time: now / 1000, reason: 'the backup disk is not mounted'}})),
+  'Last run skipped: the backup disk is not mounted',
+  'a skip more recent than the last backup is surfaced'
+)
+assertEqual(Model.problem(status({})), '', 'a healthy backup reports no problem')
+JS

--- a/test/shell.d/backup-restore-test.sh
+++ b/test/shell.d/backup-restore-test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+# restic's local backend makes a full round trip cheap and hermetic. Without
+# restic there is nothing to round-trip, and the rest of the suite still covers
+# the state machine with a stub.
+if ! command -v restic >/dev/null; then
+  pass "restic is not installed; skipping the backup round trip"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+fake_home="$test_tmp/home"
+mkdir -p "$fake_bin" "$fake_home/Documents" "$fake_home/.cache"
+
+secrets_dir="$fake_home/.local/share/omarchy/backup"
+state_dir="$fake_home/.local/state/omarchy/backup"
+status_file="$state_dir/status.json"
+
+stub() {
+  local name="$1"
+  cat >"$fake_bin/$name"
+  chmod +x "$fake_bin/$name"
+}
+
+stub omarchy-cmd-missing <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+
+stub omarchy-battery-below <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+
+stub omarchy-notification-send <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+omarchy() {
+  HOME="$fake_home" \
+    XDG_STATE_HOME="$fake_home/.local/state" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$fake_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-$1" "${@:2}"
+}
+
+printf 'the numbers that matter\n' >"$fake_home/Documents/taxes.txt"
+printf 'a note\n' >"$fake_home/Documents/note.txt"
+printf 'regenerable\n' >"$fake_home/.cache/junk"
+
+mkdir -p "$secrets_dir"
+printf 'RESTIC_REPOSITORY=%s\n' "$test_tmp/repo" >"$secrets_dir/env"
+printf 'test-passphrase\n' >"$secrets_dir/passphrase"
+chmod 600 "$secrets_dir"/*
+
+RESTIC_REPOSITORY="$test_tmp/repo" RESTIC_PASSWORD="test-passphrase" restic init >/dev/null
+
+omarchy backup-run >/dev/null 2>&1
+
+[[ $(jq -r '.last_backup.result' "$status_file") == "complete" ]] ||
+  fail "the first backup completes against a real repository" "$(cat "$status_file")"
+(( $(jq -r '.repository.snapshot_count' "$status_file") == 1 )) || fail "the snapshot is recorded"
+pass "a real backup lands in a real repository"
+
+RESTIC_REPOSITORY="$test_tmp/repo" RESTIC_PASSWORD="test-passphrase" \
+  restic ls latest >"$test_tmp/listing" 2>/dev/null
+grep -q 'Documents/taxes.txt' "$test_tmp/listing" || fail "personal files are in the backup"
+! grep -q '.cache/junk' "$test_tmp/listing" || fail "caches are excluded from the backup" "$(cat "$test_tmp/listing")"
+pass "the backup holds the files worth keeping and none of the regenerable ones"
+
+# The point of the whole feature: a file that is gone comes back, without
+# touching anything else that is still there.
+rm "$fake_home/Documents/taxes.txt"
+omarchy backup-restore "$fake_home/Documents/taxes.txt" >"$test_tmp/restore-output"
+
+restored=$(find "$fake_home/Restored" -name taxes.txt | head -n 1)
+[[ -n $restored ]] || fail "the restore produces a file" "$(cat "$test_tmp/restore-output")"
+[[ $(<"$restored") == "the numbers that matter" ]] || fail "the restored file has its contents back"
+[[ ! -e $fake_home/Documents/taxes.txt ]] || fail "a default restore does not write over the live folder"
+pass "a deleted file comes back into a staging folder"
+
+printf 'edited badly\n' >"$fake_home/Documents/note.txt"
+printf 'restore\n' | omarchy backup-restore "$fake_home/Documents/note.txt" --in-place >"$test_tmp/in-place-output"
+
+[[ $(<"$fake_home/Documents/note.txt") == "a note" ]] || fail "an in-place restore puts the old version back"
+grep -q 'edited badly' -r "$fake_home/Restored" ||
+  fail "an in-place restore keeps the version it replaced" "$(cat "$test_tmp/in-place-output")"
+pass "an in-place restore is itself recoverable"
+
+printf 'no\n' | omarchy backup-restore "$fake_home/Documents/note.txt" --in-place >/dev/null 2>&1 || true
+[[ $(<"$fake_home/Documents/note.txt") == "a note" ]] || fail "an unconfirmed in-place restore changes nothing"
+pass "an in-place restore that is not confirmed does nothing"
+
+set +e
+omarchy backup-restore "$fake_home/Documents/note.txt" --at "1999-01-01" >/dev/null 2>"$test_tmp/at-error"
+status=$?
+set -e
+(( status != 0 )) || fail "restoring from before the first backup fails"
+grep -q 'no backup from before' "$test_tmp/at-error" || fail "the failure says why" "$(cat "$test_tmp/at-error")"
+pass "asking for a version older than the oldest backup fails clearly"

--- a/test/shell.d/backup-run-test.sh
+++ b/test/shell.d/backup-run-test.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+fake_home="$test_tmp/home"
+mkdir -p "$fake_bin" "$fake_home"
+
+secrets_dir="$fake_home/.local/share/omarchy/backup"
+state_dir="$fake_home/.local/state/omarchy/backup"
+config_dir="$fake_home/.config/omarchy/backup"
+status_file="$state_dir/status.json"
+
+stub() {
+  local name="$1"
+  cat >"$fake_bin/$name"
+  chmod +x "$fake_bin/$name"
+}
+
+# restic, reduced to the three things the runner reads: the JSON stream, the
+# exit code, and the snapshot listing.
+stub restic <<'STUB'
+#!/bin/bash
+while [[ $1 == --retry-lock ]]; do shift 2; done
+printf 'restic %s\n' "$*" >>"$TEST_LOG"
+
+case "$1" in
+backup)
+  printf '{"message_type":"status","percent_done":0.5,"bytes_done":100,"total_bytes":200,"files_done":3}\n'
+  if [[ ${STUB_UNREADABLE:-0} == 1 ]]; then
+    printf '{"message_type":"error","item":"/home/x/vault"}\n'
+  fi
+  printf '{"message_type":"summary","snapshot_id":"abcd1234"}\n'
+  [[ ${STUB_BACKUP_EXIT:-0} == 0 ]] || echo "restic said no" >&2
+  exit "${STUB_BACKUP_EXIT:-0}"
+  ;;
+snapshots)
+  printf '[{"short_id":"abcd1234","time":"2026-08-22T10:00:00.123456+02:00","hostname":"%s","paths":["/home/x"]}]\n' "$(hostname)"
+  ;;
+stats)
+  echo '{"total_size":12345}'
+  ;;
+esac
+exit 0
+STUB
+
+stub omarchy-cmd-missing <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+
+stub omarchy-battery-below <<'STUB'
+#!/bin/bash
+exit "${STUB_BATTERY_LOW:-1}"
+STUB
+
+stub omarchy-notification-send <<'STUB'
+#!/bin/bash
+printf 'notification %s\n' "$*" >>"$TEST_LOG"
+STUB
+
+run_backup() {
+  : >"$test_tmp/calls.log"
+  TEST_LOG="$test_tmp/calls.log" \
+    HOME="$fake_home" \
+    XDG_STATE_HOME="$fake_home/.local/state" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$fake_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-backup-run" >/dev/null 2>&1
+}
+
+field() {
+  jq -r "$1" "$status_file"
+}
+
+configure() {
+  mkdir -p "$secrets_dir" "$config_dir"
+  printf 'RESTIC_REPOSITORY=%s\n' "$test_tmp/repo" >"$secrets_dir/env"
+  printf 'passphrase\n' >"$secrets_dir/passphrase"
+  cat >"$config_dir/settings" <<SETTINGS
+BACKUP_DESTINATION_LABEL="test bucket"
+BACKUP_DESTINATION_KIND="s3"
+BACKUP_MAINTENANCE_HOST="$(hostname)"
+SETTINGS
+}
+
+# An unconfigured machine must record that it is unconfigured rather than
+# looking like a machine whose backups merely have not run yet.
+run_backup
+[[ $(field '.phase') == "unconfigured" ]] || fail "an unconfigured run records unconfigured" "$(cat "$status_file")"
+! grep -q '^restic backup' "$test_tmp/calls.log" || fail "an unconfigured run does not call restic"
+pass "a run without credentials records unconfigured and touches nothing"
+
+configure
+run_backup
+
+[[ $(field '.last_backup.result') == "complete" ]] || fail "a successful run is recorded as complete" "$(cat "$status_file")"
+[[ $(field '.last_backup.snapshot') == "abcd1234" ]] || fail "the snapshot id is recorded"
+[[ $(field '.last_complete.snapshot') == "abcd1234" ]] || fail "a complete run advances the restore default"
+[[ $(field '.phase') == "idle" ]] || fail "the run finishes idle, not running"
+[[ $(field '.pid') == "0" ]] || fail "the finished run clears its pid"
+[[ $(field '.repository.size_bytes') == "12345" ]] || fail "the repository size is refreshed"
+(( $(field '.snapshots[0].time') > 0 )) || fail "snapshot times are converted to epoch seconds" "$(field '.snapshots')"
+pass "a successful run records the snapshot, the size, and an idle phase"
+
+grep -q '^restic backup --json --one-file-system' "$test_tmp/calls.log" ||
+  fail "the backup stays on one filesystem" "$(cat "$test_tmp/calls.log")"
+pass "mounted disks and network shares are never traversed"
+
+# restic takes exclude patterns literally, so a ~ that survives into the file
+# excludes a directory named "~" and nothing else.
+! grep -q '~' "$state_dir/excludes" || fail "exclude patterns are expanded, not left as tildes" "$(cat "$state_dir/excludes")"
+grep -qxF "$secrets_dir" "$state_dir/excludes" || fail "the credentials are excluded from the backup that they unlock"
+grep -qxF "$fake_home/.cache" "$state_dir/excludes" || fail "caches are excluded"
+pass "the effective exclude file is absolute and keeps the credentials out"
+
+printf 'Videos/raw\n' >"$config_dir/excludes"
+run_backup
+grep -qxF "$fake_home/Videos/raw" "$state_dir/excludes" || fail "user patterns are honored" "$(cat "$state_dir/excludes")"
+rm -f "$config_dir/excludes"
+pass "user exclude patterns are expanded the same way"
+
+printf 'manual\n' >"$state_dir/pause"
+run_backup
+[[ $(field '.phase') == "paused" ]] || fail "a paused machine records the pause"
+[[ $(field '.last_skip.reason') == *paused* ]] || fail "the pause is recorded as a skip, not a failure"
+! grep -q '^restic backup' "$test_tmp/calls.log" || fail "a paused machine does not back up"
+pass "an open-ended pause skips the run without failing it"
+
+# A pause that has expired has to clear itself: the runner is the only thing
+# that runs on a schedule, so nothing else would ever notice.
+printf '%s\n' "$(( $(date +%s) - 60 ))" >"$state_dir/pause"
+run_backup
+[[ ! -f $state_dir/pause ]] || fail "an expired pause is cleared"
+[[ $(field '.last_backup.result') == "complete" ]] || fail "an expired pause lets the backup run"
+pass "an expired pause clears itself and the backup resumes"
+
+STUB_BATTERY_LOW=0 run_backup
+[[ $(field '.last_skip.reason') == *battery* ]] || fail "a flat battery is a skip" "$(cat "$status_file")"
+pass "a discharging laptop below the floor skips instead of uploading"
+
+complete_at=$(field '.last_complete.time')
+complete_snapshot=$(field '.last_complete.snapshot')
+
+STUB_BACKUP_EXIT=3 STUB_UNREADABLE=1 run_backup
+[[ $(field '.last_backup.result') == "partial" ]] || fail "exit 3 is a partial backup, not a failure"
+[[ $(field '.last_backup.unreadable[0]') == "/home/x/vault" ]] || fail "the unreadable paths are surfaced"
+[[ $(field '.last_complete.snapshot') == "$complete_snapshot" ]] || fail "the earlier complete snapshot is still the restore default"
+[[ $(field '.last_complete.time') == "$complete_at" ]] ||
+  fail "a partial backup must not become the snapshot restores default to"
+pass "a partial backup is kept, flagged, and never becomes the restore default"
+
+STUB_BACKUP_EXIT=1 run_backup
+[[ $(field '.phase') == "error" ]] || fail "a failed run records an error phase"
+[[ $(field '.last_backup.error') == *"restic said no"* ]] || fail "the failure carries restic's own words" "$(field '.last_backup.error')"
+pass "a failed run records why it failed"
+
+STUB_BACKUP_EXIT=11 run_backup
+[[ $(field '.last_skip.reason') == *"another machine"* ]] || fail "lock contention is a skip"
+[[ $(field '.phase') != "error" ]] || fail "lock contention is not an error"
+pass "another machine holding the repository lock is a skip, not a failure"
+
+# A crash or a reboot mid-backup leaves a `running` record behind. Left alone
+# the panel shows an upload that will never finish.
+jq '.phase = "running" | .pid = 999999' "$status_file" >"$status_file.tmp" && mv "$status_file.tmp" "$status_file"
+printf 'manual\n' >"$state_dir/pause"
+run_backup
+[[ $(field '.last_backup.result') == "failed" ]] || fail "a run that died is reconciled as failed" "$(cat "$status_file")"
+rm -f "$state_dir/pause"
+pass "a run that died without reporting is reconciled instead of showing forever"
+
+printf '%s 0\n' "$(( $(date +%s) - 40 * 86400 ))" >"$state_dir/maintenance"
+run_backup
+grep -q 'restic forget --prune .*--keep-hourly 24 --keep-daily 7 --keep-weekly 5 --keep-monthly 12' "$test_tmp/calls.log" ||
+  fail "maintenance forgets on the documented retention" "$(cat "$test_tmp/calls.log")"
+grep -q 'restic check --read-data-subset=1/12' "$test_tmp/calls.log" ||
+  fail "maintenance reads a rotating slice of the data" "$(cat "$test_tmp/calls.log")"
+[[ $(cut -d' ' -f2 "$state_dir/maintenance") == "1" ]] || fail "the read-data slice advances"
+pass "monthly maintenance prunes and verifies a rotating slice"
+
+# The expensive half of the work belongs to one machine, or every laptop
+# sharing a repository pays for it.
+sed -i "s/^BACKUP_MAINTENANCE_HOST=.*/BACKUP_MAINTENANCE_HOST=\"some-other-machine\"/" "$config_dir/settings"
+printf '%s 0\n' "$(( $(date +%s) - 40 * 86400 ))" >"$state_dir/maintenance"
+run_backup
+! grep -q 'restic forget' "$test_tmp/calls.log" || fail "only the maintenance host prunes"
+pass "machines that do not own maintenance never prune or check"

--- a/test/shell.d/backup-setup-test.sh
+++ b/test/shell.d/backup-setup-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+fake_home="$test_tmp/home"
+mkdir -p "$fake_bin" "$fake_home"
+
+secrets_dir="$fake_home/.local/share/omarchy/backup"
+config_dir="$fake_home/.config/omarchy/backup"
+unit_dir="$fake_home/.config/systemd/user"
+recovery_card="$fake_home/Omarchy Backup Recovery.txt"
+
+printf 'correct-horse-battery-staple\n' >"$test_tmp/passphrase"
+
+stub() {
+  local name="$1"
+  cat >"$fake_bin/$name"
+  chmod +x "$fake_bin/$name"
+}
+
+stub restic <<'STUB'
+#!/bin/bash
+printf 'restic %s\n' "$*" >>"$TEST_LOG"
+if [[ $1 == "cat" ]]; then
+  exit "${STUB_PROBE_EXIT:-10}"
+fi
+exit 0
+STUB
+
+for command in omarchy-pkg-add omarchy-plugin-enable omarchy-plugin-disable systemctl gum fusermount; do
+  stub "$command" <<STUB
+#!/bin/bash
+printf '$command %s\n' "\$*" >>"\$TEST_LOG"
+exit 0
+STUB
+done
+
+setup() {
+  TEST_LOG="$test_tmp/calls.log" \
+    HOME="$fake_home" \
+    XDG_STATE_HOME="$fake_home/.local/state" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$fake_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-setup-backup" "$@"
+}
+
+mode() {
+  stat -c '%a' "$1"
+}
+
+: >"$test_tmp/calls.log"
+setup --repository "$test_tmp/repo" --passphrase-file "$test_tmp/passphrase" --no-first-backup >/dev/null
+
+# The repository is created only after the probe says there is nothing there.
+grep -q '^restic cat config' "$test_tmp/calls.log" || fail "the destination is probed before anything is created"
+grep -q '^restic init' "$test_tmp/calls.log" || fail "an absent repository is initialized"
+pass "setup probes the destination and initializes only what is missing"
+
+[[ $(mode "$secrets_dir") == "700" ]] || fail "the secrets directory is private" "$(mode "$secrets_dir")"
+[[ $(mode "$secrets_dir/env") == "600" ]] || fail "the credentials file is private"
+[[ $(mode "$secrets_dir/passphrase") == "600" ]] || fail "the passphrase file is private"
+grep -q "RESTIC_REPOSITORY=$test_tmp/repo" "$secrets_dir/env" || fail "the repository is recorded"
+! grep -q "correct-horse-battery-staple" "$secrets_dir/env" || fail "the passphrase does not leak into the environment file"
+pass "credentials and passphrase are written privately, and separately"
+
+# ~/.config is versioned and synced by people; a delete-capable credential must
+# not ride along with it.
+! grep -rq "correct-horse-battery-staple" "$config_dir" || fail "the passphrase is not in ~/.config"
+! grep -rq "RESTIC_REPOSITORY" "$config_dir" 2>/dev/null || fail "credentials are not in ~/.config"
+grep -q "BACKUP_MAINTENANCE_HOST=\"$(hostname)\"" "$config_dir/settings" ||
+  fail "the machine that set the repository up owns maintenance" "$(cat "$config_dir/settings")"
+pass "only non-secret settings land in ~/.config"
+
+[[ -f $recovery_card ]] || fail "a recovery card is written"
+[[ $(mode "$recovery_card") == "600" ]] || fail "the recovery card is private"
+grep -q "$test_tmp/repo" "$recovery_card" || fail "the recovery card names the repository"
+! grep -q "correct-horse-battery-staple" "$recovery_card" ||
+  fail "the recovery card carries no live secret; the passphrase is written on by hand"
+pass "the recovery card explains the restore without holding the keys"
+
+[[ -L $unit_dir/omarchy-backup.timer ]] || fail "the timer is linked into the user's units"
+[[ -L $unit_dir/omarchy-backup.service ]] || fail "the service is linked into the user's units"
+grep -q 'systemctl --user enable --now omarchy-backup.timer' "$test_tmp/calls.log" || fail "the schedule is enabled"
+grep -q 'omarchy-plugin-enable omarchy.backup' "$test_tmp/calls.log" || fail "the bar widget is placed"
+pass "the schedule and the widget arrive together, at the end"
+
+# Re-running the wizard must not double up or fail on what already exists.
+: >"$test_tmp/calls.log"
+setup --repository "$test_tmp/repo" --passphrase-file "$test_tmp/passphrase" --no-first-backup >/dev/null
+[[ $(ls "$unit_dir" | wc -l) == "2" ]] || fail "re-running the setup does not duplicate units"
+pass "the setup is idempotent"
+
+# A passphrase that does not open an existing repository is a stop, not a
+# reason to create a second repository next to the first.
+: >"$test_tmp/calls.log"
+set +e
+STUB_PROBE_EXIT=12 setup --repository "$test_tmp/repo" --passphrase-file "$test_tmp/passphrase" --no-first-backup >/dev/null 2>"$test_tmp/stderr"
+status=$?
+set -e
+(( status != 0 )) || fail "a wrong passphrase fails the setup"
+grep -qi 'passphrase does not open' "$test_tmp/stderr" || fail "the wrong passphrase is named" "$(cat "$test_tmp/stderr")"
+! grep -q '^restic init' "$test_tmp/calls.log" || fail "a wrong passphrase must not initialize anything"
+pass "a wrong passphrase stops the setup without creating a repository"
+
+: >"$test_tmp/calls.log"
+set +e
+STUB_PROBE_EXIT=1 setup --repository "$test_tmp/repo" --passphrase-file "$test_tmp/passphrase" --no-first-backup >/dev/null 2>"$test_tmp/stderr"
+status=$?
+set -e
+(( status != 0 )) || fail "an unreachable destination fails the setup"
+! grep -q '^restic init' "$test_tmp/calls.log" || fail "an unreachable destination must not initialize anything"
+pass "an unreachable destination stops the setup without creating a repository"
+
+: >"$test_tmp/calls.log"
+setup --remove >"$test_tmp/removal"
+
+grep -q 'systemctl --user disable omarchy-backup.timer' "$test_tmp/calls.log" || fail "removal disables the schedule"
+grep -q 'omarchy-plugin-disable omarchy.backup' "$test_tmp/calls.log" || fail "removal takes the widget out of the bar"
+[[ ! -e $secrets_dir ]] || fail "removal deletes the local credentials"
+[[ ! -e $unit_dir/omarchy-backup.timer ]] || fail "removal unlinks the units"
+grep -qi 'untouched' "$test_tmp/removal" || fail "removal says the backups themselves are still there" "$(cat "$test_tmp/removal")"
+pass "removal forgets the destination without pretending to delete the backups"


### PR DESCRIPTION
Implements `plans/backup.md` (rev 2): restic engine, hourly user timer, one state file, a bar widget, and restores that don't need flags.

- `omarchy setup backup` — gum wizard for an S3-compatible bucket, a local disk, or any restic repository URL. Probes before it creates anything (absent → init, wrong passphrase → stop, unreachable → stop), writes a recovery card, runs the first backup in front of you, and only then enables the timer and places the widget. `--remove` tears it down and says plainly that the repository itself is untouched.
- `omarchy-backup-run` — the timer's target and the only writer of `~/.local/state/omarchy/backup/status.json`. Skips (paused, battery, lock held, backup disk absent) are recorded as skips, not failures; exit 3 is a `partial` snapshot that never becomes the restore default; exit 11 is a retryable skip; a run whose pid is gone is reconciled instead of showing an eternal upload.
- `omarchy backup status|now|pause|resume|snapshots|log|restore|browse` — restores land in `~/Restored/<timestamp>/` by default; `--in-place` copies the current version aside first; `browse` mounts every backup as dated folders.
- Bar widget at `shell/plugins/panels/backup/`, watching the state file (plus its directory, since the runner replaces the file by rename). Never shells out to restic.
- Maintenance monthly, on one machine only: `forget --prune` plus `check` with a rotating `--read-data-subset`.
- Docs: `manual/52-backups.md`, `docs/backup.md`, and cross-links from the snapshots, Dropbox, and coming-from-mac pages so "snapshot vs backup vs sync" is stated once.

Verified: `test/cli` green; `test/shell` 189/192 — the three failures (`config-test`, `snapper-test`, `unowned-system-paths-test`) are the missing `omarchy-pkgs` checkout and fail identically on `quattro` here. New coverage: state-machine transitions against a stub restic, the unattended wizard path including the two abort cases, a real backup/restore round trip on restic's local backend, and Model.js under node. The widget was checked in a running shell in its unconfigured, healthy, running, failed, and paused states.

Deliberate deviations from the plan, both easy to change:

- The units ship in `default/systemd/user/` and the wizard symlinks them into `~/.config/systemd/user/` rather than being installed to `/usr/lib/systemd/user` by `omarchy-settings`. That keeps the feature working from a checkout and avoids adding `package_defaults` entries that would fail `config-test` until a PKGBUILD lands in the other repo. Happy to move it.
- Open questions 1–7 in the plan are answered conservatively: VM disks and model files stay in, cadence is hourly for everyone with no metered-connection detection, no bandwidth limit, no widget for unconfigured users, plain `omarchy backup` naming, one shared repository with per-machine ones documented rather than wizarded.


## Demo

Setup, first backup, a deleted file coming back, pause/resume, and the snapshot list — recorded against a sandbox home folder and a local repository, every command from this branch:

![backup demo](https://github.com/achevalier-dev/omarchy/releases/download/backup-demo/backup-demo.gif)

([same thing as mp4](https://github.com/achevalier-dev/omarchy/releases/download/backup-demo/backup-demo.mp4))

The bar widget, open, after a healthy run:

![backup panel](https://github.com/achevalier-dev/omarchy/releases/download/backup-demo/panel-healthy.png)

And its other states — not set up, running, failed, paused:

![backup panel states](https://github.com/achevalier-dev/omarchy/releases/download/backup-demo/panel-states.png)
