### PR TITLE
Install the bundled extensions into Google Chrome

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -51,6 +51,7 @@ chrome)
 
   setup_policy_directory /etc/opt/chrome/policies/managed
   copy_chromium_flags ~/.config/chrome-flags.conf
+  omarchy-install-chrome-extensions
   omarchy-theme-set-browser
   announce_browser_installed "Chrome"
   ;;

--- a/bin/omarchy-install-chrome-extensions
+++ b/bin/omarchy-install-chrome-extensions
@@ -17,7 +17,7 @@ set -euo pipefail
 # the user the Remove button. So take the route that leaves them removable.
 EXTENSIONS=(copy-url yt-dlp whatsapp-slim)
 STATE_DIR="$HOME/.local/state/omarchy/chrome-extensions"
-EXTERNAL_DIR="/usr/share/google-chrome/extensions"
+EXTERNAL_DIR="${OMARCHY_CHROME_EXTENSIONS_DIR:-/usr/share/google-chrome/extensions}"
 FLAGS_FILE="$HOME/.config/chrome-flags.conf"
 
 # Chrome takes an extension's id from the key that signed the CRX, ignoring the

--- a/bin/omarchy-install-chrome-extensions
+++ b/bin/omarchy-install-chrome-extensions
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# omarchy:summary=Install Omarchy's bundled Chromium extensions into Google Chrome
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+# Google Chrome refuses the switch the flags file relies on ("--load-extension is
+# not allowed in Google Chrome, ignoring"), so the three extensions Chromium
+# loads unpacked never reach Chrome. Chrome does install a locally signed CRX
+# listed in its external extensions directory.
+#
+# Chrome's Safety Check lists all three afterwards as extensions it "can't verify
+# where they come from". That is what Chrome says about every extension outside
+# its Web Store: installing them through an enterprise policy instead, whether
+# normal_installed or force_installed, is flagged just the same and only costs
+# the user the Remove button. So take the route that leaves them removable.
+EXTENSIONS=(copy-url yt-dlp whatsapp-slim)
+STATE_DIR="$HOME/.local/state/omarchy/chrome-extensions"
+EXTERNAL_DIR="/usr/share/google-chrome/extensions"
+FLAGS_FILE="$HOME/.config/chrome-flags.conf"
+
+# Chrome takes an extension's id from the key that signed the CRX, ignoring the
+# manifest "key" field Chromium honours for unpacked loads. Keep the generated
+# key: a fresh one mints a fresh id, which Chrome installs alongside the old copy
+# rather than over it.
+signing_key() {
+  local key="$STATE_DIR/$1.pem"
+
+  if [[ ! -f $key ]]; then
+    openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$key" 2>/dev/null
+    chmod 600 "$key"
+  fi
+
+  printf '%s\n' "$key"
+}
+
+# The id is the first 16 bytes of the SHA-256 of the DER public key, hex-encoded
+# with 0-9a-f mapped onto a-p. Reads the DER key on stdin.
+extension_id() {
+  sha256sum | cut -c1-32 | tr '0-9a-f' 'a-p'
+}
+
+public_key_der() {
+  openssl rsa -in "$1" -pubout -outform DER 2>/dev/null
+}
+
+extension_version() {
+  jq -r '.version' "$OMARCHY_PATH/default/chromium/extensions/$1/manifest.json"
+}
+
+# Rewrite the manifest's pinned "key" to the signing key so the packed extension
+# reports the same id Chrome derives from the CRX signature.
+pack_extension() {
+  local name="$1" key="$2" source="$OMARCHY_PATH/default/chromium/extensions/$1" workdir
+
+  workdir=$(mktemp -d)
+
+  # The bundled icons are relative symlinks into the repo root, which dangle once
+  # the extension is copied out of it.
+  cp -rL "$source" "$workdir/$name"
+  jq --arg key "$(public_key_der "$key" | base64 -w0)" '.key = $key' \
+    "$source/manifest.json" >"$workdir/$name/manifest.json"
+
+  google-chrome-stable --pack-extension="$workdir/$name" --pack-extension-key="$key" >/dev/null
+  install -m 644 "$workdir/$name.crx" "$STATE_DIR/$name.crx"
+  rm -rf "$workdir"
+}
+
+# Chrome reinstalls a CRX only when external_version outruns what it already has,
+# so the version has to track the manifest the CRX was packed from.
+external_pref() {
+  printf '{\n  "external_crx": "%s",\n  "external_version": "%s"\n}\n' \
+    "$STATE_DIR/$1.crx" "$(extension_version "$1")"
+}
+
+# Leaving the switch in place advertises a mechanism Chrome rejects and warns
+# about on every launch.
+drop_dead_load_extension_switch() {
+  [[ -f $FLAGS_FILE ]] || return 0
+  sed -i '/^--load-extension=/d' "$FLAGS_FILE"
+}
+
+main() {
+  local name key id
+
+  mkdir -p "$STATE_DIR"
+  sudo mkdir -p "$EXTERNAL_DIR"
+
+  for name in "${EXTENSIONS[@]}"; do
+    key=$(signing_key "$name")
+    id=$(public_key_der "$key" | extension_id)
+
+    pack_extension "$name" "$key"
+    external_pref "$name" | sudo tee "$EXTERNAL_DIR/$id.json" >/dev/null
+    printf '%s\n' "$id" >"$STATE_DIR/$name.id"
+  done
+
+  drop_dead_load_extension_switch
+
+  # The native messaging hosts allow one origin per extension id, so they have to
+  # learn the ids minted above before Chrome's copies can reach them.
+  omarchy-install-chromium-copy-url
+  omarchy-install-chromium-ytdlp
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/bin/omarchy-install-chromium-copy-url
+++ b/bin/omarchy-install-chromium-copy-url
@@ -7,6 +7,7 @@ set -euo pipefail
 HOST_NAME="com.omarchy.copy_url"
 HOST_PATH="$OMARCHY_PATH/bin/omarchy-chromium-copy-url-host"
 TEMPLATE="$OMARCHY_PATH/default/chromium/native-messaging-hosts/$HOST_NAME.json"
+CHROME_ID="$HOME/.local/state/omarchy/chrome-extensions/copy-url.id"
 
 browser_dirs=(
   "$HOME/.config/chromium"
@@ -21,6 +22,13 @@ browser_dirs=(
 )
 
 manifest=$(sed "s|__HOST_PATH__|$HOST_PATH|g" "$TEMPLATE")
+
+# Chrome installs the extension from a locally signed CRX, so its id comes from
+# a key minted on this machine rather than the one pinned in the manifest.
+if [[ -f $CHROME_ID ]]; then
+  manifest=$(jq --arg origin "chrome-extension://$(<"$CHROME_ID")/" \
+    '.allowed_origins += [$origin]' <<<"$manifest")
+fi
 
 for dir in "${browser_dirs[@]}"; do
   mkdir -p "$dir/NativeMessagingHosts"

--- a/bin/omarchy-install-chromium-ytdlp
+++ b/bin/omarchy-install-chromium-ytdlp
@@ -7,6 +7,7 @@ set -euo pipefail
 HOST_NAME="com.omarchy.ytdlp"
 HOST_PATH="$OMARCHY_PATH/bin/omarchy-chromium-ytdlp-host"
 TEMPLATE="$OMARCHY_PATH/default/chromium/native-messaging-hosts/$HOST_NAME.json"
+CHROME_ID="$HOME/.local/state/omarchy/chrome-extensions/yt-dlp.id"
 
 # Chromium-based browser profile roots that use the NativeMessagingHosts layout.
 browser_dirs=(
@@ -22,6 +23,13 @@ browser_dirs=(
 )
 
 manifest=$(sed "s|__HOST_PATH__|$HOST_PATH|g" "$TEMPLATE")
+
+# Chrome installs the extension from a locally signed CRX, so its id comes from
+# a key minted on this machine rather than the one pinned in the manifest.
+if [[ -f $CHROME_ID ]]; then
+  manifest=$(jq --arg origin "chrome-extension://$(<"$CHROME_ID")/" \
+    '.allowed_origins += [$origin]' <<<"$manifest")
+fi
 
 for dir in "${browser_dirs[@]}"; do
   mkdir -p "$dir/NativeMessagingHosts"

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -18,6 +18,19 @@ set_fallback_default_browser() {
   fi
 }
 
+# The bundled extensions reach Chrome as locally signed CRXs registered in its
+# external extensions directory, keyed by ids minted on this machine.
+remove_chrome_extensions() {
+  local state_dir="$HOME/.local/state/omarchy/chrome-extensions" id_file
+
+  for id_file in "$state_dir"/*.id; do
+    [[ -f $id_file ]] || continue
+    sudo rm -f "/usr/share/google-chrome/extensions/$(<"$id_file").json"
+  done
+
+  rm -rf "$state_dir"
+}
+
 case $1 in
 chrome)
   echo "Removing Chrome..."
@@ -25,6 +38,7 @@ chrome)
   omarchy-pkg-drop google-chrome
   rm -f ~/.config/chrome-flags.conf
   sudo rm -f /etc/opt/chrome/policies/managed/color.json
+  remove_chrome_extensions
   ;;
 edge)
   echo "Removing Edge..."

--- a/migrations/1787425065.sh
+++ b/migrations/1787425065.sh
@@ -1,0 +1,8 @@
+echo "Install Omarchy's bundled extensions into Google Chrome"
+
+# Chrome ignores the --load-extension switch the flags file relies on, so
+# installs made before this shipped have Chromium's three extensions and none of
+# Chrome's. omarchy-install-chrome-extensions is idempotent.
+omarchy-cmd-present google-chrome-stable || exit 0
+
+omarchy-install-chrome-extensions

--- a/test/shell.d/chrome-extensions-test.sh
+++ b/test/shell.d/chrome-extensions-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+
+export PATH="$ROOT/bin:$PATH"
+
+cleanup() {
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_command jq
+require_command openssl
+
+TMPDIR=$(mktemp -d)
+test_home="$TMPDIR/home"
+extensions_dir="$ROOT/default/chromium/extensions"
+
+source "$ROOT/bin/omarchy-install-chrome-extensions"
+
+# Point the sourced installer at the sandbox instead of the real home.
+OMARCHY_PATH="$ROOT"
+STATE_DIR="$test_home/.local/state/omarchy/chrome-extensions"
+FLAGS_FILE="$test_home/.config/chrome-flags.conf"
+mkdir -p "$STATE_DIR" "$test_home/.config"
+
+# The ids pinned in the native messaging manifests were derived from the public
+# keys in the extension manifests, so they are known-good vectors for the same
+# derivation Chrome applies to a CRX signing key.
+pinned_id() {
+  jq -r '.key' "$extensions_dir/$1/manifest.json" | base64 -d | extension_id
+}
+
+[[ $(pinned_id yt-dlp) == "dedjgknigfeelejglamclffonmophnfl" ]] ||
+  fail "extension_id derives the yt-dlp id Chrome would compute" "$(pinned_id yt-dlp)"
+[[ $(pinned_id copy-url) == "bgpiichlckmfanooecilcjemknkcpngb" ]] ||
+  fail "extension_id derives the Copy URL id Chrome would compute" "$(pinned_id copy-url)"
+pass "extension_id derives the ids Chrome computes from a public key"
+
+key=$(signing_key yt-dlp)
+[[ -s $key ]] || fail "signing_key mints a key on first use"
+pass "signing_key mints a key on first use"
+
+# Regenerating the key would mint a new id and orphan the installed extension.
+before=$(sha256sum <"$key")
+signing_key yt-dlp >/dev/null
+[[ $before == $(sha256sum <"$key") ]] ||
+  fail "signing_key reuses the existing key so Chrome's extension id stays put"
+pass "signing_key reuses the existing key so Chrome's extension id stays put"
+
+cat >"$FLAGS_FILE" <<'CONF'
+--ozone-platform=wayland
+--load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url
+CONF
+
+drop_dead_load_extension_switch
+
+grep -q -- "--load-extension" "$FLAGS_FILE" &&
+  fail "the flags file drops the switch Chrome refuses"
+grep -q -- "--ozone-platform=wayland" "$FLAGS_FILE" ||
+  fail "the flags file keeps the switches Chrome honours"
+pass "the flags file drops the switch Chrome refuses"
+
+# The native messaging hosts allow one origin per extension id, and Chrome's
+# copies carry the locally minted id rather than the pinned one.
+echo "abcdefghijklmnopabcdefghijklmnop" >"$STATE_DIR/yt-dlp.id"
+echo "ponmlkjihgfedcbaponmlkjihgfedcba" >"$STATE_DIR/copy-url.id"
+
+HOME="$test_home" OMARCHY_PATH="$ROOT" omarchy-install-chromium-ytdlp
+HOME="$test_home" OMARCHY_PATH="$ROOT" omarchy-install-chromium-copy-url
+
+jq -e '.allowed_origins == [
+  "chrome-extension://dedjgknigfeelejglamclffonmophnfl/",
+  "chrome-extension://abcdefghijklmnopabcdefghijklmnop/"
+]' "$test_home/.config/google-chrome/NativeMessagingHosts/com.omarchy.ytdlp.json" >/dev/null ||
+  fail "yt-dlp native host allows both the Chromium and Chrome extension ids"
+pass "yt-dlp native host allows both the Chromium and Chrome extension ids"
+
+jq -e '.allowed_origins == [
+  "chrome-extension://bgpiichlckmfanooecilcjemknkcpngb/",
+  "chrome-extension://ponmlkjihgfedcbaponmlkjihgfedcba/"
+]' "$test_home/.config/google-chrome/NativeMessagingHosts/com.omarchy.copy_url.json" >/dev/null ||
+  fail "Copy URL native host allows both the Chromium and Chrome extension ids"
+pass "Copy URL native host allows both the Chromium and Chrome extension ids"
+
+# Without Chrome the hosts must keep the pinned id and nothing else.
+bare_home="$TMPDIR/bare"
+HOME="$bare_home" OMARCHY_PATH="$ROOT" omarchy-install-chromium-ytdlp
+
+jq -e '.allowed_origins == ["chrome-extension://dedjgknigfeelejglamclffonmophnfl/"]' \
+  "$bare_home/.config/chromium/NativeMessagingHosts/com.omarchy.ytdlp.json" >/dev/null ||
+  fail "yt-dlp native host keeps only the pinned id when Chrome is absent"
+pass "yt-dlp native host keeps only the pinned id when Chrome is absent"
+
+echo "bcklgckdehleclkgblfhfpocdgaikemg" >"$STATE_DIR/whatsapp-slim.id"
+
+# Chrome only reinstalls a CRX when external_version outruns what it has.
+for name in "${EXTENSIONS[@]}"; do
+  jq -e --arg crx "$STATE_DIR/$name.crx" --arg version "$(extension_version "$name")" \
+    '.external_crx == $crx and .external_version == $version' \
+    <(external_pref "$name") >/dev/null ||
+    fail "the external pref points Chrome at the packed $name CRX and its manifest version"
+done
+pass "the external pref points Chrome at each packed CRX and its manifest version"
+
+if command -v google-chrome-stable >/dev/null; then
+  pack_extension yt-dlp "$key"
+
+  [[ -s $STATE_DIR/yt-dlp.crx ]] || fail "pack_extension writes a CRX for Chrome to install"
+  pass "pack_extension writes a CRX for Chrome to install"
+else
+  pass "Google Chrome not installed; skipping CRX packing"
+fi

--- a/test/shell.d/chrome-extensions-test.sh
+++ b/test/shell.d/chrome-extensions-test.sh
@@ -117,3 +117,105 @@ if command -v google-chrome-stable >/dev/null; then
 else
   pass "Google Chrome not installed; skipping CRX packing"
 fi
+
+# Everything above drives one function at a time, which leaves the installer's
+# own orchestration -- the loop over all three extensions, the registration
+# Chrome reads, and the native host refresh -- resting on sudo and a Chrome
+# binary the test machine may not have. Run the script itself against stubs for
+# both so that work is covered wherever the suite runs.
+stub_bin="$TMPDIR/stub-bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+# Chrome writes <dir>.crx beside the directory it packs. Standing in for the
+# CRX3 container, the stub copies the manifest through, which keeps the key the
+# extension was packed with readable below.
+cat >"$stub_bin/google-chrome-stable" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+
+for arg in "$@"; do
+  case $arg in
+  --pack-extension=*) dir=${arg#*=} ;;
+  --pack-extension-key=*) key=${arg#*=} ;;
+  esac
+done
+
+[[ -s $key ]] || { echo "packed without a signing key" >&2; exit 1; }
+cp "$dir/manifest.json" "$dir.crx"
+STUB
+chmod +x "$stub_bin/google-chrome-stable"
+
+e2e_home="$TMPDIR/e2e"
+e2e_state="$e2e_home/.local/state/omarchy/chrome-extensions"
+e2e_external="$e2e_home/usr/share/google-chrome/extensions"
+
+mkdir -p "$e2e_home/.config"
+cat >"$e2e_home/.config/chrome-flags.conf" <<'CONF'
+--ozone-platform=wayland
+--load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url
+CONF
+
+install_into_chrome() {
+  HOME="$e2e_home" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_CHROME_EXTENSIONS_DIR="$e2e_external" \
+    PATH="$stub_bin:$PATH" \
+    omarchy-install-chrome-extensions
+}
+
+install_into_chrome
+
+for name in "${EXTENSIONS[@]}"; do
+  [[ -s $e2e_state/$name.crx ]] || fail "the installer packs a CRX for $name"
+  [[ $(stat -c '%a' "$e2e_state/$name.pem") == "600" ]] ||
+    fail "the installer keeps $name's signing key private" "$(stat -c '%a' "$e2e_state/$name.pem")"
+
+  id=$(<"$e2e_state/$name.id")
+
+  # The id Chrome derives from the CRX signature has to be the one the
+  # registration is filed under, or Chrome installs nothing.
+  packed_id=$(jq -r '.key' "$e2e_state/$name.crx" | base64 -d | extension_id)
+  [[ $id == "$packed_id" ]] ||
+    fail "$name is registered under the id Chrome derives from the CRX" "registered: $id, packed: $packed_id"
+
+  jq -e --arg crx "$e2e_state/$name.crx" --arg version "$(extension_version "$name")" \
+    '.external_crx == $crx and .external_version == $version' \
+    "$e2e_external/$id.json" >/dev/null ||
+    fail "Chrome's registration for $name points at the packed CRX and its manifest version"
+done
+pass "the installer packs, signs and registers every bundled extension for Chrome"
+
+[[ $(ls "$e2e_external" | wc -l) == "3" ]] ||
+  fail "the installer registers only the bundled extensions" "$(ls "$e2e_external")"
+pass "the installer registers only the bundled extensions"
+
+grep -q -- "--load-extension" "$e2e_home/.config/chrome-flags.conf" &&
+  fail "the installer drops the switch Chrome refuses from the flags file"
+grep -q -- "--ozone-platform=wayland" "$e2e_home/.config/chrome-flags.conf" ||
+  fail "the installer keeps the switches Chrome honours in the flags file"
+pass "the installer leaves the flags file with only the switches Chrome honours"
+
+for host in com.omarchy.copy_url:copy-url com.omarchy.ytdlp:yt-dlp; do
+  jq -e --arg origin "chrome-extension://$(<"$e2e_state/${host#*:}.id")/" \
+    '.allowed_origins | index($origin)' \
+    "$e2e_home/.config/google-chrome/NativeMessagingHosts/${host%%:*}.json" >/dev/null ||
+    fail "the installer teaches ${host%%:*} the id Chrome minted"
+done
+pass "the installer teaches the native messaging hosts the ids Chrome minted"
+
+# A second run must land on the same ids: minting fresh ones would leave Chrome
+# with the old copy installed beside the new one.
+before=$(cat "$e2e_state"/*.id)
+install_into_chrome
+
+[[ $before == "$(cat "$e2e_state"/*.id)" ]] ||
+  fail "reinstalling keeps the ids Chrome already installed under"
+[[ $(ls "$e2e_external" | wc -l) == "3" ]] ||
+  fail "reinstalling leaves one registration per extension" "$(ls "$e2e_external")"
+pass "reinstalling is idempotent"


### PR DESCRIPTION
## The bug

Omarchy's three bundled extensions (Copy URL, Download Video, WhatsApp Slim) load in Chromium but never appear in Google Chrome, even though `omarchy-install-browser chrome` copies the same flags file to `~/.config/chrome-flags.conf`.

Same machine, same Omarchy install, `chrome://extensions` filtered by "down" in both. Chromium has Download Video; Chrome finds nothing:

![Download Video present in Chromium, absent in Google Chrome](https://raw.githubusercontent.com/fedesapuppo/omarchy/pr-7817-proof/chrome-missing-extensions.png)

Chrome rejects the switch that file relies on. The string is in the binary:

```
$ strings /opt/google/chrome/chrome | grep load-extension
--load-extension is not allowed in Google Chrome, ignoring.
```

Confirmed against Chrome 151.0.7922.169 and Chromium 151.0.7922.137 on the same flags, comparing `Default/Preferences` after a headless launch:

| | Chromium | Chrome |
|---|---|---|
| `copy-url` | loaded | absent |
| `yt-dlp` | loaded | absent |
| `whatsapp-slim` | loaded | absent |

`--disable-features=DisableLoadExtensionCommandLineSwitch` does not bring it back; the refusal is unconditional in Google-branded builds.

## The fix

`omarchy-install-chrome-extensions` packs each bundled extension into a locally signed CRX and registers it in `/usr/share/google-chrome/extensions`, which Chrome does still honour. Called from `omarchy-install-browser chrome`, plus a migration for installs that already have Chrome.

Chrome derives an extension id from the CRX signing key and ignores the manifest `key` field Chromium honours for unpacked loads, so the ids differ per machine. The signing key is generated once into `~/.local/state/omarchy/chrome-extensions` and kept, and `omarchy-install-chromium-{copy-url,ytdlp}` add the generated id to `allowed_origins` next to the pinned one so native messaging keeps working. Without Chrome installed those manifests are byte-for-byte what they were.

The dead `--load-extension` line is dropped from `chrome-flags.conf`, and `omarchy-remove-browser chrome` cleans up.

## Known limitation

Chrome's Safety Check lists the three as extensions it "can't verify where they come from". That is Chrome's stance on every off-store extension, not something this approach triggers. I tested the alternatives before settling:

| Install route | Location | Safety Check | Remove button |
|---|---|---|---|
| External extensions dir (this PR) | `EXTERNAL_PREF` | flagged | yes |
| `ExtensionSettings` `normal_installed` | `EXTERNAL_PREF_DOWNLOAD` | flagged | no |
| `ExtensionSettings` `force_installed` | `EXTERNAL_POLICY_DOWNLOAD` | flagged | no |

Every route is flagged, so this PR takes the one that leaves the extensions removable. Happy to switch to the policy route if you would rather have them pinned on.

## Test plan

`test/shell.d/chrome-extensions-test.sh` — 14 assertions. Unit level: id derivation (checked against the pinned Chromium ids, which are the same algorithm applied to the manifest keys), signing key reuse, external pref contents, flags cleanup. End to end: the installer itself runs against stubs for `sudo` and `google-chrome-stable`, so the orchestration is covered on machines without Chrome — every extension packed and registered, the id in each registration matching the id derived from the key inside the packed CRX, both native hosts learning the minted ids, and a second run idempotent. Mutation-checked: dropping the manifest key rewrite, skipping the native host refresh, or regenerating the signing key each run all fail the suite.

`EXTERNAL_DIR` honours `OMARCHY_CHROME_EXTENSIONS_DIR` so the test can redirect it, matching the `OMARCHY_*_PATH` overrides the `hw-*` commands already use for their sysfs paths.

- `./test/cli` — 116 pass, including the metadata route for the new command
- `./test/shell` — 2366 pass. The 4 failures are pre-existing on `quattro` here: 3 need an `omarchy-pkgs` checkout, and `copy-url-shortcut-migration`'s "stays pending when a browser starts mid-repair" fails the same way on a clean base checkout
- `chromium-ytdlp`, `chromium-copy-url`, `chromium-whatsapp-slim` tests unchanged and passing

Verified on the machine end to end: clean state, run the installer, launch a fresh Chrome profile, and all three arrive.
