### PR TITLE
Stand down the tailscale poll watchdog once its polls exit

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -73,6 +73,14 @@ function loginPlan(needsLogin, authUrl) {
   return { authUrl: "", command: ["tailscale", "up"] }
 }
 
+// The poll watchdog exists to reap polls that never come back, so it must
+// stand down once the polls of its launch cycle have all exited — otherwise
+// it fires into whatever the next cycle has in flight and kills healthy
+// slow polls (large tailnets routinely take longer than the timeout).
+function allPollsSettled(statusRunning, mullvadRunning, accountsRunning) {
+  return !statusRunning && !mullvadRunning && !accountsRunning
+}
+
 // Taildrop is a tailnet feature the admin can turn off, so the button for it
 // only makes sense when this profile actually carries the capability.
 function hasFileSharing(self) {
@@ -312,6 +320,7 @@ if (typeof module !== "undefined") {
     osIcon: osIcon,
     accountLabel: accountLabel,
     loginPlan: loginPlan,
+    allPollsSettled: allPollsSettled,
     hasFileSharing: hasFileSharing,
     isTaildropTarget: isTaildropTarget,
     isMullvadPeer: isMullvadPeer,

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -74,11 +74,18 @@ function loginPlan(needsLogin, authUrl) {
 }
 
 // The poll watchdog exists to reap polls that never come back, so it must
-// stand down once the polls of its launch cycle have all exited — otherwise
-// it fires into whatever the next cycle has in flight and kills healthy
+// stand down once the launches of its own cycle have all exited — otherwise
+// it fires into whatever a later cycle has in flight and kills healthy
 // slow polls (large tailnets routinely take longer than the timeout).
-function allPollsSettled(statusRunning, mullvadRunning, accountsRunning) {
-  return !statusRunning && !mullvadRunning && !accountsRunning
+// Cycles overlap: a refresh tick relaunches one poll while another is still
+// in flight, so membership in the armed cycle is decided per launch, not per
+// instant — a running poll from a newer cycle does not keep an older
+// watchdog alive.
+function allPollsSettled(armedCycle, statusRunning, statusCycle, mullvadRunning, mullvadCycle, accountsRunning, accountsCycle) {
+  var statusGuarded = statusRunning && statusCycle === armedCycle
+  var mullvadGuarded = mullvadRunning && mullvadCycle === armedCycle
+  var accountsGuarded = accountsRunning && accountsCycle === armedCycle
+  return !statusGuarded && !mullvadGuarded && !accountsGuarded
 }
 
 // Taildrop is a tailnet feature the admin can turn off, so the button for it

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -188,8 +188,14 @@ Item {
     // Arm on the launch that needs watching and leave it alone after that.
     // Restarting it every refresh pushes the deadline out ahead of a hung
     // process forever once the refresh interval is shorter than the timeout,
-    // and refreshIntervalSec goes down to five seconds.
+    // and refreshIntervalSec goes down to five seconds. Once this cycle's
+    // polls exit, settlePollWatchdog stands it down so its fire can only ever
+    // land on a poll of its own launch cycle that exceeded the timeout.
     if (launched && !pollWatchdog.running) pollWatchdog.start()
+  }
+
+  function settlePollWatchdog() {
+    if (Model.allPollsSettled(statusProcess.running, mullvadExitNodesProcess.running, accountsProcess.running)) pollWatchdog.stop()
   }
 
   function elideStatus(text) {
@@ -423,7 +429,9 @@ Item {
     // never exits — tailscale can hang on a network that is coming and going —
     // silently stops the panel refreshing at all, and it stays stopped. Reap
     // anything still running well inside the refresh interval so the next tick
-    // starts clean.
+    // starts clean. Polls that finish normally stand it down first
+    // (settlePollWatchdog), so the fire only ever reaches a poll of its own
+    // launch cycle that is still running past the timeout.
     id: pollWatchdog
     interval: 15000
     repeat: false
@@ -475,6 +483,7 @@ Item {
     stdout: StdioCollector { id: statusStdout; waitForEnd: true; onStreamFinished: root._statusOutput = text }
     stderr: StdioCollector { id: statusStderr; waitForEnd: true; onStreamFinished: root._statusError = text }
     onExited: function(exitCode) {
+      root.settlePollWatchdog()
       root.refreshing = false
       var stdout = String(statusStdout.text || root._statusOutput || "")
       var stderr = String(statusStderr.text || root._statusError || "")
@@ -493,6 +502,7 @@ Item {
     stdout: StdioCollector { id: accountsStdout; waitForEnd: true; onStreamFinished: root._accountsOutput = text }
     stderr: StdioCollector { id: accountsStderr; waitForEnd: true; onStreamFinished: root._accountsError = text }
     onExited: function(exitCode) {
+      root.settlePollWatchdog()
       var stdout = String(accountsStdout.text || root._accountsOutput || "")
       var stderr = String(accountsStderr.text || root._accountsError || "")
       if (exitCode === 0) root.parseAccounts(stdout)
@@ -515,6 +525,7 @@ Item {
     stdout: StdioCollector { id: mullvadExitNodesStdout; waitForEnd: true; onStreamFinished: root._mullvadExitNodesOutput = text }
     stderr: StdioCollector { id: mullvadExitNodesStderr; waitForEnd: true; onStreamFinished: root._mullvadExitNodesError = text }
     onExited: function(exitCode) {
+      root.settlePollWatchdog()
       var stdout = String(mullvadExitNodesStdout.text || root._mullvadExitNodesOutput || "")
       if (exitCode === 0) root.parseMullvadExitNodes(stdout)
       else root.parseMullvadExitNodes("")

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -19,6 +19,11 @@ Item {
   property int _desired: -1
   readonly property bool active: _desired === -1 ? running : (_desired === 1)
   property bool refreshing: false
+  // Launch cycles for the poll watchdog: every refresh that starts at least
+  // one poll bumps lastLaunchCycle and stamps its polls; the armed watchdog
+  // remembers its own cycle so settlePollWatchdog can ignore newer ones.
+  property int lastLaunchCycle: 0
+  property int armedCycle: 0
   property string backendState: "Unknown"
   property string statusText: "Checking…"
   property string selfName: ""
@@ -160,11 +165,13 @@ Item {
   function refreshStatusAndAccounts(forceAccounts) {
     if (!installed) return
     var launched = false
+    var cycle = lastLaunchCycle + 1
     if (!statusProcess.running) {
       _statusOutput = ""
       _statusError = ""
       refreshing = true
       statusProcess.command = ["tailscale", "status", "--json"]
+      statusProcess.launchCycle = cycle
       statusProcess.running = true
       launched = true
     }
@@ -172,6 +179,7 @@ Item {
       _mullvadExitNodesOutput = ""
       _mullvadExitNodesError = ""
       mullvadExitNodesProcess.command = ["tailscale", "exit-node", "list"]
+      mullvadExitNodesProcess.launchCycle = cycle
       mullvadExitNodesProcess.running = true
       launched = true
     }
@@ -182,20 +190,31 @@ Item {
       _accountsError = ""
       _lastAccountsRefreshMs = now
       accountsProcess.command = ["tailscale", "switch", "--list", "--json"]
+      accountsProcess.launchCycle = cycle
       accountsProcess.running = true
       launched = true
     }
+    if (launched) lastLaunchCycle = cycle
     // Arm on the launch that needs watching and leave it alone after that.
     // Restarting it every refresh pushes the deadline out ahead of a hung
     // process forever once the refresh interval is shorter than the timeout,
-    // and refreshIntervalSec goes down to five seconds. Once this cycle's
-    // polls exit, settlePollWatchdog stands it down so its fire can only ever
-    // land on a poll of its own launch cycle that exceeded the timeout.
-    if (launched && !pollWatchdog.running) pollWatchdog.start()
+    // and refreshIntervalSec goes down to five seconds. Once every launch of
+    // the armed cycle has exited, settlePollWatchdog stands it down — cycles
+    // overlap, so membership is tracked per launch (launchCycle), not per
+    // instant — and its fire can only ever land on a poll of its own cycle
+    // that exceeded the timeout.
+    if (launched && !pollWatchdog.running) {
+      armedCycle = cycle
+      pollWatchdog.start()
+    }
   }
 
   function settlePollWatchdog() {
-    if (Model.allPollsSettled(statusProcess.running, mullvadExitNodesProcess.running, accountsProcess.running)) pollWatchdog.stop()
+    var settled = Model.allPollsSettled(armedCycle,
+      statusProcess.running, statusProcess.launchCycle,
+      mullvadExitNodesProcess.running, mullvadExitNodesProcess.launchCycle,
+      accountsProcess.running, accountsProcess.launchCycle)
+    if (settled) pollWatchdog.stop()
   }
 
   function elideStatus(text) {
@@ -480,6 +499,7 @@ Item {
     id: statusProcess
     running: false
     command: []
+    property int launchCycle: 0
     stdout: StdioCollector { id: statusStdout; waitForEnd: true; onStreamFinished: root._statusOutput = text }
     stderr: StdioCollector { id: statusStderr; waitForEnd: true; onStreamFinished: root._statusError = text }
     onExited: function(exitCode) {
@@ -499,6 +519,7 @@ Item {
     id: accountsProcess
     running: false
     command: []
+    property int launchCycle: 0
     stdout: StdioCollector { id: accountsStdout; waitForEnd: true; onStreamFinished: root._accountsOutput = text }
     stderr: StdioCollector { id: accountsStderr; waitForEnd: true; onStreamFinished: root._accountsError = text }
     onExited: function(exitCode) {
@@ -522,6 +543,7 @@ Item {
     id: mullvadExitNodesProcess
     running: false
     command: []
+    property int launchCycle: 0
     stdout: StdioCollector { id: mullvadExitNodesStdout; waitForEnd: true; onStreamFinished: root._mullvadExitNodesOutput = text }
     stderr: StdioCollector { id: mullvadExitNodesStderr; waitForEnd: true; onStreamFinished: root._mullvadExitNodesError = text }
     onExited: function(exitCode) {

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -208,22 +208,25 @@ assertDeepEqual(
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')
 
-assert(tailscale.allPollsSettled(false, false, false), 'tailscale stands the poll watchdog down once every guarded poll has exited')
-assert(!tailscale.allPollsSettled(true, false, false), 'tailscale keeps the poll watchdog armed while a status poll is in flight')
-assert(!tailscale.allPollsSettled(false, true, false), 'tailscale keeps the poll watchdog armed while an exit-node poll is in flight')
-assert(!tailscale.allPollsSettled(false, false, true), 'tailscale keeps the poll watchdog armed while an accounts poll is in flight')
+assert(tailscale.allPollsSettled(1, false, 0, false, 0, false, 0), 'tailscale stands the poll watchdog down once its launch cycle has fully exited')
+assert(!tailscale.allPollsSettled(1, true, 1, false, 0, false, 0), 'tailscale keeps the poll watchdog armed while its own status launch is in flight')
+assert(!tailscale.allPollsSettled(1, false, 0, true, 1, false, 0), 'tailscale keeps the poll watchdog armed while its own exit-node launch is in flight')
+assert(!tailscale.allPollsSettled(1, false, 0, false, 0, true, 1), 'tailscale keeps the poll watchdog armed while its own accounts launch is in flight')
+assert(tailscale.allPollsSettled(1, true, 2, false, 0, true, 2), 'tailscale stands the poll watchdog down when only newer-cycle relaunches remain in flight')
+assert(!tailscale.allPollsSettled(2, true, 2, false, 0, false, 0), 'tailscale keeps the watchdog of its own cycle armed across overlapping older cycles')
 
 const serviceSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Service.qml', 'utf8')
 
 assert(
-  /if \(launched && !pollWatchdog\.running\) pollWatchdog\.start\(\)/.test(serviceSource),
-  'tailscale arms the poll watchdog once per launch cycle'
+  /if \(launched && !pollWatchdog\.running\) \{\n      armedCycle = cycle\n      pollWatchdog\.start\(\)\n    \}/.test(serviceSource),
+  'tailscale arms the poll watchdog once per launch cycle and records the armed cycle'
 )
 
 function guardedProcessStandsDown(processId) {
   var blocks = serviceSource.split('  Process {')
   var block = blocks.find(function(candidate) { return candidate.indexOf('id: ' + processId) !== -1 })
-  return !!block && /onExited[\s\S]*?settlePollWatchdog\(\)/.test(block)
+  if (!block) return false
+  return /property int launchCycle: 0/.test(block) && /onExited[\s\S]*?settlePollWatchdog\(\)/.test(block)
 }
 
 assert(guardedProcessStandsDown('statusProcess'), 'tailscale stands the poll watchdog down when the status poll exits')

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -207,4 +207,26 @@ assertDeepEqual(
 
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')
+
+assert(tailscale.allPollsSettled(false, false, false), 'tailscale stands the poll watchdog down once every guarded poll has exited')
+assert(!tailscale.allPollsSettled(true, false, false), 'tailscale keeps the poll watchdog armed while a status poll is in flight')
+assert(!tailscale.allPollsSettled(false, true, false), 'tailscale keeps the poll watchdog armed while an exit-node poll is in flight')
+assert(!tailscale.allPollsSettled(false, false, true), 'tailscale keeps the poll watchdog armed while an accounts poll is in flight')
+
+const serviceSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Service.qml', 'utf8')
+
+assert(
+  /if \(launched && !pollWatchdog\.running\) pollWatchdog\.start\(\)/.test(serviceSource),
+  'tailscale arms the poll watchdog once per launch cycle'
+)
+
+function guardedProcessStandsDown(processId) {
+  var blocks = serviceSource.split('  Process {')
+  var block = blocks.find(function(candidate) { return candidate.indexOf('id: ' + processId) !== -1 })
+  return !!block && /onExited[\s\S]*?settlePollWatchdog\(\)/.test(block)
+}
+
+assert(guardedProcessStandsDown('statusProcess'), 'tailscale stands the poll watchdog down when the status poll exits')
+assert(guardedProcessStandsDown('mullvadExitNodesProcess'), 'tailscale stands the poll watchdog down when the exit-node poll exits')
+assert(guardedProcessStandsDown('accountsProcess'), 'tailscale stands the poll watchdog down when the accounts poll exits')
 JS


### PR DESCRIPTION
## Problem

`pollWatchdog` arms when a poll launches but is never stood down when the polls finish, so its unconditional 15s fire kills whatever healthy status, exit-node, or accounts process a *later* refresh has in flight. On tailnets where responses don't reliably beat the deadline, the panel flaps to TAILSCALE IS DISCONNECTED forever while the tailnet is fine.

Fixes #7774.

## Reproduction (Quickshell 0.3.0, unmodified plugin, stubbed binary)

Two failure modes, both reproduced live before/after:

1. **Stale deadline into a later cycle** — status answers after 9s, exit-node after 12s, `refreshIntervalSec=5`: the t=10 relaunch of status (healthy, 5s in) is killed at t=15 by a watchdog armed back at t=0. Cycles overlap, so no settle-instant ever occurs.
2. **Slow-tailnet flapping** — all commands answer healthy at 18s: every poll dies at its cycle's fire time and the panel never converges.

| | before | after |
|---|---|---|
| scenario 1 (staggered) | Disconnected at t=15.5, recovers t≈19, killed again next cycle | Connected throughout |
| scenario 2 (18s polls) | perpetual flap (by-design timeout; see note below) | unchanged by design |

## Change (+77/−3 across 3 files)

- `Model.js` — `allPollsSettled(armedCycle, …)`: the stand-down decision per launch cycle, unit-tested including the overlap case.
- `Service.qml` — each launch records its cycle (`launchCycle`); the watchdog remembers the cycle it armed for and stands down when every launch of that cycle has exited, so newer-cycle relaunches can't keep an older deadline alive. Comments state the contract.
- `test/shell.d/tailscale-test.sh` — truth-table unit tests (own-cycle in flight vs newer-cycle relaunches); source assertions that all three guarded processes stamp their cycle and settle the watchdog on exit.

Arming deliberately stays once per launch cycle: restarting per launch lets refresh intervals below the timeout push the deadline out forever, so a genuinely hung poll would never be reaped. Cycle-scoped settle keeps that property while making the fire only ever apply to its own cycle's launches.

## Test plan

- `./test/shell.d/tailscale-test.sh`: 51/51.
- Full `./test/shell`: same pass/fail set as clean `quattro` (four unrelated, pre-existing, environment-dependent failures reproduce identically on both trees).

## Note for the maintainer

A single poll slower than 15s is still reaped — by design, since at this layer hung and slow are indistinguishable without progress signals. For very large tailnets (the 4.6 MB `status --json` premise of #7623), the fixed threshold itself may deserve a second look; kept out of this PR to stay one concern.

Credit: Copilot's review supplied the staggered-overlap counterexample that shaped the cycle tracking.
