### PR TITLE
Add media label scroll settings

### DIFF
--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -57,7 +57,7 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.menu` | Omarchy menu launcher | left = menu · right = terminal |
 | `omarchy.workspaces` | Hyprland workspace switcher | left = focus workspace |
 | `omarchy.clock` | Date/time label + popup with a month grid, ISO week numbers, and month stepping | left = popup · right = cycle label format · middle = timezone selector |
-| `omarchy.media` | MPRIS now-playing — scrolling track + artist, cover-art popup | left = play/pause · middle = next · scroll = prev/next · right = popup |
+| `omarchy.media` | MPRIS now-playing — track + artist, cover-art popup | left = play/pause · middle = next · scroll = prev/next · right = popup |
 | `omarchy.indicators` | Manual state indicators | left = indicator action |
 | `omarchy.system-update` | Available update indicator | left = update |
 | `omarchy.tray` | System tray | hover = reveal drawer · right on chevron = manage |
@@ -73,6 +73,12 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.monitor` | Brightness and laptop display controls | left = popup |
 
 The `omarchy.indicators` widget loads individual bar indicators from `indicators/`. Omit `items` (or set it to an empty array) to show all indicators in the default order, or set `items` to a subset such as `["Dnd", "Reminder", "NightLight"]`. Set `alwaysShow` to `true` to keep inactive indicators visible instead of revealing them only on hover. Multiple `omarchy.indicators` instances are allowed, so different sections can show different subsets.
+
+The `omarchy.media` widget scrolls long track labels by default. Set `scrollLabel` to `false` to keep the label static, and `maxLabelWidth` to a positive pixel value to set its maximum width:
+
+```json
+{ "id": "omarchy.media", "scrollLabel": false, "maxLabelWidth": 110 }
+```
 
 ## Orientation
 

--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -60,8 +60,8 @@ BarWidget {
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
         anchors.verticalCenter: parent.verticalCenter
-        width: scrollClip.width
-        elide: Text.ElideRight
+        width: root.scrollLabel ? implicitWidth : scrollClip.width
+        elide: root.scrollLabel ? Text.ElideNone : Text.ElideRight
 
         property bool needsScroll: implicitWidth > scrollClip.width
 

--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -15,11 +15,13 @@ BarWidget {
   readonly property string playIcon: activePlayer && activePlayer.isPlaying ? "󰏤" : "󰐊"
   readonly property string title: activePlayer ? (activePlayer.trackTitle || "") : ""
   readonly property string artist: activePlayer ? (activePlayer.trackArtist || "") : ""
+  readonly property bool scrollLabel: setting("scrollLabel", true) !== false
+  readonly property real maxLabelWidth: Number(setting("maxLabelWidth", 180)) > 0
+    ? Number(setting("maxLabelWidth", 180)) : 180
 
   property bool popupOpen: false
 
   function close() { popupOpen = false }
-  property real maxLabelWidth: 180
 
   visible: hasMedia
   implicitWidth: hasMedia ? row.implicitWidth + Style.space(14) : 0
@@ -58,12 +60,14 @@ BarWidget {
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
         anchors.verticalCenter: parent.verticalCenter
+        width: scrollClip.width
+        elide: Text.ElideRight
 
         property bool needsScroll: implicitWidth > scrollClip.width
 
         NumberAnimation on x {
           id: scrollAnim
-          running: labelText.needsScroll && !root.popupOpen && !root.bar.vertical
+          running: root.scrollLabel && labelText.needsScroll && !root.popupOpen && !root.bar.vertical
           loops: Animation.Infinite
           duration: Math.max(6000, labelText.implicitWidth * 25)
           from: scrollClip.width

--- a/test/shell.d/media-test.sh
+++ b/test/shell.d/media-test.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const media = requireFromRoot('shell/plugins/services/media/MediaModel.js')
+const widgetSource = fs.readFileSync(root + '/shell/plugins/services/media/BarWidget.qml', 'utf8')
+  .replace(/^\s*\/\/.*$/gm, '')
 
 assert(media.isProxyPlayer({ dbusName: 'org.mpris.MediaPlayer2.playerctld' }), 'media detects playerctld proxy by DBus name')
 assert(media.isProxyPlayer({ desktopEntry: 'playerctld' }), 'media detects playerctld proxy by desktop entry')
@@ -40,4 +43,10 @@ assert(media.trackChanged(trackSignature, { ...track, trackTitle: 'Next song' })
 assertEqual(media.labelFor({ trackTitle: 'Song', identity: 'Spotify' }), 'Song', 'media labels players by track first')
 assertEqual(media.osdMessage({ trackTitle: 'Song', trackArtist: 'Artist' }, 'Fallback'), 'Song - Artist', 'media builds OSD messages')
 assertEqual(media.osdMessage(null, 'Fallback'), 'Fallback', 'media falls back OSD messages')
+
+assert(widgetSource.includes('setting("scrollLabel", true) !== false'), 'media scrolls labels unless explicitly disabled')
+assert(widgetSource.includes('Number(setting("maxLabelWidth", 180)) > 0'), 'media accepts positive configured label widths')
+assert(widgetSource.includes('width: scrollClip.width'), 'media constrains static labels to the scroll clip width')
+assert(widgetSource.includes('elide: Text.ElideRight'), 'media elides labels that do not fit')
+assert(widgetSource.includes('running: root.scrollLabel && labelText.needsScroll'), 'media only animates labels when scrolling is enabled')
 JS

--- a/test/shell.d/media-test.sh
+++ b/test/shell.d/media-test.sh
@@ -46,7 +46,7 @@ assertEqual(media.osdMessage(null, 'Fallback'), 'Fallback', 'media falls back OS
 
 assert(widgetSource.includes('setting("scrollLabel", true) !== false'), 'media scrolls labels unless explicitly disabled')
 assert(widgetSource.includes('Number(setting("maxLabelWidth", 180)) > 0'), 'media accepts positive configured label widths')
-assert(widgetSource.includes('width: scrollClip.width'), 'media constrains static labels to the scroll clip width')
-assert(widgetSource.includes('elide: Text.ElideRight'), 'media elides labels that do not fit')
+assert(widgetSource.includes('width: root.scrollLabel ? implicitWidth : scrollClip.width'), 'media constrains only static labels to the scroll clip width')
+assert(widgetSource.includes('elide: root.scrollLabel ? Text.ElideNone : Text.ElideRight'), 'media elides only static labels that do not fit')
 assert(widgetSource.includes('running: root.scrollLabel && labelText.needsScroll'), 'media only animates labels when scrolling is enabled')
 JS


### PR DESCRIPTION
Adds optional inline settings for the media bar widget.

- scrollLabel: false disables marquee scrolling while keeping the default enabled
- maxLabelWidth accepts a positive pixel width and defaults to 180
- Static labels use right elision without changing the marquee measurement

Documents the settings and adds focused media widget coverage.

Tested: bash test/shell.d/media-test.sh