### PR TITLE
Set an explicit lazygit editor preset to avoid vim fallback

### DIFF
--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,0 +1,6 @@
+# Default lazygit editor preset. Kept in sync with the Omarchy default editor
+# by omarchy-default-editor; see https://github.com/jesseduffield/lazygit —
+# lazygit cannot parse Omarchy's EDITOR wrapper, so an explicit preset is
+# required to avoid falling back to vim.
+os:
+  editPreset: nvim

--- a/migrations/1787422694.sh
+++ b/migrations/1787422694.sh
@@ -1,69 +1,18 @@
-#!/bin/bash
+echo "Set the lazygit editor to match the Omarchy default editor"
 
-# omarchy:summary=Set the default editor used by omarchy-launch-editor
-# omarchy:args=[code|cursor|zed|sublime_text|helix|vim|emacs|nvim]
-# omarchy:examples=omarchy default editor | omarchy default editor code | omarchy default editor helix
-
-installing=false
-if [[ ${1:-} == "--install" ]]; then
-  installing=true
-  shift
+editor="nvim"
+if [[ -f "$HOME/.local/state/omarchy/defaults/editor" ]]; then
+  read -r editor <"$HOME/.local/state/omarchy/defaults/editor" || editor="nvim"
 fi
 
-editor_file="$HOME/.local/state/omarchy/defaults/editor"
-
-if (($# == 0)); then
-  if [[ -f $editor_file ]]; then
-    read -r editor <"$editor_file"
-  fi
-
-  [[ -n $editor ]] && echo "$editor" || echo "nvim"
-  exit 0
-fi
-
-case "$1" in
-code) selection="code"; editor="code"; name="VSCode"; glyph= ;;
-cursor) selection="cursor"; editor="cursor"; name="Cursor"; glyph= ;;
-zed | zeditor) selection="zed"; editor="zeditor"; name="Zed"; glyph= ;;
-sublime_text) selection="sublime_text"; editor="sublime_text"; name="Sublime Text"; glyph= ;;
-helix) selection="helix"; editor="helix"; name="Helix"; glyph= ;;
-vim) selection="vim"; editor="vim"; name="Vim"; glyph= ;;
-emacs) selection="emacs"; editor="emacs"; name="Emacs"; glyph= ;;
-nvim) selection="nvim"; editor="nvim"; name="Neovim"; glyph= ;;
-*)
-  echo "Usage: omarchy-default-editor <code|cursor|zed|sublime_text|helix|vim|emacs|nvim>"
-  exit 1
-  ;;
-esac
-
-if omarchy-cmd-missing "$editor"; then
-  if [[ $installing == "false" ]]; then
-    exec omarchy-launch-floating-terminal-with-presentation omarchy-default-editor --install "$selection"
-  else
-    case "$selection" in
-    code) omarchy-install-editor-vscode ;;
-    cursor) omarchy-pkg-add cursor-bin ;;
-    zed) omarchy-install-editor-zed ;;
-    sublime_text) omarchy-pkg-add sublime-text-4 ;;
-    helix) omarchy-install-editor-helix ;;
-    vim) omarchy-pkg-add vim ;;
-    emacs) omarchy-install-editor-emacs ;;
-    nvim) omarchy-pkg-add neovim ;;
-    esac || exit 1
-  fi
-fi
-
-# Keep lazygit's editor preset in sync. lazygit only recognizes known editor
-# names from $EDITOR (first word), so Omarchy's omarchy-launch-editor wrapper
-# is invisible to it and it falls back to vim otherwise.
-lg_config="$HOME/.config/lazygit/config.yml"
+config="$HOME/.config/lazygit/config.yml"
 
 # Only keys directly inside the top-level os mapping may be touched; lazygit
 # configs nest same-named keys elsewhere (e.g. keybinding.universal.edit) and
 # whole-document matches would corrupt them. The os block's own indentation is
 # discovered from the document instead of assumed, so four-space configs stay
 # consistent.
-os_present=n
+os_present=0
 os_child="  " # indentation used by the os block's children
 preset_indent="" # set when the block already carries an editPreset child
 
@@ -84,33 +33,12 @@ scan_os_block() {
       if (preset == "" && indent == child && substr($0, RLENGTH + 1) ~ /^editPreset:/) preset = indent
     }
     END { print (os_seen ? "y" : "n") "|" child "|" preset }
-  ' "$lg_config")
+  ' "$config")
   os_present=${raw%%|*}
   raw=${raw#*|}
   os_child=${raw%%|*}
   preset_indent=${raw#*|}
   [[ -n $os_child ]] || os_child="  "
-}
-
-write_preset() {
-  local value="$1" lg_payload=""
-
-  # Only a bare block header (optionally commented) may take an appended
-  # child. Unnormalizable flow mappings, scalars, and sequences stay exactly
-  # as the user wrote them.
-  lg_payload=$(grep -m1 "^os:" "$lg_config" 2> /dev/null) || lg_payload=""
-  lg_payload=$(sed -n "s/^os:[[:space:]]*//p" <<<"$lg_payload")
-  case $lg_payload in
-  "" | "#"*) ;;
-  *) return 0 ;;
-  esac
-
-  mkdir -p "$(dirname "$lg_config")"
-  if [[ $os_present == "y" ]]; then
-    sed -i "/^os:/a\\${os_child}editPreset: $value" "$lg_config"
-  else
-    printf "\nos:\n%seditPreset: %s\n" "$os_child" "$value" >>"$lg_config"
-  fi
 }
 
 # Rewrite a one-line flow-style os mapping (os: {a: b, c: d}) into block style
@@ -124,20 +52,20 @@ replace_os_line() {
   if awk -v flow="$old" -v block="$new"$'\n' '
     $0 == flow { printf "%s", block; next }
     { print }
-  ' "$lg_config" >"$lg_config.tmp"; then
+  ' "$config" >"$config.tmp"; then
     # The redirect creates the temp file from the umask, so restoring the
     # original mode keeps e.g. a private 0600 config private after the swap.
-    chmod --reference="$lg_config" "$lg_config.tmp"
-    mv "$lg_config.tmp" "$lg_config"
+    chmod --reference="$config" "$config.tmp"
+    mv "$config.tmp" "$config"
   else
-    rm -f "$lg_config.tmp"
+    rm -f "$config.tmp"
   fi
 }
 
 normalize_os_mapping() {
   local line inner pair block="" comment="" parts
 
-  line=$(grep -m1 "^os:[[:space:]]*{" "$lg_config" 2> /dev/null) || return 0
+  line=$(grep -m1 "^os:[[:space:]]*{" "$config" 2> /dev/null) || return 0
   # Capture the members AND the trailing YAML comment separately: the comment
   # is user-authored content and must ride onto the rebuilt os: header. Each
   # segment is wrapped in brackets so a matched-but-empty piece differs from a
@@ -173,7 +101,7 @@ normalize_os_mapping() {
 normalize_null_os_mapping() {
   local line payload token comment=""
 
-  line=$(grep -m1 -E "^os:[[:space:]]*([nN][uU][lL][lL]|~)([[:space:]]+#.*)?$" "$lg_config") || return 0
+  line=$(grep -m1 -E "^os:[[:space:]]*([nN][uU][lL][lL]|~)([[:space:]]+#.*)?$" "$config") || return 0
   payload=$(sed -n "s/^os:[[:space:]]*//p" <<<"$line")
   token=${payload%%[[:space:]]*}
   case $token in
@@ -192,7 +120,28 @@ normalize_null_os_mapping() {
   replace_os_line "$line" "$os_header"
 }
 
-if [[ -f $lg_config ]] && grep -q "^os:" "$lg_config"; then
+write_preset() {
+  local value="$1" payload=""
+
+  # Only a bare block header (optionally commented) may take an appended
+  # child. Unnormalizable flow mappings, scalars, and sequences stay exactly
+  # as the user wrote them.
+  payload=$(grep -m1 "^os:" "$config" 2> /dev/null) || payload=""
+  payload=$(sed -n "s/^os:[[:space:]]*//p" <<<"$payload")
+  case $payload in
+  "" | "#"*) ;;
+  *) return 0 ;;
+  esac
+
+  mkdir -p "$(dirname "$config")"
+  if [[ $os_present == "y" ]]; then
+    sed -i "/^os:/a\\${os_child}editPreset: $value" "$config"
+  else
+    printf "\nos:\n%seditPreset: %s\n" "$os_child" "$value" >>"$config"
+  fi
+}
+
+if [[ -f $config ]] && grep -q "^os:" "$config"; then
   normalize_os_mapping
   normalize_null_os_mapping
   scan_os_block
@@ -234,13 +183,13 @@ swap_os_preset() {
       next
     }
     { print }
-  ' "$lg_config" >"$lg_config.tmp"; then
+  ' "$config" >"$config.tmp"; then
     # The redirect creates the temp file from the umask, so restoring the
     # original mode keeps e.g. a private 0600 config private after the swap.
-    chmod --reference="$lg_config" "$lg_config.tmp"
-    mv "$lg_config.tmp" "$lg_config"
+    chmod --reference="$config" "$config.tmp"
+    mv "$config.tmp" "$config"
   else
-    rm -f "$lg_config.tmp"
+    rm -f "$config.tmp"
   fi
 }
 
@@ -253,8 +202,3 @@ if [[ -n $preset ]]; then
 elif [[ -z $preset_indent ]]; then
   write_preset nvim
 fi
-
-mkdir -p "$(dirname "$editor_file")"
-printf '%s\n' "$editor" >"$editor_file"
-
-omarchy-notification-send -g $glyph "$name is now the default editor"

--- a/test/shell.d/lazygit-editor-migration-test.sh
+++ b/test/shell.d/lazygit-editor-migration-test.sh
@@ -1,0 +1,374 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command sha256sum
+require_command stat
+
+migration="$ROOT/migrations/1787422694.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+config="$home/.config/lazygit/config.yml"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+set_editor() {
+  mkdir -p "$home/.local/state/omarchy/defaults"
+  printf '%s\n' "$1" >"$home/.local/state/omarchy/defaults/editor"
+}
+
+assert_line() {
+  local key="$1" value="$2" indent="${3:-  }"
+
+  grep -q "^${indent}${key}: ${value}\$" "$config" ||
+    fail "config sets $indent$key: $2" "$(cat "$config")"
+  pass "config sets $indent$key: $2"
+}
+
+# A user config that nests keys sharing names with the ones this migration
+# manages; whole-document rewrites would corrupt these.
+write_user_config() {
+  mkdir -p "$home/.config/lazygit"
+  cat >"$config" <<'YAML'
+gui:
+  showRandomTip: false
+keybinding:
+  universal:
+    edit: v
+os:
+  suspendOnEdit: true
+YAML
+}
+
+assert_user_config_intact() {
+  grep -q '^gui:' "$config" || fail "keeps unrelated top-level keys" "$(cat "$config")"
+  grep -q '^    edit: v$' "$config" || fail "keeps the nested keybinding edit" "$(cat "$config")"
+  assert_line suspendOnEdit true
+}
+
+# No config at all and no saved editor: defaults to nvim.
+run_migration
+
+assert_line editPreset nvim
+pass "migration creates the config when it is absent"
+
+# Existing installs ship an empty config file.
+mkdir -p "$home/.config/lazygit"
+: >"$config"
+run_migration
+
+assert_line editPreset nvim
+pass "migration fills in an empty config"
+
+# An empty saved editor falls back to nvim instead of aborting.
+mkdir -p "$home/.local/state/omarchy/defaults"
+: >"$home/.local/state/omarchy/defaults/editor"
+run_migration
+
+assert_line editPreset nvim
+pass "an empty saved editor falls back to nvim"
+rm -f "$home/.local/state/omarchy/defaults/editor"
+
+# An os block without an editPreset gets one; nested and sibling keys survive.
+write_user_config
+run_migration
+
+assert_line editPreset nvim
+assert_user_config_intact
+pass "migration inserts into an existing os block"
+
+# A stale preset is replaced without touching the rest of the document.
+write_user_config
+printf '\n' >>"$config"
+sed -i '/^os:/a\  editPreset: vim' "$config"
+run_migration
+
+assert_line editPreset nvim
+assert_user_config_intact
+pass "migration replaces a stale preset"
+
+# Editor mappings.
+for pair in \
+  "code vscode" \
+  "helix helix" \
+  "vim vim" \
+  "emacs emacs" \
+  "zed zed" \
+  "zeditor zed" \
+  "sublime_text sublime"; do
+  read -r editor preset <<<"$pair"
+  set_editor "$editor"
+  run_migration
+
+  assert_line editPreset "$preset"
+done
+pass "migration maps every preset editor"
+
+# Cursor has no lazygit preset: an absent choice is seeded with nvim so
+# lazygit stops falling back to vim, and the document is left otherwise whole.
+set_editor cursor
+write_user_config
+run_migration
+
+assert_line editPreset nvim
+assert_user_config_intact
+pass "cursor seeds nvim when no preset is set"
+
+# An explicit choice is kept even when the saved editor has no preset.
+set_editor cursor
+write_user_config
+printf '' >>"$config"
+sed -i '/^os:/a\  editPreset: emacs' "$config"
+run_migration
+
+assert_line editPreset emacs
+assert_user_config_intact
+pass "cursor keeps an explicit preset"
+
+# A one-line flow-style os mapping is normalized to block style before a child
+# is inserted beneath it, with or without a trailing YAML comment.
+set_editor nvim
+mkdir -p "$home/.config/lazygit"
+cat >"$config" <<'YAML'
+keybinding:
+  universal:
+    edit: v
+os: {suspendOnEdit: true} # tui
+YAML
+run_migration
+
+assert_line editPreset nvim
+assert_line suspendOnEdit true
+grep -q '^os: # tui$' "$config" ||
+  fail "keeps the trailing comment on the os header" "$(cat "$config")"
+grep -q '^os: {' "$config" && fail "rewrites the flow-style os mapping" "$(cat "$config")"
+pass "migration rewrites a flow-style os mapping to block style"
+
+# A preset hidden inside a flow mapping is replaced, not duplicated, even when
+# the line carries a trailing comment.
+set_editor code
+cat >"$config" <<'YAML'
+os: {editPreset: emacs} # keep this
+YAML
+run_migration
+
+assert_line editPreset vscode
+grep -q '^os: # keep this$' "$config" ||
+  fail "keeps the comment on the rewritten header" "$(cat "$config")"
+(($(grep -c 'editPreset:' "$config") == 1)) || fail "keeps a single editPreset" "$(cat "$config")"
+pass "migration replaces a preset inside a flow-style mapping"
+
+# An inline comment on an existing block-style preset survives the replace,
+# including sed metacharacters, and a decoy editPreset in another section is
+# neither rewritten nor used as the comment source.
+set_editor helix
+mkdir -p "$home/.config/lazygit"
+cat >"$config" <<'YAML'
+gui:
+  editPreset: decoy # gui note
+os:
+  suspendOnEdit: true
+  editPreset: vim # a & b | c \ d
+YAML
+run_migration
+
+grep -q '^  editPreset: decoy # gui note$' "$config" ||
+  fail "leaves another section's editPreset alone" "$(cat "$config")"
+grep -qxF "  editPreset: helix # a & b | c \\ d" "$config" ||
+  fail "keeps the inline comment when replacing the preset" "$(cat "$config")"
+(($(grep -c 'editPreset:' "$config") == 2)) || fail "touches only the os child" "$(cat "$config")"
+pass "migration keeps the inline comment when replacing the preset"
+
+# A saved editor without a lazygit preset must not wipe flow members either.
+set_editor cursor
+cat >"$config" <<'YAML'
+os: {editPreset: emacs} # mine
+YAML
+run_migration
+
+assert_line editPreset emacs
+grep -q '^os: # mine$' "$config" ||
+  fail "keeps the comment on the untouched flow mapping" "$(cat "$config")"
+(($(grep -c 'editPreset:' "$config") == 1)) || fail "keeps the explicit preset" "$(cat "$config")"
+pass "cursor keeps an explicit preset inside a flow-style mapping"
+
+# An empty flow mapping still gains a block child.
+set_editor code
+cat >"$config" <<'YAML'
+os: {}
+YAML
+run_migration
+
+assert_line editPreset vscode
+pass "migration handles an empty flow-style os mapping"
+
+# Exotic flow payloads (nested braces) are left untouched instead of being
+# rewritten incorrectly.
+cat >"$config" <<'YAML'
+os: {themeOverride: {light: x}, suspendOnEdit: true}
+YAML
+run_migration
+
+grep -q '^os: {themeOverride' "$config" ||
+  fail "leaves nested-flow mappings untouched" "$(cat "$config")"
+if grep -q '  editPreset:' "$config"; then
+  fail "does not insert under a nested-flow mapping" "$(cat "$config")"
+fi
+pass "migration leaves nested-flow mappings untouched"
+
+# Unterminated or bracket-carrying payloads are also left alone.
+for payload in '{oops' '{list: [a, b]}'; do
+  printf 'os: %s\n' "$payload" >"$config"
+  run_migration
+
+  [[ $(cat "$config") == "os: $payload" ]] ||
+    fail "leaves os: $payload untouched" "$(cat "$config")"
+  if grep -q '  editPreset:' "$config"; then
+    fail "does not insert under os: $payload" "$(cat "$config")"
+  fi
+done
+pass "migration leaves malformed and bracketed payloads untouched"
+
+# A private config keeps its mode after normalization, whatever the umask.
+set_editor nvim
+cat >"$config" <<'YAML'
+os: {suspendOnEdit: true}
+YAML
+chmod 600 "$config"
+(umask 000; run_migration)
+
+assert_line suspendOnEdit true
+[[ $(stat -c %a "$config") == 600 ]] ||
+  fail "normalization preserves the config mode" "$(stat -c %a "$config") $(cat "$config")"
+pass "normalization preserves the config mode"
+
+# Four-space configs keep their own indentation for both replace and insert.
+set_editor code
+mkdir -p "$home/.config/lazygit"
+cat >"$config" <<'YAML'
+keybinding:
+    universal:
+        edit: v
+os:
+    suspendOnEdit: true
+    editPreset: emacs
+YAML
+run_migration
+
+assert_line editPreset vscode "    "
+assert_line suspendOnEdit true "    "
+(($(grep -c 'editPreset:' "$config") == 1)) || fail "keeps a single editPreset" "$(cat "$config")"
+pass "migration replaces inside a four-space os block"
+
+set_editor nvim
+cat >"$config" <<'YAML'
+os:
+    suspendOnEdit: true
+YAML
+run_migration
+
+assert_line editPreset nvim "    "
+assert_line suspendOnEdit true "    "
+pass "migration inserts using a four-space block's indentation"
+
+# An editPreset nested deeper than the os block's children is not the managed
+# key; it survives untouched while a fresh child is seeded at the child level.
+set_editor cursor
+mkdir -p "$home/.config/lazygit"
+cat >"$config" <<'YAML'
+os:
+  commands:
+      editPreset: emacs
+YAML
+run_migration
+
+assert_line editPreset nvim
+assert_line editPreset emacs "      "
+pass "deeper-nested editPreset keys are left alone"
+
+# Comments do not participate in indentation: an unindented comment inside the
+# os block neither ends it nor hides a later editPreset.
+set_editor code
+cat >"$config" <<'YAML'
+os:
+  suspendOnEdit: true
+# editor notes
+  editPreset: emacs
+YAML
+run_migration
+
+assert_line editPreset vscode
+grep -q '^# editor notes$' "$config" ||
+  fail "keeps the unindented comment" "$(cat "$config")"
+(($(grep -c 'editPreset:' "$config") == 1)) || fail "keeps a single editPreset" "$(cat "$config")"
+pass "unindented comments do not end the os block"
+
+# A leading indented comment does not define the child indentation.
+set_editor nvim
+mkdir -p "$home/.config/lazygit"
+cat >"$config" <<'YAML'
+os:
+    # tui notes
+    suspendOnEdit: true
+YAML
+run_migration
+
+assert_line editPreset nvim "    "
+grep -q '^    # tui notes$' "$config" ||
+  fail "keeps the leading indented comment" "$(cat "$config")"
+pass "leading comments do not set the child indentation"
+
+# A null os value carries no settings, so it becomes an empty mapping; a
+# trailing comment moves onto the header line.
+set_editor nvim
+mkdir -p "$home/.config/lazygit"
+cat >"$config" <<'YAML'
+keybinding:
+  universal:
+    edit: v
+os: null # disabled
+YAML
+run_migration
+
+assert_line editPreset nvim
+grep -q '^os: # disabled$' "$config" ||
+  fail "keeps the comment on the normalized null header" "$(cat "$config")"
+pass "migration normalizes a null os mapping"
+
+# Every YAML null spelling is supported.
+set_editor code
+for form in 'null' 'Null' 'NULL' '~'; do
+  printf 'os: %s\n' "$form" >"$config"
+  run_migration
+
+  assert_line editPreset vscode
+done
+pass "migration normalizes every null spelling"
+
+# Non-mapping values are not mappings; they stay byte-identical and gain no
+# child.
+set_editor cursor
+for payload in 'true' '42' '"text"' '[a, b]'; do
+  printf 'os: %s\n' "$payload" >"$config"
+  before=$(sha256sum "$config")
+  run_migration
+
+  [[ $before == $(sha256sum "$config") ]] ||
+    fail "leaves os: $payload untouched" "$(cat "$config")"
+  if grep -q 'editPreset' "$config"; then
+    fail "does not insert under os: $payload" "$(cat "$config")"
+  fi
+done
+pass "migration leaves non-mapping os values untouched"
+
+# Idempotence.
+before=$(sha256sum "$config")
+run_migration
+[[ $before == $(sha256sum "$config") ]] || fail "migration is idempotent" "$(cat "$config")"
+pass "migration is idempotent"


### PR DESCRIPTION
At the moment lazygit e to edit file is broken in a new Omarchy install, as it fails to parse omarchy-launch-editor so falls back to vim which is not installed. See: https://github.com/jesseduffield/lazygit/blob/ea916395469808d37d726ae183fa40fd575a9d8a/pkg/config/editor_presets.go#L55-L181

Firstly we set the default config to use nvim in lazygit and add a migration for that.

Then we add support so that modifying the default editor (e.g. to emacs), updates that lazygit config - **all of the complexity is here** - I think it is worth ensuring this still works nicely for emacs users, but if we want to keep things simple we could drop this and just stick to "lazygit uses neovim always".

----------------------------

lazygit only recognizes known editor names from $EDITOR (first word only), so Omarchy's omarchy-launch-editor wrapper is never matched and lazygit falls back to vim, which isn't installed. Ship os.editPreset: nvim as the default, keep it in sync when switching editors via omarchy-default-editor, and migrate existing installs off the empty config file.