### PR TITLE
Fix Codex limits with current approval policy

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,8 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+printf '%s\n' "$*" >"$HOME/codex-args"
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -42,6 +44,10 @@ EOF
 
 result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(<"$TEST_HOME/codex-args") == "-s read-only -a never app-server" ]] ||
+  fail "Codex collector starts app-server with a supported approval policy" "$(<"$TEST_HOME/codex-args")"
+pass "Codex collector starts app-server with a supported approval policy"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"


### PR DESCRIPTION
## Summary

- launch the Codex app-server with the supported `never` approval policy
- add regression coverage for the exact app-server arguments

Codex CLI 0.149.0 rejects the retired `untrusted` value before app-server initialization, which leaves the agents widget showing “Codex limits unavailable”.

## Testing

- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- `./test/all` *(Codex coverage passes; unrelated existing/environment-dependent failures: `a roomy window animates` and `omarchy-pkgs checkout is available for packaging coverage`)*