### PR TITLE
Finish superseded menu-select requests so their waiters exit

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -68,6 +68,16 @@ Item {
   property bool cursorActive: false
   property int requestSerial: 0
   property int applySerial: 0
+  // Completion writes share one Process, so they queue: a supersede can land
+  // while the previous write is still spawning, and reassigning a running
+  // Process would silently drop its command.
+  property var pendingDoneWrites: []
+
+  function runNextDoneWrite() {
+    if (resultProc.running || root.pendingDoneWrites.length === 0) return
+    resultProc.command = root.pendingDoneWrites.shift()
+    resultProc.running = true
+  }
   property var items: ({})
   property var itemOrder: []
   property var navStack: []
@@ -127,11 +137,11 @@ Item {
     root.doneFile = ""
 
     if (selection === null || selection === undefined) {
-      resultProc.command = ["bash", "-c", ": > " + Util.shellQuote(activeDoneFile)]
+      root.pendingDoneWrites.push(["bash", "-c", ": > " + Util.shellQuote(activeDoneFile)])
     } else {
-      resultProc.command = ["bash", "-c", "printf '%s\\n' " + Util.shellQuote(selection) + " > " + Util.shellQuote(activeSelectionFile) + "; : > " + Util.shellQuote(activeDoneFile)]
+      root.pendingDoneWrites.push(["bash", "-c", "printf '%s\\n' " + Util.shellQuote(selection) + " > " + Util.shellQuote(activeSelectionFile) + "; : > " + Util.shellQuote(activeDoneFile)])
     }
-    resultProc.running = true
+    root.runNextDoneWrite()
   }
 
   function runAction(action) {
@@ -948,6 +958,7 @@ Item {
   Process {
     id: resultProc
     onExited: {
+      root.runNextDoneWrite()
       if (root.applySerial === root.requestSerial)
         root.opened = false
     }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -835,6 +835,9 @@ Item {
   }
 
   function openExistingMenu(initialMenu) {
+    // Taking the surface over must not drop a live select/input request:
+    // its waiter polls the done file forever once these handles are cleared.
+    root.finishRequest(null)
     requestSerial += 1
     mode = "menu"
     requestActive = false
@@ -859,6 +862,9 @@ Item {
   }
 
   function openDmenu(payload) {
+    // Same contract as openExistingMenu: a request displaced by a newer one
+    // still gets its done file written, or the waiting script never exits.
+    root.finishRequest(null)
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))

--- a/test/shell.d/fixtures/menu-select-supersede/shell.qml
+++ b/test/shell.d/fixtures/menu-select-supersede/shell.qml
@@ -1,0 +1,115 @@
+import QtQuick
+import Quickshell
+
+// Drives the REAL shell/plugins/menu/Menu.qml through the two supersede paths
+// that strand a waiting omarchy-menu-select: opening the regular menu over an
+// active select request, and opening a new select request over another one.
+// The bash runner asserts afterwards that every displaced request had its done
+// file written, which is what lets the waiting script exit.
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string scratchDir: Quickshell.env("OMARCHY_MENU_TMP")
+  property var menu: null
+  property var failures: []
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures
+    })
+
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  function selectPayload(prompt, name) {
+    return JSON.stringify({
+      mode: "select",
+      prompt: prompt,
+      options: ["alpha", "bravo"],
+      selectionFile: scratchDir + "/sel-" + name,
+      doneFile: scratchDir + "/done-" + name
+    })
+  }
+
+  Timer {
+    id: driver
+    interval: 100
+    repeat: true
+    running: true
+    property int tick: 0
+
+    onTriggered: {
+      try {
+        tick += 1
+
+        if (tick === 1) {
+          var component = Qt.createComponent("file://" + Quickshell.env("OMARCHY_PATH") + "/shell/plugins/menu/Menu.qml", Component.PreferSynchronous)
+          if (component.status !== Component.Ready) {
+            root.fail("Menu.qml failed to load: " + component.errorString())
+            root.finish()
+            return
+          }
+          root.menu = component.createObject(null)
+          if (!root.menu) {
+            root.fail("Menu.qml failed to instantiate")
+            root.finish()
+            return
+          }
+        }
+
+        // Scenario A: a live select request is superseded by the regular menu.
+        if (tick === 3) {
+          root.menu.open(root.selectPayload("A", "a"))
+          root.assertTrue(root.menu.requestActive === true, "select A becomes the active request")
+          root.assertTrue(root.menu.dmenuActive === true, "select A puts the menu into dmenu mode")
+          root.menu.openExistingMenu("root")
+          root.assertTrue(root.menu.mode === "menu", "the regular menu takes over from select A")
+        }
+
+        // Scenario B: a live select request is superseded by another select.
+        if (tick === 12) {
+          root.menu.open(root.selectPayload("B", "b"))
+          root.assertTrue(root.menu.requestActive === true, "select B becomes the active request")
+          root.menu.open(root.selectPayload("C", "c"))
+          root.assertTrue(root.menu.doneFile === root.scratchDir + "/done-c", "select C holds the live request afterwards")
+        }
+
+        if (tick === 20) root.finish()
+      } catch (error) {
+        root.fail("menu supersede fixture threw: " + error)
+        root.finish()
+      }
+    }
+  }
+
+  function finish() {
+    driver.running = false
+    // Result first, quit later: execDetached spawns asynchronously, and an
+    // immediate Qt.quit() can win the race and leave the result unwritten.
+    root.writeResult()
+    quitDelay.restart()
+  }
+
+  Timer {
+    id: quitDelay
+    interval: 500
+    repeat: false
+    onTriggered: Qt.quit()
+  }
+}

--- a/test/shell.d/fixtures/menu-select-supersede/shell.qml
+++ b/test/shell.d/fixtures/menu-select-supersede/shell.qml
@@ -82,12 +82,17 @@ ShellRoot {
           root.assertTrue(root.menu.mode === "menu", "the regular menu takes over from select A")
         }
 
-        // Scenario B: a live select request is superseded by another select.
+        // Scenario B: several requests opened back-to-back with no delay in
+        // between, so b, c and d are displaced synchronously — possibly while
+        // an earlier completion write is still spawning. Their done files must
+        // all land anyway.
         if (tick === 12) {
           root.menu.open(root.selectPayload("B", "b"))
           root.assertTrue(root.menu.requestActive === true, "select B becomes the active request")
           root.menu.open(root.selectPayload("C", "c"))
-          root.assertTrue(root.menu.doneFile === root.scratchDir + "/done-c", "select C holds the live request afterwards")
+          root.menu.open(root.selectPayload("D", "d"))
+          root.menu.open(root.selectPayload("E", "e"))
+          root.assertTrue(root.menu.doneFile === root.scratchDir + "/done-e", "select E holds the live request afterwards")
         }
 
         if (tick === 20) root.finish()

--- a/test/shell.d/menu-select-supersede-test.sh
+++ b/test/shell.d/menu-select-supersede-test.sh
@@ -71,7 +71,7 @@ if ! jq -e '.ok == true' "$result" >/dev/null; then
   fixture_failed=1
 fi
 
-for name in a b; do
+for name in a b c d; do
   if [[ ! -e $scratch/done-$name ]]; then
     printf 'done-%s was never written; the displaced omarchy-menu-select waiter would spin forever\n' "$name" >&2
     fixture_failed=1

--- a/test/shell.d/menu-select-supersede-test.sh
+++ b/test/shell.d/menu-select-supersede-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "menu select supersede test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping menu select supersede test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+scratch="$TMPDIR/scratch"
+config_dir="$TMPDIR/menu-select-supersede"
+mkdir -p "$config_dir" "$scratch"
+cp "$SHELL_TEST_DIR/fixtures/menu-select-supersede/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+OMARCHY_MENU_TMP="$scratch" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "menu select supersede quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "menu select supersede test timed out"
+}
+
+fixture_failed=0
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Menu select supersede result:\n' >&2
+  jq . "$result" >&2
+  fixture_failed=1
+fi
+
+for name in a b; do
+  if [[ ! -e $scratch/done-$name ]]; then
+    printf 'done-%s was never written; the displaced omarchy-menu-select waiter would spin forever\n' "$name" >&2
+    fixture_failed=1
+  fi
+done
+
+if (( fixture_failed )); then
+  printf 'Quickshell log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "superseding a pending menu select strands its waiter"
+fi
+
+pass "superseding a pending menu select finishes its request instead of leaking the waiter"


### PR DESCRIPTION
Fixes #7818

## Problem

Superseding a pending `omarchy-menu-select` leaks its waiter forever: the bash script polls a done file at 20 Hz that nothing will ever write. Reproduced here on 4.0.0-1 before touching anything:

```
LEAK CONFIRMED: waiter alive after supersede + Escape-dismissed menu (hyprctl layers 1 -> 0)
    PID ELAPSED STAT WCHAN     COMMAND
      8       4 S    do_wait   /bin/bash /usr/share/omarchy/bin/omarchy-menu-select ReproTest ...

unique child processes spawned in 3s: 48 (~16/sec)   # sleep 0.05, one per poll
```

Each leak also strands its mktemp files for the life of the session, since the `trap ... EXIT` cleanup never runs.

## Root cause

Two paths discard a live select/input request without finishing it, and both neutralize every escape hatch:

- `openExistingMenu()` clears `requestActive`, `selectionFile` and `doneFile` outright. The later dismiss can't help (`cancel()` guards on `dmenuActive`, which the `mode = "menu"` reassignment just turned false), and `finishRequest()` would early-return anyway on the cleared handles.
- `openDmenu()` overwrites those same properties when a new select/input supersedes an active one — identical leak through a sibling trigger.

## Fix

Both functions now call `root.finishRequest(null)` before reassigning state, so a displaced request gets its done file written (empty selection -> waiter exits 1). Safe to call unconditionally because `finishRequest()` already early-returns when nothing is pending, and `resultProc.onExited` is serial-guarded so the cancellation write cannot close the menu taking over.

Since several supersedes can land within the few milliseconds one completion spawn takes, `finishRequest()` no longer reassigns the shared `resultProc` directly — writes push onto a `pendingDoneWrites` queue drained from `onExited` with a `running` guard, mirroring the existing `releaseNextDoneFile` pattern in `ImagePicker.qml`. No visual change in any flow — only hidden bookkeeping writes are added, which is why there are no screenshots to attach.

## Test

New `test/shell.d/menu-select-supersede-test.sh` (compositor-gated, skips cleanly without quickshell) drives the real `Menu.qml` through both supersede paths via a fixture under `test/shell.d/fixtures/menu-select-supersede/`. Scenario A supersedes a live select by opening the regular menu; scenario B opens four selects back-to-back with no delay, displacing three requests synchronously while an earlier completion write may still be spawning. The runner asserts every displaced done file was written and empty.

- Watched it fail first: with unfixed code the done files stay unwritten and the test reports `superseding a pending menu select strands its waiter`; with the fix it passes, including four consecutive clean runs of the back-to-back scenario.
- `./test/all`: 183/189 files pass. The 6 failing files (`config-test`, `launch-about-test`, `runtime-smoke-test`, `screenshot-sanity-test`, `snapper-test`, `unowned-system-paths-test`) fail identically on pristine `quattro` on this machine — pre-existing environment issues, unrelated to this change.
