### PR TITLE
Apply power profiles to Slimbook fan and TDP modes

### DIFF
--- a/bin/omarchy-hw-slimbook
+++ b/bin/omarchy-hw-slimbook
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# omarchy:summary=Detect Slimbook laptops by their DMI vendor.
+
+# The vendor alone, so setup can lay down rules for a driver Slimbook ships in
+# its own repository and that a fresh install does not have yet.
+grep -qi "slimbook" "${OMARCHY_DMI_SYS_VENDOR:-/sys/class/dmi/id/sys_vendor}" 2>/dev/null

--- a/bin/omarchy-hw-slimbook-qc71
+++ b/bin/omarchy-hw-slimbook-qc71
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Detect Slimbook laptops whose fan and TDP modes are driven by the qc71 platform driver.
+
+# Slimbook ships this driver as slimbook-qc71-dkms on the Executive and its
+# siblings, from its own repository rather than Omarchy's, so it is commonly
+# installed after Omarchy is. The attribute is the real signal: without the
+# driver bound there is nothing to drive.
+performance_mode="${OMARCHY_QC71_PERFORMANCE_MODE:-/sys/devices/platform/qc71_laptop/performance_mode}"
+
+omarchy-hw-slimbook && [[ -e $performance_mode ]]

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -61,3 +61,8 @@ if [[ -n $requested_profile ]]; then
   mkdir -p "$state_dir"
   printf '%s\n' "$requested_profile" >"$state_file"
 fi
+
+# Some laptops keep their fan and TDP modes outside anything
+# power-profiles-daemon can reach, and stay in the previous mode unless the
+# profile is handed to them directly.
+omarchy-powerprofiles-sync-hardware "$profile"

--- a/bin/omarchy-powerprofiles-sync-hardware
+++ b/bin/omarchy-powerprofiles-sync-hardware
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# omarchy:summary=Push a power profile onto fan and TDP controls that power-profiles-daemon cannot reach.
+# omarchy:args=<power-saver|balanced|performance>
+# omarchy:hidden=true
+
+profile="${1:-}"
+[[ -n $profile ]] || exit 0
+
+# Slimbook Executive and its qc71 siblings.
+#
+# These machines register no ACPI platform_profile, so power-profiles-daemon
+# falls back to its placeholder platform driver and only moves intel_pstate's
+# energy_performance_preference. The fan and TDP modes live in the qc71 platform
+# driver instead. slimbook-service normally mirrors the profile onto them, but it
+# drops an event repeated inside a 1.25s window, so two quick profile changes
+# leave the machine in the mode the first one chose while the bar reports the
+# second. Writing the mode here closes that window: slimbook-service derives it
+# from the same profile, so the two never disagree about the value.
+if omarchy-hw-slimbook-qc71; then
+  performance_mode="${OMARCHY_QC71_PERFORMANCE_MODE:-/sys/devices/platform/qc71_laptop/performance_mode}"
+
+  case "$profile" in
+    power-saver) mode=1 ;;
+    balanced) mode=2 ;;
+    performance) mode=3 ;;
+    *) exit 0 ;;
+  esac
+
+  # Only write on a real difference, so the common case where slimbook-service
+  # already applied the mode costs a read and touches no hardware.
+  if [[ $(<"$performance_mode") != $mode ]]; then
+    # Group the write so the redirection's own failure is caught with it: a bare
+    # `2>/dev/null` on the printf is applied only after the redirect has already
+    # complained, leaking a raw "Permission denied" out of the bar's switch.
+    if ! { printf '%s\n' "$mode" >"$performance_mode"; } 2>/dev/null; then
+      echo "Could not set the qc71 performance mode; is 99-omarchy-slimbook-qc71-performance-mode.rules applied?" >&2
+    fi
+  fi
+fi

--- a/default/udev/slimbook-qc71-performance-mode.rules
+++ b/default/udev/slimbook-qc71-performance-mode.rules
@@ -1,0 +1,5 @@
+# Let the desktop set the fan and TDP mode on Slimbook laptops driven by the
+# qc71 platform driver, so a power profile change can reach it without root.
+# Two bare RUN commands rather than one `sh -c`: udev splits RUN on whitespace
+# without honouring shell quoting, so a quoted script arrives as fragments.
+ACTION=="add|change|bind", SUBSYSTEM=="platform", KERNEL=="qc71_laptop", RUN+="/usr/bin/chgrp wheel %S%p/performance_mode", RUN+="/usr/bin/chmod g+w %S%p/performance_mode"

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -39,6 +39,8 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 
+run_logged "$OMARCHY_INSTALL/hardware/slimbook/fix-executive-power-profiles.sh"
+
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-yt6801-ethernet-adapter.sh"

--- a/install/hardware/slimbook/fix-executive-power-profiles.sh
+++ b/install/hardware/slimbook/fix-executive-power-profiles.sh
@@ -1,0 +1,31 @@
+# Let power profile changes reach the fan and TDP modes on Slimbook laptops.
+#
+# The Executive and its qc71 siblings register no ACPI platform_profile, so
+# power-profiles-daemon falls back to its placeholder platform driver and only
+# moves intel_pstate's energy_performance_preference. The fan and TDP modes sit
+# behind a root-owned attribute of the qc71 platform driver, out of reach of the
+# desktop. This hands that attribute to the wheel group so
+# omarchy-powerprofiles-sync-hardware can apply the profile the user picked.
+#
+# Gated on the vendor, not the driver: Slimbook ships the driver from its own
+# repository, so a fresh install usually gets it later. The rule waits for that
+# module to bind and hands the attribute over then.
+
+if omarchy-hw-slimbook; then
+  sudo mkdir -p /etc/udev/rules.d
+  sudo cp -f "$OMARCHY_PATH/default/udev/slimbook-qc71-performance-mode.rules" \
+    /etc/udev/rules.d/99-omarchy-slimbook-qc71-performance-mode.rules
+  sudo udevadm control --reload
+
+  # Apply to a driver that is already bound, rather than waiting for a reboot.
+  # --settle: a plain trigger only queues the event, so the chgrp and chmod it
+  # runs are still pending when it returns. Scoped to the platform device: a
+  # bare trigger on it also reaches the qc71 input device underneath, and
+  # slimbook-service reads any non-add action there as the driver going away,
+  # which silently stops it mirroring the profile onto the fan and TDP modes,
+  # and every qc71 hotkey with it, for the rest of the session.
+  if omarchy-hw-slimbook-qc71; then
+    sudo udevadm trigger --settle --action=change --subsystem-match=platform \
+      /sys/devices/platform/qc71_laptop
+  fi
+fi

--- a/migrations/1787422694.sh
+++ b/migrations/1787422694.sh
@@ -1,0 +1,47 @@
+echo "Let power profile changes reach the fan and TDP modes on Slimbook laptops"
+
+# install/hardware/slimbook/fix-executive-power-profiles.sh only reaches machines
+# set up after it shipped, so an existing Slimbook Executive still keeps the qc71
+# performance mode attribute owned by root and out of the desktop's reach. Until
+# it is handed over, picking a profile in the bar moves intel_pstate's
+# energy_performance_preference and leaves the fan and TDP mode where it was.
+
+# The vendor, not the driver: Slimbook ships the driver from its own repository,
+# and a machine that gets it after this runs still needs the rule in place.
+omarchy-hw-slimbook || exit 0
+
+rule="${OMARCHY_QC71_UDEV_RULE:-/etc/udev/rules.d/99-omarchy-slimbook-qc71-performance-mode.rules}"
+source_rule="$OMARCHY_PATH/default/udev/slimbook-qc71-performance-mode.rules"
+performance_mode="${OMARCHY_QC71_PERFORMANCE_MODE:-/sys/devices/platform/qc71_laptop/performance_mode}"
+
+# Machine-wide, so a second user on the same laptop finds it already done.
+if [[ ! -f $rule ]] || ! cmp -s "$source_rule" "$rule"; then
+  sudo mkdir -p "$(dirname "$rule")"
+  sudo cp -f "$source_rule" "$rule"
+  sudo udevadm control --reload
+fi
+
+# Without the driver bound there is nothing to hand over yet; the rule catches
+# the module when it arrives.
+omarchy-hw-slimbook-qc71 || exit 0
+
+# Hand the attribute over on the driver that is already bound, rather than
+# waiting for a reboot. Keyed on the attribute rather than on the rule file: a
+# rule copied by hand but never applied leaves the mode just as unreachable.
+# --settle because a plain trigger only queues the event, so its chgrp and chmod
+# are still pending when it returns and the sync below would find the attribute
+# root-owned and report a failure instead of doing the one job it is here for.
+if [[ ! -w $performance_mode ]]; then
+  # Scoped to the platform device: a bare trigger on it also reaches the qc71
+  # input device underneath, and slimbook-service reads any non-add action there
+  # as the driver going away. That silently stops it mirroring the profile onto
+  # the fan and TDP modes, and every qc71 hotkey with it, for the rest of the
+  # session.
+  sudo udevadm trigger --settle --action=change --subsystem-match=platform \
+    "$(dirname "$performance_mode")"
+fi
+
+# The rule only grants access; the mode itself is still whatever it was left in.
+# Hand it the profile that is active right now so the laptop matches the bar
+# without waiting for the next profile change.
+omarchy-powerprofiles-sync-hardware "$(powerprofilesctl get 2>/dev/null)"

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -36,6 +36,12 @@ export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
 export POWERPROFILES_LOG="$tmp_dir/calls"
 export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
 
+# Keep the hardware sync off the real embedded controller when this suite runs
+# on a Slimbook; omarchy-powerprofiles-sync-hardware has its own test file.
+export OMARCHY_DMI_SYS_VENDOR="$tmp_dir/sys_vendor"
+export OMARCHY_QC71_PERFORMANCE_MODE="$tmp_dir/performance_mode"
+printf 'NOT-A-SLIMBOOK\n' >"$tmp_dir/sys_vendor"
+
 "$ROOT/bin/omarchy-powerprofiles-set" ac balanced
 [[ $(<"$tmp_dir/state/ac") == "balanced" ]] || fail "power profile stores AC preference"
 [[ $(tail -n 1 "$tmp_dir/calls") == "balanced" ]] || fail "power profile applies selected AC preference"

--- a/test/shell.d/powerprofiles-slimbook-migration-test.sh
+++ b/test/shell.d/powerprofiles-slimbook-migration-test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+# Root can write the attribute whatever its mode is, so the handover this
+# migration performs cannot be observed from a root test run.
+if (( EUID == 0 )); then
+  pass "running as root; skipping the qc71 attribute handover"
+  exit 0
+fi
+
+migration="$ROOT/migrations/1787422694.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+
+# sudo runs the real command, so the rule below is copied into the test tree and
+# the elevated udev calls land in the stub beside it.
+cat >"$test_dir/bin/sudo" <<'STUB'
+#!/bin/bash
+
+printf 'sudo %s\n' "$*" >>"$CALLS"
+exec "$@"
+STUB
+
+# `udevadm trigger` only queues the event: the rule's chgrp and chmod are still
+# pending when it returns, and only --settle waits for them. Granting access
+# just for --settle is what keeps this test honest about that difference. A
+# Slimbook hands the attribute to the wheel group; here the test user owns the
+# stand-in file, so the owner bit stands in for that membership.
+cat >"$test_dir/bin/udevadm" <<'STUB'
+#!/bin/bash
+
+printf 'udevadm %s\n' "$*" >>"$CALLS"
+
+if [[ $1 == "trigger" && " $* " == *" --settle "* ]]; then
+  chmod u+w "$OMARCHY_QC71_PERFORMANCE_MODE"
+fi
+STUB
+
+cat >"$test_dir/bin/powerprofilesctl" <<'STUB'
+#!/bin/bash
+
+[[ $1 == "get" ]] && echo "performance"
+STUB
+
+chmod +x "$test_dir/bin/"*
+
+export CALLS="$test_dir/calls"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_DMI_SYS_VENDOR="$test_dir/sys_vendor"
+export OMARCHY_QC71_PERFORMANCE_MODE="$test_dir/performance_mode"
+export OMARCHY_QC71_UDEV_RULE="$test_dir/udev/99-omarchy-slimbook-qc71-performance-mode.rules"
+
+source_rule="$ROOT/default/udev/slimbook-qc71-performance-mode.rules"
+
+# A Slimbook that has never had the rule: root owns the mode, so the desktop
+# cannot write it and the bar and the fan disagree.
+reset_machine() {
+  rm -rf "$test_dir/udev"
+  printf 'SLIMBOOK\n' >"$OMARCHY_DMI_SYS_VENDOR"
+  printf '2\n' >"$OMARCHY_QC71_PERFORMANCE_MODE"
+  chmod 0444 "$OMARCHY_QC71_PERFORMANCE_MODE"
+}
+
+run_migration() {
+  : >"$CALLS"
+
+  PATH="$test_dir/bin:$ROOT/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null 2>"$test_dir/stderr"
+}
+
+reset_machine
+run_migration
+
+cmp -s "$source_rule" "$OMARCHY_QC71_UDEV_RULE" ||
+  fail "migration installs the udev rule" "$(cat "$CALLS")"
+pass "migration installs the udev rule"
+
+grep -q 'udevadm trigger .*--settle' "$CALLS" ||
+  fail "migration waits for the rule to be applied" "$(cat "$CALLS")"
+pass "migration waits for the rule to be applied"
+
+# A bare trigger on the platform device also reaches the qc71 input device
+# underneath, and slimbook-service reads any non-add action there as the driver
+# going away: it then stops mirroring the profile onto the fan and TDP modes for
+# the rest of the session, leaving this migration to break what it came to fix.
+grep -q 'udevadm trigger .*--subsystem-match=platform' "$CALLS" ||
+  fail "migration keeps the trigger off the qc71 input device" "$(cat "$CALLS")"
+pass "migration keeps the trigger off the qc71 input device"
+
+# The whole point of the migration: the machine matches the bar afterwards,
+# rather than waiting for the next profile change.
+[[ $(<"$OMARCHY_QC71_PERFORMANCE_MODE") == "3" ]] ||
+  fail "migration carries the current profile onto the hardware" "$(cat "$CALLS")"
+pass "migration carries the current profile onto the hardware"
+
+[[ ! -s $test_dir/stderr ]] ||
+  fail "migration completes without a warning" "$(cat "$test_dir/stderr")"
+pass "migration completes without a warning"
+
+# A second user on the same laptop finds the rule installed and the attribute
+# already handed over, so there is nothing left to do.
+run_migration
+
+[[ ! -s $CALLS ]] ||
+  fail "migration touches nothing on a second run" "$(cat "$CALLS")"
+pass "migration touches nothing on a second run"
+
+# The rule can be in place while the bound driver never saw it, from a hand
+# install or an interrupted run. The attribute is what decides, not the file.
+chmod 0444 "$OMARCHY_QC71_PERFORMANCE_MODE"
+run_migration
+
+grep -q 'udevadm trigger .*--settle' "$CALLS" ||
+  fail "migration applies a rule the bound driver never saw" "$(cat "$CALLS")"
+[[ $(<"$OMARCHY_QC71_PERFORMANCE_MODE") == "3" ]] ||
+  fail "migration syncs after applying an unapplied rule" "$(cat "$CALLS")"
+pass "migration applies a rule the bound driver never saw"
+
+# Slimbook ships the driver from its own repository, so a fresh install mostly
+# gets it later, and a fresh install marks every migration done. The rule has to
+# be laid down now, for the module to find when it binds, and nothing may touch
+# a driver that is not there.
+reset_machine
+rm -f "$OMARCHY_QC71_PERFORMANCE_MODE"
+run_migration
+
+cmp -s "$source_rule" "$OMARCHY_QC71_UDEV_RULE" ||
+  fail "migration installs the rule before the driver is there" "$(cat "$CALLS")"
+if grep -q 'udevadm trigger' "$CALLS"; then
+  fail "migration leaves a missing driver alone" "$(cat "$CALLS")"
+fi
+[[ ! -s $test_dir/stderr ]] ||
+  fail "migration stays quiet without the driver" "$(cat "$test_dir/stderr")"
+pass "migration installs the rule before the driver is there"
+
+# Every other machine has to come out of this untouched.
+reset_machine
+printf 'LENOVO\n' >"$OMARCHY_DMI_SYS_VENDOR"
+run_migration
+
+if [[ -e $OMARCHY_QC71_UDEV_RULE ]]; then
+  fail "migration leaves other vendors alone"
+fi
+[[ ! -s $CALLS ]] || fail "migration leaves other vendors alone" "$(cat "$CALLS")"
+pass "migration leaves other vendors alone"

--- a/test/shell.d/powerprofiles-sync-hardware-test.sh
+++ b/test/shell.d/powerprofiles-sync-hardware-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/state"
+
+cat >"$tmp_dir/bin/powerprofilesctl" <<'EOF'
+#!/bin/bash
+
+if [[ $1 == "list" ]]; then
+  printf '  power-saver:\n* balanced:\n  performance:\n'
+fi
+EOF
+chmod +x "$tmp_dir/bin/powerprofilesctl"
+
+cat >"$tmp_dir/bin/busctl" <<'EOF'
+#!/bin/bash
+
+echo "b false"
+EOF
+chmod +x "$tmp_dir/bin/busctl"
+
+export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
+
+# Never let the suite reach the real attribute when it runs on a Slimbook.
+vendor_file="$tmp_dir/sys_vendor"
+mode_file="$tmp_dir/performance_mode"
+export OMARCHY_DMI_SYS_VENDOR="$vendor_file"
+export OMARCHY_QC71_PERFORMANCE_MODE="$mode_file"
+
+printf 'SLIMBOOK\n' >"$vendor_file"
+printf '2\n' >"$mode_file"
+
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware" performance
+[[ $(<"$mode_file") == "3" ]] || fail "performance maps onto the qc71 performance mode"
+pass "performance maps onto the qc71 performance mode"
+
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware" power-saver
+[[ $(<"$mode_file") == "1" ]] || fail "power-saver maps onto the qc71 silent mode"
+pass "power-saver maps onto the qc71 silent mode"
+
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware" balanced
+[[ $(<"$mode_file") == "2" ]] || fail "balanced maps onto the qc71 normal mode"
+pass "balanced maps onto the qc71 normal mode"
+
+# A mode that already agrees must not be rewritten: the write reaches the
+# embedded controller, and slimbook-service applies most changes on its own.
+chmod 0444 "$mode_file"
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware" balanced
+chmod 0644 "$mode_file"
+pass "an already matching mode is left untouched"
+
+# Anything that is not one of the three profiles must not reach the hardware.
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware" nonsense
+[[ $(<"$mode_file") == "2" ]] || fail "an unknown profile leaves the mode alone"
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware"
+[[ $(<"$mode_file") == "2" ]] || fail "a missing profile leaves the mode alone"
+pass "unknown and missing profiles leave the mode alone"
+
+printf 'LENOVO\n' >"$vendor_file"
+"$ROOT/bin/omarchy-powerprofiles-sync-hardware" performance
+[[ $(<"$mode_file") == "2" ]] || fail "other vendors are left alone"
+pass "other vendors are left alone"
+
+if omarchy-hw-slimbook-qc71; then
+  fail "hardware detection rejects other vendors"
+fi
+printf 'SLIMBOOK\n' >"$vendor_file"
+omarchy-hw-slimbook-qc71 || fail "hardware detection accepts a Slimbook running the qc71 driver"
+if OMARCHY_QC71_PERFORMANCE_MODE="$tmp_dir/absent" omarchy-hw-slimbook-qc71; then
+  fail "hardware detection needs the qc71 driver, not just the vendor"
+fi
+# The vendor alone still counts as a Slimbook, so setup can lay the rule down
+# ahead of a driver that arrives from Slimbook's own repository later.
+OMARCHY_QC71_PERFORMANCE_MODE="$tmp_dir/absent" omarchy-hw-slimbook ||
+  fail "vendor detection does not need the qc71 driver"
+pass "hardware detection needs both the vendor and the qc71 driver"
+
+# The profile has already been applied by the time the mode is written, so a
+# hardware write that fails must not fail the profile change with it.
+export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
+chmod 0444 "$mode_file"
+if ! "$ROOT/bin/omarchy-powerprofiles-set" ac performance 2>"$tmp_dir/stderr"; then
+  fail "a mode that cannot be written still reports a successful profile change"
+fi
+grep -q "qc71" "$tmp_dir/stderr" || fail "a failed mode write explains itself"
+# The redirection's own failure has to be caught with the printf's, or a raw
+# "Permission denied" escapes into the bar's profile switch alongside it.
+if grep -q "Permission denied" "$tmp_dir/stderr"; then
+  fail "a failed mode write reports only its own message"
+fi
+(( $(wc -l <"$tmp_dir/stderr") == 1 )) || fail "a failed mode write reports exactly one message"
+chmod 0644 "$mode_file"
+pass "a mode that cannot be written neither fails nor hides the profile change"
+
+"$ROOT/bin/omarchy-powerprofiles-set" ac performance
+[[ $(<"$mode_file") == "3" ]] || fail "setting a profile carries it onto the hardware"
+pass "setting a profile carries it onto the hardware"


### PR DESCRIPTION
## The problem

On the Slimbook Executive (and its qc71 siblings) picking a power profile in the bar's battery panel changes very little. The machine registers no ACPI `platform_profile`, so `power-profiles-daemon` falls back to its placeholder platform driver and only moves intel_pstate's `energy_performance_preference`. The fan and TDP modes live in the qc71 platform driver, at `/sys/devices/platform/qc71_laptop/performance_mode` (1 silent, 2 normal, 3 performance).

`slimbook-service` normally mirrors the profile onto that attribute, but `/usr/share/slimbook/event-notify.py` de-duplicates an event repeated inside a 1.25s window. Two profile changes in quick succession — easy to produce clicking through the panel — drop the second sync. The panel then reads Performance while the laptop stays in Normal, so the fans and clocks stay where balanced left them.

The same gap shows up at boot from a different direction: `power-profiles-daemon` always starts on `balanced`, so when the remembered profile is also `balanced`, `omarchy-powerprofiles-init` produces no change for `slimbook-service` to act on and the mode is never synced at all.

## The fix

Write the mode from `omarchy-powerprofiles-set`. Every profile change already goes through it — the battery panel, the menu, `omarchy-powerprofiles-init`, and the AC/battery switch in `Service.qml` — so no new daemon or watcher is needed.

- `omarchy-hw-slimbook` matches the DMI vendor; `omarchy-hw-slimbook-qc71` adds the attribute itself. Slimbook ships the driver from its own repository, so a fresh install usually gets it after Omarchy — and a fresh install marks every migration done. Setup therefore lays the rule down on the vendor alone and lets the module's `bind` hand the attribute over when it arrives, while anything that touches the hardware checks for the driver.
- `omarchy-powerprofiles-sync-hardware` maps the profile onto the mode and writes only when the two disagree. `slimbook-service` derives the mode from the same profile, so they never fight over the value; this just closes the window where the event was dropped.
- A udev rule hands the attribute to `wheel`, following `default/udev/framework16-qmk-hid.rules` and `install/hardware/asus/fix-z13-touchpad.sh`.
- A failed write warns on stderr and never fails the profile change, which has already been applied by that point.
- The migration covers existing installs and applies the currently active profile, so the laptop matches the bar without waiting for the next change.

The new command is deliberately named for the general problem rather than the vendor, so other hardware that `power-profiles-daemon` cannot fully drive has somewhere to go.

Three things found after review, each with a regression test:

- `udevadm trigger` only queues the event, so the migration's sync ran before the rule's `chgrp`/`chmod` had landed — measured as the attribute still `root` in 5/5 runs at the moment the trigger returned, and `wheel` in 3/3 with `--settle`. Both scripts now settle, and the migration keys the handover on `[[ -w ]]` rather than on the rule file, so a rule copied by hand but never applied is repaired too.
- A bare trigger on `/sys/devices/platform/qc71_laptop` also reaches the qc71 input device beneath it, and `slimbook-service` reads any non-`add` action there as the driver going away. It then stops mirroring the profile onto the hardware, and stops handling the qc71 hotkeys, until it is restarted — so installing this silently degraded the very bridging it reinforces. The trigger is now scoped with `--subsystem-match=platform`, verified to reach exactly the one device.
- The fresh-install gap described above.

The second commit fixes the udev rule: udev splits a `RUN` value on whitespace and does not honour shell quoting, so the original `RUN+="/bin/sh -c '… && …'"` reached the helper as fragments and neither command ran. Two bare `RUN+=` commands, the shape the documented backlight rules use. Worth knowing that `udevadm verify` accepts the broken form happily — only loading it catches this.

## Testing

Measured on an Executive-14-UC2 (Core Ultra 7 255H), on battery. Every run below used a control first, with the packaged `omarchy-powerprofiles-set` and nothing else touching the attribute, to confirm the scenario still reproduces before claiming a fix:

| | result |
|---|---|
| control: packaged command, `performance → balanced → performance` under 1s | 3/3 desync (`ppd=performance qc71=1`) |
| this branch, same scenario | 3/3 in sync |
| this branch, each profile individually | `power-saver→1`, `balanced→2`, `performance→3` |
| `install/hardware/slimbook/fix-executive-power-profiles.sh` from a clean state | rule installed, attribute `-rw-rw-r-- root:wheel` |
| the migration from a clean state | same, exit 0 |
| the migration re-run | idempotent, no change |
| the migration with a non-Slimbook vendor | skips, exit 0 |

Effect once the mode actually follows, under load: 2175 → 3011 → 3857 rpm fan and 1572 → 1576 → 2286 MHz average clock across the three profiles.

Automated: `./test/cli` passes. `./test/shell` passes except `config-test`, `snapper-test` and `unowned-system-paths-test`, which all want an `omarchy-pkgs` checkout and fail identically on an untouched `quattro` worktree. `udevadm verify` accepts the rule.

`test/shell.d/powerprofiles-sync-hardware-test.sh` covers all three mappings, the no-write-when-equal path, unknown and missing profiles, vendor gating, and that an unwritable attribute neither fails the profile change nor leaks a raw `Permission denied` alongside the warning. `test/shell.d/powerprofiles-slimbook-migration-test.sh` runs the migration against stubbed `sudo` and `udevadm`, where only `--settle` grants access, and covers the handover, the scoped trigger, the sync, idempotence, an unapplied rule, a Slimbook without the driver yet, and other vendors. `test/shell.d/powerprofiles-set-test.sh` now points the hardware paths at temp files so the suite cannot reach a real embedded controller when it runs on a Slimbook.

The `bind` path, which a fresh install relies on entirely: `modprobe -r qc71_laptop && modprobe qc71_laptop` with the rule loaded and no trigger — the attribute was gone while unloaded and came back `-rw-rw-r-- root:wheel` straight after the reload. `slimbook-service` handled the remove/add cycle and bridged 4/4 profile changes on its own afterwards.

The de-duplication itself is arguably a `slimbook-service` bug and worth reporting there too; this makes Omarchy's own profile switch reliable in the meantime.

