### PR TITLE
Add "Join hidden network" to the Wi-Fi panel

### DIFF
--- a/shell/Ui/Dropdown.qml
+++ b/shell/Ui/Dropdown.qml
@@ -43,6 +43,10 @@ Item {
   // own keyCatcher so j/k inside the popup don't double-drive the panel
   // cursor.
   readonly property bool popupOpen: popup.opened
+  // Exposed for the same reason as popupOpen: a parent panel's BeforeItem
+  // key catcher must stand down while the trigger holds Qt focus (Tab), or
+  // Enter/Space never reach it to open the popup.
+  readonly property bool triggerFocused: trigger.activeFocus
   function open() { popup.open() }
   function close() { popup.close() }
   function toggle() { popup.opened ? popup.close() : popup.open() }

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -360,6 +360,15 @@ var enterpriseConnectScript =
 // must stay wifi-only on exactly fifteen fields -- -g prints one line per
 // field (blank when unset) plus a blank line between connections, so a
 // missing or extra field would slip the group alignment.
+//
+// The "auto" literal assumes NetworkManager's stock per-connection default;
+// a site that overrides ipv4.method/ipv6.method in NetworkManager.conf's
+// [connection] section gives both the new profile and prior hidden profiles
+// that other value, so this comparison never matches and dedupe silently
+// stops -- every join then leaves another same-named profile behind instead
+// of deleting one. That is the intended failure direction: this dedupe
+// exists because the old code deleted too much, so failing toward "leave
+// profiles alone" beats failing toward "delete a customized one."
 var hiddenConnectDedupe =
   " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
   " old=\"\"; wifi=\"\";" +

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -341,40 +341,26 @@ var enterpriseConnectScript =
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
-// Same stdin-secret shape as enterpriseConnectScript above: create the hidden
-// profile first, then push the PSK through the scriptable `connection edit`
-// editor over stdin. `nmcli device wifi connect ... password "$pw"` would put
-// the passphrase in argv (world-readable via /proc), so it must not be used.
-// Key-mgmt comes from $2 ("wpa-psk" or "sae") -- always a literal we pass,
-// never user text. WPA3/SAE mandates Protected Management Frames, so $pmf
-// is set to "wifi-sec.pmf 3" for that case only; it's a fixed internal
-// string too, so the intentional word-split into the nmcli argv is safe.
+// Hidden PSK/SAE connect. Secrets stay off argv (same shape as
+// enterpriseConnectScript): create the profile, set wifi-sec.psk via the
+// `connection edit` stdin editor, then activate. $2 is the key-mgmt
+// ("wpa-psk"|"sae") and $pmf adds the PMF SAE requires -- both our own
+// literals, never user text.
 //
-// Repeat joins to the same hidden SSID shouldn't pile up duplicate profiles,
-// but con-name is not unique in NetworkManager -- `connection delete id
-// "$1"` would delete the FIRST match by NAME, which could be an unrelated
-// VPN/Ethernet/broadcast-Wi-Fi profile that happens to share that name, and
-// doing it before the new profile is proven to work means a typo/wrong
-// password destroys working config. Instead: capture the UUIDs of existing
-// 802-11-wireless profiles whose ssid == "$1" and hidden == yes (matched by
-// UUID/field, never by name) BEFORE adding the new one, and only remove them
-// AFTER the new profile activates successfully; a failed attempt deletes
-// nothing but its own new (still-unproven) profile. The type/ssid/hidden
-// fields are fetched in one `-g` call (one value per line) and split with
-// three `IFS= read -r` calls off a single here-string instead of three
-// separate nmcli invocations per candidate UUID, with `--escape no` so a
-// backslash-escaped SSID (nmcli escapes ":" and "\\" by default) still
-// compares equal to the raw "$1"; the `IFS=` prefix is required so a
-// space-padded SSID isn't silently trimmed before the comparison.
+// Dedupe: con-name isn't unique, so prior hidden wifi profiles for this
+// SSID are matched by UUID + type/ssid/hidden fields (`--escape no` so
+// escaped ":"/"\\" SSIDs still compare; `IFS=` so padded SSIDs aren't
+// trimmed) and removed only after the new profile activates AND autoconnect
+// is armed -- a failed arm keeps the old, still-autoconnecting profiles.
 //
-// The profile is created with `connection.autoconnect no` and only flipped
-// to "yes" after `connection up` succeeds, so a killed/failed attempt can
-// never be retried in the background by NetworkManager. `-w 25` bounds
-// nmcli's own wait below the QML side's 30s kill timeout, so a slow/stuck
-// activation hits the `||` cleanup path instead of being killed mid-command
-// and leaving a stray half-proven profile behind.
+// Cleanup is one mechanism: an EXIT trap deletes the new profile on any
+// failure or kill (TERM/INT exit into it; SIGKILL would bypass, Quickshell
+// sends TERM) and is disarmed once `connection up` proves it. The profile
+// starts autoconnect-off so even a leak can't retry in the background;
+// `-w 25` keeps nmcli under the panel's 30s kill.
 var hiddenPskConnectScript =
   "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
+  " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
   " old=\"\";" +
   " for c in $(nmcli -t -f UUID connection show); do" +
   "   info=$(nmcli --escape no -g connection.type,802-11-wireless.ssid,802-11-wireless.hidden connection show uuid \"$c\" 2>/dev/null);" +
@@ -388,9 +374,10 @@ var hiddenPskConnectScript =
   " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
   " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
   " && nmcli -w 25 connection up uuid \"$u\"" +
-  " && { nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1;" +
-  "     for o in $old; do [[ $o == \"$u\" ]] || nmcli connection delete uuid \"$o\" >/dev/null 2>&1; done; true; }" +
-  " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
+  " && { trap - EXIT;" +
+  "     if nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1; then" +
+  "       for o in $old; do [[ $o == \"$u\" ]] || nmcli connection delete uuid \"$o\" >/dev/null 2>&1; done;" +
+  "     fi; true; }"
 
 function networkFailureReason(reason, needsCredentials, reasons) {
   var r = reasons || {}

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -341,10 +341,17 @@ var enterpriseConnectScript =
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
-// Same stdin-secret shape as enterpriseConnectScript above: SSID is a
-// positional arg, the passphrase is never interpolated into the script text.
+// Same stdin-secret shape as enterpriseConnectScript above: create the hidden
+// profile first, then push the PSK through the scriptable `connection edit`
+// editor over stdin. `nmcli device wifi connect ... password "$pw"` would put
+// the passphrase in argv (world-readable via /proc), so it must not be used.
 var hiddenPskConnectScript =
-  "IFS= read -r pw; nmcli device wifi connect \"$1\" password \"$pw\" hidden yes"
+  "u=$(uuidgen); IFS= read -r pw;" +
+  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
+  " 802-11-wireless.hidden yes wifi-sec.key-mgmt wpa-psk >/dev/null" +
+  " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
+  " && nmcli connection up uuid \"$u\"" +
+  " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
 var hiddenEnterpriseConnectScript =
   "u=$(uuidgen); IFS= read -r pw;" +

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -369,10 +369,37 @@ var enterpriseConnectScript =
 // of deleting one. That is the intended failure direction: this dedupe
 // exists because the old code deleted too much, so failing toward "leave
 // profiles alone" beats failing toward "delete a customized one."
+//
+// Both queries feed their loops through process substitution, never
+// `<<< "$(...)"`: a command substitution is a foreground child, and bash
+// defers a trapped TERM until a foreground child returns, so a hung nmcli
+// would outlive the panel's 30s kill. With < <(...) the shell blocks in the
+// interruptible `read` builtin instead, and the TERM trap kills $! -- the
+// substitution's nmcli -- on its way out. The same trap covers the
+// `connection add`/`connection edit` steps, which run backgrounded under
+// `wait $!`, and the EXIT-trap delete is bounded by `timeout -k 1 5` (KILL a second after an ignored TERM) so a wedged
+// NetworkManager cannot stall the dying process either -- worst case it
+// leaves the unproven, autoconnect-off profile behind, the same residue an
+// untrappable SIGKILL already leaves.
+// Arms the cleanup EXIT trap and the kill-the-in-flight-child TERM trap
+// before anything runs; both connect scripts start with it.
+var hiddenConnectGuard =
+  " trap 'timeout -k 1 5 nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT;" +
+  " trap 'kill -TERM $! 2>/dev/null; exit 143' TERM INT;"
+
+// The snapshot runs INSIDE the activation's modify-success block, immediately
+// before the batched delete, not up front: deciding "this profile is an
+// uncustomized duplicate" ~30 seconds before acting on it invites a TOCTOU
+// where a profile customized mid-join (nm-connection-editor, a config agent)
+// is deleted from a stale list. Adjacent snapshot-and-delete shrinks that
+// window to milliseconds -- the best available, since NetworkManager has no
+// compare-and-delete. By then the new profile exists and matches this very
+// predicate, so the loop skips $u explicitly. The TERM trap is re-armed
+// beforehand so a panel kill still interrupts the late queries; killed there,
+// the connection is already up and armed, and the duplicates simply survive.
 var hiddenConnectDedupe =
-  " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
   " old=\"\"; wifi=\"\";" +
-  " while IFS=: read -r c t; do [[ $t == \"802-11-wireless\" ]] && wifi=\"$wifi uuid $c\"; done <<< \"$(nmcli -t -f UUID,TYPE connection show)\";" +
+  " while IFS=: read -r c t; do [[ $t == \"802-11-wireless\" ]] && wifi=\"$wifi uuid $c\"; done < <(nmcli -t -f UUID,TYPE connection show);" +
   " if [[ -n $wifi ]]; then" +
   "   while IFS= read -r c; do" +
   "     [[ -n $c ]] || continue;" +
@@ -381,6 +408,7 @@ var hiddenConnectDedupe =
   "     IFS= read -r ip4m; IFS= read -r ip6m;" +
   "     IFS= read -r ip4addr; IFS= read -r ip4dns; IFS= read -r ip4routes;" +
   "     IFS= read -r ip6addr; IFS= read -r ip6dns; IFS= read -r ip6routes;" +
+  "     [[ $c != \"$u\" ]] || continue;" +
   "     [[ $ssid == \"$1\" ]] || continue;" +
   "     [[ $hidden == \"yes\" ]] || continue;" +
   "     [[ $keymgmt == \"${2-}\" ]] || continue;" +
@@ -388,13 +416,14 @@ var hiddenConnectDedupe =
   "     [[ $ip4m == \"auto\" && $ip6m == \"auto\" ]] || continue;" +
   "     [[ -z $ip4addr && -z $ip4dns && -z $ip4routes && -z $ip6addr && -z $ip6dns && -z $ip6routes ]] || continue;" +
   "     old=\"$old uuid $c\";" +
-  "   done <<< \"$(LC_ALL=C nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden,802-11-wireless-security.key-mgmt,802-11-wireless.bssid,802-11-wireless.mac-address,connection.interface-name,ipv4.method,ipv6.method,ipv4.addresses,ipv4.dns,ipv4.routes,ipv6.addresses,ipv6.dns,ipv6.routes connection show $wifi 2>/dev/null)\";" +
+  "   done < <(LC_ALL=C nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden,802-11-wireless-security.key-mgmt,802-11-wireless.bssid,802-11-wireless.mac-address,connection.interface-name,ipv4.method,ipv6.method,ipv4.addresses,ipv4.dns,ipv4.routes,ipv6.addresses,ipv6.dns,ipv6.routes connection show $wifi 2>/dev/null);" +
   " fi;"
 
 // A lone EXIT trap deletes the unproven profile on any failure or TERM/INT
 // kill, disarmed only after `connection up`. The profile is born
-// autoconnect-off so a leak can't retry; old duplicates go in one batched
-// delete, only once it is up and armed. `connection up` runs backgrounded so
+// autoconnect-off so a leak can't retry; the duplicate snapshot runs, and the
+// old duplicates it finds go in one batched delete, only once it is up and
+// armed. `connection up` runs backgrounded so
 // the panel's 30s kill (Process.running = false -> SIGTERM) reaches it
 // directly: bash defers a trapped signal until a foreground child returns,
 // so a synchronous `nmcli -w 25 connection up` would leave the panel's
@@ -406,6 +435,8 @@ var hiddenConnectActivate =
   "     wait $up; }" +
   " && { trap - EXIT;" +
   "     if nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1; then" +
+  "       trap 'kill -TERM $! 2>/dev/null; exit 143' TERM INT;" +
+  hiddenConnectDedupe +
   "       [[ -n $old ]] && nmcli connection delete $old >/dev/null 2>&1;" +
   "     fi; true; }"
 
@@ -413,10 +444,10 @@ var hiddenConnectActivate =
 // `connection edit` editor, never argv.
 var hiddenPskConnectScript =
   "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
-  hiddenConnectDedupe +
-  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
-  " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
-  " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
+  hiddenConnectGuard +
+  " { nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
+  " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null & wait $!; }" +
+  " && { printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null & wait $!; }" +
   hiddenConnectActivate
 
 // An open hidden network has no credentials, but still must not use `nmcli
@@ -426,9 +457,9 @@ var hiddenPskConnectScript =
 // minus the secret.
 var hiddenOpenConnectScript =
   "u=$(uuidgen);" +
-  hiddenConnectDedupe +
-  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
-  " connection.autoconnect no 802-11-wireless.hidden yes >/dev/null" +
+  hiddenConnectGuard +
+  " { nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
+  " connection.autoconnect no 802-11-wireless.hidden yes >/dev/null & wait $!; }" +
   hiddenConnectActivate
 
 function networkFailureReason(reason, needsCredentials, reasons) {

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -345,21 +345,14 @@ var enterpriseConnectScript =
 // profile first, then push the PSK through the scriptable `connection edit`
 // editor over stdin. `nmcli device wifi connect ... password "$pw"` would put
 // the passphrase in argv (world-readable via /proc), so it must not be used.
+// Deletes any same-named profile left behind by a prior join first, so
+// repeat connects to the same hidden SSID don't pile up duplicate profiles.
 var hiddenPskConnectScript =
-  "u=$(uuidgen); IFS= read -r pw;" +
+  "nmcli connection delete id \"$1\" >/dev/null 2>&1;" +
+  " u=$(uuidgen); IFS= read -r pw;" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
   " 802-11-wireless.hidden yes wifi-sec.key-mgmt wpa-psk >/dev/null" +
   " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
-  " && nmcli connection up uuid \"$u\"" +
-  " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
-
-var hiddenEnterpriseConnectScript =
-  "u=$(uuidgen); IFS= read -r pw;" +
-  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
-  " 802-11-wireless.hidden yes" +
-  " wifi-sec.key-mgmt wpa-eap 802-1x.eap peap 802-1x.phase2-auth mschapv2" +
-  " 802-1x.identity \"$2\" 802-1x.auth-timeout 8 >/dev/null" +
-  " && printf 'set 802-1x.password %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
@@ -415,7 +408,6 @@ if (typeof module !== "undefined") {
     canForgetNetwork: canForgetNetwork,
     enterpriseConnectScript: enterpriseConnectScript,
     hiddenPskConnectScript: hiddenPskConnectScript,
-    hiddenEnterpriseConnectScript: hiddenEnterpriseConnectScript,
     networkFailureReason: networkFailureReason,
     shouldRepromptPassphrase: shouldRepromptPassphrase
   }

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -360,26 +360,36 @@ var enterpriseConnectScript =
 // UUID/field, never by name) BEFORE adding the new one, and only remove them
 // AFTER the new profile activates successfully; a failed attempt deletes
 // nothing but its own new (still-unproven) profile. The type/ssid/hidden
-// fields are fetched in one `-g` call (one value per line) instead of three
+// fields are fetched in one `-g` call (one value per line) and split with
+// three `IFS= read -r` calls off a single here-string instead of three
 // separate nmcli invocations per candidate UUID, with `--escape no` so a
 // backslash-escaped SSID (nmcli escapes ":" and "\\" by default) still
-// compares equal to the raw "$1".
+// compares equal to the raw "$1"; the `IFS=` prefix is required so a
+// space-padded SSID isn't silently trimmed before the comparison.
+//
+// The profile is created with `connection.autoconnect no` and only flipped
+// to "yes" after `connection up` succeeds, so a killed/failed attempt can
+// never be retried in the background by NetworkManager. `-w 25` bounds
+// nmcli's own wait below the QML side's 30s kill timeout, so a slow/stuck
+// activation hits the `||` cleanup path instead of being killed mid-command
+// and leaving a stray half-proven profile behind.
 var hiddenPskConnectScript =
   "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
   " old=\"\";" +
   " for c in $(nmcli -t -f UUID connection show); do" +
   "   info=$(nmcli --escape no -g connection.type,802-11-wireless.ssid,802-11-wireless.hidden connection show uuid \"$c\" 2>/dev/null);" +
-  "   type=$(printf '%s\\n' \"$info\" | sed -n 1p); ssid=$(printf '%s\\n' \"$info\" | sed -n 2p); hidden=$(printf '%s\\n' \"$info\" | sed -n 3p);" +
+  "   { IFS= read -r type; IFS= read -r ssid; IFS= read -r hidden; } <<< \"$info\";" +
   "   [[ $type == \"802-11-wireless\" ]] || continue;" +
   "   [[ $ssid == \"$1\" ]] || continue;" +
   "   [[ $hidden == \"yes\" ]] || continue;" +
   "   old=\"$old $c\";" +
   " done;" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
-  " 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
+  " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
   " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
-  " && nmcli connection up uuid \"$u\"" +
-  " && { for o in $old; do [[ $o == \"$u\" ]] || nmcli connection delete uuid \"$o\" >/dev/null 2>&1; done; true; }" +
+  " && nmcli -w 25 connection up uuid \"$u\"" +
+  " && { nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1;" +
+  "     for o in $old; do [[ $o == \"$u\" ]] || nmcli connection delete uuid \"$o\" >/dev/null 2>&1; done; true; }" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
 function networkFailureReason(reason, needsCredentials, reasons) {

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -341,10 +341,10 @@ var enterpriseConnectScript =
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
-// Join a hidden SSID. Only $1 (ssid) and the stdin passphrase are user input;
-// $2 (key-mgmt "wpa-psk"|"sae") and $pmf are our own literals. The secret
-// reaches nmcli through the `connection edit` editor, not argv (see
-// enterpriseConnectScript).
+// Join a hidden SSID. Only $1 (ssid) and, for the PSK variant, the stdin
+// passphrase are user input; $2 (key-mgmt "wpa-psk"|"sae") and $pmf are our
+// own literals. The secret reaches nmcli through the `connection edit`
+// editor, not argv (see enterpriseConnectScript).
 //
 // Dedupe is by UUID, not con-name (not unique -- a name match could delete an
 // unrelated profile), in two fixed nmcli calls, never one per connection:
@@ -352,14 +352,7 @@ var enterpriseConnectScript =
 // ":"/"\\" SSID compares raw). It must stay wifi-only on exactly three fields
 // -- -g prints one line per field (blank when unset) plus a blank line
 // between connections, so a missing field would slip the group alignment.
-//
-// A lone EXIT trap deletes the unproven profile on any failure or TERM/INT
-// kill, disarmed only after `connection up`. The profile is born
-// autoconnect-off so a leak can't retry; old duplicates go in one batched
-// delete, only once it is up and armed; `-w 25` bounds nmcli under the
-// panel's 30s kill.
-var hiddenPskConnectScript =
-  "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
+var hiddenConnectDedupe =
   " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
   " old=\"\"; wifi=\"\";" +
   " while IFS=: read -r c t; do [[ $t == \"802-11-wireless\" ]] && wifi=\"$wifi uuid $c\"; done <<< \"$(nmcli -t -f UUID,TYPE connection show)\";" +
@@ -371,15 +364,41 @@ var hiddenPskConnectScript =
   "     [[ $hidden == \"yes\" ]] || continue;" +
   "     old=\"$old uuid $c\";" +
   "   done <<< \"$(nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden connection show $wifi 2>/dev/null)\";" +
-  " fi;" +
-  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
-  " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
-  " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
+  " fi;"
+
+// A lone EXIT trap deletes the unproven profile on any failure or TERM/INT
+// kill, disarmed only after `connection up`. The profile is born
+// autoconnect-off so a leak can't retry; old duplicates go in one batched
+// delete, only once it is up and armed; `-w 25` bounds nmcli under the
+// panel's 30s kill.
+var hiddenConnectActivate =
   " && nmcli -w 25 connection up uuid \"$u\"" +
   " && { trap - EXIT;" +
   "     if nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1; then" +
   "       [[ -n $old ]] && nmcli connection delete $old >/dev/null 2>&1;" +
   "     fi; true; }"
+
+// The passphrase arrives on stdin and reaches nmcli through the scriptable
+// `connection edit` editor, never argv.
+var hiddenPskConnectScript =
+  "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
+  hiddenConnectDedupe +
+  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
+  " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
+  " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
+  hiddenConnectActivate
+
+// An open hidden network has no credentials, but still must not use `nmcli
+// device wifi connect`, which persists an autoconnecting profile before
+// activation -- a timed-out or killed attempt would stay saved and retry in
+// the background. It shares the PSK script's dedupe/EXIT-trap lifecycle,
+// minus the secret.
+var hiddenOpenConnectScript =
+  "u=$(uuidgen);" +
+  hiddenConnectDedupe +
+  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
+  " connection.autoconnect no 802-11-wireless.hidden yes >/dev/null" +
+  hiddenConnectActivate
 
 function networkFailureReason(reason, needsCredentials, reasons) {
   var r = reasons || {}
@@ -433,6 +452,7 @@ if (typeof module !== "undefined") {
     canForgetNetwork: canForgetNetwork,
     enterpriseConnectScript: enterpriseConnectScript,
     hiddenPskConnectScript: hiddenPskConnectScript,
+    hiddenOpenConnectScript: hiddenOpenConnectScript,
     networkFailureReason: networkFailureReason,
     shouldRepromptPassphrase: shouldRepromptPassphrase
   }

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -363,7 +363,7 @@ var hiddenConnectDedupe =
   "     [[ $ssid == \"$1\" ]] || continue;" +
   "     [[ $hidden == \"yes\" ]] || continue;" +
   "     old=\"$old uuid $c\";" +
-  "   done <<< \"$(nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden connection show $wifi 2>/dev/null)\";" +
+  "   done <<< \"$(LC_ALL=C nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden connection show $wifi 2>/dev/null)\";" +
   " fi;"
 
 // A lone EXIT trap deletes the unproven profile on any failure or TERM/INT

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -341,25 +341,23 @@ var enterpriseConnectScript =
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
-// Hidden PSK/SAE connect. Secrets stay off argv (same shape as
-// enterpriseConnectScript): create the profile, set wifi-sec.psk via the
-// `connection edit` stdin editor, then activate. $2 is the key-mgmt
-// ("wpa-psk"|"sae") and $pmf adds the PMF SAE requires -- both our own
-// literals, never user text.
+// Join a hidden SSID. Only $1 (ssid) and the stdin passphrase are user input;
+// $2 (key-mgmt "wpa-psk"|"sae") and $pmf are our own literals. The secret
+// reaches nmcli through the `connection edit` editor, not argv (see
+// enterpriseConnectScript).
 //
-// Dedupe: con-name isn't unique, so prior hidden wifi profiles for this
-// SSID are found in two fixed nmcli calls -- a UUID/TYPE listing, then one
-// batched ssid/hidden query over just the wifi profiles (groups come back
-// blank-line separated; `--escape no` so ":"/"\\" SSIDs compare raw, `IFS=`
-// so padded SSIDs aren't trimmed) -- and removed only after the new profile
-// activates AND autoconnect is armed; a failed arm keeps the old,
-// still-autoconnecting profiles.
+// Dedupe is by UUID, not con-name (not unique -- a name match could delete an
+// unrelated profile), in two fixed nmcli calls, never one per connection:
+// list UUID/TYPE, then one batched -g over the wifi UUIDs (--escape no so a
+// ":"/"\\" SSID compares raw). It must stay wifi-only on exactly three fields
+// -- -g prints one line per field (blank when unset) plus a blank line
+// between connections, so a missing field would slip the group alignment.
 //
-// Cleanup is one mechanism: an EXIT trap deletes the new profile on any
-// failure or kill (TERM/INT exit into it; SIGKILL would bypass, Quickshell
-// sends TERM) and is disarmed once `connection up` proves it. The profile
-// starts autoconnect-off so even a leak can't retry in the background;
-// `-w 25` keeps nmcli under the panel's 30s kill.
+// A lone EXIT trap deletes the unproven profile on any failure or TERM/INT
+// kill, disarmed only after `connection up`. The profile is born
+// autoconnect-off so a leak can't retry; old duplicates go in one batched
+// delete, only once it is up and armed; `-w 25` bounds nmcli under the
+// panel's 30s kill.
 var hiddenPskConnectScript =
   "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
   " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
@@ -371,7 +369,7 @@ var hiddenPskConnectScript =
   "     IFS= read -r ssid; IFS= read -r hidden;" +
   "     [[ $ssid == \"$1\" ]] || continue;" +
   "     [[ $hidden == \"yes\" ]] || continue;" +
-  "     old=\"$old $c\";" +
+  "     old=\"$old uuid $c\";" +
   "   done <<< \"$(nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden connection show $wifi 2>/dev/null)\";" +
   " fi;" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
@@ -380,7 +378,7 @@ var hiddenPskConnectScript =
   " && nmcli -w 25 connection up uuid \"$u\"" +
   " && { trap - EXIT;" +
   "     if nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1; then" +
-  "       for o in $old; do [[ $o == \"$u\" ]] || nmcli connection delete uuid \"$o\" >/dev/null 2>&1; done;" +
+  "       [[ -n $old ]] && nmcli connection delete $old >/dev/null 2>&1;" +
   "     fi; true; }"
 
 function networkFailureReason(reason, needsCredentials, reasons) {

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -385,10 +385,16 @@ var hiddenConnectDedupe =
 // A lone EXIT trap deletes the unproven profile on any failure or TERM/INT
 // kill, disarmed only after `connection up`. The profile is born
 // autoconnect-off so a leak can't retry; old duplicates go in one batched
-// delete, only once it is up and armed; `-w 25` bounds nmcli under the
-// panel's 30s kill.
+// delete, only once it is up and armed. `connection up` runs backgrounded so
+// the panel's 30s kill (Process.running = false -> SIGTERM) reaches it
+// directly: bash defers a trapped signal until a foreground child returns,
+// so a synchronous `nmcli -w 25 connection up` would leave the panel's
+// "Connecting..." state and disabled actions running well past the
+// advertised timeout while nmcli's own -w 25 has yet to elapse.
 var hiddenConnectActivate =
-  " && nmcli -w 25 connection up uuid \"$u\"" +
+  " && { nmcli -w 25 connection up uuid \"$u\" & up=$!;" +
+  "     trap 'kill -TERM $up 2>/dev/null; wait $up 2>/dev/null; exit 143' TERM INT;" +
+  "     wait $up; }" +
   " && { trap - EXIT;" +
   "     if nmcli connection modify uuid \"$u\" connection.autoconnect yes >/dev/null 2>&1; then" +
   "       [[ -n $old ]] && nmcli connection delete $old >/dev/null 2>&1;" +

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -341,6 +341,21 @@ var enterpriseConnectScript =
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
+// Same stdin-secret shape as enterpriseConnectScript above: SSID is a
+// positional arg, the passphrase is never interpolated into the script text.
+var hiddenPskConnectScript =
+  "IFS= read -r pw; nmcli device wifi connect \"$1\" password \"$pw\" hidden yes"
+
+var hiddenEnterpriseConnectScript =
+  "u=$(uuidgen); IFS= read -r pw;" +
+  " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
+  " 802-11-wireless.hidden yes" +
+  " wifi-sec.key-mgmt wpa-eap 802-1x.eap peap 802-1x.phase2-auth mschapv2" +
+  " 802-1x.identity \"$2\" 802-1x.auth-timeout 8 >/dev/null" +
+  " && printf 'set 802-1x.password %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
+  " && nmcli connection up uuid \"$u\"" +
+  " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
+
 function networkFailureReason(reason, needsCredentials, reasons) {
   var r = reasons || {}
   if (needsCredentials && reason === r.NoSecrets) return "Passphrase required"
@@ -392,6 +407,8 @@ if (typeof module !== "undefined") {
     requiresCredentials: requiresCredentials,
     canForgetNetwork: canForgetNetwork,
     enterpriseConnectScript: enterpriseConnectScript,
+    hiddenPskConnectScript: hiddenPskConnectScript,
+    hiddenEnterpriseConnectScript: hiddenEnterpriseConnectScript,
     networkFailureReason: networkFailureReason,
     shouldRepromptPassphrase: shouldRepromptPassphrase
   }

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -348,10 +348,12 @@ var enterpriseConnectScript =
 // literals, never user text.
 //
 // Dedupe: con-name isn't unique, so prior hidden wifi profiles for this
-// SSID are matched by UUID + type/ssid/hidden fields (`--escape no` so
-// escaped ":"/"\\" SSIDs still compare; `IFS=` so padded SSIDs aren't
-// trimmed) and removed only after the new profile activates AND autoconnect
-// is armed -- a failed arm keeps the old, still-autoconnecting profiles.
+// SSID are found in two fixed nmcli calls -- a UUID/TYPE listing, then one
+// batched ssid/hidden query over just the wifi profiles (groups come back
+// blank-line separated; `--escape no` so ":"/"\\" SSIDs compare raw, `IFS=`
+// so padded SSIDs aren't trimmed) -- and removed only after the new profile
+// activates AND autoconnect is armed; a failed arm keeps the old,
+// still-autoconnecting profiles.
 //
 // Cleanup is one mechanism: an EXIT trap deletes the new profile on any
 // failure or kill (TERM/INT exit into it; SIGKILL would bypass, Quickshell
@@ -361,15 +363,17 @@ var enterpriseConnectScript =
 var hiddenPskConnectScript =
   "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
   " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
-  " old=\"\";" +
-  " for c in $(nmcli -t -f UUID connection show); do" +
-  "   info=$(nmcli --escape no -g connection.type,802-11-wireless.ssid,802-11-wireless.hidden connection show uuid \"$c\" 2>/dev/null);" +
-  "   { IFS= read -r type; IFS= read -r ssid; IFS= read -r hidden; } <<< \"$info\";" +
-  "   [[ $type == \"802-11-wireless\" ]] || continue;" +
-  "   [[ $ssid == \"$1\" ]] || continue;" +
-  "   [[ $hidden == \"yes\" ]] || continue;" +
-  "   old=\"$old $c\";" +
-  " done;" +
+  " old=\"\"; wifi=\"\";" +
+  " while IFS=: read -r c t; do [[ $t == \"802-11-wireless\" ]] && wifi=\"$wifi uuid $c\"; done <<< \"$(nmcli -t -f UUID,TYPE connection show)\";" +
+  " if [[ -n $wifi ]]; then" +
+  "   while IFS= read -r c; do" +
+  "     [[ -n $c ]] || continue;" +
+  "     IFS= read -r ssid; IFS= read -r hidden;" +
+  "     [[ $ssid == \"$1\" ]] || continue;" +
+  "     [[ $hidden == \"yes\" ]] || continue;" +
+  "     old=\"$old $c\";" +
+  "   done <<< \"$(nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden connection show $wifi 2>/dev/null)\";" +
+  " fi;" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
   " connection.autoconnect no 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
   " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -345,19 +345,35 @@ var enterpriseConnectScript =
 // profile first, then push the PSK through the scriptable `connection edit`
 // editor over stdin. `nmcli device wifi connect ... password "$pw"` would put
 // the passphrase in argv (world-readable via /proc), so it must not be used.
-// Deletes any same-named profile left behind by a prior join first, so
-// repeat connects to the same hidden SSID don't pile up duplicate profiles.
 // Key-mgmt comes from $2 ("wpa-psk" or "sae") -- always a literal we pass,
 // never user text. WPA3/SAE mandates Protected Management Frames, so $pmf
 // is set to "wifi-sec.pmf 3" for that case only; it's a fixed internal
 // string too, so the intentional word-split into the nmcli argv is safe.
+//
+// Repeat joins to the same hidden SSID shouldn't pile up duplicate profiles,
+// but con-name is not unique in NetworkManager -- `connection delete id
+// "$1"` would delete the FIRST match by NAME, which could be an unrelated
+// VPN/Ethernet/broadcast-Wi-Fi profile that happens to share that name, and
+// doing it before the new profile is proven to work means a typo/wrong
+// password destroys working config. Instead: capture the UUIDs of existing
+// 802-11-wireless profiles whose ssid == "$1" and hidden == yes (matched by
+// UUID/field, never by name) BEFORE adding the new one, and only remove them
+// AFTER the new profile activates successfully; a failed attempt deletes
+// nothing but its own new (still-unproven) profile.
 var hiddenPskConnectScript =
-  "nmcli connection delete id \"$1\" >/dev/null 2>&1;" +
-  " u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [ \"$2\" = \"sae\" ] && pmf=\"wifi-sec.pmf 3\";" +
+  "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
+  " old=\"\";" +
+  " for c in $(nmcli -t -f UUID connection show); do" +
+  "   [[ $(nmcli -g connection.type connection show uuid \"$c\" 2>/dev/null) == \"802-11-wireless\" ]] || continue;" +
+  "   [[ $(nmcli -g 802-11-wireless.ssid connection show uuid \"$c\" 2>/dev/null) == \"$1\" ]] || continue;" +
+  "   [[ $(nmcli -g 802-11-wireless.hidden connection show uuid \"$c\" 2>/dev/null) == \"yes\" ]] || continue;" +
+  "   old=\"$old $c\";" +
+  " done;" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
   " 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
   " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
   " && nmcli connection up uuid \"$u\"" +
+  " && { for o in $old; do [[ $o == \"$u\" ]] || nmcli connection delete uuid \"$o\" >/dev/null 2>&1; done; true; }" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
 function networkFailureReason(reason, needsCredentials, reasons) {

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -347,11 +347,15 @@ var enterpriseConnectScript =
 // the passphrase in argv (world-readable via /proc), so it must not be used.
 // Deletes any same-named profile left behind by a prior join first, so
 // repeat connects to the same hidden SSID don't pile up duplicate profiles.
+// Key-mgmt comes from $2 ("wpa-psk" or "sae") -- always a literal we pass,
+// never user text. WPA3/SAE mandates Protected Management Frames, so $pmf
+// is set to "wifi-sec.pmf 3" for that case only; it's a fixed internal
+// string too, so the intentional word-split into the nmcli argv is safe.
 var hiddenPskConnectScript =
   "nmcli connection delete id \"$1\" >/dev/null 2>&1;" +
-  " u=$(uuidgen); IFS= read -r pw;" +
+  " u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [ \"$2\" = \"sae\" ] && pmf=\"wifi-sec.pmf 3\";" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +
-  " 802-11-wireless.hidden yes wifi-sec.key-mgmt wpa-psk >/dev/null" +
+  " 802-11-wireless.hidden yes wifi-sec.key-mgmt \"$2\" $pmf >/dev/null" +
   " && printf 'set wifi-sec.psk %s\\nsave\\nquit\\n' \"$pw\" | nmcli connection edit uuid \"$u\" >/dev/null" +
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -349,9 +349,17 @@ var enterpriseConnectScript =
 // Dedupe is by UUID, not con-name (not unique -- a name match could delete an
 // unrelated profile), in two fixed nmcli calls, never one per connection:
 // list UUID/TYPE, then one batched -g over the wifi UUIDs (--escape no so a
-// ":"/"\\" SSID compares raw). It must stay wifi-only on exactly three fields
-// -- -g prints one line per field (blank when unset) plus a blank line
-// between connections, so a missing field would slip the group alignment.
+// ":"/"\\" SSID compares raw). A saved profile is only replaceable if it is
+// indistinguishable from the one about to be created: same SSID, hidden,
+// key-mgmt (comparing against "${2-}" covers both the PSK script's "$2" and
+// the open script's unset $2, since an open profile also reports empty
+// key-mgmt), no BSSID/MAC/interface pin, and ipv4/ipv6 left at the defaults
+// our own `connection add` leaves behind -- method "auto" on both stacks, no
+// manual addresses/dns/routes, confirmed by creating a throwaway profile with
+// this script's exact `connection add` invocation and reading it back. It
+// must stay wifi-only on exactly fifteen fields -- -g prints one line per
+// field (blank when unset) plus a blank line between connections, so a
+// missing or extra field would slip the group alignment.
 var hiddenConnectDedupe =
   " trap 'nmcli connection delete uuid \"$u\" >/dev/null 2>&1' EXIT; trap 'exit 143' TERM INT;" +
   " old=\"\"; wifi=\"\";" +
@@ -359,11 +367,19 @@ var hiddenConnectDedupe =
   " if [[ -n $wifi ]]; then" +
   "   while IFS= read -r c; do" +
   "     [[ -n $c ]] || continue;" +
-  "     IFS= read -r ssid; IFS= read -r hidden;" +
+  "     IFS= read -r ssid; IFS= read -r hidden; IFS= read -r keymgmt;" +
+  "     IFS= read -r bssid; IFS= read -r mac; IFS= read -r iface;" +
+  "     IFS= read -r ip4m; IFS= read -r ip6m;" +
+  "     IFS= read -r ip4addr; IFS= read -r ip4dns; IFS= read -r ip4routes;" +
+  "     IFS= read -r ip6addr; IFS= read -r ip6dns; IFS= read -r ip6routes;" +
   "     [[ $ssid == \"$1\" ]] || continue;" +
   "     [[ $hidden == \"yes\" ]] || continue;" +
+  "     [[ $keymgmt == \"${2-}\" ]] || continue;" +
+  "     [[ -z $bssid && -z $mac && -z $iface ]] || continue;" +
+  "     [[ $ip4m == \"auto\" && $ip6m == \"auto\" ]] || continue;" +
+  "     [[ -z $ip4addr && -z $ip4dns && -z $ip4routes && -z $ip6addr && -z $ip6dns && -z $ip6routes ]] || continue;" +
   "     old=\"$old uuid $c\";" +
-  "   done <<< \"$(LC_ALL=C nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden connection show $wifi 2>/dev/null)\";" +
+  "   done <<< \"$(LC_ALL=C nmcli --escape no -g connection.uuid,802-11-wireless.ssid,802-11-wireless.hidden,802-11-wireless-security.key-mgmt,802-11-wireless.bssid,802-11-wireless.mac-address,connection.interface-name,ipv4.method,ipv6.method,ipv4.addresses,ipv4.dns,ipv4.routes,ipv6.addresses,ipv6.dns,ipv6.routes connection show $wifi 2>/dev/null)\";" +
   " fi;"
 
 // A lone EXIT trap deletes the unproven profile on any failure or TERM/INT

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -359,14 +359,20 @@ var enterpriseConnectScript =
 // 802-11-wireless profiles whose ssid == "$1" and hidden == yes (matched by
 // UUID/field, never by name) BEFORE adding the new one, and only remove them
 // AFTER the new profile activates successfully; a failed attempt deletes
-// nothing but its own new (still-unproven) profile.
+// nothing but its own new (still-unproven) profile. The type/ssid/hidden
+// fields are fetched in one `-g` call (one value per line) instead of three
+// separate nmcli invocations per candidate UUID, with `--escape no` so a
+// backslash-escaped SSID (nmcli escapes ":" and "\\" by default) still
+// compares equal to the raw "$1".
 var hiddenPskConnectScript =
   "u=$(uuidgen); IFS= read -r pw; pmf=\"\"; [[ $2 == \"sae\" ]] && pmf=\"wifi-sec.pmf 3\";" +
   " old=\"\";" +
   " for c in $(nmcli -t -f UUID connection show); do" +
-  "   [[ $(nmcli -g connection.type connection show uuid \"$c\" 2>/dev/null) == \"802-11-wireless\" ]] || continue;" +
-  "   [[ $(nmcli -g 802-11-wireless.ssid connection show uuid \"$c\" 2>/dev/null) == \"$1\" ]] || continue;" +
-  "   [[ $(nmcli -g 802-11-wireless.hidden connection show uuid \"$c\" 2>/dev/null) == \"yes\" ]] || continue;" +
+  "   info=$(nmcli --escape no -g connection.type,802-11-wireless.ssid,802-11-wireless.hidden connection show uuid \"$c\" 2>/dev/null);" +
+  "   type=$(printf '%s\\n' \"$info\" | sed -n 1p); ssid=$(printf '%s\\n' \"$info\" | sed -n 2p); hidden=$(printf '%s\\n' \"$info\" | sed -n 3p);" +
+  "   [[ $type == \"802-11-wireless\" ]] || continue;" +
+  "   [[ $ssid == \"$1\" ]] || continue;" +
+  "   [[ $hidden == \"yes\" ]] || continue;" +
   "   old=\"$old $c\";" +
   " done;" +
   " nmcli connection add type wifi con-name \"$1\" ssid \"$1\" connection.uuid \"$u\"" +

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -20,12 +20,40 @@ Panel {
   function close() {
     root.controller.hide()
     cancelPasswordPrompt()
+    cancelHiddenForm()
   }
 
   function cancelPasswordPrompt() {
     passwordSsid = ""
     passwordText = ""
     identityText = ""
+  }
+
+  function cancelHiddenForm() {
+    hiddenFormOpen = false
+    hiddenPasswordText = ""
+    // A connect still in flight is tracked by ssid/security/identity
+    // (hiddenBusy derives from hiddenSsidText) -- clearing them here would
+    // drop the in-flight state a reopened panel needs to keep rendering
+    // "Connecting…" instead of a silently-busy panel with nothing shown.
+    if (hiddenBusy) return
+    hiddenSsidText = ""
+    hiddenSecurity = "personal"
+    hiddenIdentityText = ""
+    // Done with this attempt (if any) -- past this point the shared
+    // actionSsid/failureSsid state no longer belongs to the hidden form.
+    hiddenConnecting = false
+    // Dropdown.selectCurrent() imperatively assigns its own `value` on a
+    // user pick, which severs the `value: root.hiddenSecurity` binding.
+    // Re-arm it here so a programmatic reset (like the line above) is
+    // reflected in what the dropdown displays next time the form opens.
+    hiddenSecurityDropdown.value = Qt.binding(function() { return root.hiddenSecurity })
+  }
+
+  function toggleHiddenForm() {
+    if (busy) return
+    if (hiddenFormOpen) cancelHiddenForm()
+    else hiddenFormOpen = true
   }
 
   // Live connection details from `ip` / /sys / iw.
@@ -98,6 +126,30 @@ Panel {
   property string passwordText: ""
   property string identityText: ""
 
+  // "Join hidden network" form state. Hidden SSIDs never scan in, so this
+  // form gathers everything up front instead of expanding out of a row.
+  // Reuses actionSsid/actionKind/failureSsid/failureReason above so the
+  // panel-wide busy gate covers this action too.
+  property bool hiddenFormOpen: false
+  property string hiddenSsidText: ""
+  property string hiddenSecurity: "personal"  // "personal" | "enterprise" | "none"
+  property string hiddenIdentityText: ""
+  property string hiddenPasswordText: ""
+  // Discriminates a hidden connect from a scanned row's -- actionSsid /
+  // failureSsid are shared with row state, and a typed hidden SSID that
+  // happens to match a scanned row's SSID would otherwise cross-talk with
+  // that row's own busy/failed rendering (and vice versa).
+  property bool hiddenConnecting: false
+  readonly property bool hiddenBusy: hiddenConnecting && actionKind === "connect" && hiddenSsidText !== "" && actionSsid === hiddenSsidText
+  readonly property bool hiddenFailed: hiddenConnecting && failureReason !== "" && hiddenSsidText !== "" && failureSsid === hiddenSsidText
+
+  // The Dropdown disappears with the rest of the form, so a cursor left
+  // pointing at it would be stuck on nothing -- same shape as
+  // onCanSelectBandChanged.
+  onHiddenFormOpenChanged: {
+    if (!hiddenFormOpen && focusSection === "hiddenSecurity") focusSection = "dns"
+  }
+
   // ConnectionFailReason values as a plain object, so Model.js helpers stay
   // pure JS and Node-testable.
   readonly property var connectionFailReasons: ({
@@ -119,9 +171,12 @@ Panel {
   property bool cursorActive: false
 
   // Keyboard focus zone for the panel. j/k crosses row boundaries:
-  // header actions ⇄ portal ⇄ band ⇄ DNS row ⇄ Wi-Fi networks. h/l move
-  // within header actions, band pills, or DNS providers.
-  property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "wifi"
+  // header actions ⇄ portal ⇄ band ⇄ DNS row ⇄ Wi-Fi networks ⇄
+  // hidden-network security Dropdown (only reachable while the
+  // hidden-network form is open; the Dropdown owns its own option
+  // navigation once opened). h/l move within header actions, band pills,
+  // or DNS providers.
+  property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "wifi" | "hiddenSecurity"
   property int headerIndex: 0
   readonly property bool canDisconnect: !!connectedWifiNetwork
   readonly property bool headerHasDisconnect: false
@@ -778,7 +833,10 @@ Panel {
 
   function clearNetworkAction() {
     actionTimeout.stop()
-    if (actionKind === "connect") passwordSsid = ""
+    // Guard on actionSsid matching the open prompt -- a completing hidden
+    // connect (or any other row's connect) must not clobber an unrelated
+    // row's still-open passphrase prompt.
+    if (actionKind === "connect" && actionSsid === passwordSsid) passwordSsid = ""
     failureSsid = ""
     failureReason = ""
     actionSsid = ""
@@ -836,6 +894,91 @@ Panel {
     onStarted: {
       write(secret + "\n")
       secret = ""
+    }
+  }
+
+  // Hidden networks never show up in a scan, so there is no WifiNetwork
+  // object to hand runNetworkAction or to watch for connected/failed signals
+  // -- completion is read straight off nmcli's exit code instead.
+  function runHiddenAction(ssid, callback) {
+    if (actionKind !== "" || !ssid) return
+    actionSsid = ssid
+    actionKind = "connect"
+    failureSsid = ""
+    failureReason = ""
+    // Marks the shared actionSsid/failureSsid state above as attributable to
+    // THIS hidden attempt -- without it, a scanned row's own in-flight
+    // connect/failure that happens to share the typed hidden SSID string
+    // would read as the hidden form's own busy/failed state (or vice versa).
+    hiddenConnecting = true
+    callback()
+    actionTimeout.restart()
+  }
+
+  function connectHidden(ssid, security, identity, passphrase) {
+    runHiddenAction(ssid, function() {
+      if (security === "enterprise") {
+        hiddenConnect.secret = passphrase
+        hiddenConnect.command = ["bash", "-c", Model.hiddenEnterpriseConnectScript, "nmcli-hidden-eap", ssid, identity]
+      } else if (security === "none") {
+        hiddenConnect.secret = ""
+        hiddenConnect.command = ["nmcli", "device", "wifi", "connect", ssid, "hidden", "yes"]
+      } else {
+        hiddenConnect.secret = passphrase
+        hiddenConnect.command = ["bash", "-c", Model.hiddenPskConnectScript, "nmcli-hidden-psk", ssid]
+      }
+      hiddenConnect.running = true
+    })
+  }
+
+  function submitHiddenNetwork() {
+    var ssid = hiddenSsidText.trim()
+    var identity = hiddenIdentityText.trim()
+    if (busy || ssid.length === 0) return
+    if (hiddenSecurity !== "none" && hiddenPasswordText.length === 0) return
+    if (hiddenSecurity === "enterprise" && identity.length === 0) return
+    // Normalize the stored text to the trimmed value submitted below so
+    // hiddenBusy/hiddenFailed (which compare actionSsid === hiddenSsidText)
+    // keep matching once actionSsid is set to the trimmed ssid.
+    hiddenSsidText = ssid
+    hiddenIdentityText = identity
+    connectHidden(ssid, hiddenSecurity, identity, hiddenPasswordText)
+  }
+
+  function completeHiddenAction() {
+    clearNetworkAction()
+    cancelHiddenForm()
+  }
+
+  function failHiddenAction(reason) {
+    if (actionKind === "") return
+    actionTimeout.stop()
+    failureSsid = actionSsid
+    failureReason = reason
+    actionSsid = ""
+    actionKind = ""
+    // hiddenConnecting deliberately stays true here (and through the shared
+    // actionTimeout timeout path) -- it still needs to gate hiddenFailed so
+    // this attempt's "Failed"/"Timed out" message renders. It clears once
+    // the user dismisses the form (cancelHiddenForm) or retries
+    // (runHiddenAction resets failureSsid/failureReason for the new attempt
+    // regardless of hiddenConnecting's prior value).
+  }
+
+  // Runs the hidden-network nmcli command (see Model.hiddenPskConnectScript /
+  // Model.hiddenEnterpriseConnectScript). Same stdin-secret handoff as
+  // enterpriseConnect; the open path never sets a secret.
+  Process {
+    id: hiddenConnect
+    property string secret: ""
+    stdinEnabled: true
+    onStarted: {
+      write(secret + "\n")
+      secret = ""
+    }
+    onExited: function(exitCode) {
+      if (exitCode === 0) root.completeHiddenAction()
+      else root.failHiddenAction("Failed to connect")
     }
   }
 
@@ -1049,9 +1192,10 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      // Freeze the cursor model while the inline password prompt is open;
-      // the TextField inside owns input until Esc/Enter/Cancel.
-      blocked: root.passwordSsid !== ""
+      // Freeze the cursor model while the inline password prompt or the
+      // hidden-security Dropdown's popup is open; the TextField / Dropdown's
+      // own ListView owns input until Esc/Enter/Cancel closes it.
+      blocked: root.passwordSsid !== "" || hiddenSecurityDropdown.popupOpen
 
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) {
@@ -1114,14 +1258,30 @@ Panel {
               root.focusSection = "wifi"
               if (root.selectedIndex < 0) root.selectedIndex = 0
             }
-          } else {  // wifi
+          } else if (root.focusSection === "wifi") {
             // k from the top row escapes back up to the DNS row rather than
-            // wrapping around to the bottom of the list.
+            // wrapping around to the bottom of the list. j from the bottom
+            // row drops into the hidden-network security Dropdown when that
+            // form is open; otherwise the list just clamps.
             if (dy < 0 && root.selectedIndex <= 0) {
               root.focusSection = "dns"
               root.wifiActionFocused = false
+            } else if (dy > 0 && root.selectedIndex >= root.wifiNetworks.length - 1 && root.hiddenFormOpen) {
+              root.focusSection = "hiddenSecurity"
+            } else {
+              root.selectByDelta(dy)
             }
-            else root.selectByDelta(dy)
+          } else {  // hiddenSecurity
+            // Nothing below the Dropdown to escape into; k climbs back to
+            // the wifi list (or DNS, if the list is empty).
+            if (dy < 0) {
+              if (root.wifiNetworks.length > 0) {
+                root.focusSection = "wifi"
+                root.selectedIndex = root.wifiNetworks.length - 1
+              } else {
+                root.focusSection = "dns"
+              }
+            }
           }
         }
         if (dx !== 0) {
@@ -1137,6 +1297,7 @@ Panel {
           else if (root.focusSection === "portal") root.openCaptivePortal()
           else if (root.focusSection === "band") root.activateBand()
           else if (root.focusSection === "dns") root.activateDns()
+          else if (root.focusSection === "hiddenSecurity") hiddenSecurityDropdown.open()
           else root.activateSelected()
         }
       }
@@ -1632,6 +1793,162 @@ Panel {
               width: parent.width
               net: modelData
               index: parent.parent.index
+            }
+          }
+        }
+      }
+
+      // Join hidden network — non-broadcasting SSIDs never scan in, so
+      // joining one gathers SSID/security/credentials up front and goes
+      // straight to nmcli (see connectHidden) instead of picking a row above.
+      PanelSeparator {
+        visible: root.wifiStationAvailable
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        visible: root.wifiStationAvailable
+        width: parent.width
+        spacing: Style.space(8)
+
+        Button {
+          id: hiddenToggleButton
+          width: parent.width
+          leftAlign: true
+          text: root.hiddenFormOpen ? "Cancel" : "Join hidden network"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          horizontalPadding: Style.space(10)
+          enabled: !root.busy
+          onClicked: root.toggleHiddenForm()
+        }
+
+        Column {
+          visible: root.hiddenFormOpen
+          width: parent.width
+          spacing: Style.space(6)
+
+          TextField {
+            id: hiddenSsidField
+            visible: root.hiddenFormOpen
+            width: parent.width
+            placeholderText: "Network name (SSID)"
+            font.family: Style.font.family
+            font.pixelSize: Style.font.body
+            foreground: root.bar.foreground
+            horizontalPadding: Style.spacing.controlGap
+            verticalPadding: Style.spacing.controlPaddingY
+            enabled: !root.hiddenBusy
+            text: root.hiddenSsidText
+
+            onAccepted: {
+              if (hiddenIdentityField.visible) hiddenIdentityField.forceActiveFocus()
+              else if (hiddenPasswordField.visible) hiddenPasswordField.forceActiveFocus()
+              else root.submitHiddenNetwork()
+            }
+            onTextChanged: if (text !== root.hiddenSsidText) root.hiddenSsidText = text
+            Keys.onEscapePressed: root.cancelHiddenForm()
+
+            onVisibleChanged: if (visible) Qt.callLater(forceActiveFocus)
+            Component.onCompleted: if (visible) Qt.callLater(forceActiveFocus)
+          }
+
+          Dropdown {
+            id: hiddenSecurityDropdown
+            label: "Security"
+            width: parent.width
+            fontFamily: root.bar.fontFamily
+            foreground: root.bar.foreground
+            options: [
+              { value: "personal",   label: "WPA/WPA2/WPA3 Personal" },
+              { value: "enterprise", label: "WPA/WPA2 Enterprise" },
+              { value: "none",       label: "None" }
+            ]
+            value: root.hiddenSecurity
+            hasCursor: root.cursorActive && root.focusSection === "hiddenSecurity"
+            onHovered: function(h) { if (h) { root.cursorActive = true; root.focusSection = "hiddenSecurity" } }
+            onChanged: function(v) { root.hiddenSecurity = v }
+          }
+
+          TextField {
+            id: hiddenIdentityField
+            visible: root.hiddenSecurity === "enterprise"
+            width: parent.width
+            placeholderText: "Identity (user@domain)"
+            font.family: Style.font.family
+            font.pixelSize: Style.font.body
+            foreground: root.bar.foreground
+            horizontalPadding: Style.spacing.controlGap
+            verticalPadding: Style.spacing.controlPaddingY
+            enabled: !root.hiddenBusy
+            text: root.hiddenIdentityText
+
+            onAccepted: hiddenPasswordField.forceActiveFocus()
+            onTextChanged: if (text !== root.hiddenIdentityText) root.hiddenIdentityText = text
+            Keys.onEscapePressed: root.cancelHiddenForm()
+          }
+
+          TextField {
+            id: hiddenPasswordField
+            visible: root.hiddenSecurity !== "none"
+            width: parent.width
+            password: true
+            placeholderText: "Passphrase"
+            font.family: Style.font.family
+            font.pixelSize: Style.font.body
+            foreground: root.bar.foreground
+            horizontalPadding: Style.spacing.controlGap
+            verticalPadding: Style.spacing.controlPaddingY
+            enabled: !root.hiddenBusy
+            text: root.hiddenPasswordText
+
+            onAccepted: root.submitHiddenNetwork()
+            onTextChanged: if (text !== root.hiddenPasswordText) root.hiddenPasswordText = text
+            Keys.onEscapePressed: root.cancelHiddenForm()
+          }
+
+          Item {
+            width: parent.width
+            implicitHeight: Math.max(Style.spacing.controlHeight, hiddenConnectBtn.implicitHeight)
+
+            // Same status-pill chrome as the scanned-row inline prompt
+            // (statusMsgWrapper below) so the two connecting/failed states
+            // in this file read consistently.
+            BorderSurface {
+              id: hiddenStatusWrapper
+              visible: root.hiddenBusy || root.hiddenFailed
+              anchors.left: parent.left
+              anchors.right: hiddenConnectBtn.left
+              anchors.rightMargin: Style.space(8)
+              anchors.verticalCenter: parent.verticalCenter
+              height: Style.spacing.controlHeight
+              color: Style.normalFillFor(root.bar.foreground)
+              borderSpec: Border.controlSpec("normal", root.bar.foreground, Color.accent)
+              radius: Style.cornerRadius
+
+              Text {
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: root.hiddenBusy ? "Connecting…" : (root.failureReason || "Failed")
+                color: root.hiddenFailed ? root.bar.urgent : root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.bodySmall
+              }
+            }
+
+            PanelActionButton {
+              id: hiddenConnectBtn
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              enabled: !root.busy && root.hiddenSsidText.trim().length > 0
+                && (root.hiddenSecurity === "none" || root.hiddenPasswordText.length > 0)
+                && (root.hiddenSecurity !== "enterprise" || root.hiddenIdentityText.trim().length > 0)
+              iconText: "󰄬"
+              tooltipText: "Connect"
+              foreground: root.bar.foreground
+              fontFamily: root.bar.fontFamily
+              onClicked: root.submitHiddenNetwork()
             }
           }
         }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -170,6 +170,7 @@ Panel {
       hiddenSsidText = ""
       hiddenSecurity = "wpa-psk"
       hiddenPasswordText = ""
+      hiddenConnecting = false
       hiddenSecurityDropdown.value = Qt.binding(function() { return root.hiddenSecurity })
     }
   }
@@ -1009,7 +1010,9 @@ Panel {
     onExited: function(exitCode) {
       var wasTimeout = timedOut
       timedOut = false
-      if (wasTimeout) root.failHiddenAction("Timed out connecting")
+      // A kill can race a genuine success: if the process still exited 0,
+      // the connection is actually up -- report success, not a timeout.
+      if (wasTimeout && exitCode !== 0) root.failHiddenAction("Timed out connecting")
       else if (exitCode === 0) root.completeHiddenAction()
       else root.failHiddenAction("Failed to connect")
     }
@@ -1879,7 +1882,6 @@ Panel {
 
           TextField {
             id: hiddenSsidField
-            visible: root.hiddenFormOpen
             width: parent.width
             placeholderText: "Network name (SSID)"
             font.family: Style.font.family

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -2040,8 +2040,11 @@ Panel {
     currentFill: root.selectedFill
     // Gate on the matching *Kind/*Reason being non-empty so a hidden-SSID
     // row (ssid == "") doesn't match the "" defaults of actionSsid etc.
-    readonly property bool isBusy: root.actionKind !== "" && root.actionSsid === (net ? net.ssid : "")
-    readonly property bool isFailed: root.failureReason !== "" && root.failureSsid === (net ? net.ssid : "")
+    // Also gate on !actionIsHidden: a hidden attempt whose typed SSID equals a
+    // scanned row's would otherwise light up that row with the hidden form's
+    // connecting/failure state.
+    readonly property bool isBusy: !root.actionIsHidden && root.actionKind !== "" && root.actionSsid === (net ? net.ssid : "")
+    readonly property bool isFailed: !root.actionIsHidden && root.failureReason !== "" && root.failureSsid === (net ? net.ssid : "")
     readonly property bool isPasswordOpen: root.passwordSsid !== "" && root.passwordSsid === (net ? net.ssid : "")
 
     function submitCredentials() {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -939,9 +939,7 @@ Panel {
     runHiddenAction(ssid, function() {
       if (security === "none") {
         hiddenConnect.secret = ""
-        // "--" keeps a flag-like SSID (e.g. "--ask") from being parsed as
-        // an nmcli option.
-        hiddenConnect.command = ["nmcli", "device", "wifi", "connect", "--", ssid, "hidden", "yes"]
+        hiddenConnect.command = ["bash", "-c", Model.hiddenOpenConnectScript, "nmcli-hidden-open", ssid]
       } else {
         // security is our own "wpa-psk"/"sae" literal, passed as $2.
         hiddenConnect.secret = passphrase
@@ -977,7 +975,8 @@ Panel {
   }
 
   // Runs the hidden-network nmcli command; secret over stdin like
-  // enterpriseConnect (the open path sets none).
+  // enterpriseConnect (the open path writes an empty secret, which its
+  // script ignores).
   Process {
     id: hiddenConnect
     property string secret: ""

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -30,10 +30,10 @@ Panel {
   }
 
   function cancelHiddenForm() {
-    // Keep the form and its full state — passphrase included — while a
-    // connect is in flight so a reopened panel still shows "Connecting…"
-    // and a later failure can be retried without retyping; the disabled
-    // toggle prevents cancel/resubmit meanwhile.
+    // Keep the form and its state while a connect is in flight so a
+    // reopened panel still shows "Connecting…"; the disabled toggle
+    // prevents cancel/resubmit meanwhile. The in-flight passphrase is
+    // dropped by hiddenConnect.onExited, not here.
     if (hiddenBusy) return
     hiddenPasswordText = ""
     hiddenFormOpen = false
@@ -1007,6 +1007,11 @@ Panel {
     onExited: function(exitCode) {
       var wasTimeout = timedOut
       timedOut = false
+      // The secret has served its purpose once the process exits: drop it
+      // from shell memory now rather than letting it linger until the form
+      // is dismissed. A failed attempt keeps SSID and security for retry,
+      // but the passphrase must be retyped.
+      root.hiddenPasswordText = ""
       // A kill can race a genuine success: if the process still exited 0,
       // the connection is actually up -- report success, not a timeout.
       if (wasTimeout && exitCode !== 0) root.failHiddenAction("Timed out connecting")
@@ -1960,7 +1965,8 @@ Panel {
           }
 
           // Shows once hiddenBusy clears with a failure pending; fields
-          // stay populated so the user can fix and retry without retyping.
+          // stay populated so the user can fix and retry; the passphrase
+          // clears on process exit and must be retyped.
           Text {
             visible: root.hiddenFailed
             width: parent.width

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1971,6 +1971,7 @@ Panel {
             visible: root.hiddenFailed
             width: parent.width
             horizontalAlignment: Text.AlignHCenter
+            textFormat: Text.PlainText
             text: root.failureReason || "Failed to connect"
             color: root.bar.urgent
             font.family: root.bar.fontFamily

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -39,7 +39,7 @@ Panel {
     if (hiddenBusy) return
     hiddenFormOpen = false
     hiddenSsidText = ""
-    hiddenSecurity = "personal"
+    hiddenSecurity = "wpa-psk"
     // Done with this attempt (if any) -- past this point the shared
     // actionSsid/failureSsid state no longer belongs to the hidden form.
     hiddenConnecting = false
@@ -142,7 +142,7 @@ Panel {
   // panel-wide busy gate covers this action too.
   property bool hiddenFormOpen: false
   property string hiddenSsidText: ""
-  property string hiddenSecurity: "personal"  // "personal" | "none"
+  property string hiddenSecurity: "wpa-psk"  // "wpa-psk" | "sae" | "none"
   property string hiddenPasswordText: ""
   // Marks this attempt as the hidden form's own, so a scanned row sharing
   // the typed SSID doesn't read as this attempt (or vice versa).
@@ -947,8 +947,10 @@ Panel {
         // of its own flags (e.g. "--ask") as that flag instead of the SSID.
         hiddenConnect.command = ["nmcli", "device", "wifi", "connect", "--", ssid, "hidden", "yes"]
       } else {
+        // security is "wpa-psk" or "sae" -- the literal nmcli key-mgmt value,
+        // never user text -- passed through as $2 for the script to set.
         hiddenConnect.secret = passphrase
-        hiddenConnect.command = ["bash", "-c", Model.hiddenPskConnectScript, "nmcli-hidden-psk", ssid]
+        hiddenConnect.command = ["bash", "-c", Model.hiddenPskConnectScript, "nmcli-hidden-psk", ssid, security]
       }
       hiddenConnect.running = true
     })
@@ -1901,8 +1903,9 @@ Panel {
             fontFamily: root.bar.fontFamily
             foreground: root.bar.foreground
             options: [
-              { value: "personal", label: "WPA/WPA2/WPA3 Personal" },
-              { value: "none",     label: "None" }
+              { value: "wpa-psk", label: "WPA/WPA2 Personal" },
+              { value: "sae",     label: "WPA3 Personal" },
+              { value: "none",    label: "None" }
             ]
             value: root.hiddenSecurity
             hasCursor: root.cursorActive && root.focusSection === "hiddenSecurity"

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -30,15 +30,16 @@ Panel {
   }
 
   function cancelHiddenForm() {
-    hiddenFormOpen = false
     hiddenPasswordText = ""
-    // Leave ssid/security/identity in place while busy: hiddenBusy keys off
-    // hiddenSsidText, so clearing it here would erase the in-flight state
-    // and a reopened form would show nothing instead of "Connecting…".
+    // Leave the form open (and ssid/security in place) while busy:
+    // hiddenBusy keys off hiddenSsidText, and closing the form here would
+    // make a reopened panel show nothing instead of "Connecting…" for the
+    // still-running attempt. The toggle button stays disabled meanwhile
+    // (enabled: !root.busy), so this doesn't reopen a way to cancel/resubmit.
     if (hiddenBusy) return
+    hiddenFormOpen = false
     hiddenSsidText = ""
     hiddenSecurity = "personal"
-    hiddenIdentityText = ""
     // Done with this attempt (if any) -- past this point the shared
     // actionSsid/failureSsid state no longer belongs to the hidden form.
     hiddenConnecting = false
@@ -141,8 +142,7 @@ Panel {
   // panel-wide busy gate covers this action too.
   property bool hiddenFormOpen: false
   property string hiddenSsidText: ""
-  property string hiddenSecurity: "personal"  // "personal" | "enterprise" | "none"
-  property string hiddenIdentityText: ""
+  property string hiddenSecurity: "personal"  // "personal" | "none"
   property string hiddenPasswordText: ""
   // Marks this attempt as the hidden form's own, so a scanned row sharing
   // the typed SSID doesn't read as this attempt (or vice versa).
@@ -859,10 +859,14 @@ Panel {
     failureReason = ""
     actionSsid = ""
     actionKind = ""
+    actionIsHidden = false
     refresh()
   }
 
   function failNetworkAction(network, reason) {
+    // A hidden connect owns the shared action* state right now -- a scanned
+    // row sharing its typed SSID must not touch it (see actionIsHidden).
+    if (actionIsHidden) return
     if (!network || actionKind === "" || actionSsid !== (network.name || "")) return
     actionTimeout.stop()
     failureSsid = actionSsid
@@ -881,6 +885,9 @@ Panel {
   }
 
   function checkActionCompletion(network) {
+    // A hidden connect owns the shared action* state right now -- a scanned
+    // row sharing its typed SSID must not touch it (see actionIsHidden).
+    if (actionIsHidden) return
     if (!network || actionKind === "" || actionSsid !== (network.name || "")) return
     if (actionKind === "connect" && network.connected) clearNetworkAction()
     else if (actionKind === "disconnect" && !network.connected && !network.stateChanging) clearNetworkAction()
@@ -932,14 +939,13 @@ Panel {
     actionTimeout.restart()
   }
 
-  function connectHidden(ssid, security, identity, passphrase) {
+  function connectHidden(ssid, security, passphrase) {
     runHiddenAction(ssid, function() {
-      if (security === "enterprise") {
-        hiddenConnect.secret = passphrase
-        hiddenConnect.command = ["bash", "-c", Model.hiddenEnterpriseConnectScript, "nmcli-hidden-eap", ssid, identity]
-      } else if (security === "none") {
+      if (security === "none") {
         hiddenConnect.secret = ""
-        hiddenConnect.command = ["nmcli", "device", "wifi", "connect", ssid, "hidden", "yes"]
+        // "--" stops nmcli from parsing an SSID that happens to look like one
+        // of its own flags (e.g. "--ask") as that flag instead of the SSID.
+        hiddenConnect.command = ["nmcli", "device", "wifi", "connect", "--", ssid, "hidden", "yes"]
       } else {
         hiddenConnect.secret = passphrase
         hiddenConnect.command = ["bash", "-c", Model.hiddenPskConnectScript, "nmcli-hidden-psk", ssid]
@@ -953,12 +959,9 @@ Panel {
     // empty-input guard -- the exact typed SSID is what gets connected and
     // what hiddenBusy/hiddenFailed compare against.
     var ssid = hiddenSsidText
-    var identity = hiddenIdentityText.trim()
     if (busy || ssid.trim().length === 0) return
     if (hiddenSecurity !== "none" && hiddenPasswordText.length === 0) return
-    if (hiddenSecurity === "enterprise" && identity.length === 0) return
-    hiddenIdentityText = identity
-    connectHidden(ssid, hiddenSecurity, identity, hiddenPasswordText)
+    connectHidden(ssid, hiddenSecurity, hiddenPasswordText)
   }
 
   function completeHiddenAction() {
@@ -978,9 +981,9 @@ Panel {
     // cancelHiddenForm (dismiss) or a fresh runHiddenAction (retry).
   }
 
-  // Runs the hidden-network nmcli command (see Model.hiddenPskConnectScript /
-  // Model.hiddenEnterpriseConnectScript). Same stdin-secret handoff as
-  // enterpriseConnect; the open path never sets a secret.
+  // Runs the hidden-network nmcli command (see Model.hiddenPskConnectScript).
+  // Same stdin-secret handoff as enterpriseConnect; the open path never
+  // sets a secret.
   Process {
     id: hiddenConnect
     property string secret: ""
@@ -1224,10 +1227,9 @@ Panel {
       // text field, or the hidden-security Dropdown's popup owns input. Without
       // gating on the hidden fields, this BeforeItem catcher would eat Space,
       // Enter, arrows, and h/j/k/l/x before the focused field saw them --
-      // blocking many valid SSIDs, identities, and passphrases.
+      // blocking many valid SSIDs and passphrases.
       blocked: root.passwordSsid !== "" || hiddenSecurityDropdown.popupOpen
-        || hiddenSsidField.activeFocus || hiddenIdentityField.activeFocus
-        || hiddenPasswordField.activeFocus
+        || hiddenSsidField.activeFocus || hiddenPasswordField.activeFocus
 
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) {
@@ -1275,7 +1277,9 @@ Panel {
           } else if (root.focusSection === "dns") {
             // k from DNS moves up into the band section when it's on screen,
             // then the disconnect button; otherwise stays put. j drops into the
-            // wifi list if there's anywhere to land.
+            // wifi list if there's anywhere to land, or straight into the
+            // hidden-network security Dropdown when the list is empty but
+            // that form is open -- otherwise j would have nowhere to go.
             if (dy < 0) {
               if (root.canSelectBand) {
                 root.focusSection = "band"
@@ -1289,6 +1293,8 @@ Panel {
             } else if (root.wifiNetworks.length > 0) {
               root.focusSection = "wifi"
               if (root.selectedIndex < 0) root.selectedIndex = 0
+            } else if (root.hiddenFormOpen) {
+              root.focusSection = "hiddenSecurity"
             }
           } else if (root.focusSection === "wifi") {
             // k from the top row escapes back up to the DNS row rather than
@@ -1874,8 +1880,7 @@ Panel {
             text: root.hiddenSsidText
 
             onAccepted: {
-              if (hiddenIdentityField.visible) hiddenIdentityField.forceActiveFocus()
-              else if (hiddenPasswordField.visible) hiddenPasswordField.forceActiveFocus()
+              if (hiddenPasswordField.visible) hiddenPasswordField.forceActiveFocus()
               else root.submitHiddenNetwork()
             }
             onTextChanged: if (text !== root.hiddenSsidText) root.hiddenSsidText = text
@@ -1885,6 +1890,10 @@ Panel {
             Component.onCompleted: if (visible) Qt.callLater(forceActiveFocus)
           }
 
+          // Enterprise is deliberately not offered for hidden networks: without
+          // a broadcast beacon to scan, there is no CA/server validation UI
+          // here, and a hidden 802.1X join would be exposed to an evil-twin
+          // credential-theft AP impersonating the SSID.
           Dropdown {
             id: hiddenSecurityDropdown
             label: "Security"
@@ -1892,32 +1901,13 @@ Panel {
             fontFamily: root.bar.fontFamily
             foreground: root.bar.foreground
             options: [
-              { value: "personal",   label: "WPA/WPA2/WPA3 Personal" },
-              { value: "enterprise", label: "WPA/WPA2 Enterprise" },
-              { value: "none",       label: "None" }
+              { value: "personal", label: "WPA/WPA2/WPA3 Personal" },
+              { value: "none",     label: "None" }
             ]
             value: root.hiddenSecurity
             hasCursor: root.cursorActive && root.focusSection === "hiddenSecurity"
             onHovered: function(h) { if (h) { root.cursorActive = true; root.focusSection = "hiddenSecurity" } }
             onChanged: function(v) { root.hiddenSecurity = v }
-          }
-
-          TextField {
-            id: hiddenIdentityField
-            visible: root.hiddenSecurity === "enterprise"
-            width: parent.width
-            placeholderText: "Identity (user@domain)"
-            font.family: Style.font.family
-            font.pixelSize: Style.font.body
-            foreground: root.bar.foreground
-            horizontalPadding: Style.spacing.controlGap
-            verticalPadding: Style.spacing.controlPaddingY
-            enabled: !root.hiddenBusy
-            text: root.hiddenIdentityText
-
-            onAccepted: hiddenPasswordField.forceActiveFocus()
-            onTextChanged: if (text !== root.hiddenIdentityText) root.hiddenIdentityText = text
-            Keys.onEscapePressed: root.cancelHiddenForm()
           }
 
           TextField {
@@ -1948,7 +1938,6 @@ Panel {
             horizontalPadding: Style.space(10)
             enabled: !root.busy && !root.hiddenBusy && root.hiddenSsidText.trim().length > 0
               && (root.hiddenSecurity === "none" || root.hiddenPasswordText.length > 0)
-              && (root.hiddenSecurity !== "enterprise" || root.hiddenIdentityText.trim().length > 0)
             onClicked: root.submitHiddenNetwork()
           }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1330,7 +1330,10 @@ Panel {
           else if (root.focusSection === "band") root.activateBand()
           else if (root.focusSection === "dns") root.activateDns()
           else if (root.focusSection === "hiddenToggle") root.toggleHiddenForm()
-          else if (root.focusSection === "hiddenSecurity") hiddenSecurityDropdown.open()
+          // open() bypasses enabled, so the busy gate must be explicit here;
+          // it sits inside the branch so a busy Enter stays a no-op instead
+          // of falling through to activateSelected().
+          else if (root.focusSection === "hiddenSecurity") { if (!root.busy) hiddenSecurityDropdown.open() }
           else root.activateSelected()
         }
       }
@@ -1904,6 +1907,7 @@ Panel {
               { value: "none",    label: "None" }
             ]
             value: root.hiddenSecurity
+            enabled: !root.busy
             hasCursor: root.cursorActive && root.focusSection === "hiddenSecurity"
             onHovered: function(h) { if (h) { root.cursorActive = true; root.focusSection = "hiddenSecurity" } }
             onChanged: function(v) { root.hiddenSecurity = v }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -161,9 +161,17 @@ Panel {
   // left open (or a cursor left on its Dropdown) would be stuck on nothing --
   // same shape as onCanSelectBandChanged. Set hiddenFormOpen directly rather
   // than through cancelHiddenForm(), since the section is being hidden anyway.
+  // The field reset below is skipped while a hidden connect is in flight, same
+  // reasoning as cancelHiddenForm: don't yank state out from under a pending action.
   onWifiStationAvailableChanged: if (!wifiStationAvailable) {
     hiddenFormOpen = false
     if (focusSection === "hiddenSecurity") focusSection = "dns"
+    if (!hiddenBusy) {
+      hiddenSsidText = ""
+      hiddenSecurity = "wpa-psk"
+      hiddenPasswordText = ""
+      hiddenSecurityDropdown.value = Qt.binding(function() { return root.hiddenSecurity })
+    }
   }
 
   // ConnectionFailReason values as a plain object, so Model.js helpers stay
@@ -1879,7 +1887,7 @@ Panel {
             foreground: root.bar.foreground
             horizontalPadding: Style.spacing.controlGap
             verticalPadding: Style.spacing.controlPaddingY
-            enabled: !root.hiddenBusy
+            enabled: !root.busy
             text: root.hiddenSsidText
 
             onAccepted: {
@@ -1925,7 +1933,7 @@ Panel {
             foreground: root.bar.foreground
             horizontalPadding: Style.spacing.controlGap
             verticalPadding: Style.spacing.controlPaddingY
-            enabled: !root.hiddenBusy
+            enabled: !root.busy
             text: root.hiddenPasswordText
 
             onAccepted: root.submitHiddenNetwork()

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -32,10 +32,9 @@ Panel {
   function cancelHiddenForm() {
     hiddenFormOpen = false
     hiddenPasswordText = ""
-    // A connect still in flight is tracked by ssid/security/identity
-    // (hiddenBusy derives from hiddenSsidText) -- clearing them here would
-    // drop the in-flight state a reopened panel needs to keep rendering
-    // "Connecting…" instead of a silently-busy panel with nothing shown.
+    // Leave ssid/security/identity in place while busy: hiddenBusy keys off
+    // hiddenSsidText, so clearing it here would erase the in-flight state
+    // and a reopened form would show nothing instead of "Connecting…".
     if (hiddenBusy) return
     hiddenSsidText = ""
     hiddenSecurity = "personal"
@@ -52,8 +51,12 @@ Panel {
 
   function toggleHiddenForm() {
     if (busy) return
-    if (hiddenFormOpen) cancelHiddenForm()
-    else hiddenFormOpen = true
+    if (hiddenFormOpen) {
+      cancelHiddenForm()
+    } else {
+      cancelPasswordPrompt()
+      hiddenFormOpen = true
+    }
   }
 
   // Live connection details from `ip` / /sys / iw.
@@ -122,6 +125,12 @@ Panel {
   property string actionKind: ""  // "connect" | "disconnect" | "forget"
   property string failureSsid: ""
   property string failureReason: ""
+  // Which code path currently owns the shared action* state above -- a row
+  // (runNetworkAction) or the hidden form (runHiddenAction). String equality
+  // on actionSsid alone can't tell those apart when a typed hidden SSID
+  // happens to match a scanned row's, so hiddenBusy/hiddenFailed also check
+  // this before claiming the state as their own.
+  property bool actionIsHidden: false
   property string passwordSsid: ""
   property string passwordText: ""
   property string identityText: ""
@@ -135,19 +144,26 @@ Panel {
   property string hiddenSecurity: "personal"  // "personal" | "enterprise" | "none"
   property string hiddenIdentityText: ""
   property string hiddenPasswordText: ""
-  // Discriminates a hidden connect from a scanned row's -- actionSsid /
-  // failureSsid are shared with row state, and a typed hidden SSID that
-  // happens to match a scanned row's SSID would otherwise cross-talk with
-  // that row's own busy/failed rendering (and vice versa).
+  // Marks this attempt as the hidden form's own, so a scanned row sharing
+  // the typed SSID doesn't read as this attempt (or vice versa).
   property bool hiddenConnecting: false
-  readonly property bool hiddenBusy: hiddenConnecting && actionKind === "connect" && hiddenSsidText !== "" && actionSsid === hiddenSsidText
-  readonly property bool hiddenFailed: hiddenConnecting && failureReason !== "" && hiddenSsidText !== "" && failureSsid === hiddenSsidText
+  readonly property bool hiddenBusy: hiddenConnecting && actionIsHidden && actionKind === "connect" && hiddenSsidText !== "" && actionSsid === hiddenSsidText
+  readonly property bool hiddenFailed: hiddenConnecting && actionIsHidden && failureReason !== "" && hiddenSsidText !== "" && failureSsid === hiddenSsidText
 
   // The Dropdown disappears with the rest of the form, so a cursor left
   // pointing at it would be stuck on nothing -- same shape as
   // onCanSelectBandChanged.
   onHiddenFormOpenChanged: {
     if (!hiddenFormOpen && focusSection === "hiddenSecurity") focusSection = "dns"
+  }
+
+  // The whole hidden-form section vanishes with the Wi-Fi station, so a form
+  // left open (or a cursor left on its Dropdown) would be stuck on nothing --
+  // same shape as onCanSelectBandChanged. Set hiddenFormOpen directly rather
+  // than through cancelHiddenForm(), since the section is being hidden anyway.
+  onWifiStationAvailableChanged: if (!wifiStationAvailable) {
+    hiddenFormOpen = false
+    if (focusSection === "hiddenSecurity") focusSection = "dns"
   }
 
   // ConnectionFailReason values as a plain object, so Model.js helpers stay
@@ -795,6 +811,7 @@ Panel {
   }
 
   function openPasswordPrompt(ssid) {
+    cancelHiddenForm()
     if (passwordSsid !== ssid) {
       passwordText = ""
       identityText = ""
@@ -824,6 +841,7 @@ Panel {
     actionKind = kind
     failureSsid = ""
     failureReason = ""
+    actionIsHidden = false
     callback(network)
     // Safety net: if onExited never fires (process death, signal handler
     // throws, etc.), clear the busy state so the row doesn't get stuck on
@@ -906,11 +924,10 @@ Panel {
     actionKind = "connect"
     failureSsid = ""
     failureReason = ""
-    // Marks the shared actionSsid/failureSsid state above as attributable to
-    // THIS hidden attempt -- without it, a scanned row's own in-flight
-    // connect/failure that happens to share the typed hidden SSID string
-    // would read as the hidden form's own busy/failed state (or vice versa).
+    // Marks this attempt as the hidden form's own, so a scanned row sharing
+    // the typed SSID doesn't read as this attempt (or vice versa).
     hiddenConnecting = true
+    actionIsHidden = true
     callback()
     actionTimeout.restart()
   }
@@ -937,9 +954,9 @@ Panel {
     if (busy || ssid.length === 0) return
     if (hiddenSecurity !== "none" && hiddenPasswordText.length === 0) return
     if (hiddenSecurity === "enterprise" && identity.length === 0) return
-    // Normalize the stored text to the trimmed value submitted below so
-    // hiddenBusy/hiddenFailed (which compare actionSsid === hiddenSsidText)
-    // keep matching once actionSsid is set to the trimmed ssid.
+    // Store the trimmed ssid back so hiddenBusy/hiddenFailed's
+    // actionSsid===hiddenSsidText comparison still matches once actionSsid
+    // is set below.
     hiddenSsidText = ssid
     hiddenIdentityText = identity
     connectHidden(ssid, hiddenSecurity, identity, hiddenPasswordText)
@@ -957,12 +974,9 @@ Panel {
     failureReason = reason
     actionSsid = ""
     actionKind = ""
-    // hiddenConnecting deliberately stays true here (and through the shared
-    // actionTimeout timeout path) -- it still needs to gate hiddenFailed so
-    // this attempt's "Failed"/"Timed out" message renders. It clears once
-    // the user dismisses the form (cancelHiddenForm) or retries
-    // (runHiddenAction resets failureSsid/failureReason for the new attempt
-    // regardless of hiddenConnecting's prior value).
+    // hiddenConnecting deliberately stays true (through this and the shared
+    // actionTimeout path) so hiddenFailed can render; it only clears via
+    // cancelHiddenForm (dismiss) or a fresh runHiddenAction (retry).
   }
 
   // Runs the hidden-network nmcli command (see Model.hiddenPskConnectScript /
@@ -1907,49 +1921,29 @@ Panel {
             Keys.onEscapePressed: root.cancelHiddenForm()
           }
 
-          Item {
+          Button {
+            id: hiddenConnectBtn
             width: parent.width
-            implicitHeight: Math.max(Style.spacing.controlHeight, hiddenConnectBtn.implicitHeight)
+            text: root.hiddenBusy ? "Connecting…" : "Connect"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            horizontalPadding: Style.space(10)
+            enabled: !root.busy && !root.hiddenBusy && root.hiddenSsidText.trim().length > 0
+              && (root.hiddenSecurity === "none" || root.hiddenPasswordText.length > 0)
+              && (root.hiddenSecurity !== "enterprise" || root.hiddenIdentityText.trim().length > 0)
+            onClicked: root.submitHiddenNetwork()
+          }
 
-            // Same status-pill chrome as the scanned-row inline prompt
-            // (statusMsgWrapper below) so the two connecting/failed states
-            // in this file read consistently.
-            BorderSurface {
-              id: hiddenStatusWrapper
-              visible: root.hiddenBusy || root.hiddenFailed
-              anchors.left: parent.left
-              anchors.right: hiddenConnectBtn.left
-              anchors.rightMargin: Style.space(8)
-              anchors.verticalCenter: parent.verticalCenter
-              height: Style.spacing.controlHeight
-              color: Style.normalFillFor(root.bar.foreground)
-              borderSpec: Border.controlSpec("normal", root.bar.foreground, Color.accent)
-              radius: Style.cornerRadius
-
-              Text {
-                anchors.fill: parent
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: root.hiddenBusy ? "Connecting…" : (root.failureReason || "Failed")
-                color: root.hiddenFailed ? root.bar.urgent : root.bar.foreground
-                font.family: root.bar.fontFamily
-                font.pixelSize: Style.font.bodySmall
-              }
-            }
-
-            PanelActionButton {
-              id: hiddenConnectBtn
-              anchors.right: parent.right
-              anchors.verticalCenter: parent.verticalCenter
-              enabled: !root.busy && root.hiddenSsidText.trim().length > 0
-                && (root.hiddenSecurity === "none" || root.hiddenPasswordText.length > 0)
-                && (root.hiddenSecurity !== "enterprise" || root.hiddenIdentityText.trim().length > 0)
-              iconText: "󰄬"
-              tooltipText: "Connect"
-              foreground: root.bar.foreground
-              fontFamily: root.bar.fontFamily
-              onClicked: root.submitHiddenNetwork()
-            }
+          // Shows once hiddenBusy clears with a failure pending; fields
+          // stay populated so the user can fix and retry without retyping.
+          Text {
+            visible: root.hiddenFailed
+            width: parent.width
+            horizontalAlignment: Text.AlignHCenter
+            text: root.failureReason || "Failed to connect"
+            color: root.bar.urgent
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
           }
         }
       }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -141,11 +141,14 @@ Panel {
   readonly property bool hiddenBusy: hiddenConnecting && actionIsHidden && actionKind === "connect" && hiddenSsidText !== "" && actionSsid === hiddenSsidText
   readonly property bool hiddenFailed: hiddenConnecting && actionIsHidden && failureReason !== "" && hiddenSsidText !== "" && failureSsid === hiddenSsidText
 
-  // The Dropdown disappears with the rest of the form, so a cursor left
-  // pointing at it would be stuck on nothing -- fall back to the toggle,
-  // which stays visible when the form closes.
+  // On close: bounce the cursor off the vanished Dropdown onto the toggle,
+  // and restore keyCatcher focus (a hidden field may still hold it) so
+  // j/k/Enter resume -- same pattern as onPasswordSsidChanged.
   onHiddenFormOpenChanged: {
-    if (!hiddenFormOpen && focusSection === "hiddenSecurity") focusSection = "hiddenToggle"
+    if (!hiddenFormOpen) {
+      if (focusSection === "hiddenSecurity") focusSection = "hiddenToggle"
+      if (opened) Qt.callLater(function() { if (keyCatcher) keyCatcher.forceActiveFocus() })
+    }
   }
 
   // The section vanishes with the Wi-Fi station: close the form, evacuate
@@ -581,6 +584,7 @@ Panel {
   function summonWifiQr(forceDetect) {
     controller.hide()
     cancelPasswordPrompt()
+    cancelHiddenForm()
     var payload = {}
     if (!forceDetect && info.type === "wifi" && info.iface) {
       payload.iface = info.iface
@@ -774,6 +778,7 @@ Panel {
   function summonSpeedTest() {
     controller.hide()
     cancelPasswordPrompt()
+    cancelHiddenForm()
     var connection = ""
     if (info.type === "wifi") connection = info.ssid || "Wi-Fi"
     else if (info.type === "ethernet") connection = "Ethernet"

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -55,6 +55,14 @@ Panel {
     }
   }
 
+  // After a failure the passphrase is the likeliest thing to fix, so it gets
+  // focus when present; otherwise fall back to the SSID field.
+  function focusHiddenForm() {
+    if (!opened || !hiddenFormOpen) return
+    if (hiddenPasswordField.visible) hiddenPasswordField.forceActiveFocus()
+    else hiddenSsidField.forceActiveFocus()
+  }
+
   // Live connection details from `ip` / /sys / iw.
   property var info: ({})  // { iface, type, ip, prefix, gateway, speed, duplex, ssid, signal, freq, bitrate, rx_bytes, tx_bytes, router_ping_ms, internet_ping_ms }
 
@@ -400,6 +408,10 @@ Panel {
       dnsIndex = idx >= 0 ? idx : 0
       syncBandIndex()
       cursorActive = hasCaptivePortal
+      // A retained failed hidden attempt reopens with the form still showing;
+      // hand it focus after KeyboardPanel's default keyCatcher grab so a
+      // keyboard-only user can fix and resubmit without a click.
+      if (hiddenFormOpen && hiddenFailed) Qt.callLater(root.focusHiddenForm)
     } else {
       // Drop a restart armed by this open: without it a close/reopen inside
       // the 100ms window reuses the running timer and re-enables the scanner
@@ -973,6 +985,9 @@ Panel {
     actionKind = ""
     // hiddenConnecting stays true so hiddenFailed renders; it clears on
     // dismiss (cancelHiddenForm) or retry (runHiddenAction).
+    // actionKind clearing above re-enables the fields synchronously, but a
+    // disabled field can't take focus yet -- defer until they're live.
+    Qt.callLater(root.focusHiddenForm)
   }
 
   // Runs the hidden-network nmcli command; secret over stdin like

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1205,10 +1205,14 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      // Freeze the cursor model while the inline password prompt or the
-      // hidden-security Dropdown's popup is open; the TextField / Dropdown's
-      // own ListView owns input until Esc/Enter/Cancel closes it.
+      // Freeze the cursor model while the inline password prompt, a hidden-form
+      // text field, or the hidden-security Dropdown's popup owns input. Without
+      // gating on the hidden fields, this BeforeItem catcher would eat Space,
+      // Enter, arrows, and h/j/k/l/x before the focused field saw them --
+      // blocking many valid SSIDs, identities, and passphrases.
       blocked: root.passwordSsid !== "" || hiddenSecurityDropdown.popupOpen
+        || hiddenSsidField.activeFocus || hiddenIdentityField.activeFocus
+        || hiddenPasswordField.activeFocus
 
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -31,22 +31,16 @@ Panel {
 
   function cancelHiddenForm() {
     hiddenPasswordText = ""
-    // Leave the form open (and ssid/security in place) while busy:
-    // hiddenBusy keys off hiddenSsidText, and closing the form here would
-    // make a reopened panel show nothing instead of "Connecting…" for the
-    // still-running attempt. The toggle button stays disabled meanwhile
-    // (enabled: !root.busy), so this doesn't reopen a way to cancel/resubmit.
+    // Keep the form (and its state) while a connect is in flight so a
+    // reopened panel still shows "Connecting…"; the disabled toggle
+    // prevents cancel/resubmit meanwhile.
     if (hiddenBusy) return
     hiddenFormOpen = false
     hiddenSsidText = ""
     hiddenSecurity = "wpa-psk"
-    // Done with this attempt (if any) -- past this point the shared
-    // actionSsid/failureSsid state no longer belongs to the hidden form.
     hiddenConnecting = false
-    // Dropdown.selectCurrent() imperatively assigns its own `value` on a
-    // user pick, which severs the `value: root.hiddenSecurity` binding.
-    // Re-arm it here so a programmatic reset (like the line above) is
-    // reflected in what the dropdown displays next time the form opens.
+    // A user pick severs the `value:` binding (Dropdown assigns its own
+    // value); re-arm it so this reset shows in the dropdown.
     hiddenSecurityDropdown.value = Qt.binding(function() { return root.hiddenSecurity })
   }
 
@@ -126,46 +120,40 @@ Panel {
   property string actionKind: ""  // "connect" | "disconnect" | "forget"
   property string failureSsid: ""
   property string failureReason: ""
-  // Which code path currently owns the shared action* state above -- a row
-  // (runNetworkAction) or the hidden form (runHiddenAction). String equality
-  // on actionSsid alone can't tell those apart when a typed hidden SSID
-  // happens to match a scanned row's, so hiddenBusy/hiddenFailed also check
-  // this before claiming the state as their own.
+  // Which path owns the shared action* state: a row (runNetworkAction) or
+  // the hidden form (runHiddenAction). actionSsid alone can't tell them
+  // apart when a typed hidden SSID matches a scanned row's.
   property bool actionIsHidden: false
   property string passwordSsid: ""
   property string passwordText: ""
   property string identityText: ""
 
-  // "Join hidden network" form state. Hidden SSIDs never scan in, so this
-  // form gathers everything up front instead of expanding out of a row.
-  // Reuses actionSsid/actionKind/failureSsid/failureReason above so the
-  // panel-wide busy gate covers this action too.
+  // "Join hidden network" form state. Hidden SSIDs never scan in, so the
+  // form gathers everything up front; it reuses the shared action* state
+  // above so the panel-wide busy gate covers it too.
   property bool hiddenFormOpen: false
   property string hiddenSsidText: ""
   property string hiddenSecurity: "wpa-psk"  // "wpa-psk" | "sae" | "none"
   property string hiddenPasswordText: ""
-  // Marks this attempt as the hidden form's own, so a scanned row sharing
-  // the typed SSID doesn't read as this attempt (or vice versa).
+  // True from submit until the attempt is dismissed/retried; keeps
+  // hiddenFailed rendering after the shared action state clears.
   property bool hiddenConnecting: false
   readonly property bool hiddenBusy: hiddenConnecting && actionIsHidden && actionKind === "connect" && hiddenSsidText !== "" && actionSsid === hiddenSsidText
   readonly property bool hiddenFailed: hiddenConnecting && actionIsHidden && failureReason !== "" && hiddenSsidText !== "" && failureSsid === hiddenSsidText
 
   // The Dropdown disappears with the rest of the form, so a cursor left
-  // pointing at it would be stuck on nothing -- same shape as
-  // onCanSelectBandChanged.
+  // pointing at it would be stuck on nothing -- fall back to the toggle,
+  // which stays visible when the form closes.
   onHiddenFormOpenChanged: {
-    if (!hiddenFormOpen && focusSection === "hiddenSecurity") focusSection = "dns"
+    if (!hiddenFormOpen && focusSection === "hiddenSecurity") focusSection = "hiddenToggle"
   }
 
-  // The whole hidden-form section vanishes with the Wi-Fi station, so a form
-  // left open (or a cursor left on its Dropdown) would be stuck on nothing --
-  // same shape as onCanSelectBandChanged. Set hiddenFormOpen directly rather
-  // than through cancelHiddenForm(), since the section is being hidden anyway.
-  // The field reset below is skipped while a hidden connect is in flight, same
-  // reasoning as cancelHiddenForm: don't yank state out from under a pending action.
+  // The section vanishes with the Wi-Fi station: close the form, evacuate
+  // the cursor, and reset the fields -- unless a connect is in flight
+  // (same reasoning as cancelHiddenForm).
   onWifiStationAvailableChanged: if (!wifiStationAvailable) {
     hiddenFormOpen = false
-    if (focusSection === "hiddenSecurity") focusSection = "dns"
+    if (focusSection === "hiddenSecurity" || focusSection === "hiddenToggle") focusSection = "dns"
     if (!hiddenBusy) {
       hiddenSsidText = ""
       hiddenSecurity = "wpa-psk"
@@ -197,11 +185,10 @@ Panel {
 
   // Keyboard focus zone for the panel. j/k crosses row boundaries:
   // header actions ⇄ portal ⇄ band ⇄ DNS row ⇄ Wi-Fi networks ⇄
-  // hidden-network security Dropdown (only reachable while the
-  // hidden-network form is open; the Dropdown owns its own option
-  // navigation once opened). h/l move within header actions, band pills,
-  // or DNS providers.
-  property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "wifi" | "hiddenSecurity"
+  // Join-hidden-network toggle ⇄ security Dropdown (Dropdown only reachable
+  // while the form is open; it owns its own option navigation once opened).
+  // h/l move within header actions, band pills, or DNS providers.
+  property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "wifi" | "hiddenToggle" | "hiddenSecurity"
   property int headerIndex: 0
   readonly property bool canDisconnect: !!connectedWifiNetwork
   readonly property bool headerHasDisconnect: false
@@ -860,10 +847,8 @@ Panel {
 
   function clearNetworkAction() {
     actionTimeout.stop()
-    // Guard on actionSsid matching the open prompt, and on !actionIsHidden --
-    // a completing hidden connect (whose typed SSID may coincidentally equal
-    // an unrelated row's) or any other row's connect must not clobber an
-    // unrelated row's still-open passphrase prompt.
+    // Only the row connect this prompt was opened for may close it --
+    // never a hidden connect that happens to share the SSID.
     if (!actionIsHidden && actionKind === "connect" && actionSsid === passwordSsid) passwordSsid = ""
     failureSsid = ""
     failureReason = ""
@@ -874,8 +859,7 @@ Panel {
   }
 
   function failNetworkAction(network, reason) {
-    // A hidden connect owns the shared action* state right now -- a scanned
-    // row sharing its typed SSID must not touch it (see actionIsHidden).
+    // Row-only: a hidden connect owns the action state right now.
     if (actionIsHidden) return
     if (!network || actionKind === "" || actionSsid !== (network.name || "")) return
     actionTimeout.stop()
@@ -895,8 +879,7 @@ Panel {
   }
 
   function checkActionCompletion(network) {
-    // A hidden connect owns the shared action* state right now -- a scanned
-    // row sharing its typed SSID must not touch it (see actionIsHidden).
+    // Row-only: a hidden connect owns the action state right now.
     if (actionIsHidden) return
     if (!network || actionKind === "" || actionSsid !== (network.name || "")) return
     if (actionKind === "connect" && network.connected) clearNetworkAction()
@@ -941,8 +924,6 @@ Panel {
     actionKind = "connect"
     failureSsid = ""
     failureReason = ""
-    // Marks this attempt as the hidden form's own, so a scanned row sharing
-    // the typed SSID doesn't read as this attempt (or vice versa).
     hiddenConnecting = true
     actionIsHidden = true
     callback()
@@ -953,12 +934,11 @@ Panel {
     runHiddenAction(ssid, function() {
       if (security === "none") {
         hiddenConnect.secret = ""
-        // "--" stops nmcli from parsing an SSID that happens to look like one
-        // of its own flags (e.g. "--ask") as that flag instead of the SSID.
+        // "--" keeps a flag-like SSID (e.g. "--ask") from being parsed as
+        // an nmcli option.
         hiddenConnect.command = ["nmcli", "device", "wifi", "connect", "--", ssid, "hidden", "yes"]
       } else {
-        // security is "wpa-psk" or "sae" -- the literal nmcli key-mgmt value,
-        // never user text -- passed through as $2 for the script to set.
+        // security is our own "wpa-psk"/"sae" literal, passed as $2.
         hiddenConnect.secret = passphrase
         hiddenConnect.command = ["bash", "-c", Model.hiddenPskConnectScript, "nmcli-hidden-psk", ssid, security]
       }
@@ -967,9 +947,8 @@ Panel {
   }
 
   function submitHiddenNetwork() {
-    // Leading/trailing spaces are legal SSID bytes, so trim only for the
-    // empty-input guard -- the exact typed SSID is what gets connected and
-    // what hiddenBusy/hiddenFailed compare against.
+    // Spaces are legal SSID bytes: trim only for the empty check, connect
+    // with the exact typed value.
     var ssid = hiddenSsidText
     if (busy || ssid.trim().length === 0) return
     if (hiddenSecurity !== "none" && hiddenPasswordText.length === 0) return
@@ -988,14 +967,12 @@ Panel {
     failureReason = reason
     actionSsid = ""
     actionKind = ""
-    // hiddenConnecting deliberately stays true (through this and the shared
-    // actionTimeout path) so hiddenFailed can render; it only clears via
-    // cancelHiddenForm (dismiss) or a fresh runHiddenAction (retry).
+    // hiddenConnecting stays true so hiddenFailed renders; it clears on
+    // dismiss (cancelHiddenForm) or retry (runHiddenAction).
   }
 
-  // Runs the hidden-network nmcli command (see Model.hiddenPskConnectScript).
-  // Same stdin-secret handoff as enterpriseConnect; the open path never
-  // sets a secret.
+  // Runs the hidden-network nmcli command; secret over stdin like
+  // enterpriseConnect (the open path sets none).
   Process {
     id: hiddenConnect
     property string secret: ""
@@ -1175,10 +1152,8 @@ Panel {
     repeat: false
     onTriggered: {
       if (!root.actionKind) return
-      // A hidden connect owns a long-lived nmcli process. Clearing the action
-      // here would strand that process: it can't be restarted while running,
-      // and its late exit would clobber whatever action started next. Kill it
-      // instead and let hiddenConnect.onExited settle the state.
+      // Kill the hidden connect's process instead of clearing the action --
+      // a stranded process's late exit would clobber the next action.
       if (root.actionIsHidden) {
         hiddenConnect.timedOut = true
         hiddenConnect.running = false
@@ -1237,12 +1212,11 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      // Freeze the cursor model while the inline password prompt, a hidden-form
-      // text field, or the hidden-security Dropdown's popup owns input. Without
-      // gating on the hidden fields, this BeforeItem catcher would eat Space,
-      // Enter, arrows, and h/j/k/l/x before the focused field saw them --
-      // blocking many valid SSIDs and passphrases.
+      // Stand down while an inline editor, the Dropdown popup, or the
+      // Dropdown trigger owns input -- this BeforeItem catcher would
+      // otherwise eat their keys.
       blocked: root.passwordSsid !== "" || hiddenSecurityDropdown.popupOpen
+        || hiddenSecurityDropdown.triggerFocused
         || hiddenSsidField.activeFocus || hiddenPasswordField.activeFocus
 
       onMoveRequested: function(dx, dy) {
@@ -1289,11 +1263,8 @@ Panel {
               root.focusSection = "dns"
             }
           } else if (root.focusSection === "dns") {
-            // k from DNS moves up into the band section when it's on screen,
-            // then the disconnect button; otherwise stays put. j drops into the
-            // wifi list if there's anywhere to land, or straight into the
-            // hidden-network security Dropdown when the list is empty but
-            // that form is open -- otherwise j would have nowhere to go.
+            // k: band section when on screen, else header. j: wifi list,
+            // or the hidden-network toggle when the list is empty.
             if (dy < 0) {
               if (root.canSelectBand) {
                 root.focusSection = "band"
@@ -1307,26 +1278,27 @@ Panel {
             } else if (root.wifiNetworks.length > 0) {
               root.focusSection = "wifi"
               if (root.selectedIndex < 0) root.selectedIndex = 0
-            } else if (root.hiddenFormOpen) {
-              root.focusSection = "hiddenSecurity"
+            } else if (root.wifiStationAvailable) {
+              root.focusSection = "hiddenToggle"
             }
           } else if (root.focusSection === "wifi") {
-            // k from the top row escapes back up to the DNS row rather than
-            // wrapping around to the bottom of the list. j from the bottom
-            // row drops into the hidden-network security Dropdown when that
-            // form is open; otherwise the list just clamps.
+            // k from the top row escapes to DNS instead of wrapping; j from
+            // the bottom row drops onto the hidden-network toggle.
             if (dy < 0 && root.selectedIndex <= 0) {
               root.focusSection = "dns"
               root.wifiActionFocused = false
-            } else if (dy > 0 && root.selectedIndex >= root.wifiNetworks.length - 1 && root.hiddenFormOpen) {
-              root.focusSection = "hiddenSecurity"
+            } else if (dy > 0 && root.selectedIndex >= root.wifiNetworks.length - 1) {
+              root.focusSection = "hiddenToggle"
+              root.wifiActionFocused = false
             } else {
               root.selectByDelta(dy)
             }
-          } else {  // hiddenSecurity
-            // Nothing below the Dropdown to escape into; k climbs back to
-            // the wifi list (or DNS, if the list is empty).
-            if (dy < 0) {
+          } else if (root.focusSection === "hiddenToggle") {
+            // j: the security Dropdown once the form is open. k: back to
+            // the wifi list, or DNS when the list is empty.
+            if (dy > 0 && root.hiddenFormOpen) {
+              root.focusSection = "hiddenSecurity"
+            } else if (dy < 0) {
               if (root.wifiNetworks.length > 0) {
                 root.focusSection = "wifi"
                 root.selectedIndex = root.wifiNetworks.length - 1
@@ -1334,6 +1306,9 @@ Panel {
                 root.focusSection = "dns"
               }
             }
+          } else {  // hiddenSecurity
+            // Nothing below the Dropdown; k climbs back to the toggle.
+            if (dy < 0) root.focusSection = "hiddenToggle"
           }
         }
         if (dx !== 0) {
@@ -1349,6 +1324,7 @@ Panel {
           else if (root.focusSection === "portal") root.openCaptivePortal()
           else if (root.focusSection === "band") root.activateBand()
           else if (root.focusSection === "dns") root.activateDns()
+          else if (root.focusSection === "hiddenToggle") root.toggleHiddenForm()
           else if (root.focusSection === "hiddenSecurity") hiddenSecurityDropdown.open()
           else root.activateSelected()
         }
@@ -1850,9 +1826,8 @@ Panel {
         }
       }
 
-      // Join hidden network — non-broadcasting SSIDs never scan in, so
-      // joining one gathers SSID/security/credentials up front and goes
-      // straight to nmcli (see connectHidden) instead of picking a row above.
+      // Join hidden network — non-broadcasting SSIDs never scan in, so the
+      // form gathers SSID/security/credentials and goes straight to nmcli.
       PanelSeparator {
         visible: root.wifiStationAvailable
         foreground: root.bar.foreground
@@ -1872,7 +1847,13 @@ Panel {
           fontFamily: root.bar.fontFamily
           horizontalPadding: Style.space(10)
           enabled: !root.busy
+          hasCursor: root.cursorActive && root.focusSection === "hiddenToggle"
           onClicked: root.toggleHiddenForm()
+          onHovered: function(isHovered) {
+            if (!isHovered) return
+            root.cursorActive = true
+            root.focusSection = "hiddenToggle"
+          }
         }
 
         Column {
@@ -1903,10 +1884,9 @@ Panel {
             Component.onCompleted: if (visible) Qt.callLater(forceActiveFocus)
           }
 
-          // Enterprise is deliberately not offered for hidden networks: without
-          // a broadcast beacon to scan, there is no CA/server validation UI
-          // here, and a hidden 802.1X join would be exposed to an evil-twin
-          // credential-theft AP impersonating the SSID.
+          // No enterprise option: with no beacon to verify and no CA/server
+          // validation UI, a hidden 802.1X join invites evil-twin credential
+          // theft.
           Dropdown {
             id: hiddenSecurityDropdown
             label: "Security"

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -63,6 +63,39 @@ Panel {
     else hiddenSsidField.forceActiveFocus()
   }
 
+  // Scrolls panelFlick just enough to bring `item` into view, without
+  // otherwise disturbing the scroll position. Mirrors the scrollItemIntoView
+  // idiom in tailscale/dropbox's Panel.qml.
+  function scrollItemIntoView(item) {
+    if (!panelFlick || !item) return
+    Qt.callLater(function() {
+      if (!item) return
+      var margin = Style.space(6)
+      var point = item.mapToItem(panelFlick.contentItem, 0, 0)
+      var top = point.y
+      var bottom = top + item.height
+      var viewTop = panelFlick.contentY
+      var viewBottom = viewTop + panelFlick.height
+      var maxY = Math.max(0, panelFlick.contentHeight - panelFlick.height)
+      if (top < viewTop + margin) panelFlick.contentY = Math.max(0, top - margin)
+      else if (bottom > viewBottom - margin) panelFlick.contentY = Math.min(maxY, bottom + margin - panelFlick.height)
+    })
+  }
+
+  // One coarse target per focusSection: sections don't scroll internally
+  // (the wifi ListView positions its own selected row via
+  // positionViewAtIndex), so bringing the section's container into view
+  // once is enough.
+  function scrollFocusSectionIntoView() {
+    if (focusSection === "header") scrollItemIntoView(heroActions)
+    else if (focusSection === "portal") scrollItemIntoView(portalAction)
+    else if (focusSection === "band") scrollItemIntoView(bandSection)
+    else if (focusSection === "dns") scrollItemIntoView(dnsRow)
+    else if (focusSection === "wifi") scrollItemIntoView(networkList)
+    else if (focusSection === "hiddenToggle") scrollItemIntoView(hiddenToggleButton)
+    else if (focusSection === "hiddenSecurity") scrollItemIntoView(hiddenSecurityDropdown)
+  }
+
   // Live connection details from `ip` / /sys / iw.
   property var info: ({})  // { iface, type, ip, prefix, gateway, speed, duplex, ssid, signal, freq, bitrate, rx_bytes, tx_bytes, router_ping_ms, internet_ping_ms }
 
@@ -201,6 +234,11 @@ Panel {
   // while the form is open; it owns its own option navigation once opened).
   // h/l move within header actions, band pills, or DNS providers.
   property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "wifi" | "hiddenToggle" | "hiddenSecurity"
+  // The outer Flickable owns scroll position, so a keyboard-focused section
+  // that moves off-screen has to be dragged back into the viewport itself --
+  // switching focusSection alone doesn't do that for free. Same idiom as
+  // tailscale/dropbox's scrollItemIntoView().
+  onFocusSectionChanged: scrollFocusSectionIntoView()
   property int headerIndex: 0
   readonly property bool canDisconnect: !!connectedWifiNetwork
   readonly property bool headerHasDisconnect: false
@@ -401,6 +439,7 @@ Panel {
   onOpenedChanged: {
     if (opened) {
       refresh(true)
+      if (panelFlick) panelFlick.contentY = 0
       selectedIndex = wifiNetworks.length > 0 ? 0 : -1
       wifiActionFocused = false
       focusSection = hasCaptivePortal ? "portal" : (wifiNetworks.length > 0 ? "wifi" : "dns")
@@ -1364,12 +1403,20 @@ Panel {
         else if (t === "w" || t === "W") root.toggleNetwork()
       }
 
-    Column {
-      id: column
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.top: parent.top
-      spacing: Style.space(12)
+      Flickable {
+        id: panelFlick
+        anchors.fill: parent
+        contentWidth: width
+        contentHeight: column.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: contentHeight > height
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        Column {
+          id: column
+          width: panelFlick.width
+          spacing: Style.space(12)
 
       // ---------- Hero: network icon · SSID + state · actions ----------
       Item {
@@ -1606,6 +1653,7 @@ Panel {
       }
 
       Column {
+        id: bandSection
         visible: root.canSelectBand
         width: parent.width
         spacing: Style.space(10)
@@ -1804,7 +1852,14 @@ Panel {
       // doesn't push the popup off-screen. ListView (vs Repeater+Column)
       // gives us positionViewAtIndex for free, which is what keeps the
       // keyboard-selected row scrolled into view as j/k walk past the
-      // visible window.
+      // visible window. It now nests inside panelFlick, but stays
+      // interactive: a drag over the list scrolls the list (Qt hands the
+      // gesture to the innermost Flickable under the cursor), and
+      // StopAtBounds means it won't chain into the outer scroller once it
+      // hits bottom -- mildly annoying, but nothing past the 240px cap
+      // becomes unreachable, since panelFlick is still draggable over every
+      // other section. Turning this off would leave overflow rows reachable
+      // only by keyboard.
       ListView {
         id: networkList
         visible: root.wifiStationAvailable
@@ -1910,6 +1965,10 @@ Panel {
 
             onVisibleChanged: if (visible) Qt.callLater(forceActiveFocus)
             Component.onCompleted: if (visible) Qt.callLater(forceActiveFocus)
+            // Gaining focus here doesn't move focusSection, so it needs its
+            // own scroll-into-view -- otherwise a field that just appeared
+            // below the fold takes focus invisibly.
+            onActiveFocusChanged: if (activeFocus) root.scrollItemIntoView(hiddenSsidField)
           }
 
           // No enterprise option: with no beacon to verify and no CA/server
@@ -1950,6 +2009,7 @@ Panel {
             onAccepted: root.submitHiddenNetwork()
             onTextChanged: if (text !== root.hiddenPasswordText) root.hiddenPasswordText = text
             Keys.onEscapePressed: root.cancelHiddenForm()
+            onActiveFocusChanged: if (activeFocus) root.scrollItemIntoView(hiddenPasswordField)
           }
 
           Button {
@@ -1979,7 +2039,8 @@ Panel {
           }
         }
       }
-    }
+        }
+      }
     }
   }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -984,13 +984,19 @@ Panel {
   Process {
     id: hiddenConnect
     property string secret: ""
+    // Set by actionTimeout before it kills this process, so the exit it
+    // provokes is reported as a timeout rather than a plain failure.
+    property bool timedOut: false
     stdinEnabled: true
     onStarted: {
       write(secret + "\n")
       secret = ""
     }
     onExited: function(exitCode) {
-      if (exitCode === 0) root.completeHiddenAction()
+      var wasTimeout = timedOut
+      timedOut = false
+      if (wasTimeout) root.failHiddenAction("Timed out connecting")
+      else if (exitCode === 0) root.completeHiddenAction()
       else root.failHiddenAction("Failed to connect")
     }
   }
@@ -1152,6 +1158,15 @@ Panel {
     repeat: false
     onTriggered: {
       if (!root.actionKind) return
+      // A hidden connect owns a long-lived nmcli process. Clearing the action
+      // here would strand that process: it can't be restarted while running,
+      // and its late exit would clobber whatever action started next. Kill it
+      // instead and let hiddenConnect.onExited settle the state.
+      if (root.actionIsHidden) {
+        hiddenConnect.timedOut = true
+        hiddenConnect.running = false
+        return
+      }
       var reason
       if (root.actionKind === "connect") reason = "Timed out connecting"
       else if (root.actionKind === "disconnect") reason = "Timed out disconnecting"

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -851,10 +851,11 @@ Panel {
 
   function clearNetworkAction() {
     actionTimeout.stop()
-    // Guard on actionSsid matching the open prompt -- a completing hidden
-    // connect (or any other row's connect) must not clobber an unrelated
-    // row's still-open passphrase prompt.
-    if (actionKind === "connect" && actionSsid === passwordSsid) passwordSsid = ""
+    // Guard on actionSsid matching the open prompt, and on !actionIsHidden --
+    // a completing hidden connect (whose typed SSID may coincidentally equal
+    // an unrelated row's) or any other row's connect must not clobber an
+    // unrelated row's still-open passphrase prompt.
+    if (!actionIsHidden && actionKind === "connect" && actionSsid === passwordSsid) passwordSsid = ""
     failureSsid = ""
     failureReason = ""
     actionSsid = ""
@@ -2069,8 +2070,11 @@ Panel {
       function onConnectionFailed(reason) {
         // Background auto-connect retries fire this too; only reprompt for
         // the connect started from this panel. Checked before
-        // failNetworkAction, which clears the action state.
-        var ours = root.actionKind === "connect" && root.actionSsid === (row.net.ssid || "")
+        // failNetworkAction, which clears the action state. Also gate on
+        // !actionIsHidden: a hidden attempt whose typed SSID equals this
+        // row's would otherwise read as "ours" and reopen this row's
+        // passphrase prompt for a failure that isn't its own.
+        var ours = !root.actionIsHidden && root.actionKind === "connect" && root.actionSsid === (row.net.ssid || "")
         root.failNetworkAction(root.networkForSsid(row.net.ssid), reason)
         if (ours && root.shouldRepromptPassphrase(reason, row.requiresCredentials)) root.openPasswordPrompt(row.net.ssid)
       }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -963,10 +963,10 @@ Panel {
   }
 
   function submitHiddenNetwork() {
-    // Spaces are legal SSID bytes: trim only for the empty check, connect
-    // with the exact typed value.
+    // Spaces are legal SSID bytes -- even an all-space SSID -- so only the
+    // truly empty string is rejected; connect with the exact typed value.
     var ssid = hiddenSsidText
-    if (busy || ssid.trim().length === 0) return
+    if (busy || ssid.length === 0) return
     if (hiddenSecurity !== "none" && hiddenPasswordText.length === 0) return
     connectHidden(ssid, hiddenSecurity, hiddenPasswordText)
   }
@@ -1954,7 +1954,7 @@ Panel {
             foreground: root.bar.foreground
             fontFamily: root.bar.fontFamily
             horizontalPadding: Style.space(10)
-            enabled: !root.busy && !root.hiddenBusy && root.hiddenSsidText.trim().length > 0
+            enabled: !root.busy && !root.hiddenBusy && root.hiddenSsidText.length > 0
               && (root.hiddenSecurity === "none" || root.hiddenPasswordText.length > 0)
             onClicked: root.submitHiddenNetwork()
           }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -949,15 +949,14 @@ Panel {
   }
 
   function submitHiddenNetwork() {
-    var ssid = hiddenSsidText.trim()
+    // Leading/trailing spaces are legal SSID bytes, so trim only for the
+    // empty-input guard -- the exact typed SSID is what gets connected and
+    // what hiddenBusy/hiddenFailed compare against.
+    var ssid = hiddenSsidText
     var identity = hiddenIdentityText.trim()
-    if (busy || ssid.length === 0) return
+    if (busy || ssid.trim().length === 0) return
     if (hiddenSecurity !== "none" && hiddenPasswordText.length === 0) return
     if (hiddenSecurity === "enterprise" && identity.length === 0) return
-    // Store the trimmed ssid back so hiddenBusy/hiddenFailed's
-    // actionSsid===hiddenSsidText comparison still matches once actionSsid
-    // is set below.
-    hiddenSsidText = ssid
     hiddenIdentityText = identity
     connectHidden(ssid, hiddenSecurity, identity, hiddenPasswordText)
   }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -30,11 +30,12 @@ Panel {
   }
 
   function cancelHiddenForm() {
-    hiddenPasswordText = ""
-    // Keep the form (and its state) while a connect is in flight so a
-    // reopened panel still shows "Connecting…"; the disabled toggle
-    // prevents cancel/resubmit meanwhile.
+    // Keep the form and its full state — passphrase included — while a
+    // connect is in flight so a reopened panel still shows "Connecting…"
+    // and a later failure can be retried without retyping; the disabled
+    // toggle prevents cancel/resubmit meanwhile.
     if (hiddenBusy) return
+    hiddenPasswordText = ""
     hiddenFormOpen = false
     hiddenSsidText = ""
     hiddenSecurity = "wpa-psk"

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -124,13 +124,6 @@ assert_not_contains() {
   pass "$description"
 }
 
-assert_file_absent() {
-  local file=$1 description=$2
-
-  [[ ! -e $file ]] || fail "$description" "expected '$file' to not exist"
-  pass "$description"
-}
-
 # Proves ordering, not just presence -- a dedupe delete that ran before
 # connection up would delete the old profile before the new one is proven.
 assert_order() {

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -60,6 +60,12 @@ case "$*" in
     exit 0
     ;;
   *"-t -f UUID,TYPE connection show"*)
+    [[ -n ${NM_LIST_PID_FILE:-} ]] && printf '%s\n' "$$" >"$NM_LIST_PID_FILE"
+    if [[ -n ${NM_LIST_SLEEP:-} ]]; then
+      sleep "$NM_LIST_SLEEP" & sleep_pid=$!
+      trap 'kill -TERM $sleep_pid 2>/dev/null; exit 143' TERM
+      wait $sleep_pid
+    fi
     printf '%s' "$NM_CONNECTIONS"
     ;;
   *"--escape no -g"*)
@@ -90,14 +96,16 @@ wifi_record() {
 # must leave it alone -- it is not hidden), and an unrelated ethernet profile
 # (dedupe must not even consider non-wifi types). The SSID carries a space to
 # prove the scripts stay space-safe end to end.
-NM_CONNECTIONS=$'old-hidden:802-11-wireless\nbroadcast:802-11-wireless\neth:802-3-ethernet\n'
+NM_CONNECTIONS=$'old-hidden:802-11-wireless\nbroadcast:802-11-wireless\neth:802-3-ethernet\nnew-uuid-0000:802-11-wireless\n'
 NM_WIFI_FIELDS_PSK=$(
   wifi_record old-hidden "my ssid" yes wpa-psk "" "" "" auto auto "" "" "" "" "" ""
   wifi_record broadcast "my ssid" no "" "" "" "" auto auto "" "" "" "" "" ""
+  wifi_record new-uuid-0000 "my ssid" yes wpa-psk "" "" "" auto auto "" "" "" "" "" ""
 )
 NM_WIFI_FIELDS_OPEN=$(
   wifi_record old-hidden "my ssid" yes "" "" "" "" auto auto "" "" "" "" "" ""
   wifi_record broadcast "my ssid" no "" "" "" "" auto auto "" "" "" "" "" ""
+  wifi_record new-uuid-0000 "my ssid" yes "" "" "" "" auto auto "" "" "" "" "" ""
 )
 
 assert_contains() {
@@ -151,7 +159,7 @@ printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
 (( rc == 0 )) || fail "hidden PSK connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
 pass "hidden PSK connect succeeds when activation and autoconnect arm both succeed"
 
-add_line=$(grep -m1 -F "connection add" "$log")
+add_line=$(grep -m1 -F "connection add" "$log") || true
 [[ $add_line == *"connection.autoconnect no"* ]] || fail "hidden PSK success creates the profile inert (autoconnect no)" "$add_line"
 pass "hidden PSK success creates the profile inert (autoconnect no)"
 [[ $add_line == *"802-11-wireless.hidden yes"* ]] || fail "hidden PSK success marks the new profile hidden" "$add_line"
@@ -167,18 +175,21 @@ assert_contains "$edit" "set wifi-sec.psk secret pass" "hidden PSK success sets 
 # readable in /proc, so a leak here is a local secret-disclosure bug.
 assert_not_contains "$log" "secret pass" "hidden PSK success never puts the passphrase in nmcli argv"
 
-delete_line=$(grep -m1 -F "connection delete" "$log")
+delete_line=$(grep -m1 -F "connection delete" "$log") || true
 [[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK success deletes an uncustomized prior hidden profile for this ssid" "$delete_line"
 pass "hidden PSK success deletes an uncustomized prior hidden profile for this ssid"
 [[ $delete_line != *"broadcast"* ]] || fail "hidden PSK success never deletes a same-ssid broadcast profile" "$delete_line"
 pass "hidden PSK success never deletes a same-ssid broadcast profile"
 [[ $delete_line != *"eth"* ]] || fail "hidden PSK success never deletes an unrelated ethernet profile" "$delete_line"
 pass "hidden PSK success never deletes an unrelated ethernet profile"
-[[ $delete_line != *"new-uuid-0000"* ]] || fail "hidden PSK success never deletes the profile it just proved" "$delete_line"
-pass "hidden PSK success never deletes the profile it just proved"
+[[ $delete_line != *"new-uuid-0000"* ]] || fail "hidden PSK success never deletes the profile it just activated (self-exclusion)" "$delete_line"
+pass "hidden PSK success never deletes the profile it just activated (self-exclusion)"
 
 assert_order "$log" "connection up" "connection modify" "hidden PSK success brings the profile up before arming autoconnect"
 assert_order "$log" "connection modify" "connection delete" "hidden PSK success arms autoconnect before deleting the old profile"
+assert_order "$log" "connection modify" "-t -f UUID,TYPE" "hidden PSK success runs the whole snapshot, both queries, only after the autoconnect arm"
+assert_order "$log" "connection modify" "--escape no -g" "hidden PSK success snapshots duplicates only after the autoconnect arm, adjacent to the delete"
+assert_order "$log" "--escape no -g" "connection delete" "hidden PSK success deletes from the fresh snapshot, not a stale pre-connect one"
 
 # --- Scenario 2: PSK activation failure ----------------------------------
 
@@ -271,6 +282,60 @@ pass "hidden PSK termination terminates the child nmcli process rather than orph
 assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK termination lets the EXIT trap delete the unproven profile"
 assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK termination leaves the old profile in place"
 
+# --- Scenario 4b: PSK termination during the post-activation snapshot -----
+#
+# Mirrors scenario 4, but hangs the dedupe's `-t -f UUID,TYPE` query instead
+# of `connection up`. The snapshot now runs inside the modify-success block,
+# after the profile is created and activated -- this proves the re-armed TERM
+# trap still reaches the process substitution's nmcli at that later point,
+# and that a kill there leaves the already-activated connection and every
+# duplicate alone (nothing left to delete yet).
+
+log=$tmp/log_psk_list_term
+edit=$tmp/edit_psk_list_term
+input=$tmp/input_psk_list_term
+pidfile=$tmp/pid_list_term
+: >"$log"
+rm -f "$pidfile"
+printf 'secret pass\n' >"$input"
+
+PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_PSK" \
+  NM_LIST_SLEEP=20 NM_LIST_PID_FILE="$pidfile" \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk <"$input" &
+pid=$!
+
+waited=0
+while [[ ! -s $pidfile ]]; do
+  sleep 0.1
+  waited=$((waited + 1))
+  (( waited < 50 )) || fail "hidden PSK post-activation snapshot termination test setup" "nmcli stub pid file never appeared within 5s"
+done
+nmcli_pid=$(<"$pidfile")
+
+start_ns=$(date +%s%N)
+kill -TERM "$pid"
+rc=0
+wait "$pid" || rc=$?
+elapsed_ms=$(( ($(date +%s%N) - start_ns) / 1000000 ))
+
+(( elapsed_ms < 2000 )) || fail "hidden PSK post-activation snapshot termination interrupts the trap-armed read instead of waiting out the query" "elapsed: ${elapsed_ms}ms"
+pass "hidden PSK post-activation snapshot termination interrupts the trap-armed read instead of waiting out the query"
+
+(( rc != 0 )) || fail "hidden PSK connect reports failure when killed during the post-activation snapshot"
+pass "hidden PSK connect reports failure when killed during the post-activation snapshot"
+
+sleep 0.3
+if kill -0 "$nmcli_pid" 2>/dev/null; then
+  fail "hidden PSK post-activation snapshot termination kills the query's nmcli rather than orphaning it" "pid $nmcli_pid is still running"
+fi
+pass "hidden PSK post-activation snapshot termination kills the query's nmcli rather than orphaning it"
+
+assert_contains "$log" "connection add" "hidden PSK snapshot-phase termination happens after the profile was created"
+assert_contains "$log" "connection up" "hidden PSK snapshot-phase termination happens after activation"
+assert_not_contains "$log" "connection delete" "hidden PSK snapshot-phase termination deletes nothing: the activated profile survives and duplicates are left alone"
+
 # --- Scenario 5: dedupe preserves customized same-SSID hidden profiles ----
 #
 # Each of these profiles matches on SSID/hidden/key-mgmt alone -- the same
@@ -298,7 +363,7 @@ printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
 (( rc == 0 )) || fail "hidden PSK connect succeeds alongside customized same-ssid profiles" "exit code: $rc"
 pass "hidden PSK connect succeeds alongside customized same-ssid profiles"
 
-delete_line=$(grep -m1 -F "connection delete" "$log")
+delete_line=$(grep -m1 -F "connection delete" "$log") || true
 [[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK dedupe still deletes the uncustomized duplicate" "$delete_line"
 pass "hidden PSK dedupe still deletes the uncustomized duplicate"
 [[ $delete_line != *"custom-ip4method"* ]] || fail "hidden PSK dedupe spares a same-ssid profile with a manual ipv4.method" "$delete_line"
@@ -328,7 +393,7 @@ printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
 (( rc == 0 )) || fail "hidden PSK connect succeeds alongside a same-ssid sae profile" "exit code: $rc"
 pass "hidden PSK connect succeeds alongside a same-ssid sae profile"
 
-delete_line=$(grep -m1 -F "connection delete" "$log")
+delete_line=$(grep -m1 -F "connection delete" "$log") || true
 [[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK dedupe still deletes the same-key-mgmt duplicate" "$delete_line"
 pass "hidden PSK dedupe still deletes the same-key-mgmt duplicate"
 [[ $delete_line != *"custom-keymgmt"* ]] || fail "hidden PSK dedupe spares a same-ssid profile using a different key-mgmt (sae vs wpa-psk)" "$delete_line"
@@ -347,7 +412,7 @@ printf '\n' | PATH="$tmp/bin:$PATH" \
 (( rc == 0 )) || fail "hidden open connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
 pass "hidden open connect succeeds when activation and autoconnect arm both succeed"
 
-add_line=$(grep -m1 -F "connection add" "$log")
+add_line=$(grep -m1 -F "connection add" "$log") || true
 [[ $add_line == *"802-11-wireless.hidden yes"* ]] || fail "hidden open success marks the new profile hidden" "$add_line"
 pass "hidden open success marks the new profile hidden"
 [[ $add_line == *"connection.autoconnect no"* ]] || fail "hidden open success creates the profile inert (autoconnect no)" "$add_line"
@@ -356,16 +421,21 @@ pass "hidden open success creates the profile inert (autoconnect no)"
 assert_not_contains "$log" "wifi-sec" "hidden open success sets no wifi security properties on an open profile"
 assert_not_contains "$log" "connection edit" "hidden open success never opens the connection editor, since there is no secret to set"
 
-delete_line=$(grep -m1 -F "connection delete" "$log")
+delete_line=$(grep -m1 -F "connection delete" "$log") || true
 [[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden open success deletes the prior hidden profile for this ssid" "$delete_line"
 pass "hidden open success deletes the prior hidden profile for this ssid"
 [[ $delete_line != *"broadcast"* ]] || fail "hidden open success never deletes a same-ssid broadcast profile" "$delete_line"
 pass "hidden open success never deletes a same-ssid broadcast profile"
 [[ $delete_line != *"eth"* ]] || fail "hidden open success never deletes an unrelated ethernet profile" "$delete_line"
 pass "hidden open success never deletes an unrelated ethernet profile"
+[[ $delete_line != *"new-uuid-0000"* ]] || fail "hidden open success never deletes the profile it just activated (self-exclusion)" "$delete_line"
+pass "hidden open success never deletes the profile it just activated (self-exclusion)"
 
 assert_order "$log" "connection up" "connection modify" "hidden open success brings the profile up before arming autoconnect"
 assert_order "$log" "connection modify" "connection delete" "hidden open success arms autoconnect before deleting the old profile"
+assert_order "$log" "connection modify" "-t -f UUID,TYPE" "hidden open success runs the whole snapshot, both queries, only after the autoconnect arm"
+assert_order "$log" "connection modify" "--escape no -g" "hidden open success snapshots duplicates only after the autoconnect arm, adjacent to the delete"
+assert_order "$log" "--escape no -g" "connection delete" "hidden open success deletes from the fresh snapshot, not a stale pre-connect one"
 
 # --- Scenario 8: Open network activation failure --------------------------
 

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -96,10 +96,11 @@ assert_order() {
   local file=$1 first=$2 second=$3 description=$4
   local first_line second_line
 
-  first_line=$(grep -n -m1 -F -- "$first" "$file" | cut -d: -f1)
-  second_line=$(grep -n -m1 -F -- "$second" "$file" | cut -d: -f1)
-  [[ -n $first_line && -n $second_line && $first_line -lt $second_line ]] ||
+  first_line=$(grep -n -m1 -F -- "$first" "$file" | cut -d: -f1 || true)
+  second_line=$(grep -n -m1 -F -- "$second" "$file" | cut -d: -f1 || true)
+  if [[ -z $first_line || -z $second_line ]] || (( first_line >= second_line )); then
     fail "$description" "first='$first' at line ${first_line:-none}; second='$second' at line ${second_line:-none}\n$(cat -n "$file")"
+  fi
   pass "$description"
 }
 

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# network-test.sh only regex-matches the generated bash source of these two
+# scripts. This file actually runs them against stubbed nmcli/uuidgen so the
+# lifecycle (dedupe, EXIT trap, autoconnect arm order) is proven, not just
+# grepped for.
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+psk_script=$(node -e 'process.stdout.write(require(process.argv[1]).hiddenPskConnectScript)' "$ROOT/shell/plugins/panels/network/Model.js")
+open_script=$(node -e 'process.stdout.write(require(process.argv[1]).hiddenOpenConnectScript)' "$ROOT/shell/plugins/panels/network/Model.js")
+
+cat >"$tmp/bin/uuidgen" <<'EOF'
+#!/bin/bash
+echo new-uuid-0000
+EOF
+chmod +x "$tmp/bin/uuidgen"
+
+# Logs the full argv of every nmcli call (one line per call) and dispatches on
+# argv substrings, so assertions can grep the log for what actually ran and in
+# what order, instead of trusting the script's own source text.
+cat >"$tmp/bin/nmcli" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$NM_CALL_LOG"
+case "$*" in
+  *"connection add"*)
+    exit 0
+    ;;
+  *"connection edit"*)
+    cat >"$NM_EDIT_INPUT"
+    exit 0
+    ;;
+  *"connection up"*)
+    [[ -n ${NM_UP_SLEEP:-} ]] && sleep "$NM_UP_SLEEP"
+    exit "${NM_UP_RC:-0}"
+    ;;
+  *"connection modify"*)
+    exit "${NM_MODIFY_RC:-0}"
+    ;;
+  *"connection delete"*)
+    exit 0
+    ;;
+  *"-t -f UUID,TYPE connection show"*)
+    printf '%s' "$NM_CONNECTIONS"
+    ;;
+  *"--escape no -g"*)
+    printf '%s' "$NM_WIFI_FIELDS"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+chmod +x "$tmp/bin/nmcli"
+
+# Three saved connections: a prior hidden profile for the SSID under test (the
+# one dedupe should remove), a broadcast profile with the same SSID (dedupe
+# must leave it alone -- it is not hidden), and an unrelated ethernet profile
+# (dedupe must not even consider non-wifi types). The SSID carries a space to
+# prove the scripts stay space-safe end to end.
+NM_CONNECTIONS=$'old-hidden:802-11-wireless\nbroadcast:802-11-wireless\neth:802-3-ethernet\n'
+NM_WIFI_FIELDS=$'old-hidden\nmy ssid\nyes\n\nbroadcast\nmy ssid\nno\n\n'
+
+assert_contains() {
+  local file=$1 needle=$2 description=$3
+
+  grep -qF -- "$needle" "$file" || fail "$description" "expected '$file' to contain: $needle\nactual:\n$(cat "$file" 2>/dev/null)"
+  pass "$description"
+}
+
+assert_not_contains() {
+  local file=$1 needle=$2 description=$3
+
+  if [[ -f $file ]] && grep -qF -- "$needle" "$file"; then
+    fail "$description" "expected '$file' to NOT contain: $needle\nactual:\n$(cat "$file")"
+  fi
+  pass "$description"
+}
+
+assert_file_absent() {
+  local file=$1 description=$2
+
+  [[ ! -e $file ]] || fail "$description" "expected '$file' to not exist"
+  pass "$description"
+}
+
+# Proves ordering, not just presence -- a dedupe delete that ran before
+# connection up would delete the old profile before the new one is proven.
+assert_order() {
+  local file=$1 first=$2 second=$3 description=$4
+  local first_line second_line
+
+  first_line=$(grep -n -m1 -F -- "$first" "$file" | cut -d: -f1)
+  second_line=$(grep -n -m1 -F -- "$second" "$file" | cut -d: -f1)
+  [[ -n $first_line && -n $second_line && $first_line -lt $second_line ]] ||
+    fail "$description" "first='$first' at line ${first_line:-none}; second='$second' at line ${second_line:-none}\n$(cat -n "$file")"
+  pass "$description"
+}
+
+# --- Scenario 1: PSK success ---------------------------------------------
+
+log=$tmp/log_psk_success
+edit=$tmp/edit_psk_success
+: >"$log"
+
+rc=0
+printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
+[[ $rc -eq 0 ]] || fail "hidden PSK connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
+pass "hidden PSK connect succeeds when activation and autoconnect arm both succeed"
+
+add_line=$(grep -m1 -F "connection add" "$log")
+[[ $add_line == *"connection.autoconnect no"* ]] || fail "hidden PSK success creates the profile inert (autoconnect no)" "$add_line"
+pass "hidden PSK success creates the profile inert (autoconnect no)"
+[[ $add_line == *"802-11-wireless.hidden yes"* ]] || fail "hidden PSK success marks the new profile hidden" "$add_line"
+pass "hidden PSK success marks the new profile hidden"
+[[ $add_line == *"wifi-sec.key-mgmt wpa-psk"* ]] || fail "hidden PSK success sets key-mgmt from the caller argument" "$add_line"
+pass "hidden PSK success sets key-mgmt from the caller argument"
+[[ $add_line == *"my ssid"* ]] || fail "hidden PSK success creates the profile with the requested ssid" "$add_line"
+pass "hidden PSK success creates the profile with the requested ssid"
+
+assert_contains "$edit" "set wifi-sec.psk secret pass" "hidden PSK success sets the passphrase through the connection editor's stdin"
+
+# The passphrase must never appear in any nmcli argv line -- argv is world
+# readable in /proc, so a leak here is a local secret-disclosure bug.
+assert_not_contains "$log" "secret pass" "hidden PSK success never puts the passphrase in nmcli argv"
+
+delete_line=$(grep -m1 -F "connection delete" "$log")
+[[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK success deletes the prior hidden profile for this ssid" "$delete_line"
+pass "hidden PSK success deletes the prior hidden profile for this ssid"
+[[ $delete_line != *"broadcast"* ]] || fail "hidden PSK success never deletes a same-ssid broadcast profile" "$delete_line"
+pass "hidden PSK success never deletes a same-ssid broadcast profile"
+[[ $delete_line != *"eth"* ]] || fail "hidden PSK success never deletes an unrelated ethernet profile" "$delete_line"
+pass "hidden PSK success never deletes an unrelated ethernet profile"
+[[ $delete_line != *"new-uuid-0000"* ]] || fail "hidden PSK success never deletes the profile it just proved" "$delete_line"
+pass "hidden PSK success never deletes the profile it just proved"
+
+assert_order "$log" "connection up" "connection modify" "hidden PSK success brings the profile up before arming autoconnect"
+assert_order "$log" "connection modify" "connection delete" "hidden PSK success arms autoconnect before deleting the old profile"
+
+# --- Scenario 2: PSK activation failure ----------------------------------
+
+log=$tmp/log_psk_up_fail
+edit=$tmp/edit_psk_up_fail
+: >"$log"
+
+rc=0
+printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_UP_RC=1 \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
+[[ $rc -ne 0 ]] || fail "hidden PSK connect fails when activation fails"
+pass "hidden PSK connect fails when activation fails"
+
+assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK activation failure lets the EXIT trap delete the unproven profile"
+assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK activation failure leaves the old profile in place"
+assert_not_contains "$log" "autoconnect yes" "hidden PSK activation failure never arms autoconnect"
+
+# --- Scenario 3: PSK autoconnect-arm failure ------------------------------
+
+log=$tmp/log_psk_modify_fail
+edit=$tmp/edit_psk_modify_fail
+: >"$log"
+
+rc=0
+printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_MODIFY_RC=1 \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
+# Success is pinned to activation, not to the autoconnect arm -- the
+# connection really is up, so the overall attempt must report success even
+# though the arm step failed.
+[[ $rc -eq 0 ]] || fail "hidden PSK connect still succeeds when only the autoconnect arm fails" "exit code: $rc"
+pass "hidden PSK connect still succeeds when only the autoconnect arm fails"
+
+assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK arm failure keeps the old, still-autoconnecting profile"
+assert_not_contains "$log" "delete uuid new-uuid-0000" "hidden PSK arm failure keeps the newly-activated profile"
+
+# --- Scenario 4: PSK termination ------------------------------------------
+
+log=$tmp/log_psk_term
+edit=$tmp/edit_psk_term
+input=$tmp/input_psk_term
+: >"$log"
+printf 'secret pass\n' >"$input"
+
+PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_UP_SLEEP=3 \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk <"$input" &
+pid=$!
+
+waited=0
+while ! grep -qF "connection up" "$log" 2>/dev/null; do
+  sleep 0.1
+  waited=$((waited + 1))
+  (( waited < 50 )) || fail "hidden PSK termination test setup" "connection up never started within 5s"
+done
+
+kill -TERM "$pid"
+rc=0
+wait "$pid" || rc=$?
+
+[[ $rc -ne 0 ]] || fail "hidden PSK connect reports failure when killed mid-activation"
+pass "hidden PSK connect reports failure when killed mid-activation"
+
+assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK termination lets the EXIT trap delete the unproven profile"
+assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK termination leaves the old profile in place"
+
+# --- Scenario 5: Open network success -------------------------------------
+
+log=$tmp/log_open_success
+: >"$log"
+
+rc=0
+printf '\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$tmp/edit_open_success" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  bash -c "$open_script" nmcli-hidden-open "my ssid" || rc=$?
+[[ $rc -eq 0 ]] || fail "hidden open connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
+pass "hidden open connect succeeds when activation and autoconnect arm both succeed"
+
+add_line=$(grep -m1 -F "connection add" "$log")
+[[ $add_line == *"802-11-wireless.hidden yes"* ]] || fail "hidden open success marks the new profile hidden" "$add_line"
+pass "hidden open success marks the new profile hidden"
+[[ $add_line == *"connection.autoconnect no"* ]] || fail "hidden open success creates the profile inert (autoconnect no)" "$add_line"
+pass "hidden open success creates the profile inert (autoconnect no)"
+
+assert_not_contains "$log" "wifi-sec" "hidden open success sets no wifi security properties on an open profile"
+assert_not_contains "$log" "connection edit" "hidden open success never opens the connection editor, since there is no secret to set"
+
+delete_line=$(grep -m1 -F "connection delete" "$log")
+[[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden open success deletes the prior hidden profile for this ssid" "$delete_line"
+pass "hidden open success deletes the prior hidden profile for this ssid"
+[[ $delete_line != *"broadcast"* ]] || fail "hidden open success never deletes a same-ssid broadcast profile" "$delete_line"
+pass "hidden open success never deletes a same-ssid broadcast profile"
+[[ $delete_line != *"eth"* ]] || fail "hidden open success never deletes an unrelated ethernet profile" "$delete_line"
+pass "hidden open success never deletes an unrelated ethernet profile"
+
+assert_order "$log" "connection up" "connection modify" "hidden open success brings the profile up before arming autoconnect"
+assert_order "$log" "connection modify" "connection delete" "hidden open success arms autoconnect before deleting the old profile"
+
+# --- Scenario 6: Open network activation failure --------------------------
+
+log=$tmp/log_open_up_fail
+: >"$log"
+
+rc=0
+printf '\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$tmp/edit_open_up_fail" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_UP_RC=1 \
+  bash -c "$open_script" nmcli-hidden-open "my ssid" || rc=$?
+[[ $rc -ne 0 ]] || fail "hidden open connect fails when activation fails"
+pass "hidden open connect fails when activation fails"
+
+assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden open activation failure lets the EXIT trap delete the unproven profile"
+assert_not_contains "$log" "delete uuid old-hidden" "hidden open activation failure leaves the old profile in place"

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -59,13 +59,33 @@ esac
 EOF
 chmod +x "$tmp/bin/nmcli"
 
+# Builds one dedupe record: 15 `nmcli -g` fields in the exact order the
+# dedupe reads them, plus the blank line separating it from the next record.
+# Keeping this as a function (rather than inline heredocs per scenario) is
+# what makes it tractable to add a distinctly-customized record per test
+# without each one silently drifting out of field-count alignment.
+wifi_record() {
+  local uuid=$1 ssid=$2 hidden=$3 keymgmt=$4 bssid=$5 mac=$6 iface=$7
+  local ip4m=$8 ip6m=$9 ip4addr=${10} ip4dns=${11} ip4routes=${12}
+  local ip6addr=${13} ip6dns=${14} ip6routes=${15}
+  printf '%s\n' "$uuid" "$ssid" "$hidden" "$keymgmt" "$bssid" "$mac" "$iface" \
+    "$ip4m" "$ip6m" "$ip4addr" "$ip4dns" "$ip4routes" "$ip6addr" "$ip6dns" "$ip6routes" ""
+}
+
 # Three saved connections: a prior hidden profile for the SSID under test (the
 # one dedupe should remove), a broadcast profile with the same SSID (dedupe
 # must leave it alone -- it is not hidden), and an unrelated ethernet profile
 # (dedupe must not even consider non-wifi types). The SSID carries a space to
 # prove the scripts stay space-safe end to end.
 NM_CONNECTIONS=$'old-hidden:802-11-wireless\nbroadcast:802-11-wireless\neth:802-3-ethernet\n'
-NM_WIFI_FIELDS=$'old-hidden\nmy ssid\nyes\n\nbroadcast\nmy ssid\nno\n\n'
+NM_WIFI_FIELDS_PSK=$(
+  wifi_record old-hidden "my ssid" yes wpa-psk "" "" "" auto auto "" "" "" "" "" ""
+  wifi_record broadcast "my ssid" no "" "" "" "" auto auto "" "" "" "" "" ""
+)
+NM_WIFI_FIELDS_OPEN=$(
+  wifi_record old-hidden "my ssid" yes "" "" "" "" auto auto "" "" "" "" "" ""
+  wifi_record broadcast "my ssid" no "" "" "" "" auto auto "" "" "" "" "" ""
+)
 
 assert_contains() {
   local file=$1 needle=$2 description=$3
@@ -113,7 +133,7 @@ edit=$tmp/edit_psk_success
 rc=0
 printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
-  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_PSK" \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
 (( rc == 0 )) || fail "hidden PSK connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
 pass "hidden PSK connect succeeds when activation and autoconnect arm both succeed"
@@ -135,8 +155,8 @@ assert_contains "$edit" "set wifi-sec.psk secret pass" "hidden PSK success sets 
 assert_not_contains "$log" "secret pass" "hidden PSK success never puts the passphrase in nmcli argv"
 
 delete_line=$(grep -m1 -F "connection delete" "$log")
-[[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK success deletes the prior hidden profile for this ssid" "$delete_line"
-pass "hidden PSK success deletes the prior hidden profile for this ssid"
+[[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK success deletes an uncustomized prior hidden profile for this ssid" "$delete_line"
+pass "hidden PSK success deletes an uncustomized prior hidden profile for this ssid"
 [[ $delete_line != *"broadcast"* ]] || fail "hidden PSK success never deletes a same-ssid broadcast profile" "$delete_line"
 pass "hidden PSK success never deletes a same-ssid broadcast profile"
 [[ $delete_line != *"eth"* ]] || fail "hidden PSK success never deletes an unrelated ethernet profile" "$delete_line"
@@ -156,7 +176,7 @@ edit=$tmp/edit_psk_up_fail
 rc=0
 printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
-  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_PSK" \
   NM_UP_RC=1 \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
 (( rc != 0 )) || fail "hidden PSK connect fails when activation fails"
@@ -175,7 +195,7 @@ edit=$tmp/edit_psk_modify_fail
 rc=0
 printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
-  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_PSK" \
   NM_MODIFY_RC=1 \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
 # Success is pinned to activation, not to the autoconnect arm -- the
@@ -197,7 +217,7 @@ printf 'secret pass\n' >"$input"
 
 PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
-  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_PSK" \
   NM_UP_SLEEP=3 \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk <"$input" &
 pid=$!
@@ -219,7 +239,70 @@ pass "hidden PSK connect reports failure when killed mid-activation"
 assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK termination lets the EXIT trap delete the unproven profile"
 assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK termination leaves the old profile in place"
 
-# --- Scenario 5: Open network success -------------------------------------
+# --- Scenario 5: dedupe preserves customized same-SSID hidden profiles ----
+#
+# Each of these profiles matches on SSID/hidden/key-mgmt alone -- the same
+# fields the pre-fix dedupe checked -- but differs on one customization the
+# fixed dedupe must also check. old-hidden is included alongside them purely
+# as the still-must-be-deleted control from scenario 1/3.
+
+log=$tmp/log_psk_customized
+edit=$tmp/edit_psk_customized
+: >"$log"
+
+NM_CONNECTIONS_CUSTOM=$'old-hidden:802-11-wireless\ncustom-ip4method:802-11-wireless\ncustom-ip4dns:802-11-wireless\ncustom-iface:802-11-wireless\neth:802-3-ethernet\n'
+NM_WIFI_FIELDS_CUSTOM=$(
+  wifi_record old-hidden "my ssid" yes wpa-psk "" "" "" auto auto "" "" "" "" "" ""
+  wifi_record custom-ip4method "my ssid" yes wpa-psk "" "" "" manual auto "" "" "" "" "" ""
+  wifi_record custom-ip4dns "my ssid" yes wpa-psk "" "" "" auto auto "" "8.8.8.8" "" "" "" ""
+  wifi_record custom-iface "my ssid" yes wpa-psk "" "" wlan0 auto auto "" "" "" "" "" ""
+)
+
+rc=0
+printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS_CUSTOM" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_CUSTOM" \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
+(( rc == 0 )) || fail "hidden PSK connect succeeds alongside customized same-ssid profiles" "exit code: $rc"
+pass "hidden PSK connect succeeds alongside customized same-ssid profiles"
+
+delete_line=$(grep -m1 -F "connection delete" "$log")
+[[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK dedupe still deletes the uncustomized duplicate" "$delete_line"
+pass "hidden PSK dedupe still deletes the uncustomized duplicate"
+[[ $delete_line != *"custom-ip4method"* ]] || fail "hidden PSK dedupe spares a same-ssid profile with a manual ipv4.method" "$delete_line"
+pass "hidden PSK dedupe spares a same-ssid profile with a manual ipv4.method"
+[[ $delete_line != *"custom-ip4dns"* ]] || fail "hidden PSK dedupe spares a same-ssid profile with a custom ipv4.dns" "$delete_line"
+pass "hidden PSK dedupe spares a same-ssid profile with a custom ipv4.dns"
+[[ $delete_line != *"custom-iface"* ]] || fail "hidden PSK dedupe spares a same-ssid profile bound to an interface" "$delete_line"
+pass "hidden PSK dedupe spares a same-ssid profile bound to an interface"
+
+# --- Scenario 6: dedupe preserves a same-SSID profile with different key-mgmt
+
+log=$tmp/log_psk_keymgmt
+edit=$tmp/edit_psk_keymgmt
+: >"$log"
+
+NM_CONNECTIONS_KEYMGMT=$'old-hidden:802-11-wireless\ncustom-keymgmt:802-11-wireless\neth:802-3-ethernet\n'
+NM_WIFI_FIELDS_KEYMGMT=$(
+  wifi_record old-hidden "my ssid" yes wpa-psk "" "" "" auto auto "" "" "" "" "" ""
+  wifi_record custom-keymgmt "my ssid" yes sae "" "" "" auto auto "" "" "" "" "" ""
+)
+
+rc=0
+printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
+  NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
+  NM_CONNECTIONS="$NM_CONNECTIONS_KEYMGMT" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_KEYMGMT" \
+  bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
+(( rc == 0 )) || fail "hidden PSK connect succeeds alongside a same-ssid sae profile" "exit code: $rc"
+pass "hidden PSK connect succeeds alongside a same-ssid sae profile"
+
+delete_line=$(grep -m1 -F "connection delete" "$log")
+[[ $delete_line == *"uuid old-hidden"* ]] || fail "hidden PSK dedupe still deletes the same-key-mgmt duplicate" "$delete_line"
+pass "hidden PSK dedupe still deletes the same-key-mgmt duplicate"
+[[ $delete_line != *"custom-keymgmt"* ]] || fail "hidden PSK dedupe spares a same-ssid profile using a different key-mgmt (sae vs wpa-psk)" "$delete_line"
+pass "hidden PSK dedupe spares a same-ssid profile using a different key-mgmt (sae vs wpa-psk)"
+
+# --- Scenario 7: Open network success -------------------------------------
 
 log=$tmp/log_open_success
 : >"$log"
@@ -227,7 +310,7 @@ log=$tmp/log_open_success
 rc=0
 printf '\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$tmp/edit_open_success" \
-  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_OPEN" \
   bash -c "$open_script" nmcli-hidden-open "my ssid" || rc=$?
 (( rc == 0 )) || fail "hidden open connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
 pass "hidden open connect succeeds when activation and autoconnect arm both succeed"
@@ -252,7 +335,7 @@ pass "hidden open success never deletes an unrelated ethernet profile"
 assert_order "$log" "connection up" "connection modify" "hidden open success brings the profile up before arming autoconnect"
 assert_order "$log" "connection modify" "connection delete" "hidden open success arms autoconnect before deleting the old profile"
 
-# --- Scenario 6: Open network activation failure --------------------------
+# --- Scenario 8: Open network activation failure --------------------------
 
 log=$tmp/log_open_up_fail
 : >"$log"
@@ -260,7 +343,7 @@ log=$tmp/log_open_up_fail
 rc=0
 printf '\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$tmp/edit_open_up_fail" \
-  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
+  NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_OPEN" \
   NM_UP_RC=1 \
   bash -c "$open_script" nmcli-hidden-open "my ssid" || rc=$?
 (( rc != 0 )) || fail "hidden open connect fails when activation fails"

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -37,7 +37,20 @@ case "$*" in
     exit 0
     ;;
   *"connection up"*)
-    [[ -n ${NM_UP_SLEEP:-} ]] && sleep "$NM_UP_SLEEP"
+    # Mirrors real nmcli's SIGTERM handling so termination coverage exercises
+    # the panel's kill actually reaching this process, not just the parent
+    # bash -c wrapper around it. The sleep itself is backgrounded (rather
+    # than run as a foreground child of this trap-bearing script) so this
+    # stub reacts to TERM immediately, the way a real, single-process nmcli
+    # would -- a foreground sleep here would reintroduce the exact
+    # defer-until-child-returns bug this stub exists to catch, just one
+    # process further down.
+    [[ -n ${NM_UP_PID_FILE:-} ]] && printf '%s\n' "$$" >"$NM_UP_PID_FILE"
+    if [[ -n ${NM_UP_SLEEP:-} ]]; then
+      sleep "$NM_UP_SLEEP" & sleep_pid=$!
+      trap 'kill -TERM $sleep_pid 2>/dev/null; exit 143' TERM
+      wait $sleep_pid
+    fi
     exit "${NM_UP_RC:-0}"
     ;;
   *"connection modify"*)
@@ -208,33 +221,52 @@ assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK arm failure keep
 assert_not_contains "$log" "delete uuid new-uuid-0000" "hidden PSK arm failure keeps the newly-activated profile"
 
 # --- Scenario 4: PSK termination ------------------------------------------
+#
+# NM_UP_SLEEP is long (20s) and the assertions require the script to exit and
+# the stubbed nmcli child to die within a couple of seconds of SIGTERM -- if
+# the panel's kill only reached the parent `bash -c` (the pre-fix behavior),
+# this would block for the full sleep instead.
 
 log=$tmp/log_psk_term
 edit=$tmp/edit_psk_term
 input=$tmp/input_psk_term
+pidfile=$tmp/pid_psk_term
 : >"$log"
+rm -f "$pidfile"
 printf 'secret pass\n' >"$input"
 
 PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
   NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS_PSK" \
-  NM_UP_SLEEP=3 \
+  NM_UP_SLEEP=20 NM_UP_PID_FILE="$pidfile" \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk <"$input" &
 pid=$!
 
 waited=0
-while ! grep -qF "connection up" "$log" 2>/dev/null; do
+while [[ ! -s $pidfile ]]; do
   sleep 0.1
   waited=$((waited + 1))
-  (( waited < 50 )) || fail "hidden PSK termination test setup" "connection up never started within 5s"
+  (( waited < 50 )) || fail "hidden PSK termination test setup" "nmcli stub pid file never appeared within 5s"
 done
+nmcli_pid=$(<"$pidfile")
 
+start_ns=$(date +%s%N)
 kill -TERM "$pid"
 rc=0
 wait "$pid" || rc=$?
+elapsed_ms=$(( ($(date +%s%N) - start_ns) / 1000000 ))
+
+(( elapsed_ms < 2000 )) || fail "hidden PSK termination reaches the child nmcli process instead of waiting for it to exit on its own" "elapsed: ${elapsed_ms}ms"
+pass "hidden PSK termination reaches the child nmcli process instead of waiting for it to exit on its own"
 
 (( rc != 0 )) || fail "hidden PSK connect reports failure when killed mid-activation"
 pass "hidden PSK connect reports failure when killed mid-activation"
+
+sleep 0.3
+if kill -0 "$nmcli_pid" 2>/dev/null; then
+  fail "hidden PSK termination terminates the child nmcli process rather than orphaning it" "pid $nmcli_pid is still running"
+fi
+pass "hidden PSK termination terminates the child nmcli process rather than orphaning it"
 
 assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK termination lets the EXIT trap delete the unproven profile"
 assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK termination leaves the old profile in place"

--- a/test/shell.d/network-hidden-connect-test.sh
+++ b/test/shell.d/network-hidden-connect-test.sh
@@ -115,7 +115,7 @@ printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$edit" \
   NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
-[[ $rc -eq 0 ]] || fail "hidden PSK connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
+(( rc == 0 )) || fail "hidden PSK connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
 pass "hidden PSK connect succeeds when activation and autoconnect arm both succeed"
 
 add_line=$(grep -m1 -F "connection add" "$log")
@@ -159,7 +159,7 @@ printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
   NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
   NM_UP_RC=1 \
   bash -c "$psk_script" nmcli-hidden-psk "my ssid" wpa-psk || rc=$?
-[[ $rc -ne 0 ]] || fail "hidden PSK connect fails when activation fails"
+(( rc != 0 )) || fail "hidden PSK connect fails when activation fails"
 pass "hidden PSK connect fails when activation fails"
 
 assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK activation failure lets the EXIT trap delete the unproven profile"
@@ -181,7 +181,7 @@ printf 'secret pass\n' | PATH="$tmp/bin:$PATH" \
 # Success is pinned to activation, not to the autoconnect arm -- the
 # connection really is up, so the overall attempt must report success even
 # though the arm step failed.
-[[ $rc -eq 0 ]] || fail "hidden PSK connect still succeeds when only the autoconnect arm fails" "exit code: $rc"
+(( rc == 0 )) || fail "hidden PSK connect still succeeds when only the autoconnect arm fails" "exit code: $rc"
 pass "hidden PSK connect still succeeds when only the autoconnect arm fails"
 
 assert_not_contains "$log" "delete uuid old-hidden" "hidden PSK arm failure keeps the old, still-autoconnecting profile"
@@ -213,7 +213,7 @@ kill -TERM "$pid"
 rc=0
 wait "$pid" || rc=$?
 
-[[ $rc -ne 0 ]] || fail "hidden PSK connect reports failure when killed mid-activation"
+(( rc != 0 )) || fail "hidden PSK connect reports failure when killed mid-activation"
 pass "hidden PSK connect reports failure when killed mid-activation"
 
 assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden PSK termination lets the EXIT trap delete the unproven profile"
@@ -229,7 +229,7 @@ printf '\n' | PATH="$tmp/bin:$PATH" \
   NM_CALL_LOG="$log" NM_EDIT_INPUT="$tmp/edit_open_success" \
   NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
   bash -c "$open_script" nmcli-hidden-open "my ssid" || rc=$?
-[[ $rc -eq 0 ]] || fail "hidden open connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
+(( rc == 0 )) || fail "hidden open connect succeeds when activation and autoconnect arm both succeed" "exit code: $rc"
 pass "hidden open connect succeeds when activation and autoconnect arm both succeed"
 
 add_line=$(grep -m1 -F "connection add" "$log")
@@ -263,7 +263,7 @@ printf '\n' | PATH="$tmp/bin:$PATH" \
   NM_CONNECTIONS="$NM_CONNECTIONS" NM_WIFI_FIELDS="$NM_WIFI_FIELDS" \
   NM_UP_RC=1 \
   bash -c "$open_script" nmcli-hidden-open "my ssid" || rc=$?
-[[ $rc -ne 0 ]] || fail "hidden open connect fails when activation fails"
+(( rc != 0 )) || fail "hidden open connect fails when activation fails"
 pass "hidden open connect fails when activation fails"
 
 assert_contains "$log" "connection delete uuid new-uuid-0000" "hidden open activation failure lets the EXIT trap delete the unproven profile"

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -294,18 +294,17 @@ assertDeepEqual(
 assertEqual(network.headerDetail({ type: 'wifi', freq: '5745' }), '', 'network keeps wifi band state out of the hero')
 assertEqual(network.headerDetail({ type: 'ethernet', speed: '100' }), '100mbit', 'network keeps ethernet speed in the hero')
 
-// Hidden-network connect scripts: SSID (and identity, for enterprise) must
-// travel as positional args -- never string-interpolated -- and the profile
-// must be marked hidden so NetworkManager probes for it instead of waiting
-// on a beacon that will never arrive.
+// Hidden-network connect script: SSID must travel as a positional arg --
+// never string-interpolated -- and the profile must be marked hidden so
+// NetworkManager probes for it instead of waiting on a beacon that will
+// never arrive.
 assert(/"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script maps ssid to the positional $1 arg')
 assert(/802-11-wireless\.hidden yes/.test(network.hiddenPskConnectScript), 'hidden PSK connect script marks the profile hidden')
 assert(/IFS= read -r pw/.test(network.hiddenPskConnectScript), 'hidden PSK connect script reads the passphrase from stdin, not argv')
 assert(/set wifi-sec\.psk %s/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets the psk through the connection editor')
 assert(!/password "\$pw"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never passes the passphrase in argv')
 
-assert(/"\$1"/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script maps ssid to the positional $1 arg')
-assert(/"\$2"/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script maps identity to the positional $2 arg')
-assert(/802-11-wireless\.hidden yes/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script marks the profile hidden')
-assert(/IFS= read -r pw/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script reads the passphrase from stdin, not argv')
+// A repeat join to the same hidden SSID must not pile up duplicate
+// NetworkManager profiles, so any same-named profile is deleted first.
+assert(/connection delete id "\$1"[\s\S]*nmcli connection add/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes an existing same-named profile before adding a new one')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -293,4 +293,17 @@ assertDeepEqual(
 
 assertEqual(network.headerDetail({ type: 'wifi', freq: '5745' }), '', 'network keeps wifi band state out of the hero')
 assertEqual(network.headerDetail({ type: 'ethernet', speed: '100' }), '100mbit', 'network keeps ethernet speed in the hero')
+
+// Hidden-network connect scripts: SSID (and identity, for enterprise) must
+// travel as positional args -- never string-interpolated -- and the profile
+// must be marked hidden so NetworkManager probes for it instead of waiting
+// on a beacon that will never arrive.
+assert(/"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script maps ssid to the positional $1 arg')
+assert(/hidden yes/.test(network.hiddenPskConnectScript), 'hidden PSK connect script marks the network hidden')
+assert(/IFS= read -r pw/.test(network.hiddenPskConnectScript), 'hidden PSK connect script reads the passphrase from stdin, not argv')
+
+assert(/"\$1"/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script maps ssid to the positional $1 arg')
+assert(/"\$2"/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script maps identity to the positional $2 arg')
+assert(/802-11-wireless\.hidden yes/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script marks the profile hidden')
+assert(/IFS= read -r pw/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script reads the passphrase from stdin, not argv')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -304,6 +304,13 @@ assert(/IFS= read -r pw/.test(network.hiddenPskConnectScript), 'hidden PSK conne
 assert(/set wifi-sec\.psk %s/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets the psk through the connection editor')
 assert(!/password "\$pw"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never passes the passphrase in argv')
 
+// One script serves both WPA/WPA2 Personal and WPA3 Personal: key-mgmt comes
+// from the caller-supplied $2 ("wpa-psk" or "sae"), and WPA3 additionally
+// requires Protected Management Frames, set only in the sae case.
+assert(/wifi-sec\.key-mgmt "\$2"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets key-mgmt from the $2 arg, not a hardcoded value')
+assert(!/wifi-sec\.key-mgmt wpa-psk/.test(network.hiddenPskConnectScript), 'hidden PSK connect script no longer hardcodes wpa-psk as the key-mgmt')
+assert(/\[ "\$2" = "sae" \] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets PMF required only for the sae (WPA3) case')
+
 // A repeat join to the same hidden SSID must not pile up duplicate
 // NetworkManager profiles, so any same-named profile is deleted first.
 assert(/connection delete id "\$1"[\s\S]*nmcli connection add/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes an existing same-named profile before adding a new one')

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -371,7 +371,8 @@ assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*
 
 // IFS= on every field read: a bare `read` trims whitespace and would corrupt
 // a space-padded SSID before the "$1" compare. The batched query blank-lines
-// between profiles, so the uuid read skips blanks to keep 3-line groups aligned.
+// between profiles, so the uuid read skips blanks to keep each connection's
+// exactly fifteen-field group aligned.
 assert(/IFS= read -r ssid; IFS= read -r hidden;/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
 assert(/\[\[ -n \$c \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script skips the blank separator lines between batched profiles so field groups stay aligned')
 assert(network.hiddenPskConnectScript.includes('[[ $c != "$u" ]] || continue'), 'hidden PSK connect script dedupe skips the profile this attempt just created, so the late snapshot cannot delete it')

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -12,6 +12,15 @@ const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.
 assert(/IpcHandler[\s\S]*?function toggleNetwork\(\) \{ root\.toggleNetwork\(\) \}/.test(panelSource), 'network exposes the Wi-Fi radio toggle over IPC')
 assert(/manageIpc: false/.test(panelSource), 'network owns its IPC handler so it can extend the target methods')
 
+// The hidden-network form is appended at the bottom of the panel's content,
+// so on a short display it can fall outside the card's capped height with no
+// way to reach it. The main column must live inside a Flickable (not a bare
+// Column) so it has a scroll path -- a future edit flattening it back out
+// must fail here.
+const mainColumn = panelSource.match(/Flickable \{\s*id: panelFlick[\s\S]*?Column \{\s*id: column\b/)
+assert(mainColumn, 'network wraps its main column in a Flickable so overflow content stays reachable')
+assert(/interactive: contentHeight > height/.test(mainColumn[0]), 'network only lets the outer Flickable drag when its content overflows')
+
 // Opening from the bar must call open() and nothing else. open() runs
 // refresh(true), which defers the PHY scan; a second bare refresh() defaults
 // scanWifi to false, sets scannerEnabled synchronously, and stalls the open on

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -324,7 +324,7 @@ assert(/nmcli --escape no -g connection\.type,802-11-wireless\.ssid,802-11-wirel
 assert(/connection\.type[\s\S]*"802-11-wireless"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
 assert(/802-11-wireless\.ssid[\s\S]*"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
 assert(/802-11-wireless\.hidden[\s\S]*"yes"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
-assert(/nmcli connection up uuid "\$u"[\s\S]*connection delete uuid "\$o"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
+assert(/connection up uuid "\$u"[\s\S]*connection delete uuid "\$o"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
 assert(/connection delete uuid "\$u" >\/dev\/null 2>&1; false; \}$/.test(network.hiddenPskConnectScript), 'hidden PSK connect script leaves prior profiles alone on failure, deleting only its own new (unproven) profile')
 
 // The cleanup loop's own exit status must never leak into the `&&`/`||`
@@ -333,4 +333,23 @@ assert(/connection delete uuid "\$u" >\/dev\/null 2>&1; false; \}$/.test(network
 // tripping the `||` failure branch and deleting the profile that just
 // connected successfully. `true` pins the block's exit status regardless.
 assert(/for o in \$old;[\s\S]*done; true; \}/.test(network.hiddenPskConnectScript), 'hidden PSK connect script cleanup block always reports success so a stale old-UUID delete failure cannot delete the just-connected new profile')
+
+// A kill mid-`connection up` (QML's own 30s timeout) must not leave a
+// half-proven profile that NetworkManager retries in the background:
+// the profile starts inert (autoconnect no) and is only armed
+// (autoconnect yes) after activation succeeds, and nmcli's own wait is
+// bounded below the QML kill timeout so the clean `||` cleanup path runs
+// instead of a hard kill.
+assert(/connection\.autoconnect no/.test(network.hiddenPskConnectScript), 'hidden PSK connect script creates the profile inert (autoconnect no) so a killed/failed attempt cannot be retried in the background')
+assert(/nmcli -w 25 connection up uuid "\$u"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script bounds nmcli\'s own wait below the QML 30s kill timeout')
+assert(/connection\.autoconnect yes/.test(network.hiddenPskConnectScript), 'hidden PSK connect script arms autoconnect only after activation succeeds')
+assert(
+  network.hiddenPskConnectScript.indexOf('connection up uuid "$u"') < network.hiddenPskConnectScript.indexOf('connection.autoconnect yes'),
+  'hidden PSK connect script only sets autoconnect yes after connection up, never before'
+)
+
+// A plain `read` strips leading/trailing whitespace, which would silently
+// corrupt a space-padded SSID (legal bytes) before it's compared against
+// the raw "$1" -- IFS= is required on every field read from the info blob.
+assert(/\{ IFS= read -r type; IFS= read -r ssid; IFS= read -r hidden; \} <<< "\$info"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses type/ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -325,28 +325,34 @@ assert(/connection\.type[\s\S]*"802-11-wireless"/.test(network.hiddenPskConnectS
 assert(/802-11-wireless\.ssid[\s\S]*"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
 assert(/802-11-wireless\.hidden[\s\S]*"yes"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
 assert(/connection up uuid "\$u"[\s\S]*connection delete uuid "\$o"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
-assert(/connection delete uuid "\$u" >\/dev\/null 2>&1; false; \}$/.test(network.hiddenPskConnectScript), 'hidden PSK connect script leaves prior profiles alone on failure, deleting only its own new (unproven) profile')
 
-// The cleanup loop's own exit status must never leak into the `&&`/`||`
-// chain: a failed delete of a stale/already-gone old UUID (the loop's own
-// last command) would otherwise make the whole `up && { cleanup }` false,
-// tripping the `||` failure branch and deleting the profile that just
-// connected successfully. `true` pins the block's exit status regardless.
-assert(/for o in \$old;[\s\S]*done; true; \}/.test(network.hiddenPskConnectScript), 'hidden PSK connect script cleanup block always reports success so a stale old-UUID delete failure cannot delete the just-connected new profile')
+// Cleanup is a single EXIT trap: armed before the profile exists, deleting
+// it on any failure or TERM/INT kill, and disarmed (`trap - EXIT`) only
+// after `connection up` proves it. `true` pins the success block's status
+// so a stale old-UUID delete can't flip the chain to failure.
+assert(/trap 'nmcli connection delete uuid "\$u"[^']*' EXIT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script arms an EXIT trap that removes the unproven profile on any failure or kill')
+assert(/trap 'exit 143' TERM INT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script converts TERM/INT into an exit so the EXIT trap cleanup runs on a panel kill')
+assert(
+  network.hiddenPskConnectScript.indexOf("' EXIT") < network.hiddenPskConnectScript.indexOf('connection add'),
+  'hidden PSK connect script arms the cleanup trap before the profile is created'
+)
+assert(
+  network.hiddenPskConnectScript.indexOf('connection up uuid "$u"') < network.hiddenPskConnectScript.indexOf('trap - EXIT'),
+  'hidden PSK connect script disarms the cleanup trap only after connection up proves the profile'
+)
+assert(/for o in \$old;[\s\S]*done;[\s\S]*true; \}/.test(network.hiddenPskConnectScript), 'hidden PSK connect script pins the success block status so a stale old-UUID delete failure cannot fail the chain')
 
-// A kill mid-`connection up` (QML's own 30s timeout) must not leave a
-// half-proven profile that NetworkManager retries in the background:
-// the profile starts inert (autoconnect no) and is only armed
-// (autoconnect yes) after activation succeeds, and nmcli's own wait is
-// bounded below the QML kill timeout so the clean `||` cleanup path runs
-// instead of a hard kill.
+// The profile starts inert (autoconnect no), is armed only after activation,
+// and old profiles are removed only if that arm succeeded -- a failed arm
+// keeps the old, still-autoconnecting profiles. `-w 25` keeps nmcli under
+// the QML 30s kill.
 assert(/connection\.autoconnect no/.test(network.hiddenPskConnectScript), 'hidden PSK connect script creates the profile inert (autoconnect no) so a killed/failed attempt cannot be retried in the background')
 assert(/nmcli -w 25 connection up uuid "\$u"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script bounds nmcli\'s own wait below the QML 30s kill timeout')
-assert(/connection\.autoconnect yes/.test(network.hiddenPskConnectScript), 'hidden PSK connect script arms autoconnect only after activation succeeds')
 assert(
   network.hiddenPskConnectScript.indexOf('connection up uuid "$u"') < network.hiddenPskConnectScript.indexOf('connection.autoconnect yes'),
   'hidden PSK connect script only sets autoconnect yes after connection up, never before'
 )
+assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*for o in \$old/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes old profiles only if the autoconnect arm succeeded')
 
 // A plain `read` strips leading/trailing whitespace, which would silently
 // corrupt a space-padded SSID (legal bytes) before it's compared against

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -317,13 +317,17 @@ assert(/\[\[ \$2 == "sae" \]\] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskC
 // happens to share it. Old profiles must be matched by UUID against
 // type + ssid + hidden, captured before the new profile exists, and only
 // removed after the new one activates -- never up front, and never by name.
+// Enumeration is two fixed nmcli calls (a UUID/TYPE listing, then one
+// batched ssid/hidden query over the wifi profiles) -- never one nmcli
+// spawn per profile.
 assert(!/connection delete id "\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never deletes an existing profile by name')
 assert(!network.hiddenPskConnectScript.includes('connection delete id '), 'hidden PSK connect script never deletes any existing profile by name (id), regardless of the argument')
-assert(/nmcli -t -f UUID connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script enumerates existing connections by UUID to find prior hidden profiles for this SSID')
-assert(/nmcli --escape no -g connection\.type,802-11-wireless\.ssid,802-11-wireless\.hidden/.test(network.hiddenPskConnectScript), 'hidden PSK connect script disables nmcli escaping so a colon/backslash SSID still compares equal to the raw $1')
-assert(/connection\.type[\s\S]*"802-11-wireless"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
-assert(/802-11-wireless\.ssid[\s\S]*"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
-assert(/802-11-wireless\.hidden[\s\S]*"yes"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
+assert(/nmcli -t -f UUID,TYPE connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script lists all connections (UUID + type) in a single nmcli call')
+assert(!/for c in \$\(nmcli/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never runs nmcli once per connection (N+1)')
+assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden connection show \$wifi/.test(network.hiddenPskConnectScript), 'hidden PSK connect script fetches ssid/hidden for all wifi profiles in one batched, unescaped query so a colon/backslash SSID still compares equal to the raw $1')
+assert(/\[\[ \$t == "802-11-wireless" \]\] && wifi=/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
+assert(/\[\[ \$ssid == "\$1" \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
+assert(/\[\[ \$hidden == "yes" \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
 assert(/connection up uuid "\$u"[\s\S]*connection delete uuid "\$o"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
 
 // Cleanup is a single EXIT trap: armed before the profile exists, deleting
@@ -356,6 +360,9 @@ assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*
 
 // A plain `read` strips leading/trailing whitespace, which would silently
 // corrupt a space-padded SSID (legal bytes) before it's compared against
-// the raw "$1" -- IFS= is required on every field read from the info blob.
-assert(/\{ IFS= read -r type; IFS= read -r ssid; IFS= read -r hidden; \} <<< "\$info"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses type/ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
+// the raw "$1" -- IFS= is required on every field read. The batched query
+// separates profiles with a blank line, which the uuid read must skip to
+// keep the 3-line groups aligned.
+assert(/IFS= read -r ssid; IFS= read -r hidden;/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
+assert(/\[\[ -n \$c \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script skips the blank separator lines between batched profiles so field groups stay aligned')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -299,8 +299,10 @@ assertEqual(network.headerDetail({ type: 'ethernet', speed: '100' }), '100mbit',
 // must be marked hidden so NetworkManager probes for it instead of waiting
 // on a beacon that will never arrive.
 assert(/"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script maps ssid to the positional $1 arg')
-assert(/hidden yes/.test(network.hiddenPskConnectScript), 'hidden PSK connect script marks the network hidden')
+assert(/802-11-wireless\.hidden yes/.test(network.hiddenPskConnectScript), 'hidden PSK connect script marks the profile hidden')
 assert(/IFS= read -r pw/.test(network.hiddenPskConnectScript), 'hidden PSK connect script reads the passphrase from stdin, not argv')
+assert(/set wifi-sec\.psk %s/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets the psk through the connection editor')
+assert(!/password "\$pw"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never passes the passphrase in argv')
 
 assert(/"\$1"/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script maps ssid to the positional $1 arg')
 assert(/"\$2"/.test(network.hiddenEnterpriseConnectScript), 'hidden enterprise connect script maps identity to the positional $2 arg')

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -327,6 +327,11 @@ assert(/\[\[ \$2 == "sae" \]\] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskC
 assert(!/connection delete id "\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never deletes an existing profile by name')
 assert(!network.hiddenPskConnectScript.includes('connection delete id '), 'hidden PSK connect script never deletes any existing profile by name (id), regardless of the argument')
 assert(/nmcli -t -f UUID,TYPE connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script lists all connections (UUID + type) in a single nmcli call')
+assert(network.hiddenPskConnectScript.includes('done < <(nmcli -t -f UUID,TYPE connection show)'), 'hidden PSK connect script reads the dedupe queries through process substitution, keeping bash in an interruptible read instead of waiting on a foreground command substitution')
+assert(network.hiddenPskConnectScript.includes('done < <(LC_ALL=C nmcli --escape no -g'), 'hidden PSK connect script reads the dedupe queries through process substitution, keeping bash in an interruptible read instead of waiting on a foreground command substitution')
+assert(network.hiddenPskConnectScript.includes('>/dev/null & wait $!; }'), 'hidden PSK connect script backgrounds connection add under wait so the TERM trap can preempt it')
+assert(network.hiddenPskConnectScript.includes('nmcli connection edit uuid "$u" >/dev/null & wait $!; }'), 'hidden PSK connect script backgrounds connection edit under wait so the TERM trap can preempt it')
+assert(network.hiddenPskConnectScript.includes('trap \'timeout -k 1 5 nmcli connection delete uuid "$u"'), 'hidden PSK connect script bounds the EXIT-trap cleanup delete so a wedged NetworkManager cannot stall the dying process')
 assert(!/for c in \$\(nmcli/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never runs nmcli once per connection (N+1)')
 assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden,802-11-wireless-security\.key-mgmt,802-11-wireless\.bssid,802-11-wireless\.mac-address,connection\.interface-name,ipv4\.method,ipv6\.method,ipv4\.addresses,ipv4\.dns,ipv4\.routes,ipv6\.addresses,ipv6\.dns,ipv6\.routes connection show \$wifi/.test(network.hiddenPskConnectScript), 'hidden PSK connect script fetches ssid/hidden/identity/IP-customization fields for all wifi profiles in one batched, unescaped query so a colon/backslash SSID still compares equal to the raw $1')
 assert(/\[\[ \$t == "802-11-wireless" \]\] && wifi=/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
@@ -340,8 +345,8 @@ assert(/connection up uuid "\$u"[\s\S]*nmcli connection delete \$old/.test(netwo
 // it on any failure or TERM/INT kill, and disarmed (`trap - EXIT`) only
 // after `connection up` proves it. `true` pins the success block's status
 // so a stale old-UUID delete can't flip the chain to failure.
-assert(/trap 'nmcli connection delete uuid "\$u"[^']*' EXIT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script arms an EXIT trap that removes the unproven profile on any failure or kill')
-assert(/trap 'exit 143' TERM INT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script converts TERM/INT into an exit so the EXIT trap cleanup runs on a panel kill')
+assert(/trap 'timeout -k 1 5 nmcli connection delete uuid "\$u"[^']*' EXIT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script arms an EXIT trap that removes the unproven profile on any failure or kill')
+assert(/trap 'kill -TERM \$! 2>\/dev\/null; exit 143' TERM INT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script\'s TERM trap kills the in-flight nmcli so a panel kill is never deferred behind a foreground child')
 assert(
   network.hiddenPskConnectScript.indexOf("' EXIT") < network.hiddenPskConnectScript.indexOf('connection add'),
   'hidden PSK connect script arms the cleanup trap before the profile is created'
@@ -369,6 +374,9 @@ assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*
 // between profiles, so the uuid read skips blanks to keep 3-line groups aligned.
 assert(/IFS= read -r ssid; IFS= read -r hidden;/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
 assert(/\[\[ -n \$c \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script skips the blank separator lines between batched profiles so field groups stay aligned')
+assert(network.hiddenPskConnectScript.includes('[[ $c != "$u" ]] || continue'), 'hidden PSK connect script dedupe skips the profile this attempt just created, so the late snapshot cannot delete it')
+assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*--escape no -g[\s\S]*nmcli connection delete \$old/.test(network.hiddenPskConnectScript), 'hidden PSK connect script snapshots duplicates inside the modify-success block, immediately before the batched delete (TOCTOU guard)')
+assert(/connection modify[\s\S]*trap 'kill -TERM \$! 2>\/dev\/null; exit 143' TERM INT/.test(network.hiddenPskConnectScript), 'hidden PSK connect script re-arms the kill-child TERM trap before the late snapshot so a panel kill still interrupts it')
 
 // An open hidden network has no credentials, but must still avoid `nmcli
 // device wifi connect`, which persists an autoconnecting profile before
@@ -381,8 +389,8 @@ assert(/connection\.autoconnect no/.test(network.hiddenOpenConnectScript), 'hidd
 assert(!/wifi-sec/.test(network.hiddenOpenConnectScript), 'hidden open connect script sets no wifi security properties on an open profile')
 assert(!/IFS= read -r pw/.test(network.hiddenOpenConnectScript), 'hidden open connect script never reads a passphrase, since open networks have none')
 
-assert(/trap 'nmcli connection delete uuid "\$u"[^']*' EXIT/.test(network.hiddenOpenConnectScript), 'hidden open connect script arms an EXIT trap that removes the unproven profile on any failure or kill')
-assert(/trap 'exit 143' TERM INT/.test(network.hiddenOpenConnectScript), 'hidden open connect script converts TERM/INT into an exit so the EXIT trap cleanup runs on a panel kill')
+assert(/trap 'timeout -k 1 5 nmcli connection delete uuid "\$u"[^']*' EXIT/.test(network.hiddenOpenConnectScript), 'hidden open connect script arms an EXIT trap that removes the unproven profile on any failure or kill')
+assert(/trap 'kill -TERM \$! 2>\/dev\/null; exit 143' TERM INT/.test(network.hiddenOpenConnectScript), 'hidden open connect script\'s TERM trap kills the in-flight nmcli so a panel kill is never deferred behind a foreground child')
 assert(
   network.hiddenOpenConnectScript.indexOf("' EXIT") < network.hiddenOpenConnectScript.indexOf('connection add'),
   'hidden open connect script arms the cleanup trap before the profile is created'
@@ -399,4 +407,11 @@ assert(
 assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*nmcli connection delete \$old/.test(network.hiddenOpenConnectScript), 'hidden open connect script deletes old profiles only if the autoconnect arm succeeded')
 
 assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden,802-11-wireless-security\.key-mgmt,802-11-wireless\.bssid,802-11-wireless\.mac-address,connection\.interface-name,ipv4\.method,ipv6\.method,ipv4\.addresses,ipv4\.dns,ipv4\.routes,ipv6\.addresses,ipv6\.dns,ipv6\.routes connection show \$wifi/.test(network.hiddenOpenConnectScript), 'hidden open connect script shares the same batched dedupe query as the PSK script, so it dedupes prior hidden profiles too')
+assert(network.hiddenOpenConnectScript.includes('done < <(nmcli -t -f UUID,TYPE connection show)'), 'hidden open connect script reads the dedupe queries through process substitution, keeping bash in an interruptible read instead of waiting on a foreground command substitution')
+assert(network.hiddenOpenConnectScript.includes('done < <(LC_ALL=C nmcli --escape no -g'), 'hidden open connect script reads the dedupe queries through process substitution, keeping bash in an interruptible read instead of waiting on a foreground command substitution')
+assert(network.hiddenOpenConnectScript.includes('>/dev/null & wait $!; }'), 'hidden open connect script backgrounds connection add under wait so the TERM trap can preempt it')
+assert(network.hiddenOpenConnectScript.includes('trap \'timeout -k 1 5 nmcli connection delete uuid "$u"'), 'hidden open connect script bounds the EXIT-trap cleanup delete so a wedged NetworkManager cannot stall the dying process')
+assert(network.hiddenOpenConnectScript.includes('[[ $c != "$u" ]] || continue'), 'hidden open connect script dedupe skips the profile this attempt just created, so the late snapshot cannot delete it')
+assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*--escape no -g[\s\S]*nmcli connection delete \$old/.test(network.hiddenOpenConnectScript), 'hidden open connect script snapshots duplicates inside the modify-success block, immediately before the batched delete (TOCTOU guard)')
+assert(/connection modify[\s\S]*trap 'kill -TERM \$! 2>\/dev\/null; exit 143' TERM INT/.test(network.hiddenOpenConnectScript), 'hidden open connect script re-arms the kill-child TERM trap before the late snapshot so a panel kill still interrupts it')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -318,7 +318,9 @@ assert(/\[\[ \$2 == "sae" \]\] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskC
 // type + ssid + hidden, captured before the new profile exists, and only
 // removed after the new one activates -- never up front, and never by name.
 assert(!/connection delete id "\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never deletes an existing profile by name')
+assert(!network.hiddenPskConnectScript.includes('connection delete id '), 'hidden PSK connect script never deletes any existing profile by name (id), regardless of the argument')
 assert(/nmcli -t -f UUID connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script enumerates existing connections by UUID to find prior hidden profiles for this SSID')
+assert(/nmcli --escape no -g connection\.type,802-11-wireless\.ssid,802-11-wireless\.hidden/.test(network.hiddenPskConnectScript), 'hidden PSK connect script disables nmcli escaping so a colon/backslash SSID still compares equal to the raw $1')
 assert(/connection\.type[\s\S]*"802-11-wireless"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
 assert(/802-11-wireless\.ssid[\s\S]*"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
 assert(/802-11-wireless\.hidden[\s\S]*"yes"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -309,9 +309,26 @@ assert(!/password "\$pw"/.test(network.hiddenPskConnectScript), 'hidden PSK conn
 // requires Protected Management Frames, set only in the sae case.
 assert(/wifi-sec\.key-mgmt "\$2"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets key-mgmt from the $2 arg, not a hardcoded value')
 assert(!/wifi-sec\.key-mgmt wpa-psk/.test(network.hiddenPskConnectScript), 'hidden PSK connect script no longer hardcodes wpa-psk as the key-mgmt')
-assert(/\[ "\$2" = "sae" \] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets PMF required only for the sae (WPA3) case')
+assert(/\[\[ \$2 == "sae" \]\] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets PMF required only for the sae (WPA3) case, using a [[ ]] string test per AGENTS.md')
 
-// A repeat join to the same hidden SSID must not pile up duplicate
-// NetworkManager profiles, so any same-named profile is deleted first.
-assert(/connection delete id "\$1"[\s\S]*nmcli connection add/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes an existing same-named profile before adding a new one')
+// Repeat joins to the same hidden SSID must not pile up duplicate profiles,
+// but con-name is not unique in NetworkManager -- deleting by name (`id`)
+// could destroy an unrelated VPN/Ethernet/broadcast-Wi-Fi profile that just
+// happens to share it. Old profiles must be matched by UUID against
+// type + ssid + hidden, captured before the new profile exists, and only
+// removed after the new one activates -- never up front, and never by name.
+assert(!/connection delete id "\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never deletes an existing profile by name')
+assert(/nmcli -t -f UUID connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script enumerates existing connections by UUID to find prior hidden profiles for this SSID')
+assert(/connection\.type[\s\S]*"802-11-wireless"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
+assert(/802-11-wireless\.ssid[\s\S]*"\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
+assert(/802-11-wireless\.hidden[\s\S]*"yes"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
+assert(/nmcli connection up uuid "\$u"[\s\S]*connection delete uuid "\$o"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
+assert(/connection delete uuid "\$u" >\/dev\/null 2>&1; false; \}$/.test(network.hiddenPskConnectScript), 'hidden PSK connect script leaves prior profiles alone on failure, deleting only its own new (unproven) profile')
+
+// The cleanup loop's own exit status must never leak into the `&&`/`||`
+// chain: a failed delete of a stale/already-gone old UUID (the loop's own
+// last command) would otherwise make the whole `up && { cleanup }` false,
+// tripping the `||` failure branch and deleting the profile that just
+// connected successfully. `true` pins the block's exit status regardless.
+assert(/for o in \$old;[\s\S]*done; true; \}/.test(network.hiddenPskConnectScript), 'hidden PSK connect script cleanup block always reports success so a stale old-UUID delete failure cannot delete the just-connected new profile')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -311,15 +311,10 @@ assert(/wifi-sec\.key-mgmt "\$2"/.test(network.hiddenPskConnectScript), 'hidden 
 assert(!/wifi-sec\.key-mgmt wpa-psk/.test(network.hiddenPskConnectScript), 'hidden PSK connect script no longer hardcodes wpa-psk as the key-mgmt')
 assert(/\[\[ \$2 == "sae" \]\] && pmf="wifi-sec\.pmf 3"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script sets PMF required only for the sae (WPA3) case, using a [[ ]] string test per AGENTS.md')
 
-// Repeat joins to the same hidden SSID must not pile up duplicate profiles,
-// but con-name is not unique in NetworkManager -- deleting by name (`id`)
-// could destroy an unrelated VPN/Ethernet/broadcast-Wi-Fi profile that just
-// happens to share it. Old profiles must be matched by UUID against
-// type + ssid + hidden, captured before the new profile exists, and only
-// removed after the new one activates -- never up front, and never by name.
-// Enumeration is two fixed nmcli calls (a UUID/TYPE listing, then one
-// batched ssid/hidden query over the wifi profiles) -- never one nmcli
-// spawn per profile.
+// Dedupe must never delete by con-name (not unique -- could hit an unrelated
+// profile): match prior profiles by UUID over (ssid, hidden), and only once
+// the new one is up. Enumeration is two fixed nmcli calls, never one per
+// connection.
 assert(!/connection delete id "\$1"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never deletes an existing profile by name')
 assert(!network.hiddenPskConnectScript.includes('connection delete id '), 'hidden PSK connect script never deletes any existing profile by name (id), regardless of the argument')
 assert(/nmcli -t -f UUID,TYPE connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script lists all connections (UUID + type) in a single nmcli call')
@@ -328,7 +323,9 @@ assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wirel
 assert(/\[\[ \$t == "802-11-wireless" \]\] && wifi=/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
 assert(/\[\[ \$ssid == "\$1" \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
 assert(/\[\[ \$hidden == "yes" \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
-assert(/connection up uuid "\$u"[\s\S]*connection delete uuid "\$o"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
+assert(/old="\$old uuid \$c"/.test(network.hiddenPskConnectScript), 'hidden PSK connect script accumulates old profiles as delete-ready "uuid <id>" tokens')
+assert(!/for o in \$old/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes duplicates in one batched nmcli call, not one per profile')
+assert(/connection up uuid "\$u"[\s\S]*nmcli connection delete \$old/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only deletes old profiles after the new one activates successfully')
 
 // Cleanup is a single EXIT trap: armed before the profile exists, deleting
 // it on any failure or TERM/INT kill, and disarmed (`trap - EXIT`) only
@@ -344,7 +341,7 @@ assert(
   network.hiddenPskConnectScript.indexOf('connection up uuid "$u"') < network.hiddenPskConnectScript.indexOf('trap - EXIT'),
   'hidden PSK connect script disarms the cleanup trap only after connection up proves the profile'
 )
-assert(/for o in \$old;[\s\S]*done;[\s\S]*true; \}/.test(network.hiddenPskConnectScript), 'hidden PSK connect script pins the success block status so a stale old-UUID delete failure cannot fail the chain')
+assert(/\[\[ -n \$old \]\] && nmcli connection delete \$old[\s\S]*true; \}/.test(network.hiddenPskConnectScript), 'hidden PSK connect script pins the success block status with `true` so a stale old-UUID delete failure cannot fail the chain')
 
 // The profile starts inert (autoconnect no), is armed only after activation,
 // and old profiles are removed only if that arm succeeded -- a failed arm
@@ -356,13 +353,11 @@ assert(
   network.hiddenPskConnectScript.indexOf('connection up uuid "$u"') < network.hiddenPskConnectScript.indexOf('connection.autoconnect yes'),
   'hidden PSK connect script only sets autoconnect yes after connection up, never before'
 )
-assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*for o in \$old/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes old profiles only if the autoconnect arm succeeded')
+assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*nmcli connection delete \$old/.test(network.hiddenPskConnectScript), 'hidden PSK connect script deletes old profiles only if the autoconnect arm succeeded')
 
-// A plain `read` strips leading/trailing whitespace, which would silently
-// corrupt a space-padded SSID (legal bytes) before it's compared against
-// the raw "$1" -- IFS= is required on every field read. The batched query
-// separates profiles with a blank line, which the uuid read must skip to
-// keep the 3-line groups aligned.
+// IFS= on every field read: a bare `read` trims whitespace and would corrupt
+// a space-padded SSID before the "$1" compare. The batched query blank-lines
+// between profiles, so the uuid read skips blanks to keep 3-line groups aligned.
 assert(/IFS= read -r ssid; IFS= read -r hidden;/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
 assert(/\[\[ -n \$c \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script skips the blank separator lines between batched profiles so field groups stay aligned')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -328,7 +328,7 @@ assert(!/connection delete id "\$1"/.test(network.hiddenPskConnectScript), 'hidd
 assert(!network.hiddenPskConnectScript.includes('connection delete id '), 'hidden PSK connect script never deletes any existing profile by name (id), regardless of the argument')
 assert(/nmcli -t -f UUID,TYPE connection show/.test(network.hiddenPskConnectScript), 'hidden PSK connect script lists all connections (UUID + type) in a single nmcli call')
 assert(!/for c in \$\(nmcli/.test(network.hiddenPskConnectScript), 'hidden PSK connect script never runs nmcli once per connection (N+1)')
-assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden connection show \$wifi/.test(network.hiddenPskConnectScript), 'hidden PSK connect script fetches ssid/hidden for all wifi profiles in one batched, unescaped query so a colon/backslash SSID still compares equal to the raw $1')
+assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden,802-11-wireless-security\.key-mgmt,802-11-wireless\.bssid,802-11-wireless\.mac-address,connection\.interface-name,ipv4\.method,ipv6\.method,ipv4\.addresses,ipv4\.dns,ipv4\.routes,ipv6\.addresses,ipv6\.dns,ipv6\.routes connection show \$wifi/.test(network.hiddenPskConnectScript), 'hidden PSK connect script fetches ssid/hidden/identity/IP-customization fields for all wifi profiles in one batched, unescaped query so a colon/backslash SSID still compares equal to the raw $1')
 assert(/\[\[ \$t == "802-11-wireless" \]\] && wifi=/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers 802-11-wireless connections for cleanup')
 assert(/\[\[ \$ssid == "\$1" \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script matches prior profiles by this SSID, not by name')
 assert(/\[\[ \$hidden == "yes" \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script only considers hidden profiles for cleanup, never a broadcast network of the same SSID')
@@ -398,5 +398,5 @@ assert(
 )
 assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*nmcli connection delete \$old/.test(network.hiddenOpenConnectScript), 'hidden open connect script deletes old profiles only if the autoconnect arm succeeded')
 
-assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden connection show \$wifi/.test(network.hiddenOpenConnectScript), 'hidden open connect script shares the same batched dedupe query as the PSK script, so it dedupes prior hidden profiles too')
+assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden,802-11-wireless-security\.key-mgmt,802-11-wireless\.bssid,802-11-wireless\.mac-address,connection\.interface-name,ipv4\.method,ipv6\.method,ipv4\.addresses,ipv4\.dns,ipv4\.routes,ipv6\.addresses,ipv6\.dns,ipv6\.routes connection show \$wifi/.test(network.hiddenOpenConnectScript), 'hidden open connect script shares the same batched dedupe query as the PSK script, so it dedupes prior hidden profiles too')
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -360,4 +360,34 @@ assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*
 // between profiles, so the uuid read skips blanks to keep 3-line groups aligned.
 assert(/IFS= read -r ssid; IFS= read -r hidden;/.test(network.hiddenPskConnectScript), 'hidden PSK connect script parses ssid/hidden with IFS= read -r so a space-padded SSID is not trimmed')
 assert(/\[\[ -n \$c \]\] \|\| continue/.test(network.hiddenPskConnectScript), 'hidden PSK connect script skips the blank separator lines between batched profiles so field groups stay aligned')
+
+// An open hidden network has no credentials, but must still avoid `nmcli
+// device wifi connect`, which persists an autoconnecting profile before
+// activation -- a timed-out or killed attempt would stay saved and retry in
+// the background. It shares the PSK script's dedupe/EXIT-trap lifecycle,
+// minus the secret.
+assert(/"\$1"/.test(network.hiddenOpenConnectScript), 'hidden open connect script maps ssid to the positional $1 arg')
+assert(/802-11-wireless\.hidden yes/.test(network.hiddenOpenConnectScript), 'hidden open connect script marks the profile hidden')
+assert(/connection\.autoconnect no/.test(network.hiddenOpenConnectScript), 'hidden open connect script creates the profile inert (autoconnect no) so a killed/failed attempt cannot be retried in the background')
+assert(!/wifi-sec/.test(network.hiddenOpenConnectScript), 'hidden open connect script sets no wifi security properties on an open profile')
+assert(!/IFS= read -r pw/.test(network.hiddenOpenConnectScript), 'hidden open connect script never reads a passphrase, since open networks have none')
+
+assert(/trap 'nmcli connection delete uuid "\$u"[^']*' EXIT/.test(network.hiddenOpenConnectScript), 'hidden open connect script arms an EXIT trap that removes the unproven profile on any failure or kill')
+assert(/trap 'exit 143' TERM INT/.test(network.hiddenOpenConnectScript), 'hidden open connect script converts TERM/INT into an exit so the EXIT trap cleanup runs on a panel kill')
+assert(
+  network.hiddenOpenConnectScript.indexOf("' EXIT") < network.hiddenOpenConnectScript.indexOf('connection add'),
+  'hidden open connect script arms the cleanup trap before the profile is created'
+)
+assert(
+  network.hiddenOpenConnectScript.indexOf('connection up uuid "$u"') < network.hiddenOpenConnectScript.indexOf('trap - EXIT'),
+  'hidden open connect script disarms the cleanup trap only after connection up proves the profile'
+)
+assert(/nmcli -w 25 connection up uuid "\$u"/.test(network.hiddenOpenConnectScript), 'hidden open connect script bounds nmcli\'s own wait below the QML 30s kill timeout')
+assert(
+  network.hiddenOpenConnectScript.indexOf('connection up uuid "$u"') < network.hiddenOpenConnectScript.indexOf('connection.autoconnect yes'),
+  'hidden open connect script only sets autoconnect yes after connection up, never before'
+)
+assert(/if nmcli connection modify uuid "\$u" connection\.autoconnect yes[\s\S]*nmcli connection delete \$old/.test(network.hiddenOpenConnectScript), 'hidden open connect script deletes old profiles only if the autoconnect arm succeeded')
+
+assert(/nmcli --escape no -g connection\.uuid,802-11-wireless\.ssid,802-11-wireless\.hidden connection show \$wifi/.test(network.hiddenOpenConnectScript), 'hidden open connect script shares the same batched dedupe query as the PSK script, so it dedupes prior hidden profiles too')
 JS


### PR DESCRIPTION
Non-broadcasting SSIDs never appear in a scan, so there was no way to join one from the Wi-Fi panel. This adds a **Join hidden network** form at the bottom of the panel — SSID, a Security dropdown (**WPA/WPA2 Personal · WPA3 Personal · None**), and a passphrase — handed straight to nmcli, and wired into the panel's keyboard cursor model.

Notes for review:

- Passphrases reach nmcli over stdin only, never argv.
- **Enterprise (802.1X) is deliberately not offered**: with no beacon to verify and no CA-validation UI, a hidden 802.1X join invites evil-twin credential theft. The scan-driven enterprise flow is unchanged.

Known limitation: on very short displays the open form can extend below the card (the panel content isn't scrollable) — planned follow-up.

| Closed | Open |
|--------|--------|
| <img width="394" height="617" alt="screenshot-2026-08-23_02-01-58" src="https://github.com/user-attachments/assets/d868ffcf-3194-45fe-b83b-a71df7458a99" /> | <img width="384" height="762" alt="screenshot-2026-08-23_02-01-38" src="https://github.com/user-attachments/assets/3c5e46a0-45f7-4e26-8cad-36b2732e5ddc" /> |

_Screenshots predate the review rounds: the dropdown now offers WPA/WPA2 Personal · WPA3 Personal · None, and there is no Identity field._
