### PR TITLE
Fix Codex usage collector with current app-server

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -549,8 +549,12 @@ def fetch_codex_rpc():
 
     account = (account_msg.get("result") or {}).get("account") or {}
     limits_result = limits_msg.get("result") or {}
-    limits = ((limits_result.get("rateLimitsByLimitId") or {}).get("codex")
-              or limits_result.get("rateLimits") or {})
+    # A codex bucket can arrive with every window null while rateLimits still
+    # mirrors the account's real numbers, so choose on content, not presence.
+    codex_limits = (limits_result.get("rateLimitsByLimitId") or {}).get("codex") or {}
+    limits = limits_result.get("rateLimits") or {}
+    if codex_limits.get("primary") or codex_limits.get("secondary"):
+      limits = codex_limits
     plan = limits.get("planType") or account.get("planType") or account.get("type") or ""
     result["tierLabel"] = str(plan) if plan else ""
 

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,
@@ -548,7 +548,9 @@ def fetch_codex_rpc():
     limits_msg = rpc_request(proc, 3, "account/rateLimits/read", timeout=4)
 
     account = (account_msg.get("result") or {}).get("account") or {}
-    limits = (limits_msg.get("result") or {}).get("rateLimits") or {}
+    limits_result = limits_msg.get("result") or {}
+    limits = ((limits_result.get("rateLimitsByLimitId") or {}).get("codex")
+              or limits_result.get("rateLimits") or {})
     plan = limits.get("planType") or account.get("planType") or account.get("type") or ""
     result["tierLabel"] = str(plan) if plan else ""
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -27,6 +27,19 @@ while read -r request; do
       jq -cn --argjson id "$id" '{id: $id, result: {account: {}}}'
       ;;
     account/rateLimits/read)
+      if [[ -n "$CODEX_TEST_LEGACY_RATE_LIMITS" ]]; then
+        jq -cn --argjson id "$id" '{
+          id: $id,
+          result: {
+            rateLimits: {
+              planType: "legacy",
+              primary: {usedPercent: 90, windowDurationMins: 300}
+            }
+          }
+        }'
+        continue
+      fi
+
       jq -cn --argjson id "$id" '{
         id: $id,
         result: {
@@ -71,6 +84,13 @@ pass "Codex collector does not double-count cache or reasoning tokens"
 [[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"5h window","percent":0.2,"resetsAt":""},{"label":"Weekly (7-day)","percent":0.3,"resetsAt":""}]}' ]] ||
   fail "Codex collector reads the Codex-specific rate-limit bucket" "$result"
 pass "Codex collector uses the current app-server arguments and Codex-specific limits"
+
+legacy_result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  CODEX_TEST_LEGACY_RATE_LIMITS=1 PATH="$TEST_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -c '{tierLabel, limits}' <<<"$legacy_result") == '{"tierLabel":"legacy","limits":[{"label":"5h window","percent":0.9,"resetsAt":""}]}' ]] ||
+  fail "Codex collector reads the legacy single-bucket rate-limit response" "$legacy_result"
+pass "Codex collector supports legacy single-bucket rate limits"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -40,6 +40,22 @@ while read -r request; do
         continue
       fi
 
+      if [[ -n $CODEX_TEST_NULL_CODEX_BUCKET ]]; then
+        jq -cn --argjson id "$id" '{
+          id: $id,
+          result: {
+            rateLimits: {
+              planType: "legacy",
+              primary: {usedPercent: 90, windowDurationMins: 300}
+            },
+            rateLimitsByLimitId: {
+              codex: {limitId: "codex", planType: null, primary: null, secondary: null}
+            }
+          }
+        }'
+        continue
+      fi
+
       jq -cn --argjson id "$id" '{
         id: $id,
         result: {
@@ -91,6 +107,16 @@ legacy_result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="
 [[ $(jq -c '{tierLabel, limits}' <<<"$legacy_result") == '{"tierLabel":"legacy","limits":[{"label":"5h window","percent":0.9,"resetsAt":""}]}' ]] ||
   fail "Codex collector reads the legacy single-bucket rate-limit response" "$legacy_result"
 pass "Codex collector supports legacy single-bucket rate limits"
+
+# A keyed bucket carrying no window is present but useless: preferring it on
+# presence alone would hide limits the legacy view still reports, and the panel
+# renders that as no limits section at all rather than as an error.
+null_bucket_result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  CODEX_TEST_NULL_CODEX_BUCKET=1 PATH="$TEST_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -c '{tierLabel, limits}' <<<"$null_bucket_result") == '{"tierLabel":"legacy","limits":[{"label":"5h window","percent":0.9,"resetsAt":""}]}' ]] ||
+  fail "Codex collector ignores a Codex bucket with no rate-limit windows" "$null_bucket_result"
+pass "Codex collector ignores a Codex bucket with no rate-limit windows"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,8 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+[[ " $* " == *" -a never "* ]] || exit 64
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -25,7 +27,22 @@ while read -r request; do
       jq -cn --argjson id "$id" '{id: $id, result: {account: {}}}'
       ;;
     account/rateLimits/read)
-      jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {}}}'
+      jq -cn --argjson id "$id" '{
+        id: $id,
+        result: {
+          rateLimits: {
+            planType: "legacy",
+            primary: {usedPercent: 90, windowDurationMins: 300}
+          },
+          rateLimitsByLimitId: {
+            codex: {
+              planType: "pro",
+              primary: {usedPercent: 20, windowDurationMins: 300},
+              secondary: {usedPercent: 30, windowDurationMins: 10080}
+            }
+          }
+        }
+      }'
       ;;
   esac
 done
@@ -51,9 +68,9 @@ pass "Codex collector counts each turn once"
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
 pass "Codex collector does not double-count cache or reasoning tokens"
 
-[[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
-  fail "Codex collector identifies itself with an empty limits list" "$result"
-pass "Codex collector identifies itself with an empty limits list"
+[[ $(jq -c '{id, tierLabel, limits}' <<<"$result") == '{"id":"codex","tierLabel":"pro","limits":[{"label":"5h window","percent":0.2,"resetsAt":""},{"label":"Weekly (7-day)","percent":0.3,"resetsAt":""}]}' ]] ||
+  fail "Codex collector reads the Codex-specific rate-limit bucket" "$result"
+pass "Codex collector uses the current app-server arguments and Codex-specific limits"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.


### PR DESCRIPTION
## Summary

Fix the Codex usage collector for current Codex CLI versions.

Codex CLI 0.149.0 no longer accepts `untrusted` as an `--ask-for-approval` value. The collector therefore exited before responding to the app-server `initialize` request and reported:

- `Codex limits unavailable`
- `initialize`

Use the supported non-interactive `never` policy instead.

Also prefer the Codex-specific entry in `rateLimitsByLimitId.codex`, while retaining the existing `rateLimits` fallback for older app-server responses.

## Verification

- Ran `test/shell.d/agent-usage-codex-scanner-test.sh`
- All focused collector tests passed
- Ran `git diff --check`
- Tested the patched collector against Codex CLI 0.149.0 with an authenticated account
- Confirmed it returned the account tier and current rate-limit window instead of the initialization error

The regression test now verifies:

- the collector launches Codex with `-a never`
- the Codex-specific rate-limit bucket takes precedence
- the legacy single-bucket response remains supported