### PR TITLE
Reload a wedged Wi-Fi radio without waiting for the user

### DIFF
--- a/bin/omarchy-restart-wifi
+++ b/bin/omarchy-restart-wifi
@@ -1,11 +1,62 @@
 #!/bin/bash
 
-# omarchy:summary=Unblock and restart the Wi-Fi service.
+# omarchy:summary=Unblock Wi-Fi and reload the radio driver.
+# omarchy:requires-sudo=true
 
-echo -e "Unblocking wifi...\n"
+# rfkill / nmcli radio on is enough when the interface is merely blocked.
+# Intel iwlwifi and Realtek rtw89 firmware can wedge the phy so hard that
+# userspace has nothing to talk to — in-driver reset times out, BAR reads
+# return 0xffffffff, and the existing radio toggle hangs. Reloading the
+# PCI driver is what actually brings the radio back. See #7003.
+
+NET_ROOT=${OMARCHY_WIFI_NET_ROOT:-/sys/class/net}
+
+echo -e "Restarting wifi...\n"
 
 rfkill unblock wifi
-nmcli networking on
-nmcli radio wifi on
-nmcli device wifi rescan 2>/dev/null || true
-rfkill list wifi
+
+seen=" "
+reload_failed=0
+for iface in "$NET_ROOT"/*; do
+  [[ -d $iface/wireless || -d $iface/phy80211 ]] || continue
+  [[ -L $iface/device/driver ]] || continue
+
+  driver=$(basename "$(readlink "$iface/device/driver")")
+  [[ -n $driver ]] || continue
+  [[ $seen == *" $driver "* ]] && continue
+  seen+="$driver "
+
+  unload=()
+  if [[ $driver == iwlwifi ]]; then
+    # iwlmld (BE200+), iwlmvm (AX210), and iwldvm all hold iwlwifi.
+    for helper in iwlmld iwlmvm iwldvm; do
+      if lsmod | grep -q "^${helper}[[:space:]]"; then
+        unload+=("$helper")
+      fi
+    done
+  fi
+  unload+=("$driver")
+
+  echo "Reloading ${unload[*]}..."
+  if ! sudo modprobe -r "${unload[@]}"; then
+    reload_failed=1
+    continue
+  fi
+  if ! sudo modprobe "$driver"; then
+    if sudo modprobe "$driver"; then
+      : # retry recovered the radio
+    else
+      reload_failed=1
+      echo "omarchy-restart-wifi: $driver left unloaded; run: sudo modprobe $driver" >&2
+    fi
+  fi
+done
+
+if ((reload_failed == 0)); then
+  nmcli networking on
+  nmcli radio wifi on
+  nmcli device wifi rescan 2>/dev/null || true
+  rfkill list wifi
+fi
+
+exit "$reload_failed"

--- a/bin/omarchy-restart-wifi
+++ b/bin/omarchy-restart-wifi
@@ -9,7 +9,22 @@
 # return 0xffffffff, and the existing radio toggle hangs. Reloading the
 # PCI driver is what actually brings the radio back. See #7003.
 
-NET_ROOT=${OMARCHY_WIFI_NET_ROOT:-/sys/class/net}
+# The tests point this at a fixture tree. Root never reads it: this command
+# carries a NOPASSWD grant, so the one path where the variable would matter
+# is the one path that must not take direction from the environment.
+if ((EUID == 0)); then
+  NET_ROOT=/sys/class/net
+else
+  NET_ROOT=${OMARCHY_WIFI_NET_ROOT:-/sys/class/net}
+fi
+
+# Two graphical sessions run two watchers, and both answer the same wedge.
+# Serialise here rather than in the watcher: this is the half that runs as
+# root, and it is the only half both sessions share.
+if ((EUID == 0)) && : >>/run/omarchy-restart-wifi.lock 2>/dev/null; then
+  exec 9>>/run/omarchy-restart-wifi.lock
+  flock -w "${OMARCHY_RESTART_WIFI_LOCK_WAIT:-90}" 9 || exit 1
+fi
 
 echo -e "Restarting wifi...\n"
 
@@ -28,8 +43,8 @@ for iface in "$NET_ROOT"/*; do
 
   unload=()
   if [[ $driver == iwlwifi ]]; then
-    # iwlmld (BE200+), iwlmvm (AX210), and iwldvm all hold iwlwifi.
-    for helper in iwlmld iwlmvm iwldvm; do
+    # iwlmld (BE200+), iwlmvm (AX210), iwldvm and iwlmei all hold iwlwifi.
+    for helper in iwlmld iwlmvm iwldvm iwlmei; do
       if lsmod | grep -q "^${helper}[[:space:]]"; then
         unload+=("$helper")
       fi
@@ -38,12 +53,15 @@ for iface in "$NET_ROOT"/*; do
   unload+=("$driver")
 
   echo "Reloading ${unload[*]}..."
-  if ! sudo modprobe -r "${unload[@]}"; then
+  if ! sudo modprobe -r -- "${unload[@]}"; then
     reload_failed=1
     continue
   fi
-  if ! sudo modprobe "$driver"; then
-    if sudo modprobe "$driver"; then
+  if ! sudo modprobe -- "$driver"; then
+    # A PCI device that has just been torn down needs a moment before it
+    # will take firmware again; an instant retry asks the same question.
+    sleep 1
+    if sudo modprobe -- "$driver"; then
       : # retry recovered the radio
     else
       reload_failed=1
@@ -52,11 +70,23 @@ for iface in "$NET_ROOT"/*; do
   fi
 done
 
-if ((reload_failed == 0)); then
-  nmcli networking on
-  nmcli radio wifi on
-  nmcli device wifi rescan 2>/dev/null || true
-  rfkill list wifi
+# Whatever did reload still needs its radio back, so this runs even when a
+# sibling driver failed -- skipping it used to leave a working adapter dark
+# because an unrelated one was busy. The radio toggle hangs on a dead phy,
+# hence the bound.
+nm_failed=0
+if ! timeout "${OMARCHY_RESTART_WIFI_NM_TIMEOUT:-20}" nmcli networking on; then
+  nm_failed=1
 fi
+if ! timeout "${OMARCHY_RESTART_WIFI_NM_TIMEOUT:-20}" nmcli radio wifi on; then
+  nm_failed=1
+fi
+nmcli device wifi rescan 2>/dev/null || true
+rfkill list wifi
 
-exit "$reload_failed"
+# The watcher toasts on exit 0, so a run NetworkManager refused must not
+# report success: the radio is no more back than a failed modprobe leaves it.
+if ((reload_failed != 0 || nm_failed != 0)); then
+  exit 1
+fi
+exit 0

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -10,7 +10,7 @@ set -e
 # a stream, because an upgrade without --noconfirm prompts on stderr. The
 # handler has already said why, so no heading here either.
 if [[ ${OMARCHY_UPDATE_CONFLICT:-} == 1 && ${OMARCHY_UPDATE_INTERACTIVE:-} == 1 ]]; then
-  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*' --overwrite '/etc/sudoers.d/omarchy-restart-wifi'
+  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*'
 fi
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
@@ -24,8 +24,7 @@ trap 'rm -f "$errors"' EXIT
 # Progress bars stay on stdout. Errors are on stderr, kept for the conflict
 # handler below; LC_ALL=C is what keeps them parseable in any locale.
 if sudo env LC_ALL=C OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm \
-  --overwrite '/usr/share/omarchy/*' \
-  --overwrite '/etc/sudoers.d/omarchy-restart-wifi' 2>"$errors"; then
+  --overwrite '/usr/share/omarchy/*' 2>"$errors"; then
   cat "$errors" >&2
   exit 0
 fi

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -10,7 +10,7 @@ set -e
 # a stream, because an upgrade without --noconfirm prompts on stderr. The
 # handler has already said why, so no heading here either.
 if [[ ${OMARCHY_UPDATE_CONFLICT:-} == 1 && ${OMARCHY_UPDATE_INTERACTIVE:-} == 1 ]]; then
-  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*'
+  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*' --overwrite '/etc/sudoers.d/omarchy-restart-wifi'
 fi
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
@@ -24,7 +24,8 @@ trap 'rm -f "$errors"' EXIT
 # Progress bars stay on stdout. Errors are on stderr, kept for the conflict
 # handler below; LC_ALL=C is what keeps them parseable in any locale.
 if sudo env LC_ALL=C OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm \
-  --overwrite '/usr/share/omarchy/*' 2>"$errors"; then
+  --overwrite '/usr/share/omarchy/*' \
+  --overwrite '/etc/sudoers.d/omarchy-restart-wifi' 2>"$errors"; then
   cat "$errors" >&2
   exit 0
 fi

--- a/bin/omarchy-wifi-recover
+++ b/bin/omarchy-wifi-recover
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+# omarchy:summary=Reload a wedged Wi-Fi radio without waiting for the user.
+# omarchy:hidden=true
+
+# NetworkManager can keep a wifi device "connected" after Intel/Realtek
+# firmware dies. The hardware menu now reloads the driver; this watcher
+# does that once the phy stays wedged, so a roam or radio toggle is not
+# enough to yank the module.
+
+set -uo pipefail
+
+PACKAGED_RESTART=/usr/bin/omarchy-restart-wifi
+PACKAGED_UNIT=${OMARCHY_WIFI_RECOVER_PACKAGED_UNIT:-/usr/lib/systemd/user/omarchy-wifi-recover.service}
+POLL_SECONDS=${OMARCHY_WIFI_RECOVER_POLL:-15}
+COOLDOWN_SECONDS=${OMARCHY_WIFI_RECOVER_COOLDOWN:-120}
+CONFIRM_POLLS=${OMARCHY_WIFI_RECOVER_CONFIRM:-2}
+MAX_POLLS=${OMARCHY_WIFI_RECOVER_MAX_POLLS:-0}
+ONCE=${OMARCHY_WIFI_RECOVER_ONCE:-0}
+NET_ROOT=${OMARCHY_WIFI_NET_ROOT:-/sys/class/net}
+NM_TIMEOUT=${OMARCHY_WIFI_RECOVER_NM_TIMEOUT:-10}
+IW_TIMEOUT=${OMARCHY_WIFI_RECOVER_IW_TIMEOUT:-5}
+RESTART_TIMEOUT=${OMARCHY_WIFI_RECOVER_RESTART_TIMEOUT:-60}
+
+# nf-md-wifi-sync, escaped so this file reads without a Nerd Font.
+readonly WIFI_GLYPH=$'\U000f16b5'
+
+last_reload=0
+wedge_streak=0
+grant_warned=0
+notified_this_wedge=0
+polls=0
+
+# A staged ~/.config copy shadows /usr/lib forever. Drop it only when it
+# still matches the packaged unit, so a user edit is left alone.
+unstage_if_packaged() {
+  local config="${XDG_CONFIG_HOME:-$HOME/.config}"
+  local staged="$config/systemd/user/omarchy-wifi-recover.service"
+  local wants="$config/systemd/user/graphical-session.target.wants/omarchy-wifi-recover.service"
+
+  [[ -f $PACKAGED_UNIT && -f $staged ]] || return 0
+  cmp -s "$staged" "$PACKAGED_UNIT" || return 0
+  rm -f "$staged"
+  if [[ -L $wants ]]; then
+    ln -sfn "$PACKAGED_UNIT" "$wants"
+  fi
+  systemctl --user daemon-reload >/dev/null 2>&1 || true
+}
+
+sudo_grants_passwordless() {
+  sudo -n -l -l "$PACKAGED_RESTART" 2>/dev/null | grep -q '!authenticate'
+}
+
+radio_on() {
+  local out rc
+
+  # Only a hung nmcli (timeout 124) is the wedge. NM down or missing is not.
+  out=$(LC_ALL=C timeout "$NM_TIMEOUT" nmcli radio wifi 2>/dev/null)
+  rc=$?
+  if ((rc == 124)); then
+    return 0
+  fi
+  ((rc == 0)) || return 1
+  [[ $out == enabled ]]
+}
+
+rfkill_blocked() {
+  LC_ALL=C rfkill list wifi 2>/dev/null | grep -q 'blocked: yes'
+}
+
+has_wireless_iface() {
+  local iface
+
+  for iface in "$NET_ROOT"/*; do
+    if [[ -d $iface/wireless || -d $iface/phy80211 ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+kernel_link_up() {
+  # nl80211 dumps can block when the driver holds rtnl. timeout → no link.
+  LC_ALL=C timeout "$IW_TIMEOUT" iw dev "$1" link 2>/dev/null | grep -q '^Connected '
+}
+
+# Instantaneous: radio on, not blocked, phy present, and either NM still
+# says connected with no kernel link, or the device is unavailable / gone
+# from NM. A roam or a radio-on race can look like this for one poll.
+looks_wedged() {
+  local dev state found=0 nm_out nm_rc
+
+  radio_on || return 1
+  rfkill_blocked && return 1
+  has_wireless_iface || return 1
+
+  nm_out=$(LC_ALL=C timeout "$NM_TIMEOUT" nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null)
+  nm_rc=$?
+  if ((nm_rc == 124)); then
+    return 0
+  fi
+  ((nm_rc == 0)) || return 1
+
+  while IFS=$'\t' read -r dev state; do
+    [[ -n $dev ]] || continue
+    found=1
+
+    case $state in
+      connected*)
+        kernel_link_up "$dev" || return 0
+        ;;
+      unavailable)
+        return 0
+        ;;
+    esac
+  done < <(awk -F: '$2 == "wifi" { print $1 "\t" $3 }' <<<"$nm_out")
+
+  # NM listed nothing, but the phy is still in sysfs: same class of wedge.
+  ((found == 0))
+}
+
+# Two consecutive polls (~30s) before we unload the driver. One miss is a
+# roam, a scan, or the user flipping the radio back on.
+wifi_wedged() {
+  if looks_wedged; then
+    wedge_streak=$((wedge_streak + 1))
+    ((wedge_streak >= CONFIRM_POLLS))
+    return
+  fi
+
+  wedge_streak=0
+  notified_this_wedge=0
+  return 1
+}
+
+try_reload() {
+  local now=$EPOCHSECONDS
+
+  if ((now - last_reload < COOLDOWN_SECONDS)); then
+    return 1
+  fi
+
+  if ! sudo_grants_passwordless; then
+    if ((grant_warned == 0)); then
+      echo "omarchy-wifi-recover: passwordless sudo is required for $PACKAGED_RESTART" >&2
+      grant_warned=1
+    fi
+    return 1
+  fi
+
+  # Cool down even on a failed reload so we do not hammer modprobe -r.
+  last_reload=$now
+
+  if ! timeout "$RESTART_TIMEOUT" sudo -n "$PACKAGED_RESTART"; then
+    echo "omarchy-wifi-recover: $PACKAGED_RESTART failed" >&2
+    return 1
+  fi
+
+  grant_warned=0
+
+  # Reload is not proof the phy came back. One toast per wedge episode.
+  if ((notified_this_wedge == 0)); then
+    omarchy-notification-send -g "$WIFI_GLYPH" "Wi-Fi radio reloaded" \
+      "The radio firmware wedged and the driver was reloaded." || true
+    notified_this_wedge=1
+  fi
+  return 0
+}
+
+if [[ ${1:-} == --check ]]; then
+  # Instantaneous: for debugging. The daemon still requires CONFIRM_POLLS.
+  if looks_wedged; then
+    echo wedged
+    exit 0
+  fi
+
+  echo ok
+  exit 1
+fi
+
+if ((ONCE)); then
+  if looks_wedged; then
+    try_reload
+  fi
+  exit 0
+fi
+
+unstage_if_packaged
+
+if ! [[ $POLL_SECONDS =~ ^[0-9]+$ ]]; then
+  POLL_SECONDS=15
+fi
+
+while true; do
+  if wifi_wedged; then
+    try_reload
+  fi
+
+  polls=$((polls + 1))
+  if ((MAX_POLLS > 0 && polls >= MAX_POLLS)); then
+    exit 0
+  fi
+
+  sleep "$POLL_SECONDS"
+done

--- a/bin/omarchy-wifi-recover
+++ b/bin/omarchy-wifi-recover
@@ -21,6 +21,7 @@ NET_ROOT=${OMARCHY_WIFI_NET_ROOT:-/sys/class/net}
 NM_TIMEOUT=${OMARCHY_WIFI_RECOVER_NM_TIMEOUT:-10}
 IW_TIMEOUT=${OMARCHY_WIFI_RECOVER_IW_TIMEOUT:-5}
 RESTART_TIMEOUT=${OMARCHY_WIFI_RECOVER_RESTART_TIMEOUT:-60}
+MAX_RELOADS=${OMARCHY_WIFI_RECOVER_MAX_RELOADS:-3}
 
 # nf-md-wifi-sync, escaped so this file reads without a Nerd Font.
 readonly WIFI_GLYPH=$'\U000f16b5'
@@ -29,17 +30,23 @@ last_reload=0
 wedge_streak=0
 grant_warned=0
 notified_this_wedge=0
+reloads_this_wedge=0
+gave_up_this_wedge=0
 polls=0
 
-# A staged ~/.config copy shadows /usr/lib forever. Drop it only when it
-# still matches the packaged unit, so a user edit is left alone.
+# A staged ~/.config copy shadows /usr/lib forever. Drop it only when it is
+# still stock, so a user edit is left alone. Stock means either copy we could
+# have put there: matching only the packaged unit would strand every staged
+# copy the first time that unit is revised upstream, which is the shadow this
+# exists to prevent.
 unstage_if_packaged() {
   local config="${XDG_CONFIG_HOME:-$HOME/.config}"
   local staged="$config/systemd/user/omarchy-wifi-recover.service"
   local wants="$config/systemd/user/graphical-session.target.wants/omarchy-wifi-recover.service"
+  local source="${OMARCHY_PATH:-/usr/share/omarchy}/default/systemd/user/omarchy-wifi-recover.service"
 
   [[ -f $PACKAGED_UNIT && -f $staged ]] || return 0
-  cmp -s "$staged" "$PACKAGED_UNIT" || return 0
+  cmp -s "$staged" "$PACKAGED_UNIT" || cmp -s "$staged" "$source" || return 0
   rm -f "$staged"
   if [[ -L $wants ]]; then
     ln -sfn "$PACKAGED_UNIT" "$wants"
@@ -51,21 +58,48 @@ sudo_grants_passwordless() {
   sudo -n -l -l "$PACKAGED_RESTART" 2>/dev/null | grep -q '!authenticate'
 }
 
-radio_on() {
+# 0 the radio is on, 1 it is off or NM cannot say, 2 nmcli never answered.
+# The three are not interchangeable: a probe that timed out is a fact about
+# NetworkManager, not evidence that the radio is enabled.
+radio_state() {
   local out rc
 
-  # Only a hung nmcli (timeout 124) is the wedge. NM down or missing is not.
   out=$(LC_ALL=C timeout "$NM_TIMEOUT" nmcli radio wifi 2>/dev/null)
   rc=$?
-  if ((rc == 124)); then
-    return 0
-  fi
+  ((rc == 124)) && return 2
   ((rc == 0)) || return 1
   [[ $out == enabled ]]
 }
 
+# This device's own soft/hard block, read from its phy. `rfkill list wifi`
+# reports every radio at once, so one deliberately blocked dongle used to
+# suppress recovery for the wedged adapter beside it.
 rfkill_blocked() {
-  LC_ALL=C rfkill list wifi 2>/dev/null | grep -q 'blocked: yes'
+  local state
+
+  for state in "$NET_ROOT/$1"/phy80211/rfkill*/soft "$NET_ROOT/$1"/phy80211/rfkill*/hard; do
+    [[ -r $state ]] || continue
+    [[ $(<"$state") == 0 ]] || return 0
+  done
+
+  return 1
+}
+
+# nl80211 interface type, empty when iw cannot say. An AP, an ad-hoc cell and
+# a mesh point are all "connected" to NetworkManager while `iw link` reports
+# no association, so the type is what separates them from a dead station.
+iface_type() {
+  LC_ALL=C timeout "$IW_TIMEOUT" iw dev "$1" info 2>/dev/null |
+    sed -n 's/^[[:space:]]*type \([a-zA-Z/]\{1,\}\)[[:space:]]*$/\1/p' | head -n1
+}
+
+# Whether the kernel still answers for this device at all. NetworkManager
+# reports `unavailable` both for a wedged phy and for a machine whose wifi
+# backend is misconfigured (#7323), where the driver is loaded and healthy
+# and reloading it fixes nothing. Only the kernel side tells them apart.
+kernel_responsive() {
+  [[ -d $NET_ROOT/$1 ]] || return 1
+  LC_ALL=C timeout "$IW_TIMEOUT" iw dev "$1" info >/dev/null 2>&1
 }
 
 has_wireless_iface() {
@@ -85,14 +119,18 @@ kernel_link_up() {
   LC_ALL=C timeout "$IW_TIMEOUT" iw dev "$1" link 2>/dev/null | grep -q '^Connected '
 }
 
-# Instantaneous: radio on, not blocked, phy present, and either NM still
-# says connected with no kernel link, or the device is unavailable / gone
-# from NM. A roam or a radio-on race can look like this for one poll.
+# Instantaneous: the radio is meant to be on, a phy is present, and some
+# wifi device is in a state only a dead phy explains. A roam or a radio-on
+# race can look like this for one poll, which is what CONFIRM_POLLS is for.
 looks_wedged() {
   local dev state found=0 nm_out nm_rc
 
-  radio_on || return 1
-  rfkill_blocked && return 1
+  radio_state
+  case $? in
+    1) return 1 ;;    # radio off, or NM has no answer: not ours to fix.
+    2) return 0 ;;    # nmcli hung. The AX210 wedge hangs do-change-link.
+  esac
+
   has_wireless_iface || return 1
 
   nm_out=$(LC_ALL=C timeout "$NM_TIMEOUT" nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null)
@@ -106,12 +144,20 @@ looks_wedged() {
     [[ -n $dev ]] || continue
     found=1
 
+    # A radio the user blocked is a radio the user wants off.
+    rfkill_blocked "$dev" && continue
+
     case $state in
       connected*)
+        # Only an infrastructure station has an association to lose. An AP,
+        # a hotspot, an ad-hoc cell and a mesh point are all connected with
+        # no link, and unloading the driver under one drops every client on
+        # it. An unreadable type is not evidence either way, so it waits.
+        [[ $(iface_type "$dev") == "managed" ]] || continue
         kernel_link_up "$dev" || return 0
         ;;
       unavailable)
-        return 0
+        kernel_responsive "$dev" || return 0
         ;;
     esac
   done < <(awk -F: '$2 == "wifi" { print $1 "\t" $3 }' <<<"$nm_out")
@@ -131,11 +177,27 @@ wifi_wedged() {
 
   wedge_streak=0
   notified_this_wedge=0
+  reloads_this_wedge=0
+  gave_up_this_wedge=0
   return 1
 }
 
 try_reload() {
   local now=$EPOCHSECONDS
+
+  # A reload that did not bring the phy back will not start working on the
+  # twentieth attempt, and unloading a PCI driver every two minutes for the
+  # rest of the session is its own fault. Stop, and say so once -- a red
+  # light nobody is shown is worse than no light at all.
+  if ((MAX_RELOADS > 0 && reloads_this_wedge >= MAX_RELOADS)); then
+    if ((gave_up_this_wedge == 0)); then
+      gave_up_this_wedge=1
+      echo "omarchy-wifi-recover: gave up after $reloads_this_wedge reloads; the radio did not come back" >&2
+      omarchy-notification-send -u critical -g "$WIFI_GLYPH" "Wi-Fi did not come back" \
+        "The radio driver was reloaded $reloads_this_wedge times without recovering. Run: omarchy restart wifi" || true
+    fi
+    return 1
+  fi
 
   if ((now - last_reload < COOLDOWN_SECONDS)); then
     return 1
@@ -151,6 +213,7 @@ try_reload() {
 
   # Cool down even on a failed reload so we do not hammer modprobe -r.
   last_reload=$now
+  reloads_this_wedge=$((reloads_this_wedge + 1))
 
   if ! timeout "$RESTART_TIMEOUT" sudo -n "$PACKAGED_RESTART"; then
     echo "omarchy-wifi-recover: $PACKAGED_RESTART failed" >&2

--- a/default/systemd/user/omarchy-wifi-recover.service
+++ b/default/systemd/user/omarchy-wifi-recover.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Reload a wedged Wi-Fi radio
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionPathExists=/sys/class/ieee80211
+ConditionPathExists=/usr/bin/omarchy-wifi-recover
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-wifi-recover
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -271,10 +271,11 @@ and/or a working user systemd instance:
   `systemctl --user enable --now` the shipped user units (`bt-agent`,
   `omarchy-sleep-lock`, `omarchy-recover-internal-monitor`,
   `omarchy-migrate-notify.service`, `omarchy-fcitx5.service`,
-  `omarchy-crash-watch.service`) so they run in the first session too.
+  `omarchy-crash-watch.service`, `omarchy-wifi-recover.service`) so they run in the first session too.
   Done here, not at finalize, because
-  the user manager isn't reachable from the ISO chroot; `ConditionPath*`
-  in the unit files keeps services inert when they don't apply.
+  the user manager isn't reachable from the ISO chroot. `ConditionPath*` on
+  units that have one keeps those services inert when they don't apply;
+  `omarchy-wifi-recover` is gated on `/sys/class/ieee80211`.
 - `install/user/first-run/gnome-theme.sh`,
   `install/user/first-run/gtk-primary-paste.sh` — GNOME/GTK settings that
   need the dconf daemon.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -121,6 +121,9 @@ Everything goes through the same sender contract, so the pieces are small:
   after `graphical-session.target`) waits for the server, then sends a
   critical toast whose click opens a terminal running `omarchy-migrate`,
   falling back to printing in the terminal if the hand-off fails.
+- **Wi-Fi recover** — `omarchy-wifi-recover` sends one low-urgency toast per
+  wedge episode after it reloads the radio driver. The wording is "reloaded",
+  not "recovered": the reload is not proof the phy came back.
 
 ## Reminders
 

--- a/etc/sudoers.d/omarchy-restart-wifi
+++ b/etc/sudoers.d/omarchy-restart-wifi
@@ -1,0 +1,3 @@
+# The wifi recover watcher has no terminal. Reloading a wedged radio is
+# module unload/reload only. Empty argv so this is not "any arguments".
+%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-restart-wifi ""

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -11,6 +11,28 @@
 
 set -euo pipefail
 
+# The settings package lists user units explicitly. Until it ships this one
+# to /usr/lib/systemd/user, stage it from the omarchy tree so enable --now
+# can find it. Prefer the packaged copy once it exists.
+stage_user_unit() {
+  local name=$1
+  local src="$OMARCHY_PATH/default/systemd/user/$name"
+  local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  local staged="$config_home/systemd/user/$name"
+  if [[ -f /usr/lib/systemd/user/$name ]]; then
+    if [[ -f $staged ]] && cmp -s "$staged" "/usr/lib/systemd/user/$name"; then
+      rm -f "$staged"
+    fi
+    return 0
+  fi
+
+  [[ -f $src ]] || return 0
+
+  install -Dm644 "$src" "$staged"
+}
+
+stage_user_unit omarchy-wifi-recover.service
+
 systemctl --user daemon-reload
 systemctl --user enable --now \
   bt-agent.service \
@@ -18,4 +40,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-wifi-recover.service

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -27,6 +27,8 @@ stage_user_unit() {
   fi
 
   [[ -f $src ]] || return 0
+  # first-run reruns with --force, so never clobber a copy already there.
+  [[ -f $staged ]] && return 0
 
   install -Dm644 "$src" "$staged"
 }

--- a/migrations/1787444800.sh
+++ b/migrations/1787444800.sh
@@ -4,22 +4,38 @@ echo "Reload a wedged Wi-Fi radio without waiting for the user"
 
 src="$OMARCHY_PATH/default/systemd/user/omarchy-wifi-recover.service"
 sudoers_src="$OMARCHY_PATH/etc/sudoers.d/omarchy-restart-wifi"
-sudoers_dest=/etc/sudoers.d/omarchy-restart-wifi
+# Overridable only so the test can exercise both halves of every branch here;
+# the watcher already reads its packaged unit the same way.
+sudoers_dest=${OMARCHY_WIFI_SUDOERS_DEST:-/etc/sudoers.d/omarchy-restart-wifi}
+packaged_unit=${OMARCHY_WIFI_RECOVER_PACKAGED_UNIT:-/usr/lib/systemd/user/omarchy-wifi-recover.service}
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
 
 # The watcher is in the omarchy package; the grant lives in omarchy-settings.
 # During package skew the unit can be enabled with no sudoers file, and
 # every reload fails silently. Install the drop-in ourselves when missing.
+#
+# Nothing here may abort: migrations run under `bash -euo pipefail`, so a
+# cancelled password prompt or a user outside %wheel would take out every
+# migration queued behind this one. Say what went wrong and carry on.
 if [[ ! -f $sudoers_dest && -f $sudoers_src ]]; then
-  if visudo -cf "$sudoers_src" >/dev/null 2>&1; then
-    sudo install -Dm440 "$sudoers_src" "$sudoers_dest"
+  if ! visudo -cf "$sudoers_src" >/dev/null 2>&1; then
+    echo "  Skipping the Wi-Fi sudoers grant: $sudoers_src does not parse"
+  elif ! sudo install -Dm440 "$sudoers_src" "$sudoers_dest"; then
+    echo "  Could not install $sudoers_dest; automatic Wi-Fi recovery stays off until omarchy-settings ships it"
   fi
 fi
 
-if [[ -f /usr/lib/systemd/user/omarchy-wifi-recover.service ]]; then
-  rm -f "$config_home/systemd/user/omarchy-wifi-recover.service"
-elif [[ -f $src ]]; then
-  install -Dm644 "$src" "$config_home/systemd/user/omarchy-wifi-recover.service"
+staged="$config_home/systemd/user/omarchy-wifi-recover.service"
+if [[ -f $packaged_unit ]]; then
+  # Only when it is still stock. An edited copy is the user's, and a copy
+  # matching either shipped version is one of ours to clean up.
+  if [[ -f $staged ]] &&
+    { cmp -s "$staged" "$packaged_unit" ||
+      { [[ -f $src ]] && cmp -s "$staged" "$src"; }; }; then
+    rm -f "$staged"
+  fi
+elif [[ -f $src && ! -f $staged ]]; then
+  install -Dm644 "$src" "$staged"
 fi
 
 systemctl --user daemon-reload >/dev/null 2>&1 || true
@@ -29,8 +45,8 @@ systemctl --user daemon-reload >/dev/null 2>&1 || true
 if ! systemctl --user enable omarchy-wifi-recover.service >/dev/null 2>&1; then
   wants_dir="$config_home/systemd/user/graphical-session.target.wants"
   mkdir -p "$wants_dir"
-  if [[ -f /usr/lib/systemd/user/omarchy-wifi-recover.service ]]; then
-    ln -sfn /usr/lib/systemd/user/omarchy-wifi-recover.service \
+  if [[ -f $packaged_unit ]]; then
+    ln -sfn "$packaged_unit" \
       "$wants_dir/omarchy-wifi-recover.service"
   elif [[ -f $config_home/systemd/user/omarchy-wifi-recover.service ]]; then
     ln -sfn ../omarchy-wifi-recover.service \

--- a/migrations/1787444800.sh
+++ b/migrations/1787444800.sh
@@ -1,0 +1,43 @@
+echo "Reload a wedged Wi-Fi radio without waiting for the user"
+
+# first-run only runs once, so existing installs need the unit enabled here.
+
+src="$OMARCHY_PATH/default/systemd/user/omarchy-wifi-recover.service"
+sudoers_src="$OMARCHY_PATH/etc/sudoers.d/omarchy-restart-wifi"
+sudoers_dest=/etc/sudoers.d/omarchy-restart-wifi
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+
+# The watcher is in the omarchy package; the grant lives in omarchy-settings.
+# During package skew the unit can be enabled with no sudoers file, and
+# every reload fails silently. Install the drop-in ourselves when missing.
+if [[ ! -f $sudoers_dest && -f $sudoers_src ]]; then
+  if visudo -cf "$sudoers_src" >/dev/null 2>&1; then
+    sudo install -Dm440 "$sudoers_src" "$sudoers_dest"
+  fi
+fi
+
+if [[ -f /usr/lib/systemd/user/omarchy-wifi-recover.service ]]; then
+  rm -f "$config_home/systemd/user/omarchy-wifi-recover.service"
+elif [[ -f $src ]]; then
+  install -Dm644 "$src" "$config_home/systemd/user/omarchy-wifi-recover.service"
+fi
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# `systemctl enable` needs a live user manager, which an update from a TTY does
+# not have, so fall back to writing the symlink it would have written.
+if ! systemctl --user enable omarchy-wifi-recover.service >/dev/null 2>&1; then
+  wants_dir="$config_home/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  if [[ -f /usr/lib/systemd/user/omarchy-wifi-recover.service ]]; then
+    ln -sfn /usr/lib/systemd/user/omarchy-wifi-recover.service \
+      "$wants_dir/omarchy-wifi-recover.service"
+  elif [[ -f $config_home/systemd/user/omarchy-wifi-recover.service ]]; then
+    ln -sfn ../omarchy-wifi-recover.service \
+      "$wants_dir/omarchy-wifi-recover.service"
+  fi
+fi
+
+if systemctl --user is-active --quiet graphical-session.target; then
+  systemctl --user start omarchy-wifi-recover.service >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/restart-wifi-test.sh
+++ b/test/shell.d/restart-wifi-test.sh
@@ -67,9 +67,9 @@ run_restart
 
 grep -qx 'rfkill unblock wifi' "$tmp_dir/calls" ||
   fail "wifi still lifts the rfkill block" "$(cat "$tmp_dir/calls")"
-grep -qx 'sudo modprobe -r iwlmvm iwlwifi' "$tmp_dir/calls" ||
+grep -qx 'sudo modprobe -r -- iwlmvm iwlwifi' "$tmp_dir/calls" ||
   fail "wifi unloads iwlmvm before iwlwifi" "$(cat "$tmp_dir/calls")"
-grep -qx 'sudo modprobe iwlwifi' "$tmp_dir/calls" ||
+grep -qx 'sudo modprobe -- iwlwifi' "$tmp_dir/calls" ||
   fail "wifi reloads iwlwifi" "$(cat "$tmp_dir/calls")"
 grep -qx 'nmcli radio wifi on' "$tmp_dir/calls" ||
   fail "wifi turns the radio back on after the reload" "$(cat "$tmp_dir/calls")"
@@ -86,7 +86,7 @@ mkdir -p "$tmp_dir/net"
 add_iface wlan0 iwlwifi
 run_restart
 
-grep -qx 'sudo modprobe -r iwlmld iwlwifi' "$tmp_dir/calls" ||
+grep -qx 'sudo modprobe -r -- iwlmld iwlwifi' "$tmp_dir/calls" ||
   fail "wifi unloads iwlmld before iwlwifi" "$(cat "$tmp_dir/calls")"
 pass "wifi reloads a wedged iwlwifi/iwlmld radio"
 
@@ -98,7 +98,7 @@ mkdir -p "$tmp_dir/net"
 add_iface wlan0 iwlwifi
 run_restart
 
-grep -qx 'sudo modprobe -r iwldvm iwlwifi' "$tmp_dir/calls" ||
+grep -qx 'sudo modprobe -r -- iwldvm iwlwifi' "$tmp_dir/calls" ||
   fail "wifi unloads iwldvm before iwlwifi" "$(cat "$tmp_dir/calls")"
 pass "wifi reloads a wedged iwlwifi/iwldvm radio"
 
@@ -111,9 +111,9 @@ mkdir -p "$tmp_dir/net"
 add_iface wlp2s0 rtw89_8852be
 run_restart
 
-grep -qx 'sudo modprobe -r rtw89_8852be' "$tmp_dir/calls" ||
+grep -qx 'sudo modprobe -r -- rtw89_8852be' "$tmp_dir/calls" ||
   fail "wifi unloads the Realtek PCI driver" "$(cat "$tmp_dir/calls")"
-grep -qx 'sudo modprobe rtw89_8852be' "$tmp_dir/calls" ||
+grep -qx 'sudo modprobe -- rtw89_8852be' "$tmp_dir/calls" ||
   fail "wifi reloads the Realtek PCI driver" "$(cat "$tmp_dir/calls")"
 grep -q iwlwifi "$tmp_dir/calls" &&
   fail "wifi does not touch iwlwifi on a Realtek radio" "$(cat "$tmp_dir/calls")"
@@ -127,7 +127,7 @@ add_iface wlp9s0 iwlwifi
 add_iface p2p-dev-wlp9s0 iwlwifi
 run_restart
 
-unload_count=$(grep -c 'sudo modprobe -r iwlmvm iwlwifi' "$tmp_dir/calls" || true)
+unload_count=$(grep -c 'sudo modprobe -r -- iwlmvm iwlwifi' "$tmp_dir/calls" || true)
 (( unload_count == 1 )) ||
   fail "wifi reloads a shared driver once" "$(cat "$tmp_dir/calls")"
 pass "wifi reloads a shared driver once"
@@ -164,7 +164,7 @@ add_iface wlp9s0 iwlwifi
 run_restart
 [[ $(<"$tmp_dir/rc") == 1 ]] ||
   fail "wifi reports a failed driver unload" "$(cat "$tmp_dir/rc"; cat "$tmp_dir/calls")"
-grep -qx 'sudo modprobe iwlwifi' "$tmp_dir/calls" &&
+grep -qx 'sudo modprobe -- iwlwifi' "$tmp_dir/calls" &&
   fail "wifi does not reload after a failed unload" "$(cat "$tmp_dir/calls")"
 pass "wifi reports a failed driver unload"
 
@@ -183,10 +183,80 @@ add_iface wlp9s0 iwlwifi
 run_restart
 [[ $(<"$tmp_dir/rc") == 1 ]] ||
   fail "wifi reports a failed driver insert" "$(cat "$tmp_dir/rc"; cat "$tmp_dir/calls")"
-(( $(grep -c 'sudo modprobe iwlwifi' "$tmp_dir/calls" || true) >= 2 )) ||
+(( $(grep -c 'sudo modprobe -- iwlwifi' "$tmp_dir/calls" || true) >= 2 )) ||
   fail "wifi retries a failed insert" "$(cat "$tmp_dir/calls")"
 pass "wifi reports a failed driver insert"
 
-rg -F 'omarchy-restart-wifi' "$ROOT/default/omarchy/omarchy-menu.jsonc" >/dev/null ||
+# iwlmei pins iwlwifi on Intel platforms that ship the management engine
+# interface, and modprobe -r fails while it is loaded.
+cat >"$tmp_dir/bin/modprobe" <<'EOF'
+#!/bin/bash
+printf 'modprobe %s\n' "$*" >>"$CALLS"
+EOF
+chmod +x "$tmp_dir/bin/modprobe"
+printf 'iwlmei 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp9s0 iwlwifi
+run_restart
+
+grep -qx 'sudo modprobe -r -- iwlmei iwlwifi' "$tmp_dir/calls" ||
+  fail "wifi unloads iwlmei before iwlwifi" "$(cat "$tmp_dir/calls")"
+pass "wifi unloads iwlmei before iwlwifi"
+
+# One busy driver must not leave a working adapter dark. The radio toggle is
+# what brings the reloaded one back, so it has to run regardless.
+cat >"$tmp_dir/bin/modprobe" <<'EOF'
+#!/bin/bash
+printf 'modprobe %s\n' "$*" >>"$CALLS"
+[[ $* == *rtw89_8852be* ]] && exit 1
+exit 0
+EOF
+chmod +x "$tmp_dir/bin/modprobe"
+printf 'iwlmvm 1 0\niwlwifi 1 1\nrtw89_8852be 1 0\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp9s0 iwlwifi
+add_iface wlp2s0 rtw89_8852be
+run_restart
+
+grep -qx 'sudo modprobe -- iwlwifi' "$tmp_dir/calls" ||
+  fail "wifi reloads the driver that can be reloaded" "$(cat "$tmp_dir/calls")"
+grep -qx 'nmcli radio wifi on' "$tmp_dir/calls" ||
+  fail "wifi turns the radio back on for the adapter that did reload" "$(cat "$tmp_dir/calls")"
+[[ $(<"$tmp_dir/rc") == 1 ]] ||
+  fail "wifi still reports the driver that failed" "$(cat "$tmp_dir/rc")"
+pass "wifi restores the radio for the adapter that did reload"
+
+# NetworkManager refusing the radio is not a recovery. The watcher toasts on
+# exit 0, so this has to be the difference between success and failure.
+cat >"$tmp_dir/bin/modprobe" <<'EOF'
+#!/bin/bash
+printf 'modprobe %s\n' "$*" >>"$CALLS"
+EOF
+cat >"$tmp_dir/bin/nmcli" <<'EOF'
+#!/bin/bash
+printf 'nmcli %s\n' "$*" >>"$CALLS"
+[[ $1 == radio ]] && exit 1
+exit 0
+EOF
+chmod +x "$tmp_dir/bin/modprobe" "$tmp_dir/bin/nmcli"
+printf 'iwlmvm 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp9s0 iwlwifi
+run_restart
+
+[[ $(<"$tmp_dir/rc") == 1 ]] ||
+  fail "wifi reports a radio NetworkManager would not turn on" "$(cat "$tmp_dir/rc"; cat "$tmp_dir/calls")"
+pass "wifi reports a radio NetworkManager would not turn on"
+
+cat >"$tmp_dir/bin/nmcli" <<'EOF'
+#!/bin/bash
+printf 'nmcli %s\n' "$*" >>"$CALLS"
+EOF
+chmod +x "$tmp_dir/bin/nmcli"
+
+grep -F 'omarchy-restart-wifi' "$ROOT/default/omarchy/omarchy-menu.jsonc" >/dev/null ||
   fail "the hardware menu still points at omarchy-restart-wifi"
 pass "the hardware menu still points at omarchy-restart-wifi"

--- a/test/shell.d/restart-wifi-test.sh
+++ b/test/shell.d/restart-wifi-test.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/net"
+
+cat >"$tmp_dir/bin/rfkill" <<'EOF'
+#!/bin/bash
+printf 'rfkill %s\n' "$*" >>"$CALLS"
+if [[ $1 == list ]]; then
+  printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n'
+fi
+EOF
+
+cat >"$tmp_dir/bin/nmcli" <<'EOF'
+#!/bin/bash
+printf 'nmcli %s\n' "$*" >>"$CALLS"
+EOF
+
+cat >"$tmp_dir/bin/sudo" <<'EOF'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$CALLS"
+exec "$@"
+EOF
+
+cat >"$tmp_dir/bin/modprobe" <<'EOF'
+#!/bin/bash
+printf 'modprobe %s\n' "$*" >>"$CALLS"
+EOF
+
+cat >"$tmp_dir/bin/lsmod" <<'EOF'
+#!/bin/bash
+cat "$LSMOD_FILE"
+EOF
+
+chmod +x "$tmp_dir/bin"/*
+
+add_iface() {
+  local name=$1
+  local driver=$2
+
+  mkdir -p "$tmp_dir/net/$name/wireless" "$tmp_dir/net/$name/device" "$tmp_dir/drivers/$driver"
+  ln -sfn "$tmp_dir/drivers/$driver" "$tmp_dir/net/$name/device/driver"
+}
+
+run_restart() {
+  : >"$tmp_dir/calls"
+  set +e
+  CALLS="$tmp_dir/calls" LSMOD_FILE="$tmp_dir/lsmod" \
+    OMARCHY_WIFI_NET_ROOT="$tmp_dir/net" \
+    PATH="$tmp_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-restart-wifi" >/dev/null
+  echo $? >"$tmp_dir/rc"
+  set -e
+}
+
+# A wedged AX210 is the case this command used to miss: rfkill was already
+# clear, and only unloading iwlmvm+iwlwifi brought the firmware back.
+printf 'iwlmvm 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+add_iface wlp9s0 iwlwifi
+run_restart
+
+grep -qx 'rfkill unblock wifi' "$tmp_dir/calls" ||
+  fail "wifi still lifts the rfkill block" "$(cat "$tmp_dir/calls")"
+grep -qx 'sudo modprobe -r iwlmvm iwlwifi' "$tmp_dir/calls" ||
+  fail "wifi unloads iwlmvm before iwlwifi" "$(cat "$tmp_dir/calls")"
+grep -qx 'sudo modprobe iwlwifi' "$tmp_dir/calls" ||
+  fail "wifi reloads iwlwifi" "$(cat "$tmp_dir/calls")"
+grep -qx 'nmcli radio wifi on' "$tmp_dir/calls" ||
+  fail "wifi turns the radio back on after the reload" "$(cat "$tmp_dir/calls")"
+pass "wifi reloads a wedged iwlwifi/iwlmvm radio"
+
+[[ $(<"$tmp_dir/rc") == 0 ]] ||
+  fail "wifi reports success when the driver reloads" "$(cat "$tmp_dir/rc")"
+pass "wifi reports success when the driver reloads"
+
+# BE200+ uses iwlmld, not iwlmvm. Same PCI driver name, different helper.
+printf 'iwlmld 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlan0 iwlwifi
+run_restart
+
+grep -qx 'sudo modprobe -r iwlmld iwlwifi' "$tmp_dir/calls" ||
+  fail "wifi unloads iwlmld before iwlwifi" "$(cat "$tmp_dir/calls")"
+pass "wifi reloads a wedged iwlwifi/iwlmld radio"
+
+
+# Older Intel cards use iwldvm.
+printf 'iwldvm 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlan0 iwlwifi
+run_restart
+
+grep -qx 'sudo modprobe -r iwldvm iwlwifi' "$tmp_dir/calls" ||
+  fail "wifi unloads iwldvm before iwlwifi" "$(cat "$tmp_dir/calls")"
+pass "wifi reloads a wedged iwlwifi/iwldvm radio"
+
+
+
+# RTL8852BE (#7003) binds as rtw89_8852be. There is no Intel-style helper.
+printf 'rtw89_8852be 1 0\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp2s0 rtw89_8852be
+run_restart
+
+grep -qx 'sudo modprobe -r rtw89_8852be' "$tmp_dir/calls" ||
+  fail "wifi unloads the Realtek PCI driver" "$(cat "$tmp_dir/calls")"
+grep -qx 'sudo modprobe rtw89_8852be' "$tmp_dir/calls" ||
+  fail "wifi reloads the Realtek PCI driver" "$(cat "$tmp_dir/calls")"
+grep -q iwlwifi "$tmp_dir/calls" &&
+  fail "wifi does not touch iwlwifi on a Realtek radio" "$(cat "$tmp_dir/calls")"
+pass "wifi reloads a wedged rtw89 radio"
+
+# Two virtual interfaces on one phy must not unload the driver twice.
+printf 'iwlmvm 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp9s0 iwlwifi
+add_iface p2p-dev-wlp9s0 iwlwifi
+run_restart
+
+unload_count=$(grep -c 'sudo modprobe -r iwlmvm iwlwifi' "$tmp_dir/calls" || true)
+(( unload_count == 1 )) ||
+  fail "wifi reloads a shared driver once" "$(cat "$tmp_dir/calls")"
+pass "wifi reloads a shared driver once"
+
+# No wireless device: still unblock and turn the radio on.
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+printf '' >"$tmp_dir/lsmod"
+run_restart
+
+grep -q 'modprobe' "$tmp_dir/calls" &&
+  fail "wifi does not reload a driver when none is bound" "$(cat "$tmp_dir/calls")"
+grep -qx 'rfkill unblock wifi' "$tmp_dir/calls" ||
+  fail "wifi still unblocks when no device is present" "$(cat "$tmp_dir/calls")"
+grep -qx 'nmcli radio wifi on' "$tmp_dir/calls" ||
+  fail "wifi still enables the radio when no device is present" "$(cat "$tmp_dir/calls")"
+pass "wifi skips the reload when no radio is bound"
+
+[[ $(<"$tmp_dir/rc") == 0 ]] ||
+  fail "wifi still succeeds when there is no driver to reload" "$(cat "$tmp_dir/rc")"
+
+# A failed unload must not look like success to the watcher.
+cat >"$tmp_dir/bin/modprobe" <<'EOF'
+#!/bin/bash
+printf 'modprobe %s\n' "$*" >>"$CALLS"
+[[ $1 == -r ]] && exit 1
+exit 0
+EOF
+chmod +x "$tmp_dir/bin/modprobe"
+printf 'iwlmvm 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp9s0 iwlwifi
+run_restart
+[[ $(<"$tmp_dir/rc") == 1 ]] ||
+  fail "wifi reports a failed driver unload" "$(cat "$tmp_dir/rc"; cat "$tmp_dir/calls")"
+grep -qx 'sudo modprobe iwlwifi' "$tmp_dir/calls" &&
+  fail "wifi does not reload after a failed unload" "$(cat "$tmp_dir/calls")"
+pass "wifi reports a failed driver unload"
+
+# Unload succeeded, insert failed: retry insert and do not exit 0.
+cat >"$tmp_dir/bin/modprobe" <<'EOF'
+#!/bin/bash
+printf 'modprobe %s\n' "$*" >>"$CALLS"
+[[ $1 == -r ]] && exit 0
+exit 1
+EOF
+chmod +x "$tmp_dir/bin/modprobe"
+printf 'iwlmvm 1 0\niwlwifi 1 1\n' >"$tmp_dir/lsmod"
+rm -rf "$tmp_dir/net" "$tmp_dir/drivers"
+mkdir -p "$tmp_dir/net"
+add_iface wlp9s0 iwlwifi
+run_restart
+[[ $(<"$tmp_dir/rc") == 1 ]] ||
+  fail "wifi reports a failed driver insert" "$(cat "$tmp_dir/rc"; cat "$tmp_dir/calls")"
+(( $(grep -c 'sudo modprobe iwlwifi' "$tmp_dir/calls" || true) >= 2 )) ||
+  fail "wifi retries a failed insert" "$(cat "$tmp_dir/calls")"
+pass "wifi reports a failed driver insert"
+
+rg -F 'omarchy-restart-wifi' "$ROOT/default/omarchy/omarchy-menu.jsonc" >/dev/null ||
+  fail "the hardware menu still points at omarchy-restart-wifi"
+pass "the hardware menu still points at omarchy-restart-wifi"

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -31,6 +31,10 @@ grep -Fx 'systemctl --user daemon-reload' "$first_run_units" >/dev/null
 grep -F 'omarchy-sleep-lock.service' "$first_run_units" >/dev/null
 pass "first-run reloads and enables the sleep lock service"
 
+grep -Fx '  omarchy-wifi-recover.service' "$first_run_units" >/dev/null ||
+  fail "first-run does not enable wifi recover, so a wedged radio stays down until the user toggles it"
+pass "first-run enables wifi recover"
+
 upgrade_to_quattro="$ROOT/bin/omarchy-upgrade-to-quattro"
 grep -F '6870b232a6c0474b59187882e6d25ae771bba735098bcbedef8a2b73b97e2b6a' "$upgrade_to_quattro" >/dev/null
 grep -F 'bcd1a76cb5c63514922bc5e11af22ae480fc6d06a99863364e02bdf3c7bdceaf' "$upgrade_to_quattro" >/dev/null

--- a/test/shell.d/wifi-recover-test.sh
+++ b/test/shell.d/wifi-recover-test.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/net"
+
+cat >"$tmp_dir/bin/nmcli" <<'EOF'
+#!/bin/bash
+if [[ ${NM_HANG:-0} == 1 ]]; then
+  sleep 100
+  exit 0
+fi
+if [[ ${NMCLI_RC:-0} != 0 ]]; then
+  exit "$NMCLI_RC"
+fi
+if [[ $1 == radio && $2 == wifi ]]; then
+  printf '%s\n' "${RADIO:-enabled}"
+  exit 0
+fi
+if [[ $1 == -t && $2 == -f && $3 == DEVICE,TYPE,STATE ]]; then
+  printf '%s\n' "${NM_STATUS:-}"
+  exit 0
+fi
+exit 0
+EOF
+
+cat >"$tmp_dir/bin/rfkill" <<'EOF'
+#!/bin/bash
+if [[ ${RFKILL_BLOCKED:-0} == 1 ]]; then
+  printf '0: phy0: Wireless LAN\n\tSoft blocked: yes\n\tHard blocked: no\n'
+  exit 0
+fi
+printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n'
+EOF
+
+cat >"$tmp_dir/bin/iw" <<'EOF'
+#!/bin/bash
+if [[ ${IW_CONNECTED:-0} == 1 ]]; then
+  printf 'Connected to aa:bb:cc:dd:ee:ff (on wlp9s0)\n'
+  exit 0
+fi
+printf 'Not connected.\n'
+EOF
+
+cat >"$tmp_dir/bin/sudo" <<'EOF'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$CALLS"
+if [[ $1 == -n && $2 == -l ]]; then
+  if [[ ${GRANT_FAIL:-0} == 1 ]]; then
+    exit 1
+  fi
+  printf '!authenticate\n'
+  exit 0
+fi
+if [[ ${RESTART_FAIL:-0} == 1 ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$tmp_dir/bin/omarchy-notification-send" <<'EOF'
+#!/bin/bash
+printf 'notify %s\n' "$*" >>"$CALLS"
+EOF
+
+chmod +x "$tmp_dir/bin"/*
+
+add_phy() {
+  mkdir -p "$tmp_dir/net/wlp9s0/wireless"
+}
+
+run_with_env() {
+  RADIO="${RADIO:-enabled}" RFKILL_BLOCKED="${RFKILL_BLOCKED:-0}" \
+    IW_CONNECTED="${IW_CONNECTED:-0}" NM_STATUS="${NM_STATUS:-}" \
+    NMCLI_RC="${NMCLI_RC:-0}" NM_HANG="${NM_HANG:-0}" \
+    GRANT_FAIL="${GRANT_FAIL:-0}" RESTART_FAIL="${RESTART_FAIL:-0}" \
+    OMARCHY_WIFI_NET_ROOT="$tmp_dir/net" \
+    OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="${OMARCHY_WIFI_RECOVER_PACKAGED_UNIT:-$tmp_dir/no-packaged-unit}" \
+    OMARCHY_WIFI_RECOVER_NM_TIMEOUT="${OMARCHY_WIFI_RECOVER_NM_TIMEOUT:-10}" \
+    PATH="$tmp_dir/bin:$PATH" \
+    "$@"
+}
+
+run_check() {
+  run_with_env "$ROOT/bin/omarchy-wifi-recover" --check
+}
+
+run_once() {
+  : >"$tmp_dir/calls"
+  CALLS="$tmp_dir/calls" run_with_env \
+    env OMARCHY_WIFI_RECOVER_ONCE=1 OMARCHY_WIFI_RECOVER_COOLDOWN=0 \
+    "$ROOT/bin/omarchy-wifi-recover" >/dev/null
+}
+
+run_loop() {
+  local max=$1
+  : >"$tmp_dir/calls"
+  : >"$tmp_dir/err"
+  CALLS="$tmp_dir/calls" run_with_env \
+    env OMARCHY_WIFI_RECOVER_POLL=0 OMARCHY_WIFI_RECOVER_CONFIRM=2 \
+    OMARCHY_WIFI_RECOVER_COOLDOWN=0 OMARCHY_WIFI_RECOVER_MAX_POLLS=$max \
+    "$ROOT/bin/omarchy-wifi-recover" >/dev/null 2>"$tmp_dir/err"
+}
+
+restart_count() {
+  grep -c '^sudo -n /usr/bin/omarchy-restart-wifi$' "$tmp_dir/calls"
+}
+
+add_phy
+
+# The mid-session AX210 hang: NM still says connected, the kernel link is gone.
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0
+if ! run_check >/dev/null; then
+  fail "wifi recover treats a connected device with no kernel link as wedged"
+fi
+pass "wifi recover treats a connected device with no kernel link as wedged"
+
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=1
+if run_check >/dev/null; then
+  fail "wifi recover leaves a healthy association alone"
+fi
+pass "wifi recover leaves a healthy association alone"
+
+# User turned the radio off, or rfkill is on. Do not fight them.
+NM_STATUS=$'wlp9s0:wifi:unavailable\n' RADIO=disabled
+if run_check >/dev/null; then
+  fail "wifi recover leaves a user-disabled radio alone"
+fi
+pass "wifi recover leaves a user-disabled radio alone"
+
+NM_STATUS=$'wlp9s0:wifi:unavailable\n' RADIO=enabled RFKILL_BLOCKED=1
+if run_check >/dev/null; then
+  fail "wifi recover leaves an rfkill-blocked radio alone"
+fi
+pass "wifi recover leaves an rfkill-blocked radio alone"
+
+# Sitting disconnected on purpose is not a wedge.
+NM_STATUS=$'wlp9s0:wifi:disconnected\n' RADIO=enabled RFKILL_BLOCKED=0 IW_CONNECTED=0
+if run_check >/dev/null; then
+  fail "wifi recover leaves a user-disconnected radio alone"
+fi
+pass "wifi recover leaves a user-disconnected radio alone"
+
+# After a failed radio toggle: NM says unavailable, phy is still there, radio on.
+NM_STATUS=$'wlp9s0:wifi:unavailable\n'
+if ! run_check >/dev/null; then
+  fail "wifi recover treats an unavailable phy with the radio on as wedged"
+fi
+pass "wifi recover treats an unavailable phy with the radio on as wedged"
+
+# NM crash-looping is not a firmware wedge.
+NMCLI_RC=8 NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0
+if run_check >/dev/null; then
+  fail "wifi recover leaves a down NetworkManager alone"
+fi
+pass "wifi recover leaves a down NetworkManager alone"
+NMCLI_RC=0
+
+# NM listed no wifi device but the phy is still in sysfs.
+add_phy
+NM_STATUS=""
+if ! run_check >/dev/null; then
+  fail "wifi recover treats a phy NM cannot see as wedged"
+fi
+pass "wifi recover treats a phy NM cannot see as wedged"
+
+NM_STATUS=$'wlp9s0:wifi:connecting\n' IW_CONNECTED=0
+if run_check >/dev/null; then
+  fail "wifi recover leaves a connecting radio alone"
+fi
+pass "wifi recover leaves a connecting radio alone"
+
+NM_HANG=1 OMARCHY_WIFI_RECOVER_NM_TIMEOUT=1
+if ! run_check >/dev/null; then
+  fail "wifi recover treats a hung nmcli as wedged"
+fi
+pass "wifi recover treats a hung nmcli as wedged"
+NM_HANG=0
+unset OMARCHY_WIFI_RECOVER_NM_TIMEOUT
+
+# No wireless hardware at all.
+rm -rf "$tmp_dir/net"
+mkdir -p "$tmp_dir/net"
+NM_STATUS=""
+if run_check >/dev/null; then
+  fail "wifi recover does nothing on a machine with no radio"
+fi
+pass "wifi recover does nothing on a machine with no radio"
+
+add_phy
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0
+run_once
+grep -qx 'sudo -n /usr/bin/omarchy-restart-wifi' "$tmp_dir/calls" ||
+  fail "wifi recover reloads through the packaged restart command" "$(cat "$tmp_dir/calls")"
+grep -q 'notify ' "$tmp_dir/calls" ||
+  fail "wifi recover tells the user it reloaded the radio" "$(cat "$tmp_dir/calls")"
+pass "wifi recover reloads through the packaged restart command"
+
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=1
+run_once
+grep -q 'sudo' "$tmp_dir/calls" &&
+  fail "wifi recover does not reload a healthy radio" "$(cat "$tmp_dir/calls")"
+pass "wifi recover does not reload a healthy radio"
+
+# A single connected-without-link poll is a roam or a radio-on race.
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0
+run_loop 1
+grep -q 'sudo' "$tmp_dir/calls" &&
+  fail "wifi recover does not reload on a single missed link poll" "$(cat "$tmp_dir/calls")"
+pass "wifi recover does not reload on a single missed link poll"
+
+run_loop 2
+grep -qx 'sudo -n /usr/bin/omarchy-restart-wifi' "$tmp_dir/calls" ||
+  fail "wifi recover reloads after two missed link polls" "$(cat "$tmp_dir/calls")"
+pass "wifi recover reloads after two missed link polls"
+
+# A permanently dead phy must not toast every cooldown.
+run_loop 4
+(( $(grep -c '^notify ' "$tmp_dir/calls") == 1 )) ||
+  fail "wifi recover toasts once per wedge episode" "$(cat "$tmp_dir/calls")"
+(( $(restart_count) == 3 )) ||
+  fail "wifi recover still retries the reload after the first toast" "$(cat "$tmp_dir/calls")"
+pass "wifi recover toasts once per wedge episode"
+
+# Missing grant: warn once, never toast, never run the restart command.
+GRANT_FAIL=1 NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 run_loop 4
+(( $(grep -c 'sudo -n -l -l' "$tmp_dir/calls") == 3 )) ||
+  fail "wifi recover rechecks the grant while it is missing" "$(cat "$tmp_dir/calls")"
+(( $(restart_count) == 0 )) ||
+  fail "wifi recover does not run restart-wifi without a grant" "$(cat "$tmp_dir/calls")"
+grep -q 'notify ' "$tmp_dir/calls" &&
+  fail "wifi recover does not toast a missing grant" "$(cat "$tmp_dir/calls")"
+(( $(grep -c 'passwordless sudo' "$tmp_dir/err") == 1 )) ||
+  fail "wifi recover warns once when the grant is missing" "$(cat "$tmp_dir/err")"
+pass "wifi recover does not toast when sudo is denied"
+GRANT_FAIL=0
+
+# Reload ran but failed: cooldown, no success toast.
+RESTART_FAIL=1 NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 run_loop 4
+(( $(restart_count) == 3 )) ||
+  fail "wifi recover retries a failed reload" "$(cat "$tmp_dir/calls")"
+grep -q 'notify ' "$tmp_dir/calls" &&
+  fail "wifi recover does not toast a failed reload" "$(cat "$tmp_dir/calls")"
+grep -q 'omarchy-restart-wifi failed' "$tmp_dir/err" ||
+  fail "wifi recover reports a failed reload" "$(cat "$tmp_dir/err")"
+pass "wifi recover does not toast a failed reload"
+RESTART_FAIL=0
+# Staged ~/.config unit must not shadow a later packaged copy.
+# Unstage runs only in the daemon path, not --check/ONCE.
+mkdir -p "$tmp_dir/home/.config/systemd/user/graphical-session.target.wants" "$tmp_dir/lib"
+touch "$tmp_dir/lib/omarchy-wifi-recover.service" \
+  "$tmp_dir/home/.config/systemd/user/omarchy-wifi-recover.service"
+ln -sfn ../omarchy-wifi-recover.service \
+  "$tmp_dir/home/.config/systemd/user/graphical-session.target.wants/omarchy-wifi-recover.service"
+HOME="$tmp_dir/home" XDG_CONFIG_HOME="$tmp_dir/home/.config" \
+  OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/lib/omarchy-wifi-recover.service" \
+  OMARCHY_WIFI_NET_ROOT="$tmp_dir/net" RADIO=disabled \
+  OMARCHY_WIFI_RECOVER_POLL=0 OMARCHY_WIFI_RECOVER_MAX_POLLS=1 \
+  PATH="$tmp_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-wifi-recover" >/dev/null || true
+[[ ! -e $tmp_dir/home/.config/systemd/user/omarchy-wifi-recover.service ]] ||
+  fail "wifi recover removes a staged unit once the packaged one exists"
+[[ $(readlink "$tmp_dir/home/.config/systemd/user/graphical-session.target.wants/omarchy-wifi-recover.service") == "$tmp_dir/lib/omarchy-wifi-recover.service" ]] ||
+  fail "wifi recover re-points the wants symlink at the packaged unit"
+pass "wifi recover removes a staged unit once the packaged one exists"
+
+# A user-edited staged unit must not be deleted.
+mkdir -p "$tmp_dir/custom/.config/systemd/user" "$tmp_dir/lib"
+printf 'packaged\n' >"$tmp_dir/lib/omarchy-wifi-recover.service"
+printf 'customized\n' >"$tmp_dir/custom/.config/systemd/user/omarchy-wifi-recover.service"
+HOME="$tmp_dir/custom" XDG_CONFIG_HOME="$tmp_dir/custom/.config" \
+  OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/lib/omarchy-wifi-recover.service" \
+  OMARCHY_WIFI_NET_ROOT="$tmp_dir/net" RADIO=disabled \
+  OMARCHY_WIFI_RECOVER_POLL=0 OMARCHY_WIFI_RECOVER_MAX_POLLS=1 \
+  PATH="$tmp_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-wifi-recover" >/dev/null || true
+[[ $(<"$tmp_dir/custom/.config/systemd/user/omarchy-wifi-recover.service") == customized ]] ||
+  fail "wifi recover leaves a customized staged unit alone"
+pass "wifi recover leaves a customized staged unit alone"
+
+
+grep -F 'timeout "$IW_TIMEOUT" iw' "$ROOT/bin/omarchy-wifi-recover" >/dev/null ||
+  fail "wifi recover does not bound iw probes"
+grep -F 'timeout "$NM_TIMEOUT" nmcli' "$ROOT/bin/omarchy-wifi-recover" >/dev/null ||
+  fail "wifi recover does not bound nmcli probes"
+pass "wifi recover bounds iw and nmcli probes"
+
+grep -F 'rm -f "$staged"' "$ROOT/install/user/first-run/enable-user-units.sh" >/dev/null ||
+  fail "first-run does not unstage a packaged wifi recover unit"
+grep -F 'rm -f "$config_home/systemd/user/omarchy-wifi-recover.service"' \
+  "$ROOT/migrations/1787444800.sh" >/dev/null ||
+  fail "migration does not unstage a packaged wifi recover unit"
+grep -F 'sudo install -Dm440' "$ROOT/migrations/1787444800.sh" >/dev/null ||
+  fail "migration does not install the sudoers grant"
+pass "first-run and migration unstage a packaged wifi recover unit"
+
+sudoers="$ROOT/etc/sudoers.d/omarchy-restart-wifi"
+rule='%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-restart-wifi ""'
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers")
+[[ $rules == "$rule" ]] ||
+  fail "wifi sudoers file grants only omarchy-restart-wifi with no args" "got: $rules"
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers" >/dev/null || fail "wifi sudoers rule parses"
+fi
+pass "wifi sudoers rule is scoped to omarchy-restart-wifi"
+
+service="$ROOT/default/systemd/user/omarchy-wifi-recover.service"
+grep -Fx 'ExecStart=/usr/bin/omarchy-wifi-recover' "$service" >/dev/null ||
+  fail "wifi recover unit starts the packaged watcher"
+grep -Fx 'WantedBy=graphical-session.target' "$service" >/dev/null ||
+  fail "wifi recover unit is pulled in at login"
+grep -Fx 'ConditionPathExists=/sys/class/ieee80211' "$service" >/dev/null ||
+  fail "wifi recover unit stays off machines with no phy"
+grep -Fx 'ConditionPathExists=/usr/bin/omarchy-wifi-recover' "$service" >/dev/null ||
+  fail "wifi recover unit stays off until the packaged binary exists"
+pass "wifi recover unit starts with the graphical session"
+
+migration=$(grep -rl 'omarchy-wifi-recover.service' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "existing installs never enable wifi recover"
+grep -F 'systemctl --user enable omarchy-wifi-recover.service' "$migration" >/dev/null ||
+  fail "wifi recover migration enables the unit"
+pass "existing installs enable wifi recover"
+
+mode=$(stat -c '%a' "$ROOT/migrations/1787444800.sh")
+[[ $mode == 644 ]] || fail "wifi recover migration must be mode 644" "$mode"
+pass "wifi recover migration is mode 644"

--- a/test/shell.d/wifi-recover-test.sh
+++ b/test/shell.d/wifi-recover-test.sh
@@ -403,12 +403,103 @@ pass "wifi recover bounds iw and nmcli probes"
 
 grep -F 'rm -f "$staged"' "$ROOT/install/user/first-run/enable-user-units.sh" >/dev/null ||
   fail "first-run does not unstage a packaged wifi recover unit"
-grep -F 'rm -f "$config_home/systemd/user/omarchy-wifi-recover.service"' \
-  "$ROOT/migrations/1787444800.sh" >/dev/null ||
-  fail "migration does not unstage a packaged wifi recover unit"
 grep -F 'sudo install -Dm440' "$ROOT/migrations/1787444800.sh" >/dev/null ||
-  fail "first-run and migration unstage a packaged wifi recover unit"
-pass "first-run and migration unstage a packaged wifi recover unit"
+  fail "migration does not install the sudoers grant"
+pass "first-run unstages a packaged wifi recover unit"
+
+# The migration runs on every existing install and had no test at all, which
+# is how it came to disagree with the two other paths that stage this unit.
+# Run it rather than grepping it. `visudo` and `systemctl` are absent or
+# unusable in a test environment, and the runner supplies OMARCHY_PATH.
+cat >"$tmp_dir/bin/visudo" <<'EOF'
+#!/bin/bash
+exit "${VISUDO_RC:-0}"
+EOF
+cat >"$tmp_dir/bin/systemctl" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$tmp_dir/bin/visudo" "$tmp_dir/bin/systemctl"
+
+mig_home="$tmp_dir/mig"
+run_migration() {
+  : >"$tmp_dir/calls"
+  rm -rf "$mig_home"
+  mkdir -p "$mig_home/.config/systemd/user"
+  "$@"
+  set +e
+  CALLS="$tmp_dir/calls" HOME="$mig_home" XDG_CONFIG_HOME="$mig_home/.config" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_WIFI_SUDOERS_DEST="$tmp_dir/sudoers-dest" \
+    OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/mig-packaged.service" \
+    RESTART_FAIL="${MIG_SUDO_FAIL:-0}" VISUDO_RC="${MIG_VISUDO_RC:-0}" \
+    PATH="$tmp_dir/bin:$PATH" \
+    bash -euo pipefail "$ROOT/migrations/1787444800.sh" >"$tmp_dir/mig.out" 2>&1
+  echo $? >"$tmp_dir/mig.rc"
+  set -e
+}
+
+mig_staged="$mig_home/.config/systemd/user/omarchy-wifi-recover.service"
+unit_src="$ROOT/default/systemd/user/omarchy-wifi-recover.service"
+rm -f "$tmp_dir/sudoers-dest" "$tmp_dir/mig-packaged.service"
+
+# A user who cancels the sudo prompt, or is not in %wheel, must not lose every
+# migration queued behind this one.
+MIG_SUDO_FAIL=1 run_migration true
+[[ $(<"$tmp_dir/mig.rc") == 0 ]] ||
+  fail "migration survives a refused sudo" "$(cat "$tmp_dir/mig.out")"
+grep -q 'Could not install' "$tmp_dir/mig.out" ||
+  fail "migration says the grant was not installed" "$(cat "$tmp_dir/mig.out")"
+pass "migration survives a refused sudo"
+
+MIG_VISUDO_RC=1 run_migration true
+[[ $(<"$tmp_dir/mig.rc") == 0 ]] ||
+  fail "migration survives an unparsable sudoers file" "$(cat "$tmp_dir/mig.out")"
+grep -q 'does not parse' "$tmp_dir/mig.out" ||
+  fail "migration says the sudoers file did not parse" "$(cat "$tmp_dir/mig.out")"
+pass "migration reports an unparsable sudoers file"
+MIG_VISUDO_RC=0
+
+# Packaged unit present and the staged copy is stock: clean it up.
+run_migration cp "$unit_src" "$tmp_dir/mig-packaged.service"
+install -Dm644 "$unit_src" "$mig_staged"
+CALLS="$tmp_dir/calls" HOME="$mig_home" XDG_CONFIG_HOME="$mig_home/.config" \
+  OMARCHY_PATH="$ROOT" OMARCHY_WIFI_SUDOERS_DEST="$tmp_dir/sudoers-dest" \
+  OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/mig-packaged.service" \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash -euo pipefail "$ROOT/migrations/1787444800.sh" >/dev/null 2>&1
+[[ ! -e $mig_staged ]] ||
+  fail "migration removes a stock staged unit once the packaged one exists"
+pass "migration removes a stock staged unit once the packaged one exists"
+
+# The same, with the user's own edits in it. The watcher and first-run both
+# leave that alone; the migration used to delete it.
+printf 'customized\n' >"$mig_staged"
+CALLS="$tmp_dir/calls" HOME="$mig_home" XDG_CONFIG_HOME="$mig_home/.config" \
+  OMARCHY_PATH="$ROOT" OMARCHY_WIFI_SUDOERS_DEST="$tmp_dir/sudoers-dest" \
+  OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/mig-packaged.service" \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash -euo pipefail "$ROOT/migrations/1787444800.sh" >/dev/null 2>&1
+[[ $(<"$mig_staged") == customized ]] ||
+  fail "migration leaves a customized staged unit alone"
+pass "migration leaves a customized staged unit alone"
+
+# No packaged unit yet: stage ours, but never over the user's.
+rm -f "$tmp_dir/mig-packaged.service"
+run_migration true
+cmp -s "$mig_staged" "$unit_src" ||
+  fail "migration stages the unit when no packaged copy exists"
+pass "migration stages the unit when no packaged copy exists"
+
+printf 'customized\n' >"$mig_staged"
+CALLS="$tmp_dir/calls" HOME="$mig_home" XDG_CONFIG_HOME="$mig_home/.config" \
+  OMARCHY_PATH="$ROOT" OMARCHY_WIFI_SUDOERS_DEST="$tmp_dir/sudoers-dest" \
+  OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/mig-packaged.service" \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash -euo pipefail "$ROOT/migrations/1787444800.sh" >/dev/null 2>&1
+[[ $(<"$mig_staged") == customized ]] ||
+  fail "migration does not restage over a customized unit"
+pass "migration does not restage over a customized unit"
 
 sudoers="$ROOT/etc/sudoers.d/omarchy-restart-wifi"
 rule='%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-restart-wifi ""'

--- a/test/shell.d/wifi-recover-test.sh
+++ b/test/shell.d/wifi-recover-test.sh
@@ -38,10 +38,30 @@ fi
 printf '0: phy0: Wireless LAN\n\tSoft blocked: no\n\tHard blocked: no\n'
 EOF
 
+# Real iw: `info` reports the nl80211 interface type, `link` reports only a
+# station association -- an AP prints "Not connected." and an ad-hoc cell
+# prints "Joined IBSS", neither of which is a dead radio.
 cat >"$tmp_dir/bin/iw" <<'EOF'
 #!/bin/bash
+if [[ ${IW_FAIL:-0} == 1 ]]; then
+  exit 1
+fi
+if [[ $3 == info ]]; then
+  printf 'Interface %s\n\tifindex 3\n\twdev 0x1\n\ttype %s\n\twiphy 0\n' "$2" "${IW_TYPE:-managed}"
+  exit 0
+fi
+case ${IW_TYPE:-managed} in
+  AP | mesh)
+    printf 'Not connected.\n'
+    exit 0
+    ;;
+  IBSS)
+    printf 'Joined IBSS aa:bb:cc:dd:ee:ff (on %s)\n' "$2"
+    exit 0
+    ;;
+esac
 if [[ ${IW_CONNECTED:-0} == 1 ]]; then
-  printf 'Connected to aa:bb:cc:dd:ee:ff (on wlp9s0)\n'
+  printf 'Connected to aa:bb:cc:dd:ee:ff (on %s)\n' "$2"
   exit 0
 fi
 printf 'Not connected.\n'
@@ -71,7 +91,11 @@ EOF
 chmod +x "$tmp_dir/bin"/*
 
 add_phy() {
-  mkdir -p "$tmp_dir/net/wlp9s0/wireless"
+  local dev=${1:-wlp9s0} blocked=${2:-0}
+
+  mkdir -p "$tmp_dir/net/$dev/wireless" "$tmp_dir/net/$dev/phy80211/rfkill0"
+  printf '%s\n' "$blocked" >"$tmp_dir/net/$dev/phy80211/rfkill0/soft"
+  printf '0\n' >"$tmp_dir/net/$dev/phy80211/rfkill0/hard"
 }
 
 run_with_env() {
@@ -79,6 +103,7 @@ run_with_env() {
     IW_CONNECTED="${IW_CONNECTED:-0}" NM_STATUS="${NM_STATUS:-}" \
     NMCLI_RC="${NMCLI_RC:-0}" NM_HANG="${NM_HANG:-0}" \
     GRANT_FAIL="${GRANT_FAIL:-0}" RESTART_FAIL="${RESTART_FAIL:-0}" \
+    IW_TYPE="${IW_TYPE:-managed}" IW_FAIL="${IW_FAIL:-0}" \
     OMARCHY_WIFI_NET_ROOT="$tmp_dir/net" \
     OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="${OMARCHY_WIFI_RECOVER_PACKAGED_UNIT:-$tmp_dir/no-packaged-unit}" \
     OMARCHY_WIFI_RECOVER_NM_TIMEOUT="${OMARCHY_WIFI_RECOVER_NM_TIMEOUT:-10}" \
@@ -104,6 +129,7 @@ run_loop() {
   CALLS="$tmp_dir/calls" run_with_env \
     env OMARCHY_WIFI_RECOVER_POLL=0 OMARCHY_WIFI_RECOVER_CONFIRM=2 \
     OMARCHY_WIFI_RECOVER_COOLDOWN=0 OMARCHY_WIFI_RECOVER_MAX_POLLS=$max \
+    OMARCHY_WIFI_RECOVER_MAX_RELOADS="${MAX_RELOADS:-0}" \
     "$ROOT/bin/omarchy-wifi-recover" >/dev/null 2>"$tmp_dir/err"
 }
 
@@ -133,11 +159,23 @@ if run_check >/dev/null; then
 fi
 pass "wifi recover leaves a user-disabled radio alone"
 
-NM_STATUS=$'wlp9s0:wifi:unavailable\n' RADIO=enabled RFKILL_BLOCKED=1
+rm -rf "$tmp_dir/net"; mkdir -p "$tmp_dir/net"; add_phy wlp9s0 1
+NM_STATUS=$'wlp9s0:wifi:connected\n' RADIO=enabled IW_CONNECTED=0
 if run_check >/dev/null; then
   fail "wifi recover leaves an rfkill-blocked radio alone"
 fi
 pass "wifi recover leaves an rfkill-blocked radio alone"
+
+# A dongle the user blocked must not hold the wedged adapter beside it down.
+rm -rf "$tmp_dir/net"; mkdir -p "$tmp_dir/net"
+add_phy wlp9s0 0
+add_phy wlx1 1
+NM_STATUS=$'wlp9s0:wifi:connected\nwlx1:wifi:unavailable\n' IW_CONNECTED=0
+if ! run_check >/dev/null; then
+  fail "wifi recover still recovers a wedged radio beside a blocked one"
+fi
+pass "wifi recover still recovers a wedged radio beside a blocked one"
+rm -rf "$tmp_dir/net"; mkdir -p "$tmp_dir/net"; add_phy
 
 # Sitting disconnected on purpose is not a wedge.
 NM_STATUS=$'wlp9s0:wifi:disconnected\n' RADIO=enabled RFKILL_BLOCKED=0 IW_CONNECTED=0
@@ -146,12 +184,14 @@ if run_check >/dev/null; then
 fi
 pass "wifi recover leaves a user-disconnected radio alone"
 
-# After a failed radio toggle: NM says unavailable, phy is still there, radio on.
-NM_STATUS=$'wlp9s0:wifi:unavailable\n'
+# After a failed radio toggle: NM says unavailable, the phy is still listed
+# in sysfs but the kernel no longer answers for it, radio on.
+NM_STATUS=$'wlp9s0:wifi:unavailable\n' IW_FAIL=1
 if ! run_check >/dev/null; then
   fail "wifi recover treats an unavailable phy with the radio on as wedged"
 fi
 pass "wifi recover treats an unavailable phy with the radio on as wedged"
+IW_FAIL=0
 
 # NM crash-looping is not a firmware wedge.
 NMCLI_RC=8 NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0
@@ -174,6 +214,44 @@ if run_check >/dev/null; then
   fail "wifi recover leaves a connecting radio alone"
 fi
 pass "wifi recover leaves a connecting radio alone"
+
+# A hotspot is "connected" to NetworkManager with no station association.
+# Unloading the driver under one drops every client on it.
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 IW_TYPE=AP
+if run_check >/dev/null; then
+  fail "wifi recover leaves a hosted access point alone"
+fi
+pass "wifi recover leaves a hosted access point alone"
+
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 IW_TYPE=IBSS
+if run_check >/dev/null; then
+  fail "wifi recover leaves an ad-hoc cell alone"
+fi
+pass "wifi recover leaves an ad-hoc cell alone"
+
+NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 IW_TYPE=mesh
+if run_check >/dev/null; then
+  fail "wifi recover leaves a mesh point alone"
+fi
+pass "wifi recover leaves a mesh point alone"
+IW_TYPE=managed
+
+# #7323: the quattro upgrade left wifi.backend=iwd with no iwd, so NM parks
+# every device at unavailable while the driver is loaded and answering.
+# Reloading it changes nothing, so the watcher must not.
+NM_STATUS=$'wlp9s0:wifi:unavailable\n' IW_FAIL=0
+if run_check >/dev/null; then
+  fail "wifi recover leaves an unavailable device whose driver still answers alone"
+fi
+pass "wifi recover leaves an unavailable device whose driver still answers alone"
+
+# The same NM state with a phy the kernel can no longer talk to is the wedge.
+NM_STATUS=$'wlp9s0:wifi:unavailable\n' IW_FAIL=1
+if ! run_check >/dev/null; then
+  fail "wifi recover treats an unavailable device the kernel cannot reach as wedged"
+fi
+pass "wifi recover treats an unavailable device the kernel cannot reach as wedged"
+IW_FAIL=0
 
 NM_HANG=1 OMARCHY_WIFI_RECOVER_NM_TIMEOUT=1
 if ! run_check >/dev/null; then
@@ -227,6 +305,19 @@ run_loop 4
   fail "wifi recover still retries the reload after the first toast" "$(cat "$tmp_dir/calls")"
 pass "wifi recover toasts once per wedge episode"
 
+# A phy that will not come back must not be unloaded every two minutes for
+# the rest of the session. Stop after the cap, and say so once -- the old
+# behaviour was silent after the first toast.
+MAX_RELOADS=2 NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 run_loop 6
+(( $(restart_count) == 2 )) ||
+  fail "wifi recover stops reloading after the cap" "$(cat "$tmp_dir/calls")"
+(( $(grep -c 'notify .*did not come back' "$tmp_dir/calls") == 1 )) ||
+  fail "wifi recover says once that it gave up" "$(cat "$tmp_dir/calls")"
+grep -q 'gave up after 2 reloads' "$tmp_dir/err" ||
+  fail "wifi recover logs that it gave up" "$(cat "$tmp_dir/err")"
+pass "wifi recover stops reloading after the cap"
+MAX_RELOADS=0
+
 # Missing grant: warn once, never toast, never run the restart command.
 GRANT_FAIL=1 NM_STATUS=$'wlp9s0:wifi:connected\n' IW_CONNECTED=0 run_loop 4
 (( $(grep -c 'sudo -n -l -l' "$tmp_dir/calls") == 3 )) ||
@@ -269,6 +360,26 @@ HOME="$tmp_dir/home" XDG_CONFIG_HOME="$tmp_dir/home/.config" \
   fail "wifi recover re-points the wants symlink at the packaged unit"
 pass "wifi recover removes a staged unit once the packaged one exists"
 
+# Once the packaged unit is revised upstream, a stock staged copy no longer
+# matches it. Matching the tree it was staged from is what stops it shadowing
+# /usr/lib for good.
+mkdir -p "$tmp_dir/revised/.config/systemd/user/graphical-session.target.wants" "$tmp_dir/lib2"
+printf 'revised packaged unit\n' >"$tmp_dir/lib2/omarchy-wifi-recover.service"
+install -Dm644 "$ROOT/default/systemd/user/omarchy-wifi-recover.service" \
+  "$tmp_dir/revised/.config/systemd/user/omarchy-wifi-recover.service"
+ln -sfn ../omarchy-wifi-recover.service \
+  "$tmp_dir/revised/.config/systemd/user/graphical-session.target.wants/omarchy-wifi-recover.service"
+HOME="$tmp_dir/revised" XDG_CONFIG_HOME="$tmp_dir/revised/.config" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_WIFI_RECOVER_PACKAGED_UNIT="$tmp_dir/lib2/omarchy-wifi-recover.service" \
+  OMARCHY_WIFI_NET_ROOT="$tmp_dir/net" RADIO=disabled \
+  OMARCHY_WIFI_RECOVER_POLL=0 OMARCHY_WIFI_RECOVER_MAX_POLLS=1 \
+  PATH="$tmp_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-wifi-recover" >/dev/null || true
+[[ ! -e $tmp_dir/revised/.config/systemd/user/omarchy-wifi-recover.service ]] ||
+  fail "wifi recover unstages a stock copy after the packaged unit is revised"
+pass "wifi recover unstages a stock copy after the packaged unit is revised"
+
 # A user-edited staged unit must not be deleted.
 mkdir -p "$tmp_dir/custom/.config/systemd/user" "$tmp_dir/lib"
 printf 'packaged\n' >"$tmp_dir/lib/omarchy-wifi-recover.service"
@@ -296,7 +407,7 @@ grep -F 'rm -f "$config_home/systemd/user/omarchy-wifi-recover.service"' \
   "$ROOT/migrations/1787444800.sh" >/dev/null ||
   fail "migration does not unstage a packaged wifi recover unit"
 grep -F 'sudo install -Dm440' "$ROOT/migrations/1787444800.sh" >/dev/null ||
-  fail "migration does not install the sudoers grant"
+  fail "first-run and migration unstage a packaged wifi recover unit"
 pass "first-run and migration unstage a packaged wifi recover unit"
 
 sudoers="$ROOT/etc/sudoers.d/omarchy-restart-wifi"


### PR DESCRIPTION
## What

`Update > Hardware > Wi-Fi` (`omarchy-restart-wifi`) only unblocked rfkill and flipped the NetworkManager radio. That cannot recover a wedged phy.

The command now unloads the PCI driver bound to each wireless interface (and `iwlmld` / `iwlmvm` / `iwldvm` / `iwlmei` when the driver is `iwlwifi`) and reloads it. `modprobe` takes `--` so a driver name read out of sysfs can never arrive as an option. A failed insert waits a second and is retried once; if the driver stays unloaded the command prints the exact `modprobe` line and exits 1. The `nmcli` radio toggle runs regardless of per-driver failures, so on a two-radio machine one busy module does not leave the adapter that did reload dark. NetworkManager refusing the radio is a failure too; the exit status used to reflect only `modprobe`, so a run where the radio never came back exited 0. Run as root, the command takes an flock so two logged-in sessions cannot reload at once, and ignores `OMARCHY_WIFI_NET_ROOT` (a test-only override) on the one path that carries a NOPASSWD grant.

A session watcher (`omarchy-wifi-recover`) does that automatically. NetworkManager can keep a wifi device "connected" after firmware dies. The watcher polls (C locale, bounded `nmcli`/`iw`) and treats a device as wedged when:

- NM says `connected`, the interface is an nl80211 station, and the kernel reports no link
- NM says `unavailable`, the radio is on, and the kernel has stopped answering for the phy
- a phy in sysfs is one NM does not list

Only stations are asked for a link: an access point prints `Not connected.` and an ad-hoc cell prints `Joined IBSS`, so a hosted hotspot (#7435) or mesh is never read as a dead radio. `unavailable` alone is not enough, because NM parks a device there just as readily when the wifi backend is misconfigured (#7323) while the driver is loaded and answering; reloading it would fix nothing. rfkill is read per device from sysfs, so a dongle the user blocked on purpose does not suppress recovery for the wedged adapter beside it.

Two consecutive polls (~30s) are required before reload, so a roam or radio-on race does not yank the module. Reload goes through `sudo -n /usr/bin/omarchy-restart-wifi` (empty-argv `%wheel` sudoers grant, 60s timeout). Failed reloads cool down for 120s and do not toast. One "Wi-Fi radio reloaded" toast per wedge episode. After three reloads in one episode the watcher stops trying and says so once at critical urgency, instead of dropping Wi-Fi every two minutes for the rest of the session with nothing on screen.

The user unit is gated on `/sys/class/ieee80211` and `/usr/bin/omarchy-wifi-recover`. Until `omarchy-settings` ships it to `/usr/lib/systemd/user`, first-run and the migration stage it under `${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user`. When the packaged unit appears, a staged copy matching either shipped version is removed and the wants symlink is re-pointed; a user-edited copy is left alone by all three paths (watcher, first-run, migration), and first-run rerun with `--force` never writes over one.

The migration also installs `/etc/sudoers.d/omarchy-restart-wifi` during package skew. Migrations run under `bash -euo pipefail`, so a cancelled password prompt or a user outside `%wheel` reports what it could not do and carries on rather than aborting every migration queued behind it. A sudoers file that fails `visudo -cf` is reported instead of silently skipped. There is no permanent `--overwrite` for that path; the one-time conflict when `omarchy-settings` starts owning the file is handled by `omarchy-update-system-pkgs-when-conflicted`, which confirms the file is unowned, moves it aside, and restores it if the retry fails.

## Packaging

`omarchy-settings` installs user units by explicit name, so the unit needs a companion change to ship: omacom/omarchy-pkgs#399 adds a guarded install of `omarchy-wifi-recover.service` to both `omarchy-settings` and `omarchy-settings-dev`. The guard means the two PRs can merge in either order. The sudoers drop-in needs nothing there; `cp -a etc/.` already picks it up.

## Why

Intel AX210 (`iwlwifi`/`iwlmvm`, firmware `89.f7dcb3ee.0`) can hang mid-session: `SYSTEM_STATISTICS_CMD` times out, `CSR_GP_CNTRL` reads `0xffffffff`, the in-driver SW reset fails with `Failed to start RT ucode: -110`, and `nmcli radio wifi on` then hangs on `do-change-link` (errno 110). Other devices on the same AP stay online.

In that hang NetworkManager stayed `activated` for 2.5 hours. A tray toggle never fires. The same userspace gap is already on #7003 for RTL8852BE (`rtw89`) and Intel BE200 (`iwlmld`) after s2idle.

Reloading the module is what actually brings the radio back. This matches `omarchy-restart-trackpad`.

## Not in this PR

- No sleep hook. A pre/post-suspend unload is the right quirk for #7003's resume wedge, but it is a different change and would not have prevented this mid-session hang. #7004 is a competing cold-probe fix for that case.
- No AX210 `modprobe` options. Power save is already off (`wifi.powersave = 2`). Disabling 11ax or ASPM is speculative and would hit every AX210.
- The unit is not conditioned on the sudoers grant. A non-`wheel` user gets the watcher enabled; it warns once to the journal and is inert after that.
- `omarchy-wifi-recover` is hidden and is the only `wifi` command, so the `wifi` group needs no `GROUP_DESCRIPTIONS` entry. #7796 removes that line; this PR does not touch `bin/omarchy`, so the two do not conflict.

## Test

`./test/shell.d/restart-wifi-test.sh`

- unloads `iwlmvm` / `iwlmld` / `iwldvm` then reloads `iwlwifi`; `iwlmei` unloaded when it pins `iwlwifi`
- reloads `rtw89_8852be` without touching iwlwifi
- reloads a shared driver once
- skips the reload when no radio is bound
- exits 1 on failed unload and on failed insert (insert is retried)
- one busy driver on a two-adapter machine still runs the radio toggle for the one that reloaded
- NetworkManager refusing the radio exits non-zero

`./test/shell.d/wifi-recover-test.sh`

- connected + no kernel link → reload after two polls
- healthy association, radio off, rfkill, user-disconnect, connecting, NM down, no hardware → leave alone
- AP, ad-hoc, and mesh interfaces with no station link → leave alone
- `unavailable` with the driver still answering (#7323) → leave alone; `unavailable` with the kernel gone → wedged
- a blocked sibling dongle does not suppress recovery for the wedged adapter
- phy NM cannot see, hung `nmcli` (timeout 124) → wedged
- reload cap: stops after three attempts, one critical toast
- missing grant: warn once, no toast, no restart
- failed reload: retry, no success toast
- sudoers is `%wheel … /usr/bin/omarchy-restart-wifi ""`
- staged unit removed when it matches either shipped version; a user-edited copy is kept
- the migration is executed, not grepped: a refused `sudo install` does not abort, a stock staged copy is cleaned up, an edited one is kept, and staging never overwrites the user's copy

`./test/shell.d/systemd-test.sh` checks first-run enables the unit.

All of this ran against fakes that model the real tools' output. Nobody has run it against an actual wedged AX210 yet; the machine that reproduced the original hang has not wedged again since.

Related: #7003, #7323, #7435, #7796, omacom/omarchy-pkgs#399
