### PR TITLE
Remove the toast when a sender closes its own notification

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -162,9 +162,14 @@ Item {
     liveRefs[snapshot.originalId] = notification
     // Guard the delete: a newer notification may have reused this originalId
     // (freedesktop replaces_id) and taken over the map slot.
-    notification.closed.connect(function() {
+    // The liveRefs entry goes first: closePopupOnRequest() runs removePopup(),
+    // which would otherwise find this very object and call dismiss() on a
+    // notification the server has already closed.
+    notification.closed.connect(function(reason) {
       if (service.liveRefs[snapshot.originalId] === notification)
         delete service.liveRefs[snapshot.originalId]
+      if (reason === NotificationCloseReason.CloseRequested)
+        service.closePopupOnRequest(snapshot)
     })
 
     // DND bypass rules: chat apps abuse urgency=critical to force
@@ -307,6 +312,29 @@ Item {
       if (isRestoredRow(row)) continue
       if (NotificationLogic.popupFileName(row) !== keepFileName) deletePopupFileFor(row)
       popupModel.remove(i)
+    }
+  }
+
+  // A sender closing its own notification through the spec's
+  // CloseNotification method means it wants the toast gone — "forcefully
+  // closed and removed from the user's view". Progress-style senders (a
+  // dictation chrono, a volume OSD, a long copy) depend on it: they post a
+  // long-lived notification, update it, and close it when the operation ends.
+  // Without this the toast sits there until its own timeout, which for a
+  // deliberately persistent one (expire_timeout 0) means forever.
+  //
+  // Only CloseRequested belongs here. Expired and Dismissed are this shell's
+  // own paths — they arrive from inside removePopup() and would re-enter it.
+  //
+  // The timestamp is what tells this popup apart from a restored row carrying
+  // the same id from a previous server generation (see isRestoredRow).
+  function closePopupOnRequest(snapshot) {
+    for (var i = 0; i < popupModel.count; i++) {
+      var row = popupModel.get(i)
+      if (!row || row.originalId !== snapshot.originalId) continue
+      if (row.timestamp !== snapshot.timestamp) continue
+      removePopup(i, "close")
+      return
     }
   }
 

--- a/test/acceptance.d/shell-surfaces-test.sh
+++ b/test/acceptance.d/shell-surfaces-test.sh
@@ -94,6 +94,18 @@ screenshot "success-notification-popup"
 omarchy-shell notifications dismissAll >/dev/null
 wait_until "notification popup closes" 15 layer_absent "omarchy-notifications"
 
+# A sender closing its own notification through the freedesktop
+# CloseNotification method must take the toast off the screen, without the
+# shell's own dismiss path being involved. The notification is posted with no
+# expiry so that only the close request can end it.
+notification_id=$(notify-send -p -t 0 "Acceptance close request" "Closed by its sender")
+wait_until "sender notification popup opens" 15 layer_present "omarchy-notifications"
+screenshot "success-notification-close-request"
+gdbus call --session --dest org.freedesktop.Notifications \
+  --object-path /org/freedesktop/Notifications \
+  --method org.freedesktop.Notifications.CloseNotification "$notification_id" >/dev/null
+wait_until "sender-closed notification popup closes" 15 layer_absent "omarchy-notifications"
+
 # The menu's Apps submenu does the full launcher loop: open, search by
 # typing, launch the top hit.
 if window_present "(?i)omawrite" >/dev/null 2>&1; then


### PR DESCRIPTION
### The problem

A sender that closes its own notification through `org.freedesktop.Notifications.CloseNotification` — the spec's "causes a notification to be forcefully closed and removed from the user's view" — does not get the toast removed. It stays on screen until its own expiry, and a deliberately persistent one (`expire_timeout` 0) stays up forever.

The shell does hear the close: Quickshell delivers `closed(reason)` with `CloseRequested`. `handleNotification()` only used that signal to drop the `liveRefs` entry (`Service.qml:165`); nothing took the row out of `popupModel`.

Reproduced on Omarchy 4.0.0-1 / quickshell-git 0.3.0.r20, and on `quattro` at 2c247e3 (the file is unchanged between the two):

```bash
id=$(notify-send -p -t 0 "Still here" "closed by its sender")
gdbus call --session --dest org.freedesktop.Notifications \
  --object-path /org/freedesktop/Notifications \
  --method org.freedesktop.Notifications.CloseNotification "$id"
# toast is still on screen; ~/.local/state/omarchy/notifications/<ts>-<id>.json still exists
```

### Who this hits

Senders that post a long-lived notification, update it in place, and close it when the operation ends: progress chronos, volume and brightness OSDs, copy/backup indicators. mako — the daemon Omarchy shipped through 3.x — honored it, so this is a behaviour change across the 4.0 upgrade for anything of that shape.

`omarchy-notification-dismiss` works around it today by dismissing through the shell's own IPC, matching on a **summary substring**. That workaround exists because the standard method does not work.

### The change

`closed(reason)` now also removes the popup, but only for `CloseRequested`. `Expired` and `Dismissed` arrive from inside `removePopup()` itself and reacting to them would re-enter it. The `liveRefs` entry is dropped first, so `removePopup()` finds no live object and does not call `dismiss()` on a notification the server has already closed. The popup is archived to history like any other toast that leaves the screen, since it did reach the user. A restored row carrying the same id from a previous server generation is excluded by the timestamp, as elsewhere in the file.

### Verification

Applied to a live Omarchy 4.0.0 desktop (single file swapped in `/usr/share/omarchy/shell/`, `omarchy-restart-shell`, then restored — `pacman -Qkk omarchy` clean):

| case | before | after |
| --- | --- | --- |
| `-t 0` notification, sender calls `CloseNotification` | toast stays indefinitely | toast removed, entry archived to history |
| notification with an expiry, left alone | expires, archived | unchanged |
| `notify-send -p` then `-r <id>` ×2 | one card, updated | unchanged |
| `omarchy-shell notifications dismiss <summary>` | removed | unchanged |
| DND-silenced notification closed by its sender | — | no-op, nothing on screen to remove |

The acceptance step added to `test/acceptance.d/shell-surfaces-test.sh` mirrors the existing notification block. I could not run it — the ISO harness needs the sibling `omarchy-iso` repo — so it is written against the helpers as they are used a few lines above; say the word if you would rather it went in a separate file or not at all.
