### PR TITLE
Swap SUPER+TAB and ALT+TAB defaults to match macOS Cmd+Tab

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -30,8 +30,10 @@ o.bind("SUPER + ALT + S", "Move window to scratchpad", hl.dsp.window.move({ work
 o.bind("SUPER + grave", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
 o.bind("SUPER + SHIFT + grave", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
 
-o.bind("SUPER + TAB", "Next workspace", hl.dsp.focus({ workspace = "e+1" }))
-o.bind("SUPER + SHIFT + TAB", "Previous workspace", hl.dsp.focus({ workspace = "e-1" }))
+o.bind("SUPER + TAB", "Focus on next window", hl.dsp.window.cycle_next())
+o.bind("SUPER + SHIFT + TAB", "Focus on previous window", hl.dsp.window.cycle_next({ next = false }))
+o.bind("SUPER + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
+o.bind("SUPER + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
 o.bind("SUPER + CTRL + TAB", "Former workspace", hl.dsp.focus({ workspace = "previous" }))
 
 o.bind("SUPER + SHIFT + ALT + LEFT", "Move workspace to left monitor", hl.dsp.workspace.move({ monitor = "l" }))
@@ -44,10 +46,8 @@ o.bind("SUPER + SHIFT + RIGHT", "Swap window to the right", hl.dsp.window.swap({
 o.bind("SUPER + SHIFT + UP", "Swap window up", hl.dsp.window.swap({ direction = "u" }))
 o.bind("SUPER + SHIFT + DOWN", "Swap window down", hl.dsp.window.swap({ direction = "d" }))
 
-o.bind("ALT + TAB", "Focus on next window", hl.dsp.window.cycle_next())
-o.bind("ALT + SHIFT + TAB", "Focus on previous window", hl.dsp.window.cycle_next({ next = false }))
-o.bind("ALT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
-o.bind("ALT + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
+o.bind("ALT + TAB", "Next workspace", hl.dsp.focus({ workspace = "e+1" }))
+o.bind("ALT + SHIFT + TAB", "Previous workspace", hl.dsp.focus({ workspace = "e-1" }))
 
 o.bind("CTRL + ALT + TAB", "Focus on next monitor", hl.dsp.focus({ monitor = "+1" }))
 o.bind("CTRL + ALT + SHIFT + TAB", "Focus on previous monitor", hl.dsp.focus({ monitor = "-1" }))


### PR DESCRIPTION
Implements option 1 from #7838.

## What

Swaps the default Tab-cycling bindings:

- `SUPER + TAB` / `SUPER + SHIFT + TAB` now cycle windows (next/previous), matching macOS's `Cmd+Tab`.
- `ALT + TAB` / `ALT + SHIFT + TAB` now cycle workspaces (next/previous).

`SUPER + CTRL + TAB` (former workspace), `SUPER + ALT + TAB` (group navigation), and `CTRL + ALT + TAB` (monitor focus) are untouched - no conflicts with those combos.

## Why

See #7838 for the full context: a large share of new Omarchy users come from macOS and keep using both systems for a long time. On a Mac keyboard, Command sends Super/Mod4 on Linux, and `Cmd+Tab` is one of the most deeply ingrained habits for switching windows. Currently `SUPER+TAB` instead switches workspaces, which is disorienting.

This also brings Omarchy's default in line with stock GNOME on Fedora and Ubuntu, both of which already bind `Super+Tab` to application/window switching by default, and with PaperWM, a popular GNOME tiling extension for people moving from macOS.

## Discussion

Opening this as a starting point per #7838 - happy to discuss the approach, and if maintainers decide this isn't the direction they want, feel free to just close it.