### PR TITLE
Preserve monitor position when adjusting scale

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -80,13 +80,15 @@ set_scale() {
   local width="$(echo "$monitor_info" | jq -r '.width')"
   local height="$(echo "$monitor_info" | jq -r '.height')"
   local refresh_rate="$(echo "$monitor_info" | jq -r '.refreshRate')"
+  local x="$(echo "$monitor_info" | jq -r '.x')"
+  local y="$(echo "$monitor_info" | jq -r '.y')"
   local new_scale="$(clean_scale "$requested_scale" "$width" "$height")"
   # GTK only honors integer GDK_SCALE values, so persist the nearest whole
   # factor even when the monitor scale itself is fractional.
   local new_gdk_scale="$(awk -v scale="$new_scale" 'BEGIN { printf "%d", int(scale + 0.5) }')"
   local monitor_lua="$HOME/.config/hypr/monitors.lua"
 
-  hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
+  hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"${x}x${y}\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -19,8 +19,9 @@ cat >"$stub_bin/hyprctl" <<'SH'
 #!/bin/bash
 
 if [[ $1 == "monitors" && $2 == "-j" ]]; then
-  printf '[{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}]' \
-    "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}"
+  printf '[{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0,"x":%s,"y":%s}]' \
+    "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}" \
+    "${OMARCHY_TEST_MONITOR_X:-0}" "${OMARCHY_TEST_MONITOR_Y:-0}"
 elif [[ $1 == "eval" ]]; then
   printf '%s\n' "$2" >"$OMARCHY_TEST_HYPRCTL_EVAL_OUT"
 else
@@ -42,6 +43,8 @@ run_scaling() {
     PATH="$stub_bin:$PATH" \
     OMARCHY_TEST_HYPRCTL_EVAL_OUT="$eval_out" \
     OMARCHY_TEST_MONITOR_SCALE="${OMARCHY_TEST_MONITOR_SCALE:-2}" \
+    OMARCHY_TEST_MONITOR_X="${OMARCHY_TEST_MONITOR_X:-0}" \
+    OMARCHY_TEST_MONITOR_Y="${OMARCHY_TEST_MONITOR_Y:-0}" \
     "$ROOT/bin/omarchy-hyprland-monitor-scaling" "$@"
 }
 
@@ -129,3 +132,10 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+# Rescaling a monitor away from the origin must keep its position, not
+# reflow it via "auto" and displace the other monitor.
+write_monitor_config
+OMARCHY_TEST_MONITOR_SCALE=2 OMARCHY_TEST_MONITOR_X=3440 OMARCHY_TEST_MONITOR_Y=0 run_scaling 3
+grep -F 'position = "3440x0"' "$eval_out" >/dev/null || fail "monitor scaling preserves the monitor's current position"
+pass "monitor scaling preserves the monitor's current position"


### PR DESCRIPTION
## Summary

- `set_scale()` in `bin/omarchy-hyprland-monitor-scaling` applies the new scale via `hyprctl eval` with `position = "auto"` for the focused monitor.
- On a multi-monitor layout where positions are set explicitly (e.g. a rotated secondary display placed to the right of a primary), `"auto"` re-runs Hyprland's placement algorithm and can displace the *other*, unrelated monitor -- the net effect is the two monitors swap sides after adjusting scale on just one of them.
- Fix: read the focused monitor's current `x`/`y` from `hyprctl monitors -j` and pass that through instead of `"auto"`, so a scale change never moves any monitor.

## Reproduction

Dual-monitor setup, explicit positions in `monitors.lua` (DP-1 at `0x0`, HDMI-A-1 rotated at `3440x0`):

```
$ hyprctl monitors -j | jq -r '.[] | "\(.name) pos=\(.x)x\(.y)"'
HDMI-A-1 pos=3440x0
DP-1 pos=0x0
```

Focus DP-1 and run `omarchy-hyprland-monitor-scaling 1` (same scale, isolating the position bug from any scale change):

```
$ hyprctl monitors -j | jq -r '.[] | "\(.name) pos=\(.x)x\(.y)"'
HDMI-A-1 pos=0x0
DP-1 pos=1080x0
```

DP-1 (originally on the left) is now to the right of HDMI-A-1, purely from touching its scale.

## Test plan

- [x] Added a regression test in `test/shell.d/monitor-scaling-test.sh` asserting the `hyprctl eval` call preserves a non-origin monitor position (`x=3440,y=0`) instead of using `"auto"`.
- [x] `test/shell.d/monitor-scaling-test.sh` passes (all 15 cases).