### PR TITLE
Don't force the NVIDIA VA-API driver on hybrid-GPU systems

### DIFF
--- a/bin/omarchy-hw-hybrid-gpu-sysfs
+++ b/bin/omarchy-hw-hybrid-gpu-sysfs
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer has display GPUs from more than one vendor (hybrid graphics).
+
+# Unlike omarchy-hw-hybrid-gpu, this only inspects the hardware and never
+# queries supergfxd, so it stays fast enough to run during Hyprland's config
+# reload. Read the cached sysfs IDs rather than lspci, which reads PCI config
+# space and resumes runtime-suspended GPUs.
+pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
+shopt -s nullglob
+
+declare -A vendors=()
+
+for device in "$pci_devices_path"/*; do
+  [[ $(< "$device/class") == 0x03* ]] || continue
+  vendors[$(< "$device/vendor")]=1
+  (( ${#vendors[@]} >= 2 )) && exit 0
+done
+
+exit 1

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,6 +3,7 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local hybrid_gpu = paths.omarchy_path .. "/bin/omarchy-hw-hybrid-gpu-sysfs"
 
 -- These detectors read cached sysfs IDs rather than shelling out to lspci.
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
@@ -10,8 +11,15 @@ local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without
 if o.shell_succeeds(o.shell_quote(nvidia)) then
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
-    hl.env("LIBVA_DRIVER_NAME", "nvidia")
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+
+    -- On hybrid-GPU systems the iGPU drives the display, and apps like
+    -- Chromium deliberately skip the NVIDIA device and decode video on the
+    -- iGPU. Forcing the NVIDIA VA-API driver breaks their hardware decode
+    -- entirely, so let libva pick the driver per device instead.
+    if not o.shell_succeeds(o.shell_quote(hybrid_gpu)) then
+      hl.env("LIBVA_DRIVER_NAME", "nvidia")
+    end
   elseif o.shell_succeeds(o.shell_quote(nvidia_without_gsp)) then
     hl.env("NVD_BACKEND", "egl")
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")

--- a/test/shell.d/hw-hybrid-gpu-sysfs-test.sh
+++ b/test/shell.d/hw-hybrid-gpu-sysfs-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-hybrid-gpu-sysfs"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Builds a fake sysfs PCI tree from vendor:class pairs.
+make_devices() {
+  local dir="$1" spec i=0
+  shift
+
+  for spec in "$@"; do
+    local device="$dir/0000:00:0$i.0"
+    mkdir -p "$device"
+    echo "${spec%%:*}" > "$device/vendor"
+    echo "${spec##*:}" > "$device/class"
+    (( i += 1 ))
+  done
+}
+
+assert_hybrid() {
+  local description="$1"
+  shift
+
+  local dir
+  dir=$(mktemp -d -p "$TMPDIR")
+  make_devices "$dir" "$@"
+
+  if OMARCHY_PCI_DEVICES_PATH="$dir" "$detector"; then
+    pass "$description"
+  else
+    fail "$description"
+  fi
+}
+
+assert_not_hybrid() {
+  local description="$1"
+  shift
+
+  local dir
+  dir=$(mktemp -d -p "$TMPDIR")
+  make_devices "$dir" "$@"
+
+  if OMARCHY_PCI_DEVICES_PATH="$dir" "$detector"; then
+    fail "$description"
+  else
+    pass "$description"
+  fi
+}
+
+assert_hybrid "detects Intel iGPU + NVIDIA dGPU as hybrid" 0x8086:0x030000 0x10de:0x030200
+assert_hybrid "detects AMD iGPU + NVIDIA dGPU as hybrid" 0x1002:0x030000 0x10de:0x030200
+assert_hybrid "detects Intel + AMD as hybrid" 0x8086:0x030000 0x1002:0x030000
+
+assert_not_hybrid "single NVIDIA GPU is not hybrid" 0x10de:0x030200
+assert_not_hybrid "two NVIDIA GPUs are not hybrid" 0x10de:0x030200 0x10de:0x030000
+assert_not_hybrid "non-display devices are ignored" 0x8086:0x060000 0x10de:0x0c8000
+assert_not_hybrid "empty device tree is not hybrid"


### PR DESCRIPTION
## Problem

On hybrid Intel+NVIDIA laptops, `default/hypr/nvidia.lua` sets `LIBVA_DRIVER_NAME=nvidia` for any GSP-capable NVIDIA GPU. On hybrid systems the iGPU drives the display, and Chromium's GPU process deliberately skips the NVIDIA DRM device (logs `Should skip nVidia device named: nvidia-drm`) and uses the Intel render node. With libva forced to the NVIDIA driver, VA-API cannot initialize for the Intel node: the Chromium GPU process loads `nvidia_drv_video.so` but never `iHD_drv_video.so`, so hardware video decode is dead and playback falls back to software decode. In practice, buffered 24-30fps VOD mostly survives on CPU, but 60fps live streams stutter and freeze the browser. Same root cause as the VAAPI part of #4901.

## Fix

Only force `LIBVA_DRIVER_NAME=nvidia` when the system is *not* hybrid. The new `omarchy-hw-hybrid-gpu-sysfs` detector reports hybrid when display-class PCI devices from more than one vendor are present. Like the existing `omarchy-hw-nvidia*` detectors it reads cached sysfs IDs instead of lspci (which resumes runtime-suspended GPUs and can exceed Hyprland's config reload budget), and unlike `omarchy-hw-hybrid-gpu` it never queries supergfxd, so it is always fast enough to run during config reload.

With the variable unset, libva auto-selects the driver per device (iHD for the Intel node, nvidia for the dGPU node) — verified with ffmpeg VA-API decode on both render nodes of a hybrid laptop.

`NVD_BACKEND=direct` and `__GLX_VENDOR_LIBRARY_NAME=nvidia` are unchanged: the former only matters when libva-nvidia-driver is actually used, the latter only affects GLX/XWayland clients.

## Testing

- Detector fixtures via `OMARCHY_PCI_DEVICES_PATH`: single NVIDIA → no, Intel+NVIDIA → yes, dual NVIDIA → no, Intel+AMD → yes, non-GPU only → no; real hybrid laptop (Core Ultra 9 285H + RTX 5090, Omarchy 4.0.0) → yes.
- On the affected machine, applying the equivalent session override (`LIBVA_DRIVER_NAME=iHD`) makes newly launched apps — including ones started through `uwsm app` — pick up the corrected driver, and Chromium VA-API initializes against the Intel iGPU.
- `./test/all` passes except 4 pre-existing environment-dependent failures (tests requiring an `omarchy-pkgs` checkout or a graphical session); they fail identically on unmodified master.

Refs #4901