### PR TITLE
Make the notification position configurable and badge agent toasts

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -255,12 +255,7 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
 }
 ```
 
-`notifications.position` names the corner the toast stack grows from as
-`<top|middle|bottom>-<left|center|right>` and defaults to `top-right`.
-`notifications.agentIcons` (default `true`) badges plain `notify-send` toasts
-whose summary starts with `claude`, `codex`, or `agy` with that agent's mark
-from the enabled agents plugin. Both are optional and apply as soon as the file
-is saved.
+`notifications.position` names the corner the toast stack grows from as `<top|middle|bottom>-<left|center|right>` and defaults to `top-right`. `notifications.agentIcons` (default `true`) badges plain `notify-send` toasts whose summary starts with `claude`, `codex`, or `agy` with that agent's mark from the enabled agents plugin. Both are optional and apply as soon as the file is saved.
 
 ### Storage rules
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -234,6 +234,10 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
     "screensaver": 150,
     "lock": 300
   },
+  "notifications": {
+    "position": "top-right",
+    "agentIcons": true
+  },
   "bar": {
     "id": "omarchy.bar",
     "position": "top",
@@ -250,6 +254,13 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
   "plugins": []
 }
 ```
+
+`notifications.position` names the corner the toast stack grows from as
+`<top|middle|bottom>-<left|center|right>` and defaults to `top-right`.
+`notifications.agentIcons` (default `true`) badges plain `notify-send` toasts
+whose summary starts with `claude`, `codex`, or `agy` with that agent's mark
+from the enabled agents plugin. Both are optional and apply as soon as the file
+is saved.
 
 ### Storage rules
 

--- a/shell/plugins/agents/assets/antigravity-light.svg
+++ b/shell/plugins/agents/assets/antigravity-light.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 540" width="100%" height="100%">
+  <defs>
+    <linearGradient id="agy-grad" x1="15%" y1="5%" x2="85%" y2="95%">
+      <stop offset="0%" stop-color="#34A853" />
+      <stop offset="25%" stop-color="#F59E0B" />
+      <stop offset="50%" stop-color="#EA4335" />
+      <stop offset="70%" stop-color="#8B5CF6" />
+      <stop offset="100%" stop-color="#2563EB" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#agy-grad)" d="M 270 84 C 315 84 354 145 382 245 C 405 328 438 410 464 438 C 475 450 464 459 450 454 C 426 446 408 416 388 384 C 358 335 322 284 270 284 C 218 284 182 335 152 384 C 132 416 114 446 90 454 C 76 459 65 450 76 438 C 102 410 135 328 158 245 C 186 145 225 84 270 84 Z" />
+</svg>

--- a/shell/plugins/agents/assets/antigravity.svg
+++ b/shell/plugins/agents/assets/antigravity.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 540" width="100%" height="100%">
+  <defs>
+    <linearGradient id="agy-grad" x1="15%" y1="5%" x2="85%" y2="95%">
+      <stop offset="0%" stop-color="#34A853" />
+      <stop offset="25%" stop-color="#F59E0B" />
+      <stop offset="50%" stop-color="#EA4335" />
+      <stop offset="70%" stop-color="#8B5CF6" />
+      <stop offset="100%" stop-color="#2563EB" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#agy-grad)" d="M 270 84 C 315 84 354 145 382 245 C 405 328 438 410 464 438 C 475 450 464 459 450 454 C 426 446 408 416 388 384 C 358 335 322 284 270 284 C 218 284 182 335 152 384 C 132 416 114 446 90 454 C 76 459 65 450 76 438 C 102 410 135 328 158 245 C 186 145 225 84 270 84 Z" />
+</svg>

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -290,17 +290,9 @@ function popupExpired(entry, duration, now) {
 // grows from: "<top|middle|bottom>-<left|center|right>". Anything else keeps
 // the top-right default.
 function parsePopupPosition(value) {
-  var parts = String(value || "").trim().toLowerCase().split(/[-\s_]+/)
-  var vertical = "top"
-  var horizontal = "right"
-  for (var i = 0; i < parts.length; i++) {
-    var part = parts[i]
-    if (part === "top" || part === "bottom") vertical = part
-    else if (part === "middle" && i === 0) vertical = "middle"
-    else if (part === "left" || part === "right") horizontal = part
-    else if (part === "center" || part === "middle") horizontal = "center"
-  }
-  return { vertical: vertical, horizontal: horizontal }
+  var match = String(value || "").trim().toLowerCase().match(/^(top|middle|bottom)[-\s_]+(left|center|right|middle)$/)
+  if (!match) return { vertical: "top", horizontal: "right" }
+  return { vertical: match[1], horizontal: match[2] === "middle" ? "center" : match[2] }
 }
 
 function popupPlacement(barPosition, barClearance, gapsOut, position) {

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -286,22 +286,69 @@ function popupExpired(entry, duration, now) {
   return (Number(now) - Number((entry || {}).timestamp || 0)) >= lifetime
 }
 
-function popupPlacement(barPosition, barClearance, gapsOut) {
-  var position = String(barPosition || "top")
+// shell.json `notifications.position` names the corner the toast stack
+// grows from: "<top|middle|bottom>-<left|center|right>". Anything else keeps
+// the top-right default.
+function parsePopupPosition(value) {
+  var parts = String(value || "").trim().toLowerCase().split(/[-\s_]+/)
+  var vertical = "top"
+  var horizontal = "right"
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i]
+    if (part === "top" || part === "bottom") vertical = part
+    else if (part === "middle" && i === 0) vertical = "middle"
+    else if (part === "left" || part === "right") horizontal = part
+    else if (part === "center" || part === "middle") horizontal = "center"
+  }
+  return { vertical: vertical, horizontal: horizontal }
+}
+
+function popupPlacement(barPosition, barClearance, gapsOut, position) {
+  var bar = String(barPosition || "top")
   var clearance = Number(barClearance)
   var gap = Number(gapsOut)
   if (!isFinite(clearance)) clearance = 0
   if (!isFinite(gap)) gap = 0
+  var corner = parsePopupPosition(position)
+  var anchors = {
+    top: corner.vertical === "top",
+    bottom: corner.vertical === "bottom",
+    left: corner.horizontal === "left",
+    right: corner.horizontal === "right"
+  }
 
+  // Only an edge the stack sits on needs to clear the bar.
   return {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: anchors,
     margins: {
-      top: position === "top" ? clearance : gap,
-      bottom: gap,
-      left: gap,
-      right: position === "right" ? clearance : gap
+      top: anchors.top && bar === "top" ? clearance : gap,
+      bottom: anchors.bottom && bar === "bottom" ? clearance : gap,
+      left: anchors.left && bar === "left" ? clearance : gap,
+      right: anchors.right && bar === "right" ? clearance : gap
     }
   }
+}
+
+// Agent CLIs notify through plain notify-send with no icon, and the summary
+// starts with the agent's name, so that word picks the mark the agents
+// plugin already ships. Marks drawn in white carry a -light twin for light
+// surfaces; Claude's brand orange works on both.
+var AGENT_MARKS = {
+  claude: { asset: "claude", light: false },
+  codex: { asset: "codex", light: true },
+  agy: { asset: "antigravity", light: true },
+  antigravity: { asset: "antigravity", light: true }
+}
+
+// The asset file name for a toast's agent mark, or "" when the toast is not
+// a plain notify-send from a known agent or already set its own icon.
+function agentMarkFor(app, appIcon, summary, lightSurface) {
+  if (String(appIcon || "").length > 0) return ""
+  if (String(app || "") !== "notify-send") return ""
+  var head = String(summary || "").trim().toLowerCase().split(/\s+/)[0] || ""
+  var mark = AGENT_MARKS[head]
+  if (!mark) return ""
+  return mark.light && lightSurface ? mark.asset + "-light" : mark.asset
 }
 
 // The archived files are the history. They are read back exactly like the
@@ -363,6 +410,8 @@ if (typeof module !== "undefined") {
     serializePopup: serializePopup,
     parsePopupFiles: parsePopupFiles,
     popupExpired: popupExpired,
-    popupPlacement: popupPlacement
+    parsePopupPosition: parsePopupPosition,
+    popupPlacement: popupPlacement,
+    agentMarkFor: agentMarkFor
   }
 }

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -40,9 +40,8 @@ Item {
   // Corner radius is shared with the menu and shell panels.
   // It mirrors Hyprland's current decoration:rounding value.
   readonly property int cornerRadius: Style.cornerRadius
-  // Toasts are fixed to the top-right corner. They only clear the omarchy bar
-  // when the bar occupies the top or right edge, so left/bottom bars do not
-  // pull notification popups away from the expected top-right location.
+  // Toasts clear the omarchy bar only when their configured position uses the
+  // same edge.
   // Falls back to the bar's default size (26 horizontal / 28 vertical) when
   // shell.bar isn't reachable so the popup never lands on top of the bar.
   readonly property string barPosition: shell && shell.barConfig ? String(shell.barConfig.position || "top") : "top"
@@ -56,6 +55,7 @@ Item {
   // The stack grows away from the edge it sits on, so a bottom corner wants
   // the newest toast nearest that edge: last in the model instead of first.
   readonly property bool stackNewestLast: NotificationLogic.parsePopupPosition(popupPosition).vertical === "bottom"
+  onStackNewestLastChanged: reversePopups()
   property var pluginRegistry: null
 
   // Live Notification objects by originalId, kept OUT of the ListModels: a
@@ -145,6 +145,15 @@ Item {
   function insertToast(entry) {
     if (stackNewestLast) popupModel.append(entry)
     else popupModel.insert(0, entry)
+  }
+
+  function insertRestoredToast(entry) {
+    if (stackNewestLast) popupModel.insert(0, entry)
+    else popupModel.append(entry)
+  }
+
+  function reversePopups() {
+    for (var i = 0; i < popupModel.count - 1; i++) popupModel.move(popupModel.count - 1, i, 1)
   }
 
   // The marks belong to the agents plugin, so they come from whichever one is
@@ -734,16 +743,15 @@ Item {
     }
 
     clearPopups()
-    // Rows arrive newest-first, and index 0 is the top of the toast stack, so
-    // a bottom-anchored stack takes them in reverse to keep the newest nearest
-    // its edge.
+    // Rows arrive newest-first; restored insertion keeps the newest nearest
+    // the configured edge.
     for (var i = 0; i < rows.length; i++) {
-      var row = service.stackNewestLast ? rows[rows.length - 1 - i] : rows[i]
+      var row = rows[i]
       // Replayed rows are restored rows: their notification died with the
       // sender long ago, so they must never resolve to a live server object
       // that has since been handed their old id.
       service.restoredPopups[NotificationLogic.popupFileName(row)] = true
-      popupModel.append(row)
+      insertRestoredToast(row)
     }
   }
 
@@ -804,12 +812,12 @@ Item {
           }
         }
         if (duplicate) continue
-        // Append (entries are newest-first) so restored toasts stack in
-        // their original order below anything that just arrived. Restored
-        // popups have no liveRefs entry — the server object died with the
-        // old shell — so dismissal and action fallbacks degrade gracefully.
+        // Entries arrive newest-first; restored insertion keeps them behind
+        // anything that just arrived. Restored popups have no liveRefs entry
+        // — the server object died with the old shell — so dismissal and
+        // action fallbacks degrade gracefully.
         service.restoredPopups[NotificationLogic.popupFileName(restored)] = true
-        popupModel.append(restored)
+        insertRestoredToast(restored)
       }
     })
   }

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -50,6 +50,13 @@ Item {
   readonly property int defaultBarSize: barVertical ? Style.bar.sizeVertical : Style.bar.sizeHorizontal
   readonly property int liveBarSize: shell && shell.bar && !shell.bar.barHidden ? Math.max(0, shell.bar.barSize) : defaultBarSize
   readonly property int barClearance: liveBarSize + Style.gapsOut
+  readonly property var notificationsConfig: shell && shell.shellConfig && Util.isPlainObject(shell.shellConfig.notifications) ? shell.shellConfig.notifications : ({})
+  readonly property string popupPosition: String(notificationsConfig.position || "top-right")
+  readonly property bool agentIconsEnabled: notificationsConfig.agentIcons !== false
+  // The stack grows away from the edge it sits on, so a bottom corner wants
+  // the newest toast nearest that edge: last in the model instead of first.
+  readonly property bool stackNewestLast: NotificationLogic.parsePopupPosition(popupPosition).vertical === "bottom"
+  property var pluginRegistry: null
 
   // Live Notification objects by originalId, kept OUT of the ListModels: a
   // QObject stored in a model role becomes a dangling C++ pointer when the
@@ -135,6 +142,35 @@ Item {
     return NotificationLogic.snapshotOf(notification, Date.now())
   }
 
+  function insertToast(entry) {
+    if (stackNewestLast) popupModel.append(entry)
+    else popupModel.insert(0, entry)
+  }
+
+  // The marks belong to the agents plugin, so they come from whichever one is
+  // enabled. A clone of it outranks the built-in, which the registry still
+  // reports as enabled while the clone stands in for it.
+  readonly property string agentAssetsDir: {
+    var plugins = pluginRegistry && pluginRegistry.installedPlugins ? pluginRegistry.installedPlugins : ({})
+    var dir = omarchyPath + "/shell/plugins/agents/assets/"
+    for (var id in plugins) {
+      var manifest = plugins[id]
+      if (!manifest || !manifest.__sourceDir) continue
+      var clonedFrom = manifest.omarchy && manifest.omarchy.clonedFrom ? String(manifest.omarchy.clonedFrom) : ""
+      if (clonedFrom !== "omarchy.agents" || !pluginRegistry.isEnabled(id)) continue
+      dir = String(manifest.__sourceDir) + "/assets/"
+    }
+    return dir
+  }
+
+  function agentIconFor(app, appIcon, summary) {
+    if (!agentIconsEnabled) return ""
+    var bg = Color.notifications.background
+    var luminance = 0.2126 * bg.r + 0.7152 * bg.g + 0.0722 * bg.b
+    var name = NotificationLogic.agentMarkFor(app, appIcon, summary, luminance >= 0.5)
+    return name === "" ? "" : Util.fileUrl(agentAssetsDir + name + ".svg")
+  }
+
   // A notification nobody looks back at:
   //   - the freedesktop `transient` hint is set ("popup only, don't store")
   //   - app_name is "notify-send" (the CLI default — means the sender
@@ -189,7 +225,7 @@ Item {
     // Repeater is mid-incubation while we mutate its model.
     Qt.callLater(function() {
       removePopupsByOriginalId(snapshot.originalId, NotificationLogic.popupFileName(snapshot))
-      popupModel.insert(0, snapshot)
+      insertToast(snapshot)
       // An update that arrived while the insert was deferred found no row to
       // write to, and a property that already changed will not change again.
       // Reading the object once the row exists catches up on it.
@@ -680,7 +716,7 @@ Item {
 
     // Replaying nothing at all looks like a dead keybinding, so say so.
     if (rows.length === 0) {
-      popupModel.insert(0, {
+      insertToast({
         id: -1,
         originalId: -1,
         app: "omarchy-action",
@@ -698,13 +734,16 @@ Item {
     }
 
     clearPopups()
-    // Rows arrive newest-first, and index 0 is the top of the toast stack.
+    // Rows arrive newest-first, and index 0 is the top of the toast stack, so
+    // a bottom-anchored stack takes them in reverse to keep the newest nearest
+    // its edge.
     for (var i = 0; i < rows.length; i++) {
+      var row = service.stackNewestLast ? rows[rows.length - 1 - i] : rows[i]
       // Replayed rows are restored rows: their notification died with the
       // sender long ago, so they must never resolve to a live server object
       // that has since been handed their old id.
-      service.restoredPopups[NotificationLogic.popupFileName(rows[i])] = true
-      popupModel.append(rows[i])
+      service.restoredPopups[NotificationLogic.popupFileName(row)] = true
+      popupModel.append(row)
     }
   }
 
@@ -964,7 +1003,9 @@ Item {
       color: "transparent"
 
       readonly property var popupPlacement: NotificationLogic.popupPlacement(
-        service.barPosition, service.barClearance, Style.gapsOut)
+        service.barPosition, service.barClearance, Style.gapsOut, service.popupPosition)
+      readonly property int popupAlignment: popupPlacement.anchors.left ? Qt.AlignLeft
+        : (popupPlacement.anchors.right ? Qt.AlignRight : Qt.AlignHCenter)
 
       // Full-screen, fixed-size surface (like the OSD overlay). Adding or
       // removing a toast changes only the content inside; the Wayland surface
@@ -978,10 +1019,18 @@ Item {
 
       ColumnLayout {
         id: popupColumn
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: popupWindow.popupPlacement.margins.top
-        anchors.rightMargin: popupWindow.popupPlacement.margins.right
+        readonly property var placement: popupWindow.popupPlacement
+        width: implicitWidth
+        height: implicitHeight
+        // Positioned by hand rather than anchored: the corner is config, and
+        // a Layout whose anchors are rebound to undefined stops laying out
+        // its children.
+        x: placement.anchors.left ? placement.margins.left
+          : (placement.anchors.right ? parent.width - width - placement.margins.right
+          : Math.round((parent.width - width) / 2))
+        y: placement.anchors.top ? placement.margins.top
+          : (placement.anchors.bottom ? parent.height - height - placement.margins.bottom
+          : Math.round((parent.height - height) / 2))
         spacing: Style.space(8)
 
         Repeater {
@@ -1006,7 +1055,7 @@ Item {
             // Each card sizes itself based on mode (text vs media); the slot
             // tracks the card so the column auto-fits to whichever is widest.
             Layout.preferredWidth: card.implicitWidth
-            Layout.alignment: Qt.AlignRight
+            Layout.alignment: popupWindow.popupAlignment
             implicitHeight: card.implicitHeight
 
             readonly property real lifetime: service.durationFor(cardSlot.urgency, cardSlot.expireTimeout)
@@ -1039,9 +1088,12 @@ Item {
 
             NotificationCard {
               id: card
+              readonly property string agentIcon: service.agentIconFor(cardSlot.app, cardSlot.appIcon, cardSlot.summary)
               anchors.right: parent.right
               app: cardSlot.app
-              appIcon: cardSlot.appIcon
+              appIcon: cardSlot.appIcon || agentIcon
+              iconScale: agentIcon !== "" ? 0.7 : 1.0
+              iconOpacity: agentIcon !== "" ? 0.5 : 1.0
               summary: cardSlot.summary
               body: cardSlot.body
               image: cardSlot.image

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -22,6 +22,10 @@ BorderSurface {
   // notifications` etc.) show their bell/lock/etc. glyph without leaking
   // into the summary text.
   property string glyph: ""
+  // Agent marks are drawn at full brand brightness; shrunk and faded they
+  // read as a badge instead of competing with the text.
+  property real iconScale: 1.0
+  property real iconOpacity: 1.0
   // NotificationUrgency: Low=0, Normal=1, Critical=2 (upstream).
   property int urgency: 1
   property double timestamp: 0
@@ -120,7 +124,10 @@ BorderSurface {
 
         Image {
           id: smallIconImage
-          anchors.fill: parent
+          anchors.centerIn: parent
+          width: parent.width * root.iconScale
+          height: parent.height * root.iconScale
+          opacity: root.iconOpacity
           source: root.smallIconSource
           sourceSize.width: smallIconSlot.width * Screen.devicePixelRatio
           sourceSize.height: smallIconSlot.height * Screen.devicePixelRatio

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -102,6 +102,13 @@ assertDeepEqual(
   { vertical: 'top', horizontal: 'right' },
   'notifications fall back to top-right for an unknown position'
 )
+for (const invalid of ['bottom-sideways', 'left', 'center-bottom']) {
+  assertDeepEqual(
+    notifications.parsePopupPosition(invalid),
+    { vertical: 'top', horizontal: 'right' },
+    'notifications reject malformed toast position ' + invalid
+  )
+}
 assertDeepEqual(
   notifications.popupPlacement('bottom', 32, 6, 'bottom-left'),
   {
@@ -135,6 +142,8 @@ assertEqual(notifications.agentMarkFor('notify-send', '', 'claude finished', tru
 assertEqual(notifications.agentMarkFor('notify-send', 'mail', 'claude finished', false), '', 'notifications keep an icon the sender chose')
 assertEqual(notifications.agentMarkFor('Slack', '', 'claude finished', false), '', 'notifications only badge plain notify-send toasts')
 assertEqual(notifications.agentMarkFor('notify-send', '', 'Build finished', false), '', 'notifications leave other notify-send toasts unbadged')
+assert(fs.existsSync(path.join(root, 'shell/plugins/agents/assets/antigravity.svg')), 'notifications ship the Antigravity mark they resolve')
+assert(fs.existsSync(path.join(root, 'shell/plugins/agents/assets/antigravity-light.svg')), 'notifications ship the Antigravity light mark they resolve')
 
 const notification = {
   id: 12,
@@ -603,6 +612,16 @@ assert(
 assert(
   /function insertToast\(entry\) \{\s*if \(stackNewestLast\) popupModel\.append\(entry\)\s*else popupModel\.insert\(0, entry\)/.test(serviceQml),
   'notifications service stacks the newest toast nearest a bottom edge'
+)
+assert(
+  /function insertRestoredToast\(entry\) \{\s*if \(stackNewestLast\) popupModel\.insert\(0, entry\)\s*else popupModel\.append\(entry\)/.test(serviceQml)
+    && (serviceQml.match(/insertRestoredToast\((?:row|restored)\)/g) || []).length === 2,
+  'notifications service restores and replays newest nearest the configured edge'
+)
+assert(
+  /onStackNewestLastChanged: reversePopups\(\)/.test(serviceQml)
+    && /function reversePopups\(\) \{\s*for \([^)]+\) popupModel\.move\(popupModel\.count - 1, i, 1\)/.test(serviceQml),
+  'notifications service reorders visible toasts when their edge changes'
 )
 assert(
   !/popupModel\.insert\(0, (snapshot|\{)/.test(serviceQml),

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -82,6 +82,60 @@ assertDeepEqual(
   'notifications ignore a left bar for popup placement'
 )
 
+assertDeepEqual(
+  notifications.parsePopupPosition('bottom-left'),
+  { vertical: 'bottom', horizontal: 'left' },
+  'notifications read a configured toast corner'
+)
+assertDeepEqual(
+  notifications.parsePopupPosition('middle-center'),
+  { vertical: 'middle', horizontal: 'center' },
+  'notifications accept a screen-centred toast position'
+)
+assertDeepEqual(
+  notifications.parsePopupPosition('bottom-middle'),
+  { vertical: 'bottom', horizontal: 'center' },
+  'notifications accept middle as the horizontal centre'
+)
+assertDeepEqual(
+  notifications.parsePopupPosition('sideways'),
+  { vertical: 'top', horizontal: 'right' },
+  'notifications fall back to top-right for an unknown position'
+)
+assertDeepEqual(
+  notifications.popupPlacement('bottom', 32, 6, 'bottom-left'),
+  {
+    anchors: { top: false, bottom: true, left: true, right: false },
+    margins: { top: 6, bottom: 32, left: 6, right: 6 }
+  },
+  'notifications clear a bottom bar when the stack sits on the bottom edge'
+)
+assertDeepEqual(
+  notifications.popupPlacement('top', 32, 6, 'bottom-left'),
+  {
+    anchors: { top: false, bottom: true, left: true, right: false },
+    margins: { top: 6, bottom: 6, left: 6, right: 6 }
+  },
+  'notifications ignore a top bar when the stack sits on the bottom edge'
+)
+assertDeepEqual(
+  notifications.popupPlacement('top', 32, 6, 'middle-center'),
+  {
+    anchors: { top: false, bottom: false, left: false, right: false },
+    margins: { top: 6, bottom: 6, left: 6, right: 6 }
+  },
+  'notifications anchor nothing for a centred stack'
+)
+
+assertEqual(notifications.agentMarkFor('notify-send', '', 'claude finished', false), 'claude', 'notifications recognise a Claude toast by its summary')
+assertEqual(notifications.agentMarkFor('notify-send', '', 'Codex needs input', false), 'codex', 'notifications recognise a Codex toast regardless of case')
+assertEqual(notifications.agentMarkFor('notify-send', '', 'agy finished', false), 'antigravity', 'notifications map the agy summary to the Antigravity mark')
+assertEqual(notifications.agentMarkFor('notify-send', '', 'codex finished', true), 'codex-light', 'notifications take the light twin of a white mark on a light surface')
+assertEqual(notifications.agentMarkFor('notify-send', '', 'claude finished', true), 'claude', 'notifications keep a mark without a light twin on a light surface')
+assertEqual(notifications.agentMarkFor('notify-send', 'mail', 'claude finished', false), '', 'notifications keep an icon the sender chose')
+assertEqual(notifications.agentMarkFor('Slack', '', 'claude finished', false), '', 'notifications only badge plain notify-send toasts')
+assertEqual(notifications.agentMarkFor('notify-send', '', 'Build finished', false), '', 'notifications leave other notify-send toasts unbadged')
+
 const notification = {
   id: 12,
   appName: 'Mail',
@@ -475,7 +529,7 @@ assert(
   'notifications service leaves the row and its file alone when a refresh finds nothing changed'
 )
 assert(
-  /popupModel\.insert\(0, snapshot\)[\s\S]{0,300}?service\.refreshPopup\(notification, snapshot\.originalId, snapshot\.timestamp\)/.test(serviceQml),
+  /insertToast\(snapshot\)[\s\S]{0,300}?service\.refreshPopup\(notification, snapshot\.originalId, snapshot\.timestamp\)/.test(serviceQml),
   'notifications service catches up on an update that beat the deferred row insert'
 )
 assert(
@@ -515,7 +569,7 @@ assert(
   'notifications service never resolves a restored popup to a live server object'
 )
 assert(
-  /service\.restoredPopups\[NotificationLogic\.popupFileName\(rows\[i\]\)\] = true/.test(serviceQml),
+  /service\.restoredPopups\[NotificationLogic\.popupFileName\(row\)\] = true/.test(serviceQml),
   'notifications service treats replayed history rows as restored, never as live notifications'
 )
 assert(
@@ -537,5 +591,29 @@ assert(
 assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
+)
+assert(
+  /readonly property string popupPosition: String\(notificationsConfig\.position \|\| "top-right"\)/.test(serviceQml),
+  'notifications service reads the toast corner from shell.json with a top-right default'
+)
+assert(
+  /readonly property bool agentIconsEnabled: notificationsConfig\.agentIcons !== false/.test(serviceQml),
+  'notifications service keeps agent marks on unless shell.json turns them off'
+)
+assert(
+  /function insertToast\(entry\) \{\s*if \(stackNewestLast\) popupModel\.append\(entry\)\s*else popupModel\.insert\(0, entry\)/.test(serviceQml),
+  'notifications service stacks the newest toast nearest a bottom edge'
+)
+assert(
+  !/popupModel\.insert\(0, (snapshot|\{)/.test(serviceQml),
+  'notifications service routes every new toast through insertToast'
+)
+assert(
+  /appIcon: cardSlot\.appIcon \|\| agentIcon/.test(serviceQml),
+  'notifications service badges agent toasts without overriding a sender icon'
+)
+assert(
+  /clonedFrom !== "omarchy\.agents" \|\| !pluginRegistry\.isEnabled\(id\)\) continue[\s\S]{0,120}?dir = String\(manifest\.__sourceDir\) \+ "\/assets\/"/.test(serviceQml),
+  'notifications service takes agent marks from the enabled agents plugin, clone included'
 )
 JS


### PR DESCRIPTION
## Motivation

Notifications in the top right are sitting on top of plugins by default, which make them feel intrusive; they block quickshell widgets.

![Toasts sitting on top of the agent usage panel](https://raw.githubusercontent.com/data-goblin/omarchy/pr-assets/7854/before-top-right.png)

I thought it would make sense to make this configurable. I also thought that adding agent icons (like the usage plugin) adds pre-attentive attributes which help make hte notifications more useful / actionable.

![Bottom-left toasts with agent icons](https://raw.githubusercontent.com/data-goblin/omarchy/pr-assets/7854/after-bottom-left.png)

## Changes

- Notifications can be configured to top/bottom/middle & left/right/middle
- Notifications can include agent icons (codex, cc and agy for now only...)

## Verification

- `bash test/shell.d/notifications-test.sh` passes all 136 assertions.
- QML lint, SVG validation, and `./test/cli` pass.
- Manually verified top and bottom ordering, live edge switching, agent badges, and sender-icon preservation.

Thanks!

---

Disclaimer: The code in this PR was AI generated (Claude Code; Fable xHigh, and Codex; GPT-5.6-sol max) and tested.
