### PR TITLE
feat(surface-touch): add touchscreen support for Surface devices via linux-surface kernel as boot option

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -2,6 +2,7 @@ run_logged "$OMARCHY_INSTALL/hardware/asus-rog.sh"
 run_logged "$OMARCHY_INSTALL/hardware/framework16.sh"
 run_logged "$OMARCHY_INSTALL/hardware/dell-xps-touchpad-haptics.sh"
 run_logged "$OMARCHY_INSTALL/hardware/surface.sh"
+run_logged "$OMARCHY_INSTALL/hardware/surface-touch.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/network.sh"
 run_logged "$OMARCHY_INSTALL/hardware/input-group.sh"

--- a/install/hardware/pacman.sh
+++ b/install/hardware/pacman.sh
@@ -1,8 +1,22 @@
 # Hardware-specific pacman repository extensions that must survive the final
 # pacman.conf restore.
+
+pacman_conf=${OMARCHY_PACMAN_CONF:-/etc/pacman.conf}
+
+# Touchscreen support on IPTS-era Surfaces installs the linux-surface kernel
+# (see surface-touch.sh); its repository has to be restored here too or future
+# kernel updates would fail.
+if omarchy-hw-surface && ! grep -q '^\[linux-surface\]' "$pacman_conf"; then
+  cat >> "$pacman_conf" <<'EOF'
+
+[linux-surface]
+Server = https://pkg.surfacelinux.com/arch/
+EOF
+fi
+
 if lspci -nn | grep "106b:180[12]" >/dev/null; then
-  if ! grep -q '^\[arch-mact2\]' /etc/pacman.conf; then
-    cat >> /etc/pacman.conf <<'EOF'
+  if ! grep -q '^\[arch-mact2\]' "$pacman_conf"; then
+    cat >> "$pacman_conf" <<'EOF'
 
 [arch-mact2]
 Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release

--- a/install/hardware/pacman.sh
+++ b/install/hardware/pacman.sh
@@ -5,8 +5,9 @@ pacman_conf=${OMARCHY_PACMAN_CONF:-/etc/pacman.conf}
 
 # Touchscreen support on IPTS-era Surfaces installs the linux-surface kernel
 # (see surface-touch.sh); its repository has to be restored here too or future
-# kernel updates would fail.
-if omarchy-hw-surface && ! grep -q '^\[linux-surface\]' "$pacman_conf"; then
+# kernel updates would fail. Gate on the package instead of the hardware so a
+# Secure Boot skip never leaves a third-party repository without its key.
+if omarchy-hw-surface && omarchy-pkg-present linux-surface && ! grep -q '^\[linux-surface\]' "$pacman_conf"; then
   cat >> "$pacman_conf" <<'EOF'
 
 [linux-surface]

--- a/install/hardware/surface-touch.sh
+++ b/install/hardware/surface-touch.sh
@@ -19,16 +19,18 @@ if omarchy-hw-surface; then
   # The efivarfs variable holds a 4-byte attributes header followed by the
   # actual 1-byte enabled flag, so read the byte at offset 4. The surface
   # kernel is not signed with Microsoft keys, so skip when Secure Boot would
-  # refuse to boot it.
+  # refuse to boot it. Hardware leaves run without pipefail, so a failed or
+  # short read would surface as an empty value: fail closed on anything that
+  # is not a definite 0 or 1.
   secure_boot_var="$(compgen -G "$efivars_dir/SecureBoot-*" | head -1)"
-  secure_boot=0
+  secure_boot=""
   if [[ -n $secure_boot_var ]]; then
     secure_boot="$(dd if=$secure_boot_var bs=1 skip=4 count=1 status=none | od -An -tu1 | tr -d '[:space:]')"
   fi
 
   if [[ $secure_boot == "1" ]]; then
     echo "Secure Boot is enabled: skipping linux-surface install (touch will not work)."
-  else
+  elif [[ $secure_boot == "0" ]]; then
     # Trust the linux-surface package signing key before installing from the
     # repository, so package signatures verify on first use.
     if ! pacman-key --list-keys 56C464BAAC421453 &>/dev/null; then
@@ -61,5 +63,7 @@ EOF
 # available in the menu for touchscreen support.
 BOOT_ORDER="linux, linux-surface*, *fallback, Snapshots"
 EOF
+  else
+    echo "Could not determine the Secure Boot state: skipping linux-surface install (touch will not work)."
   fi
 fi

--- a/install/hardware/surface-touch.sh
+++ b/install/hardware/surface-touch.sh
@@ -1,0 +1,50 @@
+# Touchscreen support for Surface devices with IPTS digitizers.
+# The stock kernel has no driver for Intel's Precise Touch & Stylus (IPTS)
+# subsystem, so on Surface Pro 4 and newer (plus Laptop Studio and Go 3+)
+# the touchscreen never appears as an input device. Install the linux-surface
+# kernel alongside the stock one from the project's signed repository;
+# iptsd then decodes touch input and starts on demand via udev rules.
+#
+# Scoped to all Surface devices for now: on models whose touch already works
+# with the stock kernel the extra kernel is unused but harmless, since the
+# stock kernel stays installed and selectable.
+if omarchy-hw-surface; then
+  echo "Detected Surface device, installing linux-surface kernel for touchscreen support..."
+
+  # The surface kernel is not signed with Microsoft keys, so skip when Secure
+  # Boot would refuse to boot it.
+  secure_boot="$(od -An -t1 /sys/firmware/efi/efivars/SecureBoot-* 2>/dev/null | tr -dc '0-9')"
+  if [[ $secure_boot == "1" ]]; then
+    echo "Secure Boot is enabled: skipping linux-surface install (touch will not work)."
+  else
+    # Trust the linux-surface package signing key before the repo lands,
+    # so the first install against it can verify signatures.
+    if ! pacman-key --list-keys 56C464BAAC421453 &>/dev/null; then
+      curl -fsSL https://raw.githubusercontent.com/linux-surface/linux-surface/master/pkg/keys/surface.asc | pacman-key --add -
+    fi
+    pacman-key --lsign-key 56C464BAAC421453
+
+    if ! grep -q '^\[linux-surface\]' /etc/pacman.conf; then
+      cat >> /etc/pacman.conf <<'EOF'
+
+[linux-surface]
+Server = https://pkg.surfacelinux.com/arch/
+EOF
+      # Sync the freshly added repo database before installing from it.
+      pacman -Sy --noconfirm
+    fi
+
+    omarchy-pkg-add linux-surface linux-surface-headers iptsd
+
+    # Boot the surface kernel by default so touch works out of the box; the
+    # stock kernel remains installed and selectable. Named to sort after
+    # omarchy-defaults.conf: drop-ins are read in order and the last
+    # BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.
+    mkdir -p /etc/limine-entry-tool.d
+    rm -f /etc/limine-entry-tool.d/surface-touch.conf
+    cat > /etc/limine-entry-tool.d/zz-surface-touch.conf <<'EOF'
+# Prefer the linux-surface kernel at boot on Surface devices
+BOOT_ORDER="linux-surface*, linux*, *fallback, Snapshots"
+EOF
+  fi
+fi

--- a/install/hardware/surface-touch.sh
+++ b/install/hardware/surface-touch.sh
@@ -8,30 +8,44 @@
 # Scoped to all Surface devices for now: on models whose touch already works
 # with the stock kernel the extra kernel is unused but harmless, since the
 # stock kernel stays installed and selectable.
+
+pacman_conf=${OMARCHY_PACMAN_CONF:-/etc/pacman.conf}
+efivars_dir=${OMARCHY_EFIVARS_DIR:-/sys/firmware/efi/efivars}
+entry_tool_dir=${OMARCHY_LIMINE_ENTRY_TOOL_DIR:-/etc/limine-entry-tool.d}
+
 if omarchy-hw-surface; then
   echo "Detected Surface device, installing linux-surface kernel for touchscreen support..."
 
-  # The surface kernel is not signed with Microsoft keys, so skip when Secure
-  # Boot would refuse to boot it.
-  secure_boot="$(od -An -t1 /sys/firmware/efi/efivars/SecureBoot-* 2>/dev/null | tr -dc '0-9')"
+  # The efivarfs variable holds a 4-byte attributes header followed by the
+  # actual 1-byte enabled flag, so read the byte at offset 4. The surface
+  # kernel is not signed with Microsoft keys, so skip when Secure Boot would
+  # refuse to boot it.
+  secure_boot_var="$(compgen -G "$efivars_dir/SecureBoot-*" | head -1)"
+  secure_boot=0
+  if [[ -n $secure_boot_var ]]; then
+    secure_boot="$(dd if=$secure_boot_var bs=1 skip=4 count=1 status=none | od -An -tu1 | tr -d '[:space:]')"
+  fi
+
   if [[ $secure_boot == "1" ]]; then
     echo "Secure Boot is enabled: skipping linux-surface install (touch will not work)."
   else
-    # Trust the linux-surface package signing key before the repo lands,
-    # so the first install against it can verify signatures.
+    # Trust the linux-surface package signing key before installing from the
+    # repository, so package signatures verify on first use.
     if ! pacman-key --list-keys 56C464BAAC421453 &>/dev/null; then
       curl -fsSL https://raw.githubusercontent.com/linux-surface/linux-surface/master/pkg/keys/surface.asc | pacman-key --add -
     fi
     pacman-key --lsign-key 56C464BAAC421453
 
-    if ! grep -q '^\[linux-surface\]' /etc/pacman.conf; then
-      cat >> /etc/pacman.conf <<'EOF'
+    if ! grep -q '^\[linux-surface\]' "$pacman_conf"; then
+      cat >> "$pacman_conf" <<'EOF'
 
 [linux-surface]
 Server = https://pkg.surfacelinux.com/arch/
 EOF
-      # Sync the freshly added repo database before installing from it.
-      pacman -Sy --noconfirm
+      # Full sync so the freshly added repository database exists and the
+      # following install cannot run against mismatched mirrors as a partial
+      # upgrade.
+      pacman -Syu --noconfirm
     fi
 
     omarchy-pkg-add linux-surface linux-surface-headers iptsd
@@ -40,9 +54,9 @@ EOF
     # kernel selectable for when touch support is wanted. Named to sort after
     # omarchy-defaults.conf: drop-ins are read in order and the last
     # BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.
-    mkdir -p /etc/limine-entry-tool.d
-    rm -f /etc/limine-entry-tool.d/surface-touch.conf
-    cat > /etc/limine-entry-tool.d/zz-surface-touch.conf <<'EOF'
+    mkdir -p "$entry_tool_dir"
+    rm -f "$entry_tool_dir/surface-touch.conf"
+    cat > "$entry_tool_dir/zz-surface-touch.conf" <<'EOF'
 # Keep the stock kernel first on Surface devices; linux-surface stays
 # available in the menu for touchscreen support.
 BOOT_ORDER="linux, linux-surface*, *fallback, Snapshots"

--- a/install/hardware/surface-touch.sh
+++ b/install/hardware/surface-touch.sh
@@ -36,15 +36,16 @@ EOF
 
     omarchy-pkg-add linux-surface linux-surface-headers iptsd
 
-    # Boot the surface kernel by default so touch works out of the box; the
-    # stock kernel remains installed and selectable. Named to sort after
+    # Keep the stock kernel as the default boot entry and leave the surface
+    # kernel selectable for when touch support is wanted. Named to sort after
     # omarchy-defaults.conf: drop-ins are read in order and the last
     # BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.
     mkdir -p /etc/limine-entry-tool.d
     rm -f /etc/limine-entry-tool.d/surface-touch.conf
     cat > /etc/limine-entry-tool.d/zz-surface-touch.conf <<'EOF'
-# Prefer the linux-surface kernel at boot on Surface devices
-BOOT_ORDER="linux-surface*, linux*, *fallback, Snapshots"
+# Keep the stock kernel first on Surface devices; linux-surface stays
+# available in the menu for touchscreen support.
+BOOT_ORDER="linux, linux-surface*, *fallback, Snapshots"
 EOF
   fi
 fi

--- a/test/shell.d/surface-touch-hardware-test.sh
+++ b/test/shell.d/surface-touch-hardware-test.sh
@@ -48,18 +48,18 @@ marker="$(dirname -- "$TEST_LOG")/surface-key-imported"
 
 case "$1" in
 --list-keys)
-	# Exit status of the marker check is whether the key exists yet.
-	[[ -f $marker ]]
-	;;
+  # Exit status of the marker check is whether the key exists yet.
+  [[ -f $marker ]]
+  ;;
 *)
-	printf 'pacman-key' >>"$TEST_LOG"
-	printf '\t%s' "$@" >>"$TEST_LOG"
-	printf '\n' >>"$TEST_LOG"
-	if [[ $1 == "--add" ]]; then
-		touch "$marker"
-	fi
-	exit 0
-	;;
+  printf 'pacman-key' >>"$TEST_LOG"
+  printf '\t%s' "$@" >>"$TEST_LOG"
+  printf '\n' >>"$TEST_LOG"
+  if [[ $1 == "--add" ]]; then
+    touch "$marker"
+  fi
+  exit 0
+  ;;
 esac
 SH
 

--- a/test/shell.d/surface-touch-hardware-test.sh
+++ b/test/shell.d/surface-touch-hardware-test.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/surface-touch.sh"
+pacman_hardware="$ROOT/install/hardware/pacman.sh"
+all_hardware="$ROOT/install/hardware/all.sh"
+defaults_conf="$ROOT/etc/limine-entry-tool.d/omarchy-defaults.conf"
+
+# The hardware leaf is wired into the install flow right after surface.sh.
+grep -Fq 'run_logged "$OMARCHY_INSTALL/hardware/surface-touch.sh"' "$all_hardware" ||
+  fail "surface-touch.sh runs from the hardware install flow"
+grep -A1 'run_logged "$OMARCHY_INSTALL/hardware/surface.sh"' "$all_hardware" | grep -q 'surface-touch' ||
+  fail "surface-touch.sh runs directly after surface.sh"
+# The repository must be restored after the final pacman.conf restore.
+grep -Fq 'linux-surface' "$pacman_hardware" ||
+  fail "pacman.sh persists the linux-surface repository across the conf restore"
+grep -Fq 'omarchy-pkg-add linux-surface linux-surface-headers iptsd' "$leaf" ||
+  fail "the leaf installs kernel, headers, and iptsd together"
+# Regression guard: the Secure Boot flag lives past the 4-byte attributes
+# header of an efivarfs variable, and od needs an explicit type.
+grep -Fq 'bs=1 skip=4 count=1 status=none | od -An -tu1' "$leaf" ||
+  fail "Secure Boot reads the enabled byte at offset 4 of the efivarfs variable"
+pass "surface-touch install flow wiring looks correct"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-hw-surface" <<'SH'
+#!/bin/bash
+
+(( ${SURFACE_HARDWARE:-0} == 1 ))
+SH
+
+cat >"$stub_bin/pacman-key" <<'SH'
+#!/bin/bash
+
+# Simulate keyring state: the key shows up in --list-keys only after an
+# --add has happened through this stub.
+marker="$(dirname -- "$TEST_LOG")/surface-key-imported"
+
+case "$1" in
+--list-keys)
+	# Exit status of the marker check is whether the key exists yet.
+	[[ -f $marker ]]
+	;;
+*)
+	printf 'pacman-key' >>"$TEST_LOG"
+	printf '\t%s' "$@" >>"$TEST_LOG"
+	printf '\n' >>"$TEST_LOG"
+	if [[ $1 == "--add" ]]; then
+		touch "$marker"
+	fi
+	exit 0
+	;;
+esac
+SH
+
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+
+printf 'curl\tkey-import\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/pacman" <<'SH'
+#!/bin/bash
+
+printf 'pacman' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+pacman_conf="$test_tmp/pacman.conf"
+efivars="$test_tmp/efivars"
+entry_tool_dir="$test_tmp/limine-entry-tool.d"
+mkdir -p "$efivars" "$entry_tool_dir"
+
+cat >"$pacman_conf" <<'EOF'
+[options]
+HoldPkg = pacman glibc
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+EOF
+
+run_leaf() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    SURFACE_HARDWARE=$1 \
+    OMARCHY_PACMAN_CONF="$pacman_conf" \
+    OMARCHY_EFIVARS_DIR="$efivars" \
+    OMARCHY_LIMINE_ENTRY_TOOL_DIR="$entry_tool_dir" \
+    bash -eE -c 'source "$1"' bash "$leaf" >/dev/null
+}
+
+secure_boot_var="$efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+# Non-Surface hardware: nothing is configured or installed.
+printf '\x06\x00\x00\x00\x00' >"$secure_boot_var"
+: >"$calls"
+run_leaf 0
+[[ ! -s $calls ]] || fail "a non-Surface device is left alone" "$(cat "$calls")"
+grep -q '^\[linux-surface\]' "$pacman_conf" &&
+  fail "no repository is added on non-Surface hardware"
+[[ ! -f $entry_tool_dir/zz-surface-touch.conf ]] ||
+  fail "no boot order drop-in lands on non-Surface hardware"
+pass "non-Surface devices are skipped entirely"
+
+# Secure Boot enabled: the unsigned surface kernel would not boot.
+printf '\x06\x00\x00\x00\x01' >"$secure_boot_var"
+: >"$calls"
+run_leaf 1
+! grep -Fq 'omarchy-pkg-add' "$calls" ||
+  fail "no packages are installed while Secure Boot blocks the kernel"
+! grep -q '^\[linux-surface\]' "$pacman_conf" ||
+  fail "no repository is added while Secure Boot blocks the kernel"
+[[ ! -f $entry_tool_dir/zz-surface-touch.conf ]] ||
+  fail "no boot order drop-in lands while Secure Boot blocks the kernel"
+pass "enabled Secure Boot skips the surface kernel install"
+
+# Surface with Secure Boot off: key trust, repository, packages, boot order.
+printf '\x06\x00\x00\x00\x00' >"$secure_boot_var"
+: >"$calls"
+run_leaf 1
+grep -Fq $'curl\tkey-import' "$calls" ||
+  fail "imports the linux-surface signing key before installing"
+grep -Fq $'pacman-key\t--lsign-key\t56C464BAAC421453' "$calls" ||
+  fail "locally signs the linux-surface signing key"
+grep -q '^\[linux-surface\]' "$pacman_conf" ||
+  fail "adds the linux-surface repository"
+grep -A1 '^\[linux-surface\]' "$pacman_conf" | grep -Fq 'Server = https://pkg.surfacelinux.com/arch/' ||
+  fail "points the linux-surface repository at pkg.surfacelinux.com"
+grep -Fq $'pacman\t-Syu\t--noconfirm' "$calls" ||
+  fail "full-syncs after adding the repository instead of a partial refresh"
+grep -Fq $'omarchy-pkg-add\tlinux-surface\tlinux-surface-headers\tiptsd' "$calls" ||
+  fail "installs the surface kernel, headers, and iptsd"
+grep -Fq 'BOOT_ORDER="linux, linux-surface*, *fallback, Snapshots"' "$entry_tool_dir/zz-surface-touch.conf" ||
+  fail "boot order keeps the stock kernel first and the surface kernel available"
+pass "Surface setup trusts the key, adds the repo, installs, and orders boot entries"
+
+# Rerunning stays idempotent: no duplicated config sections, drop-ins, or
+# redundant key imports.
+before_dropin=$(cat "$entry_tool_dir/zz-surface-touch.conf")
+run_leaf 1
+(( $(grep -c '^\[linux-surface\]' "$pacman_conf") == 1 )) ||
+  fail "reruns do not duplicate the linux-surface repository entry"
+[[ $(cat "$entry_tool_dir/zz-surface-touch.conf") == "$before_dropin" ]] ||
+  fail "reruns leave the boot order drop-in unchanged"
+(( $(grep -c 'curl' "$calls") == 1 )) ||
+  fail "an imported signing key is not re-downloaded on reruns"
+pass "reruns are idempotent"
+
+# The persisted repository survives a post-install pacman.conf restore.
+: >"$calls"
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  SURFACE_HARDWARE=1 \
+  OMARCHY_PACMAN_CONF="$pacman_conf" \
+  bash -eE -c 'source "$1"' bash "$pacman_hardware" >/dev/null
+cp -f "$pacman_conf" "$pacman_conf.restored"
+rm -f "$pacman_conf"
+mv "$pacman_conf.restored" "$pacman_conf"
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  SURFACE_HARDWARE=1 \
+  OMARCHY_PACMAN_CONF="$pacman_conf" \
+  bash -eE -c 'source "$1"' bash "$pacman_hardware" >/dev/null
+grep -q '^\[linux-surface\]' "$pacman_conf" ||
+  fail "pacman.sh re-adds the linux-surface repository after a conf restore"
+(( $(grep -c '^\[linux-surface\]' "$pacman_conf") == 1 )) ||
+  fail "pacman.sh does not duplicate the linux-surface repository entry"
+pass "the linux-surface repository survives the final pacman.conf restore"

--- a/test/shell.d/surface-touch-hardware-test.sh
+++ b/test/shell.d/surface-touch-hardware-test.sh
@@ -85,6 +85,12 @@ printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
 SH
 
+cat >"$stub_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+
+(( ${SURFACE_KERNEL_INSTALLED:-0} == 1 ))
+SH
+
 chmod +x "$stub_bin"/*
 
 pacman_conf="$test_tmp/pacman.conf"
@@ -135,6 +141,17 @@ run_leaf 1
   fail "no boot order drop-in lands while Secure Boot blocks the kernel"
 pass "enabled Secure Boot skips the surface kernel install"
 
+# An unreadable or truncated efivar leaves the Secure Boot state unknown;
+# installing an unbootable kernel would be worse than skipping it.
+printf '\x06\x00' >"$secure_boot_var"
+: >"$calls"
+run_leaf 1
+! grep -Fq 'omarchy-pkg-add' "$calls" ||
+  fail "an undecidable Secure Boot state does not install the kernel"
+[[ ! -f $entry_tool_dir/zz-surface-touch.conf ]] ||
+  fail "an undecidable Secure Boot state creates no boot order drop-in"
+pass "undecidable Secure Boot state fails closed"
+
 # Surface with Secure Boot off: key trust, repository, packages, boot order.
 printf '\x06\x00\x00\x00\x00' >"$secure_boot_var"
 : >"$calls"
@@ -167,23 +184,41 @@ run_leaf 1
   fail "an imported signing key is not re-downloaded on reruns"
 pass "reruns are idempotent"
 
-# The persisted repository survives a post-install pacman.conf restore.
+# The persisted repository survives a post-install pacman.conf restore: start
+# from a pristine configuration without the entry, as the final restore
+# produces, then verify restoration and idempotence against it.
+cat >"$pacman_conf" <<'EOF'
+[options]
+HoldPkg = pacman glibc
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+EOF
+
+run_pacman_hardware() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    SURFACE_HARDWARE=$1 \
+    SURFACE_KERNEL_INSTALLED=$2 \
+    OMARCHY_PACMAN_CONF="$pacman_conf" \
+    bash -eE -c 'source "$1"' bash "$pacman_hardware" >/dev/null
+}
+
+# A Secure Boot skip never installed the kernel, so its repository must not
+# appear either.
 : >"$calls"
-PATH="$stub_bin:$PATH" \
-  TEST_LOG="$calls" \
-  SURFACE_HARDWARE=1 \
-  OMARCHY_PACMAN_CONF="$pacman_conf" \
-  bash -eE -c 'source "$1"' bash "$pacman_hardware" >/dev/null
-cp -f "$pacman_conf" "$pacman_conf.restored"
-rm -f "$pacman_conf"
-mv "$pacman_conf.restored" "$pacman_conf"
-PATH="$stub_bin:$PATH" \
-  TEST_LOG="$calls" \
-  SURFACE_HARDWARE=1 \
-  OMARCHY_PACMAN_CONF="$pacman_conf" \
-  bash -eE -c 'source "$1"' bash "$pacman_hardware" >/dev/null
+run_pacman_hardware 1 0
+! grep -q '^\[linux-surface\]' "$pacman_conf" ||
+  fail "no repository is restored when the surface kernel is not installed"
+pass "Secure Boot skips keep the third-party repository away"
+
+run_pacman_hardware 1 1
 grep -q '^\[linux-surface\]' "$pacman_conf" ||
   fail "pacman.sh re-adds the linux-surface repository after a conf restore"
 (( $(grep -c '^\[linux-surface\]' "$pacman_conf") == 1 )) ||
   fail "pacman.sh does not duplicate the linux-surface repository entry"
+
+run_pacman_hardware 1 1
+(( $(grep -c '^\[linux-surface\]' "$pacman_conf") == 1 )) ||
+  fail "pacman.sh stays idempotent across reruns"
 pass "the linux-surface repository survives the final pacman.conf restore"


### PR DESCRIPTION
## Summary

Surface Pro 4 and newer (plus Laptop Studio, Go 3/4) use Intel's IPTS subsystem for their touchscreen. The stock kernel has no driver for it, so the touchscreen never appears as an input device on those devices. This adds an install-time hardware leaf that installs the [linux-surface](https://github.com/linux-surface/linux-surface) kernel alongside the stock one, plus `iptsd` which decodes touch input (started on demand via its udev rules).

- Imports and locally signs the linux-surface package signing key before installing from the repository, so signatures verify on first use
- Installs `linux-surface`, `linux-surface-headers` (DKMS readiness) and `iptsd` via `omarchy-pkg-add`
- Persists the `[linux-surface]` repository through `install/hardware/pacman.sh` so it survives the final `pacman.conf` restore and future kernel updates keep arriving
- Full `pacman -Syu` syncs the freshly added repository before installing, avoiding partial-upgrade states
- Adds a `/etc/limine-entry-tool.d/zz-surface-touch.conf` drop-in keeping the **stock kernel as the default boot entry**, with linux-surface selectable in the menu for when touch support is wanted
- Skips cleanly when Secure Boot is enabled (the surface kernel is not signed with Microsoft keys); reads the enabled flag from offset 4 of the efivarfs variable, past its 4-byte attributes header
- Wired into `install/hardware/all.sh` directly after `surface.sh`

Tested on real hardware: Surface Pro 7 running Omarchy; touchscreen works out of the box after selecting linux-surface at boot.

## Precedents followed

- Kernel swap + Limine boot order drop-in: pattern from `install/hardware/intel/ptl-kernel.sh`
- Third-party repo appended to `/etc/pacman.conf`: pattern from `install/hardware/pacman.sh`
- Key import + local sign: pattern from `bin/omarchy-update-keyring`

## Coverage

New `test/shell.d/surface-touch-hardware-test.sh` covers non-Surface detection, Secure Boot enabled/disabled, repository setup, idempotent boot-order creation, key re-import avoidance, and restore-survival of the repository entry.

Scoping is deliberately broad (all detected Surfaces): on models whose touch already works with mainline (Surface Laptop 1-5, Go 1/2, Surface 3) the second kernel is unused but harmless since the stock kernel stays installed and default. Happy to narrow via explicit model matching if preferred.