### PR TITLE
Sort agents by total usage

### DIFF
--- a/shell/plugins/agents/AgentsModel.js
+++ b/shell/plugins/agents/AgentsModel.js
@@ -1,0 +1,28 @@
+function numberValue(value) {
+  var parsed = Number(value)
+  return isFinite(parsed) ? parsed : 0
+}
+
+function totalTokens(provider) {
+  var total = 0
+  var models = provider.modelUsage || {}
+  for (var id in models) {
+    var usage = models[id] || {}
+    total += numberValue(usage.inputTokens)
+      + numberValue(usage.outputTokens)
+      + numberValue(usage.cacheReadInputTokens)
+      + numberValue(usage.cacheCreationInputTokens)
+  }
+  return total
+}
+
+function sortByUsage(providers) {
+  return providers.sort(function(a, b) {
+    return totalTokens(b) - totalTokens(a)
+      || numberValue(b.totalPrompts) - numberValue(a.totalPrompts)
+      || String(a.providerName || a.providerId).localeCompare(String(b.providerName || b.providerId))
+      || String(a.providerId).localeCompare(String(b.providerId))
+  })
+}
+
+if (typeof module !== "undefined") module.exports = { sortByUsage, totalTokens }

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import "AgentsModel.js" as AgentsModel
 
 // The display side of agent usage. All extraction lives behind
 // omarchy-agent-usage-update, which writes one JSON record per agent into
@@ -206,7 +207,8 @@ Item {
       var syncedDisplay = displayProvider({ id: syncedId, name: stats.providerName || syncedId })
       if (providerHasData(syncedDisplay)) result.push(syncedDisplay)
     }
-    return result
+    // Sort agents L-->R by usage
+    return AgentsModel.sortByUsage(result)
   }
 
   function providerEnabled(id) {

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -17,6 +17,13 @@ assertDeepEqual(agents.sortByUsage([
   { providerId: 'codex', providerName: 'Codex', totalPrompts: 10, modelUsage: { codex: { inputTokens: 50 } } },
   { providerId: 'fireworks', providerName: 'Fireworks', totalPrompts: 0, modelUsage: {} }
 ]).map(provider => provider.providerId), ['claude', 'codex', 'antigravity', 'fireworks'], 'agents sort left to right by total usage')
+assertDeepEqual(agents.sortByUsage([
+  { providerId: 'zeta', providerName: 'Zeta', totalPrompts: 1, modelUsage: { model: { inputTokens: 1 } } },
+  { providerId: 'same-b', providerName: 'Same', totalPrompts: 1, modelUsage: { model: { inputTokens: 1 } } },
+  { providerId: 'prompts', providerName: 'Prompts', totalPrompts: 2, modelUsage: { model: { inputTokens: 1 } } },
+  { providerId: 'alpha', providerName: 'Alpha', totalPrompts: 1, modelUsage: { model: { inputTokens: 1 } } },
+  { providerId: 'same-a', providerName: 'Same', totalPrompts: 1, modelUsage: { model: { inputTokens: 1 } } }
+]).map(provider => provider.providerId), ['prompts', 'alpha', 'same-a', 'same-b', 'zeta'], 'agents break usage ties by prompts, provider name, then id')
 assert(/import "AgentsModel\.js" as AgentsModel/.test(mainSource), 'agents panel imports its usage ordering model')
 assert(/return AgentsModel\.sortByUsage\(result\)/.test(mainSource), 'agents panel orders enabled providers by usage')
 

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -7,6 +7,18 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+const agents = requireFromRoot('shell/plugins/agents/AgentsModel.js')
+
+assertEqual(agents.totalTokens({ modelUsage: { model: { inputTokens: 1, outputTokens: 2, cacheReadInputTokens: 3, cacheCreationInputTokens: 4 } } }), 10, 'agents total every token category')
+assertDeepEqual(agents.sortByUsage([
+  { providerId: 'antigravity', providerName: 'Antigravity', totalPrompts: 4, modelUsage: { gemini: { inputTokens: 4 } } },
+  { providerId: 'claude', providerName: 'Claude Code', totalPrompts: 20, modelUsage: { claude: { inputTokens: 100 } } },
+  { providerId: 'codex', providerName: 'Codex', totalPrompts: 10, modelUsage: { codex: { inputTokens: 50 } } },
+  { providerId: 'fireworks', providerName: 'Fireworks', totalPrompts: 0, modelUsage: {} }
+]).map(provider => provider.providerId), ['claude', 'codex', 'antigravity', 'fireworks'], 'agents sort left to right by total usage')
+assert(/import "AgentsModel\.js" as AgentsModel/.test(mainSource), 'agents panel imports its usage ordering model')
+assert(/return AgentsModel\.sortByUsage\(result\)/.test(mainSource), 'agents panel orders enabled providers by usage')
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')


### PR DESCRIPTION
## Motivation

Agents panel currently sorts alphabetically. This is less useful as when you click it, you have to click multiple times to get to your most-used agent if it's not starting first. I thought it'd make more sense to sort by total usage L-->R.

Before — alphabetical:

![Agents panel before the change, with Antigravity first](https://raw.githubusercontent.com/data-goblin/omarchy/pr-assets/7861/before-agent-limits.png)

After — total usage:

![Agents panel after the change, with Claude Code first](https://raw.githubusercontent.com/data-goblin/omarchy/pr-assets/7861/after-agent-limits.png)

## Changes

- Sort agents by total token usage, falling back to prompts and provider name.
- Add focused tests for the ordering and QML wiring.

## Verification

- `bash test/shell.d/agents-panel-test.sh` passes all 11 assertions.
- `qmllint shell/plugins/agents/Main.qml` passes.

Thanks!

---

Disclaimer: The code in this PR was AI generated (Codex; GPT-5.6-sol max) and tested.
