### PR TITLE
Add a native Pomodoro timer to the shell

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -116,6 +116,7 @@ tensaku
 sddm
 slurp
 socat
+sound-theme-freedesktop
 starship
 sushi
 system-config-printer

--- a/migrations/1787487615.sh
+++ b/migrations/1787487615.sh
@@ -1,0 +1,2 @@
+echo "Install freedesktop sound theme for Omarchy plugin alarms"
+omarchy-pkg-add sound-theme-freedesktop

--- a/shell/plugins/panels/pomodoro/Model.js
+++ b/shell/plugins/panels/pomodoro/Model.js
@@ -1,0 +1,26 @@
+
+function advancePhase(phase, completedSessions, sessionsBeforeLongBreak, completed) {
+  if (phase === "custom") {
+    return "focus"
+  }
+  if (phase === "focus") {
+    if (completed && completedSessions > 0 && completedSessions % sessionsBeforeLongBreak === 0) {
+      return "longBreak"
+    }
+    return "shortBreak"
+  }
+  return "focus"
+}
+
+function getPhaseSecs(phase, focusSecs, shortBreakSecs, longBreakSecs, customMinutes) {
+  if (phase === "focus") return focusSecs
+  if (phase === "shortBreak") return shortBreakSecs
+  if (phase === "longBreak") return longBreakSecs
+  if (phase === "custom") return customMinutes * 60
+  return focusSecs
+}
+
+// Ensure Node.js can require this for testing
+if (typeof module !== 'undefined') {
+  module.exports = { advancePhase, getPhaseSecs }
+}

--- a/shell/plugins/panels/pomodoro/Panel.qml
+++ b/shell/plugins/panels/pomodoro/Panel.qml
@@ -1,0 +1,369 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+
+Panel {
+  id: root
+  moduleName: "omarchy.pomodoro"
+  ipcTarget: "omarchy.pomodoro"
+
+  manageIpc: false
+
+  IpcHandler {
+    target: "omarchy.pomodoro"
+    function open() { root.open() }
+    function close() { root.close() }
+    function toggle() { root.toggle() }
+    function start() { if (root.service) root.service.start() }
+    function pause() { if (root.service) root.service.pause() }
+    function reset() { root.stop() }
+    function skip() { root.skip() }
+  }
+
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  readonly property var service: bar && bar.shell ? (bar.shell.serviceFor("omarchy.pomodoro")) : null
+
+  onSettingsChanged: {
+    if (root.service) root.service.settings = root.settings
+  }
+
+  readonly property color foreground: bar ? bar.foreground : Color.foreground
+  readonly property color urgent: bar ? bar.urgent : Color.urgent
+  readonly property color dim: Qt.darker(foreground, 1.55)
+  readonly property color surface: Color.popups.background
+  readonly property color track: Style.selectedFillFor(foreground, Color.accent)
+  readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+
+  readonly property string phase: root.service ? root.service.phase : "focus"
+  readonly property bool running: root.service ? root.service.running : false
+  readonly property int remainingSecs: root.service ? root.service.remainingSecs : 0
+  readonly property int totalSecs: root.service ? root.service.totalSecs : 0
+  readonly property int completedSessions: root.service ? root.service.completedSessions : 0
+  readonly property int customMinutes: root.service ? root.service.customMinutes : 10
+
+  readonly property string phaseLabel: root.service ? root.service.phaseLabel : ""
+  readonly property string timeText: root.service ? root.service.timeText : "00:00"
+  readonly property real progress: root.service ? root.service.progress : 0
+  readonly property bool alarming: root.service ? root.service.alarming : false
+
+  function startPause() {
+    if (!root.service) return
+    if (root.running) root.service.pause()
+    else root.service.start(0)
+  }
+
+  function stop() { if (root.service) root.service.reset() }
+  function skip() { if (root.service) root.service.skip() }
+  function setCustom(m) { if (root.service) root.service.setCustom(m) }
+
+  function switchPhase(newPhase) {
+    if (!root.service) return
+    root.service.running = false
+    root.service.phase = newPhase
+    if (newPhase === "focus") root.service.totalSecs = root.service.focusSecs
+    else if (newPhase === "shortBreak") root.service.totalSecs = root.service.shortBreakSecs
+    else if (newPhase === "longBreak") root.service.totalSecs = root.service.longBreakSecs
+    root.service.remainingSecs = root.service.totalSecs
+  }
+
+  // ---- bar slot ----------------------------------------------------------
+  WidgetButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    text: {
+      var icon = root.phase === "shortBreak" || root.phase === "longBreak" ? "󰒲" : "󰔟"
+      if (root.bar && root.bar.vertical) return icon
+      return root.running || root.remainingSecs !== root.totalSecs ? (icon + " " + root.timeText) : icon
+    }
+    tooltipText: root.phaseLabel
+    active: root.running || root.alarming
+    horizontalMargin: 7.5
+
+    onPressed: function(b) {
+      if (b === Qt.LeftButton) root.toggle()
+    }
+  }
+
+  // ---- dropdown panel ----------------------------------------------------
+  KeyboardPanel {
+    id: panel
+    anchorItem: button
+    owner: root
+    bar: root.bar
+    open: root.opened
+    focusTarget: keyCatcher
+    contentWidth: panel.fittedContentWidth(Style.space(320))
+    contentHeight: panel.fittedContentHeight(column.implicitHeight, Style.space(560))
+
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+      blocked: customField.field.activeFocus
+
+      onActivateRequested: root.startPause()
+      onCloseRequested: root.close()
+      onTabRequested: function(direction) { root.switchPanel(direction) }
+      onTextKey: function(t) {
+        if (t === "s" || t === "S") root.startPause()
+        else if (t === "r" || t === "R") root.stop()
+        else if (t === "n" || t === "N") root.skip()
+        else if (t === "1") root.switchPhase("focus")
+        else if (t === "2") root.switchPhase("shortBreak")
+        else if (t === "3") root.switchPhase("longBreak")
+        else if (t === "c" || t === "C") customField.field.forceActiveFocus()
+      }
+
+      ScrollView {
+        id: scroll
+        anchors.fill: parent
+        contentWidth: availableWidth
+        clip: true
+
+        Column {
+          id: column
+          width: parent.width
+          spacing: Style.space(14)
+
+          // Timer display
+          Item {
+            width: parent.width
+            implicitHeight: heroCol.implicitHeight
+
+            Column {
+              id: heroCol
+              width: parent.width
+              spacing: Style.space(4)
+
+              Text {
+                width: parent.width
+                text: root.phaseLabel.toUpperCase()
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+                font.letterSpacing: 1.2
+                horizontalAlignment: Text.AlignHCenter
+              }
+
+              Text {
+                width: parent.width
+                text: root.timeText
+                color: root.alarming ? root.urgent : root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Math.round(Style.font.displayLarge * 1.5)
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+
+                Behavior on color { ColorAnimation { duration: 200 } }
+              }
+
+              Text {
+                width: parent.width
+                text: root.completedSessions > 0
+                  ? root.completedSessions + " session" + (root.completedSessions > 1 ? "s" : "") + " completed"
+                  : "Ready to focus"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                horizontalAlignment: Text.AlignHCenter
+              }
+            }
+          }
+
+          // Progress track
+          Item {
+            width: parent.width
+            height: Style.space(4)
+
+            Rectangle {
+              anchors.fill: parent
+              radius: height / 2
+              color: root.track
+              opacity: 0.3
+            }
+
+            Rectangle {
+              width: parent.width * root.progress
+              height: parent.height
+              radius: height / 2
+              color: root.alarming ? root.urgent : root.foreground
+
+              Behavior on width {
+                NumberAnimation { duration: 400; easing.type: Easing.OutCubic }
+              }
+            }
+          }
+
+          Row {
+            width: parent.width
+            spacing: Style.space(6)
+            property real cellWidth: (width - spacing * 2) / 3
+
+            Button {
+              width: parent.cellWidth
+              iconText: root.running ? "󰏤" : "󰐊"
+              text: root.running ? "Pause" : "Start"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+              bordered: true
+              accent: root.running ? root.foreground : root.urgent
+              onClicked: root.startPause()
+            }
+
+            Button {
+              width: parent.cellWidth
+              iconText: "󰒭"
+              text: "Skip"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+              bordered: true
+              onClicked: root.skip()
+            }
+
+            Button {
+              width: parent.cellWidth
+              iconText: "󰑐"
+              text: "Reset"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+              bordered: true
+              onClicked: root.stop()
+            }
+          }
+
+          PanelSeparator { foreground: root.foreground }
+
+          PanelSectionHeader {
+            text: "MODES"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+
+          Row {
+            width: parent.width
+            spacing: Style.space(6)
+            property real cellWidth: (width - spacing * 2) / 3
+
+            Button {
+              width: parent.cellWidth
+              text: "Focus"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+              bordered: true
+              selected: root.phase === "focus"
+              onClicked: root.switchPhase("focus")
+            }
+
+            Button {
+              width: parent.cellWidth
+              text: "Short"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+              bordered: true
+              selected: root.phase === "shortBreak"
+              onClicked: root.switchPhase("shortBreak")
+            }
+
+            Button {
+              width: parent.cellWidth
+              text: "Long"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+              bordered: true
+              selected: root.phase === "longBreak"
+              onClicked: root.switchPhase("longBreak")
+            }
+          }
+
+          PanelSeparator { foreground: root.foreground }
+
+          PanelSectionHeader {
+            text: "CUSTOM TIMER"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+
+          Row {
+            width: parent.width
+            spacing: Style.space(6)
+
+            NumberField {
+              id: customField
+              value: root.customMinutes
+              from: 1
+              to: 999
+              stepSize: 1
+              foreground: root.foreground
+              accent: root.track
+              fontFamily: root.fontFamily
+              fontSize: Style.font.body
+              onModified: function(v) { if (root.service) root.service.customMinutes = v }
+
+              field.Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Escape) {
+                  keyCatcher.forceActiveFocus()
+                  event.accepted = true
+                } else if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+                  keyCatcher.forceActiveFocus()
+                  root.switchPanel(event.key === Qt.Key_Backtab ? "previous" : "next")
+                  event.accepted = true
+                } else if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
+                  root.setCustom(customField.value)
+                  keyCatcher.forceActiveFocus()
+                  event.accepted = true
+                }
+              }
+            }
+
+            Button {
+              width: parent.width - customField.width - parent.spacing
+              height: customField.height
+              iconText: "󰐊"
+              text: "Start Timer"
+              fontSize: Style.font.bodySmall
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              horizontalPadding: Style.spacing.controlPaddingX
+              bordered: true
+              active: root.phase === "custom"
+              onClicked: root.setCustom(customField.value)
+            }
+          }
+
+          Text {
+            width: parent.width
+            text: "S start/pause · N skip · R reset\n1/2/3 modes · C custom · Enter start"
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            horizontalAlignment: Text.AlignHCenter
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/panels/pomodoro/Service.qml
+++ b/shell/plugins/panels/pomodoro/Service.qml
@@ -1,0 +1,143 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import "Model.js" as Model
+
+Item {
+  id: root
+
+  property var shell: null
+  property var settings: ({})
+
+  function setting(name, fallback, min, max) {
+    var value = settings ? settings[name] : undefined
+    value = value === undefined || value === null ? fallback : value
+    if (min !== undefined) value = Math.max(min, value)
+    if (max !== undefined) value = Math.min(max, value)
+    return value
+  }
+
+  readonly property int focusSecs: setting("focusMinutes", 25, 1, 120) * 60
+  readonly property int shortBreakSecs: setting("shortBreakMinutes", 5, 1, 60) * 60
+  readonly property int longBreakSecs: setting("longBreakMinutes", 15, 1, 120) * 60
+  readonly property int sessionsBeforeLong: setting("sessionsBeforeLongBreak", 4, 1, 10)
+
+  onFocusSecsChanged: { if (!running && phase === "focus") { totalSecs = focusSecs; remainingSecs = focusSecs; } }
+  onShortBreakSecsChanged: { if (!running && phase === "shortBreak") { totalSecs = shortBreakSecs; remainingSecs = shortBreakSecs; } }
+  onLongBreakSecsChanged: { if (!running && phase === "longBreak") { totalSecs = longBreakSecs; remainingSecs = longBreakSecs; } }
+
+  property string phase: "focus"
+  property int totalSecs: focusSecs
+  property int remainingSecs: focusSecs
+  property bool running: false
+  property int completedSessions: 0
+  property int customMinutes: 10
+
+  property double targetTimeMs: 0
+  
+  // Human-readable helpers
+  readonly property string phaseLabel: phase === "focus" ? "Focus"
+    : phase === "shortBreak" ? "Short Break"
+    : phase === "longBreak" ? "Long Break"
+    : "Custom Timer"
+
+  readonly property string timeText: {
+    var m = Math.floor(remainingSecs / 60)
+    var s = remainingSecs % 60
+    return (m < 10 ? "0" : "") + m + ":" + (s < 10 ? "0" : "") + s
+  }
+
+  readonly property real progress: totalSecs > 0
+    ? 1.0 - (remainingSecs / totalSecs) : 0
+
+  readonly property bool alarming: running && remainingSecs <= 30
+
+  function start(duration) {
+    if (!running) {
+      if (duration) {
+        remainingSecs = duration
+        totalSecs = duration
+      }
+      targetTimeMs = Date.now() + (remainingSecs * 1000)
+      running = true
+    }
+  }
+
+  function pause() {
+    running = false
+  }
+
+  function skip() {
+    running = false
+    advancePhase(false)
+  }
+
+  function reset() {
+    running = false
+    phase = "focus"
+    completedSessions = 0
+    totalSecs = focusSecs
+    remainingSecs = focusSecs
+  }
+
+  function setCustom(mins) {
+    running = false
+    customMinutes = mins
+    phase = "custom"
+    totalSecs = mins * 60
+    remainingSecs = mins * 60
+    start(0)
+  }
+
+  function advancePhase(completed) {
+    var previousPhase = phase
+    if (completed && phase === "focus") {
+      completedSessions++
+    }
+    phase = Model.advancePhase(previousPhase, completedSessions, sessionsBeforeLong, completed)
+    totalSecs = Model.getPhaseSecs(phase, focusSecs, shortBreakSecs, longBreakSecs, customMinutes)
+    remainingSecs = totalSecs
+  }
+
+  Process {
+    id: alarmSound
+    command: ["pw-play", "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga"]
+  }
+
+  Process {
+    id: notifyProcess
+    property string titleMsg: ""
+    property string bodyMsg: ""
+    command: ["omarchy-notification-send", titleMsg, bodyMsg]
+  }
+
+  function onPhaseComplete() {
+    running = false
+    
+    notifyProcess.titleMsg = phase === "focus" ? "Focus complete" : (phase === "custom" ? "Timer complete" : "Break complete")
+    notifyProcess.bodyMsg = phase === "focus" ? "Time for a break." : (phase === "custom" ? "Your custom timer has elapsed." : "Back to work!")
+    
+    alarmSound.running = true
+    notifyProcess.running = true
+    
+    advancePhase(true)
+  }
+
+  Timer {
+    id: countdown
+    interval: 500
+    running: root.running
+    repeat: true
+    onTriggered: {
+      if (root.running) {
+        var now = Date.now()
+        var rem = Math.ceil(Math.max(0, root.targetTimeMs - now) / 1000)
+        root.remainingSecs = rem
+        if (rem <= 0) {
+          root.onPhaseComplete()
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/panels/pomodoro/manifest.json
+++ b/shell/plugins/panels/pomodoro/manifest.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.pomodoro",
+  "name": "Pomodoro",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "license": "MIT",
+  "description": "Pomodoro focus timer with live countdown in the bar.",
+  "kinds": ["service", "bar-widget"],
+  "entryPoints": {
+    "service": "Service.qml",
+    "barWidget": "Panel.qml"
+  },
+  "barWidget": {
+    "displayName": "Pomodoro",
+    "description": "Focus timer with start/pause/reset controls and a live countdown in the bar.",
+    "category": "Productivity",
+    "allowMultiple": false,
+    "defaults": {
+      "focusMinutes": 25,
+      "shortBreakMinutes": 5,
+      "longBreakMinutes": 15,
+      "sessionsBeforeLongBreak": 4
+    },
+    "schema": [
+      { "key": "focusMinutes", "type": "integer", "label": "Focus duration (minutes)", "min": 1, "max": 120, "step": 1, "defaultValue": 25 },
+      { "key": "shortBreakMinutes", "type": "integer", "label": "Short break (minutes)", "min": 1, "max": 60, "step": 1, "defaultValue": 5 },
+      { "key": "longBreakMinutes", "type": "integer", "label": "Long break (minutes)", "min": 1, "max": 120, "step": 1, "defaultValue": 15 },
+      { "key": "sessionsBeforeLongBreak", "type": "integer", "label": "Sessions before long break", "min": 1, "max": 10, "step": 1, "defaultValue": 4 }
+    ]
+  }
+}

--- a/test/shell.d/pomodoro-test.sh
+++ b/test/shell.d/pomodoro-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test "pomodoro transitions" <<'JS'
+const pomodoro = requireFromRoot('shell/plugins/panels/pomodoro/Model.js')
+
+assertEqual(pomodoro.advancePhase("custom", 0, 4, true), "focus", "pomodoro clears custom timer to focus")
+assertEqual(pomodoro.advancePhase("shortBreak", 0, 4, true), "focus", "pomodoro goes back to focus after short break")
+assertEqual(pomodoro.advancePhase("longBreak", 4, 4, true), "focus", "pomodoro goes back to focus after long break")
+assertEqual(pomodoro.advancePhase("focus", 1, 4, true), "shortBreak", "pomodoro short breaks after 1st session")
+assertEqual(pomodoro.advancePhase("focus", 2, 4, true), "shortBreak", "pomodoro short breaks after 2nd session")
+assertEqual(pomodoro.advancePhase("focus", 3, 4, true), "shortBreak", "pomodoro short breaks after 3rd session")
+assertEqual(pomodoro.advancePhase("focus", 4, 4, true), "longBreak", "pomodoro long breaks after 4th session")
+
+assertEqual(pomodoro.getPhaseSecs("focus", 1500, 300, 900, 10), 1500, "pomodoro returns focus secs")
+assertEqual(pomodoro.getPhaseSecs("custom", 1500, 300, 900, 10), 600, "pomodoro returns custom secs")
+assertEqual(pomodoro.advancePhase("focus", 4, 4, false), "shortBreak", "pomodoro short breaks if focus is skipped even at long break threshold")
+JS


### PR DESCRIPTION
Add a native Pomodoro timer to the shell

The bar gains a Pomodoro timer that tracks standard intervals: a 25-minute focus phase, 5-minute short breaks, and a 15-minute long break after four completed sessions. Timer state is stored in a shared global service, ensuring the countdown stays perfectly synchronized across multiple monitors. It uses absolute wall-time deadlines rather than interval ticks, so the remaining time stays accurate even if the system suspends or the shell event loop stalls.

A custom timer mode allows users to specify an exact number of minutes. Skipping a phase cleanly advances the timer without playing an alarm or erroneously counting the session as completed. Desktop notifications and standard freedesktop alarm sounds announce when it is time to switch focus. The widget is fully integrated with the Omarchy Settings app via a configurable schema.