### PR TITLE
Add optional idle.blank: power off the display without locking

### DIFF
--- a/bin/omarchy-system-blank
+++ b/bin/omarchy-system-blank
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# omarchy:summary=Turn off displays and keyboard backlight for power saving
+# omarchy:group=system
+# omarchy:name=blank
+# omarchy:examples=omarchy system blank
+
+omarchy-brightness-keyboard off
+omarchy-brightness-display off

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -168,7 +168,7 @@ Rules:
 5. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
-7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+7. `idle.screensaver` and `idle.lock` are seconds since user idle began. `idle.blank` is optional and, when set, independently blanks the display (and keyboard backlight) at its own idle deadline without engaging the session lock — omit it to keep blanking tied to `idle.lock` as before.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -82,7 +82,24 @@ If you dismiss the screensaver before the lock deadline, that counts as activity
 
 To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
 
-This is about locking and the screensaver, not power. Suspend and hibernation have their own setup in [system sleep](36-system-sleep.md).
+### Blanking the display without locking
+
+Locking always blanks the display a few seconds after it engages, but you don't have to reach for the lock screen just to save power. Add a third number, `blank`, to turn off the display and keyboard backlight on its own schedule, independent of the lock:
+
+```json
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 900,
+    "blank": 1200,
+    "lock": 86400
+  }
+}
+```
+
+`blank` counts from the same idle start as the other two. Here the screensaver comes up at 15 minutes and the display powers off at 20 minutes, while the lock is effectively parked out at a full day. Any input wakes the display back up the same way it cancels the screensaver or an in-progress lock. Leave `blank` out entirely and nothing changes — the display keeps blanking only as part of locking, same as before.
+
+This is about locking, the screensaver, and now display power — not suspend. Suspend and hibernation have their own setup in [system sleep](36-system-sleep.md).
 
 ### The screensaver
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -276,7 +276,10 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. `idle.blank` is optional and,
+   when set, independently blanks the display and keyboard backlight at its
+   own deadline without engaging the lock — omit it to keep blanking tied to
+   `idle.lock` as before.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -408,7 +408,7 @@ Item {
 
   Process {
     id: blankProcess
-    command: ["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"]
+    command: ["bash", "-c", "omarchy-system-blank"]
   }
 
   Timer {

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -5,7 +5,9 @@ function secondsFromConfig(value, fallback) {
 }
 
 function blankEnabled(value) {
-  return value !== undefined && value !== null
+  if (value === undefined || value === null) return false
+  var n = Number(value)
+  return isFinite(n) && n >= 0
 }
 
 function eventParts(event, count) {

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -4,6 +4,10 @@ function secondsFromConfig(value, fallback) {
   return Math.floor(n)
 }
 
+function blankEnabled(value) {
+  return value !== undefined && value !== null
+}
+
 function eventParts(event, count) {
   try {
     if (event && event.parse) return event.parse(count)
@@ -46,6 +50,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
+    blankEnabled: blankEnabled,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -104,9 +104,12 @@ Item {
     if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
     else lockTimer.restart()
 
-    // When lock is the earliest deadline, its own post-lock timer already
-    // owns blanking (see lock/Service.qml armBlankTimer) -- don't race it.
-    if (root.blankConfigured && root.lockDelaySeconds !== 0) {
+    // Independent blanking only ever fires strictly before the lock deadline.
+    // At or after that point, lock/Service.qml's own post-lock timer owns
+    // blanking -- comparing absolute deadlines (rather than whichever delay
+    // happens to be 0) keeps that true even when blank and lock coincide
+    // exactly while screensaver is the earlier deadline.
+    if (root.blankConfigured && root.blankTimeoutSeconds < root.lockTimeoutSeconds) {
       if (root.blankDelaySeconds === 0) blankDisplay()
       else blankTimer.restart()
     }
@@ -293,7 +296,11 @@ Item {
     id: blankTimer
     interval: root.blankDelaySeconds * 1000
     repeat: false
-    onTriggered: if (root.idleEnabled && root.idledThisCycle) root.blankDisplay()
+    // shell.json reloads live: if idle.blank is removed while this timer is
+    // running, the interval binding above can drop to 0 and fire almost
+    // immediately. Recheck blankConfigured so a just-removed setting can't
+    // still blank the display.
+    onTriggered: if (root.idleEnabled && root.idledThisCycle && root.blankConfigured) root.blankDisplay()
   }
 
   Timer {

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -19,9 +19,12 @@ Item {
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
-  readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
+  readonly property bool blankConfigured: IdleModel.blankEnabled(idleConfig.blank)
+  readonly property int blankTimeoutSeconds: secondsFromConfig(idleConfig.blank, 0)
+  readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds, blankConfigured ? blankTimeoutSeconds : Number.MAX_SAFE_INTEGER)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
+  readonly property int blankDelaySeconds: blankConfigured ? Math.max(0, blankTimeoutSeconds - firstIdleTimeoutSeconds) : 0
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
@@ -68,10 +71,15 @@ Item {
     runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
   }
 
+  function blankDisplay() {
+    runProcess(blankProcess, "blank", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-system-blank")
+  }
+
   function lockSystem(reason) {
     logEvent("lock-system", reason || "requested")
     screensaverTimer.stop()
     lockTimer.stop()
+    blankTimer.stop()
     screensaverLaunchGraceTimer.stop()
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
@@ -85,7 +93,7 @@ Item {
       return
     }
 
-    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
+    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds + (root.blankConfigured ? " blank=" + root.blankTimeoutSeconds : ""))
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
@@ -95,12 +103,20 @@ Item {
 
     if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
     else lockTimer.restart()
+
+    // When lock is the earliest deadline, its own post-lock timer already
+    // owns blanking (see lock/Service.qml armBlankTimer) -- don't race it.
+    if (root.blankConfigured && root.lockDelaySeconds !== 0) {
+      if (root.blankDelaySeconds === 0) blankDisplay()
+      else blankTimer.restart()
+    }
   }
 
   function cancelIdleCycle(reason) {
     logEvent("idle-cycle-cancel", reason || "requested")
     screensaverTimer.stop()
     lockTimer.stop()
+    blankTimer.stop()
     screensaverLaunchGraceTimer.stop()
 
     if (root.idledThisCycle) runProcess(wakeProcess, "wake", "omarchy-system-wake")
@@ -188,17 +204,21 @@ Item {
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,
+      blank: root.blankConfigured ? root.blankTimeoutSeconds : null,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
+      blankDelay: root.blankConfigured ? root.blankDelaySeconds : null,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
         screensaver: screensaverTimer.running,
         lock: lockTimer.running,
+        blank: blankTimer.running,
         screensaverLaunchGrace: screensaverLaunchGraceTimer.running
       },
       processes: {
         screensaver: screensaverProcess.running,
         lock: lockProcess.running,
+        blank: blankProcess.running,
         wake: wakeProcess.running
       },
       lastEvent: root.lastEvent,
@@ -270,6 +290,13 @@ Item {
   }
 
   Timer {
+    id: blankTimer
+    interval: root.blankDelaySeconds * 1000
+    repeat: false
+    onTriggered: if (root.idleEnabled && root.idledThisCycle) root.blankDisplay()
+  }
+
+  Timer {
     id: screensaverLaunchGraceTimer
     interval: 3000
     repeat: false
@@ -292,6 +319,10 @@ Item {
   Process {
     id: lockProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "lock exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+  Process {
+    id: blankProcess
+    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "blank exitCode=" + exitCode + " status=" + exitStatus) }
   }
   Process {
     id: wakeProcess

--- a/shell/plugins/services/idle/manifest.json
+++ b/shell/plugins/services/idle/manifest.json
@@ -4,7 +4,7 @@
   "name": "Idle",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Quickshell-based idle detection for screensaver, lock, and display wake.",
+  "description": "Quickshell-based idle detection for screensaver, lock, optional independent display blanking, and wake.",
   "kinds": [
     "service"
   ],

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -11,6 +11,11 @@ assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seco
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
 
+assertEqual(idle.blankEnabled(1200), true, 'idle treats a configured blank seconds value as enabled')
+assertEqual(idle.blankEnabled(0), true, 'idle treats an explicit zero blank seconds value as enabled')
+assertEqual(idle.blankEnabled(undefined), false, 'idle treats a missing blank key as disabled')
+assertEqual(idle.blankEnabled(null), false, 'idle treats a null blank key as disabled')
+
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(
   idle.eventParts({ parse: function(count) { return ['parsed', count] } }, 4),

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -12,9 +12,13 @@ assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
 
 assertEqual(idle.blankEnabled(1200), true, 'idle treats a configured blank seconds value as enabled')
+assertEqual(idle.blankEnabled('1200'), true, 'idle treats a configured blank seconds string as enabled')
 assertEqual(idle.blankEnabled(0), true, 'idle treats an explicit zero blank seconds value as enabled')
 assertEqual(idle.blankEnabled(undefined), false, 'idle treats a missing blank key as disabled')
 assertEqual(idle.blankEnabled(null), false, 'idle treats a null blank key as disabled')
+assertEqual(idle.blankEnabled('nope'), false, 'idle treats an invalid blank value as disabled rather than falling back to zero seconds')
+assertEqual(idle.blankEnabled(-1), false, 'idle treats a negative blank value as disabled rather than falling back to zero seconds')
+assertEqual(idle.blankEnabled(Infinity), false, 'idle treats a non-finite blank value as disabled')
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(


### PR DESCRIPTION
## Summary

Blanking the display has always been wired exclusively behind the session lock (`lock/Service.qml`'s `armBlankTimer`, only reachable from `beginLock()`). There's currently no way to turn the screen off on idle without also password-protecting the session — even though the pieces to do it independently (`hyprctl dispatch 'hl.dsp.dpms(...)'` via `omarchy-brightness-display off`) already exist and work fine on their own.

This adds a third, optional `idle.blank` key (seconds since idle began, alongside the existing `screensaver`/`lock`) that independently blanks the display and keyboard backlight without requesting a lock:

```json
{
  "version": 1,
  "idle": {
    "screensaver": 900,
    "blank": 1200,
    "lock": 86400
  }
}
```

- Omitting `idle.blank` keeps today's behavior exactly — blanking stays tied to the lock, byte-for-byte the same as before.
- New `bin/omarchy-system-blank` command (mirrors the existing `omarchy-system-wake`); the lock plugin's own blank step now calls it too, so there's one implementation instead of two duplicated inline commands.
- When lock is the earliest deadline, its own post-lock timer keeps owning the blank — the new idle-driven blank timer is skipped in that case so the two paths never race or double-fire.
- Any input wakes the display the same way it already cancels the screensaver or an in-progress lock (reuses the existing `omarchy-system-wake` path).

## Why

I hit this on my own machine wanting "screensaver at 15 min, display off at 20 min, no password lock" — a fairly common ask for a desktop that isn't shared. Today the only way to get there is bypassing the shell's idle system entirely and reinstalling `hypridle` alongside it with `idle.screensaver`/`idle.lock` parked at a no-op value, which is exactly the kind of thing `omarchy-shell`'s idle service is supposed to make unnecessary.

## Test plan

- [x] `./test/cli` — 116/116 pass
- [x] `./test/shell` — same result as unmodified `upstream/quattro` (4 pre-existing environmental failures unrelated to this change, confirmed via `git stash`); new `idle-test.sh` cases for `IdleModel.blankEnabled` pass
- [x] `omarchy system --help` lists the new `blank` command correctly under the `system` group
- [ ] Manual verification in a running session (screensaver/blank/lock sequencing, wake-on-input) — happy to do this if a maintainer wants it before review, just flagging it wasn't run in the graphical acceptance VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)