### PR TITLE
Use supported Codex approval policy

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,10 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+if [[ -n ${CODEX_ARGS_LOG:-} ]]; then
+  printf '%s\n' "$@" >"$CODEX_ARGS_LOG"
+fi
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -40,8 +44,13 @@ cat >"$session" <<EOF
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}}}}
 EOF
 
-result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+CODEX_ARGS_LOG="$TEST_HOME/codex-args.log"
+result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" CODEX_ARGS_LOG="$CODEX_ARGS_LOG" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(paste -sd ' ' "$CODEX_ARGS_LOG") == "-s read-only -a never app-server" ]] ||
+  fail "Codex collector starts the app server with a supported approval policy" "$(cat "$CODEX_ARGS_LOG")"
+pass "Codex collector starts the app server with a supported approval policy"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"


### PR DESCRIPTION
## Summary

- launch the Codex app server with the supported `never` approval policy
- verify the collector passes the expected sandbox, approval, and app-server arguments

Codex 0.149.0 rejects `untrusted` as an approval policy, causing initialization to fail and the Agents panel to show "Codex limits unavailable." Using `never` preserves the non-interactive collector behavior while matching the policies supported by the current CLI.

## Testing

- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- real Codex 0.149.0 integration: `omarchy-agent-usage-codex --limits-only` returned the Pro tier and weekly limit data
- `./test/all`: 183 of 188 shell test files passed; the focused Codex test passed. Five unrelated environment/baseline failures remain: three require the companion `omarchy-pkgs` checkout, plus `launch-about-test` and `network-qr-test`.