### PR TITLE
Pin the bar center through plugin clones

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -127,7 +127,7 @@ All of it is stored in `~/.config/omarchy/shell.json`, under the `bar` key. Here
 
 Every widget is one entry in one of the three layout arrays, and its settings sit inline on that entry — there's no separate settings file and no `config` sub-object. The clock's `format`, `formatAlt` (what right-click cycles to), and `verticalFormat` all live right there on `{ "id": "omarchy.clock" }`.
 
-`centerAnchor` names the one center widget that gets pinned to the exact center of the screen, with the others flanking it. That's how the clock stays dead center even as the weather and update badge come and go. Set it to an empty string and the center list is just centered as a group instead.
+`centerAnchor` names the one center widget that gets pinned to the exact center of the screen, with the others flanking it. That's how the clock stays dead center even as the weather and update badge come and go. A clone of that widget still counts as it, so cloning the clock does not require rewriting `centerAnchor`. Set it to an empty string and the center list is just centered as a group instead.
 
 One rule worth internalizing: **once you have your own `shell.json`, it's canonical**. Until you customize anything, the shell reads Omarchy's default file. The moment you drag a widget, run `omarchy bar`, or edit the file yourself, you own it — there's no deep merge, so new default widgets in future Omarchy releases won't appear on your bar automatically. `omarchy bar defaults` puts the shipped layout back whenever you want a clean slate.
 

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -66,7 +66,7 @@ omarchy plugin clone omarchy.clock
 
 That copies the whole plugin into `~/.config/omarchy/plugins/dhh.clock` (your username, not mine), renames it to "My Clock", enables it, and switches the shell over from the built-in to your copy — keeping an existing bar widget's position and settings. Add `--edit` to open the new directory in your `$EDITOR` right away, which is what the menu's _Setup > Plugins > Clone Plugin_ does for you.
 
-The username prefix keeps your clone's id yours, so sharing it doesn't collide with anyone else's. Calls made to the original built-in id get routed to your clone, so nothing that referred to `omarchy.clock` needs updating. And if you make a mess of it, `omarchy plugin remove dhh.clock` puts the built-in back.
+The username prefix keeps your clone's id yours, so sharing it doesn't collide with anyone else's. Calls made to the original built-in id get routed to your clone, so nothing that referred to `omarchy.clock` needs updating — including the bar's `centerAnchor` pin. And if you make a mess of it, `omarchy plugin remove dhh.clock` puts the built-in back.
 
 Saving a file anywhere under `~/.config/omarchy/plugins/` reloads the plugin code automatically, so you can leave the editor open and watch your changes land.
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -41,6 +41,23 @@ Item {
   })
   property var layoutConfig: fallbackBarConfig.layout
   property string centerAnchor: ""
+  // Clone replaces the layout entry but leaves centerAnchor on the built-in
+  // id, the way findRelativeBarLocation already follows clones. Resolve here
+  // so the pin stays on the clock after `omarchy plugin clone omarchy.clock`.
+  readonly property var cloneSources: {
+    var map = ({})
+    if (!barWidgetRegistry) return map
+    var _rev = barWidgetRegistry.revision
+    var widgets = barWidgetRegistry.widgets
+    for (var id in widgets) {
+      var meta = widgets[id] && widgets[id].metadata
+      if (meta && meta.clonedFrom)
+        map[id] = Util.canonicalWidgetId(String(meta.clonedFrom))
+    }
+    return map
+  }
+  readonly property string resolvedCenterAnchor: BarModel.resolveCenterAnchor(
+    layoutEntries("center"), centerAnchor, cloneSources)
   property bool requestedTransparent: false
   property bool useTransparentForeground: false
   property bool transparent: false
@@ -1271,7 +1288,7 @@ Item {
 
   function findCenterAnchorEntry() {
     var entries = root.layoutEntries("center")
-    var idx = root.entryIndex(entries, root.centerAnchor)
+    var idx = root.entryIndex(entries, root.resolvedCenterAnchor)
     return idx === -1 ? null : entries[idx]
   }
 
@@ -1289,7 +1306,7 @@ Item {
     id: centerRoot
 
     property var entries: root.layoutEntries("center")
-    readonly property bool hasAnchor: root.entryIndex(entries, root.centerAnchor) !== -1
+    readonly property bool hasAnchor: root.entryIndex(entries, root.resolvedCenterAnchor) !== -1
     readonly property var anchorEntry: root.findCenterAnchorEntry()
 
     Loader {
@@ -1318,7 +1335,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesBefore(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.right: centerAnchorModule.left
           anchors.verticalCenter: centerAnchorModule.verticalCenter
@@ -1334,7 +1351,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesAfter(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.left: centerAnchorModule.right
           anchors.verticalCenter: centerAnchorModule.verticalCenter
@@ -1363,7 +1380,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesBefore(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.bottom: centerAnchorModule.top
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter
@@ -1379,7 +1396,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesAfter(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.top: centerAnchorModule.bottom
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -65,6 +65,23 @@ function entriesAfter(entries, name) {
   return index === -1 ? [] : entries.slice(index + 1)
 }
 
+// Clone replaces the layout entry but leaves centerAnchor on the built-in
+// id. Exact match still wins, so a user who names the clone pins that;
+// otherwise the clone sitting in the source's place is the pin. Do not
+// rewrite shell.json — remove then puts the built-in id back and the pin
+// matches again.
+function resolveCenterAnchor(entries, name, clones) {
+  var anchor = String(name || "")
+  if (!anchor) return ""
+  if (entryIndex(entries, anchor) !== -1) return anchor
+  if (!Array.isArray(entries) || !isPlainObject(clones)) return anchor
+  for (var i = 0; i < entries.length; i++) {
+    var id = entryId(entries[i])
+    if (id && String(clones[id] || "") === anchor) return id
+  }
+  return anchor
+}
+
 // A shell.json write that only changes inline widget settings (the battery
 // percentage toggle, a clock format change) must not rebuild the bar.
 // Compare two normalized layouts: when the structure is unchanged — same
@@ -222,6 +239,7 @@ if (typeof module !== "undefined") {
     entryIndex: entryIndex,
     entriesBefore: entriesBefore,
     entriesAfter: entriesAfter,
+    resolveCenterAnchor: resolveCenterAnchor,
     inlineSettingsDelta: inlineSettingsDelta,
     expandPath: expandPath,
     customModuleSafeName: customModuleSafeName,

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -46,7 +46,7 @@ Example `shell.json` (bar subtree only shown):
 }
 ```
 
-`centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. Set to an empty string to disable anchoring (the center list is centered as a group).
+`centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. A clone of the named widget is treated as that widget, so cloning the clock does not require rewriting `centerAnchor`. Set it to an empty string to disable anchoring (the center list is centered as a group).
 
 ## Module catalogue
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -696,7 +696,10 @@ ShellRoot {
         schema: meta.schema || [],
         pluginId: manifest.id,
         sourceDir: manifest.__sourceDir || "",
-        source: "plugin"
+        source: "plugin",
+        clonedFrom: Util.canonicalWidgetId(String(
+          (Util.isPlainObject(manifest.omarchy) && manifest.omarchy.clonedFrom) || ""
+        ))
       }
 
       // A load already in flight for this URL registers itself when it

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -343,6 +343,50 @@ assertEqual(bar.entryIndex(entries, 'b'), 2, 'bar finds entry indexes')
 assertDeepEqual(bar.entriesBefore(entries, 'b').map(bar.entryId), ['a', 'omarchy.tray'], 'bar returns entries before target')
 assertDeepEqual(bar.entriesAfter(entries, 'a').map(bar.entryId), ['omarchy.tray', 'b'], 'bar returns entries after target')
 
+const center = [
+  { id: 'omarchy.indicators' },
+  { id: 'tester.clock', format: 'HH:mm' },
+  { id: 'omarchy.weather' }
+]
+const clones = { 'tester.clock': 'omarchy.clock' }
+assertEqual(
+  bar.resolveCenterAnchor(center, 'omarchy.clock', clones),
+  'tester.clock',
+  'bar pins a clone of the configured center anchor'
+)
+assertEqual(
+  bar.resolveCenterAnchor(center, 'tester.clock', clones),
+  'tester.clock',
+  'bar pins the named clone when it is already in the center'
+)
+assertEqual(
+  bar.resolveCenterAnchor(
+    [{ id: 'omarchy.indicators' }, { id: 'omarchy.clock' }, { id: 'omarchy.weather' }],
+    'omarchy.clock',
+    clones
+  ),
+  'omarchy.clock',
+  'bar prefers the exact center anchor over a clone of it'
+)
+assertEqual(
+  bar.resolveCenterAnchor(center, 'omarchy.clock', {}),
+  'omarchy.clock',
+  'bar leaves the configured pin when no clone metadata is present'
+)
+assertEqual(bar.resolveCenterAnchor(center, '', clones), '', 'bar treats an empty center pin as disabled')
+assert(
+  /BarModel\.resolveCenterAnchor\(/.test(barSource),
+  'bar resolves the center pin through clones'
+)
+assert(
+  /readonly property bool hasAnchor: root\.entryIndex\(entries, root\.resolvedCenterAnchor\) !== -1/.test(barSource),
+  'bar pins the resolved center widget, not the configured id'
+)
+assert(
+  /clonedFrom:\s*Util\.canonicalWidgetId/.test(shellSource),
+  'plugin widgets carry clonedFrom into the bar widget registry'
+)
+
 assertEqual(bar.expandPath('~/module.qml', '/home/dhh'), '/home/dhh/module.qml', 'bar expands tilde paths')
 assertEqual(bar.expandPath('$HOME/module.qml', '/home/dhh'), '/home/dhh/module.qml', 'bar expands HOME paths')
 assert(bar.customModuleSafeName('local.weather'), 'bar accepts safe custom module names')


### PR DESCRIPTION
Fixes #7868

`omarchy plugin clone omarchy.clock` replaces the bar slot with `<user>.clock` but leaves `bar.centerAnchor` set to `"omarchy.clock"`. The pin misses, so hovering the clock reveals inactive indicators, the center group grows, and the clock slides.

Clone already routes `omarchy bar move --after omarchy.clock` through `findRelativeBarLocation`. The center pin is the one lookup that still did an exact id match.

This resolves the pin at runtime instead of rewriting `shell.json`:

- Plugin widgets carry `clonedFrom` into bar-widget registry metadata
- Exact id still wins; otherwise the clone of that id in the center is the pin
- The lookup rebinds on registry revision so a clone that appears after first layout still pins

Clone replaces the source in place, so the center has one clone of that clock. Leaving `centerAnchor` as `"omarchy.clock"` means clone and remove both keep working with no extra config.

## Test plan

- [x] `test/shell.d/bar-test.sh` — resolveCenterAnchor cases plus Bar.qml / shell.qml wiring
- [x] `test/shell.d/plugin-clone-test.sh`
- [x] Hover the clock on a cloned clock: inactive indicators appear, clock stays dead center
- [x] `omarchy plugin remove <user>.clock` restores the built-in pin without a stale clone id