### PR TITLE
Stop the lid gate logging a PAM failure on every open-lid sudo

### DIFF
--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -16,7 +16,12 @@ setup_pam_config() {
   # fixed /usr/bin path the omarchy package always provides, so the gate keeps
   # working across package installs and dev-link — the latter overlays
   # $OMARCHY_PATH trees but leaves /usr/bin untouched.
-  local fprintd_gate="auth      [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed"
+  #
+  # quiet_log because the gate is a predicate, not an action: exit 1 just means
+  # "lid is open, carry on to pam_fprintd". Without it pam_exec writes a NOTICE
+  # ("failed: exit code 1") on every open-lid sudo and pkexec. quiet alone only
+  # suppresses the terminal echo.
+  local fprintd_gate="auth      [success=1 default=ignore] pam_exec.so quiet quiet_log /usr/bin/omarchy-hw-laptop-closed"
 
   # Configure sudo
   if ! grep -q pam_fprintd.so /etc/pam.d/sudo; then

--- a/migrations/1787422694.sh
+++ b/migrations/1787422694.sh
@@ -1,0 +1,18 @@
+echo "Silence the lid gate's per-sudo journal noise"
+
+# The clamshell gate in front of pam_fprintd is a predicate, not an action:
+# exit 1 means "lid is open, carry on to pam_fprintd". pam_exec has no notion
+# of that and logs every non-zero exit as "failed: exit code 1", so machines
+# that took the gate from 1784818437 (or an older omarchy-setup-security-
+# fingerprint) write a NOTICE to the journal on every open-lid sudo and pkexec.
+#
+# quiet only suppresses the terminal echo; quiet_log suppresses the log write.
+# Both are stock pam_exec options (quiet_log since Linux-PAM 1.5.2).
+
+for pam in /etc/pam.d/sudo /etc/pam.d/polkit-1; do
+  if [[ -f $pam ]] &&
+    grep -q 'omarchy-hw-laptop-closed' "$pam" &&
+    ! grep -q 'quiet_log.*omarchy-hw-laptop-closed' "$pam"; then
+    sudo sed -i '/omarchy-hw-laptop-closed/s/pam_exec\.so quiet /pam_exec.so quiet quiet_log /' "$pam"
+  fi
+done

--- a/migrations/1787422694.sh
+++ b/migrations/1787422694.sh
@@ -9,7 +9,12 @@ echo "Silence the lid gate's per-sudo journal noise"
 # quiet only suppresses the terminal echo; quiet_log suppresses the log write.
 # Both are stock pam_exec options (quiet_log since Linux-PAM 1.5.2).
 
-for pam in /etc/pam.d/sudo /etc/pam.d/polkit-1; do
+pam_dir="${OMARCHY_LID_GATE_PAM_DIR:-/etc/pam.d}"
+
+for pam in "$pam_dir/sudo" "$pam_dir/polkit-1"; do
+  # Only the gate line is touched, so a hand-edited pam_exec elsewhere in the
+  # stack stands. Skipping a file that already carries quiet_log keeps a second
+  # run from rewriting a stack the user may have edited since.
   if [[ -f $pam ]] &&
     grep -q 'omarchy-hw-laptop-closed' "$pam" &&
     ! grep -q 'quiet_log.*omarchy-hw-laptop-closed' "$pam"; then

--- a/migrations/1787422694.sh
+++ b/migrations/1787422694.sh
@@ -4,7 +4,7 @@ echo "Silence the lid gate's per-sudo journal noise"
 # exit 1 means "lid is open, carry on to pam_fprintd". pam_exec has no notion
 # of that and logs every non-zero exit as "failed: exit code 1", so machines
 # that took the gate from 1784818437 (or an older omarchy-setup-security-
-# fingerprint) write a NOTICE to the journal on every open-lid sudo and pkexec.
+# fingerprint) write an error to the journal on every open-lid sudo and pkexec.
 #
 # quiet only suppresses the terminal echo; quiet_log suppresses the log write.
 # Both are stock pam_exec options (quiet_log since Linux-PAM 1.5.2).

--- a/test/shell.d/lid-gate-quiet-log-migration-test.sh
+++ b/test/shell.d/lid-gate-quiet-log-migration-test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1787422694.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin" "$test_dir/pam.d"
+
+# sudo runs the real command, so sed acts on the redirected pam.d below.
+cat >"$test_dir/bin/sudo" <<'STUB'
+#!/bin/bash
+
+exec "$@"
+STUB
+
+chmod +x "$test_dir/bin/"*
+
+pam_dir="$test_dir/pam.d"
+gate="auth      [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed"
+gated="auth      [success=1 default=ignore] pam_exec.so quiet quiet_log /usr/bin/omarchy-hw-laptop-closed"
+
+write_stack() {
+  printf '%s\nauth      sufficient pam_fprintd.so\nauth      include system-auth\n' "$1"
+}
+
+reset_machine() {
+  rm -f "$pam_dir/sudo" "$pam_dir/polkit-1"
+}
+
+run_migration() {
+  OMARCHY_LID_GATE_PAM_DIR="$pam_dir" \
+    PATH="$test_dir/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# The machines this migration exists for: the gate is in place from 1784818437
+# or an older setup script, with no quiet_log.
+reset_machine
+write_stack "$gate" >"$pam_dir/sudo"
+write_stack "$gate" >"$pam_dir/polkit-1"
+run_migration
+
+grep -qxF "$gated" "$pam_dir/sudo" ||
+  fail "migration adds quiet_log to the sudo gate" "$(cat "$pam_dir/sudo")"
+pass "migration adds quiet_log to the sudo gate"
+
+grep -qxF "$gated" "$pam_dir/polkit-1" ||
+  fail "migration adds quiet_log to the polkit gate" "$(cat "$pam_dir/polkit-1")"
+pass "migration adds quiet_log to the polkit gate"
+
+# The gate is one line of an auth stack; everything under it must survive.
+grep -qx 'auth      sufficient pam_fprintd.so' "$pam_dir/sudo" &&
+  grep -qx 'auth      include system-auth' "$pam_dir/sudo" ||
+  fail "migration leaves the rest of the stack alone" "$(cat "$pam_dir/sudo")"
+pass "migration leaves the rest of the stack alone"
+
+# Migrations are marker-file based per user, so a second account runs this again
+# on a machine that is already converted.
+before=$(cat "$pam_dir/sudo")
+run_migration
+
+[[ $(cat "$pam_dir/sudo") == "$before" ]] ||
+  fail "migration is idempotent on a second run" "$(cat "$pam_dir/sudo")"
+pass "migration is idempotent on a second run"
+
+# No fingerprint reader set up means no gate to convert, and the stack must not
+# be rewritten on the way past.
+reset_machine
+printf '#%%PAM-1.0\nauth      include system-auth\n' >"$pam_dir/sudo"
+before=$(cat "$pam_dir/sudo")
+run_migration
+
+[[ $(cat "$pam_dir/sudo") == "$before" ]] ||
+  fail "migration leaves an ungated stack alone" "$(cat "$pam_dir/sudo")"
+pass "migration leaves an ungated stack alone"
+
+# polkit-1 is not shipped by a package; omarchy writes it during fingerprint
+# setup, so it is absent on a machine that never ran one.
+reset_machine
+write_stack "$gate" >"$pam_dir/sudo"
+run_migration
+
+[[ ! -e $pam_dir/polkit-1 ]] ||
+  fail "migration does not create a missing polkit-1"
+pass "migration does not create a missing polkit-1"
+
+# Only the gate line carries the substitution, so an unrelated pam_exec the user
+# added keeps its own options.
+reset_machine
+{
+  printf '%s\n' "$gate"
+  printf 'auth      optional pam_exec.so quiet /usr/local/bin/something-else\n'
+} >"$pam_dir/sudo"
+run_migration
+
+grep -qx 'auth      optional pam_exec.so quiet /usr/local/bin/something-else' "$pam_dir/sudo" ||
+  fail "migration leaves an unrelated pam_exec alone" "$(cat "$pam_dir/sudo")"
+pass "migration leaves an unrelated pam_exec alone"

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -32,7 +32,7 @@ auth include system-auth
 )
 assert(
   polkit.fingerprintConfiguredFromPamConfig(`
-auth [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed
+auth [success=1 default=ignore] pam_exec.so quiet quiet_log /usr/bin/omarchy-hw-laptop-closed
 auth sufficient pam_fprintd.so
 auth required pam_unix.so
 `),


### PR DESCRIPTION
The clamshell gate in front of `pam_fprintd` is a predicate, not an action: exit 1 means "lid is open, carry on to pam_fprintd". `pam_exec` has no notion of that and logs every non-zero exit at `LOG_ERR`, so an open lid writes this on each sudo and pkexec:

```
sudo[10740]: pam_exec(sudo:auth): /usr/bin/omarchy-hw-laptop-closed failed: exit code 1
```

Normal operation, error severity — it makes `journalctl -p err` useless for finding real errors on any laptop with fingerprint set up.

`quiet` only suppresses the terminal echo. `quiet_log` suppresses the log write. Both are stock `pam_exec` options; `quiet_log` landed in Linux-PAM 1.5.2 and exists for exactly this case ([linux-pam#334](https://github.com/linux-pam/linux-pam/issues/334)).

It does not hide real breakage: `quiet_log` gates only the "failed: exit code %d" line. The `execve(...) failed: %m` path is ungated, so a missing or non-executable helper still logs.

## Changes

- `bin/omarchy-setup-security-fingerprint` — add `quiet_log` to `fprintd_gate`, for new setups.
- `migrations/1787422694.sh` — retrofit machines that already took the gate from `1784818437` or an older setup script.
- `test/shell.d/polkit-test.sh` — the clamshell-gate fixture carried the old literal line.

`1784818437.sh` is left alone; migrations are marker-file based, so editing an already-run one does nothing.

## Testing

Migration run against copies of a real `/etc/pam.d/sudo` and `/etc/pam.d/polkit-1`: one line changed per file, idempotent on a second run, no-op when the gate is absent (no fingerprint configured) or when `polkit-1` doesn't exist. `test/shell` polkit suite passes.

Nothing parses the gate line strictly, so the extra token is safe — `PolkitModel.js` matches `pam_fprintd.so` with `indexOf`, and `omarchy-remove-security-fingerprint` deletes by `/omarchy-hw-laptop-closed/d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
