### PR TITLE
Keep the screensaver above pinned windows

### DIFF
--- a/default/hypr/apps/screensaver.lua
+++ b/default/hypr/apps/screensaver.lua
@@ -1,0 +1,142 @@
+-- Fullscreen screensaver.
+o.window("org.omarchy.screensaver", { fullscreen = true })
+o.window("org.omarchy.screensaver", { float = true })
+o.window("org.omarchy.screensaver", { animation = "slide" })
+
+-- Hyprland draws pinned windows in a pass of their own, after the workspace,
+-- so a pinned pop-out or picture-in-picture window stays on top of the
+-- fullscreen screensaver. No window rule changes that order. Drop the pin
+-- while the screensaver is up and put it back when it goes away.
+--
+-- The pin has to go before the screensaver takes fullscreen, because Hyprland
+-- skips pinned windows when it hides the windows under a new fullscreen
+-- window. That is why the first pass runs on window.open_early. The second
+-- pass on window.open lowers whatever the first pass missed, which clears the
+-- same "allowed over fullscreen" flag.
+
+local SCREENSAVER_CLASS = "org.omarchy.screensaver"
+
+-- Addresses of the open screensaver windows. One opens on each monitor.
+local screensavers = {}
+
+-- Addresses of the windows unpinned here, from the bottom of the stack up.
+local unpinned = {}
+local unpinned_set = {}
+
+local function window_at(address)
+  if not address then
+    return nil
+  end
+
+  return hl.get_window("address:" .. address)
+end
+
+local function set_pin(window, action)
+  hl.dispatch(hl.dsp.window.pin({ action = action, window = window }))
+end
+
+local function set_zorder(window, mode)
+  hl.dispatch(hl.dsp.window.alter_zorder({ mode = mode, window = window }))
+end
+
+-- Count the open screensaver windows and forget the ones that are gone.
+local function screensaver_count()
+  local total = 0
+
+  for address in pairs(screensavers) do
+    local window = window_at(address)
+    if window and window.mapped then
+      total = total + 1
+    else
+      screensavers[address] = nil
+    end
+  end
+
+  return total
+end
+
+local function unpin(window)
+  local address = window.address
+  if not address or unpinned_set[address] then
+    return
+  end
+
+  unpinned_set[address] = true
+  table.insert(unpinned, address)
+  set_pin(window, "off")
+end
+
+local function unpin_pinned_windows()
+  for _, window in ipairs(hl.get_windows()) do
+    if window.pinned and window.class ~= SCREENSAVER_CLASS then
+      unpin(window)
+    end
+  end
+end
+
+-- Push anything the compositor still ranks above the screensaver below it.
+local function lower_unpinned()
+  for _, address in ipairs(unpinned) do
+    local window = window_at(address)
+    if window and window.allowed_over_fullscreen then
+      set_zorder(window, "bottom")
+    end
+  end
+end
+
+local function restore_pins()
+  -- The list runs bottom to top, so each raise lands the next window above the
+  -- previous one and the old stack order comes back.
+  for _, address in ipairs(unpinned) do
+    local window = window_at(address)
+    if window then
+      set_zorder(window, "top")
+      set_pin(window, "on")
+    end
+  end
+
+  unpinned = {}
+  unpinned_set = {}
+end
+
+local function on_screensaver_open(window)
+  screensavers[window.address] = true
+  unpin_pinned_windows()
+end
+
+hl.on("window.open_early", function(window)
+  if window.class == SCREENSAVER_CLASS then
+    on_screensaver_open(window)
+  end
+end)
+
+hl.on("window.open", function(window)
+  if window.class == SCREENSAVER_CLASS then
+    on_screensaver_open(window)
+    lower_unpinned()
+  elseif next(screensavers) and window.pinned then
+    -- A pinned window opened while the screensaver was already up.
+    unpin(window)
+    lower_unpinned()
+  end
+end)
+
+-- The window is still mapped on window.close, so the count reaches zero only
+-- on window.destroy. Both events keep the address list correct.
+local function on_window_gone(window)
+  local address = window.address
+  if address then
+    screensavers[address] = nil
+  end
+
+  if #unpinned == 0 then
+    return
+  end
+
+  if screensaver_count() == 0 then
+    restore_pins()
+  end
+end
+
+hl.on("window.close", on_window_gone)
+hl.on("window.destroy", on_window_gone)

--- a/default/hypr/apps/screensaver.lua
+++ b/default/hypr/apps/screensaver.lua
@@ -16,53 +16,36 @@ o.window("org.omarchy.screensaver", { animation = "slide" })
 
 local SCREENSAVER_CLASS = "org.omarchy.screensaver"
 
--- Addresses of the open screensaver windows. One opens on each monitor.
-local screensavers = {}
-
--- Addresses of the windows unpinned here, from the bottom of the stack up.
-local unpinned = {}
-local unpinned_set = {}
-
-local function window_at(address)
-  if not address then
-    return nil
-  end
-
-  return hl.get_window("address:" .. address)
-end
+-- Every unpinned window carries this tag, and the tag is the only record of
+-- the work. A config reload replaces the Lua state, so state in a local table
+-- would strand the windows unpinned. A tag from a dispatcher stays on the
+-- window: Hyprland only drops the dynamic tags that window rules apply.
+local UNPINNED_TAG = "omarchy-screensaver-unpinned"
 
 local function set_pin(window, action)
   hl.dispatch(hl.dsp.window.pin({ action = action, window = window }))
+end
+
+local function set_tag(window, tag)
+  hl.dispatch(hl.dsp.window.tag({ tag = tag, window = window }))
 end
 
 local function set_zorder(window, mode)
   hl.dispatch(hl.dsp.window.alter_zorder({ mode = mode, window = window }))
 end
 
--- Count the open screensaver windows and forget the ones that are gone.
-local function screensaver_count()
-  local total = 0
+local function screensaver_windows()
+  return hl.get_windows({ class = SCREENSAVER_CLASS })
+end
 
-  for address in pairs(screensavers) do
-    local window = window_at(address)
-    if window and window.mapped then
-      total = total + 1
-    else
-      screensavers[address] = nil
-    end
-  end
-
-  return total
+-- hl.get_windows returns the stack from the bottom up, which is the order the
+-- windows need for the raise in restore_pins.
+local function unpinned_windows()
+  return hl.get_windows({ tag = UNPINNED_TAG })
 end
 
 local function unpin(window)
-  local address = window.address
-  if not address or unpinned_set[address] then
-    return
-  end
-
-  unpinned_set[address] = true
-  table.insert(unpinned, address)
+  set_tag(window, "+" .. UNPINNED_TAG)
   set_pin(window, "off")
 end
 
@@ -76,67 +59,72 @@ end
 
 -- Push anything the compositor still ranks above the screensaver below it.
 local function lower_unpinned()
-  for _, address in ipairs(unpinned) do
-    local window = window_at(address)
-    if window and window.allowed_over_fullscreen then
+  for _, window in ipairs(unpinned_windows()) do
+    if window.allowed_over_fullscreen then
       set_zorder(window, "bottom")
     end
   end
 end
 
+-- Each raise lands the next window above the previous one, so the windows come
+-- back in the order they had.
 local function restore_pins()
-  -- The list runs bottom to top, so each raise lands the next window above the
-  -- previous one and the old stack order comes back.
-  for _, address in ipairs(unpinned) do
-    local window = window_at(address)
-    if window then
-      set_zorder(window, "top")
-      set_pin(window, "on")
+  for _, window in ipairs(unpinned_windows()) do
+    set_zorder(window, "top")
+    set_pin(window, "on")
+
+    -- Hyprland refuses the pin while a window is fullscreen. Keep the tag on
+    -- such a window so that a later pass picks it up again.
+    if window.pinned then
+      set_tag(window, "-" .. UNPINNED_TAG)
     end
   end
-
-  unpinned = {}
-  unpinned_set = {}
 end
 
-local function on_screensaver_open(window)
-  screensavers[window.address] = true
-  unpin_pinned_windows()
+local function restore_pins_if_screensaver_gone()
+  if #unpinned_windows() == 0 then
+    return
+  end
+
+  if #screensaver_windows() == 0 then
+    restore_pins()
+  end
 end
 
 hl.on("window.open_early", function(window)
   if window.class == SCREENSAVER_CLASS then
-    on_screensaver_open(window)
+    unpin_pinned_windows()
   end
 end)
 
 hl.on("window.open", function(window)
   if window.class == SCREENSAVER_CLASS then
-    on_screensaver_open(window)
+    unpin_pinned_windows()
     lower_unpinned()
-  elseif next(screensavers) and window.pinned then
-    -- A pinned window opened while the screensaver was already up.
+  elseif window.pinned and #screensaver_windows() > 0 then
+    unpin(window)
+    lower_unpinned()
+  end
+end)
+
+-- A window can also gain the pin later, from omarchy-hyprland-window-pop or
+-- from a keybind. The unpin here makes the event fire again with the pin off,
+-- and that second pass stops at the check below.
+hl.on("window.pin", function(window)
+  if window.pinned and window.class ~= SCREENSAVER_CLASS and #screensaver_windows() > 0 then
     unpin(window)
     lower_unpinned()
   end
 end)
 
 -- The window is still mapped on window.close, so the count reaches zero only
--- on window.destroy. Both events keep the address list correct.
-local function on_window_gone(window)
-  local address = window.address
-  if address then
-    screensavers[address] = nil
-  end
+-- on window.destroy. Both events keep the check honest.
+hl.on("window.close", restore_pins_if_screensaver_gone)
+hl.on("window.destroy", restore_pins_if_screensaver_gone)
 
-  if #unpinned == 0 then
-    return
-  end
+-- A reload during the screensaver leaves this file with no memory of the work.
+-- The tags carry it, so pick the windows back up here.
+hl.on("config.reloaded", restore_pins_if_screensaver_gone)
 
-  if screensaver_count() == 0 then
-    restore_pins()
-  end
-end
-
-hl.on("window.close", on_window_gone)
-hl.on("window.destroy", on_window_gone)
+-- Retry for a window that was fullscreen when the screensaver went away.
+hl.on("window.fullscreen", restore_pins_if_screensaver_gone)

--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -31,11 +31,6 @@ o.window("dev.tensaku.Tensaku", { float = true })
 o.window("dev.tensaku.Tensaku", { center = true })
 o.window("omacalc", { float = true })
 
--- Fullscreen screensaver.
-o.window("org.omarchy.screensaver", { fullscreen = true })
-o.window("org.omarchy.screensaver", { float = true })
-o.window("org.omarchy.screensaver", { animation = "slide" })
-
 -- No transparency on media windows.
 o.window(
   "^(zoom|vlc|mpv|org.kde.kdenlive|com.obsproject.Studio|com.github.PintaProject.Pinta|imv|org.gnome.NautilusPreviewer)$",


### PR DESCRIPTION
Fixes #5268.

## Problem

Hyprland draws pinned windows in a pass of their own, after it draws the workspace (`renderWorkspace`, "pinned always above"). A pinned pop-out (`SUPER + O`) or a picture-in-picture video therefore stays on top of the fullscreen screensaver. No window rule changes that order: `CWindow::isAllowedOverFullscreen()` returns true for any pinned window, and Hyprland has no z-order rule.

## Fix

Drop the pin from every pinned window when a screensaver window opens, and put it back when the last one closes.

Two details matter:

- The first pass runs on `window.open_early`, before the screensaver takes fullscreen. Hyprland skips pinned windows when it hides the windows under a new fullscreen window, so a later pass is too late.
- The pass on `window.open` lowers anything that still slipped through, which clears the same "allowed over fullscreen" flag.

Restore runs on both `window.close` and `window.destroy`, so it also fires when the screensaver is killed instead of dismissed. The unpinned addresses are kept in stack order, so several overlays come back in the order they had.

The screensaver window rules move from `apps/system.lua` into the new `apps/screensaver.lua`, so all screensaver behaviour sits in one file.

## Testing

Omarchy 4.0.0, Hyprland 0.56.2, single 4K monitor. With a Chromium picture-in-picture window and a pinned pop-out terminal open, the screensaver now covers both. Both come back pinned at the same position and size after the screensaver closes, whether it is dismissed or killed. `hyprctl configerrors` stays clean.

`./test/all`: 185 of 188 test files pass. The three failures (`config`, `snapper`, `unowned-system-paths`) need an `omarchy-pkgs` checkout and fail the same way on `quattro` without this change.

## Images

### Before
<img width="960" height="540" alt="before" src="https://github.com/user-attachments/assets/f544444d-a824-4d55-9810-59c257f35db3" />

### After
<img width="960" height="540" alt="after" src="https://github.com/user-attachments/assets/d83d23e3-3b41-4251-8b0f-a707ab5cc424" />
