### PR TITLE
Force Firefox's media wakelock onto the Wayland idle-inhibit protocol

### DIFF
--- a/default/hypr/envs.lua
+++ b/default/hypr/envs.lua
@@ -17,6 +17,12 @@ hl.env("ELECTRON_OZONE_PLATFORM_HINT", "wayland")
 hl.env("OZONE_PLATFORM", "wayland")
 hl.env("XDG_SESSION_TYPE", "wayland")
 
+-- Keep Firefox's media wakelock on the compositor's idle-inhibit protocol.
+-- Auto-detection prefers the Inhibit portal, which xdg-desktop-portal-gtk answers
+-- successfully while inhibiting nothing under Hyprland, so video playback never
+-- holds off the screensaver or lock.
+hl.env("MOZ_WAKE_LOCK_TYPE", "WaylandIdleInhibit")
+
 -- Allow better support for screen sharing (Google Meet, Discord, etc).
 hl.env("XDG_CURRENT_DESKTOP", "Hyprland")
 hl.env("XDG_SESSION_DESKTOP", "Hyprland")


### PR DESCRIPTION
Firefox never inhibits idle during media playback on Omarchy: the screensaver fires
mid-video at `idle.screensaver` (150s by default) and the session locks at 300s, even
with a video playing fullscreen. Chromium-based browsers are unaffected.

## Root cause

Firefox's Linux `WakeLockTopic` auto-detects a backend among `FreeDesktopScreensaver`,
`Portal`, `WaylandIdleInhibit`, and `XScreenSaver`. It settles on
`org.freedesktop.portal.Inhibit`, which on Omarchy is implemented by
**xdg-desktop-portal-gtk** (it owns `org.freedesktop.impl.portal.Inhibit`; the Hyprland
backend does not implement that interface).

xdg-desktop-portal-gtk inhibits by way of GNOME's session manager, which is not present
under Hyprland. The call still returns a valid handle, so Firefox treats the inhibit as
successful and never falls back to `WaylandIdleInhibit` — the one backend that actually
talks to the compositor. The result is a silent no-op.

Chromium browsers bypass the portal and speak `zwp_idle_inhibit_manager_v1` to the
compositor directly, which is why Brave holds the screensaver off on the same machine.

The omarchy-shell side was never at fault — its `IdleMonitor` already sets
`respectInhibitors: true` and honors inhibitors correctly. Firefox simply wasn't sending one.

## Fix

Pin the backend via `MOZ_WAKE_LOCK_TYPE=WaylandIdleInhibit`, alongside the existing
`MOZ_ENABLE_WAYLAND` in `default/hypr/envs.lua`. This covers both the `video-playing` and
`audio-playing` wakelock topics.

## Verification

Confirmed on two Omarchy 4.0.0-1 machines, one with Firefox 153 and one with 154.

Before — screensaver fires at the 150s mark while a fullscreen video plays with an active
PipeWire stream:

```
omarchy idle ... idle-monitor: idle
omarchy idle ... idle-cycle-start: screensaver=150 lock=300
omarchy idle ... process-start: screensaver
```

After — Firefox drives a real Wayland inhibitor (`MOZ_LOG=LinuxWakeLock:5`):

```
WakeLockTopic::SendInhibit() WakeLockType WaylandIdleInhibit
UninhibitWaylandIdle() mWaylandInhibitor 7f0e733c03c0
```

with zero idle events logged across a 14-minute playback run on the first machine and a
3.5-minute run on the second, both with audio confirmed active throughout.

`./test/all` shows no new failures. Three files fail identically before and after this
change (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`); they depend
on a sibling `omarchy-pkgs` checkout and system state absent from this environment.

## Note on scope

This pins the backend unconditionally, disabling Firefox's auto-detection fallback. That is
correct for a Hyprland session. An arguably more general fix would be to stop routing
`org.freedesktop.impl.portal.Inhibit` to the gtk backend so the portal call fails and
Firefox's own fallback engages — that would fix every app rather than Firefox alone, but it
is a broader change and wants testing against anything else using Inhibit. Happy to take
that route instead if preferred.
