### PR TITLE
Detach 1Password from the installer terminal

### DIFF
--- a/bin/omarchy-install-service-1password
+++ b/bin/omarchy-install-service-1password
@@ -28,7 +28,7 @@ echo "Installing 1Password extension for Chromium..."
 install_chromium_extension
 
 echo "Opening 1Password..."
-uwsm-app -- 1password >/dev/null 2>&1 &
+setsid uwsm-app -- 1password >/dev/null 2>&1 &
 
 echo ""
 echo "1Password has been installed. Restart Chromium to load the browser extension."

--- a/bin/omarchy-install-service-dropbox
+++ b/bin/omarchy-install-service-dropbox
@@ -9,5 +9,5 @@ echo "Adding Dropbox to the bar..."
 omarchy-plugin-enable omarchy.dropbox
 
 echo "Starting Dropbox..."
-uwsm-app -- dropbox-cli start &>/dev/null &
+setsid uwsm-app -- dropbox-cli start &>/dev/null &
 echo "See Dropbox icon behind  hover tray in top right and right-click for setup."

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -32,3 +32,42 @@ assertEqual(
   'dropbox file metadata includes relative time and folder'
 )
 JS
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+launch_log="$test_tmp/launch-log"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+:
+SH
+
+cat >"$mock_bin/omarchy-plugin-enable" <<'SH'
+#!/bin/bash
+:
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH_LOG"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf 'direct:%s\n' "$*" >"$OMARCHY_TEST_LAUNCH_LOG"
+SH
+
+chmod +x "$mock_bin"/*
+
+PATH="$mock_bin:$PATH" OMARCHY_TEST_LAUNCH_LOG="$launch_log" \
+  bash "$ROOT/bin/omarchy-install-service-dropbox"
+for _ in {1..50}; do
+  [[ -s $launch_log ]] && break
+  sleep 0.01
+done
+grep -Fxq 'uwsm-app -- dropbox-cli start' "$launch_log" ||
+  fail "Dropbox installer detaches the service from its terminal" "$(cat "$launch_log")"
+pass "Dropbox installer detaches the service from its terminal"

--- a/test/shell.d/launch-1password-test.sh
+++ b/test/shell.d/launch-1password-test.sh
@@ -15,10 +15,24 @@ cat >"$mock_bin/omarchy-cmd-present" <<'SH'
 [[ ${OMARCHY_TEST_INSTALLED:-false} == "true" ]]
 SH
 
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+:
+SH
+
 cat >"$mock_bin/setsid" <<'SH'
 #!/bin/bash
-shift
 printf 'launch:%s\n' "$*" >"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf 'direct:%s\n' "$*" >"$OMARCHY_TEST_LOG"
 SH
 
 cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
@@ -31,7 +45,7 @@ chmod +x "$mock_bin"/*
 launch_log="$test_tmp/launch-log"
 PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=true OMARCHY_TEST_LOG="$launch_log" \
   bash "$ROOT/bin/omarchy-launch-1password"
-grep -Fxq 'launch:-- 1password' "$launch_log" || fail "1Password launcher starts the installed app"
+grep -Fxq 'launch:uwsm-app -- 1password' "$launch_log" || fail "1Password launcher starts the installed app"
 pass "1Password launcher starts the installed app"
 
 PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=false OMARCHY_TEST_LOG="$launch_log" \
@@ -39,6 +53,17 @@ PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=false OMARCHY_TEST_LOG="$launch_lo
 grep -Fxq 'install:omarchy-install-service-1password' "$launch_log" ||
   fail "1Password launcher starts the installer when missing"
 pass "1Password launcher starts the installer when missing"
+
+: >"$launch_log"
+PATH="$mock_bin:$PATH" OMARCHY_TEST_LOG="$launch_log" \
+  bash "$ROOT/bin/omarchy-install-service-1password"
+for _ in {1..50}; do
+  [[ -s $launch_log ]] && break
+  sleep 0.01
+done
+grep -Fxq 'launch:uwsm-app -- 1password' "$launch_log" ||
+  fail "1Password installer detaches the app from its terminal" "$(cat "$launch_log")"
+pass "1Password installer detaches the app from its terminal"
 
 grep -Fq '{ omarchy = "1password" }' "$ROOT/default/hypr/bindings/applications.lua" ||
   fail "1Password keybinding uses the conditional launcher"


### PR DESCRIPTION
Closes #7870

Launches 1Password through `setsid` after installation so closing the installer terminal does not send SIGHUP to the app. Adds a regression test that runs the real installer with stubbed dependencies and asserts the exact detached launch invocation.

Tests:
- `bash test/shell.d/launch-1password-test.sh`
- `bash -n bin/omarchy-install-service-1password test/shell.d/launch-1password-test.sh`