### PR TITLE
Fix WoW fullscreen and focus stealing

### DIFF
--- a/default/hypr/apps/battlenet.lua
+++ b/default/hypr/apps/battlenet.lua
@@ -14,3 +14,9 @@ o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net Setup$" }, {
   no_blur = true,
   no_shadow = true,
 })
+
+-- Keep Hyprland in charge of WoW's fullscreen state and ignore background activation requests.
+o.window({ class = "^steam_app_battlenet$", title = "^World of Warcraft$", xwayland = true }, {
+  focus_on_activate = false,
+  suppress_event = "fullscreen maximize",
+})

--- a/test/shell.d/battlenet-test.sh
+++ b/test/shell.d/battlenet-test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+require_command lua
+
 install_script="$ROOT/bin/omarchy-install-gaming-battlenet"
 
 [[ ! -f $ROOT/applications/battlenet.desktop ]] || fail "Battle.net launcher is not part of default application refresh"
@@ -12,3 +14,26 @@ grep -F '$OMARCHY_PATH/default/applications/battlenet.desktop' "$install_script"
   fail "Battle.net installer installs the launcher from the installer-only template"
 
 pass "Battle.net launcher is only installed by the Battle.net installer"
+
+wow_rule=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+o = {
+  window = function(match, rules)
+    if match.title == "^World of Warcraft$" then
+      print(match.class)
+      print(tostring(match.xwayland))
+      print(tostring(rules.focus_on_activate))
+      print(rules.suppress_event)
+    end
+  end,
+}
+
+require("default.hypr.apps.battlenet")
+LUA
+)
+
+expected_wow_rule=$'^steam_app_battlenet$\ntrue\nfalse\nfullscreen maximize'
+[[ $wow_rule == "$expected_wow_rule" ]] || fail "WoW keeps compositor fullscreen without stealing focus" "$wow_rule"
+
+pass "WoW keeps compositor fullscreen without stealing focus"


### PR DESCRIPTION
## Summary

- keep Hyprland authoritative over World of Warcraft XWayland fullscreen state
- ignore WoW background activation requests so it cannot pull users to another workspace
- add regression coverage for the exact Battle.net class/title rule

## Reproduction

Using a synthetic XWayland window with the live WoW identity (`steam_app_battlenet`, `World of Warcraft`) and the same EWMH events:

- before: client fullscreen cancellation changed internal/client state `2/2 -> 0/0`; activation changed workspace `1 -> 99`
- after: fullscreen remained `2/2`; workspace remained `1`

## Tests

- `bash test/shell.d/battlenet-test.sh`
- `bash test/shell.d/hyprland-default-config-test.sh`
- `luac -p default/hypr/apps/battlenet.lua`
- `bash -n test/shell.d/battlenet-test.sh`
- `shellcheck test/shell.d/battlenet-test.sh`
- live synthetic XWayland baseline/candidate verification

Broad sweep: 184/187 available shell tests passed. The remaining failures either reproduce on upstream or require the unavailable `omarchy-pkgs` checkout: `launch-about-test.sh` (reproduced on clean `upstream/quattro`), `snapper-test.sh`, and `unowned-system-paths-test.sh`; `config-test.sh` was excluded for the same missing checkout.