### PR TITLE
Fix Codex usage collector approval policy

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,8 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+printf '%s\n' "$*" >"$HOME/codex-args"
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -42,6 +44,10 @@ EOF
 
 result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(<"$TEST_HOME/codex-args") == "-s read-only -a never app-server" ]] ||
+  fail "Codex collector starts app-server with supported non-interactive permissions" "$(<"$TEST_HOME/codex-args")"
+pass "Codex collector starts app-server with supported non-interactive permissions"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"


### PR DESCRIPTION
## Summary

- replace the removed Codex `untrusted` approval policy with the supported non-interactive `never` policy
- keep the app server in the existing `read-only` sandbox
- assert the exact app-server launch arguments in the Codex collector test

## Problem

Codex CLI 0.149.0 rejects the collector command before the app server starts:

```text
error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'
[possible values: on-request, never]
```

Because the collector suppresses app-server stderr, the agents panel only reports `Codex limits unavailable` and stops updating rate limits.

## Verification

- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- ran the patched collector against Codex CLI 0.149.0 and confirmed it returned the live plan and weekly limit window
- `git diff --check`

The full `./test/shell` suite reached and passed the Codex scanner test; unrelated local visual/environment checks failed later and the suite eventually requested interactive sudo.