### PR TITLE
Stop a stalled charge reading as a charge-limit hold

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -85,9 +85,23 @@ if awk -v rate="${power_rate_raw:-0}" 'BEGIN { exit !(rate <= 0.2) }'; then
   charge_idle=true
 fi
 
+# The floor of the band a configured limit holds the pack in. A start of 0 is
+# sysfs saying "no start threshold", not "holds from empty", so fall back to the
+# end value there.
+if [[ -n $threshold_start ]] && (( threshold_start > 0 )); then
+  threshold_floor=$threshold_start
+else
+  threshold_floor=$threshold_end
+fi
+
+# "pending-charge" only means AC is present and the EC is not charging. A
+# threshold hold reports it, but so does a failed pack, an insufficient supply
+# and charge_behaviour=inhibit-charge. Claim a hold only when a limit is really
+# configured and the level has reached its band, or a dead battery at 0% reads
+# as a deliberate "Holding at 75-80%".
 charge_holding=false
-if [[ $ac_online == "true" && -n $threshold_end ]]; then
-  if [[ $state == "pending-charge" ]]; then
+if [[ $ac_online == "true" && -n $threshold_end ]] && (( threshold_end < 100 )); then
+  if [[ $state == "pending-charge" ]] && (( percentage >= threshold_floor )); then
     charge_holding=true
   elif [[ $state == "fully-charged" ]] && (( percentage < 99 )); then
     charge_holding=true
@@ -130,6 +144,11 @@ if [[ $charge_holding == "true" ]]; then
   fi
 
   echo "Battery ${percentage}%  ·  Holding at ${threshold_label}  ·  ${power_rate}W / ${capacity}Wh"
+elif [[ $state == "pending-charge" ]]; then
+  # AC is present and the EC is not charging, but no limit is holding it. There
+  # is no time estimate either way, so say what is happening instead of printing
+  # an empty "left".
+  echo "Battery ${percentage}%  ·  Not charging  ·  ${power_rate}W / ${capacity}Wh"
 elif [[ $state == "charging" ]]; then
   echo "Battery ${percentage}%  ·  ${time_remaining} to full  ·   ${power_rate}W / ${capacity}Wh"
 else

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -49,21 +49,25 @@ function batteryFraction(device) {
   return device && device.isPresent ? Math.max(0, Math.min(1, device.percentage)) : 0
 }
 
-// The floor of the band a configured charge limit holds the pack in, as a
-// 0..1 fraction, or -1 when no real limit is configured. The threshold string
-// is the one omarchy-battery-status prints: "75-80%" for a start/end pair,
-// "80%" when only one value is known. An end of 100% is sysfs reporting no
-// limit at all, and a start of 0 is "no start threshold" rather than "holds
-// from empty".
-function chargeHoldFloor(threshold) {
+// The band a configured charge limit holds the pack in, as 0..1 fractions, or
+// null when no real limit is configured. The threshold string is the one
+// omarchy-battery-status prints: "75-80%" for a start/end pair, "80%" when only
+// one value is known. An end of 100% is sysfs reporting no limit at all, and a
+// start of 0 is "no start threshold" rather than "holds from empty".
+function chargeHoldBand(threshold) {
   var match = /(\d+)\s*(?:-\s*(\d+))?\s*%/.exec(String(threshold || ""))
-  if (!match) return -1
+  if (!match) return null
 
   var end = Number(match[2] !== undefined ? match[2] : match[1])
-  if (end >= 100) return -1
+  if (end >= 100) return null
 
   var start = Number(match[1])
-  return (start > 0 ? start : end) / 100
+  return { floor: (start > 0 ? start : end) / 100, end: end / 100 }
+}
+
+function chargeHoldFloor(threshold) {
+  var band = chargeHoldBand(threshold)
+  return band ? band.floor : -1
 }
 
 function chargeThresholdActive(device, onBattery, states, threshold) {
@@ -74,17 +78,26 @@ function chargeThresholdActive(device, onBattery, states, threshold) {
   var fraction = batteryFraction(d)
   if (d.state === s.Discharging) return false
 
-  // PendingCharge is only "AC is present and the EC is not charging", which a
-  // failed pack, an insufficient supply and charge_behaviour=inhibit-charge all
-  // report too. Without a configured limit and a level inside its band there is
-  // no hold to claim.
-  if (d.state === s.PendingCharge) {
-    var floor = chargeHoldFloor(threshold)
-    return floor >= 0 && fraction >= floor
-  }
+  // Each branch below reads a stopped or stalled charge as a deliberate hold,
+  // and none of them can be one without a limit configured to do the holding: a
+  // failed pack, an insufficient supply and charge_behaviour=inhibit-charge stop
+  // the charge just as flatly. omarchy-battery-status gates the same three cases
+  // on the same limit, and the panel has to agree with the line it prints.
+  var band = chargeHoldBand(threshold)
+  if (!band) return false
 
-  if (d.state === s.FullyCharged && fraction < 0.99) return true
+  // PendingCharge is only "AC is present and the EC is not charging", so the
+  // level has to have reached the band before the limit explains it.
+  if (d.state === s.PendingCharge) return fraction >= band.floor
+
+  // A healthy pack reports FullyCharged at the top of whatever band it is held
+  // in; stopping short of full is the limit doing its job.
+  if (d.state === s.FullyCharged) return fraction < 0.99
+
   if (d.state !== s.Charging || fraction >= 0.99) return false
+
+  // A charge that crawls below the limit is a slow charge, not a hold.
+  if (fraction < band.end) return false
 
   return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
 }
@@ -106,12 +119,16 @@ function batteryIcon(device, onBattery, states, threshold) {
 
 function modeLabel(device, onBattery, states, threshold) {
   var d = device || {}
+  var s = states || {}
   if (!d.isPresent) return ""
 
   var percentage = d.isPresent ? d.percentage : 0
   if (chargeThresholdActive(d, onBattery, states, threshold)) return "Threshold"
   if (onBattery) return "On battery"
-  if (!onBattery && percentage >= 1) return "Fully charged"
+  // A worn pack reports FullyCharged short of 100%. The percentage alone
+  // cannot see that, and the icon already reads the state, so the label has
+  // to as well or the two disagree on the same battery.
+  if (d.state === s.FullyCharged || percentage >= 1) return "Fully charged"
   return "Charging"
 }
 
@@ -123,6 +140,7 @@ if (typeof module !== "undefined") {
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    chargeHoldBand: chargeHoldBand,
     chargeHoldFloor: chargeHoldFloor,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -49,41 +49,67 @@ function batteryFraction(device) {
   return device && device.isPresent ? Math.max(0, Math.min(1, device.percentage)) : 0
 }
 
-function chargeThresholdActive(device, onBattery, states) {
+// The floor of the band a configured charge limit holds the pack in, as a
+// 0..1 fraction, or -1 when no real limit is configured. The threshold string
+// is the one omarchy-battery-status prints: "75-80%" for a start/end pair,
+// "80%" when only one value is known. An end of 100% is sysfs reporting no
+// limit at all, and a start of 0 is "no start threshold" rather than "holds
+// from empty".
+function chargeHoldFloor(threshold) {
+  var match = /(\d+)\s*(?:-\s*(\d+))?\s*%/.exec(String(threshold || ""))
+  if (!match) return -1
+
+  var end = Number(match[2] !== undefined ? match[2] : match[1])
+  if (end >= 100) return -1
+
+  var start = Number(match[1])
+  return (start > 0 ? start : end) / 100
+}
+
+function chargeThresholdActive(device, onBattery, states, threshold) {
   var d = device || {}
   var s = states || {}
   if (!(d && d.isPresent && !onBattery)) return false
 
   var fraction = batteryFraction(d)
   if (d.state === s.Discharging) return false
-  if (d.state === s.PendingCharge) return true
+
+  // PendingCharge is only "AC is present and the EC is not charging", which a
+  // failed pack, an insufficient supply and charge_behaviour=inhibit-charge all
+  // report too. Without a configured limit and a level inside its band there is
+  // no hold to claim.
+  if (d.state === s.PendingCharge) {
+    var floor = chargeHoldFloor(threshold)
+    return floor >= 0 && fraction >= floor
+  }
+
   if (d.state === s.FullyCharged && fraction < 0.99) return true
   if (d.state !== s.Charging || fraction >= 0.99) return false
 
   return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
 }
 
-function batteryIcon(device, onBattery, states) {
+function batteryIcon(device, onBattery, states, threshold) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
-  var threshold = chargeThresholdActive(d, onBattery, states)
+  var holding = chargeThresholdActive(d, onBattery, states, threshold)
 
-  if (threshold) return defaultIcons[index]
+  if (holding) return defaultIcons[index]
   if (d.state === states.FullyCharged) return "󰂅"
   if (!onBattery) return chargingIcons[index]
   return defaultIcons[index]
 }
 
-function modeLabel(device, onBattery, states) {
+function modeLabel(device, onBattery, states, threshold) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var percentage = d.isPresent ? d.percentage : 0
-  if (chargeThresholdActive(d, onBattery, states)) return "Threshold"
+  if (chargeThresholdActive(d, onBattery, states, threshold)) return "Threshold"
   if (onBattery) return "On battery"
   if (!onBattery && percentage >= 1) return "Fully charged"
   return "Charging"
@@ -97,6 +123,7 @@ if (typeof module !== "undefined") {
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    chargeHoldFloor: chargeHoldFloor,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -49,12 +49,12 @@ Panel {
 
   function batteryIcon() {
     var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    return Model.batteryIcon(device, root.discharging, upowerStates(), root.batteryInfo.threshold)
   }
 
   function modeLabel() {
     var device = UPower.displayDevice
-    return Model.modeLabel(device, root.discharging, upowerStates())
+    return Model.modeLabel(device, root.discharging, upowerStates(), root.batteryInfo.threshold)
   }
 
   function profileIcon(name) {
@@ -71,7 +71,7 @@ Panel {
   }
   readonly property bool chargeThresholdActive: {
     var device = UPower.displayDevice
-    return Model.chargeThresholdActive(device, root.discharging, upowerStates())
+    return Model.chargeThresholdActive(device, root.discharging, upowerStates(), root.batteryInfo.threshold)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -49,3 +49,96 @@ if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/
 fi
 
 pass "battery status owns capacity and remaining calculations"
+
+# "pending-charge" only means AC is present and the EC is not charging, so a
+# charge-limit hold has to be told apart from a pack the EC refuses for any
+# other reason. Build a machine per case rather than mutating one in place.
+battery_machine() {
+  local state="$1" percentage="$2" start="$3" end="$4"
+  local case_dir
+  case_dir=$(mktemp -d "$tmp_dir/case.XXXXXX")
+
+  mkdir -p "$case_dir/bin" "$case_dir/power/BAT0" "$case_dir/power/AC"
+  printf 'Mains\n' >"$case_dir/power/AC/type"
+  printf '1\n' >"$case_dir/power/AC/online"
+  printf 'Battery\n' >"$case_dir/power/BAT0/type"
+  printf '0\n' >"$case_dir/power/BAT0/power_now"
+  printf '%s\n' "$start" >"$case_dir/power/BAT0/charge_control_start_threshold"
+  printf '%s\n' "$end" >"$case_dir/power/BAT0/charge_control_end_threshold"
+
+  {
+    printf '#!/bin/bash\n'
+    printf 'if [[ $1 == "-e" ]]; then echo /org/freedesktop/UPower/devices/battery_BAT0; exit 0; fi\n'
+    printf 'if [[ $1 == "-i" ]]; then\n'
+    printf '  echo "  native-path:          BAT0"\n'
+    printf '  echo "  state:                %s"\n' "$state"
+    printf '  echo "  energy-full:          58.0 Wh"\n'
+    printf '  echo "  energy-rate:          0 W"\n'
+    printf '  echo "  percentage:           %s%%"\n' "$percentage"
+    printf '  exit 0\n'
+    printf 'fi\n'
+    printf 'exit 1\n'
+  } >"$case_dir/bin/upower"
+  chmod +x "$case_dir/bin/upower"
+
+  printf '%s' "$case_dir"
+}
+
+battery_status_for() {
+  local case_dir
+  case_dir=$(battery_machine "$@")
+
+  OMARCHY_POWER_SUPPLY_PATH="$case_dir/power" PATH="$case_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-battery-status" --shell
+}
+
+battery_line_for() {
+  local case_dir
+  case_dir=$(battery_machine "$@")
+
+  OMARCHY_POWER_SUPPLY_PATH="$case_dir/power" PATH="$case_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-battery-status"
+}
+
+assert_battery_state() {
+  local description="$1" expected="$2"
+  shift 2
+  local output
+  output=$(battery_status_for "$@")
+
+  grep -Fx "state	$expected" <<<"$output" >/dev/null ||
+    fail "$description" "$output"
+  pass "$description"
+}
+
+# A dead pack the EC refuses to charge, on a machine with no limit configured.
+assert_battery_state "battery status does not call an unheld stall a charge limit" \
+  "pending-charge" "pending-charge" 0 0 100
+
+# UPower's hwdb default supplies a 75-80 threshold this machine never set, so
+# the level is the only thing that separates a hold from a refusal.
+assert_battery_state "battery status does not claim a hold below the threshold band" \
+  "pending-charge" "pending-charge" 0 75 80
+
+# A real hold: the pack sat up to the end threshold and the EC stopped.
+assert_battery_state "battery status reports a hold inside the threshold band" \
+  "holding" "pending-charge" 80 75 80
+
+# A start of 0 is sysfs saying there is no start threshold, not that the limit
+# holds from empty.
+assert_battery_state "battery status does not read a zero start threshold as holding from empty" \
+  "pending-charge" "pending-charge" 40 0 80
+assert_battery_state "battery status reports a hold at a lone end threshold" \
+  "holding" "pending-charge" 80 0 80
+
+# The notification line has no time estimate to print for a stall, so it has to
+# name the state rather than fall through to an empty "left".
+line=$(battery_line_for "pending-charge" 0 0 100)
+[[ $line == *"Not charging"* && $line != *"left"* ]] ||
+  fail "battery status names an unheld stall in the notification line" "$line"
+pass "battery status names an unheld stall in the notification line"
+
+line=$(battery_line_for "pending-charge" 80 75 80)
+[[ $line == *"Holding at 75-80%"* ]] ||
+  fail "battery status still names a real hold in the notification line" "$line"
+pass "battery status still names a real hold in the notification line"

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -23,7 +23,18 @@ assertDeepEqual(
 assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
 
-assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states, '75-80%'), 'power detects threshold by pending charge state')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0, state: states.PendingCharge }, false, states, '75-80%'), 'power does not flag a pack below the hold band as threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.PendingCharge }, false, states), 'power does not flag pending charge as threshold without a limit')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.PendingCharge }, false, states, '0-100%'), 'power reads a 100% end threshold as no limit')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states, '80%'), 'power holds at a single-value threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.7, state: states.PendingCharge }, false, states, '80%'), 'power does not hold below a single-value threshold')
+assertEqual(power.chargeHoldFloor('0-80%'), 0.8, 'power reads a zero start threshold as no start band')
+assertEqual(
+  power.modeLabel({ isPresent: true, percentage: 0, state: states.PendingCharge }, false, states, '75-80%'),
+  'Charging',
+  'power does not label a stalled pack below the band as Threshold'
+)
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -35,8 +35,29 @@ assertEqual(
   'Charging',
   'power does not label a stalled pack below the band as Threshold'
 )
-assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
-assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states, '75-80%'), 'power detects threshold by stalled charging')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states, '75-80%'), 'power does not flag active charging as threshold')
+
+// A stalled charge is only a hold when a limit is there to hold it, and only
+// once the pack has reached that limit. omarchy-battery-status gates its own
+// charging branch the same way; these two layers describe the same battery.
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power does not flag a stalled charge as threshold without a limit')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states, '75-80%'), 'power does not flag a stalled charge below the limit as threshold')
+assertEqual(
+  power.modeLabel({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states, '75-80%'),
+  'Charging',
+  'power labels a slow charge below the limit as charging'
+)
+
+// FullyCharged short of full is the same claim: with no limit configured it is
+// a worn pack reporting its own ceiling, not a hold.
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.FullyCharged }, false, states, '75-80%'), 'power detects a limit holding below full')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.FullyCharged }, false, states), 'power does not flag a worn pack reporting full early as threshold')
+assertEqual(
+  power.modeLabel({ isPresent: true, percentage: 0.8, state: states.FullyCharged }, false, states),
+  'Fully charged',
+  'power labels a worn pack reporting full early as fully charged'
+)
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')


### PR DESCRIPTION
Fixes #7803.

`pending-charge` only means "AC is present and the EC is not charging the pack". A threshold hold reports it, but so does a failed battery, an insufficient supply, and `charge_behaviour=inhibit-charge`. Two implementations collapsed that to "a charge limit is holding it":

- `shell/plugins/panels/power/Model.js` returned `true` for `PendingCharge` unconditionally and never read a threshold value at all, driving the `Charge limit` / `Holding` pair, the `Threshold` mode label, and the battery icon.
- `bin/omarchy-battery-status` guarded on a threshold *existing* but not on the level, while the `charging` branch two lines below already applied `percentage >= threshold_end`.

Both now claim a hold only when a limit is really configured and the level has reached its band. `Model.js` gets the threshold string the panel already reads from `omarchy-battery-status --shell`, so the QML side stops classifying on state alone. A stall with no hold behind it prints `Not charging` rather than falling through to the `left` branch, which has no time estimate to print.

Two details worth calling out:

- A `charge_control_end_threshold` of `100` is sysfs saying no limit is configured, so it no longer counts as one. That alone cures the T14 Gen 6 report in #7374's comments.
- A start threshold of `0` is "no start threshold", not "holds from empty", so the band floor falls back to the end value there.

The reporter's machine also hits #7374 — upower's hwdb default supplies a `75-80` limit it never set — so the level check, not the `100` check, is what fixes it there. The two are independent; this holds either way.

### Evidence

Rebuilt the reporter's X1 Yoga as a fake `OMARCHY_POWER_SUPPLY_PATH` plus a `upower` stub: dead pack at 0%, `pending-charge`, sysfs `0`/`100`, upower reporting the hwdb `75-80`. Before:

```
Battery 0%  ·  Holding at 75-80%  ·  0W / 58Wh
```

byte-for-byte what the issue reports. After:

```
Battery 0%  ·  Not charging  ·  0W / 58Wh
```

and a genuine hold is untouched — same machine at 80% in a real 75-80 band still prints `Battery 80%  ·  Holding at 75-80%  ·  0W / 58Wh`.

Same on the JS side, driving `Model.js` directly: `chargeThresholdActive` on that pack went `true` → `false` and `modeLabel` went `Threshold` → `Charging`, while a pack at 80% with a `75-80%` limit still returns `true`.

Tests are in both suites — seven new cases in `battery-status-test.sh`, six in `power-test.sh`, covering the unheld stall, the below-band stall, the real hold, the `100` end, and the `0` start. I checked they have teeth by reverting the fix and confirming each file fails.

`test/shell.d/{battery-status,power,power-present,battery,system-power,bin-style}-test.sh` all pass.

### What I did not run

I developed this on macOS, so I could not run the graphical acceptance suite, and I have not seen the change in the running Quickshell UI — `agents/skills/visual-verification.md` asks for that and I can't provide it. The panel behaviour is exercised through `Model.js` under node instead; the QML change is three call sites gaining a fourth argument.

One behaviour I can't verify on hardware: `batteryInfo` starts empty, so during the first refresh cycle after the panel opens a genuine hold reads as "Time to full" for a moment before the threshold arrives. Previously it read as a hold immediately. I think that's the right trade — it's the same data the `Charge limit` value was already waiting on — but a second opinion from someone with a limit set would be worth having.

This was AI-assisted; the diagnosis in #7803 did the hard part.