### PR TITLE
Quote input device names before embedding them in Lua

### DIFF
--- a/bin/omarchy-lua-quote
+++ b/bin/omarchy-lua-quote
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Quote a string for embedding in a double-quoted Lua string literal
+# omarchy:args=<string>
+# omarchy:hidden=true
+
+# Externally sourced strings (e.g. USB device names from hyprctl) land inside
+# double-quoted Lua string literals via hyprctl eval and persisted toggle state
+# files. Escape the only characters that can break out of or corrupt such a
+# literal: backslashes first, so the escapes added below stay literal, then
+# double quotes, then raw newlines and carriage returns, which Lua rejects
+# inside a short literal. Everything else stays byte-for-byte intact so the
+# string still matches what Hyprland reports.
+value=${1-}
+value=${value//\\/\\\\}
+value=${value//\"/\\\"}
+value=${value//$'\n'/\\n}
+value=${value//$'\r'/\\r}
+printf '%s\n' "$value"

--- a/bin/omarchy-toggle-input-device
+++ b/bin/omarchy-toggle-input-device
@@ -26,16 +26,21 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
+# The device name is reported by the peripheral itself and can contain quotes
+# or other characters that would break out of the Lua string literals below
+# (live eval now, and the persisted state file on every Hyprland reload).
+device_lua="$(omarchy-lua-quote "$device")"
+
 enable() {
-  hyprctl eval "hl.device({ name = \"$device\", enabled = true })" >/dev/null
+  hyprctl eval "hl.device({ name = \"$device_lua\", enabled = true })" >/dev/null
   rm -f "$STATE_FILE"
   omarchy-osd -i "$ICON" -m "$LABEL enabled"
 }
 
 disable() {
-  hyprctl eval "hl.device({ name = \"$device\", enabled = false })" >/dev/null
+  hyprctl eval "hl.device({ name = \"$device_lua\", enabled = false })" >/dev/null
   mkdir -p "$(dirname "$STATE_FILE")"
-  printf 'hl.device({ name = "%s", enabled = false })\n' "$device" >"$STATE_FILE"
+  printf 'hl.device({ name = "%s", enabled = false })\n' "$device_lua" >"$STATE_FILE"
   omarchy-osd -i "$ICON" -m "$LABEL disabled"
 }
 

--- a/test/cli
+++ b/test/cli
@@ -807,3 +807,30 @@ assert_output_contains "a --help behind -- belongs to the command and still forw
 
 output=$("$TMPDIR/omarchy" parenthelp --helpme x--help)
 assert_output_contains "help lookalike tokens do not trigger help" "$output" "parenthelp-parent-ran args=[--helpme x--help]"
+
+# USB device names are peripheral-controlled and land inside double-quoted Lua
+# string literals (hyprctl eval, persisted toggle state files), so the quoting
+# helper must keep hostile names inside the literal.
+output=$(omarchy-lua-quote 'ELAN1200:00 04F3:30BA Touchpad')
+[[ $output == 'ELAN1200:00 04F3:30BA Touchpad' ]] || fail "lua quote leaves a plain device name untouched"
+pass "lua quote leaves a plain device name untouched"
+
+output=$(omarchy-lua-quote 'foo"bar')
+[[ $output == 'foo\"bar' ]] || fail "lua quote escapes double quotes"
+pass "lua quote escapes double quotes"
+
+output=$(omarchy-lua-quote 'foo\bar')
+[[ $output == 'foo\\bar' ]] || fail "lua quote escapes backslashes"
+pass "lua quote escapes backslashes"
+
+output=$(omarchy-lua-quote $'line1\nline2')
+[[ $output == 'line1\nline2' ]] || fail "lua quote escapes newlines"
+pass "lua quote escapes newlines"
+
+output=$(omarchy-lua-quote $'line1\rline2')
+[[ $output == 'line1\rline2' ]] || fail "lua quote escapes carriage returns"
+pass "lua quote escapes carriage returns"
+
+output=$(omarchy-lua-quote 'evil" }); os.execute("id"); --')
+[[ $output == 'evil\" }); os.execute(\"id\"); --' ]] || fail "lua quote neutralizes a Lua injection attempt"
+pass "lua quote neutralizes a Lua injection attempt"


### PR DESCRIPTION
Touchpad and touchscreen names come from the peripheral's own USB string descriptors, so they are attacker-controlled data: a malicious or compromised device can report a name containing a double quote. `omarchy-toggle-input-device` embedded that name unescaped into two Lua string literals — the live `hyprctl eval "hl.device({ name = \"$device\", ... })"` call and the persisted toggle state file under `~/.local/state/omarchy/toggles/hypr/`, which Hyprland sources on every config reload. A crafted device name could therefore execute arbitrary Lua as the session user, immediately and persistently across restarts.

The fix adds a small `omarchy-lua-quote` helper that escapes the only characters able to break out of or corrupt a double-quoted Lua literal — backslash first so the later escapes stay literal, then double quote, then raw newline and carriage return, which Lua rejects inside a short literal — and leaves every other byte untouched, so the quoted name still matches what Hyprland reports. `omarchy-toggle-input-device` quotes the name once and uses the quoted form for both sinks. New `test/cli` cases pin the behavior against a plain device name, embedded quotes, backslashes, newlines, carriage returns, and a full breakout payload, and the quoted output was verified against Lua 5.4 to parse as a pure string literal and round-trip byte-for-byte.

Reviewed by Codex at xhigh effort: it round-tripped every non-NUL byte through Lua 5.4 and 5.5 against both sink expressions and found no exploitable defect or regression; the carriage-return test case its review prompted is part of the change.

🤖 Generated by Kimi K3 in OpenCode. Reviewed by Codex XHigh.
