### PR TITLE
Keep the cursor in place when switching workspaces

### DIFF
--- a/default/hypr/looknfeel.lua
+++ b/default/hypr/looknfeel.lua
@@ -116,7 +116,9 @@ hl.config({
 
   cursor = {
     hide_on_key_press = true,
-    warp_on_change_workspace = 1,
+    -- Keep the cursor where it is on workspace switches instead of warping
+    -- it to the last focused window.
+    warp_on_change_workspace = 0,
   },
 
   binds = {


### PR DESCRIPTION
## Summary

`default/hypr/looknfeel.lua` sets `cursor:warp_on_change_workspace = 1`, which moves the cursor to the last focused window on every workspace change. In practice this makes the pointer jump to the center of the screen when cycling workspaces, which many users find disruptive (it also breaks muscle memory for hovering UI).

Hyprland's own default for this setting is `0`, so this pins it explicitly with a short comment documenting why.

## Testing

- `./test/all`: shell suite passes except three pre-existing failures that reproduce identically on `b71c60fe` and are unrelated (`config-test.sh` and `unowned-system-paths-test.sh` expect an `omarchy-pkgs` checkout; `snapper-test.sh` is committed without its executable bit).
- Verified locally on Hyprland 0.56.2: `hyprctl configerrors` clean after reload and `hyprctl getoption cursor:warp_on_change_workspace` reports `0`.
