### PR TITLE
[Security] Keep the Windows VM password out of the RDP client's argument list

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -363,8 +363,31 @@ To stop: omarchy-windows-vm stop"
   fi
   # If scale is less than 130%, don't set any scale (use default 100)
 
-  # Connect with RDP in fullscreen (auto-detects resolution)
-  xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 -grab-keyboard /sound /microphone /clipboard /cert:ignore /title:"Windows VM - Omarchy" /dynamic-resolution /gfx:AVC444 /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
+  RDP_ARGS=(
+    "/u:$WIN_USER"
+    "/p:$WIN_PASS"
+    /v:127.0.0.1:3389
+    -grab-keyboard
+    /sound
+    /microphone
+    /clipboard
+    /cert:ignore
+    "/title:Windows VM - Omarchy"
+    /dynamic-resolution
+    /gfx:AVC444
+    /floatbar:sticky:off,default:visible,show:fullscreen
+  )
+  if [[ -n $RDP_SCALE ]]; then
+    RDP_ARGS+=("$RDP_SCALE")
+  fi
+
+  # Connect with RDP in fullscreen (auto-detects resolution). The arguments go
+  # in over stdin rather than on the command line: /proc/<pid>/cmdline is
+  # world-readable, so passing the VM password as /p:"$WIN_PASS" would show it
+  # to every other user on the machine for as long as the session is open.
+  # /args-from must stay the only argument here — FreeRDP rejects it outright
+  # when it is combined with any other, so new flags belong in RDP_ARGS above.
+  printf '%s\n' "${RDP_ARGS[@]}" | xfreerdp3 /args-from:stdin
 
   # After RDP closes, stop the container unless --keep-alive was specified
   if [[ $KEEP_ALIVE = "false" ]]; then


### PR DESCRIPTION
`omarchy-windows-vm launch` hands the VM password to the RDP client on its command line:

```bash
xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 ...
```

`/proc/<pid>/cmdline` is world-readable, so for as long as the session stays open, any other user on the machine reads the password with one command:

```
$ ps -eo cmd | grep xfreerdp3
xfreerdp3 /u:paolo /p:<the VM password> /v:127.0.0.1:3389 -grab-keyboard ...
```

No root, no exploit. The credential is the one chosen during `omarchy-windows-vm install`, and it stays exposed for the whole session rather than for an instant.

Impact is bounded: it needs an attacker who already runs code on the machine as a *different* user, so on a single-user laptop it is close to moot. It matters on shared workstations and wherever a service account or a sandboxed process runs under another uid. I looked for ways it could travel further and did not find any — `omarchy-debug` collects no process list, and a crashed client's arguments land in the journal's structured `COREDUMP_CMDLINE` field, which the plain-text capture omits.

## Change

- Build the client arguments in an array and pass them over stdin with `/args-from:stdin`. The process list then shows only `xfreerdp3 /args-from:stdin`.
- The argument list itself is unchanged; the array also fixes the unquoted `$RDP_SCALE` expansion on the old line.
- A comment records that `/args-from` must stay the sole argument: `cmdline.c` only takes that path under `argc == 2` and otherwise fails with "can not be used in combination with other arguments!", so a future flag belongs in `RDP_ARGS`.

## Verification

- The generated argument list is byte-identical to the old one, checked with a password containing spaces and shell metacharacters, and with `RDP_SCALE` both set and empty (empty adds no stray argument).
- Launched against a running Windows VM and read the client's own `/proc/<pid>/cmdline`: it contains only `xfreerdp3 /args-from:stdin`, and the session connects and behaves normally.
- `./test/all`: `test/shell.d/windows-vm-test.sh` passes. Four unrelated files fail (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`); they fail identically on a clean checkout of `quattro` without this change.
- `/args-from` has been available since FreeRDP **3.0.0**, so there is no version to guard against for a project that already requires `xfreerdp3`. Tested here on 3.30.0.
