### PR TITLE
Dictation indicator toggles dictation on left click

### DIFF
--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -31,8 +31,12 @@ BarIndicator {
     }
   }
 
-  onPressed: function() {
+  onPressed: function(button) {
     if (!root.bar) return
-    root.bar.run("omarchy-voxtype-config")
+    // Left click toggles dictation, matching the SUPER+CTRL+X binding and the
+    // toggle-on-click behavior of every sibling indicator. Any other button
+    // opens the Voxtype config TUI.
+    if (button === Qt.LeftButton) root.bar.run("voxtype record toggle")
+    else root.bar.run("omarchy-voxtype-config")
   }
 }

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -204,7 +204,8 @@ ShellRoot {
         root.injectBar(dictation)
         dictation.triggerPress(Qt.LeftButton)
         dictation.triggerPress(Qt.RightButton)
-        root.assertTrue(root.commandCount("omarchy-voxtype-config") === 2, "Dictation clicks run config command")
+        root.assertTrue(root.commandCount("voxtype record toggle") === 1, "Dictation left click toggles dictation")
+        root.assertTrue(root.commandCount("omarchy-voxtype-config") === 1, "Dictation right click opens the Voxtype config")
         root.assertTrue(root.commandCount("omarchy-voxtype-model") === 0, "Dictation clicks do not run model command")
       }
 


### PR DESCRIPTION
Closes #7900.

## What

The dictation glyph sat in the hover cluster acting like a toggle but opened the Voxtype config TUI on **both** left and right click — the only indicator of the six that didn't act on its own mode, and it left no way to start dictation from the bar at all.

- **Left click** now runs `voxtype record toggle` — the exact action of the existing `SUPER+CTRL+X` binding (`default/hypr/bindings/voxtype.lua`)
- **Right click** still opens `omarchy-voxtype-config`

## Why this shape

The manual describes these glyphs as status modes, and every sibling (`Dnd`, `NightLight`, `StayAwake`, `ScreenRecording`) flips its mode on press. Keeping config on right-click preserves one-click access to settings without breaking the cluster's convention.

## Tests

Updated `test/shell.d/fixtures/indicator-contract/shell.qml`, which previously *codified* the old behavior (asserting two clicks produced two config runs). It now asserts:

- left press → exactly one `voxtype record toggle`
- right press → exactly one `omarchy-voxtype-config`
- no `omarchy-voxtype-model` command from either

`indicator-contract-test.sh`, `voxtype-invitation-test.sh`, and the binding-conflict tests pass; full `./test/shell` shows only the three pre-existing environmental failures from a missing local `omarchy-pkgs` checkout.