### PR TITLE
Clock and calendar follow the system locale

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -57,7 +57,10 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    // Locale-aware form: Qt.formatDateTime has no locale overload and formats
+    // with the default C locale, so day and month names stay English no matter
+    // what the system locale is.
+    return date.toLocaleString(Qt.locale(), activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -312,7 +312,7 @@ Panel {
               Text {
                 id: heroDate
                 anchors.verticalCenter: parent.verticalCenter
-                text: Qt.formatDate(root.today, "MMMM d")
+                text: root.today.toLocaleDateString(Qt.locale(), "MMMM d")
                 color: heroMouse.containsMouse
                   ? Style.hoverStateColor(root.contentForeground, Color.accent)
                   : root.contentForeground
@@ -713,7 +713,7 @@ Panel {
                 // "MAY 2026" and a "SEPTEMBER 2026".
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.formatDate(root.viewDate, "MMMM yyyy").toUpperCase()
+                text: root.viewDate.toLocaleDateString(Qt.locale(), "MMMM yyyy").toUpperCase()
                 color: Qt.darker(root.contentForeground, 1.4)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -212,7 +212,13 @@ assert(/function close\(\) \{\s*\n\s*setCenterHoverRevealSuppressed\(false\)/.te
 assert(/width: Math\.max\(calendarScroll\.width, gridColumn\.width\)/.test(panelSource), 'calendar scrolls rather than clipping the grid on a narrow popup')
 assert(/enabled: !root\.viewingCurrentMonth/.test(panelSource) && /onClicked: root\.goToToday\(\)/.test(panelSource), 'calendar hero returns to today once the view has stepped away')
 assert(!/clampMonth/.test(panelSource), 'calendar steps freely into future months')
-assert(/Qt\.formatDate\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+assert(/root\.today\.toLocaleDateString\(Qt\.locale\(\), "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+// Qt.formatDate/formatDateTime have no locale overload and always name days
+// and months in English, so neither may survive anywhere in the clock.
+assert(!/Qt\.formatDate(Time)?\(/.test(panelSource), 'calendar keeps no locale-blind date formatting')
+assert(!/Qt\.formatDate(Time)?\(/.test(widgetSource), 'clock bar label keeps no locale-blind date formatting')
+assert(/toLocaleString\(Qt\.locale\(\), activeFormat/.test(widgetSource), 'clock bar label formats through the system locale')
+assert(/root\.viewDate\.toLocaleDateString\(Qt\.locale\(\), "MMMM yyyy"\)/.test(panelSource), 'calendar month header follows the system locale')
 assert(/id: yearLabel/.test(panelSource) && /root\.yearDone/.test(panelSource), 'calendar panel shows the year progress bar')
 
 // The memento mori bar is opt-in: double-tapping the year bar asks for an age,


### PR DESCRIPTION
Closes #7760.

## What

The bar clock and the calendar popup rendered weekday and month names in English regardless of the system locale (`LANG=sv_SE.UTF-8` still showed "Saturday 11:18" and "August 22").

## Root cause (as reported, confirmed in source)

`Qt.formatDateTime(date, format)` / `Qt.formatDate(date, format)` have **no locale overload** — QML's global functions always format with the default C locale, so day and month names are English no matter what. `Qt.locale()` resolves correctly; it just never gets asked.

## Fix

Route all three call sites through the locale-aware `Date` methods:

- `BarWidget.qml` `formatted()`: `date.toLocaleString(Qt.locale(), activeFormat.replace(...))` — keeps the ISO-week `ww` substitution
- `Panel.qml` hero date: `root.today.toLocaleDateString(Qt.locale(), "MMMM d")`
- `Panel.qml` month header: `root.viewDate.toLocaleDateString(Qt.locale(), "MMMM yyyy").toUpperCase()`

The reporter verified this exact API on sv_SE (`"lördag augusti"`), including that the tempting 3-arg `Qt.formatDateTime(date, Qt.locale(), fmt)` is *not* a valid alternative.

## Tests

`clock-test.sh` now asserts all three sites format through `Qt.locale()`, and that neither clock file retains a call to the locale-blind `Qt.formatDate`/`Qt.formatDateTime`. Full suite green.

## Verification note

I could not flip my machine to a non-English locale for a visual check — if a maintainer or reporter can confirm the bar reads localized names after this lands, that closes the loop.