### PR TITLE
Agents panel: fix Codex limits for Codex CLI 0.149.0

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -527,8 +527,13 @@ def fetch_codex_rpc():
     return result
 
   try:
+    # Codex 0.149 dropped "untrusted" from --ask-for-approval, which made this
+    # spawn exit before answering initialize and left the limits meters empty.
+    # This poller is detached: an approval prompt can never be answered, so
+    # "never" plus the read-only sandbox is both valid across CLI versions and
+    # the only policy that cannot stall the poll.
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,8 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+[[ -n $CODEX_SPAWN_LOG ]] && printf '%s\n' "$*" >>"$CODEX_SPAWN_LOG"
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -54,6 +56,19 @@ pass "Codex collector does not double-count cache or reasoning tokens"
 [[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
   fail "Codex collector identifies itself with an empty limits list" "$result"
 pass "Codex collector identifies itself with an empty limits list"
+
+# Codex 0.149 dropped "untrusted" from --ask-for-approval, which made the
+# app-server exit before answering initialize and left the limits meters dark.
+# The poller is detached, so its policy must also be one that cannot prompt.
+CODEX_SPAWN_LOG="$TEST_HOME/codex-spawn.log" \
+  HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-codex" >/dev/null
+grep -q -- '-a never' "$TEST_HOME/codex-spawn.log" ||
+  fail "Codex collector spawns app-server with a prompt-free approval policy" "$(cat "$TEST_HOME/codex-spawn.log")"
+if grep -q 'untrusted' "$TEST_HOME/codex-spawn.log"; then
+  fail "Codex collector still spawns app-server with the removed untrusted policy" "$(cat "$TEST_HOME/codex-spawn.log")"
+fi
+pass "Codex collector spawns app-server with a prompt-free approval policy"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.


### PR DESCRIPTION
Closes #7873.

## What

The Codex collector spawned the app-server with `-a untrusted`, and Codex CLI 0.149.0 removed that value from `--ask-for-approval`:

```
error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'
  [possible values: on-request, never]
```

The process exited on argument parsing before ever answering `initialize`, so every subscription-limit meter read "Codex Limits Unavailable / initialize".

## Fix

Spawn with `-a never` instead. Two reasons for that specific value over dropping the flag or using `on-request`:

1. **Valid across versions** — both old CLIs (where all four policies existed) and 0.149+ accept it.
2. **Cannot stall a detached poller** — this collector runs detached with no UI; an approval policy that can prompt is one that can hang the poll forever. Combined with the existing `-s read-only` sandbox, `never` is the only policy that can never block.

## Verification

- Reproduced the argparse failure locally on codex 0.149.0, then confirmed `-a never app-server` answers the `initialize` RPC (both `never` and `on-request` do).
- The collector now completes its RPC handshake against real codex 0.149.0 (`usageStatusText` empty instead of "limits unavailable"); limit meters populate wherever the CLI is authenticated.
- `agent-usage-codex-scanner-test.sh` extended: the stubbed codex logs its spawn args, and the test asserts `-a never` is present and `untrusted` never returns.