### PR TITLE
window-pop: don't tile an already-floating window

### DIFF
--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -10,6 +10,7 @@ y=${4:-}
 
 active=$(hyprctl activewindow -j)
 pinned=$(echo "$active" | jq ".pinned")
+floating=$(echo "$active" | jq ".floating")
 addr=$(echo "$active" | jq -r ".address")
 window="address:$addr"
 
@@ -25,7 +26,13 @@ if [[ $pinned == "true" ]]; then
   hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
   hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
 elif [[ -n $addr ]]; then
-  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  # An already-floating window must keep its state: toggling would tile it,
+  # and the absolute resize below would then rewrite the dwindle split ratio
+  # instead of sizing a floating window. Skip the toggle so the rest of the
+  # pop presentation lands on a floating window either way.
+  if [[ $floating != "true" ]]; then
+    hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  fi
   hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
 
   if [[ -n $x && -n $y ]]; then

--- a/test/shell.d/window-pop-test.sh
+++ b/test/shell.d/window-pop-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+DISPATCH_LOG="$tmp_dir/dispatch.log"
+export DISPATCH_LOG
+
+# hyprctl stub: `activewindow -j` replays the window state the test sets via
+# WINDOW_JSON; every dispatch lands in DISPATCH_LOG so assertions read the
+# exact command sequence the pop script produced.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "activewindow" ]]; then
+  printf '%s' "$WINDOW_JSON"
+  exit 0
+fi
+printf '%s\n' "$*" >>"$DISPATCH_LOG"
+exit 0
+SH
+chmod +x "$stub_bin/hyprctl"
+
+run_pop() {
+  : >"$DISPATCH_LOG"
+  WINDOW_JSON="$1" PATH="$stub_bin:$PATH" \
+    "$ROOT/bin/omarchy-hyprland-window-pop" "${@:2}"
+}
+
+# A tiled window gets the full pop: float, resize, center, pin, raise, tag.
+run_pop '{"address":"0x1","pinned":false,"floating":false}'
+grep -Fq 'action = "toggle"' "$DISPATCH_LOG" ||
+  fail "popping a tiled window floats it" "$(cat "$DISPATCH_LOG")"
+grep -Fq 'window.resize' "$DISPATCH_LOG" ||
+  fail "popping a tiled window sizes it" "$(cat "$DISPATCH_LOG")"
+if grep -cF 'window.pin' "$DISPATCH_LOG" | grep -qv '^1$'; then
+  fail "popping pins exactly once" "$(cat "$DISPATCH_LOG")"
+fi
+grep -Fq '"+pop' "$DISPATCH_LOG" ||
+  fail "popping tags the window" "$(cat "$DISPATCH_LOG")"
+pass "popping a tiled window floats, sizes, pins, and tags it"
+
+# An already-floating window keeps its state: no float toggle, so the resize
+# can never land on a tiled window and rewrite the dwindle split.
+run_pop '{"address":"0x2","pinned":false,"floating":true}'
+if grep -Fq 'action = "toggle"' "$DISPATCH_LOG"; then
+  fail "popping an already-floating window must not toggle floating" "$(cat "$DISPATCH_LOG")"
+fi
+grep -Fq 'window.resize' "$DISPATCH_LOG" ||
+  fail "an already-floating window still gets the pop size" "$(cat "$DISPATCH_LOG")"
+grep -Fq '"+pop' "$DISPATCH_LOG" ||
+  fail "an already-floating window still gets tagged as popped" "$(cat "$DISPATCH_LOG")"
+pass "popping an already-floating window skips the float toggle"
+
+# An explicit position replaces the centering step for both entry states.
+run_pop '{"address":"0x3","pinned":false,"floating":true}' 800 600 20 30
+grep -Fq 'window.move' "$DISPATCH_LOG" ||
+  fail "an explicit x/y moves the window" "$(cat "$DISPATCH_LOG")"
+if grep -Fq 'window.center' "$DISPATCH_LOG"; then
+  fail "an explicit x/y must not also center" "$(cat "$DISPATCH_LOG")"
+fi
+pass "an explicit x/y moves instead of centering"
+
+# The pinned branch is the unpick path and stays untouched by the guard.
+run_pop '{"address":"0x4","pinned":true,"floating":true}'
+[[ $(grep -c . "$DISPATCH_LOG") == 3 ]] || fail "a pinned window runs exactly three dispatches" "$(cat "$DISPATCH_LOG")"
+if grep -Fq 'window.resize' "$DISPATCH_LOG"; then
+  fail "unpinning never resizes" "$(cat "$DISPATCH_LOG")"
+fi
+pass "a pinned window unpins, tiles, and drops the tag without resizing"
+
+# No active window is a no-op.
+run_pop ''
+[[ ! -s $DISPATCH_LOG ]] || fail "no active window dispatches nothing" "$(cat "$DISPATCH_LOG")"
+pass "no active window dispatches nothing"


### PR DESCRIPTION
Closes #7721.

## What

`omarchy-hyprland-window-pop` (SUPER+O) toggled floating **unconditionally** before applying its absolute resize. On a window that was already floating and unpinned — reachable from stock defaults via the shipped Steam float rule — the toggle *tiled* the window, and the follow-up `1300x900` exact resize then landed on a tiled window, rewriting the dwindle split ratio instead of sizing anything. First press on Steam mangled the layout; later presses behaved, which is why it read as a once-per-boot glitch.

## Fix

Read `floating` from `hyprctl activewindow -j` alongside `pinned`, and dispatch the float toggle only when the window is currently tiled. Everything after it (resize → move/center → pin → raise → `+pop` tag) still runs either way, so an already-floating window gets the same pop presentation without ever passing through tiled state. The pinned (unpop) branch is untouched.

## Tests

New `test/shell.d/window-pop-test.sh` stubs `hyprctl`, capturing every dispatched command, and covers five entry states:

- tiled → full sequence incl. float toggle
- **floating+unpinned → no float toggle; resize/center/pin/tag still applied**
- explicit x/y moves instead of centering
- pinned → exactly three dispatches, never resizes
- no active window → no-op

## Verified live

On a real Hyprland session: an already-floating, unpinned window popped by this branch stays `floating:true` through the operation and ends pinned at the requested size — previously it ended up tiled with a rewritten split. A tiled window still gets the full float+pin treatment.