### PR TITLE
Fix Codex usage limits with current app-server approval policy

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,9 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      # The collector has no interactive approval channel. `never` is the
+      # current Codex CLI policy for non-interactive app-server clients.
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -13,6 +13,11 @@ mkdir -p "$TEST_HOME/.codex/sessions/$(date +%Y/%m/%d)" "$TEST_HOME/bin"
 cat >"$TEST_HOME/bin/codex" <<'EOF'
 #!/bin/bash
 
+[[ $* == "-s read-only -a never app-server" ]] || {
+  printf 'unexpected Codex app-server args: %s\n' "$*" >&2
+  exit 2
+}
+
 while read -r request; do
   id=$(jq -r '.id // empty' <<<"$request")
   method=$(jq -r '.method // empty' <<<"$request")
@@ -54,6 +59,10 @@ pass "Codex collector does not double-count cache or reasoning tokens"
 [[ $(jq -c '.id + "/" + (.limits|tostring)' <<<"$result") == '"codex/[]"' ]] ||
   fail "Codex collector identifies itself with an empty limits list" "$result"
 pass "Codex collector identifies itself with an empty limits list"
+
+[[ $(jq -r '.usageStatusText' <<<"$result") == "" ]] ||
+  fail "Codex collector completes the app-server handshake" "$result"
+pass "Codex collector completes the app-server handshake"
 
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.


### PR DESCRIPTION
## Summary
- Use Codex CLI's current non-interactive approval policy when starting the app-server.
- Add a regression check that rejects the obsolete approval-policy argument and requires a successful app-server handshake.

## Testing
- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- `./test/all (the suite reaches the changed tests successfully; six unrelated environment/fixture tests fail because the omarchy-pkgs companion checkout is unavailable and the sandbox lacks normal compositor/runtime paths)`