### PR TITLE
Fix Codex usage collector's stale --ask-for-approval value

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -528,7 +528,7 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "untrusted", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
- `bin/omarchy-agent-usage-codex` spawns `codex ... app-server` with `-a untrusted` to probe `account/read` and `account/rateLimits/read` over RPC.
- The installed Codex CLI no longer accepts `untrusted` for `-a`/`--ask-for-approval` (only `on-request`/`never` remain), so the app-server subprocess exits immediately on the invalid argument and the collector's `initialize` RPC call just times out.
- Effect: the Agents bar widget shows "Codex limits unavailable" even when Codex is signed in and would otherwise report real rate-limit data.
- Fix: use `never`, the closest valid equivalent — the collector never sends a tool-execution request (only account/limits reads), so the approval policy is inert here; `never` keeps the headless probe from ever blocking on an unanswerable approval prompt.

## Test plan
- [x] Ran `omarchy-agent-usage-codex --force` before the fix: `usageStatusText: "Codex limits unavailable"`, `authHelpText: "initialize"`, `limits: []`.
- [x] Ran it after the fix: real `limits` (weekly window %, reset time) and `tierLabel` populated.
- [x] Ran `omarchy-agent-usage-update` and confirmed the on-disk record at `~/.local/state/omarchy/agents/usage/codex.json` reflects the fix.
- [x] Refreshed the running Agents bar panel via `omarchy-shell omarchy.agents refresh` and confirmed Codex now shows session/weekly limits alongside Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)