### PR TITLE
image-picker: navigate theme carousel with mouse wheel

### DIFF
--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -45,8 +45,25 @@ Item {
   property int sliceSpacing: -30
   property int skewOffset: 28
   property int bottomChromeHeight: showLabels ? (filterable ? 104 : 74) : (filterable ? 60 : 30)
+  property real wheelAccumulator: 0
 
-  onOpenedChanged: if (!opened) layoutSettled = false
+  onOpenedChanged: {
+    wheelAccumulator = 0
+    if (!opened) layoutSettled = false
+  }
+
+  // One theme per wheel notch (~120 units); finer touchpad deltas accumulate
+  // until they cross the threshold. Down/right moves to the next theme,
+  // up/left to the previous one, matching the arrow keys.
+  function nudgeWheel(deltaX, deltaY) {
+    var forward = Math.abs(deltaX) > Math.abs(deltaY) ? deltaX : -deltaY
+    root.wheelAccumulator += forward
+
+    while (Math.abs(root.wheelAccumulator) >= 120) {
+      root.selectAdjacent(root.wheelAccumulator > 0 ? 1 : -1)
+      root.wheelAccumulator -= root.wheelAccumulator > 0 ? 120 : -120
+    }
+  }
 
   function scriptPath(name) {
     return omarchyPath + "/shell/plugins/image-picker/" + name
@@ -380,6 +397,9 @@ Item {
       anchors.fill: parent
       enabled: root.opened && root.imagesLoaded
       onClicked: root.cancel()
+      onWheel: function(wheel) {
+        root.nudgeWheel(wheel.angleDelta.x, wheel.angleDelta.y)
+      }
     }
 
     Item {
@@ -389,7 +409,13 @@ Item {
       height: root.expandedHeight + Style.space(30) + root.bottomChromeHeight
       anchors.centerIn: parent
 
-        MouseArea { anchors.fill: parent; onClicked: {} }
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {}
+          onWheel: function(wheel) {
+            root.nudgeWheel(wheel.angleDelta.x, wheel.angleDelta.y)
+          }
+        }
 
         Item {
           id: carousel

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -57,12 +57,9 @@ Item {
   // up/left to the previous one, matching the arrow keys.
   function nudgeWheel(deltaX, deltaY) {
     var forward = Math.abs(deltaX) > Math.abs(deltaY) ? deltaX : -deltaY
-    root.wheelAccumulator += forward
-
-    while (Math.abs(root.wheelAccumulator) >= 120) {
-      root.selectAdjacent(root.wheelAccumulator > 0 ? 1 : -1)
-      root.wheelAccumulator -= root.wheelAccumulator > 0 ? 120 : -120
-    }
+    var wheel = Util.wheelSteps(root.wheelAccumulator, forward)
+    root.wheelAccumulator = wheel.remainder
+    if (wheel.steps !== 0) root.selectAdjacent(wheel.steps)
   }
 
   function scriptPath(name) {


### PR DESCRIPTION
### The problem

The image picker overlay (used by the theme switcher and the background picker) only navigates through items via clicks or the left/right arrow keys. For a horizontal carousel of images, scrolling with the mouse wheel is the most natural gesture, but it currently does nothing.

### The fix

Add mouse wheel navigation to the image picker carousel:

- A shared `nudgeWheel(deltaX, deltaY)` accumulates `angleDelta` across events and steps one item per ~120 units (one wheel notch). Finer deltas, like touchpad scroll, accumulate until they cross that threshold.
- `onWheel` handlers on the scrim `MouseArea` (so the wheel works anywhere on screen) and on the card `MouseArea` (over the carousel itself). We went with `MouseArea.onWheel` instead of `WheelHandler` since that is the pattern already used elsewhere in the shell.
- Scrolling down/right moves to the next item, up/left to the previous one, matching the arrow keys. Horizontal tilt wheels are handled by taking the dominant axis per event.
- Filter behavior is preserved: `selectAdjacent()` still skips non-matching items while a filter is active.
- The accumulator resets whenever the picker opens or closes.

This benefits every image-picker consumer: the theme switcher (`omarchy theme switcher`) and the background pickers.

### Verification

Video of navigating the theme switcher with the mouse wheel: attached below.

https://github.com/user-attachments/assets/26cee47c-b754-4076-8f51-704d0ed6d594

`./test/all`: 187/190 test files pass on my machine; the 3 failures are pre-existing/environmental and unrelated to this change (`config-test.sh` and `unowned-system-paths-test.sh` expect an `omarchy-pkgs` checkout, and `snapper-test.sh` is not executable in a fresh clone).
