### PR TITLE
Change 'Spending coulombs' to 'Cascading coulombs'

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -110,7 +110,7 @@ Panel {
     "Draining watts",
     "Burning electrons",
     "Sipping juice",
-    "Spending coulombs",
+    "Circulating coulombs",
     "Bleeding amps",
     "Guzzling volts",
     "Munching reserves"

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -110,7 +110,7 @@ Panel {
     "Draining watts",
     "Burning electrons",
     "Sipping juice",
-    "Circulating coulombs",
+    "Cascading coulombs",
     "Bleeding amps",
     "Guzzling volts",
     "Munching reserves"


### PR DESCRIPTION
Fix #7930.

You can never spend charge 😃
Cascading can mean making something fall down, which is an analogy of charges moving to a lower potential energy, releasing energy for computing.