### PR TITLE
Stop one blocked address from reading as an internet outage

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -5,7 +5,18 @@
 # omarchy:args=[--verbose]
 
 verbose=false
-internet_probe=1.1.1.1
+
+# Only used for `ip route get`, to find the interface carrying default traffic.
+# Reachability does not matter here: the lookup is answered from the local
+# routing table, so a blocked address still resolves the right route.
+route_probe=1.1.1.1
+
+# Reachability probes used when the system has no public resolver configured.
+# More than one, because any single address can be blocked on a given network.
+fallback_probes=(1.1.1.1 8.8.8.8 9.9.9.9)
+
+# Upper bound on addresses probed per sample, to keep a sample cheap.
+max_probes=3
 
 case "${1:-}" in
   "")
@@ -22,7 +33,7 @@ esac
 print_status() {
   local device nm state ssid signal freq
 
-  device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+  device=$(ip route get "$route_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
 
   if [[ -z $device ]]; then
     printf 'disconnected\t\t\t\n'
@@ -48,10 +59,91 @@ print_status() {
   printf 'wifi\t%s\t%s\t%s\n' "${ssid:-$device}" "$signal" "$freq"
 }
 
+# A resolver inside the LAN says nothing about whether the internet is
+# reachable, and the systemd-resolved stub listens on loopback, so only public
+# unicast IPv4 addresses make usable reachability probes.
+is_public_ipv4() {
+  local ip=$1 a b c d
+
+  [[ $ip =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+
+  a=$((10#${BASH_REMATCH[1]}))
+  b=$((10#${BASH_REMATCH[2]}))
+  c=$((10#${BASH_REMATCH[3]}))
+  d=$((10#${BASH_REMATCH[4]}))
+
+  if (( a > 255 || b > 255 || c > 255 || d > 255 )); then
+    return 1
+  fi
+
+  if (( a == 0 || a == 10 || a == 127 || a >= 224 )) ||
+    (( a == 169 && b == 254 )) ||
+    (( a == 172 && b >= 16 && b <= 31 )) ||
+    (( a == 192 && b == 168 )) ||
+    (( a == 100 && b >= 64 && b <= 127 )); then
+    return 1
+  fi
+
+  return 0
+}
+
+# Resolvers this system is configured to use. `resolvectl` reports the global
+# and per-link servers; /etc/resolv.conf covers hosts not running
+# systemd-resolved, where it lists real servers rather than the local stub.
+configured_dns_servers() {
+  resolvectl dns 2>/dev/null | sed 's/^[^:]*://'
+  awk '$1 == "nameserver" { print $2 }' /etc/resolv.conf 2>/dev/null
+}
+
+# Probe targets for the internet sample: configured public resolvers first,
+# since those are addresses this system already depends on reaching, then the
+# fallbacks. Deduplicated and capped.
+internet_probes() {
+  local ip seen="" probes=()
+
+  for ip in $(configured_dns_servers) "${fallback_probes[@]}"; do
+    is_public_ipv4 "$ip" || continue
+    [[ $seen == *" $ip "* ]] && continue
+
+    seen+=" $ip "
+    probes+=("$ip")
+
+    if (( ${#probes[@]} >= max_probes )); then
+      break
+    fi
+  done
+
+  if (( ${#probes[@]} > 0 )); then
+    printf '%s\n' "${probes[@]}"
+  fi
+}
+
 ping_latency_ms() {
   local host=$1
 
   LC_ALL=C ping -n -c 1 -W 1 "$host" 2>/dev/null | awk -F'time[=<]' '/time[=<]/ { split($2, parts, " "); print parts[1]; exit }'
+}
+
+# Probe the candidates together and keep the best answer, so one unreachable
+# address no longer reads as a total outage. Networks that blackhole a single
+# well-known resolver are common enough to plan for, and probing concurrently
+# keeps a sample within the same timeout as a single ping.
+ping_internet_ms() {
+  local tmpdir=$1
+  local host index=0 pids=()
+
+  for host in $(internet_probes); do
+    ping_latency_ms "$host" >"$tmpdir/internet.$index" &
+    pids+=($!)
+    index=$((index + 1))
+  done
+
+  if (( ${#pids[@]} > 0 )); then
+    wait "${pids[@]}" 2>/dev/null
+  fi
+
+  cat "$tmpdir"/internet.* 2>/dev/null |
+    awk 'NF { if (best == "" || $1 + 0 < best + 0) best = $1 } END { if (best != "") print best }'
 }
 
 print_ping_samples() {
@@ -69,7 +161,7 @@ print_ping_samples() {
     router_pid=$!
   fi
 
-  ping_latency_ms "$internet_probe" >"$internet_file" &
+  ping_internet_ms "$tmpdir" >"$internet_file" &
   internet_pid=$!
 
   if [[ -n $router_pid ]]; then
@@ -85,7 +177,7 @@ print_ping_samples() {
 print_verbose() {
   local route_json iface gw src prefix link
 
-  route_json=$(ip -j route get "$internet_probe" 2>/dev/null)
+  route_json=$(ip -j route get "$route_probe" 2>/dev/null)
   [[ -z $route_json ]] && return
 
   iface=$(jq -r '.[0].dev // ""' <<<"$route_json" 2>/dev/null)

--- a/test/shell.d/network-status-probe-test.sh
+++ b/test/shell.d/network-status-probe-test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+STATUS="$ROOT/bin/omarchy-network-status"
+
+# Load the address classifier and probe selection on their own, so the
+# reachability rules can be checked without any real network.
+eval "$(sed -n '/^is_public_ipv4()/,/^}$/p' "$STATUS")"
+eval "$(sed -n '/^configured_dns_servers()/,/^}$/p' "$STATUS")"
+eval "$(sed -n '/^internet_probes()/,/^}$/p' "$STATUS")"
+
+fallback_probes=(1.1.1.1 8.8.8.8 9.9.9.9)
+max_probes=3
+
+for ip in 8.8.8.8 1.0.0.1 208.67.222.222 172.15.0.1 172.32.0.1 192.169.0.1 100.63.0.1; do
+  is_public_ipv4 "$ip" || fail "public address is usable as a probe: $ip"
+done
+pass "public addresses are usable as probes"
+
+# A resolver on the LAN, on loopback, or outside unicast IPv4 proves nothing
+# about internet reachability.
+for ip in 127.0.0.53 192.168.1.4 10.0.0.1 172.16.5.5 172.31.255.1 169.254.1.1 \
+  100.64.0.1 0.0.0.0 224.0.0.1 2001:4860:4860::8888 999.1.1.1 8.8.8 abc ""; do
+  ! is_public_ipv4 "$ip" || fail "address is rejected as a probe: ${ip:-<empty>}"
+done
+pass "non-public and malformed addresses are rejected as probes"
+
+probes_for() {
+  local dns_output=$1 stub probes
+
+  stub=$(mktemp -d)
+  cat >"$stub/resolvectl" <<EOF
+#!/bin/bash
+[[ \$1 == "dns" ]] && cat <<'DNS'
+$dns_output
+DNS
+EOF
+  chmod +x "$stub/resolvectl"
+  probes=$(PATH="$stub:$PATH" bash -c "$(declare -f is_public_ipv4 configured_dns_servers internet_probes)
+    fallback_probes=(1.1.1.1 8.8.8.8 9.9.9.9)
+    max_probes=3
+    internet_probes" | tr '\n' ' ')
+  rm -rf "$stub"
+  printf '%s' "${probes% }"
+}
+
+[[ $(probes_for 'Global: 8.8.8.8 8.8.4.4 9.9.9.9') == "8.8.8.8 8.8.4.4 9.9.9.9" ]] ||
+  fail "configured public resolvers are probed" "got: $(probes_for 'Global: 8.8.8.8 8.8.4.4 9.9.9.9')"
+pass "configured public resolvers are probed"
+
+# `omarchy dns DHCP` typically yields a resolver inside the LAN. Probing it
+# would report the internet as reachable whenever the router is up.
+[[ $(probes_for 'Link 2 (wlp3s0): 192.168.1.4') == "1.1.1.1 8.8.8.8 9.9.9.9" ]] ||
+  fail "a LAN-only resolver falls back to public probes" "got: $(probes_for 'Link 2 (wlp3s0): 192.168.1.4')"
+pass "a LAN-only resolver falls back to public probes"
+
+[[ $(probes_for 'Global: 2001:4860:4860::8888') == "1.1.1.1 8.8.8.8 9.9.9.9" ]] ||
+  fail "IPv6-only resolvers fall back to public probes"
+pass "IPv6-only resolvers fall back to public probes"
+
+# The whole point: more than one address, so a network that blocks a single
+# well-known resolver does not read as an outage.
+probes=$(probes_for 'Global: 1.1.1.1 1.0.0.1')
+(( $(wc -w <<<"$probes") > 1 )) || fail "more than one address is probed" "got: $probes"
+pass "more than one address is probed"
+
+# The router lookup must stay on a fixed public address: pointing it at a
+# configured resolver would resolve an on-link route instead of the default one.
+grep -q '^route_probe=' "$STATUS" || fail "route lookup uses a dedicated probe address"
+grep -q 'ip route get "$route_probe"' "$STATUS" || fail "route lookup uses the dedicated probe address"
+grep -q 'ip -j route get "$route_probe"' "$STATUS" || fail "verbose route lookup uses the dedicated probe address"
+pass "route lookup uses a dedicated public address"
+
+# An unreachable internet must still report as unreachable.
+stub=$(mktemp -d)
+cat >"$stub/ping" <<'PING'
+#!/bin/bash
+host=${!#}
+if [[ $host == 192.168.1.1 ]]; then
+  echo "64 bytes from $host: icmp_seq=1 ttl=64 time=1.23 ms"
+  exit 0
+fi
+exit 1
+PING
+chmod +x "$stub/ping"
+eval "$(sed -n '/^ping_latency_ms()/,/^}$/p' "$STATUS")"
+eval "$(sed -n '/^ping_internet_ms()/,/^}$/p' "$STATUS")"
+workdir=$(mktemp -d)
+result=$(PATH="$stub:$PATH" ping_internet_ms "$workdir")
+rm -rf "$stub" "$workdir"
+[[ -z $result ]] || fail "an unreachable internet reports no latency" "got: $result"
+pass "an unreachable internet reports no latency"


### PR DESCRIPTION
## Problem

`omarchy-network-status` measures internet reachability by pinging a single hardcoded address:

```bash
internet_probe=1.1.1.1
```

Some networks blackhole `1.1.1.1` outright. A number of ISPs and consumer routers used it internally before Cloudflare acquired it, and those blocks are still around. On such a network the address fails for every protocol, not just ICMP:

| Target | ICMP | TCP 443 | TCP 53 | DNS |
|---|---|---|---|---|
| `1.1.1.1` | 100% loss | blocked | blocked | fails |
| `1.0.0.1` (Cloudflare's own secondary) | 0% loss, 3.9 ms | open | — | — |
| `8.8.8.8` | 0% loss, 4.5 ms | — | — | ok |
| `9.9.9.9` | 0% loss, 15.5 ms | — | — | ok |

The route is normal and nothing on the LAN claims the address, so this is an upstream block, not a local fault. The result is that the network panel permanently shows **Ping: Timeout** and **Packet Loss: 100%** on a working connection:

```
$ omarchy-network-status --verbose
router_ping_ms      1.05
internet_ping_ms                 <- empty, forever
```

Related: `omarchy dns Cloudflare` also sets `1.1.1.1` as the primary resolver, which is a dead server on these networks. That is a separate issue and not addressed here.

## Change

Derive the probe targets from the resolvers the system is actually configured to use — via `resolvectl dns`, falling back to `/etc/resolv.conf` for hosts not running systemd-resolved — and fall back to a list of public addresses when none qualify.

Three details worth calling out:

**Only public unicast IPv4 addresses qualify as probes.** `omarchy dns DHCP` commonly yields a resolver inside the LAN. Probing that would report the internet as reachable whenever the router answered, which is a worse bug than the one being fixed. The systemd-resolved stub also listens on loopback. Private, loopback, link-local, CGNAT, and multicast/reserved ranges are all rejected.

**Candidates are probed concurrently and the best answer wins.** A sample still costs one ping timeout rather than one per address, and a single blocked address no longer blanks the reading.

**Route lookup keeps its own fixed public address.** `internet_probe` was doing double duty — `ip route get` used it to find the interface carrying default traffic. That lookup is answered from the local routing table, so reachability is irrelevant there, but pointing it at a configured resolver could return an on-link route instead of the default one. It is now a separate `route_probe`.

## Result

On a network that blocks `1.1.1.1`:

```
before:  internet_ping_ms                    (1.06s -- full timeout burned)
after:   internet_ping_ms      4.01          (0.07s)
```

Non-verbose output is byte-identical. A genuine outage still reports empty, verified with a stubbed `ping` that fails for every public address while the gateway answers.

## Tests

Adds `test/shell.d/network-status-probe-test.sh`, covering:

- public addresses accepted, including the RFC boundaries that must stay public (`172.15.0.1`, `172.32.0.1`, `192.169.0.1`, `100.63.0.1`)
- private, loopback, link-local, CGNAT, multicast, IPv6, and malformed input rejected
- configured public resolvers used as probes
- a LAN-only resolver falling back to public probes rather than being probed
- IPv6-only resolvers falling back
- more than one address probed
- route lookup still using a dedicated fixed address
- an unreachable internet still reporting no latency

The test fails against the current code and passes with the change. `./test/cli` and the shell suite pass.
