### PR TITLE
Sync cliamp with Omarchy themes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -324,6 +324,7 @@ post_theme_commands=(
   omarchy-theme-set-foot
   omarchy-theme-set-tmux
   omarchy-theme-set-gnome
+  omarchy-theme-set-cliamp
   omarchy-theme-set-pi
   omarchy-theme-set-claude
   omarchy-theme-set-browser

--- a/bin/omarchy-theme-set-cliamp
+++ b/bin/omarchy-theme-set-cliamp
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# omarchy:summary=Sync the generated Omarchy theme to cliamp
+# omarchy:hidden=true
+
+set -euo pipefail
+
+CLIAMP_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/cliamp"
+CLIAMP_CONFIG_PATH="$CLIAMP_CONFIG_DIR/config.toml"
+CLIAMP_THEME_DIR="$CLIAMP_CONFIG_DIR/themes"
+CLIAMP_THEME_PATH="$CLIAMP_THEME_DIR/omarchy.toml"
+OMARCHY_THEME_PATH="$HOME/.local/state/omarchy/current/theme/cliamp.toml"
+
+[[ -f $OMARCHY_THEME_PATH ]] || exit 0
+
+mkdir -p "$CLIAMP_THEME_DIR"
+ln -sfn "$OMARCHY_THEME_PATH" "$CLIAMP_THEME_PATH"
+
+tmp=$(mktemp "$CLIAMP_CONFIG_PATH.XXXXXX")
+if [[ -f $CLIAMP_CONFIG_PATH ]]; then
+  awk '
+    BEGIN { written = 0; in_tables = 0 }
+    !in_tables && /^[[:space:]]*theme[[:space:]]*=/ {
+      if (!written) print "theme = \"omarchy\""
+      written = 1
+      next
+    }
+    /^[[:space:]]*\[/ {
+      if (!written) {
+        print "theme = \"omarchy\""
+        print ""
+        written = 1
+      }
+      in_tables = 1
+    }
+    { print }
+    END { if (!written) print "theme = \"omarchy\"" }
+  ' "$CLIAMP_CONFIG_PATH" >"$tmp"
+else
+  printf 'theme = "omarchy"\n' >"$tmp"
+fi
+mv "$tmp" "$CLIAMP_CONFIG_PATH"
+
+# A running cliamp reloads immediately. If none is running, the persisted
+# setting applies the next time it starts.
+cliamp theme omarchy >/dev/null 2>&1 || true

--- a/default/themed/cliamp.toml.tpl
+++ b/default/themed/cliamp.toml.tpl
@@ -1,0 +1,7 @@
+bg = "{{ background }}"
+accent = "{{ accent }}"
+bright_fg = "{{ bright_foreground }}"
+fg = "{{ foreground }}"
+green = "{{ green }}"
+yellow = "{{ yellow }}"
+red = "{{ red }}"

--- a/install/user/theme.sh
+++ b/install/user/theme.sh
@@ -10,6 +10,7 @@ if [[ ! -s $HOME/.local/state/omarchy/current/theme.name ]]; then
     omarchy-theme-set "Tokyo Night"
   fi
 fi
+omarchy-theme-set-cliamp
 omarchy-theme-set-pi --activate
 
 mkdir -p ~/.config/btop/themes

--- a/test/cli
+++ b/test/cli
@@ -469,6 +469,37 @@ jq -e '.name == "omarchy-system" and .vars.panel == "#0f0f0f" and .vars.border =
 pass "pi theme template is generated from standard themed templates"
 cp "$NEXT_THEME/pi.json" "$CURRENT_THEME/pi.json"
 
+grep -qx 'bg = "#000000"' "$NEXT_THEME/cliamp.toml" || fail "cliamp theme uses generated background"
+grep -qx 'accent = "#336699"' "$NEXT_THEME/cliamp.toml" || fail "cliamp theme uses generated accent"
+grep -qx 'bright_fg = "#eeeeee"' "$NEXT_THEME/cliamp.toml" || fail "cliamp theme uses generated bright foreground"
+pass "cliamp theme template is generated from standard themed templates"
+cp "$NEXT_THEME/cliamp.toml" "$CURRENT_THEME/cliamp.toml"
+
+CLIAMP_TEST_CONFIG="$PI_TMPDIR/.config/cliamp"
+CLIAMP_LOG="$PI_TMPDIR/cliamp.log"
+mkdir -p "$CLIAMP_TEST_CONFIG"
+cat >"$CLIAMP_TEST_CONFIG/config.toml" <<'EOF'
+visualizer = "Bars"
+
+[audio]
+device = "keep-me"
+theme = "keep-this-too"
+EOF
+cat >"$PI_TMPDIR/cliamp" <<'EOF'
+#!/bin/bash
+echo "$*" >>"$CLIAMP_LOG"
+EOF
+chmod +x "$PI_TMPDIR/cliamp"
+CLIAMP_LOG="$CLIAMP_LOG" PATH="$PI_TMPDIR:$PATH" HOME="$PI_TMPDIR" XDG_CONFIG_HOME="$PI_TMPDIR/.config" "$ROOT/bin/omarchy-theme-set-cliamp"
+[[ -L $CLIAMP_TEST_CONFIG/themes/omarchy.toml ]] || fail "cliamp generated theme is linked"
+[[ $(readlink "$CLIAMP_TEST_CONFIG/themes/omarchy.toml") == "$CURRENT_THEME/cliamp.toml" ]] || fail "cliamp generated theme references current theme file"
+grep -q '^theme = "omarchy"$' "$CLIAMP_TEST_CONFIG/config.toml" || fail "cliamp generated theme is activated"
+grep -q '^visualizer = "Bars"$' "$CLIAMP_TEST_CONFIG/config.toml" || fail "cliamp theme activation preserves root settings"
+grep -q '^device = "keep-me"$' "$CLIAMP_TEST_CONFIG/config.toml" || fail "cliamp theme activation preserves table settings"
+grep -q '^theme = "keep-this-too"$' "$CLIAMP_TEST_CONFIG/config.toml" || fail "cliamp theme activation preserves nested theme settings"
+grep -qx 'theme omarchy' "$CLIAMP_LOG" || fail "cliamp running session is rethemed"
+pass "cliamp generated theme is synced and activated"
+
 echo '{"name":"omarchy-system","vars":{"custom":"yes"}}' >"$NEXT_THEME/pi.json"
 OMARCHY_PATH="$ROOT" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-templates"
 jq -e '.name == "omarchy-system" and .vars.custom == "yes"' "$NEXT_THEME/pi.json" >/dev/null


### PR DESCRIPTION
## Summary

- generate a cliamp theme from the active Omarchy palette
- activate it in cliamp while preserving existing TOML settings
- reload running cliamp sessions and seed the integration during user setup

## Testing

- `./test/cli`
- `bash -n bin/omarchy-theme-set-cliamp`
- `git diff --check`

`./test/all` reached and passed the new cliamp coverage, but the shell suite requires a separate `omarchy-pkgs` checkout that is unavailable in this environment. `shellcheck` is not installed on this machine.