### PR TITLE
Quattro: Reduce wallpaper memory under low-memory conditions

### DIFF
--- a/manual/39-backgrounds.md
+++ b/manual/39-backgrounds.md
@@ -8,11 +8,4 @@ You can find a huge collection of cool curated backgrounds on https://github.com
 
 ## Wallpaper memory
 
-On systems with less than 4 GiB of available memory, Omarchy automatically
-decodes wallpapers at a bounded size derived from the physical display size
-instead of keeping their full source resolution in memory. A 1366x768 display
-therefore requests a 1366x768 source image. The behavior is automatic and
-requires no setting; when more memory is available, wallpapers keep their
-current full-resolution behavior. This is intentionally conservative: when a
-source is larger than the display, the display-sized decode avoids retaining
-detail that cannot be shown, while smaller sources are not enlarged.
+When Omarchy starts with less than 4 GiB of available memory, it automatically decodes wallpapers at a crop-aware size derived from the physical display instead of keeping their full source resolution in memory. The decision is made once per shell startup and requires no setting; when more memory is available at startup, wallpapers keep their current full-resolution behavior. This is intentionally conservative: when a source is larger than the display, the display-sized decode avoids retaining detail that cannot be shown, while smaller sources are not enlarged.

--- a/manual/39-backgrounds.md
+++ b/manual/39-backgrounds.md
@@ -10,7 +10,9 @@ You can find a huge collection of cool curated backgrounds on https://github.com
 
 On systems with less than 4 GiB of available memory, Omarchy automatically
 decodes wallpapers at a bounded size derived from the physical display size
-instead of keeping their full source resolution in memory. The low-memory
-factor is 1, so a 1366x768 display requests a 1366x768 source image. The
-behavior is automatic and requires no setting; when more memory is available,
-wallpapers keep their current full-resolution behavior.
+instead of keeping their full source resolution in memory. A 1366x768 display
+therefore requests a 1366x768 source image. The behavior is automatic and
+requires no setting; when more memory is available, wallpapers keep their
+current full-resolution behavior. This is intentionally conservative: when a
+source is larger than the display, the display-sized decode avoids retaining
+detail that cannot be shown, while smaller sources are not enlarged.

--- a/manual/39-backgrounds.md
+++ b/manual/39-backgrounds.md
@@ -10,8 +10,7 @@ You can find a huge collection of cool curated backgrounds on https://github.com
 
 On systems with less than 4 GiB of available memory, Omarchy automatically
 decodes wallpapers at a bounded size derived from the physical display size
-instead of keeping their full source resolution in memory. The current
-low-memory test factor is 16, so a 1366x768 display requests an approximately
-85x48 source image. The behavior is automatic and requires no setting; when
-more memory is available, wallpapers keep their current full-resolution
-behavior.
+instead of keeping their full source resolution in memory. The low-memory
+factor is 1, so a 1366x768 display requests a 1366x768 source image. The
+behavior is automatic and requires no setting; when more memory is available,
+wallpapers keep their current full-resolution behavior.

--- a/manual/39-backgrounds.md
+++ b/manual/39-backgrounds.md
@@ -5,3 +5,13 @@ Every theme ships with its own set of backgrounds, and you can add extras of you
 You can do this most easily by going to _Install > Style > Background_ in the Omarchy Menu. That'll bring up the folder where the backgrounds for that theme is stored. Hit `Super + Shift + F` to start another file manager, find your background, copy it over.  Now it'll be included in the choices of backgrounds you can select between using `Super + Ctrl + Space`.
 
 You can find a huge collection of cool curated backgrounds on https://github.com/dharmx/walls.
+
+## Wallpaper memory
+
+On systems with less than 4 GiB of available memory, Omarchy automatically
+decodes wallpapers at a bounded size derived from the physical display size
+instead of keeping their full source resolution in memory. The current
+low-memory test factor is 16, so a 1366x768 display requests an approximately
+85x48 source image. The behavior is automatic and requires no setting; when
+more memory is available, wallpapers keep their current full-resolution
+behavior.

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -14,7 +14,6 @@ Item {
   readonly property string stateHome: home + "/.local/state"
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
   readonly property real lowMemoryLimitKiB: 4 * 1024 * 1024
-  readonly property real lowMemoryDownscaleFactor: 1
 
   property string currentBackground: ""
   property string displayedBackground: ""
@@ -36,13 +35,6 @@ Item {
 
   function imageUrl(path) {
     return Util.fileUrl(path)
-  }
-
-  function lowMemorySourceSize(width, height, devicePixelRatio) {
-    return Qt.size(
-      Math.max(1, Math.ceil(width * devicePixelRatio / lowMemoryDownscaleFactor)),
-      Math.max(1, Math.ceil(height * devicePixelRatio / lowMemoryDownscaleFactor))
-    )
   }
 
   function refreshMemory() {
@@ -279,7 +271,7 @@ Item {
         // Qt never upscales a source smaller than sourceSize. Under memory
         // pressure this bounds large wallpapers to the physical display size.
         sourceSize: root.lowMemory
-          ? root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)
+          ? Qt.size(Math.ceil(width * Screen.devicePixelRatio), Math.ceil(height * Screen.devicePixelRatio))
           : undefined
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
@@ -298,7 +290,7 @@ Item {
         anchors.fill: parent
         source: root.imageUrl(root.oldBackground)
         sourceSize: root.lowMemory
-          ? root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)
+          ? Qt.size(Math.ceil(width * Screen.devicePixelRatio), Math.ceil(height * Screen.devicePixelRatio))
           : undefined
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
@@ -327,7 +319,7 @@ Item {
           anchors.fill: parent
           source: root.imageUrl(root.incomingBackground)
           sourceSize: root.lowMemory
-            ? root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)
+            ? Qt.size(Math.ceil(width * Screen.devicePixelRatio), Math.ceil(height * Screen.devicePixelRatio))
             : undefined
           fillMode: Image.PreserveAspectCrop
           asynchronous: true

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -194,14 +194,6 @@ Item {
     onTriggered: root.applyPendingTheme()
   }
 
-  Timer {
-    id: memoryRefreshTimer
-    interval: 5000
-    running: true
-    repeat: true
-    onTriggered: root.refreshMemory()
-  }
-
   NumberAnimation {
     id: revealAnimation
     target: root

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -13,6 +13,8 @@ Item {
   readonly property string home: Quickshell.env("HOME")
   readonly property string stateHome: home + "/.local/state"
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
+  readonly property real lowMemoryLimitKiB: 4 * 1024 * 1024
+  readonly property real lowMemoryDownscaleFactor: 16
 
   property string currentBackground: ""
   property string displayedBackground: ""
@@ -25,12 +27,44 @@ Item {
   property string pendingColorsRaw: ""
   property string pendingShellRaw: ""
   property real revealProgress: 1
+  property real availableMemoryKiB: -1
+  property bool memoryReady: false
+  property bool backgroundRefreshPending: false
+  readonly property bool lowMemory: memoryReady
+    && availableMemoryKiB >= 0
+    && availableMemoryKiB < lowMemoryLimitKiB
 
   function imageUrl(path) {
     return Util.fileUrl(path)
   }
 
+  function lowMemorySourceSize(width, height, devicePixelRatio) {
+    return Qt.size(
+      Math.max(1, Math.ceil(width * devicePixelRatio / lowMemoryDownscaleFactor)),
+      Math.max(1, Math.ceil(height * devicePixelRatio / lowMemoryDownscaleFactor))
+    )
+  }
+
+  function refreshMemory() {
+    memoryFile.reload()
+  }
+
+  function updateAvailableMemory(raw) {
+    var match = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(String(raw || ""))
+    availableMemoryKiB = match ? Number(match[1]) : -1
+    memoryReady = true
+    if (backgroundRefreshPending) {
+      backgroundRefreshPending = false
+      refreshBackground()
+    }
+  }
+
   function refreshBackground() {
+    if (!memoryReady) {
+      backgroundRefreshPending = true
+      refreshMemory()
+      return
+    }
     if (!readlinkProc.running) readlinkProc.running = true
   }
 
@@ -120,6 +154,15 @@ Item {
     onExited: root.refreshBackground()
   }
 
+  FileView {
+    id: memoryFile
+    path: "/proc/meminfo"
+    watchChanges: false
+    printErrors: false
+    onLoaded: root.updateAvailableMemory(text())
+    onLoadFailed: root.updateAvailableMemory("")
+  }
+
   Process {
     id: readlinkProc
     command: ["readlink", "-f", root.currentBackgroundLink]
@@ -159,6 +202,14 @@ Item {
     onTriggered: root.applyPendingTheme()
   }
 
+  Timer {
+    id: memoryRefreshTimer
+    interval: 5000
+    running: true
+    repeat: true
+    onTriggered: root.refreshMemory()
+  }
+
   NumberAnimation {
     id: revealAnimation
     target: root
@@ -176,7 +227,10 @@ Item {
     }
   }
 
-  Component.onCompleted: refreshBackground()
+  Component.onCompleted: {
+    refreshMemory()
+    refreshBackground()
+  }
 
   Variants {
     model: Quickshell.screens
@@ -222,6 +276,11 @@ Item {
         id: base
         anchors.fill: parent
         source: root.imageUrl(root.displayedBackground)
+        // Qt never upscales a source smaller than sourceSize. Under memory
+        // pressure this bounds large wallpapers to the physical display size.
+        sourceSize: root.lowMemory
+          ? root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)
+          : undefined
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: true
@@ -238,6 +297,9 @@ Item {
         id: oldFrame
         anchors.fill: parent
         source: root.imageUrl(root.oldBackground)
+        sourceSize: root.lowMemory
+          ? root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)
+          : undefined
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: false
@@ -264,6 +326,9 @@ Item {
           id: incomingFrame
           anchors.fill: parent
           source: root.imageUrl(root.incomingBackground)
+          sourceSize: root.lowMemory
+            ? root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)
+            : undefined
           fillMode: Image.PreserveAspectCrop
           asynchronous: true
           cache: false

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -14,7 +14,7 @@ Item {
   readonly property string stateHome: home + "/.local/state"
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
   readonly property real lowMemoryLimitKiB: 4 * 1024 * 1024
-  readonly property real lowMemoryDownscaleFactor: 16
+  readonly property real lowMemoryDownscaleFactor: 1
 
   property string currentBackground: ""
   property string displayedBackground: ""

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -6,6 +6,7 @@ import QtQuick.Effects
 import QtQuick.Shapes
 import qs.Commons
 import qs.Ui
+import "BackgroundModel.js" as BackgroundModel
 
 Item {
   id: root
@@ -29,21 +30,15 @@ Item {
   property real availableMemoryKiB: -1
   property bool memoryReady: false
   property bool backgroundRefreshPending: false
-  readonly property bool lowMemory: memoryReady
-    && availableMemoryKiB >= 0
-    && availableMemoryKiB < lowMemoryLimitKiB
+  readonly property bool lowMemory: memoryReady && BackgroundModel.isLowMemory(availableMemoryKiB, lowMemoryLimitKiB)
 
   function imageUrl(path) {
     return Util.fileUrl(path)
   }
 
-  function refreshMemory() {
-    memoryFile.reload()
-  }
-
   function updateAvailableMemory(raw) {
-    var match = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(String(raw || ""))
-    availableMemoryKiB = match ? Number(match[1]) : -1
+    if (memoryReady) return
+    availableMemoryKiB = BackgroundModel.parseAvailableMemoryKiB(raw)
     memoryReady = true
     if (backgroundRefreshPending) {
       backgroundRefreshPending = false
@@ -54,7 +49,6 @@ Item {
   function refreshBackground() {
     if (!memoryReady) {
       backgroundRefreshPending = true
-      refreshMemory()
       return
     }
     if (!readlinkProc.running) readlinkProc.running = true
@@ -211,10 +205,7 @@ Item {
     }
   }
 
-  Component.onCompleted: {
-    refreshMemory()
-    refreshBackground()
-  }
+  Component.onCompleted: refreshBackground()
 
   Variants {
     model: Quickshell.screens
@@ -260,8 +251,8 @@ Item {
         id: base
         anchors.fill: parent
         source: root.imageUrl(root.displayedBackground)
-        // Qt never upscales a source smaller than sourceSize. Under memory
-        // pressure this bounds large wallpapers to the physical display size.
+        // With PreserveAspectCrop, Qt decodes the cover-sized image needed for
+        // this physical display while avoiding full-resolution storage.
         sourceSize: root.lowMemory
           ? Qt.size(Math.ceil(width * Screen.devicePixelRatio), Math.ceil(height * Screen.devicePixelRatio))
           : undefined

--- a/shell/plugins/background/BackgroundModel.js
+++ b/shell/plugins/background/BackgroundModel.js
@@ -1,0 +1,17 @@
+function parseAvailableMemoryKiB(raw) {
+  var match = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(String(raw || ""))
+  return match ? Number(match[1]) : -1
+}
+
+function isLowMemory(availableMemoryKiB, limitKiB) {
+  var available = Number(availableMemoryKiB)
+  var limit = Number(limitKiB)
+  return isFinite(available) && available >= 0 && isFinite(limit) && available < limit
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    parseAvailableMemoryKiB: parseAvailableMemoryKiB,
+    isLowMemory: isLowMemory
+  }
+}

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -3,8 +3,18 @@ source "$(dirname "$0")/base-test.sh"
 
 run_node_test <<'JS'
 const fs = require('fs')
+const background = requireFromRoot('shell/plugins/background/BackgroundModel.js')
 
 const backgroundQml = fs.readFileSync(path.join(root, 'shell/plugins/background/Background.qml'), 'utf8')
+
+const lowMemoryLimitKiB = 4 * 1024 * 1024
+assertEqual(background.parseAvailableMemoryKiB('MemTotal: 8 kB\nMemAvailable: 4194303 kB\n'), 4194303, 'background parses MemAvailable')
+assertEqual(background.parseAvailableMemoryKiB('MemTotal: 8 kB\n'), -1, 'background rejects missing MemAvailable')
+assertEqual(background.parseAvailableMemoryKiB('MemAvailable: unknown kB\n'), -1, 'background rejects malformed MemAvailable')
+assert(background.isLowMemory(lowMemoryLimitKiB - 1, lowMemoryLimitKiB), 'background detects memory below 4 GiB')
+assert(!background.isLowMemory(lowMemoryLimitKiB, lowMemoryLimitKiB), 'background accepts memory equal to 4 GiB')
+assert(!background.isLowMemory(lowMemoryLimitKiB + 1, lowMemoryLimitKiB), 'background accepts memory above 4 GiB')
+assert(!background.isLowMemory(-1, lowMemoryLimitKiB), 'background falls back for unavailable memory')
 
 assert(
   /theme=\$\(omarchy-theme-switcher\); \[\[ -n \$theme \]\] && omarchy-theme-set \\"\$theme\\" >\/dev\/null 2>&1 &/.test(backgroundQml),
@@ -22,15 +32,23 @@ assert(
 assert(
   backgroundQml.includes('lowMemoryLimitKiB: 4 * 1024 * 1024') &&
     backgroundQml.includes('path: "/proc/meminfo"') &&
-    backgroundQml.includes('MemAvailable:') &&
-    backgroundQml.includes('availableMemoryKiB < lowMemoryLimitKiB'),
-  'background detects low memory from MemAvailable below 4 GiB'
+    backgroundQml.includes('BackgroundModel.parseAvailableMemoryKiB(raw)') &&
+    backgroundQml.includes('BackgroundModel.isLowMemory(availableMemoryKiB, lowMemoryLimitKiB)'),
+  'background uses tested memory parsing and threshold logic'
 )
 
 assert(
   (backgroundQml.match(/sourceSize: root\.lowMemory/g) || []).length === 3 &&
     backgroundQml.includes('Qt.size(Math.ceil(width * Screen.devicePixelRatio), Math.ceil(height * Screen.devicePixelRatio))') &&
+    (backgroundQml.match(/fillMode: Image\.PreserveAspectCrop/g) || []).length === 3 &&
     backgroundQml.includes(': undefined'),
-  'background bounds all wallpaper frames only while memory is low'
+  'background uses crop-aware bounded decoding for all wallpaper frames only while memory is low'
+)
+
+assert(
+  backgroundQml.includes('if (memoryReady) return') &&
+    backgroundQml.includes('Component.onCompleted: refreshBackground()') &&
+    !backgroundQml.includes('memoryFile.reload()'),
+  'background makes one startup memory decision from the FileView preload'
 )
 JS

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -21,7 +21,6 @@ assert(
 
 assert(
   backgroundQml.includes('lowMemoryLimitKiB: 4 * 1024 * 1024') &&
-    backgroundQml.includes('lowMemoryDownscaleFactor: 1') &&
     backgroundQml.includes('path: "/proc/meminfo"') &&
     backgroundQml.includes('MemAvailable:') &&
     backgroundQml.includes('availableMemoryKiB < lowMemoryLimitKiB'),
@@ -30,7 +29,7 @@ assert(
 
 assert(
   (backgroundQml.match(/sourceSize: root\.lowMemory/g) || []).length === 3 &&
-    backgroundQml.includes('root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)') &&
+    backgroundQml.includes('Qt.size(Math.ceil(width * Screen.devicePixelRatio), Math.ceil(height * Screen.devicePixelRatio))') &&
     backgroundQml.includes(': undefined'),
   'background bounds all wallpaper frames only while memory is low'
 )

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -18,4 +18,20 @@ assert(
     !backgroundQml.includes('pendingThemeVersion !== backgroundVersion'),
   'background theme transition applies pending colors even if image reveal stalls'
 )
+
+assert(
+  backgroundQml.includes('lowMemoryLimitKiB: 4 * 1024 * 1024') &&
+    backgroundQml.includes('lowMemoryDownscaleFactor: 16') &&
+    backgroundQml.includes('path: "/proc/meminfo"') &&
+    backgroundQml.includes('MemAvailable:') &&
+    backgroundQml.includes('availableMemoryKiB < lowMemoryLimitKiB'),
+  'background detects low memory from MemAvailable below 4 GiB'
+)
+
+assert(
+  (backgroundQml.match(/sourceSize: root\.lowMemory/g) || []).length === 3 &&
+    backgroundQml.includes('root.lowMemorySourceSize(width, height, Screen.devicePixelRatio)') &&
+    backgroundQml.includes(': undefined'),
+  'background bounds all wallpaper frames only while memory is low'
+)
 JS

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -21,7 +21,7 @@ assert(
 
 assert(
   backgroundQml.includes('lowMemoryLimitKiB: 4 * 1024 * 1024') &&
-    backgroundQml.includes('lowMemoryDownscaleFactor: 16') &&
+    backgroundQml.includes('lowMemoryDownscaleFactor: 1') &&
     backgroundQml.includes('path: "/proc/meminfo"') &&
     backgroundQml.includes('MemAvailable:') &&
     backgroundQml.includes('availableMemoryKiB < lowMemoryLimitKiB'),


### PR DESCRIPTION
## Summary

- Read Linux `MemAvailable` once before the initial wallpaper load and activate bounded decoding below 4 GiB.
- Under the threshold, bound `base`, `oldFrame`, and `incomingFrame` to a crop-aware size derived from the physical display.
- At or above the threshold, leave `sourceSize` undefined and preserve full-resolution behavior.
- Keep the change minimal: the memory decision is made once per shell startup, avoiding periodic image reloads or threshold thrashing.
- Document the intentionally conservative behavior and add focused background tests.

## Wallpaper context

The wallpaper used for measurement was `/home/eric/.local/state/omarchy/current/theme/backgrounds/3-omakub.jpg`, with source resolution `6930x3960`. Its uncompressed RGBA pixels are approximately 109.8 MB (104.7 MiB). The test display was `1366x768` at DPR 1, so the low-memory path requested a crop-aware display-sized source instead of retaining the full source resolution.

This is intentionally conservative: a source larger than the display is decoded only at the scale the display can show, while smaller sources are not enlarged.

## Memory comparison

Measured in the same isolated shell setup with the test bar parked off-screen:

| Mode | RSS | PSS |
| --- | ---: | ---: |
| Original full-resolution | ~474 MiB | ~365 MiB |
| Low memory, display-sized | ~386 MiB | ~277 MiB |
| Savings | ~88 MiB | ~88 MiB |

The low-memory process was activated by `MemAvailable` of `1920752 kB` (below the `4194304 kB` threshold).

## Validation

- `PATH=/tmp/omarchy-test-bin:$PATH bash ./test/shell.d/background-test.sh`
- `qmllint shell/plugins/background/Background.qml`
- Isolated startup with the final no-poll implementation succeeded.
- Isolated high-memory fallback retained full-resolution behavior.
- Live `/usr/share/omarchy` shell was not modified or restarted.

## Attribution

This code was generated by GPT-5.6 Luna (max), directed by ericvrp. Copilot review analysis and the resulting changes were performed by GPT-5.6 Sol (high), directed by ericvrp.