### PR TITLE
Route file chooser portal requests to Nautilus

### DIFF
--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -2,6 +2,7 @@ run_logged "$OMARCHY_INSTALL/user/theme.sh"
 run_logged "$OMARCHY_INSTALL/user/chromium.sh"
 run_logged "$OMARCHY_INSTALL/user/git.sh"
 run_logged "$OMARCHY_INSTALL/user/xcompose.sh"
+run_logged "$OMARCHY_INSTALL/user/xdg-desktop-portal.sh"
 run_logged "$OMARCHY_INSTALL/user/mise-work.sh"
 
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-audio-mixer.sh"

--- a/install/user/xdg-desktop-portal.sh
+++ b/install/user/xdg-desktop-portal.sh
@@ -1,0 +1,23 @@
+portal_config="$HOME/.config/xdg-desktop-portal/hyprland-portals.conf"
+nautilus_portal="$HOME/.local/share/xdg-desktop-portal/portals/nautilus.portal"
+
+mkdir -p "$(dirname "$portal_config")" "$(dirname "$nautilus_portal")"
+
+if [[ ! -e $portal_config ]]; then
+  printf '%s\n' \
+    '[preferred]' \
+    'default=hyprland;gtk' \
+    'org.freedesktop.impl.portal.FileChooser=nautilus' >"$portal_config"
+elif ! grep -q '^org\.freedesktop\.impl\.portal\.FileChooser=' "$portal_config"; then
+  if grep -q '^\[preferred\]$' "$portal_config"; then
+    sed -i '/^\[preferred\]$/a org.freedesktop.impl.portal.FileChooser=nautilus' "$portal_config"
+  else
+    sed -i '1i [preferred]\norg.freedesktop.impl.portal.FileChooser=nautilus\n' "$portal_config"
+  fi
+fi
+
+printf '%s\n' \
+  '[portal]' \
+  'DBusName=org.gnome.Nautilus' \
+  'Interfaces=org.freedesktop.impl.portal.FileChooser' \
+  'UseIn=Hyprland' >"$nautilus_portal"

--- a/install/user/xdg-desktop-portal.sh
+++ b/install/user/xdg-desktop-portal.sh
@@ -2,6 +2,10 @@ config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
 data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
 
 portal_config="$config_home/xdg-desktop-portal/hyprland-portals.conf"
+# portals.conf is read from $XDG_CONFIG_HOME. .portal descriptors are not:
+# xdg-desktop-portal (>= 1.21.0) loads them from $XDG_DATA_HOME, then
+# $XDG_DATA_DIRS, then /usr/share. A file under
+# ~/.config/xdg-desktop-portal/portals/ is ignored.
 nautilus_portal="$data_home/xdg-desktop-portal/portals/nautilus.portal"
 nautilus_dbus_service="$data_home/dbus-1/services/org.gnome.Nautilus.service"
 

--- a/install/user/xdg-desktop-portal.sh
+++ b/install/user/xdg-desktop-portal.sh
@@ -1,7 +1,14 @@
-portal_config="$HOME/.config/xdg-desktop-portal/hyprland-portals.conf"
-nautilus_portal="$HOME/.local/share/xdg-desktop-portal/portals/nautilus.portal"
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
 
-mkdir -p "$(dirname "$portal_config")" "$(dirname "$nautilus_portal")"
+portal_config="$config_home/xdg-desktop-portal/hyprland-portals.conf"
+nautilus_portal="$data_home/xdg-desktop-portal/portals/nautilus.portal"
+nautilus_dbus_service="$data_home/dbus-1/services/org.gnome.Nautilus.service"
+
+mkdir -p \
+  "$(dirname "$portal_config")" \
+  "$(dirname "$nautilus_portal")" \
+  "$(dirname "$nautilus_dbus_service")"
 
 if [[ ! -e $portal_config ]]; then
   printf '%s\n' \
@@ -9,15 +16,36 @@ if [[ ! -e $portal_config ]]; then
     'default=hyprland;gtk' \
     'org.freedesktop.impl.portal.FileChooser=nautilus' >"$portal_config"
 elif ! grep -q '^org\.freedesktop\.impl\.portal\.FileChooser=' "$portal_config"; then
-  if grep -q '^\[preferred\]$' "$portal_config"; then
-    sed -i '/^\[preferred\]$/a org.freedesktop.impl.portal.FileChooser=nautilus' "$portal_config"
+  # Tolerate surrounding whitespace on the section header: a miss here falls
+  # through to inserting a second [preferred], and GKeyFile treats a duplicate
+  # group as a parse error, which would take out portals.conf loading entirely.
+  if grep -qE '^[[:space:]]*\[preferred\][[:space:]]*$' "$portal_config"; then
+    sed -i -E '/^[[:space:]]*\[preferred\][[:space:]]*$/a org.freedesktop.impl.portal.FileChooser=nautilus' "$portal_config"
   else
     sed -i '1i [preferred]\norg.freedesktop.impl.portal.FileChooser=nautilus\n' "$portal_config"
   fi
 fi
 
+# No UseIn key: that is the deprecated pre-portals.conf selector, consulted only
+# when portals.conf picks nothing, and xdg-desktop-portal logs a deprecation
+# warning when it falls back to it.
 printf '%s\n' \
   '[portal]' \
   'DBusName=org.gnome.Nautilus' \
-  'Interfaces=org.freedesktop.impl.portal.FileChooser' \
-  'UseIn=Hyprland' >"$nautilus_portal"
+  'Interfaces=org.freedesktop.impl.portal.FileChooser' >"$nautilus_portal"
+
+# Deadlock guard. Registering a GTK4/libadwaita app as a portal backend makes
+# xdg-desktop-portal activate it from inside its own init to build the
+# FileChooser impl proxy; Nautilus's startup then calls synchronously back into
+# the still-activating portal. Only the 25s D-Bus timeout breaks the cycle, and
+# every GTK app in the session queues behind the pending activation. There are
+# two independent synchronous callers, one per toolkit layer, each with its own
+# opt-out: GDK's startup portal query (GDK_DEBUG=no-portals) and libadwaita's
+# AdwSettingsImplPortal constructor (ADW_DISABLE_PORTAL=1, falls back to its
+# GSettings impl). Disarming only one moves the stall up a layer rather than
+# fixing it. Nautilus needs neither: it is the chooser, and theming still
+# tracks GSettings.
+printf '%s\n' \
+  '[D-BUS Service]' \
+  'Name=org.gnome.Nautilus' \
+  'Exec=/usr/bin/env GDK_DEBUG=no-portals ADW_DISABLE_PORTAL=1 /usr/bin/nautilus --gapplication-service' >"$nautilus_dbus_service"

--- a/install/user/xdg-desktop-portal.sh
+++ b/install/user/xdg-desktop-portal.sh
@@ -14,15 +14,22 @@ mkdir -p \
   "$(dirname "$nautilus_portal")" \
   "$(dirname "$nautilus_dbus_service")"
 
-if [[ ! -e $portal_config ]]; then
+# -s, not -e: sed's `1i` is a line address, so it inserts nothing into a
+# zero-line file. An empty portals.conf would otherwise be left untouched and
+# the preference silently never written.
+if [[ ! -s $portal_config ]]; then
   printf '%s\n' \
     '[preferred]' \
     'default=hyprland;gtk' \
     'org.freedesktop.impl.portal.FileChooser=nautilus' >"$portal_config"
-elif ! grep -q '^org\.freedesktop\.impl\.portal\.FileChooser=' "$portal_config"; then
-  # Tolerate surrounding whitespace on the section header: a miss here falls
-  # through to inserting a second [preferred], and GKeyFile treats a duplicate
-  # group as a parse error, which would take out portals.conf loading entirely.
+# GKeyFile allows whitespace around the separator, so the existing-preference
+# check has to as well. Matching only `key=` misses `key = kde`, and the
+# insertion below then adds a second FileChooser key; GKeyFile resolves a
+# duplicate key to the last occurrence, so the user's backend keeps winning and
+# this whole script becomes a silent no-op on exactly the installs it targets.
+elif ! grep -qE '^[[:space:]]*org\.freedesktop\.impl\.portal\.FileChooser[[:space:]]*=' "$portal_config"; then
+  # Same tolerance on the section header, so a padded [preferred] is amended
+  # rather than gaining a confusing second copy of itself.
   if grep -qE '^[[:space:]]*\[preferred\][[:space:]]*$' "$portal_config"; then
     sed -i -E '/^[[:space:]]*\[preferred\][[:space:]]*$/a org.freedesktop.impl.portal.FileChooser=nautilus' "$portal_config"
   else

--- a/migrations/1787508122.sh
+++ b/migrations/1787508122.sh
@@ -2,4 +2,9 @@ echo "Route file chooser portal requests to Nautilus"
 
 source "$OMARCHY_PATH/install/user/xdg-desktop-portal.sh"
 
-systemctl --user try-restart xdg-desktop-portal.service
+# Never fail the migration on an unreachable user bus. omarchy-migrate runs each
+# migration with strict error handling and only marks it complete afterwards,
+# so a nonzero exit here would also skip every later pending migration. When
+# there is no user bus, there is no running portal to restart either.
+systemctl --user reload dbus-broker.service >/dev/null 2>&1 || true
+systemctl --user try-restart xdg-desktop-portal.service >/dev/null 2>&1 || true

--- a/migrations/1787508122.sh
+++ b/migrations/1787508122.sh
@@ -1,0 +1,5 @@
+echo "Route file chooser portal requests to Nautilus"
+
+source "$OMARCHY_PATH/install/user/xdg-desktop-portal.sh"
+
+systemctl --user try-restart xdg-desktop-portal.service

--- a/test/shell.d/xdg-desktop-portal-test.sh
+++ b/test/shell.d/xdg-desktop-portal-test.sh
@@ -10,7 +10,8 @@ migration="$ROOT/migrations/1787508122.sh"
 fresh=$(mktemp -d)
 legacy=$(mktemp -d)
 busless=$(mktemp -d)
-trap 'rm -rf "$fresh" "$legacy" "$busless"' EXIT
+xdg_home=$(mktemp -d)
+trap 'rm -rf "$fresh" "$legacy" "$busless" "$xdg_home"' EXIT
 
 # Keep each case isolated and use non-default XDG paths so the test proves the
 # setup script honours the base-directory variables instead of hard-coding HOME.
@@ -83,7 +84,19 @@ printf '%s\n' '  [preferred]  ' 'default=hyprland;gtk' >"$fresh_conf"
 run_in_home "$fresh" bash -euo pipefail "$setup_script"
 section_count=$(grep -cE '^[[:space:]]*\[preferred\]' "$fresh_conf")
 ((section_count == 1)) || fail "A whitespace-padded [preferred] header is not duplicated"
+grep -Fx 'org.freedesktop.impl.portal.FileChooser=nautilus' "$fresh_conf" >/dev/null ||
+  fail "A whitespace-padded [preferred] section still receives the file chooser line"
 pass "a whitespace-padded [preferred] section is amended, not duplicated"
+
+# Unset XDG dirs: files must land in the $HOME defaults.
+HOME="$xdg_home" env -u XDG_CONFIG_HOME -u XDG_DATA_HOME bash -euo pipefail "$setup_script"
+[[ -e $xdg_home/.config/xdg-desktop-portal/hyprland-portals.conf ]] ||
+  fail "without XDG overrides, portal preference is written under ~/.config"
+[[ -e $xdg_home/.local/share/xdg-desktop-portal/portals/nautilus.portal ]] ||
+  fail "without XDG overrides, portal descriptor is written under ~/.local/share"
+[[ -e $xdg_home/.local/share/dbus-1/services/org.gnome.Nautilus.service ]] ||
+  fail "without XDG overrides, Nautilus D-Bus override is written under ~/.local/share"
+pass "XDG defaults are used when XDG_CONFIG_HOME and XDG_DATA_HOME are unset"
 
 # 3. The migration repairs a separate empty home and restarts the portal.
 legacy_stub=$(install_recording_systemctl "$legacy")

--- a/test/shell.d/xdg-desktop-portal-test.sh
+++ b/test/shell.d/xdg-desktop-portal-test.sh
@@ -1,38 +1,113 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/base-test.sh"
 
 setup_script="$ROOT/install/user/xdg-desktop-portal.sh"
 migration="$ROOT/migrations/1787508122.sh"
-test_home=$(mktemp -d)
-trap 'rm -rf "$test_home"' EXIT
 
-HOME="$test_home" bash -euo pipefail "$setup_script"
+fresh=$(mktemp -d)
+legacy=$(mktemp -d)
+busless=$(mktemp -d)
+trap 'rm -rf "$fresh" "$legacy" "$busless"' EXIT
 
-portal_config="$test_home/.config/xdg-desktop-portal/hyprland-portals.conf"
-nautilus_portal="$test_home/.local/share/xdg-desktop-portal/portals/nautilus.portal"
+# Keep each case isolated and use non-default XDG paths so the test proves the
+# setup script honours the base-directory variables instead of hard-coding HOME.
+run_in_home() {
+  local home="$1"
+  shift
+  env \
+    HOME="$home" \
+    XDG_CONFIG_HOME="$home/xdg-config" \
+    XDG_DATA_HOME="$home/xdg-data" \
+    "$@"
+}
 
-grep -Fx 'org.freedesktop.impl.portal.FileChooser=nautilus' "$portal_config" >/dev/null || fail "Nautilus is selected for file chooser requests"
-grep -Fx 'default=hyprland;gtk' "$portal_config" >/dev/null || fail "Hyprland and GTK remain the default portal backends"
-grep -Fx 'DBusName=org.gnome.Nautilus' "$nautilus_portal" >/dev/null || fail "Nautilus portal descriptor names the Nautilus D-Bus service"
-grep -Fx 'Interfaces=org.freedesktop.impl.portal.FileChooser' "$nautilus_portal" >/dev/null || fail "Nautilus portal descriptor exposes only the file chooser"
+assert_generated() {
+  local home="$1" label="$2"
+  local conf="$home/xdg-config/xdg-desktop-portal/hyprland-portals.conf"
+  local portal="$home/xdg-data/xdg-desktop-portal/portals/nautilus.portal"
+  local service="$home/xdg-data/dbus-1/services/org.gnome.Nautilus.service"
+
+  grep -Fx 'org.freedesktop.impl.portal.FileChooser=nautilus' "$conf" >/dev/null ||
+    fail "$label: Nautilus is selected for file chooser requests"
+  grep -Fx 'default=hyprland;gtk' "$conf" >/dev/null ||
+    fail "$label: Hyprland and GTK remain the default portal backends"
+  grep -Fx 'DBusName=org.gnome.Nautilus' "$portal" >/dev/null ||
+    fail "$label: portal descriptor names the Nautilus D-Bus service"
+  grep -Fx 'Interfaces=org.freedesktop.impl.portal.FileChooser' "$portal" >/dev/null ||
+    fail "$label: portal descriptor exposes only the file chooser"
+  if grep -q 'UseIn' "$portal"; then
+    fail "$label: portal descriptor does not carry the deprecated UseIn key"
+  fi
+  grep -Fx 'Exec=/usr/bin/env GDK_DEBUG=no-portals ADW_DISABLE_PORTAL=1 /usr/bin/nautilus --gapplication-service' "$service" >/dev/null ||
+    fail "$label: Nautilus activation disarms both synchronous portal callers"
+}
+
+# A stub that records how it was called, so the migration's service reload and
+# portal restart can be asserted exactly.
+install_recording_systemctl() {
+  local dir="$1/stub"
+  mkdir -p "$dir"
+  cat >"$dir/systemctl" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+STUB
+  chmod +x "$dir/systemctl"
+  printf '%s\n' "$dir"
+}
+
+# 1. Fresh install.
+run_in_home "$fresh" bash -euo pipefail "$setup_script"
+assert_generated "$fresh" "fresh install"
 pass "fresh installs route file chooser requests to Nautilus"
 
+# 2. An explicit user preference survives a re-run.
+fresh_conf="$fresh/xdg-config/xdg-desktop-portal/hyprland-portals.conf"
 printf '%s\n' \
   '[preferred]' \
   'default=hyprland;gtk' \
-  'org.freedesktop.impl.portal.FileChooser=custom' >"$portal_config"
+  'org.freedesktop.impl.portal.FileChooser=custom' >"$fresh_conf"
 
-HOME="$test_home" bash -euo pipefail "$setup_script"
+run_in_home "$fresh" bash -euo pipefail "$setup_script"
 
-grep -Fx 'org.freedesktop.impl.portal.FileChooser=custom' "$portal_config" >/dev/null || fail "Existing file chooser preference is preserved"
-[[ $(grep -c '^org\.freedesktop\.impl\.portal\.FileChooser=' "$portal_config") -eq 1 ]] || fail "File chooser preference is not duplicated"
+grep -Fx 'org.freedesktop.impl.portal.FileChooser=custom' "$fresh_conf" >/dev/null ||
+  fail "Existing file chooser preference is preserved"
+chooser_count=$(grep -c '^org\.freedesktop\.impl\.portal\.FileChooser=' "$fresh_conf")
+((chooser_count == 1)) || fail "File chooser preference is not duplicated"
 pass "explicit user portal preferences are preserved"
 
-stub_bin="$test_home/bin"
-mkdir -p "$stub_bin"
-printf '%s\n' '#!/bin/bash' 'exit 0' >"$stub_bin/systemctl"
-chmod +x "$stub_bin/systemctl"
+# 2b. A [preferred] header with stray whitespace must not gain a second section.
+printf '%s\n' '  [preferred]  ' 'default=hyprland;gtk' >"$fresh_conf"
+run_in_home "$fresh" bash -euo pipefail "$setup_script"
+section_count=$(grep -cE '^[[:space:]]*\[preferred\]' "$fresh_conf")
+((section_count == 1)) || fail "A whitespace-padded [preferred] header is not duplicated"
+pass "a whitespace-padded [preferred] section is amended, not duplicated"
 
-HOME="$test_home" PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" bash -euo pipefail "$migration" >/dev/null
+# 3. The migration repairs a separate empty home and restarts the portal.
+legacy_stub=$(install_recording_systemctl "$legacy")
+run_in_home "$legacy" \
+  PATH="$legacy_stub:$PATH" SYSTEMCTL_LOG="$legacy/systemctl.log" OMARCHY_PATH="$ROOT" \
+  bash -euo pipefail "$migration" >/dev/null
+
+assert_generated "$legacy" "migration"
+grep -Fx -- '--user reload dbus-broker.service' "$legacy/systemctl.log" >/dev/null ||
+  fail "migration reloads the D-Bus service registry"
+grep -Fx -- '--user try-restart xdg-desktop-portal.service' "$legacy/systemctl.log" >/dev/null ||
+  fail "migration restarts the portal frontend"
 pass "existing installs apply the portal migration"
+
+# 4. No user bus reachable: the migration must still succeed, or omarchy-migrate
+# aborts the whole run and skips every later pending migration.
+busless_stub="$busless/stub"
+mkdir -p "$busless_stub"
+printf '%s\n' '#!/bin/bash' 'echo "Failed to connect to bus: No medium found" >&2' 'exit 1' \
+  >"$busless_stub/systemctl"
+chmod +x "$busless_stub/systemctl"
+
+run_in_home "$busless" PATH="$busless_stub:$PATH" OMARCHY_PATH="$ROOT" \
+  bash -euo pipefail "$migration" >/dev/null ||
+  fail "migration tolerates an unreachable user bus"
+assert_generated "$busless" "migration without a user bus"
+pass "the migration does not abort when no user bus is reachable"

--- a/test/shell.d/xdg-desktop-portal-test.sh
+++ b/test/shell.d/xdg-desktop-portal-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+setup_script="$ROOT/install/user/xdg-desktop-portal.sh"
+migration="$ROOT/migrations/1787508122.sh"
+test_home=$(mktemp -d)
+trap 'rm -rf "$test_home"' EXIT
+
+HOME="$test_home" bash -euo pipefail "$setup_script"
+
+portal_config="$test_home/.config/xdg-desktop-portal/hyprland-portals.conf"
+nautilus_portal="$test_home/.local/share/xdg-desktop-portal/portals/nautilus.portal"
+
+grep -Fx 'org.freedesktop.impl.portal.FileChooser=nautilus' "$portal_config" >/dev/null || fail "Nautilus is selected for file chooser requests"
+grep -Fx 'default=hyprland;gtk' "$portal_config" >/dev/null || fail "Hyprland and GTK remain the default portal backends"
+grep -Fx 'DBusName=org.gnome.Nautilus' "$nautilus_portal" >/dev/null || fail "Nautilus portal descriptor names the Nautilus D-Bus service"
+grep -Fx 'Interfaces=org.freedesktop.impl.portal.FileChooser' "$nautilus_portal" >/dev/null || fail "Nautilus portal descriptor exposes only the file chooser"
+pass "fresh installs route file chooser requests to Nautilus"
+
+printf '%s\n' \
+  '[preferred]' \
+  'default=hyprland;gtk' \
+  'org.freedesktop.impl.portal.FileChooser=custom' >"$portal_config"
+
+HOME="$test_home" bash -euo pipefail "$setup_script"
+
+grep -Fx 'org.freedesktop.impl.portal.FileChooser=custom' "$portal_config" >/dev/null || fail "Existing file chooser preference is preserved"
+[[ $(grep -c '^org\.freedesktop\.impl\.portal\.FileChooser=' "$portal_config") -eq 1 ]] || fail "File chooser preference is not duplicated"
+pass "explicit user portal preferences are preserved"
+
+stub_bin="$test_home/bin"
+mkdir -p "$stub_bin"
+printf '%s\n' '#!/bin/bash' 'exit 0' >"$stub_bin/systemctl"
+chmod +x "$stub_bin/systemctl"
+
+HOME="$test_home" PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" bash -euo pipefail "$migration" >/dev/null
+pass "existing installs apply the portal migration"

--- a/test/shell.d/xdg-desktop-portal-test.sh
+++ b/test/shell.d/xdg-desktop-portal-test.sh
@@ -88,6 +88,27 @@ grep -Fx 'org.freedesktop.impl.portal.FileChooser=nautilus' "$fresh_conf" >/dev/
   fail "A whitespace-padded [preferred] section still receives the file chooser line"
 pass "a whitespace-padded [preferred] section is amended, not duplicated"
 
+# 2c. GKeyFile allows whitespace around the separator, so a hand-written config
+# may well use it. Missing that form inserts a second FileChooser key; GKeyFile
+# resolves a duplicate key to the last occurrence, so the user's backend keeps
+# winning and the routing this script exists to apply silently never happens.
+printf '%s\n' '[preferred]' 'default = hyprland;gtk' \
+  'org.freedesktop.impl.portal.FileChooser = kde' >"$fresh_conf"
+run_in_home "$fresh" bash -euo pipefail "$setup_script"
+chooser_count=$(grep -cE '^[[:space:]]*org\.freedesktop\.impl\.portal\.FileChooser[[:space:]]*=' "$fresh_conf")
+((chooser_count == 1)) || fail "A spaced file chooser preference is not duplicated"
+grep -Fx 'org.freedesktop.impl.portal.FileChooser = kde' "$fresh_conf" >/dev/null ||
+  fail "A spaced file chooser preference is preserved"
+pass "a preference written with spaces around the separator is preserved"
+
+# 2d. An empty portals.conf. `sed 1i` is a line address and inserts nothing into
+# a zero-line file, so a plain -e existence check leaves the file untouched.
+: >"$fresh_conf"
+run_in_home "$fresh" bash -euo pipefail "$setup_script"
+grep -Fx 'org.freedesktop.impl.portal.FileChooser=nautilus' "$fresh_conf" >/dev/null ||
+  fail "An empty portal preference file is populated"
+pass "an empty portals.conf is populated rather than left untouched"
+
 # Unset XDG dirs: files must land in the $HOME defaults.
 HOME="$xdg_home" env -u XDG_CONFIG_HOME -u XDG_DATA_HOME bash -euo pipefail "$setup_script"
 [[ -e $xdg_home/.config/xdg-desktop-portal/hyprland-portals.conf ]] ||


### PR DESCRIPTION
Fixes #7944.

## What changed

- Register Nautilus's existing `org.freedesktop.impl.portal.FileChooser` implementation for Hyprland sessions.
- Select Nautilus only for `FileChooser`, preserving Hyprland/GTK as the default portal chain for screen capture, shortcuts, and other interfaces.
- Preserve an explicit user-selected file chooser backend.
- Write portal preferences under `$XDG_CONFIG_HOME` and the Nautilus `.portal` descriptor under `$XDG_DATA_HOME` (xdg-desktop-portal does not load `.portal` files from config).
- Override `org.gnome.Nautilus` D-Bus activation with `GDK_DEBUG=no-portals` and `ADW_DISABLE_PORTAL=1` so Nautilus cannot deadlock xdg-desktop-portal during session init.
- Apply the setup during fresh user finalization and through a migration for existing installs.
- Reload dbus-broker and restart the frontend portal after migration so the repaired picker works immediately; do not fail the migration when no user bus is reachable.

## Why

Omarchy 4 ships Nautilus 50, which implements the modern GNOME file chooser, but no portal descriptor or Hyprland preference selects it. File chooser calls therefore fall through to `xdg-desktop-portal-gtk`; on the affected installation that backend hangs for 25 seconds and returns `Timeout was reached`.

`xdg-desktop-portal-gnome` cannot bridge this on Hyprland because it detects the non-GNOME display server and exposes settings only. Registering Nautilus directly avoids that restriction and was verified with a live `org.freedesktop.portal.FileChooser.OpenFile` request.

Registering the descriptor alone is not enough: xdg-desktop-portal activates Nautilus while building the FileChooser proxy, and Nautilus then calls synchronously back into the still-activating portal. That is a 25s hang at every cold login unless both GDK and libadwaita portal queries are disarmed on the Nautilus activation path.

## Tests

- `bash test/shell.d/xdg-desktop-portal-test.sh` — passes
- `git diff --check` — passes


## Related work

- Relates to #2798: another 25-second Nautilus/portal startup cycle; the D-Bus activation override here disables both synchronous portal callbacks in Nautilus.
- Relates to #8543: routing FileChooser away from `xdg-desktop-portal-gtk` avoids the crashing GTK backend for portal-based picker requests.
- Overlaps #6019 in user-facing intent, but not implementation: that PR routes through `xdg-desktop-portal-gnome`, which declines to expose FileChooser outside GNOME; this PR registers Nautilus directly for Hyprland instead.
