### PR TITLE
Allow plugins to add menu launchers

### DIFF
--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -22,8 +22,8 @@ Usage: omarchy plugin validate <plugin-folder>
 
 Checks a plugin folder's manifest.json against the schema the shell enforces:
 schemaVersion, required fields, safe relative entry points that exist, an entry
-point for each kind that needs one, no symlinks, and an id that is not reserved.
-Exits 0 if valid — handy for plugin authors before publishing.
+point for each kind that needs one, menu launcher metadata, no symlinks, and an
+id that is not reserved. Exits 0 if valid — handy before publishing.
 USAGE
   exit 0
 fi
@@ -59,6 +59,28 @@ jq -e '(.kinds | type) == "array" and (.kinds | length) > 0' "$MANIFEST" >/dev/n
 # entryPoints must be an object and every value a safe relative path that exists.
 jq -e '(.entryPoints | type) == "object"' "$MANIFEST" >/dev/null 2>&1 \
   || fail "'entryPoints' must be an object"
+
+# A plugin can opt into one root-level Omarchy menu launcher. The menu builds
+# the action itself, so manifests only provide presentation metadata and only
+# plugin kinds the shell can summon may declare one.
+if jq -e 'has("menuItem")' "$MANIFEST" >/dev/null 2>&1; then
+  jq -e '(.menuItem | type) == "object"' "$MANIFEST" >/dev/null 2>&1 \
+    || fail "'menuItem' must be an object"
+  jq -e '
+    . as $manifest
+    | all(["label", "icon", "iconFont", "description"][];
+        . as $field
+        | (($manifest.menuItem | has($field) | not)
+          or ($manifest.menuItem[$field] | type == "string")))
+  ' "$MANIFEST" >/dev/null 2>&1 \
+    || fail "'menuItem' presentation fields must be strings"
+  jq -e '(.menuItem.label? // "fallback") != ""' "$MANIFEST" >/dev/null 2>&1 \
+    || fail "'menuItem.label' must not be empty"
+  jq -e '
+    any(.kinds[]; . == "bar-widget" or . == "menu" or . == "overlay" or . == "panel")
+  ' "$MANIFEST" >/dev/null 2>&1 \
+    || fail "'menuItem' requires a summonable kind: bar-widget, menu, overlay, or panel"
+fi
 
 # A bar widget may declare where it should land when enabled without an
 # explicit placement.

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -60,7 +60,7 @@ A plugin with a `bar-widget`, `menu`, `overlay`, or `panel` kind can opt into on
 
 The block is presentation metadata, not a general menu entry. `label` falls back to the manifest name, `description` falls back to the manifest description, and `icon` plus `iconFont` are optional strings. The menu generates the action itself as `omarchy-shell shell toggle <plugin-id>`; manifests cannot inject a different shell command through this field.
 
-Launchers appear only while their plugin is enabled, update on plugin rescans and enable/disable changes, and disappear without mutating the user's extension file. Their generated id is `plugin.<plugin-id>`. A user extension can override that id because user entries merge last; since the generated id contains dots, an override that should remain at the top level must declare `"parent": "root"` explicitly.
+Launchers appear only while their plugin is enabled, update on plugin rescans and enable/disable changes, and disappear without mutating the user's extension file. Their generated id is `plugin.<plugin-id>`. A user extension can override that id because user entries merge last, but the override is ignored while the corresponding plugin launcher is absent. Since the generated id contains dots, an override that should remain at the top level must declare `"parent": "root"` explicitly.
 
 The manifest kind `menu` remains a different concept: it declares that the plugin's own entry point is a summoned menu surface. `menuItem` adds a launcher for a summonable plugin to the built-in Omarchy menu.
 

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -1,16 +1,6 @@
 # The Omarchy menu
 
-The menu is the `omarchy.menu` plugin of the Quickshell desktop, with its
-content defined as data in `default/omarchy/omarchy-menu.jsonc` (read at
-runtime from `$OMARCHY_PATH`) and overlaid by the user's
-`~/.config/omarchy/extensions/omarchy-menu.jsonc`. The shell parses both files
-at startup and watches them for changes, so the keybind → IPC → visible path
-never shells out to parse anything, and edits to either file take effect
-without restarting the shell. Rendering and behavior live in
-`shell/plugins/menu/Menu.qml`; the pure logic lives in
-`shell/plugins/menu/MenuModel.js`, which is plain JavaScript that Node can
-also load — the shell tests in `test/shell.d/menu-test.sh` and
-`menu-guards-test.sh` exercise it directly.
+The menu is the `omarchy.menu` plugin of the Quickshell desktop, with its content defined as data in `default/omarchy/omarchy-menu.jsonc` (read at runtime from `$OMARCHY_PATH`), optional launchers declared by enabled plugin manifests, and the user's `~/.config/omarchy/extensions/omarchy-menu.jsonc`. The shell parses both files at startup and watches them for changes, so the keybind → IPC → visible path never shells out to parse anything, and edits to either file take effect without restarting the shell. Rendering and behavior live in `shell/plugins/menu/Menu.qml`; the pure logic lives in `shell/plugins/menu/MenuModel.js`, which is plain JavaScript that Node can also load — the shell tests in `test/shell.d/menu-test.sh` and `menu-guards-test.sh` exercise it directly.
 
 JSONC here means JSON plus comments and trailing commas, stripped by the
 parser rather than a real JSONC grammar: only whole-line `//` comments are
@@ -50,15 +40,29 @@ id segment, and descriptions are all searchable.
 
 ## Load and merge
 
-`mergeMenuSources` overlays user entries on the defaults per key: reusing a
-shipped id replaces only the fields you declare, so an extension can retitle
-or re-icon a row without re-declaring its action, and an overridden entry
-keeps its original position in the list. New ids append. A `root` entry is
-injected if neither file declares one.
+`mergeMenuSources` merges defaults → enabled plugin launchers → user entries per key. Reusing an existing id applies the later normalized entry while keeping the row's original position; new ids append. A `root` entry is injected if no source declares one.
 
-The sample extension at `config/omarchy/extensions/omarchy-menu.jsonc`
-(refreshed into `~/.config/`) documents the format in its header and ships
-only comments, so the default state adds nothing.
+The sample extension at `config/omarchy/extensions/omarchy-menu.jsonc` (refreshed into `~/.config/`) documents the format in its header and ships only comments, so the default state adds nothing.
+
+## Plugin launchers
+
+A plugin with a `bar-widget`, `menu`, `overlay`, or `panel` kind can opt into one root-level launcher by adding `menuItem` to its manifest:
+
+```json
+{
+  "menuItem": {
+    "label": "Text Polish",
+    "icon": "󰚩",
+    "description": "Correct and refine clipboard text"
+  }
+}
+```
+
+The block is presentation metadata, not a general menu entry. `label` falls back to the manifest name, `description` falls back to the manifest description, and `icon` plus `iconFont` are optional strings. The menu generates the action itself as `omarchy-shell shell toggle <plugin-id>`; manifests cannot inject a different shell command through this field.
+
+Launchers appear only while their plugin is enabled, update on plugin rescans and enable/disable changes, and disappear without mutating the user's extension file. Their generated id is `plugin.<plugin-id>`. A user extension can override that id because user entries merge last; since the generated id contains dots, an override that should remain at the top level must declare `"parent": "root"` explicitly.
+
+The manifest kind `menu` remains a different concept: it declares that the plugin's own entry point is a summoned menu surface. `menuItem` adds a launcher for a summonable plugin to the built-in Omarchy menu.
 
 ## Guards
 

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -41,6 +41,20 @@ Panels, overlays, and menus are loaded when summoned. Plugins can set the
 top-level manifest key `keepLoaded: true` to survive between summons.
 First-party services are loaded at startup.
 
+A plugin with a `bar-widget`, `menu`, `overlay`, or `panel` kind can add one root-level launcher to the built-in Omarchy menu by declaring a `menuItem` object. The object accepts optional string fields `label`, `icon`, `iconFont`, and `description`; label and description fall back to the manifest values. The launcher is present only while the plugin is enabled and always invokes the standard `toggle` lifecycle for that plugin — manifests cannot supply an arbitrary command through `menuItem`.
+
+```json
+{
+  "menuItem": {
+    "label": "Cool clock",
+    "icon": "󰥔",
+    "description": "Open the clock panel"
+  }
+}
+```
+
+This is separate from `kinds: ["menu"]`, which says that the plugin itself implements a summoned menu surface.
+
 Entry points are QML `Item`s. Panel, overlay, and menu entry points expose
 `open(payloadJson)` and `close()` for summon/hide; on load the host injects
 `omarchyPath`, `shell`, `manifest`, and the registries (`pluginRegistry` /

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -85,13 +85,27 @@ A plugin is a directory with a `manifest.json` and some QML. The manifest declar
 
 A plugin can declare several kinds at once — the media plugin is both a `service` and a `bar-widget`. Bar widgets get an extra `barWidget` block with a display name, a category, an optional `defaultSection`, and `allowMultiple`, which says whether it makes sense to have more than one on the bar. Most widgets set it to `false`; spacers and indicators set it to `true`.
 
+A plugin with a visible kind (`bar-widget`, `menu`, `overlay`, or `panel`) can also add one launcher to the root Omarchy menu. Include a `menuItem` block in the manifest with any of the optional string fields `label`, `icon`, `iconFont`, and `description`:
+
+```json
+{
+  "menuItem": {
+    "label": "Text Polish",
+    "icon": "󰚩",
+    "description": "Correct and refine clipboard text"
+  }
+}
+```
+
+The launcher appears only while the plugin is enabled and opens it through the standard toggle lifecycle. It cannot declare its own shell command. This is different from the `menu` kind, which means that the plugin itself provides a summoned menu surface.
+
 Before you publish anything, check it:
 
 ```
 omarchy plugin validate ./my-plugin
 ```
 
-That runs the same checks the shell does at load time: the schema version, the required fields, an id that isn't reserved, entry points that are safe relative paths and actually exist, an entry point for every kind you claimed, and no symlinks anywhere inside the folder.
+That runs the same checks the shell does at load time: the schema version, the required fields, an id that isn't reserved, entry points that are safe relative paths and actually exist, an entry point for every kind you claimed, valid menu launcher metadata, and no symlinks anywhere inside the folder.
 
 For the full picture, the source is the documentation: `shell/README.md` in the Omarchy repo covers the manifest schema, the shell's IPC contract, and the exact shape of `shell.json`, and `shell/plugins/README.md` lists every first-party plugin with its id, kinds, and entry points.
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -89,6 +89,20 @@ to outlive a single summon can set `keepLoaded: true` (e.g. the image
 picker keeps its overlay window mounted between summons). First-party
 services are loaded at startup.
 
+A plugin with a `bar-widget`, `menu`, `overlay`, or `panel` kind can opt into one root-level launcher in the built-in Omarchy menu with a `menuItem` object:
+
+```json
+{
+  "menuItem": {
+    "label": "Cool clock",
+    "icon": "󰥔",
+    "description": "Open the clock panel"
+  }
+}
+```
+
+The optional string fields are `label`, `icon`, `iconFont`, and `description`; label and description fall back to the manifest values. The launcher exists only while the plugin is enabled and always runs the shell's standard `toggle` lifecycle for that plugin, so `menuItem` cannot inject an arbitrary command. This is separate from the `menu` kind, which declares that the plugin itself supplies a summoned menu surface.
+
 The full schema lives in `services/PluginRegistry.qml`.
 
 ## Installing a third-party plugin

--- a/shell/plugins/README.md
+++ b/shell/plugins/README.md
@@ -102,6 +102,7 @@ second Quickshell instance.
 The menu definition lives outside the shell host code:
 
 - defaults: `default/omarchy/omarchy-menu.jsonc`
+- plugin launchers: `menuItem` blocks from enabled plugin manifests
 - user extensions: `~/.config/omarchy/extensions/omarchy-menu.jsonc`
 
 The shell parses both JSONC files at startup (with `watchChanges: true`

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -45,8 +45,8 @@ Item {
 
   property string fontFamily: Style.font.menuFamily
   // JSONC menu definitions. The shell parses both at startup and merges
-  // the user file on top of the defaults, so the keybind → IPC → visible
-  // path doesn't have to shell out to bash + jq on every open.
+  // enabled plugin contributions between the defaults and user file, so the
+  // keybind → IPC → visible path doesn't shell out on every open.
   property string defaultMenuPath: omarchyPath + "/default/omarchy/omarchy-menu.jsonc"
   property string userMenuPath: Quickshell.env("HOME") + "/.config/omarchy/extensions/omarchy-menu.jsonc"
   property var defaultMenuItems: []
@@ -240,11 +240,21 @@ Item {
     return MenuModel.parseMenuJsonc(raw)
   }
 
-  // Merge defaults + user extension. Later entries override earlier ones
-  // on a per-key basis (so the user can tweak label/icon/action without
-  // re-declaring the whole row).
+  function enabledPluginMenuItems() {
+    var registry = root.shell ? root.shell.pluginRegistry : null
+    if (!registry) return []
+    return MenuModel.pluginMenuItems(registry.installedPlugins, function(pluginId) {
+      return registry.isEnabled(pluginId)
+    })
+  }
+
+  // Merge defaults + enabled plugins + user extension. Later entries override
+  // earlier ones on a per-key basis, so user configuration stays authoritative.
   function rebuildItemsFromSources() {
-    var mergedMenu = MenuModel.mergeMenuSources(root.defaultMenuItems, root.userMenuItems)
+    var mergedMenu = MenuModel.mergeMenuSources(
+      root.defaultMenuItems,
+      root.enabledPluginMenuItems(),
+      root.userMenuItems)
     root.providerRevision += 1
     root.providersLoaded = ({})
     root.providerQueue = []
@@ -958,6 +968,13 @@ Item {
       if (root.providersLoaded["apps"]) root.mergeAppRows()
     }
   }
+
+  Connections {
+    target: root.shell ? root.shell.pluginRegistry : null
+    function onPluginsChanged() { root.rebuildItemsFromSources() }
+  }
+
+  onShellChanged: root.rebuildItemsFromSources()
 
   // The JSONC sources are watched so live edits to the default file (or the
   // user extension at ~/.config/omarchy/extensions/omarchy-menu.jsonc) take

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -103,9 +103,24 @@ function pluginMenuItems(plugins, isEnabled) {
 function mergeMenuSources(defaultItems, pluginItems, userItems) {
   var nextItems = ({})
   var nextOrder = []
-  var sources = userItems === undefined
-    ? [defaultItems || [], pluginItems || []]
-    : [defaultItems || [], pluginItems || [], userItems || []]
+  var sources
+  if (userItems === undefined) {
+    sources = [defaultItems || [], pluginItems || []]
+  } else {
+    var activePluginItems = ({})
+    var plugins = pluginItems || []
+    for (var p = 0; p < plugins.length; p++) {
+      if (plugins[p] && plugins[p].id) activePluginItems[plugins[p].id] = true
+    }
+
+    // Generated plugin ids are reserved for overrides. Do not let an override
+    // survive as a standalone launcher after its plugin has been disabled.
+    var users = (userItems || []).filter(function(entry) {
+      return !entry || !entry.id || entry.id.indexOf("plugin.") !== 0
+        || activePluginItems[entry.id]
+    })
+    sources = [defaultItems || [], plugins, users]
+  }
 
   for (var s = 0; s < sources.length; s++) {
     var src = sources[s]

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -63,10 +63,49 @@ function parseMenuJsonc(raw) {
   return out
 }
 
-function mergeMenuSources(defaultItems, userItems) {
+function shellQuote(value) {
+  return "'" + String(value || "").replace(/'/g, "'\\''") + "'"
+}
+
+// A manifest menuItem is deliberately smaller than the user menu schema. It
+// launches the plugin through the shell's standard lifecycle instead of
+// accepting an arbitrary command from the manifest. The generated id is
+// namespaced away from shipped menu routes and pinned to root so dots in a
+// plugin id do not turn it into an accidental submenu path.
+function pluginMenuItems(plugins, isEnabled) {
+  var manifests = plugins || ({})
+  var ids = Object.keys(manifests).sort()
+  var out = []
+
+  for (var i = 0; i < ids.length; i++) {
+    var pluginId = ids[i]
+    var manifest = manifests[pluginId]
+    if (!manifest || !manifest.menuItem || typeof manifest.menuItem !== "object"
+        || Array.isArray(manifest.menuItem)) continue
+    if (typeof isEnabled === "function" && !isEnabled(pluginId)) continue
+
+    var menuItem = manifest.menuItem
+    out.push(normalizeItem("plugin." + pluginId, {
+      parent: "root",
+      icon: typeof menuItem.icon === "string" ? menuItem.icon : "",
+      iconFont: typeof menuItem.iconFont === "string" ? menuItem.iconFont : "",
+      label: typeof menuItem.label === "string" && menuItem.label
+        ? menuItem.label : String(manifest.name || pluginId),
+      description: typeof menuItem.description === "string"
+        ? menuItem.description : String(manifest.description || ""),
+      action: "omarchy-shell shell toggle " + shellQuote(pluginId)
+    }))
+  }
+
+  return out
+}
+
+function mergeMenuSources(defaultItems, pluginItems, userItems) {
   var nextItems = ({})
   var nextOrder = []
-  var sources = [defaultItems || [], userItems || []]
+  var sources = userItems === undefined
+    ? [defaultItems || [], pluginItems || []]
+    : [defaultItems || [], pluginItems || [], userItems || []]
 
   for (var s = 0; s < sources.length; s++) {
     var src = sources[s]
@@ -498,6 +537,7 @@ if (typeof module !== "undefined") {
     normalizeAliases: normalizeAliases,
     normalizeItem: normalizeItem,
     parseMenuJsonc: parseMenuJsonc,
+    pluginMenuItems: pluginMenuItems,
     mergeMenuSources: mergeMenuSources,
     mergeAppRows: mergeAppRows,
     swapProviderRows: swapProviderRows,

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -69,6 +69,38 @@ QtObject {
       console.warn("PluginRegistry: entryPoints must be an object at " + sourcePath)
       return null
     }
+    if (manifest.menuItem !== undefined) {
+      if (!Util.isPlainObject(manifest.menuItem)) {
+        console.warn("PluginRegistry: menuItem must be an object at " + sourcePath)
+        return null
+      }
+      var menuItemFields = ["label", "icon", "iconFont", "description"]
+      for (var m = 0; m < menuItemFields.length; m++) {
+        var menuItemField = menuItemFields[m]
+        if (manifest.menuItem[menuItemField] !== undefined
+            && typeof manifest.menuItem[menuItemField] !== "string") {
+          console.warn("PluginRegistry: menuItem." + menuItemField
+            + " must be a string at " + sourcePath)
+          return null
+        }
+      }
+      if (manifest.menuItem.label !== undefined && !manifest.menuItem.label) {
+        console.warn("PluginRegistry: menuItem.label must not be empty at " + sourcePath)
+        return null
+      }
+      var summonableKinds = ["bar-widget", "menu", "overlay", "panel"]
+      var summonable = false
+      for (var s = 0; s < summonableKinds.length; s++) {
+        if (manifest.kinds.indexOf(summonableKinds[s]) !== -1) {
+          summonable = true
+          break
+        }
+      }
+      if (!summonable) {
+        console.warn("PluginRegistry: menuItem requires a summonable kind at " + sourcePath)
+        return null
+      }
+    }
     if (manifest.barWidget !== undefined && Util.isPlainObject(manifest.barWidget)
         && manifest.barWidget.defaultSection !== undefined) {
       var defaultSection = String(manifest.barWidget.defaultSection)

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -84,6 +84,9 @@ ShellRoot {
     scan += block("firstparty", "/first/panels/grouped", manifest("omarchy.grouped-panel", ["panel"], { panel: "Panel.qml" }))
     scan += block("firstparty", "/first/hybrid", manifest("omarchy.hybrid", ["menu", "bar-widget"], { menu: "Menu.qml", barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/panel", manifest("third.panel", ["panel"], { panel: "Panel.qml" }))
+    var menuPanel = manifest("third.menu-panel", ["panel"], { panel: "Panel.qml" })
+    menuPanel.menuItem = { label: "Menu panel", icon: "P", description: "Open the panel" }
+    scan += block("thirdparty", "/third/menu-panel", menuPanel)
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
     scan += block("thirdparty", "/third/center-widget", manifest("third.center-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/right-widget", manifest("third.right-widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "right" }))
@@ -108,6 +111,12 @@ ShellRoot {
     scan += block("thirdparty", "/third/unsafe", manifest("third.unsafe", ["panel"], { panel: "../Panel.qml" }))
     scan += block("thirdparty", "/third/missing", { schemaVersion: 1, id: "third.missing", name: "missing", version: "1.0.0", kinds: ["panel"] })
     scan += block("thirdparty", "/third/bad-section", manifest("third.bad-section", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "bottom" }))
+    var badMenuItem = manifest("third.bad-menu-item", ["panel"], { panel: "Panel.qml" })
+    badMenuItem.menuItem = { icon: 42 }
+    scan += block("thirdparty", "/third/bad-menu-item", badMenuItem)
+    var serviceMenuItem = manifest("third.service-menu-item", ["service"], { service: "Service.qml" })
+    serviceMenuItem.menuItem = {}
+    scan += block("thirdparty", "/third/service-menu-item", serviceMenuItem)
     scan += block("thirdparty", "/third/schema", { schemaVersion: 2, id: "third.schema", name: "schema", version: "1.0.0", kinds: ["panel"], entryPoints: { panel: "Panel.qml" } })
     scan += block("thirdparty", "/third/bad-json", "{")
 
@@ -125,6 +134,7 @@ ShellRoot {
       "omarchy.hybrid",
       "third.bar",
       "third.center-widget",
+      "third.menu-panel",
       "third.panel",
       "third.right-widget",
       "third.widget"
@@ -135,11 +145,14 @@ ShellRoot {
     root.assertEqual(registry.installedPlugins["omarchy.grouped-panel"].__sourceDir, "/first/panels/grouped", "grouped plugin source paths are preserved")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel"), "file:///third/panel/Panel.qml", "entryPointUrl resolves plugin-relative paths")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.widget"], "barWidget"), "file:///third/widget/Widget.qml", "entryPointUrl resolves bar widget paths")
+    root.assertEqual(registry.installedPlugins["third.menu-panel"].menuItem.label, "Menu panel", "registry preserves valid menu launcher metadata")
 
     root.assertTrue(!has("omarchy.reserved"), "third-party omarchy namespace ids are rejected")
     root.assertTrue(!has("third.unsafe"), "unsafe entry points are rejected")
     root.assertTrue(!has("third.missing"), "incomplete manifests are rejected")
     root.assertTrue(!has("third.bad-section"), "invalid default bar widget sections are rejected")
+    root.assertTrue(!has("third.bad-menu-item"), "invalid menu launcher presentation is rejected")
+    root.assertTrue(!has("third.service-menu-item"), "service-only menu launchers are rejected")
     root.assertTrue(!has("third.schema"), "unsupported schema versions are rejected")
 
     root.assertTrue(registry.isEnabled("omarchy.first-widget"), "first-party plugins are implicitly enabled")

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -120,6 +120,18 @@ assertEqual(mergedWithPlugins.items['plugin.acme.polish'].label, 'My Polish', 'm
 assertEqual(mergedWithPlugins.items['plugin.acme.polish'].action, 'custom-polish', 'menu user actions override generated plugin actions')
 assertEqual(mergedWithPlugins.items['plugin.acme.polish'].parent, 'root', 'menu user overrides can keep dotted plugin ids on the root menu')
 assertEqual(mergedWithPlugins.items['plugin.acme.polish'].order, parsed.length, 'menu plugin launchers append after shipped entries')
+const mergedAfterPluginDisabled = menu.mergeMenuSources(parsed, [], [
+  userPluginOverride,
+  menu.normalizeItem('tools', { label: 'Tools' })
+])
+assert(
+  !mergedAfterPluginDisabled.items['plugin.acme.polish'],
+  'menu hides a plugin launcher override after its plugin is disabled'
+)
+assert(
+  mergedAfterPluginDisabled.items.tools,
+  'menu keeps ordinary user entries when plugin launcher overrides are hidden'
+)
 assert(
   /function enabledPluginMenuItems\(\)[\s\S]*registry\.isEnabled\(pluginId\)/.test(menuQml)
     && /function onPluginsChanged\(\) \{ root\.rebuildItemsFromSources\(\) \}/.test(menuQml),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -58,6 +58,74 @@ assertEqual(merged.items['style.theme'].label, 'Theme picker', 'menu user entrie
 assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order on override')
 assert(merged.items.root, 'menu injects root when merging sources')
 
+const pluginItems = menu.pluginMenuItems({
+  'acme.hidden': {
+    id: 'acme.hidden',
+    name: 'Hidden tool',
+    kinds: ['overlay'],
+    menuItem: { label: 'Hidden tool' }
+  },
+  'acme.plain': {
+    id: 'acme.plain',
+    name: 'Plain service',
+    kinds: ['service']
+  },
+  'acme.polish': {
+    id: 'acme.polish',
+    name: 'Polish',
+    description: 'Manifest description',
+    kinds: ['overlay'],
+    menuItem: { label: 'Text Polish', icon: 'P', iconFont: 'icons', description: 'Refine text' }
+  },
+  'acme.timer': {
+    id: 'acme.timer',
+    name: 'Timer',
+    description: 'Manifest fallback',
+    kinds: ['panel'],
+    menuItem: {}
+  }
+}, id => id !== 'acme.hidden')
+assertDeepEqual(
+  pluginItems.map(item => item.id),
+  ['plugin.acme.polish', 'plugin.acme.timer'],
+  'menu adds enabled manifest launchers in stable plugin-id order'
+)
+assertDeepEqual(
+  pluginItems[0],
+  {
+    id: 'plugin.acme.polish',
+    parent: 'root',
+    kind: 'action',
+    icon: 'P',
+    iconFont: 'icons',
+    label: 'Text Polish',
+    title: '',
+    target: '',
+    description: 'Refine text',
+    action: "omarchy-shell shell toggle 'acme.polish'",
+    provider: '',
+    aliases: [],
+    when: '',
+    checked: '',
+    disabled: ''
+  },
+  'menu turns presentation-only manifest metadata into a root plugin action'
+)
+assertEqual(pluginItems[1].label, 'Timer', 'menu launcher labels fall back to the manifest name')
+assertEqual(pluginItems[1].description, 'Manifest fallback', 'menu launcher descriptions fall back to the manifest description')
+
+const userPluginOverride = menu.normalizeItem('plugin.acme.polish', { parent: 'root', label: 'My Polish', action: 'custom-polish' })
+const mergedWithPlugins = menu.mergeMenuSources(parsed, pluginItems, [userPluginOverride])
+assertEqual(mergedWithPlugins.items['plugin.acme.polish'].label, 'My Polish', 'menu user entries override plugin launchers')
+assertEqual(mergedWithPlugins.items['plugin.acme.polish'].action, 'custom-polish', 'menu user actions override generated plugin actions')
+assertEqual(mergedWithPlugins.items['plugin.acme.polish'].parent, 'root', 'menu user overrides can keep dotted plugin ids on the root menu')
+assertEqual(mergedWithPlugins.items['plugin.acme.polish'].order, parsed.length, 'menu plugin launchers append after shipped entries')
+assert(
+  /function enabledPluginMenuItems\(\)[\s\S]*registry\.isEnabled\(pluginId\)/.test(menuQml)
+    && /function onPluginsChanged\(\) \{ root\.rebuildItemsFromSources\(\) \}/.test(menuQml),
+  'menu rebuilds enabled plugin launchers when registry state changes'
+)
+
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -42,6 +42,12 @@ validate() {
   OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-plugin-validate" "$1" 2>&1
 }
 
+set_menu_item() {
+  local dir="$1" value="$2"
+  jq --argjson value "$value" '.menuItem = $value' "$dir/manifest.json" >"$dir/manifest.next.json"
+  mv "$dir/manifest.next.json" "$dir/manifest.json"
+}
+
 # Every kind the shell knows how to load names the entry point it loads from.
 # Declaring the kind without it installs a plugin that does nothing at all.
 while IFS=: read -r kind entry_point; do
@@ -90,6 +96,53 @@ output=$(validate "$dir") && fail "validate refuses an invalid default bar widge
 grep -qF "'barWidget.defaultSection' must be left, center, or right" <<<"$output" \
   || fail "validate explains the default bar widget section contract" "$output"
 pass "validate refuses an invalid default bar widget section"
+
+# A menuItem is a presentation-only launcher for plugin kinds the shell can
+# summon. Its fields are optional strings; the menu supplies the action.
+dir=$(write_plugin "menu-item" '["overlay"]' '{"overlay": "Overlay.qml"}')
+set_menu_item "$dir" '{}'
+validate "$dir" >/dev/null || fail "validate accepts a menu launcher using manifest fallbacks"
+pass "validate accepts a menu launcher using manifest fallbacks"
+
+dir=$(write_plugin "menu-presentation" '["panel"]' '{"panel": "Panel.qml"}')
+set_menu_item "$dir" '{"label":"Acme panel","icon":"P","iconFont":"icons","description":"Open Acme"}'
+validate "$dir" >/dev/null || fail "validate accepts menu launcher presentation strings"
+pass "validate accepts menu launcher presentation strings"
+
+dir=$(write_plugin "menu-not-object" '["overlay"]' '{"overlay": "Overlay.qml"}')
+set_menu_item "$dir" '"Acme"'
+output=$(validate "$dir") && fail "validate refuses a non-object menu launcher" "$output"
+grep -qF "'menuItem' must be an object" <<<"$output" \
+  || fail "validate explains that menuItem must be an object" "$output"
+pass "validate refuses a non-object menu launcher"
+
+dir=$(write_plugin "menu-bad-field" '["overlay"]' '{"overlay": "Overlay.qml"}')
+set_menu_item "$dir" '{"icon":42}'
+output=$(validate "$dir") && fail "validate refuses non-string menu launcher presentation" "$output"
+grep -qF "'menuItem' presentation fields must be strings" <<<"$output" \
+  || fail "validate explains menu launcher presentation types" "$output"
+pass "validate refuses non-string menu launcher presentation"
+
+dir=$(write_plugin "menu-null-field" '["overlay"]' '{"overlay": "Overlay.qml"}')
+set_menu_item "$dir" '{"description":null}'
+output=$(validate "$dir") && fail "validate refuses null menu launcher presentation" "$output"
+grep -qF "'menuItem' presentation fields must be strings" <<<"$output" \
+  || fail "validate treats explicit null like every other non-string field" "$output"
+pass "validate refuses null menu launcher presentation"
+
+dir=$(write_plugin "menu-empty-label" '["overlay"]' '{"overlay": "Overlay.qml"}')
+set_menu_item "$dir" '{"label":""}'
+output=$(validate "$dir") && fail "validate refuses an empty menu launcher label" "$output"
+grep -qF "'menuItem.label' must not be empty" <<<"$output" \
+  || fail "validate explains an empty menu launcher label" "$output"
+pass "validate refuses an empty menu launcher label"
+
+dir=$(write_plugin "menu-service" '["service"]' '{"service": "Service.qml"}')
+set_menu_item "$dir" '{}'
+output=$(validate "$dir") && fail "validate refuses a launcher for a service-only plugin" "$output"
+grep -qF "'menuItem' requires a summonable kind" <<<"$output" \
+  || fail "validate explains which plugins can expose a menu launcher" "$output"
+pass "validate refuses a launcher for a service-only plugin"
 
 # A kind the table does not cover is left alone rather than guessed at, so an
 # unknown kind is not turned into a demand for an entry point nobody reads.


### PR DESCRIPTION
## Summary

- let enabled `bar-widget`, `menu`, `overlay`, and `panel` plugins declare one root-level Omarchy menu launcher through `manifest.json`
- merge plugin launchers between shipped menu entries and user extensions, preserving user precedence
- validate the new presentation-only metadata in both the shell registry and `omarchy plugin validate`
- rebuild launchers on plugin rescans and enable/disable changes without mutating the user's menu extension file

## Manifest contract

```json
{
  "menuItem": {
    "label": "Text Polish",
    "icon": "󰚩",
    "description": "Correct and refine clipboard text"
  }
}
```

`label`, `icon`, `iconFont`, and `description` are optional strings. Label and description fall back to the plugin manifest. The menu generates `omarchy-shell shell toggle <plugin-id>` itself, so this field cannot inject an arbitrary command.

The launcher is visible only while its plugin is enabled. Its generated menu id is `plugin.<plugin-id>`, and the user extension remains the final merge source.

This is intentionally separate from the `menu` kind: `menu` means the plugin implements a summoned menu surface, while `menuItem` exposes a launcher inside the built-in Omarchy menu.

## Validation

- `./test/cli`
- `bash test/shell.d/menu-test.sh`
- `bash test/shell.d/plugin-validate-test.sh`
- `bash test/shell.d/plugins-test.sh`
- `./test/shell.d/plugin-registry-contract-test.sh`
- `qmllint shell/plugins/menu/Menu.qml shell/services/PluginRegistry.qml`
- manually verified that a manifest launcher rendered in the live menu and opened the declared overlay

The complete `./test/shell` run reached all 190 test files. Its five local failures reproduce unchanged on a detached `origin/quattro` baseline: three require an `omarchy-pkgs` checkout, while `launch-about-test.sh` and `network-qr-test.sh` also fail in the current environment.
