### PR TITLE
Stop the DMI chassis fallback in omarchy-hw-laptop reading an empty string

### DIFF
--- a/bin/omarchy-hw-laptop
+++ b/bin/omarchy-hw-laptop
@@ -10,7 +10,7 @@ done
 # Fall back to the DMI chassis type for laptops that don't expose an ACPI lid
 # button. 8=Portable 9=Laptop 10=Notebook 14=Sub Notebook 30=Tablet
 # 31=Convertible 32=Detachable.
-case $(< /sys/class/dmi/id/chassis_type 2>/dev/null) in
+case $(cat /sys/class/dmi/id/chassis_type 2>/dev/null) in
 8 | 9 | 10 | 14 | 30 | 31 | 32) exit 0 ;;
 esac
 


### PR DESCRIPTION
`omarchy-hw-laptop` falls back to the DMI chassis type when the machine exposes no ACPI lid button, but the fallback can never match. Bash only treats `$(< file)` as "read this file" when the substitution holds that one redirection and nothing else; adding `2>/dev/null` turns it into a null command with two redirections, whose stdout is empty.

```
$ v=$(< /sys/class/dmi/id/chassis_type 2>/dev/null); printf '[%s]\n' "$v"
[]
$ v=$(< /sys/class/dmi/id/chassis_type); printf '[%s]\n' "$v"
[9]
$ v=$(cat /sys/class/dmi/id/chassis_type 2>/dev/null); printf '[%s]\n' "$v"
[9]
```

So the `case` always compares the empty string, and every laptop that reaches the fallback exits 1. On x86 the ACPI loop above answers first, which is what has kept this invisible: only hardware with no `/proc/acpi` at all falls through. Apple Silicon under Asahi is such a machine — `hostnamectl chassis` says `laptop` and `/sys/class/dmi/id/chassis_type` holds `9`, yet `omarchy-hw-laptop` reports that this is not a laptop.

Everything gated on the command is silently off there. `Laptop Display`, `Mirror Display`, and `Battery Percentage` all carry `"when": "omarchy-hw-laptop"` in `default/omarchy/omarchy-menu.jsonc`, and `omarchy-hyprland-monitor-watch:78` skips its `omarchy-hw-laptop && omarchy-hyprland-monitor-external-active` branch.

`cat` keeps the error suppression the original form was reaching for. After this change no `$(<` in the tree carries an extra redirection.

Tested on a MacBook Air M2 (J413) running Asahi Arch: `bin/omarchy-hw-laptop` goes from exit 1 to exit 0, matching `hostnamectl chassis`.

`./test/all` — 188 of 190 test files pass. The two failures, `bar-icon-geometry-test.sh` and `snapper-test.sh`, fail identically on a clean checkout on this machine and are unrelated to this change: a bar icon is painted 0.59 px off center, and the Snapper suite wants a sibling `omarchy-iso` checkout that isn't present.
