### PR TITLE
Read the lid from logind so clamshell works without an ACPI lid button

### DIFF
--- a/bin/omarchy-hw-laptop-closed
+++ b/bin/omarchy-hw-laptop-closed
@@ -3,6 +3,18 @@
 # omarchy:summary=Returns true when the laptop lid is closed
 # omarchy:hidden=true
 
+# logind reads the lid through evdev's SW_LID, so it answers on hardware that
+# exposes no ACPI lid button at all. Apple Silicon has no /proc/acpi, where the
+# glob below matches nothing and reports the lid open forever.
+lid=$(busctl get-property org.freedesktop.login1 /org/freedesktop/login1 \
+  org.freedesktop.login1.Manager LidClosed 2>/dev/null)
+
+if [[ $lid == "b true" ]]; then
+  exit 0
+elif [[ $lid == "b false" ]]; then
+  exit 1
+fi
+
 for state in /proc/acpi/button/lid/*/state; do
   [[ -r $state ]] || continue
   [[ $(< "$state") == *"closed"* ]] && exit 0

--- a/test/shell.d/hw-laptop-closed-test.sh
+++ b/test/shell.d/hw-laptop-closed-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hw_laptop_closed="$ROOT/bin/omarchy-hw-laptop-closed"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# logind is the only lid source every laptop answers from, so each scenario pins
+# its reply and checks the exit code the callers branch on.
+stub_logind() {
+  mock_bin="$tmpdir/$1"
+  mkdir -p "$mock_bin"
+
+  cat >"$mock_bin/busctl" <<SH
+#!/bin/bash
+printf '%s\n' "$2"
+SH
+  chmod +x "$mock_bin/busctl"
+}
+
+lid_status() {
+  local status=0
+
+  PATH="$mock_bin:$PATH" "$hw_laptop_closed" || status=$?
+  printf '%s\n' "$status"
+}
+
+stub_logind closed "b true"
+status=$(lid_status)
+(( status == 0 )) || fail "a lid logind calls closed is closed" "exit: $status"
+pass "a lid logind calls closed is closed"
+
+stub_logind open "b false"
+status=$(lid_status)
+(( status == 1 )) || fail "a lid logind calls open is open" "exit: $status"
+pass "a lid logind calls open is open"
+
+# Nothing else in the tree can stand in for logind here, so a machine whose
+# logind cannot answer has to keep reaching the ACPI button this command has
+# always read.
+grep -F '/proc/acpi/button/lid/*/state' "$hw_laptop_closed" >/dev/null ||
+  fail "the ACPI lid button stays as the fallback"
+pass "the ACPI lid button stays as the fallback"


### PR DESCRIPTION
`omarchy-hw-laptop-closed` reads the lid from `/proc/acpi/button/lid/*/state`. Hardware without an ACPI lid button has no such file — Apple Silicon has no `/proc/acpi` at all — so the glob matches nothing and the command reports the lid open forever. logind tracks the lid through evdev's `SW_LID`, which answers on that hardware, so ask it first and keep the ACPI button as the fallback.

That stale answer is load-bearing in three places:

- `omarchy-hw-clamshell` is `omarchy-hw-laptop-closed && omarchy-hw-external-monitors`, so clamshell mode never engages: `omarchy-hyprland-monitor-clamshell` takes its `enable_internal` branch with the lid shut and leaves the internal panel driving while docked.
- `omarchy-system-lid-close` gates the lock on it, so a lid close never locks early and always waits for logind's `PrepareForSleep` instead — the head start its own comment describes cannot happen.
- The clamshell fingerprint gate misjudges: `pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed` in the polkit PAM config and `fingerprintMode: … && !laptopClosed` in `shell/plugins/polkit/PolkitAgent.qml` both keep offering the reader when the lid it sits under is closed.

`busctl get-property` is the same idiom `omarchy-powerprofiles-set` already uses for UPower's `OnBattery`, and four commands in `bin/` call `busctl`, so this adds no new dependency. Only the command changes here; #7871's work on the same lid gate touches the PAM config side, so the two diffs don't overlap.

Verified on a MacBook Air M2 (J413) running Asahi Arch, where `/proc/acpi` does not exist:

```
$ busctl get-property org.freedesktop.login1 /org/freedesktop/login1 \
    org.freedesktop.login1.Manager LidClosed
b false
$ hyprctl devices | sed -n '/Switches:/,$p'
Switches:
	Switch Device at aaab39e32040:
		Apple SMC power/lid events
```

`test/shell.d/hw-laptop-closed-test.sh` stubs logind's two answers, asserts the exit codes the callers branch on, and asserts the ACPI fallback stays. It fails against the current command — the closed lid exits 1 — and passes against this one.

`./test/all` — 189 of 191 test files pass. `bar-icon-geometry-test.sh` and `snapper-test.sh` fail identically on a clean checkout on this machine and are unrelated: a bar icon painted 0.59 px off center, and a missing sibling `omarchy-iso` checkout. `bar-widget-contract-test.sh` flaked once during a full run and passes both in isolation and on re-run.
