### PR TITLE
Let a received Taildrop file wait to be answered

### DIFF
--- a/bin/omarchy-tailscale-receive
+++ b/bin/omarchy-tailscale-receive
@@ -59,7 +59,12 @@ claim_path() {
 announce() {
   local path="$1"
   local name="${path##*/}"
-  local args=("Received $name" "Saved to ${dir/#$HOME/~}")
+  # A delivery arrives whenever the sender gets round to it, so the toast has
+  # to still be there when you come back to the machine. Critical urgency is
+  # what the shell reads as "stays until it is clicked or dismissed" -- it
+  # survives shell restarts too, and the file is no use if you never saw it
+  # land. omarchy-notification-send's default app name already bypasses DND.
+  local args=("Received $name" "Saved to ${dir/#$HOME/~}" -u critical)
 
   case "${name,,}" in
   *.png | *.jpg | *.jpeg | *.gif | *.webp | *.avif | *.bmp | *.tif | *.tiff)

--- a/bin/omarchy-tailscale-receive
+++ b/bin/omarchy-tailscale-receive
@@ -59,11 +59,6 @@ claim_path() {
 announce() {
   local path="$1"
   local name="${path##*/}"
-  # A delivery arrives whenever the sender gets round to it, so the toast has
-  # to still be there when you come back to the machine. Critical urgency is
-  # what the shell reads as "stays until it is clicked or dismissed" -- it
-  # survives shell restarts too, and the file is no use if you never saw it
-  # land. omarchy-notification-send's default app name already bypasses DND.
   local args=("Received $name" "Saved to ${dir/#$HOME/~}" -u critical)
 
   case "${name,,}" in

--- a/manual/35-networking.md
+++ b/manual/35-networking.md
@@ -36,7 +36,7 @@ SSH is off until you turn it on with _Setup > Security > SSHD_, which starts the
 
 [Tailscale](https://tailscale.com/) is a mesh VPN that makes reaching all your computers and servers over the internet simple and secure. Install it with _Install > Service > Tailscale_.
 
-That gives you a Tailscale panel in the bar, which connects and disconnects the tailnet, switches accounts, and picks an exit node — your own machines and Mullvad regions both show up in the list. It also browses your machines, and that's where Taildrop lives: select a machine and press `s` to send it files, or `c`, `n`, and `d` to copy its IP, name, or full DNS name. The terminal equivalent is `omarchy tailscale send <machine> [file...]`, and files sent to you land in `~/Downloads` automatically.
+That gives you a Tailscale panel in the bar, which connects and disconnects the tailnet, switches accounts, and picks an exit node — your own machines and Mullvad regions both show up in the list. It also browses your machines, and that's where Taildrop lives: select a machine and press `s` to send it files, or `c`, `n`, and `d` to copy its IP, name, or full DNS name. The terminal equivalent is `omarchy tailscale send <machine> [file...]`, and files sent to you land in `~/Downloads` automatically. The notification announcing an arrival waits until you click it open or dismiss it, so a file that turns up while you're away from the machine is still there to answer when you get back.
 
 Installing it also adds a web app for the Tailscale admin console.
 

--- a/test/shell.d/notification-send-test.sh
+++ b/test/shell.d/notification-send-test.sh
@@ -37,9 +37,6 @@ pass "notification wrapper supports app, glyph, urgency, image, and exec options
 # libnotify action round-trip.
 grep -q -- "-A" "$args_file" && fail "notification wrapper must not register a libnotify action"
 
-# Options are just as valid after the headline and description, which is how
-# omarchy-tailscale-receive builds its argument list. An urgency that stopped
-# being parsed there would leave the toast expiring before anyone saw it.
 : >"$args_file"
 OMARCHY_TEST_NOTIFY_ARGS="$args_file" PATH="$tmpdir:$ROOT/bin:$PATH" \
   omarchy-notification-send "Received photo.png" "Saved to ~/Downloads" -u critical -g K

--- a/test/shell.d/notification-send-test.sh
+++ b/test/shell.d/notification-send-test.sh
@@ -37,6 +37,23 @@ pass "notification wrapper supports app, glyph, urgency, image, and exec options
 # libnotify action round-trip.
 grep -q -- "-A" "$args_file" && fail "notification wrapper must not register a libnotify action"
 
+# Options are just as valid after the headline and description, which is how
+# omarchy-tailscale-receive builds its argument list. An urgency that stopped
+# being parsed there would leave the toast expiring before anyone saw it.
+: >"$args_file"
+OMARCHY_TEST_NOTIFY_ARGS="$args_file" PATH="$tmpdir:$ROOT/bin:$PATH" \
+  omarchy-notification-send "Received photo.png" "Saved to ~/Downloads" -u critical -g K
+
+mapfile -t args <"$args_file"
+
+[[ ${args[2]} == "-u" && ${args[3]} == "critical" ]] ||
+  fail "notification wrapper reads an urgency that follows the description" "$(printf '%s ' "${args[@]}")"
+(( $(grep -cFx -- "-u" "$args_file") == 1 )) ||
+  fail "notification wrapper sets the urgency once" "$(printf '%s ' "${args[@]}")"
+[[ ${args[4]} == "--hint=string:omarchy-glyph:K" ]] ||
+  fail "notification wrapper reads a glyph that follows the description" "$(printf '%s ' "${args[@]}")"
+pass "notification wrapper reads options that follow the headline and description"
+
 : >"$args_file"
 OMARCHY_TEST_NOTIFY_ARGS="$args_file" PATH="$tmpdir:$ROOT/bin:$PATH" \
   omarchy-notification-send "Plain" >/dev/null

--- a/test/shell.d/tailscale-receive-test.sh
+++ b/test/shell.d/tailscale-receive-test.sh
@@ -52,9 +52,17 @@ notifications=$(<"$WORKDIR/notifications")
   fail "taildrop receive saves incoming files" "$(ls "$downloads")"
 pass "taildrop receive saves incoming files"
 
-grep -qF -- "Received photo.png Saved to $downloads --image $downloads/photo.png" <<<"$notifications" ||
+grep -qF -- "Received photo.png Saved to $downloads -u critical --image $downloads/photo.png" <<<"$notifications" ||
   fail "taildrop receive previews received images" "$notifications"
 pass "taildrop receive previews received images"
+
+# A file can arrive hours after it was sent, so the toast has to wait for the
+# machine's owner rather than time out into history unseen. Critical urgency is
+# how the shell is told a popup lives until it is clicked or dismissed.
+while IFS= read -r line; do
+  [[ $line == *"-u critical"* ]] || fail "taildrop receive announcements wait to be answered" "$line"
+done <<<"$notifications"
+pass "taildrop receive announcements wait to be answered"
 
 grep -q "^Received notes with space.pdf .* -g " <<<"$notifications" ||
   fail "taildrop receive announces other files with a glyph" "$notifications"

--- a/test/shell.d/tailscale-receive-test.sh
+++ b/test/shell.d/tailscale-receive-test.sh
@@ -56,9 +56,6 @@ grep -qF -- "Received photo.png Saved to $downloads -u critical --image $downloa
   fail "taildrop receive previews received images" "$notifications"
 pass "taildrop receive previews received images"
 
-# A file can arrive hours after it was sent, so the toast has to wait for the
-# machine's owner rather than time out into history unseen. Critical urgency is
-# how the shell is told a popup lives until it is clicked or dismissed.
 while IFS= read -r line; do
   [[ $line == *"-u critical"* ]] || fail "taildrop receive announcements wait to be answered" "$line"
 done <<<"$notifications"


### PR DESCRIPTION
A file sent over Taildrop can land hours after it was sent, but the toast announcing it expired after five seconds — so the arrival nobody was at the machine for is exactly the one that vanished unseen, and the file then sat in `~/Downloads` with nothing to say it had come.

The announcement now goes out at critical urgency, which is what the shell reads as a popup that lives until it is clicked or dismissed: `durationFor` gives Critical a lifetime of 0, the card's countdown never runs, and `popupExpired` keeps a zero-lifetime popup across a shell restart instead of archiving it. Clicking still opens the file through the `omarchy-exec` hint that was already there, dismissing still moves it into history, and `Super + Shift + ,` still clears the screen in one gesture. `omarchy-crash-watch` keeps its click-to-diagnose toast around the same way.

Urgency costs nothing else here. It has no visual effect on the card — `accentColor` has been unused since the progress indicator came out — and do-not-disturb was already being bypassed by `omarchy-notification-send`'s default `omarchy-action` app name, whatever the urgency.

The wrapper accepts options after the headline and description as well as before, which is how the receiver builds its argument list, and that path had no test. It is worth one because it fails quietly: the wrapper appends its own default urgency last, so an urgency it stopped parsing would reach `notify-send` as `-u critical ... -u low` and the toast would go back to expiring with nothing to show for it.

One consequence to weigh, since it is the shape of the feature rather than a defect in it: a multi-file drop announces one toast per file and now none of them leave on their own, so twelve photos are twelve cards stacked down the right edge until they are answered — `Super + Shift + ,` takes them all at once, and a batch that announced itself as one card would take a design decision rather than a fix. Opening notification history replays an already-answered receipt as a card that again waits to be dismissed, because stickiness is carried by urgency and history keeps urgency; a dedicated "wants an answer" hint would separate the two, at the cost of a new concept in the notification path.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
