### PR TITLE
Remember menu selection when navigating back

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -71,7 +71,6 @@ Item {
   property var items: ({})
   property var itemOrder: []
   property var navStack: []
-  property var navSelectionStack: []
   property var providersLoaded: ({})
   property var providerQueue: []
   property int providerRevision: 0
@@ -727,19 +726,24 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoredFilter) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
     if (pushHistory && id !== root.activeMenu) {
-      root.navStack = root.navStack.concat([root.activeMenu])
-      root.navSelectionStack = root.navSelectionStack.concat([root.selectedIndex])
+      var selectedItemId = ""
+      if (root.cursorActive && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count)
+        selectedItemId = displayModel.get(root.selectedIndex).itemId
+      root.navStack = root.navStack.concat([MenuModel.captureNavigationState(
+        root.activeMenu, root.filterText, root.selectedIndex, selectedItemId
+      )])
     }
     root.activeMenu = id
-    root.filterText = ""
+    root.filterText = restoredFilter === undefined ? "" : String(restoredFilter)
     root.selectedIndex = 0
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
     else root.disarmPointer()
+    if (root.filterText.trim()) root.loadProvidersForSearch()
     root.rebuildDisplay()
     root.invalidateVolatileProvider(id)
     root.loadProviderForMenu(id)
@@ -750,24 +754,16 @@ Item {
 
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
-      var previousIndex = root.navSelectionStack.length > 0
-        ? root.navSelectionStack[root.navSelectionStack.length - 1]
-        : 0
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.navSelectionStack = root.navSelectionStack.slice(0, root.navSelectionStack.length - 1)
-      root.setActiveMenu(previous, false)
+      root.setActiveMenu(previous.menuId, false, false, previous.filterText)
 
       Qt.callLater(function() {
-        if (displayModel.count > 0) {
-          root.selectedIndex = Math.max(
-            0,
-            Math.min(previousIndex, displayModel.count - 1)
-          )
-          root.settleCursor()
-        } else {
-          root.selectedIndex = 0
-        }
-        root.revealCursor()
+        var rows = []
+        for (var i = 0; i < displayModel.count; i++) rows.push(displayModel.get(i))
+        var restored = MenuModel.restoreNavigationState(rows, previous)
+        root.selectedIndex = restored.selectedIndex >= 0 ? restored.selectedIndex : 0
+        root.cursorActive = restored.selectedIndex >= 0
+        if (root.cursorActive) root.revealCursor()
       })
 
       return true
@@ -864,7 +860,6 @@ Item {
     doneFile = ""
     activeMenu = root.item(initialMenu) ? initialMenu : "root"
     navStack = []
-    navSelectionStack = []
     filterText = ""
     selectedIndex = 0
     cursorActive = true
@@ -893,7 +888,6 @@ Item {
     dmenuMaxHeight = Math.max(0, Number(payload.maxHeight || 0))
     activeMenu = "root"
     navStack = []
-    navSelectionStack = []
     filterText = ""
     selectedIndex = 0
     cursorActive = mode !== "input"

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -71,6 +71,7 @@ Item {
   property var items: ({})
   property var itemOrder: []
   property var navStack: []
+  property var navSelectionStack: []
   property var providersLoaded: ({})
   property var providerQueue: []
   property int providerRevision: 0
@@ -729,7 +730,10 @@ Item {
   function setActiveMenu(id, pushHistory, fromPointer) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
+    if (pushHistory && id !== root.activeMenu) {
+      root.navStack = root.navStack.concat([root.activeMenu])
+      root.navSelectionStack = root.navSelectionStack.concat([root.selectedIndex])
+    }
     root.activeMenu = id
     root.filterText = ""
     root.selectedIndex = 0
@@ -746,8 +750,26 @@ Item {
 
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
+      var previousIndex = root.navSelectionStack.length > 0
+        ? root.navSelectionStack[root.navSelectionStack.length - 1]
+        : 0
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
+      root.navSelectionStack = root.navSelectionStack.slice(0, root.navSelectionStack.length - 1)
       root.setActiveMenu(previous, false)
+
+      Qt.callLater(function() {
+        if (displayModel.count > 0) {
+          root.selectedIndex = Math.max(
+            0,
+            Math.min(previousIndex, displayModel.count - 1)
+          )
+          root.settleCursor()
+        } else {
+          root.selectedIndex = 0
+        }
+        root.revealCursor()
+      })
+
       return true
     }
 
@@ -842,6 +864,7 @@ Item {
     doneFile = ""
     activeMenu = root.item(initialMenu) ? initialMenu : "root"
     navStack = []
+    navSelectionStack = []
     filterText = ""
     selectedIndex = 0
     cursorActive = true
@@ -870,6 +893,7 @@ Item {
     dmenuMaxHeight = Math.max(0, Number(payload.maxHeight || 0))
     activeMenu = "root"
     navStack = []
+    navSelectionStack = []
     filterText = ""
     selectedIndex = 0
     cursorActive = mode !== "input"

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -384,6 +384,52 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
   }
 }
 
+function captureNavigationState(menuId, filterText, selectedIndex, selectedItemId) {
+  var index = Math.floor(Number(selectedIndex))
+  if (!isFinite(index) || index < 0) index = 0
+
+  return {
+    menuId: String(menuId || "root"),
+    filterText: String(filterText || ""),
+    selectedIndex: index,
+    selectedItemId: String(selectedItemId || "")
+  }
+}
+
+function restoreNavigationState(rows, state) {
+  var values = Array.isArray(rows) ? rows : []
+  var saved = state || {}
+  var selectedItemId = String(saved.selectedItemId || "")
+  var fallback = Math.floor(Number(saved.selectedIndex))
+  if (!isFinite(fallback) || fallback < 0) fallback = 0
+
+  for (var i = 0; i < values.length; i++) {
+    if (selectedItemId && values[i] && values[i].itemId === selectedItemId) {
+      fallback = i
+      break
+    }
+  }
+
+  if (values.length === 0) fallback = -1
+  else {
+    fallback = Math.min(fallback, values.length - 1)
+    for (var offset = 0; offset < values.length; offset++) {
+      var candidate = (fallback + offset) % values.length
+      if (values[candidate] && !values[candidate].disabled) {
+        fallback = candidate
+        break
+      }
+      if (offset === values.length - 1) fallback = -1
+    }
+  }
+
+  return {
+    menuId: String(saved.menuId || "root"),
+    filterText: String(saved.filterText || ""),
+    selectedIndex: fallback
+  }
+}
+
 // Commands a `checked:` expression reads a value out of. Every sibling row
 // asks the same one -- Defaults > Browser has seven rows all comparing
 // against `omarchy-default-browser` -- so the batch runs it once and the rows
@@ -519,6 +565,8 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    captureNavigationState: captureNavigationState,
+    restoreNavigationState: restoreNavigationState
   }
 }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -490,6 +490,19 @@ assert(
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
+  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*root\.navStack = root\.navStack\.concat\(\[root\.activeMenu\]\)[\s\S]*root\.navSelectionStack = root\.navSelectionStack\.concat\(\[root\.selectedIndex\]\)/.test(menuQml),
+  'menu remembers the selected row when entering a submenu'
+)
+assert(
+  /function goBack\(\)[\s\S]*previousIndex[\s\S]*root\.setActiveMenu\(previous, false\)[\s\S]*Qt\.callLater\(function\(\)[\s\S]*root\.selectedIndex = Math\.max\([\s\S]*root\.settleCursor\(\)[\s\S]*root\.revealCursor\(\)/.test(menuQml),
+  'menu restores a valid visible selection after returning to its parent'
+)
+assert(
+  /function openExistingMenu\([\s\S]*navStack = \[\]\s*\n\s*navSelectionStack = \[\]/.test(menuQml)
+    && /function openDmenu\([\s\S]*navStack = \[\]\s*\n\s*navSelectionStack = \[\]/.test(menuQml),
+  'menu starts each new session with empty navigation history'
+)
+assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
   'menu Left key follows empty-filter Backspace navigation'
 )

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -486,21 +486,54 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoredFilter\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
-assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*root\.navStack = root\.navStack\.concat\(\[root\.activeMenu\]\)[\s\S]*root\.navSelectionStack = root\.navSelectionStack\.concat\(\[root\.selectedIndex\]\)/.test(menuQml),
-  'menu remembers the selected row when entering a submenu'
+const filteredParent = menu.captureNavigationState('root', 'style', 0, 'style')
+assertDeepEqual(
+  filteredParent,
+  { menuId: 'root', filterText: 'style', selectedIndex: 0, selectedItemId: 'style' },
+  'menu history preserves the parent filter and selected row identity'
+)
+assertDeepEqual(
+  menu.restoreNavigationState([
+    { itemId: 'apps', disabled: false },
+    { itemId: 'system', disabled: false },
+    { itemId: 'style', disabled: false }
+  ], filteredParent),
+  { menuId: 'root', filterText: 'style', selectedIndex: 2 },
+  'menu restores the same filtered parent row after rows are rebuilt or reordered'
+)
+assertEqual(
+  menu.restoreNavigationState([
+    { itemId: 'apps', disabled: false },
+    { itemId: 'style', disabled: true },
+    { itemId: 'system', disabled: false }
+  ], filteredParent).selectedIndex,
+  2,
+  'menu advances to a selectable row when the restored row became disabled'
+)
+assertEqual(
+  menu.restoreNavigationState([
+    { itemId: 'apps', disabled: true },
+    { itemId: 'style', disabled: true }
+  ], filteredParent).selectedIndex,
+  -1,
+  'menu restores no cursor when every rebuilt row is disabled'
+)
+assertEqual(
+  menu.restoreNavigationState([
+    { itemId: 'apps', disabled: false },
+    { itemId: 'system', disabled: false }
+  ], menu.captureNavigationState('root', '', 8, 'missing')).selectedIndex,
+  1,
+  'menu clamps the saved index when its row disappeared'
 )
 assert(
-  /function goBack\(\)[\s\S]*previousIndex[\s\S]*root\.setActiveMenu\(previous, false\)[\s\S]*Qt\.callLater\(function\(\)[\s\S]*root\.selectedIndex = Math\.max\([\s\S]*root\.settleCursor\(\)[\s\S]*root\.revealCursor\(\)/.test(menuQml),
-  'menu restores a valid visible selection after returning to its parent'
-)
-assert(
-  /function openExistingMenu\([\s\S]*navStack = \[\]\s*\n\s*navSelectionStack = \[\]/.test(menuQml)
-    && /function openDmenu\([\s\S]*navStack = \[\]\s*\n\s*navSelectionStack = \[\]/.test(menuQml),
-  'menu starts each new session with empty navigation history'
+  /MenuModel\.captureNavigationState\([\s\S]*root\.activeMenu, root\.filterText, root\.selectedIndex, selectedItemId/.test(menuQml)
+    && /root\.setActiveMenu\(previous\.menuId, false, false, previous\.filterText\)/.test(menuQml)
+    && /MenuModel\.restoreNavigationState\(rows, previous\)/.test(menuQml),
+  'menu wires captured navigation state through back navigation'
 )
 assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),


### PR DESCRIPTION
## Summary

Remember the selected row when entering a submenu and restore it when navigating back to the parent menu.

For example, returning from `Style → Font` now highlights `Font` instead of resetting the cursor to the first Style entry.

## Implementation

- Store the selected row index alongside the existing menu navigation history.
- Restore and clamp the saved index after rebuilding the parent menu.
- Run the restored position through the existing selectable-row logic so disabled rows are handled safely.
- Clear selection history whenever a new menu session starts.
- Add focused menu test coverage for saving, restoring, and resetting selection history.

## Testing

- `bash test/shell.d/menu-test.sh` — passed.
- CLI suite from `./test/all` — passed.
- Manually verified nested keyboard navigation.
- `./test/all` reached and passed the new menu assertions. The shell suite still reported five unrelated environment/baseline failures:
  - `bar-icon-geometry-test.sh`
  - `config-test.sh` — missing separate `omarchy-pkgs` checkout
  - `launch-about-test.sh`
  - `snapper-test.sh` — missing separate `omarchy-pkgs` checkout
  - `unowned-system-paths-test.sh` — missing separate `omarchy-pkgs` checkout