### PR TITLE
Treat Ctrl+G as cancel throughout the shell

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -112,6 +112,11 @@ QtObject {
     return text.slice(0, -1)                                     // Backspace: char
   }
 
+  function isCancelKey(event) {
+    return event.key === Qt.Key_Escape
+      || (event.key === Qt.Key_G && event.modifiers === Qt.ControlModifier)
+  }
+
   // Layout normalization shared by bar config consumers
   // so the two never drift. Entries are deep-cloned to decouple from the
   // input config; consumers can mutate without leaking back to shell.json.

--- a/shell/Ui/ConfirmDialog.qml
+++ b/shell/Ui/ConfirmDialog.qml
@@ -23,7 +23,7 @@ Item {
   function handleKey(event) {
     if (!root.opened) return false
 
-    if (event.key === Qt.Key_Escape) {
+    if (Util.isCancelKey(event)) {
       root.canceled()
       return true
     } else if (event.key === Qt.Key_Left || event.key === Qt.Key_Right || event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {

--- a/shell/Ui/Dropdown.qml
+++ b/shell/Ui/Dropdown.qml
@@ -104,7 +104,7 @@ Item {
             || event.key === Qt.Key_Space || event.key === Qt.Key_Down) {
           popup.opened ? popup.close() : popup.open()
           event.accepted = true
-        } else if (event.key === Qt.Key_Escape && popup.opened) {
+        } else if (Util.isCancelKey(event) && popup.opened) {
           popup.close(); event.accepted = true
         }
       }
@@ -173,7 +173,7 @@ Item {
 
           Keys.priority: Keys.BeforeItem
           Keys.onPressed: function(event) {
-            if (event.key === Qt.Key_Escape) { popup.close(); event.accepted = true }
+            if (Util.isCancelKey(event)) { popup.close(); event.accepted = true }
             else if (event.key === Qt.Key_Down || event.text === "j") {
               optionList.currentIndex = Math.min(root.options.length - 1, optionList.currentIndex + 1)
               event.accepted = true

--- a/shell/Ui/MultiSelect.qml
+++ b/shell/Ui/MultiSelect.qml
@@ -292,7 +292,7 @@ Item {
             || event.key === Qt.Key_Space || event.key === Qt.Key_Down) {
           popup.opened ? popup.close() : popup.open()
           event.accepted = true
-        } else if (event.key === Qt.Key_Escape && popup.opened) {
+        } else if (Util.isCancelKey(event) && popup.opened) {
           popup.close(); event.accepted = true
         }
       }
@@ -418,7 +418,7 @@ Item {
                 }
 
                 Keys.onPressed: function(event) {
-                  if (event.key === Qt.Key_Escape) {
+                  if (Util.isCancelKey(event)) {
                     popup.close(); event.accepted = true
                   } else if (event.key === Qt.Key_Down) {
                     if (resultList.count > 0) {
@@ -511,7 +511,7 @@ Item {
 
               Keys.priority: Keys.BeforeItem
               Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Escape) {
+                if (Util.isCancelKey(event)) {
                   popup.close(); event.accepted = true
                 } else if (event.key === Qt.Key_Down || event.text === "j") {
                   if (resultList.currentIndex >= resultList.count - 1) {

--- a/shell/Ui/PanelKeyCatcher.qml
+++ b/shell/Ui/PanelKeyCatcher.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import qs.Commons
 
 // Drop-in key dispatcher for keyboard-driven panels. Wraps panel content
 // and emits semantic signals so each panel keeps its own state machine
@@ -48,7 +49,7 @@ Item {
   Keys.onPressed: function(event) {
     if (blocked) return
 
-    if (event.key === Qt.Key_Escape) {
+    if (Util.isCancelKey(event)) {
       closeRequested(); event.accepted = true; return
     }
     if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {

--- a/shell/Ui/SearchableDropdown.qml
+++ b/shell/Ui/SearchableDropdown.qml
@@ -126,7 +126,7 @@ Item {
             || event.key === Qt.Key_Space || event.key === Qt.Key_Down) {
           popup.opened ? popup.close() : popup.open()
           event.accepted = true
-        } else if (event.key === Qt.Key_Escape && popup.opened) {
+        } else if (Util.isCancelKey(event) && popup.opened) {
           popup.close(); event.accepted = true
         }
       }
@@ -216,7 +216,7 @@ Item {
               }
 
               Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Escape) {
+                if (Util.isCancelKey(event)) {
                   popup.close(); event.accepted = true
                 } else if (event.key === Qt.Key_Down) {
                   if (resultList.count > 0) {
@@ -274,7 +274,7 @@ Item {
 
               Keys.priority: Keys.BeforeItem
               Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Escape) {
+                if (Util.isCancelKey(event)) {
                   popup.close(); event.accepted = true
                 } else if (event.key === Qt.Key_Down || event.text === "j") {
                   if (resultList.currentIndex >= resultList.count - 1) {

--- a/shell/Ui/SpeedTestOverlay.qml
+++ b/shell/Ui/SpeedTestOverlay.qml
@@ -106,7 +106,12 @@ PanelWindow {
     anchors.fill: parent
     focus: true
 
-    Keys.onEscapePressed: root.closeRequested()
+    Keys.onPressed: function(event) {
+      if (Util.isCancelKey(event)) {
+        root.closeRequested()
+        event.accepted = true
+      }
+    }
     Keys.onReturnPressed: if (!root.running) root.runAgainRequested()
     Keys.onEnterPressed: if (!root.running) root.runAgainRequested()
 

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -356,7 +356,7 @@ Item {
             return
           }
 
-          if (event.key === Qt.Key_Escape) {
+          if (Util.isCancelKey(event)) {
             if (root.filterText) root.setFilter("")
             else root.close()
             event.accepted = true

--- a/shell/plugins/dev-gallery/GalleryPanel.qml
+++ b/shell/plugins/dev-gallery/GalleryPanel.qml
@@ -1336,7 +1336,7 @@ Item {
                   }
                   onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(this)
                   Keys.onPressed: function(event) {
-                    if (event.key === Qt.Key_Escape) {
+                    if (Util.isCancelKey(event)) {
                       focus = false
                       event.accepted = true
                     }
@@ -1358,7 +1358,7 @@ Item {
                   }
                   onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(this)
                   Keys.onPressed: function(event) {
-                    if (event.key === Qt.Key_Escape) {
+                    if (Util.isCancelKey(event)) {
                       focus = false
                       event.accepted = true
                     }

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -196,7 +196,7 @@ Item {
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
-          if (event.key === Qt.Key_Escape) {
+          if (Util.isCancelKey(event)) {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -407,7 +407,7 @@ Item {
 
           Keys.priority: Keys.BeforeItem
           Keys.onPressed: function(event) {
-            if (event.key === Qt.Key_Escape) {
+            if (Util.isCancelKey(event)) {
               if (root.filterText) {
                 root.updateFilter("")
               } else {

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -176,7 +176,7 @@ Item {
 
         Keys.onPressed: function(event) {
           root.wakeRequested()
-          if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
+          if (Util.isCancelKey(event) || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
             event.accepted = true
           }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1129,7 +1129,7 @@ Item {
           if (event.key === Qt.Key_Delete) {
             root.requestDeleteSelected()
             event.accepted = true
-          } else if (event.key === Qt.Key_Escape) {
+          } else if (Util.isCancelKey(event)) {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -184,7 +184,7 @@ Panel {
   // Shared by both fields: Tab hops to the other one, Enter commits the pair,
   // Escape drops the lot.
   function handleLifeKey(event, other) {
-    if (event.key === Qt.Key_Escape) {
+    if (Util.isCancelKey(event)) {
       root.cancelEditingLife()
       event.accepted = true
     } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1849,7 +1849,12 @@ Panel {
 
         onAccepted: pwField.forceActiveFocus()
         onTextChanged: if (row.isPasswordOpen && text !== root.identityText) root.identityText = text
-        Keys.onEscapePressed: root.cancelPasswordPrompt()
+        Keys.onPressed: function(event) {
+          if (Util.isCancelKey(event)) {
+            root.cancelPasswordPrompt()
+            event.accepted = true
+          }
+        }
 
         onVisibleChanged: if (visible) Qt.callLater(forceActiveFocus)
         Component.onCompleted: if (visible) Qt.callLater(forceActiveFocus)
@@ -1875,7 +1880,12 @@ Panel {
 
         onAccepted: row.submitCredentials()
         onTextChanged: if (row.isPasswordOpen && text !== root.passwordText) root.passwordText = text
-        Keys.onEscapePressed: root.cancelPasswordPrompt()
+        Keys.onPressed: function(event) {
+          if (Util.isCancelKey(event)) {
+            root.cancelPasswordPrompt()
+            event.accepted = true
+          }
+        }
 
         onVisibleChanged: if (visible && !row.isEnterprise) Qt.callLater(forceActiveFocus)
         Component.onCompleted: if (visible && !row.isEnterprise) Qt.callLater(forceActiveFocus)
@@ -1904,7 +1914,7 @@ Panel {
       }
 
       // 22×22 right-anchored to line up with lockIndicator above. Esc closes
-      // the prompt (handled by pwField.Keys.onEscapePressed)
+      // the prompt (handled by pwField.Keys.onPressed)
       // so there's no separate cancel button.
       PanelActionButton {
         id: connectPwBtn

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -626,7 +626,7 @@ Panel {
                       event.accepted = true
                       return
                     }
-                    if (event.key === Qt.Key_Escape) {
+                    if (Util.isCancelKey(event)) {
                       root.mullvadPickerOpen = false
                       keyCatcher.forceActiveFocus()
                       event.accepted = true
@@ -1000,7 +1000,7 @@ Panel {
         focus: true
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
         function handleKey(event) {
-          if (event.key === Qt.Key_Escape) {
+          if (Util.isCancelKey(event)) {
             close()
             event.accepted = true
             return

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -617,7 +617,7 @@ Panel {
               onTextChanged: if (root.editingLocation && !root.savingLocation) geocodeDebounce.restart()
 
               Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Escape) {
+                if (Util.isCancelKey(event)) {
                   root.cancelEditingLocation()
                   event.accepted = true
                 } else if (event.key === Qt.Key_Down) {

--- a/shell/plugins/panels/wifiqr/Panel.qml
+++ b/shell/plugins/panels/wifiqr/Panel.qml
@@ -236,7 +236,12 @@ Item {
       anchors.fill: parent
       focus: true
 
-      Keys.onEscapePressed: root.dismiss()
+      Keys.onPressed: function(event) {
+        if (Util.isCancelKey(event)) {
+          root.dismiss()
+          event.accepted = true
+        }
+      }
 
       Item {
         anchors.centerIn: parent

--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -258,7 +258,7 @@ Item {
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
-          if (event.key === Qt.Key_Escape) {
+          if (Util.isCancelKey(event)) {
             root.cancelRequest()
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
@@ -324,7 +324,7 @@ Item {
             enabled: root.dialogVisible
             onAccepted: root.submitResponse()
             Keys.onPressed: function(event) {
-              if (event.key === Qt.Key_Escape) {
+              if (Util.isCancelKey(event)) {
                 root.cancelRequest()
                 event.accepted = true
               }

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -131,7 +131,7 @@ Item {
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
-          if (event.key === Qt.Key_Escape) {
+          if (Util.isCancelKey(event)) {
             if (root.filterText) root.setFilter("")
             else root.dismiss()
             event.accepted = true

--- a/test/shell.d/cancel-key-test.sh
+++ b/test/shell.d/cancel-key-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+python3 - "$ROOT" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1]) / "shell"
+util = (root / "Commons/Util.qml").read_text()
+predicate = re.compile(
+    r"function isCancelKey\(event\)\s*\{\s*"
+    r"return event\.key === Qt\.Key_Escape\s*"
+    r"\|\| \(event\.key === Qt\.Key_G\s*"
+    r"&& event\.modifiers === Qt\.ControlModifier\)\s*\}",
+    re.DOTALL,
+)
+if not predicate.search(util):
+    print("shared cancel predicate no longer matches Escape and exact Ctrl+G", file=sys.stderr)
+    raise SystemExit(1)
+print("ok - shared cancel predicate matches Escape and exact Ctrl+G")
+
+cancel_paths = [
+    "Ui/ConfirmDialog.qml",
+    "Ui/Dropdown.qml",
+    "Ui/MultiSelect.qml",
+    "Ui/PanelKeyCatcher.qml",
+    "Ui/SearchableDropdown.qml",
+    "Ui/SpeedTestOverlay.qml",
+    "plugins/clipboard/Clipboard.qml",
+    "plugins/dev-gallery/GalleryPanel.qml",
+    "plugins/emojis/Emojis.qml",
+    "plugins/image-picker/ImagePicker.qml",
+    "plugins/lock/LockView.qml",
+    "plugins/menu/Menu.qml",
+    "plugins/panels/clock/Panel.qml",
+    "plugins/panels/network/Panel.qml",
+    "plugins/panels/tailscale/Panel.qml",
+    "plugins/panels/weather/Panel.qml",
+    "plugins/panels/wifiqr/Panel.qml",
+    "plugins/polkit/PolkitAgent.qml",
+    "plugins/reminders/ReminderFlow.qml",
+]
+
+for relative in cancel_paths:
+    text = (root / relative).read_text()
+    if "Util.isCancelKey(event)" not in text:
+        print(f"shared cancel predicate missing from {relative}", file=sys.stderr)
+        raise SystemExit(1)
+    if "import qs.Commons" not in text:
+        print(f"qs.Commons import missing from {relative}", file=sys.stderr)
+        raise SystemExit(1)
+    if "event.key === Qt.Key_Escape" in text or "onEscapePressed" in text:
+        print(f"raw Escape handling remains in {relative}", file=sys.stderr)
+        raise SystemExit(1)
+print("ok - existing QML cancel paths use the shared key predicate")
+PY


### PR DESCRIPTION
## Why

Escape already means “cancel the current thing” throughout Omarchy Shell. Keyboard-driven users also reach for Ctrl+G to abort a menu or prompt, but today that chord does nothing. This adds it as an alternative without replacing Escape or claiming plain G, Ctrl+Shift+G, or any other Ctrl chord.

## What changed

- add one shared cancel-key predicate for Escape and exact Ctrl+G
- route the existing menu, panel, dropdown, prompt, overlay, lock, and Polkit cancel paths through it
- keep a regression inventory of the current cancel surfaces and their `qs.Commons` imports

Lock and Polkit already cancel on Escape; Ctrl+G reaches that same existing path and introduces no new action.

## Testing

- `./test/shell.d/cancel-key-test.sh`
- live UI on Omarchy 4.0.0: Ctrl+G closed the root menu; with a filter active, the first Ctrl+G cleared it and the next closed the menu
- `./test/all`

The aggregate run retained five baseline/environment failures reproduced unchanged on the base commit: `bar-icon-geometry-test.sh`, `config-test.sh`, `runtime-smoke-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`.
