### PR TITLE
Gate low-battery warn and sleep on live remaining energy

### DIFF
--- a/bin/omarchy-battery-critical
+++ b/bin/omarchy-battery-critical
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# omarchy:summary=Take the critical low-battery action using live remaining energy.
+# omarchy:args=<percentage>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+if (($# != 1)); then
+  echo "Usage: omarchy-battery-critical <percentage>" >&2
+  exit 1
+fi
+
+level=$1
+
+omarchy-hook battery-critical "$level"
+
+if systemctl suspend-then-hibernate; then
+  exit 0
+fi
+
+systemctl suspend

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,101 +18,348 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+read_numeric() {
+  local file="$1"
+  local value
+  [[ -r $file ]] || return 1
+  # `$(<file 2>/dev/null)` is not the special $(<file) form and reads empty.
+  # cat also fails closed when the attribute exists but the kernel returns ENODEV.
+  value=$(cat -- "$file" 2>/dev/null) || return 1
+  value=${value//$'\n'/}
+  [[ $value =~ ^-?[0-9]+([.][0-9]+)?$ ]] || return 1
+  printf '%s' "$value"
+}
 
-battery_info=$(upower -i "$battery")
+format_rate() {
+  awk -v rate="${1:-0}" 'BEGIN {
+    if (rate < 0) rate = -rate
+    rounded = sprintf("%.1f", rate)
+    sub(/\.0$/, "", rounded)
+    print rounded
+  }'
+}
 
-percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
-capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
-time_remaining=$(awk '/time to (empty|full)/ {
-  value = $4
-  unit = $5
-  if (unit ~ /^minute/) {
-    printf "%dm", int(value)
-  } else {
-    hours = int(value)
-    minutes = int((value - hours) * 60)
-    if (minutes > 0) {
-      printf "%dh %dm", hours, minutes
-    } else {
-      printf "%dh", hours
+format_hours() {
+  awk -v hours="${1:-0}" 'BEGIN {
+    if (hours <= 0) exit
+    if (hours * 60 < 60) {
+      printf "%dm", int(hours * 60)
+      exit
     }
-  }
-  exit
-}' <<<"$battery_info")
-power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
+    whole = int(hours)
+    minutes = int((hours - whole) * 60)
+    if (minutes > 0) {
+      printf "%dh %dm", whole, minutes
+    } else {
+      printf "%dh", whole
+    }
+  }'
+}
 
-# UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
-# the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
-fi
+format_upower_time() {
+  awk '/time to (empty|full)/ {
+    value = $4
+    unit = $5
+    if (unit ~ /^minute/) {
+      printf "%dm", int(value)
+    } else {
+      hours = int(value)
+      minutes = int((value - hours) * 60)
+      if (minutes > 0) {
+        printf "%dh %dm", hours, minutes
+      } else {
+        printf "%dh", hours
+      }
+    }
+    exit
+  }' <<<"$1"
+}
 
-power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
-  rounded = sprintf("%.1f", rate)
-  sub(/\.0$/, "", rounded)
-  print rounded
-}')
-state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+live_rate_watts() {
+  local battery_path="$1"
+  local fallback="${2:-0}"
+  local microwatts microamps microvolts
 
-[[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
-[[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
+  if microwatts=$(read_numeric "$battery_path/power_now"); then
+    awk -v microwatts="$microwatts" 'BEGIN { print microwatts / 1000000 }'
+    return
+  fi
+
+  if microamps=$(read_numeric "$battery_path/current_now") &&
+     microvolts=$(read_numeric "$battery_path/voltage_now"); then
+    awk -v microamps="$microamps" -v microvolts="$microvolts" \
+      'BEGIN { print microamps * microvolts / 1000000000000 }'
+    return
+  fi
+
+  printf '%s\n' "$fallback"
+}
+
+# A pack that is present but reports no voltage, energy, or current is dead or
+# disconnected. A healthy empty cell still shows voltage (and usually a rate).
+pack_is_live() {
+  local battery_path="$1"
+  local energy="$2"
+  local energy_rate="$3"
+  local percentage="$4"
+  local voltage_uv energy_uwh power_uw current_ua charge_uah
+
+  voltage_uv=$(read_numeric "$battery_path/voltage_now" || true)
+  energy_uwh=$(read_numeric "$battery_path/energy_now" || true)
+  power_uw=$(read_numeric "$battery_path/power_now" || true)
+  current_ua=$(read_numeric "$battery_path/current_now" || true)
+  charge_uah=$(read_numeric "$battery_path/charge_now" || true)
+
+  awk -v voltage="${voltage_uv:-0}" \
+      -v energy_uwh="${energy_uwh:-0}" \
+      -v power="${power_uw:-0}" \
+      -v current="${current_ua:-0}" \
+      -v charge="${charge_uah:-0}" \
+      -v energy="${energy:-0}" \
+      -v rate="${energy_rate:-0}" \
+      -v percentage="${percentage:-0}" 'BEGIN {
+    if (voltage < 0) voltage = -voltage
+    if (energy_uwh < 0) energy_uwh = -energy_uwh
+    if (power < 0) power = -power
+    if (current < 0) current = -current
+    if (charge < 0) charge = -charge
+    if (energy < 0) energy = -energy
+    if (rate < 0) rate = -rate
+    if (percentage < 0) percentage = -percentage
+    # 0.5 V in microvolts; any remaining charge/current means the pack is live.
+    if (voltage > 500000) exit 0
+    if (energy_uwh > 0 || charge > 0) exit 0
+    if (power > 0 || current > 0) exit 0
+    if (energy > 0.05) exit 0
+    if (rate > 0.05) exit 0
+    if (percentage > 0) exit 0
+    exit 1
+  }'
+}
+
+rate_idle() {
+  awk -v rate="${1:-0}" 'BEGIN {
+    if (rate < 0) rate = -rate
+    exit !(rate <= 0.2)
+  }'
+}
 
 ac_online=false
 for supply in "$power_supply_path"/*; do
   [[ -r $supply/type ]] || continue
-  [[ $(<"$supply/type") == "Mains" ]] || continue
+  type=$(<"$supply/type")
+  [[ $type == "Mains" || $type == "USB" ]] || continue
   [[ -r $supply/online ]] || continue
-
   if [[ $(<"$supply/online") == "1" ]]; then
     ac_online=true
     break
   fi
 done
 
-charge_idle=false
-if awk -v rate="${power_rate_raw:-0}" 'BEGIN { exit !(rate <= 0.2) }'; then
-  charge_idle=true
+mapfile -t battery_paths < <(upower -e 2>/dev/null | grep BAT || true)
+if ((${#battery_paths[@]} == 0)); then
+  exit 0
 fi
 
-charge_holding=false
-if [[ $ac_online == "true" && -n $threshold_end ]]; then
+declare -a all_paths live_paths
+declare -A info_for path_for energy_for full_for rate_for pct_for state_for
+declare -A start_for end_for time_for cycle_for
+
+for battery in "${battery_paths[@]}"; do
+  battery_info=$(upower -i "$battery")
+
+  native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
+  [[ -n $native_path ]] || continue
+  battery_path="$power_supply_path/$native_path"
+
+  energy=$(awk '/^[[:space:]]*energy:/ { print $2; exit }' <<<"$battery_info")
+  energy_full=$(awk '/energy-full:/ { print $2; exit }' <<<"$battery_info")
+  energy_rate=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
+  percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
+  state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
+  pack_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  pack_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  pack_time=$(format_upower_time "$battery_info")
+  pack_rate=$(live_rate_watts "$battery_path" "${energy_rate:-0}")
+
+  pack_cycle=""
+  if pack_cycle=$(read_numeric "$battery_path/cycle_count"); then
+    :
+  else
+    pack_cycle=$(awk '/charge-cycles:/ { print $2; exit }' <<<"$battery_info")
+    [[ $pack_cycle == "N/A" ]] && pack_cycle=""
+  fi
+
+  all_paths+=("$battery")
+  path_for[$battery]=$native_path
+  info_for[$battery]=$battery_info
+  energy_for[$battery]=${energy:-0}
+  full_for[$battery]=${energy_full:-0}
+  rate_for[$battery]=$pack_rate
+  pct_for[$battery]=${percentage:-0}
+  state_for[$battery]=$state
+  start_for[$battery]=$pack_start
+  end_for[$battery]=$pack_end
+  time_for[$battery]=$pack_time
+  cycle_for[$battery]=$pack_cycle
+
+  if pack_is_live "$battery_path" "${energy:-0}" "${energy_rate:-0}" "${percentage:-0}"; then
+    live_paths+=("$battery")
+  fi
+done
+
+selected_paths=("${live_paths[@]}")
+if ((${#selected_paths[@]} == 0)); then
+  selected_paths=("${all_paths[@]}")
+fi
+((${#selected_paths[@]} > 0)) || exit 0
+
+pack_holding() {
+  local battery="$1"
+  local state=${state_for[$battery]}
+  local percentage=${pct_for[$battery]}
+  local pack_rate=${rate_for[$battery]}
+  local threshold_end=${end_for[$battery]}
+
+  [[ $ac_online == "true" && -n $threshold_end ]] || return 1
+
   if [[ $state == "pending-charge" ]]; then
+    return 0
+  fi
+  if [[ $state == "fully-charged" ]] && ((percentage < 99)); then
+    return 0
+  fi
+  if [[ $state == "charging" ]] && rate_idle "$pack_rate" &&
+     ((threshold_end < 99 && percentage >= threshold_end)); then
+    return 0
+  fi
+  return 1
+}
+
+total_energy=0
+total_full=0
+total_rate=0
+any_charging=false
+any_discharging=false
+any_live_charge=false
+threshold_start=""
+threshold_end=""
+cycles=""
+time_remaining=""
+
+for battery in "${selected_paths[@]}"; do
+  total_energy=$(awk -v total="$total_energy" -v add="${energy_for[$battery]}" 'BEGIN { print total + add }')
+  total_full=$(awk -v total="$total_full" -v add="${full_for[$battery]}" 'BEGIN { print total + add }')
+  total_rate=$(awk -v total="$total_rate" -v add="${rate_for[$battery]}" 'BEGIN { print total + add }')
+
+  state=${state_for[$battery]}
+  pack_rate=${rate_for[$battery]}
+  if [[ $state == "charging" ]] && ! rate_idle "$pack_rate"; then
+    any_live_charge=true
+    any_charging=true
+  elif [[ $state == "charging" ]]; then
+    any_charging=true
+  elif [[ $state == "discharging" ]]; then
+    any_discharging=true
+  fi
+
+  if [[ -z $threshold_end && -n ${end_for[$battery]} ]]; then
+    threshold_start=${start_for[$battery]}
+    threshold_end=${end_for[$battery]}
+  fi
+
+  if [[ -z $cycles && -n ${cycle_for[$battery]} && ${cycle_for[$battery]} != 0 ]]; then
+    cycles=${cycle_for[$battery]}
+  elif [[ -n ${cycle_for[$battery]} && ${cycle_for[$battery]} != 0 ]]; then
+    cycles+=", ${cycle_for[$battery]}"
+  fi
+done
+
+if [[ -z $threshold_end ]]; then
+  for battery in "${selected_paths[@]}"; do
+    native=${path_for[$battery]}
+    [[ -z $threshold_end ]] && threshold_end=$(read_numeric "$power_supply_path/$native/charge_control_end_threshold" || true)
+    [[ -z $threshold_start ]] && threshold_start=$(read_numeric "$power_supply_path/$native/charge_control_start_threshold" || true)
+  done
+fi
+
+if ((${#selected_paths[@]} == 1)); then
+  only=${selected_paths[0]}
+  percentage=${pct_for[$only]}
+  state=${state_for[$only]}
+  time_remaining=${time_for[$only]}
+else
+  percentage=$(awk -v now="$total_energy" -v full="$total_full" 'BEGIN {
+    if (full <= 0) { print 0; exit }
+    printf "%d", (now / full) * 100
+  }')
+  state=${state_for[${selected_paths[0]}]}
+fi
+
+capacity=$(awk -v full="$total_full" 'BEGIN { printf "%d", full }')
+power_rate_raw=$total_rate
+power_rate=$(format_rate "$power_rate_raw")
+
+charge_holding=false
+if [[ $ac_online == "true" && $any_live_charge == "false" ]]; then
+  all_resting=true
+  any_hold=false
+  for battery in "${selected_paths[@]}"; do
+    if pack_holding "$battery"; then
+      any_hold=true
+    elif [[ ${state_for[$battery]} == "fully-charged" ]]; then
+      :
+    else
+      all_resting=false
+    fi
+  done
+  if [[ $any_hold == "true" && $all_resting == "true" ]]; then
     charge_holding=true
-  elif [[ $state == "fully-charged" ]] && (( percentage < 99 )); then
-    charge_holding=true
-  elif [[ $state == "charging" && $charge_idle == "true" ]] && (( threshold_end < 99 && percentage >= threshold_end )); then
-    charge_holding=true
+  elif [[ $any_charging == "false" && $any_discharging == "false" && -n $threshold_end ]]; then
+    # Dead leftover pending-charge should not force Holding when a live pack
+    # is already excluded; only the selected set counts here.
+    first_state=${state_for[${selected_paths[0]}]}
+    if [[ $first_state == "pending-charge" ]]; then
+      charge_holding=true
+    fi
+  fi
+fi
+
+if [[ $charge_holding == "true" ]]; then
+  state="holding"
+elif [[ $any_live_charge == "true" || $any_charging == "true" ]]; then
+  state="charging"
+elif [[ $any_discharging == "true" ]]; then
+  state="discharging"
+fi
+
+if [[ -z $time_remaining ]]; then
+  if [[ $state == "charging" ]] && ! rate_idle "$power_rate_raw"; then
+    time_remaining=$(format_hours "$(awk -v now="$total_energy" -v full="$total_full" -v rate="$power_rate_raw" 'BEGIN {
+      if (rate <= 0) exit
+      print (full - now) / rate
+    }')")
+  elif [[ $state == "discharging" ]] && ! rate_idle "$power_rate_raw"; then
+    time_remaining=$(format_hours "$(awk -v now="$total_energy" -v rate="$power_rate_raw" 'BEGIN {
+      if (rate < 0) rate = -rate
+      if (rate <= 0) exit
+      print now / rate
+    }')")
+  elif ((${#selected_paths[@]} == 1)); then
+    time_remaining=${time_for[${selected_paths[0]}]}
   fi
 fi
 
 if [[ $shell_output == "true" ]]; then
   printf 'percentage\t%s\n' "${percentage}%"
-  if [[ $charge_holding == "true" ]]; then
-    printf 'state\tholding\n'
-  else
-    printf 'state\t%s\n' "$state"
-  fi
+  printf 'state\t%s\n' "$state"
   printf 'rate\t%s\n' "${power_rate}W"
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
-
-  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
-
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 
   if [[ -n $threshold_end ]]; then
-    if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
+    if [[ -n $threshold_start && $threshold_start != "$threshold_end" ]]; then
       printf 'threshold\t%s-%s%%\n' "$threshold_start" "$threshold_end"
     else
       printf 'threshold\t%s%%\n' "$threshold_end"
@@ -122,8 +369,8 @@ if [[ $shell_output == "true" ]]; then
   exit 0
 fi
 
-if [[ $charge_holding == "true" ]]; then
-  if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
+if [[ $state == "holding" ]]; then
+  if [[ -n $threshold_start && $threshold_start != "$threshold_end" ]]; then
     threshold_label="${threshold_start}-${threshold_end}%"
   else
     threshold_label="${threshold_end}%"

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -366,6 +366,10 @@ if [[ $shell_output == "true" ]]; then
     fi
   fi
 
+  for i in "${!selected_paths[@]}"; do
+    printf 'pack.%s.path\t%s\n' "$i" "${path_for[${selected_paths[$i]}]}"
+  done
+
   exit 0
 fi
 

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -56,23 +56,12 @@ format_hours() {
   }'
 }
 
-format_upower_time() {
-  awk '/time to (empty|full)/ {
-    value = $4
-    unit = $5
-    if (unit ~ /^minute/) {
-      printf "%dm", int(value)
-    } else {
-      hours = int(value)
-      minutes = int((value - hours) * 60)
-      if (minutes > 0) {
-        printf "%dh %dm", hours, minutes
-      } else {
-        printf "%dh", hours
-      }
-    }
-    exit
-  }' <<<"$1"
+format_wh() {
+  awk -v wh="${1:-0}" 'BEGIN {
+    rounded = sprintf("%.1f", wh)
+    sub(/\.0$/, "", rounded)
+    print rounded
+  }'
 }
 
 live_rate_watts() {
@@ -163,7 +152,7 @@ fi
 
 declare -a all_paths live_paths
 declare -A info_for path_for energy_for full_for rate_for pct_for state_for
-declare -A start_for end_for time_for cycle_for
+declare -A start_for end_for cycle_for
 
 for battery in "${battery_paths[@]}"; do
   battery_info=$(upower -i "$battery")
@@ -179,7 +168,6 @@ for battery in "${battery_paths[@]}"; do
   state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
   pack_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
   pack_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-  pack_time=$(format_upower_time "$battery_info")
   pack_rate=$(live_rate_watts "$battery_path" "${energy_rate:-0}")
 
   pack_cycle=""
@@ -200,7 +188,6 @@ for battery in "${battery_paths[@]}"; do
   state_for[$battery]=$state
   start_for[$battery]=$pack_start
   end_for[$battery]=$pack_end
-  time_for[$battery]=$pack_time
   cycle_for[$battery]=$pack_cycle
 
   if pack_is_live "$battery_path" "${energy:-0}" "${energy_rate:-0}" "${percentage:-0}"; then
@@ -219,9 +206,9 @@ pack_holding() {
   local state=${state_for[$battery]}
   local percentage=${pct_for[$battery]}
   local pack_rate=${rate_for[$battery]}
-  local threshold_end=${end_for[$battery]}
 
   [[ $ac_online == "true" && -n $threshold_end ]] || return 1
+  ((threshold_end > 0 && threshold_end < 99)) || return 1
 
   if [[ $state == "pending-charge" ]]; then
     return 0
@@ -230,7 +217,7 @@ pack_holding() {
     return 0
   fi
   if [[ $state == "charging" ]] && rate_idle "$pack_rate" &&
-     ((threshold_end < 99 && percentage >= threshold_end)); then
+     ((percentage >= threshold_end)); then
     return 0
   fi
   return 1
@@ -263,11 +250,6 @@ for battery in "${selected_paths[@]}"; do
     any_discharging=true
   fi
 
-  if [[ -z $threshold_end && -n ${end_for[$battery]} ]]; then
-    threshold_start=${start_for[$battery]}
-    threshold_end=${end_for[$battery]}
-  fi
-
   if [[ -z $cycles && -n ${cycle_for[$battery]} && ${cycle_for[$battery]} != 0 ]]; then
     cycles=${cycle_for[$battery]}
   elif [[ -n ${cycle_for[$battery]} && ${cycle_for[$battery]} != 0 ]]; then
@@ -275,33 +257,44 @@ for battery in "${selected_paths[@]}"; do
   fi
 done
 
+threshold_start=""
+threshold_end=""
+for battery in "${selected_paths[@]}"; do
+  native=${path_for[$battery]}
+  sys_end=$(read_numeric "$power_supply_path/$native/charge_control_end_threshold" || true)
+  sys_start=$(read_numeric "$power_supply_path/$native/charge_control_start_threshold" || true)
+  if [[ -n $sys_end ]]; then
+    threshold_end=$sys_end
+    threshold_start=$sys_start
+    break
+  fi
+done
 if [[ -z $threshold_end ]]; then
   for battery in "${selected_paths[@]}"; do
-    native=${path_for[$battery]}
-    [[ -z $threshold_end ]] && threshold_end=$(read_numeric "$power_supply_path/$native/charge_control_end_threshold" || true)
-    [[ -z $threshold_start ]] && threshold_start=$(read_numeric "$power_supply_path/$native/charge_control_start_threshold" || true)
+    if [[ -n ${end_for[$battery]} ]]; then
+      threshold_end=${end_for[$battery]}
+      threshold_start=${start_for[$battery]}
+      break
+    fi
   done
 fi
-
-if ((${#selected_paths[@]} == 1)); then
-  only=${selected_paths[0]}
-  percentage=${pct_for[$only]}
-  state=${state_for[$only]}
-  time_remaining=${time_for[$only]}
-else
-  percentage=$(awk -v now="$total_energy" -v full="$total_full" 'BEGIN {
-    if (full <= 0) { print 0; exit }
-    printf "%d", (now / full) * 100
-  }')
-  state=${state_for[${selected_paths[0]}]}
+if [[ -n $threshold_end ]] && ((threshold_end <= 0 || threshold_end >= 99)); then
+  threshold_end=""
+  threshold_start=""
 fi
 
-capacity=$(awk -v full="$total_full" 'BEGIN { printf "%d", full }')
-power_rate_raw=$total_rate
+percentage=$(awk -v now="$total_energy" -v full="$total_full" 'BEGIN {
+  if (full <= 0) { print 0; exit }
+  printf "%d", (now / full) * 100 + 0.5
+}')
+state=${state_for[${selected_paths[0]}]}
+
+capacity=$(format_wh "$total_full")
+power_rate_raw=$(awk -v rate="$total_rate" 'BEGIN { if (rate < 0) rate = -rate; print rate }')
 power_rate=$(format_rate "$power_rate_raw")
 
 charge_holding=false
-if [[ $ac_online == "true" && $any_live_charge == "false" ]]; then
+if [[ $ac_online == "true" && $any_live_charge == "false" && -n $threshold_end ]]; then
   all_resting=true
   any_hold=false
   for battery in "${selected_paths[@]}"; do
@@ -315,13 +308,6 @@ if [[ $ac_online == "true" && $any_live_charge == "false" ]]; then
   done
   if [[ $any_hold == "true" && $all_resting == "true" ]]; then
     charge_holding=true
-  elif [[ $any_charging == "false" && $any_discharging == "false" && -n $threshold_end ]]; then
-    # Dead leftover pending-charge should not force Holding when a live pack
-    # is already excluded; only the selected set counts here.
-    first_state=${state_for[${selected_paths[0]}]}
-    if [[ $first_state == "pending-charge" ]]; then
-      charge_holding=true
-    fi
   fi
 fi
 
@@ -333,21 +319,17 @@ elif [[ $any_discharging == "true" ]]; then
   state="discharging"
 fi
 
-if [[ -z $time_remaining ]]; then
-  if [[ $state == "charging" ]] && ! rate_idle "$power_rate_raw"; then
-    time_remaining=$(format_hours "$(awk -v now="$total_energy" -v full="$total_full" -v rate="$power_rate_raw" 'BEGIN {
-      if (rate <= 0) exit
-      print (full - now) / rate
-    }')")
-  elif [[ $state == "discharging" ]] && ! rate_idle "$power_rate_raw"; then
-    time_remaining=$(format_hours "$(awk -v now="$total_energy" -v rate="$power_rate_raw" 'BEGIN {
-      if (rate < 0) rate = -rate
-      if (rate <= 0) exit
-      print now / rate
-    }')")
-  elif ((${#selected_paths[@]} == 1)); then
-    time_remaining=${time_for[${selected_paths[0]}]}
-  fi
+time_remaining=""
+if [[ $state == "charging" ]] && ! rate_idle "$power_rate_raw"; then
+  time_remaining=$(format_hours "$(awk -v now="$total_energy" -v full="$total_full" -v rate="$power_rate_raw" 'BEGIN {
+    if (rate <= 0) exit
+    print (full - now) / rate
+  }')")
+elif [[ $state == "discharging" ]] && ! rate_idle "$power_rate_raw"; then
+  time_remaining=$(format_hours "$(awk -v now="$total_energy" -v rate="$power_rate_raw" 'BEGIN {
+    if (rate <= 0) exit
+    print now / rate
+  }')")
 fi
 
 if [[ $shell_output == "true" ]]; then

--- a/migrations/1787516800.sh
+++ b/migrations/1787516800.sh
@@ -1,0 +1,37 @@
+echo "Ignore UPower critical sleep so the shell can act on live remaining energy"
+
+# UPower Auto/Sleep keys off DisplayDevice / the EC fuel gauge. On dual-battery
+# ThinkPads that cliff (40% → 6% in a minute) it suspends while live watt-hours
+# are still well above 2%. omarchy.battery now warns at 10% and acts at 2% using
+# live remaining energy; Ignore stops the daemon from racing that path.
+# Ignore is marked "risky" in UPower.conf and needs AllowRiskyCriticalPowerAction.
+
+conf=/etc/UPower/UPower.conf
+[[ -r $conf ]] || exit 0
+
+if grep -q '^CriticalPowerAction=Ignore$' "$conf" &&
+  grep -q '^AllowRiskyCriticalPowerAction=true$' "$conf"; then
+  exit 0
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+python3 - "$conf" "$tmp" <<'PY'
+import sys
+
+src, dest = sys.argv[1], sys.argv[2]
+out = []
+for line in open(src):
+    if line.startswith("AllowRiskyCriticalPowerAction="):
+        out.append("AllowRiskyCriticalPowerAction=true\n")
+    elif line.startswith("CriticalPowerAction="):
+        out.append("CriticalPowerAction=Ignore\n")
+    else:
+        out.append(line)
+open(dest, "w").writelines(out)
+PY
+
+sudo install -m 644 "$tmp" "$conf"
+if omarchy-cmd-present systemctl; then
+  sudo systemctl try-restart upower.service || true
+fi

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -70,28 +70,51 @@ function laptopDevices(devices) {
   return packs
 }
 
-// Present-but-dead packs (ThinkPad internal cells at 0 V / 0 Wh) still expose
-// energyCapacity, so DisplayDevice percentage is pulled down by empty mass.
+// Same liveness test as bin/omarchy-battery-status pack_is_live: a healthy
+// empty cell still shows voltage, while a present-but-dead pack is 0 V / 0 Wh.
+// Quickshell's UPowerDevice may omit voltage; the CLI then supplies pack.N.path.
 function isLivePack(device) {
   if (!device || !device.isPresent) return false
   if (Number(device.energy || 0) > 0.05) return true
   if (Math.abs(Number(device.changeRate || 0)) > 0.05) return true
   if (Number(device.percentage || 0) > 0) return true
+  if (Number(device.voltage || 0) > 0.5) return true
   return false
 }
 
-function liveLaptopDevices(devices) {
+function selectedPackPaths(info) {
+  var kv = info || {}
+  var paths = []
+  for (var i = 0; i < 16; i++) {
+    var path = kv["pack." + i + ".path"]
+    if (path === undefined || path === "") break
+    paths.push(String(path))
+  }
+  return paths
+}
+
+function liveLaptopDevices(devices, statusInfo) {
   var packs = laptopDevices(devices)
+  var selected = selectedPackPaths(statusInfo)
+  if (selected.length > 0) {
+    var wanted = {}
+    for (var i = 0; i < selected.length; i++) wanted[selected[i]] = true
+    var matched = []
+    for (var j = 0; j < packs.length; j++) {
+      if (wanted[String(packs[j].nativePath || "")]) matched.push(packs[j])
+    }
+    if (matched.length > 0) return matched
+  }
+
   var live = []
-  for (var i = 0; i < packs.length; i++) {
-    if (isLivePack(packs[i])) live.push(packs[i])
+  for (var k = 0; k < packs.length; k++) {
+    if (isLivePack(packs[k])) live.push(packs[k])
   }
   return live.length > 0 ? live : packs
 }
 
-function combinedEnergyFraction(devices) {
-  var packs = liveLaptopDevices(devices)
-  if (packs.length === 0) return -1
+function packsEnergyFraction(packs) {
+  if (!packs || packs.length === 0) return -1
   if (packs.length === 1) return batteryFraction(packs[0])
 
   var now = 0
@@ -104,6 +127,10 @@ function combinedEnergyFraction(devices) {
   return batteryFraction(packs[0])
 }
 
+function combinedEnergyFraction(devices, statusInfo) {
+  return packsEnergyFraction(liveLaptopDevices(devices, statusInfo))
+}
+
 function combinedFractionFromStatus(info) {
   var raw = info && info.percentage
   if (raw === undefined || raw === "") return -1
@@ -112,8 +139,8 @@ function combinedFractionFromStatus(info) {
   return Math.max(0, Math.min(1, value / 100))
 }
 
-function viewDevice(devices, fallback, states) {
-  var packs = liveLaptopDevices(devices)
+function viewDevice(devices, fallback, states, statusInfo) {
+  var packs = liveLaptopDevices(devices, statusInfo)
   if (packs.length === 0) return fallback || {}
   if (packs.length === 1) return packs[0]
 
@@ -132,7 +159,7 @@ function viewDevice(devices, fallback, states) {
 
   return {
     isPresent: true,
-    percentage: combinedEnergyFraction(packs),
+    percentage: packsEnergyFraction(packs),
     state: state,
     changeRate: changeRate,
     timeToFull: 0,
@@ -141,8 +168,8 @@ function viewDevice(devices, fallback, states) {
   }
 }
 
-function anyPackCharging(devices, states) {
-  var packs = liveLaptopDevices(devices)
+function anyPackCharging(devices, states, statusInfo) {
+  var packs = liveLaptopDevices(devices, statusInfo)
   var s = states || {}
   for (var i = 0; i < packs.length; i++) {
     if (packs[i].state === s.Charging && Number(packs[i].changeRate || 0) > 0.2) return true
@@ -168,11 +195,11 @@ function chargeThresholdActive(device, onBattery, states) {
 
 function chargeThresholdActiveForPacks(devices, onBattery, states, statusInfo) {
   if (onBattery) return false
-  if (anyPackCharging(devices, states)) return false
+  if (anyPackCharging(devices, states, statusInfo)) return false
   if (statusInfo && statusInfo.state === "holding") return true
   if (statusInfo && (statusInfo.state === "charging" || statusInfo.state === "discharging")) return false
 
-  var packs = liveLaptopDevices(devices)
+  var packs = liveLaptopDevices(devices, statusInfo)
   if (packs.length === 0) return chargeThresholdActive(null, onBattery, states)
 
   for (var i = 0; i < packs.length; i++) {
@@ -218,7 +245,9 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     laptopDevices: laptopDevices,
     isLivePack: isLivePack,
+    selectedPackPaths: selectedPackPaths,
     liveLaptopDevices: liveLaptopDevices,
+    packsEnergyFraction: packsEnergyFraction,
     combinedEnergyFraction: combinedEnergyFraction,
     combinedFractionFromStatus: combinedFractionFromStatus,
     viewDevice: viewDevice,

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -115,7 +115,6 @@ function liveLaptopDevices(devices, statusInfo) {
 
 function packsEnergyFraction(packs) {
   if (!packs || packs.length === 0) return -1
-  if (packs.length === 1) return batteryFraction(packs[0])
 
   var now = 0
   var full = 0
@@ -142,7 +141,18 @@ function combinedFractionFromStatus(info) {
 function viewDevice(devices, fallback, states, statusInfo) {
   var packs = liveLaptopDevices(devices, statusInfo)
   if (packs.length === 0) return fallback || {}
-  if (packs.length === 1) return packs[0]
+  if (packs.length === 1) {
+    var only = packs[0]
+    return {
+      isPresent: true,
+      percentage: packsEnergyFraction(packs),
+      state: only.state,
+      changeRate: only.changeRate,
+      timeToFull: only.timeToFull,
+      energy: only.energy,
+      energyCapacity: only.energyCapacity
+    }
+  }
 
   var s = states || {}
   var changeRate = 0

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -56,6 +56,18 @@ function deviceList(devices) {
   return []
 }
 
+function packPathKey(path) {
+  var parts = String(path || "").split("/")
+  return parts.length > 0 ? parts[parts.length - 1] : ""
+}
+
+function pathsMatch(a, b) {
+  var ka = packPathKey(a)
+  var kb = packPathKey(b)
+  if (!ka || !kb) return false
+  return ka === kb
+}
+
 function laptopDevices(devices) {
   var list = deviceList(devices)
   var packs = []
@@ -97,11 +109,15 @@ function liveLaptopDevices(devices, statusInfo) {
   var packs = laptopDevices(devices)
   var selected = selectedPackPaths(statusInfo)
   if (selected.length > 0) {
-    var wanted = {}
-    for (var i = 0; i < selected.length; i++) wanted[selected[i]] = true
     var matched = []
     for (var j = 0; j < packs.length; j++) {
-      if (wanted[String(packs[j].nativePath || "")]) matched.push(packs[j])
+      var nativePath = String(packs[j].nativePath || "")
+      for (var i = 0; i < selected.length; i++) {
+        if (pathsMatch(nativePath, selected[i])) {
+          matched.push(packs[j])
+          break
+        }
+      }
     }
     if (matched.length > 0) return matched
   }
@@ -255,6 +271,8 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     laptopDevices: laptopDevices,
     isLivePack: isLivePack,
+    packPathKey: packPathKey,
+    pathsMatch: pathsMatch,
     selectedPackPaths: selectedPackPaths,
     liveLaptopDevices: liveLaptopDevices,
     packsEnergyFraction: packsEnergyFraction,

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -154,6 +154,120 @@ function combinedFractionFromStatus(info) {
   return Math.max(0, Math.min(1, value / 100))
 }
 
+function parseWh(raw) {
+  var value = parseFloat(String(raw || "").replace(/Wh$/i, ""))
+  return isNaN(value) ? -1 : value
+}
+
+function parseWatts(raw) {
+  var value = parseFloat(String(raw || "").replace(/W$/i, ""))
+  return isNaN(value) ? 0 : value
+}
+
+function formatHoursJs(hours) {
+  if (!(hours > 0)) return ""
+  if (hours * 60 < 60) return Math.max(1, Math.floor(hours * 60)) + "m"
+  var whole = Math.floor(hours)
+  var minutes = Math.floor((hours - whole) * 60)
+  if (minutes > 0) return whole + "h " + minutes + "m"
+  return whole + "h"
+}
+
+function formatWhJs(wh) {
+  var rounded = Math.round(wh * 10) / 10
+  if (Math.abs(rounded - Math.round(rounded)) < 0.05) return String(Math.round(rounded))
+  return String(rounded)
+}
+
+// Reject EC fuel-gauge cliffs (e.g. 37% → 6% in a minute) that exceed what
+// the measured wattage could have moved. Reset on charge/discharge flips so
+// a real plug-in is not stuck on the pre-cliff value.
+function applyEnergySample(previous, next, nowMs) {
+  var sample = next || {}
+  var energy = parseWh(sample.energy)
+  var full = parseWh(sample.size)
+  var rate = parseWatts(sample.rate)
+  var prev = previous || {}
+  var prevEnergy = parseWh(prev.energy)
+  var prevRate = parseWatts(prev.rate)
+  var prevMs = Number(prev._sampleMs || 0)
+  var dt = prevMs > 0 ? (Number(nowMs) - prevMs) / 1000 : 0
+  var state = sample.state || ""
+  var prevState = prev.state || ""
+
+  if (energy >= 0 && prevEnergy >= 0 && dt > 0 && dt < 120) {
+    var flipped = (state === "charging" && prevState !== "charging") ||
+      (state === "discharging" && prevState !== "discharging")
+    if (!flipped && energy < prevEnergy) {
+      var maxDrop = Math.abs(prevRate) * (dt / 3600) * 3 + 0.5
+      if (prevEnergy - energy > maxDrop) energy = prevEnergy
+    }
+  }
+
+  var out = {}
+  var key
+  for (key in sample) {
+    if (Object.prototype.hasOwnProperty.call(sample, key)) out[key] = sample[key]
+  }
+  if (energy >= 0) {
+    out.energy = formatWhJs(energy) + "Wh"
+    if (full > 0) {
+      out.percentage = String(Math.round(Math.max(0, Math.min(1, energy / full)) * 100)) + "%"
+      if (Math.abs(rate) > 0.2) {
+        if (state === "charging") out.time = formatHoursJs((full - energy) / Math.abs(rate))
+        else if (state === "discharging") out.time = formatHoursJs(energy / Math.abs(rate))
+      }
+    }
+  }
+  out._sampleMs = String(nowMs)
+  return out
+}
+
+// Combine live packs into a watt-hour sample, reject EC cliffs against
+// `previous`, and return the fraction warn and critical-action must use.
+function liveEnergySnapshot(devices, statusInfo, previous, nowMs, states) {
+  var packs = liveLaptopDevices(devices, statusInfo)
+  if (!packs || packs.length === 0) {
+    return { sample: previous || {}, fraction: -1, discharging: false }
+  }
+
+  var now = 0
+  var full = 0
+  var rate = 0
+  var discharging = false
+  var charging = false
+  var s = states || {}
+  var chargingState = s.Charging !== undefined ? s.Charging : "charging"
+  var dischargingState = s.Discharging !== undefined ? s.Discharging : "discharging"
+  var i
+
+  for (i = 0; i < packs.length; i++) {
+    now += Number(packs[i].energy || 0)
+    full += Number(packs[i].energyCapacity || 0)
+    rate += Number(packs[i].changeRate || 0)
+    if (packs[i].state === chargingState) charging = true
+    if (packs[i].state === dischargingState) discharging = true
+  }
+
+  var stateName = "unknown"
+  if (charging) stateName = "charging"
+  else if (discharging) stateName = "discharging"
+
+  var rateAbs = rate < 0 ? -rate : rate
+  var sample = {
+    energy: formatWhJs(now) + "Wh",
+    size: formatWhJs(full) + "Wh",
+    rate: formatWhJs(rateAbs) + "W",
+    state: stateName
+  }
+  var smoothed = applyEnergySample(previous, sample, nowMs)
+  return {
+    sample: smoothed,
+    fraction: combinedFractionFromStatus(smoothed),
+    discharging: discharging && !charging
+  }
+}
+
 function viewDevice(devices, fallback, states, statusInfo) {
   var packs = liveLaptopDevices(devices, statusInfo)
   if (packs.length === 0) return fallback || {}
@@ -278,6 +392,9 @@ if (typeof module !== "undefined") {
     packsEnergyFraction: packsEnergyFraction,
     combinedEnergyFraction: combinedEnergyFraction,
     combinedFractionFromStatus: combinedFractionFromStatus,
+    parseWh: parseWh,
+    applyEnergySample: applyEnergySample,
+    liveEnergySnapshot: liveEnergySnapshot,
     viewDevice: viewDevice,
     anyPackCharging: anyPackCharging,
     chargeThresholdActive: chargeThresholdActive,

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -49,6 +49,107 @@ function batteryFraction(device) {
   return device && device.isPresent ? Math.max(0, Math.min(1, device.percentage)) : 0
 }
 
+function deviceList(devices) {
+  if (!devices) return []
+  if (Array.isArray(devices)) return devices
+  if (devices.values) return devices.values
+  return []
+}
+
+function laptopDevices(devices) {
+  var list = deviceList(devices)
+  var packs = []
+  for (var i = 0; i < list.length; i++) {
+    var device = list[i]
+    if (!device || !device.isPresent) continue
+    if (device.isLaptopBattery === false) continue
+    var path = String(device.nativePath || "")
+    if (!path || path === "DisplayDevice") continue
+    packs.push(device)
+  }
+  return packs
+}
+
+// Present-but-dead packs (ThinkPad internal cells at 0 V / 0 Wh) still expose
+// energyCapacity, so DisplayDevice percentage is pulled down by empty mass.
+function isLivePack(device) {
+  if (!device || !device.isPresent) return false
+  if (Number(device.energy || 0) > 0.05) return true
+  if (Math.abs(Number(device.changeRate || 0)) > 0.05) return true
+  if (Number(device.percentage || 0) > 0) return true
+  return false
+}
+
+function liveLaptopDevices(devices) {
+  var packs = laptopDevices(devices)
+  var live = []
+  for (var i = 0; i < packs.length; i++) {
+    if (isLivePack(packs[i])) live.push(packs[i])
+  }
+  return live.length > 0 ? live : packs
+}
+
+function combinedEnergyFraction(devices) {
+  var packs = liveLaptopDevices(devices)
+  if (packs.length === 0) return -1
+  if (packs.length === 1) return batteryFraction(packs[0])
+
+  var now = 0
+  var full = 0
+  for (var i = 0; i < packs.length; i++) {
+    now += Number(packs[i].energy || 0)
+    full += Number(packs[i].energyCapacity || 0)
+  }
+  if (full > 0) return Math.max(0, Math.min(1, now / full))
+  return batteryFraction(packs[0])
+}
+
+function combinedFractionFromStatus(info) {
+  var raw = info && info.percentage
+  if (raw === undefined || raw === "") return -1
+  var value = parseFloat(String(raw).replace("%", ""))
+  if (isNaN(value)) return -1
+  return Math.max(0, Math.min(1, value / 100))
+}
+
+function viewDevice(devices, fallback, states) {
+  var packs = liveLaptopDevices(devices)
+  if (packs.length === 0) return fallback || {}
+  if (packs.length === 1) return packs[0]
+
+  var s = states || {}
+  var changeRate = 0
+  var state = packs[0].state
+  var charging = false
+  var discharging = false
+  for (var i = 0; i < packs.length; i++) {
+    changeRate += Number(packs[i].changeRate || 0)
+    if (packs[i].state === s.Charging && Number(packs[i].changeRate || 0) > 0.2) charging = true
+    if (packs[i].state === s.Discharging) discharging = true
+  }
+  if (charging) state = s.Charging
+  else if (discharging) state = s.Discharging
+
+  return {
+    isPresent: true,
+    percentage: combinedEnergyFraction(packs),
+    state: state,
+    changeRate: changeRate,
+    timeToFull: 0,
+    energy: 0,
+    energyCapacity: 0
+  }
+}
+
+function anyPackCharging(devices, states) {
+  var packs = liveLaptopDevices(devices)
+  var s = states || {}
+  for (var i = 0; i < packs.length; i++) {
+    if (packs[i].state === s.Charging && Number(packs[i].changeRate || 0) > 0.2) return true
+  }
+  return false
+}
+
 function chargeThresholdActive(device, onBattery, states) {
   var d = device || {}
   var s = states || {}
@@ -60,17 +161,34 @@ function chargeThresholdActive(device, onBattery, states) {
   if (d.state === s.FullyCharged && fraction < 0.99) return true
   if (d.state !== s.Charging || fraction >= 0.99) return false
 
-  return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
+  // A slow charge into a second pack can take well over eight hours. Only
+  // treat the pack as holding when current has actually stalled.
+  return Number(d.changeRate || 0) <= 0.2
 }
 
-function batteryIcon(device, onBattery, states) {
+function chargeThresholdActiveForPacks(devices, onBattery, states, statusInfo) {
+  if (onBattery) return false
+  if (anyPackCharging(devices, states)) return false
+  if (statusInfo && statusInfo.state === "holding") return true
+  if (statusInfo && (statusInfo.state === "charging" || statusInfo.state === "discharging")) return false
+
+  var packs = liveLaptopDevices(devices)
+  if (packs.length === 0) return chargeThresholdActive(null, onBattery, states)
+
+  for (var i = 0; i < packs.length; i++) {
+    if (!chargeThresholdActive(packs[i], onBattery, states)) return false
+  }
+  return true
+}
+
+function batteryIcon(device, onBattery, states, thresholdOverride) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
-  var threshold = chargeThresholdActive(d, onBattery, states)
+  var threshold = thresholdOverride !== undefined ? !!thresholdOverride : chargeThresholdActive(d, onBattery, states)
 
   if (threshold) return defaultIcons[index]
   if (d.state === states.FullyCharged) return "󰂅"
@@ -78,12 +196,13 @@ function batteryIcon(device, onBattery, states) {
   return defaultIcons[index]
 }
 
-function modeLabel(device, onBattery, states) {
+function modeLabel(device, onBattery, states, thresholdOverride) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var percentage = d.isPresent ? d.percentage : 0
-  if (chargeThresholdActive(d, onBattery, states)) return "Threshold"
+  var threshold = thresholdOverride !== undefined ? !!thresholdOverride : chargeThresholdActive(d, onBattery, states)
+  if (threshold) return "Threshold"
   if (onBattery) return "On battery"
   if (!onBattery && percentage >= 1) return "Fully charged"
   return "Charging"
@@ -97,7 +216,15 @@ if (typeof module !== "undefined") {
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    laptopDevices: laptopDevices,
+    isLivePack: isLivePack,
+    liveLaptopDevices: liveLaptopDevices,
+    combinedEnergyFraction: combinedEnergyFraction,
+    combinedFractionFromStatus: combinedFractionFromStatus,
+    viewDevice: viewDevice,
+    anyPackCharging: anyPackCharging,
     chargeThresholdActive: chargeThresholdActive,
+    chargeThresholdActiveForPacks: chargeThresholdActiveForPacks,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel
   }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -51,7 +51,7 @@ Panel {
   }
 
   function viewDevice() {
-    return Model.viewDevice(root.powerDevices, UPower.displayDevice, upowerStates(), root.opened ? root.batteryInfo : null)
+    return Model.viewDevice(root.powerDevices, { isPresent: false }, upowerStates(), root.opened ? root.batteryInfo : null)
   }
 
   function batteryIcon() {
@@ -79,14 +79,13 @@ Panel {
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
 
-  // 0..1 charge level, used by the visual progress bar. Prefer live packs
-  // over DisplayDevice, which still counts a present-but-dead cell's energy-full.
+  // Live watt-hours only. DisplayDevice still counts a dead pack's energy-full.
   readonly property real batteryFraction: {
     var fromStatus = root.opened ? Model.combinedFractionFromStatus(root.batteryInfo) : -1
     if (fromStatus >= 0) return fromStatus
     var combined = Model.combinedEnergyFraction(root.powerDevices, root.opened ? root.batteryInfo : null)
     if (combined >= 0) return combined
-    return Model.batteryFraction(UPower.displayDevice)
+    return 0
   }
 
   readonly property bool charging: {

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -20,11 +20,14 @@ Panel {
   property int profileIndex: 0
   property bool cursorActive: false
   readonly property bool showPercentage: setting("showPercentage", false) === true
+  readonly property var powerDevices: UPower.devices ? UPower.devices.values : []
+  readonly property var livePacks: Model.liveLaptopDevices(powerDevices)
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
   readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
   readonly property bool batteryPresent: {
+    if (root.livePacks.length > 0) return true
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
   }
@@ -47,14 +50,16 @@ Panel {
     setProfile(profiles[profileIndex])
   }
 
+  function viewDevice() {
+    return Model.viewDevice(root.livePacks, UPower.displayDevice, upowerStates())
+  }
+
   function batteryIcon() {
-    var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    return Model.batteryIcon(viewDevice(), root.discharging, upowerStates(), root.chargeThresholdActive)
   }
 
   function modeLabel() {
-    var device = UPower.displayDevice
-    return Model.modeLabel(device, root.discharging, upowerStates())
+    return Model.modeLabel(viewDevice(), root.discharging, upowerStates(), root.chargeThresholdActive)
   }
 
   function profileIcon(name) {
@@ -62,29 +67,30 @@ Panel {
   }
 
   readonly property bool fullyCharged: {
-    var device = UPower.displayDevice
+    var device = viewDevice()
     return device && device.isPresent && device.state === UPowerDeviceState.FullyCharged && !root.chargeThresholdActive
   }
   readonly property bool discharging: {
-    var device = UPower.displayDevice
-    return !!(device && device.isPresent && UPower.onBattery)
+    return !!(root.batteryPresent && UPower.onBattery)
   }
   readonly property bool chargeThresholdActive: {
-    var device = UPower.displayDevice
-    return Model.chargeThresholdActive(device, root.discharging, upowerStates())
+    return Model.chargeThresholdActiveForPacks(root.livePacks, root.discharging, upowerStates(), root.batteryInfo)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
 
-  // 0..1 charge level, used by the visual progress bar.
+  // 0..1 charge level, used by the visual progress bar. Prefer live packs
+  // over DisplayDevice, which still counts a present-but-dead cell's energy-full.
   readonly property real batteryFraction: {
-    var d = UPower.displayDevice
-    return Model.batteryFraction(d)
+    var fromStatus = Model.combinedFractionFromStatus(root.batteryInfo)
+    if (fromStatus >= 0) return fromStatus
+    var combined = Model.combinedEnergyFraction(root.livePacks)
+    if (combined >= 0) return combined
+    return Model.batteryFraction(UPower.displayDevice)
   }
 
   readonly property bool charging: {
-    var d = UPower.displayDevice
-    return d && d.isPresent && !UPower.onBattery && !root.batteryFlowIdle
+    return root.batteryPresent && !UPower.onBattery && !root.batteryFlowIdle
   }
 
   readonly property color batteryFillColor: {

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -74,7 +74,7 @@ Panel {
     return !!(root.batteryPresent && UPower.onBattery)
   }
   readonly property bool chargeThresholdActive: {
-    return Model.chargeThresholdActiveForPacks(root.livePacks, root.discharging, upowerStates(), root.batteryInfo)
+    return Model.chargeThresholdActiveForPacks(root.livePacks, root.discharging, upowerStates(), root.opened ? root.batteryInfo : null)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -21,7 +21,7 @@ Panel {
   property bool cursorActive: false
   readonly property bool showPercentage: setting("showPercentage", false) === true
   readonly property var powerDevices: UPower.devices ? UPower.devices.values : []
-  readonly property var livePacks: Model.liveLaptopDevices(powerDevices)
+  readonly property var livePacks: Model.liveLaptopDevices(powerDevices, opened ? batteryInfo : null)
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
@@ -51,7 +51,7 @@ Panel {
   }
 
   function viewDevice() {
-    return Model.viewDevice(root.livePacks, UPower.displayDevice, upowerStates())
+    return Model.viewDevice(root.powerDevices, UPower.displayDevice, upowerStates(), root.opened ? root.batteryInfo : null)
   }
 
   function batteryIcon() {
@@ -74,7 +74,7 @@ Panel {
     return !!(root.batteryPresent && UPower.onBattery)
   }
   readonly property bool chargeThresholdActive: {
-    return Model.chargeThresholdActiveForPacks(root.livePacks, root.discharging, upowerStates(), root.opened ? root.batteryInfo : null)
+    return Model.chargeThresholdActiveForPacks(root.powerDevices, root.discharging, upowerStates(), root.opened ? root.batteryInfo : null)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
@@ -82,9 +82,9 @@ Panel {
   // 0..1 charge level, used by the visual progress bar. Prefer live packs
   // over DisplayDevice, which still counts a present-but-dead cell's energy-full.
   readonly property real batteryFraction: {
-    var fromStatus = Model.combinedFractionFromStatus(root.batteryInfo)
+    var fromStatus = root.opened ? Model.combinedFractionFromStatus(root.batteryInfo) : -1
     if (fromStatus >= 0) return fromStatus
-    var combined = Model.combinedEnergyFraction(root.livePacks)
+    var combined = Model.combinedEnergyFraction(root.powerDevices, root.opened ? root.batteryInfo : null)
     if (combined >= 0) return combined
     return Model.batteryFraction(UPower.displayDevice)
   }

--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -1,3 +1,6 @@
+var LOW_BATTERY_WARN_PERCENT = 10
+var LOW_BATTERY_ACTION_PERCENT = 2
+
 function batteryPercentage(device) {
   if (!device || !device.isPresent) return -1
   return Math.round(Number(device.percentage || 0) * 100)
@@ -7,11 +10,17 @@ function isDischarging(device, onBattery, dischargingState) {
   return !!(device && device.isPresent && onBattery && device.state === dischargingState)
 }
 
-function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
-  var level = batteryPercentage(device)
+function livePercent(fraction) {
+  if (!(fraction >= 0)) return -1
+  return Math.round(Number(fraction) * 100)
+}
+
+function shouldWarnLowBattery(fraction, onBattery, discharging, alreadyNotified, warnPercent) {
+  var threshold = warnPercent === undefined || warnPercent === null ? LOW_BATTERY_WARN_PERCENT : Number(warnPercent)
+  var level = livePercent(fraction)
   if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
 
-  var low = isDischarging(device, onBattery, dischargingState) && level <= threshold
+  var low = !!(onBattery && discharging && level <= threshold)
   return {
     level: level,
     notify: low && !alreadyNotified,
@@ -19,10 +28,26 @@ function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, al
   }
 }
 
+function shouldActCriticalBattery(fraction, onBattery, discharging, alreadyActed, actionPercent) {
+  var threshold = actionPercent === undefined || actionPercent === null ? LOW_BATTERY_ACTION_PERCENT : Number(actionPercent)
+  var level = livePercent(fraction)
+  if (level < 0) return { level: level, act: false, actedCriticalBattery: false }
+
+  var critical = !!(onBattery && discharging && level <= threshold)
+  return {
+    level: level,
+    act: critical && !alreadyActed,
+    actedCriticalBattery: critical
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
+    LOW_BATTERY_WARN_PERCENT: LOW_BATTERY_WARN_PERCENT,
+    LOW_BATTERY_ACTION_PERCENT: LOW_BATTERY_ACTION_PERCENT,
     batteryPercentage: batteryPercentage,
     isDischarging: isDischarging,
-    shouldWarnLowBattery: shouldWarnLowBattery
+    shouldWarnLowBattery: shouldWarnLowBattery,
+    shouldActCriticalBattery: shouldActCriticalBattery
   }
 }

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.UPower
+import "../../panels/power/Model.js" as PowerModel
 import "BatteryModel.js" as BatteryModel
 
 Item {
@@ -10,27 +11,62 @@ Item {
   property var shell: null
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
 
-  readonly property int batteryThreshold: 10
+  readonly property var powerDevices: UPower.devices ? UPower.devices.values : []
   property string pendingPowerSource: ""
 
   PersistentProperties {
     id: persisted
     reloadableId: "omarchy-battery"
     property bool notifiedLowBattery: false
+    property bool actedCriticalBattery: false
+    property string previousEnergy: ""
+    property string previousSize: ""
+    property string previousRate: ""
+    property string previousState: ""
+    property string previousSampleMs: "0"
   }
 
-  function batteryPercentage() {
-    return BatteryModel.batteryPercentage(UPower.displayDevice)
+  function upowerStates() {
+    return {
+      Charging: UPowerDeviceState.Charging,
+      Discharging: UPowerDeviceState.Discharging,
+      FullyCharged: UPowerDeviceState.FullyCharged,
+      PendingCharge: UPowerDeviceState.PendingCharge
+    }
   }
 
-  function isDischarging() {
-    return BatteryModel.isDischarging(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging)
+  function previousSample() {
+    if (!persisted.previousEnergy) return {}
+    return {
+      energy: persisted.previousEnergy,
+      size: persisted.previousSize,
+      rate: persisted.previousRate,
+      state: persisted.previousState,
+      _sampleMs: persisted.previousSampleMs
+    }
+  }
+
+  function rememberSample(sample) {
+    var next = sample || {}
+    persisted.previousEnergy = String(next.energy || "")
+    persisted.previousSize = String(next.size || "")
+    persisted.previousRate = String(next.rate || "")
+    persisted.previousState = String(next.state || "")
+    persisted.previousSampleMs = String(next._sampleMs || "0")
   }
 
   function checkBattery() {
-    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
-    persisted.notifiedLowBattery = state.notifiedLowBattery
-    if (state.notify) sendLowBatteryWarning(state.level)
+    var snap = PowerModel.liveEnergySnapshot(root.powerDevices, null, previousSample(), Date.now(), upowerStates())
+    rememberSample(snap.sample)
+
+    var discharging = !!(UPower.onBattery && snap.discharging)
+    var warn = BatteryModel.shouldWarnLowBattery(snap.fraction, UPower.onBattery, discharging, persisted.notifiedLowBattery)
+    persisted.notifiedLowBattery = warn.notifiedLowBattery
+    if (warn.notify) sendLowBatteryWarning(warn.level)
+
+    var act = BatteryModel.shouldActCriticalBattery(snap.fraction, UPower.onBattery, discharging, persisted.actedCriticalBattery)
+    persisted.actedCriticalBattery = act.actedCriticalBattery
+    if (act.act) sendCriticalAction(act.level)
   }
 
   function sendLowBatteryWarning(level) {
@@ -40,6 +76,15 @@ Item {
       String(level)
     ]
     warningProcess.running = true
+  }
+
+  function sendCriticalAction(level) {
+    if (criticalProcess.running) return
+    criticalProcess.command = [
+      "omarchy-battery-critical",
+      String(level)
+    ]
+    criticalProcess.running = true
   }
 
   function applyPowerProfile() {
@@ -54,6 +99,7 @@ Item {
   }
 
   Process { id: warningProcess }
+  Process { id: criticalProcess }
 
   Process {
     id: powerProfileProcess
@@ -71,6 +117,10 @@ Item {
   Connections {
     target: UPower
     function onOnBatteryChanged() {
+      if (!UPower.onBattery) {
+        persisted.notifiedLowBattery = false
+        persisted.actedCriticalBattery = false
+      }
       root.checkBattery()
       root.applyPowerProfile()
     }

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -109,6 +109,10 @@ grep -Fx $'state\tcharging' <<<"$shell_output" >/dev/null || fail "battery statu
 grep -Fx $'rate\t2.2W' <<<"$shell_output" >/dev/null || fail "battery status reports the live pack's power" "$shell_output"
 grep -Fx $'size\t20Wh' <<<"$shell_output" >/dev/null || fail "battery status reports live capacity, not dead+live energy-full" "$shell_output"
 grep -Fx $'time\t14m' <<<"$shell_output" >/dev/null || fail "battery status reports the live pack's time to full" "$shell_output"
+grep -Fx $'pack.0.path\tBAT1' <<<"$shell_output" >/dev/null || fail "battery status names the live pack for the panel" "$shell_output"
+if grep -F $'pack.1.path' <<<"$shell_output" >/dev/null; then
+  fail "battery status does not name a dead pack" "$shell_output"
+fi
 
 pass "battery status ignores a present-but-dead pack"
 

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -38,11 +38,11 @@ chmod +x "$tmp_dir/bin/upower"
 
 shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
 
-grep -Fx $'percentage\t51%' <<<"$shell_output" >/dev/null || fail "battery status reports percentage"
+grep -Fx $'percentage\t50%' <<<"$shell_output" >/dev/null || fail "battery status reports energy-based percentage" "$shell_output"
 grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery status reports state"
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
-grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
-grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'size\t56.7Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity" "$shell_output"
+grep -Fx $'time\t2h 37m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time from Wh/W" "$shell_output"
 
 pass "battery status reports a single live pack"
 
@@ -60,6 +60,8 @@ printf '1\n' >"$tmp_dir/power/AC/online"
 printf '2169000\n' >"$tmp_dir/power/BAT1/power_now"
 printf '12257000\n' >"$tmp_dir/power/BAT1/voltage_now"
 printf '20430000\n' >"$tmp_dir/power/BAT1/energy_now"
+printf '100\n' >"$tmp_dir/power/BAT1/charge_control_end_threshold"
+printf '0\n' >"$tmp_dir/power/BAT1/charge_control_start_threshold"
 cat >"$tmp_dir/bin/upower" <<'STUB'
 #!/bin/bash
 
@@ -107,14 +109,25 @@ shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PA
 grep -Fx $'percentage\t98%' <<<"$shell_output" >/dev/null || fail "battery status ignores a dead first pack" "$shell_output"
 grep -Fx $'state\tcharging' <<<"$shell_output" >/dev/null || fail "battery status does not treat a dead pending-charge pack as holding" "$shell_output"
 grep -Fx $'rate\t2.2W' <<<"$shell_output" >/dev/null || fail "battery status reports the live pack's power" "$shell_output"
-grep -Fx $'size\t20Wh' <<<"$shell_output" >/dev/null || fail "battery status reports live capacity, not dead+live energy-full" "$shell_output"
+grep -Fx $'size\t20.9Wh' <<<"$shell_output" >/dev/null || fail "battery status reports live capacity, not dead+live energy-full" "$shell_output"
 grep -Fx $'time\t14m' <<<"$shell_output" >/dev/null || fail "battery status reports the live pack's time to full" "$shell_output"
 grep -Fx $'pack.0.path\tBAT1' <<<"$shell_output" >/dev/null || fail "battery status names the live pack for the panel" "$shell_output"
 if grep -F $'pack.1.path' <<<"$shell_output" >/dev/null; then
   fail "battery status does not name a dead pack" "$shell_output"
 fi
+if grep -F $'threshold' <<<"$shell_output" >/dev/null; then
+  fail "battery status omits a 0-100 kernel charge window" "$shell_output"
+fi
 
 pass "battery status ignores a present-but-dead pack"
+
+# Signed sysfs power_now while UPower says charging must still yield a time.
+printf -- '-2169000\n' >"$tmp_dir/power/BAT1/power_now"
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'state\tcharging' <<<"$shell_output" >/dev/null || fail "signed charging rate keeps charging state" "$shell_output"
+grep -Fx $'rate\t2.2W' <<<"$shell_output" >/dev/null || fail "signed charging rate is displayed absolute" "$shell_output"
+grep -Fx $'time\t14m' <<<"$shell_output" >/dev/null || fail "signed charging rate still estimates time to full" "$shell_output"
+pass "battery status estimates time from signed charging watts"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -44,6 +44,74 @@ grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status re
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
 
+pass "battery status reports a single live pack"
+
+# Dual-battery ThinkPad with a present-but-dead internal pack (0 V / 0 Wh)
+# enumerated first. DisplayDevice would report ~49% because it still counts
+# BAT0's energy-full; the CLI must follow the live slice instead.
+rm -rf "$tmp_dir"
+tmp_dir=$(mktemp -d)
+mkdir -p "$tmp_dir/bin" "$tmp_dir/power/BAT0" "$tmp_dir/power/BAT1" "$tmp_dir/power/AC"
+printf '0\n' >"$tmp_dir/power/BAT0/voltage_now"
+printf '0\n' >"$tmp_dir/power/BAT0/power_now"
+printf '0\n' >"$tmp_dir/power/BAT0/energy_now"
+printf 'Mains\n' >"$tmp_dir/power/AC/type"
+printf '1\n' >"$tmp_dir/power/AC/online"
+printf '2169000\n' >"$tmp_dir/power/BAT1/power_now"
+printf '12257000\n' >"$tmp_dir/power/BAT1/voltage_now"
+printf '20430000\n' >"$tmp_dir/power/BAT1/energy_now"
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT0 ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                pending-charge
+  energy:               0 Wh
+  energy-full:          20.65 Wh
+  energy-rate:          0 W
+  percentage:           0%
+  charge-start-threshold:        75%
+  charge-end-threshold:          80%
+INFO
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT1 ]]; then
+  cat <<'INFO'
+  native-path:          BAT1
+  state:                charging
+  energy:               20.43 Wh
+  energy-full:          20.94 Wh
+  energy-rate:          2.17 W
+  time to full:         14.1 minutes
+  percentage:           98%
+  charge-start-threshold:        75%
+  charge-end-threshold:          80%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t98%' <<<"$shell_output" >/dev/null || fail "battery status ignores a dead first pack" "$shell_output"
+grep -Fx $'state\tcharging' <<<"$shell_output" >/dev/null || fail "battery status does not treat a dead pending-charge pack as holding" "$shell_output"
+grep -Fx $'rate\t2.2W' <<<"$shell_output" >/dev/null || fail "battery status reports the live pack's power" "$shell_output"
+grep -Fx $'size\t20Wh' <<<"$shell_output" >/dev/null || fail "battery status reports live capacity, not dead+live energy-full" "$shell_output"
+grep -Fx $'time\t14m' <<<"$shell_output" >/dev/null || fail "battery status reports the live pack's time to full" "$shell_output"
+
+pass "battery status ignores a present-but-dead pack"
+
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"
 fi

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -5,27 +5,111 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const battery = requireFromRoot('shell/plugins/services/battery/BatteryModel.js')
+const power = requireFromRoot('shell/plugins/panels/power/Model.js')
+const serviceSource = fs.readFileSync(root + '/shell/plugins/services/battery/Service.qml', 'utf8')
+const criticalSource = fs.readFileSync(root + '/bin/omarchy-battery-critical', 'utf8')
+const states = { Charging: 1, Discharging: 2, FullyCharged: 3, PendingCharge: 4 }
 const discharging = 1
 
+assertEqual(battery.LOW_BATTERY_WARN_PERCENT, 10, 'battery warn mark stays 10%')
+assertEqual(battery.LOW_BATTERY_ACTION_PERCENT, 2, 'battery action mark stays 2%')
 assertEqual(battery.batteryPercentage({ isPresent: true, percentage: 0.126 }), 13, 'battery rounds display percentage')
 assertEqual(battery.batteryPercentage({ isPresent: false, percentage: 0.5 }), -1, 'battery reports missing battery')
 assert(battery.isDischarging({ isPresent: true, state: discharging }, true, discharging), 'battery detects discharging state')
 assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, discharging), 'battery requires on-battery state')
 
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
+  battery.shouldWarnLowBattery(0.08, true, true, false),
   { level: 8, notify: true, notifiedLowBattery: true },
-  'battery warns once under threshold'
+  'battery warns once under live 10%'
 )
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true),
+  battery.shouldWarnLowBattery(0.08, true, true, true),
   { level: 8, notify: false, notifiedLowBattery: true },
   'battery keeps low-battery notified state'
 )
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, true),
+  battery.shouldWarnLowBattery(0.4, true, true, true),
   { level: 40, notify: false, notifiedLowBattery: false },
-  'battery clears notified state after recovery'
+  'battery clears notified state after live recovery'
 )
+assertDeepEqual(
+  battery.shouldWarnLowBattery(0.05, false, true, false),
+  { level: 5, notify: false, notifiedLowBattery: false },
+  'battery does not warn on AC'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery(0.05, true, false, false),
+  { level: 5, notify: false, notifiedLowBattery: false },
+  'battery does not warn while charging'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery(-1, true, true, false),
+  { level: -1, notify: false, notifiedLowBattery: false },
+  'battery does not warn without a live fraction'
+)
+
+assertDeepEqual(
+  battery.shouldActCriticalBattery(0.02, true, true, false),
+  { level: 2, act: true, actedCriticalBattery: true },
+  'battery acts at live 2% while discharging on battery'
+)
+assertDeepEqual(
+  battery.shouldActCriticalBattery(0.10, true, true, false),
+  { level: 10, act: false, actedCriticalBattery: false },
+  'battery does not act at the 10% warn mark'
+)
+assertDeepEqual(
+  battery.shouldActCriticalBattery(0.01, false, true, false),
+  { level: 1, act: false, actedCriticalBattery: false },
+  'battery does not act on AC'
+)
+assertDeepEqual(
+  battery.shouldActCriticalBattery(0.01, true, true, true),
+  { level: 1, act: false, actedCriticalBattery: true },
+  'battery acts only once at critical'
+)
+
+const dead = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', energy: 0, energyCapacity: 23.2, changeRate: 0, percentage: 0, voltage: 0, state: states.PendingCharge }
+const live = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT1', energy: 8.4, energyCapacity: 20.94, changeRate: -8, percentage: 0.4, voltage: 11.2, state: states.Discharging }
+const liveFraction = power.combinedEnergyFraction([dead, live])
+assert(liveFraction > 0.39 && liveFraction < 0.41, 'live remaining energy ignores a present-but-dead pack')
+assertDeepEqual(
+  battery.shouldWarnLowBattery(liveFraction, true, true, false),
+  { level: 40, notify: false, notifiedLowBattery: false },
+  'dead pack cannot pull warn to empty while the live pack is above 10%'
+)
+assertDeepEqual(
+  battery.shouldActCriticalBattery(liveFraction, true, true, false),
+  { level: 40, act: false, actedCriticalBattery: false },
+  'dead pack cannot pull critical action while the live pack is above 2%'
+)
+
+const first = power.applyEnergySample({}, { energy: '8.4Wh', size: '20.94Wh', rate: '8W', state: 'discharging' }, 1e6)
+const cliffed = power.applyEnergySample(first, { energy: '1.3Wh', size: '20.94Wh', rate: '8W', state: 'discharging' }, 1e6 + 60 * 1000)
+assert(Math.abs(power.parseWh(cliffed.energy) - 8.4) < 0.05, 'EC cliff 8.4→1.3 Wh in 60s at 8W keeps ~8.4 Wh')
+const cliffFraction = power.combinedFractionFromStatus(cliffed)
+assert(cliffFraction > 0.10, 'rejected cliff stays above the 10% warn mark')
+assertEqual(battery.shouldWarnLowBattery(cliffFraction, true, true, false).notify, false, 'EC cliff must not notify')
+assertEqual(battery.shouldActCriticalBattery(cliffFraction, true, true, false).act, false, 'EC cliff must not sleep')
+
+const snap = power.liveEnergySnapshot(
+  [dead, { isPresent: true, isLaptopBattery: true, nativePath: 'BAT1', energy: 1.3, energyCapacity: 20.94, changeRate: -8, percentage: 0.06, voltage: 10.6, state: states.Discharging }],
+  null,
+  first,
+  1e6 + 60 * 1000,
+  states
+)
+assert(Math.abs(snap.fraction - cliffFraction) < 0.02, 'liveEnergySnapshot applies the same cliff reject')
+assertEqual(snap.discharging, true, 'liveEnergySnapshot reports discharging from pack state')
+
+assert(!/UPower\.displayDevice/.test(serviceSource), 'battery service does not gate on DisplayDevice')
+assert(/PowerModel\.liveEnergySnapshot/.test(serviceSource), 'battery service snapshots live remaining energy')
+assert(/BatteryModel\.shouldWarnLowBattery/.test(serviceSource), 'battery service warns from live remaining energy')
+assert(/BatteryModel\.shouldActCriticalBattery/.test(serviceSource), 'battery service acts from live remaining energy')
+assert(/omarchy-battery-critical/.test(serviceSource), 'battery service wires the 2% critical command')
+assert(/suspend-then-hibernate/.test(criticalSource), 'critical command requests suspend-then-hibernate')
+assert(/omarchy:hidden=true/.test(criticalSource), 'critical command is hidden')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -29,11 +29,20 @@ assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: s
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 20 * 3600 }, false, states), 'power does not treat a long charge as a hold')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
 
-const dead = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', energy: 0, energyCapacity: 20.65, changeRate: 0, percentage: 0, state: states.PendingCharge }
+const dead = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', energy: 0, energyCapacity: 20.65, changeRate: 0, percentage: 0, voltage: 0, state: states.PendingCharge }
+const emptyLive = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', energy: 0, energyCapacity: 23.2, changeRate: 0, percentage: 0, voltage: 11.1, state: states.PendingCharge }
 const live = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT1', energy: 20.43, energyCapacity: 20.94, changeRate: 2.17, percentage: 0.98, state: states.Charging }
 const display = { isPresent: true, nativePath: '', energy: 20.43, energyCapacity: 41.59, changeRate: 2.17, percentage: 0.49, state: states.Charging }
 const packs = [dead, live, display]
+assert(!power.isLivePack(dead), 'power treats a 0 V pack as dead')
+assert(power.isLivePack(emptyLive), 'power treats a 0% pack with voltage as live')
 assertDeepEqual(power.liveLaptopDevices(packs).map((p) => p.nativePath), ['BAT1'], 'power skips a present-but-dead pack')
+assertDeepEqual(power.liveLaptopDevices([emptyLive, live, display]).map((p) => p.nativePath), ['BAT0', 'BAT1'], 'power keeps a healthy empty pack beside a live one')
+assertDeepEqual(
+  power.liveLaptopDevices([dead, live], { 'pack.0.path': 'BAT0', 'pack.1.path': 'BAT1' }).map((p) => p.nativePath),
+  ['BAT0', 'BAT1'],
+  'power follows CLI-selected pack ids when voltage is missing'
+)
 assertEqual(power.combinedEnergyFraction(packs), 0.98, 'power fill level follows the live pack, not DisplayDevice')
 assert(!power.chargeThresholdActiveForPacks(packs, false, states, { state: 'holding' }), 'power does not hold while a live pack is charging')
 assertEqual(power.viewDevice(packs, display, states).percentage, 0.98, 'power icon uses the live pack percentage')
@@ -58,6 +67,6 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
-assert(/liveLaptopDevices/.test(panelSource), 'power panel reads live packs instead of DisplayDevice alone')
+assert(/liveLaptopDevices\(powerDevices, opened \? batteryInfo : null\)/.test(panelSource), 'power panel reads live packs instead of DisplayDevice alone')
 assert(/chargeThresholdActiveForPacks/.test(panelSource), 'power panel uses the multi-pack hold detector')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -26,7 +26,17 @@ assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'pow
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 20 * 3600 }, false, states), 'power does not treat a long charge as a hold')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
+
+const dead = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT0', energy: 0, energyCapacity: 20.65, changeRate: 0, percentage: 0, state: states.PendingCharge }
+const live = { isPresent: true, isLaptopBattery: true, nativePath: 'BAT1', energy: 20.43, energyCapacity: 20.94, changeRate: 2.17, percentage: 0.98, state: states.Charging }
+const display = { isPresent: true, nativePath: '', energy: 20.43, energyCapacity: 41.59, changeRate: 2.17, percentage: 0.49, state: states.Charging }
+const packs = [dead, live, display]
+assertDeepEqual(power.liveLaptopDevices(packs).map((p) => p.nativePath), ['BAT1'], 'power skips a present-but-dead pack')
+assertEqual(power.combinedEnergyFraction(packs), 0.98, 'power fill level follows the live pack, not DisplayDevice')
+assert(!power.chargeThresholdActiveForPacks(packs, false, states, { state: 'holding' }), 'power does not hold while a live pack is charging')
+assertEqual(power.viewDevice(packs, display, states).percentage, 0.98, 'power icon uses the live pack percentage')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
@@ -48,4 +58,6 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(/liveLaptopDevices/.test(panelSource), 'power panel reads live packs instead of DisplayDevice alone')
+assert(/chargeThresholdActiveForPacks/.test(panelSource), 'power panel uses the multi-pack hold detector')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -43,9 +43,9 @@ assertDeepEqual(
   ['BAT0', 'BAT1'],
   'power follows CLI-selected pack ids when voltage is missing'
 )
-assertEqual(power.combinedEnergyFraction(packs), 0.98, 'power fill level follows the live pack, not DisplayDevice')
+assertEqual(power.combinedEnergyFraction(packs), 20.43 / 20.94, 'power fill level follows live energy, not DisplayDevice')
 assert(!power.chargeThresholdActiveForPacks(packs, false, states, { state: 'holding' }), 'power does not hold while a live pack is charging')
-assertEqual(power.viewDevice(packs, display, states).percentage, 0.98, 'power icon uses the live pack percentage')
+assertEqual(power.viewDevice(packs, display, states).percentage, 20.43 / 20.94, 'power icon uses live energy fraction')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
@@ -69,4 +69,5 @@ assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentag
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
 assert(/liveLaptopDevices\(powerDevices, opened \? batteryInfo : null\)/.test(panelSource), 'power panel reads live packs instead of DisplayDevice alone')
 assert(/chargeThresholdActiveForPacks/.test(panelSource), 'power panel uses the multi-pack hold detector')
+assert(!/UPower\.displayDevice/.test(panelSource.split('batteryFraction')[1].split('readonly property bool charging')[0]), 'power fill does not fall back to DisplayDevice')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -43,6 +43,16 @@ assertDeepEqual(
   ['BAT0', 'BAT1'],
   'power follows CLI-selected pack ids when voltage is missing'
 )
+assertEqual(power.packPathKey('/sys/class/power_supply/BAT1'), 'BAT1', 'power pack path key is the native-path basename')
+assert(power.pathsMatch('/sys/class/power_supply/BAT1', 'BAT1'), 'power matches a sysfs nativePath to a CLI BAT id')
+assert(!power.pathsMatch('BAT0', 'BAT1'), 'power does not match distinct pack ids')
+const deadSys = Object.assign({}, dead, { nativePath: '/sys/class/power_supply/BAT0' })
+const liveSys = Object.assign({}, live, { nativePath: '/sys/class/power_supply/BAT1' })
+assertDeepEqual(
+  power.liveLaptopDevices([deadSys, liveSys], { 'pack.0.path': 'BAT1' }).map((p) => p.nativePath),
+  ['/sys/class/power_supply/BAT1'],
+  'power matches CLI pack ids to UPower nativePath suffixes'
+)
 assertEqual(power.combinedEnergyFraction(packs), 20.43 / 20.94, 'power fill level follows live energy, not DisplayDevice')
 assert(!power.chargeThresholdActiveForPacks(packs, false, states, { state: 'holding' }), 'power does not hold while a live pack is charging')
 assertEqual(power.viewDevice(packs, display, states).percentage, 20.43 / 20.94, 'power icon uses live energy fraction')

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -78,6 +78,15 @@ assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
 assert(/liveLaptopDevices\(powerDevices, opened \? batteryInfo : null\)/.test(panelSource), 'power panel reads live packs instead of DisplayDevice alone')
+
+const firstSample = power.applyEnergySample({}, { energy: '8.4Wh', size: '20.94Wh', rate: '8W', state: 'discharging' }, 1000)
+const cliffSample = power.applyEnergySample(firstSample, { energy: '1.3Wh', size: '20.94Wh', rate: '8W', state: 'discharging' }, 61000)
+assert(Math.abs(power.parseWh(cliffSample.energy) - 8.4) < 0.05, 'power rejects an EC fuel-gauge cliff that beats measured watts')
+assertEqual(
+  power.applyEnergySample(firstSample, { energy: '1.3Wh', size: '20.94Wh', rate: '8W', state: 'charging' }, 61000).energy,
+  '1.3Wh',
+  'power allows an energy drop across a charge/discharge flip'
+)
 assert(/chargeThresholdActiveForPacks/.test(panelSource), 'power panel uses the multi-pack hold detector')
 assert(!/UPower\.displayDevice/.test(panelSource.split('batteryFraction')[1].split('readonly property bool charging')[0]), 'power fill does not fall back to DisplayDevice')
 JS


### PR DESCRIPTION
Depends on #7917. **Draft until that lands** — rebase onto `quattro` after merge. Unique work is the commit after `Match CLI pack ids to UPower nativePath suffixes`.

Fixes the other half of the dual-battery ThinkPad failure: the bar can show a live pack at ~40% while UPower Auto still `suspend-then-hibernate`s because `DisplayDevice` / the EC fuel gauge cliffed to ~3%.

On a T460 with a present-but-dead internal pack, BAT1 dropped **40% → 6% in 60 seconds** at ~8 W (physically ~1%). `upowerd` then requested suspend-then-hibernate. The machine never resumed (`e1000e Failed to disable ULP`); a tap on the power button does nothing in that S3.

#7917 already skips dead packs for the widget and `omarchy-battery-status`. This PR points the **warning and the 2% action** at the same live watt-hour remainder, and stops UPower from racing it.

### Behavior
- Warn at **10%** and act at **2%** only while discharging on battery, using live remaining energy (dead packs skipped; EC cliffs that beat measured watts rejected).
- A 40% → 6% cliff at ~8 W must not notify or sleep.
- A present-but-dead pack cannot pull either decision to empty while a live pack is above those marks.
- `omarchy.battery` no longer reads `UPower.displayDevice`.
- Hidden `omarchy-battery-critical` runs `systemctl suspend-then-hibernate` (falls back to `suspend`). Hibernate is still optional; the contract is “do not act before live 2%”.
- Migration sets `CriticalPowerAction=Ignore` (and `AllowRiskyCriticalPowerAction=true`) so UPower Auto cannot suspend on the EC percentage. The shell owns the 2% path after login.

### Tests
- `test/shell.d/battery-test.sh` — live 10% warn, live 2% act, dead-pack skip, 8.4→1.3 Wh / 60 s / 8 W cliff, Service.qml wiring.
- `test/shell.d/power-test.sh` — same cliff reject on `applyEnergySample`.

`bash test/shell.d/battery-test.sh` and `bash test/shell.d/power-test.sh` are green.

Verified on a ThinkPad T460 (dead BAT0, live BAT1): the local clone of this path is what now owns warn/act; UPower reports `critical-action: Ignore`.