### PR TITLE
Make the tray the bar's organizer: drag any widget in, around, and out

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -80,7 +80,7 @@ If you'd rather they were always visible, set `alwaysShow` to `true` on the widg
 
 The bar configures itself. You don't have to open a config file to move things.
 
-Grab an empty patch of the bar around the center and drag it toward another screen edge, and the bar moves there — left, right, top, or bottom all work, and every widget adapts (vertical bars fall back to compact icon-only forms). A click-and-hold starts the same drag. Double-left-click that same empty space to toggle transparency. And drag any widget to reorder it or throw it into another section.
+Grab an empty patch of the bar around the center and drag it toward another screen edge, and the bar moves there — left, right, top, or bottom all work, and every widget adapts (vertical bars fall back to compact icon-only forms). A click-and-hold starts the same drag. Double-left-click that same empty space to toggle transparency. And drag any widget to reorder it or throw it into another section. The system tray is a drop target too: release a widget over it and it moves inside the tray's slide-out drawer, where it keeps working exactly as before — drag it back out whenever you want it on the bar full-time. To move the tray itself, drag its expander arrow.
 
 If you'd rather pick from a menu, **Style → Menu Bar** has both position and transparency.
 

--- a/manual/42-common-tweaks.md
+++ b/manual/42-common-tweaks.md
@@ -4,9 +4,9 @@ This is a collection of common tailorings to the Omarchy setup. Know that it mig
 
 If you screw something up, you can restore individual configs to their original setup via _Update > Config_ in the Omarchy menu. If you _really_ screw everything up, you can reset all configs via `omarchy-reinstall`.
 
-### Reveal all tray icons all the time
+### Hide or rearrange tray icons
 
-By default, tray icons, like Dropbox, 1password, or Steam, are hidden behind the tray expander arrow, which reveals them when you hover it. If you'd like to have them exposed all the time, right-click the expander arrow to open the tray icon manager, then pin the icons you want to keep visible (you can also hide the ones you never want to see).
+By default, tray icons, like Dropbox, 1password, or Steam, sit behind the tray expander arrow, which reveals them when you hover it. Drag an icon within the open drawer to rearrange it. Right-click the expander arrow to open the tray manager: the Show System Icons switch hides or reveals them all at once, and each icon's row toggles just that one. You can also drag any bar widget onto the tray to store it in the drawer, and drag it back out whenever you want it on the bar full-time.
 
 ### Rounded window corners
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1092,6 +1092,7 @@ Item {
           id: tooltipLabel
           anchors.centerIn: parent
           text: root.tooltipText
+          textFormat: Text.PlainText
           color: Color.tooltip.text
           font.family: root.fontFamily
           font.pixelSize: Style.font.body

--- a/shell/plugins/bar/widgets/Tray.manifest.json
+++ b/shell/plugins/bar/widgets/Tray.manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "omarchy.tray",
   "name": "System tray",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "Omarchy",
-  "description": "Status notifier items",
+  "description": "Status notifier items, plus any bar widgets you drag into the drawer",
   "kinds": [
     "bar-widget"
   ],
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "System tray",
-    "description": "Status notifier items",
+    "description": "Status notifier items, plus any bar widgets you drag into the drawer",
     "category": "Status",
     "allowMultiple": false
   },

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -1,4 +1,5 @@
 import Quickshell
+import Quickshell.Io
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Effects
@@ -7,43 +8,674 @@ import qs.Commons
 import qs.Ui
 import "TrayModel.js" as TrayModel
 
+// The system tray: status notifier icons behind a slide-out drawer, with
+// in-popup app menus — and the bar's organizer. Any bar widget (clock,
+// workspaces, weather, panels, custom modules, plugins...) can be dragged
+// onto the tray to live inside the drawer, reordered in one mixed sequence
+// with the tray icons, and dragged back out to any spot on the bar. Captured
+// widgets keep their settings, clicks, tooltips, and panels. Icons can be
+// hidden (individually or all at once) from the right-click manage popup.
 BarWidget {
   id: root
   moduleName: "omarchy.tray"
 
-  property bool expanded: false
+  // Hover-to-expand, driven by the drag-out overlay's single HoverHandler:
+  // two stacked hover items (the overlay plus a handler in the drawer) fight
+  // over hover and oscillate the reveal, so the overlay is the one authority.
+  // While another widget's panel is open, its focus grab swallows hover
+  // entirely, so the drawer cannot open by pointing at it — but clicks still
+  // arrive, so a deliberate chevron click holds it open (clickExpanded) until
+  // that panel closes.
+  property bool expanded: clickExpanded || (overlayHover.hovered && !exteriorPopoutOpen)
+  readonly property bool exteriorPopoutOpen: root.bar && root.bar.activePopout ? !ownPopoutActive : false
+  property bool clickExpanded: false
+  onExteriorPopoutOpenChanged: if (!exteriorPopoutOpen) clickExpanded = false
+
+  function closeExteriorPopout() {
+    var popout = root.bar ? root.bar.activePopout : null
+    if (popout && popout !== root && typeof popout.close === "function") popout.close()
+  }
   property bool managePopupOpen: false
   property bool trayMenuOpen: false
   property var activeTrayItem: null
   property var activeTrayAnchor: null
   readonly property color foreground: bar ? bar.foreground : Color.foreground
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
-  readonly property var pinnedIds: settings.pinned instanceof Array ? settings.pinned : []
-  readonly property var hiddenIds: settings.hidden instanceof Array ? settings.hidden : []
-  readonly property var pinnedItems: bucket("pinned")
+  readonly property var hiddenIds: TrayModel.asList(settings.hidden).map(String)
+  // Master switch for status-notifier icons: off removes them all from the
+  // drawer (they stay listed in the manage popup for when it comes back on).
+  readonly property bool showTrayIcons: settings.showTrayIcons !== false
+  // One user-arranged order across BOTH kinds of drawer content: hosted
+  // widget ids and status-notifier item ids share the token list, so icons
+  // and plugin widgets interleave freely. Missing tokens keep arrival order
+  // after the arranged ones.
+  readonly property var orderIds: TrayModel.asList(settings.order).map(String)
   readonly property var drawerItems: bucket("drawer")
   readonly property var allItems: bucket("all")
   readonly property int drawerCount: drawerItems.length
   readonly property int trayItemExtent: Style.bar.iconSlot
-  readonly property int trayItemGap: 0
-  readonly property int trayJoinGap: 0
-  readonly property int drawerExtent: drawerCount > 0 ? drawerCount * trayItemExtent + (drawerCount - 1) * trayItemGap : 0
+
+  // Bar widgets captured into the drawer. Stored on this widget's own
+  // shell.json entry so they survive restarts and sync across monitors.
+  readonly property var hostedWrappers: TrayModel.normalizeWrappers(settings.widgets)
+
+  // The drawer's single mixed model: hosted widgets and tray icons in one
+  // ordered sequence.
+  readonly property var drawerEntries: {
+    var entries = []
+    for (var i = 0; i < hostedWrappers.length; i++) {
+      entries.push({ kind: "widget", key: TrayModel.wrapperId(hostedWrappers[i]), data: hostedWrappers[i] })
+    }
+    for (var j = 0; j < drawerItems.length; j++) {
+      entries.push({ kind: "icon", key: String(drawerItems[j].id || ""), data: drawerItems[j] })
+    }
+    return TrayModel.sortByOrder(entries, orderIds)
+  }
+  readonly property bool hasDrawerContent: drawerEntries.length > 0
+
+  // True while an open popup belongs to the tray or to a widget hosted in
+  // it: the bar's popout coordinator tracks the owning widget item, and
+  // panels register their widget root as owner. Holds the drawer open while
+  // a hosted widget's panel is up; it collapses when that panel closes
+  // (escape, click-away) or when a panel outside the tray takes over.
+  readonly property bool ownPopoutActive: {
+    var popout = root.bar ? root.bar.activePopout : null
+    if (!popout) return false
+    if (popout === root) return true
+    for (var i = 0; i < hostedDelegates.length; i++) {
+      var d = hostedDelegates[i]
+      if (d && (d === popout || d.activeItem === popout)) return true
+    }
+    return false
+  }
+
+  // ---------------------------------------------------------------------------
+  // Center-section fence. While the drawer is out it can overrun the bar's
+  // center widgets (always on a vertical bar, and on a horizontal one when
+  // the drawer is wide), so the whole center section is scrimmed and made
+  // inert for the duration. The scrim is two rectangles — the center span
+  // minus whatever part the tray itself covers — parented to the bar window
+  // above every section, so it dims center content without ever dimming the
+  // drawer. Geometry is refreshed on a timer while visible: the reveal
+  // animates and center widgets (the clock) resize on their own.
+  // ---------------------------------------------------------------------------
+
+  readonly property bool drawerOut: revealProgress > 0.02
+
+  // The center fence is a vertical-bar concern: there the drawer expands
+  // straight through the center section, so it dims in both bar modes — with
+  // the bar background when opaque, with a translucent dark tint when the
+  // bar is transparent (there is no background to dim against, but the
+  // wallpaper and center glyphs still recede). Horizontal bars leave the
+  // center alone: opaque needs no dimming, and transparent stays pristine.
+  readonly property bool barTransparent: root.bar ? root.bar.transparent === true : false
+
+  component ScrimBlock: Rectangle {
+    parent: root.QsWindow && root.QsWindow.window ? root.QsWindow.window.contentItem : root
+    z: 80
+    visible: root.drawerOut && root.vertical && parent !== root && width > 0.5 && height > 0.5
+    color: root.barTransparent ? "black" : (root.bar ? root.bar.background : Color.background)
+    opacity: (root.barTransparent ? 0.5 : 0.8) * root.revealProgress
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      acceptedButtons: Qt.AllButtons
+      onWheel: function(wheel) { wheel.accepted = true }
+    }
+  }
+
+  ScrimBlock { id: scrimBefore }
+  ScrimBlock { id: scrimAfter }
+
+  onDrawerOutChanged: if (drawerOut) updateCenterScrim()
+
+  Timer {
+    running: root.drawerOut
+    interval: 120
+    repeat: true
+    onTriggered: root.updateCenterScrim()
+  }
+
+  function updateCenterScrim() {
+    var win = root.QsWindow ? root.QsWindow.window : null
+    var b = root.bar
+    if (!win || !win.contentItem || !b || !b.moduleSlots) {
+      scrimBefore.width = 0
+      scrimAfter.width = 0
+      return
+    }
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    var found = false
+    for (var i = 0; i < b.moduleSlots.length; i++) {
+      var slot = b.moduleSlots[i]
+      if (!slot || slot.region !== "center" || !slot.visible || slot.width <= 0 || slot.height <= 0) continue
+      if (typeof b.slotWindow === "function" && b.slotWindow(slot) !== win) continue
+      var p
+      try {
+        p = slot.mapToItem(win.contentItem, 0, 0)
+      } catch (e) {
+        continue
+      }
+      minX = Math.min(minX, p.x); minY = Math.min(minY, p.y)
+      maxX = Math.max(maxX, p.x + slot.width); maxY = Math.max(maxY, p.y + slot.height)
+      found = true
+    }
+    if (!found) {
+      scrimBefore.width = 0
+      scrimAfter.width = 0
+      return
+    }
+    var trayPos
+    try {
+      trayPos = root.mapToItem(win.contentItem, 0, 0)
+    } catch (e) {
+      scrimBefore.width = 0
+      scrimAfter.width = 0
+      return
+    }
+    if (root.vertical) {
+      var cut0 = Math.max(minY, Math.min(maxY, trayPos.y))
+      var cut1 = Math.max(minY, Math.min(maxY, trayPos.y + root.height))
+      scrimBefore.x = minX; scrimBefore.width = maxX - minX
+      scrimBefore.y = minY; scrimBefore.height = Math.max(0, cut0 - minY)
+      scrimAfter.x = minX; scrimAfter.width = maxX - minX
+      scrimAfter.y = cut1; scrimAfter.height = Math.max(0, maxY - cut1)
+    } else {
+      var cx0 = Math.max(minX, Math.min(maxX, trayPos.x))
+      var cx1 = Math.max(minX, Math.min(maxX, trayPos.x + root.width))
+      scrimBefore.y = minY; scrimBefore.height = maxY - minY
+      scrimBefore.x = minX; scrimBefore.width = Math.max(0, cx0 - minX)
+      scrimAfter.y = minY; scrimAfter.height = maxY - minY
+      scrimAfter.x = cx1; scrimAfter.width = Math.max(0, maxX - cx1)
+    }
+  }
+
   // Match Waybar's group/tray-expander drawer transition-duration.
   readonly property int animationDuration: 600
-  property real revealProgress: expanded ? 1 : 0
-  readonly property real revealExtent: drawerExtent * revealProgress
+  property real revealProgress: (expanded || dragOver || ownPopoutActive) ? 1 : 0
 
+  Behavior on revealProgress {
+    NumberAnimation { duration: root.animationDuration; easing.type: Easing.OutCubic }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Drag-into-tray. The bar host tracks every widget drag globally
+  // (barDragSource + barDragSceneX/Y). Watch that state: while a drag from
+  // another widget hovers over this tray, highlight and hold the drawer open;
+  // when it is released here, capture the widget into the drawer.
+  // ---------------------------------------------------------------------------
+
+  readonly property bool dragActive: root.bar ? dragEligible(root.bar.barDragSource) : false
+  property bool dragOver: false
+  property string dragSourceId: ""
+  // Insertion pick for a bar widget being dragged in: where among the drawer
+  // content it would land if released right now.
+  property var dragInPick: null
+  property bool markerGuard: false
+
+  // Imperative on purpose: the drag-start handler runs inside the very signal
+  // dispatch that dirtied the dragActive binding, and reading the binding
+  // there can return a stale false. Recomputing from the live properties is
+  // always current.
+  function dragEligible(slot) {
+    if (!slot || !root.bar) return false
+    if (String(slot.moduleName || "") === root.moduleName) return false
+    var win = root.QsWindow ? root.QsWindow.window : null
+    return !!win && root.bar.barDragWindow === win
+  }
+
+  function updateDragOver() {
+    if (!dragEligible(root.bar ? root.bar.barDragSource : null)) {
+      dragOver = false
+      return
+    }
+    var origin
+    try {
+      origin = root.mapToItem(null, 0, 0)
+    } catch (e) {
+      dragOver = false
+      return
+    }
+    var x = root.bar.barDragSceneX
+    var y = root.bar.barDragSceneY
+    dragOver = x >= origin.x && x <= origin.x + root.width
+      && y >= origin.y && y <= origin.y + root.height
+    dragInPick = dragOver ? drawerReorderPick(Qt.point(x, y), null) : null
+  }
+
+  Connections {
+    target: root.bar
+    ignoreUnknownSignals: true
+
+    function onBarDragSourceChanged() {
+      var slot = root.bar.barDragSource
+      if (slot) {
+        // Only the instance living in the drag's own bar window can win the
+        // drop; every other monitor's copy keeps an empty id and stays inert.
+        var eligible = root.dragEligible(slot)
+        root.dragSourceId = eligible ? String(slot.moduleName || "") : ""
+        root.updateDragOver()
+        return
+      }
+      // The drop. Defer the capture past the bar's own release handling: a
+      // synchronous config write here rebuilds the bar mid-gesture, which
+      // tears down the source slot's context while its release handler is
+      // still on the stack (ReferenceError in Bar.qml, and the release leaks
+      // to whatever sits under the cursor). The closure keeps only the shell
+      // reference and plain values, so it survives this widget's own
+      // destruction in the rebuild that the bar's adjacent-slot move causes.
+      var wanted = root.dragOver ? root.dragSourceId : ""
+      // Land the widget exactly where it was released: build the drawer's
+      // next order from the insertion edge tracked during the drag.
+      var nextOrder = null
+      if (wanted) {
+        var keys = root.drawerEntries.map(function(entry) { return entry.key })
+        var beforeKey = root.dragInPick ? String(root.dragInPick.beforeKey) : ""
+        var insertAt = beforeKey !== "" ? keys.indexOf(beforeKey) : -1
+        if (insertAt < 0) keys.push(wanted)
+        else keys.splice(insertAt, 0, wanted)
+        nextOrder = keys
+      }
+      root.dragOver = false
+      root.dragSourceId = ""
+      root.dragInPick = null
+      if (!wanted) return
+      var shellRef = root.bar ? root.bar.shell : null
+      var trayId = root.moduleName || "omarchy.tray"
+      if (!shellRef || typeof shellRef.mutateShellConfig !== "function") return
+      Qt.callLater(function() {
+        shellRef.mutateShellConfig(function(config) {
+          TrayModel.captureIntoTray(config, trayId, wanted, nextOrder)
+        })
+      })
+    }
+
+    // The bar recomputes its own drop marker every pointer move; while an
+    // eligible drag hovers the tray, repaint it as the drawer's insertion
+    // edge instead of the bar's adjacent-slot line. The guard stops the
+    // override from re-triggering itself.
+    function onBarDragTargetGeometryChanged() {
+      if (root.markerGuard || !root.dragOver || !root.bar) return
+      root.markerGuard = true
+      root.bar.barDragTargetGeometry = root.dragInPick
+        ? root.bar.dropMarkerRect(root.dragInPick.delegate, root.dragInPick.after)
+        : null
+      root.markerGuard = false
+    }
+
+    function onBarDragSceneXChanged() { root.updateDragOver() }
+    function onBarDragSceneYChanged() { root.updateDragOver() }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Drag-out-of-tray. A transparent overlay is parented into the bar's module
+  // slot ABOVE its whole-slot drag MouseArea, covering everything except the
+  // chevron. Dragging a hosted widget there drives the bar's own drag state
+  // (ghost, drop marker) through a stand-in slot, and the drop moves the
+  // widget's entry back into the bar layout at that position. Consequence:
+  // the chevron is the only handle that moves the tray itself.
+  // ---------------------------------------------------------------------------
+
+  // Extent of the chevron along the bar axis, exported by whichever
+  // orientation component is loaded. The drag-out overlay starts after it.
+  property real chevronExtent: 0
+
+  // Live HostedWidget delegates, for hit-testing which widget a press lands on.
+  property var hostedDelegates: []
+
+  function registerHostedDelegate(item) {
+    if (!item || hostedDelegates.indexOf(item) !== -1) return
+    var next = hostedDelegates.slice()
+    next.push(item)
+    hostedDelegates = next
+  }
+
+  function unregisterHostedDelegate(item) {
+    hostedDelegates = hostedDelegates.filter(function(d) { return d !== item })
+  }
+
+  // While anything is dragged over the tray, resolve the pointer to the
+  // nearest insertion edge among ALL other drawer content — hosted widgets
+  // and status-notifier icons share one order, so the two kinds interleave
+  // freely (same math as the bar's nearestDropTarget). Returns {delegate,
+  // after, beforeKey} where beforeKey is the order token to insert before
+  // ("" = move to the end), or null when there is nothing to reorder against.
+  function drawerReorderPick(scenePoint, dragged) {
+    var axis = root.vertical ? scenePoint.y : scenePoint.x
+    var candidates = hostedDelegates.concat(trayIconDelegates)
+    var bestDelegate = null
+    var bestAfter = false
+    var bestDist = Infinity
+    for (var i = 0; i < candidates.length; i++) {
+      var d = candidates[i]
+      if (!d || d === dragged || !d.visible || d.width <= 0 || d.height <= 0) continue
+      var origin
+      try {
+        origin = d.mapToItem(null, 0, 0)
+      } catch (e) {
+        continue
+      }
+      var start = root.vertical ? origin.y : origin.x
+      var size = root.vertical ? d.height : d.width
+      var beforeDist = Math.abs(axis - start)
+      var afterDist = Math.abs(axis - (start + size))
+      var after = afterDist < beforeDist
+      var dist = after ? afterDist : beforeDist
+      if (dist < bestDist) {
+        bestDist = dist
+        bestDelegate = d
+        bestAfter = after
+      }
+    }
+    if (!bestDelegate) return null
+
+    var draggedKey = dragged ? String(dragged.widgetId || dragged.itemId || "") : ""
+    var keys = drawerEntries.map(function(entry) { return entry.key })
+    var targetIndex = keys.indexOf(String(bestDelegate.widgetId || bestDelegate.itemId || ""))
+    if (targetIndex === -1) return null
+    var beforeKey
+    if (!bestAfter) {
+      beforeKey = keys[targetIndex]
+    } else {
+      beforeKey = ""
+      for (var j = targetIndex + 1; j < keys.length; j++) {
+        if (keys[j] !== draggedKey) { beforeKey = keys[j]; break }
+      }
+    }
+    return { delegate: bestDelegate, after: bestAfter, beforeKey: beforeKey }
+  }
+
+  function hostedDelegateAt(rootX, rootY) {
+    return delegateAt(hostedDelegates, rootX, rootY)
+  }
+
+  // Live TrayItem delegates (status-notifier icons), for hit-testing and
+  // in-tray reordering. Unlike hosted widgets, these can only ever be
+  // rearranged inside the tray — they have no life in the bar layout.
+  property var trayIconDelegates: []
+
+  function registerTrayIconDelegate(item) {
+    if (!item || trayIconDelegates.indexOf(item) !== -1) return
+    var next = trayIconDelegates.slice()
+    next.push(item)
+    trayIconDelegates = next
+  }
+
+  function unregisterTrayIconDelegate(item) {
+    trayIconDelegates = trayIconDelegates.filter(function(d) { return d !== item })
+  }
+
+  function trayIconDelegateAt(rootX, rootY) {
+    return delegateAt(trayIconDelegates, rootX, rootY)
+  }
+
+  function delegateAt(delegates, rootX, rootY) {
+    for (var i = 0; i < delegates.length; i++) {
+      var d = delegates[i]
+      if (!d || !d.visible || d.width <= 0 || d.height <= 0) continue
+      var p
+      try {
+        p = root.mapToItem(d, rootX, rootY)
+      } catch (e) {
+        continue
+      }
+      if (p.x >= 0 && p.x <= d.width && p.y >= 0 && p.y <= d.height) return d
+    }
+    return null
+  }
+
+  // Stand-in for a bar module slot, fed to the bar's drag plumbing while a
+  // hosted widget is dragged out. Provides exactly the properties the bar
+  // reads from a drag source: moduleName, region, and activeItem (for the
+  // ghost image and window resolution).
+  Item {
+    id: fakeDragSlot
+    visible: false
+    property string region: "tray"
+    property string moduleName: ""
+    property var activeItem: null
+  }
+
+  Item {
+    id: dragOutOverlay
+    // The slot stacks its own drag MouseArea above every widget it loads, so
+    // an overlay that must win the press has to live beside it in the slot,
+    // not inside this widget. Our root fills the slot, so root coordinates
+    // are slot coordinates. Covers the whole widget; presses in the chevron
+    // zone are rejected below so they fall through to the slot's MouseArea,
+    // making the chevron the tray's only whole-widget drag handle.
+    parent: root.parent && root.parent.parent ? root.parent.parent : root
+    z: 60
+    visible: root.visible && parent !== root
+    x: 0
+    y: 0
+    width: root.width
+    height: root.height
+
+    // The single hover authority for the tray (drives root.expanded) and the
+    // pointing-hand cursor over clickable content. Non-blocking, so hosted
+    // widgets' own hover styling and tooltips still work underneath.
+    HoverHandler {
+      id: overlayHover
+      onHoveredChanged: if (!hovered) root.clickExpanded = false
+      cursorShape: {
+        var slot = dragOutOverlay.parent
+        if (root && root.bar && slot !== root && typeof root.bar.moduleClickTargetAt === "function"
+            && root.bar.moduleClickTargetAt(slot,
+                 dragOutOverlay.x + overlayHover.point.position.x,
+                 dragOutOverlay.y + overlayHover.point.position.y))
+          return Qt.PointingHandCursor
+        return Qt.ArrowCursor
+      }
+    }
+
+    MouseArea {
+      id: dragOutMouse
+
+      property bool dragging: false
+      property bool suppressClick: false
+      property real pressedX: 0
+      property real pressedY: 0
+      property var dragDelegate: null
+      // A status-notifier icon being dragged. Icons reorder within the tray
+      // only; releasing outside the tray is a deliberate no-op.
+      property var dragIconDelegate: null
+      // Order token to insert before when released over the tray ("" = end);
+      // null while the pointer is off the tray or nothing can be reordered.
+      property var orderBeforeKey: null
+      readonly property bool canReorder: root.bar && root.bar.shell
+        && typeof root.bar.shell.mutateShellConfig === "function"
+      readonly property real dragThreshold: Style.space(4)
+
+      anchors.fill: parent
+      acceptedButtons: Qt.LeftButton
+      propagateComposedEvents: true
+
+      function rootPoint(mouse) {
+        return dragOutMouse.mapToItem(root, mouse.x, mouse.y)
+      }
+
+      function beginDragOut(mouse) {
+        var b = root.bar
+        var win = root.QsWindow ? root.QsWindow.window : null
+        var delegate = dragDelegate || dragIconDelegate
+        if (!b || !win || !delegate) return false
+        fakeDragSlot.moduleName = String(delegate.widgetId || delegate.itemId || "")
+        fakeDragSlot.activeItem = delegate.activeItem || delegate
+        b.barDragWindow = win
+        b.barDragScreen = win.screen
+        var local = dragOutMouse.mapToItem(delegate, mouse.x, mouse.y)
+        b.barDragOffsetX = local.x
+        b.barDragOffsetY = local.y
+        b.captureBarDragGhost(fakeDragSlot)
+        b.barDragSource = fakeDragSlot
+        return true
+      }
+
+      function updateDragOut(mouse) {
+        var b = root.bar
+        if (!b) return
+        var scenePoint = dragOutMouse.mapToItem(null, mouse.x, mouse.y)
+        var screenPoint = b.barDragScreenPoint(scenePoint)
+        b.barDragSceneX = scenePoint.x
+        b.barDragSceneY = scenePoint.y
+        b.barDragScreenX = screenPoint.x
+        b.barDragScreenY = screenPoint.y
+
+        var p = rootPoint(mouse)
+        var overTray = p.x >= 0 && p.x <= root.width && p.y >= 0 && p.y <= root.height
+
+        // Over the tray the release reorders — widgets and icons share one
+        // order, so a single pick covers both kinds. Clear the bar-level
+        // drop target and mark the in-tray insertion edge, reusing the
+        // bar's marker rendering for the visual.
+        if (overTray) {
+          b.barDragTarget = null
+          b.barDragAfter = false
+          var pick = root.drawerReorderPick(scenePoint, dragDelegate || dragIconDelegate)
+          orderBeforeKey = pick ? pick.beforeKey : null
+          b.barDragTargetGeometry = pick ? b.dropMarkerRect(pick.delegate, pick.after) : null
+          return
+        }
+        orderBeforeKey = null
+
+        // Status-notifier icons only ever move inside the tray: outside it
+        // there is no drop target and the release is a no-op.
+        if (dragIconDelegate) {
+          b.barDragTarget = null
+          b.barDragAfter = false
+          b.barDragTargetGeometry = null
+          return
+        }
+        var drop = b.moduleDropAtScene(scenePoint, fakeDragSlot)
+        b.barDragTarget = drop ? drop.slot : null
+        b.barDragAfter = drop ? drop.after : false
+        b.barDragTargetGeometry = drop ? b.dropMarkerRect(drop.slot, drop.after) : null
+      }
+
+      onPressed: function(mouse) {
+        dragging = false
+        suppressClick = false
+        var p = rootPoint(mouse)
+        // Chevron zone: refuse the press so it falls through to the slot's
+        // own MouseArea — dragging the chevron moves the whole tray.
+        var main = root.vertical ? p.y : p.x
+        if (root.chevronExtent > 0 && main < root.chevronExtent) {
+          mouse.accepted = false
+          return
+        }
+        pressedX = mouse.x
+        pressedY = mouse.y
+        dragDelegate = root.hostedDelegateAt(p.x, p.y)
+        dragIconDelegate = dragDelegate ? null : root.trayIconDelegateAt(p.x, p.y)
+      }
+
+      onPositionChanged: function(mouse) {
+        if (!canReorder || !(dragDelegate || dragIconDelegate) || !(mouse.buttons & Qt.LeftButton)) return
+
+        var distance = Math.abs(mouse.x - pressedX) + Math.abs(mouse.y - pressedY)
+        if (!dragging && distance >= dragThreshold) {
+          if (!beginDragOut(mouse)) return
+          dragging = true
+          if (root.bar) root.bar.hideTooltip(root)
+        }
+        if (dragging) updateDragOut(mouse)
+      }
+
+      onReleased: function(mouse) {
+        var wasDragging = dragging
+        dragging = false
+        if (!wasDragging) return
+
+        suppressClick = true
+        var b = root.bar
+        var target = b ? b.barDragTarget : null
+        var after = b ? b.barDragAfter : false
+        var widgetId = fakeDragSlot.moduleName
+        var reorder = orderBeforeKey
+        orderBeforeKey = null
+        var wasIconDrag = dragIconDelegate !== null
+        dragIconDelegate = null
+        var toRegion = target ? String(target.region || "") : ""
+        var beforeName = ""
+        if (target && b) {
+          beforeName = after
+            ? String(b.nextVisibleModuleName(target.region, target.moduleName, fakeDragSlot) || "")
+            : String(target.moduleName || "")
+        }
+        if (b) b.clearBarDrag()
+        fakeDragSlot.activeItem = null
+        fakeDragSlot.moduleName = ""
+        mouse.accepted = true
+
+        if (!widgetId || !b || !b.shell) return
+
+        // Released over the tray: rearrange the shared order (widgets and
+        // icons alike). A settings-only write, so no bar rebuild occurs;
+        // deferring just keeps the release handler off the write path.
+        if (reorder !== null && reorder !== undefined) {
+          var keys = root.drawerEntries.map(function(entry) { return entry.key })
+          var nextOrder = TrayModel.movedBefore(keys, widgetId, String(reorder))
+          if (nextOrder) Qt.callLater(function() { root.persistState({ order: nextOrder }) })
+          return
+        }
+
+        // Icon drags never leave the tray: outside it the release is a no-op.
+        if (wasIconDrag) return
+
+        if (!target || !toRegion) return
+        var shellRef = b.shell
+        var trayId = root.moduleName || "omarchy.tray"
+        // Deferred for the same reason as drag-in: a synchronous write would
+        // rebuild the bar while this release handler is on the stack. The
+        // closure holds only the shell reference and plain values.
+        Qt.callLater(function() {
+          if (typeof shellRef.mutateShellConfig !== "function") return
+          shellRef.mutateShellConfig(function(config) {
+            TrayModel.dragOutOfTray(config, trayId, widgetId, toRegion, beforeName)
+          })
+        })
+      }
+
+      onCanceled: {
+        dragging = false
+        suppressClick = false
+        orderBeforeKey = null
+        dragIconDelegate = null
+        if (root.bar && root.bar.barDragSource === fakeDragSlot) root.bar.clearBarDrag()
+        fakeDragSlot.activeItem = null
+        fakeDragSlot.moduleName = ""
+      }
+
+      onClicked: function(mouse) {
+        if (suppressClick) {
+          suppressClick = false
+          mouse.accepted = true
+          return
+        }
+        // Mirror the slot MouseArea's click routing so hosted widgets and
+        // tray icons behave exactly as before: registered click targets get
+        // triggerPress, everything else sees the composed click propagate.
+        var slot = dragOutOverlay.parent
+        if (slot === root || !root.bar || typeof root.bar.pressModuleClickTarget !== "function"
+            || !root.bar.pressModuleClickTarget(slot, mouse.button, dragOutOverlay.x + mouse.x, dragOutOverlay.y + mouse.y))
+          mouse.accepted = false
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Submenu drill-down state. QsMenuEntry.display() renders a *platform* menu,
   // which Quickshell refuses unless the shell root sets `//@ pragma
   // UseQApplication` - omarchy's shell.qml does not, so every submenu click was
-  // a silent no-op ("Cannot display PlatformMenuEntry as quickshell was not
-  // started in QApplication mode" in the shell log) and apps whose whole UI is
-  // submenus, e.g. radiotray-ng's station list, were unusable. QsMenuEntry
-  // inherits QsMenuHandle, so a child entry can feed a nested QsMenuOpener and
-  // render inside this popup instead of going through the platform. Each level
-  // keeps its own live opener: a child entry is owned by its parent opener's
-  // model, so collapsing the stack to a single opener would destroy the very
-  // entry being displayed (submenu turns up empty).
+  // a silent no-op and apps whose whole UI is submenus were unusable.
+  // QsMenuEntry inherits QsMenuHandle, so a child entry can feed a nested
+  // QsMenuOpener and render inside this popup instead of going through the
+  // platform. Each level keeps its own live opener: a child entry is owned by
+  // its parent opener's model, so collapsing the stack to a single opener
+  // would destroy the very entry being displayed.
+  // ---------------------------------------------------------------------------
   property var submenuStack: []
   readonly property int submenuDepth: submenuStack.length
   readonly property string currentTitle: submenuDepth > 0 ? submenuStack[submenuDepth - 1].title : ""
@@ -52,10 +684,8 @@ BarWidget {
     : trayMenuOpener.children
 
   // Changing level rebuilds the row delegates synchronously, so the next
-  // row lands under a cursor that hasn't moved. Submenu clicks used to be
-  // silent no-ops, which trained users to click them twice, and that second
-  // click would now fire whatever entry took the spot. Ignore row clicks for
-  // a beat after each level change; a deliberate follow-up click is slower.
+  // row lands under a cursor that hasn't moved. Ignore row clicks for a beat
+  // after each level change; a deliberate follow-up click is slower.
   property bool menuLevelSettling: false
 
   Component {
@@ -81,11 +711,9 @@ BarWidget {
     // is still tall enough to hold it, so a menu dismissed while scrolled
     // would otherwise reopen part-way down with its first entries off screen.
     trayMenuFlick.contentY = 0
-    // Clear the reactive stack before tearing anything down, so no binding can
-    // read a partially-destroyed opener while this runs. Then destroy deepest
-    // first: an inner opener's menu entry is owned by its parent's children
-    // model, so destroying a parent first would invalidate an entry a still-
-    // live child opener references.
+    // Clear the reactive stack before tearing anything down, then destroy
+    // deepest first: an inner opener's menu entry is owned by its parent's
+    // children model.
     var openers = submenuStack
     submenuStack = []
     for (var i = openers.length - 1; i >= 0; i--) openers[i].opener.destroy()
@@ -123,26 +751,25 @@ BarWidget {
 
     // Reset before switching items: trayMenuOpener.menu binds to
     // activeTrayItem.menu, so assigning a new item invalidates the old root's
-    // children immediately, before any nested opener referencing them would
-    // otherwise get torn down.
+    // children immediately.
     resetTrayMenu()
     activeTrayItem = item
     activeTrayAnchor = anchorItem
+    // Kill any pending tooltip for the icon under the cursor: with the menu
+    // open, a "Dropbox" bubble popping up over it is pure noise.
+    if (root.bar) root.bar.hideTooltip(anchorItem)
     trayMenuOpen = true
   }
 
   function trayIconSource(icon) {
     // Quickshell already resolves the tray icon into a ready-to-use image://
     // URL, including a "?path=" fallback search dir for apps that ship their
-    // tray icon outside a standard theme (e.g. Steam's flat public/ dir). Hand
-    // it straight to IconImage; guessing a theme sub-directory here only broke
-    // apps whose layout didn't match the guess.
+    // tray icon outside a standard theme.
     return String(icon || "")
   }
 
-  // Symbolic icons ship a fixed fill (often near-white) that the host is meant
-  // to recolor to its foreground; detect them by the freedesktop "-symbolic"
-  // name suffix so they can be tinted instead of rendered as-is.
+  // Symbolic icons ship a fixed fill the host is meant to recolor; detect by
+  // the freedesktop "-symbolic" name suffix so they can be tinted.
   function iconIsSymbolic(icon) {
     var name = String(icon || "").split("?")[0]
     return name.slice(-9) === "-symbolic"
@@ -154,9 +781,7 @@ BarWidget {
 
   function classifyItem(item) {
     var iid = String(item.id || "")
-    if (hiddenIds.indexOf(iid) !== -1) return "hidden"
-    if (pinnedIds.indexOf(iid) !== -1) return "pinned"
-    return "drawer"
+    return hiddenIds.indexOf(iid) !== -1 ? "hidden" : "drawer"
   }
 
   function ownedByOmarchy(item) {
@@ -175,48 +800,64 @@ BarWidget {
         result.push(item)
         continue
       }
+      if (!showTrayIcons) continue
       if (classifyItem(item) === category) result.push(item)
     }
-    return result
+    return TrayModel.sortByOrder(result, orderIds)
   }
 
-  function persistTrayState(pinned, hidden) {
+  // Writes the widget's full inline state. updateEntryInline replaces the
+  // whole layout entry, so every persisted key has to ride along on every
+  // write or a toggle would silently drop the captured widgets. Keys from
+  // retired features (pinning, the split icon order) are stripped so old
+  // configs converge on the simple shape.
+  function persistState(overrides) {
     if (!root.bar || !root.bar.shell || typeof root.bar.shell.updateEntryInline !== "function") return
     var id = root.moduleName || "omarchy.tray"
-    root.bar.shell.updateEntryInline(id, { id: id, pinned: pinned, hidden: hidden })
-  }
-
-  function togglePin(iid) {
-    var p = pinnedIds.slice(), h = hiddenIds.slice()
-    var idx = p.indexOf(iid)
-    if (idx !== -1) p.splice(idx, 1)
-    else {
-      p.push(iid)
-      var hi = h.indexOf(iid)
-      if (hi !== -1) h.splice(hi, 1)
+    var payload = { id: id }
+    var current = root.settings || {}
+    for (var key in current) {
+      if (key === "id" || key === "pinned" || key === "pinnedWidgets" || key === "iconOrder") continue
+      payload[key] = current[key]
     }
-    persistTrayState(p, h)
+    payload.hidden = root.hiddenIds
+    for (var name in overrides) payload[name] = overrides[name]
+    root.bar.shell.updateEntryInline(id, payload)
   }
 
   function toggleHide(iid) {
-    var p = pinnedIds.slice(), h = hiddenIds.slice()
+    var h = hiddenIds.slice()
     var idx = h.indexOf(iid)
     if (idx !== -1) h.splice(idx, 1)
-    else {
-      h.push(iid)
-      var pi = p.indexOf(iid)
-      if (pi !== -1) p.splice(pi, 1)
-    }
-    persistTrayState(p, h)
+    else h.push(iid)
+    persistState({ hidden: h })
   }
 
-  visible: pinnedItems.length > 0 || drawerCount > 0
+  // Stay on screen while a drag is in flight even when otherwise empty, so
+  // there is always a drop target to aim at.
+  visible: hasDrawerContent || hostedWrappers.length > 0 || dragActive
+
+  // When the manage popup is open, the bar underlines the whole tray — from
+  // the chevron's left edge to the last icon — instead of its default 55%
+  // fraction of the slot.
+  readonly property real openPanelIndicatorWidth: width
+  readonly property real openPanelIndicatorHeight: height
   clip: false
   implicitWidth: root.vertical ? root.barSize : trayContent.implicitWidth
   implicitHeight: root.vertical ? trayContent.implicitHeight : root.barSize
 
-  Behavior on revealProgress {
-    NumberAnimation { duration: root.animationDuration; easing.type: Easing.OutCubic }
+  // Backdrop while the drawer is out: the tray paints over other sections it
+  // overruns, but its content is sparse glyphs — without a ground, whatever
+  // sits underneath shows through the gaps un-dimmed. The scrim handles the
+  // center content BESIDE the drawer; this covers what is directly under it.
+  // Opaque bars get the solid background; a transparent VERTICAL bar gets
+  // the same dark tint as its scrim (so under-drawer content dims with the
+  // rest of the center); a transparent horizontal bar stays pristine.
+  Rectangle {
+    anchors.fill: parent
+    visible: root.drawerOut && (root.vertical || !root.barTransparent)
+    color: root.barTransparent ? "black" : (root.bar ? root.bar.background : Color.background)
+    opacity: (root.barTransparent ? 0.5 : 1.0) * root.revealProgress
   }
 
   Loader {
@@ -225,31 +866,40 @@ BarWidget {
     sourceComponent: root.vertical ? verticalTray : horizontalTray
   }
 
+  // Drop-target highlight while a dragged widget hovers over the tray.
+  Rectangle {
+    anchors.fill: parent
+    visible: root.dragOver
+    color: Qt.rgba(Color.accent.r, Color.accent.g, Color.accent.b, 0.14)
+    border.color: Color.accent
+    border.width: 1
+    radius: Math.min(Style.cornerRadius, height / 2)
+    z: 40
+  }
+
   Component {
     id: horizontalTray
 
     Item {
       id: horizontalTrayRoot
 
-      readonly property int pinnedWidth: pinnedRow.implicitWidth
-      readonly property int drawerBlockWidth: root.allItems.length > 0 ? expandIcon.implicitWidth + root.drawerExtent : 0
+      // Content-driven: unlike the stock tray's fixed icon-count math, the
+      // drawer holds arbitrary widgets, so its extent is whatever the row
+      // measures. The widget grows only while revealed rather than reserving
+      // the expanded width — with whole widgets inside, a permanent reserved
+      // gap could hollow out most of the bar.
+      readonly property real drawerExtent: drawerRow.implicitWidth
+      readonly property real revealExtent: drawerExtent * root.revealProgress
+      readonly property bool showDrawerBlock: root.hasDrawerContent || root.dragActive
+      readonly property real drawerBlockWidth: showDrawerBlock ? expandIcon.implicitWidth + revealExtent : 0
 
-      implicitWidth: pinnedWidth + drawerBlockWidth
+      implicitWidth: drawerBlockWidth
       implicitHeight: root.barSize
 
-      // Mask out the empty area the collapsed drawer reserves for its slide-in,
-      // so hovering it doesn't trigger expand and clicks pass through.
-      containmentMask: QtObject {
-        function contains(point: point): bool {
-          if (point.y < 0 || point.y > horizontalTrayRoot.height) return false
-          // Drawer reveals leftward; chevron sits at the right end when collapsed
-          // and slides left as it opens. The visible region starts at the chevron.
-          var chevronX = root.drawerExtent - root.revealExtent
-          if (point.x >= chevronX && point.x <= horizontalTrayRoot.drawerBlockWidth) return true
-          // Pinned items, placed to the right of the drawer block.
-          var pinnedStart = horizontalTrayRoot.drawerBlockWidth
-          return point.x >= pinnedStart && point.x <= horizontalTrayRoot.implicitWidth
-        }
+      Binding {
+        target: root
+        property: "chevronExtent"
+        value: horizontalTrayRoot.showDrawerBlock ? expandIcon.implicitWidth : 0
       }
 
       Item {
@@ -257,56 +907,48 @@ BarWidget {
         x: 0
         width: horizontalTrayRoot.drawerBlockWidth
         height: root.barSize
-        visible: root.allItems.length > 0
-
-        HoverHandler {
-          onHoveredChanged: root.expanded = hovered
-        }
+        visible: horizontalTrayRoot.showDrawerBlock
 
         BarIconButton {
           id: expandIcon
           bar: root.bar
           width: implicitWidth
           height: implicitHeight
-          x: root.drawerExtent - root.revealExtent
+          x: 0
           text: "\uf053"
           onPressed: function(button) {
             if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
+            else if (button === Qt.LeftButton) {
+              // Opening the drawer is also a dismissal gesture for whatever
+              // exterior panel is up.
+              root.closeExteriorPopout()
+              root.clickExpanded = true
+            }
           }
         }
 
         Item {
           id: trayClip
-          x: expandIcon.width
+          x: expandIcon.implicitWidth
           anchors.verticalCenter: parent.verticalCenter
-          width: root.drawerExtent
+          width: horizontalTrayRoot.revealExtent
           height: root.barSize
           clip: true
 
           Row {
-            id: trayIcons
-            x: root.drawerExtent - root.revealExtent
+            id: drawerRow
+            // Right-anchored inside the clip: the drawer's inner edge stays
+            // put while the reveal uncovers content leftward, matching the
+            // stock slide.
+            x: horizontalTrayRoot.revealExtent - horizontalTrayRoot.drawerExtent
             anchors.verticalCenter: parent.verticalCenter
-            spacing: root.trayItemGap
-            layer.enabled: true
+            spacing: 0
 
             Repeater {
-              model: root.drawerItems
-              TrayItem {}
+              model: root.drawerEntries
+              delegate: DrawerEntry {}
             }
           }
-        }
-      }
-
-      Row {
-        id: pinnedRow
-        x: drawerArea.x + horizontalTrayRoot.drawerBlockWidth
-        anchors.verticalCenter: parent.verticalCenter
-        spacing: root.trayItemGap
-        leftPadding: root.pinnedItems.length > 0 && root.allItems.length > 0 ? root.trayJoinGap : 0
-        Repeater {
-          model: root.pinnedItems
-          TrayItem {}
         }
       }
     }
@@ -318,20 +960,18 @@ BarWidget {
     Item {
       id: verticalTrayRoot
 
-      readonly property int pinnedHeight: pinnedCol.implicitHeight
-      readonly property int drawerBlockHeight: root.allItems.length > 0 ? expandIcon.implicitHeight + root.drawerExtent : 0
+      readonly property real drawerExtent: drawerColumn.implicitHeight
+      readonly property real revealExtent: drawerExtent * root.revealProgress
+      readonly property bool showDrawerBlock: root.hasDrawerContent || root.dragActive
+      readonly property real drawerBlockHeight: showDrawerBlock ? expandIcon.implicitHeight + revealExtent : 0
 
       implicitWidth: root.barSize
-      implicitHeight: pinnedHeight + drawerBlockHeight
+      implicitHeight: drawerBlockHeight
 
-      containmentMask: QtObject {
-        function contains(point: point): bool {
-          if (point.x < 0 || point.x > verticalTrayRoot.width) return false
-          var chevronY = root.drawerExtent - root.revealExtent
-          if (point.y >= chevronY && point.y <= verticalTrayRoot.drawerBlockHeight) return true
-          var pinnedStart = verticalTrayRoot.drawerBlockHeight
-          return point.y >= pinnedStart && point.y <= verticalTrayRoot.implicitHeight
-        }
+      Binding {
+        target: root
+        property: "chevronExtent"
+        value: verticalTrayRoot.showDrawerBlock ? expandIcon.implicitHeight : 0
       }
 
       Item {
@@ -339,110 +979,198 @@ BarWidget {
         y: 0
         width: root.barSize
         height: verticalTrayRoot.drawerBlockHeight
-        visible: root.allItems.length > 0
-
-        HoverHandler {
-          onHoveredChanged: root.expanded = hovered
-        }
+        visible: verticalTrayRoot.showDrawerBlock
 
         BarIconButton {
           id: expandIcon
           bar: root.bar
           width: implicitWidth
           height: implicitHeight
-          y: root.drawerExtent - root.revealExtent
+          y: 0
           text: "\uf053"
           textRotation: 90
           onPressed: function(button) {
             if (button === Qt.RightButton) root.managePopupOpen = !root.managePopupOpen
+            else if (button === Qt.LeftButton) {
+              // Opening the drawer is also a dismissal gesture for whatever
+              // exterior panel is up.
+              root.closeExteriorPopout()
+              root.clickExpanded = true
+            }
           }
         }
 
         Item {
           id: trayClip
-          y: expandIcon.height
+          y: expandIcon.implicitHeight
           anchors.horizontalCenter: parent.horizontalCenter
           width: root.barSize
-          height: root.drawerExtent
+          height: verticalTrayRoot.revealExtent
           clip: true
 
           Column {
-            id: trayIcons
-            y: root.drawerExtent - root.revealExtent
+            id: drawerColumn
+            y: verticalTrayRoot.revealExtent - verticalTrayRoot.drawerExtent
             anchors.horizontalCenter: parent.horizontalCenter
-            spacing: root.trayItemGap
-            layer.enabled: true
+            spacing: 0
 
             Repeater {
-              model: root.drawerItems
-              TrayItem {}
+              model: root.drawerEntries
+              delegate: DrawerEntry {}
             }
           }
-        }
-      }
-
-      Column {
-        id: pinnedCol
-        y: drawerArea.y + verticalTrayRoot.drawerBlockHeight
-        anchors.horizontalCenter: parent.horizontalCenter
-        spacing: root.trayItemGap
-        topPadding: root.pinnedItems.length > 0 && root.allItems.length > 0 ? root.trayJoinGap : 0
-        Repeater {
-          model: root.pinnedItems
-          TrayItem {}
         }
       }
     }
   }
 
-  PopupCard {
+  // One delegate for the drawer's mixed model: instantiates a hosted widget
+  // or a status-notifier icon depending on the entry kind. modelData on the
+  // inner components is set post-creation, so they tolerate a null start.
+  component DrawerEntry: Loader {
+    id: drawerEntry
+
+    required property var modelData
+
+    sourceComponent: modelData && modelData.kind === "widget" ? hostedWidgetComponent : trayItemComponent
+    onLoaded: item.modelData = drawerEntry.modelData.data
+  }
+
+  Component { id: hostedWidgetComponent; HostedWidget {} }
+  Component { id: trayItemComponent; TrayItem {} }
+
+  // The popup anchors to a frozen snapshot of the tray's rect rather than
+  // the live widget: toggling icons resizes the drawer, which moves the
+  // tray, and a live anchor would drag the open modal around with it. The
+  // snapshot is parented to the bar window so slot reflow can't move it.
+  Item {
+    id: popupAnchorProxy
+    parent: root.QsWindow && root.QsWindow.window ? root.QsWindow.window.contentItem : root
+    visible: false
+  }
+
+  function snapshotPopupAnchor() {
+    var win = root.QsWindow ? root.QsWindow.window : null
+    if (!win || !win.contentItem) return
+    var p = root.mapToItem(win.contentItem, 0, 0)
+    popupAnchorProxy.x = p.x
+    popupAnchorProxy.y = p.y
+    popupAnchorProxy.width = root.width
+    popupAnchorProxy.height = root.height
+  }
+
+  onManagePopupOpenChanged: if (managePopupOpen) snapshotPopupAnchor()
+
+  // KeyboardPanel rather than PopupCard: an xdg-popup can never take layer
+  // keyboard focus, so Escape could not reach it. This is the same base the
+  // bluetooth/network modals use — Escape closes, click-away dismisses.
+  KeyboardPanel {
     id: managePopup
-    anchorItem: root
+    anchorItem: popupAnchorProxy
     owner: root
     bar: root.bar
     open: root.managePopupOpen
-    contentWidth: managePopup.fittedContentWidth(Style.space(300))
+    contentWidth: managePopup.fittedContentWidth(Style.space(320))
     contentHeight: managePopup.fittedContentHeight(manageColumn.implicitHeight)
+
+    // Manage-popup row glyphs — swap freely.
+    readonly property string iconHiddenGlyph: ""
+    readonly property string iconVisibleGlyph: ""
+
+    PanelKeyCatcher {
+      anchors.fill: parent
+      onCloseRequested: root.close()
 
     Column {
       id: manageColumn
       anchors.fill: parent
-      spacing: Style.space(8)
+      // Same section rhythm as the bluetooth panel's content column.
+      spacing: Style.space(14)
 
-      Text {
-        text: "Tray icons"
-        color: root.foreground
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.body
-        font.bold: true
+      // Same hero arrangement as the audio panel: display-size glyph, title,
+      // and an auto-uppercased letter-spaced caption (PanelHero's meta).
+      PanelHero {
+        width: manageColumn.width
+        title: "Tray"
+        meta: "Hide & reorder bar icons"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        iconComponent: Component {
+          Text {
+            text: "󱊖"
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Math.round(Style.font.display * 1.2)
+          }
+        }
       }
 
-      Text {
-        text: "Pinned icons stay visible. Hidden icons never show."
-        color: Qt.darker(root.foreground, 1.4)
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.caption
-        wrapMode: Text.WordWrap
-        width: parent.width
+      PanelSeparator {
+        foreground: root.foreground
       }
 
-      Text {
-        visible: root.allItems.length === 0
-        text: "No tray items reporting."
-        color: Qt.darker(root.foreground, 1.5)
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.bodySmall
-        font.italic: true
-      }
+      // The section header row and its icon rows form one tight block,
+      // spaced like the wifi panel's network list (Style.space(4) between
+      // rows); the outer column's looser section rhythm stays above it.
+      Column {
+        width: manageColumn.width
+        spacing: Style.space(4)
 
-      Repeater {
-        model: root.allItems
-        delegate: Item {
+        Item {
+          width: parent.width
+          implicitHeight: Math.max(hideIconsLabel.implicitHeight, hideIconsSwitch.implicitHeight)
+
+          // Switch first, then the wifi-style all-caps section label.
+          ToggleSwitch {
+            id: hideIconsSwitch
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            checked: root.showTrayIcons
+            foreground: root.foreground
+            onToggled: root.persistState({ showTrayIcons: !root.showTrayIcons })
+          }
+
+          PanelSectionHeader {
+            id: hideIconsLabel
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: hideIconsSwitch.right
+            anchors.leftMargin: Style.space(10)
+            anchors.right: parent.right
+            text: "SHOW SYSTEM ICONS"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            elide: Text.ElideRight
+          }
+        }
+
+        Text {
+          visible: root.allItems.length === 0
+          text: "No system tray icons reporting."
+          color: Qt.darker(root.foreground, 1.5)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.bodySmall
+          font.italic: true
+        }
+
+        Repeater {
+          model: root.allItems
+        // Built like the wifi panel's network rows: a CursorSurface that
+        // lights up as one hoverable button, icon at the far left, title,
+        // and a status glyph in a fixed slot at the far right. Clicking
+        // anywhere on the row toggles the icon's hidden state.
+        delegate: CursorSurface {
           id: rowRoot
           required property var modelData
           required property int index
           width: manageColumn.width
-          implicitHeight: 28
+          implicitHeight: rowBody.implicitHeight
+          hasCursor: iconRowMouse.containsMouse && root.showTrayIcons
+          foreground: root.foreground
+          // Grayed out while the master switch hides them all (inert too) or
+          // while this icon is individually hidden (still clickable, so it
+          // can be brought back).
+          opacity: !root.showTrayIcons || isHidden ? 0.4 : 1.0
+          enabled: root.showTrayIcons
 
           readonly property string itemId: String(modelData.id || "")
           readonly property string displayName: {
@@ -454,61 +1182,72 @@ BarWidget {
             var slash = id.lastIndexOf("/")
             return slash !== -1 ? id.substring(slash + 1) : (id || "Unknown")
           }
-          readonly property bool isPinned: root.pinnedIds.indexOf(itemId) !== -1
           readonly property bool isHidden: root.hiddenIds.indexOf(itemId) !== -1
 
-          TrayIcon {
-            id: rowIcon
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.left
-            width: 16
-            height: 16
-            icon: rowRoot.modelData.icon
-          }
-
-          Text {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: rowIcon.right
-            anchors.leftMargin: Style.space(10)
-            anchors.right: rowHideBtn.left
-            anchors.rightMargin: Style.space(8)
-            text: rowRoot.displayName
-            color: root.foreground
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.bodySmall
-            elide: Text.ElideRight
-          }
-
-          Button {
-            id: rowPinBtn
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: parent.right
-            iconText: "\uf08d"
-            text: rowRoot.isPinned ? "Unpin" : "Pin"
-            foreground: root.foreground
-            horizontalPadding: 8
-            verticalPadding: 3
-            iconSize: Style.font.bodySmall
-            fontSize: Style.font.bodySmall
-            onClicked: root.togglePin(rowRoot.itemId)
-          }
-
-          Button {
-            id: rowHideBtn
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: rowPinBtn.left
-            anchors.rightMargin: Style.space(6)
-            iconText: "\uf06e"
-            text: rowRoot.isHidden ? "Show" : "Hide"
-            foreground: root.foreground
-            horizontalPadding: 8
-            verticalPadding: 3
-            iconSize: Style.font.bodySmall
-            fontSize: Style.font.bodySmall
+          MouseArea {
+            id: iconRowMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            acceptedButtons: Qt.LeftButton
+            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
             onClicked: root.toggleHide(rowRoot.itemId)
+          }
+
+          Item {
+            id: rowBody
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.leftMargin: Style.space(10)
+            anchors.rightMargin: Style.space(10)
+            implicitHeight: Math.max(rowIcon.height, rowTitle.implicitHeight, rightGlyph.implicitHeight) + Style.spacing.rowPaddingX
+
+            TrayIcon {
+              id: rowIcon
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+              width: Style.font.title
+              height: Style.font.title
+              icon: rowRoot.modelData.icon
+            }
+
+            Text {
+              id: rowTitle
+              anchors.left: rowIcon.right
+              anchors.leftMargin: Style.space(10)
+              anchors.right: rightGlyph.left
+              anchors.rightMargin: Style.space(8)
+              anchors.verticalCenter: parent.verticalCenter
+              text: rowRoot.displayName
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+              elide: Text.ElideRight
+            }
+
+            Item {
+              id: rightGlyph
+              width: Style.space(22)
+              implicitHeight: rightGlyphText.implicitHeight
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+
+              Text {
+                id: rightGlyphText
+                width: parent.width
+                anchors.verticalCenter: parent.verticalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: rowRoot.isHidden ? managePopup.iconHiddenGlyph : managePopup.iconVisibleGlyph
+                color: Qt.darker(root.foreground, 1.4)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.subtitle
+              }
+            }
           }
         }
       }
+      }
+    }
     }
   }
 
@@ -517,21 +1256,24 @@ BarWidget {
     menu: root.activeTrayItem ? root.activeTrayItem.menu : null
   }
 
-  PopupCard {
+  // KeyboardPanel for the same reasons as the manage popup: an xdg-popup can
+  // never take layer keyboard focus, so Escape could not close the app menu.
+  // The fullscreen overlay also takes the pointer off the bar icon, which is
+  // what used to let a stray tooltip pop up on top of the open menu.
+  KeyboardPanel {
     id: trayMenuPopup
     anchorItem: root.activeTrayAnchor || root
     owner: root
     bar: root.bar
     open: root.trayMenuOpen
-    // The card fades out over 140ms (visible stays true for that whole time --
-    // see PopupCard's own visible: open || card.opacity > 0), so resetting on
-    // "open" would swap a live submenu for the root menu mid-fade: a visible
-    // flash, and a resize/reposition if the two have different geometry. Wait
-    // for the fade to actually finish. Switching to a different tray item
-    // still resets immediately, from openTrayMenu() itself.
+    // The card fades out over 140ms (visible stays true for that whole time),
+    // so resetting on "open" would swap a live submenu for the root menu
+    // mid-fade. Wait for the fade to actually finish. Switching to a different
+    // tray item still resets immediately, from openTrayMenu() itself.
     onVisibleChanged: if (!visible) root.resetTrayMenu()
     padding: Style.space(8)
-    borderColor: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45)
+    borderSpec: Border.surfaceSpec("popups", "border",
+      Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45), Math.max(1, Style.space(2)))
     contentWidth: trayMenuPopup.fittedContentWidth(Style.space(232))
     contentHeight: trayMenuPopup.fittedContentHeight(menuHeaderHeight + trayMenuColumn.implicitHeight, Style.space(420))
 
@@ -539,15 +1281,18 @@ BarWidget {
     // read the header's extent through its own visibility.
     readonly property int menuHeaderHeight: menuHeader.visible ? menuHeader.implicitHeight : 0
 
+    PanelKeyCatcher {
+      anchors.fill: parent
+      onCloseRequested: root.close()
+
     Column {
       id: trayMenuLayout
       anchors.fill: parent
       spacing: 0
 
       // Header for a drilled-into submenu: names where we are and walks back
-      // out. Pinned above the Flickable rather than scrolling with the rows,
-      // so the way back stays reachable in a submenu taller than the card.
-      // Only present below the root level, so the root menu is unchanged.
+      // out. Pinned above the Flickable so the way back stays reachable in a
+      // submenu taller than the card. Only present below the root level.
       Column {
         id: menuHeader
         visible: root.submenuDepth > 0
@@ -570,7 +1315,7 @@ BarWidget {
             anchors.left: parent.left
             width: Style.space(22)
             horizontalAlignment: Text.AlignHCenter
-            text: "\u2039"
+            text: "‹"
             color: root.foreground
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
@@ -649,8 +1394,8 @@ BarWidget {
 
               readonly property string rowText: String(modelData.text || "")
               readonly property string activeTitle: root.activeTrayItem ? String(root.activeTrayItem.title || root.activeTrayItem.id || "") : ""
-              // Both only ever describe the root menu; inside a submenu the first
-              // rows are real entries and must not be swallowed.
+              // Both only ever describe the root menu; inside a submenu the
+              // first rows are real entries and must not be swallowed.
               readonly property bool atRoot: root.submenuDepth === 0
               readonly property bool rootTitleEntry: atRoot && index === 0 && modelData.hasChildren && rowText.toLowerCase() === activeTitle.toLowerCase()
               readonly property bool leadingSeparator: atRoot && modelData.isSeparator && index <= 1
@@ -702,7 +1447,7 @@ BarWidget {
                 height: Style.space(16)
                 fillMode: Image.PreserveAspectFit
                 // Decode at physical pixels: IconImage uses the logical size,
-                // which leaves PNG icons upscaled and blurry on HiDPI displays.
+                // which leaves PNG icons upscaled and blurry on HiDPI.
                 sourceSize.width: width * Screen.devicePixelRatio
                 sourceSize.height: height * Screen.devicePixelRatio
                 source: menuRow.modelData.icon
@@ -728,7 +1473,7 @@ BarWidget {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.right: parent.right
                 anchors.rightMargin: Style.space(10)
-                text: "\u203a"
+                text: "›"
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.bodySmall
@@ -743,8 +1488,9 @@ BarWidget {
                 onClicked: {
                   if (root.menuLevelSettling) return
                   if (menuRow.modelData.hasChildren) {
-                    // Reset scroll BEFORE swapping the model: the swap destroys
-                    // this delegate synchronously and ids stop resolving after.
+                    // Reset scroll BEFORE swapping the model: the swap
+                    // destroys this delegate synchronously and ids stop
+                    // resolving after.
                     trayMenuFlick.contentY = 0
                     root.enterSubmenu(menuRow.modelData, menuRow.rowText)
                   } else {
@@ -758,11 +1504,11 @@ BarWidget {
         }
       }
     }
+    }
   }
 
   // Renders a tray icon, recoloring symbolic icons to the bar foreground so
-  // they stay visible on any theme (a raw symbolic icon keeps its baked-in
-  // fill and disappears against a matching background).
+  // they stay visible on any theme.
   component TrayIcon: Item {
     id: trayIconRoot
     required property var icon
@@ -772,8 +1518,8 @@ BarWidget {
       id: trayIconImage
       anchors.fill: parent
       fillMode: Image.PreserveAspectFit
-      // Decode at physical pixels: IconImage uses the logical size,
-      // which leaves PNG icons upscaled and blurry on HiDPI displays.
+      // Decode at physical pixels: IconImage uses the logical size, which
+      // leaves PNG icons upscaled and blurry on HiDPI displays.
       sourceSize.width: Math.round(Math.min(width, height) * Screen.devicePixelRatio)
       sourceSize.height: Math.round(Math.min(width, height) * Screen.devicePixelRatio)
       source: root.trayIconSource(trayIconRoot.icon)
@@ -794,21 +1540,29 @@ BarWidget {
   component TrayItem: Item {
     id: trayItemRoot
 
-    required property var modelData
+    property var modelData: null
 
-    visible: modelData.status !== Status.Passive
+    readonly property string itemId: String(modelData && modelData.id ? modelData.id : "")
+
+    visible: modelData ? modelData.status !== Status.Passive : false
     implicitWidth: visible ? root.trayItemExtent : 0
     implicitHeight: visible ? root.trayItemExtent : 0
 
+    Component.onCompleted: root.registerTrayIconDelegate(trayItemRoot)
+    Component.onDestruction: {
+      root.unregisterTrayIconDelegate(trayItemRoot)
+      if (dragOutMouse && dragOutMouse.dragIconDelegate === trayItemRoot) dragOutMouse.dragIconDelegate = null
+    }
+
     function displayMenu(mouse) {
-      root.openTrayMenu(trayItemRoot.modelData, trayItemRoot, mouse)
+      if (trayItemRoot.modelData) root.openTrayMenu(trayItemRoot.modelData, trayItemRoot, mouse)
     }
 
     TrayIcon {
       anchors.centerIn: parent
       width: Style.space(12)
       height: Style.space(12)
-      icon: trayItemRoot.modelData.icon
+      icon: trayItemRoot.modelData ? trayItemRoot.modelData.icon : ""
     }
 
     MouseArea {
@@ -817,7 +1571,12 @@ BarWidget {
       acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onEntered: if (root.bar) root.bar.showTooltip(trayItemRoot, root.trayTooltip(modelData))
+      // No tooltips while one of the tray's own popups is up — they would
+      // render on top of the open menu.
+      onEntered: {
+        if (root.trayMenuOpen || root.managePopupOpen) return
+        if (root.bar && trayItemRoot.modelData) root.bar.showTooltip(trayItemRoot, root.trayTooltip(trayItemRoot.modelData))
+      }
       onExited: if (root.bar) root.bar.hideTooltip(trayItemRoot)
       onPressed: function(mouse) {
         if (mouse.button === Qt.RightButton) {
@@ -826,6 +1585,7 @@ BarWidget {
         }
       }
       onClicked: function(mouse) {
+        if (!trayItemRoot.modelData) return
         if (mouse.button === Qt.RightButton) {
           mouse.accepted = true
         } else if (mouse.button === Qt.MiddleButton) {
@@ -837,10 +1597,164 @@ BarWidget {
         }
       }
       onWheel: function(wheel) {
-        trayItemRoot.modelData.scroll(wheel.angleDelta.y, false)
+        if (trayItemRoot.modelData) trayItemRoot.modelData.scroll(wheel.angleDelta.y, false)
       }
     }
 
     readonly property bool tooltipHovered: visible && opacity > 0 && mouseArea.containsMouse
+      && !root.trayMenuOpen && !root.managePopupOpen
+  }
+
+  // A captured bar widget living inside the tray. Instantiates the same
+  // registry component the bar's own module slots use and injects the same
+  // three properties (bar, moduleName, settings), so the widget cannot tell
+  // it isn't sitting directly in a bar section — clicks route through the
+  // bar's registered click targets, tooltips and panels anchor normally.
+  component HostedWidget: Item {
+    id: hostedRoot
+
+    property var modelData: null
+
+    readonly property var entry: modelData && modelData.entry ? modelData.entry : ({})
+    readonly property string widgetId: TrayModel.entryId(entry)
+    readonly property var widgetSettings: TrayModel.entrySettings(entry)
+    readonly property string customType: root.bar && typeof root.bar.customModuleType === "function"
+      ? String(root.bar.customModuleType(entry) || "") : ""
+    readonly property var registryComponent: {
+      if (customType) return null
+      var registry = root.bar ? root.bar.barWidgetRegistry : null
+      if (!registry) return null
+      var revision = registry.revision
+      var record = registry.widgets[widgetId]
+      return record ? record.component : null
+    }
+    readonly property var activeItem: {
+      if (registryComponent) return registryLoader.item
+      if (customType === "qml") return qmlLoader.item
+      if (customType === "command") return commandLoader.item
+      return null
+    }
+
+    implicitWidth: activeItem && activeItem.visible ? (root.vertical ? root.barSize : activeItem.implicitWidth) : 0
+    implicitHeight: activeItem && activeItem.visible ? (root.vertical ? activeItem.implicitHeight : root.barSize) : 0
+    width: implicitWidth
+    height: implicitHeight
+
+    Component.onCompleted: root.registerHostedDelegate(hostedRoot)
+    Component.onDestruction: {
+      // Unregister first: if anything below throws mid-teardown, a stale
+      // delegate left in the list would poison every future hit test.
+      root.unregisterHostedDelegate(hostedRoot)
+      if (dragOutMouse && dragOutMouse.dragDelegate === hostedRoot) dragOutMouse.dragDelegate = null
+    }
+
+    onActiveItemChanged: Qt.callLater(injectProps)
+    onWidgetSettingsChanged: injectProps()
+
+    function injectProps() {
+      var target = activeItem
+      if (!target) return
+      if ("bar" in target) target.bar = root.bar
+      if ("moduleName" in target) target.moduleName = widgetId
+      if ("settings" in target) target.settings = widgetSettings
+    }
+
+    Loader {
+      id: registryLoader
+      active: hostedRoot.registryComponent !== null
+      sourceComponent: hostedRoot.registryComponent
+      anchors.fill: parent
+      onLoaded: {
+        hostedRoot.injectProps()
+        Qt.callLater(hostedRoot.injectProps)
+      }
+    }
+
+    Loader {
+      id: qmlLoader
+      active: hostedRoot.customType === "qml"
+      source: active && root.bar && typeof root.bar.customModuleSource === "function"
+        ? root.bar.customModuleSource(hostedRoot.entry) : ""
+      anchors.fill: parent
+      onLoaded: {
+        hostedRoot.injectProps()
+        Qt.callLater(hostedRoot.injectProps)
+      }
+    }
+
+    Loader {
+      id: commandLoader
+      active: hostedRoot.customType === "command"
+      sourceComponent: hostedCommandComponent
+      anchors.fill: parent
+      onLoaded: item.entry = hostedRoot.entry
+    }
+  }
+
+  // Minimal clone of the bar's private exec-based custom module, so command
+  // widgets can live inside the tray too.
+  Component {
+    id: hostedCommandComponent
+
+    WidgetButton {
+      id: commandRoot
+
+      property var entry: ({})
+      readonly property var moduleSettings: TrayModel.entrySettings(entry)
+      property string outputText: ""
+      property string outputTooltip: ""
+      property bool outputActive: false
+
+      function setting(name, fallback) {
+        var value = moduleSettings ? moduleSettings[name] : undefined
+        return value === undefined || value === null ? fallback : value
+      }
+
+      function update(raw) {
+        var data = Util.parseModuleJson(raw)
+        var klass = data.class || data.alt || ""
+        outputText = data.text || String(raw || "").trim()
+        outputTooltip = data.tooltip || String(setting("tooltip", ""))
+        outputActive = klass === "active" || (Array.isArray(klass) && klass.indexOf("active") !== -1)
+      }
+
+      bar: root.bar
+      text: outputText || String(setting("text", ""))
+      tooltipText: outputTooltip || String(setting("tooltip", ""))
+      active: outputActive
+      keepSpace: setting("keepSpace", false) === true
+      horizontalMargin: Number(setting("horizontalMargin", 7.5))
+      verticalPadding: Number(setting("verticalPadding", 6))
+      fontSize: Number(setting("fontSize", 12))
+
+      onPressed: function(button) {
+        var command = ""
+        if (button === Qt.RightButton)
+          command = String(setting("onRightClick", ""))
+        else if (button === Qt.MiddleButton)
+          command = String(setting("onMiddleClick", ""))
+        else
+          command = String(setting("onClick", ""))
+
+        if (command && root.bar) root.bar.run(command)
+      }
+
+      Process {
+        id: commandProc
+        command: ["bash", "-lc", String(commandRoot.setting("exec", ""))]
+        stdout: StdioCollector {
+          waitForEnd: true
+          onStreamFinished: commandRoot.update(text)
+        }
+      }
+
+      Timer {
+        interval: Math.max(1, Number(commandRoot.setting("interval", 5))) * 1000
+        running: String(commandRoot.setting("exec", "")) !== ""
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: if (!commandProc.running) commandProc.running = true
+      }
+    }
   }
 }

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -1219,6 +1219,7 @@ BarWidget {
               anchors.rightMargin: Style.space(8)
               anchors.verticalCenter: parent.verticalCenter
               text: rowRoot.displayName
+              textFormat: Text.PlainText
               color: root.foreground
               font.family: root.fontFamily
               font.pixelSize: Style.font.body
@@ -1328,6 +1329,7 @@ BarWidget {
             anchors.right: parent.right
             anchors.rightMargin: Style.space(10)
             text: root.currentTitle
+            textFormat: Text.PlainText
             color: root.foreground
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
@@ -1461,6 +1463,7 @@ BarWidget {
                 anchors.right: submenuGlyph.left
                 anchors.rightMargin: Style.space(8)
                 text: menuRow.rowText
+                textFormat: Text.PlainText
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.bodySmall

--- a/shell/plugins/bar/widgets/TrayModel.js
+++ b/shell/plugins/bar/widgets/TrayModel.js
@@ -1,3 +1,5 @@
+var SECTIONS = ["left", "center", "right"]
+
 function text(value) {
   return String(value || "").toLowerCase()
 }
@@ -11,17 +13,26 @@ function itemNamed(item, name) {
 
 function entryId(entry) {
   if (typeof entry === "string") return entry
-  if (entry && typeof entry === "object") {
+  if (entry && typeof entry === "object" && !Array.isArray(entry)) {
     var id = entry.id
     if (id !== undefined && id !== null && String(id) !== "") return String(id)
   }
   return ""
 }
 
+function entrySettings(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return {}
+  var copy = {}
+  for (var key in entry) {
+    if (key === "id") continue
+    copy[key] = entry[key]
+  }
+  return copy
+}
+
 function layoutHasWidget(layout, id) {
-  var sections = ["left", "center", "right"]
-  for (var s = 0; s < sections.length; s++) {
-    var entries = layout && layout[sections[s]]
+  for (var s = 0; s < SECTIONS.length; s++) {
+    var entries = layout && layout[SECTIONS[s]]
     if (!Array.isArray(entries)) continue
     for (var i = 0; i < entries.length; i++) {
       if (entryId(entries[i]) === id) return true
@@ -38,11 +49,228 @@ function ownedByOmarchy(item, layout) {
     || (layoutHasWidget(layout, "omarchy.dropbox") && itemNamed(item, "dropbox"))
 }
 
+// QML can hand a settings array across property boundaries as a variant-list
+// proxy: typeof "object", instanceof Array, but Array.isArray false and array
+// methods missing. Which form arrives depends on the injection path, so every
+// settings-derived list must be copied into a real array before use.
+function asList(value) {
+  if (Array.isArray(value)) return value
+  if (value && typeof value === "object" && typeof value.length === "number") {
+    var out = []
+    for (var i = 0; i < value.length; i++) out.push(value[i])
+    return out
+  }
+  return []
+}
+
+// The `widgets` setting holds one wrapper per captured bar widget:
+//   { entry: <original layout entry> }
+// Tolerate hand-edited shorthand (a bare id string, or a bare entry object)
+// so a typo'd shell.json degrades to defaults instead of a dead tray.
+function normalizeWrappers(raw) {
+  var out = []
+  var values = asList(raw)
+  for (var i = 0; i < values.length; i++) {
+    var wrapper = values[i]
+    if (!wrapper) continue
+    if (typeof wrapper === "string") {
+      out.push({ entry: { id: wrapper } })
+      continue
+    }
+    if (wrapper.entry && entryId(wrapper.entry)) {
+      out.push({ entry: wrapper.entry })
+      continue
+    }
+    if (entryId(wrapper)) out.push({ entry: wrapper })
+  }
+  return out
+}
+
+function wrapperId(wrapper) {
+  if (!wrapper) return ""
+  return wrapper.entry ? entryId(wrapper.entry) : entryId(wrapper)
+}
+
+// The shell loads a third-party plugin's widget component only while its id
+// is referenced in shell.json (bar.id, a bar.layout entry, or plugins[]).
+// A captured widget's id lives inside the tray's settings, which that scan
+// does not see, so without a plugins[] entry the shell unloads the component
+// and the hosted widget renders as nothing. Returns true when an entry was
+// added (i.e. the tray owns it and must remove it again on release).
+function ensurePluginListed(config, id) {
+  if (!Array.isArray(config.plugins)) config.plugins = []
+  for (var i = 0; i < config.plugins.length; i++) {
+    var e = config.plugins[i]
+    var eid = typeof e === "string" ? e : (e ? String(e.id || "") : "")
+    if (eid === id) return false
+  }
+  config.plugins.push({ id: id })
+  return true
+}
+
+function unlistPlugin(config, id) {
+  if (!Array.isArray(config.plugins)) return
+  config.plugins = config.plugins.filter(function(e) {
+    if (!e) return false
+    var eid = typeof e === "string" ? e : String(e.id || "")
+    return eid !== id
+  })
+}
+
+function findLayoutEntry(layout, id) {
+  for (var s = 0; s < SECTIONS.length; s++) {
+    var entries = layout ? layout[SECTIONS[s]] : null
+    if (!Array.isArray(entries)) continue
+    for (var i = 0; i < entries.length; i++) {
+      if (entryId(entries[i]) === id) {
+        return { section: SECTIONS[s], entries: entries, index: i, entry: entries[i] }
+      }
+    }
+  }
+  return null
+}
+
+// Mutates `config` in place: pull `sourceId`'s entry out of the bar layout
+// and append it to the tray entry's `widgets` list. `orderTokens`, when
+// given, becomes the tray's drawer order — the caller computes it from the
+// drop position so a dragged-in widget lands exactly where it was released.
+// Returns true when anything moved.
+function captureIntoTray(config, trayId, sourceId, orderTokens) {
+  if (!sourceId || sourceId === trayId) return false
+  var layout = config && config.bar ? config.bar.layout : null
+  if (!layout) return false
+
+  var source = findLayoutEntry(layout, sourceId)
+  if (!source) return false
+  source.entries.splice(source.index, 1)
+
+  // Resolve the tray entry only after the splice: both can live in the same
+  // section array, and an index recorded before the removal would be stale.
+  var tray = findLayoutEntry(layout, trayId)
+  if (!tray) {
+    source.entries.splice(source.index, 0, source.entry)
+    return false
+  }
+
+  var trayEntry = tray.entry
+  if (typeof trayEntry === "string") {
+    trayEntry = { id: trayEntry }
+    tray.entries[tray.index] = trayEntry
+  }
+  if (!Array.isArray(trayEntry.widgets)) trayEntry.widgets = []
+  var entry = typeof source.entry === "string" ? { id: source.entry } : source.entry
+  var wrapper = { entry: entry }
+  // Keep the plugin loaded while its only reference is inside the tray.
+  if (ensurePluginListed(config, sourceId)) wrapper.listed = true
+  trayEntry.widgets.push(wrapper)
+  if (Array.isArray(orderTokens) && orderTokens.length) trayEntry.order = orderTokens.map(String)
+  return true
+}
+
+// Remove `widgetId`'s wrapper from a tray entry (widgets + pinnedWidgets)
+// and return it, or null when it isn't hosted there.
+function takeWrapper(trayEntry, widgetId) {
+  var wrappers = Array.isArray(trayEntry.widgets) ? trayEntry.widgets : []
+  var index = -1
+  for (var i = 0; i < wrappers.length; i++) {
+    if (wrapperId(wrappers[i]) === widgetId) { index = i; break }
+  }
+  if (index === -1) return null
+  var wrapper = wrappers.splice(index, 1)[0]
+  if (wrappers.length === 0) delete trayEntry.widgets
+  if (Array.isArray(trayEntry.order)) {
+    trayEntry.order = trayEntry.order.filter(function(token) { return String(token) !== widgetId })
+    if (trayEntry.order.length === 0) delete trayEntry.order
+  }
+  return wrapper
+}
+
+function indexOfEntry(entries, id) {
+  for (var i = 0; i < entries.length; i++) {
+    if (entryId(entries[i]) === id) return i
+  }
+  return -1
+}
+
+// Drop a hosted widget back into the bar layout at an explicit position —
+// the drag-out counterpart of captureIntoTray. Inserts before `beforeName`
+// in `toRegion`, or at the section's end when beforeName is empty or gone.
+function dragOutOfTray(config, trayId, widgetId, toRegion, beforeName) {
+  var layout = config && config.bar ? config.bar.layout : null
+  if (!layout) return false
+
+  var tray = findLayoutEntry(layout, trayId)
+  if (!tray || typeof tray.entry === "string") return false
+  var wrapper = takeWrapper(tray.entry, widgetId)
+  if (!wrapper) return false
+  // Back in the layout, the entry itself keeps the plugin loaded again.
+  if (wrapper.listed) unlistPlugin(config, widgetId)
+
+  var entry = wrapper && wrapper.entry ? wrapper.entry : wrapper
+  var region = SECTIONS.indexOf(toRegion) !== -1 ? toRegion : "right"
+  if (!Array.isArray(layout[region])) layout[region] = []
+  var target = layout[region]
+  var index = beforeName ? indexOfEntry(target, String(beforeName)) : -1
+  if (index < 0) target.push(entry)
+  else target.splice(index, 0, entry)
+  return true
+}
+
+// Sort drawer content by the persisted `order` token list. Works on anything
+// carrying a `key` (mixed drawer entries) or an `id` (raw status-notifier
+// items). Tokens not in the list keep their arrival order, after every
+// ordered one, so new content appears at the end instead of shuffling the
+// arranged pieces.
+function orderKey(item) {
+  if (!item) return ""
+  if (item.key !== undefined) return String(item.key)
+  return String(item.id || "")
+}
+
+function sortByOrder(items, order) {
+  var ord = asList(order).map(String)
+  var decorated = []
+  for (var i = 0; i < items.length; i++) decorated.push({ item: items[i], index: i })
+  decorated.sort(function(a, b) {
+    var ai = ord.indexOf(orderKey(a.item))
+    var bi = ord.indexOf(orderKey(b.item))
+    var ak = ai === -1 ? ord.length + a.index : ai
+    var bk = bi === -1 ? ord.length + b.index : bi
+    return ak - bk
+  })
+  return decorated.map(function(e) { return e.item })
+}
+
+// Move `id` within an id list so it sits before `beforeId` ("" = end).
+// Returns the new array, or null when the order would not change.
+function movedBefore(order, id, beforeId) {
+  var ids = asList(order).map(String)
+  var from = ids.indexOf(String(id))
+  if (from === -1) return null
+  ids.splice(from, 1)
+  var to = beforeId ? ids.indexOf(String(beforeId)) : ids.length
+  if (to === -1) to = ids.length
+  if (to === from) return null
+  ids.splice(to, 0, String(id))
+  return ids
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
+    asList: asList,
+    ensurePluginListed: ensurePluginListed,
+    unlistPlugin: unlistPlugin,
     itemNamed: itemNamed,
     entryId: entryId,
+    entrySettings: entrySettings,
     layoutHasWidget: layoutHasWidget,
-    ownedByOmarchy: ownedByOmarchy
+    ownedByOmarchy: ownedByOmarchy,
+    normalizeWrappers: normalizeWrappers,
+    wrapperId: wrapperId,
+    findLayoutEntry: findLayoutEntry,
+    captureIntoTray: captureIntoTray,
+    dragOutOfTray: dragOutOfTray,
+    sortByOrder: sortByOrder,
+    movedBefore: movedBefore
   }
 }

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -24,3 +24,51 @@ assert(!tray.ownedByOmarchy({ id: 'dropbox' }, { left: [], center: [], right: []
 assert(tray.ownedByOmarchy({ id: 'qlBCprNUqU', title: 'localsend' }, { left: [], center: [], right: [] }), 'tray suppresses localsend regardless of layout')
 assert(!tray.ownedByOmarchy({ id: 'nextcloud' }, layout), 'tray keeps unrelated tray items')
 JS
+
+run_node_test "tray drawer capture, order, and drag-out" <<'JS'
+const tray = requireFromRoot('shell/plugins/bar/widgets/TrayModel.js')
+
+function config() {
+  return {
+    bar: { layout: {
+      left: [],
+      center: [{ id: 'omarchy.weather' }],
+      right: [{ id: 'omarchy.tray' }, { id: 'omarchy.bluetooth' }]
+    } },
+    plugins: []
+  }
+}
+
+// Capturing pulls the entry out of the layout, wraps it, and applies the
+// drop-position order the caller computed.
+let c = config()
+assert(tray.captureIntoTray(c, 'omarchy.tray', 'omarchy.weather', ['omarchy.weather', 'icon-1']), 'capture moves a layout entry into the tray')
+assert(c.bar.layout.center.length === 0, 'captured entry leaves its section')
+const entry = c.bar.layout.right[0]
+assert(entry.widgets.length === 1 && entry.widgets[0].entry.id === 'omarchy.weather', 'tray holds the captured wrapper')
+assert(entry.order.join(',') === 'omarchy.weather,icon-1', 'capture applies the drop-position order')
+assert(!tray.captureIntoTray(c, 'omarchy.tray', 'omarchy.tray', null), 'the tray cannot capture itself')
+
+// Third-party widgets stay loaded via a plugins[] listing, removed again on
+// the way out; entries that were already listed are left alone.
+c = config()
+c.bar.layout.center.push({ id: 'acme.widget' })
+assert(tray.captureIntoTray(c, 'omarchy.tray', 'acme.widget', null), 'captures a third-party widget')
+assert(c.plugins.some(p => p.id === 'acme.widget'), 'capture lists the plugin so its component stays loaded')
+assert(tray.dragOutOfTray(c, 'omarchy.tray', 'acme.widget', 'right', 'omarchy.bluetooth'), 'drag-out returns the widget to the layout')
+assert(!c.plugins.some(p => p.id === 'acme.widget'), 'drag-out unlists what capture listed')
+assert(c.bar.layout.right.map(e => e.id).join(',') === 'omarchy.tray,acme.widget,omarchy.bluetooth', 'drag-out inserts before the named entry')
+
+// Order helpers: stable sort by token list with unknowns last, and
+// no-op-aware reordering.
+const items = [{ id: 'b' }, { id: 'a' }, { id: 'new' }]
+assert(tray.sortByOrder(items, ['a', 'b']).map(i => i.id).join(',') === 'a,b,new', 'sortByOrder applies the token list, unknowns last')
+assert(tray.movedBefore(['a', 'b', 'c'], 'c', 'a').join(',') === 'c,a,b', 'movedBefore inserts ahead of the target')
+assert(tray.movedBefore(['a', 'b'], 'b', '') === null, 'movedBefore reports no-ops as null')
+
+// Settings arrays can arrive as array-like proxies from QML; asList copies
+// anything list-shaped into a real array.
+const proxy = { length: 2, 0: 'x', 1: 'y' }
+assert(tray.asList(proxy).join(',') === 'x,y', 'asList unwraps array-like proxies')
+assert(tray.asList(null).length === 0, 'asList tolerates junk')
+JS

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -4,6 +4,22 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+run_node_test "tray application text boundaries" <<'JS'
+const fs = require('fs')
+const trayQml = fs.readFileSync(path.join(root, 'shell/plugins/bar/widgets/Tray.qml'), 'utf8')
+const barQml = fs.readFileSync(path.join(root, 'shell/plugins/bar/Bar.qml'), 'utf8')
+
+function bindingUsesPlainText(source, binding) {
+  const start = source.indexOf(binding)
+  return start !== -1 && source.slice(start, start + 200).includes('textFormat: Text.PlainText')
+}
+
+assert(bindingUsesPlainText(trayQml, 'text: rowRoot.displayName'), 'tray manage-list application title is plain text')
+assert(bindingUsesPlainText(trayQml, 'text: root.currentTitle'), 'tray submenu application title is plain text')
+assert(bindingUsesPlainText(trayQml, 'text: menuRow.rowText'), 'tray application menu row is plain text')
+assert(bindingUsesPlainText(barQml, 'id: tooltipLabel'), 'bar tooltip application metadata is plain text')
+JS
+
 run_node_test "tray model helpers" <<'JS'
 const tray = requireFromRoot('shell/plugins/bar/widgets/TrayModel.js')
 


### PR DESCRIPTION
As proposed in discussion https://github.com/basecamp/omarchy/discussions/7856: the tray is a good overflow drawer, but it only holds status-notifier icons. Users expect that drawer to be where you tuck away *anything* you don't want on the bar full-time. This PR makes the stock tray exactly that — an organizer for the whole bar — while keeping everything it already does (status-notifier items, in-popup app menus with submenu drill-down, the slide-out chevron).

![demo](https://raw.githubusercontent.com/TyRichards/omarchy-tray/main/demo.gif)

## What it adds

- **Drag any bar widget onto the tray** — first-party or plugin — and it moves inside the drawer, landing exactly where released. Hosted widgets keep their inline settings, clicks, tooltips, wheel actions, and panels (the drawer holds itself open while a hosted widget's panel is up).
- **One mixed order**: hosted widgets and tray icons reorder against each other with the same drag, using the bar's own ghost and insertion marker. Icons rearrange within the drawer but can never leave it; dragging a widget out returns it to wherever it is dropped. The chevron is the tray's only whole-widget drag handle.
- **Content-sized drawer**: the tray grows only while revealed instead of permanently reserving its expanded width, so it can hold arbitrarily wide widgets. Taken to the limit, the bar can be a clock and one chevron.
- **Vertical bars**: the drawer expands through the center section, so while it is out the center dims and goes inert — bar background when opaque, a translucent tint when the bar is transparent. Horizontal bars leave the center untouched.

![vertical](https://raw.githubusercontent.com/TyRichards/omarchy-tray/main/demo-vertical.gif)

- **Manage popup** rebuilt as a standard KeyboardPanel (PanelHero header, Escape/click-away close): a master Show System Icons switch plus wifi-style per-icon rows that toggle individual visibility. Tray-icon right-click menus also close on Escape now, and stray tooltips no longer appear over open menus.

## Behavior changes

- **Pinning is retired** in favor of the drag-arranged order (the manual's pin tweak is updated accordingly). Legacy `pinned`/`pinnedWidgets` settings keys are stripped lazily on the next write; previously pinned icons simply rejoin the drawer.
- Hosting a third-party plugin widget lists its id in `plugins[]` while captured (so the registry keeps its component loaded — the enablement scan cannot see ids inside the tray's settings) and removes it again on the way out.

## Testing

- `test/shell.d/tray-test.sh` gains node coverage for capture, drag-out, ordering, and the QML variant-list proxy coercion; the existing tray and tray-menu tests pass unchanged.
- `./test/shell`: 175/179 files pass; the 4 failures (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`) fail identically on a clean checkout in this environment (three need an `omarchy-pkgs` checkout, one cannot start a second Quickshell beside a live session).
- The implementation shipped and iterated as the [`io.github.tyrichards.tray`](https://github.com/TyRichards/omarchy-tray) plugin, exercised end-to-end with injected pointer drags across horizontal/vertical bars, opaque/transparent modes, capture, reorder, drag-out, and popup interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)