### PR TITLE
Apply theme accent color to OpenRGB devices

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -330,6 +330,7 @@ post_theme_commands=(
   omarchy-theme-set-vscode
   omarchy-theme-set-obsidian
   omarchy-theme-set-keyboard
+  omarchy-theme-set-openrgb
 )
 
 if [[ $THEME_HEADLESS != "1" ]]; then

--- a/bin/omarchy-theme-set-openrgb
+++ b/bin/omarchy-theme-set-openrgb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Apply the current theme accent color to OpenRGB devices
+# omarchy:hidden=true
+
+OPENRGB_THEME=$HOME/.local/state/omarchy/current/theme/colors.toml
+
+if omarchy-cmd-present openrgb && [[ -f $OPENRGB_THEME ]]; then
+  color=$(sed -n 's/^accent[[:space:]]*=[[:space:]]*"\?#\?\([0-9A-Fa-f]\{6\}\)"\?.*/\1/p' "$OPENRGB_THEME" | head -n1)
+  [[ $color =~ ^[0-9A-Fa-f]{6}$ ]] || exit 0
+
+  # Direct mode only. ENE DRAM modules and ASUS Aura controllers accept
+  # "static", report success, and never apply the color.
+  openrgb --noautoconnect -m direct -c "$color" >/dev/null 2>&1
+fi


### PR DESCRIPTION
Omarchy already syncs theme colors to keyboard lighting through `omarchy-theme-set-keyboard`, which dispatches to per-vendor scripts (`-asus-rog` via `asusctl`, `-f16` via `qmk_hid`). This adds the same treatment for anything OpenRGB can drive — RAM modules, case fans, motherboard headers, GPUs — as a new `omarchy-theme-set-openrgb` in `post_theme_commands`.

It follows the existing convention: guarded by `omarchy-cmd-present openrgb` so it is a no-op for anyone without OpenRGB installed, validates the color before use, silent on failure.

**Reads `colors.toml`, not `keyboard.rgb`.** The existing keyboard scripts read `keyboard.rgb`, which currently ships in 1 of 22 stock themes (tokyo-night). `colors.toml` ships in 22 of 22, so sourcing `accent` works on every theme without touching theme data. I checked the parser against all 22 stock themes plus 6 generated ones — 28/28 parse cleanly.

**Direct mode is load-bearing.** Several controllers — ENE DRAM modules and ASUS Aura among them — accept `-m static`, report success, and never apply the color. `-m direct` is the only mode that reliably writes. That took a while to pin down, hence the comment in the script.

### Things worth deciding

1. **Overlap with the keyboard scripts.** With no `-d` filter, OpenRGB applies the color to every detected device, including keyboards already handled by `omarchy-theme-set-keyboard`. For an OpenRGB-supported keyboard both fire, and `run_parallel` makes ordering nondeterministic. Both write the same accent so the visible result matches either way, but if you would rather this never touch keyboards it needs a device-type filter, which the OpenRGB CLI does not expose cleanly.

2. **It is slower than its neighbors.** A plain color set measures ~3.8s here, nearly all of it OpenRGB's device enumeration (i2c + HID probing). `asusctl` and `qmk_hid` return effectively instantly. It runs inside `run_parallel` so it does not serialize behind other commands, but it will extend the tail of a theme switch. Happy to background it instead if that matters.

3. **Addressable headers may need one-time sizing.** ASUS Aura addressable zones default to 0 LEDs, and a color write to a zero-LED zone is a silent no-op that still reports success — `--list-devices` just omits the `LEDs:` line. Users with ARGB headers must size their zones once (OpenRGB GUI, or `openrgb -d N -z Z -sz COUNT`) before this does anything visible. I deliberately left resizing out of this script: the correct LED count is per-build, and writing a guessed value into someone's controller on every theme change is not a theme hook's job. Could add a manual note instead if you prefer.

### Testing

`test/cli` passes, including the command-metadata checks.

Verified on ASUS B650EM MAX GAMING WIFI (Aura USB `0b05:19af`, 3 addressable headers) with 4x Patriot Viper Venom DDR5 (`ENE DRAM` over SMBus) and case fans on a passive hub wired to the Aura headers. Theme switches drive all of them to the new accent.

One gap to be transparent about: I have not exercised the unfiltered apply against an OpenRGB-supported *keyboard*, only against RAM, fans, and motherboard headers. That is the same surface as open question 1 above.