### PR TITLE
Address a named workspace by name when toggling its layout

### DIFF
--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -41,12 +41,21 @@ LAYOUT_FILE="$LAYOUTS_DIR/$STATE_KEY.lua"
 mkdir -p "$LAYOUTS_DIR"
 printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ESCAPED_SELECTOR" "$NEW_LAYOUT" >"$LAYOUT_FILE"
 
+# Named workspaces used to persist as <id>.lua. require_all.files globs every
+# *.lua at -maxdepth 1, so leaving that file behind loads both the new name
+# rule and a leftover keyed on an id Hyprland will reassign next session.
+if (( ACTIVE_WORKSPACE_ID < 0 )); then
+  rm -f "$LAYOUTS_DIR/${ACTIVE_WORKSPACE_ID}.lua"
+fi
+
 hyprctl eval "hl.workspace_rule({ workspace = \"$ESCAPED_SELECTOR\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 ||
   hyprctl keyword workspace "$WORKSPACE_SELECTOR, layout:$NEW_LAYOUT"
 
 # `hyprctl eval` reports ok for a rule that matched no workspace, so the only
-# honest confirmation is reading the layout back.
-APPLIED_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout // empty')
+# honest confirmation is reading the layout back — from the workspace we
+# applied to, not whatever is active now. The user can switch away between
+# apply and this query.
+APPLIED_LAYOUT=$(hyprctl workspaces -j | jq -r --arg n "$ACTIVE_WORKSPACE_NAME" '.[] | select(.name==$n) | .tiledLayout // empty')
 if [[ $APPLIED_LAYOUT != "$NEW_LAYOUT" ]]; then
   omarchy-notification-send -u critical -g 󱂬 "Could not set workspace layout to $NEW_LAYOUT"
   exit 1

--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -42,11 +42,11 @@ mkdir -p "$LAYOUTS_DIR"
 printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ESCAPED_SELECTOR" "$NEW_LAYOUT" >"$LAYOUT_FILE"
 
 # Named workspaces used to persist as <id>.lua. require_all.files globs every
-# *.lua at -maxdepth 1, so leaving that file behind loads both the new name
-# rule and a leftover keyed on an id Hyprland will reassign next session.
-if (( ACTIVE_WORKSPACE_ID < 0 )); then
-  rm -f "$LAYOUTS_DIR/${ACTIVE_WORKSPACE_ID}.lua"
-fi
+# *.lua at -maxdepth 1. Ids are reassigned each session, so a leftover is not
+# necessarily named after the id this workspace has now. Under the new scheme a
+# negative id always persists as name-<...>, so every bare negative filename
+# left in here is from the old scheme and safe to drop.
+rm -f "$LAYOUTS_DIR"/-[0-9]*.lua
 
 hyprctl eval "hl.workspace_rule({ workspace = \"$ESCAPED_SELECTOR\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 ||
   hyprctl keyword workspace "$WORKSPACE_SELECTOR, layout:$NEW_LAYOUT"

--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -2,20 +2,54 @@
 
 # omarchy:summary=Toggle the layout on the current active workspace between dwindle and scrolling
 
-ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
-[[ $ACTIVE_WORKSPACE =~ ^-?[0-9]+$ ]] || exit 1
-CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
-LAYOUTS_DIR="$HOME/.local/state/omarchy/workspace-layouts"
-LAYOUT_FILE="$LAYOUTS_DIR/$ACTIVE_WORKSPACE.lua"
+# One query: id, name and layout have to describe the same workspace, and a
+# second call can land after the user has already switched away.
+ACTIVE_WORKSPACE_JSON=$(hyprctl activeworkspace -j)
+ACTIVE_WORKSPACE_ID=$(jq -r '.id // empty' <<<"$ACTIVE_WORKSPACE_JSON")
+ACTIVE_WORKSPACE_NAME=$(jq -r '.name // empty' <<<"$ACTIVE_WORKSPACE_JSON")
+[[ $ACTIVE_WORKSPACE_ID =~ ^-?[0-9]+$ ]] || exit 1
+CURRENT_LAYOUT=$(jq -r '.tiledLayout // empty' <<<"$ACTIVE_WORKSPACE_JSON")
+
+# Hyprland gives named workspaces a negative id and reassigns it every session,
+# so a rule keyed by that id matches nothing — and `hyprctl eval` still answers
+# "ok", so the failure is silent. Address those by name instead, which is what
+# the user chose and what survives a reboot.
+if (( ACTIVE_WORKSPACE_ID < 0 )); then
+  [[ -n $ACTIVE_WORKSPACE_NAME ]] || exit 1
+  WORKSPACE_SELECTOR="name:$ACTIVE_WORKSPACE_NAME"
+  # The state filename becomes a Lua module name, so keep it to characters a
+  # module path can hold. Names collide only if they differ solely by the
+  # characters being replaced.
+  STATE_KEY="name-$(printf '%s' "$ACTIVE_WORKSPACE_NAME" | tr -c 'A-Za-z0-9_-' '_')"
+else
+  WORKSPACE_SELECTOR="$ACTIVE_WORKSPACE_ID"
+  STATE_KEY="$ACTIVE_WORKSPACE_ID"
+fi
 
 case "$CURRENT_LAYOUT" in
   dwindle) NEW_LAYOUT=scrolling ;;
   *) NEW_LAYOUT=dwindle ;;
 esac
 
-mkdir -p "$LAYOUTS_DIR"
-printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ACTIVE_WORKSPACE" "$NEW_LAYOUT" >"$LAYOUT_FILE"
+# The selector is interpolated into a double-quoted Lua string.
+ESCAPED_SELECTOR=${WORKSPACE_SELECTOR//\\/\\\\}
+ESCAPED_SELECTOR=${ESCAPED_SELECTOR//\"/\\\"}
 
-hyprctl eval "hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 || \
-  hyprctl keyword workspace "$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT"
+LAYOUTS_DIR="$HOME/.local/state/omarchy/workspace-layouts"
+LAYOUT_FILE="$LAYOUTS_DIR/$STATE_KEY.lua"
+
+mkdir -p "$LAYOUTS_DIR"
+printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ESCAPED_SELECTOR" "$NEW_LAYOUT" >"$LAYOUT_FILE"
+
+hyprctl eval "hl.workspace_rule({ workspace = \"$ESCAPED_SELECTOR\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 ||
+  hyprctl keyword workspace "$WORKSPACE_SELECTOR, layout:$NEW_LAYOUT"
+
+# `hyprctl eval` reports ok for a rule that matched no workspace, so the only
+# honest confirmation is reading the layout back.
+APPLIED_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout // empty')
+if [[ $APPLIED_LAYOUT != "$NEW_LAYOUT" ]]; then
+  omarchy-notification-send -u critical -g 󱂬 "Could not set workspace layout to $NEW_LAYOUT"
+  exit 1
+fi
+
 omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_LAYOUT"

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -27,8 +27,30 @@ layout=$(<"$state")
 if [[ $1 == "activeworkspace" && -n $HYPRCTL_BROKEN ]]; then
   printf '{}\n'
 elif [[ $1 == "activeworkspace" ]]; then
-  printf '{"id":%s,"name":"%s","tiledLayout":"%s"}\n' \
+  # A second query can land after the user has switched away. Count calls so
+  # the readback test can prove we do not re-query the active workspace.
+  count_file="${state}.aw_count"
+  count=0
+  [[ -f $count_file ]] && count=$(<"$count_file")
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$count_file"
+
+  if [[ -n $HYPRCTL_SWITCHED ]] && (( count > 1 )); then
+    printf '{"id":%s,"name":"%s","tiledLayout":"%s"}\n' \
+      "${HYPRCTL_OTHER_ID:-1}" "${HYPRCTL_OTHER_NAME:-1}" "${HYPRCTL_OTHER_LAYOUT:-dwindle}"
+  else
+    printf '{"id":%s,"name":"%s","tiledLayout":"%s"}\n' \
+      "${HYPRCTL_ID:-3}" "${HYPRCTL_NAME:-3}" "$layout"
+  fi
+elif [[ $1 == "workspaces" ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+  printf '[{"id":%s,"name":"%s","tiledLayout":"%s"}' \
     "${HYPRCTL_ID:-3}" "${HYPRCTL_NAME:-3}" "$layout"
+  if [[ -n $HYPRCTL_SWITCHED ]]; then
+    printf ',{"id":%s,"name":"%s","tiledLayout":"%s"}' \
+      "${HYPRCTL_OTHER_ID:-1}" "${HYPRCTL_OTHER_NAME:-1}" "${HYPRCTL_OTHER_LAYOUT:-dwindle}"
+  fi
+  printf ']\n'
 else
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
   if [[ $1 == "eval" && -n $HYPRCTL_ACCEPTS && $* == *"workspace = \"$HYPRCTL_ACCEPTS\""* ]]; then
@@ -94,9 +116,44 @@ grep -q "Workspace layout set to" "$notify_file" &&
   fail "workspace layout toggle does not claim success for a rule that matched nothing"
 pass "workspace layout toggle reports a rule that applied to nothing"
 
+# ── leftover id-keyed file is removed on upgrade ─────────────────────────────
+# require_all.files globs every *.lua, so a leftover <id>.lua from the old
+# scheme would load alongside the new name-based rule.
+: >"$log_file"
+: >"$notify_file"
+stale_id_file="$home_dir/.local/state/omarchy/workspace-layouts/-1340.lua"
+mkdir -p "$(dirname "$stale_id_file")"
+printf 'hl.workspace_rule({ workspace = "-1340", layout = "dwindle" })\n' >"$stale_id_file"
+run_toggle HYPRCTL_STATE="$tmpdir/s4" HYPRCTL_ID=-1340 HYPRCTL_NAME="DP-1 desk:1" \
+  HYPRCTL_ACCEPTS="name:DP-1 desk:1" ||
+  fail "workspace layout toggle succeeds when replacing an id-keyed state file"
+[[ -f $stale_id_file ]] &&
+  fail "workspace layout toggle removes the leftover id-keyed file"
+[[ -f $named_file ]] ||
+  fail "workspace layout toggle still writes the name-based state file"
+pass "workspace layout toggle removes the leftover id-keyed state file"
+
+# ── readback uses the named workspace, not a later active workspace ──────────
+# If the user switches away between apply and readback, re-querying
+# activeworkspace would read a different workspace and fail a change that
+# worked.
+: >"$log_file"
+: >"$notify_file"
+run_toggle HYPRCTL_STATE="$tmpdir/s5" HYPRCTL_ID=-1340 HYPRCTL_NAME="DP-1 desk:1" \
+  HYPRCTL_ACCEPTS="name:DP-1 desk:1" HYPRCTL_SWITCHED=1 \
+  HYPRCTL_OTHER_ID=7 HYPRCTL_OTHER_NAME=7 HYPRCTL_OTHER_LAYOUT=dwindle ||
+  fail "workspace layout toggle still succeeds if the active workspace changes after apply"
+grep -q "Could not set workspace layout" "$notify_file" &&
+  fail "workspace layout toggle does not fail readback against a different workspace"
+grep -q "Workspace layout set to scrolling" "$notify_file" ||
+  fail "workspace layout toggle confirms the layout on the named workspace"
+grep -F 'workspaces -j' "$log_file" >/dev/null ||
+  fail "workspace layout toggle reads the layout back from the workspace list"
+pass "workspace layout toggle reads back the named workspace after a switch"
+
 # ── malformed hyprctl output ─────────────────────────────────────────────────
 : >"$log_file"
-if run_toggle HYPRCTL_STATE="$tmpdir/s4" HYPRCTL_BROKEN=1 2>/dev/null; then
+if run_toggle HYPRCTL_STATE="$tmpdir/s6" HYPRCTL_BROKEN=1 2>/dev/null; then
   fail "workspace layout toggle exits nonzero without a workspace id"
 fi
 [[ -f "$home_dir/.local/state/omarchy/workspace-layouts/null.lua" ]] &&
@@ -122,5 +179,6 @@ end
 
 assert(seen["3"] == "scrolling", "numeric workspace rule did not load")
 assert(seen["name:DP-1 desk:1"] == "scrolling", "named workspace rule did not load")
+assert(seen["-1340"] == nil, "stale id-keyed rule was not left behind")
 LUA
 pass "saved workspace layouts load into Hyprland configuration"

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -116,22 +116,30 @@ grep -q "Workspace layout set to" "$notify_file" &&
   fail "workspace layout toggle does not claim success for a rule that matched nothing"
 pass "workspace layout toggle reports a rule that applied to nothing"
 
-# ── leftover id-keyed file is removed on upgrade ─────────────────────────────
-# require_all.files globs every *.lua, so a leftover <id>.lua from the old
-# scheme would load alongside the new name-based rule.
+# ── leftover id-keyed files are removed on upgrade ───────────────────────────
+# require_all.files globs every *.lua. The leftover for this workspace is named
+# after an id it no longer has; the file matching the current id usually
+# belongs to a different workspace. Sweep every bare negative-id file.
 : >"$log_file"
 : >"$notify_file"
-stale_id_file="$home_dir/.local/state/omarchy/workspace-layouts/-1340.lua"
-mkdir -p "$(dirname "$stale_id_file")"
-printf 'hl.workspace_rule({ workspace = "-1340", layout = "dwindle" })\n' >"$stale_id_file"
+layouts_dir="$home_dir/.local/state/omarchy/workspace-layouts"
+mkdir -p "$layouts_dir"
+printf 'hl.workspace_rule({ workspace = "-1337", layout = "dwindle" })\n' >"$layouts_dir/-1337.lua"
+printf 'hl.workspace_rule({ workspace = "-1340", layout = "dwindle" })\n' >"$layouts_dir/-1340.lua"
+printf 'hl.workspace_rule({ workspace = "4", layout = "dwindle" })\n' >"$layouts_dir/4.lua"
+rm -f "$named_file"
 run_toggle HYPRCTL_STATE="$tmpdir/s4" HYPRCTL_ID=-1340 HYPRCTL_NAME="DP-1 desk:1" \
   HYPRCTL_ACCEPTS="name:DP-1 desk:1" ||
   fail "workspace layout toggle succeeds when replacing an id-keyed state file"
-[[ -f $stale_id_file ]] &&
-  fail "workspace layout toggle removes the leftover id-keyed file"
+[[ -f $layouts_dir/-1337.lua ]] &&
+  fail "workspace layout toggle removes this workspace's leftover id-keyed file"
+[[ -f $layouts_dir/-1340.lua ]] &&
+  fail "workspace layout toggle removes leftover files even when they match the current id"
+[[ -f $layouts_dir/4.lua ]] ||
+  fail "workspace layout toggle leaves numeric workspace files alone"
 [[ -f $named_file ]] ||
   fail "workspace layout toggle still writes the name-based state file"
-pass "workspace layout toggle removes the leftover id-keyed state file"
+pass "workspace layout toggle removes leftover id-keyed state files"
 
 # ── readback uses the named workspace, not a later active workspace ──────────
 # If the user switches away between apply and readback, re-querying
@@ -160,7 +168,7 @@ fi
   fail "workspace layout toggle does not persist a rule without a workspace id"
 pass "workspace layout toggle ignores broken hyprctl output"
 
-HOME="$home_dir" OMARCHY_PATH="$ROOT" lua <<'LUA'
+HOME="$home_dir" XDG_STATE_HOME="$home_dir/.local/state" OMARCHY_PATH="$ROOT" lua <<'LUA'
 local rules = {}
 
 hl = {

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -10,29 +10,51 @@ trap 'rm -rf "$tmpdir"' EXIT
 stub_dir="$tmpdir/bin"
 home_dir="$tmpdir/home"
 log_file="$tmpdir/hyprctl.log"
+notify_file="$tmpdir/notify.log"
 mkdir -p "$stub_dir" "$home_dir"
 
-cat >"$stub_dir/hyprctl" <<'EOF'
+# The stub models the one behaviour the script has to cope with: `eval` answers
+# ok whether or not the rule matched anything, so the layout only actually
+# changes when the selector is the one Hyprland accepts. HYPRCTL_ACCEPTS names
+# that selector; anything else is applied to nothing.
+cat >"$stub_dir/hyprctl" <<'STUB'
 #!/bin/bash
+
+state="$HYPRCTL_STATE"
+[[ -f $state ]] || printf '%s\n' "${HYPRCTL_LAYOUT:-dwindle}" >"$state"
+layout=$(<"$state")
 
 if [[ $1 == "activeworkspace" && -n $HYPRCTL_BROKEN ]]; then
   printf '{}\n'
 elif [[ $1 == "activeworkspace" ]]; then
-  printf '{"id":3,"tiledLayout":"dwindle"}\n'
+  printf '{"id":%s,"name":"%s","tiledLayout":"%s"}\n' \
+    "${HYPRCTL_ID:-3}" "${HYPRCTL_NAME:-3}" "$layout"
 else
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+  if [[ $1 == "eval" && -n $HYPRCTL_ACCEPTS && $* == *"workspace = \"$HYPRCTL_ACCEPTS\""* ]]; then
+    printf '%s\n' "$(sed -n 's/.*layout = "\([^"]*\)".*/\1/p' <<<"$*")" >"$state"
+  fi
+  printf 'ok\n'
 fi
-EOF
+STUB
 chmod +x "$stub_dir/hyprctl"
 
-cat >"$stub_dir/omarchy-notification-send" <<'EOF'
+cat >"$stub_dir/omarchy-notification-send" <<'STUB'
 #!/bin/bash
-:
-EOF
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUB
 chmod +x "$stub_dir/omarchy-notification-send"
 
-HOME="$home_dir" HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
-  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
+run_toggle() {
+  env HOME="$home_dir" HYPRCTL_LOG="$log_file" NOTIFY_LOG="$notify_file" \
+    PATH="$stub_dir:$PATH" "$@" "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
+}
+
+# ── numeric workspace ────────────────────────────────────────────────────────
+: >"$log_file"
+: >"$notify_file"
+run_toggle HYPRCTL_STATE="$tmpdir/s1" HYPRCTL_ID=3 HYPRCTL_NAME=3 HYPRCTL_ACCEPTS=3 ||
+  fail "workspace layout toggle succeeds on a numeric workspace"
 
 layout_file="$home_dir/.local/state/omarchy/workspace-layouts/3.lua"
 [[ -f $layout_file ]] || fail "workspace layout toggle saves a workspace rule"
@@ -42,8 +64,39 @@ grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling" })' "$l
   fail "workspace layout toggle applies the selected layout immediately"
 pass "workspace layout toggle persists and applies the selected layout"
 
-if HOME="$home_dir" HYPRCTL_LOG="$log_file" HYPRCTL_BROKEN=1 PATH="$stub_dir:$PATH" \
-  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle" 2>/dev/null; then
+# ── named workspace ──────────────────────────────────────────────────────────
+# Hyprland gives these a negative id and reassigns it every session, so the id
+# is useless as a selector and as a filename.
+: >"$log_file"
+: >"$notify_file"
+run_toggle HYPRCTL_STATE="$tmpdir/s2" HYPRCTL_ID=-1340 HYPRCTL_NAME="DP-1 desk:1" \
+  HYPRCTL_ACCEPTS="name:DP-1 desk:1" ||
+  fail "workspace layout toggle succeeds on a named workspace"
+
+grep -Fx 'eval hl.workspace_rule({ workspace = "name:DP-1 desk:1", layout = "scrolling" })' "$log_file" >/dev/null ||
+  fail "workspace layout toggle addresses a named workspace by name"
+named_file="$home_dir/.local/state/omarchy/workspace-layouts/name-DP-1_desk_1.lua"
+[[ -f $named_file ]] ||
+  fail "workspace layout toggle keys the saved rule on the name, not the reassigned id"
+[[ -f "$home_dir/.local/state/omarchy/workspace-layouts/-1340.lua" ]] &&
+  fail "workspace layout toggle does not key a named workspace on its id"
+pass "workspace layout toggle handles named workspaces by name"
+
+# ── a rule that matches nothing must not report success ──────────────────────
+: >"$log_file"
+: >"$notify_file"
+if run_toggle HYPRCTL_STATE="$tmpdir/s3" HYPRCTL_ID=-1340 HYPRCTL_NAME="desk" HYPRCTL_ACCEPTS="never"; then
+  fail "workspace layout toggle exits nonzero when the layout did not change"
+fi
+grep -q "Could not set workspace layout" "$notify_file" ||
+  fail "workspace layout toggle reports a layout it could not apply"
+grep -q "Workspace layout set to" "$notify_file" &&
+  fail "workspace layout toggle does not claim success for a rule that matched nothing"
+pass "workspace layout toggle reports a rule that applied to nothing"
+
+# ── malformed hyprctl output ─────────────────────────────────────────────────
+: >"$log_file"
+if run_toggle HYPRCTL_STATE="$tmpdir/s4" HYPRCTL_BROKEN=1 2>/dev/null; then
   fail "workspace layout toggle exits nonzero without a workspace id"
 fi
 [[ -f "$home_dir/.local/state/omarchy/workspace-layouts/null.lua" ]] &&
@@ -62,8 +115,12 @@ hl = {
 dofile(os.getenv("OMARCHY_PATH") .. "/default/hypr/bootstrap.lua")
 require("default.hypr.workspace-layouts")
 
-assert(#rules == 1)
-assert(rules[1].workspace == "3")
-assert(rules[1].layout == "scrolling")
+local seen = {}
+for _, rule in ipairs(rules) do
+  seen[rule.workspace] = rule.layout
+end
+
+assert(seen["3"] == "scrolling", "numeric workspace rule did not load")
+assert(seen["name:DP-1 desk:1"] == "scrolling", "named workspace rule did not load")
 LUA
 pass "saved workspace layouts load into Hyprland configuration"


### PR DESCRIPTION
Fixes #7961 (thanks @alebak — the diagnosis there is exact).

`omarchy-hyprland-workspace-layout-toggle` keys its `workspace_rule` on `.id`. Hyprland gives named workspaces a **negative** id and reassigns it every session, so the rule matches no workspace. `hyprctl eval` answers `ok` regardless of whether a rule matched anything, so the `||` fallback never fired and the toggle sent a success notification for a change that did not happen.

Three consequences, all in the issue:

- the layout never changes on a named workspace;
- because `CURRENT_LAYOUT` is re-read from `.tiledLayout`, which never moved, every press computes the same target — it never toggles back;
- the persisted state file is named after the id, and ids are reassigned, so two named workspaces can swap rules across a reboot.

This selects named workspaces with `name:<name>` — what the user chose, and stable — and keys the state file on the name too.

Two smaller things came with it:

- **The layout is read back after applying.** `eval`'s `ok` carries no information about whether the rule matched, so reading `.tiledLayout` is the only honest confirmation. A rule that changed nothing now reports that and exits non-zero instead of claiming success.
- **`hyprctl activeworkspace` is queried once.** It was called twice, and id, name and layout have to describe the same workspace — the second call can land after the user has switched away.

The state filename becomes a Lua module name (`require_all.files` requires each `*.lua` under the state dir), so the name is reduced to `[A-Za-z0-9_-]` for the filename while the rule body keeps the real name. The selector is also escaped for the double-quoted Lua string it is interpolated into.

### Evidence

`test/shell.d/hyprland-workspace-layout-test.sh` gains a stub that models the behaviour that made this invisible: `eval` returns `ok` either way, and the layout only actually moves when the selector is the one Hyprland accepts. Cases: numeric workspace (unchanged behaviour), named workspace (selector is `name:…`, state file is `name-…`, and *no* `-1340.lua` is written), and a rule that matches nothing (non-zero exit, no success notification).

Reverting only the script and re-running the test fails at the named-workspace case, so the new coverage has teeth.

`bin-style`, `hyprland-workspace-layout`, `hyprland-default-config` and `hyprland-binding-conflicts` all pass.

### What I could not run

I developed this on macOS, so no Hyprland: the stub covers the script's logic, not Hyprland's acceptance of the `name:` selector — that comes from the issue, where `hl.workspace_rule({ workspace = "name:<monitor description>:1", … })` is shown applying while the id form does not.

The test's Lua block also can't execute here — `require_all.files` shells out to `find -printf`, and Lua's `popen` picks up BSD `find`. Separately, I found that block cannot fail the test on *any* platform: `lua` reading a script from stdin exits 0 even on an uncaught error (`lua -e 'assert(false)'` exits 1; `lua <<EOF` with the same assert exits 0). Five test files use `lua <<`, so that is its own fix and I've kept it out of this PR.

This was AI-assisted.