### PR TITLE
Let a failing Lua assertion fail the test

### DIFF
--- a/test/shell.d/base-test.sh
+++ b/test/shell.d/base-test.sh
@@ -76,6 +76,36 @@ require_compositor() {
   exit 0
 }
 
+# Run a Lua script supplied on stdin, passing its stdout through.
+#
+# `lua` reading a script from stdin exits 0 even when that script raises, so
+# `lua <<'LUA'` silently discards every failure: a failed assert leaves the
+# following pass() reporting success, and a script that dies half way returns
+# partial output that the caller compares against as if it were complete.
+# Running the script from a file is where the interpreter propagates the error.
+lua_script() {
+  local dir status
+  dir=$(mktemp -d)
+  cat >"$dir/script.lua"
+
+  lua "$dir/script.lua"
+  status=$?
+  rm -rf "$dir"
+
+  return $status
+}
+
+# Run a Lua script supplied on stdin and report it as a single assertion.
+run_lua_test() {
+  local description="$1"
+
+  if lua_script; then
+    pass "$description"
+  else
+    fail "$description"
+  fi
+}
+
 run_node_test() {
   require_command node
 

--- a/test/shell.d/base-test.sh
+++ b/test/shell.d/base-test.sh
@@ -78,21 +78,14 @@ require_compositor() {
 
 # Run a Lua script supplied on stdin, passing its stdout through.
 #
-# `lua` reading a script from stdin exits 0 even when that script raises, so
-# `lua <<'LUA'` silently discards every failure: a failed assert leaves the
+# `lua` with no script argument reads stdin but discards the chunk's status, so
+# `lua <<'LUA'` silently swallows every failure: a failed assert leaves the
 # following pass() reporting success, and a script that dies half way returns
 # partial output that the caller compares against as if it were complete.
-# Running the script from a file is where the interpreter propagates the error.
+# Naming stdin explicitly as the script -- `lua -` -- runs the same chunk down
+# the path that does report the error.
 lua_script() {
-  local dir status
-  dir=$(mktemp -d)
-  cat >"$dir/script.lua"
-
-  lua "$dir/script.lua"
-  status=$?
-  rm -rf "$dir"
-
-  return $status
+  lua -
 }
 
 # Run a Lua script supplied on stdin and report it as a single assertion.

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -189,7 +189,7 @@ grep -F 'package.path = home' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
 grep -F '/.local/state/?.lua;' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
 pass "Hyprland user entrypoint keeps package and state path bootstrap in defaults"
 
-OMARCHY_PATH="$ROOT" lua <<'LUA'
+OMARCHY_PATH="$ROOT" run_lua_test "Hyprland bootstrap reloads cached Omarchy config modules" <<'LUA'
 package.loaded["default.hypr.omarchy"] = true
 package.loaded["default.hypr.require_optional"] = true
 package.loaded["hypr.looknfeel"] = true
@@ -204,7 +204,6 @@ assert(package.loaded["hypr.looknfeel"] == nil)
 assert(package.loaded["omarchy.current.theme.hyprland"] == nil)
 assert(package.loaded["unrelated.module"] == true)
 LUA
-pass "Hyprland bootstrap reloads cached Omarchy config modules"
 
 TMPDIR=$(mktemp -d)
 mkdir -p "$TMPDIR/home/.config/omarchy"

--- a/test/shell.d/hyprland-binding-conflicts-test.sh
+++ b/test/shell.d/hyprland-binding-conflicts-test.sh
@@ -143,7 +143,8 @@ mkdir -p "$home" "$stub_bin"
 touch "$stub_bin/voxtype"
 chmod +x "$stub_bin/voxtype"
 
-bindings=$(PATH="$stub_bin:$PATH" list_bindings "$home")
+bindings=$(PATH="$stub_bin:$PATH" list_bindings "$home") ||
+  fail "default bindings load for the conflict check"
 [[ -n $bindings ]] || fail "default bindings load for the conflict check"
 
 grep -Fq $'SUPER + RETURN\tTerminal' <<<"$bindings" || fail "conflict check sees the essential bindings"
@@ -177,14 +178,18 @@ pass "press and release bindings on one key do not read as a conflict"
 
 # Guard the guard: a keysym that lands on an already bound keycode has to be
 # caught, or the check above passes by simply not looking.
-probe=$(PATH="$stub_bin:$PATH" list_bindings "$home" \
-  'o.bind("SUPER + 1", "Conflict probe", "true")' | duplicate_signatures)
+probe_bindings=$(PATH="$stub_bin:$PATH" list_bindings "$home" \
+  'o.bind("SUPER + 1", "Conflict probe", "true")') ||
+  fail "the conflict check catches a keysym colliding with a bound keycode"
+probe=$(duplicate_signatures <<<"$probe_bindings")
 grep -Fqx "SUPER+1" <<<"$probe" ||
   fail "the conflict check catches a keysym colliding with a bound keycode"
 
 # Modifier order is cosmetic; Hyprland binds the same chord either way.
-probe=$(PATH="$stub_bin:$PATH" list_bindings "$home" \
-  'o.bind("SUPER + ALT + SHIFT + RIGHT", "Conflict probe", "true")' | duplicate_signatures)
+probe_bindings=$(PATH="$stub_bin:$PATH" list_bindings "$home" \
+  'o.bind("SUPER + ALT + SHIFT + RIGHT", "Conflict probe", "true")') ||
+  fail "the conflict check ignores modifier order"
+probe=$(duplicate_signatures <<<"$probe_bindings")
 grep -Fqx "ALT+SHIFT+SUPER+RIGHT" <<<"$probe" ||
   fail "the conflict check ignores modifier order"
 pass "the conflict check catches collisions across keycodes and modifier order"

--- a/test/shell.d/hyprland-binding-conflicts-test.sh
+++ b/test/shell.d/hyprland-binding-conflicts-test.sh
@@ -12,7 +12,7 @@ list_bindings() {
   local home="$1"
   local epilogue="${2:-}"
 
-  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_EPILOGUE="$epilogue" lua <<'LUA'
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_EPILOGUE="$epilogue" lua_script <<'LUA'
 package.path = os.getenv("HOME") .. "/.config/?.lua;" .. os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local function proxy()

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -100,7 +100,8 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 fresh_home="$tmpdir/fresh-home"
 mkdir -p "$fresh_home"
-fresh_output=$(run_application_bindings "$fresh_home")
+fresh_output=$(run_application_bindings "$fresh_home") ||
+  fail "default application bindings load from package defaults"
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default application bindings include essentials"
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
@@ -122,7 +123,8 @@ pass "universal clipboard shortcuts avoid virtual keyboard modifier merging"
 removed_home="$tmpdir/removed-home"
 mkdir -p "$removed_home/.local/state/omarchy"
 touch "$removed_home/.local/state/omarchy/preinstalls-removed"
-removed_output=$(run_application_bindings "$removed_home")
+removed_output=$(run_application_bindings "$removed_home") ||
+  fail "preinstall removal flag skips optional application bindings"
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$removed_output" || fail "preinstall removal keeps essential bindings"
 if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$removed_output"; then
   fail "preinstall removal skips preinstalled web app bindings"
@@ -131,7 +133,8 @@ pass "preinstall removal flag skips optional application bindings"
 
 variable_home="$tmpdir/variable-home"
 mkdir -p "$variable_home"
-variable_output=$(run_application_bindings "$variable_home" 'omarchy_preinstalled_bindings = false')
+variable_output=$(run_application_bindings "$variable_home" 'omarchy_preinstalled_bindings = false') ||
+  fail "preinstalled binding variable skips optional application bindings"
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$variable_output" || fail "preinstalled binding variable keeps essential bindings"
 if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$variable_output"; then
   fail "preinstalled binding variable skips optional application bindings"
@@ -140,7 +143,8 @@ pass "preinstalled binding variable skips optional application bindings"
 
 no_bindings_home="$tmpdir/no-bindings-home"
 mkdir -p "$no_bindings_home"
-no_bindings_output=$(run_omarchy_bindings "$no_bindings_home" 'omarchy_default_bindings = false')
+no_bindings_output=$(run_omarchy_bindings "$no_bindings_home" 'omarchy_default_bindings = false') ||
+  fail "default binding variable disables all Omarchy bindings"
 [[ -z $no_bindings_output ]] || fail "default binding variable disables all Omarchy bindings" "$no_bindings_output"
 pass "default binding variable disables all Omarchy bindings"
 
@@ -149,7 +153,8 @@ voxtype_bin="$tmpdir/voxtype-bin"
 mkdir -p "$voxtype_home" "$voxtype_bin"
 touch "$voxtype_bin/voxtype"
 chmod +x "$voxtype_bin/voxtype"
-voxtype_output=$(PATH="$voxtype_bin:$PATH" run_omarchy_bindings "$voxtype_home")
+voxtype_output=$(PATH="$voxtype_bin:$PATH" run_omarchy_bindings "$voxtype_home") ||
+  fail "installed Voxtype conditionally enables dictation bindings"
 grep -Fq $'SUPER + CTRL + X	Toggle dictation' <<<"$voxtype_output" ||
   fail "installed Voxtype enables its toggle binding"
 grep -Fq $'F9	Start dictation (push-to-talk)' <<<"$voxtype_output" ||
@@ -159,7 +164,8 @@ grep -Fq $'F9	Stop dictation (push-to-talk)' <<<"$voxtype_output" ||
 pass "installed Voxtype conditionally enables dictation bindings"
 
 voxtype_without_execute_output=$(PATH="$voxtype_bin:$PATH" run_omarchy_bindings \
-  "$voxtype_home" 'os.execute = function() return nil, "No child processes", 10 end')
+  "$voxtype_home" 'os.execute = function() return nil, "No child processes", 10 end') ||
+  fail "installed Voxtype detection works without os.execute"
 grep -Fq $'SUPER + CTRL + X	Toggle dictation' <<<"$voxtype_without_execute_output" ||
   fail "Voxtype detection does not require spawning a subprocess"
 pass "installed Voxtype detection works without os.execute"
@@ -169,7 +175,8 @@ mkdir -p "$missing_bin"
 ln -s "$(command -v lua)" "$missing_bin/lua"
 ln -s "$(command -v lspci)" "$missing_bin/lspci"
 ln -s "$(command -v sort)" "$missing_bin/sort"
-missing_voxtype_output=$(PATH="$missing_bin" run_omarchy_bindings "$voxtype_home")
+missing_voxtype_output=$(PATH="$missing_bin" run_omarchy_bindings "$voxtype_home") ||
+  fail "missing Voxtype skips dictation bindings"
 if grep -Fq $'SUPER + CTRL + X	Toggle dictation' <<<"$missing_voxtype_output"; then
   fail "missing Voxtype skips its bindings"
 fi
@@ -179,7 +186,8 @@ pass "missing Voxtype skips dictation bindings"
 # working alongside them.
 scratchpad_home="$tmpdir/scratchpad-home"
 mkdir -p "$scratchpad_home"
-scratchpad_output=$(run_omarchy_bindings "$scratchpad_home")
+scratchpad_output=$(run_omarchy_bindings "$scratchpad_home") ||
+  fail "scratchpad retains existing bindings and adds Grave shortcuts"
 grep -Fqx $'SUPER + S	Toggle scratchpad' <<<"$scratchpad_output" ||
   fail "scratchpad keeps its existing toggle binding"
 grep -Fqx $'SUPER + grave	Toggle scratchpad' <<<"$scratchpad_output" ||
@@ -195,7 +203,8 @@ pass "scratchpad retains existing bindings and adds Grave shortcuts"
 # claim on SUPER + CTRL + a number is a collision with one of these.
 panels_home="$tmpdir/panels-home"
 mkdir -p "$panels_home"
-panels_output=$(run_omarchy_bindings "$panels_home")
+panels_output=$(run_omarchy_bindings "$panels_home") ||
+  fail "bar panel hotkeys count the right section"
 for panel in 1 2 3 4 5 6 7 8 9; do
   grep -Fqx "SUPER + CTRL + code:$((panel + 9))"$'\t'"Bar panel $panel" <<<"$panels_output" ||
     fail "bar panel hotkeys count the right section" "$panel"

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -8,7 +8,7 @@ run_application_bindings() {
   local home="$1"
   local prelude="${2:-}"
 
-  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua <<'LUA'
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua_script <<'LUA'
 package.path = os.getenv("HOME") .. "/.config/?.lua;" .. os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local prelude = os.getenv("OMARCHY_BINDING_PRELUDE") or ""
@@ -39,7 +39,7 @@ run_omarchy_bindings() {
   local home="$1"
   local prelude="${2:-}"
 
-  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua <<'LUA'
+  HOME="$home" XDG_CONFIG_HOME="$home/.config" XDG_STATE_HOME="$home/.local/state" OMARCHY_PATH="$ROOT" OMARCHY_BINDING_PRELUDE="$prelude" lua_script <<'LUA'
 package.path = os.getenv("HOME") .. "/.config/?.lua;" .. os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local function proxy()

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 require_command lua
 
 resolved_input() {
-  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua_script <<'LUA'
 package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local vconsole = os.getenv("OMARCHY_VCONSOLE")

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -45,9 +45,9 @@ assert_input() {
   local actual
 
   if (( $# > 2 )); then
-    actual=$(resolved_input "$3")
+    actual=$(resolved_input "$3") || fail "$description" "the Lua script failed"
   else
-    actual=$(resolved_input)
+    actual=$(resolved_input) || fail "$description" "the Lua script failed"
   fi
 
   [[ $actual == "$expected" ]] ||

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -50,7 +50,7 @@ fi
   fail "workspace layout toggle does not persist a rule without a workspace id"
 pass "workspace layout toggle ignores broken hyprctl output"
 
-HOME="$home_dir" OMARCHY_PATH="$ROOT" lua <<'LUA'
+HOME="$home_dir" OMARCHY_PATH="$ROOT" run_lua_test "saved workspace layouts load into Hyprland configuration" <<'LUA'
 local rules = {}
 
 hl = {
@@ -66,4 +66,3 @@ assert(#rules == 1)
 assert(rules[1].workspace == "3")
 assert(rules[1].layout == "scrolling")
 LUA
-pass "saved workspace layouts load into Hyprland configuration"

--- a/test/shell.d/lua-test-helpers-test.sh
+++ b/test/shell.d/lua-test-helpers-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# The point of lua_script is that a raising script returns nonzero, which
+# `lua <<'LUA'` does not. Nothing else covers that: every converted suite runs
+# scripts that succeed, so the false-green behaviour could come back unnoticed.
+printf 'print("hello")\n' >"$tmpdir/hello.lua"
+output=$(lua_script <"$tmpdir/hello.lua") || fail "a succeeding Lua script returns success"
+[[ $output == "hello" ]] || fail "lua_script passes stdout through" "actual: $output"
+pass "lua_script passes stdout through and returns success"
+
+status=0
+lua_script >/dev/null 2>&1 <<'LUA' || status=$?
+assert(false)
+LUA
+(( status != 0 )) || fail "a failing Lua assertion returns nonzero"
+pass "lua_script propagates a failing Lua assertion"
+
+status=0
+lua_script >/dev/null 2>&1 <<'LUA' || status=$?
+error("boom")
+LUA
+(( status != 0 )) || fail "a raised Lua error returns nonzero"
+pass "lua_script propagates a raised Lua error"
+
+# run_lua_test reports one assertion, so its failure path exits; run it in a
+# subshell to observe the exit status rather than inherit it.
+(run_lua_test "a subshell assertion that should not be reported" >/dev/null 2>&1 <<'LUA'
+assert(false)
+LUA
+)
+(( $? != 0 )) || fail "run_lua_test fails on a failing Lua assertion"
+pass "run_lua_test fails on a failing Lua assertion"
+
+run_lua_test "run_lua_test reports a passing Lua script" <<'LUA'
+assert(1 + 1 == 2)
+LUA
+
+# The suites run these scripts under a deliberately stripped PATH to prove a
+# missing binary is detected, so the helper cannot reach for anything but the
+# interpreter itself.
+lua_bin=$(command -v lua)
+bare_bin="$tmpdir/bare-bin"
+mkdir -p "$bare_bin"
+ln -s "$lua_bin" "$bare_bin/lua"
+printf 'print("bare")\n' >"$tmpdir/bare.lua"
+bare=$(PATH="$bare_bin" lua_script <"$tmpdir/bare.lua") ||
+  fail "lua_script runs with only the interpreter on PATH"
+[[ $bare == "bare" ]] || fail "lua_script runs with only the interpreter on PATH" "actual: $bare"
+pass "lua_script needs nothing on PATH but the interpreter"


### PR DESCRIPTION
`lua` reading a script from **stdin** exits 0 even when that script raises. The same script in a file exits 1:

```
$ lua -e 'assert(false)'; echo $?
1
$ printf 'assert(false)\n' > /tmp/t.lua && lua /tmp/t.lua; echo $?
1
$ lua <<'L'
assert(false)
L
echo $?
0                      # <- traceback on stderr, status 0
```

Every Lua block in `test/shell.d` uses the stdin form, so all of them discard their own failures. Five files, six call sites:

- **Assertion-style** (`config-test.sh`, `hyprland-workspace-layout-test.sh`): the block ends `LUA` and the next line is `pass "…"`. A failed `assert` inside prints a traceback and the test reports **ok** anyway. Those assertions have never been able to fail anything.
- **Value-producing** (`hyprland-default-config-test.sh` ×2, `hyprland-binding-conflicts-test.sh`, `hyprland-keyboard-layout-test.sh`): the block prints a value that bash compares against. A script that dies half way returns *partial* output, which the caller then diffs as though it were complete — so the failure surfaces, if at all, as a confusing mismatch rather than the error that caused it.

This adds two helpers to `base-test.sh`:

- `lua_script` — writes stdin to a file, runs `lua` on it, passes stdout through and returns the interpreter's status.
- `run_lua_test <description>` — the assertion-style wrapper, reporting one `ok`/`not ok` instead of an unconditional `pass()`.

and converts all six call sites. No Lua was changed.

### Evidence

The helper itself, both ways round: a passing script reports `ok`, and `assert(false, "boom")` prints the traceback and reports `not ok` — where the old form printed `ok`.

All the affected suites pass after conversion: `hyprland-default-config` (14 assertions), `hyprland-binding-conflicts` (5), `hyprland-keyboard-layout` (7), `hyprland-workspace-layout` (3). So the newly-enabled assertions are genuinely passing, not newly failing.

Two verification notes, because this machine is macOS and Omarchy is Arch:

- `require_all.files` shells out to `find -printf`, which BSD `find` lacks, and Lua's `popen` picks up `/usr/bin/find`. I ran these with a small GNU-`find` shim on `PATH` so the loader behaves as it does on Arch. Without it `hyprland-workspace-layout-test` fails — which is the fix working: that failure was previously invisible.
- `config-test.sh` exits before its Lua block on this machine, at the pre-existing `omarchy-pkgs checkout found for PKGBUILD coverage` gate (that repo isn't public, so the check can't pass outside a Basecamp checkout — it fails identically on unmodified `quattro`). I extracted that Lua block and ran it standalone the way `run_lua_test` does; it exits 0.

**The risk worth naming:** these assertions have never been able to fail, so if any of them is latently wrong, this is the change that turns it red. Everything I can execute here passes, but `config-test`'s block is the one I could only verify in isolation.

This was AI-assisted.