### PR TITLE
Add a Grok collector to the agents panel

### DIFF
--- a/bin/omarchy-agent-usage-grok
+++ b/bin/omarchy-agent-usage-grok
@@ -1,0 +1,491 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Grok usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Grok CLI usage into one display-ready JSON record.
+
+Local stats come from the Grok CLI's session update logs at
+`~/.grok/sessions/<cwd>/<session>/updates.jsonl`; the weekly credit meter comes
+from `/v1/billing?format=credits` on the CLI chat proxy. The agents panel only
+ever reads the JSON this prints.
+"""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+AGENT_ID = "grok"
+AGENT_NAME = "Grok"
+AUTH_HELP = "Run `grok login` to authenticate."
+
+# See omarchy-agent-usage-codex for the same reuse contract: a short window
+# just dedups concurrent collector runs; --limits-only reuses the local scan
+# for the panel's refreshLimits() call, so only the billing probe stays hot.
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+DEFAULT_BILLING_BASE = "https://cli-chat-proxy.grok.com/v1"
+
+# Grok CLI reports weekly quotas today. Monthly and daily are named for
+# future-proofing; the panel's meter is bar-style either way.
+PERIOD_LABELS = {
+  "USAGE_PERIOD_TYPE_WEEKLY": "Weekly",
+  "USAGE_PERIOD_TYPE_MONTHLY": "Monthly",
+  "USAGE_PERIOD_TYPE_DAILY": "Daily",
+}
+
+
+def grok_home():
+  return Path(os.environ.get("GROK_HOME") or (Path.home() / ".grok"))
+
+
+def billing_base_url():
+  return (os.environ.get("GROK_CLI_CHAT_PROXY_BASE_URL") or DEFAULT_BILLING_BASE).rstrip("/")
+
+
+def cache_root():
+  root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def number(value):
+  try:
+    return max(0, int(value or 0))
+  except (TypeError, ValueError):
+    try:
+      return max(0, round(float(value)))
+    except (TypeError, ValueError):
+      return 0
+
+
+def empty_bucket():
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def empty_stats():
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [],
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+  }
+
+
+def local_day(timestamp, mtime=None):
+  raw = timestamp if timestamp is not None else mtime
+  if raw is None:
+    return None
+  try:
+    value = float(raw)
+  except (TypeError, ValueError):
+    return None
+  if value > 10_000_000_000:  # milliseconds
+    value = value / 1000.0
+  try:
+    return datetime.fromtimestamp(value).date().isoformat()
+  except (OverflowError, OSError, ValueError):
+    return None
+
+
+def iter_turn_completed(path):
+  """Yield (usage, day) tuples for each turn_completed update in one session."""
+  try:
+    mtime = path.stat().st_mtime
+  except OSError:
+    mtime = None
+  try:
+    handle = path.open("r", encoding="utf-8", errors="replace")
+  except OSError:
+    return
+  with handle:
+    for line in handle:
+      line = line.strip()
+      if not line:
+        continue
+      try:
+        entry = json.loads(line)
+      except json.JSONDecodeError:
+        continue
+      if not isinstance(entry, dict):
+        continue
+      params = entry.get("params")
+      update = params.get("update") if isinstance(params, dict) else None
+      if not isinstance(update, dict):
+        continue
+      if update.get("sessionUpdate") != "turn_completed":
+        continue
+      usage = update.get("usage")
+      if not isinstance(usage, dict):
+        continue
+      yield usage, local_day(entry.get("timestamp"), mtime)
+
+
+def scan_sessions(sessions_root, today):
+  stats = empty_stats()
+  if not sessions_root.is_dir():
+    return stats
+
+  recent_dates = [
+    (datetime.fromisoformat(today) - timedelta(days=offset)).date().isoformat()
+    for offset in range(6, -1, -1)
+  ]
+  recent = {day: 0 for day in recent_dates}
+  today_by_model = {}
+  model_usage = {}
+  active_dates = set()
+  sessions_touched = set()
+  today_sessions = set()
+  total_prompts = 0
+  today_prompts = 0
+
+  # Layout: ~/.grok/sessions/<url-encoded-cwd>/<session-id>/updates.jsonl
+  for updates_path in sorted(sessions_root.glob("*/*/updates.jsonl")):
+    session_dir = updates_path.parent
+    saw_session = False
+    saw_today = False
+    for usage, day in iter_turn_completed(updates_path):
+      saw_session = True
+      total_prompts += 1
+      per_model = usage.get("modelUsage") if isinstance(usage.get("modelUsage"), dict) else {}
+      if not per_model:
+        # A minimal session that dropped modelUsage still counts toward the
+        # rollup, filed under a generic bucket so the row is not lost.
+        per_model = {"grok": {
+          "inputTokens": usage.get("inputTokens"),
+          "outputTokens": usage.get("outputTokens"),
+          "cachedReadTokens": usage.get("cachedReadTokens"),
+          "cacheCreationTokens": usage.get("cacheCreationTokens"),
+        }}
+      turn_total = 0
+      for raw_model, mstats in per_model.items():
+        if not isinstance(mstats, dict):
+          continue
+        model = str(raw_model or "grok")
+        cached = number(mstats.get("cachedReadTokens"))
+        cache_create = number(mstats.get("cacheCreationTokens"))
+        input_total = number(mstats.get("inputTokens"))
+        # Grok's inputTokens already includes cached reads; split them so the
+        # widget's input/output/cache tooltip lines up with the other
+        # collectors' contract (input = uncached prompt tokens).
+        uncached = max(0, input_total - cached - cache_create)
+        output = number(mstats.get("outputTokens"))
+        bucket = model_usage.setdefault(model, empty_bucket())
+        bucket["inputTokens"] += uncached
+        bucket["outputTokens"] += output
+        bucket["cacheReadInputTokens"] += cached
+        bucket["cacheCreationInputTokens"] += cache_create
+        model_total = uncached + output + cached + cache_create
+        turn_total += model_total
+        if day == today:
+          today_by_model[model] = today_by_model.get(model, 0) + model_total
+      if day:
+        active_dates.add(day)
+        if day in recent:
+          recent[day] += turn_total
+      if day == today:
+        saw_today = True
+        today_prompts += 1
+    if saw_session:
+      sessions_touched.add(session_dir)
+    if saw_today:
+      today_sessions.add(session_dir)
+
+  stats.update({
+    "todayPrompts": today_prompts,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": sum(today_by_model.values()),
+    "todayTokensByModel": today_by_model,
+    "recentDays": [{"date": day, "messageCount": recent[day]} for day in recent_dates],
+    "totalPrompts": total_prompts,
+    "totalSessions": len(sessions_touched),
+    "activeDays": len(active_dates),
+    "activeDates": sorted(active_dates),
+    "modelUsage": model_usage,
+  })
+  return stats
+
+
+def scan_cache_paths():
+  # The digest binds the cache to the resolved home so switching users or
+  # $GROK_HOME never hands the collector a stale fixture.
+  digest = hashlib.sha1(str(grok_home()).encode("utf-8")).hexdigest()[:16]
+  root = cache_root()
+  return root / f"grok-scan-{digest}.json", root / f"grok-scan-{digest}.lock"
+
+
+def read_fresh_json(path, max_age_seconds):
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path, payload):
+  # A per-writer temp name; two collectors running at once (updater + panel)
+  # would otherwise trip over a shared temp path on the second replace.
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+def read_cached_stats(cache_file, max_age_seconds, today):
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+    return None
+  # today* fields only mean "today" on the day they were written.
+  if cached.get("scanDate") != today:
+    return None
+  stats = cached.get("stats")
+  if not isinstance(stats, dict):
+    return None
+  if not all(key in stats for key in ("todayPrompts", "todayTotalTokens", "recentDays", "activeDates", "modelUsage")):
+    return None
+  return stats
+
+
+def write_cached_stats(cache_file, today, stats):
+  try:
+    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+  except Exception as exc:
+    print(f"omarchy-agent-usage-grok: could not write usage cache ({exc})", file=sys.stderr)
+
+
+def cached_local_stats(max_age, today):
+  try:
+    return _cached_local_stats(max_age, today)
+  except Exception as exc:
+    print(f"omarchy-agent-usage-grok: cache unavailable ({exc}); scanning directly", file=sys.stderr)
+    return scan_sessions(grok_home() / "sessions", today)
+
+
+def _cached_local_stats(max_age, today):
+  cache_file, lock_file = scan_cache_paths()
+
+  cached = read_cached_stats(cache_file, max_age, today)
+  if cached is not None:
+    return cached
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_cached_stats(cache_file, max_age, today)
+    if cached is not None:
+      return cached
+    stats = scan_sessions(grok_home() / "sessions", today)
+    write_cached_stats(cache_file, today, stats)
+    return stats
+
+
+class GrokAuthError(Exception):
+  """Raised when the bearer cannot be used against the billing API."""
+
+
+class GrokBillingClient:
+  """Minimal client for the CLI chat proxy billing endpoint."""
+
+  def __init__(self, token, base_url):
+    self.token = token
+    self.base_url = base_url.rstrip("/")
+
+  def credits(self):
+    request = urllib.request.Request(
+      f"{self.base_url}/billing?format=credits",
+      headers={
+        "Authorization": f"Bearer {self.token}",
+        "Accept": "application/json",
+        "x-grok-client-mode": "cli",
+      },
+    )
+    try:
+      with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.load(response)
+    except urllib.error.HTTPError as error:
+      if error.code == 401:
+        raise GrokAuthError("Grok session expired")
+      if error.code == 403:
+        raise GrokAuthError("Grok billing scope denied")
+      raise GrokAuthError(f"Grok billing returned HTTP {error.code}")
+    except (urllib.error.URLError, TimeoutError) as error:
+      raise GrokAuthError("Could not reach the Grok billing API") from error
+    except (json.JSONDecodeError, OSError):
+      raise GrokAuthError("Grok returned an invalid billing response")
+    if not isinstance(payload, dict):
+      raise GrokAuthError("Grok returned an invalid billing response")
+    config = payload.get("config")
+    return config if isinstance(config, dict) else None
+
+
+def read_auth(auth_path):
+  """Return (bearer_token, tier_label, expired) from `~/.grok/auth.json`."""
+  if not auth_path.is_file():
+    return "", "Grok", False
+  try:
+    parsed = json.loads(auth_path.read_text(encoding="utf-8"))
+  except (OSError, json.JSONDecodeError):
+    return "", "Grok", False
+  if not isinstance(parsed, dict) or not parsed:
+    return "", "Grok", False
+  # Prefer the first oidc entry so an old api-key entry never masks a live
+  # login. Users rarely have more than one either way.
+  candidates = [value for value in parsed.values() if isinstance(value, dict)]
+  entry = next((value for value in candidates if str(value.get("auth_mode") or "").lower() == "oidc"), None)
+  entry = entry or (candidates[0] if candidates else {})
+  token = str(entry.get("key") or "").strip()
+  auth_mode = str(entry.get("auth_mode") or "").lower()
+  tier = "grok.com" if auth_mode == "oidc" else ("xAI API" if token else "Grok")
+  expired = False
+  expires_at = str(entry.get("expires_at") or "").strip()
+  if expires_at:
+    try:
+      parsed_expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+      if parsed_expiry.tzinfo is None:
+        parsed_expiry = parsed_expiry.replace(tzinfo=timezone.utc)
+      expired = parsed_expiry < datetime.now(timezone.utc)
+    except ValueError:
+      expired = False
+  return token, tier, expired
+
+
+def credentials(auth_path):
+  """Resolve (token, tier, statusText, helpText) from disk auth + env vars."""
+  env_key = str(os.environ.get("XAI_API_KEY") or "").strip()
+  disk_token, disk_tier, expired = read_auth(auth_path)
+  if env_key:
+    # A bare API key wins over disk auth so users can point the collector at a
+    # different account without disturbing their signed-in CLI.
+    return env_key, "xAI API", "", ""
+  if not disk_token:
+    return "", disk_tier, "Grok signed out", AUTH_HELP
+  if expired:
+    return disk_token, disk_tier, "Grok session expired", AUTH_HELP
+  return disk_token, disk_tier, "", ""
+
+
+def limits_from_billing(config):
+  """Translate the billing config into the widget's limits schema."""
+  limits = []
+  period = config.get("currentPeriod") if isinstance(config.get("currentPeriod"), dict) else {}
+  label = PERIOD_LABELS.get(str(period.get("type") or ""), "Period")
+  try:
+    percent = max(0.0, min(1.0, float(config.get("creditUsagePercent") or 0) / 100.0))
+  except (TypeError, ValueError):
+    percent = 0.0
+  resets_at = str(period.get("end") or config.get("billingPeriodEnd") or "").strip()
+  limits.append({"label": label, "percent": percent, "resetsAt": resets_at})
+
+  cap = 0
+  used = 0
+  try:
+    cap = int((config.get("onDemandCap") or {}).get("val") or 0)
+    used = int((config.get("onDemandUsed") or {}).get("val") or 0)
+  except (TypeError, ValueError):
+    pass
+  if cap > 0:
+    limits.append({
+      "label": "On-demand",
+      "percent": max(0.0, min(1.0, used / cap)),
+      "resetsAt": resets_at,
+    })
+  return limits
+
+
+def scan(max_age, limits_only=False, client_cls=GrokBillingClient):
+  today = datetime.now().astimezone().date().isoformat()
+  token, tier, status_text, help_text = credentials(grok_home() / "auth.json")
+
+  stats = empty_stats() if limits_only else cached_local_stats(max_age, today)
+  has_local = stats["totalPrompts"] > 0
+
+  limits = []
+  if token and not status_text:
+    try:
+      config = client_cls(token, billing_base_url()).credits()
+      if config:
+        limits = limits_from_billing(config)
+    except GrokAuthError as error:
+      status_text = str(error) or "Billing unavailable"
+      if "expired" in status_text.lower():
+        help_text = AUTH_HELP
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": bool(token) or has_local,
+    "hasLocalStats": has_local,
+    "tierLabel": tier,
+    "usageStatusText": status_text,
+    "authHelpText": help_text,
+    "limits": limits,
+  }
+  record.update(stats)
+  return record
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Print the Grok usage record as JSON")
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
+
+  try:
+    record = scan(max_age, limits_only=args.limits_only)
+  except Exception as error:
+    # An unexpected crash still has to leave a valid record: the update runner
+    # rejects anything that is not JSON, and the panel deserves a signal, not
+    # a silent gap.
+    record = {
+      "schemaVersion": 1,
+      "id": AGENT_ID,
+      "name": AGENT_NAME,
+      "updatedAt": datetime.now(timezone.utc).isoformat(),
+      "ready": False,
+      "hasLocalStats": False,
+      "tierLabel": "Grok",
+      "usageStatusText": "Grok usage scan failed",
+      "authHelpText": AUTH_HELP,
+      "limits": [],
+    }
+    record.update(empty_stats())
+    print(f"omarchy-agent-usage-grok: {type(error).__name__}: {error}", file=sys.stderr)
+
+  print(json.dumps(record, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -54,14 +54,17 @@ light surfaces — and the bar glyph stands in when there is none.
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
+| `grok` | The CLI chat proxy's `/billing?format=credits` (weekly credits + on-demand cap) | Grok CLI `updates.jsonl` per session |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
-`CLAUDE_CONFIG_DIR`, Codex via `CODEX_HOME`. Fireworks reads
-`FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
-`~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
-opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
+`CLAUDE_CONFIG_DIR`, Codex via `CODEX_HOME`, Grok via `GROK_HOME`. Grok also
+accepts `XAI_API_KEY` as a bearer, which wins over the disk auth so the
+collector can point at a different account without disturbing a signed-in
+CLI. Fireworks reads `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first,
+then `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the
+key opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
 
 ### Fireworks balance

--- a/shell/plugins/agents/assets/grok-light.svg
+++ b/shell/plugins/agents/assets/grok-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="8">
+    <path d="M14 14 50 50 M50 14 14 50"/>
+  </g>
+</svg>

--- a/shell/plugins/agents/assets/grok.svg
+++ b/shell/plugins/agents/assets/grok.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="8">
+    <path d="M14 14 50 50 M50 14 14 50"/>
+  </g>
+</svg>

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Grok, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,6 +21,7 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
+        "grok": { "enabled": true },
         "fireworks": { "enabled": true }
       },
       "refreshIntervalSec": 900,

--- a/test/shell.d/agent-usage-grok-scanner-test.sh
+++ b/test/shell.d/agent-usage-grok-scanner-test.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+session_dir="$TEST_HOME/.grok/sessions/%2Fhome%2Fers%2Fproj/01a0"
+mkdir -p "$session_dir" "$TEST_HOME/.cache"
+
+cat >"$TEST_HOME/.grok/auth.json" <<'EOF'
+{
+  "https://auth.x.ai::abc": {
+    "auth_mode": "oidc",
+    "key": "test-bearer-token",
+    "expires_at": "2999-01-01T00:00:00Z"
+  }
+}
+EOF
+
+# One turn today, one turn yesterday, per-model split, both in the same
+# session so totalSessions == 1 while activeDays == 2.
+today_ts=$(date -d "today 12:00" +%s)
+yesterday_ts=$(date -d "yesterday 12:00" +%s)
+cat >"$session_dir/updates.jsonl" <<EOF
+{"timestamp":$yesterday_ts,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"turn_completed","prompt_id":"a","stop_reason":"end_turn","usage":{"inputTokens":100,"outputTokens":50,"cachedReadTokens":40,"cacheCreationTokens":0,"totalTokens":150,"modelUsage":{"grok-4.6":{"inputTokens":100,"outputTokens":50,"cachedReadTokens":40,"cacheCreationTokens":0}}}}}}
+{"timestamp":$today_ts,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"turn_completed","prompt_id":"b","stop_reason":"end_turn","usage":{"inputTokens":200,"outputTokens":75,"cachedReadTokens":100,"cacheCreationTokens":0,"totalTokens":275,"modelUsage":{"grok-4.6":{"inputTokens":200,"outputTokens":75,"cachedReadTokens":100,"cacheCreationTokens":0}}}}}}
+{"timestamp":$today_ts,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"turn_started"}}}
+EOF
+
+result=$(python3 - "$ROOT/bin/omarchy-agent-usage-grok" "$TEST_HOME" <<'PY'
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+collector_path = str(Path(sys.argv[1]))
+test_home = Path(sys.argv[2])
+os.environ["HOME"] = str(test_home)
+os.environ["GROK_HOME"] = str(test_home / ".grok")
+os.environ["XDG_CACHE_HOME"] = str(test_home / ".cache")
+os.environ.pop("XAI_API_KEY", None)
+
+loader = importlib.machinery.SourceFileLoader("grok_collector", collector_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+scanner = importlib.util.module_from_spec(spec)
+loader.exec_module(scanner)
+
+summary = {}
+
+# The scanner used by the panel is called with a mock billing client so the
+# test never touches the network. A working client returns the credits config.
+class WorkingClient:
+  def __init__(self, token, base_url):
+    summary.setdefault("clientToken", token)
+
+  def credits(self):
+    return {
+      "currentPeriod": {
+        "type": "USAGE_PERIOD_TYPE_WEEKLY",
+        "end": "2026-08-25T06:15:57+00:00",
+      },
+      "creditUsagePercent": 42.5,
+      "onDemandCap": {"val": 100},
+      "onDemandUsed": {"val": 25},
+      "billingPeriodEnd": "2026-08-25T06:15:57+00:00",
+    }
+
+class ExpiredClient(WorkingClient):
+  def credits(self):
+    raise scanner.GrokAuthError("Grok session expired")
+
+class ForbiddenClient(WorkingClient):
+  def credits(self):
+    raise scanner.GrokAuthError("Grok billing scope denied")
+
+class NetworkFailureClient(WorkingClient):
+  def credits(self):
+    raise scanner.GrokAuthError("Could not reach the Grok billing API")
+
+record = scanner.scan(0, client_cls=WorkingClient)
+summary["record"] = {
+  "schemaVersion": record["schemaVersion"],
+  "id": record["id"],
+  "ready": record["ready"],
+  "hasLocalStats": record["hasLocalStats"],
+  "tierLabel": record["tierLabel"],
+  "usageStatusText": record["usageStatusText"],
+  "authHelpText": record["authHelpText"],
+  "limits": record["limits"],
+  "todayPrompts": record["todayPrompts"],
+  "todaySessions": record["todaySessions"],
+  "activeDays": record["activeDays"],
+  "totalSessions": record["totalSessions"],
+  "todayTokensByModel": record["todayTokensByModel"],
+  "modelUsage": record["modelUsage"],
+}
+
+# --limits-only skips session scanning; totals go to zero even with sessions on disk.
+limits_only = scanner.scan(0, limits_only=True, client_cls=WorkingClient)
+summary["limitsOnlySkipsScan"] = (
+  limits_only["todayTotalTokens"] == 0
+  and limits_only["totalPrompts"] == 0
+  and limits_only["limits"] == record["limits"]
+)
+
+# 401 from billing shows the session-expired message and reasserts the auth
+# help without blowing away the local stats the user already earned.
+expired = scanner.scan(0, client_cls=ExpiredClient)
+summary["expired"] = {
+  "usageStatusText": expired["usageStatusText"],
+  "authHelpText": expired["authHelpText"],
+  "limits": expired["limits"],
+  "hasLocalStats": expired["hasLocalStats"],
+}
+
+forbidden = scanner.scan(0, client_cls=ForbiddenClient)
+summary["forbidden"] = forbidden["usageStatusText"]
+
+network = scanner.scan(0, client_cls=NetworkFailureClient)
+summary["networkFailure"] = network["usageStatusText"]
+
+# XAI_API_KEY overrides the disk token even when the CLI is logged in, so an
+# operator can point the collector at a separate account without touching
+# their signed-in session.
+os.environ["XAI_API_KEY"] = "env-key"
+token, tier, status, _ = scanner.credentials(test_home / ".grok" / "auth.json")
+summary["envKeyWins"] = token == "env-key" and tier == "xAI API" and status == ""
+os.environ.pop("XAI_API_KEY", None)
+
+# An expired disk token drops ready to False but leaves the token available
+# so a retry with fresh credentials does not have to re-parse the file.
+expired_auth = test_home / ".grok" / "auth.json"
+expired_auth.write_text(json.dumps({
+  "https://auth.x.ai::abc": {
+    "auth_mode": "oidc",
+    "key": "stale",
+    "expires_at": "2000-01-01T00:00:00Z",
+  }
+}))
+token, tier, status, help_text = scanner.credentials(expired_auth)
+summary["expiredAuth"] = {
+  "token": token,
+  "tier": tier,
+  "status": status,
+  "help": help_text,
+}
+
+# The signed-out case is a valid record with a hint, never a crash.
+missing_auth = test_home / "missing.json"
+token, tier, status, help_text = scanner.credentials(missing_auth)
+summary["missingAuth"] = {"token": token, "status": status, "help": help_text}
+
+# limits_from_billing rounds the percent, honors on-demand only when a cap
+# exists, and reads billingPeriodEnd when currentPeriod is missing.
+weekly = scanner.limits_from_billing({
+  "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "2026-08-25T00:00:00Z"},
+  "creditUsagePercent": 250,
+})
+summary["percentClamped"] = weekly[0]["percent"] == 1.0
+
+no_ondemand = scanner.limits_from_billing({
+  "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "end": "x"},
+  "creditUsagePercent": 5,
+  "onDemandCap": {"val": 0},
+  "onDemandUsed": {"val": 3},
+})
+summary["ondemandHiddenWithoutCap"] = len(no_ondemand) == 1
+
+fallback_end = scanner.limits_from_billing({
+  "currentPeriod": {"type": "USAGE_PERIOD_TYPE_UNKNOWN"},
+  "creditUsagePercent": 5,
+  "billingPeriodEnd": "2026-09-01T00:00:00Z",
+})
+summary["unknownPeriodLabel"] = fallback_end[0]["label"] == "Period"
+summary["resetFallsBackToBillingPeriod"] = fallback_end[0]["resetsAt"] == "2026-09-01T00:00:00Z"
+
+# GrokBillingClient maps HTTP status codes onto GrokAuthError kinds; the
+# collector then translates those into the panel's status/help text.
+def http_error(code):
+  return urllib.error.HTTPError("https://example", code, "boom", {}, None)
+
+client = scanner.GrokBillingClient("t", "https://example.invalid")
+with mock.patch("urllib.request.urlopen", side_effect=http_error(401)):
+  try:
+    client.credits()
+    summary["mapped401"] = False
+  except scanner.GrokAuthError as e:
+    summary["mapped401"] = "expired" in str(e).lower()
+
+with mock.patch("urllib.request.urlopen", side_effect=http_error(403)):
+  try:
+    client.credits()
+    summary["mapped403"] = False
+  except scanner.GrokAuthError as e:
+    summary["mapped403"] = "scope" in str(e).lower() or "forbidden" in str(e).lower()
+
+print(json.dumps(summary, separators=(",", ":")))
+PY
+)
+
+[[ $(jq -r '.record.todayPrompts' <<<"$result") == "1" ]] ||
+  fail "Grok collector counts each turn_completed once" "$result"
+pass "Grok collector counts each turn_completed once"
+
+[[ $(jq -r '.record.activeDays' <<<"$result") == "2" ]] ||
+  fail "Grok collector spans multiple days into activeDays" "$result"
+pass "Grok collector spans multiple days into activeDays"
+
+[[ $(jq -r '.record.totalSessions' <<<"$result") == "1" ]] ||
+  fail "Grok collector counts one session per session directory" "$result"
+pass "Grok collector counts one session per session directory"
+
+[[ $(jq -c '.record.todayTokensByModel' <<<"$result") == '{"grok-4.6":275}' ]] ||
+  fail "Grok collector groups today's tokens by model" "$result"
+pass "Grok collector groups today's tokens by model"
+
+[[ $(jq -c '.record.modelUsage["grok-4.6"]' <<<"$result") == '{"inputTokens":160,"outputTokens":125,"cacheReadInputTokens":140,"cacheCreationInputTokens":0}' ]] ||
+  fail "Grok collector splits cached reads out of inputTokens for the model table" "$result"
+pass "Grok collector splits cached reads out of inputTokens for the model table"
+
+[[ $(jq -c '.record.limits' <<<"$result") == '[{"label":"Weekly","percent":0.425,"resetsAt":"2026-08-25T06:15:57+00:00"},{"label":"On-demand","percent":0.25,"resetsAt":"2026-08-25T06:15:57+00:00"}]' ]] ||
+  fail "Grok collector emits weekly + on-demand limits from the billing config" "$result"
+pass "Grok collector emits weekly + on-demand limits from the billing config"
+
+[[ $(jq -r '.record.tierLabel + ":" + (.record.ready | tostring)' <<<"$result") == "grok.com:true" ]] ||
+  fail "Grok collector labels an OIDC session as grok.com and marks it ready" "$result"
+pass "Grok collector labels an OIDC session as grok.com and marks it ready"
+
+[[ $(jq -r '.limitsOnlySkipsScan' <<<"$result") == "true" ]] ||
+  fail "Grok collector's --limits-only skips the local scan but still fetches limits" "$result"
+pass "Grok collector's --limits-only skips the local scan but still fetches limits"
+
+[[ $(jq -r '.expired.usageStatusText' <<<"$result") == "Grok session expired" ]] ||
+  fail "Grok collector surfaces 401 as a session-expired message" "$result"
+[[ $(jq -r '.expired.hasLocalStats' <<<"$result") == "true" ]] ||
+  fail "Grok collector preserves local stats when billing 401s" "$result"
+pass "Grok collector preserves local stats when billing 401s"
+
+[[ $(jq -r '.forbidden' <<<"$result") =~ "scope" ]] ||
+  fail "Grok collector distinguishes 403 from expired" "$result"
+pass "Grok collector distinguishes 403 from expired"
+
+[[ $(jq -r '.networkFailure' <<<"$result") =~ "reach" ]] ||
+  fail "Grok collector surfaces network failure as billing status" "$result"
+pass "Grok collector surfaces network failure as billing status"
+
+[[ $(jq -r '.envKeyWins' <<<"$result") == "true" ]] ||
+  fail "Grok collector honors XAI_API_KEY over the disk auth" "$result"
+pass "Grok collector honors XAI_API_KEY over the disk auth"
+
+[[ $(jq -r '.expiredAuth.status' <<<"$result") == "Grok session expired" ]] ||
+  fail "Grok collector flags an expired disk auth" "$result"
+[[ $(jq -r '.expiredAuth.token' <<<"$result") == "stale" ]] ||
+  fail "Grok collector still returns the expired token so a retry can decide what to do" "$result"
+pass "Grok collector flags an expired disk auth without discarding the token"
+
+[[ $(jq -r '.missingAuth.status' <<<"$result") == "Grok signed out" ]] ||
+  fail "Grok collector reports signed-out when auth.json is missing" "$result"
+pass "Grok collector reports signed-out when auth.json is missing"
+
+[[ $(jq -r '.percentClamped' <<<"$result") == "true" ]] ||
+  fail "Grok collector clamps limits.percent to at most 1.0" "$result"
+pass "Grok collector clamps limits.percent to at most 1.0"
+
+[[ $(jq -r '.ondemandHiddenWithoutCap' <<<"$result") == "true" ]] ||
+  fail "Grok collector hides the on-demand bar when no cap is configured" "$result"
+pass "Grok collector hides the on-demand bar when no cap is configured"
+
+[[ $(jq -r '.unknownPeriodLabel' <<<"$result") == "true" ]] ||
+  fail "Grok collector falls back to a generic label for unknown period types" "$result"
+[[ $(jq -r '.resetFallsBackToBillingPeriod' <<<"$result") == "true" ]] ||
+  fail "Grok collector falls back to billingPeriodEnd when currentPeriod.end is missing" "$result"
+pass "Grok collector falls back to billingPeriodEnd when currentPeriod.end is missing"
+
+[[ $(jq -r '.mapped401' <<<"$result") == "true" ]] ||
+  fail "GrokBillingClient maps HTTP 401 onto a session-expired GrokAuthError" "$result"
+pass "GrokBillingClient maps HTTP 401 onto a session-expired GrokAuthError"
+
+[[ $(jq -r '.mapped403' <<<"$result") == "true" ]] ||
+  fail "GrokBillingClient maps HTTP 403 onto a scope-denied GrokAuthError" "$result"
+pass "GrokBillingClient maps HTTP 403 onto a scope-denied GrokAuthError"


### PR DESCRIPTION
## Summary

Adds `omarchy-agent-usage-grok`, the fourth provider in the agents panel. The tab shows a Weekly credit meter (drawn from `/billing?format=credits` on `cli-chat-proxy.grok.com`) and the standard local session/model breakdown scanned out of `~/.grok/sessions/*/*/updates.jsonl`.

The Grok CLI already logs full per-turn usage locally (input/output/cached/reasoning tokens with a per-model split), so the scan side is straightforward. The billing endpoint isn't documented but is what the CLI's own `/usage` slash-command calls, using the OIDC bearer that `grok login` writes to `~/.grok/auth.json`. `XAI_API_KEY` overrides the disk auth for the operator-with-two-accounts case.

Follows the same shape as `omarchy-agent-usage-codex`: same record schema, same cache scheme (20s reuse, 15m for `--limits-only`), same `--force` semantics. Local stats survive when the billing probe fails; 401 / 403 / network errors each map to a distinct panel message.

## Files

- `bin/omarchy-agent-usage-grok` — the collector
- `shell/plugins/agents/manifest.json` — `grok` added to `defaults.providers`
- `shell/plugins/agents/README.md` — Grok row in the collector table and env-var notes
- `shell/plugins/agents/assets/grok{,-light}.svg` — hero mark
- `test/shell.d/agent-usage-grok-scanner-test.sh` — 19 tests covering session parsing, limits shape, `--limits-only`, credential precedence, HTTP status mapping

## Open questions I'd like your steer on before I polish

1. **`scope`.** Fireworks marks the whole record `scope: "account"` because its billing API is account-global. Grok is a mix — sessions are per-machine, but the `/billing` config is account-global. The current schema is per-record. I left `scope` off so per-machine session totals still sum correctly under sync mode; the trade-off is the limit bar is duplicated across synced snapshots. Better to lie about scope, invent a per-field `scope`, or accept the duplication?

2. **Endpoint stability.** `/v1/billing?format=credits` isn't in xAI's public docs — the CLI calls it internally. Fine for now, breaks silently if xAI renames it. Options: (a) leave as-is and fix when it breaks, (b) probe both `/billing` (older schema, still returns 200) and `/billing?format=credits` and prefer whichever has `creditUsagePercent`, (c) put the path behind an env var. I'd lean (a) unless you prefer otherwise.

3. **Token refresh.** The collector doesn't refresh expired OIDC tokens — it emits `Grok session expired` and stops pulling limits until the user runs `grok login`. Local stats keep working. Doing refresh right means implementing the same `refresh_chain` the CLI uses (with the `auth.json.lock` semantics) or shelling out to `grok` itself; either is more code than seemed worth v1. Comfortable landing without it?

## Test plan

- [x] `./test/shell.d/agent-usage-grok-scanner-test.sh` — 19 assertions passing
- [x] Existing `agent-usage-*` and `agents-panel` tests still green
- [ ] Visual verification in the running shell — needs a signed-in `grok` CLI on a machine with the Omarchy shell up