### PR TITLE
Resolve a drive to its disk, not to the deepest device below it

### DIFF
--- a/bin/omarchy-drive-info
+++ b/bin/omarchy-drive-info
@@ -10,13 +10,19 @@ else
   drive="$1"
 fi
 
-# Find the root drive in case we are looking at partitions
-root_drive=$(lsblk -no PKNAME "$drive" 2>/dev/null | tail -n1)
-if [[ -n $root_drive ]]; then
-  root_drive="/dev/$root_drive"
-else
-  root_drive="$drive"
-fi
+# Find the physical drive in case we are looking at a partition or a mapping.
+#
+# `lsblk -no PKNAME <dev>` prints a line for the device *and every descendant*,
+# so taking the last one returned the deepest parent in the subtree rather than
+# the parent of the device asked about. Any LUKS/LVM/MD layer below a partition
+# therefore resolved to that partition, and partitions report no VENDOR/MODEL.
+# `-d` limits the query to the device itself; walk up until there is no parent.
+root_drive="$drive"
+while true; do
+  parent=$(lsblk -dno PKNAME "$root_drive" 2>/dev/null)
+  [[ -n $parent && "/dev/$parent" != "$root_drive" ]] || break
+  root_drive="/dev/$parent"
+done
 
 # Get basic disk information
 size=$(lsblk -dno SIZE "$drive" 2>/dev/null)

--- a/test/shell.d/drive-info-test.sh
+++ b/test/shell.d/drive-info-test.sh
@@ -28,6 +28,7 @@ parent_of() {
   case "$1" in
     sda1|sda2) printf 'sda\n' ;;
     root) printf 'sda2\n' ;;
+    sdb1) printf 'sdb\n' ;;
     *) : ;;
   esac
 }
@@ -41,6 +42,8 @@ elif [[ $opts == *-no\ PKNAME* ]]; then
     sda2) printf 'sda\nsda2\n' ;;
     sda1) printf 'sda\n' ;;
     root) printf 'sda2\n' ;;
+    sdb) printf '\nsdb\n' ;;
+    sdb1) printf 'sdb\n' ;;
   esac
 elif [[ $opts == *-dno\ SIZE* ]]; then
   case "$name" in
@@ -48,12 +51,20 @@ elif [[ $opts == *-dno\ SIZE* ]]; then
     sda1) printf '2G\n' ;;
     sda2) printf '929.5G\n' ;;
     root) printf '929.5G\n' ;;
+    sdb) printf '931.5G\n' ;;
+    sdb1) printf '931.5G\n' ;;
   esac
 elif [[ $opts == *-dno\ VENDOR* ]]; then
   # Only the disk carries these; partitions and mappings report nothing.
-  [[ $name == sda ]] && printf 'ATA     \n'
+  case "$name" in
+    sda | sdb) printf 'ATA     \n' ;;
+  esac
 elif [[ $opts == *-dno\ MODEL* ]]; then
-  [[ $name == sda ]] && printf 'Samsung SSD 870 EVO 1TB\n'
+  case "$name" in
+    sda) printf 'Samsung SSD 870 EVO 1TB\n' ;;
+    # Some controllers repeat the vendor at the head of the model string.
+    sdb) printf 'ATA WDC WD10EZEX-08WN4A0\n' ;;
+  esac
 elif [[ $opts == *TYPE,NAME,FSTYPE,MOUNTPOINT* ]]; then
   case "$name" in
     sda)
@@ -65,6 +76,10 @@ elif [[ $opts == *TYPE,NAME,FSTYPE,MOUNTPOINT* ]]; then
     sda2)
       printf 'part sda2 crypto_LUKS \n'
       printf 'crypt root ext4 /\n'
+      ;;
+    sdb)
+      printf 'disk sdb  \n'
+      printf 'part sdb1 ext4 /home\n'
       ;;
   esac
 fi
@@ -97,7 +112,18 @@ out=$(drive_info /dev/root)
   fail "drive info walks up through a crypt mapping to the disk" "$out"
 pass "drive info walks up through a nested mapping"
 
-# ATA is a prefix of the model string, so it must not be printed twice.
-out=$(drive_info /dev/sda)
+# sdb reports the vendor twice: once as VENDOR and again at the head of MODEL.
+# sda cannot cover this -- its model shares no word with its vendor, so it reads
+# the same whether the labels are deduplicated or simply concatenated.
+out=$(drive_info /dev/sdb)
+[[ $out == *"ATA WDC WD10EZEX-08WN4A0"* ]] ||
+  fail "drive info keeps a model that begins with the vendor" "$out"
 [[ $out != *"ATA ATA"* ]] || fail "drive info does not duplicate the vendor" "$out"
 pass "drive info does not duplicate a vendor already in the model"
+
+# The dedup still has to resolve up first: a partition reports no vendor at all.
+out=$(drive_info /dev/sdb1)
+[[ $out == *"ATA WDC WD10EZEX-08WN4A0"* ]] ||
+  fail "drive info labels a partition from its disk" "$out"
+[[ $out != *"ATA ATA"* ]] || fail "drive info does not duplicate the vendor of a partition" "$out"
+pass "drive info deduplicates the vendor after resolving to the disk"

--- a/test/shell.d/drive-info-test.sh
+++ b/test/shell.d/drive-info-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+# A machine with an encrypted root, which is the topology that broke this:
+#
+#   sda            disk   Samsung SSD 870 EVO 1TB
+#   ├─sda1         part   vfat  /boot
+#   └─sda2         part   crypto_LUKS
+#     └─root       crypt  ext4  /
+#
+# The mapping under sda2 is the whole difference: without it the PKNAME listing
+# ends on the disk, which is why unencrypted drives happened to work.
+cat >"$tmp_dir/bin/lsblk" <<'STUB'
+#!/bin/bash
+
+dev=${*: -1}
+name=${dev#/dev/}
+opts=$*
+
+parent_of() {
+  case "$1" in
+    sda1|sda2) printf 'sda\n' ;;
+    root) printf 'sda2\n' ;;
+    *) : ;;
+  esac
+}
+
+# -d limits the query to the device itself; without it lsblk walks descendants.
+if [[ $opts == *-dno\ PKNAME* ]]; then
+  parent_of "$name"
+elif [[ $opts == *-no\ PKNAME* ]]; then
+  case "$name" in
+    sda) printf '\nsda\nsda\nsda2\n' ;;
+    sda2) printf 'sda\nsda2\n' ;;
+    sda1) printf 'sda\n' ;;
+    root) printf 'sda2\n' ;;
+  esac
+elif [[ $opts == *-dno\ SIZE* ]]; then
+  case "$name" in
+    sda) printf '931.5G\n' ;;
+    sda1) printf '2G\n' ;;
+    sda2) printf '929.5G\n' ;;
+    root) printf '929.5G\n' ;;
+  esac
+elif [[ $opts == *-dno\ VENDOR* ]]; then
+  # Only the disk carries these; partitions and mappings report nothing.
+  [[ $name == sda ]] && printf 'ATA     \n'
+elif [[ $opts == *-dno\ MODEL* ]]; then
+  [[ $name == sda ]] && printf 'Samsung SSD 870 EVO 1TB\n'
+elif [[ $opts == *TYPE,NAME,FSTYPE,MOUNTPOINT* ]]; then
+  case "$name" in
+    sda)
+      printf 'disk sda  \n'
+      printf 'part sda1 vfat /boot\n'
+      printf 'part sda2 crypto_LUKS \n'
+      printf 'crypt root ext4 /\n'
+      ;;
+    sda2)
+      printf 'part sda2 crypto_LUKS \n'
+      printf 'crypt root ext4 /\n'
+      ;;
+  esac
+fi
+STUB
+chmod +x "$tmp_dir/bin/lsblk"
+
+drive_info() {
+  PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-drive-info" "$1"
+}
+
+# The disk itself: the model must survive the crypt layer further down.
+out=$(drive_info /dev/sda)
+[[ $out == *"Samsung SSD 870 EVO 1TB"* ]] ||
+  fail "drive info keeps the model when a crypt layer hangs below the disk" "$out"
+[[ $out == *"vfat(/boot)"* && $out == *"crypto_LUKS"* ]] ||
+  fail "drive info summarises every partition of the disk" "$out"
+pass "drive info reports a disk with an encrypted partition"
+
+# A partition resolves up to its disk, not to itself.
+out=$(drive_info /dev/sda2)
+[[ $out == *"Samsung SSD 870 EVO 1TB"* ]] ||
+  fail "drive info resolves a partition to its disk" "$out"
+[[ $out == *"(929.5G)"* ]] ||
+  fail "drive info reports the size of the device asked about, not the disk" "$out"
+pass "drive info resolves a partition up to its disk"
+
+# The mapping is two levels down; one hop up is still a partition.
+out=$(drive_info /dev/root)
+[[ $out == *"Samsung SSD 870 EVO 1TB"* ]] ||
+  fail "drive info walks up through a crypt mapping to the disk" "$out"
+pass "drive info walks up through a nested mapping"
+
+# ATA is a prefix of the model string, so it must not be printed twice.
+out=$(drive_info /dev/sda)
+[[ $out != *"ATA ATA"* ]] || fail "drive info does not duplicate the vendor" "$out"
+pass "drive info does not duplicate a vendor already in the model"


### PR DESCRIPTION
Fixes #7974.

`omarchy-drive-info` resolved the parent disk with:

```bash
root_drive=$(lsblk -no PKNAME "$drive" 2>/dev/null | tail -n1)
```

`lsblk -no PKNAME <dev>` prints a line for the device **and every descendant**, so `tail -n1` returns the deepest parent in the subtree — not the parent of the device that was asked about. Put a LUKS, LVM or MD layer under a partition and that last line is the *partition*:

```
$ lsblk -no PKNAME /dev/sda
          <- sda itself, no parent
sda       <- sda1
sda       <- sda2
sda2      <- /dev/mapper/root
```

Partitions report no `VENDOR`/`MODEL`, so the label vanished. Unencrypted drives on the same machine were fine only because their listing happens to end on the disk — which is exactly what makes it read as "that drive has no model" rather than a bug.

The partition summary is built from the same `$root_drive`, so an encrypted disk also lost the rest of its partitions: `[crypto_LUKS]` instead of `[vfat(/boot), crypto_LUKS]`. One cause, both symptoms.

Querying with `-d` limits `lsblk` to the device itself, and walking up terminates on the disk. That also fixes the case the old code could never handle: asking about the mapping (`/dev/mapper/root`) is two levels down, so one hop up is still a partition.

### Evidence

New `test/shell.d/drive-info-test.sh` with an `lsblk` stub modelling the reporter's topology — `sda` (Samsung SSD 870 EVO 1TB) → `sda1` vfat `/boot`, `sda2` crypto_LUKS → `root` crypt — where only the disk carries VENDOR/MODEL, as on real hardware.

Four cases: the disk keeps its model and lists both partitions; a partition resolves up to its disk while still reporting *its own* size; the crypt mapping walks up two levels; and `ATA` isn't printed twice when it already prefixes the model.

Reverting just the script and re-running the test reproduces the reported output exactly:

```
/dev/sda (931.5G) [crypto_LUKS]
not ok - drive info keeps the model when a crypt layer hangs below the disk
```

`bin-style-test` passes.

### What I could not run

This machine is macOS, so there is no real `lsblk` — the stub encodes the flag behaviour the script depends on (`-d` restricting to the device, partitions having empty VENDOR/MODEL), taken from the issue's own `lsblk` output. Someone on the reporter's hardware confirming `omarchy-drive-info /dev/sda` now prints the model would close the loop.

This was AI-assisted.