### PR TITLE
Clear passwordless sudo grants at boot

### DIFF
--- a/bin/omarchy-sudo-passwordless
+++ b/bin/omarchy-sudo-passwordless
@@ -15,7 +15,8 @@ fi
 
 echo "Toggle passwordless sudo..."
 
-# Safety: if the file exists but the timer doesn't (e.g. after reboot), clean up
+# Second layer behind etc/tmpfiles.d/omarchy-nopasswd-sudo.conf, which clears the
+# grant at boot: catch a grant whose timer went away some other way.
 if sudo test -f "$NOPASSWD_FILE" && ! systemctl is-active "${TIMER_NAME}.timer" &>/dev/null; then
   sudo rm "$NOPASSWD_FILE"
 fi
@@ -53,7 +54,7 @@ else
 
     echo ""
     echo "Passwordless sudo has been ENABLED. It will automatically disable in ${MINUTES} minutes."
-    echo "Note: if you restart before then, run omarchy-sudo-passwordless again to disable it."
+    echo "A restart clears it too, so it never outlives the window you asked for."
   else
     echo "Aborted. No changes made."
   fi

--- a/etc/tmpfiles.d/omarchy-nopasswd-sudo.conf
+++ b/etc/tmpfiles.d/omarchy-nopasswd-sudo.conf
@@ -1,0 +1,7 @@
+# omarchy-sudo-passwordless writes /etc/sudoers.d/99-omarchy-nopasswd-<user> and
+# arms a transient systemd-run timer to remove it again. Transient units do not
+# survive a reboot, so a reboot inside the window left the grant sitting there
+# with nothing left to take it back, and NOPASSWD: ALL stayed on until the user
+# happened to run the command a second time. Boot-only (r!), so a grant made
+# after boot still lives out its timer the way it was asked to.
+r! /etc/sudoers.d/99-omarchy-nopasswd-*

--- a/manual/48-security.md
+++ b/manual/48-security.md
@@ -20,7 +20,7 @@ It works by restoring the baseline snapshot the installer takes, so it's only av
 
 ## Passwordless sudo
 
-Sometimes you want `sudo` to stop asking, most often when an AI agent is doing a long stretch of system work for you. _Setup > Security > Passwordless Sudo_ turns that off for 15 minutes and then puts it back automatically. Run it again before the timer runs out to end it early, and pass your own number of minutes with `omarchy-sudo-passwordless 30` if 15 isn't enough.
+Sometimes you want `sudo` to stop asking, most often when an AI agent is doing a long stretch of system work for you. _Setup > Security > Passwordless Sudo_ turns that off for 15 minutes and then puts it back automatically. Run it again before the timer runs out to end it early, and pass your own number of minutes with `omarchy-sudo-passwordless 30` if 15 isn't enough. A restart clears it as well, so it cannot outlive the window you asked for.
 
 Be clear-eyed about this one: while it's on, anything running as your user can do anything as root without being asked. That's the whole point, and it's also the whole risk.
 

--- a/test/shell.d/nopasswd-sudo-expiry-test.sh
+++ b/test/shell.d/nopasswd-sudo-expiry-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+script="$ROOT/bin/omarchy-sudo-passwordless"
+tmpfiles_file="$ROOT/etc/tmpfiles.d/omarchy-nopasswd-sudo.conf"
+
+[[ -f $tmpfiles_file ]] ||
+  fail "a tmpfiles rule clears passwordless sudo grants at boot"
+
+# Exactly one rule. A second line here removes something at every boot on every
+# machine, so this file has no room for a passenger.
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$tmpfiles_file")
+(( $(grep -c . <<<"$rules") == 1 )) ||
+  fail "the boot cleanup carries exactly one rule" "got: $rules"
+
+read -r rule_type rule_path _ <<<"$rules"
+
+# r is the removal type, and it runs whenever systemd-tmpfiles is called with
+# --remove, which is not only at boot. The ! holds it to runs that also pass
+# --boot, so a manual systemd-tmpfiles --remove cannot cut a live grant short
+# mid-window.
+[[ $rule_type == 'r!' ]] ||
+  fail "the boot cleanup removes at boot only" "got: $rule_type"
+
+pass "the boot cleanup is a single boot-only removal"
+
+# The rule and the script have to keep naming the same file. If either side is
+# renamed on its own, the grant quietly stops being cleared and nothing fails.
+script_path=$(grep -m1 '^NOPASSWD_FILE=' "$script" | cut -d'"' -f2)
+[[ -n $script_path ]] ||
+  fail "the script names the grant file it writes"
+
+granted=${script_path/'${USER}'/alice}
+# shellcheck disable=SC2053
+[[ $granted == $rule_path ]] ||
+  fail "the boot cleanup matches the grant the script writes" "grant: $granted, rule: $rule_path"
+
+pass "the boot cleanup matches the grant the script writes"
+
+# Everything else under /etc/sudoers.d is a rule Omarchy means to keep. A glob
+# that reached any of them would drop it at every boot.
+for shipped in "$ROOT"/etc/sudoers.d/*; do
+  [[ -f $shipped ]] || continue
+  installed="/etc/sudoers.d/$(basename "$shipped")"
+  # shellcheck disable=SC2053
+  if [[ $installed == $rule_path ]]; then
+    fail "the boot cleanup leaves the shipped sudoers rules alone" "would remove: $installed"
+  fi
+done
+
+pass "the boot cleanup leaves the shipped sudoers rules alone"
+
+# The timer the script arms is transient, which is the whole reason the boot
+# rule exists. If this ever becomes a persistent unit the rule is still correct,
+# but the reason recorded in both files would no longer be.
+grep -q 'systemd-run --on-active' "$script" ||
+  fail "the script still expires the grant with a transient timer"
+
+pass "the script still expires the grant with a transient timer"


### PR DESCRIPTION
`omarchy-sudo-passwordless` writes `/etc/sudoers.d/99-omarchy-nopasswd-<user>` and arms the expiry with `systemd-run`:

```bash
echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee "$NOPASSWD_FILE" > /dev/null
sudo chmod 440 "$NOPASSWD_FILE"
sudo systemd-run --on-active=${MINUTES}m --timer-property=AccuracySec=1s --unit="$TIMER_NAME" \
  rm "$NOPASSWD_FILE"
```

`--on-active` makes a transient timer. Transient units do not survive a reboot. The sudoers file does. So a reboot inside the window takes the timer away and leaves `NOPASSWD: ALL` behind with nothing left to remove it.

Nothing at boot cleans it up. The stale-grant check at the top of the script is the only cleanup there is, and it runs when the user invokes the command a second time, which is the one thing someone who believes the grant already expired has no reason to do. A repo-wide grep finds no other caller: the script, the menu entry, a menu test and the manual.

The window closing on its own is the whole promise. The manual says the setup "turns that off for 15 minutes and then puts it back automatically". The script's own output said "Passwordless sudo will automatically disable after ${MINUTES} minutes." A note further down did admit the gap, telling the user to run the command again after a restart, but a note is not a mechanism, and the reboot is most likely exactly when this feature is in use, since updates restart the machine.

The failure mode is the bad one. The grant does not expire early, it never expires.

The fix is a boot-only tmpfiles rule:

```
r! /etc/sudoers.d/99-omarchy-nopasswd-*
```

`r` removes a path and accepts shell-style globs. `systemd-tmpfiles-setup.service` runs `systemd-tmpfiles --create --remove --boot` at sysinit, long before anyone can reach a shell, so the grant is gone by the time a session exists. The `!` holds the line to runs that also pass `--boot`. Removal entries run under `--remove`, which is not only reached at boot, so without the mark a manual `systemd-tmpfiles --remove` could cut a live grant short mid-window. A grant made after boot still lives out its timer the way it was asked to.

This goes in `etc/tmpfiles.d/`, which `omarchy-settings` already installs to `/etc/tmpfiles.d/` alongside `omarchy-zswap.conf`, so there is no new unit and nothing to enable. Existing installs pick it up with the package.

The check at the top of the script stays as a second layer, for a grant whose timer went away some other way. Its comment now points at the tmpfiles rule rather than naming reboot as the case it handles. The closing note and the manual line now say a restart clears the grant, because it does.

Tests: new `test/shell.d/nopasswd-sudo-expiry-test.sh`. The part worth guarding is that the rule and the script keep naming the same file, since renaming either one alone stops the grant being cleared without anything failing. So the test reads `NOPASSWD_FILE` out of the script, substitutes a username, and checks the tmpfiles glob matches it. It also checks the file carries exactly one rule, that the rule is `r!` rather than a plain `r`, and that the glob matches none of the sudoers files Omarchy ships, so a widened pattern cannot start dropping real rules at every boot. Four checks, all pass, and removing the rule file fails the run before any of them. `./test/shell` comes out the same on this branch as on the base commit, 1740 passing here with the 4 new, same 52 failing files either way. Those 52 are tools missing from my environment, `jq` and `lua` and `magick` and others, and not anything this touches. `./test/cli` needs `jq` and would not run on this machine at all.