### PR TITLE
Stop refresh-config overwriting a config it could not back up

### DIFF
--- a/bin/omarchy-refresh-config
+++ b/bin/omarchy-refresh-config
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # omarchy:summary=Copy a shipped user config from $OMARCHY_PATH/config into ~/.config (backs up your version).
 # omarchy:args=<config-path>
 
@@ -19,7 +21,9 @@ fi
 
 user_config_file="${HOME}/.config/$config_file"
 default_config_file="$OMARCHY_PATH/config/$config_file"
-backup_config_file="$user_config_file.bak.$(date +%s)"
+# The pid keeps two refreshes of the same file in the same second from landing
+# on one name, where the second cp would overwrite the first one's backup.
+backup_config_file="$user_config_file.bak.$(date +%s).$$"
 
 if [[ ! -e $default_config_file ]]; then
   echo "Not a shipped user config: $config_file" >&2
@@ -29,8 +33,18 @@ fi
 mkdir -p "$(dirname "$user_config_file")"
 
 if [[ -f $user_config_file ]]; then
-  cp -f "$user_config_file" "$backup_config_file"
-  cp -f "$default_config_file" "$user_config_file"
+  # The backup is what this command promises, so a copy that fails has to stop
+  # here. Carrying on would put the default in place with nothing to go back to,
+  # and the message below would name a backup that was never written.
+  if ! cp -f "$user_config_file" "$backup_config_file"; then
+    echo -e "\e[31mCould not back up $user_config_file, so it was left alone.\e[0m" >&2
+    exit 1
+  fi
+
+  if ! cp -f "$default_config_file" "$user_config_file"; then
+    echo -e "\e[31mCould not write $user_config_file. Your version is at $backup_config_file.\e[0m" >&2
+    exit 1
+  fi
 
   if cmp -s "$user_config_file" "$backup_config_file"; then
     rm "$backup_config_file"

--- a/test/shell.d/refresh-config-test.sh
+++ b/test/shell.d/refresh-config-test.sh
@@ -38,3 +38,68 @@ grep -Fq 'Not a shipped user config: hypr/missing.lua' "$tmpdir/err" ||
   fail "refresh-config reports missing shipped config"
 
 pass "refresh-config validates against OMARCHY_PATH/config"
+
+# A backup that cannot be written has to stop the refresh. Before this, the
+# second copy went ahead anyway: the user's file was replaced by the default,
+# and the message went on to name a backup that was never written.
+guard_home="$tmpdir/guard-home"
+mkdir -p "$guard_home/.config/hypr"
+printf -- '-- precious user config\n' >"$guard_home/.config/hypr/bindings.lua"
+
+real_cp=$(command -v cp)
+nobackup_bin="$tmpdir/bin-nobackup"
+mkdir -p "$nobackup_bin"
+
+cat >"$nobackup_bin/cp" <<SH
+#!/bin/bash
+
+# Fail only the backup copy, which is the one writing a .bak. destination.
+case "\${!#}" in
+  *.bak.*) exit 1 ;;
+esac
+
+exec "$real_cp" "\$@"
+SH
+chmod +x "$nobackup_bin/cp"
+
+if HOME="$guard_home" OMARCHY_PATH="$omarchy_path" PATH="$nobackup_bin:$PATH" \
+  "$ROOT/bin/omarchy-refresh-config" hypr/bindings.lua >"$tmpdir/guard-out" 2>"$tmpdir/guard-err"; then
+  fail "refresh-config stops when the backup cannot be written"
+fi
+
+grep -Fq -- '-- precious user config' "$guard_home/.config/hypr/bindings.lua" ||
+  fail "refresh-config leaves the user config in place when the backup fails" \
+    "got: $(cat "$guard_home/.config/hypr/bindings.lua")"
+
+grep -Fq 'Could not back up' "$tmpdir/guard-err" ||
+  fail "refresh-config says why it stopped" "got: $(cat "$tmpdir/guard-err")"
+
+pass "refresh-config leaves the user config alone when the backup fails"
+
+# Two refreshes of the same file in the same second landed on one backup name,
+# and the second copy overwrote the first one's backup. The clock is pinned
+# here so the collision is certain rather than a matter of timing.
+clash_home="$tmpdir/clash-home"
+mkdir -p "$clash_home/.config/hypr"
+
+clock_bin="$tmpdir/bin-clock"
+mkdir -p "$clock_bin"
+
+cat >"$clock_bin/date" <<'SH'
+#!/bin/bash
+
+printf '1700000000\n'
+SH
+chmod +x "$clock_bin/date"
+
+for content in first second; do
+  printf -- '-- %s user config\n' "$content" >"$clash_home/.config/hypr/bindings.lua"
+  HOME="$clash_home" OMARCHY_PATH="$omarchy_path" PATH="$clock_bin:$PATH" \
+    "$ROOT/bin/omarchy-refresh-config" hypr/bindings.lua >/dev/null
+done
+
+backups=$(find "$clash_home/.config/hypr" -name 'bindings.lua.bak.*' | wc -l)
+(( backups == 2 )) ||
+  fail "two refreshes in the same second keep both backups" "got: $backups"
+
+pass "two refreshes in the same second keep both backups"


### PR DESCRIPTION
`omarchy-refresh-config` says in its own summary that it backs up your version before overwriting, and `test/shell.d/refresh-config-test.sh` pins that contract. The code did not check whether the backup happened:

```bash
if [[ -f $user_config_file ]]; then
  cp -f "$user_config_file" "$backup_config_file"
  cp -f "$default_config_file" "$user_config_file"
```

There is no `set -e` and no test of the first copy's status, so a backup that fails for any reason, a full disk, a read-only mount, a permissions problem, falls straight through to the copy that replaces the user's file with the shipped default. The customizations are gone and there is nothing to go back to.

The message afterwards makes it worse. With no backup on disk, `cmp -s` cannot match, so the run takes the else branch and prints:

```
Replaced ~/.config/hypr/bindings.lua with new Omarchy default.
Saved backup as ~/.config/hypr/bindings.lua.bak.1700000000.
```

That file does not exist. The user is told their version was kept at the exact moment it was destroyed.

Separately, the backup name is `$user_config_file.bak.$(date +%s)`, which is only unique per second. Refreshes are triggered from updates, menus and migrations, so two runs against the same file can overlap, and the second `cp -f` then overwrites the first one's backup without a word.

What changed:

- Both copies are checked. A failed backup stops the run with a message saying the user's file was left alone, and the file really is left alone. A failed write stops the run and says where the backup is.
- `set -e` at the top, so the `mkdir -p` and the copy on the no-existing-config path cannot fail quietly either.
- The backup name gains the pid, so two refreshes in the same second get two names.

Tests: two cases added to `test/shell.d/refresh-config-test.sh`. The first stubs `cp` to fail only on the `.bak.` destination and checks the run exits non-zero, the user's config still holds its own content, and the error says why. The second pins the clock with a `date` stub so the collision is certain rather than a matter of timing, refreshes the same file twice with different content, and checks both backups survive. Both fail against the old script, the second one reporting one backup where two were expected. Four cases in the file now, all pass. `./test/shell` comes out the same on this branch as on the base commit, 1748 passing here with the 2 new, same 52 failing files either way. Those 52 are tools missing from my environment, `jq` and `lua` and `magick` and others, and not anything this touches. `./test/cli` needs `jq` and would not run on this machine at all.
