### PR TITLE
Route Goodix 53xc fingerprint readers to Dell's proprietary TOD driver

### DIFF
--- a/bin/omarchy-hw-fingerprint-tod
+++ b/bin/omarchy-hw-fingerprint-tod
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when the fingerprint reader present is a Goodix 53xc, which open libfprint cannot drive
+# omarchy:hidden=true
+
+# Goodix 27c6:530c / 533c / 538c readers (Dell machines) have no open-source
+# driver — stock libfprint's goodixmoc table starts at 5840. Dell publishes a
+# proprietary TOD plugin for Linux, packaged in the AUR as
+# libfprint-goodix-53xc, whose compiled id table is exactly these three (the
+# udev rule in that package also lists 5840, but the open driver covers it).
+# Matching is by exact vid:pid, not vendor: nothing else from this vendor
+# should be steered toward a closed blob when the open driver works.
+tod_products=" 530c 533c 538c "
+usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
+
+for dev in "$usb_devices_path"/*; do
+  [[ -r $dev/idVendor && -r $dev/idProduct ]] || continue
+  [[ $(<"$dev/idVendor") == "27c6" ]] || continue
+  [[ $tod_products == *" $(<"$dev/idProduct") "* ]] && exit 0
+done
+
+exit 1

--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -34,6 +34,6 @@ remove_pam_config
 remove_lock_fingerprint_pam
 
 echo "Removing fingerprint packages..."
-omarchy-pkg-drop fprintd libfprint libfprint-git
+omarchy-pkg-drop fprintd libfprint libfprint-git libfprint-tod libfprint-goodix-53xc
 
 echo -e "\e[32mFingerprint authentication has been completely removed.\e[0m"

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -62,6 +62,45 @@ account    include                     system-local-login
 EOF
 }
 
+setup_goodix_tod_driver() {
+  # Goodix 53xc readers (Dell machines) have no open libfprint driver, so
+  # nothing claims the sensor and fprintd reports no devices. Dell ships a
+  # proprietary Linux one, repackaged in the AUR: the closed binary
+  # libfprint-goodix-53xc from Dell's Ubuntu archive, loaded through
+  # libfprint-tod — an open libfprint fork with a vendor-plugin interface.
+  # Closed source installs on a yes, not silently.
+  echo -e "\e[33m\nYour Goodix fingerprint reader has no open-source driver.\e[0m"
+  echo "Dell ships a proprietary one for Linux, packaged in the AUR as"
+  echo "libfprint-goodix-53xc (a closed binary from Dell's Ubuntu archive),"
+  echo "loaded on top of libfprint-tod (an open libfprint fork)."
+
+  if ! gum confirm --default=false "Install the proprietary Dell driver?"; then
+    echo -e "\e[31m\nFingerprint setup cannot continue without it. Aborting.\e[0m"
+    exit 1
+  fi
+
+  # libfprint-tod provides+conflicts libfprint — the same dance as
+  # libfprint-git above, making room in the other direction. Deps-only keeps
+  # an installed fprintd in place.
+  if pacman -Q libfprint &>/dev/null; then
+    sudo pacman -Rdd --noconfirm libfprint
+  fi
+  omarchy-pkg-aur-add libfprint-tod libfprint-goodix-53xc || exit 1
+
+  # fprintd loads TOD plugins when libfprint initializes, and the driver
+  # installs a udev rule for the reader. Reload the rules and stop the daemon
+  # (it dbus-activates fresh on the next call) so the new driver is claimed.
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger
+  sudo systemctl stop fprintd 2>/dev/null || true
+
+  if ! fprintd-list "$USER" &>/dev/null; then
+    echo -e "\e[31m\nThe driver is installed, but fprintd still sees no devices.\e[0m"
+    echo "The reader sometimes needs a reboot before it answers a new driver."
+    exit 1
+  fi
+}
+
 
 echo -e "\e[32mSetting up fingerprint scanner for authentication.\n\e[0m"
 
@@ -81,11 +120,42 @@ if pacman -Q libfprint-git &>/dev/null; then
   sudo pacman -Rdd --noconfirm libfprint-git
 fi
 
-omarchy-pkg-add libfprint fprintd usbutils
+# libfprint-tod provides it too, so a re-run after the Goodix setup below
+# must not try to pull stock libfprint back in. fprintd and usbutils are
+# ensured either way — the fork provides libfprint, not them.
+if ! pacman -Q libfprint-tod &>/dev/null; then
+  omarchy-pkg-add libfprint fprintd usbutils
+else
+  omarchy-pkg-add fprintd usbutils
+fi
+
+# Hardware detection proves a reader exists, not that libfprint can drive
+# it — a reader no open driver claims never reaches fprintd, and enrollment
+# dies instantly on "No devices available" with nothing pointing at the
+# real problem. Ask fprintd before putting a finger on glass, and route
+# Goodix 53xc readers to Dell's proprietary driver.
+if ! fprintd-list "$USER" &>/dev/null; then
+  if omarchy-hw-fingerprint-tod; then
+    setup_goodix_tod_driver
+  else
+    echo -e "\e[31m\nNo installed driver supports your fingerprint reader.\e[0m"
+    echo "The sensor is connected, but fprintd reports no devices, so open"
+    echo "libfprint has no driver for it. Check whether your reader's USB id"
+    echo "is listed at https://fprint.freedesktop.org/supported-devices.html"
+    exit 1
+  fi
+fi
 
 # Enroll first fingerprint
 echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\e[0m"
-echo -e "Keep moving the finger around on sensor until the process completes.\n"
+# The 53xc on Dell's driver is a press sensor, not a swipe sensor — the hint
+# has to match or users scrub a finger it wants held still. Derived from the
+# installed package, not this run's path, so it holds on every re-run too.
+if pacman -Q libfprint-goodix-53xc &>/dev/null; then
+  echo -e "This is a press sensor: lay your finger flat and hold it until each stage completes.\n"
+else
+  echo -e "Keep moving the finger around on sensor until the process completes.\n"
+fi
 
 if sudo fprintd-enroll "$USER"; then
   echo -e "\e[32m\nFingerprint enrolled successfully!\e[0m"

--- a/manual/37-hardware-authentication.md
+++ b/manual/37-hardware-authentication.md
@@ -6,6 +6,8 @@ A lot of laptops come with a fingerprint sensor to do authentication. You can us
 
 That'll install the fingerprint package, collect your print, verify it, and you'll be set to go using your fingerprint to unlock from the lock screen (which you can trigger with `Super + Ctrl + L`), enter sudo mode, and authorize system prompts.
 
+Some Goodix readers found in Dell laptops (the 53xc family) have no open-source driver, so nothing in the stock fingerprint stack can talk to them. When setup detects one of those, it explains the situation and offers to install the proprietary driver Dell ships for Linux. That driver is closed source, which is why Omarchy asks before installing it. These sensors also read a finger that is pressed onto them rather than swiped: lay your finger flat and hold it still until each enrollment stage completes, and give the sensor a break if it reports that it has disabled itself to prevent overheating.
+
 When your laptop lid is closed, the fingerprint prompt is automatically skipped, so you go straight to the password prompt instead of waiting on a sensor you can't reach. If you otherwise need to work on an external keyboard that doesn't have a sensor, just hit `CTRL + C`, when you're prompted for your fingerprint during `sudo`.
 
 You can remove the fingerprint authentication under _Remove > Security > Fingerprint_ in the Omarchy menu.

--- a/test/shell.d/hw-fingerprint-tod-test.sh
+++ b/test/shell.d/hw-fingerprint-tod-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+write_usb_devices() {
+  rm -rf "$tmp_dir/devices"
+  mkdir -p "$tmp_dir/devices"
+
+  local index=0
+  local spec
+  for spec in "$@"; do
+    local vendor=${spec%%:*}
+    local product=${spec#*:}
+    local dev="$tmp_dir/devices/1-$index"
+
+    mkdir -p "$dev"
+    printf '%s\n' "$vendor" >"$dev/idVendor"
+    printf '%s\n' "$product" >"$dev/idProduct"
+    index=$((index + 1))
+  done
+}
+
+hw_fingerprint_tod() {
+  OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-fingerprint-tod"
+}
+
+assert_needs_tod() {
+  local description="$1"
+
+  hw_fingerprint_tod || fail "$description"
+  pass "$description"
+}
+
+assert_open_driver() {
+  local description="$1"
+
+  if hw_fingerprint_tod; then
+    fail "$description"
+  fi
+  pass "$description"
+}
+
+write_usb_devices '27c6:530c'
+assert_needs_tod "a Goodix 530c is flagged for the proprietary driver"
+
+write_usb_devices '27c6:533c'
+assert_needs_tod "a Goodix 533c is flagged for the proprietary driver"
+
+write_usb_devices '27c6:538c'
+assert_needs_tod "a Goodix 538c is flagged for the proprietary driver"
+
+# The open goodixmoc driver covers 5840 and up, so those must not be steered
+# toward the closed blob.
+write_usb_devices '27c6:5840'
+assert_open_driver "a Goodix 5840 stays on the open driver"
+
+write_usb_devices '27c6:6014'
+assert_open_driver "a Goodix 6014 stays on the open driver"
+
+write_usb_devices '27c6:9999'
+assert_open_driver "an unknown Goodix product is not flagged"
+
+write_usb_devices '138a:530c'
+assert_open_driver "another vendor's 530c product id is not flagged"
+
+# Real sysfs device directories can lack attribute files; a missing vendor
+# attribute must be skipped rather than misread as a non-match on another
+# field.
+rm -rf "$tmp_dir/devices"
+mkdir -p "$tmp_dir/devices/1-0"
+printf '530c\n' >"$tmp_dir/devices/1-0/idProduct"
+assert_open_driver "a device missing its vendor attribute is skipped"
+
+write_usb_devices
+assert_open_driver "a machine with no USB devices is not flagged"


### PR DESCRIPTION
# PR: Route Goodix 53xc fingerprint readers to Dell's proprietary TOD driver

Fixes #7991

## What

Goodix `27c6:530c` / `533c` / `538c` readers (Dell machines) have no open-source libfprint driver — the `goodixmoc` id table starts at `5840`. On these, the wizard detects the sensor, installs `fprintd` + stock `libfprint`, and then `fprintd-enroll` dies instantly on "No devices available", reported to the user as "Enrollment failed. Please try again." — a failure retrying can never fix (#7991, also the 533c case from #1590).

- `bin/omarchy-hw-fingerprint-tod` — hidden `hw-` helper: true when a Goodix 53xc reader is present, mirroring `omarchy-hw-fingerprint`'s `OMARCHY_USB_DEVICES_PATH` override for testability. Exact vid:pid match only — the same vendor's 5840+ readers are driven by the open driver and must not be steered toward a closed blob.
- `omarchy-setup-security-fingerprint` — after installing packages, ask `fprintd-list` whether any driver actually claimed the reader before putting a finger on glass:
  - Goodix 53xc present → explain the situation and offer, via `gum confirm --default=false`, to install Dell's proprietary driver (`libfprint-tod` + `libfprint-goodix-53xc` from the AUR, handling the `provides+conflicts libfprint` dance the script already does for `libfprint-git`). Closed source installs on a yes, not silently.
  - any other driverless reader → an actionable message pointing at the fprint supported-devices list, instead of a doomed enroll.
  - re-runs after the TOD install skip reinstalling stock `libfprint` (provider conflict), and the enroll hint switches to press-and-hold since the 53xc is a press sensor, not a swipe sensor — scrubbing a finger it wants held still both fails stages and trips the firmware's overheat lockout (`Device disabled to prevent overheating`, the same self-protection behind #7179), which rapid retries extend.
- `omarchy-remove-security-fingerprint` — also drops the TOD packages (`omarchy-pkg-drop` already ignores names that aren't installed).

PAM wiring is untouched: it comes last, only after a print is enrolled and verified, against whatever driver fprintd loaded.

## Why this shape

The driver is a closed binary, so the wizard asks instead of installing silently — same line #7667 draws for Lenovo's ELAN blob, applied before enrollment rather than after a bogus verify. Keeping the known-id list to the blob's verified table (`530c`, `533c`, `538c`) follows the "no guessing at siblings" approach from #7667; 5840 stays out because the open driver covers it.

## Testing

- `test/shell.d/hw-fingerprint-tod-test.sh` (new), same fixture pattern as `hw-fingerprint-test.sh`: flags 530c/533c/538c, rejects 5840/6014/unknown pids, another vendor's 530c, and an empty bus.
- Full `test/shell` and `test/cli` suites pass (the only failures on this machine are three pre-existing files requiring a local `omarchy-pkgs` checkout; they fail identically on `quattro` HEAD).
- Verified end to end on real hardware (Dell Inspiron 5585, Goodix 27c6:530c): the pre-flight fires, the TOD install completes, fprintd claims the device, and enrollment + verify + PAM setup succeed through the unmodified wizard flow.
