### PR TITLE
Quote mise-install arguments and refuse unusable command names

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -12,7 +12,26 @@ package=$1
 command=${2:-$1}
 bin=${3:-$command}
 
+# The command name becomes a file name under ~/.local/bin, so a slash in it
+# writes the wrapper somewhere else and the rm below deletes somewhere else. A
+# leading dot hides it or walks up, and a leading dash makes a name that reads
+# as an option to whatever picks it up. Checked before anything is removed or
+# written, and kept to those shapes so package names like npm:playwright still
+# stand in for the command name.
+case "$command" in
+  */* | .* | -* | *[[:cntrl:]]*)
+    echo "omarchy-mise-install: '$command' is not usable as a command name" >&2
+    exit 1
+    ;;
+esac
+
 mkdir -p "$HOME/.local/bin"
+
+# The heredoc below is unquoted, so whatever these hold is written into the
+# wrapper as shell source. Quote them the way omarchy-install-and-launch does, so
+# a package name carrying shell characters stays one argument instead of running.
+printf -v package_arg '%q' "$package"
+printf -v bin_arg '%q' "$bin"
 
 # These tools install and upgrade on first run, so mise's release cooldown would
 # hold a new version back for days after it ships. Exported rather than set on
@@ -22,8 +41,8 @@ rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g --quiet "$package" || exit 1
-exec mise x "$package" -- "$bin" "\$@"
+mise use -g --quiet $package_arg || exit 1
+exec mise x $package_arg -- $bin_arg "\$@"
 EOF
 
 chmod +x "$HOME/.local/bin/$command"

--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -33,6 +33,17 @@ mkdir -p "$HOME/.local/bin"
 printf -v package_arg '%q' "$package"
 printf -v bin_arg '%q' "$bin"
 
+# Keep values that are inert inside double quotes in the form existing migrations
+# recognize, including mise backend options that %q would unnecessarily escape.
+case "$package" in
+  *'$'* | *'`'* | *'"'* | *'\'* | *'!'* | *[[:cntrl:]]*) ;;
+  *) package_arg="\"$package\"" ;;
+esac
+case "$bin" in
+  *'$'* | *'`'* | *'"'* | *'\'* | *'!'* | *[[:cntrl:]]*) ;;
+  *) bin_arg="\"$bin\"" ;;
+esac
+
 # These tools install and upgrade on first run, so mise's release cooldown would
 # hold a new version back for days after it ships. Exported rather than set on
 # the install line alone, so resolving the version to execute agrees with the

--- a/test/shell.d/mise-install-test.sh
+++ b/test/shell.d/mise-install-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+stub_bin="$tmpdir/bin"
+mkdir -p "$home" "$stub_bin"
+
+# Stands in for the real mise so a generated wrapper can be run and asked what
+# arguments it passed on.
+cat >"$stub_bin/mise" <<'SH'
+#!/bin/bash
+
+printf 'mise' >>"$OMARCHY_MISE_TEST_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >>"$OMARCHY_MISE_TEST_LOG"
+done
+printf '\n' >>"$OMARCHY_MISE_TEST_LOG"
+SH
+chmod +x "$stub_bin/mise"
+
+install_wrapper() {
+  HOME="$home" "$ROOT/bin/omarchy-mise-install" "$@"
+}
+
+# The ordinary case still works, and every call site in install/user/mise.sh
+# passes names of this shape.
+install_wrapper npm:playwright playwright >/dev/null
+[[ -x $home/.local/bin/playwright ]] ||
+  fail "a normal install writes an executable wrapper"
+
+log="$tmpdir/normal.log"
+: >"$log"
+OMARCHY_MISE_TEST_LOG="$log" PATH="$stub_bin:$PATH" "$home/.local/bin/playwright" >/dev/null
+grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:playwright' "$log" ||
+  fail "the wrapper asks mise for the package it was given" "$(cat "$log")"
+
+pass "a normal install writes a wrapper that names its package"
+
+# A package name is data. Quoted with %q it reaches mise as one argument
+# instead of being read as shell source when the wrapper runs.
+install_wrapper 'npm:pkg$(touch '"$tmpdir"'/PWNED)end' hostile >/dev/null
+
+log="$tmpdir/hostile.log"
+: >"$log"
+OMARCHY_MISE_TEST_LOG="$log" PATH="$stub_bin:$PATH" "$home/.local/bin/hostile" >/dev/null
+
+[[ -e $tmpdir/PWNED ]] &&
+  fail "a package name with shell characters does not run when the wrapper does" \
+    "wrapper: $(cat "$home/.local/bin/hostile")"
+
+grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:pkg$(touch '"$tmpdir"'/PWNED)end' "$log" ||
+  fail "the package reaches mise whole" "$(cat "$log")"
+
+pass "a package name with shell characters reaches mise as one argument"
+
+# The command name is a file name under ~/.local/bin. These shapes escape it,
+# hide it, or make something that reads as an option.
+for name in ../escaped .hidden -dash; do
+  if install_wrapper somepkg "$name" >/dev/null 2>"$tmpdir/err"; then
+    fail "a command name of '$name' is refused"
+  fi
+  grep -Fq 'is not usable as a command name' "$tmpdir/err" ||
+    fail "the refusal says why for '$name'" "$(cat "$tmpdir/err")"
+done
+
+pass "command names that are not plain file names are refused"
+
+# The refusal has to land before the rm, which would otherwise delete the
+# escaped path on its way to failing.
+victim="$tmpdir/victim"
+printf 'keep me\n' >"$victim"
+if install_wrapper somepkg "../../../..$victim" >/dev/null 2>&1; then
+  fail "an escaping command name is refused"
+fi
+[[ -f $victim ]] ||
+  fail "an escaping command name removes nothing outside ~/.local/bin"
+
+pass "an escaping command name removes nothing outside ~/.local/bin"

--- a/test/shell.d/mise-install-test.sh
+++ b/test/shell.d/mise-install-test.sh
@@ -60,13 +60,26 @@ grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:pkg$(touch '"$tmpdir"'/PWNED)end' "$log"
 pass "a package name with shell characters reaches mise as one argument"
 
 # The command name is a file name under ~/.local/bin. These shapes escape it,
-# hide it, or make something that reads as an option.
-for name in ../escaped .hidden -dash; do
+# hide it, make something that reads as an option, or carry characters that have
+# no business in a file name. Labelled so a newline in the value does not end up
+# inside the test output.
+refused=(
+  "a slash" "../escaped"
+  "a leading dot" ".hidden"
+  "a leading dash" "-dash"
+  "a newline" $'with\nnewline'
+  "a tab" $'with\ttab'
+)
+
+for (( i = 0; i < ${#refused[@]}; i += 2 )); do
+  label=${refused[i]}
+  name=${refused[i + 1]}
+
   if install_wrapper somepkg "$name" >/dev/null 2>"$tmpdir/err"; then
-    fail "a command name of '$name' is refused"
+    fail "a command name with $label is refused"
   fi
   grep -Fq 'is not usable as a command name' "$tmpdir/err" ||
-    fail "the refusal says why for '$name'" "$(cat "$tmpdir/err")"
+    fail "the refusal says why for a command name with $label" "$(cat "$tmpdir/err")"
 done
 
 pass "command names that are not plain file names are refused"


### PR DESCRIPTION
`omarchy-mise-install` builds a small wrapper script and writes it with an unquoted heredoc:

```bash
rm -f "$HOME/.local/bin/$command"
cat >"$HOME/.local/bin/$command" <<EOF
#!/bin/bash
export MISE_MINIMUM_RELEASE_AGE=0
mise use -g --quiet "$package" || exit 1
exec mise x "$package" -- "$bin" "\$@"
EOF
```

Two things go wrong there.

The package and bin names are written into the wrapper as shell source. Nothing runs at the moment the file is written, since the heredoc inserts the value and does not look at it again, but the value is now code in a file the user runs later. `omarchy-mise-install 'npm:pkg$(id)end' hostile` produces this:

```bash
mise use -g --quiet "npm:pkg$(id)end" || exit 1
exec mise x "npm:pkg$(id)end" -- "hostile" "$@"
```

`id` runs on every invocation of the wrapper from then on. A package name holding a double quote breaks the wrapper's own quoting the same way.

The command name is used raw as a file name. `omarchy-mise-install somepkg ../../evil` writes the wrapper outside `~/.local/bin`, and the `rm -f` on the line above removes that path first, so an escaping name deletes a file before the write is even attempted.

Every call site in `install/user/mise.sh` passes fixed names, so nothing here is reachable from the shipped configuration. But `manual/17-ai.md` documents the command for exactly this purpose, "To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`", so the arguments are meant to be data and were not treated as data.

What changed:

- `package` and `bin` are quoted with `printf %q` before they enter the heredoc, which is what `omarchy-install-and-launch` already does for the values it interpolates. The wrapper's own double quotes come off, since `%q` supplies the quoting.
- The command name is checked before the `rm`, and refused if it holds a slash, starts with a dot or a dash, or carries control characters. A slash escapes the directory, a leading dot hides it or walks up, and a leading dash makes a name that reads as an option.

The check is by shape rather than an allowed character list on purpose. Package names like `npm:playwright` stand in for the command name when no second argument is given, and an allowed list would have to keep guessing which characters mise backends use next.

Tests: new `test/shell.d/mise-install-test.sh` stubs `mise` so a generated wrapper can be run and asked what it passed on. Four cases: a normal install writes a wrapper that hands mise the package it was given, a package name holding `$(...)` reaches mise whole and does not run when the wrapper runs, the three refused name shapes are refused with a reason, and an escaping name removes nothing outside `~/.local/bin`. All 4 pass, and the second one fails against the old script with the wrapper visibly carrying the live substitution. `./test/shell` comes out the same on this branch as on the base commit, 1740 passing here with the 4 new, same 52 failing files either way. Those 52 are tools missing from my environment, `jq` and `lua` and `magick` and others, and not anything this touches. `./test/cli` needs `jq` and would not run on this machine at all.
