### PR TITLE
Stage diagnostics logs privately instead of at fixed /tmp paths

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -26,7 +26,12 @@ while (( $# > 0 )); do
   esac
 done
 
-LOG_FILE="/tmp/omarchy-debug.log"
+# The log holds sudo dmesg output and the boot journal. At a fixed name in /tmp
+# it was created with the default umask, so every local user on the machine
+# could read it, and it stayed there after the command exited. mktemp makes it
+# 0600 under a name nobody can guess, and the trap clears it on the way out.
+LOG_FILE=$(mktemp) || exit 1
+trap 'rm -f "$LOG_FILE"' EXIT
 
 if [[ $NO_SUDO = "true" ]]; then
   DMESG_OUTPUT="(skipped - --no-sudo flag used)"

--- a/bin/omarchy-install-gaming-battlenet
+++ b/bin/omarchy-install-gaming-battlenet
@@ -57,7 +57,13 @@ app launcher.
 
 EOF
 
-  log="/tmp/omarchy-battlenet-installer.log"
+  # The log is written by the detached installer after this script exits, so it
+  # cannot be cleaned up here. At a fixed name in /tmp another local account
+  # could read it, and with fs.protected_regular a second user running this
+  # command got "Permission denied" on the file the first user left. The cache
+  # directory is private to the user, so a fixed name here is fine and each run
+  # overwrites the last log instead of leaving a new file behind.
+  log="$cache_dir/battlenet-installer.log"
   setsid -f sh -c "umu-run '$installer' >'$log' 2>&1" </dev/null >/dev/null 2>&1
   echo "Installer log: $log"
   launched_installer=1

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -8,8 +8,15 @@
 set -e
 
 if [[ -z ${OMARCHY_UPDATE_LOGGED:-} ]]; then
+  # The transcript is read back by omarchy-update-analyze-logs after the run,
+  # so it needs a stable name rather than mktemp. At a fixed name in /tmp
+  # another local account could read the output, and with fs.protected_regular
+  # a second user running the update got "Permission denied" on the file the
+  # first user left. The user's own state directory avoids both.
+  update_log="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/update.log"
+  mkdir -p "$(dirname "$update_log")"
   script_command=$(printf '%q ' "$0" "$@")
-  exec env OMARCHY_UPDATE_LOGGED=1 script -qefc "$script_command" "/tmp/omarchy-update.log"
+  exec env OMARCHY_UPDATE_LOGGED=1 script -qefc "$script_command" "$update_log"
 fi
 
 if ! omarchy-update-lock held; then

--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -2,7 +2,10 @@
 
 # omarchy:summary=Check the update log for known failure conditions
 
-update_log="/tmp/omarchy-update.log"
+# Same transcript path omarchy-update writes. Kept in the user's state
+# directory, not /tmp, so no other local account can read it and two users
+# running the update do not collide on one file.
+update_log="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/update.log"
 
 # Check for initramfs generation failure
 if grep -q "Updating linux initcpios" "$update_log"; then

--- a/bin/omarchy-upload-log
+++ b/bin/omarchy-upload-log
@@ -5,8 +5,13 @@
 # omarchy:hidden=true
 
 LOG_TYPE="${1:-install}"
-TEMP_LOG="/tmp/upload-log.txt"
-SYSTEM_INFO="/tmp/system-info.txt"
+# The bundle collects the boot journal and the install logs before it is sent.
+# At fixed names in /tmp both files were world readable under the default umask
+# and were never removed, so the last bundle sat there for any local user to
+# read. mktemp makes them 0600, and the trap clears them on the way out.
+TEMP_LOG=$(mktemp) || exit 1
+SYSTEM_INFO=$(mktemp) || exit 1
+trap 'rm -f "$TEMP_LOG" "$SYSTEM_INFO"' EXIT
 
 # Get system information if fastfetch is available
 if omarchy-cmd-present fastfetch; then

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -86,9 +86,9 @@ gh issue create --repo basecamp/omarchy --title "..." --body "..."
 ```
 
 Include what happened, what was expected, steps to reproduce, system details from
-`omarchy version`, and diagnostics from `omarchy debug --no-sudo --print` (which
-also writes `/tmp/omarchy-debug.log`; the interactive `omarchy debug` can upload
-it and print a shareable URL worth including).
+`omarchy version`, and diagnostics from `omarchy debug --no-sudo --print` (the
+interactive `omarchy debug` can upload the same log and print a shareable URL
+worth including, or save a copy in the current directory).
 
 `gh` cannot attach media. If a screenshot would help, save one and give the user
 the path to drag into the web form.

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -22,7 +22,7 @@ description with steps to reproduce, and diagnostics. Gather them:
 ```bash
 omarchy version
 
-# Generate the diagnostic log (also written to /tmp/omarchy-debug.log)
+# Print the diagnostic log
 omarchy debug --no-sudo --print
 
 # Interactive variant: `omarchy debug` offers to upload the log to

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -22,7 +22,7 @@ The design goal is:
 | Path | Owner | Purpose |
 | --- | --- | --- |
 | `${XDG_RUNTIME_DIR:-/tmp}/omarchy-update.lock` | user | Prevent overlapping update runs. Owned by `omarchy-update-lock`; compatibility wrappers inherit/respect it. |
-| `/tmp/omarchy-update.log` | user | Transcript of `omarchy update`, used by `omarchy-update-analyze-logs`. |
+| `~/.local/state/omarchy/update.log` | user | Transcript of `omarchy update`, used by `omarchy-update-analyze-logs`. |
 | `~/.local/state/omarchy/current/` | user | Generated active theme, selected theme name, and current background symlink. |
 | `~/.local/state/omarchy/migrations/` | user | Per-user migration markers. |
 | `~/.local/state/omarchy/reboot-required` | user | Optional reboot marker checked by `omarchy-update-restart`. |
@@ -112,7 +112,7 @@ High-level flow:
 
 ```text
 omarchy-update
-  ├─ ensure transcript logging through script(1) → /tmp/omarchy-update.log
+  ├─ ensure transcript logging through script(1) → ~/.local/state/omarchy/update.log
   ├─ omarchy-update-lock
   │    └─ acquire the update lock and run omarchy-update inside it
   ├─ omarchy-update-requires-free-space
@@ -145,8 +145,8 @@ Important behavior:
   check is silently skipped. Set `OMARCHY_UPDATE_FORCE=1` to bypass the check.
 - `omarchy update` checks/runs migrations in the same visible terminal via
   `omarchy-migrate` after pacman finishes.
-- A failure should leave enough output in `/tmp/omarchy-update.log` and the
-  terminal transcript to debug.
+- A failure should leave enough output in `~/.local/state/omarchy/update.log`
+  and the terminal transcript to debug.
 
 ## Path 2: direct `sudo pacman -Syu` attempt
 
@@ -284,7 +284,7 @@ scripts.
 | `omarchy-update-aur-pkgs` | Updates AUR packages with `yay -Sua` if foreign packages exist and AUR is reachable. | **Question.** Omarchy is package-backed now, but users may still install AUR packages. Keep for now. |
 | `omarchy-update-mise` | Runs `MISE_MINIMUM_RELEASE_AGE=0 mise up` for mise-managed tools — the override of mise's release-age cooldown is the point. | **Keep.** Mise-managed tools are intentionally part of the blessed update path. |
 | `omarchy-update-orphan-pkgs` | Lists orphans and prompts before removal; noninteractive mode never removes. | **Keep for now.** Safe because it is prompt-only. |
-| `omarchy-update-analyze-logs` | Scans `/tmp/omarchy-update.log` for known failure patterns, currently initramfs generation. | **Keep/expand.** Useful safety net; should grow only for high-signal checks. |
+| `omarchy-update-analyze-logs` | Scans `~/.local/state/omarchy/update.log` for known failure patterns, currently initramfs generation. | **Keep/expand.** Useful safety net; should grow only for high-signal checks. |
 | `omarchy-update-restart` | Prompts for reboot after kernel/Hyprland updates, restarts components with `restart-*-required` markers, and always restarts the shell. | **Keep.** Important final step; may eventually include service-restart checks. |
 | `omarchy-update-firmware` | Manual firmware update command using fwupd. Not part of the normal update pipeline. | **Keep separate.** Firmware is not a routine system update step. |
 | `omarchy-update-time` | Restarts `systemd-timesyncd`. | **Question.** Not really an update command. Consider renaming/moving under system/time maintenance. |

--- a/test/shell.d/diagnostics-staging-test.sh
+++ b/test/shell.d/diagnostics-staging-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+staging="$tmpdir/staging"
+rm_log="$tmpdir/rm.log"
+mkdir -p "$stub_bin" "$staging"
+: >"$rm_log"
+
+real_rm=$(command -v rm)
+
+# Everything omarchy-debug gathers, answering fast and saying nothing that
+# matters.
+for tool in dmesg inxi journalctl pacman expac comm gum ping curl less; do
+  cat >"$stub_bin/$tool" <<'SH'
+#!/bin/bash
+
+exit 0
+SH
+  chmod +x "$stub_bin/$tool"
+done
+
+# Only dmesg is elevated here, and its output is the privileged part of the log.
+# The marker lets the print check find it without matching on anything else.
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'DMESG-MARKER\n'
+SH
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/hostname" <<'SH'
+#!/bin/bash
+
+printf 'test-host\n'
+SH
+chmod +x "$stub_bin/hostname"
+
+# Records what the script removes, then removes it for real. An empty staging
+# directory on its own would also pass for a script that never staged there,
+# which is what the old fixed /tmp path did.
+cat >"$stub_bin/rm" <<SH
+#!/bin/bash
+
+printf '%s\n' "\$@" >>"$rm_log"
+exec "$real_rm" "\$@"
+SH
+chmod +x "$stub_bin/rm"
+
+# TMPDIR points the staging somewhere this test owns, so the checks below read
+# only what this run created.
+output=$(TMPDIR="$staging" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-debug" --print 2>/dev/null)
+
+grep -q 'DMESG-MARKER' <<<"$output" ||
+  fail "omarchy debug --print still prints what it gathered"
+pass "omarchy debug --print still prints what it gathered"
+
+grep -q "$staging/" "$rm_log" ||
+  fail "omarchy debug stages under TMPDIR and removes it again" \
+    "removed: $(cat "$rm_log")"
+
+left_behind=$(find "$staging" -type f | wc -l)
+(( left_behind == 0 )) ||
+  fail "omarchy debug leaves no staged log behind" "found: $(find "$staging" -type f)"
+
+pass "omarchy debug stages under TMPDIR and removes it again"
+
+# The staged file used to sit at a fixed name, created under the default umask,
+# which is world readable in a directory every local user can reach. Keep both
+# commands off any name that can be guessed.
+grep -q '^LOG_FILE="/tmp/' "$ROOT/bin/omarchy-debug" &&
+  fail "omarchy debug stages its log at a name nobody can guess"
+grep -q 'LOG_FILE=$(mktemp' "$ROOT/bin/omarchy-debug" ||
+  fail "omarchy debug stages its log with mktemp"
+pass "omarchy debug stages its log with mktemp"
+
+for staged in TEMP_LOG SYSTEM_INFO; do
+  grep -q "^$staged=\"/tmp/" "$ROOT/bin/omarchy-upload-log" &&
+    fail "omarchy-upload-log stages $staged at a name nobody can guess"
+  grep -q "$staged=\$(mktemp" "$ROOT/bin/omarchy-upload-log" ||
+    fail "omarchy-upload-log stages $staged with mktemp"
+done
+pass "omarchy-upload-log stages its bundle with mktemp"

--- a/test/shell.d/diagnostics-staging-test.sh
+++ b/test/shell.d/diagnostics-staging-test.sh
@@ -87,3 +87,132 @@ for staged in TEMP_LOG SYSTEM_INFO; do
     fail "omarchy-upload-log stages $staged with mktemp"
 done
 pass "omarchy-upload-log stages its bundle with mktemp"
+
+
+# --- omarchy-update transcript -------------------------------------------------
+
+# The transcript is read back by omarchy-update-analyze-logs after the run, so
+# it keeps a stable name. That name moves off /tmp into the user's own state
+# directory, where no other local account can read it and two users running
+# the update do not collide on one file.
+script_log="$tmpdir/script.log"
+: >"$script_log"
+
+cat >"$stub_bin/script" <<SH
+#!/bin/bash
+
+printf '%s\n' "\$@" >>"$script_log"
+exit 0
+SH
+chmod +x "$stub_bin/script"
+
+state_home="$tmpdir/xdg-state"
+XDG_STATE_HOME="$state_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update" >/dev/null 2>&1
+
+grep -qF "$state_home/omarchy/update.log" "$script_log" ||
+  fail "omarchy update writes its transcript under XDG_STATE_HOME" \
+    "script got: $(cat "$script_log")"
+pass "omarchy update writes its transcript under XDG_STATE_HOME"
+
+fake_home="$tmpdir/home"
+mkdir -p "$fake_home"
+: >"$script_log"
+env -u XDG_STATE_HOME HOME="$fake_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update" >/dev/null 2>&1
+
+grep -qF "$fake_home/.local/state/omarchy/update.log" "$script_log" ||
+  fail "omarchy update falls back to ~/.local/state without XDG_STATE_HOME" \
+    "script got: $(cat "$script_log")"
+pass "omarchy update falls back to ~/.local/state without XDG_STATE_HOME"
+
+# --- omarchy-update-analyze-logs -----------------------------------------------
+
+mkdir -p "$state_home/omarchy"
+printf 'Updating linux initcpios\n' >"$state_home/omarchy/update.log"
+output=$(XDG_STATE_HOME="$state_home" "$ROOT/bin/omarchy-update-analyze-logs" 2>&1)
+
+grep -q "Initramfs generation may have failed" <<<"$output" ||
+  fail "omarchy-update-analyze-logs reads the transcript from the state directory" \
+    "output: $output"
+pass "omarchy-update-analyze-logs reads the transcript from the state directory"
+
+printf 'Updating linux initcpios\nInitcpio image generation successful\n' >"$state_home/omarchy/update.log"
+output=$(XDG_STATE_HOME="$state_home" "$ROOT/bin/omarchy-update-analyze-logs" 2>&1)
+
+[[ -z $output ]] ||
+  fail "omarchy-update-analyze-logs stays quiet on a good transcript" "output: $output"
+pass "omarchy-update-analyze-logs stays quiet on a good transcript"
+
+for update_script in omarchy-update omarchy-update-analyze-logs; do
+  grep -q '/tmp/omarchy-update\.log' "$ROOT/bin/$update_script" &&
+    fail "$update_script no longer references the fixed /tmp transcript path"
+done
+pass "update scripts no longer reference the fixed /tmp transcript path"
+
+# --- omarchy-install-gaming-battlenet ------------------------------------------
+
+# The installer log is written by a detached process after the script exits, so
+# it cannot be trapped away. It moves from a fixed /tmp name to a fixed name in
+# the user's own cache directory, which is private to the user already.
+setsid_log="$tmpdir/setsid.log"
+: >"$setsid_log"
+
+for tool in omarchy-pkg-add omarchy-install-gaming-gpu-lib32 update-desktop-database; do
+  cat >"$stub_bin/$tool" <<'SH'
+#!/bin/bash
+
+exit 0
+SH
+  chmod +x "$stub_bin/$tool"
+done
+
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+
+out=""
+while (($#)); do
+  if [[ $1 == "--output" ]]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+[[ -z $out ]] || printf 'fake installer\n' >"$out"
+exit 0
+SH
+chmod +x "$stub_bin/curl"
+
+cat >"$stub_bin/setsid" <<SH
+#!/bin/bash
+
+printf '%s\n' "\$*" >>"$setsid_log"
+exit 0
+SH
+chmod +x "$stub_bin/setsid"
+
+battle_home="$tmpdir/battle-home"
+mkdir -p "$battle_home"
+
+HOME="$battle_home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-install-gaming-battlenet" >/dev/null 2>&1
+
+grep -qF '/tmp/omarchy-battlenet-installer.log' "$setsid_log" &&
+  fail "Battle.net installer log moved off the fixed /tmp name" \
+    "setsid got: $(cat "$setsid_log")"
+
+grep -qF "$battle_home/.cache/omarchy/battlenet-installer.log" "$setsid_log" ||
+  fail "Battle.net installer log stages in the user's cache directory" \
+    "setsid got: $(cat "$setsid_log")"
+pass "Battle.net installer log stages in the user's cache directory"
+
+# The stub saw the whole command as one line. Pull the path out of the
+# redirect target and check the directory the detached writer points at exists,
+# since the writer creates the file itself after the script exits.
+log_file=$(sed -n "s/.*>'\([^']*\)'.*/\1/p" "$setsid_log" | head -1)
+[[ $log_file == "$battle_home/.cache/omarchy/battlenet-installer.log" && -d $(dirname "$log_file") ]] ||
+  fail "Battle.net installer log points into the user's cache directory" \
+    "setsid got: $(cat "$setsid_log")"
+pass "Battle.net installer log points into the user's cache directory"
+
+grep -q '/tmp/omarchy-battlenet-installer\.log' "$ROOT/bin/omarchy-install-gaming-battlenet" &&
+  fail "Battle.net installer script no longer names the fixed /tmp log"
+pass "Battle.net installer script no longer names the fixed /tmp log"


### PR DESCRIPTION
`omarchy-debug` gathers the machine's diagnostics into a file at a fixed name:

```bash
LOG_FILE="/tmp/omarchy-debug.log"

if [[ $NO_SUDO = "true" ]]; then
  DMESG_OUTPUT="(skipped - --no-sudo flag used)"
else
  DMESG_OUTPUT="$(sudo dmesg)"
fi

cat > "$LOG_FILE" <<EOF
```

The redirect creates that file under the caller's umask, which is 022, so it lands mode 0644 in a directory every local user can reach. The interesting part is what goes in it. `sudo dmesg` is elevated on purpose, because the kernel ring buffer is not readable by an ordinary user, and the script then writes it somewhere an ordinary user can read. The boot journal at `-p 4..1` and the full package inventory go in alongside it. Nothing removes the file, so the last run's log sits there until reboot.

`omarchy-upload-log` does the same thing with `/tmp/upload-log.txt` and `/tmp/system-info.txt`. Those hold the assembled bundle, including the install logs and the journal, and are likewise never removed.

The symlink and pre-created-file variants of this are not the issue. `fs.protected_symlinks` and `fs.protected_regular` are on by default, so another user planting either path makes the redirect fail rather than succeed somewhere unintended. What is left is plain disclosure: a predictable name, a readable mode, and content the machine went out of its way to elevate for. Omarchy is a single-user desktop, so this only matters on machines with more than one local account.

All three now go through `mktemp`, which creates at 0600 under a name nobody can guess, with a trap clearing them on the way out. Every use of the files is a read by path, so nothing else in either script had to change.

Two more fixed `/tmp` paths in `bin/` get the same treatment:

- `omarchy update` wrote its transcript to `/tmp/omarchy-update.log`. It is read back by `omarchy-update-analyze-logs` after the run, so it keeps a stable name, but that name moves to `~/.local/state/omarchy/update.log`. `docs/update-process.md` names the new path.
- `omarchy-install-gaming-battlenet` wrote the installer log to `/tmp/omarchy-battlenet-installer.log`. It is written by a detached process after the script exits, so a trap cannot clean it up. It now lives at `~/.cache/omarchy/battlenet-installer.log`, next to the installer itself. `~/.cache` is already 0700 on Arch, so a fixed name is fine there and each run overwrites the last log.

Moving these two off `/tmp` has a side benefit. With `fs.protected_regular` on, a second local user running the same command got "Permission denied" on the file the first user left behind. Per-user paths remove that collision.

Two agent skill docs mentioned `/tmp/omarchy-debug.log` as a side effect of `omarchy debug --no-sudo --print`. The primary route there is `--print`, which puts the same content on stdout, and the interactive menu still offers "Save in current directory" for anyone who wants a file. Both mentions are updated rather than left pointing at a path that no longer exists.

Tests: new `test/shell.d/diagnostics-staging-test.sh` stubs the collectors and points `TMPDIR` at a directory the test owns. It checks `--print` still prints what was gathered, that the run removes the file it staged, that nothing is left behind, and that neither script names a `/tmp` literal. The cleanup case is checked through an `rm` stub that records what it was asked to remove, because an empty staging directory on its own would also pass for a script that never staged there, which is exactly what the old fixed path did. Further cases cover the transcript landing under `XDG_STATE_HOME`, the fallback to `~/.local/state` when it is unset, `omarchy-update-analyze-logs` reading from the new path and staying quiet on a good run, and the Battle.net log pointing at the fixed name in the cache directory. Twelve cases, all pass. I ran `test/shell.d/diagnostics-staging-test.sh` directly; the rest of `./test/shell` and `./test/cli` depend on tools my environment does not have (`jq`, `lua`, `magick`), so I did not run them.