### PR TITLE
Timestamp the limine and pacman refresh backups

### DIFF
--- a/bin/omarchy-refresh-limine
+++ b/bin/omarchy-refresh-limine
@@ -11,7 +11,10 @@ if sudo test -f /boot/EFI/Linux/omarchy_linux.efi && sudo test -f "$legacy_uki";
 fi
 echo "Resetting limine config"
 
-sudo mv /boot/limine.conf /boot/limine.conf.bak
+# Timestamped, the way omarchy-refresh-config names its backups. A fixed .bak
+# name means a second run overwrites the backup from the first, so the config
+# the machine booted with before any refresh cannot be recovered.
+sudo mv /boot/limine.conf "/boot/limine.conf.bak.$(date +%s)"
 
 sudo cp "$OMARCHY_PATH/default/limine/limine.conf" /boot/limine.conf
 

--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -3,15 +3,20 @@
 # omarchy:summary=Overwrite the package configuration for /etc/pacman with the Omarchy default of using its dedicated mirrors and repositories, then update all packages.
 # omarchy:requires-sudo=true
 
-sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
-sudo cp -f /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
-
 channel="${1:-stable}"
 
 if [[ $channel != "stable" && $channel != "rc" && $channel != "edge" ]]; then
   echo "Error: Invalid channel '$channel'. Must be one of: stable, rc, edge"
   exit 1
 fi
+
+# Taken after the channel is checked, so a typo no longer spends the backups on
+# its way to exiting. Timestamped, the way omarchy-refresh-config names its
+# backups, so a second run does not overwrite the first run's copy and leave
+# the pre-refresh configuration unrecoverable.
+stamp=$(date +%s)
+sudo cp -f /etc/pacman.conf "/etc/pacman.conf.bak.$stamp"
+sudo cp -f /etc/pacman.d/mirrorlist "/etc/pacman.d/mirrorlist.bak.$stamp"
 
 echo "Setting channel to $channel"
 echo

--- a/test/shell.d/refresh-backup-test.sh
+++ b/test/shell.d/refresh-backup-test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+root_fs="$tmpdir/fs"
+log="$tmpdir/sudo.log"
+mkdir -p "$stub_bin" "$root_fs/etc/pacman.d" "$root_fs/boot"
+: >"$log"
+
+# Reroots the paths these scripts touch into a tree the test owns, so the real
+# /etc and /boot are never in reach, and records what was run.
+cat >"$stub_bin/sudo" <<SH
+#!/bin/bash
+
+printf 'sudo' >>"$log"
+for arg in "\$@"; do
+  printf '\t%s' "\$arg" >>"$log"
+done
+printf '\n' >>"$log"
+
+action=\$1
+shift
+
+rerooted=()
+for arg in "\$@"; do
+  case "\$arg" in
+    /etc/* | /boot/*) rerooted+=("$root_fs\$arg") ;;
+    *) rerooted+=("\$arg") ;;
+  esac
+done
+
+case "\$action" in
+  cp | mv) command "\$action" "\${rerooted[@]}" ;;
+  test) command test "\${rerooted[@]}" ;;
+  *) exit 0 ;;
+esac
+SH
+chmod +x "$stub_bin/sudo"
+
+tools_log="$tmpdir/tools.log"
+: >"$tools_log"
+
+# omarchy-hook is in this list for a reason worth naming: refresh-pacman calls
+# `omarchy-hook pre-refresh-pacman`, which runs ~/.config/omarchy/hooks/<name>
+# through bash. Left unstubbed on a machine that has Omarchy on PATH, this test
+# would run the developer's own hook and whatever that hook does.
+for tool in limine-update limine-snapper-sync omarchy-update omarchy-pkg-add omarchy-hook; do
+  cat >"$stub_bin/$tool" <<SH
+#!/bin/bash
+
+printf '%s %s\n' "\$(basename "\$0")" "\$*" >>"$tools_log"
+exit 0
+SH
+  chmod +x "$stub_bin/$tool"
+done
+
+# HOME is where omarchy-hook looks, so point it somewhere empty as well. The
+# stub covers the call, and this covers anything else that reaches for a hook.
+home="$tmpdir/home"
+mkdir -p "$home"
+
+backups_in() {
+  find "$1" -maxdepth 1 -name "$2" | wc -l
+}
+
+# refresh-pacman: two runs have to leave two backups, not one overwritten twice.
+printf 'first pacman conf\n' >"$root_fs/etc/pacman.conf"
+printf 'first mirrorlist\n' >"$root_fs/etc/pacman.d/mirrorlist"
+
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-refresh-pacman" stable >/dev/null 2>&1
+printf 'second pacman conf\n' >"$root_fs/etc/pacman.conf"
+sleep 1
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-refresh-pacman" stable >/dev/null 2>&1
+
+count=$(backups_in "$root_fs/etc" 'pacman.conf.bak.*')
+(( count == 2 )) ||
+  fail "two pacman refreshes keep both backups" "got: $count"
+
+grep -rqx 'first pacman conf' "$root_fs/etc"/pacman.conf.bak.* ||
+  fail "the first pacman refresh's backup survives the second"
+
+# The mirrorlist is backed up on the same lines and is just as easy to regress
+# to a fixed name on its own, so it gets the same checks rather than riding on
+# pacman.conf's.
+count=$(backups_in "$root_fs/etc/pacman.d" 'mirrorlist.bak.*')
+(( count == 2 )) ||
+  fail "two pacman refreshes keep both mirrorlist backups" "got: $count"
+
+grep -rqx 'first mirrorlist' "$root_fs/etc/pacman.d"/mirrorlist.bak.* ||
+  fail "the first pacman refresh's mirrorlist backup survives the second"
+
+# Both files share one timestamp per run, so a pair stays recognisable as a
+# pair. Reading the stamp off each pacman.conf backup and requiring the matching
+# mirrorlist proves that, and fails if either side drifts to its own clock.
+for backup in "$root_fs/etc"/pacman.conf.bak.*; do
+  stamp=${backup##*/pacman.conf.bak.}
+  [[ -f $root_fs/etc/pacman.d/mirrorlist.bak.$stamp ]] ||
+    fail "each pacman.conf backup has a mirrorlist backup from the same run" \
+      "no mirrorlist for stamp $stamp, have: $(find "$root_fs/etc/pacman.d" -name 'mirrorlist.bak.*' -printf '%f ')"
+done
+
+pass "two pacman refreshes keep both backups, paired by run"
+
+# A rejected channel must not spend the backups on its way out.
+before=$(backups_in "$root_fs/etc" 'pacman.conf.bak.*')
+if HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-refresh-pacman" nonsense >/dev/null 2>&1; then
+  fail "an unknown channel is refused"
+fi
+after=$(backups_in "$root_fs/etc" 'pacman.conf.bak.*')
+(( before == after )) ||
+  fail "an unknown channel writes no backup" "before: $before, after: $after"
+
+pass "an unknown channel is refused before any backup is written"
+
+# The hook call is what makes isolation matter here, so prove the stub is the
+# thing that answered it. If refresh-pacman stops calling omarchy-hook this
+# fails, which is the point: the day it starts calling something else, this test
+# should be looked at again.
+grep -q 'omarchy-hook pre-refresh-pacman' "$tools_log" ||
+  fail "the omarchy-hook call is answered by the stub, not the real hook" \
+    "ran: $(cat "$tools_log")"
+
+pass "the omarchy-hook call is answered by the stub"
+
+# refresh-limine: same rule, and the config it replaces is moved rather than
+# copied, so an overwritten backup loses the original outright.
+printf 'first limine conf\n' >"$root_fs/boot/limine.conf"
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-refresh-limine" >/dev/null 2>&1
+printf 'second limine conf\n' >"$root_fs/boot/limine.conf"
+sleep 1
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-refresh-limine" >/dev/null 2>&1
+
+count=$(backups_in "$root_fs/boot" 'limine.conf.bak.*')
+(( count == 2 )) ||
+  fail "two limine refreshes keep both backups" "got: $count"
+
+grep -rqx 'first limine conf' "$root_fs/boot"/limine.conf.bak.* ||
+  fail "the first limine refresh's backup survives the second"
+
+pass "two limine refreshes keep both backups"


### PR DESCRIPTION
`omarchy-refresh-limine` and `omarchy-refresh-pacman` both keep a backup of what they replace, at a name that does not change between runs:

```bash
# omarchy-refresh-limine
sudo mv /boot/limine.conf /boot/limine.conf.bak

# omarchy-refresh-pacman
sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
sudo cp -f /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
```

Run either one twice and the second run overwrites the first run's backup. What is lost is the state the machine was in before any refresh, which is the state someone reaching for a backup usually wants. `omarchy-refresh-limine` is the worse of the two, because it moves the config rather than copying it, so once the backup is overwritten the original is gone outright.

The sibling scripts already timestamp. `omarchy-refresh-config` writes `<file>.bak.$(date +%s)` and `omarchy-restart-audio` does the same, so recoverable history is the house pattern and these two are the ones that drifted from it.

`omarchy-refresh-pacman` has a second problem in the same lines. The backups are taken at the top of the file, before the channel argument is checked:

```bash
sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
sudo cp -f /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak

channel="${1:-stable}"

if [[ $channel != "stable" && $channel != "rc" && $channel != "edge" ]]; then
  echo "Error: Invalid channel '$channel'. Must be one of: stable, rc, edge"
  exit 1
fi
```

So `omarchy refresh pacman stabel` overwrites both backups and then exits without changing anything else. A typo costs you the backups from the previous real run.

What changed: both scripts name their backups `<file>.bak.<epoch>`, the same form `omarchy-refresh-config` uses, and `omarchy-refresh-pacman` checks the channel before it writes anything. The two pacman backups share one timestamp so a pair from the same run stays recognisable as a pair.

Tests: new `test/shell.d/refresh-backup-test.sh` stubs `sudo` so the `/etc` and `/boot` paths are rerooted into a directory the test owns, which keeps the real ones out of reach. `omarchy-hook` is stubbed too and `HOME` points inside the temp tree, because `refresh-pacman` calls `omarchy-hook pre-refresh-pacman` and that runs a script from `~/.config/omarchy/hooks` through bash. Four cases: two pacman refreshes leave two `pacman.conf` and two `mirrorlist` backups with the first run's content still readable and each pair sharing one timestamp, an unknown channel is refused without writing a backup, the hook call is answered by the stub rather than a real hook, and two limine refreshes leave two backups. All 4 pass. Against the original scripts the first case fails reporting no timestamped backup where two were expected, which is the overwrite.
