### PR TITLE
Make locked Hyprland groups follow the theme

### DIFF
--- a/default/hypr/looknfeel.lua
+++ b/default/hypr/looknfeel.lua
@@ -35,6 +35,8 @@ hl.config({
     col = {
       border_active = active_border_color,
       border_inactive = inactive_border_color,
+      border_locked_active = active_border_color,
+      border_locked_inactive = inactive_border_color,
     },
 
     groupbar = {
@@ -49,9 +51,13 @@ hl.config({
       gaps_out = 0,
       text_color = "rgb(ffffff)",
       text_color_inactive = "rgba(ffffff90)",
+      text_color_locked_active = "rgb(ffffff)",
+      text_color_locked_inactive = "rgba(ffffff90)",
       col = {
         active = "rgba(00000040)",
         inactive = "rgba(00000020)",
+        locked_active = "rgba(00000040)",
+        locked_inactive = "rgba(00000020)",
       },
       gradients = true,
       gradient_rounding = 0,

--- a/default/themed/hyprland.lua.tpl
+++ b/default/themed/hyprland.lua.tpl
@@ -13,6 +13,8 @@ hl.config({
     col = {
       border_active = active_border_color,
       border_inactive = inactive_border_color,
+      border_locked_active = active_border_color,
+      border_locked_inactive = inactive_border_color,
     },
   },
 })

--- a/migrations/1787545025.sh
+++ b/migrations/1787545025.sh
@@ -1,0 +1,3 @@
+echo "Refresh theme files to style locked Hyprland groups"
+
+omarchy-theme-refresh

--- a/test/cli
+++ b/test/cli
@@ -337,6 +337,35 @@ border = "#ffffff"
 EOF
 
 OMARCHY_PATH="$ROOT" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-templates"
+
+grep -Fq 'border_locked_active = active_border_color,' "$NEXT_THEME/hyprland.lua" ||
+  fail "theme templates apply the active border to locked groups"
+grep -Fq 'border_locked_inactive = inactive_border_color,' "$NEXT_THEME/hyprland.lua" ||
+  fail "theme templates apply the inactive border to locked groups"
+pass "theme templates style locked group borders"
+
+for theme_hyprland in "$ROOT"/themes/*/hyprland.lua; do
+  if grep -Fq 'border_active =' "$theme_hyprland"; then
+    grep -Fq 'border_locked_active = active_border_color,' "$theme_hyprland" ||
+      fail "$(basename "$(dirname "$theme_hyprland")") applies its active border to locked groups"
+  fi
+  if grep -Fq 'border_inactive =' "$theme_hyprland"; then
+    grep -Fq 'border_locked_inactive = inactive_border_color,' "$theme_hyprland" ||
+      fail "$(basename "$(dirname "$theme_hyprland")") applies its inactive border to locked groups"
+  fi
+done
+pass "handwritten Hyprland themes style locked group borders"
+
+grep -Fq 'border_locked_active = active_border_color,' "$ROOT/default/hypr/looknfeel.lua" ||
+  fail "default locked groups inherit the active border"
+grep -Fq 'text_color_locked_inactive = "rgba(ffffff90)",' "$ROOT/default/hypr/looknfeel.lua" ||
+  fail "default locked groupbar text matches the translucent inactive text"
+grep -Fq 'locked_active = "rgba(00000040)",' "$ROOT/default/hypr/looknfeel.lua" ||
+  fail "default locked active groupbars match unlocked groupbars"
+grep -Fq 'locked_inactive = "rgba(00000020)",' "$ROOT/default/hypr/looknfeel.lua" ||
+  fail "default locked inactive groupbars match unlocked groupbars"
+pass "default Hyprland styling covers locked groups generically"
+
 grep -qx 'mix=#808080' "$NEXT_THEME/mix-test.txt" || fail "theme template mix helper works"
 grep -qx 'strip=808080' "$NEXT_THEME/mix-test.txt" || fail "theme template mix_strip helper works"
 grep -qx 'rgb=128,128,128' "$NEXT_THEME/mix-test.txt" || fail "theme template mix_rgb helper works"

--- a/themes/kanagawa/hyprland.lua
+++ b/themes/kanagawa/hyprland.lua
@@ -10,6 +10,7 @@ hl.config({
   group = {
     col = {
       border_active = active_border_color,
+      border_locked_active = active_border_color,
     },
   },
 })

--- a/themes/last-horizon/hyprland.lua
+++ b/themes/last-horizon/hyprland.lua
@@ -12,6 +12,8 @@ hl.config({
     col = {
       border_active = active_border_color,
       border_inactive = inactive_border_color,
+      border_locked_active = active_border_color,
+      border_locked_inactive = inactive_border_color,
     },
   },
 })

--- a/themes/lumon/hyprland.lua
+++ b/themes/lumon/hyprland.lua
@@ -15,6 +15,8 @@ hl.config({
     col = {
       border_active = active_border_color,
       border_inactive = inactive_border_color,
+      border_locked_active = active_border_color,
+      border_locked_inactive = inactive_border_color,
     },
   },
 

--- a/themes/retro-82/hyprland.lua
+++ b/themes/retro-82/hyprland.lua
@@ -10,6 +10,7 @@ hl.config({
   group = {
     col = {
       border_active = active_border_color,
+      border_locked_active = active_border_color,
     },
   },
 })

--- a/themes/solitude/hyprland.lua
+++ b/themes/solitude/hyprland.lua
@@ -12,6 +12,8 @@ hl.config({
     col = {
       border_active = active_border_color,
       border_inactive = inactive_border_color,
+      border_locked_active = active_border_color,
+      border_locked_inactive = inactive_border_color,
     },
   },
   decoration = {


### PR DESCRIPTION
Locked Hyprland groups currently fall back to Hyprland's orange and brown defaults. This gives locked tabs the same translucent styling as regular tabs and keeps their borders in sync with the active theme.

This updates the shared theme template plus the five themes that ship handwritten Hyprland config. A migration refreshes the current theme so existing installs get the fix too.

Tested with:

- `./test/cli`
- rendered and parsed all 22 stock themes
- visual checks in Nord and Catppuccin Latte

`./test/all` still reports the existing `launch-about-test.sh` failure; I reproduced it on a clean `quattro` checkout.

### Before — Nord

<img width="1920" height="1080" alt="Before — Nord" src="https://github.com/user-attachments/assets/b60a0eab-f355-49ec-bcdf-d11ce625e96b" />

### After — Nord

<img width="1920" height="1080" alt="After — Nord" src="https://github.com/user-attachments/assets/2e9bf13d-d3a3-480b-806b-3bb274c8cb4d" />

### After — Catppuccin Latte

<img width="1920" height="1080" alt="After — Catppuccin Latte" src="https://github.com/user-attachments/assets/c72159d6-7294-4a7b-8cb3-ead9ce58edc8" />
