### PR TITLE
Regenerate noisy mise wrappers on update

### DIFF
--- a/migrations/1787529117.sh
+++ b/migrations/1787529117.sh
@@ -1,13 +1,28 @@
 echo "Regenerate noisy mise wrappers so they stop writing to stdout"
 
+# Exact pre--quiet stub from omarchy-mise-install before #6940 (four lines).
+# Matching the whole file avoids rewriting user scripts that merely call mise.
+legacy_wrapper() {
+  local package=$1 bin=$2
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'export MISE_MINIMUM_RELEASE_AGE=0' \
+    "mise use -g \"$package\" || exit 1" \
+    "exec mise x \"$package\" -- \"$bin\" \"\$@\""
+}
+
 for wrapper in "$HOME/.local/bin"/*; do
   [[ -f $wrapper && -x $wrapper ]] || continue
 
-  # Only rewrite the pre--quiet form that still pollutes stdout (#7426).
-  package=$(sed -n 's/^mise use -g "\(.*\)" || exit 1$/\1/p' "$wrapper")
-  bin=$(sed -n 's/^exec mise x ".*" -- "\(.*\)" "\$@"$/\1/p' "$wrapper")
+  package=$(sed -n '3s/^mise use -g "\(.*\)" || exit 1$/\1/p' "$wrapper")
+  bin=$(sed -n '4s/^exec mise x ".*" -- "\(.*\)" "\$@"$/\1/p' "$wrapper")
+  [[ -n $package && -n $bin ]] || continue
 
-  if [[ -n $package && -n $bin ]]; then
-    omarchy-mise-install "$package" "$(basename "$wrapper")" "$bin"
-  fi
+  # Package on the exec line must match the use line.
+  exec_package=$(sed -n '4s/^exec mise x "\(.*\)" -- ".*" "\$@"$/\1/p' "$wrapper")
+  [[ $exec_package == "$package" ]] || continue
+
+  [[ $(<"$wrapper") == "$(legacy_wrapper "$package" "$bin")" ]] || continue
+
+  omarchy-mise-install "$package" "$(basename "$wrapper")" "$bin"
 done

--- a/migrations/1787529117.sh
+++ b/migrations/1787529117.sh
@@ -1,0 +1,13 @@
+echo "Regenerate noisy mise wrappers so they stop writing to stdout"
+
+for wrapper in "$HOME/.local/bin"/*; do
+  [[ -f $wrapper && -x $wrapper ]] || continue
+
+  # Only rewrite the pre--quiet form that still pollutes stdout (#7426).
+  package=$(sed -n 's/^mise use -g "\(.*\)" || exit 1$/\1/p' "$wrapper")
+  bin=$(sed -n 's/^exec mise x ".*" -- "\(.*\)" "\$@"$/\1/p' "$wrapper")
+
+  if [[ -n $package && -n $bin ]]; then
+    omarchy-mise-install "$package" "$(basename "$wrapper")" "$bin"
+  fi
+done

--- a/test/shell.d/mise-wrapper-quiet-migration-test.sh
+++ b/test/shell.d/mise-wrapper-quiet-migration-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Regenerate noisy mise wrappers so they stop writing to stdout' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "noisy mise wrapper migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export HOME="$TMPDIR"
+export PATH="$ROOT/bin:$PATH"
+export OMARCHY_PATH="$ROOT"
+mkdir -p "$HOME/.local/bin"
+
+# Exact pre--quiet stub — must be regenerated.
+cat >"$HOME/.local/bin/gh" <<'SH'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+mise use -g "gh" || exit 1
+exec mise x "gh" -- "gh" "$@"
+SH
+chmod +x "$HOME/.local/bin/gh"
+
+# Already quiet — leave alone.
+cat >"$HOME/.local/bin/codex" <<'SH'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+mise use -g --quiet "codex" || exit 1
+exec mise x "codex" -- "codex" "$@"
+SH
+chmod +x "$HOME/.local/bin/codex"
+codex_before=$(<"$HOME/.local/bin/codex")
+
+# Custom script that calls mise — must not be overwritten.
+cat >"$HOME/.local/bin/mytool" <<'SH'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+mise use -g "gh" || exit 1
+echo custom setup
+exec mise x "gh" -- "gh" "$@"
+SH
+chmod +x "$HOME/.local/bin/mytool"
+mytool_before=$(<"$HOME/.local/bin/mytool")
+
+bash -euo pipefail "$migration" >/dev/null || fail "migration exits clean"
+
+grep -Fq 'mise use -g --quiet "gh"' "$HOME/.local/bin/gh" ||
+  fail "legacy wrapper regenerated with --quiet"
+[[ $(<"$HOME/.local/bin/codex") == "$codex_before" ]] ||
+  fail "already-quiet wrapper left alone"
+[[ $(<"$HOME/.local/bin/mytool") == "$mytool_before" ]] ||
+  fail "custom mise script left alone"
+pass "migration rewrites only exact legacy mise stubs"


### PR DESCRIPTION
## Summary
- `bin/omarchy-mise-install` already writes `--quiet` wrappers (#6940), but existing `~/.local/bin` stubs from 4.0.0-1 still run bare `mise use -g` and prepend the mise banner to stdout (#7426).
- Add a migration that regenerates only those pre-`--quiet` wrappers via `omarchy-mise-install`, leaving already-quiet and non-mise scripts alone.

## Test plan
- [x] Temp-home migration: noisy `gh` wrapper becomes `mise use -g --quiet "gh"`; already-quiet and unrelated scripts unchanged
- [x] `./test/cli` — 116 passed
- [x] `./test/shell` — failures match environment gaps (`omarchy-pkgs`, etc.), none related to this migration

Fixes #7426

Made with [Cursor](https://cursor.com)