### PR TITLE
Fix GitHub credential helpers after mise gh upgrades

### DIFF
--- a/migrations/1787547773.sh
+++ b/migrations/1787547773.sh
@@ -1,0 +1,21 @@
+echo "Point GitHub credential helpers at a stable mise gh invocation"
+
+# gh auth setup-git records the absolute path of the running binary. After a
+# mise upgrade that path is gone, and pointing the helper at ~/.local/bin/gh
+# still fails when that stub prints mise status on stdout (#7712). Rewrite
+# only the github.com / gist.github.com helpers that match those bad forms.
+
+omarchy-cmd-present git || exit 0
+
+good='!mise exec --quiet gh -- gh auth git-credential'
+# git config value-regex uses POSIX extended regex.
+bad_ere='^!(.+/mise/installs/gh/.+/gh|.+/\.local/bin/gh) auth git-credential$'
+
+fix_helper() {
+  local key=$1
+  git config --global --get-all "$key" 2>/dev/null | grep -qE "$bad_ere" || return 0
+  git config --global --replace-all "$key" "$good" "$bad_ere"
+}
+
+fix_helper credential.https://github.com.helper
+fix_helper credential.https://gist.github.com.helper

--- a/test/shell.d/gh-credential-helper-migration-test.sh
+++ b/test/shell.d/gh-credential-helper-migration-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Point GitHub credential helpers at a stable mise gh invocation' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "gh credential helper migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cfg="$TMPDIR/gitconfig"
+export GIT_CONFIG_GLOBAL="$cfg"
+export GIT_CONFIG_SYSTEM=/dev/null
+: >"$cfg"
+
+# Migrations run with OMARCHY_PATH/bin on PATH; keep that for omarchy-cmd-present.
+export PATH="$ROOT/bin:$PATH"
+export OMARCHY_PATH="$ROOT"
+
+good='!mise exec --quiet gh -- gh auth git-credential'
+versioned='!/home/u/.local/share/mise/installs/gh/2.97.0/gh_2.97.0_linux_amd64/bin/gh auth git-credential'
+wrapper='!/home/u/.local/bin/gh auth git-credential'
+
+run_migration() {
+  bash -euo pipefail "$migration" >/dev/null || fail "migration exits clean"
+}
+
+git config --global credential.https://github.com.helper "$versioned"
+git config --global --add credential.https://github.com.helper ''
+git config --global credential.https://gist.github.com.helper "$wrapper"
+git config --global credential.helper store
+
+run_migration
+
+git config --global --get-all credential.https://github.com.helper | grep -Fxq "$good" ||
+  fail "github helper rewritten to mise exec"
+git config --global --get-all credential.https://github.com.helper | grep -Fq 'mise/installs/gh/' &&
+  fail "versioned github helper removed"
+# Empty values are a blank line from --get-all; check before capturing into a var
+# (command substitution strips a trailing empty line).
+git config --global --get-all credential.https://github.com.helper | grep -Fxq '' ||
+  fail "empty github helper entry preserved"
+git config --global --get-all credential.https://gist.github.com.helper | grep -Fxq "$good" ||
+  fail "gist helper rewritten to mise exec"
+git config --global --get-all credential.https://gist.github.com.helper | grep -Fq '.local/bin/gh' &&
+  fail "wrapper gist helper removed"
+[[ $(git config --global --get credential.helper) == store ]] || fail "unrelated credential.helper untouched"
+pass "migration rewrites only broken GitHub and Gist helpers"
+
+# Already-good values must not be duplicated on a second run.
+run_migration
+github_count=$(git config --global --get-all credential.https://github.com.helper | grep -Fxc "$good")
+gist_count=$(git config --global --get-all credential.https://gist.github.com.helper | grep -Fxc "$good")
+(( github_count == 1 )) || fail "idempotent: one good github helper ($github_count)"
+(( gist_count == 1 )) || fail "idempotent: one good gist helper ($gist_count)"
+pass "migration is idempotent when helpers are already fixed"


### PR DESCRIPTION
## Summary
- After a mise-managed `gh` upgrade, Git HTTPS auth can keep a credential helper pointing at a deleted versioned binary (`gh auth setup-git` records `os.Executable()`).
- Pointing the helper at `~/.local/bin/gh` still fails when that stub prints mise status on stdout.
- Migration rewrites only matching `credential.https://github.com.helper` and `credential.https://gist.github.com.helper` values to `!mise exec --quiet gh -- gh auth git-credential`, leaving unrelated helpers alone.

## Test plan
- [x] `bash test/shell.d/gh-credential-helper-migration-test.sh` — rewrites versioned + wrapper helpers, preserves empty entries and `credential.helper=store`, idempotent on re-run

Fixes #7712

Made with [Cursor](https://cursor.com)