### PR TITLE
Stop killing running opencode sessions when changing themes

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -319,7 +319,10 @@ post_theme_commands=(
   omarchy-restart-terminal
   omarchy-restart-hyprctl
   omarchy-restart-btop
-  omarchy-restart-opencode
+  # omarchy-restart-opencode is deliberately not called. It broadcasts SIGUSR2
+  # to every opencode process, which kills headless runs outright and aborts
+  # active TUI generation, while delivering nothing: Omarchy generates no
+  # opencode theme data for it to pick up (#8002).
   omarchy-restart-helix
   omarchy-theme-set-foot
   omarchy-theme-set-tmux


### PR DESCRIPTION
Closes #8002

## Problem

`omarchy theme set` runs `omarchy-restart-opencode`, which broadcasts `killall -SIGUSR2 opencode` to every opencode process on the system. Verified against opencode 1.18.x binaries:

- Only the interactive TUI registers SIGUSR2 handlers. Headless processes (`opencode run`, servers, spawned agents) have no handler and terminate with the default disposition — a task that was mid-generation dies with exit code 140.
- Even TUI sessions take a forced server reload that aborts active generation.
- The signal delivers nothing: Omarchy generates no opencode theme data (no opencode template under `default/themed/`, nothing in stock themes), so there are no Omarchy colors for opencode to pick up.

Repro (targeted version of what the broadcast does to each match):

```
$ opencode run "Write the numbers from 1 to 80, one per line" &
$ kill -USR2 <pid>
User defined signal 2      # exit 140, zero output produced
```

For contrast, Claude Code is retinted passively (`omarchy-theme-set-claude` writes a watched theme file) and Codex is never signaled — only opencode gets interrupted work as the price of a theme change.

## Fix

Drop `omarchy-restart-opencode` from `post_theme_commands` in `bin/omarchy-theme-set`, with a comment explaining why it must not be re-added.

The `omarchy-restart-opencode` command itself stays, so `omarchy restart opencode` remains available to users who deliberately want the reload (e.g. those maintaining their own `~/.config/opencode/themes/*.json`).

## Testing

- `./test/cli`: 116 ok, 0 failures
- `./test/all`: the 3 failing shell test files (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`) fail identically on a pristine checkout of this branch on my machine — environment-dependent, unrelated to this change
- Live behavior verified on an Omarchy 4.0 system (43bfe9b9): with the call removed, `opencode run` tasks and interactive sessions survive `omarchy theme set` untouched
