### PR TITLE
Fix file manager shortcut in hotkeys manual

### DIFF
--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -300,7 +300,7 @@ Ghostty terminal is installed using _Install > Terminal_ via the Omarchy menu.
 | ------------------- | ------------------------------ |
 | `Ctrl + L`            | Go to path                     |
 | `Space`               | Preview file (arrows navigate) |
-| `Backspace`      | Go back one folder             |
+| `Alt + Up`       | Go up to parent folder        |
 
 ## Neovim (w/ lazyvim)
 


### PR DESCRIPTION
Fixes #7964

Nautilus uses Alt + Up to go to the parent folder. Update the hotkeys manual to document the working shortcut and clarify the action.