### PR TITLE
Add web search fallback to the menu

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -62,5 +62,8 @@
       ]
     }
   },
+  "menu": {
+    "webSearchUrl": "https://www.google.com/search?q={searchTerms}"
+  },
   "plugins": []
 }

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -153,6 +153,20 @@ link is followed to its target. The default Hyprland bindings in
 `default/hypr/bindings/utilities.lua` all go through this surface
 (SUPER+SPACE toggles root, SUPER+ESCAPE the system menu, and so on).
 
+## Web search fallback
+
+While a search query is typed, the menu appends a fallback row that opens the default browser with the query. Text that reads as a URL (a scheme, a dot, or a `localhost` host) opens that URL; anything else becomes a search-engine query. The search URL is the `{searchTerms}` template in `shell.json` under `menu.webSearchUrl`, defaulting to Google:
+
+```json
+{
+  "menu": {
+    "webSearchUrl": "https://www.google.com/search?q={searchTerms}"
+  }
+}
+```
+
+The URL-vs-search decision and template substitution live in `webSearchLooksLikeUrl` and `webSearchTarget` in `MenuModel.js`, so the shell tests exercise them directly.
+
 ## Select and input modes
 
 The same plugin doubles as the system's dmenu. `omarchy-menu-select` and

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -165,6 +165,8 @@ While a search query is typed, the menu appends a fallback row that opens the de
 }
 ```
 
+The template must begin with `http://` or `https://`. Anything else falls back to the Google default, so whatever writes `shell.json` cannot choose the scheme the browser opens or pass it a leading dash it would read as a flag.
+
 The URL-vs-search decision and template substitution live in `webSearchLooksLikeUrl` and `webSearchTarget` in `MenuModel.js`, so the shell tests exercise them directly.
 
 ## Select and input modes

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -49,6 +49,14 @@ Item {
   // path doesn't have to shell out to bash + jq on every open.
   property string defaultMenuPath: omarchyPath + "/default/omarchy/omarchy-menu.jsonc"
   property string userMenuPath: Quickshell.env("HOME") + "/.config/omarchy/extensions/omarchy-menu.jsonc"
+  // Search-engine URL template for the "search the web" fallback row. The
+  // {searchTerms} placeholder is replaced with the URL-encoded query; the
+  // menu falls back to Google when the shell config does not set one.
+  readonly property string webSearchUrl: {
+    var menu = root.shell && root.shell.shellConfig ? root.shell.shellConfig.menu : null
+    var url = menu && typeof menu.webSearchUrl === "string" ? menu.webSearchUrl : ""
+    return url || "https://www.google.com/search?q={searchTerms}"
+  }
   property var defaultMenuItems: []
   property var userMenuItems: []
   property bool opened: false
@@ -646,6 +654,25 @@ Item {
         for (var d = 0; d < drilldownRows.length; d++) drilldownRows[d].section = "drilldown"
       }
       rows = currentRows.concat(drilldownRows)
+      var webIsUrl = MenuModel.webSearchLooksLikeUrl(query)
+      rows.push({
+        itemId: "websearch",
+        disabled: false,
+        kind: "action",
+        icon: "\udb80\udf49",
+        iconFont: "",
+        appIcon: "",
+        appId: "",
+        label: webIsUrl ? ("Open \"" + query + "\"") : ("Search the web for \"" + query + "\""),
+        target: "",
+        detail: "",
+        path: "",
+        childCount: 0,
+        action: "omarchy-launch-browser " + Util.shellQuote(MenuModel.webSearchTarget(query, root.webSearchUrl)),
+        provider: "",
+        score: 0,
+        section: ""
+      })
     } else {
       for (var j = 0; j < root.itemOrder.length; j++) {
         var child = root.item(root.itemOrder[j])

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -490,6 +490,30 @@ function guardScript(items) {
   return guards ? guardPrelude(guards) + guards : ""
 }
 
+function webSearchLooksLikeUrl(query) {
+  var q = String(query || "").trim()
+  // A space reads as search, matching the browser omnibox: URLs do not
+  // carry raw whitespace.
+  if (!q || /\s/.test(q)) return false
+  return q.indexOf("://") >= 0 || q.indexOf(".") >= 0 || /^localhost([/:]|$)/i.test(q)
+}
+
+// Turn a menu-search query into the URL to open: a bare URL (with a scheme
+// added when missing, http for localhost) or a search-engine query when the
+// text does not read as a URL. `template` is the search URL with a
+// {searchTerms} placeholder; Google is the fallback.
+function webSearchTarget(query, template) {
+  var q = String(query || "").trim()
+  if (!q) return ""
+  if (webSearchLooksLikeUrl(q)) {
+    if (q.indexOf("://") >= 0) return q
+    if (/^localhost([/:]|$)/i.test(q)) return "http://" + q
+    return "https://" + q
+  }
+  var tpl = String(template || "https://www.google.com/search?q={searchTerms}")
+  return tpl.split("{searchTerms}").join(encodeURIComponent(q))
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     guardReaders: GUARD_READERS,
@@ -519,6 +543,8 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    webSearchLooksLikeUrl: webSearchLooksLikeUrl,
+    webSearchTarget: webSearchTarget
   }
 }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -495,7 +495,7 @@ function webSearchLooksLikeUrl(query) {
   // A space reads as search, matching the browser omnibox: URLs do not
   // carry raw whitespace.
   if (!q || /\s/.test(q)) return false
-  return q.indexOf("://") >= 0 || q.indexOf(".") >= 0 || /^localhost([/:]|$)/i.test(q)
+  return /^[a-z][a-z0-9+.-]*:/i.test(q) || q.indexOf(".") >= 0 || /^localhost([:/?#]|$)/i.test(q)
 }
 
 // Turn a menu-search query into the URL to open: a bare URL (with a scheme
@@ -506,8 +506,8 @@ function webSearchTarget(query, template) {
   var q = String(query || "").trim()
   if (!q) return ""
   if (webSearchLooksLikeUrl(q)) {
-    if (q.indexOf("://") >= 0) return q
-    if (/^localhost([/:]|$)/i.test(q)) return "http://" + q
+    if (/^localhost([:/?#]|$)/i.test(q)) return "http://" + q
+    if (/^[a-z][a-z0-9+.-]*:/i.test(q)) return q
     return "https://" + q
   }
   var tpl = String(template || "https://www.google.com/search?q={searchTerms}")

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -507,6 +507,7 @@ function webSearchTarget(query, template) {
   if (!q) return ""
   if (webSearchLooksLikeUrl(q)) {
     if (/^localhost([:/?#]|$)/i.test(q)) return "http://" + q
+    if (/^[^:/?#]+\.[^:/?#]+:\d+(?:[/?#]|$)/.test(q)) return "https://" + q
     if (/^[a-z][a-z0-9+.-]*:/i.test(q)) return q
     return "https://" + q
   }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -511,7 +511,11 @@ function webSearchTarget(query, template) {
     if (/^[a-z][a-z0-9+.-]*:/i.test(q)) return q
     return "https://" + q
   }
-  var tpl = String(template || "https://www.google.com/search?q={searchTerms}")
+  var tpl = String(template || "")
+  // Only an http(s) template may reach the browser: anything else lets whatever
+  // writes shell.json choose the scheme (javascript:, file:) or pass a leading
+  // dash that the browser parses as a flag rather than a URL.
+  if (!/^https?:\/\//i.test(tpl)) tpl = "https://www.google.com/search?q={searchTerms}"
   return tpl.split("{searchTerms}").join(encodeURIComponent(q))
 }
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -633,6 +633,22 @@ assert(
     && /onClicked:[\s\S]*root\.activateIndex\(row\.index, true\)/.test(menuQml),
   'mouse activation carries pointer intent into subordinate menus'
 )
+
+// Web search fallback: URL-vs-search decision and template substitution.
+assertEqual(menu.webSearchLooksLikeUrl('hola'), false, 'web search treats bare text as a search')
+assertEqual(menu.webSearchLooksLikeUrl('hola mundo'), false, 'web search treats whitespace as a search')
+assertEqual(menu.webSearchLooksLikeUrl('hola.com'), true, 'web search treats a dotted name as a URL')
+assertEqual(menu.webSearchLooksLikeUrl('example.com/page'), true, 'web search treats a path as a URL')
+assertEqual(menu.webSearchLooksLikeUrl('https://x.com'), true, 'web search keeps a scheme as a URL')
+assertEqual(menu.webSearchLooksLikeUrl('localhost'), true, 'web search treats localhost as a URL')
+assertEqual(menu.webSearchLooksLikeUrl('localhost:3000'), true, 'web search treats localhost with a port as a URL')
+
+assertEqual(menu.webSearchTarget('hola'), 'https://www.google.com/search?q=hola', 'web search builds a Google query for plain text')
+assertEqual(menu.webSearchTarget('hola mundo'), 'https://www.google.com/search?q=hola%20mundo', 'web search URL-encodes the query')
+assertEqual(menu.webSearchTarget('hola.com'), 'https://hola.com', 'web search adds https to a bare domain')
+assertEqual(menu.webSearchTarget('https://x.com'), 'https://x.com', 'web search keeps an explicit scheme')
+assertEqual(menu.webSearchTarget('localhost:3000'), 'http://localhost:3000', 'web search uses http for localhost')
+assertEqual(menu.webSearchTarget('hola', 'https://duckduckgo.com/?q={searchTerms}'), 'https://duckduckgo.com/?q=hola', 'web search honors a custom template')
 JS
 
 font_charset=$(fc-query --format='%{charset}' "$ROOT/default/fonts/omarchy/omarchy.ttf")

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -642,12 +642,18 @@ assertEqual(menu.webSearchLooksLikeUrl('example.com/page'), true, 'web search tr
 assertEqual(menu.webSearchLooksLikeUrl('https://x.com'), true, 'web search keeps a scheme as a URL')
 assertEqual(menu.webSearchLooksLikeUrl('localhost'), true, 'web search treats localhost as a URL')
 assertEqual(menu.webSearchLooksLikeUrl('localhost:3000'), true, 'web search treats localhost with a port as a URL')
+assertEqual(menu.webSearchLooksLikeUrl('mailto:x@y.com'), true, 'web search treats a non-http scheme as a URL')
+assertEqual(menu.webSearchLooksLikeUrl('localhost#frag'), true, 'web search treats a localhost fragment as a URL')
 
 assertEqual(menu.webSearchTarget('hola'), 'https://www.google.com/search?q=hola', 'web search builds a Google query for plain text')
 assertEqual(menu.webSearchTarget('hola mundo'), 'https://www.google.com/search?q=hola%20mundo', 'web search URL-encodes the query')
 assertEqual(menu.webSearchTarget('hola.com'), 'https://hola.com', 'web search adds https to a bare domain')
 assertEqual(menu.webSearchTarget('https://x.com'), 'https://x.com', 'web search keeps an explicit scheme')
 assertEqual(menu.webSearchTarget('localhost:3000'), 'http://localhost:3000', 'web search uses http for localhost')
+assertEqual(menu.webSearchTarget('mailto:x@y.com'), 'mailto:x@y.com', 'web search keeps a non-http scheme')
+assertEqual(menu.webSearchTarget('chrome:settings'), 'chrome:settings', 'web search keeps a custom scheme')
+assertEqual(menu.webSearchTarget('localhost#frag'), 'http://localhost#frag', 'web search uses http for a localhost fragment')
+assertEqual(menu.webSearchTarget('example.com:8080'), 'example.com:8080', 'web search keeps a host with a port')
 assertEqual(menu.webSearchTarget('hola', 'https://duckduckgo.com/?q={searchTerms}'), 'https://duckduckgo.com/?q=hola', 'web search honors a custom template')
 JS
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -653,8 +653,13 @@ assertEqual(menu.webSearchTarget('localhost:3000'), 'http://localhost:3000', 'we
 assertEqual(menu.webSearchTarget('mailto:x@y.com'), 'mailto:x@y.com', 'web search keeps a non-http scheme')
 assertEqual(menu.webSearchTarget('chrome:settings'), 'chrome:settings', 'web search keeps a custom scheme')
 assertEqual(menu.webSearchTarget('localhost#frag'), 'http://localhost#frag', 'web search uses http for a localhost fragment')
-assertEqual(menu.webSearchTarget('example.com:8080'), 'example.com:8080', 'web search keeps a host with a port')
+assertEqual(menu.webSearchTarget('example.com:8080'), 'https://example.com:8080', 'web search adds https to a host with a port')
 assertEqual(menu.webSearchTarget('hola', 'https://duckduckgo.com/?q={searchTerms}'), 'https://duckduckgo.com/?q=hola', 'web search honors a custom template')
+assertEqual(menu.webSearchTarget('hola', 'http://intranet/search?q={searchTerms}'), 'http://intranet/search?q=hola', 'web search honors a plain http template')
+assertEqual(menu.webSearchTarget('hello', 'javascript:alert(1)//{searchTerms}'), 'https://www.google.com/search?q=hello', 'web search rejects a javascript template')
+assertEqual(menu.webSearchTarget('shadow', 'file:///etc/{searchTerms}'), 'https://www.google.com/search?q=shadow', 'web search rejects a file template')
+assertEqual(menu.webSearchTarget('hello', '--flag-injected={searchTerms}'), 'https://www.google.com/search?q=hello', 'web search rejects a template that starts with a dash')
+assertEqual(menu.webSearchTarget('hello', '--private'), 'https://www.google.com/search?q=hello', 'web search rejects a bare flag as a template')
 JS
 
 font_charset=$(fc-query --format='%{charset}' "$ROOT/default/fonts/omarchy/omarchy.ttf")


### PR DESCRIPTION
Closes #7012

When typing a search query in the Omarchy menu, append a fallback row that opens the default browser with the query:

- Text that reads as a URL (a scheme, a dot, or a `localhost` host) opens that URL, with `https://` (or `http://` for localhost) added when a scheme is missing.
- Anything else becomes a search-engine query, using the `{searchTerms}` template in `shell.json` under `menu.webSearchUrl` (Google by default).

The URL-vs-search decision and the template substitution live in `MenuModel.js` (`webSearchLooksLikeUrl`, `webSearchTarget`) so the shell tests exercise them directly.

## Changes

- `shell/plugins/menu/Menu.qml` — append the fallback row during search; read the `menu.webSearchUrl` setting with a Google fallback.
- `shell/plugins/menu/MenuModel.js` — add `webSearchLooksLikeUrl` and `webSearchTarget`.
- `config/omarchy/shell.json` — ship the default `menu.webSearchUrl`.
- `docs/menu.md` — document the fallback and its setting.
- `test/shell.d/menu-test.sh` — cover the URL-vs-search decision and template substitution.

## Testing

`./test/all` passes for the menu and shell tests. The only failing files (`config-test`, `bar-icon-geometry-test`, `screenshot-sanity-test`, `snapper-test`, `unowned-system-paths-test`) fail for environment reasons unrelated to this change (missing `omarchy-pkgs` checkout / no compositor). The fallback row was also exercised manually in a running session.