### PR TITLE
Keep Wi-Fi password entry stable during scans

### DIFF
--- a/shell/Ui/PanelActionButton.qml
+++ b/shell/Ui/PanelActionButton.qml
@@ -42,6 +42,10 @@ BorderSurface {
   signal clicked()
   signal hovered(bool isHovered)
 
+  Accessible.role: Accessible.Button
+  Accessible.name: root.tooltipText
+  Accessible.onPressAction: if (root.enabled) root.clicked()
+
   activeFocusOnTab: focusable
   Keys.onReturnPressed: if (focusable) root.clicked()
   Keys.onEnterPressed: if (focusable) root.clicked()

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -26,6 +26,7 @@ Panel {
     passwordSsid = ""
     passwordText = ""
     identityText = ""
+    passwordVisible = false
   }
 
   // Live connection details from `ip` / /sys / iw.
@@ -97,6 +98,7 @@ Panel {
   property string passwordSsid: ""
   property string passwordText: ""
   property string identityText: ""
+  property bool passwordVisible: false
 
   // ConnectionFailReason values as a plain object, so Model.js helpers stay
   // pure JS and Node-testable.
@@ -354,7 +356,14 @@ Panel {
   onPasswordSsidChanged: {
     if (passwordSsid === "" && opened) {
       passwordText = ""
-      Qt.callLater(function() { if (keyCatcher) keyCatcher.forceActiveFocus() })
+      passwordVisible = false
+      Qt.callLater(function() {
+        // Publish the latest scan only after the credential editor has
+        // unmounted. Deferring also lets a completed connection clear its
+        // action state before syncWifiNetworks() checks live completion.
+        if (passwordSsid === "" && opened) syncWifiNetworks()
+        if (keyCatcher) keyCatcher.forceActiveFocus()
+      })
     }
   }
 
@@ -603,9 +612,13 @@ Panel {
       var row = Model.wifiRow(network)
       if (row) nets.push(row)
     }
-    wifiNetworks = Model.sortWifiRows(nets)
     wifiStationAvailable = !!wifiDevice
     scanning = false
+    // Keep the visible snapshot stable while a user is entering credentials.
+    // Live objects are still inspected above for connection completion; only
+    // scan-driven insertion, removal, and reordering are deferred.
+    if (passwordSsid !== "") return
+    wifiNetworks = Model.sortWifiRows(nets)
   }
 
   function wifiSectionTitle(index) {
@@ -688,6 +701,7 @@ Panel {
     if (passwordSsid !== ssid) {
       passwordText = ""
       identityText = ""
+      passwordVisible = false
     }
     passwordSsid = ssid
   }
@@ -1835,9 +1849,8 @@ Panel {
         id: idField
         visible: row.isEnterprise && !row.isBusy && !row.isFailed
         anchors.left: parent.left
-        anchors.right: connectPwBtn.left
+        anchors.right: parent.right
         anchors.top: parent.top
-        anchors.rightMargin: Style.space(6)
         placeholderText: "Identity (user@domain)"
         font.family: Style.font.family
         font.pixelSize: Style.font.body
@@ -1859,11 +1872,11 @@ Panel {
         id: pwField
         visible: !row.isBusy && !row.isFailed
         anchors.left: parent.left
-        anchors.right: connectPwBtn.left
+        anchors.right: revealPwBtn.left
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.spacing.rowGap / 2
         anchors.rightMargin: Style.space(6)
-        password: true
+        password: !root.passwordVisible
         placeholderText: "Passphrase"
         font.family: Style.font.family
         font.pixelSize: Style.font.body
@@ -1879,6 +1892,26 @@ Panel {
 
         onVisibleChanged: if (visible && !row.isEnterprise) Qt.callLater(forceActiveFocus)
         Component.onCompleted: if (visible && !row.isEnterprise) Qt.callLater(forceActiveFocus)
+      }
+
+      PanelActionButton {
+        id: revealPwBtn
+        visible: !row.isBusy && !row.isFailed
+        anchors.right: connectPwBtn.left
+        anchors.rightMargin: Style.space(4)
+        anchors.verticalCenter: pwField.verticalCenter
+        iconText: "󰈉"
+        tooltipText: root.passwordVisible ? "Hide password" : "Show password"
+        foreground: root.passwordVisible ? Color.accent : root.bar.foreground
+        hoverColor: Color.accent
+        fontFamily: root.bar.fontFamily
+        focusable: true
+        onClicked: {
+          root.passwordVisible = !root.passwordVisible
+          // Revealing the value is part of credential entry, not a change of
+          // task. Return focus so typing can continue immediately.
+          Qt.callLater(function() { if (pwField.visible) pwField.forceActiveFocus() })
+        }
       }
 
       BorderSurface {
@@ -1910,7 +1943,7 @@ Panel {
         id: connectPwBtn
         visible: !row.isBusy && !row.isFailed
         anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenter: pwField.verticalCenter
         enabled: row.net && pwField.text.length > 0 && (!row.isEnterprise || idField.text.length > 0)
         iconText: "󰄬"
         tooltipText: "Connect"

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -774,14 +774,14 @@ Panel {
     runNetworkAction("connect", networkForSsid(ssid), function(network) { network.connect() })
   }
 
-  function connectWithPassphrase(ssid, passphrase) {
-    runNetworkAction("connect", networkForSsid(ssid), function(network) { network.connectWithPsk(passphrase) })
+  function connectWithPassphrase(network, passphrase) {
+    runNetworkAction("connect", network, function(liveNetwork) { liveNetwork.connectWithPsk(passphrase) })
   }
 
-  function connectEnterprise(ssid, identity, passphrase) {
-    runNetworkAction("connect", networkForSsid(ssid), function(network) {
+  function connectEnterprise(network, identity, passphrase) {
+    runNetworkAction("connect", network, function(liveNetwork) {
       enterpriseConnect.secret = passphrase
-      enterpriseConnect.command = ["bash", "-c", Model.enterpriseConnectScript, "nmcli-eap", ssid, identity]
+      enterpriseConnect.command = ["bash", "-c", Model.enterpriseConnectScript, "nmcli-eap", liveNetwork.name, identity]
       enterpriseConnect.running = true
     })
   }
@@ -1633,8 +1633,17 @@ Panel {
 
     function submitCredentials() {
       if (!net || root.busy || root.passwordText.length === 0) return
-      if (!isEnterprise) return root.connectWithPassphrase(net.ssid, root.passwordText)
-      if (root.identityText.length > 0) root.connectEnterprise(net.ssid, root.identityText, root.passwordText)
+      var liveNetwork = root.networkForSsid(net.ssid)
+      if (!liveNetwork) {
+        // The visible rows stay frozen during entry, but the selected access
+        // point can still disappear from the live scan. Close the stale
+        // prompt and publish the latest scan instead of accepting a submit
+        // that cannot start.
+        root.cancelPasswordPrompt()
+        return
+      }
+      if (!isEnterprise) return root.connectWithPassphrase(liveNetwork, root.passwordText)
+      if (root.identityText.length > 0) root.connectEnterprise(liveNetwork, root.identityText, root.passwordText)
     }
 
     Connections {

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -8,6 +8,7 @@ run_node_test <<'JS'
 const fs = require('fs')
 const network = requireFromRoot('shell/plugins/panels/network/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
+const actionButtonSource = fs.readFileSync(root + '/shell/Ui/PanelActionButton.qml', 'utf8')
 
 assert(/IpcHandler[\s\S]*?function toggleNetwork\(\) \{ root\.toggleNetwork\(\) \}/.test(panelSource), 'network exposes the Wi-Fi radio toggle over IPC')
 assert(/manageIpc: false/.test(panelSource), 'network owns its IPC handler so it can extend the target methods')
@@ -118,6 +119,9 @@ assert(
 assert(/property bool passwordVisible: false/.test(panelSource), 'network keeps password visibility explicit and hidden by default')
 assert(/password: !root\.passwordVisible/.test(panelSource), 'network binds passphrase masking to the visibility control')
 assert(/tooltipText: root\.passwordVisible \? "Hide password" : "Show password"/.test(panelSource), 'network labels the password visibility action')
+assert(/Accessible\.role: Accessible\.Button/.test(actionButtonSource), 'panel action buttons expose their button role')
+assert(/Accessible\.name: root\.tooltipText/.test(actionButtonSource), 'panel action buttons expose their tooltip as an accessible name')
+assert(/Accessible\.onPressAction: if \(root\.enabled\) root\.clicked\(\)/.test(actionButtonSource), 'assistive technology can invoke enabled panel action buttons')
 assert(
   /id: revealPwBtn[\s\S]*onClicked: \{[\s\S]*passwordVisible = !root\.passwordVisible[\s\S]*pwField\.forceActiveFocus/.test(panelSource),
   'network exposes a password visibility toggle and returns focus to credential entry'
@@ -133,6 +137,14 @@ assert(
 assert(
   /function cancelPasswordPrompt\(\)[\s\S]*passwordVisible = false/.test(panelSource),
   'network hides the password again whenever credential entry is cancelled'
+)
+assert(
+  /function submitCredentials\(\)[\s\S]*var liveNetwork = root\.networkForSsid\(net\.ssid\)[\s\S]*if \(!liveNetwork\) \{[\s\S]*root\.cancelPasswordPrompt\(\)[\s\S]*return[\s\S]*root\.connectWithPassphrase\(liveNetwork, root\.passwordText\)/.test(panelSource),
+  'network closes a stale credential prompt instead of silently submitting after its access point disappears'
+)
+assert(
+  /function connectWithPassphrase\(network, passphrase\)[\s\S]*runNetworkAction\("connect", network/.test(panelSource),
+  'network submits credentials against the live access point resolved by the prompt'
 )
 
 // A row is a primitive snapshot that can outlive its WifiNetwork, and

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -75,6 +75,66 @@ assert(
 )
 assert(!/wifiDevice\.scannerEnabled\s*=/.test(panelSource), 'network writes scanner state through its owned device reference rather than the moving wifiDevice reference')
 
+// Access-point scans can add, remove, and reorder rows several times per
+// second. Once credential entry is open, keep the rendered row snapshot fixed
+// while still checking the live objects for connection completion.
+const syncWifiFn = panelSource.match(/function syncWifiNetworks\(\) \{[\s\S]*?\n {2}\}/)
+assert(syncWifiFn, 'network has a wifi snapshot synchronization function')
+assert(
+  /if \(passwordSsid !== ""\) return\s*wifiNetworks = Model\.sortWifiRows\(nets\)/.test(syncWifiFn[0]),
+  'network defers scan-driven row updates while credential entry is open'
+)
+assert(
+  /checkActionCompletion\(network\)[\s\S]*if \(passwordSsid !== ""\) return/.test(syncWifiFn[0]),
+  'network keeps checking live connection completion while its visible rows are frozen'
+)
+
+var Model = network
+var wifiNetworkObjects = [
+  { connected: false, known: false, name: 'Cafe', signalStrength: 0.4, security: 3 },
+  { connected: false, known: false, name: 'New arrival', signalStrength: 0.9, security: 3 },
+]
+var wifiDevice = {}
+var wifiNetworks = [{ connected: false, known: false, ssid: 'Cafe', signal: 40, security: 3 }]
+var passwordSsid = 'Cafe'
+var wifiStationAvailable = false
+var scanning = true
+var completionChecks = 0
+function checkActionCompletion() { completionChecks += 1 }
+eval(syncWifiFn[0])
+
+syncWifiNetworks()
+assertDeepEqual(wifiNetworks.map(row => row.ssid), ['Cafe'], 'network keeps the visible row snapshot fixed during credential entry')
+assertEqual(completionChecks, 2, 'network checks each live row while the visible snapshot is fixed')
+assertEqual(scanning, false, 'network still completes scan state while the visible snapshot is fixed')
+
+passwordSsid = ''
+syncWifiNetworks()
+assertDeepEqual(wifiNetworks.map(row => row.ssid), ['New arrival', 'Cafe'], 'network publishes the latest sorted scan after credential entry')
+assert(
+  /onPasswordSsidChanged:[\s\S]*Qt\.callLater[\s\S]*syncWifiNetworks\(\)[\s\S]*keyCatcher\.forceActiveFocus/.test(panelSource),
+  'network publishes the deferred scan and restores navigation after credential entry closes'
+)
+assert(/property bool passwordVisible: false/.test(panelSource), 'network keeps password visibility explicit and hidden by default')
+assert(/password: !root\.passwordVisible/.test(panelSource), 'network binds passphrase masking to the visibility control')
+assert(/tooltipText: root\.passwordVisible \? "Hide password" : "Show password"/.test(panelSource), 'network labels the password visibility action')
+assert(
+  /id: revealPwBtn[\s\S]*onClicked: \{[\s\S]*passwordVisible = !root\.passwordVisible[\s\S]*pwField\.forceActiveFocus/.test(panelSource),
+  'network exposes a password visibility toggle and returns focus to credential entry'
+)
+assert(
+  /id: idField[\s\S]*anchors\.right: parent\.right[\s\S]*id: pwField[\s\S]*anchors\.right: revealPwBtn\.left/.test(panelSource),
+  'enterprise identity keeps its full row while passphrase actions stay on the passphrase row'
+)
+assert(
+  /id: revealPwBtn[\s\S]*anchors\.verticalCenter: pwField\.verticalCenter[\s\S]*id: connectPwBtn[\s\S]*anchors\.verticalCenter: pwField\.verticalCenter/.test(panelSource),
+  'password visibility and connect actions align with the passphrase field'
+)
+assert(
+  /function cancelPasswordPrompt\(\)[\s\S]*passwordVisible = false/.test(panelSource),
+  'network hides the password again whenever credential entry is cancelled'
+)
+
 // A row is a primitive snapshot that can outlive its WifiNetwork, and
 // disconnect() falls back to the live connection when handed null, so row
 // activation must go through the guarded disconnectRow().


### PR DESCRIPTION
Closes #8013

The Wi-Fi panel currently renders directly from each live access-point scan. While a password prompt is open, a scan can insert, remove, or reorder rows, moving the credential editor under the user's hands or removing it entirely.

## Changes

- Freeze the visible Wi-Fi row snapshot while credential entry is open.
- Continue inspecting live network objects so successful connection completion is still detected.
- Publish the newest sorted scan immediately after the prompt closes.
- Add a show/hide-password control and return focus to the passphrase field after it is toggled.
- Keep enterprise identity on its own full-width row and align passphrase actions with the passphrase field.

## Testing

- `bash test/shell.d/network-test.sh` — 119 assertions passed.
- `./test/all` — all 190 test files passed on an Omarchy Quattro laptop with the documented `omarchy-pkgs` and `omarchy-iso` sibling checkouts.
- `git diff --check` — clean.
- The fixture capture uses synthetic access-point data and performs no network actions.

![Fixture-driven before and after comparison](https://raw.githubusercontent.com/jeremydixon22/omarchy/wifi-credential-entry-evidence/docs/evidence/omarchy-wifi-credential-before-after.png)

[Watch the 5.5-second fixture-driven comparison](https://raw.githubusercontent.com/jeremydixon22/omarchy/wifi-credential-entry-evidence/docs/evidence/omarchy-wifi-credential-before-after.mp4)