### PR TITLE
fix(notifications): render <br/> line breaks instead of literal tag

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -5,8 +5,40 @@ function isChromiumDerived(app, appIcon) {
          source.indexOf("opera") >= 0
 }
 
+function decodeHtmlEntities(text) {
+  var s = String(text || "")
+  s = s.replace(/&#(\d+);/g, function(_, d) {
+    var code = parseInt(d, 10)
+    return isFinite(code) ? String.fromCharCode(code) : _
+  })
+  s = s.replace(/&#x([0-9a-fA-F]+);/g, function(_, h) {
+    var code = parseInt(h, 16)
+    return isFinite(code) ? String.fromCharCode(code) : _
+  })
+  var entities = { "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'", "&#39;": "'" }
+  var prev
+  do {
+    prev = s
+    for (var k in entities) s = s.split(k).join(entities[k])
+  } while (s !== prev)
+  return s
+}
+
+function normalizeBrTags(text) {
+  return String(text || "")
+    .replace(/&amp;lt;br\s*\/?&amp;gt;/gi, "\n")
+    .replace(/&lt;br\s*\/?&gt;/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+}
+
 function sanitizeBody(body, app, appIcon) {
   var text = String(body || "").replace(/<img[^>]*>/gi, "")
+  text = normalizeBrTags(text)
+  // Decode entities iteratively so double-encoded payloads (e.g. &amp;quot; or &amp;lt;)
+  // from KDE Connect / Android bridges render as their intended characters
+  // instead of literal &quot; / &lt;br/&gt;. The card's StyledText will
+  // re-encode plain &/</> where needed, so decoding here is safe.
+  text = decodeHtmlEntities(text)
   if (!isChromiumDerived(app, appIcon)) return text
 
   return text
@@ -366,6 +398,8 @@ if (typeof module !== "undefined") {
   module.exports = {
     isChromiumDerived: isChromiumDerived,
     sanitizeBody: sanitizeBody,
+    decodeHtmlEntities: decodeHtmlEntities,
+    normalizeBrTags: normalizeBrTags,
     summaryStartsWithGlyph: summaryStartsWithGlyph,
     shouldBypassDnd: shouldBypassDnd,
     isEphemeralApp: isEphemeralApp,

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -44,7 +44,23 @@ BorderSurface {
   readonly property bool singleLineToast: sanitizedBody.length === 0
   readonly property bool collapseRedundantIcon: singleLineToast && !hasGlyph && summaryStartsWithGlyph
   readonly property string sanitizedBody: sanitizeBody(body)
-  readonly property string styledBody: sanitizedBody.replace(/\r\n|\r|\n/g, "<br/>")
+  readonly property string styledBody: {
+    var raw = String(sanitizedBody || "")
+    // Defensive: normalize any remaining <br> variants (encoded or raw) that
+    // slipped through sanitizeBody (e.g. direct body updates). sanitizeBody
+    // already does this via NotificationLogic.normalizeBrTags, so this is
+    // idempotent.
+    if (NotificationLogic.normalizeBrTags) raw = NotificationLogic.normalizeBrTags(raw)
+    // Normalize Windows/Mac newlines to \n
+    raw = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+    // Use placeholder so escaping doesn't touch our line-break markers
+    var placeholder = "___BR___"
+    raw = raw.replace(/\n/g, placeholder)
+    // Escape for Text.StyledText - plain &/</> would break HTML parsing and
+    // cause the entire body (including our <br/>) to render literally.
+    raw = raw.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    return raw.split(placeholder).join("<br/>")
+  }
 
   readonly property color dimColor: Qt.darker(Color.notifications.text, 1.4)
   readonly property color bodyColor: Qt.darker(Color.notifications.text, 1.15)


### PR DESCRIPTION
Fixes literal `<br/>` appearing in notification bodies instead of line breaks.

## Problem

Recent notifications (notably KDE Connect/ Android bridges) showed the string `<br/>` literally in the card body. Two stored history examples at `~/.local/state/omarchy/notifications/history/`:

* `SATYAM SHIVAM SUNDARAM: &lt;br/&gt;Sent a reel …` — body stored as `&lt;br/&gt;` (HTML-escaped), rendered by `Text.StyledText` as literal `<br/>` because `&lt;` is an escaped `<`, not a tag start.
* `IGNOU … Toll Free: 1800112346&lt;br/&gt;https://…&lt;br/&gt;https://…` — same
* Hermes digest: `… (inter&lt;br/&gt;Cronjob Response: job-loop-p1-discover …` — joiner encoded as `&lt;br/&gt;`
* Double-encoded `&amp;quot;` / `&amp;amp;` also showed as `&quot;` / `&amp;`.

`shell/plugins/notifications/components/NotificationCard.qml:47` only converted `\r?\n` → `<br/>`:

```qml
readonly property string styledBody: sanitizedBody.replace(/\r\n|\r|\n/g, "<br/>")
```

Any `&lt;br/&gt;` / `&amp;lt;br/&amp;gt;` or raw `<br>` variants bypassed that and stayed encoded, so `StyledText` showed them literally. Plain `&` / `<` / `>` in bodies also broke `StyledText` HTML parsing, causing the whole `<br/>` injection to be shown literally.

`shell/plugins/notifications/NotificationLogic.js:8` `sanitizeBody` only stripped `<img>` and (for Chromium) leading origin links — no `br` normalization or entity decoding.

## Fix

* `NotificationLogic.js`: Add `decodeHtmlEntities(text)` (iterative `&amp;`/`&lt;`/`&gt;`/`&quot;`/`&apos;` + numeric `&#…;`/`&#x…;`) and `normalizeBrTags(text)` (`&amp;lt;br…&amp;gt;` → `\n`, `&lt;br…&gt;` → `\n`, `<br…>` → `\n`). `sanitizeBody` now calls both before the Chromium origin strip, so double-encoded KDE Connect payloads decode to plain text with real line breaks. Export both helpers.

* `NotificationCard.qml`: Replace one-liner `styledBody` with escaped pipeline: `normalizeBrTags` (defensive, idempotent) → `\r\n`/`\r` → placeholder `___BR___` → escape `&`/`</>` for `StyledText` → restore `___BR___` → `<br/>`. This makes `a < b & c` safe for `StyledText` and ensures every `br` variant renders as a line break, not a literal tag.

Before/after with the IGNOU history entry (~4500 B body with `&lt;br/&gt;` links): before showed `1800112346<br/>https://…<br/>https://…` literally; after shows three separate lines with proper breaks and `&` → `&amp;` escaped for display.

## Verification

* `bash test/shell.d/notifications-test.sh` — all `ok` (62 checks, including legacy `exec`→`execArgv` history).
* Node smoke test with real history payloads (Hermes digest 4-item, IGNOU 3:30-4:00, Honista `&lt;br/&gt;Sent a reel`, Brave email `\n` list, `"Line1<br/>Line2<br>Line3<br />Line4 &lt;br/&gt; Line5 &amp;lt;br/&amp;gt;"`) — `sanitizeBody` → `\n`, `styledBody` → `<br/>` without `&lt;br`, `&` correctly escaped to `&amp;`.

## Risk

Strictly display-side; persistence (`~/.local/state/omarchy/notifications/…`) unchanged. `normalizeBrTags` is case-insensitive, handles `br`/`br/`/`br /`, and double-encoded forms. `decodeHtmlEntities` iterates to cover `&amp;quot;` → `"` etc., matching what `StyledText` would otherwise half-decode.

