### PR TITLE
Hibernate with shutdown mode on ThinkBook X IMH so the machine powers off

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -38,6 +38,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
+run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-thinkbook-imh-hibernate.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"

--- a/install/hardware/lenovo/fix-thinkbook-imh-hibernate.sh
+++ b/install/hardware/lenovo/fix-thinkbook-imh-hibernate.sh
@@ -1,0 +1,20 @@
+# Fix hibernate never powering off on Lenovo ThinkBook X IMH (21NW)
+# After writing the hibernation image, the firmware's S4 entry never completes:
+# the machine stays on with a frozen screen and only a forced power-off
+# recovers it, while resume itself works fine. Kernel docs recommend shutdown
+# mode for machines whose platform S4 handling is broken: the kernel powers
+# the system off itself after writing the image, and resume still works from
+# the swap signature on next boot.
+# References:
+# https://docs.kernel.org/power/basic-pm-debugging.html
+# https://wiki.archlinux.org/title/Power_management/Suspend_and_hibernate
+
+if omarchy-hw-match "ThinkBook X IMH"; then
+  echo "Detected ThinkBook X IMH. Switching hibernation to shutdown mode..."
+
+  sudo mkdir -p /etc/systemd/sleep.conf.d
+  sudo tee /etc/systemd/sleep.conf.d/hibernatemode.conf >/dev/null <<'EOF'
+[Sleep]
+HibernateMode=shutdown
+EOF
+fi

--- a/migrations/1787560538.sh
+++ b/migrations/1787560538.sh
@@ -1,0 +1,22 @@
+echo "Switch ThinkBook X IMH hibernation to shutdown mode"
+
+# After writing the hibernation image, this model's firmware never completes
+# the S4 entry: the machine stays on with a frozen screen until a forced
+# power-off, while resume works fine. HibernateMode=shutdown lets the kernel
+# power the system off itself after writing the image. Same rationale as
+# install/hardware/lenovo/fix-thinkbook-imh-hibernate.sh.
+if ! omarchy-hw-match "ThinkBook X IMH"; then
+  exit 0
+fi
+
+hibernate_mode_conf="${OMARCHY_HIBERNATE_MODE_CONF:-/etc/systemd/sleep.conf.d/hibernatemode.conf}"
+
+if [[ -f $hibernate_mode_conf ]] && grep -q '^HibernateMode=shutdown$' "$hibernate_mode_conf"; then
+  exit 0
+fi
+
+sudo mkdir -p /etc/systemd/sleep.conf.d
+sudo tee "$hibernate_mode_conf" >/dev/null <<'EOF'
+[Sleep]
+HibernateMode=shutdown
+EOF

--- a/test/shell.d/thinkbook-imh-hibernate-test.sh
+++ b/test/shell.d/thinkbook-imh-hibernate-test.sh
@@ -22,9 +22,12 @@ trap 'rm -rf "$test_tmp"' EXIT
 stub_bin="$test_tmp/bin"
 mkdir -p "$stub_bin"
 conf_dir="$test_tmp/etc/systemd/sleep.conf.d"
+calls="$test_tmp/calls"
 
 cat >"$stub_bin/sudo" <<'SH'
 #!/bin/bash
+
+echo "$1" >>"$CALLS"
 
 if [[ $1 == mkdir ]]; then
   mkdir -p "$CONF_DIR"
@@ -36,7 +39,7 @@ chmod +x "$stub_bin/sudo"
 
 run_migration() {
   (cd "$test_tmp" &&
-    PATH="$stub_bin:$PATH" CONF_DIR="$conf_dir" \
+    PATH="$stub_bin:$PATH" CONF_DIR="$conf_dir" CALLS="$calls" \
     OMARCHY_HIBERNATE_MODE_CONF="$conf_dir/hibernatemode.conf" \
     bash "$migration")
 }
@@ -63,9 +66,12 @@ grep -qx 'HibernateMode=shutdown' "$conf_dir/hibernatemode.conf" ||
   fail "the migration writes HibernateMode=shutdown for ThinkBook X IMH"
 pass "the migration writes HibernateMode=shutdown for ThinkBook X IMH"
 
-# Re-running stays idempotent.
+# Re-running stays idempotent: no sudo call at all once the drop-in is in
+# place, not merely the same bytes written again.
 before=$(<"$conf_dir/hibernatemode.conf")
+: >"$calls"
 run_migration >/dev/null
 [[ $(<"$conf_dir/hibernatemode.conf") == "$before" ]] ||
   fail "the migration is idempotent when run twice"
+[[ ! -s $calls ]] || fail "an already-configured install is left untouched" "$(cat "$calls")"
 pass "re-running the migration changes nothing"

--- a/test/shell.d/thinkbook-imh-hibernate-test.sh
+++ b/test/shell.d/thinkbook-imh-hibernate-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+fix="$ROOT/install/hardware/lenovo/fix-thinkbook-imh-hibernate.sh"
+migration="$ROOT/migrations/1787560538.sh"
+
+grep -Fq 'omarchy-hw-match "ThinkBook X IMH"' "$fix" ||
+  fail "the fix is gated on ThinkBook X IMH hardware"
+grep -Fq 'HibernateMode=shutdown' "$fix" ||
+  fail "the fix installs HibernateMode=shutdown"
+grep -Fq '/hardware/lenovo/fix-thinkbook-imh-hibernate.sh' \
+  "$ROOT/install/hardware/all.sh" ||
+  fail "the fix is wired into install/hardware/all.sh"
+pass "fresh installs write HibernateMode=shutdown on ThinkBook X IMH"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+conf_dir="$test_tmp/etc/systemd/sleep.conf.d"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+if [[ $1 == mkdir ]]; then
+  mkdir -p "$CONF_DIR"
+elif [[ $1 == tee ]]; then
+  cat >"$CONF_DIR/hibernatemode.conf"
+fi
+SH
+chmod +x "$stub_bin/sudo"
+
+run_migration() {
+  (cd "$test_tmp" &&
+    PATH="$stub_bin:$PATH" CONF_DIR="$conf_dir" \
+    OMARCHY_HIBERNATE_MODE_CONF="$conf_dir/hibernatemode.conf" \
+    bash "$migration")
+}
+
+# Other hardware: migration is a no-op and writes nothing.
+cat >"$stub_bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$stub_bin/omarchy-hw-match"
+run_migration >/dev/null
+[[ ! -e $conf_dir/hibernatemode.conf ]] ||
+  fail "the migration skips machines that are not a ThinkBook X IMH"
+pass "the migration skips other hardware"
+
+# ThinkBook X IMH: the migration writes the drop-in.
+cat >"$stub_bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$stub_bin/omarchy-hw-match"
+run_migration >/dev/null
+grep -qx 'HibernateMode=shutdown' "$conf_dir/hibernatemode.conf" ||
+  fail "the migration writes HibernateMode=shutdown for ThinkBook X IMH"
+pass "the migration writes HibernateMode=shutdown for ThinkBook X IMH"
+
+# Re-running stays idempotent.
+before=$(<"$conf_dir/hibernatemode.conf")
+run_migration >/dev/null
+[[ $(<"$conf_dir/hibernatemode.conf") == "$before" ]] ||
+  fail "the migration is idempotent when run twice"
+pass "re-running the migration changes nothing"


### PR DESCRIPTION
## Why

On the Lenovo ThinkBook X IMH / ThinkBook 13x Gen4 (21NW), hibernate writes the image but the firmware never finishes entering S4: the machine stays on with a frozen screen until a forced power-off, while resume itself works fine. The model's ACPI tables are visibly broken (`\_SB.PC00.LPCB.UPFS` unresolved, `acpi-fan` `_ON` methods abort during S4 restore), which makes the platform sleep path untrustworthy. Firmware is current (MTCN47WW via fwupd), so this is not fixable by updating.

The kernel PM debugging docs recommend exactly this workaround ("the 'platform' mode of hibernation does not work on some systems with broken BIOSes. In such cases the 'shutdown' mode … might work"), and ArchWiki documents the same symptom under "System does not power off when hibernating":

- https://docs.kernel.org/power/basic-pm-debugging.html
- https://wiki.archlinux.org/title/Power_management/Suspend_and_hibernate

Verified on this hardware: with `HibernateMode=shutdown`, `systemctl hibernate` powers the machine fully off by itself after writing the image, and pressing power + LUKS passphrase restores the session as before.

## What

- `install/hardware/lenovo/fix-thinkbook-imh-hibernate.sh` — gated on `omarchy-hw-match "ThinkBook X IMH"`, writes `/etc/systemd/sleep.conf.d/hibernatemode.conf` with `[Sleep] HibernateMode=shutdown`
- Wire it into `install/hardware/all.sh` next to the existing Lenovo fix
- Migration `1787560538.sh` applies it to existing installs on `omarchy update` (skips other hardware, idempotent)
- Shell test covering gating, wiring, migration behavior and idempotency

## Test plan

- [x] `bash test/shell.d/thinkbook-imh-hibernate-test.sh` — 4/4 pass
- [x] Real hardware (ThinkBook X IMH 21NW, kernel 7.1.8-arch1-3): menu → Hibernate now powers off by itself and resumes cleanly