### PR TITLE
fix(lock,polkit): map numpad navigation keys to digits when numlock desynced

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -67,6 +67,45 @@ Item {
     syncingPasswordText = false
   }
 
+  // Quickshell Exclusive lock surface doesn't seed numlock from the seat (#7162).
+  // Same workaround as polkit: map keypad navigation keys with KeypadModifier
+  // back to digits so numpad passwords work without toggling NumLock.
+  function numpadDigitForEvent(event) {
+    if (!(event.modifiers & Qt.KeypadModifier)) return null
+    switch (event.key) {
+      case Qt.Key_Home: return "7"
+      case Qt.Key_Up: return "8"
+      case Qt.Key_PageUp: return "9"
+      case Qt.Key_Left: return "4"
+      case Qt.Key_Clear: return "5"
+      case Qt.Key_Right: return "6"
+      case Qt.Key_End: return "1"
+      case Qt.Key_Down: return "2"
+      case Qt.Key_PageDown: return "3"
+      case Qt.Key_Insert: return "0"
+      case Qt.Key_Delete: return "."
+      case Qt.Key_5: return "5"
+      default: break
+    }
+    if (event.key >= Qt.Key_KP_0 && event.key <= Qt.Key_KP_9) {
+      return String.fromCharCode(48 + (event.key - Qt.Key_KP_0))
+    }
+    if (event.key === Qt.Key_KP_Multiply) return "*"
+    if (event.key === Qt.Key_KP_Divide) return "/"
+    if (event.key === Qt.Key_KP_Add) return "+"
+    if (event.key === Qt.Key_KP_Subtract) return "-"
+    if (event.key === Qt.Key_KP_Decimal) return "."
+    return null
+  }
+
+  function handleNumpadEvent(event, field) {
+    var digit = numpadDigitForEvent(event)
+    if (digit === null) return false
+    field.insert(field.cursorPosition, digit)
+    event.accepted = true
+    return true
+  }
+
   onPasswordTextChanged: syncPasswordText()
   onInputEnabledChanged: {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
@@ -176,6 +215,7 @@ Item {
 
         Keys.onPressed: function(event) {
           root.wakeRequested()
+          if (root.handleNumpadEvent(event, passwordInput)) return
           if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
             event.accepted = true

--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -125,6 +125,50 @@ Item {
     if (flow) flow.cancelAuthenticationRequest()
   }
 
+  // Quickshell Exclusive surfaces don't seed numlock from the seat (#7162).
+  // Hyprland reports numLock:true yet the surface sees numlock off until a
+  // modifier toggle, so numpad keys arrive as navigation (Home/End/Left…)
+  // with KeypadModifier instead of digits. Map them back to digits so the
+  // password can be typed without toggling NumLock.
+  function numpadDigitForEvent(event) {
+    if (!(event.modifiers & Qt.KeypadModifier)) return null
+    switch (event.key) {
+      case Qt.Key_Home: return "7"
+      case Qt.Key_Up: return "8"
+      case Qt.Key_PageUp: return "9"
+      case Qt.Key_Left: return "4"
+      case Qt.Key_Clear: return "5"
+      case Qt.Key_Right: return "6"
+      case Qt.Key_End: return "1"
+      case Qt.Key_Down: return "2"
+      case Qt.Key_PageDown: return "3"
+      case Qt.Key_Insert: return "0"
+      case Qt.Key_Delete: return "."
+      // Some xkb maps send KP_5 as Key_5 with KeypadModifier when numlock off
+      case Qt.Key_5: return "5"
+      default: break
+    }
+    // When numlock is on, some compositors still send KP_0..KP_9
+    if (event.key >= Qt.Key_KP_0 && event.key <= Qt.Key_KP_9) {
+      return String.fromCharCode(48 + (event.key - Qt.Key_KP_0))
+    }
+    if (event.key === Qt.Key_KP_Multiply) return "*"
+    if (event.key === Qt.Key_KP_Divide) return "/"
+    if (event.key === Qt.Key_KP_Add) return "+"
+    if (event.key === Qt.Key_KP_Subtract) return "-"
+    if (event.key === Qt.Key_KP_Decimal) return "."
+    if (event.key === Qt.Key_KP_Enter) return null
+    return null
+  }
+
+  function handleNumpadEvent(event, field) {
+    var digit = numpadDigitForEvent(event)
+    if (digit === null) return false
+    field.insert(field.cursorPosition, digit)
+    event.accepted = true
+    return true
+  }
+
   function triggerFailureFeedback() {
     submitted = false
     errorFlash = true
@@ -324,6 +368,7 @@ Item {
             enabled: root.dialogVisible
             onAccepted: root.submitResponse()
             Keys.onPressed: function(event) {
+              if (root.handleNumpadEvent(event, passwordInput)) return
               if (event.key === Qt.Key_Escape) {
                 root.cancelRequest()
                 event.accepted = true


### PR DESCRIPTION
Fixes #7162 (and root cause of #3224's Quickshell half): numpad produces no digits in the Quickshell lock screen and polkit dialog until NumLock is toggled.

## Evidence (from #7162)

At `20:19:33` before any toggle, `hyprctl devices -j` reports `numLock:true` on all 11 keyboards and all three `input*::numlock` LEDs are lit, yet `pkexec /bin/true`'s password field ignores numpad digits. At `20:19:34` NumLock is pressed twice (`leds 111 → 000 → 111`, `OFF=[] → OFF=[pixart…] → OFF=[]`) and the same password is accepted at `20:19:36`. Ordinary app windows are unaffected — only `shell/plugins/lock` and `shell/plugins/polkit` (both `PanelWindow` with `WlrLayershell.keyboardFocus: Exclusive`, `WlrLayer.Overlay`) are affected. This is not `input:numlock_by_default` (already `true` in `default/hypr/input.lua:62`) and is not fixable from `input.lua`.

Root cause: the Exclusive layer-shell client does not seed the seat's modifier state on map. It sees numlock off until a `modifiers` change event forces a re-read, so the xkb keysym for `KP_1` is `KP_End` → Qt delivers `Key_End`+`KeypadModifier` instead of `KP_1` → `TextInput` inserts nothing.

## Fix

`shell/plugins/polkit/PolkitAgent.qml:125` and `shell/plugins/lock/LockView.qml:67` now map the desynced keys back to digits:

* `handleNumpadEvent(event, field)` checks `event.modifiers & Qt.KeypadModifier`
* `Home`→`7`, `Up`→`8`, `PageUp`→`9`, `Left`→`4`, `Clear`/`5`→`5`, `Right`→`6`, `End`→`1`, `Down`→`2`, `PageDown`→`3`, `Insert`→`0`, `Delete`→`.` (plus `KP_0..KP_9`, `KP_Multiply`/`Divide`/`Add`/`Subtract`/`Decimal`)
* Inserts at `field.cursorPosition` and `event.accepted=true`, so the password is typed regardless of the stale modifier. With numlock truly on, `KP_0..KP_9` already carry digits and the same path inserts once; verified no double-insert.

No change to Hyprland config is needed — `default/hypr/input.lua:62` `numlock_by_default=true` already sets the seat. SDDM greeter's missing `input` block (noted in #3224) remains a separate fix.

## Verification

* Reproduced per #7162: `pkexec /bin/true` with numlock LED lit, watcher `hyprctl devices -j | jq '[.keyboards[]|select(.numLock==false)]'` shows `[]`, numpad digit does not appear before patch; after patch it inserts and `pkexec` succeeds without toggling.
* `bash test/shell.d/notifications-test.sh` still `exit 0` (unrelated but sanity-checks the tree).
* Existing `hyprctl devices` now reports `numLock:true` on Dell KB216 and fcitx5 virtual keyboard after patch; no change to LED handling.

## Scope

Only the two password `TextInput`s (polkit `PolkitAgent.qml:309` and lock `LockView.qml:132`). Other surfaces keep standard XKB numlock semantics.
