### PR TITLE
Eye toggle to show/hide the Wi-Fi password

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1831,11 +1831,15 @@ Panel {
       implicitHeight: (idField.visible ? idField.implicitHeight + Style.space(4) : 0) + pwField.implicitHeight + Style.spacing.rowGap
       height: implicitHeight
 
+      // The eye toggle unmasks pwField by flipping its `password`; every
+      // close path lands here, so a reopened prompt always starts masked.
+      onVisibleChanged: if (!visible) pwField.password = true
+
       TextField {
         id: idField
         visible: row.isEnterprise && !row.isBusy && !row.isFailed
         anchors.left: parent.left
-        anchors.right: connectPwBtn.left
+        anchors.right: revealPwBtn.left
         anchors.top: parent.top
         anchors.rightMargin: Style.space(6)
         placeholderText: "Identity (user@domain)"
@@ -1859,7 +1863,7 @@ Panel {
         id: pwField
         visible: !row.isBusy && !row.isFailed
         anchors.left: parent.left
-        anchors.right: connectPwBtn.left
+        anchors.right: revealPwBtn.left
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.spacing.rowGap / 2
         anchors.rightMargin: Style.space(6)
@@ -1901,6 +1905,19 @@ Panel {
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall
         }
+      }
+
+      PanelActionButton {
+        id: revealPwBtn
+        visible: !row.isBusy && !row.isFailed
+        anchors.right: connectPwBtn.left
+        anchors.rightMargin: Style.space(4)
+        anchors.verticalCenter: parent.verticalCenter
+        iconText: pwField.password ? "\uf06e" : "\uf070"
+        tooltipText: pwField.password ? "Show password" : "Hide password"
+        foreground: root.bar.foreground
+        fontFamily: root.bar.fontFamily
+        onClicked: pwField.password = !pwField.password
       }
 
       // 22×22 right-anchored to line up with lockIndicator above. Esc closes


### PR DESCRIPTION
An eye beside Connect in the Wi-Fi passphrase prompt unmasks the field; clicking again re-masks it. Every close path (Esc, click-away, connect, IPC) resets the toggle so the prompt always reopens masked.

References #7815 and #7215; complements the lock screen variant in #7680.