### PR TITLE
Recover Intel Bluetooth when an rfkill block interrupts the firmware load

### DIFF
--- a/bin/omarchy-bluetooth-recover
+++ b/bin/omarchy-bluetooth-recover
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# omarchy:summary=Reload btusb when an rfkill unblock leaves no Bluetooth adapter
+# omarchy:group=bluetooth
+# omarchy:hidden=true
+
+# omarchy-bluetooth-power keeps the off state in the rfkill soft block, and
+# systemd-rfkill restores that block early on the next boot. On Intel CNVi
+# adapters that restore can land while btusb is still downloading the firmware:
+# the device drops off the bus mid-transfer, the download fails with -19
+# (ENODEV), and hci0 is torn down completely.
+#
+#   Bluetooth: hci0: Failed to send firmware data (-19)
+#   Bluetooth: hci0: FW download error recovery failed (-19)
+#
+# BlueZ is then left with no controller at all, so the unblock-and-wait in
+# power_on() has nothing to wait for and turning Bluetooth back on always
+# reports that the adapter did not come up. Reloading btusb starts the firmware
+# download over.
+
+set -u
+
+ADAPTER_WAIT_SECONDS=${OMARCHY_BLUETOOTH_ADAPTER_WAIT_SECONDS:-5}
+
+adapter_present() {
+  compgen -G "/sys/class/bluetooth/hci*" >/dev/null
+}
+
+# The ordinary case is an adapter that just needs a moment to appear after the
+# unblock. Only a wait that runs out means the firmware never loaded, so nothing
+# is reloaded on hardware that does not have this problem.
+deadline=$((SECONDS + ADAPTER_WAIT_SECONDS))
+while :; do
+  adapter_present && exit 0
+  ((SECONDS < deadline)) || break
+  sleep 0.2
+done
+
+# Still blocked means Bluetooth is meant to be off, and a missing adapter is the
+# correct state rather than something to recover.
+rfkill list bluetooth 2>/dev/null | grep -q "Soft blocked: yes" && exit 0
+
+logger -t omarchy-bluetooth-recover "No Bluetooth adapter after unblock; reloading btusb"
+
+modprobe -r btusb btintel 2>/dev/null
+modprobe btusb || exit 1
+systemctl restart bluetooth

--- a/bin/omarchy-hw-intel-bluetooth
+++ b/bin/omarchy-hw-intel-bluetooth
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Detect an Intel Bluetooth controller.
+
+# Read sysfs rather than shelling out: usbutils is not part of the base install,
+# so lsusb is usually absent. Intel's USB vendor is 8087 and Bluetooth
+# controllers report the wireless device class (0xe0).
+
+for device in /sys/bus/usb/devices/*/; do
+  [[ $(cat "$device/idVendor" 2>/dev/null) == "8087" ]] || continue
+  [[ $(cat "$device/bDeviceClass" 2>/dev/null) == "e0" ]] || continue
+  exit 0
+done
+
+exit 1

--- a/default/udev/intel-bluetooth-recover.rules
+++ b/default/udev/intel-bluetooth-recover.rules
@@ -1,0 +1,4 @@
+# Lifting the Bluetooth rfkill block can leave no adapter behind when a
+# boot-time block interrupted the firmware download. Check once the block is
+# gone, and reload btusb if the adapter never came back.
+SUBSYSTEM=="rfkill", ACTION=="change", ENV{RFKILL_TYPE}=="bluetooth", ENV{RFKILL_STATE}=="1", TAG+="systemd", ENV{SYSTEMD_WANTS}+="omarchy-bluetooth-recover.service"

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -24,6 +24,7 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/ipu7-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/sof-firmware.sh"
+run_logged "$OMARCHY_INSTALL/hardware/intel/fix-bluetooth-rfkill-firmware.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"

--- a/install/hardware/intel/fix-bluetooth-rfkill-firmware.sh
+++ b/install/hardware/intel/fix-bluetooth-rfkill-firmware.sh
@@ -1,0 +1,37 @@
+# Recover Intel Bluetooth when an rfkill soft block interrupts the firmware load.
+#
+# omarchy-bluetooth-power holds the off state in the rfkill soft block because
+# that is the half systemd-rfkill restores across reboots. On Intel CNVi adapters
+# the restore happens early enough to land while btusb is still downloading the
+# firmware: the device drops off the bus mid-transfer, the download fails with
+# -19 (ENODEV) and hci0 is torn down, so the machine boots with no Bluetooth
+# controller rather than one that is merely powered off.
+#
+#   Bluetooth: hci0: Found device firmware: intel/ibt-0040-0041.sfi
+#   Bluetooth: hci0: Failed to send firmware data (-19)
+#   Bluetooth: hci0: FW download error recovery failed (-19)
+#
+# Turning Bluetooth back on cannot recover from that on its own: power_on() lifts
+# the block and waits for BlueZ to power an adapter that no longer exists, then
+# falls back to a bluetoothctl power on that has no controller to address.
+#
+# So watch for the unblock and reload btusb when it leaves no adapter behind.
+
+if omarchy-hw-intel-bluetooth; then
+  sudo mkdir -p /etc/systemd/system /etc/udev/rules.d
+
+  sudo tee /etc/systemd/system/omarchy-bluetooth-recover.service >/dev/null <<'UNIT'
+[Unit]
+Description=Recover the Bluetooth adapter after an rfkill unblock
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/omarchy-bluetooth-recover
+UNIT
+
+  sudo cp -f "$OMARCHY_PATH/default/udev/intel-bluetooth-recover.rules" \
+    /etc/udev/rules.d/90-omarchy-bluetooth-recover.rules
+
+  sudo systemctl daemon-reload
+  sudo udevadm control --reload-rules
+fi


### PR DESCRIPTION
## The problem

Turning Bluetooth off and rebooting leaves an Intel CNVi machine with **no Bluetooth adapter at all**, not one that is merely powered off. `bluetoothctl` reports `No default controller available`, and turning Bluetooth back on cannot recover it.

## Mechanism

`omarchy-bluetooth-power off` sets an rfkill soft block, and the reasoning in that script is sound: BlueZ never persists `Powered`, while systemd-rfkill saves every switch under `/var/lib/systemd/rfkill` and restores it early on the next boot.

The trouble is how early. On this adapter the restore lands while `btusb` is still downloading the firmware. The device drops off the bus mid-transfer, the download fails with `-19` (`ENODEV`), and `hci0` is torn down completely:

```
Bluetooth: hci0: Found device firmware: intel/ibt-0040-0041.sfi
Bluetooth: hci0: Boot Address: 0x100800
Bluetooth: hci0: Firmware Version: 202-5.26
Bluetooth: hci0: Failed to send firmware data (-19)
Bluetooth: hci0: sending frame failed (-19)
Bluetooth: hci0: FW download error recovery failed (-19)
Bluetooth: hci0: Failed to read MSFT supported features (-19)
```

`/sys/class/bluetooth/` is then empty. That also defeats the recovery path in `power_on()`: it lifts the block and waits for BlueZ to auto-power the adapter, then falls back to `bluetoothctl power on`. Both need a controller to exist, so both fail and the helper reports that the adapter did not come up.

## Evidence

Firmware load outcome per boot on one machine. The only failure is the boot where Bluetooth had been turned off beforehand:

| boot | blocked at boot | firmware loaded | firmware errors |
|------|-----------------|-----------------|-----------------|
| -4 | no | yes | 0 |
| -3 | no | yes | 0 |
| -2 | no | yes | 0 |
| -1 | no | yes | 0 |
| 0 | **yes** | only after a manual `btusb` reload | **2** |

## Reproduction

1. On an Intel CNVi adapter, run `omarchy-bluetooth-power off` (or use the bar widget).
2. Reboot.
3. `journalctl -b -k | grep hci0` shows the `-19` failures.
4. `bluetoothctl list` is empty.
5. Turning Bluetooth back on does not help.

## The change

A udev rule watches for the Bluetooth rfkill block being lifted and starts a oneshot unit that reloads `btusb` if that left no adapter behind.

It is deliberately inert outside the broken case. It waits for an adapter first and exits as soon as one appears, so hardware without this problem never reloads anything; and it exits when the block is still set, since a missing adapter is the intended state while Bluetooth is off.

- `bin/omarchy-bluetooth-recover` — the recovery itself
- `bin/omarchy-hw-intel-bluetooth` — detection, reading sysfs because `usbutils` is not in the base install so `lsusb` is usually absent
- `default/udev/intel-bluetooth-recover.rules` — the trigger
- `install/hardware/intel/fix-bluetooth-rfkill-firmware.sh` — installs the rule and unit, gated on the adapter being present
- one line in `install/hardware/all.sh`

## Testing

Verified on Omarchy 4.0.0-1, kernel 7.1.8-arch1-3, Intel Raptor Lake PCH CNVi (`8087:0033`, firmware `intel/ibt-0040-0041.sfi`).

**The real failure, and that a `btusb` reload fixes it.** Reached by turning Bluetooth off and rebooting. The boot logged the `-19` failures above and left no adapter; reloading `btusb` recovered it:

```
Bluetooth: hci0: Firmware loaded in 1378869 usecs
Bluetooth: hci0: Device booted in 15662 usecs
Bluetooth: hci0: Fseq status: Success (0x00)
```

**That the script takes the reload branch and recovers the adapter.** `btusb` was removed without touching rfkill, so no device event could make udev auto-load it — leaving the module unloaded and no adapter, which is the state the script has to act on:

```
btusb loaded: 0   adapters: (none)
# omarchy-bluetooth-recover
omarchy-bluetooth-recover[48677]: No Bluetooth adapter after unblock; reloading btusb
btusb loaded: 1   adapters: hci0
Controller 08:9D:F4:86:E6:C3 ITS [default]
```

Exit status 0, no `-19` errors. The controller in that run reported `Firmware already loaded`, since it kept the firmware from the previous successful load — so this run proves the recovery mechanics, while the case above proves a reload repairs a genuinely failed download.

**That the guards keep it inert.** With an adapter present the script exits in 2ms without reloading and logs nothing. With the block still set it exits without reloading, so turning Bluetooth off keeps working normally.

**That the trigger fires.** Unblocking Bluetooth starts the unit through the udev rule (`Starting Recover Bluetooth adapter after rfkill unblock` → `Finished`).

**Detection.** `omarchy-hw-intel-bluetooth` returns 0 on this hardware, matching `8087:0033` at device class `e0`. It reads sysfs deliberately: an earlier version used `lsusb -d 8087:`, which exits 127 on a base install because `usbutils` is not included — that would have silently disabled the fix.

## Note on timing

`omarchy-bluetooth-power` gives up after `POWER_WAIT_SECONDS` (2s) while the recovery waits 5s for an adapter before reloading, so the first toggle after a blocked boot can still report that the adapter did not come up, with the adapter appearing a few seconds later. Happy to align those.

If you would rather keep this in one place, the reload could move into `power_on()` instead. That needs a privileged path, though: `rfkill` works unprivileged through the uaccess ACL on `/dev/rfkill`, but `modprobe` and `systemctl restart bluetooth` do not, and the helper is called detached from the shell where a sudo prompt has nowhere to go. That is why this is a root-side unit driven by udev.
