### PR TITLE
Accept numpad and AltGr input in the menu and image picker filters

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -101,6 +101,19 @@ QtObject {
     }
   }
 
+  // True when the event types one visible character into a searchable
+  // panel's filter: a single printable char with no Ctrl, Alt or Super held,
+  // so chords stay with the panel's own shortcuts. Qt also flags keypad keys
+  // with KeypadModifier and AltGr characters with GroupSwitchModifier; both
+  // still type, so neither is a reason to drop the key. Append event.text
+  // when this is true.
+  function extendsFilter(event) {
+    if (!event.text || event.text.length !== 1) return false
+    var code = event.text.charCodeAt(0)
+    if (code < 32 || code === 127) return false
+    return !(event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier))
+  }
+
   // Standard Qt text-editing keys shared by every searchable panel's filter:
   //   Backspace       delete previous character
   //   Ctrl+Backspace  delete previous word (Qt DeleteStartOfWord)

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -426,7 +426,7 @@ Item {
             } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab) {
               root.selectAdjacent(1)
               event.accepted = true
-            } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
+            } else if (root.filterable && Util.extendsFilter(event)) {
               root.updateFilter(root.filterText + event.text)
               event.accepted = true
             }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1158,7 +1158,7 @@ Item {
             } else if (root.cursorActive) root.activateIndex(root.selectedIndex)
             else root.settleCursor()
             event.accepted = true
-          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
+          } else if (Util.extendsFilter(event)) {
             root.setFilter(root.filterText + event.text)
             event.accepted = true
           }

--- a/test/shell.d/filter-input-test.sh
+++ b/test/shell.d/filter-input-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Every searchable panel decides "does this keystroke type into the filter?"
+# the same way, and the decision has a trap: Qt stamps KeypadModifier on every
+# keypad key while NumLock is on and GroupSwitchModifier on AltGr characters,
+# so a check for "no modifier" drops numpad digits and AltGr symbols while the
+# number row types fine. Run the shared helper's own JavaScript against the
+# real Qt modifier values.
+run_node_test <<'JS'
+const fs = require('fs')
+const utilQml = fs.readFileSync(path.join(root, 'shell/Commons/Util.qml'), 'utf8')
+const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+const pickerQml = fs.readFileSync(path.join(root, 'shell/plugins/image-picker/ImagePicker.qml'), 'utf8')
+
+const Qt = {
+  NoModifier: 0x00000000,
+  ShiftModifier: 0x02000000,
+  ControlModifier: 0x04000000,
+  AltModifier: 0x08000000,
+  MetaModifier: 0x10000000,
+  KeypadModifier: 0x20000000,
+  GroupSwitchModifier: 0x40000000
+}
+
+const helper = utilQml.match(/function extendsFilter\(event\) \{[\s\S]*?\n {2}\}/)
+assert(helper, 'Util exposes extendsFilter for the searchable panels')
+eval(helper[0])
+
+const key = (text, modifiers) => ({ text, modifiers })
+
+assert(extendsFilter(key('6', Qt.NoModifier)), 'a number-row digit extends the filter')
+assert(extendsFilter(key('5', Qt.KeypadModifier)), 'a numpad digit with NumLock on extends the filter')
+assert(extendsFilter(key('A', Qt.ShiftModifier)), 'a shifted letter extends the filter')
+assert(extendsFilter(key('*', Qt.ShiftModifier | Qt.KeypadModifier)), 'a shifted keypad key still extends the filter')
+assert(extendsFilter(key(' ', Qt.NoModifier)), 'a space extends the filter')
+assert(extendsFilter(key('+', Qt.GroupSwitchModifier)), 'an AltGr character extends the filter')
+assert(extendsFilter(key('+', Qt.ShiftModifier | Qt.GroupSwitchModifier)), 'a shifted AltGr character extends the filter')
+
+assert(!extendsFilter(key('u', Qt.ControlModifier)), 'a Ctrl chord is left to the panel')
+assert(!extendsFilter(key('u', Qt.ControlModifier | Qt.KeypadModifier)), 'a Ctrl chord on the keypad is left to the panel')
+assert(!extendsFilter(key('U', Qt.ControlModifier | Qt.ShiftModifier)), 'a Ctrl+Shift chord is left to the panel')
+assert(!extendsFilter(key('a', Qt.AltModifier)), 'an Alt chord is left to the panel')
+assert(!extendsFilter(key('a', Qt.MetaModifier)), 'a Super chord is left to the panel')
+assert(!extendsFilter(key('', Qt.NoModifier)), 'a key with no text does not extend the filter')
+assert(!extendsFilter(key(String.fromCharCode(127), Qt.NoModifier)), 'Delete does not extend the filter')
+assert(!extendsFilter(key(String.fromCharCode(9), Qt.NoModifier)), 'a control character does not extend the filter')
+assert(!extendsFilter(key('ab', Qt.NoModifier)), 'multi-character text does not extend the filter')
+
+// The panels must route through the helper rather than carry their own copy
+// of the check, or the next exact modifier comparison brings the bug back.
+assert(/Util\.extendsFilter\(event\)/.test(menuQml), 'menu types into its filter through Util.extendsFilter')
+assert(/root\.filterable && Util\.extendsFilter\(event\)/.test(pickerQml), 'image picker types into its filter through Util.extendsFilter')
+assert(!/event\.modifiers === Qt\.NoModifier/.test(menuQml + pickerQml), 'no panel filter compares modifiers for equality with Qt.NoModifier')
+JS


### PR DESCRIPTION
## Problem

Typing a digit on the numeric keypad does nothing in the menu search (`SUPER+SPACE`) or the image picker filter. The same digit on the number row types fine. Characters reached through AltGr, such as `+` on some layouts (#7629), are dropped the same way.

## Cause

Qt sets `Qt.KeypadModifier` on every keypad key event while NumLock is on, and `Qt.GroupSwitchModifier` on AltGr characters. Both panels only append a character when `event.modifiers` is exactly `Qt.NoModifier` or `Qt.ShiftModifier`, so those events match neither and are dropped, even though `event.text` already holds the character. The other searchable panels (clipboard, emojis, lock) test modifiers with bitmasks and are unaffected. These two sites are the only exact modifier comparisons on character input under `shell/`.

## Fix

The "does this keystroke type into the filter?" check was the same expression in both panels. Move it into `Util.extendsFilter(event)` next to the existing `editsFilter` / `editedFilter` helpers, reject only Ctrl, Alt and Super chords there, and route both panels through it.

+15 / −2 in `shell/`, plus one test.

## Related

- #7659 loosens the same guard in the menu alone, to the same deny-list. This applies it to both panels through a shared helper, with a test that exercises the helper's logic rather than its spelling. Happy to rebase on #7659 if that lands first.
- #8176 and #8552 are a different failure with the same symptom: Qt has NumLock out of sync and the keypad arrives as arrow keys with no text. That needs the key-to-digit mapping in #10530 / #8018. With NumLock in sync the digit does arrive, as text, and this PR is what lets it through. Both are needed for the keypad to work everywhere.

## Verification

Live A/B in a running shell on Omarchy 4.0.3-1, Hyprland 0.56.2, kernel 7.2.3: cloned the menu plugin, injected a row `6` then `KP_5` with `wtype`, with the key handler logging modifier bits only.

| Character check | `KP_5` as seen by the handler | Filter text |
|---|---|---|
| exact comparison (current) | `mods=0x20000000` (`KeypadModifier`), printable | `6` |
| keypad bit ignored | same event | `65` |

`test/shell.d/filter-input-test.sh` runs the helper's own JavaScript against the real Qt modifier values (row digit, numpad digit, Shift, AltGr, Ctrl/Alt/Super chords, empty, control and multi-character text) and checks both panels route through it. It fails on unmodified `quattro`.

`./test/shell`: 232 of 237 files pass. The remaining files fail identically on an unmodified `quattro` checkout on this machine (no `omarchy-pkgs` checkout, a two-screen IPC handler count), so they are unrelated to this change.
