### PR TITLE
Add automatic display brightness

### DIFF
--- a/bin/omarchy-brightness-auto
+++ b/bin/omarchy-brightness-auto
@@ -1,0 +1,399 @@
+#!/bin/bash
+
+# omarchy:summary=Control automatic display brightness from an ambient light sensor.
+# omarchy:args=<on|off|toggle|status>
+
+curve_center_percent=30
+curve_percent_per_octave=7.5
+curve_center_lux=200
+smoothing_new_weight=0.25
+change_threshold=2
+max_step=3
+poll_seconds=1
+retry_seconds=5
+iio_root=${OMARCHY_AUTO_BRIGHTNESS_IIO_ROOT:-/sys/bus/iio/devices}
+service=omarchy-brightness-auto.service
+last_status=""
+
+is_apple_sensor() {
+  local path=""
+  local product=""
+  local vendor=""
+
+  path="$(realpath -e "$1")" || return 1
+  while [[ $path != "/" ]]; do
+    if [[ -r $path/idVendor && -r $path/idProduct ]]; then
+      read -r vendor <"$path/idVendor" || return 1
+      read -r product <"$path/idProduct" || return 1
+      [[ ${vendor,,} == "05ac" && ${product,,} == "1114" ]] && return 0
+    fi
+    path="${path%/*}"
+    [[ -n $path ]] || path="/"
+  done
+
+  return 1
+}
+
+find_illuminance_channel() {
+  local sensor="$1"
+  local channel=""
+  local name=""
+
+  if [[ -r $sensor/in_illuminance_input ]]; then
+    printf '%s\n' "$sensor/in_illuminance_input"
+    return
+  fi
+  for channel in "$sensor"/in_illuminance*_input; do
+    name=${channel##*/}
+    if [[ -r $channel && $name =~ ^in_illuminance[0-9]+_input$ ]]; then
+      printf '%s\n' "$channel"
+      return
+    fi
+  done
+  if [[ -r $sensor/in_illuminance_raw ]]; then
+    printf '%s\n' "$sensor/in_illuminance_raw"
+    return
+  fi
+  for channel in "$sensor"/in_illuminance*_raw; do
+    name=${channel##*/}
+    if [[ -r $channel && $name =~ ^in_illuminance[0-9]+_raw$ ]]; then
+      printf '%s\n' "$channel"
+      return
+    fi
+  done
+
+  return 1
+}
+
+find_sensor() {
+  local root="${1:-$iio_root}"
+  local fallback=""
+  local sensor=""
+
+  for sensor in "$root"/iio:device*; do
+    [[ -e $sensor ]] || continue
+    find_illuminance_channel "$sensor" >/dev/null || continue
+
+    if is_apple_sensor "$sensor"; then
+      printf '%s apple\n' "$sensor"
+      return 0
+    fi
+    [[ -n $fallback ]] || fallback="$sensor"
+  done
+
+  [[ -n $fallback ]] || return 1
+  printf '%s generic\n' "$fallback"
+}
+
+read_lux() {
+  local sensor="$1"
+  local channel=""
+  local input=""
+  local offset=0
+  local raw=""
+  local scale=1
+
+  channel="$(find_illuminance_channel "$sensor")" || return 1
+  if [[ $channel == *_input ]]; then
+    read -r input <"$channel" || return 1
+    awk -v value="$input" '
+      BEGIN {
+        if (value !~ /^[-+]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$/) exit 1
+        printf "%.10g\n", value + 0
+      }
+    '
+    return
+  fi
+
+  read -r raw <"$channel" || return 1
+  if [[ -r ${channel%_raw}_offset ]]; then
+    read -r offset <"${channel%_raw}_offset" || return 1
+  elif [[ -r $sensor/in_illuminance_offset ]]; then
+    read -r offset <"$sensor/in_illuminance_offset" || return 1
+  fi
+  if [[ -r ${channel%_raw}_scale ]]; then
+    read -r scale <"${channel%_raw}_scale" || return 1
+  elif [[ -r $sensor/in_illuminance_scale ]]; then
+    read -r scale <"$sensor/in_illuminance_scale" || return 1
+  fi
+
+  awk -v raw="$raw" -v offset="$offset" -v scale="$scale" '
+    function number(value) {
+      return value ~ /^[-+]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$/
+    }
+    BEGIN {
+      if (!number(raw) || !number(offset) || !number(scale)) exit 1
+      printf "%.10g\n", (raw + offset) * scale
+    }
+  '
+}
+
+curve_brightness() {
+  awk \
+    -v lux="$1" \
+    -v center_percent="$curve_center_percent" \
+    -v percent_per_octave="$curve_percent_per_octave" \
+    -v center_lux="$curve_center_lux" '
+      BEGIN {
+        if (lux !~ /^[-+]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$/) exit 1
+        if (lux < 0.1) lux = 0.1
+        target = int(center_percent + percent_per_octave * log(lux / center_lux) / log(2) + 0.5)
+        print target
+      }
+    '
+}
+
+smooth_lux() {
+  awk -v old="$1" -v new="$2" -v new_weight="$smoothing_new_weight" '
+    BEGIN { printf "%.10g\n", old * (1 - new_weight) + new * new_weight }
+  '
+}
+
+target_with_offset() {
+  local target=$(( $1 + $2 ))
+
+  (( target < 1 )) && target=1
+  (( target > 100 )) && target=100
+  printf '%s\n' "$target"
+}
+
+needs_adjustment() {
+  local difference=$(( $1 - $2 ))
+
+  (( difference < 0 )) && difference=$(( -difference ))
+  (( difference >= change_threshold ))
+}
+
+adopt_manual_offset() {
+  printf '%s\n' "$(( $1 + $3 - $2 ))"
+}
+
+step_toward() {
+  local target="$1"
+  local current="$2"
+
+  if (( target - current > max_step )); then
+    printf '%s\n' "$(( current + max_step ))"
+  elif (( current - target > max_step )); then
+    printf '%s\n' "$(( current - max_step ))"
+  else
+    printf '%s\n' "$target"
+  fi
+}
+
+select_monitor() {
+  local kind="$1"
+  local monitors=""
+
+  monitors="$(hyprctl monitors -j 2>/dev/null)" || return 1
+  jq -er --arg kind "$kind" '
+    [.[] | select(.disabled == false)] as $active
+    | if $kind == "apple" then
+        [$active[]
+          | select(
+              .make == "Apple Computer Inc"
+              and ((.model // "") | test("StudioDisplay|ProDisplayXDR|Studio XDR"))
+            )]
+      else
+        [$active[] | select(.name | test("^(eDP|LVDS|DSI)-"))]
+      end as $preferred
+    | if ($preferred | length) == 1 then
+        $preferred[0].name
+      elif ($preferred | length) == 0 and ($active | length) == 1 then
+        $active[0].name
+      else
+        empty
+      end
+  ' <<<"$monitors"
+}
+
+read_brightness() {
+  local brightness=""
+
+  brightness="$(omarchy-brightness-display --monitor "$1" 2>/dev/null)" || return 1
+  [[ $brightness =~ ^[0-9]+$ ]] || return 1
+  (( brightness >= 0 && brightness <= 100 )) || return 1
+  printf '%s\n' "$brightness"
+}
+
+write_brightness() {
+  local monitor="$1"
+  local brightness="$2"
+
+  [[ $brightness =~ ^[0-9]+$ ]] || return 1
+  (( brightness >= 1 && brightness <= 100 )) || return 1
+  omarchy-brightness-display --nonblocking --no-osd --monitor "$monitor" "$brightness%" >/dev/null
+}
+
+log_message() {
+  printf 'omarchy-brightness-auto: %s\n' "$*" >&2
+}
+
+log_state() {
+  local status="$*"
+
+  [[ $status == $last_status ]] && return 0
+  last_status="$status"
+  log_message "$status"
+}
+
+control_session() {
+  local sensor="$1"
+  local kind="$2"
+  local monitor="$3"
+  local lux=""
+  local smoothed_lux=""
+  local base_target=""
+  local target=""
+  local current=""
+  local last_auto=""
+  local offset=""
+  local next=""
+  local mapped_monitor=""
+  local write_status=0
+
+  lux="$(read_lux "$sensor")" || {
+    log_state "unable to read sensor $sensor"
+    return 1
+  }
+  smoothed_lux="$lux"
+  base_target="$(curve_brightness "$smoothed_lux")" || return 1
+  current="$(read_brightness "$monitor")" || {
+    log_state "unable to read brightness for $monitor"
+    return 1
+  }
+  offset=$(( current - base_target ))
+  last_auto="$current"
+  log_state "controlling $monitor from $sensor at $current%"
+
+  while sleep "$poll_seconds"; do
+    mapped_monitor="$(select_monitor "$kind")" || {
+      log_state "lost display $monitor"
+      return 1
+    }
+    if [[ $mapped_monitor != $monitor ]]; then
+      log_state "display mapping changed from $monitor to $mapped_monitor"
+      return 1
+    fi
+    lux="$(read_lux "$sensor")" || {
+      log_state "lost sensor $sensor"
+      return 1
+    }
+    smoothed_lux="$(smooth_lux "$smoothed_lux" "$lux")" || return 1
+    base_target="$(curve_brightness "$smoothed_lux")" || return 1
+    target="$(target_with_offset "$base_target" "$offset")"
+    needs_adjustment "$target" "$last_auto" || continue
+
+    current="$(read_brightness "$monitor")" || {
+      log_state "lost brightness control for $monitor"
+      return 1
+    }
+    if (( current != last_auto )); then
+      offset="$(adopt_manual_offset "$offset" "$last_auto" "$current")"
+      last_auto="$current"
+      target="$(target_with_offset "$base_target" "$offset")"
+      needs_adjustment "$target" "$last_auto" || continue
+    fi
+
+    next="$(step_toward "$target" "$last_auto")"
+    if write_brightness "$monitor" "$next"; then
+      last_auto="$next"
+    else
+      write_status=$?
+      (( write_status == 75 )) && continue
+      log_state "unable to set brightness for $monitor"
+      return 1
+    fi
+  done
+}
+
+controller_pass() {
+  local sensor=""
+  local kind=""
+  local monitor=""
+
+  if ! read -r sensor kind < <(find_sensor); then
+    log_state "no ambient light sensor found"
+    return 1
+  fi
+  monitor="$(select_monitor "$kind")" || {
+    log_state "no unambiguous active monitor for $sensor"
+    return 1
+  }
+  control_session "$sensor" "$kind" "$monitor"
+}
+
+run_controller() {
+  while true; do
+    controller_pass || true
+    sleep "$retry_seconds" || return 0
+  done
+}
+
+automatic_brightness_supported() {
+  local sensor=""
+  local kind=""
+  local monitor=""
+
+  read -r sensor kind < <(find_sensor) || return 1
+  monitor="$(select_monitor "$kind")" || return 1
+  read_brightness "$monitor" >/dev/null
+}
+
+service_enabled() {
+  systemctl --user is-enabled --quiet "$service" 2>/dev/null
+}
+
+print_status() {
+  local supported=false
+  local enabled=false
+  local active=false
+
+  automatic_brightness_supported && supported=true
+  service_enabled && enabled=true
+  systemctl --user is-active --quiet "$service" 2>/dev/null && active=true
+  printf '{"supported":%s,"enabled":%s,"active":%s}\n' "$supported" "$enabled" "$active"
+}
+
+usage() {
+  printf 'Usage: omarchy-brightness-auto <on|off|toggle|status>\n' >&2
+}
+
+main() {
+  if (( $# == 0 )); then
+    run_controller
+    return
+  fi
+
+  (( $# == 1 )) || {
+    usage
+    return 2
+  }
+
+  case "$1" in
+  on)
+    systemctl --user enable --now "$service"
+    ;;
+  off)
+    systemctl --user disable --now "$service"
+    ;;
+  toggle)
+    if service_enabled; then
+      systemctl --user disable --now "$service"
+    else
+      systemctl --user enable --now "$service"
+    fi
+    ;;
+  status)
+    print_status
+    ;;
+  *)
+    usage
+    return 2
+    ;;
+  esac
+}
+
+if [[ ${BASH_SOURCE[0]} == $0 ]]; then
+  main "$@"
+fi

--- a/bin/omarchy-brightness-auto
+++ b/bin/omarchy-brightness-auto
@@ -222,7 +222,7 @@ write_brightness() {
 
   [[ $brightness =~ ^[0-9]+$ ]] || return 1
   (( brightness >= 1 && brightness <= 100 )) || return 1
-  omarchy-brightness-display --nonblocking --no-osd --monitor "$monitor" "$brightness%" >/dev/null
+  omarchy-brightness-display --no-osd --monitor "$monitor" "$brightness%" --nonblocking >/dev/null
 }
 
 log_message() {

--- a/bin/omarchy-brightness-auto
+++ b/bin/omarchy-brightness-auto
@@ -197,7 +197,7 @@ select_monitor() {
       else
         [$active[] | select(.name | test("^(eDP|LVDS|DSI)-"))]
       end as $preferred
-    | if ($preferred | length) == 1 then
+    | if ($preferred | length) == 1 or ($kind == "apple" and ($preferred | length) > 0) then
         $preferred[0].name
       elif ($preferred | length) == 0 and ($active | length) == 1 then
         $active[0].name

--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -1,16 +1,21 @@
 #!/bin/bash
 
 # omarchy:summary=Show or adjust brightness on the focused display.
-# omarchy:args=[--no-osd] [--monitor name] [+N%|N%-|N%|off|on]
+# omarchy:args=[--no-osd] [--nonblocking] [--monitor name] [+N%|N%-|N%|off|on]
 # omarchy:examples=omarchy brightness display | omarchy brightness display +5% | omarchy brightness display --monitor DP-1 50% | omarchy brightness display off | omarchy brightness display on
 
 no_osd=0
+nonblocking=0
 monitor=""
 
 while (( $# > 0 )); do
   case "$1" in
   --no-osd)
     no_osd=1
+    shift
+    ;;
+  --nonblocking)
+    nonblocking=1
     shift
     ;;
   --monitor)
@@ -74,7 +79,13 @@ fi
 # Drop overlapping brightness key events so concurrent invocations do not race.
 # Hardware key repeat present on some devices can otherwise glitch OSD rendering.
 exec {lock_fd}>"${XDG_RUNTIME_DIR:-/tmp}/omarchy-brightness-display.lock"
-flock -n "$lock_fd" || exit 0
+if (( nonblocking )); then
+  flock -n "$lock_fd" || exit 75
+elif [[ $step =~ ^[0-9]+%$ ]]; then
+  flock "$lock_fd"
+else
+  flock -n "$lock_fd" || exit 0
+fi
 
 if use_apple_display; then
   if (( no_osd )); then

--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -29,6 +29,13 @@ while (( $# > 0 )); do
   esac
 done
 
+# Keep this form compatible with older dispatchers, which ignore arguments
+# after the brightness value.
+if (( $# == 2 )) && [[ $2 == "--nonblocking" ]]; then
+  nonblocking=1
+  set -- "$1"
+fi
+
 # Get the brightness of the passed display
 backlight_brightness() {
   brightnessctl -d "$1" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'

--- a/bin/omarchy-brightness-display-apple
+++ b/bin/omarchy-brightness-display-apple
@@ -4,91 +4,81 @@
 # omarchy:args=[--no-osd] [+N%|N%-|N%]
 # omarchy:examples=omarchy brightness display apple | omarchy brightness display apple +5% | omarchy brightness display apple --no-osd 50%
 
-device_cache="${XDG_RUNTIME_DIR:-/tmp}/omarchy-brightness-display-apple.device"
+device_root=${OMARCHY_BRIGHTNESS_APPLE_DEV_ROOT:-/dev}
 no_osd=0
 if [[ ${1:-} == "--no-osd" ]]; then
   no_osd=1
   shift
 fi
 
-detect_apple_display_device() {
+detect_apple_display_devices() {
   local devices=()
   local path=""
 
-  for path in /dev/usb/hiddev* /dev/hiddev*; do
+  for path in "$device_root"/usb/hiddev* "$device_root"/hiddev*; do
     [[ -e $path ]] && devices+=("$path")
   done
 
   (( ${#devices[@]} > 0 )) || return 1
 
-  sudo asdcontrol --detect "${devices[@]}" 2>/dev/null | awk -F: '/^\/dev\/(usb\/)?hiddev/{ print $1; exit }'
-}
-
-find_apple_display_device() {
-  local cached=""
-  local device=""
-
-  if [[ -r $device_cache ]]; then
-    read -r cached <"$device_cache" || true
-    if [[ -n $cached && -e $cached ]]; then
-      printf '%s\n' "$cached"
-      return 0
-    fi
-  fi
-
-  device="$(detect_apple_display_device)" || return 1
-  [[ -n $device ]] || return 1
-
-  printf '%s\n' "$device" >"$device_cache"
-  printf '%s\n' "$device"
+  sudo asdcontrol --detect "${devices[@]}" 2>/dev/null |
+    awk -F: '/: USB Monitor - SUPPORTED\./{ print $1 }'
 }
 
 current_brightness() {
-  local device="$1"
+  local brightness=""
+  local count=0
+  local device=""
+  local total=0
 
-  sudo asdcontrol "$device" 2>/dev/null | awk -F= '
-    /BRIGHTNESS=/ {
-      print int($2 * 100 / 60000)
-      found = 1
-    }
+  for device in "$@"; do
+    brightness="$(sudo asdcontrol "$device" 2>/dev/null | awk -F= '
+      /BRIGHTNESS=/ {
+        print int($2 * 100 / 60000)
+        found = 1
+      }
 
-    END { exit !found }
-  '
+      END { exit !found }
+    ')" || return 1
+    total=$(( total + brightness ))
+    count=$(( count + 1 ))
+  done
+
+  (( count > 0 )) || return 1
+  printf '%s\n' "$(( total / count ))"
 }
 
-retry_with_fresh_device() {
-  rm -f "$device_cache"
-  device="$(find_apple_display_device || true)"
-  if [[ -z $device ]]; then
-    echo "No Apple Display HID device found" >&2
-    exit 1
-  fi
-}
-
-device="$(find_apple_display_device || true)"
-if [[ -z $device ]]; then
+mapfile -t devices < <(detect_apple_display_devices)
+if (( ${#devices[@]} == 0 )); then
   echo "No Apple Display HID device found" >&2
   exit 1
 fi
 
 if (( $# == 0 )); then
-  if current_brightness "$device"; then
-    exit
-  else
-    retry_with_fresh_device
-    current_brightness "$device"
-    exit
-  fi
+  current_brightness "${devices[@]}"
+  exit
 fi
 
 step="$1"
 if [[ $step =~ ^([0-9]+)%-$ ]]; then
   step="-${BASH_REMATCH[1]}%"
 fi
-
-if ! sudo asdcontrol "$device" -- "$step" >/dev/null; then
-  retry_with_fresh_device
-  sudo asdcontrol "$device" -- "$step" >/dev/null
+if [[ $step =~ ^([+-])([0-9]+)%$ ]]; then
+  brightness="$(current_brightness "${devices[@]}")" || exit 1
+  if [[ ${BASH_REMATCH[1]} == "+" ]]; then
+    target=$(( brightness + BASH_REMATCH[2] ))
+  else
+    target=$(( brightness - BASH_REMATCH[2] ))
+  fi
+  (( target < 0 )) && target=0
+  (( target > 100 )) && target=100
+  step="$target%"
 fi
 
-(( no_osd )) || omarchy-osd -i brightness -p "$(current_brightness "$device")"
+write_failed=0
+for device in "${devices[@]}"; do
+  sudo asdcontrol "$device" -- "$step" >/dev/null || write_failed=1
+done
+(( write_failed == 0 )) || exit 1
+
+(( no_osd )) || omarchy-osd -i brightness -p "$(current_brightness "${devices[@]}")"

--- a/default/systemd/user/omarchy-brightness-auto.service
+++ b/default/systemd/user/omarchy-brightness-auto.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Adjust display brightness from ambient light
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-brightness-auto
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -111,6 +111,21 @@ function parseDisplays(raw) {
   }
 }
 
+function parseAutoBrightnessStatus(raw) {
+  var status = {}
+  try {
+    status = raw ? JSON.parse(String(raw)) : {}
+  } catch (e) {
+    status = {}
+  }
+
+  return {
+    supported: status.supported === true,
+    enabled: status.enabled === true,
+    active: status.active === true
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -119,6 +134,7 @@ if (typeof module !== "undefined") {
     matchingScaleIndex: matchingScaleIndex,
     availableScales: availableScales,
     brightnessName: brightnessName,
-    parseDisplays: parseDisplays
+    parseDisplays: parseDisplays,
+    parseAutoBrightnessStatus: parseAutoBrightnessStatus
   }
 }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -18,6 +18,10 @@ Panel {
   property int pendingBrightnessPercent: 0
   property bool brightnessSetQueued: false
   property bool brightnessAvailable: false
+  property bool automaticBrightnessSupported: false
+  property bool automaticBrightnessEnabled: false
+  property bool automaticBrightnessActive: false
+  property bool automaticBrightnessBusy: false
   property string internalMonitor: ""
   property string externalMonitor: ""
   property string focusedMonitor: ""
@@ -75,6 +79,7 @@ Panel {
   readonly property var visibleSections: {
     var list = []
     if (brightnessAvailable) list.push("brightness")
+    if (automaticBrightnessSupported) list.push("automatic-brightness")
     list.push("textsize")
     list.push("scale")
     if (displays.length > 1) list.push("monitors")
@@ -83,6 +88,7 @@ Panel {
 
   function sectionCount(section) {
     if (section === "brightness") return 0  // only the slider sentinel at -1
+    if (section === "automatic-brightness") return 0
     if (section === "textsize") return 0    // slider sentinel at -1, like brightness
     if (section === "scale") return scaleValues.length
     if (section === "monitors") return displays.length
@@ -91,11 +97,12 @@ Panel {
 
   function sectionIsSingleRow(section) {
     // brightness and text size are lone sliders; scale presets sit horizontally.
-    return section === "brightness" || section === "textsize" || section === "scale"
+    return section === "brightness" || section === "automatic-brightness"
+      || section === "textsize" || section === "scale"
   }
 
   function sectionFirstIndex(section) {
-    if (section === "brightness" || section === "textsize") return -1
+    if (section === "brightness" || section === "automatic-brightness" || section === "textsize") return -1
     return 0
   }
 
@@ -147,6 +154,10 @@ Panel {
   }
 
   function activateCursor() {
+    if (focusSection === "automatic-brightness") {
+      toggleAutomaticBrightness()
+      return
+    }
     if (focusSection === "scale" && selectedIndex >= 0 && selectedIndex < scaleValues.length) {
       setScale(scaleValues[selectedIndex])
       return
@@ -169,7 +180,7 @@ Panel {
     var count = sectionCount(focusSection)
     if (sectionIsSingleRow(focusSection)) {
       // brightness/text size use the -1 sentinel; scale clamps into the presets.
-      if (focusSection === "brightness" || focusSection === "textsize") selectedIndex = -1
+      if (focusSection === "brightness" || focusSection === "automatic-brightness" || focusSection === "textsize") selectedIndex = -1
       else if (selectedIndex < 0 || selectedIndex >= count) selectedIndex = 0
       return
     }
@@ -231,6 +242,26 @@ Panel {
 
   function refresh() {
     if (!stateProc.running) stateProc.running = true
+    if (!automaticBrightnessStatusProc.running) automaticBrightnessStatusProc.running = true
+  }
+
+  function updateAutomaticBrightness(statusJson) {
+    var status = Model.parseAutoBrightnessStatus(statusJson)
+    root.automaticBrightnessSupported = status.supported
+    root.automaticBrightnessEnabled = status.enabled
+    root.automaticBrightnessActive = status.active
+  }
+
+  function toggleAutomaticBrightness() {
+    if (!root.automaticBrightnessSupported || root.automaticBrightnessBusy) return
+
+    root.automaticBrightnessEnabled = !root.automaticBrightnessEnabled
+    root.automaticBrightnessBusy = true
+    automaticBrightnessActionProc.command = [
+      "omarchy-brightness-auto",
+      root.automaticBrightnessEnabled ? "on" : "off"
+    ]
+    automaticBrightnessActionProc.running = true
   }
 
   function setBrightness(value) {
@@ -369,6 +400,7 @@ Panel {
   }
 
   onBrightnessAvailableChanged: clampCursor()
+  onAutomaticBrightnessSupportedChanged: clampCursor()
   onDisplaysChanged: clampCursor()
   onScaleValuesChanged: clampCursor()
   onVisibleSectionsChanged: clampCursor()
@@ -401,6 +433,25 @@ Panel {
         root.monitorScale = root.normalizeScale(String(lines[6] || "").trim())
         root.updateDisplays(String(lines[7] || "[]").trim())
       }
+    }
+  }
+
+  Process {
+    id: automaticBrightnessStatusProc
+    command: ["omarchy-brightness-auto", "status"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateAutomaticBrightness(text)
+    }
+  }
+
+  Process {
+    id: automaticBrightnessActionProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running) return
+      root.automaticBrightnessBusy = false
+      if (!automaticBrightnessStatusProc.running) automaticBrightnessStatusProc.running = true
     }
   }
 
@@ -648,6 +699,34 @@ Panel {
                 }
               }
             }
+
+          }
+
+          PanelSeparator {
+            visible: root.automaticBrightnessSupported
+            foreground: root.bar.foreground
+          }
+
+          Toggle {
+            id: automaticBrightnessToggle
+            visible: root.automaticBrightnessSupported
+            width: parent.width
+            label: "Automatic brightness"
+            description: root.automaticBrightnessActive ? "Following ambient light" : "Adjust to ambient light"
+            checked: root.automaticBrightnessEnabled
+            enabled: !root.automaticBrightnessBusy
+            opacity: enabled ? 1.0 : 0.65
+            hasCursor: root.cursorActive && root.focusSection === "automatic-brightness"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            onClicked: root.toggleAutomaticBrightness()
+            onHovered: function(isHovered) {
+              if (!isHovered || root.reflowingText) return
+              root.cursorActive = true
+              root.focusSection = "automatic-brightness"
+              root.selectedIndex = -1
+            }
+            onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(automaticBrightnessToggle)
           }
 
           // ---------- Text size ----------

--- a/test/shell.d/brightness-auto-test.sh
+++ b/test/shell.d/brightness-auto-test.sh
@@ -108,8 +108,8 @@ cat >"$mock_bin/omarchy-brightness-display" <<'SH'
 [[ ${BRIGHTNESS_AVAILABLE:-1} == "1" ]] || exit 1
 if (( $# == 2 )) && [[ $1 == "--monitor" ]]; then
   printf '%s\n' "${BRIGHTNESS_VALUE:-30}"
-elif (( $# == 4 )) && [[ $1 == "--no-osd" && $2 == "--monitor" ]]; then
-  printf '%s\n' "$4" >>"$BRIGHTNESS_WRITES"
+elif (( $# == 5 )) && [[ $1 == "--no-osd" && $2 == "--monitor" && $5 == "--nonblocking" ]]; then
+  printf '%s\n' "$*" >>"$BRIGHTNESS_WRITES"
 else
   exit 2
 fi
@@ -133,6 +133,15 @@ case "$*" in
 esac
 SH
 chmod +x "$mock_bin"/*
+
+brightness_writes="$test_tmp/brightness-writes"
+: >"$brightness_writes"
+if ! BRIGHTNESS_WRITES="$brightness_writes" PATH="$mock_bin:$PATH" write_brightness eDP-1 31; then
+  fail "automatic brightness keeps silent writes compatible with older display commands"
+fi
+grep -Fx -- '--no-osd --monitor eDP-1 31% --nonblocking' "$brightness_writes" >/dev/null ||
+  fail "automatic brightness keeps silent writes compatible with older display commands"
+pass "automatic brightness keeps silent writes compatible with older display commands"
 
 run_auto() {
   OMARCHY_AUTO_BRIGHTNESS_IIO_ROOT="${AUTO_IIO_ROOT:-$test_tmp/iio-generic}" \
@@ -169,7 +178,6 @@ pass "automatic brightness exposes persistent service controls"
 
 session_sensor="$test_tmp/session-sensor"
 sleep_count="$test_tmp/sleep-count"
-brightness_writes="$test_tmp/brightness-writes"
 mkdir -p "$session_sensor"
 printf '200\n' >"$session_sensor/in_illuminance_input"
 printf '0\n' >"$sleep_count"

--- a/test/shell.d/brightness-auto-test.sh
+++ b/test/shell.d/brightness-auto-test.sh
@@ -135,7 +135,7 @@ SH
 chmod +x "$mock_bin"/*
 
 run_auto() {
-  OMARCHY_AUTO_BRIGHTNESS_IIO_ROOT="$test_tmp/iio-generic" \
+  OMARCHY_AUTO_BRIGHTNESS_IIO_ROOT="${AUTO_IIO_ROOT:-$test_tmp/iio-generic}" \
     SYSTEMCTL_STATE="$systemctl_state" SYSTEMCTL_CALLS="$systemctl_calls" \
     MONITORS_FILE="$monitors_file" BRIGHTNESS_WRITES="$test_tmp/brightness-writes" \
     PATH="$mock_bin:$PATH" "$script" "$@"
@@ -150,6 +150,15 @@ jq -e '.supported == true and .enabled == false and .active == false' <<<"$statu
 status=$(BRIGHTNESS_AVAILABLE=0 run_auto status)
 jq -e '.supported == false' <<<"$status" >/dev/null ||
   fail "automatic brightness hides when its mapped display is not controllable" "$status"
+
+printf '%s\n' '[
+  {"name":"DP-1","make":"Apple Computer Inc","model":"StudioDisplay","disabled":false},
+  {"name":"DP-3","make":"Apple Computer Inc","model":"StudioDisplay","disabled":false}
+]' >"$monitors_file"
+status=$(AUTO_IIO_ROOT="$test_tmp/iio" run_auto status)
+jq -e '.supported == true' <<<"$status" >/dev/null ||
+  fail "automatic brightness supports a group of Apple displays" "$status"
+
 run_auto on
 run_auto toggle
 grep -Fx -- '--user enable --now omarchy-brightness-auto.service' "$systemctl_calls" >/dev/null ||

--- a/test/shell.d/brightness-auto-test.sh
+++ b/test/shell.d/brightness-auto-test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+script="$ROOT/bin/omarchy-brightness-auto"
+unit="$ROOT/default/systemd/user/omarchy-brightness-auto.service"
+
+[[ -x $script ]] || fail "automatic brightness command is installed"
+source "$script"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+generic_sensor="$test_tmp/iio/iio:device0"
+apple_sensor="$test_tmp/devices/usb/1-1/1-1:1.8/iio:device1"
+mkdir -p "$generic_sensor" "$apple_sensor"
+printf '50\n' >"$generic_sensor/in_illuminance_input"
+printf '05ac\n' >"$test_tmp/devices/usb/1-1/idVendor"
+printf '1114\n' >"$test_tmp/devices/usb/1-1/idProduct"
+printf '10\n' >"$apple_sensor/in_illuminance_raw"
+printf '0.5\n' >"$apple_sensor/in_illuminance_offset"
+printf '2\n' >"$apple_sensor/in_illuminance_scale"
+ln -s "$apple_sensor" "$test_tmp/iio/iio:device1"
+
+read -r sensor kind < <(find_sensor "$test_tmp/iio")
+[[ $sensor == $test_tmp/iio/iio:device1 && $kind == "apple" ]] ||
+  fail "Apple ambient sensor is preferred when several sensors exist"
+[[ $(read_lux "$sensor") == "21" ]] || fail "raw sensor values use their IIO offset and scale"
+[[ $(curve_brightness 200) == "30" ]] || fail "brightness curve keeps its calibrated midpoint"
+[[ $(target_with_offset "$(curve_brightness 3276800)" -46) == "89" ]] ||
+  fail "a manual baseline does not cap bright-light headroom"
+[[ $(smooth_lux 100 200) == "125" ]] || fail "ambient readings are smoothed"
+[[ $(step_toward 45 35) == "38" ]] || fail "brightness changes are capped per poll"
+pass "automatic brightness sensor and curve behavior"
+
+(
+  lux_read_count="$test_tmp/lux-read-count"
+  sleep_count="$test_tmp/contention-sleep-count"
+  write_count="$test_tmp/contention-write-count"
+  contention_writes="$test_tmp/contention-writes"
+  printf '0\n' >"$lux_read_count"
+  printf '0\n' >"$sleep_count"
+  printf '0\n' >"$write_count"
+  : >"$contention_writes"
+  smoothing_new_weight=1
+
+  read_lux() {
+    local count=""
+    read -r count <"$lux_read_count"
+    printf '%s\n' "$(( count + 1 ))" >"$lux_read_count"
+    (( count == 0 )) && printf '200\n' || printf '240\n'
+  }
+  read_brightness() { printf '30\n'; }
+  select_monitor() { printf 'eDP-1\n'; }
+  log_state() { :; }
+  sleep() {
+    local count=""
+    read -r count <"$sleep_count"
+    (( count < 2 )) || return 1
+    printf '%s\n' "$(( count + 1 ))" >"$sleep_count"
+  }
+  write_brightness() {
+    local count=""
+    read -r count <"$write_count"
+    printf '%s\n' "$2" >>"$contention_writes"
+    printf '%s\n' "$(( count + 1 ))" >"$write_count"
+    (( count > 0 )) || return 75
+  }
+
+  control_session ignored generic eDP-1
+  [[ $(cat "$contention_writes") == $'32\n32' ]] ||
+    fail "a contended automatic write retries without advancing its brightness state"
+)
+pass "automatic brightness retries a contended write"
+
+indexed_sensor="$test_tmp/iio-indexed/iio:device0"
+mkdir -p "$indexed_sensor"
+printf '10\n' >"$indexed_sensor/in_illuminance0_raw"
+printf '0.5\n' >"$indexed_sensor/in_illuminance0_offset"
+printf '2\n' >"$indexed_sensor/in_illuminance_scale"
+if ! read -r sensor kind < <(find_sensor "$test_tmp/iio-indexed"); then
+  fail "indexed IIO illuminance channels are discovered"
+fi
+[[ $sensor == $indexed_sensor && $kind == "generic" ]] ||
+  fail "indexed IIO illuminance channels are discovered"
+[[ $(read_lux "$sensor") == "21" ]] ||
+  fail "indexed IIO channels use channel and shared calibration attributes"
+pass "automatic brightness supports indexed IIO illuminance channels"
+
+mock_bin="$test_tmp/bin"
+systemctl_state="$test_tmp/systemctl-state"
+systemctl_calls="$test_tmp/systemctl-calls"
+monitors_file="$test_tmp/monitors.json"
+mkdir -p "$mock_bin"
+printf 'disabled inactive\n' >"$systemctl_state"
+printf '%s\n' '[{"name":"eDP-1","make":"BOE","model":"Panel","disabled":false}]' >"$monitors_file"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ ${1:-} == "monitors" && ${2:-} == "-j" ]] || exit 1
+cat "$MONITORS_FILE"
+SH
+
+cat >"$mock_bin/omarchy-brightness-display" <<'SH'
+#!/bin/bash
+[[ ${BRIGHTNESS_AVAILABLE:-1} == "1" ]] || exit 1
+if (( $# == 2 )) && [[ $1 == "--monitor" ]]; then
+  printf '%s\n' "${BRIGHTNESS_VALUE:-30}"
+elif (( $# == 4 )) && [[ $1 == "--no-osd" && $2 == "--monitor" ]]; then
+  printf '%s\n' "$4" >>"$BRIGHTNESS_WRITES"
+else
+  exit 2
+fi
+SH
+
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+read -r enabled active <"$SYSTEMCTL_STATE"
+case "$*" in
+  "--user is-enabled --quiet omarchy-brightness-auto.service") [[ $enabled == "enabled" ]] ;;
+  "--user is-active --quiet omarchy-brightness-auto.service") [[ $active == "active" ]] ;;
+  "--user enable --now omarchy-brightness-auto.service")
+    printf 'enabled active\n' >"$SYSTEMCTL_STATE"
+    printf '%s\n' "$*" >>"$SYSTEMCTL_CALLS"
+    ;;
+  "--user disable --now omarchy-brightness-auto.service")
+    printf 'disabled inactive\n' >"$SYSTEMCTL_STATE"
+    printf '%s\n' "$*" >>"$SYSTEMCTL_CALLS"
+    ;;
+  *) exit 2 ;;
+esac
+SH
+chmod +x "$mock_bin"/*
+
+run_auto() {
+  OMARCHY_AUTO_BRIGHTNESS_IIO_ROOT="$test_tmp/iio-generic" \
+    SYSTEMCTL_STATE="$systemctl_state" SYSTEMCTL_CALLS="$systemctl_calls" \
+    MONITORS_FILE="$monitors_file" BRIGHTNESS_WRITES="$test_tmp/brightness-writes" \
+    PATH="$mock_bin:$PATH" "$script" "$@"
+}
+
+mkdir -p "$test_tmp/iio-generic/iio:device0"
+printf '200\n' >"$test_tmp/iio-generic/iio:device0/in_illuminance_input"
+
+status=$(run_auto status)
+jq -e '.supported == true and .enabled == false and .active == false' <<<"$status" >/dev/null ||
+  fail "automatic brightness reports supported disabled state" "$status"
+status=$(BRIGHTNESS_AVAILABLE=0 run_auto status)
+jq -e '.supported == false' <<<"$status" >/dev/null ||
+  fail "automatic brightness hides when its mapped display is not controllable" "$status"
+run_auto on
+run_auto toggle
+grep -Fx -- '--user enable --now omarchy-brightness-auto.service' "$systemctl_calls" >/dev/null ||
+  fail "automatic brightness can be enabled"
+grep -Fx -- '--user disable --now omarchy-brightness-auto.service' "$systemctl_calls" >/dev/null ||
+  fail "automatic brightness can be disabled"
+pass "automatic brightness exposes persistent service controls"
+
+session_sensor="$test_tmp/session-sensor"
+sleep_count="$test_tmp/sleep-count"
+brightness_writes="$test_tmp/brightness-writes"
+mkdir -p "$session_sensor"
+printf '200\n' >"$session_sensor/in_illuminance_input"
+printf '0\n' >"$sleep_count"
+: >"$brightness_writes"
+cat >"$mock_bin/sleep" <<'SH'
+#!/bin/bash
+read -r count <"$SLEEP_COUNT"
+if (( count == 0 )); then
+  printf '[]\n' >"$MONITORS_FILE"
+  printf '1\n' >"$SLEEP_COUNT"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$mock_bin/sleep"
+
+if MONITORS_FILE="$monitors_file" SLEEP_COUNT="$sleep_count" BRIGHTNESS_WRITES="$brightness_writes" \
+  PATH="$mock_bin:$PATH" control_session "$session_sensor" generic eDP-1 2>/dev/null; then
+  fail "automatic brightness detects display loss under steady light"
+fi
+[[ ! -s $brightness_writes ]] || fail "display loss does not write a stale brightness target"
+pass "automatic brightness remaps after display loss under steady light"
+
+grep -Fx 'ExecStart=/usr/bin/omarchy-brightness-auto' "$unit" >/dev/null ||
+  fail "automatic brightness unit runs the package command"
+grep -Fx 'WantedBy=graphical-session.target' "$unit" >/dev/null ||
+  fail "automatic brightness unit follows the graphical session"
+grep -F 'omarchy-brightness-auto.service' "$ROOT/install/user/first-run/enable-user-units.sh" >/dev/null &&
+  fail "automatic brightness must remain opt-in"
+pass "automatic brightness ships disabled by default"

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -153,6 +153,13 @@ else
   [[ $? == 75 ]] || fail "nonblocking automatic writes use the busy exit status"
 fi
 
+if timeout 0.1 env CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" PATH="$mock_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-brightness-display" --no-osd --monitor DP-1 35% --nonblocking; then
+  fail "trailing nonblocking writes report lock contention"
+else
+  [[ $? == 75 ]] || fail "trailing nonblocking writes use the busy exit status"
+fi
+
 write_count=$(grep -c ' setvcp 10 ' "$call_log")
 if timeout 0.1 env CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" PATH="$mock_bin:$ROOT/bin:$PATH" \
   "$ROOT/bin/omarchy-brightness-display" --no-osd --monitor DP-1 35%; then

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -14,7 +14,7 @@ mkdir -p "$mock_bin" "$runtime_dir"
 
 cat >"$mock_bin/omarchy-hyprland-monitor-focused-apple" <<'SH'
 #!/bin/bash
-exit 1
+[[ ${APPLE_MONITOR:-0} == "1" ]]
 SH
 
 cat >"$mock_bin/omarchy-hyprland-monitor-focused" <<'SH'
@@ -32,6 +32,36 @@ cat >"$mock_bin/brightnessctl" <<'SH'
 printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
 if [[ $* == *" -m"* ]]; then
   printf 'mock_backlight,backlight,40,40%%\n'
+fi
+SH
+
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$mock_bin/asdcontrol" <<'SH'
+#!/bin/bash
+printf 'asdcontrol %s\n' "$*" >>"$CALL_LOG"
+
+if [[ ${1:-} == "--detect" ]]; then
+  shift
+  for device in "$@"; do
+    case "$device" in
+    *hiddev5 | *hiddev10) printf '%s: USB Monitor - SUPPORTED.\n' "$device" ;;
+    *hiddev7) printf '%s: USB Monitor - UNSUPPORTED.\n' "$device" ;;
+    esac
+  done
+elif (( $# == 1 )); then
+  case "$1" in
+  *hiddev5) printf 'BRIGHTNESS=24000\n' ;;
+  *hiddev10) printf 'BRIGHTNESS=36000\n' ;;
+  *) exit 1 ;;
+  esac
+elif (( $# == 3 )) && [[ $2 == "--" ]]; then
+  [[ ${ASD_WRITE_FAIL_DEVICE:-} != "$1" ]]
+else
+  exit 2
 fi
 SH
 
@@ -54,9 +84,33 @@ SH
 chmod +x "$mock_bin"/*
 
 run_brightness() {
-  CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" PATH="$mock_bin:$ROOT/bin:$PATH" \
+  CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" \
+    OMARCHY_BRIGHTNESS_APPLE_DEV_ROOT="$test_tmp/dev" PATH="$mock_bin:$ROOT/bin:$PATH" \
     "$ROOT/bin/omarchy-brightness-display" "$@"
 }
+
+mkdir -p "$test_tmp/dev/usb"
+touch "$test_tmp/dev/usb/hiddev5" "$test_tmp/dev/usb/hiddev7" "$test_tmp/dev/usb/hiddev10"
+
+if ! brightness=$(APPLE_MONITOR=1 run_brightness --monitor DP-1); then
+  fail "Apple displays report their group brightness"
+fi
+[[ $brightness == "50" ]] || fail "Apple displays report their group brightness" "actual: $brightness"
+APPLE_MONITOR=1 run_brightness --no-osd --monitor DP-1 +5%
+grep -F "asdcontrol $test_tmp/dev/usb/hiddev5 -- 55%" "$call_log" >/dev/null ||
+  fail "Apple brightness is written to the first display"
+grep -F "asdcontrol $test_tmp/dev/usb/hiddev10 -- 55%" "$call_log" >/dev/null ||
+  fail "Apple brightness is written to the second display"
+if grep -F "asdcontrol $test_tmp/dev/usb/hiddev7 -- 55%" "$call_log" >/dev/null; then
+  fail "unsupported HID devices are excluded from the Apple brightness group"
+fi
+pass "Apple displays share one brightness"
+
+if APPLE_MONITOR=1 ASD_WRITE_FAIL_DEVICE="$test_tmp/dev/usb/hiddev10" \
+  run_brightness --no-osd --monitor DP-1 55%; then
+  fail "Apple group brightness reports a partial write failure"
+fi
+pass "Apple group brightness reports a partial write failure"
 
 brightness=$(run_brightness --monitor DP-1)
 [[ $brightness == "50" ]] || fail "external brightness is converted to a percentage" "actual: $brightness"

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -80,6 +80,39 @@ grep -F 'ddcutil --bus 7 --skip-ddc-checks --noverify setvcp 10 24' "$call_log" 
   fail "absolute external brightness skips write verification"
 pass "absolute external brightness reuses the cached VCP range"
 
+lock_file="$runtime_dir/omarchy-brightness-display.lock"
+lock_ready="$test_tmp/lock-ready"
+lock_release="$test_tmp/lock-release"
+mkfifo "$lock_release"
+(
+  exec {held_lock_fd}>"$lock_file"
+  flock "$held_lock_fd"
+  touch "$lock_ready"
+  read -r <"$lock_release"
+) &
+lock_holder_pid=$!
+while [[ ! -e $lock_ready ]]; do sleep 0.01; done
+
+if run_brightness --nonblocking --no-osd --monitor DP-1 35%; then
+  fail "nonblocking automatic writes report lock contention"
+else
+  [[ $? == 75 ]] || fail "nonblocking automatic writes use the busy exit status"
+fi
+
+write_count=$(grep -c ' setvcp 10 ' "$call_log")
+if timeout 0.1 env CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" PATH="$mock_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-brightness-display" --no-osd --monitor DP-1 35%; then
+  fail "manual absolute writes wait for the brightness lock"
+else
+  [[ $? == 124 ]] || fail "manual absolute writes block during lock contention"
+fi
+printf '\n' >"$lock_release"
+wait "$lock_holder_pid"
+run_brightness --no-osd --monitor DP-1 35%
+(( $(grep -c ' setvcp 10 ' "$call_log") == write_count + 1 )) ||
+  fail "manual absolute writes wait for the brightness lock"
+pass "automatic writes yield the brightness lock to manual absolute writes"
+
 brightness=$(run_brightness --monitor eDP-1)
 [[ $brightness == "40" ]] || fail "internal monitor uses the kernel backlight" "actual: $brightness"
 grep -F 'brightnessctl -d mock_backlight -m' "$call_log" >/dev/null || \

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -118,12 +118,14 @@ if pkgs_root is None:
   )
   sys.exit(1)
 settings_pkgbuild_path = pkgs_root / "omarchy-settings/PKGBUILD"
+settings_dev_pkgbuild_path = pkgs_root / "omarchy-settings-dev/PKGBUILD"
 omarchy_pkgbuild_path = pkgs_root / "omarchy/PKGBUILD"
 if not settings_pkgbuild_path.exists():
   settings_pkgbuild_path = pkgs_root / "omarchy-settings-dev/PKGBUILD"
 if not omarchy_pkgbuild_path.exists():
   omarchy_pkgbuild_path = pkgs_root / "omarchy-dev/PKGBUILD"
 pkgbuild = settings_pkgbuild_path.read_text()
+settings_dev_pkgbuild = settings_dev_pkgbuild_path.read_text() if settings_dev_pkgbuild_path.exists() else ""
 omarchy_pkgbuild = omarchy_pkgbuild_path.read_text()
 errors = []
 package_defaults = [
@@ -135,6 +137,7 @@ package_defaults = [
   ("default/applications/mimeapps.list", "/usr/share/applications/mimeapps.list", "mimeapps.list"),
   ("etc/fastfetch/config.jsonc", "/etc/fastfetch/config.jsonc", "fastfetch/config.jsonc"),
   ("default/systemd/user/bt-agent.service", "/usr/lib/systemd/user/bt-agent.service", "systemd/user/bt-agent.service"),
+  ("default/systemd/user/omarchy-brightness-auto.service", None, "systemd/user/omarchy-brightness-auto.service"),
   ("default/systemd/user/omarchy-sleep-lock.service", "/usr/lib/systemd/user/omarchy-sleep-lock.service", "systemd/user/omarchy-sleep-lock.service"),
   ("default/systemd/user/omarchy-recover-internal-monitor.service", "/usr/lib/systemd/user/omarchy-recover-internal-monitor.service", "systemd/user/omarchy-recover-internal-monitor.service"),
   ("default/systemd/user/omarchy-migrate-notify.service", "/usr/lib/systemd/user/omarchy-migrate-notify.service", "systemd/user/omarchy-migrate-notify.service"),
@@ -153,6 +156,14 @@ for source, destination, legacy in package_defaults:
     errors.append(f"legacy path still in config/: {legacy}")
   if destination and (source not in pkgbuild or destination not in pkgbuild):
     errors.append(f"PKGBUILD does not explicitly install {source} -> {destination}")
+
+auto_brightness_source = "default/systemd/user/omarchy-brightness-auto.service"
+auto_brightness_destination = "/usr/lib/systemd/user/omarchy-brightness-auto.service"
+if auto_brightness_source not in settings_dev_pkgbuild or auto_brightness_destination not in settings_dev_pkgbuild:
+  errors.append(
+    "omarchy-settings-dev PKGBUILD does not explicitly install "
+    f"{auto_brightness_source} -> {auto_brightness_destination}"
+  )
 
 # Existing users have an absolute wants symlink to the old unit path, and the
 # migration that repoints it only runs for users who run an update -- the

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -75,4 +75,15 @@ assertDeepEqual(
 )
 
 assertDeepEqual(monitor.parseDisplays('{'), { displays: [], enabledDisplayCount: 0 }, 'monitor handles invalid display JSON')
+
+assertDeepEqual(
+  monitor.parseAutoBrightnessStatus('{"supported":true,"enabled":true,"active":false}'),
+  { supported: true, enabled: true, active: false },
+  'monitor parses automatic brightness state'
+)
+assertDeepEqual(
+  monitor.parseAutoBrightnessStatus('{'),
+  { supported: false, enabled: false, active: false },
+  'monitor handles invalid automatic brightness state'
+)
 JS


### PR DESCRIPTION
## What changed

- Adds `omarchy brightness auto on|off|toggle|status` commands and an opt-in user service.
- Reads ambient light from IIO sensors to adjust matching internal or external displays.
- Controls connected Apple displays as one brightness group when they share an Apple ambient-light sensor.
- Adds an accessible automatic-brightness toggle to the Display panel.
- Treats manual brightness changes as a new baseline, restoring that level when ambient light returns to its previous range.

The service prefers the Apple display sensor for Apple Studio Display, Pro Display XDR, and supported Apple Cinema Display models. Generic sensors control the internal display or the only active display.

## Development

OpenAI GPT-5.6 Sol wrote the code at xhigh reasoning effort under my supervision.

## Packaging

Companion package change: [omacom-io/omarchy-pkgs#193](https://github.com/omacom-io/omarchy-pkgs/pull/193).

## Testing

- `./test/all` (191 test files)
- `test/shell.d/brightness-auto-test.sh`
- `test/shell.d/brightness-display-test.sh`
- Live tested on dual Apple Studio Displays: enable and disable, dark and bright ambient-light response, manual baseline changes, synchronized brightness, and restart stability
- Regression coverage for silent automatic writes during upgrades from an older display dispatcher
