### PR TITLE
Stop counting Hyprland's virtual outputs as external monitors

### DIFF
--- a/bin/omarchy-hyprland-monitor-external-active
+++ b/bin/omarchy-hyprland-monitor-external-active
@@ -3,4 +3,62 @@
 # omarchy:summary=Returns true when Hyprland has an active external monitor
 # omarchy:hidden=true
 
-hyprctl monitors all -j | jq -e '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not) | select(.disabled == false)' >/dev/null 2>&1
+# Hyprland runs outputs that have no display behind them, and a name test cannot
+# tell them apart from a real monitor. The FallbackStateKeeper
+# (src/state/FallbackState.cpp, since 0.56.0) creates one named literally
+# FALLBACK through the headless backend the moment the set of ENABLED monitors
+# becomes empty -- ENABLED matters: it watches `monitors()`, not
+# `allMonitors()`, so an internal panel sitting at `disabled = true` does not
+# stop it firing. `hyprctl output create headless` makes HEADLESS-n the same
+# way. Both report disabled=false and neither name matches the internal-panel
+# prefixes, so asking only about names counts them as an external monitor.
+#
+# That state is reached by ordinary use: disable the laptop panel while docked,
+# then unplug the external display. Zero enabled monitors leaves FALLBACK, this
+# helper answered "an external monitor is active", and every caller that uses it
+# to decide whether re-enabling the internal panel is safe backed off --
+# omarchy-hyprland-monitor-internal's recover(),
+# omarchy-hyprland-monitor-clamshell's enable_internal(), and the watcher's own
+# poll. The laptop was left with no display at all until the next login, where
+# omarchy-recover-internal-monitor.service finally cleared the toggle because
+# that unit asks omarchy-hw-external-monitors instead.
+#
+# So ask the kernel too: a real display has a DRM connector, a virtual output has
+# none. This is the hardware truth 96afc684 moved recovery onto for the same
+# class of reason ("deal with recover timing"), and which recover() lost when it
+# moved back onto this helper.
+#
+# Still `monitors all`, not plain `monitors` (see the mirror case in the tests):
+# a mirrored external is absent from plain `monitors`, which reads as a
+# disconnect and hands the mirror toggle to recovery. A mirrored external has a
+# connected connector, so it keeps counting here.
+
+drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+
+# Connector directories are card<N>-<CONNECTOR> and Hyprland names outputs after
+# the connector, so card*-$name matches whatever the card index happens to be. A
+# name with no connector at all is virtual: no status file, nothing to read.
+physically_connected() {
+  local name="$1" status
+
+  for status in "$drm_path"/card*-"$name"/status; do
+    [[ -e $status ]] || continue
+    [[ $(<"$status") == connected ]] && return 0
+  done
+
+  return 1
+}
+
+# A hyprctl that fails or answers with nothing yields an empty loop and exit 1,
+# the same "no external active" the previous `jq -e` gave on bad input, so a
+# query hiccup shows callers no new behaviour.
+while read -r name; do
+  [[ -n $name ]] || continue
+  physically_connected "$name" && exit 0
+done < <(hyprctl monitors all -j 2>/dev/null | jq -r '
+  .[]
+  | select(.disabled == false)
+  | select(.name | test("^(eDP|LVDS|DSI)-") | not)
+  | .name' 2>/dev/null)
+
+exit 1

--- a/test/shell.d/monitor-external-active-test.sh
+++ b/test/shell.d/monitor-external-active-test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+drm_path="$test_tmp/drm"
+mkdir -p "$stub_bin"
+
+# The helper only ever asks `hyprctl monitors all -j`, so the stub answers that
+# and nothing else -- an unexpected call is louder as a failure than as an empty
+# reply.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "monitors" && $2 == "all" && $3 == "-j" ]]; then
+  printf '%s' "${OMARCHY_TEST_MONITORS_JSON:-[]}"
+  exit 0
+fi
+
+printf 'unexpected hyprctl call: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "$stub_bin/hyprctl"
+
+write_connectors() {
+  rm -rf "$drm_path"
+  mkdir -p "$drm_path"
+
+  local connector state
+  while (($#)); do
+    connector="$1"
+    state="$2"
+    mkdir -p "$drm_path/card0-$connector"
+    printf '%s\n' "$state" >"$drm_path/card0-$connector/status"
+    shift 2
+  done
+}
+
+external_active() {
+  PATH="$stub_bin:$PATH" \
+    OMARCHY_DRM_PATH="$drm_path" \
+    OMARCHY_TEST_MONITORS_JSON="$1" \
+    "$ROOT/bin/omarchy-hyprland-monitor-external-active"
+}
+
+internal_only='[{"name":"eDP-1","disabled":false}]'
+
+# The regression this helper existed to cause: disabling the laptop panel while
+# docked and then unplugging the external display empties Hyprland's ENABLED
+# monitor set, so its FallbackStateKeeper conjures an output named FALLBACK.
+# Counted as an external monitor, it stopped recovery from ever re-enabling the
+# panel and left the laptop with no display until the next login.
+write_connectors eDP-1 connected DP-1 disconnected
+if external_active '[{"name":"eDP-1","disabled":true},{"name":"FALLBACK","disabled":false}]'; then
+  fail "the FALLBACK output is not counted as an external monitor"
+fi
+pass "active external monitor helper ignores Hyprland's FALLBACK output"
+
+write_connectors eDP-1 connected
+if external_active '[{"name":"eDP-1","disabled":false},{"name":"HEADLESS-1","disabled":false}]'; then
+  fail "a headless output is not counted as an external monitor"
+fi
+pass "active external monitor helper ignores headless outputs"
+
+# Everything below is the behaviour the helper already had, pinned so the sysfs
+# cross-check cannot quietly take it away.
+write_connectors eDP-1 connected DP-1 connected
+external_active '[{"name":"eDP-1","disabled":false},{"name":"DP-1","disabled":false}]' ||
+  fail "a connected external monitor is still reported as active"
+pass "active external monitor helper finds a connected external monitor"
+
+# A mirrored external is absent from plain `monitors`, which is why the helper
+# asks `monitors all`; it is a real display and must keep counting.
+write_connectors eDP-1 connected DP-1 connected
+external_active '[{"name":"eDP-1","disabled":false},{"name":"DP-1","disabled":false,"mirrorOf":"eDP-1"}]' ||
+  fail "a mirrored external monitor is still reported as active"
+pass "active external monitor helper sees mirrored externals"
+
+write_connectors eDP-1 connected DP-1 connected
+if external_active '[{"name":"eDP-1","disabled":false},{"name":"DP-1","disabled":true}]'; then
+  fail "an external monitor disabled on purpose is not reported as active"
+fi
+pass "active external monitor helper ignores monitors disabled on purpose"
+
+for connector in eDP-1 LVDS-1 DSI-1; do
+  write_connectors "$connector" connected
+  if external_active "[{\"name\":\"$connector\",\"disabled\":false}]"; then
+    fail "$connector is treated as an internal panel, not an external monitor"
+  fi
+done
+pass "active external monitor helper ignores common internal panel connectors"
+
+write_connectors DP-1 connected
+external_active '[{"name":"DP-1","disabled":false}]' ||
+  fail "external-only systems still report an active external monitor"
+pass "active external monitor helper still supports external-only systems"
+
+# A compositor that cannot be asked is not a compositor with a monitor attached.
+write_connectors eDP-1 connected DP-1 connected
+if external_active ''; then
+  fail "an unanswered query does not invent an external monitor"
+fi
+pass "active external monitor helper treats an unanswered query as no external monitor"
+
+if external_active "$internal_only"; then
+  fail "an internal-only session reports no external monitor"
+fi
+pass "active external monitor helper reports nothing on an internal-only session"


### PR DESCRIPTION
Fixes #8027. Likely also #7228 and #7209.

### The bug

Disable the laptop panel while docked, unplug the external display, and the laptop is left with **no display at all** until the next login.

Hyprland's `FallbackStateKeeper` (`src/state/FallbackState.cpp`, since 0.56.0) creates an output named literally `FALLBACK` the moment the set of **enabled** monitors becomes empty. Enabled is the part that bites: it watches `monitors()`, not `allMonitors()`, so an internal panel sitting at `disabled = true` does not stop it firing. Unplugging the external display in that state therefore leaves exactly one monitor -- a virtual one, reporting `disabled: false`, whose name matches none of the internal-panel prefixes.

`omarchy-hyprland-monitor-external-active` asked only about names, so it answered "an external monitor is active", and every caller that uses it to decide whether re-enabling the internal panel is safe backed off: `omarchy-hyprland-monitor-internal`'s `recover()`, `omarchy-hyprland-monitor-clamshell`'s `enable_internal()`, and the watcher's clamshell poll. The `monitorremoved` retries at 1s, 3s and 7s all bailed at the same line.

Only the next login recovered it, because `omarchy-recover-internal-monitor.service` asks `omarchy-hw-external-monitors` instead -- and that one reads DRM state, which cannot be fooled this way.

### The fix

Ask the kernel too: a real display has a DRM connector, a virtual output has none.

This restores the hardware truth 96afc684 deliberately moved recovery onto ("Move to a hardware check for external monitors instead to deal with recover timing") and which `recover()` lost when it moved back onto this helper. omarchy 3.8.5 guarded `recover()` on `omarchy-hw-external-monitors` and was immune.

Fixing the helper rather than each caller corrects `recover()`, `off()`, `clamshell`'s `enable_internal()`/`disable_internal()` and the watcher's poll in one place.

`monitors all` stays, so a mirrored external -- absent from plain `monitors`, and a real display with a connected connector -- keeps counting. That case is pinned in the new test.

`OMARCHY_DRM_PATH` is honoured for the same reason `omarchy-hw-external-monitors` honours it: the tests point it at a fixture tree.

### Tests

New `test/shell.d/monitor-external-active-test.sh`, 9 assertions. It stubs `hyprctl` and builds a fixture DRM tree, following `hw-external-monitors-test.sh` and `monitor-clamshell-scale-test.sh`.

It covers the two regressions (`FALLBACK`, `HEADLESS-n`) and pins the behaviour the helper already had so the sysfs cross-check cannot quietly take it away: a connected external, a mirrored external, an external disabled on purpose, the internal-panel prefixes, external-only systems, an unanswered `hyprctl`, and an internal-only session.

Against the current helper it fails at its first assertion:

```console
$ bash test/shell.d/monitor-external-active-test.sh
not ok - the FALLBACK output is not counted as an external monitor
```

With the fix, all 9 pass. The existing `grep` assertions on this helper in `monitor-recovery-test.sh` still pass unchanged.

Full suite: 187 of 191 files pass. The 4 that fail (`agent-usage-claude-scanner`, `config`, `snapper`, `unowned-system-paths`) fail identically on a pristine `quattro` checkout -- see #7125.

### Verifying by hand, without unplugging anything

```console
$ hyprctl output create headless
$ omarchy-hw-external-monitors; echo "DRM check  -> $?"          # 1, correct
$ omarchy-hyprland-monitor-external-active; echo "helper -> $?"  # 0 before, 1 after
$ hyprctl output remove HEADLESS-1
```
