### PR TITLE
Add configurable shell edge margin

### DIFF
--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -72,6 +72,9 @@ selection-fill-alpha = 0.35
 # of the scale. Uncomment any to tune a specific surface.
 scale = 1.0
 scale-with-font = true
+# Exact screen/bar-edge margin. Omit it to track half of Hyprland's
+# general:gaps_out; set it to the full value to align shell surfaces with windows.
+# screen-edge-margin        = 10
 # xxs                       = 2
 # xs                        = 3
 # sm                        = 4

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -295,10 +295,14 @@ QML components should prefer semantic tokens where possible:
 | `Style.spacing.panelGap` / `panelPadding` | Panel section spacing and interior padding |
 | `Style.spacing.popupPadding` | Popout interior padding |
 
-Popout placement deliberately follows Hyprland's `general:gaps_out`
-(`Style.gapsOut`) so panels align with tiled windows. Use a theme's
-`hyprland.lua` to change that outer alignment; `[spacing]` controls the
-interior breathing room.
+`Style.gapsOut` controls the screen/bar-edge margin for popouts, notifications, and other shell surfaces. It defaults to half of Hyprland's `general:gaps_out`, keeping shell surfaces closer to the edge while still tracking changes to the window gap.
+
+Set `screen-edge-margin` to an exact pixel value when the shell margin should differ from that default. A machine-level override survives theme switches; setting it to the full Hyprland gap aligns shell surfaces with tiled windows:
+
+```toml
+[spacing]
+screen-edge-margin = 10
+```
 
 For one-off proportional constants, use `Style.space(px)` to preserve the
 old default at scale `1.0` and `base-size = 12` while still responding to

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -8,13 +8,14 @@ import Quickshell.Io
 // rounding, gap to screen edges, state affordances, spacing, typography
 // scale, and bar dimensions.
 //
-// `cornerRadius` mirrors Hyprland's `decoration:rounding`. `gapsOut` is
-// half of Hyprland's `general:gaps_out` — Hyprland's value works well as
-// a window-to-window gap but feels too cavernous when used as the
-// distance from a panel/notification to the screen edge, so the shell
-// halves it. Themes and user Hyprland config own those values; the
-// shell picks them up by re-running `hyprctl getoption` on startup and
-// after theme IPC applies a theme.
+// `cornerRadius` mirrors Hyprland's `decoration:rounding`. `gapsOut`
+// defaults to half of Hyprland's `general:gaps_out` — Hyprland's value
+// works well as a window-to-window gap but feels too cavernous when used
+// as the distance from a panel/notification to the screen edge. The
+// `[spacing] screen-edge-margin` shell token can override that derived
+// value. Themes and user Hyprland config own those values; the shell picks
+// them up by re-running `hyprctl getoption` on startup and after theme IPC
+// applies a theme.
 //
 // Typography, spacing, and bar size come from theme/shell.toml.
 // `[font] base-size` is the rem root; every `Style.font.<token>` derives
@@ -29,7 +30,14 @@ QtObject {
   id: root
 
   property int cornerRadius: 0
-  property int gapsOut: 5
+  property real hyprlandGapsOut: 10
+  property int gapsOut: effectiveGapsOut(hyprlandGapsOut, spacingOverrides)
+
+  function effectiveGapsOut(hyprlandValue, overrides) {
+    var fallback = Math.max(0, Math.round((Number(hyprlandValue) || 0) / 2))
+    var configured = Number((overrides || {})["screen-edge-margin"])
+    return isFinite(configured) && configured >= 0 ? Math.round(configured) : fallback
+  }
 
   // ---------------------------------------------------------- state tokens
   //
@@ -372,7 +380,7 @@ QtObject {
       var css = String(json.css || "")
       var parts = css.match(/-?\d+(?:\.\d+)?/g) || []
       var n = parts.length > 0 ? Number(parts[0]) : Number(json.int)
-      if (isFinite(n) && n >= 0) gapsOut = Math.max(0, Math.round(n / 2))
+      if (isFinite(n) && n >= 0) hyprlandGapsOut = n
     } catch (e) {
       // hyprctl missing / Hyprland not running — leave the previous value.
     }

--- a/test/shell.d/style-test.sh
+++ b/test/shell.d/style-test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+
+const source = fs.readFileSync(path.join(root, 'shell/Commons/Style.qml'), 'utf8')
+const match = source.match(/function effectiveGapsOut\(hyprlandValue, overrides\) \{[\s\S]*?\n  \}/)
+assert(match, 'style exposes its effective outer-gap calculation for testing')
+
+const style = {}
+vm.createContext(style)
+vm.runInContext(match[0], style)
+
+assertEqual(style.effectiveGapsOut(10, {}), 5, 'shell outer gap defaults to half the Hyprland gap')
+assertEqual(style.effectiveGapsOut(18, {}), 9, 'default shell outer gap tracks custom Hyprland gaps')
+assertEqual(style.effectiveGapsOut(10, { 'screen-edge-margin': 10 }), 10, 'screen-edge margin can align shell surfaces with windows')
+assertEqual(style.effectiveGapsOut(10, { 'screen-edge-margin': 0 }), 0, 'screen-edge margin accepts a flush layout')
+assertEqual(style.effectiveGapsOut(10, { 'screen-edge-margin': '12' }), 12, 'screen-edge margin accepts numeric string values')
+assertEqual(style.effectiveGapsOut(10, { 'screen-edge-margin': -1 }), 5, 'negative screen-edge margins fall back to the Hyprland gap')
+assertEqual(style.effectiveGapsOut(10, { 'screen-edge-margin': 'invalid' }), 5, 'invalid screen-edge margins fall back to the Hyprland gap')
+JS
+
+require_compositor "style token runtime test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping style token runtime test"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+ln -s "$ROOT/shell/Commons" "$test_tmp/Commons"
+
+cat >"$test_tmp/shell.qml" <<'QML'
+import QtQuick
+import Quickshell
+import qs.Commons
+
+ShellRoot {
+  function fail(message) {
+    console.log("RESULT fail " + message)
+    Qt.quit()
+  }
+
+  Component.onCompleted: Qt.callLater(function() {
+    Style.applyGapsOutJson('{"css":"10 10 10 10"}')
+    Style.applyShellValues({})
+    if (Style.gapsOut !== 5) {
+      fail("default gap is " + Style.gapsOut)
+      return
+    }
+
+    Style.applyShellValues({ "spacing.screen-edge-margin": "10" })
+    if (Style.gapsOut !== 10) {
+      fail("configured gap is " + Style.gapsOut)
+      return
+    }
+
+    Style.applyShellValues({})
+    if (Style.gapsOut !== 5) {
+      fail("restored gap is " + Style.gapsOut)
+      return
+    }
+
+    console.log("RESULT pass")
+    Qt.quit()
+  })
+}
+QML
+
+output=$(timeout 15 env \
+  QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+  QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+  quickshell -p "$test_tmp" --no-color 2>&1) || {
+  printf '%s\n' "$output" >&2
+  fail "style token runtime fixture exits cleanly"
+}
+
+if ! grep -q 'RESULT pass' <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail "shell style applies and removes the screen-edge margin override"
+fi
+
+pass "shell style applies and removes the screen-edge margin override"


### PR DESCRIPTION
## Summary

- add a `[spacing] screen-edge-margin` shell token for an exact global outer margin
- preserve the current default of half Hyprland's `general:gaps_out` when the token is omitted
- document the token and cover fallback, override, validation, and live removal in tests

## Testing

- `./test/shell.d/style-test.sh`
- `qmllint -I shell shell/Commons/Style.qml`
- `git diff --check upstream/quattro...HEAD`
- `./test/all` with the adjacent `omarchy-pkgs` checkout: the 30-minute local run completed the CLI suite and reached the final shell tests before the runner limit; its only reported failure was the existing runtime-smoke IPC handler-count flake, reproduced with the same result on clean `upstream/quattro`
- Omarchy 4.0.0 VM acceptance against this branch: 4 failures; clean `upstream/quattro` reproduced all 4 and additionally failed the reminder prompt test. Three failures are desktop timing/state checks (menu position, weather, and bar reveal); the package check expects `mise-bin` and `qt6-imageformats`, which are absent from the older ISO

## Visual verification

Tested the dev-linked branch in a disposable Omarchy 4.0.0 VM with Hyprland `general:gaps_out = 10`:

- token omitted: shell edge position `873` (effective 5 px fallback)
- `screen-edge-margin = 10`: shell edge position `868` (5 px outward shift)
- token removed live: shell edge position returned to `873`

The notification, bar, OSD, and panel surfaces all use the shared value. The original guest config was restored after the scenario, and the shell journal contained no QML errors.
