### PR TITLE
Keep Ghostty terminals in the active working directory

### DIFF
--- a/bin/omarchy-default-terminal
+++ b/bin/omarchy-default-terminal
@@ -42,10 +42,17 @@ if omarchy-cmd-missing "$terminal"; then
   fi
 fi
 
+if [[ $terminal == "ghostty" && ! -e ~/.local/share/applications/$desktop_id ]]; then
+  mkdir -p ~/.local/share/applications
+  cp "$OMARCHY_PATH/default/ghostty/$desktop_id" ~/.local/share/applications/
+fi
+
 cat >~/.config/xdg-terminals.list <<EOF
 # Terminal emulator preference order for xdg-terminal-exec
 # The first found and valid terminal will be used
 $desktop_id
 EOF
+
+rm -f "${XDG_CACHE_HOME:-$HOME/.cache}/xdg-terminal-exec"
 
 omarchy-notification-send -g $glyph "$name is now the default terminal"

--- a/bin/omarchy-default-terminal
+++ b/bin/omarchy-default-terminal
@@ -42,7 +42,7 @@ if omarchy-cmd-missing "$terminal"; then
   fi
 fi
 
-if [[ $terminal == "ghostty" && ! -e ~/.local/share/applications/$desktop_id ]]; then
+if [[ $terminal == "ghostty" && ! -e ~/.local/share/applications/$desktop_id && ! -L ~/.local/share/applications/$desktop_id ]]; then
   mkdir -p ~/.local/share/applications
   cp "$OMARCHY_PATH/default/ghostty/$desktop_id" ~/.local/share/applications/
 fi

--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -34,6 +34,9 @@ if omarchy-pkg-add $package; then
   elif [[ $package == "foot" ]]; then
     mkdir -p ~/.local/share/applications
     cp "$OMARCHY_PATH/applications/$desktop_id" ~/.local/share/applications/
+  elif [[ $package == "ghostty" && ! -e ~/.local/share/applications/$desktop_id ]]; then
+    mkdir -p ~/.local/share/applications
+    cp "$OMARCHY_PATH/default/ghostty/$desktop_id" ~/.local/share/applications/
   fi
 
   # Copy default config for optional terminals when missing
@@ -47,6 +50,8 @@ if omarchy-pkg-add $package; then
 # The first found and valid terminal will be used
 $desktop_id
 EOF
+
+  rm -f "${XDG_CACHE_HOME:-$HOME/.cache}/xdg-terminal-exec"
 else
   echo "Failed to install $package"
 fi

--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -34,7 +34,7 @@ if omarchy-pkg-add $package; then
   elif [[ $package == "foot" ]]; then
     mkdir -p ~/.local/share/applications
     cp "$OMARCHY_PATH/applications/$desktop_id" ~/.local/share/applications/
-  elif [[ $package == "ghostty" && ! -e ~/.local/share/applications/$desktop_id ]]; then
+  elif [[ $package == "ghostty" && ! -e ~/.local/share/applications/$desktop_id && ! -L ~/.local/share/applications/$desktop_id ]]; then
     mkdir -p ~/.local/share/applications
     cp "$OMARCHY_PATH/default/ghostty/$desktop_id" ~/.local/share/applications/
   fi

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -10,6 +10,11 @@ if omarchy-cmd-present alacritty; then
   cp "$OMARCHY_PATH/default/alacritty/Alacritty.desktop" ~/.local/share/applications/
 fi
 
+ghostty_desktop="com.mitchellh.ghostty.desktop"
+if omarchy-cmd-present ghostty && [[ ! -e ~/.local/share/applications/$ghostty_desktop ]]; then
+  cp "$OMARCHY_PATH/default/ghostty/$ghostty_desktop" ~/.local/share/applications/
+fi
+
 if [[ -f "$OMARCHY_PATH/install/user/mise.sh" ]]; then
   bash "$OMARCHY_PATH/install/user/mise.sh"
 fi

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -11,7 +11,7 @@ if omarchy-cmd-present alacritty; then
 fi
 
 ghostty_desktop="com.mitchellh.ghostty.desktop"
-if omarchy-cmd-present ghostty && [[ ! -e ~/.local/share/applications/$ghostty_desktop ]]; then
+if omarchy-cmd-present ghostty && [[ ! -e ~/.local/share/applications/$ghostty_desktop && ! -L ~/.local/share/applications/$ghostty_desktop ]]; then
   cp "$OMARCHY_PATH/default/ghostty/$ghostty_desktop" ~/.local/share/applications/
 fi
 

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -13,6 +13,7 @@ window-padding-y = 14
 confirm-close-surface=false
 resize-overlay = never
 gtk-toolbar-style = flat
+gtk-single-instance = false
 
 # Cursor styling
 cursor-style = "block"

--- a/default/ghostty/com.mitchellh.ghostty.desktop
+++ b/default/ghostty/com.mitchellh.ghostty.desktop
@@ -1,0 +1,26 @@
+[Desktop Entry]
+Version=1.0
+Name=Ghostty
+Type=Application
+Comment=A terminal emulator
+TryExec=/usr/bin/ghostty
+Exec=/usr/bin/ghostty
+Icon=com.mitchellh.ghostty
+Categories=System;TerminalEmulator;
+Keywords=terminal;tty;pty;
+StartupNotify=true
+StartupWMClass=com.mitchellh.ghostty
+Terminal=false
+Actions=new-window;
+X-GNOME-UsesNotifications=true
+X-TerminalArgExec=-e
+X-TerminalArgTitle=--title=
+X-TerminalArgAppId=--class=
+X-TerminalArgDir=--working-directory=
+X-TerminalArgHold=--wait-after-command
+DBusActivatable=false
+X-KDE-Shortcuts=Ctrl+Alt+T
+
+[Desktop Action new-window]
+Name=New Window
+Exec=/usr/bin/ghostty

--- a/migrations/1787566169.sh
+++ b/migrations/1787566169.sh
@@ -16,7 +16,7 @@ if ! grep -Eq '^[[:space:]]*gtk-single-instance[[:space:]]*=' "${ghostty_configs
   printf '\ngtk-single-instance = false\n' >>"${ghostty_configs[-1]}"
 fi
 
-if [[ ! -e $ghostty_desktop ]]; then
+if [[ ! -e $ghostty_desktop && ! -L $ghostty_desktop ]]; then
   mkdir -p "$(dirname "$ghostty_desktop")"
   cp "$OMARCHY_PATH/default/ghostty/com.mitchellh.ghostty.desktop" "$ghostty_desktop"
 fi

--- a/migrations/1787566169.sh
+++ b/migrations/1787566169.sh
@@ -1,0 +1,17 @@
+echo "Keep Ghostty terminal launches in the active working directory"
+
+ghostty_config="$HOME/.config/ghostty/config"
+ghostty_desktop="$HOME/.local/share/applications/com.mitchellh.ghostty.desktop"
+
+[[ -f $ghostty_config ]] || exit 0
+
+if ! grep -Eq '^[[:space:]]*gtk-single-instance[[:space:]]*=' "$ghostty_config"; then
+  printf '\ngtk-single-instance = false\n' >>"$ghostty_config"
+fi
+
+if [[ ! -e $ghostty_desktop ]]; then
+  mkdir -p "$(dirname "$ghostty_desktop")"
+  cp "$OMARCHY_PATH/default/ghostty/com.mitchellh.ghostty.desktop" "$ghostty_desktop"
+fi
+
+rm -f "${XDG_CACHE_HOME:-$HOME/.cache}/xdg-terminal-exec"

--- a/migrations/1787566169.sh
+++ b/migrations/1787566169.sh
@@ -1,12 +1,19 @@
 echo "Keep Ghostty terminal launches in the active working directory"
 
-ghostty_config="$HOME/.config/ghostty/config"
 ghostty_desktop="$HOME/.local/share/applications/com.mitchellh.ghostty.desktop"
+ghostty_configs=()
 
-[[ -f $ghostty_config ]] || exit 0
+if [[ -f $HOME/.config/ghostty/config ]]; then
+  ghostty_configs+=("$HOME/.config/ghostty/config")
+fi
+if [[ -f $HOME/.config/ghostty/config.ghostty ]]; then
+  ghostty_configs+=("$HOME/.config/ghostty/config.ghostty")
+fi
 
-if ! grep -Eq '^[[:space:]]*gtk-single-instance[[:space:]]*=' "$ghostty_config"; then
-  printf '\ngtk-single-instance = false\n' >>"$ghostty_config"
+(( ${#ghostty_configs[@]} > 0 )) || exit 0
+
+if ! grep -Eq '^[[:space:]]*gtk-single-instance[[:space:]]*=' "${ghostty_configs[@]}"; then
+  printf '\ngtk-single-instance = false\n' >>"${ghostty_configs[-1]}"
 fi
 
 if [[ ! -e $ghostty_desktop ]]; then

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -70,6 +70,7 @@ omarchy-pkg-add)
   sublime-text-4) command=sublime_text ;;
   vim) command=vim ;;
   neovim) command=nvim ;;
+  ghostty) command=ghostty ;;
   esac
   ;;
 omarchy-install-browser)
@@ -246,6 +247,56 @@ for entry in "${terminal_cases[@]}"; do
     fail "$selection becomes the default terminal after installation"
 done
 pass "terminal defaults install every missing terminal before selection"
+
+ghostty_desktop="$test_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+ghostty_desktop_ref="$test_tmp/ghostty-desktop-ref"
+cache_home="$test_home/custom-cache"
+
+rm -rf "$test_home/.local/share/applications"
+mkdir -p "$(dirname "$ghostty_desktop")" "$cache_home"
+touch "$installed_dir/ghostty"
+touch "$cache_home/xdg-terminal-exec"
+XDG_CACHE_HOME="$cache_home" omarchy-default-terminal ghostty
+cmp -s "$ROOT/default/ghostty/com.mitchellh.ghostty.desktop" "$ghostty_desktop" ||
+  fail "selecting Ghostty installs Omarchy's desktop entry"
+[[ ! -e $cache_home/xdg-terminal-exec ]] ||
+  fail "selecting a terminal invalidates the xdg-terminal-exec cache"
+pass "selecting Ghostty installs its desktop entry and invalidates the cache"
+
+printf '%s\n' \
+  '[Desktop Entry]' \
+  'Type=Application' \
+  'Name=Custom Ghostty' \
+  'Exec=/usr/bin/ghostty --custom' >"$ghostty_desktop_ref"
+cp "$ghostty_desktop_ref" "$ghostty_desktop"
+touch "$cache_home/xdg-terminal-exec"
+XDG_CACHE_HOME="$cache_home" omarchy-default-terminal ghostty
+cmp -s "$ghostty_desktop_ref" "$ghostty_desktop" ||
+  fail "selecting Ghostty preserves an existing user desktop entry"
+[[ ! -e $cache_home/xdg-terminal-exec ]] ||
+  fail "selecting a terminal invalidates the xdg-terminal-exec cache"
+pass "selecting Ghostty preserves an existing user desktop entry"
+
+rm -rf "$test_home/.config/ghostty" "$test_home/.local/share/applications"
+mkdir -p "$cache_home"
+touch "$cache_home/xdg-terminal-exec"
+XDG_CACHE_HOME="$cache_home" "$ROOT/bin/omarchy-install-terminal" ghostty
+cmp -s "$ROOT/config/ghostty/config" "$test_home/.config/ghostty/config" ||
+  fail "direct Ghostty install copies the default config"
+cmp -s "$ROOT/default/ghostty/com.mitchellh.ghostty.desktop" "$ghostty_desktop" ||
+  fail "direct Ghostty install copies Omarchy's desktop entry"
+[[ ! -e $cache_home/xdg-terminal-exec ]] ||
+  fail "direct Ghostty install invalidates the xdg-terminal-exec cache"
+[[ $(tail -n 1 "$test_home/.config/xdg-terminals.list") == "com.mitchellh.ghostty.desktop" ]] ||
+  fail "direct Ghostty install selects Ghostty as the default terminal"
+pass "direct Ghostty install copies the config and desktop entry and invalidates the cache"
+
+cp "$ghostty_desktop_ref" "$ghostty_desktop"
+touch "$cache_home/xdg-terminal-exec"
+XDG_CACHE_HOME="$cache_home" "$ROOT/bin/omarchy-install-terminal" ghostty
+cmp -s "$ghostty_desktop_ref" "$ghostty_desktop" ||
+  fail "direct Ghostty install preserves an existing user desktop entry"
+pass "direct Ghostty install preserves an existing user desktop entry"
 
 for entry in "${editor_cases[@]}"; do
   read -r selection command installer <<<"$entry"

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -277,6 +277,22 @@ cmp -s "$ghostty_desktop_ref" "$ghostty_desktop" ||
   fail "selecting a terminal invalidates the xdg-terminal-exec cache"
 pass "selecting Ghostty preserves an existing user desktop entry"
 
+ghostty_symlink_target="$test_tmp/custom-ghostty-target"
+ghostty_symlink_error="$test_tmp/ghostty-symlink-error"
+rm "$ghostty_desktop"
+ln -s "$ghostty_symlink_target" "$ghostty_desktop"
+touch "$cache_home/xdg-terminal-exec"
+XDG_CACHE_HOME="$cache_home" omarchy-default-terminal ghostty 2>"$ghostty_symlink_error"
+[[ ! -s $ghostty_symlink_error ]] ||
+  fail "selecting Ghostty does not write through a dangling desktop symlink" "$(<"$ghostty_symlink_error")"
+[[ -L $ghostty_desktop && $(readlink "$ghostty_desktop") == "$ghostty_symlink_target" ]] ||
+  fail "selecting Ghostty preserves a dangling desktop symlink"
+[[ ! -e $ghostty_symlink_target ]] ||
+  fail "selecting Ghostty does not create a dangling symlink target"
+[[ ! -e $cache_home/xdg-terminal-exec ]] ||
+  fail "selecting Ghostty invalidates the cache while preserving a symlink"
+pass "selecting Ghostty preserves a dangling desktop symlink"
+
 rm -rf "$test_home/.config/ghostty" "$test_home/.local/share/applications"
 mkdir -p "$cache_home"
 touch "$cache_home/xdg-terminal-exec"
@@ -297,6 +313,21 @@ XDG_CACHE_HOME="$cache_home" "$ROOT/bin/omarchy-install-terminal" ghostty
 cmp -s "$ghostty_desktop_ref" "$ghostty_desktop" ||
   fail "direct Ghostty install preserves an existing user desktop entry"
 pass "direct Ghostty install preserves an existing user desktop entry"
+
+rm "$ghostty_desktop"
+ln -s "$ghostty_symlink_target" "$ghostty_desktop"
+touch "$cache_home/xdg-terminal-exec"
+XDG_CACHE_HOME="$cache_home" "$ROOT/bin/omarchy-install-terminal" ghostty \
+  >"$test_tmp/direct-ghostty-symlink-output" 2>"$ghostty_symlink_error"
+[[ ! -s $ghostty_symlink_error ]] ||
+  fail "direct Ghostty install does not write through a dangling desktop symlink" "$(<"$ghostty_symlink_error")"
+[[ -L $ghostty_desktop && $(readlink "$ghostty_desktop") == "$ghostty_symlink_target" ]] ||
+  fail "direct Ghostty install preserves a dangling desktop symlink"
+[[ ! -e $ghostty_symlink_target ]] ||
+  fail "direct Ghostty install does not create a dangling symlink target"
+[[ ! -e $cache_home/xdg-terminal-exec ]] ||
+  fail "direct Ghostty install invalidates the cache while preserving a symlink"
+pass "direct Ghostty install preserves a dangling desktop symlink"
 
 for entry in "${editor_cases[@]}"; do
   read -r selection command installer <<<"$entry"

--- a/test/shell.d/ghostty-cwd-migration-test.sh
+++ b/test/shell.d/ghostty-cwd-migration-test.sh
@@ -31,8 +31,10 @@ touch "$existing_cache/xdg-terminal-exec"
 
 run_migration "$existing_home" "$existing_cache"
 
-[[ $(grep -cE '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$existing_config") == 1 ]] ||
+single_false=$(grep -cE '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$existing_config" || true)
+if (( single_false != 1 )); then
   fail "migration adds the multi-process default to an existing Ghostty config"
+fi
 cmp -s "$ROOT/default/ghostty/com.mitchellh.ghostty.desktop" "$existing_desktop" ||
   fail "migration installs Omarchy's Ghostty desktop entry"
 [[ ! -e $existing_cache/xdg-terminal-exec ]] ||

--- a/test/shell.d/ghostty-cwd-migration-test.sh
+++ b/test/shell.d/ghostty-cwd-migration-test.sh
@@ -121,6 +121,29 @@ for explicit_name in config config.ghostty; do
 done
 pass "migration preserves explicit settings in either Ghostty config file"
 
+symlink_home="$test_tmp/symlink-home"
+symlink_config="$symlink_home/.config/ghostty/config"
+symlink_desktop="$symlink_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+symlink_target="$test_tmp/custom-ghostty-target"
+symlink_cache="$symlink_home/custom-cache"
+symlink_error="$test_tmp/migration-symlink-error"
+
+mkdir -p "$(dirname "$symlink_config")" "$(dirname "$symlink_desktop")" "$symlink_cache"
+printf '%s\n' 'window-theme = ghostty' >"$symlink_config"
+ln -s "$symlink_target" "$symlink_desktop"
+touch "$symlink_cache/xdg-terminal-exec"
+
+if ! run_migration "$symlink_home" "$symlink_cache" 2>"$symlink_error"; then
+  fail "migration preserves a dangling Ghostty desktop symlink" "$(<"$symlink_error")"
+fi
+[[ -L $symlink_desktop && $(readlink "$symlink_desktop") == "$symlink_target" ]] ||
+  fail "migration leaves a dangling Ghostty desktop symlink unchanged"
+[[ ! -e $symlink_target ]] ||
+  fail "migration does not create a dangling desktop symlink target"
+[[ ! -e $symlink_cache/xdg-terminal-exec ]] ||
+  fail "migration invalidates the cache while preserving a desktop symlink"
+pass "migration preserves a dangling Ghostty desktop symlink"
+
 unused_home="$test_tmp/unused-home"
 unused_cache="$unused_home/custom-cache"
 mkdir -p "$unused_cache"

--- a/test/shell.d/ghostty-cwd-migration-test.sh
+++ b/test/shell.d/ghostty-cwd-migration-test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787566169.sh"
+[[ -f $migration ]] || fail "Ghostty working-directory migration exists"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+run_migration() {
+  local home=$1
+  local cache_home=$2
+
+  HOME="$home" XDG_CACHE_HOME="$cache_home" OMARCHY_PATH="$ROOT" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+existing_home="$test_tmp/existing-home"
+existing_config="$existing_home/.config/ghostty/config"
+existing_desktop="$existing_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+existing_cache="$existing_home/custom-cache"
+
+mkdir -p "$(dirname "$existing_config")" "$existing_cache"
+printf '%s\n' \
+  '# Window' \
+  'window-theme = ghostty' >"$existing_config"
+touch "$existing_cache/xdg-terminal-exec"
+
+run_migration "$existing_home" "$existing_cache"
+
+[[ $(grep -cE '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$existing_config") == 1 ]] ||
+  fail "migration adds the multi-process default to an existing Ghostty config"
+cmp -s "$ROOT/default/ghostty/com.mitchellh.ghostty.desktop" "$existing_desktop" ||
+  fail "migration installs Omarchy's Ghostty desktop entry"
+[[ ! -e $existing_cache/xdg-terminal-exec ]] ||
+  fail "migration invalidates the xdg-terminal-exec cache"
+pass "migration applies the Ghostty working-directory defaults"
+
+before=$(sha256sum "$existing_config" "$existing_desktop")
+run_migration "$existing_home" "$existing_cache"
+after=$(sha256sum "$existing_config" "$existing_desktop")
+[[ $before == "$after" ]] || fail "Ghostty working-directory migration is idempotent"
+pass "Ghostty working-directory migration is idempotent"
+
+custom_home="$test_tmp/custom-home"
+custom_config="$custom_home/.config/ghostty/config"
+custom_desktop="$custom_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+custom_cache="$custom_home/custom-cache"
+
+mkdir -p "$(dirname "$custom_config")" "$(dirname "$custom_desktop")" "$custom_cache"
+printf '%s\n' \
+  '# User requires shared Ghostty windows' \
+  'gtk-single-instance = true' >"$custom_config"
+printf '%s\n' \
+  '[Desktop Entry]' \
+  'Name=Custom Ghostty' \
+  'Exec=/usr/bin/ghostty --custom' >"$custom_desktop"
+touch "$custom_cache/xdg-terminal-exec"
+
+custom_before=$(sha256sum "$custom_config" "$custom_desktop")
+run_migration "$custom_home" "$custom_cache"
+custom_after=$(sha256sum "$custom_config" "$custom_desktop")
+
+[[ $custom_before == "$custom_after" ]] ||
+  fail "migration preserves explicit Ghostty settings and desktop overrides"
+[[ ! -e $custom_cache/xdg-terminal-exec ]] ||
+  fail "migration invalidates the cache while preserving Ghostty customizations"
+pass "migration preserves explicit Ghostty customizations"
+
+unused_home="$test_tmp/unused-home"
+unused_cache="$unused_home/custom-cache"
+mkdir -p "$unused_cache"
+touch "$unused_cache/xdg-terminal-exec"
+
+run_migration "$unused_home" "$unused_cache"
+
+[[ ! -e $unused_home/.config/ghostty ]] ||
+  fail "migration does not create a Ghostty config for users without one"
+[[ ! -e $unused_home/.local/share/applications/com.mitchellh.ghostty.desktop ]] ||
+  fail "migration does not install a Ghostty desktop entry for users without a config"
+[[ -e $unused_cache/xdg-terminal-exec ]] ||
+  fail "migration leaves unrelated xdg-terminal-exec state alone"
+pass "migration leaves users without Ghostty configuration unchanged"

--- a/test/shell.d/ghostty-cwd-migration-test.sh
+++ b/test/shell.d/ghostty-cwd-migration-test.sh
@@ -47,30 +47,79 @@ after=$(sha256sum "$existing_config" "$existing_desktop")
 [[ $before == "$after" ]] || fail "Ghostty working-directory migration is idempotent"
 pass "Ghostty working-directory migration is idempotent"
 
-custom_home="$test_tmp/custom-home"
-custom_config="$custom_home/.config/ghostty/config"
-custom_desktop="$custom_home/.local/share/applications/com.mitchellh.ghostty.desktop"
-custom_cache="$custom_home/custom-cache"
+current_home="$test_tmp/current-home"
+current_config="$current_home/.config/ghostty/config.ghostty"
+current_desktop="$current_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+current_cache="$current_home/custom-cache"
 
-mkdir -p "$(dirname "$custom_config")" "$(dirname "$custom_desktop")" "$custom_cache"
+mkdir -p "$(dirname "$current_config")" "$current_cache"
 printf '%s\n' \
-  '# User requires shared Ghostty windows' \
-  'gtk-single-instance = true' >"$custom_config"
-printf '%s\n' \
-  '[Desktop Entry]' \
-  'Name=Custom Ghostty' \
-  'Exec=/usr/bin/ghostty --custom' >"$custom_desktop"
-touch "$custom_cache/xdg-terminal-exec"
+  '# Current Ghostty configuration filename' \
+  'window-theme = ghostty' >"$current_config"
+touch "$current_cache/xdg-terminal-exec"
 
-custom_before=$(sha256sum "$custom_config" "$custom_desktop")
-run_migration "$custom_home" "$custom_cache"
-custom_after=$(sha256sum "$custom_config" "$custom_desktop")
+run_migration "$current_home" "$current_cache"
 
-[[ $custom_before == "$custom_after" ]] ||
-  fail "migration preserves explicit Ghostty settings and desktop overrides"
-[[ ! -e $custom_cache/xdg-terminal-exec ]] ||
-  fail "migration invalidates the cache while preserving Ghostty customizations"
-pass "migration preserves explicit Ghostty customizations"
+current_false=$(grep -cE '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$current_config" || true)
+if (( current_false != 1 )); then
+  fail "migration updates an existing config.ghostty file"
+fi
+cmp -s "$ROOT/default/ghostty/com.mitchellh.ghostty.desktop" "$current_desktop" ||
+  fail "migration installs the desktop entry for a config.ghostty user"
+[[ ! -e $current_cache/xdg-terminal-exec ]] ||
+  fail "migration invalidates the cache for a config.ghostty user"
+pass "migration supports Ghostty's current config.ghostty filename"
+
+dual_home="$test_tmp/dual-home"
+dual_legacy_config="$dual_home/.config/ghostty/config"
+dual_current_config="$dual_home/.config/ghostty/config.ghostty"
+dual_cache="$dual_home/custom-cache"
+
+mkdir -p "$(dirname "$dual_legacy_config")" "$dual_cache"
+printf '%s\n' 'window-theme = ghostty' >"$dual_legacy_config"
+printf '%s\n' 'cursor-style = block' >"$dual_current_config"
+touch "$dual_cache/xdg-terminal-exec"
+
+dual_legacy_before=$(sha256sum "$dual_legacy_config")
+run_migration "$dual_home" "$dual_cache"
+dual_legacy_after=$(sha256sum "$dual_legacy_config")
+
+[[ $dual_legacy_before == "$dual_legacy_after" ]] ||
+  fail "migration leaves the earlier-loaded legacy config unchanged"
+dual_false=$(grep -cE '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$dual_current_config" || true)
+if (( dual_false != 1 )); then
+  fail "migration adds the default to the later-loaded current config"
+fi
+pass "migration writes to config.ghostty when both config files exist"
+
+for explicit_name in config config.ghostty; do
+  custom_home="$test_tmp/custom-${explicit_name//./-}-home"
+  custom_config_dir="$custom_home/.config/ghostty"
+  custom_legacy_config="$custom_config_dir/config"
+  custom_current_config="$custom_config_dir/config.ghostty"
+  custom_desktop="$custom_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+  custom_cache="$custom_home/custom-cache"
+
+  mkdir -p "$custom_config_dir" "$(dirname "$custom_desktop")" "$custom_cache"
+  printf '%s\n' 'window-theme = ghostty' >"$custom_legacy_config"
+  printf '%s\n' 'cursor-style = block' >"$custom_current_config"
+  printf '%s\n' 'gtk-single-instance = true' >>"$custom_config_dir/$explicit_name"
+  printf '%s\n' \
+    '[Desktop Entry]' \
+    'Name=Custom Ghostty' \
+    'Exec=/usr/bin/ghostty --custom' >"$custom_desktop"
+  touch "$custom_cache/xdg-terminal-exec"
+
+  custom_before=$(sha256sum "$custom_legacy_config" "$custom_current_config" "$custom_desktop")
+  run_migration "$custom_home" "$custom_cache"
+  custom_after=$(sha256sum "$custom_legacy_config" "$custom_current_config" "$custom_desktop")
+
+  [[ $custom_before == "$custom_after" ]] ||
+    fail "migration preserves an explicit setting in $explicit_name and the desktop override"
+  [[ ! -e $custom_cache/xdg-terminal-exec ]] ||
+    fail "migration invalidates the cache while preserving $explicit_name customizations"
+done
+pass "migration preserves explicit settings in either Ghostty config file"
 
 unused_home="$test_tmp/unused-home"
 unused_cache="$unused_home/custom-cache"

--- a/test/shell.d/ghostty-cwd-test.sh
+++ b/test/shell.d/ghostty-cwd-test.sh
@@ -71,6 +71,21 @@ cmp -s "$custom_desktop" "$installed_desktop" ||
   fail "application refresh preserves an existing Ghostty desktop entry"
 pass "application refresh preserves an existing Ghostty desktop entry"
 
+refresh_symlink_target="$test_tmp/custom-ghostty-target"
+refresh_symlink_log="$test_tmp/refresh-symlink-log"
+rm "$installed_desktop"
+ln -s "$refresh_symlink_target" "$installed_desktop"
+HOME="$refresh_home" PATH="$refresh_bin:$PATH" OMARCHY_PATH="$refresh_root" \
+  "$ROOT/bin/omarchy-refresh-applications" >"$refresh_symlink_log" 2>&1
+
+[[ ! -s $refresh_symlink_log ]] ||
+  fail "application refresh does not write through a dangling Ghostty desktop symlink" "$(<"$refresh_symlink_log")"
+[[ -L $installed_desktop && $(readlink "$installed_desktop") == "$refresh_symlink_target" ]] ||
+  fail "application refresh preserves a dangling Ghostty desktop symlink"
+[[ ! -e $refresh_symlink_target ]] ||
+  fail "application refresh does not create a dangling Ghostty symlink target"
+pass "application refresh preserves a dangling Ghostty desktop symlink"
+
 rm "$installed_desktop"
 HOME="$refresh_home" PATH="$refresh_bin:$PATH" OMARCHY_PATH="$refresh_root" \
   "$ROOT/bin/omarchy-refresh-applications"

--- a/test/shell.d/ghostty-cwd-test.sh
+++ b/test/shell.d/ghostty-cwd-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+ghostty_config="$ROOT/config/ghostty/config"
+ghostty_desktop="$ROOT/default/ghostty/com.mitchellh.ghostty.desktop"
+
+[[ -f $ghostty_config ]] || fail "ghostty ships a default configuration"
+
+single_false=$(grep -cE '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$ghostty_config" || true)
+if (( single_false != 1 )); then
+  fail "ghostty config has exactly one active gtk-single-instance = false line" "found $single_false"
+fi
+if grep -Eq '^[[:space:]]*gtk-single-instance[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$ghostty_config"; then
+  fail "ghostty config does not force single-instance mode"
+fi
+pass "ghostty config enables multi-process windows by default"
+
+[[ -f $ghostty_desktop ]] || fail "ghostty ships an Omarchy desktop entry"
+
+exec_bare=$(grep -c '^Exec=/usr/bin/ghostty$' "$ghostty_desktop" || true)
+if (( exec_bare != 2 )); then
+  fail "ghostty desktop entry has bare Exec lines for the main and new-window actions" "found $exec_bare"
+fi
+if grep -q -- '--gtk-single-instance' "$ghostty_desktop"; then
+  fail "ghostty desktop entry does not force gtk-single-instance on the command line"
+fi
+grep -Eq '^DBusActivatable=false$' "$ghostty_desktop" ||
+  fail "ghostty desktop entry disables D-Bus activation"
+grep -Eq '^X-TerminalArgDir=--working-directory=$' "$ghostty_desktop" ||
+  fail "ghostty desktop entry preserves the working-directory argument"
+pass "ghostty desktop entry launches bare multi-process windows"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+refresh_root="$test_tmp/omarchy"
+refresh_home="$test_tmp/home"
+refresh_bin="$test_tmp/bin"
+installed_desktop="$refresh_home/.local/share/applications/com.mitchellh.ghostty.desktop"
+custom_desktop="$test_tmp/custom-ghostty.desktop"
+
+mkdir -p "$refresh_root/applications" "$refresh_root/default/ghostty" "$refresh_home/.local/share/applications" "$refresh_bin"
+cp "$ROOT"/applications/*.desktop "$refresh_root/applications/"
+cp "$ghostty_desktop" "$refresh_root/default/ghostty/"
+
+cat >"$refresh_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == "ghostty" ]]
+SH
+
+cat >"$refresh_bin/update-desktop-database" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$refresh_bin"/*
+
+printf '%s\n' \
+  '[Desktop Entry]' \
+  'Name=Custom Ghostty' \
+  'Exec=/usr/bin/ghostty --custom' >"$custom_desktop"
+cp "$custom_desktop" "$installed_desktop"
+
+HOME="$refresh_home" PATH="$refresh_bin:$PATH" OMARCHY_PATH="$refresh_root" \
+  "$ROOT/bin/omarchy-refresh-applications"
+
+cmp -s "$custom_desktop" "$installed_desktop" ||
+  fail "application refresh preserves an existing Ghostty desktop entry"
+pass "application refresh preserves an existing Ghostty desktop entry"
+
+rm "$installed_desktop"
+HOME="$refresh_home" PATH="$refresh_bin:$PATH" OMARCHY_PATH="$refresh_root" \
+  "$ROOT/bin/omarchy-refresh-applications"
+
+cmp -s "$ghostty_desktop" "$installed_desktop" ||
+  fail "application refresh installs the Ghostty desktop entry when missing"
+pass "application refresh installs the Ghostty desktop entry when missing"


### PR DESCRIPTION
# Keep Ghostty terminals in the active working directory

## Problem

`Super+Enter` launches the selected terminal with the directory returned by `omarchy-cmd-terminal-cwd`. Ghostty's packaged desktop entry forces `--gtk-single-instance=true`, so all top-level windows share one process and Hyprland reports the same PID for each of them. Omarchy can then select a shell belonging to a different window, and Ghostty's single-instance activation also drops the `--working-directory` argument for a plain new window.

The result is that a new Ghostty window can open in another terminal's directory instead of the active terminal's directory.

## Context

Working-directory inheritance predates Ghostty. It was introduced in `2cca0269` while Alacritty was the shipped default, before Omarchy moved terminal launching to `xdg-terminal-exec` in `4c97a31c` and later made Ghostty the default in `b6ba588f`.

The reported setup previously used Kitty as its selected default terminal, where this behavior worked because current Omarchy can query Kitty's focused window through the per-window remote-control socket. Ghostty's packaged desktop entry changes the process model underneath the same Omarchy feature by forcing all top-level windows into one process.

## Reproduction on the affected machine

1. Select Ghostty as the Omarchy default terminal.
2. Open two independent Ghostty windows and change each shell to a different directory.
3. Focus the first window and press `Super+Enter`.
4. Observe that the new window can inherit the other Ghostty window's directory instead of the focused window's directory.

On this machine, the packaged `/usr/share/applications/com.mitchellh.ghostty.desktop` launched both actions with `--gtk-single-instance=true` and enabled D-Bus activation. The independent windows therefore shared one Ghostty PID. `omarchy-cmd-terminal-cwd` starts from the PID reported by `hyprctl activewindow` and selects a child shell, so that shared PID did not uniquely identify the focused window's shell.

The local fix was to set `gtk-single-instance = false`, install a user desktop entry with bare Ghostty `Exec` lines and no D-Bus activation, and remove the `xdg-terminal-exec` cache. After opening new top-level Ghostty windows, `Super+Enter` inherited the focused window's directory again. This patch makes that repair the Omarchy default and applies it to existing users through an idempotent migration.

## Affected machine

| Component | Details |
| --- | --- |
| System | Framework Desktop (AMD Ryzen AI Max 300 Series), revision A6 |
| CPU | AMD Ryzen AI Max+ 395 |
| GPU | AMD Strix Halo Radeon 8060S |
| Kernel | Linux 7.1.8-arch1-3 x86_64 |
| Omarchy | `omarchy-dev 4.0.0.r1791.ged7bae4-1` |
| Hyprland | `0.56.2-1` |
| Ghostty | `1.3.1-2` |
| xdg-terminal-exec | `0.14.2-1` |
| uwsm | `0.26.6-1` |

## Fix

- Default Ghostty to `gtk-single-instance = false`, giving independently launched top-level windows distinct processes that Omarchy can map to their shells.
- Ship an Omarchy Ghostty desktop entry outside the globally refreshed application set, without the packaged `--gtk-single-instance=true` override and with `DBusActivatable=false`, so the user configuration controls the process model.
- Install that desktop entry during fresh provisioning, direct installation, or default-terminal selection, without replacing an existing user desktop override.
- Invalidate the `xdg-terminal-exec` cache after a successful terminal selection or installation so the next launch resolves the selected entry immediately.
- Migrate existing Ghostty users across both the legacy `config` and current `config.ghostty` paths while preserving an explicit `gtk-single-instance` setting and any existing desktop override.

## Tradeoff

Each independently launched Ghostty window now starts a GTK process, which uses more memory and has more startup overhead than sharing one process. This is required for Omarchy's current PID-based working-directory detection.

Ghostty tabs and splits still share their window's process. Omarchy cannot reliably distinguish their focused shell until Ghostty exposes focused-surface process or working-directory information through IPC.

## Tests

- Default-terminal selection installs the Ghostty desktop entry and invalidates a custom XDG cache path.
- Existing user desktop entries survive selection and direct installation.
- Dangling desktop symlink overrides survive selection, direct installation, application refresh, and migration.
- Application refresh installs a missing Ghostty desktop entry and preserves an existing one.
- Direct Ghostty installation copies the config and desktop entry and selects Ghostty.
- The shipped config and desktop entry enforce the required integration contract.
- The migration handles either Ghostty config filename and both-file load precedence, applies missing defaults, preserves explicit customization, is idempotent, and leaves users without Ghostty configuration untouched.
- `./test/all` passes all 192 shell test files with the companion packaging and ISO fixtures available.

Fixes #3963

Related to #5447 and #6567
