### PR TITLE
Dev layouts fall back to the default coding agent

### DIFF
--- a/default/bash/fns/herdr
+++ b/default/bash/fns/herdr
@@ -12,14 +12,14 @@ _herdr_split() {
 }
 
 # Create a Herdr Dev Layout with editor, ai, and terminal
-# Usage: hdl <c|cx|codex|other_ai> [<second_ai>]
+# Usage: hdl [<c|cx|codex|other_ai>] [<second_ai>]
+# Without an agent, the AI pane runs the default agent set with `omarchy default agent`
 hdl() {
-  [[ -z $1 ]] && { echo "Usage: hdl <c|cx|codex|other_ai> [<second_ai>]"; return 1; }
   [[ -z $HERDR_PANE_ID ]] && { echo "You must start herdr to use hdl."; return 1; }
 
   local current_dir="${PWD}"
   local editor_pane ai_pane ai2_pane
-  local ai="$1"
+  local ai="${1:-omarchy-agent --inline}"
   local ai2="${2:-}"
 
   # Use HERDR_PANE_ID for the pane we're running in (stable even if focus moves)
@@ -47,14 +47,15 @@ hdl() {
   herdr pane run "$editor_pane" "$EDITOR ." >/dev/null
 }
 
-# Create a Herdr Dev Square layout with editor, diff watch, terminal, and opencode
-# Usage: hds
+# Create a Herdr Dev Square layout with editor, diff watch, terminal, and ai
+# Usage: hds [<c|cx|codex|other_ai>]
+# Without an agent, the AI pane runs the default agent set with `omarchy default agent`
 hds() {
-  [[ -n $1 ]] && { echo "Usage: hds"; return 1; }
   [[ -z $HERDR_PANE_ID ]] && { echo "You must start herdr to use hds."; return 1; }
 
   local current_dir="${PWD}"
-  local editor_pane diff_pane terminal_pane opencode_pane
+  local editor_pane diff_pane terminal_pane ai_pane
+  local ai="${1:-omarchy-agent --inline}"
 
   editor_pane="$HERDR_PANE_ID"
 
@@ -62,20 +63,19 @@ hds() {
 
   terminal_pane=$(_herdr_split "$editor_pane" down 0.5 "$current_dir")
   diff_pane=$(_herdr_split "$editor_pane" right 0.5 "$current_dir")
-  opencode_pane=$(_herdr_split "$terminal_pane" right 0.5 "$current_dir")
+  ai_pane=$(_herdr_split "$terminal_pane" right 0.5 "$current_dir")
 
   herdr pane run "$editor_pane" "nvim ." >/dev/null
   herdr pane run "$diff_pane" "hunk diff --watch" >/dev/null
-  herdr pane run "$opencode_pane" "opencode" >/dev/null
+  herdr pane run "$ai_pane" "$ai" >/dev/null
 }
 
 # Create multiple hdl tabs with one per subdirectory in the current directory
-# Usage: hdlm <c|cx|codex|other_ai> [<second_ai>]
+# Usage: hdlm [<c|cx|codex|other_ai>] [<second_ai>]
 hdlm() {
-  [[ -z $1 ]] && { echo "Usage: hdlm <c|cx|codex|other_ai> [<second_ai>]"; return 1; }
   [[ -z $HERDR_PANE_ID ]] && { echo "You must start herdr to use hdlm."; return 1; }
 
-  local ai="$1"
+  local ai="${1:-}"
   local ai2="${2:-}"
   local base_dir="$PWD"
   local first=true
@@ -88,7 +88,8 @@ hdlm() {
     [[ -d $dir ]] || continue
     local dirpath="${dir%/}"
 
-    printf -v hdl_command 'hdl %q' "$ai"
+    hdl_command="hdl"
+    [[ -n $ai ]] && printf -v hdl_command '%s %q' "$hdl_command" "$ai"
     [[ -n $ai2 ]] && printf -v hdl_command '%s %q' "$hdl_command" "$ai2"
 
     if $first; then

--- a/default/bash/fns/tmux
+++ b/default/bash/fns/tmux
@@ -34,7 +34,7 @@ tdl() {
   tmux send-keys -t "$editor_pane" "$EDITOR ." C-m
 
   # Select the nvim pane for focus
-  tmux select-pane -t "$opencode_pane"
+  tmux select-pane -t "$editor_pane"
 }
 
 # Create a Tmux Dev Square layout with editor, diff watch, terminal, and opencode

--- a/default/bash/fns/tmux
+++ b/default/bash/fns/tmux
@@ -1,13 +1,13 @@
 # Create a Tmux Dev Layout with editor, ai, and terminal
-# Usage: tdl <c|cx|codex|other_ai> [<second_ai>]
+# Usage: tdl [<c|cx|codex|other_ai>] [<second_ai>]
+# Without an agent, the AI pane runs the default agent set with `omarchy default agent`
 tdl() {
-  [[ -z $1 ]] && { echo "Usage: tdl <c|cx|codex|other_ai> [<second_ai>]"; return 1; }
   [[ -z $TMUX ]] && { echo "You must start tmux to use tdl."; return 1; }
 
   local current_dir="${PWD}"
   local editor_pane ai_pane ai2_pane
-  local ai="$1"
-  local ai2="$2"
+  local ai="${1:-omarchy-agent --inline}"
+  local ai2="${2:-}"
 
   # Use TMUX_PANE for the pane we're running in (stable even if active window changes)
   editor_pane="$TMUX_PANE"
@@ -37,14 +37,15 @@ tdl() {
   tmux select-pane -t "$editor_pane"
 }
 
-# Create a Tmux Dev Square layout with editor, diff watch, terminal, and opencode
-# Usage: tds
+# Create a Tmux Dev Square layout with editor, diff watch, terminal, and ai
+# Usage: tds [<c|cx|codex|other_ai>]
+# Without an agent, the AI pane runs the default agent set with `omarchy default agent`
 tds() {
-  [[ -n $1 ]] && { echo "Usage: tds"; return 1; }
   [[ -z $TMUX ]] && { echo "You must start tmux to use tds."; return 1; }
 
   local current_dir="${PWD}"
-  local editor_pane diff_pane terminal_pane opencode_pane
+  local editor_pane diff_pane terminal_pane ai_pane
+  local ai="${1:-omarchy-agent --inline}"
 
   editor_pane="$TMUX_PANE"
 
@@ -52,28 +53,28 @@ tds() {
 
   terminal_pane=$(tmux split-window -v -p 50 -t "$editor_pane" -c "$current_dir" -P -F '#{pane_id}')
   diff_pane=$(tmux split-window -h -p 50 -t "$editor_pane" -c "$current_dir" -P -F '#{pane_id}')
-  opencode_pane=$(tmux split-window -h -p 50 -t "$terminal_pane" -c "$current_dir" -P -F '#{pane_id}')
+  ai_pane=$(tmux split-window -h -p 50 -t "$terminal_pane" -c "$current_dir" -P -F '#{pane_id}')
 
   tmux send-keys -t "$editor_pane" -l "nvim ."
   tmux send-keys -t "$editor_pane" C-m
   tmux send-keys -t "$diff_pane" -l "hunk diff --watch"
   tmux send-keys -t "$diff_pane" C-m
-  tmux send-keys -t "$opencode_pane" -l "opencode"
-  tmux send-keys -t "$opencode_pane" C-m
+  tmux send-keys -t "$ai_pane" -l "$ai"
+  tmux send-keys -t "$ai_pane" C-m
 
   tmux select-pane -t "$editor_pane"
 }
 
 # Create multiple tdl windows with one per subdirectory in the current directory
-# Usage: tdlm <c|cx|codex|other_ai> [<second_ai>]
+# Usage: tdlm [<c|cx|codex|other_ai>] [<second_ai>]
 tdlm() {
-  [[ -z $1 ]] && { echo "Usage: tdlm <c|cx|codex|other_ai> [<second_ai>]"; return 1; }
   [[ -z $TMUX ]] && { echo "You must start tmux to use tdlm."; return 1; }
 
-  local ai="$1"
-  local ai2="$2"
+  local ai="${1:-}"
+  local ai2="${2:-}"
   local base_dir="$PWD"
   local first=true
+  local tdl_command
 
   # Rename the session to the current directory name (replace dots/colons which tmux disallows)
   tmux rename-session "$(basename "$base_dir" | tr '.:' '--')"
@@ -82,13 +83,18 @@ tdlm() {
     [[ -d $dir ]] || continue
     local dirpath="${dir%/}"
 
+    tdl_command="tdl"
+    [[ -n $ai ]] && printf -v tdl_command '%s %q' "$tdl_command" "$ai"
+    [[ -n $ai2 ]] && printf -v tdl_command '%s %q' "$tdl_command" "$ai2"
+
     if $first; then
       # Reuse the current window for the first project
-      tmux send-keys -t "$TMUX_PANE" "cd '$dirpath' && tdl $ai $ai2" C-m
+      printf -v tdl_command 'cd %q && %s' "$dirpath" "$tdl_command"
+      tmux send-keys -t "$TMUX_PANE" "$tdl_command" C-m
       first=false
     else
       local pane_id=$(tmux new-window -c "$dirpath" -P -F '#{pane_id}')
-      tmux send-keys -t "$pane_id" "tdl $ai $ai2" C-m
+      tmux send-keys -t "$pane_id" "$tdl_command" C-m
     fi
   done
 }

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -274,8 +274,8 @@ These functions must be run inside a Tmux session.
 
 | Command | Function |
 | ------- | -------- |
-| `tdl <ai> [<second_ai>]` | Create dev layout with editor, AI, and terminal |
-| `tdlm <ai> [<second_ai>]` | Create dev layout per subdirectory |
+| `tdl [<ai>] [<second_ai>]` | Create dev layout with editor, AI, and terminal |
+| `tdlm [<ai>] [<second_ai>]` | Create dev layout per subdirectory |
 | `tsl <count> <command>` | Create multi-pane swarm layout |
 
 ## Ghostty Terminal

--- a/manual/15-terminal.md
+++ b/manual/15-terminal.md
@@ -18,7 +18,7 @@ Omarchy ships with an ergonomically-optimized Tmux configuration, which has a lo
 
 Because Tmux is programmable, we can use functions to create layouts. Omarchy ships with four different functions for common developer layouts.
 
-`tdl [agent]` starts a three-way split IDE-like interface with the `$EDITOR` on the left, your chosen AI agent on the right (like `c` for opencode or `cx` for Claude or `codex` for OpenAI), and then a terminal at the bottom.
+`tdl [agent]` starts a three-way split IDE-like interface with the `$EDITOR` on the left, an AI agent on the right, and then a terminal at the bottom. On its own, `tdl` runs your [default agent](17-ai.md#the-default-agent); name one to pick a different agent, like `c` for opencode or `cx` for Claude or `codex` for OpenAI.
 
 So `tdl c` would start this (or just `ic`):
 
@@ -28,7 +28,7 @@ You can also start a second agent with `tdl c cx` (opencode + claude) (or just `
 
  ![tmux-tdl2](images/tmux-tdl2.webp)
 
-There's also `tds`, which starts a four-way square with the editor top left, a live diff watcher top right, a terminal bottom left, and opencode bottom right.
+There's also `tds [agent]`, which starts a four-way square with the editor top left, a live diff watcher top right, a terminal bottom left, and your default agent (or the one you name) bottom right.
 
 You can also start this layout configuration for every subdirectory in the current directory using `tdlm [agent]`, then navigate using `alt + 1/2/3/4/5/...`:
 

--- a/manual/20-shell-functions.md
+++ b/manual/20-shell-functions.md
@@ -16,9 +16,9 @@ Omarchy comes with a set of shell functions to simplify common tasks and encapsu
 
 Instant multi-pane development layouts for tmux:
 
-- `tdl [ai]`: Create a Tmux Dev Layout with your editor, an AI agent, and a terminal. Use the agent aliases, like `tdl c` for opencode or `tdl cx` for Claude Code, or pass a second agent to run both, like `tdl c cx`.
-- `tds`: Create a Tmux Dev Square with editor, diff watching (via `hunk diff --watch`), terminal, and opencode.
-- `tdlm [ai]`: Create a `tdl` window for every subdirectory in the current directory.
+- `tdl [ai] [second_ai]`: Create a Tmux Dev Layout with your editor, an AI agent, and a terminal. Run it without arguments to use your default coding agent (set with `omarchy default agent`), or use the agent aliases, like `tdl c` for opencode or `tdl cx` for Claude Code, or pass a second agent to run both, like `tdl c cx`.
+- `tds [ai]`: Create a Tmux Dev Square with editor, diff watching (via `hunk diff --watch`), terminal, and your default agent (or the one you name).
+- `tdlm [ai] [second_ai]`: Create a `tdl` window for every subdirectory in the current directory.
 - `tsl [count] [command]`: Create a swarm of panes tiled in a grid, all running the same command (great for AI agents).
 
 The same layouts are available for Herdr as `hdl`, `hds`, `hdlm`, and `hsl`.

--- a/test/shell.d/herdr-functions-test.sh
+++ b/test/shell.d/herdr-functions-test.sh
@@ -46,3 +46,40 @@ expected_first=$(printf 'cd %q && hdl %q' "$test_dir/first project's files" "cod
 
 [[ ${commands[0]} == "$expected_first" ]] || fail "hdlm omits an absent second agent argument"
 pass "hdlm omits an absent second agent argument"
+
+: >"$log"
+hdlm
+mapfile -t commands <"$log"
+expected_first=$(printf 'cd %q && hdl' "$test_dir/first project's files")
+
+[[ ${commands[0]} == "$expected_first" ]] || fail "hdlm without agents queues a bare hdl"
+pass "hdlm without agents queues a bare hdl"
+
+export HERDR_TAB_ID="tab"
+: >"$log"
+hdl
+mapfile -t commands <"$log"
+
+[[ ${commands[0]} == "omarchy-agent --inline" ]] || fail "hdl without an agent runs the default agent"
+pass "hdl without an agent runs the default agent"
+
+: >"$log"
+hdl "codex --quiet"
+mapfile -t commands <"$log"
+
+[[ ${commands[0]} == "codex --quiet" ]] || fail "hdl with an agent runs that agent"
+pass "hdl with an agent runs that agent"
+
+: >"$log"
+hds
+mapfile -t commands <"$log"
+
+[[ ${commands[2]} == "omarchy-agent --inline" ]] || fail "hds without an agent runs the default agent"
+pass "hds without an agent runs the default agent"
+
+: >"$log"
+hds "codex --quiet"
+mapfile -t commands <"$log"
+
+[[ ${commands[2]} == "codex --quiet" ]] || fail "hds with an agent runs that agent"
+pass "hds with an agent runs that agent"

--- a/test/shell.d/tmux-functions-test.sh
+++ b/test/shell.d/tmux-functions-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+source "$ROOT/default/bash/fns/tmux"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf -- "$test_dir"' EXIT
+
+mkdir -p "$test_dir/first project's files" "$test_dir/second project"
+log="$test_dir/tmux.log"
+
+# Every split answers with one fixed pane id, and whatever send-keys would type
+# into a pane lands in the log. tdl passes the text and C-m in one call while
+# tds types with -l and sends C-m on its own, so strip options and Enter rather
+# than trusting a position.
+tmux() {
+  local -a keys=()
+
+  case $1 in
+    split-window | new-window)
+      if [[ $* == *" -P "* ]]; then
+        echo "new-pane"
+      fi
+      ;;
+    send-keys)
+      shift
+      while (($#)); do
+        case $1 in
+          -t) shift 2 ;;
+          -l | C-m) shift ;;
+          *) keys+=("$1"); shift ;;
+        esac
+      done
+      if (( ${#keys[@]} )); then
+        printf '%s\n' "${keys[*]}" >>"$log"
+      fi
+      ;;
+  esac
+}
+
+export TMUX="fake-tmux"
+export TMUX_PANE="current-pane"
+export EDITOR="nvim"
+
+cd "$test_dir"
+
+tdl
+mapfile -t commands <"$log"
+
+[[ ${commands[0]} == "omarchy-agent --inline" ]] || fail "tdl without an agent runs the default agent"
+pass "tdl without an agent runs the default agent"
+
+[[ ${commands[1]} == "nvim ." ]] || fail "tdl opens the editor"
+pass "tdl opens the editor"
+
+: >"$log"
+tdl "codex --quiet"
+mapfile -t commands <"$log"
+
+[[ ${commands[0]} == "codex --quiet" ]] || fail "tdl with an agent runs that agent"
+pass "tdl with an agent runs that agent"
+
+: >"$log"
+tds
+mapfile -t commands <"$log"
+
+[[ ${commands[2]} == "omarchy-agent --inline" ]] || fail "tds without an agent runs the default agent"
+pass "tds without an agent runs the default agent"
+
+: >"$log"
+tds "codex --quiet"
+mapfile -t commands <"$log"
+
+[[ ${commands[2]} == "codex --quiet" ]] || fail "tds with an agent runs that agent"
+pass "tds with an agent runs that agent"
+
+: >"$log"
+tdlm
+mapfile -t commands <"$log"
+expected_first=$(printf 'cd %q && tdl' "$test_dir/first project's files")
+
+[[ ${commands[0]} == "$expected_first" ]] || fail "tdlm without agents queues a bare tdl"
+pass "tdlm without agents queues a bare tdl"
+
+[[ ${commands[1]} == "tdl" ]] || fail "tdlm without agents queues a bare tdl per extra subdirectory"
+pass "tdlm without agents queues a bare tdl per extra subdirectory"
+
+: >"$log"
+tdlm "codex --flag='value with spaces'" "claude --model sonnet"
+mapfile -t commands <"$log"
+expected_first=$(printf 'cd %q && tdl %q %q' \
+  "$test_dir/first project's files" "codex --flag='value with spaces'" "claude --model sonnet")
+expected_second=$(printf 'tdl %q %q' "codex --flag='value with spaces'" "claude --model sonnet")
+
+[[ ${commands[0]} == "$expected_first" ]] || fail "tdlm safely quotes its first queued command"
+pass "tdlm safely quotes its first queued command"
+
+[[ ${commands[1]} == "$expected_second" ]] || fail "tdlm preserves agent argument boundaries"
+pass "tdlm preserves agent argument boundaries"


### PR DESCRIPTION
Im using `tdl` and `hdl` all the time, now that we are able to configure a default agent, we should be able to run the commands without having to specifiy which agent to use - should be optional.

The dev layout functions previously errored with a usage message when called without an agent. Now they fall back to the configured default agent by running `omarchy-agent --inline` in the AI pane, which already knows each agent's auto-approve flags. Passing agents explicitly works exactly as before.

- Bare `tdl` / `hdl` opens the dev layout with your default agent (set via `omarchy default agent`); if none is configured, the AI pane shows omarchy-agent's own hint to pick one
- Bare `tdlm` / `hdlm` queue a bare `tdl` / `hdl` per subdirectory (quoted with `%q` on both sides), so they inherit the same fallback
- `tds` / `hds` join the family: the square layouts no longer hardcode opencode - they run the default agent, or take an optional agent argument like their siblings
- The usage comments above each function carry the contract; no `-h` / `--help` guards
- Updated `manual/15-terminal.md`, `manual/20-shell-functions.md`, and `manual/07-hotkeys.md`; added `test/shell.d/tmux-functions-test.sh` and extended the herdr test to cover all six functions
- Separate first commit: `tdl` now actually focuses the editor pane - `select-pane` targeted the never-set `$opencode_pane`, which tmux resolves to the active (AI) pane, so focus was user-visibly wrong before

Tested manually in tmux and Herdr by sourcing the updated fns; both shell test files pass.
