### PR TITLE
Add VPN section to the network panel

### DIFF
--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -9,6 +9,14 @@ set -euo pipefail
 
 internet_probe=1.1.1.1
 
+# nmcli's own exit codes are documented as 0-10 (0 success, 1 unspecified
+# error, 2 invalid user input, ... 10 not found). A raw nmcli failure can
+# already legitimately exit 2, so the traffic-verification signal below
+# needs a code clearly outside that range or the two get confused -- a
+# `down` that nmcli itself refuses with its own exit 2 must not be reported
+# as "Connected, no traffic".
+EXIT_NO_TRAFFIC=75
+
 # `-e no` keeps ':' in a connection NAME from being escaped, matching the
 # convention already used by omarchy-network-band's nm_get.
 nm_get() {
@@ -129,11 +137,14 @@ case "$1" in
 
     if ! verify_tunnel "$2"; then
       echo "Warning: $2 connected but is not passing traffic." >&2
-      exit 2
+      exit "$EXIT_NO_TRAFFIC"
     fi
     ;;
   down)
-    nmcli connection down "$2" >/dev/null
+    if ! nmcli connection down "$2" >/dev/null 2>&1; then
+      echo "Error: failed to deactivate $2." >&2
+      exit 1
+    fi
     ;;
   *)
     usage

--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -7,6 +7,8 @@
 
 set -euo pipefail
 
+internet_probe=1.1.1.1
+
 # `-e no` keeps ':' in a connection NAME from being escaped, matching the
 # convention already used by omarchy-network-band's nm_get.
 nm_get() {
@@ -44,6 +46,24 @@ deactivate_other_vpns() {
   done < <(list_vpn_connections)
 }
 
+# NetworkManager reports a WireGuard profile as fully "activated" once its
+# own local setup (device, keys, routes) succeeds -- it does not wait on or
+# check the peer handshake. A wrong endpoint, a blocked UDP port, or a dead
+# server all still read as "connected" from nmcli alone. One ping bound to
+# the tunnel device is the only way to tell a working tunnel from one that
+# is locally configured but not actually carrying traffic.
+verify_tunnel() {
+  local name=$1 device state
+
+  device=$(nm_get GENERAL.DEVICES connection show "$name")
+  [[ -n $device ]] || return 1
+
+  state=$(nm_get GENERAL.STATE device show "$device")
+  [[ $state == 100* ]] || return 1
+
+  ping -c 1 -W 2 -I "$device" "$internet_probe" >/dev/null 2>&1
+}
+
 case "$1" in
   up)
     # Nothing at the NetworkManager/WireGuard level stops two tunnels being
@@ -51,6 +71,10 @@ case "$1" in
     # selection as exclusive, one profile carrying traffic at a time.
     deactivate_other_vpns "$2"
     nmcli connection up "$2" >/dev/null
+    if ! verify_tunnel "$2"; then
+      echo "Warning: $2 connected but is not passing traffic." >&2
+      exit 2
+    fi
     ;;
   down)
     nmcli connection down "$2" >/dev/null

--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# omarchy:summary=List or toggle WireGuard/VPN connections
+# omarchy:group=network
+# omarchy:args=[up|down <name>]
+# omarchy:examples=omarchy network vpn | omarchy network vpn up pvpn-ch | omarchy network vpn down pvpn-ch
+
+set -euo pipefail
+
+# `-e no` keeps ':' in a connection NAME from being escaped, matching the
+# convention already used by omarchy-network-band's nm_get.
+nm_get() {
+  LC_ALL=C nmcli -e no -g "$@" 2>/dev/null
+}
+
+# Wireguard profiles report TYPE=wireguard; other tunnel types NetworkManager
+# manages (OpenVPN, etc.) report TYPE=vpn. Both belong in the same list.
+list_vpn_connections() {
+  nm_get NAME,TYPE,ACTIVE connection show |
+    awk -F: '$2 == "wireguard" || $2 == "vpn" { print $1 "\t" $3 }'
+}
+
+usage() {
+  echo "Usage: omarchy-network-vpn [up|down <name>]" >&2
+}
+
+if (( $# == 0 )); then
+  list_vpn_connections
+  exit 0
+fi
+
+if (( $# != 2 )); then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  up)
+    nmcli connection up "$2" >/dev/null
+    ;;
+  down)
+    nmcli connection down "$2" >/dev/null
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -17,9 +17,19 @@ nm_get() {
 
 # Wireguard profiles report TYPE=wireguard; other tunnel types NetworkManager
 # manages (OpenVPN, etc.) report TYPE=vpn. Both belong in the same list.
+#
+# `-e no` leaves a ':' inside NAME unescaped (connection names allow it), so
+# TYPE and ACTIVE are read off the *end* of the line and NAME is whatever is
+# left, rather than splitting on every ':' and assuming NAME never has one.
 list_vpn_connections() {
   nm_get NAME,TYPE,ACTIVE connection show |
-    awk -F: '$2 == "wireguard" || $2 == "vpn" { print $1 "\t" $3 }'
+    awk -F: '{
+      active = $NF
+      type = $(NF - 1)
+      name = $1
+      for (i = 2; i <= NF - 2; i++) name = name ":" $i
+      if (type == "wireguard" || type == "vpn") print name "\t" active
+    }'
 }
 
 usage() {
@@ -40,7 +50,7 @@ deactivate_other_vpns() {
   local keep=$1 name active
 
   while IFS=$'\t' read -r name active; do
-    [[ $name == "$keep" ]] && continue
+    [[ $name == $keep ]] && continue
     [[ $active == "yes" ]] || continue
     nmcli connection down "$name" >/dev/null 2>&1 || true
   done < <(list_vpn_connections)
@@ -52,6 +62,12 @@ deactivate_other_vpns() {
 # server all still read as "connected" from nmcli alone. One ping bound to
 # the tunnel device is the only way to tell a working tunnel from one that
 # is locally configured but not actually carrying traffic.
+#
+# Only checked for a full tunnel (a default route through the device): a
+# split-tunnel profile that only routes specific subnets, or a peer that
+# firewalls off ICMP, would fail this probe while working exactly as
+# configured, so there is nothing generic to verify there -- take NetworkManager's
+# word for those instead of guessing at a false negative.
 verify_tunnel() {
   local name=$1 device state
 
@@ -60,6 +76,8 @@ verify_tunnel() {
 
   state=$(nm_get GENERAL.STATE device show "$device")
   [[ $state == 100* ]] || return 1
+
+  ip route show table all dev "$device" 2>/dev/null | grep -q '^default' || return 0
 
   ping -c 1 -W 2 -I "$device" "$internet_probe" >/dev/null 2>&1
 }

--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -56,11 +56,21 @@ if (( $# != 2 )); then
   exit 1
 fi
 
+# Reads connections (as printed by list_vpn_connections) on stdin, rather
+# than calling it again itself -- the caller already fetched one listing for
+# previously_active, and a second nmcli shellout back to back would only
+# reread the same thing (or, worse, a slightly different snapshot if
+# something else changed NetworkManager state in between the two calls).
 deactivate_other_vpns() {
   local keep=$1 name active
 
   while IFS=$'\t' read -r name active; do
-    [[ $name == $keep ]] && continue
+    # $keep is compared literally, not as a glob pattern -- unquoted here it
+    # would treat a name with a glob metacharacter (e.g. "work*") as a
+    # pattern instead of a literal, matching connections it was never meant
+    # to. This is the one place in this file a variable is deliberately
+    # quoted inside [[ ]] against the repo's usual style, for that reason.
+    [[ $name == "$keep" ]] && continue
     [[ $active == "yes" ]] || continue
     # Best-effort: a stuck old tunnel should not block bringing the new one
     # up. If this fails, both can end up active at once -- rare (a transient
@@ -70,7 +80,7 @@ deactivate_other_vpns() {
     if ! nmcli connection down "$name" >/dev/null 2>&1; then
       echo "Warning: could not deactivate $name; it may still be active alongside $keep." >&2
     fi
-  done < <(list_vpn_connections)
+  done
 }
 
 # NetworkManager reports a WireGuard profile as fully "activated" once its
@@ -121,9 +131,15 @@ case "$1" in
     # Nothing at the NetworkManager/WireGuard level stops two tunnels being
     # active at once -- they'd just fight over the default route. Treat VPN
     # selection as exclusive, one profile carrying traffic at a time.
-    previously_active=$(list_vpn_connections | awk -F'\t' -v keep="$2" '$1 != keep && $2 == "yes" { print $1 }')
+    #
+    # Fetched once and reused below: a bare `x=$(...)` assignment under
+    # set -e aborts the whole script outright if the pipeline inside it
+    # fails (a transient nmcli/D-Bus hiccup), so `|| true` degrades to "no
+    # connections known" instead of killing the up attempt before it starts.
+    connections=$(list_vpn_connections) || true
+    previously_active=$(awk -F'\t' -v keep="$2" '$1 != keep && $2 == "yes" { print $1 }' <<<"$connections")
 
-    deactivate_other_vpns "$2"
+    deactivate_other_vpns "$2" <<<"$connections"
 
     if ! nmcli connection up "$2" >/dev/null 2>&1; then
       echo "Error: failed to activate $2." >&2

--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -23,13 +23,15 @@ nm_get() {
 # left, rather than splitting on every ':' and assuming NAME never has one.
 list_vpn_connections() {
   nm_get NAME,TYPE,ACTIVE connection show |
-    awk -F: '{
-      active = $NF
-      type = $(NF - 1)
-      name = $1
-      for (i = 2; i <= NF - 2; i++) name = name ":" $i
-      if (type == "wireguard" || type == "vpn") print name "\t" active
-    }'
+    awk -F: '
+      NF == 0 { next }
+      {
+        active = $NF
+        type = $(NF - 1)
+        name = $1
+        for (i = 2; i <= NF - 2; i++) name = name ":" $i
+        if (type == "wireguard" || type == "vpn") print name "\t" active
+      }'
 }
 
 usage() {
@@ -52,7 +54,14 @@ deactivate_other_vpns() {
   while IFS=$'\t' read -r name active; do
     [[ $name == $keep ]] && continue
     [[ $active == "yes" ]] || continue
-    nmcli connection down "$name" >/dev/null 2>&1 || true
+    # Best-effort: a stuck old tunnel should not block bringing the new one
+    # up. If this fails, both can end up active at once -- rare (a transient
+    # D-Bus/NetworkManager error), but worth a line on stderr rather than
+    # disappearing outright, since it means the exclusivity guarantee above
+    # didn't hold.
+    if ! nmcli connection down "$name" >/dev/null 2>&1; then
+      echo "Warning: could not deactivate $name; it may still be active alongside $keep." >&2
+    fi
   done < <(list_vpn_connections)
 }
 
@@ -63,11 +72,23 @@ deactivate_other_vpns() {
 # the tunnel device is the only way to tell a working tunnel from one that
 # is locally configured but not actually carrying traffic.
 #
-# Only checked for a full tunnel (a default route through the device): a
-# split-tunnel profile that only routes specific subnets, or a peer that
-# firewalls off ICMP, would fail this probe while working exactly as
-# configured, so there is nothing generic to verify there -- take NetworkManager's
-# word for those instead of guessing at a false negative.
+# A full tunnel shows up either as a literal default route, or as the
+# classic wg-quick split of 0.0.0.0/1 + 128.0.0.0/1 that some NetworkManager
+# versions use instead, specifically to avoid clobbering an existing default
+# route. Either form covers "all traffic goes through this device".
+is_full_tunnel() {
+  local device=$1 routes
+  routes=$(ip route show table all dev "$device" 2>/dev/null)
+  [[ -n $routes ]] || return 1
+  grep -q '^default' <<<"$routes" && return 0
+  grep -q '^0\.0\.0\.0/1 ' <<<"$routes" && grep -q '^128\.0\.0\.0/1 ' <<<"$routes"
+}
+
+# Only checked for a full tunnel: a split-tunnel profile that only routes
+# specific subnets, or a peer that firewalls off ICMP, would fail this probe
+# while working exactly as configured, so there is nothing generic to verify
+# there -- take NetworkManager's word for those instead of guessing at a
+# false negative.
 verify_tunnel() {
   local name=$1 device state
 
@@ -77,7 +98,12 @@ verify_tunnel() {
   state=$(nm_get GENERAL.STATE device show "$device")
   [[ $state == 100* ]] || return 1
 
-  ip route show table all dev "$device" 2>/dev/null | grep -q '^default' || return 0
+  is_full_tunnel "$device" || return 0
+
+  # No ping binary is nothing to hold against the tunnel -- omarchy-network-status
+  # treats it the same way (omarchy-cmd-present ping || return) rather than
+  # failing a check it cannot actually run.
+  omarchy-cmd-present ping || return 0
 
   ping -c 1 -W 2 -I "$device" "$internet_probe" >/dev/null 2>&1
 }
@@ -87,8 +113,20 @@ case "$1" in
     # Nothing at the NetworkManager/WireGuard level stops two tunnels being
     # active at once -- they'd just fight over the default route. Treat VPN
     # selection as exclusive, one profile carrying traffic at a time.
+    previously_active=$(list_vpn_connections | awk -F'\t' -v keep="$2" '$1 != keep && $2 == "yes" { print $1 }')
+
     deactivate_other_vpns "$2"
-    nmcli connection up "$2" >/dev/null
+
+    if ! nmcli connection up "$2" >/dev/null 2>&1; then
+      echo "Error: failed to activate $2." >&2
+      # Bringing the new profile up failed outright -- put back whatever was
+      # working before rather than leaving the user with nothing active.
+      while IFS= read -r name; do
+        [[ -n $name ]] && nmcli connection up "$name" >/dev/null 2>&1
+      done <<<"$previously_active" || true
+      exit 1
+    fi
+
     if ! verify_tunnel "$2"; then
       echo "Warning: $2 connected but is not passing traffic." >&2
       exit 2

--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -34,8 +34,22 @@ if (( $# != 2 )); then
   exit 1
 fi
 
+deactivate_other_vpns() {
+  local keep=$1 name active
+
+  while IFS=$'\t' read -r name active; do
+    [[ $name == "$keep" ]] && continue
+    [[ $active == "yes" ]] || continue
+    nmcli connection down "$name" >/dev/null 2>&1 || true
+  done < <(list_vpn_connections)
+}
+
 case "$1" in
   up)
+    # Nothing at the NetworkManager/WireGuard level stops two tunnels being
+    # active at once -- they'd just fight over the default route. Treat VPN
+    # selection as exclusive, one profile carrying traffic at a time.
+    deactivate_other_vpns "$2"
     nmcli connection up "$2" >/dev/null
     ;;
   down)

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -287,6 +287,38 @@ function sortWifiRows(rows) {
   return nets
 }
 
+// omarchy-network-vpn prints "name\tactive" lines, one per NetworkManager
+// wireguard/vpn connection profile -- known profiles whether or not they are
+// currently up, mirroring how the Wi-Fi list carries known-but-disconnected
+// networks.
+function parseVpnConnections(raw) {
+  var lines = String(raw || "").split("\n")
+  var rows = []
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i]
+    if (!line) continue
+    var idx = line.indexOf("\t")
+    if (idx === -1) continue
+
+    rows.push({
+      name: line.substring(0, idx),
+      active: line.substring(idx + 1).trim() === "yes"
+    })
+  }
+
+  return rows
+}
+
+function sortVpnConnections(rows) {
+  var conns = Array.isArray(rows) ? rows.slice() : []
+  conns.sort(function(a, b) {
+    if (a.active !== b.active) return a.active ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  return conns
+}
+
 function wifiSectionTitle(wifiNetworks, index) {
   var networks = Array.isArray(wifiNetworks) ? wifiNetworks : []
   if (index < 0 || index >= networks.length) return ""
@@ -370,6 +402,8 @@ if (typeof module !== "undefined") {
     formatPingLatency: formatPingLatency,
     wifiRow: wifiRow,
     sortWifiRows: sortWifiRows,
+    parseVpnConnections: parseVpnConnections,
+    sortVpnConnections: sortVpnConnections,
     wifiSectionTitle: wifiSectionTitle,
     requiresCredentials: requiresCredentials,
     canForgetNetwork: canForgetNetwork,

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -86,8 +86,12 @@ Panel {
   // VPN/WireGuard connection profiles from `omarchy-network-vpn`.
   // `vpnActionName` is the profile currently being brought up/down, so its
   // row can render a busy state while the toggle is in flight.
+  // `vpnWarningName` is the profile whose last "up" reported connected but
+  // not actually passing traffic -- nmcli alone cannot tell a live tunnel
+  // from one whose peer never answered.
   property var vpnConnections: []
   property string vpnActionName: ""
+  property string vpnWarningName: ""
 
   // Per-row in-flight state. `actionSsid` flips on for the row whose action
   // is currently running so it can render "Connecting…" / "Disconnecting…" /
@@ -909,7 +913,12 @@ Panel {
   // band change still in flight, and each needs its own exit handler.
   Process {
     id: vpnActionProc
-    onExited: {
+    // Exit 2 is omarchy-network-vpn's own signal: nmcli brought the profile
+    // up, but the post-activation ping through the tunnel device found no
+    // real peer behind it. Only the most recent toggle's outcome is kept,
+    // same as the single failureSsid/failureReason pair Wi-Fi rows use.
+    onExited: function(exitCode) {
+      root.vpnWarningName = exitCode === 2 ? root.vpnActionName : ""
       root.vpnActionName = ""
       if (!vpnProc.running) vpnProc.running = true
     }
@@ -1689,6 +1698,7 @@ Panel {
 
     readonly property bool isActive: !!(conn && conn.active)
     readonly property bool isBusy: root.vpnActionName !== "" && conn && root.vpnActionName === conn.name
+    readonly property bool isWarning: !isBusy && root.vpnWarningName !== "" && conn && root.vpnWarningName === conn.name
 
     current: isActive
     foreground: root.bar.foreground
@@ -1727,8 +1737,12 @@ Panel {
 
       Text {
         id: statusText
-        text: row.isBusy ? (row.isActive ? "Disconnecting…" : "Connecting…") : (row.isActive ? "Connected" : "")
-        color: row.isActive ? root.bar.foreground : Qt.darker(root.bar.foreground, 1.5)
+        text: {
+          if (row.isBusy) return row.isActive ? "Disconnecting…" : "Connecting…"
+          if (row.isWarning) return "Connected, no traffic"
+          return row.isActive ? "Connected" : ""
+        }
+        color: row.isWarning ? root.bar.urgent : (row.isActive ? root.bar.foreground : Qt.darker(root.bar.foreground, 1.5))
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.bodySmall
         anchors.right: parent.right

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -958,17 +958,20 @@ Panel {
   // band change still in flight, and each needs its own exit handler.
   Process {
     id: vpnActionProc
-    // Exit 2 is omarchy-network-vpn's own signal: nmcli brought the profile
-    // up, but the post-activation ping through the tunnel device found no
-    // real peer behind it. Any other nonzero code is nmcli itself failing
-    // the up/down outright. Only the most recent toggle's outcome is kept,
-    // same as the single failureSsid/failureReason pair Wi-Fi rows use.
+    // Exit 75 is omarchy-network-vpn's own private signal: nmcli brought the
+    // profile up, but the post-activation ping through the tunnel device
+    // found no real peer behind it. It deliberately sits outside nmcli's own
+    // documented 0-10 exit code range, so a raw nmcli failure (which can
+    // itself exit 2, "invalid user input") is never confused with it. Any
+    // other nonzero code is nmcli itself failing the up/down outright. Only
+    // the most recent toggle's outcome is kept, same as the single
+    // failureSsid/failureReason pair Wi-Fi rows use.
     onExited: function(exitCode) {
       if (exitCode === 0) {
         root.vpnFailureName = ""
       } else {
         root.vpnFailureName = root.vpnActionName
-        root.vpnFailureReason = exitCode === 2
+        root.vpnFailureReason = exitCode === 75
           ? "Connected, no traffic"
           : (root.vpnActionKind === "down" ? "Failed to disconnect" : "Failed to connect")
       }
@@ -1606,29 +1609,39 @@ Panel {
           fontFamily: root.bar.fontFamily
         }
 
-        Column {
+        // Capped and scrollable like networkList below: a handful of saved
+        // profiles is the common case, but nothing stops someone importing
+        // many, and an uncapped column would push the DNS/wifi sections
+        // below it off the card instead of scrolling.
+        ListView {
+          id: vpnList
           width: parent.width
+          height: Math.min(contentHeight, Style.space(240))
           spacing: Style.space(4)
+          clip: true
+          boundsBehavior: Flickable.StopAtBounds
+          interactive: contentHeight > height
 
-          // Wrapper takes modelData from the Repeater's delegate context,
-          // which doesn't bind into nested `component` declarations, and
-          // passes it down explicitly -- same shape as the band pills and
-          // the network list delegate.
-          Repeater {
-            model: root.vpnConnections
+          ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
 
-            delegate: Item {
-              required property var modelData
-              required property int index
+          model: root.vpnConnections
+          currentIndex: root.vpnIndex
+          onCurrentIndexChanged: if (currentIndex >= 0) positionViewAtIndex(currentIndex, ListView.Contain)
+
+          // Wrapper takes modelData/index from the Repeater's delegate
+          // context, which doesn't bind into nested `component`
+          // declarations -- same shape as the band pills and networkList.
+          delegate: Item {
+            required property var modelData
+            required property int index
+            width: ListView.view.width
+            height: vpnRow.implicitHeight
+
+            VpnRow {
+              id: vpnRow
               width: parent.width
-              height: vpnRow.implicitHeight
-
-              VpnRow {
-                id: vpnRow
-                width: parent.width
-                conn: modelData
-                index: parent.index
-              }
+              conn: modelData
+              index: parent.index
             }
           }
         }
@@ -1816,7 +1829,10 @@ Panel {
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.bodySmall
+        elide: Text.ElideRight
         anchors.left: parent.left
+        anchors.right: statusText.left
+        anchors.rightMargin: Style.space(8)
         anchors.verticalCenter: parent.verticalCenter
       }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -84,14 +84,17 @@ Panel {
   property string pendingBand: ""
 
   // VPN/WireGuard connection profiles from `omarchy-network-vpn`.
-  // `vpnActionName` is the profile currently being brought up/down, so its
-  // row can render a busy state while the toggle is in flight.
-  // `vpnWarningName` is the profile whose last "up" reported connected but
-  // not actually passing traffic -- nmcli alone cannot tell a live tunnel
-  // from one whose peer never answered.
+  // `vpnActionName`/`vpnActionKind` are the profile currently being brought
+  // up/down and which direction, so its row can render a busy state while
+  // the toggle is in flight. `vpnFailureName`/`vpnFailureReason` are the
+  // profile whose last toggle didn't end in a plain success -- either nmcli
+  // itself failed, or (see verify_tunnel in omarchy-network-vpn) it reported
+  // connected without a live peer behind it.
   property var vpnConnections: []
   property string vpnActionName: ""
-  property string vpnWarningName: ""
+  property string vpnActionKind: ""  // "up" | "down"
+  property string vpnFailureName: ""
+  property string vpnFailureReason: ""
 
   // Per-row in-flight state. `actionSsid` flips on for the row whose action
   // is currently running so it can render "Connecting…" / "Disconnecting…" /
@@ -656,8 +659,19 @@ Panel {
     actionProc.running = true
   }
 
+  // A failure tied to a connection that has since gone inactive (dropped,
+  // or torn down from outside the panel) no longer means anything -- clear
+  // it here rather than leaving a stale "Connected, no traffic" on a row
+  // that plainly is not connected. This does not catch the opposite case,
+  // a still-active tunnel that silently starts passing traffic again on its
+  // own: that would need re-running the ping check on a timer, which is
+  // more polling than a once-per-toggle verification is worth.
   function updateVpnConnections(raw) {
     vpnConnections = Model.sortVpnConnections(Model.parseVpnConnections(raw))
+
+    if (vpnFailureName === "") return
+    var stillActive = vpnConnections.some(function(conn) { return conn.name === vpnFailureName && conn.active })
+    if (!stillActive) vpnFailureName = ""
   }
 
   // Toggling stays open, same as setBand -- the row's own busy/active state
@@ -666,7 +680,8 @@ Panel {
     if (!name || vpnActionProc.running) return
 
     vpnActionName = name
-    vpnActionProc.command = ["omarchy-network-vpn", active ? "down" : "up", name]
+    vpnActionKind = active ? "down" : "up"
+    vpnActionProc.command = ["omarchy-network-vpn", vpnActionKind, name]
     vpnActionProc.running = true
   }
 
@@ -915,11 +930,20 @@ Panel {
     id: vpnActionProc
     // Exit 2 is omarchy-network-vpn's own signal: nmcli brought the profile
     // up, but the post-activation ping through the tunnel device found no
-    // real peer behind it. Only the most recent toggle's outcome is kept,
+    // real peer behind it. Any other nonzero code is nmcli itself failing
+    // the up/down outright. Only the most recent toggle's outcome is kept,
     // same as the single failureSsid/failureReason pair Wi-Fi rows use.
     onExited: function(exitCode) {
-      root.vpnWarningName = exitCode === 2 ? root.vpnActionName : ""
+      if (exitCode === 0) {
+        root.vpnFailureName = ""
+      } else {
+        root.vpnFailureName = root.vpnActionName
+        root.vpnFailureReason = exitCode === 2
+          ? "Connected, no traffic"
+          : (root.vpnActionKind === "down" ? "Failed to disconnect" : "Failed to connect")
+      }
       root.vpnActionName = ""
+      root.vpnActionKind = ""
       if (!vpnProc.running) vpnProc.running = true
     }
   }
@@ -1698,7 +1722,7 @@ Panel {
 
     readonly property bool isActive: !!(conn && conn.active)
     readonly property bool isBusy: root.vpnActionName !== "" && conn && root.vpnActionName === conn.name
-    readonly property bool isWarning: !isBusy && root.vpnWarningName !== "" && conn && root.vpnWarningName === conn.name
+    readonly property bool isFailed: !isBusy && root.vpnFailureName !== "" && conn && root.vpnFailureName === conn.name
 
     current: isActive
     foreground: root.bar.foreground
@@ -1739,10 +1763,10 @@ Panel {
         id: statusText
         text: {
           if (row.isBusy) return row.isActive ? "Disconnecting…" : "Connecting…"
-          if (row.isWarning) return "Connected, no traffic"
+          if (row.isFailed) return root.vpnFailureReason
           return row.isActive ? "Connected" : ""
         }
-        color: row.isWarning ? root.bar.urgent : (row.isActive ? root.bar.foreground : Qt.darker(root.bar.foreground, 1.5))
+        color: row.isFailed ? root.bar.urgent : (row.isActive ? root.bar.foreground : Qt.darker(root.bar.foreground, 1.5))
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.bodySmall
         anchors.right: parent.right

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -696,10 +696,18 @@ Panel {
   // a still-active tunnel that silently starts passing traffic again on its
   // own: that would need re-running the ping check on a timer, which is
   // more polling than a once-per-toggle verification is worth.
+  // Only the "connected but not passing traffic" warning goes stale on its
+  // own: if that connection is later found inactive (dropped, or torn down
+  // from outside the panel), the warning no longer describes anything real.
+  // A plain "Failed to connect"/"Failed to disconnect" reflects the toggle
+  // that just ran, not the connection's current active state -- a failed
+  // connect leaves the row inactive by definition, so clearing on inactive
+  // the same way would wipe the message before the user ever saw it. That
+  // one clears only when a new toggle supersedes it, in vpnActionProc.onExited.
   function updateVpnConnections(raw) {
     vpnConnections = Model.sortVpnConnections(Model.parseVpnConnections(raw))
 
-    if (vpnFailureName === "") return
+    if (vpnFailureName === "" || vpnFailureReason !== "Connected, no traffic") return
     var stillActive = vpnConnections.some(function(conn) { return conn.name === vpnFailureName && conn.active })
     if (!stillActive) vpnFailureName = ""
   }
@@ -945,12 +953,16 @@ Panel {
   }
 
   // Same cadence as bandPoll: an nmcli listing, not something that needs
-  // detailsPoll's faster tick.
+  // detailsPoll's faster tick. Gated on already having profiles to show --
+  // most machines have none, and there's nothing worth polling nmcli every
+  // 4s for on those. refresh() still checks once on open either way, so a
+  // profile added after that point needs a close/reopen to show up, which
+  // is a fair trade against shelling out to nmcli forever for nothing.
   Timer {
     id: vpnPoll
     interval: 4000
     repeat: true
-    running: root.opened
+    running: root.opened && root.vpnConnections.length > 0
     onTriggered: if (!vpnProc.running) vpnProc.running = true
   }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1794,7 +1794,10 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      enabled: !row.isBusy
+      // Locks every row while any VPN toggle is in flight, not just this
+      // one's -- clicking a different row mid-toggle would otherwise no-op
+      // silently against toggleVpn's own vpnActionProc.running guard.
+      enabled: root.vpnActionName === ""
       onContainsMouseChanged: if (containsMouse) { root.cursorActive = true; root.focusSection = "vpn"; root.vpnIndex = row.index }
       onClicked: root.toggleVpn(row.conn.name, row.isActive)
     }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -83,6 +83,12 @@ Panel {
   property var bandAvailable: []
   property string pendingBand: ""
 
+  // VPN/WireGuard connection profiles from `omarchy-network-vpn`.
+  // `vpnActionName` is the profile currently being brought up/down, so its
+  // row can render a busy state while the toggle is in flight.
+  property var vpnConnections: []
+  property string vpnActionName: ""
+
   // Per-row in-flight state. `actionSsid` flips on for the row whose action
   // is currently running so it can render "Connecting…" / "Disconnecting…" /
   // "Forgetting…". `passwordSsid` is the row currently expanded into
@@ -479,6 +485,7 @@ Panel {
       bandProc.command = ["omarchy-network-band"]
       bandProc.running = true
     }
+    if (!vpnProc.running) vpnProc.running = true
     // A closed panel has no nearby-network list to fill, and bare refresh()
     // reaches here from action completion, timeouts and construction.
     if (opened && wifiDevice) {
@@ -643,6 +650,20 @@ Panel {
     root.pendingBand = band
     actionProc.command = ["omarchy-network-band", band]
     actionProc.running = true
+  }
+
+  function updateVpnConnections(raw) {
+    vpnConnections = Model.sortVpnConnections(Model.parseVpnConnections(raw))
+  }
+
+  // Toggling stays open, same as setBand -- the row's own busy/active state
+  // is the feedback, and closing the panel would hide a failed toggle.
+  function toggleVpn(name, active) {
+    if (!name || vpnActionProc.running) return
+
+    vpnActionName = name
+    vpnActionProc.command = ["omarchy-network-vpn", active ? "down" : "up", name]
+    vpnActionProc.running = true
   }
 
   // The speed test is its own panel plugin (omarchy.speedtest) so a
@@ -862,6 +883,35 @@ Panel {
       if (bandProc.running) return
       bandProc.command = ["omarchy-network-band"]
       bandProc.running = true
+    }
+  }
+
+  Process {
+    id: vpnProc
+    command: ["omarchy-network-vpn"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateVpnConnections(text)
+    }
+  }
+
+  // Same cadence as bandPoll: an nmcli listing, not something that needs
+  // detailsPoll's faster tick.
+  Timer {
+    id: vpnPoll
+    interval: 4000
+    repeat: true
+    running: root.opened
+    onTriggered: if (!vpnProc.running) vpnProc.running = true
+  }
+
+  // Separate from actionProc: a VPN toggle can legitimately outlive a DNS or
+  // band change still in flight, and each needs its own exit handler.
+  Process {
+    id: vpnActionProc
+    onExited: {
+      root.vpnActionName = ""
+      if (!vpnProc.running) vpnProc.running = true
     }
   }
 
@@ -1452,6 +1502,49 @@ Panel {
         }
       }
 
+      // VPN/WireGuard connections (only shown once NetworkManager knows
+      // about at least one profile -- most machines have none).
+      PanelSeparator {
+        visible: root.vpnConnections.length > 0
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        width: parent.width
+        spacing: Style.space(6)
+        visible: root.vpnConnections.length > 0
+
+        PanelSectionHeader {
+          text: "VPN"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(4)
+
+          // Wrapper takes modelData from the Repeater's delegate context,
+          // which doesn't bind into nested `component` declarations, and
+          // passes it down explicitly -- same shape as the band pills and
+          // the network list delegate.
+          Repeater {
+            model: root.vpnConnections
+
+            delegate: Item {
+              required property var modelData
+              width: parent.width
+              height: vpnRow.implicitHeight
+
+              VpnRow {
+                id: vpnRow
+                width: parent.width
+                conn: modelData
+              }
+            }
+          }
+        }
+      }
 
       // Wi-Fi networks (only if a Wi-Fi station is available).
       PanelSeparator {
@@ -1583,6 +1676,64 @@ Panel {
       root.cursorActive = true
       root.focusSection = "dns"
       root.dnsIndex = pill.index
+    }
+  }
+
+  // A single VPN/WireGuard connection profile. Click toggles it up/down.
+  // Busy state comes from vpnActionName rather than a per-row Connections
+  // block: nmcli connection up/down is a single fire-and-forget call with no
+  // WifiNetwork-style signal to listen on.
+  component VpnRow: CursorSurface {
+    id: row
+    required property var conn
+
+    readonly property bool isActive: !!(conn && conn.active)
+    readonly property bool isBusy: root.vpnActionName !== "" && conn && root.vpnActionName === conn.name
+
+    current: isActive
+    foreground: root.bar.foreground
+    fill: root.hoverFill
+    currentFill: root.selectedFill
+    hasCursor: mouseArea.containsMouse
+
+    implicitHeight: rowBody.implicitHeight
+
+    MouseArea {
+      id: mouseArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      enabled: !row.isBusy
+      onClicked: root.toggleVpn(row.conn.name, row.isActive)
+    }
+
+    Item {
+      id: rowBody
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      implicitHeight: Math.max(nameText.implicitHeight, statusText.implicitHeight) + Style.spacing.rowPaddingX
+
+      Text {
+        id: nameText
+        text: row.conn ? row.conn.name : ""
+        color: root.bar.foreground
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+      }
+
+      Text {
+        id: statusText
+        text: row.isBusy ? (row.isActive ? "Disconnecting…" : "Connecting…") : (row.isActive ? "Connected" : "")
+        color: row.isActive ? root.bar.foreground : Qt.darker(root.bar.foreground, 1.5)
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+      }
     }
   }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -130,11 +130,13 @@ Panel {
   property int selectedIndex: -1
   property bool wifiActionFocused: false
   property bool cursorActive: false
+  // Index into `vpnConnections` for keyboard navigation. -1 = no selection.
+  property int vpnIndex: -1
 
   // Keyboard focus zone for the panel. j/k crosses row boundaries:
-  // header actions ⇄ band ⇄ DNS row ⇄ Wi-Fi networks. h/l move
+  // header actions ⇄ band ⇄ DNS row ⇄ VPN ⇄ Wi-Fi networks. h/l move
   // within header actions, band pills, or DNS providers.
-  property string focusSection: "dns"  // "header" | "band" | "dns" | "wifi"
+  property string focusSection: "dns"  // "header" | "band" | "dns" | "vpn" | "wifi"
   property int headerIndex: 0
   readonly property bool canDisconnect: !!connectedWifiNetwork
   readonly property bool headerHasDisconnect: false
@@ -396,6 +398,20 @@ Panel {
     }
   }
 
+  // Keep vpnIndex valid as the VPN list refreshes on its poll, mirroring
+  // onWifiNetworksChanged above: an emptied list bounces the cursor back to
+  // DNS instead of leaving focusSection pointed at rows that no longer exist.
+  onVpnConnectionsChanged: {
+    if (vpnConnections.length === 0) {
+      vpnIndex = -1
+      if (focusSection === "vpn") focusSection = "dns"
+    } else if (vpnIndex >= vpnConnections.length) {
+      vpnIndex = vpnConnections.length - 1
+    } else if (vpnIndex < 0 && opened) {
+      vpnIndex = 0
+    }
+  }
+
   onWifiDeviceChanged: {
     setScannerEnabled(true)
     syncWifiNetworks()
@@ -408,6 +424,20 @@ Panel {
     if (selectedIndex < 0) selectedIndex = delta > 0 ? 0 : wifiNetworks.length - 1
     else selectedIndex = Math.max(0, Math.min(wifiNetworks.length - 1, selectedIndex + delta))
     wifiActionFocused = false
+  }
+
+  function selectVpnByDelta(delta) {
+    if (vpnConnections.length === 0) { vpnIndex = -1; return }
+    if (vpnIndex < 0) vpnIndex = delta > 0 ? 0 : vpnConnections.length - 1
+    else vpnIndex = Math.max(0, Math.min(vpnConnections.length - 1, vpnIndex + delta))
+  }
+
+  // Enter/Space on the highlighted VPN row. Mirrors row-click semantics.
+  function activateVpn() {
+    if (vpnIndex < 0 || vpnIndex >= vpnConnections.length) return
+    var conn = vpnConnections[vpnIndex]
+    if (!conn) return
+    toggleVpn(conn.name, conn.active)
   }
 
   function canForgetNetwork(net) {
@@ -1112,8 +1142,8 @@ Panel {
             }
           } else if (root.focusSection === "dns") {
             // k from DNS moves up into the band section when it's on screen,
-            // then the disconnect button; otherwise stays put. j drops into the
-            // wifi list if there's anywhere to land.
+            // then the disconnect button; otherwise stays put. j drops into
+            // VPN if there's anywhere to land there, otherwise the wifi list.
             if (dy < 0) {
               if (root.canSelectBand) {
                 root.focusSection = "band"
@@ -1122,15 +1152,37 @@ Panel {
                 root.focusSection = "header"
                 root.headerIndex = 0
               }
+            } else if (root.vpnConnections.length > 0) {
+              root.focusSection = "vpn"
+              if (root.vpnIndex < 0) root.vpnIndex = 0
             } else if (root.wifiNetworks.length > 0) {
               root.focusSection = "wifi"
               if (root.selectedIndex < 0) root.selectedIndex = 0
             }
-          } else {  // wifi
-            // k from the top row escapes back up to the DNS row rather than
-            // wrapping around to the bottom of the list.
-            if (dy < 0 && root.selectedIndex <= 0) {
+          } else if (root.focusSection === "vpn") {
+            // k from the top row escapes back up to DNS; j from the bottom
+            // row drops into wifi if there's anywhere to land there.
+            if (dy < 0 && root.vpnIndex <= 0) {
               root.focusSection = "dns"
+            } else if (dy > 0 && root.vpnIndex >= root.vpnConnections.length - 1) {
+              if (root.wifiNetworks.length > 0) {
+                root.focusSection = "wifi"
+                if (root.selectedIndex < 0) root.selectedIndex = 0
+              }
+            } else {
+              root.selectVpnByDelta(dy)
+            }
+          } else {  // wifi
+            // k from the top row escapes back up to VPN when it's on screen,
+            // otherwise DNS, rather than wrapping around to the bottom of
+            // the list.
+            if (dy < 0 && root.selectedIndex <= 0) {
+              if (root.vpnConnections.length > 0) {
+                root.focusSection = "vpn"
+                root.vpnIndex = root.vpnConnections.length - 1
+              } else {
+                root.focusSection = "dns"
+              }
               root.wifiActionFocused = false
             }
             else root.selectByDelta(dy)
@@ -1148,6 +1200,7 @@ Panel {
           if (root.focusSection === "header") root.activateHeader()
           else if (root.focusSection === "band") root.activateBand()
           else if (root.focusSection === "dns") root.activateDns()
+          else if (root.focusSection === "vpn") root.activateVpn()
           else root.activateSelected()
         }
       }
@@ -1566,6 +1619,7 @@ Panel {
 
             delegate: Item {
               required property var modelData
+              required property int index
               width: parent.width
               height: vpnRow.implicitHeight
 
@@ -1573,6 +1627,7 @@ Panel {
                 id: vpnRow
                 width: parent.width
                 conn: modelData
+                index: parent.index
               }
             }
           }
@@ -1719,16 +1774,18 @@ Panel {
   component VpnRow: CursorSurface {
     id: row
     required property var conn
+    required property int index
 
     readonly property bool isActive: !!(conn && conn.active)
     readonly property bool isBusy: root.vpnActionName !== "" && conn && root.vpnActionName === conn.name
     readonly property bool isFailed: !isBusy && root.vpnFailureName !== "" && conn && root.vpnFailureName === conn.name
+    readonly property bool isSelected: root.focusSection === "vpn" && root.vpnIndex === index
 
     current: isActive
     foreground: root.bar.foreground
     fill: root.hoverFill
     currentFill: root.selectedFill
-    hasCursor: mouseArea.containsMouse
+    hasCursor: root.cursorActive && isSelected
 
     implicitHeight: rowBody.implicitHeight
 
@@ -1738,6 +1795,7 @@ Panel {
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
       enabled: !row.isBusy
+      onContainsMouseChanged: if (containsMouse) { root.cursorActive = true; root.focusSection = "vpn"; root.vpnIndex = row.index }
       onClicked: root.toggleVpn(row.conn.name, row.isActive)
     }
 

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -147,3 +147,152 @@ assert(/positionViewAtIndex\(currentIndex, ListView\.Contain\)/.test(vpnListView
 assert(/elide: Text\.ElideRight/.test(vpnRow[0]), 'VpnRow elides a name too long to fit')
 assert(/anchors\.right: statusText\.left/.test(vpnRow[0]), 'VpnRow name is width-constrained against the status text, not free to overlap it')
 JS
+
+# The JS tests above only regex-match Panel.qml/omarchy-network-vpn source; they
+# never exercise the shell script itself. These stub nmcli/ip/ping on PATH and
+# run the real binary, covering exclusivity, rollback, and probe-failure
+# mapping end to end.
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mock_bin="$tmp_dir/bin"
+mkdir -p "$mock_bin"
+call_log="$tmp_dir/calls"
+
+cat >"$mock_bin/nmcli" <<'STUB'
+#!/bin/bash
+
+printf 'nmcli %s\n' "$*" >>"$CALL_LOG"
+
+if [[ $1 == "-e" && $2 == "no" && $3 == "-g" ]]; then
+  field=$4
+  obj=$5
+  target=${7:-}
+
+  if [[ $obj == "connection" && -z $target ]]; then
+    printf '%s\n' "$CONN_LIST"
+  elif [[ $field == "GENERAL.DEVICES" ]]; then
+    [[ $target == "$VPN_NAME" ]] && printf '%s\n' "$VPN_DEVICE"
+  elif [[ $field == "GENERAL.STATE" ]]; then
+    [[ $target == "$VPN_DEVICE" ]] && printf '%s\n' "$VPN_STATE"
+  fi
+  exit 0
+fi
+
+if [[ $1 == "connection" && $2 == "up" ]]; then
+  [[ $3 == "${NMCLI_UP_FAIL:-}" ]] && exit 1
+  exit 0
+fi
+
+if [[ $1 == "connection" && $2 == "down" ]]; then
+  [[ $3 == "${NMCLI_DOWN_FAIL:-}" ]] && exit 1
+  exit 0
+fi
+
+exit 1
+STUB
+
+cat >"$mock_bin/ip" <<'STUB'
+#!/bin/bash
+
+printf 'ip %s\n' "$*" >>"$CALL_LOG"
+[[ $6 == "$VPN_DEVICE" ]] && printf '%s\n' "$VPN_ROUTES"
+exit 0
+STUB
+
+cat >"$mock_bin/ping" <<'STUB'
+#!/bin/bash
+
+printf 'ping %s\n' "$*" >>"$CALL_LOG"
+exit "${PING_EXIT:-0}"
+STUB
+
+chmod +x "$mock_bin/nmcli" "$mock_bin/ip" "$mock_bin/ping"
+
+export CALL_LOG="$call_log" VPN_NAME="" VPN_DEVICE="" VPN_STATE="" VPN_ROUTES="" \
+  PING_EXIT=0 CONN_LIST="" NMCLI_UP_FAIL="" NMCLI_DOWN_FAIL=""
+
+# $ROOT/bin so omarchy-network-vpn resolves the real omarchy-cmd-present.
+vpn_run() {
+  : >"$call_log"
+  PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-network-vpn" "$@"
+}
+
+logged_before() {
+  local first="$1" second="$2" first_line second_line
+  first_line=$(grep -Fxn -- "$first" "$call_log" | head -1 | cut -d: -f1)
+  second_line=$(grep -Fxn -- "$second" "$call_log" | head -1 | cut -d: -f1)
+  [[ -n $first_line && -n $second_line ]] || return 1
+  (( first_line < second_line ))
+}
+
+# list_vpn_connections: bare invocation prints name/active pairs, dropping type.
+CONN_LIST=$'pvpn-ch:wireguard:no\npvpn-fr:vpn:yes'
+list_output=$(vpn_run) || fail "omarchy-network-vpn lists connections cleanly"
+[[ $list_output == $'pvpn-ch\tno\npvpn-fr\tyes' ]] ||
+  fail "omarchy-network-vpn lists profiles as name/active pairs" "$list_output"
+pass "omarchy-network-vpn lists profiles as name/active pairs"
+
+# up: exclusivity deactivates the other active profile before activating the
+# requested one. Split-tunnel routes skip the traffic probe outright.
+CONN_LIST=$'pvpn-ch:wireguard:yes\npvpn-fr:wireguard:no'
+VPN_NAME=pvpn-fr VPN_DEVICE=wg1 VPN_STATE="100 (connected)" VPN_ROUTES="10.0.0.0/24 dev wg1 scope link"
+vpn_run up pvpn-fr || fail "omarchy-network-vpn activates a verified split-tunnel profile"
+pass "omarchy-network-vpn activates a verified split-tunnel profile"
+logged_before "nmcli connection down pvpn-ch" "nmcli connection up pvpn-fr" ||
+  fail "omarchy-network-vpn deactivates the other active profile before activating the requested one" "$(cat "$call_log")"
+pass "omarchy-network-vpn deactivates the other active profile before activating the requested one"
+
+# up: a full tunnel that fails the traffic probe reports the dedicated exit
+# code and warning, without touching exclusivity.
+CONN_LIST=$'pvpn-de:wireguard:no'
+VPN_NAME=pvpn-de VPN_DEVICE=wg2 VPN_STATE="100 (connected)" VPN_ROUTES="default via 10.0.0.1 dev wg2"
+PING_EXIT=1
+if err=$(vpn_run up pvpn-de 2>&1 >/dev/null); then status=0; else status=$?; fi
+(( status == 75 )) || fail "omarchy-network-vpn reports the no-traffic exit code" "exit status: $status"
+pass "omarchy-network-vpn reports the no-traffic exit code"
+[[ $err == *"Warning: pvpn-de connected but is not passing traffic."* ]] ||
+  fail "omarchy-network-vpn warns when a full tunnel carries no traffic" "$err"
+pass "omarchy-network-vpn warns when a full tunnel carries no traffic"
+
+# up: the same full tunnel succeeds outright once the probe passes.
+PING_EXIT=0
+vpn_run up pvpn-de || fail "omarchy-network-vpn accepts a full tunnel that passes traffic"
+pass "omarchy-network-vpn accepts a full tunnel that passes traffic"
+
+# up: a profile that fails to activate outright rolls back to whatever was
+# active before, instead of leaving nothing connected.
+CONN_LIST=$'pvpn-ch:wireguard:yes\npvpn-fr:wireguard:no'
+NMCLI_UP_FAIL=pvpn-fr
+if err=$(vpn_run up pvpn-fr 2>&1 >/dev/null); then status=0; else status=$?; fi
+(( status == 1 )) || fail "omarchy-network-vpn fails when activation is refused outright" "exit status: $status"
+pass "omarchy-network-vpn fails when activation is refused outright"
+[[ $err == *"Error: failed to activate pvpn-fr."* ]] ||
+  fail "omarchy-network-vpn reports the activation failure" "$err"
+pass "omarchy-network-vpn reports the activation failure"
+grep -Fxq "nmcli connection up pvpn-ch" "$call_log" ||
+  fail "omarchy-network-vpn rolls back to the previously active profile" "$(cat "$call_log")"
+pass "omarchy-network-vpn rolls back to the previously active profile"
+NMCLI_UP_FAIL=""
+
+# down: a refused deactivation is reported, not silently swallowed.
+NMCLI_DOWN_FAIL=pvpn-ch
+if err=$(vpn_run down pvpn-ch 2>&1 >/dev/null); then status=0; else status=$?; fi
+(( status == 1 )) || fail "omarchy-network-vpn fails when deactivation is refused" "exit status: $status"
+pass "omarchy-network-vpn fails when deactivation is refused"
+[[ $err == *"Error: failed to deactivate pvpn-ch."* ]] ||
+  fail "omarchy-network-vpn reports the deactivation failure" "$err"
+pass "omarchy-network-vpn reports the deactivation failure"
+NMCLI_DOWN_FAIL=""
+
+# up: deactivate_other_vpns compares the activating profile's name literally,
+# not as a glob pattern -- a name with a glob metacharacter must not make an
+# unrelated active profile with a matching prefix look like a self-match and
+# get skipped, breaking exclusivity.
+CONN_LIST=$'work*:wireguard:no\nworkstation:wireguard:yes'
+VPN_NAME='work*' VPN_DEVICE=wg3 VPN_STATE="100 (connected)" VPN_ROUTES="10.0.0.0/24 dev wg3"
+vpn_run up 'work*' || fail "omarchy-network-vpn activates a profile whose name contains a glob metacharacter"
+pass "omarchy-network-vpn activates a profile whose name contains a glob metacharacter"
+grep -Fxq "nmcli connection down workstation" "$call_log" ||
+  fail "omarchy-network-vpn deactivates an unrelated profile instead of glob-matching it against the activating name" "$(cat "$call_log")"
+pass "omarchy-network-vpn deactivates an unrelated profile instead of glob-matching it against the activating name"

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -83,4 +83,41 @@ assert(vpnRow, 'network panel defines a VpnRow row component')
 assert(/onClicked: root\.toggleVpn\(row\.conn\.name, row\.isActive\)/.test(vpnRow[0]), 'VpnRow click toggles the connection')
 assert(/isFailed: !isBusy && root\.vpnFailureName/.test(vpnRow[0]), 'VpnRow only shows a failure once its own toggle has settled')
 assert(/root\.vpnFailureReason/.test(vpnRow[0]), 'VpnRow renders the failure reason the panel recorded')
+
+// Keyboard navigation: PanelKeyCatcher maps both arrow keys and j/k/h/l to
+// the same onMoveRequested(dx, dy), so wiring the "vpn" section into that
+// one handler covers both input styles at once -- nothing arrow-specific to
+// test separately.
+assert(/property int vpnIndex: -1/.test(panelSource), 'network panel declares vpnIndex')
+assert(/"header" \| "band" \| "dns" \| "vpn" \| "wifi"/.test(panelSource), 'focusSection docs list vpn between dns and wifi')
+
+const moveHandler = panelSource.match(/onMoveRequested: function\(dx, dy\) \{[\s\S]*?\n {6}\}\n {4}\}/)
+assert(moveHandler, 'network panel has the onMoveRequested handler')
+assert(
+  /root\.focusSection === "dns"[\s\S]*?root\.vpnConnections\.length > 0\)[\s\S]*?root\.focusSection = "vpn"/.test(moveHandler[0]),
+  'j from DNS enters the VPN section when it has profiles'
+)
+assert(
+  /root\.focusSection === "vpn"[\s\S]*?dy < 0 && root\.vpnIndex <= 0[\s\S]*?root\.focusSection = "dns"/.test(moveHandler[0]),
+  'k from the top VPN row escapes back to DNS'
+)
+assert(
+  /root\.focusSection === "vpn"[\s\S]*?dy > 0 && root\.vpnIndex >= root\.vpnConnections\.length - 1[\s\S]*?root\.focusSection = "wifi"/.test(moveHandler[0]),
+  'j from the bottom VPN row drops into wifi when there is somewhere to land'
+)
+assert(
+  /root\.selectedIndex <= 0\)[\s\S]*?root\.vpnConnections\.length > 0\)[\s\S]*?root\.focusSection = "vpn"/.test(moveHandler[0]),
+  'k from the top wifi row returns to VPN when it has profiles'
+)
+
+const activateHandler = panelSource.match(/onActivateRequested: \{[\s\S]*?\n {6}\}\n {4}\}/)
+assert(activateHandler, 'network panel has the onActivateRequested handler')
+assert(/root\.focusSection === "vpn"\) root\.activateVpn\(\)/.test(activateHandler[0]), 'Enter/Space on the VPN section activates the selected row')
+
+const activateVpn = panelSource.match(/function activateVpn\(\) \{[\s\S]*?\n {2}\}/)
+assert(activateVpn, 'network panel has an activateVpn function')
+assert(/toggleVpn\(conn\.name, conn\.active\)/.test(activateVpn[0]), 'activateVpn toggles the row under the keyboard cursor')
+
+assert(/isSelected: root\.focusSection === "vpn" && root\.vpnIndex === index/.test(vpnRow[0]), 'VpnRow tracks whether it is the keyboard-selected row')
+assert(/hasCursor: root\.cursorActive && isSelected/.test(vpnRow[0]), 'VpnRow shows the keyboard cursor, not just mouse hover')
 JS

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const network = requireFromRoot('shell/plugins/panels/network/Model.js')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
+
+// parseVpnConnections: omarchy-network-vpn prints "name\tactive" lines.
+assertDeepEqual(
+  network.parseVpnConnections('pvpn-ch\tno\npvpn-fr\tyes\n'),
+  [{ name: 'pvpn-ch', active: false }, { name: 'pvpn-fr', active: true }],
+  'parseVpnConnections reads name/active pairs'
+)
+
+assertDeepEqual(network.parseVpnConnections(''), [], 'parseVpnConnections handles empty output')
+assertDeepEqual(network.parseVpnConnections(undefined), [], 'parseVpnConnections handles undefined input')
+
+// sortVpnConnections: active profile first, then alphabetical among the rest --
+// mirrors sortWifiRows putting the connected network first.
+assertDeepEqual(
+  network.sortVpnConnections([
+    { name: 'pvpn-fr', active: false },
+    { name: 'pvpn-ch', active: true },
+    { name: 'pvpn-de', active: false }
+  ]),
+  [
+    { name: 'pvpn-ch', active: true },
+    { name: 'pvpn-de', active: false },
+    { name: 'pvpn-fr', active: false }
+  ],
+  'sortVpnConnections puts the active connection first, then sorts by name'
+)
+
+// Structural checks against Panel.qml, same style as network-test.sh: catch a
+// wiring mistake (poll timer not gated, action not clearing busy state, list
+// section still visible with nothing to show) without a running compositor.
+assert(/property var vpnConnections: \[\]/.test(panelSource), 'network panel declares vpnConnections')
+assert(/property string vpnActionName: ""/.test(panelSource), 'network panel declares vpnActionName')
+
+assert(/if \(!vpnProc\.running\) vpnProc\.running = true/.test(panelSource), 'refresh() kicks off the VPN listing')
+
+const vpnPoll = panelSource.match(/Timer \{\n {4}id: vpnPoll[\s\S]*?\n {2}\}/)
+assert(vpnPoll, 'network panel has a vpnPoll timer')
+assert(/running: root\.opened/.test(vpnPoll[0]), 'vpnPoll only runs while the panel is open, like bandPoll')
+
+const vpnActionProc = panelSource.match(/Process \{\n {4}id: vpnActionProc[\s\S]*?\n {2}\}/)
+assert(vpnActionProc, 'network panel has a vpnActionProc')
+assert(/root\.vpnActionName = ""/.test(vpnActionProc[0]), 'vpnActionProc clears the busy row on exit')
+
+const toggleVpn = panelSource.match(/function toggleVpn\(name, active\) \{[\s\S]*?\n {2}\}/)
+assert(toggleVpn, 'network panel has a toggleVpn function')
+assert(/vpnActionProc\.running/.test(toggleVpn[0]), 'toggleVpn guards against overlapping toggles')
+
+assert(/visible: root\.vpnConnections\.length > 0/.test(panelSource), 'VPN section is hidden when there are no profiles')
+assert(/component VpnRow: CursorSurface/.test(panelSource), 'network panel defines a VpnRow row component')
+assert(/onClicked: root\.toggleVpn\(row\.conn\.name, row\.isActive\)/.test(panelSource), 'VpnRow click toggles the connection')
+JS

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -120,4 +120,8 @@ assert(/toggleVpn\(conn\.name, conn\.active\)/.test(activateVpn[0]), 'activateVp
 
 assert(/isSelected: root\.focusSection === "vpn" && root\.vpnIndex === index/.test(vpnRow[0]), 'VpnRow tracks whether it is the keyboard-selected row')
 assert(/hasCursor: root\.cursorActive && isSelected/.test(vpnRow[0]), 'VpnRow shows the keyboard cursor, not just mouse hover')
+assert(
+  /enabled: root\.vpnActionName === ""/.test(vpnRow[0]),
+  'VpnRow locks every row while any VPN toggle is in flight, not just its own'
+)
 JS

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -50,12 +50,22 @@ assert(/running: root\.opened/.test(vpnPoll[0]), 'vpnPoll only runs while the pa
 const vpnActionProc = panelSource.match(/Process \{\n {4}id: vpnActionProc[\s\S]*?\n {2}\}/)
 assert(vpnActionProc, 'network panel has a vpnActionProc')
 assert(/root\.vpnActionName = ""/.test(vpnActionProc[0]), 'vpnActionProc clears the busy row on exit')
+assert(
+  /root\.vpnWarningName = exitCode === 2 \? root\.vpnActionName : ""/.test(vpnActionProc[0]),
+  'vpnActionProc reads exit code 2 as a connected-but-no-traffic warning'
+)
+
+assert(/property string vpnWarningName: ""/.test(panelSource), 'network panel declares vpnWarningName')
 
 const toggleVpn = panelSource.match(/function toggleVpn\(name, active\) \{[\s\S]*?\n {2}\}/)
 assert(toggleVpn, 'network panel has a toggleVpn function')
 assert(/vpnActionProc\.running/.test(toggleVpn[0]), 'toggleVpn guards against overlapping toggles')
 
 assert(/visible: root\.vpnConnections\.length > 0/.test(panelSource), 'VPN section is hidden when there are no profiles')
-assert(/component VpnRow: CursorSurface/.test(panelSource), 'network panel defines a VpnRow row component')
-assert(/onClicked: root\.toggleVpn\(row\.conn\.name, row\.isActive\)/.test(panelSource), 'VpnRow click toggles the connection')
+
+const vpnRow = panelSource.match(/component VpnRow: CursorSurface \{[\s\S]*?\n {2}\}/)
+assert(vpnRow, 'network panel defines a VpnRow row component')
+assert(/onClicked: root\.toggleVpn\(row\.conn\.name, row\.isActive\)/.test(vpnRow[0]), 'VpnRow click toggles the connection')
+assert(/isWarning: !isBusy && root\.vpnWarningName/.test(vpnRow[0]), 'VpnRow only shows a warning once its own toggle has settled')
+assert(/"Connected, no traffic"/.test(vpnRow[0]), 'VpnRow surfaces the no-traffic warning text')
 JS

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -40,6 +40,9 @@ assertDeepEqual(
 // section still visible with nothing to show) without a running compositor.
 assert(/property var vpnConnections: \[\]/.test(panelSource), 'network panel declares vpnConnections')
 assert(/property string vpnActionName: ""/.test(panelSource), 'network panel declares vpnActionName')
+assert(/property string vpnActionKind: ""/.test(panelSource), 'network panel declares vpnActionKind')
+assert(/property string vpnFailureName: ""/.test(panelSource), 'network panel declares vpnFailureName')
+assert(/property string vpnFailureReason: ""/.test(panelSource), 'network panel declares vpnFailureReason')
 
 assert(/if \(!vpnProc\.running\) vpnProc\.running = true/.test(panelSource), 'refresh() kicks off the VPN listing')
 
@@ -47,25 +50,37 @@ const vpnPoll = panelSource.match(/Timer \{\n {4}id: vpnPoll[\s\S]*?\n {2}\}/)
 assert(vpnPoll, 'network panel has a vpnPoll timer')
 assert(/running: root\.opened/.test(vpnPoll[0]), 'vpnPoll only runs while the panel is open, like bandPoll')
 
+const updateVpnConnections = panelSource.match(/function updateVpnConnections\(raw\) \{[\s\S]*?\n {2}\}/)
+assert(updateVpnConnections, 'network panel has an updateVpnConnections function')
+assert(
+  /if \(!stillActive\) vpnFailureName = ""/.test(updateVpnConnections[0]),
+  'updateVpnConnections drops a failure once its connection is no longer active'
+)
+
 const vpnActionProc = panelSource.match(/Process \{\n {4}id: vpnActionProc[\s\S]*?\n {2}\}/)
 assert(vpnActionProc, 'network panel has a vpnActionProc')
 assert(/root\.vpnActionName = ""/.test(vpnActionProc[0]), 'vpnActionProc clears the busy row on exit')
+assert(/root\.vpnActionKind = ""/.test(vpnActionProc[0]), 'vpnActionProc clears the pending action kind on exit')
+assert(/exitCode === 0/.test(vpnActionProc[0]), 'vpnActionProc treats exit 0 as a plain success')
 assert(
-  /root\.vpnWarningName = exitCode === 2 \? root\.vpnActionName : ""/.test(vpnActionProc[0]),
+  /exitCode === 2\s*\n\s*\? "Connected, no traffic"/.test(vpnActionProc[0]),
   'vpnActionProc reads exit code 2 as a connected-but-no-traffic warning'
 )
-
-assert(/property string vpnWarningName: ""/.test(panelSource), 'network panel declares vpnWarningName')
+assert(
+  /root\.vpnActionKind === "down" \? "Failed to disconnect" : "Failed to connect"/.test(vpnActionProc[0]),
+  'vpnActionProc surfaces a plain nmcli failure distinctly from the no-traffic case'
+)
 
 const toggleVpn = panelSource.match(/function toggleVpn\(name, active\) \{[\s\S]*?\n {2}\}/)
 assert(toggleVpn, 'network panel has a toggleVpn function')
 assert(/vpnActionProc\.running/.test(toggleVpn[0]), 'toggleVpn guards against overlapping toggles')
+assert(/vpnActionKind = active \? "down" : "up"/.test(toggleVpn[0]), 'toggleVpn records which direction it requested')
 
 assert(/visible: root\.vpnConnections\.length > 0/.test(panelSource), 'VPN section is hidden when there are no profiles')
 
 const vpnRow = panelSource.match(/component VpnRow: CursorSurface \{[\s\S]*?\n {2}\}/)
 assert(vpnRow, 'network panel defines a VpnRow row component')
 assert(/onClicked: root\.toggleVpn\(row\.conn\.name, row\.isActive\)/.test(vpnRow[0]), 'VpnRow click toggles the connection')
-assert(/isWarning: !isBusy && root\.vpnWarningName/.test(vpnRow[0]), 'VpnRow only shows a warning once its own toggle has settled')
-assert(/"Connected, no traffic"/.test(vpnRow[0]), 'VpnRow surfaces the no-traffic warning text')
+assert(/isFailed: !isBusy && root\.vpnFailureName/.test(vpnRow[0]), 'VpnRow only shows a failure once its own toggle has settled')
+assert(/root\.vpnFailureReason/.test(vpnRow[0]), 'VpnRow renders the failure reason the panel recorded')
 JS

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -63,8 +63,8 @@ assert(/root\.vpnActionName = ""/.test(vpnActionProc[0]), 'vpnActionProc clears 
 assert(/root\.vpnActionKind = ""/.test(vpnActionProc[0]), 'vpnActionProc clears the pending action kind on exit')
 assert(/exitCode === 0/.test(vpnActionProc[0]), 'vpnActionProc treats exit 0 as a plain success')
 assert(
-  /exitCode === 2\s*\n\s*\? "Connected, no traffic"/.test(vpnActionProc[0]),
-  'vpnActionProc reads exit code 2 as a connected-but-no-traffic warning'
+  /exitCode === 75\s*\n\s*\? "Connected, no traffic"/.test(vpnActionProc[0]),
+  'vpnActionProc reads the private exit code 75 as a connected-but-no-traffic warning, not nmcli\'s own exit 2'
 )
 assert(
   /root\.vpnActionKind === "down" \? "Failed to disconnect" : "Failed to connect"/.test(vpnActionProc[0]),
@@ -124,4 +124,18 @@ assert(
   /enabled: root\.vpnActionName === ""/.test(vpnRow[0]),
   'VpnRow locks every row while any VPN toggle is in flight, not just its own'
 )
+
+// The VPN list is a capped, scrollable ListView (like networkList below it),
+// not an unbounded Column -- a long profile list must scroll instead of
+// pushing DNS/wifi off the card.
+const vpnListView = panelSource.match(/ListView \{\n {10}id: vpnList[\s\S]*?\n {8}\}/)
+assert(vpnListView, 'network panel has a capped vpnList ListView')
+assert(/height: Math\.min\(contentHeight, Style\.space\(240\)\)/.test(vpnListView[0]), 'vpnList caps its height like networkList')
+assert(/clip: true/.test(vpnListView[0]), 'vpnList clips overflow instead of pushing later sections off the card')
+assert(/currentIndex: root\.vpnIndex/.test(vpnListView[0]), 'vpnList follows the keyboard cursor')
+assert(/positionViewAtIndex\(currentIndex, ListView\.Contain\)/.test(vpnListView[0]), 'vpnList scrolls the keyboard-selected row into view')
+
+// A long connection name must not run under the status text on its right.
+assert(/elide: Text\.ElideRight/.test(vpnRow[0]), 'VpnRow elides a name too long to fit')
+assert(/anchors\.right: statusText\.left/.test(vpnRow[0]), 'VpnRow name is width-constrained against the status text, not free to overlap it')
 JS

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -49,9 +49,17 @@ assert(/if \(!vpnProc\.running\) vpnProc\.running = true/.test(panelSource), 're
 const vpnPoll = panelSource.match(/Timer \{\n {4}id: vpnPoll[\s\S]*?\n {2}\}/)
 assert(vpnPoll, 'network panel has a vpnPoll timer')
 assert(/running: root\.opened/.test(vpnPoll[0]), 'vpnPoll only runs while the panel is open, like bandPoll')
+assert(
+  /running: root\.opened && root\.vpnConnections\.length > 0/.test(vpnPoll[0]),
+  'vpnPoll does not shell out to nmcli every 4s on a machine with no VPN profiles'
+)
 
 const updateVpnConnections = panelSource.match(/function updateVpnConnections\(raw\) \{[\s\S]*?\n {2}\}/)
 assert(updateVpnConnections, 'network panel has an updateVpnConnections function')
+assert(
+  /if \(vpnFailureName === "" \|\| vpnFailureReason !== "Connected, no traffic"\) return/.test(updateVpnConnections[0]),
+  'updateVpnConnections only auto-clears the no-traffic warning, not a plain connect/disconnect failure'
+)
 assert(
   /if \(!stillActive\) vpnFailureName = ""/.test(updateVpnConnections[0]),
   'updateVpnConnections drops a failure once its connection is no longer active'


### PR DESCRIPTION
## Summary
- Lists NetworkManager wireguard/vpn connection profiles in the native network panel (previously only reachable through nm-applet)
- Click a profile to bring it up or down via a new `omarchy-network-vpn` command; activating one profile deactivates any other active VPN, since nothing at the NetworkManager level stops two tunnels running at once (and rolls back to whatever was active before if the new profile fails to activate outright)
- After activation, a ping through the tunnel device confirms it's actually passing traffic (not just NetworkManager-"connected") for full-tunnel profiles; the row shows "Connected, no traffic" if it isn't
- Full keyboard navigation: the VPN section is wired into the panel's existing focus chain (header ⇄ band ⇄ dns ⇄ vpn ⇄ wifi), reachable with both arrow keys and j/k/h/l, Enter/Space to toggle
- Section stays hidden when no VPN profile is configured

<img width="571" height="940" alt="image" src="https://github.com/user-attachments/assets/3010a813-ae49-482e-9690-eee742cc141e" />


## Test plan
- [x] `./test/shell.d/network-vpn-test.sh` — unit/structural tests for parsing, sorting, exclusivity, failure-state wiring, and keyboard-nav wiring
- [x] `./test/shell.d/network-test.sh` — existing Wi-Fi/band panel tests, unaffected
- [x] Visual verification in a running Hyprland session via `omarchy dev link` — confirmed end-to-end against a real ProtonVPN WireGuard profile: exclusivity, traffic verification, activation rollback (simulated a failed activation, confirmed the previous VPN was restored), and keyboard navigation driven with real key events (wifi ⇄ vpn ⇄ dns transitions, Space toggling the row under the cursor and actually bringing the tunnel up per `nmcli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)