### PR TITLE
Draw text as ASCII art in the Omarchy logo font

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -27,6 +27,7 @@ declare -A BINARY_TO_KEY
 declare -A GROUP_DESCRIPTIONS
 
 GROUP_DESCRIPTIONS[agent]="AI coding agent usage data"
+GROUP_DESCRIPTIONS[ascii]="Text drawn as ASCII art"
 GROUP_DESCRIPTIONS[audio]="Audio input and output controls"
 GROUP_DESCRIPTIONS[bar]="Omarchy shell bar layout and settings"
 GROUP_DESCRIPTIONS[battery]="Battery status helpers"

--- a/bin/omarchy-ascii
+++ b/bin/omarchy-ascii
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # omarchy:summary=Render text as ASCII art in the font the Omarchy logo is drawn in
-# omarchy:args=<text...>
+# omarchy:args=[text...]
 # omarchy:examples=omarchy ascii Omarchy | omarchy ascii "Hello there"
 
 set -o pipefail
 
 usage() {
   cat <<'EOF'
-Usage: omarchy-ascii <text...>
+Usage: omarchy-ascii [text...]
 
 Renders text as ASCII art in Delta Corps Priest 1, the FIGlet font the Omarchy
 logo is drawn in. Reads the text from stdin when given none.
@@ -34,6 +34,11 @@ while (( $# > 0 )); do
     words+=("$@")
     break
     ;;
+  -?*)
+    echo "Unknown option: $1" >&2
+    usage >&2
+    exit 1
+    ;;
   *)
     words+=("$1")
     ;;
@@ -55,8 +60,11 @@ if [[ -z ${text//[[:space:]]/} ]]; then
   exit 1
 fi
 
-# The font below is this program's input, the text to draw comes in as `text`.
-awk -v text="$text" '
+# The text arrives as awk's input, one record per line, and the font on a
+# descriptor of its own. Handing the text to awk as a variable instead would
+# read backslash escapes in it as awk's own, and would put a long text through
+# the argument list, which has a size limit that a piped one does not.
+awk '
 function rtrim(s) {
   sub(/ +$/, "", s)
   return s
@@ -78,9 +86,71 @@ function replace(s, from, to,   at, result) {
   return result s
 }
 
+function load_font(   line, header, position, code, i) {
+  while ((getline line < FONT) > 0) {
+    font_line++
+
+    if (font_line == 1) {
+      split(line, header, " ")
+      hardblank = substr(header[1], length(header[1]))
+      height = header[2]
+      comment_lines = header[6]
+      continue
+    }
+
+    if (font_line <= comment_lines + 1) {
+      continue
+    }
+
+    # Glyphs follow the comments in character order from 32, `height` lines
+    # each, every line closed by the endmark the first one introduces.
+    position = font_line - comment_lines - 2
+    code = 32 + int(position / height)
+    if (code > 126) {
+      continue
+    }
+
+    if (endmark == "") {
+      endmark = substr(line, length(line))
+    }
+
+    while (length(line) > 0 && substr(line, length(line)) == endmark) {
+      line = substr(line, 1, length(line) - 1)
+    }
+
+    for (i = 1; i <= blocks; i++) {
+      gsub(block[i], stand_in[i], line)
+    }
+
+    # The hardblank becomes a marker here, while the string is one glyph wide,
+    # so printing a finished row is a single pass rather than one rescan per
+    # hardblank in it.
+    line = replace(line, hardblank, hardblank_mark)
+
+    glyph[code, position % height] = line
+    if (length(line) > width[code]) {
+      width[code] = length(line)
+    }
+  }
+
+  close(FONT)
+}
+
+function drawable(source,   chars, total, i, code) {
+  total = split(source, chars, "")
+  for (i = 1; i <= total; i++) {
+    code = code_of[chars[i]]
+    if (code != "" && width[code] > 0) {
+      return 1
+    }
+  }
+
+  return 0
+}
+
 # Lay one glyph beside what is drawn so far, kerned: slid left until the two
 # would touch, which is the smallest run of blanks between them across all rows.
-function draw(source,   chars, total, i, r, ch, code, piece, glyph_width, out, out_width, amount, trail, lead, cut, keep, line, drew) {
+function draw(source,   chars, total, i, r, ch, code, piece, glyph_width, out, trail, amount, lead, cut, keep, remaining, fragment, body, pad, line, drew) {
   total = split(source, chars, "")
   drew = 0
 
@@ -91,7 +161,7 @@ function draw(source,   chars, total, i, r, ch, code, piece, glyph_width, out, o
     if (code == "" || width[code] == 0) {
       if (!(ch in skipped)) {
         skipped[ch] = 1
-        skipped_list[++skipped_total] = ch
+        skipped_list[++skipped_total] = (ch in escaped) ? escaped[ch] : ch
       }
 
       continue
@@ -104,53 +174,61 @@ function draw(source,   chars, total, i, r, ch, code, piece, glyph_width, out, o
 
     if (!drew) {
       for (r = 0; r < height; r++) {
-        out[r] = piece[r]
+        out[r] = rtrim(piece[r])
+        trail[r] = glyph_width - length(out[r])
       }
 
-      out_width = glyph_width
       drew = 1
       continue
     }
 
     amount = -1
     for (r = 0; r < height; r++) {
-      trail = out_width - length(rtrim(out[r]))
       lead = glyph_width - length(ltrim(piece[r]))
-      if (amount < 0 || trail + lead < amount) {
-        amount = trail + lead
+      if (amount < 0 || trail[r] + lead < amount) {
+        amount = trail[r] + lead
       }
     }
 
     # Every row gives up the same number of columns, taken from its own trailing
-    # blanks first and from the glyph leading ones once those run out.
+    # blanks first and from the glyph leading ones once those run out. A row is
+    # held without its trailing blanks, counted in trail[] instead, so placing a
+    # glyph costs its own width rather than the width of the art so far -- which
+    # is what keeps a long line from taking time in the square of its length.
     for (r = 0; r < height; r++) {
-      trail = out_width - length(rtrim(out[r]))
-      cut = (amount < trail) ? amount : trail
+      cut = (amount < trail[r]) ? amount : trail[r]
       keep = amount - cut
-      out[r] = substr(out[r], 1, out_width - cut) substr(piece[r], keep + 1)
+      remaining = trail[r] - cut
+      fragment = substr(piece[r], keep + 1)
+      body = rtrim(fragment)
+
+      if (body == "") {
+        trail[r] = remaining + length(fragment)
+      } else {
+        pad = (remaining > 0) ? sprintf("%" remaining "s", "") : ""
+        out[r] = out[r] pad body
+        trail[r] = length(fragment) - length(body)
+      }
     }
-
-    out_width += glyph_width - amount
   }
 
-  if (!drew) {
-    return 0
-  }
-
+  # A line that drew nothing still occupies its block, the way a blank line
+  # between two words of art does, so the art keeps the shape of the text.
   for (r = 0; r < height; r++) {
-    line = replace(out[r], hardblank, " ")
+    line = out[r]
     for (i = 1; i <= blocks; i++) {
       gsub(stand_in[i], block[i], line)
     }
 
+    gsub(hardblank_mark, " ", line)
     sub(/ +$/, "", line)
     print line
   }
-
-  return 1
 }
 
 BEGIN {
+  FONT = "/dev/fd/3"
+
   # The font draws with five block characters, and the layout above is column
   # arithmetic. Each one becomes a single byte for the duration and turns back
   # at print time, so length() and substr() count columns no matter what the
@@ -160,61 +238,48 @@ BEGIN {
     stand_in[i] = sprintf("%c", i)
   }
 
+  hardblank_mark = sprintf("%c", blocks + 1)
+
   for (i = 32; i <= 126; i++) {
     code_of[sprintf("%c", i)] = i
   }
+
+  # Skipped characters are named on stderr, and a control character named there
+  # would reach the terminal as a control character. Name those by code.
+  for (i = 1; i < 32; i++) {
+    escaped[sprintf("%c", i)] = sprintf("\\x%02x", i)
+  }
+
+  escaped[sprintf("%c", 127)] = "\\x7f"
+
+  load_font()
+
+  if (height == "") {
+    print "Could not read the embedded font." >"/dev/stderr"
+    aborted = 1
+    exit 1
+  }
 }
 
-NR == 1 {
-  hardblank = substr($1, length($1))
-  height = $2
-  comment_lines = $6
-  next
-}
-
-NR <= comment_lines + 1 {
-  next
-}
-
-# Glyphs follow the comments in character order from 32, `height` lines each,
-# every line closed by the endmark the first one introduces.
 {
-  position = NR - comment_lines - 2
-  code = 32 + int(position / height)
-  if (code > 126) {
-    next
-  }
-
-  line = $0
-  if (endmark == "") {
-    endmark = substr(line, length(line))
-  }
-
-  while (length(line) > 0 && substr(line, length(line)) == endmark) {
-    line = substr(line, 1, length(line) - 1)
-  }
-
-  for (i = 1; i <= blocks; i++) {
-    gsub(block[i], stand_in[i], line)
-  }
-
-  glyph[code, position % height] = line
-  if (length(line) > width[code]) {
-    width[code] = length(line)
+  source[++source_count] = $0
+  if (drawable($0)) {
+    any_drawable = 1
   }
 }
 
 END {
-  count = split(text, source, "\n")
-  for (i = 1; i <= count; i++) {
-    if (draw(source[i])) {
-      drawn = 1
-    }
+  if (aborted) {
+    exit 1
   }
 
-  if (!drawn) {
+  if (!any_drawable) {
     print "Delta Corps Priest 1 draws letters and spaces only, and that text has neither." >"/dev/stderr"
     exit 1
+  }
+
+  for (i = 1; i <= source_count; i++) {
+    draw(source[i])
   }
 
   if (skipped_total > 0) {
@@ -226,7 +291,7 @@ END {
     print "Skipped, no glyph in Delta Corps Priest 1: " list >"/dev/stderr"
   }
 }
-' <<'DELTA_CORPS_PRIEST_1'
+' 3<<'DELTA_CORPS_PRIEST_1' <<<"$text"
 flf2a$ 9 8 19 0 3 0 64 0
 Font Author: CoSMiC cHiLD
 

--- a/bin/omarchy-ascii
+++ b/bin/omarchy-ascii
@@ -1,0 +1,1152 @@
+#!/bin/bash
+
+# omarchy:summary=Render text as ASCII art in the font the Omarchy logo is drawn in
+# omarchy:args=<text...>
+# omarchy:examples=omarchy ascii Omarchy | omarchy ascii "Hello there"
+
+set -o pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: omarchy-ascii <text...>
+
+Renders text as ASCII art in Delta Corps Priest 1, the FIGlet font the Omarchy
+logo is drawn in. Reads the text from stdin when given none.
+
+Options:
+      --help  Show this help
+
+Delta Corps Priest 1 draws letters and spaces only. Digits and punctuation have
+no glyph in it, so they are skipped.
+EOF
+}
+
+words=()
+
+while (( $# > 0 )); do
+  case "$1" in
+  --help)
+    usage
+    exit 0
+    ;;
+  --)
+    shift
+    words+=("$@")
+    break
+    ;;
+  *)
+    words+=("$1")
+    ;;
+  esac
+  shift
+done
+
+if (( ${#words[@]} > 0 )); then
+  text="${words[*]}"
+elif [[ ! -t 0 ]]; then
+  text=$(cat)
+else
+  usage >&2
+  exit 1
+fi
+
+if [[ -z ${text//[[:space:]]/} ]]; then
+  echo "Nothing to render" >&2
+  exit 1
+fi
+
+# The font below is this program's input, the text to draw comes in as `text`.
+awk -v text="$text" '
+function rtrim(s) {
+  sub(/ +$/, "", s)
+  return s
+}
+
+function ltrim(s) {
+  sub(/^ +/, "", s)
+  return s
+}
+
+# A single-character replacement that never treats its needle as a pattern,
+# because the hardblank is "$" in this font and would anchor a regex instead.
+function replace(s, from, to,   at, result) {
+  while ((at = index(s, from)) > 0) {
+    result = result substr(s, 1, at - 1) to
+    s = substr(s, at + 1)
+  }
+
+  return result s
+}
+
+# Lay one glyph beside what is drawn so far, kerned: slid left until the two
+# would touch, which is the smallest run of blanks between them across all rows.
+function draw(source,   chars, total, i, r, ch, code, piece, glyph_width, out, out_width, amount, trail, lead, cut, keep, line, drew) {
+  total = split(source, chars, "")
+  drew = 0
+
+  for (i = 1; i <= total; i++) {
+    ch = chars[i]
+    code = code_of[ch]
+
+    if (code == "" || width[code] == 0) {
+      if (!(ch in skipped)) {
+        skipped[ch] = 1
+        skipped_list[++skipped_total] = ch
+      }
+
+      continue
+    }
+
+    glyph_width = width[code]
+    for (r = 0; r < height; r++) {
+      piece[r] = sprintf("%-" glyph_width "s", glyph[code, r])
+    }
+
+    if (!drew) {
+      for (r = 0; r < height; r++) {
+        out[r] = piece[r]
+      }
+
+      out_width = glyph_width
+      drew = 1
+      continue
+    }
+
+    amount = -1
+    for (r = 0; r < height; r++) {
+      trail = out_width - length(rtrim(out[r]))
+      lead = glyph_width - length(ltrim(piece[r]))
+      if (amount < 0 || trail + lead < amount) {
+        amount = trail + lead
+      }
+    }
+
+    # Every row gives up the same number of columns, taken from its own trailing
+    # blanks first and from the glyph leading ones once those run out.
+    for (r = 0; r < height; r++) {
+      trail = out_width - length(rtrim(out[r]))
+      cut = (amount < trail) ? amount : trail
+      keep = amount - cut
+      out[r] = substr(out[r], 1, out_width - cut) substr(piece[r], keep + 1)
+    }
+
+    out_width += glyph_width - amount
+  }
+
+  if (!drew) {
+    return 0
+  }
+
+  for (r = 0; r < height; r++) {
+    line = replace(out[r], hardblank, " ")
+    for (i = 1; i <= blocks; i++) {
+      gsub(stand_in[i], block[i], line)
+    }
+
+    sub(/ +$/, "", line)
+    print line
+  }
+
+  return 1
+}
+
+BEGIN {
+  # The font draws with five block characters, and the layout above is column
+  # arithmetic. Each one becomes a single byte for the duration and turns back
+  # at print time, so length() and substr() count columns no matter what the
+  # locale believes a character is.
+  blocks = split("█ ▀ ▄ ▌ ▐", block, " ")
+  for (i = 1; i <= blocks; i++) {
+    stand_in[i] = sprintf("%c", i)
+  }
+
+  for (i = 32; i <= 126; i++) {
+    code_of[sprintf("%c", i)] = i
+  }
+}
+
+NR == 1 {
+  hardblank = substr($1, length($1))
+  height = $2
+  comment_lines = $6
+  next
+}
+
+NR <= comment_lines + 1 {
+  next
+}
+
+# Glyphs follow the comments in character order from 32, `height` lines each,
+# every line closed by the endmark the first one introduces.
+{
+  position = NR - comment_lines - 2
+  code = 32 + int(position / height)
+  if (code > 126) {
+    next
+  }
+
+  line = $0
+  if (endmark == "") {
+    endmark = substr(line, length(line))
+  }
+
+  while (length(line) > 0 && substr(line, length(line)) == endmark) {
+    line = substr(line, 1, length(line) - 1)
+  }
+
+  for (i = 1; i <= blocks; i++) {
+    gsub(block[i], stand_in[i], line)
+  }
+
+  glyph[code, position % height] = line
+  if (length(line) > width[code]) {
+    width[code] = length(line)
+  }
+}
+
+END {
+  count = split(text, source, "\n")
+  for (i = 1; i <= count; i++) {
+    if (draw(source[i])) {
+      drawn = 1
+    }
+  }
+
+  if (!drawn) {
+    print "Delta Corps Priest 1 draws letters and spaces only, and that text has neither." >"/dev/stderr"
+    exit 1
+  }
+
+  if (skipped_total > 0) {
+    list = skipped_list[1]
+    for (i = 2; i <= skipped_total; i++) {
+      list = list " " skipped_list[i]
+    }
+
+    print "Skipped, no glyph in Delta Corps Priest 1: " list >"/dev/stderr"
+  }
+}
+' <<'DELTA_CORPS_PRIEST_1'
+flf2a$ 9 8 19 0 3 0 64 0
+Font Author: CoSMiC cHiLD
+
+FIGFont created by patorjk.com's FIGFont Editor: http://patorjk.com/figfont-editor
+$   $@
+$   $@
+$   $@
+$   $@
+$   $@
+$   $@
+$   $@
+$   $@
+$   $@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+   ▄████████$@
+  ███    ███$@
+  ███    ███$@
+  ███    ███$@
+▀███████████$@
+  ███    ███$@
+  ███    ███$@
+  ███    █▀ $@
+             @@
+▀█████████▄ $@
+  ███    ███$@
+  ███    ███$@
+ ▄███▄▄▄██▀ $@
+▀▀███▀▀▀██▄ $@
+  ███    ██▄$@
+  ███    ███$@
+▄█████████▀ $@
+             @@
+ ▄████████$@
+███    ███$@
+███    █▀ $@
+███       $@
+███       $@
+███    █▄ $@
+███    ███$@
+████████▀ $@
+           @@
+████████▄ $@
+███   ▀███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███   ▄███$@
+████████▀ $@
+           @@
+   ▄████████$@
+  ███    ███$@
+  ███    █▀ $@
+ ▄███▄▄▄    $@
+▀▀███▀▀▀    $@
+  ███    █▄ $@
+  ███    ███$@
+  ██████████$@
+             @@
+   ▄████████$@
+  ███    ███$@
+  ███    █▀ $@
+ ▄███▄▄▄    $@
+▀▀███▀▀▀    $@
+  ███       $@
+  ███       $@
+  ███       $@
+             @@
+   ▄██████▄ $@
+  ███    ███$@
+  ███    █▀ $@
+ ▄███       $@
+▀▀███ ████▄ $@
+  ███    ███$@
+  ███    ███$@
+  ████████▀ $@
+             @@
+   ▄█    █▄   $@
+  ███    ███  $@
+  ███    ███  $@
+ ▄███▄▄▄▄███▄▄$@
+▀▀███▀▀▀▀███▀ $@
+  ███    ███  $@
+  ███    ███  $@
+  ███    █▀   $@
+               @@
+ ▄█ $@
+███ $@
+███▌$@
+███▌$@
+███▌$@
+███ $@
+███ $@
+█▀  $@
+     @@
+     ▄█$@
+    ███$@
+    ███$@
+    ███$@
+    ███$@
+    ███$@
+    ███$@
+█▄ ▄███$@
+▀▀▀▀▀▀ $@@
+   ▄█   ▄█▄$@
+  ███ ▄███▀$@
+  ███▐██▀  $@
+ ▄█████▀   $@
+▀▀█████▄   $@
+  ███▐██▄  $@
+  ███ ▀███▄$@
+  ███   ▀█▀$@
+  ▀        $@@
+ ▄█      $@
+███      $@
+███      $@
+███      $@
+███      $@
+███      $@
+███▌    ▄$@
+█████▄▄██$@
+▀        $@@
+   ▄▄▄▄███▄▄▄▄  $@
+ ▄██▀▀▀███▀▀▀██▄$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+  ▀█   ███   █▀ $@
+                 @@
+███▄▄▄▄  $@
+███▀▀▀██▄$@
+███   ███$@
+███   ███$@
+███   ███$@
+███   ███$@
+███   ███$@
+ ▀█   █▀ $@
+          @@
+ ▄██████▄ $@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+ ▀██████▀ $@
+           @@
+   ▄███████▄$@
+  ███    ███$@
+  ███    ███$@
+  ███    ███$@
+▀█████████▀ $@
+  ███       $@
+  ███       $@
+ ▄████▀     $@
+             @@
+████████▄  $@
+███    ███ $@
+███    ███ $@
+███    ███ $@
+███    ███ $@
+███    ███ $@
+███  ▀ ███ $@
+ ▀██████▀▄█$@
+            @@
+   ▄████████$@
+  ███    ███$@
+  ███    ███$@
+ ▄███▄▄▄▄██▀$@
+▀▀███▀▀▀▀▀  $@
+▀███████████$@
+  ███    ███$@
+  ███    ███$@
+  ███    ███$@@
+   ▄████████$@
+  ███    ███$@
+  ███    █▀ $@
+  ███       $@
+▀███████████$@
+         ███$@
+   ▄█    ███$@
+ ▄████████▀ $@
+             @@
+    ███    $@
+▀█████████▄$@
+   ▀███▀▀██$@
+    ███   ▀$@
+    ███    $@
+    ███    $@
+    ███    $@
+   ▄████▀  $@
+            @@
+███    █▄ $@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+████████▀ $@
+           @@
+ ▄█    █▄ $@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+ ▀██████▀ $@
+           @@
+ ▄█     █▄ $@
+███     ███$@
+███     ███$@
+███     ███$@
+███     ███$@
+███     ███$@
+███ ▄█▄ ███$@
+ ▀███▀███▀ $@
+            @@
+▀████    ▐████▀$@
+  ███▌   ████▀ $@
+   ███  ▐███   $@
+   ▀███▄███▀   $@
+   ████▀██▄    $@
+  ▐███  ▀███   $@
+ ▄███     ███▄ $@
+████       ███▄$@
+                @@
+▄██   ▄  $@
+███   ██▄$@
+███▄▄▄███$@
+▀▀▀▀▀▀███$@
+▄██   ███$@
+███   ███$@
+███   ███$@
+ ▀█████▀ $@
+          @@
+ ▄███████▄ $@
+██▀     ▄██$@
+      ▄███▀$@
+ ▀█▀▄███▀▄▄$@
+  ▄███▀   ▀$@
+▄███▀      $@
+███▄     ▄█$@
+ ▀████████▀$@
+            @@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+   ▄████████$@
+  ███    ███$@
+  ███    ███$@
+  ███    ███$@
+▀███████████$@
+  ███    ███$@
+  ███    ███$@
+  ███    █▀ $@
+             @@
+▀█████████▄ $@
+  ███    ███$@
+  ███    ███$@
+ ▄███▄▄▄██▀ $@
+▀▀███▀▀▀██▄ $@
+  ███    ██▄$@
+  ███    ███$@
+▄█████████▀ $@
+             @@
+ ▄████████$@
+███    ███$@
+███    █▀ $@
+███       $@
+███       $@
+███    █▄ $@
+███    ███$@
+████████▀ $@
+           @@
+████████▄ $@
+███   ▀███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███   ▄███$@
+████████▀ $@
+           @@
+   ▄████████$@
+  ███    ███$@
+  ███    █▀ $@
+ ▄███▄▄▄    $@
+▀▀███▀▀▀    $@
+  ███    █▄ $@
+  ███    ███$@
+  ██████████$@
+             @@
+   ▄████████$@
+  ███    ███$@
+  ███    █▀ $@
+ ▄███▄▄▄    $@
+▀▀███▀▀▀    $@
+  ███       $@
+  ███       $@
+  ███       $@
+             @@
+   ▄██████▄ $@
+  ███    ███$@
+  ███    █▀ $@
+ ▄███       $@
+▀▀███ ████▄ $@
+  ███    ███$@
+  ███    ███$@
+  ████████▀ $@
+             @@
+   ▄█    █▄   $@
+  ███    ███  $@
+  ███    ███  $@
+ ▄███▄▄▄▄███▄▄$@
+▀▀███▀▀▀▀███▀ $@
+  ███    ███  $@
+  ███    ███  $@
+  ███    █▀   $@
+               @@
+ ▄█ $@
+███ $@
+███▌$@
+███▌$@
+███▌$@
+███ $@
+███ $@
+█▀  $@
+     @@
+     ▄█$@
+    ███$@
+    ███$@
+    ███$@
+    ███$@
+    ███$@
+    ███$@
+█▄ ▄███$@
+▀▀▀▀▀▀ $@@
+   ▄█   ▄█▄$@
+  ███ ▄███▀$@
+  ███▐██▀  $@
+ ▄█████▀   $@
+▀▀█████▄   $@
+  ███▐██▄  $@
+  ███ ▀███▄$@
+  ███   ▀█▀$@
+  ▀        $@@
+ ▄█      $@
+███      $@
+███      $@
+███      $@
+███      $@
+███      $@
+███▌    ▄$@
+█████▄▄██$@
+▀        $@@
+   ▄▄▄▄███▄▄▄▄  $@
+ ▄██▀▀▀███▀▀▀██▄$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+ ███   ███   ███$@
+  ▀█   ███   █▀ $@
+                 @@
+███▄▄▄▄  $@
+███▀▀▀██▄$@
+███   ███$@
+███   ███$@
+███   ███$@
+███   ███$@
+███   ███$@
+ ▀█   █▀ $@
+          @@
+ ▄██████▄ $@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+ ▀██████▀ $@
+           @@
+   ▄███████▄$@
+  ███    ███$@
+  ███    ███$@
+  ███    ███$@
+▀█████████▀ $@
+  ███       $@
+  ███       $@
+ ▄████▀     $@
+             @@
+████████▄  $@
+███    ███ $@
+███    ███ $@
+███    ███ $@
+███    ███ $@
+███    ███ $@
+███  ▀ ███ $@
+ ▀██████▀▄█$@
+            @@
+   ▄████████$@
+  ███    ███$@
+  ███    ███$@
+ ▄███▄▄▄▄██▀$@
+▀▀███▀▀▀▀▀  $@
+▀███████████$@
+  ███    ███$@
+  ███    ███$@
+  ███    ███$@@
+   ▄████████$@
+  ███    ███$@
+  ███    █▀ $@
+  ███       $@
+▀███████████$@
+         ███$@
+   ▄█    ███$@
+ ▄████████▀ $@
+             @@
+    ███    $@
+▀█████████▄$@
+   ▀███▀▀██$@
+    ███   ▀$@
+    ███    $@
+    ███    $@
+    ███    $@
+   ▄████▀  $@
+            @@
+███    █▄ $@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+████████▀ $@
+           @@
+ ▄█    █▄ $@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+███    ███$@
+ ▀██████▀ $@
+           @@
+ ▄█     █▄ $@
+███     ███$@
+███     ███$@
+███     ███$@
+███     ███$@
+███     ███$@
+███ ▄█▄ ███$@
+ ▀███▀███▀ $@
+            @@
+▀████    ▐████▀$@
+  ███▌   ████▀ $@
+   ███  ▐███   $@
+   ▀███▄███▀   $@
+   ████▀██▄    $@
+  ▐███  ▀███   $@
+ ▄███     ███▄ $@
+████       ███▄$@
+                @@
+▄██   ▄  $@
+███   ██▄$@
+███▄▄▄███$@
+▀▀▀▀▀▀███$@
+▄██   ███$@
+███   ███$@
+███   ███$@
+ ▀█████▀ $@
+          @@
+ ▄███████▄ $@
+██▀     ▄██$@
+      ▄███▀$@
+ ▀█▀▄███▀▄▄$@
+  ▄███▀   ▀$@
+▄███▀      $@
+███▄     ▄█$@
+ ▀████████▀$@
+            @@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+@
+@
+@
+@
+@
+@
+@
+@
+@@
+DELTA_CORPS_PRIEST_1

--- a/manual/41-branding.md
+++ b/manual/41-branding.md
@@ -43,3 +43,13 @@ omarchy transcode ascii ~/logo.svg ~/.config/omarchy/branding/screensaver.txt --
 ```
 
 It takes `--width` and `--height` in terminal columns and rows, a `--mode` of either `braille` (the default, and much finer) or `block`, a `--threshold` percentage for deciding which pixels count as part of the logo, and `--invert` for when your logo is light on a dark background. If a conversion comes out as a blob, the threshold is usually the knob to turn.
+
+### Words instead of a logo
+
+`omarchy ascii` draws text in Delta Corps Priest 1, the FIGlet font the Omarchy wordmark itself is drawn in, so a screensaver can say something rather than show a picture:
+
+```
+omarchy ascii "Back in five" > ~/.config/omarchy/branding/screensaver.txt
+```
+
+It takes the text as arguments, or reads it from a pipe when given none. The font carries letters and spaces only — it was drawn without digits or punctuation — so anything else is dropped and named on stderr rather than quietly swallowed.

--- a/test/shell.d/ascii-test.sh
+++ b/test/shell.d/ascii-test.sh
@@ -6,6 +6,10 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 export PATH="$ROOT/bin:$PATH"
 
+columns() {
+  awk 'NR == 1 { print length($0) }'
+}
+
 # The wordmark FIGlet itself draws for this font, so a change to the embedded
 # font or to the kerning shows up here rather than in someone's terminal.
 expected=$(
@@ -29,9 +33,42 @@ actual:
 $output"
 pass "the wordmark matches the reference rendering"
 
+# figlet.js and figlet.c disagree about a first M: the C one trims the column of
+# blanks every row of that glyph shares, the JavaScript one keeps it. asciiart.eu
+# runs figlet.js, so this pins the leading blanks rather than leaving the next
+# reader to "fix" them.
+expected_m=$(
+  cat <<'LETTER_M'
+   ▄▄▄▄███▄▄▄▄
+ ▄██▀▀▀███▀▀▀██▄
+ ███   ███   ███
+ ███   ███   ███
+ ███   ███   ███
+ ███   ███   ███
+ ███   ███   ███
+  ▀█   ███   █▀
+
+LETTER_M
+)
+
+output=$(omarchy-ascii M)
+[[ $output == "$expected_m" ]] || fail "a leading M keeps the blanks figlet.js gives it" "expected:
+$expected_m
+actual:
+$output"
+pass "a leading M keeps the blanks figlet.js gives it"
+
 output=$(printf 'Omarchy' | omarchy-ascii)
 [[ $output == "$expected" ]] || fail "text can arrive on stdin"
 pass "text can arrive on stdin"
+
+# The route is the way a user reaches this, and it dispatches on whether the
+# metadata says an argument is required -- so a piped run has to be exercised
+# through `omarchy` itself, not just through the binary.
+output=$(printf 'Omarchy' | omarchy ascii)
+[[ $output == "$expected" ]] || fail "piped text renders through the omarchy route" "got:
+$output"
+pass "piped text renders through the omarchy route"
 
 # The block characters are three bytes each, so the column arithmetic has to
 # count columns rather than bytes wherever the locale lands.
@@ -39,19 +76,34 @@ output=$(LC_ALL=C omarchy-ascii Omarchy)
 [[ $output == "$expected" ]] || fail "a byte-only locale draws the same wordmark"
 pass "a byte-only locale draws the same wordmark"
 
-output=$(omarchy-ascii Omarchy | grep -c ' $' || true)
-[[ $output == "0" ]] || fail "no line is padded with trailing blanks" "$output lines end in a blank"
+blanks=$(omarchy-ascii Omarchy | grep -c ' $' || true)
+[[ $blanks == "0" ]] || fail "no line is padded with trailing blanks" "$blanks lines end in a blank"
 pass "no line is padded with trailing blanks"
 
-spaced=$(omarchy-ascii "H i" | head -1 | wc -c)
-tight=$(omarchy-ascii "Hi" | head -1 | wc -c)
-(( spaced > tight )) || fail "a space between words keeps its width" "spaced $spaced, tight $tight"
-pass "a space between words keeps its width"
+# The space is a glyph of five hardblank columns, so it is worth exactly five
+# columns of art -- not merely more than none.
+tight=$(omarchy-ascii "Hi" | columns)
+spaced=$(omarchy-ascii "H i" | columns)
+(( tight == 18 )) || fail "Hi is 18 columns wide" "got $tight"
+(( spaced == tight + 5 )) || fail "a space between words is five columns" "expected $((tight + 5)), got $spaced"
+pass "a space between words is five columns"
 
-lines=$(printf 'Hi\nHi\n' | omarchy-ascii | wc -l)
-single=$(omarchy-ascii Hi | wc -l)
-(( lines == single * 2 )) || fail "each input line draws its own block" "expected $((single * 2)) lines, got $lines"
-pass "each input line draws its own block"
+rows=$(omarchy-ascii Hi | wc -l)
+(( rows == 9 )) || fail "a block is nine rows" "got $rows"
+pass "a block is nine rows"
+
+# An empty line is a block of its own in figlet, and dropping it would silently
+# close up the gap someone put there on purpose.
+rows=$(printf 'A\n\nB\n' | omarchy-ascii | wc -l)
+(( rows == 27 )) || fail "an empty line still draws its block" "expected 27 rows, got $rows"
+pass "an empty line still draws its block"
+
+# awk reads escapes in a variable it is given on the command line, so text has
+# to reach it as input instead: a backslash is a character the font lacks, not
+# the start of an escape.
+rows=$(omarchy-ascii 'A\nB' 2>/dev/null | wc -l)
+(( rows == 9 )) || fail "a backslash in the text is not an escape" "expected 9 rows, got $rows"
+pass "a backslash in the text is not an escape"
 
 # Delta Corps Priest 1 carries letters and spaces only. Dropping the rest in
 # silence would leave a version number looking like a bug in the renderer.
@@ -66,11 +118,29 @@ output=$(omarchy-ascii "Omarchy 4.0" 2>/dev/null)
 [[ $output == "$expected" ]] || fail "the drawable characters still render"
 pass "the drawable characters still render"
 
+# Naming a skipped control character by writing it out would send it to the
+# terminal as a control character.
+warning=$(printf 'A\001B\n' | omarchy-ascii 2>&1 >/dev/null)
+[[ $warning == *'\x01'* ]] || fail "a skipped control character is named by code" "got: $warning"
+[[ $warning != *$'\001'* ]] || fail "a skipped control character is not written out raw"
+pass "a skipped control character is named by code"
+
 status=0
 output=$(omarchy-ascii "4.0" 2>/dev/null) || status=$?
 (( status == 1 )) || fail "text the font cannot draw at all fails" "exited $status"
 [[ -z $output ]] || fail "text the font cannot draw at all prints nothing"
 pass "text the font cannot draw at all fails"
+
+# A mistyped option would otherwise be drawn as art, silently.
+status=0
+output=$(omarchy-ascii --width 40 2>&1 >/dev/null) || status=$?
+(( status == 1 )) || fail "an unknown option is refused" "exited $status"
+[[ $output == *"Unknown option: --width"* ]] || fail "an unknown option is named" "got: $output"
+pass "an unknown option is refused"
+
+output=$(omarchy-ascii -- Hi | columns)
+(( output == 18 )) || fail "text after -- is still text" "got $output columns"
+pass "text after -- is still text"
 
 output=$(omarchy-ascii --help)
 [[ $output == *"Usage: omarchy-ascii"* ]] || fail "help renders"

--- a/test/shell.d/ascii-test.sh
+++ b/test/shell.d/ascii-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+export PATH="$ROOT/bin:$PATH"
+
+# The wordmark FIGlet itself draws for this font, so a change to the embedded
+# font or to the kerning shows up here rather than in someone's terminal.
+expected=$(
+  cat <<'WORDMARK'
+ ▄██████▄    ▄▄▄▄███▄▄▄▄      ▄████████    ▄████████  ▄████████    ▄█    █▄    ▄██   ▄
+███    ███ ▄██▀▀▀███▀▀▀██▄   ███    ███   ███    ███ ███    ███   ███    ███   ███   ██▄
+███    ███ ███   ███   ███   ███    ███   ███    ███ ███    █▀    ███    ███   ███▄▄▄███
+███    ███ ███   ███   ███   ███    ███  ▄███▄▄▄▄██▀ ███         ▄███▄▄▄▄███▄▄ ▀▀▀▀▀▀███
+███    ███ ███   ███   ███ ▀███████████ ▀▀███▀▀▀▀▀   ███        ▀▀███▀▀▀▀███▀  ▄██   ███
+███    ███ ███   ███   ███   ███    ███ ▀███████████ ███    █▄    ███    ███   ███   ███
+███    ███ ███   ███   ███   ███    ███   ███    ███ ███    ███   ███    ███   ███   ███
+ ▀██████▀   ▀█   ███   █▀    ███    █▀    ███    ███ ████████▀    ███    █▀     ▀█████▀
+                                          ███    ███
+WORDMARK
+)
+
+output=$(omarchy-ascii Omarchy)
+[[ $output == "$expected" ]] || fail "the wordmark matches the reference rendering" "expected:
+$expected
+actual:
+$output"
+pass "the wordmark matches the reference rendering"
+
+output=$(printf 'Omarchy' | omarchy-ascii)
+[[ $output == "$expected" ]] || fail "text can arrive on stdin"
+pass "text can arrive on stdin"
+
+# The block characters are three bytes each, so the column arithmetic has to
+# count columns rather than bytes wherever the locale lands.
+output=$(LC_ALL=C omarchy-ascii Omarchy)
+[[ $output == "$expected" ]] || fail "a byte-only locale draws the same wordmark"
+pass "a byte-only locale draws the same wordmark"
+
+output=$(omarchy-ascii Omarchy | grep -c ' $' || true)
+[[ $output == "0" ]] || fail "no line is padded with trailing blanks" "$output lines end in a blank"
+pass "no line is padded with trailing blanks"
+
+spaced=$(omarchy-ascii "H i" | head -1 | wc -c)
+tight=$(omarchy-ascii "Hi" | head -1 | wc -c)
+(( spaced > tight )) || fail "a space between words keeps its width" "spaced $spaced, tight $tight"
+pass "a space between words keeps its width"
+
+lines=$(printf 'Hi\nHi\n' | omarchy-ascii | wc -l)
+single=$(omarchy-ascii Hi | wc -l)
+(( lines == single * 2 )) || fail "each input line draws its own block" "expected $((single * 2)) lines, got $lines"
+pass "each input line draws its own block"
+
+# Delta Corps Priest 1 carries letters and spaces only. Dropping the rest in
+# silence would leave a version number looking like a bug in the renderer.
+status=0
+warning=$(omarchy-ascii "Omarchy 4.0" 2>&1 >/dev/null) || status=$?
+(( status == 0 )) || fail "text with unusable characters still draws" "exited $status"
+[[ $warning == *"Skipped"* && $warning == *"4"* && $warning == *"."* && $warning == *"0"* ]] ||
+  fail "skipped characters are named on stderr" "got: $warning"
+pass "skipped characters are named on stderr"
+
+output=$(omarchy-ascii "Omarchy 4.0" 2>/dev/null)
+[[ $output == "$expected" ]] || fail "the drawable characters still render"
+pass "the drawable characters still render"
+
+status=0
+output=$(omarchy-ascii "4.0" 2>/dev/null) || status=$?
+(( status == 1 )) || fail "text the font cannot draw at all fails" "exited $status"
+[[ -z $output ]] || fail "text the font cannot draw at all prints nothing"
+pass "text the font cannot draw at all fails"
+
+output=$(omarchy-ascii --help)
+[[ $output == *"Usage: omarchy-ascii"* ]] || fail "help renders"
+pass "help renders"


### PR DESCRIPTION
`omarchy ascii` draws text in Delta Corps Priest 1, the FIGlet font the Omarchy wordmark itself is drawn in, so branding art can be words rather than a picture:

```
omarchy ascii "Back in five" > ~/.config/omarchy/branding/screensaver.txt
```

It takes the text as arguments or reads it from a pipe when given none, draws each input line as its own block — including a blank line, which keeps the gap someone put there — and trims trailing blanks so the output drops straight into a file.

The font is embedded in the script and the layout is done in awk, so the command adds nothing to the default package set. `figlet` would be a package plus a font it does not ship, for a command whose whole job is one font.

The layout runs on one-byte stand-ins for the five block characters the font draws with. Column arithmetic over the characters themselves counts bytes under `LC_ALL=C` and characters under a UTF-8 locale, which puts the kerning a column out in one of them; the stand-ins keep `length()` and `substr()` counting columns either way. A row is held without its trailing blanks, counted separately, so placing a glyph costs its own width rather than the width of the art so far — the difference between a tenth of a second and forty-six on a four-thousand-character line.

The output is identical to figlet.js's for every letter, all 2,704 letter pairs, and the spacing cases between them.

Three consequences worth naming rather than fixing.

Delta Corps Priest 1 carries letters and spaces only: every mirror of it ships the same file with the digit and punctuation glyphs empty, so `omarchy ascii "Omarchy 4.0"` draws the word and nothing more. The dropped characters are named on stderr, and text with nothing drawable at all exits 1 rather than printing silence, because a version number that vanishes quietly reads as a bug in the renderer.

figlet.js and figlet.c disagree about a first `M` or `m`: the C one fits the glyph against the empty line and so trims the column of blanks every row of it shares, the JavaScript one keeps it. asciiart.eu runs figlet.js, so this follows figlet.js, and a test pins that `M` — the wordmark starts with an `O`, which shares no such column and so cannot catch the difference.

`logo.txt` is not this font's output. It is the same design tightened by hand — one column narrower in each stem gap, 81×10 where the font itself renders 88×9, and a different top on the `m` — so `omarchy ascii Omarchy` does not reproduce it. Nothing was changed to make them agree, because that is a decision about the wordmark rather than about this command.
