### PR TITLE
Guard three x86-only assumptions so Omarchy can install on aarch64

### DIFF
--- a/etc/mkinitcpio.conf.d/thunderbolt_module.conf
+++ b/etc/mkinitcpio.conf.d/thunderbolt_module.conf
@@ -1,1 +1,7 @@
-MODULES+=(thunderbolt)
+# Thunderbolt is x86-oriented hardware and the module is not built for every
+# architecture -- ALARM's aarch64 kernel has no `thunderbolt`. mkinitcpio treats
+# an unresolvable MODULES entry as an error, which fails every initramfs build
+# on such a system, so gate it rather than forcing it unconditionally.
+if [[ $(uname -m) == x86_64 ]]; then
+  MODULES+=(thunderbolt)
+fi

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -1,13 +1,31 @@
 # Configure pacman after package installation completes. Offline target package
 # installs use the live ISO's offline pacman.conf until this final restore.
-# Omarchy's pacman.conf points [core]/[extra]/[multilib] at Omarchy's mirror of
-# Arch (x86_64 only) and [omarchy] at pkgs.omarchy.org/$arch, which 404s for
-# aarch64. Applying it on ARM leaves the installed system unable to update at
-# all, so keep the working configuration there.
-if [[ $(uname -m) == x86_64 ]]; then
-  cp -f "$OMARCHY_PATH/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf" /etc/pacman.conf
-  cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-${OMARCHY_MIRROR:-stable}" /etc/pacman.d/mirrorlist
-fi
+case "$(uname -m)" in
+  aarch64)
+    # Omarchy's pacman.conf and mirrorlist describe an x86_64 Arch system:
+    # [multilib] is 32-bit x86 libraries and no ARM mirror carries it, and the
+    # mirrorlist points at Omarchy's mirror of Arch, which is x86_64 only.
+    # Arch Linux ARM also lays its tree out as $arch/$repo rather than Arch's
+    # $repo/os/$arch, so the mirrorlist cannot be reused with a different host.
+    #
+    # Derive the config from Omarchy's instead: drop [multilib], keep [omarchy]
+    # (its $arch placeholder resolves correctly), add Arch Linux ARM's own
+    # [alarm] and [aur] repositories, and leave the mirrorlist the distribution
+    # installed. Skipping this step is not an option: the live ISO's pacman.conf
+    # only knows the offline mirror, which does not exist on the installed system.
+    awk '
+      /^\[multilib\]$/ { skip = 1; next }
+      /^\[/            { skip = 0 }
+      skip             { next }
+      { print }
+    ' "$OMARCHY_PATH/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf" >/etc/pacman.conf
+    printf '\n[alarm]\nInclude = /etc/pacman.d/mirrorlist\n\n[aur]\nInclude = /etc/pacman.d/mirrorlist\n' >>/etc/pacman.conf
+    ;;
+  *)
+    cp -f "$OMARCHY_PATH/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf" /etc/pacman.conf
+    cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-${OMARCHY_MIRROR:-stable}" /etc/pacman.d/mirrorlist
+    ;;
+esac
 
 # omarchy-settings skips this override until cups-browsed is actually present
 # to avoid pacman creating cups-browsed.conf.pacnew during ISO package install.

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -1,7 +1,13 @@
 # Configure pacman after package installation completes. Offline target package
 # installs use the live ISO's offline pacman.conf until this final restore.
-cp -f "$OMARCHY_PATH/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf" /etc/pacman.conf
-cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-${OMARCHY_MIRROR:-stable}" /etc/pacman.d/mirrorlist
+# Omarchy's pacman.conf points [core]/[extra]/[multilib] at Omarchy's mirror of
+# Arch (x86_64 only) and [omarchy] at pkgs.omarchy.org/$arch, which 404s for
+# aarch64. Applying it on ARM leaves the installed system unable to update at
+# all, so keep the working configuration there.
+if [[ $(uname -m) == x86_64 ]]; then
+  cp -f "$OMARCHY_PATH/default/pacman/pacman-${OMARCHY_MIRROR:-stable}.conf" /etc/pacman.conf
+  cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-${OMARCHY_MIRROR:-stable}" /etc/pacman.d/mirrorlist
+fi
 
 # omarchy-settings skips this override until cups-browsed is actually present
 # to avoid pacman creating cups-browsed.conf.pacnew during ISO package install.

--- a/install/user/mise-work.sh
+++ b/install/user/mise-work.sh
@@ -19,7 +19,12 @@ case ${OMARCHY_SETUP_CONTEXT:-runtime} in
 esac
 
 if [[ -n $NODE_PACKAGE_DIR ]]; then
-  NODE_TARBALL=$(find "$NODE_PACKAGE_DIR" -name "node-v*-linux-x64.tar.gz" -type f 2>/dev/null | head -n1)
+  # Node names its builds x64/arm64, not by uname
+  case "$(uname -m)" in
+    aarch64) _NODE_ARCH=arm64 ;;
+    *)       _NODE_ARCH=x64   ;;
+  esac
+  NODE_TARBALL=$(find "$NODE_PACKAGE_DIR" -name "node-v*-linux-${_NODE_ARCH}.tar.gz" -type f 2>/dev/null | head -n1)
   if [[ -z $NODE_TARBALL ]]; then
     if [[ ${OMARCHY_SETUP_CONTEXT:-} == "provision-owner" ]]; then
       # A factory snapshot predating the bundled tarball may not have it staged.
@@ -31,7 +36,7 @@ if [[ -n $NODE_PACKAGE_DIR ]]; then
       exit 1
     fi
   else
-    NODE_VERSION=$(basename "$NODE_TARBALL" | sed 's/node-v\(.*\)-linux-x64.tar.gz/\1/')
+    NODE_VERSION=$(basename "$NODE_TARBALL" | sed "s/node-v\\(.*\\)-linux-${_NODE_ARCH}.tar.gz/\\1/")
     NODE_INSTALL_DIR="$HOME/.local/share/mise/installs/node/$NODE_VERSION"
 
     mkdir -p "$NODE_INSTALL_DIR"


### PR DESCRIPTION
Three unconditional assumptions in the install path only hold on x86_64. None is
x86-specific in spirit, and each one blocks or breaks an ARM64 install. All three were
found by actually installing Omarchy on aarch64 (Arch Linux ARM) and are fixed the same
way: derive from `uname -m` instead of assuming.

### 1. `etc/mkinitcpio.conf.d/thunderbolt_module.conf`

`MODULES+=(thunderbolt)` is unconditional, but Thunderbolt is x86-oriented hardware and the
module isn't built for every architecture. ALARM's aarch64 kernel has no `thunderbolt`, and
mkinitcpio treats an unresolvable `MODULES` entry as a hard error, so **every** initramfs
build fails:

```
==> ERROR: module not found: `thunderbolt'
```

No initramfs means no UKI, no boot entry, and an install that completes and then can't boot.
Because bootloader setup is the last phase, the failure surfaces as *"no operating system
installed"* at the firmware, which points at the wrong end of the process entirely.

### 2. `install/post-install/pacman.sh`

This overwrites `/etc/pacman.conf` and the mirrorlist unconditionally with files that
describe an x86_64 Arch system: `[multilib]` is 32-bit x86 libraries and exists on no ARM
mirror, and the mirrorlist points at Omarchy's mirror of Arch, which is x86_64 only. Arch
Linux ARM also lays its tree out as `$arch/$repo` rather than Arch's `$repo/os/$arch`, so
the mirrorlist can't simply be pointed at a different host.

The first revision of this PR skipped the restore on aarch64. That was wrong: at this point
the target still carries the live ISO's `pacman.conf`, which knows only the offline mirror,
and that directory doesn't exist on the installed system. Skipping left every aarch64
install unable to run pacman at all.

This revision derives the config from Omarchy's template instead: drop `[multilib]`, keep
`[omarchy]` (its `$arch` placeholder resolves correctly), add ALARM's `[alarm]` and `[aur]`
repositories, and leave the mirrorlist the distribution installed. The `[options]` block
and everything else in the template come through unchanged, so `OMARCHY_MIRROR` still
selects stable/edge/rc as it does on x86.

> **Known gap, not addressed here:** `pkgs.omarchy.org` has no aarch64 tree yet
> (omacom-io/omarchy-pkgs#199), so `[omarchy]` 404s on ARM. pacman refuses all sync
> transactions while a configured repository's database is missing, so until that tree is
> published an aarch64 install can't `pacman -S` anything. The config written here is the
> one that starts working the moment the tree exists; omitting `[omarchy]` would work today
> and then never update Omarchy.

### 3. `install/user/mise-work.sh`

Node publishes its builds as `linux-x64` / `linux-arm64`, which does **not** match
`uname -m`. The bundled-tarball lookup hardcodes `linux-x64`, so on ARM it finds nothing and
the install aborts:

```
failed phase: Staging provisioning: no bundled Node tarball in /opt/packages
```

The `sed` that parses the version back out of the filename needs the same treatment,
otherwise it silently yields the whole filename instead of the version.

### Testing

On Arch Linux ARM aarch64, natively rather than under emulation:

- **Each guard, both branches.** `thunderbolt_module.conf` sourced with `uname -m` faked to
  each architecture yields `MODULES=(thunderbolt)` on x86_64 and empty on aarch64, and a
  real `mkinitcpio` run with the guarded file succeeds on a kernel without the module.
  `mise-work.sh`'s lookup and `sed` were run against `node-v24.7.0-linux-{x64,arm64}.tar.gz`
  under both architectures; each finds its own tarball and extracts `24.7.0`, and the
  upstream x86 `sed` gives the same answer on the x64 file.
- **`pacman.sh`, sandboxed, all three mirrors.** With `/etc` redirected, the script was run
  for `stable`, `edge` and `rc` on aarch64: `[multilib]` gone, `[options]` byte-identical to
  the template, the mirrorlist untouched, and `pacman-conf --repo-list` parses the result as
  `core extra omarchy alarm aur`. With `uname -m` faked to x86_64 the output is
  byte-identical to the plain `cp` of both files. A live `pacman -Sy` against the stable
  output synced `core`, `extra`, `alarm` and `aur` from ALARM's mirror; only `omarchy`
  failed, with the 404 described above.
- **Full install.** `omarchy` and `omarchy-settings` packages built from this branch went
  into an ISO (omacom-io/omarchy-iso#121), which installed to an encrypted target and
  booted unattended into the desktop. On the installed system `/etc/pacman.conf` is the
  derived one, the mirrorlist is the one ALARM's `pacman-mirrorlist` installed, and
  `pacman -Sy` syncs `core`, `extra`, `alarm` and `aur` with no errors; the only failure is
  `omarchy.db`, the 404 described above.

  The first run of this test also showed the installer prepending three x86 Arch mirrors to
  the target's mirrorlist, so every sync walked through a dozen 404s before reaching ALARM's.
  That is the ISO's configurator, not this repository, and is fixed in omarchy-iso#121.

All three files pass `bash -n` and ShellCheck. No behaviour change on x86_64: each guard
takes the existing path there, and `pacman.sh`'s x86_64 branch is the unchanged two-line copy.
