### PR TITLE
Match Brave refresh on binary path to avoid Origin collision

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -40,7 +40,7 @@ set_browser_policy /etc/opt/edge/policies/managed
 refresh_running_browser msedge microsoft-edge-stable
 
 set_browser_policy /etc/brave/policies/managed
-refresh_running_browser brave brave
-# Match on the binary path: the running process is named plain "brave", and a
-# bare -f brave-origin pattern would also match the installer's own terminal.
+# Match on binary paths: both Brave packages run processes named plain "brave",
+# and a bare -f brave-origin pattern would also match the installer's terminal.
+refresh_running_browser /opt/brave-bin/ brave -f
 refresh_running_browser /opt/brave-origin-bin/ brave-origin -f


### PR DESCRIPTION
Brave and Brave Origin both run as `brave`, so the regular Brave check also matches Brave Origin. This can launch a hidden regular Brave instance that blocks `omarchy-theme-set-browser` and `omarchy-update`.

Match regular Brave by `/opt/brave-bin/`, mirroring the existing path-based check for Brave Origin.