### PR TITLE
Remember the menu cursor when going back to a parent menu

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -729,7 +729,12 @@ Item {
   function setActiveMenu(id, pushHistory, fromPointer) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
+    if (pushHistory && id !== root.activeMenu) {
+      var leaving = root.cursorActive && root.rowSelectable(root.selectedIndex)
+        ? displayModel.get(root.selectedIndex).itemId
+        : ""
+      root.navStack = root.navStack.concat([{ menu: root.activeMenu, itemId: leaving }])
+    }
     root.activeMenu = id
     root.filterText = ""
     root.selectedIndex = 0
@@ -747,7 +752,14 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous, false)
+      root.setActiveMenu(previous.menu, false)
+      // setActiveMenu parks the cursor on the first row, which is what going
+      // into a menu wants and what coming back out of one does not: the row
+      // that opened this submenu is where the cursor was left. It has just
+      // been rebuilt unfiltered, so look the row up by id rather than trusting
+      // where it sat on the way in. Nothing found leaves settleCursor's pick.
+      var restored = MenuModel.rowIndexOfItem(displayModel, previous.itemId)
+      if (restored >= 0) root.selectedIndex = restored
       return true
     }
 

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -384,6 +384,29 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
   }
 }
 
+// Where a row lives in the current list, found by its id. `rows` is the live
+// display list -- the QML ListModel at runtime, anything with `count` and
+// `get(i)` in tests.
+//
+// Going back to a parent menu clears its filter and rebuilds it from scratch,
+// so a row's position on the way in says nothing about its position on the way
+// out: filtering the root to "Style" puts that row at index 0, which is where
+// "Apps" sits once the filter is gone. The id is the row's identity; the index
+// is only ever true of one build of the list.
+//
+// A disabled row reports -1 like a missing one. The cursor never parks
+// somewhere Enter would do nothing.
+function rowIndexOfItem(rows, itemId) {
+  if (!itemId) return -1
+
+  for (var i = 0; i < rows.count; i++) {
+    var row = rows.get(i)
+    if (row.itemId === itemId) return row.disabled ? -1 : i
+  }
+
+  return -1
+}
+
 // Commands a `checked:` expression reads a value out of. Every sibling row
 // asks the same one -- Defaults > Browser has seven rows all comparing
 // against `omarchy-default-browser` -- so the batch runs it once and the rows
@@ -519,6 +542,7 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    rowIndexOfItem: rowIndexOfItem
   }
 }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -493,6 +493,61 @@ assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
   'menu Left key follows empty-filter Backspace navigation'
 )
+// Entering a submenu records which row was under the cursor, so leaving it
+// again lands on that row instead of the top of the list. The row is
+// remembered by id: going back clears the filter and rebuilds the parent from
+// scratch, so where the row sat on the way in says nothing about where it sits
+// on the way out.
+const navMerged = menu.mergeMenuSources([
+  menu.normalizeItem('root', { label: 'Go' }),
+  menu.normalizeItem('apps', { label: 'Apps' }),
+  menu.normalizeItem('style', { label: 'Style' }),
+  menu.normalizeItem('style.theme', { label: 'Themes', action: 'omarchy-theme-set' }),
+  menu.normalizeItem('install', { label: 'Install', disabled: 'already-have-it' })
+], [])
+// Stands in for the QML ListModel the rows live in at runtime.
+const navModel = rows => ({ count: rows.length, get: index => rows[index] })
+const navRow = (id, disabledResults) => menu.displayRow(
+  navMerged.items, navMerged.itemOrder, {}, disabledResults || {}, navMerged.items[id], '', 0
+)
+const navRootRows = disabledResults => ['apps', 'style', 'install'].map(id => navRow(id, disabledResults))
+
+// Filtering the root to "style" leaves the Style row alone at index 0 -- the
+// same slot Apps occupies once the filter is gone, since navRootRows builds
+// ['apps', 'style', 'install'] in that order.
+const navFiltered = navRootRows().filter(row => menu.matchesQuery(navMerged.items[row.itemId], 'style', true))
+assertEqual(navFiltered.length, 1, 'menu filtered root fixture matches Style alone')
+assertEqual(navFiltered[0].itemId, 'style', 'menu filtered root puts Style at index 0')
+
+assertEqual(
+  menu.rowIndexOfItem(navModel(navRootRows()), navFiltered[0].itemId),
+  1,
+  'menu finds the remembered row by id after the parent is rebuilt unfiltered'
+)
+assertEqual(
+  menu.rowIndexOfItem(navModel(navRootRows()), 'style.theme'),
+  -1,
+  'menu reports no row when the remembered id is not in the rebuilt parent'
+)
+assertEqual(
+  menu.rowIndexOfItem(navModel(navRootRows()), ''),
+  -1,
+  'menu reports no row when there was no cursor to remember'
+)
+assertEqual(
+  menu.rowIndexOfItem(navModel(navRootRows({ install: true })), 'install'),
+  -1,
+  'menu refuses to restore the cursor onto a row that has since been disabled'
+)
+
+assert(
+  /root\.navStack = root\.navStack\.concat\(\[\{ menu: root\.activeMenu, itemId: leaving \}\]\)/.test(menuQml),
+  'menu remembers the id of the row it is leaving behind, not its position'
+)
+assert(
+  /function goBack\(\)[\s\S]*?root\.setActiveMenu\(previous\.menu, false\)[\s\S]*?var restored = MenuModel\.rowIndexOfItem\(displayModel, previous\.itemId\)\s*\n\s*if \(restored >= 0\) root\.selectedIndex = restored/.test(menuQml),
+  'menu going back resolves the remembered row id against the rebuilt list'
+)
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),
   'menu uses shared pointer movement gate in card coordinates'


### PR DESCRIPTION
I found it irritating when exploring the sub-menues that you always have to "restart" from top, changing the behavior to remember last selected item:

https://github.com/user-attachments/assets/c86b42f3-2c84-4ed6-9d8d-0626c65a7946

