### PR TITLE
Remove the sudo lockout reset command

### DIFF
--- a/bin/omarchy-sudo-reset
+++ b/bin/omarchy-sudo-reset
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# omarchy:summary=Reset the sudo lockout/faillock for the current user.
-
-su -c "faillock --reset --user $USER"


### PR DESCRIPTION
`omarchy sudo reset` was a single line, and that line handed an environment variable to a root shell:

```bash
su -c "faillock --reset --user $USER"
```

`$USER` is an environment variable rather than a kernel-supplied identity, so whatever set it before the command ran chose the rest of the string root's shell would execute: with `USER='dhh; curl … | sh'`, `su` is asked to run `faillock --reset --user dhh; curl … | sh`. This is not a way past PAM on its own — `su` still has to authenticate, and an attacker who could already run `su` as root would not need the detour. What makes it worth removing rather than quoting is the prompt it puts in front of the user. `install/provisioning/setup-form.sh` sets root's password to the user's own ("Used for user + root"), and `bin/omarchy-provision-owner` does the same on deferred provisioning, so the password `su` asks for is the one the user types into sudo prompts all day, at a prompt a documented Omarchy command just raised.

It bought little in return. Omarchy's PAM configuration sets `deny=10 unlock_time=120` on `/etc/pam.d/system-auth` (`install/config/increase-lockout-limit.sh`) and on the lock screen's own stack (`bin/omarchy-apply-lock`), so a lockout takes ten wrong passwords to reach and clears itself two minutes later. For anyone who would rather not wait, `manual/45-troubleshooting.md` documents the TTY-and-root reset, which still works and is unaffected by this change. Nothing in the repository called the command; the CLI router was its only caller.

The `sudo` group keeps `keepalive` and `passwordless`, so `GROUP_DESCRIPTIONS[sudo]` is unchanged, and `omarchy sudo reset` now falls through to the router's unknown-command path. No migration is needed: `bin/omarchy-*` ships as files in the `omarchy` package, so an upgrade drops what the package no longer contains — the same handling every previous command removal has had.

One reference survives on purpose. `basecamp/omarchy-iso`'s `manifests/fresh-4-semantic.json` lists `omarchy-sudo-reset` among the commands a built v4 image contained. That file is a capture of what shipped rather than a live index, and editing it would falsify the record.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
