### PR TITLE
Dismiss screensaver on pointer motion

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -7,6 +7,7 @@ screensaver_in_focus() {
 }
 
 exit_screensaver() {
+  printf '\033[?1003l\033[?1006l'  # Stop mouse reporting before the pty goes away
   hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
   pkill -x ttfx 2>/dev/null
   pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null
@@ -33,7 +34,25 @@ wait_for_terminal_resize() {
   done
 }
 
+# ttfx never enables mouse reporting, so pointer motion never reaches this
+# script's stdin and only a keypress can dismiss the screensaver. Any-event
+# tracking makes the terminal deliver motion, so the read loop below exits on
+# pointer input too.
+#
+# Arm it late: omarchy-launch-screensaver focuses each monitor in turn, warping
+# the pointer on multi-monitor setups, and a warp that lands after arming reads
+# as user input and dismisses the screensaver on sight.
+arm_mouse_reporting() {
+  local settle_seconds=1
+  sleep $settle_seconds
+  printf '\033[?1003h\033[?1006h'
+}
+
 wait_for_terminal_resize
+
+# Backgrounded so the read loop starts now, keeping the keyboard responsive from
+# the first frame; the mouse joins once reporting is armed.
+arm_mouse_reporting &
 
 while true; do
   ttfx -i ~/.config/omarchy/branding/screensaver.txt \


### PR DESCRIPTION
Addresses part of #7762.

## Problem

Only a keypress dismisses the screensaver. Mouse and trackpad input do nothing.

`omarchy-screensaver` detects input with `read -n1` on stdin, which carries the keyboard alone — `ttfx` never enables terminal mouse reporting, so pointer motion has no path into the process. The other exit condition cannot fire either: `screensaver_in_focus` only goes false when the focused window's class changes, and the window is fullscreen on every monitor.

## This was shipped once and reverted — and the stated cause no longer reproduces

Being upfront about the precedent, because it applies to every proposed fix in #7762:

- `ddf0d1e8` (#3723) armed terminal mouse reporting and shipped in **v3.2.3**
- `d2ea6ad1` reverted it for **v3.3.0**: *"Canceling the screensaver on mouse movement doesn't work with bluetooth mice. Could not get it to stop existing with a Logitech MX4 when connected via bluetooth."*

I tested that specific failure. On a **Logitech M720 Triathlon over Bluetooth** — BlueZ `uhid` transport, bus `0005` (`BUS_BLUETOOTH`), `lsusb` showing no Unifying receiver, and Hyprland listing it as a second pointer alongside the internal trackpad — with reporting armed:

| Input | SGR bytes delivered |
|---|---|
| Trackpad motion (control) | 3876, and 4488 on a repeat |
| **Bluetooth mouse motion** | **3559** |
| **Bluetooth mouse click** | **177** |
| **Bluetooth mouse scroll** | **876** |

A Bluetooth mouse reaches the terminal at essentially the same rate as the built-in trackpad. Different mouse model and nine months of libinput/Wayland/foot changes since `d2ea6ad1`, so this does not prove the original report was wrong — but the reason it was reverted does not hold on current Omarchy, and that precedent is otherwise hanging over this whole area unexamined.

## Fix

Enable any-event mouse tracking (`?1003h`) with SGR coordinates (`?1006h`) so the terminal delivers pointer motion on stdin, where the existing read loop already dismisses. Disabled again on teardown.

Two details worth calling out:

**Arming is delayed one second.** `omarchy-launch-screensaver` focuses each monitor in turn, which warps the pointer on multi-monitor setups. A warp landing after reporting is armed reads as user input and dismisses the screensaver the instant it appears. Sampling the pointer every 100ms across three runs on a two-monitor session:

```
  0 ms  win=0
100 ms  win=0  LAUNCHER WARP -> 479, 613     (focusing the second monitor)
200 ms  win=1  LAUNCHER WARP -> -960, 553    (restoring focus)
300 ms  win=2                                 both screensavers up
```

Last warp lands 100–400ms out; one second leaves a margin. It is a heuristic, not a proof — `wait_for_screensaver_window` permits up to 5s per monitor, so a heavily loaded or many-monitor machine could warp later. The failure mode is mild (screensaver closes immediately, idle re-triggers). Happy to switch to waiting on pointer-stillness or on window count reaching monitor count if you'd prefer something without a constant.

**Arming runs in the background.** In the foreground it blocks before the read loop, leaving the keyboard dead for that second — worse than current behaviour.

## It also fixes the lock-during-activity defect

Worth separating, because #7762 contains two problems and this addresses both.

The genuine regression identified in that thread is that `handleActiveSignal()` is edge-triggered off `IdleMonitor.onIsIdleChanged`: while the user keeps moving, the monitor never re-idles, no further edge arrives, `lockTimer` is never stopped, and **the session locks on the original deadline however active the user has been**.

This patch fixes that through the sanctioned path — pointer input closes the window, so `closewindow` → `handleScreensaverWindowClosed` → `cancelIdleCycle` → `lockTimer.stop()`. Note the guard-narrowing suggested in the issue does *not* fix it.

## Verification

Two-monitor Hyprland session with one display at negative X, so focusing it warps the pointer ~1400px. Both windows survived 2.8s past arming untouched, then a single trackpad nudge closed both within 200ms.

Input coverage, measured by logging bytes arriving with reporting armed:

| Input | Dismisses |
|---|---|
| Pointer motion | yes |
| Left click | yes |
| Two-finger scroll | yes |
| Pinch to zoom | yes |
| Bluetooth mouse (motion / click / scroll) | yes |
| Three-finger swipe | **no** |
| Volume / brightness keys | **no** |

The two gaps are inherent to the terminal layer: Wayland three-finger gestures use the pointer-gestures protocol, which foot does not implement, and media keys never arrive as stdin bytes. Neither is a regression — today nothing but a keypress dismisses at all.

### All four supported terminals

Dismissal depends on the terminal translating pointer input into SGR reports on the pty, which is per-terminal behaviour, so I measured each one using the flags `omarchy-launch-screensaver` passes it. Bytes delivered with reporting armed, internal trackpad and the Bluetooth M720:

| Terminal | Version | Trackpad | Bluetooth mouse |
|---|---|---|---|
| foot | 1.27.0 | 552 | 583 |
| ghostty | 1.3.1 | 270 / 324 | 416 / 696 |
| alacritty | 0.17.0 | 330 | 465 |
| kitty | 0.48.2 | 526 | 792 |

Every terminal reports both devices (ghostty run twice, consistent). So the mechanism is not foot-specific, and the Bluetooth result is not terminal-specific either.

`./test/all`: 186/190. The four failures are pre-existing in my environment and unrelated to a shell script in `bin/` — `config-test.sh` and `unowned-system-paths-test.sh` need an `omarchy-pkgs` checkout, `snapper-test.sh` hits a permission error, and `runtime-smoke-test.sh` fails its per-screen IPC assertion (`saw 3 for 2 screen(s)`) whenever two displays are attached, on a clean tree as well.

## Limitations, stated plainly

- **Touch is verified on foot only.** Pointer and Bluetooth-mouse input are measured on all four terminals (table above). Touch is not: this machine has no touchscreen, so the 132-byte `wl_touch` result in #7762 stands for foot alone, and touch-to-mouse-report translation on ghostty, alacritty and kitty is unverified. If touch is the case you care most about, that is a real gap in this PR and the compositor route sidesteps it.
- **Conflicts with #6813.** That PR rewrites this file (48 → 100 lines), replacing `exit_screensaver()` with `request_shutdown()` and removing `tty=$(tty)`. Both of my hunks land where it rewrites. There is no guarantee of merge order, so I have left this patch against `quattro` rather than rebasing onto an unmerged branch — happy to rebase onto #6813 if you intend to land it first.
- **Exposes an upstream foot crash.** Dismissing by touch with the finger still down could segfault foot — an upstream use-after-free, fixed at foot#2436, unmerged when last checked. Arming mouse reporting is what exposes it. Neither compositor-level PR touches the terminal, so neither has this exposure.
- **This is the terminal layer, not the compositor layer.** It depends on a terminal translating pointer input into pty bytes, which is per-device and per-terminal by construction. The measurements above show every supported terminal and a Bluetooth mouse all working, so the practical risk is low — but the architecture is still per-device, whereas #7528 and #7780 route through `ext-idle-notify`, which is seat-scoped and cannot have a per-device failure mode at all. That is a real argument in their favour and measurements do not erase it. Which route Omarchy takes is your call — I would rather say so than let this look like the obvious choice. If you go compositor-side, the Bluetooth and four-terminal data above is the part of this worth keeping, since `d2ea6ad1` is the precedent that route also has to answer.

Tested on Omarchy 4.0.0-1, ttfx 0.3.1, Hyprland with 1 and 2 monitors, internal trackpad and a Bluetooth Logitech M720, across foot 1.27.0, ghostty 1.3.1, alacritty 0.17.0 and kitty 0.48.2.
