### PR TITLE
Avoid oversized image picker arguments

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -276,13 +276,27 @@ fi
 # Qt.atob()s on the other side.
 rows_b64=$(printf '%s' "$rows" | base64 -w 0)
 
+# Linux limits each process argument to roughly 128 KiB. Leave enough room
+# below that ceiling for the IPC wrapper, and let the picker scan the already
+# cached directories when the encoded rows would be too large.
+max_rows_argument_size=$((96 * 1024))
+image_dirs_arg=""
+if (( ${#rows_b64} > max_rows_argument_size )); then
+  if [[ $preload == true ]]; then
+    exit 0
+  fi
+
+  image_dirs_arg="$image_dirs_env"
+  rows_b64=""
+fi
+
 if [[ $preload == true ]]; then
   omarchy-shell image-selector preload "$rows_b64" "$selected_list_image" "$show_labels" "$filterable" >/dev/null || true
   exit 0
 fi
 
 if ! open_result=$(omarchy-shell image-selector open \
-     "" \
+     "$image_dirs_arg" \
      "$rows_b64" \
      "$selected_list_image" \
      "$selection_file" \

--- a/test/shell.d/menu-images-test.sh
+++ b/test/shell.d/menu-images-test.sh
@@ -139,3 +139,39 @@ PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" VIPSTHUMBNAIL_CALLS_FILE="$t
 
 (( $(wc -l <"$tmp/calls") == 6 )) || fail "image menu releases thumbnail locks after generation"
 pass "image menu owns locks for exactly one generator lifetime"
+
+large_images="$tmp/large-images"
+mkdir -p "$large_images"
+large_cache_key=$(printf '%s' "$large_images" | md5sum | cut -d ' ' -f 1)
+large_rows=""
+for index in {1..1500}; do
+  row="$large_images/image-$index.png"$'\t'"$cache_dir/thumbnail-$index.jpg"
+  large_rows+="${large_rows:+$'\n'}$row"
+done
+printf '%s' "$large_rows" >"$cache_dir/$large_cache_key.rows"
+printf 'v2\n%s:%s\n' "$large_images" "$(stat -Lc '%Y' "$large_images")" >"$cache_dir/$large_cache_key.fast-signature"
+
+cat >"$stub_bin/omarchy-shell" <<'EOF'
+#!/bin/bash
+
+printf '%s\0' "$@" >"$OMARCHY_SHELL_ARGS_FILE"
+if [[ $1 == "image-selector" && $2 == "open" ]]; then
+  : >"$7"
+  printf 'ok\n'
+fi
+EOF
+chmod +x "$stub_bin/omarchy-shell"
+
+PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" OMARCHY_SHELL_ARGS_FILE="$tmp/ipc-args" \
+  "$ROOT/bin/omarchy-menu-images" "$large_images"
+
+mapfile -d '' -t ipc_args <"$tmp/ipc-args"
+[[ ${ipc_args[2]} == "$large_images" ]] || fail "large image menus pass directories to IPC"
+[[ -z ${ipc_args[3]} ]] || fail "large image menus keep row data out of IPC arguments"
+pass "image menu opens large collections without oversized arguments"
+
+rm "$tmp/ipc-args"
+PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" OMARCHY_SHELL_ARGS_FILE="$tmp/ipc-args" \
+  "$ROOT/bin/omarchy-menu-images" --preload "$large_images"
+[[ ! -e $tmp/ipc-args ]] || fail "large image menu preloads avoid oversized arguments"
+pass "image menu skips oversized preloads"


### PR DESCRIPTION
## Summary

- fall back to the image picker directory scan when encoded rows approach the Linux per-argument limit
- skip oversized preloads so the next open can safely scan the cached directories
- cover large opens and preloads with a regression test

## Problem

A sufficiently large background collection produces more than 128 KiB of Base64 row data. Passing that data as one argument prevents `omarchy-shell` from starting with `Argument list too long`, so the background switcher never opens.

## Testing

- `bash test/shell.d/menu-images-test.sh`
- manually opened the picker with 611 user backgrounds that reproduced the original failure
- `git diff --check`

I also attempted `./test/all`; this machine cannot complete unrelated suites because Node is installed through mise without an active version, the sibling `omarchy-pkgs` checkout is absent, and the runtime smoke test conflicts with the active desktop shell.