### PR TITLE
Prevent notification markup from crashing Quickshell

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -5,8 +5,12 @@ function isChromiumDerived(app, appIcon) {
          source.indexOf("opera") >= 0
 }
 
+function stripImageTags(value) {
+  return String(value || "").replace(/<img\b[^>]*(?:>|$)/gi, "")
+}
+
 function sanitizeBody(body, app, appIcon) {
-  var text = String(body || "").replace(/<img[^>]*>/gi, "")
+  var text = stripImageTags(body)
   if (!isChromiumDerived(app, appIcon)) return text
 
   return text
@@ -365,6 +369,7 @@ function historyRows(raw, liveRows, normalUrgency, limit) {
 if (typeof module !== "undefined") {
   module.exports = {
     isChromiumDerived: isChromiumDerived,
+    stripImageTags: stripImageTags,
     sanitizeBody: sanitizeBody,
     summaryStartsWithGlyph: summaryStartsWithGlyph,
     shouldBypassDnd: shouldBypassDnd,

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -40,7 +40,8 @@ BorderSurface {
   readonly property bool hasGlyph: glyph.length > 0
   readonly property bool compactGlyph: NotificationLogic.shouldRenderCompactGlyph(glyph, smallIconSource, singleLineToast)
   readonly property bool hasSmallIcon: smallIconSource.length > 0
-  readonly property bool summaryStartsWithGlyph: NotificationLogic.summaryStartsWithGlyph(summary)
+  readonly property string sanitizedSummary: NotificationLogic.stripImageTags(summary)
+  readonly property bool summaryStartsWithGlyph: NotificationLogic.summaryStartsWithGlyph(sanitizedSummary)
   readonly property bool singleLineToast: sanitizedBody.length === 0
   readonly property bool collapseRedundantIcon: singleLineToast && !hasGlyph && summaryStartsWithGlyph
   readonly property string sanitizedBody: sanitizeBody(body)
@@ -160,8 +161,9 @@ BorderSurface {
 
         Text {
           Layout.fillWidth: true
-          visible: root.summary.length > 0
-          text: root.summary
+          visible: root.sanitizedSummary.length > 0
+          text: root.sanitizedSummary
+          textFormat: Text.PlainText
           font.family: "Liberation Sans"
           color: Color.notifications.text
           font.pixelSize: Style.font.title

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -13,9 +13,21 @@ assert(notifications.isChromiumDerived('', 'microsoft-edge'), 'notifications det
 assert(!notifications.isChromiumDerived('Slack', ''), 'notifications do not treat unrelated apps as chromium-derived')
 
 assertEqual(
+  notifications.stripImageTags('Before <IMG src="x"> after'),
+  'Before  after',
+  'notifications strip closed image tags from displayed text'
+)
+
+assertEqual(
+  notifications.stripImageTags('Before <img src'),
+  'Before ',
+  'notifications strip truncated image tags from displayed text'
+)
+
+assertEqual(
   notifications.sanitizeBody('<img src="x">Hello', 'Slack', ''),
   'Hello',
-  'notifications strip inline image tags'
+  'notifications sanitize image tags from bodies'
 )
 
 assertEqual(


### PR DESCRIPTION
Malformed notification image markup could reach Quickshell's notification card. The summary used Qt's automatic rich-text detection, while incomplete image tags in notification text were not always removed. Qt Quick could then crash while laying out the notification.

This strips closed and truncated image tags before display, renders summaries as plain text, preserves rich formatting for sanitized bodies, and adds focused regression coverage.
