### PR TITLE
Select share regions in output relative coordinates

### DIFF
--- a/config/hyprland-preview-share-picker/config.yaml
+++ b/config/hyprland-preview-share-picker/config.yaml
@@ -62,8 +62,9 @@ outputs:
 
 region:
   # command to run for region selection
-  # the output needs to be in the <output>@<x>,<y>,<w>,<h> (e.g. DP-3@2789,436,756,576) format
-  command: slurp -f '%o@%x,%y,%w,%h'
+  # the output needs to be in the <output>@<x>,<y>,<w>,<h> (e.g. DP-3@869,436,756,576) format
+  # where x and y are relative to the top left corner of the output
+  command: slurp -f '%o@%X,%Y,%W,%H'
 
 # hide the token restore checkbox and use the default value instead
 hide_token_restore: true

--- a/migrations/1787582797.sh
+++ b/migrations/1787582797.sh
@@ -1,0 +1,8 @@
+echo "Select share regions in output relative coordinates"
+
+config="$HOME/.config/hyprland-preview-share-picker/config.yaml"
+
+[[ -f $config ]] || exit 0
+grep -q "%o@%x,%y,%w,%h" "$config" || exit 0
+
+sed -i "s|%o@%x,%y,%w,%h|%o@%X,%Y,%W,%H|" "$config"


### PR DESCRIPTION
### The problem

Sharing a *region* of the screen shows up as an all black window on the receiving end. Sharing a whole screen or a single window works fine.

It reproduces in any consumer of the screencast portal — verified with teams-for-linux and with Chrome on meet.google.com.

The catch is that it only happens when your monitors are not all at the origin of the layout, which is why it isn't universal.

### Cause

`config/hyprland-preview-share-picker/config.yaml` sets

```yaml
command: slurp -f '%o@%x,%y,%w,%h'
```

`%x`/`%y` are the selection's position in **global layout coordinates**. The picker forwards that string to xdg-desktop-portal-hyprland unchanged, and xdph passes it straight into a `zwlr_screencopy_manager_v1.capture_output_region` request. That box is specified in **output logical coordinates**:

> The region is given in output logical coordinates, see xdg_output.logical_size. The region will be clipped to the output's extents.

Nothing subtracts the monitor's position along the way, so the box is offset by it and then clipped. Hyprland renders the frame as `CBox{{}, PMONITOR->m_transformedSize}.translate(-captureBox.pos())`, so once the offset exceeds the output's own size the monitor content lands entirely outside the buffer and every frame is black.

On this layout:

```
HDMI-A-1  2560x1440  at 1280,0
DP-1      5120x1440  at 0,1440
```

every selection on `DP-1` has a global y of at least 1440, already past that output's 1440px height:

```
[LOG] [sc] Selection: r/region:DP-1@1983,1665,1084,609
[LOG] [screencopy] Sharing initialized
```

Selections on `HDMI-A-1` come out shifted 1280px to the right instead, and go black too once the offset pushes them past the right edge. A single monitor at `0,0` is the case where it happens to work.

Worth noting the Qt picker bundled with xdg-desktop-portal-hyprland does this conversion by hand, which is why the problem is specific to the preview picker:

```cpp
std::cout << "region:" << SCREEN_NAME << "@" << X - pScreen->geometry().x() << "," << Y - pScreen->geometry().y() << "," << W << "," << H << "\n";
```

### The fix

slurp already provides output relative format specifiers, so no arithmetic is needed:

```yaml
command: slurp -f '%o@%X,%Y,%W,%H'
```

- `%X`/`%Y` — relative to the top left corner of the output containing the selection's top left corner
- `%W`/`%H` — clamped to the output's extents, so dragging past the edge of a monitor no longer asks for a box bigger than the output

`%o` resolves its output through the same top left lookup as `%X`/`%Y`, so the name and the coordinates always agree.

The migration rewrites `~/.config/hyprland-preview-share-picker/config.yaml` for existing installs, and only when it still pins the old format, so a customized region command is left alone.

I've also opened WhySoBad/hyprland-preview-share-picker#26 to fix the same default upstream. Our config sets the command explicitly either way, so the two changes don't depend on each other.

### Testing

`./test/all` — no new failures. The 4 failing files (`config`, `runtime-smoke`, `snapper`, `unowned-system-paths`) fail identically on a clean `quattro` checkout; three want a sibling `omarchy-pkgs` checkout and the fourth is a running-shell artifact.

Migration exercised against a temporary home for the fresh, already-migrated, customized, and missing-config cases.

Confirmed on the desktop: region sharing in teams-for-linux and Google Meet is black before, correct after.
