### PR TITLE
Keep Hyprland helpers global

### DIFF
--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -1,6 +1,7 @@
 -- Shared helpers for Hyprland Lua configuration.
 
-o = o or {}
+_G.o = _G.o or {}
+local o = _G.o
 
 local function shell_quote(value)
   return "'" .. tostring(value):gsub("'", "'\\''") .. "'"

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -4,6 +4,26 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
 
+if ! helper_global_output=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+local helper_environment = setmetatable({}, { __index = _G })
+local helpers = assert(loadfile(os.getenv("OMARCHY_PATH") .. "/default/hypr/helpers.lua", "t", helper_environment))
+
+_G.o = nil
+helpers()
+
+assert(_G.o, "helpers store o globally")
+assert(rawget(helper_environment, "o") == nil, "helpers do not rely on their module environment")
+
+local later_environment = setmetatable({}, { __index = _G })
+local later_module = assert(load("return o", "later-module", "t", later_environment))
+assert(later_module() == _G.o, "later modules can access o")
+LUA
+); then
+  fail "Hyprland helpers load across module environments" "$helper_global_output"
+fi
+[[ -z $helper_global_output ]] || fail "helpers load without output" "$helper_global_output"
+pass "Hyprland helpers remain global across module environments"
+
 run_application_bindings() {
   local home="$1"
   local prelude="${2:-}"


### PR DESCRIPTION
I hit this after rebasing a dev-linked checkout. Hyprland reloaded the Lua config, then later user modules found `o` nil and failed at calls such as `o.bind` and `o.launch_on_start`.

That leaves Hyprland with no normal bindings registered, so it trips emergency mode. The top-of-screen error shows the failing user modules and only the emergency bindings remain available.

Store the shared helper table on `_G` and use a local reference in the helper module, so every later module sees the same table after a reload.

Tested: `./test/cli`