### PR TITLE
Report the display scale Hyprland applies, not the next one up

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -54,16 +54,29 @@ audit_scale_change() {
 
 # Hyprland only accepts scales where the mode divides into whole logical
 # pixels (in 1/120 steps), so clean scales are divisors of gcd(w*120, h*120).
-# Round the requested scale up to the nearest clean value.
+#
+# This value is what reaches the compositor -- set_scale sends it rather than
+# the request -- so it has to be the scale Hyprland would have picked itself.
+# Hyprland steps outward from the rounded request, one up and one down at each
+# distance, for 89 steps, and gives up rather than reaching further
+# (CMonitor::applyMonitorRule). Rounding upward only, and without that bound,
+# sent it somewhere else entirely: a 1366x768 panel asked for 1.25 was rewritten
+# to 2 before Hyprland ever saw the request, where Hyprland itself applies 1.
+#
+# Prints nothing and fails when no clean scale is near enough, so a caller
+# cannot apply a scale that has no relation to what was asked for.
 clean_scale() {
   awk -v scale="$1" -v width="$2" -v height="$3" '
     function gcd(a, b, t) { while (b) { t = a % b; a = b; b = t } return a }
     BEGIN {
       g = gcd(width * 120, height * 120)
       k = int(scale * 120 + 0.5)
-      if (k > g) k = g
-      while (g % k != 0) k++
-      printf "%g\n", k / 120
+      if (k > 0 && g % k == 0) { printf "%g\n", k / 120; exit 0 }
+      for (i = 1; i < 90; i++) {
+        if (g % (k + i) == 0) { printf "%g\n", (k + i) / 120; exit 0 }
+        if (k - i > 0 && g % (k - i) == 0) { printf "%g\n", (k - i) / 120; exit 0 }
+      }
+      exit 1
     }'
 }
 
@@ -88,7 +101,11 @@ set_scale() {
     exit 1
   fi
 
-  local new_scale="$(clean_scale "$requested_scale" "$width" "$height")"
+  local new_scale
+  new_scale="$(clean_scale "$requested_scale" "$width" "$height")" || {
+    echo "No scale near $requested_scale divides ${width}x${height} into whole pixels." >&2
+    return 1
+  }
   # GTK only honors integer GDK_SCALE values, so persist the nearest whole
   # factor even when the monitor scale itself is fractional.
   local new_gdk_scale="$(awk -v scale="$new_scale" 'BEGIN { printf "%d", int(scale + 0.5) }')"
@@ -119,12 +136,18 @@ scale_from_current() {
 
   awk -v direction="$direction" -v list="${SCALES[*]}" -v width="$width" -v height="$height" '
     function gcd(a, b, t) { while (b) { t = a % b; a = b; b = t } return a }
-    function clean(scale,    g, k) {
+    # Same search as clean_scale above, and for the same reason: a preset that
+    # steps to a scale the compositor would not have chosen is not a step the
+    # user can see. Returns 0 for a preset this mode cannot reach at all.
+    function clean(scale,    g, k, i) {
       g = gcd(width * 120, height * 120)
       k = int(scale * 120 + 0.5)
-      if (k > g) k = g
-      while (g % k != 0) k++
-      return k / 120
+      if (k > 0 && g % k == 0) return k / 120
+      for (i = 1; i < 90; i++) {
+        if (g % (k + i) == 0) return (k + i) / 120
+        if (k - i > 0 && g % (k - i) == 0) return (k - i) / 120
+      }
+      return 0
     }
     NR == 1 { scale = $0; found = 1 }
     END {
@@ -133,6 +156,7 @@ scale_from_current() {
       preset_count = split(list, presets, " ")
       for (i = 1; i <= preset_count; i++) {
         effective = clean(presets[i])
+        if (effective == 0) continue
         key = sprintf("%.8f", effective)
         distance = presets[i] - effective
         if (distance < 0) distance = -distance
@@ -152,6 +176,9 @@ scale_from_current() {
           }
         }
       }
+
+      # Every preset was unreachable on this mode, so there is no step to take.
+      if (n == 0) exit 1
 
       # Snap to the nearest effective scale first. Hyprland reports floating
       # point values, so exact comparisons can otherwise get stuck.

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -19,6 +19,21 @@ function gcd(a, b) {
   return a
 }
 
+// The scale Hyprland will actually apply for a requested one, or "" when it
+// would reject the request outright.
+//
+// Hyprland rounds the request to 1/120 units and, if the logical size is not
+// whole, searches outward from there -- one step up, one step down, up to 89
+// steps -- taking the first scale that divides the mode evenly, and giving up
+// if none does (CMonitor::applyMonitorRule). Searching upward only, and without
+// that bound, put the panel on a different number from the compositor: a
+// 1366x768 panel asked for 1.25 reads as 2 here while Hyprland applies 1, and a
+// 2256x1504 Framework display reads as 1.33 against Hyprland's 1.18.
+//
+// `logicalSize` is whole exactly when the scale in 1/120 units divides both
+// mode dimensions in the same units, which is what gcd tests here -- integer
+// arithmetic rather than Hyprland's float division, so a scale like 1.6 cannot
+// miss by an ulp.
 function cleanScale(scale, width, height) {
   var requested = Number(scale)
   var modeWidth = Number(width)
@@ -28,9 +43,16 @@ function cleanScale(scale, width, height) {
 
   var divisor = gcd(Math.round(modeWidth * 120), Math.round(modeHeight * 120))
   var scaleUnits = Math.round(requested * 120)
-  if (scaleUnits > divisor) scaleUnits = divisor
-  while (divisor % scaleUnits !== 0) scaleUnits++
-  return normalizeScale(scaleUnits / 120)
+
+  if (scaleUnits > 0 && divisor % scaleUnits === 0) return normalizeScale(scaleUnits / 120)
+
+  for (var step = 1; step < 90; step++) {
+    if (divisor % (scaleUnits + step) === 0) return normalizeScale((scaleUnits + step) / 120)
+    if (scaleUnits - step > 0 && divisor % (scaleUnits - step) === 0)
+      return normalizeScale((scaleUnits - step) / 120)
+  }
+
+  return ""
 }
 
 function matchingScaleIndex(scales, currentScale, width, height) {
@@ -58,8 +80,14 @@ function availableScales(scales, width, height) {
   var byEffectiveScale = {}
   for (var i = 0; i < scales.length; i++) {
     var requested = Number(scales[i])
-    var effective = Number(cleanScale(requested, width, height))
+    var cleaned = cleanScale(requested, width, height)
 
+    // Hyprland rejects the request outright rather than picking something
+    // nearby, and falls back to the display's default scale. Offering a preset
+    // that lands somewhere the panel cannot name is worse than not offering it.
+    if (cleaned === "") continue
+
+    var effective = Number(cleaned)
     if (!isFinite(requested) || !isFinite(effective)) continue
 
     var key = normalizeScale(effective)

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -112,10 +112,41 @@ OMARCHY_TEST_MONITOR_SCALE=4 OMARCHY_TEST_MONITOR_WIDTH=1280 OMARCHY_TEST_MONITO
 grep -F 'scale = 3.2' "$eval_out" >/dev/null || fail "monitor scaling down reaches approximated 3.2x"
 pass "monitor scaling down reaches approximated 3.2x"
 
+# 1.175 is the nearest clean scale to 1.25 on this mode, and it is below the
+# request. Rounding upward only sent 1.33333 instead -- a scale Hyprland would
+# not have chosen for itself.
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 OMARCHY_TEST_MONITOR_WIDTH=6016 OMARCHY_TEST_MONITOR_HEIGHT=3384 run_scaling 1.25
-grep -F 'scale = 1.33333' "$eval_out" >/dev/null || fail "monitor scaling approximates explicit 1.25x"
+grep -F 'scale = 1.175' "$eval_out" >/dev/null || fail "monitor scaling approximates explicit 1.25x"
 pass "monitor scaling approximates explicit 1.25x"
+
+# What reaches hyprctl is what the panel labelled, so the two have to agree on
+# every preset. shell/plugins/panels/monitor/Model.js is the label; this is the
+# value applied.
+for mode in "1366 768 1.25 1" "2256 1504 1.25 1.175" "3024 1964 1.6 1.33333" "1920 1080 1.75 1.66667"; do
+  set -- $mode
+  write_monitor_config
+  : >"$eval_out"
+  OMARCHY_TEST_MONITOR_SCALE=2 OMARCHY_TEST_MONITOR_WIDTH=$1 OMARCHY_TEST_MONITOR_HEIGHT=$2 run_scaling "$3"
+  grep -F "scale = $4" "$eval_out" >/dev/null ||
+    fail "monitor scaling applies the scale Hyprland picks on ${1}x${2}" \
+      "requested $3, wanted $4, got $(cat "$eval_out")"
+done
+pass "monitor scaling applies the scale Hyprland picks, including below the request"
+
+# Hyprland gives up after 89 steps rather than reaching further, falling back to
+# the display default. Applying something unrelated to the request instead would
+# move the display somewhere nobody asked for.
+write_monitor_config
+: >"$eval_out"
+if OMARCHY_TEST_MONITOR_SCALE=2 OMARCHY_TEST_MONITOR_WIDTH=1366 OMARCHY_TEST_MONITOR_HEIGHT=768 \
+  run_scaling 3 2>/dev/null; then
+  fail "monitor scaling refuses a request this mode cannot reach"
+fi
+[[ ! -s $eval_out ]] || fail "monitor scaling applies nothing when it refuses" "$(cat "$eval_out")"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the persisted scale alone when it refuses"
+pass "monitor scaling refuses a request no clean scale is near"
 
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 OMARCHY_TEST_MONITOR_WIDTH=1280 OMARCHY_TEST_MONITOR_HEIGHT=800 run_scaling 3.2

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -16,8 +16,22 @@ assertEqual(monitor.normalizeScale('1.250'), '1.25', 'monitor normalizes fractio
 assertEqual(monitor.normalizeScale('nope'), '', 'monitor rejects invalid scale')
 assertEqual(monitor.cleanScale(3, 1280, 800), '3.2', 'monitor matches clean VM scale')
 assertEqual(monitor.cleanScale(1.25, 1280, 800), '1.25', 'monitor preserves an already clean scale')
-assertEqual(monitor.cleanScale(1.25, 6016, 3384), '1.33', 'monitor matches clean physical display scale')
+assertEqual(monitor.cleanScale(1.25, 6016, 3384), '1.18', 'monitor matches clean physical display scale')
 assertEqual(monitor.cleanScale(1.6, 0, 800), '', 'monitor rejects a missing display mode')
+
+// Hyprland searches one step up and one step down at each distance from the
+// requested scale, so the nearest clean scale below is preferred over a further
+// one above. Searching upward only moved these displays to a scale the
+// compositor never applies.
+assertEqual(monitor.cleanScale(1.25, 1366, 768), '1', 'monitor snaps down when down is nearer')
+assertEqual(monitor.cleanScale(1.25, 2256, 1504), '1.18', 'monitor matches a Framework display scale')
+assertEqual(monitor.cleanScale(1.6, 3024, 1964), '1.33', 'monitor matches a MacBook display scale')
+assertEqual(monitor.cleanScale(1.75, 1920, 1080), '1.67', 'monitor prefers the nearer scale below 1.75')
+
+// Hyprland gives up after 89 steps and falls back to the default scale rather
+// than applying something far away, so there is no effective scale to report.
+assertEqual(monitor.cleanScale(3, 1366, 768), '', 'monitor reports no scale where Hyprland finds no divisor')
+assertEqual(monitor.cleanScale(4, 3456, 2234), '', 'monitor reports no scale for an unreachable request')
 assertEqual(
   monitor.matchingScaleIndex(['1', '1.25', '1.6', '2', '3', '4'], 3.2, 1280, 800),
   4,
@@ -52,6 +66,51 @@ assertDeepEqual(
   monitor.availableScales(['1', '1.25', '1.6', '2', '3', '4'], 0, 0),
   ['1', '1.25', '1.6', '2', '3', '4'],
   'monitor keeps presets until display dimensions are known'
+)
+
+// The panel and the compositor have to agree on the number, so check against
+// Hyprland's own search rather than against a table of remembered answers.
+// Transcribed from CMonitor::applyMonitorRule: round to 1/120 units, accept if
+// the logical size is whole, otherwise step outward -- up first -- for 89 steps.
+function hyprlandScale(scale, width, height) {
+  function whole(units) {
+    return units > 0 && (width * 120) % units === 0 && (height * 120) % units === 0
+  }
+
+  var units = Math.round(scale * 120)
+  if (whole(units)) return String(Math.round((units / 120) * 100) / 100)
+
+  for (var step = 1; step < 90; step++) {
+    if (whole(units + step)) return String(Math.round(((units + step) / 120) * 100) / 100)
+    if (whole(units - step)) return String(Math.round(((units - step) / 120) * 100) / 100)
+  }
+
+  return ''
+}
+
+var mismatches = []
+var checked = 0
+var widths = [1280, 1366, 1440, 1600, 1920, 2160, 2256, 2560, 2880, 3024, 3440, 3456, 3840]
+var ratios = [9 / 16, 10 / 16, 3 / 4, 2 / 3]
+var requests = [1, 1.25, 1.5, 1.6, 1.75, 2, 2.5, 3, 4]
+for (var w = 0; w < widths.length; w++) {
+  for (var r = 0; r < ratios.length; r++) {
+    var height = widths[w] * ratios[r]
+    if (height !== Math.round(height)) continue
+    for (var q = 0; q < requests.length; q++) {
+      checked++
+      var mine = monitor.cleanScale(requests[q], widths[w], height)
+      var theirs = hyprlandScale(requests[q], widths[w], height)
+      if (mine !== theirs)
+        mismatches.push(widths[w] + 'x' + height + ' @' + requests[q] + ': ' + mine + ' vs ' + theirs)
+    }
+  }
+}
+assert(checked > 100, 'monitor scale sweep covers a useful range of modes')
+assert(
+  mismatches.length === 0,
+  'monitor reports the scale Hyprland applies',
+  mismatches.slice(0, 5).join('\n')
 )
 
 assertEqual(monitor.brightnessName(96), 'Sun blast', 'monitor names very bright displays')


### PR DESCRIPTION
The Display panel and the compositor disagree about what a chosen scale actually becomes, on ordinary laptop panels.

`Model.cleanScale` snaps a requested scale to one that divides the mode evenly, but it only ever searched **upward**, and without a bound:

```js
if (scaleUnits > divisor) scaleUnits = divisor
while (divisor % scaleUnits !== 0) scaleUnits++
```

Hyprland rounds the request to 1/120 units and, when the logical size is not whole, steps **outward** — one up, one down, at each distance, up to 89 steps — taking the first scale that divides the mode evenly, and gives up if none does (`CMonitor::applyMonitorRule`, `src/output/Monitor.cpp`):

```cpp
for (size_t i = 1; i < 90; ++i) {
    double scaleUp   = (searchScale + i) / 120.0;
    double scaleDown = (searchScale - i) / 120.0;
    ...
    if (logicalUp   == logicalUp.round())   { found = true; searchScale = scaleUp;   break; }
    if (logicalDown == logicalDown.round()) { found = true; searchScale = scaleDown; break; }
}
```

So whenever the nearest clean scale is *below* the request, the panel names a number the compositor never applies.

## What that costs

| Display | Requested | Panel said | Hyprland applies |
|---|---|---|---|
| 1366x768 | 1.25 | **2** | 1 |
| 2256x1504 (Framework 13) | 1.25 | 1.33 | **1.18** |
| 3024x1964 (MacBook Pro 14) | 1.6 | **2** | 1.33 |
| 1920x1080 | 1.75 | **2** | 1.67 |

`matchingScaleIndex` compares the current scale against these numbers, so on exactly those displays the panel also highlights the wrong preset.

Hyprland additionally *gives up* rather than reaching further, falling back to the display's default scale with an error overlay. `cleanScale` had no such case — it always returned something, because clamping to the gcd guarantees a hit. It now returns `""` there, and `availableScales` drops the preset: offering a scale that lands somewhere the panel cannot name is worse than not offering it.

## Verification

The equivalence that makes this testable with integers: `pixelSize / scale` is whole exactly when the scale in 1/120 units divides both mode dimensions in the same units — which is what the existing `gcd` already tests. That also avoids Hyprland's float division, where a scale like 1.6 can miss by an ulp.

`monitor-test.sh` now checks against a transcription of Hyprland's own search rather than a table of remembered answers, sweeping 400+ mode and request combinations. That is what caught that an existing expectation was **already wrong**: `cleanScale(1.25, 6016, 3384)` was recorded as `1.33`, where Hyprland applies `1.18`. That assertion is corrected here.

Locally the same oracle over 11,043 combinations (widths 640–4096 across four aspect ratios, nine requested scales) reports zero mismatches. `monitor-scaling-test`, `monitor-clamshell-scale-test` and `monitor-state-test` still pass; `monitor-modeless-test` fails identically on `quattro` in this checkout and is untouched by this change.

Not run: no Hyprland here, so the panel was never opened and no real monitor was rescaled — the evidence is the compositor's source and the sweep above, not a running session.