### PR TITLE
Add fallback logic to resolve current user in SDDM greeter

### DIFF
--- a/default/sddm/omarchy/Main.qml
+++ b/default/sddm/omarchy/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import SddmComponents 2.0
+import "resolve-current-user.js" as CurrentUser
 
 Rectangle {
   id: root
@@ -7,7 +8,7 @@ Rectangle {
   height: 480
   color: "#1a1b26"
 
-  property string currentUser: userModel.lastUser
+  property string currentUser: CurrentUser.resolveCurrentUser(userModel, Qt.DisplayRole)
   property bool loginFailed: false
   property int sessionIndex: {
     for (var i = 0; i < sessionModel.rowCount(); i++) {

--- a/default/sddm/omarchy/Main.qml
+++ b/default/sddm/omarchy/Main.qml
@@ -8,7 +8,10 @@ Rectangle {
   height: 480
   color: "#1a1b26"
 
-  property string currentUser: CurrentUser.resolveCurrentUser(userModel, Qt.DisplayRole)
+  // SDDM's UserModel.data() only handles its own UserRoles enum (NameRole =
+  // Qt.UserRole + 1); it has no Qt.DisplayRole case and returns an invalid
+  // QVariant for it, so DisplayRole must not be used here.
+  property string currentUser: CurrentUser.resolveCurrentUser(userModel, Qt.UserRole + 1)
   property bool loginFailed: false
   property int sessionIndex: {
     for (var i = 0; i < sessionModel.rowCount(); i++) {

--- a/default/sddm/omarchy/resolve-current-user.js
+++ b/default/sddm/omarchy/resolve-current-user.js
@@ -1,0 +1,16 @@
+.pragma library
+
+// userModel.lastUser is sourced from SDDM's state.conf and can be empty (e.g.
+// an install interrupted before first login ever wrote one). This greeter
+// theme has no username field, so a blank result used to submit an empty
+// username silently instead of asking who's logging in. Only a
+// single-account machine is unambiguous enough to guess; leave multi-user
+// machines to populate lastUser normally rather than picking one of several
+// accounts.
+function resolveCurrentUser(userModel, displayRole) {
+  if (userModel.lastUser)
+    return userModel.lastUser
+  if (userModel.rowCount() === 1)
+    return (userModel.data(userModel.index(0, 0), displayRole) || "").toString()
+  return ""
+}

--- a/default/sddm/omarchy/resolve-current-user.js
+++ b/default/sddm/omarchy/resolve-current-user.js
@@ -7,10 +7,10 @@
 // single-account machine is unambiguous enough to guess; leave multi-user
 // machines to populate lastUser normally rather than picking one of several
 // accounts.
-function resolveCurrentUser(userModel, displayRole) {
+function resolveCurrentUser(userModel, nameRole) {
   if (userModel.lastUser)
     return userModel.lastUser
   if (userModel.rowCount() === 1)
-    return (userModel.data(userModel.index(0, 0), displayRole) || "").toString()
+    return (userModel.data(userModel.index(0, 0), nameRole) || "").toString()
   return ""
 }

--- a/test/shell.d/sddm-greeter-user-fallback-test.sh
+++ b/test/shell.d/sddm-greeter-user-fallback-test.sh
@@ -15,6 +15,7 @@ const sandbox = {}
 vm.createContext(sandbox)
 vm.runInContext(source, sandbox)
 
+const NAME_ROLE = 257
 const DISPLAY_ROLE = 0
 
 function mockUserModel(lastUser, users) {
@@ -22,31 +23,37 @@ function mockUserModel(lastUser, users) {
     lastUser,
     rowCount: () => users.length,
     index: (row, _column) => row,
-    data: (idx, _role) => users[idx],
+    data: (idx, role) => (role === NAME_ROLE ? users[idx] : undefined),
   }
 }
 
 assertEqual(
-  sandbox.resolveCurrentUser(mockUserModel('alice', ['alice']), DISPLAY_ROLE),
+  sandbox.resolveCurrentUser(mockUserModel('alice', ['alice']), NAME_ROLE),
   'alice',
   'uses the recorded last user when state.conf has one'
 )
 
 assertEqual(
-  sandbox.resolveCurrentUser(mockUserModel('', ['alice']), DISPLAY_ROLE),
+  sandbox.resolveCurrentUser(mockUserModel('', ['alice']), NAME_ROLE),
   'alice',
   'falls back to the sole account when lastUser is empty (#7949)'
 )
 
 assertEqual(
-  sandbox.resolveCurrentUser(mockUserModel('', ['alice', 'bob']), DISPLAY_ROLE),
+  sandbox.resolveCurrentUser(mockUserModel('', ['alice', 'bob']), NAME_ROLE),
   '',
   'does not guess a user when lastUser is empty and multiple accounts exist'
 )
 
 assertEqual(
-  sandbox.resolveCurrentUser(mockUserModel('', []), DISPLAY_ROLE),
+  sandbox.resolveCurrentUser(mockUserModel('', []), NAME_ROLE),
   '',
   'stays empty rather than crashing when the model has no accounts at all'
+)
+
+assertEqual(
+  sandbox.resolveCurrentUser(mockUserModel('', ['alice']), DISPLAY_ROLE),
+  '',
+  'querying Qt.DisplayRole instead of NameRole resolves nothing, as it does on real SDDM'
 )
 JS

--- a/test/shell.d/sddm-greeter-user-fallback-test.sh
+++ b/test/shell.d/sddm-greeter-user-fallback-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Regression coverage for #7949
+
+source "$(dirname "$0")/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+
+const source = fs
+  .readFileSync(path.join(root, 'default/sddm/omarchy/resolve-current-user.js'), 'utf8')
+  .replace(/^\.pragma library\n/, '')
+const sandbox = {}
+vm.createContext(sandbox)
+vm.runInContext(source, sandbox)
+
+const DISPLAY_ROLE = 0
+
+function mockUserModel(lastUser, users) {
+  return {
+    lastUser,
+    rowCount: () => users.length,
+    index: (row, _column) => row,
+    data: (idx, _role) => users[idx],
+  }
+}
+
+assertEqual(
+  sandbox.resolveCurrentUser(mockUserModel('alice', ['alice']), DISPLAY_ROLE),
+  'alice',
+  'uses the recorded last user when state.conf has one'
+)
+
+assertEqual(
+  sandbox.resolveCurrentUser(mockUserModel('', ['alice']), DISPLAY_ROLE),
+  'alice',
+  'falls back to the sole account when lastUser is empty (#7949)'
+)
+
+assertEqual(
+  sandbox.resolveCurrentUser(mockUserModel('', ['alice', 'bob']), DISPLAY_ROLE),
+  '',
+  'does not guess a user when lastUser is empty and multiple accounts exist'
+)
+
+assertEqual(
+  sandbox.resolveCurrentUser(mockUserModel('', []), DISPLAY_ROLE),
+  '',
+  'stays empty rather than crashing when the model has no accounts at all'
+)
+JS


### PR DESCRIPTION
Fixes issue #7949.

**Problem:** SDDM authenticates an empty username after an interrupted/resumed install. Password and account are correct, but the greeter has no username field, so there's no way to log in through the graphical greeter.

**Root cause:** Omarchy's SDDM theme (`default/sddm/omarchy/Main.qml`) read `currentUser` straight from `userModel.lastUser`, which SDDM only populates from `state.conf`. An install interrupted before the first login never writes that file, so `lastUser` is empty and the theme submits `sddm.login("", password, ...)`.

**Fix:** Extract the resolution logic into `resolve-current-user.js`. When `lastUser` is empty:
- if there's exactly one real account, use it (the common single-user case this theme is built for)
- if there's more than one, leave it empty rather than guess

**Testing:** Added `test/shell.d/sddm-greeter-user-fallback-test.sh`, which runs the real `resolve-current-user.js` source (same technique already used for `BorderGeometry.js`) against four scenarios: known last user, empty with one account, empty with multiple accounts, empty with no accounts. Verified the test fails against the old one-line behavior and passes with the fix. Full `./test/shell` suite passes with no regressions.