### PR TITLE
Toggle night light against the threshold the indicator reports

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -42,7 +42,13 @@ fi
 # Query the current temperature
 CURRENT_TEMP=$(current_temp)
 
-if [[ -z $CURRENT_TEMP || $CURRENT_TEMP == $OFF_TEMP ]]; then
+# Toggle against the same threshold status_json reports, not against one exact
+# daylight value. Any temperature that is neither exactly $OFF_TEMP nor below
+# identity -- a hyprsunset started with its own -t, another tool setting one, a
+# gradual transition caught part way -- reads as off in the indicator while the
+# toggle treats it as on and "turns it off", so the first press does nothing the
+# user can see and night light needs two.
+if [[ -z $CURRENT_TEMP ]] || (( CURRENT_TEMP >= IDENTITY_TEMP )); then
   TARGET_TEMP=$ON_TEMP
 else
   TARGET_TEMP=$OFF_TEMP

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -86,6 +86,46 @@ nightlight_cli >/dev/null
 [[ $(<"$STATE") == 6500 ]] || fail "nightlight toggle restores daylight from night light"
 pass "nightlight toggle restores daylight from night light"
 
+# The indicator and --status call anything at or above identity daylight, so the
+# toggle has to warm those too. Comparing against one exact daylight value left
+# a band -- a hyprsunset started with its own -t, another tool setting one, a
+# gradual transition caught part way -- where the indicator read off and the
+# first press did nothing the user could see.
+toggle_from() {
+  printf '%s\n' "$1" >"$STATE"
+  nightlight_cli >/dev/null
+  cat "$STATE"
+}
+
+for daylight in 6000 6200 6499; do
+  [[ $(nightlight_status "$daylight" | jq -r .enabled) == "false" ]] ||
+    fail "nightlight status reports ${daylight}K as disabled"
+  landed=$(toggle_from "$daylight")
+  [[ $landed == 4000 ]] ||
+    fail "nightlight toggle warms the screen from ${daylight}K" "landed on $landed"
+done
+pass "nightlight toggle warms the screen from any temperature the indicator calls off"
+
+# And the other direction stays intact: anything the indicator calls on goes
+# back to daylight in one press.
+for warm in 3000 4000 5999; do
+  [[ $(nightlight_status "$warm" | jq -r .enabled) == "true" ]] ||
+    fail "nightlight status reports ${warm}K as enabled"
+  landed=$(toggle_from "$warm")
+  [[ $landed == 6500 ]] ||
+    fail "nightlight toggle restores daylight from ${warm}K" "landed on $landed"
+done
+pass "nightlight toggle restores daylight from any temperature the indicator calls on"
+
+# One press is always the inverse of what the indicator shows, which is the
+# property the two halves have to share.
+grep -F 'IDENTITY_TEMP' "$ROOT/bin/omarchy-toggle-nightlight" >/dev/null ||
+  fail "nightlight toggle decides on the identity threshold"
+if grep -F '$CURRENT_TEMP == $OFF_TEMP' "$ROOT/bin/omarchy-toggle-nightlight" >/dev/null; then
+  fail "nightlight toggle does not decide on one exact daylight value"
+fi
+pass "nightlight toggle and indicator share the identity threshold"
+
 if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"
 fi


### PR DESCRIPTION
`NightlightModel.js` opens with:

```js
// Temperatures below the identity point count as night light. Keep in sync
// with bin/omarchy-toggle-nightlight, which applies the same threshold.
var IDENTITY_TEMPERATURE = 6000
```

`status_json()` in that script does apply the same threshold. The toggle does not — it decides on one exact daylight value:

```bash
if [[ -z $CURRENT_TEMP || $CURRENT_TEMP == $OFF_TEMP ]]; then
  TARGET_TEMP=$ON_TEMP
else
  TARGET_TEMP=$OFF_TEMP
fi
```

So any temperature that is neither exactly `$OFF_TEMP` nor below identity reads as **off** in the indicator while the toggle treats it as on and sets daylight again. The first press does nothing the user can see, and night light takes two.

## Measured with the repo's own stubs

| current | `--status` says | one press lands on |
|---|---|---|
| 4000 | on | 6500 ✔ |
| 5999 | on | 6500 ✔ |
| **6000** | **off** | **6500 ✘** |
| **6200** | **off** | **6500 ✘** |
| **6499** | **off** | **6500 ✘** |
| 6500 | off | 4000 ✔ |

Only exactly 6500 turns night light on. The band is reachable without doing anything unusual: `hyprsunset` can be started with its own `-t`, another tool can set a temperature, and a gradual transition passes through it on the way down.

## Fix

```bash
if [[ -z $CURRENT_TEMP ]] || (( CURRENT_TEMP >= IDENTITY_TEMP )); then
```

One press is now always the inverse of what the indicator shows, which is the property the two halves were documented to share. The empty case still warms, as before, for a `hyprsunset` that has just been started and cannot be queried yet.

## Verification

`nightlight-test.sh` gained the whole table above rather than a single case — the three daylight temperatures the indicator calls off must all warm to 4000, and 3000/4000/5999 must all restore 6500 in one press — plus an assertion that the toggle decides on `IDENTITY_TEMP` and no longer on one exact value. 16 assertions, green with the change; reverting only `bin/` fails at 6000K.

Not run: no Hyprland or hyprsunset here, so this is the existing test's stubbed `hyprctl`, not a real screen changing colour.