### PR TITLE
Require signed packages from the Omarchy repository

### DIFF
--- a/default/pacman/pacman-edge.conf
+++ b/default/pacman/pacman-edge.conf
@@ -26,7 +26,6 @@ Include = /etc/pacman.d/mirrorlist
 Include = /etc/pacman.d/mirrorlist
 
 [omarchy]
-SigLevel = Optional TrustAll
 Server = https://pkgs.omarchy.org/edge/$arch
 
 # Repositories for debug symbol packages.

--- a/default/pacman/pacman-rc.conf
+++ b/default/pacman/pacman-rc.conf
@@ -26,5 +26,4 @@ Include = /etc/pacman.d/mirrorlist
 Include = /etc/pacman.d/mirrorlist
 
 [omarchy]
-SigLevel = Optional TrustAll
 Server = https://pkgs.omarchy.org/edge/$arch

--- a/default/pacman/pacman-stable.conf
+++ b/default/pacman/pacman-stable.conf
@@ -26,5 +26,4 @@ Include = /etc/pacman.d/mirrorlist
 Include = /etc/pacman.d/mirrorlist
 
 [omarchy]
-SigLevel = Optional TrustAll
 Server = https://pkgs.omarchy.org/stable/$arch

--- a/migrations/1787589206.sh
+++ b/migrations/1787589206.sh
@@ -1,0 +1,20 @@
+echo "Require signed packages from the Omarchy repository"
+
+# The [omarchy] repo predates the Omarchy packaging key, so existing installs
+# carry a SigLevel override that also accepts unsigned packages. Packages are
+# signed now, so drop the override and let the repo inherit the global
+# SigLevel = Required DatabaseOptional like every other repo. Machine-wide and
+# self-detecting, so another user's rerun no-ops.
+omarchy_sig_override='SigLevel = Optional TrustAll'
+
+if [[ -f /etc/pacman.conf ]] &&
+  sed -n '/^\[omarchy\]/,/^\[/p' /etc/pacman.conf | grep -qxF "$omarchy_sig_override"; then
+  # Requiring signatures with an untrusted packaging key would fail every
+  # omarchy transaction, including the one that could repair it.
+  if omarchy-pkg-missing omarchy-keyring ||
+    ! sudo pacman-key --list-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 &>/dev/null; then
+    omarchy-update-keyring
+  fi
+
+  sudo sed -i "/^\[omarchy\]/,/^\[/{/^$omarchy_sig_override$/d}" /etc/pacman.conf
+fi


### PR DESCRIPTION
The global `SigLevel` has been `Required DatabaseOptional` all along, but the `[omarchy]` repo section overrode it with `SigLevel = Optional TrustAll`, so pacman accepted unsigned packages from Omarchy's own repository.

(This re-lands 39cffb8f, which briefly hit quattro through an accidental direct push and was reverted in 5afc9e14 so it could go through review here.)

## Changes

- **`default/pacman/pacman-{stable,rc,edge}.conf`** — drop the `SigLevel = Optional TrustAll` override from `[omarchy]` so the repo inherits the global `Required DatabaseOptional`, like `[core]`/`[extra]`/`[multilib]`. Fresh installs and `omarchy-refresh-pacman` pick this up automatically.
- **`migrations/1787589206.sh`** — hardens existing installs. It detects the old override inside the `[omarchy]` section of `/etc/pacman.conf`, ensures the packaging key is trusted first (via `omarchy-update-keyring` if `omarchy-keyring` or the key is missing — requiring signatures with an untrusted key would break the very transactions needed to repair it), then deletes just that line.

## Safety

- Migrated configs come out byte-identical to the new defaults (verified against both the stable and edge layouts).
- Idempotent: a second user's rerun detects nothing to do and no-ops.
- Customizations survive: the sed is scoped to the `[omarchy]` section, so a user-added repo with its own lax `SigLevel` is untouched, as is the hardware `[arch-mact2] SigLevel = Never` section.
- `omarchy-upgrade-to-quattro` intentionally still writes `Optional TrustAll` during bootstrap (the keyring isn't trusted yet at that point); its `run_post_upgrade_migrations` step then runs this migration in the same upgrade, so upgraded machines end hardened too.

## Prerequisite

This assumes pkgs.omarchy.org signs every published package (including anything currently in the repos) with the omarchy-keyring key. Any unsigned package in `[omarchy]` will fail to install once this ships — worth confirming on the packaging side before merge.