### PR TITLE
fix: detect early Codex app-server exits

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -474,18 +474,31 @@ def _cached_local_stats(max_age):
     return stats
 
 
+def rpc_send(proc, payload, operation):
+  try:
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+  except OSError as exc:
+    try:
+      proc.stdin.close()
+    except OSError:
+      pass
+    raise RuntimeError(f"Codex app-server exited before {operation}") from exc
+
+
 def rpc_request(proc, request_id, method, params=None, timeout=8):
   payload = {"id": request_id, "method": method, "params": params or {}}
-  proc.stdin.write(json.dumps(payload) + "\n")
-  proc.stdin.flush()
+  rpc_send(proc, payload, method)
   deadline = time.time() + timeout
   while time.time() < deadline:
     ready, _, _ = select.select([proc.stdout], [], [], 0.25)
     if not ready:
+      if proc.poll() is not None:
+        raise RuntimeError(f"Codex app-server exited before {method}")
       continue
     line = proc.stdout.readline()
     if not line:
-      break
+      raise RuntimeError(f"Codex app-server exited before {method}")
     try:
       message = json.loads(line)
     except Exception:
@@ -542,8 +555,7 @@ def fetch_codex_rpc():
 
   try:
     rpc_request(proc, 1, "initialize", {"clientInfo": {"name": "omarchy-agent-usage", "version": "1"}}, timeout=8)
-    proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
-    proc.stdin.flush()
+    rpc_send(proc, {"method": "initialized", "params": {}}, "initialized")
     account_msg = rpc_request(proc, 2, "account/read", timeout=4)
     limits_msg = rpc_request(proc, 3, "account/rateLimits/read", timeout=4)
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -68,6 +68,41 @@ pass "Codex collector does not double-count cache or reasoning tokens"
   fail "Codex collector identifies itself with an empty limits list" "$result"
 pass "Codex collector identifies itself with an empty limits list"
 
+mv "$TEST_HOME/bin/codex" "$TEST_HOME/bin/codex-working"
+cat >"$TEST_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+
+exec 1>&-
+sleep 2
+EOF
+chmod +x "$TEST_HOME/bin/codex"
+
+failed_rpc=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+[[ $(jq -r '.authHelpText' <<<"$failed_rpc") == "Codex app-server exited before initialize" ]] ||
+  fail "Codex collector identifies an app server that exits during startup" "$failed_rpc"
+pass "Codex collector identifies an app server that exits during startup"
+
+cat >"$TEST_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+
+read -r request
+exec 0<&-
+jq -cn --argjson id "$(jq -r '.id' <<<"$request")" '{id: $id, result: {}}'
+sleep 2
+EOF
+chmod +x "$TEST_HOME/bin/codex"
+
+failed_rpc=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+[[ $(jq -r '.authHelpText' <<<"$failed_rpc") == "Codex app-server exited before initialized" ]] ||
+  fail "Codex collector translates failure to send the initialized notification" "$failed_rpc"
+pass "Codex collector translates failure to send the initialized notification"
+
+mv "$TEST_HOME/bin/codex-working" "$TEST_HOME/bin/codex"
+
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.
 PI_HOME=$(mktemp -d)


### PR DESCRIPTION
## Summary

* Detect Codex app-server termination during requests and notifications immediately.
* Return an operation-specific error instead of waiting for the RPC timeout.
* Add regression coverage for startup EOF and failure while sending the initialized notification.

The approval-policy change previously included in this PR was removed because upstream commit 4cd8a08, merged as #7649, already resolved it with `-a on-request`. Issue #8032 was closed by that PR, so this PR does not close it.

## Testing

* `bash test/shell.d/agent-usage-codex-scanner-test.sh`
* `git diff --check`

The full `./test/shell` suite was also started; it reported an unrelated missing `omarchy-pkgs` checkout in `config-test.sh` and did not complete within the task timeout.