### PR TITLE
Use mise registry shorthands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ matching guide before starting:
 
 - [`agents/skills/command-metadata.md`](agents/skills/command-metadata.md) - adding or changing commands in `bin/`
 - [`agents/skills/install-scripts.md`](agents/skills/install-scripts.md) - working under `install/` or on system/user setup commands
+- [`agents/skills/mise-tools.md`](agents/skills/mise-tools.md) - adding or changing mise-managed tools
 - [`agents/skills/shell-dev.md`](agents/skills/shell-dev.md) - editing the Quickshell desktop under `shell/`
 - [`agents/skills/icon-font.md`](agents/skills/icon-font.md) - adding branded glyphs to `default/fonts/omarchy/omarchy.ttf`
 - [`agents/skills/acceptance-tests.md`](agents/skills/acceptance-tests.md) - writing or running graphical acceptance tests under `test/acceptance.d/`

--- a/agents/skills/mise-tools.md
+++ b/agents/skills/mise-tools.md
@@ -1,0 +1,11 @@
+# mise-managed tools
+
+Read this before adding or changing a mise-managed tool, including entries in `install/user/mise.sh` and calls to `omarchy-mise-install`.
+
+Use a mise registry shorthand such as `codex` or `hey-cli`. Do not add an explicit backend such as `github:owner/repo`, `aqua:owner/repo`, or `npm:package`.
+
+Before adding a tool, run `mise registry <name>` to confirm that its shorthand exists. The shorthand may differ from the installed binary name, so inspect the result instead of assuming they match.
+
+If the tool is missing, stop and request an upstream mise registry entry. Include the upstream repository or package URL and the binary Omarchy needs. Do not work around a missing entry with explicit backend syntax; wait for the registry entry before adding the tool to Omarchy.
+
+Registry shorthands let mise use <https://mise-versions.jdx.dev> for cached version and public GitHub release metadata. This avoids most unauthenticated GitHub API calls and reduces rate-limit failures and GitHub flakiness during Omarchy installs and updates.

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -25,13 +25,13 @@ fi
 
 case "$1" in
 pi) agent="pi"; name="Pi" ;;
-omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-my-pi" ;;
+omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="oh-my-pi" ;;
 opencode | open-code) agent="opencode"; name="OpenCode" ;;
-ori | openrouter) agent="ori"; name="Ori"; agent_package="github:OpenRouterLabs/ori-releases" ;;
+ori | openrouter) agent="ori"; name="Ori"; agent_package="ori" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
 codex) agent="codex"; name="Codex" ;;
 crush) agent="crush"; name="Crush" ;;
-grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
+grok) agent="grok"; name="Grok"; agent_package="grok" ;;
 agy | antigravity | antigravity-cli | gemini | gemini-cli) agent="agy"; name="Antigravity"; agent_package="antigravity-cli" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
 *)

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -5,11 +5,11 @@ omarchy-mise-install antigravity-cli agy
 omarchy-mise-install gh
 omarchy-mise-install copilot
 omarchy-mise-install opencode
-omarchy-mise-install npm:playwright playwright
+omarchy-mise-install playwright
 omarchy-mise-install pi
-omarchy-mise-install github:can1357/oh-my-pi omp
-omarchy-mise-install npm:@xai-official/grok grok
-omarchy-mise-install npm:@kitlangton/ghui ghui
-omarchy-mise-install aqua:modem-dev/hunk hunk
-omarchy-mise-install github:basecamp/hey-cli hey
-omarchy-mise-install github:OpenRouterLabs/ori-releases ori
+omarchy-mise-install oh-my-pi omp
+omarchy-mise-install grok
+omarchy-mise-install ghui
+omarchy-mise-install hunk
+omarchy-mise-install hey-cli hey
+omarchy-mise-install ori

--- a/migrations/1785617047.sh
+++ b/migrations/1785617047.sh
@@ -1,5 +1,5 @@
 echo "Install oh-my-pi (omp) via mise wrapper"
 
 if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
-  omarchy-mise-install github:can1357/oh-my-pi omp
+  omarchy-mise-install oh-my-pi omp
 fi

--- a/migrations/1785846769.sh
+++ b/migrations/1785846769.sh
@@ -1,8 +1,8 @@
 echo "Install default coding agent mise wrappers"
 
 if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
-  omarchy-mise-install github:can1357/oh-my-pi omp
-  omarchy-mise-install npm:@xai-official/grok grok
+  omarchy-mise-install oh-my-pi omp
+  omarchy-mise-install grok
   omarchy-mise-install crush
 elif [[ -f $HOME/.local/bin/omp ]] && grep -Eq 'mise use -g .*"oh-my-pi"' "$HOME/.local/bin/omp"; then
   rm -f "$HOME/.local/bin/omp"

--- a/migrations/1787215824.sh
+++ b/migrations/1787215824.sh
@@ -1,5 +1,5 @@
 echo "Install hey (hey-cli) via mise wrapper"
 
 if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
-  omarchy-mise-install github:basecamp/hey-cli hey
+  omarchy-mise-install hey-cli hey
 fi

--- a/migrations/1787342993.sh
+++ b/migrations/1787342993.sh
@@ -1,5 +1,5 @@
 echo "Install ori (OpenRouter's agent harness) via mise wrapper"
 
 if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
-  omarchy-mise-install github:OpenRouterLabs/ori-releases ori
+  omarchy-mise-install ori
 fi

--- a/migrations/1787590397.sh
+++ b/migrations/1787590397.sh
@@ -1,0 +1,29 @@
+echo "Switch mise wrappers to registry shorthands"
+
+legacy_template() {
+  local package=$1 bin=$2
+
+  printf '#!/bin/bash\nexport MISE_MINIMUM_RELEASE_AGE=0\nmise use -g --quiet "%s" || exit 1\nexec mise x "%s" -- "%s" "$@"' "$package" "$package" "$bin"
+}
+
+rewrite_wrapper() {
+  local old_package=$1 new_package=$2 command=$3
+  local wrapper="$HOME/.local/bin/$command"
+
+  [[ -f $wrapper && ! -L $wrapper && -r $wrapper ]] || return 0
+  (($(stat -c%s "$wrapper") <= 1024)) || return 0
+  [[ $(<"$wrapper") == "$(legacy_template "$old_package" "$command")" ]] || return 0
+  mise registry "$new_package" >/dev/null 2>&1 || return 0
+
+  omarchy-mise-install "$new_package" "$command"
+}
+
+if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  rewrite_wrapper npm:playwright playwright playwright
+  rewrite_wrapper github:can1357/oh-my-pi oh-my-pi omp
+  rewrite_wrapper npm:@xai-official/grok grok grok
+  rewrite_wrapper npm:@kitlangton/ghui ghui ghui
+  rewrite_wrapper aqua:modem-dev/hunk hunk hunk
+  rewrite_wrapper github:basecamp/hey-cli hey-cli hey
+  rewrite_wrapper github:OpenRouterLabs/ori-releases ori ori
+fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -93,11 +93,12 @@ export OMARCHY_TEST_AGENT_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
 export OMARCHY_PATH="$ROOT"
 
-grok_package="npm:@xai-official/grok"
-omp_package="github:can1357/oh-my-pi"
+grok_package="grok"
+omp_package="oh-my-pi"
+legacy_omp_package="github:can1357/oh-my-pi"
 crush_package="crush"
 agy_package="antigravity-cli"
-ori_package="github:OpenRouterLabs/ori-releases"
+ori_package="ori"
 
 assert_lazy_stub() {
   local package=$1
@@ -120,11 +121,74 @@ pass "custom agent lazy stubs preserve their mise packages"
 
 source "$ROOT/install/user/mise.sh"
 grep -Fx "$agy_package agy" "$stub_log" >/dev/null || fail "user setup creates the Antigravity lazy stub"
-grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
+grep -Fx "$grok_package" "$stub_log" >/dev/null || fail "user setup creates the Grok lazy stub"
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "user setup creates the Oh My Pi lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the Crush lazy stub"
-grep -Fx "$ori_package ori" "$stub_log" >/dev/null || fail "user setup creates the Ori lazy stub"
+grep -Fx "$ori_package" "$stub_log" >/dev/null || fail "user setup creates the Ori lazy stub"
 pass "user setup creates the custom agent lazy stubs"
+
+if grep -Eq '^omarchy-mise-install [^[:space:]]+:' "$ROOT/install/user/mise.sh"; then
+  fail "user setup uses only mise registry shorthands"
+fi
+pass "user setup uses only mise registry shorthands"
+
+write_legacy_wrapper() {
+  local package=$1 command=$2
+
+  printf '#!/bin/bash\nexport MISE_MINIMUM_RELEASE_AGE=0\nmise use -g --quiet "%s" || exit 1\nexec mise x "%s" -- "%s" "$@"\n' \
+    "$package" "$package" "$command" >"$test_home/.local/bin/$command"
+  chmod +x "$test_home/.local/bin/$command"
+}
+
+wrapper_migrations=(
+  'npm:playwright|playwright|playwright'
+  'github:can1357/oh-my-pi|oh-my-pi|omp'
+  'npm:@xai-official/grok|grok|grok'
+  'npm:@kitlangton/ghui|ghui|ghui'
+  'aqua:modem-dev/hunk|hunk|hunk'
+  'github:basecamp/hey-cli|hey-cli|hey'
+  'github:OpenRouterLabs/ori-releases|ori|ori'
+)
+
+for mapping in "${wrapper_migrations[@]}"; do
+  IFS='|' read -r legacy_package shorthand_package command <<<"$mapping"
+  write_legacy_wrapper "$legacy_package" "$command"
+done
+
+: >"$stub_log"
+export OMARCHY_TEST_MISE_FAIL=true
+source "$ROOT/migrations/1787590397.sh" >/dev/null
+unset OMARCHY_TEST_MISE_FAIL
+[[ ! -s $stub_log ]] || fail "registry shorthand migration preserves wrappers unsupported by the installed mise"
+for mapping in "${wrapper_migrations[@]}"; do
+  IFS='|' read -r legacy_package shorthand_package command <<<"$mapping"
+  grep -Fq "$legacy_package" "$test_home/.local/bin/$command" ||
+    fail "registry shorthand migration leaves unsupported $command wrapper intact"
+done
+pass "registry shorthand migration requires shorthand support from the installed mise"
+
+source "$ROOT/migrations/1787590397.sh" >/dev/null
+for mapping in "${wrapper_migrations[@]}"; do
+  IFS='|' read -r legacy_package shorthand_package command <<<"$mapping"
+  expected="$shorthand_package $command"
+  grep -Fx "$expected" "$stub_log" >/dev/null ||
+    fail "registry shorthand migration rewrites $command with $shorthand_package"
+  rm -f "$test_home/.local/bin/$command"
+done
+[[ $(wc -l <"$stub_log") == ${#wrapper_migrations[@]} ]] || fail "registry shorthand migration rewrites each known wrapper once"
+pass "registry shorthand migration rewrites every known Omarchy wrapper"
+
+cat >"$test_home/.local/bin/hunk" <<'EOF'
+#!/bin/bash
+echo "user-owned hunk"
+EOF
+chmod +x "$test_home/.local/bin/hunk"
+: >"$stub_log"
+source "$ROOT/migrations/1787590397.sh" >/dev/null
+[[ ! -s $stub_log ]] || fail "registry shorthand migration leaves unrecognized wrappers alone"
+grep -Fq 'user-owned hunk' "$test_home/.local/bin/hunk" || fail "registry shorthand migration preserves a user-owned wrapper"
+rm -f "$test_home/.local/bin/hunk"
+pass "registry shorthand migration rewrites only recognized Omarchy wrappers"
 
 : >"$stub_log"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
@@ -132,12 +196,12 @@ grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "Oh My Pi migration c
 
 : >"$stub_log"
 source "$ROOT/migrations/1787342993.sh" >/dev/null
-grep -Fx "$ori_package ori" "$stub_log" >/dev/null || fail "Ori migration creates a working lazy stub"
+grep -Fx "$ori_package" "$stub_log" >/dev/null || fail "Ori migration creates a working lazy stub"
 
 : >"$stub_log"
 source "$ROOT/migrations/1785846769.sh" >/dev/null
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "agent migration repairs the Oh My Pi lazy stub"
-grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "agent migration creates the Grok lazy stub"
+grep -Fx "$grok_package" "$stub_log" >/dev/null || fail "agent migration creates the Grok lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "agent migration creates the Crush lazy stub"
 
 : >"$stub_log"
@@ -216,6 +280,7 @@ touch "$test_home/.local/state/omarchy/preinstalls-removed"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
 source "$ROOT/migrations/1785846769.sh" >/dev/null
 source "$ROOT/migrations/1787342993.sh" >/dev/null
+source "$ROOT/migrations/1787590397.sh" >/dev/null
 [[ ! -s $stub_log ]] || fail "agent migrations respect the preinstall opt-out"
 [[ ! -e $test_home/.local/bin/omp ]] || fail "agent migration removes the obsolete Oh My Pi wrapper after opt-out"
 
@@ -229,11 +294,11 @@ for obsolete_form in 'mise use -g "oh-my-pi"' 'mise use -g --quiet "oh-my-pi"'; 
     fail "agent migration removes a wrapper built on [$obsolete_form]"
 done
 
-printf '#!/bin/bash\nmise use -g --quiet "%s" || exit 1\n' "$omp_package" >"$test_home/.local/bin/omp"
+printf '#!/bin/bash\nmise use -g --quiet "%s" || exit 1\n' "$legacy_omp_package" >"$test_home/.local/bin/omp"
 chmod +x "$test_home/.local/bin/omp"
 source "$ROOT/migrations/1785846769.sh" >/dev/null
 [[ -e $test_home/.local/bin/omp ]] ||
-  fail "agent migration keeps a wrapper built on $omp_package"
+  fail "agent migration keeps a wrapper built on $legacy_omp_package"
 rm -f "$test_home/.local/bin/omp"
 
 rm "$test_home/.local/state/omarchy/preinstalls-removed"


### PR DESCRIPTION
## Summary

- add an agent task guide requiring registry shorthands for mise-managed tools
- direct contributors to request missing tools upstream instead of using explicit backend syntax
- switch the installer, default-agent flow, and existing migrations to registry shorthands
- migrate existing lazy wrappers to shorthands while preserving the preinstall opt-out and user-owned wrappers
- enforce shorthand-only entries in the user mise manifest test

Registry-backed tools can use `mise-versions.jdx.dev` for cached version and public GitHub release metadata, avoiding most unauthenticated GitHub API calls and reducing rate-limit failures and GitHub flakiness.

## Registry dependencies

All required registry entries are merged:

- jdx/mise#12385
- jdx/mise#12386
- jdx/mise#12387
- jdx/mise#12388

## Testing

- `bash -n install/user/mise.sh bin/omarchy-default-agent migrations/1785617047.sh migrations/1785846769.sh migrations/1787215824.sh migrations/1787342993.sh migrations/1787590397.sh test/shell.d/default-agent-test.sh`
- `bash test/shell.d/default-agent-test.sh`
- `bash test/shell.d/mise-wrapper-quiet-migration-test.sh`
- `./test/cli`
