### PR TITLE
Install Grok Bot from grokbot-linux-port-bin

### DIFF
--- a/bin/omarchy-install-ai-grok-bot
+++ b/bin/omarchy-install-ai-grok-bot
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Install the Grok Bot desktop app
+# omarchy:requires-sudo=true
+
+set -e
+
+echo "Installing Grok Bot..."
+# omarchy/grok-bot 0.18.0 is broken as of 2026-08-24 and conflicts with the
+# replacement. Drop the exact package name only; grokbot-linux-port-bin
+# provides grok-bot, so pacman -Q grok-bot is not a safe install-time check.
+omarchy-pkg-drop grok-bot
+omarchy-pkg-aur-add grokbot-linux-port-bin
+
+echo "Opening Grok Bot..."
+setsid uwsm-app -- /usr/bin/grok-bot >/dev/null 2>&1 &
+
+echo ""
+echo "Grok Bot has been installed."

--- a/bin/omarchy-remove-ai-grok-bot
+++ b/bin/omarchy-remove-ai-grok-bot
@@ -5,7 +5,7 @@
 
 set -e
 
-omarchy-pkg-drop grok-bot
+omarchy-pkg-drop grokbot-linux-port-bin grokbot-linux-port grok-bot
 
 # Not ~/.grok: that is the Grok CLI, which is installed and used on its own.
 rm -rf \

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -237,7 +237,7 @@
   "install.terminal.kitty": {"icon":"","label":"Kitty","disabled":"omarchy-pkg-present kitty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal kitty'"},
   "install.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","disabled":"omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-chatgpt"},
   "install.ai.dictation": {"icon":"","label":"Dictation","disabled":"omarchy-pkg-present voxtype-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"},
-  "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","disabled":"omarchy-pkg-present grok-bot","action":"omarchy-install-and-launch 'Grok Bot' grok-bot grok-bot"},
+  "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","disabled":"omarchy-pkg-present grokbot-linux-port-bin || omarchy-pkg-present grokbot-linux-port","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-grok-bot"},
   "install.ai.lm-studio": {"icon":"","iconFont":"omarchy","label":"LM Studio","disabled":"omarchy-pkg-present lmstudio-bin","action":"omarchy-install-app 'LM Studio' lmstudio-bin"},
   "install.ai.ollama": {"icon":"","iconFont":"omarchy","label":"Ollama","disabled":"omarchy-cmd-present ollama","action":"if omarchy-cmd-present nvidia-smi; then ollama_pkg=ollama-cuda; elif omarchy-cmd-present rocminfo; then ollama_pkg=ollama-rocm; else ollama_pkg=ollama; fi; omarchy-install-app Ollama \"$ollama_pkg\""},
   "install.ai.t3-code": {"icon":"","iconFont":"omarchy","label":"T3 Code","disabled":"omarchy-pkg-present t3code-bin","action":"omarchy-install-and-launch 'T3 Code' t3code-bin t3code"},

--- a/test/shell.d/remove-ai-test.sh
+++ b/test/shell.d/remove-ai-test.sh
@@ -77,6 +77,7 @@ pass "T3 Code removal keeps the agent state it bootstrapped"
 
 # ~/.grok belongs to the Grok CLI that omarchy-default-agent installs.
 fresh_home
+: >"$TEST_LOG"
 mkdir -p "$HOME/.config/Grok Bot" "$HOME/.grokbot" "$HOME/.grok"
 "$ROOT/bin/omarchy-remove-ai-grok-bot" >/dev/null
 
@@ -85,6 +86,18 @@ pass "Grok Bot removal deletes its own data"
 
 [[ -d $HOME/.grok ]] || fail "Grok Bot removal keeps the Grok CLI's state"
 pass "Grok Bot removal keeps the Grok CLI's state"
+
+drop_line=$(<"$TEST_LOG")
+[[ $drop_line == drop:grokbot-linux-port-bin\ grokbot-linux-port\ grok-bot ]] ||
+  fail "Grok Bot removal drops the linux-port package and the stale grok-bot" "$drop_line"
+pass "Grok Bot removal drops the linux-port package and the stale grok-bot"
+
+install_row=$(grep '^  "install.ai.grok-bot":' "$ROOT/default/omarchy/omarchy-menu.jsonc")
+[[ $install_row == *'omarchy-install-ai-grok-bot'* ]] ||
+  fail "Grok Bot install uses the linux-port installer" "$install_row"
+[[ $install_row == *'grokbot-linux-port-bin'* ]] ||
+  fail "Grok Bot install is disabled only when linux-port is present" "$install_row"
+pass "Grok Bot install uses grokbot-linux-port-bin"
 
 # Every acceleration variant depends on the base package, so package presence is
 # the test the remover can actually act on; the command alone is also provided by


### PR DESCRIPTION
Fixes #8070

Install → AI → Grok Bot currently runs `omarchy-pkg-add grok-bot`, which pulls **omarchy/grok-bot 0.18.0**. That package does not work as of 2026-08-24.

This switches the installer to AUR [`grokbot-linux-port-bin`](https://aur.archlinux.org/packages/grokbot-linux-port-bin) ([Nichokas/grokbot-linux-port](https://github.com/Nichokas/grokbot-linux-port)), current Grok Bot 0.24.0.

- New `omarchy-install-ai-grok-bot`: drops the exact `grok-bot` package if it is installed (it conflicts), then `omarchy-pkg-aur-add grokbot-linux-port-bin`, then launches `/usr/bin/grok-bot`.
- Remove drops `grokbot-linux-port-bin`, `grokbot-linux-port`, and `grok-bot`.
- The install row is disabled only when linux-port is present, so a machine still on 0.18.0 can install the replacement from the menu.

`omarchy-pkg-present grok-bot` still matches linux-port because that package provides `grok-bot`.
