### PR TITLE
Stop the hybrid GPU test from failing without Omarchy installed

### DIFF
--- a/test/shell.d/hw-hybrid-gpu-test.sh
+++ b/test/shell.d/hw-hybrid-gpu-test.sh
@@ -39,7 +39,7 @@ STUB
 chmod +x "$fake_bin"/*
 
 hybrid_gpu() {
-  PATH="$fake_bin:$PATH" timeout --kill-after=1s 10s bash "$ROOT/bin/omarchy-hw-hybrid-gpu"
+  PATH="$fake_bin:$ROOT/bin:$PATH" timeout --kill-after=1s 10s bash "$ROOT/bin/omarchy-hw-hybrid-gpu"
 }
 
 hybrid_gpu ||


### PR DESCRIPTION
`test/all` fails on a fresh checkout unless the machine already has Omarchy installed.

`bin/omarchy-hw-hybrid-gpu` checks for supergfxctl through `omarchy-cmd-present`, which lives in `bin/`. The test helper only puts its stub directory on PATH, so that lookup finds nothing:

```
$ bash test/shell.d/hw-hybrid-gpu-test.sh
bin/omarchy-hw-hybrid-gpu: line 9: omarchy-cmd-present: command not found
not ok - hybrid GPU detection sees a supported Hybrid mode
```

The test already stubs `omarchy-cmd-present` at line 83 so the last assertion can see it missing. The earlier assertions were meant to run the real one. On a machine that does have Omarchy installed they pass by running the installed copy instead of the checkout.

Putting `$ROOT/bin` after the stubs is what seventy other files in `test/shell.d` already do, twenty three of them with this same stub-first ordering. The stubs still come first, so `supergfxctl` and `lspci` are untouched.

Before this, on a machine without Omarchy, `1 of 193 test files failed`. After it, `All 193 test files passed`.

Swapping `grep -qw Hybrid` for `grep -qw NOPE` in the script still fails the test, so it keeps its teeth.
