### PR TITLE
Draw the screensaver from words you type

### DIFF
--- a/bin/omarchy-branding-screensaver
+++ b/bin/omarchy-branding-screensaver
@@ -3,26 +3,110 @@
 # omarchy:summary=Edit, set, or reset screensaver branding
 # omarchy:group=branding
 # omarchy:name=screensaver
-# omarchy:args=<image|text|reset>
-# omarchy:examples=omarchy branding screensaver image | omarchy branding screensaver text | omarchy branding screensaver reset
+# omarchy:args=<image|text|words [text]|reset>
+# omarchy:examples=omarchy branding screensaver image | omarchy branding screensaver words | omarchy branding screensaver words Omarchy | omarchy branding screensaver reset
 
 set -euo pipefail
+
+SCREENSAVER_FILE=~/.config/omarchy/branding/screensaver.txt
+
+# The screensaver fills every monitor with a terminal and ttfx draws the art into
+# a canvas the size of it. It is not given --wrap-text, so art wider than the
+# canvas is cut off at both edges rather than wrapped, and the art has to fit the
+# narrowest monitor.
+#
+# Every screensaver terminal config sets JetBrains Mono at size 18. Its advance is
+# 0.6em, and foot -- which is what these sizes are measured against -- leaves
+# dpi-aware off by default, so a point is 96dpi and the monitor's scale is what
+# multiplies the font rather than its physical DPI. That puts a column at 14.4
+# scaled pixels, which the terminal then rounds to a whole pixel.
+#
+# Measured against real terminals: 1280 wide at scale 1 gives 91 columns, 1920 at
+# scale 1 gives 137, 1920 at scale 1.5 gives 87, and 3840 at scale 2 gives 132.
+# This reproduces all four.
+COLUMN_WIDTH=14.4
+
+# What the image path already targets, for a machine with no compositor to ask:
+# omarchy-transcode-ascii defaults to this width and the shipped logo fits it.
+FALLBACK_COLUMNS=80
+
+screensaver_columns() {
+  local columns=""
+
+  # A monitor turned on its side is as wide as it is tall, the same way the
+  # acceptance helpers read it.
+  columns=$(hyprctl monitors -j 2>/dev/null |
+    jq -r --argjson column "$COLUMN_WIDTH" '
+      [ .[]
+        | (if (.transform // 0) % 2 == 1 then .height else .width end) as $across
+        | ($column * .scale | round) as $cell
+        | $across / $cell | floor
+      ] | min' 2>/dev/null) || columns=""
+
+  [[ $columns =~ ^[0-9]+$ ]] && ((columns > 0)) || columns=$FALLBACK_COLUMNS
+
+  printf '%s' "$columns"
+}
+
+# wc -L counts display columns only in a UTF-8 locale. The art is drawn in block
+# characters, which a session that never set one counts as nothing.
+art_columns() {
+  LC_ALL=C.UTF-8 wc -L
+}
+
+set_from_words() {
+  local text="$1"
+  local columns art
+
+  columns=$(screensaver_columns)
+
+  # Drawn to a file rather than captured in a variable: the last row of a glyph
+  # like A or O is blank, and command substitution eats it, which would leave the
+  # art a row shorter than the renderer drew it and shift where ttfx centres it.
+  # Anything the font could not draw is named on stderr rather than swallowed.
+  art=$(mktemp)
+
+  if ! omarchy-ascii -- "$text" >"$art"; then
+    rm -f "$art"
+    omarchy-notification-send -g 󱄄 "Nothing to draw" "The screensaver font draws letters and spaces only"
+    exit 1
+  fi
+
+  if (($(art_columns <"$art") > columns)); then
+    rm -f "$art"
+    omarchy-notification-send -g 󱄄 "Text too long" "It draws wider than the $columns columns this screen has"
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$SCREENSAVER_FILE")"
+  cat "$art" >"$SCREENSAVER_FILE"
+  rm -f "$art"
+  omarchy-launch-screensaver force >/dev/null 2>&1
+}
 
 case "${1:-}" in
 image)
   image=$(omarchy-file-select --title "Pick PNG or SVG for screensaver" --extensions "png svg")
-  if omarchy-transcode-ascii "$image" ~/.config/omarchy/branding/screensaver.txt; then
+  if omarchy-transcode-ascii "$image" "$SCREENSAVER_FILE"; then
     omarchy-launch-screensaver force >/dev/null 2>&1
   fi
   ;;
+words)
+  shift
+  if (($# > 0)); then
+    set_from_words "$*"
+  else
+    omarchy-shell shell summon omarchy.screensaver-text "{\"columns\":$(screensaver_columns)}"
+  fi
+  ;;
 text)
-  omarchy-launch-editor ~/.config/omarchy/branding/screensaver.txt >/dev/null 2>&1 && omarchy-launch-screensaver force >/dev/null 2>&1
+  omarchy-launch-editor "$SCREENSAVER_FILE" >/dev/null 2>&1 && omarchy-launch-screensaver force >/dev/null 2>&1
   ;;
 reset)
-  cp "$OMARCHY_PATH/logo.txt" ~/.config/omarchy/branding/screensaver.txt && omarchy-launch-screensaver force >/dev/null 2>&1
+  cp "$OMARCHY_PATH/logo.txt" "$SCREENSAVER_FILE" && omarchy-launch-screensaver force >/dev/null 2>&1
   ;;
 *)
-  echo "Usage: omarchy-branding-screensaver <image|text|reset>" >&2
+  echo "Usage: omarchy-branding-screensaver <image|text|words [text]|reset>" >&2
   exit 1
   ;;
 esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -120,6 +120,7 @@
   "style.about.default": {"icon":"","label":"Restore Default","action":"omarchy-branding-about reset"},
   "style.screensaver.text": {"icon":"","label":"Edit Text","action":"omarchy-branding-screensaver text"},
   "style.screensaver.image": {"icon":"","label":"Set From Image","action":"omarchy-branding-screensaver image"},
+  "style.screensaver.words": {"icon":"󰌌","label":"Set From Text","action":"omarchy-branding-screensaver words"},
   "style.screensaver.default": {"icon":"","label":"Restore Default","action":"omarchy-branding-screensaver reset"},
 
   // Setup

--- a/manual/41-branding.md
+++ b/manual/41-branding.md
@@ -20,10 +20,11 @@ You can change the logo used for the screensaver under _Style > Screensaver_. It
 
  ![branding-screensaver](images/branding-screensaver.webp)
 
-There are three entries in that menu:
+There are four entries in that menu:
 
 - **Edit Text** opens `~/.config/omarchy/branding/screensaver.txt` in your editor. Type or paste whatever you like — ASCII art, your name, a rude word. Save and quit, and the screensaver fires up immediately so you can see it.
 - **Set From Image** opens a file picker for a png or svg, converts it to ASCII, and shows you the result. Logos with a clear silhouette work far better than photos.
+- **Set From Text** asks you for a few words and draws them in the same font as the Omarchy wordmark. The box stops taking letters once the next one would run off the edge of your narrowest screen, so whatever you can type is whatever fits — and since that font has no digits or punctuation, those keys do nothing here.
 - **Restore Default** puts the Omarchy logo back.
 
 ### About screen

--- a/shell/plugins/screensaver-text/ScreensaverTextFlow.qml
+++ b/shell/plugins/screensaver-text/ScreensaverTextFlow.qml
@@ -1,0 +1,166 @@
+import Quickshell
+import Quickshell.Wayland
+import QtQuick
+import qs.Commons
+import qs.Ui
+import "ScreensaverTextModel.js" as ScreensaverTextModel
+
+Item {
+  id: root
+
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  property var shell: null
+  property var manifest: null
+
+  property bool opened: false
+  property string filterText: ""
+  property string fontFamily: Style.font.menuFamily
+
+  // How many columns of art the narrowest monitor can show. omarchy-branding-
+  // screensaver works that out and passes it in; the fallback is the width the
+  // image path already targets, for a summon that arrives without one.
+  readonly property int fallbackColumns: 80
+  property int columns: fallbackColumns
+
+  property color background: Color.menu.background
+  property color foreground: Color.menu.text
+  property color border: Color.menu.border
+  property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
+  property color scrim: Color.menu.scrim
+  readonly property int cornerRadius: Style.cornerRadius
+  property int contentMargin: Style.spacing.panelPadding
+  property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
+  property int cardWidth: Math.min(Style.space(300), panel.width - Style.gapsOut * 2)
+  property int cardHeight: Math.min(contentMargin * 2 + headerHeight, panel.height - Style.gapsOut * 2)
+  readonly property string promptText: "Screensaver text"
+
+  function open(payloadJson) {
+    // The plugin stays loaded between summons, so every field a payload can set
+    // is reset here rather than left holding what the last one said. JSON.parse
+    // returns null for "null" as happily as it throws on nonsense, and either
+    // one reaching the lines below would leave the panel unopened.
+    var payload = null
+    try { payload = JSON.parse(payloadJson || "{}") } catch (e) { payload = null }
+    if (!payload || typeof payload !== "object") payload = ({})
+
+    root.fontFamily = payload.fontFamily || Style.font.menuFamily
+    root.columns = payload.columns > 0 ? payload.columns : root.fallbackColumns
+
+    root.opened = true
+    root.filterText = ""
+
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function close() {
+    root.opened = false
+  }
+
+  function dismiss() {
+    root.opened = false
+    if (root.shell && typeof root.shell.hide === "function")
+      root.shell.hide((root.manifest && root.manifest.id) || "omarchy.screensaver-text")
+  }
+
+  function toggle() {
+    if (root.opened) root.dismiss()
+    else root.open("{}")
+  }
+
+  function setFilter(nextFilter) {
+    root.filterText = nextFilter
+  }
+
+  function submit() {
+    var selection = root.filterText.trim()
+
+    if (!selection) {
+      root.dismiss()
+      return
+    }
+
+    root.dismiss()
+    Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-branding-screensaver", "words", selection])
+  }
+
+  PanelWindow {
+    id: panel
+    visible: root.opened
+    anchors { top: true; bottom: true; left: true; right: true }
+    color: "transparent"
+    WlrLayershell.namespace: "omarchy-screensaver-text"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    exclusionMode: ExclusionMode.Ignore
+
+    Rectangle {
+      anchors.fill: parent
+      color: root.scrim
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: root.dismiss()
+    }
+
+    BorderSurface {
+      id: card
+      width: root.cardWidth
+      height: root.cardHeight
+      radius: root.cornerRadius
+      anchors.centerIn: parent
+      color: root.background
+      borderSpec: root.borderSpec
+      padding: root.contentMargin
+
+      MouseArea { anchors.fill: parent; onClicked: {} }
+
+      Item {
+        id: keyCatcher
+        anchors.fill: parent
+        focus: true
+
+        Keys.priority: Keys.BeforeItem
+        Keys.onPressed: function(event) {
+          if (event.key === Qt.Key_Escape) {
+            if (root.filterText) root.setFilter("")
+            else root.dismiss()
+            event.accepted = true
+          } else if (Util.editsFilter(event, root.filterText)) {
+            root.setFilter(Util.editedFilter(event, root.filterText))
+            event.accepted = true
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            root.submit()
+            event.accepted = true
+          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127) {
+            // A character the font cannot draw, or one that would push the art
+            // past the edge of the screen, is dropped rather than typed: what
+            // you can see here is what the screensaver can show.
+            root.setFilter(ScreensaverTextModel.extended(root.filterText, event.text, root.columns))
+            event.accepted = true
+          }
+        }
+      }
+
+      Item {
+        anchors.fill: parent
+        anchors.topMargin: card.contentTopInset
+        anchors.rightMargin: card.contentRightInset
+        anchors.bottomMargin: card.contentBottomInset
+        anchors.leftMargin: card.contentLeftInset
+
+        Text {
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          text: root.filterText || (root.promptText + "...")
+          color: root.foreground
+          opacity: root.filterText ? 1 : 0.58
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.heading
+          elide: Text.ElideRight
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/screensaver-text/ScreensaverTextModel.js
+++ b/shell/plugins/screensaver-text/ScreensaverTextModel.js
@@ -1,0 +1,81 @@
+// How wide omarchy-ascii draws each character, in terminal columns: the width it
+// takes as the first character of a line, and the width it adds after one. Both
+// are properties of Delta Corps Priest 1, which is embedded in omarchy-ascii, and
+// screensaver-text-test.sh measures the renderer to check every entry against it.
+//
+// A character adds the same width whatever precedes it -- the font kerns, but the
+// amount never depends on the left neighbour -- so a line's width is the first
+// character's width plus the sum of what the rest add. Upper and lower case are
+// drawn identically, so one entry serves both.
+var METRICS = {
+  "A": [12, 13], "B": [12, 13], "C": [10, 11], "D": [10, 11], "E": [12, 13],
+  "F": [12, 13], "G": [12, 13], "H": [14, 15], "I": [4, 5], "J": [7, 8],
+  "K": [11, 12], "L": [9, 10], "M": [16, 16], "N": [9, 10], "O": [10, 11],
+  "P": [12, 13], "Q": [11, 12], "R": [12, 13], "S": [12, 13], "T": [11, 12],
+  "U": [10, 11], "V": [10, 11], "W": [11, 12], "X": [15, 16], "Y": [9, 10],
+  "Z": [11, 12], " ": [4, 5]
+}
+
+// The narrowest letter there is, which is what a space has to leave room for.
+var NARROWEST = "I"
+
+// Matched on the character itself rather than on its upper case: U+017F upper
+// cases to S and U+0131 to I, and the renderer can draw neither.
+function drawable(character) {
+  return /^[A-Za-z ]$/.test(String(character))
+}
+
+// Trailing blanks are trimmed off the art, so a space at the end costs nothing
+// until something follows it.
+function columnsFor(text) {
+  var body = String(text || "").replace(/ +$/, "")
+  var total = 0
+  var first = true
+
+  for (var i = 0; i < body.length; i++) {
+    var metric = METRICS[body[i].toUpperCase()]
+    if (!metric) continue
+    total += first ? metric[0] : metric[1]
+    first = false
+  }
+
+  return total
+}
+
+function accepts(text, character, columns) {
+  if (!drawable(character)) return false
+
+  var current = String(text || "")
+
+  // A space that opens the text, follows another space, or has no room for even
+  // the narrowest letter after it would sit in the box invisibly -- costing
+  // nothing to show, and then refusing the letter it was typed to separate.
+  if (character === " ") {
+    if (!current.length || current.slice(-1) === " ") return false
+    return columnsFor(current + " " + NARROWEST) <= columns
+  }
+
+  return columnsFor(current + character) <= columns
+}
+
+function extended(text, character, columns) {
+  var current = String(text || "")
+  return accepts(current, character, columns) ? current + character : current
+}
+
+// The screensaver opens on every monitor and ttfx draws into a canvas the size of
+// the terminal, so the art has to fit the narrowest one.
+function fits(text, columns) {
+  return columnsFor(text) <= columns
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    METRICS: METRICS,
+    drawable: drawable,
+    columnsFor: columnsFor,
+    accepts: accepts,
+    extended: extended,
+    fits: fits
+  }
+}

--- a/shell/plugins/screensaver-text/manifest.json
+++ b/shell/plugins/screensaver-text/manifest.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.screensaver-text",
+  "name": "Screensaver Text",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Type the words the screensaver draws",
+  "kinds": [
+    "overlay"
+  ],
+  "keepLoaded": true,
+  "entryPoints": {
+    "overlay": "ScreensaverTextFlow.qml"
+  }
+}

--- a/test/shell.d/screensaver-text-test.sh
+++ b/test/shell.d/screensaver-text-test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+STUBS="$TMPDIR/stubs"
+mkdir -p "$STUBS"
+export PATH="$STUBS:$ROOT/bin:$PATH"
+
+MODEL="$ROOT/shell/plugins/screensaver-text/ScreensaverTextModel.js"
+
+stub() {
+  local name="$1"
+  shift
+  printf '#!/bin/bash\n%s\n' "$*" >"$STUBS/$name"
+  chmod +x "$STUBS/$name"
+}
+
+monitors() {
+  stub hyprctl "cat <<'JSON'
+$1
+JSON"
+}
+
+stub omarchy-launch-screensaver 'exit 0'
+stub omarchy-notification-send 'printf "%s\n" "$*" >>"$TMPDIR/notifications"'
+stub omarchy-shell 'printf "%s\n" "$*" >>"$TMPDIR/summons"'
+sed -i "s|\$TMPDIR|$TMPDIR|" "$STUBS/omarchy-notification-send" "$STUBS/omarchy-shell"
+
+branding="$TMPDIR/.config/omarchy/branding"
+
+run_node_test <<'JS'
+const model = requireFromRoot('shell/plugins/screensaver-text/ScreensaverTextModel.js')
+
+assertEqual(model.columnsFor('Omarchy'), 88, 'the wordmark measures 88 columns')
+assertEqual(model.columnsFor(''), 0, 'empty text measures nothing')
+assertEqual(model.columnsFor('omarchy'), model.columnsFor('OMARCHY'), 'case does not change the width')
+
+// Trailing blanks come off the art, so a space at the end is free until
+// something follows it.
+assertEqual(model.columnsFor('Hi '), model.columnsFor('Hi'), 'a trailing space costs nothing')
+assert(model.columnsFor('H i') > model.columnsFor('Hi'), 'a space between letters costs something')
+
+assert(model.drawable('a'), 'a letter is drawable')
+assert(model.drawable(' '), 'a space is drawable')
+assert(!model.drawable('4'), 'a digit is not drawable')
+assert(!model.drawable('.'), 'a full stop is not drawable')
+assert(!model.drawable('ab'), 'only single characters are drawable')
+
+// U+017F upper cases to S and U+0131 to I, so a check on the upper case alone
+// would let through two characters the renderer cannot draw.
+assert(!model.drawable('ſ'), 'a long s is not drawable though it upper cases to S')
+assert(!model.drawable('ı'), 'a dotless i is not drawable though it upper cases to I')
+assertEqual(model.extended('A', 'ſ', 200), 'A', 'a long s is refused rather than typed')
+
+assertEqual(model.extended('Omarch', 'y', 200), 'Omarchy', 'a character that fits is typed')
+assertEqual(model.extended('Omarch', 'y', 80), 'Omarch', 'a character that would overflow is dropped')
+assertEqual(model.extended('Omarch', '4', 200), 'Omarch', 'a character the font cannot draw is dropped')
+assertEqual(model.extended('', 'M', 10), '', 'even the first character has to fit')
+
+// A space nobody can see is a space that silently eats the next letter's room.
+assertEqual(model.extended('', ' ', 200), '', 'the text cannot open with a space')
+assertEqual(model.extended('A ', ' ', 200), 'A ', 'a second space in a row is refused')
+assertEqual(model.extended('A', ' ', 200), 'A ', 'a space between words is allowed')
+assertEqual(model.extended('Omarchy', ' ', 88), 'Omarchy', 'a space with no room for a letter after it is refused')
+assertEqual(model.extended('Omarchy', ' ', 98), 'Omarchy ', 'a space with room for a letter after it is allowed')
+
+assert(model.fits('Omarchy', 88), 'art exactly as wide as the screen fits')
+assert(!model.fits('Omarchy', 87), 'a column too wide does not fit')
+JS
+
+# The table is a measurement of a font that lives in another file, so measure the
+# renderer and check every entry against it: each letter alone for its width in
+# first position, and each between two others for what it adds after one.
+probes=()
+for c in {A..Z} {a..z}; do probes+=("$c"); done
+for c in {A..Z} {a..z}; do probes+=("A${c}A"); done
+probes+=("A A" "A  A" " A" "Omarchy" "Hi" "H i" "Set From Text" "Wavy" "jelly" "MMMM" "iiii")
+
+predicted=$(node -e '
+  const model = require(process.argv[1])
+  console.log(process.argv.slice(2).map(w => model.columnsFor(w)).join("\n"))
+' "$MODEL" "${probes[@]}")
+
+actual=$(printf '%s\n' "${probes[@]}" |
+  omarchy-ascii |
+  LC_ALL=C.UTF-8 awk '{ w = length($0); if (w > max) max = w } NR % 9 == 0 { print max; max = 0 }')
+
+[[ $predicted == "$actual" ]] || fail "the model measures what omarchy-ascii draws" "predicted:
+$predicted
+actual:
+$actual"
+pass "the model measures what omarchy-ascii draws"
+
+# 1280 wide at scale 1 is 91 columns of JetBrains Mono at size 18, measured in a
+# real screensaver terminal. The narrowest monitor is the one the art must fit.
+monitors '[{"width":1280,"height":800,"scale":1.0,"transform":0},{"width":3840,"height":2160,"scale":1.0,"transform":0}]'
+HOME="$TMPDIR" omarchy-branding-screensaver words
+summon=$(<"$TMPDIR/summons")
+[[ $summon == *"omarchy.screensaver-text"* ]] || fail "the menu entry summons the text panel" "got: $summon"
+[[ $summon == *'"columns":91'* ]] || fail "the panel is told the narrowest monitor's columns" "got: $summon"
+pass "the panel is told the narrowest monitor's columns"
+
+# A terminal cannot draw a fractional cell, so it rounds one: 14.4 at scale 1.5
+# is a 22 pixel column, which is 87 of them across 1920 rather than 88.
+rm -f "$TMPDIR/summons"
+monitors '[{"width":1920,"height":1080,"scale":1.5,"transform":0}]'
+HOME="$TMPDIR" omarchy-branding-screensaver words
+[[ $(<"$TMPDIR/summons") == *'"columns":87'* ]] || fail "a fractional scale rounds to whole pixel columns" "got: $(<"$TMPDIR/summons")"
+pass "a fractional scale rounds to whole pixel columns"
+
+rm -f "$TMPDIR/summons"
+monitors '[{"width":3840,"height":2160,"scale":2.0,"transform":0}]'
+HOME="$TMPDIR" omarchy-branding-screensaver words
+[[ $(<"$TMPDIR/summons") == *'"columns":132'* ]] || fail "a doubled scale counts its own columns" "got: $(<"$TMPDIR/summons")"
+pass "a doubled scale counts its own columns"
+
+# A monitor on its side is as wide as it is tall.
+rm -f "$TMPDIR/summons"
+monitors '[{"width":1920,"height":1080,"scale":1.0,"transform":1}]'
+HOME="$TMPDIR" omarchy-branding-screensaver words
+[[ $(<"$TMPDIR/summons") == *'"columns":77'* ]] || fail "a rotated monitor measures across its height" "got: $(<"$TMPDIR/summons")"
+pass "a rotated monitor measures across its height"
+
+rm -f "$TMPDIR/summons"
+stub hyprctl 'exit 1'
+HOME="$TMPDIR" omarchy-branding-screensaver words
+[[ $(<"$TMPDIR/summons") == *'"columns":80'* ]] || fail "no compositor falls back to the width the image path targets" "got: $(<"$TMPDIR/summons")"
+pass "no compositor falls back to the width the image path targets"
+
+monitors '[{"width":1920,"height":1080,"scale":1.0,"transform":0}]'
+HOME="$TMPDIR" omarchy-branding-screensaver words Omarchy
+[[ -f $branding/screensaver.txt ]] || fail "typed words are written to the screensaver branding"
+width=$(LC_ALL=C.UTF-8 wc -L <"$branding/screensaver.txt")
+(( width == 88 )) || fail "the art is the width the model predicted" "got $width columns"
+grep -q '█' "$branding/screensaver.txt" || fail "the branding file holds drawn art"
+pass "typed words are drawn into the screensaver branding"
+
+# The last row of an A is blank, and a variable would have eaten it: the art has
+# to reach the file exactly as the renderer drew it, or ttfx centres it wrong.
+HOME="$TMPDIR" omarchy-branding-screensaver words A
+rows=$(wc -l <"$branding/screensaver.txt")
+direct=$(omarchy-ascii A | wc -l)
+(( rows == direct )) || fail "the art keeps every row the renderer drew" "file has $rows rows, renderer draws $direct"
+pass "the art keeps every row the renderer drew"
+
+# A screen the art does not fit is the whole reason the input is capped, so the
+# command that the panel calls has to refuse it too.
+before=$(cat "$branding/screensaver.txt")
+status=0
+HOME="$TMPDIR" omarchy-branding-screensaver words "Something far too long to fit" || status=$?
+(( status == 1 )) || fail "text wider than the screen is refused" "exited $status"
+[[ $(cat "$branding/screensaver.txt") == "$before" ]] || fail "a refused text leaves the branding alone"
+[[ $(<"$TMPDIR/notifications") == *"Text too long"* ]] || fail "a refused text says why" "got: $(<"$TMPDIR/notifications")"
+pass "text wider than the screen is refused"
+
+rm -f "$TMPDIR/notifications"
+status=0
+HOME="$TMPDIR" omarchy-branding-screensaver words "4.0" 2>/dev/null || status=$?
+(( status == 1 )) || fail "text the font cannot draw is refused" "exited $status"
+[[ $(<"$TMPDIR/notifications") == *"Nothing to draw"* ]] || fail "undrawable text says why" "got: $(<"$TMPDIR/notifications")"
+pass "text the font cannot draw is refused"
+
+# The panel will not let a digit be typed, but the command is reachable without
+# it, and dropping half the text in silence would look like a renderer bug.
+warning=$(HOME="$TMPDIR" omarchy-branding-screensaver words "R2D2" 2>&1 >/dev/null)
+[[ $warning == *"Skipped"* && $warning == *"2"* ]] || fail "characters the font skipped are named" "got: $warning"
+pass "characters the font skipped are named"
+
+status=0
+HOME="$TMPDIR" omarchy-branding-screensaver bogus 2>/dev/null || status=$?
+(( status == 1 )) || fail "an unknown subcommand still fails" "exited $status"
+pass "an unknown subcommand still fails"


### PR DESCRIPTION
_Style > Screensaver > Set From Text_ asks for a few words and draws them in Delta Corps Priest 1, the font the Omarchy wordmark is drawn in, so a screensaver can say something without anyone having to hand it ASCII art:

The input is the reminder flow's, in a plugin of its own: a card, a key catcher, one line of text. It refuses a keystroke the font cannot draw and a keystroke that would push the art past the edge of the screen, so what can be typed is what will appear. Delta Corps Priest 1 carries letters and spaces only, which is why the digit keys do nothing.

How wide the screen is has to be worked out rather than assumed. The screensaver fills every monitor with a terminal and ttfx draws into a canvas the size of it, and it is not given `--wrap-text`, so art that does not fit is cut off at both edges rather than wrapped — and it has to fit the narrowest monitor. Every screensaver terminal sets JetBrains Mono at size 18, whose advance is 0.6em, and foot leaves `dpi-aware` off, so the monitor's scale is what multiplies the font rather than its physical DPI. That puts a column at 14.4 scaled pixels, which the terminal then rounds to a whole one. Measured against real terminals, that reproduces 91 columns at 1280 and scale 1, 137 at 1920, 87 at 1920 and scale 1.5, and 132 at 3840 and scale 2. A monitor on its side is measured across its height, the way the acceptance helpers already read one.

The cap is exact rather than a character count, because a letter here is anywhere from 4 columns to 16. A character in this font adds the same width whatever precedes it — the kerning never depends on the left neighbour, across all 2,704 letter pairs — so a line's width is the first character's width plus what the rest add, and a table of 27 entries measures any text to the column.

A space is refused where it would be invisible: opening the text, following another space, or with no room left for even the narrowest letter after it. A space costs nothing at the end of a line, since the art has its trailing blanks trimmed, so one left sitting there would silently spend the next letter's room and then refuse the letter it was typed to separate.

Four consequences worth naming rather than fixing.

Kitty and Ghostty read the user's own config alongside the screensaver one, and it sets only the font size and the padding. Someone who has set `font_family` or `modify_font cell_width` there gets a cap worked out for JetBrains Mono at its ordinary width, and art that overruns their screen. Foot and Alacritty take the screensaver config alone and are unaffected, and a font that wide already truncates the shipped logo.

When `hyprctl` cannot be asked, the cap falls back to the 80 columns the image path already targets. On a screen narrower than about 1,150 pixels that is itself too generous — but the screensaver only runs under Hyprland, so this is reachable only when monitor discovery fails on a machine where the screensaver is about to run anyway.

Rotating a monitor, or plugging in a narrower one, while the panel is open leaves the panel capping against the columns it was opened with. The command measures again before it writes, so nothing oversized reaches the file; the typed text is refused instead of applied.

_Style > About_ has the same three entries and does not get this one. Its art is converted to a smaller size than the screensaver's, so the width it has to fit is a different number, and giving it the same entry is a decision about that screen rather than about this one.
