### PR TITLE
Stop AUR daemons from keeping the omarchy-update lock

### DIFF
--- a/bin/omarchy-update-lock
+++ b/bin/omarchy-update-lock
@@ -9,14 +9,12 @@ set -e
 lock_dir="${XDG_RUNTIME_DIR:-/tmp}"
 lock_path="$lock_dir/omarchy-update.lock"
 
+# The wrapper process holds the flock. The command runs with the descriptor
+# closed, so AUR daemons that outlive the update (Flutter's adb, for example)
+# cannot keep the lock after we exit. held() is an env flag set only for that
+# child, which is how omarchy-update knows not to acquire the lock a second time.
 lock_is_held() {
-  local lock_fd_path=""
-
-  [[ -n ${OMARCHY_UPDATE_LOCK_FD:-} && -e /proc/$$/fd/$OMARCHY_UPDATE_LOCK_FD ]] || return 1
-
-  lock_fd_path=$(readlink -f "/proc/$$/fd/$OMARCHY_UPDATE_LOCK_FD" 2>/dev/null || true)
-  [[ $lock_fd_path == "$(readlink -m "$lock_path")" ]] &&
-    flock -n "$OMARCHY_UPDATE_LOCK_FD"
+  [[ ${OMARCHY_UPDATE_LOCKED:-} == "1" ]]
 }
 
 case "${1:-}" in
@@ -37,8 +35,8 @@ case "${1:-}" in
       exit 1
     fi
 
-    export OMARCHY_UPDATE_LOCK_FD
-    exec "$@"
+    export OMARCHY_UPDATE_LOCKED=1
+    "$@" {OMARCHY_UPDATE_LOCK_FD}>&-
     ;;
   *)
     echo "Usage: omarchy-update-lock <held|run> [command] [args...]" >&2

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -186,11 +186,16 @@ file belongs to whoever created it first, so honouring it would let one user
 silence another user's notification. Missing an update and showing a redundant
 toast is the better failure.
 
-Suppression is why `omarchy-update-stay-awake` starts its sleep inhibitor with
-the lock descriptor closed. That inhibitor outlives the step that starts it, so
-an update killed before cleanup would otherwise leave it holding the flock
-indefinitely — blocking later updates and, now that the notifier reads the same
-lock, silencing migration notifications at every login.
+`omarchy-update-lock run` keeps the flock in the wrapper process and runs the
+update with that descriptor closed. AUR children that daemonize (Flutter's `adb`
+is the one that showed up in the wild) would otherwise inherit the flock, survive
+the update, and make every later `omarchy update` report that one is already
+running. `omarchy-update-stay-awake` still starts its sleep inhibitor with the
+lock descriptor closed when it has one, for the same reason: that inhibitor
+outlives the step that starts it, so an update killed before cleanup would
+otherwise leave it holding the flock indefinitely — blocking later updates and,
+now that the notifier reads the same lock, silencing migration notifications at
+every login.
 
 Fallbacks:
 

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 source "$(dirname "$0")/base-test.sh"
 
 test_tmp=$(mktemp -d)
-trap 'rm -rf "$test_tmp"' EXIT
+linger_pids=()
+trap 'for pid in "${linger_pids[@]}"; do kill "$pid" 2>/dev/null || true; done; rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
@@ -212,3 +213,98 @@ kill -0 "$unrelated_pid" 2>/dev/null ||
 kill "$unrelated_pid"
 wait "$unrelated_pid" 2>/dev/null || true
 pass "stale inhibitor state does not terminate a reused PID"
+
+# The lock wrapper used to exec the update, so every child inherited the flock.
+# Flutter's adb daemonizes onto user systemd and kept it after the update
+# exited; the next omarchy update then reported one was already running (#8077).
+linger="$test_tmp/linger"
+daemon_pid_file="$test_tmp/daemon.pid"
+cat >"$linger" <<'SH'
+#!/bin/bash
+printf '%s\n' "$$" >"$1"
+exec sleep 30
+SH
+chmod +x "$linger"
+
+lock_held_by_pid() {
+  local pid="$1"
+  local lock_target="$2"
+  local fd
+
+  for fd in /proc/"$pid"/fd/*; do
+    [[ -e $fd ]] || continue
+    [[ $(readlink -f "$fd" 2>/dev/null) == "$lock_target" ]] && return 0
+  done
+  return 1
+}
+
+run_with_lock_env "$ROOT/bin/omarchy-update-lock" run \
+  bash -c 'setsid -f "$1" "$2"' bash "$linger" "$daemon_pid_file" ||
+  fail "omarchy-update-lock run succeeds while spawning a daemonized child"
+
+for _ in {1..50}; do
+  [[ -s $daemon_pid_file ]] && break
+  sleep 0.02
+done
+[[ -s $daemon_pid_file ]] || fail "daemonized child recorded its pid"
+linger_pid=$(<"$daemon_pid_file")
+linger_pids+=("$linger_pid")
+kill -0 "$linger_pid" 2>/dev/null || fail "daemonized child outlives omarchy-update-lock"
+
+lock_target=$(readlink -f "$runtime_dir/omarchy-update.lock")
+lock_held_by_pid "$linger_pid" "$lock_target" &&
+  fail "daemonized child does not inherit the update lock descriptor"
+
+flock -n "$runtime_dir/omarchy-update.lock" true ||
+  fail "update lock is released after omarchy-update-lock exits despite a living daemonized child"
+
+run_with_lock_env "$ROOT/bin/omarchy-update-lock" run true ||
+  fail "a later omarchy-update-lock run acquires the lock after a daemonized child was left behind"
+pass "omarchy-update-lock does not leak its flock to daemonized children"
+
+# Same leak through the real update pipeline, via the AUR step that starts adb.
+write_stub omarchy-snapshot 'exit 0'
+write_stub omarchy-update-keyring 'exit 0'
+write_stub omarchy-update-restart 'exit 0'
+write_stub systemd-inhibit 'exec sleep infinity'
+rm -f "$daemon_pid_file" "$test_home/.local/state/omarchy/indicators/stay-awake"
+write_stub omarchy-update-aur-pkgs 'setsid -f "$LINGER" "$DAEMON_PID_FILE"'
+
+OMARCHY_UPDATE_LOGGED=1 LINGER="$linger" DAEMON_PID_FILE="$daemon_pid_file" \
+  run_with_lock_env "$ROOT/bin/omarchy-update" -y ||
+  fail "omarchy-update succeeds when the AUR step daemonizes a child"
+
+for _ in {1..50}; do
+  [[ -s $daemon_pid_file ]] && break
+  sleep 0.02
+done
+[[ -s $daemon_pid_file ]] || fail "AUR step recorded a daemonized child"
+update_linger_pid=$(<"$daemon_pid_file")
+linger_pids+=("$update_linger_pid")
+kill -0 "$update_linger_pid" 2>/dev/null || fail "AUR daemonized child outlives omarchy-update"
+
+lock_target=$(readlink -f "$runtime_dir/omarchy-update.lock")
+lock_held_by_pid "$update_linger_pid" "$lock_target" &&
+  fail "AUR daemonized child does not inherit the update lock descriptor"
+
+flock -n "$runtime_dir/omarchy-update.lock" true ||
+  fail "update lock is released after omarchy-update exits despite a living AUR daemon"
+
+write_stub omarchy-update-aur-pkgs 'exit 0'
+OMARCHY_UPDATE_LOGGED=1 run_with_lock_env "$ROOT/bin/omarchy-update" -y ||
+  fail "a later omarchy-update runs after a previous AUR step daemonized a child"
+pass "omarchy-update does not leak its lock through AUR daemons"
+
+# held() is how omarchy-update avoids re-acquiring the lock after the wrapper
+# starts it. It must be true only inside that child, never because a leftover
+# daemon still has an open descriptor.
+held_inside="$test_tmp/held-inside"
+run_with_lock_env "$ROOT/bin/omarchy-update-lock" run \
+  bash -c 'omarchy-update-lock held && echo yes >"$1" || echo no >"$1"' bash "$held_inside" ||
+  fail "omarchy-update-lock run with a held check exits 0"
+[[ $(<"$held_inside") == "yes" ]] || fail "omarchy-update-lock held is true inside the locked child"
+
+if run_with_lock_env "$ROOT/bin/omarchy-update-lock" held; then
+  fail "omarchy-update-lock held is false outside a locked child"
+fi
+pass "omarchy-update-lock held is only true for the locked child"


### PR DESCRIPTION
Fixes #8077

`omarchy-update-lock` used to `exec` the update, so every child inherited the flock. Flutter's `adb` daemonizes onto user systemd during AUR updates and kept that descriptor after the update exited. The next `omarchy update` then died immediately with `An Omarchy update is already running.`

The wrapper now holds the flock itself and runs the update with the descriptor closed — the same thing `omarchy-update-stay-awake` already does for the sleep inhibitor.

**Proof**

Before this change, a daemonized child of `omarchy-update-lock run` kept fd 10 on `$XDG_RUNTIME_DIR/omarchy-update.lock` and `flock -n` failed after the helper exited.

After:

```
test/shell.d/update-lock-test.sh
ok - omarchy-update-lock does not leak its flock to daemonized children
ok - omarchy-update does not leak its lock through AUR daemons
ok - omarchy-update-lock held is only true for the locked child
```

Overlapping-update exclusion, the sleep-inhibitor close, update sequence, and migrate-notify lock tests still pass. `./test/cli` is green. Four shell files fail on this machine for reasons outside this change (no `omarchy-pkgs` checkout; one compositor animation check).