### PR TITLE
Wait for the keypress ourselves instead of asking gum to

### DIFF
--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -141,7 +141,8 @@ say() {
 notice() {
   clear_logo
   echo
-  gum spin --spinner "pulse" --title "$1" -- sleep "${2:-2}"
+  printf '%*s\033[32m● \033[0m%s\n' "$PADDING_LEFT" '' "$1"
+  sleep "${2:-2}"
   echo
 }
 

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-# omarchy:summary=Display a "Done!" message with a spinner and wait for user to press any key.
+# omarchy:summary=Display a "Done!" message and wait for user to press any key.
+
+[[ -e /dev/tty ]] || exit 0
 
 echo
-gum spin --spinner "globe" --title "Done! Press any key to close..." -- bash -c 'read -n 1 -s'
+
+# gum 2.0 no longer lets a spun command read the terminal, so the wait has to
+# happen here. Its own query replies are still queued on the tty; drop those or
+# they answer the keypress for the user.
+while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
+
+printf '\033[32m● \033[0mDone! Press any key to close...'
+read -rsn 1 </dev/tty
+echo

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -2,15 +2,17 @@
 
 # omarchy:summary=Display a "Done!" message and wait for user to press any key.
 
-[[ -e /dev/tty ]] || exit 0
-
-echo
+# The device node is there whether or not a terminal is behind it, so opening
+# it is the only test that means anything.
+: 2>/dev/null <>/dev/tty || exit 0
 
 # gum 2.0 no longer lets a spun command read the terminal, so the wait has to
 # happen here. Its own query replies are still queued on the tty; drop those or
 # they answer the keypress for the user.
 while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
 
-printf '\033[32m● \033[0mDone! Press any key to close...'
+# Prompt on the terminal rather than stdout, or a caller that redirects us
+# leaves the user waiting on a prompt they were never shown.
+printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
 read -rsn 1 </dev/tty
-echo
+echo >/dev/tty


### PR DESCRIPTION
`gum` 2.0 runs a spun command without the terminal attached, so the `gum spin -- bash -c 'read -n 1 -s'` that `omarchy-show-done` relied on returns immediately instead of waiting for a keypress.

Every command launched through `omarchy-launch-floating-terminal-with-presentation` ends in `omarchy-show-done`, so the pause at the end of those terminals is simply gone. When the command succeeds that is mostly invisible — something else usually prompts. When it fails, the window takes the error down with it, which is how a failed update looks like a terminal that just quits before anything can be read.

Measured in a foot window on gum 2.0.0:

| | result |
|---|---|
| `read -n1 -s -t 6` | blocks the full 6s |
| `gum spin --spinner globe --title "Done!" -- bash -c 'read -n 1 -s'` | returns rc=0 in **0s** |

The `script` logging wrapper in `omarchy-update` is not involved — the spinner returns instantly with or without it.

## The fix

Read the key directly instead of asking gum to. Three details this has to get right:

- gum's own terminal query replies are still queued on the tty when the spinner stops, so those get drained first — otherwise they answer the prompt on the user's behalf and the window closes just the same.
- The prompt is written to the terminal rather than stdout. A caller that redirects stdout would otherwise send the prompt to a log while the read waits on `/dev/tty`, leaving a terminal that looks hung with no instruction.
- `/dev/tty` is opened rather than tested with `-e`. The device node exists whether or not a terminal is behind it, so a headless run (cron, systemd, ssh without `-t`) would pass an `-e` check and then fail both reads with "No such device or address".

The green dot reads better than the globe did, so `omarchy-provision-owner`'s `notice()` picks it up too and drops its spinner along the way. Those were the only two `gum spin` sites in the repo.

## Verification

- In a pty, the patched `omarchy-show-done` holds until a keypress is injected, then returns rc=0. Before the fix the same harness returned in 0s.
- Headless (`setsid`, no controlling terminal): exits 0, silently.
- With stdout redirected: prompt lands on the terminal, 0 bytes in the redirect target, still waits.
- `test/cli`: 116 ok, 0 failures.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
