### PR TITLE
Leave the alternate screen only when the connection dropped

### DIFF
--- a/default/bash/fns/ssh-reconnect
+++ b/default/bash/fns/ssh-reconnect
@@ -5,7 +5,7 @@
 # the connection dies instead of exiting cleanly, those modes stay armed on the
 # local terminal, and every mouse move floods the prompt with escape junk.
 ssh() {
-  local rc started
+  local rc started attempt
 
   started=$SECONDS
   command ssh "$@"
@@ -24,6 +24,10 @@ ssh() {
     return $rc
   fi
 
+  # Past here a session was established and then died, so a remote TUI may
+  # still be holding the alternate screen with no way to leave it itself.
+  _ssh_leave_alt_screen
+
   # Retry in a subshell: Ctrl-C reaches the whole foreground process group,
   # so it cancels both the in-flight attempt and the loop itself. Keep
   # retrying fast failures, since a rebooting server refuses connections too.
@@ -31,18 +35,30 @@ ssh() {
     while true; do
       echo "Connection lost. Reconnecting (Ctrl-C to stop)..."
       sleep 2
+      attempt=$SECONDS
       command ssh "$@"
       rc=$?
       _ssh_disarm
+      (( SECONDS - attempt < 30 )) || _ssh_leave_alt_screen
       (( rc != 255 )) && exit $rc
     done
   )
 }
 
 # Disarm mouse tracking (1000/1002/1003, 1006 encoding), focus reporting
-# (1004), and the alternate screen (1049), and show the cursor again.
+# (1004), and show the cursor again. Every sequence here is a plain toggle
+# with no side effect, so it is safe after any ssh.
 _ssh_disarm() {
-  printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1004l\e[?1049l\e[?25h'
+  printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1004l\e[?25h'
+}
+
+# Leave the alternate screen, for a remote TUI that died with the connection
+# and never left it itself. Sent only on that path, because 1049l also
+# restores the saved cursor and terminals disagree on what that means when no
+# 1049h ever arrived: foot ignores it, ghostty and herdr move the cursor to
+# 1;1, which paints the next prompt over the session output.
+_ssh_leave_alt_screen() {
+  printf '\e[?1049l'
 }
 
 # True for an interactive session: a destination and no remote command. The

--- a/test/shell.d/ssh-reconnect-test.sh
+++ b/test/shell.d/ssh-reconnect-test.sh
@@ -94,11 +94,16 @@ attempts() {
   cat "$fake_dir/count"
 }
 
-disarm=$(printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1004l\e[?1049l\e[?25h')
+disarm=$(printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1004l\e[?25h')
+leave_alt_screen=$(printf '\e[?1049l')
 
 out=$(run_case "0 255" host)
 [[ $out == *"$disarm"* ]] || fail "stray terminal modes are reset after ssh exits" "$out"
 pass "stray terminal modes are reset after ssh exits"
+
+[[ $out != *"$leave_alt_screen"* ]] ||
+  fail "a session that never established leaves the alternate screen alone" "$out"
+pass "a session that never established leaves the alternate screen alone"
 
 [[ $out == *"rc=255"* ]] && (( $(attempts) == 1 )) ||
   fail "fast connection failure does not reconnect" "$out"
@@ -108,6 +113,10 @@ out=$(run_case $'2 255\n0 0' host)
 [[ $out == *"Connection lost"* ]] && [[ $out == *"rc=0"* ]] && (( $(attempts) == 2 )) ||
   fail "dropped session reconnects" "$out"
 pass "dropped session reconnects"
+
+[[ $out == *"$disarm$leave_alt_screen"* ]] ||
+  fail "a dropped session leaves the alternate screen" "$out"
+pass "a dropped session leaves the alternate screen"
 
 out=$(run_case $'2 255\n0 255\n0 0' host)
 [[ $out == *"rc=0"* ]] && (( $(attempts) == 3 )) ||


### PR DESCRIPTION
Fixes #8083.

`_ssh_disarm` sends `ESC[?1049l` after every ssh. `1049` pairs the alternate screen with a cursor save/restore, so resetting it also restores the saved cursor — and terminals disagree on what that should mean when no `?1049h` ever arrived.

Measured with `CSI 6n` before and after each sequence:

| terminal | unpaired `1049l` | unpaired `1048l` | unpaired `1047l` | paired `1049h`+`1049l` |
| --- | --- | --- | --- | --- |
| foot 1.27.0 | neutral | moves to 1;1 | neutral | neutral |
| ghostty 1.3.1 | **moves to 1;1** | moves to 1;1 | neutral | neutral |
| herdr 0.8.2 | **moves to 1;1** | moves to 1;1 | neutral | neutral |

So the cursor restore is the harmful half, and on ghostty and herdr the next prompt is drawn at the top of the screen, painting over the session output. Repro, no ssh involved:

```sh
clear; seq 1 15; printf '\e[?1049l'; echo hello
```

A cleanly exited remote TUI has already left the alternate screen itself, so the reset does nothing useful there. It is only needed when a connection drops while a TUI is still running and never gets to leave on its own — which is the case this wrapper exists for, and where `1049h` was genuinely issued, making the restore correct.

This splits the two apart:

- **clean exit** — the cursor-neutral toggles only (mouse `1000/1002/1003/1006`, focus `1004`, cursor `25h`)
- **dropped session** — those plus `1049l`, on the same established-session path that already gates reconnection

Known limitation: a session that drops without a remote TUI still sends an unpaired `1049l`, so the cursor jump survives there. Only a "Connection lost. Reconnecting..." line is on screen at that point. Fixing it properly needs the terminal side, since only the terminal knows whether a save happened — filed for herdr as https://github.com/herdrdev/herdr/issues/3602.

`test/shell.d/ssh-reconnect-test.sh` pinned the exact sequence; it now asserts both paths. 19/19 pass, and both new assertions fail if the behaviour is reverted either way.
