### PR TITLE
Re-arm idle monitor when timeouts change in shell.json (#8038)

### DIFF
--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -37,7 +37,7 @@ Item {
   property var screensaverWindows: ({})
   property int screensaverWindowCount: 0
 
-  onFirstIdleTimeoutSecondsChanged: {
+  function handleIdleTimeoutsChanged() {
     logEvent("idle-timeout-rearm", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
     if (root.idledThisCycle) {
       root.cancelIdleCycle("timeout-change")
@@ -49,6 +49,9 @@ Item {
       })
     }
   }
+
+  onScreensaverTimeoutSecondsChanged: root.handleIdleTimeoutsChanged()
+  onLockTimeoutSecondsChanged: root.handleIdleTimeoutsChanged()
 
   function secondsFromConfig(value, fallback) {
     return IdleModel.secondsFromConfig(value, fallback)

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -27,6 +27,7 @@ Item {
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
+  property bool monitorArmed: true
   property bool hasPendingStayAwakePersist: false
   property bool pendingStayAwakePersist: false
   property bool idledThisCycle: false
@@ -35,6 +36,19 @@ Item {
   property string lastEventAt: ""
   property var screensaverWindows: ({})
   property int screensaverWindowCount: 0
+
+  onFirstIdleTimeoutSecondsChanged: {
+    logEvent("idle-timeout-rearm", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
+    if (root.idledThisCycle) {
+      root.cancelIdleCycle("timeout-change")
+    }
+    if (root.idleEnabled) {
+      root.monitorArmed = false
+      Qt.callLater(function() {
+        root.monitorArmed = true
+      })
+    }
+  }
 
   function secondsFromConfig(value, fallback) {
     return IdleModel.secondsFromConfig(value, fallback)
@@ -249,7 +263,7 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.idleEnabled
+    enabled: root.idleEnabled && root.monitorArmed
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()


### PR DESCRIPTION
### Summary

Fixes #8038.

When a user modifies `idle.screensaver` or `idle.lock` timeouts in `~/.config/omarchy/shell.json` on a running session, `firstIdleTimeoutSeconds` updates reactively. However, Quickshell's Wayland `IdleMonitor` does not automatically re-register the compositor's `ext-idle-notify` listener unless the monitor is re-armed. This left the session with an idle monitor that reports `enabled: true` in diagnostics but never receives idle notifications, causing the session to stay unlocked indefinitely.

### Changes Made

* **Re-arm on Timeout Change**: Added `property bool monitorArmed: true` bound to `IdleMonitor { enabled: root.idleEnabled && root.monitorArmed }`.
* **Dynamic Lifecycle Reset**: Added `onFirstIdleTimeoutSecondsChanged`:
  * Cancels any active idle cycle if timeouts change mid-cycle (`cancelIdleCycle("timeout-change")`).
  * Cycles `monitorArmed` via `Qt.callLater` to force Quickshell to tear down the old listener and register the new timeout with the Wayland compositor.
  * Emits `idle-timeout-rearm` event log with the updated screensaver and lock timeouts for journal diagnostic tracking.

### Verification

* Ran `./test/shell.d/idle-test.sh` — all 9 test assertions passed.
* Verified that property bindings and event handlers adhere to repository QML style conventions.