### PR TITLE
Keep the migration list off each migration's stdin

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -85,7 +85,7 @@ wait_for_pacman_transaction
 mkdir -p "$STATE_DIR"
 [[ -d $MIGRATIONS_DIR ]] || exit 0
 
-while IFS=$'\t' read -r name file marker; do
+while IFS=$'\t' read -r -u 3 name file marker; do
   [[ -n $name ]] || continue
 
   if [[ ! -f $marker ]]; then
@@ -94,7 +94,7 @@ while IFS=$'\t' read -r name file marker; do
     mkdir -p "$(dirname "$marker")"
     touch "$marker"
   fi
-done < <(migration_entries)
+done 3< <(migration_entries)
 
 # Clear a login-time notification the user left sitting there and then resolved
 # by running migrations some other way. The substring matches both the current

--- a/test/shell.d/migrate-scope-test.sh
+++ b/test/shell.d/migrate-scope-test.sh
@@ -75,3 +75,30 @@ set -e
 grep -q '^before-fail$' "$calls" || fail "migration runner started failing migration"
 ! grep -q '^after-fail$' "$calls" || fail "migration runner stops failing migration under strict mode"
 pass "migration runner does not mark failed migrations complete"
+
+stdin_root="$test_tmp/stdin-omarchy"
+stdin_home="$test_tmp/stdin-home"
+stdin_calls="$test_tmp/stdin-calls"
+mkdir -p "$stdin_root/migrations" "$stdin_home"
+
+# Migrations are expected to prompt, so they keep the caller's stdin. What they must not
+# inherit is the migration list itself: a migration that reads a line would take the next
+# migration's entry, and that migration would never run.
+cat >"$stdin_root/migrations/300-reads-stdin.sh" <<'SH'
+echo reads-stdin >>"$TEST_CALLS"
+if IFS= read -r -t 1 stolen; then
+  echo "stole:$stolen" >>"$TEST_CALLS"
+fi
+SH
+cat >"$stdin_root/migrations/400-after.sh" <<'SH'
+echo after >>"$TEST_CALLS"
+SH
+
+HOME="$stdin_home" \
+OMARCHY_PATH="$stdin_root" \
+TEST_CALLS="$stdin_calls" \
+  "$ROOT/bin/omarchy-migrate" >"$test_tmp/stdin-run.out" </dev/null
+! grep -q '^stole:' "$stdin_calls" || fail "migration runner keeps the migration list off a migration's stdin"
+grep -q '^after$' "$stdin_calls" || fail "migration runner runs the migration after one that reads stdin"
+[[ -f $stdin_home/.local/state/omarchy/migrations/400-after.sh ]] || fail "migration runner marks the migration after one that reads stdin"
+pass "migration runner keeps the migration list off a migration's stdin"


### PR DESCRIPTION
A migration that reads stdin swallows the next migration's entry, and that migration never runs.

The run loop is fed by a process substitution attached to the compound command, so the list is stdin for everything inside the loop body, including the `bash` that runs each migration:

```
while IFS=$'\t' read -r name file marker; do
  ...
  OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$file"
done < <(migration_entries)
```

Four synthetic migrations, where the second one reads one line:

```
Running migration (1000000001)
RAN 1000000001
Running migration (1000000002)
RAN 1000000002
  !! consumed stdin: [1000000003.sh	/tmp/mig/1000000003.sh	/tmp/state/1000000003.sh]
Running migration (1000000004)
RAN 1000000004

markers written: 1000000001.sh 1000000002.sh 1000000004.sh
```

1000000003 never ran. It also never got a marker, so it stays pending and the login notifier keeps asking, which is how this hides.

There is a live instance in the tree. `migrations/1786643346.sh:170` calls `gum confirm` to ask for browser windows to be closed, and gum reads stdin, so under `omarchy-migrate` it reads a migration entry instead of a keypress.

Reading the list on a dedicated descriptor leaves stdin alone. That matters more than redirecting the migration from `/dev/null` would, because `agents/skills/migrations.md` says migrations prompt themselves in the visible update terminal, so they need to keep the real stdin.

`pending_migrations()` has the same loop shape but only prints names, so it is untouched.

The test goes in `migrate-scope-test.sh` next to the other run-loop cases. It fails without the change:

```
not ok - migration runner keeps the migration list off a migration's stdin
```

Not the same as #7026, which fixes that migration's own loop condition (a stale `SingletonLock` left by a dead process) and does not touch the runner or stdin. Both can land independently.
