### PR TITLE
Keep RTL8852BE Wi-Fi alive across suspend

### DIFF
--- a/default/modprobe.d/omarchy-rtw89.conf
+++ b/default/modprobe.d/omarchy-rtw89.conf
@@ -1,0 +1,6 @@
+# Realtek RTL8852BE loses the link across suspend when the PCIe link comes back
+# in ASPM L1 ("failed to write DBI register" then "mac preinit fail, ret: -110")
+# and stalls on power-on when CLKREQ# gates the reference clock ("xtal si not
+# ready"). Paired with /usr/lib/systemd/system-sleep/rtw89-suspend, which keeps
+# the card's root port out of D3cold so the slot does not lose power entirely.
+options rtw89_pci disable_aspm_l1=y disable_aspm_l1ss=y disable_clkreq=y

--- a/default/systemd/system-sleep/rtw89-suspend
+++ b/default/systemd/system-sleep/rtw89-suspend
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Keep the Realtek RTL8852BE (10ec:b852) alive across suspend.
+#
+# The card's PCIe root port carries an ACPI power resource under _PR3
+# (\_SB.PC00.RPxx.PXP_ on the machines seen so far) that gates power to the
+# slot itself. Left alone the port drops to D3cold during s2idle, that resource
+# goes off, and the card comes back unpowered. The port resumes perfectly and
+# reports an empty bus, so nothing in the resume path ever re-enumerates the
+# Wi-Fi -- there is no error anywhere in dmesg, the interface is simply gone:
+#
+#   pci 0000:00:1c.7: PCI bridge to [bus 05]
+#   pci 0000:00:1c.7: disabling bridge window [mem ...] to [bus 05] (unused)
+#
+# Two halves to the fix:
+#
+#   - d3cold_allowed=0 on both the port and the card, so the port can only
+#     reach D3hot and slot power stays up. This is the part that matters.
+#     It resets to 1 on every boot and on any remove/rescan, so it has to be
+#     re-asserted rather than set once.
+#
+#   - hot-remove the card before sleep and rescan after. Without it the PCI
+#     core spends ~127s ("not ready 65535ms after resume; giving up") trying
+#     to resume a device that never answers, before the driver gets a turn at
+#     all. Taking it off the bus leaves the core nothing to wait for, so this
+#     makes resume faster, not slower.
+#
+# Pairs with /etc/modprobe.d/omarchy-rtw89.conf, which disables ASPM L1/L1SS
+# and CLKREQ# on the same card; both are installed together by
+# install/hardware/fix-rtw89-suspend.sh.
+
+WIFI_VENDOR=0x10ec
+WIFI_DEVICE=0xb852
+STATE=/run/omarchy-rtw89-suspend.state
+PCI_DEVICES=/sys/bus/pci/devices
+
+log() { logger -t omarchy-rtw89-suspend "$*"; }
+
+# Write to a sysfs attribute that may not exist on every machine.
+poke() {
+  [[ -w $2 ]] && echo "$1" >"$2" 2>/dev/null
+}
+
+# The port the card hangs off is simply its parent in sysfs.
+bridge_of() {
+  basename "$(dirname "$(readlink -f "$PCI_DEVICES/$1")")"
+}
+
+module_of() {
+  local driver=$PCI_DEVICES/$1/driver
+  [[ -L $driver ]] && basename "$(readlink -f "$driver")"
+}
+
+find_cards() {
+  local dev vendor device
+  for dev in "$PCI_DEVICES"/*; do
+    read -r vendor <"$dev/vendor" 2>/dev/null || continue
+    read -r device <"$dev/device" 2>/dev/null || continue
+    if [[ $vendor == "$WIFI_VENDOR" && $device == "$WIFI_DEVICE" ]]; then
+      basename "$dev"
+    fi
+  done
+}
+
+# d3cold_allowed on the port is what keeps slot power up; the card's own flag
+# stops the port being taken down while the card is still attached to it.
+keep_powered() {
+  poke 0 "$PCI_DEVICES/$2/d3cold_allowed"
+  poke 0 "$PCI_DEVICES/$1/d3cold_allowed"
+  poke on "$PCI_DEVICES/$2/power/control"
+}
+
+netdev_present() {
+  compgen -G "$PCI_DEVICES/$1/net/*" >/dev/null
+}
+
+suspend_card() {
+  local card=$1 bridge=$2 module=$3
+
+  keep_powered "$card" "$bridge"
+  [[ -n $module ]] && modprobe -r "$module" 2>/dev/null
+  poke 1 "$PCI_DEVICES/$card/remove"
+  log "pre: $card off the bus, $bridge held out of D3cold"
+}
+
+resume_card() {
+  local card=$1 bridge=$2 module=$3 try
+
+  poke 0 "$PCI_DEVICES/$bridge/d3cold_allowed"
+  poke on "$PCI_DEVICES/$bridge/power/control"
+
+  for try in 1 2 3; do
+    sleep 2
+    poke 1 "$PCI_DEVICES/$bridge/rescan"
+    [[ -e $PCI_DEVICES/$card ]] || poke 1 /sys/bus/pci/rescan
+    sleep 1
+
+    if [[ -e $PCI_DEVICES/$card ]]; then
+      keep_powered "$card" "$bridge"
+      [[ -n $module ]] && modprobe "$module" 2>/dev/null
+      sleep 2
+
+      if netdev_present "$card"; then
+        poke auto "$PCI_DEVICES/$bridge/power/control"
+        log "post: $card back on attempt $try"
+        return 0
+      fi
+
+      # On the bus but unclaimed: a driver problem, so look for rtw89 errors
+      # in dmesg rather than at power management.
+      log "post: $card enumerated but no netdev appeared on attempt $try"
+      poke 1 "$PCI_DEVICES/$card/remove"
+    else
+      # Never came back: the slot is still unpowered or the link is down.
+      log "post: $card did not reappear on attempt $try"
+    fi
+  done
+
+  poke auto "$PCI_DEVICES/$bridge/power/control"
+  log "post: $card did not come back after 3 attempts"
+  return 1
+}
+
+case "$1" in
+  pre)
+    : >"$STATE"
+    for card in $(find_cards); do
+      bridge=$(bridge_of "$card")
+      module=$(module_of "$card")
+      echo "$card $bridge $module" >>"$STATE"
+      suspend_card "$card" "$bridge" "$module"
+    done
+    ;;
+  post)
+    [[ -r $STATE ]] || exit 0
+    while read -r card bridge module; do
+      [[ -n $card ]] && resume_card "$card" "$bridge" "$module"
+    done <"$STATE"
+    rm -f "$STATE"
+    ;;
+esac
+
+exit 0

--- a/default/systemd/system-sleep/rtw89-suspend
+++ b/default/systemd/system-sleep/rtw89-suspend
@@ -84,7 +84,7 @@ suspend_card() {
 }
 
 resume_card() {
-  local card=$1 bridge=$2 module=$3 try
+  local card=$1 bridge=$2 module=$3 try outcome="never reached the bus"
 
   poke 0 "$PCI_DEVICES/$bridge/d3cold_allowed"
   poke on "$PCI_DEVICES/$bridge/power/control"
@@ -108,16 +108,20 @@ resume_card() {
 
       # On the bus but unclaimed: a driver problem, so look for rtw89 errors
       # in dmesg rather than at power management.
+      outcome="enumerated but was never claimed by ${module:-its driver}"
       log "post: $card enumerated but no netdev appeared on attempt $try"
       poke 1 "$PCI_DEVICES/$card/remove"
     else
       # Never came back: the slot is still unpowered or the link is down.
+      outcome="never reappeared on the bus"
       log "post: $card did not reappear on attempt $try"
     fi
   done
 
   poke auto "$PCI_DEVICES/$bridge/power/control"
-  log "post: $card did not come back after 3 attempts"
+  # Name the failure that actually happened: "enumerated but unclaimed" sends
+  # you to rtw89 errors in dmesg, "never reappeared" to slot power and the link.
+  log "post: gave up on $card after 3 attempts, $outcome"
   return 1
 }
 

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -40,6 +40,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
+run_logged "$OMARCHY_INSTALL/hardware/fix-rtw89-suspend.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-yt6801-ethernet-adapter.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-tuxedo-backlight.sh"

--- a/install/hardware/fix-rtw89-suspend.sh
+++ b/install/hardware/fix-rtw89-suspend.sh
@@ -9,7 +9,12 @@
 #
 # Verified on an ASUS TUF Gaming F16 (FX607VJ, Intel root port 8086:51bf).
 
-if lspci -nn | grep -q '\[10ec:b852\]'; then
+# Read lspci into a variable rather than piping it into grep -q: grep quits at
+# the first match, lspci catches SIGPIPE, and under the caller's pipefail that
+# 141 reads as "no such hardware" on the very machines this targets (#6608).
+pci_devices=$(lspci -nn)
+
+if [[ $pci_devices == *"[10ec:b852]"* ]]; then
   mkdir -p /etc/modprobe.d
   install -m 644 "$OMARCHY_PATH/default/modprobe.d/omarchy-rtw89.conf" \
     /etc/modprobe.d/omarchy-rtw89.conf

--- a/install/hardware/fix-rtw89-suspend.sh
+++ b/install/hardware/fix-rtw89-suspend.sh
@@ -1,0 +1,20 @@
+# Realtek RTL8852BE (10ec:b852) does not survive suspend: the Wi-Fi interface is
+# simply gone after a lid close, with nothing in dmesg to explain it.
+#
+# Its PCIe root port drops to D3cold during s2idle, which turns off the ACPI
+# power resource under _PR3 that gates power to the slot, so the card resumes
+# unpowered and is never re-enumerated. Two files fix it: modprobe options that
+# keep ASPM L1/L1SS and CLKREQ# off the link, and a sleep hook that holds the
+# port out of D3cold and cycles the card off and back onto the bus.
+#
+# Verified on an ASUS TUF Gaming F16 (FX607VJ, Intel root port 8086:51bf).
+
+if lspci -nn | grep -q '\[10ec:b852\]'; then
+  mkdir -p /etc/modprobe.d
+  install -m 644 "$OMARCHY_PATH/default/modprobe.d/omarchy-rtw89.conf" \
+    /etc/modprobe.d/omarchy-rtw89.conf
+
+  mkdir -p /usr/lib/systemd/system-sleep
+  install -m 755 "$OMARCHY_PATH/default/systemd/system-sleep/rtw89-suspend" \
+    /usr/lib/systemd/system-sleep/rtw89-suspend
+fi

--- a/migrations/1787596412.sh
+++ b/migrations/1787596412.sh
@@ -1,0 +1,20 @@
+echo "Keep RTL8852BE Wi-Fi alive across suspend"
+
+# Only machines carrying the affected Realtek card need any of this.
+lspci -nn | grep -q '\[10ec:b852\]' || exit 0
+
+conf_source="$OMARCHY_PATH/default/modprobe.d/omarchy-rtw89.conf"
+conf=/etc/modprobe.d/omarchy-rtw89.conf
+hook_source="$OMARCHY_PATH/default/systemd/system-sleep/rtw89-suspend"
+hook=/usr/lib/systemd/system-sleep/rtw89-suspend
+
+# Another user on the same machine may have applied this already.
+if ! cmp -s "$conf_source" "$conf"; then
+  sudo mkdir -p /etc/modprobe.d
+  sudo install -m 644 "$conf_source" "$conf"
+fi
+
+if ! cmp -s "$hook_source" "$hook"; then
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo install -m 755 "$hook_source" "$hook"
+fi

--- a/migrations/1787596412.sh
+++ b/migrations/1787596412.sh
@@ -1,7 +1,12 @@
 echo "Keep RTL8852BE Wi-Fi alive across suspend"
 
-# Only machines carrying the affected Realtek card need any of this.
-lspci -nn | grep -q '\[10ec:b852\]' || exit 0
+# Only machines carrying the affected Realtek card need any of this. Read lspci
+# into a variable rather than piping it into grep -q: grep quits at the first
+# match, lspci catches SIGPIPE, and under the runner's pipefail that 141 reads
+# as "no such hardware" on the very machines this targets (#6608).
+pci_devices=$(lspci -nn)
+
+[[ $pci_devices == *"[10ec:b852]"* ]] || exit 0
 
 conf_source="$OMARCHY_PATH/default/modprobe.d/omarchy-rtw89.conf"
 conf=/etc/modprobe.d/omarchy-rtw89.conf

--- a/test/shell.d/rtw89-suspend-test.sh
+++ b/test/shell.d/rtw89-suspend-test.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/fix-rtw89-suspend.sh"
+hook="$ROOT/default/systemd/system-sleep/rtw89-suspend"
+migration="$ROOT/migrations/1787596412.sh"
+all="$ROOT/install/hardware/all.sh"
+
+grep -q 'fix-rtw89-suspend.sh' "$all" ||
+  fail "the rtw89 quirk runs during hardware setup"
+pass "the rtw89 quirk runs during hardware setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would die of SIGPIPE and pipefail would read that
+# as "no such hardware" (#6608).
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "05:00.0 Network controller [0280]: Realtek Semiconductor Co., Ltd. RTL8852BE [10ec:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+# The hook drives real hardware; every escape from the sandbox is stubbed.
+cat >"$stub_bin/modprobe" <<'SH'
+#!/bin/bash
+
+printf 'modprobe' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/logger" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "${*: -1}" >>"$HOOK_LOG"
+SH
+
+# The hook waits for hardware to settle; the sandbox has none to wait for.
+cat >"$stub_bin/sleep" <<'SH'
+#!/bin/bash
+
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+conf="$test_tmp/etc/modprobe.d/omarchy-rtw89.conf"
+installed_hook="$test_tmp/lib/systemd/system-sleep/rtw89-suspend"
+
+# The leaf writes to absolute system paths, so rewrite them into the sandbox.
+run_leaf() {
+  local wifi_id="${1:-}"
+  rm -rf "$test_tmp/etc" "$test_tmp/lib"
+  : >"$calls"
+
+  local script="$test_tmp/leaf.sh"
+  sed -e "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
+      -e "s|/usr/lib/systemd/system-sleep|$test_tmp/lib/systemd/system-sleep|g" \
+      "$leaf" >"$script"
+
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" OMARCHY_PATH="$ROOT" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+# The case #6608 was about: an affected machine, a chatty lspci, and pipefail.
+run_leaf b852 >/dev/null
+grep -q 'disable_clkreq=y' "$conf" 2>/dev/null ||
+  fail "an affected machine gets the modprobe options" "$(ls -R "$test_tmp" 2>&1)"
+[[ -f $installed_hook ]] || fail "an affected machine gets the sleep hook"
+pass "an affected machine gets both files under pipefail"
+
+# systemd ignores a sleep hook that is not executable, so the mode is the fix.
+[[ -x $installed_hook ]] || fail "the installed sleep hook is executable"
+pass "the installed sleep hook is executable"
+
+run_leaf 8852 >/dev/null
+[[ ! -f $conf ]] || fail "another rtw89 card is left alone" "$(cat "$conf")"
+[[ ! -f $installed_hook ]] || fail "another rtw89 card gets no sleep hook"
+pass "another rtw89 card is left alone"
+
+run_leaf "" >/dev/null
+[[ ! -f $conf ]] || fail "a machine with no Realtek Wi-Fi is left alone"
+pass "a machine with no Realtek Wi-Fi is left alone"
+
+# A sysfs stand-in: the card behind its root port, plus a device that must not
+# be mistaken for either.
+mock_pci=""
+make_mock_pci() {
+  local with_netdev="${1:-1}"
+  rm -rf "$test_tmp/sys"
+  mock_pci="$test_tmp/sys/devices"
+
+  local card="$test_tmp/sys/tree/pci0000:00/0000:00:1c.7/0000:05:00.0"
+  local bridge="$test_tmp/sys/tree/pci0000:00/0000:00:1c.7"
+  local other="$test_tmp/sys/tree/pci0000:00/0000:00:1f.3"
+  mkdir -p "$card/power" "$bridge/power" "$other" "$mock_pci" "$test_tmp/sys/drivers/rtw89_8852be"
+
+  printf '0x10ec\n' >"$card/vendor"
+  printf '0xb852\n' >"$card/device"
+  printf '1\n' >"$card/d3cold_allowed"
+  printf 'on\n' >"$card/power/control"
+  : >"$card/remove"
+  ln -s "$test_tmp/sys/drivers/rtw89_8852be" "$card/driver"
+  (( with_netdev == 1 )) && mkdir -p "$card/net/wlp5s0"
+
+  printf '0x8086\n' >"$bridge/vendor"
+  printf '0x51bf\n' >"$bridge/device"
+  printf '1\n' >"$bridge/d3cold_allowed"
+  printf 'auto\n' >"$bridge/power/control"
+  : >"$bridge/rescan"
+
+  printf '0x8086\n' >"$other/vendor"
+  printf '0x51ca\n' >"$other/device"
+
+  ln -s "$card" "$mock_pci/0000:05:00.0"
+  ln -s "$bridge" "$mock_pci/0000:00:1c.7"
+  ln -s "$other" "$mock_pci/0000:00:1f.3"
+}
+
+hook_log="$test_tmp/hook.log"
+hook_state="$test_tmp/state"
+
+run_hook() {
+  local script="$test_tmp/hook.sh"
+  sed -e "s|^PCI_DEVICES=.*|PCI_DEVICES=$mock_pci|" \
+      -e "s|^STATE=.*|STATE=$hook_state|" \
+      -e "s|/sys/bus/pci/rescan|$test_tmp/sys/rescan|g" \
+      "$hook" >"$script"
+
+  : >"$hook_log"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" HOOK_LOG="$hook_log" \
+    bash "$script" "$1" suspend </dev/null
+}
+
+card_dir="$test_tmp/sys/tree/pci0000:00/0000:00:1c.7/0000:05:00.0"
+bridge_dir="$test_tmp/sys/tree/pci0000:00/0000:00:1c.7"
+
+make_mock_pci
+run_hook pre
+
+# d3cold_allowed on the port is the whole fix: it is what keeps the slot powered
+# across s2idle. The card's own flag keeps the port from being taken down under
+# it while the two are still attached.
+[[ $(cat "$bridge_dir/d3cold_allowed") == "0" ]] ||
+  fail "suspending holds the root port out of D3cold"
+[[ $(cat "$card_dir/d3cold_allowed") == "0" ]] ||
+  fail "suspending holds the card out of D3cold"
+[[ $(cat "$bridge_dir/power/control") == "on" ]] ||
+  fail "suspending pins the root port awake"
+[[ $(cat "$card_dir/remove") == "1" ]] ||
+  fail "suspending takes the card off the bus"
+grep -Fq $'modprobe\t-r\trtw89_8852be' "$calls" ||
+  fail "suspending unloads the bound module" "$(cat "$calls")"
+pass "suspending holds slot power up and takes the card off the bus"
+
+# Discovery has to survive a reboot renumbering the bus, so it is read from
+# sysfs rather than hardcoded -- and it must not pick up anything else.
+[[ $(cat "$hook_state") == "0000:05:00.0 0000:00:1c.7 rtw89_8852be" ]] ||
+  fail "the card, its root port and its module are discovered" "$(cat "$hook_state")"
+pass "the card, its root port and its module are discovered from sysfs"
+
+run_hook post
+grep -q 'back on attempt 1' "$hook_log" ||
+  fail "resuming brings the card back" "$(cat "$hook_log")"
+grep -Fq $'modprobe\trtw89_8852be' "$calls" ||
+  fail "resuming reloads the module" "$(cat "$calls")"
+[[ $(cat "$bridge_dir/power/control") == "auto" ]] ||
+  fail "resuming lets the root port sleep again"
+[[ ! -e $hook_state ]] || fail "resuming clears the state file"
+pass "resuming re-enumerates the card and releases the root port"
+
+# Two failures that need telling apart: on the bus but unclaimed sends you to
+# rtw89 errors in dmesg, never reappearing sends you to slot power and the link.
+make_mock_pci 0
+printf '0000:05:00.0 0000:00:1c.7 rtw89_8852be\n' >"$hook_state"
+run_hook post
+grep -q 'gave up on 0000:05:00.0 after 3 attempts, enumerated but was never claimed by rtw89_8852be' "$hook_log" ||
+  fail "giving up names an unclaimed card as a driver problem" "$(cat "$hook_log")"
+pass "giving up on an enumerated card names it a driver problem"
+
+make_mock_pci
+rm "$mock_pci/0000:05:00.0"
+printf '0000:05:00.0 0000:00:1c.7 rtw89_8852be\n' >"$hook_state"
+run_hook post
+grep -q 'gave up on 0000:05:00.0 after 3 attempts, never reappeared on the bus' "$hook_log" ||
+  fail "giving up names a missing card as a power problem" "$(cat "$hook_log")"
+pass "giving up on a card that never returns names it a power problem"
+
+# Nothing to do, and nothing to resume: the hook ships only on affected
+# machines but must not misfire if the card is ever pulled.
+make_mock_pci
+rm "$mock_pci/0000:05:00.0"
+run_hook pre
+[[ ! -s $hook_state ]] || fail "no card means nothing is recorded" "$(cat "$hook_state")"
+run_hook post
+[[ ! -s $hook_log ]] || fail "no card means nothing is attempted" "$(cat "$hook_log")"
+pass "a machine with the card pulled is left alone"
+
+# Installs that predate the quirk never ran the leaf, so the migration has to
+# reach them. It runs as the user under pipefail, the context #6608 was about.
+run_migration() {
+  local wifi_id="${1:-}"
+  : >"$calls"
+
+  local script="$test_tmp/migration.sh"
+  sed -e "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
+      -e "s|/usr/lib/systemd/system-sleep|$test_tmp/lib/systemd/system-sleep|g" \
+      "$migration" >"$script"
+
+  WIFI_ID="$wifi_id" PATH="$stub_bin:$PATH" TEST_LOG="$calls" OMARCHY_PATH="$ROOT" \
+    bash -euo pipefail "$script" </dev/null
+}
+
+rm -rf "$test_tmp/etc" "$test_tmp/lib"
+run_migration b852 >/dev/null
+grep -q 'disable_clkreq=y' "$conf" 2>/dev/null ||
+  fail "the migration fixes an install that never got the quirk" "$(ls -R "$test_tmp" 2>&1)"
+[[ -x $installed_hook ]] || fail "the migration installs an executable sleep hook"
+pass "the migration fixes an affected install under pipefail"
+
+run_migration b852 >/dev/null
+[[ ! -s $calls ]] ||
+  fail "a machine another user already repaired is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent across users on one machine"
+
+rm -rf "$test_tmp/etc" "$test_tmp/lib"
+run_migration 8852 >/dev/null
+[[ ! -f $conf ]] || fail "the migration skips an unaffected card" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected machines" "$(cat "$calls")"
+pass "the migration skips machines without the affected card"


### PR DESCRIPTION
## Problem

On laptops with a Realtek RTL8852BE (`10ec:b852`), Wi-Fi does not survive suspend. After a lid close there is no `wlp5s0` and nothing in `nmcli` — and, unhelpfully, **nothing in `dmesg` either**. No driver error, no timeout, no rfkill. The interface is simply gone until a reboot.

## Root cause

The card's PCIe root port carries an ACPI power resource under `_PR3` (`\_SB.PC00.RP08.PXP_` on the machine I debugged this on) that gates power to the **slot itself**. With `d3cold_allowed=1` the port drops to D3cold during s2idle, that resource goes off, and the card comes back physically unpowered. The port then resumes perfectly and reports an empty bus, so nothing in the resume path ever re-enumerates the Wi-Fi:

```
pci 0000:00:1c.7: PCI bridge to [bus 05]
pci 0000:00:1c.7: disabling bridge window [mem 0x82200000-0x822fffff] to [bus 05] (unused)
```

That silence is what makes this one hard to place — it reads like a driver bug, but the driver never gets a device to bind to. It is not firmware, not rfkill, and not NetworkManager powersave.

Two smaller failures sit on top of the same hardware and show up while fixing it:

- the PCIe link comes back in ASPM L1 and the chip stops answering (`failed to write DBI register, addr=0xB48`, then `mac preinit fail, ret: -110`);
- CLKREQ# gates the reference clock so the crystal never spins up (`xtal si not ready(R): offset=41`, `probe ... failed with error -110`).

## Fix

Three parts, installed only when `10ec:b852` is actually present:

1. `default/modprobe.d/omarchy-rtw89.conf` — `disable_aspm_l1`, `disable_aspm_l1ss`, `disable_clkreq` for `rtw89_pci`.
2. `default/systemd/system-sleep/rtw89-suspend` — sets `d3cold_allowed=0` on the port and the card so the port can only reach D3hot and slot power stays up. The flag resets to `1` on every boot and on any remove/rescan, so the hook re-asserts it rather than setting it once.
3. The same hook hot-removes the card before sleep and rescans after. Without that the PCI core spends **~127 seconds** (`not ready 65535ms after resume; giving up`) trying to resume a device that never answers, before the driver gets a turn at all. Taking it off the bus leaves the core nothing to wait for, so this makes resume *faster*.

The hook discovers the card, its parent port and its bound module from sysfs at suspend time and stashes them in `/run` — no hardcoded PCI addresses, and it no-ops on machines without the card.

There is prior art for the `d3cold_allowed` half in `install/hardware/apple/fix-suspend-nvme.sh`; this generalizes the same idea rather than pinning one bus address.

## Verification

Machine: ASUS TUF Gaming F16 (`FX607VJ`), RTL8852BE at `05:00.0` behind Intel root port `8086:51bf` at `00:1c.7`, kernel 7.1.8-arch1-3, s2idle.

**Before** — three rescans find nothing, adapter never returns, `systemd-suspend.service` burns `1m17s` of wall clock.

**After** a real lid close, the whole log is:

```
pre: 0000:05:00.0 off the bus, 0000:00:1c.7 held out of D3cold
post: 0000:05:00.0 back on attempt 1
```

`dmesg` is clean — no `not ready ... after resume`, no `xtal si`, no DBI errors, just a normal enumerate-and-probe and `wlp5s0: renamed from wlan0`. `systemd-suspend.service` consumed **9.967s** wall clock, against 1m17s before.

Scope of what was tested, to be precise about it:

- The **mechanism** above is what ran through that live suspend/resume cycle, as a hand-installed script with the addresses hardcoded.
- The hook in this PR is that script with the addresses replaced by runtime discovery. On the same machine discovery resolves to exactly the values that were verified (`0000:05:00.0`, `0000:00:1c.7`, `rtw89_8852be`), and ignores unrelated PCI devices.
- Its control flow is covered by `test/shell.d/rtw89-suspend-test.sh`, which drives the real hook against a mock sysfs tree: suspend holds slot power up and takes the card off the bus, discovery reads card/port/module from sysfs and ignores unrelated devices, resume re-enumerates and releases the port, and both give-up paths report distinguishably. The leaf and the migration are exercised under `pipefail` against a chatty `lspci` stub.
- `./test/shell` passes (2481 ok). Three files fail in my environment — `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` — all needing an `omarchy-pkgs` checkout I do not have; they fail identically on the base commit. `./test/cli` passes (116 ok, 0 failures).

I only have the one affected machine, so I have gated this narrowly on `10ec:b852` rather than widening it to the rest of the rtw89 family, even though the same D3cold behaviour is reported for its siblings. Adding IDs later is a one-line change in `install/hardware/fix-rtw89-suspend.sh`.

## Notes

- `migrations/1787596412.sh` applies both files to existing installs; it is idempotent and no-ops when another user on the machine already applied it.
- The modprobe options are deliberately *not* shipped in `etc/` unconditionally: `rtw89_pci` is shared with the 8852AE/8851BE/8922AE, and disabling ASPM for everyone would be a needless power regression on cards that do not have this bug.
