### PR TITLE
Keep provisioning inside the user's configured XDG directories

### DIFF
--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -95,16 +95,40 @@ for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   ln -sfn "$skill" ~/.gemini/config/skills/"$name"
 done
 
-mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0
+# Follow user-dirs.dirs rather than assuming the default names. Creating
+# ~/Pictures beside a relocated picture directory leaves an empty duplicate
+# behind and bookmarks the wrong one. xdg-user-dir echoes $HOME for a directory
+# it has no setting for, which is what marks it unset.
+xdg_user_dir() {
+  local resolved
+  resolved=$(xdg-user-dir "$1" 2>/dev/null) || true
+
+  if [[ -n $resolved && $resolved != "$HOME" ]]; then
+    echo "$resolved"
+  else
+    echo "$HOME/$2"
+  fi
+}
+
+bookmark_dir() {
+  local bookmark="file://$1 $2"
+  grep -qxF "$bookmark" ~/.config/gtk-3.0/bookmarks || echo "$bookmark" >>~/.config/gtk-3.0/bookmarks
+}
+
+downloads_dir=$(xdg_user_dir DOWNLOAD Downloads)
+pictures_dir=$(xdg_user_dir PICTURES Pictures)
+videos_dir=$(xdg_user_dir VIDEOS Videos)
+
+mkdir -p "$downloads_dir" "$pictures_dir" "$videos_dir" ~/.config/gtk-3.0
 xdg-user-dirs-update --set TEMPLATES "$HOME"
 xdg-user-dirs-update --set PUBLICSHARE "$HOME"
 xdg-user-dirs-update --set DESKTOP "$HOME"
 rmdir ~/Templates ~/Public ~/Desktop 2>/dev/null || true
 touch ~/.config/gtk-3.0/bookmarks
-for dir in Downloads Projects Pictures Videos; do
-  bookmark="file://$HOME/$dir $dir"
-  grep -qxF "$bookmark" ~/.config/gtk-3.0/bookmarks || echo "$bookmark" >>~/.config/gtk-3.0/bookmarks
-done
+bookmark_dir "$downloads_dir" Downloads
+bookmark_dir "$HOME/Projects" Projects
+bookmark_dir "$pictures_dir" Pictures
+bookmark_dir "$videos_dir" Videos
 
 source "$OMARCHY_INSTALL/user/all.sh"
 

--- a/test/shell.d/provision-user-test.sh
+++ b/test/shell.d/provision-user-test.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 
 source "$(dirname "$0")/base-test.sh"
 
+require_command xdg-user-dir
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 mock_bin="$test_tmp/bin"
-mkdir -p "$mock_bin" "$test_tmp/home"
+mkdir -p "$mock_bin"
 
 for command in xdg-user-dirs-update xdg-settings xdg-mime; do
   printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$command"
@@ -22,14 +24,68 @@ chmod +x "$mock_bin"/*
 mkdir -p "$test_tmp/install/user"
 : >"$test_tmp/install/user/all.sh"
 
-HOME="$test_tmp/home" PATH="$mock_bin:$ROOT/bin:$PATH" OMARCHY_PATH="$ROOT" \
-  OMARCHY_INSTALL="$test_tmp/install" bash "$ROOT/bin/omarchy-provision-user" >/dev/null ||
-  fail "omarchy-provision-user finishes"
+# XDG_CONFIG_HOME is cleared so xdg-user-dir reads the fixture's own
+# user-dirs.dirs rather than whatever the developer running the suite has.
+provision() {
+  env -u XDG_CONFIG_HOME HOME="$1" PATH="$mock_bin:$ROOT/bin:$PATH" \
+    OMARCHY_PATH="$ROOT" OMARCHY_INSTALL="$test_tmp/install" \
+    bash "$ROOT/bin/omarchy-provision-user" >/dev/null
+}
+
+bookmarked() {
+  grep -qxF "file://$2 $3" "$1/.config/gtk-3.0/bookmarks"
+}
+
+default_home="$test_tmp/home"
+mkdir -p "$default_home"
+provision "$default_home" || fail "omarchy-provision-user finishes"
 
 for skill in omarchy diagnose-crash; do
-  link="$test_tmp/home/.gemini/config/skills/$skill"
+  link="$default_home/.gemini/config/skills/$skill"
   [[ -L $link && $(readlink "$link") == "$ROOT/default/agents/skills/$skill" ]] ||
     fail "omarchy-provision-user provisions the $skill skill for Antigravity"
 done
 
 pass "omarchy-provision-user provisions Antigravity skills"
+
+# With nothing configured, xdg-user-dir reports $HOME for every directory, and
+# the default names are what provisioning has to fall back to.
+for dir in Downloads Pictures Videos; do
+  [[ -d "$default_home/$dir" ]] ||
+    fail "omarchy-provision-user creates ~/$dir when nothing is configured"
+  bookmarked "$default_home" "$default_home/$dir" "$dir" ||
+    fail "omarchy-provision-user bookmarks ~/$dir when nothing is configured"
+done
+
+bookmarked "$default_home" "$default_home/Projects" Projects ||
+  fail "omarchy-provision-user bookmarks ~/Projects"
+
+pass "omarchy-provision-user uses the default directories when none are configured"
+
+# A user who moved their XDG directories keeps them: provisioning must not
+# create an empty duplicate under the default name and bookmark that instead.
+custom_home="$test_tmp/custom"
+mkdir -p "$custom_home/.config" "$custom_home/inbox" "$custom_home/media/fotos" "$custom_home/media/clips"
+cat >"$custom_home/.config/user-dirs.dirs" <<'DIRS'
+XDG_DOWNLOAD_DIR="$HOME/inbox"
+XDG_PICTURES_DIR="$HOME/media/fotos"
+XDG_VIDEOS_DIR="$HOME/media/clips"
+DIRS
+
+provision "$custom_home" || fail "omarchy-provision-user finishes with customized XDG directories"
+
+for dir in Downloads Pictures Videos; do
+  [[ -e "$custom_home/$dir" ]] &&
+    fail "omarchy-provision-user leaves a duplicate ~/$dir beside the configured directory"
+done
+
+pass "omarchy-provision-user creates no duplicates beside customized XDG directories"
+
+bookmarked "$custom_home" "$custom_home/inbox" Downloads ||
+  fail "omarchy-provision-user bookmarks the configured download directory"
+bookmarked "$custom_home" "$custom_home/media/fotos" Pictures ||
+  fail "omarchy-provision-user bookmarks the configured picture directory"
+bookmarked "$custom_home" "$custom_home/media/clips" Videos ||
+  fail "omarchy-provision-user bookmarks the configured video directory"
+
+pass "omarchy-provision-user bookmarks the configured XDG directories"


### PR DESCRIPTION
Fixes #7733.

`omarchy-provision-user` created `~/Downloads`, `~/Pictures` and `~/Videos` unconditionally and wrote GTK bookmarks pointing at those names. A home whose `user-dirs.dirs` puts those directories somewhere else came back from an upgrade with empty duplicates sitting beside the real ones, and the file-chooser sidebar pointed at the empties rather than at the directories the user actually keeps things in.

Each directory now resolves through `xdg-user-dir` first. It reports `$HOME` for anything it has no setting for, so that is the signal to fall back to the default name — which keeps a fresh install exactly where it was. Resolution is per directory, so a home that relocated only some of them keeps the defaults for the rest.

Before, on a home with `XDG_DOWNLOAD_DIR="$HOME/inbox"` and `XDG_PICTURES_DIR="$HOME/media/fotos"`:

```
inbox  media  Downloads  Pictures  Videos     <- two empty duplicates
file://$HOME/Downloads Downloads              <- bookmarked the empty one
```

After:

```
inbox  media  Videos                          <- Videos is uncustomised, so it still gets the default
file://$HOME/inbox Downloads
file://$HOME/media/fotos Pictures
```

`test/shell.d/provision-user-test.sh` grows coverage for both halves: the default-name fallback when nothing is configured, and the customised case. The new assertions fail against the current script (`not ok - omarchy-provision-user leaves a duplicate ~/Downloads beside the configured directory`) and pass with this change.