### PR TITLE
Call a lapsed Claude access token paused, not signed out

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -581,16 +581,21 @@ def merge_stats(base: dict[str, Any], extra: dict[str, Any]) -> dict[str, Any]:
 # CLI's login. Nothing else leaves the credential store: the token goes
 # nowhere but the Authorization header of the limits probe, and only the
 # plan label may travel into the printed record.
-def oauth_login(claude_dir: Path) -> tuple[str, int, str]:
+def oauth_login(claude_dir: Path) -> tuple[str, int, int, str]:
   try:
     data = json.loads((claude_dir / ".credentials.json").read_text(encoding="utf-8"))
   except Exception:
-    return "", 0, ""
+    return "", 0, 0, ""
   login = data.get("claudeAiOauth")
   if not isinstance(login, dict):
-    return "", 0, ""
+    return "", 0, 0, ""
   plan = plan_label(str(login.get("rateLimitTier") or ""), str(login.get("subscriptionType") or ""))
-  return str(login.get("accessToken") or ""), number(login.get("expiresAt")), plan
+  return (
+    str(login.get("accessToken") or ""),
+    number(login.get("expiresAt")),
+    number(login.get("refreshTokenExpiresAt")),
+    plan,
+  )
 
 
 def plan_label(tier: str, subscription: str) -> str:
@@ -791,7 +796,7 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+def collect_limits(access_token: str, expires_at_ms: int, refresh_expires_at_ms: int, force: bool) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   # A panel that is opened and shut repeatedly must not turn into a request
@@ -812,6 +817,19 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
     return result
   if expires_at_ms > 0 and expires_at_ms <= time.time() * 1000:
     result["limits"] = fallback
+    # A lapsed access token is routine, not a sign-out: it lives about eight
+    # hours, and the CLI mints a new one from the refresh token the next time
+    # it runs. Only a lapsed *refresh* token is a sign-in a person must redo,
+    # and saying so either way sends people to `claude auth login` nightly --
+    # which does not restore anything the CLI would not have restored itself.
+    if refresh_expires_at_ms > time.time() * 1000:
+      result["usageStatusText"] = "Limits paused"
+      result["authHelpText"] = (
+        "Claude Code's access token has lapsed"
+        + (" — showing the last known limits." if fallback else ".")
+        + " Start Claude Code to refresh it; signing in again is not needed."
+      )
+      return result
     result["usageStatusText"] = "Sign-in expired"
     result["authHelpText"] = (
       "Claude Code's saved sign-in expired"
@@ -879,8 +897,8 @@ def main() -> int:
   if opencode is not None:
     stats = merge_stats(stats, opencode)
 
-  access_token, expires_at_ms, plan = oauth_login(claude_dir)
-  limits = collect_limits(access_token, expires_at_ms, args.force)
+  access_token, expires_at_ms, refresh_expires_at_ms, plan = oauth_login(claude_dir)
+  limits = collect_limits(access_token, expires_at_ms, refresh_expires_at_ms, args.force)
 
   record = {
     "schemaVersion": 1,

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -72,15 +72,16 @@ for payload in '{"five_hour":{"utilization":78.0},"limits":[{"kind":"session","p
 done
 pass "Claude collector adds no limit when the payload scopes none"
 
-# Only the Claude Code CLI refreshes the saved token, so between its runs the
-# collector can find a lapsed one. Drive collect_limits over a planted cache
-# with the network unreachable, so nothing but the credential state decides
-# the answer.
+# Only the Claude Code CLI refreshes the saved tokens, so between its runs the
+# collector can find the access token lapsed while the refresh token behind it
+# is still good. Drive collect_limits over a planted cache with the network
+# unreachable, so nothing but the credential state decides the answer.
 CACHE_HOME=$(mktemp -d)
 trap 'rm -rf "$CACHE_HOME"' EXIT
 
 collect_limits() {
-  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" \
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" \
+    REFRESH_EXPIRES_AT="$3" CACHED="$4" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
 import importlib.machinery, importlib.util, json, os, pathlib
 
@@ -100,7 +101,12 @@ def unreachable(request, timeout=None):
   raise OSError("no route to host")
 
 collector.urllib.request.urlopen = unreachable
-print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False)))
+print(json.dumps(collector.collect_limits(
+  os.environ["TOKEN"],
+  int(os.environ["EXPIRES_AT"]),
+  int(os.environ["REFRESH_EXPIRES_AT"]),
+  False,
+)))
 PY
 }
 
@@ -116,9 +122,10 @@ cache=$(jq -nc --arg open "$open_at" --arg past "$past_at" '{
   ]
 }')
 
-# An expired token used to return an empty limits list and no status at all,
-# which hides the panel's whole limits section without saying why.
-expired=$(collect_limits "token" 1000 "$cache")
+# Both tokens lapsed is a genuine sign-out. It used to return an empty limits
+# list and no status at all, which hides the panel's whole limits section
+# without saying why.
+expired=$(collect_limits "token" 1000 1000 "$cache")
 [[ $(jq -r '.usageStatusText' <<<"$expired") == "Sign-in expired" ]] ||
   fail "Claude collector reports an expired sign-in" "$expired"
 [[ $(jq -r '.authHelpText' <<<"$expired") == *"claude auth login"* ]] ||
@@ -131,15 +138,29 @@ pass "Claude collector reports an expired sign-in instead of hiding the section"
 pass "Claude collector keeps only cached windows that have not reset"
 
 # Nothing worth showing: the status still explains the silence.
-stale=$(collect_limits "token" 1000 "$(jq -c '.limits |= [.[0]]' <<<"$cache")")
+stale=$(collect_limits "token" 1000 1000 "$(jq -c '.limits |= [.[0]]' <<<"$cache")")
 [[ $(jq -c '.limits' <<<"$stale") == "[]" && $(jq -r '.usageStatusText' <<<"$stale") == "Sign-in expired" ]] ||
   fail "Claude collector drops a wholly reset cache but keeps explaining itself" "$stale"
 [[ $(jq -r '.authHelpText' <<<"$stale") != *"last known"* ]] ||
   fail "Claude collector promises no last-known limits when it has none" "$stale"
 pass "Claude collector drops a wholly reset cache but keeps explaining itself"
 
+# The access token lives about eight hours; the refresh token behind it lives
+# about thirty days, and the CLI mints a new access token from it on its next
+# run. A machine left overnight finds the first lapsed and the second fine --
+# routine, and nothing a person fixes by signing in again.
+live_refresh=$(python3 -c 'import time; print(round((time.time() + 30 * 86400) * 1000))')
+paused=$(collect_limits "token" 1000 "$live_refresh" "$cache")
+[[ $(jq -r '.usageStatusText' <<<"$paused") == "Limits paused" ]] ||
+  fail "Claude collector calls a lapsed access token paused, not signed out" "$paused"
+[[ $(jq -r '.authHelpText' <<<"$paused") != *"claude auth login"* ]] ||
+  fail "Claude collector does not send a signed-in machine back through login" "$paused"
+[[ $(jq -c '[.limits[].label]' <<<"$paused") == '["Weekly (7-day)"]' ]] ||
+  fail "Claude collector keeps open cached windows while the access token is stale" "$paused"
+pass "Claude collector calls a lapsed access token paused, not signed out"
+
 # A signed-out machine says so, and still shows what it last knew.
-signed_out=$(collect_limits "" 0 "$cache")
+signed_out=$(collect_limits "" 0 0 "$cache")
 [[ $(jq -r '.usageStatusText' <<<"$signed_out") == "Waiting for auth" ]] ||
   fail "Claude collector still reports a missing token" "$signed_out"
 [[ $(jq -c '[.limits[].label]' <<<"$signed_out") == '["Weekly (7-day)"]' ]] ||
@@ -148,7 +169,7 @@ pass "Claude collector serves open cached windows without a token"
 
 # A live token that cannot reach the endpoint keeps the old contract: the open
 # window stands in, and the shell is asked to retry sooner than its interval.
-unreachable=$(collect_limits "token" 0 "$cache")
+unreachable=$(collect_limits "token" 0 0 "$cache")
 [[ $(jq -c '[.limits[].label]' <<<"$unreachable") == '["Weekly (7-day)"]' ]] ||
   fail "Claude collector falls back to cache when the probe cannot connect" "$unreachable"
 [[ $(jq -r '.retryAdvised' <<<"$unreachable") == "true" ]] ||
@@ -177,7 +198,7 @@ def urlopen(request, timeout=None):
   return io.BytesIO(os.environ["PAYLOAD"].encode())
 
 collector.urllib.request.urlopen = urlopen
-result = collector.collect_limits("token", 0, os.environ["FORCE"] == "true")
+result = collector.collect_limits("token", 0, 0, os.environ["FORCE"] == "true")
 print(json.dumps({
   "result": result,
   "probes": len(probes),


### PR DESCRIPTION
The agents panel treats a lapsed **access** token as a lapsed **sign-in**. Those differ by about thirty days.

`~/.claude/.credentials.json` carries two expiries — `expiresAt` (access token, ~8 hours) and `refreshTokenExpiresAt` (refresh token, ~30 days). `collect_limits` read only the first, so any machine idle overnight woke to **SIGN-IN EXPIRED** and was told to run `claude auth login` while its stored session still had weeks left.

That advice is worse than redundant: `claude auth login` mints a new OAuth session and rotates the credentials, so people who follow the panel record a fresh login every morning and reasonably conclude Claude Code keeps signing them out. Starting Claude Code refreshes the access token on its own and changes nothing else.

On the machine this was found on, never signed out:

```
expiresAt              = 1787624562658  -> 2026-08-25 04:22:42   (8h after the file was written)
refreshTokenExpiresAt  = 1790070218658  -> 2026-09-22 11:43:38   (30d from 2026-08-23 11:43)
```

The access token was reissued from the refresh token with `refreshTokenExpiresAt` unchanged — no new login — yet the panel would have said "Sign-in expired" for the eight-hour gap before it.

## What this changes

`oauth_login()` already parses the credential file, so the refresh expiry costs one key. `collect_limits` now splits the two cases:

| case | before | after |
|---|---|---|
| access lapsed, refresh live | `Sign-in expired` → run `claude auth login` | `Limits paused` → "Start Claude Code to refresh it; signing in again is not needed." |
| access **and** refresh lapsed | `Sign-in expired` | unchanged |
| both live | limits fetched | unchanged |

The cached-limits fallback from #6795 applies in both branches, so the last known windows keep rendering either way. `Panel.qml` reads `usageStatusText` and `authHelpText` verbatim, so the new status needs no shell change.

## Tests

`collect_limits` gained an argument, so the eight cases from #6795 were updated — the sign-out cases now lapse both expiries, which is what a real sign-out is. One case added for the reason this exists: a lapsed access token behind a live refresh token reports `Limits paused`, never mentions `claude auth login`, and still serves the open cached window.

Checked that the new case is not vacuous — with the signature kept but the branch removed, it fails on the message rather than on arity:

```
not ok - Claude collector calls a lapsed access token paused, not signed out
{"usageStatusText": "Sign-in expired", "authHelpText": "... run `claude auth login` ..."}
```

`test/all`: 193 of 196 files pass. The three failures — `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` — fail identically on the unmodified upstream commit here and are unrelated to this change.

Closes #8092.

---
Written by Claude Opus 5 via Claude Code.
