### PR TITLE
Show power profile in bar and add graphics mode controls

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -16,14 +16,29 @@ Panel {
   property var batteryInfo: ({})
   property var systemInfo: ({})
   property var profiles: []
-  property string activeProfile: ""
+  readonly property string activeProfile: {
+    if (PowerProfiles.profile === PowerProfile.PowerSaver) return "power-saver"
+    if (PowerProfiles.profile === PowerProfile.Performance) return "performance"
+    return "balanced"
+  }
   property int profileIndex: 0
+  property int gpuModeIndex: 0
+  property bool gpuModeFocused: false
   property bool cursorActive: false
+  property string activeGpuMode: ""
+  readonly property bool hybridGpuAvailable: activeGpuMode !== ""
   readonly property bool showPercentage: setting("showPercentage", false) === true
-  // With the percentage shown the button paints a text block wider than an
-  // icon, so the open-panel mark takes the painted width instead of the
-  // icon-sized fraction of the slot the fallback assumes.
-  readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  readonly property bool showProfile: setting("showProfile", false) === true
+  readonly property string barPercentageText: showPercentage && !button.vertical ? "\u2009" + Math.round(batteryFraction * 100) + "%\u2009\u2009\u2009" : ""
+  readonly property string barProfileText: showProfile && !button.vertical ? profileIcon(activeProfile) + " " : ""
+  readonly property string barBatteryText: batteryIcon()
+  readonly property string barText: barPercentageText + barProfileText + barBatteryText
+  readonly property real openPanelIndicatorWidth: {
+    if (button.vertical) return 0
+    if (showPercentage) return barTextMetrics.tightBoundingRect.width
+    if (showProfile) return barTextMetrics.tightBoundingRect.width + Style.space(5)
+    return 0
+  }
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -59,6 +74,19 @@ Panel {
 
   function profileIcon(name) {
     return Model.profileIcon(name)
+  }
+
+  function updateGpuMode(raw) {
+    var mode = String(raw || "").trim()
+    activeGpuMode = mode === "Integrated" || mode === "Hybrid" ? mode : ""
+    if (!cursorActive || !gpuModeFocused) gpuModeIndex = activeGpuMode === "Hybrid" ? 1 : 0
+  }
+
+  function selectGpuMode(mode) {
+    if (activeGpuMode === mode) return
+
+    close()
+    Quickshell.execDetached(["omarchy-launch-floating-terminal-with-presentation", "omarchy-toggle-hybrid-gpu"])
   }
 
   readonly property bool fullyCharged: {
@@ -155,7 +183,6 @@ Panel {
     // transient empty payloads so the buttons don't blink out.
     if (parsed.profiles.length === 0) return
     profiles = parsed.profiles
-    activeProfile = parsed.activeProfile
     profileIndex = parsed.profileIndex
     if (opened && !cursorActive) {
       var idx = profiles.indexOf(activeProfile)
@@ -193,8 +220,10 @@ Panel {
       }
 
       refresh()
+      if (!gpuModeProc.running) gpuModeProc.running = true
       var idx = profiles.indexOf(activeProfile)
       profileIndex = idx >= 0 ? idx : 0
+      gpuModeFocused = false
       cursorActive = false
     }
   }
@@ -221,6 +250,15 @@ Panel {
     id: systemProc
     command: ["omarchy-system-stats"]
     stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.updateKeyValue(text, "system") }
+  }
+
+  Process {
+    id: gpuModeProc
+    command: ["timeout", "--kill-after=1s", "3s", "supergfxctl", "-g"]
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.updateGpuMode(text) }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) root.activeGpuMode = ""
+    }
   }
 
   Process {
@@ -277,10 +315,23 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.showPercentage && !vertical
-      ? Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
-      : root.batteryIcon()
-    slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
+    text: root.barText
+    iconComponent: Component {
+      Item {
+        Row {
+          anchors.centerIn: parent
+          height: Style.bar.iconCanvas
+
+          BarTextSegment {
+            text: root.barPercentageText
+            verticalOffset: Style.space(2)
+          }
+          BarTextSegment { text: root.barProfileText }
+          BarTextSegment { text: root.barBatteryText }
+        }
+      }
+    }
+    slotSize: Style.bar.iconSlot * (1 + (root.showPercentage && !vertical ? 1 : 0) + (root.showProfile && !vertical ? 0.5 : 0))
     tooltipText: ""
     onPressed: function(b) {
       if (!root.batteryPresent) return
@@ -303,11 +354,22 @@ Panel {
       id: keyCatcher
       anchors.fill: parent
       onMoveRequested: function(dx, dy) {
-        if (!root.cursorActive) { root.cursorActive = true; return }
-        if (dx !== 0) root.selectProfileByDelta(dx)
-        else if (dy !== 0) root.selectProfileByDelta(dy)
+        if (!root.cursorActive) {
+          root.cursorActive = true
+        } else if (dy !== 0) {
+          if (root.hybridGpuAvailable) root.gpuModeFocused = dy > 0
+          else root.selectProfileByDelta(dy)
+        } else if (dx !== 0 && root.gpuModeFocused) {
+          root.gpuModeIndex = Math.max(0, Math.min(1, root.gpuModeIndex + dx))
+        } else if (dx !== 0) {
+          root.selectProfileByDelta(dx)
+        }
       }
-      onActivateRequested: if (root.cursorActive) root.activateSelectedProfile()
+      onActivateRequested: {
+        if (!root.cursorActive) return
+        if (root.gpuModeFocused) root.selectGpuMode(root.gpuModeIndex === 0 ? "Integrated" : "Hybrid")
+        else root.activateSelectedProfile()
+      }
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
 
@@ -488,12 +550,68 @@ Panel {
                 verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
                 bordered: true
                 active: root.activeProfile === modelData
-                hasCursor: root.cursorActive && root.profileIndex === index
+                hasCursor: root.cursorActive && !root.gpuModeFocused && root.profileIndex === index
                 onClicked: root.setProfile(modelData)
                 onHovered: function(h) {
                   if (h) {
                     root.cursorActive = true
+                    root.gpuModeFocused = false
                     root.profileIndex = index
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        // ---------- Hybrid graphics mode ----------
+        PanelSeparator {
+          visible: root.hybridGpuAvailable
+          foreground: root.bar.foreground
+        }
+
+        Column {
+          visible: root.hybridGpuAvailable
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            text: "GRAPHICS MODE"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Row {
+            id: gpuModeRow
+            width: parent.width
+            spacing: Style.space(6)
+            readonly property var modes: [
+              { mode: "Integrated", label: "iGPU" },
+              { mode: "Hybrid", label: "Hybrid (iGPU + dGPU)" }
+            ]
+            readonly property real cellWidth: (width - spacing) / modes.length
+
+            Repeater {
+              model: gpuModeRow.modes
+              Button {
+                required property var modelData
+                required property int index
+                width: gpuModeRow.cellWidth
+                text: modelData.label
+                fontSize: Style.font.bodySmall
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                horizontalPadding: Style.spacing.controlPaddingX
+                verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+                bordered: true
+                selected: root.activeGpuMode === modelData.mode
+                hasCursor: root.cursorActive && root.gpuModeFocused && root.gpuModeIndex === index
+                onClicked: root.selectGpuMode(modelData.mode)
+                onHovered: function(h) {
+                  if (h) {
+                    root.cursorActive = true
+                    root.gpuModeFocused = true
+                    root.gpuModeIndex = index
                   }
                 }
               }
@@ -516,6 +634,24 @@ Panel {
     InfoValue { text: value }
   }
 
+  component BarTextSegment: Item {
+    property alias text: label.text
+    property real verticalOffset: 0
+
+    width: label.implicitWidth
+    height: parent.height
+
+    Text {
+      id: label
+      anchors.centerIn: parent
+      anchors.verticalCenterOffset: verticalOffset
+      color: button.active && button.useActiveColor ? button.activeColor : button.foreground
+      font.family: button.fontFamily
+      font.pixelSize: button.fontSize
+      renderType: Text.NativeRendering
+    }
+  }
+
   component InfoLabel: Text {
     color: root.bar.foreground
     opacity: 0.6
@@ -527,5 +663,12 @@ Panel {
     color: root.bar.foreground
     font.family: root.bar.fontFamily
     font.pixelSize: Style.font.bodySmall
+  }
+
+  TextMetrics {
+    id: barTextMetrics
+    font.family: button.fontFamily
+    font.pixelSize: Math.max(1, Math.round(button.fontSize))
+    text: root.barText
   }
 }

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -44,8 +44,15 @@ assertEqual(
 
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
-assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')
-assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
+assert(/setting\("showProfile", false\)/.test(panelSource), 'power can show the active profile in the bar')
+assert(/PowerProfiles\.profile === PowerProfile\.Performance/.test(panelSource), 'power tracks the active profile while its panel is closed')
+assert(/barProfileText:.*profileIcon\(activeProfile\) \+ " "/.test(panelSource), 'power places the profile before the battery icon')
+assert(/readonly property bool hybridGpuAvailable: activeGpuMode !== ""/.test(panelSource), 'power only enables graphics controls when the current mode is available')
+assert(/command: \["timeout", "--kill-after=1s", "3s", "supergfxctl", "-g"\]/.test(panelSource), 'power bounds the hybrid GPU mode query')
+assert(/visible: root\.hybridGpuAvailable[\s\S]*text: "GRAPHICS MODE"/.test(panelSource), 'power only shows graphics controls on supported systems')
+assert(/hasCursor: root\.cursorActive && root\.gpuModeFocused && root\.gpuModeIndex === index/.test(panelSource), 'power exposes keyboard cursor state on graphics choices')
+assert(/onActivateRequested:[\s\S]*root\.selectGpuMode\(root\.gpuModeIndex === 0 \? "Integrated" : "Hybrid"\)/.test(panelSource), 'power activates graphics choices from the keyboard')
+assert(/if \(root\.hybridGpuAvailable\) root\.gpuModeFocused = dy > 0[\s\S]*else root\.selectProfileByDelta\(dy\)/.test(panelSource), 'power keeps vertical profile navigation without graphics controls')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
 JS


### PR DESCRIPTION
## Summary

- Add an optional `showProfile` setting that displays the active power profile beside the battery icon.
- Keep the displayed profile current while the panel is closed.
- Show integrated and hybrid GPU controls on supported systems (opens: omarchy -> trigger -> hardware -> hybrid gpu).
- Align the open-panel indicator with the optional bar status.
- Improve percentage spacing when profile visibility is enabled.

`showProfile` defaults to `false`, preserving the existing bar appearance.

## Testing

- `qmllint -I shell shell/plugins/panels/power/Panel.qml`
- `bash test/shell.d/power-test.sh`

## Showcase 

Panel opened, both percentage and power profile enabled:
<img width="445" height="378" alt="omarchy-power-showcase-both-enabled" src="https://github.com/user-attachments/assets/4d29e799-538a-43e7-a259-1d2340a8853e" />

Percentage enabled, power profile hidden:
<img width="190" height="31" alt="omarchy-power-showcase-percentage-only" src="https://github.com/user-attachments/assets/8a3efd72-acaf-41b5-92c0-ea146ad174ce" />

Percentage hidden, power profile enabled:
<img width="190" height="31" alt="omarchy-power-showcase-profile-only" src="https://github.com/user-attachments/assets/a8b0d7d8-f99d-4869-b740-a65e8452772d" />

Default state (both percentage and power profile hidden):
<img width="190" height="31" alt="omarchy-power-showcase-default" src="https://github.com/user-attachments/assets/ef25015b-8982-46fb-9e44-0562dc3c0a42" />

Assisted by GPT-5.6 Sol.
