### PR TITLE
Keep Bluetooth in the bar while the radio is blocked

### DIFF
--- a/bin/omarchy-bluetooth-power
+++ b/bin/omarchy-bluetooth-power
@@ -54,13 +54,22 @@ power_on() {
   # Usually all it takes: with AutoEnable at its default, bluetoothd powers the
   # adapter up on its own once the block is gone. It will not do that for an
   # adapter powered down without a block, so ask directly before giving up.
-  wait_powered && return 0
+  if ! wait_powered; then
+    timeout 5s bluetoothctl power on >/dev/null 2>&1
+    if ! wait_powered; then
+      echo "omarchy-bluetooth-power: adapter did not come up" >&2
+      return 1
+    fi
+  fi
 
-  timeout 5s bluetoothctl power on >/dev/null 2>&1
-  wait_powered && return 0
-
-  echo "omarchy-bluetooth-power: adapter did not come up" >&2
-  return 1
+  # On switch-gated hardware a login-time block removes the adapter from sysfs,
+  # so the enabled bt-agent.service failed its ConditionPathIsDirectory at
+  # session start and was skipped — systemd never rechecks a condition on its
+  # own, and pairing needs the NoInputNoOutput agent. Both of its gates hold
+  # now that bluetoothd reports the adapter powered, so start it here. A start
+  # is a no-op while the agent already runs, and a context without a user
+  # manager must not turn a successful power-on into a failure.
+  systemctl --user start bt-agent.service 2>/dev/null || true
 }
 
 case "${1:-}" in

--- a/bin/omarchy-hw-bluetooth
+++ b/bin/omarchy-hw-bluetooth
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer has Bluetooth hardware.
+
+# Read rfkill, do not ask BlueZ. On hardware where a platform switch gates the
+# radio, a soft block removes the hci device, and BlueZ then reports no adapter.
+# The rfkill entry survives the block. Only rfkill shows the difference between
+# blocked hardware and missing hardware.
+rfkill_path="${OMARCHY_RFKILL_PATH:-/sys/class/rfkill}"
+
+shopt -s nullglob
+
+for device in "$rfkill_path"/*; do
+  [[ $(< "$device/type") == "bluetooth" ]] && exit 0
+done
+
+exit 1

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -23,6 +23,14 @@ Panel {
 
   readonly property var adapter: Bluetooth.defaultAdapter
 
+  // A null adapter cannot show the difference between blocked hardware and missing
+  // hardware: on hardware where a platform switch gates the radio, a soft block
+  // removes the hci device from the kernel, and BlueZ then reports no adapter. The
+  // rfkill entry survives, and omarchy-hw-bluetooth reads that. Thus the widget
+  // stands for the radio, not for the view that BlueZ has of it.
+  property bool bluetoothPresent: false
+  readonly property bool hasBluetooth: adapter !== null || bluetoothPresent
+
   // True while this instance owes BlueZ a StopDiscovery: set when it starts
   // discovery (or opens onto a session already running) and cleared once
   // discovery is confirmed down after close. Ownership, not state — BlueZ's
@@ -56,8 +64,10 @@ Panel {
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
   readonly property string icon: {
-    if (!adapter) return ""
-    if (!adapter.enabled) return "󰂲"
+    // A blocked radio shows the off glyph, not a blank slot. Only a machine with no
+    // Bluetooth radio draws nothing: BarIconButton has no visual content at an empty
+    // string, and the widget then holds a blank slot.
+    if (!adapter || !adapter.enabled) return hasBluetooth ? "󰂲" : ""
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
   }
@@ -75,7 +85,7 @@ Panel {
   ]
   readonly property bool rotatingPhrases: adapter && adapter.enabled
   readonly property string heroStatusText: {
-    if (!adapter) return "No adapter"
+    if (!adapter) return hasBluetooth ? "Blocked" : "No adapter"
     if (!adapter.enabled) return "Turned Off"
     return activePhrases[phraseIndex % activePhrases.length]
   }
@@ -497,9 +507,20 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: adapter !== null
+  visible: hasBluetooth
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
+
+  Process {
+    id: hardwareProbe
+    command: ["omarchy-hw-bluetooth"]
+    running: true
+    onExited: function(exitCode) { root.bluetoothPresent = exitCode === 0 }
+  }
+
+  // An adapter that disappears no longer proves that the hardware is present. On
+  // switch-gated hardware, the block removes the radio at exactly this moment.
+  onAdapterChanged: if (!adapter) hardwareProbe.running = true
 
   // BlueZ rejects StartDiscovery while the adapter is still powering up, and
   // discovery can also time out on its own. While the panel is open, keep
@@ -627,14 +648,17 @@ Panel {
   // Not adapter.enabled: that writes BlueZ's Powered, which nothing persists, so
   // the adapter came back on at the next boot. omarchy-bluetooth-power moves the
   // rfkill soft block instead, which systemd-rfkill restores across reboots.
-  // Powered still follows the block, so the switch and icon read it as before.
+  //
+  // The guard reads hasBluetooth, not the adapter: a switch-gated block removes the
+  // adapter with the radio (see bluetoothPresent), and an rfkill unblock does not
+  // need BlueZ. A guard on the adapter made the block permanent on that hardware.
   //
   // Asking for a direction rather than a toggle: the helper runs detached and the
   // switch only moves once BlueZ catches up, so a second click inside that window
   // would re-read the old state and undo the first.
   function toggleBluetooth() {
-    if (!adapter) return
-    Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
+    if (!hasBluetooth) return
+    Quickshell.execDetached(["omarchy-bluetooth-power", adapter && adapter.enabled ? "off" : "on"])
   }
 
   IpcHandler {
@@ -711,7 +735,7 @@ Panel {
           // header's only cursor target.
           ToggleSwitch {
             id: powerSwitch
-            visible: !!root.adapter
+            visible: root.hasBluetooth
             checked: !!root.adapter && root.adapter.enabled
             hasCursor: root.headerHasCursor
             foreground: root.bar.foreground
@@ -864,8 +888,8 @@ Panel {
 
         Text {
           visible: root.connectedDevices.length === 0 && root.scrollRows.length === 0
-          text: !root.adapter ? "No Bluetooth adapter"
-              : !root.adapter.enabled ? "Turn Bluetooth on to scan"
+          text: !root.hasBluetooth ? "No Bluetooth adapter"
+              : !root.adapter || !root.adapter.enabled ? "Turn Bluetooth on to scan"
               : "Scanning for devices…"
           color: Qt.darker(root.bar.foreground, 1.5)
           font.family: root.bar.fontFamily

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -17,8 +17,25 @@ assert(/IpcHandler[\s\S]*?function toggleBluetooth\(\) \{ root\.toggleBluetooth\
 assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so it can extend the target methods')
 
 // Writing adapter.enabled sets BlueZ Powered, which does not survive a reboot.
-assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
+assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter && adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
 assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the adapter power state directly')
+
+// A soft block can remove the adapter from BlueZ. The shell must remove the block
+// in exactly this case, with no adapter to read. A guard on the adapter made the
+// block permanent. rfkill is the only layer that still knows the hardware is
+// present, so the probe reports the hardware, and BlueZ does not.
+assert(/function toggleBluetooth\(\)\s*\{\s*if \(!hasBluetooth\) return\b/.test(panelSource), 'bluetooth does not try to unblock hardware that does not exist')
+assert(/command: \["omarchy-hw-bluetooth"\]/.test(panelSource), 'bluetooth probes for hardware the adapter cannot report')
+assert(/onExited: function\(exitCode\)[\s\S]*?bluetoothPresent = exitCode === 0/.test(panelSource), 'bluetooth takes hardware presence from the probe exit code')
+assert(/readonly property bool hasBluetooth: adapter !== null \|\| bluetoothPresent/.test(panelSource), 'bluetooth treats the rfkill probe as hardware presence when BlueZ has no adapter')
+assert(/visible: hasBluetooth\b/.test(panelSource), 'bluetooth stays in the bar while the radio is blocked')
+assert(/visible: root\.hasBluetooth\b/.test(panelSource), 'bluetooth offers the power switch while the radio is blocked')
+
+// BarIconButton has no visual content at an empty string. A visible widget with no
+// glyph is then a blank slot in the bar. A blocked radio reuses the off glyph.
+assert(/if \(!adapter \|\| !adapter\.enabled\) return hasBluetooth \? "\u{f00b2}" : ""/u.test(panelSource), 'bluetooth draws the off glyph while blocked instead of a blank bar entry')
+assert(/if \(!adapter\) return hasBluetooth \? "Blocked" : "No adapter"/.test(panelSource), 'bluetooth names the blocked state instead of reporting no adapter')
+assert(/!root\.hasBluetooth \? "No Bluetooth adapter"/.test(panelSource), 'bluetooth only reports a missing adapter when the machine has no radio at all')
 
 // Discovery is a BlueZ session that nothing ends at panel close: it persists
 // until StopDiscovery or until quickshell's D-Bus connection drops with the

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -197,7 +197,16 @@ printf 'rfkill %s\n' "$*" >>"$BLUETOOTHCTL_LOG"
 exit 0
 SH
 
-chmod +x "$mock_bin/bluetoothctl" "$mock_bin/rfkill"
+# Stands in for the user manager that power-on asks to revive bt-agent, and
+# keeps the real systemctl out of the test run.
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+
+printf 'systemctl %s\n' "$*" >>"$BLUETOOTHCTL_LOG"
+exit 0
+SH
+
+chmod +x "$mock_bin/bluetoothctl" "$mock_bin/rfkill" "$mock_bin/systemctl"
 
 # $ROOT/bin so omarchy-bluetooth-device resolves the real omarchy-bluetooth-power.
 bluetooth_run() {
@@ -227,6 +236,10 @@ grep -q "power off" "$off_log" &&
   fail "bluetooth does not also power the adapter down" "$(cat "$off_log")"
 pass "bluetooth does not also power the adapter down"
 
+grep -q "bt-agent" "$off_log" &&
+  fail "bluetooth leaves the pairing agent alone when turning off" "$(cat "$off_log")"
+pass "bluetooth leaves the pairing agent alone when turning off"
+
 # Unblocking is enough on its own, so there is nothing left to ask bluetoothctl.
 on_log=$(bluetooth_power no on)
 grep -qx "rfkill unblock bluetooth" "$on_log" ||
@@ -237,11 +250,22 @@ grep -q "power on" "$on_log" &&
   fail "bluetooth leaves the power-on to bluetoothd when the block is lifted" "$(cat "$on_log")"
 pass "bluetooth leaves the power-on to bluetoothd when the block is lifted"
 
+# A login-time block on switch-gated hardware removes the adapter from sysfs, so
+# the enabled bt-agent.service was skipped on its ConditionPathIsDirectory and
+# systemd never rechecks it. Power-on is the moment both of its gates hold again.
+grep -qx "systemctl --user start bt-agent.service" "$on_log" ||
+  fail "bluetooth revives the skipped pairing agent after power-on" "$(cat "$on_log")"
+pass "bluetooth revives the skipped pairing agent after power-on"
+
 # An adapter powered down without a block is one bluetoothd will not pick up.
 inert_log=$(RFKILL_INERT=1 bluetooth_power no on)
 grep -qx "power on" "$inert_log" ||
   fail "bluetooth powers the adapter on when unblocking does not" "$(cat "$inert_log")"
 pass "bluetooth powers the adapter on when unblocking does not"
+
+grep -qx "systemctl --user start bt-agent.service" "$inert_log" ||
+  fail "bluetooth revives the pairing agent after the fallback power-on too" "$(cat "$inert_log")"
+pass "bluetooth revives the pairing agent after the fallback power-on too"
 
 # The panel switch reads Powered, so that is what toggle has to invert.
 toggle_on_log=$(bluetooth_power yes toggle)

--- a/test/shell.d/hw-bluetooth-test.sh
+++ b/test/shell.d/hw-bluetooth-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Each argument is an rfkill device as "name:type". The function writes each device
+# in the layout of sysfs: /sys/class/rfkill/rfkillN/{name,type}.
+write_rfkill_devices() {
+  rm -rf "$tmp_dir/rfkill"
+  mkdir -p "$tmp_dir/rfkill"
+
+  local index=0
+  local spec
+  for spec in "$@"; do
+    local device="$tmp_dir/rfkill/rfkill$index"
+    mkdir -p "$device"
+    printf '%s\n' "${spec%%:*}" >"$device/name"
+    printf '%s\n' "${spec##*:}" >"$device/type"
+    index=$((index + 1))
+  done
+}
+
+hw_bluetooth() {
+  OMARCHY_RFKILL_PATH="$tmp_dir/rfkill" "$ROOT/bin/omarchy-hw-bluetooth"
+}
+
+assert_detects() {
+  local description="$1" expected="$2"
+
+  local actual=no
+  hw_bluetooth && actual=yes
+
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "omarchy-hw-bluetooth: expected $expected, got $actual"
+
+  pass "$description"
+}
+
+# This device is the radio, on hardware where the block keeps the hci device in the
+# kernel.
+write_rfkill_devices "hci0:bluetooth"
+assert_detects "a machine with an hci device has bluetooth hardware" yes
+
+# Only the ThinkPad ACPI switch survives a soft block. The kernel no longer has the
+# radio that this switch gates, so this entry is the only proof of the hardware.
+write_rfkill_devices "tpacpi_bluetooth_sw:bluetooth"
+assert_detects "a machine with only the platform switch has bluetooth hardware" yes
+
+write_rfkill_devices "tpacpi_bluetooth_sw:bluetooth" "phy0:wlan"
+assert_detects "a machine with more than one radio has bluetooth hardware" yes
+
+write_rfkill_devices "phy0:wlan"
+assert_detects "wifi alone is not bluetooth hardware" no
+
+write_rfkill_devices
+assert_detects "a machine with no radios has no bluetooth hardware" no
+
+# A machine without rfkill in the kernel has no sysfs directory for the glob.
+rm -rf "$tmp_dir/rfkill"
+assert_detects "a machine with no rfkill tree has no bluetooth hardware" no


### PR DESCRIPTION
`omarchy-bluetooth-power off` runs `rfkill block bluetooth`. On hardware where a platform switch gates the radio, the block removes the hci device from the kernel, and BlueZ then reports no adapter. The `tpacpi_bluetooth_sw` switch on a ThinkPad works this way.

`Bluetooth.defaultAdapter` is null there, so `visible: adapter !== null` removed the widget from the bar, and `toggleBluetooth()` returned early on the same test. The shell had no way to remove a block that the shell set, and systemd-rfkill restores the block across reboots.

An rfkill unblock does not need an adapter, and rfkill still lists the switch. Add `omarchy-hw-bluetooth`, which searches `/sys/class/rfkill` for a device of type bluetooth. The widget, its power switch, the icon and the toggle now gate on this command.

Before:

https://github.com/user-attachments/assets/8e773ec0-f3e6-44b1-91c7-fd81044afef3

After:

https://github.com/user-attachments/assets/fae82331-a37e-4f2a-bcef-a0f2861eee13



