### PR TITLE
Add US International keyboard layout

### DIFF
--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -33,6 +33,7 @@ OMARCHY_KEYBOARD_LAYOUTS=$'English (US)|us
 English (UK)|uk
 English (US, Dvorak)|dvorak
 English (US, Colemak)|colemak
+English (US, International)|us-acentos
 Azerbaijani|azerty
 Belarusian|by
 Belgian|be-latin1

--- a/test/shell.d/setup-form-test.sh
+++ b/test/shell.d/setup-form-test.sh
@@ -121,6 +121,8 @@ source "$ROOT/install/provisioning/setup-form.sh"
 ((OMARCHY_FORM_SIGNAL == 130)) || fail "Ctrl+C reports status 130"
 [[ $(printf '%s\n' "$OMARCHY_KEYBOARD_LAYOUTS" | head -n 1) == "English (US)|us" ]] ||
   fail "English (US) leads the keyboard layouts so gum choose opens on the default"
+grep -qxF 'English (US, International)|us-acentos' <<<"$OMARCHY_KEYBOARD_LAYOUTS" ||
+  fail "the international pick resolves to its console keymap" "$OMARCHY_KEYBOARD_LAYOUTS"
 pass "the form publishes the 0/1/130 status contract and leads with English (US)"
 
 # Keyboard
@@ -132,6 +134,12 @@ assert_status 0 "keyboard prompt succeeds"
 [[ $(head -n 1 "$tmp_dir/stdin.1") == "English (US)" ]] || fail "keyboard prompt offers English (US) first"
 grep -qF -- '--selected English (US)' "$GUM_ARGS" || fail "keyboard prompt preselects English (US)"
 pass "keyboard prompt maps the chosen label to its keymap"
+
+run_prompt omarchy_prompt_keyboard "0:English (US, International)"
+assert_status 0 "international keyboard prompt succeeds"
+[[ $(field keyboard) == "us-acentos" ]] || fail "keyboard prompt resolves the international pick to its keymap"
+[[ $(field keyboard_label) == "English (US, International)" ]] || fail "keyboard prompt keeps the international label"
+pass "keyboard prompt maps US International to us-acentos"
 
 run_prompt omarchy_prompt_keyboard "1:"
 assert_status "$OMARCHY_FORM_BACK" "keyboard prompt reports Esc as back"


### PR DESCRIPTION
The installer's keyboard picker has no choice for people who type English on a US physical keyboard but still need accented characters — Portuguese, Spanish, or French words in an otherwise English workflow. The closest options today are a national layout, which moves the punctuation around, or going without accents; users have resorted to asking how to wire this up by hand (#2979).

This adds **English (US, International)** as `us-acentos`, listed with the other English variants at the top of the picker.

## Why nothing downstream needed touching

`us-acentos` rides the existing pipeline end to end:

- `localectl list-keymaps` knows the keymap, so `apply_keyboard` accepts it, and `loadkeys` gives the console real dead keys — `us-acentos` is the US map plus dead keys and accent compositions.
- `kbd-model-map`, shipped by systemd, translates it to XKB layout `us` with variant `intl`. So `systemd-firstboot --keymap=us-acentos` writes `XKBLAYOUT=us XKBVARIANT=intl` into `/etc/vconsole.conf`, which is exactly what Hyprland's `input.lua` reads — first login lands on US International with no extra plumbing anywhere.

## Deliberately left out

XKB also ships an `altgr-intl` variant ("US International with AltGr dead keys"). No console keymap expresses it and nothing in `kbd-model-map` points at it, so offering it would mean teaching every consumer of this form — the ISO configurator included — about XKB-only variants. Omitted to keep this a data-only change.

## Verification

`./test/shell.d/setup-form-test.sh`: 16 ok, 0 failures, including two new assertions covering the list row and its label→keymap resolution through `omarchy_prompt_keyboard`.
