### PR TITLE
Enable the NVIDIA suspend services on 580xx installs

### DIFF
--- a/install/hardware/nvidia.sh
+++ b/install/hardware/nvidia.sh
@@ -17,6 +17,17 @@ if lspci | grep -qi 'nvidia'; then
 
   omarchy-pkg-add "${PACKAGES[@]}"
 
+  # gpu-screen-recorder (base package set) ships a modprobe drop-in setting
+  # NVreg_PreserveVideoMemoryAllocations=1. The 580xx driver has no kernel
+  # suspend notifier support, so with that option it depends on these services
+  # to save and restore VRAM around sleep; without them resume returns to
+  # corrupted GPU state. The open modules need none of this: they handle it
+  # automatically via NVreg_UseKernelSuspendNotifiers=1 from nvidia-utils'
+  # own nvidia-sleep.conf.
+  if omarchy-hw-nvidia-without-gsp; then
+    systemctl enable nvidia-suspend.service nvidia-hibernate.service nvidia-resume.service
+  fi
+
   # Per-session Hyprland NVIDIA env vars are handled by default/hypr/nvidia.lua.
 
   # Configure modprobe for early KMS

--- a/migrations/1787620313.sh
+++ b/migrations/1787620313.sh
@@ -12,6 +12,10 @@ if omarchy-pkg-missing nvidia-580xx-utils; then
   exit 0
 fi
 
-if ! systemctl is-enabled --quiet nvidia-suspend.service; then
+# Check each unit: is-enabled with multiple units succeeds when at least one
+# is enabled, which would let a partially applied enable slip through.
+if ! systemctl is-enabled --quiet nvidia-suspend.service ||
+  ! systemctl is-enabled --quiet nvidia-hibernate.service ||
+  ! systemctl is-enabled --quiet nvidia-resume.service; then
   sudo systemctl enable nvidia-suspend.service nvidia-hibernate.service nvidia-resume.service
 fi

--- a/migrations/1787620313.sh
+++ b/migrations/1787620313.sh
@@ -1,0 +1,17 @@
+echo "Enable the NVIDIA suspend services on 580xx installs so VRAM survives sleep"
+
+# gpu-screen-recorder ships NVreg_PreserveVideoMemoryAllocations=1, which makes
+# the NVIDIA driver depend on nvidia-suspend/hibernate/resume to save and
+# restore VRAM around sleep. The 580xx legacy driver has no kernel suspend
+# notifier support (the open modules handle this automatically), so those
+# installs slept without the save and resumed to corrupted GPU state. See
+# basecamp/omarchy#8126. Machine-wide repair: no-ops when another user
+# already applied it.
+
+if omarchy-pkg-missing nvidia-580xx-utils; then
+  exit 0
+fi
+
+if ! systemctl is-enabled --quiet nvidia-suspend.service; then
+  sudo systemctl enable nvidia-suspend.service nvidia-hibernate.service nvidia-resume.service
+fi


### PR DESCRIPTION
Addresses #8126 (no auto-close: the fix needs verification on 580xx hardware, which I don't have).

### Mechanism

Omarchy's base package set includes gpu-screen-recorder, whose packaging ships `/usr/lib/modprobe.d/gsr-nvidia.conf` with `NVreg_PreserveVideoMemoryAllocations=1`. Under that option the driver stops using its internal video memory save/restore and expects suspend/resume to be driven through `/proc/driver/nvidia/suspend` by `nvidia-suspend.service` / `nvidia-hibernate.service` / `nvidia-resume.service`.

The open kernel modules escape this: nvidia-utils ships `nvidia-sleep.conf` with `NVreg_UseKernelSuspendNotifiers=1`, and per the 610.57.04 README video memory preservation "is handled automatically" there — the services are needed only "for the proprietary driver or if kernel suspend notifiers are disabled". The 580xx legacy branch has no notifier support (the parameter is absent from the 580.178.04 README), so on the `omarchy-hw-nvidia-without-gsp` path every suspend sleeps without the save and resume returns to corrupted GPU state.

### Change

- `install/hardware/nvidia.sh`: enable the three services when the 580xx driver is selected. Enable-only, consistent with `install/config/enable-services.sh` (installs are followed by reboot).
- `migrations/1787620313.sh`: same repair for existing installs. Gated on `omarchy-pkg-missing nvidia-580xx-utils`, and skips the sudo prompt when a previous user's run already enabled the services. No initramfs work needed: the modprobe options involved are already in place, only the units change state.

### Verification

- nvidia-580xx-utils 580.178.04-1.1 ships all three units — confirmed against the omarchy pacman repo's file database (`omarchy.files`), so `systemctl enable` has targets on that path.
- Driver requirement confirmed from NVIDIA's 580.178.04 and 610.57.04 READMEs (power management chapter), quoted above.
- `bash -n` on both files; migration is 0644, no shebang, echo first line, idempotent.
- `./test/all`: `test/cli` passes; `test/shell` has the same 4 failing files (`config-test`, `runtime-smoke-test`, `snapper-test`, `unowned-system-paths-test`) on a clean `upstream/quattro` tree on this machine, so they're environmental, not from this change.
- Not verified: an actual suspend/resume cycle on a pre-Turing card. The defect itself was established from a machine that turned out to be on the open-module path (see the issue's correction history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
