### PR TITLE
Fix empty array shell IPC transport

### DIFF
--- a/bin/omarchy-shell
+++ b/bin/omarchy-shell
@@ -55,8 +55,18 @@ fi
 # The -- keeps function names that shadow qs subcommands (e.g. show) as
 # positionals. qs reports connection failures with a nonzero exit, but IPC-level
 # failures (unknown target/function, bad arguments) go to stdout with exit 0.
+# CLI11 drops a standalone [] as an empty variadic argument list. Its [[]]
+# escape transports the intended empty JSON array as one positional argument.
+ipc_args=()
+for arg in "$@"; do
+  if [[ $arg == "[]" ]]; then
+    arg="[[]]"
+  fi
+  ipc_args+=("$arg")
+done
+
 ipc_timeout=${OMARCHY_SHELL_IPC_TIMEOUT:-2s}
-output=$(timeout --kill-after=1s "$ipc_timeout" qs ipc -n -p "$OMARCHY_PATH/shell" call -- "$@" 2>/dev/null)
+output=$(timeout --kill-after=1s "$ipc_timeout" qs ipc -n -p "$OMARCHY_PATH/shell" call -- "${ipc_args[@]}" 2>/dev/null)
 ipc_status=$?
 
 if (( ipc_status == 124 || ipc_status == 137 )); then

--- a/test/shell.d/restart-shell-test.sh
+++ b/test/shell.d/restart-shell-test.sh
@@ -24,6 +24,7 @@ cat >"$wrapper_bin/qs" <<'SH'
 #!/bin/bash
 
 [[ -n ${OMARCHY_TEST_QS_ARGS:-} ]] && printf '%s\n' "$*" >"$OMARCHY_TEST_QS_ARGS"
+[[ -n ${OMARCHY_TEST_QS_ARGV:-} ]] && printf '%s\n' "$@" >"$OMARCHY_TEST_QS_ARGV"
 
 if [[ ${OMARCHY_TEST_QS_HANG:-0} == 1 ]]; then
   sleep 5
@@ -66,6 +67,21 @@ OMARCHY_TEST_QS_ARGS="$wrapper_args" \
 
 grep -F -- 'ipc -n -p' "$wrapper_args" >/dev/null || fail "shell IPC targets the newest live Quickshell instance"
 pass "shell IPC targets the newest live Quickshell instance"
+
+wrapper_argv="$test_tmp/wrapper-argv"
+PATH="$wrapper_bin:$PATH" \
+OMARCHY_PATH="$wrapper_root" \
+OMARCHY_TEST_QS_ARGV="$wrapper_argv" \
+  "$ROOT/bin/omarchy-shell" shell setBarWidget omarchy.tray hidden '[]' '{}' >/dev/null
+
+mapfile -t qs_argv <"$wrapper_argv"
+expected_qs_argv=(ipc -n -p "$wrapper_root/shell" call -- shell setBarWidget omarchy.tray hidden "[[]]" "{}")
+(( ${#qs_argv[@]} == ${#expected_qs_argv[@]} )) || fail "shell IPC records the full Quickshell argument vector"
+for index in "${!expected_qs_argv[@]}"; do
+  [[ ${qs_argv[$index]} == "${expected_qs_argv[$index]}" ]] ||
+    fail "shell IPC preserves the exact Quickshell argument vector" "argument $index: ${qs_argv[$index]}"
+done
+pass "shell IPC transports empty arrays without dropping an argument"
 
 restart_root="$test_tmp/restart-root"
 restart_bin="$restart_root/bin"


### PR DESCRIPTION
## Summary

- transport a standalone empty JSON array through Quickshell IPC using CLI11's `[[]]` escape
- keep all other IPC arguments unchanged
- cover the complete Quickshell argument vector with a regression test

Closes #7120

## Reproduction

On Quickshell `0.3.0.r20.g28771c7-2`, a literal `[]` is consumed by CLI11 as an empty variadic argument list before the IPC function receives it:

```console
$ qs ipc -n -p "$OMARCHY_PATH/shell" call -- shell setBarWidget __omarchy_missing_widget__ hidden '[]' '{}'
Too few arguments provided (4 required but 3 were provided.)
```

Using CLI11's `[[]]` transport escape preserves the intended empty-array argument and reaches the handler. The fix performs that exact rewrite in `omarchy-shell`, so documented commands such as `omarchy bar set omarchy.tray hidden '[]' --json` work without changing callers.

The live verification used a deliberately nonexistent widget, so it exercised the real running shell without changing bar state:

```console
$ bin/omarchy-shell shell setBarWidget __omarchy_missing_widget__ hidden '[]' '{}'
could not find widget __omarchy_missing_widget__
```

## Tests

- `bash -n bin/omarchy-shell test/shell.d/restart-shell-test.sh`
- `bash test/shell.d/restart-shell-test.sh`
- `./test/all` — all 198 test files passed
- `./bin/omarchy commands --check` — all 434 command metadata checks passed
- `git diff --check`
