### PR TITLE
Stop NordVPN installation after setup failure

### DIFF
--- a/bin/omarchy-install-service-nordvpn
+++ b/bin/omarchy-install-service-nordvpn
@@ -3,6 +3,8 @@
 # omarchy:summary=Install the NordVPN service with optional GUI.
 # omarchy:requires-sudo=true
 
+set -e
+
 echo "Installing NordVPN..."
 omarchy-pkg-add nordvpn-bin
 

--- a/test/shell.d/nordvpn-install-test.sh
+++ b/test/shell.d/nordvpn-install-test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+test_bin="$test_tmp/bin"
+calls="$test_tmp/calls"
+mkdir -p "$test_bin"
+trap 'rm -rf "$test_tmp"' EXIT
+
+cat >"$test_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'package:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+if [[ ${OMARCHY_TEST_FAIL_STEP:-} == "interrupt" ]]; then
+  exit 130
+fi
+[[ ${OMARCHY_TEST_FAIL_STEP:-} != "package" ]]
+SH
+
+cat >"$test_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+case ${1:-} in
+  systemctl) [[ ${OMARCHY_TEST_FAIL_STEP:-} != "service" ]] ;;
+  usermod) [[ ${OMARCHY_TEST_FAIL_STEP:-} != "group" ]] ;;
+  *) exit 0 ;;
+esac
+SH
+
+cat >"$test_bin/gum" <<'SH'
+#!/bin/bash
+printf 'gum:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+exit 0
+SH
+
+cat >"$test_bin/omarchy-system-reboot" <<'SH'
+#!/bin/bash
+printf 'reboot\n' >>"$OMARCHY_TEST_CALLS"
+SH
+
+chmod +x "$test_bin"/*
+
+run_installer() {
+  local fail_step="$1"
+
+  : >"$calls"
+  set +e
+  output=$(PATH="$test_bin:$PATH" \
+    OMARCHY_TEST_CALLS="$calls" \
+    OMARCHY_TEST_FAIL_STEP="$fail_step" \
+    USER="omarchy-test" \
+    "$ROOT/bin/omarchy-install-service-nordvpn" 2>&1)
+  status=$?
+  set -e
+}
+
+assert_failed_step() {
+  local fail_step="$1"
+  local expected_calls="$2"
+  local expected_status="${3:-}"
+
+  run_installer "$fail_step"
+
+  (( status != 0 )) || fail "NordVPN installer fails when the $fail_step step fails"
+  if [[ -n $expected_status ]]; then
+    (( status == expected_status )) || fail "NordVPN installer preserves the $fail_step exit status" "$status"
+  fi
+  [[ $(<"$calls") == "$expected_calls" ]] ||
+    fail "NordVPN installer stops after the $fail_step step fails" "$(<"$calls")"
+  [[ $output != *"NordVPN installed!"* ]] ||
+    fail "NordVPN installer does not report success after the $fail_step step fails" "$output"
+  pass "NordVPN installer stops when the $fail_step step fails"
+}
+
+assert_failed_step "package" 'package:nordvpn-bin'
+assert_failed_step "interrupt" 'package:nordvpn-bin' 130
+assert_failed_step "service" $'package:nordvpn-bin\nsudo:systemctl enable --now nordvpnd'
+assert_failed_step "group" $'package:nordvpn-bin\nsudo:systemctl enable --now nordvpnd\nsudo:usermod -aG nordvpn omarchy-test'
+
+run_installer ""
+(( status == 0 )) || fail "NordVPN installer succeeds when every required step succeeds" "$output"
+expected_success_calls=$'package:nordvpn-bin\nsudo:systemctl enable --now nordvpnd\nsudo:usermod -aG nordvpn omarchy-test\ngum:confirm Reboot now to make NordVPN usable?\nreboot'
+[[ $(<"$calls") == "$expected_success_calls" ]] ||
+  fail "NordVPN installer runs every setup step before the optional reboot" "$(<"$calls")"
+[[ $output == *"NordVPN installed!"* ]] || fail "NordVPN installer reports a successful installation" "$output"
+pass "NordVPN installer reports success after every required step succeeds"


### PR DESCRIPTION
## Summary

- stop the NordVPN installer immediately when a required setup command fails or is interrupted
- prevent later privileged steps, the success message, and reboot prompt after an incomplete installation
- cover package, exit-130 interruption, service, group, and success paths with hermetic command stubs

Closes #7852

## Reproduction

The installer previously had no fail-fast mode. If `omarchy-pkg-add`, `sudo systemctl`, or `sudo usermod` returned nonzero, execution continued and could still print:

```text
NordVPN installed! After reboot, run 'nordvpn login' to authenticate.
```

The regression test reproduces this without installing NordVPN or invoking privileges. Before the fix, a stubbed package failure still reached every later step, the success message, reboot prompt, and reboot command, and the script exited successfully.

The installer now uses the same `set -e` behavior as comparable Omarchy installers. A required command failure stops the script at that command, and an interruption status of 130 is preserved.

## Tests

- `bash -n bin/omarchy-install-service-nordvpn test/shell.d/nordvpn-install-test.sh`
- `bash test/shell.d/nordvpn-install-test.sh`
- `./test/all` — all 199 test files passed
- `./bin/omarchy commands --check` — all 434 command metadata checks passed
- `git diff --cached --check`
