### PR TITLE
Prefer apple-panel-bl over the Asahi DSI backlight decoy

### DIFF
--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -11,7 +11,9 @@ backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
 device="$(ls -1 "$backlight_path" 2>/dev/null | grep -vx appletb_backlight | head -n1)"
 # gmux comes first: apple-gmux only registers when the kernel has already picked it, and on
 # dual-GPU Macs the GPU's own PWM stops driving the panel once that GPU suspends.
-for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
+# apple-panel-bl is Asahi's real panel backlight; without it here the alphabetical fallback
+# picks a DSI decoy (e.g. 228600000.dsi.0) that accepts writes with no visible effect.
+for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/apple-panel-bl "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
   if [[ -e $candidate ]]; then
     device="${candidate##*/}"
     break

--- a/test/shell.d/hw-display-test.sh
+++ b/test/shell.d/hw-display-test.sh
@@ -57,6 +57,26 @@ device=$(hw_display)
 [[ $device == "gmux_backlight" ]] || fail "gmux outranks the GPU backlights on dual-GPU Macs" "actual: $device"
 pass "gmux outranks the GPU backlights on dual-GPU Macs"
 
+write_backlights 228600000.dsi.0 apple-panel-bl
+device=$(hw_display)
+[[ $device == "apple-panel-bl" ]] || fail "apple-panel-bl beats the alphabetical DSI fallback" "actual: $device"
+pass "apple-panel-bl beats the alphabetical DSI fallback"
+
+write_backlights apple-panel-bl
+device=$(hw_display)
+[[ $device == "apple-panel-bl" ]] || fail "apple-panel-bl is used when it is the only backlight" "actual: $device"
+pass "apple-panel-bl is used when it is the only backlight"
+
+write_backlights apple-panel-bl gmux_backlight
+device=$(hw_display)
+[[ $device == "gmux_backlight" ]] || fail "gmux outranks apple-panel-bl on T2 Macs" "actual: $device"
+pass "gmux outranks apple-panel-bl on T2 Macs"
+
+write_backlights 228600000.dsi.0 appletb_backlight
+device=$(hw_display)
+[[ $device == "228600000.dsi.0" ]] || fail "the Touch Bar is skipped even when the fallback is a DSI backlight" "actual: $device"
+pass "the Touch Bar is skipped even when the fallback is a DSI backlight"
+
 write_backlights
 if hw_display >/dev/null 2>&1; then
   fail "no backlight device reports failure"


### PR DESCRIPTION
On Apple Silicon, `/sys/class/backlight` lists both `apple-panel-bl` (the real panel) and a numeric DSI node that sorts first alphabetically and accepts writes with no visible effect. `omarchy-hw-display` had no `apple-panel-bl` in its candidate list, so it fell through to that decoy and brightness slider/keys no-op'd.

Put `apple-panel-bl` after gmux (T2 dual-GPU Macs still want gmux first) and before GPU PWM devices. Keep excluding `appletb_backlight` (Touch Bar). Existing gmux/amdgpu/intel/acpi order is unchanged.

`hw-display-test.sh` is at 12 assertions: Asahi DSI decoy loses to `apple-panel-bl`, gmux still wins on T2, Touch Bar stays unused.

Fixes #8125
