### PR TITLE
Force software cursors on vmwgfx to fix invisible mouse pointer

### DIFF
--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -9,6 +9,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/fix-vmware-cursor.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"
 run_logged "$OMARCHY_INSTALL/user/mise.sh"

--- a/install/user/hardware/fix-vmware-cursor.sh
+++ b/install/user/hardware/fix-vmware-cursor.sh
@@ -7,7 +7,9 @@ if omarchy-cmd-present lspci &&
   LC_ALL=C lspci -k | grep -qi 'Kernel driver in use: vmwgfx'; then
   looknfeel="$HOME/.config/hypr/looknfeel.lua"
 
-  if [[ -f $looknfeel ]] && ! grep -q 'no_hardware_cursors' "$looknfeel"; then
+  # A comment mentioning the setting is not an assignment — vmwgfx guests
+  # still have an invisible pointer until a real no_hardware_cursors = line exists.
+  if [[ -f $looknfeel ]] && ! grep -Eq '^[[:space:]]*no_hardware_cursors[[:space:]]*=' "$looknfeel"; then
     echo "Detected vmwgfx driver. Forcing software cursors so the mouse pointer stays visible."
 
     cat >>"$looknfeel" <<'EOF'

--- a/install/user/hardware/fix-vmware-cursor.sh
+++ b/install/user/hardware/fix-vmware-cursor.sh
@@ -1,0 +1,24 @@
+# Disable hardware cursors when the vmwgfx driver is in use.
+#
+# The VMware SVGA II DRM driver (vmwgfx) does not display the hardware cursor
+# plane, leaving the mouse pointer invisible under Hyprland.
+
+if omarchy-cmd-present lspci &&
+  LC_ALL=C lspci -k | grep -qi 'Kernel driver in use: vmwgfx'; then
+  looknfeel="$HOME/.config/hypr/looknfeel.lua"
+
+  if [[ -f $looknfeel ]] && ! grep -q 'no_hardware_cursors' "$looknfeel"; then
+    echo "Detected vmwgfx driver. Forcing software cursors so the mouse pointer stays visible."
+
+    cat >>"$looknfeel" <<'EOF'
+
+-- VMware SVGA II (vmwgfx) does not display the hardware cursor plane,
+-- leaving the pointer invisible. Render it in software.
+hl.config({
+  cursor = {
+    no_hardware_cursors = true,
+  },
+})
+EOF
+  fi
+fi

--- a/test/shell.d/vmware-cursor-test.sh
+++ b/test/shell.d/vmware-cursor-test.sh
@@ -43,3 +43,9 @@ if grep -q 'no_hardware_cursors' "$looknfeel"; then
   fail "vmware cursor setup ignores other video drivers"
 fi
 pass "vmware cursor setup ignores other video drivers"
+
+printf '%s\n' '-- User look and feel' '-- no_hardware_cursors is mentioned in a comment' >"$looknfeel"
+run_fix >/dev/null
+grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null ||
+  fail "a comment mentioning the setting still gets a real assignment"
+pass "vmware cursor setup ignores a comment mentioning the setting"

--- a/test/shell.d/vmware-cursor-test.sh
+++ b/test/shell.d/vmware-cursor-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+all="$ROOT/install/user/all.sh"
+grep -q 'run_logged .*user/hardware/fix-vmware-cursor.sh' "$all" ||
+  fail "the vmware cursor quirk runs during user hardware setup"
+pass "the vmware cursor quirk runs during user hardware setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mkdir -p "$test_tmp/bin" "$test_tmp/home/.config/hypr"
+cat >"$test_tmp/bin/lspci" <<'SH'
+#!/bin/bash
+printf '%s\n' "Kernel driver in use: ${TEST_VIDEO_DRIVER:-vmwgfx}"
+SH
+chmod +x "$test_tmp/bin/lspci"
+
+looknfeel="$test_tmp/home/.config/hypr/looknfeel.lua"
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+
+run_fix() {
+  HOME="$test_tmp/home" \
+    PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    TEST_VIDEO_DRIVER="${1:-vmwgfx}" \
+    bash -euo pipefail -c 'source "$ROOT/install/user/hardware/fix-vmware-cursor.sh"'
+}
+
+run_fix >/dev/null
+grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null
+pass "vmware hardware setup enables software cursors"
+
+run_fix >/dev/null
+(( $(grep -c 'no_hardware_cursors = true' "$looknfeel") == 1 )) || fail "vmware cursor setup is idempotent"
+pass "vmware cursor setup is idempotent"
+
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+run_fix i915 >/dev/null
+if grep -q 'no_hardware_cursors' "$looknfeel"; then
+  fail "vmware cursor setup ignores other video drivers"
+fi
+pass "vmware cursor setup ignores other video drivers"


### PR DESCRIPTION
The VMware SVGA II DRM driver (`vmwgfx`) cannot commit Hyprland's hardware cursor plane, so the pointer is invisible after login. User hardware setup already does this for nouveau; do the same when `lspci -k` reports `Kernel driver in use: vmwgfx`.

If `~/.config/hypr/looknfeel.lua` exists and does not already set `no_hardware_cursors`, append that config. No-op on any other driver, and idempotent if the setting is already there.

`vmware-cursor-test.sh` covers the orchestrator source, the vmwgfx path, idempotence, and ignoring other drivers. No VMware guest here, so the pointer itself was not checked on hardware.

Fixes #7918
