### PR TITLE
Symlink mise tools so argv[0] survives exec -a

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Install a small mise-backed wrapper for a given tool.
+# omarchy:summary=Install a mise-backed symlink for a given tool.
 # omarchy:args=<package> [command-name [bin-name]]
 
 if [[ -z $1 ]]; then
@@ -13,7 +13,7 @@ command=${2:-$1}
 bin=${3:-$command}
 
 # The command name becomes a file name under ~/.local/bin, so a slash in it
-# writes the wrapper somewhere else and the rm below deletes somewhere else. A
+# writes the link somewhere else and the rm below deletes somewhere else. A
 # leading dot hides it or walks up, and a leading dash makes a name that reads
 # as an option to whatever picks it up. Checked before anything is removed or
 # written, and kept to those shapes so package names like npm:playwright still
@@ -27,33 +27,23 @@ esac
 
 mkdir -p "$HOME/.local/bin"
 
-# The heredoc below is unquoted, so whatever these hold is written into the
-# wrapper as shell source. Quote them the way omarchy-install-and-launch does, so
-# a package name carrying shell characters stays one argument instead of running.
-printf -v package_arg '%q' "$package"
-printf -v bin_arg '%q' "$bin"
-
-# Keep values that are inert inside double quotes in the form existing migrations
-# recognize, including mise backend options that %q would unnecessarily escape.
-case "$package" in
-  *'$'* | *'`'* | *'"'* | *'\'* | *'!'* | *[[:cntrl:]]*) ;;
-  *) package_arg="\"$package\"" ;;
-esac
-case "$bin" in
-  *'$'* | *'`'* | *'"'* | *'\'* | *'!'* | *[[:cntrl:]]*) ;;
-  *) bin_arg="\"$bin\"" ;;
-esac
-
+# Shell wrappers re-exec through `mise x … -- $bin`, so argv[0] becomes $bin
+# instead of whatever name the caller used (Claude Code's built-in grep calls
+# its binary as ugrep via exec -a). Symlink the real binary so the kernel
+# keeps the intended invocation name.
+#
 # These tools install and upgrade on first run, so mise's release cooldown would
 # hold a new version back for days after it ships. Exported rather than set on
-# the install line alone, so resolving the version to execute agrees with the
-# one just installed.
-rm -f "$HOME/.local/bin/$command"
-cat >"$HOME/.local/bin/$command" <<EOF
-#!/bin/bash
+# the install line alone, so resolving the version to link agrees with the one
+# just installed.
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g --quiet $package_arg || exit 1
-exec mise x $package_arg -- $bin_arg "\$@"
-EOF
+mise use -g --quiet "$package" || exit 1
 
-chmod +x "$HOME/.local/bin/$command"
+install_root=$(mise where "$package") || exit 1
+target="$install_root/$bin"
+if [[ ! -x $target ]]; then
+  exit 1
+fi
+
+rm -f "$HOME/.local/bin/$command"
+ln -sf "$target" "$HOME/.local/bin/$command"

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -17,15 +17,27 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
        ~/.local/bin/gh ~/.local/bin/opencode ~/.local/bin/playwright ~/.local/bin/playwright-cli ~/.local/bin/pi \
        ~/.local/bin/omp ~/.local/bin/ori ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk
 
-  # Cursor's own installer links ~/.local/bin/cursor-agent as well, so only
-  # the mise wrapper omarchy-mise-install wrote is a preinstall.
-  if [[ -f ~/.local/bin/cursor-agent && ! -L ~/.local/bin/cursor-agent ]] &&
+  # Cursor's own installer also links ~/.local/bin/cursor-agent, so only drop
+  # Omarchy's install: the old mise wrapper script, or a symlink whose target is
+  # an absolute path (mise where) rather than Cursor's same-directory link.
+  if [[ -L ~/.local/bin/cursor-agent ]]; then
+    cursor_target=$(readlink ~/.local/bin/cursor-agent)
+    if [[ $cursor_target == /* ]]; then
+      rm -f ~/.local/bin/cursor-agent
+    fi
+  elif [[ -f ~/.local/bin/cursor-agent ]] &&
     grep -Eq '^mise use -g .*"cursor-agent"' ~/.local/bin/cursor-agent; then
     rm -f ~/.local/bin/cursor-agent
   fi
 
-  # Preserve a user-managed Muse launcher at the same path.
-  if [[ -f ~/.local/bin/muse && ! -L ~/.local/bin/muse ]] &&
+  # Preserve a user-managed Muse launcher. Omarchy's mise install is either the
+  # old wrapper script or an absolute symlink from mise where.
+  if [[ -L ~/.local/bin/muse ]]; then
+    muse_target=$(readlink ~/.local/bin/muse)
+    if [[ $muse_target == /* ]]; then
+      rm -f ~/.local/bin/muse
+    fi
+  elif [[ -f ~/.local/bin/muse ]] &&
     grep -Eq '^mise use -g .*"http:muse\[' ~/.local/bin/muse; then
     rm -f ~/.local/bin/muse
   fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -19,8 +19,16 @@ mise_history="$test_tmp/mise-history"
 stub_log="$test_tmp/stubs"
 terminal_log="$test_tmp/terminal"
 menu_log="$test_tmp/menu"
+mise_install_root="$test_tmp/mise-installs"
 muse_login_log="$test_tmp/muse-login"
-mkdir -p "$mock_bin" "$test_home"
+mkdir -p "$mock_bin" "$test_home" "$mise_install_root"
+
+# Real omarchy-mise-install resolves `$install_root/$command`, so each command
+# the installer is asked for needs an executable there.
+for name in grok omp crush ori gemini claude agy opencode pi copilot codex cursor-agent muse; do
+  printf '#!/bin/bash\nexit 0\n' >"$mise_install_root/$name"
+  chmod +x "$mise_install_root/$name"
+done
 
 cat >"$mock_bin/omarchy-notification-send" <<'SH'
 #!/bin/bash
@@ -58,8 +66,12 @@ printf '%s\0' "$@" >"$OMARCHY_TEST_MISE_LOG"
 printf '%s\n' "$*" >>"$OMARCHY_TEST_MISE_HISTORY"
 
 if [[ $1 == "where" ]]; then
-  [[ ${OMARCHY_TEST_AGENT_INSTALLED:-false} == "true" ]]
-  exit
+  if [[ ${OMARCHY_TEST_AGENT_INSTALLED:-false} == "true" ]]; then
+    printf '%s
+' "$OMARCHY_TEST_MISE_INSTALL_ROOT"
+    exit 0
+  fi
+  exit 1
 fi
 
 [[ ${OMARCHY_TEST_MISE_FAIL:-false} != "true" ]]
@@ -105,6 +117,7 @@ export OMARCHY_TEST_AGENT_LAUNCH_LOG="$launch_log"
 export OMARCHY_TEST_AGENT_INLINE_LOG="$inline_log"
 export OMARCHY_TEST_MISE_LOG="$mise_log"
 export OMARCHY_TEST_MISE_HISTORY="$mise_history"
+export OMARCHY_TEST_MISE_INSTALL_ROOT="$mise_install_root"
 export OMARCHY_TEST_STUB_LOG="$stub_log"
 export OMARCHY_TEST_AGENT_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
@@ -124,11 +137,14 @@ assert_lazy_stub() {
   local command=$2
 
   : >"$mise_history"
-  "$ROOT/bin/omarchy-mise-install" "$package" "$command"
-  "$test_home/.local/bin/$command" --version
-  mapfile -t mise_calls <"$mise_history"
+  OMARCHY_TEST_AGENT_INSTALLED=true "$ROOT/bin/omarchy-mise-install" "$package" "$command"
 
-  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+  [[ -L $test_home/.local/bin/$command ]] || fail "$command is a symlink, not a wrapper"
+  [[ $(readlink "$test_home/.local/bin/$command") == "$mise_install_root/$command" ]] ||
+    fail "$command points at the mise binary"
+
+  mapfile -t mise_calls <"$mise_history"
+  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "where $package" ]] ||
     fail "$command lazy stub preserves its mise package"
 }
 
@@ -199,7 +215,7 @@ grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "agent migration create
 : >"$stub_log"
 mkdir -p "$(dirname "$agent_file")"
 printf '%s\n' gemini >"$agent_file"
-"$ROOT/bin/omarchy-mise-install" gemini
+OMARCHY_TEST_AGENT_INSTALLED=true "$ROOT/bin/omarchy-mise-install" gemini
 export OMARCHY_TEST_MISSING_COMMAND=agy
 source "$ROOT/migrations/1786719479.sh" >/dev/null
 unset OMARCHY_TEST_MISSING_COMMAND
@@ -267,7 +283,9 @@ pass "Antigravity migration preserves an existing Antigravity install"
 
 mkdir -p "$test_home/.local/state/omarchy"
 touch "$test_home/.local/state/omarchy/preinstalls-removed"
-"$ROOT/bin/omarchy-mise-install" oh-my-pi omp
+mkdir -p "$test_home/.local/bin"
+printf '#!/bin/bash\nmise use -g --quiet "oh-my-pi" || exit 1\n' >"$test_home/.local/bin/omp"
+chmod +x "$test_home/.local/bin/omp"
 : >"$stub_log"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
 source "$ROOT/migrations/1785846769.sh" >/dev/null
@@ -297,7 +315,7 @@ rm "$test_home/.local/state/omarchy/preinstalls-removed"
 rm -f "$agent_file"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"
 
-"$ROOT/bin/omarchy-mise-install" "$muse_package" muse
+OMARCHY_TEST_AGENT_INSTALLED=true "$ROOT/bin/omarchy-mise-install" "$muse_package" muse
 touch "$test_home/.local/bin/agy" "$test_home/.local/bin/ori"
 omarchy-remove-preinstalls >/dev/null
 for command in agy omp ori grok crush cursor-agent muse; do

--- a/test/shell.d/mise-install-test.sh
+++ b/test/shell.d/mise-install-test.sh
@@ -9,60 +9,116 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 home="$tmpdir/home"
 stub_bin="$tmpdir/bin"
-mkdir -p "$home" "$stub_bin"
+installs="$tmpdir/mise-installs"
+mise_log="$tmpdir/mise-log"
+argv0_bin="$tmpdir/argv0printer"
+argv0_is_bash=0
+mkdir -p "$home" "$stub_bin" "$installs"
 
-# Stands in for the real mise so a generated wrapper can be run and asked what
-# arguments it passed on.
+# A native binary is the only way to observe argv[0]: a shebang script loses
+# the forged name before line 1, which is the wrapper bug this installer fixes.
+if command -v cc >/dev/null; then
+  cc -o "$argv0_bin" -x c - <<'EOF'
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  if (argc > 0) {
+    puts(argv[0]);
+  }
+  return 0;
+}
+EOF
+else
+  ln -sf "$(command -v bash)" "$argv0_bin"
+  argv0_is_bash=1
+fi
+
 cat >"$stub_bin/mise" <<'SH'
 #!/bin/bash
+printf '%s\n' "$*" >>"$MISE_LOG"
 
-printf 'mise' >>"$OMARCHY_MISE_TEST_LOG"
-for arg in "$@"; do
-  printf '\t%s' "$arg" >>"$OMARCHY_MISE_TEST_LOG"
-done
-printf '\n' >>"$OMARCHY_MISE_TEST_LOG"
+if [[ $1 == "use" ]]; then
+  if (( ${MISE_USE_FAIL:-0} )); then
+    exit 1
+  fi
+  exit 0
+fi
+
+if [[ $1 == "where" ]]; then
+  if (( ${MISE_WHERE_FAIL:-0} )); then
+    exit 1
+  fi
+  printf '%s\n' "$MISE_WHERE"
+  exit 0
+fi
+
+exit 0
 SH
 chmod +x "$stub_bin/mise"
 
-install_wrapper() {
-  HOME="$home" "$ROOT/bin/omarchy-mise-install" "$@"
+seed_tool() {
+  local package=$1
+  local bin=$2
+  local root="$installs/$package"
+
+  mkdir -p "$root"
+  cp "$argv0_bin" "$root/$bin"
+  chmod +x "$root/$bin"
 }
 
-# The ordinary case still works, and every call site in install/user/mise.sh
-# passes names of this shape.
-install_wrapper npm:playwright playwright >/dev/null
-[[ -x $home/.local/bin/playwright ]] ||
-  fail "a normal install writes an executable wrapper"
+invoke_argv0() {
+  local dest=$1
+  local name=$2
 
-log="$tmpdir/normal.log"
-: >"$log"
-OMARCHY_MISE_TEST_LOG="$log" PATH="$stub_bin:$PATH" "$home/.local/bin/playwright" >/dev/null
-grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:playwright' "$log" ||
-  fail "the wrapper asks mise for the package it was given" "$(cat "$log")"
+  if (( argv0_is_bash )); then
+    bash -c 'exec -a "$1" "$2" -c "printf %s\\n \"\$BASH_ARGV0\""' _ "$name" "$dest"
+  else
+    bash -c 'exec -a "$1" "$2"' _ "$name" "$dest"
+  fi
+}
 
-pass "a normal install writes a wrapper that names its package"
+run_install() {
+  HOME="$home" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    MISE_LOG="$mise_log" MISE_WHERE="$MISE_WHERE" \
+    MISE_USE_FAIL="${MISE_USE_FAIL:-0}" MISE_WHERE_FAIL="${MISE_WHERE_FAIL:-0}" \
+    "$ROOT/bin/omarchy-mise-install" "$@"
+}
 
-# A package name is data. Quoted with %q it reaches mise as one argument
-# instead of being read as shell source when the wrapper runs.
-install_wrapper 'npm:pkg$(touch '"$tmpdir"'/PWNED)end' hostile >/dev/null
+: >"$mise_log"
+seed_tool npm:playwright playwright
+MISE_WHERE="$installs/npm:playwright"
+run_install npm:playwright playwright
 
-log="$tmpdir/hostile.log"
-: >"$log"
-OMARCHY_MISE_TEST_LOG="$log" PATH="$stub_bin:$PATH" "$home/.local/bin/hostile" >/dev/null
+dest="$home/.local/bin/playwright"
+[[ -L $dest ]] || fail "a normal install writes a symlink, not a script"
+[[ $(readlink "$dest") == "$installs/npm:playwright/playwright" ]] ||
+  fail "symlink points at the real binary"
+got=$(invoke_argv0 "$dest" ugrep)
+[[ $got == "ugrep" ]] || fail "symlink preserves argv[0] via exec -a" "expected ugrep, got: $got"
+grep -qx 'use -g --quiet npm:playwright' "$mise_log" ||
+  fail "installer still calls mise use -g --quiet" "$(cat "$mise_log")"
+grep -qx 'where npm:playwright' "$mise_log" ||
+  fail "installer resolves the binary with mise where" "$(cat "$mise_log")"
+if awk '$1 == "x" { found = 1 } END { exit found ? 0 : 1 }' "$mise_log"; then
+  fail "installer no longer re-execs through mise x"
+fi
+pass "a normal install writes a symlink that preserves argv[0]"
 
-[[ -e $tmpdir/PWNED ]] &&
-  fail "a package name with shell characters does not run when the wrapper does" \
-    "wrapper: $(cat "$home/.local/bin/hostile")"
-
-grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:pkg$(touch '"$tmpdir"'/PWNED)end' "$log" ||
-  fail "the package reaches mise whole" "$(cat "$log")"
-
+# A package name is mise argv data, never shell source. Confirm it stays one
+# argument and does not expand.
+: >"$mise_log"
+package_hostile='npm:pkg$(touch '"$tmpdir"'/PWNED)end'
+seed_root="$installs/hostile-pkg"
+mkdir -p "$seed_root"
+cp "$argv0_bin" "$seed_root/hostile"
+chmod +x "$seed_root/hostile"
+MISE_WHERE="$seed_root"
+run_install "$package_hostile" hostile
+[[ -e $tmpdir/PWNED ]] && fail "a package name with shell characters does not run at install time"
+grep -qx "use -g --quiet $package_hostile" "$mise_log" ||
+  fail "the package reaches mise whole" "$(cat "$mise_log")"
 pass "a package name with shell characters reaches mise as one argument"
 
-# The command name is a file name under ~/.local/bin. These shapes escape it,
-# hide it, make something that reads as an option, or carry characters that have
-# no business in a file name. Labelled so a newline in the value does not end up
-# inside the test output.
 refused=(
   "a slash" "../escaped"
   "a leading dot" ".hidden"
@@ -75,7 +131,7 @@ for (( i = 0; i < ${#refused[@]}; i += 2 )); do
   label=${refused[i]}
   name=${refused[i + 1]}
 
-  if install_wrapper somepkg "$name" >/dev/null 2>"$tmpdir/err"; then
+  if run_install somepkg "$name" >/dev/null 2>"$tmpdir/err"; then
     fail "a command name with $label is refused"
   fi
   grep -Fq 'is not usable as a command name' "$tmpdir/err" ||
@@ -84,14 +140,76 @@ done
 
 pass "command names that are not plain file names are refused"
 
-# The refusal has to land before the rm, which would otherwise delete the
-# escaped path on its way to failing.
 victim="$tmpdir/victim"
 printf 'keep me\n' >"$victim"
-if install_wrapper somepkg "../../../..$victim" >/dev/null 2>&1; then
+if run_install somepkg "../../../..$victim" >/dev/null 2>&1; then
   fail "an escaping command name is refused"
 fi
 [[ -f $victim ]] ||
   fail "an escaping command name removes nothing outside ~/.local/bin"
 
 pass "an escaping command name removes nothing outside ~/.local/bin"
+
+: >"$mise_log"
+mkdir -p "$installs/missing"
+MISE_WHERE="$installs/missing"
+if run_install missing >/dev/null 2>&1; then
+  fail "missing target exits non-zero"
+fi
+pass "missing target exits non-zero"
+
+: >"$mise_log"
+mkdir -p "$installs/unusable"
+printf '#!/bin/bash\nexit 0\n' >"$installs/unusable/unusable"
+chmod a-x "$installs/unusable/unusable"
+MISE_WHERE="$installs/unusable"
+if run_install unusable >/dev/null 2>&1; then
+  fail "unusable target exits non-zero"
+fi
+pass "unusable target exits non-zero"
+
+: >"$mise_log"
+MISE_WHERE="$seed_root"
+MISE_USE_FAIL=1
+if run_install claude >/dev/null 2>&1; then
+  fail "mise use failure exits non-zero"
+fi
+pass "mise use failure exits non-zero"
+
+: >"$mise_log"
+MISE_USE_FAIL=0
+MISE_WHERE_FAIL=1
+if run_install claude >/dev/null 2>&1; then
+  fail "mise where failure exits non-zero"
+fi
+pass "mise where failure exits non-zero"
+
+# Replacing an old wrapper file with a symlink.
+MISE_WHERE_FAIL=0
+seed_tool claude claude
+mkdir -p "$home/.local/bin"
+rm -f "$home/.local/bin/claude"
+cat >"$home/.local/bin/claude" <<'EOF'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+mise use -g --quiet "claude" || exit 1
+exec mise x "claude" -- "claude" "$@"
+EOF
+chmod +x "$home/.local/bin/claude"
+[[ -L $home/.local/bin/claude ]] && fail "precondition: old wrapper is a regular file"
+
+: >"$mise_log"
+MISE_WHERE="$installs/claude"
+run_install claude
+
+[[ -L $home/.local/bin/claude ]] || fail "installer replaces an old wrapper with a symlink"
+[[ $(readlink "$home/.local/bin/claude") == "$installs/claude/claude" ]] ||
+  fail "replacement symlink points at the real binary"
+got=$(invoke_argv0 "$home/.local/bin/claude" ugrep)
+[[ $got == "ugrep" ]] || fail "replacement symlink preserves argv[0]" "expected ugrep, got: $got"
+pass "installer replaces an old wrapper with a symlink"
+
+if HOME="$home" PATH="$stub_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-mise-install" >/dev/null 2>&1; then
+  fail "missing package argument exits non-zero"
+fi
+pass "missing package argument exits non-zero"

--- a/test/shell.d/mise-wrapper-quiet-migration-test.sh
+++ b/test/shell.d/mise-wrapper-quiet-migration-test.sh
@@ -10,13 +10,66 @@ trap 'rm -rf "$test_dir"' EXIT
 
 home="$test_dir/home"
 bin_dir="$home/.local/bin"
-mkdir -p "$bin_dir"
+stub_bin="$test_dir/bin"
+installs="$test_dir/mise-installs"
+mise_log="$test_dir/mise-log"
+mkdir -p "$bin_dir" "$stub_bin" "$installs"
+
+cat >"$stub_bin/mise" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$MISE_LOG"
+
+if [[ $1 == "where" ]]; then
+  printf '%s\n' "$MISE_INSTALLS/$2"
+  exit 0
+fi
+
+exit 0
+SH
+
+# The migration uses GNU `stat -c%s`. Provide it so the real script can run
+# here, not only on Linux.
+cat >"$stub_bin/stat" <<'SH'
+#!/bin/bash
+if [[ $1 == "-c%s" ]]; then
+  wc -c <"$2" | awk '{ print $1 }'
+  exit 0
+fi
+if [[ $1 == "-c" && $2 == "%s" ]]; then
+  wc -c <"$3" | awk '{ print $1 }'
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+SH
+chmod +x "$stub_bin/mise" "$stub_bin/stat"
+
+seed_tool() {
+  local package=$1
+  local bin=$2
+  local root="$installs/$package"
+
+  mkdir -p "$root"
+  printf '#!/bin/bash\nexit 0\n' >"$root/$bin"
+  chmod +x "$root/$bin"
+}
 
 # The migration calls omarchy-mise-install to rewrite a wrapper, so the real
 # one has to be reachable: this proves the template it writes today, not a
 # copy of it that could drift.
 run_migration() {
-  HOME="$home" PATH="$ROOT/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+  HOME="$home" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    MISE_LOG="$mise_log" MISE_INSTALLS="$installs" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+assert_symlink() {
+  local command=$1 package=$2 bin=$3
+  local dest="$bin_dir/$command"
+  local expected="$installs/$package/$bin"
+
+  [[ -L $dest ]] || fail "$command is a symlink after migration"
+  [[ $(readlink "$dest") == "$expected" ]] ||
+    fail "$command points at $package's $bin"
 }
 
 write_stale_wrapper() {
@@ -63,45 +116,39 @@ exec "other-bin" "$@"
 EOF
 chmod +x "$bin_dir/mise-exec-era" "$bin_dir/bare-exec-era"
 
+seed_tool claude claude
+seed_tool "github:can1357/oh-my-pi" omp
+seed_tool "npm:@kitlangton/ghui" ghui
+seed_tool "github:someone/custom-tool" custom-tool
+seed_tool "npm:some/tool" tool-bin
+seed_tool "aqua:some/other" other-bin
+
+: >"$mise_log"
 run_migration
 
-grep -qF 'mise use -g --quiet "claude" || exit 1' "$bin_dir/claude" ||
-  fail "migration adds --quiet to a stale wrapper"
-pass "migration adds --quiet to a stale wrapper"
+assert_symlink claude claude claude
+grep -qx 'use -g --quiet claude' "$mise_log" ||
+  fail "migration still calls mise use -g --quiet"
+pass "migration replaces a stale wrapper with a symlink"
 
-grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi" || exit 1' "$bin_dir/omp" ||
-  fail "migration keeps a wrapper's package when the command name differs"
-grep -qF 'exec mise x "github:can1357/oh-my-pi" -- "omp" "$@"' "$bin_dir/omp" ||
-  fail "migration keeps a wrapper's bin name when the command name differs"
+assert_symlink omp "github:can1357/oh-my-pi" omp
+assert_symlink ghui "npm:@kitlangton/ghui" ghui
 pass "migration preserves package and bin names"
 
-grep -qF 'exec mise x "npm:@kitlangton/ghui" -- "ghui" "$@"' "$bin_dir/ghui" ||
-  fail "migration preserves a scoped npm package name"
-pass "migration preserves a scoped npm package name"
-
-grep -qF 'mise use -g --quiet "github:someone/custom-tool" || exit 1' "$bin_dir/custom-tool" ||
-  fail "migration rewrites a wrapper on the pre-export template"
-grep -qF 'export MISE_MINIMUM_RELEASE_AGE=0' "$bin_dir/custom-tool" ||
-  fail "migration brings a pre-export wrapper up to the current template"
+assert_symlink custom-tool "github:someone/custom-tool" custom-tool
 pass "migration rewrites wrappers on the pre-export template"
 
-grep -qF 'mise use -g --quiet "npm:some/tool" || exit 1' "$bin_dir/mise-exec-era" ||
-  fail "migration rewrites a wrapper on the mise-exec template"
-grep -qF 'exec mise x "npm:some/tool" -- "tool-bin" "$@"' "$bin_dir/mise-exec-era" ||
-  fail "migration keeps the bin name from a mise-exec wrapper"
-grep -qF 'mise use -g --quiet "aqua:some/other" || exit 1' "$bin_dir/bare-exec-era" ||
-  fail "migration rewrites a wrapper on the bare-exec template"
-grep -qF 'exec mise x "aqua:some/other" -- "other-bin" "$@"' "$bin_dir/bare-exec-era" ||
-  fail "migration keeps the bin name from a bare-exec wrapper"
+assert_symlink mise-exec-era "npm:some/tool" tool-bin
+assert_symlink bare-exec-era "aqua:some/other" other-bin
 pass "migration rewrites every generated form that predates --quiet"
 
-[[ -x $bin_dir/claude ]] || fail "migration leaves the rewritten wrapper executable"
-pass "migration leaves the rewritten wrapper executable"
+[[ -x $bin_dir/claude ]] || fail "migration leaves the rewritten symlink executable"
+pass "migration leaves the rewritten symlink executable"
 
-# Running twice must not touch an already-quiet wrapper.
-before=$(cat "$bin_dir/claude")
+# Running twice must not touch an already-converted symlink.
+before=$(readlink "$bin_dir/claude")
 run_migration
-[[ $(cat "$bin_dir/claude") == "$before" ]] || fail "migration is idempotent"
+[[ $(readlink "$bin_dir/claude") == "$before" ]] || fail "migration is idempotent"
 pass "migration is idempotent"
 
 # Anything the generator did not write is the user's own file.
@@ -149,12 +196,21 @@ run_migration
 [[ $(cat "$bin_dir/customized") == "$customized_before" ]] ||
   fail "migration leaves a generated wrapper a user has added a line to alone"
 [[ -L $bin_dir/linked ]] || fail "migration leaves a symlink alone"
-[[ $(stat -c%s "$bin_dir/uv") -eq 5000000 ]] || fail "migration leaves a native binary alone"
+if command -v gstat >/dev/null; then
+  uv_size=$(gstat -c%s "$bin_dir/uv")
+elif stat -c%s "$bin_dir/uv" >/dev/null 2>&1; then
+  uv_size=$(stat -c%s "$bin_dir/uv")
+else
+  uv_size=$(stat -f%z "$bin_dir/uv")
+fi
+(( uv_size == 5000000 )) || fail "migration leaves a native binary alone"
 pass "migration only rewrites wrappers it recognizes"
 
 # A machine with no ~/.local/bin at all must not fail the run.
 empty_home="$test_dir/empty-home"
 mkdir -p "$empty_home"
-HOME="$empty_home" PATH="$ROOT/bin:$PATH" bash -euo pipefail "$migration" >/dev/null ||
+HOME="$empty_home" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  MISE_LOG="$mise_log" MISE_INSTALLS="$installs" \
+  bash -euo pipefail "$migration" >/dev/null ||
   fail "migration succeeds when ~/.local/bin is missing"
 pass "migration succeeds when ~/.local/bin is missing"


### PR DESCRIPTION
`omarchy-mise-install` used to write a shell wrapper that ended in `exec mise x "$package" -- "$bin" "$@"`. That re-execs the real binary by name, so argv[0] is `$bin` rather than whatever the caller passed.

That breaks multi-call binaries. Claude Code's built-in grep is the same binary invoked as `ugrep` via `exec -a`. Through the wrapper, argv[0] becomes `claude`, `-G` is an unknown flag, and every `grep` in that shell returns empty.

A wrapper cannot preserve a forged argv[0] through a shebang. After `mise use -g --quiet`, resolve the install dir with `mise where` and `ln -sf` the real binary into `~/.local/bin`. The kernel then passes the intended invocation name through.

`mise-install-test.sh` stubs mise and a tiny argv[0] printer: the result is a symlink, `exec -a ugrep` prints `ugrep`, and `mise x` is not used.

Fixes #8120
