### PR TITLE
Keep keyboard backlight level across repeated lock blanks

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -13,7 +13,8 @@ direction="${1:-up}"
 
 # Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
 device=""
-for candidate in /sys/class/leds/*kbd_backlight*; do
+leds_path=${OMARCHY_LEDS_PATH:-/sys/class/leds}
+for candidate in "$leds_path"/*kbd_backlight*; do
   if [[ -e $candidate ]]; then
     device="$(basename "$candidate")"
     break
@@ -26,7 +27,13 @@ if [[ -z $device ]]; then
 fi
 
 if [[ $direction == "off" ]]; then
-  brightnessctl -sd "$device" set 0 >/dev/null
+  # Only save-before-set when the backlight is lit. A second off while already
+  # at 0 would save 0 and make unlock restore darkness (#7650).
+  if (( $(brightnessctl -d "$device" get) > 0 )); then
+    brightnessctl -sd "$device" set 0 >/dev/null
+  else
+    brightnessctl -d "$device" set 0 >/dev/null
+  fi
   exit 0
 elif [[ $direction == "restore" ]]; then
   brightnessctl -rd "$device" >/dev/null

--- a/test/shell.d/brightness-keyboard-test.sh
+++ b/test/shell.d/brightness-keyboard-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mock_bin="$tmp/bin"
+call_log="$tmp/calls"
+mkdir -p "$mock_bin" "$tmp/leds/chromeos::kbd_backlight"
+: >"$call_log"
+
+state="$tmp/brightness"
+saved="$tmp/saved"
+printf '40\n' >"$state"
+printf '40\n' >"$saved"
+
+cat >"$mock_bin/brightnessctl" <<'SH'
+#!/bin/bash
+printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
+
+state="${BRIGHTNESS_STATE:?}"
+saved="${BRIGHTNESS_SAVED:?}"
+
+if [[ $1 == -d && $3 == get ]]; then
+  cat "$state"
+  exit 0
+fi
+
+if [[ $1 == -d && $3 == max ]]; then
+  printf '100\n'
+  exit 0
+fi
+
+if [[ $1 == -sd && $3 == set ]]; then
+  cat "$state" >"$saved"
+  printf '%s\n' "$4" >"$state"
+  exit 0
+fi
+
+if [[ $1 == -d && $3 == set ]]; then
+  printf '%s\n' "$4" >"$state"
+  exit 0
+fi
+
+if [[ $1 == -rd ]]; then
+  cat "$saved" >"$state"
+  exit 0
+fi
+
+exit 1
+SH
+chmod +x "$mock_bin/brightnessctl"
+
+run_kb() {
+  CALL_LOG="$call_log" BRIGHTNESS_STATE="$state" BRIGHTNESS_SAVED="$saved" \
+    OMARCHY_LEDS_PATH="$tmp/leds" PATH="$mock_bin:$ROOT/bin:$PATH" \
+    omarchy-brightness-keyboard "$@"
+}
+
+run_kb off
+[[ $(<"$state") == 0 ]] || fail "first off blanks the backlight"
+[[ $(<"$saved") == 40 ]] || fail "first off saves the prior level"
+pass "first off saves the lit level"
+
+run_kb off
+[[ $(<"$state") == 0 ]] || fail "second off stays blank"
+[[ $(<"$saved") == 40 ]] || fail "second off must not overwrite the saved level with 0"
+pass "second off preserves the saved level"
+
+run_kb restore
+[[ $(<"$state") == 40 ]] || fail "restore returns the original level"
+pass "restore returns the level saved before blanking"
+
+grep -Fq 'brightnessctl -d chromeos::kbd_backlight set 0' "$call_log" ||
+  fail "second off uses brightnessctl without -s"
+pass "second off skips brightnessctl -s"

--- a/test/shell.d/brightness-keyboard-test.sh
+++ b/test/shell.d/brightness-keyboard-test.sh
@@ -13,7 +13,8 @@ mkdir -p "$mock_bin" "$tmp/leds/chromeos::kbd_backlight"
 state="$tmp/brightness"
 saved="$tmp/saved"
 printf '40\n' >"$state"
-printf '40\n' >"$saved"
+# Distinct from the lit level so a no-op off that never saves still fails.
+printf '7\n' >"$saved"
 
 cat >"$mock_bin/brightnessctl" <<'SH'
 #!/bin/bash
@@ -57,6 +58,8 @@ run_kb() {
     OMARCHY_LEDS_PATH="$tmp/leds" PATH="$mock_bin:$ROOT/bin:$PATH" \
     omarchy-brightness-keyboard "$@"
 }
+
+[[ $(<"$saved") == 7 ]] || fail "saved sentinel starts distinct from lit level"
 
 run_kb off
 [[ $(<"$state") == 0 ]] || fail "first off blanks the backlight"


### PR DESCRIPTION
## Summary
- `omarchy-brightness-keyboard off` always used `brightnessctl -s`, so a second blank while already at 0 saved darkness and unlock restored it (#7650).
- Only save-before-set when the current level is above zero; otherwise set 0 without clobbering the saved value.
- Allow `OMARCHY_LEDS_PATH` override for tests.

## Test plan
- [x] `bash test/shell.d/brightness-keyboard-test.sh` — first off saves, second off preserves, restore returns original

Fixes #7650

Made with [Cursor](https://cursor.com)