### PR TITLE
Open the power panel without a battery for profile controls

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -133,9 +133,9 @@ Panel {
   }
 
   function refresh() {
-    if (!batteryPresent) return
-
-    if (!batteryProc.running) batteryProc.running = true
+    // Profiles and system stats belong on desktops too; only skip the battery
+    // collector when UPower has no display device (#7119).
+    if (batteryPresent && !batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
   }
@@ -187,11 +187,6 @@ Panel {
 
   onOpenedChanged: {
     if (opened) {
-      if (!batteryPresent) {
-        close()
-        return
-      }
-
       refresh()
       var idx = profiles.indexOf(activeProfile)
       profileIndex = idx >= 0 ? idx : 0
@@ -199,8 +194,8 @@ Panel {
     }
   }
 
-  onBatteryPresentChanged: if (!batteryPresent) close()
-
+  // Bar slot stays battery-gated; the panel itself must still open from
+  // Super+Ctrl+P on desktops so power profiles remain reachable (#7119).
   visible: batteryPresent
   implicitWidth: batteryPresent ? button.implicitWidth : 0
   implicitHeight: batteryPresent ? button.implicitHeight : 0
@@ -283,7 +278,6 @@ Panel {
     slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
     tooltipText: ""
     onPressed: function(b) {
-      if (!root.batteryPresent) return
       if (b === Qt.RightButton) root.togglePercentage()
       else root.toggle()
     }
@@ -294,7 +288,7 @@ Panel {
     anchorItem: button
     owner: root
     bar: root.bar
-    open: root.opened && root.batteryPresent
+    open: root.opened
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(380))
     contentHeight: panel.fittedContentHeight(column.implicitHeight)
@@ -320,8 +314,11 @@ Panel {
 
         // ---------- Hero: battery icon · title/status · percentage ----------
         Item {
+          visible: root.batteryPresent
           width: parent.width
-          implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, heroPercent.implicitHeight)
+          implicitHeight: visible
+            ? Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, heroPercent.implicitHeight)
+            : 0
 
           Text {
             id: heroIcon
@@ -383,8 +380,9 @@ Panel {
 
         // ---------- Battery progress bar ----------
         Item {
+          visible: root.batteryPresent
           width: parent.width
-          implicitHeight: Style.space(8)
+          implicitHeight: visible ? Style.space(8) : 0
 
           Rectangle {
             id: barTrack
@@ -423,7 +421,7 @@ Panel {
         // the battery sits above the charge-control start threshold, and we
         // refuse to flicker the whole panel for that ~1s window.
         Row {
-          visible: root.batteryInfo.percentage !== undefined
+          visible: root.batteryPresent && root.batteryInfo.percentage !== undefined
           width: parent.width
           spacing: Style.space(20)
 
@@ -450,6 +448,7 @@ Panel {
 
         // ---------- Power profile picker ----------
         PanelSeparator {
+          visible: root.batteryPresent
           foreground: root.bar.foreground
         }
 

--- a/test/acceptance.d/panels-test.sh
+++ b/test/acceptance.d/panels-test.sh
@@ -73,9 +73,8 @@ while IFS='|' read -r name plugin; do
   fi
 done <<<"$panels"
 
-# The power widget intentionally disappears on desktops and VMs without a
-# battery. Exercise it on laptops, and verify that hardware-less sessions take
-# the supported no-panel path instead of treating that as a shell failure.
+# Power panel must open everywhere: battery chrome when present, power
+# profiles always (desktops/VMs without a battery used to self-close, #7119).
 if upower -e | grep '/battery_' >/dev/null; then
   if ! (trap - EXIT; open_and_capture_panel "power" "omarchy.power"); then
     status=1
@@ -83,8 +82,20 @@ if upower -e | grep '/battery_' >/dev/null; then
     wait_until "power failed panel is dismissed" 15 layer_absent "omarchy-keyboard-panel"
   fi
 else
-  pass "power panel is hidden without battery hardware"
-  screenshot "success-panel-power-unavailable"
+  if ! (
+    trap - EXIT
+    omarchy-shell shell summon omarchy.power >/dev/null
+    wait_until "power panel opens without battery" 15 layer_present "omarchy-keyboard-panel"
+    wait_until "power profiles are visible without battery" 15 screen_contains "POWER PROFILE"
+    sleep 1
+    screenshot "success-panel-power-no-battery"
+    omarchy-shell shell hide omarchy.power >/dev/null
+    wait_until "power panel closes without battery" 15 layer_absent "omarchy-keyboard-panel"
+  ); then
+    status=1
+    hide_panels
+    wait_until "power failed panel is dismissed" 15 layer_absent "omarchy-keyboard-panel"
+  fi
 fi
 
 # The common panel keyboard contract uses Tab to move to the next bar panel.

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -48,4 +48,9 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(!/if \(!batteryPresent\) \{\s*close\(\)/.test(panelSource), 'power does not self-close when opened without a battery')
+assert(!/onBatteryPresentChanged: if \(!batteryPresent\) close\(\)/.test(panelSource), 'power does not close when battery presence drops')
+assert(/open: root\.opened\b/.test(panelSource), 'power panel opens from the opened flag even without a battery')
+assert(/visible: root\.batteryPresent/.test(panelSource), 'power hides battery chrome when no battery is present')
+assert(/if \(batteryPresent && !batteryProc\.running\)/.test(panelSource), 'power still refreshes profiles without a battery')
 JS


### PR DESCRIPTION
## Summary
- `SUPER+CTRL+P` was a silent no-op on desktops/VMs: the power panel opened then immediately closed when `batteryPresent` was false (#7119).
- Keep the bar battery slot hidden without a battery, but allow the panel to stay open and show power-profile controls (battery chrome stays hidden).
- Refresh still loads profiles/system stats when no battery is present.

## Test plan
- [x] `bash test/shell.d/power-test.sh` — existing model tests plus assertions that the panel no longer self-closes without a battery
- [ ] On a desktop/VM without a battery: `SUPER+CTRL+P` / `omarchy-shell shell toggle omarchy.power` opens the profile picker and stays open

Fixes #7119

Made with [Cursor](https://cursor.com)