### PR TITLE
Enable Sunshine by its canonical systemd user unit

### DIFF
--- a/bin/omarchy-install-service-sunshine
+++ b/bin/omarchy-install-service-sunshine
@@ -69,9 +69,24 @@ enable_hyprland_autostart() {
   fi
 }
 
+enable_sunshine_unit() {
+  local unit=app-dev.lizardbyte.app.Sunshine.service
+
+  # systemd only resolves Alias= after enable by the real unit name. Arch
+  # ships this unit with Alias=sunshine.service, so enabling "sunshine" fails
+  # on a fresh install ("Unit sunshine.service does not exist").
+  if [[ -f /usr/lib/systemd/user/$unit ]]; then
+    systemctl --user enable --now "$unit"
+  elif systemctl --user is-enabled sunshine.service >/dev/null 2>&1; then
+    systemctl --user enable --now sunshine.service
+  else
+    systemctl --user enable --now "$unit"
+  fi
+}
+
 echo "Installing Sunshine..."
 omarchy-pkg-add sunshine
-systemctl --user enable --now sunshine
+enable_sunshine_unit
 
 echo "Opening Sunshine firewall ports..."
 open_ufw_ports

--- a/bin/omarchy-remove-service-sunshine
+++ b/bin/omarchy-remove-service-sunshine
@@ -59,6 +59,8 @@ disable_hyprland_autostart() {
   fi
 }
 
+# Alias=sunshine.service only exists after the canonical unit has been enabled.
+systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service 2>/dev/null || true
 systemctl --user disable --now sunshine 2>/dev/null || true
 omarchy-pkg-drop sunshine
 omarchy-webapp-remove "$SUNSHINE_ADMIN_APP" 2>/dev/null || true

--- a/test/shell.d/sunshine-install-test.sh
+++ b/test/shell.d/sunshine-install-test.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+log="$test_tmp/calls.log"
+systemctl_log="$test_tmp/systemctl.log"
+enabled_flag="$test_tmp/sunshine-enabled"
+mkdir -p "$mock_bin" "$test_home"
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+printf 'cmd-missing:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+
+if [[ $1 == "ufw" && ${OMARCHY_TEST_UFW:-} == "1" ]]; then
+  exit 1
+fi
+
+exit 0
+SH
+
+cat >"$mock_bin/omarchy-webapp-install" <<'SH'
+#!/bin/bash
+printf 'webapp-install:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+printf 'webapp-launch:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/ufw" <<'SH'
+#!/bin/bash
+printf 'ufw %s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/ip" <<'SH'
+#!/bin/bash
+printf 'ip %s\n' "$*" >>"$OMARCHY_TEST_LOG"
+exit 1
+SH
+
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_SYSTEMCTL_LOG"
+
+action=""
+unit=""
+for arg in "$@"; do
+  case $arg in
+    --user|--now|--quiet)
+      ;;
+    enable|disable|start|stop|is-enabled|is-active)
+      action=$arg
+      ;;
+    -*)
+      ;;
+    *)
+      unit=$arg
+      ;;
+  esac
+done
+
+[[ $unit == "sunshine" ]] && unit=sunshine.service
+
+canonical=app-dev.lizardbyte.app.Sunshine.service
+
+if [[ $action == "is-enabled" ]]; then
+  if [[ $unit == "sunshine.service" || $unit == $canonical ]]; then
+    if [[ -f $OMARCHY_TEST_SUNSHINE_ENABLED ]]; then
+      exit 0
+    fi
+  fi
+  exit 1
+fi
+
+if [[ $action == "enable" ]]; then
+  if [[ $unit == $canonical ]]; then
+    printf '1\n' >"$OMARCHY_TEST_SUNSHINE_ENABLED"
+    exit 0
+  fi
+
+  if [[ $unit == "sunshine.service" ]]; then
+    if [[ -f $OMARCHY_TEST_SUNSHINE_ENABLED ]]; then
+      exit 0
+    fi
+
+    printf 'Failed to enable unit: Unit sunshine.service does not exist\n' >&2
+    exit 1
+  fi
+fi
+
+exit 0
+SH
+
+chmod +x "$mock_bin"/*
+
+run_install() {
+  HOME="$test_home" \
+  PATH="$mock_bin:$PATH" \
+  OMARCHY_TEST_LOG="$log" \
+  OMARCHY_TEST_SYSTEMCTL_LOG="$systemctl_log" \
+  OMARCHY_TEST_SUNSHINE_ENABLED="$enabled_flag" \
+  OMARCHY_TEST_UFW="${OMARCHY_TEST_UFW:-}" \
+    "$ROOT/bin/omarchy-install-service-sunshine"
+}
+
+wait_for_log() {
+  local pattern="$1"
+  local file="$2"
+  local attempt
+
+  for attempt in {1..50}; do
+    grep -q -- "$pattern" "$file" && return 0
+    sleep 0.05
+  done
+
+  return 1
+}
+
+: >"$log"
+: >"$systemctl_log"
+rm -f "$enabled_flag"
+
+output=$(run_install)
+
+grep -Fxq 'pkg-add:sunshine' "$log" || fail "sunshine install adds the sunshine package" "$output"
+grep -Fq 'enable --now app-dev.lizardbyte.app.Sunshine.service' "$systemctl_log" ||
+  fail "sunshine install enables the canonical Arch unit" "$(cat "$systemctl_log")"
+grep -E 'enable --now sunshine([.]service)?$' "$systemctl_log" &&
+  fail "sunshine install must not enable the alias before the canonical unit exists" "$(cat "$systemctl_log")"
+grep -Fxq 'cmd-missing:ufw' "$log" || fail "sunshine install still checks the firewall after enable" "$output"
+grep -Fq 'UFW is not installed; skipping Sunshine firewall rules.' <<<"$output" ||
+  fail "sunshine install skips ufw when it is missing" "$output"
+grep -Fq 'webapp-install:Sunshine Admin' "$log" ||
+  fail "sunshine install still installs the admin webapp after enable" "$log"
+wait_for_log 'webapp-launch:https://localhost:47990' "$log" ||
+  fail "sunshine install still launches the admin webapp after enable" "$log"
+grep -Fxq 'o.launch_on_start("sunshine")' "$test_home/.config/hypr/autostart.lua" ||
+  fail "sunshine install still enables hyprland autostart after enable"
+pass "fresh sunshine install enables the canonical unit and continues"
+
+: >"$log"
+: >"$systemctl_log"
+OMARCHY_TEST_UFW=1 output=$(run_install)
+
+grep -Fq 'enable --now sunshine' "$systemctl_log" ||
+  fail "already-enabled sunshine.service is reused via its alias" "$(cat "$systemctl_log")"
+grep -Fq 'sudo ufw allow' "$log" || fail "sunshine install still opens firewall ports after enable" "$log"
+grep -Fq 'webapp-install:Sunshine Admin' "$log" ||
+  fail "re-running sunshine install still installs the admin webapp" "$log"
+autostart_count=$(grep -cFx 'o.launch_on_start("sunshine")' "$test_home/.config/hypr/autostart.lua")
+(( autostart_count == 1 )) || fail "sunshine autostart stays a single line on reinstall"
+pass "already-enabled sunshine.service is idempotent and later steps still run"


### PR DESCRIPTION
Arch's Sunshine package ships `app-dev.lizardbyte.app.Sunshine.service` with `Alias=sunshine.service`. systemd only resolves that alias after the unit has been enabled by its real name, so `systemctl --user enable --now sunshine` fails on a fresh install and `set -e` skips the firewall, webapp, and autostart steps.

Enable the canonical unit when the file is on disk (and still use that name if the alias is not resolvable yet). A machine that already has `sunshine.service` enabled is a no-op. Remove disables both names.

`sunshine-install-test.sh` covers a fresh canonical enable and an already-enabled alias, and checks later steps still run.

Fixes #7967
