### PR TITLE
Fix install-and-launch done prompt race

### DIFF
--- a/bin/omarchy-install-and-launch
+++ b/bin/omarchy-install-and-launch
@@ -17,5 +17,7 @@ printf -v install_message '%q' "Installing ${name}..."
 printf -v desktop_id_arg '%q' "$desktop_id"
 
 # The subshell keeps & from backgrounding the package installation too.
+# Exiting 130 tells the presentation wrapper not to show the trailing done
+# prompt, avoiding a focus race with the GUI window this command just launched.
 exec omarchy-launch-floating-terminal-with-presentation \
-  "echo ${install_message}; omarchy-pkg-add ${packages} && (setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &)"
+  "echo ${install_message}; omarchy-pkg-add ${packages} && (setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &) && exit 130"

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -79,15 +79,23 @@ presentation_command=$(<"$OMARCHY_TEST_PRESENTATION")
   fail "generic installer shell-quotes the display name" "$presentation_command"
 [[ $presentation_command == *'omarchy-pkg-add alpha beta && (setsid uwsm-app -- gtk-launch Disk\ Usage >/dev/null 2>&1 &)'* ]] ||
   fail "generic installer waits for packages and detaches only the scoped launch" "$presentation_command"
+[[ $presentation_command == *'&& exit 130' ]] ||
+  fail "generic installer suppresses the wrapper done prompt after launching" "$presentation_command"
 pass "generic installer waits for packages and detaches only the scoped launch"
 
 : >"$OMARCHY_TEST_LOG"
+set +e
 bash -c "$presentation_command"
+status=$?
+set -e
+(( status == 130 )) ||
+  fail "generic installer exits with wrapper skip status after launching" "$status"
 grep -Fxq 'pkg:alpha beta' "$OMARCHY_TEST_LOG" ||
   fail "generic installer passes every package to the package helper"
 wait_for_launch 'launch:uwsm-app -- gtk-launch Disk Usage' ||
   fail "generic installer preserves a desktop ID containing spaces"
 pass "generic installer preserves a desktop ID containing spaces"
+pass "generic installer suppresses the wrapper done prompt after launching"
 
 : >"$OMARCHY_TEST_LOG"
 if OMARCHY_TEST_PKG_STATUS=1 bash -c "$presentation_command"; then


### PR DESCRIPTION
## Summary
- Make `omarchy-install-and-launch` exit with the presentation wrapper skip status after a successful GUI launch.
- Keeps package installation failures on the existing wrapper path so terminal feedback remains visible.
- Adds shell coverage that the generic installer launches the desktop entry and suppresses the trailing done prompt.

Fixes #8122.

## Tests
- `bash test/shell.d/desktop-entry-launch-test.sh`
- `git diff --check`

## Note
- I also started `./test/shell`, but stopped it after the changed test passed because this macOS host lacks several Linux/GNU dependencies required by unrelated shell tests (`lua`, `magick`, `flock`, `setpriv`, GNU `stat`/`realpath`, etc.).