### PR TITLE
Keep the screensaver up while launch hops between monitors

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -2,8 +2,20 @@
 
 # omarchy:summary=Run the Omarchy screensaver using random effects from TTE.
 
+# activewindow is global. Launch hops focus across screensaver windows, and the
+# compositor can report no class while switching monitors. Stay up unless a real
+# non-screensaver client is focused.
 screensaver_in_focus() {
-  hyprctl activewindow -j | jq -e '.class == "org.omarchy.screensaver"' >/dev/null 2>&1
+  local json class
+
+  json=$(hyprctl activewindow -j 2>/dev/null) || return 0
+  class=$(jq -r '.class // empty' <<<"$json" 2>/dev/null) || return 0
+
+  if [[ -z $class || $class == "null" ]]; then
+    return 0
+  fi
+
+  [[ $class == "org.omarchy.screensaver" ]]
 }
 
 exit_screensaver() {
@@ -12,6 +24,14 @@ exit_screensaver() {
   pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null
   exit 0
 }
+
+if [[ ${1:-} == "--check-focus" ]]; then
+  if screensaver_in_focus; then
+    exit 0
+  else
+    exit 1
+  fi
+fi
 
 # Exit the screensaver on signals and input from keyboard and mouse
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT

--- a/test/shell.d/screensaver-test.sh
+++ b/test/shell.d/screensaver-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "activewindow" && $2 == "-j" ]]; then
+  printf '%s\n' "${OMARCHY_TEST_ACTIVEWINDOW_JSON-}"
+  exit 0
+fi
+
+exit 1
+SH
+
+# --check-focus must not start the screensaver; if the hook is missing these
+# would be invoked and the test would fail instead of hanging in ttfx.
+cat >"$stub_bin/ttfx" <<'SH'
+#!/bin/bash
+printf 'ttfx must not run during --check-focus\n' >&2
+exit 99
+SH
+
+chmod +x "$stub_bin/hyprctl" "$stub_bin/ttfx"
+
+check_focus() {
+  PATH="$stub_bin:$PATH" OMARCHY_TEST_ACTIVEWINDOW_JSON="$1" \
+    "$ROOT/bin/omarchy-screensaver" --check-focus
+}
+
+assert_stays() {
+  local json="$1"
+  local description="$2"
+
+  if check_focus "$json"; then
+    pass "$description"
+  else
+    fail "$description"
+  fi
+}
+
+assert_dismisses() {
+  local json="$1"
+  local description="$2"
+
+  if check_focus "$json"; then
+    fail "$description"
+  else
+    pass "$description"
+  fi
+}
+
+assert_stays '{"address":"0xaaa","class":"org.omarchy.screensaver"}' \
+  "screensaver stays when this screensaver window is focused"
+
+assert_stays '{"address":"0xbbb","class":"org.omarchy.screensaver","title":"DP-3"}' \
+  "screensaver stays when another screensaver window is focused"
+
+assert_dismisses '{"class":"kitty"}' \
+  "screensaver dismisses when kitty is focused"
+
+assert_dismisses '{"class":"firefox"}' \
+  "screensaver dismisses when firefox is focused"
+
+assert_stays '{}' \
+  "screensaver stays when activewindow has no class"
+
+assert_stays '{"address":"0xccc","class":null}' \
+  "screensaver stays when activewindow class is null"
+
+assert_stays 'null' \
+  "screensaver stays when activewindow is null"
+
+assert_stays '' \
+  "screensaver stays when activewindow is empty during a monitor switch"
+
+if rg -F -q "pkill -f '[o]rg.omarchy.screensaver'" "$ROOT/bin/omarchy-screensaver"; then
+  pass "real dismiss still kills all screensaver clients"
+else
+  fail "real dismiss still kills all screensaver clients"
+fi


### PR DESCRIPTION
`omarchy-launch-screensaver` focuses each monitor in turn while spawning. `hyprctl activewindow` is global, so on 3+ monitors the first screensaver's 1s poll could see another output's client (or no class) and `exit_screensaver`, which `pkill`s every `org.omarchy.screensaver` instance. The idle manager treated that as a user dismiss and cancelled lock/DPMS.

`screensaver_in_focus` now stays up when the focused window is another screensaver or has no class (monitor switch). It dismisses only when a real non-screensaver client is focused. Real dismiss still kills all instances.

`screensaver-test.sh` covers screensaver class, empty class, and a foreign client.

Fixes #8114
