### PR TITLE
Disable USB autosuspend on the kernel cmdline

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1202,7 +1202,6 @@ run_final_system_package_upgrade() {
     --overwrite '/etc/gnupg/dirmngr.conf' \
     --overwrite '/etc/mkinitcpio.conf.d/omarchy_hooks.conf' \
     --overwrite '/etc/mkinitcpio.conf.d/thunderbolt_module.conf' \
-    --overwrite '/etc/modprobe.d/omarchy-usb-autosuspend.conf' \
     --overwrite '/etc/sddm.conf.d/10-theme.conf' \
     --overwrite '/etc/sddm.conf.d/10-wayland.conf' \
     --overwrite '/etc/sudoers.d/omarchy-asdcontrol' \

--- a/etc/limine-entry-tool.d/omarchy-defaults.conf
+++ b/etc/limine-entry-tool.d/omarchy-defaults.conf
@@ -9,6 +9,9 @@ KERNEL_CMDLINE[default]+=" quiet splash loglevel=0 systemd.show_status=false rd.
 # is fixed upstream.
 KERNEL_CMDLINE[default]+=" initramfs_async=0"
 
+# usbcore is built into the Arch kernel, so modprobe.d options never apply.
+KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"
+
 CUSTOM_UKI_NAME="omarchy"
 ENABLE_LIMINE_FALLBACK=yes
 

--- a/etc/modprobe.d/omarchy-usb-autosuspend.conf
+++ b/etc/modprobe.d/omarchy-usb-autosuspend.conf
@@ -1,1 +1,0 @@
-options usbcore autosuspend=-1

--- a/migrations/1787601557.sh
+++ b/migrations/1787601557.sh
@@ -1,0 +1,41 @@
+echo "Disable USB autosuspend on the kernel cmdline"
+
+# usbcore is built into the Arch kernel, so the old modprobe.d drop-in never
+# applied and autosuspend stayed at the default of 2. Put the parameter on the
+# Limine command line, where built-in usbcore reads it. Fresh installs get the
+# same line from the packaged omarchy-defaults.conf. Append only: do not rewrite
+# KERNEL_CMDLINE, or cryptdevice/root from other drop-ins would be lost.
+
+defaults_conf="${OMARCHY_LIMINE_DEFAULTS_CONF:-/etc/limine-entry-tool.d/omarchy-defaults.conf}"
+running_cmdline="${OMARCHY_RUNNING_CMDLINE:-/proc/cmdline}"
+rebuild_marker="${OMARCHY_USB_AUTOSUSPEND_REBUILD_MARKER:-/var/lib/omarchy/migrations/1787601557}"
+modprobe_conf="${OMARCHY_USB_AUTOSUSPEND_MODPROBE:-/etc/modprobe.d/omarchy-usb-autosuspend.conf}"
+
+if [[ -e $modprobe_conf ]]; then
+  sudo rm -f "$modprobe_conf"
+fi
+
+omarchy-cmd-present limine-mkinitcpio || exit 0
+[[ -f $defaults_conf ]] || exit 0
+
+if ! grep -Fq 'usbcore.autosuspend' "$defaults_conf"; then
+  echo 'KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"' |
+    sudo tee -a "$defaults_conf" >/dev/null
+fi
+
+# The running kernel keeps its old command line until reboot, so a marker
+# records the machine-wide rebuild instead: another user's migration must not
+# repeat it before then, while a missing marker still retries an interrupted
+# rebuild.
+[[ ! -e $rebuild_marker ]] || exit 0
+[[ -r $running_cmdline ]] || exit 0
+grep -Fq 'usbcore.autosuspend=-1' "$defaults_conf" || exit 0
+
+booted=$(<"$running_cmdline")
+if [[ " $booted " == *" usbcore.autosuspend=-1 "* ]]; then
+  exit 0
+fi
+
+echo "The booted kernel is missing usbcore.autosuspend=-1; rebuilding the boot image"
+sudo limine-mkinitcpio
+sudo install -Dm644 /dev/null "$rebuild_marker"

--- a/test/shell.d/usb-autosuspend-cmdline-test.sh
+++ b/test/shell.d/usb-autosuspend-cmdline-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787601557.sh"
+packaged_defaults="$ROOT/etc/limine-entry-tool.d/omarchy-defaults.conf"
+upgrade_to_quattro="$ROOT/bin/omarchy-upgrade-to-quattro"
+
+grep -Fq 'KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"' "$packaged_defaults" ||
+  fail "the packaged Limine defaults disable USB autosuspend on the kernel cmdline"
+pass "packaged Limine defaults set usbcore.autosuspend=-1"
+
+[[ ! -e $ROOT/etc/modprobe.d/omarchy-usb-autosuspend.conf ]] ||
+  fail "the useless usbcore modprobe drop-in is still shipped"
+! grep -Fq '/etc/modprobe.d/omarchy-usb-autosuspend.conf' "$upgrade_to_quattro" ||
+  fail "the quattro upgrade still overwrites the removed usbcore modprobe drop-in"
+pass "modprobe drop-in is gone and not packaged as an upgrade overwrite"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+(( ${LIMINE_MKINITCPIO_INSTALLED:-1} == 1 ))
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+defaults_conf="$test_tmp/omarchy-defaults.conf"
+running_cmdline="$test_tmp/cmdline"
+rebuild_marker="$test_tmp/rebuild-complete"
+modprobe_conf="$test_tmp/omarchy-usb-autosuspend.conf"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_LIMINE_DEFAULTS_CONF="$defaults_conf" \
+    OMARCHY_RUNNING_CMDLINE="$running_cmdline" \
+    OMARCHY_USB_AUTOSUSPEND_REBUILD_MARKER="$rebuild_marker" \
+    OMARCHY_USB_AUTOSUSPEND_MODPROBE="$modprobe_conf" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# Existing install: packaged defaults have not yet landed, leftover modprobe
+# drop-in is still on disk, boot image still has the machine's root parameters
+# and none of usbcore.autosuspend=-1.
+cat >"$defaults_conf" <<'EOF'
+TARGET_OS_NAME="Omarchy"
+
+KERNEL_CMDLINE[default]+=" quiet splash loglevel=0 systemd.show_status=false rd.udev.log_level=0 vt.global_cursor_default=0"
+KERNEL_CMDLINE[default]+=" initramfs_async=0"
+EOF
+echo 'options usbcore autosuspend=-1' >"$modprobe_conf"
+echo 'quiet splash cryptdevice=PARTUUID=fake:root root=/dev/mapper/root rw' >"$running_cmdline"
+
+run_migration
+
+grep -Fq 'KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"' "$defaults_conf" ||
+  fail "migration appends usbcore.autosuspend=-1 to the Limine defaults"
+grep -Fq 'initramfs_async=0' "$defaults_conf" ||
+  fail "migration leaves existing Limine defaults in place"
+[[ ! -e $modprobe_conf ]] || fail "migration removes the leftover modprobe drop-in"
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "a boot image missing usbcore.autosuspend=-1 is rebuilt"
+[[ -f $rebuild_marker ]] || fail "the rebuild records the machine-wide repair"
+pass "migration adds usbcore.autosuspend=-1 when it is missing"
+
+: >"$calls"
+run_migration
+
+(( $(grep -c 'usbcore.autosuspend=-1' "$defaults_conf") == 1 )) ||
+  fail "migration does not append usbcore.autosuspend=-1 twice"
+[[ ! -s $calls ]] || fail "a recorded rebuild is not repeated" "$(cat "$calls")"
+pass "migration is a no-op when usbcore.autosuspend=-1 is already present"
+
+rm -f "$rebuild_marker"
+: >"$calls"
+run_migration
+
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "an interrupted rebuild is retried"
+(( $(grep -c 'usbcore.autosuspend=-1' "$defaults_conf") == 1 )) ||
+  fail "a rebuild retry does not duplicate the cmdline parameter"
+pass "migration retries an interrupted rebuild without duplicating the parameter"
+
+# Package already wrote the defaults (or a previous run did) and the boot
+# image already carries the parameter, including the machine's root unlock.
+cp "$packaged_defaults" "$defaults_conf"
+configured=$(sed -n 's/^KERNEL_CMDLINE\[default\]+="\(.*\)"[[:space:]]*$/\1/p' "$defaults_conf" | tr '\n' ' ')
+echo "cryptdevice=PARTUUID=fake:root root=/dev/mapper/root rw $configured" >"$running_cmdline"
+rm -f "$rebuild_marker"
+: >"$calls"
+run_migration
+
+[[ ! -s $calls ]] || fail "a boot image that already has usbcore.autosuspend=-1 is left alone" "$(cat "$calls")"
+[[ ! -e $rebuild_marker ]] || fail "an untouched machine is not marked as repaired"
+(( $(grep -c 'usbcore.autosuspend=-1' "$defaults_conf") == 1 )) ||
+  fail "a current boot image does not get a second cmdline line"
+pass "migration is a no-op when the running cmdline already has the parameter"
+
+echo 'quiet splash cryptdevice=PARTUUID=fake:root root=/dev/mapper/root rw' >"$running_cmdline"
+: >"$calls"
+LIMINE_MKINITCPIO_INSTALLED=0 run_migration
+
+[[ ! -s $calls ]] || fail "installs without limine-mkinitcpio are skipped" "$(cat "$calls")"
+grep -Fq 'cryptdevice=PARTUUID=fake:root' "$running_cmdline" ||
+  fail "migration must not rewrite the running cmdline"
+
+mv "$defaults_conf" "$defaults_conf.away"
+run_migration
+mv "$defaults_conf.away" "$defaults_conf"
+
+[[ ! -s $calls ]] || fail "installs without the Limine defaults are skipped" "$(cat "$calls")"
+pass "migration skips installs it does not apply to"


### PR DESCRIPTION
usbcore is built into the Arch kernel, so `etc/modprobe.d/omarchy-usb-autosuspend.conf` never applied and autosuspend stayed at 2.

Set `usbcore.autosuspend=-1` via `KERNEL_CMDLINE[default]+=` in `etc/limine-entry-tool.d/omarchy-defaults.conf` and stop shipping the modprobe drop-in. Existing installs get the same parameter through an append-only Limine migration, so cryptdevice/root are left alone.

A reboot is required for `/sys/module/usbcore/parameters/autosuspend` to become `-1`.

Fixes #8097