### PR TITLE
Keep the Bluetooth adapter pairable only while the panel is open

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -154,6 +154,17 @@ function sectionDevices(lists, section) {
   return []
 }
 
+// Pairable is not a BlueZ session (unlike Discovering): one write is enough.
+// Returns true/false to write, or null to leave the adapter alone because
+// another monitor's panel is still open. A powered-off adapter is never
+// pairable — every instance shares the default adapter.
+function wantedPairable(opened, adapterEnabled, siblingOpen) {
+  if (!adapterEnabled) return false
+  if (opened) return true
+  if (siblingOpen) return null
+  return false
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     deviceLabel: deviceLabel,
@@ -172,6 +183,7 @@ if (typeof module !== "undefined") {
     pendingAction: pendingAction,
     withPendingAction: withPendingAction,
     visibleSections: visibleSections,
-    sectionDevices: sectionDevices
+    sectionDevices: sectionDevices,
+    wantedPairable: wantedPairable
   }
 }

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -411,12 +411,15 @@ Panel {
       // from another monitor, or one leaked by an instance that could not
       // finish its own stop — so this close settles it either way.
       if (adapter !== null && adapter.discovering) owesDiscoveryStop = true
+      applyPairable()
       if (connectedDevices.length > 0) { focusSection = "connected"; selectedIndex = 0 }
       else if (knownDevices.length > 0) { focusSection = "known"; selectedIndex = 0 }
       else if (discoveredDevices.length > 0) { focusSection = "discovered"; selectedIndex = 0 }
       else { focusSection = "header" }
       actionFocused = false
       cursorActive = false
+    } else {
+      applyPairable()
     }
   }
 
@@ -432,6 +435,27 @@ Panel {
     }
     return null
   }
+
+  // Pairable is the inbound-pairing gate bt-agent.service's NoInputNoOutput
+  // comment relies on. BlueZ defaults PairableTimeout=0, so once true it
+  // stays true forever unless we write it false. Quickshell only forwards a
+  // pairable write that differs from the last state it holds, same as
+  // discovering. Sibling care matches discovery: a close on one monitor
+  // must not lock out a panel still open on another.
+  function setPairable(want) {
+    if (want == null || adapter === null) return
+    if (adapter.pairable === want) return
+    adapter.pairable = want
+  }
+
+  function applyPairable(opened) {
+    if (opened === undefined) opened = root.opened
+    var siblingOpen = openSibling() !== null
+    var enabled = adapter !== null && !!adapter.enabled
+    setPairable(Model.wantedPairable(opened, enabled, siblingOpen))
+  }
+
+  onAdapterChanged: applyPairable()
 
   function updateFocusedAddress() {
     var d = deviceAt(focusSection, selectedIndex)
@@ -513,6 +537,7 @@ Panel {
     onTriggered: {
       root.owesDiscoveryStop = true
       root.adapter.discovering = true
+      root.applyPairable()
     }
   }
 
@@ -547,6 +572,7 @@ Panel {
         root.owesDiscoveryStop = false
         return
       }
+      root.applyPairable()
       attempts += 1
       if (attempts > 3) { root.owesDiscoveryStop = false; return }
       root.adapter.discovering = false
@@ -562,6 +588,9 @@ Panel {
     function onDiscoveringChanged() {
       if (!root.adapter.discovering) root.owesDiscoveryStop = false
     }
+    function onEnabledChanged() {
+      root.applyPairable()
+    }
   }
 
   // A destroyed instance cannot wait for BlueZ confirmations, so it hands any
@@ -569,12 +598,13 @@ Panel {
   // confirmed after this object is gone — and only writes the stop directly
   // when it is the last one standing.
   Component.onDestruction: {
-    if (!owesDiscoveryStop) return
+    if (!owesDiscoveryStop) { applyPairable(false); return }
     var items = bar && typeof bar.moduleWidgets === "function" ? bar.moduleWidgets(moduleName) : []
     for (var i = 0; i < items.length; i++) {
-      if (items[i] && items[i] !== root) { items[i].owesDiscoveryStop = true; return }
+      if (items[i] && items[i] !== root) { items[i].owesDiscoveryStop = true; applyPairable(false); return }
     }
     if (adapter !== null && adapter.discovering) adapter.discovering = false
+    applyPairable(false)
   }
 
   Timer {

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -450,12 +450,26 @@ Panel {
 
   function applyPairable(opened) {
     if (opened === undefined) opened = root.opened
+    // Widgets are constructed with bar === null; injectProps assigns it from
+    // Loader.onLoaded. Without bar we cannot see an open sibling, so do not
+    // write pairable false — that would lock out a panel already open on
+    // another monitor while this instance is still coming up.
+    if (!opened && !bar) return
     var siblingOpen = openSibling() !== null
     var enabled = adapter !== null && !!adapter.enabled
     setPairable(Model.wantedPairable(opened, enabled, siblingOpen))
   }
 
+  // After bar is injected, ask an already-open sibling to reassert true in
+  // case this instance wrote false during the bar === null window.
+  function reassertPairable() {
+    applyPairable()
+    var sibling = openSibling()
+    if (sibling && typeof sibling.applyPairable === "function") sibling.applyPairable()
+  }
+
   onAdapterChanged: applyPairable()
+  onBarChanged: reassertPairable()
 
   function updateFocusedAddress() {
     var d = deviceAt(focusSection, selectedIndex)

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -56,6 +56,9 @@ assert(/Component\.onDestruction: \{[\s\S]{0,400}owesDiscoveryStop = true[\s\S]{
 // is only safe inside that window.
 assert(/function setPairable\(want\)[\s\S]*?adapter\.pairable === want[\s\S]*?adapter\.pairable = want/.test(panelSource), 'bluetooth only writes pairable when it differs from the adapter')
 assert(/function applyPairable\(opened\)[\s\S]*?Model\.wantedPairable\(opened/.test(panelSource), 'bluetooth derives pairable from panel open, adapter power, and sibling state')
+assert(/if \(!opened && !bar\) return/.test(panelSource), 'bluetooth does not turn pairable off before bar is injected')
+assert(/onBarChanged: reassertPairable\(\)/.test(panelSource), 'bluetooth re-evaluates pairable once bar is injected')
+assert(/function reassertPairable\(\)[\s\S]*?sibling\.applyPairable\(\)/.test(panelSource), 'bluetooth asks an open sibling to reassert pairable after bar is injected')
 
 assert(/onOpenedChanged: \{[\s\S]*?if \(opened\) \{[\s\S]*?applyPairable\(\)/.test(panelSource), 'bluetooth writes pairable on the open path')
 assert(retryTimer && /applyPairable\(\)/.test(retryTimer[0]), 'bluetooth writes pairable on the discovery start path')

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -50,6 +50,29 @@ assert(/sibling\.owesDiscoveryStop = true/.test(stopTimer[0]), 'bluetooth moves 
 assert(/onDiscoveringChanged[\s\S]{0,120}owesDiscoveryStop = false/.test(panelSource), 'bluetooth settles the stop it owes once discovery is confirmed down')
 assert(/Component\.onDestruction: \{[\s\S]{0,400}owesDiscoveryStop = true[\s\S]{0,200}discovering = false/.test(panelSource), 'bluetooth passes the stop it owes to a sibling when an instance is destroyed')
 
+// Pairable is BlueZ's inbound-pairing gate. The adapter defaults to
+// Pairable: true with PairableTimeout=0, so it stays pairable forever
+// unless the panel writes it false when closed. bt-agent's NoInputNoOutput
+// is only safe inside that window.
+assert(/function setPairable\(want\)[\s\S]*?adapter\.pairable === want[\s\S]*?adapter\.pairable = want/.test(panelSource), 'bluetooth only writes pairable when it differs from the adapter')
+assert(/function applyPairable\(opened\)[\s\S]*?Model\.wantedPairable\(opened/.test(panelSource), 'bluetooth derives pairable from panel open, adapter power, and sibling state')
+
+assert(/onOpenedChanged: \{[\s\S]*?if \(opened\) \{[\s\S]*?applyPairable\(\)/.test(panelSource), 'bluetooth writes pairable on the open path')
+assert(retryTimer && /applyPairable\(\)/.test(retryTimer[0]), 'bluetooth writes pairable on the discovery start path')
+
+assert(stopTimer && /applyPairable\(\)/.test(stopTimer[0]), 'bluetooth writes pairable false on close when no sibling is open')
+const siblingBranch = stopTimer[0].match(/if \(sibling\) \{[\s\S]*?return/)
+assert(siblingBranch && !/pairable/.test(siblingBranch[0]), 'bluetooth leaves pairable alone when a sibling panel is still open')
+
+assert(/Component\.onDestruction: \{[\s\S]*?applyPairable\(false\)/.test(panelSource), 'bluetooth applies pairable as closed when an instance is destroyed')
+
+assertEqual(bluetooth.wantedPairable(true, true, false), true, 'bluetooth wants pairable while the panel is open and the adapter is on')
+assertEqual(bluetooth.wantedPairable(true, true, true), true, 'bluetooth wants pairable on an open panel even when a sibling is also open')
+assertEqual(bluetooth.wantedPairable(false, true, false), false, 'bluetooth wants pairable off after close when no sibling is open')
+assertEqual(bluetooth.wantedPairable(false, true, true), null, 'bluetooth leaves pairable alone when a sibling panel is still open')
+assertEqual(bluetooth.wantedPairable(true, false, false), false, 'bluetooth wants pairable off when the adapter is powered down')
+assertEqual(bluetooth.wantedPairable(false, false, true), false, 'bluetooth wants pairable off when the adapter is powered down even with a sibling')
+
 assert(bluetooth.isUuidLike('0000110b-0000-1000-8000-00805f9b34fb'), 'bluetooth detects UUID-like names')
 assert(bluetooth.isAddressLike('AA:BB:CC:DD:EE:FF'), 'bluetooth detects address-like names')
 assertEqual(bluetooth.normalizedAddress('AA:BB_CC-dd-ee-ff'), 'aabbccddeeff', 'bluetooth normalizes BlueZ and PipeWire address formats')


### PR DESCRIPTION
The Bluetooth panel never wrote `adapter.pairable`. BlueZ defaults `PairableTimeout=0`, so the adapter stayed pairable forever after a visit to the panel. `bt-agent.service` already documents NoInputNoOutput as safe only while the panel is open and scanning.

The panel now sets pairable true while it is open and the adapter is powered, and false when the last panel closes, is destroyed, or Bluetooth is turned off. Multi-monitor popout handoff matches discovery: `openSibling()` leaves pairable alone so a panel still open on another monitor can keep pairing.

Node assertions in `bluetooth-test.sh` cover open / close / sibling / power-off / destruction. No live BlueZ adapter here.

Fixes #7889
