### PR TITLE
Pass required bar properties at Loader creation so cloned bars render

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -5,7 +5,6 @@ import Quickshell.Io
 
 import qs.Commons
 
-import "plugins/bar"
 import "services"
 
 ShellRoot {
@@ -183,6 +182,7 @@ ShellRoot {
     return shell.barManifestFor(shell.activeBarId)
   }
   readonly property string activeBarSourceUrl: activeBarId === defaultBarId ? "" : shell.pluginRegistry.entryPointUrl(activeBarManifest, "bar")
+  readonly property string defaultBarSourceUrl: Qt.resolvedUrl("plugins/bar/Bar.qml")
   property var bar: null
 
   onSelectedBarIdChanged: if (failedBarId !== "") failedBarId = ""
@@ -211,6 +211,27 @@ ShellRoot {
     return String(pluginId || "") === shell.activeBarId
   }
 
+  // QML required properties must be set at construction. Loader.source and
+  // configureBar()'s later `"in"` assignments are too late for a cloned bar.
+  function barInitialProperties(manifest) {
+    return {
+      omarchyPath: shell.omarchyPath,
+      barWidgetRegistry: shell.barWidgetRegistry,
+      barConfig: shell.barConfig,
+      shell: shell,
+      manifest: manifest || null
+    }
+  }
+
+  function loadBar(loader, url, manifest) {
+    if (!loader) return
+    if (!loader.active || !url) {
+      loader.setSource("")
+      return
+    }
+    loader.setSource(url, barInitialProperties(manifest))
+  }
+
   function configureBar(target, manifest) {
     if (!target) return
     if ("omarchyPath" in target) target.omarchyPath = shell.omarchyPath
@@ -222,35 +243,31 @@ ShellRoot {
     shell.bar = target
   }
 
-  Component {
-    id: defaultBarComponent
-
-    Bar {
-      omarchyPath: shell.omarchyPath
-      barWidgetRegistry: shell.barWidgetRegistry
-      barConfig: shell.barConfig
-      shell: shell
-      manifest: shell.barManifestFor(shell.defaultBarId)
-    }
-  }
-
   Loader {
     id: defaultBarLoader
 
     active: shell.activeBarId === shell.defaultBarId
-    sourceComponent: defaultBarComponent
     onLoaded: shell.configureBar(item, shell.barManifestFor(shell.defaultBarId))
-    onActiveChanged: if (!active && shell.activeBarId !== shell.defaultBarId) shell.bar = null
+    onActiveChanged: {
+      shell.loadBar(defaultBarLoader, shell.defaultBarSourceUrl, shell.barManifestFor(shell.defaultBarId))
+      if (!active && shell.activeBarId !== shell.defaultBarId) shell.bar = null
+    }
+    Component.onCompleted: shell.loadBar(defaultBarLoader, shell.defaultBarSourceUrl, shell.barManifestFor(shell.defaultBarId))
   }
 
   Loader {
     id: pluginBarLoader
 
     active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
-    source: shell.activeBarId !== shell.defaultBarId ? shell.activeBarSourceUrl : ""
     asynchronous: true
+    readonly property string pluginBarUrl: shell.activeBarSourceUrl
+    onPluginBarUrlChanged: shell.loadBar(pluginBarLoader, pluginBarUrl, shell.activeBarManifest)
     onLoaded: shell.configureBar(item, shell.activeBarManifest)
-    onActiveChanged: if (!active) shell.bar = null
+    onActiveChanged: {
+      shell.loadBar(pluginBarLoader, shell.activeBarSourceUrl, shell.activeBarManifest)
+      if (!active) shell.bar = null
+    }
+    Component.onCompleted: shell.loadBar(pluginBarLoader, shell.activeBarSourceUrl, shell.activeBarManifest)
     onStatusChanged: {
       if (status === Loader.Error) {
         var detail = errorString && errorString() ? errorString() : ""

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -36,6 +36,40 @@ const bar = requireFromRoot('shell/plugins/bar/BarModel.js')
 const barSource = fs.readFileSync(root + '/shell/plugins/bar/Bar.qml', 'utf8')
 const shellSource = fs.readFileSync(root + '/shell/shell.qml', 'utf8')
 
+const helper = shellSource.match(/function barInitialProperties\(manifest\) \{[\s\S]*?\n  \}/)
+assert(helper, 'shell has a shared barInitialProperties helper')
+for (const key of ['omarchyPath', 'barWidgetRegistry', 'barConfig']) {
+  assert(
+    new RegExp(key + '\\s*:').test(helper[0]),
+    `barInitialProperties injects ${key} at construction`
+  )
+}
+assert(
+  /function loadBar\(loader, url, manifest\) \{[\s\S]*?loader\.setSource\(url, barInitialProperties\(manifest\)\)/.test(shellSource),
+  'loadBar passes required properties through setSource initialProperties'
+)
+
+const defaultLoader = shellSource.slice(
+  shellSource.indexOf('id: defaultBarLoader'),
+  shellSource.indexOf('id: pluginBarLoader')
+)
+const pluginLoader = shellSource.slice(
+  shellSource.indexOf('id: pluginBarLoader'),
+  shellSource.indexOf('// ------------------------------------------------------------- services')
+)
+assert(/shell\.loadBar\(defaultBarLoader/.test(defaultLoader), 'built-in bar loads through the shared inject helper')
+assert(/shell\.loadBar\(pluginBarLoader/.test(pluginLoader), 'cloned and third-party bars load through the shared inject helper')
+assert(
+  !/source:\s*shell\.activeBarSourceUrl/.test(pluginLoader),
+  'plugin bars are not loaded via Loader.source without initial properties'
+)
+assert(
+  /required property string omarchyPath/.test(barSource)
+    && /required property var barWidgetRegistry/.test(barSource)
+    && /required property var barConfig/.test(barSource),
+  'bar keeps omarchyPath, barWidgetRegistry, and barConfig required'
+)
+
 assert(/function toggleBarTransparency\(\): string \{[\s\S]*?shell\.bar\.toggleTransparency\(\)/.test(shellSource), 'shell exposes the bar transparency toggle over IPC')
 
 // put tolerates a placement target the bar does not carry, so the IPC call

--- a/test/shell.d/plugin-clone-test.sh
+++ b/test/shell.d/plugin-clone-test.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+# A cloned bar is the same QML as omarchy.bar. Required properties must be
+# passed at construction; Loader.source + later `"in"` assignment never maps it.
+if ! rg -qF 'function barInitialProperties' "$ROOT/shell/shell.qml" ||
+   ! rg -qF 'loader.setSource(url, barInitialProperties(manifest))' "$ROOT/shell/shell.qml" ||
+   ! rg -qF 'shell.loadBar(pluginBarLoader' "$ROOT/shell/shell.qml" ||
+   ! rg -qF 'shell.loadBar(defaultBarLoader' "$ROOT/shell/shell.qml"; then
+  fail "cloned bars are not given required properties at create time"
+fi
+pass "cloned bars share create-time host injection with the built-in bar"
+
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/home/.config/omarchy" "$TMPDIR/bin"


### PR DESCRIPTION
Cloning `omarchy.bar` produced a bar that never mapped a layer surface. `pluginBarLoader` set `source:` and only assigned `omarchyPath`, `barWidgetRegistry`, and `barConfig` afterward. Those are QML `required property` fields, so they have to be present at construction.

Both the built-in bar and plugin bars now go through one `loadBar` helper that calls `Loader.setSource` with `barInitialProperties`. `required` on `Bar.qml` is unchanged.

`bar-test.sh` asserts the shared helper. No live Quickshell on this machine.

Fixes #8007
