### PR TITLE
Launch installed apps after the presentation Done prompt

### DIFF
--- a/bin/omarchy-install-and-launch
+++ b/bin/omarchy-install-and-launch
@@ -22,6 +22,7 @@ read -r -d '' -a package_list <<<"$packages" || true
 printf -v packages_arg '%q ' "${package_list[@]}"
 packages_arg="${packages_arg% }"
 
-# The subshell keeps & from backgrounding the package installation too.
+# Launch after Done so the new window cannot steal the dismiss keystroke.
 exec omarchy-launch-floating-terminal-with-presentation \
-  "echo ${install_message}; omarchy-pkg-add ${packages_arg} && (setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &)"
+  --after-done "setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &" \
+  "echo ${install_message}; omarchy-pkg-add ${packages_arg}"

--- a/bin/omarchy-install-and-launch
+++ b/bin/omarchy-install-and-launch
@@ -24,5 +24,5 @@ packages_arg="${packages_arg% }"
 
 # Launch after Done so the new window cannot steal the dismiss keystroke.
 exec omarchy-launch-floating-terminal-with-presentation \
-  --after-done "setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &" \
+  --after-done "setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1" \
   "echo ${install_message}; omarchy-pkg-add ${packages_arg}"

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,13 +1,31 @@
 #!/bin/bash
 
 # omarchy:summary=Launch a floating terminal with the Omarchy presentation wrapper
-# omarchy:args=<command>
+# omarchy:args=[--after-done <command>] <command>
 
 # Export the current theme's gum styling so gum widgets match the active theme
 # even after a theme switch (the inherited environment is captured at login).
 source omarchy-restart-gum
 
+after_done=""
+if [[ ${1-} == "--after-done" ]]; then
+  after_done="${2-}"
+  shift 2
+fi
+
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+
+if [[ -n $after_done ]]; then
+  presentation_script="omarchy-show-logo; $cmd
+status=\$?
+if (( status != 130 )); then
+  omarchy-show-done
+  if (( status == 0 )); then
+    $after_done
+  fi
+fi"
+else
+  presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+fi
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -36,7 +36,12 @@ SH
 
 cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
 #!/bin/bash
-printf '%s\n' "$1" >"$OMARCHY_TEST_PRESENTATION"
+if [[ $1 == "--after-done" ]]; then
+  printf '%s\n' "$2" >"$OMARCHY_TEST_AFTER_DONE"
+  printf '%s\n' "$3" >"$OMARCHY_TEST_PRESENTATION"
+else
+  printf '%s\n' "$1" >"$OMARCHY_TEST_PRESENTATION"
+fi
 SH
 
 chmod +x "$mock_bin"/*
@@ -44,6 +49,7 @@ chmod +x "$mock_bin"/*
 export HOME="$test_home"
 export OMARCHY_TEST_LOG="$test_tmp/launch.log"
 export OMARCHY_TEST_PRESENTATION="$test_tmp/presentation"
+export OMARCHY_TEST_AFTER_DONE="$test_tmp/after-done"
 export PATH="$mock_bin:$PATH"
 
 wait_for_launch() {
@@ -79,17 +85,26 @@ assert_detached_installer_launch omarchy-install-gaming-steam steam
 
 bash "$ROOT/bin/omarchy-install-and-launch" "Example App" "alpha beta" "Disk Usage"
 presentation_command=$(<"$OMARCHY_TEST_PRESENTATION")
+after_done=$(<"$OMARCHY_TEST_AFTER_DONE")
 
 [[ $presentation_command == *'echo Installing\ Example\ App...;'* ]] ||
   fail "generic installer shell-quotes the display name" "$presentation_command"
-[[ $presentation_command == *'omarchy-pkg-add alpha beta && (setsid uwsm-app -- gtk-launch Disk\ Usage >/dev/null 2>&1 &)'* ]] ||
-  fail "generic installer waits for packages and detaches only the scoped launch" "$presentation_command"
-pass "generic installer waits for packages and detaches only the scoped launch"
+[[ $presentation_command == *'omarchy-pkg-add alpha beta'* ]] ||
+  fail "generic installer installs packages in the presentation command" "$presentation_command"
+[[ $presentation_command != *gtk-launch* && $presentation_command != *uwsm-app* ]] ||
+  fail "generic installer does not launch during the presentation command" "$presentation_command"
+[[ $after_done == *'setsid uwsm-app -- gtk-launch Disk\ Usage >/dev/null 2>&1 &'* ]] ||
+  fail "generic installer detaches the scoped launch after Done" "$after_done"
+pass "generic installer waits for packages then detaches the scoped launch after Done"
 
 : >"$OMARCHY_TEST_LOG"
 bash -c "$presentation_command"
 grep -Fxq 'pkg:alpha beta' "$OMARCHY_TEST_LOG" ||
   fail "generic installer passes every package to the package helper"
+if grep -q '^launch:' "$OMARCHY_TEST_LOG"; then
+  fail "generic installer does not launch before Done"
+fi
+bash -c "$after_done"
 wait_for_launch 'launch:uwsm-app -- gtk-launch Disk Usage' ||
   fail "generic installer preserves a desktop ID containing spaces"
 pass "generic installer preserves a desktop ID containing spaces"

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -93,7 +93,7 @@ after_done=$(<"$OMARCHY_TEST_AFTER_DONE")
   fail "generic installer installs packages in the presentation command" "$presentation_command"
 [[ $presentation_command != *gtk-launch* && $presentation_command != *uwsm-app* ]] ||
   fail "generic installer does not launch during the presentation command" "$presentation_command"
-[[ $after_done == *'setsid uwsm-app -- gtk-launch Disk\ Usage >/dev/null 2>&1 &'* ]] ||
+[[ $after_done == *'setsid uwsm-app -- gtk-launch Disk\ Usage >/dev/null 2>&1'* ]] ||
   fail "generic installer detaches the scoped launch after Done" "$after_done"
 pass "generic installer waits for packages then detaches the scoped launch after Done"
 

--- a/test/shell.d/install-and-launch-test.sh
+++ b/test/shell.d/install-and-launch-test.sh
@@ -124,6 +124,8 @@ wrapped_cmd=${launcher_args[2]}
   fail "install-and-launch does not background gtk-launch before Done" "$wrapped_cmd"
 [[ $after_done == *'uwsm-app -- gtk-launch Disk\ Usage'* ]] ||
   fail "install-and-launch launches through uwsm-app after Done" "$after_done"
+[[ $after_done != *'& '* && $after_done != *' &' ]] ||
+  fail "install-and-launch does not background gtk-launch" "$after_done"
 pass "install-and-launch sequences gtk-launch after Done, not before it"
 
 script=$(<"$OMARCHY_TEST_SCRIPT")

--- a/test/shell.d/install-and-launch-test.sh
+++ b/test/shell.d/install-and-launch-test.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home"
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+exit "${OMARCHY_TEST_PKG_STATUS:-0}"
+SH
+
+cat >"$mock_bin/omarchy-show-logo" <<'SH'
+#!/bin/bash
+printf 'logo\n' >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/omarchy-show-done" <<'SH'
+#!/bin/bash
+printf 'done\n' >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+if [[ ${1-} == -- ]]; then
+  shift
+fi
+exec "$@"
+SH
+
+cat >"$mock_bin/xdg-terminal-exec" <<'SH'
+#!/bin/bash
+while (($# > 0)); do
+  if [[ $1 == -e ]]; then
+    shift
+    if [[ ${1-} == bash && ${2-} == -c ]]; then
+      printf '%s' "$3" >"$OMARCHY_TEST_SCRIPT"
+    fi
+    exec "$@"
+  fi
+  shift
+done
+exit 1
+SH
+
+cat >"$mock_bin/gtk-launch" <<'SH'
+#!/bin/bash
+printf 'launch:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<SH
+#!/bin/bash
+printf '%s\n' "\$@" >"\$OMARCHY_TEST_ARGS"
+exec "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "\$@"
+SH
+
+chmod +x "$mock_bin"/*
+
+export HOME="$test_home"
+export OMARCHY_TEST_LOG="$test_tmp/sequence.log"
+export OMARCHY_TEST_ARGS="$test_tmp/launcher.args"
+export OMARCHY_TEST_SCRIPT="$test_tmp/presentation.script"
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+
+wait_for_log() {
+  local expected="$1"
+
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    grep -Fxq "$expected" "$OMARCHY_TEST_LOG" && return 0
+    sleep 0.01
+  done
+
+  return 1
+}
+
+assert_log() {
+  local expected="$1"
+  local description="$2"
+  local actual
+
+  actual=$(<"$OMARCHY_TEST_LOG")
+  [[ $actual == "$expected" ]] || fail "$description" "$actual"
+  pass "$description"
+}
+
+run_install() {
+  : >"$OMARCHY_TEST_LOG"
+  : >"$OMARCHY_TEST_ARGS"
+  : >"$OMARCHY_TEST_SCRIPT"
+  bash "$ROOT/bin/omarchy-install-and-launch" "$@" >/dev/null
+}
+
+run_presentation() {
+  : >"$OMARCHY_TEST_LOG"
+  : >"$OMARCHY_TEST_SCRIPT"
+  bash "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "$@" >/dev/null
+}
+
+run_install "Example App" "alpha beta" "Disk Usage"
+
+mapfile -t launcher_args <"$OMARCHY_TEST_ARGS"
+[[ ${launcher_args[0]} == "--after-done" ]] ||
+  fail "install-and-launch hands the wrapper a post-Done command" "$(<"$OMARCHY_TEST_ARGS")"
+after_done=${launcher_args[1]}
+wrapped_cmd=${launcher_args[2]}
+
+[[ $wrapped_cmd == *'echo Installing\ Example\ App...;'* ]] ||
+  fail "install-and-launch shell-quotes the display name" "$wrapped_cmd"
+[[ $wrapped_cmd == *'omarchy-pkg-add alpha beta'* ]] ||
+  fail "install-and-launch installs packages in the presentation command" "$wrapped_cmd"
+[[ $wrapped_cmd != *gtk-launch* && $wrapped_cmd != *uwsm-app* ]] ||
+  fail "install-and-launch does not background gtk-launch before Done" "$wrapped_cmd"
+[[ $after_done == *'uwsm-app -- gtk-launch Disk\ Usage'* ]] ||
+  fail "install-and-launch launches through uwsm-app after Done" "$after_done"
+pass "install-and-launch sequences gtk-launch after Done, not before it"
+
+script=$(<"$OMARCHY_TEST_SCRIPT")
+[[ $script == *omarchy-show-done* ]] || fail "presentation script still prompts Done" "$script"
+[[ $script == *gtk-launch* ]] || fail "presentation script still launches the app" "$script"
+done_hits=$(grep -o 'omarchy-show-done' <<<"$script" | wc -l)
+(( done_hits == 1 )) || fail "presentation script prompts Done once" "$script"
+done_at=${script%%omarchy-show-done*}
+launch_at=${script%%gtk-launch*}
+(( ${#done_at} < ${#launch_at} )) ||
+  fail "presentation script runs gtk-launch after the Done prompt" "$script"
+pass "presentation script runs gtk-launch after a single Done prompt"
+
+wait_for_log 'launch:Disk Usage' ||
+  fail "install-and-launch preserves a desktop ID containing spaces" "$(<"$OMARCHY_TEST_LOG")"
+assert_log $'logo\npkg:alpha beta\ndone\nlaunch:Disk Usage' "runtime order is pkg-add, Done, then gtk-launch"
+
+OMARCHY_TEST_PKG_STATUS=1 run_install "Example App" "alpha beta" "Disk Usage"
+assert_log $'logo\npkg:alpha beta\ndone' "a failed install still shows Done and does not launch"
+
+OMARCHY_TEST_PKG_STATUS=130 run_install "Example App" "alpha beta" "Disk Usage"
+assert_log $'logo\npkg:alpha beta' "Ctrl-C skips Done and does not launch"
+
+unset OMARCHY_TEST_PKG_STATUS
+run_presentation 'omarchy-pkg-add foo'
+assert_log $'logo\npkg:foo\ndone' "a plain presentation caller still gets one Done prompt"
+script=$(<"$OMARCHY_TEST_SCRIPT")
+[[ $script != *gtk-launch* ]] ||
+  fail "a plain presentation caller is unchanged" "$script"
+pass "a plain presentation caller does not launch an app"
+
+OMARCHY_TEST_PKG_STATUS=130 run_presentation 'omarchy-pkg-add foo'
+assert_log $'logo\npkg:foo' "Ctrl-C still skips Done for other callers"


### PR DESCRIPTION
`omarchy-install-and-launch` backgrounded `gtk-launch` during the presentation command, so the new app window stole the keystroke meant to dismiss "Done! Press any key to close...".

The presentation wrapper takes an optional `--after-done` command: pkg-add runs, Done waits, then `setsid uwsm-app -- gtk-launch` runs. Exit 130 still skips both Done and the launch. Other wrapper callers are unchanged.

`install-and-launch-test.sh` logs logo → pkg → done → launch on the success path.

Fixes #8122
