### PR TITLE
Re-arm the sleep delay inhibitor only after resume

### DIFF
--- a/bin/omarchy-system-sleep-monitor
+++ b/bin/omarchy-system-sleep-monitor
@@ -4,20 +4,24 @@
 # omarchy:group=system
 # omarchy:hidden=true
 
+sleep_monitor="$OMARCHY_PATH/bin/omarchy-system-sleep-monitor"
+
 consume_sleep_events() {
-  local line sleep_lock
+  local line wanted=${1:-true} sleep_lock
   sleep_lock="$OMARCHY_PATH/bin/omarchy-system-sleep-lock"
 
   while IFS= read -r line; do
-    if [[ $line == *"boolean true"* ]]; then
-      "$sleep_lock"
+    if [[ $line == *"boolean ${wanted}"* ]]; then
+      if [[ $wanted == "true" ]]; then
+        "$sleep_lock"
+      fi
       return 0
     fi
   done
 }
 
 monitor_sleep_events() {
-  local monitor_fd monitor_pid status
+  local wanted=${1:-true} monitor_fd monitor_pid status
 
   coproc SLEEP_EVENTS {
     exec dbus-monitor --system \
@@ -32,12 +36,72 @@ monitor_sleep_events() {
   }
   trap cleanup_monitor EXIT
 
-  consume_sleep_events <&"$monitor_fd"
+  consume_sleep_events "$wanted" <&"$monitor_fd"
   status=$?
   cleanup_monitor
   trap - EXIT
 
   return "$status"
+}
+
+# logind refuses a second delay inhibitor while PreparingForSleep is still
+# true ("inhibition already running"). Unknown means we cannot ask, not that
+# we are awake.
+sleep_prepare_state() {
+  local value
+  value=$(timeout --kill-after=0.1s 1s busctl get-property \
+    org.freedesktop.login1 /org/freedesktop/login1 \
+    org.freedesktop.login1.Manager PreparingForSleep 2>/dev/null) || {
+    echo unknown
+    return
+  }
+
+  if [[ $value == *"true"* ]]; then
+    echo true
+  else
+    echo false
+  fi
+}
+
+# Backgrounded because bash defers a trap until a foreground command returns
+# but interrupts wait.
+run_child() {
+  "$@" &
+  child_pid=$!
+
+  local status
+  while true; do
+    wait "$child_pid"
+    status=$?
+
+    kill -0 "$child_pid" 2>/dev/null || break
+  done
+
+  child_pid=""
+  return "$status"
+}
+
+wait_until_resume() {
+  if [[ $(sleep_prepare_state) == "false" ]]; then
+    return 0
+  fi
+
+  run_child "$BASH" "$sleep_monitor" --wait-resume
+}
+
+wait_until_idle_awake() {
+  if [[ $(sleep_prepare_state) == "true" ]]; then
+    run_child "$BASH" "$sleep_monitor" --wait-resume
+  fi
+}
+
+acquire_delay_inhibitor() {
+  run_child systemd-inhibit \
+    --what=sleep \
+    --mode=delay \
+    --who=Omarchy \
+    --why="Lock screen before suspend" \
+    "$BASH" "$sleep_monitor" --inhibited
 }
 
 case ${1:-} in
@@ -46,16 +110,42 @@ case ${1:-} in
     exit 0
     ;;
   --inhibited)
-    monitor_sleep_events
+    monitor_sleep_events true
+    exit 0
+    ;;
+  --wait-resume)
+    monitor_sleep_events false
     exit 0
     ;;
 esac
 
-sleep_monitor="$OMARCHY_PATH/bin/omarchy-system-sleep-monitor"
+child_pid=""
+terminating=0
 
-exec systemd-inhibit \
-  --what=sleep \
-  --mode=delay \
-  --who=Omarchy \
-  --why="Lock screen before suspend" \
-  "$sleep_monitor" --inhibited
+stop() {
+  terminating=1
+  [[ -n $child_pid ]] && kill -TERM "$child_pid" 2>/dev/null
+  return 0
+}
+trap stop HUP INT TERM
+
+# Drop the delay inhibitor after locking so suspend can proceed, then wait
+# for PrepareForSleep(false) before taking another. Restart=always cannot
+# re-arm us: RestartSec freezes during suspend and a fast second sleep
+# beats the respawn.
+while true; do
+  if (( terminating )); then
+    exit 0
+  fi
+  wait_until_idle_awake
+
+  if (( terminating )); then
+    exit 0
+  fi
+  acquire_delay_inhibitor
+
+  if (( terminating )); then
+    exit 0
+  fi
+  wait_until_resume
+done

--- a/default/systemd/user/omarchy-sleep-lock.service
+++ b/default/systemd/user/omarchy-sleep-lock.service
@@ -12,6 +12,8 @@ ConditionEnvironment=WAYLAND_DISPLAY
 [Service]
 Type=simple
 ExecStart=/usr/bin/omarchy-system-sleep-monitor
+# The monitor re-arms itself across suspend/resume. Restart=always is a crash
+# net; RestartSec freezes during suspend and cannot beat a fast second sleep.
 Restart=always
 RestartSec=2
 

--- a/test/shell.d/sleep-monitor-test.sh
+++ b/test/shell.d/sleep-monitor-test.sh
@@ -6,7 +6,15 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 sleep_monitor="$ROOT/bin/omarchy-system-sleep-monitor"
 tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+monitor_pid=
+cleanup() {
+  if [[ -n $monitor_pid ]]; then
+    kill "$monitor_pid" 2>/dev/null || true
+    wait "$monitor_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
 
 mock_bin="$tmpdir/bin"
 mock_omarchy="$tmpdir/omarchy"
@@ -22,6 +30,12 @@ while [[ $1 == --* ]]; do
 done
 
 exec "$@"
+SH
+
+cat >"$mock_bin/busctl" <<'SH'
+#!/bin/bash
+
+exit 1
 SH
 
 cat >"$mock_bin/dbus-monitor" <<'SH'
@@ -40,16 +54,19 @@ SH
 
 chmod +x \
   "$mock_bin/systemd-inhibit" \
+  "$mock_bin/busctl" \
   "$mock_bin/dbus-monitor" \
   "$mock_omarchy/bin/omarchy-system-sleep-lock"
 ln -s "$sleep_monitor" "$mock_omarchy/bin/omarchy-system-sleep-monitor"
 
+# --inhibited is the process systemd-inhibit wraps; returning after the lock
+# is what drops the delay inhibitor.
 start_us=${EPOCHREALTIME//[!0-9]/}
 OMARCHY_PATH="$mock_omarchy" \
   PATH="$mock_bin:$PATH" \
   PRODUCER_PID_FILE="$producer_pid_file" \
   LOCK_LOG="$lock_log" \
-  "$sleep_monitor"
+  bash "$sleep_monitor" --inhibited
 elapsed_us=$((10#${EPOCHREALTIME//[!0-9]/} - 10#$start_us))
 
 [[ $(<"$lock_log") == "locked" ]] ||
@@ -82,7 +99,7 @@ OMARCHY_PATH="$mock_omarchy" \
   PATH="$mock_bin:$PATH" \
   PRODUCER_PID_FILE="$producer_pid_file" \
   LOCK_LOG="$lock_log" \
-  "$sleep_monitor" &
+  bash "$sleep_monitor" &
 monitor_pid=$!
 
 for _ in {1..100}; do
@@ -90,17 +107,96 @@ for _ in {1..100}; do
   sleep 0.01
 done
 if [[ ! -s $producer_pid_file ]]; then
-  kill "$monitor_pid" 2>/dev/null || true
-  wait "$monitor_pid" 2>/dev/null || true
   fail "sleep monitor starts its event producer"
 fi
 
 producer_pid=$(<"$producer_pid_file")
 kill "$monitor_pid"
 wait "$monitor_pid" 2>/dev/null || true
+monitor_pid=
 
 if kill -0 "$producer_pid" 2>/dev/null; then
   kill "$producer_pid" 2>/dev/null || true
   fail "sleep monitor cleans up its producer when terminated" "producer still running: $producer_pid"
 fi
 pass "sleep monitor cleans up its producer when terminated"
+
+# A second delay inhibitor while logind is still in PrepareForSleep(true) is
+# the "inhibition already running" failure. After one true, wait for false.
+inhibit_log="$tmpdir/inhibit-log"
+resume_gate="$tmpdir/resume-gate"
+emitted_true="$tmpdir/emitted-true"
+: >"$inhibit_log"
+rm -f "$lock_log" "$resume_gate" "$emitted_true" "$producer_pid_file"
+
+cat >"$mock_bin/systemd-inhibit" <<'SH'
+#!/bin/bash
+
+echo inhibit >>"$INHIBIT_LOG"
+while [[ $1 == --* ]]; do
+  shift
+done
+exec "$@"
+SH
+
+cat >"$mock_bin/dbus-monitor" <<'SH'
+#!/bin/bash
+
+echo "$$" >"$PRODUCER_PID_FILE"
+
+if [[ ! -f $EMITTED_TRUE ]]; then
+  touch "$EMITTED_TRUE"
+  printf '   boolean true\n'
+  exec sleep 30
+fi
+
+while [[ ! -f $RESUME_GATE ]]; do
+  sleep 0.01
+done
+printf '   boolean false\n'
+exec sleep 30
+SH
+
+chmod +x "$mock_bin/systemd-inhibit" "$mock_bin/dbus-monitor"
+
+OMARCHY_PATH="$mock_omarchy" \
+  PATH="$mock_bin:$PATH" \
+  PRODUCER_PID_FILE="$producer_pid_file" \
+  LOCK_LOG="$lock_log" \
+  INHIBIT_LOG="$inhibit_log" \
+  RESUME_GATE="$resume_gate" \
+  EMITTED_TRUE="$emitted_true" \
+  bash "$sleep_monitor" &
+monitor_pid=$!
+
+for _ in {1..200}; do
+  [[ -s $lock_log ]] && break
+  sleep 0.01
+done
+[[ -s $lock_log ]] || fail "sleep monitor locks on the first PrepareForSleep true"
+
+# The inhibitor must already have been dropped (and not retaken) while we
+# are still waiting for resume.
+sleep 0.3
+inhibit_count=$(grep -c '^inhibit$' "$inhibit_log" || true)
+(( inhibit_count == 1 )) ||
+  fail "sleep monitor does not re-take the inhibitor before resume" \
+    "inhibits: $inhibit_count"
+pass "sleep monitor does not re-take the inhibitor before resume"
+
+touch "$resume_gate"
+
+for _ in {1..200}; do
+  inhibit_count=$(grep -c '^inhibit$' "$inhibit_log" || true)
+  (( inhibit_count >= 2 )) && break
+  sleep 0.01
+done
+inhibit_count=$(grep -c '^inhibit$' "$inhibit_log" || true)
+(( inhibit_count >= 2 )) ||
+  fail "sleep monitor re-takes the inhibitor after resume" \
+    "inhibits: $inhibit_count"
+pass "sleep monitor re-takes the inhibitor after resume"
+
+kill "$monitor_pid"
+wait "$monitor_pid" 2>/dev/null || true
+monitor_pid=


### PR DESCRIPTION
`omarchy-system-sleep-monitor` took a delay inhibitor, locked on one `PrepareForSleep(true)`, and exited. Re-arm relied on `Restart=always` / `RestartSec=2`. That timer freezes during suspend; a fast second suspend beats the respawn, and the restarted `systemd-inhibit` hits "inhibition already running".

The monitor now loops in-process: take a delay inhibitor, lock on true, return so systemd-inhibit exits (suspend can proceed), then wait for `PrepareForSleep(false)` before taking another. Do not re-take while logind is still in a sleep transition. `Restart=always` stays as a crash net only.

`sleep-monitor-test.sh` still asserts lock + inhibitor release, and that a second inhibit is not attempted until a false event.

Fixes #8112
