### PR TITLE
Paint the presentation logo with the current theme's green

### DIFF
--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -13,6 +13,12 @@ while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
 
 # Prompt on the terminal rather than stdout, or a caller that redirects us
 # leaves the user waiting on a prompt they were never shown.
-printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+hex=$(omarchy-theme-color green accent 2>/dev/null || true)
+if [[ $hex =~ ^#[0-9A-Fa-f]{6}$ ]]; then
+  hex="${hex#\#}"
+  printf '\n\033[38;2;%d;%d;%dm● \033[0mDone! Press any key to close...' "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}" >/dev/tty
+else
+  printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+fi
 read -rsn 1 </dev/tty
 echo >/dev/tty

--- a/bin/omarchy-show-logo
+++ b/bin/omarchy-show-logo
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-# omarchy:summary=Display the Omarchy logo in the terminal using green color.
+# omarchy:summary=Display the Omarchy logo in the current theme's green
 
 clear
-echo -e "\033[32m"
-cat <$OMARCHY_PATH/logo.txt
+
+# Theme green, else accent, else the stock ANSI 32 the wordmark used to be.
+hex=$(omarchy-theme-color green accent 2>/dev/null || true)
+if [[ $hex =~ ^#[0-9A-Fa-f]{6}$ ]]; then
+  hex="${hex#\#}"
+  printf '\033[38;2;%d;%d;%dm\n' "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}"
+else
+  printf '\033[32m\n'
+fi
+cat <"$OMARCHY_PATH/logo.txt"
 echo -e "\033[0m"
 echo

--- a/test/shell.d/show-logo-test.sh
+++ b/test/shell.d/show-logo-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+omarchy_path="$tmp/omarchy"
+home="$tmp/home"
+theme_dir="$home/.local/state/omarchy/current/theme"
+mkdir -p "$omarchy_path" "$theme_dir" "$tmp/bin"
+
+cp "$ROOT/logo.txt" "$omarchy_path/logo.txt"
+
+# clear dumps terminfo into the capture; the colour is what this file pins.
+printf '#!/bin/bash\n' >"$tmp/bin/clear"
+chmod +x "$tmp/bin/clear"
+
+# omarchy-theme-color needs bash 4 associative arrays. Invoke it with this
+# test's bash rather than the shebang, so the suite can run where /bin/bash is older.
+printf '#!/usr/bin/env bash\nexec bash %q "$@"\n' "$ROOT/bin/omarchy-theme-color" >"$tmp/bin/omarchy-theme-color"
+chmod +x "$tmp/bin/omarchy-theme-color"
+
+run_logo() {
+  HOME="$home" OMARCHY_PATH="$omarchy_path" PATH="$tmp/bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-show-logo"
+}
+
+logo_art=$(cat "$ROOT/logo.txt")
+
+# #9ece6a — Tokyo Night green, and not the stock ANSI 32.
+cat >"$theme_dir/colors.toml" <<'TOML'
+green = "#9ece6a"
+accent = "#7aa2f7"
+TOML
+
+output=$(run_logo)
+green_sgr=$'\033[38;2;158;206;106m'
+[[ $output == *"$green_sgr"* ]] || fail "logo uses the theme's green" "$(printf '%q' "$output")"
+[[ $output == *$'\033[0m'* ]] || fail "logo resets the colour" "$(printf '%q' "$output")"
+[[ $output == *"$logo_art"* ]] || fail "logo art is the wordmark from logo.txt"
+pass "logo uses the theme's green"
+
+# green wins when both keys are present; accent is the fallback when it is not.
+cat >"$theme_dir/colors.toml" <<'TOML'
+accent = "#bb9af7"
+TOML
+
+output=$(run_logo)
+accent_sgr=$'\033[38;2;187;154;247m'
+[[ $output == *"$accent_sgr"* ]] || fail "logo falls back to the theme's accent" "$(printf '%q' "$output")"
+pass "logo falls back to the theme's accent"
+
+rm -rf "$theme_dir"
+output=$(run_logo)
+[[ $output == *$'\033[32m'* ]] || fail "missing theme falls back to ANSI 32" "$(printf '%q' "$output")"
+[[ $output != *$'\033[38;2;'* ]] || fail "missing theme does not emit truecolor" "$(printf '%q' "$output")"
+[[ $output == *$'\033[0m'* ]] || fail "fallback still resets the colour" "$(printf '%q' "$output")"
+[[ $output == *"$logo_art"* ]] || fail "fallback still draws the wordmark from logo.txt"
+pass "missing theme falls back to ANSI 32"

--- a/test/shell.d/show-logo-test.sh
+++ b/test/shell.d/show-logo-test.sh
@@ -20,7 +20,7 @@ chmod +x "$tmp/bin/clear"
 
 # omarchy-theme-color needs bash 4 associative arrays. Invoke it with this
 # test's bash rather than the shebang, so the suite can run where /bin/bash is older.
-printf '#!/usr/bin/env bash\nexec bash %q "$@"\n' "$ROOT/bin/omarchy-theme-color" >"$tmp/bin/omarchy-theme-color"
+printf '#!/bin/bash\nexec %q %q "$@"\n' "$BASH" "$ROOT/bin/omarchy-theme-color" >"$tmp/bin/omarchy-theme-color"
 chmod +x "$tmp/bin/omarchy-theme-color"
 
 run_logo() {


### PR DESCRIPTION
Install, update, and theme-install all draw the wordmark through `omarchy-show-logo`, which hardcoded ANSI 32. A magenta or Tokyo Night rice still got a stock-green logo.

It now asks `omarchy-theme-color` for `green`, then `accent`, converts `#rrggbb` to a truecolor SGR sequence, and falls back to 32 when the palette is missing. The Done bullet in `omarchy-show-done` is the same 32, so it follows. `logo.txt` is still the art.

`show-logo-test.sh` covers theme green, accent-only, and missing colors.toml.
