### PR TITLE
Add omarchy theme next/prev to cycle installed themes

### DIFF
--- a/bin/omarchy-theme-next
+++ b/bin/omarchy-theme-next
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# omarchy:summary=Cycle to the next installed theme
+# omarchy:examples=omarchy theme next
+
+# Display name mapping matches omarchy-theme-list / omarchy-theme-current:
+# tokyo-night → Tokyo Night. omarchy-theme-set accepts either form.
+theme_display_name() {
+  local slug=$1
+  local IFS=-
+  local parts=($slug)
+  local i name=""
+
+  for i in "${!parts[@]}"; do
+    if (( i > 0 )); then
+      name+=" "
+    fi
+    name+=${parts[$i]^}
+  done
+
+  printf '%s\n' "$name"
+}
+
+# Same union as omarchy-theme-list: user dirs/links plus stock dirs.
+mapfile -t slugs < <(
+  {
+    find "$HOME/.config/omarchy/themes/" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print 2>/dev/null
+    find "$OMARCHY_PATH/themes/" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null
+  } | sed 's|.*/||' | sort -u
+)
+total=${#slugs[@]}
+
+if (( total > 0 )); then
+  current=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null || true)
+  index=-1
+  for i in "${!slugs[@]}"; do
+    if [[ ${slugs[$i]} == "$current" ]]; then
+      index=$i
+      break
+    fi
+  done
+
+  if (( index == -1 )); then
+    next_slug="${slugs[0]}"
+  else
+    next_slug="${slugs[$(((index + 1) % total))]}"
+  fi
+
+  next=$(theme_display_name "$next_slug")
+
+  if [[ $next_slug != "$current" ]]; then
+    omarchy-theme-set "$next"
+  fi
+
+  omarchy-notification-send "$next" -t 2000
+fi

--- a/bin/omarchy-theme-prev
+++ b/bin/omarchy-theme-prev
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# omarchy:summary=Cycle to the previous installed theme
+# omarchy:examples=omarchy theme prev
+
+# Display name mapping matches omarchy-theme-list / omarchy-theme-current:
+# tokyo-night → Tokyo Night. omarchy-theme-set accepts either form.
+theme_display_name() {
+  local slug=$1
+  local IFS=-
+  local parts=($slug)
+  local i name=""
+
+  for i in "${!parts[@]}"; do
+    if (( i > 0 )); then
+      name+=" "
+    fi
+    name+=${parts[$i]^}
+  done
+
+  printf '%s\n' "$name"
+}
+
+# Same union as omarchy-theme-list: user dirs/links plus stock dirs.
+mapfile -t slugs < <(
+  {
+    find "$HOME/.config/omarchy/themes/" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print 2>/dev/null
+    find "$OMARCHY_PATH/themes/" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null
+  } | sed 's|.*/||' | sort -u
+)
+total=${#slugs[@]}
+
+if (( total > 0 )); then
+  current=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null || true)
+  index=-1
+  for i in "${!slugs[@]}"; do
+    if [[ ${slugs[$i]} == "$current" ]]; then
+      index=$i
+      break
+    fi
+  done
+
+  if (( index == -1 )); then
+    next_slug="${slugs[$((total - 1))]}"
+  else
+    next_slug="${slugs[$(((index - 1 + total) % total))]}"
+  fi
+
+  next=$(theme_display_name "$next_slug")
+
+  if [[ $next_slug != "$current" ]]; then
+    omarchy-theme-set "$next"
+  fi
+
+  omarchy-notification-send "$next" -t 2000
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -102,6 +102,8 @@
 
   // Style
   "style.theme": {"icon":"󰸌","label":"Theme","aliases":["theme","themes"],"action":"theme=$(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\""},
+  "style.theme-next": {"icon":"󰸌","label":"Next Theme","action":"omarchy-theme-next"},
+  "style.theme-prev": {"icon":"󰸌","label":"Previous Theme","action":"omarchy-theme-prev"},
   "style.background": {"icon":"","label":"Background","aliases":["background","wallpaper"],"action":"background=$(omarchy-theme-bg-switcher); [[ -n $background ]] && omarchy-theme-bg-set \"$background\""},
   "style.unlock": {"icon":"󰟵","label":"Unlock","aliases":["unlock"],"action":"unlock=$(omarchy-plymouth-switcher); if [[ $unlock == default ]]; then omarchy-launch-floating-terminal-with-presentation omarchy-plymouth-reset; elif [[ -n $unlock ]]; then omarchy-launch-floating-terminal-with-presentation \"omarchy-plymouth-set-by-theme '$unlock'\"; fi"},
   "style.font": {"icon":"","label":"Font","provider":"fonts"},

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -336,6 +336,26 @@ assertEqual(
   'omarchy-bar transparent toggle',
   'menu exposes Menu Bar transparency as a toggle'
 )
+const styleIds = defaultItems.filter(item => item.parent === 'style').map(item => item.id)
+const themeAt = styleIds.indexOf('style.theme')
+assert(
+  styleIds[themeAt + 1] === 'style.theme-next' && styleIds[themeAt + 2] === 'style.theme-prev',
+  'menu offers next and previous theme under Style after Theme'
+)
+assertEqual(
+  defaultById['style.theme-next'].action,
+  'omarchy-theme-next',
+  'menu cycles to the next theme from Style'
+)
+assertEqual(
+  defaultById['style.theme-prev'].action,
+  'omarchy-theme-prev',
+  'menu cycles to the previous theme from Style'
+)
+assert(
+  defaultById['style.theme-next'].aliases.length === 0 && defaultById['style.theme-prev'].aliases.length === 0,
+  'menu does not alias the new Style theme cycle rows'
+)
 assertDeepEqual(
   defaultItems.filter(item => item.parent === 'setup.plugin').map(item => item.label),
   ['Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],

--- a/test/shell.d/theme-next-test.sh
+++ b/test/shell.d/theme-next-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+omarchy="$test_tmp/omarchy"
+mock_bin="$test_tmp/bin"
+set_log="$test_tmp/theme-set"
+notify_log="$test_tmp/notify"
+
+mkdir -p "$mock_bin" \
+  "$home/.config/omarchy/themes" \
+  "$home/.local/state/omarchy/current" \
+  "$omarchy/themes"
+
+cat >"$mock_bin/omarchy-theme-set" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_THEME_SET"
+SH
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_NOTIFY"
+SH
+
+chmod +x "$mock_bin"/*
+
+# Stock + user dirs, same union omarchy-theme-list walks. Slugs sort as
+# catppuccin, gruvbox, tokyo-night → Catppuccin, Gruvbox, Tokyo Night.
+mkdir -p "$omarchy/themes/catppuccin" "$omarchy/themes/tokyo-night" \
+  "$home/.config/omarchy/themes/gruvbox"
+
+run_cycle() {
+  : >"$set_log"
+  : >"$notify_log"
+  HOME="$home" OMARCHY_PATH="$omarchy" PATH="$mock_bin:$ROOT/bin:$PATH" \
+    OMARCHY_TEST_THEME_SET="$set_log" OMARCHY_TEST_NOTIFY="$notify_log" \
+    bash "$ROOT/bin/$1"
+}
+
+printf 'gruvbox\n' >"$home/.local/state/omarchy/current/theme.name"
+run_cycle omarchy-theme-next
+grep -Fx 'Tokyo Night' "$set_log" >/dev/null || fail "next from Gruvbox applies Tokyo Night" "$(cat "$set_log")"
+grep -Fq 'Tokyo Night' "$notify_log" >/dev/null || fail "next notifies Tokyo Night" "$(cat "$notify_log")"
+
+printf 'gruvbox\n' >"$home/.local/state/omarchy/current/theme.name"
+run_cycle omarchy-theme-prev
+grep -Fx 'Catppuccin' "$set_log" >/dev/null || fail "prev from Gruvbox applies Catppuccin" "$(cat "$set_log")"
+grep -Fq 'Catppuccin' "$notify_log" >/dev/null || fail "prev notifies Catppuccin" "$(cat "$notify_log")"
+
+printf 'tokyo-night\n' >"$home/.local/state/omarchy/current/theme.name"
+run_cycle omarchy-theme-next
+grep -Fx 'Catppuccin' "$set_log" >/dev/null || fail "next wraps last theme to first" "$(cat "$set_log")"
+
+printf 'catppuccin\n' >"$home/.local/state/omarchy/current/theme.name"
+run_cycle omarchy-theme-prev
+grep -Fx 'Tokyo Night' "$set_log" >/dev/null || fail "prev wraps first theme to last" "$(cat "$set_log")"
+
+rm -rf "$omarchy/themes/tokyo-night" "$home/.config/omarchy/themes/gruvbox"
+printf 'catppuccin\n' >"$home/.local/state/omarchy/current/theme.name"
+run_cycle omarchy-theme-next
+[[ ! -s $set_log ]] || fail "next with one theme does not re-apply" "$(cat "$set_log")"
+grep -Fq 'Catppuccin' "$notify_log" >/dev/null || fail "next with one theme still names it" "$(cat "$notify_log")"
+
+run_cycle omarchy-theme-prev
+[[ ! -s $set_log ]] || fail "prev with one theme does not re-apply" "$(cat "$set_log")"
+
+pass "theme next and prev wrap installed themes"


### PR DESCRIPTION
`omarchy theme bg next` already cycles wallpapers. There was no sibling for themes.

`omarchy theme next` / `omarchy theme prev` walk the same installed-theme union as `omarchy theme list` (stock `$OMARCHY_PATH/themes` plus `~/.config/omarchy/themes`), wrap both ways, and apply through `omarchy-theme-set`. Display names stay on the existing mapping (`tokyo-night` ↔ `Tokyo Night`). One installed theme is a no-op, not an error.

Style menu gets Next Theme / Previous Theme (`style.theme-next`, `style.theme-prev`) with no aliases. No new binding: every SPACE combo in that family is taken.

`theme-next-test.sh` covers wrap both ways and the single-theme no-op.
