### PR TITLE
Make tray icons click targets so the bar dispatches to them

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -292,7 +292,7 @@ BarWidget {
 
             Repeater {
               model: root.drawerItems
-              TrayItem {}
+              TrayItem { inDrawer: true }
             }
           }
         }
@@ -375,7 +375,7 @@ BarWidget {
 
             Repeater {
               model: root.drawerItems
-              TrayItem {}
+              TrayItem { inDrawer: true }
             }
           }
         }
@@ -795,6 +795,13 @@ BarWidget {
     id: trayItemRoot
 
     required property var modelData
+    // Drawer icons live in a clipped strip that is parked outside its own clip
+    // rectangle while collapsed. They still occupy geometry there, so they stay
+    // out of the click registry until the drawer is actually revealed.
+    property bool inDrawer: false
+    property var registeredBar: null
+
+    readonly property bool interactive: !inDrawer || root.revealProgress > 0
 
     visible: modelData.status !== Status.Passive
     implicitWidth: visible ? root.trayItemExtent : 0
@@ -802,6 +809,39 @@ BarWidget {
 
     function displayMenu(mouse) {
       root.openTrayMenu(trayItemRoot.modelData, trayItemRoot, mouse)
+    }
+
+    // The bar routes clicks through its own registry rather than leaving them to
+    // each widget's MouseArea: a slot-wide area takes the press so a drag can
+    // reorder the bar, then hands the click to whichever registered target sits
+    // under the cursor. A tray icon that registers nothing is never a target, so
+    // the click is refused and falls through to the bar's gesture area, where a
+    // double click toggles the bar's transparency instead of activating the
+    // icon. Registering is what every other widget inherits from WidgetButton.
+    function triggerPress(button) {
+      if (root.bar) root.bar.hideTooltip(trayItemRoot)
+
+      // The slot hands over a button but no position, so anchor menus to the
+      // icon itself rather than to wherever the pointer happened to land.
+      var center = { x: trayItemRoot.width / 2, y: trayItemRoot.height / 2 }
+
+      if (button === Qt.RightButton || trayItemRoot.modelData.onlyMenu) trayItemRoot.displayMenu(center)
+      else if (button === Qt.MiddleButton) trayItemRoot.modelData.secondaryActivate()
+      else trayItemRoot.modelData.activate()
+    }
+
+    function syncClickRegistration() {
+      if (registeredBar && registeredBar.unregisterClickTarget) registeredBar.unregisterClickTarget(trayItemRoot)
+      registeredBar = root.bar
+      if (registeredBar && registeredBar.registerClickTarget) registeredBar.registerClickTarget(trayItemRoot)
+    }
+
+    Component.onCompleted: syncClickRegistration()
+    Component.onDestruction: if (registeredBar && registeredBar.unregisterClickTarget) registeredBar.unregisterClickTarget(trayItemRoot)
+
+    Connections {
+      target: root
+      function onBarChanged() { trayItemRoot.syncClickRegistration() }
     }
 
     TrayIcon {

--- a/test/shell.d/tray-click-target-test.sh
+++ b/test/shell.d/tray-click-target-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+bar="$ROOT/shell/plugins/bar/Bar.qml"
+tray="$ROOT/shell/plugins/bar/widgets/Tray.qml"
+widget_button="$ROOT/shell/Ui/WidgetButton.qml"
+
+# The bar does not let a widget's own MouseArea see clicks: a slot-wide area
+# takes the press so a drag can reorder the bar, then hands the click to
+# whichever registered target sits under the cursor. These two lines are the
+# contract every clickable bar surface has to satisfy — pin them, so a widget
+# that stops meeting it fails here rather than by silently swallowing clicks.
+grep -q 'typeof target.triggerPress === "function"' "$bar" ||
+  fail "the bar selects click targets by their triggerPress function"
+grep -q 'if (!root.pressModuleClickTarget(slot, mouse.button, mouse.x, mouse.y)) mouse.accepted = false' "$bar" ||
+  fail "the bar refuses a click no registered target claims"
+pass "the bar dispatches clicks through registered click targets"
+
+# WidgetButton is where every other widget picks the contract up for free.
+grep -q 'function triggerPress' "$widget_button" ||
+  fail "WidgetButton exposes triggerPress"
+grep -q 'registeredBar.registerClickTarget(root)' "$widget_button" ||
+  fail "WidgetButton registers itself as a click target"
+pass "WidgetButton meets the click-target contract"
+
+# Tray icons are not WidgetButtons, so they have to meet it themselves. Without
+# this a left click on a tray icon is refused and falls through to the bar's
+# gesture area, where a double click toggles the bar's transparency.
+grep -q 'function triggerPress' "$tray" ||
+  fail "tray icons expose triggerPress" "a tray icon that cannot be pressed is not a click target"
+grep -q 'registeredBar.registerClickTarget(trayItemRoot)' "$tray" ||
+  fail "tray icons register as click targets"
+grep -q 'registeredBar.unregisterClickTarget(trayItemRoot)' "$tray" ||
+  fail "tray icons unregister their click target"
+grep -q 'Component.onDestruction: if (registeredBar' "$tray" ||
+  fail "tray icons drop their click target when destroyed"
+pass "tray icons meet the click-target contract"
+
+# A left click has to reach the item; the other buttons keep their old meaning.
+trigger_body=$(awk '/function triggerPress\(button\)/,/^    \}/' "$tray")
+grep -q 'modelData.activate()' <<<"$trigger_body" ||
+  fail "a left click activates the tray item"
+grep -q 'Qt.RightButton || trayItemRoot.modelData.onlyMenu' <<<"$trigger_body" ||
+  fail "a right click, and a menu-only item, opens the tray menu"
+grep -q 'Qt.MiddleButton' <<<"$trigger_body" ||
+  fail "a middle click secondary-activates the tray item"
+pass "each mouse button keeps its meaning through the bar's dispatch"
+
+# Collapsed drawer icons are parked outside their clip rectangle but still hold
+# geometry there, so they must not be selectable until the drawer is revealed.
+grep -q 'readonly property bool interactive: !inDrawer || root.revealProgress > 0' "$tray" ||
+  fail "drawer icons stay unclickable until the drawer is revealed"
+(( $(grep -c 'TrayItem { inDrawer: true }' "$tray") == 2 )) ||
+  fail "both drawer repeaters mark their icons as drawer icons" \
+    "found $(grep -c 'TrayItem { inDrawer: true }' "$tray"), expected 2 (horizontal and vertical bars)"
+grep -q 'target.interactive !== false' "$bar" ||
+  fail "the bar honours a target's interactive flag when selecting it"
+pass "drawer icons are only click targets once revealed"


### PR DESCRIPTION
Fixes #8111.

The bar does not leave clicks to a widget's own `MouseArea`. A slot-wide area takes the press so a drag can reorder the bar, then hands the click to whichever registered target sits under the cursor (`Bar.qml` → `pressModuleClickTarget` → `moduleClickTargetAt`). Selection requires a `triggerPress` function on the target, and `WidgetButton` is where every other widget picks that up for free.

`TrayItem` is not a `WidgetButton` and registered nothing, so a left click on a tray icon found no target, `pressModuleClickTarget` returned false, and `Bar.qml` set `mouse.accepted = false`. The unclaimed click fell through to `CenterGestureArea` — which despite the name is `anchors.fill: parent` across the whole bar — so a double click on a tray icon toggled the bar's transparency and rewrote `bar.transparent` in `shell.json` instead of activating the icon.

There is a third symptom the report does not mention: `Bar.qml:1667` derives `cursorShape` from the same lookup, so tray icons also showed an arrow rather than a pointing hand.

This gives `TrayItem` the `triggerPress` and registry wiring `WidgetButton` provides, so tray icons take part in the same dispatch as every other widget. Left click activates, middle click secondary-activates, and a right click or a menu-only item opens the menu. The slot hands over a button but no position, so menus anchor to the icon rather than to wherever the pointer landed.

Drawer icons opt in with `inDrawer: true` and stay out of the registry until the drawer is revealed: while collapsed the row is parked at `x: drawerExtent` — outside its own clip rectangle — but still holds geometry there, so registering it unconditionally would let a click on the pinned row map onto a hidden icon.

Right and middle clicks keep working exactly as before and cannot double-fire: both slot `MouseArea`s are `acceptedButtons: Qt.LeftButton`, so those buttons still reach the tray's own `MouseArea`, and on a left click that `MouseArea` never sees the press.

`test/shell.d/tray-click-target-test.sh` pins the contract across all three files — that `Bar.qml` still selects targets by `triggerPress` and refuses unclaimed clicks, that `WidgetButton` meets it, and that tray icons now do too. The Bar and WidgetButton assertions pass against the current tree, so the test is not just asserting the new code back to itself; the tray assertions fail on it (`not ok - tray icons expose triggerPress`) and pass with this change. `tray-menu-test.sh` still passes, so the existing DBusMenu path is unchanged.

Not verified in a live session: I do not have a tray app pinned on a bar built from this checkout. The reproduction in the issue (`udiskie --tray`, pin it, left click) is the check worth running.