### PR TITLE
Keep the Windows VM display fully opaque

### DIFF
--- a/default/hypr/apps/windows-vm.lua
+++ b/default/hypr/apps/windows-vm.lua
@@ -1,0 +1,5 @@
+-- Keep the Windows VM display opaque instead of applying the default window opacity.
+o.window({ class = "^xfreerdp$", title = "^Windows VM - Omarchy$" }, {
+  tag = "-default-opacity",
+  opacity = "1 1",
+})

--- a/test/shell.d/windows-vm-test.sh
+++ b/test/shell.d/windows-vm-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 windows_vm_command="$ROOT/bin/omarchy-windows-vm"
+windows_vm_rules="$ROOT/default/hypr/apps/windows-vm.lua"
 
 rg -q '^    restart: "no"$' "$windows_vm_command" ||
   fail "Windows VM uses manual startup by default"
@@ -14,3 +15,13 @@ if rg -q '^    restart: unless-stopped$' "$windows_vm_command"; then
   fail "Windows VM does not restart automatically at boot"
 fi
 pass "Windows VM does not restart automatically at boot"
+
+rg -q '/title:"Windows VM - Omarchy"' "$windows_vm_command" ||
+  fail "Windows VM launches FreeRDP with its expected title"
+rg -q 'class = "\^xfreerdp\$", title = "\^Windows VM - Omarchy\$"' "$windows_vm_rules" ||
+  fail "Windows VM opacity rule targets its FreeRDP window"
+rg -q 'tag = "-default-opacity"' "$windows_vm_rules" ||
+  fail "Windows VM opts out of default opacity"
+rg -q 'opacity = "1 1"' "$windows_vm_rules" ||
+  fail "Windows VM stays fully opaque"
+pass "Windows VM stays fully opaque"

--- a/test/shell.d/windows-vm-test.sh
+++ b/test/shell.d/windows-vm-test.sh
@@ -16,7 +16,9 @@ if rg -q '^    restart: unless-stopped$' "$windows_vm_command"; then
 fi
 pass "Windows VM does not restart automatically at boot"
 
-rg -q '/title:"Windows VM - Omarchy"' "$windows_vm_command" ||
+# Tolerate either shell quoting of the argument -- what must not drift is the
+# title itself, since the Hyprland rule below matches on it.
+rg -q 'title:"?Windows VM - Omarchy"' "$windows_vm_command" ||
   fail "Windows VM launches FreeRDP with its expected title"
 rg -q 'class = "\^xfreerdp\$", title = "\^Windows VM - Omarchy\$"' "$windows_vm_rules" ||
   fail "Windows VM opacity rule targets its FreeRDP window"


### PR DESCRIPTION
Omarchy excludes QEMU windows from the default opacity, but the built-in Windows VM is displayed by FreeRDP instead. Its `xfreerdp` window therefore inherits the default active and inactive transparency, allowing the Omarchy wallpaper to bleed through the Windows desktop and applications.

Match the class and title set by `omarchy-windows-vm`, remove the `default-opacity` tag, and keep both active and inactive opacity at 1. The title constraint keeps unrelated FreeRDP sessions unchanged.

The regression test ties the launcher title to the Hyprland rule and verifies that the VM opts out of default opacity.

## Testing

- `luac -p default/hypr/apps/windows-vm.lua`
- `bash test/shell.d/windows-vm-test.sh`
- `git diff --cached --check`
- Confirmed on a live XWayland window that the rule removed the `default-opacity` tag and kept the Windows desktop fully opaque both focused and unfocused
