### PR TITLE
Skip the Neovim clipboard provider when omarchy-nvim is not installed

### DIFF
--- a/migrations/1781587663.sh
+++ b/migrations/1781587663.sh
@@ -4,9 +4,12 @@ nvim_config_dir="$HOME/.config/nvim"
 nvim_options="$nvim_config_dir/lua/config/options.lua"
 nvim_provider="$nvim_config_dir/lua/config/remote_clipboard.lua"
 
-provider_source="/usr/share/omarchy-nvim/config/lua/config/remote_clipboard.lua"
+provider_source="${OMARCHY_NVIM_REMOTE_CLIPBOARD:-/usr/share/omarchy-nvim/config/lua/config/remote_clipboard.lua}"
 
-if [[ -d $nvim_config_dir ]]; then
+# The provider ships in omarchy-nvim, a package a user running their own Neovim
+# config can drop, so its absence is normal and not a reason to abort. Bailing
+# out here would take the migration queue and the rest of the update with it.
+if [[ -d $nvim_config_dir && -f $provider_source ]]; then
   mkdir -p "$(dirname "$nvim_provider")"
   install -m 0644 "$provider_source" "$nvim_provider"
 

--- a/test/shell.d/nvim-remote-clipboard-migration-test.sh
+++ b/test/shell.d/nvim-remote-clipboard-migration-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1781587663.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+nvim_config_dir="$home/.config/nvim"
+nvim_options="$nvim_config_dir/lua/config/options.lua"
+nvim_provider="$nvim_config_dir/lua/config/remote_clipboard.lua"
+tmux_config="$home/.config/tmux/tmux.conf"
+
+provider_source="$test_dir/share/remote_clipboard.lua"
+mkdir -p "$(dirname "$provider_source")"
+printf '%s\n' 'return { setup = function() end }' >"$provider_source"
+
+run_migration() {
+  HOME="$home" OMARCHY_NVIM_REMOTE_CLIPBOARD="${1:-$provider_source}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+reset_home() {
+  rm -rf "$home"
+  mkdir -p "$home/.config/tmux"
+  printf '%s\n' 'set -g mouse on' >"$tmux_config"
+}
+
+# ------------------------------------------------------------ provider present
+
+reset_home
+mkdir -p "$(dirname "$nvim_options")"
+printf '%s\n' 'vim.opt.number = true' >"$nvim_options"
+
+run_migration
+
+[[ -f $nvim_provider ]] || fail "an installed provider lands in the user's Neovim config"
+[[ $(stat -c %a "$nvim_provider") == "644" ]] ||
+  fail "the installed provider keeps the shipped mode" "$(stat -c %a "$nvim_provider")"
+head -n 1 "$nvim_options" | grep -qF 'require("config.remote_clipboard").setup()' ||
+  fail "the provider is required from options.lua" "$(cat "$nvim_options")"
+pass "an installed provider lands in the user's Neovim config"
+
+before=$(sha256sum "$nvim_options")
+run_migration
+[[ $before == $(sha256sum "$nvim_options") ]] || fail "requiring the provider is idempotent" "$(cat "$nvim_options")"
+pass "requiring the provider is idempotent"
+
+# ------------------------------------------------------------ provider missing
+
+# omarchy-nvim is its own package. Someone running their own Neovim config can
+# drop it and keep ~/.config/nvim, and that must not fail the migration: a
+# non-zero exit here ends the migration queue and the rest of omarchy update.
+reset_home
+mkdir -p "$(dirname "$nvim_options")"
+printf '%s\n' 'vim.opt.number = true' >"$nvim_options"
+
+run_migration "$test_dir/share/absent.lua" ||
+  fail "a missing provider leaves the migration succeeding"
+pass "a missing provider leaves the migration succeeding"
+
+[[ ! -e $nvim_provider ]] || fail "a missing provider writes no half-installed file"
+grep -qF 'config.remote_clipboard' "$nvim_options" &&
+  fail "a missing provider is not required from options.lua" "$(cat "$nvim_options")"
+pass "a missing provider writes nothing into the Neovim config"
+
+# The tmux half of this migration stands on its own, so it still has to run for
+# someone without the package.
+grep -qF 'set -as terminal-features ",*:clipboard"' "$tmux_config" ||
+  fail "a missing provider still gets the tmux clipboard feature" "$(cat "$tmux_config")"
+pass "a missing provider still gets the tmux clipboard feature"
+
+before=$(sha256sum "$tmux_config")
+run_migration "$test_dir/share/absent.lua"
+[[ $before == $(sha256sum "$tmux_config") ]] || fail "the tmux clipboard feature is added once" "$(cat "$tmux_config")"
+pass "the tmux clipboard feature is added once"
+
+# ------------------------------------------------------------- no Neovim config
+
+reset_home
+run_migration
+
+[[ ! -e $nvim_config_dir ]] || fail "no Neovim config means no Neovim config is created"
+pass "no Neovim config means no Neovim config is created"


### PR DESCRIPTION
Fixes #7108.

`migrations/1781587663.sh` guards on the user's `~/.config/nvim` existing, then installs a file that ships in the separate `omarchy-nvim` package:

```bash
if [[ -d $nvim_config_dir ]]; then
  mkdir -p "$(dirname "$nvim_provider")"
  install -m 0644 "$provider_source" "$nvim_provider"
```

Someone running their own Neovim config who dropped that package gets:

```
install: cannot stat '/usr/share/omarchy-nvim/config/lua/config/remote_clipboard.lua': No such file or directory
```

`bin/omarchy-migrate:93` runs every migration under `bash -euo pipefail`, so that exit status ends the migration queue and every remaining step of `omarchy update` behind it. No marker gets written, so the next update repeats the same failure.

`migrations/1784809451.sh:16` already guards its source file this way after the same class of bug.

## What changed

The source file joins the existing guard instead of exiting the script early. The tmux OSC 52 half of this migration does not depend on `omarchy-nvim`, and a top level bail would skip it permanently once the marker lands.

The source path now reads from `OMARCHY_NVIM_REMOTE_CLIPBOARD` with the same default, matching how `1784809451.sh` and `1784809452.sh` expose their absolute paths so tests can point them at a temp file.

Editing the migration in place is safe here: anyone who hit the failure never got a marker, so they pick up the fixed version on their next update.

## Tests

New `test/shell.d/nvim-remote-clipboard-migration-test.sh`, 7 assertions. Reverting the guard reproduces the reported `install: cannot stat` failure against it.

All migration tests pass locally. `test/shell.d/copy-url-shortcut-migration-test.sh` hangs on my machine, on this branch and on its parent commit alike, so it is unrelated.
