### PR TITLE
Supervise hyprsunset so night light survives a crash

### DIFF
--- a/bin/omarchy-restart-hyprsunset
+++ b/bin/omarchy-restart-hyprsunset
@@ -2,4 +2,7 @@
 
 # omarchy:summary=Restart the hyprsunset service (used for blue light filtering/night light).
 
-omarchy-restart-app hyprsunset
+# hyprsunset runs as a systemd user service, so restart it there rather than
+# through omarchy-restart-app: pkill would race the unit's own Restart=, and
+# uwsm-app would leave a second, unsupervised copy alongside the unit's.
+systemctl --user restart hyprsunset.service

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Toggle nightlight screen temperature
-# omarchy:args=[--status]
+# omarchy:args=[--status|--apply|on|off]
 # omarchy:examples=omarchy toggle nightlight
 
 ON_TEMP=4000
@@ -29,31 +29,65 @@ status_json() {
     '{enabled:$enabled, temperature:(($temp | tonumber?) // null)}'
 }
 
-if [[ ${1:-} == "--status" ]]; then
-  status_json
-  exit 0
-fi
-
-# Ensure hyprsunset is running
-if ! pgrep -x hyprsunset >/dev/null; then
-  setsid uwsm-app -- hyprsunset &
-fi
-
-# Query the current temperature
-CURRENT_TEMP=$(current_temp)
-
-if [[ -z $CURRENT_TEMP || $CURRENT_TEMP == $OFF_TEMP ]]; then
-  TARGET_TEMP=$ON_TEMP
-else
-  TARGET_TEMP=$OFF_TEMP
-fi
-
 # A freshly-started hyprsunset applies its default temperature at the end of
 # its boot, overriding anything set before then — so resend until it sticks
-for _ in {1..10}; do
-  hyprctl hyprsunset temperature $TARGET_TEMP >/dev/null 2>&1
-  sleep 0.2
-  [[ $(current_temp) == "$TARGET_TEMP" ]] && break
-done
+apply_temp() {
+  local target=$1
 
-omarchy-shell -q nightlight refresh
+  for _ in {1..10}; do
+    hyprctl hyprsunset temperature $target >/dev/null 2>&1
+    sleep 0.2
+    [[ $(current_temp) == "$target" ]] && break
+  done
+
+  omarchy-shell -q nightlight refresh
+}
+
+case ${1:-} in
+  --status)
+    status_json
+    exit 0
+    ;;
+  --apply)
+    # Run from hyprsunset.service's ExecStartPost. Every hyprsunset start
+    # re-reads hyprsunset.conf, whose shipped profile is identity, so one that
+    # died holding night light comes back neutral — a healthy daemon and a cold
+    # screen. Re-assert the temperature the toggle last asked for.
+    #
+    # Only when the flag is set: with night light off, hyprsunset.conf is the
+    # standing intent, and forcing a temperature here would stomp the scheduled
+    # profiles the manual points people at. Never starts the unit either, or it
+    # would recurse into the start job it is part of.
+    omarchy-toggle-enabled nightlight || exit 0
+    apply_temp $ON_TEMP
+    exit 0
+    ;;
+  on) TARGET_TEMP=$ON_TEMP ;;
+  off) TARGET_TEMP=$OFF_TEMP ;;
+  *)
+    # Read the direction off the screen rather than the flag, so a toggle still
+    # does the obvious thing when the two have drifted apart.
+    CURRENT_TEMP=$(current_temp)
+
+    if [[ -z $CURRENT_TEMP || $CURRENT_TEMP == $OFF_TEMP ]]; then
+      TARGET_TEMP=$ON_TEMP
+    else
+      TARGET_TEMP=$OFF_TEMP
+    fi
+    ;;
+esac
+
+# Record the intent before starting hyprsunset, so the service's own re-apply
+# sees the new state rather than the one being replaced.
+if (( TARGET_TEMP == ON_TEMP )); then
+  omarchy-toggle nightlight on
+else
+  omarchy-toggle nightlight off
+fi
+
+# hyprsunset runs as a systemd user service so a crash comes back on its own.
+# --no-block: the start job runs --apply above, and waiting for it here would
+# just pay for the same resend loop twice. The loop below waits for the socket.
+systemctl --user start --no-block hyprsunset.service >/dev/null
+
+apply_temp $TARGET_TEMP

--- a/default/systemd/user/hyprsunset.service.d/10-omarchy.conf
+++ b/default/systemd/user/hyprsunset.service.d/10-omarchy.conf
@@ -1,0 +1,20 @@
+# Restore night light along with the daemon.
+#
+# hyprsunset ships its own unit with Restart=on-failure, so the process comes
+# back by itself. The temperature does not: every start re-reads
+# hyprsunset.conf, and Omarchy's shipped profile is `identity = true`, so a
+# hyprsunset killed while holding night light returns neutral. The user is left
+# with a healthy daemon and a cold screen, which is the half of the failure they
+# actually notice.
+#
+# A monitor hotplug is enough to cause it. Destroying a wl_output global
+# disconnects every client with a bind still in flight, and hyprsunset aborts
+# with the rest of them.
+#
+# --apply re-asserts only what the toggle asked for, leaving a scheduled profile
+# in hyprsunset.conf to govern itself, and never starts the unit, so it cannot
+# recurse into this job. The leading `-` keeps a failed re-apply from failing
+# the start: with Restart=on-failure that would turn a missed tint into a
+# restart loop.
+[Service]
+ExecStartPost=-/usr/bin/omarchy-toggle-nightlight --apply

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -124,6 +124,7 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ applications/mimeapps.list                         /usr/share/applications/mimeapps.list
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
+  ├─ systemd/user/hyprsunset.service.d/10-omarchy.conf  /usr/lib/systemd/user/hyprsunset.service.d/
   ├─ systemd/system-sleep/{force-igpu,
   │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -52,7 +52,7 @@ profile {
 }
 ```
 
-Then start hyprsunset at login by adding `o.launch_on_start("hyprsunset")` to `~/.config/hypr/autostart.lua`. The 4000K/6500K pair used by the toggle is fixed, so the config file is where you go if you want a different temperature.
+Then start hyprsunset at login with `systemctl --user enable --now hyprsunset.service`. Running it as a user service rather than a plain autostart line means a hyprsunset that dies gets restarted — a monitor hotplug can disconnect every Wayland client at once, and an unsupervised one would take your whole schedule down with it until the next login. The 4000K/6500K pair used by the toggle is fixed, so the config file is where you go if you want a different temperature.
 
 ### Do not disturb
 

--- a/migrations/1787634461.sh
+++ b/migrations/1787634461.sh
@@ -1,0 +1,74 @@
+echo "Supervise hyprsunset so night light can't silently die"
+
+# hyprsunset was started fire-and-forget, from the nightlight toggle and from
+# the shell's nightlight service. Nothing restarted it and nothing noticed when
+# it went away, so one death left the screen cold for the rest of the session.
+# A monitor hotplug is enough to cause it: destroying a wl_output global
+# disconnects every client with a bind still in flight, and hyprsunset aborts
+# along with the browser and the shell.
+#
+# It runs through hyprsunset.service now, which the hyprsunset package ships
+# with Restart=on-failure, plus an Omarchy drop-in that re-applies the
+# temperature the daemon comes back without.
+
+user_config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+autostart="$user_config_home/hypr/autostart.lua"
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# The manual used to point schedule users at an autostart line. That copy is
+# unsupervised and would also fight the unit's, so retire it and enable the unit
+# for exactly the users who had it -- night light is off by default, and nobody
+# else should gain a daemon at login from this. Anchored past any `--`, so a line
+# someone had already commented out is left alone rather than read as intent.
+scheduled=0
+pattern='^[[:space:]]*o\.launch_on_start\("hyprsunset"\)'
+if [[ -f $autostart ]] && grep -Eq "$pattern" "$autostart"; then
+  scheduled=1
+  sed -Ei "\\|$pattern|d" "$autostart"
+fi
+
+if ((scheduled)); then
+  # Enable without --now; the start below is conditional on there being a
+  # session to start into. `systemctl enable` needs a live user manager, which
+  # an `omarchy update` from a TTY does not have, so fall back to writing
+  # exactly the symlink it would have written rather than leaving this unenabled.
+  if ! systemctl --user enable hyprsunset.service >/dev/null 2>&1; then
+    wants_dir="$user_config_home/systemd/user/graphical-session.target.wants"
+    mkdir -p "$wants_dir"
+    ln -sfn /usr/lib/systemd/user/hyprsunset.service \
+      "$wants_dir/hyprsunset.service"
+  fi
+fi
+
+# Outside a graphical session -- an update over SSH -- there is nothing to hand
+# over: no stray hyprsunset to replace, and the unit's own ConditionEnvironment
+# would skip the start anyway. Any enablement above is the whole job.
+systemctl --user is-active --quiet graphical-session.target || exit 0
+
+# Nothing running means nothing to migrate. Don't start one: night light is a
+# toggle, and this migration is not the user asking for it.
+pgrep -x hyprsunset >/dev/null || exit 0
+
+# Already under the unit from an earlier run of this migration.
+systemctl --user is-active --quiet hyprsunset.service && exit 0
+
+# Carry the current temperature across the handover. The flag is new, so a
+# hyprsunset holding night light right now has nothing recording that yet, and
+# the drop-in's re-apply would bring it back neutral.
+temperature=$(hyprctl hyprsunset temperature 2>/dev/null | grep -oE '[0-9]+' | head -n1)
+if [[ -n $temperature ]] && ((temperature < 6000)); then
+  omarchy-toggle nightlight on
+fi
+
+# The two can't coexist: a second hyprsunset fails to bind the socket the first
+# owns, and Restart=on-failure would turn that into a restart loop.
+pkill -x hyprsunset >/dev/null 2>&1 || true
+
+# Report what systemctl actually said. This kills a hyprsunset that was working
+# a moment ago, so a start failure has to be loud rather than leaving the screen
+# stuck and the migration marked complete.
+if ! error=$(systemctl --user start hyprsunset.service 2>&1); then
+  echo "Could not start hyprsunset.service: $error"
+  echo "Night light will not work until the next login."
+fi

--- a/shell/plugins/services/nightlight/Service.qml
+++ b/shell/plugins/services/nightlight/Service.qml
@@ -8,8 +8,8 @@ Item {
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
 
-  // Keep in sync with bin/omarchy-toggle-nightlight, which sets the same
-  // temperatures for callers outside the shell (keybindings, menu, ssh).
+  // Only for the optimistic display below: applying goes through
+  // omarchy-toggle-nightlight, which owns the temperatures these mirror.
   readonly property int nightTemperature: 4000
   readonly property int dayTemperature: 6500
 
@@ -46,9 +46,12 @@ Item {
   }
 
   function runApply(temp) {
-    applyProcess.command = ["bash", "-lc",
-      "pgrep -x hyprsunset >/dev/null || { setsid uwsm-app -- hyprsunset >/dev/null 2>&1 & sleep 1; }; " +
-      "hyprctl hyprsunset temperature " + Number(temp)]
+    // Delegate rather than drive hyprsunset from here. The command starts it
+    // through its systemd user service, so a hyprsunset that dies is restarted,
+    // and it records the choice where that restart can read it back — which
+    // this service cannot do, since a shell restart loses the state above.
+    applyProcess.command = ["omarchy-toggle-nightlight",
+      temp === root.nightTemperature ? "on" : "off"]
     applyProcess.running = true
   }
 

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -37,22 +37,31 @@ fi
 exit 1
 SH
 
-cat >"$TMPDIR/bin/pgrep" <<'SH'
-#!/bin/bash
-exit 0
-SH
-
 cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >>"$OMARCHY_SHELL_LOG"
 SH
 
-chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/pgrep" "$TMPDIR/bin/omarchy-shell"
+# Stubbed, or the suite would start a real hyprsunset on the dev machine.
+cat >"$TMPDIR/bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+SH
 
+chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/omarchy-shell" "$TMPDIR/bin/systemctl"
+
+SYSTEMCTL_LOG="$TMPDIR/systemctl-log"
+FAKE_HOME="$TMPDIR/home"
+FLAG="$FAKE_HOME/.local/state/omarchy/toggles/nightlight"
+
+# $ROOT/bin on PATH so omarchy-toggle and omarchy-toggle-enabled are the repo's
+# own, not whatever version is installed on the machine running the suite.
 nightlight_cli() {
-  PATH="$TMPDIR/bin:$PATH" \
+  PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  HOME="$FAKE_HOME" \
   HYPRSUNSET_STATE="$STATE" \
   OMARCHY_SHELL_LOG="$SHELL_LOG" \
+  SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
     "$ROOT/bin/omarchy-toggle-nightlight" "$@"
 }
 
@@ -90,3 +99,62 @@ if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"
 fi
 pass "nightlight toggle leaves indicator refresh to the nightlight service"
+
+# hyprsunset has to come back on its own after a crash: a monitor hotplug
+# disconnects every Wayland client with a bind in flight and takes it with them.
+# An unsupervised copy left night light off for the rest of the session.
+
+printf '6500\n' >"$STATE"
+: >"$SYSTEMCTL_LOG"
+nightlight_cli on >/dev/null
+[[ $(<"$STATE") == 4000 ]] || fail "nightlight accepts an explicit on"
+pass "nightlight accepts an explicit on"
+
+grep -Fqx -- '--user start --no-block hyprsunset.service' "$SYSTEMCTL_LOG" ||
+  fail "nightlight starts hyprsunset through its systemd user service"
+pass "nightlight starts hyprsunset through its systemd user service"
+
+[[ -f $FLAG ]] || fail "nightlight records the toggle so a restart can restore it"
+pass "nightlight records the toggle so a restart can restore it"
+
+nightlight_cli off >/dev/null
+[[ $(<"$STATE") == 6500 ]] || fail "nightlight accepts an explicit off"
+pass "nightlight accepts an explicit off"
+
+[[ -f $FLAG ]] && fail "nightlight clears the record when switched off"
+pass "nightlight clears the record when switched off"
+
+# What the service's ExecStartPost runs. hyprsunset re-reads its config on every
+# start, and Omarchy ships an identity profile, so a restart returns neutral.
+nightlight_cli on >/dev/null
+printf '6500\n' >"$STATE"
+: >"$SYSTEMCTL_LOG"
+nightlight_cli --apply >/dev/null
+[[ $(<"$STATE") == 4000 ]] || fail "nightlight re-applies the tint a restarted hyprsunset came back without"
+pass "nightlight re-applies the tint a restarted hyprsunset came back without"
+
+[[ -s $SYSTEMCTL_LOG ]] && fail "nightlight re-apply never starts the unit it runs inside"
+pass "nightlight re-apply never starts the unit it runs inside"
+
+# With night light off, hyprsunset.conf is the standing intent. Forcing a
+# temperature here would stomp the scheduled profiles the manual points at.
+nightlight_cli off >/dev/null
+printf '4000\n' >"$STATE"
+nightlight_cli --apply >/dev/null
+[[ $(<"$STATE") == 4000 ]] || fail "nightlight re-apply leaves a scheduled profile alone when switched off"
+pass "nightlight re-apply leaves a scheduled profile alone when switched off"
+
+# Comments stripped first: these files explain in prose why they no longer reach
+# for uwsm-app, and the guard is about what they run, not what they mention.
+for path in bin/omarchy-toggle-nightlight bin/omarchy-restart-hyprsunset \
+  shell/plugins/services/nightlight/Service.qml; do
+  if rg -N --invert-match '^\s*(#|//)' "$ROOT/$path" | rg -q 'uwsm-app'; then
+    fail "$path leaves starting hyprsunset to its systemd user service"
+  fi
+done
+pass "nightlight never starts an unsupervised hyprsunset"
+
+rg -q 'ExecStartPost=-/usr/bin/omarchy-toggle-nightlight --apply' \
+  "$ROOT/default/systemd/user/hyprsunset.service.d/10-omarchy.conf" ||
+  fail "hyprsunset drop-in re-applies the temperature after a restart"
+pass "hyprsunset drop-in re-applies the temperature after a restart"


### PR DESCRIPTION
Fixes #8161.

hyprsunset was started fire-and-forget — `setsid uwsm-app -- hyprsunset &`, from both `omarchy-toggle-nightlight` and the shell's nightlight service. Nothing restarted it and nothing noticed when it went away, so a single death left the screen cold for the rest of the session.

That is not hypothetical. A monitor hotplug destroys a `wl_output` global, which disconnects every Wayland client with a bind still in flight:

```
XWAYLAND: wl_registry#2: error 0: global wl_output (73) is unavailable
```

Thirteen clients died together on the machine this came from. The shell relaunched itself and `omarchy-fcitx5.service` restarted on its own policy; hyprsunset stayed dead, and night light was silently off for thirteen hours.

## What changed

hyprsunset now runs through `hyprsunset.service`, which the hyprsunset package already ships with `Restart=on-failure`, `PartOf=graphical-session.target` and `ConditionEnvironment=WAYLAND_DISPLAY` — the shape `plans/remote.md` already argues for, and the workaround people converge on in #1434.

Restarting the daemon is only half of it. Every hyprsunset start re-reads `hyprsunset.conf`, whose shipped profile is `identity = true`, so a restarted one comes back neutral: a healthy daemon and a cold screen, which is the half users actually notice. A drop-in adds `ExecStartPost=-/usr/bin/omarchy-toggle-nightlight --apply`, and the toggle records its choice in `toggles/nightlight` so that re-apply has something to read — the shell couldn't hold that state itself, since it restarts in the same events.

`--apply` re-asserts a temperature only when the toggle flag is set. With night light off, `hyprsunset.conf` is the standing intent, so a scheduled profile is left to govern itself rather than being overwritten with 6500K. It also never starts the unit, so it can't recurse into the start job it runs inside.

While in here, the shell's nightlight service stopped driving hyprsunset itself and calls `omarchy-toggle-nightlight on|off` instead, which retires the duplicated start logic and the "keep in sync" comment over the temperatures.

The manual pointed schedule users at `o.launch_on_start("hyprsunset")`, which is unsupervised too — those users lose the whole schedule, not just a toggle. It now points at `systemctl --user enable --now hyprsunset.service`, and a migration retires the autostart line and enables the unit for exactly the users who had it. The pattern is anchored past any `--` so a line someone had already commented out is left alone rather than read as intent.

## Verification

- `test/shell.d/nightlight-test.sh` — 24 assertions, including that the toggle starts hyprsunset through the unit and never through `uwsm-app`, that `--apply` restores the tint, that it doesn't start the unit it runs inside, and that it leaves a scheduled profile alone when night light is off. `systemctl` is stubbed so the suite can't start a real hyprsunset.
- Migration exercised against a sandboxed `HOME`/`XDG_CONFIG_HOME` for the active-line, commented-out-line, no-session and already-migrated cases, including a second run for idempotency.
- End to end on a live session: with night light on, `kill -KILL $(pgrep -x hyprsunset)` brought it back within a second under a new pid with 4000K restored. Before this change the same kill left it dead indefinitely.
- `./test/cli` green. `./test/shell` leaves the same five unrelated files failing as on a clean `origin/quattro` checkout (`agent-usage-claude-scanner`, `config`, `runtime-smoke`, `snapper`, `unowned-system-paths`).

## Not addressed here

The crash that surfaced this was Chrome taking `SIGTRAP` in the same event. Both halves of that are upstream: Chrome treats a Wayland protocol error as fatal by design, and destroying an output global while binds are in flight — rather than using a removal grace period, as wlroots does with `wlr_global_destroy_safe()` — is Hyprland's.
