### PR TITLE
Give every silent test assertion a failure message

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -60,6 +60,13 @@ Assertions are TAP-flavored and blunt:
   already invalidated.
 - `require_command <cmd>` fails the file when a needed tool is absent.
 
+Every assertion has to route its own failure through `fail`. A bare command used as an assertion is caught by `set -e` instead, which ends the file before any `fail` runs: the TAP stream carries no `not ok` line. The preceding `ok` lines still narrow the failure to one assertion block, but nothing names the predicate that broke, and a block can hold a dozen of them.
+
+```bash
+grep -F 'MANUAL_DISABLE_FLAG' "$clamshell" >/dev/null                      # silent on failure
+grep -F 'MANUAL_DISABLE_FLAG' "$clamshell" >/dev/null || fail "sync reads the flag"
+```
+
 The runner compensates for that early exit: `./test/shell` continues past a
 failing file and summarizes the failures at the end. Aborting the whole run at
 the first bad file once let a single packaging failure mask 114 of 134 files.

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -10,10 +10,10 @@ require_command jq
 require_command lua
 require_command python3
 
-jq empty "$ROOT/config/omarchy/shell.json"
+jq empty "$ROOT/config/omarchy/shell.json" || fail "default shell.json is valid JSON"
 pass "default shell.json is valid JSON"
 
-jq -e '.version == 1 and (.bar.layout.left | type == "array") and (.bar.layout.center | type == "array") and (.bar.layout.right | type == "array")' "$ROOT/config/omarchy/shell.json" >/dev/null
+jq -e '.version == 1 and (.bar.layout.left | type == "array") and (.bar.layout.center | type == "array") and (.bar.layout.right | type == "array")' "$ROOT/config/omarchy/shell.json" >/dev/null || fail "default shell.json has versioned bar layout"
 pass "default shell.json has versioned bar layout"
 
 # Pinning the whole row made this fail every time an unrelated widget moved,
@@ -24,18 +24,18 @@ jq -e '
   ($ids | index("omarchy.weather")) as $weather |
   ($ids | index("omarchy.system-update")) as $update |
   $weather != null and $update == $weather + 1
-' "$ROOT/config/omarchy/shell.json" >/dev/null
+' "$ROOT/config/omarchy/shell.json" >/dev/null || fail "default center layout keeps update next to weather"
 pass "default center layout keeps update next to weather"
 
 jq -e '
   (.bar.centerAnchor // "") as $anchor |
   any(.bar.layout.center[]; (.id // .) == $anchor)
-' "$ROOT/config/omarchy/shell.json" >/dev/null
+' "$ROOT/config/omarchy/shell.json" >/dev/null || fail "default center anchor exists in center layout"
 pass "default center anchor exists in center layout"
 
 jq -e '
   any(.bar.layout.center[]; (.id // .) == "omarchy.clock" and (.formatAlt // "") == "d MMMM \u0027W\u0027ww yyyy")
-' "$ROOT/config/omarchy/shell.json" >/dev/null
+' "$ROOT/config/omarchy/shell.json" >/dev/null || fail "default clock date format has no leading zero"
 pass "default clock date format has no leading zero"
 
 ROOT="$ROOT" python3 <<'PY'
@@ -183,10 +183,10 @@ if errors:
 PY
 pass "package-owned defaults live outside config"
 
-grep -F 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")' "$ROOT/config/hypr/hyprland.lua" >/dev/null
-grep -F 'require("default.hypr.omarchy")' "$ROOT/config/hypr/hyprland.lua" >/dev/null
-grep -F 'package.path = home' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
-grep -F '/.local/state/?.lua;' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
+grep -F 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")' "$ROOT/config/hypr/hyprland.lua" >/dev/null || fail "Hyprland user entrypoint loads the packaged bootstrap"
+grep -F 'require("default.hypr.omarchy")' "$ROOT/config/hypr/hyprland.lua" >/dev/null || fail "Hyprland user entrypoint requires the Omarchy defaults module"
+grep -F 'package.path = home' "$ROOT/default/hypr/bootstrap.lua" >/dev/null || fail "Hyprland bootstrap extends package.path with the user home"
+grep -F '/.local/state/?.lua;' "$ROOT/default/hypr/bootstrap.lua" >/dev/null || fail "Hyprland bootstrap resolves modules from the Omarchy state directory"
 pass "Hyprland user entrypoint keeps package and state path bootstrap in defaults"
 
 OMARCHY_PATH="$ROOT" lua <<'LUA'
@@ -257,21 +257,21 @@ fi
 pass "bar use rejects an unknown bar option"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar use local.demo-bar
-jq -e '.bar.id == "local.demo-bar"' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+jq -e '.bar.id == "local.demo-bar"' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell config selects a bar option"
 pass "shell config selects a bar option"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar reset
-jq -e '.bar.id == null' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+jq -e '.bar.id == null' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell config resets to built-in bar option"
 pass "shell config resets to built-in bar option"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar move omarchy.active-window right
 grep -Fqx 'shell moveBarWidget omarchy.active-window {"section":"right"}' \
-  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" || fail "bar move accepts a positional target section"
 pass "bar move accepts a positional target section"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar move omarchy.active-window left
 grep -Fqx 'shell moveBarWidget omarchy.active-window {"section":"left"}' \
-  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" || fail "bar move can restore a widget with positional syntax"
 pass "bar move can restore a widget with positional syntax"
 
 if HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar move omarchy.active-window left --section right 2>/dev/null; then
@@ -283,7 +283,7 @@ HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar position bottom
 jq -e '
   .bar.position == "bottom" and
   .plugins == []
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell config sets bar position"
 pass "shell config sets bar position"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent true
@@ -291,21 +291,21 @@ jq -e '
   .bar.transparent == true and
   .bar.position == "bottom" and
   .plugins == []
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell config sets bar transparency"
 pass "shell config sets bar transparency"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent toggle
-jq -e '.bar.transparent == false' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+jq -e '.bar.transparent == false' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell config toggles bar transparency"
 pass "shell config toggles bar transparency"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.bluetooth enabled false --json
 grep -Fqx 'shell setBarWidget omarchy.bluetooth enabled false {}' \
-  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" || fail "bar set accepts false JSON values"
 pass "bar set accepts false JSON values"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.bluetooth optional null --json
 grep -Fqx 'shell setBarWidget omarchy.bluetooth optional null {}' \
-  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" || fail "bar set accepts null JSON values"
 pass "bar set accepts null JSON values"
 
 if HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.bluetooth broken '{' --json 2>/dev/null; then
@@ -366,7 +366,7 @@ HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" PATH="$mock_path" OMARCHY_TEST_DROPBOX=
 jq -e --slurpfile defaults "$ROOT/config/omarchy/shell.json" '
   .bar == $defaults[0].bar and
   .plugins == []
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "bar defaults restores the stock bar"
 pass "bar defaults restores the stock bar"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" PATH="$mock_path" OMARCHY_TEST_DROPBOX=1 OMARCHY_TEST_TAILSCALE=1 omarchy-bar defaults
@@ -377,7 +377,7 @@ jq -e '
   ($right | index("omarchy.tailscale") == $tray + 1) and
   ($right | index("omarchy.dropbox") == $tray + 2) and
   (.bar.layout.center | ids | index("omarchy.tailscale") == null)
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "bar defaults places plugins for running optional services"
 pass "bar defaults places plugins for running optional services"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" PATH="$mock_path" \
@@ -390,7 +390,7 @@ jq -e '
   ($right | index("omarchy.tailscale") == $tray + 1) and
   ($right | index("omarchy.dropbox") == $tray + 2) and
   (.bar.layout.center | ids | index("omarchy.tailscale") == null)
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "bar defaults places service widgets without a running shell"
 pass "bar defaults places service widgets without a running shell"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" PATH="$mock_path" OMARCHY_TEST_DROPBOX=0 OMARCHY_TEST_TAILSCALE=0 omarchy-refresh-shell
@@ -399,7 +399,7 @@ jq -e '
   ([.bar.layout.left, .bar.layout.center, .bar.layout.right] | map(ids) | add) as $all |
   ($all | index("omarchy.dropbox") == null) and
   ($all | index("omarchy.tailscale") == null)
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell refresh keeps optional service widgets absent when services are unavailable"
 pass "shell refresh keeps optional service widgets absent when services are unavailable"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" PATH="$mock_path" OMARCHY_TEST_DROPBOX=1 OMARCHY_TEST_TAILSCALE=1 omarchy-refresh-shell
@@ -410,7 +410,7 @@ jq -e '
   ($right | index("omarchy.tailscale") == $tray + 1) and
   ($right | index("omarchy.dropbox") == $tray + 2) and
   (.bar.layout.center | ids | index("omarchy.tailscale") == null)
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "shell refresh places optional service widgets when services are available"
 [[ -f $TMPDIR/home/.local/state/omarchy/restart-shell-called ]] || fail "shell refresh restarts shell"
 pass "shell refresh places optional service widgets when services are available"
 
@@ -446,7 +446,7 @@ HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" bash "$clock_migration"
 jq -e '
   .bar.layout.center[0].formatAlt == "d MMMM \u0027W\u0027ww yyyy" and
   .bar.layout.right[0].formatAlt == "dd MMMM \u0027W\u0027ww yyyy"
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null || fail "clock date format migration removes leading zero from clock"
 pass "clock date format migration removes leading zero from clock"
 
 before=$(sha256sum "$TMPDIR/home/.config/omarchy/shell.json" | awk '{print $1}')

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -16,97 +16,97 @@ hw_clamshell="$ROOT/bin/omarchy-hw-clamshell"
 hw_laptop_closed="$ROOT/bin/omarchy-hw-laptop-closed"
 utilities="$ROOT/default/hypr/bindings/utilities.lua"
 
-grep -F 'sleep "$delay"' "$monitor_watch" >/dev/null
-grep -F 'for delay in 1 3 7; do' "$monitor_watch" >/dev/null
-grep -F 'poll_clamshell_state &' "$monitor_watch" >/dev/null
-grep -F 'flock -n 9' "$monitor_watch" >/dev/null
-grep -F 'omarchy-hyprland-monitor-clamshell' "$monitor_watch" >/dev/null
+grep -F 'sleep "$delay"' "$monitor_watch" >/dev/null || fail "monitor watcher waits between recovery attempts"
+grep -F 'for delay in 1 3 7; do' "$monitor_watch" >/dev/null || fail "monitor watcher retries recovery on a 1/3/7 second ladder"
+grep -F 'poll_clamshell_state &' "$monitor_watch" >/dev/null || fail "monitor watcher polls clamshell state in the background"
+grep -F 'flock -n 9' "$monitor_watch" >/dev/null || fail "monitor watcher locks so one recovery loop runs at a time"
+grep -F 'omarchy-hyprland-monitor-clamshell' "$monitor_watch" >/dev/null || fail "monitor watcher calls the clamshell sync helper"
 pass "monitor watcher retries internal monitor recovery after removal"
 
-grep -F 'monitoradded\>\>*|monitoraddedv2\>\>*)' "$monitor_watch" >/dev/null
-grep -F 'omarchy-hyprland-monitor-clamshell' "$monitor_watch" >/dev/null
+grep -F 'monitoradded\>\>*|monitoraddedv2\>\>*)' "$monitor_watch" >/dev/null || fail "monitor watcher reacts to monitoradded and monitoraddedv2"
+grep -F 'omarchy-hyprland-monitor-clamshell' "$monitor_watch" >/dev/null || fail "monitor watcher syncs clamshell state on a monitor hotplug"
 pass "monitor watcher disables the internal monitor after closed-lid external hotplug"
 
-grep -F 'sync_clamshell_after_monitor_change' "$monitor_watch" >/dev/null
-grep -F 'socat -U - "UNIX-CONNECT:$SOCKET"' "$monitor_watch" >/dev/null
+grep -F 'sync_clamshell_after_monitor_change' "$monitor_watch" >/dev/null || fail "monitor watcher reconciles clamshell state after a monitor change"
+grep -F 'socat -U - "UNIX-CONNECT:$SOCKET"' "$monitor_watch" >/dev/null || fail "monitor watcher reads the Hyprland event socket"
 pass "monitor watcher reconciles clamshell state on startup"
 
-grep -F 'omarchy-hw-laptop && omarchy-hyprland-monitor-external-active' "$monitor_watch" >/dev/null
-grep -F 'sync_poll_state' "$monitor_watch" >/dev/null
-grep -F 'done < <(socat' "$monitor_watch" >/dev/null
+grep -F 'omarchy-hw-laptop && omarchy-hyprland-monitor-external-active' "$monitor_watch" >/dev/null || fail "clamshell poll starts only on a docked laptop"
+grep -F 'sync_poll_state' "$monitor_watch" >/dev/null || fail "monitor watcher tracks whether the clamshell poll should run"
+grep -F 'done < <(socat' "$monitor_watch" >/dev/null || fail "monitor watcher reads events without losing state to a subshell"
 pass "clamshell poll only runs on a docked laptop, not desktops or undocked laptops"
 
 # Recovery costs a reload per attempt, so it must not run on a healthy machine,
 # and only one loop may run across the events that start it.
-grep -F '(( state == 1 )) && break' "$monitor_watch" >/dev/null
-grep -F 'delay = delay * 2 > 60 ? 60 : delay * 2' "$monitor_watch" >/dev/null
-grep -F '9>"$MODELESS_LOCK"' "$monitor_watch" >/dev/null
-grep -F 'flock -w 1 9 || exit 0' "$monitor_watch" >/dev/null
+grep -F '(( state == 1 )) && break' "$monitor_watch" >/dev/null || fail "modeless recovery stops once a monitor reports a mode"
+grep -F 'delay = delay * 2 > 60 ? 60 : delay * 2' "$monitor_watch" >/dev/null || fail "modeless recovery backs off and caps the delay at 60 seconds"
+grep -F '9>"$MODELESS_LOCK"' "$monitor_watch" >/dev/null || fail "modeless recovery takes its own lock file"
+grep -F 'flock -w 1 9 || exit 0' "$monitor_watch" >/dev/null || fail "a second modeless recovery loop exits instead of stacking"
 pass "modeless monitor recovery runs one backing-off loop while a monitor has no mode"
 
 # Nothing fires an event for this state, so an unanswered query must not end
 # recovery -- but a compositor that never answers has gone with the session.
-grep -F '(( state == 2 )) && (( ++unanswered > 20 )) && break' "$monitor_watch" >/dev/null
+grep -F '(( state == 2 )) && (( ++unanswered > 20 )) && break' "$monitor_watch" >/dev/null || fail "modeless recovery gives up after 20 unanswered queries"
 pass "modeless recovery retries unanswered queries without waiting on a dead compositor"
 
-grep -F 'configreloaded\>\>*)' "$monitor_watch" >/dev/null
+grep -F 'configreloaded\>\>*)' "$monitor_watch" >/dev/null || fail "modeless recovery also runs after a config reload"
 pass "modeless recovery also runs after a config reload"
 
-grep -F 'omarchy-hyprland-reload-guard paused' "$monitor_watch" >/dev/null
+grep -F 'omarchy-hyprland-reload-guard paused' "$monitor_watch" >/dev/null || fail "modeless recovery does not reload into a package transaction"
 pass "modeless recovery does not reload into a package transaction"
 
-grep -F '.disabled != true and (.width == 0 or .height == 0)' "$ROOT/bin/omarchy-hyprland-monitor-modeless" >/dev/null
-grep -F 'hyprctl monitors all -j' "$ROOT/bin/omarchy-hyprland-monitor-modeless" >/dev/null
+grep -F '.disabled != true and (.width == 0 or .height == 0)' "$ROOT/bin/omarchy-hyprland-monitor-modeless" >/dev/null || fail "modeless helper ignores monitors disabled on purpose"
+grep -F 'hyprctl monitors all -j' "$ROOT/bin/omarchy-hyprland-monitor-modeless" >/dev/null || fail "modeless helper asks for all monitors so mirrors stay visible"
 pass "modeless helper sees mirrors and ignores monitors disabled on purpose"
 
-grep -F 'omarchy-hw-laptop-closed && omarchy-hw-external-monitors' "$hw_clamshell" >/dev/null
-grep -F '/proc/acpi/button/lid/*/state' "$hw_laptop_closed" >/dev/null
+grep -F 'omarchy-hw-laptop-closed && omarchy-hw-external-monitors' "$hw_clamshell" >/dev/null || fail "clamshell helper needs both a closed lid and an external monitor"
+grep -F '/proc/acpi/button/lid/*/state' "$hw_laptop_closed" >/dev/null || fail "laptop-closed helper reads the ACPI lid state"
 pass "clamshell helper detects closed-lid external monitor state"
 
 # A mirrored external is absent from plain `monitors`, so asking without `all`
 # reads as a disconnect and hands the mirror toggle straight to recovery.
-grep -F 'hyprctl monitors all -j' "$monitor_external_active" >/dev/null
-grep -F 'select(.name | test("^(eDP|LVDS|DSI)-") | not)' "$monitor_external_active" >/dev/null
-grep -F 'select(.disabled == false)' "$monitor_external_active" >/dev/null
+grep -F 'hyprctl monitors all -j' "$monitor_external_active" >/dev/null || fail "active external helper asks for all monitors so mirrors stay visible"
+grep -F 'select(.name | test("^(eDP|LVDS|DSI)-") | not)' "$monitor_external_active" >/dev/null || fail "active external helper skips internal panels"
+grep -F 'select(.disabled == false)' "$monitor_external_active" >/dev/null || fail "active external helper ignores disabled monitors"
 pass "active external monitor helper sees mirrors and ignores monitors disabled on purpose"
 
-grep -F 'omarchy-hyprland-monitor-internal recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null
-grep -F 'omarchy-hyprland-monitor-internal-mirror recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null
-grep -F 'internal-monitor-clamshell.lua' "$clamshell" >/dev/null
-grep -F 'disabled = true' "$clamshell" >/dev/null
-grep -F 'MANUAL_DISABLE_FLAG' "$clamshell" >/dev/null
-! grep -F 'rm -f "$MANUAL_DISABLE_FLAG"' "$clamshell" >/dev/null
-! grep -F '>"$MANUAL_DISABLE_FLAG"' "$clamshell" >/dev/null
-grep -F 'read_monitor_scale' "$clamshell" >/dev/null
-grep -F 'scale = $scale' "$clamshell" >/dev/null
-grep -F 'hyprctl dispatch "hl.dsp.dpms({ action = \"$action\", monitor = \"$INTERNAL\" })"' "$clamshell" >/dev/null
-grep -F 'hyprctl monitors all -j' "$clamshell" >/dev/null
-grep -F 'omarchy-hyprland-monitor-external-active' "$clamshell" >/dev/null
-grep -F 'omarchy-hw-clamshell' "$clamshell" >/dev/null
+grep -F 'omarchy-hyprland-monitor-internal recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null || fail "clamshell sync force-recovers the internal monitor"
+grep -F 'omarchy-hyprland-monitor-internal-mirror recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null || fail "clamshell sync force-recovers the internal mirror"
+grep -F 'internal-monitor-clamshell.lua' "$clamshell" >/dev/null || fail "clamshell sync writes internal-monitor-clamshell.lua"
+grep -F 'disabled = true' "$clamshell" >/dev/null || fail "clamshell sync disables the internal monitor"
+grep -F 'MANUAL_DISABLE_FLAG' "$clamshell" >/dev/null || fail "clamshell sync reads the manual disable flag"
+! grep -F 'rm -f "$MANUAL_DISABLE_FLAG"' "$clamshell" >/dev/null || fail "clamshell sync never clears the manual disable flag"
+! grep -F '>"$MANUAL_DISABLE_FLAG"' "$clamshell" >/dev/null || fail "clamshell sync never writes the manual disable flag"
+grep -F 'read_monitor_scale' "$clamshell" >/dev/null || fail "clamshell sync reads the configured monitor scale"
+grep -F 'scale = $scale' "$clamshell" >/dev/null || fail "clamshell sync keeps the monitor scale when it rewrites the config"
+grep -F 'hyprctl dispatch "hl.dsp.dpms({ action = \"$action\", monitor = \"$INTERNAL\" })"' "$clamshell" >/dev/null || fail "clamshell sync drives DPMS on the internal monitor"
+grep -F 'hyprctl monitors all -j' "$clamshell" >/dev/null || fail "clamshell sync asks for all monitors so mirrors stay visible"
+grep -F 'omarchy-hyprland-monitor-external-active' "$clamshell" >/dev/null || fail "clamshell sync checks for an active external monitor"
+grep -F 'omarchy-hw-clamshell' "$clamshell" >/dev/null || fail "clamshell sync checks the clamshell hardware state"
 pass "clamshell monitor sync disables laptop output and force-recovers it"
 
-grep -F "hyprctl dispatch 'hl.dsp.dpms({ action = \"enable\" })' >/dev/null 2>&1 || true" "$monitor_internal" >/dev/null
-grep -F 'omarchy-hyprland-monitor-laptop' "$monitor_internal" >/dev/null
-grep -F 'hyprctl monitors all -j' "$monitor_laptop" >/dev/null
-grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_internal" >/dev/null
-grep -F 'wake' "$monitor_internal" >/dev/null
-grep -F 'omarchy-hyprland-toggle-enabled $TOGGLE || return 0' "$monitor_internal" >/dev/null
+grep -F "hyprctl dispatch 'hl.dsp.dpms({ action = \"enable\" })' >/dev/null 2>&1 || true" "$monitor_internal" >/dev/null || fail "internal monitor recovery re-enables DPMS"
+grep -F 'omarchy-hyprland-monitor-laptop' "$monitor_internal" >/dev/null || fail "internal monitor helper resolves the laptop output"
+grep -F 'hyprctl monitors all -j' "$monitor_laptop" >/dev/null || fail "laptop helper asks for all monitors so mirrors stay visible"
+grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_internal" >/dev/null || fail "internal monitor helper checks for an active external monitor"
+grep -F 'wake' "$monitor_internal" >/dev/null || fail "internal monitor helper supports the wake action"
+grep -F 'omarchy-hyprland-toggle-enabled $TOGGLE || return 0' "$monitor_internal" >/dev/null || fail "internal monitor recovery only wakes displays when it re-enabled one"
 pass "internal monitor helper can re-enable disabled laptop displays"
 pass "internal monitor recovery only wakes displays when it re-enables one"
 
-grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_mirror" >/dev/null
+grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_mirror" >/dev/null || fail "internal mirror helper checks for an active external monitor"
 pass "internal mirror helper recovers when no active external display remains"
 
-grep -F 'switch:on:Lid Switch", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null
-grep -F 'switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null
+grep -F 'switch:on:Lid Switch", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null || fail "lid close binding locks the session"
+grep -F 'switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null || fail "lid open binding reconciles clamshell display state"
 pass "lid switch bindings lock on close and reconcile clamshell display state"
 
-grep -F 'omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true' "$system_wake" >/dev/null
+grep -F 'omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true' "$system_wake" >/dev/null || fail "system wake resyncs clamshell display state"
 pass "system wake resyncs clamshell display state"
 
-grep -F 'lock-pending: no-real-screen' "$lock_service" >/dev/null
-grep -F 'lock-pending: screen-stabilizing' "$lock_service" >/dev/null
-grep -F 'id: sessionLockStabilizeTimer' "$lock_service" >/dev/null
-grep -Pzo 'function onScreensChanged\(\) \{\n(.*\n)*?\s*root\.requestSessionLock\(\)\n' "$lock_service" >/dev/null
-grep -F 'realScreens: root.realScreenCount()' "$lock_service" >/dev/null
+grep -F 'lock-pending: no-real-screen' "$lock_service" >/dev/null || fail "lock service reports a pending lock with no real screen"
+grep -F 'lock-pending: screen-stabilizing' "$lock_service" >/dev/null || fail "lock service reports a pending lock while screens stabilize"
+grep -F 'id: sessionLockStabilizeTimer' "$lock_service" >/dev/null || fail "lock service has a screen stabilize timer"
+grep -Pzo 'function onScreensChanged\(\) \{\n(.*\n)*?\s*root\.requestSessionLock\(\)\n' "$lock_service" >/dev/null || fail "a screen change requests the session lock"
+grep -F 'realScreens: root.realScreenCount()' "$lock_service" >/dev/null || fail "lock service counts real screens"
 pass "lock service waits for stable real screens before session lock"

--- a/test/shell.d/network-manager-transition-test.sh
+++ b/test/shell.d/network-manager-transition-test.sh
@@ -9,27 +9,27 @@ hardware_network="$ROOT/install/hardware/network.sh"
 migration="$ROOT/migrations/1782002156.sh"
 
 ! grep -F 'systemd-networkd' "$dns" >/dev/null || fail "omarchy-dns no longer restarts systemd-networkd"
-grep -F 'NetworkManager/conf.d/20-omarchy-dns.conf' "$dns" >/dev/null
-grep -F '[global-dns-domain-*]' "$dns" >/dev/null
-grep -F 'ipv4.ignore-auto-dns yes' "$dns" >/dev/null
-grep -F 'ipv4.ignore-auto-dns no' "$dns" >/dev/null
-grep -F 'nmcli device reapply' "$dns" >/dev/null
-grep -F 'nmcli general reload conf' "$dns" >/dev/null
-grep -F 'nmcli general reload dns-full' "$dns" >/dev/null
+grep -F 'NetworkManager/conf.d/20-omarchy-dns.conf' "$dns" >/dev/null || fail "omarchy-dns writes the NetworkManager DNS drop-in"
+grep -F '[global-dns-domain-*]' "$dns" >/dev/null || fail "omarchy-dns writes a global DNS domain section"
+grep -F 'ipv4.ignore-auto-dns yes' "$dns" >/dev/null || fail "omarchy-dns can ignore DHCP DNS on a connection"
+grep -F 'ipv4.ignore-auto-dns no' "$dns" >/dev/null || fail "omarchy-dns can restore DHCP DNS on a connection"
+grep -F 'nmcli device reapply' "$dns" >/dev/null || fail "omarchy-dns reapplies the active device profile"
+grep -F 'nmcli general reload conf' "$dns" >/dev/null || fail "omarchy-dns reloads NetworkManager configuration"
+grep -F 'nmcli general reload dns-full' "$dns" >/dev/null || fail "omarchy-dns reloads NetworkManager DNS"
 if grep -F 'nmcli general reload conf,dns-full' "$dns" >/dev/null; then
   fail "omarchy-dns must not push DNS before reapplying active profiles"
 fi
 pass "omarchy-dns configures DNS through NetworkManager"
 
-grep -F 'systemd-networkd.service' "$hardware_network" >/dev/null
-grep -F 'systemd-networkd.socket' "$hardware_network" >/dev/null
-grep -F '20-wlan.network' "$hardware_network" >/dev/null
-grep -F 'omarchy-networkd-retired' "$hardware_network" >/dev/null
+grep -F 'systemd-networkd.service' "$hardware_network" >/dev/null || fail "hardware setup retires systemd-networkd.service"
+grep -F 'systemd-networkd.socket' "$hardware_network" >/dev/null || fail "hardware setup retires the systemd-networkd socket"
+grep -F '20-wlan.network' "$hardware_network" >/dev/null || fail "hardware setup clears the archinstall 20-wlan.network profile"
+grep -F 'omarchy-networkd-retired' "$hardware_network" >/dev/null || fail "hardware setup marks networkd retired"
 pass "hardware setup retires archinstall networkd state"
 
-grep -F 'OMARCHY_UPGRADE_TO_QUATTRO_LIVE' "$migration" >/dev/null
-grep -F 'systemctl disable --now "$unit"' "$migration" >/dev/null
-grep -F 'systemctl stop systemd-networkd.service' "$migration" >/dev/null
-grep -F 'NetworkManager.service' "$migration" >/dev/null
-grep -F '20-wlan.network' "$migration" >/dev/null
+grep -F 'OMARCHY_UPGRADE_TO_QUATTRO_LIVE' "$migration" >/dev/null || fail "migration leaves the live upgrade environment alone"
+grep -F 'systemctl disable --now "$unit"' "$migration" >/dev/null || fail "migration disables the networkd units it finds"
+grep -F 'systemctl stop systemd-networkd.service' "$migration" >/dev/null || fail "migration stops systemd-networkd.service"
+grep -F 'NetworkManager.service' "$migration" >/dev/null || fail "migration hands the network back to NetworkManager"
+grep -F '20-wlan.network' "$migration" >/dev/null || fail "migration clears the archinstall 20-wlan.network profile"
 pass "migration repairs upgraded systems with networkd still active"

--- a/test/shell.d/nouveau-cursor-test.sh
+++ b/test/shell.d/nouveau-cursor-test.sh
@@ -26,7 +26,8 @@ run_fix() {
 }
 
 run_fix >/dev/null
-grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null
+grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null ||
+  fail "nouveau hardware setup enables software cursors" "$(cat "$looknfeel")"
 pass "nouveau hardware setup enables software cursors"
 
 run_fix >/dev/null

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -8,15 +8,15 @@ template="$ROOT/default/snapper/root"
 limine_defaults="$ROOT/etc/limine-entry-tool.d/omarchy-defaults.conf"
 limine_notify_autostart="$ROOT/config/autostart/limine-snapper-notify.desktop"
 
-grep -Fx 'NUMBER_CLEANUP="yes"' "$template" >/dev/null
-grep -Fx 'NUMBER_LIMIT="5"' "$template" >/dev/null
-grep -Fx 'TIMELINE_CREATE="no"' "$template" >/dev/null
+grep -Fx 'NUMBER_CLEANUP="yes"' "$template" >/dev/null || fail "Snapper template caps snapshots by number"
+grep -Fx 'NUMBER_LIMIT="5"' "$template" >/dev/null || fail "Snapper template keeps five numbered snapshots"
+grep -Fx 'TIMELINE_CREATE="no"' "$template" >/dev/null || fail "Snapper template leaves timeline snapshot creation off"
 ! grep -Eq '^TIMELINE_(CLEANUP|LIMIT_)' "$template" || fail "Snapper template keeps timeline cleanup details out of the default config"
 grep -Fx 'MAX_SNAPSHOT_ENTRIES=6' "$limine_defaults" >/dev/null || fail "Limine allows for a snapshot created before Snapper cleanup"
 pass "Snapper and Limine retain update snapshots without a transient limit mismatch"
 
-grep -Fx '[Desktop Entry]' "$limine_notify_autostart" >/dev/null
-grep -Fx 'Hidden=true' "$limine_notify_autostart" >/dev/null
+grep -Fx '[Desktop Entry]' "$limine_notify_autostart" >/dev/null || fail "Limine Snapper notifier autostart is a desktop entry"
+grep -Fx 'Hidden=true' "$limine_notify_autostart" >/dev/null || fail "Limine Snapper notifier autostart ships hidden"
 pass "Limine Snapper warning notifier is disabled by default"
 
 test_tmp=$(mktemp -d)
@@ -39,9 +39,9 @@ chmod +x "$fake_bin/systemctl"
 
 notification_migration=$(grep -rl 'Disable Limine Snapper warning notifier' "$ROOT/migrations" | head -n 1 || true)
 [[ -n $notification_migration ]] || fail "Limine Snapper warning notifier migration exists"
-grep -F 'limine-snapper-notify.desktop' "$notification_migration" >/dev/null
-grep -F 'systemctl --user daemon-reload' "$notification_migration" >/dev/null
-grep -F "app-limine\\x2dsnapper\\x2dnotify@autostart.service" "$notification_migration" >/dev/null
+grep -F 'limine-snapper-notify.desktop' "$notification_migration" >/dev/null || fail "notifier migration overrides limine-snapper-notify.desktop"
+grep -F 'systemctl --user daemon-reload' "$notification_migration" >/dev/null || fail "notifier migration reloads the user manager"
+grep -F "app-limine\\x2dsnapper\\x2dnotify@autostart.service" "$notification_migration" >/dev/null || fail "notifier migration stops the escaped autostart unit"
 
 migration_home="$test_tmp/migration-home"
 mkdir -p "$migration_home"
@@ -80,10 +80,10 @@ pass "system setup normalizes Snapper during fresh installs"
 
 migration=$(grep -rl 'Normalize Snapper snapshot services' "$ROOT/migrations" | head -n 1 || true)
 [[ -n $migration ]] || fail "Snapper service migration exists"
-grep -F 'unit_active snapper-cleanup.timer' "$migration" >/dev/null
-grep -F 'unit_active limine-snapper-sync.service' "$migration" >/dev/null
-grep -F 'sudo "$@"' "$migration" >/dev/null
-grep -F 'as_root env OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$snapper_config_script"' "$migration" >/dev/null
+grep -F 'unit_active snapper-cleanup.timer' "$migration" >/dev/null || fail "Snapper service migration checks snapper-cleanup.timer"
+grep -F 'unit_active limine-snapper-sync.service' "$migration" >/dev/null || fail "Snapper service migration checks limine-snapper-sync.service"
+grep -F 'sudo "$@"' "$migration" >/dev/null || fail "Snapper service migration escalates with sudo"
+grep -F 'as_root env OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$snapper_config_script"' "$migration" >/dev/null || fail "Snapper service migration reruns the packaged Snapper config script"
 ! grep -F 'NUMBER_LIMIT="5"' "$migration" >/dev/null || fail "Snapper service migration does not overwrite working custom retention"
 pass "Snapper service migration only repairs broken services idempotently"
 

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -6,14 +6,14 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 service="$ROOT/default/systemd/user/bt-agent.service"
 
-grep -Fx 'ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service' "$service" >/dev/null
+grep -Fx 'ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service' "$service" >/dev/null || fail "bt-agent skips when bluetooth.service is inactive"
 pass "bt-agent skips when bluetooth.service is inactive"
 
-grep -Fx 'Restart=on-failure' "$service" >/dev/null
+grep -Fx 'Restart=on-failure' "$service" >/dev/null || fail "bt-agent still restarts after runtime failures"
 pass "bt-agent still restarts after runtime failures"
 
 sleep_service="$ROOT/default/systemd/user/omarchy-sleep-lock.service"
-grep -Fx 'ExecStart=/usr/bin/omarchy-system-sleep-monitor' "$sleep_service" >/dev/null
+grep -Fx 'ExecStart=/usr/bin/omarchy-system-sleep-monitor' "$sleep_service" >/dev/null || fail "sleep lock service uses the package-backed monitor path"
 pass "sleep lock service uses the package-backed monitor path"
 
 grep -Fx 'After=dbus.socket wayland-session-waitenv.service' "$sleep_service" >/dev/null ||
@@ -27,16 +27,16 @@ grep -Fx 'ConditionEnvironment=WAYLAND_DISPLAY' "$sleep_service" >/dev/null ||
 pass "sleep lock service follows the initialized graphical session"
 
 first_run_units="$ROOT/install/user/first-run/enable-user-units.sh"
-grep -Fx 'systemctl --user daemon-reload' "$first_run_units" >/dev/null
-grep -F 'omarchy-sleep-lock.service' "$first_run_units" >/dev/null
+grep -Fx 'systemctl --user daemon-reload' "$first_run_units" >/dev/null || fail "first-run reloads the user manager before enabling units"
+grep -F 'omarchy-sleep-lock.service' "$first_run_units" >/dev/null || fail "first-run enables the sleep lock service"
 pass "first-run reloads and enables the sleep lock service"
 
 upgrade_to_quattro="$ROOT/bin/omarchy-upgrade-to-quattro"
-grep -F '6870b232a6c0474b59187882e6d25ae771bba735098bcbedef8a2b73b97e2b6a' "$upgrade_to_quattro" >/dev/null
-grep -F 'bcd1a76cb5c63514922bc5e11af22ae480fc6d06a99863364e02bdf3c7bdceaf' "$upgrade_to_quattro" >/dev/null
-grep -F 'ExecStart=%h/.local/share/omarchy/bin/omarchy-system-sleep-monitor' "$upgrade_to_quattro" >/dev/null
-grep -F 'ExecStart=/usr/bin/omarchy-system-sleep-monitor' "$upgrade_to_quattro" >/dev/null
-grep -F 'reset-failed omarchy-sleep-lock.service' "$upgrade_to_quattro" >/dev/null
+grep -F '6870b232a6c0474b59187882e6d25ae771bba735098bcbedef8a2b73b97e2b6a' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade knows the first legacy sleep lock unit checksum"
+grep -F 'bcd1a76cb5c63514922bc5e11af22ae480fc6d06a99863364e02bdf3c7bdceaf' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade knows the second legacy sleep lock unit checksum"
+grep -F 'ExecStart=%h/.local/share/omarchy/bin/omarchy-system-sleep-monitor' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade recognizes the legacy sleep lock ExecStart"
+grep -F 'ExecStart=/usr/bin/omarchy-system-sleep-monitor' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade rewrites the sleep lock ExecStart to the package path"
+grep -F 'reset-failed omarchy-sleep-lock.service' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade clears the failed state on the sleep lock unit"
 pass "Omarchy 4 upgrade repairs the legacy sleep lock unit path"
 
 [[ -e $ROOT/default/systemd/user/omarchy-update-user-notify.path ]] &&
@@ -46,8 +46,8 @@ grep -rlE '^(Path[A-Za-z]+|DirectoryNotEmpty)=.*/usr/share/omarchy/migrations' "
 pass "no unit watches the migration directory, so package updates cannot trigger the notifier"
 
 notify_service="$ROOT/default/systemd/user/omarchy-migrate-notify.service"
-grep -Fx 'ExecStart=/usr/bin/omarchy-migrate-notify' "$notify_service" >/dev/null
-grep -Fx 'WantedBy=graphical-session.target' "$notify_service" >/dev/null
+grep -Fx 'ExecStart=/usr/bin/omarchy-migrate-notify' "$notify_service" >/dev/null || fail "migration notifier runs omarchy-migrate-notify"
+grep -Fx 'WantedBy=graphical-session.target' "$notify_service" >/dev/null || fail "migration notifier is pulled in at graphical login"
 grep -Fx 'After=graphical-session.target' "$notify_service" >/dev/null ||
   fail "migration notifier can deadlock UWSM by blocking graphical-session.target"
 pass "migration notifier checks once per login after the graphical session is ready"
@@ -59,7 +59,7 @@ grep -F 'omarchy-update-user-notify' "$first_run_units" >/dev/null &&
 pass "first-run enables the login-only migration notifier"
 
 fcitx_service="$ROOT/default/systemd/user/omarchy-fcitx5.service"
-grep -Fx 'ExecStart=/usr/bin/fcitx5 --disable notificationitem' "$fcitx_service" >/dev/null
+grep -Fx 'ExecStart=/usr/bin/fcitx5 --disable notificationitem' "$fcitx_service" >/dev/null || fail "fcitx5 unit starts fcitx5 with the notification item disabled"
 grep -Fx 'Restart=always' "$fcitx_service" >/dev/null ||
   fail "fcitx5 exits 0 on a duplicate bus name, so on-failure would leave the user with no input method"
 grep -Fx 'After=graphical-session.target' "$fcitx_service" >/dev/null ||

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -10,28 +10,28 @@ snapshot_line=$(grep -n '^create_pre_upgrade_snapshot$' "$upgrade_to_quattro" | 
 pacman_line=$(grep -n '^configure_pacman_channel$' "$upgrade_to_quattro" | cut -d: -f1)
 [[ -n $snapshot_line && -n $pacman_line ]] || fail "upgrade snapshot and first mutation calls exist"
 (( snapshot_line < pacman_line )) || fail "upgrade snapshot runs before pacman configuration"
-grep -F 'omarchy-snapshot create || (($? == 127))' "$upgrade_to_quattro" >/dev/null
+grep -F 'omarchy-snapshot create || (($? == 127))' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade tolerates a missing omarchy-snapshot"
 pass "Omarchy 4 upgrade snapshots the system before mutation"
 
 # The mirrors are repointed immediately before the keyrings go in, so only a
 # forced refresh replaces the legacy database and its stale checksums.
-grep -F 'pacman -Syy --noconfirm archlinux-keyring omarchy-keyring' "$upgrade_to_quattro" >/dev/null
+grep -F 'pacman -Syy --noconfirm archlinux-keyring omarchy-keyring' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade force-refreshes the database before the keyrings"
 if grep -F 'pacman -Sy --noconfirm archlinux-keyring omarchy-keyring' "$upgrade_to_quattro" >/dev/null; then
   fail "Omarchy 4 upgrade forces a database refresh before installing keyrings"
 fi
 pass "Omarchy 4 upgrade forces a database refresh before installing keyrings"
 
-grep -F 'pacman -Syu --needed' "$upgrade_to_quattro" >/dev/null
-grep -F 'omarchy-update-aur-pkgs' "$upgrade_to_quattro" >/dev/null
-grep -F 'omarchy-update-available' "$upgrade_to_quattro" >/dev/null
-grep -F 'omarchy-update-mise' "$upgrade_to_quattro" >/dev/null
-grep -F 'run_final_system_package_upgrade' "$upgrade_to_quattro" >/dev/null
+grep -F 'pacman -Syu --needed' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade runs a full system package upgrade"
+grep -F 'omarchy-update-aur-pkgs' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade updates AUR packages"
+grep -F 'omarchy-update-available' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade rechecks for available updates"
+grep -F 'omarchy-update-mise' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade updates mise tools"
+grep -F 'run_final_system_package_upgrade' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade runs a final system package upgrade"
 pass "Omarchy 4 upgrade completes package update checks"
 
-grep -F 'run_post_upgrade_migrations' "$upgrade_to_quattro" >/dev/null
-grep -F 'omarchy-migrate' "$upgrade_to_quattro" >/dev/null
-grep -F 'dust' "$upgrade_to_quattro" >/dev/null
-grep -F 'satty' "$upgrade_to_quattro" >/dev/null
+grep -F 'run_post_upgrade_migrations' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade has a post-upgrade migration step"
+grep -F 'omarchy-migrate' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade runs omarchy-migrate"
+grep -F 'dust' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade installs dust"
+grep -F 'satty' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade installs satty"
 pass "Omarchy 4 upgrade applies packaged migrations"
 
 if grep -F 'skip-first-run-update-notification' "$upgrade_to_quattro" >/dev/null; then
@@ -39,8 +39,8 @@ if grep -F 'skip-first-run-update-notification' "$upgrade_to_quattro" >/dev/null
 fi
 pass "Omarchy 4 upgrade completes first-run as one lifecycle"
 
-grep -F 'touch "$done_dir/first-run-user" "$done_dir/finalize-user"' "$upgrade_to_quattro" >/dev/null
-grep -F 'rm -f "$state_dir/first-run-user.done" "$state_dir/finalize-user.done"' "$upgrade_to_quattro" >/dev/null
+grep -F 'touch "$done_dir/first-run-user" "$done_dir/finalize-user"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade writes the first-run and finalize markers"
+grep -F 'rm -f "$state_dir/first-run-user.done" "$state_dir/finalize-user.done"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade clears the legacy completion markers"
 pass "Omarchy 4 upgrade completes first-run and migrates legacy completion markers"
 
 # The script runs from the branch against whatever packaged tree the channel
@@ -57,20 +57,20 @@ for guarded_step in omarchy-refresh-applications 'omarchy-bar defaults'; do
 done
 pass "Omarchy 4 upgrade survives a packaged tree missing top-level commands"
 
-grep -F 'configure_snapper_policy' "$upgrade_to_quattro" >/dev/null
-grep -F '/usr/share/omarchy/install/config/snapper.sh' "$upgrade_to_quattro" >/dev/null
-grep -F 'bash -euo pipefail "$snapper_config_script"' "$upgrade_to_quattro" >/dev/null
+grep -F 'configure_snapper_policy' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade has a Snapper policy step"
+grep -F '/usr/share/omarchy/install/config/snapper.sh' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade uses the packaged Snapper config script"
+grep -F 'bash -euo pipefail "$snapper_config_script"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade runs the Snapper config script under a strict shell"
 pass "Omarchy 4 upgrade normalizes Snapper retention"
 
-grep -F 'configure_lock_authentication' "$upgrade_to_quattro" >/dev/null
-grep -F 'OMARCHY_INSTALL_USER="$target_user"' "$upgrade_to_quattro" >/dev/null
-grep -F '"$apply_lock"' "$upgrade_to_quattro" >/dev/null
+grep -F 'configure_lock_authentication' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade has a lock authentication step"
+grep -F 'OMARCHY_INSTALL_USER="$target_user"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade passes the target user to the lock setup"
+grep -F '"$apply_lock"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade runs the lock authentication script"
 pass "Omarchy 4 upgrade configures lock screen authentication for the target user"
 
-grep -F 'OMARCHY_UPGRADE_TO_QUATTRO_LIVE=1' "$upgrade_to_quattro" >/dev/null
-grep -F 'systemd-networkd.service' "$upgrade_to_quattro" >/dev/null
-grep -F 'systemd-networkd.socket' "$upgrade_to_quattro" >/dev/null
-grep -F 'systemd-networkd-resolve-hook.socket' "$upgrade_to_quattro" >/dev/null
+grep -F 'OMARCHY_UPGRADE_TO_QUATTRO_LIVE=1' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade marks itself as the live upgrade environment"
+grep -F 'systemd-networkd.service' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade retires systemd-networkd.service"
+grep -F 'systemd-networkd.socket' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade retires the systemd-networkd socket"
+grep -F 'systemd-networkd-resolve-hook.socket' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade retires the networkd resolve hook socket"
 pass "Omarchy 4 upgrade retires systemd-networkd for NetworkManager"
 
 # Booting with both managers enabled leaves them fighting over the Wi-Fi
@@ -122,56 +122,56 @@ pass "Omarchy 4 upgrade reports an aborted run instead of exiting silently"
   fail "Omarchy 4 upgrade leaves the retired session processes running until reboot"
 pass "Omarchy 4 upgrade leaves the Omarchy 3 session alone until the reboot"
 
-grep -F 'omarchy-bar defaults' "$upgrade_to_quattro" >/dev/null
+grep -F 'omarchy-bar defaults' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade restores service-aware bar defaults"
 pass "Omarchy 4 upgrade restores service-aware bar defaults"
 
-grep -F 'install_hardware_transition_packages' "$upgrade_to_quattro" >/dev/null
-grep -F 'sof-firmware' "$upgrade_to_quattro" >/dev/null
-grep -F 'vulkan-intel' "$upgrade_to_quattro" >/dev/null
-grep -F 'apply_user_hardware_transition' "$upgrade_to_quattro" >/dev/null
-grep -F 'DX13260' "$upgrade_to_quattro" >/dev/null
+grep -F 'install_hardware_transition_packages' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade has a hardware transition package step"
+grep -F 'sof-firmware' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade backfills sof-firmware"
+grep -F 'vulkan-intel' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade backfills vulkan-intel"
+grep -F 'apply_user_hardware_transition' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade applies the user hardware transition"
+grep -F 'DX13260' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade keeps the DX13260 panel quirk"
 pass "Omarchy 4 upgrade backfills hardware support from the legacy release"
 
-grep -F 'omarchy-refresh-applications' "$upgrade_to_quattro" >/dev/null
+grep -F 'omarchy-refresh-applications' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade refreshes application launchers"
 pass "Omarchy 4 upgrade refreshes application launchers"
 
-grep -F '/etc/systemd/system.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null
-grep -F '/etc/systemd/user.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null
+grep -F '/etc/systemd/system.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade removes the system nofile drop-in"
+grep -F '/etc/systemd/user.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade removes the user nofile drop-in"
 pass "Omarchy 4 upgrade removes stale nofile drop-ins"
 
 cmdline_line=$(grep -n '^preserve_kernel_cmdline_root$' "$upgrade_to_quattro" | cut -d: -f1)
 packages_line=$(grep -n '^install_omarchy_quattro_packages$' "$upgrade_to_quattro" | cut -d: -f1)
 [[ -n $cmdline_line && -n $packages_line ]] || fail "kernel cmdline preservation and package install calls exist"
 (( packages_line < cmdline_line )) || fail "kernel cmdline preservation runs once limine-mkinitcpio is installed"
-grep -F '/etc/default/limine' "$upgrade_to_quattro" >/dev/null
-grep -F 'KERNEL_CMDLINE[default]+=" ${boot_params[*]}"' "$upgrade_to_quattro" >/dev/null
-grep -F 'cat /proc/cmdline' "$upgrade_to_quattro" >/dev/null
-grep -F 'findmnt -no UUID /' "$upgrade_to_quattro" >/dev/null
-grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null
-grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null
+grep -F '/etc/default/limine' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade writes the Limine defaults file"
+grep -F 'KERNEL_CMDLINE[default]+=" ${boot_params[*]}"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade appends recovered boot parameters to the default cmdline"
+grep -F 'cat /proc/cmdline' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade reads the running kernel cmdline"
+grep -F 'findmnt -no UUID /' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade resolves the root filesystem UUID"
+grep -F 'rootflags=subvol=' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade preserves the root subvolume"
+grep -F 'cryptdevice' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade preserves the cryptdevice parameter"
 pass "Omarchy 4 upgrade preserves the kernel cmdline root parameters"
 
 # The += drop-ins make limine-entry-tool ignore /etc/kernel/cmdline and
 # /proc/cmdline, so only the tool's own merge can say whether root= survives.
 # Queried for the default key, so a kernel-specific pin cannot cover for the
 # entries this repairs.
-grep -F 'limine-entry-tool --get-cmdline default' "$upgrade_to_quattro" >/dev/null
-grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null
+grep -F 'limine-entry-tool --get-cmdline default' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade asks limine-entry-tool for the default cmdline"
+grep -F "grep -qE '(^|[[:space:]])root='" "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade checks the merged cmdline for root="
 pass "Omarchy 4 upgrade asks limine-entry-tool whether root= survives"
 
 # The crypt layer hides in the parents on LVM-on-LUKS, and a partial cmdline
 # for an encrypted root must not be written at all.
-grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null
-grep -F 'lsblk -nso TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null
-grep -F 'grep -qx crypt' "$upgrade_to_quattro" >/dev/null
-grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null
+grep -F 'findmnt -no SOURCE --nofsroot /' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade resolves the backing device for /"
+grep -F 'lsblk -nso TYPE "$root_source"' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade walks the device parents looking for a crypt layer"
+grep -F 'grep -qx crypt' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade detects a dm-crypt root"
+grep -F '((have_mount_mode)) || boot_params+=(rw)' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade defaults to a read-write root when no mount mode survives"
 pass "Omarchy 4 upgrade repair path refuses a partial dm-crypt cmdline"
 
 # The cmdline that boots is the one embedded in the UKIs, and an unverified
 # root= must block the reboot rather than just warn.
-grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null
-grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null
-grep -F 'boot_cmdline_unsafe=1' "$upgrade_to_quattro" >/dev/null
+grep -F -- '--only-section=.cmdline' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade reads the cmdline section out of the UKIs"
+grep -F "as_root find /boot/EFI/Linux -maxdepth 1 -name 'omarchy_linux*.efi'" "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade finds the Omarchy UKIs on the ESP"
+grep -F 'boot_cmdline_unsafe=1' "$upgrade_to_quattro" >/dev/null || fail "Omarchy 4 upgrade flags an unverified boot cmdline"
 unsafe_line=$(grep -n 'if (( boot_cmdline_unsafe )); then' "$upgrade_to_quattro" | cut -d: -f1)
 reboot_line=$(grep -n 'Rebooting because --reboot was passed' "$upgrade_to_quattro" | cut -d: -f1)
 [[ -n $unsafe_line && -n $reboot_line ]] || fail "reboot gate and reboot branch exist"


### PR DESCRIPTION
Fixes #7123.

Seven test files write assertions as bare commands under `set -euo pipefail`:

```bash
grep -F 'MANUAL_DISABLE_FLAG' "$clamshell" >/dev/null
grep -F 'disabled = true' "$clamshell" >/dev/null
pass "monitor watcher disables the internal monitor after closed-lid external hotplug"
```

When one of those fails, `set -e` ends the file before any `fail` runs, so the TAP stream carries no `not ok` line. The `ok` lines already printed do place the failure in the block after the last one, but nothing in the output names the predicate that broke.

## Before and after

Renaming one symbol the watcher asserts on, exactly as the issue describes:

```
$ sed -i 's/MANUAL_DISABLE_FLAG/MANUAL_DISABLED_FLAG/g' bin/omarchy-hyprland-monitor-clamshell
```

On `quattro`:

```
ok - active external monitor helper sees mirrors and ignores monitors disabled on purpose
rc=1
```

Eleven `ok` lines, then silence. That locates the failure in the clamshell sync block, which holds 13 assertions, and stops there. On this branch:

```
ok - active external monitor helper sees mirrors and ignores monitors disabled on purpose
not ok - clamshell sync reads the manual disable flag
rc=1
```

## What changed

167 assertions across the seven files now route through `|| fail "..."`, each with a message naming the thing it checks rather than repeating the group's `pass` text. Nothing else moved: no assertion was added, removed, or reordered, and every diff line is the same command with a failure message appended.

`docs/testing.md` gains a short note on the rule, since the assertion protocol section described `pass` and `fail` without saying that a bare command silently bypasses both.

## Tests

Six of the seven files pass in full locally. `snapper-test.sh` stops at its `omarchy-iso` checkout gate and `config-test.sh` at its `omarchy-pkgs` gate, both pre-existing on `quattro` and both already reporting themselves properly. To confirm the edits past those gates actually run, I re-ran the two files against stub `PKGBUILD`s via `OMARCHY_PKGS_PATH`, and both then pass end to end.
