### PR TITLE
Stop creating world-writable browser policy directories

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -7,8 +7,16 @@
 set -e
 
 setup_policy_directory() {
-  sudo mkdir -p "$1"
-  sudo chmod a+rw "$1"
+  sudo install -d -m 755 "$1"
+}
+
+# Chromium-family browsers write their theme colour here (color.json) as the
+# user through omarchy-theme-set-browser, so hand the directory to that user at
+# 0755 instead of making it world-writable. A world-writable managed-policy
+# directory lets any local user or process drop a mandatory browser policy -- an
+# extension forcelist, a proxy, disabled Safe Browsing -- that every browser obeys.
+setup_chromium_policy_directory() {
+  sudo install -d -o "$USER" -g "$(id -gn)" -m 755 "$1"
 }
 
 announce_browser_installed() {
@@ -40,7 +48,7 @@ chromium)
   echo "Installing Chromium..."
   omarchy-pkg-add chromium
 
-  setup_policy_directory /etc/chromium/policies/managed
+  setup_chromium_policy_directory /etc/chromium/policies/managed
   copy_chromium_flags ~/.config/chromium-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Chromium"
@@ -49,7 +57,7 @@ chrome)
   echo "Installing Chrome..."
   omarchy-pkg-aur-add google-chrome || exit 1
 
-  setup_policy_directory /etc/opt/chrome/policies/managed
+  setup_chromium_policy_directory /etc/opt/chrome/policies/managed
   copy_chromium_flags ~/.config/chrome-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Chrome"
@@ -58,7 +66,7 @@ edge)
   echo "Installing Edge..."
   omarchy-pkg-aur-add microsoft-edge-stable-bin || exit 1
 
-  setup_policy_directory /etc/opt/edge/policies/managed
+  setup_chromium_policy_directory /etc/opt/edge/policies/managed
   copy_chromium_flags ~/.config/microsoft-edge-stable-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Edge"
@@ -67,7 +75,7 @@ brave)
   echo "Installing Brave..."
   omarchy-pkg-aur-add brave-bin || exit 1
 
-  setup_policy_directory /etc/brave/policies/managed
+  setup_chromium_policy_directory /etc/brave/policies/managed
   copy_chromium_flags ~/.config/brave-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Brave"
@@ -76,7 +84,7 @@ brave-origin)
   echo "Installing Brave Origin..."
   omarchy-pkg-aur-add brave-origin-bin || exit 1
 
-  setup_policy_directory /etc/brave/policies/managed
+  setup_chromium_policy_directory /etc/brave/policies/managed
   copy_chromium_flags ~/.config/brave-origin-flags.conf
   omarchy-theme-set-browser
   announce_browser_installed "Brave Origin"

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -744,6 +744,20 @@ create_user() {
   chmod 440 /etc/sudoers.d/00-omarchy-wheel
 }
 
+# In the deferred-provisioning path OMARCHY_INSTALL_USER is empty when
+# install/config/theme-system.sh creates /etc/chromium/policies/managed, so the
+# directory stays root-owned and omarchy-theme-set-browser (which runs as the
+# user) cannot write color.json. Now that the account exists, hand the directory
+# to the user at 0755 so theming works, without ever making it world-writable.
+claim_browser_policy_dir() {
+  local dir=/etc/chromium/policies/managed
+
+  [[ -d $dir ]] || return 0
+
+  chown "$username:$username" "$dir"
+  chmod 755 "$dir"
+}
+
 install_authorized_keys() {
   [[ -f $PROVISIONING_DIR/authorized_keys ]] || return 0
 
@@ -991,6 +1005,7 @@ cleanup_oem_state() {
 run_provisioning() {
   log_step "creating user $username"
   create_user
+  claim_browser_policy_dir
   install_authorized_keys
   configure_login
 

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1312,7 +1312,10 @@ apply_system_transition() {
     /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
   as_root gtk-update-icon-cache /usr/share/icons/Yaru >/dev/null 2>&1 || true
 
-  as_root install -d -m 0777 /etc/chromium/policies/managed
+  # Owned by the upgrading user at 0755, not world-writable: the theme colour
+  # file is written here as that user, and a world-writable managed-policy
+  # directory would let any local user force a mandatory browser policy.
+  as_root install -d -o "$target_user" -g "$(id -gn "$target_user")" -m 0755 /etc/chromium/policies/managed
   as_root install -d -m 0755 /usr/lib/chromium
   printf '%s\n' '{"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}' | \
     as_root tee /usr/lib/chromium/initial_preferences >/dev/null

--- a/install/config/theme-system.sh
+++ b/install/config/theme-system.sh
@@ -6,9 +6,16 @@ ln -snf /usr/share/icons/Adwaita/symbolic/actions/go-next-symbolic.svg \
           /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
 gtk-update-icon-cache /usr/share/icons/Yaru &>/dev/null || true
 
-# Chromium policy directory for theme
+# Chromium policy directory for theme. omarchy-theme-set-browser writes the theme
+# colour file (color.json) here as the user, so give the directory to that user at
+# 0755 rather than making it world-writable: a world-writable managed-policy
+# directory lets any local user or process force a mandatory browser policy -- an
+# extension forcelist, a proxy, disabled Safe Browsing.
 mkdir -p /etc/chromium/policies/managed
-chmod a+rw /etc/chromium/policies/managed
+if [[ -n ${OMARCHY_INSTALL_USER:-} ]]; then
+  chown "$OMARCHY_INSTALL_USER:$(id -gn "$OMARCHY_INSTALL_USER")" /etc/chromium/policies/managed
+fi
+chmod 755 /etc/chromium/policies/managed
 
 # Default Chromium to follow system appearance ("device") instead of dark
 mkdir -p /usr/lib/chromium

--- a/migrations/1787636874.sh
+++ b/migrations/1787636874.sh
@@ -1,0 +1,41 @@
+echo "Lock down world-writable browser managed-policy directories"
+
+# Omarchy used to make each browser's managed-policy directory world-writable
+# (chmod a+rw) so the theme colour file could be written as the user. A
+# world-writable managed-policy directory lets any local user or process drop a
+# mandatory browser policy -- an extension forcelist, a proxy, disabled Safe
+# Browsing -- that every browser then obeys. Close that on existing installs.
+# Chromium-family directories are still written by the user who themes the
+# browser, so they are handed to this user at 0755; firefox/zen only ever receive
+# a root-written policies.json, so they return to root ownership.
+
+lock_policy_dir() {
+  local dir="$1"
+  local owner="$2"
+
+  [[ -d $dir ]] || return 0
+
+  # Only act while the directory is still group- or other-writable. A second user
+  # on the machine, or a re-run after the repair, then needs no privilege prompt
+  # and changes nothing.
+  if [[ -z $(find "$dir" -maxdepth 0 -perm /022 -print 2>/dev/null) ]]; then
+    return 0
+  fi
+
+  sudo chown "$owner" "$dir"
+  sudo chmod 755 "$dir"
+}
+
+for dir in \
+  /etc/chromium/policies/managed \
+  /etc/opt/chrome/policies/managed \
+  /etc/opt/edge/policies/managed \
+  /etc/brave/policies/managed; do
+  lock_policy_dir "$dir" "$USER:$(id -gn)"
+done
+
+for dir in \
+  /usr/lib/firefox/distribution \
+  /opt/zen-browser/distribution; do
+  lock_policy_dir "$dir" "root:root"
+done

--- a/migrations/1787636874.sh
+++ b/migrations/1787636874.sh
@@ -5,22 +5,47 @@ echo "Lock down world-writable browser managed-policy directories"
 # world-writable managed-policy directory lets any local user or process drop a
 # mandatory browser policy -- an extension forcelist, a proxy, disabled Safe
 # Browsing -- that every browser then obeys. Close that on existing installs.
+#
+# Locking the directory is not enough on its own: a policy file another account
+# already dropped, or one left group/other-writable, stays under that account's
+# control afterwards. So each entry is repaired too. A managed-policy directory
+# holds only regular policy files; a symlink there is never legitimate, and a
+# file owned by neither root nor the theming user was planted by another account
+# while the directory was open, so neither survives the repair.
+#
 # Chromium-family directories are still written by the user who themes the
-# browser, so they are handed to this user at 0755; firefox/zen only ever receive
-# a root-written policies.json, so they return to root ownership.
+# browser (color.json), so they are handed to this user at 0755 and that user may
+# keep a writable color.json. Firefox/zen only ever receive a root-written
+# policies.json, so they return to root ownership and keep no user-writable file.
 
 lock_policy_dir() {
   local dir="$1"
   local owner="$2"
+  local keep_owner="$3" # account allowed to keep a writable file, or empty for root-only dirs
 
   [[ -d $dir ]] || return 0
 
-  # Only act while the directory is still group- or other-writable. A second user
-  # on the machine, or a re-run after the repair, then needs no privilege prompt
-  # and changes nothing.
-  if [[ -z $(find "$dir" -maxdepth 0 -perm /022 -print 2>/dev/null) ]]; then
+  # Only act while something is still wrong: the directory is group/other-writable,
+  # or it holds a symlink or a group/other-writable entry. After the repair, and
+  # for a second user on the machine, this is a no-op and needs no privilege prompt.
+  if [[ -z $(find "$dir" -maxdepth 0 -perm /022 -print 2>/dev/null) &&
+        -z $(find "$dir" -mindepth 1 -maxdepth 1 \( -type l -o -perm /022 \) -print 2>/dev/null) ]]; then
     return 0
   fi
+
+  local entry entry_owner
+  while IFS= read -r -d '' entry; do
+    if [[ -L $entry ]]; then
+      sudo rm -f "$entry"
+      continue
+    fi
+    entry_owner=$(stat -c '%U' "$entry" 2>/dev/null || echo "")
+    if [[ $entry_owner != "root" && ( -z $keep_owner || $entry_owner != "$keep_owner" ) ]]; then
+      sudo rm -f "$entry"
+      continue
+    fi
+    sudo chmod go-w "$entry"
+  done < <(find "$dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null)
 
   sudo chown "$owner" "$dir"
   sudo chmod 755 "$dir"
@@ -31,11 +56,11 @@ for dir in \
   /etc/opt/chrome/policies/managed \
   /etc/opt/edge/policies/managed \
   /etc/brave/policies/managed; do
-  lock_policy_dir "$dir" "$USER:$(id -gn)"
+  lock_policy_dir "$dir" "$USER:$(id -gn)" "$USER"
 done
 
 for dir in \
   /usr/lib/firefox/distribution \
   /opt/zen-browser/distribution; do
-  lock_policy_dir "$dir" "root:root"
+  lock_policy_dir "$dir" "root:root" ""
 done


### PR DESCRIPTION
Browser managed-policy directories were created world-writable (`chmod a+rw` / `install -d -m 0777`), so any local account can force a mandatory browser policy (extension forcelist, proxy, Safe Browsing) on every Chromium-family browser.

Fix: create them user-owned at 0755, plus a migration that locks existing installs.
