### PR TITLE
Stop apply-system reruns leaving the install log world-writable

### DIFF
--- a/install/helpers/logging.sh
+++ b/install/helpers/logging.sh
@@ -13,8 +13,33 @@ omarchy_log_line() {
 start_install_log() {
   if ! omarchy_log_to_stdout; then
     mkdir -p "$(dirname "$OMARCHY_INSTALL_LOG_FILE")"
-    touch "$OMARCHY_INSTALL_LOG_FILE"
-    chmod 666 "$OMARCHY_INSTALL_LOG_FILE" 2>/dev/null || true
+
+    # Only root writes here through this helper: the ISO runs the target setup
+    # with OMARCHY_LOG_TO_STDOUT=1 and copies the log itself, so this branch is
+    # reached when omarchy-apply-system or omarchy-apply-hardware is rerun by
+    # hand on an installed system. The old world-writable mode then let every
+    # local account read the step output and append forged lines.
+    #
+    # The log is published as a fresh file, not chmodded in place. A chmod only
+    # changes who can open the file from now on; a process that already had the
+    # old 0666 file open keeps writing to it. Building the new file privately
+    # and moving it over the old name leaves such a descriptor pointing at an
+    # unlinked inode. Existing content is carried across.
+    #
+    # Mode 0640 with group wheel: the owner account is in wheel and already has
+    # full sudo, so wheel read gives up nothing, and omarchy-upload-log can
+    # still read the log as that user. Other local accounts are shut out.
+    local old_umask staged
+    old_umask=$(umask)
+    umask 077
+    staged=$(mktemp "$OMARCHY_INSTALL_LOG_FILE.XXXXXX")
+    umask "$old_umask"
+    if [[ -f $OMARCHY_INSTALL_LOG_FILE ]]; then
+      cat "$OMARCHY_INSTALL_LOG_FILE" >>"$staged" 2>/dev/null || true
+    fi
+    chgrp wheel "$staged" 2>/dev/null || true
+    chmod 640 "$staged"
+    mv -f "$staged" "$OMARCHY_INSTALL_LOG_FILE"
   fi
 
   export OMARCHY_START_TIME="${OMARCHY_START_TIME:-$(date '+%Y-%m-%d %H:%M:%S')}"

--- a/test/shell.d/logging-test.sh
+++ b/test/shell.d/logging-test.sh
@@ -49,3 +49,80 @@ grep -q "about to fail" "$stdout_log" || fail "stdout logging mode emits script 
 grep -q "Failed: $failing_script (exit code: 1)" "$stdout_log" || fail "stdout logging mode emits failure marker"
 
 pass "run_logged records failures under errexit"
+
+
+# --- start_install_log permissions ---------------------------------------------
+
+# start_install_log only writes the file when a root-side apply command is
+# rerun by hand on an installed system (the ISO logs to stdout and copies the
+# log itself). It used to chmod 666 the file, so every local account could read
+# the step output and append forged lines. Only root writes it; wheel may read
+# it so omarchy-upload-log keeps working for the owner account.
+
+grep -q 'chmod 666' "$ROOT/install/helpers/logging.sh" &&
+  fail "install log is no longer world readable and writable"
+grep -q 'chmod 640' "$ROOT/install/helpers/logging.sh" ||
+  fail "install log is readable by root and wheel only"
+pass "install log is readable by root and wheel only in the source"
+
+# Logging still works after the permission change.
+perms_log="$work_dir/perms-install.log"
+(
+  set -euo pipefail
+  export OMARCHY_INSTALL_LOG_FILE="$perms_log"
+  source "$ROOT/install/helpers/logging.sh"
+  start_install_log
+  omarchy_log_line "still logging"
+)
+grep -q "still logging" "$perms_log" ||
+  fail "start_install_log still writes the log"
+pass "start_install_log still writes the log"
+
+# Where the filesystem reports modes faithfully, pin the actual bits. A
+# filesystem that maps everything to one mode takes the source check above
+# instead.
+mode_probe="$work_dir/mode-probe"
+touch "$mode_probe"
+chmod 600 "$mode_probe"
+if [[ $(stat -c %a "$mode_probe") == "600" ]]; then
+  (
+    set -euo pipefail
+    export OMARCHY_INSTALL_LOG_FILE="$work_dir/root-only.log"
+    source "$ROOT/install/helpers/logging.sh"
+    start_install_log >/dev/null
+  )
+  [[ $(stat -c %a "$work_dir/root-only.log") == "640" ]] ||
+    fail "a new install log is 0640"
+
+  # A log left behind by an older, 0666 version is replaced the moment the new
+  # run starts: same name, same content, new inode, restricted mode.
+  left_open="$work_dir/left-open.log"
+  printf 'earlier run\n' >"$left_open"
+  chmod 666 "$left_open"
+  old_inode=$(stat -c %i "$left_open")
+
+  # A writer that opened the old file before the rerun. A chmod alone would
+  # leave this descriptor able to append; the fresh file must not see it.
+  exec 7>>"$left_open"
+
+  (
+    set -euo pipefail
+    export OMARCHY_INSTALL_LOG_FILE="$left_open"
+    source "$ROOT/install/helpers/logging.sh"
+    start_install_log >/dev/null
+  )
+  printf 'stale write\n' >&7
+  exec 7>&-
+
+  [[ $(stat -c %a "$left_open") == "640" ]] ||
+    fail "an existing world-open install log is restricted at startup"
+  [[ $(stat -c %i "$left_open") != "$old_inode" ]] ||
+    fail "an existing world-open install log is replaced, not chmodded in place"
+  grep -q 'earlier run' "$left_open" ||
+    fail "replacing the install log keeps its earlier content"
+  grep -q 'stale write' "$left_open" &&
+    fail "a descriptor opened on the old install log cannot write to the new one"
+  pass "install log is 0640 when new, and an old 0666 log is replaced with a fresh file"
+else
+  pass "filesystem does not report modes here; mode bits pinned by the source check"
+fi


### PR DESCRIPTION
`install/helpers/logging.sh` starts the install log like this:

```bash
touch "$OMARCHY_INSTALL_LOG_FILE"
chmod 666 "$OMARCHY_INSTALL_LOG_FILE" 2>/dev/null || true
```

Scope first, because it is narrower than I first wrote. On a fresh install this code never runs: the ISO orchestrator (`phases_impl.py`) runs `omarchy-apply-system` and `omarchy-provision-user` with `OMARCHY_LOG_TO_STDOUT=1`, and in that mode `start_install_log` skips the `touch` and `chmod`. The ISO then copies the log into the target itself and leaves it 0644 root:root. That mode comes from the ISO and is out of scope here. `omarchy-provision-owner` also runs first-boot finalization with `OMARCHY_LOG_TO_STDOUT=1`.

The `chmod 666` fires when someone reruns `omarchy-apply-system` or `omarchy-apply-hardware` by hand on an installed system, which the scripts allow for diagnostics. From that point `/var/log/omarchy-install.log` is world-readable and world-writable. Reading it gives every local account the output of every root-side setup step. Writing it lets anyone append forged `Completed:` or `Failed:` lines or truncate the file. This is also the file `omarchy upload` sends in when someone reports a broken install.

What changed:

- The log is published as a fresh file, not chmodded in place. `start_install_log` builds it under `umask 077`, copies any existing content across, sets it to 0640 root:wheel, and moves it over the old name. A chmod alone only changes who can open the file from then on; a process that already had the old 0666 file open would keep writing. With the move, that descriptor points at an unlinked inode.
- Mode 0640 with group wheel rather than 0600. The owner account is in wheel and already has full sudo, so wheel read gives up nothing, and `omarchy-upload-log install` keeps reading the log as that user without a new privileged helper. Other local accounts are shut out. 0600 would have made the upload go out with an empty log.
- No second writer. I checked every caller of `start_install_log` and every reader of `OMARCHY_INSTALL_LOG_FILE` in `bin/` and `install/`: only root writes this file through `logging.sh`. `omarchy-provision-user` only sources `logging.sh` when the ISO or `omarchy-provision-owner` hands it a log path, and both of those set `OMARCHY_LOG_TO_STDOUT=1`.

Not in this PR: cleaning up a 0666 log on systems where nobody reruns an apply command. That needs a package-upgrade migration, which #9465 covers on top of this base.

Tests: `test/shell.d/logging-test.sh` gains a source check that `chmod 666` is gone and `chmod 640` is present, a run that proves logging still works after the change, and, where the filesystem reports modes faithfully, checks that a new log is 0640, that an old 0666 log is replaced by a new inode with its content kept, and that a descriptor opened on the old file cannot write into the new one. All pass. The runtime cases fail against the base `logging.sh` and against a chmod-in-place version.
