### PR TITLE
Refuse hook and state names that are paths

### DIFF
--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -11,6 +11,18 @@ if (( $# < 1 )); then
 fi
 
 HOOK=$1
+
+# Hook names are fixed labels chosen by Omarchy code (post-update, theme-set,
+# font-set). The name becomes a filename under the hooks directory. A slash
+# would turn it into directory levels, and a bare `.` or `..` would point bash
+# at the directory itself or its parent. Refuse those rather than follow them.
+# Dots inside a name (a..b) are fine; once slashes are out, only the whole
+# name being `.` or `..` can leave the directory.
+if [[ -z $HOOK || $HOOK == */* || $HOOK == "." || $HOOK == ".." ]]; then
+  echo "Invalid hook name: $HOOK" >&2
+  exit 2
+fi
+
 HOOK_PATH="$HOME/.config/omarchy/hooks/$1"
 HOOK_DIR="$HOOK_PATH.d"
 shift

--- a/bin/omarchy-hook-install
+++ b/bin/omarchy-hook-install
@@ -15,6 +15,17 @@ fi
 
 HOOK_TYPE=$1
 HOOK_FILE=$2
+
+# Hook types are the same labels omarchy-hook runs (post-update, theme-set).
+# The type becomes a directory under the hooks directory. A slash would turn
+# it into directory levels. A bare `.` or `..` is a name the runner already
+# refuses, so installing under it would write a hook nothing can run. Refuse
+# those rather than mkdir/cp into them. Dots inside a name (a..b) are fine.
+if [[ -z $HOOK_TYPE || $HOOK_TYPE == */* || $HOOK_TYPE == "." || $HOOK_TYPE == ".." ]]; then
+  echo "Invalid hook name: $HOOK_TYPE" >&2
+  exit 2
+fi
+
 HOOK_DIR="$HOME/.config/omarchy/hooks/$HOOK_TYPE.d"
 HOOK_NAME=$(basename "$HOOK_FILE")
 HOOK_PATH="$HOOK_DIR/$HOOK_NAME"

--- a/bin/omarchy-state
+++ b/bin/omarchy-state
@@ -21,6 +21,19 @@ if [[ -z $STATE_NAME ]]; then
 fi
 
 case "$COMMAND" in
-set) touch "$STATE_DIR/$STATE_NAME" ;;
+set)
+  # State names are fixed labels (reboot-required, restart-*-required). The
+  # name becomes a filename under the state directory. A slash would turn it
+  # into directory levels, and a bare `.` or `..` would touch the directory
+  # itself or its parent. Refuse those. Dots inside a name (a..b) are fine;
+  # once slashes are out, only the whole name being `.` or `..` can leave the
+  # directory. clear needs no such guard: find -name matches basenames only,
+  # so a pattern can never walk out of the directory.
+  if [[ $STATE_NAME == */* || $STATE_NAME == "." || $STATE_NAME == ".." ]]; then
+    echo "Invalid state name: $STATE_NAME" >&2
+    exit 2
+  fi
+  touch "$STATE_DIR/$STATE_NAME"
+  ;;
 clear) find "$STATE_DIR" -maxdepth 1 -type f -name "$STATE_NAME" -delete ;;
 esac

--- a/test/shell.d/hook-state-name-guard-test.sh
+++ b/test/shell.d/hook-state-name-guard-test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+fake_home="$work_dir/home"
+mkdir -p "$fake_home/.config/omarchy/hooks" "$fake_home/.local/state/omarchy"
+
+# --- omarchy-hook --------------------------------------------------------------
+
+# A hook name is a label, not a path. One carrying a slash, or one that is a
+# bare `.` or `..`, would run a script from outside the hooks directory.
+
+cat >"$fake_home/.config/omarchy/hooks/test-hook" <<'SH'
+touch "$HOME/hook-ran"
+SH
+
+HOME="$fake_home" "$ROOT/bin/omarchy-hook" test-hook
+[[ -f $fake_home/hook-ran ]] ||
+  fail "omarchy hook runs a named hook from the hooks directory"
+pass "omarchy hook runs a named hook from the hooks directory"
+
+# Dots inside a name are not a path. a..b stays inside the hooks directory.
+cat >"$fake_home/.config/omarchy/hooks/a..b" <<'SH'
+touch "$HOME/dotted-hook-ran"
+SH
+
+HOME="$fake_home" "$ROOT/bin/omarchy-hook" a..b
+[[ -f $fake_home/dotted-hook-ran ]] ||
+  fail "omarchy hook accepts a hook name with dots in the middle"
+pass "omarchy hook accepts a hook name with dots in the middle"
+
+for name in . ..; do
+  status=0
+  HOME="$fake_home" "$ROOT/bin/omarchy-hook" "$name" >/dev/null 2>&1 || status=$?
+  (( status == 2 )) ||
+    fail "omarchy hook refuses a hook name of $name" "exit: $status"
+  pass "omarchy hook refuses a hook name of $name"
+done
+
+# This file sits where a name of ../../evil would resolve: hooks/../.. is
+# ~/.config.
+cat >"$fake_home/.config/evil" <<'SH'
+touch "$HOME/escape-ran"
+SH
+chmod +x "$fake_home/.config/evil"
+
+status=0
+HOME="$fake_home" "$ROOT/bin/omarchy-hook" "../../evil" >/dev/null 2>&1 || status=$?
+(( status == 2 )) ||
+  fail "omarchy hook refuses a hook name with a dot-dot" "exit: $status"
+[[ ! -e $fake_home/escape-ran ]] ||
+  fail "omarchy hook runs nothing when it refuses the name"
+pass "omarchy hook refuses a hook name with a dot-dot"
+
+status=0
+HOME="$fake_home" "$ROOT/bin/omarchy-hook" "sub/dir" >/dev/null 2>&1 || status=$?
+(( status == 2 )) ||
+  fail "omarchy hook refuses a hook name with a slash" "exit: $status"
+pass "omarchy hook refuses a hook name with a slash"
+
+# --- omarchy-state -------------------------------------------------------------
+
+state_dir="$fake_home/.local/state/omarchy"
+
+HOME="$fake_home" "$ROOT/bin/omarchy-state" set reboot-required
+[[ -f $state_dir/reboot-required ]] ||
+  fail "omarchy state set still creates a plain state file"
+pass "omarchy state set still creates a plain state file"
+
+HOME="$fake_home" "$ROOT/bin/omarchy-state" set v1..2
+[[ -f $state_dir/v1..2 ]] ||
+  fail "omarchy state set accepts a state name with dots in the middle"
+pass "omarchy state set accepts a state name with dots in the middle"
+
+for name in . ..; do
+  status=0
+  HOME="$fake_home" "$ROOT/bin/omarchy-state" set "$name" >/dev/null 2>&1 || status=$?
+  (( status == 2 )) ||
+    fail "omarchy state set refuses a state name of $name" "exit: $status"
+  pass "omarchy state set refuses a state name of $name"
+done
+
+# state/../.. is ~/.local. The guard must fire before touch gets there.
+status=0
+HOME="$fake_home" "$ROOT/bin/omarchy-state" set "../../escape" >/dev/null 2>&1 || status=$?
+(( status == 2 )) ||
+  fail "omarchy state set refuses a state name with a dot-dot" "exit: $status"
+[[ ! -e $fake_home/.local/escape ]] ||
+  fail "omarchy state set creates nothing outside the state directory"
+pass "omarchy state set refuses a state name with a dot-dot"
+
+status=0
+HOME="$fake_home" "$ROOT/bin/omarchy-state" set "sub/dir" >/dev/null 2>&1 || status=$?
+(( status == 2 )) ||
+  fail "omarchy state set refuses a state name with a slash" "exit: $status"
+pass "omarchy state set refuses a state name with a slash"
+
+# clear takes patterns by design ("state-name-or-pattern") and matches
+# basenames through find -name, so it can never walk out of the directory.
+touch "$state_dir/restart-a-required" "$state_dir/restart-b-required" "$state_dir/keep-me"
+HOME="$fake_home" "$ROOT/bin/omarchy-state" clear "restart-*-required"
+[[ ! -e $state_dir/restart-a-required && ! -e $state_dir/restart-b-required && -f $state_dir/keep-me ]] ||
+  fail "omarchy state clear still clears matching patterns only"
+pass "omarchy state clear still clears matching patterns only"

--- a/test/shell.d/hook-state-name-guard-test.sh
+++ b/test/shell.d/hook-state-name-guard-test.sh
@@ -63,6 +63,55 @@ HOME="$fake_home" "$ROOT/bin/omarchy-hook" "sub/dir" >/dev/null 2>&1 || status=$
   fail "omarchy hook refuses a hook name with a slash" "exit: $status"
 pass "omarchy hook refuses a hook name with a slash"
 
+# --- omarchy-hook-install ------------------------------------------------------
+
+# The installer joins the type into ~/.config/omarchy/hooks/<type>.d before
+# mkdir/cp. The runner already refuses a slashed type; install must too, or a
+# name the runner will not run still lands on disk.
+
+source_hook="$work_dir/source-hook"
+cat >"$source_hook" <<'SH'
+#!/bin/bash
+true
+SH
+
+HOME="$fake_home" "$ROOT/bin/omarchy-hook-install" post-update "$source_hook" >/dev/null
+[[ -f $fake_home/.config/omarchy/hooks/post-update.d/source-hook ]] ||
+  fail "omarchy hook install still installs a named hook"
+pass "omarchy hook install still installs a named hook"
+
+HOME="$fake_home" "$ROOT/bin/omarchy-hook-install" a..b "$source_hook" >/dev/null
+[[ -f $fake_home/.config/omarchy/hooks/a..b.d/source-hook ]] ||
+  fail "omarchy hook install accepts a hook name with dots in the middle"
+pass "omarchy hook install accepts a hook name with dots in the middle"
+
+for name in . ..; do
+  status=0
+  HOME="$fake_home" "$ROOT/bin/omarchy-hook-install" "$name" "$source_hook" >/dev/null 2>&1 || status=$?
+  (( status == 2 )) ||
+    fail "omarchy hook install refuses a hook name of $name" "exit: $status"
+  [[ ! -e $fake_home/.config/omarchy/hooks/${name}.d ]] ||
+    fail "omarchy hook install creates no directory for a hook name of $name"
+  pass "omarchy hook install refuses a hook name of $name"
+done
+
+# hooks/../../evil.d is ~/.config/evil.d. The guard must fire before mkdir.
+status=0
+HOME="$fake_home" "$ROOT/bin/omarchy-hook-install" "../../evil" "$source_hook" >/dev/null 2>&1 || status=$?
+(( status == 2 )) ||
+  fail "omarchy hook install refuses a hook name with a dot-dot" "exit: $status"
+[[ ! -e $fake_home/.config/evil.d ]] ||
+  fail "omarchy hook install creates nothing outside the hooks directory"
+pass "omarchy hook install refuses a hook name with a dot-dot"
+
+status=0
+HOME="$fake_home" "$ROOT/bin/omarchy-hook-install" "sub/dir" "$source_hook" >/dev/null 2>&1 || status=$?
+(( status == 2 )) ||
+  fail "omarchy hook install refuses a hook name with a slash" "exit: $status"
+[[ ! -e $fake_home/.config/omarchy/hooks/sub ]] ||
+  fail "omarchy hook install creates no nested directory from a slashed name"
+pass "omarchy hook install refuses a hook name with a slash"
+
 # --- omarchy-state -------------------------------------------------------------
 
 state_dir="$fake_home/.local/state/omarchy"


### PR DESCRIPTION
`omarchy-hook` and `omarchy-state set` join a name straight into a path without looking at it:

```bash
HOOK_PATH="$HOME/.config/omarchy/hooks/$1"
...
bash "$HOOK_PATH" "$@"
```

```bash
set) touch "$STATE_DIR/$STATE_NAME" ;;
```

On the current code, `omarchy-hook ../../evil` runs `~/.config/evil`, and `omarchy-state set ../../escape` creates `~/.local/escape`. I checked that both happen before this change.

This is a robustness fix, not a security one. Every caller in the repo passes a fixed label: `omarchy-update` runs `omarchy-hook post-update`, `omarchy-theme-set` runs `omarchy-hook theme-set "$THEME_NAME"` (the theme name is the argument, not the hook name), `omarchy-channel-set` and the migrations run `omarchy-state set reboot-required`. No user or network input reaches either command. The guard is there so a future caller that builds a name from something else cannot quietly write or run outside the directory.

What changed:

- Both commands refuse an empty name, a name with a `/` in it, or a name that is exactly `.` or `..`. They exit 2 and print why on stderr.
- Nothing else is refused. Once slashes are out, only a whole name of `.` or `..` can leave the directory, so names like `a..b` or `v1..2` stay valid. This matches how `omarchy-webapp-install` and `omarchy-theme-set` guard their names.
- `omarchy-state clear` is unchanged on purpose. It matches basenames through `find -name`, so a pattern can never walk out of the directory.

Tests: new `test/shell.d/hook-state-name-guard-test.sh`, 13 cases. A plain hook still runs, a plain state file is still created, `a..b` and `v1..2` are accepted, `.` and `..` and `../x` and `sub/dir` are refused with nothing created or run outside the directory, and `clear` still honors glob patterns. Against the code before this change the test stops at the first refusal case. The other hook and state tests (`monitor-state-test.sh`, `nvidia-kms-hook-test.sh`) pass unchanged.