### PR TITLE
Quote launcher arguments so they survive the launch-or-focus re-parse

### DIFF
--- a/bin/omarchy-launch-or-focus-tui
+++ b/bin/omarchy-launch-or-focus-tui
@@ -9,6 +9,10 @@ else
   APP_ID="org.omarchy.$(basename "$1")"
 fi
 
-LAUNCH_COMMAND="omarchy-launch-tui $@"
+# The command crosses omarchy-launch-or-focus as one string and is re-parsed
+# there with eval, so each word is quoted first. An argument holding spaces or
+# shell characters would otherwise arrive as extra words or run as code.
+printf -v quoted '%q ' "$@"
+LAUNCH_COMMAND="omarchy-launch-tui ${quoted% }"
 
 exec omarchy-launch-or-focus "$APP_ID" "$LAUNCH_COMMAND"

--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -10,6 +10,11 @@ fi
 
 WINDOW_PATTERN="$1"
 shift
-LAUNCH_COMMAND="omarchy-launch-webapp $@"
+
+# The command crosses omarchy-launch-or-focus as one string and is re-parsed
+# there with eval, so each word is quoted first. A URL holding & or an argument
+# holding spaces would otherwise split or run as shell syntax on the far side.
+printf -v quoted '%q ' "$@"
+LAUNCH_COMMAND="omarchy-launch-webapp ${quoted% }"
 
 exec omarchy-launch-or-focus "$WINDOW_PATTERN" "$LAUNCH_COMMAND"

--- a/bin/omarchy-launch-tui
+++ b/bin/omarchy-launch-tui
@@ -7,7 +7,7 @@ if [[ ${1:-} == --app-id=* ]]; then
   APP_ID="${1#--app-id=}"
   shift
 else
-  APP_ID="org.omarchy.$(basename $1)"
+  APP_ID="org.omarchy.$(basename "$1")"
 fi
 
-exec setsid uwsm-app -- xdg-terminal-exec --app-id=$APP_ID -e "$1" "${@:2}"
+exec setsid uwsm-app -- xdg-terminal-exec --app-id="$APP_ID" -e "$1" "${@:2}"

--- a/config/omarchy/extensions/omarchy-menu.jsonc
+++ b/config/omarchy/extensions/omarchy-menu.jsonc
@@ -25,6 +25,8 @@
   // providers map in Menu.qml). Static submenus only need dotted ids.
   //
   // Example: replace the default About action by reusing the same id. Existing
-  // fields are kept unless overridden.
-  // "about": {"icon":"","label":"About","action":"omarchy-launch-or-focus-tui \"zsh -c 'fastfetch; read -k 1'\""},
+  // fields are kept unless overridden. Pass the command and its arguments as
+  // separate words. The wrapper keeps each word intact, so a quoted multi-word
+  // string would reach the terminal as one argument.
+  // "about": {"icon":"","label":"About","action":"omarchy-launch-or-focus-tui zsh -c 'fastfetch; read -k 1'"},
 }

--- a/test/shell.d/launch-wrapper-argv-test.sh
+++ b/test/shell.d/launch-wrapper-argv-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+stub_bin="$work_dir/bin"
+argv_log="$work_dir/argv.log"
+mkdir -p "$stub_bin"
+: >"$argv_log"
+
+# No windows, so every launch takes the exec path.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+printf '[]\n'
+SH
+chmod +x "$stub_bin/hyprctl"
+
+# Records one line per argument, so splitting mistakes show up as extra lines
+# and a re-parsed metacharacter shows up as a changed line.
+cat >"$stub_bin/setsid" <<SH
+#!/bin/bash
+
+i=0
+for arg in "\$@"; do
+  printf '%d:%s\n' "\$i" "\$arg" >>"$argv_log"
+  i=\$((i + 1))
+done
+SH
+chmod +x "$stub_bin/setsid"
+
+run_wrapper() {
+  : >"$argv_log"
+  PATH="$stub_bin:$ROOT/bin:$PATH" "$@" >/dev/null 2>&1
+}
+
+# --- omarchy-launch-or-focus-tui ------------------------------------------------
+
+# The wrapper hands omarchy-launch-or-focus one string, which re-parses it with
+# eval. Quoting each word first is what keeps an argument whole on that ride.
+run_wrapper "$ROOT/bin/omarchy-launch-or-focus-tui" mytui "two words" 'a;b$(id)'
+
+grep -Fxq '0:omarchy-launch-tui' "$argv_log" ||
+  fail "tui wrapper launches through omarchy-launch-tui" "$(cat "$argv_log")"
+grep -Fxq '2:two words' "$argv_log" ||
+  fail "tui wrapper keeps a two-word argument whole through the re-parse" "$(cat "$argv_log")"
+grep -Fxq '3:a;b$(id)' "$argv_log" ||
+  fail "tui wrapper keeps shell characters inert through the re-parse" "$(cat "$argv_log")"
+(( $(wc -l <"$argv_log") == 4 )) ||
+  fail "tui wrapper adds no extra words through the re-parse" "$(cat "$argv_log")"
+pass "tui wrapper carries arguments whole through the launch-or-focus re-parse"
+
+# The app id flag is part of the same string ride and must survive it too.
+run_wrapper "$ROOT/bin/omarchy-launch-or-focus-tui" --app-id=org.custom mytui
+
+grep -Fxq '1:--app-id=org.custom' "$argv_log" ||
+  fail "tui wrapper keeps the app id flag whole" "$(cat "$argv_log")"
+pass "tui wrapper keeps the app id flag whole"
+
+# --- omarchy-launch-or-focus-webapp ---------------------------------------------
+
+# A URL with a query string holds & and =. Unquoted, eval reads & as a command
+# separator and the browser gets a truncated URL.
+run_wrapper "$ROOT/bin/omarchy-launch-or-focus-webapp" "Chat" 'https://chat.example/?a=1&b=2'
+
+grep -Fxq '1:https://chat.example/?a=1&b=2' "$argv_log" ||
+  fail "webapp wrapper keeps a URL with a query string whole" "$(cat "$argv_log")"
+(( $(wc -l <"$argv_log") == 2 )) ||
+  fail "webapp wrapper adds no extra words through the re-parse" "$(cat "$argv_log")"
+pass "webapp wrapper carries a URL with a query string whole"
+
+# --- omarchy-launch-tui ----------------------------------------------------------
+
+# Direct quoting: the command path and the app id reach the terminal unchanged.
+run_wrapper "$ROOT/bin/omarchy-launch-tui" --app-id=org.custom "/opt/my tools/foo" "two words"
+
+grep -Fxq '2:xdg-terminal-exec' "$argv_log" ||
+  fail "launch-tui still drives xdg-terminal-exec" "$(cat "$argv_log")"
+grep -Fxq '3:--app-id=org.custom' "$argv_log" ||
+  fail "launch-tui quotes the app id" "$(cat "$argv_log")"
+grep -Fxq '5:/opt/my tools/foo' "$argv_log" ||
+  fail "launch-tui keeps a command path with a space whole" "$(cat "$argv_log")"
+grep -Fxq '6:two words' "$argv_log" ||
+  fail "launch-tui keeps arguments whole" "$(cat "$argv_log")"
+pass "launch-tui quotes the app id and the command path"
+
+# Without the flag, the app id comes from the basename of a path that may hold
+# spaces.
+run_wrapper "$ROOT/bin/omarchy-launch-tui" "/opt/my tools/foo"
+
+grep -Fxq '3:--app-id=org.omarchy.foo' "$argv_log" ||
+  fail "launch-tui derives the app id from a path with spaces" "$(cat "$argv_log")"
+pass "launch-tui derives the app id from a path with spaces"


### PR DESCRIPTION
`omarchy-launch-or-focus-tui` and `omarchy-launch-or-focus-webapp` pack their arguments into one string with `$@`, and `omarchy-launch-or-focus` unpacks that string with `eval`:

```bash
# omarchy-launch-or-focus-tui
LAUNCH_COMMAND="omarchy-launch-tui $@"
exec omarchy-launch-or-focus "$APP_ID" "$LAUNCH_COMMAND"
```

```bash
# omarchy-launch-or-focus
eval exec setsid $LAUNCH_COMMAND
```

The pack step drops the quoting, so the eval step re-splits on spaces and re-reads shell characters. `omarchy-launch-or-focus-tui mytui "two words"` hands the TUI three arguments instead of two. A web app URL with a query string fares worse: `omarchy-launch-or-focus-webapp Chat 'https://chat.example/?a=1&b=2'` puts `&` through eval, which reads it as a command separator, and the browser gets the URL cut off at the first `&`.

What changed:

- Both wrappers quote each argument with `printf %q` before joining, so the eval in `omarchy-launch-or-focus` puts back exactly the words it was given.
- `omarchy-launch-tui` quotes two spots that rode along unquoted: `basename "$1"` when deriving the app id, and `--app-id="$APP_ID"` on the xdg-terminal-exec line.
- The commented About example in `config/omarchy/extensions/omarchy-menu.jsonc` now passes `zsh -c '...'` as separate words instead of one quoted string, with a note on why.

Every shipped caller passes fixed strings (keybindings, the menu, `helpers.lua` and its `shell_quote`), and `%q` leaves a plain word untouched, so nothing they launch changes.

One behavior change for custom configs. Before, a multi-word command passed as one quoted string was re-split by the eval, so `{ tui = "btop --utf-force", focus = true }` in a user's `helpers.lua` binding reached the terminal as two words. Now it reaches the terminal as one argument, the same way the non-focus `omarchy-launch-tui` path always treated it. Shell expansion of `~` or `$HOME` inside a wrapper argument also stops, again matching the non-focus path. Anyone with a binding of that shape should split the words, which the updated example shows.

Tests: new `test/shell.d/launch-wrapper-argv-test.sh` drives the real wrappers with a stubbed `hyprctl` and a `setsid` that records its argv one line per argument. Five cases: a two-word argument and a string holding shell characters arrive whole, the app id flag survives the ride, a URL with a query string arrives uncut, and launch-tui quotes its app id and a command path with spaces. They fail against the old code, where the two-word argument split and the URL stopped at the `&`. All 5 pass, along with `default-agent-test.sh` and `launcher-remove-test.sh`, which also go through these wrappers.
