### PR TITLE
Pin trusted PATH in privileged DNS helper

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -6,6 +6,18 @@
 
 set -euo pipefail
 
+# Whenever this runs as root — invoked directly through the passwordless
+# sudoers rule, or re-execed by require_root below — sudo's secure_path decides
+# where a bare helper resolves, and a dev link (etc/sudoers.d/omarchy-dev-path)
+# prepends a user-writable checkout bin/ to it. Every helper this script calls
+# by bare name (dirname, install, tee, rm, nmcli, systemctl, awk) is a system
+# tool, never an omarchy-* command, so pin PATH to trusted system directories
+# and keep root from resolving one out of that checkout. The unprivileged
+# wrapper phase keeps the caller's PATH so it can still find sudo/pkexec.
+if (( EUID == 0 )); then
+  export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+fi
+
 NM_DNS_CONF=/etc/NetworkManager/conf.d/20-omarchy-dns.conf
 
 provider_from_arg() {

--- a/test/shell.d/dns-sudoers-test.sh
+++ b/test/shell.d/dns-sudoers-test.sh
@@ -51,33 +51,38 @@ gated=$(grep -A1 -E '^if \(\( EUID == 0 \)\); then$' "$dns" || true)
 # tr while EUID is 0 without giving an ordinary test run any host privileges.
 root_runner=()
 if (( EUID != 0 )); then
-  if ! unshare --user --map-root-user true 2>/dev/null; then
-    fail "dns trusted-PATH check requires an available unprivileged user namespace"
-  fi
   root_runner=(unshare --user --map-root-user)
 fi
 
-poison_dir=$(mktemp -d)
-poison_ran="$poison_dir/ran"
-for helper in tr awk dirname install tee; do
-  cat >"$poison_dir/$helper" <<SH
+# A sandbox or a hardened kernel can refuse unprivileged user namespaces, and
+# the non-graphical suites have to stay green on any machine -- a skip is a
+# passing test. Only the runtime probe needs the namespace; the static checks
+# above and the elevation checks below run either way.
+if (( EUID == 0 )) || unshare --user --map-root-user true 2>/dev/null; then
+  poison_dir=$(mktemp -d)
+  poison_ran="$poison_dir/ran"
+  for helper in tr awk dirname install tee; do
+    cat >"$poison_dir/$helper" <<SH
 #!/bin/bash
 printf 'x' >"$poison_ran"
 exec "/usr/bin/$helper" "\$@"
 SH
-  chmod +x "$poison_dir/$helper"
-done
+    chmod +x "$poison_dir/$helper"
+  done
 
-if ! PATH="$poison_dir:$PATH" "${root_runner[@]}" bash "$dns" </dev/null >/dev/null 2>&1; then
+  if ! PATH="$poison_dir:$PATH" "${root_runner[@]}" bash "$dns" </dev/null >/dev/null 2>&1; then
+    rm -rf "$poison_dir"
+    fail "root omarchy-dns failed its read-only trusted-PATH probe"
+  fi
+  if [[ -e $poison_ran ]]; then
+    rm -rf "$poison_dir"
+    fail "root omarchy-dns resolved a bare helper from the front of PATH instead of a trusted system path"
+  fi
   rm -rf "$poison_dir"
-  fail "root omarchy-dns failed its read-only trusted-PATH probe"
+  pass "root omarchy-dns resolves system helpers from a trusted PATH, not the invocation PATH"
+else
+  pass "no unprivileged user namespace; skipping the root trusted-PATH probe"
 fi
-if [[ -e $poison_ran ]]; then
-  rm -rf "$poison_dir"
-  fail "root omarchy-dns resolved a bare helper from the front of PATH instead of a trusted system path"
-fi
-rm -rf "$poison_dir"
-pass "root omarchy-dns resolves system helpers from a trusted PATH, not the invocation PATH"
 
 # require_root returns immediately for root, so the stubs below would not stand
 # between the script and the host's real NetworkManager and resolved config.

--- a/test/shell.d/dns-sudoers-test.sh
+++ b/test/shell.d/dns-sudoers-test.sh
@@ -39,7 +39,11 @@ pass "dns sudoers rule is scoped to the stock providers"
 # the pin is gated on EUID rather than set unconditionally.
 grep -Eq '^\s*export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin' "$dns" ||
   fail "omarchy-dns pins PATH to trusted system directories when it holds root"
-grep -Eq '\(\( EUID == 0 \)\)' "$dns" ||
+# require_root carries its own `(( EUID == 0 ))`, so matching that text alone
+# would pass with the pin deleted. Anchor on the unindented guard and require the
+# pin to be the line it opens.
+gated=$(grep -A1 -E '^if \(\( EUID == 0 \)\); then$' "$dns" || true)
+[[ $gated == *"export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin"* ]] ||
   fail "omarchy-dns gates the trusted-PATH pin on holding root"
 
 # The no-argument path only reads DNS config, so exercise the privileged phase

--- a/test/shell.d/dns-sudoers-test.sh
+++ b/test/shell.d/dns-sudoers-test.sh
@@ -30,6 +30,51 @@ grep -E 'sudo -n -l -l' "$dns" >/dev/null ||
 
 pass "dns sudoers rule is scoped to the stock providers"
 
+# The privileged half runs as root under sudo's secure_path, and a dev link
+# (etc/sudoers.d/omarchy-dev-path) prepends a user-writable checkout bin/ to it.
+# Every helper the script calls by bare name -- dirname, install, tee, nmcli,
+# systemctl, awk -- is a system tool, so once it holds root the script pins PATH
+# to trusted system directories and never resolves one of them out of the
+# checkout. The unprivileged wrapper phase keeps the caller's PATH, which is why
+# the pin is gated on EUID rather than set unconditionally.
+grep -Eq '^\s*export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin' "$dns" ||
+  fail "omarchy-dns pins PATH to trusted system directories when it holds root"
+grep -Eq '\(\( EUID == 0 \)\)' "$dns" ||
+  fail "omarchy-dns gates the trusted-PATH pin on holding root"
+
+# The no-argument path only reads DNS config, so exercise the privileged phase
+# directly when the suite is root and as namespaced root otherwise. This reaches
+# tr while EUID is 0 without giving an ordinary test run any host privileges.
+root_runner=()
+if (( EUID != 0 )); then
+  if ! unshare --user --map-root-user true 2>/dev/null; then
+    fail "dns trusted-PATH check requires an available unprivileged user namespace"
+  fi
+  root_runner=(unshare --user --map-root-user)
+fi
+
+poison_dir=$(mktemp -d)
+poison_ran="$poison_dir/ran"
+for helper in tr awk dirname install tee; do
+  cat >"$poison_dir/$helper" <<SH
+#!/bin/bash
+printf 'x' >"$poison_ran"
+exec "/usr/bin/$helper" "\$@"
+SH
+  chmod +x "$poison_dir/$helper"
+done
+
+if ! PATH="$poison_dir:$PATH" "${root_runner[@]}" bash "$dns" </dev/null >/dev/null 2>&1; then
+  rm -rf "$poison_dir"
+  fail "root omarchy-dns failed its read-only trusted-PATH probe"
+fi
+if [[ -e $poison_ran ]]; then
+  rm -rf "$poison_dir"
+  fail "root omarchy-dns resolved a bare helper from the front of PATH instead of a trusted system path"
+fi
+rm -rf "$poison_dir"
+pass "root omarchy-dns resolves system helpers from a trusted PATH, not the invocation PATH"
+
 # require_root returns immediately for root, so the stubs below would not stand
 # between the script and the host's real NetworkManager and resolved config.
 if (( EUID == 0 )); then


### PR DESCRIPTION
Harden omarchy-dns against PATH hijacking when it runs with root privileges.

Once the script has an effective UID of root, it now replaces PATH with trusted system directories  before invoking helpers such as dirname, install, tee, rm, nmcli, systemctl, and awk.

  ## Security issue

  omarchy dev link adds the user-writable checkout’s `bin/` directory to sudo’s `secure_path`. This ensures privileged Omarchy commands resolve to development versions, but it also affects subprocesses launched by those commands.

  Omarchy permits wheel users to run the following commands without a password:

```
  /usr/bin/omarchy-dns Cloudflare
  /usr/bin/omarchy-dns Google
  /usr/bin/omarchy-dns DHCP
```

  Although sudo executes the packaged `/usr/bin/omarchy-dns`, the script previously inherited the dev-
  linked `secure_path`. Its bare helper commands could therefore resolve from the user-writable
  checkout.

  An attacker able to write to the checkout could place a malicious executable such as install in its
  bin/ directory and trigger a permitted DNS change. The helper would then execute as root without
  requiring a password.

  ## Fix

  When `omarchy-dns` detects that it is running as root, it sets:

`  PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin`

  The restriction is applied only after elevation. The unprivileged wrapper phase retains the caller’s
  PATH so it can continue locating sudo or pkexec normally.

  All helpers used by the privileged portion are system utilities, so it does not need access to the
  dev checkout.

  ## Tests

  Added regression coverage which:

  - verifies that the trusted PATH is applied only while running as root;
  - places poisoned helper executables at the front of the invocation PATH;
  - confirms the privileged DNS script ignores those executables;
  - preserves the existing sudoers scope and elevation behavior.

  Validation performed:

```
  ./test/shell.d/dns-sudoers-test.sh
  bash test/shell.d/dev-link-test.sh
  bash test/shell.d/bin-style-test.sh
  ./test/cli
  bash -n bin/omarchy-dns test/shell.d/dns-sudoers-test.sh
  git diff --check
```