### PR TITLE
Point ~/.XCompose and the power udev rules at the packaged tree after the quattro upgrade

### DIFF
--- a/migrations/1787639388.sh
+++ b/migrations/1787639388.sh
@@ -1,0 +1,34 @@
+echo "Point ~/.XCompose and the power udev rules at the packaged Omarchy tree"
+
+# Omarchy 3 wrote ~/.XCompose with an include under ~/.local/share/omarchy and
+# installed udev rules that ran omarchy-powerprofiles-set and
+# omarchy-wifi-powersave out of that same checkout. The quattro upgrade rewrote
+# neither, so both only kept working through the ~/.local/share/omarchy compat
+# symlink it leaves behind. Remove that symlink -- an obvious cleanup next to the
+# upgrade's backup of the old checkout -- and xkbcommon rejects the whole
+# ~/.XCompose on the failed include, taking every CapsLock sequence (emoji,
+# name, email) with it, while udev keeps shelling out to a path that no longer
+# exists on every power-source change. Point the include at the packaged file
+# and drop the rules: quattro's shell switches power profiles itself.
+
+xcompose="$HOME/.XCompose"
+rules_dir="${OMARCHY_UDEV_RULES_DIR:-/etc/udev/rules.d}"
+
+if [[ -f $xcompose ]] && grep -q 'local/share/omarchy/default/xcompose' "$xcompose"; then
+  sed -i -E 's|^([[:space:]]*include[[:space:]]+")[^"]*/\.local/share/omarchy/default/xcompose"|\1/usr/share/omarchy/default/xcompose"|' "$xcompose"
+  # A headless update has no session to reload; the next login picks it up.
+  omarchy-restart-xcompose >/dev/null 2>&1 || true
+fi
+
+reload_udev=0
+for rule in 99-power-profile 99-wifi-powersave; do
+  file="$rules_dir/$rule.rules"
+  if [[ -f $file ]] && grep -q 'local/share/omarchy' "$file"; then
+    sudo rm -f "$file"
+    reload_udev=1
+  fi
+done
+
+if (( reload_udev )); then
+  sudo udevadm control --reload || true
+fi

--- a/test/shell.d/xcompose-packaged-path-migration-test.sh
+++ b/test/shell.d/xcompose-packaged-path-migration-test.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787639388.sh"
+[[ -f $migration ]] || fail "the XCompose packaged-path migration exists at $migration"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo\t%s\n' "$*" >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/udevadm" <<'SH'
+#!/bin/bash
+
+printf 'udevadm\t%s\n' "$*" >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-restart-xcompose" <<'SH'
+#!/bin/bash
+
+echo 'omarchy-restart-xcompose' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+packaged_include='include "/usr/share/omarchy/default/xcompose"'
+
+reset_fixture() {
+  rm -rf "$test_tmp/home" "$test_tmp/rules.d"
+  mkdir -p "$test_tmp/home" "$test_tmp/rules.d"
+  : >"$calls"
+}
+
+write_xcompose() {
+  cat >"$test_tmp/home/.XCompose" <<EOF
+# Run omarchy-restart-xcompose to apply changes
+
+# Include fast emoji access
+$1
+
+# Identification
+<Multi_key> <space> <n> : "Test User"
+<Multi_key> <space> <e> : "test@example.com"
+EOF
+}
+
+run_migration() {
+  HOME="$test_tmp/home" \
+    TEST_LOG="$calls" \
+    OMARCHY_UDEV_RULES_DIR="$test_tmp/rules.d" \
+    PATH="$stub_bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# Omarchy 3 wrote the include with the %H home shorthand; a hand-edited file may
+# spell the same location with ~ or the expanded home. All of them only resolve
+# through the ~/.local/share/omarchy compat symlink the upgrade left behind.
+for legacy_include in \
+  'include "%H/.local/share/omarchy/default/xcompose"' \
+  'include "~/.local/share/omarchy/default/xcompose"' \
+  "include \"$test_tmp/home/.local/share/omarchy/default/xcompose\""; do
+  reset_fixture
+  write_xcompose "$legacy_include"
+
+  run_migration || fail "migration succeeds for $legacy_include"
+  grep -qxF "$packaged_include" "$test_tmp/home/.XCompose" ||
+    fail "migration points $legacy_include at the packaged compose file" "$(cat "$test_tmp/home/.XCompose")"
+  ! grep -q 'local/share/omarchy' "$test_tmp/home/.XCompose" ||
+    fail "migration leaves no legacy include behind for $legacy_include"
+done
+pass "migration repoints a legacy ~/.XCompose include at the packaged compose file"
+
+grep -qF '<Multi_key> <space> <e> : "test@example.com"' "$test_tmp/home/.XCompose" ||
+  fail "migration preserves the user's own compose sequences"
+grep -qxF 'omarchy-restart-xcompose' "$calls" ||
+  fail "migration reloads compose sequences after rewriting the include"
+pass "migration keeps the user's sequences and reloads them"
+
+reset_fixture
+write_xcompose "$packaged_include"
+before_hash=$(sha256sum "$test_tmp/home/.XCompose" | cut -d' ' -f1)
+run_migration || fail "migration succeeds on an already packaged include"
+[[ $(sha256sum "$test_tmp/home/.XCompose" | cut -d' ' -f1) == "$before_hash" ]] ||
+  fail "migration leaves an already packaged include untouched"
+! grep -q 'omarchy-restart-xcompose' "$calls" ||
+  fail "migration does not restart compose when nothing changed"
+pass "migration is idempotent on an already packaged include"
+
+reset_fixture
+run_migration || fail "migration succeeds without a ~/.XCompose"
+[[ ! -e $test_tmp/home/.XCompose ]] || fail "migration does not create a ~/.XCompose"
+pass "migration leaves a home without ~/.XCompose alone"
+
+# Omarchy 3 installed these two rules with the user's checkout path baked in;
+# quattro's shell switches power profiles itself, so the rules are dead weight
+# that fails on every power-source change once the compat symlink is gone.
+reset_fixture
+cat >"$test_tmp/rules.d/99-power-profile.rules" <<'EOF'
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-power-profile /home/test/.local/share/omarchy/bin/omarchy-powerprofiles-set"
+EOF
+cat >"$test_tmp/rules.d/99-wifi-powersave.rules" <<'EOF'
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", ATTR{online}=="0", RUN+="/usr/bin/systemd-run --no-block --collect --unit=omarchy-wifi-powersave-on /home/test/.local/share/omarchy/bin/omarchy-wifi-powersave on"
+EOF
+cat >"$test_tmp/rules.d/99-power-profile-custom.rules" <<'EOF'
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/local/bin/my-own-hook"
+EOF
+run_migration || fail "migration succeeds with legacy udev rules present"
+[[ ! -e $test_tmp/rules.d/99-power-profile.rules ]] ||
+  fail "migration removes the legacy power-profile udev rule"
+[[ ! -e $test_tmp/rules.d/99-wifi-powersave.rules ]] ||
+  fail "migration removes the legacy wifi-powersave udev rule"
+[[ -e $test_tmp/rules.d/99-power-profile-custom.rules ]] ||
+  fail "migration leaves unrelated udev rules alone"
+grep -q '^sudo.*rm .*99-power-profile.rules' "$calls" ||
+  fail "migration removes the rules through sudo"
+grep -q '^udevadm.*control --reload' "$calls" ||
+  fail "migration reloads udev after removing rules"
+pass "migration removes the legacy power udev rules and reloads udev"
+
+reset_fixture
+cat >"$test_tmp/rules.d/99-power-profile.rules" <<'EOF'
+SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="/usr/local/bin/my-own-power-hook"
+EOF
+run_migration || fail "migration succeeds with a user-owned rule of the same name"
+[[ -e $test_tmp/rules.d/99-power-profile.rules ]] ||
+  fail "migration keeps a same-named rule that does not point at the legacy checkout"
+! grep -q '^sudo' "$calls" || fail "migration does not touch sudo when nothing is removed"
+pass "migration only removes rules that point at the legacy checkout"


### PR DESCRIPTION
Fixes #8173.

Omarchy 3 wrote `~/.XCompose` with `include "%H/.local/share/omarchy/default/xcompose"` and installed `99-power-profile.rules` / `99-wifi-powersave.rules` that run `omarchy-powerprofiles-set` and `omarchy-wifi-powersave` out of that same checkout. `omarchy-upgrade-to-quattro` rewrites neither (it only writes a fresh `~/.XCompose` when none exists), so on every upgraded install both survive only through the `~/.local/share/omarchy -> /usr/share/omarchy` compat symlink that `cleanup_legacy_user_paths` leaves behind. Delete that symlink — the obvious cleanup next to the upgrade's `.bak` of the old checkout — and xkbcommon rejects the whole `~/.XCompose` on the failed include (every CapsLock sequence dies, emoji and name/email alike), while udev keeps shelling out to a missing path on every power-source change.

### Change

One migration, `migrations/1787639388.sh`:

- repoints a legacy `include` (`%H/…`, `~/…`, or the expanded home) at `/usr/share/omarchy/default/xcompose` — the same literal the installer and the upgrade write — and runs `omarchy-restart-xcompose` only when the file actually changed (tolerating a headless update with no session);
- removes `99-power-profile.rules` and `99-wifi-powersave.rules` only when they still point at the legacy checkout, then reloads udev. Quattro's shell switches power profiles itself (`shell/plugins/services/battery/Service.qml`), so the rules are dead weight; a same-named rule a user wrote themselves is left alone.

No change to `bin/omarchy-upgrade-to-quattro`: it already runs `omarchy-migrate` after the user transition (`run_post_upgrade_migrations`), so the migration covers fresh 3 → 4 upgrades and systems that upgraded earlier alike, and there is no second copy of the rewrite to keep in sync.

### Tests

`test/shell.d/xcompose-packaged-path-migration-test.sh` (written first, watched fail on the missing migration, then pass):

- rewrites each legacy include spelling, keeps the user's own sequences, reloads compose
- idempotent on an already packaged include (file untouched, no reload)
- no-op without a `~/.XCompose`
- removes both legacy rules through `sudo`, reloads udev, leaves unrelated rules alone
- keeps a same-named rule that does not point at the legacy checkout, without touching `sudo`

Also run end-to-end against the real pre-upgrade `~/.XCompose` from the affected machine: `xkbcli compile-compose` fails before, compiles 5170 sequences after.

`./test/all`: `test/cli` passes; `test/shell` fails the same environment-dependent files as the `quattro` baseline on this machine (config, snapper, ssh-reconnect, unowned-system-paths), plus two known flakes (screenshot-sanity, runtime-smoke) that swap between runs and pass when rerun on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwvkbBKv6ihUK6xgBsqJxR
