### PR TITLE
Respect XDG_CONFIG_HOME for font and text sizing

### DIFF
--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -6,7 +6,7 @@
 
 # One knob for apparent text size across the desktop. It drives three settings
 # in lockstep, all anchored to the shell default of 12px:
-#   • the omarchy shell's font base-size (~/.config/omarchy/shell.toml [font])
+#   • the omarchy shell's font base-size ($XDG_CONFIG_HOME/omarchy/shell.toml [font])
 #   • GNOME/GTK's text-scaling-factor    (12px -> 1.0, quantized so the GTK
 #     interface font lands on a whole point size, so 16 -> 15pt/11pt = 1.3636)
 #   • the terminal font point size       (12px -> 9pt, so terminal_pt = px * 9/12)

--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -23,7 +23,8 @@ GKEY_NAME="text-scaling-factor"
 TERM_DEFAULT_PT=9
 SHELL_DEFAULT_PX=12
 
-shell_config="$HOME/.config/omarchy/shell.toml"
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+shell_config="$config_home/omarchy/shell.toml"
 
 usage() {
   echo "Usage: omarchy-display-text-size [size|reset]"
@@ -135,22 +136,22 @@ term_pt_for() {
 set_terminal_size() {
   local pt="$1"
 
-  if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-    sed -i -E "s/^size[[:space:]]*=.*/size = $pt/" ~/.config/alacritty/alacritty.toml
+  if [[ -f $config_home/alacritty/alacritty.toml ]]; then
+    sed -i -E "s/^size[[:space:]]*=.*/size = $pt/" "$config_home/alacritty/alacritty.toml"
   fi
 
-  if [[ -f ~/.config/kitty/kitty.conf ]]; then
-    sed -i -E "s/^font_size[[:space:]]+.*/font_size $pt.0/" ~/.config/kitty/kitty.conf
+  if [[ -f $config_home/kitty/kitty.conf ]]; then
+    sed -i -E "s/^font_size[[:space:]]+.*/font_size $pt.0/" "$config_home/kitty/kitty.conf"
     pkill -USR1 kitty 2>/dev/null || true
   fi
 
-  if [[ -f ~/.config/ghostty/config ]]; then
-    sed -i -E "s/^font-size = .*/font-size = $pt/" ~/.config/ghostty/config
+  if [[ -f $config_home/ghostty/config ]]; then
+    sed -i -E "s/^font-size = .*/font-size = $pt/" "$config_home/ghostty/config"
     pkill -SIGUSR2 ghostty 2>/dev/null || true
   fi
 
-  if [[ -f ~/.config/foot/foot.ini ]]; then
-    sed -i -E "s/(:size=)[0-9.]+/\1$pt/" ~/.config/foot/foot.ini
+  if [[ -f $config_home/foot/foot.ini ]]; then
+    sed -i -E "s/(:size=)[0-9.]+/\1$pt/" "$config_home/foot/foot.ini"
     # Foot has no config-reload signal, so a running instance keeps its startup
     # size until relaunched (new windows pick up the change). Nudge the user —
     # but reuse the same notification id (freedesktop replaces_id) so dragging
@@ -172,14 +173,14 @@ set_terminal_size() {
 
 # Report the current terminal point size from whichever config we find first.
 term_current_pt() {
-  if [[ -f ~/.config/ghostty/config ]]; then
-    grep -oP '^font-size = \K[0-9.]+' ~/.config/ghostty/config | head -1
-  elif [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-    grep -oP '^size[[:space:]]*=[[:space:]]*\K[0-9.]+' ~/.config/alacritty/alacritty.toml | head -1
-  elif [[ -f ~/.config/kitty/kitty.conf ]]; then
-    grep -oP '^font_size[[:space:]]+\K[0-9.]+' ~/.config/kitty/kitty.conf | head -1
-  elif [[ -f ~/.config/foot/foot.ini ]]; then
-    grep -oP ':size=\K[0-9.]+' ~/.config/foot/foot.ini | head -1
+  if [[ -f $config_home/ghostty/config ]]; then
+    grep -oP '^font-size = \K[0-9.]+' "$config_home/ghostty/config" | head -1
+  elif [[ -f $config_home/alacritty/alacritty.toml ]]; then
+    grep -oP '^size[[:space:]]*=[[:space:]]*\K[0-9.]+' "$config_home/alacritty/alacritty.toml" | head -1
+  elif [[ -f $config_home/kitty/kitty.conf ]]; then
+    grep -oP '^font_size[[:space:]]+\K[0-9.]+' "$config_home/kitty/kitty.conf" | head -1
+  elif [[ -f $config_home/foot/foot.ini ]]; then
+    grep -oP ':size=\K[0-9.]+' "$config_home/foot/foot.ini" | head -1
   fi
 }
 

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -9,6 +9,7 @@ usage() {
 }
 
 font_name="${1:-}"
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
 
 case "$font_name" in
   -h|--help)
@@ -26,29 +27,29 @@ if ! fc-list | grep -Fqi -- "$font_name"; then
   exit 1
 fi
 
-if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-  sed -i "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
+if [[ -f $config_home/alacritty/alacritty.toml ]]; then
+  sed -i "s/family = \".*\"/family = \"$font_name\"/g" "$config_home/alacritty/alacritty.toml"
 fi
 
-if [[ -f ~/.config/kitty/kitty.conf ]]; then
-  sed -i "s/^font_family .*/font_family $font_name/g" ~/.config/kitty/kitty.conf
+if [[ -f $config_home/kitty/kitty.conf ]]; then
+  sed -i "s/^font_family .*/font_family $font_name/g" "$config_home/kitty/kitty.conf"
   pkill -USR1 kitty
 fi
 
-if [[ -f ~/.config/ghostty/config ]]; then
-  sed -i "s/font-family = \".*\"/font-family = \"$font_name\"/g" ~/.config/ghostty/config
+if [[ -f $config_home/ghostty/config ]]; then
+  sed -i "s/font-family = \".*\"/font-family = \"$font_name\"/g" "$config_home/ghostty/config"
   pkill -SIGUSR2 ghostty
 fi
 
-if [[ -f ~/.config/foot/foot.ini ]]; then
-  sed -i "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
+if [[ -f $config_home/foot/foot.ini ]]; then
+  sed -i "s/^font=.*/font=$font_name:size=9/g" "$config_home/foot/foot.ini"
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,
 # and anything resolving "monospace" all read from here. This file is loaded
 # after the package-owned default, and prepend_first puts the chosen family at
 # the head of the list so it wins over the family that default prefers.
-fontconfig_file="$HOME/.config/fontconfig/fonts.conf"
+fontconfig_file="$config_home/fontconfig/fonts.conf"
 mkdir -p "$(dirname "$fontconfig_file")"
 cat >"$fontconfig_file" <<XML
 <?xml version="1.0"?>

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -27,22 +27,28 @@ if ! fc-list | grep -Fqi -- "$font_name"; then
   exit 1
 fi
 
+# Font names are inserted into both sed replacements and XML text. Escape the
+# replacement metacharacters before editing terminal configs, and XML entities
+# before writing fontconfig, so a valid font name cannot corrupt either file.
+sed_font_name="$(printf '%s' "$font_name" | sed 's/[\\&|]/\\&/g')"
+xml_font_name="$(printf '%s' "$font_name" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
+
 if [[ -f $config_home/alacritty/alacritty.toml ]]; then
-  sed -i "s/family = \".*\"/family = \"$font_name\"/g" "$config_home/alacritty/alacritty.toml"
+  sed -i "s|family = \".*\"|family = \"$sed_font_name\"|g" "$config_home/alacritty/alacritty.toml"
 fi
 
 if [[ -f $config_home/kitty/kitty.conf ]]; then
-  sed -i "s/^font_family .*/font_family $font_name/g" "$config_home/kitty/kitty.conf"
+  sed -i "s|^font_family .*|font_family $sed_font_name|g" "$config_home/kitty/kitty.conf"
   pkill -USR1 kitty
 fi
 
 if [[ -f $config_home/ghostty/config ]]; then
-  sed -i "s/font-family = \".*\"/font-family = \"$font_name\"/g" "$config_home/ghostty/config"
+  sed -i "s|font-family = \".*\"|font-family = \"$sed_font_name\"|g" "$config_home/ghostty/config"
   pkill -SIGUSR2 ghostty
 fi
 
 if [[ -f $config_home/foot/foot.ini ]]; then
-  sed -i "s/^font=.*/font=$font_name:size=9/g" "$config_home/foot/foot.ini"
+  sed -i "s|^font=.*|font=$sed_font_name:size=9|g" "$config_home/foot/foot.ini"
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,
@@ -60,7 +66,7 @@ cat >"$fontconfig_file" <<XML
       <string>monospace</string>
     </test>
     <edit name="family" mode="prepend_first" binding="strong">
-      <string>$font_name</string>
+      <string>$xml_font_name</string>
     </edit>
   </match>
 </fontconfig>

--- a/bin/omarchy-restart-terminal
+++ b/bin/omarchy-restart-terminal
@@ -2,8 +2,10 @@
 
 # omarchy:summary=Reload supported terminal emulators after config changes
 
-if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-  touch ~/.config/alacritty/alacritty.toml
+config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+
+if [[ -f $config_home/alacritty/alacritty.toml ]]; then
+  touch "$config_home/alacritty/alacritty.toml"
 fi
 
 if pgrep -x kitty >/dev/null; then

--- a/test/shell.d/display-text-size-test.sh
+++ b/test/shell.d/display-text-size-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+config_home="$test_tmp/xdg-config"
+stub_bin="$test_tmp/bin"
+mkdir -p "$home/.config" "$config_home" "$stub_bin"
+
+cat >"$stub_bin/gsettings" <<'STUB'
+#!/bin/bash
+case "${1:-} ${2:-} ${3:-}" in
+  "get org.gnome.desktop.interface font-name")
+    printf "'Cantarell 11'\n"
+    ;;
+  "set org.gnome.desktop.interface text-scaling-factor")
+    printf '%s\n' "$*" >>"$GSETTINGS_LOG"
+    ;;
+  *)
+    printf '%s\n' "$*" >>"$GSETTINGS_LOG"
+    ;;
+esac
+STUB
+chmod +x "$stub_bin/gsettings"
+
+cat >"$stub_bin/pkill" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+chmod +x "$stub_bin/pkill"
+
+for terminal in alacritty kitty ghostty foot; do
+  mkdir -p "$config_home/$terminal"
+done
+printf 'size = 9\n' >"$config_home/alacritty/alacritty.toml"
+printf 'font_size 9.0\n' >"$config_home/kitty/kitty.conf"
+printf 'font-size = 9\n' >"$config_home/ghostty/config"
+printf 'font=monospace:size=9\n' >"$config_home/foot/foot.ini"
+
+mkdir -p "$home/.config/alacritty"
+printf 'size = 3\n' >"$home/.config/alacritty/alacritty.toml"
+
+HOME="$home" XDG_CONFIG_HOME="$config_home" GSETTINGS_LOG="$test_tmp/gsettings.log" \
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-display-text-size" 16
+
+grep -qxF 'size = 12' "$config_home/alacritty/alacritty.toml" || fail "XDG Alacritty config is updated"
+grep -qxF 'font_size 12.0' "$config_home/kitty/kitty.conf" || fail "XDG Kitty config is updated"
+grep -qxF 'font-size = 12' "$config_home/ghostty/config" || fail "XDG Ghostty config is updated"
+grep -qxF 'font=monospace:size=12' "$config_home/foot/foot.ini" || fail "XDG Foot config is updated"
+grep -qxF 'size = 3' "$home/.config/alacritty/alacritty.toml" || fail "legacy HOME config is left untouched"
+grep -q 'set org.gnome.desktop.interface text-scaling-factor 1.3636' "$test_tmp/gsettings.log" ||
+  fail "GTK scaling uses the requested size"
+pass "display text size honors XDG_CONFIG_HOME"
+
+HOME="$home" XDG_CONFIG_HOME="$config_home" GSETTINGS_LOG="$test_tmp/gsettings.log" \
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-display-text-size" reset
+
+! grep -q '^base-size[[:space:]]*=' "$config_home/omarchy/shell.toml" ||
+  fail "reset removes the shell size override"
+grep -qxF 'size = 9' "$config_home/alacritty/alacritty.toml" || fail "reset restores XDG Alacritty config"
+grep -qxF 'font_size 9.0' "$config_home/kitty/kitty.conf" || fail "reset restores XDG Kitty config"
+grep -qxF 'font-size = 9' "$config_home/ghostty/config" || fail "reset restores XDG Ghostty config"
+grep -qxF 'font=monospace:size=9' "$config_home/foot/foot.ini" || fail "reset restores XDG Foot config"
+pass "display text size reset honors XDG_CONFIG_HOME"

--- a/test/shell.d/font-set-test.sh
+++ b/test/shell.d/font-set-test.sh
@@ -14,7 +14,7 @@ mkdir -p "$home/.config" "$config_home" "$stub_bin"
 
 cat >"$stub_bin/fc-list" <<'STUB'
 #!/bin/bash
-printf 'Test Font\n'
+printf 'Test & | Font\n'
 STUB
 chmod +x "$stub_bin/fc-list"
 
@@ -54,14 +54,14 @@ mkdir -p "$home/.config/alacritty"
 printf 'family = "Legacy Font"\n' >"$home/.config/alacritty/alacritty.toml"
 
 HOME="$home" XDG_CONFIG_HOME="$config_home" FONT_LOG="$test_tmp/font.log" \
-  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-font-set" "Test Font"
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-font-set" "Test & | Font"
 
-grep -qxF 'family = "Test Font"' "$config_home/alacritty/alacritty.toml" || fail "XDG Alacritty config is updated"
-grep -qxF 'font_family Test Font' "$config_home/kitty/kitty.conf" || fail "XDG Kitty config is updated"
-grep -qxF 'font-family = "Test Font"' "$config_home/ghostty/config" || fail "XDG Ghostty config is updated"
-grep -qxF 'font=Test Font:size=9' "$config_home/foot/foot.ini" || fail "XDG Foot config is updated"
+grep -qxF 'family = "Test & | Font"' "$config_home/alacritty/alacritty.toml" || fail "XDG Alacritty config is updated"
+grep -qxF 'font_family Test & | Font' "$config_home/kitty/kitty.conf" || fail "XDG Kitty config is updated"
+grep -qxF 'font-family = "Test & | Font"' "$config_home/ghostty/config" || fail "XDG Ghostty config is updated"
+grep -qxF 'font=Test & | Font:size=9' "$config_home/foot/foot.ini" || fail "XDG Foot config is updated"
 grep -qxF 'family = "Legacy Font"' "$home/.config/alacritty/alacritty.toml" || fail "legacy HOME config is left untouched"
-grep -q '<string>Test Font</string>' "$config_home/fontconfig/fonts.conf" || fail "fontconfig is written under XDG_CONFIG_HOME"
+grep -q '<string>Test &amp; | Font</string>' "$config_home/fontconfig/fonts.conf" || fail "fontconfig escapes special characters"
 grep -qxF 'restart' "$test_tmp/font.log" || fail "font change restarts the shell"
-grep -qxF 'hook: font-set Test Font' "$test_tmp/font.log" || fail "font change invokes the hook"
+grep -qxF 'hook: font-set Test & | Font' "$test_tmp/font.log" || fail "font change invokes the hook"
 pass "font set honors XDG_CONFIG_HOME"

--- a/test/shell.d/font-set-test.sh
+++ b/test/shell.d/font-set-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+config_home="$test_tmp/xdg-config"
+stub_bin="$test_tmp/bin"
+mkdir -p "$home/.config" "$config_home" "$stub_bin"
+
+cat >"$stub_bin/fc-list" <<'STUB'
+#!/bin/bash
+printf 'Test Font\n'
+STUB
+chmod +x "$stub_bin/fc-list"
+
+cat >"$stub_bin/pkill" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+chmod +x "$stub_bin/pkill"
+
+cat >"$stub_bin/pgrep" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$stub_bin/pgrep"
+
+cat >"$stub_bin/omarchy-restart-shell" <<'STUB'
+#!/bin/bash
+printf 'restart\n' >>"$FONT_LOG"
+STUB
+chmod +x "$stub_bin/omarchy-restart-shell"
+
+cat >"$stub_bin/omarchy-hook" <<'STUB'
+#!/bin/bash
+printf 'hook: %s\n' "$*" >>"$FONT_LOG"
+STUB
+chmod +x "$stub_bin/omarchy-hook"
+
+for terminal in alacritty kitty ghostty foot; do
+  mkdir -p "$config_home/$terminal"
+done
+printf 'family = "Old Font"\n' >"$config_home/alacritty/alacritty.toml"
+printf 'font_family Old Font\n' >"$config_home/kitty/kitty.conf"
+printf 'font-family = "Old Font"\n' >"$config_home/ghostty/config"
+printf 'font=Old Font:size=9\n' >"$config_home/foot/foot.ini"
+
+mkdir -p "$home/.config/alacritty"
+printf 'family = "Legacy Font"\n' >"$home/.config/alacritty/alacritty.toml"
+
+HOME="$home" XDG_CONFIG_HOME="$config_home" FONT_LOG="$test_tmp/font.log" \
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-font-set" "Test Font"
+
+grep -qxF 'family = "Test Font"' "$config_home/alacritty/alacritty.toml" || fail "XDG Alacritty config is updated"
+grep -qxF 'font_family Test Font' "$config_home/kitty/kitty.conf" || fail "XDG Kitty config is updated"
+grep -qxF 'font-family = "Test Font"' "$config_home/ghostty/config" || fail "XDG Ghostty config is updated"
+grep -qxF 'font=Test Font:size=9' "$config_home/foot/foot.ini" || fail "XDG Foot config is updated"
+grep -qxF 'family = "Legacy Font"' "$home/.config/alacritty/alacritty.toml" || fail "legacy HOME config is left untouched"
+grep -q '<string>Test Font</string>' "$config_home/fontconfig/fonts.conf" || fail "fontconfig is written under XDG_CONFIG_HOME"
+grep -qxF 'restart' "$test_tmp/font.log" || fail "font change restarts the shell"
+grep -qxF 'hook: font-set Test Font' "$test_tmp/font.log" || fail "font change invokes the hook"
+pass "font set honors XDG_CONFIG_HOME"

--- a/test/shell.d/restart-terminal-test.sh
+++ b/test/shell.d/restart-terminal-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+config_home="$test_tmp/xdg-config"
+stub_bin="$test_tmp/bin"
+mkdir -p "$home/.config/alacritty" "$config_home/alacritty" "$stub_bin"
+
+printf 'legacy\n' >"$home/.config/alacritty/alacritty.toml"
+printf 'xdg\n' >"$config_home/alacritty/alacritty.toml"
+
+cat >"$stub_bin/touch" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$1" >>"$TOUCH_LOG"
+STUB
+chmod +x "$stub_bin/touch"
+
+cat >"$stub_bin/pgrep" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$stub_bin/pgrep"
+
+cat >"$stub_bin/killall" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+chmod +x "$stub_bin/killall"
+
+HOME="$home" XDG_CONFIG_HOME="$config_home" TOUCH_LOG="$test_tmp/touch.log" \
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-restart-terminal"
+
+grep -qxF "$config_home/alacritty/alacritty.toml" "$test_tmp/touch.log" ||
+  fail "terminal restart touches the XDG Alacritty config"
+! grep -qxF "$home/.config/alacritty/alacritty.toml" "$test_tmp/touch.log" ||
+  fail "terminal restart leaves the legacy config untouched"
+pass "terminal restart honors XDG_CONFIG_HOME"


### PR DESCRIPTION
This change makes omarchy-font-set and omarchy-display-text-size honor XDG_CONFIG_HOME for shell, terminal, and fontconfig files.

It adds focused shell regression tests covering custom XDG config directories and reset behavior.

Tests: targeted font-set and display-text-size tests pass.