### PR TITLE
Add native Zed theming

### DIFF
--- a/bin/omarchy-install-editor-zed
+++ b/bin/omarchy-install-editor-zed
@@ -3,9 +3,9 @@
 # omarchy:summary=Install Zed Editor and configure it with the current Omarchy theme
 
 echo "Installing Zed Editor..."
-omarchy-pkg-add zed omazed
+omarchy-pkg-add zed
 
 # Apply Omarchy theme to Zed
-omazed setup
+omarchy-theme-set-zed --select
 
 setsid uwsm-app -- gtk-launch dev.zed.Zed >/dev/null 2>&1 &

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -328,6 +328,7 @@ post_theme_commands=(
   omarchy-theme-set-claude
   omarchy-theme-set-browser
   omarchy-theme-set-vscode
+  omarchy-theme-set-zed
   omarchy-theme-set-obsidian
   omarchy-theme-set-keyboard
 )

--- a/bin/omarchy-theme-set-zed
+++ b/bin/omarchy-theme-set-zed
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# omarchy:summary=Sync Omarchy theme to Zed
+# omarchy:args=[--select]
+# omarchy:hidden=true
+
+CURRENT_THEME_DIR="$HOME/.local/state/omarchy/current/theme"
+ZED_CONFIG_DIR="$HOME/.config/zed"
+ZED_SETTINGS_PATH="$ZED_CONFIG_DIR/settings.json"
+
+if omarchy-cmd-missing zed && omarchy-cmd-missing zeditor && [[ ! -d $ZED_CONFIG_DIR ]]; then
+  exit 0
+fi
+
+[[ -f $CURRENT_THEME_DIR/zed.json ]] || exit 0
+
+mkdir -p "$ZED_CONFIG_DIR/themes"
+cp "$CURRENT_THEME_DIR/zed.json" "$ZED_CONFIG_DIR/themes/omarchy.json"
+
+[[ ${1:-} == "--select" ]] || exit 0
+
+if [[ ! -f $ZED_SETTINGS_PATH ]]; then
+  printf '{\n  "theme": "Omarchy"\n}\n' >"$ZED_SETTINGS_PATH"
+elif grep -qE '"theme"[[:space:]]*:[[:space:]]*"' "$ZED_SETTINGS_PATH"; then
+  sed -i --follow-symlinks -E \
+    's|("theme"[[:space:]]*:[[:space:]]*")[^"]*(")|\1Omarchy\2|' \
+    "$ZED_SETTINGS_PATH"
+elif grep -qE '"theme"[[:space:]]*:[[:space:]]*\{' "$ZED_SETTINGS_PATH"; then
+  sed -i --follow-symlinks -zE \
+    's|"theme"[[:space:]]*:[[:space:]]*\{[^}]*\}|"theme": "Omarchy"|' \
+    "$ZED_SETTINGS_PATH"
+else
+  sed -i --follow-symlinks -E '0,/\{/{s/\{/{\n  "theme": "Omarchy",/}' "$ZED_SETTINGS_PATH"
+fi

--- a/bin/omarchy-theme-set-zed
+++ b/bin/omarchy-theme-set-zed
@@ -8,27 +8,145 @@ CURRENT_THEME_DIR="$HOME/.local/state/omarchy/current/theme"
 ZED_CONFIG_DIR="$HOME/.config/zed"
 ZED_SETTINGS_PATH="$ZED_CONFIG_DIR/settings.json"
 
+select_theme() {
+  local action="$1"
+  local native_theme_ready="$2"
+
+  python3 - "$ZED_SETTINGS_PATH" "$action" "$native_theme_ready" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+
+path, action, native_theme_ready = sys.argv[1:]
+with open(path, encoding="utf-8") as settings_file:
+    text = settings_file.read()
+
+try:
+    token_pattern = re.compile(r'"(?:\\.|[^"\\])*"|//[^\n]*|/\*.*?\*/|[{}\[\]]', re.DOTALL)
+    trivia_pattern = re.compile(r'(?:\s+|//[^\n]*(?:\n|$)|/\*.*?\*/)*', re.DOTALL)
+
+    def skip_trivia(position):
+        return trivia_pattern.match(text, position).end()
+
+    root_start = skip_trivia(0)
+    if root_start >= len(text) or text[root_start] != "{":
+        raise ValueError("settings root is not an object")
+
+    start = end = None
+    pairs = {"{": "}", "[": "]"}
+    stack = []
+    for token in token_pattern.finditer(text):
+        value = token.group()
+        if value.startswith(("//", "/*")):
+            continue
+        if value in pairs:
+            stack.append(value)
+            continue
+        if stack and value == pairs[stack[-1]]:
+            stack.pop()
+            continue
+        if stack != ["{"] or json.loads(value) != "theme":
+            continue
+
+        colon = skip_trivia(token.end())
+        if colon >= len(text) or text[colon] != ":":
+            continue
+        start = skip_trivia(colon + 1)
+        if text[start] == '"':
+            value_token = token_pattern.match(text, start)
+            if value_token is None:
+                raise ValueError("unterminated theme string")
+            end = value_token.end()
+        elif text[start] in pairs:
+            value_stack = [text[start]]
+            for value_token in token_pattern.finditer(text, start + 1):
+                value = value_token.group()
+                if value.startswith(("//", "/*")) or value.startswith('"'):
+                    continue
+                if value in pairs:
+                    value_stack.append(value)
+                elif value == pairs[value_stack[-1]]:
+                    value_stack.pop()
+                    if not value_stack:
+                        end = value_token.end()
+                        break
+            if value_stack:
+                raise ValueError("unterminated theme value")
+        else:
+            delimiter = re.search(r"[,}]", text[start:])
+            end = len(text) if delimiter is None else start + delimiter.start()
+        break
+
+    if action == "select":
+        if start is None:
+            updated = text[: root_start + 1] + '\n  "theme": "Omarchy",' + text[root_start + 1 :]
+        else:
+            updated = text[:start] + '"Omarchy"' + text[end:]
+    elif start is None:
+        sys.exit(0)
+    else:
+        replacements = [
+            (token.start(), token.end())
+            for token in token_pattern.finditer(text, start, end)
+            if token.group().startswith('"') and json.loads(token.group()) == "Omazed"
+        ]
+        if not replacements:
+            sys.exit(0)
+        if native_theme_ready != "true":
+            raise ValueError("native Zed theme is not ready")
+        updated = text
+        for left, right in reversed(replacements):
+            updated = updated[:left] + '"Omarchy"' + updated[right:]
+except (ValueError, json.JSONDecodeError) as error:
+    print(f"Could not update Zed settings: {error}", file=sys.stderr)
+    sys.exit(1)
+
+target = os.path.realpath(path)
+target_stat = os.stat(target)
+descriptor, temporary = tempfile.mkstemp(prefix=".settings.json.", dir=os.path.dirname(target))
+try:
+    with os.fdopen(descriptor, "w", encoding="utf-8") as settings_file:
+        settings_file.write(updated)
+    os.chmod(temporary, stat.S_IMODE(target_stat.st_mode))
+    os.replace(temporary, target)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+}
+
 if omarchy-cmd-missing zed && omarchy-cmd-missing zeditor && [[ ! -d $ZED_CONFIG_DIR ]]; then
   exit 0
 fi
 
-[[ -f $CURRENT_THEME_DIR/zed.json ]] || exit 0
+action=${1:-sync}
+native_theme_ready=false
 
-mkdir -p "$ZED_CONFIG_DIR/themes"
-cp "$CURRENT_THEME_DIR/zed.json" "$ZED_CONFIG_DIR/themes/omarchy.json"
+case $action in
+  sync) ;;
+  --select) action=select ;;
+  --migrate) action=migrate ;;
+  *) echo "Usage: omarchy-theme-set-zed [--select]" >&2; exit 1 ;;
+esac
 
-[[ ${1:-} == "--select" ]] || exit 0
+if [[ -f $CURRENT_THEME_DIR/zed.json ]]; then
+  mkdir -p "$ZED_CONFIG_DIR/themes" || exit 1
+  cp "$CURRENT_THEME_DIR/zed.json" "$ZED_CONFIG_DIR/themes/omarchy.json" || exit 1
+  native_theme_ready=true
+elif [[ $action != migrate ]]; then
+  exit 0
+fi
+
+[[ $action == sync ]] && exit 0
 
 if [[ ! -f $ZED_SETTINGS_PATH ]]; then
-  printf '{\n  "theme": "Omarchy"\n}\n' >"$ZED_SETTINGS_PATH"
-elif grep -qE '"theme"[[:space:]]*:[[:space:]]*"' "$ZED_SETTINGS_PATH"; then
-  sed -i --follow-symlinks -E \
-    's|("theme"[[:space:]]*:[[:space:]]*")[^"]*(")|\1Omarchy\2|' \
-    "$ZED_SETTINGS_PATH"
-elif grep -qE '"theme"[[:space:]]*:[[:space:]]*\{' "$ZED_SETTINGS_PATH"; then
-  sed -i --follow-symlinks -zE \
-    's|"theme"[[:space:]]*:[[:space:]]*\{[^}]*\}|"theme": "Omarchy"|' \
-    "$ZED_SETTINGS_PATH"
-else
-  sed -i --follow-symlinks -E '0,/\{/{s/\{/{\n  "theme": "Omarchy",/}' "$ZED_SETTINGS_PATH"
+  if [[ $action == select ]]; then
+    printf '{\n  "theme": "Omarchy"\n}\n' >"$ZED_SETTINGS_PATH" || exit 1
+  fi
+  exit 0
 fi
+
+select_theme "$action" "$native_theme_ready"

--- a/default/themed/zed.json.tpl
+++ b/default/themed/zed.json.tpl
@@ -1,0 +1,368 @@
+{
+  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "name": "Omarchy",
+  "author": "APS",
+  "themes": [
+    {
+      "name": "Omarchy",
+      "appearance": "{{ mode }}",
+      "style": {
+        "background": "{{ background }}",
+        "foreground": "{{ foreground }}",
+        "border": "{{ dark_background }}",
+        "border.variant": "{{ lighter_background }}",
+        "border.focused": "{{ accent }}",
+        "border.selected": "{{ accent }}",
+        "border.transparent": "#00000000",
+        "border.disabled": "{{ lighter_background }}",
+        "elevated_surface.background": "{{ dark_background }}",
+        "surface.background": "{{ background }}",
+        "drop_target.background": "{{ accent }}33",
+        "element.background": "{{ background }}",
+        "element.hover": "{{ lighter_background }}",
+        "element.active": "{{ accent }}66",
+        "element.selected": "{{ lighter_background }}",
+        "element.disabled": "{{ muted }}",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "{{ lighter_background }}",
+        "ghost_element.active": "{{ accent }}66",
+        "ghost_element.selected": "{{ accent }}33",
+        "ghost_element.disabled": "{{ lighter_background }}",
+        "text": "{{ foreground }}",
+        "text.muted": "{{ muted }}",
+        "text.placeholder": "{{ muted }}",
+        "text.disabled": "{{ muted }}",
+        "text.accent": "{{ accent }}",
+        "icon": "{{ foreground }}",
+        "icon.muted": "{{ muted }}",
+        "icon.disabled": "{{ muted }}",
+        "icon.placeholder": "{{ muted }}",
+        "icon.accent": "{{ accent }}",
+        "status_bar.background": "{{ dark_background }}",
+        "title_bar.background": "{{ dark_background }}",
+        "toolbar.background": "{{ background }}",
+        "tab_bar.background": "{{ dark_background }}",
+        "tab.inactive_background": "{{ dark_background }}",
+        "tab.active_background": "{{ background }}",
+        "search.match_background": "{{ lighter_background }}",
+        "panel.background": "{{ dark_background }}",
+        "panel.focused_border": "{{ accent }}",
+        "pane.focused_border": "{{ accent }}",
+        "scrollbar.thumb.background": "{{ mix background bright_foreground 20% }}",
+        "scrollbar.thumb.hover_background": "{{ lighter_background }}",
+        "scrollbar.thumb.border": "{{ lighter_background }}",
+        "scrollbar.track.background": "{{ dark_background }}",
+        "scrollbar.track.border": "{{ dark_background }}",
+        "editor.foreground": "{{ foreground }}",
+        "editor.background": "{{ background }}",
+        "editor.gutter.background": "{{ background }}",
+        "editor.subheader.background": "{{ dark_background }}",
+        "editor.active_line.background": "{{ lighter_background }}",
+        "editor.highlighted_line.background": "{{ lighter_background }}",
+        "editor.line_number": "{{ muted }}",
+        "editor.active_line_number": "{{ foreground }}",
+        "editor.invisible": "{{ muted }}",
+        "editor.wrap_guide": "{{ lighter_background }}",
+        "editor.active_wrap_guide": "{{ muted }}",
+        "editor.document_highlight.read_background": "{{ accent }}33",
+        "editor.document_highlight.write_background": "{{ accent }}33",
+        "terminal.background": "{{ background }}",
+        "terminal.foreground": "{{ foreground }}",
+        "terminal.bright_foreground": "{{ foreground }}",
+        "terminal.dim_foreground": "{{ muted }}",
+        "terminal.ansi.black": "{{ color0 }}",
+        "terminal.ansi.bright_black": "{{ color8 }}",
+        "terminal.ansi.dim_black": "{{ color0 }}",
+        "terminal.ansi.red": "{{ color1 }}",
+        "terminal.ansi.bright_red": "{{ color9 }}",
+        "terminal.ansi.dim_red": "{{ color1 }}",
+        "terminal.ansi.green": "{{ color2 }}",
+        "terminal.ansi.bright_green": "{{ color10 }}",
+        "terminal.ansi.dim_green": "{{ color2 }}",
+        "terminal.ansi.yellow": "{{ color3 }}",
+        "terminal.ansi.bright_yellow": "{{ color11 }}",
+        "terminal.ansi.dim_yellow": "{{ color3 }}",
+        "terminal.ansi.blue": "{{ color4 }}",
+        "terminal.ansi.bright_blue": "{{ color12 }}",
+        "terminal.ansi.dim_blue": "{{ color4 }}",
+        "terminal.ansi.magenta": "{{ color5 }}",
+        "terminal.ansi.bright_magenta": "{{ color13 }}",
+        "terminal.ansi.dim_magenta": "{{ color5 }}",
+        "terminal.ansi.cyan": "{{ color6 }}",
+        "terminal.ansi.bright_cyan": "{{ color14 }}",
+        "terminal.ansi.dim_cyan": "{{ color6 }}",
+        "terminal.ansi.white": "{{ color7 }}",
+        "terminal.ansi.bright_white": "{{ color15 }}",
+        "terminal.ansi.dim_white": "{{ color7 }}",
+        "link_text.hover": "{{ accent }}",
+        "conflict": "{{ yellow }}",
+        "conflict.background": "{{ yellow }}33",
+        "conflict.border": "{{ yellow }}",
+        "created": "{{ green }}",
+        "created.background": "{{ green }}33",
+        "created.border": "{{ green }}",
+        "deleted": "{{ red }}",
+        "deleted.background": "{{ red }}33",
+        "deleted.border": "{{ red }}",
+        "error": "{{ red }}",
+        "error.background": "{{ red }}33",
+        "error.border": "{{ red }}",
+        "hidden": "{{ muted }}",
+        "hidden.background": "{{ background }}",
+        "hidden.border": "{{ lighter_background }}",
+        "hint": "{{ muted }}",
+        "hint.background": "{{ accent }}33",
+        "hint.border": "{{ accent }}",
+        "ignored": "{{ muted }}",
+        "ignored.background": "{{ background }}",
+        "ignored.border": "{{ lighter_background }}",
+        "info": "{{ accent }}",
+        "info.background": "{{ accent }}33",
+        "info.border": "{{ accent }}",
+        "modified": "{{ yellow }}",
+        "modified.background": "{{ yellow }}33",
+        "modified.border": "{{ yellow }}",
+        "predictive": "{{ muted }}",
+        "predictive.background": "{{ lighter_background }}",
+        "predictive.border": "{{ lighter_background }}",
+        "renamed": "{{ color4 }}",
+        "renamed.background": "{{ color4 }}33",
+        "renamed.border": "{{ color4 }}",
+        "success": "{{ green }}",
+        "success.background": "{{ green }}33",
+        "success.border": "{{ green }}",
+        "unreachable": "{{ muted }}",
+        "unreachable.background": "{{ background }}",
+        "unreachable.border": "{{ lighter_background }}",
+        "warning": "{{ yellow }}",
+        "warning.background": "{{ yellow }}66",
+        "warning.border": "{{ yellow }}",
+        "players": [
+          {
+            "cursor": "{{ accent }}",
+            "background": "{{ accent }}",
+            "selection": "{{ accent }}33"
+          },
+          {
+            "cursor": "{{ color5 }}",
+            "background": "{{ color5 }}",
+            "selection": "{{ color5 }}33"
+          },
+          {
+            "cursor": "{{ color6 }}",
+            "background": "{{ color6 }}",
+            "selection": "{{ color6 }}33"
+          },
+          {
+            "cursor": "{{ color2 }}",
+            "background": "{{ color2 }}",
+            "selection": "{{ color2 }}33"
+          }
+        ],
+        "version_control.added": "{{ green }}",
+        "version_control.added_background": "{{ green }}33",
+        "version_control.deleted": "{{ red }}",
+        "version_control.deleted_background": "{{ red }}33",
+        "version_control.modified": "{{ yellow }}",
+        "version_control.modified_background": "{{ yellow }}33",
+        "syntax": {
+          "attribute": {
+            "color": "{{ color3 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "{{ color1 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "{{ muted }}",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "{{ muted }}",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constant": {
+            "color": "{{ color1 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "{{ color5 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "embedded": {
+            "color": "{{ foreground }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "emphasis": {
+            "color": "{{ color1 }}",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "emphasis.strong": {
+            "color": "{{ color1 }}",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "enum": {
+            "color": "{{ color6 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "{{ color4 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "hint": {
+            "color": "{{ color6 }}",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "keyword": {
+            "color": "{{ color5 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "label": {
+            "color": "{{ color4 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "link_text": {
+            "color": "{{ color4 }}",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
+            "color": "{{ color5 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "{{ color1 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "{{ color6 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "predictive": {
+            "color": "{{ muted }}",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "preproc": {
+            "color": "{{ foreground }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "primary": {
+            "color": "{{ foreground }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "{{ color4 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "{{ muted }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.bracket": {
+            "color": "{{ muted }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.delimiter": {
+            "color": "{{ muted }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.list_marker": {
+            "color": "{{ muted }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation.special": {
+            "color": "{{ color6 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "{{ color2 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "{{ color5 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.regex": {
+            "color": "{{ color6 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special": {
+            "color": "{{ color5 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.special.symbol": {
+            "color": "{{ color2 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "{{ color4 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "{{ color2 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "title": {
+            "color": "{{ color4 }}",
+            "font_style": null,
+            "font_weight": 700
+          },
+          "type": {
+            "color": "{{ color3 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "{{ foreground }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "{{ color1 }}",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variant": {
+            "color": "{{ color4 }}",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/default/themed/zed.json.tpl
+++ b/default/themed/zed.json.tpl
@@ -8,7 +8,6 @@
       "appearance": "{{ mode }}",
       "style": {
         "background": "{{ background }}",
-        "foreground": "{{ foreground }}",
         "border": "{{ dark_background }}",
         "border.variant": "{{ lighter_background }}",
         "border.focused": "{{ accent }}",
@@ -159,12 +158,6 @@
             "selection": "{{ color2 }}33"
           }
         ],
-        "version_control.added": "{{ green }}",
-        "version_control.added_background": "{{ green }}33",
-        "version_control.deleted": "{{ red }}",
-        "version_control.deleted_background": "{{ red }}33",
-        "version_control.modified": "{{ yellow }}",
-        "version_control.modified_background": "{{ yellow }}33",
         "syntax": {
           "attribute": {
             "color": "{{ color3 }}",

--- a/default/themed/zed.json.tpl.license
+++ b/default/themed/zed.json.tpl.license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 aps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/migrations/1787583487.sh
+++ b/migrations/1787583487.sh
@@ -1,0 +1,27 @@
+echo "Replace omazed with native Zed theming"
+
+marker_start="# >>> omazed hook - do not edit >>>"
+marker_end="# <<< omazed hook - do not edit <<<"
+hook_file="$HOME/.config/omarchy/hooks/theme-set"
+hook_dir="$HOME/.config/omarchy/hooks/theme-set.d"
+zed_settings="$HOME/.config/zed/settings.json"
+was_using_omazed=false
+
+if [[ -f $zed_settings ]] && grep -qE '"theme"[[:space:]]*:[[:space:]]*"Omazed"' "$zed_settings"; then
+  was_using_omazed=true
+fi
+
+if [[ -f $hook_file ]] && grep -Fq "$marker_start" "$hook_file"; then
+  sed -i "/^$marker_start$/,/^$marker_end$/d" "$hook_file"
+fi
+
+rm -f "$hook_dir/omazed"
+rmdir "$hook_dir" 2>/dev/null || true
+rm -f "$HOME/.config/zed/themes/omazed.json"
+
+omarchy-pkg-drop omazed
+omarchy-theme-refresh
+
+if [[ $was_using_omazed == true ]]; then
+  omarchy-theme-set-zed --select
+fi

--- a/migrations/1787583487.sh
+++ b/migrations/1787583487.sh
@@ -4,24 +4,22 @@ marker_start="# >>> omazed hook - do not edit >>>"
 marker_end="# <<< omazed hook - do not edit <<<"
 hook_file="$HOME/.config/omarchy/hooks/theme-set"
 hook_dir="$HOME/.config/omarchy/hooks/theme-set.d"
-zed_settings="$HOME/.config/zed/settings.json"
-was_using_omazed=false
 
-if [[ -f $zed_settings ]] && grep -qE '"theme"[[:space:]]*:[[:space:]]*"Omazed"' "$zed_settings"; then
-  was_using_omazed=true
-fi
-
-if [[ -f $hook_file ]] && grep -Fq "$marker_start" "$hook_file"; then
-  sed -i "/^$marker_start$/,/^$marker_end$/d" "$hook_file"
+if [[ -f $hook_file ]] && awk -v start="$marker_start" -v end="$marker_end" '
+  $0 == start { found_start = 1 }
+  found_start && $0 == end { found_end = 1; exit }
+  END { exit !(found_start && found_end) }
+' "$hook_file"; then
+  sed -i --follow-symlinks "/^$marker_start$/,/^$marker_end$/d" "$hook_file"
 fi
 
 rm -f "$hook_dir/omazed"
 rmdir "$hook_dir" 2>/dev/null || true
-rm -f "$HOME/.config/zed/themes/omazed.json"
 
 omarchy-pkg-drop omazed
 omarchy-theme-refresh
+omarchy-theme-set-zed --migrate
 
-if [[ $was_using_omazed == true ]]; then
-  omarchy-theme-set-zed --select
-fi
+rm -f "$HOME/.config/zed/themes/omazed.json"
+rm -f "$HOME/.local/share/omazed/initialized"
+rmdir "$HOME/.local/share/omazed" 2>/dev/null || true

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -17,7 +17,7 @@ printf 'pkg:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
 exit "${OMARCHY_TEST_PKG_STATUS:-0}"
 SH
 
-for command in omarchy-pkg-aur-add omarchy-install-emacs omazed omarchy-theme-set-vscode omarchy-install-gaming-gpu-lib32; do
+for command in omarchy-pkg-aur-add omarchy-install-emacs omarchy-theme-set-vscode omarchy-theme-set-zed omarchy-install-gaming-gpu-lib32; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 exit 0

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -207,7 +207,7 @@ pass "a theme name cannot climb out of the theme directories"
 # generates. Every generated theme file is either denied to an installed theme or
 # recorded here as carrying colour, so a new template fails until it is placed.
 denied=(alacritty.toml foot.ini ghostty.conf kitty.conf gum_env.lua hyprland.lua neovim.lua vscode.json)
-colour_only=(btop.theme chromium.theme claude.json helix.toml hyprland-preview-share-picker.css keyboard.rgb obsidian.css pi.json shell.toml vscode-theme.json)
+colour_only=(btop.theme chromium.theme claude.json helix.toml hyprland-preview-share-picker.css keyboard.rgb obsidian.css pi.json shell.toml vscode-theme.json zed.json)
 
 for tpl in "$ROOT"/default/themed/*.tpl; do
   generated=$(basename "$tpl" .tpl)

--- a/test/shell.d/zed-theme-test.sh
+++ b/test/shell.d/zed-theme-test.sh
@@ -64,6 +64,7 @@ pass "Zed sync updates a string theme without rewriting JSONC"
 
 cat >"$settings" <<'JSONC'
 {
+  // "theme": "Omazed",
   "theme": {
     "mode": "system",
     "light": "One Light",
@@ -73,12 +74,29 @@ cat >"$settings" <<'JSONC'
 }
 JSONC
 run_sync --select
+grep -q '// "theme": "Omazed",' "$settings" || fail "Zed sync ignores a commented-out string theme"
 grep -q '"theme": "Omarchy"' "$settings" || fail "Zed sync replaces a theme object"
 ! grep -q 'One Light\|One Dark' "$settings" || fail "Zed sync removes the old theme object"
 grep -q '"autosave": "on_focus_change"' "$settings" || fail "Zed sync preserves settings after a theme object"
-jq -e '.theme == "Omarchy" and .autosave == "on_focus_change"' "$settings" >/dev/null ||
+sed '/^[[:space:]]*\/\//d' "$settings" | jq -e '.theme == "Omarchy" and .autosave == "on_focus_change"' >/dev/null ||
   fail "Zed sync keeps settings valid after replacing a theme object"
-pass "Zed sync updates Zed's light/dark theme object"
+pass "Zed sync ignores comments while updating Zed's light/dark theme object"
+
+cat >"$settings" <<'JSONC'
+{
+  "theme": {
+    "mode": "system",
+    // A closing brace } in a comment must not terminate the object.
+    "light": "One Light",
+    "dark": "One Dark"
+  },
+  "autosave": "on_focus_change"
+}
+JSONC
+run_sync --select
+jq -e '.theme == "Omarchy" and .autosave == "on_focus_change"' "$settings" >/dev/null ||
+  fail "Zed sync safely replaces a theme object containing braces in comments"
+pass "Zed sync does not corrupt JSONC containing braces in comments"
 
 cat >"$settings" <<'JSONC'
 {
@@ -91,10 +109,21 @@ grep -q '"theme": "Omarchy"' "$settings" || fail "Zed sync adds a missing theme 
 grep -q '// Keep this comment too.' "$settings" || fail "Zed sync preserves JSONC while adding a theme"
 pass "Zed sync adds its theme to existing JSONC settings"
 
+settings_target="$home/.config/zed/settings-target.json"
+mv "$settings" "$settings_target"
+ln -s "$(basename "$settings_target")" "$settings"
+run_sync --select
+[[ -L $settings ]] || fail "Zed sync preserves a symlinked settings file"
+grep -q '"theme": "Omarchy"' "$settings_target" || fail "Zed sync updates a symlink target"
+rm "$settings"
+mv "$settings_target" "$settings"
+pass "Zed sync preserves symlinked settings"
+
 hook_dir="$home/.config/omarchy/hooks/theme-set.d"
 hook_file="$home/.config/omarchy/hooks/theme-set"
+hook_target="$home/.config/omarchy/hooks/theme-set-target"
 mkdir -p "$hook_dir"
-cat >"$hook_file" <<'HOOK'
+cat >"$hook_target" <<'HOOK'
 #!/bin/bash
 echo before
 # >>> omazed hook - do not edit >>>
@@ -102,6 +131,7 @@ omazed set "$1"
 # <<< omazed hook - do not edit <<<
 echo after
 HOOK
+ln -s "$(basename "$hook_target")" "$hook_file"
 touch "$hook_dir/omazed"
 touch "$home/.config/zed/themes/omazed.json"
 printf '{"theme":"Omazed"}\n' >"$settings"
@@ -114,36 +144,55 @@ cat >"$stub_bin/omarchy-theme-refresh" <<'STUB'
 #!/bin/bash
 echo refresh >>"$TEST_LOG"
 STUB
-cat >"$stub_bin/omarchy-theme-set-zed" <<'STUB'
-#!/bin/bash
-printf 'zed %s\n' "$*" >>"$TEST_LOG"
-sed -i 's/Omazed/Omarchy/' "$HOME/.config/zed/settings.json"
-STUB
-chmod +x "$stub_bin/omarchy-pkg-drop" "$stub_bin/omarchy-theme-refresh" "$stub_bin/omarchy-theme-set-zed"
+chmod +x "$stub_bin/omarchy-pkg-drop" "$stub_bin/omarchy-theme-refresh"
 
 export TEST_LOG="$test_tmp/migration.log"
 for _ in 1 2; do
-  HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
+  HOME="$home" PATH="$stub_bin:$ROOT/bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
 done
 
 ! grep -q 'omazed hook\|omazed set' "$hook_file" || fail "Zed migration removes the omazed hook block"
 grep -q '^echo before$' "$hook_file" && grep -q '^echo after$' "$hook_file" ||
   fail "Zed migration preserves user theme hooks"
+[[ -L $hook_file ]] || fail "Zed migration preserves a symlinked hook file"
 [[ ! -e $hook_dir/omazed ]] || fail "Zed migration removes the omazed hook fragment"
 [[ ! -e $home/.config/zed/themes/omazed.json ]] || fail "Zed migration removes the generated omazed theme"
 grep -q '^drop omazed$' "$TEST_LOG" || fail "Zed migration removes the external omazed package"
 grep -q '^refresh$' "$TEST_LOG" || fail "Zed migration refreshes the current theme"
-[[ $(grep -c '^zed --select$' "$TEST_LOG") == "1" ]] || fail "Zed migration replaces Omazed exactly once"
+grep -q '"theme":"Omarchy"' "$settings" || fail "Zed migration replaces the selected Omazed theme"
 pass "Zed migration is idempotent and preserves user hooks"
 
 other_home="$test_tmp/other-home"
-mkdir -p "$other_home/.config/zed/themes"
-printf '{"theme":"One Dark"}\n' >"$other_home/.config/zed/settings.json"
+mkdir -p "$other_home/.config/zed/themes" "$other_home/.local/state/omarchy/current/theme"
+cp "$generated_theme" "$other_home/.local/state/omarchy/current/theme/zed.json"
+printf '%s\n' '{' '  // "theme": "Omazed",' '  "theme": "One Dark"' '}' >"$other_home/.config/zed/settings.json"
 touch "$other_home/.config/zed/themes/omazed.json"
 
-HOME="$other_home" PATH="$stub_bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
+HOME="$other_home" PATH="$stub_bin:$ROOT/bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
 
-grep -q '"theme":"One Dark"' "$other_home/.config/zed/settings.json" ||
+grep -q '"theme": "One Dark"' "$other_home/.config/zed/settings.json" ||
   fail "Zed migration preserves a manually selected theme"
-[[ $(grep -c '^zed --select$' "$TEST_LOG") == "1" ]] || fail "Zed migration only selects Omarchy for Omazed users"
+grep -q '// "theme": "Omazed",' "$other_home/.config/zed/settings.json" ||
+  fail "Zed migration ignores an Omazed reference inside a comment"
 pass "Zed migration preserves another selected theme"
+
+incomplete_home="$test_tmp/incomplete-home"
+mkdir -p "$incomplete_home/.config/omarchy/hooks"
+printf '%s\n' 'echo before' '# >>> omazed hook - do not edit >>>' 'echo keep me' >"$incomplete_home/.config/omarchy/hooks/theme-set"
+HOME="$incomplete_home" PATH="$stub_bin:$ROOT/bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
+grep -q '^echo keep me$' "$incomplete_home/.config/omarchy/hooks/theme-set" ||
+  fail "Zed migration leaves an incomplete hook marker block untouched"
+pass "Zed migration requires a complete hook marker block"
+
+missing_theme_home="$test_tmp/missing-theme-home"
+mkdir -p "$missing_theme_home/.config/zed/themes"
+printf '{"theme":"Omazed"}\n' >"$missing_theme_home/.config/zed/settings.json"
+touch "$missing_theme_home/.config/zed/themes/omazed.json"
+if HOME="$missing_theme_home" PATH="$stub_bin:$ROOT/bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null 2>&1; then
+  fail "Zed migration fails while a selected Omazed theme has no native replacement"
+fi
+[[ -e $missing_theme_home/.config/zed/themes/omazed.json ]] ||
+  fail "Zed migration keeps Omazed in place until the native theme is ready"
+grep -q '"theme":"Omazed"' "$missing_theme_home/.config/zed/settings.json" ||
+  fail "Zed migration keeps the working selection when the native theme is unavailable"
+pass "Zed migration does not remove Omazed before its replacement is ready"

--- a/test/shell.d/zed-theme-test.sh
+++ b/test/shell.d/zed-theme-test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+state="$home/.local/state/omarchy/current"
+stub_bin="$test_tmp/bin"
+mkdir -p "$state" "$stub_bin"
+
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+  OMARCHY_THEME_HEADLESS=1 OMARCHY_THEME_SKIP_BACKGROUND=1 \
+  XDG_RUNTIME_DIR="$test_tmp" \
+  bash "$ROOT/bin/omarchy-theme-set" "Tokyo Night"
+
+generated_theme="$state/theme/zed.json"
+[[ -f $generated_theme ]] || fail "Zed theme is generated with the current theme"
+jq -e '.themes[0].name == "Omarchy" and .themes[0].appearance == "dark"' "$generated_theme" >/dev/null ||
+  fail "Zed theme is valid JSON with the Omarchy identity and appearance"
+! grep -q '{{' "$generated_theme" || fail "Zed theme resolves every template placeholder"
+pass "Zed theme is rendered by the shared theme pipeline"
+
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+  OMARCHY_THEME_HEADLESS=1 OMARCHY_THEME_SKIP_BACKGROUND=1 \
+  XDG_RUNTIME_DIR="$test_tmp" \
+  bash "$ROOT/bin/omarchy-theme-set" "Catppuccin Latte"
+jq -e '.themes[0].appearance == "light"' "$generated_theme" >/dev/null ||
+  fail "Zed theme follows a light Omarchy theme"
+pass "Zed theme renders both dark and light appearances"
+
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/zeditor"
+chmod +x "$stub_bin/zeditor"
+
+run_sync() {
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-theme-set-zed" "$@"
+}
+
+run_sync
+settings="$home/.config/zed/settings.json"
+installed_theme="$home/.config/zed/themes/omarchy.json"
+cmp -s "$generated_theme" "$installed_theme" || fail "Zed receives the generated Omarchy theme"
+[[ ! -e $settings ]] || fail "Zed theme sync does not take over the user's theme selection"
+run_sync --select
+jq -e '.theme == "Omarchy"' "$settings" >/dev/null || fail "Zed selects Omarchy when requested"
+pass "Zed receives the generated theme and selects it only when requested"
+
+cat >"$settings" <<'JSONC'
+{
+  // Keep this user preference.
+  "autosave": "on_focus_change",
+  "theme": "Existing"
+}
+JSONC
+run_sync --select
+grep -q '// Keep this user preference.' "$settings" || fail "Zed sync preserves JSONC comments"
+grep -q '"autosave": "on_focus_change"' "$settings" || fail "Zed sync preserves unrelated settings"
+grep -q '"theme": "Omarchy"' "$settings" || fail "Zed sync replaces a string theme"
+pass "Zed sync updates a string theme without rewriting JSONC"
+
+cat >"$settings" <<'JSONC'
+{
+  "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "One Dark"
+  },
+  "autosave": "on_focus_change"
+}
+JSONC
+run_sync --select
+grep -q '"theme": "Omarchy"' "$settings" || fail "Zed sync replaces a theme object"
+! grep -q 'One Light\|One Dark' "$settings" || fail "Zed sync removes the old theme object"
+grep -q '"autosave": "on_focus_change"' "$settings" || fail "Zed sync preserves settings after a theme object"
+jq -e '.theme == "Omarchy" and .autosave == "on_focus_change"' "$settings" >/dev/null ||
+  fail "Zed sync keeps settings valid after replacing a theme object"
+pass "Zed sync updates Zed's light/dark theme object"
+
+cat >"$settings" <<'JSONC'
+{
+  // Keep this comment too.
+  "autosave": "on_focus_change",
+}
+JSONC
+run_sync --select
+grep -q '"theme": "Omarchy"' "$settings" || fail "Zed sync adds a missing theme setting"
+grep -q '// Keep this comment too.' "$settings" || fail "Zed sync preserves JSONC while adding a theme"
+pass "Zed sync adds its theme to existing JSONC settings"
+
+hook_dir="$home/.config/omarchy/hooks/theme-set.d"
+hook_file="$home/.config/omarchy/hooks/theme-set"
+mkdir -p "$hook_dir"
+cat >"$hook_file" <<'HOOK'
+#!/bin/bash
+echo before
+# >>> omazed hook - do not edit >>>
+omazed set "$1"
+# <<< omazed hook - do not edit <<<
+echo after
+HOOK
+touch "$hook_dir/omazed"
+touch "$home/.config/zed/themes/omazed.json"
+printf '{"theme":"Omazed"}\n' >"$settings"
+
+cat >"$stub_bin/omarchy-pkg-drop" <<'STUB'
+#!/bin/bash
+printf 'drop %s\n' "$*" >>"$TEST_LOG"
+STUB
+cat >"$stub_bin/omarchy-theme-refresh" <<'STUB'
+#!/bin/bash
+echo refresh >>"$TEST_LOG"
+STUB
+cat >"$stub_bin/omarchy-theme-set-zed" <<'STUB'
+#!/bin/bash
+printf 'zed %s\n' "$*" >>"$TEST_LOG"
+sed -i 's/Omazed/Omarchy/' "$HOME/.config/zed/settings.json"
+STUB
+chmod +x "$stub_bin/omarchy-pkg-drop" "$stub_bin/omarchy-theme-refresh" "$stub_bin/omarchy-theme-set-zed"
+
+export TEST_LOG="$test_tmp/migration.log"
+for _ in 1 2; do
+  HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
+done
+
+! grep -q 'omazed hook\|omazed set' "$hook_file" || fail "Zed migration removes the omazed hook block"
+grep -q '^echo before$' "$hook_file" && grep -q '^echo after$' "$hook_file" ||
+  fail "Zed migration preserves user theme hooks"
+[[ ! -e $hook_dir/omazed ]] || fail "Zed migration removes the omazed hook fragment"
+[[ ! -e $home/.config/zed/themes/omazed.json ]] || fail "Zed migration removes the generated omazed theme"
+grep -q '^drop omazed$' "$TEST_LOG" || fail "Zed migration removes the external omazed package"
+grep -q '^refresh$' "$TEST_LOG" || fail "Zed migration refreshes the current theme"
+[[ $(grep -c '^zed --select$' "$TEST_LOG") == "1" ]] || fail "Zed migration replaces Omazed exactly once"
+pass "Zed migration is idempotent and preserves user hooks"
+
+other_home="$test_tmp/other-home"
+mkdir -p "$other_home/.config/zed/themes"
+printf '{"theme":"One Dark"}\n' >"$other_home/.config/zed/settings.json"
+touch "$other_home/.config/zed/themes/omazed.json"
+
+HOME="$other_home" PATH="$stub_bin:$PATH" bash -euo pipefail "$ROOT/migrations/1787583487.sh" >/dev/null
+
+grep -q '"theme":"One Dark"' "$other_home/.config/zed/settings.json" ||
+  fail "Zed migration preserves a manually selected theme"
+[[ $(grep -c '^zed --select$' "$TEST_LOG") == "1" ]] || fail "Zed migration only selects Omarchy for Omazed users"
+pass "Zed migration preserves another selected theme"


### PR DESCRIPTION
Zed currently gets theme support through omazed, an AUR package with its own hook and rendering pipeline. That puts a second integration next to the one Omarchy already uses for every other themed app, and it has already broken during the Quattro path move in #7325.

This replaces it with a `default/themed/zed.json.tpl` template and a small sync command wired into `omarchy-theme-set`. Installing Zed selects Omarchy once. Later theme changes refresh the file without overriding a manual Zed theme choice.

The migration drops omazed and its hooks, refreshes the current theme, and only switches users whose selected theme is still Omazed.

The Zed theme mapping is adapted from [APS6/omazed](https://github.com/APS6/omazed) (MIT).

Tested across every built-in theme, both appearances, Zed's string and object settings formats, and repeated migrations.
