### PR TITLE
Add keyd as an optional Install > Service for low-level key remapping

### DIFF
--- a/bin/omarchy-install-service-keyd
+++ b/bin/omarchy-install-service-keyd
@@ -15,6 +15,26 @@ else
   echo "Existing /etc/keyd/default.conf found, leaving it as-is."
 fi
 
+quirks_file=/etc/libinput/local-overrides.quirks
+if grep -q "MatchName=keyd\*keyboard" "$quirks_file" 2>/dev/null; then
+  echo "Existing keyd libinput quirk found in $quirks_file, leaving it as-is."
+else
+  # keyd's virtual keyboard reads as external to libinput as soon as keyd
+  # starts, which can stop disable-while-typing from suppressing the
+  # touchpad. Mark it internal before starting the service.
+  echo "Marking keyd's virtual keyboard internal for libinput (touchpad disable-while-typing)..."
+  sudo mkdir -p "$(dirname "$quirks_file")"
+  if [[ -s $quirks_file ]]; then
+    { echo ""; cat "$OMARCHY_PATH/default/libinput/local-overrides.quirks"; } | sudo tee -a "$quirks_file" >/dev/null
+  else
+    sudo install -Dm644 "$OMARCHY_PATH/default/libinput/local-overrides.quirks" "$quirks_file"
+  fi
+  # libinput only reads quirks when a device is added, so already-running
+  # sessions won't see this until they restart.
+  omarchy-state set reboot-required
+  quirk_just_added=true
+fi
+
 echo "Starting keyd..."
 sudo systemctl enable --now keyd.service
 
@@ -25,3 +45,8 @@ echo ""
 echo "keyd remaps physical keys before Hyprland ever sees them, so a remap"
 echo "on CapsLock takes priority over Omarchy's compose:caps input option."
 echo "See the Keyboard, Mouse, Trackpad manual page for details."
+
+if [[ -n ${quirk_just_added:-} && -z ${OMARCHY_DEFER_REBOOT:-} ]]; then
+  echo ""
+  gum confirm "A reboot is needed for the touchpad disable-while-typing fix to apply. Reboot now?" && omarchy-system-reboot
+fi

--- a/bin/omarchy-install-service-keyd
+++ b/bin/omarchy-install-service-keyd
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Install the keyd low-level key remapping daemon.
+# omarchy:requires-sudo=true
+
+set -e
+
+echo "Installing keyd..."
+omarchy-pkg-add keyd
+
+if [[ ! -f /etc/keyd/default.conf ]]; then
+  echo "Seeding a starter config at /etc/keyd/default.conf..."
+  sudo install -Dm644 "$OMARCHY_PATH/default/keyd/default.conf" /etc/keyd/default.conf
+else
+  echo "Existing /etc/keyd/default.conf found, leaving it as-is."
+fi
+
+echo "Starting keyd..."
+sudo systemctl enable --now keyd.service
+
+echo ""
+echo "keyd is installed and running. Edit /etc/keyd/default.conf, then run"
+echo "'sudo systemctl reload keyd' to apply changes."
+echo ""
+echo "keyd remaps physical keys before Hyprland ever sees them, so a remap"
+echo "on CapsLock takes priority over Omarchy's compose:caps input option."
+echo "See the Keyboard, Mouse, Trackpad manual page for details."

--- a/bin/omarchy-install-service-keyd
+++ b/bin/omarchy-install-service-keyd
@@ -20,7 +20,7 @@ sudo systemctl enable --now keyd.service
 
 echo ""
 echo "keyd is installed and running. Edit /etc/keyd/default.conf, then run"
-echo "'sudo systemctl reload keyd' to apply changes."
+echo "'sudo keyd reload' to apply changes."
 echo ""
 echo "keyd remaps physical keys before Hyprland ever sees them, so a remap"
 echo "on CapsLock takes priority over Omarchy's compose:caps input option."

--- a/default/keyd/default.conf
+++ b/default/keyd/default.conf
@@ -1,0 +1,18 @@
+[ids]
+*
+
+[main]
+# keyd remaps run below Hyprland/XKB, so anything bound here on CapsLock
+# takes priority over Omarchy's compose:caps input option. Test that
+# Compose still behaves the way you expect before relying on both, or move
+# Compose elsewhere first (see the Keyboard, Mouse, Trackpad manual page).
+#
+# Tap CapsLock for Escape, hold it for the "capslock" layer below:
+# capslock = overload(capslock, esc)
+
+# [capslock]
+# Example: CapsLock + hjkl as arrow keys while held.
+# h = left
+# j = down
+# k = up
+# l = right

--- a/default/libinput/local-overrides.quirks
+++ b/default/libinput/local-overrides.quirks
@@ -1,0 +1,8 @@
+# keyd's virtual keyboard is otherwise indistinguishable from an external
+# one, so libinput won't pair it with the internal touchpad and
+# disable-while-typing (palm rejection) stops working. Mark it internal.
+# See https://github.com/rvaiya/keyd/issues/745.
+[Serial Keyboards]
+MatchUdevType=keyboard
+MatchName=keyd*keyboard
+AttrKeyboardIntegration=internal

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -222,6 +222,7 @@
   "install.service.signal": {"icon":"󰭹","label":"Signal","disabled":"omarchy-pkg-present signal-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-signal"},
   "install.service.tailscale": {"icon":"","label":"Tailscale","disabled":"omarchy-pkg-present tailscale","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-tailscale"},
   "install.service.nordvpn": {"icon":"󱇱","label":"NordVPN","disabled":"omarchy-pkg-present nordvpn-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-nordvpn"},
+  "install.service.keyd": {"icon":"󰌌","label":"keyd","disabled":"omarchy-pkg-present keyd","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-keyd"},
   "install.service.once": {"icon":"󰏖","label":"ONCE","disabled":"omarchy-pkg-present once-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-once"},
   "install.service.bitwarden": {"icon":"󰟵","label":"Bitwarden","disabled":"omarchy-pkg-present bitwarden","action":"omarchy-install-and-launch Bitwarden 'bitwarden bitwarden-cli' bitwarden"},
   "install.service.chromium-account": {"icon":"","label":"Chromium Account","when":"[[ -f ~/.config/chromium-flags.conf ]]","disabled":"grep -q oauth2-client-id ~/.config/chromium-flags.conf","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-chromium-google-account"},

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -47,6 +47,25 @@ hl.config({
 })
 ```
 
+### Low-level key remapping with keyd
+
+`kb_options` and Hyprland's bindings cover window-manager shortcuts, but they can't do physical key remapping — swapping what a key sends before it reaches Hyprland at all, tap/hold behavior on a single key, or layers. For that, install [keyd](https://github.com/rvaiya/keyd) from _Install > Service > keyd_ in the Omarchy menu (`Super + Space`), or run `omarchy-install-service-keyd`.
+
+keyd ships with an inert starter config at `/etc/keyd/default.conf` — edit it as root, then `sudo systemctl reload keyd` to apply. A common example, tap CapsLock for Escape and hold it as a layer:
+
+```
+[main]
+capslock = overload(capslock, esc)
+
+[capslock]
+h = left
+j = down
+k = up
+l = right
+```
+
+keyd intercepts keys below Hyprland and XKB, so remapping CapsLock here takes priority over the `compose:caps` option above — test that Compose still fires the way you expect before relying on both together, or move Compose to another key first. See `man keyd` for the full remapping, layer, and macro syntax.
+
 ### Trackpad gestures
 
 You can also turn on [touchpad gestures](https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/), like swiping with three fingers to change workspaces:

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -69,6 +69,8 @@ l = right
 
 keyd intercepts keys below Hyprland and XKB, so remapping CapsLock here takes priority over the `compose:caps` option above — test that Compose still fires the way you expect before relying on both together, or move Compose to another key first. See `man keyd` for the full remapping, layer, and macro syntax.
 
+keyd's virtual keyboard is otherwise indistinguishable from an external one, which stops libinput's disable-while-typing from suppressing the touchpad while you type. The installer adds a libinput quirk marking it internal, at `/etc/libinput/local-overrides.quirks` — a reboot is needed for it to take effect.
+
 ### Trackpad gestures
 
 You can also turn on [touchpad gestures](https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/), like swiping with three fingers to change workspaces:

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -54,6 +54,9 @@ hl.config({
 keyd ships with an inert starter config at `/etc/keyd/default.conf` — edit it as root, then `sudo keyd reload` to apply. A common example, tap CapsLock for Escape and hold it as a layer:
 
 ```
+[ids]
+*
+
 [main]
 capslock = overload(capslock, esc)
 

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -51,7 +51,7 @@ hl.config({
 
 `kb_options` and Hyprland's bindings cover window-manager shortcuts, but they can't do physical key remapping — swapping what a key sends before it reaches Hyprland at all, tap/hold behavior on a single key, or layers. For that, install [keyd](https://github.com/rvaiya/keyd) from _Install > Service > keyd_ in the Omarchy menu (`Super + Space`), or run `omarchy-install-service-keyd`.
 
-keyd ships with an inert starter config at `/etc/keyd/default.conf` — edit it as root, then `sudo systemctl reload keyd` to apply. A common example, tap CapsLock for Escape and hold it as a layer:
+keyd ships with an inert starter config at `/etc/keyd/default.conf` — edit it as root, then `sudo keyd reload` to apply. A common example, tap CapsLock for Escape and hold it as a layer:
 
 ```
 [main]


### PR DESCRIPTION
## Summary
- Adds `omarchy-install-service-keyd`, following the pattern of the other optional services under Install > Service, to install and enable [keyd](https://github.com/rvaiya/keyd) and seed an inert starter config at `/etc/keyd/default.conf` (only if one doesn't already exist).
- Adds a `Low-level key remapping with keyd` section to the Keyboard, Mouse, Trackpad manual page explaining what keyd is for (physical remaps, tap/hold, layers) versus `kb_options`/Hyprland bindings, and how it interacts with the `compose:caps` input option.
- Wires up the `install.service.keyd` entry in the Omarchy menu.

## Test plan
- [x] `bash -n bin/omarchy-install-service-keyd` passes
- [x] Installed via the menu on a live system: package installs, starter config seeds correctly when absent and is left alone when present, service enables and starts
- [x] Manual page renders correctly