### PR TITLE
Add and remove tailnets from the Tailscale panel

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -59,9 +59,17 @@ function osIcon(os) {
 
 function accountLabel(account) {
   if (!account) return "Unknown account"
-  if (account.nickname) return String(account.nickname)
-  if (account.tailnet) return String(account.tailnet)
-  if (account.account) return String(account.account)
+  var nickname = String(account.nickname || "")
+  var tailnet = String(account.tailnet || "")
+  var login = String(account.account || "")
+  // Tailscale names a profile after the login it was created from unless one
+  // is set explicitly, so a nickname only carries intent once it differs from
+  // that login. Otherwise the tailnet's display name -- the one set in the
+  // admin console, and what `tailscale switch --list` prints -- says more
+  // about which tailnet this row is.
+  if (nickname !== "" && nickname !== login) return nickname
+  if (tailnet !== "") return tailnet
+  if (login !== "") return login
   return String(account.id || "Unknown account")
 }
 

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -281,6 +281,25 @@ function connectionRows(accounts, canAdd) {
   return rows
 }
 
+// What to do once the login that adds a tailnet exits. tailscale login makes
+// the new profile current before the browser half finishes, so anything other
+// than a clean exit leaves the machine on a profile it never asked to be on
+// and the previous connection has to be put back.
+function addAccountOutcome(exitCode, urlOpened, previousId, output) {
+  if (exitCode === 0) return { returnTo: "", status: "", error: "" }
+
+  var previous = String(previousId || "")
+  // Having opened the browser says the login was reachable and simply was not
+  // finished, which is a plain outcome rather than a failure worth shouting.
+  if (urlOpened === true) {
+    return { returnTo: previous, status: "Login not completed — back on the previous connection", error: "" }
+  }
+
+  var message = String(output || "").trim()
+  if (message === "") message = "tailscale login failed"
+  return { returnTo: previous, status: message, error: message }
+}
+
 function parseAccounts(raw) {
   var text = String(raw || "").trim()
   if (text === "") return { accounts: [], selectedAccountId: "", selectedAccountLabel: "" }
@@ -332,6 +351,7 @@ if (typeof module !== "undefined") {
     mullvadCountryOptions: mullvadCountryOptions,
     parseStatus: parseStatus,
     parseAccounts: parseAccounts,
-    connectionRows: connectionRows
+    connectionRows: connectionRows,
+    addAccountOutcome: addAccountOutcome
   }
 }

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -308,6 +308,27 @@ function addAccountOutcome(exitCode, urlOpened, previousId, output) {
   return { returnTo: previous, status: message, error: message }
 }
 
+// tailscale prints a version skew warning on every invocation whenever the
+// client and the daemon differ, so it arrives in front of whatever actually
+// went wrong and crowds the real message out of the panel's one status line.
+function commandMessage(text) {
+  var lines = String(text || "").split("\n")
+  var kept = []
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].replace(/\s+/g, " ").trim()
+    if (line === "") continue
+    if (/^Warning: client version .*tailscaled server version/.test(line)) continue
+    kept.push(line)
+  }
+  return kept.join(" ")
+}
+
+// Being told to go and use sudo is not something to read out: the panel can
+// offer to grant the operator itself.
+function isAccessDenied(text) {
+  return /access denied/i.test(String(text || ""))
+}
+
 function parseAccounts(raw) {
   var text = String(raw || "").trim()
   if (text === "") return { accounts: [], selectedAccountId: "", selectedAccountLabel: "" }
@@ -360,6 +381,8 @@ if (typeof module !== "undefined") {
     parseStatus: parseStatus,
     parseAccounts: parseAccounts,
     connectionRows: connectionRows,
-    addAccountOutcome: addAccountOutcome
+    addAccountOutcome: addAccountOutcome,
+    commandMessage: commandMessage,
+    isAccessDenied: isAccessDenied
   }
 }

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -329,6 +329,19 @@ function isAccessDenied(text) {
   return /access denied/i.test(String(text || ""))
 }
 
+// Getting connected can take three things in order -- authorize the operator,
+// sign in, come up -- and the panel knows which are still outstanding. Naming
+// the next one lets it run the sequence instead of making someone rediscover
+// the next step after finishing each.
+function nextConnectStep(state) {
+  var s = state || {}
+  if (s.installed !== true) return "none"
+  if (s.accessDenied === true) return "authorize"
+  if (s.needsLogin === true) return "login"
+  if (s.running !== true) return "up"
+  return "done"
+}
+
 function parseAccounts(raw) {
   var text = String(raw || "").trim()
   if (text === "") return { accounts: [], selectedAccountId: "", selectedAccountLabel: "" }
@@ -383,6 +396,7 @@ if (typeof module !== "undefined") {
     connectionRows: connectionRows,
     addAccountOutcome: addAccountOutcome,
     commandMessage: commandMessage,
-    isAccessDenied: isAccessDenied
+    isAccessDenied: isAccessDenied,
+    nextConnectStep: nextConnectStep
   }
 }

--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -270,6 +270,17 @@ function parseStatus(raw) {
   }
 }
 
+// The panel offers adding a tailnet as a row in the connection list, so a
+// machine with a single profile has something to switch from. The exit node
+// list carries its Mullvad picker the same way.
+function connectionRows(accounts, canAdd) {
+  var rows = []
+  var list = accounts instanceof Array ? accounts : []
+  for (var i = 0; i < list.length; i++) rows.push(list[i])
+  if (canAdd === true) rows.push({ id: "account:add", AddAccount: true })
+  return rows
+}
+
 function parseAccounts(raw) {
   var text = String(raw || "").trim()
   if (text === "") return { accounts: [], selectedAccountId: "", selectedAccountLabel: "" }
@@ -320,6 +331,7 @@ if (typeof module !== "undefined") {
     mullvadRegionOptions: mullvadRegionOptions,
     mullvadCountryOptions: mullvadCountryOptions,
     parseStatus: parseStatus,
-    parseAccounts: parseAccounts
+    parseAccounts: parseAccounts,
+    connectionRows: connectionRows
   }
 }

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -966,10 +966,17 @@ Panel {
 
       PanelActionButton {
         // Removing, confirming an add, and bailing out of one in progress all
-        // land on the same trailing control.
-        visible: accountRow.addingAccount || accountRow.addArmed
+        // land on the same trailing control, which stays in the layout whether
+        // or not it shows: the button is taller than the row's text, so
+        // appearing on hover grew the row and re-elided the label under the
+        // pointer. Disabled, it passes hover and clicks through to the row.
+        readonly property bool shown: accountRow.addingAccount || accountRow.addArmed
                  || (accountRow.removable && !accountRow.removingAccount
                      && (accountRow.armed || accountRow.hasCursor || accountMouse.containsMouse))
+        opacity: shown ? 1 : 0
+        enabled: shown
+
+        Behavior on opacity { NumberAnimation { duration: 90; easing.type: Easing.OutQuad } }
         iconText: accountRow.addingAccount ? "󰅙" : (accountRow.armed || accountRow.addArmed ? "󰄬" : "󰅙")
         tooltipText: accountRow.addingAccount ? "Cancel and go back"
                      : (accountRow.addArmed ? "Sign out and add a tailnet"

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -43,6 +43,7 @@ Panel {
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   property string removeArmedId: ""
+  property bool addArmed: false
   readonly property var connections: displayConnections()
   readonly property bool showConnections: connections.length > 1 || tailscale.accountsAccessDenied
   readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
@@ -199,6 +200,7 @@ Panel {
 
   function disarmRemoval() {
     removeArmedId = ""
+    addArmed = false
   }
 
   function confirmRemoval(account) {
@@ -218,7 +220,15 @@ Panel {
   function chooseConnection(account) {
     if (!account) return
     if (account.AddAccount === true) {
-      disarmRemoval()
+      if (tailscale.addingAccount) return
+      removeArmedId = ""
+      // Adding signs this machine out of the tailnet it is on until the
+      // browser half finishes, so it asks before it does that.
+      if (!addArmed) {
+        addArmed = true
+        return
+      }
+      addArmed = false
       tailscale.addAccount()
       return
     }
@@ -878,11 +888,19 @@ Panel {
     readonly property bool removingAccount: !addAccount && accountId !== "" && tailscale.removingAccountId === accountId
     readonly property bool removable: root.canRemoveAccount(account)
     readonly property bool armed: removable && root.removeArmedId === accountId
+    readonly property bool addArmed: addAccount && root.addArmed && !addingAccount
     // The row is the thing being clicked, so it carries the progress rather
     // than leaving it to the status line under the panel.
     readonly property bool working: switchingAccount || addingAccount || removingAccount
     readonly property string accountText: {
-      if (addAccount) return addingAccount ? "Opening browser…" : "Add account…"
+      if (addAccount) {
+        if (addingAccount) return "Opening browser…"
+        if (addArmed) {
+          var current = tailscale.selectedAccountLabel
+          return current === "" ? "Signs this machine out — confirm?" : "Signs out of " + current + " — confirm?"
+        }
+        return "Add account…"
+      }
       if (!account) return "Account"
       var label = tailscale.accountLabel(account)
       if (removingAccount) return "Removing " + label + "…"
@@ -891,7 +909,7 @@ Panel {
     }
 
     hasCursor: root.cursorActive && root.focusSection === "accounts" && root.accountIndex === rowIndex
-    current: selectedAccount || armed
+    current: selectedAccount || armed || addArmed
     foreground: root.foreground
     fill: root.hoverFill
     currentFill: root.selectedFill
@@ -939,7 +957,7 @@ Panel {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter
         text: accountRow.accountText
-        color: accountRow.armed ? root.urgent : root.foreground
+        color: accountRow.armed || accountRow.addArmed ? root.urgent : root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
         font.bold: accountRow.selectedAccount
@@ -947,14 +965,22 @@ Panel {
       }
 
       PanelActionButton {
-        visible: accountRow.removable && !accountRow.removingAccount && (accountRow.armed || accountRow.hasCursor || accountMouse.containsMouse)
-        iconText: accountRow.armed ? "󰄬" : "󰅙"
-        tooltipText: accountRow.armed ? "Confirm removal" : "Remove from this machine"
-        foreground: accountRow.armed ? root.urgent : root.foreground
+        // Removing, confirming an add, and bailing out of one in progress all
+        // land on the same trailing control.
+        visible: accountRow.addingAccount || accountRow.addArmed
+                 || (accountRow.removable && !accountRow.removingAccount
+                     && (accountRow.armed || accountRow.hasCursor || accountMouse.containsMouse))
+        iconText: accountRow.addingAccount ? "󰅙" : (accountRow.armed || accountRow.addArmed ? "󰄬" : "󰅙")
+        tooltipText: accountRow.addingAccount ? "Cancel and go back"
+                     : (accountRow.addArmed ? "Sign out and add a tailnet"
+                        : (accountRow.armed ? "Confirm removal" : "Remove from this machine"))
+        foreground: accountRow.armed || accountRow.addArmed || accountRow.addingAccount ? root.urgent : root.foreground
         fontFamily: root.fontFamily
         Layout.alignment: Qt.AlignVCenter
         onClicked: {
-          if (accountRow.armed) root.confirmRemoval(accountRow.account)
+          if (accountRow.addingAccount) tailscale.cancelAddAccount()
+          else if (accountRow.addArmed) root.chooseConnection(accountRow.account)
+          else if (accountRow.armed) root.confirmRemoval(accountRow.account)
           else root.armRemoval(accountRow.account)
         }
       }

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -318,7 +318,7 @@ Panel {
     if (focusSection === "header") {
       tailscale.toggleTailscale()
     } else if (focusSection === "auth") {
-      tailscale.authorizeTailscaleOperator()
+      tailscale.startConnecting()
     } else if (focusSection === "accounts") {
       var account = selectedAccount()
       if (account) chooseConnection(account)
@@ -830,7 +830,7 @@ Panel {
       cursorShape: tailscale.busy ? Qt.ArrowCursor : Qt.PointingHandCursor
       enabled: !tailscale.busy
       onEntered: root.setAuthCursor()
-      onClicked: tailscale.authorizeTailscaleOperator()
+      onClicked: tailscale.startConnecting()
     }
 
     RowLayout {

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -42,6 +42,7 @@ Panel {
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+  property string removeArmedId: ""
   readonly property var connections: displayConnections()
   readonly property bool showConnections: connections.length > 1 || tailscale.accountsAccessDenied
   readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
@@ -185,13 +186,63 @@ Panel {
     return connections[Math.max(0, Math.min(accountIndex, connections.length - 1))]
   }
 
+  // Removing the connection in use would strand the machine, so the panel
+  // only offers it on the others; the CLI still covers the general case.
+  function canRemoveAccount(account) {
+    return !!account && account.AddAccount !== true && account.selected !== true && String(account.id || "") !== ""
+  }
+
+  function armRemoval(account) {
+    if (!canRemoveAccount(account)) return
+    removeArmedId = String(account.id || "")
+  }
+
+  function disarmRemoval() {
+    removeArmedId = ""
+  }
+
+  function confirmRemoval(account) {
+    if (!canRemoveAccount(account)) return
+    tailscale.removeAccount(account.id)
+    removeArmedId = ""
+  }
+
+  function toggleRemoval() {
+    if (focusSection !== "accounts") return
+    var account = selectedAccount()
+    if (!canRemoveAccount(account)) return
+    if (removeArmedId === String(account.id || "")) confirmRemoval(account)
+    else armRemoval(account)
+  }
+
   function chooseConnection(account) {
     if (!account) return
-    if (account.AddAccount === true) tailscale.addAccount()
-    else tailscale.switchAccount(account.id)
+    if (account.AddAccount === true) {
+      disarmRemoval()
+      tailscale.addAccount()
+      return
+    }
+    // A row waiting on its confirmation takes the activation, so the second
+    // press finishes what the first one asked for.
+    if (removeArmedId === String(account.id || "")) {
+      confirmRemoval(account)
+      return
+    }
+    disarmRemoval()
+    tailscale.switchAccount(account.id)
   }
 
   function ensureCursor() {
+    if (removeArmedId !== "") {
+      var stillOffered = false
+      for (var c = 0; c < connections.length; c++) {
+        if (canRemoveAccount(connections[c]) && String(connections[c].id || "") === removeArmedId) {
+          stillOffered = true
+          break
+        }
+      }
+      if (!stillOffered) removeArmedId = ""
+    }
     if (headerIndex < 0) headerIndex = 0
     if (headerIndex > 0) headerIndex = 0
     if (accountIndex >= root.connections.length) accountIndex = Math.max(0, root.connections.length - 1)
@@ -206,6 +257,7 @@ Panel {
 
   function moveCursor(dx, dy) {
     cursorActive = true
+    disarmRemoval()
     ensureCursor()
     if (dy !== 0) {
       if (focusSection === "header") {
@@ -433,7 +485,10 @@ Panel {
         root.moveCursor(dx, dy)
       }
       onActivateRequested: if (root.cursorActive) root.activateCursor()
-      onCloseRequested: root.close()
+      onCloseRequested: {
+        if (root.removeArmedId !== "") root.disarmRemoval()
+        else root.close()
+      }
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
         if (t === "t" || t === "T") tailscale.toggleTailscale()
@@ -441,6 +496,7 @@ Panel {
         else if (t === "n" || t === "N") tailscale.copyPeerName(root.selectedPeer())
         else if (t === "d" || t === "D") tailscale.copyPeerDnsName(root.selectedPeer())
         else if (t === "s" || t === "S") root.sendPeerFile(root.selectedPeer())
+        else if (t === "x" || t === "X") root.toggleRemoval()
       }
 
       Flickable {
@@ -814,20 +870,44 @@ Panel {
     id: accountRow
     property var account: null
     property int rowIndex: 0
+    readonly property string accountId: account ? String(account.id || "") : ""
     readonly property bool addAccount: account && account.AddAccount === true
     readonly property bool selectedAccount: !addAccount && account && account.selected === true
-    readonly property bool switchingAccount: !addAccount && account && tailscale.switchingAccountId === String(account.id || "")
-    readonly property string accountText: addAccount ? "Add account…" : (account ? tailscale.accountLabel(account) : "Account")
+    readonly property bool switchingAccount: !addAccount && accountId !== "" && tailscale.switchingAccountId === accountId
+    readonly property bool addingAccount: addAccount && tailscale.addingAccount
+    readonly property bool removingAccount: !addAccount && accountId !== "" && tailscale.removingAccountId === accountId
+    readonly property bool removable: root.canRemoveAccount(account)
+    readonly property bool armed: removable && root.removeArmedId === accountId
+    // The row is the thing being clicked, so it carries the progress rather
+    // than leaving it to the status line under the panel.
+    readonly property bool working: switchingAccount || addingAccount || removingAccount
+    readonly property string accountText: {
+      if (addAccount) return addingAccount ? "Opening browser…" : "Add account…"
+      if (!account) return "Account"
+      var label = tailscale.accountLabel(account)
+      if (removingAccount) return "Removing " + label + "…"
+      if (armed) return "Remove " + label + "?"
+      return label
+    }
 
     hasCursor: root.cursorActive && root.focusSection === "accounts" && root.accountIndex === rowIndex
-    current: selectedAccount
+    current: selectedAccount || armed
     foreground: root.foreground
     fill: root.hoverFill
     currentFill: root.selectedFill
 
     implicitHeight: accountInner.implicitHeight + Style.spacing.xl
 
-    Row {
+    MouseArea {
+      id: accountMouse
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onEntered: root.setAccountCursor(accountRow.rowIndex)
+      onClicked: root.chooseConnection(accountRow.account)
+    }
+
+    RowLayout {
       id: accountInner
       anchors.left: parent.left
       anchors.right: parent.right
@@ -839,16 +919,16 @@ Panel {
       Text {
         id: accountGlyph
         text: accountRow.addAccount ? "+" : ""
-        color: accountRow.selectedAccount || accountRow.switchingAccount || accountRow.addAccount ? root.foreground : root.dim
+        color: accountRow.selectedAccount || accountRow.working || accountRow.addAccount ? root.foreground : root.dim
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
-        width: Style.space(22)
         horizontalAlignment: Text.AlignHCenter
-        anchors.verticalCenter: parent.verticalCenter
-        opacity: accountRow.switchingAccount ? 0.45 : 1.0
+        Layout.preferredWidth: Style.space(22)
+        Layout.alignment: Qt.AlignVCenter
+        opacity: accountRow.working ? 0.45 : 1.0
 
         SequentialAnimation on opacity {
-          running: accountRow.switchingAccount
+          running: accountRow.working
           NumberAnimation { to: 1.0; duration: 420; easing.type: Easing.InOutQuad }
           NumberAnimation { to: 0.45; duration: 420; easing.type: Easing.InOutQuad }
           loops: Animation.Infinite
@@ -856,23 +936,28 @@ Panel {
       }
 
       Text {
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignVCenter
         text: accountRow.accountText
-        color: root.foreground
+        color: accountRow.armed ? root.urgent : root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
         font.bold: accountRow.selectedAccount
         elide: Text.ElideRight
-        width: parent.width - Style.space(22) - Style.space(8)
-        anchors.verticalCenter: parent.verticalCenter
       }
-    }
 
-    MouseArea {
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onEntered: root.setAccountCursor(accountRow.rowIndex)
-      onClicked: root.chooseConnection(accountRow.account)
+      PanelActionButton {
+        visible: accountRow.removable && !accountRow.removingAccount && (accountRow.armed || accountRow.hasCursor || accountMouse.containsMouse)
+        iconText: accountRow.armed ? "󰄬" : "󰅙"
+        tooltipText: accountRow.armed ? "Confirm removal" : "Remove from this machine"
+        foreground: accountRow.armed ? root.urgent : root.foreground
+        fontFamily: root.fontFamily
+        Layout.alignment: Qt.AlignVCenter
+        onClicked: {
+          if (accountRow.armed) root.confirmRemoval(accountRow.account)
+          else root.armRemoval(accountRow.account)
+        }
+      }
     }
   }
 

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -219,8 +219,10 @@ Panel {
 
   function chooseConnection(account) {
     if (!account) return
+    // A login owns the daemon's pending registration until it finishes, so no
+    // row starts anything beside it. Cancelling goes straight to the service.
+    if (tailscale.addingAccount) return
     if (account.AddAccount === true) {
-      if (tailscale.addingAccount) return
       removeArmedId = ""
       // Adding signs this machine out of the tailnet it is on until the
       // browser half finishes, so it asks before it does that.
@@ -496,7 +498,7 @@ Panel {
       }
       onActivateRequested: if (root.cursorActive) root.activateCursor()
       onCloseRequested: {
-        if (root.removeArmedId !== "") root.disarmRemoval()
+        if (root.removeArmedId !== "" || root.addArmed) root.disarmRemoval()
         else root.close()
       }
       onTabRequested: function(direction) { root.switchPanel(direction) }

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import "Model.js" as Model
 
 Panel {
   id: root
@@ -41,7 +42,8 @@ Panel {
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
-  readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
+  readonly property var connections: displayConnections()
+  readonly property bool showConnections: connections.length > 1 || tailscale.accountsAccessDenied
   readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
   readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
@@ -78,6 +80,12 @@ Panel {
     for (var j = 0; j < recentMullvadExitNodes.length; j++) nodes.push(recentMullvadExitNodes[j])
     if (tailscale.mullvadRegions.length > 0) nodes.push({ id: "mullvad:add", AddMullvad: true, DisplayName: "Choose Mullvad region" })
     return nodes
+  }
+
+  // Switching tailnets is only reachable once a second profile exists, and the
+  // CLI was the only thing that could create one.
+  function displayConnections() {
+    return Model.connectionRows(tailscale.accounts, tailscale.installed && tailscale.active)
   }
 
   function recentMullvadNodes() {
@@ -173,21 +181,27 @@ Panel {
   }
 
   function selectedAccount() {
-    if (tailscale.accounts.length === 0) return null
-    return tailscale.accounts[Math.max(0, Math.min(accountIndex, tailscale.accounts.length - 1))]
+    if (connections.length === 0) return null
+    return connections[Math.max(0, Math.min(accountIndex, connections.length - 1))]
+  }
+
+  function chooseConnection(account) {
+    if (!account) return
+    if (account.AddAccount === true) tailscale.addAccount()
+    else tailscale.switchAccount(account.id)
   }
 
   function ensureCursor() {
     if (headerIndex < 0) headerIndex = 0
     if (headerIndex > 0) headerIndex = 0
-    if (accountIndex >= tailscale.accounts.length) accountIndex = Math.max(0, tailscale.accounts.length - 1)
+    if (accountIndex >= root.connections.length) accountIndex = Math.max(0, root.connections.length - 1)
     if (peerIndex >= tailscale.peers.length) peerIndex = Math.max(0, tailscale.peers.length - 1)
     if (exitNodeIndex >= exitNodes.length) exitNodeIndex = Math.max(0, exitNodes.length - 1)
     if (mullvadRegionIndex >= filteredMullvadRegions.length) mullvadRegionIndex = Math.max(0, filteredMullvadRegions.length - 1)
-    if (focusSection === "auth" && !tailscale.accountsAccessDenied) focusSection = tailscale.accounts.length > 1 ? "accounts" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
-    if (focusSection === "accounts" && tailscale.accounts.length <= 1) focusSection = tailscale.accountsAccessDenied ? "auth" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
-    if (focusSection === "peers" && !showPeers) focusSection = showExitNodes ? "exitNodes" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : "header"))
-    if (focusSection === "exitNodes" && !showExitNodes) focusSection = showPeers ? "peers" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : "header"))
+    if (focusSection === "auth" && !tailscale.accountsAccessDenied) focusSection = root.connections.length > 1 ? "accounts" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
+    if (focusSection === "accounts" && root.connections.length <= 1) focusSection = tailscale.accountsAccessDenied ? "auth" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
+    if (focusSection === "peers" && !showPeers) focusSection = showExitNodes ? "exitNodes" : (tailscale.accountsAccessDenied ? "auth" : (root.connections.length > 1 ? "accounts" : "header"))
+    if (focusSection === "exitNodes" && !showExitNodes) focusSection = showPeers ? "peers" : (tailscale.accountsAccessDenied ? "auth" : (root.connections.length > 1 ? "accounts" : "header"))
   }
 
   function moveCursor(dx, dy) {
@@ -197,13 +211,13 @@ Panel {
       if (focusSection === "header") {
         if (dy > 0) {
           if (tailscale.accountsAccessDenied) focusSection = "auth"
-          else if (tailscale.accounts.length > 1) focusSection = "accounts"
+          else if (root.connections.length > 1) focusSection = "accounts"
           else if (showExitNodes) focusSection = "exitNodes"
           else if (showPeers) focusSection = "peers"
         }
       } else if (focusSection === "auth") {
         if (dy < 0) focusSection = "header"
-        else if (tailscale.accounts.length > 1) focusSection = "accounts"
+        else if (root.connections.length > 1) focusSection = "accounts"
         else if (showExitNodes) focusSection = "exitNodes"
         else if (showPeers) focusSection = "peers"
       } else if (focusSection === "accounts") {
@@ -211,20 +225,20 @@ Panel {
           if (accountIndex <= 0) focusSection = tailscale.accountsAccessDenied ? "auth" : "header"
           else accountIndex--
         } else {
-          if (accountIndex < tailscale.accounts.length - 1) accountIndex++
+          if (accountIndex < root.connections.length - 1) accountIndex++
           else if (showExitNodes) focusSection = "exitNodes"
           else if (showPeers) focusSection = "peers"
         }
       } else if (focusSection === "peers") {
         if (dy < 0) {
-          if (peerIndex <= 0) focusSection = showExitNodes ? "exitNodes" : (tailscale.accounts.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header"))
+          if (peerIndex <= 0) focusSection = showExitNodes ? "exitNodes" : (root.connections.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header"))
           else peerIndex--
         } else if (peerIndex < tailscale.peers.length - 1) {
           peerIndex++
         }
       } else if (focusSection === "exitNodes") {
         if (dy < 0) {
-          if (exitNodeIndex <= 0) focusSection = tailscale.accounts.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header")
+          if (exitNodeIndex <= 0) focusSection = root.connections.length > 1 ? "accounts" : (tailscale.accountsAccessDenied ? "auth" : "header")
           else exitNodeIndex--
         } else if (exitNodeIndex < exitNodes.length - 1) {
           exitNodeIndex++
@@ -245,7 +259,7 @@ Panel {
       tailscale.authorizeTailscaleOperator()
     } else if (focusSection === "accounts") {
       var account = selectedAccount()
-      if (account) tailscale.switchAccount(account.id)
+      if (account) chooseConnection(account)
     } else if (focusSection === "peers") {
       openSelectedPeerCopyMenu()
     } else if (focusSection === "exitNodes") {
@@ -549,7 +563,7 @@ Panel {
             }
 
             Repeater {
-              model: tailscale.accounts
+              model: root.connections
               AccountRow {
                 required property var modelData
                 required property int index
@@ -800,9 +814,10 @@ Panel {
     id: accountRow
     property var account: null
     property int rowIndex: 0
-    readonly property bool selectedAccount: account && account.selected === true
-    readonly property bool switchingAccount: account && tailscale.switchingAccountId === String(account.id || "")
-    readonly property string accountText: account ? tailscale.accountLabel(account) : "Account"
+    readonly property bool addAccount: account && account.AddAccount === true
+    readonly property bool selectedAccount: !addAccount && account && account.selected === true
+    readonly property bool switchingAccount: !addAccount && account && tailscale.switchingAccountId === String(account.id || "")
+    readonly property string accountText: addAccount ? "Add account…" : (account ? tailscale.accountLabel(account) : "Account")
 
     hasCursor: root.cursorActive && root.focusSection === "accounts" && root.accountIndex === rowIndex
     current: selectedAccount
@@ -823,8 +838,8 @@ Panel {
 
       Text {
         id: accountGlyph
-        text: ""
-        color: accountRow.selectedAccount || accountRow.switchingAccount ? root.foreground : root.dim
+        text: accountRow.addAccount ? "+" : ""
+        color: accountRow.selectedAccount || accountRow.switchingAccount || accountRow.addAccount ? root.foreground : root.dim
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
         width: Style.space(22)
@@ -857,7 +872,7 @@ Panel {
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
       onEntered: root.setAccountCursor(accountRow.rowIndex)
-      onClicked: if (accountRow.account) tailscale.switchAccount(accountRow.account.id)
+      onClicked: root.chooseConnection(accountRow.account)
     }
   }
 

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -760,16 +760,6 @@ Panel {
               fontFamily: root.fontFamily
             }
 
-            Text {
-              visible: tailscale.installed && tailscale.active && tailscale.peers.length === 0
-              width: parent.width
-              text: "No machines found on this tailnet."
-              color: root.dim
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.body
-              horizontalAlignment: Text.AlignHCenter
-            }
-
             Column {
               id: peerColumn
               visible: root.showPeers

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -87,7 +87,7 @@ Panel {
   // Switching tailnets is only reachable once a second profile exists, and the
   // CLI was the only thing that could create one.
   function displayConnections() {
-    return Model.connectionRows(tailscale.accounts, tailscale.installed && tailscale.active)
+    return Model.connectionRows(tailscale.accounts, tailscale.installed && tailscale.active && !tailscale.accountsAccessDenied)
   }
 
   function recentMullvadNodes() {

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -41,6 +41,12 @@ Removing a connection drops it from this machine only. The account itself is
 untouched, and logging in again brings it back. The connection in use is never
 offered for removal, so a removal cannot strand the machine mid-session.
 
+Connecting can take three things in order: authorizing the operator, signing
+in, and coming up. The panel runs whichever are outstanding rather than
+stopping after each, so connecting is one action however much of the sequence
+is left. It only ever starts from someone asking to connect, never on its own,
+and stops on the first step that fails or a dismissed prompt.
+
 ## Requirements
 
 - `tailscale` CLI on `PATH`

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -8,6 +8,7 @@ Native Omarchy bar widget for Tailscale.
 - Left click opens a keyboard-friendly panel
 - Right click toggles Tailscale on/off
 - Switch between available Tailscale connections when multiple are available
+- Add another tailnet, so a machine with a single connection has one to switch to
 - Browse machines from `tailscale status --json`
 - Copy a machine's Tailscale IP, host name, or DNS name
 - Send files to a machine with Taildrop, when the tailnet allows file sharing

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -8,7 +8,8 @@ Native Omarchy bar widget for Tailscale.
 - Left click opens a keyboard-friendly panel
 - Right click toggles Tailscale on/off
 - Switch between available Tailscale connections when multiple are available
-- Add another tailnet, so a machine with a single connection has one to switch to
+- Add another tailnet, so a machine with a single connection has one to switch to,
+  after confirming the sign-out it costs
 - Remove a tailnet you no longer use, with an inline confirmation
 - Browse machines from `tailscale status --json`
 - Copy a machine's Tailscale IP, host name, or DNS name
@@ -28,6 +29,13 @@ Inside the panel:
 - `t`: toggle Tailscale
 - `r`: refresh status
 - `esc`: close
+
+Adding a tailnet runs `tailscale login`, which makes the new profile current
+before the browser half finishes -- the machine leaves the tailnet it is on the
+moment it starts. The row asks before doing that, offers a cancel while it runs,
+and returns to the previous connection if the login never lands. The profile is
+created with the same operator as the install sets, so the way back never needs
+sudo.
 
 Removing a connection drops it from this machine only. The account itself is
 untouched, and logging in again brings it back. The connection in use is never

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -30,6 +30,12 @@ Inside the panel:
 - `r`: refresh status
 - `esc`: close
 
+The machines list carries only peers that are online, and shows nothing when
+there are none -- an empty section says that on its own, and a machine list is
+one of the things this panel is worst placed to be certain about. While it is
+empty and the machine is up, the panel polls quickly rather than waiting out
+the refresh interval, so the list appears about as fast as the tailnet answers.
+
 Adding a tailnet runs `tailscale login`, which makes the new profile current
 before the browser half finishes -- the machine leaves the tailnet it is on the
 moment it starts. The row asks before doing that, offers a cancel while it runs,

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -9,6 +9,7 @@ Native Omarchy bar widget for Tailscale.
 - Right click toggles Tailscale on/off
 - Switch between available Tailscale connections when multiple are available
 - Add another tailnet, so a machine with a single connection has one to switch to
+- Remove a tailnet you no longer use, with an inline confirmation
 - Browse machines from `tailscale status --json`
 - Copy a machine's Tailscale IP, host name, or DNS name
 - Send files to a machine with Taildrop, when the tailnet allows file sharing
@@ -23,9 +24,14 @@ Inside the panel:
 - `n`: copy selected peer name
 - `d`: copy selected peer DNS name
 - `s`: send files to selected peer
+- `x`: remove the selected connection, press again to confirm
 - `t`: toggle Tailscale
 - `r`: refresh status
 - `esc`: close
+
+Removing a connection drops it from this machine only. The account itself is
+untouched, and logging in again brings it back. The connection in use is never
+offered for removal, so a removal cannot strand the machine mid-session.
 
 ## Requirements
 

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -64,6 +64,10 @@ Item {
   property string _removeOutput: ""
   property string _removeError: ""
   property string _addAccountPreviousId: ""
+  // Only ever set by someone asking to connect, so the panel never brings
+  // Tailscale up on its own.
+  property bool _connecting: false
+  property int _connectSteps: 0
   property bool _returnedFromAddAccount: false
   property string _addAccountOutput: ""
   property string _addAccountError: ""
@@ -287,6 +291,9 @@ Item {
         actionStatusTimer.restart()
       }
     }
+    if (_connecting && !needsLogin && !running && !loginProcess.running && !actionProcess.running && backendState !== "NoState") {
+      continueConnecting()
+    }
     if (needsLogin) statusText = "Needs login"
     else if (running) {
       statusText = "Connected"
@@ -319,18 +326,50 @@ Item {
   function toggleTailscale() {
     if (!installed) return
     if (active) down()
+    else startConnecting()
+  }
+
+  function connectState() {
+    return { installed: installed, accessDenied: accountsAccessDenied, needsLogin: needsLogin, running: running }
+  }
+
+  function startConnecting() {
+    if (addAccountProcess.running) return
+    _connecting = true
+    _connectSteps = 0
+    continueConnecting()
+  }
+
+  function stopConnecting() {
+    _connecting = false
+    _connectSteps = 0
+  }
+
+  // Runs the outstanding steps in order. Each one only continues on its own
+  // success, and the count is a backstop against a step that keeps failing in
+  // a way that leaves the state unchanged.
+  function continueConnecting() {
+    if (!_connecting) return
+    // A login is already under way and owns the daemon's pending registration.
+    if (addAccountProcess.running) return
+    if (_connectSteps >= 4) { stopConnecting(); return }
+    var step = Model.nextConnectStep(connectState())
+    if (step === "done" || step === "none") { stopConnecting(); return }
+    _connectSteps += 1
+    if (step === "authorize") authorizeTailscaleOperator()
     else loginOrUp()
   }
 
   function down() {
     // No progress status here — the greyed icon and hero line already convey
     // the optimistic off; only surface a message if the command fails.
+    stopConnecting()
     _desired = 0
     runAction(["tailscale", "down"])
   }
 
   function loginOrUp() {
-    if (!installed || loginProcess.running) return
+    if (!installed || loginProcess.running || addAccountProcess.running) return
     _desired = -1
     var plan = Model.loginPlan(needsLogin, authUrl)
     if (plan.authUrl !== "") {
@@ -388,6 +427,8 @@ Item {
     // finishes, so the machine leaves the tailnet it is on the moment this
     // starts. Remember where to put it back if the login never lands.
     _addAccountPreviousId = selectedAccountId
+    // Whatever the sequence was going to do next, this login supersedes it.
+    stopConnecting()
     actionStatus = "Opening Tailscale login…"
     addAccountProcess.command = addAccountCommand()
     addAccountProcess.running = true
@@ -570,6 +611,12 @@ Item {
     repeat: false
     onTriggered: {
       if (!root._loginInProgress || root._loginUrlOpened) return
+      // An add took over the daemon's pending registration, so this is no
+      // longer the login whose link is worth waiting on.
+      if (addAccountProcess.running) {
+        root._loginInProgress = false
+        return
+      }
       if (root.openAuthUrlFrom(root.authUrl, true)) return
       attempts += 1
       if (attempts < 3) {
@@ -800,6 +847,7 @@ Item {
       // is an answer rather than a failure, so it leaves nothing behind; 127
       // and the rest are real errors and still get reported.
       if (exitCode === 126) {
+        root.stopConnecting()
         root.lastError = ""
         root.actionStatus = ""
       } else if (exitCode !== 0) {
@@ -812,6 +860,7 @@ Item {
         root.actionStatus = "Tailscale operator authorized"
         actionStatusTimer.restart()
         root._lastAccountsRefreshMs = 0
+        root.continueConnecting()
       }
       delayedRefresh.restart()
     }

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -64,6 +64,7 @@ Item {
   property string _removeOutput: ""
   property string _removeError: ""
   property string _addAccountPreviousId: ""
+  property bool _returnedFromAddAccount: false
   property string _addAccountOutput: ""
   property string _addAccountError: ""
   property bool _addAccountUrlOpened: false
@@ -259,6 +260,17 @@ Item {
     tailnetExitNodes = parsed.running ? parsed.exitNodes : []
     exitNodes = parsed.running ? tailnetExitNodes.concat(mullvadRegions) : []
 
+    // Adding a tailnet re-registers the machine, which can supersede the node
+    // key the previous connection was using. Returning to it then lands on a
+    // profile that needs signing in again, and "disconnected" alone does not
+    // say that.
+    if (_returnedFromAddAccount && !switchProcess.running) {
+      _returnedFromAddAccount = false
+      if (needsLogin) {
+        actionStatus = "Back on your connection — sign in again to reconnect"
+        actionStatusTimer.restart()
+      }
+    }
     if (needsLogin) statusText = "Needs login"
     else if (running) {
       statusText = "Connected"
@@ -382,6 +394,7 @@ Item {
     _switchOutput = ""
     _switchError = ""
     switchingAccountId = previous
+    _returnedFromAddAccount = true
     switchProcess.command = ["tailscale", "switch", previous]
     switchProcess.running = true
   }
@@ -687,18 +700,12 @@ Item {
     onExited: function(exitCode) {
       var combined = String(root._addAccountOutput || "") + "\n" + String(root._addAccountError || "")
       var opened = root.openAddAccountUrl(combined)
-      if (exitCode !== 0) {
-        // A login that was abandoned, cancelled or refused leaves the machine
-        // on a half-made profile it never asked to be on.
-        root.returnToPreviousAccount()
-        root.lastError = opened ? "" : elideStatus(combined || "tailscale login failed")
-        root.actionStatus = opened ? "Login not completed — back on the previous connection" : root.lastError
-        actionStatusTimer.restart()
-      } else {
-        root._addAccountPreviousId = ""
-        root.lastError = ""
-        root.actionStatus = ""
-      }
+      var outcome = Model.addAccountOutcome(exitCode, opened, root._addAccountPreviousId, root.elideStatus(combined))
+      if (outcome.returnTo !== "") root.returnToPreviousAccount()
+      else root._addAccountPreviousId = ""
+      root.lastError = outcome.error
+      root.actionStatus = outcome.status
+      if (outcome.status !== "") actionStatusTimer.restart()
       // A fresh login lands on a new profile and makes it the active one, so
       // don't sit behind the accounts throttle waiting to notice.
       root._lastAccountsRefreshMs = 0

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -331,7 +331,10 @@ Item {
     _preLoginAuthUrl = authUrl
     loginProcess.command = plan.command
     loginProcess.running = true
-    if (needsLogin) loginTimeoutTimer.restart()
+    if (needsLogin) {
+      loginTimeoutTimer.attempts = 0
+      loginTimeoutTimer.restart()
+    }
   }
 
   function switchAccount(id) {
@@ -542,14 +545,28 @@ Item {
 
   Timer {
     id: loginTimeoutTimer
+    // tailscaled does not always have the URL ready within one interval, and
+    // standing down on the first miss stranded the login: the flag below is
+    // what lets a status poll open the URL when it does arrive, so clearing it
+    // early left the panel holding a link it would never open.
+    property int attempts: 0
     interval: 10000
     repeat: false
     onTriggered: {
       if (!root._loginInProgress || root._loginUrlOpened) return
-      if (!root.openAuthUrlFrom(root.authUrl, true)) {
-        root._loginInProgress = false
-        root.actionStatus = "Tailscale login link not available yet"
+      if (root.openAuthUrlFrom(root.authUrl, true)) return
+      attempts += 1
+      if (attempts < 3) {
+        root.actionStatus = "Waiting for the Tailscale login link…"
+        actionStatusTimer.restart()
+        loginTimeoutTimer.restart()
+        return
       }
+      root._loginInProgress = false
+      root.actionStatus = "Tailscale login link not available yet"
+      // Every other status message clears itself. This one used to sit there
+      // for good, which reads as a frozen panel rather than a failed attempt.
+      actionStatusTimer.restart()
     }
   }
 

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -61,6 +61,7 @@ Item {
   property bool _loginUrlOpened: false
   property string _preLoginAuthUrl: ""
   property double _lastAccountsRefreshMs: 0
+  property string _previousBackendState: ""
   property string _removeOutput: ""
   property string _removeError: ""
   property string _addAccountPreviousId: ""
@@ -265,6 +266,15 @@ Item {
     }
 
     backendState = parsed.backendState
+    // A profile's tailnet name arrives with the netmap, so a connection list
+    // read while the machine was still coming up names a new profile by
+    // whatever it had then -- and the refresh throttle keeps that for a
+    // minute. Coming up is exactly when it is worth reading again.
+    if (backendState === "Running" && _previousBackendState !== "Running") {
+      _lastAccountsRefreshMs = 0
+      delayedRefresh.restart()
+    }
+    _previousBackendState = backendState
     running = parsed.running
     // Reality caught up to the pending toggle — stop overriding.
     if (_desired !== -1 && running === (_desired === 1)) _desired = -1

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -63,6 +63,7 @@ Item {
   property double _lastAccountsRefreshMs: 0
   property string _removeOutput: ""
   property string _removeError: ""
+  property string _addAccountPreviousId: ""
   property string _addAccountOutput: ""
   property string _addAccountError: ""
   property bool _addAccountUrlOpened: false
@@ -336,16 +337,53 @@ Item {
   // poll clears that as soon as it sees a running tailscaled — which is
   // exactly the state we are in here, so a poll landing between launching
   // the login and its first line of output would swallow the auth URL.
+  // Match how the service install brings the first profile up, so a tailnet
+  // added here does not quietly differ from the one already on the machine.
+  // The operator matters most: tailscale login starts a fresh profile, and
+  // without it that profile answers even `tailscale switch` with "access
+  // denied", so an abandoned login locks the way back behind sudo.
+  function addAccountCommand() {
+    var command = ["tailscale", "login", "--accept-routes"]
+    if (userName !== "") command.push("--operator=" + userName)
+    return command
+  }
+
   function addAccount() {
     if (!installed || addAccountProcess.running) return
     _addAccountOutput = ""
     _addAccountError = ""
     _addAccountUrlOpened = false
+    // tailscale login makes the new profile current before the browser half
+    // finishes, so the machine leaves the tailnet it is on the moment this
+    // starts. Remember where to put it back if the login never lands.
+    _addAccountPreviousId = selectedAccountId
     actionStatus = "Opening Tailscale login…"
-    // Match how the service install brings the first profile up, so a tailnet
-    // added here does not quietly differ from the one already on the machine.
-    addAccountProcess.command = ["tailscale", "login", "--accept-routes"]
+    addAccountProcess.command = addAccountCommand()
     addAccountProcess.running = true
+  }
+
+  function cancelAddAccount() {
+    if (!addAccountProcess.running) return
+    actionStatus = "Returning to the previous connection…"
+    addAccountProcess.running = false
+    returnToPreviousAccount()
+  }
+
+  // Clears the record as it goes, so the exit handler and an explicit cancel
+  // can both call it and only the first one does anything.
+  function returnToPreviousAccount() {
+    var previous = _addAccountPreviousId
+    _addAccountPreviousId = ""
+    // Nothing is compared against selectedAccountId here: the accounts list is
+    // only re-read once a minute, so at this point it still names the profile
+    // being returned to and the comparison would skip the switch that matters.
+    // Switching to the profile already current is a harmless no-op anyway.
+    if (previous === "" || switchProcess.running) return
+    _switchOutput = ""
+    _switchError = ""
+    switchingAccountId = previous
+    switchProcess.command = ["tailscale", "switch", previous]
+    switchProcess.running = true
   }
 
   function openAddAccountUrl(text) {
@@ -649,11 +687,15 @@ Item {
     onExited: function(exitCode) {
       var combined = String(root._addAccountOutput || "") + "\n" + String(root._addAccountError || "")
       var opened = root.openAddAccountUrl(combined)
-      if (exitCode !== 0 && !opened) {
-        root.lastError = elideStatus(combined || "tailscale login failed")
-        root.actionStatus = root.lastError
+      if (exitCode !== 0) {
+        // A login that was abandoned, cancelled or refused leaves the machine
+        // on a half-made profile it never asked to be on.
+        root.returnToPreviousAccount()
+        root.lastError = opened ? "" : elideStatus(combined || "tailscale login failed")
+        root.actionStatus = opened ? "Login not completed — back on the previous connection" : root.lastError
         actionStatusTimer.restart()
       } else {
+        root._addAccountPreviousId = ""
         root.lastError = ""
         root.actionStatus = ""
       }

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -216,6 +216,10 @@ Item {
   // A command refused for want of the operator has a fix the panel can offer,
   // so raise that rather than repeating the CLI's advice to go and use sudo.
   function reportCommandError(text, fallback) {
+    // A step that failed ends the sequence: it is the stop-on-first-failure
+    // the sequence promises, and without it the next status poll picks the
+    // same step straight back up.
+    stopConnecting()
     var message = elideStatus(text)
     if (message === "") message = String(fallback || "")
     if (Model.isAccessDenied(message)) {
@@ -432,6 +436,10 @@ Item {
 
   function addAccount() {
     if (!installed || addAccountProcess.running) return
+    // Every one of these is already moving daemon profile state, and the
+    // recovery switch is skipped while one is running, so a login started
+    // beside them can strand the machine on the half-made profile.
+    if (switchProcess.running || removeProcess.running || loginProcess.running || operatorProcess.running) return
     _addAccountOutput = ""
     _addAccountError = ""
     _addAccountUrlOpened = false
@@ -555,6 +563,31 @@ Item {
     if (isError) _loginError += text + "\n"
     else _loginOutput += text + "\n"
     if (_loginInProgress && !_loginUrlOpened) openAuthUrlFrom(text, false)
+  }
+
+  Timer {
+    id: refreshTimer
+    interval: root.refreshIntervalSec * 1000
+    repeat: true
+    running: true
+    triggeredOnStart: true
+    onTriggered: root.refresh()
+  }
+
+  Timer {
+    // After a fresh boot the startup poll usually lands before tailscaled has
+    // connected, which left the icon stale until the next periodic refresh.
+    // Poll quickly until the service shows up, or give up after ~30 seconds.
+    id: startupRamp
+    property int ticks: 0
+    interval: 2000
+    repeat: true
+    running: true
+    onTriggered: {
+      ticks += 1
+      if (root.running || ticks >= 15) startupRamp.running = false
+      else root.refresh()
+    }
   }
 
   Timer {
@@ -804,9 +837,7 @@ Item {
       var stdout = String(removeStdout.text || root._removeOutput || "")
       var stderr = String(removeStderr.text || root._removeError || "")
       if (exitCode !== 0) {
-        root.lastError = elideStatus(stderr || stdout || "Could not remove the connection")
-        root.actionStatus = root.lastError
-        actionStatusTimer.restart()
+        root.reportCommandError(stderr || stdout, "Could not remove the connection")
       } else {
         root.lastError = ""
         root.actionStatus = ""

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -202,8 +202,24 @@ Item {
   }
 
   function elideStatus(text) {
-    var value = String(text || "").replace(/\s+/g, " ").trim()
+    // Drop the version skew warning before measuring, or it eats the budget
+    // and elides away the part that says what went wrong.
+    var value = Model.commandMessage(text)
     return value.length > 140 ? value.substring(0, 137) + "…" : value
+  }
+
+  // A command refused for want of the operator has a fix the panel can offer,
+  // so raise that rather than repeating the CLI's advice to go and use sudo.
+  function reportCommandError(text, fallback) {
+    var message = elideStatus(text)
+    if (message === "") message = String(fallback || "")
+    if (Model.isAccessDenied(message)) {
+      accountsAccessDenied = true
+      message = "Tailscale needs permission on this machine"
+    }
+    lastError = message
+    actionStatus = message
+    actionStatusTimer.restart()
   }
 
   function resetUnavailable(message) {
@@ -648,9 +664,7 @@ Item {
       var stderr = String(actionStderr.text || root._actionError || "")
       if (exitCode !== 0) {
         root._desired = -1
-        root.lastError = elideStatus(stderr || stdout || "Tailscale command failed")
-        root.actionStatus = root.lastError
-        actionStatusTimer.restart()
+        root.reportCommandError(stderr || stdout, "Tailscale command failed")
       } else {
         root.lastError = ""
         root.actionStatus = ""
@@ -671,9 +685,7 @@ Item {
       if (exitCode !== 0 && !opened) {
         root._desired = -1
         root._loginInProgress = false
-        root.lastError = elideStatus(combined || "tailscale up failed")
-        root.actionStatus = root.lastError
-        actionStatusTimer.restart()
+        root.reportCommandError(combined, "tailscale up failed")
       } else if (!opened) {
         root.lastError = ""
         root.actionStatus = ""
@@ -692,9 +704,7 @@ Item {
       var stdout = String(switchStdout.text || root._switchOutput || "")
       var stderr = String(switchStderr.text || root._switchError || "")
       if (exitCode !== 0) {
-        root.lastError = elideStatus(stderr || stdout || "Account switch failed")
-        root.actionStatus = root.lastError
-        actionStatusTimer.restart()
+        root.reportCommandError(stderr || stdout, "Account switch failed")
       } else {
         root.lastError = ""
         root.actionStatus = ""
@@ -763,9 +773,7 @@ Item {
       var stdout = String(exitNodeStdout.text || root._exitNodeOutput || "")
       var stderr = String(exitNodeStderr.text || root._exitNodeError || "")
       if (exitCode !== 0) {
-        root.lastError = elideStatus(stderr || stdout || "Exit node selection failed")
-        root.actionStatus = root.lastError
-        actionStatusTimer.restart()
+        root.reportCommandError(stderr || stdout, "Exit node selection failed")
       } else {
         root.lastError = ""
         root.actionStatus = ""

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -287,6 +287,8 @@ Item {
     selfUserId = parsed.selfUserId
     fileSharing = parsed.fileSharing
     peers = parsed.running ? parsed.peers : []
+    // Stop hurrying as soon as there is something to show.
+    if (peers.length > 0) peersRamp.ticks = 0
     tailnetExitNodes = parsed.running ? parsed.exitNodes : []
     exitNodes = parsed.running ? tailnetExitNodes.concat(mullvadRegions) : []
 
@@ -556,27 +558,18 @@ Item {
   }
 
   Timer {
-    id: refreshTimer
-    interval: root.refreshIntervalSec * 1000
-    repeat: true
-    running: true
-    triggeredOnStart: true
-    onTriggered: root.refresh()
-  }
-
-  Timer {
-    // After a fresh boot the startup poll usually lands before tailscaled has
-    // connected, which left the icon stale until the next periodic refresh.
-    // Poll quickly until the service shows up, or give up after ~30 seconds.
-    id: startupRamp
+    // A tailnet answers within a second or two of coming up, but the ordinary
+    // poll is half a minute away, so an empty list sat there for the rest of
+    // the interval whatever it actually contained. Ask again quickly while
+    // there is nothing to show, and stop the moment there is.
+    id: peersRamp
     property int ticks: 0
     interval: 2000
     repeat: true
-    running: true
+    running: root.running && root.peers.length === 0 && ticks < 8
     onTriggered: {
       ticks += 1
-      if (root.running || ticks >= 15) startupRamp.running = false
-      else root.refresh()
+      root.refreshStatusAndAccounts(false)
     }
   }
 

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -42,7 +42,7 @@ Item {
   property string lastError: ""
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
-  readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || operatorProcess.running || exitNodeProcess.running
+  readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || addAccountProcess.running || operatorProcess.running || exitNodeProcess.running
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
 
   property string _statusOutput: ""
@@ -59,6 +59,9 @@ Item {
   property bool _loginUrlOpened: false
   property string _preLoginAuthUrl: ""
   property double _lastAccountsRefreshMs: 0
+  property string _addAccountOutput: ""
+  property string _addAccountError: ""
+  property bool _addAccountUrlOpened: false
   property string _switchOutput: ""
   property string _switchError: ""
   property string _exitNodeOutput: ""
@@ -324,6 +327,33 @@ Item {
     switchProcess.running = true
   }
 
+  // Adding a tailnet runs its own login rather than borrowing the toggle's.
+  // The toggle keys its browser hand-off off _loginInProgress, and a status
+  // poll clears that as soon as it sees a running tailscaled — which is
+  // exactly the state we are in here, so a poll landing between launching
+  // the login and its first line of output would swallow the auth URL.
+  function addAccount() {
+    if (!installed || addAccountProcess.running) return
+    _addAccountOutput = ""
+    _addAccountError = ""
+    _addAccountUrlOpened = false
+    actionStatus = "Opening Tailscale login…"
+    // Match how the service install brings the first profile up, so a tailnet
+    // added here does not quietly differ from the one already on the machine.
+    addAccountProcess.command = ["tailscale", "login", "--accept-routes"]
+    addAccountProcess.running = true
+  }
+
+  function openAddAccountUrl(text) {
+    if (_addAccountUrlOpened) return true
+    var match = String(text || "").match(/https?:\/\/\S+/)
+    if (!match || !match[0]) return false
+    _addAccountUrlOpened = true
+    actionStatus = "Finish signing in in your browser"
+    Quickshell.execDetached(["omarchy-launch-browser", match[0]])
+    return true
+  }
+
   function exitNodeTarget(peer) {
     if (!peer) return ""
     if (peer.Mullvad === true) {
@@ -585,6 +615,33 @@ Item {
         root._lastAccountsRefreshMs = 0
       }
       root.switchingAccountId = ""
+      delayedRefresh.restart()
+    }
+  }
+
+  Process {
+    id: addAccountProcess
+    running: false
+    command: []
+    // The auth URL arrives on whichever stream tailscale feels like using, and
+    // it arrives while the process is still running: `tailscale login` blocks
+    // until the browser half finishes.
+    stdout: SplitParser { onRead: function(data) { root._addAccountOutput += data + "\n"; root.openAddAccountUrl(data) } }
+    stderr: SplitParser { onRead: function(data) { root._addAccountError += data + "\n"; root.openAddAccountUrl(data) } }
+    onExited: function(exitCode) {
+      var combined = String(root._addAccountOutput || "") + "\n" + String(root._addAccountError || "")
+      var opened = root.openAddAccountUrl(combined)
+      if (exitCode !== 0 && !opened) {
+        root.lastError = elideStatus(combined || "tailscale login failed")
+        root.actionStatus = root.lastError
+        actionStatusTimer.restart()
+      } else {
+        root.lastError = ""
+        root.actionStatus = ""
+      }
+      // A fresh login lands on a new profile and makes it the active one, so
+      // don't sit behind the accounts throttle waiting to notice.
+      root._lastAccountsRefreshMs = 0
       delayedRefresh.restart()
     }
   }

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -784,7 +784,13 @@ Item {
     onExited: function(exitCode) {
       var stdout = String(operatorStdout.text || root._operatorOutput || "")
       var stderr = String(operatorStderr.text || root._operatorError || "")
-      if (exitCode !== 0) {
+      // pkexec exits 126 when the dialog was dismissed. Declining to authorize
+      // is an answer rather than a failure, so it leaves nothing behind; 127
+      // and the rest are real errors and still get reported.
+      if (exitCode === 126) {
+        root.lastError = ""
+        root.actionStatus = ""
+      } else if (exitCode !== 0) {
         root.lastError = elideStatus(stderr || stdout || "Tailscale authorization failed")
         root.actionStatus = root.lastError
         actionStatusTimer.restart()

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -36,13 +36,15 @@ Item {
   property string selectedAccountId: ""
   property string selectedAccountLabel: ""
   property string switchingAccountId: ""
+  readonly property bool addingAccount: addAccountProcess.running
+  property string removingAccountId: ""
   property string settingExitNodeId: ""
   property bool accountsAccessDenied: false
   property string actionStatus: ""
   property string lastError: ""
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
-  readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || addAccountProcess.running || operatorProcess.running || exitNodeProcess.running
+  readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || addAccountProcess.running || removeProcess.running || operatorProcess.running || exitNodeProcess.running
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
 
   property string _statusOutput: ""
@@ -59,6 +61,8 @@ Item {
   property bool _loginUrlOpened: false
   property string _preLoginAuthUrl: ""
   property double _lastAccountsRefreshMs: 0
+  property string _removeOutput: ""
+  property string _removeError: ""
   property string _addAccountOutput: ""
   property string _addAccountError: ""
   property bool _addAccountUrlOpened: false
@@ -354,6 +358,20 @@ Item {
     return true
   }
 
+  // Removing a connection only drops it from this machine -- the account
+  // itself is untouched, and logging in again brings it back.
+  function removeAccount(id) {
+    var accountId = String(id || "")
+    if (!installed || accountId === "" || removeProcess.running) return
+    // Removing the connection in use would strand the machine mid-session.
+    if (accountId === selectedAccountId) return
+    _removeOutput = ""
+    _removeError = ""
+    removingAccountId = accountId
+    removeProcess.command = ["tailscale", "switch", "remove", accountId]
+    removeProcess.running = true
+  }
+
   function exitNodeTarget(peer) {
     if (!peer) return ""
     if (peer.Mullvad === true) {
@@ -642,6 +660,29 @@ Item {
       // A fresh login lands on a new profile and makes it the active one, so
       // don't sit behind the accounts throttle waiting to notice.
       root._lastAccountsRefreshMs = 0
+      delayedRefresh.restart()
+    }
+  }
+
+  Process {
+    id: removeProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: removeStdout; waitForEnd: true; onStreamFinished: root._removeOutput = text }
+    stderr: StdioCollector { id: removeStderr; waitForEnd: true; onStreamFinished: root._removeError = text }
+    onExited: function(exitCode) {
+      var stdout = String(removeStdout.text || root._removeOutput || "")
+      var stderr = String(removeStderr.text || root._removeError || "")
+      if (exitCode !== 0) {
+        root.lastError = elideStatus(stderr || stdout || "Could not remove the connection")
+        root.actionStatus = root.lastError
+        actionStatusTimer.restart()
+      } else {
+        root.lastError = ""
+        root.actionStatus = ""
+        root._lastAccountsRefreshMs = 0
+      }
+      root.removingAccountId = ""
       delayedRefresh.restart()
     }
   }

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -730,9 +730,13 @@ Item {
       var outcome = Model.addAccountOutcome(exitCode, opened, root._addAccountPreviousId, root.elideStatus(combined))
       if (outcome.returnTo !== "") root.returnToPreviousAccount()
       else root._addAccountPreviousId = ""
-      root.lastError = outcome.error
-      root.actionStatus = outcome.status
-      if (outcome.status !== "") actionStatusTimer.restart()
+      if (Model.isAccessDenied(outcome.error)) {
+        root.reportCommandError(outcome.error, "")
+      } else {
+        root.lastError = outcome.error
+        root.actionStatus = outcome.status
+        if (outcome.status !== "") actionStatusTimer.restart()
+      }
       // A fresh login lands on a new profile and makes it the active one, so
       // don't sit behind the accounts throttle waiting to notice.
       root._lastAccountsRefreshMs = 0

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -207,8 +207,21 @@ assertDeepEqual(
 )
 assertDeepEqual(tailscale.connectionRows(null, true).map(row => row.id), ['account:add'], 'tailscale handles a missing connection list')
 
-assert(/if \(account\.AddAccount === true\) tailscale\.addAccount\(\)/.test(panelSource), 'tailscale activates the add row as a login rather than a switch')
+assert(/if \(account\.AddAccount === true\) \{\s*\n\s*disarmRemoval\(\)\s*\n\s*tailscale\.addAccount\(\)/.test(panelSource), 'tailscale activates the add row as a login rather than a switch')
 assert(/addAccountProcess\.command = \["tailscale", "login", "--accept-routes"\]/.test(serviceSource), 'tailscale adds a connection the way the service install brings one up')
+assert(/readonly property bool addingAccount: addAccountProcess\.running/.test(serviceSource), 'tailscale publishes that a connection is being added')
+assert(/running: accountRow\.working/.test(panelSource), 'tailscale animates the row while it is adding or switching')
+assert(/addingAccount \? "Opening browser…" : "Add account…"/.test(panelSource), 'tailscale says what the add row is doing while it runs')
+
+assert(/removeProcess\.command = \["tailscale", "switch", "remove", accountId\]/.test(serviceSource), 'tailscale removes a connection from this machine')
+// Removing the profile in use would strand the machine mid-session.
+assert(/if \(accountId === selectedAccountId\) return/.test(serviceSource), 'tailscale refuses to remove the connection in use')
+assert(/account\.selected !== true && String\(account\.id \|\| ""\) !== ""/.test(panelSource), 'tailscale offers removal only on connections that are not in use')
+// Two deliberate activations, so a stray click cannot drop a connection.
+assert(/if \(removeArmedId === String\(account\.id \|\| ""\)\) \{\s*\n\s*confirmRemoval\(account\)/.test(panelSource), 'tailscale takes a second activation to confirm a removal')
+assert(/armed \? "Remove " \+ label \+ "\?"/.test(panelSource) || /if \(armed\) return "Remove " \+ label \+ "\?"/.test(panelSource), 'tailscale asks before removing')
+assert(/onCloseRequested: \{\s*\n\s*if \(root\.removeArmedId !== ""\) root\.disarmRemoval\(\)/.test(panelSource), 'tailscale backs out of the question before closing the panel')
+assert(/disarmRemoval\(\)\s*\n\s*ensureCursor\(\)/.test(panelSource), 'tailscale abandons the question when the cursor moves off the row')
 // The toggle's login hand-off keys off _loginInProgress, which a status poll
 // clears as soon as tailscaled is running — the state adding an account starts
 // from. Sharing that process would drop the auth URL.

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -189,6 +189,29 @@ assertEqual(
   'tailnet.example',
   'tailscale labels connections by tailnet when nickname is missing'
 )
+// Tailscale names a profile after its login unless one is set explicitly, so
+// the nickname is never empty and would otherwise hide the display name the
+// admin console set.
+assertEqual(
+  tailscale.accountLabel({ nickname: 'user@example', tailnet: 'Acme Corp', account: 'user@example', id: 'abcd' }),
+  'Acme Corp',
+  'tailscale labels connections by tailnet display name when the profile only carries its login'
+)
+assertEqual(
+  tailscale.accountLabel({ nickname: 'Work', tailnet: 'Acme Corp', account: 'user@example', id: 'abcd' }),
+  'Work',
+  'tailscale prefers a deliberately set nickname over the tailnet display name'
+)
+assertEqual(
+  tailscale.accountLabel({ nickname: 'user@example', tailnet: '', account: 'user@example', id: 'abcd' }),
+  'user@example',
+  'tailscale falls back to the login when no display name is available'
+)
+assertEqual(
+  tailscale.accountLabel({ nickname: '', tailnet: '', account: '', id: 'abcd' }),
+  'abcd',
+  'tailscale falls back to the profile id'
+)
 
 assertDeepEqual(
   tailscale.connectionRows(accounts.accounts, true).map(row => row.id),

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -386,6 +386,18 @@ assert(/_previousBackendState = backendState/.test(serviceSource), 'tailscale on
 assert(/opacity: shown \? 1 : 0\s*\n\s*enabled: shown/.test(panelSource), 'tailscale keeps the row action in the layout so hovering cannot resize the row')
 assert(!/visible: accountRow\.addingAccount \|\| accountRow\.addArmed/.test(panelSource), 'tailscale no longer toggles the row action with visible')
 
+// after it, so running-and-named is not on its own enough to call it empty.
+// before the peer list arrives, so the list says it is loading until it turns
+// up or has had long enough to be an answer.
+assert(/interval: 10000/.test(serviceSource), 'tailscale waits long enough to be sure')
+// polls never landed outside Running never looked like a transition at all.
+// The list emptying while the machine is up is the signal, whatever caused it.
+// The ordinary poll is half a minute away, so an empty list stayed empty for
+// the rest of the interval whatever the tailnet actually held.
+assert(/id: peersRamp/.test(serviceSource), 'tailscale asks again quickly while it has nothing to show')
+assert(/running: root\.running && root\.peers\.length === 0 && ticks < 8/.test(serviceSource), 'tailscale only hurries while the list is empty, and not forever')
+assert(/if \(peers\.length > 0\) peersRamp\.ticks = 0/.test(serviceSource), 'tailscale stops hurrying once the list arrives')
+
 // The real shape of a second tailnet: Tailscale names the profile after the
 // login it was made from, and the tailnet carries the name set in the admin
 // console.

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -207,11 +207,26 @@ assertDeepEqual(
 )
 assertDeepEqual(tailscale.connectionRows(null, true).map(row => row.id), ['account:add'], 'tailscale handles a missing connection list')
 
-assert(/if \(account\.AddAccount === true\) \{\s*\n\s*disarmRemoval\(\)\s*\n\s*tailscale\.addAccount\(\)/.test(panelSource), 'tailscale activates the add row as a login rather than a switch')
-assert(/addAccountProcess\.command = \["tailscale", "login", "--accept-routes"\]/.test(serviceSource), 'tailscale adds a connection the way the service install brings one up')
+assert(/addArmed = false\s*\n\s*tailscale\.addAccount\(\)/.test(panelSource), 'tailscale activates the add row as a login rather than a switch')
+assert(/var command = \["tailscale", "login", "--accept-routes"\]/.test(serviceSource), 'tailscale adds a connection the way the service install brings one up')
+// A fresh profile without an operator answers even `tailscale switch` with
+// access denied, so an abandoned login would lock the way back behind sudo.
+assert(/command\.push\("--operator=" \+ userName\)/.test(serviceSource), 'tailscale keeps operator access on the profile it creates')
+// tailscale login makes the new profile current before the browser half
+// finishes, so an abandoned login must not leave the machine stranded on it.
+assert(/_addAccountPreviousId = selectedAccountId/.test(serviceSource), 'tailscale remembers the connection it is leaving')
+assert(/root\.returnToPreviousAccount\(\)/.test(serviceSource), 'tailscale goes back when the login does not land')
+// The accounts list is only re-read once a minute, so at the moment the login
+// fails selectedAccountId still names the profile being returned to. Comparing
+// against it there skips the one switch that matters.
+assert(!/if \(previous === "" \|\| previous === selectedAccountId/.test(serviceSource), 'tailscale does not skip the return on a stale selected account')
+assert(/function cancelAddAccount\(\) \{[\s\S]*?addAccountProcess\.running = false[\s\S]*?returnToPreviousAccount\(\)/.test(serviceSource), 'tailscale can bail out of a login in progress')
+assert(/if \(accountRow\.addingAccount\) tailscale\.cancelAddAccount\(\)/.test(panelSource), 'tailscale offers the bail-out on the row that is running')
+assert(/if \(!addArmed\) \{\s*\n\s*addArmed = true/.test(panelSource), 'tailscale asks before signing the machine out to add a tailnet')
 assert(/readonly property bool addingAccount: addAccountProcess\.running/.test(serviceSource), 'tailscale publishes that a connection is being added')
 assert(/running: accountRow\.working/.test(panelSource), 'tailscale animates the row while it is adding or switching')
-assert(/addingAccount \? "Opening browser…" : "Add account…"/.test(panelSource), 'tailscale says what the add row is doing while it runs')
+assert(/if \(addingAccount\) return "Opening browser…"/.test(panelSource), 'tailscale says what the add row is doing while it runs')
+assert(/"Signs out of " \+ current \+ " — confirm\?"/.test(panelSource), 'tailscale says which connection adding will sign out of')
 
 assert(/removeProcess\.command = \["tailscale", "switch", "remove", accountId\]/.test(serviceSource), 'tailscale removes a connection from this machine')
 // Removing the profile in use would strand the machine mid-session.

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -346,6 +346,11 @@ assertEqual(tailscale.commandMessage(''), '', 'tailscale handles empty command o
 assertEqual(tailscale.commandMessage(null), '', 'tailscale handles missing command output')
 
 assert(tailscale.isAccessDenied('Access denied: checkprefs access denied'), 'tailscale spots a refusal for want of the operator')
+// tailscale login --operator is refused by the very check it would fix, so the
+// add row can only dead-end while the panel already knows it lacks the operator.
+assertDeepEqual(tailscale.connectionRows([{ id: 'db1b' }], false).map(row => row.id), ['db1b'], 'tailscale withholds the add row when it cannot be used')
+assert(/tailscale\.active && !tailscale\.accountsAccessDenied/.test(panelSource), 'tailscale hides the add row while it lacks the operator')
+assert(/if \(Model\.isAccessDenied\(outcome\.error\)\) \{\s*\n\s*root\.reportCommandError/.test(serviceSource), 'tailscale offers the operator fix when the add is refused')
 assert(tailscale.isAccessDenied('profiles access denied'), 'tailscale spots the profiles refusal too')
 assert(!tailscale.isAccessDenied('tailscale up failed'), 'tailscale does not mistake an ordinary failure for a refusal')
 

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -8,6 +8,7 @@ run_node_test <<'JS'
 const fs = require('fs')
 const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
+const serviceSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Service.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
 
@@ -188,6 +189,30 @@ assertEqual(
   'tailnet.example',
   'tailscale labels connections by tailnet when nickname is missing'
 )
+
+assertDeepEqual(
+  tailscale.connectionRows(accounts.accounts, true).map(row => row.id),
+  ['db1b', '1785', 'account:add'],
+  'tailscale offers adding a tailnet after the existing connections'
+)
+assertDeepEqual(
+  tailscale.connectionRows([{ id: 'db1b', nickname: 'Home', selected: true }], true).map(row => row.id),
+  ['db1b', 'account:add'],
+  'tailscale offers adding a tailnet when only one connection exists'
+)
+assertDeepEqual(
+  tailscale.connectionRows(accounts.accounts, false).map(row => row.id),
+  ['db1b', '1785'],
+  'tailscale withholds the add row while disconnected'
+)
+assertDeepEqual(tailscale.connectionRows(null, true).map(row => row.id), ['account:add'], 'tailscale handles a missing connection list')
+
+assert(/if \(account\.AddAccount === true\) tailscale\.addAccount\(\)/.test(panelSource), 'tailscale activates the add row as a login rather than a switch')
+assert(/addAccountProcess\.command = \["tailscale", "login", "--accept-routes"\]/.test(serviceSource), 'tailscale adds a connection the way the service install brings one up')
+// The toggle's login hand-off keys off _loginInProgress, which a status poll
+// clears as soon as tailscaled is running — the state adding an account starts
+// from. Sharing that process would drop the auth URL.
+assert(/Process \{\s*\n\s*id: addAccountProcess/.test(serviceSource), 'tailscale adds a connection on its own process, not the toggle\'s')
 
 assertDeepEqual(
   tailscale.loginPlan(true, 'https://login.tailscale.com/a/existing'),

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -327,7 +327,7 @@ assert(/root\.actionStatus = "Tailscale login link not available yet"\s*\n(\s*\/
 assert(/loginTimeoutTimer\.attempts = 0/.test(serviceSource), 'tailscale starts each login with a fresh attempt count')
 // pkexec exits 126 when the dialog is dismissed, which is a decision rather
 // than a failure and should not be reported as one.
-assert(/if \(exitCode === 126\) \{\s*\n\s*root\.lastError = ""\s*\n\s*root\.actionStatus = ""/.test(serviceSource), 'tailscale leaves nothing behind when the operator prompt is dismissed')
+assert(/if \(exitCode === 126\) \{[\s\S]{0,120}?root\.lastError = ""\s*\n\s*root\.actionStatus = ""/.test(serviceSource), 'tailscale leaves nothing behind when the operator prompt is dismissed')
 assert(/\} else if \(exitCode !== 0\) \{\s*\n\s*root\.lastError = elideStatus\(stderr \|\| stdout \|\| "Tailscale authorization failed"\)/.test(serviceSource), 'tailscale still reports a real authorization failure')
 // Exactly what the panel showed on a machine whose client and daemon differ:
 // the warning arrives on stderr ahead of the real refusal.
@@ -350,6 +350,30 @@ assert(tailscale.isAccessDenied('Access denied: checkprefs access denied'), 'tai
 // add row can only dead-end while the panel already knows it lacks the operator.
 assertDeepEqual(tailscale.connectionRows([{ id: 'db1b' }], false).map(row => row.id), ['db1b'], 'tailscale withholds the add row when it cannot be used')
 assert(/tailscale\.active && !tailscale\.accountsAccessDenied/.test(panelSource), 'tailscale hides the add row while it lacks the operator')
+
+// Getting connected can take three things in order, and the panel runs them
+// rather than making someone rediscover the next step after each one.
+assertEqual(tailscale.nextConnectStep({ installed: false }), 'none', 'tailscale has no step without the CLI')
+assertEqual(tailscale.nextConnectStep({ installed: true, accessDenied: true, needsLogin: true }), 'authorize', 'tailscale authorizes before anything it would refuse')
+assertEqual(tailscale.nextConnectStep({ installed: true, needsLogin: true }), 'login', 'tailscale signs in once it is allowed to')
+assertEqual(tailscale.nextConnectStep({ installed: true, needsLogin: false, running: false }), 'up', 'tailscale comes up after signing in, without a second ask')
+assertEqual(tailscale.nextConnectStep({ installed: true, needsLogin: false, running: true }), 'done', 'tailscale stops once it is connected')
+assertEqual(tailscale.nextConnectStep(null), 'none', 'tailscale handles a missing state')
+
+assert(/root\.continueConnecting\(\)/.test(serviceSource), 'tailscale carries on after authorizing instead of stopping there')
+assert(/if \(exitCode === 126\) \{\s*\n\s*root\.stopConnecting\(\)/.test(serviceSource), 'tailscale stops the sequence when the prompt is dismissed')
+assert(/if \(_connectSteps >= 4\) \{ stopConnecting\(\); return \}/.test(serviceSource), 'tailscale will not loop on a step that keeps failing')
+assert(/function down\(\) \{[\s\S]*?stopConnecting\(\)/.test(serviceSource), 'tailscale abandons the sequence when told to disconnect')
+
+// Adding a tailnet is a login of its own and owns the daemon's pending
+// registration. Running the connect sequence beside it starts a second one and
+// the two race for the daemon, which is how a completed sign-in still landed
+// on a machine that was logged out.
+assert(/function startConnecting\(\) \{\s*\n\s*if \(addAccountProcess\.running\) return/.test(serviceSource), 'tailscale will not start the sequence beside a login that is adding')
+assert(/function continueConnecting\(\) \{[\s\S]{0,200}?if \(addAccountProcess\.running\) return/.test(serviceSource), 'tailscale will not continue the sequence beside a login that is adding')
+assert(/if \(!installed \|\| loginProcess\.running \|\| addAccountProcess\.running\) return/.test(serviceSource), 'tailscale will not connect over a login that is adding')
+assert(/stopConnecting\(\)\s*\n\s*actionStatus = "Opening Tailscale login…"/.test(serviceSource), 'tailscale drops the pending sequence when an add supersedes it')
+assert(/if \(addAccountProcess\.running\) \{\s*\n\s*root\._loginInProgress = false/.test(serviceSource), 'tailscale stops waiting on a link an add has superseded')
 assert(/if \(Model\.isAccessDenied\(outcome\.error\)\) \{\s*\n\s*root\.reportCommandError/.test(serviceSource), 'tailscale offers the operator fix when the add is refused')
 assert(tailscale.isAccessDenied('profiles access denied'), 'tailscale spots the profiles refusal too')
 assert(!tailscale.isAccessDenied('tailscale up failed'), 'tailscale does not mistake an ordinary failure for a refusal')

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -329,6 +329,30 @@ assert(/loginTimeoutTimer\.attempts = 0/.test(serviceSource), 'tailscale starts 
 // than a failure and should not be reported as one.
 assert(/if \(exitCode === 126\) \{\s*\n\s*root\.lastError = ""\s*\n\s*root\.actionStatus = ""/.test(serviceSource), 'tailscale leaves nothing behind when the operator prompt is dismissed')
 assert(/\} else if \(exitCode !== 0\) \{\s*\n\s*root\.lastError = elideStatus\(stderr \|\| stdout \|\| "Tailscale authorization failed"\)/.test(serviceSource), 'tailscale still reports a real authorization failure')
+// Exactly what the panel showed on a machine whose client and daemon differ:
+// the warning arrives on stderr ahead of the real refusal.
+assertEqual(
+  tailscale.commandMessage('Warning: client version "1.102.3" != tailscaled server version "1.102.2"\nAccess denied: checkprefs access denied\nUse \'sudo tailscale up\'.'),
+  "Access denied: checkprefs access denied Use 'sudo tailscale up'.",
+  'tailscale drops the version skew warning from what it shows'
+)
+assertEqual(
+  tailscale.commandMessage('Warning: client version "1.2" != tailscaled server version "1.1"'),
+  '',
+  'tailscale is left with nothing when the warning was the whole of it'
+)
+assertEqual(tailscale.commandMessage('  boom  \n\n  bang \n'), 'boom bang', 'tailscale joins what is left onto one line')
+assertEqual(tailscale.commandMessage(''), '', 'tailscale handles empty command output')
+assertEqual(tailscale.commandMessage(null), '', 'tailscale handles missing command output')
+
+assert(tailscale.isAccessDenied('Access denied: checkprefs access denied'), 'tailscale spots a refusal for want of the operator')
+assert(tailscale.isAccessDenied('profiles access denied'), 'tailscale spots the profiles refusal too')
+assert(!tailscale.isAccessDenied('tailscale up failed'), 'tailscale does not mistake an ordinary failure for a refusal')
+
+// A refusal has a fix the panel can offer, so it raises that instead of
+// repeating the CLI's advice to go and use sudo.
+assert(/accountsAccessDenied = true\s*\n\s*message = "Tailscale needs permission on this machine"/.test(serviceSource), 'tailscale offers the operator fix when a command is refused')
+assert(/root\.reportCommandError\(combined, "tailscale up failed"\)/.test(serviceSource), 'tailscale reports a failed connect through the same path')
 
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -295,7 +295,7 @@ assert(/account\.selected !== true && String\(account\.id \|\| ""\) !== ""/.test
 // Two deliberate activations, so a stray click cannot drop a connection.
 assert(/if \(removeArmedId === String\(account\.id \|\| ""\)\) \{\s*\n\s*confirmRemoval\(account\)/.test(panelSource), 'tailscale takes a second activation to confirm a removal')
 assert(/armed \? "Remove " \+ label \+ "\?"/.test(panelSource) || /if \(armed\) return "Remove " \+ label \+ "\?"/.test(panelSource), 'tailscale asks before removing')
-assert(/onCloseRequested: \{\s*\n\s*if \(root\.removeArmedId !== ""\) root\.disarmRemoval\(\)/.test(panelSource), 'tailscale backs out of the question before closing the panel')
+assert(/onCloseRequested: \{\s*\n\s*if \(root\.removeArmedId !== "" \|\| root\.addArmed\) root\.disarmRemoval\(\)/.test(panelSource), 'tailscale backs out of the question before closing the panel')
 assert(/disarmRemoval\(\)\s*\n\s*ensureCursor\(\)/.test(panelSource), 'tailscale abandons the question when the cursor moves off the row')
 // The toggle's login hand-off keys off _loginInProgress, which a status poll
 // clears as soon as tailscaled is running — the state adding an account starts
@@ -395,6 +395,22 @@ assert(/interval: 10000/.test(serviceSource), 'tailscale waits long enough to be
 // The ordinary poll is half a minute away, so an empty list stayed empty for
 // the rest of the interval whatever the tailnet actually held.
 assert(/id: peersRamp/.test(serviceSource), 'tailscale asks again quickly while it has nothing to show')
+// The quick ramp is on top of the ordinary poll, not instead of it: without
+// the periodic timer the panel never refreshes once the list is populated, and
+// without the startup one it does not look until something opens the panel.
+assert(/id: refreshTimer\s*\n\s*interval: root\.refreshIntervalSec \* 1000\s*\n\s*repeat: true\s*\n\s*running: true\s*\n\s*triggeredOnStart: true/.test(serviceSource), 'tailscale keeps polling on its own interval')
+assert(/id: startupRamp/.test(serviceSource), 'tailscale still looks for the service at startup')
+
+// A step that failed ends the sequence, or the next poll picks it straight up.
+assert(/function reportCommandError\(text, fallback\) \{[\s\S]{0,260}?stopConnecting\(\)/.test(serviceSource), 'tailscale stops the sequence on a reported failure')
+// Removal was the one account command reporting for itself, so a refusal there
+// showed the CLI's sudo advice rather than the authorization the panel offers.
+assert(/root\.reportCommandError\(stderr \|\| stdout, "Could not remove the connection"\)/.test(serviceSource), 'tailscale reports a failed removal like every other refusal')
+// A login owns the daemon's pending registration until it finishes.
+assert(/if \(switchProcess\.running \|\| removeProcess\.running \|\| loginProcess\.running \|\| operatorProcess\.running\) return/.test(serviceSource), 'tailscale will not start a login beside another profile change')
+assert(/if \(!account\) return\s*\n(\s*\/\/[^\n]*\n)*\s*if \(tailscale\.addingAccount\) return/.test(panelSource), 'tailscale blocks every row while a login is running, not just the add row')
+// Either question left open would otherwise survive the panel closing.
+assert(/if \(root\.removeArmedId !== "" \|\| root\.addArmed\) root\.disarmRemoval\(\)/.test(panelSource), 'tailscale backs out of whichever confirmation is open')
 assert(/running: root\.running && root\.peers\.length === 0 && ticks < 8/.test(serviceSource), 'tailscale only hurries while the list is empty, and not forever')
 assert(/if \(peers\.length > 0\) peersRamp\.ticks = 0/.test(serviceSource), 'tailscale stops hurrying once the list arrives')
 

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -325,6 +325,10 @@ assert(/if \(attempts < 3\) \{/.test(serviceSource), 'tailscale waits more than 
 assert(/attempts \+= 1/.test(serviceSource), 'tailscale counts its attempts at the login link')
 assert(/root\.actionStatus = "Tailscale login link not available yet"\s*\n(\s*\/\/[^\n]*\n)*\s*actionStatusTimer\.restart\(\)/.test(serviceSource), 'tailscale clears the login link message instead of freezing on it')
 assert(/loginTimeoutTimer\.attempts = 0/.test(serviceSource), 'tailscale starts each login with a fresh attempt count')
+// pkexec exits 126 when the dialog is dismissed, which is a decision rather
+// than a failure and should not be reported as one.
+assert(/if \(exitCode === 126\) \{\s*\n\s*root\.lastError = ""\s*\n\s*root\.actionStatus = ""/.test(serviceSource), 'tailscale leaves nothing behind when the operator prompt is dismissed')
+assert(/\} else if \(exitCode !== 0\) \{\s*\n\s*root\.lastError = elideStatus\(stderr \|\| stdout \|\| "Tailscale authorization failed"\)/.test(serviceSource), 'tailscale still reports a real authorization failure')
 
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -220,6 +220,43 @@ assert(/root\.returnToPreviousAccount\(\)/.test(serviceSource), 'tailscale goes 
 // fails selectedAccountId still names the profile being returned to. Comparing
 // against it there skips the one switch that matters.
 assert(!/if \(previous === "" \|\| previous === selectedAccountId/.test(serviceSource), 'tailscale does not skip the return on a stale selected account')
+
+// The whole point of the recovery is what happens on each way this can end, so
+// the decision is a plain function rather than something only a real second
+// tailnet could exercise.
+assertDeepEqual(
+  tailscale.addAccountOutcome(0, true, 'db1b', ''),
+  { returnTo: '', status: '', error: '' },
+  'tailscale stays put when the login lands'
+)
+assertDeepEqual(
+  tailscale.addAccountOutcome(1, true, 'db1b', ''),
+  { returnTo: 'db1b', status: 'Login not completed — back on the previous connection', error: '' },
+  'tailscale returns to the previous connection when the login is abandoned'
+)
+assertDeepEqual(
+  tailscale.addAccountOutcome(1, false, 'db1b', 'access denied'),
+  { returnTo: 'db1b', status: 'access denied', error: 'access denied' },
+  'tailscale reports a login that failed before it reached the browser'
+)
+assertDeepEqual(
+  tailscale.addAccountOutcome(1, false, 'db1b', '   '),
+  { returnTo: 'db1b', status: 'tailscale login failed', error: 'tailscale login failed' },
+  'tailscale still says something when the login fails silently'
+)
+assertDeepEqual(
+  tailscale.addAccountOutcome(1, true, '', ''),
+  { returnTo: '', status: 'Login not completed — back on the previous connection', error: '' },
+  'tailscale has nowhere to return when there was no previous connection'
+)
+// A cancel kills the process, which exits non-zero like any other failure.
+assertDeepEqual(
+  tailscale.addAccountOutcome(143, true, 'db1b', ''),
+  { returnTo: 'db1b', status: 'Login not completed — back on the previous connection', error: '' },
+  'tailscale returns to the previous connection when the login is cancelled'
+)
+
+assert(/Back on your connection — sign in again to reconnect/.test(serviceSource), 'tailscale says the returned connection needs signing in again')
 assert(/function cancelAddAccount\(\) \{[\s\S]*?addAccountProcess\.running = false[\s\S]*?returnToPreviousAccount\(\)/.test(serviceSource), 'tailscale can bail out of a login in progress')
 assert(/if \(accountRow\.addingAccount\) tailscale\.cancelAddAccount\(\)/.test(panelSource), 'tailscale offers the bail-out on the row that is running')
 assert(/if \(!addArmed\) \{\s*\n\s*addArmed = true/.test(panelSource), 'tailscale asks before signing the machine out to add a tailnet')

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -381,6 +381,11 @@ assert(/if \(addAccountProcess\.running\) \{\s*\n\s*root\._loginInProgress = fal
 assert(/if \(backendState === "Running" && _previousBackendState !== "Running"\) \{\s*\n\s*_lastAccountsRefreshMs = 0/.test(serviceSource), 'tailscale re-reads the connections once the machine comes up')
 assert(/_previousBackendState = backendState/.test(serviceSource), 'tailscale only re-reads on the transition, not every poll')
 
+// The action button is taller than the row's text, so showing it on hover grew
+// the row and re-elided the label under the pointer.
+assert(/opacity: shown \? 1 : 0\s*\n\s*enabled: shown/.test(panelSource), 'tailscale keeps the row action in the layout so hovering cannot resize the row')
+assert(!/visible: accountRow\.addingAccount \|\| accountRow\.addArmed/.test(panelSource), 'tailscale no longer toggles the row action with visible')
+
 // The real shape of a second tailnet: Tailscale names the profile after the
 // login it was made from, and the tailnet carries the name set in the admin
 // console.

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -374,6 +374,26 @@ assert(/function continueConnecting\(\) \{[\s\S]{0,200}?if \(addAccountProcess\.
 assert(/if \(!installed \|\| loginProcess\.running \|\| addAccountProcess\.running\) return/.test(serviceSource), 'tailscale will not connect over a login that is adding')
 assert(/stopConnecting\(\)\s*\n\s*actionStatus = "Opening Tailscale login…"/.test(serviceSource), 'tailscale drops the pending sequence when an add supersedes it')
 assert(/if \(addAccountProcess\.running\) \{\s*\n\s*root\._loginInProgress = false/.test(serviceSource), 'tailscale stops waiting on a link an add has superseded')
+
+// A profile's tailnet name arrives with the netmap, so a connection list read
+// while the machine was still coming up names a new one by whatever it had
+// then, and the throttle keeps that for a minute.
+assert(/if \(backendState === "Running" && _previousBackendState !== "Running"\) \{\s*\n\s*_lastAccountsRefreshMs = 0/.test(serviceSource), 'tailscale re-reads the connections once the machine comes up')
+assert(/_previousBackendState = backendState/.test(serviceSource), 'tailscale only re-reads on the transition, not every poll')
+
+// The real shape of a second tailnet: Tailscale names the profile after the
+// login it was made from, and the tailnet carries the name set in the admin
+// console.
+assertEqual(
+  tailscale.accountLabel({ id: '1785', nickname: 'you@example.com', tailnet: 'example.com', account: 'you@example.com' }),
+  'example.com',
+  'tailscale names a second connection by its tailnet rather than the login it was made from'
+)
+assertEqual(
+  tailscale.accountLabel({ id: 'db1b', nickname: 'a@example.com', tailnet: 'a@example.com', account: 'a@example.com' }),
+  'a@example.com',
+  'tailscale falls back to the login when the tailnet has no name of its own'
+)
 assert(/if \(Model\.isAccessDenied\(outcome\.error\)\) \{\s*\n\s*root\.reportCommandError/.test(serviceSource), 'tailscale offers the operator fix when the add is refused')
 assert(tailscale.isAccessDenied('profiles access denied'), 'tailscale spots the profiles refusal too')
 assert(!tailscale.isAccessDenied('tailscale up failed'), 'tailscale does not mistake an ordinary failure for a refusal')

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -295,6 +295,14 @@ assertDeepEqual(
   'tailscale ignores stale authorization URLs outside the login state'
 )
 
+// The login hand-off keys off _loginInProgress, so standing down on the first
+// missed interval left the panel holding a URL it would never open, behind a
+// message that never cleared.
+assert(/if \(attempts < 3\) \{/.test(serviceSource), 'tailscale waits more than one interval for the login link')
+assert(/attempts \+= 1/.test(serviceSource), 'tailscale counts its attempts at the login link')
+assert(/root\.actionStatus = "Tailscale login link not available yet"\s*\n(\s*\/\/[^\n]*\n)*\s*actionStatusTimer\.restart\(\)/.test(serviceSource), 'tailscale clears the login link message instead of freezing on it')
+assert(/loginTimeoutTimer\.attempts = 0/.test(serviceSource), 'tailscale starts each login with a fresh attempt count')
+
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')
 JS


### PR DESCRIPTION
The Tailscale panel could only switch between tailnets you were already logged into, and nothing in it could ever create the second one — so on a machine with a single login the CONNECTIONS section never appeared at all. `Panel.qml` gated it on `accounts.length > 1`, and `loginOrUp()` only logs in when the backend is in `NeedsLogin`. Chicken and egg: the switcher shows up once you have something to switch to, and only the CLI could get you there.

This adds that, and removal to go with it. Six separate bugs turned up while using it, each fixed here as its own commit.

## The bugs

**The login link could strand you.** `loginTimeoutTimer` gives tailscaled one 10s interval to publish the auth URL. On a miss it clears `_loginInProgress` — the only flag that lets a later status poll open the URL — so the panel stood down holding a link it would never open. The message it left behind was the one `actionStatus` in the file that never calls `actionStatusTimer`, so it sat there for good and read as a frozen panel. Reproduced: toggle on, and if the daemon is slow the panel is stuck with no way forward but toggling again.

**A dismissed operator prompt was reported as failure.** `pkexec` exits 126 when the dialog is dismissed and 127 when authorization genuinely fails. Both were treated as failure, so declining the prompt reported "Tailscale authorization failed" for something you had just chosen to do.

**The version warning crowded out every error.** `tailscale` prints `Warning: client version "x" != tailscaled server version "y"` to stderr on *every* invocation when they differ, so `elideStatus(stderr || ...)` put it in front of each failure and the 140-character elide then cut off the part that mattered. On a machine refused for want of the operator the status line read as the warning followed by the CLI's advice to go and use sudo — advice you cannot act on from a panel. Refusals now raise the operator authorization the panel already has.

**Connections were labelled by login, never by tailnet.** `accountLabel()` checks `nickname` first, but Tailscale defaults a profile's name to the login it was created from (`lp.Name = up.LoginName`), so it is never empty and the `tailnet` branch below it — `NetworkProfile.DisplayNameOrDefault()`, the name set in the admin console — was unreachable. A tailnet named in the admin console showed as the address it was joined with, disagreeing with `tailscale switch --list` and with the macOS client.

**The connection list went stale after coming up.** A profile's tailnet name arrives with the netmap, but the list was re-read 600ms after login exited, while the machine was still coming up and the new profile had no name yet. The 60s throttle then kept that reading, so a tailnet just added sat unnamed until something else forced a re-read.

**The machines list claimed the tailnet was empty before it had answered.** The empty state was gated on `active`, which is optimistic and turns true the moment the toggle is clicked, and peers arrive with the netmap a couple of seconds after the machine reports Running. So connecting, and the window after a switch, both announced that the tailnet had no machines. Whether a tailnet is empty or has not answered yet is not something the panel can tell, so the claim is gone; what replaces it is a quick re-poll while the list is empty, which makes it arrive about as fast as the tailnet gives it.

## Adding and removing

The connection list carries an add row, the way the exit node list carries its Mullvad row. `tailscale login` makes the new profile current *before* the browser half finishes and its `--timeout` defaults to blocking forever, so an abandoned login leaves the machine signed out of the tailnet it was on — and the fresh profile carries no operator, which makes even `tailscale switch` back answer "access denied". So it asks before starting, creates the profile with the same operator the service install sets, offers a cancel while it runs, and returns to the previous connection whenever the login does not land. The row is withheld entirely when the panel already knows it lacks the operator, since `tailscale login --operator` is refused by the very check it would fix.

Removal is offered on connections that are not in use, behind an inline confirmation — the first activation turns the row into the question, the second answers it, escape or moving off abandons it. Removing is local only: the account is untouched and logging in again brings it back.

Getting connected can also take three things in order — authorize, sign in, come up — and each was its own action that reported and stopped, so the sequence fell to the person in front of it. The panel now runs whichever steps are outstanding. It only ever starts from someone asking to connect, never on its own, and stops on a failure, a dismissed prompt, a disconnect, or four steps.

## Testing

`test/shell.d/tailscale-test.sh` covers the added logic: the connection rows, the label precedence against both real profile shapes, every way the add login can end (landed, abandoned after the browser opened, failed before it, failed silently, cancelled, nothing to return to), the connect sequence's next-step table, and the message cleaning against the exact string a version-skewed machine produced. 121 assertions pass, alongside the existing receive tests. Both QML files lint clean.

Exercised on hardware across two real tailnets — adding, switching, removing, and the failure paths, including abandoning the browser login and dismissing the polkit prompt.

Happy to split this up if you would rather take it in pieces: the six bug fixes are independent of the feature and of each other.
