### PR TITLE
Offer US International in the keyboard picker

### DIFF
--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -33,6 +33,7 @@ OMARCHY_KEYBOARD_LAYOUTS=$'English (US)|us
 English (UK)|uk
 English (US, Dvorak)|dvorak
 English (US, Colemak)|colemak
+English (US, International)|us-acentos
 Azerbaijani|azerty
 Belarusian|by
 Belgian|be-latin1

--- a/install/user/xcompose.sh
+++ b/install/user/xcompose.sh
@@ -9,3 +9,20 @@ include "/usr/share/omarchy/default/xcompose"
 <Multi_key> <space> <n> : "$OMARCHY_USER_NAME"
 <Multi_key> <space> <e> : "$OMARCHY_USER_EMAIL"
 EOF
+
+# US International puts ç behind ' + c, but the compose table an English locale
+# loads reads dead_acute + c as ć, the Slavic letter. pt_BR.UTF-8's table
+# overrides exactly this pair for the same reason; do it here so the layout the
+# installer offers behaves like the one it is named after. Keyed off the variant
+# the keyboard step already persisted, so no other layout is touched.
+vconsole_config="${OMARCHY_VCONSOLE_CONFIG:-/etc/vconsole.conf}"
+
+if [[ -f $vconsole_config ]] &&
+  [[ $(unset XKBVARIANT; . "$vconsole_config"; echo "${XKBVARIANT:-}") == "intl" ]]; then
+  tee -a ~/.XCompose >/dev/null <<'CEDILLA'
+
+# Cedilla, not C with acute, on the US International layout
+<dead_acute> <c> : "ç" ccedilla
+<dead_acute> <C> : "Ç" Ccedilla
+CEDILLA
+fi

--- a/test/shell.d/xcompose-test.sh
+++ b/test/shell.d/xcompose-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+cedilla='<dead_acute> <c> : "ç" ccedilla'
+
+# $1 names the home to write into, $2 the vconsole.conf to read the keyboard
+# choice from; omitting it stands in for a machine without the file.
+run_xcompose() {
+  local home="$test_tmp/$1"
+
+  mkdir -p "$home"
+  HOME="$home" \
+    OMARCHY_USER_NAME="Ada Lovelace" \
+    OMARCHY_USER_EMAIL="ada@example.com" \
+    OMARCHY_VCONSOLE_CONFIG="${2:-$test_tmp/absent.conf}" \
+    bash "$ROOT/install/user/xcompose.sh"
+}
+
+printf 'KEYMAP=us-acentos\nXKBLAYOUT=us\nXKBVARIANT=intl\n' >"$test_tmp/intl.conf"
+printf 'KEYMAP=de\nXKBLAYOUT=de\n' >"$test_tmp/de.conf"
+
+run_xcompose intl "$test_tmp/intl.conf"
+grep -Fx "$cedilla" "$test_tmp/intl/.XCompose" >/dev/null ||
+  fail "US International seeds the cedilla override"
+grep -F 'Ada Lovelace' "$test_tmp/intl/.XCompose" >/dev/null ||
+  fail "seeding the cedilla override keeps the identification sequences"
+
+# The file is rewritten from scratch on every run, so a re-provision must not
+# leave the overrides in twice.
+run_xcompose intl "$test_tmp/intl.conf"
+(($(grep -Fxc "$cedilla" "$test_tmp/intl/.XCompose") == 1)) ||
+  fail "re-running the setup does not duplicate the cedilla override"
+
+run_xcompose de "$test_tmp/de.conf"
+grep -F ccedilla "$test_tmp/de/.XCompose" >/dev/null &&
+  fail "a layout other than US International is left alone"
+
+run_xcompose absent
+grep -F ccedilla "$test_tmp/absent/.XCompose" >/dev/null &&
+  fail "a machine without a vconsole.conf is left alone"
+
+pass "xcompose setup adds the cedilla override for US International only"


### PR DESCRIPTION
The keyboard picker has no entry with dead keys, so anyone arriving from Windows' US-International — the default for most of Latin America and a common choice across Europe — installs on plain `us` and then discovers there is no way to type an accent. The fix is to hand-write `kb_variant = "intl"` into `~/.config/hypr/input.lua`, which you only find by reading the commented-out block in that file or by asking in Discord.

## Change

`English (US, International)|us-acentos`, one line in the picker, next to the other English variants.

`us-acentos` is the console keymap for it — the name is Portuguese because Arnaldo Carvalho de Melo wrote the map at Conectiva, and it stuck. Nothing else is needed to make it reach the session: systemd's `kbd-model-map` already carries the XKB translation, so `systemd-firstboot --keymap=us-acentos` writes the variant out on its own.

```
$ systemd-firstboot --root=/tmp/probe --keymap=us-acentos --force
$ cat /tmp/probe/etc/vconsole.conf
KEYMAP=us-acentos
XKBLAYOUT=us
XKBVARIANT=intl
```

`default/hypr/input.lua` reads `XKBVARIANT` from there, so the session comes up on `us(intl)` with no further plumbing.

## Cedilla

The second commit exists because the layout is otherwise wrong for the people most likely to pick it. `' + c` is ç on the layout Windows named, and the console map has it, but in the session the compose table comes from the locale rather than the layout — and `en_US.UTF-8/Compose` reads `<dead_acute> <c>` as ć, the Slavic letter. Someone installing in English gets ć and no ç, which is what #2979 ran into.

`pt_BR.UTF-8/Compose` overrides that exact pair for the same reason, and has since kov wrote it for Debian. This does the same thing, seeded into the user's own `~/.XCompose` — the file the manual already treats as yours to edit — rather than `default/xcompose`, and only when the keyboard step persisted the `intl` variant. Nothing in the picker but `us-acentos` produces that variant, so a locale that wants ć keeps it, and no existing install changes on update.

## Test

`test/shell.d/xcompose-test.sh` covers four states: `XKBVARIANT=intl` seeds the two rules and keeps the identification sequences, a re-provision doesn't duplicate them, a non-intl variant is left alone, and a machine with no `vconsole.conf` is left alone. Reading the path through `OMARCHY_VCONSOLE_CONFIG` follows `install/user/hardware/fix-nouveau-cursor.sh`, which does the same for `/etc/modprobe.d/nvidia.conf`.
