### PR TITLE
Constrain the tzupdate sudoers rule to a single timezone argument

### DIFF
--- a/etc/sudoers.d/omarchy-tzupdate
+++ b/etc/sudoers.d/omarchy-tzupdate
@@ -1,1 +1,1 @@
-%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl set-timezone *
+%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl ^set-timezone [A-Za-z0-9_+][A-Za-z0-9_+.-]*(/[A-Za-z0-9_+][A-Za-z0-9_+.-]*)*$

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -7,8 +7,11 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 timezone_menu="$ROOT/bin/omarchy-menu-timezone"
 sudoers_file="$ROOT/etc/sudoers.d/omarchy-tzupdate"
 
-grep -F '%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl set-timezone *' "$sudoers_file" >/dev/null ||
+grep -F '%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl ^set-timezone [A-Za-z0-9_+][A-Za-z0-9_+.-]*(/[A-Za-z0-9_+][A-Za-z0-9_+.-]*)*$' "$sudoers_file" >/dev/null ||
   fail "timezone sudoers rule allows passwordless timedatectl timezone changes"
+
+! grep -F 'set-timezone *' "$sudoers_file" >/dev/null ||
+  fail "timezone sudoers rule uses a bare wildcard that admits extra arguments like -H and -M"
 
 ! grep -F 'tzupdate' "$sudoers_file" >/dev/null ||
   fail "timezone sudoers rule does not grant passwordless tzupdate"


### PR DESCRIPTION
## What was wrong

`etc/sudoers.d/omarchy-tzupdate` granted `%wheel` passwordless root for `timedatectl set-timezone` with a trailing `*`:

```
%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl set-timezone *
```

sudo matches command arguments as one space-joined string, and `*` crosses argument boundaries, so the rule admits far more than a timezone. Its only caller, `bin/omarchy-menu-timezone`, runs exactly `sudo timedatectl set-timezone "$timezone"` with a single value chosen from `timedatectl list-timezones` — so everything the wildcard adds beyond that one token is unintended authority.

`timedatectl` parses its global options (`-H`/`--host`, `-M`/`--machine`) wherever they appear, including after the zone, so the rule lets any wheel user run, passwordless as root:

```
timedatectl set-timezone UTC --host=SOMEHOST      # root drives an SSH transport to SOMEHOST
timedatectl set-timezone UTC --machine=NAME       # root acts against a container/machine
timedatectl set-timezone UTC anything at all      # arbitrary trailing arguments
```

The direct argv-injection paths are guarded in systemd 261 — the SSH bus address places the host after a literal `--` and validates it — so `-H` cannot smuggle an `ssh` option or shell syntax. But `-H` still makes **root** open an outbound SSH connection to an attacker-chosen host, using root's SSH configuration and keys, which the timezone menu never needed to grant. And the transport resolves its helper with `execvp("ssh", …)`, which searches `PATH`: a stock Arch/Omarchy install closes that with `Defaults secure_path`, but the passwordless-root grant then depends entirely on `secure_path` being present and pointing only at root-owned directories. If `secure_path` is ever removed or widened to include a user-writable directory, the same rule becomes unconditional local root via a planted `ssh` — a wildcard passwordless grant should not lean on a separate `Defaults` line for its safety. The sibling `etc/sudoers.d/omarchy-dns` already enumerates its exact arguments rather than trusting a wildcard, for the same reason.

## The change

Constrain the argument with sudo's POSIX ERE command-argument matching (sudo 1.9.10+; Omarchy ships 1.9.17p2) to a single timezone token, anchored `^…$`:

```
%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl ^set-timezone [A-Za-z0-9_+][A-Za-z0-9_+.-]*(/[A-Za-z0-9_+][A-Za-z0-9_+.-]*)*$
```

The character class contains no whitespace, so the pattern cannot match any argv with a second argument — `-H`, `-M`, `--adjust-system-clock`, and any extra operand now require a password. Each `/`-separated segment must start with an alphanumeric, `_`, or `+`, so a leading-dash value such as `-Hlocalhost` (which `timedatectl` would read as `--host`) and a traversal component such as `../UTC` are rejected too. Once `-H`/`-M` can no longer match, the SSH transport is never reached, so no `PATH`/`SYSTEMD_SSH` vector remains regardless of `secure_path`.

This was verified in an `archlinux:latest` container (sudo 1.9.17p2): all 598 names from `timedatectl list-timezones` — including `UTC`, `America/Argentina/Buenos_Aires`, and `Etc/GMT+12` — still resolve passwordless, while `-H localhost`, `-Hlocalhost`, `-Mctr`, `--adjust-system-clock`, a trailing extra operand, and `../etc`-style values all fall through to a password prompt. `visudo` parses the line.

`test/shell.d/timezone-test.sh` is updated to assert the constrained rule and adds a guard that fails if the bare `set-timezone *` wildcard ever returns.

## Not changed

The drop-in keeps the `omarchy-tzupdate` filename even though `tzupdate` itself was dropped in #6694; renaming it would ripple through the package manifest and `omarchy-upgrade-to-quattro`, and is unrelated to this fix.

🤖 Generated by Opus 4.8 in Claude Code. Reviewed by Codex XHigh.
