### PR TITLE
Read actual gmux display brightness

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -26,7 +26,19 @@ done
 
 # Get the brightness of the passed display
 backlight_brightness() {
-  brightnessctl -d "$1" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'
+  local device="$1"
+  local backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
+
+  # apple-gmux can retain a stale requested value after switching GPUs while
+  # the hardware keeps a different level. Its actual_brightness register uses
+  # the same scale as max_brightness, so report the level the panel is using.
+  if [[ $device == "gmux_backlight" && -r $backlight_path/$device/actual_brightness && -r $backlight_path/$device/max_brightness ]]; then
+    awk 'NR == FNR { actual = $1; next } $1 > 0 { print int(actual * 100 / $1 + 0.5); found = 1 } END { exit !found }' \
+      "$backlight_path/$device/actual_brightness" "$backlight_path/$device/max_brightness"
+    return
+  fi
+
+  brightnessctl -d "$device" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'
 }
 
 [[ -n $monitor ]] || monitor="$(omarchy-hyprland-monitor-focused 2>/dev/null || true)"

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -10,7 +10,8 @@ trap 'rm -rf "$test_tmp"' EXIT
 mock_bin="$test_tmp/bin"
 call_log="$test_tmp/calls"
 runtime_dir="$test_tmp/runtime"
-mkdir -p "$mock_bin" "$runtime_dir"
+backlight_dir="$test_tmp/backlight"
+mkdir -p "$mock_bin" "$runtime_dir" "$backlight_dir"
 
 cat >"$mock_bin/omarchy-hyprland-monitor-focused-apple" <<'SH'
 #!/bin/bash
@@ -24,7 +25,7 @@ SH
 
 cat >"$mock_bin/omarchy-hw-display" <<'SH'
 #!/bin/bash
-printf 'mock_backlight\n'
+printf '%s\n' "${BACKLIGHT_DEVICE:-mock_backlight}"
 SH
 
 cat >"$mock_bin/brightnessctl" <<'SH'
@@ -54,7 +55,7 @@ SH
 chmod +x "$mock_bin"/*
 
 run_brightness() {
-  CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" PATH="$mock_bin:$ROOT/bin:$PATH" \
+  CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" OMARCHY_BACKLIGHT_PATH="$backlight_dir" PATH="$mock_bin:$ROOT/bin:$PATH" \
     "$ROOT/bin/omarchy-brightness-display" "$@"
 }
 
@@ -85,6 +86,20 @@ brightness=$(run_brightness --monitor eDP-1)
 grep -F 'brightnessctl -d mock_backlight -m' "$call_log" >/dev/null || \
   fail "internal monitor queries brightnessctl"
 pass "internal monitor uses the kernel backlight"
+
+mkdir -p "$backlight_dir/gmux_backlight"
+printf '1794\n' >"$backlight_dir/gmux_backlight/brightness"
+printf '52428\n' >"$backlight_dir/gmux_backlight/actual_brightness"
+printf '65535\n' >"$backlight_dir/gmux_backlight/max_brightness"
+
+brightness=$(BACKLIGHT_DEVICE=gmux_backlight run_brightness --monitor eDP-1)
+[[ $brightness == "80" ]] || fail "gmux reports the hardware brightness instead of a stale requested value" "actual: $brightness"
+pass "gmux reports the hardware brightness instead of a stale requested value"
+
+BACKLIGHT_DEVICE=gmux_backlight run_brightness --no-osd --monitor eDP-1 +5%
+grep -F 'brightnessctl -d gmux_backlight set 85%' "$call_log" >/dev/null || \
+  fail "gmux brightness steps start from the hardware brightness"
+pass "gmux brightness steps start from the hardware brightness"
 
 brightness=$(FOCUSED_MONITOR=DP-1 run_brightness)
 [[ $brightness == "50" ]] || fail "brightness follows the focused external monitor" "actual: $brightness"


### PR DESCRIPTION
## Summary

- read `actual_brightness` for `gmux_backlight`, whose requested brightness can remain stale after GPU switching
- use the hardware value as the starting point for brightness steps
- preserve the existing `brightnessctl` path for every other backlight driver
- add regression coverage for a stale 3% requested value with 80% hardware brightness

## Hardware verification

Verified on a 2019 Intel/T2 MacBook Pro with `apple-gmux`:

```
brightness=1794
actual_brightness=52428
max_brightness=65535
```

The installed command reported 3%; this branch reports the hardware level of 80%.

## Tests

- `bash test/shell.d/brightness-display-test.sh`
- `./test/cli`
- `git diff --check`

A full `./test/shell` run reached the unrelated checkout invariant requiring a local `omarchy-pkgs` checkout; the focused brightness suite passes.