### PR TITLE
Let themes set Hyprland rounding and shadow through colors.toml

### DIFF
--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -251,7 +251,7 @@ add_mix_values() {
   done
 }
 
-add_gradient_function_value() {
+add_template_function_value() {
   local token="$1"
   local content fn key fallback value
 
@@ -269,6 +269,9 @@ add_gradient_function_value() {
     shell_gradient)
       value=$(shell_gradient_value "$key" "$fallback")
       ;;
+    value)
+      value=$(resolve_theme_ref "$key" "$fallback")
+      ;;
     *)
       return
       ;;
@@ -277,7 +280,7 @@ add_gradient_function_value() {
   printf 's|%s|%s|g\n' "$token" "$value" >>"$sed_script"
 }
 
-add_gradient_function_values() {
+add_template_function_values() {
   local tpl token
   local -A seen=()
 
@@ -285,8 +288,8 @@ add_gradient_function_values() {
     while IFS= read -r token; do
       [[ -n ${seen[$token]:-} ]] && continue
       seen[$token]=1
-      add_gradient_function_value "$token"
-    done < <(grep -hEo '\{\{[[:space:]]*(hypr_gradient|gradient_start|shell_gradient)[[:space:]]+[^}]+[[:space:]]*\}\}' "$tpl" 2>/dev/null || true)
+      add_template_function_value "$token"
+    done < <(grep -hEo '\{\{[[:space:]]*(hypr_gradient|gradient_start|shell_gradient|value)[[:space:]]+[^}]+[[:space:]]*\}\}' "$tpl" 2>/dev/null || true)
   done
 }
 
@@ -385,7 +388,7 @@ if [[ -f $COLORS_FILE ]]; then
   done
 
   add_mix_values
-  add_gradient_function_values
+  add_template_function_values
 
   # Process user templates first, then built-in templates (user overrides built-in)
   for tpl in "${template_files[@]}"; do

--- a/default/themed/hyprland.lua.tpl
+++ b/default/themed/hyprland.lua.tpl
@@ -15,4 +15,18 @@ hl.config({
       border_inactive = inactive_border_color,
     },
   },
+
+  decoration = {
+    rounding = {{ value hyprland_rounding 0 }},
+    rounding_power = {{ value hyprland_rounding_power 2 }},
+
+    shadow = {
+      enabled = {{ value hyprland_shadow_enabled false }},
+      range = {{ value hyprland_shadow_range 4 }},
+      render_power = {{ value hyprland_shadow_render_power 3 }},
+      offset = "{{ value hyprland_shadow_offset 0 0 }}",
+      color = "{{ value hyprland_shadow_color rgba(1a1a1aee) }}",
+      color_inactive = "{{ value hyprland_shadow_color_inactive rgba(1a1a1aee) }}",
+    },
+  },
 })

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -177,17 +177,13 @@ The helper does not choose the first color unless you use `gradient_start`.
 
 ### Value helper
 
-`{{ value key fallback }}` resolves a plain (non-color) `colors.toml` key with
-a fallback, the same way the gradient helpers do:
+`{{ value key fallback }}` resolves a plain (non-color) `colors.toml` key with a fallback, the same way the gradient helpers do:
 
 ```text
 {{ value hyprland_rounding 0 }}
 ```
 
-If the theme defines `hyprland_rounding`, that value is used; otherwise the
-fallback is tried as another palette key first, then used literally (`0`
-here). This is how optional numeric/boolean settings, like the Hyprland
-decoration keys below, stay valid Lua even when a theme never mentions them.
+If the theme defines `hyprland_rounding`, that value is used; otherwise the fallback is tried as another palette key first, then used literally (`0` here). This is how optional numeric/boolean settings, like the Hyprland decoration keys below, stay valid Lua even when a theme never mentions them.
 
 ## `shell.toml`
 
@@ -385,9 +381,7 @@ For a gradient it renders:
 local active_border_color = { colors = { "rgba(33ccffee)", "rgba(00ff99ee)" }, angle = 45 }
 ```
 
-`hyprland.lua.tpl` also renders a `decoration` block from optional `colors.toml`
-keys, using the `value` helper so a theme that never sets them still gets valid
-Lua matching Omarchy's own defaults:
+`hyprland.lua.tpl` also renders a `decoration` block from optional `colors.toml` keys, using the `value` helper so a theme that never sets them still gets valid Lua matching Omarchy's own defaults:
 
 | `colors.toml` key | Default | `decoration` field |
 |---|---|---|
@@ -400,10 +394,7 @@ Lua matching Omarchy's own defaults:
 | `hyprland_shadow_color` | `rgba(1a1a1aee)` | `shadow.color` |
 | `hyprland_shadow_color_inactive` | `rgba(1a1a1aee)` | `shadow.color_inactive` |
 
-This is what lets a theme installed from a git repo (see
-[What an installed theme may not ship](#what-an-installed-theme-may-not-ship))
-still ship rounded corners and a window shadow, without shipping a
-hand-written `hyprland.lua` that the staging filter would drop.
+This is what lets a theme installed from a git repo (see [What an installed theme may not ship](#what-an-installed-theme-may-not-ship)) still ship rounded corners and a window shadow, without shipping a hand-written `hyprland.lua` that the staging filter would drop.
 
 ## Adding or overriding theme files
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -175,6 +175,20 @@ The second argument is a fallback. For example,
 `hyprland_active_border` if the theme defines it; otherwise use `accent`.
 The helper does not choose the first color unless you use `gradient_start`.
 
+### Value helper
+
+`{{ value key fallback }}` resolves a plain (non-color) `colors.toml` key with
+a fallback, the same way the gradient helpers do:
+
+```text
+{{ value hyprland_rounding 0 }}
+```
+
+If the theme defines `hyprland_rounding`, that value is used; otherwise the
+fallback is tried as another palette key first, then used literally (`0`
+here). This is how optional numeric/boolean settings, like the Hyprland
+decoration keys below, stay valid Lua even when a theme never mentions them.
+
 ## `shell.toml`
 
 `shell.toml` contains shell surface roles, control states, spacing, typography,
@@ -370,6 +384,26 @@ For a gradient it renders:
 ```lua
 local active_border_color = { colors = { "rgba(33ccffee)", "rgba(00ff99ee)" }, angle = 45 }
 ```
+
+`hyprland.lua.tpl` also renders a `decoration` block from optional `colors.toml`
+keys, using the `value` helper so a theme that never sets them still gets valid
+Lua matching Omarchy's own defaults:
+
+| `colors.toml` key | Default | `decoration` field |
+|---|---|---|
+| `hyprland_rounding` | `0` | `rounding` |
+| `hyprland_rounding_power` | `2` | `rounding_power` |
+| `hyprland_shadow_enabled` | `false` | `shadow.enabled` |
+| `hyprland_shadow_range` | `4` | `shadow.range` |
+| `hyprland_shadow_render_power` | `3` | `shadow.render_power` |
+| `hyprland_shadow_offset` | `0 0` | `shadow.offset` |
+| `hyprland_shadow_color` | `rgba(1a1a1aee)` | `shadow.color` |
+| `hyprland_shadow_color_inactive` | `rgba(1a1a1aee)` | `shadow.color_inactive` |
+
+This is what lets a theme installed from a git repo (see
+[What an installed theme may not ship](#what-an-installed-theme-may-not-ship))
+still ship rounded corners and a window shadow, without shipping a
+hand-written `hyprland.lua` that the staging filter would drop.
 
 ## Adding or overriding theme files
 

--- a/test/cli
+++ b/test/cli
@@ -257,6 +257,14 @@ cat >"$NEXT_THEME/colors.toml" <<'EOF'
 mode = "light"
 accent = "#336699"
 hyprland_active_border = "rgba(010203ee) rgba(040506ee) 45deg"
+hyprland_rounding = "6"
+hyprland_rounding_power = "3"
+hyprland_shadow_enabled = "true"
+hyprland_shadow_range = "22"
+hyprland_shadow_render_power = "3"
+hyprland_shadow_offset = "0 6"
+hyprland_shadow_color = "rgba(00000099)"
+hyprland_shadow_color_inactive = "rgba(00000055)"
 background = "#000000"
 dark_background = "#010101"
 darker_background = "#020202"
@@ -304,6 +312,9 @@ shell-gradient={{ shell_gradient hyprland_active_border accent }}
 fallback-hypr={{ hypr_gradient missing accent }}
 fallback-shell={{ gradient_start missing accent }}
 fallback-shell-gradient={{ shell_gradient missing accent }}
+value={{ value hyprland_rounding 0 }}
+fallback-value={{ value missing 0 }}
+fallback-value-key={{ value missing accent }}
 EOF
 
 cat >"$USER_THEMED/alias-test.txt.tpl" <<'EOF'
@@ -454,6 +465,23 @@ grep -qx 'fallback-hypr="#336699"' "$NEXT_THEME/gradient-test.txt" || fail "them
 grep -qx 'fallback-shell=#336699' "$NEXT_THEME/gradient-test.txt" || fail "theme template gradient_start fallback works"
 grep -qx 'fallback-shell-gradient=#336699' "$NEXT_THEME/gradient-test.txt" || fail "theme template shell_gradient fallback works"
 pass "theme template gradient helpers work"
+
+grep -qx 'value=6' "$NEXT_THEME/gradient-test.txt" || fail "theme template value helper works"
+grep -qx 'fallback-value=0' "$NEXT_THEME/gradient-test.txt" || fail "theme template value helper literal fallback works"
+grep -qx 'fallback-value-key=#336699' "$NEXT_THEME/gradient-test.txt" || fail "theme template value helper key fallback works"
+pass "theme template value helper works"
+
+grep -Fq 'rounding = 6,' "$NEXT_THEME/hyprland.lua" || fail "theme template renders custom hyprland rounding"
+grep -Fq 'rounding_power = 3,' "$NEXT_THEME/hyprland.lua" || fail "theme template renders custom hyprland rounding power"
+grep -Fq 'enabled = true,' "$NEXT_THEME/hyprland.lua" || fail "theme template renders custom hyprland shadow enabled"
+grep -Fq 'range = 22,' "$NEXT_THEME/hyprland.lua" || fail "theme template renders custom hyprland shadow range"
+grep -Fq 'offset = "0 6",' "$NEXT_THEME/hyprland.lua" || fail "theme template renders custom hyprland shadow offset"
+grep -Fq 'color = "rgba(00000099)",' "$NEXT_THEME/hyprland.lua" || fail "theme template renders custom hyprland shadow color"
+pass "theme template renders custom hyprland decoration settings"
+
+grep -Fq 'rounding = 0,' "$LEGACY_NEXT_THEME/hyprland.lua" || fail "theme without decoration keys falls back to default rounding"
+grep -Fq 'enabled = false,' "$LEGACY_NEXT_THEME/hyprland.lua" || fail "theme without decoration keys falls back to shadow disabled"
+pass "theme without decoration keys falls back to Omarchy's default look'n'feel"
 
 awk '
   /^\[lock\]$/ { in_lock = 1; next }


### PR DESCRIPTION
Related to #7942, same root cause really. Since #7884 dropped every `.lua` from git-installed themes, there's no way left for a theme like that to set `decoration.rounding` or `shadow`, only border colors through `colors.toml`. A theme just silently loses its window rounding and shadow after install, no warning, nothing.

This adds a handful of optional `colors.toml` keys (`hyprland_rounding`, `hyprland_rounding_power`, `hyprland_shadow_enabled`, `hyprland_shadow_range`, `hyprland_shadow_render_power`, `hyprland_shadow_offset`, `hyprland_shadow_color`, `hyprland_shadow_color_inactive`) rendered into `hyprland.lua.tpl` through a new `value` helper, same pattern as the existing `hypr_gradient`/`shell_gradient` ones, just without the gradient parsing. A theme that doesn't set them falls back to the exact defaults Omarchy already ships, so nothing changes for any existing theme.

Added tests for the new helper and both the with/without-keys render paths.