### PR TITLE
Paint the pressed state on panel action buttons

### DIFF
--- a/shell/Ui/PanelActionButton.qml
+++ b/shell/Ui/PanelActionButton.qml
@@ -53,17 +53,20 @@ BorderSurface {
 
   readonly property bool _showFocusRing: focusable && activeFocus
   readonly property bool _hot: (mouse.containsMouse || root.hasCursor) && root.enabled
+  readonly property bool _pressed: mouse.pressed && root.enabled
   readonly property var _borderSpec: _showFocusRing
     ? Border.controlSpec("focus", hoverColor, hoverColor)
     : (_hot && bordered
       ? Border.controlSpec("hover-cursor", hoverColor, hoverColor)
       : (bordered ? Border.controlSpec("normal", foreground, Color.accent) : Border.none()))
 
-  color: _showFocusRing
-    ? Style.focusFillFor(hoverColor, hoverColor)
-    : (_hot
-      ? Style.hoverFillFor(hoverColor, hoverColor)
-      : "transparent")
+  color: _pressed
+    ? Style.pressedFillFor(hoverColor, hoverColor)
+    : (_showFocusRing
+      ? Style.focusFillFor(hoverColor, hoverColor)
+      : (_hot
+        ? Style.hoverFillFor(hoverColor, hoverColor)
+        : "transparent"))
   borderSpec: _borderSpec
 
   Behavior on color { ColorAnimation { duration: 60 } }


### PR DESCRIPTION
`PanelActionButton` never paints a pressed state. Holding the mouse down on one
changes nothing — it keeps the hover fill it already had — so twelve first-party
controls across six panels do not respond to a press, while the `Button` sitting
beside them does.

The token is already there. `pressed-fill-alpha` is `0.22` against `0.08` for
hover and focus: the same colour at 2.75× the fill. `Style.pressedFillFor` has
existed since the tokens were standardized, and `Button.qml` uses it.

The pass that standardized the tokens, 8b2bb217, gave `Button` all three states
in one hunk:

```qml
color: mouseArea.pressed ? Style.pressedFillFor(root.foreground, root.accent)
  : _showFocusRing       ? Style.focusFillFor(root.foreground, root.accent)
  : hot                  ? Style.hoverFillFor(root.foreground, root.accent)
```

and gave `PanelActionButton` two of them, focus and hover. This adds the third,
in the same order of precedence. If leaving it out was deliberate and these
controls are meant to stay quiet under a press, say so and I'll close this.

It matches `Button` rather than improving on it, so the two agree. One
consequence, noted rather than changed: press and drag off and the fill stays,
on both controls, because `MouseArea.pressed` holds while the grab does.
Dropping it when the pointer leaves would be a change to `Button` and belongs in
its own patch.

## Where it shows

Twelve `PanelActionButton` instances across `bluetooth`, `clock`, `dropbox`,
`network`, and `tailscale`, plus the dev gallery. The gallery shows it most
plainly: five of each button type on one surface, and only one type responds to
a press.

## Testing

- `qmllint` reports one more `unqualified` warning than before, for the added
  `Style.pressedFillFor` reference. That is the same warning the file already
  carries thirteen times and `Button.qml` fifty-three, so it is the existing
  pattern rather than a new one, but it is a count that changes.
- Instantiated offscreen against the current theme. The three fills it can now
  reach are `transparent` → `#cacccc a=0.080` (hover and focus) → `#cacccc
  a=0.220` (pressed), so the new state is reachable and visibly different from
  the other two.
- Clicked by hand in a scratch Quickshell instance holding the patched control,
  the current one, and a `Button`, side by side at the same size. All three tint
  identically on hover; holding the pointer down darkens the patched control and
  the `Button` and leaves the current one unchanged; releasing returns both to
  the hover tint. Dragging off while held keeps the fill on both, as above.
