### PR TITLE
Reference count the Wi-Fi scanner so a closed panel cannot scan

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -131,10 +131,18 @@ Panel {
   // radio to switch. On a wired box it would otherwise sit there reading
   // "off" beside a perfectly live Ethernet connection.
   readonly property bool canToggleWifi: networkManagerAvailable && wifiStationAvailable
-  readonly property int qrHeaderIndex: canShareWifi ? 0 : -1
-  readonly property int speedHeaderIndex: canRunSpeedTest ? (canShareWifi ? 1 : 0) : -1
-  readonly property int toggleHeaderIndex: canToggleWifi ? (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) : -1
-  readonly property int headerActionCount: (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0)
+  // Rescanning has to be reachable without a keyboard, and `r` has to be
+  // discoverable at all: a scan the panel no longer starts on its own is only
+  // useful if there is something to press. The action exists whenever there is
+  // a radio to scan with, independently of the scan settings, so the mouse
+  // path does not disappear on the default configuration.
+  readonly property bool canRescanWifi: networkManagerAvailable && wifiStationAvailable
+  readonly property int rescanHeaderIndex: canRescanWifi ? 0 : -1
+  readonly property int qrHeaderIndex: canShareWifi ? (canRescanWifi ? 1 : 0) : -1
+  readonly property int speedHeaderIndex: canRunSpeedTest ? (canRescanWifi ? 1 : 0) + (canShareWifi ? 1 : 0) : -1
+  readonly property int toggleHeaderIndex: canToggleWifi ? (canRescanWifi ? 1 : 0) + (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) : -1
+  readonly property int headerActionCount: (canRescanWifi ? 1 : 0) + (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0)
+  readonly property bool rescanHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === rescanHeaderIndex
   readonly property bool qrHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === qrHeaderIndex
   readonly property bool speedHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === speedHeaderIndex
   readonly property bool toggleHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === toggleHeaderIndex
@@ -224,7 +232,8 @@ Panel {
   }
 
   function activateHeader() {
-    if (headerIndex === qrHeaderIndex) summonWifiQr()
+    if (headerIndex === rescanHeaderIndex) refresh(true)
+    else if (headerIndex === qrHeaderIndex) summonWifiQr()
     else if (headerIndex === speedHeaderIndex) summonSpeedTest()
     else if (headerIndex === toggleHeaderIndex) toggleNetwork()
   }
@@ -1181,6 +1190,22 @@ Panel {
           anchors.verticalCenter: parent.verticalCenter
 
           Button {
+            id: rescanAction
+            visible: root.canRescanWifi
+            iconText: "󰑐"
+            tooltipText: root.scanning ? "Scanning…" : "Rescan Wi-Fi (r)"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            iconSize: Style.font.subtitle * 1.5
+            horizontalPadding: Style.space(5)
+            verticalPadding: Style.space(2)
+            hasCursor: root.rescanHeaderHasCursor
+            Layout.alignment: Qt.AlignVCenter
+            onHovered: function(on) { if (on) root.setHeaderCursor(root.rescanHeaderIndex) }
+            onClicked: root.refresh(true)
+          }
+
+          Button {
             id: qrAction
             visible: root.canShareWifi
             iconText: "󰐲"
@@ -1545,7 +1570,7 @@ Panel {
       // say so rather than letting stale results read as live ones.
       PanelSectionHeader {
         visible: root.wifiStationAvailable && root.scanPulsed && !root.scanning && !root.scanPulseActive
-        text: "NEARBY WI-FI (CACHED) · PRESS R TO RESCAN"
+        text: "NEARBY WI-FI (CACHED) · PRESS R OR 󰑐 TO RESCAN"
         foreground: root.bar.foreground
         fontFamily: root.bar.fontFamily
       }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -299,8 +299,63 @@ Panel {
   // Scanner.js rather than tracked per instance. This instance holds a claim
   // exactly while its own panel is open; the scanner stops when the last
   // instance lets go, and keeps running for the panels that still want it.
+  // How much airtime an open panel may spend. A full sweep parks the radio off
+  // its operating channel for as long as it runs — seconds on an older card —
+  // and quickshell re-arms the scanner every 10001ms, so a claim held for as
+  // long as the panel is open can leave the radio off-channel almost
+  // continuously. On a fast card that is invisible. On a slow one it stalls
+  // every connection in flight for as long as the panel is up.
+  //
+  // Both settings default to what the panel has always done:
+  //   scanOnOpen  true — opening the panel starts a sweep
+  //   scanHoldSec 0    — the scanner stays claimed while the panel is open
+  // A scanHoldSec above zero turns the claim into a pulse: it is dropped that
+  // many seconds after a sweep starts even though the panel is still open, and
+  // the next sweep waits for the user to ask with `r`.
+  readonly property bool scanOnOpen: settings.scanOnOpen === undefined ? true : !!settings.scanOnOpen
+  readonly property int scanHoldSec: {
+    var value = parseInt(settings.scanHoldSec)
+    return isNaN(value) || value < 0 ? 0 : value
+  }
+  readonly property bool scanPulsed: scanHoldSec > 0
+  property bool scanPulseActive: false
+
+  // With no hold configured this is the original rule verbatim — panel open,
+  // claim held. With one, the pulse owns the claim and an open panel alone is
+  // no longer enough to keep it.
   function setScannerEnabled(enabled) {
-    Scanner.acquire(root, opened && enabled ? wifiDevice : null)
+    var wanted = opened && enabled && (!scanPulsed || scanPulseActive)
+    Scanner.acquire(root, wanted ? wifiDevice : null)
+  }
+
+  // One sweep, then let go. Restarting a running pulse extends it rather than
+  // stacking claims — Scanner.acquire is keyed by owner.
+  function startScanPulse() {
+    if (!opened || !wifiDevice) return
+    if (!scanPulsed) {
+      setScannerEnabled(true)
+      return
+    }
+    scanPulseActive = true
+    scanPulseTimer.restart()
+    setScannerEnabled(true)
+  }
+
+  // Release mid-open. scanPulseActive drops first so setScannerEnabled resolves
+  // to a release, and the reconcile below keeps driving the device off for as
+  // long as no pulse is running.
+  function endScanPulse() {
+    scanPulseActive = false
+    scanPulseTimer.stop()
+    setScannerEnabled(false)
+    scanning = false
+  }
+
+  Timer {
+    id: scanPulseTimer
+    interval: Math.max(1, root.scanHoldSec) * 1000
+    repeat: false
+    onTriggered: root.endScanPulse()
   }
 
   Component.onDestruction: Scanner.release(root)
@@ -320,7 +375,9 @@ Panel {
       // scanner early and undo the deferral that keeps opening the panel off
       // NetworkManager's access-point flood.
       if (scanRestart.running) return
-      root.setScannerEnabled(root.opened)
+      // Once a hold is configured an open panel alone no longer counts, so
+      // this is what drives the device off after a pulse expires.
+      root.setScannerEnabled(root.opened && (!root.scanPulsed || root.scanPulseActive))
       Scanner.sweep(root.wifiDevice)
     }
   }
@@ -329,7 +386,9 @@ Panel {
   // what makes the SUPER+CTRL+W keybind land here with navigation ready.
   onOpenedChanged: {
     if (opened) {
-      refresh(true)
+      // scanOnOpen false means opening the panel costs no airtime at all: the
+      // list renders from NetworkManager's last results and `r` refreshes it.
+      refresh(scanOnOpen)
       selectedIndex = wifiNetworks.length > 0 ? 0 : -1
       wifiActionFocused = false
       focusSection = wifiNetworks.length > 0 ? "wifi" : "dns"
@@ -342,6 +401,7 @@ Panel {
       // the 100ms window reuses the running timer and re-enables the scanner
       // almost immediately, undoing the deferral #6605 restored.
       scanRestart.stop()
+      root.endScanPulse()
       // Reset throughput tracking so the next open doesn't compute a fake
       // rate from a sample taken minutes ago.
       prevSampleTime = 0
@@ -496,9 +556,11 @@ Panel {
         scanning = true
         setScannerEnabled(false)
         scanRestart.start()
-      } else {
+      } else if (!scanPulsed) {
         setScannerEnabled(true)
       }
+      // With a hold configured a bare refresh() never re-claims — the claim
+      // belongs to the pulse and expires with it.
     }
     syncWifiNetworks()
   }
@@ -832,7 +894,7 @@ Panel {
     repeat: false
     onTriggered: {
       if (root.opened && root.wifiDevice) {
-        root.setScannerEnabled(true)
+        root.startScanPulse()
         scanDone.start()
       }
     }
@@ -971,10 +1033,11 @@ Panel {
 
     onPressed: function(b) {
       if (root.opened) root.close()
-      // open() is enough: onOpenedChanged runs refresh(true), which defers the
-      // PHY scan past the first frame. The bare refresh() that used to follow
-      // took the no-scan branch and set scannerEnabled synchronously, undoing
-      // that deferral and stalling the open on NetworkManager's AP flood.
+      // open() is enough: onOpenedChanged runs refresh(scanOnOpen), which
+      // defers any PHY scan past the first frame. The bare refresh() that used
+      // to follow took the no-scan branch and set scannerEnabled synchronously,
+      // undoing that deferral and stalling the open on NetworkManager's AP
+      // flood.
       else root.open()
     }
   }
@@ -1081,7 +1144,7 @@ Panel {
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
-        if (t === "r" || t === "R") root.refresh()
+        if (t === "r" || t === "R") root.refresh(true)
         else if (t === "w" || t === "W") root.toggleNetwork()
       }
 
@@ -1470,8 +1533,19 @@ Panel {
       }
 
       PanelSectionHeader {
-        visible: root.wifiStationAvailable && root.scanning
+        // A sweep outlives the 1.5s repaint that clears `scanning`, so track the
+        // pulse too rather than reading idle mid-sweep.
+        visible: root.wifiStationAvailable && (root.scanning || root.scanPulseActive)
         text: "SCANNING WI-FI…"
+        foreground: root.bar.foreground
+        fontFamily: root.bar.fontFamily
+      }
+
+      // Under a hold the list stops refreshing itself once the pulse ends, so
+      // say so rather than letting stale results read as live ones.
+      PanelSectionHeader {
+        visible: root.wifiStationAvailable && root.scanPulsed && !root.scanning && !root.scanPulseActive
+        text: "NEARBY WI-FI (CACHED) · PRESS R TO RESCAN"
         foreground: root.bar.foreground
         fontFamily: root.bar.fontFamily
       }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -7,6 +7,7 @@ import Quickshell.Networking
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
+import "Scanner.js" as Scanner
 
 Panel {
   id: root
@@ -292,27 +293,36 @@ Panel {
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
 
-  // scannerEnabled lives on the shared WifiDevice, which has no reference
-  // counting, and a bar widget is instantiated once per monitor. Tracking the
-  // device this instance turned scanning on for keeps the release correct when
-  // the panel closes, the device is replaced, or the widget is destroyed —
-  // without a closed instance ever claiming the scanner.
-  property var scannerDevice: null
-
+  // scannerEnabled is shared mutable state on the WifiDevice and this widget
+  // outlives no instance alone — one per monitor, plus a transient overlap
+  // across a plugin reload — so claims are reference counted in
+  // Scanner.js rather than tracked per instance. This instance holds a claim
+  // exactly while its own panel is open; the scanner stops when the last
+  // instance lets go, and keeps running for the panels that still want it.
   function setScannerEnabled(enabled) {
-    var nextDevice = opened ? wifiDevice : null
-
-    if (scannerDevice && scannerDevice !== nextDevice)
-      scannerDevice.scannerEnabled = false
-
-    scannerDevice = nextDevice
-
-    if (scannerDevice)
-      scannerDevice.scannerEnabled = enabled
+    Scanner.acquire(root, opened && enabled ? wifiDevice : null)
   }
 
-  Component.onDestruction: {
-    if (scannerDevice) scannerDevice.scannerEnabled = false
+  Component.onDestruction: Scanner.release(root)
+
+  // The scanner costs real airtime — a full scan parks the radio off-channel
+  // for seconds on a slow card — so re-assert the invariant periodically
+  // instead of trusting every release path to fire. The sweep is what bounds
+  // a missed release: it drops claims whose owner died or closed and drives
+  // the device from what is left, so no instance can pin the scanner on after
+  // its panel is gone.
+  Timer {
+    interval: 30000
+    repeat: true
+    running: true
+    onTriggered: {
+      // Reconciling inside the 100ms scanRestart window would re-enable the
+      // scanner early and undo the deferral that keeps opening the panel off
+      // NetworkManager's access-point flood.
+      if (scanRestart.running) return
+      root.setScannerEnabled(root.opened)
+      Scanner.sweep(root.wifiDevice)
+    }
   }
 
   // KeyboardPanel primes layer-shell focus whenever the panel opens. That's

--- a/shell/plugins/panels/network/Scanner.js
+++ b/shell/plugins/panels/network/Scanner.js
@@ -1,0 +1,96 @@
+.pragma library
+
+// Reference counting for WifiDevice.scannerEnabled.
+//
+// scannerEnabled is a plain shared bool on a long-lived WifiDevice, but the
+// network bar widget is instantiated once per monitor, and again transiently
+// while a plugin reload overlaps the outgoing instance, so several panel
+// instances write to it. Per-instance bookkeeping cannot express "another
+// panel still wants this on" or "nobody wants this on any more": a release
+// from one instance stops scanning under an open panel on another monitor,
+// and a claim that is never released leaves the radio scanning every 10s
+// with no panel open at all (basecamp/omarchy#7896).
+//
+// Claims live here instead, keyed by owner. A claim is never trusted on its
+// own: it counts only while its owner is still alive and still open, so an
+// instance that dies without releasing cannot pin the scanner on. That makes
+// the registry self-healing rather than dependent on every release path
+// firing. .pragma library keeps this a single shared scope engine-wide.
+
+var claims = []  // [{ owner, device }]
+
+// A destroyed QObject throws on property access rather than reading back
+// null, so the throw is what makes a dead owner detectable here instead of
+// lingering as a permanent claim.
+function ownerWants(claim) {
+  try {
+    return !!claim.owner && claim.owner.opened === true
+  } catch (e) {
+    return false
+  }
+}
+
+function indexOfOwner(owner) {
+  for (var i = 0; i < claims.length; i++) {
+    if (claims[i].owner === owner) return i
+  }
+  return -1
+}
+
+// Only live, open owners count. A stale claim is ignored rather than kept.
+function claimCount(device) {
+  var count = 0
+  for (var i = 0; i < claims.length; i++) {
+    if (claims[i].device === device && ownerWants(claims[i])) count++
+  }
+  return count
+}
+
+// Drive the device to whatever its valid claims say. A device that is gone
+// took its scanner with it, so a throw here is nothing to do.
+function apply(device) {
+  if (!device) return
+  try {
+    var wanted = claimCount(device) > 0
+    if (device.scannerEnabled !== wanted) device.scannerEnabled = wanted
+  } catch (e) {
+  }
+}
+
+// Hold the scanner on `device` for `owner`, dropping any device this owner
+// held before. A null device releases without claiming anything.
+function acquire(owner, device) {
+  var index = indexOfOwner(owner)
+  var previous = index >= 0 ? claims[index].device : null
+
+  if (index >= 0) claims.splice(index, 1)
+  if (device) claims.push({ owner: owner, device: device })
+
+  if (previous !== device) apply(previous)
+  apply(device)
+}
+
+function release(owner) {
+  acquire(owner, null)
+}
+
+// Drop claims whose owner died or closed, then drive every device that was
+// mentioned -- including `device`, so a device left with no valid claims is
+// forced off even when the registry never held a claim for it. This is what
+// bounds a missed release, rather than trusting the caller's own claim.
+function sweep(device) {
+  var devices = device ? [device] : []
+
+  for (var i = 0; i < claims.length; i++) {
+    var claimed = claims[i].device
+    if (claimed && devices.indexOf(claimed) === -1) devices.push(claimed)
+  }
+
+  var kept = []
+  for (var j = 0; j < claims.length; j++) {
+    if (ownerWants(claims[j])) kept.push(claims[j])
+  }
+  claims = kept
+
+  for (var k = 0; k < devices.length; k++) apply(devices[k])
+}

--- a/shell/plugins/panels/network/manifest.json
+++ b/shell/plugins/panels/network/manifest.json
@@ -15,6 +15,27 @@
     "displayName": "Network",
     "description": "Wi-Fi list and connection state",
     "category": "Network",
-    "allowMultiple": false
+    "allowMultiple": false,
+    "defaults": {
+      "scanOnOpen": true,
+      "scanHoldSec": 0
+    },
+    "schema": [
+      {
+        "key": "scanOnOpen",
+        "type": "boolean",
+        "label": "Scan for networks when the panel opens",
+        "defaultValue": true
+      },
+      {
+        "key": "scanHoldSec",
+        "type": "integer",
+        "label": "Stop scanning this many seconds after a sweep starts (0 = keep scanning while open)",
+        "min": 0,
+        "max": 300,
+        "step": 5,
+        "defaultValue": 0
+      }
+    ]
   }
 }

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -36,44 +36,169 @@ assert(scanRestart, 'network has the deferred scan restart timer')
 assert(/root\.opened/.test(scanRestart[0]), 'network re-checks the panel before the deferred restart re-enables scanning')
 assert(/scanRestart\.stop\(\)/.test(panelSource), 'network cancels a pending scan restart when the panel closes')
 
-// scannerEnabled lives on a shared WifiDevice with no reference counting, so
-// the panel has to own what it enabled. Run the helper's own JavaScript against
-// stand-in devices: the two invariants it carries are that a closed panel never
-// takes a device, and that adopting a new one releases the previous.
+// scannerEnabled is a plain shared bool on a WifiDevice, and this widget is
+// instantiated once per monitor, so ownership is reference counted in
+// Scanner.js. Load that module the way the QML engine does -- one shared scope
+// for every instance -- and drive it with stand-in panels and devices.
+const scannerSource = fs.readFileSync(root + '/shell/plugins/panels/network/Scanner.js', 'utf8')
+assert(/^\.pragma library/m.test(scannerSource), 'network scanner claims share one engine-wide scope')
+
+function loadScanner() {
+  const body = scannerSource.replace(/^\.pragma library/m, '')
+  return new Function(body + '\nreturn { acquire, release, claimCount, sweep }')()
+}
+
 const scannerHelper = panelSource.match(/function setScannerEnabled\(enabled\) \{[\s\S]*?\n {2}\}/)
 assert(scannerHelper, 'network has a scanner ownership helper')
+assert(/Scanner\.acquire\(root,/.test(scannerHelper[0]), 'network claims the scanner through the reference-counted registry')
 
-var opened = false
-var wifiDevice = { scannerEnabled: false }
-var scannerDevice = null
-eval(scannerHelper[0])
+// Bind the helper's free variables explicitly rather than leaking a `root`
+// into this scope, so the panel under test is the stand-in and not the suite.
+function bindSetScannerEnabled(Scanner, panel, opened, wifiDevice) {
+  // A claim counts only while its owner reports itself open, so the stand-in
+  // has to carry the same state the helper is being handed.
+  panel.opened = opened
+  return new Function(
+    'Scanner', 'root', 'opened', 'wifiDevice',
+    scannerHelper[0] + '\nreturn setScannerEnabled'
+  )(Scanner, panel, opened, wifiDevice)
+}
 
-setScannerEnabled(true)
+// A closed panel must never claim the scanner, whatever it asks for.
+var Scanner = loadScanner()
+const closedPanel = { name: 'closed' }
+const idleDevice = { scannerEnabled: false }
+bindSetScannerEnabled(Scanner, closedPanel, false, idleDevice)(true)
 assert(
-  scannerDevice === null && wifiDevice.scannerEnabled === false,
+  idleDevice.scannerEnabled === false && Scanner.claimCount(idleDevice) === 0,
   'network does not let a closed panel claim or enable a scanner device'
 )
 
-var previousScannerDevice = { scannerEnabled: true }
-var replacementScannerDevice = { scannerEnabled: false }
-opened = true
-scannerDevice = previousScannerDevice
-wifiDevice = replacementScannerDevice
-setScannerEnabled(true)
+// Adopting a replacement device must release the one left behind.
+Scanner = loadScanner()
+const openPanel = { name: 'open' }
+const previousScannerDevice = { scannerEnabled: false }
+const replacementScannerDevice = { scannerEnabled: false }
+bindSetScannerEnabled(Scanner, openPanel, true, previousScannerDevice)(true)
+bindSetScannerEnabled(Scanner, openPanel, true, replacementScannerDevice)(true)
 assert(
   previousScannerDevice.scannerEnabled === false &&
-    scannerDevice === replacementScannerDevice &&
-    replacementScannerDevice.scannerEnabled === true,
+    replacementScannerDevice.scannerEnabled === true &&
+    Scanner.claimCount(previousScannerDevice) === 0,
   'network releases the previous scanner device before enabling its replacement'
 )
+
+// Closing releases: the same panel asking with opened=false drops its claim.
+bindSetScannerEnabled(Scanner, openPanel, false, replacementScannerDevice)(false)
+assert(
+  replacementScannerDevice.scannerEnabled === false &&
+    Scanner.claimCount(replacementScannerDevice) === 0,
+  'network releases the scanner when its panel closes'
+)
+
+// The bug this reference counting exists for: one panel per monitor sharing a
+// device. Whoever closes first must not stop the scan the other is watching,
+// and the last one out must stop it. Without counting, either the scanner dies
+// under an open panel or it runs on forever behind a closed one.
+Scanner = loadScanner()
+var sharedDevice = { scannerEnabled: false }
+var panelA = { name: 'a', opened: true }
+var panelB = { name: 'b', opened: true }
+Scanner.acquire(panelA, sharedDevice)
+Scanner.acquire(panelB, sharedDevice)
+Scanner.release(panelA)
+assert(sharedDevice.scannerEnabled === true, 'network keeps scanning while another monitor still has the panel open')
+Scanner.release(panelB)
+assert(sharedDevice.scannerEnabled === false, 'network stops scanning once the last open panel lets go')
+
+// Releasing twice must not disturb a claim someone else has since taken.
+Scanner.release(panelB)
+Scanner.acquire(panelA, sharedDevice)
+Scanner.release(panelB)
+assert(sharedDevice.scannerEnabled === true, 'network ignores a repeated release from an instance holding no claim')
+Scanner.release(panelA)
+
+// A device destroyed underneath a live claim throws on property access rather
+// than reading back null; releasing it must not take the shell down with it.
+Scanner = loadScanner()
+var destroyedDevice = {
+  get scannerEnabled() { throw new TypeError('Cannot read property of null') },
+  set scannerEnabled(value) { throw new TypeError('Cannot write property of null') }
+}
+Scanner.acquire(panelA, destroyedDevice)
+Scanner.release(panelA)
+pass('network survives releasing a device that was destroyed underneath it')
 
 // Destruction is the case a guard-only fix misses: the widget dies with the
 // panel still open, as a bar reload does, and nothing else would release it.
 assert(
-  /Component\.onDestruction[\s\S]{0,140}scannerDevice\.scannerEnabled = false/.test(panelSource),
+  /Component\.onDestruction: Scanner\.release\(root\)/.test(panelSource),
   'network releases the scanner it owns when the widget is destroyed'
 )
-assert(!/wifiDevice\.scannerEnabled\s*=/.test(panelSource), 'network writes scanner state through its owned device reference rather than the moving wifiDevice reference')
+assert(!/wifiDevice\.scannerEnabled\s*=/.test(panelSource), 'network writes scanner state through the registry rather than the moving wifiDevice reference')
+
+// A claim is only as good as its owner. An instance that dies without its
+// release running, or one whose release is simply missed, must not be able to
+// pin the scanner on -- that is the exact failure #7896 describes.
+Scanner = loadScanner()
+const abandonedDevice = { scannerEnabled: false }
+const doomedPanel = { opened: true }
+Scanner.acquire(doomedPanel, abandonedDevice)
+assert(abandonedDevice.scannerEnabled === true, 'network scans while an open panel holds the claim')
+
+// Destroyed: property access throws rather than reading back null.
+Object.defineProperty(doomedPanel, 'opened', {
+  get() { throw new TypeError('Cannot read property of null') },
+  configurable: true
+})
+Scanner.sweep(abandonedDevice)
+assert(
+  abandonedDevice.scannerEnabled === false && Scanner.claimCount(abandonedDevice) === 0,
+  'network drops the claim of an owner destroyed without releasing'
+)
+
+// Closed but never released: same outcome, without the destruction.
+Scanner = loadScanner()
+const forgottenDevice = { scannerEnabled: false }
+const forgottenPanel = { opened: true }
+Scanner.acquire(forgottenPanel, forgottenDevice)
+forgottenPanel.opened = false
+Scanner.sweep(forgottenDevice)
+assert(forgottenDevice.scannerEnabled === false, 'network drops a claim whose panel closed without releasing')
+
+// A device enabled out of band with nothing claiming it must still be driven
+// off -- releasing alone never touches a device the registry has no claim for.
+Scanner = loadScanner()
+const strayDevice = { scannerEnabled: true }
+Scanner.sweep(strayDevice)
+assert(strayDevice.scannerEnabled === false, 'network turns off a scanner nothing is claiming')
+
+// The sweep must not be indiscriminate: a live open panel keeps its scan.
+Scanner = loadScanner()
+const sharedLive = { scannerEnabled: false }
+const stillOpen = { opened: true }
+const alsoDead = { opened: true }
+Scanner.acquire(stillOpen, sharedLive)
+Scanner.acquire(alsoDead, sharedLive)
+Object.defineProperty(alsoDead, 'opened', {
+  get() { throw new TypeError('Cannot read property of null') },
+  configurable: true
+})
+Scanner.sweep(sharedLive)
+assert(
+  sharedLive.scannerEnabled === true && Scanner.claimCount(sharedLive) === 1,
+  'network sweeps the dead owner but keeps scanning for the open one'
+)
+
+// The scanner is shared mutable state on a long-lived device, so a missed
+// release must not be able to leave the radio scanning indefinitely.
+const scannerReconcile = panelSource.match(/Timer \{\s*interval: 30000[\s\S]*?\n {2}\}/)
+assert(scannerReconcile, 'network re-asserts scanner state on a timer so a stale claim cannot persist')
+assert(/running: true/.test(scannerReconcile[0]), 'network runs the scanner reconcile whether or not its panel is open')
+assert(/Scanner\.sweep\(root\.wifiDevice\)/.test(scannerReconcile[0]), 'network sweeps dead claims on reconcile rather than only re-asserting its own')
+// Reconciling inside the deferred-restart window would re-enable the scanner
+// early and undo the deferral that keeps panel opening off the AP flood.
+assert(/if \(scanRestart\.running\) return/.test(scannerReconcile[0]), 'network skips reconciling while a deferred scan restart is pending')
 
 // A row is a primitive snapshot that can outlive its WifiNetwork, and
 // disconnect() falls back to the live connection when handed null, so row

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -465,4 +465,24 @@ assert(
   /refresh\(scanOnOpen\)/.test(panelSource),
   'network routes the panel-open scan through the scanOnOpen setting'
 )
+
+// A scan the panel no longer starts on its own needs something to press, and
+// the keyboard path alone leaves mouse users with no way to rescan at all.
+assert(/id: rescanAction/.test(panelSource), 'network offers a rescan button in the panel header')
+const rescanButton = panelSource.match(/Button \{\s*\n\s*id: rescanAction[\s\S]*?\n {10}\}/)
+assert(rescanButton, 'network rescan button is a complete header action')
+assert(/onClicked: root\.refresh\(true\)/.test(rescanButton[0]), 'network rescan button starts a real sweep')
+assert(/visible: root\.canRescanWifi/.test(rescanButton[0]), 'network shows the rescan button whenever there is a radio to scan with')
+assert(/tooltipText:[^\n]*\(r\)/.test(rescanButton[0]), 'network rescan button names its keyboard shortcut')
+
+const activateHeaderFn = panelSource.match(/function activateHeader\(\)[\s\S]*?\n {2}\}/)
+assert(activateHeaderFn, 'network has an activateHeader dispatcher')
+assert(
+  /headerIndex === rescanHeaderIndex\) refresh\(true\)/.test(activateHeaderFn[0]),
+  'network keyboard-activates the rescan header action'
+)
+assert(
+  /headerActionCount:[^\n]*canRescanWifi/.test(panelSource),
+  'network counts the rescan action so header navigation can reach it'
+)
 JS

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -54,14 +54,16 @@ assert(/Scanner\.acquire\(root,/.test(scannerHelper[0]), 'network claims the sca
 
 // Bind the helper's free variables explicitly rather than leaking a `root`
 // into this scope, so the panel under test is the stand-in and not the suite.
-function bindSetScannerEnabled(Scanner, panel, opened, wifiDevice) {
+function bindSetScannerEnabled(Scanner, panel, opened, wifiDevice, scanPulsed, scanPulseActive) {
   // A claim counts only while its owner reports itself open, so the stand-in
-  // has to carry the same state the helper is being handed.
+  // has to carry the same state the helper is being handed. scanPulsed defaults
+  // to false, which is the shipped default (scanHoldSec 0) and the behaviour
+  // every case below this one asserts.
   panel.opened = opened
   return new Function(
-    'Scanner', 'root', 'opened', 'wifiDevice',
+    'Scanner', 'root', 'opened', 'wifiDevice', 'scanPulsed', 'scanPulseActive',
     scannerHelper[0] + '\nreturn setScannerEnabled'
-  )(Scanner, panel, opened, wifiDevice)
+  )(Scanner, panel, opened, wifiDevice, !!scanPulsed, !!scanPulseActive)
 }
 
 // A closed panel must never claim the scanner, whatever it asks for.
@@ -418,4 +420,49 @@ assertDeepEqual(
 
 assertEqual(network.headerDetail({ type: 'wifi', freq: '5745' }), '', 'network keeps wifi band state out of the hero')
 assertEqual(network.headerDetail({ type: 'ethernet', speed: '100' }), '100mbit', 'network keeps ethernet speed in the hero')
+
+// scanHoldSec turns the claim into a pulse. The point of the setting is that a
+// panel can be open without the radio being off-channel, so an open panel with
+// no pulse running must not claim -- the case that is a plain bug when the
+// setting is off.
+Scanner = loadScanner()
+const heldDevice = { scannerEnabled: false }
+const heldPanel = { name: 'held' }
+bindSetScannerEnabled(Scanner, heldPanel, true, heldDevice, true, false)(true)
+assert(
+  heldDevice.scannerEnabled === false && Scanner.claimCount(heldDevice) === 0,
+  'network does not claim the scanner for an open panel once its pulse has expired'
+)
+
+Scanner = loadScanner()
+const pulsingDevice = { scannerEnabled: false }
+const pulsingPanel = { name: 'pulsing' }
+bindSetScannerEnabled(Scanner, pulsingPanel, true, pulsingDevice, true, true)(true)
+assert(
+  pulsingDevice.scannerEnabled === true && Scanner.claimCount(pulsingDevice) === 1,
+  'network claims the scanner while a pulse is live'
+)
+
+// A pulse cannot resurrect a closed panel's claim either.
+Scanner = loadScanner()
+const closedPulseDevice = { scannerEnabled: false }
+bindSetScannerEnabled(Scanner, { name: 'closed-pulse' }, false, closedPulseDevice, true, true)(true)
+assert(
+  closedPulseDevice.scannerEnabled === false && Scanner.claimCount(closedPulseDevice) === 0,
+  'network keeps a closed panel from claiming even with a pulse marked live'
+)
+
+// The defaults have to reproduce the old behaviour exactly, or this setting is
+// a silent regression for everyone who never sets it.
+const networkManifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/panels/network/manifest.json', 'utf8'))
+assertEqual(networkManifest.barWidget.defaults.scanOnOpen, true, 'network still scans on open by default')
+assertEqual(networkManifest.barWidget.defaults.scanHoldSec, 0, 'network still holds the scanner while open by default')
+assert(
+  /settings\.scanOnOpen/.test(panelSource) && /settings\.scanHoldSec/.test(panelSource),
+  'network reads both scan settings from its widget config'
+)
+assert(
+  /refresh\(scanOnOpen\)/.test(panelSource),
+  'network routes the panel-open scan through the scanOnOpen setting'
+)
 JS


### PR DESCRIPTION
Fixes #7896.

## The bug

`scannerEnabled` is a plain shared `bool` on a long-lived `WifiDevice`, but the network bar widget is instantiated once per monitor — and again transiently while a plugin reload overlaps the outgoing instance, which happens on single-monitor machines too. Several instances therefore write to one flag.

Per-instance bookkeeping cannot express "another panel still wants this on" or "nobody wants this any more". That gives two failures from one hole:

- A claim that is never released leaves NetworkManager scanning **every 10s behind a closed panel**. `mScanIntervalMs = 10001` in quickshell's `src/network/nm/wireless.hpp` is exactly the cadence measured in #7896.
- `Component.onDestruction` unconditionally cleared the flag, so a dying instance **stops scanning under a panel still open** on another monitor.

On a slow radio the first one is destructive rather than cosmetic: on the BCM43224 / `brcmsmac` in #7896 a 37-channel scan parks the card off its operating channel for ~11s, so a scan every 10s loses inbound frames continuously — measured there at 19.7% loss to the gateway.

## The fix

Claims move into `Scanner.js`, keyed by owner: the scanner runs exactly while at least one live instance holds a claim, and stops the moment the last one lets go.

A claim is never trusted on its own. It counts only while its owner is still alive and still open — a destroyed `QObject` throws on property access rather than reading back `null`, and that throw is what makes a dead owner detectable instead of leaving a permanent claim. A 30s reconcile sweeps on that basis: it drops claims whose owner died or closed and drives the device from what is left, including forcing off a device nothing is claiming. That is what bounds a missed release, rather than each instance merely re-asserting its own claim.

To be straight about scope: the indefinite stuck state in #7896 could not be reproduced on demand, there or here. This makes that class impossible for anything going through `setScannerEnabled`, and bounds a leaked or abandoned claim to one sweep interval. It is not a fix for a reproduced hang.

One behavioural note: with two panels open, one instance's `refresh(true)` off/on toggle no longer force-restarts the scan globally, since the sibling's claim holds it on. Scanning is already in flight in that case, so it is benign.

## Second commit: an open panel on a slow radio

The first commit stops a *closed* panel from scanning. An open one still scans
continuously, and on a slow card that is its own outage: quickshell re-arms
every 10001ms while a sweep on a BCM43224 / `brcmsmac` takes ~11s, so the radio
is off-channel essentially the whole time the panel is up. Ping to 1.1.1.1 on
that card: **18.75% loss during a sweep, 0% with none in flight**. A download
dies because the Wi-Fi panel is open — which is what you open when a download
looks stuck.

Two widget settings, both defaulting to today's behaviour exactly:

| Setting | Default | Effect |
|---|---|---|
| `scanOnOpen` | `true` | opening the panel starts a sweep, as now |
| `scanHoldSec` | `0` | the scanner stays claimed while the panel is open, as now |

Above zero, `scanHoldSec` turns the claim into a pulse — released that many
seconds after a sweep starts even though the panel is still open, with the next
sweep waiting for `r`. With `scanOnOpen` false, opening costs no airtime at all
and a header says the list is cached rather than letting stale results read as
live. On the affected hardware, `scanOnOpen: false` + `scanHoldSec: 15` gives
**0 scans and 0% loss across 120s with the panel open**, against ~4 sweeps per
45s before.

`r` now calls `refresh(true)`; it called a bare `refresh()` before, which
repainted from results already held and never actually rescanned.

## Third commit: a rescan button

`r` alone is not an affordance — nothing said the key existed, and a mouse user
had no rescan at all, which with `scanOnOpen` false means a list that can never
be refreshed without a keyboard. The third commit adds a rescan action to the
panel header beside the QR and speed-test buttons, using their existing
`Button` / `hasCursor` / `setHeaderCursor` wiring so it works by click and by
header navigation. The tooltip names the shortcut and reads "Scanning…" during
a sweep, which is what makes `r` discoverable on the default configuration as
well. It is present whenever there is a radio to scan with, not only when a
hold is configured.

Tests assert the pulse cases and that the defaults still reproduce the old
behaviour — 127 assertions pass. Happy to split this into its own PR if you
would rather keep the first commit single-purpose.

## Tests

`test/shell.d/network-test.sh` already `eval`'d the old helper directly, so it had to be updated. It now also covers the two-instance case, a repeated release, a device destroyed underneath a live claim, an owner destroyed without releasing, a panel closed without releasing, a scanner enabled with nothing claiming it, and a sweep that must spare a live open sibling. 120 assertions pass.

`./test/all` has 4 pre-existing failures on this machine (`config`, `runtime-smoke`, `snapper`, `unowned-system-paths`); all four fail identically on a clean tree.

## Verified on the affected hardware

Omarchy 4.0.0-1, quickshell-git 0.3.0.r20.g28771c7-2, MacBookAir5,2 / BCM43224. Scans counted via NetworkManager's `LastScan` property:

| Panel state | Scans |
|---|---|
| closed, 40s | **0** |
| open, 40s | **2** |
| closed again, 40s | **0** |

Two scans in 40s is the expected rate when each sweep takes ~11s. Instrumented logging confirmed every transition, including startup correctly refusing to claim while closed, and the reconcile firing on schedule.


