### PR TITLE
Run ONCE with sudo when installing

### DIFF
--- a/bin/omarchy-install-service-once
+++ b/bin/omarchy-install-service-once
@@ -10,4 +10,4 @@ echo "Enabling ONCE background service..."
 sudo systemctl enable --now once-background.service
 
 echo -e "\nLaunching ONCE..."
-once
+sudo once


### PR DESCRIPTION
The install user is no longer in the docker group by default, so a bare `once` cannot reach the Docker socket. Run with `sudo` instead.

The script already requires sudo to install the command and enable the service, so we can safely use it for the initial command launch as well.