### PR TITLE
Stop one speaker dropping out on the Dell XPS 14

### DIFF
--- a/bin/omarchy-hw-sku
+++ b/bin/omarchy-hw-sku
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Match the computer's DMI product SKU, whole value (case-insensitive).
+# omarchy:args=<sku>...
+
+# The SKU is the most precise identifier these machines expose -- narrower than a
+# product name, and it separates models whose names differ only by marketing.
+# Vendors key speaker firmware on it. Compared against the whole value, never a
+# substring, so a caller cannot accidentally widen to a product line.
+
+sku=$(cat /sys/class/dmi/id/product_sku 2>/dev/null)
+
+[[ -n $sku ]] || exit 1
+
+for want in "$@"; do
+  if [[ ${sku,,} == "${want,,}" ]]; then
+    exit 0
+  fi
+done
+
+exit 1

--- a/default/wireplumber/wireplumber.conf.d/dell-xps14-speaker-no-suspend.conf
+++ b/default/wireplumber/wireplumber.conf.d/dell-xps14-speaker-no-suspend.conf
@@ -1,0 +1,26 @@
+## Keep the speaker sink open on the Dell XPS 14 (SKU 0DB9).
+##
+## The machine has four cs35l56 amps split across two SoundWire links, two per
+## side. Link 3 intermittently loses the bus when it re-enumerates on resume
+## from idle ("soundwire_intel.link.3: Bus clash for control word"), and its two
+## amps then stay silent for the life of the open PCM -- playback continues from
+## one side only until the stream is reopened.
+##
+## WirePlumber suspends an idle node after 5s, so an ordinary listening session
+## power-cycles the link constantly. Holding the sink open stops the cycling.
+## Scoped to the speakers: the headphone and HDMI sinks still suspend normally.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_output.*sof_sdw\\.HiFi__Speaker__sink"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -8,6 +8,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-audio-mixer.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/dell/fix-xps14-speaker-dropout.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"

--- a/install/user/hardware/dell/fix-xps14-speaker-dropout.sh
+++ b/install/user/hardware/dell/fix-xps14-speaker-dropout.sh
@@ -1,0 +1,19 @@
+# Stop one side of the speakers dropping out on the Dell XPS 14 (SKU 0DB9).
+#
+# The machine has four cs35l56 amps split across two SoundWire links, two per
+# side. Link 3 intermittently loses the bus when it re-enumerates on resume from
+# idle ("soundwire_intel.link.3: Bus clash for control word"), and its two amps
+# then stay silent for the life of the open PCM. Playback continues from one
+# side only until the stream is torn down and reopened, so pausing and resuming
+# the player clears it -- which is what makes the symptom look intermittent and
+# player-specific. The digital path is fine throughout: the sink monitor
+# measures correct stereo the whole time.
+#
+# WirePlumber suspends an idle node after 5s and the amps runtime-suspend after
+# 100ms, so an ordinary listening session power-cycles the link constantly and
+# keeps rolling the dice. Holding the speaker sink open stops the cycling, at
+# the cost of a little idle battery while the sink exists.
+if omarchy-hw-sku "0DB9"; then
+  mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+  cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/dell-xps14-speaker-no-suspend.conf" ~/.config/wireplumber/wireplumber.conf.d/
+fi

--- a/migrations/1787670253.sh
+++ b/migrations/1787670253.sh
@@ -1,0 +1,24 @@
+echo "Keep the speaker sink open on the Dell XPS 14 to stop one side dropping out"
+
+# The XPS 14 (SKU 0DB9) has four cs35l56 amps split across two SoundWire links,
+# two per side. Link 3 intermittently loses the bus when it re-enumerates on
+# resume from idle ("soundwire_intel.link.3: Bus clash for control word"), and
+# its two amps then stay silent for the life of the open PCM -- playback
+# continues from one side only until the stream is reopened. WirePlumber
+# suspends an idle node after 5s, so an ordinary listening session power-cycles
+# the link constantly. New installs get the drop-in from
+# install/user/hardware/dell/fix-xps14-speaker-dropout.sh; place it here for
+# installs that already exist.
+if omarchy-hw-sku "0DB9"; then
+  config="wireplumber/wireplumber.conf.d/dell-xps14-speaker-no-suspend.conf"
+  dest="$HOME/.config/$config"
+
+  if [[ ! -f $dest ]]; then
+    mkdir -p "$(dirname "$dest")"
+    cp "$OMARCHY_PATH/default/$config" "$dest"
+
+    # Apply it now rather than leaving the fix inert until the next login. A
+    # session that has no running wireplumber to restart is not an error here.
+    systemctl --user restart wireplumber.service || true
+  fi
+fi


### PR DESCRIPTION
> Draft: the fix is verified live on the affected machine, but the failure is intermittent and hasn't had enough soak time yet to call confirmed. Details at the bottom.

## Problem

On the Dell XPS 14 (SKU `0DB9`), audio intermittently drops to a single speaker mid-playback. It looks player-specific and random — pausing and resuming the player restores stereo, which makes it easy to misread as an app bug.

It isn't. The machine has four cs35l56 amps split across two SoundWire links, two per side, and link 3 intermittently loses the bus when it re-enumerates on resume from idle:

```
soundwire_intel soundwire_intel.link.3: Bus clash for control word
soundwire_intel soundwire_intel.link.3: Bus clash for data word
```

Every clash in the log is on link 3; link 2 never clashes. Those two amps then stay silent for the life of the open PCM, so playback continues from one side until the stream is torn down and reopened — hence the pause/resume "fix".

The digital path is fine throughout, which is what makes this hard to spot:

- sink monitor recorded during a dropout measures L/R within 0.7 dB, correlation 0.68 — correct stereo
- `spotify:output_FL → playback_FL` / `output_FR → playback_FR` links are correct
- all four amps report on at 100%, no balance offset anywhere

The loss is entirely downstream of the sink, on the bus.

## Why it happens so often

WirePlumber suspends an idle node after 5s and the amps runtime-suspend after 100ms, so an ordinary listening session power-cycles the link constantly and keeps rolling the dice on the resync.

## Fix

Hold the speaker sink open so the link stops cycling. Scoped to the speaker sink — headphone and HDMI sinks still suspend normally. Costs a little idle battery while the sink exists.

Follows the existing pattern from `install/user/hardware/asus/fix-audio-mixer.sh`: a drop-in under `default/wireplumber/wireplumber.conf.d/` copied in by a hardware-gated leaf under `install/user/hardware/`, registered in `install/user/all.sh`. Includes a migration so existing installs get it too, not just new ones.

## The `omarchy-hw-sku` commit

Gating this on `omarchy-hw-match "DA14260"` would have keyed the fix to a marketing name, which `docs/audio-tuning.md` explicitly argues against for speaker hardware — vendors key speaker firmware on the SKU, and this machine's amp firmware is literally `cs35l57-b2-dsp1-misc-10280db9-...`. `omarchy-audio-tuning` already matches on SKU, but privately in a local `sku_matches()`, so nothing else can reuse it.

The first commit exposes that same test as an `hw-` predicate, matching the whole value rather than a substring so callers can't accidentally widen to a product line. Happy to drop it and inline the check if you'd rather not grow `bin/`.

Deliberately **not** included: refactoring `omarchy-audio-tuning` to call the new helper. It's a behaviour-neutral cleanup on code this PR doesn't otherwise touch, so it seemed better left separate. Glad to follow up if wanted.

## Scope

This is a workaround for a kernel/hardware resync failure, not a fix for it. Worth filing upstream against SOF/SoundWire separately.

Gated on `0DB9` only. The XPS 16 (`0DBA`) may well have the same 4-amp/2-link layout and the same bug — the shipped tuning already covers both SKUs — but I have no XPS 16 to confirm on, and `docs/audio-tuning.md` says to gate narrowly and widen as models are validated. It's a one-word change if someone can reproduce it there.

A structural gate (cs35l56 amps spanning more than one SoundWire link, in the style of `omarchy-hw-dell-xps-oled`) would cover every affected model automatically and is arguably the more precise test, since it detects the actual buggy layout rather than a model. I went with the narrow SKU gate because I can only validate one machine, but I'm happy to switch if you'd prefer it.

## Testing

- `./test/all` — 201/205 pass. The 4 failures (`config`, `snapper`, `theme-install-guards`, `unowned-system-paths`) fail identically on a clean `quattro` in this environment: three want an `omarchy-pkgs` sibling checkout, one is a URL reachability check. Unrelated to this change — but it does mean the packaging-coverage assertions never actually ran against the new files, so that's worth a second look from someone with `omarchy-pkgs` checked out.
- `./test/cli` passes; `omarchy hw sku` routes with correct summary and args.
- `omarchy-hw-sku` verified on the affected machine: matches `0DB9` and `0db9`, rejects `0DBA`, rejects the substring `0DB`, rejects no-args, and takes multiple SKUs.
- Migration tested per `agents/skills/migrations.md`: `HOME=$(mktemp -d) bash -euo pipefail migrations/1787670253.sh` places the drop-in, and a second run is a clean no-op.
- Drop-in verified live: speaker sink reports `session.suspend-timeout-seconds = 0` and holds `RUNNING`; headphone and HDMI sinks untouched.

Soak time is the honest gap. At a few clashes a day, "no clashes since" isn't yet proof — I'd want several days of clean logs before calling it confirmed, which is why this is a draft.
