### PR TITLE
fix(windows-vm): replace TZ with LANGUAGE/REGION for proper timezone support

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -137,7 +137,7 @@ valid_ram() { [[ $1 =~ ^[0-9]{1,3}G$ ]]; }
 valid_cores() { [[ $1 =~ ^[0-9]{1,2}$ ]] && ((10#$1 >= 1)); }
 valid_disk() { [[ $1 =~ ^[0-9]{1,4}G$ ]]; }
 valid_username() { [[ $1 =~ ^[A-Za-z0-9_-]{1,20}$ ]]; }
-valid_tz() { [[ $1 =~ ^[A-Za-z0-9_/.+-]{1,64}$ ]]; }
+valid_region() { [[ $1 =~ ^[a-z]{2}-[A-Z]{2}$ ]]; }
 valid_password() { [[ $1 =~ ^[[:print:]]{1,64}$ ]]; }
 
 # The only privileged sub-actions __priv may dispatch. A bash command name
@@ -668,7 +668,7 @@ rollback_new_caller_mounts() {
 }
 
 write_compose_atomically() (
-  local ram="$1" cores="$2" disk="$3" username="$4" password="$5" tz="$6"
+  local ram="$1" cores="$2" disk="$3" username="$4" password="$5" region="$6"
   local tmp="" rc esc_password
   cleanup_writer() {
     rc=$?
@@ -707,8 +707,9 @@ services:
       DISK_SIZE: "$disk"
       USERNAME: "$username"
       PASSWORD: "$esc_password"
+      LANGUAGE: "$region"
+      REGION: "$region"
       PROTECT: "Y"
-      TZ: "$tz"
       ARGUMENTS: "-rtc base=localtime,clock=host,driftfix=slew"
     devices:
       - /dev/kvm
@@ -740,7 +741,7 @@ EOF
 # Only these fixed keys are honored; image, container name, devices, caps, and
 # port bindings are hard-coded and never taken from input.
 __priv_write_compose() {
-  local ram cores disk username password tz key value
+  local ram cores disk username password region key value
 
   while IFS='=' read -r key value; do
     case "$key" in
@@ -749,7 +750,7 @@ __priv_write_compose() {
     DISK) disk="$value" ;;
     USERNAME) username="$value" ;;
     PASSWORD) password="$value" ;;
-    TZ) tz="$value" ;;
+    REGION) region="$value" ;;
     esac
   done
 
@@ -758,11 +759,11 @@ __priv_write_compose() {
   valid_disk "$disk" || { echo "invalid disk size: $disk" >&2; exit 2; }
   valid_username "$username" || { echo "invalid username: $username" >&2; exit 2; }
   valid_password "$password" || { echo "invalid password" >&2; exit 2; }
-  valid_tz "$tz" || tz="UTC"
+  valid_region "$region" || region="en-US"
   prepare_caller_mounts || exit 2
   # Readable by root and the docker group only. Any failure after mounting rolls
   # back just the binds this writer created and leaves an old compose untouched.
-  write_compose_atomically "$ram" "$cores" "$disk" "$username" "$password" "$tz" || exit 2
+  write_compose_atomically "$ram" "$cores" "$disk" "$username" "$password" "$region" || exit 2
 }
 
 # Read the host source of a bind mount out of the compose (e.g. /storage).
@@ -1034,9 +1035,9 @@ available_storage_gb() {
 
 # Feed the collected settings to the elevated writer.
 write_compose() {
-  local ram="$1" cores="$2" disk="$3" username="$4" password="$5" tz="$6"
-  printf 'RAM=%s\nCORES=%s\nDISK=%s\nUSERNAME=%s\nPASSWORD=%s\nTZ=%s\n' \
-    "$ram" "$cores" "$disk" "$username" "$password" "$tz" |
+  local ram="$1" cores="$2" disk="$3" username="$4" password="$5" region="$6"
+  printf 'RAM=%s\nCORES=%s\nDISK=%s\nUSERNAME=%s\nPASSWORD=%s\nREGION=%s\n' \
+    "$ram" "$cores" "$disk" "$username" "$password" "$region" |
     priv write_compose
 }
 
@@ -1098,14 +1099,14 @@ migrate_legacy_compose() {
   [[ -f $LEGACY_COMPOSE_FILE ]] || return 1
 
   echo "Migrating Windows VM configuration to $COMPOSE_FILE ..."
-  local ram cores disk username password tz
+  local ram cores disk username password region
   ram=$(read_compose_value RAM_SIZE "$LEGACY_COMPOSE_FILE")
   cores=$(read_compose_value CPU_CORES "$LEGACY_COMPOSE_FILE")
   disk=$(read_compose_value DISK_SIZE "$LEGACY_COMPOSE_FILE")
   username=$(read_compose_value USERNAME "$LEGACY_COMPOSE_FILE")
   password=$(read_compose_value PASSWORD "$LEGACY_COMPOSE_FILE")
-  tz=$(read_compose_value TZ "$LEGACY_COMPOSE_FILE")
-  [[ -z $tz ]] && tz="UTC"
+  region=$(read_compose_value REGION "$LEGACY_COMPOSE_FILE")
+  [[ -z $region ]] && region="en-US"
   prepare_user_mount_sources || {
     echo "Could not validate the existing Windows VM data directories." >&2
     return 1
@@ -1113,7 +1114,7 @@ migrate_legacy_compose() {
   write_credentials "$username" "$password" || return 1
   # The elevated writer derives both mount anchors from the authenticated uid;
   # it never consumes volume paths from this user-owned legacy file.
-  if ! write_compose "$ram" "$cores" "$disk" "$username" "$password" "$tz"; then
+  if ! write_compose "$ram" "$cores" "$disk" "$username" "$password" "$region"; then
     echo "Could not migrate the existing configuration automatically." >&2
     echo "Re-run: omarchy-windows-vm install" >&2
     return 1
@@ -1303,14 +1304,19 @@ EOF
     exit 1
   fi
 
-  local tz
-  tz=$(timedatectl show -p Timezone --value 2>/dev/null || echo UTC)
+  # Derive Windows locale from the system LANG (e.g. en_US.UTF-8 -> en-US).
+  local lang_val="${LANG:-en_US.UTF-8}"
+  local region
+  region=$(echo "$lang_val" | sed 's/_/-/;s/\.UTF-8//')
+  if [[ ! "$region" =~ ^[a-z]{2}-[A-Z]{2}$ ]]; then
+    region="en-US"
+  fi
 
   # Write the root-owned compose from the validated settings (one prompt if
   # sudoless Docker is off). The writer pins the familiar home directories (or
   # their legitimate symlink targets) into root-protected bind anchors.
   write_compose "$SELECTED_RAM" "$SELECTED_CORES" "$SELECTED_DISK" \
-    "$USERNAME" "$PASSWORD" "$tz" || {
+    "$USERNAME" "$PASSWORD" "$region" || {
     echo "❌ Failed to write the Windows VM configuration."
     exit 1
   }

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -39,8 +39,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-write() { # RAM CORES DISK USER PASS TZ
-  printf 'RAM=%s\nCORES=%s\nDISK=%s\nUSERNAME=%s\nPASSWORD=%s\nTZ=%s\n' \
+write() { # RAM CORES DISK USER PASS REGION
+  printf 'RAM=%s\nCORES=%s\nDISK=%s\nUSERNAME=%s\nPASSWORD=%s\nREGION=%s\n' \
     "$@" | __priv_write_compose
 }
 
@@ -54,7 +54,7 @@ reset_case() {
 
 # Fixed protected anchors consume the pinned source inodes.
 prepare_user_mount_sources
-write 4G 2 64G alice s3cret Europe/Copenhagen
+write 4G 2 64G alice s3cret en-US
 resolve_caller
 [[ -f $COMPOSE ]] || fail "writer produced a compose file"
 grep -q 'image: dockurr/windows' "$COMPOSE" || fail "image is pinned"
@@ -62,6 +62,8 @@ grep -q -- '- NET_ADMIN' "$COMPOSE" || fail "cap_add is pinned"
 grep -q -- "- $EXPECTED_STORAGE:/storage" "$COMPOSE" || fail "storage uses the protected anchor"
 grep -q -- "- $EXPECTED_SHARED:/shared" "$COMPOSE" || fail "shared uses the protected anchor"
 grep -q 'PROTECT: "Y"' "$COMPOSE" || fail "web console is not password protected"
+grep -q 'LANGUAGE: "en-US"' "$COMPOSE" || fail "Windows language is missing"
+grep -q 'REGION: "en-US"' "$COMPOSE" || fail "Windows region is missing"
 [[ ! -L $HOME/.windows && ! -L $HOME/Windows ]] || fail "fresh sources stay real directories"
 [[ $(stat -Lc '%d:%i' "$HOME/.windows") == $(stat -Lc '%d:%i' "$EXPECTED_STORAGE") ]] || fail "storage bind did not pin source"
 [[ $(stat -Lc '%d:%i' "$HOME/Windows") == $(stat -Lc '%d:%i' "$EXPECTED_SHARED") ]] || fail "shared bind did not pin source"
@@ -73,7 +75,7 @@ pass "writer emits fixed anchors bound to exact private source inodes"
 rm -f "$COMPOSE"
 write 4G 2 64G 'x -v /:/h' p UTC 2>/dev/null && fail "malicious username accepted"
 [[ ! -f $COMPOSE ]] || fail "bad input wrote compose"
-printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=ok\nPASSWORD=p\nTZ=UTC\nSTORAGE=/\nSHARED=/etc\n' | __priv_write_compose
+printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=ok\nPASSWORD=p\nREGION=en-US\nSTORAGE=/\nSHARED=/etc\n' | __priv_write_compose
 grep -q -- "- $EXPECTED_STORAGE:/storage" "$COMPOSE" || fail "caller storage affected compose"
 grep -q -- '- /:/storage' "$COMPOSE" && fail "host root accepted as storage"
 write '4G; rm -rf /' 2 64G ok p UTC 2>/dev/null && fail "malicious RAM accepted"
@@ -169,7 +171,7 @@ ln -s / "$HOME/Windows"
 before_fds=$(fd_count)
 prepare_user_mount_sources 2>/dev/null && fail "root symlink passed user preflight"
 [[ -L $HOME/Windows && $(readlink "$HOME/Windows") == / ]] || fail "rejected symlink consumed"
-printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=x\nPASSWORD=p\nTZ=UTC\n' | __priv_write_compose 2>/dev/null && fail "root symlink passed privileged preflight"
+printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=x\nPASSWORD=p\nREGION=en-US\n' | __priv_write_compose 2>/dev/null && fail "root symlink passed privileged preflight"
 resolve_caller
 [[ $(mount_layer_count "$EXPECTED_STORAGE") == 0 && $(mount_layer_count "$EXPECTED_SHARED") == 0 ]] || fail "one source mounted before other failed"
 [[ $(fd_count) == "$before_fds" ]] || fail "source preflight leaked FD"
@@ -280,7 +282,7 @@ ln -s "$same" "$HOME/.windows"
 ln -s "$same" "$HOME/Windows"
 before_fds=$(fd_count)
 prepare_user_mount_sources 2>/dev/null && fail "same source passed user preflight"
-printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=x\nPASSWORD=p\nTZ=UTC\n' | __priv_write_compose 2>/dev/null && fail "same source passed root preflight"
+printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=x\nPASSWORD=p\nREGION=en-US\n' | __priv_write_compose 2>/dev/null && fail "same source passed root preflight"
 resolve_caller
 [[ $(mount_layer_count "$EXPECTED_STORAGE") == 0 && $(mount_layer_count "$EXPECTED_SHARED") == 0 ]] || fail "same source left mount"
 [[ $(fd_count) == "$before_fds" ]] || fail "same source leaked FDs"

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -150,7 +150,7 @@ actual_space=$(available_storage_gb)
 pass "disk-space accounting measures the actual storage filesystem, not home"
 
 # Exercise the real root writer and final guard against the production paths.
-printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=alice\nPASSWORD=pw\nTZ=UTC\n' |
+printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=alice\nPASSWORD=pw\nREGION=en-US\n' |
   with_vm_lock __priv_write_compose
 [[ $(command stat -Lc '%u:%a' "$COMPOSE_FILE") == 0:640 ]] || fail "root compose ownership/mode is wrong"
 with_vm_lock assert_mounts_safe || fail "final root mount/compose assertion rejected the verified pair"


### PR DESCRIPTION
## Problem

The Windows VM docker-compose.yml sets a `TZ` environment variable, but dockur/windows ignores it. The `TZ` variable only affects the Linux side of the container, not the Windows guest. This means the Windows VM always uses the default timezone (Pacific Time) regardless of the host system's locale settings.

## Solution

Replace `TZ` with the `LANGUAGE` and `REGION` environment variables that dockur/windows actually uses to configure the Windows guest timezone.

The Windows locale is derived from the system's `$LANG` variable (e.g., `en_US.UTF-8` → `en-US`). This matches the format dockur/windows expects for both `LANGUAGE` and `REGION`.

## Changes

- **`bin/omarchy-windows-vm`**:
  - Replace `valid_tz()` with `valid_region()` using the `xx-XX` format pattern
  - Update `__priv_write_compose()` to accept `REGION` instead of `TZ`
  - Set both `LANGUAGE` and `REGION` in the compose template
  - Derive region from `$LANG` in `install_windows()`
  - Update `migrate_legacy_compose()` to read `REGION` (falls back to `en-US`)
  - Remove `timedatectl` call (no longer needed)

## Fallback

Invalid or unsupported locale formats (e.g., `C`, `POSIX`, locales with `@` modifiers) fall back to `en-US`.

## Testing

- [x] Fresh install with `LANG=en_GB.UTF-8` → verify `LANGUAGE: "en-GB"` and `REGION: "en-GB"` in compose
- [x] Verified Windows VM uses correct timezone and regional settings after install
- [x] Legacy compose migration tested (old `TZ` values ignored, defaults to `en-US`)