### PR TITLE
Stop the keybindings cache key flipping on menu keyboard focus

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -528,10 +528,16 @@ output_binding_records_uncached() {
   [[ -n $dynamic ]]
 }
 
+# Hash only what the records are built from. The active keymap looks like part
+# of the input but is not: while an Omarchy menu holds keyboard focus, Hyprland
+# stops reporting an active keymap altogether, so hashing that line handed
+# every menu-open a second cache name and a cold build that deleted the cache
+# the next press wanted. Keycode resolution goes through xkbcli reading the
+# user's configured XKB defaults, not the session's transiently active keymap,
+# so `hyprctl devices` contributes nothing the cache depends on.
 keybindings_cache_key() {
   {
-    printf 'v13\n'
-    hyprctl devices 2>/dev/null | grep -F 'active keymap:'
+    printf 'v14\n'
     hyprctl binds 2>/dev/null
   } | sha256sum | awk '{ print $1 }'
 }

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -220,3 +220,30 @@ for action in "${expected_alternatives[@]}"; do
     fail "every action named as having an alternative is bound twice" "$action"
 done
 pass "every action named as having an alternative is bound twice"
+
+# While an Omarchy menu holds exclusive keyboard focus, Hyprland reports no
+# active keymap at all. A cache name that moves with that state hands every
+# alternating press a cold rebuild that deletes the cache it just replaced,
+# so the same binds have to land on one records file either way.
+stub_hyprctl <<BINDS
+$(exec_bind 64 "SUPER + K" "Keybindings" "omarchy-menu-keybindings")
+BINDS
+
+records_files() { find "$tmpdir/cache/omarchy" -maxdepth 1 -name 'keybindings-*.records'; }
+
+with_keymap=$(keybindings)
+(( $(records_files | wc -l) == 1 )) ||
+  fail "one press leaves exactly one records cache"
+name_with_keymap=$(records_files)
+
+sed -i 's/echo "active keymap: English (US)"/:/' "$stub_bin/hyprctl"
+
+without_keymap=$(keybindings)
+name_without_keymap=$(records_files)
+
+[[ $name_without_keymap == "$name_with_keymap" ]] ||
+  fail "the cache name ignores the transient active-keymap state" \
+    "$(basename "$name_with_keymap") vs $(basename "$name_without_keymap")"
+[[ $without_keymap == "$with_keymap" ]] ||
+  fail "the warm cache renders the same entries back"
+pass "the cache outlives a menu taking keyboard focus"


### PR DESCRIPTION
Fixes #8140.

## The bug

`keybindings_cache_key()` hashed the `active keymap:` line from `hyprctl devices` alongside `hyprctl binds`. While an Omarchy menu holds exclusive keyboard focus, Hyprland stops reporting an active keymap altogether, so the same binds produced two different cache names depending on whether a menu was open. Each successful refresh deletes sibling caches (`find ... ! -name "" -delete`), so every alternating press paid a ~540ms cold rebuild and threw away the cache it had just replaced. On the reporter's machine that meant Super+K was slow on nearly every press.

## The fix

Hash only what the records are built from:

- Drop the `hyprctl devices` line from the hash. Nothing in the pipeline consumes the session's active keymap: keycode resolution goes through `xkbcli compile-keymap`, which reads the user's configured XKB defaults, not Hyprland's transiently reported keymap.
- Bump the version marker v13 to v14 so caches written under old keys cannot be mistaken for current ones.

The sibling-cache cleanup stays as is: with a stable key there is normally exactly one live cache, and the deletion still clears stale entries after real config changes.

## Verification

Added a regression test in `test/shell.d/keybindings-menu-test.sh`: it renders once with the stub reporting `active keymap: English (US)`, flips the stub to report no keymap (the state while a menu has focus), renders again, and asserts both runs land on one records file and render identically.

- Against unfixed code the test fails: identical binds hash to two names (`6e9583...` vs `197c92...`).
- With this change the full `keybindings-menu-test.sh`, `bin-style-test.sh`, and `./test/cli` all pass.