### PR TITLE
Decode iw's escaped SSID before matching it against nmcli's

### DIFF
--- a/bin/omarchy-network-band
+++ b/bin/omarchy-network-band
@@ -49,7 +49,8 @@ band_for_freq() {
 # Every value read back from nmcli goes through here. LC_ALL=C because nmcli
 # translates state words such as "connected", which would silently stop matching
 # under a non-English session; `-e no` because `-g` otherwise escapes ':' and
-# '\' in values, and an escaped SSID would never match iw's raw one.
+# '\' in values, and nmcli's escaping is not iw's, so two differently escaped
+# spellings of one SSID would never match.
 nm_get() {
   LC_ALL=C nmcli -e no -g "$@" 2>/dev/null
 }
@@ -67,12 +68,23 @@ selected_band() {
   band_from_nm "$(nm_get 802-11-wireless.band connection show "$1")"
 }
 
+# iw prints an SSID through its own escaper: every byte that is not printable
+# ASCII becomes \xNN, as do a backslash and a leading or trailing space. So a
+# name carrying an accent, a CJK character or an emoji reaches us escaped while
+# nmcli prints it raw, and comparing the two as they arrive never matches. Turn
+# it back into the bytes the AP broadcasts, the way the panel's own
+# decodeIwSsid does. printf %b is enough on its own here: the only backslash iw
+# ever emits is the one opening an escape.
+decode_iw_ssid() {
+  printf '%b' "$1"
+}
+
 # Sets $ssid and $freq from one `iw dev <device> link`. iw prints the SSID as
 # the rest of its line, so an SSID containing ':' needs no special handling.
 read_link() {
   local link
   link=$(iw dev "$1" link 2>/dev/null)
-  ssid=$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")
+  ssid=$(decode_iw_ssid "$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")")
   freq=$(awk '/freq:/ { print $2; exit }' <<<"$link")
 }
 

--- a/test/shell.d/network-band-test.sh
+++ b/test/shell.d/network-band-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+# iw escapes every byte of an SSID that is not printable ASCII, so a name with
+# an accent in it arrives as \xNN even though nmcli prints the same name raw.
+cat >"$stub_bin/iw" <<'SH'
+#!/bin/bash
+
+[[ $1 == "dev" && $3 == "link" ]] || exit 1
+
+printf '%s\n' "Connected to 00:11:22:33:44:55 (on $2)"
+printf '\t%s\n' "SSID: ${OMARCHY_TEST_IW_SSID:-Caf\\xc3\\xa9}"
+printf '\t%s\n' "freq: ${OMARCHY_TEST_IW_FREQ:-5180}"
+SH
+
+cat >"$stub_bin/nmcli" <<'SH'
+#!/bin/bash
+
+args=("$@")
+fields=""
+for i in "${!args[@]}"; do
+  if [[ ${args[i]} == "-g" ]]; then
+    fields="${args[i + 1]}"
+    break
+  fi
+done
+
+case "$fields" in
+DEVICE,TYPE,STATE)
+  printf '%s\n' "wlan0:wifi:connected"
+  ;;
+GENERAL.CONNECTION)
+  printf '%s\n' "Home"
+  ;;
+FREQ,SSID)
+  printf '%s\n' "2412 MHz:${OMARCHY_TEST_NM_SSID:-Café}"
+  printf '%s\n' "5180 MHz:${OMARCHY_TEST_NM_SSID:-Café}"
+  printf '%s\n' "5745 MHz:Neighbour"
+  ;;
+802-11-wireless.band)
+  printf '%s\n' ""
+  ;;
+esac
+SH
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+
+status=$("$ROOT/bin/omarchy-network-band")
+
+expected=$'band\t5\navailable\t2.4 5\nselected\tauto'
+[[ $status == "$expected" ]] ||
+  fail "network band lists every band an escaped SSID answers on" "$(printf 'expected:\n%s\nactual:\n%s' "$expected" "$status")"
+pass "network band lists every band an escaped SSID answers on"
+
+# A plain ASCII SSID is printed identically by both tools and must keep working.
+plain=$(OMARCHY_TEST_IW_SSID="Home" OMARCHY_TEST_NM_SSID="Home" "$ROOT/bin/omarchy-network-band")
+
+[[ $plain == "$expected" ]] ||
+  fail "network band still matches an unescaped SSID" "$(printf 'expected:\n%s\nactual:\n%s' "$expected" "$plain")"
+pass "network band still matches an unescaped SSID"
+
+# An SSID whose name only differs from another by its escaped bytes must not
+# borrow that network's bands.
+other=$(OMARCHY_TEST_NM_SSID="Cafe" "$ROOT/bin/omarchy-network-band")
+
+expected_other=$'band\t5\navailable\t5\nselected\tauto'
+[[ $other == "$expected_other" ]] ||
+  fail "network band offers nothing a different SSID answers on" "$(printf 'expected:\n%s\nactual:\n%s' "$expected_other" "$other")"
+pass "network band offers nothing a different SSID answers on"
+
+if OMARCHY_TEST_NM_SSID="Cafe" "$ROOT/bin/omarchy-network-band" 2.4 2>/dev/null; then
+  fail "network band refuses a band the network does not answer on"
+fi
+pass "network band refuses a band the network does not answer on"


### PR DESCRIPTION
Fixes #8233.

`available_bands()` compares the SSID `iw dev <device> link` reports against the one `nmcli ... dev wifi list` reports. iw escapes every byte of an SSID that is not printable ASCII as `\xNN` (also a backslash, and a leading or trailing space); nmcli under `-e no` prints the raw bytes. So the two spellings of one network never match, the scan rows are all dropped, and `available_bands` returns only the band already in use — leaving one pill in the panel and `Error: <n>GHz is not available on this network.` for every other band.

Decode iw's escapes back to the bytes the AP broadcasts before the comparison, which is what `decodeIwSsid()` in `shell/plugins/panels/network/Model.js` already does for the same SSIDs on the same panel. `printf %b` is enough on its own: the only backslash iw ever emits is the one opening an escape (a literal `\` comes out as `\x5c`).

Also corrects the `nm_get` comment, which asserted iw's SSID was raw.

## Verification

New `test/shell.d/network-band-test.sh` stubs `iw` and `nmcli` around the real command:

```
ok - network band lists every band an escaped SSID answers on
ok - network band still matches an unescaped SSID
ok - network band offers nothing a different SSID answers on
ok - network band refuses a band the network does not answer on
```

Checked the test has teeth — on the unfixed script the first case reports `available 5` instead of `available 2.4 5` and the test fails.

`test/shell.d/bin-style-test.sh` and the rest of the network tests still pass. This is a Linux/NetworkManager path, so it was verified through the stubs rather than against a live radio; I have not run it on hardware with a non-ASCII SSID.
