### PR TITLE
Float Bitwarden extension popouts in all Chromium browsers

### DIFF
--- a/default/hypr/apps/bitwarden.lua
+++ b/default/hypr/apps/bitwarden.lua
@@ -1,6 +1,10 @@
 o.window("^(Bitwarden)$", { no_screen_share = true, tag = "+floating-window" })
 
-o.window("chrome-nngceckbapebfimnlniiiahkandclblb-Default", {
+-- The browser-extension popouts (passkey prompts, vault popouts) are matched by
+-- the extension ID alone: Chromium names these windows "<browser>-<extid>-Default",
+-- so a chrome-only prefix misses Brave, Edge, Vivaldi and the rest, leaving the
+-- popout tiled and too small to use.
+o.window(".*nngceckbapebfimnlniiiahkandclblb.*", {
   no_screen_share = true,
   tag = "+floating-window",
 })


### PR DESCRIPTION
## What happened

On Brave, the Bitwarden extension's passkey popout is tiled rather than floated, and ends up far too small to use — as small as **148x155** with several open at once. The confirm button is unreachable, so the WebAuthn ceremony never completes, the site retries, and each retry spawns another popout that shrinks the rest further.

Captured from the Hyprland event socket during one failed login — six popouts in a single second:

```
17:10:01 openwindow>>...,brave-nngceckbapebfimnlniiiahkandclblb-Default,_crx_nngceck...
17:10:01 openwindow>>...,brave-nngceckbapebfimnlniiiahkandclblb-Default,_crx_nngceck...
17:10:01 openwindow>>...,brave-nngceckbapebfimnlniiiahkandclblb-Default,_crx_nngceck...
17:10:01 openwindow>>...,brave-nngceckbapebfimnlniiiahkandclblb-Default,_crx_nngceck...
17:10:01 openwindow>>...,brave-nngceckbapebfimnlniiiahkandclblb-Default,_crx_nngceck...
17:10:01 openwindow>>...,brave-nngceckbapebfimnlniiiahkandclblb-Default,_crx_nngceck...
```

And the resulting windows:

```
class=brave-nngceckbapebfimnlniiiahkandclblb-Default floating=False size=[148, 155]
class=brave-nngceckbapebfimnlniiiahkandclblb-Default floating=False size=[148, 159]
class=brave-nngceckbapebfimnlniiiahkandclblb-Default floating=False size=[144, 328]
class=brave-nngceckbapebfimnlniiiahkandclblb-Default floating=False size=[306, 328]
class=brave-nngceckbapebfimnlniiiahkandclblb-Default floating=False size=[301, 670]
```

## Cause

`default/hypr/apps/bitwarden.lua` matched the popout as `chrome-<extid>-Default`. Chromium names these windows `<browser>-<extid>-Default`, so on Brave the class is `brave-<extid>-Default`, the rule misses, and the window never gets the `floating-window` tag. It works on Chrome and silently fails on every other Chromium browser.

## Expected

The popout floats, as it already does on Chrome.

## Fix

Match on the extension ID alone, which covers every Chromium browser. It also catches the `__popup_index.html` class variant that Chromium uses for some popouts, which the exact-class rule missed even on Chrome.

## Steps to reproduce

1. Brave with the Bitwarden extension, on Hyprland
2. Sign in to any site with a Bitwarden-stored passkey
3. The popout is tiled and too small to interact with; `hyprctl clients` shows `floating: False`

## System

- Omarchy 4.0.1-1
- Hyprland 0.56.2
- Brave 1:1.93.138-1, Bitwarden extension 2026.8.0
- ThinkPad X1 Yoga Gen 4, i5-8265U / UHD 620

## Verification

With the fix, the popout opens `floating = True` at 875x600.

`./test/all` — 201 files pass. Four fail (`config`, `snapper`, `theme-install-guards`, `unowned-system-paths`), but they fail identically on a clean `quattro` checkout on this machine, so they look environment-dependent and unrelated to this change.

## Possibly related, not addressed here

`default/hypr/apps/1password.lua` matches only `^(1[p|P]assword)$`, which is the desktop app class — so 1Password's browser-extension popouts may have the same gap. I have not reproduced it and did not want to widen this commit, so I have left it alone; worth a look by someone who uses it.
