### PR TITLE
Snap a bare capture click to the rectangle slurp highlighted

### DIFF
--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -335,22 +335,16 @@ smart | *)
   # A bare click (area < 20px^2) snaps to whichever rectangle it landed in,
   # so users don't end up with accidental 2px captures. X and Y can be
   # negative (Hyprland monitor positions in multi-display layouts).
+  #
+  # Through resolve_rect_at, so the click lands on the rectangle slurp was
+  # highlighting under the cursor: the smallest one containing the point.
+  # The candidates start with the monitors, which contain every click, so
+  # taking the first match instead would snap every click to the whole
+  # monitor and never to the window the user was pointing at.
   if [[ $SELECTION =~ ^(-?[0-9]+),(-?[0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]] && ((BASH_REMATCH[3] * BASH_REMATCH[4] < 20)); then
-    click_x=${BASH_REMATCH[1]}
-    click_y=${BASH_REMATCH[2]}
-
-    while IFS= read -r rect; do
-      [[ $rect =~ ^(-?[0-9]+),(-?[0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]] || continue
-      rect_x=${BASH_REMATCH[1]}
-      rect_y=${BASH_REMATCH[2]}
-      rect_width=${BASH_REMATCH[3]}
-      rect_height=${BASH_REMATCH[4]}
-
-      if ((click_x >= rect_x && click_x < rect_x + rect_width && click_y >= rect_y && click_y < rect_y + rect_height)); then
-        SELECTION="${rect_x},${rect_y} ${rect_width}x${rect_height}"
-        break
-      fi
-    done <<<"$RECTS"
+    if resolve_rect_at "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" <<<"$RECTS"; then
+      SELECTION=$RESOLVED_RECT
+    fi
   fi
   ;;
 esac

--- a/test/shell.d/capture-region-test.sh
+++ b/test/shell.d/capture-region-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+# One monitor with two overlapping windows on its active workspace: a tiled one
+# filling the left half and a floating one sitting inside it.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+case $1 in
+monitors)
+  printf '%s\n' '[{"name":"DP-1","focused":true,"x":0,"y":0,"width":2560,"height":1440,"scale":1,"transform":0,"activeWorkspace":{"id":1}}]'
+  ;;
+clients)
+  printf '%s\n' '[{"workspace":{"id":1},"at":[0,0],"size":[1280,1440]},{"workspace":{"id":1},"at":[400,500],"size":[400,300]}]'
+  ;;
+cursorpos)
+  printf '%s\n' "${OMARCHY_TEST_CURSOR:-500, 600}"
+  ;;
+esac
+SH
+
+cat >"$stub_bin/hyprpicker" <<'SH'
+#!/bin/bash
+sleep 5
+SH
+
+# slurp answers with whatever the test is simulating; a bare click comes back as
+# a 1x1 rectangle at the pointer.
+cat >"$stub_bin/slurp" <<'SH'
+#!/bin/bash
+cat >/dev/null
+printf '%s\n' "${OMARCHY_TEST_SLURP:-500,600 1x1}"
+SH
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export XDG_RUNTIME_DIR="$tmp_dir"
+
+selection=$("$ROOT/bin/omarchy-capture-region" smart)
+[[ $selection == "400,500 400x300" ]] ||
+  fail "a bare click snaps to the smallest rectangle under the pointer" "actual: $selection"
+pass "a bare click snaps to the smallest rectangle under the pointer"
+
+# A click in the part of the monitor no window covers still has the monitor to
+# fall back on.
+bare=$(OMARCHY_TEST_SLURP="2000,200 1x1" "$ROOT/bin/omarchy-capture-region" smart)
+[[ $bare == "0,0 2560x1440" ]] ||
+  fail "a bare click outside every window snaps to the monitor" "actual: $bare"
+pass "a bare click outside every window snaps to the monitor"
+
+# A real drag is the user's own rectangle and must survive untouched.
+drag=$(OMARCHY_TEST_SLURP="450,550 120x90" "$ROOT/bin/omarchy-capture-region" smart)
+[[ $drag == "450,550 120x90" ]] ||
+  fail "a dragged selection is left alone" "actual: $drag"
+pass "a dragged selection is left alone"
+
+# --match-monitor reports the monitor by name when the pick covers all of it.
+named=$(OMARCHY_TEST_SLURP="2000,200 1x1" "$ROOT/bin/omarchy-capture-region" smart --match-monitor)
+[[ $named == "monitor:DP-1" ]] ||
+  fail "a monitor-sized pick is reported by name" "actual: $named"
+pass "a monitor-sized pick is reported by name"


### PR DESCRIPTION
Fixes #8237.

The click-to-snap path in `smart` mode walked the candidate list and took the first rectangle containing the point. `get_rectangles()` prints the monitors before the windows and a monitor contains every click on it, so a bare click always resolved to the whole screen — never to the window slurp had highlighted under the pointer.

Resolve it through `resolve_rect_at()` instead, which already implements the rule the rest of the file uses: smallest containing rectangle, first one on a tie, matching slurp's own highlight and `geo_at_cursor()`.

## Verification

New `test/shell.d/capture-region-test.sh` stubs `hyprctl`, `hyprpicker` and `slurp` around the real command, with a floating window inside a tiled one inside a monitor:

```
ok - a bare click snaps to the smallest rectangle under the pointer
ok - a bare click outside every window snaps to the monitor
ok - a dragged selection is left alone
ok - a monitor-sized pick is reported by name
```

On the unfixed script the first case returns `0,0 2560x1440` instead of `400,500 400x300`, so the test has teeth. `screenrecording-test.sh` and `bin-style-test.sh` still pass.

Note: #6986 also touches `bin/omarchy-capture-region`, on a different concern (gathering rectangles across all monitors). This change is confined to the click-snap block and should rebase cleanly either way.
