### PR TITLE
Force hardware cursors for the shot, not for the region picker

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -38,8 +38,16 @@ PROCESSING="${2:-slurp}"
 #
 # Software-composited cursors (Hyprland's fallback on GPUs without working
 # hardware cursors) are baked into the frames grim captures, so force
-# hardware cursors until after grim runs and restore the setting on exit.
+# hardware cursors for the capture itself and restore the setting on exit.
+#
+# Only for the capture. Software cursors are what a machine whose hardware
+# cursor plane does not work is left with -- nouveau on older NVIDIA GPUs,
+# vmwgfx in a VMware guest -- and Omarchy turns them on itself there
+# (install/user/hardware/fix-nouveau-cursor.sh). Forcing them off around the
+# picker takes the pointer off the screen for the whole selection, which is
+# exactly the part of a screenshot that needs one.
 NO_HW_CURSORS=$(hyprctl getoption cursor:no_hardware_cursors -j | jq '.int')
+FORCED_HW_CURSORS=false
 
 set_no_hw_cursors() {
   hyprctl eval "hl.config({ cursor = { no_hardware_cursors = $1 } })" &>/dev/null ||
@@ -48,14 +56,18 @@ set_no_hw_cursors() {
 
 cleanup() {
   [[ -n $FREEZE_PID ]] && kill $FREEZE_PID 2>/dev/null
-  set_no_hw_cursors "$NO_HW_CURSORS"
+  [[ $FORCED_HW_CURSORS == true ]] && set_no_hw_cursors "$NO_HW_CURSORS"
 }
 trap cleanup EXIT
 
-set_no_hw_cursors 0
 { read -r FREEZE_PID; read -r SELECTION; } < <(omarchy-capture-region "$MODE" --keep-freeze)
 
 [[ -z $SELECTION ]] && exit 0
+
+# The screen is frozen and the selection is made; nobody is pointing at
+# anything now, so the pointer can move to its own plane for the shot.
+FORCED_HW_CURSORS=true
+set_no_hw_cursors 0
 
 FILENAME="screenshot-$(date +'%Y-%m-%d_%H-%M-%S').png"
 FILEPATH="$OUTPUT_DIR/$FILENAME"

--- a/test/shell.d/screenshot-cursor-test.sh
+++ b/test/shell.d/screenshot-cursor-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin" "$tmp_dir/shots"
+
+export OMARCHY_TEST_CALLS="$tmp_dir/calls"
+: >"$OMARCHY_TEST_CALLS"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "getoption" ]]; then
+  printf '%s\n' '{"option":"cursor:no_hardware_cursors","int":1,"set":true}'
+  exit 0
+fi
+
+printf 'hyprctl %s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+
+cat >"$stub_bin/omarchy-capture-region" <<'SH'
+#!/bin/bash
+
+printf 'pick %s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+printf '\n'
+printf '%s\n' "0,0 100x100"
+SH
+
+cat >"$stub_bin/grim" <<'SH'
+#!/bin/bash
+
+printf 'grim %s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+: >"${@: -1}"
+SH
+
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+for stub in wl-copy omarchy-notification-send; do
+  printf '#!/bin/bash\ncat >/dev/null 2>&1 || true\n' >"$stub_bin/$stub"
+done
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export HOME="$tmp_dir"
+export OMARCHY_SCREENSHOT_DIR="$tmp_dir/shots"
+
+"$ROOT/bin/omarchy-capture-screenshot" region save >/dev/null
+
+calls=$(<"$OMARCHY_TEST_CALLS")
+force_line=$(grep -n 'no_hardware_cursors = 0' <<<"$calls" | head -1 | cut -d: -f1)
+pick_line=$(grep -n '^pick ' <<<"$calls" | head -1 | cut -d: -f1)
+grim_line=$(grep -n '^grim ' <<<"$calls" | head -1 | cut -d: -f1)
+restore_line=$(grep -n 'no_hardware_cursors = 1' <<<"$calls" | head -1 | cut -d: -f1)
+
+[[ -n $force_line && -n $pick_line && -n $grim_line && -n $restore_line ]] ||
+  fail "the screenshot forces and restores hardware cursors around the capture" "$calls"
+
+# Software cursors are the only pointer a machine with a broken hardware cursor
+# plane has, so the picker has to run with the setting the user is on.
+(( pick_line < force_line )) ||
+  fail "hardware cursors are not forced until the region has been picked" "$calls"
+pass "hardware cursors are not forced until the region has been picked"
+
+(( force_line < grim_line )) ||
+  fail "hardware cursors are forced before grim captures the frame" "$calls"
+pass "hardware cursors are forced before grim captures the frame"
+
+(( grim_line < restore_line )) ||
+  fail "the previous cursor setting is restored after the capture" "$calls"
+pass "the previous cursor setting is restored after the capture"
+
+# A cancelled pick never changes the setting, so it has nothing to put back.
+cat >"$stub_bin/omarchy-capture-region" <<'SH'
+#!/bin/bash
+
+printf '\n'
+SH
+chmod +x "$stub_bin/omarchy-capture-region"
+: >"$OMARCHY_TEST_CALLS"
+
+"$ROOT/bin/omarchy-capture-screenshot" region save >/dev/null
+
+if grep -q 'no_hardware_cursors' "$OMARCHY_TEST_CALLS"; then
+  fail "a cancelled pick leaves the cursor setting alone" "$(<"$OMARCHY_TEST_CALLS")"
+fi
+pass "a cancelled pick leaves the cursor setting alone"


### PR DESCRIPTION
Fixes #8240.

The pointer setting was flipped before `omarchy-capture-region` ran, so the entire selection happened with hardware cursors forced on. On machines whose hardware cursor plane does not land — nouveau on older NVIDIA GPUs, vmwgfx in a VMware guest, both of which Omarchy switches to software cursors itself — that takes the pointer off screen for exactly as long as the user is trying to point at something.

Move the override to after the pick, with the screen already frozen, so it still keeps a software cursor out of grim's frame without costing the selection its pointer. Restore only when it was actually changed, so a cancelled pick writes nothing back.

## Verification

New `test/shell.d/screenshot-cursor-test.sh` stubs `hyprctl`, `omarchy-capture-region` and `grim`, and asserts the call order:

```
ok - hardware cursors are not forced until the region has been picked
ok - hardware cursors are forced before grim captures the frame
ok - the previous cursor setting is restored after the capture
ok - a cancelled pick leaves the cursor setting alone
```

On the unfixed script the first case fails — the force lands before the pick. `screenrecording-test.sh` and `bin-style-test.sh` still pass.

I do not have nouveau or a VMware guest here, so the pointer behaviour itself is argued from `install/user/hardware/fix-nouveau-cursor.sh` and #7918 rather than observed; what is verified locally is the ordering and the capture path.
