### PR TITLE
Enhance screensaver with media playback checks and DND management

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -6,9 +6,34 @@
 pgrep -f '[o]rg.omarchy.screensaver' && exit 0
 
 # Allow screensaver to be turned off but also force started
-if omarchy-toggle-enabled screensaver-off && [[ $1 != "force" ]]; then
+if [[ $1 != "force" ]] && omarchy-toggle-enabled screensaver-off; then
   exit 1
 fi
+
+media_playing=false
+if [[ $1 != "force" ]] && [[ $(playerctl status 2>/dev/null) == "Playing" ]]; then
+  media_playing=true
+fi
+
+monitors_to_blank=()
+while IFS=':' read -r id name; do
+  if $media_playing; then
+    if hyprctl clients -j | jq -e "any(.monitor == $id and (.fullscreen == true or .fullscreen == 1))" >/dev/null 2>&1; then
+      continue
+    fi
+  fi
+  monitors_to_blank+=("$name")
+done < <(hyprctl monitors -j | jq -r '.[] | "\(.id):\(.name)"')
+
+if ((${#monitors_to_blank[@]} == 0)); then
+  exit 0
+fi
+
+# Save DND state and set it to on
+if ! [[ -f /tmp/omarchy_screensaver_dnd_state ]]; then
+  omarchy-shell notifications isDnd > /tmp/omarchy_screensaver_dnd_state 2>/dev/null || echo "off" > /tmp/omarchy_screensaver_dnd_state
+fi
+omarchy-shell notifications setDnd on >/dev/null 2>&1
 
 focused=$(omarchy-hyprland-monitor-focused)
 terminal=$(xdg-terminal-exec --print-id)
@@ -49,7 +74,7 @@ wait_for_screensaver_window() {
   done
 }
 
-for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+for m in "${monitors_to_blank[@]}"; do
   hypr_focus_monitor "$m"
 
   case $terminal in

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -8,6 +8,15 @@ screensaver_in_focus() {
 
 exit_screensaver() {
   hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
+  
+  if [[ -f /tmp/omarchy_screensaver_dnd_state ]]; then
+    local state=$(cat /tmp/omarchy_screensaver_dnd_state 2>/dev/null)
+    if [[ -n $state ]]; then
+      omarchy-shell notifications setDnd "$state" >/dev/null 2>&1
+    fi
+    rm -f /tmp/omarchy_screensaver_dnd_state
+  fi
+
   pkill -x ttfx 2>/dev/null
   pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null
   exit 0

--- a/test_monitor.sh
+++ b/test_monitor.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+monitors_to_blank=()
+while IFS=':' read -r id name; do
+  echo "Found monitor ID: $id, Name: $name"
+  monitors_to_blank+=("$name")
+done < <(hyprctl monitors -j | jq -r '.[] | "\(.id):\(.name)"')
+echo "Monitors to blank: ${monitors_to_blank[@]}"

--- a/test_monitor.sh
+++ b/test_monitor.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-monitors_to_blank=()
-while IFS=':' read -r id name; do
-  echo "Found monitor ID: $id, Name: $name"
-  monitors_to_blank+=("$name")
-done < <(hyprctl monitors -j | jq -r '.[] | "\(.id):\(.name)"')
-echo "Monitors to blank: ${monitors_to_blank[@]}"


### PR DESCRIPTION
 ## Enhance screensaver with media playback awareness and DND integration

 ### Summary

This PR improves the screensaver behavior to prevent interruptions when media is playing in fullscreen and suppresses notifications by managing the Do Not Disturb (DND) state while the screensaver is active. 
### Key Changes
  • Media Playback Detection: Added checks using playerctl to determine if media is actively playing.
  • Selective Monitor Blanking: If media is playing, the screensaver will no longer activate on monitors displaying a fullscreen application. Other monitors will still blank appropriately.
  • Do Not Disturb Integration:
      • The omarchy-launch-screensaver script now captures the system's current DND state and saves it to /tmp/omarchy_screensaver_dnd_state.
      • Automatically enables DND while the screensaver is running, preventing visual or audible notification interruptions.
      • The omarchy-screensaver exit routine gracefully restores the original DND state and cleans up the temporary state file when exiting.

 ### Rationale

Previously, the screensaver would interrupt fullscreen media playback (like watching a movie) unless explicitly toggled off. This change introduces context awareness, skipping blanking on active fullscreen media monitors. Furthermore, this enhances privacy by stopping notifications showing while on screensaver, which usually starts when you're away from your computer.