### PR TITLE
Add a copy action for the revealed wifi password

### DIFF
--- a/shell/plugins/panels/wifiqr/Panel.qml
+++ b/shell/plugins/panels/wifiqr/Panel.qml
@@ -38,6 +38,31 @@ Item {
   property bool passwordVisible: false
   property string passwordError: ""
   property bool pwExpectedStop: false
+  property bool copied: false
+
+  function copyPassword() {
+    if (!root.passwordVisible || root.password === "") return
+    // wl-clipboard ships with the base install (the emojis plugin relies on
+    // it). The secret reaches wl-copy as an argv element, never a shell.
+    copyProc.command = ["wl-copy", "--", root.password]
+    copyProc.running = true
+    root.copied = true
+    copiedTimer.restart()
+  }
+
+  Timer {
+    id: copiedTimer
+    interval: 1600
+    onTriggered: root.copied = false
+  }
+
+  Process {
+    id: copyProc
+    onExited: function(exitCode) {
+      if (exitCode !== 0) root.copied = false
+    }
+  }
+
 
   readonly property bool showingQr: qrSize > 0 && !loading && error === ""
 
@@ -237,6 +262,10 @@ Item {
       focus: true
 
       Keys.onEscapePressed: root.dismiss()
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_C && !(event.modifiers & Qt.ControlModifier) && root.passwordVisible)
+          root.copyPassword()
+      }
 
       Item {
         anchors.centerIn: parent
@@ -359,8 +388,25 @@ Item {
               onClicked: root.togglePassword()
             }
           }
+          Text {
+            visible: root.showingQr && root.secured && root.passwordVisible && root.passwordError === ""
+            text: root.copied ? "Copied ✓" : "Copy password"
+            color: root.copied ? "#7ee787" : root.onScrimDim
+            opacity: root.copied ? 1 : 0.85
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.underline: !root.copied
+            Layout.alignment: Qt.AlignHCenter
+
+            MouseArea {
+              anchors.fill: parent
+              cursorShape: Qt.PointingHandCursor
+              onClicked: root.copyPassword()
+            }
+          }
         }
       }
     }
   }
 }
+

--- a/shell/plugins/panels/wifiqr/Panel.qml
+++ b/shell/plugins/panels/wifiqr/Panel.qml
@@ -40,11 +40,18 @@ Item {
   property bool pwExpectedStop: false
   property bool copied: false
 
+  function resetCopied() {
+    copiedTimer.stop()
+    root.copied = false
+  }
+
   function copyPassword() {
-    if (!root.passwordVisible || root.password === "") return
+    if (!root.passwordVisible || root.password === "" || copyProc.running) return
     // wl-clipboard ships with the base install (the emojis plugin relies on
-    // it). The secret reaches wl-copy as an argv element, never a shell.
-    copyProc.command = ["wl-copy", "--", root.password]
+    // it). Mark the secret so Omarchy's clipboard watcher does not persist it,
+    // and pass it over stdin so it is not exposed in wl-copy's argv.
+    copyProc.stdinEnabled = true
+    copyProc.command = ["wl-copy", "--sensitive", "--type", "text/plain;charset=utf-8"]
     copyProc.running = true
     root.copied = true
     copiedTimer.restart()
@@ -58,8 +65,20 @@ Item {
 
   Process {
     id: copyProc
+    stdinEnabled: true
+    onStarted: {
+      // wl-copy reads stdin to EOF. Closing the write channel after write()
+      // flushes the password and lets wl-copy take ownership of the selection.
+      write(root.password)
+      stdinEnabled = false
+    }
     onExited: function(exitCode) {
-      if (exitCode !== 0) root.copied = false
+      // Re-enable stdin for the next run; this process's channel stays closed.
+      stdinEnabled = true
+      if (exitCode !== 0) {
+        copiedTimer.stop()
+        root.copied = false
+      }
     }
   }
 
@@ -110,6 +129,7 @@ Item {
     root.password = ""
     root.passwordVisible = false
     root.passwordError = ""
+    root.resetCopied()
   }
 
   function dismiss() {
@@ -145,6 +165,7 @@ Item {
     password = ""
     passwordVisible = false
     passwordError = ""
+    root.resetCopied()
     if (pwProc.running) {
       pwExpectedStop = true
       pwProc.running = false
@@ -409,4 +430,3 @@ Item {
     }
   }
 }
-


### PR DESCRIPTION
When you reveal the password on the wifi share card, a small **Copy password** line appears right below it. Clicking it places the password on the clipboard, the label flips to Copied for about two seconds, and pressing **c** does the same while the password is visible.

Built by [ArnoStride](https://x.com/ArnoStride).

### How it works

Copies through wl-copy, which the base install already relies on. The password is passed to wl-copy as a single argument and never touches a shell. The copied flag follows the same lifecycle as the password itself: dropped on close and on regeneration, so no secret outlives the card. If wl-copy fails, the success label clears instead of claiming it worked.

### Why

The QR covers phones, but laptops still end up typing the password by hand. This removes the retyping using tooling that is already present, and adds no new dependencies.

### Tested

Secured network on real hardware: reveal, click copy, paste elsewhere, hotkey path, closing and reopening between different networks, and the wl-copy failure path.
