### PR TITLE
Stop shipping world-writable browser enterprise policies

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -7,8 +7,11 @@
 set -e
 
 setup_policy_directory() {
-  sudo mkdir -p "$1"
-  sudo chmod a+rw "$1"
+  # An enterprise policy trust root: the browser reads what lands here as
+  # administrator-managed policy, so it is root-owned and not writable by
+  # ordinary users. omarchy-theme-set-browser-policy is the privileged half that
+  # writes the theme color into it.
+  sudo install -d -m 0755 -o root -g root "$1"
 }
 
 announce_browser_installed() {
@@ -27,7 +30,11 @@ setup_firefox_preferences() {
   local distribution_dir="$1"
 
   setup_policy_directory "$distribution_dir"
-  sudo cp -f "$OMARCHY_PATH/default/firefox/policies.json" "$distribution_dir/policies.json"
+  # install rather than cp: cp onto an existing file keeps that file's mode and
+  # owner, which on an install predating the tightening above is whatever was
+  # written into the world-writable directory.
+  sudo install -m 0644 -o root -g root \
+    "$OMARCHY_PATH/default/firefox/policies.json" "$distribution_dir/policies.json"
 }
 
 setup_firefox_wayland() {

--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -5,20 +5,23 @@
 
 CHROMIUM_THEME=$HOME/.local/state/omarchy/current/theme/chromium.theme
 
+# A neutral grey, used for a theme that ships no color and for a chromium.theme
+# this cannot read as an RGB triple.
+THEME_HEX_COLOR="1c2027"
+
 if [[ -f $CHROMIUM_THEME ]]; then
-  THEME_RGB_COLOR=$(<$CHROMIUM_THEME)
-  THEME_HEX_COLOR=$(printf '#%02x%02x%02x' ${THEME_RGB_COLOR//,/ })
-else
-  # Use a default, neutral grey if theme doesn't have a color
-  THEME_HEX_COLOR="#1c2027"
+  theme_rgb=$(<$CHROMIUM_THEME)
+
+  # Themes are user-installed, so read the file as data. Handing unvetted words
+  # to printf does not produce a color: printf repeats its format for extra
+  # arguments and errors on non-numeric ones, so a malformed or hostile
+  # chromium.theme could put something other than six hex digits downstream.
+  # Take the value only when it is exactly three 0-255 components.
+  if [[ $theme_rgb =~ ^[[:space:]]*([0-9]{1,3})[[:space:]]*,[[:space:]]*([0-9]{1,3})[[:space:]]*,[[:space:]]*([0-9]{1,3})[[:space:]]*$ ]] &&
+    ((BASH_REMATCH[1] < 256 && BASH_REMATCH[2] < 256 && BASH_REMATCH[3] < 256)); then
+    THEME_HEX_COLOR=$(printf '%02x%02x%02x' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}")
+  fi
 fi
-
-set_browser_policy() {
-  local policy_dir="$1"
-
-  [[ -d $policy_dir ]] || return
-  echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "$policy_dir/color.json" >/dev/null
-}
 
 refresh_running_browser() {
   local process="$1"
@@ -30,16 +33,16 @@ refresh_running_browser() {
   fi
 }
 
-set_browser_policy /etc/chromium/policies/managed
+# The policy directories are enterprise policy trust roots, so they are
+# root-owned and not writable by ordinary users. omarchy-theme-set-browser-policy
+# is the privileged half that writes color.json into the ones that exist; it
+# takes root of its own and accepts nothing but the color. It covers every
+# browser in one call, so this runs it once and then refreshes whatever is up.
+omarchy-theme-set-browser-policy "$THEME_HEX_COLOR"
+
 refresh_running_browser chromium chromium
-
-set_browser_policy /etc/opt/chrome/policies/managed
 refresh_running_browser chrome google-chrome-stable || refresh_running_browser chrome google-chrome
-
-set_browser_policy /etc/opt/edge/policies/managed
 refresh_running_browser msedge microsoft-edge-stable
-
-set_browser_policy /etc/brave/policies/managed
 refresh_running_browser brave brave
 # Match on the binary path: the running process is named plain "brave", and a
 # bare -f brave-origin pattern would also match the installer's own terminal.

--- a/bin/omarchy-theme-set-browser-policy
+++ b/bin/omarchy-theme-set-browser-policy
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# omarchy:summary=Write the current theme color into the browser policy directories
+# omarchy:args=<rrggbb>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+# Whenever this runs as root — invoked directly through the passwordless
+# sudoers rule, or re-execed by require_root below — sudo's secure_path decides
+# where a bare helper resolves, and a dev link (etc/sudoers.d/omarchy-dev-path)
+# prepends a user-writable checkout bin/ to it. Every helper this script calls
+# by bare name (printf's builtin aside: chmod, mv, rm) is a system tool, never
+# an omarchy-* command, so pin PATH to trusted system directories and keep root
+# from resolving one out of that checkout. The unprivileged wrapper phase keeps
+# the caller's PATH so it can still find sudo.
+if (( EUID == 0 )); then
+  export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+fi
+
+# Enterprise policy trust roots. Browsers read every JSON file under these as
+# administrator-managed policy, so they stay root-owned and not writable by
+# ordinary users, and this helper is the only thing Omarchy points at them with
+# root. The list is fixed here rather than taken from the caller: the caller
+# chooses a color, never a path.
+POLICY_DIRS=(
+  /etc/chromium/policies/managed
+  /etc/opt/chrome/policies/managed
+  /etc/opt/edge/policies/managed
+  /etc/brave/policies/managed
+)
+
+# The path etc/sudoers.d/omarchy-theme-browser names. The privileged half always
+# runs from there rather than from whichever copy was invoked, so the rule
+# matches even where $OMARCHY_PATH points at a checkout.
+PACKAGED_PATH=/usr/bin/omarchy-theme-set-browser-policy
+
+usage() {
+  echo "Usage: omarchy-theme-set-browser-policy <rrggbb>" >&2
+}
+
+if (( $# != 1 )); then
+  usage
+  exit 1
+fi
+
+color="$1"
+
+# The color reaches this helper from the current theme's chromium.theme, which
+# lives under the user's own state directory and is therefore chosen by whoever
+# installed the theme. Six lowercase hex digits is the whole of what this
+# accepts, so nothing out of that file can land in a policy file as anything but
+# a color. The leading "#" is added when the JSON is written rather than passed
+# in: "#" opens a comment in sudoers, and keeping it out of argv lets the
+# sudoers rule spell the argument as a plain six-character glob.
+if [[ ! $color =~ ^[0-9a-f]{6}$ ]]; then
+  echo "omarchy-theme-set-browser-policy: expected six lowercase hex digits, got '$color'" >&2
+  exit 1
+fi
+
+# True when sudo would run this exact command without stopping for a password.
+# `sudo -l` on its own reports whether a command is permitted, which the blanket
+# %wheel rule answers yes to for everything; the long listing prints the matched
+# entry's tags, so !authenticate is the grant in
+# etc/sudoers.d/omarchy-theme-browser and nothing else. Listing runs nothing
+# and, under -n, prompts for nothing.
+sudo_grants_passwordless() {
+  sudo -n -l -l "$PACKAGED_PATH" "$@" 2>/dev/null | grep -q '!authenticate'
+}
+
+require_root() {
+  if (( EUID == 0 )); then
+    return
+  elif [[ -t 0 ]] || sudo_grants_passwordless "$@"; then
+    # A terminal can carry sudo's own password prompt. Without one, sudo is
+    # right only where the grant reaches.
+    exec sudo "$PACKAGED_PATH" "$@"
+  else
+    # Unlike omarchy-dns, this does not fall back to pkexec. It runs unattended
+    # on every theme switch, and a browser accent color does not justify putting
+    # an authentication dialog on screen. Where the grant does not reach — an
+    # install still on an older omarchy-settings, or a user outside %wheel —
+    # leave the policy directories alone and let the rest of the theme apply.
+    exit 0
+  fi
+}
+
+require_root "$color"
+
+staged=""
+cleanup() {
+  [[ -n $staged ]] && rm -f "$staged"
+}
+trap cleanup EXIT
+
+for policy_dir in "${POLICY_DIRS[@]}"; do
+  # Only browsers Omarchy has installed have a policy directory. Creating one
+  # here would hand a browser a managed-policy root it does not otherwise have.
+  [[ -d $policy_dir ]] || continue
+
+  staged="$policy_dir/.color.json.omarchy"
+  printf '{"BrowserThemeColor": "#%s", "BrowserColorScheme": "device"}\n' "$color" >"$staged"
+  chmod 0644 "$staged"
+  # Replacing through a staged file in the same directory gives the policy this
+  # run's root ownership and mode instead of inheriting whatever the
+  # world-writable era left on the old file, and never leaves a browser reading
+  # a half-written policy.
+  mv -f "$staged" "$policy_dir/color.json"
+  staged=""
+done

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1312,7 +1312,9 @@ apply_system_transition() {
     /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
   as_root gtk-update-icon-cache /usr/share/icons/Yaru >/dev/null 2>&1 || true
 
-  as_root install -d -m 0777 /etc/chromium/policies/managed
+  # 0755, not 0777: this is an enterprise policy trust root, and
+  # omarchy-theme-set-browser-policy takes root to write the theme color into it.
+  as_root install -d -m 0755 /etc/chromium/policies/managed
   as_root install -d -m 0755 /usr/lib/chromium
   printf '%s\n' '{"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}' | \
     as_root tee /usr/lib/chromium/initial_preferences >/dev/null

--- a/etc/sudoers.d/omarchy-theme-browser
+++ b/etc/sudoers.d/omarchy-theme-browser
@@ -1,0 +1,8 @@
+# Theme switching is a menu action with no terminal to carry a password prompt,
+# and it repaints the browser accent on every switch, so this one write must not
+# stop for a password. The argument is spelled out as six hex digits rather than
+# a wildcard: the grant covers a color and nothing else, and sudoers matches a
+# command's arguments exactly, so it cannot be stretched into extra ones. The
+# helper revalidates the same shape, since the terminal path does not come
+# through this rule.
+%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-theme-set-browser-policy [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]

--- a/install/config/theme-system.sh
+++ b/install/config/theme-system.sh
@@ -6,9 +6,11 @@ ln -snf /usr/share/icons/Adwaita/symbolic/actions/go-next-symbolic.svg \
           /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
 gtk-update-icon-cache /usr/share/icons/Yaru &>/dev/null || true
 
-# Chromium policy directory for theme
-mkdir -p /etc/chromium/policies/managed
-chmod a+rw /etc/chromium/policies/managed
+# Chromium policy directory for theme. This is an enterprise policy trust root:
+# Chromium reads every JSON file here as administrator-managed policy, so it
+# stays root-owned and not writable by ordinary users.
+# omarchy-theme-set-browser-policy takes root of its own to write color.json.
+install -d -m 0755 -o root -g root /etc/chromium/policies/managed
 
 # Default Chromium to follow system appearance ("device") instead of dark
 mkdir -p /usr/lib/chromium

--- a/migrations/1787677233.sh
+++ b/migrations/1787677233.sh
@@ -8,10 +8,26 @@ echo "Close the world-writable browser policy directories"
 # extension, a proxy, a disabled protection -- without ever holding root.
 # omarchy-theme-set-browser-policy now takes root for that one write, so put the
 # directories back to 0755 root:root.
+#
+# Restoring the mode is not enough on its own. While a directory was writable,
+# an ordinary account could move the real one aside and leave its own in place,
+# or leave behind a policy file it still owns. Either survives a chmod: the
+# directory reports a tight mode while its owner can still reopen it, and the
+# file stays writable by the account that planted it. So this checks ownership
+# as well as mode, and moves anything an ordinary account still controls out of
+# the trust root rather than leaving it live.
 
 # Prefixed so the test can point the whole scan at a fixture. Empty in every
 # real run.
 prefix="${OMARCHY_BROWSER_POLICY_ROOT:-}"
+
+# Root-only, and outside the browser policy tree: a copy left beside the
+# original would still be read as policy. Mirrors the full path the way
+# omarchy-update-system-pkgs-when-conflicted does.
+quarantine="${OMARCHY_BROWSER_POLICY_QUARANTINE:-$prefix/var/lib/omarchy/quarantine/browser-policy}"
+
+# uid 0 everywhere but the test, which cannot create root-owned fixtures.
+expected_owner="${OMARCHY_BROWSER_POLICY_OWNER:-0}"
 
 policy_dirs=(
   "$prefix/etc/chromium/policies/managed"
@@ -29,7 +45,8 @@ distribution_dirs=(
 # mode lands on every directory the command had to create, so a machine with no
 # /etc/chromium before the upgrade got a world-writable parent chain too. A
 # writable parent is as good as a writable policy directory: it lets any user
-# rename the real one aside and put their own in its place.
+# rename the real one aside and put their own in its place. Shallowest first, so
+# a compromised parent is dealt with before the children it carries.
 parent_dirs=(
   "$prefix/etc/chromium"
   "$prefix/etc/chromium/policies"
@@ -41,19 +58,40 @@ parent_dirs=(
   "$prefix/etc/brave/policies"
 )
 
-loose=()
-for dir in "${policy_dirs[@]}" "${distribution_dirs[@]}" "${parent_dirs[@]}"; do
-  [[ -d $dir ]] || continue
+# Paths carry no "|", so a joined string is set enough for this.
+present_marker=""
+repair_marker=""
 
+present() { [[ $present_marker == *"|$1|"* ]]; }
+needs_repair() { [[ $repair_marker == *"|$1|"* ]]; }
+
+for dir in "${parent_dirs[@]}" "${policy_dirs[@]}" "${distribution_dirs[@]}"; do
+  # -L first, because the checks below cannot speak for a symlink. [[ -d ]] and
+  # chmod follow one; stat does not, so it would report the link's own 0777
+  # rather than anything about the directory finally written to. A link whose
+  # target does not exist yet fails [[ -d ]] outright and would be skipped
+  # entirely, leaving the path for its owner to fill in later.
+  if [[ -L $dir ]]; then
+    present_marker+="|$dir|"
+    repair_marker+="|$dir|"
+    continue
+  fi
+
+  [[ -d $dir ]] || continue
+  present_marker+="|$dir|"
+
+  owner=$(stat -c '%u' "$dir" 2>/dev/null) || continue
   mode=$(stat -c '%a' "$dir" 2>/dev/null) || continue
-  # Group- or other-writable. Migrations run once per user, so on a machine
-  # another user already repaired nothing reports loose and this no-ops.
-  if ((8#$mode & 022)); then
-    loose+=("$dir")
+
+  # Not root's, or group- or other-writable.
+  if [[ $owner != "$expected_owner" ]] || ((8#$mode & 022)); then
+    repair_marker+="|$dir|"
   fi
 done
 
-if ((${#loose[@]} == 0)); then
+# Migrations run once per user, so on a machine another user already repaired
+# nothing needs repair and this no-ops.
+if [[ -z $repair_marker ]]; then
   exit 0
 fi
 
@@ -63,56 +101,118 @@ else
   elevate() { pkexec "$@"; }
 fi
 
-for dir in "${loose[@]}"; do
-  echo "  Tightening $dir"
+unexpected=()
+
+quarantine_path() {
+  local path="$1"
+  local reason="$2"
+  local target="$quarantine$path"
+  local n=1
+
+  while [[ -e $target || -L $target ]]; do
+    target="$quarantine$path.$n"
+    n=$((n + 1))
+  done
+
+  elevate install -d -m 0700 -o root -g root "${target%/*}"
+  elevate mv -T "$path" "$target"
+  echo "  Quarantined $path"
+  echo "    $reason"
+  echo "    Moved to $target"
+}
+
+# Leaves the path a real, root-owned, 0755 directory, whatever was there before.
+ensure_root_dir() {
+  local dir="$1"
+  local owner
+
+  if [[ -L $dir ]]; then
+    quarantine_path "$dir" "the policy directory had been replaced by a symlink"
+  elif [[ -d $dir ]]; then
+    owner=$(stat -c '%u' "$dir")
+    if [[ $owner != "$expected_owner" ]]; then
+      quarantine_path "$dir" "the policy directory was owned by uid $owner, not root"
+    fi
+  fi
+
+  # install -d applies the mode only to the last component, which is why every
+  # parent is on the list above. It also recreates a directory whose compromised
+  # parent was just quarantined out from under it.
+  elevate install -d -m 0755 -o root -g root "$dir"
+}
+
+# Parents before the directories they carry.
+for dir in "${parent_dirs[@]}" "${policy_dirs[@]}" "${distribution_dirs[@]}"; do
+  present "$dir" || continue
+  ensure_root_dir "$dir"
 done
 
-elevate chmod 0755 "${loose[@]}"
+for dir in "${policy_dirs[@]}" "${distribution_dirs[@]}"; do
+  [[ -d $dir ]] || continue
 
-# color.json is Omarchy's own file and it sat in a directory anyone could write,
-# so its contents are not trusted and it is not chowned into place. Remove it and
-# let omarchy-theme-set-browser regenerate it through the privileged helper.
-stale_color=()
-for dir in "${policy_dirs[@]}"; do
-  [[ -f $dir/color.json ]] && stale_color+=("$dir/color.json")
+  for file in "$dir"/*; do
+    [[ -f $file || -L $file ]] || continue
+
+    name=${file##*/}
+
+    # A symlink in a policy directory is never Omarchy's, and the install below
+    # would write straight through it as root.
+    if [[ -L $file ]]; then
+      quarantine_path "$file" "a policy file had been replaced by a symlink"
+      continue
+    fi
+
+    # Omarchy's own files. Both sat where anyone could write, so neither is
+    # trusted: color.json is regenerated by the repaint below, and policies.json
+    # is reinstalled from the shipped copy.
+    if [[ $name == "color.json" && $dir != *"/distribution" ]]; then
+      elevate rm -f "$file"
+      continue
+    fi
+    if [[ $name == "policies.json" && $dir == *"/distribution" ]]; then
+      elevate rm -f "$file"
+      continue
+    fi
+
+    owner=$(stat -c '%u' "$file")
+    mode=$(stat -c '%a' "$file")
+
+    # A file an ordinary account owns, or can still write, stays under that
+    # account's control after this migration. Reporting it would leave it live,
+    # so move it out of the trust root instead.
+    if [[ $owner != "$expected_owner" ]] || ((8#$mode & 022)); then
+      quarantine_path "$file" "an ordinary account could still change this policy file"
+      continue
+    fi
+
+    # Root's, and no ordinary account can write it. distribution.ini is the
+    # browser package's own file; anything else is most likely a policy this
+    # machine's administrator put there deliberately, and deleting that would be
+    # its own bug. Neither is under an attacker's control, so both stay.
+    if [[ $name != "distribution.ini" ]]; then
+      unexpected+=("$file")
+    fi
+  done
 done
 
-if ((${#stale_color[@]} > 0)); then
-  elevate rm -f "${stale_color[@]}"
-fi
-
-# Same reasoning for policies.json, except Omarchy ships the authoritative copy,
-# so restore it rather than dropping it. distribution.ini belongs to the browser
-# package and is left alone.
+# Omarchy ships the authoritative Firefox/Zen policy. Restore it wherever this
+# migration had to repair the directory: an account that could write the
+# directory could equally have deleted the file, so keying on the file still
+# being there would leave the policy missing.
 for dir in "${distribution_dirs[@]}"; do
-  [[ -f $dir/policies.json ]] || continue
+  present "$dir" || continue
+  needs_repair "$dir" || [[ -f $dir/policies.json ]] || continue
 
   elevate install -m 0644 -o root -g root \
     "${OMARCHY_PATH:-/usr/share/omarchy}/default/firefox/policies.json" "$dir/policies.json"
 done
 
-# Anything else in a policy directory is either a policy the machine's admin put
-# there deliberately or one planted while the directory was open to everyone.
-# There is no way to tell them apart from here, so report them and change
-# nothing: deleting a real admin policy would be its own bug.
-unexpected=()
-for dir in "${policy_dirs[@]}" "${distribution_dirs[@]}"; do
-  [[ -d $dir ]] || continue
-
-  for file in "$dir"/*; do
-    [[ -f $file ]] || continue
-    case "${file##*/}" in
-    color.json | policies.json | distribution.ini) continue ;;
-    esac
-    unexpected+=("$file")
-  done
-done
-
 if ((${#unexpected[@]} > 0)); then
   echo
   echo "  These files were in a browser policy directory while it was writable by any"
-  echo "  local user. Omarchy did not put them there and has left them in place."
-  echo "  Review them, and remove any you do not recognize:"
+  echo "  local user. They belong to root and no ordinary account can change them now,"
+  echo "  so Omarchy has left them in place. Review them, and remove any you do not"
+  echo "  recognize:"
   for file in "${unexpected[@]}"; do
     echo "    $file"
   done

--- a/migrations/1787677233.sh
+++ b/migrations/1787677233.sh
@@ -1,0 +1,124 @@
+echo "Close the world-writable browser policy directories"
+
+# Browser enterprise policy directories are trust roots: browsers read every
+# JSON file under policies/managed, and Firefox/Zen read distribution/
+# policies.json, as administrator-managed policy. Omarchy used to make those
+# directories world-writable so an unprivileged theme switch could drop
+# color.json in, which let any local account install browser policy -- a forced
+# extension, a proxy, a disabled protection -- without ever holding root.
+# omarchy-theme-set-browser-policy now takes root for that one write, so put the
+# directories back to 0755 root:root.
+
+# Prefixed so the test can point the whole scan at a fixture. Empty in every
+# real run.
+prefix="${OMARCHY_BROWSER_POLICY_ROOT:-}"
+
+policy_dirs=(
+  "$prefix/etc/chromium/policies/managed"
+  "$prefix/etc/opt/chrome/policies/managed"
+  "$prefix/etc/opt/edge/policies/managed"
+  "$prefix/etc/brave/policies/managed"
+)
+
+distribution_dirs=(
+  "$prefix/usr/lib/firefox/distribution"
+  "$prefix/opt/zen-browser/distribution"
+)
+
+# The quattro transition created the chromium directory with mode 0777, and that
+# mode lands on every directory the command had to create, so a machine with no
+# /etc/chromium before the upgrade got a world-writable parent chain too. A
+# writable parent is as good as a writable policy directory: it lets any user
+# rename the real one aside and put their own in its place.
+parent_dirs=(
+  "$prefix/etc/chromium"
+  "$prefix/etc/chromium/policies"
+  "$prefix/etc/opt/chrome"
+  "$prefix/etc/opt/chrome/policies"
+  "$prefix/etc/opt/edge"
+  "$prefix/etc/opt/edge/policies"
+  "$prefix/etc/brave"
+  "$prefix/etc/brave/policies"
+)
+
+loose=()
+for dir in "${policy_dirs[@]}" "${distribution_dirs[@]}" "${parent_dirs[@]}"; do
+  [[ -d $dir ]] || continue
+
+  mode=$(stat -c '%a' "$dir" 2>/dev/null) || continue
+  # Group- or other-writable. Migrations run once per user, so on a machine
+  # another user already repaired nothing reports loose and this no-ops.
+  if ((8#$mode & 022)); then
+    loose+=("$dir")
+  fi
+done
+
+if ((${#loose[@]} == 0)); then
+  exit 0
+fi
+
+if [[ -t 0 ]]; then
+  elevate() { sudo "$@"; }
+else
+  elevate() { pkexec "$@"; }
+fi
+
+for dir in "${loose[@]}"; do
+  echo "  Tightening $dir"
+done
+
+elevate chmod 0755 "${loose[@]}"
+
+# color.json is Omarchy's own file and it sat in a directory anyone could write,
+# so its contents are not trusted and it is not chowned into place. Remove it and
+# let omarchy-theme-set-browser regenerate it through the privileged helper.
+stale_color=()
+for dir in "${policy_dirs[@]}"; do
+  [[ -f $dir/color.json ]] && stale_color+=("$dir/color.json")
+done
+
+if ((${#stale_color[@]} > 0)); then
+  elevate rm -f "${stale_color[@]}"
+fi
+
+# Same reasoning for policies.json, except Omarchy ships the authoritative copy,
+# so restore it rather than dropping it. distribution.ini belongs to the browser
+# package and is left alone.
+for dir in "${distribution_dirs[@]}"; do
+  [[ -f $dir/policies.json ]] || continue
+
+  elevate install -m 0644 -o root -g root \
+    "${OMARCHY_PATH:-/usr/share/omarchy}/default/firefox/policies.json" "$dir/policies.json"
+done
+
+# Anything else in a policy directory is either a policy the machine's admin put
+# there deliberately or one planted while the directory was open to everyone.
+# There is no way to tell them apart from here, so report them and change
+# nothing: deleting a real admin policy would be its own bug.
+unexpected=()
+for dir in "${policy_dirs[@]}" "${distribution_dirs[@]}"; do
+  [[ -d $dir ]] || continue
+
+  for file in "$dir"/*; do
+    [[ -f $file ]] || continue
+    case "${file##*/}" in
+    color.json | policies.json | distribution.ini) continue ;;
+    esac
+    unexpected+=("$file")
+  done
+done
+
+if ((${#unexpected[@]} > 0)); then
+  echo
+  echo "  These files were in a browser policy directory while it was writable by any"
+  echo "  local user. Omarchy did not put them there and has left them in place."
+  echo "  Review them, and remove any you do not recognize:"
+  for file in "${unexpected[@]}"; do
+    echo "    $file"
+  done
+  echo
+fi
+
+# Repaint the browser accent through the privileged helper, so the color removed
+# above comes back in this update rather than at the next theme switch.
+omarchy-theme-set-browser || true

--- a/test/shell.d/browser-policy-migration-test.sh
+++ b/test/shell.d/browser-policy-migration-test.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Close the world-writable browser policy directories' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "browser policy permission migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+
+# The migration elevates to chmod, remove and install. Run those directly against
+# the fixture rather than reaching the real system. Both elevation paths are
+# stubbed: the migration picks between them on whether it has a terminal, and
+# which one a test run gets is not something to depend on.
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+
+cat >"$stub_bin/pkexec" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+
+# -o root -g root cannot be honoured by a test that is not root, and the
+# ownership is not what these assertions are about.
+cat >"$stub_bin/install" <<'STUB'
+#!/bin/bash
+args=()
+while (($# > 0)); do
+  case "$1" in
+  -o | -g)
+    shift 2
+    ;;
+  *)
+    args+=("$1")
+    shift
+    ;;
+  esac
+done
+exec /usr/bin/install "${args[@]}"
+STUB
+
+cat >"$stub_bin/omarchy-theme-set-browser" <<'STUB'
+#!/bin/bash
+printf 'called\n' >>"$THEME_LOG"
+STUB
+
+chmod +x "$stub_bin/sudo" "$stub_bin/pkexec" "$stub_bin/install" "$stub_bin/omarchy-theme-set-browser"
+
+fixture=""
+
+new_fixture() {
+  fixture="$TMPDIR/root-$1"
+  rm -rf "$fixture"
+  mkdir -p "$fixture/etc/chromium/policies/managed" \
+    "$fixture/etc/brave/policies/managed" \
+    "$fixture/usr/lib/firefox/distribution"
+}
+
+# omarchy-migrate runs each migration with `bash -euo pipefail` and stops the
+# whole chain on a non-zero exit, so match that invocation exactly.
+run_migration() {
+  : >"$TMPDIR/theme-log"
+  PATH="$stub_bin:$PATH" \
+    OMARCHY_BROWSER_POLICY_ROOT="$fixture" \
+    OMARCHY_PATH="$ROOT" \
+    THEME_LOG="$TMPDIR/theme-log" \
+    bash -euo pipefail "$migration" >"$TMPDIR/out" 2>&1
+}
+
+mode_of() {
+  stat -c '%a' "$1"
+}
+
+# A machine as the quattro upgrade left it: world-writable policy directory with
+# a color.json an unprivileged theme switch wrote into it.
+new_fixture loose
+chmod 0777 "$fixture/etc/chromium/policies/managed"
+chmod 0777 "$fixture/usr/lib/firefox/distribution"
+echo '{"BrowserThemeColor": "#1c2027"}' >"$fixture/etc/chromium/policies/managed/color.json"
+echo '{"planted": true}' >"$fixture/etc/chromium/policies/managed/evil.json"
+echo 'tampered' >"$fixture/usr/lib/firefox/distribution/policies.json"
+echo 'pkg' >"$fixture/usr/lib/firefox/distribution/distribution.ini"
+
+run_migration || fail "migration succeeds on a world-writable install"
+
+[[ $(mode_of "$fixture/etc/chromium/policies/managed") == "755" ]] ||
+  fail "migration tightens the chromium policy directory" "got: $(mode_of "$fixture/etc/chromium/policies/managed")"
+[[ $(mode_of "$fixture/usr/lib/firefox/distribution") == "755" ]] ||
+  fail "migration tightens the firefox distribution directory" "got: $(mode_of "$fixture/usr/lib/firefox/distribution")"
+
+# color.json sat in a directory anyone could write, so it is dropped rather than
+# trusted, and regenerated through the privileged helper.
+[[ ! -e $fixture/etc/chromium/policies/managed/color.json ]] ||
+  fail "migration drops the untrusted color.json"
+[[ -s $TMPDIR/theme-log ]] ||
+  fail "migration repaints the browser accent through omarchy-theme-set-browser"
+
+# Omarchy ships the authoritative policies.json, so that one is restored.
+cmp -s "$ROOT/default/firefox/policies.json" "$fixture/usr/lib/firefox/distribution/policies.json" ||
+  fail "migration restores the shipped firefox policies.json"
+[[ $(mode_of "$fixture/usr/lib/firefox/distribution/policies.json") == "644" ]] ||
+  fail "migration installs policies.json 0644"
+
+# A file Omarchy did not put there could equally be a real admin policy, so it is
+# reported and left alone.
+[[ -e $fixture/etc/chromium/policies/managed/evil.json ]] ||
+  fail "migration leaves an unrecognized policy file in place"
+grep -q 'evil.json' "$TMPDIR/out" ||
+  fail "migration reports an unrecognized policy file" "got: $(<"$TMPDIR/out")"
+[[ -e $fixture/usr/lib/firefox/distribution/distribution.ini ]] ||
+  fail "migration leaves the browser package's distribution.ini alone"
+
+pass "migration tightens loose browser policy directories and distrusts what was in them"
+
+# A writable parent is as good as a writable policy directory, so the whole chain
+# the 0777 install could have created is checked.
+new_fixture parents
+chmod 0777 "$fixture/etc/chromium" "$fixture/etc/chromium/policies"
+run_migration || fail "migration succeeds on a world-writable parent chain"
+
+[[ $(mode_of "$fixture/etc/chromium") == "755" ]] ||
+  fail "migration tightens /etc/chromium" "got: $(mode_of "$fixture/etc/chromium")"
+[[ $(mode_of "$fixture/etc/chromium/policies") == "755" ]] ||
+  fail "migration tightens /etc/chromium/policies" "got: $(mode_of "$fixture/etc/chromium/policies")"
+
+pass "migration tightens a world-writable policy parent directory"
+
+# Already repaired, by an earlier run or by another user on the same machine.
+# Migrations run once per user, so this has to be a silent no-op that changes
+# nothing -- including not dropping a color.json that is now trustworthy.
+new_fixture tight
+echo 'keep' >"$fixture/etc/chromium/policies/managed/color.json"
+run_migration || fail "migration succeeds on an already-tightened install"
+
+[[ $(<"$fixture/etc/chromium/policies/managed/color.json") == "keep" ]] ||
+  fail "migration leaves a color.json alone once the directory is not writable"
+[[ ! -s $TMPDIR/theme-log ]] ||
+  fail "migration does no work when nothing is loose"
+
+pass "migration no-ops once the policy directories are tight"
+
+# Group-writable is not safe either: it is the same grant to a smaller set.
+new_fixture group
+chmod 0775 "$fixture/etc/brave/policies/managed"
+run_migration || fail "migration succeeds on a group-writable directory"
+[[ $(mode_of "$fixture/etc/brave/policies/managed") == "755" ]] ||
+  fail "migration tightens a group-writable policy directory" "got: $(mode_of "$fixture/etc/brave/policies/managed")"
+
+pass "migration tightens group-writable policy directories too"
+
+# Nothing to repair on a machine with no browser policy directories at all.
+new_fixture empty
+rm -rf "$fixture"
+mkdir -p "$fixture"
+run_migration || fail "migration succeeds where no browser policy directory exists"
+
+pass "migration no-ops where no browser policy directory exists"

--- a/test/shell.d/browser-policy-migration-test.sh
+++ b/test/shell.d/browser-policy-migration-test.sh
@@ -11,7 +11,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 stub_bin="$TMPDIR/bin"
 mkdir -p "$stub_bin"
 
-# The migration elevates to chmod, remove and install. Run those directly against
+# The migration elevates to install, move and remove. Run those directly against
 # the fixture rather than reaching the real system. Both elevation paths are
 # stubbed: the migration picks between them on whether it has a terminal, and
 # which one a test run gets is not something to depend on.
@@ -25,8 +25,8 @@ cat >"$stub_bin/pkexec" <<'STUB'
 exec "$@"
 STUB
 
-# -o root -g root cannot be honoured by a test that is not root, and the
-# ownership is not what these assertions are about.
+# -o root -g root cannot be honoured by a test that is not root, and ownership is
+# steered by OMARCHY_BROWSER_POLICY_OWNER below rather than by real uids.
 cat >"$stub_bin/install" <<'STUB'
 #!/bin/bash
 args=()
@@ -51,15 +51,21 @@ STUB
 
 chmod +x "$stub_bin/sudo" "$stub_bin/pkexec" "$stub_bin/install" "$stub_bin/omarchy-theme-set-browser"
 
+quarantine="$TMPDIR/quarantine"
 fixture=""
 
 new_fixture() {
   fixture="$TMPDIR/root-$1"
-  rm -rf "$fixture"
+  rm -rf "$fixture" "$quarantine"
   mkdir -p "$fixture/etc/chromium/policies/managed" \
     "$fixture/etc/brave/policies/managed" \
     "$fixture/usr/lib/firefox/distribution"
 }
+
+# The fixture's directories belong to whoever runs the suite, so that uid stands
+# in for root. A case that needs a directory to look foreign passes a different
+# one.
+owner_uid=$(id -u)
 
 # omarchy-migrate runs each migration with `bash -euo pipefail` and stops the
 # whole chain on a non-zero exit, so match that invocation exactly.
@@ -67,6 +73,8 @@ run_migration() {
   : >"$TMPDIR/theme-log"
   PATH="$stub_bin:$PATH" \
     OMARCHY_BROWSER_POLICY_ROOT="$fixture" \
+    OMARCHY_BROWSER_POLICY_QUARANTINE="$quarantine" \
+    OMARCHY_BROWSER_POLICY_OWNER="${OWNER_OVERRIDE:-$owner_uid}" \
     OMARCHY_PATH="$ROOT" \
     THEME_LOG="$TMPDIR/theme-log" \
     bash -euo pipefail "$migration" >"$TMPDIR/out" 2>&1
@@ -76,13 +84,17 @@ mode_of() {
   stat -c '%a' "$1"
 }
 
+# Where the migration parks a path it moved out of the trust root.
+quarantined() {
+  echo "$quarantine$1"
+}
+
 # A machine as the quattro upgrade left it: world-writable policy directory with
 # a color.json an unprivileged theme switch wrote into it.
 new_fixture loose
 chmod 0777 "$fixture/etc/chromium/policies/managed"
 chmod 0777 "$fixture/usr/lib/firefox/distribution"
 echo '{"BrowserThemeColor": "#1c2027"}' >"$fixture/etc/chromium/policies/managed/color.json"
-echo '{"planted": true}' >"$fixture/etc/chromium/policies/managed/evil.json"
 echo 'tampered' >"$fixture/usr/lib/firefox/distribution/policies.json"
 echo 'pkg' >"$fixture/usr/lib/firefox/distribution/distribution.ini"
 
@@ -105,17 +117,123 @@ cmp -s "$ROOT/default/firefox/policies.json" "$fixture/usr/lib/firefox/distribut
   fail "migration restores the shipped firefox policies.json"
 [[ $(mode_of "$fixture/usr/lib/firefox/distribution/policies.json") == "644" ]] ||
   fail "migration installs policies.json 0644"
-
-# A file Omarchy did not put there could equally be a real admin policy, so it is
-# reported and left alone.
-[[ -e $fixture/etc/chromium/policies/managed/evil.json ]] ||
-  fail "migration leaves an unrecognized policy file in place"
-grep -q 'evil.json' "$TMPDIR/out" ||
-  fail "migration reports an unrecognized policy file" "got: $(<"$TMPDIR/out")"
 [[ -e $fixture/usr/lib/firefox/distribution/distribution.ini ]] ||
   fail "migration leaves the browser package's distribution.ini alone"
 
 pass "migration tightens loose browser policy directories and distrusts what was in them"
+
+# A file an ordinary account can still write keeps that account in control of
+# administrator policy after the directory is tightened, so reporting it is not
+# enough: it has to leave the trust root.
+new_fixture planted
+chmod 0777 "$fixture/etc/chromium/policies/managed"
+echo '{"planted": true}' >"$fixture/etc/chromium/policies/managed/evil.json"
+chmod 0666 "$fixture/etc/chromium/policies/managed/evil.json"
+# Root's own, and no ordinary account can write it: most likely a real admin
+# policy, and deleting that would be its own bug.
+echo '{"admin": true}' >"$fixture/etc/chromium/policies/managed/admin.json"
+chmod 0644 "$fixture/etc/chromium/policies/managed/admin.json"
+
+run_migration || fail "migration succeeds with planted policy files"
+
+[[ ! -e $fixture/etc/chromium/policies/managed/evil.json ]] ||
+  fail "migration removes a writable policy file from the trust root"
+[[ -f $(quarantined "$fixture/etc/chromium/policies/managed/evil.json") ]] ||
+  fail "migration quarantines the writable policy file rather than deleting it"
+grep -q 'Quarantined' "$TMPDIR/out" ||
+  fail "migration reports what it quarantined" "got: $(<"$TMPDIR/out")"
+
+[[ -f $fixture/etc/chromium/policies/managed/admin.json ]] ||
+  fail "migration leaves a root-owned, unwritable policy file in place"
+grep -q 'admin.json' "$TMPDIR/out" ||
+  fail "migration reports the policy file it left in place" "got: $(<"$TMPDIR/out")"
+
+pass "migration quarantines policy files an ordinary account can still change"
+
+# stat and chmod both follow a symlink, so a policy directory swapped for a link
+# reports the target's mode and would otherwise pass for tight.
+new_fixture symlink
+elsewhere="$TMPDIR/attacker-dir"
+rm -rf "$elsewhere"
+mkdir -p "$elsewhere"
+chmod 0755 "$elsewhere"
+rm -rf "$fixture/etc/chromium/policies/managed"
+ln -s "$elsewhere" "$fixture/etc/chromium/policies/managed"
+
+run_migration || fail "migration succeeds where a policy directory is a symlink"
+
+[[ ! -L $fixture/etc/chromium/policies/managed ]] ||
+  fail "migration replaces a symlinked policy directory with a real one"
+[[ -d $fixture/etc/chromium/policies/managed ]] ||
+  fail "migration leaves a real policy directory behind"
+[[ $(mode_of "$fixture/etc/chromium/policies/managed") == "755" ]] ||
+  fail "migration creates the replacement policy directory 0755"
+[[ -d $elsewhere ]] ||
+  fail "migration does not follow the link and delete what it pointed at"
+
+pass "migration replaces a symlinked policy directory instead of chmod'ing through it"
+
+# A link to a target that does not exist yet fails [[ -d ]], so nothing but the
+# -L check keeps the scan from skipping the path and leaving its owner free to
+# create the target later. Nothing else in this fixture is loose, so the scan is
+# the only thing that can put the path on the repair list.
+new_fixture dangling
+rm -rf "$fixture/etc/chromium/policies/managed"
+ln -s "$TMPDIR/does-not-exist" "$fixture/etc/chromium/policies/managed"
+
+run_migration || fail "migration succeeds where a policy directory is a dangling symlink"
+
+[[ ! -L $fixture/etc/chromium/policies/managed ]] ||
+  fail "migration replaces a dangling symlinked policy directory"
+[[ -d $fixture/etc/chromium/policies/managed ]] ||
+  fail "migration leaves a real policy directory where a dangling link was"
+[[ ! -e $TMPDIR/does-not-exist ]] ||
+  fail "migration does not create what the dangling link pointed at"
+
+pass "migration replaces a dangling symlinked policy directory"
+
+# A directory an ordinary account owns can be reopened by that account at any
+# time, whatever mode it currently reports.
+new_fixture owner
+echo '{"planted": true}' >"$fixture/etc/chromium/policies/managed/evil.json"
+OWNER_OVERRIDE=$((owner_uid + 1)) run_migration ||
+  fail "migration succeeds where the policy directories are not root's"
+
+[[ -d $fixture/etc/chromium/policies/managed ]] ||
+  fail "migration leaves a policy directory behind after quarantining a foreign one"
+[[ ! -e $fixture/etc/chromium/policies/managed/evil.json ]] ||
+  fail "migration carries the contents of a foreign policy directory out of the trust root"
+[[ -e $(quarantined "$fixture/etc/chromium") ]] ||
+  fail "migration quarantines the foreign directory"
+
+pass "migration quarantines a policy directory an ordinary account owns"
+
+# An account that could write the distribution directory could equally have
+# deleted the policy Omarchy ships, so restoration cannot key on the file still
+# being there.
+new_fixture deleted
+chmod 0777 "$fixture/usr/lib/firefox/distribution"
+rm -f "$fixture/usr/lib/firefox/distribution/policies.json"
+
+run_migration || fail "migration succeeds where policies.json was deleted"
+
+cmp -s "$ROOT/default/firefox/policies.json" "$fixture/usr/lib/firefox/distribution/policies.json" ||
+  fail "migration restores a policies.json that was deleted while the directory was writable"
+
+pass "migration restores a deleted firefox policy"
+
+# A distribution directory Omarchy never opened belongs to the browser package.
+# Repairing chromium is no reason to start managing someone else's Firefox.
+new_fixture untouched
+chmod 0777 "$fixture/etc/chromium/policies/managed"
+rm -f "$fixture/usr/lib/firefox/distribution/policies.json"
+
+run_migration || fail "migration succeeds with a pristine distribution directory"
+
+[[ ! -e $fixture/usr/lib/firefox/distribution/policies.json ]] ||
+  fail "migration leaves a distribution directory it did not have to repair alone"
+
+pass "migration does not install a policy into a distribution directory it never opened"
 
 # A writable parent is as good as a writable policy directory, so the whole chain
 # the 0777 install could have created is checked.

--- a/test/shell.d/browser-policy-test.sh
+++ b/test/shell.d/browser-policy-test.sh
@@ -81,13 +81,6 @@ printf 'sudo %s\n' "$*" >"$ELEVATION_LOG"
 SH
 chmod +x "$stub_bin/sudo"
 
-# Running as root skips require_root entirely, and the helper would then write
-# this machine's real browser policy directories.
-if ((EUID == 0)); then
-  pass "running as root; skipping the elevation checks, which would rewrite this machine's browser policy"
-  exit 0
-fi
-
 elevation_for() {
   : >"$test_tmp/elevation"
   ELEVATION_LOG="$test_tmp/elevation" \
@@ -96,33 +89,42 @@ elevation_for() {
   cat "$test_tmp/elevation"
 }
 
-elevation=$(elevation_for 1c2027)
-[[ $elevation == "sudo /usr/bin/omarchy-theme-set-browser-policy 1c2027" ]] ||
-  fail "omarchy-theme-set-browser-policy takes the passwordless sudo grant without a terminal" \
-    "got: $elevation"
+# require_root returns immediately for root, so a run that passes validation
+# would fall through to the write and rewrite this machine's real policy
+# directories. Only the valid-color scenarios reach that far: everything below
+# is either rejected before require_root or does not run the helper at all, so
+# the guard stays around these and no further.
+if ((EUID == 0)); then
+  pass "running as root; skipping the valid-color elevation checks, which would rewrite this machine's browser policy"
+else
+  elevation=$(elevation_for 1c2027)
+  [[ $elevation == "sudo /usr/bin/omarchy-theme-set-browser-policy 1c2027" ]] ||
+    fail "omarchy-theme-set-browser-policy takes the passwordless sudo grant without a terminal" \
+      "got: $elevation"
 
-# A dev-linked checkout elevates the packaged path like everyone else, rather
-# than handing sudo a path no rule can name and losing the grant.
-dev_linked=$(OMARCHY_PATH="$test_tmp/checkout" elevation_for 1c2027)
-[[ $dev_linked == "sudo /usr/bin/omarchy-theme-set-browser-policy 1c2027" ]] ||
-  fail "omarchy-theme-set-browser-policy elevates the system install wherever OMARCHY_PATH points" \
-    "got: $dev_linked"
+  # A dev-linked checkout elevates the packaged path like everyone else, rather
+  # than handing sudo a path no rule can name and losing the grant.
+  dev_linked=$(OMARCHY_PATH="$test_tmp/checkout" elevation_for 1c2027)
+  [[ $dev_linked == "sudo /usr/bin/omarchy-theme-set-browser-policy 1c2027" ]] ||
+    fail "omarchy-theme-set-browser-policy elevates the system install wherever OMARCHY_PATH points" \
+      "got: $dev_linked"
 
-pass "browser policy helper elevates a valid color through the sudo grant"
+  pass "browser policy helper elevates a valid color through the sudo grant"
 
-# Where the grant does not reach and there is no terminal, the helper leaves the
-# policy alone. A browser accent color does not justify an authentication dialog
-# on every theme switch, so this must not reach pkexec either.
-ungranted=$(STUB_GRANTED="" elevation_for 1c2027)
-[[ -z $ungranted ]] ||
-  fail "omarchy-theme-set-browser-policy stays quiet where the grant does not reach" "got: $ungranted"
+  # Where the grant does not reach and there is no terminal, the helper leaves
+  # the policy alone. A browser accent color does not justify an authentication
+  # dialog on every theme switch, so this must not reach pkexec either.
+  ungranted=$(STUB_GRANTED="" elevation_for 1c2027)
+  [[ -z $ungranted ]] ||
+    fail "omarchy-theme-set-browser-policy stays quiet where the grant does not reach" "got: $ungranted"
 
-if ! STUB_GRANTED="" PATH="$stub_bin:$PATH" ELEVATION_LOG="$test_tmp/elevation" \
-  bash "$helper" 1c2027 </dev/null >/dev/null 2>&1; then
-  fail "omarchy-theme-set-browser-policy succeeds when it declines to elevate, so the rest of the theme applies"
+  if ! STUB_GRANTED="" PATH="$stub_bin:$PATH" ELEVATION_LOG="$test_tmp/elevation" \
+    bash "$helper" 1c2027 </dev/null >/dev/null 2>&1; then
+    fail "omarchy-theme-set-browser-policy succeeds when it declines to elevate, so the rest of the theme applies"
+  fi
+
+  pass "browser policy helper skips the write rather than prompting where the grant is absent"
 fi
-
-pass "browser policy helper skips the write rather than prompting where the grant is absent"
 
 # Validation runs before any elevation, so a rejected argument never reaches
 # sudo. Anything but six lowercase hex digits is rejected, and the sudoers glob

--- a/test/shell.d/browser-policy-test.sh
+++ b/test/shell.d/browser-policy-test.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+helper="$ROOT/bin/omarchy-theme-set-browser-policy"
+setter="$ROOT/bin/omarchy-theme-set-browser"
+sudoers_file="$ROOT/etc/sudoers.d/omarchy-theme-browser"
+rule='%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-theme-set-browser-policy [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]'
+
+# Exactly one rule, matched whole. Dropping the argument -- which sudoers reads
+# as "any arguments" -- or widening the glob to `*` would let the grant carry
+# something other than a color while leaving this line looking right.
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
+[[ $rules == "$rule" ]] ||
+  fail "browser policy sudoers file carries exactly the six-hex-digit rule and nothing else" "got: $rules"
+
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers_file" >/dev/null || fail "browser policy sudoers rule parses"
+fi
+
+grep -Fx 'PACKAGED_PATH=/usr/bin/omarchy-theme-set-browser-policy' "$helper" >/dev/null ||
+  fail "omarchy-theme-set-browser-policy elevates the path the sudoers rule names"
+
+grep -E 'sudo -n -l -l' "$helper" >/dev/null ||
+  fail "omarchy-theme-set-browser-policy reads the grant from the long sudo listing"
+
+# Same reasoning as omarchy-dns: the privileged half runs under sudo's
+# secure_path, and a dev link prepends a user-writable checkout bin/ to it.
+grep -Eq '^\s*export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin' "$helper" ||
+  fail "omarchy-theme-set-browser-policy pins PATH to trusted system directories when it holds root"
+gated=$(grep -A1 -E '^if \(\( EUID == 0 \)\); then$' "$helper" || true)
+[[ $gated == *"export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin"* ]] ||
+  fail "omarchy-theme-set-browser-policy gates the trusted-PATH pin on holding root"
+
+pass "browser policy sudoers rule is scoped to a single color argument"
+
+# The directories are enterprise policy trust roots and the caller only ever
+# picks a color, so the paths are fixed in the script. A path assembled from
+# argv would let the grant write policy anywhere.
+for dir in /etc/chromium/policies/managed /etc/opt/chrome/policies/managed \
+  /etc/opt/edge/policies/managed /etc/brave/policies/managed; do
+  grep -Fx "  $dir" "$helper" >/dev/null ||
+    fail "omarchy-theme-set-browser-policy names $dir in its fixed policy directory list"
+done
+
+policy_dir_count=$(sed -n '/^POLICY_DIRS=(/,/^)/p' "$helper" | grep -c '^  /')
+((policy_dir_count == 4)) ||
+  fail "omarchy-theme-set-browser-policy writes only the four known policy directories" \
+    "got: $policy_dir_count"
+
+pass "browser policy helper writes a fixed set of policy directories"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/pkexec" <<'SH'
+#!/bin/bash
+printf 'pkexec %s\n' "$*" >"$ELEVATION_LOG"
+SH
+chmod +x "$stub_bin/pkexec"
+
+# The sudo stub plays both parts: it answers the passwordless probe according to
+# STUB_GRANTED, and logs the elevation otherwise. STUB_GRANTED empty stands for
+# an install whose omarchy-settings predates the sudoers file.
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+if [[ $1 == -n && $2 == -l ]]; then
+  if [[ ${STUB_GRANTED-granted} == "granted" ]]; then
+    echo "    Options: !authenticate"
+  else
+    echo "    Matched: ${!#}"
+  fi
+  exit 0
+fi
+printf 'sudo %s\n' "$*" >"$ELEVATION_LOG"
+SH
+chmod +x "$stub_bin/sudo"
+
+# Running as root skips require_root entirely, and the helper would then write
+# this machine's real browser policy directories.
+if ((EUID == 0)); then
+  pass "running as root; skipping the elevation checks, which would rewrite this machine's browser policy"
+  exit 0
+fi
+
+elevation_for() {
+  : >"$test_tmp/elevation"
+  ELEVATION_LOG="$test_tmp/elevation" \
+    PATH="$stub_bin:$PATH" \
+    bash "$helper" "$@" </dev/null >/dev/null 2>&1 || true
+  cat "$test_tmp/elevation"
+}
+
+elevation=$(elevation_for 1c2027)
+[[ $elevation == "sudo /usr/bin/omarchy-theme-set-browser-policy 1c2027" ]] ||
+  fail "omarchy-theme-set-browser-policy takes the passwordless sudo grant without a terminal" \
+    "got: $elevation"
+
+# A dev-linked checkout elevates the packaged path like everyone else, rather
+# than handing sudo a path no rule can name and losing the grant.
+dev_linked=$(OMARCHY_PATH="$test_tmp/checkout" elevation_for 1c2027)
+[[ $dev_linked == "sudo /usr/bin/omarchy-theme-set-browser-policy 1c2027" ]] ||
+  fail "omarchy-theme-set-browser-policy elevates the system install wherever OMARCHY_PATH points" \
+    "got: $dev_linked"
+
+pass "browser policy helper elevates a valid color through the sudo grant"
+
+# Where the grant does not reach and there is no terminal, the helper leaves the
+# policy alone. A browser accent color does not justify an authentication dialog
+# on every theme switch, so this must not reach pkexec either.
+ungranted=$(STUB_GRANTED="" elevation_for 1c2027)
+[[ -z $ungranted ]] ||
+  fail "omarchy-theme-set-browser-policy stays quiet where the grant does not reach" "got: $ungranted"
+
+if ! STUB_GRANTED="" PATH="$stub_bin:$PATH" ELEVATION_LOG="$test_tmp/elevation" \
+  bash "$helper" 1c2027 </dev/null >/dev/null 2>&1; then
+  fail "omarchy-theme-set-browser-policy succeeds when it declines to elevate, so the rest of the theme applies"
+fi
+
+pass "browser policy helper skips the write rather than prompting where the grant is absent"
+
+# Validation runs before any elevation, so a rejected argument never reaches
+# sudo. Anything but six lowercase hex digits is rejected, and the sudoers glob
+# independently refuses the same shapes.
+for bad in "" "1C2027" "abc12" "abc1234" "1c202g" "../../etc/passwd" "1c2027 1c2027" \
+  '$(id)' "1c2027;id" "#1c2027"; do
+  if PATH="$stub_bin:$PATH" ELEVATION_LOG="$test_tmp/elevation" \
+    bash "$helper" "$bad" </dev/null >/dev/null 2>&1; then
+    fail "omarchy-theme-set-browser-policy rejects '$bad'"
+  fi
+
+  rejected=$(elevation_for "$bad")
+  [[ -z $rejected ]] ||
+    fail "omarchy-theme-set-browser-policy rejects '$bad' before elevating" "got: $rejected"
+done
+
+# Two arguments, where each on its own would be valid.
+if PATH="$stub_bin:$PATH" bash "$helper" 1c2027 ffffff </dev/null >/dev/null 2>&1; then
+  fail "omarchy-theme-set-browser-policy rejects more than one argument"
+fi
+
+pass "browser policy helper accepts nothing but six lowercase hex digits"
+
+# The color comes out of the current theme's chromium.theme, a file under the
+# user's own state directory. A malformed or hostile one must land on the neutral
+# fallback rather than reaching the policy writer as anything else.
+setter_bin="$test_tmp/setter-bin"
+mkdir -p "$setter_bin"
+
+cat >"$setter_bin/omarchy-theme-set-browser-policy" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$COLOR_LOG"
+SH
+chmod +x "$setter_bin/omarchy-theme-set-browser-policy"
+
+# No browser is "present", so the refresh half does nothing.
+cat >"$setter_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$setter_bin/omarchy-cmd-present"
+
+setter_home="$test_tmp/home"
+theme_dir="$setter_home/.local/state/omarchy/current/theme"
+mkdir -p "$theme_dir"
+
+color_for_theme() {
+  : >"$test_tmp/color"
+  if [[ $# -gt 0 ]]; then
+    printf '%s' "$1" >"$theme_dir/chromium.theme"
+  else
+    rm -f "$theme_dir/chromium.theme"
+  fi
+
+  HOME="$setter_home" COLOR_LOG="$test_tmp/color" PATH="$setter_bin:$stub_bin:$PATH" \
+    bash "$setter" </dev/null >/dev/null 2>&1 || true
+  cat "$test_tmp/color"
+}
+
+# A theme with no trailing newline is the common case in themes/.
+[[ $(color_for_theme "242,240,229") == "f2f0e5" ]] ||
+  fail "omarchy-theme-set-browser converts an RGB triple to six hex digits"
+[[ $(color_for_theme $'14,31,41\n') == "0e1f29" ]] ||
+  fail "omarchy-theme-set-browser accepts a trailing newline"
+[[ $(color_for_theme "0,0,0") == "000000" ]] ||
+  fail "omarchy-theme-set-browser pads single-digit components"
+[[ $(color_for_theme " 12 , 11 , 12 ") == "0c0b0c" ]] ||
+  fail "omarchy-theme-set-browser tolerates surrounding whitespace"
+
+for malformed in "" "not,a,color" "1,2" "1,2,3,4" "256,0,0" "999,999,999" "-1,0,0" \
+  "1,2,3;id" '1,2,$(id)' "0x10,0,0" "1,2,3 4,5,6"; do
+  color=$(color_for_theme "$malformed")
+  [[ $color == "1c2027" ]] ||
+    fail "omarchy-theme-set-browser falls back to the neutral color for '$malformed'" "got: $color"
+done
+
+[[ $(color_for_theme) == "1c2027" ]] ||
+  fail "omarchy-theme-set-browser falls back to the neutral color with no theme file"
+
+pass "browser theme color is derived as six hex digits or falls back to the neutral color"
+
+# Nothing in the tree may reopen a browser policy directory. Check the bits each
+# mode change actually sets rather than matching the one string that caused this
+# bug, so a different spelling of the same mistake is caught too. Paths stay
+# relative: an absolute checkout path can itself contain "policy" and would
+# match every line.
+policy_path='polic(y|ies)|distribution|/etc/chromium|/etc/brave|/etc/opt/(chrome|edge)'
+offenders=()
+
+while IFS= read -r line; do
+  [[ $line =~ $policy_path ]] || continue
+
+  # Symbolic forms that hand a write bit to group or other. u+w is not one.
+  if [[ $line =~ chmod[^\&\|]*[ago]+\+[rx]*w ]]; then
+    offenders+=("$line")
+    continue
+  fi
+
+  if [[ $line =~ (chmod|-m)[[:space:]]+([0-7]{3,4}) ]]; then
+    mode=${BASH_REMATCH[2]}
+    if ((8#$mode & 022)); then
+      offenders+=("$line")
+    fi
+  fi
+done < <(cd "$ROOT" && grep -rnE 'chmod|install -d|install -m' bin install migrations 2>/dev/null)
+
+((${#offenders[@]} == 0)) ||
+  fail "no script opens a browser policy directory to other users" "got: ${offenders[*]}"
+
+pass "no script makes a browser policy directory writable by other users"

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -205,10 +205,14 @@ OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install chromiu
 [[ $(omarchy-default-browser) == "chromium" ]] || fail "Chromium becomes the default after its full installer succeeds"
 cmp -s "$ROOT/config/chromium-flags.conf" "$test_home/.config/chromium-flags.conf" ||
   fail "Chromium browser installer copies the default flags"
-grep -Fxq 'sudo:mkdir -p /etc/chromium/policies/managed' "$setup_log" ||
-  fail "Chromium browser installer creates its policy directory"
-grep -Fxq 'sudo:chmod a+rw /etc/chromium/policies/managed' "$setup_log" ||
-  fail "Chromium browser installer makes its policy directory writable"
+grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium/policies/managed' "$setup_log" ||
+  fail "Chromium browser installer creates its policy directory root-owned and not world-writable"
+# The policy directory is an enterprise policy trust root. It was world-writable
+# so an unprivileged theme switch could write color.json; that write goes through
+# omarchy-theme-set-browser-policy now, and nothing may open the directory again.
+if grep -Eq 'a\+rw|o\+w|0777' "$setup_log"; then
+  fail "Chromium browser installer leaves its policy directory writable by other users"
+fi
 grep -Fxq 'omarchy-install-chromium-copy-url:' "$setup_log" ||
   fail "Chromium browser installer registers the Copy URL host"
 grep -Fxq 'omarchy-install-chromium-ytdlp:' "$setup_log" ||


### PR DESCRIPTION
Omarchy made browser policy directories world-writable so an unprivileged theme switch could drop color.json in. Those directories are enterprise policy trust roots: browsers read every JSON file under policies/managed, and Firefox/Zen read distribution/policies.json, as administrator-managed policy. Any local account could therefore install browser policy, a forced extension, a proxy for interception, a disabled protection, without ever holding root.

Adds omarchy-theme-set-browser-policy, a privileged helper that takes root for that one write. It accepts nothing but six lowercase hex digits and writes only color.json, only into the four known policy directories. A sudoers rule spells the argument out as six hex digits so the passwordless grant covers a color and nothing else, keeping the theme switch from stopping for a password. Where the grant does not reach and there is no terminal it skips the write rather than raising a dialog for a color.

The color comes from the current theme's chromium.theme, which the user owns, so omarchy-theme-set-browser now parses it as an RGB triple and falls back to the neutral grey instead of handing unvetted words to printf.

Add a migration to repair existing installs: it tightens the loose directories and their parents, drops the color.json that sat in them, restores the shipped policies.json, and reports any other file it finds rather than deleting what may be a real admin policy.