### PR TITLE
Enable three-finger workspace swiping by default

### DIFF
--- a/config/hypr/input.lua
+++ b/config/hypr/input.lua
@@ -48,9 +48,9 @@
 -- o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 -- o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })
 
--- Enable touchpad gestures for changing workspaces.
+-- Disable the default touchpad gesture for changing workspaces.
 -- See https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/
--- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+-- hl.gesture({ fingers = 3, direction = "horizontal", action = "unset" })
 
 -- Enable touchpad gestures for moving focus (helpful on scrolling layout).
 -- hl.gesture({ fingers = 3, direction = "left", action = function() hl.dispatch(hl.dsp.focus({ direction = "l" })) end })

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -74,6 +74,9 @@ hl.config({
   },
 })
 
+-- Swipe between workspaces with three fingers on a touchpad.
+hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+
 -- Scroll nicely in the terminal.
 o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -105,6 +105,22 @@ grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default applicat
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
 
+input_gestures=$(ROOT="$ROOT" lua <<'LUA'
+hl = {
+  config = function() end,
+  gesture = function(spec)
+    print(spec.fingers .. "\t" .. spec.direction .. "\t" .. spec.action)
+  end,
+}
+o = { window = function() end }
+
+dofile(os.getenv("ROOT") .. "/default/hypr/input.lua")
+LUA
+)
+grep -Fqx $'3\thorizontal\tworkspace' <<<"$input_gestures" ||
+  fail "default input enables three-finger workspace swiping"
+pass "default input enables three-finger workspace swiping"
+
 grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
   fail "universal clipboard shortcuts send explicit mods to the focused surface"
 pass "universal clipboard shortcuts send explicit mods to the focused surface"


### PR DESCRIPTION
A simple, opinionated, vibes suggestion for an Omarchy default...3-finger swipe! 

Having this turned on will be bring joy to anyone migrating from the MacOS ecosystem. Tested on a Dell XPS 13 and it feels natural. 

Also tested on an almost decades old Lenovo IdeaPad with a smaller trackpad and feels natural there.

## Summary

- enable Hyprland's native three-finger horizontal workspace gesture by default
- document how to disable the default gesture in the user input override
- verify the default gesture registration in the Hyprland config test

## Testing

- `bash test/shell.d/hyprland-default-config-test.sh`
- `hyprctl reload`
- `hyprctl configerrors` (no errors)
- verified three-finger horizontal swipes switch workspaces interactively on a Dell XPS 13 touchpad