### PR TITLE
Fix Brave Origin refresh collision

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -28,7 +28,7 @@ omarchy-theme-set-browser-policy "${THEME_HEX_COLOR#\#}" || failed=1
 refresh_running_browser chromium chromium
 refresh_running_browser chrome google-chrome-stable || refresh_running_browser chrome google-chrome
 refresh_running_browser msedge microsoft-edge-stable
-refresh_running_browser brave brave
+refresh_running_browser /opt/brave-bin/ brave -f
 # Match on the binary path: the running process is named plain "brave", and a
 # bare -f brave-origin pattern would also match the installer's own terminal.
 refresh_running_browser /opt/brave-origin-bin/ brave-origin -f

--- a/test/shell.d/theme-set-browser-test.sh
+++ b/test/shell.d/theme-set-browser-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+call_log="$test_tmp/browser-calls.log"
+mkdir -p "$stub_bin" "$test_tmp/home"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'STUB'
+#!/bin/bash
+[[ $1 == "brave" || $1 == "brave-origin" ]]
+STUB
+
+cat >"$stub_bin/omarchy-theme-set-browser-policy" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+cat >"$stub_bin/pgrep" <<'STUB'
+#!/bin/bash
+if [[ ${BROWSER_SCENARIO:-origin} == "origin" ]]; then
+  [[ $* == "-x brave" || $* == "-f /opt/brave-origin-bin/" ]]
+else
+  [[ $* == "-f /opt/brave-bin/" ]]
+fi
+STUB
+
+cat >"$stub_bin/brave" <<'STUB'
+#!/bin/bash
+printf 'brave\n' >>"$BROWSER_CALL_LOG"
+STUB
+
+cat >"$stub_bin/brave-origin" <<'STUB'
+#!/bin/bash
+printf 'brave-origin\n' >>"$BROWSER_CALL_LOG"
+STUB
+
+cat >"$stub_bin/tee" <<'STUB'
+#!/bin/bash
+cat >/dev/null
+STUB
+
+chmod +x "$stub_bin"/*
+
+HOME="$test_tmp/home" OMARCHY_PATH="$ROOT" BROWSER_CALL_LOG="$call_log" PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-theme-set-browser"
+
+[[ ! -e $call_log ]] || ! grep -Fxq brave "$call_log" ||
+  fail "Brave refresh ignores Brave Origin processes"
+grep -Fxq brave-origin "$call_log" ||
+  fail "Brave Origin refresh still matches its binary path"
+pass "Brave refresh distinguishes Brave from Brave Origin"
+
+: >"$call_log"
+HOME="$test_tmp/home" OMARCHY_PATH="$ROOT" BROWSER_CALL_LOG="$call_log" BROWSER_SCENARIO=regular \
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-theme-set-browser"
+
+grep -Fxq brave "$call_log" ||
+  fail "Brave refresh still matches its binary path"
+[[ $(wc -l <"$call_log") -eq 1 ]] ||
+  fail "Regular Brave does not refresh another Brave package"
+pass "Brave refresh still detects regular Brave"


### PR DESCRIPTION
## Summary

- detect regular Brave by its binary path instead of the shared `brave` process name
- keep Brave Origin detection on its own binary path
- add hermetic regression coverage for both the Brave-Origin-only and regular-Brave cases

## Problem

Brave Origin child processes use the generic process name `brave`. The regular Brave refresh probe used `pgrep -x brave`, so running only Brave Origin could incorrectly launch the regular `brave -f` refresh command and leave theme updates waiting on the wrong browser.

## Approach

Match `/opt/brave-bin/` for regular Brave, mirroring the existing path-based Brave Origin probe. This distinguishes the two installed variants without changing refresh behavior for an actually running regular Brave instance.

## Tests

- `bash test/shell.d/theme-set-browser-test.sh`
- `bash test/shell.d/manifest-entrypoints-test.sh`
- `./test/all` — all 206 test files passed on current `quattro`
- sabotage check: restoring `pgrep -x brave` makes the regression test fail
- `bash -n bin/omarchy-theme-set-browser test/shell.d/theme-set-browser-test.sh`
- `git diff --check`

Closes #8158
