### PR TITLE
Keep notification contents out of process arguments

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -429,7 +429,7 @@ Item {
   // match these rows against fresh notifications.
   property var restoredPopups: ({})
 
-  // Entries are either { command, done } for a file job or { read: true } for
+  // Entries are either { command, stdin, done } for a file job or { read: true } for
   // a replay's directory read. Queueing the read rather than running it beside
   // the queue is what makes it a barrier: it takes its place in line, so the
   // history it sees is the one that existed when the replay was asked for.
@@ -439,9 +439,16 @@ Item {
 
   // Done callback of the job popupFileProc is currently running.
   property var runningPopupFileJobDone: null
+  // Stdin payload of the job popupFileProc is currently starting. Cleared as
+  // soon as onStarted has handed it to the process.
+  property var runningPopupFileJobStdin: null
 
-  function enqueuePopupFileJob(command, done) {
-    popupFileQueue = popupFileQueue.concat([{ command: command, done: done || null }])
+  function enqueuePopupFileJob(command, stdin, done) {
+    popupFileQueue = popupFileQueue.concat([{
+      command: command,
+      stdin: stdin === undefined ? null : stdin,
+      done: done || null
+    }])
     runNextPopupFileJob()
   }
 
@@ -463,6 +470,7 @@ Item {
     }
 
     popupFileProc.command = job.command
+    service.runningPopupFileJobStdin = job.stdin
     service.runningPopupFileJobDone = job.done || null
     popupFileProc.running = true
   }
@@ -470,6 +478,13 @@ Item {
   Process {
     id: popupFileProc
     running: false
+    stdinEnabled: true
+    onStarted: {
+      if (service.runningPopupFileJobStdin !== null) {
+        write(service.runningPopupFileJobStdin + "\n")
+        service.runningPopupFileJobStdin = null
+      }
+    }
     onExited: {
       var done = service.runningPopupFileJobDone
       service.runningPopupFileJobDone = null
@@ -496,24 +511,25 @@ Item {
     "done\n"
 
   function persistPopupFile(snapshot) {
-    // The JSON travels as an argument, not through shell interpolation, so
-    // summaries/bodies with quotes or backticks can't break the command. The
-    // mkdir guards notifications that arrive before ensureDirsProc has run.
-    // Copies run before the JSON referencing them, while the source exists.
+    // The JSON travels over stdin so sensitive summaries and bodies never
+    // appear in the process argv. The mkdir guards notifications that arrive
+    // before ensureDirsProc has run. Copies run before the JSON referencing
+    // them, while the source exists.
     var persistable = NotificationLogic.persistablePopup(snapshot, imagesDir)
+    var json = NotificationLogic.serializePopup(persistable.entry, NotificationUrgency.Normal)
     var command = ["bash", "-c",
       "mkdir -p \"$1\" \"$2\" || exit 0\n" +
-      "dir=\"$1\" json=\"$3\" name=\"$4\"\n" +
-      "shift 4\n" +
+      "dir=\"$1\" name=\"$3\"\n" +
+      "shift 3\n" +
       copyImagesScript +
+      "IFS= read -r json || exit 0\n" +
       "printf '%s\\n' \"$json\" > \"$dir/$name\"", "--",
       popupStateDir,
       imagesDir,
-      NotificationLogic.serializePopup(persistable.entry, NotificationUrgency.Normal),
       NotificationLogic.popupFileName(snapshot)]
     for (var i = 0; i < persistable.copies.length; i++)
       command.push(persistable.copies[i].from, persistable.copies[i].to)
-    enqueuePopupFileJob(command)
+    enqueuePopupFileJob(command, json)
   }
 
   function deletePopupFileFor(row) {
@@ -568,21 +584,22 @@ Item {
       return
     }
     var persistable = NotificationLogic.persistablePopup(entry, imagesDir)
+    var json = NotificationLogic.serializePopup(persistable.entry, NotificationUrgency.Normal)
     var command = ["bash", "-c",
-      "mkdir -p \"$1\" \"$5\" || exit 0\n" +
-      "hist=\"$1\" limit=\"$2\" name=\"$3\" json=\"$4\" imgs=\"$5\"\n" +
-      "shift 5\n" +
+      "mkdir -p \"$1\" \"$4\" || exit 0\n" +
+      "hist=\"$1\" limit=\"$2\" name=\"$3\" imgs=\"$4\"\n" +
+      "shift 4\n" +
       copyImagesScript +
+      "IFS= read -r json || exit 0\n" +
       "printf '%s\\n' \"$json\" > \"$hist/$name\" || exit 0\n" +
       trimHistoryScript, "--",
       historyDir,
       String(historyLimit),
       NotificationLogic.popupFileName(entry),
-      NotificationLogic.serializePopup(persistable.entry, NotificationUrgency.Normal),
       imagesDir]
     for (var i = 0; i < persistable.copies.length; i++)
       command.push(persistable.copies[i].from, persistable.copies[i].to)
-    enqueuePopupFileJob(command, done)
+    enqueuePopupFileJob(command, json, done)
   }
 
   function clearHistory() {

--- a/test/shell.d/notification-persistence-stdin-test.sh
+++ b/test/shell.d/notification-persistence-stdin-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const os = require('os')
+const { spawnSync } = require('child_process')
+const notifications = requireFromRoot('shell/plugins/notifications/NotificationLogic.js')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+
+function functionBody(name) {
+  const marker = `function ${name}(`
+  const start = serviceQml.indexOf(marker)
+  assert(start >= 0, `notifications service defines ${name}`)
+  const open = serviceQml.indexOf('{', start)
+  const nextFunction = serviceQml.indexOf('\n  function ', open + 1)
+  const close = serviceQml.lastIndexOf('}', nextFunction)
+  assert(close > open, `notifications service closes ${name}`)
+  return serviceQml.slice(open + 1, close)
+}
+
+function assembledJob(name, entry, paths) {
+  let queued = null
+  const done = () => {}
+  const body = functionBody(name)
+  const build = new Function(
+    name === 'persistPopupFile' ? 'snapshot' : 'entry',
+    'done', 'NotificationLogic', 'NotificationUrgency', 'imagesDir',
+    'popupStateDir', 'historyDir', 'historyLimit', 'copyImagesScript',
+    'trimHistoryScript', 'enqueuePopupFileJob', body
+  )
+  build(
+    entry, done, notifications, { Normal: 1 }, paths.images,
+    paths.popup, paths.history, 10,
+    'while (( $# >= 2 )); do cp -- "$1" "$2"; shift 2; done\n',
+    ':', (...args) => { queued = args }
+  )
+  assert(queued, `notifications service queues ${name}`)
+  return { command: queued[0], stdin: queued[1], done: queued[2], expectedDone: done }
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'omarchy-notification-stdin-'))
+try {
+  const paths = {
+    popup: path.join(tmp, 'popups'),
+    history: path.join(tmp, 'history'),
+    images: path.join(tmp, 'images')
+  }
+  const sourceImage = path.join(tmp, 'sender image')
+  fs.writeFileSync(sourceImage, 'image bytes')
+  const entry = {
+    id: 17,
+    originalId: 17,
+    app: 'Mail',
+    appIcon: sourceImage,
+    summary: 'private "subject" $(not a command)\nsecond line',
+    body: "apostrophe ' and backtick ` stay private",
+    image: '',
+    glyph: '',
+    urgency: 1,
+    expireTimeout: 4000,
+    timestamp: 123456
+  }
+  const expected = notifications.serializePopup(
+    notifications.persistablePopup(entry, paths.images).entry,
+    1
+  )
+
+  const popupJob = assembledJob('persistPopupFile', entry, paths)
+  assertEqual(popupJob.stdin, expected, 'popup persistence carries notification JSON separately from argv')
+  assert(!popupJob.command.some(arg => arg.includes(expected)), 'popup persistence does not expose notification JSON in argv')
+  assert(popupJob.command.includes(sourceImage), 'popup persistence keeps image copy paths in argv')
+  const popupRun = spawnSync(popupJob.command[0], popupJob.command.slice(1), {
+    input: popupJob.stdin + '\n',
+    encoding: 'utf8'
+  })
+  assertEqual(popupRun.status, 0, 'popup persistence command accepts notification JSON on stdin')
+  assertEqual(
+    fs.readFileSync(path.join(paths.popup, notifications.popupFileName(entry)), 'utf8'),
+    expected + '\n',
+    'popup persistence preserves special characters and newlines from stdin'
+  )
+
+  const historyJob = assembledJob('writeHistoryFile', entry, paths)
+  assertEqual(historyJob.stdin, expected, 'history persistence carries notification JSON separately from argv')
+  assert(!historyJob.command.some(arg => arg.includes(expected)), 'history persistence does not expose notification JSON in argv')
+  assertEqual(historyJob.done, historyJob.expectedDone, 'history persistence keeps its queued completion callback')
+  const historyRun = spawnSync(historyJob.command[0], historyJob.command.slice(1), {
+    input: historyJob.stdin + '\n',
+    encoding: 'utf8'
+  })
+  assertEqual(historyRun.status, 0, 'history persistence command accepts notification JSON on stdin')
+  assertEqual(
+    fs.readFileSync(path.join(paths.history, notifications.popupFileName(entry)), 'utf8'),
+    expected + '\n',
+    'history persistence preserves special characters and newlines from stdin'
+  )
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true })
+}
+
+assert(
+  /popupFileQueue = popupFileQueue\.concat\(\[\{\s*command: command,[\s\S]{0,150}?stdin: stdin[\s\S]{0,150}?done: done/.test(serviceQml),
+  'notifications service keeps each stdin payload with its serialized queue job'
+)
+assert(
+  /popupFileProc\.command = job\.command[\s\S]{0,200}?runningPopupFileJobStdin = job\.stdin[\s\S]{0,200}?popupFileProc\.running = true/.test(serviceQml),
+  'notifications service installs a queued stdin payload before starting its process'
+)
+assert(
+  /id: popupFileProc[\s\S]{0,300}?stdinEnabled: true[\s\S]{0,300}?onStarted:[\s\S]{0,300}?write\(service\.runningPopupFileJobStdin \+ "\\n"\)[\s\S]{0,200}?runningPopupFileJobStdin = null/.test(serviceQml),
+  'notifications service writes queued JSON only after start and clears it promptly'
+)
+JS

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -608,8 +608,8 @@ assert(
   'notifications service keeps image copies beside the popup and history files'
 )
 assert(
-  /copyImagesScript \+\n\s*"printf/.test(serviceQml),
-  'notifications service copies images before writing the JSON that references them'
+  /copyImagesScript \+\n\s*"IFS= read -r json \|\| exit 0\\n" \+\n\s*"printf/.test(serviceQml),
+  'notifications service copies images before reading and writing the JSON that references them'
 )
 assert(
   /timeout 5 head -c 5242881 -- \\"\$1\\" > \\"\$2\.tmp\\"[\s\S]{0,120}?mv -f -- \\"\$2\.tmp\\" \\"\$2\\"/.test(serviceQml),


### PR DESCRIPTION
## Summary

- carry persisted notification JSON through `Process` stdin instead of process arguments
- keep only file paths and image-copy pairs in argv
- serialize each stdin payload with its queue job and clear it after writing
- cover popup and history persistence, special characters, queue ordering, callback preservation, and image-copy ordering

## Problem

Popup and history JSON included notification summaries and bodies directly in `bash -c` arguments. That exposed potentially sensitive notification content through `/proc/*/cmdline` and could trigger endpoint-security detections.

## Approach

Each persistence queue entry now owns an optional stdin payload. `popupFileProc` writes that payload after the process starts, then clears the in-memory copy. Persistence commands read one JSON line from stdin after copying any image files. Non-write queue jobs continue to run without stdin.

## Tests

- `bash test/shell.d/notification-persistence-stdin-test.sh` — 19 focused assertions passed
- `bash test/shell.d/notifications-test.sh`
- `./test/all` — all 206 test files passed on current `quattro`
- sabotage check: restoring the original `Service.qml` makes the new regression test fail
- `bash -n test/shell.d/notification-persistence-stdin-test.sh test/shell.d/notifications-test.sh`
- `git diff --check`

Closes #8209
