### PR TITLE
Cycle Super + L on into a floating workspace

### DIFF
--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -1,21 +1,39 @@
 #!/bin/bash
 
-# omarchy:summary=Toggle the layout on the current active workspace between dwindle and scrolling
+# omarchy:summary=Cycle the current active workspace through the dwindle, scrolling, and floating layouts
 
 ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
-[[ $ACTIVE_WORKSPACE =~ ^-?[0-9]+$ ]] || exit 1
-CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
-LAYOUTS_DIR="$HOME/.local/state/omarchy/workspace-layouts"
-LAYOUT_FILE="$LAYOUTS_DIR/$ACTIVE_WORKSPACE.lua"
+# Named workspaces report a negative id, and Hyprland reads a leading "-" as a
+# selector relative to the current workspace: targeting one lands on workspace 1
+# and reconfigures that instead.
+[[ $ACTIVE_WORKSPACE =~ ^[0-9]+$ ]] || exit 1
+MODES_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/workspace-layouts"
+MODE_FILE="$MODES_DIR/$ACTIVE_WORKSPACE.lua"
 
-case "$CURRENT_LAYOUT" in
-  dwindle) NEW_LAYOUT=scrolling ;;
-  *) NEW_LAYOUT=dwindle ;;
+# Hyprland only reports the tiled layout, and floating is not one, so the mode is
+# read back from the file this script wrote. Files saved before floating existed
+# name no mode and fall through to what Hyprland reports.
+CURRENT_MODE=$(sed -n 's/.*mode = "\([a-z]*\)".*/\1/p' "$MODE_FILE" 2>/dev/null)
+if [[ -z $CURRENT_MODE ]]; then
+  CURRENT_MODE=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+fi
+
+case "$CURRENT_MODE" in
+  dwindle) NEW_MODE=scrolling ;;
+  scrolling) NEW_MODE=floating ;;
+  *) NEW_MODE=dwindle ;;
 esac
 
-mkdir -p "$LAYOUTS_DIR"
-printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ACTIVE_WORKSPACE" "$NEW_LAYOUT" >"$LAYOUT_FILE"
+APPLY="o.workspace_mode({ workspace = \"$ACTIVE_WORKSPACE\", mode = \"$NEW_MODE\" })"
 
-hyprctl eval "hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 || \
-  hyprctl keyword workspace "$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT"
-omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_LAYOUT"
+# Saving a mode that did not apply would leave the file naming one layout while
+# the screen shows another, and restore it at the next login.
+if ! hyprctl eval "$APPLY" >/dev/null 2>&1; then
+  omarchy-notification-send -g 󱂬 "Workspace layout needs a Hyprland reload"
+elif mkdir -p "$MODES_DIR" && printf '%s\n' "$APPLY" >"$MODE_FILE"; then
+  omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_MODE"
+else
+  # The mode is on screen but nothing will bring it back, and the next press
+  # reads the mode from this file, so say so rather than counting it as set.
+  omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_MODE but could not be saved"
+fi

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -11,7 +11,7 @@ o.bind("SUPER + ALT + F", "Full width", hl.dsp.window.fullscreen({ mode = "maxim
 o.bind("SUPER + O", "Pop window out (float & pin)", "omarchy-hyprland-window-pop")
 o.bind("SUPER + ALT + Home", "Save window width", "omarchy-hyprland-window-width save")
 o.bind("SUPER + Home", "Restore window width", "omarchy-hyprland-window-width restore")
-o.bind("SUPER + L", "Toggle workspace layout", "omarchy-hyprland-workspace-layout-toggle")
+o.bind("SUPER + L", "Cycle workspace layout", "omarchy-hyprland-workspace-layout-toggle")
 
 o.bind("SUPER + LEFT", "Focus on left window", hl.dsp.focus({ direction = "l" }))
 o.bind("SUPER + RIGHT", "Focus on right window", hl.dsp.focus({ direction = "r" }))

--- a/default/hypr/workspace-layouts.lua
+++ b/default/hypr/workspace-layouts.lua
@@ -3,6 +3,15 @@
 local paths = require("default.hypr.paths")
 local require_all = require("default.hypr.require_all")
 
+-- The saved files call o.workspace_mode, so it has to exist before they load.
+require("default.hypr.workspace-modes")
+
 local layouts_dir = paths.state_home .. "/omarchy/workspace-layouts"
+
+-- The directory is found through XDG_STATE_HOME but the files are loaded by
+-- module name, and bootstrap only puts ~/.local/state on the search path. A
+-- state home anywhere else would list the saved layouts and then fail to require
+-- them, or load same-named ones from under the home directory instead.
+package.path = paths.state_home .. "/?.lua;" .. package.path
 
 require_all.files(layouts_dir, "omarchy.workspace-layouts", { reload = true })

--- a/default/hypr/workspace-modes.lua
+++ b/default/hypr/workspace-modes.lua
@@ -1,0 +1,125 @@
+-- Workspace modes for omarchy-hyprland-workspace-layout-toggle.
+--
+-- Hyprland has dwindle and scrolling as tiled layouts, but nothing that floats a
+-- whole workspace: it reports a workspace's `tiledLayout` and takes an unknown
+-- layout name in silence, falling back to dwindle. So floating is applied to the
+-- windows themselves.
+--
+-- Ending the mode has to tile the windows the mode floated and only those, so
+-- each one is tagged. The tag lives on the window: it dies with it, follows it
+-- between workspaces, and survives the config reload that a monitor being
+-- plugged in performs, none of which a table on this side would do.
+
+require("default.hypr.helpers")
+
+local FLOATED_TAG = "omarchy-mode-floated"
+
+local modes = {}
+local watching = false
+
+local function set_floating(window, floating)
+  hl.dispatch(hl.dsp.window.float({ action = floating and "on" or "off", window = window }))
+end
+
+local function set_claimed(window, claimed)
+  hl.dispatch(hl.dsp.window.tag({ tag = (claimed and "+" or "-") .. FLOATED_TAG, window = window }))
+end
+
+local function claimed()
+  local addresses = {}
+
+  for _, window in ipairs(hl.get_windows({ tag = FLOATED_TAG })) do
+    addresses[window.address] = true
+  end
+
+  return addresses
+end
+
+-- A window already floating on its own account -- an app with a float rule of
+-- its own, a dialog, one popped out with SUPER + T -- is left unclaimed, so it
+-- is still floating when the mode ends.
+local function float_for_mode(window)
+  if window.floating then
+    return
+  end
+
+  set_claimed(window, true)
+  set_floating(window, true)
+end
+
+-- A pinned window is one the user asked to keep above everything, and tiling it
+-- would unpin it as well, so the mode leaves it be.
+local function tile_for_mode(window, mine)
+  if not mine[window.address] or window.pinned then
+    return
+  end
+
+  set_claimed(window, false)
+  set_floating(window, false)
+end
+
+-- Windows arrive by opening and by being carried in, and a window rule only ever
+-- fires for the first. One carried back out gives up the floating the mode gave
+-- it rather than staying floating somewhere that tiles.
+local function watch()
+  if watching then
+    return
+  end
+
+  watching = true
+
+  hl.on("window.open", function(window)
+    if modes[tostring(window.workspace.id)] == "floating" then
+      float_for_mode(window)
+    end
+  end)
+
+  hl.on("window.move_to_workspace", function(window, workspace)
+    if modes[tostring(workspace.id)] == "floating" then
+      float_for_mode(window)
+    else
+      tile_for_mode(window, claimed())
+    end
+  end)
+end
+
+function o.workspace_mode(spec)
+  local workspace = tostring(spec.workspace)
+  local floating = spec.mode == "floating"
+
+  watch()
+
+  -- Floating keeps whatever tiled layout the workspace had, so nothing has to be
+  -- chosen for it on the way back out.
+  if not floating then
+    hl.workspace_rule({ workspace = workspace, layout = spec.mode })
+  end
+
+  modes[workspace] = spec.mode
+
+  local windows = hl.get_workspace_windows(workspace)
+
+  if floating then
+    local claiming = {}
+
+    -- Claim every tiled window before floating any of them: floating one member
+    -- of a group floats the rest, and a single pass would then find those
+    -- already floating and leave them to be stranded when the mode ends.
+    for _, window in ipairs(windows) do
+      if not window.floating then
+        set_claimed(window, true)
+        table.insert(claiming, window)
+      end
+    end
+
+    for _, window in ipairs(claiming) do
+      set_floating(window, true)
+    end
+  else
+    local mine = claimed()
+
+    for _, window in ipairs(windows) do
+      tile_for_mode(window, mine)
+    end
+  end
+end

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -34,6 +34,8 @@ Omarchy's default layout is called dwindle. It keeps all the windows you open on
 
 But you can also choose to turn a workspace into the scrolling layout where windows are lined up side-by-side, beyond the visible edge of the display. You turn a single workspace into this layout via `Super + L`.
 
+Pressing `Super + L` again turns the workspace floating, where windows overlap freely and you place them yourself, and a third press returns it to dwindle. A window that floats anyway — one you popped out with `Super + T`, or an app that always opens floating — keeps floating when the workspace goes back to tiling.
+
  ![navigation-scrolling-layout](images/navigation-scrolling-layout.webp)
 
 The choice is per workspace, and it sticks. So you can keep workspace 1 on dwindle for browsing and workspace 2 on scrolling for code, and they'll come back that way after a restart. (The same toggle is under _Trigger > Toggle > Workspace Layout_ in the Omarchy menu).

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -15,7 +15,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + T`               | Toggle window between tiling/floating             |
 | `Super + J` | Toggle window position (horizontal/vertical) |
 | `Super + O`               | Toggle popping window into sticky'n'floating |
-| `Super + L`               | Toggle between dwindle and scrolling layout |
+| `Super + L`               | Cycle through the dwindle, scrolling, and floating layouts |
 | `Super + P`               | Toggle pseudo window style (natural v stretch) |
 | `Super + F`                 | Go full screen              |
 | `Super + Alt + F`                 | Go full width              |

--- a/migrations/1787679775.sh
+++ b/migrations/1787679775.sh
@@ -1,0 +1,31 @@
+echo "Drop saved workspace layouts belonging to named workspaces"
+
+# omarchy-hyprland-workspace-layout-toggle acted on whatever id activeworkspace
+# reported, and a named workspace reports a negative one. Hyprland reads a
+# leading "-" as a selector relative to the current workspace, so a layout saved
+# for one is applied to workspace 1 at every login instead. The command no longer
+# writes these; this clears the ones already on disk. It wrote to ~/.local/state
+# whatever XDG_STATE_HOME said, so both are cleared.
+removed=0
+
+for state_home in "$HOME/.local/state" "${XDG_STATE_HOME:-}"; do
+  [[ -n $state_home ]] || continue
+
+  layouts_dir="$state_home/omarchy/workspace-layouts"
+  [[ -d $layouts_dir ]] || continue
+
+  for saved in "$layouts_dir"/-*.lua; do
+    if [[ -f $saved ]]; then
+      rm -f -- "$saved"
+      removed=1
+    fi
+  done
+done
+
+# The package hook reloads Hyprland before migrations run, so the rule from the
+# file just deleted is already applied to workspace 1. Hyprland watches the files
+# it required and picks the deletion up on its own, but not for a user who has
+# turned autoreload off, so ask for one.
+if (( removed )); then
+  hyprctl reload >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
@@ -18,60 +20,448 @@ cat >"$stub_dir/hyprctl" <<'EOF'
 if [[ $1 == "activeworkspace" && -n $HYPRCTL_BROKEN ]]; then
   printf '{}\n'
 elif [[ $1 == "activeworkspace" ]]; then
-  printf '{"id":3,"tiledLayout":"dwindle"}\n'
+  printf '{"id":%s,"tiledLayout":"%s"}\n' "${HYPRCTL_WS_ID:-3}" "${HYPRCTL_TILED_LAYOUT:-dwindle}"
 else
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+
+  if [[ $1 == "eval" && -n $HYPRCTL_EVAL_FAILS ]]; then
+    exit 7
+  fi
 fi
 EOF
 chmod +x "$stub_dir/hyprctl"
 
 cat >"$stub_dir/omarchy-notification-send" <<'EOF'
 #!/bin/bash
-:
+printf '%s\n' "$*" >>"$NOTIFICATION_LOG"
 EOF
 chmod +x "$stub_dir/omarchy-notification-send"
 
-HOME="$home_dir" HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
-  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
-
 layout_file="$home_dir/.local/state/omarchy/workspace-layouts/3.lua"
-[[ -f $layout_file ]] || fail "workspace layout toggle saves a workspace rule"
-grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "scrolling" })' "$layout_file" >/dev/null ||
-  fail "workspace layout toggle saves the selected layout"
-grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling" })' "$log_file" >/dev/null ||
-  fail "workspace layout toggle applies the selected layout immediately"
-pass "workspace layout toggle persists and applies the selected layout"
+notification_log="$tmpdir/notifications.log"
 
-if HOME="$home_dir" HYPRCTL_LOG="$log_file" HYPRCTL_BROKEN=1 PATH="$stub_dir:$PATH" \
-  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle" 2>/dev/null; then
+# XDG_STATE_HOME is named explicitly rather than left to be inherited: a machine
+# that sets it would otherwise have its real saved layouts written over by these
+# runs. It is the value the command would derive from this HOME anyway, and a
+# case that needs another one passes its own, which env applies last.
+toggle() {
+  env HOME="$home_dir" XDG_STATE_HOME="$home_dir/.local/state" \
+    HYPRCTL_LOG="$log_file" NOTIFICATION_LOG="$notification_log" \
+    PATH="$stub_dir:$PATH" "$@" "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
+}
+
+saved_mode() {
+  sed -n 's/.*mode = "\([a-z]*\)".*/\1/p' "$layout_file" 2>/dev/null
+}
+
+applied() {
+  grep -Fx "eval o.workspace_mode({ workspace = \"3\", mode = \"$1\" })" "$log_file" >/dev/null
+}
+
+# Nothing saved yet, so the cycle starts from the layout Hyprland reports.
+: >"$notification_log"
+toggle
+[[ -f $layout_file ]] || fail "workspace layout toggle saves the selected mode"
+[[ $(saved_mode) == "scrolling" ]] || fail "dwindle cycles to scrolling" "saved: $(cat "$layout_file")"
+applied scrolling || fail "scrolling is applied immediately" "$(cat "$log_file")"
+grep -q "set to scrolling" "$notification_log" ||
+  fail "the new mode is announced" "$(cat "$notification_log")"
+if grep -q "could not be saved" "$notification_log"; then
+  fail "a saved mode is announced as saved" "$(cat "$notification_log")"
+fi
+pass "dwindle cycles to scrolling"
+
+# The saved file is what carries the mode from here: floating is not a tiled
+# layout, so Hyprland could never report it back.
+toggle
+[[ $(saved_mode) == "floating" ]] || fail "scrolling cycles to floating" "saved: $(cat "$layout_file")"
+applied floating || fail "floating is applied immediately" "$(cat "$log_file")"
+pass "scrolling cycles to floating"
+
+# Hyprland still reports a tiled layout underneath a floating workspace, so a
+# toggle that trusted the compositor here would cycle back to scrolling and skip
+# dwindle entirely. The apply matters as much as the file: without it the saved
+# mode says dwindle while the screen stays floating.
+toggle
+[[ $(saved_mode) == "dwindle" ]] || fail "floating cycles back to dwindle" "saved: $(cat "$layout_file")"
+applied dwindle || fail "dwindle is applied immediately" "$(cat "$log_file")"
+pass "floating cycles back to dwindle"
+
+# Files written before floating existed name a layout rather than a mode.
+: >"$log_file"
+printf 'hl.workspace_rule({ workspace = "3", layout = "scrolling" })\n' >"$layout_file"
+toggle HYPRCTL_TILED_LAYOUT=scrolling
+[[ $(saved_mode) == "floating" ]] ||
+  fail "a saved layout from before floating cycles on into floating" "saved: $(cat "$layout_file")"
+applied floating || fail "the mode after a legacy layout is applied" "$(cat "$log_file")"
+pass "a saved layout from before floating cycles on into floating"
+
+# A mode that did not apply must not be restored at the next login, and must not
+# be announced as though it had been.
+printf 'o.workspace_mode({ workspace = "3", mode = "scrolling" })\n' >"$layout_file"
+: >"$notification_log"
+toggle HYPRCTL_EVAL_FAILS=1
+[[ $(saved_mode) == "scrolling" ]] ||
+  fail "a mode that failed to apply is not saved" "saved: $(cat "$layout_file")"
+grep -q "needs a Hyprland reload" "$notification_log" ||
+  fail "a mode that failed to apply says so" "$(cat "$notification_log")"
+if grep -q "set to" "$notification_log"; then
+  fail "a mode that failed to apply is announced as set" "$(cat "$notification_log")"
+fi
+pass "a mode that failed to apply is neither saved nor announced as set"
+
+# The mode is on screen but nothing will bring it back, and the next press reads
+# the mode from the file that was not written, so it cannot count as set. A
+# regular file where the state directory belongs fails mkdir for any user,
+# including root.
+blocked="$tmpdir/blocked"
+printf 'not a directory\n' >"$blocked"
+: >"$log_file"
+: >"$notification_log"
+toggle XDG_STATE_HOME="$blocked" 2>/dev/null
+applied scrolling || fail "the mode is still applied when it cannot be saved" "$(cat "$log_file")"
+grep -q "could not be saved" "$notification_log" ||
+  fail "a mode that could not be saved says so" "$(cat "$notification_log")"
+pass "a mode that applied but could not be saved says so"
+
+# A named workspace reports a negative id, and Hyprland reads a leading "-" as a
+# selector relative to the current workspace: acting on one reconfigures
+# workspace 1 rather than the workspace the user is looking at.
+: >"$log_file"
+if toggle HYPRCTL_WS_ID=-1337 2>/dev/null; then
+  fail "workspace layout toggle exits nonzero on a named workspace"
+fi
+if grep -q "workspace_mode" "$log_file"; then
+  fail "workspace layout toggle applies nothing for a named workspace" "$(cat "$log_file")"
+fi
+if [[ -f $home_dir/.local/state/omarchy/workspace-layouts/-1337.lua ]]; then
+  fail "workspace layout toggle does not persist a mode for a named workspace"
+fi
+pass "workspace layout toggle leaves a named workspace alone"
+
+# The guard stops new ones being written; the ones an earlier version already
+# wrote go on reconfiguring workspace 1 at every login until they are removed.
+migration=$(grep -rl 'Drop saved workspace layouts belonging to named workspaces' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "a migration removes saved layouts for named workspaces"
+
+migration_home="$tmpdir/migration"
+migration_layouts="$migration_home/.local/state/omarchy/workspace-layouts"
+mkdir -p "$migration_layouts"
+printf 'o.workspace_mode({ workspace = "-1337", mode = "scrolling" })\n' >"$migration_layouts/-1337.lua"
+printf 'o.workspace_mode({ workspace = "3", mode = "scrolling" })\n' >"$migration_layouts/3.lua"
+
+# omarchy-migrate runs each migration as `bash -euo pipefail` and only records it
+# as done if it exits 0, so run it the same way here: under those flags an
+# unmatched glob is the difference between a migration that finishes and one that
+# stops the whole run and repeats it at every login.
+# The stub is on the path because the migration asks Hyprland to reload once it
+# has removed something, and the real one would reload the compositor of whoever
+# is running the suite.
+run_migration() {
+  env HOME="$migration_home" XDG_STATE_HOME="$migration_home/.local/state" \
+    HYPRCTL_LOG="$tmpdir/migration-hyprctl.log" PATH="$stub_dir:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+migration_log="$tmpdir/migration-hyprctl.log"
+: >"$migration_log"
+run_migration || fail "the migration exits cleanly with a layout to remove"
+
+if [[ -f $migration_layouts/-1337.lua ]]; then
+  fail "the migration removes a saved layout for a named workspace"
+fi
+[[ -f $migration_layouts/3.lua ]] ||
+  fail "the migration keeps saved layouts for numbered workspaces"
+
+# The bad rule is already applied in the running session, and a user who has
+# turned autoreload off would keep it until their next login.
+grep -q "^reload" "$migration_log" ||
+  fail "the migration asks Hyprland to reload what it removed" "$(cat "$migration_log")"
+
+# The ordinary case is a machine with nothing to remove, where the glob matches
+# no file at all.
+: >"$migration_log"
+run_migration || fail "the migration exits cleanly with nothing to remove"
+[[ -f $migration_layouts/3.lua ]] ||
+  fail "the migration with nothing to remove keeps what is there"
+if grep -q "^reload" "$migration_log"; then
+  fail "the migration reloads Hyprland having removed nothing" "$(cat "$migration_log")"
+fi
+pass "the migration removes saved layouts for named workspaces"
+
+if toggle HYPRCTL_BROKEN=1 2>/dev/null; then
   fail "workspace layout toggle exits nonzero without a workspace id"
 fi
-[[ -f "$home_dir/.local/state/omarchy/workspace-layouts/null.lua" ]] &&
-  fail "workspace layout toggle does not persist a rule without a workspace id"
+if [[ -f $home_dir/.local/state/omarchy/workspace-layouts/null.lua ]]; then
+  fail "workspace layout toggle does not persist a mode without a workspace id"
+fi
 pass "workspace layout toggle ignores broken hyprctl output"
 
-lua_script="$tmpdir/workspace-layouts.lua"
+# A state home somewhere else has to work end to end: the shell writes there and
+# Hyprland loads from there. Saving to one place and restoring from another is a
+# mode that silently never comes back.
+state_home="$tmpdir/state"
+toggle XDG_STATE_HOME="$state_home"
+[[ -f $state_home/omarchy/workspace-layouts/3.lua ]] ||
+  fail "workspace layout toggle honours XDG_STATE_HOME"
 
-cat >"$lua_script" <<'LUA'
-local rules = {}
+# A decoy of the same name under the home directory, saying something else. The
+# loader lists the custom state home but loads by module name, so without the
+# search path it finds this one and the mode restored is the wrong one.
+printf 'hl.workspace_rule({ workspace = "3", layout = "dwindle" })\n' >"$layout_file"
+
+xdg_probe="$tmpdir/xdg-probe.lua"
+cat >"$xdg_probe" <<'LUA'
+local applied = {}
 
 hl = {
   workspace_rule = function(rule)
-    table.insert(rules, rule)
+    table.insert(applied, rule)
+  end,
+  get_workspace_windows = function()
+    return {}
+  end,
+  get_windows = function()
+    return {}
+  end,
+  dispatch = function() end,
+  dsp = { window = { float = function(spec) return spec end, tag = function(spec) return spec end } },
+  on = function() end,
+}
+
+dofile(os.getenv("OMARCHY_PATH") .. "/default/hypr/bootstrap.lua")
+require("default.hypr.helpers")
+require("default.hypr.workspace-layouts")
+
+assert(#applied == 1, "a mode saved under XDG_STATE_HOME was not restored")
+assert(applied[1].workspace == "3", "the restored mode named the wrong workspace")
+assert(applied[1].layout == "scrolling", "the restored mode was not the one saved")
+LUA
+
+if ! HOME="$home_dir" XDG_STATE_HOME="$state_home" OMARCHY_PATH="$ROOT" lua "$xdg_probe"; then
+  fail "a mode saved under XDG_STATE_HOME is restored from there"
+fi
+pass "workspace layout toggle saves and restores through XDG_STATE_HOME"
+
+printf 'o.workspace_mode({ workspace = "3", mode = "floating" })\n' >"$layout_file"
+
+lua_script="$tmpdir/workspace-modes.lua"
+
+cat >"$lua_script" <<'LUA'
+local workspace_rules = {}
+local subscriptions = {}
+local queried = {}
+local all = {}
+
+local function window(address, options)
+  options = options or {}
+
+  local created = {
+    address = address,
+    floating = options.floating or false,
+    pinned = options.pinned or false,
+    group = options.group,
+    tags = {},
+    workspace = { id = options.workspace or 3 },
+  }
+
+  table.insert(all, created)
+
+  return created
+end
+
+local function has_tag(target, tag)
+  for _, held in ipairs(target.tags) do
+    if held == tag then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Two plain windows, one already floating on its own account, and a group whose
+-- members float together the way Hyprland floats a group target.
+local tiled = window("0xA")
+local already = window("0xB", { floating = true })
+local grouped = window("0xC", { group = "g" })
+local partner = window("0xD", { group = "g" })
+local pinned = window("0x12")
+
+hl = {
+  workspace_rule = function(rule)
+    table.insert(workspace_rules, rule)
+  end,
+  get_workspace_windows = function(selector)
+    table.insert(queried, tostring(selector))
+
+    local found = {}
+    for _, candidate in ipairs(all) do
+      if tostring(candidate.workspace.id) == tostring(selector) then
+        table.insert(found, candidate)
+      end
+    end
+
+    return found
+  end,
+  get_windows = function(filter)
+    local found = {}
+    for _, candidate in ipairs(all) do
+      if filter and filter.tag and has_tag(candidate, filter.tag) then
+        table.insert(found, candidate)
+      end
+    end
+
+    return found
+  end,
+  dispatch = function(action)
+    local target = action.window
+
+    if action.tag then
+      local name = action.tag:sub(2)
+
+      if action.tag:sub(1, 1) == "+" then
+        if not has_tag(target, name) then
+          table.insert(target.tags, name)
+        end
+      else
+        for index, held in ipairs(target.tags) do
+          if held == name then
+            table.remove(target.tags, index)
+            break
+          end
+        end
+      end
+    else
+      -- Floating a grouped window takes the rest of its group with it.
+      for _, candidate in ipairs(all) do
+        if candidate == target or (target.group and candidate.group == target.group) then
+          candidate.floating = action.action == "on"
+        end
+      end
+    end
+  end,
+  dsp = {
+    window = {
+      float = function(spec) return spec end,
+      tag = function(spec) return spec end,
+    },
+  },
+  on = function(event, callback)
+    subscriptions[event] = subscriptions[event] or {}
+    table.insert(subscriptions[event], callback)
   end,
 }
 
 dofile(os.getenv("OMARCHY_PATH") .. "/default/hypr/bootstrap.lua")
+require("default.hypr.helpers")
 require("default.hypr.workspace-layouts")
 
-assert(#rules == 1)
-assert(rules[1].workspace == "3")
-assert(rules[1].layout == "scrolling")
+local CLAIMED = "omarchy-mode-floated"
+
+-- Floating is not a layout, so the saved file must not have asked Hyprland for
+-- one by that name: Hyprland takes an unknown layout in silence and falls back
+-- to dwindle.
+assert(#workspace_rules == 0, "floating asked Hyprland for a layout")
+
+-- The windows of the workspace the file named, not of some other one.
+assert(#queried == 1 and queried[1] == "3", "the wrong workspace was queried: " .. table.concat(queried, ","))
+
+assert(tiled.floating == true, "the tiled window was not floated")
+assert(has_tag(tiled, CLAIMED), "the window the mode floated was not claimed")
+assert(already.floating == true, "the already floating window changed")
+assert(not has_tag(already, CLAIMED), "a window floating on its own account was claimed")
+
+-- Every member of a group is claimed. Floating one floats them all, so claiming
+-- as it goes would find the rest already floating and leave them unclaimed.
+assert(grouped.floating == true and partner.floating == true, "the group was not floated")
+assert(has_tag(grouped, CLAIMED) and has_tag(partner, CLAIMED), "a group member went unclaimed")
+
+-- One handler each: subscribing on every call would float a window as many
+-- times as the mode has ever been set.
+assert(#subscriptions["window.open"] == 1, "window.open subscribed more than once")
+assert(#subscriptions["window.move_to_workspace"] == 1, "moves subscribed more than once")
+
+local opened = subscriptions["window.open"][1]
+local moved = subscriptions["window.move_to_workspace"][1]
+
+-- A window opening on a floating workspace floats; one that arrives floating
+-- already is left alone, so the mode never claims it.
+local fresh = window("0xE")
+opened(fresh)
+assert(fresh.floating == true, "a window opened on a floating workspace stayed tiled")
+assert(has_tag(fresh, CLAIMED), "a window opened into the mode was not claimed")
+
+local own_rule = window("0xF", { floating = true })
+opened(own_rule)
+assert(not has_tag(own_rule, CLAIMED), "a window with its own float rule was claimed")
+
+-- A window carried onto a floating workspace never had that workspace's mode
+-- applied to it.
+local carried = window("0x10", { workspace = 4 })
+moved(carried, { id = 3 })
+assert(carried.floating == true, "a window carried onto a floating workspace stayed tiled")
+
+-- Carried on to a tiled workspace, the mode gives back what it took.
+carried.workspace.id = 5
+moved(carried, { id = 5 })
+assert(carried.floating == false, "a window the mode floated stayed floating on a tiled workspace")
+assert(not has_tag(carried, CLAIMED), "a window the mode gave back is still claimed")
+
+-- A window floating on its own account keeps floating wherever it goes.
+moved(own_rule, { id = 5 })
+assert(own_rule.floating == true, "a window floating on its own account was tiled by a move")
+
+-- Carried between two floating workspaces it stays claimed, so the workspace it
+-- ends on can still give it back.
+o.workspace_mode({ workspace = "6", mode = "floating" })
+tiled.workspace.id = 6
+moved(tiled, { id = 6 })
+assert(tiled.floating == true, "a window moved between floating workspaces was tiled")
+assert(has_tag(tiled, CLAIMED), "a window moved between floating workspaces lost its claim")
+
+o.workspace_mode({ workspace = "6", mode = "dwindle" })
+assert(tiled.floating == false, "the workspace a claimed window moved to could not give it back")
+
+-- A pinned window was put above everything on purpose, and tiling it would unpin
+-- it too, so the mode leaves it where the user put it.
+assert(has_tag(pinned, CLAIMED), "the window to be pinned was never claimed")
+pinned.pinned = true
+
+-- Ending the mode tiles what the mode claimed, and only that.
+o.workspace_mode({ workspace = "3", mode = "dwindle" })
+assert(#workspace_rules == 2, "leaving floating did not set a layout")
+assert(workspace_rules[2].layout == "dwindle")
+assert(workspace_rules[2].workspace == "3", "the layout was applied to the wrong workspace")
+assert(grouped.floating == false, "the window the mode floated was left floating")
+assert(already.floating == true, "a window floating on its own account was tiled by the mode ending")
+assert(partner.floating == false, "a group member the mode floated was left floating")
+assert(pinned.floating == true, "a pinned window was tiled by the mode ending")
+assert(has_tag(pinned, CLAIMED), "a pinned window lost the claim that returns it once unpinned")
+
+-- Still one handler each after a second mode: the count above was taken before
+-- this call, so only a check on this side catches subscribing every time.
+assert(#subscriptions["window.open"] == 1, "window.open subscribed again on the next mode")
+assert(#subscriptions["window.move_to_workspace"] == 1, "moves subscribed again on the next mode")
+
+-- The workspace is tiled now, so nothing opening on it should float.
+local after = window("0x11")
+opened(after)
+assert(after.floating == false, "a window opened after the mode ended was floated")
+
+-- Scrolling is a layout like dwindle, and has to reach Hyprland as one.
+o.workspace_mode({ workspace = "3", mode = "scrolling" })
+assert(workspace_rules[#workspace_rules].layout == "scrolling", "scrolling was not applied as a layout")
+assert(workspace_rules[#workspace_rules].workspace == "3")
 LUA
 
 # Lua 5.5 exits 0 when a script that failed came in on stdin, so a heredoc piped
 # straight into lua reports every assertion above as passing. Run it as a file.
-if ! HOME="$home_dir" OMARCHY_PATH="$ROOT" lua "$lua_script"; then
-  fail "saved workspace layouts load into Hyprland configuration"
+# XDG_STATE_HOME is named here for the same reason the toggle helper names it:
+# the loader reads the saved modes from paths.state_home, so a machine that
+# exports it would load its own saved layouts instead of the fixture below.
+if ! HOME="$home_dir" XDG_STATE_HOME="$home_dir/.local/state" OMARCHY_PATH="$ROOT" \
+  lua "$lua_script"; then
+  fail "a saved floating mode floats the workspace without inventing a layout"
 fi
-pass "saved workspace layouts load into Hyprland configuration"
+pass "a saved floating mode floats the workspace without inventing a layout"

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -50,7 +50,9 @@ fi
   fail "workspace layout toggle does not persist a rule without a workspace id"
 pass "workspace layout toggle ignores broken hyprctl output"
 
-HOME="$home_dir" OMARCHY_PATH="$ROOT" lua <<'LUA'
+lua_script="$tmpdir/workspace-layouts.lua"
+
+cat >"$lua_script" <<'LUA'
 local rules = {}
 
 hl = {
@@ -66,4 +68,10 @@ assert(#rules == 1)
 assert(rules[1].workspace == "3")
 assert(rules[1].layout == "scrolling")
 LUA
+
+# Lua 5.5 exits 0 when a script that failed came in on stdin, so a heredoc piped
+# straight into lua reports every assertion above as passing. Run it as a file.
+if ! HOME="$home_dir" OMARCHY_PATH="$ROOT" lua "$lua_script"; then
+  fail "saved workspace layouts load into Hyprland configuration"
+fi
 pass "saved workspace layouts load into Hyprland configuration"


### PR DESCRIPTION
Super + L toggled the active workspace between the dwindle and scrolling tiled layouts. It now cycles dwindle → scrolling → floating → dwindle, and on a floating workspace every window floats.

## Floating cannot be a third layout

Hyprland has no tiled layout called `floating`, and it does not complain when asked for one. `hl.workspace_rule({ workspace = "1", layout = "floating" })` returns `ok` and leaves the workspace on dwindle — the same silence a misspelt name gets. The one-word version of this change would have been a no-op that still announced "Workspace layout set to floating". `hyprctl activeworkspace` names the field `tiledLayout` for the reason underneath that: floating is a property of a window, not an arrangement of them.

So the mode floats the windows themselves, through the same `float` dispatcher Super + T uses. `default/hypr/workspace-modes.lua` holds it, and `bin/` reaches it through `hyprctl eval`, which shares the config's Lua state.

## Giving back only what it took

Ending the mode has to tile the windows the mode floated and leave the rest alone, so each one it floats is tagged `omarchy-mode-floated`. A window already floating when the mode reaches it — an app with a float rule of its own, a dialog, one popped out with Super + T — is never claimed, and is still floating when the mode ends. Without that, one trip through floating would tile every window that is meant to float always: everything tagged `floating-window` in `apps/system.lua`, and `org.omarchy.terminal`, `imv`, `mpv`, 1Password among them.

The tag lives on the window rather than in a table on the Lua side, because a table does not survive `hyprctl reload` — which `omarchy-hyprland-monitor-watch` performs when a monitor is plugged in, and `omarchy-hyprland-window-gaps-toggle` on a keypress. A reload rebuilds the Lua state, and provenance kept there would be lost while the windows stayed floating, so leaving the mode afterwards would strand them. The tag also follows a window between workspaces and dies with it, so nothing has to be cleaned up when a window closes.

A pinned window is left alone entirely: tiling one unpins it too, and it was put above everything on purpose.

## Why events rather than a window rule

Windows arrive on a workspace three ways and a rule only covers one. `window.open` catches what opens there, `window.move_to_workspace` what is carried in, and the same event what is carried back out — which gives up the floating the mode gave it rather than leaving it floating on a workspace that tiles. A rule also cannot tell a window it floated from one that was floating already, which is the distinction the whole of the section above rests on.

Every tiled window is claimed in one pass before any is floated in the next, because floating one member of a group floats the rest, and claiming as it went would find those already floating and leave them stranded.

## What remembers the mode

The saved file, not the compositor. Hyprland reports a workspace's tiled layout and floating is not one, so a floating workspace still answers `dwindle` or `scrolling`; a cycle that trusted that answer would skip a step. A file saved before floating existed names a layout rather than a mode, falls through to what Hyprland reports, and is rewritten by the next press, so nothing needs migrating.

## Two faults that had to go first

Saving the mode makes both of them persistent rather than momentary.

Named workspaces report a negative id, which passed the old `^-?[0-9]+$` guard, and Hyprland reads a leading `-` as a selector relative to the current workspace. Pressing Super + L on a named workspace reconfigured workspace 1 instead — `name:mail` reports `-1337`, and targeting it moved workspace 1 to scrolling. It would now also save a file that did the same at every login. Such a workspace is left alone.

A migration removes the ones an earlier version already wrote, because the guard only stops new ones and the files on disk go on being loaded at every login.

The saved state was written under `$HOME/.local/state` while the Hyprland side reads `XDG_STATE_HOME`, and that had to reach `package.path` as well: the loader lists the directory but loads the files by module name, so a state home anywhere else listed the saved layouts and then loaded same-named ones from the home directory. `toggles.lua` already solves this the same way.

## Applying and saving fail separately

Reaching the compositor and reaching disk are different things that go wrong for different reasons, and the next press reads the mode back from the file. A save that failed quietly would leave the cycle running between two modes and never arriving at the third, so it is reported: a mode that applied but could not be saved says so rather than counting as set.

## The keyword fallback is gone

The old script fell back to `hyprctl keyword workspace "<id>, layout:<layout>"` when the Lua call failed. `hyprctl keyword` refuses a Lua configuration outright — *keyword can't work with non-legacy parsers. Use eval.* — and exits 0 while doing so, so as a fallback it neither worked nor reported that it had not. A failed apply now says so and saves nothing, rather than announcing a layout the screen does not show and restoring it at the next login.

## Consequences, for a decision rather than a fix

- A window opening while another window on that workspace is fullscreen takes the fullscreen with it. That follows from floating at the open event instead of at map time, and the event is what makes ownership knowable; the window is visible and focusable either way.
- Super + L now does nothing at all on a named workspace, where it previously did something wrong to a different one. Making it work there is a separate change: the mode would have to be keyed by name while the move handler sees numeric ids.
- The mode is per workspace and the cycle acts on the active one, so each workspace keeps its own.
- Grouping is the edge the ownership model does not reach. A window opened into a group that is already floating inherits the group's floating state, so the mode never claims it and it stays floating when the mode ends; and tiling a claimed window tiles its unclaimed group members with it, because Hyprland floats and tiles a group as one. Following group membership as it changes is a larger piece of bookkeeping than the rest of this put together, and it is worth deciding whether it is wanted before it is written.
- `Super + O` mis-fires on a window that is floating, because `omarchy-hyprland-window-pop` begins by toggling float on anything unpinned. That is true today of any window with its own float rule; a floating workspace only makes it easier to meet. It belongs in its own change.

The first commit is separate because it is a different bug: Lua 5.5 exits 0 when a failing script arrives on stdin, so the heredoc form this test used made every Lua assertion in it unfailable — pointing one at a layout the toggle never writes still left the file green. It runs as a script file now.

Checked by Codex at xhigh as an independent reviewer.
