### PR TITLE
Stop early-loading the NVIDIA driver on hybrid GPU machines so hibernation can resume

### DIFF
--- a/bin/omarchy-hw-nvidia-only-display
+++ b/bin/omarchy-hw-nvidia-only-display
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether NVIDIA owns every display controller (no iGPU or other GPU).
+
+# Read the cached sysfs IDs rather than lspci, which reads PCI config space and
+# resumes runtime-suspended GPUs. Anything unreadable could be another GPU, so
+# it counts as one: callers use a "yes" to early-load nvidia and to drop the
+# kms hook from the initramfs, so the answer must err towards "no".
+pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
+shopt -s nullglob
+
+nvidia=0
+for device in "$pci_devices_path"/*; do
+  [[ -r $device/class && -r $device/vendor ]] || exit 1
+  [[ $(< "$device/class") == 0x03* ]] || continue
+  [[ $(< "$device/vendor") == "0x10de" ]] || exit 1
+  nvidia=1
+done
+
+((nvidia))

--- a/install/hardware/nvidia.sh
+++ b/install/hardware/nvidia.sh
@@ -25,9 +25,24 @@ if lspci | grep -qi 'nvidia'; then
 options nvidia_drm modeset=1
 EOF
 
-  # Configure mkinitcpio for early loading
+  # Early-load the driver in the initramfs only when NVIDIA owns every display
+  # controller. That is the one case that needs it: without it an NVIDIA-only
+  # machine has no KMS at the LUKS prompt.
+  #
+  # A hybrid machine gets early KMS from its iGPU, and early-loading nvidia
+  # there breaks resume from hibernation: the kernel freezes devices to restore
+  # the image while the driver is already loaded but nothing has called its
+  # procfs suspend interface (nvidia-hibernate.service only runs from the real
+  # root), so nv_pmops_freeze returns -5 and the machine boots fresh instead.
+  # udev still loads the driver once the root is mounted.
+  #
+  # Same scan omarchy_hooks.conf uses to decide whether to drop the kms hook.
   mkdir -p /etc/mkinitcpio.conf.d
-  cat > /etc/mkinitcpio.conf.d/nvidia.conf <<'EOF'
+  if omarchy-hw-nvidia-only-display; then
+    cat > /etc/mkinitcpio.conf.d/nvidia.conf <<'EOF'
 MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
+  else
+    rm -f /etc/mkinitcpio.conf.d/nvidia.conf
+  fi
 fi

--- a/migrations/1787683023.sh
+++ b/migrations/1787683023.sh
@@ -1,0 +1,21 @@
+echo "Stop early-loading the NVIDIA driver on hybrid GPU systems so hibernation can resume"
+
+# install/hardware/nvidia.sh used to write nvidia.conf on every NVIDIA machine.
+# On a hybrid laptop the iGPU provides early KMS, and having nvidia already
+# loaded inside the initramfs makes resume from hibernation fail with
+# "nv_pmops_freeze returns -5" / "PM: hibernation: resume failed (-5)".
+# Drop the drop-in on those machines and rebuild the initramfs once. A marker
+# records completion so another user's run does not repeat the rebuild.
+
+nvidia_conf="${OMARCHY_MKINITCPIO_NVIDIA_CONF:-/etc/mkinitcpio.conf.d/nvidia.conf}"
+rebuild_marker="${OMARCHY_NVIDIA_REBUILD_MARKER:-/var/lib/omarchy/migrations/1787683023}"
+
+omarchy-cmd-present limine-mkinitcpio || exit 0
+[[ -f $nvidia_conf ]] || exit 0
+[[ ! -e $rebuild_marker ]] || exit 0
+omarchy-hw-nvidia-only-display && exit 0
+
+echo "This is a hybrid GPU machine; removing nvidia from the initramfs and rebuilding it"
+sudo rm -f "$nvidia_conf"
+sudo limine-mkinitcpio
+sudo install -Dm644 /dev/null "$rebuild_marker"

--- a/migrations/1787683023.sh
+++ b/migrations/1787683023.sh
@@ -16,6 +16,18 @@ omarchy-cmd-present limine-mkinitcpio || exit 0
 omarchy-hw-nvidia-only-display && exit 0
 
 echo "This is a hybrid GPU machine; removing nvidia from the initramfs and rebuilding it"
+
+# The drop-in has to be gone before the rebuild, but the rebuild is what makes
+# the change real. If it fails, put the drop-in back so the next run finds it
+# and retries instead of exiting at the check above with a stale image.
+backup=$(mktemp)
+cp "$nvidia_conf" "$backup"
 sudo rm -f "$nvidia_conf"
-sudo limine-mkinitcpio
+if ! sudo limine-mkinitcpio; then
+  sudo install -m644 "$backup" "$nvidia_conf"
+  rm -f "$backup"
+  echo "Rebuilding the initramfs failed; restored $nvidia_conf so the migration retries" >&2
+  exit 1
+fi
+rm -f "$backup"
 sudo install -Dm644 /dev/null "$rebuild_marker"

--- a/test/shell.d/hw-nvidia-only-display-test.sh
+++ b/test/shell.d/hw-nvidia-only-display-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Each argument is a PCI device as "vendor:class", in sysfs's own format.
+write_pci_devices() {
+  rm -rf "$tmp_dir/devices"
+  mkdir -p "$tmp_dir/devices"
+
+  local index=0
+  local spec
+  for spec in "$@"; do
+    local slot
+    slot=$(printf '0000:%02x:00.0' "$index")
+    mkdir -p "$tmp_dir/devices/$slot"
+    printf '%s\n' "${spec%%:*}" >"$tmp_dir/devices/$slot/vendor"
+    printf '%s\n' "${spec##*:}" >"$tmp_dir/devices/$slot/class"
+    index=$((index + 1))
+  done
+}
+
+assert_nvidia_only() {
+  local description="$1" expected="$2"
+
+  local actual=no
+  OMARCHY_PCI_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-nvidia-only-display" && actual=yes
+
+  [[ $actual == "$expected" ]] || fail "$description" "expected $expected, got $actual"
+  pass "$description"
+}
+
+write_pci_devices 0x10de:0x030000
+assert_nvidia_only "a lone NVIDIA GPU owns every display controller" yes
+
+# The GPU's own audio function is not a display controller.
+write_pci_devices 0x10de:0x030000 0x10de:0x040300
+assert_nvidia_only "a non-display NVIDIA function does not change the answer" yes
+
+write_pci_devices 0x8086:0x030000 0x10de:0x030200
+assert_nvidia_only "an Intel iGPU beside the NVIDIA GPU makes it hybrid" no
+
+write_pci_devices 0x1002:0x030000 0x10de:0x030200
+assert_nvidia_only "an AMD iGPU beside the NVIDIA GPU makes it hybrid" no
+
+write_pci_devices 0x1002:0x030000
+assert_nvidia_only "a machine without NVIDIA is not NVIDIA-only" no
+
+write_pci_devices
+assert_nvidia_only "a machine with no PCI devices is not NVIDIA-only" no
+
+# A device whose class cannot be read could be another GPU, so the helper
+# refuses to claim NVIDIA-only.
+write_pci_devices 0x10de:0x030000 0x8086:0x030000
+chmod 000 "$tmp_dir/devices/0000:01:00.0/class"
+if [[ $(id -u) -ne 0 ]]; then
+  assert_nvidia_only "an unreadable device keeps the answer conservative" no
+fi

--- a/test/shell.d/nvidia-hybrid-initramfs-migration-test.sh
+++ b/test/shell.d/nvidia-hybrid-initramfs-migration-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787683023.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+(( ${LIMINE_MKINITCPIO_INSTALLED:-1} == 1 ))
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+exit "${LIMINE_MKINITCPIO_STATUS:-0}"
+SH
+
+chmod +x "$stub_bin"/*
+
+nvidia_conf="$test_tmp/nvidia.conf"
+rebuild_marker="$test_tmp/rebuild-complete"
+nvidia_conf_body='MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)'
+
+write_nvidia_conf() {
+  echo "$nvidia_conf_body" >"$nvidia_conf"
+}
+
+# Each argument is a PCI device as "vendor:class", in sysfs's own format.
+write_pci_devices() {
+  rm -rf "$test_tmp/devices"
+  mkdir -p "$test_tmp/devices"
+
+  local index=0
+  local spec
+  for spec in "$@"; do
+    local slot
+    slot=$(printf '0000:%02x:00.0' "$index")
+    mkdir -p "$test_tmp/devices/$slot"
+    printf '%s\n' "${spec%%:*}" >"$test_tmp/devices/$slot/vendor"
+    printf '%s\n' "${spec##*:}" >"$test_tmp/devices/$slot/class"
+    index=$((index + 1))
+  done
+}
+
+# The migration shells out to omarchy-hw-nvidia-only-display, so the real
+# helper from bin/ sits on PATH behind the stubs.
+run_migration() {
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_MKINITCPIO_NVIDIA_CONF="$nvidia_conf" \
+    OMARCHY_NVIDIA_REBUILD_MARKER="$rebuild_marker" \
+    OMARCHY_PCI_DEVICES_PATH="$test_tmp/devices" \
+    bash -euo pipefail "$migration" >/dev/null 2>&1
+}
+
+# Hybrid laptop (Intel iGPU + NVIDIA dGPU): the drop-in goes, the image is
+# rebuilt, and the repair is recorded.
+write_pci_devices 0x8086:0x030000 0x10de:0x030200
+write_nvidia_conf
+run_migration
+
+[[ ! -e $nvidia_conf ]] || fail "a hybrid machine loses the nvidia drop-in"
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "a hybrid machine rebuilds its initramfs"
+[[ -f $rebuild_marker ]] || fail "the rebuild records the machine-wide repair"
+pass "migration removes the drop-in and rebuilds on a hybrid machine"
+
+: >"$calls"
+run_migration
+
+[[ ! -s $calls ]] || fail "a recorded rebuild is not repeated" "$(cat "$calls")"
+pass "migration is machine-idempotent across users"
+
+# A rebuild that fails must leave the machine retryable: the drop-in comes
+# back, nothing is marked done, and the next run rebuilds again.
+rm -f "$rebuild_marker"
+write_nvidia_conf
+: >"$calls"
+if LIMINE_MKINITCPIO_STATUS=1 run_migration; then
+  fail "a failed rebuild is reported as a failure"
+fi
+
+[[ -f $nvidia_conf ]] || fail "a failed rebuild restores the nvidia drop-in"
+[[ $(<"$nvidia_conf") == "$nvidia_conf_body" ]] || fail "the restored drop-in is intact"
+[[ ! -e $rebuild_marker ]] || fail "a failed rebuild is not marked as repaired"
+pass "migration restores the drop-in when the rebuild fails"
+
+: >"$calls"
+run_migration
+
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "a failed rebuild is retried on the next run"
+[[ ! -e $nvidia_conf ]] || fail "the retry removes the drop-in again"
+[[ -f $rebuild_marker ]] || fail "the retry records the repair"
+pass "migration retries after a failed rebuild"
+
+# NVIDIA-only desktop: the early load is what gives it KMS at the LUKS prompt.
+write_pci_devices 0x10de:0x030000
+rm -f "$rebuild_marker"
+write_nvidia_conf
+: >"$calls"
+run_migration
+
+[[ -f $nvidia_conf ]] || fail "an NVIDIA-only machine keeps its drop-in"
+[[ ! -s $calls ]] || fail "an NVIDIA-only machine is left alone" "$(cat "$calls")"
+[[ ! -e $rebuild_marker ]] || fail "an untouched machine is not marked as repaired"
+pass "migration skips an NVIDIA-only machine"
+
+# Installs the migration does not apply to.
+write_pci_devices 0x8086:0x030000 0x10de:0x030200
+: >"$calls"
+LIMINE_MKINITCPIO_INSTALLED=0 run_migration
+
+[[ ! -s $calls ]] || fail "installs without limine-mkinitcpio are skipped" "$(cat "$calls")"
+
+rm -f "$nvidia_conf"
+run_migration
+
+[[ ! -s $calls ]] || fail "machines without the nvidia drop-in are skipped" "$(cat "$calls")"
+[[ ! -e $rebuild_marker ]] || fail "a skipped machine is not marked as repaired"
+pass "migration skips installs it does not apply to"


### PR DESCRIPTION
## Stop early-loading the NVIDIA driver on hybrid GPU machines so hibernation can resume

### Problem

On a hybrid laptop (Intel/AMD iGPU + NVIDIA dGPU), hibernate writes the image fine but resume silently boots fresh. The previous boot's journal shows:

```
NVRM: PreserveVideoMemoryAllocations module parameter is set. System Power
      Management attempted without driver procfs suspend interface.
nvidia: PM: pci_pm_freeze(): nv_pmops_freeze returns -5
PM: hibernation: resume failed (-5)
```

`install/hardware/nvidia.sh` writes `/etc/mkinitcpio.conf.d/nvidia.conf` with `MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)` on every NVIDIA machine. During resume the kernel freezes devices before restoring the image; the driver is already loaded from the initramfs, but nothing has called its procfs suspend interface (`nvidia-hibernate.service` only runs from the real root), so `nv_pmops_freeze` returns `-EIO` and the resume is abandoned.

On a hybrid machine the early load buys nothing, the iGPU already provides KMS at the LUKS prompt  and udev loads nvidia normally once root is mounted. Removing the modules from the initramfs fixes resume; I've been running this way on an ASUS ROG Strix G16 (Raptor Lake-HX + RTX, nvidia-open-dkms 610.57.04, linux 7.1.8, LUKS + btrfs, `resume=`/`resume_offset=`).

### Change

- **`bin/omarchy-hw-nvidia-only-display`** (new): true when NVIDIA owns every display controller. Reads sysfs like `omarchy-hw-nvidia-gsp` (no `lspci`, so it doesn't wake a runtime-suspended GPU), and treats any unreadable device as "another GPU" so the answer errs toward not early-loading. It is the same scan `omarchy_hooks.conf` already does inline to decide whether to drop the `kms` hook.
- **`install/hardware/nvidia.sh`**: write `nvidia.conf` only when that helper says NVIDIA-only; otherwise ensure it is absent.
- **`migrations/1787683023.sh`**: on existing hybrid installs, remove `nvidia.conf` and rebuild once via `limine-mkinitcpio`, with a marker so the machine-wide rebuild isn't repeated per user (same pattern as `1786605598.sh`).

NVIDIA-only machines are unchanged: they still early-load and still drop `kms`. `omarchy_hooks.conf`'s conditional keys off `nvidia_drm` in `MODULES`, so on hybrid machines (where `MODULES` no longer contains it) it keeps `kms`, which is what it did before anyway.

### Testing

- Helper: exits 1 on the Strix G16 (Intel + NVIDIA), exits 0 on a fake `OMARCHY_PCI_DEVICES_PATH` tree with a single `0x10de` class-`0x03` device.
- With nvidia stripped from the initramfs (`lsinitcpio` shows 0 nvidia entries), `systemctl hibernate` resumes to the running session; before the change every hibernate ended in a fresh boot with the log lines above.
