### PR TITLE
Discover agent usage collectors in ~/.local/bin

### DIFF
--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -7,7 +7,8 @@
 # Each omarchy-agent-usage-<agent> collector prints one display-ready JSON
 # record; this writes them to ~/.local/state/omarchy/agents/usage/ where the
 # agents panel watches them. Adding an agent is adding a collector — the
-# panel picks up any record that appears here.
+# panel picks up any record that appears here, and collectors are read from
+# both Omarchy's bin and ~/.local/bin.
 
 USAGE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
 mkdir -p "$USAGE_DIR"
@@ -51,13 +52,34 @@ collect() {
   mv "$tmp" "$USAGE_DIR/$agent.json"
 }
 
-pids=()
-for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
-  [[ -x $collector ]] || continue
+declare -A collector_for
+agents=()
+
+register() {
+  local collector="$1" agent
+  [[ -x $collector ]] || return
   agent="${collector##*/omarchy-agent-usage-}"
-  [[ $agent == "update" ]] && continue
+  [[ $agent == "update" ]] && return
+  if [[ -z ${collector_for[$agent]:-} ]]; then
+    agents+=("$agent")
+  fi
+  collector_for[$agent]="$collector"
+}
+
+for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
+  register "$collector"
+done
+
+# A user collector wins a name collision: overriding a packaged one is the
+# reason to put a script there in the first place.
+for collector in "$HOME"/.local/bin/omarchy-agent-usage-*; do
+  register "$collector"
+done
+
+pids=()
+for agent in "${agents[@]}"; do
   wanted "$agent" || continue
-  collect "$collector" "$agent" &
+  collect "${collector_for[$agent]}" "$agent" &
   pids+=($!)
 done
 

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -63,3 +63,33 @@ pass "update succeeds when the requested collectors all pass"
 [[ -e $usage_dir/skipped.json && ! -e $usage_dir/noisy.json ]] ||
   fail "update with agent arguments only runs the named collectors"
 pass "update with agent arguments only runs the named collectors"
+
+# A collector dropped into ~/.local/bin is discovered too: the panel already
+# picks up any record in the usage directory, so adding one should not also
+# require shadowing this script.
+mkdir -p "$TEST_HOME/.local/bin"
+
+cat >"$TEST_HOME/.local/bin/omarchy-agent-usage-userly" <<'COLLECTOR'
+#!/bin/bash
+echo '{"schemaVersion":1,"id":"userly","name":"User Agent"}'
+COLLECTOR
+
+cat >"$TEST_HOME/.local/bin/omarchy-agent-usage-good" <<'COLLECTOR'
+#!/bin/bash
+echo '{"schemaVersion":1,"id":"good","name":"Overridden Agent"}'
+COLLECTOR
+
+chmod +x "$TEST_HOME/.local/bin/"omarchy-agent-usage-*
+
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" userly good 2>/dev/null ||
+  fail "update runs collectors from ~/.local/bin"
+pass "update runs collectors from ~/.local/bin"
+
+[[ $(jq -r '.name' "$usage_dir/userly.json") == "User Agent" ]] ||
+  fail "update writes a record for a collector found in ~/.local/bin"
+pass "update writes a record for a collector found in ~/.local/bin"
+
+[[ $(jq -r '.name' "$usage_dir/good.json") == "Overridden Agent" ]] ||
+  fail "a user collector takes precedence over the packaged one"
+pass "a user collector takes precedence over the packaged one"


### PR DESCRIPTION
The comment at the top of `bin/omarchy-agent-usage-update` says:

> Adding an agent is adding a collector — the panel picks up any record that appears here.

The panel lives up to that. `shell/plugins/agents/Main.qml` discovers by globbing the usage directory:

```
command: ["find", root.usageDir, "-maxdepth", "1", "-name", "*.json", "-printf", "%f\n"]
```

The updater does not. It globs only `$OMARCHY_PATH/bin/omarchy-agent-usage-*`, so a collector written by a user is never run and no record is ever written for it. The only way to get one collected today is to shadow `omarchy-agent-usage-update` itself with a copy that calls the packaged one and then runs your collector — which then has to be maintained against every release.

I hit this writing a collector for Antigravity: it follows the documented record contract and the panel renders it correctly once a record exists, but nothing runs it.

## Change

Register collectors from `$OMARCHY_PATH/bin` and `~/.local/bin`, keyed by agent name so each is collected once. A user collector wins a name collision, since replacing a packaged one is the reason to put a script there.

## Tests

Three cases added to `test/shell.d/agent-usage-update-test.sh`, which already sets `HOME` to a temp dir:

- a collector in `~/.local/bin` is run
- its record is written to the usage directory
- a user collector takes precedence over a packaged one of the same name

They fail on master and pass with the change. `test/cli` is green. `test/shell` has 5 pre-existing failures on my machine (`bar-icon-geometry`, `config`, `runtime-smoke`, `snapper`, `unowned-system-paths`) — identical before and after this change, so unrelated to it.