### PR TITLE
Avoid mise shim recursion in Copy URL migration test

### DIFF
--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -28,7 +28,7 @@ write_stale_preferences() {
 stub_bin="$test_dir/bin"
 mkdir -p "$stub_bin"
 
-REAL_PYTHON=$(command -v python3)
+REAL_PYTHON=$(command -p -v python3)
 export REAL_PYTHON
 
 run_migration() {

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -28,8 +28,18 @@ write_stale_preferences() {
 stub_bin="$test_dir/bin"
 mkdir -p "$stub_bin"
 
-REAL_PYTHON=$(command -p -v python3)
+cat >"$stub_bin/python3" <<'STUB'
+#!/bin/bash
+exit 127
+STUB
+chmod +x "$stub_bin/python3"
+
+# Test stubs must delegate to the system interpreter, not a user shim that can
+# route python3 back through the stubs and recurse.
+REAL_PYTHON=$(PATH="$stub_bin:$PATH" command -p -v python3)
+[[ $REAL_PYTHON != "$stub_bin/python3" ]] || fail "real Python resolution bypasses user shims"
 export REAL_PYTHON
+rm -f "$stub_bin/python3"
 
 run_migration() {
   HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1


### PR DESCRIPTION
## Summary

- Resolve the real Python interpreter through the standard command path.
- Prevent the Copy URL migration test stub from recursing through a mise shim.

## Why

On systems where mise shims precede system binaries, `command -v python3` returns the mise shim. The test later puts its own `python3` stub first in `PATH` and invokes the saved command.

Mise then resolves `python3` back to the test stub. This recursively creates processes until the PID limit is reached. Mise can then abort while building its Tokio runtime.

`command -p -v python3` selects the system Python and keeps the stub handoff finite.

## Observed failure

On an affected Arch Linux ARM system with mise 2026.8.6:

- `systemd-coredump` recorded 10 matching `mise` SIGABRT events across two boots.
- The failing scope reached both `pids.max = 9447` and `pids.peak = 9447`; its PID controller recorded rejected task creation.
- The core contained: `OS can't spawn worker thread: Resource temporarily unavailable (os error 11)`.
- Memory remained available and the scope recorded no OOM event.
- The two latest recurrences were traced live to an unfixed checkout running this test repeatedly; the task count returned to normal after the abort unwound the recursive chain.

## Testing

- `./test/all` with the local packaging and ISO checkouts: all 190 test files passed
- `bin/omarchy commands --check`: 430 commands passed
- All `bin/omarchy-*` scripts passed syntax checks
- `bash -n test/shell.d/copy-url-shortcut-migration-test.sh`
- `git diff --check omarchy/quattro...HEAD`

Filed by GPT-5 via Codex.