### PR TITLE
Skip cross-repository checks without sibling repos

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,18 @@ A new shell test only needs the right name: drop `<area>-test.sh` into
 `test/shell.d/` and `./test/shell` picks it up automatically. Shared fixtures
 live under `test/shell.d/fixtures/`.
 
+## Cross-repository coverage
+
+Some shell tests also verify packaging and installer contracts in the separate `omarchy-pkgs` and `omarchy-iso` repositories. They look for conventional sibling checkouts automatically. When a checkout is unavailable, only its cross-repository assertions are reported as skipped; the rest of the test file still runs.
+
+Set `OMARCHY_PKGS_PATH` to the `omarchy-pkgs` checkout or its `pkgbuilds/` directory, and set `OMARCHY_ISO_PATH` to the `omarchy-iso` checkout, to run that coverage from repositories stored elsewhere:
+
+```bash
+OMARCHY_PKGS_PATH=../omarchy-pkgs OMARCHY_ISO_PATH=../omarchy-iso ./test/all
+```
+
+An explicit path that cannot be resolved fails the dependent test instead of skipping it.
+
 ## The base-test.sh contract
 
 Every shell test starts the same way:

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -107,22 +107,23 @@ pkgs_candidates = [
 # Accepts either the omarchy-pkgs checkout or its pkgbuilds/ directory.
 override = os.environ.get("OMARCHY_PKGS_PATH")
 if override:
-  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)] + pkgs_candidates
+  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)]
 pkgs_root = next((path for path in pkgs_candidates if path.exists()), None)
 if pkgs_root is None:
   if override:
     print("not ok - OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout", file=sys.stderr)
     sys.exit(1)
-  print("ok - no omarchy-pkgs checkout; skipping PKGBUILD coverage")
-  sys.exit(0)
-settings_pkgbuild_path = pkgs_root / "omarchy-settings/PKGBUILD"
-omarchy_pkgbuild_path = pkgs_root / "omarchy/PKGBUILD"
-if not settings_pkgbuild_path.exists():
-  settings_pkgbuild_path = pkgs_root / "omarchy-settings-dev/PKGBUILD"
-if not omarchy_pkgbuild_path.exists():
-  omarchy_pkgbuild_path = pkgs_root / "omarchy-dev/PKGBUILD"
-pkgbuild = settings_pkgbuild_path.read_text()
-omarchy_pkgbuild = omarchy_pkgbuild_path.read_text()
+  pkgbuild = None
+  omarchy_pkgbuild = None
+else:
+  settings_pkgbuild_path = pkgs_root / "omarchy-settings/PKGBUILD"
+  omarchy_pkgbuild_path = pkgs_root / "omarchy/PKGBUILD"
+  if not settings_pkgbuild_path.exists():
+    settings_pkgbuild_path = pkgs_root / "omarchy-settings-dev/PKGBUILD"
+  if not omarchy_pkgbuild_path.exists():
+    omarchy_pkgbuild_path = pkgs_root / "omarchy-dev/PKGBUILD"
+  pkgbuild = settings_pkgbuild_path.read_text()
+  omarchy_pkgbuild = omarchy_pkgbuild_path.read_text()
 errors = []
 package_defaults = [
   ("default/uwsm/env.d/10-omarchy", "/usr/share/uwsm/env.d/10-omarchy", "uwsm/env"),
@@ -149,14 +150,14 @@ for source, destination, legacy in package_defaults:
     errors.append(f"missing package default source: {source}")
   if (root / "config" / legacy).exists():
     errors.append(f"legacy path still in config/: {legacy}")
-  if destination and (source not in pkgbuild or destination not in pkgbuild):
+  if pkgbuild is not None and destination and (source not in pkgbuild or destination not in pkgbuild):
     errors.append(f"PKGBUILD does not explicitly install {source} -> {destination}")
 
 # Existing users have an absolute wants symlink to the old unit path, and the
 # migration that repoints it only runs for users who run an update -- the
 # opposite of who the notifier is for. Dropping this alias strands them.
 notify_alias = 'ln -sfn omarchy-migrate-notify.service "$pkgdir/usr/lib/systemd/user/omarchy-update-user-notify.service"'
-if notify_alias not in pkgbuild:
+if pkgbuild is not None and notify_alias not in pkgbuild:
   errors.append(
     "PKGBUILD does not ship the omarchy-update-user-notify.service compatibility "
     "alias, so users who have not run migration 1785095882 lose the login notifier"
@@ -172,13 +173,15 @@ for hook in alpm_hooks:
   destination = f"/usr/share/libalpm/hooks/{hook}"
   if not (root / source).exists():
     errors.append(f"missing package default source: {source}")
-  if source not in omarchy_pkgbuild or destination not in omarchy_pkgbuild:
+  if omarchy_pkgbuild is not None and (source not in omarchy_pkgbuild or destination not in omarchy_pkgbuild):
     errors.append(f"omarchy PKGBUILD does not install {source} -> {destination}")
 
 if errors:
   print("\n".join(errors), file=sys.stderr)
   sys.exit(1)
 print("ok - package-owned defaults live outside config")
+if pkgs_root is None:
+  print("ok - no omarchy-pkgs checkout; skipping PKGBUILD coverage")
 PY
 
 grep -F 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")' "$ROOT/config/hypr/hyprland.lua" >/dev/null

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -110,13 +110,11 @@ if override:
   pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)] + pkgs_candidates
 pkgs_root = next((path for path in pkgs_candidates if path.exists()), None)
 if pkgs_root is None:
-  print("not ok - omarchy-pkgs checkout found for PKGBUILD coverage", file=sys.stderr)
-  print(
-    "looked in:\n  " + "\n  ".join(str(path) for path in pkgs_candidates) +
-    "\nset OMARCHY_PKGS_PATH to the omarchy-pkgs checkout",
-    file=sys.stderr,
-  )
-  sys.exit(1)
+  if override:
+    print("not ok - OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout", file=sys.stderr)
+    sys.exit(1)
+  print("ok - no omarchy-pkgs checkout; skipping PKGBUILD coverage")
+  sys.exit(0)
 settings_pkgbuild_path = pkgs_root / "omarchy-settings/PKGBUILD"
 omarchy_pkgbuild_path = pkgs_root / "omarchy/PKGBUILD"
 if not settings_pkgbuild_path.exists():
@@ -180,8 +178,8 @@ for hook in alpm_hooks:
 if errors:
   print("\n".join(errors), file=sys.stderr)
   sys.exit(1)
+print("ok - package-owned defaults live outside config")
 PY
-pass "package-owned defaults live outside config"
 
 grep -F 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")' "$ROOT/config/hypr/hyprland.lua" >/dev/null
 grep -F 'require("default.hypr.omarchy")' "$ROOT/config/hypr/hyprland.lua" >/dev/null

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -106,11 +106,11 @@ pkgs_candidates = [
 # Checkouts differ per machine, so allow an explicit pointer at the sibling repo.
 # Accepts either the omarchy-pkgs checkout or its pkgbuilds/ directory.
 override = os.environ.get("OMARCHY_PKGS_PATH")
-if override:
-  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)]
+if override is not None:
+  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)] if override else []
 pkgs_root = next((path for path in pkgs_candidates if path.exists()), None)
 if pkgs_root is None:
-  if override:
+  if override is not None:
     print("not ok - OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout", file=sys.stderr)
     sys.exit(1)
   pkgbuild = None

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -107,18 +107,23 @@ find_omarchy_pks_root() {
   return 1
 }
 
-pkgs_root=$(find_omarchy_pks_root) || fail "omarchy-pkgs checkout is available for packaging coverage"
-settings_pkgbuild="$pkgs_root/omarchy-settings-dev/PKGBUILD"
-omarchy_pkgbuild="$pkgs_root/omarchy-dev/PKGBUILD"
+if pkgs_root=$(find_omarchy_pks_root); then
+  settings_pkgbuild="$pkgs_root/omarchy-settings-dev/PKGBUILD"
+  omarchy_pkgbuild="$pkgs_root/omarchy-dev/PKGBUILD"
 
-grep -F 'cp -a default/. "$pkgdir/usr/share/omarchy/default/"' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package bundles default/"
-grep -F 'install -Dm644 default/snapper/root \' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package installs Snapper template source"
-grep -F '"$pkgdir/etc/snapper/config-templates/omarchy"' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package installs Snapper template destination"
-grep -F "'snapper'" "$omarchy_pkgbuild" >/dev/null || fail "omarchy package depends on snapper"
-grep -F "'limine-snapper-sync'" "$omarchy_pkgbuild" >/dev/null || fail "omarchy package depends on limine-snapper-sync"
-grep -F 'cp -a install "$pkgdir/usr/share/omarchy/"' "$omarchy_pkgbuild" >/dev/null || fail "omarchy package bundles install scripts"
-grep -F 'cp -a migrations "$pkgdir/usr/share/omarchy/"' "$omarchy_pkgbuild" >/dev/null || fail "omarchy package bundles migrations"
-pass "omarchy-pkgs packages Snapper template, setup, and migration coverage"
+  grep -F 'cp -a default/. "$pkgdir/usr/share/omarchy/default/"' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package bundles default/"
+  grep -F 'install -Dm644 default/snapper/root \' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package installs Snapper template source"
+  grep -F '"$pkgdir/etc/snapper/config-templates/omarchy"' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package installs Snapper template destination"
+  grep -F "'snapper'" "$omarchy_pkgbuild" >/dev/null || fail "omarchy package depends on snapper"
+  grep -F "'limine-snapper-sync'" "$omarchy_pkgbuild" >/dev/null || fail "omarchy package depends on limine-snapper-sync"
+  grep -F 'cp -a install "$pkgdir/usr/share/omarchy/"' "$omarchy_pkgbuild" >/dev/null || fail "omarchy package bundles install scripts"
+  grep -F 'cp -a migrations "$pkgdir/usr/share/omarchy/"' "$omarchy_pkgbuild" >/dev/null || fail "omarchy package bundles migrations"
+  pass "omarchy-pkgs packages Snapper template, setup, and migration coverage"
+elif [[ -n ${OMARCHY_PKGS_PATH:-} ]]; then
+  fail "OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout"
+else
+  pass "no omarchy-pkgs checkout; skipping packaging coverage"
+fi
 
 # Same per-machine checkout problem as omarchy-pkgs; OMARCHY_ISO_PATH points at it.
 find_omarchy_iso_root() {
@@ -139,19 +144,24 @@ find_omarchy_iso_root() {
   return 1
 }
 
-iso_root=$(find_omarchy_iso_root) || fail "omarchy-iso checkout is available for installer coverage"
-configurator="$iso_root/configs/airootfs/root/configurator"
-phases="$iso_root/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py"
-manifest="$iso_root/manifests/fresh-4-semantic.json"
+if iso_root=$(find_omarchy_iso_root); then
+  configurator="$iso_root/configs/airootfs/root/configurator"
+  phases="$iso_root/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py"
+  manifest="$iso_root/manifests/fresh-4-semantic.json"
 
-! grep -F 'snapshot_config' "$configurator" >/dev/null || fail "ISO does not ask archinstall to create Snapper timeline config"
+  ! grep -F 'snapshot_config' "$configurator" >/dev/null || fail "ISO does not ask archinstall to create Snapper timeline config"
 
-# The phases/manifest assertions cover the newer ISO orchestrator structure.
-# Skip them when the checkout predates that layout.
-if [[ -f $phases && -f $manifest ]]; then
-  ! grep -F '_configure_snapper_root' "$phases" >/dev/null || fail "ISO does not duplicate Omarchy Snapper setup"
-  grep -F 'run_system_finalizer' "$phases" >/dev/null || fail "ISO runs packaged system setup"
-  grep -F '/etc/systemd/system/timers.target.wants/snapper-cleanup.timer' "$manifest" >/dev/null || fail "fresh ISO manifest has snapper-cleanup timer enabled"
-  ! grep -F '/etc/systemd/system/timers.target.wants/snapper-timeline.timer' "$manifest" >/dev/null || fail "fresh ISO manifest does not enable snapper timeline timer"
+  # The phases/manifest assertions cover the newer ISO orchestrator structure.
+  # Skip them when the checkout predates that layout.
+  if [[ -f $phases && -f $manifest ]]; then
+    ! grep -F '_configure_snapper_root' "$phases" >/dev/null || fail "ISO does not duplicate Omarchy Snapper setup"
+    grep -F 'run_system_finalizer' "$phases" >/dev/null || fail "ISO runs packaged system setup"
+    grep -F '/etc/systemd/system/timers.target.wants/snapper-cleanup.timer' "$manifest" >/dev/null || fail "fresh ISO manifest has snapper-cleanup timer enabled"
+    ! grep -F '/etc/systemd/system/timers.target.wants/snapper-timeline.timer' "$manifest" >/dev/null || fail "fresh ISO manifest does not enable snapper timeline timer"
+  fi
+  pass "omarchy-iso delegates Snapper setup to packaged system setup"
+elif [[ -n ${OMARCHY_ISO_PATH:-} ]]; then
+  fail "OMARCHY_ISO_PATH resolves to an omarchy-iso checkout"
+else
+  pass "no omarchy-iso checkout; skipping installer coverage"
 fi
-pass "omarchy-iso delegates Snapper setup to packaged system setup"

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -93,8 +93,12 @@ find_omarchy_pks_root() {
   local candidate
   local -a candidates
 
-  if [[ -n ${OMARCHY_PKGS_PATH:-} ]]; then
-    candidates=("$OMARCHY_PKGS_PATH/pkgbuilds" "$OMARCHY_PKGS_PATH")
+  if [[ -v OMARCHY_PKGS_PATH ]]; then
+    if [[ -n $OMARCHY_PKGS_PATH ]]; then
+      candidates=("$OMARCHY_PKGS_PATH/pkgbuilds" "$OMARCHY_PKGS_PATH")
+    else
+      candidates=()
+    fi
   else
     candidates=(
       "$ROOT/../omarchy-pkgs/pkgbuilds"
@@ -127,7 +131,7 @@ if pkgs_root=$(find_omarchy_pks_root); then
   grep -F 'cp -a install "$pkgdir/usr/share/omarchy/"' "$omarchy_pkgbuild" >/dev/null || fail "omarchy package bundles install scripts"
   grep -F 'cp -a migrations "$pkgdir/usr/share/omarchy/"' "$omarchy_pkgbuild" >/dev/null || fail "omarchy package bundles migrations"
   pass "omarchy-pkgs packages Snapper template, setup, and migration coverage"
-elif [[ -n ${OMARCHY_PKGS_PATH:-} ]]; then
+elif [[ -v OMARCHY_PKGS_PATH ]]; then
   fail "OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout"
 else
   pass "no omarchy-pkgs checkout; skipping packaging coverage"
@@ -138,8 +142,12 @@ find_omarchy_iso_root() {
   local candidate
   local -a candidates
 
-  if [[ -n ${OMARCHY_ISO_PATH:-} ]]; then
-    candidates=("$OMARCHY_ISO_PATH")
+  if [[ -v OMARCHY_ISO_PATH ]]; then
+    if [[ -n $OMARCHY_ISO_PATH ]]; then
+      candidates=("$OMARCHY_ISO_PATH")
+    else
+      candidates=()
+    fi
   else
     candidates=(
       "$ROOT/../omarchy-iso"
@@ -176,7 +184,7 @@ if iso_root=$(find_omarchy_iso_root); then
     ! grep -F '/etc/systemd/system/timers.target.wants/snapper-timeline.timer' "$manifest" >/dev/null || fail "fresh ISO manifest does not enable snapper timeline timer"
   fi
   pass "omarchy-iso delegates Snapper setup to packaged system setup"
-elif [[ -n ${OMARCHY_ISO_PATH:-} ]]; then
+elif [[ -v OMARCHY_ISO_PATH ]]; then
   fail "OMARCHY_ISO_PATH resolves to an omarchy-iso checkout"
 else
   pass "no omarchy-iso checkout; skipping installer coverage"

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -91,14 +91,22 @@ pass "Snapper service migration only repairs broken services idempotently"
 # Accepts either the omarchy-pkgs checkout or its pkgbuilds/ directory.
 find_omarchy_pks_root() {
   local candidate
-  for candidate in \
-    ${OMARCHY_PKGS_PATH:+"$OMARCHY_PKGS_PATH/pkgbuilds" "$OMARCHY_PKGS_PATH"} \
-    "$ROOT/../omarchy-pkgs/pkgbuilds" \
-    "$ROOT/../omarchy/omarchy-pkgs/pkgbuilds" \
-    "$ROOT/../../omarchy-pkgs/pkgbuilds" \
-    "$ROOT/../omacom/omarchy-pkgs/pkgbuilds" \
-    "$ROOT/../../omacom/omarchy-pkgs/pkgbuilds" \
-    "$HOME/Work/omacom/omarchy-pkgs/pkgbuilds"; do
+  local -a candidates
+
+  if [[ -n ${OMARCHY_PKGS_PATH:-} ]]; then
+    candidates=("$OMARCHY_PKGS_PATH/pkgbuilds" "$OMARCHY_PKGS_PATH")
+  else
+    candidates=(
+      "$ROOT/../omarchy-pkgs/pkgbuilds"
+      "$ROOT/../omarchy/omarchy-pkgs/pkgbuilds"
+      "$ROOT/../../omarchy-pkgs/pkgbuilds"
+      "$ROOT/../omacom/omarchy-pkgs/pkgbuilds"
+      "$ROOT/../../omacom/omarchy-pkgs/pkgbuilds"
+      "$HOME/Work/omacom/omarchy-pkgs/pkgbuilds"
+    )
+  fi
+
+  for candidate in "${candidates[@]}"; do
     if [[ -d $candidate ]]; then
       cd "$candidate" && pwd
       return 0
@@ -128,14 +136,22 @@ fi
 # Same per-machine checkout problem as omarchy-pkgs; OMARCHY_ISO_PATH points at it.
 find_omarchy_iso_root() {
   local candidate
-  for candidate in \
-    ${OMARCHY_ISO_PATH:+"$OMARCHY_ISO_PATH"} \
-    "$ROOT/../omarchy-iso" \
-    "$ROOT/../omarchy/omarchy-iso" \
-    "$ROOT/../../omarchy-iso" \
-    "$ROOT/../omacom/omarchy-iso" \
-    "$ROOT/../../omacom/omarchy-iso" \
-    "$HOME/Work/omacom/omarchy-iso"; do
+  local -a candidates
+
+  if [[ -n ${OMARCHY_ISO_PATH:-} ]]; then
+    candidates=("$OMARCHY_ISO_PATH")
+  else
+    candidates=(
+      "$ROOT/../omarchy-iso"
+      "$ROOT/../omarchy/omarchy-iso"
+      "$ROOT/../../omarchy-iso"
+      "$ROOT/../omacom/omarchy-iso"
+      "$ROOT/../../omacom/omarchy-iso"
+      "$HOME/Work/omacom/omarchy-iso"
+    )
+  fi
+
+  for candidate in "${candidates[@]}"; do
     if [[ -d $candidate ]]; then
       cd "$candidate" && pwd
       return 0

--- a/test/shell.d/unowned-system-paths-test.sh
+++ b/test/shell.d/unowned-system-paths-test.sh
@@ -53,11 +53,11 @@ pkgs_candidates = [
   Path.home() / "Work/omacom/omarchy-pkgs/pkgbuilds",
 ]
 override = os.environ.get("OMARCHY_PKGS_PATH")
-if override:
-  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)]
+if override is not None:
+  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)] if override else []
 pkgs_root = next((p for p in pkgs_candidates if p.exists()), None)
 if pkgs_root is None:
-  if override:
+  if override is not None:
     print("not ok - OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout", file=sys.stderr)
     sys.exit(1)
   print("ok - no omarchy-pkgs checkout; skipping package ownership check")

--- a/test/shell.d/unowned-system-paths-test.sh
+++ b/test/shell.d/unowned-system-paths-test.sh
@@ -57,8 +57,11 @@ if override:
   pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)] + pkgs_candidates
 pkgs_root = next((p for p in pkgs_candidates if p.exists()), None)
 if pkgs_root is None:
-  print("not ok - omarchy-pkgs checkout found for package ownership check", file=sys.stderr)
-  sys.exit(1)
+  if override:
+    print("not ok - OMARCHY_PKGS_PATH resolves to an omarchy-pkgs checkout", file=sys.stderr)
+    sys.exit(1)
+  print("ok - no omarchy-pkgs checkout; skipping package ownership check")
+  sys.exit(0)
 
 packaged = "\n".join(p.read_text() for p in pkgs_root.glob("*/PKGBUILD"))
 
@@ -129,6 +132,5 @@ if problems:
     file=sys.stderr,
   )
   sys.exit(1)
+print("ok - no Omarchy script writes a path under /usr that no package owns")
 PYTHON
-
-pass "no Omarchy script writes a path under /usr that no package owns"

--- a/test/shell.d/unowned-system-paths-test.sh
+++ b/test/shell.d/unowned-system-paths-test.sh
@@ -54,7 +54,7 @@ pkgs_candidates = [
 ]
 override = os.environ.get("OMARCHY_PKGS_PATH")
 if override:
-  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)] + pkgs_candidates
+  pkgs_candidates = [Path(override) / "pkgbuilds", Path(override)]
 pkgs_root = next((p for p in pkgs_candidates if p.exists()), None)
 if pkgs_root is None:
   if override:


### PR DESCRIPTION
Fixes #7125.

## Summary

A standalone Omarchy checkout currently fails three test files because packaging and installer repositories are treated as required local dependencies. This keeps those cross-repository assertions active when their checkouts are available, but reports them as skipped when automatic discovery finds nothing.

Explicit `OMARCHY_PKGS_PATH` and `OMARCHY_ISO_PATH` overrides still fail when they point nowhere, so an intended integration run cannot silently lose coverage.

## Changes

- Skip only the packaging and ISO assertions that cannot run without their repositories.
- Keep the rest of each test file running.
- Preserve the existing assertions when sibling or explicitly configured checkouts are available.
- Document both environment overrides in `docs/testing.md`.

## How to test

1. Run `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` from a standalone clone and confirm the cross-repository checks report skips.
2. Run them with `OMARCHY_PKGS_PATH` and `OMARCHY_ISO_PATH` pointing at current checkouts and confirm the original assertions run.
3. Point either override at a missing directory and confirm the dependent test fails.
4. Break a checked PKGBUILD, ISO configurator rule, or `/usr` ownership rule and confirm the relevant test still fails.

I exercised both modes against `omacom-io/omarchy-pkgs@0ea0c5f` and `omacom-io/omarchy-iso@268bac1`. `./test/all` also dropped the two reachable checkout-gate failures on this workstation; its remaining failures match unrelated local dependency and Quickshell baselines.

## Related work

#8165 improves failure messages in two of the same test files, but does not change the sibling-checkout requirement. The changes are independent; I will rebase if that PR lands first.
