### PR TITLE
Harden browser managed-policy permissions behind a constrained theme writer (#5547)

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -7,8 +7,7 @@
 set -e
 
 setup_policy_directory() {
-  sudo mkdir -p "$1"
-  sudo chmod a+rw "$1"
+  sudo install -d -m 0755 -o root -g root "$1"
 }
 
 announce_browser_installed() {
@@ -27,7 +26,7 @@ setup_firefox_preferences() {
   local distribution_dir="$1"
 
   setup_policy_directory "$distribution_dir"
-  sudo cp -f "$OMARCHY_PATH/default/firefox/policies.json" "$distribution_dir/policies.json"
+  sudo install -m 0644 -o root -g root -T "$OMARCHY_PATH/default/firefox/policies.json" "$distribution_dir/policies.json"
 }
 
 setup_firefox_wayland() {

--- a/bin/omarchy-theme-browser-policy
+++ b/bin/omarchy-theme-browser-policy
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# omarchy:summary=Write the Omarchy browser theme policy
+# omarchy:args=<hex-color>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+PACKAGED_PATH=/usr/bin/omarchy-theme-browser-policy
+
+POLICY_DIRS=(
+  /etc/chromium/policies/managed
+  /etc/opt/chrome/policies/managed
+  /etc/opt/edge/policies/managed
+  /etc/brave/policies/managed
+)
+
+if (( EUID == 0 )); then
+  export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+fi
+
+usage() {
+  echo "Usage: omarchy-theme-browser-policy <#RRGGBB>" >&2
+}
+
+valid_color() {
+  (( $# == 1 )) && [[ $1 =~ ^#[0-9A-Fa-f]{6}$ ]]
+}
+
+sudo_grants_passwordless() {
+  sudo -n -l -l "$PACKAGED_PATH" "$@" 2>/dev/null | grep -q '!authenticate'
+}
+
+require_root() {
+  if (( EUID == 0 )); then
+    return
+  elif [[ -t 0 ]] || sudo_grants_passwordless "$@"; then
+    exec sudo "$PACKAGED_PATH" "$@"
+  else
+    exec pkexec "$PACKAGED_PATH" "$@"
+  fi
+}
+
+safe_admin_policy() {
+  local path=$1
+  local mode
+
+  [[ -f $path && ! -L $path ]] || return 1
+  [[ $(stat -c '%u' -- "$path") == 0 ]] || return 1
+
+  mode=$(stat -c '%a' -- "$path")
+  (( (8#$mode & 022) == 0 ))
+}
+
+if ! valid_color "$@"; then
+  usage
+  exit 1
+fi
+
+require_root "$@"
+
+color=$1
+tmp=""
+
+cleanup() {
+  [[ -z $tmp ]] || rm -f -- "$tmp"
+}
+trap cleanup EXIT
+
+shopt -s dotglob nullglob
+
+for policy_dir in "${POLICY_DIRS[@]}"; do
+  [[ -e $policy_dir || -L $policy_dir ]] || continue
+
+  if [[ -L $policy_dir || ! -d $policy_dir ]]; then
+    echo "Refusing unsafe browser policy path: $policy_dir" >&2
+    exit 1
+  fi
+
+  # Close directory writes before inspecting files left by the old 0777 setup.
+  install -d -m 0755 -o root -g root "$policy_dir"
+
+  for entry in "$policy_dir"/*; do
+    if [[ $entry != "$policy_dir/color.json" ]] && safe_admin_policy "$entry"; then
+      continue
+    fi
+
+    printf 'Removing unsafe browser policy entry: %q\n' "$entry" >&2
+    rm -rf -- "$entry"
+  done
+
+  tmp=$(mktemp "$policy_dir/.color.json.XXXXXX")
+  printf '{"BrowserThemeColor": "%s", "BrowserColorScheme": "device"}\n' "$color" >"$tmp"
+  chown root:root "$tmp"
+  chmod 0644 "$tmp"
+  mv -fT -- "$tmp" "$policy_dir/color.json"
+  tmp=""
+done

--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -13,13 +13,6 @@ else
   THEME_HEX_COLOR="#1c2027"
 fi
 
-set_browser_policy() {
-  local policy_dir="$1"
-
-  [[ -d $policy_dir ]] || return
-  echo "{\"BrowserThemeColor\": \"$THEME_HEX_COLOR\", \"BrowserColorScheme\": \"device\"}" | tee "$policy_dir/color.json" >/dev/null
-}
-
 refresh_running_browser() {
   local process="$1"
   local command="$2"
@@ -30,16 +23,14 @@ refresh_running_browser() {
   fi
 }
 
-set_browser_policy /etc/chromium/policies/managed
+omarchy-theme-browser-policy "$THEME_HEX_COLOR" || exit 1
+
 refresh_running_browser chromium chromium
 
-set_browser_policy /etc/opt/chrome/policies/managed
 refresh_running_browser chrome google-chrome-stable || refresh_running_browser chrome google-chrome
 
-set_browser_policy /etc/opt/edge/policies/managed
 refresh_running_browser msedge microsoft-edge-stable
 
-set_browser_policy /etc/brave/policies/managed
 refresh_running_browser brave brave
 # Match on the binary path: the running process is named plain "brave", and a
 # bare -f brave-origin pattern would also match the installer's own terminal.

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1312,7 +1312,7 @@ apply_system_transition() {
     /usr/share/icons/Yaru/scalable/actions/go-next-symbolic.svg
   as_root gtk-update-icon-cache /usr/share/icons/Yaru >/dev/null 2>&1 || true
 
-  as_root install -d -m 0777 /etc/chromium/policies/managed
+  as_root install -d -m 0755 -o root -g root /etc/chromium/policies/managed
   as_root install -d -m 0755 /usr/lib/chromium
   printf '%s\n' '{"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}' | \
     as_root tee /usr/lib/chromium/initial_preferences >/dev/null

--- a/etc/sudoers.d/omarchy-theme-browser-policy
+++ b/etc/sudoers.d/omarchy-theme-browser-policy
@@ -1,0 +1,3 @@
+# Theme changes can run from the graphical menu without a terminal. The helper
+# accepts exactly one hex color and writes only Omarchy's fixed browser policy.
+%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-theme-browser-policy *

--- a/install/config/theme-system.sh
+++ b/install/config/theme-system.sh
@@ -7,8 +7,7 @@ ln -snf /usr/share/icons/Adwaita/symbolic/actions/go-next-symbolic.svg \
 gtk-update-icon-cache /usr/share/icons/Yaru &>/dev/null || true
 
 # Chromium policy directory for theme
-mkdir -p /etc/chromium/policies/managed
-chmod a+rw /etc/chromium/policies/managed
+install -d -m 0755 -o root -g root /etc/chromium/policies/managed
 
 # Default Chromium to follow system appearance ("device") instead of dark
 mkdir -p /usr/lib/chromium

--- a/migrations/1787676640.sh
+++ b/migrations/1787676640.sh
@@ -64,13 +64,21 @@ distribution_needs_repair() {
   return 1
 }
 
+chromium_has_refused_policy_path() {
+  local policy_dir
+
+  for policy_dir in "${chromium_policy_dirs[@]}"; do
+    [[ -e $policy_dir || -L $policy_dir ]] || continue
+    if [[ -L $policy_dir || ! -d $policy_dir ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 repair_distribution() {
   local distribution_dir=$1 policy_file="$1/policies.json" entry
-
-  if [[ -L $distribution_dir || ! -d $distribution_dir ]]; then
-    echo "Refusing unsafe browser distribution path: $distribution_dir" >&2
-    return 1
-  fi
 
   sudo install -d -m 0755 -o root -g root "$distribution_dir"
 
@@ -108,17 +116,26 @@ repair_distribution() {
 (
   shopt -s dotglob nullglob
 
-  # One refused path (an admin-symlinked policy directory, say) must not stop
-  # the remaining repairs or leave this migration permanently pending.
-  if chromium_needs_repair; then
-    omarchy-theme-set-browser ||
-      echo "Browser policy repair could not finish the Chromium theme write" >&2
+  # A refused path (an admin-symlinked policy directory, say) never heals by
+  # retrying, so it is detected by inspection up front and tolerated with a
+  # warning; when one exists alongside repairable dirt, the dirt waits for the
+  # admin to resolve the path first. Everything below is an operational step:
+  # any failure propagates so the runner leaves this migration pending and it
+  # retries on the next update or login.
+  if chromium_has_refused_policy_path; then
+    echo "Browser policy repair skipped: a Chromium policy path needs admin attention" >&2
+  elif chromium_needs_repair; then
+    omarchy-theme-set-browser
   fi
 
   for distribution_dir in /usr/lib/firefox/distribution /opt/zen-browser/distribution; do
-    if distribution_needs_repair "$distribution_dir"; then
-      repair_distribution "$distribution_dir" ||
-        echo "Browser policy repair could not secure $distribution_dir" >&2
+    distribution_needs_repair "$distribution_dir" || continue
+
+    if [[ -L $distribution_dir || ! -d $distribution_dir ]]; then
+      echo "Browser policy repair skipped: $distribution_dir needs admin attention" >&2
+      continue
     fi
+
+    repair_distribution "$distribution_dir"
   done
 )

--- a/migrations/1787676640.sh
+++ b/migrations/1787676640.sh
@@ -1,0 +1,124 @@
+echo "Secure browser managed-policy directories created by older Omarchy installs"
+
+safe_admin_file() {
+  local path=$1 mode
+
+  [[ -f $path && ! -L $path ]] || return 1
+  [[ $(stat -c '%u' -- "$path") == 0 ]] || return 1
+
+  mode=$(stat -c '%a' -- "$path")
+  (( (8#$mode & 022) == 0 ))
+}
+
+safe_admin_entry() {
+  local path=$1 mode
+
+  [[ ! -L $path && ( -f $path || -d $path ) ]] || return 1
+  [[ $(stat -c '%u' -- "$path") == 0 ]] || return 1
+
+  mode=$(stat -c '%a' -- "$path")
+  (( (8#$mode & 022) == 0 ))
+}
+
+chromium_policy_dirs=(
+  /etc/chromium/policies/managed
+  /etc/opt/chrome/policies/managed
+  /etc/opt/edge/policies/managed
+  /etc/brave/policies/managed
+)
+
+chromium_needs_repair() {
+  local policy_dir entry
+
+  for policy_dir in "${chromium_policy_dirs[@]}"; do
+    [[ -e $policy_dir || -L $policy_dir ]] || continue
+
+    if [[ -L $policy_dir || ! -d $policy_dir || $(stat -c '%u:%g:%a' -- "$policy_dir") != "0:0:755" ]]; then
+      return 0
+    fi
+
+    for entry in "$policy_dir"/*; do
+      if [[ $entry == "$policy_dir/color.json" ]]; then
+        [[ $(stat -c '%u:%g:%a' -- "$entry" 2>/dev/null || true) == "0:0:644" && ! -L $entry ]] || return 0
+      elif ! safe_admin_file "$entry"; then
+        return 0
+      fi
+    done
+  done
+
+  return 1
+}
+
+distribution_needs_repair() {
+  local distribution_dir=$1 entry
+
+  [[ -e $distribution_dir || -L $distribution_dir ]] || return 1
+  if [[ -L $distribution_dir || ! -d $distribution_dir || $(stat -c '%u:%g:%a' -- "$distribution_dir") != "0:0:755" ]]; then
+    return 0
+  fi
+
+  for entry in "$distribution_dir"/*; do
+    safe_admin_entry "$entry" || return 0
+  done
+
+  return 1
+}
+
+repair_distribution() {
+  local distribution_dir=$1 policy_file="$1/policies.json" entry
+
+  if [[ -L $distribution_dir || ! -d $distribution_dir ]]; then
+    echo "Refusing unsafe browser distribution path: $distribution_dir" >&2
+    return 1
+  fi
+
+  sudo install -d -m 0755 -o root -g root "$distribution_dir"
+
+  for entry in "$distribution_dir"/*; do
+    if safe_admin_entry "$entry"; then
+      continue
+    fi
+
+    printf 'Removing unsafe browser distribution entry: %q\n' "$entry" >&2
+    sudo rm -rf -- "$entry"
+  done
+
+  # A root-owned directory squatting on the policy file name would survive the
+  # cleanup above and then break the install below, so remove it like any other
+  # anomaly at that exact name.
+  if [[ -d $policy_file && ! -L $policy_file ]]; then
+    printf 'Removing unsafe browser distribution entry: %q\n' "$policy_file" >&2
+    sudo rm -rf -- "$policy_file"
+  fi
+
+  # Only install the packaged policy out of a root-owned Omarchy tree. A
+  # dev-linked checkout must never choose what root writes into a machine-wide
+  # policy path.
+  if [[ $(stat -c '%u' -- "$OMARCHY_PATH") != 0 ]] ||
+    [[ $(stat -c '%u' -- "$OMARCHY_PATH/default/firefox/policies.json") != 0 ]]; then
+    echo "Keeping existing $policy_file: $OMARCHY_PATH is not a root-owned Omarchy tree" >&2
+    return 0
+  fi
+
+  if ! safe_admin_file "$policy_file"; then
+    sudo install -m 0644 -o root -g root -T "$OMARCHY_PATH/default/firefox/policies.json" "$policy_file"
+  fi
+}
+
+(
+  shopt -s dotglob nullglob
+
+  # One refused path (an admin-symlinked policy directory, say) must not stop
+  # the remaining repairs or leave this migration permanently pending.
+  if chromium_needs_repair; then
+    omarchy-theme-set-browser ||
+      echo "Browser policy repair could not finish the Chromium theme write" >&2
+  fi
+
+  for distribution_dir in /usr/lib/firefox/distribution /opt/zen-browser/distribution; do
+    if distribution_needs_repair "$distribution_dir"; then
+      repair_distribution "$distribution_dir" ||
+        echo "Browser policy repair could not secure $distribution_dir" >&2
+    fi
+  done
+)

--- a/test/shell.d/browser-policy-migration-test.sh
+++ b/test/shell.d/browser-policy-migration-test.sh
@@ -8,14 +8,18 @@ migration="$ROOT/migrations/1787676640.sh"
 
 [[ -f $migration ]] || fail "browser policy repair migration exists"
 [[ $(stat -c '%a' "$migration") == 644 ]] || fail "browser policy repair migration is not executable"
-grep -Fxq '    omarchy-theme-set-browser ||' "$migration" ||
+grep -Fxq '    omarchy-theme-set-browser' "$migration" ||
   fail "browser policy migration reuses the constrained Chromium policy writer"
 grep -Fq '/usr/lib/firefox/distribution /opt/zen-browser/distribution' "$migration" ||
   fail "browser policy migration covers Firefox and Zen distribution directories"
 grep -Fq 'not a root-owned Omarchy tree' "$migration" ||
   fail "browser policy migration refuses to install policy out of a non-root-owned tree"
-grep -Fq 'could not finish the Chromium theme write' "$migration" ||
-  fail "browser policy migration tolerates one refused Chromium path"
+grep -Fq 'chromium_has_refused_policy_path' "$migration" ||
+  fail "browser policy migration detects refused Chromium paths by inspection"
+grep -Fq 'needs admin attention' "$migration" ||
+  fail "browser policy migration warns on refused paths instead of swallowing failures"
+grep -Fxq '    omarchy-theme-set-browser' "$migration" ||
+  fail "browser policy migration propagates Chromium theme write failures"
 
 pass "browser policy migration covers existing supported browser installs"
 
@@ -242,9 +246,96 @@ run_migration "$refusal_log"
 [[ ! -e $firefox_b/unsafe-file ]] || fail "the tolerated run still repairs the reachable browser"
 cmp -s <(printf '{"Custom": true}\n') "$firefox_b/policies.json" ||
   fail "the tolerated run keeps a safe administrator policy"
-grep -Fq 'Refusing unsafe browser distribution path: /opt/zen-browser/distribution' "$refusal_log" ||
+grep -Fq 'Browser policy repair skipped: /opt/zen-browser/distribution needs admin attention' "$refusal_log" ||
   fail "the refused distribution path is reported" "got: $(<"$refusal_log")"
-grep -Fq 'Browser policy repair could not secure /opt/zen-browser/distribution' "$refusal_log" ||
-  fail "the refused distribution path does not stop the migration" "got: $(<"$refusal_log")"
 
 pass "browser policy migration tolerates one refused path while repairing the rest"
+
+# Operational failures must propagate: the runner leaves the migration pending
+# so it retries, instead of marking a half-repaired machine complete.
+
+# A failing theme write (a canceled sudo prompt, say) aborts the whole run.
+chromium_c="$test_tmp/chromium-c/managed"
+mkdir -p "$chromium_c"
+chmod 0777 "$chromium_c"
+printf '{"Evil": true}\n' >"$chromium_c/unsafe.json"
+chmod 0666 "$chromium_c/unsafe.json"
+
+cat >"$stub_bin/omarchy-theme-set-browser" <<'SH'
+#!/bin/bash
+printf 'theme\n' >>"$THEME_CALLS"
+exit 77
+SH
+
+sandbox_args=(
+  "${common_sandbox_args[@]}"
+  --dir /etc/chromium
+  --dir /etc/chromium/policies
+  --bind "$chromium_c" /etc/chromium/policies/managed
+)
+
+failure_log="$test_tmp/failure-log"
+: >"$theme_calls"
+: >"$sudo_calls"
+set +e
+run_migration "$failure_log"
+theme_status=$?
+set -e
+(( theme_status == 77 )) ||
+  fail "an operational Chromium theme failure propagates its exit status" "got: $theme_status"
+[[ $(wc -l <"$theme_calls") == 1 ]] || fail "the failing theme write is attempted once"
+[[ ! -s $sudo_calls ]] || fail "no privileged work happens after a refused theme write"
+
+pass "browser policy migration stays pending when the Chromium repair fails operationally"
+
+# A failing privileged step in a distribution repair aborts the run too.
+# The unused Chromium paths get clean binds so host /etc state (whose
+# ownership is unmapped inside the namespace) cannot look dirty and drag the
+# failing theme stub into the run.
+chromium_unused=(chromium-clean chrome-clean edge-clean brave-clean)
+for browser in "${chromium_unused[@]}"; do
+  mkdir -p "$test_tmp/$browser"
+  chmod 0755 "$test_tmp/$browser"
+done
+
+firefox_c="$test_tmp/firefox-c/distribution"
+mkdir -p "$firefox_c"
+chmod 0777 "$firefox_c"
+printf '{"policies":{"DisableSecurity":true}}\n' >"$firefox_c/policies.json"
+chmod 0666 "$firefox_c/policies.json"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SUDO_CALLS"
+if [[ $1 == install ]]; then
+  exit 9
+fi
+exec "$@"
+SH
+
+sandbox_args=(
+  "${common_sandbox_args[@]}"
+  --dir /etc/chromium
+  --dir /etc/chromium/policies
+  --bind "$test_tmp/chromium-clean" /etc/chromium/policies/managed
+  --dir /etc/opt
+  --bind "$test_tmp/chrome-clean" /etc/opt/chrome/policies/managed
+  --bind "$test_tmp/edge-clean" /etc/opt/edge/policies/managed
+  --dir /etc/brave
+  --bind "$test_tmp/brave-clean" /etc/brave/policies/managed
+  --dir /usr/lib/firefox
+  --bind "$firefox_c" /usr/lib/firefox/distribution
+)
+
+distribution_log="$test_tmp/distribution-log"
+: >"$sudo_calls"
+set +e
+run_migration "$distribution_log"
+distribution_status=$?
+set -e
+(( distribution_status == 9 )) ||
+  fail "an operational distribution repair failure propagates its exit status" "got: $distribution_status"
+[[ -f $firefox_c/policies.json ]] ||
+  fail "a failed distribution repair changes nothing before it aborts"
+
+pass "browser policy migration stays pending when a distribution repair fails operationally"

--- a/test/shell.d/browser-policy-migration-test.sh
+++ b/test/shell.d/browser-policy-migration-test.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787676640.sh"
+
+[[ -f $migration ]] || fail "browser policy repair migration exists"
+[[ $(stat -c '%a' "$migration") == 644 ]] || fail "browser policy repair migration is not executable"
+grep -Fxq '    omarchy-theme-set-browser ||' "$migration" ||
+  fail "browser policy migration reuses the constrained Chromium policy writer"
+grep -Fq '/usr/lib/firefox/distribution /opt/zen-browser/distribution' "$migration" ||
+  fail "browser policy migration covers Firefox and Zen distribution directories"
+grep -Fq 'not a root-owned Omarchy tree' "$migration" ||
+  fail "browser policy migration refuses to install policy out of a non-root-owned tree"
+grep -Fq 'could not finish the Chromium theme write' "$migration" ||
+  fail "browser policy migration tolerates one refused Chromium path"
+
+pass "browser policy migration covers existing supported browser installs"
+
+if ! command -v bwrap >/dev/null ||
+  ! bwrap --unshare-user --uid 0 --gid 0 --ro-bind / / \
+    --overlay-src /etc --tmp-overlay /etc \
+    --overlay-src /usr/lib --tmp-overlay /usr/lib \
+    --overlay-src /opt --tmp-overlay /opt true 2>/dev/null; then
+  pass "Bubblewrap user namespaces unavailable; skipping browser policy migration runtime test"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+theme_home="$test_tmp/home"
+theme_dir="$theme_home/.local/state/omarchy/current/theme"
+theme_calls="$test_tmp/theme-calls"
+sudo_calls="$test_tmp/sudo-calls"
+mkdir -p "$stub_bin" "$theme_dir"
+printf '10,20,30\n' >"$theme_dir/chromium.theme"
+
+cat >"$stub_bin/omarchy-theme-set-browser" <<'SH'
+#!/bin/bash
+printf 'theme\n' >>"$THEME_CALLS"
+exec "$OMARCHY_PATH/bin/omarchy-theme-set-browser"
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SUDO_CALLS"
+exec "$@"
+SH
+
+ln -s "$ROOT/bin/omarchy-theme-browser-policy" "$stub_bin/omarchy-theme-browser-policy"
+chmod +x "$stub_bin/omarchy-theme-set-browser" "$stub_bin/omarchy-cmd-present" "$stub_bin/sudo"
+
+seed_hostile_entries() {
+  local policy_dir=$1
+
+  printf '{"Unsafe": true}\n' >"$policy_dir/unsafe.json"
+  chmod 0666 "$policy_dir/unsafe.json"
+  printf 'hidden\n' >"$policy_dir/.omarchy-hidden"
+  chmod 0666 "$policy_dir/.omarchy-hidden"
+  printf 'spaced\n' >"$policy_dir/with space.json"
+  chmod 0666 "$policy_dir/with space.json"
+  printf 'dashed\n' >"$policy_dir/-dash-led.json"
+  chmod 0666 "$policy_dir/-dash-led.json"
+  printf '{"Safe": true}\n' >"$policy_dir/admin.json"
+  chmod 0644 "$policy_dir/admin.json"
+  printf '{"Setuid": true}\n' >"$policy_dir/setuid-admin.json"
+  chmod 4755 "$policy_dir/setuid-admin.json"
+  mkdir "$policy_dir/sticky-dir"
+  chmod 1777 "$policy_dir/sticky-dir"
+  mkfifo "$policy_dir/fifo-pipe"
+}
+
+chromium_dirs=(chromium chrome edge brave)
+for browser in "${chromium_dirs[@]}"; do
+  policy_dir="$test_tmp/$browser/managed"
+  mkdir -p "$policy_dir/nested"
+  chmod 0777 "$policy_dir"
+  printf 'nested\n' >"$policy_dir/nested/policy.json"
+  ln -s "$test_tmp/outside" "$policy_dir/color.json"
+  seed_hostile_entries "$policy_dir"
+done
+
+firefox_dir="$test_tmp/firefox/distribution"
+zen_dir="$test_tmp/zen/distribution"
+mkdir -p "$firefox_dir/admin-assets" "$zen_dir"
+chmod 0777 "$firefox_dir" "$zen_dir"
+printf 'keep\n' >"$firefox_dir/admin-assets/keep.txt"
+printf '{"Admin": true}\n' >"$firefox_dir/admin.json"
+chmod 0644 "$firefox_dir/admin.json"
+printf '{"policies":{"DisableSecurity":true}}\n' >"$firefox_dir/policies.json"
+chmod 0666 "$firefox_dir/policies.json"
+printf 'unsafe\n' >"$firefox_dir/unsafe-file"
+chmod 0666 "$firefox_dir/unsafe-file"
+ln -s "$test_tmp/outside" "$firefox_dir/unsafe-link"
+
+common_sandbox_args=(
+  --unshare-user
+  --uid 0
+  --gid 0
+  --ro-bind / /
+  --bind "$test_tmp" "$test_tmp"
+  --proc /proc
+  --dev /dev
+  --overlay-src /etc
+  --tmp-overlay /etc
+  --overlay-src /usr/lib
+  --tmp-overlay /usr/lib
+  --overlay-src /opt
+  --tmp-overlay /opt
+)
+
+sandbox_args=(
+  "${common_sandbox_args[@]}"
+  --dir /etc/chromium
+  --dir /etc/chromium/policies
+  --bind "$test_tmp/chromium/managed" /etc/chromium/policies/managed
+  --dir /etc/opt
+  --dir /etc/opt/chrome
+  --dir /etc/opt/chrome/policies
+  --bind "$test_tmp/chrome/managed" /etc/opt/chrome/policies/managed
+  --dir /etc/opt/edge
+  --dir /etc/opt/edge/policies
+  --bind "$test_tmp/edge/managed" /etc/opt/edge/policies/managed
+  --dir /etc/brave
+  --dir /etc/brave/policies
+  --bind "$test_tmp/brave/managed" /etc/brave/policies/managed
+  --dir /usr/lib/firefox
+  --bind "$firefox_dir" /usr/lib/firefox/distribution
+  --dir /opt/zen-browser
+  --bind "$zen_dir" /opt/zen-browser/distribution
+)
+
+run_migration() {
+  local err_log=${1:-/dev/null}
+
+  HOME="$theme_home" \
+  OMARCHY_PATH="$ROOT" \
+  PATH="$stub_bin:/usr/bin:/bin" \
+  THEME_CALLS="$theme_calls" \
+  SUDO_CALLS="$sudo_calls" \
+    bwrap "${sandbox_args[@]}" bash -euo pipefail "$migration" >/dev/null 2>"$err_log"
+}
+
+: >"$theme_calls"
+: >"$sudo_calls"
+run_migration
+
+[[ $(wc -l <"$theme_calls") == 1 ]] ||
+  fail "browser policy migration invokes the Chromium repair once" "got: $(<"$theme_calls")"
+
+for browser in "${chromium_dirs[@]}"; do
+  policy_dir="$test_tmp/$browser/managed"
+  [[ $(stat -c '%a' "$policy_dir") == 755 ]] || fail "$browser policy directory is secured"
+  [[ -f $policy_dir/admin.json ]] || fail "$browser safe administrator policy is preserved"
+  [[ $(stat -c '%a' "$policy_dir/setuid-admin.json") == 4755 ]] ||
+    fail "$browser root-owned special-bit policy is preserved"
+  for hostile in unsafe.json .omarchy-hidden "with space.json" -dash-led.json sticky-dir; do
+    [[ ! -e $policy_dir/$hostile ]] || fail "$browser hostile entry $hostile is removed"
+  done
+  [[ ! -p $policy_dir/fifo-pipe ]] || fail "$browser FIFO entry is removed"
+  [[ ! -e $policy_dir/nested ]] || fail "$browser non-policy directory is removed"
+  [[ ! -L $policy_dir/color.json ]] || fail "$browser planted color policy symlink is removed"
+  [[ $(stat -c '%a' "$policy_dir/color.json") == 644 ]] || fail "$browser color policy mode is secured"
+  grep -Fxq '{"BrowserThemeColor": "#0a141e", "BrowserColorScheme": "device"}' "$policy_dir/color.json" ||
+    fail "$browser color policy is regenerated from the current theme"
+done
+
+[[ $(stat -c '%a' "$firefox_dir") == 755 ]] || fail "Firefox distribution directory is secured"
+[[ $(stat -c '%a' "$zen_dir") == 755 ]] || fail "Zen distribution directory is secured"
+[[ -f $firefox_dir/admin.json && -f $firefox_dir/admin-assets/keep.txt ]] ||
+  fail "Firefox safe administrator entries are preserved"
+for hostile in unsafe-file unsafe-link "with space.json" .omarchy-hidden -dash-led.json; do
+  [[ ! -e $firefox_dir/$hostile ]] || fail "Firefox hostile entry $hostile is removed"
+done
+cmp -s "$ROOT/default/firefox/policies.json" "$firefox_dir/policies.json" ||
+  fail "Firefox unsafe policy is replaced with the packaged policy"
+cmp -s "$ROOT/default/firefox/policies.json" "$zen_dir/policies.json" ||
+  fail "Zen missing policy is restored from the packaged policy"
+[[ $(stat -c '%a' "$firefox_dir/policies.json") == 644 ]] || fail "Firefox policy mode is secured"
+[[ $(stat -c '%a' "$zen_dir/policies.json") == 644 ]] || fail "Zen policy mode is secured"
+
+pass "browser policy migration repairs unsafe existing browser state in a sandbox"
+
+: >"$theme_calls"
+: >"$sudo_calls"
+run_migration
+
+[[ ! -s $theme_calls ]] || fail "browser policy migration repeats the Chromium repair on secure state"
+[[ ! -s $sudo_calls ]] || fail "browser policy migration repeats privileged distribution repairs on secure state"
+
+pass "browser policy migration is machine-idempotent"
+
+# One refused path must not stop the remaining repairs or wedge the migration:
+# a symlinked distribution directory is refused while the other browser is
+# repaired, and the run still succeeds.
+firefox_b="$test_tmp/firefox-b/distribution"
+zen_b="$test_tmp/zen-b"
+mkdir -p "$firefox_b"
+chmod 0755 "$firefox_b"
+printf 'unsafe\n' >"$firefox_b/unsafe-file"
+chmod 0666 "$firefox_b/unsafe-file"
+printf '{"Custom": true}\n' >"$firefox_b/policies.json"
+chmod 0644 "$firefox_b/policies.json"
+mkdir "$zen_b"
+ln -s "$test_tmp/nowhere" "$zen_b/distribution"
+
+sandbox_args=(
+  "${common_sandbox_args[@]}"
+  --dir /etc/chromium
+  --dir /etc/chromium/policies
+  --bind "$test_tmp/chromium/managed" /etc/chromium/policies/managed
+  --dir /etc/opt
+  --dir /etc/opt/chrome
+  --dir /etc/opt/chrome/policies
+  --bind "$test_tmp/chrome/managed" /etc/opt/chrome/policies/managed
+  --dir /etc/opt/edge
+  --dir /etc/opt/edge/policies
+  --bind "$test_tmp/edge/managed" /etc/opt/edge/policies/managed
+  --dir /etc/brave
+  --dir /etc/brave/policies
+  --bind "$test_tmp/brave/managed" /etc/brave/policies/managed
+  --dir /usr/lib/firefox
+  --bind "$firefox_b" /usr/lib/firefox/distribution
+  --bind "$zen_b" /opt/zen-browser
+)
+
+refusal_log="$test_tmp/refusal-log"
+: >"$theme_calls"
+: >"$sudo_calls"
+run_migration "$refusal_log"
+
+[[ ! -s $theme_calls ]] || fail "secure Chromium state skips the theme write in the tolerated run"
+[[ ! -e $firefox_b/unsafe-file ]] || fail "the tolerated run still repairs the reachable browser"
+cmp -s <(printf '{"Custom": true}\n') "$firefox_b/policies.json" ||
+  fail "the tolerated run keeps a safe administrator policy"
+grep -Fq 'Refusing unsafe browser distribution path: /opt/zen-browser/distribution' "$refusal_log" ||
+  fail "the refused distribution path is reported" "got: $(<"$refusal_log")"
+grep -Fq 'Browser policy repair could not secure /opt/zen-browser/distribution' "$refusal_log" ||
+  fail "the refused distribution path does not stop the migration" "got: $(<"$refusal_log")"
+
+pass "browser policy migration tolerates one refused path while repairing the rest"

--- a/test/shell.d/browser-policy-test.sh
+++ b/test/shell.d/browser-policy-test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+policy="$ROOT/bin/omarchy-theme-browser-policy"
+sudoers_file="$ROOT/etc/sudoers.d/omarchy-theme-browser-policy"
+rule='%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-theme-browser-policy *'
+
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
+[[ $rules == "$rule" ]] ||
+  fail "browser theme policy sudoers file contains exactly the constrained helper rule" "got: $rules"
+
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers_file" >/dev/null ||
+    fail "browser theme policy sudoers rule parses"
+fi
+
+grep -Fx 'PACKAGED_PATH=/usr/bin/omarchy-theme-browser-policy' "$policy" >/dev/null ||
+  fail "browser theme policy elevates the packaged path"
+
+grep -E 'sudo -n -l -l' "$policy" >/dev/null ||
+  fail "browser theme policy reads the passwordless grant from sudo's long listing"
+
+gated=$(grep -A1 -E '^if \(\( EUID == 0 \)\); then$' "$policy" || true)
+[[ $gated == *"export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin"* ]] ||
+  fail "browser theme policy pins PATH only after it holds root"
+
+expected_dirs=$'/etc/chromium/policies/managed\n/etc/opt/chrome/policies/managed\n/etc/opt/edge/policies/managed\n/etc/brave/policies/managed'
+policy_dirs=$(awk '
+  /^POLICY_DIRS=\($/ { inside = 1; next }
+  inside && /^\)$/ { exit }
+  inside { gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print }
+' "$policy")
+[[ $policy_dirs == "$expected_dirs" ]] ||
+  fail "browser theme policy writes only the supported Chromium policy paths" "got: $policy_dirs"
+
+pass "browser theme policy fixes its authorization, command, and destination paths"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+elevation_log="$test_tmp/elevation"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/pkexec" <<'SH'
+#!/bin/bash
+printf 'pkexec %s\n' "$*" >"$ELEVATION_LOG"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+if [[ $1 == -n && $2 == -l && $3 == -l ]]; then
+  if [[ ${STUB_GRANTED-1} == 1 ]]; then
+    echo "    Options: !authenticate"
+  fi
+  exit 0
+fi
+
+printf 'sudo %s\n' "$*" >"$ELEVATION_LOG"
+SH
+
+chmod +x "$stub_bin/pkexec" "$stub_bin/sudo"
+
+run_policy() {
+  : >"$elevation_log"
+  ELEVATION_LOG="$elevation_log" \
+  PATH="$stub_bin:$PATH" \
+    bash "$policy" "$@" </dev/null
+}
+
+assert_rejected() {
+  local description=$1
+  shift
+
+  if run_policy "$@" >"$test_tmp/rejected.out" 2>&1; then
+    fail "$description"
+  fi
+  [[ ! -s $elevation_log ]] ||
+    fail "$description before attempting elevation" "got: $(<"$elevation_log")"
+}
+
+assert_rejected "browser theme policy rejects a missing color"
+assert_rejected "browser theme policy rejects a color without a hash" "112233"
+assert_rejected "browser theme policy rejects short colors" "#12345"
+assert_rejected "browser theme policy rejects non-hex colors" "#12gg33"
+assert_rejected "browser theme policy rejects option-like input" "--help"
+assert_rejected "browser theme policy rejects extra arguments" "#112233" "#445566"
+assert_rejected "browser theme policy rejects input containing a newline" $'#112233\n/etc/passwd'
+
+pass "browser theme policy accepts only one six-digit hex color"
+
+# A direct root run would reach the real policy directories before these PATH
+# stubs could stop it, because root intentionally pins PATH. The static checks
+# and all validation coverage above remain safe under a root-run test suite.
+if (( EUID == 0 )); then
+  pass "running as root; skipping unprivileged elevation routing"
+  exit 0
+fi
+
+run_policy "#A1b2C3" >/dev/null
+elevation=$(<"$elevation_log")
+[[ $elevation == "sudo /usr/bin/omarchy-theme-browser-policy #A1b2C3" ]] ||
+  fail "browser theme policy uses its passwordless sudo grant" "got: $elevation"
+
+OMARCHY_PATH="$test_tmp/checkout" run_policy "#A1b2C3" >/dev/null
+elevation=$(<"$elevation_log")
+[[ $elevation == "sudo /usr/bin/omarchy-theme-browser-policy #A1b2C3" ]] ||
+  fail "a dev-linked browser policy command still elevates the packaged path" "got: $elevation"
+
+STUB_GRANTED="" run_policy "#A1b2C3" >/dev/null
+elevation=$(<"$elevation_log")
+[[ $elevation == "pkexec /usr/bin/omarchy-theme-browser-policy #A1b2C3" ]] ||
+  fail "browser theme policy falls back to polkit without the sudoers grant" "got: $elevation"
+
+pass "browser theme policy routes elevation without exposing checkout code"

--- a/test/shell.d/browser-policy-test.sh
+++ b/test/shell.d/browser-policy-test.sh
@@ -92,6 +92,57 @@ assert_rejected "browser theme policy rejects input containing a newline" $'#112
 
 pass "browser theme policy accepts only one six-digit hex color"
 
+theme_set_browser="$ROOT/bin/omarchy-theme-set-browser"
+theme_home="$test_tmp/home"
+theme_dir="$theme_home/.local/state/omarchy/current/theme"
+policy_log="$test_tmp/policy-calls"
+refresh_log="$test_tmp/refresh-calls"
+mkdir -p "$theme_dir"
+
+cat >"$stub_bin/omarchy-theme-browser-policy" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$POLICY_LOG"
+[[ ${POLICY_FAIL:-0} != 1 ]]
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$REFRESH_LOG"
+exit 1
+SH
+
+chmod +x "$stub_bin/omarchy-theme-browser-policy" "$stub_bin/omarchy-cmd-present"
+
+run_theme_set_browser() {
+  : >"$policy_log"
+  : >"$refresh_log"
+  HOME="$theme_home" \
+  POLICY_LOG="$policy_log" \
+  REFRESH_LOG="$refresh_log" \
+  PATH="$stub_bin:$PATH" \
+    bash "$theme_set_browser"
+}
+
+printf '26,27,38\n' >"$theme_dir/chromium.theme"
+run_theme_set_browser
+[[ $(<"$policy_log") == "#1a1b26" ]] ||
+  fail "browser theme set converts the staged RGB color for the policy helper" "got: $(<"$policy_log")"
+
+rm "$theme_dir/chromium.theme"
+run_theme_set_browser
+[[ $(<"$policy_log") == "#1c2027" ]] ||
+  fail "browser theme set passes the neutral fallback to the policy helper" "got: $(<"$policy_log")"
+
+if POLICY_FAIL=1 run_theme_set_browser >/dev/null 2>&1; then
+  fail "browser theme set reports a failed policy write"
+fi
+[[ $(wc -l <"$policy_log") == 1 ]] ||
+  fail "browser theme set invokes the policy helper exactly once" "got: $(<"$policy_log")"
+[[ ! -s $refresh_log ]] ||
+  fail "browser theme set does not refresh browsers after a failed policy write" "got: $(<"$refresh_log")"
+
+pass "browser theme set delegates one resolved color before refreshing browsers"
+
 # A direct root run would reach the real policy directories before these PATH
 # stubs could stop it, because root intentionally pins PATH. The static checks
 # and all validation coverage above remain safe under a root-run test suite.

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -205,10 +205,8 @@ OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install chromiu
 [[ $(omarchy-default-browser) == "chromium" ]] || fail "Chromium becomes the default after its full installer succeeds"
 cmp -s "$ROOT/config/chromium-flags.conf" "$test_home/.config/chromium-flags.conf" ||
   fail "Chromium browser installer copies the default flags"
-grep -Fxq 'sudo:mkdir -p /etc/chromium/policies/managed' "$setup_log" ||
-  fail "Chromium browser installer creates its policy directory"
-grep -Fxq 'sudo:chmod a+rw /etc/chromium/policies/managed' "$setup_log" ||
-  fail "Chromium browser installer makes its policy directory writable"
+grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium/policies/managed' "$setup_log" ||
+  fail "Chromium browser installer secures its policy directory"
 grep -Fxq 'omarchy-install-chromium-copy-url:' "$setup_log" ||
   fail "Chromium browser installer registers the Copy URL host"
 grep -Fxq 'omarchy-install-chromium-ytdlp:' "$setup_log" ||
@@ -216,6 +214,15 @@ grep -Fxq 'omarchy-install-chromium-ytdlp:' "$setup_log" ||
 grep -Fxq 'omarchy-theme-set-browser:' "$setup_log" ||
   fail "Chromium browser installer applies the current theme"
 pass "Chromium browser installer restores the complete Omarchy setup"
+
+: >"$setup_log"
+rm -f "$installed_dir/firefox"
+OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install firefox >/dev/null
+grep -Fxq 'sudo:install -d -m 0755 -o root -g root /usr/lib/firefox/distribution' "$setup_log" ||
+  fail "Firefox browser installer secures its policy directory"
+grep -Fxq "sudo:install -m 0644 -o root -g root -T $ROOT/default/firefox/policies.json /usr/lib/firefox/distribution/policies.json" "$setup_log" ||
+  fail "Firefox browser installer replaces its policy without following a planted symlink"
+pass "Firefox browser installer secures its policy setup"
 
 omarchy-default-browser zen
 rm -f "$installed_dir/chromium"

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -139,6 +139,12 @@ grep -F '/etc/systemd/system.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro
 grep -F '/etc/systemd/user.conf.d/99-omarchy-nofile.conf' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade removes stale nofile drop-ins"
 
+grep -F 'as_root install -d -m 0755 -o root -g root /etc/chromium/policies/managed' "$upgrade_to_quattro" >/dev/null ||
+  fail "Omarchy 4 upgrade secures the Chromium policy directory"
+! grep -F 'install -d -m 0777 /etc/chromium/policies/managed' "$upgrade_to_quattro" >/dev/null ||
+  fail "Omarchy 4 upgrade does not leave Chromium policy world-writable"
+pass "Omarchy 4 upgrade secures the Chromium policy directory"
+
 cmdline_line=$(grep -n '^preserve_kernel_cmdline_root$' "$upgrade_to_quattro" | cut -d: -f1)
 packages_line=$(grep -n '^install_omarchy_quattro_packages$' "$upgrade_to_quattro" | cut -d: -f1)
 [[ -n $cmdline_line && -n $packages_line ]] || fail "kernel cmdline preservation and package install calls exist"


### PR DESCRIPTION
Closes #5547.
Prior art: #5548 ships a group-writable (`root:wheel 0664`) `color.json`, and
#6531 ships a user-owned `color.json` inside hardened directories. Both keep
theme switching sudo-free by leaving the policy file writable by a non-root
identity, so its full JSON contents remain controllable outside root. This PR
instead routes the single legitimate write through a constrained NOPASSWD
helper, the same pattern Omarchy already uses for `omarchy-dns`, keeping
everything under `/etc` unwritable outside root while graphical theme changes
stay prompt-free.
                                                                                             
## Problem
Omarchy creates browser managed-policy dirs (`/etc/chromium`, `/etc/opt/{chrome,edge}`,      
`/etc/brave`) mode 0777 so theme changes can write `color.json` unprivileged, and installs   
Firefox/Zen distribution dirs the same way. Any local process can plant mandatory policies:
forced extensions, proxies, disabled security features.                                      
                                                                                             
## Approach                                                                                  
Keep everything root-owned (`dirs 0755`, `files 0644`) and move the one legitimate write     
behind a constrained helper:                                                                 
                                                                                             
- `bin/omarchy-theme-browser-policy`: accepts exactly one `#RRGGBB` value, validates before  
  elevating, writes fixed JSON atomically (`root:root 0644`), secures dirs before inspecting,
  removes attacker-writable/symlinked entries while preserving genuine root-owned admin
  policies, refuses symlinked/non-directory policy paths, pins PATH while root.
- `etc/sudoers.d/omarchy-theme-browser-policy`: NOPASSWD scoped to that one command,
  keeps graphical theme switching prompt-free.
- `bin/omarchy-install-browser` / `install/config/theme-system.sh` /
  `bin/omarchy-upgrade-to-quattro`: create dirs `root:root 0755`; Firefox/Zen `policies.json`
  installed `0644` via `install -T` (symlink-safe).
- `migrations/1787676640.sh`: repairs existing installs, Chromium-family dirs via the helper
  chain, Firefox/Zen distribution dirs directly; idempotent; tolerates one refused path
  without blocking the rest; refuses to source policy from a non-root-owned `$OMARCHY_PATH`.

Unlike #5548's group-writable `color.json` (any wheel process could rewrite arbitrary policy
JSON), the passwordless surface here is one regex-validated color into fixed content.

## Testing
- Focused suites: `browser-policy-test.sh`, `browser-policy-migration-test.sh`,
  `default-apps-test.sh`, `upgrade-to-quattro-test.sh`, `bin-style-test.sh`.
- Migration runtime-tested under bwrap user namespaces with tmpfs overlays over
  `/etc`, `/usr/lib`, `/opt`: hostile entries (world-writable, dotfiles, spaces,
  dash-leading names, FIFOs, sticky dirs, planted symlinks) removed; setuid/root-owned
  admin policies preserved; second run performs zero privileged work.
- Validated on a live affected install: dirs `0777→0755`, user-owned `color.json` replaced
  `root:root 0644`, seeded hostile policy removed, admin policy preserved, theme switching
  updates browsers end-to-end without prompts.
- Fresh installs get migration markers pre-seeded via the existing skel mechanism.

Run those three checks, then you're clear to open it.
