### PR TITLE
Add a Celsius/Fahrenheit toggle to the weather widget

### DIFF
--- a/bin/omarchy-toggle-weather-unit
+++ b/bin/omarchy-toggle-weather-unit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the weather widget between Celsius and Fahrenheit
+# omarchy:examples=omarchy toggle weather unit
+
+(( $# <= 0 )) || { echo "Usage: omarchy-toggle-weather-unit" >&2; exit 1; }
+
+exec omarchy-shell omarchy.weather toggleUnit

--- a/bin/omarchy-weather-location
+++ b/bin/omarchy-weather-location
@@ -3,13 +3,16 @@
 # omarchy:summary=Show or set the location used for weather reports
 #
 # State lives in ~/.local/state/omarchy/settings/weather.json as
-# {"name": ..., "latitude": ..., "longitude": ...}. A missing file means the
-# location is auto-detected from the IP address. Coordinates make the weather
-# panel exact; a hand-written {"name": "Malibu"} alone works too.
+# {"name": ..., "latitude": ..., "longitude": ...} plus an optional
+# {"country": ...} the weather panel uses for unit auto-detection. A missing
+# file means the location is auto-detected from the IP address. Coordinates
+# make the weather panel exact; a hand-written {"name": "Malibu"} alone works
+# too.
 #
 #   (no args)           the current location: the stored name, or the
 #                       IP-detected city when nothing is set
-#   --set <name> [lat,lon]  store a location
+#   --set <name> [lat,lon] [country]
+#                       store a location
 #   --clear             return to IP auto-detect
 
 LOC_FILE="$HOME/.local/state/omarchy/settings/weather.json"
@@ -26,21 +29,27 @@ case "${1:-}" in
   [[ -n $name ]] && echo "$name"
   ;;
 --set)
-  [[ -n ${2:-} ]] || { echo "Usage: omarchy-weather-location --set <name> [lat,lon]" >&2; exit 1; }
+  [[ -n ${2:-} ]] || { echo "Usage: omarchy-weather-location --set <name> [lat,lon] [country]" >&2; exit 1; }
   if [[ -n ${3:-} ]]; then
     [[ ${3} =~ $COORDS_PATTERN ]] || { echo "Invalid coordinates: $3 (expected lat,lon)" >&2; exit 1; }
-    location=$(jq -n --arg name "$2" --argjson latitude "${3%,*}" --argjson longitude "${3#*,}" '{$name, $latitude, $longitude}')
+    if [[ -n ${4:-} ]]; then
+      location=$(jq -n --arg name "$2" --argjson latitude "${3%,*}" --argjson longitude "${3#*,}" --arg country "$4" '{$name, $latitude, $longitude, $country}')
+    else
+      location=$(jq -n --arg name "$2" --argjson latitude "${3%,*}" --argjson longitude "${3#*,}" '{$name, $latitude, $longitude}')
+    fi
   else
     location=$(jq -n --arg name "$2" '{$name}')
   fi
   mkdir -p "$(dirname "$LOC_FILE")"
-  echo "$location" >"$LOC_FILE"
+  # Atomic replace: a reader watching the file (the weather panel) never sees
+  # the truncated in-between state of a plain redirect.
+  printf '%s\n' "$location" >"$LOC_FILE.tmp.$$" && mv -f "$LOC_FILE.tmp.$$" "$LOC_FILE"
   ;;
 --clear)
   rm -f "$LOC_FILE"
   ;;
 *)
-  echo "Usage: omarchy-weather-location [--set <name> [lat,lon]|--clear]" >&2
+  echo "Usage: omarchy-weather-location [--set <name> [lat,lon] [country]|--clear]" >&2
   exit 1
   ;;
 esac

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -27,6 +27,8 @@ o.bind_toggle("SUPER + CTRL + comma", "Toggle silencing notifications", "notific
 o.bind("SUPER + ALT + comma", "Invoke last notification", "omarchy-shell notifications invokeLast")
 o.bind("SUPER + SHIFT + ALT + comma", "Open notification history", "omarchy-shell notifications showHistory")
 
+o.bind_toggle("SUPER + ALT + U", "Toggle weather units", "weather-unit")
+
 o.bind_toggle("SUPER + CTRL + I", "Toggle locking on idle", "idle")
 o.bind_toggle("SUPER + CTRL + N", "Toggle nightlight", "nightlight")
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")

--- a/shell/plugins/panels/weather/BarWidget.qml
+++ b/shell/plugins/panels/weather/BarWidget.qml
@@ -11,6 +11,10 @@ BarWidget {
     if (!target) return
     if ("bar" in target) target.bar = root.bar
     if ("settings" in target) target.settings = root.settings
+    // The slot renames cloned widgets (<user>.weather); panels persist
+    // settings under moduleName, so hand down the mounted id, not the
+    // hardcoded one.
+    if ("moduleName" in target) target.moduleName = root.moduleName
     if ("anchorItem" in target) target.anchorItem = button
     if ("hostWidget" in target) target.hostWidget = root
   }

--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -1,8 +1,9 @@
-// weather.json holds {"name": ..., "latitude": ..., "longitude": ...} (see
-// omarchy-weather-location, which owns the format). Missing, blank, or
-// unparseable means the location is auto-detected from the IP address.
+// weather.json holds {"name": ..., "latitude": ..., "longitude": ...} and
+// optionally {"country": ...} (see omarchy-weather-location, which owns the
+// format). Missing, blank, or unparseable means the location is auto-detected
+// from the IP address.
 function parseLocationFile(raw) {
-  var unset = { name: "", latitude: null, longitude: null }
+  var unset = { name: "", latitude: null, longitude: null, country: "" }
   try {
     var data = JSON.parse(String(raw || ""))
     if (!data || typeof data !== "object") return unset
@@ -13,7 +14,8 @@ function parseLocationFile(raw) {
     return {
       name: typeof data.name === "string" ? data.name.replace(/^\s+|\s+$/g, "") : "",
       latitude: hasCoordinates ? latitude : null,
-      longitude: hasCoordinates ? longitude : null
+      longitude: hasCoordinates ? longitude : null,
+      country: typeof data.country === "string" ? data.country.replace(/^\s+|\s+$/g, "") : ""
     }
   } catch (e) {
     return unset
@@ -48,7 +50,8 @@ function parseGeocodingResults(raw) {
         name: String(r.name),
         description: region,
         latitude: r.latitude,
-        longitude: r.longitude
+        longitude: r.longitude,
+        country: typeof r.country === "string" ? r.country : ""
       })
     }
     return out
@@ -59,14 +62,14 @@ function parseGeocodingResults(raw) {
 
 function locationCommit(text, suggestions, selectedIndex) {
   var name = String(text || "").replace(/^\s+|\s+$/g, "")
-  if (name === "") return { name: "", latitude: null, longitude: null }
+  if (name === "") return { name: "", latitude: null, longitude: null, country: "" }
 
   var choices = suggestions || []
   var index = Math.max(0, Math.min(parseInt(selectedIndex, 10) || 0, choices.length - 1))
   var suggestion = choices[index]
   if (suggestion) return suggestion
 
-  return { name: name, latitude: null, longitude: null }
+  return { name: name, latitude: null, longitude: null, country: "" }
 }
 
 function isFutureForecastDate(dateString, todayString) {

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -76,8 +76,9 @@ Panel {
   // omarchy-weather-location). The query is the wttr.in path segment
   // (coordinates when stored, else the encoded name); empty means IP
   // auto-detect. The watch makes hand edits take effect live.
-  property var configuredLocationState: ({ name: "", latitude: null, longitude: null })
+  property var configuredLocationState: ({ name: "", latitude: null, longitude: null, country: "" })
   readonly property string configuredLocation: configuredLocationState.name
+  readonly property string configuredCountry: configuredLocationState.country || ""
   readonly property string locationQuery: Model.wttrLocationQuery(configuredLocationState.name, configuredLocationState.latitude, configuredLocationState.longitude)
 
   // Keep the previous report visible while the new location loads. The
@@ -97,7 +98,9 @@ Panel {
     watchChanges: true
     printErrors: false
     onFileChanged: reload()
-    onLoaded: root.configuredLocationState = Model.parseLocationFile(text())
+    onLoaded: {
+      root.configuredLocationState = Model.parseLocationFile(text())
+    }
     onLoadFailed: root.configuredLocationState = Model.parseLocationFile("")
   }
 
@@ -135,7 +138,10 @@ Panel {
   readonly property var forecastDays: buildForecastDays()
   readonly property string reportCountry: areaInfo && areaInfo.country && areaInfo.country[0] ? areaInfo.country[0].value : ""
 
-  readonly property bool useImperial: Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, reportCountry)
+  // Unit precedence: explicit shell.json override, then the configured
+  // location's country (known without any network round-trip), then wttr's
+  // reported area, then the session locale.
+  readonly property bool useImperial: Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, configuredCountry || reportCountry)
 
   // Auto-refresh interval in minutes; clamped to a sane minimum.
   readonly property int refreshMinutes: Math.max(1, parseInt(setting("refreshMinutes", 15), 10) || 15)
@@ -221,9 +227,10 @@ Panel {
     configuredLocationState = {
       name: location.name,
       latitude: location.latitude,
-      longitude: location.longitude
+      longitude: location.longitude,
+      country: location.country || ""
     }
-    persistLocation(location.name, location.latitude, location.longitude)
+    persistLocation(location.name, location.latitude, location.longitude, location.country)
   }
 
   function clearLocation() {
@@ -239,18 +246,23 @@ Panel {
     configuredLocationState = {
       name: suggestion.name,
       latitude: suggestion.latitude,
-      longitude: suggestion.longitude
+      longitude: suggestion.longitude,
+      country: suggestion.country || ""
     }
-    persistLocation(suggestion.name, suggestion.latitude, suggestion.longitude)
+    persistLocation(suggestion.name, suggestion.latitude, suggestion.longitude, suggestion.country)
   }
 
   function finishSavingLocation() {
     if (savingLocation && savingLocationQueryStarted) cancelEditingLocation()
   }
 
-  function persistLocation(name, latitude, longitude) {
-    if (name && latitude !== null && longitude !== null)
-      locationSaveProc.command = ["omarchy-weather-location", "--set", name, latitude + "," + longitude]
+  function persistLocation(name, latitude, longitude, country) {
+    var trimmedCountry = String(country || "").replace(/^\s+|\s+$/g, "")
+    if (name && latitude !== null && longitude !== null) {
+      var args = ["omarchy-weather-location", "--set", name, latitude + "," + longitude]
+      if (trimmedCountry !== "") args.push(trimmedCountry)
+      locationSaveProc.command = args
+    }
     else if (name)
       locationSaveProc.command = ["omarchy-weather-location", "--set", name]
     else

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -140,8 +140,10 @@ Panel {
 
   // Unit precedence: explicit shell.json override, then the configured
   // location's country (known without any network round-trip), then wttr's
-  // reported area, then the session locale.
+  // reported area, then the session locale. Empty override = automatic: the
+  // location picks the unit, same contract as the network panel's band.
   readonly property bool useImperial: Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, configuredCountry || reportCountry)
+  readonly property bool unitPinned: setting("unit", "") !== ""
 
   // Auto-refresh interval in minutes; clamped to a sane minimum.
   readonly property int refreshMinutes: Math.max(1, parseInt(setting("refreshMinutes", 15), 10) || 15)
@@ -254,6 +256,36 @@ Panel {
 
   function finishSavingLocation() {
     if (savingLocation && savingLocationQueryStarted) cancelEditingLocation()
+  }
+
+  // Write widget settings back to the module's shell.json entry. Applied
+  // locally first so the label flips on the click itself; the shell.json
+  // write comes back through the bar as the same value.
+  function persistSettings(values) {
+    var entry = { id: root.moduleName }
+    for (var existing in root.settings) if (existing !== "id") entry[existing] = root.settings[existing]
+    for (var key in values) entry[key] = values[key]
+
+    root.settings = entry
+    if (root.hostWidget && "settings" in root.hostWidget) root.hostWidget.settings = entry
+    if (root.bar && root.bar.shell && typeof root.bar.shell.updateEntryInline === "function")
+      root.bar.shell.updateEntryInline(root.moduleName, entry)
+  }
+
+  // Clicking the degree label pins the opposite of what is showing — the
+  // unit the user is asking for, never a silent mode change.
+  function pinOppositeUnit() {
+    persistSettings({ unit: useImperial ? "metric" : "imperial" })
+  }
+
+  // SUPER + U and the IPC toggle flip while automatic and restore automatic
+  // when pinned, so automatic is always one press away.
+  function toggleUnit() {
+    persistSettings({ unit: unitPinned ? "" : (useImperial ? "metric" : "imperial") })
+  }
+
+  function unitAuto() {
+    persistSettings({ unit: "" })
   }
 
   function persistLocation(name, latitude, longitude, country) {
@@ -494,6 +526,7 @@ Panel {
     function hide(): void { root.close() }
     function toggle(): void { root.toggle() }
     function edit(): void { root.openFromHotkey(); root.startEditingLocation() }
+    function toggleUnit(): void { root.toggleUnit() }
   }
 
   KeyboardPanel {
@@ -568,12 +601,48 @@ Panel {
               font.bold: true
             }
             Text {
+              id: unitLabel
               text: root.current ? root.tempUnit : ""
               color: root.bar.foreground
               font.family: root.bar.fontFamily
               font.pixelSize: Style.font.display
               anchors.top: tempBig.top
               anchors.topMargin: Style.space(10)
+
+              TapHandler {
+                onTapped: root.pinOppositeUnit()
+              }
+              HoverHandler {
+                id: unitHover
+                cursorShape: Qt.PointingHandCursor
+              }
+              PanelToolTip {
+                visible: unitHover.containsMouse
+                text: root.unitPinned
+                  ? "Pinned " + root.tempUnit + " · click to switch"
+                  : "Automatic · following " + (root.reportLocation || "your location")
+              }
+            }
+            Text {
+              id: unitAutoDot
+              visible: root.unitPinned
+              text: "·"
+              color: Qt.darker(root.bar.foreground, 1.4)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.display
+              anchors.baseline: unitLabel.baseline
+
+              TapHandler {
+                onTapped: root.unitAuto()
+              }
+              HoverHandler {
+                id: unitAutoHover
+                cursorShape: Qt.PointingHandCursor
+              }
+              PanelToolTip {
+                visible: unitAutoHover.containsMouse
+                text: "Let your location pick the unit"
+              }
             }
           }
         }

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -10,17 +10,19 @@ const weather = requireFromRoot('shell/plugins/panels/weather/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/weather/Panel.qml', 'utf8')
 const widgetSource = fs.readFileSync(root + '/shell/plugins/panels/weather/BarWidget.qml', 'utf8')
 
-assertDeepEqual(weather.parseLocationFile('{"name": "Malibu", "latitude": 34.02577, "longitude": -118.7804}\n'), { name: 'Malibu', latitude: 34.02577, longitude: -118.7804 }, 'weather parses name plus coordinates from weather.json')
-assertDeepEqual(weather.parseLocationFile('{"name": "New York"}'), { name: 'New York', latitude: null, longitude: null }, 'weather parses a name-only weather.json')
-assertDeepEqual(weather.parseLocationFile('{"name": "Malibu", "latitude": 34.02577}'), { name: 'Malibu', latitude: null, longitude: null }, 'weather requires both coordinates')
-assertDeepEqual(weather.parseLocationFile('not json'), { name: '', latitude: null, longitude: null }, 'weather treats an unparseable weather.json as auto-detect')
-assertDeepEqual(weather.parseLocationFile(''), { name: '', latitude: null, longitude: null }, 'weather treats a missing weather.json as auto-detect')
+assertDeepEqual(weather.parseLocationFile('{"name": "Malibu", "latitude": 34.02577, "longitude": -118.7804}\n'), { name: 'Malibu', latitude: 34.02577, longitude: -118.7804, country: '' }, 'weather parses name plus coordinates from weather.json')
+assertDeepEqual(weather.parseLocationFile('{"name": "New York"}'), { name: 'New York', latitude: null, longitude: null, country: '' }, 'weather parses a name-only weather.json')
+assertDeepEqual(weather.parseLocationFile('{"name": "Malibu", "latitude": 34.02577}'), { name: 'Malibu', latitude: null, longitude: null, country: '' }, 'weather requires both coordinates')
+assertDeepEqual(weather.parseLocationFile('{"name": "Turbaco", "latitude": 10.32944, "longitude": -75.41137, "country": "Colombia"}'), { name: 'Turbaco', latitude: 10.32944, longitude: -75.41137, country: 'Colombia' }, 'weather parses the stored country')
+assertDeepEqual(weather.parseLocationFile('{"name": "Windsor", "country": "  Canada  "}'), { name: 'Windsor', latitude: null, longitude: null, country: 'Canada' }, 'weather trims whitespace around a stored country')
+assertDeepEqual(weather.parseLocationFile('not json'), { name: '', latitude: null, longitude: null, country: '' }, 'weather treats an unparseable weather.json as auto-detect')
+assertDeepEqual(weather.parseLocationFile(''), { name: '', latitude: null, longitude: null, country: '' }, 'weather treats a missing weather.json as auto-detect')
 
-assertDeepEqual(weather.locationCommit('  Pasadena  ', [], 0), { name: 'Pasadena', latitude: null, longitude: null }, 'weather commits typed locations before suggestions load')
-assertDeepEqual(weather.locationCommit('', [], 0), { name: '', latitude: null, longitude: null }, 'weather commits an empty location as auto-detect')
+assertDeepEqual(weather.locationCommit('  Pasadena  ', [], 0), { name: 'Pasadena', latitude: null, longitude: null, country: '' }, 'weather commits typed locations before suggestions load')
+assertDeepEqual(weather.locationCommit('', [], 0), { name: '', latitude: null, longitude: null, country: '' }, 'weather commits an empty location as auto-detect')
 assertDeepEqual(
-  weather.locationCommit('mal', [{ name: 'Malibu', latitude: 34.02577, longitude: -118.7804 }], 0),
-  { name: 'Malibu', latitude: 34.02577, longitude: -118.7804 },
+  weather.locationCommit('mal', [{ name: 'Malibu', latitude: 34.02577, longitude: -118.7804, country: 'United States' }], 0),
+  { name: 'Malibu', latitude: 34.02577, longitude: -118.7804, country: 'United States' },
   'weather commits the selected geocoding suggestion when available'
 )
 
@@ -41,9 +43,9 @@ assertDeepEqual(
     ]
   })),
   [
-    { name: 'Malibu', description: 'California, United States', latitude: 34.02577, longitude: -118.7804 },
-    { name: 'Malibu', description: 'Tanganyika, Democratic Republic of Congo', latitude: -7.18333, longitude: 29.65 },
-    { name: 'Bare', description: '', latitude: 2.0, longitude: 3.0 }
+    { name: 'Malibu', description: 'California, United States', latitude: 34.02577, longitude: -118.7804, country: 'United States' },
+    { name: 'Malibu', description: 'Tanganyika, Democratic Republic of Congo', latitude: -7.18333, longitude: 29.65, country: 'Democratic Republic of Congo' },
+    { name: 'Bare', description: '', latitude: 2.0, longitude: 3.0, country: '' }
   ],
   'weather parses geocoding suggestions and drops incomplete rows'
 )
@@ -145,6 +147,20 @@ assert(
   panelSource.split('root.controller.show()\n    locationFile.reload()\n    root.refresh()').length === 3,
   'weather reloads external location changes whenever either open path runs'
 )
+assert(
+  panelSource.includes('Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, configuredCountry || reportCountry)'),
+  'weather prefers the configured location country over wttr and locale for units'
+)
+assert(
+  /persistLocation\(location\.name, location\.latitude, location\.longitude, location\.country\)/.test(panelSource) &&
+    /persistLocation\(suggestion\.name, suggestion\.latitude, suggestion\.longitude, suggestion\.country\)/.test(panelSource),
+  'weather persists the geocoded country alongside name and coordinates'
+)
+assert(
+  panelSource.includes("configuredLocationState = Model.parseLocationFile(text())"),
+  'weather reads location directly from the file without a mid-write guard'
+)
+
 assert(!weather.weatherResponseCompletesSave(true, 'wttr'), 'weather keeps the spinner through a non-authoritative pinned-location response')
 assert(weather.weatherResponseCompletesSave(true, 'open-meteo'), 'weather completes a pinned-location save with Open-Meteo data')
 assert(weather.weatherResponseCompletesSave(false, 'wttr'), 'weather completes a name-only location save with wttr data')
@@ -165,6 +181,14 @@ weather_location() {
 weather_location --set "Malibu" "34.02577,-118.7804"
 [[ $(jq -c . "$test_tmp/.local/state/omarchy/settings/weather.json") == '{"name":"Malibu","latitude":34.02577,"longitude":-118.7804}' ]] || fail "weather location stores name and coordinates as JSON"
 pass "weather location stores name and coordinates as JSON"
+
+weather_location --set "Turbaco" "10.32944,-75.41137" "Colombia"
+[[ $(jq -c . "$test_tmp/.local/state/omarchy/settings/weather.json") == '{"name":"Turbaco","latitude":10.32944,"longitude":-75.41137,"country":"Colombia"}' ]] || fail "weather location stores an optional country alongside coordinates"
+pass "weather location stores an optional country alongside coordinates"
+
+weather_location --set "Malibu" "34.02577,-118.7804"
+[[ $(jq 'has("country")' "$test_tmp/.local/state/omarchy/settings/weather.json") == "false" ]] || fail "weather location omits the country key when none is given"
+pass "weather location omits the country key when none is given"
 
 [[ $(weather_location) == "Malibu" ]] || fail "weather location returns the stored name"
 pass "weather location returns the stored name"

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -160,6 +160,26 @@ assert(
   panelSource.includes("configuredLocationState = Model.parseLocationFile(text())"),
   'weather reads location directly from the file without a mid-write guard'
 )
+assert(
+  panelSource.includes('function persistSettings(values)') && panelSource.includes('updateEntryInline'),
+  'weather persists unit changes back into its shell.json entry'
+)
+assert(
+  panelSource.includes('function pinOppositeUnit()') && panelSource.includes('onTapped: root.pinOppositeUnit()'),
+  'weather pins the requested unit from the hero degree label itself'
+)
+assert(
+  panelSource.includes('unitPinned ? "" :') && panelSource.includes('function unitAuto()'),
+  'weather toggle restores automatic when pinned, and the dot returns it'
+)
+assert(
+  panelSource.includes('function toggleUnit(): void { root.toggleUnit() }'),
+  'weather exposes toggleUnit over IPC so keybindings and menus can reach it'
+)
+assert(
+  widgetSource.includes('target.moduleName = root.moduleName'),
+  'weather hands the mounted (possibly cloned) widget id to its panel so settings persist'
+)
 
 assert(!weather.weatherResponseCompletesSave(true, 'wttr'), 'weather keeps the spinner through a non-authoritative pinned-location response')
 assert(weather.weatherResponseCompletesSave(true, 'open-meteo'), 'weather completes a pinned-location save with Open-Meteo data')
@@ -206,3 +226,27 @@ pass "weather location rejects malformed coordinates"
 weather_location --clear
 [[ ! -e "$test_tmp/.local/state/omarchy/settings/weather.json" ]] || fail "weather location clear removes the state file"
 pass "weather location clear removes the state file"
+
+# ---- Weather unit toggle command
+
+toggle_stub_dir=$(mktemp -d)
+trap 'rm -rf "$test_tmp" "$toggle_stub_dir"' EXIT
+mkdir -p "$toggle_stub_dir"
+cat >"$toggle_stub_dir/omarchy-shell" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${CAPTURE_FILE:?}"
+STUB
+chmod +x "$toggle_stub_dir/omarchy-shell"
+
+capture_file="$test_tmp/toggle-capture"
+: >"$capture_file"
+CAPTURE_FILE="$capture_file" HOME="$test_tmp" PATH="$toggle_stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-toggle-weather-unit"
+[[ $(cat "$capture_file") == "omarchy.weather toggleUnit" ]] || fail "weather unit toggle flips units through the shell IPC"
+pass "weather unit toggle flips units through the shell IPC"
+
+if CAPTURE_FILE="$capture_file" PATH="$toggle_stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-toggle-weather-unit" fahrenheit >/dev/null 2>&1; then
+  fail "weather unit toggle rejects arguments"
+fi
+pass "weather unit toggle rejects arguments"


### PR DESCRIPTION
Stacked on #8277 — merge that first; this diff shrinks to the toggle once it
lands.

The unit was only changeable by hand-editing shell.json. This adds a visible,
recoverable toggle that mirrors the network panel's Automatic/pinned band
pattern.

## What

- **Click the degree label** in the panel hero to pin the opposite unit.
- **A small dot** appears while pinned; click it to return to automatic — the
  location picks the unit again, using the precedence from the country
  detection change.
- **SUPER + ALT + U** flips while automatic and restores automatic when
  pinned, so automatic is always one press away. Exposed as
  `omarchy-shell omarchy.weather toggleUnit`, with
  `omarchy-toggle-weather-unit` forwarding to it so menus and scripts can
  reach the same behavior.
- The degree label states the mode on hover ("Automatic · following
  <location>" / "Pinned °F · click to switch" / "Let your location pick the
  unit").

`injectPanel` now hands the panel the mounted widget id, so cloned widgets
(`<user>.weather`) persist settings into their own shell.json entry instead of
silently writing to one that does not exist.

## Design

`auto` is a first-class stored state (empty `unit`), `pinned` is any explicit
value, and the affordance collapses to nothing while automatic — the bar looks
exactly like stock until a unit is pinned. The keybinding sits near the
existing weather binding (SUPER+CTRL+ALT+W) and is trivial to move if another
spot is preferred.

## Tests

`test/shell.d/weather-test.sh` at 71 assertions total: the pin/auto/IPC source
contract on Panel.qml and BarWidget.qml, and end-to-end cases for the toggle
command (forwards to the shell IPC; rejects arguments).

`./test/shell.d/weather-test.sh` passes.

Happy to attach panel captures if useful.
