### PR TITLE
Delay the first low-battery check until UPower settles

### DIFF
--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -14,6 +14,11 @@ Item {
   property string pendingPowerSource: ""
   property string activePowerProfile: ""
   readonly property bool powerSaverOnBattery: UPower.onBattery && activePowerProfile === "power-saver"
+  // UPower's first onBattery / display-device values can still reflect the
+  // pre-suspend discharging state for a few seconds after shell start (#7679).
+  // Hold low-battery warnings until settleTimer completes; power profiles still
+  // apply immediately on charger changes.
+  property bool lowBatteryChecksReady: false
 
   PersistentProperties {
     id: persisted
@@ -30,6 +35,7 @@ Item {
   }
 
   function checkBattery() {
+    if (!lowBatteryChecksReady) return
     var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
     persisted.notifiedLowBattery = state.notifiedLowBattery
     if (state.notify) sendLowBatteryWarning(state.level)
@@ -102,18 +108,23 @@ Item {
 
   // First evaluation after UPower has had a moment to report the real charger state.
   Timer {
+    id: settleTimer
     interval: 5000
     running: true
     repeat: false
-    onTriggered: root.checkBattery()
+    onTriggered: {
+      root.lowBatteryChecksReady = true
+      root.checkBattery()
+    }
   }
 
   Connections {
     target: UPower
     function onOnBatteryChanged() {
-      root.checkBattery()
+      // Always switch profiles immediately; low-battery warnings wait for settle.
       root.applyPowerProfile()
       root.refreshPowerProfile()
+      root.checkBattery()
     }
   }
 

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -93,7 +93,18 @@ Item {
     interval: 30000
     running: true
     repeat: true
-    triggeredOnStart: true
+    // Wait for UPower's AC state to settle before the first check. An immediate
+    // run on shell start can still see the pre-death discharging state after a
+    // battery-empty suspend, and fire "Time to recharge!" while already on AC (#7679).
+    triggeredOnStart: false
+    onTriggered: root.checkBattery()
+  }
+
+  // First evaluation after UPower has had a moment to report the real charger state.
+  Timer {
+    interval: 5000
+    running: true
+    repeat: false
     onTriggered: root.checkBattery()
   }
 

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -36,5 +36,8 @@ assertDeepEqual(
 
 const serviceSource = require('fs').readFileSync(root + '/shell/plugins/services/battery/Service.qml', 'utf8')
 assert(/triggeredOnStart:\s*false/.test(serviceSource), 'battery defers the first low-battery check past shell start')
-assert(/interval:\s*5000[\s\S]*onTriggered:\s*root\.checkBattery\(\)/.test(serviceSource), 'battery runs a delayed first low-battery check')
+assert(/lowBatteryChecksReady:\s*false/.test(serviceSource), 'battery gates low-battery checks until UPower settles')
+assert(/lowBatteryChecksReady\s*=\s*true[\s\S]*checkBattery\(\)/.test(serviceSource), 'battery enables checks on the settle timer before the first evaluation')
+assert(/function checkBattery\(\)\s*\{[\s\S]*if\s*\(\s*!lowBatteryChecksReady\s*\)\s*return/.test(serviceSource), 'battery skips low-battery warnings until settle completes')
+assert(/onOnBatteryChanged\(\)\s*\{[\s\S]*applyPowerProfile\(\)[\s\S]*checkBattery\(\)/.test(serviceSource), 'battery still applies power profiles immediately on charger changes')
 JS

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -28,4 +28,13 @@ assertDeepEqual(
   { level: 40, notify: false, notifiedLowBattery: false },
   'battery clears notified state after recovery'
 )
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, false, discharging, 10, false),
+  { level: 8, notify: false, notifiedLowBattery: false },
+  'battery does not warn while on AC even if percentage is low'
+)
+
+const serviceSource = require('fs').readFileSync(root + '/shell/plugins/services/battery/Service.qml', 'utf8')
+assert(/triggeredOnStart:\s*false/.test(serviceSource), 'battery defers the first low-battery check past shell start')
+assert(/interval:\s*5000[\s\S]*onTriggered:\s*root\.checkBattery\(\)/.test(serviceSource), 'battery runs a delayed first low-battery check')
 JS

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -39,5 +39,6 @@ assert(/triggeredOnStart:\s*false/.test(serviceSource), 'battery defers the firs
 assert(/lowBatteryChecksReady:\s*false/.test(serviceSource), 'battery gates low-battery checks until UPower settles')
 assert(/lowBatteryChecksReady\s*=\s*true[\s\S]*checkBattery\(\)/.test(serviceSource), 'battery enables checks on the settle timer before the first evaluation')
 assert(/function checkBattery\(\)\s*\{[\s\S]*if\s*\(\s*!lowBatteryChecksReady\s*\)\s*return/.test(serviceSource), 'battery skips low-battery warnings until settle completes')
-assert(/onOnBatteryChanged\(\)\s*\{[\s\S]*applyPowerProfile\(\)[\s\S]*checkBattery\(\)/.test(serviceSource), 'battery still applies power profiles immediately on charger changes')
+assert(/powerSaverOnBattery:\s*UPower\.onBattery\s*&&\s*activePowerProfile\s*===\s*"power-saver"/.test(serviceSource), 'battery keeps power-saver tracking for wallpaper and lock consumers')
+assert(/onOnBatteryChanged\(\)\s*\{[\s\S]*applyPowerProfile\(\)[\s\S]*refreshPowerProfile\(\)[\s\S]*checkBattery\(\)/.test(serviceSource), 'battery applies profiles immediately, refreshes tracked profile, then checks battery on charger changes')
 JS


### PR DESCRIPTION
## Summary
- After a battery-empty suspend, boot while plugged in could still show \"Time to recharge!\" because the battery service checked immediately on shell start before UPower reported AC (#7679).
- Stop `triggeredOnStart` on the 30s timer and run the first check after a 5s delay; plug/unplug still checks immediately via `onOnBatteryChanged`.

## Test plan
- [x] `bash test/shell.d/battery-test.sh`

Fixes #7679

Made with [Cursor](https://cursor.com)