### PR TITLE
Enable speakers on pre-T2 MacBooks with the Cirrus CS8409 bridge

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -35,6 +35,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-cs8409-audio.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-cs8409-audio.sh
+++ b/install/hardware/apple/fix-cs8409-audio.sh
@@ -1,0 +1,24 @@
+# The 2016-2017 MacBook Pros drive their speakers through a Cirrus CS8409 HDA
+# bridge paired with a CS42L83 codec and external amplifiers switched on over
+# GPIO/I2C. The in-tree snd_hda_codec_cs8409 driver binds the codec but never
+# enables those lines, so the card enumerates and PipeWire reports a healthy
+# analog-stereo sink sitting on analog-output-speaker while nothing comes out.
+# The tell is /proc/asound/card0/codec#0 reporting "GPIO: io=8" with every IO[n]
+# at enable=0, and amixer exposing only a PCM control with no Speaker or
+# Headphone jacks.
+#
+# snd-hda-macbookpro-dkms-git replaces the in-tree module with a build that
+# programs the amplifiers and brings up the CS42L83. T2 Macs take a different
+# audio path and are handled by fix-t2.sh; every model matched here predates it.
+#
+# linux-headers is installed alongside the driver deliberately. Arch's DKMS
+# pacman hook discovers kernels by globbing usr/lib/modules/*/build, so with no
+# headers installed it finds nothing to build against, builds nothing and exits
+# quietly. That leaves an installed package, an empty `dkms status` and silent
+# speakers, which reads like the driver not supporting the model.
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+if [[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123] ]]; then
+  echo "Detected MacBook with Cirrus CS8409 audio"
+
+  omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms-git
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -72,5 +72,8 @@ linux-t2
 linux-t2-headers
 t2fanrd
 
+# Pre-T2 MacBook audio (Cirrus CS8409 bridge)
+snd-hda-macbookpro-dkms-git
+
 # Framework 16
 qmk-hid


### PR DESCRIPTION
Pre-T2 MacBooks built around the Cirrus CS8409 HDA bridge boot Omarchy with
completely silent speakers. The card enumerates, PipeWire shows a healthy
`analog-stereo` sink sitting on `analog-output-speaker`, nothing is muted — and
no sound comes out, which makes it look like a PipeWire routing problem rather
than a driver one.

The cause is that these machines switch their speaker amplifiers on over
GPIO/I2C, and the in-tree `snd_hda_codec_cs8409` driver binds the codec without
ever enabling those lines. On a MacBookPro14,2 (subsystem `0x106b3600`):

```
# in-tree driver — /proc/asound/card0/codec#0
GPIO: io=8
  IO[0]: enable=0, dir=0, wake=0, sticky=0, data=0, unsol=0
  ...all eight at enable=0

$ amixer -c 0 scontrols
  -> only 'PCM' and mic controls; no Speaker or Headphone jacks at all
```

`snd-hda-macbookpro-dkms-git` replaces the module with a build that programs the
amps and brings up the CS42L83. Same machine afterwards:

```
GPIO: io=8
  IO[0]: enable=1, dir=0, wake=1, sticky=0, data=1, unsol=1
  IO[1]: enable=1, dir=1, wake=0, sticky=0, data=1, unsol=0
  IO[2]: enable=1 ... IO[3]: enable=1

$ aplay -l
  -> device 0: CS8409/CS42L83 Analog     (was "CS8409 Analog")

$ amixer -c 0 controls
  -> 'Speaker Front Phantom Jack', 'Speaker Surround Phantom Jack', 'Headphone Jack'
```

T2 Macs already get their audio through `apple-t2-audio-config` in `fix-t2.sh`.
This is the pre-T2 sibling of that fix, and every model the regex matches
predates the T2, so the two can't collide.

### On installing `linux-headers` explicitly

This is the part I'd most like a second opinion on, because it's the reason the
bug is so easy to misdiagnose. Arch's DKMS pacman hook discovers kernels by
globbing `usr/lib/modules/*/build` (`all_kver()` in
`/usr/share/libalpm/scripts/dkms`). With no headers installed that glob matches
nothing, so the hook iterates zero kernels, builds nothing, and exits 0. The end
state is an installed package, an empty `dkms status`, and silent speakers —
with no error anywhere in the pacman output.

`linux-headers` is already in `omarchy-other.packages`, but that only guarantees
ISO availability, not that it's installed on the target. Since the hook is
`PostTransaction` and also triggers on `usr/lib/modules/*/build/include/`,
installing both in the same `omarchy-pkg-add` call is race-free.

### Packaging note

`snd-hda-macbookpro-dkms-git` is AUR-only today. I've added it to
`omarchy-other.packages` on the assumption it should be built into the
`[omarchy]` repo the same way `macbook12-spi-driver-dkms` was, since no script
under `install/` uses the AUR helper and `omarchy-pkg-add` goes through pacman.

That half needs you: it presumably requires a matching PKGBUILD in the
`omarchy-pkgs` repo, which isn't public, so this PR can't carry it. **Until the
package exists in `[omarchy]`, `omarchy-pkg-add` will fail on it** — so this
should probably land alongside (or after) that packaging change rather than
before it. Happy to restructure if you'd rather do the promotion separately, or
if you'd prefer the script call the AUR helper instead.

### Testing

- Verified on a MacBookPro14,2 (2017 13" Touch Bar, i5-7267U) on kernel 7.1.8:
  speakers and headphones both working after the driver builds and the machine
  reboots. The driver compiled clean against kernel 7.1.8 with gcc 16 with no
  patching.
- Confirmed the detection matches this machine and that `dkms status` reports
  `installed` afterwards.
- `./test/all`: 202 of 205 test files pass. The three failures are
  `config-test.sh`, `snapper-test.sh` and `unowned-system-paths-test.sh`, all
  reporting a missing `omarchy-pkgs` checkout ("not ok - omarchy-pkgs checkout
  found for PKGBUILD coverage" and equivalents). I verified they fail
  identically on clean `quattro` without this change, so they're environmental
  rather than caused by it — but I can't run those three properly, so they're
  worth a look on your side given this PR touches `omarchy-other.packages`.

### Scope

Limited to `MacBookPro13,x` / `MacBookPro14,x`, matching the regex already used
by `fix-spi-keyboard.sh`. The same driver also covers iMac18,x and iMac19,1
(subsystems `0x106b0e00`/`0f00`/`1000`), but I have no way to test those, so I
left them out rather than guess at DMI strings. Easy to extend later if someone
with the hardware confirms.
