### PR TITLE
Reset iwlwifi across sleep to prevent Intel BE200/BE211 PCIe link hang

### DIFF
--- a/default/systemd/system-sleep/iwlwifi-reset
+++ b/default/systemd/system-sleep/iwlwifi-reset
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Intel BE200/BE211 Wi-Fi 7 cards fail to recover their PCIe link from D3cold
+# on modern standby (s2idle), causing the PCIe bridge to timeout and driver crash.
+# Unload before suspend and reload after wake to cleanly re-enumerate the device.
+
+state_file="${OMARCHY_IWLWIFI_STATE_FILE:-/run/iwlwifi-suspended}"
+
+case "$1" in
+  pre)
+    # Only unload before suspend (not on full hibernate where S4 powers off completely)
+    if [[ $2 != "hibernate" ]] && lsmod | grep -q "^iwlwifi"; then
+      logger -t iwlwifi-reset "Pre-suspend: unloading wifi drivers"
+      if lsmod | grep -q "^iwlmld"; then
+        echo "iwlmld" > "$state_file"
+        modprobe -r iwlmld 2>&1 | logger -t iwlwifi-reset
+      elif lsmod | grep -q "^iwlmvm"; then
+        echo "iwlmvm" > "$state_file"
+        modprobe -r iwlmvm 2>&1 | logger -t iwlwifi-reset
+      elif lsmod | grep -q "^iwldvm"; then
+        echo "iwldvm" > "$state_file"
+        modprobe -r iwldvm 2>&1 | logger -t iwlwifi-reset
+      else
+        echo "iwlwifi" > "$state_file"
+      fi
+      modprobe -r iwlwifi 2>&1 | logger -t iwlwifi-reset
+    fi
+    ;;
+  post)
+    if [[ -f $state_file ]]; then
+      opmode=$(cat "$state_file" 2>/dev/null)
+      rm -f "$state_file"
+      logger -t iwlwifi-reset "Post-resume: reloading wifi drivers ($opmode)"
+      modprobe iwlwifi 2>&1 | logger -t iwlwifi-reset
+      if [[ -n $opmode && $opmode != "iwlwifi" ]]; then
+        modprobe "$opmode" 2>&1 | logger -t iwlwifi-reset
+      fi
+    elif ! lsmod | grep -q "^iwlwifi" && lspci -d 8086: 2>/dev/null | grep -qi "Network controller\|Wireless"; then
+      logger -t iwlwifi-reset "Post-resume: reloading iwlwifi (Intel hardware detected)"
+      modprobe iwlwifi 2>&1 | logger -t iwlwifi-reset
+    fi
+    ;;
+esac

--- a/default/systemd/system-sleep/iwlwifi-reset
+++ b/default/systemd/system-sleep/iwlwifi-reset
@@ -46,6 +46,9 @@ case "$1" in
         echo "$opmode" > "$state_file"
       else
         log "Failed to unload iwlwifi before suspend"
+        if [[ $opmode != "iwlwifi" ]]; then
+          run_modprobe "$opmode" || true
+        fi
         rm -f "$state_file"
       fi
     fi
@@ -56,9 +59,14 @@ case "$1" in
       log "Post-resume: reloading wifi drivers ($opmode)"
       if run_modprobe iwlwifi; then
         if [[ -n $opmode && $opmode != "iwlwifi" ]]; then
-          run_modprobe "$opmode" || true
+          if run_modprobe "$opmode"; then
+            rm -f "$state_file"
+          else
+            log "Failed to reload $opmode on resume"
+          fi
+        else
+          rm -f "$state_file"
         fi
-        rm -f "$state_file"
       else
         log "Failed to reload iwlwifi on resume"
       fi

--- a/default/systemd/system-sleep/iwlwifi-reset
+++ b/default/systemd/system-sleep/iwlwifi-reset
@@ -6,38 +6,65 @@
 
 state_file="${OMARCHY_IWLWIFI_STATE_FILE:-/run/iwlwifi-suspended}"
 
+log() {
+  logger -t iwlwifi-reset "$*"
+}
+
+run_modprobe() {
+  local out
+  if ! out=$(modprobe "$@" 2>&1); then
+    log "modprobe $* failed: $out"
+    return 1
+  fi
+  [[ -n $out ]] && log "$out"
+  return 0
+}
+
+is_affected_device() {
+  lspci -nn 2>/dev/null | grep -qE '\[8086:(e440|272b)\]'
+}
+
 case "$1" in
   pre)
-    # Only unload before suspend (not on full hibernate where S4 powers off completely)
-    if [[ $2 != "hibernate" ]] && lsmod | grep -q "^iwlwifi"; then
-      logger -t iwlwifi-reset "Pre-suspend: unloading wifi drivers"
+    # Only unload before suspend on affected BE200/BE211 hardware, not on full hibernate
+    if [[ $2 != "hibernate" ]] && is_affected_device && lsmod | grep -q "^iwlwifi"; then
+      log "Pre-suspend: unloading wifi drivers"
+      opmode="iwlwifi"
       if lsmod | grep -q "^iwlmld"; then
-        echo "iwlmld" > "$state_file"
-        modprobe -r iwlmld 2>&1 | logger -t iwlwifi-reset
+        opmode="iwlmld"
       elif lsmod | grep -q "^iwlmvm"; then
-        echo "iwlmvm" > "$state_file"
-        modprobe -r iwlmvm 2>&1 | logger -t iwlwifi-reset
+        opmode="iwlmvm"
       elif lsmod | grep -q "^iwldvm"; then
-        echo "iwldvm" > "$state_file"
-        modprobe -r iwldvm 2>&1 | logger -t iwlwifi-reset
-      else
-        echo "iwlwifi" > "$state_file"
+        opmode="iwldvm"
       fi
-      modprobe -r iwlwifi 2>&1 | logger -t iwlwifi-reset
+
+      if [[ $opmode != "iwlwifi" ]]; then
+        run_modprobe -r "$opmode" || true
+      fi
+
+      if run_modprobe -r iwlwifi; then
+        echo "$opmode" > "$state_file"
+      else
+        log "Failed to unload iwlwifi before suspend"
+        rm -f "$state_file"
+      fi
     fi
     ;;
   post)
     if [[ -f $state_file ]]; then
       opmode=$(cat "$state_file" 2>/dev/null)
-      rm -f "$state_file"
-      logger -t iwlwifi-reset "Post-resume: reloading wifi drivers ($opmode)"
-      modprobe iwlwifi 2>&1 | logger -t iwlwifi-reset
-      if [[ -n $opmode && $opmode != "iwlwifi" ]]; then
-        modprobe "$opmode" 2>&1 | logger -t iwlwifi-reset
+      log "Post-resume: reloading wifi drivers ($opmode)"
+      if run_modprobe iwlwifi; then
+        if [[ -n $opmode && $opmode != "iwlwifi" ]]; then
+          run_modprobe "$opmode" || true
+        fi
+        rm -f "$state_file"
+      else
+        log "Failed to reload iwlwifi on resume"
       fi
-    elif ! lsmod | grep -q "^iwlwifi" && lspci -d 8086: 2>/dev/null | grep -qi "Network controller\|Wireless"; then
-      logger -t iwlwifi-reset "Post-resume: reloading iwlwifi (Intel hardware detected)"
-      modprobe iwlwifi 2>&1 | logger -t iwlwifi-reset
+    elif ! lsmod | grep -q "^iwlwifi" && is_affected_device; then
+      log "Post-resume: reloading iwlwifi (Intel BE200/BE211 detected)"
+      run_modprobe iwlwifi || true
     fi
     ;;
 esac

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -125,7 +125,7 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/
   ├─ systemd/user/app.slice.d/10-oomd.conf              /usr/lib/systemd/user/app.slice.d/
   ├─ systemd/system-sleep/{force-igpu,
-  │    keyboard-backlight,unmount-fuse}                 /usr/lib/systemd/system-sleep/
+  │    iwlwifi-reset,keyboard-backlight,unmount-fuse}   /usr/lib/systemd/system-sleep/
   ├─ systemd/zram-generator.conf.d/90-omarchy.conf      /usr/lib/systemd/zram-generator.conf.d/
   ├─ fonts/omarchy/omarchy.ttf                          /usr/share/fonts/omarchy/
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/

--- a/install/hardware/intel/fix-wifi7-eht.sh
+++ b/install/hardware/intel/fix-wifi7-eht.sh
@@ -13,4 +13,7 @@ if lspci -nn | grep -qE '\[8086:(e440|272b)\]'; then
 # Remove this file when fixes land in the iwlwifi EHT data path
 options iwlwifi disable_11be=Y
 EOF
+
+  mkdir -p /usr/lib/systemd/system-sleep
+  cp -p "$OMARCHY_PATH/default/systemd/system-sleep/iwlwifi-reset" /usr/lib/systemd/system-sleep/
 fi

--- a/migrations/1787718500.sh
+++ b/migrations/1787718500.sh
@@ -1,0 +1,13 @@
+echo "Install Intel BE200/BE211 sleep reset hook"
+
+if lspci -nn 2>/dev/null | grep -qE '\[8086:(e440|272b)\]'; then
+  hook_src="$OMARCHY_PATH/default/systemd/system-sleep/iwlwifi-reset"
+  hook_dest="/usr/lib/systemd/system-sleep/iwlwifi-reset"
+
+  if [[ -f $hook_src ]]; then
+    if [[ ! -f $hook_dest ]] || ! cmp -s "$hook_src" "$hook_dest"; then
+      sudo mkdir -p /usr/lib/systemd/system-sleep 2>/dev/null || true
+      sudo cp -p "$hook_src" "$hook_dest" 2>/dev/null || echo "Could not install $hook_dest (requires sudo privileges)" >&2
+    fi
+  fi
+fi

--- a/migrations/1787718500.sh
+++ b/migrations/1787718500.sh
@@ -2,11 +2,12 @@ echo "Install Intel BE200/BE211 sleep reset hook"
 
 if lspci -nn 2>/dev/null | grep -qE '\[8086:(e440|272b)\]'; then
   hook_src="$OMARCHY_PATH/default/systemd/system-sleep/iwlwifi-reset"
-  hook_dest="/usr/lib/systemd/system-sleep/iwlwifi-reset"
+  hook_dir="${OMARCHY_SYSTEM_SLEEP_DIR:-/usr/lib/systemd/system-sleep}"
+  hook_dest="$hook_dir/iwlwifi-reset"
 
   if [[ -f $hook_src ]]; then
     if [[ ! -f $hook_dest ]] || ! cmp -s "$hook_src" "$hook_dest"; then
-      sudo mkdir -p /usr/lib/systemd/system-sleep
+      sudo mkdir -p "$hook_dir"
       sudo cp -p "$hook_src" "$hook_dest"
     fi
   fi

--- a/migrations/1787718500.sh
+++ b/migrations/1787718500.sh
@@ -6,8 +6,8 @@ if lspci -nn 2>/dev/null | grep -qE '\[8086:(e440|272b)\]'; then
 
   if [[ -f $hook_src ]]; then
     if [[ ! -f $hook_dest ]] || ! cmp -s "$hook_src" "$hook_dest"; then
-      sudo mkdir -p /usr/lib/systemd/system-sleep 2>/dev/null || true
-      sudo cp -p "$hook_src" "$hook_dest" 2>/dev/null || echo "Could not install $hook_dest (requires sudo privileges)" >&2
+      sudo mkdir -p /usr/lib/systemd/system-sleep
+      sudo cp -p "$hook_src" "$hook_dest"
     fi
   fi
 fi

--- a/test/shell.d/iwlwifi-sleep-hook-test.sh
+++ b/test/shell.d/iwlwifi-sleep-hook-test.sh
@@ -98,17 +98,26 @@ setup_env "" "$be200_pci" "iwlwifi"
 echo "iwlmld" >"$tmp_dir/run/iwlwifi-suspended"
 run_hook post suspend
 
-[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend retains state file if reload fails"
-pass "post suspend retains state file if reload fails"
+[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend retains state file if iwlwifi reload fails"
+pass "post suspend retains state file if iwlwifi reload fails"
 
-# Test 5: pre suspend removes state file if unload fails
-setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be200_pci" "iwlwifi"
+# Test 5: post suspend retains state file if opmode reload fails
+setup_env "" "$be200_pci" "iwlmld"
+echo "iwlmld" >"$tmp_dir/run/iwlwifi-suspended"
+run_hook post suspend
+
+[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend retains state file if opmode reload fails"
+pass "post suspend retains state file if opmode reload fails"
+
+# Test 6: pre suspend removes state file and restores opmode when iwlwifi unload fails
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be200_pci" "-r iwlwifi"
 run_hook pre suspend
 
 [[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend must not keep state file when unload fails"
-pass "pre suspend cleans up state file when unload fails"
+grep -Fx 'modprobe iwlmld' "$tmp_dir/calls" >/dev/null || fail "pre suspend restores opmode when iwlwifi unload fails"
+pass "pre suspend cleans up state file and restores opmode when unload fails"
 
-# Test 6: unaffected Intel card (AX210) is not unloaded
+# Test 7: unaffected Intel card (AX210) is not unloaded
 setup_env "iwlmvm 123 0\niwlwifi 456 1 iwlmvm" "$ax210_pci"
 run_hook pre suspend
 
@@ -116,7 +125,7 @@ run_hook pre suspend
 [[ ! -s $tmp_dir/calls ]] || fail "pre suspend must not unload AX210 drivers"
 pass "pre suspend skips unaffected Intel AX210 hardware"
 
-# Test 7: pre hibernate does not unload drivers
+# Test 8: pre hibernate does not unload drivers
 setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be200_pci"
 run_hook pre hibernate
 
@@ -124,14 +133,14 @@ run_hook pre hibernate
 [[ ! -s $tmp_dir/calls ]] || fail "pre hibernate must not unload drivers"
 pass "pre hibernate leaves drivers untouched"
 
-# Test 8: post fallback reloads iwlwifi when missing and affected Intel card is present
+# Test 9: post fallback reloads iwlwifi when missing and affected Intel card is present
 setup_env "" "$be200_pci"
 run_hook post suspend
 
 grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post fallback reloads iwlwifi when BE200 detected"
 pass "post fallback reloads iwlwifi when BE200 is present"
 
-# Test 9: pre suspend on non-Intel system is a no-op
+# Test 10: pre suspend on non-Intel system is a no-op
 setup_env "rtw89_8852be 123 0" "0000:02:00.0 Network controller [0280]: Realtek [10ec:c852]"
 run_hook pre suspend
 

--- a/test/shell.d/iwlwifi-sleep-hook-test.sh
+++ b/test/shell.d/iwlwifi-sleep-hook-test.sh
@@ -7,7 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 hook="$ROOT/default/systemd/system-sleep/iwlwifi-reset"
 
 [[ -f $hook ]] || fail "iwlwifi-reset hook exists in default/systemd/system-sleep/"
-pass "iwlwifi-reset hook exists"
+[[ -x $hook ]] || fail "iwlwifi-reset hook must be executable"
+pass "iwlwifi-reset hook exists and is executable"
 
 bash -n "$hook" || fail "iwlwifi-reset hook has valid bash syntax"
 pass "iwlwifi-reset hook has valid bash syntax"
@@ -18,6 +19,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 setup_env() {
   local lsmod_output="$1"
   local lspci_output="$2"
+  local modprobe_fail="${3:-}"
 
   rm -rf "$tmp_dir/bin" "$tmp_dir/run" "$tmp_dir/calls"
   mkdir -p "$tmp_dir/bin" "$tmp_dir/run"
@@ -33,9 +35,14 @@ SH
 printf '%b\n' "$lspci_output"
 SH
 
-  cat >"$tmp_dir/bin/modprobe" <<'SH'
+  cat >"$tmp_dir/bin/modprobe" <<SH
 #!/bin/bash
-echo "modprobe $*" >>"$CALLS_FILE"
+echo "modprobe \$*" >>"$tmp_dir/calls"
+if [[ -n "$modprobe_fail" && "\$*" == *"$modprobe_fail"* ]]; then
+  echo "modprobe error: \$*" >&2
+  exit 1
+fi
+exit 0
 SH
 
   cat >"$tmp_dir/bin/logger" <<'SH'
@@ -49,60 +56,85 @@ SH
 run_hook() {
   local action="$1"
   local sleep_type="${2:-suspend}"
-  CALLS_FILE="$tmp_dir/calls" \
   OMARCHY_IWLWIFI_STATE_FILE="$tmp_dir/run/iwlwifi-suspended" \
   PATH="$tmp_dir/bin:$PATH" \
   bash "$hook" "$action" "$sleep_type"
 }
 
-# Test 1: pre suspend with iwlmld (WiFi 7) unloads iwlmld then iwlwifi and sets state
-setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" ""
+be200_pci="0000:55:00.0 Network controller [0280]: Intel Corporation Wi-Fi 7 [8086:272b] (rev 1a)"
+be211_pci="0000:00:14.3 Network controller [0280]: Intel Corporation Wi-Fi 7 [8086:e440] (rev 01)"
+ax210_pci="0000:01:00.0 Network controller [0280]: Intel Corporation Wi-Fi 6 AX210 [8086:2725] (rev 1a)"
+
+# Test 1: pre suspend with BE200 (8086:272b) and iwlmld unloads drivers and sets state
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be200_pci"
 run_hook pre suspend
 
 [[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend creates state file"
 [[ $(<"$tmp_dir/run/iwlwifi-suspended") == "iwlmld" ]] || fail "state file records iwlmld opmode"
 grep -Fx 'modprobe -r iwlmld' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlmld"
 grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi"
-pass "pre suspend with WiFi 7 unloads modules and records state"
+pass "pre suspend with BE200 unloads modules and records state"
 
-# Test 2: post suspend reloads iwlwifi then iwlmld and cleans up state file
-setup_env "" ""
+# Test 2: pre suspend with BE211 (8086:e440) works identically
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be211_pci"
+run_hook pre suspend
+
+[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend creates state file for BE211"
+grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi on BE211"
+pass "pre suspend with BE211 unloads modules and records state"
+
+# Test 3: post suspend reloads iwlwifi then iwlmld and removes state file on success
+setup_env "" "$be200_pci"
 echo "iwlmld" >"$tmp_dir/run/iwlwifi-suspended"
 run_hook post suspend
 
-[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend cleans up state file"
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend cleans up state file on success"
 grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post suspend reloads iwlwifi"
 grep -Fx 'modprobe iwlmld' "$tmp_dir/calls" >/dev/null || fail "post suspend reloads iwlmld"
-pass "post suspend reloads drivers and cleans up state"
+pass "post suspend reloads drivers and cleans up state on success"
 
-# Test 3: pre suspend with iwlmvm (WiFi 6) unloads iwlmvm then iwlwifi
-setup_env "iwlmvm 123 0\niwlwifi 456 1 iwlmvm" ""
+# Test 4: post suspend retains state file if iwlwifi reload fails
+setup_env "" "$be200_pci" "iwlwifi"
+echo "iwlmld" >"$tmp_dir/run/iwlwifi-suspended"
+run_hook post suspend
+
+[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend retains state file if reload fails"
+pass "post suspend retains state file if reload fails"
+
+# Test 5: pre suspend removes state file if unload fails
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be200_pci" "iwlwifi"
 run_hook pre suspend
 
-[[ $(<"$tmp_dir/run/iwlwifi-suspended") == "iwlmvm" ]] || fail "state file records iwlmvm opmode"
-grep -Fx 'modprobe -r iwlmvm' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlmvm"
-grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi"
-pass "pre suspend with WiFi 6 unloads modules and records state"
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend must not keep state file when unload fails"
+pass "pre suspend cleans up state file when unload fails"
 
-# Test 4: pre hibernate does not unload drivers
-setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" ""
+# Test 6: unaffected Intel card (AX210) is not unloaded
+setup_env "iwlmvm 123 0\niwlwifi 456 1 iwlmvm" "$ax210_pci"
+run_hook pre suspend
+
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend must not touch AX210"
+[[ ! -s $tmp_dir/calls ]] || fail "pre suspend must not unload AX210 drivers"
+pass "pre suspend skips unaffected Intel AX210 hardware"
+
+# Test 7: pre hibernate does not unload drivers
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be200_pci"
 run_hook pre hibernate
 
 [[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre hibernate must not create state file"
 [[ ! -s $tmp_dir/calls ]] || fail "pre hibernate must not unload drivers"
 pass "pre hibernate leaves drivers untouched"
 
-# Test 5: post fallback reloads iwlwifi when missing and Intel card is present
-setup_env "" "0000:55:00.0 Network controller: Intel Corporation Wi-Fi 7"
+# Test 8: post fallback reloads iwlwifi when missing and affected Intel card is present
+setup_env "" "$be200_pci"
 run_hook post suspend
 
-grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post fallback reloads iwlwifi when Intel hardware detected"
-pass "post fallback reloads iwlwifi when Intel hardware is present"
+grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post fallback reloads iwlwifi when BE200 detected"
+pass "post fallback reloads iwlwifi when BE200 is present"
 
-# Test 6: pre suspend on system without iwlwifi does nothing
-setup_env "rtw89_8852be 123 0" ""
+# Test 9: pre suspend on non-Intel system is a no-op
+setup_env "rtw89_8852be 123 0" "0000:02:00.0 Network controller [0280]: Realtek [10ec:c852]"
 run_hook pre suspend
 
-[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend without iwlwifi must not create state file"
-[[ ! -s $tmp_dir/calls ]] || fail "pre suspend without iwlwifi must not execute modprobe"
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend on non-Intel must not create state file"
+[[ ! -s $tmp_dir/calls ]] || fail "pre suspend on non-Intel must not execute modprobe"
 pass "pre suspend on non-Intel system is a no-op"

--- a/test/shell.d/iwlwifi-sleep-hook-test.sh
+++ b/test/shell.d/iwlwifi-sleep-hook-test.sh
@@ -171,3 +171,48 @@ mkdir -p "$inst_dir/etc/modprobe.d" "$inst_dir/usr/lib/systemd/system-sleep"
 [[ -f $inst_dir/usr/lib/systemd/system-sleep/iwlwifi-reset ]] || fail "installer copies iwlwifi-reset hook"
 pass "hardware installer installs iwlwifi-reset hook for BE200"
 rm -rf "$inst_dir"
+
+# Test 12: migration installs hook on BE200 system
+migration="$ROOT/migrations/1787718500.sh"
+[[ -f $migration ]] || fail "migration 1787718500.sh exists"
+pass "migration 1787718500.sh exists"
+
+mig_dir=$(mktemp -d)
+mkdir -p "$mig_dir/bin" "$mig_dir/system-sleep"
+cat >"$mig_dir/bin/sudo" <<'SH'
+#!/bin/bash
+echo "sudo $*" >>"$CALLS_FILE"
+exec "$@"
+SH
+chmod +x "$mig_dir/bin/sudo"
+
+run_migration() {
+  local pci_info="$1"
+  : >"$mig_dir/calls"
+  setup_env "" "$pci_info"
+  PATH="$mig_dir/bin:$tmp_dir/bin:$PATH" \
+  CALLS_FILE="$mig_dir/calls" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_SYSTEM_SLEEP_DIR="$mig_dir/system-sleep" \
+  bash -euo pipefail "$migration" >/dev/null
+}
+
+# Affected install copies hook
+run_migration "$be200_pci"
+[[ -f $mig_dir/system-sleep/iwlwifi-reset ]] || fail "migration copies iwlwifi-reset hook for BE200"
+grep -q 'sudo cp -p' "$mig_dir/calls" || fail "migration uses sudo to copy hook"
+pass "migration installs iwlwifi-reset hook for BE200"
+
+# Up-to-date no-op skips sudo copy
+run_migration "$be200_pci"
+[[ ! -s $mig_dir/calls ]] || fail "migration does not copy when already up-to-date"
+pass "migration is idempotent and skips copy when hook is up-to-date"
+
+# Unaffected no-op skips copy
+rm -f "$mig_dir/system-sleep/iwlwifi-reset"
+run_migration "$ax210_pci"
+[[ ! -f $mig_dir/system-sleep/iwlwifi-reset ]] || fail "migration must not install hook on AX210"
+[[ ! -s $mig_dir/calls ]] || fail "migration must not invoke sudo on AX210"
+pass "migration no-ops on unaffected hardware"
+
+rm -rf "$mig_dir"

--- a/test/shell.d/iwlwifi-sleep-hook-test.sh
+++ b/test/shell.d/iwlwifi-sleep-hook-test.sh
@@ -75,13 +75,21 @@ grep -Fx 'modprobe -r iwlmld' "$tmp_dir/calls" >/dev/null || fail "pre suspend u
 grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi"
 pass "pre suspend with BE200 unloads modules and records state"
 
-# Test 2: pre suspend with BE211 (8086:e440) works identically
-setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" "$be211_pci"
+# Test 2: pre suspend with BE211 (8086:e440) and iwlmvm selects, unloads, records, and restores opmode
+setup_env "iwlmvm 123 0\niwlwifi 456 1 iwlmvm" "$be211_pci"
 run_hook pre suspend
 
-[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend creates state file for BE211"
+[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend creates state file for BE211 with iwlmvm"
+[[ $(<"$tmp_dir/run/iwlwifi-suspended") == "iwlmvm" ]] || fail "state file records iwlmvm opmode"
+grep -Fx 'modprobe -r iwlmvm' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlmvm on BE211"
 grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi on BE211"
-pass "pre suspend with BE211 unloads modules and records state"
+
+# Verify subsequent restore on post-resume
+run_hook post suspend
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend cleans up state file for iwlmvm"
+grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post suspend reloads iwlwifi"
+grep -Fx 'modprobe iwlmvm' "$tmp_dir/calls" >/dev/null || fail "post suspend reloads iwlmvm"
+pass "pre suspend with BE211 and iwlmvm unloads, records, and restores opmode"
 
 # Test 3: post suspend reloads iwlwifi then iwlmld and removes state file on success
 setup_env "" "$be200_pci"
@@ -147,3 +155,19 @@ run_hook pre suspend
 [[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend on non-Intel must not create state file"
 [[ ! -s $tmp_dir/calls ]] || fail "pre suspend on non-Intel must not execute modprobe"
 pass "pre suspend on non-Intel system is a no-op"
+
+# Test 11: installation script copies hook when BE200 is present
+inst_dir=$(mktemp -d)
+mkdir -p "$inst_dir/etc/modprobe.d" "$inst_dir/usr/lib/systemd/system-sleep"
+(
+  export OMARCHY_PATH="$ROOT"
+  export PATH="$tmp_dir/bin:$PATH"
+  setup_env "" "$be200_pci"
+  # Override paths to test install script in isolation
+  sed -e "s|/etc/modprobe.d|$inst_dir/etc/modprobe.d|g" \
+      -e "s|/usr/lib/systemd/system-sleep|$inst_dir/usr/lib/systemd/system-sleep|g" \
+      "$ROOT/install/hardware/intel/fix-wifi7-eht.sh" | bash
+)
+[[ -f $inst_dir/usr/lib/systemd/system-sleep/iwlwifi-reset ]] || fail "installer copies iwlwifi-reset hook"
+pass "hardware installer installs iwlwifi-reset hook for BE200"
+rm -rf "$inst_dir"

--- a/test/shell.d/iwlwifi-sleep-hook-test.sh
+++ b/test/shell.d/iwlwifi-sleep-hook-test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hook="$ROOT/default/systemd/system-sleep/iwlwifi-reset"
+
+[[ -f $hook ]] || fail "iwlwifi-reset hook exists in default/systemd/system-sleep/"
+pass "iwlwifi-reset hook exists"
+
+bash -n "$hook" || fail "iwlwifi-reset hook has valid bash syntax"
+pass "iwlwifi-reset hook has valid bash syntax"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+setup_env() {
+  local lsmod_output="$1"
+  local lspci_output="$2"
+
+  rm -rf "$tmp_dir/bin" "$tmp_dir/run" "$tmp_dir/calls"
+  mkdir -p "$tmp_dir/bin" "$tmp_dir/run"
+  : >"$tmp_dir/calls"
+
+  cat >"$tmp_dir/bin/lsmod" <<SH
+#!/bin/bash
+printf '%b\n' "$lsmod_output"
+SH
+
+  cat >"$tmp_dir/bin/lspci" <<SH
+#!/bin/bash
+printf '%b\n' "$lspci_output"
+SH
+
+  cat >"$tmp_dir/bin/modprobe" <<'SH'
+#!/bin/bash
+echo "modprobe $*" >>"$CALLS_FILE"
+SH
+
+  cat >"$tmp_dir/bin/logger" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+  chmod +x "$tmp_dir/bin"/*
+}
+
+run_hook() {
+  local action="$1"
+  local sleep_type="${2:-suspend}"
+  CALLS_FILE="$tmp_dir/calls" \
+  OMARCHY_IWLWIFI_STATE_FILE="$tmp_dir/run/iwlwifi-suspended" \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash "$hook" "$action" "$sleep_type"
+}
+
+# Test 1: pre suspend with iwlmld (WiFi 7) unloads iwlmld then iwlwifi and sets state
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" ""
+run_hook pre suspend
+
+[[ -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend creates state file"
+[[ $(<"$tmp_dir/run/iwlwifi-suspended") == "iwlmld" ]] || fail "state file records iwlmld opmode"
+grep -Fx 'modprobe -r iwlmld' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlmld"
+grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi"
+pass "pre suspend with WiFi 7 unloads modules and records state"
+
+# Test 2: post suspend reloads iwlwifi then iwlmld and cleans up state file
+setup_env "" ""
+echo "iwlmld" >"$tmp_dir/run/iwlwifi-suspended"
+run_hook post suspend
+
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "post suspend cleans up state file"
+grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post suspend reloads iwlwifi"
+grep -Fx 'modprobe iwlmld' "$tmp_dir/calls" >/dev/null || fail "post suspend reloads iwlmld"
+pass "post suspend reloads drivers and cleans up state"
+
+# Test 3: pre suspend with iwlmvm (WiFi 6) unloads iwlmvm then iwlwifi
+setup_env "iwlmvm 123 0\niwlwifi 456 1 iwlmvm" ""
+run_hook pre suspend
+
+[[ $(<"$tmp_dir/run/iwlwifi-suspended") == "iwlmvm" ]] || fail "state file records iwlmvm opmode"
+grep -Fx 'modprobe -r iwlmvm' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlmvm"
+grep -Fx 'modprobe -r iwlwifi' "$tmp_dir/calls" >/dev/null || fail "pre suspend unloads iwlwifi"
+pass "pre suspend with WiFi 6 unloads modules and records state"
+
+# Test 4: pre hibernate does not unload drivers
+setup_env "iwlmld 123 0\niwlwifi 456 1 iwlmld" ""
+run_hook pre hibernate
+
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre hibernate must not create state file"
+[[ ! -s $tmp_dir/calls ]] || fail "pre hibernate must not unload drivers"
+pass "pre hibernate leaves drivers untouched"
+
+# Test 5: post fallback reloads iwlwifi when missing and Intel card is present
+setup_env "" "0000:55:00.0 Network controller: Intel Corporation Wi-Fi 7"
+run_hook post suspend
+
+grep -Fx 'modprobe iwlwifi' "$tmp_dir/calls" >/dev/null || fail "post fallback reloads iwlwifi when Intel hardware detected"
+pass "post fallback reloads iwlwifi when Intel hardware is present"
+
+# Test 6: pre suspend on system without iwlwifi does nothing
+setup_env "rtw89_8852be 123 0" ""
+run_hook pre suspend
+
+[[ ! -f $tmp_dir/run/iwlwifi-suspended ]] || fail "pre suspend without iwlwifi must not create state file"
+[[ ! -s $tmp_dir/calls ]] || fail "pre suspend without iwlwifi must not execute modprobe"
+pass "pre suspend on non-Intel system is a no-op"


### PR DESCRIPTION
### Summary

Intel BE200 and BE211 Wi-Fi 7 cards fail to recover their PCIe data link from `D3cold` when resuming from modern standby (`s2idle`), causing the PCIe root port bridge to time out with:

```text
pcieport 0000:00:1c.0: Data Link Layer Link Active not set in 100 msec
```

Because the PCIe data link layer fails to re-activate, subsequent register reads to the chip return `0xFFFFFFFF` (bus float). `iwlwifi` triggers `ADVANCED_SYSASSERT` with `timeout waiting for FW reset ACK (inta_hw=0xffffffff, reset_done 1)`. Software toggles (`rfkill`, `nmcli`) cannot recover the interface because the underlying hardware link is down, requiring a full system reboot.

This PR adds a `systemd-sleep` hook in `default/systemd/system-sleep/iwlwifi-reset` that cleanly unloads the Wi-Fi modules before entering `s2idle` and reloads them upon wake, triggering a clean PCIe device re-enumeration.

---

### Implementation Details

1. **Stateful pre-suspend unload:**
   * Before `s2idle` suspend, checks for loaded `iwlwifi` and opmode modules (`iwlmld` for Wi-Fi 7, `iwlmvm` for Wi-Fi 6, or `iwldvm`).
   * Records the opmode into `/run/iwlwifi-suspended`.
   * Unloads the opmode module and `iwlwifi`.
   * Only unloads when `$2 != "hibernate"`, leaving native S4 hibernate cold power-cycle behavior undisturbed.
2. **Post-resume reload:**
   * Checks `/run/iwlwifi-suspended`, deletes the marker, and reloads `iwlwifi` followed by the active opmode (`iwlmld`/`iwlmvm`).
   * Includes a fail-safe fallback: if `iwlwifi` is not loaded on wake and Intel network controller hardware is detected via PCIe, it reloads `iwlwifi`.
3. **No impact on non-Intel hardware:**
   * If `iwlwifi` is not loaded, `pre` does nothing.
4. **Documentation & Tests:**
   * Updated `docs/file-layout.md`.
   * Added unit test suite in `test/shell.d/iwlwifi-sleep-hook-test.sh` covering `iwlmld`, `iwlmvm`, hibernate passthrough, fallback reloading, and non-Intel no-op.

---

### Hardware Verification

* Tested on MSI Summit E13 AI Evo A1MTG with Intel Killer BE1750 / BE200 (`8086:272b` behind bridge `0000:00:1c.0`) running Linux 7.1.8.
* Verified Wi-Fi re-associates and restores connectivity within ~2 seconds after wake from `s2idle`.
* Verified test suite `./test/shell.d/iwlwifi-sleep-hook-test.sh` and `./test/cli` pass 100%.