### PR TITLE
Register the Chromium native messaging hosts for Brave Origin

### DIFF
--- a/bin/omarchy-install-chromium-copy-url
+++ b/bin/omarchy-install-chromium-copy-url
@@ -16,6 +16,9 @@ browser_dirs=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  # Brave Origin is a separate browser, not a Brave channel: its own package,
+  # binary, flags conf and profile root.
+  "$HOME/.config/BraveSoftware/Brave-Origin"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-dev"
 )

--- a/bin/omarchy-install-chromium-ytdlp
+++ b/bin/omarchy-install-chromium-ytdlp
@@ -17,6 +17,9 @@ browser_dirs=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  # Brave Origin is a separate browser, not a Brave channel: its own package,
+  # binary, flags conf and profile root.
+  "$HOME/.config/BraveSoftware/Brave-Origin"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-dev"
 )

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,8 @@
+echo "Register the Chromium native messaging hosts for Brave Origin"
+
+# Brave Origin's profile root was missing from the host installers, so its
+# NativeMessagingHosts directory was never written and Copy URL and Download
+# Video did nothing there. Both installers are idempotent, so re-running them
+# registers the hosts for Brave Origin and leaves every other profile as is.
+omarchy-install-chromium-copy-url
+omarchy-install-chromium-ytdlp

--- a/test/shell.d/chromium-copy-url-test.sh
+++ b/test/shell.d/chromium-copy-url-test.sh
@@ -71,6 +71,12 @@ jq -e --arg path "$ROOT/bin/omarchy-chromium-copy-url-host" '
 ' "$native_manifest" >/dev/null || fail "copy-url native host manifest uses Omarchy host path and extension id"
 pass "copy-url native host installer registers the stable extension id"
 
+# Brave Origin is a separate browser with its own profile root, and
+# omarchy-install-browser installs it, so the host has to reach it too.
+[[ -f $test_home/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/com.omarchy.copy_url.json ]] ||
+  fail "copy-url native host installer registers Brave Origin"
+pass "copy-url native host installer registers Brave Origin"
+
 # Chromium ships in the base packages, so fresh installs do not go through
 # omarchy-install-browser, and they mark every migration as already applied.
 # The user install still has to register the host itself.

--- a/test/shell.d/chromium-ytdlp-test.sh
+++ b/test/shell.d/chromium-ytdlp-test.sh
@@ -33,6 +33,12 @@ jq -e --arg path "$ROOT/bin/omarchy-chromium-ytdlp-host" '
 ' "$manifest_path" >/dev/null
 pass "yt-dlp native host manifest uses Omarchy host path and extension id"
 
+# Brave Origin is a separate browser with its own profile root, and
+# omarchy-install-browser installs it, so the host has to reach it too.
+[[ -f $test_home/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/com.omarchy.ytdlp.json ]] ||
+  fail "yt-dlp native host installer registers Brave Origin"
+pass "yt-dlp native host installer registers Brave Origin"
+
 parse_result=$(bash -c '
   OMARCHY_PATH="$3"
   source "$1"


### PR DESCRIPTION
Brave Origin is a separate browser rather than a Brave channel — its own package, binary, flags conf and profile root. Omarchy knows that everywhere except the two native messaging host installers, whose profile list stops at `Brave-Browser-Nightly`.

So `omarchy install browser brave-origin` registers the hosts for every Chromium-family profile *except* the browser it just installed — `copy_chromium_flags` calls both installers, but neither writes to `~/.config/BraveSoftware/Brave-Origin`. The extensions load fine, so Copy URL and Download Video look installed; Alt+Shift+L and Alt+Shift+D just reach no host and do nothing. It's exactly the failure `install/user/chromium.sh`'s own comment warns about.

On my machine, after installing Brave Origin through the menu:

```
~/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/   (empty)
~/.config/chromium/NativeMessagingHosts/                     com.omarchy.copy_url.json, com.omarchy.ytdlp.json
```

This adds Brave Origin's profile root to both installers and re-runs them from a migration so existing installs get repaired. Only the stable channel is listed, since that's the one channel `omarchy-install-browser` installs — beta/nightly can follow the `Brave-Browser` convention if they're ever supported.

Both chromium host tests now assert the Brave Origin manifest is written, and both fail without the installer change. Full `test/shell` run: 203/206 files pass, with the same 3 unrelated failures (`locale-env`, `snapper`, `theme-install-guards`) before and after — they fail on a pristine `quattro` checkout here too.

One thing I left alone: `migrations/1786643346.sh` carries a third, longer copy of the profile list (it adds Edge Beta, Vivaldi, Opera, Helium) and is also missing Brave Origin. Since it's already been run and marked applied for most people, editing it seemed worse than leaving it — happy to fold it in if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)