### PR TITLE
Launch Opera webapps as a tab URL instead of --app=

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -10,4 +10,12 @@ google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1)
+
+# Opera is Chromium-based but ignores --app= and opens the start page instead.
+# A positional URL opens a tab in the existing window, or starts Opera with that tab.
+if [[ $browser == opera* ]]; then
+  exec setsid uwsm-app -- "$browser_exec" "$1" "${@:2}"
+else
+  exec setsid uwsm-app -- "$browser_exec" --app="$1" "${@:2}"
+fi

--- a/test/shell.d/launch-webapp-test.sh
+++ b/test/shell.d/launch-webapp-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications"
+
+cat >"$test_home/.local/share/applications/opera.desktop" <<'EOF'
+[Desktop Entry]
+Exec=opera %U
+EOF
+
+cat >"$test_home/.local/share/applications/chromium.desktop" <<'EOF'
+[Desktop Entry]
+Exec=chromium %U
+EOF
+
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+echo "${OMARCHY_TEST_BROWSER:-chromium.desktop}"
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH"
+SH
+
+chmod +x "$mock_bin"/*
+
+launch_webapp() {
+  HOME="$test_home" PATH="$mock_bin:$PATH" \
+    OMARCHY_TEST_BROWSER="$1" OMARCHY_TEST_LAUNCH="$test_tmp/launch" \
+    bash "$ROOT/bin/omarchy-launch-webapp" "$2"
+}
+
+launch_webapp opera.desktop "https://chatgpt.com"
+[[ $(<"$test_tmp/launch") == "-- opera https://chatgpt.com" ]] ||
+  fail "Opera webapps launch as a tab URL" "$(<"$test_tmp/launch")"
+pass "Opera webapps launch as a tab URL"
+
+launch_webapp chromium.desktop "https://chatgpt.com"
+[[ $(<"$test_tmp/launch") == "-- chromium --app=https://chatgpt.com" ]] ||
+  fail "Chromium webapps still use --app=" "$(<"$test_tmp/launch")"
+pass "Chromium webapps still use --app="


### PR DESCRIPTION
Closes #8298

## Problem

`omarchy-launch-webapp` treats Opera as a Chromium-family browser that supports `--app=`. Opera ignores that switch and opens the start page / restored tabs instead of the requested URL. Stock binds like Super+Shift+A (ChatGPT), Super+Shift+Alt+A (Grok), and Super+Shift+X therefore do nothing useful when Opera is the default browser.

Observed process: `/usr/lib/opera-stable/opera --app=https://grok.com` while the window showed Opera's start page.

This is distinct from #7034 (Firefox is not on the whitelist at all). Opera *is* on the whitelist, so the launch succeeds and silently drops the URL.

## Fix

Keep `opera*` on the supported-browser list so we do not fall back to `chromium.desktop`. When the default is Opera, pass the URL as a positional argument:

```
opera https://chatgpt.com
```

That opens a tab in the existing window, or starts Opera with that tab. Chromium-family browsers that honor `--app=` are unchanged.

## Testing

- `test/shell.d/launch-webapp-test.sh` — Opera gets a positional URL; Chromium still gets `--app=`
- `./test/cli` passed
- `./test/shell` ran 207 files; the new test passed. Five unrelated files failed in this environment (`omarchy-pkgs` checkout missing, about-window animation, theme-install URL check)
- Manual: Super+Shift+A / Grok / X open the matching site as a tab in one Opera window