### PR TITLE
Fix monitor scaling on per-output rules, and three defects the other fixes share

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -71,10 +71,17 @@ normalize_scale() {
   awk 'NR == 1 { printf "%g\n", $0 }'
 }
 
-# Persisting GDK_SCALE happens from three places below.
+# GDK_SCALE is one integer for the whole session, so it can only follow a
+# monitor scale when there is a single monitor to follow. With several outputs
+# enabled, rewriting it here resizes XWayland windows on the displays the user
+# did not touch.
 persist_gdk_scale() {
   local gdk_scale="$1"
   local file="$2"
+  local enabled
+
+  enabled="$(hyprctl monitors -j | jq '[.[] | select(.disabled != true)] | length')"
+  [[ $enabled == 1 ]] || return 0
 
   sed -i -E \
     -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${gdk_scale}|" \

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -144,8 +144,13 @@ update_named_monitor_scale() {
       if (value == monitor) return 1
       # Compared literally rather than as a pattern: a description is EDID free
       # text and routinely carries . ( and +.
-      if (substr(value, 1, 5) != "desc:" || length(value) == 5) return 0
-      return index(description, substr(value, 6)) == 1
+      if (substr(value, 1, 5) != "desc:") return 0
+      # Hyprland trims the selector before comparing, so a rule that spaces one
+      # out names the output there and has to name it here too.
+      value = substr(value, 6)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      if (value == "") return 0
+      return index(description, value) == 1
     }
     # A --[[ ]] comment runs across lines, so a rule inside one has to be seen
     # as commented out before it is matched: rewriting a scale in there reports

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -95,8 +95,10 @@ persist_gdk_scale() {
 # Rewrite `scale = ...` inside the hl.monitor rule naming this output, in both
 # the single-line form Omarchy writes and the multi-line form nwg-displays
 # writes. Commented-out examples and rules for other outputs are left alone. A
-# matching rule with no scale field gets one. Returns 1 when the file carries
-# no rule for this output.
+# matching rule with no scale field gets one. Returns 3 when the file carries no
+# rule for this output, and 1 when the rewrite could not be run at all: a
+# caller that took those for the same thing would answer an unwritable config
+# by falling back to the catch-all and reporting success.
 update_named_monitor_scale() {
   local monitor="$1"
   local scale="$2"
@@ -181,9 +183,19 @@ update_named_monitor_scale() {
     }
     END {
       if (rule != "") printf "%s", rule
-      exit changed ? 0 : 1
+      exit changed ? 0 : 3
     }
-  ' "$file" >"$tmp" || { rm -f "$tmp"; return 1; }
+  ' "$file" >"$tmp"
+  local status=$?
+
+  if (( status == 3 )); then
+    rm -f "$tmp"
+    return 3
+  elif (( status != 0 )); then
+    rm -f "$tmp"
+    echo "Could not read $file to persist the scale" >&2
+    return 1
+  fi
 
   # cat rather than mv: monitors.lua is commonly a symlink into a dotfiles
   # repo, and mv would replace the link with a regular file.
@@ -222,9 +234,14 @@ set_scale() {
   # A rule naming this output overrides the catch-all, so the catch-all is the
   # wrong place to write: the reload that writing monitors.lua triggers would
   # re-apply the named rule and undo the scale just eval'd.
-  if update_named_monitor_scale "$active_monitor" "$new_scale" "$monitor_lua"; then
+  update_named_monitor_scale "$active_monitor" "$new_scale" "$monitor_lua"
+  local rewrite_status=$?
+
+  if (( rewrite_status == 0 )); then
     persist_gdk_scale "$new_gdk_scale" "$monitor_lua"
     return 0
+  elif (( rewrite_status != 3 )); then
+    return 1
   fi
 
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -95,10 +95,12 @@ persist_gdk_scale() {
 # Rewrite `scale = ...` inside the hl.monitor rule naming this output, in both
 # the single-line form Omarchy writes and the multi-line form nwg-displays
 # writes. Commented-out examples and rules for other outputs are left alone. A
-# matching rule with no scale field gets one. Returns 3 when the file carries no
-# rule for this output, and 1 when the rewrite could not be run at all: a
-# caller that took those for the same thing would answer an unwritable config
-# by falling back to the catch-all and reporting success.
+# matching rule with no scale field gets one. Returns 3 when no rule names this
+# output and the shared scale variable is read only by a catch-all rule, 4 when
+# no rule names it and writing that variable would reach another output's rule
+# instead, and 1 when the rewrite could not be run at all: a caller that took
+# those for the same thing would answer an unwritable config by falling back to
+# the catch-all and reporting success.
 update_named_monitor_scale() {
   local monitor="$1"
   local description="$2"
@@ -115,11 +117,30 @@ update_named_monitor_scale() {
     # setups this matters on, because connectors renumber across hotplug. A
     # hand-written rule may also space its keys out, and matching a fixed
     # "output = " would send those to the catch-all the reload overrides.
-    function names_monitor(text,   value) {
-      if (!match(text, /output[[:space:]]*=[[:space:]]*"[^"]*"/)) return 0
+    function output_value(text,   value) {
+      has_output = 0
+      if (!match(text, /output[[:space:]]*=[[:space:]]*"[^"]*"/)) return ""
+      has_output = 1
       value = substr(text, RSTART, RLENGTH)
       sub(/^output[[:space:]]*=[[:space:]]*"/, "", value)
       sub(/"$/, "", value)
+      return value
+    }
+    # The shared variable is only the right place to write when a catch-all
+    # rule is what reads it. A rule naming another output reads it just as
+    # well, and then writing it resizes a display the user did not touch.
+    function note_scale_variable(text,   field, value) {
+      if (!match(text, /scale[[:space:]]*=[[:space:]]*[^,;[:space:]}]+/)) return
+      field = substr(text, RSTART, RLENGTH)
+      sub(/^scale[[:space:]]*=[[:space:]]*/, "", field)
+      if (field != "omarchy_monitor_scale") return
+      value = output_value(text)
+      if (has_output && value == "") catch_all_reads_variable = 1
+      else named_reads_variable = 1
+    }
+    function names_monitor(text,   value) {
+      value = output_value(text)
+      if (!has_output) return 0
       if (value == monitor) return 1
       # Compared literally rather than as a pattern: a description is EDID free
       # text and routinely carries . ( and +.
@@ -132,6 +153,8 @@ update_named_monitor_scale() {
     # then leaves the catch-all alone too, persisting the scale nowhere.
     # Comments are blanked rather than cut, so a position found in the blanked
     # copy still indexes the original. in_block carries the state between lines.
+    # Only the plain --[[ ]] form is recognised; a long bracket with an equals
+    # level is rare enough in a monitors.lua to leave to the reader.
     function blank(line,   out, i, n, pair) {
       out = ""
       n = length(line)
@@ -194,6 +217,7 @@ update_named_monitor_scale() {
       depth -= gsub(/[})]/, "", line)
       if (depth > 0) next
       depth = 0
+      note_scale_variable(bare_rule)
       replaced = rewrite(rule, bare_rule)
       if (replaced != "") { changed = 1; printf "%s", replaced } else printf "%s", rule
       rule = ""
@@ -201,14 +225,15 @@ update_named_monitor_scale() {
     }
     END {
       if (rule != "") printf "%s", rule
-      exit changed ? 0 : 3
+      if (changed) exit 0
+      exit (catch_all_reads_variable && !named_reads_variable) ? 3 : 4
     }
   ' "$file" >"$tmp"
   local status=$?
 
-  if (( status == 3 )); then
+  if (( status == 3 || status == 4 )); then
     rm -f "$tmp"
-    return 3
+    return "$status"
   elif (( status != 0 )); then
     rm -f "$tmp"
     echo "Could not read $file to persist the scale" >&2
@@ -259,13 +284,13 @@ set_scale() {
   if (( rewrite_status == 0 )); then
     persist_gdk_scale "$new_gdk_scale" "$monitor_lua"
     return 0
-  elif (( rewrite_status != 3 )); then
+  elif (( rewrite_status != 3 && rewrite_status != 4 )); then
     return 1
   fi
 
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.
-  if grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
+  if (( rewrite_status == 3 )) && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
     sed -i --follow-symlinks -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       "$monitor_lua"

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -101,6 +101,13 @@ update_named_monitor_scale() {
   local tmp="${file}.omarchy-scale.$$"
 
   awk -v monitor="$monitor" -v scale="$scale" '
+    BEGIN {
+      # A hand-written rule may space its keys out, and matching a fixed
+      # "output = " would send those to the catch-all the reload overrides.
+      named = monitor
+      gsub(/\./, "[.]", named)
+      named = "output[[:space:]]*=[[:space:]]*\"" named "\""
+    }
     function uncommented(text,   n, i, lines, out) {
       n = split(text, lines, "\n")
       out = ""
@@ -111,7 +118,7 @@ update_named_monitor_scale() {
       return out
     }
     function rewrite(text,   n, i, lines, line, head, out, done, pos, end) {
-      if (index(uncommented(text), "output = \"" monitor "\"") == 0) return ""
+      if (uncommented(text) !~ named) return ""
       n = split(text, lines, "\n")
       out = ""
       done = 0

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -113,73 +113,78 @@ update_named_monitor_scale() {
       gsub(/\./, "[.]", named)
       named = "output[[:space:]]*=[[:space:]]*\"" named "\""
     }
-    function uncommented(text,   n, i, lines, out) {
-      n = split(text, lines, "\n")
+    # A --[[ ]] comment runs across lines, so a rule inside one has to be seen
+    # as commented out before it is matched: rewriting a scale in there reports
+    # a rule was written while the reload reads no such rule, and the caller
+    # then leaves the catch-all alone too, persisting the scale nowhere.
+    # Comments are blanked rather than cut, so a position found in the blanked
+    # copy still indexes the original. in_block carries the state between lines.
+    function blank(line,   out, i, n, pair) {
       out = ""
-      for (i = 1; i <= n; i++) {
-        sub(/--.*/, "", lines[i])
-        out = out lines[i] "\n"
+      n = length(line)
+      i = 1
+      while (i <= n) {
+        pair = substr(line, i, 2)
+        if (in_block) {
+          if (pair == "]]") { in_block = 0; out = out "  "; i += 2 } else { out = out " "; i++ }
+        } else if (substr(line, i, 4) == "--[[") {
+          in_block = 1
+          out = out "    "
+          i += 4
+        } else if (pair == "--") {
+          out = out sprintf("%" (n - i + 1) "s", "")
+          i = n + 1
+        } else {
+          out = out substr(line, i, 1)
+          i++
+        }
       }
       return out
     }
-    # The same text with comments blanked rather than cut, so a position found
-    # in it still indexes the original.
-    function blanked(text,   n, i, lines, line, cut, out) {
+    function rewrite(text, blanks,   n, i, lines, bare, line, out, done, pos, end) {
+      if (blanks !~ named) return ""
       n = split(text, lines, "\n")
-      out = ""
-      for (i = 1; i <= n; i++) {
-        line = lines[i]
-        cut = index(line, "--")
-        if (cut > 0) line = substr(line, 1, cut - 1) sprintf("%" (length(line) - cut + 1) "s", "")
-        out = (i == 1) ? line : out "\n" line
-      }
-      return out
-    }
-    function rewrite(text,   n, i, lines, line, head, out, done, pos, end, tail) {
-      if (uncommented(text) !~ named) return ""
-      n = split(text, lines, "\n")
+      split(blanks, bare, "\n")
       out = ""
       done = 0
       for (i = 1; i <= n; i++) {
         line = lines[i]
-        if (!done && line !~ /^[[:space:]]*--/) {
-          head = line
-          sub(/--.*/, "", head)
-          if (match(head, /scale[[:space:]]*=[[:space:]]*("[^"]*"|[^,[:space:]}]+)/)) {
-            line = substr(line, 1, RSTART - 1) "scale = " scale substr(line, RSTART + RLENGTH)
-            done = 1
-          }
+        if (!done && match(bare[i], /scale[[:space:]]*=[[:space:]]*("[^"]*"|[^,;[:space:]}]+)/)) {
+          line = substr(line, 1, RSTART - 1) "scale = " scale substr(line, RSTART + RLENGTH)
+          done = 1
         }
         out = (i == 1) ? line : out "\n" line
       }
       if (done) return out
       # Append against the blanked copy: a brace or a separator inside a
-      # trailing comment would otherwise take the field, leaving the rule with
-      # no scale while this reports one was written.
-      tail = blanked(out)
+      # comment would otherwise take the field, leaving the rule with no scale
+      # while this reports one was written.
       pos = 0
-      for (i = length(tail); i >= 1; i--)
-        if (substr(tail, i, 1) == "}") { pos = i; break }
+      for (i = length(blanks); i >= 1; i--)
+        if (substr(blanks, i, 1) == "}") { pos = i; break }
       if (pos == 0) return ""
       end = pos - 1
-      while (end > 0 && substr(tail, end, 1) ~ /[[:space:]]/) end--
+      while (end > 0 && substr(blanks, end, 1) ~ /[[:space:]]/) end--
       # Lua takes , and ; interchangeably between table fields, and so does the
       # rule reader in omarchy-hyprland-monitor-clamshell.
-      if (substr(tail, end, 1) ~ /[,;]/)
-        return substr(out, 1, end) " scale = " scale substr(out, end + 1)
-      return substr(out, 1, end) ", scale = " scale substr(out, end + 1)
+      if (substr(blanks, end, 1) ~ /[,;]/)
+        return substr(text, 1, end) " scale = " scale substr(text, end + 1)
+      return substr(text, 1, end) ", scale = " scale substr(text, end + 1)
     }
     {
-      if (depth == 0 && $0 !~ /hl\.monitor[[:space:]]*\(/) { print; next }
+      bare_line = blank($0)
+      if (depth == 0 && bare_line !~ /hl\.monitor[[:space:]]*\(/) { print; next }
       rule = (depth == 0) ? $0 "\n" : rule $0 "\n"
-      line = $0
+      bare_rule = (depth == 0) ? bare_line "\n" : bare_rule bare_line "\n"
+      line = bare_line
       depth += gsub(/[{(]/, "", line)
       depth -= gsub(/[})]/, "", line)
       if (depth > 0) next
       depth = 0
-      replaced = rewrite(rule)
+      replaced = rewrite(rule, bare_rule)
       if (replaced != "") { changed = 1; printf "%s", replaced } else printf "%s", rule
       rule = ""
+      bare_rule = ""
     }
     END {
       if (rule != "") printf "%s", rule

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -101,17 +101,30 @@ persist_gdk_scale() {
 # by falling back to the catch-all and reporting success.
 update_named_monitor_scale() {
   local monitor="$1"
-  local scale="$2"
-  local file="$3"
+  local description="$2"
+  local scale="$3"
+  local file="$4"
   local tmp="${file}.omarchy-scale.$$"
 
-  awk -v monitor="$monitor" -v scale="$scale" '
-    BEGIN {
-      # A hand-written rule may space its keys out, and matching a fixed
-      # "output = " would send those to the catch-all the reload overrides.
-      named = monitor
-      gsub(/\./, "[.]", named)
-      named = "output[[:space:]]*=[[:space:]]*\"" named "\""
+  # The description goes through the environment rather than -v, which would
+  # read a backslash in the EDID text as an escape sequence.
+  OMARCHY_MONITOR_DESCRIPTION="$description" awk -v monitor="$monitor" -v scale="$scale" '
+    BEGIN { description = ENVIRON["OMARCHY_MONITOR_DESCRIPTION"] }
+    # Hyprland takes a connector name or desc: followed by any prefix of the
+    # monitor description, and desc: is the usual advice for the multi-monitor
+    # setups this matters on, because connectors renumber across hotplug. A
+    # hand-written rule may also space its keys out, and matching a fixed
+    # "output = " would send those to the catch-all the reload overrides.
+    function names_monitor(text,   value) {
+      if (!match(text, /output[[:space:]]*=[[:space:]]*"[^"]*"/)) return 0
+      value = substr(text, RSTART, RLENGTH)
+      sub(/^output[[:space:]]*=[[:space:]]*"/, "", value)
+      sub(/"$/, "", value)
+      if (value == monitor) return 1
+      # Compared literally rather than as a pattern: a description is EDID free
+      # text and routinely carries . ( and +.
+      if (substr(value, 1, 5) != "desc:" || length(value) == 5) return 0
+      return index(description, substr(value, 6)) == 1
     }
     # A --[[ ]] comment runs across lines, so a rule inside one has to be seen
     # as commented out before it is matched: rewriting a scale in there reports
@@ -142,7 +155,7 @@ update_named_monitor_scale() {
       return out
     }
     function rewrite(text, blanks,   n, i, lines, bare, line, out, done, pos, end) {
-      if (blanks !~ named) return ""
+      if (!names_monitor(blanks)) return ""
       n = split(text, lines, "\n")
       split(blanks, bare, "\n")
       out = ""
@@ -214,6 +227,7 @@ set_scale() {
   local monitor_info="$(hyprctl monitors -j | jq -e -c '.[] | select(.focused == true)')"
   local active_monitor="$(echo "$monitor_info" | jq -r '.name')"
   local current_scale="$(echo "$monitor_info" | jq -r '.scale')"
+  local monitor_description="$(echo "$monitor_info" | jq -r '.description // ""')"
   local width="$(echo "$monitor_info" | jq -r '.width')"
   local height="$(echo "$monitor_info" | jq -r '.height')"
   local refresh_rate="$(echo "$monitor_info" | jq -r '.refreshRate')"
@@ -239,7 +253,7 @@ set_scale() {
   # A rule naming this output overrides the catch-all, so the catch-all is the
   # wrong place to write: the reload that writing monitors.lua triggers would
   # re-apply the named rule and undo the scale just eval'd.
-  update_named_monitor_scale "$active_monitor" "$new_scale" "$monitor_lua"
+  update_named_monitor_scale "$active_monitor" "$monitor_description" "$new_scale" "$monitor_lua"
   local rewrite_status=$?
 
   if (( rewrite_status == 0 )); then

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -182,6 +182,22 @@ update_named_monitor_scale() {
       }
       return out
     }
+    # A description is free text, so a desc: value can carry a bracket that
+    # closes nothing -- a prefix cut mid-parenthesis is enough. Counting it
+    # leaves the rule open, swallows every rule after it, and the catch-all is
+    # written as if none of them named this output. The depth counter reads the
+    # line with quoted values emptied for that reason, and nothing else does:
+    # matching a rule still needs to see what the value says.
+    function outside_strings(line,   out, i, n, quoted) {
+      out = ""
+      n = length(line)
+      quoted = 0
+      for (i = 1; i <= n; i++) {
+        if (substr(line, i, 1) == "\"") quoted = !quoted
+        out = out (quoted ? " " : substr(line, i, 1))
+      }
+      return out
+    }
     function rewrite(text, blanks,   n, i, lines, bare, line, out, done, pos, end) {
       if (!names_monitor(blanks)) return ""
       n = split(text, lines, "\n")
@@ -214,10 +230,10 @@ update_named_monitor_scale() {
     }
     {
       bare_line = blank($0)
-      if (depth == 0 && bare_line !~ /hl\.monitor[[:space:]]*\(/) { print; next }
+      line = outside_strings(bare_line)
+      if (depth == 0 && line !~ /hl\.monitor[[:space:]]*\(/) { print; next }
       rule = (depth == 0) ? $0 "\n" : rule $0 "\n"
       bare_rule = (depth == 0) ? bare_line "\n" : bare_rule bare_line "\n"
-      line = bare_line
       depth += gsub(/[{(]/, "", line)
       depth -= gsub(/[})]/, "", line)
       if (depth > 0) next

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -83,7 +83,7 @@ persist_gdk_scale() {
   enabled="$(hyprctl monitors -j | jq '[.[] | select(.disabled != true)] | length')"
   [[ $enabled == 1 ]] || return 0
 
-  sed -i -E \
+  sed -i --follow-symlinks -E \
     -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${gdk_scale}|" \
     -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$gdk_scale"'")|' \
     "$file"
@@ -156,7 +156,10 @@ update_named_monitor_scale() {
     }
   ' "$file" >"$tmp" || { rm -f "$tmp"; return 1; }
 
-  mv "$tmp" "$file"
+  # cat rather than mv: monitors.lua is commonly a symlink into a dotfiles
+  # repo, and mv would replace the link with a regular file.
+  cat "$tmp" >"$file"
+  rm -f "$tmp"
 }
 
 set_scale() {
@@ -198,12 +201,12 @@ set_scale() {
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.
   if grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
-    sed -i -E \
+    sed -i --follow-symlinks -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       "$monitor_lua"
     persist_gdk_scale "$new_gdk_scale" "$monitor_lua"
   elif grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
-    sed -i -E \
+    sed -i --follow-symlinks -E \
       -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
       "$monitor_lua"
     persist_gdk_scale "$new_gdk_scale" "$monitor_lua"

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -71,6 +71,87 @@ normalize_scale() {
   awk 'NR == 1 { printf "%g\n", $0 }'
 }
 
+# Persisting GDK_SCALE happens from three places below.
+persist_gdk_scale() {
+  local gdk_scale="$1"
+  local file="$2"
+
+  sed -i -E \
+    -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${gdk_scale}|" \
+    -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$gdk_scale"'")|' \
+    "$file"
+}
+
+# Rewrite `scale = ...` inside the hl.monitor rule naming this output, in both
+# the single-line form Omarchy writes and the multi-line form nwg-displays
+# writes. Commented-out examples and rules for other outputs are left alone. A
+# matching rule with no scale field gets one. Returns 1 when the file carries
+# no rule for this output.
+update_named_monitor_scale() {
+  local monitor="$1"
+  local scale="$2"
+  local file="$3"
+  local tmp="${file}.omarchy-scale.$$"
+
+  awk -v monitor="$monitor" -v scale="$scale" '
+    function uncommented(text,   n, i, lines, out) {
+      n = split(text, lines, "\n")
+      out = ""
+      for (i = 1; i <= n; i++) {
+        sub(/--.*/, "", lines[i])
+        out = out lines[i] "\n"
+      }
+      return out
+    }
+    function rewrite(text,   n, i, lines, line, head, out, done, pos, end) {
+      if (index(uncommented(text), "output = \"" monitor "\"") == 0) return ""
+      n = split(text, lines, "\n")
+      out = ""
+      done = 0
+      for (i = 1; i <= n; i++) {
+        line = lines[i]
+        if (!done && line !~ /^[[:space:]]*--/) {
+          head = line
+          sub(/--.*/, "", head)
+          if (match(head, /scale[[:space:]]*=[[:space:]]*("[^"]*"|[^,[:space:]}]+)/)) {
+            line = substr(line, 1, RSTART - 1) "scale = " scale substr(line, RSTART + RLENGTH)
+            done = 1
+          }
+        }
+        out = (i == 1) ? line : out "\n" line
+      }
+      if (done) return out
+      pos = 0
+      for (i = length(out); i >= 1; i--)
+        if (substr(out, i, 1) == "}") { pos = i; break }
+      if (pos == 0) return ""
+      end = pos - 1
+      while (end > 0 && substr(out, end, 1) ~ /[[:space:]]/) end--
+      if (substr(out, end, 1) == ",")
+        return substr(out, 1, end) " scale = " scale substr(out, end + 1)
+      return substr(out, 1, end) ", scale = " scale substr(out, end + 1)
+    }
+    {
+      if (depth == 0 && $0 !~ /hl\.monitor[[:space:]]*\(/) { print; next }
+      rule = (depth == 0) ? $0 "\n" : rule $0 "\n"
+      line = $0
+      depth += gsub(/[{(]/, "", line)
+      depth -= gsub(/[})]/, "", line)
+      if (depth > 0) next
+      depth = 0
+      replaced = rewrite(rule)
+      if (replaced != "") { changed = 1; printf "%s", replaced } else printf "%s", rule
+      rule = ""
+    }
+    END {
+      if (rule != "") printf "%s", rule
+      exit changed ? 0 : 1
+    }
+  ' "$file" >"$tmp" || { rm -f "$tmp"; return 1; }
+
+  mv "$tmp" "$file"
+}
+
 set_scale() {
   local requested_scale="$1"
   local requested="${2:-$requested_scale}"
@@ -97,18 +178,28 @@ set_scale() {
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
+  [[ -f $monitor_lua ]] || return 0
+
+  # A rule naming this output overrides the catch-all, so the catch-all is the
+  # wrong place to write: the reload that writing monitors.lua triggers would
+  # re-apply the named rule and undo the scale just eval'd.
+  if update_named_monitor_scale "$active_monitor" "$new_scale" "$monitor_lua"; then
+    persist_gdk_scale "$new_gdk_scale" "$monitor_lua"
+    return 0
+  fi
+
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.
-  if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
+  if grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
     sed -i -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
-      -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
       "$monitor_lua"
-  elif [[ -f $monitor_lua ]] && grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
+    persist_gdk_scale "$new_gdk_scale" "$monitor_lua"
+  elif grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
     sed -i -E \
       -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
-      -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
       "$monitor_lua"
+    persist_gdk_scale "$new_gdk_scale" "$monitor_lua"
   fi
 }
 

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -117,7 +117,20 @@ update_named_monitor_scale() {
       }
       return out
     }
-    function rewrite(text,   n, i, lines, line, head, out, done, pos, end) {
+    # The same text with comments blanked rather than cut, so a position found
+    # in it still indexes the original.
+    function blanked(text,   n, i, lines, line, cut, out) {
+      n = split(text, lines, "\n")
+      out = ""
+      for (i = 1; i <= n; i++) {
+        line = lines[i]
+        cut = index(line, "--")
+        if (cut > 0) line = substr(line, 1, cut - 1) sprintf("%" (length(line) - cut + 1) "s", "")
+        out = (i == 1) ? line : out "\n" line
+      }
+      return out
+    }
+    function rewrite(text,   n, i, lines, line, head, out, done, pos, end, tail) {
       if (uncommented(text) !~ named) return ""
       n = split(text, lines, "\n")
       out = ""
@@ -135,13 +148,19 @@ update_named_monitor_scale() {
         out = (i == 1) ? line : out "\n" line
       }
       if (done) return out
+      # Append against the blanked copy: a brace or a separator inside a
+      # trailing comment would otherwise take the field, leaving the rule with
+      # no scale while this reports one was written.
+      tail = blanked(out)
       pos = 0
-      for (i = length(out); i >= 1; i--)
-        if (substr(out, i, 1) == "}") { pos = i; break }
+      for (i = length(tail); i >= 1; i--)
+        if (substr(tail, i, 1) == "}") { pos = i; break }
       if (pos == 0) return ""
       end = pos - 1
-      while (end > 0 && substr(out, end, 1) ~ /[[:space:]]/) end--
-      if (substr(out, end, 1) == ",")
+      while (end > 0 && substr(tail, end, 1) ~ /[[:space:]]/) end--
+      # Lua takes , and ; interchangeably between table fields, and so does the
+      # rule reader in omarchy-hyprland-monitor-clamshell.
+      if (substr(tail, end, 1) ~ /[,;]/)
         return substr(out, 1, end) " scale = " scale substr(out, end + 1)
       return substr(out, 1, end) ", scale = " scale substr(out, end + 1)
     }

--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -80,7 +80,10 @@ persist_gdk_scale() {
   local file="$2"
   local enabled
 
-  enabled="$(hyprctl monitors -j | jq '[.[] | select(.disabled != true)] | length')"
+  # Mirrors are absent from plain `monitors`, so counting there can miss an
+  # output whose XWayland windows this would resize; `all` plus an explicit
+  # disabled filter is what the other monitor helpers use.
+  enabled="$(hyprctl monitors all -j | jq '[.[] | select(.disabled != true)] | length')"
   [[ $enabled == 1 ]] || return 0
 
   sed -i --follow-symlinks -E \

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -268,3 +268,19 @@ grep -F 'position = "0x0", scale = 1.6 })' "$real_lua" >/dev/null ||
   fail "monitor scaling writes through a symlinked monitors.lua"
 pass "monitor scaling keeps a symlinked monitors.lua a symlink"
 rm -f "$monitor_lua"
+
+# A config that cannot be read is not a config with no rule for this output.
+# Taking the two for the same thing sends an unwritable setup down the
+# catch-all branch, which rewrites the shared scale and reports success.
+if (( EUID != 0 )); then
+  write_named_config
+  chmod 000 "$monitor_lua"
+  if OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6 2>/dev/null; then
+    chmod 644 "$monitor_lua"
+    fail "monitor scaling reports failure when monitors.lua cannot be read"
+  fi
+  chmod 644 "$monitor_lua"
+  grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+    fail "monitor scaling leaves the catch-all alone when monitors.lua cannot be read"
+  pass "monitor scaling reports failure when monitors.lua cannot be read"
+fi

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -19,10 +19,10 @@ cat >"$stub_bin/hyprctl" <<'SH'
 #!/bin/bash
 
 if [[ $1 == "monitors" ]]; then
-  primary=$(printf '{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}' \
+  primary=$(printf '{"name":"eDP-1","description":"BOE NE180WUM-NX1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}' \
     "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}")
   if [[ -n ${OMARCHY_TEST_SECOND_MONITOR:-} ]]; then
-    printf '[%s,{"name":"HDMI-A-1","focused":false,"scale":1,"width":2560,"height":1440,"refreshRate":60.0}]' "$primary"
+    printf '[%s,{"name":"HDMI-A-1","description":"LG Electronics LG HDR 4K 0x0007F1E8","focused":false,"scale":1,"width":2560,"height":1440,"refreshRate":60.0}]' "$primary"
   else
     printf '[%s]' "$primary"
   fi
@@ -302,3 +302,23 @@ grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", 
 grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
   fail "monitor scaling falls back to the catch-all when the only named rule is block commented"
 pass "monitor scaling leaves a rule inside a block comment alone"
+
+# desc: is Hyprland's own syntax and the usual advice for multi-monitor setups,
+# because connector names renumber across hotplug. A desc: rule that goes
+# unrecognised sends the write to the catch-all, which here is read by the rule
+# for the other output.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+hl.monitor({ output = "desc:BOE NE180WUM", mode = "preferred", position = "0x0", scale = 2 })
+hl.monitor({ output = "desc:LG Electronics LG HDR 4K", mode = "preferred", position = "auto-right", scale = 1 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "desc:BOE NE180WUM", mode = "preferred", position = "0x0", scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling writes onto a rule naming the output by desc:"
+grep -Fx 'hl.monitor({ output = "desc:LG Electronics LG HDR 4K", mode = "preferred", position = "auto-right", scale = 1 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves another output's desc: rule alone"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the catch-all alone once a desc: rule matched"
+pass "monitor scaling writes onto a rule naming the output by desc:"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -190,6 +190,19 @@ grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", 
   fail "monitor scaling adds a scale to a named rule that has none"
 pass "monitor scaling adds a scale to a named rule that has none"
 
+# A hand-written rule spaces its keys however the author likes.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output  =  "eDP-1", mode = "preferred", position = "auto", scale = 2 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output  =  "eDP-1", mode = "preferred", position = "auto", scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling matches a named rule whose keys are spaced out"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the catch-all alone for a spaced-out named rule"
+pass "monitor scaling matches a named rule whose keys are spaced out"
+
 # GDK_SCALE is one integer for the whole session. Following one display's scale
 # while another is enabled resizes XWayland windows on the untouched display.
 write_named_config

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -129,3 +129,58 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+# A rule naming an output overrides the catch-all, so writing the catch-all
+# leaves it stale and the reload that write triggers undoes the live change.
+
+write_named_config() {
+  cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+hl.monitor({ output = "eDP-1", mode = "2880x1800@120", position = "0x0", scale = 2 })
+hl.monitor({ output = "HDMI-A-1", mode = "2560x1440@60", position = "auto-right", scale = 1 })
+-- hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 4 })
+LUA
+}
+
+write_named_config
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "2880x1800@120", position = "0x0", scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling writes onto the rule naming the focused output"
+grep -Fx 'hl.monitor({ output = "HDMI-A-1", mode = "2560x1440@60", position = "auto-right", scale = 1 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves another output's rule alone"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the catch-all alone once a named rule matched"
+grep -Fx -e '-- hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 4 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves a commented-out rule alone"
+pass "monitor scaling writes onto a named per-output rule"
+
+# nwg-displays writes one field per line.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({
+  output = "eDP-1",
+  mode = "2880x1800@120",
+  position = "0x0",
+  scale = 2,
+})
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx '  scale = 1.6,' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling rewrites the multi-line rule form"
+pass "monitor scaling rewrites the multi-line rule form"
+
+# A named rule may leave scale to the catch-all; it still has to be pinned here,
+# or the reload puts the catch-all's value back.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", transform = 3 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", transform = 3, scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling adds a scale to a named rule that has none"
+pass "monitor scaling adds a scale to a named rule that has none"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -19,8 +19,13 @@ cat >"$stub_bin/hyprctl" <<'SH'
 #!/bin/bash
 
 if [[ $1 == "monitors" && $2 == "-j" ]]; then
-  printf '[{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}]' \
-    "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}"
+  primary=$(printf '{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}' \
+    "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}")
+  if [[ -n ${OMARCHY_TEST_SECOND_MONITOR:-} ]]; then
+    printf '[%s,{"name":"HDMI-A-1","focused":false,"scale":1,"width":2560,"height":1440,"refreshRate":60.0}]' "$primary"
+  else
+    printf '[%s]' "$primary"
+  fi
 elif [[ $1 == "eval" ]]; then
   printf '%s\n' "$2" >"$OMARCHY_TEST_HYPRCTL_EVAL_OUT"
 else
@@ -184,3 +189,19 @@ OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
 grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", transform = 3, scale = 1.6 })' "$monitor_lua" >/dev/null ||
   fail "monitor scaling adds a scale to a named rule that has none"
 pass "monitor scaling adds a scale to a named rule that has none"
+
+# GDK_SCALE is one integer for the whole session. Following one display's scale
+# while another is enabled resizes XWayland windows on the untouched display.
+write_named_config
+OMARCHY_TEST_SECOND_MONITOR=1 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.25
+grep -Fx 'local omarchy_gdk_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves GDK scale alone while a second display is enabled"
+grep -F 'position = "0x0", scale = 1.25 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling still writes the per-output scale with two displays"
+pass "monitor scaling leaves GDK scale alone with two displays enabled"
+
+write_named_config
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.25
+grep -Fx 'local omarchy_gdk_scale = 1' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling still tracks GDK scale on a single display"
+pass "monitor scaling still tracks GDK scale on a single display"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -343,6 +343,23 @@ grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling leaves the catch-all alone for a spaced-out desc: rule"
 pass "monitor scaling matches a desc: selector whose spacing Hyprland trims"
 
+# A desc: prefix cut mid-parenthesis is ordinary selector text to Hyprland. Read
+# as a table delimiter it leaves the rule open, so every rule below it goes
+# unseen and the catch-all is rewritten as if none of them named this output.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+hl.monitor({ output = "desc:LG Electronics (LG HDR", mode = "preferred", position = "auto-right", scale = 1 })
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "0x0", scale = 2 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "0x0", scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling reads past a bracket inside a quoted value"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the catch-all alone past a bracket inside a quoted value"
+pass "monitor scaling reads past a bracket inside a quoted value"
+
 # The shared variable is only the catch-all when a catch-all rule reads it. A
 # connector name that has gone stale across a renumber leaves no rule naming
 # the focused output, and writing the variable then resizes whichever display

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -284,3 +284,21 @@ if (( EUID != 0 )); then
     fail "monitor scaling leaves the catch-all alone when monitors.lua cannot be read"
   pass "monitor scaling reports failure when monitors.lua cannot be read"
 fi
+
+# A rule inside a --[[ ]] block is commented out. Rewriting a scale in there
+# reports a rule was written, and the caller then leaves the catch-all alone
+# too, so the change is persisted nowhere and the reload undoes it.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+--[[
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 4 })
+]]
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 4 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves a rule inside a block comment alone"
+grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling falls back to the catch-all when the only named rule is block commented"
+pass "monitor scaling leaves a rule inside a block comment alone"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -327,6 +327,22 @@ grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling leaves the catch-all alone once a desc: rule matched"
 pass "monitor scaling writes onto a rule naming the output by desc:"
 
+# Hyprland trims the desc: selector before comparing, so a rule that spaces one
+# out does name the output. Missing it here sends the write to the catch-all
+# the reload then overrides, which is the defect this command exists to remove.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+hl.monitor({ output = "desc:  BOE NE180WUM  ", mode = "preferred", position = "0x0", scale = 2 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "desc:  BOE NE180WUM  ", mode = "preferred", position = "0x0", scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling matches a desc: selector whose spacing Hyprland trims"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the catch-all alone for a spaced-out desc: rule"
+pass "monitor scaling matches a desc: selector whose spacing Hyprland trims"
+
 # The shared variable is only the catch-all when a catch-all rule reads it. A
 # connector name that has gone stale across a renumber leaves no rule naming
 # the focused output, and writing the variable then resizes whichever display

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -203,6 +203,43 @@ grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling leaves the catch-all alone for a spaced-out named rule"
 pass "monitor scaling matches a named rule whose keys are spaced out"
 
+# Lua takes ; between table fields, and appending a comma after one is a syntax
+# error Hyprland reports as a config that will not load.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "eDP-1"; mode = "preferred"; position = "auto"; })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "eDP-1"; mode = "preferred"; position = "auto"; scale = 1.6 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling appends a scale after a semicolon separator"
+pass "monitor scaling appends a scale after a semicolon separator"
+
+# A comment carries commas and braces of its own, and the field goes in the
+# table rather than in the comment.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({
+  output = "eDP-1",
+  transform = 3, -- keep the panel rotated
+})
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx '  transform = 3, scale = 1.6 -- keep the panel rotated' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling appends a scale beside a commented field, not inside the comment"
+pass "monitor scaling appends a scale beside a commented field"
+
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "eDP-1", transform = 3 }) -- was { 1 }
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -Fx 'hl.monitor({ output = "eDP-1", transform = 3, scale = 1.6 }) -- was { 1 }' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling ignores a brace inside a trailing comment"
+pass "monitor scaling ignores a brace inside a trailing comment"
+
 # GDK_SCALE is one integer for the whole session. Following one display's scale
 # while another is enabled resizes XWayland windows on the untouched display.
 write_named_config

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -205,3 +205,16 @@ OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.25
 grep -Fx 'local omarchy_gdk_scale = 1' "$monitor_lua" >/dev/null ||
   fail "monitor scaling still tracks GDK scale on a single display"
 pass "monitor scaling still tracks GDK scale on a single display"
+
+# monitors.lua is commonly a symlink into a dotfiles repo. Replacing the link
+# with a regular file detaches the config from the repo without saying so.
+real_lua="$test_tmp/dotfiles-monitors.lua"
+write_named_config
+mv "$monitor_lua" "$real_lua"
+ln -s "$real_lua" "$monitor_lua"
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+[[ -L $monitor_lua ]] || fail "monitor scaling keeps a symlinked monitors.lua a symlink"
+grep -F 'position = "0x0", scale = 1.6 })' "$real_lua" >/dev/null ||
+  fail "monitor scaling writes through a symlinked monitors.lua"
+pass "monitor scaling keeps a symlinked monitors.lua a symlink"
+rm -f "$monitor_lua"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -34,10 +34,14 @@ fi
 SH
 chmod +x "$stub_bin/hyprctl"
 
+# The shape monitors.lua ships in: a catch-all rule reading the shared scale
+# variable, and no rule naming any output.
 write_monitor_config() {
   cat >"$monitor_lua" <<'LUA'
-local omarchy_gdk_scale = 2
 local omarchy_monitor_scale = 2
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+local omarchy_gdk_scale = 2
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
 LUA
 }
 
@@ -322,3 +326,20 @@ grep -Fx 'hl.monitor({ output = "desc:LG Electronics LG HDR 4K", mode = "preferr
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling leaves the catch-all alone once a desc: rule matched"
 pass "monitor scaling writes onto a rule naming the output by desc:"
+
+# The shared variable is only the catch-all when a catch-all rule reads it. A
+# connector name that has gone stale across a renumber leaves no rule naming
+# the focused output, and writing the variable then resizes whichever display
+# does read it.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+hl.monitor({ output = "HDMI-A-1", mode = "preferred", position = "0x0", scale = omarchy_monitor_scale })
+hl.monitor({ output = "DP-9", mode = "preferred", position = "auto", scale = 1 })
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
+grep -F 'scale = 1.6' "$eval_out" >/dev/null ||
+  fail "monitor scaling still applies the scale with no rule naming the output"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves a scale variable another output's rule reads alone"
+pass "monitor scaling leaves a scale variable another output's rule reads alone"

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -18,7 +18,7 @@ mkdir -p "$stub_bin" "$home_dir/.config/hypr"
 cat >"$stub_bin/hyprctl" <<'SH'
 #!/bin/bash
 
-if [[ $1 == "monitors" && $2 == "-j" ]]; then
+if [[ $1 == "monitors" ]]; then
   primary=$(printf '{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}' \
     "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}")
   if [[ -n ${OMARCHY_TEST_SECOND_MONITOR:-} ]]; then


### PR DESCRIPTION
`omarchy-hyprland-monitor-scaling` applies a scale with `hyprctl eval`, then persists it by rewriting the catch-all `omarchy_monitor_scale` in `monitors.lua`. When the file carries an `hl.monitor` rule naming that output, the catch-all is the wrong place to write, and writing it is actively harmful: Hyprland reloads on the write, the reload re-applies the named rule, and the scale reverts before it is visible. The command reports success either way.

Measured on Omarchy 4.0.1-1 with Hyprland 0.56.2, two displays, `monitors.lua` holding a named rule per output. Pressing SUPER + / five times stepped a 1440p external from 1 to 4 in the audit log while the screen never changed, and setting a scale from the Display panel logged `requested=1 current=4 new=1` three times with the monitor staying on 4. Stepping up stops at 4, which on a 27" 1440p is a 640x360 desktop, so the display it strands on is the one you cannot read.

## This is already reported and already fixed several times

Open reports: #6673, #7242, #7505, #8103, and #7625. #7978 is the closed one.

Open PRs fixing the persistence half in this same file: #7437, #7497, #7519, #7575, #8145 and #8982. Six independent takes on one command, and the persistence branch itself is not what makes this one worth reading.

**The value here is the three defects the others do not cover, and each stands alone.** If you would rather take one of the six, please cherry-pick these onto it and close this.

## What the others do not do

**GDK_SCALE is rewritten from one display's scale while other displays are enabled.** It is a single integer for the session, and Omarchy sets `xwayland.force_zero_scaling`, so it is what sizes every XWayland window. Adjusting a laptop panel to 1.6 next to an external at 1.0 persists `GDK_SCALE=2` and doubles the external's X11 windows. That is the overflow reported in #7021. No value is right for two displays at different scales, so this leaves the configured value alone once more than one output is enabled, counted with `hyprctl monitors all`. Single-display behaviour is unchanged. #7437 has a test asserting the current behaviour, which is worth a look if you take that one instead. #8145's `persist_gdk_scale` rewrites unconditionally.

**A symlinked `monitors.lua` is replaced by a regular file.** Keeping `monitors.lua` in a dotfiles repo and symlinking it is common, and both write paths detach it silently: the scale change works, and every later edit goes somewhere the repo no longer tracks. Third failure in #7625.

**#7309 already fixes half of this and should land.** It adds `sed -i --follow-symlinks` across `bin/` and `migrations/` including this file, with an architectural test that fails any new bare `sed -i`. It does not cover the second path: a rule rewrite that renames a temporary over the target detaches the link just the same, and `--follow-symlinks` cannot help there because no `sed -i` is involved. This branch uses `sed -i --follow-symlinks` in all three of its `sed` calls and `cat` over the target instead of `mv` for the rewrite, so it is already compliant with the rule #7309 wants to enforce and the two merge without fighting. #8145 uses a bare `sed -i` and a temporary rename, so it would need both halves.

**Rule shapes the matcher does not see.** A named rule is matched however its keys are spaced, in the multi-line form nwg-displays writes, and when it names the output by `desc:`. A rule inside a `--[[ ]]` block is treated as commented out rather than matched. A matching rule with no `scale` field gets one appended into the table, not into a trailing comment and not after a semicolon.

## Deliberately not here

**Position.** The `hyprctl eval` still sends `position = "auto"`, which reshuffles a pinned layout until the next reload. #7495 and #7840 own that, and #7326 is the report.

**The other parser.** `omarchy-hyprland-monitor-clamshell` carries its own separate `monitor_rules`/`monitor_rule_regex` pair over the same file format, with the same blindness to `desc:` and multi-line rules. **#8808 fixes it there** and is complementary rather than competing: different file, different function, same class of bug. Both are worth taking, and the fact that `monitors.lua` is parsed independently in two commands is the thing actually worth fixing once someone has the appetite for it.

**#8982** is in this list for completeness rather than as an alternative: it is 190 files and +8562/-555 against an unrebased branch, with the monitor-scaling change inside it.

## Tests

`test/shell.d/monitor-scaling-test.sh` goes from 14 assertions to 28: a named single-line rule updated with other outputs and the catch-all left alone, a commented-out rule ignored, a rule inside a `--[[ ]]` block ignored, the multi-line form nwg-displays writes, a `desc:` keyed rule, a named rule with no scale field getting one, appending past a trailing comment and past a semicolon, GDK_SCALE held with two displays and still tracked with one, and a symlinked `monitors.lua` still being a symlink afterwards.

Each new assertion was checked to be load-bearing by reverting its fix: removing the multi-display guard fails the GDK assertion, `cat` back to `mv` fails the symlink assertion, and disabling the named-rule path fails the persistence assertion.

## 2026-09-01

Rebased onto current `quattro` (b71dcad9) with no conflicts. No code changed in this revision; the corrections are to this description, which had claims that no longer held.

- **Corrected the symlink claim.** The previous revision said the two defects were ones nobody had fixed. That is not true of the `sed -i` half: **#7309** got there on 17 August, eight days before this branch, and covers the whole repository. The section now says what #7309 does, what it does not reach, and why this branch merges cleanly with it.
- **Added #8808** as complementary work on the second parser in `omarchy-hyprland-monitor-clamshell`, and named the duplication as the underlying problem.
- **Added #8982** to the list of takes on the persistence half.
- **Compared against #8145 concretely** on the two axes where this differs, rather than conceding to it in general terms.
- **Corrected the assertion count** to 28, which is what the file has after the later commits on this branch.
- Re-ran `monitor-scaling-test.sh` (28), `monitor-clamshell-scale-test.sh` (25), `monitor-test.sh` (21), `monitor-output-name-test.sh` (8) and `monitor-state-test.sh` (5) on the rebase. All pass.
