### PR TITLE
Run the built-in panel slower on battery

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -138,6 +138,10 @@ string on a miss.
     "screensaver": 150,
     "lock": 300
   },
+  "refreshRate": {
+    "enabled": true,
+    "threshold": 50
+  },
   "bar": {
     "id": "omarchy.bar",
     "position": "top",
@@ -169,7 +173,12 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
-8. `version: 1` is required.
+8. `refreshRate` runs the built-in panel at the fastest rate it advertises for
+   its current resolution while on mains, and the slowest one otherwise. It is
+   off unless `enabled` is `true`, and `threshold` is the battery percent below
+   which the slow rate applies even on mains (default 50). External displays
+   are never touched, and neither is a panel that offers only one rate.
+9. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/shell/plugins/services/refresh-rate/RefreshRateModel.js
+++ b/shell/plugins/services/refresh-rate/RefreshRateModel.js
@@ -1,0 +1,82 @@
+// Which outputs count as the machine's own panel. Same test the monitor
+// helpers in bin/ use, so "internal" means the same thing across the system.
+var INTERNAL = /^(eDP|LVDS|DSI)/i
+
+function isInternal(name) {
+  return !!name && INTERNAL.test(name)
+}
+
+// The rates an output advertises at the resolution it is already using.
+// Restricting to the current mode means a rate change can never also change
+// the resolution behind the user's back.
+function ratesFor(monitor) {
+  if (!monitor || !monitor.availableModes) return []
+  var prefix = monitor.width + "x" + monitor.height + "@"
+  var seen = ({})
+  var rates = []
+  for (var i = 0; i < monitor.availableModes.length; i++) {
+    var mode = monitor.availableModes[i]
+    if (mode.indexOf(prefix) !== 0) continue
+    var rate = mode.substring(prefix.length).replace(/Hz$/, "")
+    if (seen[rate]) continue
+    seen[rate] = true
+    rates.push(rate)
+  }
+  rates.sort(function (a, b) { return parseFloat(a) - parseFloat(b) })
+  return rates
+}
+
+// On mains with charge to spare, run the panel as fast as it goes. Otherwise
+// run it as slow as it goes. Being on mains is the hard requirement: on
+// battery the frugal rate applies at any charge. A battery that cannot be read
+// only relaxes the threshold, so a laptop with a dead gauge still runs fast
+// while plugged in rather than being pinned low forever.
+function targetRate(monitor, onBattery, percent, threshold) {
+  var rates = ratesFor(monitor)
+  if (rates.length < 2) return ""
+  var readable = typeof percent === "number" && percent >= 0
+  var charged = readable ? percent >= threshold : true
+  return (!onBattery && charged) ? rates[rates.length - 1] : rates[0]
+}
+
+// Hyprland reports 165.02000 for the mode written as 165.02, so compare on the
+// rounded value rather than the string.
+function needsChange(monitor, rate) {
+  if (!rate || !monitor) return false
+  return Math.round(Number(monitor.refreshRate)) !== Math.round(parseFloat(rate))
+}
+
+function monitorSpec(monitor, rate) {
+  if (!monitor || !rate) return ""
+  if (!/^[A-Za-z0-9._-]+$/.test(monitor.name)) return ""
+  return 'hl.monitor({ output = "' + monitor.name + '", mode = "' +
+    monitor.width + "x" + monitor.height + "@" + rate +
+    '", position = "' + monitor.x + "x" + monitor.y +
+    '", scale = ' + monitor.scale + " })"
+}
+
+// Every internal output that is on the wrong rate, as ready-to-eval specs.
+function pendingSpecs(monitors, onBattery, percent, threshold) {
+  var specs = []
+  if (!monitors) return specs
+  for (var i = 0; i < monitors.length; i++) {
+    var monitor = monitors[i]
+    if (!monitor || monitor.disabled === true || !isInternal(monitor.name)) continue
+    var rate = targetRate(monitor, onBattery, percent, threshold)
+    if (!needsChange(monitor, rate)) continue
+    var spec = monitorSpec(monitor, rate)
+    if (spec) specs.push(spec)
+  }
+  return specs
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    isInternal: isInternal,
+    ratesFor: ratesFor,
+    targetRate: targetRate,
+    needsChange: needsChange,
+    monitorSpec: monitorSpec,
+    pendingSpecs: pendingSpecs
+  }
+}

--- a/shell/plugins/services/refresh-rate/Service.qml
+++ b/shell/plugins/services/refresh-rate/Service.qml
@@ -57,9 +57,19 @@ Item {
     }
   }
 
+  // A rate Hyprland refuses is worth a line. Nothing here is visible to the
+  // user until the panel fails to change rate, and a service that reports
+  // success over a refused eval leaves nothing to look at.
   Process {
     id: applyProc
-    stdout: StdioCollector { waitForEnd: true }
+    stdout: StdioCollector {
+      id: applyStdout
+      waitForEnd: true
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0)
+        console.warn("refresh-rate", "eval exited", exitCode, String(applyStdout.text || "").trim())
+    }
     onRunningChanged: if (!running) root.applyNext()
   }
 

--- a/shell/plugins/services/refresh-rate/Service.qml
+++ b/shell/plugins/services/refresh-rate/Service.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Quickshell.Services.UPower
+import "RefreshRateModel.js" as RefreshRateModel
+
+Item {
+  id: root
+
+  property var shell: null
+
+  // Off unless asked for. Changing what someone's panel does on battery is not
+  // a thing to start doing to them on upgrade.
+  readonly property var config: shell && shell.shellConfig && shell.shellConfig.refreshRate
+    ? shell.shellConfig.refreshRate
+    : ({})
+  readonly property bool enabled: config.enabled === true
+  readonly property int threshold: typeof config.threshold === "number" ? config.threshold : 50
+
+  property var pending: []
+
+  function batteryPercentage() {
+    var device = UPower.displayDevice
+    if (!device || !device.isPresent) return -1
+    return Math.round(Number(device.percentage || 0) * 100)
+  }
+
+  function refresh() {
+    if (!enabled || monitorsProc.running || applyProc.running) return
+    monitorsProc.running = true
+  }
+
+  function applyNext() {
+    if (root.pending.length === 0) return
+    var spec = root.pending[0]
+    root.pending = root.pending.slice(1)
+    applyProc.command = ["hyprctl", "eval", spec]
+    applyProc.running = true
+  }
+
+  Process {
+    id: monitorsProc
+    command: ["hyprctl", "monitors", "all", "-j"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var monitors = []
+        try {
+          monitors = JSON.parse(String(text || "[]"))
+        } catch (e) {
+          return
+        }
+        root.pending = RefreshRateModel.pendingSpecs(
+          monitors, UPower.onBattery, root.batteryPercentage(), root.threshold)
+        root.applyNext()
+      }
+    }
+  }
+
+  Process {
+    id: applyProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: if (!running) root.applyNext()
+  }
+
+  // Charge crossing the threshold is not something UPower raises an event for,
+  // so the rate is re-checked on a clock as well as on the mains transition.
+  Timer {
+    interval: 60000
+    running: root.enabled
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.refresh()
+  }
+
+  Connections {
+    target: UPower
+    function onOnBatteryChanged() { root.refresh() }
+  }
+}

--- a/shell/plugins/services/refresh-rate/manifest.json
+++ b/shell/plugins/services/refresh-rate/manifest.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.refresh-rate",
+  "name": "Refresh Rate",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Runs the built-in panel at its fastest advertised rate on mains and its slowest on battery.",
+  "kinds": [
+    "service"
+  ],
+  "keepLoaded": true,
+  "entryPoints": {
+    "service": "Service.qml"
+  }
+}

--- a/test/shell.d/refresh-rate-test.sh
+++ b/test/shell.d/refresh-rate-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const refresh = requireFromRoot('shell/plugins/services/refresh-rate/RefreshRateModel.js')
+
+const panel = {
+  name: 'eDP-1', width: 2560, height: 1600, refreshRate: 60.008,
+  scale: 1.6, x: 0, y: 0,
+  availableModes: ['2560x1600@60.01Hz', '2560x1600@165.02Hz', '1920x1080@120.00Hz']
+}
+const external = {
+  name: 'HDMI-A-1', width: 2560, height: 1440, refreshRate: 59.951,
+  scale: 1, x: 1600, y: 0,
+  availableModes: ['2560x1440@59.95Hz', '2560x1440@143.91Hz']
+}
+
+assertEqual(refresh.isInternal('eDP-1'), true, 'refresh rate treats eDP as internal')
+assertEqual(refresh.isInternal('LVDS-1'), true, 'refresh rate treats LVDS as internal')
+assertEqual(refresh.isInternal('DSI-1'), true, 'refresh rate treats DSI as internal')
+assertEqual(refresh.isInternal('HDMI-A-1'), false, 'refresh rate treats HDMI as external')
+assertEqual(refresh.isInternal(''), false, 'refresh rate rejects a missing output name')
+
+// Only the modes at the resolution already in use, so a rate change can never
+// also change the resolution.
+assertEqual(
+  refresh.ratesFor(panel).join(','), '60.01,165.02',
+  'refresh rate offers only the rates at the current resolution'
+)
+assertEqual(refresh.ratesFor(null).length, 0, 'refresh rate handles a missing monitor')
+
+assertEqual(refresh.targetRate(panel, false, 60, 50), '165.02', 'refresh rate runs fast on mains above the threshold')
+assertEqual(refresh.targetRate(panel, false, 50, 50), '165.02', 'refresh rate treats the threshold as inclusive')
+assertEqual(refresh.targetRate(panel, false, 49, 50), '60.01', 'refresh rate runs slow on mains below the threshold')
+assertEqual(refresh.targetRate(panel, true, 90, 50), '60.01', 'refresh rate runs slow on battery at any charge')
+// A dead gauge should not pin a plugged-in laptop to its slowest rate forever.
+assertEqual(refresh.targetRate(panel, false, -1, 50), '165.02', 'refresh rate runs fast on mains with an unreadable battery')
+assertEqual(refresh.targetRate(external, true, 10, 50), '59.95', 'refresh rate still resolves a rate for any monitor asked about')
+
+const singleRate = { name: 'eDP-1', width: 1920, height: 1080, availableModes: ['1920x1080@60.00Hz'] }
+assertEqual(refresh.targetRate(singleRate, false, 90, 50), '', 'refresh rate declines a display with nothing to choose')
+
+// Hyprland reports 165.02000 for the mode written as 165.02.
+assertEqual(refresh.needsChange({ refreshRate: 165.02 }, '165.02'), false, 'refresh rate leaves a matching rate alone')
+assertEqual(refresh.needsChange({ refreshRate: 60.008 }, '165.02'), true, 'refresh rate changes a mismatched rate')
+assertEqual(refresh.needsChange({ refreshRate: 143.912 }, '143.91'), false, 'refresh rate compares on the rounded value')
+
+assertEqual(
+  refresh.monitorSpec(panel, '165.02'),
+  'hl.monitor({ output = "eDP-1", mode = "2560x1600@165.02", position = "0x0", scale = 1.6 })',
+  'refresh rate keeps the position and scale it found'
+)
+assertEqual(
+  refresh.monitorSpec({ name: 'eDP-1"; os.execute("x")', width: 1, height: 1, x: 0, y: 0, scale: 1 }, '60'),
+  '',
+  'refresh rate refuses an output name it would have to quote'
+)
+
+// The whole decision, over a real two-display laptop.
+assertEqual(
+  refresh.pendingSpecs([panel, external], false, 80, 50).join('\n'),
+  'hl.monitor({ output = "eDP-1", mode = "2560x1600@165.02", position = "0x0", scale = 1.6 })',
+  'refresh rate drives the internal panel and leaves the external alone'
+)
+assertEqual(
+  refresh.pendingSpecs([{ ...panel, refreshRate: 165.02 }, external], false, 80, 50).length,
+  0,
+  'refresh rate does nothing when the panel is already on the right rate'
+)
+assertEqual(
+  refresh.pendingSpecs([{ ...panel, disabled: true }], false, 80, 50).length,
+  0,
+  'refresh rate skips a disabled panel'
+)
+assertEqual(refresh.pendingSpecs(null, false, 80, 50).length, 0, 'refresh rate handles a missing monitor list')
+JS


### PR DESCRIPTION
A laptop panel that advertises 165 Hz runs at 165 Hz on battery too, and nothing in the shell offers to trade that back for runtime. Setting the rate by hand does not survive either: it lives in `monitors.lua`, so the next reload puts the configured one back.

This adds a service that picks the rate from the power state. On mains it uses the fastest rate the panel advertises for the resolution it is already on. Otherwise it uses the slowest.

## Scope, and what it will not touch

Only rates at the **current resolution** are considered, so the mode cannot change underneath the user. Only **internal** outputs are driven, matched with the same `eDP|LVDS|DSI` test the monitor helpers in `bin/` already use, so external displays are never touched. A panel advertising a single rate is left alone.

It is **off unless asked for**. Changing what someone's display does on battery is not a thing to start doing to them on upgrade.

```json
"refreshRate": { "enabled": true, "threshold": 50 }
```

`threshold` is the charge below which the slow rate applies even on mains, defaulting to 50. A battery that cannot be read only relaxes that threshold rather than forcing the slow rate, so a laptop with a dead gauge still runs fast while plugged in instead of being pinned low forever.

The service follows `UPower.onBattery` from `Quickshell.Services.UPower` for the mains transition, rather than introducing a second source of power state, and re-checks on a minute timer, because charge crossing the threshold is not something UPower raises an event for.

## Relationship to #6402

#6402 adds **manual** refresh-rate control to the Display panel. This is the **automatic** policy, and they are complementary rather than competing: that PR gives you the picker, this one decides when nobody has picked.

They do interact, and it is worth deciding deliberately rather than discovering it. If both land and this service is enabled, a rate chosen by hand from the panel is overwritten on this service's next tick. The clean resolution is for a manual pick to suppress the automatic policy until it is handed back, which is what I do locally, but that belongs in whichever of the two lands second rather than being guessed at here.

#8595 is the same shape applied to idle timeouts, using separate values on AC and battery. If a general "what changes on battery" grouping is wanted in `shell.json` rather than a key per feature, those two are the cases to design it against.

#8695 caps the screensaver's frame rate at the panel's refresh rate. It reads the rate this service changes, so with both in place the screensaver follows the panel down on battery, which is the intended direction and needs nothing from either side.

## Tests

`test/shell.d/refresh-rate-test.sh`, 23 assertions against the pure decision in `RefreshRateModel.js`: the internal-output test, rate extraction at the current resolution only, the threshold being inclusive, the mains requirement holding at any charge, an unreadable battery relaxing rather than forcing, the rounding Hyprland's reported rate needs (`165.02000` against the `165.02` that was asked for), refusing an output name that would have to be quoted into Lua, and the whole decision over a two-display laptop.

Checked that they are load-bearing rather than decorative: removing the internal-output filter fails the two-display assertion, and dropping the mains requirement fails the on-battery one.

Also exercised live rather than only in unit tests: loaded as a plugin against a running shell on a two-display laptop, with the threshold set above the current charge it dropped the panel from 165.02 to 60.01 and left the external on 143.91, and with the threshold below it the panel went back to 165.02.

## 2026-09-01

Rebased onto current `quattro` (b71dcad9) with no conflicts.

- **Report a rate Hyprland refused.** The service applied each spec and dropped the result, so a refused `hyprctl eval` reached neither the user nor the log, and a panel that stayed on its old rate was indistinguishable from the policy deciding not to change it. It now warns with the exit code and whatever hyprctl printed. This is the same failure mode #7036 is about, in a service rather than a panel.
- **Added #8595 and #8695** to the neighbours section. #8595 is the same on-battery policy shape applied to idle timeouts and is the other case to design a shared grouping against; #8695 reads the rate this service writes.
- **Named `Quickshell.Services.UPower` explicitly** as the power-state source, since "follows UPower" did not make clear that this adds no second source of truth.
- `refresh-rate-test.sh` passes on the rebase.
