### PR TITLE
Stop re-sampling the wallpaper for the transparent bar on unrelated state writes

### DIFF
--- a/bin/omarchy-bar-text-color
+++ b/bin/omarchy-bar-text-color
@@ -90,28 +90,41 @@ screen_width=${BASH_REMATCH[1]}
 screen_height=${BASH_REMATCH[2]}
 ((screen_width > 0 && screen_height > 0 && bar_size > 0)) || fallback
 
+# Sample at a reduced scale. The bar strip is averaged down to a single pixel,
+# so the wallpaper does not need to be rendered at full screen resolution
+# first: a 5K screen turned a 7 MP JPEG into ~4 core-seconds across every
+# thread per sample. Shrink the whole geometry by an integer factor instead
+# (never upscale) and let the JPEG decoder skip the detail on the way in.
+scale=$(((screen_width + 511) / 512))
+((scale >= 1)) || scale=1
+sample_width=$((screen_width / scale))
+sample_height=$((screen_height / scale))
+sample_bar=$(((bar_size + scale - 1) / scale))
+((sample_width > 0 && sample_height > 0 && sample_bar > 0)) || fallback
+
 case "$position" in
 top)
-  crop="${screen_width}x${bar_size}+0+0"
+  crop="${sample_width}x${sample_bar}+0+0"
   ;;
 bottom)
-  crop_y=$((screen_height - bar_size))
+  crop_y=$((sample_height - sample_bar))
   ((crop_y >= 0)) || fallback
-  crop="${screen_width}x${bar_size}+0+${crop_y}"
+  crop="${sample_width}x${sample_bar}+0+${crop_y}"
   ;;
 left)
-  crop="${bar_size}x${screen_height}+0+0"
+  crop="${sample_bar}x${sample_height}+0+0"
   ;;
 right)
-  crop_x=$((screen_width - bar_size))
+  crop_x=$((sample_width - sample_bar))
   ((crop_x >= 0)) || fallback
-  crop="${bar_size}x${screen_height}+${crop_x}+0"
+  crop="${sample_bar}x${sample_height}+${crop_x}+0"
   ;;
 esac
 
-pixel=$(magick "$background_path" -auto-orient \
-  -resize "${screen_width}x${screen_height}^" \
-  -gravity center -extent "${screen_width}x${screen_height}" \
+pixel=$(MAGICK_THREAD_LIMIT=2 magick -define "jpeg:size=$((sample_width * 2))x$((sample_height * 2))" \
+  "$background_path" -auto-orient \
+  -resize "${sample_width}x${sample_height}^" \
+  -gravity center -extent "${sample_width}x${sample_height}" \
   -gravity NorthWest -crop "$crop" +repage \
   -resize '1x1!' -format '%[fx:int(255*r)],%[fx:int(255*g)],%[fx:int(255*b)]' info:- 2>/dev/null || true)
 [[ $pixel =~ ^([0-9]+),([0-9]+),([0-9]+)$ ]] || fallback

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -893,6 +893,10 @@ Item {
   Process {
     id: transparentBackgroundProbe
     property bool rerun: false
+    // Resolve once at startup too: FileView reports no change for its initial
+    // load, and without a baseline the first unrelated write would still
+    // compare against "" and sample.
+    running: true
     command: ["readlink", "-f", root.stateHome + "/omarchy/current/background"]
     stdout: StdioCollector {
       onStreamFinished: {

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -870,11 +870,43 @@ Item {
     }
   }
 
+  // omarchy-theme-set and omarchy-theme-bg-set repoint the `current/background`
+  // symlink with `ln -nsf`. FileView cannot watch the link itself: inotify
+  // follows it to the old image, and Quickshell's parent-directory fallback
+  // only fires once the watched file has vanished, so a relink never arrives.
+  // Watching the `current` directory does arrive, but a directory path is never
+  // in the watcher's file set, so every event in ~/.local/state/omarchy lands
+  // here too: any atomic write by any plugin in that directory re-sampled the
+  // wallpaper. Resolve the link and only resample when it actually moved.
+  property string transparentBackgroundPath: ""
+
   FileView {
     path: root.stateHome + "/omarchy/current"
     watchChanges: true
     printErrors: false
-    onFileChanged: root.scheduleTransparentForegroundRefresh()
+    onFileChanged: {
+      if (transparentBackgroundProbe.running) transparentBackgroundProbe.rerun = true
+      else transparentBackgroundProbe.running = true
+    }
+  }
+
+  Process {
+    id: transparentBackgroundProbe
+    property bool rerun: false
+    command: ["readlink", "-f", root.stateHome + "/omarchy/current/background"]
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var path = String(text || "").trim()
+        if (path === root.transparentBackgroundPath) return
+        root.transparentBackgroundPath = path
+        root.scheduleTransparentForegroundRefresh()
+      }
+    }
+    onExited: {
+      if (!rerun) return
+      rerun = false
+      running = true
+    }
   }
 
   function runProcess(process) {

--- a/test/shell.d/bar-text-color-test.sh
+++ b/test/shell.d/bar-text-color-test.sh
@@ -25,6 +25,21 @@ result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --back
 [[ $result == "#ffffff" ]] || fail "transparent bar text keeps text color on dark wallpaper" "expected #ffffff, got $result"
 pass "transparent bar text keeps text color on dark wallpaper"
 
+# Screens wider than 512px are sampled at a reduced scale. A 5K screen with a
+# 26px bar shrinks by 10x, so the strip is a few rows tall: the light band still
+# has to win at the top and the dark band at the bottom. The image shares the
+# screen's aspect so cover-fitting does not crop the band away.
+wide="$TMPDIR/wide.jpg"
+magick -size 2560x1080 xc:'#202020' -fill '#f5f5f5' -draw 'rectangle 0,0 2559,19' "$wide"
+
+result=$(HOME="$TMPDIR" omarchy-bar-text-color top 26 '#ffffff' '#101010' --background "$wide" --screen 5120x2160)
+[[ $result == "#101010" ]] || fail "transparent bar text samples a light strip at reduced scale" "expected #101010, got $result"
+pass "transparent bar text samples a light strip at reduced scale"
+
+result=$(HOME="$TMPDIR" omarchy-bar-text-color bottom 26 '#ffffff' '#101010' --background "$wide" --screen 5120x2160)
+[[ $result == "#ffffff" ]] || fail "transparent bar text samples the bottom strip at reduced scale" "expected #ffffff, got $result"
+pass "transparent bar text samples the bottom strip at reduced scale"
+
 result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$TMPDIR/missing.png" --screen 100x100)
 [[ $result == "#ffffff" ]] || fail "transparent bar text falls back to text color when sampling fails" "expected #ffffff, got $result"
 pass "transparent bar text falls back to text color when sampling fails"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -81,6 +81,22 @@ exit 0
 SH
 chmod +x "$stub_bin/omarchy-update-available"
 
+# The transparent bar samples the wallpaper through this; the test counts the
+# calls to check what does and does not trigger a sample.
+text_color_calls="$TMPDIR/text-color.calls"
+cat >"$stub_bin/omarchy-bar-text-color" <<SH
+#!/bin/bash
+echo "\$*" >>"$text_color_calls"
+echo "#ffffff"
+SH
+chmod +x "$stub_bin/omarchy-bar-text-color"
+
+state_dir="$test_home/.local/state/omarchy"
+mkdir -p "$state_dir/current"
+: >"$state_dir/wallpaper-a.png"
+: >"$state_dir/wallpaper-b.png"
+ln -s "$state_dir/wallpaper-a.png" "$state_dir/current/background"
+
 cat >"$stub_bin/curl" <<'SH'
 #!/bin/bash
 
@@ -362,3 +378,36 @@ jq -e 'all(.bar.layout.right[]; (.id // .) != "omarchy.keyboard-layout")' \
   <<<"$(shell_ipc shell listShellConfig)" >/dev/null ||
   fail_with_log "bar put added a second copy of a widget already on the bar"
 pass "bar put leaves a widget already on the bar alone"
+
+# The bar watches ~/.local/state/omarchy/current for a wallpaper change. That
+# directory watch also fires for every entry created, renamed or removed in the
+# parent directory, so a write by any plugin there must not re-sample the
+# wallpaper, while repointing the background link must.
+text_color_count() {
+  [[ -f $text_color_calls ]] && wc -l <"$text_color_calls" || echo 0
+}
+wait_for_text_color_count() {
+  local want="$1"
+  for _ in {1..50}; do
+    (( $(text_color_count) >= want )) && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+shell_ipc shell toggleBarTransparency >/dev/null
+wait_for_text_color_count 1 || fail_with_log "transparent bar samples the wallpaper when turned on"
+before=$(text_color_count)
+
+printf '{}' >"$state_dir/unrelated.tmp"
+mv "$state_dir/unrelated.tmp" "$state_dir/unrelated.json"
+rm "$state_dir/unrelated.json"
+sleep 1
+(( $(text_color_count) == before )) ||
+  fail_with_log "unrelated writes to the state directory must not re-sample the wallpaper (was $before, now $(text_color_count))"
+pass "unrelated state writes leave the transparent bar alone"
+
+ln -nsf "$state_dir/wallpaper-b.png" "$state_dir/current/background"
+wait_for_text_color_count $((before + 1)) ||
+  fail_with_log "repointing the background link must re-sample the wallpaper (still $(text_color_count))"
+pass "background link changes re-sample the transparent bar"


### PR DESCRIPTION
## What

The transparent bar re-sampled the wallpaper with ImageMagick every time *anything* was written atomically into `~/.local/state/omarchy`, not just when the background changed. On a 5K display each sample cost ~2.6 core-seconds across every thread.

## Why it happened

`Bar.qml` watched `~/.local/state/omarchy/current` with `FileView { watchChanges: true }`. Quickshell's `FileView` adds both the path and its parent directory to a `QFileSystemWatcher`, and in `onWatchedDirectoryChanged` it re-emits `fileChanged` whenever the path is missing from `watcher->files()`. A directory is never in that set, so every create/rename/delete in `~/.local/state/omarchy` fired the handler.

Any plugin that saves state there with tmp + rename (the safe way) became a trigger. On my machine one plugin saving every 10 s held **~40% of a core for the whole session**. It never shows up in quickshell's own CPU figure because `magick` is a reaped grandchild.

Reproduced with a standalone `quickshell -p` probe: a `FileView` on the `current` directory fires on `touch ~/.local/state/omarchy/x`, `mv x.tmp x` and `rm x`; in-place appends and writes in subdirectories do not.

## Why not watch the symlink

Also tried in the probe: a `FileView` on `current/background` never fires when `ln -nsf` repoints the link to a different image (which is what `omarchy-theme-bg-set` and `omarchy-theme-set` do). inotify follows the link to the old inode and the parent-directory fallback only fires once the watched file has vanished. So the directory watch stays, and the handler now runs `readlink -f` and only refreshes when the resolved path actually moved.

## Cheaper sampling too

`omarchy-bar-text-color` rendered the wallpaper at full screen resolution before cropping the bar strip and averaging it to one pixel. It now shrinks the whole geometry by an integer factor (never upscales) and gives the JPEG decoder a size hint so it skips the detail on the way in.

| | user+sys per sample |
|---|---|
| before | 2.58 s |
| after | 0.065 s |

(2912x1632 JPEG at 5120x2160, 10-run average, identical result `#cacccc`.) Both scripts agree on every fixture in `test/shell.d/bar-text-color-test.sh`, which gains two reduced-scale cases.

## Checks

- `./test/shell`: bar-text-color 5/5; the only failures in the full run are the `omarchy-pkgs` checkout / network-guard tests that need a sibling checkout
- `qmllint shell/plugins/bar/Bar.qml` clean
