### PR TITLE
Add tiled window equalization

### DIFF
--- a/bin/omarchy-hyprland-window-equalize
+++ b/bin/omarchy-hyprland-window-equalize
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+# omarchy:summary=Equalize tiled windows on the active workspace
+
+set -euo pipefail
+
+lua_quote() {
+  jq -Rn --arg value "$1" '$value'
+}
+
+ensure_workspace() {
+  local current
+  current=$(hyprctl activeworkspace -j)
+
+  [[ $(jq -r '.id' <<<"$current") == "$workspace_id" ]] &&
+    [[ $(jq -r '.tiledLayout // empty' <<<"$current") == "dwindle" ]]
+}
+
+dispatch() {
+  local result
+
+  ensure_workspace
+  result=$(hyprctl dispatch "$1")
+  [[ $result == "ok" ]]
+}
+
+move_window() {
+  local address="$1"
+  local workspace="$2"
+
+  dispatch "hl.dsp.window.move({ window = $(lua_quote "address:$address"), workspace = $(lua_quote "$workspace"), follow = false })"
+}
+
+focus_window() {
+  dispatch "hl.dsp.focus({ window = $(lua_quote "address:$1") })"
+}
+
+layout_message() {
+  dispatch "hl.dsp.layout($(lua_quote "$1"))"
+}
+
+workspace=$(hyprctl activeworkspace -j)
+workspace_id=$(jq -r '.id' <<<"$workspace")
+workspace_name=$(jq -r '.name' <<<"$workspace")
+workspace_layout=$(jq -r '.tiledLayout // empty' <<<"$workspace")
+
+if [[ $workspace_layout != "dwindle" ]]; then
+  echo "Equalizing windows requires a Dwindle workspace" >&2
+  exit 1
+fi
+
+if [[ -z ${XDG_RUNTIME_DIR:-} ]]; then
+  echo "XDG_RUNTIME_DIR is required for window equalization" >&2
+  exit 1
+fi
+
+lock_file="$XDG_RUNTIME_DIR/omarchy-window-equalize.lock"
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  echo "Window equalization is already running" >&2
+  exit 1
+fi
+
+clients=$(hyprctl clients -j)
+unsafe_fullscreen=$(jq -r --argjson workspace "$workspace_id" '
+  any(.[];
+    .workspace.id == $workspace and
+    .mapped == true and
+    .floating == false and
+    ((.fullscreen // 0) != 0 or (.fullscreenClient // 0) != 0)
+  )
+' <<<"$clients")
+
+if [[ $unsafe_fullscreen == "true" ]]; then
+  echo "Exit fullscreen before equalizing windows" >&2
+  exit 1
+fi
+
+unsafe_grouped=$(jq -r --argjson workspace "$workspace_id" '
+  any(.[];
+    .workspace.id == $workspace and
+    .mapped == true and
+    .floating == false and
+    ((.grouped // []) | length > 0)
+  )
+' <<<"$clients")
+
+if [[ $unsafe_grouped == "true" ]]; then
+  echo "Move windows out of groups before equalizing them" >&2
+  exit 1
+fi
+
+mapfile -t windows < <(jq -r --argjson workspace "$workspace_id" '
+  [.[]
+    | select(.workspace.id == $workspace and .mapped == true and .floating == false)
+    | { address, x: .at[0], y: .at[1] }]
+  | sort_by(.x, .y)
+  | .[].address
+' <<<"$clients")
+
+count=${#windows[@]}
+(( count >= 2 )) || exit 0
+
+case $count in
+2) columns=2 ;;
+3) columns=3 ;;
+4) columns=2 ;;
+*)
+  columns=1
+  while ((columns * columns < count)); do
+    columns=$((columns + 1))
+  done
+  ;;
+esac
+
+base=$((count / columns))
+extra=$((count % columns))
+declare -a column_sizes column_starts representatives
+index=0
+for ((column = 0; column < columns; column++)); do
+  size=$base
+  if ((column < extra)); then
+    size=$((size + 1))
+  fi
+
+  column_sizes[column]=$size
+  column_starts[column]=$index
+  representatives[column]=${windows[index]}
+  index=$((index + size))
+done
+
+active=$(hyprctl activewindow -j | jq -r '.address // empty')
+if [[ -z $active ]]; then
+  active=${representatives[0]}
+fi
+
+temporary="special:equalize-$$"
+destination="name:$workspace_name"
+rebuilding=false
+
+rollback_on_failure() {
+  local status=$?
+
+  if ((status != 0)) && [[ $rebuilding == "true" ]]; then
+    set +e
+    for window in "${windows[@]}"; do
+      hyprctl dispatch "hl.dsp.window.move({ window = $(lua_quote "address:$window"), workspace = $(lua_quote "$destination"), follow = false })" >/dev/null
+    done
+    hyprctl dispatch "hl.dsp.focus({ workspace = $(lua_quote "$destination") })" >/dev/null
+    if [[ -n $active ]]; then
+      hyprctl dispatch "hl.dsp.focus({ window = $(lua_quote "address:$active") })" >/dev/null
+    fi
+  fi
+
+  exit "$status"
+}
+trap rollback_on_failure EXIT
+rebuilding=true
+
+for window in "${windows[@]}"; do
+  move_window "$window" "$temporary"
+done
+
+move_window "${representatives[0]}" "$destination"
+focus_window "${representatives[0]}"
+for ((column = 1; column < columns; column++)); do
+  focus_window "${representatives[column - 1]}"
+  layout_message "preselect r"
+  move_window "${representatives[column]}" "$destination"
+done
+
+remaining=$count
+for ((column = 0; column < columns - 1; column++)); do
+  size=${column_sizes[column]}
+  ratio=$(printf '%.8f' "$(jq -nr --argjson part "$size" --argjson total "$remaining" '$part * 2 / $total')")
+  focus_window "${representatives[column]}"
+  layout_message "splitratio $ratio exact"
+  remaining=$((remaining - size))
+done
+
+for ((column = 0; column < columns; column++)); do
+  start=${column_starts[column]}
+  size=${column_sizes[column]}
+
+  for ((row = 1; row < size; row++)); do
+    previous=${windows[start + row - 1]}
+    current=${windows[start + row]}
+    focus_window "$previous"
+    layout_message "preselect d"
+    move_window "$current" "$destination"
+  done
+
+  remaining=$size
+  for ((row = 0; row < size - 1; row++)); do
+    ratio=$(printf '%.8f' "$(jq -nr --argjson total "$remaining" '2 / $total')")
+    focus_window "${windows[start + row]}"
+    layout_message "splitratio $ratio exact"
+    remaining=$((remaining - 1))
+  done
+done
+
+focus_window "$active"
+rebuilding=false

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -3,6 +3,7 @@ o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + E", "Equalize tiled windows", "omarchy-hyprland-window-equalize")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/test/shell.d/hyprland-window-equalize-test.sh
+++ b/test/shell.d/hyprland-window-equalize-test.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+runtime="$tmpdir/runtime"
+mkdir -p "$runtime"
+export XDG_RUNTIME_DIR="$runtime"
+
+cat >"$tmpdir/hyprctl" <<'BASH'
+#!/bin/bash
+
+case "$1 $2" in
+"activeworkspace -j")
+  if [[ -n ${HYPR_SWITCH_COUNTER:-} ]]; then
+    count=0
+    [[ -f $HYPR_SWITCH_COUNTER ]] && count=$(<"$HYPR_SWITCH_COUNTER")
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$HYPR_SWITCH_COUNTER"
+    if ((count > ${HYPR_SWITCH_AFTER:-999999})); then
+      printf '%s\n' '{"id":2,"name":"2","tiledLayout":"dwindle"}'
+      exit 0
+    fi
+  fi
+
+  if [[ -n ${HYPR_WORKSPACE:-} ]]; then
+    printf '%s\n' "$HYPR_WORKSPACE"
+  else
+    printf '%s\n' '{"id":1,"name":"1","tiledLayout":"dwindle"}'
+  fi
+  ;;
+"activewindow -j")
+  if [[ -n ${HYPR_ACTIVE_WINDOW:-} ]]; then
+    printf '%s\n' "$HYPR_ACTIVE_WINDOW"
+  else
+    printf '%s\n' '{"address":"0xa"}'
+  fi
+  ;;
+"clients -j")
+  printf '%s\n' "$HYPR_CLIENTS"
+  ;;
+"dispatch "*)
+  printf '%s\n' "$2" >>"$HYPRCTL_LOG"
+  if [[ -n ${HYPR_FAIL_ON_MATCH:-} && $2 == *"$HYPR_FAIL_ON_MATCH"* && ! -e ${HYPR_FAIL_MARKER:-/nonexistent} ]]; then
+    touch "$HYPR_FAIL_MARKER"
+    printf '%s\n' 'error: simulated dispatcher failure'
+  else
+    printf '%s\n' ok
+  fi
+  ;;
+*)
+  exit 1
+  ;;
+esac
+BASH
+chmod +x "$tmpdir/hyprctl"
+
+cat >"$tmpdir/flock" <<'BASH'
+#!/bin/bash
+
+if [[ ${HYPR_FLOCK_FAIL:-false} == "true" ]]; then
+  exit 1
+fi
+BASH
+chmod +x "$tmpdir/flock"
+
+clients='[
+  {"address":"0xa","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[0,0]},
+  {"address":"0xb","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[0,500]},
+  {"address":"0xc","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[500,0]},
+  {"address":"0xd","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[500,500]}
+]'
+log="$tmpdir/hyprctl.log"
+
+unset_runtime_error="$tmpdir/unset-runtime-error"
+if env -u XDG_RUNTIME_DIR PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>"$unset_runtime_error"; then
+  fail "equalize refuses to use a shared temporary lock path without XDG_RUNTIME_DIR"
+fi
+grep -Fqx 'XDG_RUNTIME_DIR is required for window equalization' "$unset_runtime_error" ||
+  fail "missing XDG_RUNTIME_DIR reports why equalization cannot start"
+[[ ! -s $log ]] || fail "missing-runtime rejection happens before moving windows"
+pass "equalize fails closed when XDG_RUNTIME_DIR is unavailable"
+
+>"$log"
+
+PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize"
+
+(( $(grep -c 'workspace = "special:equalize-' "$log") == 4 )) ||
+  fail "equalize moves every tiled window through a temporary workspace"
+(( $(grep -c 'workspace = "name:1"' "$log") == 4 )) ||
+  fail "equalize returns every tiled window to its original workspace"
+(( $(grep -c 'hl.dsp.layout("preselect r")' "$log") == 1 )) ||
+  fail "four-window grid creates two columns"
+(( $(grep -c 'hl.dsp.layout("preselect d")' "$log") == 2 )) ||
+  fail "four-window grid creates two rows per column"
+(( $(grep -c 'hl.dsp.layout("splitratio 1' "$log") == 3 )) ||
+  fail "four-window grid centers every split"
+grep -Fqx 'hl.dsp.focus({ window = "address:0xa" })' "$log" ||
+  fail "equalize restores the previously focused window"
+pass "four tiled windows become an equal two-by-two grid"
+
+clients='[
+  {"address":"0xa","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[0,0]},
+  {"address":"0xb","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[500,0]},
+  {"address":"0xc","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[1000,0]}
+]'
+>"$log"
+
+PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize"
+
+(( $(grep -c 'hl.dsp.layout("preselect r")' "$log") == 2 )) ||
+  fail "three-window grid creates three columns"
+(( $(grep -c 'hl.dsp.layout("preselect d")' "$log" || true) == 0 )) ||
+  fail "three-window grid does not create rows"
+grep -Fqx 'hl.dsp.layout("splitratio 0.66666667 exact")' "$log" ||
+  fail "three-window grid gives the first column one third of the width"
+grep -Fqx 'hl.dsp.layout("splitratio 1.00000000 exact")' "$log" ||
+  fail "three-window grid divides the remaining width equally"
+pass "three tiled windows become three equal columns"
+
+>"$log"
+scrolling='{"id":1,"name":"1","tiledLayout":"scrolling"}'
+if PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" HYPR_WORKSPACE="$scrolling" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>/dev/null; then
+  fail "equalize rejects non-Dwindle workspaces"
+fi
+[[ ! -s $log ]] || fail "non-Dwindle rejection happens before moving windows"
+pass "equalize rejects non-Dwindle workspaces before moving windows"
+
+unsafe_clients='[
+  {"address":"0xa","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":2,"fullscreenClient":2,"grouped":[],"at":[0,0]},
+  {"address":"0xb","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[500,0]}
+]'
+>"$log"
+if PATH="$tmpdir:$PATH" HYPR_CLIENTS="$unsafe_clients" HYPRCTL_LOG="$log" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>/dev/null; then
+  fail "equalize rejects fullscreen tiled windows"
+fi
+[[ ! -s $log ]] || fail "fullscreen rejection happens before moving windows"
+pass "equalize rejects fullscreen tiled windows before moving windows"
+
+grouped_clients='[
+  {"address":"0xa","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":["0xa","0xb"],"at":[0,0]},
+  {"address":"0xb","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":["0xa","0xb"],"at":[500,0]}
+]'
+>"$log"
+if PATH="$tmpdir:$PATH" HYPR_CLIENTS="$grouped_clients" HYPRCTL_LOG="$log" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>/dev/null; then
+  fail "equalize rejects grouped tiled windows"
+fi
+[[ ! -s $log ]] || fail "grouped-window rejection happens before moving windows"
+pass "equalize rejects grouped tiled windows before moving windows"
+
+>"$log"
+fail_marker="$tmpdir/dispatch-failed"
+if PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" \
+  HYPR_FAIL_ON_MATCH='preselect r' HYPR_FAIL_MARKER="$fail_marker" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>/dev/null; then
+  fail "equalize reports a dispatcher failure"
+fi
+for address in 0xa 0xb 0xc; do
+  grep -Fq "window = \"address:$address\", workspace = \"name:1\"" "$log" ||
+    fail "failed equalize returns $address to the original workspace"
+done
+grep -Fqx 'hl.dsp.focus({ window = "address:0xa" })' "$log" ||
+  fail "failed equalize restores the original focus"
+pass "dispatcher failure rolls every window back to the original workspace"
+
+>"$log"
+switch_counter="$tmpdir/workspace-queries"
+if PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" \
+  HYPR_SWITCH_COUNTER="$switch_counter" HYPR_SWITCH_AFTER=3 \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>/dev/null; then
+  fail "equalize aborts when the active workspace changes"
+fi
+grep -Fqx 'hl.dsp.focus({ workspace = "name:1" })' "$log" ||
+  fail "workspace-switch rollback returns to the original workspace"
+pass "workspace switch aborts equalization and rolls windows back"
+
+>"$log"
+if PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" XDG_RUNTIME_DIR="$runtime" HYPR_FLOCK_FAIL=true \
+  "$ROOT/bin/omarchy-hyprland-window-equalize" 2>/dev/null; then
+  fail "equalize rejects a concurrent run"
+fi
+[[ ! -s $log ]] || fail "concurrent-run rejection happens before moving windows"
+pass "equalize rejects concurrent runs across workspaces"
+
+five_clients='[
+  {"address":"0xa","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[0,0]},
+  {"address":"0xb","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[0,500]},
+  {"address":"0xc","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[500,0]},
+  {"address":"0xd","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[500,500]},
+  {"address":"0xe","workspace":{"id":1},"mapped":true,"floating":false,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[1000,0]},
+  {"address":"0xf","workspace":{"id":1},"mapped":true,"floating":true,"fullscreen":0,"fullscreenClient":0,"grouped":[],"at":[200,200]}
+]'
+>"$log"
+PATH="$tmpdir:$PATH" HYPR_CLIENTS="$five_clients" HYPRCTL_LOG="$log" XDG_RUNTIME_DIR="$runtime" \
+  "$ROOT/bin/omarchy-hyprland-window-equalize"
+
+(( $(grep -c 'workspace = "special:equalize-' "$log") == 5 )) ||
+  fail "five-window grid moves only the five tiled windows"
+! grep -Fq 'address:0xf' "$log" || fail "equalize leaves floating windows untouched"
+(( $(grep -c 'hl.dsp.layout("preselect r")' "$log") == 2 )) ||
+  fail "five-window grid creates three columns"
+(( $(grep -c 'hl.dsp.layout("preselect d")' "$log") == 2 )) ||
+  fail "five-window grid creates two stacked columns"
+grep -Fqx 'hl.dsp.layout("splitratio 0.80000000 exact")' "$log" ||
+  fail "five-window grid sizes the first column by its window count"
+grep -Fqx 'hl.dsp.layout("splitratio 1.33333333 exact")' "$log" ||
+  fail "five-window grid sizes the second column by its window count"
+pass "five tiled windows receive equal areas while floating windows stay untouched"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPR_CLIENTS="$five_clients" HYPRCTL_LOG="$log" HYPR_ACTIVE_WINDOW='{"address":"0xf"}' \
+  "$ROOT/bin/omarchy-hyprland-window-equalize"
+mapfile -t dispatches <"$log"
+last_dispatch=${dispatches[${#dispatches[@]} - 1]}
+[[ $last_dispatch == 'hl.dsp.focus({ window = "address:0xf" })' ]] ||
+  fail "equalize restores focus to an untouched floating window"
+pass "equalize preserves focus on an untouched floating window"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPR_CLIENTS="$clients" HYPRCTL_LOG="$log" HYPR_ACTIVE_WINDOW='{}' \
+  "$ROOT/bin/omarchy-hyprland-window-equalize"
+! grep -Fq 'window = "address:"' "$log" ||
+  fail "equalize never dispatches an empty focus selector"
+grep -Fqx 'hl.dsp.focus({ window = "address:0xa" })' "$log" ||
+  fail "equalize falls back to the first tiled window when focus has no address"
+pass "missing active-window address falls back to the first tiled window"
+
+grep -Fqx 'o.bind("SUPER + E", "Equalize tiled windows", "omarchy-hyprland-window-equalize")' \
+  "$ROOT/default/hypr/bindings/tiling.lua" ||
+  fail "Super + E exposes equalize in the default keybindings"
+pass "Super + E exposes equalize in the default keybindings"


### PR DESCRIPTION
## Summary

- add `omarchy-hyprland-window-equalize` to rebuild the active Dwindle workspace as an equal-area grid
- bind the action to `Super + E` and expose it through the existing keybinding viewer
- preserve tiled-window ordering and focus while leaving floating windows untouched
- reject fullscreen, grouped, non-Dwindle, concurrent, and workspace-switch cases safely
- roll every captured window back if a Hyprland dispatcher fails

## Layout behavior

- 2 windows: two equal columns
- 3 windows: three equal columns
- 4 windows: equal 2×2 grid
- 5+ windows: compact near-square grid with equal area per tiled window

## Testing

- `bash test/shell.d/hyprland-window-equalize-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- `bash test/shell.d/bin-style-test.sh`
- `./test/cli`
- `./test/all`
- live Hyprland 0.56.2 visual verification with four temporary Foot windows

The live four-window test produced four identical `1181×643` tiles, restored the original focus/workspace, and left no temporary workspace behind. The before/after captures were inspected for overlap and clipping.

## Safety and scope

The helper requires `XDG_RUNTIME_DIR`, uses a compositor-wide advisory lock there, and fails closed rather than falling back to shared `/tmp`. It revalidates the active workspace before every mutation. An exit trap moves all captured windows back to the original workspace on failures. Floating windows are intentionally excluded but retain focus when active; fullscreen and grouped tiled windows are rejected because moving them could alter state the helper cannot faithfully preserve.

Suggestion: https://github.com/basecamp/omarchy/discussions/8306
