### PR TITLE
Add workspace compaction command

### DIFF
--- a/bin/omarchy-hyprland-workspace-compact
+++ b/bin/omarchy-hyprland-workspace-compact
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# omarchy:summary=Close gaps between occupied workspace numbers
+
+set -euo pipefail
+
+clients_json=$(hyprctl clients -j)
+active_workspace=$(hyprctl activeworkspace -j | jq -r '.id')
+[[ $active_workspace =~ ^-?[0-9]+$ ]] || exit 1
+
+commands=()
+active_destination=
+
+# Build every move from a single client snapshot. Special workspaces are
+# excluded, and only workspaces containing windows participate in compaction.
+while IFS=$'\t' read -r source_workspace destination_workspace address; do
+  if ((source_workspace == active_workspace)); then
+    active_destination=$destination_workspace
+  fi
+
+  if ((source_workspace != destination_workspace)); then
+    commands+=("dispatch hl.dsp.window.move({ workspace = \"$destination_workspace\", follow = false, window = \"address:$address\" })")
+  fi
+done < <(
+  jq -r '
+    [.[] | select(.workspace.id > 0)]
+    | sort_by(.workspace.id)
+    | group_by(.workspace.id)
+    | to_entries[]
+    | (.key + 1) as $destination
+    | .value[]
+    | [.workspace.id, $destination, .address]
+    | @tsv
+  ' <<<"$clients_json"
+)
+
+if [[ -n $active_destination ]] && ((active_workspace != active_destination)); then
+  commands+=("dispatch hl.dsp.focus({ workspace = \"$active_destination\" })")
+fi
+
+if ((${#commands[@]} > 0)); then
+  printf -v batch '%s;' "${commands[@]}"
+  hyprctl --batch "${batch%;}" >/dev/null
+fi

--- a/test/shell.d/hyprland-workspace-compact-test.sh
+++ b/test/shell.d/hyprland-workspace-compact-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+mkdir -p "$TEST_ROOT/bin"
+
+cat >"$TEST_ROOT/bin/hyprctl" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$HYPRCTL_CALLS"
+
+case "$1 $2" in
+  "clients -j")
+    printf '%s\n' '[
+      {"address":"0x1","workspace":{"id":1}},
+      {"address":"0x2","workspace":{"id":3}},
+      {"address":"0x3","workspace":{"id":3}},
+      {"address":"0x4","workspace":{"id":7}},
+      {"address":"0x5","workspace":{"id":-99}}
+    ]'
+    ;;
+  "activeworkspace -j")
+    printf '%s\n' '{"id":7}'
+    ;;
+  "--batch "*) ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$TEST_ROOT/bin/hyprctl"
+
+export HYPRCTL_CALLS="$TEST_ROOT/hyprctl-calls"
+PATH="$TEST_ROOT/bin:$PATH" "$ROOT/bin/omarchy-hyprland-workspace-compact"
+
+mapfile -t calls <"$HYPRCTL_CALLS"
+[[ ${#calls[@]} == 3 ]] || fail "workspace compaction uses three hyprctl calls" "${calls[*]}"
+[[ ${calls[0]} == "clients -j" ]] || fail "workspace compaction reads clients once" "${calls[0]}"
+[[ ${calls[1]} == "activeworkspace -j" ]] || fail "workspace compaction reads the active workspace once" "${calls[1]}"
+
+batch=${calls[2]}
+[[ $batch == "--batch "* ]] || fail "workspace compaction sends one dispatch batch" "$batch"
+[[ $batch == *'address:0x2'* ]] || fail "workspace compaction moves the first window from a gapped workspace"
+[[ $batch == *'address:0x3'* ]] || fail "workspace compaction moves every window from a gapped workspace"
+[[ $batch == *'address:0x4'* ]] || fail "workspace compaction moves later occupied workspaces"
+[[ $batch != *'address:0x1'* ]] || fail "workspace compaction leaves already compact windows alone"
+[[ $batch != *'address:0x5'* ]] || fail "workspace compaction leaves special workspaces alone"
+[[ $batch == *'workspace = "3"'*'hl.dsp.focus'* ]] || fail "workspace compaction follows the renumbered active workspace" "$batch"
+
+pass "workspace compaction batches window moves and preserves workspace behavior"


### PR DESCRIPTION
## What

Add `omarchy hyprland workspace compact` to close gaps between occupied numbered workspaces while leaving special workspaces untouched. If the active workspace is renumbered, focus follows it.

## Why

Closing applications can leave gaps in the numbered workspace sequence. Compacting those workspaces currently requires a custom script or manually moving every window.

The command takes one client snapshot, computes the complete move plan in one `jq` pass, and sends all moves through one `hyprctl --batch` call. Its compositor interaction is constant: two state reads plus one batched dispatch instead of one dispatch process per moved window.

## Tests

- `./test/shell.d/hyprland-workspace-compact-test.sh`
- `./test/cli`
- `git diff --check`

The test verifies batching, multiple windows in one workspace, active-workspace focus, no-op windows, and exclusion of special workspaces.