### PR TITLE
Show UPower device batteries in Bluetooth panel

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -74,6 +74,24 @@ function bluetoothSinkMatchesDevice(node, device) {
   return label !== "" && text.indexOf(label) !== -1
 }
 
+function deviceBatteryPercentage(device, powerDevices) {
+  if (!device) return null
+  if (device.batteryAvailable) return Math.round(Number(device.battery || 0) * 100)
+
+  var address = normalizedAddress(device.address)
+  if (address === "") return null
+
+  var devices = toArray(powerDevices)
+  for (var i = 0; i < devices.length; i++) {
+    var powerDevice = devices[i]
+    if (!powerDevice || !powerDevice.ready || !powerDevice.isPresent) continue
+    if (normalizedAddress(powerDevice.nativePath).indexOf(address) === -1) continue
+    return Math.round(Number(powerDevice.percentage || 0) * 100)
+  }
+
+  return null
+}
+
 function sortedByLabel(devices) {
   var list = toArray(devices)
   list.sort(function(a, b) { return deviceLabel(a).localeCompare(deviceLabel(b)) })
@@ -165,6 +183,7 @@ if (typeof module !== "undefined") {
     nodeProps: nodeProps,
     nodeText: nodeText,
     bluetoothSinkMatchesDevice: bluetoothSinkMatchesDevice,
+    deviceBatteryPercentage: deviceBatteryPercentage,
     sortedByLabel: sortedByLabel,
     deviceRow: deviceRow,
     deviceLists: deviceLists,

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Bluetooth
 import Quickshell.Services.Pipewire
+import Quickshell.Services.UPower
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
@@ -30,6 +31,7 @@ Panel {
   // never this panel's to stop.
   property bool owesDiscoveryStop: false
   readonly property var devices: Bluetooth.devices ? Bluetooth.devices.values : []
+  readonly property var upowerDevices: UPower.devices ? UPower.devices.values : []
   readonly property var pipewireNodes: Pipewire.nodes ? Pipewire.nodes.values : []
   property var pendingAudioOutputDevice: null
   property int pendingAudioOutputAttempts: 0
@@ -911,7 +913,8 @@ Panel {
       if (action === "forgetting") return "Forgetting…"
       if (action === "disconnecting" || devState === 2) return "Disconnecting…"
       if (isConnected) {
-        if (dev.batteryAvailable) return Math.round(dev.battery * 100) + "%"
+        var batteryPercentage = Model.deviceBatteryPercentage(dev, root.upowerDevices)
+        if (batteryPercentage !== null) return batteryPercentage + "%"
         return sectionName === "connected" ? "" : "Connected"
       }
       if (action === "connecting" || devState === 3 || dev.pairing === true) return "Connecting…"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -140,6 +140,33 @@ assert(
   !bluetooth.bluetoothSinkMatchesDevice({ isSink: false, isStream: false, ready: true, name: 'bluez_output.AA_BB_CC_DD_EE_FF.1', properties: {} }, { address: 'AA:BB:CC:DD:EE:FF', name: 'JBL Go 3' }),
   'bluetooth ignores non-sink nodes when matching audio outputs'
 )
+
+const upowerKeyboard = {
+  ready: true,
+  isPresent: true,
+  nativePath: 'hid-04:69:f8:cd:4e:ea-battery-144',
+  percentage: 0.03
+}
+assertEqual(
+  bluetooth.deviceBatteryPercentage({ address: '04:69:F8:CD:4E:EA' }, [upowerKeyboard]),
+  3,
+  'bluetooth falls back to a matching UPower device battery'
+)
+assertEqual(
+  bluetooth.deviceBatteryPercentage({ address: '04:69:F8:CD:4E:EA', batteryAvailable: true, battery: 0.75 }, [upowerKeyboard]),
+  75,
+  'bluetooth prefers its native battery reading over UPower'
+)
+assertEqual(
+  bluetooth.deviceBatteryPercentage({ address: 'AA:BB:CC:DD:EE:FF' }, [upowerKeyboard]),
+  null,
+  'bluetooth ignores UPower devices with a different address'
+)
+assertEqual(
+  bluetooth.deviceBatteryPercentage({ address: '04:69:F8:CD:4E:EA' }, [{ ...upowerKeyboard, ready: false }]),
+  null,
+  'bluetooth ignores UPower devices that are not ready'
+)
 JS
 
 # Turning Bluetooth off is an rfkill soft block, not a bluetoothctl power off,


### PR DESCRIPTION
## Why?

I noticed that when I connected some keyboards via bluetooth, the battery charge was not displaying in the bluetooth widget and I really wanted to know what the battery charge level was in my keyboard. My mouse battery charge displayed without issue. There began the trot down the rabbit hole. 

Now I know how much charge my keyboard has.

Before
<img width="731" height="824" alt="keyboard_without_battery" src="https://github.com/user-attachments/assets/f8bd5662-a55a-490d-b3bf-9a74b7511e8a" />

After
<img width="447" height="349" alt="keyboard_with_battery" src="https://github.com/user-attachments/assets/f458ca21-2404-4fa6-b624-0dc092311405" />

## What changed

- Fall back to UPower when a connected Bluetooth device does not expose BlueZ Battery1 data.
- Match UPower HID batteries to Bluetooth devices by normalized address.
- Keep native BlueZ battery readings as the preferred source.
- Add focused model tests for fallback matching, source precedence, mismatches, and unready devices.

## Testing

- `bash test/shell.d/bluetooth-test.sh`
- `./test/shell` reached 180 of 184 passing test files. Three failures require the absent `omarchy-pkgs` checkout. The unrelated `network-qr-test.sh` passed when rerun alone.
- Loaded the exact source files in the running Omarchy Bluetooth widget and visually confirmed the Apple keyboard battery displays as `3%` beneath the device name without clipping or layout changes.