### PR TITLE
Add Vim style navigation to Menu, Clipboard, Emoji & Image-Picker

### DIFF
--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -373,6 +373,10 @@ Item {
           } else if (event.key === Qt.Key_Down) {
             root.select(1)
             event.accepted = true
+          } else if ((event.key === Qt.Key_J || event.key === Qt.Key_K) && (event.modifiers & Qt.ControlModifier)) {
+            // Ctrl+J / Ctrl+K mirror Down / Up for vim-style list navigation.
+            root.select(event.key === Qt.Key_J ? 1 : -1)
+            event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {
             root.select(-6)
             event.accepted = true

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -215,6 +215,14 @@ Item {
           } else if (event.key === Qt.Key_Down) {
             root.selectRow(1)
             event.accepted = true
+          } else if ((event.key === Qt.Key_H || event.key === Qt.Key_L) && (event.modifiers & Qt.ControlModifier)) {
+            // Ctrl+H / Ctrl+L mirror Left / Right in the grid.
+            root.select(event.key === Qt.Key_L ? 1 : -1)
+            event.accepted = true
+          } else if ((event.key === Qt.Key_J || event.key === Qt.Key_K) && (event.modifiers & Qt.ControlModifier)) {
+            // Ctrl+J / Ctrl+K mirror Down / Up for vim-style grid navigation.
+            root.selectRow(event.key === Qt.Key_J ? 1 : -1)
+            event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {
             root.selectPage(-1)
             event.accepted = true

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -426,6 +426,10 @@ Item {
             } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab) {
               root.selectAdjacent(1)
               event.accepted = true
+            } else if ((event.key === Qt.Key_H || event.key === Qt.Key_L) && (event.modifiers & Qt.ControlModifier)) {
+              // Ctrl+H / Ctrl+L mirror Left / Right for vim-style grid navigation.
+              root.selectAdjacent(event.key === Qt.Key_L ? 1 : -1)
+              event.accepted = true
             } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
               root.updateFilter(root.filterText + event.text)
               event.accepted = true

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1136,7 +1136,7 @@ Item {
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
+          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left || (event.key === Qt.Key_H && (event.modifiers & Qt.ControlModifier))) && !root.filterText) {
             root.goBack()
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {
@@ -1145,13 +1145,17 @@ Item {
           } else if (event.key === Qt.Key_Down) {
             root.select(1)
             event.accepted = true
+          } else if ((event.key === Qt.Key_J || event.key === Qt.Key_K) && (event.modifiers & Qt.ControlModifier)) {
+            // Ctrl+J / Ctrl+K mirror Down / Up for vim-style menu navigation.
+            root.select(event.key === Qt.Key_J ? 1 : -1)
+            event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {
             root.select(-6)
             event.accepted = true
           } else if (event.key === Qt.Key_PageDown) {
             root.select(6)
             event.accepted = true
-          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right) {
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right || (event.key === Qt.Key_L && (event.modifiers & Qt.ControlModifier))) {
             if (root.dmenuActive) {
               if (root.mode === "input") root.applyDmenuSelection(root.filterText)
               else if (displayModel.count > 0) root.activateIndex(root.cursorActive ? root.selectedIndex : 0)

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -143,6 +143,10 @@ assert(
   'clipboard End selects the last entry'
 )
 assert(
+  /Qt\.Key_J \|\| event\.key === Qt\.Key_K\) && \(event\.modifiers & Qt\.ControlModifier\)[\s\S]*root\.select\(event\.key === Qt\.Key_J \? 1 : -1\)/.test(clipboardQml),
+  'clipboard Ctrl+J and Ctrl+K mirror Down and Up selection'
+)
+assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(clipboardQml),
   'clipboard uses shared pointer movement gate in card coordinates'
 )

--- a/test/shell.d/emojis-test.sh
+++ b/test/shell.d/emojis-test.sh
@@ -9,11 +9,21 @@ const fs = require('fs')
 const emojis = requireFromRoot('shell/plugins/emojis/EmojiSearch.js')
 
 const raw = fs.readFileSync(path.join(root, 'shell/plugins/emojis/emojis.json'), 'utf8')
+const emojiQml = fs.readFileSync(path.join(root, 'shell/plugins/emojis/Emojis.qml'), 'utf8')
 const data = emojis.parseEmojis(raw)
 
 assert(data.length > 1000, 'emoji dataset parses')
 assertDeepEqual(emojis.parseEmojis('{'), [], 'invalid emoji JSON parses as empty list')
 assertDeepEqual(emojis.parseEmojis('{"e":"nope"}'), [], 'non-array emoji JSON parses as empty list')
+
+assert(
+  /Qt\.Key_H \|\| event\.key === Qt\.Key_L\) && \(event\.modifiers & Qt\.ControlModifier\)[\s\S]*root\.select\(event\.key === Qt\.Key_L \? 1 : -1\)/.test(emojiQml),
+  'emoji grid Ctrl+H and Ctrl+L mirror Left and Right'
+)
+assert(
+  /Qt\.Key_J \|\| event\.key === Qt\.Key_K\) && \(event\.modifiers & Qt\.ControlModifier\)[\s\S]*root\.selectRow\(event\.key === Qt\.Key_J \? 1 : -1\)/.test(emojiQml),
+  'emoji grid Ctrl+J and Ctrl+K mirror Down and Up rows'
+)
 
 const fixture = [
   { e: 'a', k: 'grinning face smile happy' },

--- a/test/shell.d/image-picker-test.sh
+++ b/test/shell.d/image-picker-test.sh
@@ -51,4 +51,8 @@ assert(
   /source: item\.sourceActivated && item\.thumbnailPath \? Util\.fileUrl\(item\.thumbnailPath\) : ""[\s\S]*asynchronous: false/.test(imagePickerQml),
   'image picker loads activated thumbnails synchronously to avoid carousel flicker'
 )
+assert(
+  /Qt\.Key_H \|\| event\.key === Qt\.Key_L\) && \(event\.modifiers & Qt\.ControlModifier\)[\s\S]*root\.selectAdjacent\(event\.key === Qt\.Key_L \? 1 : -1\)/.test(imagePickerQml),
+  'image picker Ctrl+H and Ctrl+L mirror Left and Right'
+)
 JS

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -490,8 +490,16 @@ assert(
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
-  /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
-  'menu Left key follows empty-filter Backspace navigation'
+  /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left \|\| \(event\.key === Qt\.Key_H && \(event\.modifiers & Qt\.ControlModifier\)\)\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
+  'menu Left or Ctrl+H follows empty-filter Backspace navigation'
+)
+assert(
+  /Qt\.Key_J \|\| event\.key === Qt\.Key_K\) && \(event\.modifiers & Qt\.ControlModifier\)[\s\S]*root\.select\(event\.key === Qt\.Key_J \? 1 : -1\)/.test(menuQml),
+  'menu Ctrl+J and Ctrl+K mirror Down and Up selection'
+)
+assert(
+  /Qt\.Key_Return \|\| event\.key === Qt\.Key_Enter \|\| event\.key === Qt\.Key_Right \|\| \(event\.key === Qt\.Key_L && \(event\.modifiers & Qt\.ControlModifier\)\)/.test(menuQml),
+  'menu Ctrl+L activates like Right'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),


### PR DESCRIPTION
## What

Adds control-modified vim navigation keys alongside the existing arrow-key handling in four launcher surfaces:

| Panel        | New keys                                                                                              |
| ------------ | ----------------------------------------------------------------------------------------------------- |
| Menu         | `Ctrl+J/K` select, `Ctrl+L` activate (like Right), `Ctrl+H` back (like Left, same empty-filter guard) |
| Clipboard    | `Ctrl+J/K` move selection                                                                             |
| Emojis       | `Ctrl+J/K` row jumps, `Ctrl+H/L` within-row steps                                                     |
| Image picker | `Ctrl+H/L` previous/next image                                                                        |

All new branches are gated on `Qt.ControlModifier`, so unmodified letters continue to reach each panel's search filter exactly as before. Existing arrow/PageUp/Home/End behavior is untouched.

## Testing

- `test/shell.d/menu-test.sh`, `clipboard-test.sh`, `emojis-test.sh`,
  `image-picker-test.sh` pass, including seven new assertions covering every
  added branch
- Manually exercised against the running shell: navigation in all four
  panels, filter typing unaffected, dmenu mode intact
