### PR TITLE
Menu recalls position on pressing back

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -71,6 +71,7 @@ Item {
   property var items: ({})
   property var itemOrder: []
   property var navStack: []
+  property var originIndex: ({})
   property var providersLoaded: ({})
   property var providerQueue: []
   property int providerRevision: 0
@@ -726,13 +727,13 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoreIndex) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
     if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
     root.activeMenu = id
     root.filterText = ""
-    root.selectedIndex = 0
+    root.selectedIndex = (typeof restoreIndex === "number" && restoreIndex > 0) ? restoreIndex : 0
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
     else root.disarmPointer()
@@ -747,12 +748,13 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous, false)
+      root.setActiveMenu(previous, false, false, root.originIndex[previous])
       return true
     }
 
     var active = root.item(root.activeMenu)
-    root.setActiveMenu((active && active.parent) ? active.parent : "root", false)
+    var parentId = (active && active.parent) ? active.parent : "root"
+    root.setActiveMenu(parentId, false, false, root.originIndex[parentId])
     return true
   }
 
@@ -773,6 +775,9 @@ Item {
 
     var row = displayModel.get(index)
     if (row.kind === "menu" || row.kind === "link") {
+      // Remember where each descent leaves the parent so Back can restore it.
+      // Search-result indices do not map onto the parent list, so skip them.
+      if (!root.filterText) root.originIndex[root.activeMenu] = index
       root.setActiveMenu(row.target || row.itemId, true, fromPointer)
     } else if (row.kind === "app") {
       var appId = row.appId
@@ -842,6 +847,7 @@ Item {
     doneFile = ""
     activeMenu = root.item(initialMenu) ? initialMenu : "root"
     navStack = []
+    originIndex = ({})
     filterText = ""
     selectedIndex = 0
     cursorActive = true
@@ -870,6 +876,7 @@ Item {
     dmenuMaxHeight = Math.max(0, Number(payload.maxHeight || 0))
     activeMenu = "root"
     navStack = []
+    originIndex = ({})
     filterText = ""
     selectedIndex = 0
     cursorActive = mode !== "input"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -486,8 +486,32 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoreIndex\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
+)
+assert(
+  /property var navStack: \[\]\s*\n\s*property var originIndex: \(\{\}\)/.test(menuQml),
+  'menu tracks the row each menu was left from'
+)
+assert(
+  /root\.selectedIndex = \(typeof restoreIndex === "number" && restoreIndex > 0\) \? restoreIndex : 0/.test(menuQml),
+  'menu restores a remembered row instead of restarting at the top'
+)
+assert(
+  /if \(row\.kind === "menu" \|\| row\.kind === "link"\) \{[\s\S]*?if \(!root\.filterText\) root\.originIndex\[root\.activeMenu\] = index[\s\S]*?root\.setActiveMenu\(row\.target \|\| row\.itemId, true, fromPointer\)/.test(menuQml),
+  'menu records the descent row, skipping search results'
+)
+assert(
+  /root\.setActiveMenu\(previous, false, false, root\.originIndex\[previous\]\)/.test(menuQml),
+  'menu Back returns to the remembered parent row via the navigation stack'
+)
+assert(
+  /var parentId = \(active && active\.parent\) \? active\.parent : "root"\s*\n\s*root\.setActiveMenu\(parentId, false, false, root\.originIndex\[parentId\]\)/.test(menuQml),
+  'menu Back restores the parent row even without stack history'
+)
+assert(
+  /navStack = \[\]\s*\n\s*originIndex = \(\{\}\)/.test(menuQml),
+  'menu fresh opens forget stored positions'
 )
 assert(
   /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),


### PR DESCRIPTION
## What

Remembering where you were: opening a submenu used to restart selection at its top, and returning with Left/Backspace dropped you at the top of the parent too — so any trip below the root lost your place. Now every descent records the row it left behind, and Back restores it:

- `activateIndex` stores the child index a `menu`/`link` row was opened
  from, keyed by the parent route. Search results are skipped: their
  indices belong to the flattened result list and mean nothing to the
  parent menu.
- `goBack` hands the remembered index back through `setActiveMenu`, which
  takes an optional `restoreIndex`. Every other caller keeps the old
  top-of-menu default.
- Both open paths clear the memory next to the navigation stack reset, so
  a freshly summoned menu still starts at the top.

Rows that shrink between visits (provider menus re-evaluate their guards) are bounded by the existing post-rebuild clamp, so a stale index can land on the wrong row at worst — never out of range.

## Why

Drilling into Setup > Defaults > Browser and backing out meant finding your place in Setup again by hand. Position memory is the difference between Back meaning "where I was" and "the top, again".

## Notes

- Independent of #8318 (vim-style navigation): same file, disjoint hunks,
  neither blocks the other. Whichever merges second may need a trivial
  rebase of `menu-test.sh`.

## Testing

- `test/shell.d/menu-test.sh` passes (127 assertions), including seven new
  ones covering the property, the filter-guarded recording, restore
  behavior on both back paths, and the open-path resets.
- Manually against the running shell: descend via keyboard and mouse,
  Back returns to the origin row; provider menus clamp safely;
  search-descents record nothing; close/reopen starts fresh.
