### PR TITLE
Decode the wallpaper at screen size instead of shipped size

### DIFF
--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -25,6 +25,13 @@ Item {
   property string pendingColorsRaw: ""
   property string pendingShellRaw: ""
   property real revealProgress: 1
+  // Native pixel size per wallpaper path, read from the file header before
+  // the image loads. Decoding at screen size only saves memory for wallpapers
+  // at least as large as the screen: with PreserveAspectCrop Qt scales the
+  // decode up to cover sourceSize, so a smaller wallpaper would cost the
+  // screen's worth of pixels instead of its own.
+  property var nativeSizes: ({})
+  property var sizeQueue: []
 
   function imageUrl(path) {
     return Util.fileUrl(path)
@@ -43,6 +50,8 @@ Item {
     finalPath = String(finalPath || path).trim()
     fromPath = String(fromPath || "").trim()
     if (!path || (!force && finalPath === currentBackground)) return
+    requestNativeSize(path)
+    requestNativeSize(fromPath)
     currentBackground = finalPath
     backgroundVersion += 1
     revealStartedVersion = -1
@@ -100,6 +109,19 @@ Item {
     revealAnimation.restart()
   }
 
+  function requestNativeSize(path) {
+    if (!path || nativeSizes[path] !== undefined || sizeQueue.indexOf(path) !== -1) return
+    sizeQueue = sizeQueue.concat([path])
+    probeNextSize()
+  }
+
+  function probeNextSize() {
+    if (sizeProbe.running || sizeQueue.length === 0) return
+    sizeProbe.path = sizeQueue[0]
+    sizeProbe.command = ["magick", "identify", "-ping", "-format", "%w %h", sizeProbe.path]
+    sizeProbe.running = true
+  }
+
   function openSelector() {
     if (!bgSwitchProc.running) bgSwitchProc.running = true
   }
@@ -118,6 +140,23 @@ Item {
     id: themeSwitchProc
     command: ["bash", "-c", "theme=$(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\" >/dev/null 2>&1 &"]
     onExited: root.refreshBackground()
+  }
+
+  Process {
+    id: sizeProbe
+    property string path: ""
+    stdout: StdioCollector { id: sizeProbeOut }
+    onExited: function(exitCode) {
+      var parts = String(sizeProbeOut.text || "").trim().split(/\s+/)
+      var width = exitCode === 0 ? parseInt(parts[0], 10) : 0
+      var height = exitCode === 0 ? parseInt(parts[1], 10) : 0
+      var known = Object.assign({}, root.nativeSizes)
+      // An unreadable header records 0x0, which decodes at screen size.
+      known[path] = { width: width > 0 ? width : 0, height: height > 0 ? height : 0 }
+      root.nativeSizes = known
+      root.sizeQueue = root.sizeQueue.filter(function(queued) { return queued !== sizeProbe.path })
+      root.probeNextSize()
+    }
   }
 
   Process {
@@ -195,10 +234,20 @@ Item {
       // screen. Stock wallpapers go up to 10456x3455 (144 MB as RGBA); a
       // 1080p laptop paid all of that for the 8 MB it can display, and paid
       // it up to three times over during a transition. The images wait for
-      // the window's size so nothing is ever decoded at native size first.
+      // the window's size and the wallpaper's native size so nothing is ever
+      // decoded at native size first, and a wallpaper smaller than the screen
+      // is decoded at its own size rather than scaled up to cover the screen.
       readonly property bool sized: width > 0 && height > 0
       readonly property int decodeWidth: sized ? Math.ceil(width * screen.devicePixelRatio) : 0
       readonly property int decodeHeight: sized ? Math.ceil(height * screen.devicePixelRatio) : 0
+
+      function decodeSize(path) {
+        if (!sized || !path) return Qt.size(0, 0)
+        var native = root.nativeSizes[path]
+        if (native === undefined) return Qt.size(0, 0)
+        if (native.width > 0 && (native.width < decodeWidth || native.height < decodeHeight)) return Qt.size(native.width, native.height)
+        return Qt.size(decodeWidth, decodeHeight)
+      }
 
       ScreenMoveRemap {
         id: remapGuard
@@ -232,9 +281,10 @@ Item {
       Image {
         id: base
         anchors.fill: parent
-        source: panel.sized ? root.imageUrl(root.displayedBackground) : ""
-        sourceSize.width: panel.decodeWidth
-        sourceSize.height: panel.decodeHeight
+        readonly property size decode: panel.decodeSize(root.displayedBackground)
+        source: decode.width > 0 ? root.imageUrl(root.displayedBackground) : ""
+        sourceSize.width: decode.width
+        sourceSize.height: decode.height
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: true
@@ -250,9 +300,10 @@ Item {
       Image {
         id: oldFrame
         anchors.fill: parent
-        source: panel.sized ? root.imageUrl(root.oldBackground) : ""
-        sourceSize.width: panel.decodeWidth
-        sourceSize.height: panel.decodeHeight
+        readonly property size decode: panel.decodeSize(root.oldBackground)
+        source: decode.width > 0 ? root.imageUrl(root.oldBackground) : ""
+        sourceSize.width: decode.width
+        sourceSize.height: decode.height
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: false
@@ -278,9 +329,10 @@ Item {
         Image {
           id: incomingFrame
           anchors.fill: parent
-          source: panel.sized ? root.imageUrl(root.incomingBackground) : ""
-          sourceSize.width: panel.decodeWidth
-          sourceSize.height: panel.decodeHeight
+          readonly property size decode: panel.decodeSize(root.incomingBackground)
+          source: decode.width > 0 ? root.imageUrl(root.incomingBackground) : ""
+          sourceSize.width: decode.width
+          sourceSize.height: decode.height
           fillMode: Image.PreserveAspectCrop
           asynchronous: true
           cache: false

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -189,6 +189,17 @@ Item {
       visible: !remapGuard.remapping
       anchors { top: true; bottom: true; left: true; right: true }
 
+      // Decode the wallpaper at the size this screen can show, not the size
+      // it was shipped at. With PreserveAspectCrop Qt takes sourceSize as the
+      // area to cover, so this is the smallest decode that still fills the
+      // screen. Stock wallpapers go up to 10456x3455 (144 MB as RGBA); a
+      // 1080p laptop paid all of that for the 8 MB it can display, and paid
+      // it up to three times over during a transition. The images wait for
+      // the window's size so nothing is ever decoded at native size first.
+      readonly property bool sized: width > 0 && height > 0
+      readonly property int decodeWidth: sized ? Math.ceil(width * screen.devicePixelRatio) : 0
+      readonly property int decodeHeight: sized ? Math.ceil(height * screen.devicePixelRatio) : 0
+
       ScreenMoveRemap {
         id: remapGuard
         window: panel
@@ -221,7 +232,9 @@ Item {
       Image {
         id: base
         anchors.fill: parent
-        source: root.imageUrl(root.displayedBackground)
+        source: panel.sized ? root.imageUrl(root.displayedBackground) : ""
+        sourceSize.width: panel.decodeWidth
+        sourceSize.height: panel.decodeHeight
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: true
@@ -237,7 +250,9 @@ Item {
       Image {
         id: oldFrame
         anchors.fill: parent
-        source: root.imageUrl(root.oldBackground)
+        source: panel.sized ? root.imageUrl(root.oldBackground) : ""
+        sourceSize.width: panel.decodeWidth
+        sourceSize.height: panel.decodeHeight
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: false
@@ -263,7 +278,9 @@ Item {
         Image {
           id: incomingFrame
           anchors.fill: parent
-          source: root.imageUrl(root.incomingBackground)
+          source: panel.sized ? root.imageUrl(root.incomingBackground) : ""
+          sourceSize.width: panel.decodeWidth
+          sourceSize.height: panel.decodeHeight
           fillMode: Image.PreserveAspectCrop
           asynchronous: true
           cache: false

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -18,4 +18,18 @@ assert(
     !backgroundQml.includes('pendingThemeVersion !== backgroundVersion'),
   'background theme transition applies pending colors even if image reveal stalls'
 )
+
+// The wallpaper is decoded at the screen's physical size, never at the size
+// the file was shipped at, and never at native size first.
+assert(
+  backgroundQml.includes('readonly property bool sized: width > 0 && height > 0') &&
+    backgroundQml.includes('readonly property int decodeWidth: sized ? Math.ceil(width * screen.devicePixelRatio) : 0') &&
+    backgroundQml.includes('readonly property int decodeHeight: sized ? Math.ceil(height * screen.devicePixelRatio) : 0'),
+  'background derives its decode size from the screen in physical pixels'
+)
+
+const count = (needle) => backgroundQml.split(needle).length - 1
+assertEqual(count('sourceSize.width: panel.decodeWidth'), 3, 'all three wallpaper images bound their decode width to the screen')
+assertEqual(count('sourceSize.height: panel.decodeHeight'), 3, 'all three wallpaper images bound their decode height to the screen')
+assertEqual(count('source: panel.sized ? root.imageUrl('), 3, 'all three wallpaper images wait for the window size before loading')
 JS

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -20,16 +20,21 @@ assert(
 )
 
 // The wallpaper is decoded at the screen's physical size, never at the size
-// the file was shipped at, and never at native size first.
+// it was shipped at, unless it is smaller than the screen: then it is decoded
+// at its own size instead of being scaled up to cover the screen.
 assert(
   backgroundQml.includes('readonly property bool sized: width > 0 && height > 0') &&
     backgroundQml.includes('readonly property int decodeWidth: sized ? Math.ceil(width * screen.devicePixelRatio) : 0') &&
     backgroundQml.includes('readonly property int decodeHeight: sized ? Math.ceil(height * screen.devicePixelRatio) : 0'),
   'background derives its decode size from the screen in physical pixels'
 )
-
+assert(
+  backgroundQml.includes('["magick", "identify", "-ping", "-format", "%w %h", sizeProbe.path]') &&
+    backgroundQml.includes('if (native.width > 0 && (native.width < decodeWidth || native.height < decodeHeight)) return Qt.size(native.width, native.height)'),
+  'background reads the wallpaper header and never decodes larger than the native size'
+)
 const count = (needle) => backgroundQml.split(needle).length - 1
-assertEqual(count('sourceSize.width: panel.decodeWidth'), 3, 'all three wallpaper images bound their decode width to the screen')
-assertEqual(count('sourceSize.height: panel.decodeHeight'), 3, 'all three wallpaper images bound their decode height to the screen')
-assertEqual(count('source: panel.sized ? root.imageUrl('), 3, 'all three wallpaper images wait for the window size before loading')
+assertEqual(count('sourceSize.width: decode.width'), 3, 'all three wallpaper images bind their decode width')
+assertEqual(count('sourceSize.height: decode.height'), 3, 'all three wallpaper images bind their decode height')
+assertEqual(count('source: decode.width > 0 ? root.imageUrl('), 3, 'all three wallpaper images wait for the screen and native sizes before loading')
 JS


### PR DESCRIPTION
## What

`Background.qml` loads the wallpaper with no `sourceSize`, so Qt decodes it at the resolution the file was shipped at, once per screen, and holds up to three of those during a transition (`base`, `oldFrame`, `incomingFrame`).

30 of the 92 stock wallpapers decode to 60 MB or more as RGBA. The four 7680×4320 ones are 132 MB each; `5-zen-boat.jpg` at 10456×3455 is 144 MB. A 1080p laptop pays all of that for the 8 MB it can display.

## Fix

Bind `sourceSize` on the three images to the screen's physical size (`width * screen.devicePixelRatio`). With `PreserveAspectCrop`, Qt takes `sourceSize` as the area to *cover*, so this is the smallest decode that still fills the screen (a 16:9 file on a 16:9 screen decodes to exactly the screen; an ultrawide file decodes to screen height and whatever width that implies). The images wait for the window to be sized so nothing is ever decoded at native size first.

## Measured

Real shell from this checkout, sandboxed `HOME`, 5120×2880 screen (scale 2), stock `1-twisted-stairs.jpg` (7680×4320), PSS from `smaps_rollup`, two runs each:

| | before | after |
|---|---|---|
| steady state | 432 / 436 MB | 362 / 366 MB |
| peak during a transition (`3-mountain-moon` → `2-layers-deep`) | 682 MB | 498 MB |

Standalone Quickshell with a single fullscreen `Image` of the same file, isolating the decode from the rest of the shell:

| decode | PSS |
|---|---|
| native 7680×4320 | 326 MB |
| covering 5120×2880 | 262 MB |
| covering 3840×2160 | 278 MB* |
| covering 1920×1080 | 224 MB |

\* the window is still 5K in that row; the point is the trend. On a 1080p panel the saving is about 100 MB per copy, so up to 300 MB at the transition peak.

## Smaller-than-screen wallpapers

With `PreserveAspectCrop`, Qt scales the decode *up* as well as down to cover `sourceSize`, so a wallpaper smaller than the screen would cost the screen's worth of pixels instead of its own. On a 2880×1920 panel a 2912×1632 file decoded to 3426×1920 and the running shell measured 39 MB more PSS than before this change.

So the native size is read from the file header first (`magick identify -ping`, 10-30 ms, no decode), and the screen-size decode is only used when the file is at least screen-sized in both dimensions; otherwise it decodes at native size. An unreadable header falls back to the screen-size decode.

Isolated Quickshell with the real plugin, 2880×1920 panel, three runs each:

| wallpaper | screen-size decode only | with the native cap |
|---|---|---|
| 2912×1632 | 253-263 MB (decoded 3426×1920) | 220-224 MB (decoded 2912×1632) |
| 6000×4000 | 257 MB (decoded 2880×1920) | 257 MB (decoded 2880×1920) |

## Checks

- `test/shell.d/background-test.sh` green
- `qmllint` gives the same result on this file before and after (it exits 255 with no diagnostics on the original too on my machine, so I could not use it as a gate here)
- both sandboxed runs log the same two warnings (portal app id, polkit listener), before and after

