### PR TITLE
Pin new tray icons when Always show is on

### DIFF
--- a/manual/42-common-tweaks.md
+++ b/manual/42-common-tweaks.md
@@ -6,7 +6,7 @@ If you screw something up, you can restore individual configs to their original 
 
 ### Reveal all tray icons all the time
 
-By default, tray icons, like Dropbox, 1password, or Steam, are hidden behind the tray expander arrow, which reveals them when you hover it. If you'd like to have them exposed all the time, right-click the expander arrow to open the tray icon manager, then pin the icons you want to keep visible (you can also hide the ones you never want to see).
+By default, tray icons, like Dropbox, 1password, or Steam, are hidden behind the tray expander arrow, which reveals them when you hover it. If you'd like to have them exposed all the time, right-click the expander arrow to open the tray icon manager and turn on **Always show**. New apps then stay visible instead of landing in the drawer. You can still pin, unpin, or hide individual icons.
 
 ### Rounded window corners
 

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -74,6 +74,8 @@ Example `shell.json` (bar subtree only shown):
 
 The `omarchy.indicators` widget loads individual bar indicators from `indicators/`. Omit `items` (or set it to an empty array) to show all indicators in the default order, or set `items` to a subset such as `["Dnd", "Reminder", "NightLight"]`. Set `alwaysShow` to `true` to keep inactive indicators visible instead of revealing them only on hover. Multiple `omarchy.indicators` instances are allowed, so different sections can show different subsets.
 
+The `omarchy.tray` widget hides new StatusNotifier icons in the hover drawer unless they are pinned. Set `pinNew` to `true`, or turn on **Always show** in the right-click manager, so new icons stay visible. Hidden icons stay hidden; unpin still sends an icon back to the drawer.
+
 ## Orientation
 
 All widgets work in `top`, `bottom`, `left`, and `right` positions. Popups anchor on the side opposite the bar edge, sliding into the workspace. Vertical bars use 28px width; widgets that show text fall back to compact icon-only forms (e.g. `media` hides its scrolling label).

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -20,6 +20,8 @@ BarWidget {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property var pinnedIds: settings.pinned instanceof Array ? settings.pinned : []
   readonly property var hiddenIds: settings.hidden instanceof Array ? settings.hidden : []
+  readonly property var unpinnedIds: settings.unpinned instanceof Array ? settings.unpinned : []
+  readonly property bool pinNew: setting("pinNew", false) === true
   readonly property var pinnedItems: bucket("pinned")
   readonly property var drawerItems: bucket("drawer")
   readonly property var allItems: bucket("all")
@@ -153,10 +155,12 @@ BarWidget {
   }
 
   function classifyItem(item) {
-    var iid = String(item.id || "")
-    if (hiddenIds.indexOf(iid) !== -1) return "hidden"
-    if (pinnedIds.indexOf(iid) !== -1) return "pinned"
-    return "drawer"
+    return TrayModel.classifyItem(item, {
+      pinnedIds: root.pinnedIds,
+      hiddenIds: root.hiddenIds,
+      unpinnedIds: root.unpinnedIds,
+      pinNew: root.pinNew
+    })
   }
 
   function ownedByOmarchy(item) {
@@ -180,34 +184,27 @@ BarWidget {
     return result
   }
 
-  function persistTrayState(pinned, hidden) {
+  function persistTrayState(pinned, hidden, unpinned, pinNew) {
     if (!root.bar || !root.bar.shell || typeof root.bar.shell.updateEntryInline !== "function") return
     var id = root.moduleName || "omarchy.tray"
-    root.bar.shell.updateEntryInline(id, { id: id, pinned: pinned, hidden: hidden })
+    var entry = { id: id, pinned: pinned, hidden: hidden }
+    if (pinNew === true) entry.pinNew = true
+    if (unpinned instanceof Array && unpinned.length > 0) entry.unpinned = unpinned
+    root.bar.shell.updateEntryInline(id, entry)
   }
 
   function togglePin(iid) {
-    var p = pinnedIds.slice(), h = hiddenIds.slice()
-    var idx = p.indexOf(iid)
-    if (idx !== -1) p.splice(idx, 1)
-    else {
-      p.push(iid)
-      var hi = h.indexOf(iid)
-      if (hi !== -1) h.splice(hi, 1)
-    }
-    persistTrayState(p, h)
+    var next = TrayModel.togglePin(iid, root.pinnedIds, root.unpinnedIds, root.hiddenIds, root.pinNew)
+    persistTrayState(next.pinned, next.hidden, next.unpinned, root.pinNew)
   }
 
   function toggleHide(iid) {
-    var p = pinnedIds.slice(), h = hiddenIds.slice()
-    var idx = h.indexOf(iid)
-    if (idx !== -1) h.splice(idx, 1)
-    else {
-      h.push(iid)
-      var pi = p.indexOf(iid)
-      if (pi !== -1) p.splice(pi, 1)
-    }
-    persistTrayState(p, h)
+    var next = TrayModel.toggleHide(iid, root.pinnedIds, root.unpinnedIds, root.hiddenIds)
+    persistTrayState(next.pinned, next.hidden, next.unpinned, root.pinNew)
+  }
+
+  function togglePinNew() {
+    persistTrayState(root.pinnedIds.slice(), root.hiddenIds.slice(), root.unpinnedIds.slice(), !root.pinNew)
   }
 
   visible: pinnedItems.length > 0 || drawerCount > 0
@@ -426,6 +423,16 @@ BarWidget {
         width: parent.width
       }
 
+      Toggle {
+        width: parent.width
+        label: "Always show"
+        description: "New apps stay visible instead of landing in the drawer."
+        checked: root.pinNew
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        onClicked: root.togglePinNew()
+      }
+
       Text {
         visible: root.allItems.length === 0
         text: "No tray items reporting."
@@ -454,7 +461,7 @@ BarWidget {
             var slash = id.lastIndexOf("/")
             return slash !== -1 ? id.substring(slash + 1) : (id || "Unknown")
           }
-          readonly property bool isPinned: root.pinnedIds.indexOf(itemId) !== -1
+          readonly property bool isPinned: root.classifyItem(modelData) === "pinned"
           readonly property bool isHidden: root.hiddenIds.indexOf(itemId) !== -1
 
           TrayIcon {

--- a/shell/plugins/bar/widgets/TrayModel.js
+++ b/shell/plugins/bar/widgets/TrayModel.js
@@ -38,11 +38,86 @@ function ownedByOmarchy(item, layout) {
     || (layoutHasWidget(layout, "omarchy.dropbox") && itemNamed(item, "dropbox"))
 }
 
+function listHas(list, id) {
+  return list instanceof Array && list.indexOf(id) !== -1
+}
+
+function copyList(list) {
+  return list instanceof Array ? list.slice() : []
+}
+
+function removeId(list, id) {
+  var next = copyList(list)
+  var idx = next.indexOf(id)
+  if (idx !== -1) next.splice(idx, 1)
+  return next
+}
+
+function addId(list, id) {
+  var next = copyList(list)
+  if (next.indexOf(id) === -1) next.push(id)
+  return next
+}
+
+function itemId(item) {
+  if (typeof item === "string") return item
+  return String((item && item.id) || "")
+}
+
+// hidden > pinned > unpinned > default. The default is the drawer unless
+// pinNew is on, in which case unknown (not hidden, not explicitly unpinned)
+// items stay visible. unpinned exists so Unpin still works when pinNew is on.
+function classifyItem(item, opts) {
+  var iid = itemId(item)
+  var hidden = (opts && opts.hiddenIds) || []
+  var pinned = (opts && opts.pinnedIds) || []
+  var unpinned = (opts && opts.unpinnedIds) || []
+  var pinNew = !!(opts && opts.pinNew)
+  if (listHas(hidden, iid)) return "hidden"
+  if (listHas(pinned, iid)) return "pinned"
+  if (listHas(unpinned, iid)) return "drawer"
+  return pinNew ? "pinned" : "drawer"
+}
+
+function togglePin(iid, pinned, unpinned, hidden, pinNew) {
+  var opts = { pinnedIds: pinned, unpinnedIds: unpinned, hiddenIds: hidden, pinNew: pinNew }
+  if (classifyItem(iid, opts) === "pinned") {
+    return {
+      pinned: removeId(pinned, iid),
+      unpinned: addId(unpinned, iid),
+      hidden: copyList(hidden)
+    }
+  }
+  return {
+    pinned: addId(pinned, iid),
+    unpinned: removeId(unpinned, iid),
+    hidden: removeId(hidden, iid)
+  }
+}
+
+function toggleHide(iid, pinned, unpinned, hidden) {
+  if (listHas(hidden, iid)) {
+    return {
+      pinned: copyList(pinned),
+      unpinned: copyList(unpinned),
+      hidden: removeId(hidden, iid)
+    }
+  }
+  return {
+    pinned: removeId(pinned, iid),
+    unpinned: removeId(unpinned, iid),
+    hidden: addId(hidden, iid)
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     itemNamed: itemNamed,
     entryId: entryId,
     layoutHasWidget: layoutHasWidget,
-    ownedByOmarchy: ownedByOmarchy
+    ownedByOmarchy: ownedByOmarchy,
+    classifyItem: classifyItem,
+    togglePin: togglePin,
+    toggleHide: toggleHide
   }
 }

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -23,4 +23,25 @@ assert(tray.ownedByOmarchy({ id: 'dropbox' }, layout), 'tray suppresses dropbox 
 assert(!tray.ownedByOmarchy({ id: 'dropbox' }, { left: [], center: [], right: [] }), 'tray keeps dropbox when dedicated widget is absent')
 assert(tray.ownedByOmarchy({ id: 'qlBCprNUqU', title: 'localsend' }, { left: [], center: [], right: [] }), 'tray suppresses localsend regardless of layout')
 assert(!tray.ownedByOmarchy({ id: 'nextcloud' }, layout), 'tray keeps unrelated tray items')
+
+const empty = { pinnedIds: [], hiddenIds: [], unpinnedIds: [], pinNew: false }
+assert(tray.classifyItem({ id: 'steam' }, empty) === 'drawer', 'unknown items go in the drawer by default')
+assert(tray.classifyItem({ id: 'steam' }, { ...empty, pinNew: true }) === 'pinned', 'pinNew shows unknown items')
+assert(tray.classifyItem({ id: 'steam' }, { ...empty, hiddenIds: ['steam'], pinNew: true }) === 'hidden', 'hidden wins over pinNew')
+assert(tray.classifyItem({ id: 'steam' }, { ...empty, unpinnedIds: ['steam'], pinNew: true }) === 'drawer', 'explicit unpin stays in the drawer when pinNew is on')
+assert(tray.classifyItem({ id: 'steam' }, { ...empty, pinnedIds: ['steam'] }) === 'pinned', 'pinned items stay visible with pinNew off')
+
+const pinned = tray.togglePin('steam', [], [], [], true)
+assertDeepEqual(pinned.unpinned, ['steam'], 'unpinning a pinNew item records it as unpinned')
+assertDeepEqual(pinned.pinned, [], 'unpinning a pinNew item does not leave it in pinned')
+assert(tray.classifyItem({ id: 'steam' }, { pinnedIds: pinned.pinned, hiddenIds: pinned.hidden, unpinnedIds: pinned.unpinned, pinNew: true }) === 'drawer', 'unpin still works when pinNew is on')
+
+const repinned = tray.togglePin('steam', pinned.pinned, pinned.unpinned, pinned.hidden, true)
+assertDeepEqual(repinned.pinned, ['steam'], 'pinning an unpinned item adds it to pinned')
+assertDeepEqual(repinned.unpinned, [], 'pinning an unpinned item clears unpinned')
+
+const hidden = tray.toggleHide('steam', ['steam'], [], [])
+assertDeepEqual(hidden.hidden, ['steam'], 'hide records the item as hidden')
+assertDeepEqual(hidden.pinned, [], 'hide removes the item from pinned')
+assert(tray.classifyItem({ id: 'steam' }, { pinnedIds: hidden.pinned, hiddenIds: hidden.hidden, unpinnedIds: hidden.unpinned, pinNew: true }) === 'hidden', 'hidden still hides when pinNew is on')
 JS


### PR DESCRIPTION
Follow-up to https://github.com/basecamp/omarchy/discussions/8321.

The tray manager can pin or hide individual icons, but new StatusNotifier items still land in the hover drawer until each one is pinned. This adds an opt-in so **new tray items stay visible**.

- Default is unchanged: unknown icons still go in the drawer.
- Right-click the chevron → **Always show** (off by default). That writes `pinNew: true` on the `omarchy.tray` layout entry; `shell.json` works too.
- Hidden icons stay hidden.
- Unpin still works when Always show is on (those ids go in `unpinned` so they are not immediately re-pinned).

Precedent: `omarchy.indicators` already has `alwaysShow`.