### PR TITLE
Read Claude limits with a sibling CLI's token when the saved one lapsed

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -21,7 +21,9 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import time
@@ -35,6 +37,19 @@ AGENT_NAME = "Claude Code"
 AUTH_HELP = "Run `claude auth login` to restore authoritative usage."
 USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage"
 PROBE_MIN_INTERVAL_SECONDS = 15
+
+# Claude Code is not the only client that signs into a Claude subscription,
+# but it is the only one that refreshes ~/.claude/.credentials.json. A machine
+# that codes through pi or omp — whose sessions this collector already counts
+# — therefore keeps a live credential in that tool's own store and a lapsed
+# copy in Claude's. Both print an access token on demand, refreshing it first
+# when it has lapsed, so ask them before reporting that the limits cannot be
+# read. Nothing travels the other way: Anthropic rotates a refresh token when
+# it is spent, so a display widget must never spend another tool's.
+SIBLING_TOKEN_COMMANDS = (
+  ("omp", "token", "anthropic"),
+  ("pi", "token", "anthropic"),
+)
 
 
 def config_dir() -> Path:
@@ -603,6 +618,30 @@ def plan_label(tier: str, subscription: str) -> str:
   return ""
 
 
+# The first sibling CLI that is installed and signed in wins. Every failure is
+# quiet and moves on to the next: a CLI that is absent, signed out, or too old
+# to know the subcommand is the ordinary case on most machines, not a fault
+# worth printing next to the usage numbers.
+def sibling_access_token() -> str:
+  for name, *arguments in SIBLING_TOKEN_COMMANDS:
+    binary = shutil.which(name)
+    if binary is None:
+      continue
+    try:
+      result = subprocess.run([binary, *arguments], capture_output=True, text=True, timeout=20)
+    except Exception:
+      continue
+    if result.returncode != 0:
+      continue
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    token = lines[-1] if lines else ""
+    # The token is the whole output on success; anything else — a prompt, a
+    # warning, a usage message — is not a credential.
+    if token.startswith("sk-ant-"):
+      return token
+  return ""
+
+
 def parse_utilization(value: Any) -> float:
   try:
     return float(str(value).strip().replace("%", ""))
@@ -801,32 +840,36 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
 
-  # Probing needs a live token and only the Claude Code CLI can mint one: it
-  # refreshes the credential file when it runs, so a machine left alone long
-  # enough finds the saved token lapsed. Say so — an empty limits list with
-  # nothing else set hides the whole section and explains nothing — and keep
-  # showing the last numbers whose window has not since reset.
-  if access_token == "":
-    result["limits"] = fallback
-    result["usageStatusText"] = "Waiting for auth"
-    return result
-  if expires_at_ms > 0 and expires_at_ms <= time.time() * 1000:
-    result["limits"] = fallback
-    result["usageStatusText"] = "Sign-in expired"
-    result["authHelpText"] = (
-      "Claude Code's saved sign-in expired"
-      + (" — showing the last known limits." if fallback else ".")
-      + " Start Claude Code, or run `claude auth login`, to refresh it."
-    )
-    return result
-
   # --force is a person asking for fresh numbers, so it skips the reuse window
   # entirely; the interval is there to absorb repeated panel opens, not to
-  # overrule someone who pressed refresh.
+  # overrule someone who pressed refresh. It is settled before the token is: a
+  # cache this young is already the answer, and spawning a sibling CLI to
+  # confirm what it says would put a process behind every flick of the panel.
   fetched_at = number(cached.get("fetchedAtMs")) / 1000
   if fallback and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
     result["limits"] = fallback
     return result
+
+  # Probing needs a live token. The saved one lapses after about eight hours
+  # and only the Claude Code CLI refreshes it, so a sibling CLI signed into the
+  # same subscription is asked next. When nothing can mint one, say why the
+  # section is thin — an empty limits list with nothing else set hides it and
+  # explains nothing — and keep showing the last numbers whose window has not
+  # since reset.
+  if access_token == "" or (expires_at_ms > 0 and expires_at_ms <= time.time() * 1000):
+    saved_token, access_token = access_token, sibling_access_token()
+    if access_token == "":
+      result["limits"] = fallback
+      if saved_token == "":
+        result["usageStatusText"] = "Waiting for auth"
+      else:
+        result["usageStatusText"] = "Sign-in expired"
+        result["authHelpText"] = (
+          "Claude Code's saved sign-in expired"
+          + (" — showing the last known limits." if fallback else ".")
+          + " Start Claude Code, or run `claude auth login`, to refresh it."
+        )
+      return result
 
   probe = probe_limits(access_token)
   if probe["ok"]:

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -56,9 +56,15 @@ light surfaces — and the bar glyph stands in when there is none.
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
-Claude limits need a signed-in CLI; without credentials the panel says so and
-falls back to local stats only. A non-default Claude directory is honored via
-`CLAUDE_CONFIG_DIR`, Codex via `CODEX_HOME`. Fireworks reads
+Claude limits need a signed-in CLI. Only Claude Code refreshes the token in
+`~/.claude/.credentials.json`, so once that copy has lapsed — about eight hours
+after its last run — the collector asks `omp`, then `pi`, for a live one, since
+either may be signed into the same subscription. Their refresh tokens stay
+theirs: nothing is written back. With no usable credential anywhere the panel
+says so, keeps drawing the last known windows until their reset passes, and is
+left with local stats only once even those are gone. A non-default Claude
+directory is honored via `CLAUDE_CONFIG_DIR`, Codex via `CODEX_HOME`.
+Fireworks reads
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -73,14 +73,16 @@ done
 pass "Claude collector adds no limit when the payload scopes none"
 
 # Only the Claude Code CLI refreshes the saved token, so between its runs the
-# collector can find a lapsed one. Drive collect_limits over a planted cache
-# with the network unreachable, so nothing but the credential state decides
-# the answer.
+# collector can find a lapsed one and turns to a sibling CLI signed into the
+# same subscription. Drive collect_limits over a planted cache with the network
+# unreachable and that lookup pinned, so nothing but the credential state
+# decides the answer — never whichever agent CLIs this machine happens to have
+# installed.
 CACHE_HOME=$(mktemp -d)
 trap 'rm -rf "$CACHE_HOME"' EXIT
 
 collect_limits() {
-  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" \
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" SIBLING="${4:-}" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
 import importlib.machinery, importlib.util, json, os, pathlib
 
@@ -99,6 +101,7 @@ elif cache.exists():
 def unreachable(request, timeout=None):
   raise OSError("no route to host")
 
+collector.sibling_access_token = lambda: os.environ["SIBLING"]
 collector.urllib.request.urlopen = unreachable
 print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False)))
 PY
@@ -137,6 +140,58 @@ stale=$(collect_limits "token" 1000 "$(jq -c '.limits |= [.[0]]' <<<"$cache")")
 [[ $(jq -r '.authHelpText' <<<"$stale") != *"last known"* ]] ||
   fail "Claude collector promises no last-known limits when it has none" "$stale"
 pass "Claude collector drops a wholly reset cache but keeps explaining itself"
+
+# A lapsed saved token is not the end of the story: pi and omp hold the same
+# subscription and refresh their own copy, so the collector asks them and
+# probes with what they answer. Serve the endpoint here — the point is that the
+# request happens at all, carrying the token that works.
+collect_with_sibling() {
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" SIBLING="$1" CACHED="$2" PAYLOAD="$3" \
+    TOKEN="$4" EXPIRES_AT="$5" XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
+import importlib.machinery, importlib.util, io, json, os
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+(collector.cache_root() / "claude-limits.json").write_text(os.environ["CACHED"], encoding="utf-8")
+
+authorizations = []
+
+def urlopen(request, timeout=None):
+  authorizations.append(request.headers.get("Authorization"))
+  return io.BytesIO(os.environ["PAYLOAD"].encode())
+
+collector.sibling_access_token = lambda: os.environ["SIBLING"]
+collector.urllib.request.urlopen = urlopen
+print(json.dumps({
+  "result": collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False),
+  "authorizations": authorizations,
+}))
+PY
+}
+
+refreshed=$(collect_with_sibling "sk-ant-oat01-sibling" "$cache" '{"five_hour":{"utilization":44.0}}' "lapsed-token" 1000)
+[[ $(jq -c '[.result.limits[].percent]' <<<"$refreshed") == "[0.44]" ]] ||
+  fail "Claude collector probes with a sibling CLI's token when the saved one lapsed" "$refreshed"
+[[ $(jq -r '.authorizations[0]' <<<"$refreshed") == "Bearer sk-ant-oat01-sibling" ]] ||
+  fail "Claude collector sends the sibling's token, not the lapsed one" "$refreshed"
+[[ -z $(jq -r '.result.usageStatusText' <<<"$refreshed") ]] ||
+  fail "Claude collector reports no auth problem once a sibling token works" "$refreshed"
+pass "Claude collector probes with a sibling CLI's token when the saved one lapsed"
+
+# A machine that never ran Claude Code has no saved token at all, which is a
+# different branch from a lapsed one and just as answerable: the sibling is
+# holding the same subscription either way.
+unsaved=$(collect_with_sibling "sk-ant-oat01-sibling" "$cache" '{"five_hour":{"utilization":21.0}}' "" 0)
+[[ $(jq -c '[.result.limits[].percent]' <<<"$unsaved") == "[0.21]" ]] ||
+  fail "Claude collector probes with a sibling CLI's token when nothing is saved" "$unsaved"
+[[ $(jq -r '.authorizations[0]' <<<"$unsaved") == "Bearer sk-ant-oat01-sibling" ]] ||
+  fail "Claude collector sends the sibling's token when nothing is saved" "$unsaved"
+[[ -z $(jq -r '.result.usageStatusText' <<<"$unsaved") ]] ||
+  fail "Claude collector stops waiting for auth once a sibling token works" "$unsaved"
+pass "Claude collector probes with a sibling CLI's token when nothing is saved"
 
 # A signed-out machine says so, and still shows what it last knew.
 signed_out=$(collect_limits "" 0 "$cache")


### PR DESCRIPTION
## Problem

`omarchy-agent-usage-claude` reads its OAuth access token from one place, `~/.claude/.credentials.json`, and only the Claude Code CLI refreshes that file. The collector already counts pi/omp sessions (`scan_pi_usage` walks `~/.pi/agent/sessions` and `~/.omp/agent/sessions`) and opencode sessions, so it already accepts that other clients spend a Claude subscription — but for limits it still depends on a CLI the user may not run at all.

On a machine that codes through omp, the saved token lapses about eight hours after Claude Code last ran and never comes back. The panel then reports a sign-in problem and serves stale cached windows or none, while the account's real limits are one HTTP request away:

```
# 4.0.1, ~/.claude token lapsed at 05:25
usageStatusText = "Sign-in expired"
limits          = [{"label": "Weekly (7-day)", "percent": 0.02, ...}]   # cached, hours old
```

The same account's live token, taken from omp, answers `api/oauth/usage` immediately:

```
five_hour: utilization 6.0, resets_at 2026-08-26T07:10:00Z
seven_day: utilization 3.0, resets_at 2026-08-30T13:00:00Z
```

## What this changes

`collect_limits` asks a sibling CLI for a token when the saved one is missing or lapsed. `omp token anthropic` and `pi token anthropic` print an access token and refresh it first if it has lapsed, so one subprocess turns an eight-hour-old credential into real numbers.

| case | before | after |
|---|---|---|
| saved token live | probe | unchanged |
| saved token lapsed, sibling signed in | `Sign-in expired`, cached windows | limits probed with the sibling's token, no status |
| saved token lapsed, no sibling | `Sign-in expired` | unchanged, verbatim |
| no credential file, sibling signed in | `Waiting for auth` | limits probed (no plan label, since that comes from the credential file) |
| no credential file, no sibling | `Waiting for auth` | unchanged |

Nothing is written back to any credential store. Anthropic rotates a refresh token when it is spent, so a usage widget that spent Claude Code's — or copied omp's into Claude's file — could invalidate a working sign-in. Only the access token is borrowed, and only for the `Authorization` header of the probe.

The reuse window moved above the token check so a cache younger than `PROBE_MIN_INTERVAL_SECONDS` answers without spawning anything; repeated panel opens cost no processes. Consequently, inside that window a lapsed saved token no longer overwrites the status text with an alarm about numbers that are seconds old.

Every sibling failure is quiet and falls through to the next candidate: absent binary, non-zero exit, timeout, or output that is not a `sk-ant-` token. A machine with neither CLI installed behaves exactly as before.

## Tests

`test/shell.d/agent-usage-claude-limits-test.sh` pins `sibling_access_token` in the `collect_limits` harness, so the machine's own installed CLIs cannot decide the outcome of the existing cases — without that, a developer with omp on `$PATH` would see the lapsed-token cases probe successfully and fail.

One case added: a lapsed saved token plus a signed-in sibling probes with the sibling's token, sends `Bearer` that token rather than the lapsed one, and reports no auth problem.

Checked that it is not vacuous — with the sibling lookup replaced by `""`, it fails on the behavior:

```
not ok - Claude collector probes with a sibling CLI's token when the saved one lapsed
```

End-to-end against a real account, with a deliberately lapsed credential fixture (`expiresAt: 1000`) and `CLAUDE_CONFIG_DIR` pointed at it:

```
patched:   usageStatusText ''              limits [('Session (5-hour)', 0.16), ('Weekly (7-day)', 0.04)]   tierLabel Pro
4.0.1:     usageStatusText 'Sign-in expired'  limits []
```

`./test/all`: 200 of 206 test files pass. The six failures — `bar-icon-geometry-test.sh`, `config-test.sh`, `launch-about-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, `unowned-system-paths-test.sh` — fail identically on the unmodified commit this branches from and are unrelated.

## Relationship to #8092 / #8093

#8092 and #8093 fix the wording of the lapsed-access-token case ("paused", not "signed out"). This fixes the case itself where a sibling CLI can supply a token, and leaves both status texts untouched, so the two changes are complementary and touch the same branch of `collect_limits` — whichever lands first, the other rebases trivially.

---

Written by Claude Opus 5 via omp (Oh My Pi), on the machine the bug was found on.
