### PR TITLE
Detect ROG machines reporting sys_vendor as "ASUS"

### DIFF
--- a/bin/omarchy-hw-asus-rog
+++ b/bin/omarchy-hw-asus-rog
@@ -2,5 +2,8 @@
 
 # omarchy:summary=Detect whether the computer is an Asus ROG machine.
 
-[[ $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) == "ASUSTeK COMPUTER INC." ]] &&
-   grep -q "ROG" /sys/class/dmi/id/product_family 2>/dev/null
+# Newer ASUS firmware reports sys_vendor as "ASUS" rather than the older
+# "ASUSTeK COMPUTER INC." (seen on the ROG Zephyrus G14 GU405AR), so match on
+# the vendor prefix instead of the full string.
+[[ $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) == ASUS* ]] &&
+  grep -q "ROG" /sys/class/dmi/id/product_family 2>/dev/null


### PR DESCRIPTION
`omarchy-hw-asus-rog` compares the DMI `sys_vendor` against the exact string `"ASUSTeK COMPUTER INC."`. Newer ASUS firmware reports simply `ASUS`, so the check returns false on genuine ROG hardware.

On a ROG Zephyrus G14 GU405AR (BIOS GU405AR.301):

```
$ cat /sys/class/dmi/id/sys_vendor
ASUS
$ cat /sys/class/dmi/id/product_family
ROG Zephyrus G14
$ omarchy-hw-asus-rog; echo $?
1
```

Because four setup paths are gated on this detector, the miss is silent:

- `install/hardware/asus-rog.sh` — skips installing `asusctl`
- `install/user/hardware/asus/fix-audio-mixer.sh`
- `install/user/hardware/asus/fix-mic.sh`
- `install/hardware/asus/fix-z13-touchpad.sh`

I hit this as a user: `asusctl` was absent on a ROG laptop and I installed it by hand before finding the cause.

## Fix

Match the vendor prefix rather than the full string, which covers both spellings. This follows the existing precedent in `install/hardware/apple/fix-brcmfmac-supplicant.sh`, which already uses `[[ $sys_vendor == Apple* ]]`.

## Testing

`./test/cli` passes.

On the affected machine, the detector goes from exit 1 to exit 0.

Logic matrix against synthetic DMI values:

| sys_vendor | product_family | result |
|---|---|---|
| `ASUS` | `ROG Zephyrus G14` | match |
| `ASUSTeK COMPUTER INC.` | `ROG Strix G16` | match |
| `ASUSTeK COMPUTER INC.` | `Zenbook` | no match |
| `ASUS` | `ExpertBook B9406` | no match |
| `Framework` | `Laptop 16` | no match |

The `ROG` requirement on `product_family` is unchanged, so non-ROG ASUS machines are still excluded.

One note for reviewers: the prefix also admits a hypothetical `ASUSTOR` vendor, but that would additionally need `ROG` in `product_family` to match, which no ASUSTOR NAS reports. Happy to switch to an explicit two-string comparison if you'd rather not rely on the prefix.
