### PR TITLE
Record that the PTL backlight fix black-screens the GU405AR

### DIFF
--- a/install/hardware/asus/fix-asus-ptl-display-backlight.sh
+++ b/install/hardware/asus/fix-asus-ptl-display-backlight.sh
@@ -2,6 +2,15 @@
 # Enabled only for ExpertBook B9406 and Zenbook UX5406AA for now.
 # Other models need confirmation whether the issue exists there too.
 #
+# Confirmed NOT to apply to the ROG Zephyrus G14 GU405AR: it shows the same
+# symptom (empty panel EDID, intel_backlight writes with no visible effect),
+# but xe.enable_dpcd_backlight=1 leaves that panel black rather than fixing it.
+# Its panel does implement DPCD/AUX brightness -- 0x0701 bit0 (TCON backlight
+# adjustment) and 0x0702 bit1 (AUX set) are both set, with an 11-bit range from
+# 0x0724 -- and driving 0x0721/0x0722/0x0723 over the AUX channel from
+# userspace dims it correctly. So the symptom matching is not sufficient on its
+# own; do not widen the gate to a model without testing it boots.
+#
 # The panel's EDID on eDP-1 reads as empty, so xe takes backlight type from
 # VBT (which says PWM) but the panel actually wants DPCD AUX backlight.
 # Without xe.enable_dpcd_backlight=1, intel_backlight sysfs writes succeed


### PR DESCRIPTION
`install/hardware/asus/fix-asus-ptl-display-backlight.sh` says:

> Enabled only for ExpertBook B9406 and Zenbook UX5406AA for now.
> Other models need confirmation whether the issue exists there too.

This is that confirmation for one more model, and it's a negative result worth recording so nobody widens the gate on symptom-matching alone.

## ROG Zephyrus G14 GU405AR

The symptom matches exactly: empty panel EDID, and `intel_backlight` accepts writes with no visible change.

```
$ cat /sys/class/dmi/id/product_name
ROG Zephyrus G14 GU405AR
$ cat /sys/class/drm/card0-eDP-2/status ; stat -c%s /sys/class/drm/card0-eDP-2/edid
connected
0
$ brightnessctl -d intel_backlight set 30%   # applies, screen unchanged
```

But `xe.enable_dpcd_backlight=1` does not fix it — the panel comes up **black** and stays black through to a fully booted session (reproduced twice; both times the machine was running fine behind a dark panel). Snapshot entries without the parameter boot normally.

## The panel does support AUX brightness

Read over `/dev/drm_dp_aux0` on the same machine:

| Register | Value | Meaning |
|---|---|---|
| `0x0701` bit 0 | 1 | TCON backlight adjustment supported |
| `0x0702` bit 1 | 1 | Brightness settable over AUX |
| `0x0702` bit 2 | 1 | Two-byte brightness value |
| `0x0724` | `0x0b` | 11-bit range, levels `0..2047` |

Writing `0x0721 = 0x02` (DPCD brightness control) plus a level into `0x0722`/`0x0723` dims the panel correctly from userspace, across its full range — level 2047 is visually identical to the panel's default mode, so the range is not clipped.

So the hardware path this fix targets is genuinely present and working on this model; something about how the driver takes it over at boot is what fails here. I didn't manage to capture kernel logs from a black-screen boot to characterise that further, so I'm not asserting a mechanism — just recording that the parameter is not safe to enable on this model as-is.

## Change

Comment only. No behaviour change; the gate already excludes this model.

Environment: Omarchy 4.0.1-1, kernel 7.1.9-arch1-2, Intel Panther Lake + RTX 5070 Ti, BIOS GU405AR.301, GPU MUX in Optimus/hybrid mode.
